### PR TITLE
[Cleanup] Quasar single-device tests modernization

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_scoped_lock_cache.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_scoped_lock_cache.cpp
@@ -205,7 +205,7 @@ std::vector<uint32_t> run_dfb_scoped_lock_cache_test(distributed::MeshDevice& me
 }
 
 #define DFB_CACHE_SKIP_IF_NOT_QUASAR()                                                               \
-    if (this->devices_.at(0)->arch() != ARCH::QUASAR) {                                              \
+    if (this->device().arch() != ARCH::QUASAR) {                                                     \
         GTEST_SKIP() << "scoped-lock cache ops are Quasar-only; the WH/BH path is the lock tracker"; \
     }
 
@@ -224,7 +224,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheFlushProducerStrided1Sx
         /*producer=*/true,
         /*mode=*/DfbCacheTestMode::FlushOnRelease,
         /*lock_n=*/4};
-    EXPECT_EQ(run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p), dfb_cache_expected(p));
+    EXPECT_EQ(run_dfb_scoped_lock_cache_test(this->device(), p), dfb_cache_expected(p));
 }
 
 // Same baseline but lock_n=1: only the head entry {0} is held/flushed.
@@ -239,7 +239,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheFlushProducerStrided1Sx
         /*producer=*/true,
         /*mode=*/DfbCacheTestMode::FlushOnRelease,
         /*lock_n=*/1};
-    EXPECT_EQ(run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p), dfb_cache_expected(p));
+    EXPECT_EQ(run_dfb_scoped_lock_cache_test(this->device(), p), dfb_cache_expected(p));
 }
 
 // 2 producers (stride==2): only this producer's held {0,2,4,6} flush; interleaved neighbours {1,3,5,7} untouched.
@@ -254,7 +254,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheFlushProducerStrided2Sx
         /*producer=*/true,
         /*mode=*/DfbCacheTestMode::FlushOnRelease,
         /*lock_n=*/4};
-    EXPECT_EQ(run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p), dfb_cache_expected(p));
+    EXPECT_EQ(run_dfb_scoped_lock_cache_test(this->device(), p), dfb_cache_expected(p));
 }
 
 // ALL pattern (broadcast, stride==1) instead of STRIDED; held = {0..3}.
@@ -269,7 +269,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheFlushProducerAll) {
         /*producer=*/true,
         /*mode=*/DfbCacheTestMode::FlushOnRelease,
         /*lock_n=*/4};
-    EXPECT_EQ(run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p), dfb_cache_expected(p));
+    EXPECT_EQ(run_dfb_scoped_lock_cache_test(this->device(), p), dfb_cache_expected(p));
 }
 
 // Wrap: held window {0,2,0} crosses the ring end -> exercises the wrap-to-base branch (idempotent); {0,2}=NEW.
@@ -284,7 +284,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheFlushProducerWrap) {
         /*producer=*/true,
         /*mode=*/DfbCacheTestMode::FlushOnRelease,
         /*lock_n=*/3};
-    EXPECT_EQ(run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p), dfb_cache_expected(p));
+    EXPECT_EQ(run_dfb_scoped_lock_cache_test(this->device(), p), dfb_cache_expected(p));
 }
 
 // Consumer release must NOT flush -> every slot reads back OLD.
@@ -299,7 +299,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheFlushConsumerDoesNotFlu
         /*producer=*/false,
         /*mode=*/DfbCacheTestMode::FlushOnRelease,
         /*lock_n=*/4};
-    EXPECT_EQ(run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p), dfb_cache_expected(p));
+    EXPECT_EQ(run_dfb_scoped_lock_cache_test(this->device(), p), dfb_cache_expected(p));
 }
 
 // ---- Invalidate-on-acquire (both lock kinds) -------------------------------------------
@@ -317,7 +317,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheInvalidateProducerStrid
         /*producer=*/true,
         /*mode=*/DfbCacheTestMode::InvalidateOnAcquire,
         /*lock_n=*/4};
-    EXPECT_EQ(run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p), dfb_cache_expected(p));
+    EXPECT_EQ(run_dfb_scoped_lock_cache_test(this->device(), p), dfb_cache_expected(p));
 }
 
 // 2 producers (stride==2): only held {0,2,4,6} invalidated; interleaved neighbours {1,3,5,7} keep stale OLD.
@@ -332,7 +332,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheInvalidateProducerStrid
         /*producer=*/true,
         /*mode=*/DfbCacheTestMode::InvalidateOnAcquire,
         /*lock_n=*/4};
-    EXPECT_EQ(run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p), dfb_cache_expected(p));
+    EXPECT_EQ(run_dfb_scoped_lock_cache_test(this->device(), p), dfb_cache_expected(p));
 }
 
 // A read lock also invalidates on acquire -> held {0,1,2,3}=NEW, rest OLD.
@@ -347,7 +347,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheInvalidateConsumer) {
         /*producer=*/false,
         /*mode=*/DfbCacheTestMode::InvalidateOnAcquire,
         /*lock_n=*/4};
-    EXPECT_EQ(run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p), dfb_cache_expected(p));
+    EXPECT_EQ(run_dfb_scoped_lock_cache_test(this->device(), p), dfb_cache_expected(p));
 }
 
 // 1 producer + 4 ALL consumers sharing entries: producer seeds shared-L2=OLD/TL1=NEW + signals, then all 4
@@ -365,7 +365,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheInvalidateMultiConsumer
         /*mode=*/DfbCacheTestMode::InvalidateOnAcquire,
         /*lock_n=*/2,
         /*multi_all=*/true};
-    const auto result = run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p);
+    const auto result = run_dfb_scoped_lock_cache_test(this->device(), p);
     const auto expected = dfb_cache_expected(p);  // held {0,1} -> NEW, {2,3} -> OLD
     ASSERT_EQ(result.size(), static_cast<size_t>(p.num_consumers) * p.num_entries);
     for (uint32_t c = 0; c < p.num_consumers; ++c) {
@@ -389,7 +389,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheHandshakeDmToDmWrap) {
         /*lock_n=*/1};
     p.handshake = true;
     p.num_rounds = 12;  // > capacity (4) so each slot is reused ~3x
-    const auto result = run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p);
+    const auto result = run_dfb_scoped_lock_cache_test(this->device(), p);
     ASSERT_EQ(result.size(), p.num_rounds);
     std::vector<uint32_t> expected(p.num_rounds);
     for (uint32_t r = 0; r < p.num_rounds; ++r) {
@@ -414,7 +414,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheHandshakeNonSnoopingPro
     p.handshake = true;
     p.num_rounds = 12;
     p.nonsnoop_producer = true;
-    const auto result = run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p);
+    const auto result = run_dfb_scoped_lock_cache_test(this->device(), p);
     ASSERT_EQ(result.size(), p.num_rounds);
     std::vector<uint32_t> expected(p.num_rounds);
     for (uint32_t r = 0; r < p.num_rounds; ++r) {

--- a/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_runtime_args.cpp
@@ -1115,14 +1115,9 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarCRTAUniqueL1Addresses) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMergeProgramRunArgs) {
-    auto mesh_device = devices_[0];
     const experimental::NodeCoord node{0, 0};
     CoreRange core_range(CoreCoord{0, 0});
     CoreRangeSet core_range_set(std::vector{core_range});
-
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
 
     const uint32_t address_1 = MetalContext::instance().hal().get_dev_addr(
         HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
@@ -1132,7 +1127,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMergeProgramRunArgs) {
 
     // Zero-init both output slots.
     std::vector<uint32_t> zeros(2, 0);
-    tt_metal::detail::WriteToDeviceL1(mesh_device->get_devices()[0], node, address_1, zeros);
+    slow_dispatch::WriteToL1(this->device(), node, address_1, zeros);
 
     // Two kernels, each using one DM thread, writing to distinct L1 addresses.
     const experimental::KernelSpecName K1{"k1"}, K2{"k2"};
@@ -1148,7 +1143,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMergeProgramRunArgs) {
     experimental::WorkUnitSpec main_wu{.name = "main", .kernels = {K1, K2}, .target_nodes = core_range_set};
     experimental::ProgramSpec spec{
         .name = "merge_test", .kernels = {make_dm_spec(K1), make_dm_spec(K2)}, .work_units = {main_wu}};
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(this->device(), spec);
 
     // Build two partial ProgramRunArgs, one per kernel.
     experimental::ProgramRunArgs part1;
@@ -1169,24 +1164,21 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMergeProgramRunArgs) {
     experimental::ProgramRunArgs merged = experimental::MergeProgramRunArgs(std::move(part1), rest);
     experimental::SetProgramRunArgs(program, merged);
 
-    distributed::MeshWorkload workload;
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> out(2, 0);
-    tt_metal::detail::ReadFromDeviceL1(mesh_device->get_devices()[0], node, address_1, 2 * sizeof(uint32_t), out);
+    slow_dispatch::ReadFromL1(this->device(), node, address_1, 2 * sizeof(uint32_t), out);
     ASSERT_EQ(out, std::vector<uint32_t>({value_1, value_2}));
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarUpdateProgramRunArgs) {
-    auto mesh_device = devices_[0];
     const experimental::NodeCoord node{0, 0};
     CoreRange core_range(CoreCoord{0, 0});
     CoreRangeSet core_range_set(std::vector{core_range});
 
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::MeshCommandQueue& cq = this->device().mesh_command_queue();
 
     const uint32_t address_1 = MetalContext::instance().hal().get_dev_addr(
         HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
@@ -1207,11 +1199,11 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarUpdateProgramRunArgs) {
         .name = "update_run_args_test", .kernels = {dm_kernel_spec}, .work_units = {main_wu}};
 
     distributed::MeshWorkload workload;
-    workload.add_program(device_range, experimental::MakeProgramFromSpec(*mesh_device, spec));
+    workload.add_program(device_range, experimental::MakeProgramFromSpec(this->device(), spec));
     Program& prog = workload.get_programs().at(device_range);
 
     std::vector<uint32_t> zeros(2, 0);
-    tt_metal::detail::WriteToDeviceL1(mesh_device->get_devices()[0], node, address_1, zeros);
+    slow_dispatch::WriteToL1(this->device(), node, address_1, zeros);
 
     // First enqueue: write value_1 to address_1.
     experimental::ProgramRunArgs params1;
@@ -1234,7 +1226,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarUpdateProgramRunArgs) {
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
     std::vector<uint32_t> outputs(2, 0);
-    tt_metal::detail::ReadFromDeviceL1(mesh_device->get_devices()[0], node, address_1, 2 * sizeof(uint32_t), outputs);
+    slow_dispatch::ReadFromL1(this->device(), node, address_1, 2 * sizeof(uint32_t), outputs);
     ASSERT_EQ(outputs, std::vector<uint32_t>({value_1, value_2}));
 }
 

--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -209,7 +209,7 @@ protected:
     }
 };
 
-class QuasarMeshDeviceSingleCardFixture : public MeshDeviceSingleCardFixture {
+class QuasarMeshDeviceSingleCardFixture : public UnitMeshFixture {
 protected:
     void SetUp() override {
         this->arch_ = tt::get_arch_from_string(tt::test_utils::get_umd_arch_name());

--- a/tests/tt_metal/tt_metal/data_movement/device_pcie_loopback/test_device_pcie_loopback.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/device_pcie_loopback/test_device_pcie_loopback.cpp
@@ -24,6 +24,8 @@
 
 #include <chrono>
 #include <thread>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -64,8 +66,7 @@ void sync_debug_servers_before_teardown() {
 }  // namespace
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, HostHugepagePcieLoopback) {
-    auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
+    IDevice* device = this->device().get_devices()[0];
     TT_FATAL(device->is_mmio_capable(), "Host hugepage test requires an MMIO-capable device");
 
     auto& cluster = MetalContext::instance().get_cluster();
@@ -101,10 +102,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, HostHugepagePcieLoopback) {
     tt_driver_atomics::sfence();
 
     // Step 2-4: Kernel reads host src -> L1, then L1 -> host dst (via compile-time args).
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-    distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
-
     const experimental::KernelSpecName DM_KERNEL{"device_pcie_loopback"};
 
     experimental::KernelSpec dm_kernel_spec{
@@ -131,10 +128,9 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, HostHugepagePcieLoopback) {
         .kernels = {dm_kernel_spec},
         .work_units = {main_wu},
     };
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(this->device(), spec);
 
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     // Step 5: Host verifies dst hugepage region matches src.
     std::vector<uint32_t> host_dst_readback(expected.size());
@@ -143,7 +139,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, HostHugepagePcieLoopback) {
 
     // Step 6: Host verifies L1 staging matches src.
     std::vector<uint32_t> l1_readback;
-    detail::ReadFromDeviceL1(device, node, l1_staging_addr, kTransferSizeBytes, l1_readback);
+    slow_dispatch::ReadFromL1(this->device(), node, l1_staging_addr, kTransferSizeBytes, l1_readback);
     EXPECT_EQ(l1_readback, expected) << "L1 staging mismatch after device PCIe read";
 
     sync_debug_servers_before_teardown();

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache/test_quasar_cache.cpp
@@ -10,6 +10,7 @@
 #include "dm_common.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
 
@@ -36,11 +37,7 @@ struct L2FlushTestConfig {
     bool expect_new_values = true;  // true for flush tests, false for invalidate tests
 };
 
-bool run_l2_flush_test(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    const L2FlushTestConfig& config) {
-
-    IDevice* device = mesh_device->get_devices()[0];
+bool run_l2_flush_test(distributed::MeshDevice& mesh_device, const L2FlushTestConfig& config) {
     constexpr CoreCoord core = {0, 0};
     const experimental::NodeCoord node{0, 0};
 
@@ -48,7 +45,7 @@ bool run_l2_flush_test(
     // that should persist after invalidation (since invalidate doesn't write back)
     uint32_t old_value = 0xDEADBEEF;
     std::vector<uint32_t> init_data(config.num_words, config.expect_new_values ? 0 : old_value);
-    tt_metal::detail::WriteToDeviceL1(device, core, config.base_addr, init_data);
+    slow_dispatch::WriteToL1(mesh_device, core, config.base_addr, init_data);
 
     const experimental::KernelSpecName DM_KERNEL{"l2_flush"};
 
@@ -75,7 +72,7 @@ bool run_l2_flush_test(
         .kernels = {dm_kernel_spec},
         .work_units = {main_wu},
     };
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
     experimental::ProgramRunArgs params;
     params.kernel_run_args = {experimental::ProgramRunArgs::KernelRunArgs{
@@ -87,16 +84,15 @@ bool run_l2_flush_test(
     experimental::SetProgramRunArgs(program, params);
 
     distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range(mesh_device->shape());
+    distributed::MeshCoordinateRange device_range(mesh_device.shape());
     workload.add_program(device_range, std::move(program));
 
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::MeshCommandQueue& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
     // Read back and verify
     std::vector<uint32_t> output_data;
-    tt_metal::detail::ReadFromDeviceL1(
-        device, core, config.base_addr, config.num_words * sizeof(uint32_t), output_data);
+    slow_dispatch::ReadFromL1(mesh_device, core, config.base_addr, config.num_words * sizeof(uint32_t), output_data);
 
     bool pass = true;
     for (uint32_t i = 0; i < config.num_words; i++) {
@@ -123,11 +119,7 @@ struct L1DCacheTestConfig {
     bool expect_new_values;  // true for flush tests, false for invalidate tests
 };
 
-bool run_l1_dcache_test(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    const L1DCacheTestConfig& config) {
-
-    IDevice* device = mesh_device->get_devices()[0];
+bool run_l1_dcache_test(distributed::MeshDevice& mesh_device, const L1DCacheTestConfig& config) {
     constexpr CoreCoord core = {0, 0};
     const experimental::NodeCoord node{0, 0};
 
@@ -135,7 +127,7 @@ bool run_l1_dcache_test(
     // that should persist after invalidation (since invalidate doesn't write back)
     uint32_t old_value = 0xDEADBEEF;
     std::vector<uint32_t> init_data(config.num_words, old_value);
-    tt_metal::detail::WriteToDeviceL1(device, core, config.base_addr, init_data);
+    slow_dispatch::WriteToL1(mesh_device, core, config.base_addr, init_data);
 
     const experimental::KernelSpecName DM_KERNEL{"l1_dcache"};
 
@@ -162,7 +154,7 @@ bool run_l1_dcache_test(
         .kernels = {dm_kernel_spec},
         .work_units = {main_wu},
     };
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
     experimental::ProgramRunArgs params;
     params.kernel_run_args = {experimental::ProgramRunArgs::KernelRunArgs{
@@ -174,16 +166,15 @@ bool run_l1_dcache_test(
     experimental::SetProgramRunArgs(program, params);
 
     distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range(mesh_device->shape());
+    distributed::MeshCoordinateRange device_range(mesh_device.shape());
     workload.add_program(device_range, std::move(program));
 
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::MeshCommandQueue& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
     // Read back and verify
     std::vector<uint32_t> output_data;
-    tt_metal::detail::ReadFromDeviceL1(
-        device, core, config.base_addr, config.num_words * sizeof(uint32_t), output_data);
+    slow_dispatch::ReadFromL1(mesh_device, core, config.base_addr, config.num_words * sizeof(uint32_t), output_data);
 
     bool pass = true;
     for (uint32_t i = 0; i < config.num_words; i++) {
@@ -217,7 +208,7 @@ TEST_F(QuasarL2CacheOps, FlushLine) {
         .value = 0x12340000,
         .test_mode = 0  // line flush
     };
-    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(devices_[0], config));
+    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(this->device(), config));
 }
 
 TEST_F(QuasarL2CacheOps, FlushRange) {
@@ -231,7 +222,7 @@ TEST_F(QuasarL2CacheOps, FlushRange) {
         .value = 0xABCD0000,
         .test_mode = 1  // range flush
     };
-    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(devices_[0], config));
+    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(this->device(), config));
 }
 
 TEST_F(QuasarL2CacheOps, FlushFull) {
@@ -245,7 +236,7 @@ TEST_F(QuasarL2CacheOps, FlushFull) {
         .value = 0x55550000,
         .test_mode = 2  // full flush
     };
-    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(devices_[0], config));
+    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(this->device(), config));
 }
 
 TEST_F(QuasarL2CacheOps, InvalidateLine) {
@@ -260,7 +251,7 @@ TEST_F(QuasarL2CacheOps, InvalidateLine) {
         .test_mode = 3,  // invalidate line
         .expect_new_values = false  // Invalidate doesn't write back, so old values should remain
     };
-    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(devices_[0], config));
+    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(this->device(), config));
 }
 
 TEST_F(QuasarL2CacheOps, InvalidateFreshRead) {
@@ -277,7 +268,7 @@ TEST_F(QuasarL2CacheOps, InvalidateFreshRead) {
         .test_mode = 4,  // invalidate fresh read
         .expect_new_values = true  // After invalidation, new values written via uncached path should be visible
     };
-    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(devices_[0], config));
+    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l2_flush_test(this->device(), config));
 }
 
 // =============================================================================
@@ -298,7 +289,7 @@ TEST_F(QuasarL1DCacheOps, FlushLine) {
         .test_mode = 0,  // flush line
         .expect_new_values = true
     };
-    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l1_dcache_test(devices_[0], config));
+    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l1_dcache_test(this->device(), config));
 }
 
 TEST_F(QuasarL1DCacheOps, FlushFull) {
@@ -313,7 +304,7 @@ TEST_F(QuasarL1DCacheOps, FlushFull) {
         .test_mode = 1,  // flush full
         .expect_new_values = true
     };
-    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l1_dcache_test(devices_[0], config));
+    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l1_dcache_test(this->device(), config));
 }
 
 TEST_F(QuasarL1DCacheOps, InvalidateLine) {
@@ -329,7 +320,7 @@ TEST_F(QuasarL1DCacheOps, InvalidateLine) {
         .test_mode = 2,  // invalidate line
         .expect_new_values = false  // should see old values
     };
-    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l1_dcache_test(devices_[0], config));
+    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l1_dcache_test(this->device(), config));
 }
 
 TEST_F(QuasarL1DCacheOps, InvalidateFull) {
@@ -345,7 +336,7 @@ TEST_F(QuasarL1DCacheOps, InvalidateFull) {
         .test_mode = 3,  // invalidate full
         .expect_new_values = false  // should see old values
     };
-    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l1_dcache_test(devices_[0], config));
+    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l1_dcache_test(this->device(), config));
 }
 
 TEST_F(QuasarL1DCacheOps, InvalidateFreshRead) {
@@ -362,7 +353,7 @@ TEST_F(QuasarL1DCacheOps, InvalidateFreshRead) {
         .test_mode = 4,  // invalidate fresh read
         .expect_new_values = true  // After invalidation, new values written via uncached path should be visible
     };
-    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l1_dcache_test(devices_[0], config));
+    EXPECT_TRUE(unit_tests::dm::quasar_cache::run_l1_dcache_test(this->device(), config));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/test_quasar_cache_perf.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_cache_perf/test_quasar_cache_perf.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <cstdint>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
 
@@ -28,15 +29,13 @@ bool should_skip_test() { return std::getenv("TT_METAL_SIMULATOR") == nullptr; }
 
 // Runs one write pass of `size_bytes` via `write_path` (0=uncached,1=cached+flush)
 // on a single DM core, then reads back and verifies the byte pattern landed.
