### PR TITLE
[Bug fix] Reset the shared GO mailboxes from the last CQ, once the others have drained

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_sub_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_sub_device.cpp
@@ -43,6 +43,14 @@ namespace {
 namespace tt::tt_metal {
 using MeshSubDeviceTestSuite = GenericMeshDeviceFixture;
 
+// Two hardware CQs plus a trace region, so a trace replay can be left running on one CQ while the
+// host keeps issuing on the other.
+class MeshSubDeviceMultiCQTraceTestSuite : public MeshDeviceFixtureBase {
+protected:
+    MeshSubDeviceMultiCQTraceTestSuite() :
+        MeshDeviceFixtureBase(Config{.num_cqs = 2, .trace_region_size = (16 << 20)}) {}
+};
+
 TEST_F(MeshSubDeviceTestSuite, SyncWorkloadsOnSubDevice) {
     SubDevice sub_device_1(std::array{CoreRangeSet(CoreRange({0, 0}, {2, 2}))});
     SubDevice sub_device_2(std::array{CoreRangeSet(std::vector{CoreRange({3, 3}, {3, 3}), CoreRange({4, 4}, {4, 4})})});
@@ -214,6 +222,59 @@ TEST_F(MeshSubDeviceTestSuite, SubDeviceSwitching) {
         mesh_device_->reset_sub_device_stall_group();
     }
     Finish(mesh_device_->mesh_command_queue());
+}
+
+// Switching sub device managers resets the worker GO mailboxes and remaps each core's go message index,
+// state that is shared by every hardware CQ. Both managers below cover the same cores in the opposite
+// order, so the switch flips the go message index of every core the trace runs on. A switch that lands
+// while the trace is still replaying on the other CQ leaves those cores polling a mailbox slot the trace
+// never signals: the workers stop launching and the replay never completes. Regressions here hang rather
+// than fail.
+TEST_F(MeshSubDeviceMultiCQTraceTestSuite, SubDeviceSwitchingWhileOtherCQReplaysTrace) {
+    constexpr uint32_t k_local_l1_size = 3200;
+    // Enough device side work that the host reaches the manager switch below mid replay.
+    constexpr uint32_t k_delay_iters = 4000000;
+    constexpr uint32_t k_workloads_in_trace = 8;
+
+    CoreRangeSet cores_0(CoreRange({0, 0}, {1, 1}));
+    CoreRangeSet cores_1(CoreRange({2, 2}, {3, 3}));
+    auto sub_device_manager_0 = mesh_device_->create_sub_device_manager(
+        {SubDevice(std::array{cores_0}), SubDevice(std::array{cores_1})}, k_local_l1_size);
+    auto sub_device_manager_1 = mesh_device_->create_sub_device_manager(
+        {SubDevice(std::array{cores_1}), SubDevice(std::array{cores_0})}, k_local_l1_size);
+    mesh_device_->load_sub_device_manager(sub_device_manager_0);
+
+    Program delay_program = CreateProgram();
+    auto delay_kernel = CreateKernel(
+        delay_program,
+        "tests/tt_metal/tt_metal/test_kernels/misc/sub_device/delay.cpp",
+        cores_0,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+    std::array<uint32_t, 1> delay_rt_args = {k_delay_iters};
+    SetRuntimeArgs(delay_program, delay_kernel, cores_0, delay_rt_args);
+
+    MeshCoordinateRange devices(mesh_device_->shape());
+    auto delay_mesh_workload = MeshWorkload();
+    delay_mesh_workload.add_program(devices, std::move(delay_program));
+
+    // Compile the workload before capturing it.
+    auto& trace_cq = mesh_device_->mesh_command_queue(1);
+    EnqueueMeshWorkload(trace_cq, delay_mesh_workload, true);
+
+    auto trace_id = BeginTraceCapture(mesh_device_.get(), 1);
+    for (uint32_t i = 0; i < k_workloads_in_trace; i++) {
+        EnqueueMeshWorkload(trace_cq, delay_mesh_workload, false);
+    }
+    mesh_device_->end_mesh_trace(1, trace_id);
+
+    mesh_device_->replay_mesh_trace(1, trace_id, false);
+    mesh_device_->load_sub_device_manager(sub_device_manager_1);
+    Finish(mesh_device_->mesh_command_queue(0));
+    Finish(trace_cq);
+
+    // The trace belongs to the manager it was captured under, so switch back to release it.
+    mesh_device_->load_sub_device_manager(sub_device_manager_0);
+    mesh_device_->release_mesh_trace(trace_id);
 }
 
 TEST_F(MeshSubDeviceTestSuite, SubDeviceBasicProgramsReuse) {

--- a/tests/tt_metal/tt_metal/test_kernels/misc/sub_device/delay.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/sub_device/delay.cpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+
+// Spins for the number of iterations given in the first runtime arg, to keep a core busy for a
+// controllable amount of time.
+void kernel_main() {
+    uint32_t num_iterations = get_arg_val<uint32_t>(0);
+
+    for (volatile uint32_t i = 0; i < num_iterations; i++) {
+    }
+}

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -1140,6 +1140,14 @@ void FDMeshCommandQueue::reset_worker_state(
     for (auto* device : mesh_device_->get_devices()) {
         TT_FATAL(!device->sysmem_manager().get_bypass_mode(), "Cannot reset worker state during trace capture");
     }
+    // The launch message ring buffer and the worker GO mailboxes are shared across hardware CQs, and only the
+    // CQ that is passed reset_launch_msg_state resets them. Nothing orders that reset against worker programs
+    // still outstanding on the other CQs, so drain this CQ before the resetting CQ remaps the mailboxes. The
+    // caller holds the MeshDevice api lock, hence the nolock variant. Note that this must happen before
+    // sub_device_cq_owner is resized: finish_nolock indexes it with the currently active sub device ids.
+    if (!reset_launch_msg_state && in_use_) {
+        this->finish_nolock();
+    }
     cq_shared_state_->sub_device_cq_owner.clear();
     cq_shared_state_->sub_device_cq_owner.resize(num_sub_devices);
     in_use_ = true;

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -136,6 +136,11 @@ public:
     // Returns true if the CQ is in use (has had commands enqueued).
     virtual bool in_use() { return false; }
 
+    // Resets this queue's dispatch state. `reset_launch_msg_state` additionally resets state that is shared
+    // by all hardware CQs (the worker launch message ring buffer and the GO mailboxes), so exactly one CQ may
+    // be given it, and only once every other CQ has been drained. The implementation drains the CQs that are
+    // not given it, so callers must reset the CQs in order and pass it to the last one. Must be called with
+    // the MeshDevice api lock held.
     virtual void reset_worker_state(
         bool reset_launch_msg_state,
         uint32_t num_sub_devices,

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1674,10 +1674,17 @@ void MeshDeviceImpl::quiesce_internal() {
             submesh_ptr->quiesce_devices();
         }
     }
-    bool have_reset_launch_msg_state = false;
-    for (auto& command_queue : mesh_command_queues_) {
-        command_queue->wait_for_completion(!have_reset_launch_msg_state);
-        have_reset_launch_msg_state = true;
+    // The launch message ring buffer and the worker GO mailboxes are shared across hardware CQs, so exactly
+    // one CQ resets them. Pick the last CQ that has work outstanding: wait_for_completion finishes each CQ in
+    // turn, so by then no other CQ can still have workers in flight whose GO mailboxes would be reset.
+    size_t launch_msg_reset_cq = mesh_command_queues_.size();
+    for (size_t cq_id = 0; cq_id < mesh_command_queues_.size(); ++cq_id) {
+        if (mesh_command_queues_[cq_id]->in_use()) {
+            launch_msg_reset_cq = cq_id;
+        }
+    }
+    for (size_t cq_id = 0; cq_id < mesh_command_queues_.size(); ++cq_id) {
+        mesh_command_queues_[cq_id]->wait_for_completion(/*reset_launch_msg_state=*/cq_id == launch_msg_reset_cq);
     }
     for (auto& command_queue : mesh_command_queues_) {
         command_queue->finish_and_reset_in_use();

--- a/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
+++ b/tt_metal/impl/sub_device/sub_device_manager_tracker.cpp
@@ -76,11 +76,15 @@ void SubDeviceManagerTracker::reset_sub_device_state(const std::unique_ptr<SubDe
     // Dynamic resolution of device types is unclean and poor design. This will be cleaned up
     // when MeshCommandQueue + HWCommandQueue are unified under the same API
     if (dynamic_cast<distributed::MeshDevice*>(device_)) {
-        // Multi CQ support for MeshDevice is not currently available
         distributed::MeshDevice* mesh_device = dynamic_cast<distributed::MeshDevice*>(device_);
-        for (uint8_t cq_id = 0; cq_id < mesh_device->num_hw_cqs(); ++cq_id) {
+        // The worker launch message ring buffer and the GO mailboxes are shared by every hardware CQ, so
+        // exactly one CQ resets them. That has to be the last CQ: reset_worker_state drains each of the
+        // preceding CQs, so by the time the last one runs, no other CQ can still have workers in flight
+        // whose GO mailboxes would be remapped out from under them.
+        const uint8_t num_hw_cqs = mesh_device->num_hw_cqs();
+        for (uint8_t cq_id = 0; cq_id < num_hw_cqs; ++cq_id) {
             mesh_device->impl().mesh_command_queue_base(cq_id).reset_worker_state(
-                cq_id == 0,
+                /*reset_launch_msg_state=*/cq_id + 1 == num_hw_cqs,
                 num_sub_devices,
                 sub_device_manager->noc_mcast_unicast_data(),
                 sub_device_manager->get_core_go_message_mapping(),


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #52768.

Switching or clearing a sub-device manager resets state that every hardware CQ shares: the worker launch message ring buffer, the workers' `launch_msg_rd_ptr`, and each core's go message index. Only one CQ performs that reset, and it was CQ 0. Nothing ordered CQ 0's reset against worker programs outstanding on CQ 1, so the `RUN_MSG_RESET_READ_PTR` handshake and `set_core_go_message_mapping_on_device` could land while CQ 1's workers were still running — the comment in `set_core_go_message_mapping_on_device` saying "All cores should already be idle at this point" was exactly the broken invariant. Remapping a core's go message index mid flight leaves it polling a mailbox slot its dispatcher never signals, which hangs.

`reset_sub_device_state` now performs the shared reset on the last CQ, and `FDMeshCommandQueue::reset_worker_state` drains every CQ that is not performing it. `MeshDeviceImpl::quiesce_internal` had the same first-CQ-wins pattern and now picks the last CQ with work outstanding.

The new test captures a trace on CQ 1 and switches sub-device managers mid replay. Its two managers cover the same cores in the opposite order, so the switch flips the go message index of every core the trace runs on.

Verified on a single p150 (Blackhole):

| build | result |
| --- | --- |
| without the fix | hangs — killed by `timeout 120`, exit 124 |
| with the fix | passes; 3 consecutive repeats of the whole `MeshSubDevice*` suite green |

Also green with the fix: `unit_tests_dispatch --gtest_filter='*SubDevice*'` (16 passed / 3 skipped), distributed `MeshSubDevice*:MeshEvents*:MeshTrace*:MeshWorkload*` (22 passed / 24 skipped, multi-device shapes unavailable on this host), and `unit_tests_ttnn --gtest_filter='*Generic*'` (15 passed / 2 skipped) for the `quiesce_devices` path.

### Notes for reviewers
- **Swapping to the last CQ alone would only mirror the race onto CQ 0** — the drain is what establishes the ordering. Please review that pairing rather than the CQ index change on its own.
- The drain must run *before* `sub_device_cq_owner` is resized: `finish_nolock` indexes that vector with the currently active sub-device ids, which can outnumber the incoming manager's.
- The drain is a host block, gated on `in_use_` and only reachable with more than one hardware CQ. Cost is not measurable in the microbenchmark (1366 ms vs 1383 ms standalone), but it does make `load_sub_device_manager` synchronous with respect to the non-final CQs. A device-side event handshake would avoid the host block; it needs `enqueue_record_event`/`enqueue_wait_for_event` variants that don't re-take the MeshDevice api lock, which seemed like more surgery than this fix warrants.
- `quiesce_internal` gates on `in_use()` because `wait_for_completion` is a no-op on an unused CQ — a blindly-last CQ would skip the reset entirely. Single-CQ behaviour is unchanged in both paths.
- Regressions in the new test manifest as a **hang**, not a gtest failure. The test comment says so.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/subdevice-multi-cq-go-message-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/subdevice-multi-cq-go-message-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/subdevice-multi-cq-go-message-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/subdevice-multi-cq-go-message-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbauman/subdevice-multi-cq-go-message-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbauman/subdevice-multi-cq-go-message-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/subdevice-multi-cq-go-message-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/subdevice-multi-cq-go-message-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/subdevice-multi-cq-go-message-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/subdevice-multi-cq-go-message-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/subdevice-multi-cq-go-message-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/subdevice-multi-cq-go-message-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/subdevice-multi-cq-go-message-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/subdevice-multi-cq-go-message-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/subdevice-multi-cq-go-message-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/subdevice-multi-cq-go-message-reset)