### PR TITLE
#52756: Performance: cut host-side EnqueueMeshWorkload cost on multi-device meshes

### DIFF
--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -15,7 +15,9 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
 #include <array>
+#include <exception>
 #include <functional>
+#include <mutex>
 #include <optional>
 #include <type_traits>
 #include <utility>
@@ -100,6 +102,24 @@ void record_program_sub_device_for_range(
             num_available_worker_cores);
     });
 }
+
+// Per-program state shared by the per-device dispatch tasks targeting that program. A program's
+// cached dispatch commands are common to every device it runs on, so they are updated exactly once
+// per workload: the first task to reach the program takes ownership through `prepared` and the rest
+// block there until the update lands. If the owner throws, the flag stays clear and the next waiter
+// retries, so a waiter can never block forever.
+struct ProgramDispatchEntry {
+    Program* program = nullptr;
+    ProgramCommandSequence* cmd_seq = nullptr;
+    std::once_flag prepared;
+};
+
+// One local device and the program it runs. A MeshWorkload's programs cover disjoint device ranges,
+// so a device appears in at most one of these; devices in none of them are sent a go signal instead.
+struct DeviceDispatchTask {
+    IDevice* device = nullptr;
+    ProgramDispatchEntry* program_entry = nullptr;
+};
 
 [[maybe_unused]] MeshCoordinate get_local_start_coord(MeshDevice* mesh_device, const MeshCoordinateRange& range) {
     for (const auto& coord : range) {
@@ -486,8 +506,6 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
         program_ordering_sync_count,
         dispatch_metadata);
 
-    std::unordered_set<uint32_t> chip_ids_in_workload = {};
-
     auto max_program_kernels_sizeB = mesh_workload.impl().max_program_kernels_sizeB_;
     bool use_prefetcher_cache = mesh_workload.impl().use_prefetcher_cache_;
     if (use_prefetcher_cache) {
@@ -508,40 +526,76 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
         // prefetcher cache will be overwritten, reset for next workload
         this->reset_prefetcher_cache_manager();
     }
-    // Iterate over all programs. Update dispatch commands per program to reflect
-    // current device state. Write the finalized program command sequence to each
-    // physical device tied to the program.
-    for (auto& [device_range, program] : mesh_workload.get_programs()) {
-        auto& program_cmd_seq = mesh_workload.impl().get_dispatch_cmds_for_program(program, command_hash);
+    // Values that are constant across the whole workload, hoisted so that the per-device tasks below
+    // never have to reach back into this command queue or into cq_shared_state_.
+    const CoreCoord dispatch_core = this->virtual_program_dispatch_core();
+    const uint32_t mcast_launch_msg_wptr =
+        cq_shared_state_->worker_launch_message_buffer_state[*sub_device_id].get_mcast_wptr();
+    const uint32_t unicast_launch_msg_wptr =
+        cq_shared_state_->worker_launch_message_buffer_state[*sub_device_id].get_unicast_wptr();
+    const ProgramBinaryStatus program_binary_status = mesh_workload.impl().get_program_binary_status(mesh_device_id);
+    // Same guards record_program_sub_device_for_range() applies, evaluated once: sub_device_id is
+    // fixed for the whole workload, so whether to record and how many worker cores to record are
+    // workload constants rather than per-device queries.
+    const uint64_t active_sub_device_manager_id = *mesh_device_->get_active_sub_device_manager_id();
+    const bool record_sub_device = active_sub_device_manager_id != *mesh_device_->get_default_sub_device_manager_id();
+    const uint32_t num_available_worker_cores =
+        record_sub_device ? mesh_device_->num_worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id) : 0;
+
+    // Update a program's dispatch commands to reflect current device state. This mutates state that
+    // every device running the program shares, so it must happen exactly once per program.
+    auto prepare_program = [&](ProgramDispatchEntry& entry) {
+        std::call_once(entry.prepared, [&]() {
+            program_dispatch::update_program_dispatch_commands(
+                entry.program->impl(),
+                *entry.cmd_seq,
+                mcast_launch_msg_wptr,
+                unicast_launch_msg_wptr,
+                expected_num_workers_completed,
+                dispatch_core,
+                sub_device_id,
+                dispatch_metadata,
+                program_binary_status,
+                std::pair<bool, int>(unicast_go_signals, num_virtual_eth_cores),
+                static_cast<uint8_t>(this->id()));
+        });
+    };
+
+    // Build the work list before dispatching any of it. Everything that can throw runs here, on the
+    // calling thread: once the first task is enqueued the tasks hold references into this frame, so
+    // an exception escaping before the join would leave them pointing at destroyed objects.
+    auto& programs = mesh_workload.get_programs();
+    std::vector<ProgramDispatchEntry> program_entries(programs.size());
+    std::vector<DeviceDispatchTask> program_tasks;
+    program_tasks.reserve(mesh_device_->shape().mesh_size());
+    std::unordered_set<uint32_t> chip_ids_in_workload = {};
+
+    uint32_t program_idx = 0;
+    for (auto& [device_range, program] : programs) {
+        auto& entry = program_entries[program_idx++];
+        entry.program = &program;
+        entry.cmd_seq = &mesh_workload.impl().get_dispatch_cmds_for_program(program, command_hash);
         TT_ASSERT(
-            use_prefetcher_cache == program_cmd_seq.prefetcher_cache_used,
+            use_prefetcher_cache == entry.cmd_seq->prefetcher_cache_used,
             "use_prefetcher_cache: {}, program_cmd_seq.prefetcher_cache_used: {}",
             use_prefetcher_cache,
-            program_cmd_seq.prefetcher_cache_used);
-        program_dispatch::update_program_dispatch_commands(
-            program.impl(),
-            program_cmd_seq,
-            cq_shared_state_->worker_launch_message_buffer_state[*sub_device_id].get_mcast_wptr(),
-            cq_shared_state_->worker_launch_message_buffer_state[*sub_device_id].get_unicast_wptr(),
-            expected_num_workers_completed,
-            this->virtual_program_dispatch_core(),
-            sub_device_id,
-            dispatch_metadata,
-            mesh_workload.impl().get_program_binary_status(mesh_device_id),
-            std::pair<bool, int>(unicast_go_signals, num_virtual_eth_cores),
-            static_cast<uint8_t>(this->id()));
+            entry.cmd_seq->prefetcher_cache_used);
 
-        record_program_sub_device_for_range(mesh_device_, device_range, program.get_runtime_id(), sub_device_id);
-
-        this->write_program_cmds_to_subgrid(
-            device_range,
-            program_cmd_seq,
-            dispatch_metadata.stall_first,
-            dispatch_metadata.stall_before_program,
-            chip_ids_in_workload);
+        const size_t tasks_before_program = program_tasks.size();
+        for_each_local(mesh_device_, device_range, [&](const auto& coord) {
+            auto* device = mesh_device_->impl().get_device(coord);
+            program_tasks.push_back(DeviceDispatchTask{device, &entry});
+            chip_ids_in_workload.insert(device->id());
+        });
+        if (program_tasks.size() == tasks_before_program) {
+            // The program runs entirely on devices owned by another host, so no task will claim it.
+            // Still update its dispatch commands here, to match what a single-host mesh would do.
+            prepare_program(entry);
+        }
 
         // Tag the host-side Tracy zone with the program's runtime_host_id so it pairs 1:1
-        // with the device-side zones emitted by the real-time profiler.
+        // with the device-side zones emitted by the real-time profiler. Emitted from the calling
+        // thread, so that it lands inside this function's zone rather than on a worker's timeline.
         if (!tt::tt_metal::getDeviceProfilerState()) {
             std::string msg = fmt::format("EnqueueProgram op_id={}", program.get_runtime_id());
             TracyMessage(msg.c_str(), msg.size());
@@ -558,14 +612,71 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
         }
     }
 
