### PR TITLE
[Cleanup] Thread context_id into ProgramImpl and its downstream

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -206,6 +206,7 @@ tt_metal/hw/inc/experimental/udm/ @yugaoTT @SeanNijjar @tenstorrent/codeowner-by
 tt_metal/api/tt-metalium/experimental/noc_estimator/ @nstamatovicTT @atatuzunerTT @tenstorrent/codeowner-bypass
 tt_metal/impl/experimental/noc_estimator/ @nstamatovicTT @atatuzunerTT @tenstorrent/codeowner-bypass
 tt_metal/impl/experimental/noc_estimator/**/CMakeLists.txt @nstamatovicTT @atatuzunerTT @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
+tt_metal/impl/experimental/offline_compile/ @ruizhangTT @tenstorrent/metalium-runtime @tenstorrent/codeowner-bypass
 tt_metal/impl/emulation/ @smeydanshahiTT @xanderchin @arminaleTT @sgholamiTT @tenstorrent/codeowner-bypass
 
 # metal misc

--- a/tests/tt_metal/tt_metal/context/test_integration.cpp
+++ b/tests/tt_metal/tt_metal/context/test_integration.cpp
@@ -15,6 +15,8 @@
 #include <tt-metalium/experimental/context/metal_env.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/experimental/fabric/fabric_types.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/mesh_config.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/mesh_device.hpp>
@@ -244,6 +246,38 @@ void RunNoOpProgram(distributed::MeshDevice& target, const std::string& label) {
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(target.mesh_command_queue(), workload, true);
     log_info(tt::LogTest, "Successfully enqueued no-op program on {}", label);
+}
+
+// Minimal Gen1 Metal 2.0 ProgramSpec: one no-op DM kernel on node (0, 0).
+experimental::ProgramSpec MakeMinimalNoOpProgramSpec() {
+    using experimental::DataMovementGen1Config;
+    using experimental::KernelSpec;
+    using experimental::KernelSpecName;
+    using experimental::NodeCoord;
+    using experimental::ProgramSpec;
+    using experimental::WorkUnitSpec;
+
+    const KernelSpecName kernel_id{"dm_kernel"};
+    KernelSpec dm_kernel{
+        .unique_id = kernel_id,
+        .source = KernelSpec::SourceCode{"void kernel_main() {}"},
+        .num_threads = 1,
+        .hw_config =
+            DataMovementGen1Config{
+                .processor = DataMovementProcessor::RISCV_0,
+                .noc = NOC::NOC_0,
+            },
+    };
+
+    return ProgramSpec{
+        .name = "context_noop",
+        .kernels = {std::move(dm_kernel)},
+        .work_units = {WorkUnitSpec{
+            .name = "work_unit_0",
+            .kernels = {kernel_id},
+            .target_nodes = NodeCoord{0, 0},
+        }},
+    };
 }
 
 // The real (silicon) device takes DEFAULT_CONTEXT_ID and must keep the device profiler active when