-bool run_cache_write(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, std::uint32_t size_bytes, std::uint32_t write_path) {
-    IDevice* device = mesh_device->get_devices()[0];
+bool run_cache_write(distributed::MeshDevice& mesh_device, std::uint32_t size_bytes, std::uint32_t write_path) {
     constexpr CoreCoord core = {0, 0};
     const experimental::NodeCoord node{0, 0};
 
     // Pre-fill destination with a sentinel so a no-op run fails the read-back.
     std::vector<std::uint32_t> init_data((size_bytes + 3) / 4, 0xA5A5A5A5);
-    tt_metal::detail::WriteToDeviceL1(device, core, BASE_ADDR, init_data);
+    slow_dispatch::WriteToL1(mesh_device, core, BASE_ADDR, init_data);
 
     const experimental::KernelSpecName DM_KERNEL{"cache_write_perf"};
     experimental::KernelSpec dm_kernel_spec{
@@ -51,7 +50,7 @@ bool run_cache_write(
     };
     experimental::WorkUnitSpec main_wu{.name = "main", .kernels = {DM_KERNEL}, .target_nodes = node};
     experimental::ProgramSpec spec{.name = "cache_write_perf", .kernels = {dm_kernel_spec}, .work_units = {main_wu}};
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
     experimental::ProgramRunArgs params;
     params.kernel_run_args = {experimental::ProgramRunArgs::KernelRunArgs{
@@ -67,12 +66,12 @@ bool run_cache_write(
     experimental::SetProgramRunArgs(program, params);
 
     distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range(mesh_device->shape());
+    distributed::MeshCoordinateRange device_range(mesh_device.shape());
     workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, /*blocking=*/true);
+    distributed::EnqueueMeshWorkload(mesh_device.mesh_command_queue(), workload, /*blocking=*/true);
 
     std::vector<std::uint32_t> out;
-    tt_metal::detail::ReadFromDeviceL1(device, core, BASE_ADDR, ((size_bytes + 3) / 4) * 4, out);
+    slow_dispatch::ReadFromL1(mesh_device, core, BASE_ADDR, ((size_bytes + 3) / 4) * 4, out);
     const std::uint8_t* bytes = reinterpret_cast<const std::uint8_t*>(out.data());
     for (std::uint32_t i = 0; i < size_bytes; i++) {
         if (bytes[i] != 0x5A) {
@@ -101,7 +100,7 @@ TEST_F(QuasarCacheWrite, SizeSweep) {
     // mode: 0=uncached 1B, 1=uncached 8B, 2=cached+range flush (April), 3=cached+fast flush
     for (std::uint32_t mode : {0u, 1u, 2u, 3u}) {
         for (std::uint32_t size_bytes : unit_tests::dm::quasar_cache_perf::kSizesBytes) {
-            pass &= unit_tests::dm::quasar_cache_perf::run_cache_write(devices_[0], size_bytes, mode);
+            pass &= unit_tests::dm::quasar_cache_perf::run_cache_write(this->device(), size_bytes, mode);
         }
     }
     EXPECT_TRUE(pass);

--- a/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/test_idma_example.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/test_idma_example.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-logger/tt-logger.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
 
@@ -28,8 +29,8 @@ constexpr auto kIdmaBasic =
 constexpr auto kIdma1DStrided =
     "tests/tt_metal/tt_metal/data_movement/quasar_examples/quasar_idma/kernels/idma_1d_strided_example.cpp";
 
-static void run_kernel(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+void run_kernel(
+    distributed::MeshDevice& mesh_device,
     const std::string& kernel_path,
     experimental::KernelSpec::CompileTimeArgs compile_time_args) {
     const experimental::KernelSpecName DM_KERNEL{"idma"};
@@ -54,16 +55,16 @@ static void run_kernel(
         .kernels = {dm_kernel_spec},
         .work_units = {main_wu},
     };
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
     experimental::ProgramRunArgs params;
     params.kernel_run_args = {experimental::ProgramRunArgs::KernelRunArgs{.kernel = DM_KERNEL}};
     experimental::SetProgramRunArgs(program, params);
 
     distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range(mesh_device->shape());
+    distributed::MeshCoordinateRange device_range(mesh_device.shape());
     workload.add_program(device_range, std::move(program));
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::MeshCommandQueue& cq = mesh_device.mesh_command_queue();
     distributed::EnqueueMeshWorkload(cq, workload, true);
 }
 
@@ -75,26 +76,24 @@ struct IdmaSrcDstBuffers {
     std::shared_ptr<distributed::MeshBuffer> dst;
 };
 
-IdmaSrcDstBuffers make_idma_src_dst_buffers(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t total_bytes) {
+IdmaSrcDstBuffers make_idma_src_dst_buffers(distributed::MeshDevice& mesh_device, uint32_t total_bytes) {
     distributed::DeviceLocalBufferConfig local_buffer_config = {
         .page_size = total_bytes, .buffer_type = tt::tt_metal::BufferType::L1};
     distributed::ReplicatedBufferConfig buffer_config = {.size = total_bytes};
     return {
-        .src = distributed::MeshBuffer::create(buffer_config, local_buffer_config, mesh_device.get()),
-        .dst = distributed::MeshBuffer::create(buffer_config, local_buffer_config, mesh_device.get()),
+        .src = distributed::MeshBuffer::create(buffer_config, local_buffer_config, &mesh_device),
+        .dst = distributed::MeshBuffer::create(buffer_config, local_buffer_config, &mesh_device),
     };
 }
 
 // Basic: 16 elements * 8 B = 128 B linear copy from src to dst
-bool run_idma_basic_test(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+bool run_idma_basic_test(distributed::MeshDevice& mesh_device) {
     constexpr CoreCoord core = {0, 0};
     constexpr uint32_t num_elements = 16;
     constexpr uint32_t elem_size = 8;
     constexpr uint32_t total_bytes = num_elements * elem_size;
     constexpr uint32_t num_words = total_bytes / sizeof(uint32_t);
 
-    IDevice* device = mesh_device->get_devices()[0];
     auto buffers = make_idma_src_dst_buffers(mesh_device, total_bytes);
     const uint32_t src_base = buffers.src->address();
     const uint32_t dst_base = buffers.dst->address();
@@ -103,12 +102,12 @@ bool run_idma_basic_test(const std::shared_ptr<distributed::MeshDevice>& mesh_de
     for (uint32_t i = 0; i < num_words; i++) {
         src_data[i] = 0xA0000000 + i;
     }
-    tt_metal::detail::WriteToDeviceL1(device, core, src_base, src_data);
+    slow_dispatch::WriteToL1(mesh_device, core, src_base, src_data);
 
     run_kernel(mesh_device, kIdmaBasic, {{"src_addr", src_base}, {"dst_addr", dst_base}});
 
     std::vector<uint32_t> dst_data;
-    tt_metal::detail::ReadFromDeviceL1(device, core, dst_base, total_bytes, dst_data);
+    slow_dispatch::ReadFromL1(mesh_device, core, dst_base, total_bytes, dst_data);
 
     bool pass = (dst_data == src_data);
     if (!pass) {
@@ -128,7 +127,7 @@ bool run_idma_basic_test(const std::shared_ptr<distributed::MeshDevice>& mesh_de
 
 // 1D strided: 10 elements, src_stride=16 B, dst linear.
 // dst[i] = src[i * src_stride] (every other 8 B element from src)
-bool run_idma_1d_strided_test(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+bool run_idma_1d_strided_test(distributed::MeshDevice& mesh_device) {
     constexpr CoreCoord core = {0, 0};
     constexpr uint32_t num_elements = 10;
     constexpr uint32_t elem_size = 8;
@@ -142,13 +141,11 @@ bool run_idma_1d_strided_test(const std::shared_ptr<distributed::MeshDevice>& me
     constexpr uint32_t src_num_words = (num_elements * src_stride) / sizeof(uint32_t);
     constexpr uint32_t dst_num_words = (num_elements * elem_size) / sizeof(uint32_t);
 
-    IDevice* device = mesh_device->get_devices()[0];
-
     std::vector<uint32_t> src_data(src_num_words);
     for (uint32_t i = 0; i < src_num_words; i++) {
         src_data[i] = 0xB0000000 + i;
     }
-    tt_metal::detail::WriteToDeviceL1(device, core, src_base, src_data);
+    slow_dispatch::WriteToL1(mesh_device, core, src_base, src_data);
 
     // Build expected: for each element i, copy elem_size bytes from src_base + i*src_stride
     constexpr uint32_t words_per_elem = elem_size / sizeof(uint32_t);     // 2
@@ -163,7 +160,7 @@ bool run_idma_1d_strided_test(const std::shared_ptr<distributed::MeshDevice>& me
     run_kernel(mesh_device, kIdma1DStrided, {{"src_addr", src_base}, {"dst_addr", dst_base}});
 
     std::vector<uint32_t> dst_data;
-    tt_metal::detail::ReadFromDeviceL1(device, core, dst_base, num_elements * elem_size, dst_data);
+    slow_dispatch::ReadFromL1(mesh_device, core, dst_base, num_elements * elem_size, dst_data);
 
     bool pass = (dst_data == expected);
     if (!pass) {
@@ -194,7 +191,7 @@ TEST_F(QuasarIdmaOps, IDMA_Basic) {
         GTEST_SKIP() << "Test requires Quasar simulator";
     }
     // Host writes pattern to src, kernel copies 16*8=128 B to dst, host verifies dst==src
-    EXPECT_TRUE(unit_tests::dm::quasar_idma::run_idma_basic_test(devices_[0]));
+    EXPECT_TRUE(unit_tests::dm::quasar_idma::run_idma_basic_test(this->device()));
 }
 
 TEST_F(QuasarIdmaOps, IDMA_1D_Strided) {
@@ -202,7 +199,7 @@ TEST_F(QuasarIdmaOps, IDMA_1D_Strided) {
         GTEST_SKIP() << "Test requires Quasar simulator";
     }
     // Host writes pattern to src, kernel copies 10 elements with src_stride=16 B to dst linearly
-    EXPECT_TRUE(unit_tests::dm::quasar_idma::run_idma_1d_strided_test(devices_[0]));
+    EXPECT_TRUE(unit_tests::dm::quasar_idma::run_idma_1d_strided_test(this->device()));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch.cpp
@@ -42,6 +42,7 @@
 #include "impl/program/program_impl.hpp"
 #include "impl/kernels/kernel.hpp"
 #include "impl/buffers/semaphore.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
 
@@ -365,8 +366,8 @@ TEST_F(MeshDispatchFixture, TensixActiveEthTestCBsAcrossDifferentCoreTypes) {
             // Skip L1 readback validation for mock devices (L1 memory not populated)
             if (tt::tt_metal::MetalContext::instance().get_cluster().get_target_device_type() !=
                 tt::TargetDevice::Mock) {
-                tt::tt_metal::detail::ReadFromDeviceL1(
-                    device,
+                slow_dispatch::ReadFromL1(
+                    *mesh_device,
                     core_coord,
                     program_.impl().get_cb_base_addr(device, core_coord, CoreType::WORKER),
                     cb_config_buffer_size,
@@ -499,10 +500,7 @@ std::optional<CoreCoord> quasar_dispatch_s_virtual_core(IDevice* device) {
 }
 
 Program create_quasar_l1_write_program(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    const experimental::NodeCoord& node,
-    uint32_t l1_address,
-    uint32_t value) {
+    distributed::MeshDevice& mesh_device, const experimental::NodeCoord& node, uint32_t l1_address, uint32_t value) {
     const experimental::KernelSpecName dm_kernel_name{"dispatch_s_test_dm"};
     experimental::KernelSpec dm_kernel_spec{
         .unique_id = dm_kernel_name,
@@ -523,7 +521,7 @@ Program create_quasar_l1_write_program(
             }},
     };
 
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
     experimental::ProgramRunArgs params;
     params.kernel_run_args = {experimental::ProgramRunArgs::KernelRunArgs{
         .kernel = dm_kernel_name,
@@ -542,8 +540,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarDispatchSInstantiatedAndRunning)
     }
 
     const bool use_tensix_fallback = MetalContext::instance().rtoptions().get_use_quasar_tensix_dispatch_cores();
-    auto mesh_device = devices_.front();
-    IDevice* device = mesh_device->get_devices().front();
+    IDevice* device = this->device().get_devices().front();
     if (!use_tensix_fallback && detail::sd_cq_kernel_tests_should_skip(device)) {
         GTEST_SKIP() << "No dispatch-engine cores in soc descriptor";
     }
@@ -577,20 +574,13 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarDispatchSInstantiatedAndRunning)
         HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
     constexpr uint32_t test_value = 0xdeadbeef;
     std::vector<uint32_t> cleared_l1(1, 0);
-    detail::WriteToDeviceL1(device, worker_node, l1_address, cleared_l1);
+    slow_dispatch::WriteToL1(this->device(), worker_node, l1_address, cleared_l1);
 
-    auto& cq = mesh_device->mesh_command_queue();
-    const distributed::MeshCoordinateRange device_range =
-        distributed::MeshCoordinateRange(distributed::MeshCoordinate(0, 0), distributed::MeshCoordinate(0, 0));
-
-    distributed::MeshWorkload workload;
-    workload.add_program(
-        device_range, create_quasar_l1_write_program(mesh_device, worker_node, l1_address, test_value));
-    distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::Finish(cq);
+    auto program = create_quasar_l1_write_program(this->device(), worker_node, l1_address, test_value);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result(1, 0);
-    detail::ReadFromDeviceL1(device, worker_node, l1_address, sizeof(uint32_t), result);
+    slow_dispatch::ReadFromL1(this->device(), worker_node, l1_address, sizeof(uint32_t), result);
     // End-to-end proof dispatch_s ran: dispatch_hd notifies dispatch_s to multicast the worker go
     // signal; without a functioning dispatch_s the worker kernel never writes L1.
     ASSERT_EQ(result[0], test_value);

--- a/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
@@ -94,18 +94,16 @@ constexpr float k_broadcast_rtol = 0.0155;
 
 // Quasar drives dataflow through the Gen2 config and takes its DFB sync explicitly; Gen1 arches pin
 // the processor/NOC pair per direction. Identical for every runner in this file, hence the helpers.
-experimental::DataMovementHardwareConfig make_reader_hw_config(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+experimental::DataMovementHardwareConfig make_reader_hw_config(const distributed::MeshDevice& mesh_device) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         return experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
     }
     return experimental::DataMovementGen1Config{
         .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default};
 }
 
-experimental::DataMovementHardwareConfig make_writer_hw_config(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+experimental::DataMovementHardwareConfig make_writer_hw_config(const distributed::MeshDevice& mesh_device) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         return experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
     }
     return experimental::DataMovementGen1Config{
@@ -113,8 +111,8 @@ experimental::DataMovementHardwareConfig make_writer_hw_config(
 }
 
 experimental::ComputeHardwareConfig make_compute_hw_config(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, MathFidelity math_fidelity) {
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+    const distributed::MeshDevice& mesh_device, MathFidelity math_fidelity) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         return experimental::ComputeGen2Config{.fpu_math_fidelity = math_fidelity};
     }
     return experimental::ComputeGen1Config{.fpu_math_fidelity = math_fidelity};
@@ -235,18 +233,15 @@ std::vector<bfloat16> gold_broadcast(
 constexpr std::uint32_t k_num_tiles_broadcast_test = 1;
 
 auto CreateDramBufferForPageSize(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    std::uint32_t page_size_bytes,
-    std::uint32_t num_pages) {
+    distributed::MeshDevice& mesh_device, std::uint32_t page_size_bytes, std::uint32_t num_pages) {
     distributed::DeviceLocalBufferConfig dram_config{
         .page_size = page_size_bytes, .buffer_type = tt_metal::BufferType::DRAM, .bottom_up = false};
     distributed::ReplicatedBufferConfig buffer_config{.size = page_size_bytes * num_pages};
-    return distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
+    return distributed::MeshBuffer::create(buffer_config, dram_config, &mesh_device);
 }
 
-void run_single_core_broadcast(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const BroadcastConfig& test_config) {
-    auto& cq = mesh_device->mesh_command_queue();
+void run_single_core_broadcast(distributed::MeshDevice& mesh_device, const BroadcastConfig& test_config) {
+    auto& cq = mesh_device.mesh_command_queue();
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     distributed::MeshWorkload workload;
@@ -271,7 +266,7 @@ void run_single_core_broadcast(
     auto dst_dram_buffer = CreateDramBufferForPageSize(mesh_device, single_tile_size, k_num_tiles_broadcast_test);
     std::uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
 
-    auto* device = mesh_device->get_devices().empty() ? nullptr : mesh_device->get_devices().front();
+    auto* device = mesh_device.get_devices().empty() ? nullptr : mesh_device.get_devices().front();
     TT_FATAL(device != nullptr, "mesh_device has no backing devices");
     const bool is_quasar = device->arch() == ARCH::QUASAR;
 
@@ -427,7 +422,7 @@ void run_single_core_broadcast(
         .work_units = {wu},
     };
 
-    Program built_program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program built_program = experimental::MakeProgramFromSpec(mesh_device, spec);
     workload.add_program(device_range, std::move(built_program));
     auto& program_run = workload.get_programs().at(device_range);
 
@@ -521,9 +516,8 @@ struct SubBcastColCustomConfig {
     MathFidelity math_fidelity = MathFidelity::LoFi;  // SUB is LoFi-only on Quasar (fidelity phases are MUL-only)
 };
 
-void run_sub_bcast_col_custom(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const SubBcastColCustomConfig& test_config) {
-    auto& cq = mesh_device->mesh_command_queue();
+void run_sub_bcast_col_custom(distributed::MeshDevice& mesh_device, const SubBcastColCustomConfig& test_config) {
+    auto& cq = mesh_device.mesh_command_queue();
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     distributed::MeshWorkload workload;
@@ -559,9 +553,7 @@ void run_sub_bcast_col_custom(
     auto dst_dram_buffer = CreateDramBufferForPageSize(mesh_device, single_tile_size, total_tiles);
     std::uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
 
-    auto* device = mesh_device->get_devices().empty() ? nullptr : mesh_device->get_devices().front();
-    TT_FATAL(device != nullptr, "mesh_device has no backing devices");
-    const bool is_quasar = device->arch() == ARCH::QUASAR;
+    const bool is_quasar = mesh_device.arch() == ARCH::QUASAR;
 
     experimental::KernelSpec::CompilerOptions::Defines defines_vec;
     defines_vec.emplace("CT_DIM", std::to_string(test_config.ct_dim));
@@ -669,7 +661,7 @@ void run_sub_bcast_col_custom(
         .work_units = {wu},
     };
 
-    Program built_program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program built_program = experimental::MakeProgramFromSpec(mesh_device, spec);
     workload.add_program(device_range, std::move(built_program));
     auto& program_run = workload.get_programs().at(device_range);
 
@@ -785,7 +777,7 @@ TEST_P(BroadcastParameterizedDeviceFixture, TensixComputeSingleTileBroadcast) {
     }
     unit_tests::compute::broadcast::BroadcastConfig test_config = GetParam();
     test_config.math_fidelity = MathFidelity::HiFi2;
-    unit_tests::compute::broadcast::run_single_core_broadcast(this->devices_.at(0), test_config);
+    unit_tests::compute::broadcast::run_single_core_broadcast(*this->devices_.at(0), test_config);
 }
 
 using namespace unit_tests::compute::broadcast;
@@ -899,7 +891,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixComputeBinaryBroadcastQuasarDfb)
                     eltwise_op_to_type.at(EltwiseOp(op)),
                     broadcast_dim_to_type.at(BroadcastDim(dim)),
                     math_fid);
-                unit_tests::compute::broadcast::run_single_core_broadcast(this->devices_.at(0), cfg);
+                unit_tests::compute::broadcast::run_single_core_broadcast(this->device(), cfg);
             }
         }
     }
@@ -951,7 +943,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ComputeSubBcastColCustom) {
         SCOPED_TRACE(
             "ct_dim=" + std::to_string(cfg.ct_dim) + " rt_dim=" + std::to_string(cfg.rt_dim) + " num_blocks=" +
             std::to_string(cfg.num_blocks) + " tiny_tile=" + std::to_string(cfg.tile_shape != TileShape::FULL_TILE));
-        unit_tests::compute::broadcast::run_sub_bcast_col_custom(this->devices_.at(0), cfg);
+        unit_tests::compute::broadcast::run_sub_bcast_col_custom(this->device(), cfg);
         if (HasFatalFailure()) {
             // Later cases are not diagnostic once an earlier one is red.
             break;

--- a/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp4_typecast.cpp
@@ -52,25 +52,19 @@ static vector<uint32_t> run_mxfp4_typecast(
     const vector<uint32_t>& src_vec,
     uint32_t num_tiles,
     bool fp32_dest_acc_en) {
-    IDevice* dev = mesh_device.get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     uint32_t input_tile_size = tt::tile_size(input_fmt);
     uint32_t output_tile_size = tt::tile_size(output_fmt);
 
-    InterleavedBufferConfig src_config{
-        .device = dev,
-        .size = num_tiles * input_tile_size,
-        .page_size = num_tiles * input_tile_size,
-        .buffer_type = BufferType::DRAM};
-    auto src_buffer = CreateBuffer(src_config);
-
-    InterleavedBufferConfig dst_config{
-        .device = dev,
-        .size = num_tiles * output_tile_size,
-        .page_size = num_tiles * output_tile_size,
-        .buffer_type = BufferType::DRAM};
-    auto dst_buffer = CreateBuffer(dst_config);
+    auto src_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = num_tiles * input_tile_size},
+        {.page_size = num_tiles * input_tile_size, .buffer_type = BufferType::DRAM},
+        &mesh_device);
+    auto dst_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = num_tiles * output_tile_size},
+        {.page_size = num_tiles * output_tile_size, .buffer_type = BufferType::DRAM},
+        &mesh_device);
 
     const experimental::DFBSpecName INPUT_DFB{"input_dfb"};
     const experimental::DFBSpecName OUTPUT_DFB{"output_dfb"};
@@ -154,7 +148,8 @@ static vector<uint32_t> run_mxfp4_typecast(
 
     Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
-    detail::WriteToBuffer(src_buffer, src_vec);
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, src_buffer, src_vec, /*blocking=*/true);
     // The direct reader/writer kernels address a single DRAM bank
     // (bank_id 0). Use page_size = whole buffer so the allocator places the
     // buffer in one bank, and advance the DRAM pointer by the native tile
@@ -189,7 +184,7 @@ static vector<uint32_t> run_mxfp4_typecast(
     LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     vector<uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_buffer, /*blocking=*/true);
     return result_vec;
 }
 
@@ -325,12 +320,16 @@ namespace mxfp4_tc = unit_tests::llk::mxfp4_typecast;
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToFloat16b) {
-    auto& mesh_device = *devices_[0];
     constexpr uint32_t num_tiles = 64;
     auto src_vec = mxfp4_tc::create_random_vector_of_mxfp4(
         tt::tile_size(tt::DataFormat::MxFp4) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
     auto result_vec = mxfp4_tc::run_mxfp4_typecast(
-        mesh_device, tt::DataFormat::MxFp4, tt::DataFormat::Float16_b, src_vec, num_tiles, /*fp32_dest_acc_en=*/false);
+        this->device(),
+        tt::DataFormat::MxFp4,
+        tt::DataFormat::Float16_b,
+        src_vec,
+        num_tiles,
+        /*fp32_dest_acc_en=*/false);
     auto src_floats = mxfp4_tc::mx_to_floats(tt::DataFormat::MxFp4, src_vec);
     auto dst_floats = mxfp4_tc::bf16_to_floats(result_vec);
     EXPECT_TRUE(mxfp4_tc::is_close_vectors<float>(src_floats, dst_floats, [](float a, float b) {
@@ -340,12 +339,16 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToFloat16b) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToFloat16bFp32Dest) {
-    auto& mesh_device = *devices_[0];
     constexpr uint32_t num_tiles = 64;
     auto src_vec = mxfp4_tc::create_random_vector_of_mxfp4(
         tt::tile_size(tt::DataFormat::MxFp4) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
     auto result_vec = mxfp4_tc::run_mxfp4_typecast(
-        mesh_device, tt::DataFormat::MxFp4, tt::DataFormat::Float16_b, src_vec, num_tiles, /*fp32_dest_acc_en=*/true);
+        this->device(),
+        tt::DataFormat::MxFp4,
+        tt::DataFormat::Float16_b,
+        src_vec,
+        num_tiles,
+        /*fp32_dest_acc_en=*/true);
     auto src_floats = mxfp4_tc::mx_to_floats(tt::DataFormat::MxFp4, src_vec);
     auto dst_floats = mxfp4_tc::bf16_to_floats(result_vec);
     EXPECT_TRUE(mxfp4_tc::is_close_vectors<float>(src_floats, dst_floats, [](float a, float b) {
@@ -361,12 +364,16 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToFloat16bFp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp4) {
-    auto& mesh_device = *devices_[0];
     constexpr uint32_t num_tiles = 64;
     auto src_vec = create_random_vector_of_bfloat16(
         tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
     auto result_vec = mxfp4_tc::run_mxfp4_typecast(
-        mesh_device, tt::DataFormat::Float16_b, tt::DataFormat::MxFp4, src_vec, num_tiles, /*fp32_dest_acc_en=*/false);
+        this->device(),
+        tt::DataFormat::Float16_b,
+        tt::DataFormat::MxFp4,
+        src_vec,
+        num_tiles,
+        /*fp32_dest_acc_en=*/false);
     auto src_floats = mxfp4_tc::bf16_to_floats(src_vec);
     auto dst_floats = mxfp4_tc::mx_to_floats(tt::DataFormat::MxFp4, result_vec);
     EXPECT_TRUE(mxfp4_tc::is_close_vectors<float>(src_floats, dst_floats, [](float a, float b) {
@@ -376,12 +383,16 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp4) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp4Fp32Dest) {
-    auto& mesh_device = *devices_[0];
     constexpr uint32_t num_tiles = 64;
     auto src_vec = create_random_vector_of_bfloat16(
         tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
     auto result_vec = mxfp4_tc::run_mxfp4_typecast(
-        mesh_device, tt::DataFormat::Float16_b, tt::DataFormat::MxFp4, src_vec, num_tiles, /*fp32_dest_acc_en=*/true);
+        this->device(),
+        tt::DataFormat::Float16_b,
+        tt::DataFormat::MxFp4,
+        src_vec,
+        num_tiles,
+        /*fp32_dest_acc_en=*/true);
     auto src_floats = mxfp4_tc::bf16_to_floats(src_vec);
     auto dst_floats = mxfp4_tc::mx_to_floats(tt::DataFormat::MxFp4, result_vec);
     EXPECT_TRUE(mxfp4_tc::is_close_vectors<float>(src_floats, dst_floats, [](float a, float b) {
@@ -396,12 +407,11 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp4Fp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToMxFp4) {
-    auto& mesh_device = *devices_[0];
     constexpr uint32_t num_tiles = 64;
     auto src_vec = mxfp4_tc::create_random_vector_of_mxfp4(
         tt::tile_size(tt::DataFormat::MxFp4) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
     auto result_vec = mxfp4_tc::run_mxfp4_typecast(
-        mesh_device, tt::DataFormat::MxFp4, tt::DataFormat::MxFp4, src_vec, num_tiles, /*fp32_dest_acc_en=*/false);
+        this->device(), tt::DataFormat::MxFp4, tt::DataFormat::MxFp4, src_vec, num_tiles, /*fp32_dest_acc_en=*/false);
     auto src_floats = mxfp4_tc::mx_to_floats(tt::DataFormat::MxFp4, src_vec);
     auto dst_floats = mxfp4_tc::mx_to_floats(tt::DataFormat::MxFp4, result_vec);
     EXPECT_TRUE(mxfp4_tc::is_close_vectors<float>(src_floats, dst_floats, [](float a, float b) {
@@ -411,12 +421,11 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToMxFp4) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToMxFp4Fp32Dest) {
-    auto& mesh_device = *devices_[0];
     constexpr uint32_t num_tiles = 64;
     auto src_vec = mxfp4_tc::create_random_vector_of_mxfp4(
         tt::tile_size(tt::DataFormat::MxFp4) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
     auto result_vec = mxfp4_tc::run_mxfp4_typecast(
-        mesh_device, tt::DataFormat::MxFp4, tt::DataFormat::MxFp4, src_vec, num_tiles, /*fp32_dest_acc_en=*/true);
+        this->device(), tt::DataFormat::MxFp4, tt::DataFormat::MxFp4, src_vec, num_tiles, /*fp32_dest_acc_en=*/true);
     auto src_floats = mxfp4_tc::mx_to_floats(tt::DataFormat::MxFp4, src_vec);
     auto dst_floats = mxfp4_tc::mx_to_floats(tt::DataFormat::MxFp4, result_vec);
     EXPECT_TRUE(mxfp4_tc::is_close_vectors<float>(src_floats, dst_floats, [](float a, float b) {
@@ -446,7 +455,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToMxFp4Fp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToBf16SpecialCases) {
-    auto& mesh_device = *devices_[0];
     auto layout = mxfp4_tc::get_mxfp4_tile_layout();
 
     // Block 0: scale = 0xFF → all 32 elements should be NaN (rule 1).
@@ -469,7 +477,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp4ToBf16SpecialCases) {
         {{32, 0x6}, {33, 0x7}, {34, 0xE}, {35, 0xF}, {64, 0x7}, {65, 0xF}, {96, 0x2}, {128, 0x1}, {129, 0x9}});
 
     auto result = mxfp4_tc::run_mxfp4_typecast(
-        mesh_device,
+        this->device(),
         tt::DataFormat::MxFp4,
         tt::DataFormat::Float16_b,
         packed,

--- a/tests/tt_metal/tt_metal/llk/test_mxfp6_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp6_typecast.cpp
@@ -53,25 +53,19 @@ static vector<uint32_t> run_mxfp6_typecast(
     const vector<uint32_t>& src_vec,
     uint32_t num_tiles,
     bool fp32_dest_acc_en) {
-    IDevice* dev = mesh_device.get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     uint32_t input_tile_size = tt::tile_size(input_fmt);
     uint32_t output_tile_size = tt::tile_size(output_fmt);
 
-    InterleavedBufferConfig src_config{
-        .device = dev,
-        .size = num_tiles * input_tile_size,
-        .page_size = num_tiles * input_tile_size,
-        .buffer_type = BufferType::DRAM};
-    auto src_buffer = CreateBuffer(src_config);
-
-    InterleavedBufferConfig dst_config{
-        .device = dev,
-        .size = num_tiles * output_tile_size,
-        .page_size = num_tiles * output_tile_size,
-        .buffer_type = BufferType::DRAM};
-    auto dst_buffer = CreateBuffer(dst_config);
+    auto src_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = num_tiles * input_tile_size},
+        {.page_size = num_tiles * input_tile_size, .buffer_type = BufferType::DRAM},
+        &mesh_device);
+    auto dst_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = num_tiles * output_tile_size},
+        {.page_size = num_tiles * output_tile_size, .buffer_type = BufferType::DRAM},
+        &mesh_device);
 
     const experimental::DFBSpecName INPUT_DFB{"input_dfb"};
     const experimental::DFBSpecName OUTPUT_DFB{"output_dfb"};
@@ -159,7 +153,8 @@ static vector<uint32_t> run_mxfp6_typecast(
 
     Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
-    detail::WriteToBuffer(src_buffer, src_vec);
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, src_buffer, src_vec, /*blocking=*/true);
     // The direct reader/writer kernels address a single DRAM bank
     // (bank_id 0). Use page_size = whole buffer so the allocator places the
     // buffer in one bank, and advance the DRAM pointer by the native tile
@@ -194,7 +189,7 @@ static vector<uint32_t> run_mxfp6_typecast(
     LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     vector<uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_buffer, /*blocking=*/true);
     return result_vec;
 }
 
@@ -460,9 +455,8 @@ namespace mxfp6_tc = unit_tests::llk::mxfp6_typecast;
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6RToFloat16b) {
-    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::MxFp6R,
         tt::DataFormat::Float16_b,
         /*rtol=*/0.0f,
@@ -472,9 +466,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6RToFloat16b) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6RToFloat16bFp32Dest) {
-    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::MxFp6R,
         tt::DataFormat::Float16_b,
         /*rtol=*/0.0f,
@@ -491,9 +484,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6RToFloat16bFp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6R) {
-    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::Float16_b,
         tt::DataFormat::MxFp6R,
         /*rtol=*/0.5f,
@@ -503,9 +495,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6R) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6RFp32Dest) {
-    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::Float16_b,
         tt::DataFormat::MxFp6R,
         /*rtol=*/0.5f,
@@ -519,9 +510,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6RFp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6RToMxFp6R) {
-    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::MxFp6R,
         tt::DataFormat::MxFp6R,
         /*rtol=*/0.0f,
@@ -531,9 +521,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6RToMxFp6R) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6RToMxFp6RFp32Dest) {
-    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::MxFp6R,
         tt::DataFormat::MxFp6R,
         /*rtol=*/0.0f,
@@ -548,9 +537,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6RToMxFp6RFp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6PToFloat16b) {
-    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::MxFp6P,
         tt::DataFormat::Float16_b,
         /*rtol=*/0.0f,
@@ -560,9 +548,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6PToFloat16b) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6PToFloat16bFp32Dest) {
-    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::MxFp6P,
         tt::DataFormat::Float16_b,
         /*rtol=*/0.0f,
@@ -579,9 +566,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6PToFloat16bFp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6P) {
-    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::Float16_b,
         tt::DataFormat::MxFp6P,
         /*rtol=*/0.5f,
@@ -591,9 +577,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6P) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6PFp32Dest) {
-    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::Float16_b,
         tt::DataFormat::MxFp6P,
         /*rtol=*/0.5f,
@@ -607,9 +592,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6PFp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6PToMxFp6P) {
-    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::MxFp6P,
         tt::DataFormat::MxFp6P,
         /*rtol=*/0.0f,
@@ -619,9 +603,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6PToMxFp6P) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6PToMxFp6PFp32Dest) {
-    auto& mesh_device = *devices_[0];
     mxfp6_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::MxFp6P,
         tt::DataFormat::MxFp6P,
         /*rtol=*/0.0f,
@@ -651,7 +634,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6PToMxFp6PFp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6RToBf16SpecialCases) {
-    auto& mesh_device = *devices_[0];
     auto layout = mxfp6_tc::get_mxfp6_tile_layout();
 
     // Block 0: scale = 0xFF → all 32 elements should be NaN.
@@ -672,7 +654,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6RToBf16SpecialCases) {
         {{32, 0x70}, {33, 0x7C}, {34, 0xF0}, {35, 0xFC}, {64, 0x7C}, {65, 0xFC}, {96, 0x30}, {128, 0x04}, {129, 0x84}});
 
     auto result = mxfp6_tc::run_mxfp6_typecast(
-        mesh_device,
+        this->device(),
         tt::DataFormat::MxFp6R,
         tt::DataFormat::Float16_b,
         packed,
@@ -719,7 +701,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6RToBf16SpecialCases) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6PToBf16SpecialCases) {
-    auto& mesh_device = *devices_[0];
     auto layout = mxfp6_tc::get_mxfp6_tile_layout();
 
     // Block 0: scale = 0xFF → all 32 elements should be NaN.
@@ -737,7 +718,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6PToBf16SpecialCases) {
         {{32, 0x60}, {33, 0x7C}, {34, 0xE0}, {35, 0xFC}, {64, 0x7C}, {65, 0xFC}, {96, 0x20}, {128, 0x04}, {129, 0x84}});
 
     auto result = mxfp6_tc::run_mxfp6_typecast(
-        mesh_device,
+        this->device(),
         tt::DataFormat::MxFp6P,
         tt::DataFormat::Float16_b,
         packed,
@@ -775,8 +756,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp6PToBf16SpecialCases) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6RSpecialCases) {
-    auto& mesh_device = *devices_[0];
-
     // Block layout (32 BF16 elements per block):
     //   0: all +NaN  → block must read as NaN (NaN propagation).
     //   1: all +Inf  → NaN or +max-normal (saturation; MXFP6R has no Inf).
@@ -790,7 +769,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6RSpecialCases) {
     auto src = mxfp6_tc::build_bf16_tile_with_block_values({kBf16PosNaN, kBf16PosInf, kBf16NegInf, kBf16PosOne});
 
     auto result = mxfp6_tc::run_mxfp6_typecast(
-        mesh_device,
+        this->device(),
         tt::DataFormat::Float16_b,
         tt::DataFormat::MxFp6R,
         src,
@@ -842,8 +821,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6RSpecialCases) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6PSpecialCases) {
-    auto& mesh_device = *devices_[0];
-
     constexpr uint16_t kBf16PosNaN = 0x7FC0;
     constexpr uint16_t kBf16PosInf = 0x7F80;
     constexpr uint16_t kBf16NegInf = 0xFF80;
@@ -852,7 +829,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp6PSpecialCases) {
     auto src = mxfp6_tc::build_bf16_tile_with_block_values({kBf16PosNaN, kBf16PosInf, kBf16NegInf, kBf16PosOne});
 
     auto result = mxfp6_tc::run_mxfp6_typecast(
-        mesh_device,
+        this->device(),
         tt::DataFormat::Float16_b,
         tt::DataFormat::MxFp6P,
         src,

--- a/tests/tt_metal/tt_metal/llk/test_mxfp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxfp8_typecast.cpp
@@ -52,25 +52,19 @@ static vector<uint32_t> run_mxfp8_typecast(
     const vector<uint32_t>& src_vec,
     uint32_t num_tiles,
     bool fp32_dest_acc_en) {
-    IDevice* dev = mesh_device.get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     uint32_t input_tile_size = tt::tile_size(input_fmt);
     uint32_t output_tile_size = tt::tile_size(output_fmt);
 
-    InterleavedBufferConfig src_config{
-        .device = dev,
-        .size = num_tiles * input_tile_size,
-        .page_size = num_tiles * input_tile_size,
-        .buffer_type = BufferType::DRAM};
-    auto src_buffer = CreateBuffer(src_config);
-
-    InterleavedBufferConfig dst_config{
-        .device = dev,
-        .size = num_tiles * output_tile_size,
-        .page_size = num_tiles * output_tile_size,
-        .buffer_type = BufferType::DRAM};
-    auto dst_buffer = CreateBuffer(dst_config);
+    auto src_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = num_tiles * input_tile_size},
+        {.page_size = num_tiles * input_tile_size, .buffer_type = BufferType::DRAM},
+        &mesh_device);
+    auto dst_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = num_tiles * output_tile_size},
+        {.page_size = num_tiles * output_tile_size, .buffer_type = BufferType::DRAM},
+        &mesh_device);
 
     const experimental::DFBSpecName INPUT_DFB{"input_dfb"};
     const experimental::DFBSpecName OUTPUT_DFB{"output_dfb"};
@@ -158,7 +152,8 @@ static vector<uint32_t> run_mxfp8_typecast(
 
     Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
-    detail::WriteToBuffer(src_buffer, src_vec);
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, src_buffer, src_vec, /*blocking=*/true);
     // The direct reader/writer kernels address a single DRAM bank
     // (bank_id 0). Use page_size = whole buffer so the allocator places the
     // buffer in one bank, and advance the DRAM pointer by the native tile
@@ -193,7 +188,7 @@ static vector<uint32_t> run_mxfp8_typecast(
     LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     vector<uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_buffer, /*blocking=*/true);
     return result_vec;
 }
 
@@ -452,9 +447,8 @@ namespace mxfp8_tc = unit_tests::llk::mxfp8_typecast;
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp8RToFloat16b) {
-    auto& mesh_device = *devices_[0];
     mxfp8_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::MxFp8R,
         tt::DataFormat::Float16_b,
         /*rtol=*/0.0f,
@@ -464,9 +458,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp8RToFloat16b) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp8RToFloat16bFp32Dest) {
-    auto& mesh_device = *devices_[0];
     mxfp8_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::MxFp8R,
         tt::DataFormat::Float16_b,
         /*rtol=*/0.0f,
@@ -483,9 +476,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp8RToFloat16bFp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp8PToFloat16b) {
-    auto& mesh_device = *devices_[0];
     mxfp8_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::MxFp8P,
         tt::DataFormat::Float16_b,
         /*rtol=*/0.0f,
@@ -495,9 +487,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp8PToFloat16b) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp8PToFloat16bFp32Dest) {
-    auto& mesh_device = *devices_[0];
     mxfp8_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::MxFp8P,
         tt::DataFormat::Float16_b,
         /*rtol=*/0.0f,
@@ -513,9 +504,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp8PToFloat16bFp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp8R) {
-    auto& mesh_device = *devices_[0];
     mxfp8_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::Float16_b,
         tt::DataFormat::MxFp8R,
         /*rtol=*/0.25f,
@@ -525,9 +515,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp8R) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp8RFp32Dest) {
-    auto& mesh_device = *devices_[0];
     mxfp8_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::Float16_b,
         tt::DataFormat::MxFp8R,
         /*rtol=*/0.25f,
@@ -543,9 +532,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp8RFp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp8P) {
-    auto& mesh_device = *devices_[0];
     mxfp8_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::Float16_b,
         tt::DataFormat::MxFp8P,
         /*rtol=*/0.125f,
@@ -555,9 +543,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp8P) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp8PFp32Dest) {
-    auto& mesh_device = *devices_[0];
     mxfp8_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::Float16_b,
         tt::DataFormat::MxFp8P,
         /*rtol=*/0.125f,
@@ -572,9 +559,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp8PFp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp8RToMxFp8R) {
-    auto& mesh_device = *devices_[0];
     mxfp8_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::MxFp8R,
         tt::DataFormat::MxFp8R,
         /*rtol=*/0.0f,
@@ -584,9 +570,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp8RToMxFp8R) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp8RToMxFp8RFp32Dest) {
-    auto& mesh_device = *devices_[0];
     mxfp8_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::MxFp8R,
         tt::DataFormat::MxFp8R,
         /*rtol=*/0.0f,
@@ -601,9 +586,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp8RToMxFp8RFp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp8PToMxFp8P) {
-    auto& mesh_device = *devices_[0];
     mxfp8_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::MxFp8P,
         tt::DataFormat::MxFp8P,
         /*rtol=*/0.0f,
@@ -613,9 +597,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp8PToMxFp8P) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp8PToMxFp8PFp32Dest) {
-    auto& mesh_device = *devices_[0];
     mxfp8_tc::run_random_typecast_test(
-        mesh_device,
+        this->device(),
         tt::DataFormat::MxFp8P,
         tt::DataFormat::MxFp8P,
         /*rtol=*/0.0f,
@@ -633,7 +616,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp8PToMxFp8PFp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp8RToBf16SpecialCases) {
-    auto& mesh_device = *devices_[0];
     auto layout = mxfp8_tc::get_e5m2_tile_layout();
 
     // Block 0: scale = 0xFF → all 32 elements should be NaN (rule 1).
@@ -648,7 +630,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp8RToBf16SpecialCases) {
         {{32, 0x7C}, {33, 0xFC}, {34, 0x7D}, {35, 0x7E}, {36, 0x7F}, {64, 0x7B}, {65, 0xFB}, {96, 0x3C}});
 
     auto result = mxfp8_tc::run_mxfp8_typecast(
-        mesh_device,
+        this->device(),
         tt::DataFormat::MxFp8R,
         tt::DataFormat::Float16_b,
         packed,
@@ -671,7 +653,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp8RToBf16SpecialCases) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp8PToBf16SpecialCases) {
-    auto& mesh_device = *devices_[0];
     auto layout = mxfp8_tc::get_e4m3_tile_layout();
 
     // Block 0: scale = 0xFF → all 32 elements should be NaN (rule 1).
@@ -687,7 +668,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxFp8PToBf16SpecialCases) {
         {{32, 0x7F}, {33, 0x78}, {34, 0x7B}, {35, 0x7E}, {64, 0x7E}, {65, 0xFE}, {96, 0x38}});
 
     auto result = mxfp8_tc::run_mxfp8_typecast(
-        mesh_device,
+        this->device(),
         tt::DataFormat::MxFp8P,
         tt::DataFormat::Float16_b,
         packed,
@@ -743,8 +724,6 @@ static vector<uint32_t> build_bf16_tile_with_block_values(std::initializer_list<
 }  // namespace unit_tests::llk::mxfp8_typecast
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp8RSpecialCases) {
-    auto& mesh_device = *devices_[0];
-
     // Block layout (32 BF16 elements per block):
     //   0: all +NaN  → block must read as NaN (NaN propagation).
     //   1: all +Inf  → +Inf, NaN, or +max-normal (saturation when ovf_en=0).
@@ -758,7 +737,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp8RSpecialCases) {
     auto src = mxfp8_tc::build_bf16_tile_with_block_values({kBf16PosNaN, kBf16PosInf, kBf16NegInf, kBf16PosOne});
 
     auto result = mxfp8_tc::run_mxfp8_typecast(
-        mesh_device,
+        this->device(),
         tt::DataFormat::Float16_b,
         tt::DataFormat::MxFp8R,
         src,
@@ -804,8 +783,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp8RSpecialCases) {
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp8PSpecialCases) {
-    auto& mesh_device = *devices_[0];
-
     // Block layout, mirroring the E5M2 test. E4M3 has no Inf encoding, so the
     // ±Inf blocks must produce either NaN or saturate to ±max-normal.
     //   0: all +NaN  → block must read as NaN.
@@ -820,7 +797,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxFp8PSpecialCases) {
     auto src = mxfp8_tc::build_bf16_tile_with_block_values({kBf16PosNaN, kBf16PosInf, kBf16NegInf, kBf16PosOne});
 
     auto result = mxfp8_tc::run_mxfp8_typecast(
-        mesh_device,
+        this->device(),
         tt::DataFormat::Float16_b,
         tt::DataFormat::MxFp8P,
         src,

--- a/tests/tt_metal/tt_metal/llk/test_mxint_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_mxint_typecast.cpp
@@ -46,25 +46,19 @@ static vector<uint32_t> run_mxint_typecast(
     const vector<uint32_t>& src_vec,
     uint32_t num_tiles,
     bool fp32_dest_acc_en) {
-    IDevice* dev = mesh_device.get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     uint32_t input_tile_size = tt::tile_size(input_fmt);
     uint32_t output_tile_size = tt::tile_size(output_fmt);
 
-    InterleavedBufferConfig src_config{
-        .device = dev,
-        .size = num_tiles * input_tile_size,
-        .page_size = num_tiles * input_tile_size,
-        .buffer_type = BufferType::DRAM};
-    auto src_buffer = CreateBuffer(src_config);
-
-    InterleavedBufferConfig dst_config{
-        .device = dev,
-        .size = num_tiles * output_tile_size,
-        .page_size = num_tiles * output_tile_size,
-        .buffer_type = BufferType::DRAM};
-    auto dst_buffer = CreateBuffer(dst_config);
+    auto src_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = num_tiles * input_tile_size},
+        {.page_size = num_tiles * input_tile_size, .buffer_type = BufferType::DRAM},
+        &mesh_device);
+    auto dst_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = num_tiles * output_tile_size},
+        {.page_size = num_tiles * output_tile_size, .buffer_type = BufferType::DRAM},
+        &mesh_device);
 
     const experimental::DFBSpecName INPUT_DFB{"input_dfb"};
     const experimental::DFBSpecName OUTPUT_DFB{"output_dfb"};
@@ -142,7 +136,8 @@ static vector<uint32_t> run_mxint_typecast(
 
     Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
-    detail::WriteToBuffer(src_buffer, src_vec);
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, src_buffer, src_vec, /*blocking=*/true);
     // These simple test kernels take an explicit bank id and linear address,
     // so keep each buffer as one DRAM page and walk tiles contiguously within
     // bank 0 instead of using interleaved per-tile pages.
@@ -176,7 +171,7 @@ static vector<uint32_t> run_mxint_typecast(
     LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     vector<uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_buffer, /*blocking=*/true);
     return result_vec;
 }
 
@@ -289,27 +284,27 @@ namespace mxint_tc = unit_tests::llk::mxint_typecast;
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxInt8ToFloat16b) {
     mxint_tc::run_widening_or_identity_test(
-        *devices_[0], tt::DataFormat::MxInt8, tt::DataFormat::Float16_b, /*fp32_dest_acc_en=*/false);
+        this->device(), tt::DataFormat::MxInt8, tt::DataFormat::Float16_b, /*fp32_dest_acc_en=*/false);
 }
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxInt8ToFloat16bFp32Dest) {
     mxint_tc::run_widening_or_identity_test(
-        *devices_[0], tt::DataFormat::MxInt8, tt::DataFormat::Float16_b, /*fp32_dest_acc_en=*/true);
+        this->device(), tt::DataFormat::MxInt8, tt::DataFormat::Float16_b, /*fp32_dest_acc_en=*/true);
 }
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxInt4ToFloat16b) {
     mxint_tc::run_widening_or_identity_test(
-        *devices_[0], tt::DataFormat::MxInt4, tt::DataFormat::Float16_b, /*fp32_dest_acc_en=*/false);
+        this->device(), tt::DataFormat::MxInt4, tt::DataFormat::Float16_b, /*fp32_dest_acc_en=*/false);
 }
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxInt4ToFloat16bFp32Dest) {
     mxint_tc::run_widening_or_identity_test(
-        *devices_[0], tt::DataFormat::MxInt4, tt::DataFormat::Float16_b, /*fp32_dest_acc_en=*/true);
+        this->device(), tt::DataFormat::MxInt4, tt::DataFormat::Float16_b, /*fp32_dest_acc_en=*/true);
 }
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxInt2ToFloat16b) {
     mxint_tc::run_widening_or_identity_test(
-        *devices_[0], tt::DataFormat::MxInt2, tt::DataFormat::Float16_b, /*fp32_dest_acc_en=*/false);
+        this->device(), tt::DataFormat::MxInt2, tt::DataFormat::Float16_b, /*fp32_dest_acc_en=*/false);
 }
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxInt2ToFloat16bFp32Dest) {
     mxint_tc::run_widening_or_identity_test(
-        *devices_[0], tt::DataFormat::MxInt2, tt::DataFormat::Float16_b, /*fp32_dest_acc_en=*/true);
+        this->device(), tt::DataFormat::MxInt2, tt::DataFormat::Float16_b, /*fp32_dest_acc_en=*/true);
 }
 
 // ============================================================================