-    // Send go signals to devices not running a program to ensure consistent global state
-    this->write_go_signal_to_unused_sub_grids(
-        chip_ids_in_workload,
-        sub_device_id,
-        expected_num_workers_completed,
-        mcast_go_signals,
-        unicast_go_signals,
-        dispatch_metadata);
+    auto write_program_for_device = [&](const DeviceDispatchTask& task) {
+        auto& entry = *task.program_entry;
+        prepare_program(entry);
+        if (record_sub_device) {
+            tt::RecordProgramSubDevice(
+                task.device->id(),
+                active_sub_device_manager_id,
+                entry.program->get_runtime_id(),
+                sub_device_id,
+                num_available_worker_cores);
+        }
+        program_dispatch::write_program_command_sequence(
+            *entry.cmd_seq,
+            task.device->sysmem_manager(),
+            id_,
+            dispatch_metadata.stall_first,
+            dispatch_metadata.stall_before_program);
+    };
+
+    // Each device has its own sysmem manager, so the program writes are independent and go out in
+    // parallel on the pool, which has a thread pinned near each device. The pool is quiescent here:
+    // every other user of it joins before releasing the MeshDevice API lock this function holds.
+    //
+    // The calling thread keeps one write for itself rather than handing out all of them. Waking a
+    // worker costs tens of microseconds, so a workload covering a single device would otherwise pay
+    // for the pool without getting any overlap in return.
+    for (size_t i = 1; i < program_tasks.size(); i++) {
+        const auto& task = program_tasks[i];
+        dispatch_thread_pool_->enqueue(
+            [&write_program_for_device, &task]() { write_program_for_device(task); }, task.device->id());
+    }
+    // The work below can throw - a device timeout surfaces as an exception out of the fetch queue -
+    // and the tasks enqueued above hold references into this frame. Join the pool on every path out
+    // of here, including the throwing one, or a worker is left reading destroyed objects. The
+    // original exception wins over anything a worker reports.
+    std::exception_ptr dispatch_exception;
+    try {
+        // A go signal is a few hundred bytes, far less work than waking a worker to hand one over,
+        // so the calling thread issues them itself here, overlapping them with the workers above.
+        this->write_go_signal_to_unused_sub_grids(
+            chip_ids_in_workload,
+            sub_device_id,
+            expected_num_workers_completed,
+            mcast_go_signals,
+            unicast_go_signals,
+            dispatch_metadata);
+        if (!program_tasks.empty()) {
+            write_program_for_device(program_tasks.front());
+        }
+    } catch (...) {
+        dispatch_exception = std::current_exception();
+    }
+    if (program_tasks.size() > 1) {
+        try {
+            dispatch_thread_pool_->wait();
+        } catch (...) {
+            if (!dispatch_exception) {
+                dispatch_exception = std::current_exception();
+            }
+        }
+    }
+    if (dispatch_exception) {
+        std::rethrow_exception(dispatch_exception);
+    }
+
     // Increment Launch Message Buffer Write Pointers
     if (mcast_go_signals) {
         cq_shared_state_->worker_launch_message_buffer_state[*sub_device_id].inc_mcast_wptr(1);
@@ -1198,20 +1309,6 @@ void FDMeshCommandQueue::reset_worker_state(
             this->cq_shared_state_->worker_launch_message_buffer_state.begin() + num_sub_devices,
             std::mem_fn(&LaunchMessageRingBufferState::reset));
     }