@@ -481,6 +515,30 @@ TEST(MetalContextIntegrationTest, MockDeviceOnly) {
 
     // Assert that the MetalContext instance was cleaned up after MeshDevice close
     ASSERT_FALSE(MetalContext::instance_exists(context_id));
+}
+
+// A Metal 2.0 program built from a mock MeshDevice can be enqueued on that same mesh.
+TEST(MetalContextIntegrationTest, MockMetal2ProgramEnqueueOnOwningMesh) {
+    MetalEnv mock_env{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 1))};
+    auto mesh_device = mock_env.create_mesh_device(distributed::MeshDeviceConfig(distributed::MeshShape(1)));
+
+    experimental::ProgramSpec spec = MakeMinimalNoOpProgramSpec();
+    distributed::MeshWorkload workload = experimental::MakeMeshWorkloadFromSpec(*mesh_device, spec);
+    EXPECT_NO_THROW(distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, /*blocking=*/true));
+}
+
+// A Metal 2.0 program built on one MeshDevice must not compile on a MeshDevice from a different
+// MetalEnv.
+TEST(MetalContextIntegrationTest, MockMetal2ProgramCompileOnForeignMeshFails) {
+    MetalEnv env_a{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 1))};
+    MetalEnv env_b{MetalEnvDescriptor(experimental::get_mock_cluster_desc_name(tt::ARCH::BLACKHOLE, 1))};
+
+    auto mesh_a = env_a.create_mesh_device(distributed::MeshDeviceConfig(distributed::MeshShape(1)));
+    auto mesh_b = env_b.create_mesh_device(distributed::MeshDeviceConfig(distributed::MeshShape(1)));
+
+    Program program = experimental::MakeProgramFromSpec(*mesh_a, MakeMinimalNoOpProgramSpec());
+    IDevice* foreign_device = mesh_b->get_devices().at(0);
+    EXPECT_THROW(detail::CompileProgram(foreign_device, program), std::runtime_error);
 }
 
 TEST(MetalContextIntegrationTest, CoexistingSiliconAndMockDevice) {

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -42,11 +42,10 @@ NarrowT dfb_narrow_field(WideT value, uint32_t dfb_id, const char* field_name) {
     return static_cast<NarrowT>(value);
 }
 
-uint32_t align_dfb_config_transfer_size(uint32_t payload_bytes) {
+uint32_t align_dfb_config_transfer_size(const Hal& hal, uint32_t payload_bytes) {
     if (payload_bytes == 0) {
         return 0;
     }
-    const auto& hal = MetalContext::instance().hal();
     // RTL sim and DMA paths move L1 in uint32_t chunks; also honor HAL L1 alignment for the region.
     const uint32_t min_align = hal.has_tile_counter_registers() ? static_cast<uint32_t>(sizeof(uint32_t)) : 1u;
     const uint32_t align_bytes = std::max(min_align, hal.get_alignment(HalMemType::L1));
@@ -207,7 +206,10 @@ uint32_t dm0_isr_blob_region_size(const std::vector<std::shared_ptr<DataflowBuff
 }
 
 uint32_t dm1_remapper_blob_core_size(const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core) {
-    if (!MetalContext::instance().hal().has_tile_counter_registers()) {
+    // Callers (compute_dfb_config_serialized_size / serialize_dfb_config_for_core) guarantee non-empty.
+    TT_ASSERT(!dfbs_on_core.empty());
+    const ContextId context_id = dfbs_on_core.front()->get_context_id();
+    if (!MetalContext::instance(context_id).hal().has_tile_counter_registers()) {
         return 0;
     }
     uint32_t num_slots = 0;
@@ -220,7 +222,10 @@ uint32_t dm1_remapper_blob_core_size(const std::vector<std::shared_ptr<DataflowB
 
 std::vector<uint8_t> serialize_dm1_remapper_core_blob(
     const CoreCoord& core, const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core) {
-    if (!MetalContext::instance().hal().has_tile_counter_registers()) {
+    // Callers (serialize_dfb_config_for_core) guarantee non-empty.
+    TT_ASSERT(!dfbs_on_core.empty());
+    const ContextId context_id = dfbs_on_core.front()->get_context_id();
+    if (!MetalContext::instance(context_id).hal().has_tile_counter_registers()) {
         return {};
     }
 
@@ -274,7 +279,8 @@ static uint32_t hart_blob_byte_size(
 uint32_t compute_dfb_config_serialized_size(
     const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core) {
     if (dfbs_on_core.empty()) { return 0; }
-    const auto& hal = MetalContext::instance().hal();
+    const ContextId context_id = dfbs_on_core.front()->get_context_id();
+    const auto& hal = MetalContext::instance(context_id).hal();
     TT_FATAL(hal.has_tile_counter_registers(), "compute_dfb_config_serialized_size requires Quasar");
 
     uint32_t payload = dfb_config_header_size();
@@ -286,7 +292,7 @@ uint32_t compute_dfb_config_serialized_size(
     // Signal region: per-producer byte slots (NUM_DFBS * MAX_PRODUCERS_PER_DFB) + uint32_t expected per DFB.
     payload += static_cast<uint32_t>(::dfb::NUM_DFBS) * static_cast<uint32_t>(::dfb::MAX_PRODUCERS_PER_DFB) +
                static_cast<uint32_t>(::dfb::NUM_DFBS) * static_cast<uint32_t>(sizeof(uint32_t));
-    return align_dfb_config_transfer_size(payload);
+    return align_dfb_config_transfer_size(hal, payload);
 }
 
 void populate_dfb_global_header_participation(
@@ -425,7 +431,8 @@ size_t serialize_dfb_config_for_core(
     const std::vector<std::shared_ptr<DataflowBufferImpl>>& dfbs_on_core,
     std::span<uint8_t> out) {
     if (dfbs_on_core.empty()) { return 0; }
-    const auto& hal = MetalContext::instance().hal();
+    const ContextId context_id = dfbs_on_core.front()->get_context_id();
+    const auto& hal = MetalContext::instance(context_id).hal();
     TT_FATAL(hal.has_tile_counter_registers(), "serialize_dfb_config_for_core requires Quasar");
 
     // ---------------------------------------------------------------------------
@@ -753,7 +760,7 @@ size_t serialize_dfb_config_for_core(
     // ---------------------------------------------------------------------------
     verify_dfb_hart_blobs(std::span<const uint8_t>(out.data(), offset), dfbs_on_core);
 
-    const uint32_t aligned_size = align_dfb_config_transfer_size(offset);
+    const uint32_t aligned_size = align_dfb_config_transfer_size(hal, offset);
     TT_FATAL(out.size() >= aligned_size, "DFB config buffer too small for aligned payload");
     if (aligned_size > offset) { std::memset(out.data() + offset, 0, aligned_size - offset); }
     return aligned_size;
@@ -1161,7 +1168,7 @@ static void validate_ring_extent(const DataflowBufferImpl& dfb) {
     const uint16_t capacity = dfb.capacity;
     const uint32_t stride_in_entries = dfb.stride_in_entries;
     const uint32_t id = dfb.id;
-    if (!MetalContext::instance().hal().has_tile_counter_registers()) {
+    if (!MetalContext::instance(dfb.get_context_id()).hal().has_tile_counter_registers()) {
         return;
     }
     const bool tensix_on_dfb = has_tensix_risc(config.producer_risc_mask) || has_tensix_risc(config.consumer_risc_mask);
@@ -1169,7 +1176,7 @@ static void validate_ring_extent(const DataflowBufferImpl& dfb) {
         return;
     }
     const uint64_t ring_bytes = static_cast<uint64_t>(config.entry_size) * (stride_in_entries * (capacity - 1U) + 1U);
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = MetalContext::instance(dfb.get_context_id()).hal();
     const uint32_t l1_align = hal.get_alignment(HalMemType::L1);
     const uint32_t unreserved_l1_size =
         hal.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED);
@@ -1293,7 +1300,7 @@ struct TileCounterGroup {
 static uint32_t dfb_wh_bh_serialized_size() { return 4u * sizeof(uint32_t); }
 
 uint16_t DataflowBufferImpl::dm1_remapper_slot_count() const {
-    if (!MetalContext::instance().hal().has_tile_counter_registers()) {
+    if (!MetalContext::instance(context_id_).hal().has_tile_counter_registers()) {
         return 0;
     }
     // Intra-tensix pairs are programmed by each Neo's packer, so they contribute no DM1 slots.
@@ -1302,7 +1309,7 @@ uint16_t DataflowBufferImpl::dm1_remapper_slot_count() const {
 
 void DataflowBufferImpl::append_dm1_remapper_slots_for_core(const CoreCoord& core, std::vector<uint8_t>& data) const {
     TT_FATAL(this->configs_finalized, "DFB {} configs not finalized before serialization", this->id);
-    if (!MetalContext::instance().hal().has_tile_counter_registers()) {
+    if (!MetalContext::instance(context_id_).hal().has_tile_counter_registers()) {
         return;
     }
 
@@ -1364,7 +1371,7 @@ void DataflowBufferImpl::append_dm1_remapper_slots_for_core(const CoreCoord& cor
 std::vector<uint8_t> DataflowBufferImpl::serialize_for_core(const CoreCoord& core) const {
     TT_FATAL(this->configs_finalized, "DFB {} configs not finalized before serialization", this->id);
     TT_FATAL(
-        !MetalContext::instance().hal().has_tile_counter_registers(),
+        !MetalContext::instance(context_id_).hal().has_tile_counter_registers(),
         "serialize_for_core is only used on WH/BH; Quasar uses serialize_dfb_config_for_core");
 
     auto it = this->core_lookup_.find(core);
@@ -1389,7 +1396,7 @@ std::vector<uint8_t> DataflowBufferImpl::serialize_for_core(const CoreCoord& cor
 }
 
 uint32_t DataflowBufferImpl::serialized_size() const {
-    if (!MetalContext::instance().hal().has_tile_counter_registers()) {
+    if (!MetalContext::instance(context_id_).hal().has_tile_counter_registers()) {
         return dfb_wh_bh_serialized_size();
     }
     // Quasar: per-hart init entry sizes are fixed for a finalized TC assignment.
@@ -1420,7 +1427,7 @@ void DataflowBufferImpl::update_size(std::optional<uint32_t> new_entry_size, std
     std::tie(capacity, stride_in_entries) = compute_capacity_and_stride(*this);
     validate_ring_extent(*this);
 
-    if (configs_finalized && MetalContext::instance().hal().has_tile_counter_registers()) {
+    if (configs_finalized && MetalContext::instance(context_id_).hal().has_tile_counter_registers()) {
         const bool producer_is_tensix_only =
             !has_dm_risc(config.producer_risc_mask) && has_tensix_risc(config.producer_risc_mask);
         const bool consumer_is_tensix_only =
@@ -1471,7 +1478,7 @@ void DataflowBufferImpl::update_size(std::optional<uint32_t> new_entry_size, std
             num_consumer_tcs);
     }
 
-    if (configs_finalized && MetalContext::instance().hal().has_tile_counter_registers()) {
+    if (configs_finalized && MetalContext::instance(context_id_).hal().has_tile_counter_registers()) {
         log_debug(
             tt::LogMetal,
             "DFB {} size override applied: entry_size={} num_entries={} prod_threshold={} prod_per_tc={} "
@@ -1643,7 +1650,8 @@ uint32_t finalize_dfbs(
         return base_offset;
     }
 
-    const auto& hal = MetalContext::instance().hal();
+    const ContextId context_id = dataflow_buffers.front()->get_context_id();
+    const auto& hal = MetalContext::instance(context_id).hal();
 
     // WH/BH addresses a DFB's config by its device slot (slot N starts at N * serialized_size), so the
     // region has to span the highest slot in use on the kernel group, not just hold one entry per DFB.
@@ -1682,7 +1690,7 @@ uint32_t finalize_dfbs(
         }
 
         if (hal.has_tile_counter_registers() && kg_dfb_size > 0) {
-            kg_dfb_size = align_dfb_config_transfer_size(kg_dfb_size);
+            kg_dfb_size = align_dfb_config_transfer_size(hal, kg_dfb_size);
         }
         dfb_size = std::max(dfb_size, kg_dfb_size);
     }
@@ -1714,7 +1722,7 @@ using namespace tt::tt_metal::experimental::dfb::detail;
 // DFBs on disjoint cores reuse low slots, so a core's config table stays as small as its own
 // DFB count rather than growing with the number of DFBs elsewhere in the program.
 uint32_t ProgramImpl::assign_dfb_device_slot(const DataflowBufferImpl& dfb) const {
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = MetalContext::instance(context_id_).hal();
     const uint32_t max_slots = hal.has_tile_counter_registers() ? ::dfb::NUM_DFBS : hal.get_arch_num_circular_buffers();
 
     uint64_t used_slots = 0;
@@ -1774,6 +1782,7 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
     auto dfb = std::make_shared<DataflowBufferImpl>();
 
     dfb->id = static_cast<uint32_t>(this->dataflow_buffers_.size());
+    dfb->context_id_ = this->context_id_;
 
     dfb->core_ranges = core_range_set.merge_ranges();
     dfb->config = config;
@@ -1857,7 +1866,7 @@ void ProgramImpl::finalize_dataflow_buffer_configs() {
     // On WH/BH there are no tile counters or remapper hardware.
     // Mark configs finalized and create a single dummy group per DFB so allocate_dataflow_buffers() can fill in the L1
     // address.
-    if (!MetalContext::instance().hal().has_tile_counter_registers()) {
+    if (!MetalContext::instance(context_id_).hal().has_tile_counter_registers()) {
         for (auto& dfb : this->dataflow_buffers_) {
             if (dfb->configs_finalized) {
                 continue;

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp
@@ -15,6 +15,7 @@
 #include <tt_stl/assert.hpp>
 
 #include <tt-metalium/core_coord.hpp>
+#include "impl/context/context_types.hpp"
 #include "impl/dataflow_buffer/dataflow_buffer.hpp"
 
 #include "tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h"
@@ -63,11 +64,15 @@ struct DfbGroup {
 struct DataflowBufferImpl {
     // Unique, program-wide handle
     uint32_t id{};
+    // Owning MetalContext; set from ProgramImpl at add_dataflow_buffer.
+    ContextId context_id_{DEFAULT_CONTEXT_ID};
     // Device-facing slot number, baked into kernel binaries as the dfb::<name> accessor value and
     // used as the config-table index in the dispatch payload.
     uint32_t device_slot{};
     CoreRangeSet core_ranges;
     DataflowBufferConfig config;
+
+    ContextId get_context_id() const { return context_id_; }
 
     uint16_t risc_mask = 0;  // bits 0-7 = DM riscs, bits 8-15 = Tensix riscs
     uint8_t tensix_trisc_mask = 0;  // bits 0-3: which TRISC(s) use DFB (producer=bit2, consumer=bit0 or bit3)

--- a/tt_metal/impl/dispatch/dispatch_engine_kernel.cpp
+++ b/tt_metal/impl/dispatch/dispatch_engine_kernel.cpp
@@ -33,7 +33,7 @@ KernelHandle create_dispatch_engine_kernel(
     const CoreRangeSet core_ranges = CoreRangeSet(core);
     const KernelSource kernel_src(file_name, KernelSource::FILE_PATH);
     std::shared_ptr<Kernel> kernel = std::make_shared<experimental::quasar::DispatchEngineKernel>(
-        kernel_src, core_ranges, config, dm_processor);
+        program.impl().get_context_id(), kernel_src, core_ranges, config, dm_processor);
     return program.impl().add_kernel(kernel, HalProgrammableCoreType::DISPATCH);
 }
 

--- a/tt_metal/impl/dispatch/dispatch_engine_kernel.cpp
+++ b/tt_metal/impl/dispatch/dispatch_engine_kernel.cpp
@@ -31,8 +31,7 @@ KernelHandle create_dispatch_engine_kernel(
         config.num_threads_per_cluster == 1,
         "CreateDispatchEngineKernel requires num_threads_per_cluster=1");
     const CoreRangeSet core_ranges = CoreRangeSet(core);
-    const KernelSource kernel_src(
-        resolve_kernel_file_path(file_name, program.impl().get_context_id()).string(), KernelSource::FILE_PATH);
+    const KernelSource kernel_src = KernelSource::from_path(program.impl().get_context_id(), file_name);
     std::shared_ptr<Kernel> kernel = std::make_shared<experimental::quasar::DispatchEngineKernel>(
         program.impl().get_context_id(), kernel_src, core_ranges, config, dm_processor);
     return program.impl().add_kernel(kernel, HalProgrammableCoreType::DISPATCH);

--- a/tt_metal/impl/dispatch/dispatch_engine_kernel.cpp
+++ b/tt_metal/impl/dispatch/dispatch_engine_kernel.cpp
@@ -31,7 +31,8 @@ KernelHandle create_dispatch_engine_kernel(
         config.num_threads_per_cluster == 1,
         "CreateDispatchEngineKernel requires num_threads_per_cluster=1");
     const CoreRangeSet core_ranges = CoreRangeSet(core);
-    const KernelSource kernel_src(file_name, KernelSource::FILE_PATH);
+    const KernelSource kernel_src(
+        resolve_kernel_file_path(file_name, program.impl().get_context_id()).string(), KernelSource::FILE_PATH);
     std::shared_ptr<Kernel> kernel = std::make_shared<experimental::quasar::DispatchEngineKernel>(
         program.impl().get_context_id(), kernel_src, core_ranges, config, dm_processor);
     return program.impl().add_kernel(kernel, HalProgrammableCoreType::DISPATCH);

--- a/tt_metal/impl/experimental/offline_compile/offline_kernel_compile.cpp
+++ b/tt_metal/impl/experimental/offline_compile/offline_kernel_compile.cpp
@@ -79,9 +79,9 @@ std::shared_ptr<Kernel> make_offline_kernel(
         [&](const auto& cfg) -> std::shared_ptr<Kernel> {
             using T = std::decay_t<decltype(cfg)>;
             if constexpr (std::is_same_v<T, DataMovementConfig>) {
-                return std::make_shared<DataMovementKernel>(kernel_src, core_range_set, cfg);
+                return std::make_shared<DataMovementKernel>(DEFAULT_CONTEXT_ID, kernel_src, core_range_set, cfg);
             } else {
-                return std::make_shared<ComputeKernel>(kernel_src, core_range_set, cfg);
+                return std::make_shared<ComputeKernel>(DEFAULT_CONTEXT_ID, kernel_src, core_range_set, cfg);
             }
         },
         config);

--- a/tt_metal/impl/experimental/offline_compile/offline_kernel_compile.cpp
+++ b/tt_metal/impl/experimental/offline_compile/offline_kernel_compile.cpp
@@ -218,7 +218,8 @@ void CompileKernelOffline(
             // The kernel's content (source, compile args, defines) is identical per config; the
             // per-config state (build options, full name, hash) is stored on JitBuildOptions and
             // refreshed on the kernel via set_full_name() each iteration.
-            const KernelSource kernel_src(file_name, KernelSource::FILE_PATH);
+            const KernelSource kernel_src(
+                resolve_kernel_file_path(file_name, DEFAULT_CONTEXT_ID).string(), KernelSource::FILE_PATH);
             const CoreRangeSet placeholder_core_range_set(CoreRange{CoreCoord{0, 0}, CoreCoord{0, 0}});
             const std::shared_ptr<Kernel> kernel = make_offline_kernel(kernel_src, placeholder_core_range_set, config);
 

--- a/tt_metal/impl/experimental/offline_compile/offline_kernel_compile.cpp
+++ b/tt_metal/impl/experimental/offline_compile/offline_kernel_compile.cpp
@@ -218,8 +218,7 @@ void CompileKernelOffline(
             // The kernel's content (source, compile args, defines) is identical per config; the
             // per-config state (build options, full name, hash) is stored on JitBuildOptions and
             // refreshed on the kernel via set_full_name() each iteration.
-            const KernelSource kernel_src(
-                resolve_kernel_file_path(file_name, DEFAULT_CONTEXT_ID).string(), KernelSource::FILE_PATH);
+            const KernelSource kernel_src = KernelSource::from_path(DEFAULT_CONTEXT_ID, file_name);
             const CoreRangeSet placeholder_core_range_set(CoreRange{CoreCoord{0, 0}, CoreCoord{0, 0}});
             const std::shared_ptr<Kernel> kernel = make_offline_kernel(kernel_src, placeholder_core_range_set, config);
 

--- a/tt_metal/impl/host_api/temp_quasar_api.cpp
+++ b/tt_metal/impl/host_api/temp_quasar_api.cpp
@@ -169,8 +169,8 @@ KernelHandle CreateQuasarDataMovementKernel(
         QUASAR_NUM_USER_DM_CORES_PER_CLUSTER);
     const std::set<DataMovementProcessor> dm_processors = GetProcessorsPerClusterQuasar<DataMovementProcessor>(
         program, core_ranges, config.num_threads_per_cluster, HalProgrammableCoreType::TENSIX);
-    std::shared_ptr<Kernel> kernel =
-        std::make_shared<QuasarDataMovementKernel>(kernel_src, core_ranges, config, dm_processors);
+    std::shared_ptr<Kernel> kernel = std::make_shared<QuasarDataMovementKernel>(
+        program.impl().get_context_id(), kernel_src, core_ranges, config, dm_processors);
     return program.impl().add_kernel(kernel, HalProgrammableCoreType::TENSIX);
 }
 
@@ -198,8 +198,8 @@ KernelHandle CreateQuasarComputeKernel(
         core_ranges,
         config.num_threads_per_cluster * QUASAR_NUM_COMPUTE_PROCESSORS_PER_TENSIX_ENGINE,
         HalProgrammableCoreType::TENSIX);
-    std::shared_ptr<Kernel> kernel =
-        std::make_shared<QuasarComputeKernel>(kernel_src, core_ranges, config, compute_processors);
+    std::shared_ptr<Kernel> kernel = std::make_shared<QuasarComputeKernel>(
+        program.impl().get_context_id(), kernel_src, core_ranges, config, compute_processors);
     return program.impl().add_kernel(kernel, HalProgrammableCoreType::TENSIX);
 }
 

--- a/tt_metal/impl/host_api/temp_quasar_api.cpp
+++ b/tt_metal/impl/host_api/temp_quasar_api.cpp
@@ -181,7 +181,11 @@ KernelHandle CreateKernel(
     const QuasarDataMovementConfig& config) {
     const CoreRangeSet core_ranges = detail::GetCoreRangeSet(core_spec);
     return CreateQuasarDataMovementKernel(
-        program, KernelSource(file_name, KernelSource::FILE_PATH), core_ranges, config);
+        program,
+        KernelSource(
+            resolve_kernel_file_path(file_name, program.impl().get_context_id()).string(), KernelSource::FILE_PATH),
+        core_ranges,
+        config);
 }
 
 KernelHandle CreateQuasarComputeKernel(
@@ -209,7 +213,12 @@ KernelHandle CreateKernel(
     const std::variant<CoreCoord, CoreRange, CoreRangeSet>& core_spec,
     const QuasarComputeConfig& config) {
     const CoreRangeSet core_ranges = detail::GetCoreRangeSet(core_spec);
-    return CreateQuasarComputeKernel(program, KernelSource(file_name, KernelSource::FILE_PATH), core_ranges, config);
+    return CreateQuasarComputeKernel(
+        program,
+        KernelSource(
+            resolve_kernel_file_path(file_name, program.impl().get_context_id()).string(), KernelSource::FILE_PATH),
+        core_ranges,
+        config);
 }
 
 }  // namespace tt::tt_metal::experimental::quasar

--- a/tt_metal/impl/host_api/temp_quasar_api.cpp
+++ b/tt_metal/impl/host_api/temp_quasar_api.cpp
@@ -181,11 +181,7 @@ KernelHandle CreateKernel(
     const QuasarDataMovementConfig& config) {
     const CoreRangeSet core_ranges = detail::GetCoreRangeSet(core_spec);
     return CreateQuasarDataMovementKernel(
-        program,
-        KernelSource(
-            resolve_kernel_file_path(file_name, program.impl().get_context_id()).string(), KernelSource::FILE_PATH),
-        core_ranges,
-        config);
+        program, KernelSource::from_path(program.impl().get_context_id(), file_name), core_ranges, config);
 }
 
 KernelHandle CreateQuasarComputeKernel(
@@ -214,11 +210,7 @@ KernelHandle CreateKernel(
     const QuasarComputeConfig& config) {
     const CoreRangeSet core_ranges = detail::GetCoreRangeSet(core_spec);
     return CreateQuasarComputeKernel(
-        program,
-        KernelSource(
-            resolve_kernel_file_path(file_name, program.impl().get_context_id()).string(), KernelSource::FILE_PATH),
-        core_ranges,
-        config);
+        program, KernelSource::from_path(program.impl().get_context_id(), file_name), core_ranges, config);
 }
 
 }  // namespace tt::tt_metal::experimental::quasar

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -1400,10 +1400,12 @@ KernelHandle CreateDataMovementKernel(
         config.processor == DataMovementProcessor::RISCV_0 || config.processor == DataMovementProcessor::RISCV_1,
         "DataMovementKernel creation failure: Data movement kernels can only be created on DM0 or DM1 processors.");
 
-    std::shared_ptr<Kernel> kernel = std::make_shared<DataMovementKernel>(kernel_src, core_range_set, config);
+    const ContextId context_id = program.impl().get_context_id();
+    std::shared_ptr<Kernel> kernel =
+        std::make_shared<DataMovementKernel>(context_id, kernel_src, core_range_set, config);
 
     // Inject all fabric-related defines (routing mode, UDM mode, dynamic header sizes, etc.)
-    const auto fabric_defines = MetalContext::instance().get_control_plane().get_fabric_kernel_defines();
+    const auto fabric_defines = MetalContext::instance(context_id).get_control_plane().get_fabric_kernel_defines();
     if (!fabric_defines.empty()) {
         kernel->add_defines(fabric_defines);
     }
@@ -1413,7 +1415,8 @@ KernelHandle CreateDataMovementKernel(
 
 KernelHandle CreateComputeKernel(
     Program& program, const KernelSource& kernel_src, const CoreRangeSet& core_range_set, const ComputeConfig& config) {
-    std::shared_ptr<Kernel> kernel = std::make_shared<ComputeKernel>(kernel_src, core_range_set, config);
+    std::shared_ptr<Kernel> kernel =
+        std::make_shared<ComputeKernel>(program.impl().get_context_id(), kernel_src, core_range_set, config);
     return program.impl().add_kernel(kernel, HalProgrammableCoreType::TENSIX);
 }
 
@@ -1434,29 +1437,31 @@ KernelHandle CreateEthernetKernel(
         config.processor == DataMovementProcessor::RISCV_0 || config.processor == DataMovementProcessor::RISCV_1,
         "EthernetKernel creation failure: Ethernet kernels can only be created on DM0 or DM1 processors.");
 
-    std::shared_ptr<Kernel> kernel = std::make_shared<EthernetKernel>(kernel_src, core_range_set, config);
+    const ContextId context_id = program.impl().get_context_id();
+    auto& metal_context = MetalContext::instance(context_id);
+    std::shared_ptr<Kernel> kernel = std::make_shared<EthernetKernel>(context_id, kernel_src, core_range_set, config);
 
     // Inject all fabric-related defines (routing mode, UDM mode, dynamic header sizes, etc.)
-    const auto fabric_defines = MetalContext::instance().get_control_plane().get_fabric_kernel_defines();
+    const auto fabric_defines = metal_context.get_control_plane().get_fabric_kernel_defines();
     if (!fabric_defines.empty()) {
         kernel->add_defines(fabric_defines);
     }
 
     // Disable watcher on ethernet cores if requested
-    const auto& rt_options = MetalContext::instance().rtoptions();
+    const auto& rt_options = metal_context.rtoptions();
     if (rt_options.watcher_eth_disabled()) {
         kernel->add_defines({{"FORCE_WATCHER_OFF", "1"}});
     }
 
     TT_FATAL(
         ttsl::as_underlying_type<DataMovementProcessor>(config.processor) <
-            MetalContext::instance().hal().get_num_risc_processors(eth_core_type),
+            metal_context.hal().get_num_risc_processors(eth_core_type),
         "EthernetKernel creation failure: {} kernel cannot target processor {} because Ethernet core only has {} "
         "processors. "
         "Update DataMovementProcessor in the config.",
         kernel->name(),
         enchantum::to_string(config.processor),
-        MetalContext::instance().hal().get_num_risc_processors(eth_core_type));
+        metal_context.hal().get_num_risc_processors(eth_core_type));
     TT_FATAL(
         !(are_both_riscv_in_use),
         "EthernetKernel creation failure: Cannot create data movement kernel for {} across specified "
@@ -1477,9 +1482,9 @@ KernelHandle CreateEthernetKernel(
     // | Single         | Not enabled for dispatch    | Dedicated NOC1              |
     // | Dual           | Dedicated NOC0, Dynamic NOC | Dedicated NOC1, Dynamic NOC |
     //
-    if (!MetalContext::instance().hal().get_eth_fw_is_cooperative() && config.eth_mode != Eth::IDLE &&
+    if (!metal_context.hal().get_eth_fw_is_cooperative() && config.eth_mode != Eth::IDLE &&
         config.noc_mode != NOC_MODE::DM_DYNAMIC_NOC) {
-        bool is_dual_erisc_mode = MetalContext::instance().rtoptions().get_enable_2_erisc_mode();
+        bool is_dual_erisc_mode = metal_context.rtoptions().get_enable_2_erisc_mode();
         bool is_erisc0 = (config.processor == DataMovementProcessor::RISCV_0);
         bool is_erisc1 = (config.processor == DataMovementProcessor::RISCV_1);
 
@@ -1512,8 +1517,7 @@ KernelHandle CreateEthernetKernel(
     }
 
     // Dynamic noc is not supported on single erisc mode
-    if (!MetalContext::instance().hal().get_eth_fw_is_cooperative() &&
-        !MetalContext::instance().rtoptions().get_enable_2_erisc_mode()) {
+    if (!metal_context.hal().get_eth_fw_is_cooperative() && !metal_context.rtoptions().get_enable_2_erisc_mode()) {
         TT_FATAL(
             config.noc_mode == NOC_MODE::DM_DEDICATED_NOC,
             "EthernetKernel creation failure: Dynamic NOC is not supported on single ERISC mode. "
@@ -1522,7 +1526,7 @@ KernelHandle CreateEthernetKernel(
             config.noc_mode);
     }
 
-    if (MetalContext::instance().hal().get_eth_fw_is_cooperative()) {
+    if (metal_context.hal().get_eth_fw_is_cooperative()) {
         // Dynamic NOC is not supported with this configuration
         TT_FATAL(
             config.noc_mode != NOC_MODE::DM_DYNAMIC_NOC,
@@ -1615,13 +1619,14 @@ KernelHandle CreateKernelFromString(
 
 static KernelHandle CreateDramKernel(
     Program& program, const KernelSource& kernel_src, const CoreRangeSet& core_range_set, const DramConfig& config) {
+    const ContextId context_id = program.impl().get_context_id();
+    auto& metal_context = MetalContext::instance(context_id);
+    TT_FATAL(metal_context.get_cluster().arch() == ARCH::BLACKHOLE, "DramKernel is only supported on Blackhole.");
     TT_FATAL(
-        MetalContext::instance().get_cluster().arch() == ARCH::BLACKHOLE, "DramKernel is only supported on Blackhole.");
-    TT_FATAL(
-        MetalContext::instance().hal().has_programmable_core_type(HalProgrammableCoreType::DRAM),
+        metal_context.hal().has_programmable_core_type(HalProgrammableCoreType::DRAM),
         "DRAM programmable cores are not enabled; they auto-enable on Blackhole with firmware >= 19.12.0.0 "
         "and either no harvested DRAM channels or a single device.");
-    std::shared_ptr<Kernel> kernel = std::make_shared<DramKernel>(kernel_src, core_range_set, config);
+    std::shared_ptr<Kernel> kernel = std::make_shared<DramKernel>(context_id, kernel_src, core_range_set, config);
     return program.impl().add_kernel(kernel, HalProgrammableCoreType::DRAM);
 }
 

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -1555,7 +1555,8 @@ KernelHandle CreateKernel(
 
     LIGHT_METAL_TRACE_FUNCTION_ENTRY();
     CoreRangeSet core_ranges = detail::GetCoreRangeSet(core_spec);
-    KernelSource kernel_src(file_name, KernelSource::FILE_PATH);
+    KernelSource kernel_src(
+        resolve_kernel_file_path(file_name, program.impl().get_context_id()).string(), KernelSource::FILE_PATH);
     KernelHandle kernel = std::visit(
         [&](const auto& cfg) -> KernelHandle {
             using T = std::decay_t<decltype(cfg)>;
@@ -1582,7 +1583,8 @@ KernelHandle CreateKernel(
     const EthernetConfig& config) {
     ValidateKernelConfigDefines(config.defines);
     CoreRangeSet core_ranges = detail::GetCoreRangeSet(core_spec);
-    KernelSource kernel_src(file_name, KernelSource::FILE_PATH);
+    KernelSource kernel_src(
+        resolve_kernel_file_path(file_name, program.impl().get_context_id()).string(), KernelSource::FILE_PATH);
     return CreateEthernetKernel(program, kernel_src, core_ranges, config);
 }
 
@@ -1637,7 +1639,8 @@ KernelHandle CreateKernel(
     const DramConfig& config) {
     ValidateKernelConfigDefines(config.defines);
     CoreRangeSet core_ranges = detail::GetCoreRangeSet(core_spec);
-    KernelSource kernel_src(file_name, KernelSource::FILE_PATH);
+    KernelSource kernel_src(
+        resolve_kernel_file_path(file_name, program.impl().get_context_id()).string(), KernelSource::FILE_PATH);
     return CreateDramKernel(program, kernel_src, core_ranges, config);
 }
 

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -1555,8 +1555,7 @@ KernelHandle CreateKernel(
 
     LIGHT_METAL_TRACE_FUNCTION_ENTRY();
     CoreRangeSet core_ranges = detail::GetCoreRangeSet(core_spec);
-    KernelSource kernel_src(
-        resolve_kernel_file_path(file_name, program.impl().get_context_id()).string(), KernelSource::FILE_PATH);
+    KernelSource kernel_src = KernelSource::from_path(program.impl().get_context_id(), file_name);
     KernelHandle kernel = std::visit(
         [&](const auto& cfg) -> KernelHandle {
             using T = std::decay_t<decltype(cfg)>;
@@ -1583,8 +1582,7 @@ KernelHandle CreateKernel(
     const EthernetConfig& config) {
     ValidateKernelConfigDefines(config.defines);
     CoreRangeSet core_ranges = detail::GetCoreRangeSet(core_spec);
-    KernelSource kernel_src(
-        resolve_kernel_file_path(file_name, program.impl().get_context_id()).string(), KernelSource::FILE_PATH);
+    KernelSource kernel_src = KernelSource::from_path(program.impl().get_context_id(), file_name);
     return CreateEthernetKernel(program, kernel_src, core_ranges, config);
 }
 
@@ -1595,7 +1593,7 @@ KernelHandle CreateKernelFromString(
     const std::variant<DataMovementConfig, ComputeConfig>& config) {
     std::visit([](const auto& cfg) { ValidateKernelConfigDefines(cfg.defines); }, config);
     CoreRangeSet core_ranges = detail::GetCoreRangeSet(core_spec);
-    KernelSource kernel_src(kernel_src_code, KernelSource::SOURCE_CODE);
+    KernelSource kernel_src = KernelSource::from_source(kernel_src_code);
     return std::visit(
         [&](const auto& cfg) -> KernelHandle {
             using T = std::decay_t<decltype(cfg)>;
@@ -1615,7 +1613,7 @@ KernelHandle CreateKernelFromString(
     const EthernetConfig& config) {
     ValidateKernelConfigDefines(config.defines);
     CoreRangeSet core_ranges = detail::GetCoreRangeSet(core_spec);
-    KernelSource kernel_src(kernel_src_code, KernelSource::SOURCE_CODE);
+    KernelSource kernel_src = KernelSource::from_source(kernel_src_code);
     return CreateEthernetKernel(program, kernel_src, core_ranges, config);
 }
 
@@ -1639,8 +1637,7 @@ KernelHandle CreateKernel(
     const DramConfig& config) {
     ValidateKernelConfigDefines(config.defines);
     CoreRangeSet core_ranges = detail::GetCoreRangeSet(core_spec);
-    KernelSource kernel_src(
-        resolve_kernel_file_path(file_name, program.impl().get_context_id()).string(), KernelSource::FILE_PATH);
+    KernelSource kernel_src = KernelSource::from_path(program.impl().get_context_id(), file_name);
     return CreateDramKernel(program, kernel_src, core_ranges, config);
 }
 
@@ -1651,7 +1648,7 @@ KernelHandle CreateKernelFromString(
     const DramConfig& config) {
     ValidateKernelConfigDefines(config.defines);
     CoreRangeSet core_ranges = detail::GetCoreRangeSet(core_spec);
-    KernelSource kernel_src(kernel_src_code, KernelSource::SOURCE_CODE);
+    KernelSource kernel_src = KernelSource::from_source(kernel_src_code);
     return CreateDramKernel(program, kernel_src, core_ranges, config);
 }
 

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -120,6 +120,7 @@ KernelSource::KernelSource(const std::string& source, const SourceType& source_t
 };
 
 Kernel::Kernel(
+    ContextId context_id,
     HalProgrammableCoreType programmable_core_type,
     HalProcessorClassType processor_class,
     const KernelSource& kernel_src,
@@ -134,6 +135,7 @@ Kernel::Kernel(
     const std::vector<std::string>& common_runtime_arg_names,
     const std::vector<TensorBindingHandle>& tensor_binding_handles,
     const KernelCrtaLayout& crta_layout) :
+    context_id_(context_id),
     programmable_core_type_(programmable_core_type),
     processor_class_(processor_class),
     kernel_src_(kernel_src),
@@ -151,8 +153,8 @@ Kernel::Kernel(
     core_with_max_runtime_args_({0, 0}),
     defines_(defines),
     watcher_assert_enabled_(
-        tt::tt_metal::MetalContext::instance().rtoptions().get_watcher_enabled() &&
-        !tt::tt_metal::MetalContext::instance().rtoptions().watcher_assert_disabled()),
+        tt::tt_metal::MetalContext::instance(context_id).rtoptions().get_watcher_enabled() &&
+        !tt::tt_metal::MetalContext::instance(context_id).rtoptions().watcher_assert_disabled()),
     watcher_count_word_offset_(watcher_assert_enabled_ ? 1 : 0) {
     this->register_kernel_with_watcher();
 
@@ -180,11 +182,11 @@ Kernel::Kernel(
 }
 
 void Kernel::register_kernel_with_watcher() {
-    auto& watcher = MetalContext::instance().watcher_server();
+    auto& watcher = MetalContext::instance(context_id_).watcher_server();
     if (!watcher) {
         // Null for mock and emulated targets (no watcher created); nothing to register.
         TT_FATAL(
-            MetalContext::instance().get_cluster().is_mock_or_emulated(),
+            MetalContext::instance(context_id_).get_cluster().is_mock_or_emulated(),
             "Watcher server is unavailable, and the target is not a mock or emulated device");
         this->watcher_kernel_id_ = -1;
         return;

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -40,14 +40,35 @@ namespace tt::tt_metal {
 namespace fs = std::filesystem;
 
 namespace {
-// Kernel path resolve:
+// Resolve a user-supplied compiler include path (-I):
+//  - Absolute paths pass through unchanged
+//  - Relative paths are resolved against the current working directory
 //
+// If the user-supplied path doesn't exist:
+//  - Absolute path will go straight to gcc, which will warn about the missing dir
+//  - Unresolved relative path will throw here
+//
+fs::path resolve_compiler_include_dir(const fs::path& given) {
+    if (given.is_absolute()) {
+        return given;
+    }
+    auto resolved = fs::current_path() / given;
+    if (!fs::is_directory(resolved)) {
+        TT_THROW(
+            "Compiler include directory '{}' not found relative to current working directory '{}'.",
+            given.string(),
+            fs::current_path().string());
+    }
+    return resolved;
+}
+}  // namespace
+
 // If the path is not an absolute path, then it must be resolved relative to:
 // 1. CWD
 // 2. TT_METAL_KERNEL_PATH
 // 3. System Kernel Directory
 // 4. TT_METAL_HOME / SetRootDir (API)
-fs::path resolve_path(const fs::path& given_file_name) {
+fs::path resolve_kernel_file_path(const fs::path& given_file_name, ContextId context_id) {
     // Priority 0: Absolute path
     if (given_file_name.is_absolute()) {
         return given_file_name;
@@ -61,7 +82,7 @@ fs::path resolve_path(const fs::path& given_file_name) {
         }
     }
 
-    const auto& rtoptions = tt_metal::MetalContext::instance().rtoptions();
+    const auto& rtoptions = MetalContext::instance(context_id).rtoptions();
 
     // Priority 2: Kernel directory
     if (rtoptions.is_kernel_dir_specified()) {
@@ -89,33 +110,13 @@ fs::path resolve_path(const fs::path& given_file_name) {
     TT_THROW("Kernel file {} doesn't exist in any of the searched paths!", given_file_name);
 }
 
-// Resolve a user-supplied compiler include path (-I):
-//  - Absolute paths pass through unchanged
-//  - Relative paths are resolved against the current working directory
-//
-// If the user-supplied path doesn't exist:
-//  - Absolute path will go straight to gcc, which will warn about the missing dir
-//  - Unresolved relative path will throw here
-//
-fs::path resolve_compiler_include_dir(const fs::path& given) {
-    if (given.is_absolute()) {
-        return given;
-    }
-    auto resolved = fs::current_path() / given;
-    if (!fs::is_directory(resolved)) {
-        TT_THROW(
-            "Compiler include directory '{}' not found relative to current working directory '{}'.",
-            given.string(),
-            fs::current_path().string());
-    }
-    return resolved;
-}
-}  // namespace
-
 KernelSource::KernelSource(const std::string& source, const SourceType& source_type) :
     source_(source), source_type_(source_type) {
     if (source_type == FILE_PATH) {
-        path_ = resolve_path(source);
+        // Residual relative-path construction without a Program uses DEFAULT_CONTEXT_ID.
+        // Program-backed factories pre-resolve via resolve_kernel_file_path so this hits the
+        // absolute-path early-out and never reads context.
+        path_ = resolve_kernel_file_path(source);
     }
 };
 

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -113,9 +113,9 @@ fs::path resolve_kernel_file_path(const fs::path& given_file_name, ContextId con
 KernelSource::KernelSource(const std::string& source, const SourceType& source_type) :
     source_(source), source_type_(source_type) {
     if (source_type == FILE_PATH) {
-        // Residual relative-path construction without a Program uses DEFAULT_CONTEXT_ID.
-        // Program-backed factories pre-resolve via resolve_kernel_file_path so this hits the
-        // absolute-path early-out and never reads context.
+        // FILE_PATH without a prior resolve uses DEFAULT_CONTEXT_ID. Program-backed factories pass
+        // an absolute path from resolve_kernel_file_path, so this hits the absolute-path early-out
+        // and never reads context.
         path_ = resolve_kernel_file_path(source);
     }
 };

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -40,35 +40,14 @@ namespace tt::tt_metal {
 namespace fs = std::filesystem;
 
 namespace {
-// Resolve a user-supplied compiler include path (-I):
-//  - Absolute paths pass through unchanged
-//  - Relative paths are resolved against the current working directory
+// Kernel path resolve:
 //
-// If the user-supplied path doesn't exist:
-//  - Absolute path will go straight to gcc, which will warn about the missing dir
-//  - Unresolved relative path will throw here
-//
-fs::path resolve_compiler_include_dir(const fs::path& given) {
-    if (given.is_absolute()) {
-        return given;
-    }
-    auto resolved = fs::current_path() / given;
-    if (!fs::is_directory(resolved)) {
-        TT_THROW(
-            "Compiler include directory '{}' not found relative to current working directory '{}'.",
-            given.string(),
-            fs::current_path().string());
-    }
-    return resolved;
-}
-}  // namespace
-
 // If the path is not an absolute path, then it must be resolved relative to:
 // 1. CWD
 // 2. TT_METAL_KERNEL_PATH
 // 3. System Kernel Directory
 // 4. TT_METAL_HOME / SetRootDir (API)
-fs::path resolve_kernel_file_path(const fs::path& given_file_name, ContextId context_id) {
+fs::path resolve_path(const fs::path& given_file_name, ContextId context_id) {
     // Priority 0: Absolute path
     if (given_file_name.is_absolute()) {
         return given_file_name;
@@ -110,15 +89,40 @@ fs::path resolve_kernel_file_path(const fs::path& given_file_name, ContextId con
     TT_THROW("Kernel file {} doesn't exist in any of the searched paths!", given_file_name);
 }
 
-KernelSource::KernelSource(const std::string& source, const SourceType& source_type) :
-    source_(source), source_type_(source_type) {
-    if (source_type == FILE_PATH) {
-        // FILE_PATH without a prior resolve uses DEFAULT_CONTEXT_ID. Program-backed factories pass
-        // an absolute path from resolve_kernel_file_path, so this hits the absolute-path early-out
-        // and never reads context.
-        path_ = resolve_kernel_file_path(source);
+// Resolve a user-supplied compiler include path (-I):
+//  - Absolute paths pass through unchanged
+//  - Relative paths are resolved against the current working directory
+//
+// If the user-supplied path doesn't exist:
+//  - Absolute path will go straight to gcc, which will warn about the missing dir
+//  - Unresolved relative path will throw here
+//
+fs::path resolve_compiler_include_dir(const fs::path& given) {
+    if (given.is_absolute()) {
+        return given;
     }
-};
+    auto resolved = fs::current_path() / given;
+    if (!fs::is_directory(resolved)) {
+        TT_THROW(
+            "Compiler include directory '{}' not found relative to current working directory '{}'.",
+            given.string(),
+            fs::current_path().string());
+    }
+    return resolved;
+}
+}  // namespace
+
+KernelSource::KernelSource(std::string source, SourceType source_type, fs::path path) :
+    source_(std::move(source)), source_type_(source_type), path_(std::move(path)) {}
+
+KernelSource KernelSource::from_path(ContextId context_id, const fs::path& path) {
+    auto resolved = resolve_path(path, context_id);
+    return KernelSource(resolved.string(), FILE_PATH, std::move(resolved));
+}
+
+KernelSource KernelSource::from_source(const std::string& source_code) {
+    return KernelSource(source_code, SOURCE_CODE, fs::path{});
+}
 
 Kernel::Kernel(
     ContextId context_id,

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -117,7 +117,8 @@ KernelSource::KernelSource(std::string source, SourceType source_type, fs::path 
 
 KernelSource KernelSource::from_path(ContextId context_id, const fs::path& path) {
     auto resolved = resolve_path(path, context_id);
-    return KernelSource(resolved.string(), FILE_PATH, std::move(resolved));
+    // Keep source_ as the caller-supplied path (metadata/watcher/hash); path_ is the resolved file.
+    return KernelSource(path.string(), FILE_PATH, std::move(resolved));
 }
 
 KernelSource KernelSource::from_source(const std::string& source_code) {

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -378,6 +378,7 @@ private:
 class DataMovementKernel : public Kernel {
 public:
     DataMovementKernel(
+        ContextId context_id,
         const KernelSource& kernel_src,
         const CoreRangeSet& cr_set,
         const DataMovementConfig& config,
@@ -388,8 +389,7 @@ public:
         const std::vector<std::string>& runtime_arg_names = {},
         const std::vector<std::string>& common_runtime_arg_names = {},
         const std::vector<TensorBindingHandle>& tensor_binding_handles = {},
-        const KernelCrtaLayout& crta_layout = {},
-        ContextId context_id = DEFAULT_CONTEXT_ID) :
+        const KernelCrtaLayout& crta_layout = {}) :
         Kernel(
             context_id,
             HalProgrammableCoreType::TENSIX,
@@ -441,10 +441,10 @@ private:
 class EthernetKernel : public Kernel {
 public:
     EthernetKernel(
+        ContextId context_id,
         const KernelSource& kernel_src,
         const CoreRangeSet& cr_set,
-        const EthernetConfig& config,
-        ContextId context_id = DEFAULT_CONTEXT_ID) :
+        const EthernetConfig& config) :
         Kernel(
             context_id,
             config.eth_mode == Eth::IDLE ? HalProgrammableCoreType::IDLE_ETH : HalProgrammableCoreType::ACTIVE_ETH,
@@ -484,10 +484,7 @@ private:
 class DramKernel : public Kernel {
 public:
     DramKernel(
-        const KernelSource& kernel_src,
-        const CoreRangeSet& cr_set,
-        const DramConfig& config,
-        ContextId context_id = DEFAULT_CONTEXT_ID) :
+        ContextId context_id, const KernelSource& kernel_src, const CoreRangeSet& cr_set, const DramConfig& config) :
         Kernel(
             context_id,
             HalProgrammableCoreType::DRAM,
@@ -529,11 +526,11 @@ namespace experimental::quasar {
 class DispatchEngineKernel : public Kernel {
 public:
     DispatchEngineKernel(
+        ContextId context_id,
         const KernelSource& kernel_src,
         const CoreRangeSet& cr_set,
         const QuasarDataMovementConfig& config,
-        DataMovementProcessor dm_processor,
-        ContextId context_id = DEFAULT_CONTEXT_ID) :
+        DataMovementProcessor dm_processor) :
         Kernel(
             context_id,
             HalProgrammableCoreType::DISPATCH,
@@ -587,6 +584,7 @@ private:
 class ComputeKernel : public Kernel {
 public:
     ComputeKernel(
+        ContextId context_id,
         const KernelSource& kernel_src,
         const CoreRangeSet& cr_set,
         const ComputeConfig& config,
@@ -597,8 +595,7 @@ public:
         const std::vector<std::string>& runtime_arg_names = {},
         const std::vector<std::string>& common_runtime_arg_names = {},
         const std::vector<TensorBindingHandle>& tensor_binding_handles = {},
-        const KernelCrtaLayout& crta_layout = {},
-        ContextId context_id = DEFAULT_CONTEXT_ID) :
+        const KernelCrtaLayout& crta_layout = {}) :
         Kernel(
             context_id,
             HalProgrammableCoreType::TENSIX,
@@ -674,6 +671,7 @@ enum class QuasarComputeProcessor : uint8_t {
 class QuasarDataMovementKernel : public Kernel {
 public:
     QuasarDataMovementKernel(
+        ContextId context_id,
         const KernelSource& kernel_src,
         const CoreRangeSet& cr_set,
         const QuasarDataMovementConfig& config,
@@ -685,8 +683,7 @@ public:
         const std::vector<std::string>& runtime_arg_names = {},
         const std::vector<std::string>& common_runtime_arg_names = {},
         const std::vector<TensorBindingHandle>& tensor_binding_handles = {},
-        const KernelCrtaLayout& crta_layout = {},
-        ContextId context_id = DEFAULT_CONTEXT_ID) :
+        const KernelCrtaLayout& crta_layout = {}) :
         Kernel(
             context_id,
             HalProgrammableCoreType::TENSIX,
@@ -748,6 +745,7 @@ private:
 class QuasarComputeKernel : public Kernel {
 public:
     QuasarComputeKernel(
+        ContextId context_id,
         const KernelSource& kernel_src,
         const CoreRangeSet& cr_set,
         const QuasarComputeConfig& config,
@@ -759,8 +757,7 @@ public:
         const std::vector<std::string>& runtime_arg_names = {},
         const std::vector<std::string>& common_runtime_arg_names = {},
         const std::vector<TensorBindingHandle>& tensor_binding_handles = {},
-        const KernelCrtaLayout& crta_layout = {},
-        ContextId context_id = DEFAULT_CONTEXT_ID) :
+        const KernelCrtaLayout& crta_layout = {}) :
         Kernel(
             context_id,
             HalProgrammableCoreType::TENSIX,

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -253,6 +253,8 @@ public:
 
     int get_watcher_kernel_id() const { return watcher_kernel_id_; }
 
+    ContextId get_context_id() const { return context_id_; }
+
     // Get the corresponding core type, processor class, and processor type of the kernel as defined by HAL.
     // The processor type is per-binary, where 0 <= index < expected_num_binaries.
     HalProgrammableCoreType get_kernel_programmable_core_type() const { return this->programmable_core_type_; }
@@ -296,6 +298,7 @@ public:
 
 protected:
     Kernel(
+        ContextId context_id,
         HalProgrammableCoreType programmable_core_type,
         HalProcessorClassType processor_class,
         const KernelSource& kernel_src,
@@ -313,6 +316,7 @@ protected:
         const std::vector<TensorBindingHandle>& tensor_binding_handles = {},
         const KernelCrtaLayout& crta_layout = {});
 
+    ContextId context_id_{DEFAULT_CONTEXT_ID};
     HalProgrammableCoreType programmable_core_type_;
     HalProcessorClassType processor_class_;
 
@@ -384,8 +388,10 @@ public:
         const std::vector<std::string>& runtime_arg_names = {},
         const std::vector<std::string>& common_runtime_arg_names = {},
         const std::vector<TensorBindingHandle>& tensor_binding_handles = {},
-        const KernelCrtaLayout& crta_layout = {}) :
+        const KernelCrtaLayout& crta_layout = {},
+        ContextId context_id = DEFAULT_CONTEXT_ID) :
         Kernel(
+            context_id,
             HalProgrammableCoreType::TENSIX,
             HalProcessorClassType::DM,
             kernel_src,
@@ -402,7 +408,7 @@ public:
             crta_layout),
         config_(config) {
         TT_FATAL(
-            MetalContext::instance().get_cluster().arch() != ARCH::QUASAR,
+            MetalContext::instance(context_id_).get_cluster().arch() != ARCH::QUASAR,
             "DataMovementKernel is not supported on Quasar. Use QuasarDataMovementKernel instead.");
         this->set_compiler_include_paths(config_.compiler_include_paths);
     }
@@ -434,8 +440,13 @@ private:
 
 class EthernetKernel : public Kernel {
 public:
-    EthernetKernel(const KernelSource& kernel_src, const CoreRangeSet& cr_set, const EthernetConfig& config) :
+    EthernetKernel(
+        const KernelSource& kernel_src,
+        const CoreRangeSet& cr_set,
+        const EthernetConfig& config,
+        ContextId context_id = DEFAULT_CONTEXT_ID) :
         Kernel(
+            context_id,
             config.eth_mode == Eth::IDLE ? HalProgrammableCoreType::IDLE_ETH : HalProgrammableCoreType::ACTIVE_ETH,
             HalProcessorClassType::DM,
             kernel_src,
@@ -472,8 +483,13 @@ private:
 
 class DramKernel : public Kernel {
 public:
-    DramKernel(const KernelSource& kernel_src, const CoreRangeSet& cr_set, const DramConfig& config) :
+    DramKernel(
+        const KernelSource& kernel_src,
+        const CoreRangeSet& cr_set,
+        const DramConfig& config,
+        ContextId context_id = DEFAULT_CONTEXT_ID) :
         Kernel(
+            context_id,
             HalProgrammableCoreType::DRAM,
             HalProcessorClassType::DM,
             kernel_src,
@@ -516,8 +532,10 @@ public:
         const KernelSource& kernel_src,
         const CoreRangeSet& cr_set,
         const QuasarDataMovementConfig& config,
-        DataMovementProcessor dm_processor) :
+        DataMovementProcessor dm_processor,
+        ContextId context_id = DEFAULT_CONTEXT_ID) :
         Kernel(
+            context_id,
             HalProgrammableCoreType::DISPATCH,
             HalProcessorClassType::DM,
             kernel_src,
@@ -528,7 +546,7 @@ public:
         config_(config),
         dm_processors_{dm_processor} {
         TT_FATAL(
-            MetalContext::instance().get_cluster().arch() == ARCH::QUASAR,
+            MetalContext::instance(context_id_).get_cluster().arch() == ARCH::QUASAR,
             "DispatchEngineKernel is only supported on Quasar");
         TT_FATAL(
             config.num_threads_per_cluster == 1,
@@ -579,8 +597,10 @@ public:
         const std::vector<std::string>& runtime_arg_names = {},
         const std::vector<std::string>& common_runtime_arg_names = {},
         const std::vector<TensorBindingHandle>& tensor_binding_handles = {},
-        const KernelCrtaLayout& crta_layout = {}) :
+        const KernelCrtaLayout& crta_layout = {},
+        ContextId context_id = DEFAULT_CONTEXT_ID) :
         Kernel(
+            context_id,
             HalProgrammableCoreType::TENSIX,
             HalProcessorClassType::COMPUTE,
             kernel_src,
@@ -597,7 +617,7 @@ public:
             crta_layout),
         config_(config) {
         TT_FATAL(
-            MetalContext::instance().get_cluster().arch() != ARCH::QUASAR,
+            MetalContext::instance(context_id_).get_cluster().arch() != ARCH::QUASAR,
             "ComputeKernel is not supported on Quasar. Use QuasarComputeKernel instead.");
         this->set_compiler_include_paths(config_.compiler_include_paths);
     }
@@ -665,8 +685,10 @@ public:
         const std::vector<std::string>& runtime_arg_names = {},
         const std::vector<std::string>& common_runtime_arg_names = {},
         const std::vector<TensorBindingHandle>& tensor_binding_handles = {},
-        const KernelCrtaLayout& crta_layout = {}) :
+        const KernelCrtaLayout& crta_layout = {},
+        ContextId context_id = DEFAULT_CONTEXT_ID) :
         Kernel(
+            context_id,
             HalProgrammableCoreType::TENSIX,
             HalProcessorClassType::DM,
             kernel_src,
@@ -684,7 +706,7 @@ public:
         config_(config),
         dm_processors_(dm_processors.begin(), dm_processors.end()) {
         TT_FATAL(
-            MetalContext::instance().get_cluster().arch() == ARCH::QUASAR,
+            MetalContext::instance(context_id_).get_cluster().arch() == ARCH::QUASAR,
             "QuasarDataMovementKernel is only supported on Quasar");
         TT_FATAL(
             config.num_threads_per_cluster == dm_processors.size(),
@@ -737,8 +759,10 @@ public:
         const std::vector<std::string>& runtime_arg_names = {},
         const std::vector<std::string>& common_runtime_arg_names = {},
         const std::vector<TensorBindingHandle>& tensor_binding_handles = {},
-        const KernelCrtaLayout& crta_layout = {}) :
+        const KernelCrtaLayout& crta_layout = {},
+        ContextId context_id = DEFAULT_CONTEXT_ID) :
         Kernel(
+            context_id,
             HalProgrammableCoreType::TENSIX,
             HalProcessorClassType::COMPUTE,
             kernel_src,
@@ -756,7 +780,7 @@ public:
         config_(config),
         compute_processors_(compute_processors.begin(), compute_processors.end()) {
         TT_FATAL(
-            MetalContext::instance().get_cluster().arch() == ARCH::QUASAR,
+            MetalContext::instance(context_id_).get_cluster().arch() == ARCH::QUASAR,
             "QuasarComputeKernel is only supported on Quasar");
         TT_FATAL(
             config.num_threads_per_cluster * QUASAR_NUM_COMPUTE_PROCESSORS_PER_TENSIX_ENGINE ==

--- a/tt_metal/impl/kernels/kernel_source.hpp
+++ b/tt_metal/impl/kernels/kernel_source.hpp
@@ -9,9 +9,16 @@
 #include <sstream>
 #include <string>
 
+#include <impl/context/context_types.hpp>
 #include <tt_stl/unreachable.hpp>
 
 namespace tt::tt_metal {
+
+// Resolve a relative kernel file path using rtoptions from the given context.
+// Absolute paths are returned unchanged. KernelSource itself does not store a ContextId;
+// Program-backed factories should call this before constructing a FILE_PATH KernelSource.
+std::filesystem::path resolve_kernel_file_path(
+    const std::filesystem::path& given_file_name, ContextId context_id = DEFAULT_CONTEXT_ID);
 
 struct KernelSource {
     enum SourceType { FILE_PATH, SOURCE_CODE };

--- a/tt_metal/impl/kernels/kernel_source.hpp
+++ b/tt_metal/impl/kernels/kernel_source.hpp
@@ -14,12 +14,6 @@
 
 namespace tt::tt_metal {
 
-// Resolve a relative kernel file path using rtoptions from the given context.
-// Absolute paths are returned unchanged. KernelSource itself does not store a ContextId;
-// Program-backed factories should call this before constructing a FILE_PATH KernelSource.
-std::filesystem::path resolve_kernel_file_path(
-    const std::filesystem::path& given_file_name, ContextId context_id = DEFAULT_CONTEXT_ID);
-
 struct KernelSource {
     enum SourceType { FILE_PATH, SOURCE_CODE };
 
@@ -28,7 +22,11 @@ struct KernelSource {
     // if source_type_ is FILE_PATH, file pointed by path_ exists at time of construction
     std::filesystem::path path_;
 
-    KernelSource(const std::string& source, const SourceType& source_type);
+    // Resolve path using rtoptions from context_id and construct a FILE_PATH KernelSource.
+    static KernelSource from_path(ContextId context_id, const std::filesystem::path& path);
+
+    // Construct a SOURCE_CODE KernelSource from inline source.
+    static KernelSource from_source(const std::string& source_code);
 
     std::string name() const {
         if (this->source_type_ == SourceType::FILE_PATH) {
@@ -56,6 +54,9 @@ struct KernelSource {
         }
         ttsl::unreachable();
     }
+
+private:
+    KernelSource(std::string source, SourceType source_type, std::filesystem::path path);
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -3067,6 +3067,7 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
                 config.compile_args = ta_bindings.cta_words;  // populate positional CTAs from tensor bindings
                 auto processors = GetDMProcessorSet(DMProcessorMask{(uint8_t)(risc_mask & 0xFF)});
                 kernel = std::make_shared<experimental::quasar::QuasarDataMovementKernel>(
+                    program_impl->get_context_id(),
                     kernel_src,
                     node_ranges,
                     config,
@@ -3083,6 +3084,7 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
                 config.compile_args = ta_bindings.cta_words;
                 auto processors = GetComputeProcessorSet(ComputeEngineMask{(uint8_t)(risc_mask >> 8)});
                 kernel = std::make_shared<experimental::quasar::QuasarComputeKernel>(
+                    program_impl->get_context_id(),
                     kernel_src,
                     node_ranges,
                     config,
@@ -3100,6 +3102,7 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
                 auto config = MakeGen1DataMovementConfig(kernel_spec);
                 config.compile_args = ta_bindings.cta_words;
                 kernel = std::make_shared<DataMovementKernel>(
+                    program_impl->get_context_id(),
                     kernel_src,
                     node_ranges,
                     config,
@@ -3114,6 +3117,7 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
                 auto config = MakeGen1ComputeConfig(kernel_spec, dfb_name_to_slot);
                 config.compile_args = ta_bindings.cta_words;
                 kernel = std::make_shared<ComputeKernel>(
+                    program_impl->get_context_id(),
                     kernel_src,
                     node_ranges,
                     config,

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2940,7 +2940,7 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
     }
 
     // Step 3: Build the Program
-    auto program_impl = std::make_shared<detail::ProgramImpl>();
+    auto program_impl = std::make_shared<detail::ProgramImpl>(extract_context_id(&mesh_device));
     program_impl->mark_created_from_spec();  // mark as Metal 2.0 ProgramSpec-created (for legality checks)
 
     // Register TensorParameters with the program for ValidateProgramRunArgs to consult at enqueue.

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2617,13 +2617,14 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
 // MakeKernelSource: Create a KernelSource from a KernelSpec
 // ----------------------------------------------------------------------------
 
-KernelSource MakeKernelSource(const KernelSpec& kernel_spec) {
+KernelSource MakeKernelSource(const KernelSpec& kernel_spec, ContextId context_id) {
     return std::visit(
         [&](const auto& src) -> KernelSource {
             using T = std::decay_t<decltype(src)>;
             if constexpr (std::is_same_v<T, std::filesystem::path>) {
                 TT_FATAL(!src.empty(), "KernelSpec '{}' has empty source file path", kernel_spec.unique_id);
-                return KernelSource(src.string(), KernelSource::SourceType::FILE_PATH);
+                return KernelSource(
+                    resolve_kernel_file_path(src, context_id).string(), KernelSource::SourceType::FILE_PATH);
             } else if constexpr (std::is_same_v<T, KernelSpec::SourceCode>) {
                 TT_FATAL(!src.code.empty(), "KernelSpec '{}' has empty inline source code", kernel_spec.unique_id);
                 return KernelSource(src.code, KernelSource::SourceType::SOURCE_CODE);
@@ -3018,7 +3019,7 @@ Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const Program
 
     // Create Kernels (arch-specific)
     for (const KernelSpec& kernel_spec : spec.kernels) {
-        KernelSource kernel_src = MakeKernelSource(kernel_spec);
+        KernelSource kernel_src = MakeKernelSource(kernel_spec, program_impl->get_context_id());
         const NodeRangeSet& node_ranges = collected.kernel_node_set.at(kernel_spec.unique_id);
 
         // Make the local accessor name -> DFB device slot map for this kernel

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2623,11 +2623,10 @@ KernelSource MakeKernelSource(const KernelSpec& kernel_spec, ContextId context_i
             using T = std::decay_t<decltype(src)>;
             if constexpr (std::is_same_v<T, std::filesystem::path>) {
                 TT_FATAL(!src.empty(), "KernelSpec '{}' has empty source file path", kernel_spec.unique_id);
-                return KernelSource(
-                    resolve_kernel_file_path(src, context_id).string(), KernelSource::SourceType::FILE_PATH);
+                return KernelSource::from_path(context_id, src);
             } else if constexpr (std::is_same_v<T, KernelSpec::SourceCode>) {
                 TT_FATAL(!src.code.empty(), "KernelSpec '{}' has empty inline source code", kernel_spec.unique_id);
-                return KernelSource(src.code, KernelSource::SourceType::SOURCE_CODE);
+                return KernelSource::from_source(src.code);
             } else {
                 static_assert(!sizeof(T*), "Unhandled KernelSpec::source alternative");
             }

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -2342,11 +2342,17 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
     TTZoneScopedD(PROGRAM);
 
     const ContextId device_context_id = extract_context_id(device);
+    // Metal 1.0 CreateProgram() always stores DEFAULT_CONTEXT_ID because no MetalEnv/device is
+    // available at construction. MetalContext::instance(DEFAULT_CONTEXT_ID) already bridges that
+    // case: when slot 0 is empty it aliases to a live non-default context (mock-only /
+    // coexistence) instead of opening silicon. Allow DEFAULT programs on any device so that
+    // bridge keeps working; do not overwrite context_id_. Reject only a real mismatch where the
+    // program was explicitly bound (Metal 2.0 MakeProgramFromSpec) to a different context.
     TT_FATAL(
-        context_id_ == device_context_id,
+        context_id_ == DEFAULT_CONTEXT_ID || context_id_ == device_context_id,
         "Program {} was created for context_id {} but is being compiled on a device from context_id {}. "
-        "Metal 1.0 CreateProgram() binds DEFAULT_CONTEXT_ID; use Metal 2.0 MakeProgramFromSpec (or a future "
-        "CreateProgram that takes MetalEnv) when compiling against a non-default context.",
+        "A program bound to a non-default context must be compiled on a device from that same context "
+        "(Metal 2.0 MakeProgramFromSpec / future CreateProgram(MetalEnv)).",
         this->id,
         context_id_.get(),
         device_context_id.get());

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -2341,10 +2341,19 @@ void ProgramImpl::generate_trace_dispatch_commands(distributed::MeshDevice* mesh
 void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
     TTZoneScopedD(PROGRAM);
 
-    const auto& cluster = MetalContext::instance(extract_context_id(device)).get_cluster();
+    const ContextId device_context_id = extract_context_id(device);
+    TT_FATAL(
+        context_id_ == device_context_id,
+        "Program {} was created for context_id {} but is being compiled on a device from context_id {}. "
+        "Metal 1.0 CreateProgram() binds DEFAULT_CONTEXT_ID; use Metal 2.0 MakeProgramFromSpec (or a future "
+        "CreateProgram that takes MetalEnv) when compiling against a non-default context.",
+        this->id,
+        context_id_.get(),
+        device_context_id.get());
 
-    const auto& build_env =
-        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id());
+    const auto& cluster = MetalContext::instance(device_context_id).get_cluster();
+
+    const auto& build_env = BuildEnvManager::get_instance(device_context_id).get_device_build_env(device->build_id());
 
     if (compiled_.contains(build_env.build_key())) {
         Inspector::program_compile_already_exists(this, device, build_env.build_key());

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -342,11 +342,12 @@ void ClearKernelCache() { jit_build_cache_clear(); }
 
 std::atomic<uint64_t> detail::ProgramImpl::program_counter = 0;
 
-detail::ProgramImpl::ProgramImpl() :
+detail::ProgramImpl::ProgramImpl(ContextId context_id) :
 
     cached_device_hash_(std::nullopt),
-    programmable_core_count_(MetalContext::instance().hal().get_programmable_core_type_count()),
-    max_cbs_(MetalContext::instance().hal().get_arch_num_circular_buffers()),
+    context_id_(context_id),
+    programmable_core_count_(MetalContext::instance(context_id).hal().get_programmable_core_type_count()),
+    max_cbs_(MetalContext::instance(context_id).hal().get_arch_num_circular_buffers()),
     id(program_counter++) {
     for (uint32_t i = 0; i < programmable_core_count_; i++) {
         kernels_.push_back({});
@@ -509,7 +510,7 @@ KernelHandle detail::ProgramImpl::add_kernel(
 
     // Id is unique across all kernels on all core types
     KernelHandle id = this->num_kernels();
-    uint32_t index = MetalContext::instance().hal().get_programmable_core_type_index(programmable_core_type);
+    uint32_t index = MetalContext::instance(context_id_).hal().get_programmable_core_type_index(programmable_core_type);
 
     auto new_kernel_core_type = kernel->get_kernel_programmable_core_type();
     auto new_kernel_processor_class = kernel->get_kernel_processor_class();
@@ -814,6 +815,7 @@ KernelGroup::KernelGroup(
     const CoreRangeSet& new_ranges,
     const dev_msgs::Factory& dev_msgs_factory) :
     programmable_core_type_index(programmable_core_type_index),
+    context_id_(program.get_context_id()),
 
     kernel_ids(std::move(kernel_ids)),
     launch_msg(dev_msgs_factory.create<dev_msgs::launch_msg_t>()),
@@ -825,7 +827,7 @@ KernelGroup::KernelGroup(
 
     // Slow dispatch uses fixed addresses for the kernel config, configured here statically
     // Fast dispatch kernel config management happens under the CQ and will re-program the base
-    const auto& hal = MetalContext::instance().hal();
+    const auto& hal = MetalContext::instance(context_id_).hal();
     for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         kernel_config.kernel_config_base()[index] =
             hal.get_dev_addr(hal.get_programmable_core_type(index), HalL1MemAddrType::KERNEL_CONFIG);
@@ -958,7 +960,7 @@ KernelGroup::KernelGroup(
 }
 
 CoreType KernelGroup::get_core_type() const {
-    return MetalContext::instance().hal().get_core_type(this->programmable_core_type_index);
+    return MetalContext::instance(context_id_).hal().get_core_type(this->programmable_core_type_index);
 };
 
 std::vector<std::shared_ptr<KernelGroup>>& detail::ProgramImpl::get_kernel_groups(
@@ -1036,7 +1038,7 @@ void detail::ProgramImpl::update_kernel_groups(uint32_t programmable_core_type_i
         core_to_kernel_group_index_table_[programmable_core_type_index].resize(
             grid_extent_[programmable_core_type_index].x * grid_extent_[programmable_core_type_index].y,
             core_to_kernel_group_invalid_index);
-        const auto& hal = MetalContext::instance().hal();
+        const auto& hal = MetalContext::instance(context_id_).hal();
         for (auto& [kernels, cores] : map) {
             // Start inclusive, max exclusive
             uint32_t max_local_cb_end_index = 0;
@@ -1094,8 +1096,9 @@ void detail::ProgramImpl::update_kernel_groups(uint32_t programmable_core_type_i
                                         // This code should be modified to log the core type index if it isn't obvious.
                                         TT_ASSERT(
                                             programmable_core_type_index ==
-                                            MetalContext::instance().hal().get_programmable_core_type_index(
-                                                HalProgrammableCoreType::TENSIX));
+                                            MetalContext::instance(context_id_)
+                                                .hal()
+                                                .get_programmable_core_type_index(HalProgrammableCoreType::TENSIX));
 
                                         std::string cb_ids;
                                         for (uint32_t i = 0; i < max_cbs_; i++) {
@@ -1873,7 +1876,7 @@ void detail::ProgramImpl::add_semaphore(
 uint32_t detail::ProgramImpl::create_semaphore(const CoreRangeSet& crs, uint32_t initial_value, CoreType core_type) {
     TT_FATAL(!crs.ranges().empty(), "Expecting a non-empty CoreRangeSet!");
     TT_FATAL(
-        MetalContext::instance().is_coord_in_range(crs.ranges().back().end_coord, core_type),
+        MetalContext::instance(context_id_).is_coord_in_range(crs.ranges().back().end_coord, core_type),
         "Coordinates out of range");
 
     std::optional<uint32_t> semaphore_id;
@@ -2567,20 +2570,18 @@ uint32_t detail::ProgramImpl::get_cb_size(IDevice* device, CoreCoord logical_cor
 
 // TODO: Too low level for program.cpp. Move this to HAL, once we have support.
 bool detail::ProgramImpl::runs_on_noc_unicast_only_cores() {
+    const auto& hal = MetalContext::instance(context_id_).hal();
     return (
-        MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1 and
-        not this->get_kernel_groups(MetalContext::instance().hal().get_programmable_core_type_index(
-                                        HalProgrammableCoreType::ACTIVE_ETH))
-                .empty());
+        hal.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH) != -1 and
+        not this->get_kernel_groups(hal.get_programmable_core_type_index(HalProgrammableCoreType::ACTIVE_ETH)).empty());
 }
 
 // TODO: Too low level for program.cpp. Move this to HAL, once we have support.
 bool detail::ProgramImpl::runs_on_noc_multicast_only_cores() {
+    const auto& hal = MetalContext::instance(context_id_).hal();
     return (
-        MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX) != -1 and
-        not this->get_kernel_groups(
-                    MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX))
-                .empty());
+        hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX) != -1 and
+        not this->get_kernel_groups(hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX)).empty());
 }
 
 Program::Program(Program&& other) noexcept = default;

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -20,6 +20,7 @@
 #include "tt-metalium/experimental/tensor/spec/tensor_spec.hpp"  // Metal 2.0 TensorParameter registry
 #include "tt-metalium/experimental/metal2_host_api/tensor_spec_relaxations.hpp"  // Metal 2.0 TensorParameter relaxations
 #include "tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp"
+#include <impl/context/context_types.hpp>
 
 #include <umd/device/types/core_coordinates.hpp>        // CoreType
 #include <umd/device/types/cluster_descriptor_types.hpp>  // ChipId
@@ -72,6 +73,7 @@ void assemble_device_commands(
 
 struct KernelGroup {
     uint32_t programmable_core_type_index{};
+    ContextId context_id_{DEFAULT_CONTEXT_ID};
     CoreRangeSet core_ranges;
     // kernel_ids are ordered by processor index
     std::vector<KernelHandle> kernel_ids;
@@ -181,7 +183,7 @@ public:
 // The internal implementation of the Program class. Program is a view of this class that's usable by API clients.
 class ProgramImpl : public std::enable_shared_from_this<ProgramImpl> {
 public:
-    ProgramImpl();
+    explicit ProgramImpl(ContextId context_id = DEFAULT_CONTEXT_ID);
 
     ProgramImpl(const ProgramImpl& other) = delete;
     ProgramImpl& operator=(const ProgramImpl& other) = delete;
@@ -195,6 +197,8 @@ public:
     using LocalCBMaskType = typename dev_msgs::kernel_config_msg_t::
         FieldTraits<false, dev_msgs::kernel_config_msg_t::Field::local_cb_mask>::element_type;
     static constexpr size_t cb_mask_width_ = sizeof(LocalCBMaskType) * 8;
+
+    ContextId get_context_id() const { return context_id_; }
 
     void set_runtime_id(ProgramId id);
     ProgramId get_runtime_id() const;
@@ -467,6 +471,7 @@ private:
         // Reset when circular buffer allocation is invalidated
         void reset_available_addresses() { this->l1_regions.clear(); }
     };
+    ContextId context_id_{DEFAULT_CONTEXT_ID};
     uint32_t programmable_core_count_;
     uint32_t max_cbs_;  // Architecture-specific max CBs
     uint64_t id;  // Need to make non-const due to move constructor


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
This makes sure that ProgramImpl and downstream consumers can properly track MetalContext to be used if multiple instances exist.

### Notes for reviewers
While many calls to MetalContext::instance() have been changed to pass in the context id explicitly, full removal of the default overload (no context id) will be done in follow-up PRs.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ruizhang/metal_context-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/metal_context-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ruizhang/metal_context-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ruizhang/metal_context-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ruizhang/metal_context-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ruizhang/metal_context-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ruizhang/metal_context-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/metal_context-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ruizhang/metal_context-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ruizhang/metal_context-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ruizhang/metal_context-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/metal_context-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ruizhang/metal_context-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/metal_context-2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ruizhang/metal_context-2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/metal_context-2)