@@ -319,22 +314,22 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxInt2ToFloat16bFp32Dest) {
 // ============================================================================
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxInt8) {
-    mxint_tc::run_narrowing_test(*devices_[0], tt::DataFormat::MxInt8, /*atol=*/0.125f, /*fp32_dest_acc_en=*/false);
+    mxint_tc::run_narrowing_test(this->device(), tt::DataFormat::MxInt8, /*atol=*/0.125f, /*fp32_dest_acc_en=*/false);
 }
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxInt8Fp32Dest) {
-    mxint_tc::run_narrowing_test(*devices_[0], tt::DataFormat::MxInt8, /*atol=*/0.125f, /*fp32_dest_acc_en=*/true);
+    mxint_tc::run_narrowing_test(this->device(), tt::DataFormat::MxInt8, /*atol=*/0.125f, /*fp32_dest_acc_en=*/true);
 }
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxInt4) {
-    mxint_tc::run_narrowing_test(*devices_[0], tt::DataFormat::MxInt4, /*atol=*/2.0f, /*fp32_dest_acc_en=*/false);
+    mxint_tc::run_narrowing_test(this->device(), tt::DataFormat::MxInt4, /*atol=*/2.0f, /*fp32_dest_acc_en=*/false);
 }
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxInt4Fp32Dest) {
-    mxint_tc::run_narrowing_test(*devices_[0], tt::DataFormat::MxInt4, /*atol=*/2.0f, /*fp32_dest_acc_en=*/true);
+    mxint_tc::run_narrowing_test(this->device(), tt::DataFormat::MxInt4, /*atol=*/2.0f, /*fp32_dest_acc_en=*/true);
 }
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxInt2) {
-    mxint_tc::run_narrowing_test(*devices_[0], tt::DataFormat::MxInt2, /*atol=*/8.0f, /*fp32_dest_acc_en=*/false);
+    mxint_tc::run_narrowing_test(this->device(), tt::DataFormat::MxInt2, /*atol=*/8.0f, /*fp32_dest_acc_en=*/false);
 }
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxInt2Fp32Dest) {
-    mxint_tc::run_narrowing_test(*devices_[0], tt::DataFormat::MxInt2, /*atol=*/8.0f, /*fp32_dest_acc_en=*/true);
+    mxint_tc::run_narrowing_test(this->device(), tt::DataFormat::MxInt2, /*atol=*/8.0f, /*fp32_dest_acc_en=*/true);
 }
 
 // ============================================================================
@@ -343,27 +338,27 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixFloat16bToMxInt2Fp32Dest) {
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxInt8ToMxInt8) {
     mxint_tc::run_widening_or_identity_test(
-        *devices_[0], tt::DataFormat::MxInt8, tt::DataFormat::MxInt8, /*fp32_dest_acc_en=*/false);
+        this->device(), tt::DataFormat::MxInt8, tt::DataFormat::MxInt8, /*fp32_dest_acc_en=*/false);
 }
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxInt8ToMxInt8Fp32Dest) {
     mxint_tc::run_widening_or_identity_test(
-        *devices_[0], tt::DataFormat::MxInt8, tt::DataFormat::MxInt8, /*fp32_dest_acc_en=*/true);
+        this->device(), tt::DataFormat::MxInt8, tt::DataFormat::MxInt8, /*fp32_dest_acc_en=*/true);
 }
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxInt4ToMxInt4) {
     mxint_tc::run_widening_or_identity_test(
-        *devices_[0], tt::DataFormat::MxInt4, tt::DataFormat::MxInt4, /*fp32_dest_acc_en=*/false);
+        this->device(), tt::DataFormat::MxInt4, tt::DataFormat::MxInt4, /*fp32_dest_acc_en=*/false);
 }
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxInt4ToMxInt4Fp32Dest) {
     mxint_tc::run_widening_or_identity_test(
-        *devices_[0], tt::DataFormat::MxInt4, tt::DataFormat::MxInt4, /*fp32_dest_acc_en=*/true);
+        this->device(), tt::DataFormat::MxInt4, tt::DataFormat::MxInt4, /*fp32_dest_acc_en=*/true);
 }
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxInt2ToMxInt2) {
     mxint_tc::run_widening_or_identity_test(
-        *devices_[0], tt::DataFormat::MxInt2, tt::DataFormat::MxInt2, /*fp32_dest_acc_en=*/false);
+        this->device(), tt::DataFormat::MxInt2, tt::DataFormat::MxInt2, /*fp32_dest_acc_en=*/false);
 }
 TEST_F(QuasarMeshDeviceSingleCardFixture, TensixMxInt2ToMxInt2Fp32Dest) {
     mxint_tc::run_widening_or_identity_test(
-        *devices_[0], tt::DataFormat::MxInt2, tt::DataFormat::MxInt2, /*fp32_dest_acc_en=*/true);
+        this->device(), tt::DataFormat::MxInt2, tt::DataFormat::MxInt2, /*fp32_dest_acc_en=*/true);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_compute.cpp
@@ -684,26 +684,22 @@ experimental::KernelSpec::CompilerOptions::Defines to_kernel_defines(const std::
 /// keeps the Gen1+Gen2 data-movement config and the MeshWorkload dispatch path. Callers supply the
 /// compute `defines` (op selection / chain) and the packed SRC bytes, and verify the returned DST bytes.
 std::vector<uint32_t> run_sfpu_pipeline(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     const SfpuConfig& test_config,
     const std::map<std::string, std::string>& defines,
     const std::vector<uint32_t>& packed_input) {
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     const size_t in_bytes = test_config.num_tiles * tt::tile_size(test_config.l1_input_data_format);
     const size_t out_bytes = test_config.num_tiles * tt::tile_size(test_config.l1_output_data_format);
 
-    tt::tt_metal::InterleavedBufferConfig in_dram{
-        .device = mesh_device->get_devices()[0],
-        .size = in_bytes,
-        .page_size = in_bytes,
-        .buffer_type = tt::tt_metal::BufferType::DRAM};
-    tt::tt_metal::InterleavedBufferConfig out_dram{
-        .device = mesh_device->get_devices()[0],
-        .size = out_bytes,
-        .page_size = out_bytes,
-        .buffer_type = tt::tt_metal::BufferType::DRAM};
-    auto input_dram_buffer = CreateBuffer(in_dram);
-    auto output_dram_buffer = CreateBuffer(out_dram);
+    auto input_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = in_bytes},
+        {.page_size = in_bytes, .buffer_type = BufferType::DRAM},
+        &mesh_device);
+    auto output_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = out_bytes},
+        {.page_size = out_bytes, .buffer_type = BufferType::DRAM},
+        &mesh_device);
 
     // Every parametrization of these tests uses a single-core CoreRangeSet of {0, 0};
     // MakeProgramFromSpec models the kernel set per single-core WorkUnit.