-}
-
-void FDMeshCommandQueue::write_program_cmds_to_subgrid(
-    const MeshCoordinateRange& sub_grid,
-    ProgramCommandSequence& program_cmd_seq,
-    bool stall_first,
-    bool stall_before_program,
-    std::unordered_set<uint32_t>& chip_ids_in_workload) {
-    for_each_local(mesh_device_, sub_grid, [&](const auto& coord) {
-        auto device = mesh_device_->impl().get_device(coord);
-        program_dispatch::write_program_command_sequence(
-            program_cmd_seq, device->sysmem_manager(), id_, stall_first, stall_before_program);
-        chip_ids_in_workload.insert(device->id());
-    });
 }
 
 void FDMeshCommandQueue::write_go_signal_to_unused_sub_grids(

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -51,14 +51,6 @@ private:
         ttsl::Span<const SubDeviceId> sub_device_ids,
         bool notify_host,
         const std::optional<MeshCoordinateRange>& device_range = std::nullopt);
-    // Workload dispatch utility functions
-    // Write dispatch commands associated with running a program on a Virtual Mesh subgrid
-    void write_program_cmds_to_subgrid(
-        const MeshCoordinateRange& sub_grid,
-        ProgramCommandSequence& program_cmd_seq,
-        bool stall_first,
-        bool stall_before_program,
-        std::unordered_set<uint32_t>& chip_ids_in_workload);
     // For a given MeshWorkload, a subgrid is unused if no programs are run on it.  Go signals
     // must be sent to this subgrid, to ensure consistent global state across the Virtual Mesh.
     // This function generates and writes dispatch commands forwarding go signals to these subgrids.

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -107,9 +107,15 @@ void MeshWorkloadImpl::compile(MeshDevice* mesh_device) {
     // 1. Compile Kernel Binaries
     // 2. Allocate and Validate CBs
     // 3. Finalize: Compute relative offsets for all data structures in L1
-    if (programs_.size() == 1) {
+    // This runs on every enqueue, not just the first. Once the workload has been finalized its
+    // programs are already compiled and laid out, so compile_program is a flag check per program;
+    // handing those to the thread pool costs a worker wake-up and a join for no work. Only the
+    // first compile of a multi-program workload does enough to be worth parallelizing.
+    if (programs_.size() == 1 || this->is_finalized()) {
         // Compile from main thread for homogeneous workloads
-        this->compile_program(programs_.begin()->first, mesh_device);
+        for (auto& [device_range, _] : programs_) {
+            this->compile_program(device_range, mesh_device);
+        }
     } else {
         for (auto& [device_range, _] : programs_) {
             // Multi-Threaded Compile: Useful for heterogeneous MeshWorkloads

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -1853,6 +1853,7 @@ uint32_t ProgramImpl::add_dataflow_buffer(const CoreRangeSet& core_range_set, co
     }
 
     this->local_dataflow_buffer_allocation_needed_ = true;
+    this->compile_and_allocate_needed_ = true;
 
     return dfb->id;
 }
@@ -2490,6 +2491,7 @@ void ProgramImpl::invalidate_dataflow_buffer_allocation() {
     // Scratchpads stack on the DFB allocators, so a DFB re-layout invalidates their addresses too.
     // Clear the guard unconditionally (even on the early-return path) so allocate_scratchpads re-runs.
     this->scratchpads_allocated_ = false;
+    this->compile_and_allocate_needed_ = true;
     if (this->local_dataflow_buffer_allocation_needed_) {
         return;
     }

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -1221,6 +1221,9 @@ CBHandle detail::ProgramImpl::add_circular_buffer_(const std::shared_ptr<Circula
         this->invalidate_circular_buffer_allocation();
     } else {
         circular_buffer->assign_global_address();
+        // invalidate_circular_buffer_allocation() would have done this; adding a buffer still means
+        // the program has to be laid out again.
+        this->compile_and_allocate_needed_ = true;
     }
 
     // Mark which buffer indices are being used on each core the circular buffer is used on
@@ -1538,6 +1541,8 @@ std::vector<CoreRange> detail::ProgramImpl::circular_buffers_unique_coreranges()
 }
 
 void detail::ProgramImpl::invalidate_circular_buffer_allocation() {
+    // Set unconditionally, before the early return below, so compile_and_allocate re-runs.
+    this->compile_and_allocate_needed_ = true;
     if (this->local_circular_buffer_allocation_needed_) {
         return;
     }
@@ -2660,6 +2665,18 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
 }
 
 void detail::ProgramImpl::compile_and_allocate(IDevice* device, bool force_slow_dispatch) {
+    // The compile and allocation steps below are individually guarded and would early-return:
+    // nothing has changed since this program was compiled and laid out for this device. Skip them
+    // outright, since this is called on every enqueue and the guards alone cost microseconds per
+    // program. The validation steps still have to run: they read live device state - L1 allocations
+    // made since the last enqueue, and service-core claims - so a buffer that has come to overlap
+    // this program's regions is only caught by re-checking them here.
+    if (not this->compile_and_allocate_needed_ and this->compile_and_allocate_device_ == device) {
+        this->validate_circular_buffer_core_ranges(device);
+        this->validate_circular_buffer_region(device);
+        this->validate_dataflow_buffer_region(device);
+        return;
+    }
     this->compile(device, force_slow_dispatch);
     this->allocate_circular_buffers(device);
     this->validate_circular_buffer_core_ranges(device);
@@ -2674,6 +2691,9 @@ void detail::ProgramImpl::compile_and_allocate(IDevice* device, bool force_slow_
     // Metal 2.0 scratchpads stack on the DFB allocations and their locations are passed as implicit CRTAs.
     this->allocate_scratchpads(device);
     this->validate_dataflow_buffer_region(device);
+
+    this->compile_and_allocate_needed_ = false;
+    this->compile_and_allocate_device_ = device;
 }
 
 void detail::ProgramImpl::set_runtime_id(ProgramId id) { this->runtime_id = id; }

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -590,6 +590,14 @@ private:
     bool local_circular_buffer_allocation_needed_{false};
     bool local_dataflow_buffer_allocation_needed_{false};
 
+    // Guards compile_and_allocate, which runs on every enqueue of a program, not just the first.
+    // Once a program has been compiled and laid out for a device, every step inside it is a no-op
+    // until something invalidates the CB or DFB layout, so it can be skipped wholesale. The
+    // invalidate_*_allocation hooks and the CB/DFB creation paths set this back to true. Recorded
+    // per device, since the layout steps also register the program against the device.
+    bool compile_and_allocate_needed_{true};
+    const IDevice* compile_and_allocate_device_{nullptr};
+
     // Scratchpads (Metal 2.0 only)
     // Guards allocate_scratchpads to ensure that it runs once per allocation cycle.
     // Scratchpad allocation occurs once on Program creation, and is re-run if the DFB layout

--- a/tt_metal/impl/threading/thread_pool.cpp
+++ b/tt_metal/impl/threading/thread_pool.cpp
@@ -191,17 +191,15 @@ public:
             std::function<void()> task;  // Task container for this thread
             while (true) {
                 {
-                    // Retry loop with linear backoff:
-                    // - Increment attempts up to BACKOFF_START_ATTEMPT. If a task is seen, exit.
-                    // - If above BACKOFF_START_ATTEMPT, apply a delay that increases with each attempt
-                    // (scaling with BACKOFF_FACTOR_MICROSECONDS and bound by BACKOFF_END_ATTEMPT).
-                    // - The goal is to minimize CPU overhead and thread startup latency
+                    // Spin briefly so back-to-back tasks are picked up without entering the kernel,
+                    // then block until a producer publishes work. Sleeping for a growing interval
+                    // instead costs the producer the remainder of that interval: a thread idle for
+                    // as little as one dispatch's worth of work was already sleeping in 5 us steps,
+                    // which put tens of microseconds between enqueue() and the task starting.
                     uint32_t attempts = 0;
                     while (task_counter_.load(std::memory_order_acquire) == 0) {
-                        attempts = std::min(attempts + 1, BACKOFF_END_ATTEMPT);
-                        if (attempts > BACKOFF_START_ATTEMPT) {
-                            std::this_thread::sleep_for(std::chrono::microseconds(
-                                (attempts - BACKOFF_START_ATTEMPT) * BACKOFF_FACTOR_MICROSECONDS));
+                        if (++attempts > BACKOFF_START_ATTEMPT) {
+                            task_counter_.wait(0, std::memory_order_relaxed);
                         }
                     }
                     if (shutdown_) {
@@ -241,6 +239,7 @@ public:
         this->wait();
         shutdown_ = true;
         task_counter_.fetch_add(1);
+        task_counter_.notify_all();
         worker.join();
     }
 
@@ -248,6 +247,10 @@ public:
         tasks_.push(std::move(f));  // Move the task directly into queue
         // Light-Weight counter increment to track the number of tasks in flight
         task_counter_.fetch_add(1, std::memory_order_relaxed);
+        // Both the worker (waiting for work) and a thread in wait() (waiting for the count to reach
+        // zero) block on this counter, so wake all of them: waking just one could wake the waiter
+        // that has no reason to run yet and leave the worker asleep.
+        task_counter_.notify_all();
     }
 
     std::exception_ptr wait() const {


### PR DESCRIPTION
### PR Category

Performance

### Summary

Dispatching a `MeshWorkload` cost more the more devices it covered, because every per-device step ran serially on the calling thread. On an 8-device Blackhole mesh a workload spanning the whole mesh took 163 µs of host time, and one with a distinct program per device took 265 µs. That cost lands directly in the eager-mode op-to-op gap.

Relates to #52756 (scaling data), which is a sub-issue of #50932 (op2op gap measured at 51.6 % of warm-iteration time for Kimi K2.6 chunked prefill on a 32-chip mesh).

Four changes:

1. **Skip `compile_and_allocate` once a program is laid out.** It runs on every enqueue, not just the first, and after the first every step inside it early-returns anyway. A flag records that the program is laid out for a device; the `invalidate_{circular,dataflow}_buffer_allocation` hooks and the CB/DFB creation paths clear it, so updating a circular buffer or resizing a dataflow buffer between enqueues still re-runs the layout.
2. **Keep `MeshWorkloadImpl::compile` off the thread pool once the workload is finalized.** Before, more than one program always meant a fan-out and a join, even when every `compile_program` call was about to return immediately. Only the first compile of a multi-program workload does enough work to pay for a worker wake-up.
3. **Block the thread-pool workers on the task counter** instead of polling it with a growing sleep. A worker idle for as little as one dispatch's worth of work was already sleeping in 5 µs steps, so a task could sit tens of microseconds before being noticed.
4. **Write each device's program commands from its own pool task** rather than in a loop. Each device has its own sysmem manager, so the writes are independent; a program's shared dispatch commands are updated once, by whichever of its devices claims it first, while the others wait on that.

Measured on an 8× p150b host (2×4 mesh, 200 enqueues per sample, median of 3 runs, p50 of per-call host time):

| workload shape | before | after | |
|---|---|---|---|
| 1 program, full mesh (8 devices) | 163.1 µs | 92.4 µs | −43% |
| 2 programs, full mesh | 197.0 µs | 95.8 µs | −51% |
| 4 programs, full mesh | 244.5 µs | 98.3 µs | −60% |
| 8 programs, one per device | 264.8 µs | 101.2 µs | −62% |
| 1 program, half the mesh (4 devices) | 86.1 µs | 73.9 µs | −14% |
| 1 program, 1 device | 29.7 µs | 28.3 µs | −5% |

No shape regressed. The program-count penalty is essentially gone: before, going from 1 to 8 programs added 102 µs; now it adds 9 µs.

### Notes for reviewers

**Where to focus — change 1 (the layout flag) is the one that can go wrong.** It is only correct if every path that invalidates a program's CB/DFB layout clears the flag. I hooked all four sites that exist today (`invalidate_circular_buffer_allocation`, `invalidate_dataflow_buffer_allocation`, `add_dataflow_buffer`, and the globally-allocated branch of `add_circular_buffer_`), and the flag is also keyed on the device so a program laid out for one device is not skipped for another. A mutator I have not found would silently skip a needed re-layout. `MeshWorkloadTestSuite.MeshWorkloadCBUpdate` and `MeshWorkloadFactoryHWTest.MakeMeshWorkloadFromSpecSupportsDfbResizeBetweenEnqueues` are the tests that guard this, and both pass — but a second pair of eyes on the invalidation set is worth more than the tests here.

**Change 3 touches shared infrastructure.** `NumaAwareExecutor` backs every user of the dispatch and reader thread pools — buffer reads/writes, event records, program compile, the profiler — not just program dispatch. It also changes idle behavior: workers now block in the kernel rather than polling, which I did not measure the CPU-utilization effect of. `notify_all` rather than `notify_one` is deliberate: both the worker (waiting for work) and a thread in `wait()` (waiting for the count to reach zero) block on the same counter, so waking one could wake the wrong one and strand the worker.

**Behavior change worth knowing about:** a program whose range is entirely on another host previously had its dispatch commands updated during the per-program loop. It still does, but now explicitly on the calling thread, since no device task exists to claim it.

**On the remaining cost.** The per-device work that is left is a bandwidth-bound copy of the command stream into each device's hugepage — 443 KB for these benchmark programs, 99.5 % of it runtime args, at ~25 GB/s per core. Parallelism lifts the aggregate to ~41 GB/s and then hits a platform ceiling, so more threads will not help further; sending fewer runtime-arg bytes is the next lever. Note also that the ~19 µs/device figure quoted in #52756 is specific to these deliberately RTA-heavy benchmark programs — the general rule is command-stream bytes ÷ ~25 GB/s, so a smaller op costs proportionally less.

**Testing.** On an 8× p150b host: `unit_tests_api` 1443/1443, and the `MeshWorkload`, `MeshTrace`, `MeshEvents` and `MeshSubDevice` suites in `distributed_unit_tests` 41/41. The benchmark used for the numbers above is not checked in — it is a `MeshDevice2x4Fixture` variant of the existing `MeshDeviceFixture4x8DispatchAgnostic.ParallelizationBenchmark` that times `EnqueueMeshWorkload` calls individually and reports min/p50. Happy to add it if reviewers want it in-tree.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/parallel-mesh-workload-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/parallel-mesh-workload-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/parallel-mesh-workload-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/parallel-mesh-workload-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/parallel-mesh-workload-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/parallel-mesh-workload-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/parallel-mesh-workload-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/parallel-mesh-workload-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/parallel-mesh-workload-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/parallel-mesh-workload-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/parallel-mesh-workload-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/parallel-mesh-workload-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/parallel-mesh-workload-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/parallel-mesh-workload-dispatch)