@@ -728,7 +724,7 @@ std::vector<uint32_t> run_sfpu_pipeline(
         make_dfb_spec(OUT_DFB, test_config, test_config.l1_output_data_format);
 
     experimental::DataMovementHardwareConfig reader_hw_config;
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         reader_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
     } else {
         reader_hw_config = experimental::DataMovementGen1Config{
@@ -750,7 +746,7 @@ std::vector<uint32_t> run_sfpu_pipeline(
     };
 
     experimental::DataMovementHardwareConfig writer_hw_config;
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         writer_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
     } else {
         writer_hw_config = experimental::DataMovementGen1Config{
@@ -777,7 +773,7 @@ std::vector<uint32_t> run_sfpu_pipeline(
         unpack_modes = {{IN_DFB, tt::tt_metal::UnpackMode::UnpackToDest}};
     }
     const bool fp32_dest_acc_en = test_config.en_32bit_dest;
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         compute_hw_config = experimental::ComputeGen2Config{
             .sfpu_precision_mode =
                 test_config.approx_mode ? tt::tt_metal::Precision::Approximate : tt::tt_metal::Precision::Precise,
@@ -831,7 +827,7 @@ std::vector<uint32_t> run_sfpu_pipeline(
         .work_units = {wu},
     };
 
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -861,12 +857,12 @@ std::vector<uint32_t> run_sfpu_pipeline(
     };
     experimental::SetProgramRunArgs(program_run, params);
 
-    tt_metal::detail::WriteToBuffer(input_dram_buffer, packed_input);
+    distributed::EnqueueWriteMeshBuffer(cq, input_dram_buffer, packed_input, /*blocking=*/true);
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::Finish(cq);
 
     std::vector<uint32_t> dest_buffer_data;
-    tt_metal::detail::ReadFromBuffer(output_dram_buffer, dest_buffer_data);
+    distributed::EnqueueReadMeshBuffer(cq, dest_buffer_data, output_dram_buffer, /*blocking=*/true);
     return dest_buffer_data;
 }
 
@@ -875,8 +871,7 @@ std::vector<uint32_t> run_sfpu_pipeline(
 /// @param device
 /// @param test_config - Configuration of the test -- see struct
 /// @return
-bool run_sfpu_all_same_buffer(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const SfpuConfig& test_config) {
+bool run_sfpu_all_same_buffer(distributed::MeshDevice& mesh_device, const SfpuConfig& test_config) {
     const size_t byte_size = test_config.num_tiles * test_config.tile_byte_size;
 
     // Input
@@ -1447,10 +1442,7 @@ bool run_sfpu_ternary_three_input_buffer(
 /// MX <-> float pairs issue no SFPU op (the unpack/pack gasket performs the conversion); the kernel
 /// chain still runs copy_tile + pack_tile, so the conversion happens symmetrically on both threads.
 bool run_sfpu_typecast(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    tt::DataFormat in_fmt,
-    tt::DataFormat out_fmt,
-    size_t num_tiles) {
+    distributed::MeshDevice& mesh_device, tt::DataFormat in_fmt, tt::DataFormat out_fmt, size_t num_tiles) {
     const size_t numel = num_tiles * tt::constants::TILE_HW;
     const int seed = std::chrono::system_clock::now().time_since_epoch().count();
     auto vals = sfpu_util::generate_typecast_input(numel, seed, in_fmt, out_fmt);
@@ -1508,10 +1500,7 @@ bool run_sfpu_typecast(
 }  // namespace unit_tests::compute::sfpu
 
 void run_quasar_sfpu_unpack_to_dest_fp32(
-    const std::shared_ptr<distributed::MeshDevice>& dev,
-    size_t num_tiles,
-    const std::string& sfpu_op,
-    bool dst_full_sync_en) {
+    distributed::MeshDevice& dev, size_t num_tiles, const std::string& sfpu_op, bool dst_full_sync_en) {
     CoreRange core_range({0, 0}, {0, 0});
     CoreRangeSet core_range_set({core_range});
     unit_tests::compute::sfpu::SfpuConfig cfg{
@@ -1532,10 +1521,7 @@ void run_quasar_sfpu_unpack_to_dest_fp32(
 }
 
 void run_quasar_sfpu_unpack_to_dest_16b(
-    const std::shared_ptr<distributed::MeshDevice>& dev,
-    size_t num_tiles,
-    const std::string& sfpu_op,
-    bool dst_full_sync_en) {
+    distributed::MeshDevice& dev, size_t num_tiles, const std::string& sfpu_op, bool dst_full_sync_en) {
     CoreRange core_range({0, 0}, {0, 0});
     CoreRangeSet core_range_set({core_range});
     unit_tests::compute::sfpu::SfpuConfig cfg{
@@ -1585,7 +1571,7 @@ TEST_P(SingleCoreSingleMeshDeviceSfpuParameterizedFixture, TensixSfpuCompute) {
         .approx_mode = false};
     log_info(tt::LogTest, "Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
     for (auto& device : this->devices_) {
-        EXPECT_TRUE(run_sfpu_all_same_buffer(device, test_config));
+        EXPECT_TRUE(run_sfpu_all_same_buffer(*device, test_config));
     }
 }
 
@@ -1671,7 +1657,7 @@ TEST_P(SingleCoreSingleMeshDeviceSfpuParameterizedApproxFixture, TensixSfpuCompu
         .approx_mode = true};
     log_info(tt::LogTest, "Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
     for (auto& device : this->devices_) {
-        EXPECT_TRUE(run_sfpu_all_same_buffer(device, test_config));
+        EXPECT_TRUE(run_sfpu_all_same_buffer(*device, test_config));
     }
 }
 INSTANTIATE_TEST_SUITE_P(
@@ -1730,7 +1716,7 @@ TEST_P(SingleCoreSingleMeshDeviceSfpuParameterized32BitDestFixture, TensixSfpuCo
         .en_32bit_dest = true};
     log_info(tt::LogTest, "Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
     for (auto& device : this->devices_) {
-        EXPECT_TRUE(run_sfpu_all_same_buffer(device, test_config));
+        EXPECT_TRUE(run_sfpu_all_same_buffer(*device, test_config));
     }
 }
 
@@ -1801,7 +1787,7 @@ TEST_P(SingleCoreSingleMeshDeviceSfpuParameterized32BitDestApproxFixture, Tensix
         .en_32bit_dest = true};
     log_info(tt::LogTest, "Testing SFPU_OP={} num_tiles={}", sfpu_op, num_tiles);
     for (auto& device : this->devices_) {
-        EXPECT_TRUE(run_sfpu_all_same_buffer(device, test_config));
+        EXPECT_TRUE(run_sfpu_all_same_buffer(*device, test_config));
     }
 }
 INSTANTIATE_TEST_SUITE_P(
@@ -1939,7 +1925,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarSfpuRelu) {
         for (const bool dst_full_sync_en : {true, false}) {
             SCOPED_TRACE(
                 std::string("num_tiles=") + std::to_string(num_tiles) + (dst_full_sync_en ? " SyncFull" : " SyncHalf"));
-            run_quasar_sfpu_unpack_to_dest_fp32(this->devices_.at(0), num_tiles, "relu", dst_full_sync_en);
+            run_quasar_sfpu_unpack_to_dest_fp32(this->device(), num_tiles, "relu", dst_full_sync_en);
         }
     }
 }
@@ -1953,7 +1939,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarSfpuUnpackToDest16b) {
                 "Quasar SFPU 16b->DEST: num_tiles={} {}",
                 num_tiles,
                 dst_full_sync_en ? "SyncFull" : "SyncHalf");
-            run_quasar_sfpu_unpack_to_dest_16b(this->devices_.at(0), num_tiles, "relu", dst_full_sync_en);
+            run_quasar_sfpu_unpack_to_dest_16b(this->device(), num_tiles, "relu", dst_full_sync_en);
         }
     }
 }
@@ -1994,7 +1980,7 @@ TEST_P(SingleCoreSingleMeshDeviceSfpuTypecastFixture, TensixSfpuTypecast) {
         unit_tests::sfpu_util::typecast_device_format_name(in_fmt),
         unit_tests::sfpu_util::typecast_device_format_name(out_fmt));
     for (auto& device : this->devices_) {
-        EXPECT_TRUE(unit_tests::compute::sfpu::run_sfpu_typecast(device, in_fmt, out_fmt, 1));
+        EXPECT_TRUE(unit_tests::compute::sfpu::run_sfpu_typecast(*device, in_fmt, out_fmt, 1));
     }
 }
 

--- a/tests/tt_metal/tt_metal/llk/test_transpose.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_transpose.cpp
@@ -40,6 +40,7 @@
 #include "impl/data_format/bfloat16_utils.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/tensor/mesh_tensor.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
 class IDevice;
@@ -161,9 +162,8 @@ static inline tt::tt_metal::TensorSpec make_flat_dram_tensor_spec(uint32_t entry
     return tt::tt_metal::TensorSpec(tt::tt_metal::Shape{total_entries, entry_size_words}, tensor_layout);
 }
 
-void run_single_core_transpose(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const TransposeConfig& test_config) {
-    auto& cq = mesh_device->mesh_command_queue();
+void run_single_core_transpose(distributed::MeshDevice& mesh_device, const TransposeConfig& test_config) {
+    auto& cq = mesh_device.mesh_command_queue();
     const experimental::NodeCoord node{0, 0};
 
     const TransposeDims dims = compute_and_validate_transpose_dims(test_config.shape);
@@ -172,9 +172,9 @@ void run_single_core_transpose(
     uint32_t dram_buffer_size = test_config.single_tile_size * num_tensor_tiles;
 
     auto in_tensor = MeshTensor::allocate_on_device(
-        *mesh_device, make_flat_dram_tensor_spec(test_config.single_tile_size, num_tensor_tiles));
+        mesh_device, make_flat_dram_tensor_spec(test_config.single_tile_size, num_tensor_tiles));
     auto out_tensor = MeshTensor::allocate_on_device(
-        *mesh_device, make_flat_dram_tensor_spec(test_config.single_tile_size, num_tensor_tiles));
+        mesh_device, make_flat_dram_tensor_spec(test_config.single_tile_size, num_tensor_tiles));
 
     constexpr uint32_t num_buffer_tiles = 32;
     constexpr uint32_t num_output_buffer_tiles = 32;
@@ -201,7 +201,7 @@ void run_single_core_transpose(
     };
 
     experimental::DataMovementHardwareConfig reader_hw_config;
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         reader_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
     } else {
         reader_hw_config = experimental::DataMovementGen1Config{
@@ -220,7 +220,7 @@ void run_single_core_transpose(
     };
 
     experimental::DataMovementHardwareConfig writer_hw_config;
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         writer_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
     } else {
         writer_hw_config = experimental::DataMovementGen1Config{
@@ -256,7 +256,7 @@ void run_single_core_transpose(
     if (test_config.unpack_to_dest) {
         unpack_modes = {{INPUT_DFB, tt::tt_metal::UnpackMode::UnpackToDest}};
     }
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         compute_hw_config = experimental::ComputeGen2Config{
             .enable_32_bit_dest = fp32_dest_acc_en,
             .double_buffer_dest = !test_config.dst_full_sync_en,
@@ -309,7 +309,7 @@ void run_single_core_transpose(
         .work_units = {wu},
     };
 
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -356,13 +356,13 @@ void run_single_core_transpose(
     } else {
         src_vec = create_random_vector_of_bfloat16(dram_buffer_size, 100.0f, kRandomSeed);
     }
-    tt_metal::detail::WriteToBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), src_vec);
+    slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), src_vec);
 
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::Finish(cq);
 
     std::vector<uint32_t> result_vec;
-    tt_metal::detail::ReadFromBuffer(*out_tensor.mesh_buffer().get_reference_buffer(), result_vec);
+    slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), result_vec);
 
     const std::uint32_t bytes_per_elem = tt::datum_size(test_config.data_format);
     EXPECT_EQ(result_vec.size(), (dims.NC * dims.H * dims.W * bytes_per_elem) / sizeof(uint32_t));
@@ -379,7 +379,7 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeTransposeWH) {
         .single_tile_size = 2 * 1024,
         .shape = {1, 3, 3 * 32 * 1, 4 * 32 * 1},
         .transpose_type = unit_tests::compute::transpose::TransposeType::WH};
-    unit_tests::compute::transpose::run_single_core_transpose(this->devices_.at(0), test_config);
+    unit_tests::compute::transpose::run_single_core_transpose(*this->devices_.at(0), test_config);
 }
 
 TEST_F(LLKMeshDeviceFixture, TensixComputeTransposeWHShortInit) {
@@ -389,7 +389,7 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeTransposeWHShortInit) {
         .single_tile_size = 2 * 1024,
         .shape = {1, 3, 3 * 32 * 1, 4 * 32 * 1},
         .transpose_type = unit_tests::compute::transpose::TransposeType::WH};
-    unit_tests::compute::transpose::run_single_core_transpose(this->devices_.at(0), test_config);
+    unit_tests::compute::transpose::run_single_core_transpose(*this->devices_.at(0), test_config);
 }
 
 TEST_F(LLKMeshDeviceFixture, TensixComputeTransposeWHDest) {
@@ -402,7 +402,7 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeTransposeWHDest) {
         .single_tile_size = 2 * 1024,
         .shape = {1, 3, 3 * 32 * 1, 4 * 32 * 1},
         .transpose_type = unit_tests::compute::transpose::TransposeType::WH};
-    unit_tests::compute::transpose::run_single_core_transpose(this->devices_.at(0), test_config);
+    unit_tests::compute::transpose::run_single_core_transpose(*this->devices_.at(0), test_config);
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarTransposeWHDestFloat32) {
@@ -419,7 +419,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarTransposeWHDestFloat32) {
             .dst_full_sync_en = dst_full_sync_en,
             .unpack_to_dest = true,
         };
-        unit_tests::compute::transpose::run_single_core_transpose(this->devices_.at(0), test_config);
+        unit_tests::compute::transpose::run_single_core_transpose(this->device(), test_config);
     }
 }
 
@@ -438,7 +438,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarTransposeWHDestFloat16b) {
             .dst_full_sync_en = dst_full_sync_en,
             .unpack_to_dest = true,
         };
-        unit_tests::compute::transpose::run_single_core_transpose(this->devices_.at(0), test_config);
+        unit_tests::compute::transpose::run_single_core_transpose(this->device(), test_config);
     }
 }
 

--- a/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
@@ -49,6 +49,7 @@
 #include <tt-metalium/tensor/mesh_tensor.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/buffer.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
 class IDevice;
@@ -242,15 +243,14 @@ bool check_is_close(
     TT_THROW("Testing infrastructure not setup for output data type {}", T_out);
 }
 
-auto CreateDramBuffer(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, tt::DataFormat dformat, uint32_t num_tiles) {
+auto CreateDramBuffer(distributed::MeshDevice& mesh_device, tt::DataFormat dformat, uint32_t num_tiles) {
     uint32_t single_tile_size = tile_size(dformat);
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
     distributed::DeviceLocalBufferConfig dram_config{
         .page_size = single_tile_size, .buffer_type = tt_metal::BufferType::DRAM, .bottom_up = false};
     distributed::ReplicatedBufferConfig buffer_config{.size = dram_buffer_size};
 
-    return distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
+    return distributed::MeshBuffer::create(buffer_config, dram_config, &mesh_device);
 }
 
 CBHandle CreateCircularBufferHelper(
@@ -281,7 +281,7 @@ void get_packed_tilized_input_output_pair(
     std::vector<uint32_t>& packed_tilized_output);
 
 void run_single_core_unary_broadcast_quasar(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const UnaryBroadcastConfig& test_config) {
+    distributed::MeshDevice& mesh_device, const UnaryBroadcastConfig& test_config) {
     const experimental::NodeCoord node{0, 0};
 
     constexpr uint32_t num_tiles = 32;
@@ -293,9 +293,8 @@ void run_single_core_unary_broadcast_quasar(
     const uint32_t out_tile_size = tile_size(out_t);
     const uint32_t dfb_num_entries = block_size * 2;
 
-    auto in_tensor = MeshTensor::allocate_on_device(*mesh_device, make_flat_dram_tensor_spec(in_tile_size, num_tiles));
-    auto out_tensor =
-        MeshTensor::allocate_on_device(*mesh_device, make_flat_dram_tensor_spec(out_tile_size, num_tiles));
+    auto in_tensor = MeshTensor::allocate_on_device(mesh_device, make_flat_dram_tensor_spec(in_tile_size, num_tiles));
+    auto out_tensor = MeshTensor::allocate_on_device(mesh_device, make_flat_dram_tensor_spec(out_tile_size, num_tiles));
 
     const experimental::DFBSpecName SRC_DFB{"src_dfb"};
     const experimental::DFBSpecName DST_DFB{"dst_dfb"};
@@ -318,7 +317,7 @@ void run_single_core_unary_broadcast_quasar(
     };
 
     experimental::DataMovementHardwareConfig reader_hw_config;
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         reader_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
     } else {
         reader_hw_config = experimental::DataMovementGen1Config{
@@ -335,7 +334,7 @@ void run_single_core_unary_broadcast_quasar(
     };
 
     experimental::DataMovementHardwareConfig writer_hw_config;
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         writer_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
     } else {
         writer_hw_config = experimental::DataMovementGen1Config{
@@ -390,9 +389,9 @@ void run_single_core_unary_broadcast_quasar(
         .work_units = {wu},
     };
 
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
-    const uint32_t src_dram_addr = static_cast<uint32_t>(in_tensor.mesh_buffer().get_reference_buffer()->address());
+    const uint32_t src_dram_addr = static_cast<uint32_t>(in_tensor.address());
 
     experimental::ProgramRunArgs params;
     params.kernel_run_args = {
@@ -418,12 +417,12 @@ void run_single_core_unary_broadcast_quasar(
     std::vector<uint32_t> golden_packed_tilized_output;
     get_packed_tilized_input_output_pair(
         in_t, out_t, num_tiles, test_config.broadcast_dim, packed_tilized_input, golden_packed_tilized_output);
-    tt_metal::detail::WriteToBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), packed_tilized_input);
+    slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), packed_tilized_input);
 
-    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> dest_buffer_data;
-    tt_metal::detail::ReadFromBuffer(*out_tensor.mesh_buffer().get_reference_buffer(), dest_buffer_data);
+    slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), dest_buffer_data);
 
     ASSERT_TRUE(check_is_close(golden_packed_tilized_output, dest_buffer_data, out_t, "unary_broadcast_dram_out"));
 }
@@ -455,14 +454,13 @@ void get_packed_tilized_input_output_pair(
     }
 }
 
-void run_single_core_unary_broadcast(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const UnaryBroadcastConfig& test_config) {
+void run_single_core_unary_broadcast(distributed::MeshDevice& mesh_device, const UnaryBroadcastConfig& test_config) {
     if (MetalContext::instance().get_cluster().arch() == ARCH::QUASAR) {
         run_single_core_unary_broadcast_quasar(mesh_device, test_config);
         return;
     }
 
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     distributed::MeshWorkload workload;
@@ -576,7 +574,7 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeSingleTileUnaryBroadcast) {
                     broadcast_dim_to_type.at(test_config.broadcast_dim),
                     test_config.in_t,
                     test_config.out_t);
-                run_single_core_unary_broadcast(this->devices_.at(0), test_config);
+                run_single_core_unary_broadcast(*this->devices_.at(0), test_config);
             }
         }
     }
@@ -610,7 +608,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixComputeUnaryBroadcastQuasarDfb) 
                 broadcast_dim_to_type.at(test_config.broadcast_dim),
                 test_config.in_t,
                 test_config.out_t);
-            run_single_core_unary_broadcast(this->devices_.at(0), test_config);
+            run_single_core_unary_broadcast(this->device(), test_config);
         }
     }
 }

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -47,6 +47,7 @@
 #include "impl/data_format/bfloat16_utils.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/tensor/mesh_tensor.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
 class IDevice;
@@ -203,29 +204,22 @@ static void validate_result(
 // Metal 2.0 single-core helper covering all migrated tilize/untilize kernels:
 //   - UntilizeType::PACK / DST (compute kernels: pack_untilize (optionally with FAST_UNTILIZE) / dst_untilize)
 //   - TilizeType::UNPACK_A (compute kernel: tilize.cpp, optionally with FAST_TILIZE)
-void run_single_core_tilize_program(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const TestConfig& test_config) {
-    auto& cq = mesh_device->mesh_command_queue();
-    auto* dev = mesh_device->get_devices()[0];
+void run_single_core_tilize_program(distributed::MeshDevice& mesh_device, const TestConfig& test_config) {
+    auto& cq = mesh_device.mesh_command_queue();
     const experimental::NodeCoord node{0, 0};
 
     const std::uint32_t num_tiles = test_config.num_tiles_r * test_config.num_tiles_c;
     const std::uint32_t input_dram_buffer_size = test_config.input_single_tile_size * num_tiles;
     const std::uint32_t output_dram_buffer_size = test_config.output_single_tile_size * num_tiles;
 
-    tt_metal::InterleavedBufferConfig input_dram_config{
-        .device = dev,
-        .size = input_dram_buffer_size,
-        .page_size = input_dram_buffer_size,
-        .buffer_type = tt_metal::BufferType::DRAM};
-    tt_metal::InterleavedBufferConfig output_dram_config{
-        .device = dev,
-        .size = output_dram_buffer_size,
-        .page_size = output_dram_buffer_size,
-        .buffer_type = tt_metal::BufferType::DRAM};
-
-    auto src0_dram_buffer = CreateBuffer(input_dram_config);
-    auto dst_dram_buffer = CreateBuffer(output_dram_config);
+    auto src0_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = input_dram_buffer_size},
+        {.page_size = input_dram_buffer_size, .buffer_type = BufferType::DRAM},
+        &mesh_device);
+    auto dst_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = output_dram_buffer_size},
+        {.page_size = output_dram_buffer_size, .buffer_type = BufferType::DRAM},
+        &mesh_device);
     const std::uint32_t dram_buffer_src0_addr = src0_dram_buffer->address();
     const std::uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
 
@@ -283,7 +277,7 @@ void run_single_core_tilize_program(
     }
 
     experimental::DataMovementHardwareConfig reader_hw_config;
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         reader_hw_config = experimental::DataMovementGen2Config{};
     } else {
         reader_hw_config = experimental::DataMovementGen1Config{
@@ -299,7 +293,7 @@ void run_single_core_tilize_program(
     };
 
     experimental::DataMovementHardwareConfig writer_hw_config;
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         writer_hw_config = experimental::DataMovementGen2Config{};
     } else {
         writer_hw_config = experimental::DataMovementGen1Config{
@@ -348,7 +342,7 @@ void run_single_core_tilize_program(
     }
 
     experimental::ComputeHardwareConfig compute_hw_config;
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         compute_hw_config = experimental::ComputeGen2Config{
             .enable_32_bit_dest = test_config.fp32_dest_acc_en,
             .double_buffer_dest = !test_config.dst_full_sync_en,
@@ -394,7 +388,7 @@ void run_single_core_tilize_program(
         .work_units = {wu},
     };
 
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -405,7 +399,7 @@ void run_single_core_tilize_program(
     std::vector<std::uint32_t> src0_vec = test_config.src0_data.empty()
                                               ? create_arange_vector_of_bfloat16(input_dram_buffer_size, false)
                                               : test_config.src0_data;
-    tt_metal::detail::WriteToBuffer(src0_dram_buffer, src0_vec);
+    distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, src0_vec, /*blocking=*/true);
 
     experimental::ProgramRunArgs params;
     if (is_unpack_a_tilize) {
@@ -438,7 +432,7 @@ void run_single_core_tilize_program(
     distributed::Finish(cq);
 
     std::vector<std::uint32_t> result_vec;
-    tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);
 
     validate_result(test_config, src0_vec, /*src1_vec=*/{}, result_vec);
 }
@@ -446,16 +440,14 @@ void run_single_core_tilize_program(
 // Gen1-only single-core helper for the `unpack_tilizeA_B` + eltwise binary add compute kernel.
 // On Quasar, llk_unpack_tilizeA_B is only compatible with the math reduce kernel, not eltwise
 // binary add, so the caller (`TensixComputeUnpackTilizeA_B`) skips on Quasar.
-void run_single_core_unpack_tilizeA_B_program(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const TestConfig& test_config) {
-    auto& cq = mesh_device->mesh_command_queue();
+void run_single_core_unpack_tilizeA_B_program(distributed::MeshDevice& mesh_device, const TestConfig& test_config) {
+    auto& cq = mesh_device.mesh_command_queue();
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = tt::tt_metal::CreateProgram();
     workload.add_program(device_range, std::move(program));
     auto& program_ = workload.get_programs().at(device_range);
-    auto* device = mesh_device->get_devices()[0];
 
     CoreCoord core = {0, 0};
 
@@ -463,22 +455,17 @@ void run_single_core_unpack_tilizeA_B_program(
     std::uint32_t input_dram_buffer_size = test_config.input_single_tile_size * num_tiles;
     std::uint32_t output_dram_buffer_size = test_config.output_single_tile_size * num_tiles;
 
-    tt_metal::InterleavedBufferConfig input_dram_config{
-        .device = device,
-        .size = input_dram_buffer_size,
-        .page_size = input_dram_buffer_size,
-        .buffer_type = tt_metal::BufferType::DRAM};
-    tt_metal::InterleavedBufferConfig output_dram_config{
-        .device = device,
-        .size = output_dram_buffer_size,
-        .page_size = output_dram_buffer_size,
-        .buffer_type = tt_metal::BufferType::DRAM};
-
-    auto src0_dram_buffer = CreateBuffer(input_dram_config);
+    distributed::ReplicatedBufferConfig input_buffer_config{.size = input_dram_buffer_size};
+    distributed::DeviceLocalBufferConfig input_dram_config{
+        .page_size = input_dram_buffer_size, .buffer_type = BufferType::DRAM};
+    auto src0_dram_buffer = distributed::MeshBuffer::create(input_buffer_config, input_dram_config, &mesh_device);
     std::uint32_t dram_buffer_src0_addr = src0_dram_buffer->address();
-    auto src1_dram_buffer = CreateBuffer(input_dram_config);
+    auto src1_dram_buffer = distributed::MeshBuffer::create(input_buffer_config, input_dram_config, &mesh_device);
     std::uint32_t dram_buffer_src1_addr = src1_dram_buffer->address();
-    auto dst_dram_buffer = CreateBuffer(output_dram_config);
+    auto dst_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = output_dram_buffer_size},
+        {.page_size = output_dram_buffer_size, .buffer_type = BufferType::DRAM},
+        &mesh_device);
     std::uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
 
     std::uint32_t src0_cb_index = tt::CBIndex::c_0;
@@ -534,10 +521,10 @@ void run_single_core_unpack_tilizeA_B_program(
     std::vector<std::uint32_t> src0_vec = test_config.src0_data.empty()
                                               ? create_arange_vector_of_bfloat16(input_dram_buffer_size, false)
                                               : test_config.src0_data;
-    tt_metal::detail::WriteToBuffer(src0_dram_buffer, src0_vec);
+    distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, src0_vec, /*blocking=*/true);
 
     std::vector<std::uint32_t> src1_vec = create_constant_vector_of_bfloat16(input_dram_buffer_size, 1.0f);
-    tt_metal::detail::WriteToBuffer(src1_dram_buffer, src1_vec);
+    distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, src1_vec, /*blocking=*/true);
 
     tt_metal::SetRuntimeArgs(
         program_,
@@ -556,7 +543,7 @@ void run_single_core_unpack_tilizeA_B_program(
     distributed::Finish(cq);
 
     std::vector<std::uint32_t> result_vec;
-    tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);
 
     validate_result(test_config, src0_vec, src1_vec, result_vec);
 }
@@ -566,8 +553,8 @@ void run_single_core_unpack_tilizeA_B_program(
 // Uses REDUCE_COL + MAX: tilizes row-major src0 data, reduces each tile independently
 // (column-wise max within each tile), producing output tiles with only row 0 populated.
 void run_single_core_unpack_tilizeA_B_reduce_program(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const TestConfig& test_config) {
-    auto& cq = mesh_device->mesh_command_queue();
+    distributed::MeshDevice& mesh_device, const TestConfig& test_config) {
+    auto& cq = mesh_device.mesh_command_queue();
     const experimental::NodeCoord node{0, 0};
 
     const std::uint32_t num_tiles_in = test_config.num_tiles_r * test_config.num_tiles_c;
@@ -584,9 +571,9 @@ void run_single_core_unpack_tilizeA_B_reduce_program(
     };
 
     auto in_tensor = MeshTensor::allocate_on_device(
-        *mesh_device, make_flat_tensor_spec(test_config.input_single_tile_size, num_tiles_in));
+        mesh_device, make_flat_tensor_spec(test_config.input_single_tile_size, num_tiles_in));
     auto out_tensor = MeshTensor::allocate_on_device(
-        *mesh_device, make_flat_tensor_spec(test_config.output_single_tile_size, num_tiles_out));
+        mesh_device, make_flat_tensor_spec(test_config.output_single_tile_size, num_tiles_out));
 
     const experimental::DFBSpecName INP_DATA_DFB{"inp_data_dfb"};
     const experimental::DFBSpecName INP_SCALER_DFB{"inp_scaler_dfb"};
@@ -618,7 +605,7 @@ void run_single_core_unpack_tilizeA_B_reduce_program(
     };
 
     experimental::DataMovementHardwareConfig reader_hw_config;
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         reader_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
     } else {
         reader_hw_config = experimental::DataMovementGen1Config{
@@ -648,7 +635,7 @@ void run_single_core_unpack_tilizeA_B_reduce_program(
     };
 
     experimental::DataMovementHardwareConfig writer_hw_config;
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         writer_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
     } else {
         writer_hw_config = experimental::DataMovementGen1Config{
@@ -673,7 +660,7 @@ void run_single_core_unpack_tilizeA_B_reduce_program(
     }
 
     experimental::ComputeHardwareConfig compute_hw_config;
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         compute_hw_config = experimental::ComputeGen2Config{
             .enable_32_bit_dest = test_config.fp32_dest_acc_en,
             .double_buffer_dest = !test_config.dst_full_sync_en,
@@ -731,7 +718,7 @@ void run_single_core_unpack_tilizeA_B_reduce_program(
         .work_units = {wu},
     };
 
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -740,7 +727,7 @@ void run_single_core_unpack_tilizeA_B_reduce_program(
     auto& program_ = workload.get_programs().at(device_range);
 
     std::vector<std::uint32_t> src0_vec = create_random_vector_of_bfloat16(input_dram_buffer_size, 100, 42);
-    tt_metal::detail::WriteToBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), src0_vec);
+    slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), src0_vec);
 
     float scaler_f = 1.0f;
     std::vector<std::uint32_t> scaler_tile_vec = create_constant_vector_of_bfloat16(scaler_tile_size, scaler_f);
@@ -768,7 +755,7 @@ void run_single_core_unpack_tilizeA_B_reduce_program(
     distributed::Finish(cq);
 
     std::vector<std::uint32_t> result_vec;
-    tt_metal::detail::ReadFromBuffer(*out_tensor.mesh_buffer().get_reference_buffer(), result_vec);
+    slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), result_vec);
 
     validate_result(test_config, src0_vec, scaler_tile_vec, result_vec);
 }
@@ -794,7 +781,7 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeUnpackTilize) {
                     .tilize_type = unit_tests::compute::tilize::TilizeType::UNPACK_A,
                     .output_fmt = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b,
                     .golden_function = ::unit_tests::compute::gold_standard_tilize};
-                unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
+                unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
             }
         }
     }
@@ -819,7 +806,7 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixComputeUnpackTilizeFp8e4m3) {
                 .output_fmt = tt::DataFormat::Fp8_e4m3,
                 .src0_data = src_data,
                 .golden_function = ::unit_tests::compute::gold_standard_tilize};
-            unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
+            unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
         }
     }
 }
@@ -843,7 +830,7 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixComputeUnpackTilizeInt8) {
                 .output_fmt = tt::DataFormat::Int8,
                 .src0_data = src_data,
                 .golden_function = ::unit_tests::compute::gold_standard_tilize};
-            unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
+            unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
         }
     }
 }
@@ -867,7 +854,7 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixComputeUnpackTilizeUInt8) {
                 .output_fmt = tt::DataFormat::UInt8,
                 .src0_data = src_data,
                 .golden_function = ::unit_tests::compute::gold_standard_tilize};
-            unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
+            unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
         }
     }
 }
@@ -895,7 +882,7 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixComputeUnpackTilizeTinyTile16x32) {
                 .face_r_dim = face_r_dim,
                 .tilize_type = unit_tests::compute::tilize::TilizeType::UNPACK_A,
                 .golden_function = ::unit_tests::compute::gold_standard_tilize};
-            unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
+            unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
         }
     }
 }
@@ -916,7 +903,7 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeFastTilize) {
                     .tilize_type = unit_tests::compute::tilize::TilizeType::UNPACK_A,
                     .output_fmt = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b,
                     .golden_function = ::unit_tests::compute::gold_standard_tilize};
-                unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
+                unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
             }
         }
     }
@@ -936,7 +923,7 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeUnpackTilizeA_B) {
             .tilize_type = unit_tests::compute::tilize::TilizeType::UNPACK_A_B,
             .output_fmt = tt::DataFormat::Float16_b,
             .golden_function = ::unit_tests::compute::gold_standard_tilize_w_elwadd};
-        unit_tests::compute::tilize::run_single_core_unpack_tilizeA_B_program(this->devices_.at(0), test_config);
+        unit_tests::compute::tilize::run_single_core_unpack_tilizeA_B_program(*this->devices_.at(0), test_config);
     }
 }
 
@@ -946,7 +933,7 @@ Following tests are for Quasar
 enum class QuasarTestMode { TILIZE, UNTILIZE, UNTILIZE_DST };
 
 static void run_quasar_tilize_untilize_test(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     std::uint32_t num_tiles_r,
     std::uint32_t num_tiles_c,
     QuasarTestMode mode,
@@ -959,8 +946,7 @@ static void run_quasar_tilize_untilize_test(
     bool tilize_cross_tile_rows = false) {
     bool is_tilize = (mode == QuasarTestMode::TILIZE);
 
-    IDevice* dev = mesh_device->get_devices()[0];
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = mesh_device.mesh_command_queue();
     const experimental::NodeCoord node{0, 0};
 
     constexpr std::uint32_t face_c_dim = tt::constants::FACE_WIDTH;
@@ -977,18 +963,14 @@ static void run_quasar_tilize_untilize_test(
     std::uint32_t src_dram_buffer_size = input_single_tile_size * num_tiles;
     std::uint32_t dst_dram_buffer_size = output_single_tile_size * num_tiles;
 
-    InterleavedBufferConfig src_config{
-        .device = dev,
-        .size = src_dram_buffer_size,
-        .page_size = src_dram_buffer_size,
-        .buffer_type = BufferType::DRAM};
-    InterleavedBufferConfig dst_config{
-        .device = dev,
-        .size = dst_dram_buffer_size,
-        .page_size = dst_dram_buffer_size,
-        .buffer_type = BufferType::DRAM};
-    auto src_dram_buffer = CreateBuffer(src_config);
-    auto dst_dram_buffer = CreateBuffer(dst_config);
+    auto src_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = src_dram_buffer_size},
+        {.page_size = src_dram_buffer_size, .buffer_type = BufferType::DRAM},
+        &mesh_device);
+    auto dst_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = dst_dram_buffer_size},
+        {.page_size = dst_dram_buffer_size, .buffer_type = BufferType::DRAM},
+        &mesh_device);
     std::uint32_t dram_buffer_src_addr = src_dram_buffer->address();
     std::uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
 
@@ -1072,7 +1054,7 @@ static void run_quasar_tilize_untilize_test(
     }
 
     experimental::ComputeHardwareConfig compute_hw_config;
-    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
         compute_hw_config = experimental::ComputeGen2Config{
             .enable_32_bit_dest = fp32_dest_acc_en,
             .double_buffer_dest = !dst_full_sync_en,
@@ -1117,7 +1099,7 @@ static void run_quasar_tilize_untilize_test(
         .work_units = {wu},
     };
 
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -1143,7 +1125,7 @@ static void run_quasar_tilize_untilize_test(
     } else {
         src_vec = create_arange_vector_of_bfloat16(src_dram_buffer_size, false);
     }
-    detail::WriteToBuffer(src_dram_buffer, src_vec);
+    distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, src_vec, /*blocking=*/true);
 
     // This test configures the DRAM buffers as a single whole-buffer page, so
     // aligned_page_size() returns the whole-buffer stride rather than per-tile.
@@ -1179,7 +1161,7 @@ static void run_quasar_tilize_untilize_test(
     distributed::Finish(cq);
 
     std::vector<std::uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);
 
     ::unit_tests::compute::GoldenConfig golden_config = {
         .num_tiles_r_dim = static_cast<int>(num_tiles_r),
@@ -1237,7 +1219,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilize) {
                         continue;  // Int16 + 32-bit dest mode is not supported on Quasar
                     }
                     run_quasar_tilize_untilize_test(
-                        this->devices_.at(0),
+                        *this->devices_.at(0),
                         cfg[0],
                         cfg[1],
                         QuasarTestMode::UNTILIZE,
@@ -1262,7 +1244,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeDst) {
                         continue;  // Int16 + 32-bit dest mode is not supported on Quasar
                     }
                     run_quasar_tilize_untilize_test(
-                        this->devices_.at(0),
+                        *this->devices_.at(0),
                         cfg[0],
                         cfg[1],
                         QuasarTestMode::UNTILIZE_DST,
@@ -1285,7 +1267,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeTinyTile) 
         for (auto& geo : geometries) {
             for (bool dst_full_sync_en : {true, false}) {
                 run_quasar_tilize_untilize_test(
-                    this->devices_.at(0),
+                    *this->devices_.at(0),
                     cfg[0],
                     cfg[1],
                     QuasarTestMode::UNTILIZE,
@@ -1309,7 +1291,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeDstTinyTil
         for (auto& geo : geometries) {
             for (bool dst_full_sync_en : {true, false}) {
                 run_quasar_tilize_untilize_test(
-                    this->devices_.at(0),
+                    *this->devices_.at(0),
                     cfg[0],
                     cfg[1],
                     QuasarTestMode::UNTILIZE_DST,
@@ -1336,7 +1318,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilize) {
                     }
 
                     run_quasar_tilize_untilize_test(
-                        this->devices_.at(0),
+                        this->device(),
                         cfg[0],
                         cfg[1],
                         QuasarTestMode::TILIZE,
@@ -1359,7 +1341,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilizeTinyTile) 
         for (auto& geo : geometries) {
             for (bool dst_full_sync_en : {true, false}) {
                 run_quasar_tilize_untilize_test(
-                    this->devices_.at(0),
+                    *this->devices_.at(0),
                     cfg[0],
                     cfg[1],
                     QuasarTestMode::TILIZE,
@@ -1384,7 +1366,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilizeTinyTileCr
         for (auto& cfg : test_configs) {
             for (bool dst_full_sync_en : {true, false}) {
                 run_quasar_tilize_untilize_test(
-                    this->devices_.at(0),
+                    *this->devices_.at(0),
                     cfg[0],
                     cfg[1],
                     QuasarTestMode::TILIZE,
@@ -1422,7 +1404,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeUnpackTilizeA_B) {
                     .output_fmt = output_data_format,
                     .golden_function = ::unit_tests::compute::gold_standard_tilize_w_reduce_col_max};
                 unit_tests::compute::tilize::run_single_core_unpack_tilizeA_B_reduce_program(
-                    this->devices_.at(0), test_config);
+                    this->device(), test_config);
             }
         }
     }
@@ -1434,7 +1416,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeInt32) {
     for (auto& cfg : test_configs) {
         for (bool dst_full_sync_en : {true, false}) {
             run_quasar_tilize_untilize_test(
-                this->devices_.at(0),
+                *this->devices_.at(0),
                 cfg[0],
                 cfg[1],
                 QuasarTestMode::UNTILIZE,
@@ -1452,7 +1434,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputePackUntilizeDstInt32) 
     for (auto& cfg : test_configs) {
         for (bool dst_full_sync_en : {true, false}) {
             run_quasar_tilize_untilize_test(
-                this->devices_.at(0),
+                *this->devices_.at(0),
                 cfg[0],
                 cfg[1],
                 QuasarTestMode::UNTILIZE_DST,
@@ -1481,7 +1463,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputeFastUntilize) {
             .untilize_type = unit_tests::compute::tilize::UntilizeType::PACK,
             .output_fmt = tt::DataFormat::Float16_b,
             .golden_function = ::unit_tests::compute::gold_standard_untilize};
-        unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
+        unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
     }
 }
 
@@ -1503,7 +1485,7 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarComputeFastTilize) {
                     .tilize_type = unit_tests::compute::tilize::TilizeType::UNPACK_A,
                     .output_fmt = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b,
                     .golden_function = ::unit_tests::compute::gold_standard_tilize};
-                unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
+                unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
             }
         }
     }
@@ -1528,7 +1510,7 @@ TEST_F(LLKMeshDeviceFixture, TensixComputePackUntilize) {
                     .untilize_type = unit_tests::compute::tilize::UntilizeType::PACK,
                     .output_fmt = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b,
                     .golden_function = ::unit_tests::compute::gold_standard_untilize};
-                unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
+                unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
             }
         }
     }
@@ -1547,7 +1529,7 @@ TEST_F(LLKMeshDeviceFixture, TensixComputePackUntilizeDst) {
                 .untilize_type = unit_tests::compute::tilize::UntilizeType::DST,
                 .output_fmt = tt::DataFormat::Float16_b,
                 .golden_function = ::unit_tests::compute::gold_standard_untilize};
-            unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
+            unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
         }
     }
 }
@@ -1566,7 +1548,7 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeFastUntilize) {
             .untilize_type = unit_tests::compute::tilize::UntilizeType::PACK,
             .output_fmt = tt::DataFormat::Float16_b,
             .golden_function = ::unit_tests::compute::gold_standard_untilize};
-        unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
+        unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
     }
 }
 
@@ -1589,7 +1571,7 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixComputePackUntilizeFp8e4m3) {
                 .output_fmt = tt::DataFormat::Fp8_e4m3,
                 .src0_data = src_data,
                 .golden_function = ::unit_tests::compute::gold_standard_untilize};
-            unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
+            unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
         }
     }
 }
@@ -1612,7 +1594,7 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixComputePackUntilizeInt8) {
                 .output_fmt = tt::DataFormat::Int8,
                 .src0_data = src_data,
                 .golden_function = ::unit_tests::compute::gold_standard_untilize};
-            unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
+            unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
         }
     }
 }
@@ -1635,7 +1617,7 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixComputePackUntilizeUInt8) {
                 .output_fmt = tt::DataFormat::UInt8,
                 .src0_data = src_data,
                 .golden_function = ::unit_tests::compute::gold_standard_untilize};
-            unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
+            unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
         }
     }
 }
@@ -1661,7 +1643,7 @@ TEST_F(LLKMeshDeviceFixture, TensixComputePackUntilizeDstTinyTile) {
                 .untilize_type = unit_tests::compute::tilize::UntilizeType::DST,
                 .output_fmt = tt::DataFormat::Float16_b,
                 .golden_function = ::unit_tests::compute::gold_standard_untilize};
-            unit_tests::compute::tilize::run_single_core_tilize_program(this->devices_.at(0), test_config);
+            unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
         }
     }
 }

--- a/tests/tt_metal/tt_metal/test_bmm.cpp
+++ b/tests/tt_metal/tt_metal/test_bmm.cpp
@@ -21,6 +21,7 @@
 #include <tt-metalium/tensor/tensor_apis.hpp>
 #include "test_gold_impls.hpp"
 #include "impl/data_format/bfloat16_utils.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using std::vector;
 using namespace tt;
@@ -329,15 +330,14 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, BmmMultinode) {
 
     auto src0_vec = create_random_vector_of_bfloat16(bytesA, 1.0f, 0x1234);
     auto src1_vec = create_random_vector_of_bfloat16(bytesB, 1.0f, 0x1234, -0.45f);
-    // MeshTensor doesn't yet expose slow-dispatch read/write APIs, so route through the
-    // underlying reference buffer to populate / read back DRAM.
-    detail::WriteToBuffer(*tensors.src0.mesh_buffer().get_reference_buffer(), src0_vec);
-    detail::WriteToBuffer(*tensors.src1.mesh_buffer().get_reference_buffer(), src1_vec);
+    // MeshTensor doesn't yet expose slow-dispatch read/write APIs; use unit-mesh MeshBuffer helpers.
+    slow_dispatch::WriteToBuffer(tensors.src0.mesh_buffer(), src0_vec);
+    slow_dispatch::WriteToBuffer(tensors.src1.mesh_buffer(), src1_vec);
 
     LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    detail::ReadFromBuffer(*tensors.dst.mesh_buffer().get_reference_buffer(), result_vec);
+    slow_dispatch::ReadFromBuffer(tensors.dst.mesh_buffer(), result_vec);
 
     int argfail = -1;
     bool pass = validate_bmm_result(p, src0_vec, src1_vec, result_vec, &argfail);

--- a/tests/tt_metal/tt_metal/test_dm_loopback.cpp
+++ b/tests/tt_metal/tt_metal/test_dm_loopback.cpp
@@ -11,6 +11,8 @@
 #include <tt-metalium/tt_metal.hpp>
 #include "impl/context/metal_context.hpp"
 #include "llrt/tt_cluster.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -34,8 +36,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
         std::cerr << "WARNING: For example, export TT_METAL_DPRINT_CORES=0,0" << std::endl;
     }
 
-    IDevice* dev = devices_[0]->get_devices()[0];
-    auto mesh_device = devices_[0];
     const experimental::NodeCoord node{0, 0};
 
     uint32_t l1_address = MetalContext::instance().hal().get_dev_addr(
@@ -43,12 +43,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
     uint32_t dram_address = MetalContext::instance().hal().get_dev_addr(HalDramMemAddrType::UNRESERVED);
     std::vector<uint32_t> value = {0x12345678};
 
-    tt_metal::detail::WriteToDeviceDRAMChannel(dev, 0, dram_address, value);
-    MetalContext::instance().get_cluster().dram_barrier(dev->id());
-
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-    distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+    slow_dispatch::WriteToDRAMChannel(this->device(), 0, dram_address, value);
+    MetalContext::instance().get_cluster().dram_barrier(this->device().get_device_ids()[0]);
 
     // Metal 2.0 reserves DM0/DM1; max 6 user DM threads per node.
     // Reduced from 4+4=8 to 3+3=6 loopback stages to fit within the limit.
@@ -118,7 +114,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
         .semaphores = {sem},
         .work_units = {main_wu},
     };
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(this->device(), spec);
 
     const experimental::KernelSpecName dram_to_l1_names[] = {DRAM_TO_L1_0, DRAM_TO_L1_1, DRAM_TO_L1_2};
     const experimental::KernelSpecName l1_to_dram_names[] = {L1_TO_DRAM_0, L1_TO_DRAM_1, L1_TO_DRAM_2};
@@ -152,11 +148,10 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, DmLoopback) {
     }
     experimental::SetProgramRunArgs(program, params);
 
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, true);
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> outputs{0};
-    tt_metal::detail::ReadFromDeviceDRAMChannel(dev, 0, dram_address, sizeof(uint32_t), outputs);
+    slow_dispatch::ReadFromDRAMChannel(this->device(), 0, dram_address, sizeof(uint32_t), outputs);
 
     ASSERT_EQ(outputs[0], value[0]) << "Got the value " << std::hex << outputs[0] << " instead of " << value[0];
 }

--- a/tests/tt_metal/tt_metal/test_globals_tls.cpp
+++ b/tests/tt_metal/tt_metal/test_globals_tls.cpp
@@ -13,6 +13,8 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -31,9 +33,6 @@ constexpr uint32_t TOTAL_RESULT_BYTES = NUM_DM_CORES * TLS_CHECK_RESULT_SLOT_BYT
 
 // This test requires simulator environment
 TEST_F(QuasarMeshDeviceSingleCardFixture, GlobalsAndTLS) {
-    auto mesh_device = devices_[0];
-    IDevice* device = mesh_device->get_devices()[0];
-
     const uint32_t signal_address = 100 * 1024;
     const uint32_t l1_result_addr = 200 * 1024;
     const uint32_t dram_address = 30000 * 1024;
@@ -44,21 +43,17 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GlobalsAndTLS) {
     }
 
     constexpr CoreCoord core = {0, 0};
-    const uint32_t dram_channel = mesh_device->dram_channel_from_virtual_core(core);
+    const uint32_t dram_channel = this->device().dram_channel_from_virtual_core(core);
 
     // Initialize L1 signal so hart FIRST_USER_DM (2) can proceed first; the simple_tls_check
     // kernel chains the signal forward (signal_addr := hartid + 1) so hartids 2..7 run in order.
     std::vector<uint32_t> init_signal = {FIRST_USER_DM};
-    tt_metal::detail::WriteToDeviceL1(
-        device,
+    slow_dispatch::WriteToL1(
+        this->device(),
         core,
         signal_address,
         std::span(reinterpret_cast<const uint8_t*>(init_signal.data()), sizeof(uint32_t)),
         CoreType::WORKER);
-
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-    distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
 
     const experimental::KernelSpecName DM_KERNEL_1{"dm_kernel_1"};
     const experimental::KernelSpecName DM_KERNEL_2{"dm_kernel_2"};
@@ -102,7 +97,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GlobalsAndTLS) {
         .kernels = {k1, k2, k3},
         .work_units = {main_wu},
     };
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(this->device(), spec);
 
     auto make_kernel_run_params = [&]() {
         return experimental::ProgramRunArgs::KernelRunArgs{
@@ -125,12 +120,10 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GlobalsAndTLS) {
     params.kernel_run_args = {kra1, kra2, kra3};
     experimental::SetProgramRunArgs(program, params);
 
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, true);
-    distributed::Finish(mesh_device->mesh_command_queue());
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> dram_data;
-    tt_metal::detail::ReadFromDeviceDRAMChannel(device, dram_channel, dram_address, TOTAL_RESULT_BYTES, dram_data);
+    slow_dispatch::ReadFromDRAMChannel(this->device(), dram_channel, dram_address, TOTAL_RESULT_BYTES, dram_data);
 
     // Reference global addresses: DM 2-4 share one binary, DM 5-6 share another, DM 7 alone.
     auto slot_global_addr = [&dram_data](uint32_t dm) {
@@ -277,9 +270,6 @@ static constexpr uint32_t NUM_COMPUTE_SLOTS =
 static constexpr uint32_t QUASAR_FIRST_COMPUTE_HARTID = 8;  // DM 0-7, compute 8-23
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelTLS) {
-    auto mesh_device = devices_[0];
-    IDevice* device = mesh_device->get_devices()[0];
-
     char* env_var = std::getenv("TT_METAL_SIMULATOR");
     if (env_var == nullptr) {
         GTEST_SKIP() << "This test can only be run using a simulator. Set TT_METAL_SIMULATOR environment variable.";
@@ -291,24 +281,20 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelTLS) {
     constexpr uint32_t total_result_bytes = NUM_COMPUTE_SLOTS * TLS_CHECK_RESULT_SLOT_BYTES;
 
     std::vector<uint32_t> init_signal = {QUASAR_FIRST_COMPUTE_HARTID};
-    tt_metal::detail::WriteToDeviceL1(
-        device,
+    slow_dispatch::WriteToL1(
+        this->device(),
         core,
         signal_address,
         std::span(reinterpret_cast<const uint8_t*>(init_signal.data()), sizeof(uint32_t)),
         CoreType::WORKER);
 
     std::vector<uint32_t> init_data(total_result_bytes / sizeof(uint32_t), 0);
-    tt_metal::detail::WriteToDeviceL1(
-        device,
+    slow_dispatch::WriteToL1(
+        this->device(),
         core,
         l1_result_addr,
         std::span(reinterpret_cast<const uint8_t*>(init_data.data()), total_result_bytes),
         CoreType::WORKER);
-
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-    distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
 
     const experimental::KernelSpecName COMPUTE_KERNEL{"compute_tls"};
     const experimental::NodeCoord node{0, 0};
@@ -337,7 +323,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelTLS) {
         .kernels = {compute_kernel_spec},
         .work_units = {main_wu},
     };
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(this->device(), spec);
 
     experimental::ProgramRunArgs params;
     params.kernel_run_args = {experimental::ProgramRunArgs::KernelRunArgs{
@@ -347,12 +333,10 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelTLS) {
     }};
     experimental::SetProgramRunArgs(program, params);
 
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(cq, workload, true);
-    distributed::Finish(mesh_device->mesh_command_queue());
+    LaunchProgram(this->device(), std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> l1_data;
-    tt_metal::detail::ReadFromDeviceL1(device, core, l1_result_addr, total_result_bytes, l1_data, CoreType::WORKER);
+    slow_dispatch::ReadFromL1(this->device(), core, l1_result_addr, total_result_bytes, l1_data, CoreType::WORKER);
 
     auto slot_global_addr = [&l1_data](uint32_t slot) {
         const uint32_t offset = slot * TLS_CHECK_RESULT_SLOT_WORDS;

--- a/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_dm_add_two_ints.cpp
@@ -13,6 +13,7 @@
 #include "hw/inc/internal/tt-2xx/quasar/dev_mem_map.h"
 #include "impl/context/metal_context.hpp"
 #include "llrt/rtoptions.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -39,8 +40,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, MultiDmAddTwoInts) {
             "Movement kernels.");
         log_error(tt::LogTest, "For example, export TT_METAL_DPRINT_CORES=(0,0),(1,0)");
     }
-
-    IDevice* dev = mesh_device->get_devices()[0];
 
     distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
     distributed::MeshWorkload workload;
@@ -121,12 +120,10 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, MultiDmAddTwoInts) {
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
     std::vector<uint32_t> result_core_0(3, 0);
-    tt_metal::detail::ReadFromDeviceL1(
-        dev, CoreCoord(0, 0), result_base, sizeof(uint32_t) * 3, result_core_0);
+    slow_dispatch::ReadFromL1(this->device(), CoreCoord(0, 0), result_base, sizeof(uint32_t) * 3, result_core_0);
 
     std::vector<uint32_t> result_core_1(3, 0);
-    tt_metal::detail::ReadFromDeviceL1(
-        dev, CoreCoord(1, 0), result_base, sizeof(uint32_t) * 3, result_core_1);
+    slow_dispatch::ReadFromL1(this->device(), CoreCoord(1, 0), result_base, sizeof(uint32_t) * 3, result_core_1);
 
     ASSERT_EQ(result_core_0, (std::vector<uint32_t>{3, 7, 11}));
     ASSERT_EQ(result_core_1, (std::vector<uint32_t>{3, 7, 15}));

--- a/tests/tt_metal/tt_metal/test_pack_relu.cpp
+++ b/tests/tt_metal/tt_metal/test_pack_relu.cpp
@@ -37,25 +37,20 @@ uint32_t make_relu_config(PackReluMode mode, float threshold = 0.0f) {
 
 // Run a pack relu test using the same infrastructure as test_direct.cpp's quasar path:
 // direct_reader_unary.cpp → eltwise_copy.cpp (with PACK_RELU) → direct_writer_unary.cpp
-static void run_pack_relu_test(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    uint32_t relu_config,
-    const std::function<float(float)>& golden_fn) {
-    IDevice* dev = mesh_device->get_devices()[0];
+void run_pack_relu_test(
+    distributed::MeshDevice& mesh_device, uint32_t relu_config, const std::function<float(float)>& golden_fn) {
     const experimental::NodeCoord node{0, 0};
 
     uint32_t single_tile_size = 2 * 1024;
     uint32_t num_tiles = 1;
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
-    InterleavedBufferConfig src_config{
-        .device = dev, .size = dram_buffer_size, .page_size = single_tile_size, .buffer_type = BufferType::DRAM};
-    auto src_dram_buffer = CreateBuffer(src_config);
-    uint32_t dram_buffer_src_addr = src_dram_buffer->address();
+    distributed::DeviceLocalBufferConfig dram_config{.page_size = single_tile_size, .buffer_type = BufferType::DRAM};
+    distributed::ReplicatedBufferConfig buffer_config{.size = dram_buffer_size};
 
-    InterleavedBufferConfig dst_config{
-        .device = dev, .size = dram_buffer_size, .page_size = single_tile_size, .buffer_type = BufferType::DRAM};
-    auto dst_dram_buffer = CreateBuffer(dst_config);
+    auto src_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &mesh_device);
+    auto dst_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &mesh_device);
+    uint32_t dram_buffer_src_addr = src_dram_buffer->address();
     uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
 
     const experimental::DFBSpecName INPUT_DFB{"input_dfb"};
@@ -140,14 +135,17 @@ static void run_pack_relu_test(
         .work_units = {wu},
     };
 
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
     // Stimulus: random bfloat16 in [-1, 1]
     std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(dram_buffer_size, 1.0f, 0xCAFE);
-    detail::WriteToBuffer(src_dram_buffer, src_vec);
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, src_vec, /*blocking=*/true);
 
-    const uint32_t src_aligned_page_size = static_cast<uint32_t>(src_dram_buffer->aligned_page_size());
-    const uint32_t dst_aligned_page_size = static_cast<uint32_t>(dst_dram_buffer->aligned_page_size());
+    const uint32_t src_aligned_page_size =
+        static_cast<uint32_t>(src_dram_buffer->get_reference_buffer()->aligned_page_size());
+    const uint32_t dst_aligned_page_size =
+        static_cast<uint32_t>(dst_dram_buffer->get_reference_buffer()->aligned_page_size());
 
     experimental::ProgramRunArgs params;
     params.kernel_run_args = {
@@ -176,10 +174,10 @@ static void run_pack_relu_test(
     };
     experimental::SetProgramRunArgs(program, params);
 
-    LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
+    LaunchProgram(mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_dram_buffer, result_vec);
+    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);
 
     // Build golden
     std::vector<uint32_t> golden(src_vec.size());
@@ -206,14 +204,14 @@ static void run_pack_relu_test(
 // ZERO_RELU: max(0, x)
 TEST_F(QuasarMeshDeviceSingleCardFixture, PackReluZero) {
     run_pack_relu_test(
-        this->devices_.at(0), make_relu_config(PackReluMode::ZERO_RELU), [](float x) { return std::max(0.0f, x); });
+        this->device(), make_relu_config(PackReluMode::ZERO_RELU), [](float x) { return std::max(0.0f, x); });
 }
 
 // MIN_THRESHOLD_RELU: x <= threshold ? 0 : x (threshold = 0.25)
 TEST_F(QuasarMeshDeviceSingleCardFixture, PackReluMinThreshold) {
     const float threshold = 0.25f;
     run_pack_relu_test(
-        this->devices_.at(0), make_relu_config(PackReluMode::MIN_THRESHOLD_RELU, threshold), [threshold](float x) {
+        this->device(), make_relu_config(PackReluMode::MIN_THRESHOLD_RELU, threshold), [threshold](float x) {
             return x <= threshold ? 0.0f : x;
         });
 }
@@ -222,7 +220,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, PackReluMinThreshold) {
 TEST_F(QuasarMeshDeviceSingleCardFixture, PackReluMaxThreshold) {
     const float threshold = 0.5f;
     run_pack_relu_test(
-        this->devices_.at(0), make_relu_config(PackReluMode::MAX_THRESHOLD_RELU, threshold), [threshold](float x) {
+        this->device(), make_relu_config(PackReluMode::MAX_THRESHOLD_RELU, threshold), [threshold](float x) {
             return x < 0.0f ? 0.0f : std::min(x, threshold);
         });
 }

--- a/tests/tt_metal/tt_metal/test_quasar_compute_kernels.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_compute_kernels.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include "llrt/rtoptions.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -46,7 +47,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelMultipleThreads) {
     const uint32_t l1_address = MetalContext::instance().hal().get_dev_addr(
         HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
     std::vector<uint32_t> init_values(16, 0);
-    tt_metal::detail::WriteToDeviceL1(mesh_device->get_devices()[0], node, l1_address, init_values);
+    slow_dispatch::WriteToL1(*mesh_device, node, l1_address, init_values);
 
     const experimental::KernelSpecName COMPUTE_KERNEL{"risc_math"};
 
@@ -87,8 +88,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelMultipleThreads) {
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
     std::vector<uint32_t> actual_values(16, 0);
-    tt_metal::detail::ReadFromDeviceL1(
-        mesh_device->get_devices()[0], node, l1_address, 16 * sizeof(uint32_t), actual_values);
+    slow_dispatch::ReadFromL1(*mesh_device, node, l1_address, 16 * sizeof(uint32_t), actual_values);
 
     const std::vector<uint32_t> expected_values = {4, 6, 5, 9, 8, 10, 9, 13, 12, 14, 13, 17, 16, 18, 17, 21};
 
@@ -123,7 +123,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelSingleThread) {
     const uint32_t l1_address = MetalContext::instance().hal().get_dev_addr(
         HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
     std::vector<uint32_t> init_values(4, 0);
-    tt_metal::detail::WriteToDeviceL1(mesh_device->get_devices()[0], node, l1_address, init_values);
+    slow_dispatch::WriteToL1(*mesh_device, node, l1_address, init_values);
 
     const experimental::KernelSpecName COMPUTE_KERNEL{"risc_math"};
 
@@ -164,8 +164,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarComputeKernelSingleThread) {
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
     std::vector<uint32_t> actual_values(4, 0);
-    tt_metal::detail::ReadFromDeviceL1(
-        mesh_device->get_devices()[0], node, l1_address, 4 * sizeof(uint32_t), actual_values);
+    slow_dispatch::ReadFromL1(*mesh_device, node, l1_address, 4 * sizeof(uint32_t), actual_values);
 
     const std::vector<uint32_t> expected_values = {4, 6, 5, 9};
 
@@ -213,5 +212,5 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarCreateMultipleComputeKernelsSing
         .work_units = {main_wu},
     };
 
-    ASSERT_THROW(experimental::MakeProgramFromSpec(*devices_[0], spec), std::runtime_error);
+    ASSERT_THROW(experimental::MakeProgramFromSpec(this->device(), spec), std::runtime_error);
 }

--- a/tests/tt_metal/tt_metal/test_quasar_events.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_events.cpp
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <vector>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -23,13 +24,13 @@ using namespace tt;
 using namespace tt::tt_metal;
 
 distributed::MeshWorkload make_l1_write_workload(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     const experimental::NodeCoord& node,
     uint32_t address,
     uint32_t value,
     const std::string& kernel_id) {
     distributed::MeshWorkload wl;
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device.shape());
     const experimental::KernelSpecName DM_KERNEL{kernel_id};
     experimental::KernelSpec dm_kernel_spec{
         .unique_id = DM_KERNEL,
@@ -41,7 +42,7 @@ distributed::MeshWorkload make_l1_write_workload(
     experimental::WorkUnitSpec main_wu{.name = "main", .kernels = {DM_KERNEL}, .target_nodes = node};
     experimental::ProgramSpec spec{
         .name = std::string("l1_write_") + kernel_id, .kernels = {dm_kernel_spec}, .work_units = {main_wu}};
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
     experimental::ProgramRunArgs params;
     params.kernel_run_args = {experimental::ProgramRunArgs::KernelRunArgs{
         .kernel = DM_KERNEL,
@@ -53,9 +54,7 @@ distributed::MeshWorkload make_l1_write_workload(
     return wl;
 }
 
-void run_cross_cq_handoff(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, uint8_t producer_cq, uint8_t consumer_cq) {
-    IDevice* dev = mesh_device->get_devices()[0];
+void run_cross_cq_handoff(distributed::MeshDevice& mesh_device, uint8_t producer_cq, uint8_t consumer_cq) {
     const experimental::NodeCoord node{0, 0};
 
     const uint32_t producer_address = MetalContext::instance().hal().get_dev_addr(
@@ -65,10 +64,10 @@ void run_cross_cq_handoff(
     const uint32_t consumer_value = 0x2c110000u | consumer_cq;
 
     std::vector<uint32_t> zeros(2, 0);
-    tt_metal::detail::WriteToDeviceL1(dev, node, producer_address, zeros);
+    slow_dispatch::WriteToL1(mesh_device, node, producer_address, zeros);
 
-    distributed::MeshCommandQueue& producer = mesh_device->mesh_command_queue(producer_cq);
-    distributed::MeshCommandQueue& consumer = mesh_device->mesh_command_queue(consumer_cq);
+    distributed::MeshCommandQueue& producer = mesh_device.mesh_command_queue(producer_cq);
+    distributed::MeshCommandQueue& consumer = mesh_device.mesh_command_queue(consumer_cq);
 
     auto producer_wl = make_l1_write_workload(
         mesh_device, node, producer_address, producer_value, "producer_cq" + std::to_string(producer_cq));
@@ -85,11 +84,11 @@ void run_cross_cq_handoff(
     distributed::Finish(consumer);
 
     std::vector<uint32_t> producer_out(1, 0);
-    tt_metal::detail::ReadFromDeviceL1(dev, node, producer_address, sizeof(uint32_t), producer_out);
+    slow_dispatch::ReadFromL1(mesh_device, node, producer_address, sizeof(uint32_t), producer_out);
     ASSERT_EQ(producer_out[0], producer_value);
 
     std::vector<uint32_t> consumer_out(1, 0);
-    tt_metal::detail::ReadFromDeviceL1(dev, node, consumer_address, sizeof(uint32_t), consumer_out);
+    slow_dispatch::ReadFromL1(mesh_device, node, consumer_address, sizeof(uint32_t), consumer_out);
     ASSERT_EQ(consumer_out[0], consumer_value);
 }
 
@@ -99,8 +98,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, EventSynchronize) {
                         "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
     }
 
-    auto mesh_device = devices_[0];
-    IDevice* dev = mesh_device->get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     const uint32_t address = MetalContext::instance().hal().get_dev_addr(
@@ -108,10 +105,10 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, EventSynchronize) {
     const uint32_t value = 0x12abcd34;
 
     std::vector<uint32_t> zeros(1, 0);
-    tt_metal::detail::WriteToDeviceL1(dev, node, address, zeros);
+    slow_dispatch::WriteToL1(this->device(), node, address, zeros);
 
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-    distributed::MeshWorkload workload = make_l1_write_workload(mesh_device, node, address, value, "cq_kernel");
+    distributed::MeshCommandQueue& cq = this->device().mesh_command_queue();
+    distributed::MeshWorkload workload = make_l1_write_workload(this->device(), node, address, value, "cq_kernel");
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::MeshEvent event = cq.enqueue_record_event_to_host();
 
@@ -119,7 +116,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, EventSynchronize) {
     distributed::EventSynchronize(event);
 
     std::vector<uint32_t> outputs(1, 0);
-    tt_metal::detail::ReadFromDeviceL1(dev, node, address, sizeof(uint32_t), outputs);
+    slow_dispatch::ReadFromL1(this->device(), node, address, sizeof(uint32_t), outputs);
     ASSERT_EQ(outputs[0], value);
 }
 
@@ -129,8 +126,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, EventQuery) {
                         "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
     }
 
-    auto mesh_device = devices_[0];
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::MeshCommandQueue& cq = this->device().mesh_command_queue();
 
     distributed::MeshEvent event = cq.enqueue_record_event_to_host();
 
@@ -146,8 +142,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, EventBetweenWorkloads) {
                         "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
     }
 
-    auto mesh_device = devices_[0];
-    IDevice* dev = mesh_device->get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     const uint32_t address_1 = MetalContext::instance().hal().get_dev_addr(
@@ -157,12 +151,12 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, EventBetweenWorkloads) {
     const uint32_t value_2 = 0xccdd3344;
 
     std::vector<uint32_t> zeros(2, 0);
-    tt_metal::detail::WriteToDeviceL1(dev, node, address_1, zeros);
+    slow_dispatch::WriteToL1(this->device(), node, address_1, zeros);
 
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::MeshCommandQueue& cq = this->device().mesh_command_queue();
 
-    auto wl1 = make_l1_write_workload(mesh_device, node, address_1, value_1, "dm_kernel_1");
-    auto wl2 = make_l1_write_workload(mesh_device, node, address_2, value_2, "dm_kernel_2");
+    auto wl1 = make_l1_write_workload(this->device(), node, address_1, value_1, "dm_kernel_1");
+    auto wl2 = make_l1_write_workload(this->device(), node, address_2, value_2, "dm_kernel_2");
 
     // Enqueue both non-blocking; record event after first to observe ordering.
     distributed::EnqueueMeshWorkload(cq, wl1, false);
@@ -173,14 +167,14 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, EventBetweenWorkloads) {
     distributed::EventSynchronize(event_after_wl1);
 
     std::vector<uint32_t> out_1(1, 0);
-    tt_metal::detail::ReadFromDeviceL1(dev, node, address_1, sizeof(uint32_t), out_1);
+    slow_dispatch::ReadFromL1(this->device(), node, address_1, sizeof(uint32_t), out_1);
     ASSERT_EQ(out_1[0], value_1);
 
     // Drain the remaining wl2.
     distributed::Finish(cq);
 
     std::vector<uint32_t> out_2(1, 0);
-    tt_metal::detail::ReadFromDeviceL1(dev, node, address_2, sizeof(uint32_t), out_2);
+    slow_dispatch::ReadFromL1(this->device(), node, address_2, sizeof(uint32_t), out_2);
     ASSERT_EQ(out_2[0], value_2);
 }
 
@@ -189,7 +183,7 @@ TEST_F(QuasarMultiCQMeshDeviceSingleCardFixture, CrossCQEventHandoffCQ0ToCQ1) {
         GTEST_SKIP() << "This test can only be run under the simulator or emulator. "
                         "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
     }
-    run_cross_cq_handoff(devices_[0], /*producer_cq=*/0, /*consumer_cq=*/1);
+    run_cross_cq_handoff(this->device(), /*producer_cq=*/0, /*consumer_cq=*/1);
 }
 
 // Reverse direction: issue_record_event_commands / issue_wait_for_event_commands branch on
@@ -199,7 +193,7 @@ TEST_F(QuasarMultiCQMeshDeviceSingleCardFixture, CrossCQEventHandoffCQ1ToCQ0) {
         GTEST_SKIP() << "This test can only be run under the simulator or emulator. "
                         "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
     }
-    run_cross_cq_handoff(devices_[0], /*producer_cq=*/1, /*consumer_cq=*/0);
+    run_cross_cq_handoff(this->device(), /*producer_cq=*/1, /*consumer_cq=*/0);
 }
 
 TEST_F(QuasarMultiCQMeshDeviceSingleCardFixture, RecordEventToHostFromBothCQs) {
@@ -208,8 +202,6 @@ TEST_F(QuasarMultiCQMeshDeviceSingleCardFixture, RecordEventToHostFromBothCQs) {
                         "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
     }
 
-    auto mesh_device = devices_[0];
-    IDevice* dev = mesh_device->get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     const uint32_t address_0 = MetalContext::instance().hal().get_dev_addr(
@@ -219,13 +211,13 @@ TEST_F(QuasarMultiCQMeshDeviceSingleCardFixture, RecordEventToHostFromBothCQs) {
     const uint32_t value_1 = 0x2c2c0001;
 
     std::vector<uint32_t> zeros(2, 0);
-    tt_metal::detail::WriteToDeviceL1(dev, node, address_0, zeros);
+    slow_dispatch::WriteToL1(this->device(), node, address_0, zeros);
 
-    distributed::MeshCommandQueue& cq0 = mesh_device->mesh_command_queue(0);
-    distributed::MeshCommandQueue& cq1 = mesh_device->mesh_command_queue(1);
+    distributed::MeshCommandQueue& cq0 = this->device().mesh_command_queue(0);
+    distributed::MeshCommandQueue& cq1 = this->device().mesh_command_queue(1);
 
-    auto wl0 = make_l1_write_workload(mesh_device, node, address_0, value_0, "cq0_kernel");
-    auto wl1 = make_l1_write_workload(mesh_device, node, address_1, value_1, "cq1_kernel");
+    auto wl0 = make_l1_write_workload(this->device(), node, address_0, value_0, "cq0_kernel");
+    auto wl1 = make_l1_write_workload(this->device(), node, address_1, value_1, "cq1_kernel");
 
     distributed::EnqueueMeshWorkload(cq0, wl0, false);
     distributed::MeshEvent event_0 = cq0.enqueue_record_event_to_host();
@@ -238,10 +230,10 @@ TEST_F(QuasarMultiCQMeshDeviceSingleCardFixture, RecordEventToHostFromBothCQs) {
     distributed::EventSynchronize(event_1);
 
     std::vector<uint32_t> out_0(1, 0);
-    tt_metal::detail::ReadFromDeviceL1(dev, node, address_0, sizeof(uint32_t), out_0);
+    slow_dispatch::ReadFromL1(this->device(), node, address_0, sizeof(uint32_t), out_0);
     ASSERT_EQ(out_0[0], value_0);
 
     std::vector<uint32_t> out_1(1, 0);
-    tt_metal::detail::ReadFromDeviceL1(dev, node, address_1, sizeof(uint32_t), out_1);
+    slow_dispatch::ReadFromL1(this->device(), node, address_1, sizeof(uint32_t), out_1);
     ASSERT_EQ(out_1[0], value_1);
 }

--- a/tests/tt_metal/tt_metal/test_quasar_mesh_workloads.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_mesh_workloads.cpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -42,14 +43,14 @@ const std::vector<uint32_t> kExpectedComputeValues = {4, 6, 5, 9, 8, 10, 9, 13, 
 //
 // workload_id_str must be unique per call (used to derive kernel names).
 distributed::MeshWorkload create_workload(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     const experimental::NodeCoord& node,
     uint32_t dm_base_address,
     uint32_t dm_base_value,
     uint32_t compute_address,
     const std::string& workload_id_str) {
     distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+    distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mesh_device.shape());
 
     std::vector<experimental::KernelSpec> kernel_specs;
     std::vector<experimental::KernelSpecName> wu_kernel_names;
@@ -86,7 +87,7 @@ distributed::MeshWorkload create_workload(
         .kernels = kernel_specs,
         .work_units = {main_wu},
     };
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
     experimental::ProgramRunArgs params;
     for (uint32_t i = 0; i < kNumUserDMThreads; i++) {
@@ -134,7 +135,7 @@ void set_multi_node_run_args(
 }
 
 distributed::MeshWorkload create_multi_node_workload(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     const experimental::NodeRange& node_range,
     const std::vector<uint32_t>& dm_addresses,
     uint32_t dm_value,
@@ -162,11 +163,11 @@ distributed::MeshWorkload create_multi_node_workload(
         .work_units = {experimental::WorkUnitSpec{
             .name = "multi_node", .kernels = {dm_kernel, compute_kernel}, .target_nodes = node_range}},
     };
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
     set_multi_node_run_args(program, nodes, dm_addresses, dm_value, compute_addresses);
 
     distributed::MeshWorkload workload;
-    workload.add_program(distributed::MeshCoordinateRange(mesh_device->shape()), std::move(program));
+    workload.add_program(distributed::MeshCoordinateRange(mesh_device.shape()), std::move(program));
     return workload;
 }
 
@@ -178,8 +179,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TestSingleWorkloadNonBlockingEnqueueFi
                         "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
     }
 
-    auto mesh_device = devices_[0];
-    IDevice* dev = mesh_device->get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     const uint32_t base_address = MetalContext::instance().hal().get_dev_addr(
@@ -189,24 +188,24 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TestSingleWorkloadNonBlockingEnqueueFi
     const uint32_t dm_base_value = 0xdead0000;
 
     std::vector<uint32_t> zeros(kWorkloadOutputCount, 0);
-    tt_metal::detail::WriteToDeviceL1(dev, node, base_address, zeros);
+    slow_dispatch::WriteToL1(this->device(), node, base_address, zeros);
 
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::MeshCommandQueue& cq = this->device().mesh_command_queue();
     distributed::MeshWorkload workload =
-        create_workload(mesh_device, node, dm_base_address, dm_base_value, compute_address, "k0");
+        create_workload(this->device(), node, dm_base_address, dm_base_value, compute_address, "k0");
 
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::Finish(cq);
 
     std::vector<uint32_t> dm_output(kNumUserDMThreads, 0);
-    tt_metal::detail::ReadFromDeviceL1(dev, node, dm_base_address, kNumUserDMThreads * sizeof(uint32_t), dm_output);
+    slow_dispatch::ReadFromL1(this->device(), node, dm_base_address, kNumUserDMThreads * sizeof(uint32_t), dm_output);
     for (uint32_t i = 0; i < kNumUserDMThreads; i++) {
         ASSERT_EQ(dm_output[i], dm_base_value + i);
     }
 
     std::vector<uint32_t> compute_output(kNumComputeNEOs * kNumTRISCsPerNEO, 0);
-    tt_metal::detail::ReadFromDeviceL1(
-        dev, node, compute_address, kNumComputeNEOs * kNumTRISCsPerNEO * sizeof(uint32_t), compute_output);
+    slow_dispatch::ReadFromL1(
+        this->device(), node, compute_address, kNumComputeNEOs * kNumTRISCsPerNEO * sizeof(uint32_t), compute_output);
     ASSERT_EQ(compute_output, kExpectedComputeValues);
 }
 
@@ -216,8 +215,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TestMultipleWorkloadsNonBlockingEnqueu
                         "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
     }
 
-    auto mesh_device = devices_[0];
-    IDevice* dev = mesh_device->get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     const uint32_t base_address = MetalContext::instance().hal().get_dev_addr(
@@ -232,15 +229,15 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TestMultipleWorkloadsNonBlockingEnqueu
     auto compute_addr_for = [&](uint32_t w) { return dm_base_addr_for(w) + kL1CacheLineBytes; };
 
     std::vector<uint32_t> zeros(kNumWorkloads * 2 * kL1CacheLineBytes / sizeof(uint32_t), 0);
-    tt_metal::detail::WriteToDeviceL1(dev, node, base_address, zeros);
+    slow_dispatch::WriteToL1(this->device(), node, base_address, zeros);
 
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::MeshCommandQueue& cq = this->device().mesh_command_queue();
     std::vector<distributed::MeshWorkload> workloads;
     workloads.reserve(kNumWorkloads);
     for (uint32_t w = 0; w < kNumWorkloads; w++) {
         const std::string kernel_id = "k" + std::to_string(w + 1);
-        workloads.push_back(
-            create_workload(mesh_device, node, dm_base_addr_for(w), dm_base_values[w], compute_addr_for(w), kernel_id));
+        workloads.push_back(create_workload(
+            this->device(), node, dm_base_addr_for(w), dm_base_values[w], compute_addr_for(w), kernel_id));
     }
 
     for (uint32_t w = 0; w < kNumWorkloads; w++) {
@@ -253,14 +250,14 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TestMultipleWorkloadsNonBlockingEnqueu
         const uint32_t compute_addr = compute_addr_for(w);
 
         std::vector<uint32_t> dm_output(kNumUserDMThreads, 0);
-        tt_metal::detail::ReadFromDeviceL1(dev, node, dm_base_addr, kNumUserDMThreads * sizeof(uint32_t), dm_output);
+        slow_dispatch::ReadFromL1(this->device(), node, dm_base_addr, kNumUserDMThreads * sizeof(uint32_t), dm_output);
         for (uint32_t i = 0; i < kNumUserDMThreads; i++) {
             EXPECT_EQ(dm_output[i], dm_base_values[w] + i);
         }
 
         std::vector<uint32_t> compute_output(kNumComputeNEOs * kNumTRISCsPerNEO, 0);
-        tt_metal::detail::ReadFromDeviceL1(
-            dev, node, compute_addr, kNumComputeNEOs * kNumTRISCsPerNEO * sizeof(uint32_t), compute_output);
+        slow_dispatch::ReadFromL1(
+            this->device(), node, compute_addr, kNumComputeNEOs * kNumTRISCsPerNEO * sizeof(uint32_t), compute_output);
         EXPECT_EQ(compute_output, kExpectedComputeValues);
     }
 }
@@ -271,8 +268,6 @@ TEST_F(QuasarMultiCQMeshDeviceSingleCardFixture, TestInterleavedWorkloadsAcrossT
                         "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
     }
 
-    auto mesh_device = devices_[0];
-    IDevice* dev = mesh_device->get_devices()[0];
     const experimental::NodeCoord node{0, 0};
 
     const uint32_t base_address = MetalContext::instance().hal().get_dev_addr(
@@ -289,17 +284,17 @@ TEST_F(QuasarMultiCQMeshDeviceSingleCardFixture, TestInterleavedWorkloadsAcrossT
     auto compute_addr_for = [&](uint32_t w) { return dm_base_addr_for(w) + kL1CacheLineBytes; };
 
     std::vector<uint32_t> zeros(num_workloads * 2 * kL1CacheLineBytes / sizeof(uint32_t), 0);
-    tt_metal::detail::WriteToDeviceL1(dev, node, base_address, zeros);
+    slow_dispatch::WriteToL1(this->device(), node, base_address, zeros);
 
-    distributed::MeshCommandQueue& cq0 = mesh_device->mesh_command_queue(0);
-    distributed::MeshCommandQueue& cq1 = mesh_device->mesh_command_queue(1);
+    distributed::MeshCommandQueue& cq0 = this->device().mesh_command_queue(0);
+    distributed::MeshCommandQueue& cq1 = this->device().mesh_command_queue(1);
 
     std::vector<distributed::MeshWorkload> workloads;
     workloads.reserve(num_workloads);
     for (uint32_t w = 0; w < num_workloads; w++) {
         const std::string kernel_id = "k" + std::to_string(w + 1);
         workloads.push_back(create_workload(
-            mesh_device, node, dm_base_addr_for(w), dm_base_value_for(w), compute_addr_for(w), kernel_id));
+            this->device(), node, dm_base_addr_for(w), dm_base_value_for(w), compute_addr_for(w), kernel_id));
     }
 
     // Interleave: w even -> CQ0, w odd -> CQ1, so consecutive enqueues alternate queues.
@@ -312,14 +307,14 @@ TEST_F(QuasarMultiCQMeshDeviceSingleCardFixture, TestInterleavedWorkloadsAcrossT
         const uint32_t compute_addr = compute_addr_for(w);
 
         std::vector<uint32_t> dm_output(kNumUserDMThreads, 0);
-        tt_metal::detail::ReadFromDeviceL1(dev, node, dm_base_addr, kNumUserDMThreads * sizeof(uint32_t), dm_output);
+        slow_dispatch::ReadFromL1(this->device(), node, dm_base_addr, kNumUserDMThreads * sizeof(uint32_t), dm_output);
         for (uint32_t i = 0; i < kNumUserDMThreads; i++) {
             EXPECT_EQ(dm_output[i], dm_base_value_for(w) + i);
         }
 
         std::vector<uint32_t> compute_output(kNumComputeNEOs * kNumTRISCsPerNEO, 0);
-        tt_metal::detail::ReadFromDeviceL1(
-            dev, node, compute_addr, kNumComputeNEOs * kNumTRISCsPerNEO * sizeof(uint32_t), compute_output);
+        slow_dispatch::ReadFromL1(
+            this->device(), node, compute_addr, kNumComputeNEOs * kNumTRISCsPerNEO * sizeof(uint32_t), compute_output);
         EXPECT_EQ(compute_output, kExpectedComputeValues);
     }
 }
@@ -330,14 +325,12 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TestWorkloadAcrossMultipleWorkerNodes)
                         "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
     }
 
-    auto mesh_device = devices_[0];
-    const CoreCoord worker_grid = mesh_device->compute_with_storage_grid_size();
+    const CoreCoord worker_grid = this->device().compute_with_storage_grid_size();
     const uint32_t num_nodes = worker_grid.x * worker_grid.y;
     if (num_nodes < 2) {
         GTEST_SKIP() << "Test requires at least two worker nodes";
     }
 
-    IDevice* dev = mesh_device->get_devices()[0];
     const experimental::NodeRange node_range{{0, 0}, {worker_grid.x - 1, worker_grid.y - 1}};
     const std::vector<experimental::NodeCoord> nodes =
         experimental::grid_to_nodes(node_range.start_coord, node_range.end_coord);
@@ -356,7 +349,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TestWorkloadAcrossMultipleWorkerNodes)
 
     std::vector<uint32_t> zeros(kNumRounds * num_nodes * 2 * kL1CacheLineBytes / sizeof(uint32_t), 0);
     for (const auto& node : nodes) {
-        tt_metal::detail::WriteToDeviceL1(dev, node, base_address, zeros);
+        slow_dispatch::WriteToL1(this->device(), node, base_address, zeros);
     }
 
     auto addresses_for_round = [&](uint32_t round) {
@@ -370,11 +363,11 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TestWorkloadAcrossMultipleWorkerNodes)
     };
 
     auto [dm_addresses_0, compute_addresses_0] = addresses_for_round(0);
-    distributed::MeshCoordinateRange device_range(mesh_device->shape());
+    distributed::MeshCoordinateRange device_range(this->device().shape());
     distributed::MeshWorkload workload =
-        create_multi_node_workload(mesh_device, node_range, dm_addresses_0, dm_values[0], compute_addresses_0);
+        create_multi_node_workload(this->device(), node_range, dm_addresses_0, dm_values[0], compute_addresses_0);
     Program& program = workload.get_programs().at(device_range);
-    auto& cq = mesh_device->mesh_command_queue();
+    auto& cq = this->device().mesh_command_queue();
 
     for (uint32_t round = 0; round < kNumRounds; ++round) {
         auto [dm_addresses, compute_addresses] = addresses_for_round(round);
@@ -389,12 +382,12 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TestWorkloadAcrossMultipleWorkerNodes)
         for (uint32_t node_index = 0; node_index < num_nodes; ++node_index) {
             const experimental::NodeCoord& node = nodes[node_index];
             std::vector<uint32_t> dm_output(1, 0);
-            tt_metal::detail::ReadFromDeviceL1(dev, node, dm_addresses[node_index], sizeof(uint32_t), dm_output);
+            slow_dispatch::ReadFromL1(this->device(), node, dm_addresses[node_index], sizeof(uint32_t), dm_output);
             EXPECT_EQ(dm_output[0], dm_values[round]);
 
             std::vector<uint32_t> compute_output(kNumComputeNEOs * kNumTRISCsPerNEO, 0);
-            tt_metal::detail::ReadFromDeviceL1(
-                dev,
+            slow_dispatch::ReadFromL1(
+                this->device(),
                 node,
                 compute_addresses[node_index],
                 kNumComputeNEOs * kNumTRISCsPerNEO * sizeof(uint32_t),

--- a/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_semaphores.cpp
@@ -12,6 +12,8 @@
 #include <tt-metalium/tt_metal.hpp>
 #include "hal.hpp"
 #include "llrt/rtoptions.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "impl/program/program_impl.hpp"
 #include <algorithm>
 
 #ifndef OVERRIDE_KERNEL_PREFIX
@@ -209,7 +211,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
     for (uint32_t i = 0; i < num_elements; i++) {
         initial_data[i] = i;
     }
-    tt_metal::detail::WriteToDeviceL1(mesh_device->get_devices()[0], node_0, buf_a_addr, initial_data);
+    slow_dispatch::WriteToL1(*mesh_device, node_0, buf_a_addr, initial_data);
 
     const CoreCoord core_1_virtual = mesh_device->worker_core_from_logical_core(node_1);
 
@@ -388,8 +390,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
     std::vector<uint32_t> actual_data(num_elements, 0);
-    tt_metal::detail::ReadFromDeviceDRAMChannel(
-        mesh_device->get_devices()[0], 0, dram_dst_addr, num_elements * sizeof(uint32_t), actual_data);
+    slow_dispatch::ReadFromDRAMChannel(*mesh_device, 0, dram_dst_addr, num_elements * sizeof(uint32_t), actual_data);
 
     const std::vector<uint32_t> expected_data = {2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
 
@@ -403,7 +404,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarMultipleClustersMultiSemaphorePi
 // Final DRAM stage = seed + N. Shows every node can both receive from the previous node
 // and send to the next, the 2-node cross-node pipeline generalized to N nodes.
 static void run_snake_chain(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     const std::vector<experimental::NodeCoord>& nodes,
     bool ring = false,
     uint32_t num_elements = 10) {
@@ -414,7 +415,6 @@ static void run_snake_chain(
     using experimental::WorkUnitSpec;
     const uint32_t N = static_cast<uint32_t>(nodes.size());
     ASSERT_GE(N, 2u);
-    IDevice* dev = mesh_device->get_devices()[0];
 
     const uint32_t buf_a = MetalContext::instance().hal().get_dev_addr(
         HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
@@ -433,14 +433,14 @@ static void run_snake_chain(
     for (uint32_t i = 0; i < num_elements; ++i) {
         seed[i] = i;
     }
-    tt_metal::detail::WriteToDeviceDRAMChannel(dev, 0, stage_addr(0), seed);
+    slow_dispatch::WriteToDRAMChannel(mesh_device, 0, stage_addr(0), seed);
     // Pre-fill the output stage with a sentinel value.
     std::vector<uint32_t> out_sentinel(num_elements, 0xdeadbeefu);
-    tt_metal::detail::WriteToDeviceDRAMChannel(dev, 0, stage_addr(N), out_sentinel);
+    slow_dispatch::WriteToDRAMChannel(mesh_device, 0, stage_addr(N), out_sentinel);
     // Ring mode also checks the token that wraps back to node[0]'s buf_wrap; pre-fill it with a
     // sentinel too so that check can't pass on stale or uninitialized data.
     if (ring) {
-        tt_metal::detail::WriteToDeviceL1(dev, nodes[0], buf_wrap, out_sentinel);
+        slow_dispatch::WriteToL1(mesh_device, nodes[0], buf_wrap, out_sentinel);
     }
 
     experimental::ProgramSpec spec{.name = "snake_chain"};
@@ -578,7 +578,7 @@ static void run_snake_chain(
                      {"num_elements", num_elements},
                      {"dram_bank_id", 0u}})});
         } else {
-            const CoreCoord nxt = mesh_device->worker_core_from_logical_core(is_sink ? nodes[0] : nodes[i + 1]);
+            const CoreCoord nxt = mesh_device.worker_core_from_logical_core(is_sink ? nodes[0] : nodes[i + 1]);
             params.kernel_run_args.push_back(experimental::ProgramRunArgs::KernelRunArgs{
                 .kernel = WRITER,
                 .runtime_arg_values = experimental::MakeRuntimeArgsForSingleNode(
@@ -592,16 +592,16 @@ static void run_snake_chain(
         }
     }
 
-    distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
+    distributed::MeshCommandQueue& cq = mesh_device.mesh_command_queue();
     distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range(mesh_device->shape());
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    distributed::MeshCoordinateRange device_range(mesh_device.shape());
+    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
     experimental::SetProgramRunArgs(program, params);
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
     std::vector<uint32_t> out(num_elements, 0);
-    tt_metal::detail::ReadFromDeviceDRAMChannel(dev, 0, stage_addr(N), num_elements * sizeof(uint32_t), out);
+    slow_dispatch::ReadFromDRAMChannel(mesh_device, 0, stage_addr(N), num_elements * sizeof(uint32_t), out);
     std::vector<uint32_t> expected(num_elements);
     for (uint32_t i = 0; i < num_elements; ++i) {
         expected[i] = i + N;  // +1 per hop
@@ -612,7 +612,7 @@ static void run_snake_chain(
 
     if (ring) {
         std::vector<uint32_t> wrapped(num_elements, 0);
-        tt_metal::detail::ReadFromDeviceL1(dev, nodes[0], buf_wrap, num_elements * sizeof(uint32_t), wrapped);
+        slow_dispatch::ReadFromL1(mesh_device, nodes[0], buf_wrap, num_elements * sizeof(uint32_t), wrapped);
         std::cout << "[snake] RING wrap-back to node0 L1[0]=" << wrapped[0] << " expected=" << expected[0]
                   << (wrapped == expected ? "  PASS" : "  FAIL") << std::endl;
         EXPECT_EQ(wrapped, expected);
@@ -623,8 +623,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, RingChainFull) {
     if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
         GTEST_SKIP() << "simulator/emulator only";
     }
-    auto md = devices_[0];
-    const auto g = md->compute_with_storage_grid_size();
+    const auto g = this->device().compute_with_storage_grid_size();
     if (g.x < 8 || g.y < 4) {
         GTEST_SKIP() << "need the full 8x4 grid";
     }
@@ -640,7 +639,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, RingChainFull) {
             }
         }
     }
-    run_snake_chain(md, nodes, /*ring=*/true);  // 32-node snake + wrap edge back to node[0]
+    run_snake_chain(this->device(), nodes, /*ring=*/true);  // 32-node snake + wrap edge back to node[0]
 }
 
 // Longest single cross-node hop: opposite corners {0,0} <-> {7,3}.
@@ -648,12 +647,11 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SnakeCornerToCorner) {
     if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
         GTEST_SKIP() << "simulator/emulator only";
     }
-    auto md = devices_[0];
-    const auto g = md->compute_with_storage_grid_size();
+    const auto g = this->device().compute_with_storage_grid_size();
     if (g.x < 8 || g.y < 4) {
         GTEST_SKIP() << "need the full 8x4 grid";
     }
-    run_snake_chain(md, {experimental::NodeCoord{0, 0}, experimental::NodeCoord{7, 3}});
+    run_snake_chain(this->device(), {experimental::NodeCoord{0, 0}, experimental::NodeCoord{7, 3}});
 }
 
 // Sweep a few payload sizes across the full 32-node snake.
@@ -661,8 +659,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SnakePayloadSweep) {
     if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
         GTEST_SKIP() << "simulator/emulator only";
     }
-    auto md = devices_[0];
-    const auto g = md->compute_with_storage_grid_size();
+    const auto g = this->device().compute_with_storage_grid_size();
     if (g.x < 8 || g.y < 4) {
         GTEST_SKIP() << "need the full 8x4 grid";
     }
@@ -680,7 +677,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SnakePayloadSweep) {
     }
     for (uint32_t ne : {64u, 256u}) {
         std::cout << "[L6] payload sweep: num_elements=" << ne << std::endl;
-        run_snake_chain(md, nodes, /*ring=*/false, ne);
+        run_snake_chain(this->device(), nodes, /*ring=*/false, ne);
     }
 }
 
@@ -689,12 +686,10 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FanOutBroadcast) {
     if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
         GTEST_SKIP() << "simulator/emulator only";
     }
-    auto md = devices_[0];
-    const auto g = md->compute_with_storage_grid_size();
+    const auto g = this->device().compute_with_storage_grid_size();
     if (g.x < 8 || g.y < 4) {
         GTEST_SKIP() << "need the full 8x4 grid";
     }
-    IDevice* dev = md->get_devices()[0];
     constexpr uint32_t ne = 8;
     const uint32_t buf_a = MetalContext::instance().hal().get_dev_addr(
         HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
@@ -703,11 +698,11 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FanOutBroadcast) {
     for (uint32_t i = 0; i < ne; ++i) {
         seed[i] = 0xa000 + i;
     }
-    tt_metal::detail::WriteToDeviceDRAMChannel(dev, 0, dram_bcast, seed);
+    slow_dispatch::WriteToDRAMChannel(this->device(), 0, dram_bcast, seed);
     for (uint32_t y = 0; y < g.y; ++y) {
         for (uint32_t x = 0; x < g.x; ++x) {
             std::vector<uint32_t> sentinel(ne, 0xffffffffu);
-            tt_metal::detail::WriteToDeviceL1(dev, experimental::NodeCoord{x, y}, buf_a, sentinel);
+            slow_dispatch::WriteToL1(this->device(), experimental::NodeCoord{x, y}, buf_a, sentinel);
         }
     }
 
@@ -737,16 +732,16 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FanOutBroadcast) {
     }
     params.kernel_run_args = {kra};
     distributed::MeshWorkload workload;
-    Program program = experimental::MakeProgramFromSpec(*md, spec);
+    Program program = experimental::MakeProgramFromSpec(this->device(), spec);
     experimental::SetProgramRunArgs(program, params);
-    workload.add_program(distributed::MeshCoordinateRange(md->shape()), std::move(program));
-    distributed::EnqueueMeshWorkload(md->mesh_command_queue(), workload, true);
+    workload.add_program(distributed::MeshCoordinateRange(this->device().shape()), std::move(program));
+    distributed::EnqueueMeshWorkload(this->device().mesh_command_queue(), workload, true);
 
     uint32_t ok = 0, fail = 0;
     for (uint32_t y = 0; y < g.y; ++y) {
         for (uint32_t x = 0; x < g.x; ++x) {
             std::vector<uint32_t> r(ne, 0);
-            tt_metal::detail::ReadFromDeviceL1(dev, experimental::NodeCoord{x, y}, buf_a, ne * sizeof(uint32_t), r);
+            slow_dispatch::ReadFromL1(this->device(), experimental::NodeCoord{x, y}, buf_a, ne * sizeof(uint32_t), r);
             (r == seed) ? ++ok : ++fail;
         }
     }
@@ -761,12 +756,10 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FanInGather) {
     if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
         GTEST_SKIP() << "simulator/emulator only";
     }
-    auto md = devices_[0];
-    const auto g = md->compute_with_storage_grid_size();
+    const auto g = this->device().compute_with_storage_grid_size();
     if (g.x < 8 || g.y < 4) {
         GTEST_SKIP() << "need the full 8x4 grid";
     }
-    IDevice* dev = md->get_devices()[0];
     constexpr uint32_t ne = 8;
     constexpr uint32_t stride = 4096;
     const uint32_t buf_a = MetalContext::instance().hal().get_dev_addr(
@@ -782,9 +775,9 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FanInGather) {
         for (uint32_t x = 0; x < g.x; ++x) {
             const uint32_t idx = x + y * g.x;
             std::vector<uint32_t> s(ne, sig_of(x, y));
-            tt_metal::detail::WriteToDeviceDRAMChannel(dev, 0, dram_src + idx * stride, s);
+            slow_dispatch::WriteToDRAMChannel(this->device(), 0, dram_src + idx * stride, s);
             std::vector<uint32_t> sentinel(ne, 0xffffffffu);
-            tt_metal::detail::WriteToDeviceDRAMChannel(dev, 0, dram_gather + idx * stride, sentinel);
+            slow_dispatch::WriteToDRAMChannel(this->device(), 0, dram_gather + idx * stride, sentinel);
         }
     }
 
@@ -835,17 +828,17 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FanInGather) {
     }
     params.kernel_run_args = {kr, kw};
     distributed::MeshWorkload workload;
-    Program program = experimental::MakeProgramFromSpec(*md, spec);
+    Program program = experimental::MakeProgramFromSpec(this->device(), spec);
     experimental::SetProgramRunArgs(program, params);
-    workload.add_program(distributed::MeshCoordinateRange(md->shape()), std::move(program));
-    distributed::EnqueueMeshWorkload(md->mesh_command_queue(), workload, true);
+    workload.add_program(distributed::MeshCoordinateRange(this->device().shape()), std::move(program));
+    distributed::EnqueueMeshWorkload(this->device().mesh_command_queue(), workload, true);
 
     uint32_t ok = 0, fail = 0;
     for (uint32_t y = 0; y < g.y; ++y) {
         for (uint32_t x = 0; x < g.x; ++x) {
             const uint32_t idx = x + y * g.x;
             std::vector<uint32_t> r(ne, 0);
-            tt_metal::detail::ReadFromDeviceDRAMChannel(dev, 0, dram_gather + idx * stride, ne * sizeof(uint32_t), r);
+            slow_dispatch::ReadFromDRAMChannel(this->device(), 0, dram_gather + idx * stride, ne * sizeof(uint32_t), r);
             (r == std::vector<uint32_t>(ne, sig_of(x, y))) ? ++ok : ++fail;
         }
     }
@@ -858,8 +851,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, PerRowChains) {
     if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
         GTEST_SKIP() << "simulator/emulator only";
     }
-    auto md = devices_[0];
-    const auto g = md->compute_with_storage_grid_size();
+    const auto g = this->device().compute_with_storage_grid_size();
     if (g.x < 8 || g.y < 4) {
         GTEST_SKIP() << "need the full 8x4 grid";
     }
@@ -870,7 +862,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, PerRowChains) {
             row.push_back(experimental::NodeCoord{x, y});
         }
         std::cout << "[L6] per-row chain y=" << y << std::endl;
-        run_snake_chain(md, row);
+        run_snake_chain(this->device(), row);
     }
 }
 
@@ -881,8 +873,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, PerColumnChains) {
     if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
         GTEST_SKIP() << "simulator/emulator only";
     }
-    auto md = devices_[0];
-    const auto g = md->compute_with_storage_grid_size();
+    const auto g = this->device().compute_with_storage_grid_size();
     if (g.x < 8 || g.y < 4) {
         GTEST_SKIP() << "need the full 8x4 grid";
     }
@@ -893,7 +884,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, PerColumnChains) {
             col.push_back(experimental::NodeCoord{x, y});
         }
         std::cout << "[L6] per-column chain x=" << x << std::endl;
-        run_snake_chain(md, col);
+        run_snake_chain(this->device(), col);
     }
 }
 
@@ -904,8 +895,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GridBarrierAllToOne) {
     if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
         GTEST_SKIP() << "simulator/emulator only";
     }
-    auto md = devices_[0];
-    const auto g = md->compute_with_storage_grid_size();
+    const auto g = this->device().compute_with_storage_grid_size();
     if (g.x != 8 || g.y != 4) {
         GTEST_SKIP() << "need the full 8x4 grid";
     }
@@ -913,7 +903,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GridBarrierAllToOne) {
     const uint32_t num_signalers = g.x * g.y - 1;  // everyone except the target
     // The target's result slot is a single-core L1 MeshBuffer on the target node, result_addr is
     // threaded into the kernel and host I/O (seed + read-back) goes through the mesh command queue.
-    distributed::MeshCommandQueue& cq = md->mesh_command_queue();
+    distributed::MeshCommandQueue& cq = this->device().mesh_command_queue();
     const CoreRangeSet result_grid(CoreRange(target, target));
     const ShardSpecBuffer result_shard(
         result_grid,
@@ -927,7 +917,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GridBarrierAllToOne) {
         .sharding_args = BufferShardingArgs(result_shard, TensorMemoryLayout::HEIGHT_SHARDED),
     };
     distributed::ReplicatedBufferConfig result_global{.size = sizeof(uint32_t)};
-    auto result_buf = distributed::MeshBuffer::create(result_global, result_local, md.get());
+    auto result_buf = distributed::MeshBuffer::create(result_global, result_local, &this->device());
     const uint32_t result_addr = result_buf->address();
 
     // Seed the target's result slot so an incomplete barrier is detectable.
@@ -936,7 +926,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GridBarrierAllToOne) {
 
     const experimental::SemaphoreSpecName BARRIER{"barrier_sem"};
     const experimental::KernelSpecName BK{"barrier_kernel"};
-    const CoreCoord tgt_phys = md->worker_core_from_logical_core(target);
+    const CoreCoord tgt_phys = this->device().worker_core_from_logical_core(target);
     const experimental::NodeRange all_nodes{experimental::NodeCoord{0, 0}, experimental::NodeCoord{g.x - 1, g.y - 1}};
 
     experimental::ProgramSpec spec{.name = "grid_barrier"};
@@ -954,7 +944,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GridBarrierAllToOne) {
     spec.kernels.push_back(bk);
     spec.work_units.push_back(experimental::WorkUnitSpec{.name = "wu", .kernels = {BK}, .target_nodes = all_nodes});
 
-    Program program = experimental::MakeProgramFromSpec(*md, spec);
+    Program program = experimental::MakeProgramFromSpec(this->device(), spec);
 
     experimental::ProgramRunArgs params;
     experimental::ProgramRunArgs::KernelRunArgs kra{.kernel = BK};
@@ -975,7 +965,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GridBarrierAllToOne) {
     experimental::SetProgramRunArgs(program, params);
 
     distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range(md->shape());
+    distributed::MeshCoordinateRange device_range(this->device().shape());
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, true);
 
@@ -992,19 +982,18 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SnakeChain3) {
         GTEST_SKIP() << "simulator/emulator only";
     }
     // Uses logical nodes {0,0},{1,0},{2,0}; skip (don't fault) on grids narrower than 3 (e.g. 1x3 CI).
-    if (devices_[0]->compute_with_storage_grid_size().x < 3) {
+    if (this->device().compute_with_storage_grid_size().x < 3) {
         GTEST_SKIP() << "need a >=3-wide grid";
     }
     // Source -> relay -> sink across 3 adjacent nodes in row 0.
-    run_snake_chain(devices_[0], {{0, 0}, {1, 0}, {2, 0}});
+    run_snake_chain(this->device(), {{0, 0}, {1, 0}, {2, 0}});
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, SnakeChainRow) {
     if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
         GTEST_SKIP() << "simulator/emulator only";
     }
-    auto md = devices_[0];
-    if (md->compute_with_storage_grid_size().x < 8) {
+    if (this->device().compute_with_storage_grid_size().x < 8) {
         GTEST_SKIP() << "need an 8-wide grid";
     }
     std::vector<experimental::NodeCoord> nodes;  // full row 0, left->right (8 hops)
@@ -1012,15 +1001,14 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SnakeChainRow) {
     for (uint32_t x = 0; x < 8; ++x) {
         nodes.push_back(experimental::NodeCoord{x, 0});
     }
-    run_snake_chain(md, nodes);
+    run_snake_chain(this->device(), nodes);
 }
 
 TEST_F(QuasarMeshDeviceSingleCardFixture, SnakeChainFull) {
     if (!MetalContext::instance().rtoptions().is_simulator_or_emulated()) {
         GTEST_SKIP() << "simulator/emulator only";
     }
-    auto md = devices_[0];
-    const auto g = md->compute_with_storage_grid_size();
+    const auto g = this->device().compute_with_storage_grid_size();
     if (g.x < 8 || g.y < 4) {
         GTEST_SKIP() << "need the full 8x4 grid";
     }
@@ -1037,5 +1025,5 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SnakeChainFull) {
             }
         }
     }
-    run_snake_chain(md, nodes);  // all 32 nodes, one continuous snake
+    run_snake_chain(this->device(), nodes);  // all 32 nodes, one continuous snake
 }

--- a/tests/tt_metal/tt_metal/test_quasar_sub_devices.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_sub_devices.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/sub_device.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 #include <array>
 #include <cstdint>
@@ -98,9 +99,9 @@ distributed::MeshWorkload create_l1_write_workload(
     return workload;
 }
 
-uint32_t read_l1_word(IDevice* device, const experimental::NodeCoord& node, uint32_t address) {
+uint32_t read_l1_word(distributed::MeshDevice& mesh_device, const experimental::NodeCoord& node, uint32_t address) {
     std::vector<uint32_t> output(1, 0);
-    detail::ReadFromDeviceL1(device, node, address, sizeof(uint32_t), output);
+    slow_dispatch::ReadFromL1(mesh_device, node, address, sizeof(uint32_t), output);
     return output[0];
 }
 
@@ -251,11 +252,10 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TestSubDevicePartitionsWorkerGrid) {
         distributed::EnqueueMeshWorkload(cq, workloads.back(), /*blocking=*/i + 1 == partitions.size());
     }
 
-    IDevice* device = mesh_device->get_devices()[0];
     for (size_t i = 0; i < partitions.size(); ++i) {
         const uint32_t value = 0x11110000u + (static_cast<uint32_t>(i) << 16);
         for (const auto& node : partitions[i]) {
-            EXPECT_EQ(read_l1_word(device, node, address), value);
+            EXPECT_EQ(read_l1_word(*mesh_device, node, address), value);
         }
     }
 }
@@ -333,10 +333,9 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TestSubDeviceShardedL1BufferAllocation
         EXPECT_EQ(outputs[i], inputs[i]);
     }
 
-    IDevice* device = mesh_device->get_devices()[0];
     for (size_t i = 0; i < partitions.size(); ++i) {
         for (const auto& node : partitions[i]) {
-            EXPECT_EQ(read_l1_word(device, node, buffers[i]->address()), inputs[i].front());
+            EXPECT_EQ(read_l1_word(*mesh_device, node, buffers[i]->address()), inputs[i].front());
         }
     }
 }
@@ -400,7 +399,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TestSubDeviceManagerSwitching) {
     const auto split_manager = mesh_device->create_sub_device_manager(split_sub_devices, kLocalL1Size);
     const uint32_t address = MetalContext::instance().hal().get_dev_addr(
         HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
-    IDevice* device = mesh_device->get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
 
     mesh_device->load_sub_device_manager(combined_manager);
@@ -417,7 +415,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TestSubDeviceManagerSwitching) {
         "combined_manager");
     distributed::EnqueueMeshWorkload(cq, combined_workload, /*blocking=*/true);
     for (const auto& node : nodes) {
-        EXPECT_EQ(read_l1_word(device, node, address), 0x33330000u);
+        EXPECT_EQ(read_l1_word(*mesh_device, node, address), 0x33330000u);
     }
 
     mesh_device->load_sub_device_manager(split_manager);
@@ -441,7 +439,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TestSubDeviceManagerSwitching) {
     for (size_t i = 0; i < partitions.size(); ++i) {
         const uint32_t value = 0x44440000u + (static_cast<uint32_t>(i) << 16);
         for (const auto& node : partitions[i]) {
-            EXPECT_EQ(read_l1_word(device, node, address), value);
+            EXPECT_EQ(read_l1_word(*mesh_device, node, address), value);
         }
     }
 }

--- a/tests/tt_metal/tt_metal/test_quasar_trace.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_trace.cpp
@@ -15,6 +15,7 @@
 
 #include <cstdint>
 #include <vector>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -29,7 +30,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarTraceSingleReplay) {
                         "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
     }
 
-    IDevice* dev = devices_[0]->get_devices()[0];
     auto mesh_device = devices_[0];
     const experimental::NodeCoord node{0, 0};
 
@@ -65,14 +65,14 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarTraceSingleReplay) {
 
     // Warm up
     std::vector<uint32_t> zeros(1, 0);
-    tt_metal::detail::WriteToDeviceL1(dev, node, address, zeros);
+    slow_dispatch::WriteToL1(*mesh_device, node, address, zeros);
     distributed::EnqueueMeshWorkload(cq, workload, true);
     std::vector<uint32_t> warm_up_result(1, 0);
-    tt_metal::detail::ReadFromDeviceL1(dev, node, address, sizeof(uint32_t), warm_up_result);
+    slow_dispatch::ReadFromL1(*mesh_device, node, address, sizeof(uint32_t), warm_up_result);
     ASSERT_EQ(warm_up_result[0], value);
 
     // Capture trace
-    tt_metal::detail::WriteToDeviceL1(dev, node, address, zeros);
+    slow_dispatch::WriteToL1(*mesh_device, node, address, zeros);
     distributed::MeshTraceId trace_id = mesh_device->begin_mesh_trace(cq);
     distributed::EnqueueMeshWorkload(cq, workload, false);
     mesh_device->end_mesh_trace(cq, trace_id);
@@ -80,7 +80,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarTraceSingleReplay) {
     // Replay trace
     mesh_device->replay_mesh_trace(cq, trace_id, true);
     std::vector<uint32_t> trace_result(1, 0);
-    tt_metal::detail::ReadFromDeviceL1(dev, node, address, sizeof(uint32_t), trace_result);
+    slow_dispatch::ReadFromL1(*mesh_device, node, address, sizeof(uint32_t), trace_result);
     ASSERT_EQ(trace_result[0], value);
 
     mesh_device->release_mesh_trace(trace_id);
@@ -92,7 +92,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarTraceMultipleReplays) {
                         "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
     }
 
-    IDevice* dev = devices_[0]->get_devices()[0];
     auto mesh_device = devices_[0];
     const experimental::NodeCoord node{0, 0};
 
@@ -129,10 +128,10 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarTraceMultipleReplays) {
 
     // Warm up
     std::vector<uint32_t> zeros(1, 0);
-    tt_metal::detail::WriteToDeviceL1(dev, node, address, zeros);
+    slow_dispatch::WriteToL1(*mesh_device, node, address, zeros);
     distributed::EnqueueMeshWorkload(cq, workload, true);
     std::vector<uint32_t> warm_up_result(1, 0);
-    tt_metal::detail::ReadFromDeviceL1(dev, node, address, sizeof(uint32_t), warm_up_result);
+    slow_dispatch::ReadFromL1(*mesh_device, node, address, sizeof(uint32_t), warm_up_result);
     ASSERT_EQ(warm_up_result[0], value);
 
     // Capture trace
@@ -144,12 +143,12 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarTraceMultipleReplays) {
     constexpr uint32_t num_replays = 5;
     for (uint32_t i = 0; i < num_replays; i++) {
         std::vector<uint32_t> zeros(1, 0);
-        tt_metal::detail::WriteToDeviceL1(dev, node, address, zeros);
+        slow_dispatch::WriteToL1(*mesh_device, node, address, zeros);
 
         mesh_device->replay_mesh_trace(cq, trace_id, true);
 
         std::vector<uint32_t> result(1, 0);
-        tt_metal::detail::ReadFromDeviceL1(dev, node, address, sizeof(uint32_t), result);
+        slow_dispatch::ReadFromL1(*mesh_device, node, address, sizeof(uint32_t), result);
         ASSERT_EQ(result[0], value);
     }
 
@@ -162,7 +161,6 @@ TEST_F(QuasarMultiCQMeshDeviceSingleCardFixture, QuasarTraceMultipleReplaysAcros
                         "Set TT_METAL_SIMULATOR or TT_METAL_EMULE_MODE=1.";
     }
 
-    IDevice* dev = devices_[0]->get_devices()[0];
     auto mesh_device = devices_[0];
     const experimental::NodeCoord node{0, 0};
 
@@ -209,10 +207,10 @@ TEST_F(QuasarMultiCQMeshDeviceSingleCardFixture, QuasarTraceMultipleReplaysAcros
     std::vector<uint32_t> zeros(1, 0);
 
     // Warm up + capture the CQ0 trace.
-    tt_metal::detail::WriteToDeviceL1(dev, node, address_0, zeros);
+    slow_dispatch::WriteToL1(*mesh_device, node, address_0, zeros);
     distributed::EnqueueMeshWorkload(cq0, wl0, true);
     std::vector<uint32_t> warm_up_0(1, 0);
-    tt_metal::detail::ReadFromDeviceL1(dev, node, address_0, sizeof(uint32_t), warm_up_0);
+    slow_dispatch::ReadFromL1(*mesh_device, node, address_0, sizeof(uint32_t), warm_up_0);
     ASSERT_EQ(warm_up_0[0], value_0);
 
     distributed::MeshTraceId trace_id_0 = mesh_device->begin_mesh_trace(cq0);
@@ -220,10 +218,10 @@ TEST_F(QuasarMultiCQMeshDeviceSingleCardFixture, QuasarTraceMultipleReplaysAcros
     mesh_device->end_mesh_trace(cq0, trace_id_0);
 
     // Warm up + capture the CQ1 trace.
-    tt_metal::detail::WriteToDeviceL1(dev, node, address_1, zeros);
+    slow_dispatch::WriteToL1(*mesh_device, node, address_1, zeros);
     distributed::EnqueueMeshWorkload(cq1, wl1, true);
     std::vector<uint32_t> warm_up_1(1, 0);
-    tt_metal::detail::ReadFromDeviceL1(dev, node, address_1, sizeof(uint32_t), warm_up_1);
+    slow_dispatch::ReadFromL1(*mesh_device, node, address_1, sizeof(uint32_t), warm_up_1);
     ASSERT_EQ(warm_up_1[0], value_1);
 
     distributed::MeshTraceId trace_id_1 = mesh_device->begin_mesh_trace(cq1);
@@ -233,18 +231,18 @@ TEST_F(QuasarMultiCQMeshDeviceSingleCardFixture, QuasarTraceMultipleReplaysAcros
     // Interleave replays of both CQs' traces and verify each lands its own value each round.
     constexpr uint32_t num_replays = 5;
     for (uint32_t i = 0; i < num_replays; i++) {
-        tt_metal::detail::WriteToDeviceL1(dev, node, address_0, zeros);
-        tt_metal::detail::WriteToDeviceL1(dev, node, address_1, zeros);
+        slow_dispatch::WriteToL1(*mesh_device, node, address_0, zeros);
+        slow_dispatch::WriteToL1(*mesh_device, node, address_1, zeros);
 
         mesh_device->replay_mesh_trace(cq0, trace_id_0, true);
         mesh_device->replay_mesh_trace(cq1, trace_id_1, true);
 
         std::vector<uint32_t> result_0(1, 0);
-        tt_metal::detail::ReadFromDeviceL1(dev, node, address_0, sizeof(uint32_t), result_0);
+        slow_dispatch::ReadFromL1(*mesh_device, node, address_0, sizeof(uint32_t), result_0);
         ASSERT_EQ(result_0[0], value_0);
 
         std::vector<uint32_t> result_1(1, 0);
-        tt_metal::detail::ReadFromDeviceL1(dev, node, address_1, sizeof(uint32_t), result_1);
+        slow_dispatch::ReadFromL1(*mesh_device, node, address_1, sizeof(uint32_t), result_1);
         ASSERT_EQ(result_1[0], value_1);
     }
 

--- a/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/test_single_dm_l1_write.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/tt_metal.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <numeric>
 
 #ifndef OVERRIDE_KERNEL_PREFIX
@@ -90,7 +91,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, SingleDmL1Write) {
         .kernels = {dm_kernel_spec},
         .work_units = {main_wu},
     };
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(this->device(), spec);
 
     experimental::ProgramRunArgs params;
     params.kernel_run_args = {experimental::ProgramRunArgs::KernelRunArgs{
@@ -176,7 +177,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FullGridDmL1Write_L1a) {
     if (std::getenv("TT_METAL_SIMULATOR") == nullptr) {
         GTEST_SKIP() << "This test can only be run using a simulator.";
     }
-    IDevice* dev = devices_[0]->get_devices()[0];
     auto mesh_device = devices_[0];
     const auto grid = mesh_device->compute_with_storage_grid_size();
     // Skip on the smaller 1x3/2x3 configs; this suite targets the 8x4 Quasar grid.
@@ -192,7 +192,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FullGridDmL1Write_L1a) {
     for (uint32_t y = 0; y < grid.y; ++y) {
         for (uint32_t x = 0; x < grid.x; ++x) {
             std::vector<uint32_t> z{0xffffffffu};
-            tt_metal::detail::WriteToDeviceL1(dev, experimental::NodeCoord{x, y}, address, z);
+            slow_dispatch::WriteToL1(this->device(), experimental::NodeCoord{x, y}, address, z);
         }
     }
 
@@ -238,8 +238,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FullGridDmL1Write_L1a) {
         std::string row;
         for (uint32_t x = 0; x < grid.x; ++x) {
             std::vector<uint32_t> r(1, 0xdeadbeefu);
-            tt_metal::detail::ReadFromDeviceL1(
-                dev, experimental::NodeCoord{x, static_cast<uint32_t>(y)}, address, sizeof(uint32_t), r);
+            slow_dispatch::ReadFromL1(
+                this->device(), experimental::NodeCoord{x, static_cast<uint32_t>(y)}, address, sizeof(uint32_t), r);
             const uint32_t sig = sig_of(x, static_cast<uint32_t>(y));
             if (r[0] == sig) {
                 row += ". ";
@@ -265,7 +265,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FullGridCompute_L1c) {
     if (std::getenv("TT_METAL_SIMULATOR") == nullptr) {
         GTEST_SKIP() << "This test can only be run using a simulator.";
     }
-    IDevice* dev = devices_[0]->get_devices()[0];
     auto mesh_device = devices_[0];
     const auto grid = mesh_device->compute_with_storage_grid_size();
     // Skip on the smaller 1x3/2x3 configs; this suite targets the 8x4 Quasar grid.
@@ -283,7 +282,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FullGridCompute_L1c) {
     for (uint32_t y = 0; y < grid.y; ++y) {
         for (uint32_t x = 0; x < grid.x; ++x) {
             std::vector<uint32_t> z(16, 0xC0FFEEu);
-            tt_metal::detail::WriteToDeviceL1(dev, experimental::NodeCoord{x, y}, l1_address, z);
+            slow_dispatch::WriteToL1(this->device(), experimental::NodeCoord{x, y}, l1_address, z);
         }
     }
 
@@ -327,8 +326,12 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, FullGridCompute_L1c) {
         std::string row;
         for (uint32_t x = 0; x < grid.x; ++x) {
             std::vector<uint32_t> r(16, 0xdeadbeefu);
-            tt_metal::detail::ReadFromDeviceL1(
-                dev, experimental::NodeCoord{x, static_cast<uint32_t>(y)}, l1_address, 16 * sizeof(uint32_t), r);
+            slow_dispatch::ReadFromL1(
+                this->device(),
+                experimental::NodeCoord{x, static_cast<uint32_t>(y)},
+                l1_address,
+                16 * sizeof(uint32_t),
+                r);
             if (r == expected) {
                 row += ". ";
                 ++ok;
@@ -354,7 +357,6 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GridMulticastFanOut) {
     if (std::getenv("TT_METAL_SIMULATOR") == nullptr) {
         GTEST_SKIP() << "This test can only be run using a simulator.";
     }
-    IDevice* dev = devices_[0]->get_devices()[0];
     auto mesh_device = devices_[0];
     const auto grid = mesh_device->compute_with_storage_grid_size();
     if (grid.x != 8u || grid.y != 4u) {
@@ -370,7 +372,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GridMulticastFanOut) {
     for (uint32_t y = 0; y < grid.y; ++y) {
         for (uint32_t x = 0; x < grid.x; ++x) {
             std::vector<uint32_t> z{sentinel};
-            tt_metal::detail::WriteToDeviceL1(dev, experimental::NodeCoord{x, y}, address, z);
+            slow_dispatch::WriteToL1(this->device(), experimental::NodeCoord{x, y}, address, z);
         }
     }
 
@@ -396,7 +398,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GridMulticastFanOut) {
     };
     experimental::WorkUnitSpec wu{.name = "main", .kernels = {MCAST}, .target_nodes = src_node};
     experimental::ProgramSpec spec{.name = "grid_mcast_fanout", .kernels = {mcast_spec}, .work_units = {wu}};
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(this->device(), spec);
 
     experimental::ProgramRunArgs params;
     params.kernel_run_args = {experimental::ProgramRunArgs::KernelRunArgs{
@@ -422,8 +424,8 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, GridMulticastFanOut) {
         std::string row;
         for (uint32_t x = 0; x < grid.x; ++x) {
             std::vector<uint32_t> r(1, 0u);
-            tt_metal::detail::ReadFromDeviceL1(
-                dev, experimental::NodeCoord{x, static_cast<uint32_t>(y)}, address, sizeof(uint32_t), r);
+            slow_dispatch::ReadFromL1(
+                this->device(), experimental::NodeCoord{x, static_cast<uint32_t>(y)}, address, sizeof(uint32_t), r);
             if (r[0] == value) {
                 row += ". ";
                 ++ok;


### PR DESCRIPTION
### PR Category
Cleanup, Test Only

### Summary

Advances https://github.com/tenstorrent/tt-metal/issues/51835

Legacy API usage related to `IDevice` and `Buffer` is replaced with mesh alternatives in tests that are based on QuasarMeshDeviceSingleCardFixture.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

I've ran the tests on Quasar emulator using the following command:
```
for t in unit_tests_legacy unit_tests_llk unit_tests_api; do
  TT_METAL_SLOW_DISPATCH_MODE=1 ./build/test/tt_metal/$t --gtest_filter='QuasarMeshDeviceSingleCardFixture.*'
done 2>&1 | tee emu_test_run.log
```
The list of failed tests was consistent with main, specifically:
```
[  FAILED  ] 3 tests, listed below:
[  FAILED  ] QuasarMeshDeviceSingleCardFixture.EventSynchronize
[  FAILED  ] QuasarMeshDeviceSingleCardFixture.QuasarTraceSingleReplay
[  FAILED  ] QuasarMeshDeviceSingleCardFixture.QuasarTraceMultipleReplays
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov-quazar-unit-mesh-fixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov-quazar-unit-mesh-fixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov-quazar-unit-mesh-fixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov-quazar-unit-mesh-fixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov-quazar-unit-mesh-fixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov-quazar-unit-mesh-fixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov-quazar-unit-mesh-fixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov-quazar-unit-mesh-fixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov-quazar-unit-mesh-fixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov-quazar-unit-mesh-fixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov-quazar-unit-mesh-fixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov-quazar-unit-mesh-fixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov-quazar-unit-mesh-fixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov-quazar-unit-mesh-fixture)