### PR TITLE
[KDA 0/8] Add KDA reference semantics and test utilities

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -454,6 +454,7 @@ tests/ttnn/unit_tests/operations/sdpa/ @tenstorrent/metalium-developers-sdpa @te
 tests/ttnn/nightly/unit_tests/operations/sdpa/ @tenstorrent/metalium-developers-sdpa @tenstorrent/codeowner-bypass
 tests/ttnn/nightly/unit_tests/operations/experimental/quasar/ @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/ @tenstorrent/metalium-developers-ds-prefill @tenstorrent/codeowner-bypass
+tests/ttnn/unit_tests/operations/experimental/kda/ @tenstorrent/metalium-developers-sdpa @tenstorrent/codeowner-bypass
 tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py @tenstorrent/metalium-developers-sdpa @tenstorrent/codeowner-bypass
 tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py @tenstorrent/metalium-developers-sdpa @tenstorrent/codeowner-bypass
 tests/ttnn/nightly/unit_tests/operations/experimental/test_rgb_to_yuv.py @cglagovichTT @jonathansuTT @tenstorrent/codeowner-bypass

--- a/models/demos/deepseek_v3_d_p/reference/kda/README.md
+++ b/models/demos/deepseek_v3_d_p/reference/kda/README.md
@@ -1,0 +1,28 @@
+# Kimi Delta Attention reference
+
+This package is the device-independent semantic oracle for Kimi Delta
+Attention (KDA). It depends only on PyTorch and does not import TTNN, model
+device code, mesh fixtures, checkpoints, or profilers.
+
+## Provenance and formula correspondence
+
+The formulas were transcribed from the `moonshotai/Kimi-K3` Hugging Face model
+configuration and the Flash Linear Attention KDA/Gated DeltaNet formulation as
+captured by tt-metal PR #51910 at prototype source revision
+`ac9ebafccd9eeb1492451ee6265a9d927429834c`.
+
+| Reference function | Semantic responsibility |
+|---|---|
+| `causal_depthwise_conv_reference` | Four-tap causal depthwise convolution, caller-owned three-token history, then SiLU |
+| `kda_gate_reference` | Per-key negative log decay, including Kimi-K3's optional bounded sigmoid form |
+| `l2_norm_reference` | FLA query/key L2 normalization with epsilon `1e-6` |
+| `kda_recurrent_reference` | Token-ordered normalized delta-rule recurrence and replacement final state |
+| `sigmoid_gated_rms_norm_reference` | RMS normalization followed by sigmoid output gating |
+| `kda_forward_reference` | Stateless full-layer composition and replacement logical state |
+
+Supported configurations require a four-tap convolution, positive dimensions
+and RMS epsilon, equal per-head query/key dimensions, and an optional gate
+lower bound in `[-5, 0)`. Reference arithmetic is accumulated in FP32.
+Operation tests choose and record their own PCC threshold; full-layer reference
+tests use `0.99999`, while exact state/metadata and determinism checks use
+value or bit identity.

--- a/models/demos/deepseek_v3_d_p/reference/kda/__init__.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 """Supported pure-Torch reference API for Kimi Delta Attention."""
 

--- a/models/demos/deepseek_v3_d_p/reference/kda/__init__.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Supported pure-Torch reference API for Kimi Delta Attention."""
+
+from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+from models.demos.deepseek_v3_d_p.reference.kda.layer import KDAReferenceState, kda_forward_reference
+
+__all__ = ["KDAConfig", "KDAReferenceState", "kda_forward_reference"]

--- a/models/demos/deepseek_v3_d_p/reference/kda/config.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/config.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 """Immutable, device-independent configuration for Kimi Delta Attention."""
 

--- a/models/demos/deepseek_v3_d_p/reference/kda/config.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/config.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Immutable, device-independent configuration for Kimi Delta Attention."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class KDAConfig:
+    """Dimensions and numerical policy for one KDA layer."""
+
+    hidden_size: int
+    num_heads: int
+    head_k_dim: int
+    head_v_dim: int
+    conv_kernel_size: int
+    norm_eps: float
+    use_full_rank_gate: bool = False
+    gate_lower_bound: float | None = None
+
+    def __post_init__(self) -> None:
+        positive = {
+            "hidden_size": self.hidden_size,
+            "num_heads": self.num_heads,
+            "head_k_dim": self.head_k_dim,
+            "head_v_dim": self.head_v_dim,
+            "conv_kernel_size": self.conv_kernel_size,
+        }
+        for name, value in positive.items():
+            if value <= 0:
+                raise ValueError(f"{name} must be positive, got {value}")
+        if self.conv_kernel_size != 4:
+            raise ValueError(f"KDA currently requires conv_kernel_size=4, got {self.conv_kernel_size}")
+        if self.norm_eps <= 0:
+            raise ValueError(f"norm_eps must be positive, got {self.norm_eps}")
+        if self.gate_lower_bound is not None and not -5.0 <= self.gate_lower_bound < 0.0:
+            raise ValueError(f"gate_lower_bound must be in [-5, 0), got {self.gate_lower_bound}")
+
+    @property
+    def q_dim(self) -> int:
+        return self.num_heads * self.head_k_dim
+
+    @property
+    def k_dim(self) -> int:
+        return self.num_heads * self.head_k_dim
+
+    @property
+    def v_dim(self) -> int:
+        return self.num_heads * self.head_v_dim
+
+    @classmethod
+    def from_model_config(cls, model_config: Mapping[str, Any]) -> "KDAConfig":
+        """Build from a Kimi Linear Hugging Face configuration mapping."""
+        try:
+            if "text_config" in model_config:
+                model_config = model_config["text_config"]
+                if not isinstance(model_config, Mapping):
+                    raise TypeError("text_config must be a mapping")
+            linear = model_config["linear_attn_config"]
+            if not isinstance(linear, Mapping):
+                raise TypeError("linear_attn_config must be a mapping")
+            head_dim = int(linear["head_dim"])
+            return cls(
+                hidden_size=int(model_config["hidden_size"]),
+                num_heads=int(linear["num_heads"]),
+                head_k_dim=head_dim,
+                head_v_dim=head_dim,
+                conv_kernel_size=int(linear["short_conv_kernel_size"]),
+                norm_eps=float(model_config["rms_norm_eps"]),
+                use_full_rank_gate=bool(linear.get("use_full_rank_gate", False)),
+                gate_lower_bound=(
+                    float(linear["gate_lower_bound"]) if linear.get("gate_lower_bound") is not None else None
+                ),
+            )
+        except KeyError as error:
+            raise ValueError(f"missing Kimi config field: {error.args[0]}") from error

--- a/models/demos/deepseek_v3_d_p/reference/kda/config.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/config.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
@@ -35,8 +36,8 @@ class KDAConfig:
                 raise ValueError(f"{name} must be positive, got {value}")
         if self.conv_kernel_size != 4:
             raise ValueError(f"KDA currently requires conv_kernel_size=4, got {self.conv_kernel_size}")
-        if self.norm_eps <= 0:
-            raise ValueError(f"norm_eps must be positive, got {self.norm_eps}")
+        if not math.isfinite(self.norm_eps) or self.norm_eps <= 0:
+            raise ValueError(f"norm_eps must be finite and positive, got {self.norm_eps}")
         if self.gate_lower_bound is not None and not -5.0 <= self.gate_lower_bound < 0.0:
             raise ValueError(f"gate_lower_bound must be in [-5, 0), got {self.gate_lower_bound}")
 

--- a/models/demos/deepseek_v3_d_p/reference/kda/layer.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/layer.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Stateless full-layer reference transition for Kimi Delta Attention."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+
+from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+from models.demos.deepseek_v3_d_p.reference.kda.ops import (
+    causal_depthwise_conv_reference,
+    kda_gate_reference,
+    kda_recurrent_reference,
+    sigmoid_gated_rms_norm_reference,
+)
+from models.demos.deepseek_v3_d_p.reference.kda.weights import validate_kda_weights
+
+
+@dataclass(frozen=True)
+class KDAReferenceState:
+    """Caller-owned reference state; convolution histories exclude the current token."""
+
+    recurrent: torch.Tensor
+    q_convolution: torch.Tensor
+    k_convolution: torch.Tensor
+    v_convolution: torch.Tensor
+
+
+def _initial_state(inputs: torch.Tensor, config: KDAConfig) -> KDAReferenceState:
+    batch = inputs.shape[0]
+    history = config.conv_kernel_size - 1
+    return KDAReferenceState(
+        recurrent=inputs.new_zeros(batch, config.num_heads, config.head_k_dim, config.head_v_dim),
+        q_convolution=inputs.new_zeros(batch, history, config.q_dim),
+        k_convolution=inputs.new_zeros(batch, history, config.k_dim),
+        v_convolution=inputs.new_zeros(batch, history, config.v_dim),
+    )
+
+
+def kda_forward_reference(
+    hidden_states: torch.Tensor,
+    weights: Mapping[str, torch.Tensor],
+    config: KDAConfig,
+    state: KDAReferenceState | None = None,
+) -> tuple[torch.Tensor, KDAReferenceState]:
+    """Execute the complete Kimi Delta Attention layer in pure Torch."""
+    if hidden_states.ndim != 3 or hidden_states.shape[-1] != config.hidden_size:
+        raise ValueError(f"hidden_states shape {tuple(hidden_states.shape)} must be [B,T,{config.hidden_size}]")
+    validate_kda_weights(weights, config)
+    state = _initial_state(hidden_states, config) if state is None else state
+    hidden = hidden_states.float()
+
+    q, q_state = causal_depthwise_conv_reference(
+        F.linear(hidden, weights["q_proj.weight"].float()), weights["q_conv1d.weight"], state.q_convolution
+    )
+    k, k_state = causal_depthwise_conv_reference(
+        F.linear(hidden, weights["k_proj.weight"].float()), weights["k_conv1d.weight"], state.k_convolution
+    )
+    v, v_state = causal_depthwise_conv_reference(
+        F.linear(hidden, weights["v_proj.weight"].float()), weights["v_conv1d.weight"], state.v_convolution
+    )
+
+    batch, sequence, _ = hidden.shape
+    q = q.reshape(batch, sequence, config.num_heads, config.head_k_dim)
+    k = k.reshape(batch, sequence, config.num_heads, config.head_k_dim)
+    v = v.reshape(batch, sequence, config.num_heads, config.head_v_dim)
+    raw_gate = F.linear(
+        F.linear(hidden, weights["f_a_proj.weight"].float()), weights["f_b_proj.weight"].float()
+    ).reshape(batch, sequence, config.num_heads, config.head_k_dim)
+    gate = kda_gate_reference(raw_gate, weights["A_log"], weights["dt_bias"], config.gate_lower_bound)
+    beta = torch.sigmoid(F.linear(hidden, weights["b_proj.weight"].float()))
+    output, recurrent = kda_recurrent_reference(q, k, v, gate, beta, state.recurrent)
+
+    if config.use_full_rank_gate:
+        output_gate = F.linear(hidden, weights["g_proj.weight"].float())
+    else:
+        output_gate = F.linear(F.linear(hidden, weights["g_a_proj.weight"].float()), weights["g_b_proj.weight"].float())
+    output_gate = output_gate.reshape(batch, sequence, config.num_heads, config.head_v_dim)
+    output = sigmoid_gated_rms_norm_reference(output, output_gate, weights["o_norm.weight"], config.norm_eps).reshape(
+        batch, sequence, config.v_dim
+    )
+    output = F.linear(output, weights["o_proj.weight"].float())
+
+    return output, KDAReferenceState(recurrent, q_state, k_state, v_state)

--- a/models/demos/deepseek_v3_d_p/reference/kda/layer.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/layer.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 """Stateless full-layer reference transition for Kimi Delta Attention."""
 

--- a/models/demos/deepseek_v3_d_p/reference/kda/ops.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/ops.py
@@ -28,7 +28,7 @@ def causal_depthwise_conv_reference(
 
     window = torch.cat((history.float(), inputs.float()), dim=1)
     output = F.conv1d(window.transpose(1, 2), weight.float(), groups=channels).transpose(1, 2)
-    final_state = window[:, -(kernel - 1) :] if kernel > 1 else window[:, :0]
+    final_state = (window[:, -(kernel - 1) :] if kernel > 1 else window[:, :0]).clone()
     return F.silu(output), final_state
 
 

--- a/models/demos/deepseek_v3_d_p/reference/kda/ops.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/ops.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 """Pure operation oracles for Kimi Delta Attention."""
 

--- a/models/demos/deepseek_v3_d_p/reference/kda/ops.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/ops.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Pure operation oracles for Kimi Delta Attention."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+
+def causal_depthwise_conv_reference(
+    inputs: torch.Tensor,
+    weight: torch.Tensor,
+    initial_state: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply causal depthwise convolution and SiLU with ``[B,W-1,D]`` history."""
+    batch, _, channels = inputs.shape
+    if weight.ndim != 3 or tuple(weight.shape[:2]) != (channels, 1):
+        raise ValueError(f"convolution weight shape {tuple(weight.shape)} incompatible with D={channels}")
+    kernel = weight.shape[-1]
+    state_shape = (batch, kernel - 1, channels)
+    if initial_state is None:
+        history = inputs.new_zeros(state_shape)
+    elif tuple(initial_state.shape) != state_shape:
+        raise ValueError(f"convolution state shape {tuple(initial_state.shape)} != {state_shape}")
+    else:
+        history = initial_state
+
+    window = torch.cat((history.float(), inputs.float()), dim=1)
+    output = F.conv1d(window.transpose(1, 2), weight.float(), groups=channels).transpose(1, 2)
+    final_state = window[:, -(kernel - 1) :] if kernel > 1 else window[:, :0]
+    return F.silu(output), final_state
+
+
+def kda_gate_reference(
+    raw_gate: torch.Tensor,
+    a_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    lower_bound: float | None = None,
+) -> torch.Tensor:
+    """Convert raw gate logits to negative per-key log decay."""
+    heads, key_dim = raw_gate.shape[-2:]
+    if a_log.numel() != heads:
+        raise ValueError(f"A_log has {a_log.numel()} values, expected {heads}")
+    if dt_bias.numel() != heads * key_dim:
+        raise ValueError(f"dt_bias has {dt_bias.numel()} values, expected {heads * key_dim}")
+    scale = a_log.float().reshape(1, 1, heads, 1).exp()
+    bias = dt_bias.float().reshape(1, 1, heads, key_dim)
+    gate_input = raw_gate.float() + bias
+    if lower_bound is not None:
+        return lower_bound * torch.sigmoid(scale * gate_input)
+    return -scale * F.softplus(gate_input)
+
+
+def l2_norm_reference(inputs: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+    """Match FLA's ``x / sqrt(sum(x²) + eps)`` normalization."""
+    inputs = inputs.float()
+    return inputs * torch.rsqrt(inputs.square().sum(dim=-1, keepdim=True) + eps)
+
+
+def kda_recurrent_reference(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    gate: torch.Tensor,
+    beta: torch.Tensor,
+    initial_state: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Execute the token-ordered KDA recurrence in ``[B,T,H,D]`` layout."""
+    batch, sequence, heads, key_dim = q.shape
+    value_dim = v.shape[-1]
+    expected = {
+        "k": (batch, sequence, heads, key_dim),
+        "v": (batch, sequence, heads, value_dim),
+        "gate": (batch, sequence, heads, key_dim),
+        "beta": (batch, sequence, heads),
+    }
+    tensors = {"k": k, "v": v, "gate": gate, "beta": beta}
+    for name, shape in expected.items():
+        if tuple(tensors[name].shape) != shape:
+            raise ValueError(f"{name} shape {tuple(tensors[name].shape)} != {shape}")
+
+    state_shape = (batch, heads, key_dim, value_dim)
+    if initial_state is None:
+        state = torch.zeros(state_shape, device=q.device, dtype=torch.float32)
+    elif tuple(initial_state.shape) != state_shape:
+        raise ValueError(f"recurrent state shape {tuple(initial_state.shape)} != {state_shape}")
+    else:
+        state = initial_state.float().clone()
+
+    q = l2_norm_reference(q) * (key_dim**-0.5)
+    k = l2_norm_reference(k)
+    v, gate, beta = v.float(), gate.float(), beta.float()
+    output = torch.empty(batch, sequence, heads, value_dim, device=q.device, dtype=torch.float32)
+
+    for token in range(sequence):
+        q_t, k_t, v_t = q[:, token], k[:, token], v[:, token]
+        state = state * gate[:, token].exp().unsqueeze(-1)
+        residual = v_t - (k_t.unsqueeze(-1) * state).sum(dim=-2)
+        state = state + k_t.unsqueeze(-1) * (beta[:, token].unsqueeze(-1) * residual).unsqueeze(-2)
+        output[:, token] = torch.einsum("bhk,bhkv->bhv", q_t, state)
+
+    return output, state
+
+
+def sigmoid_gated_rms_norm_reference(
+    inputs: torch.Tensor,
+    gate: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """Apply RMSNorm followed by sigmoid output gating, per Kimi/FLA."""
+    inputs = inputs.float()
+    normalized = inputs * torch.rsqrt(inputs.square().mean(dim=-1, keepdim=True) + eps)
+    return normalized * weight.float() * torch.sigmoid(gate.float())

--- a/models/demos/deepseek_v3_d_p/reference/kda/tests/helpers.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/tests/helpers.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Small deterministic fixtures for CPU-only KDA reference tests."""
+
+import torch
+
+from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+
+
+def make_config(*, use_full_rank_gate: bool = False) -> KDAConfig:
+    return KDAConfig(
+        hidden_size=64,
+        num_heads=2,
+        head_k_dim=32,
+        head_v_dim=32,
+        conv_kernel_size=4,
+        norm_eps=1e-5,
+        use_full_rank_gate=use_full_rank_gate,
+    )
+
+
+def random_weights(config: KDAConfig) -> dict[str, torch.Tensor]:
+    generator = torch.Generator().manual_seed(20260723)
+
+    def normal(*shape: int, scale: float = 0.05) -> torch.Tensor:
+        return scale * torch.randn(*shape, generator=generator)
+
+    hidden = config.hidden_size
+    key_rank, value_rank = config.head_k_dim, config.head_v_dim
+    weights = {
+        "q_proj.weight": normal(config.q_dim, hidden),
+        "k_proj.weight": normal(config.k_dim, hidden),
+        "v_proj.weight": normal(config.v_dim, hidden),
+        "q_conv1d.weight": normal(config.q_dim, 1, config.conv_kernel_size, scale=0.2),
+        "k_conv1d.weight": normal(config.k_dim, 1, config.conv_kernel_size, scale=0.2),
+        "v_conv1d.weight": normal(config.v_dim, 1, config.conv_kernel_size, scale=0.2),
+        "A_log": torch.log(torch.linspace(1.0, 4.0, config.num_heads)).reshape(1, 1, config.num_heads, 1),
+        "f_a_proj.weight": normal(key_rank, hidden),
+        "f_b_proj.weight": normal(config.num_heads * key_rank, key_rank),
+        "dt_bias": normal(config.num_heads * key_rank),
+        "b_proj.weight": normal(config.num_heads, hidden),
+        "o_norm.weight": 1.0 + normal(value_rank),
+        "o_proj.weight": normal(hidden, config.num_heads * value_rank),
+    }
+    if config.use_full_rank_gate:
+        weights["g_proj.weight"] = normal(config.v_dim, hidden)
+    else:
+        weights["g_a_proj.weight"] = normal(value_rank, hidden)
+        weights["g_b_proj.weight"] = normal(config.num_heads * value_rank, value_rank)
+    return weights

--- a/models/demos/deepseek_v3_d_p/reference/kda/tests/helpers.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/tests/helpers.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 """Small deterministic fixtures for CPU-only KDA reference tests."""
 

--- a/models/demos/deepseek_v3_d_p/reference/kda/tests/test_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/tests/test_config.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 """CPU tests for KDA semantic configuration."""
 

--- a/models/demos/deepseek_v3_d_p/reference/kda/tests/test_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/tests/test_config.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""CPU tests for KDA semantic configuration."""
+
+import pytest
+
+from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+from models.demos.deepseek_v3_d_p.reference.kda.tests.helpers import make_config
+
+
+def test_model_config_mapping() -> None:
+    config = KDAConfig.from_model_config(
+        {
+            "hidden_size": 2304,
+            "rms_norm_eps": 1e-5,
+            "linear_attn_config": {
+                "head_dim": 128,
+                "num_heads": 32,
+                "short_conv_kernel_size": 4,
+                "use_full_rank_gate": True,
+                "gate_lower_bound": -5.0,
+            },
+        }
+    )
+    assert (config.q_dim, config.k_dim, config.v_dim) == (4096, 4096, 4096)
+    assert config.use_full_rank_gate
+    assert config.gate_lower_bound == -5.0
+
+
+def test_nested_text_config_mapping() -> None:
+    base = make_config()
+    mapped = KDAConfig.from_model_config(
+        {
+            "text_config": {
+                "hidden_size": base.hidden_size,
+                "rms_norm_eps": base.norm_eps,
+                "linear_attn_config": {
+                    "head_dim": base.head_k_dim,
+                    "num_heads": base.num_heads,
+                    "short_conv_kernel_size": base.conv_kernel_size,
+                },
+            }
+        }
+    )
+    assert mapped == base
+
+
+@pytest.mark.parametrize("field", ["hidden_size", "num_heads", "head_k_dim", "head_v_dim"])
+def test_config_rejects_nonpositive_dimensions(field: str, expect_error) -> None:
+    values = make_config().__dict__.copy()
+    values[field] = 0
+    with expect_error(ValueError, field):
+        KDAConfig(**values)
+
+
+def test_config_rejects_invalid_numerical_policy(expect_error) -> None:
+    values = make_config().__dict__.copy()
+    with expect_error(ValueError, "conv_kernel_size=4"):
+        KDAConfig(**(values | {"conv_kernel_size": 3}))
+    with expect_error(ValueError, "norm_eps"):
+        KDAConfig(**(values | {"norm_eps": 0.0}))
+    with expect_error(ValueError, "gate_lower_bound"):
+        KDAConfig(**(values | {"gate_lower_bound": 0.0}))
+
+
+def test_config_module_does_not_import_ttnn() -> None:
+    import models.demos.deepseek_v3_d_p.reference.kda.config as config_module
+
+    assert "ttnn" not in config_module.__dict__

--- a/models/demos/deepseek_v3_d_p/reference/kda/tests/test_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/tests/test_config.py
@@ -59,6 +59,9 @@ def test_config_rejects_invalid_numerical_policy(expect_error) -> None:
         KDAConfig(**(values | {"conv_kernel_size": 3}))
     with expect_error(ValueError, "norm_eps"):
         KDAConfig(**(values | {"norm_eps": 0.0}))
+    for norm_eps in (float("nan"), float("inf")):
+        with expect_error(ValueError, "norm_eps"):
+            KDAConfig(**(values | {"norm_eps": norm_eps}))
     with expect_error(ValueError, "gate_lower_bound"):
         KDAConfig(**(values | {"gate_lower_bound": 0.0}))
 

--- a/models/demos/deepseek_v3_d_p/reference/kda/tests/test_layer.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/tests/test_layer.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the stateless full-layer KDA reference transition."""
 

--- a/models/demos/deepseek_v3_d_p/reference/kda/tests/test_layer.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/tests/test_layer.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the stateless full-layer KDA reference transition."""
+
+import pytest
+import torch
+
+from models.demos.deepseek_v3_d_p.reference.kda import kda_forward_reference
+from models.demos.deepseek_v3_d_p.reference.kda.tests.helpers import make_config, random_weights
+from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import (
+    assert_accurate,
+    assert_bit_identical,
+    assert_equal,
+)
+
+
+@pytest.mark.parametrize("use_full_rank_gate", [False, True])
+def test_split_forward_matches_full_forward_without_mutating_input_state(use_full_rank_gate: bool) -> None:
+    config = make_config(use_full_rank_gate=use_full_rank_gate)
+    weights = random_weights(config)
+    hidden_states = torch.randn(1, 7, config.hidden_size, generator=torch.Generator().manual_seed(31))
+
+    full_output, full_state = kda_forward_reference(hidden_states, weights, config)
+    first_output, first_state = kda_forward_reference(hidden_states[:, :5], weights, config)
+    input_state_snapshot = tuple(tensor.clone() for tensor in first_state.__dict__.values())
+    last_output, split_state = kda_forward_reference(hidden_states[:, 5:], weights, config, first_state)
+
+    assert_accurate(
+        full_output,
+        torch.cat((first_output, last_output), dim=1),
+        name="split layer output",
+        pcc_threshold=0.99999,
+    )
+    for index, (full_tensor, split_tensor) in enumerate(
+        zip(full_state.__dict__.values(), split_state.__dict__.values())
+    ):
+        assert_accurate(full_tensor, split_tensor, name=f"split layer state {index}", pcc_threshold=0.99999)
+    for input_tensor, snapshot in zip(first_state.__dict__.values(), input_state_snapshot):
+        assert_equal(snapshot, input_tensor, name="reference input state unchanged")
+
+
+def test_reference_layer_is_bit_identical() -> None:
+    config = make_config()
+    weights = random_weights(config)
+    hidden_states = torch.randn(1, 32, config.hidden_size, generator=torch.Generator().manual_seed(3031))
+    expected_output, expected_state = kda_forward_reference(hidden_states, weights, config)
+    for iteration in range(2):
+        actual_output, actual_state = kda_forward_reference(hidden_states, weights, config)
+        assert_bit_identical(expected_output, actual_output, name=f"output iteration {iteration}")
+        for field in expected_state.__dataclass_fields__:
+            assert_bit_identical(
+                getattr(expected_state, field),
+                getattr(actual_state, field),
+                name=f"{field} iteration {iteration}",
+            )
+
+
+def test_reference_rejects_missing_or_mismatched_weights(expect_error) -> None:
+    config = make_config()
+    hidden_states = torch.zeros(1, 1, config.hidden_size)
+    weights = random_weights(config)
+    del weights["q_proj.weight"]
+    with expect_error(ValueError, "missing KDA weight: q_proj.weight"):
+        kda_forward_reference(hidden_states, weights, config)
+
+    weights = random_weights(config)
+    weights["q_proj.weight"] = weights["q_proj.weight"][:-1]
+    with expect_error(ValueError, "q_proj.weight shape"):
+        kda_forward_reference(hidden_states, weights, config)

--- a/models/demos/deepseek_v3_d_p/reference/kda/tests/test_ops.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/tests/test_ops.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 """CPU tests for the independent KDA operation semantics."""
 

--- a/models/demos/deepseek_v3_d_p/reference/kda/tests/test_ops.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/tests/test_ops.py
@@ -30,6 +30,13 @@ def test_causal_convolution_split_equivalence() -> None:
     assert_equal(full_state, split_state, name="split convolution state")
 
 
+def test_causal_convolution_state_has_compact_storage() -> None:
+    inputs = torch.randn(2, 64, 32)
+    weight = torch.randn(32, 1, 4)
+    _, state = causal_depthwise_conv_reference(inputs, weight)
+    assert state.untyped_storage().nbytes() == state.numel() * state.element_size()
+
+
 def test_gate_formulas() -> None:
     raw = torch.tensor([[[[-2.0, 0.5], [1.0, 3.0]]]])
     a_log = torch.log(torch.tensor([[[[2.0], [4.0]]]]))

--- a/models/demos/deepseek_v3_d_p/reference/kda/tests/test_ops.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/tests/test_ops.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""CPU tests for the independent KDA operation semantics."""
+
+import torch
+import torch.nn.functional as F
+
+from models.demos.deepseek_v3_d_p.reference.kda.ops import (
+    causal_depthwise_conv_reference,
+    kda_gate_reference,
+    kda_recurrent_reference,
+    sigmoid_gated_rms_norm_reference,
+)
+from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import assert_accurate, assert_equal
+
+
+def test_causal_convolution_split_equivalence() -> None:
+    generator = torch.Generator().manual_seed(11)
+    inputs = torch.randn(2, 7, 32, generator=generator)
+    weight = torch.randn(32, 1, 4, generator=generator)
+    full_output, full_state = causal_depthwise_conv_reference(inputs, weight)
+    first_output, first_state = causal_depthwise_conv_reference(inputs[:, :5], weight)
+    last_output, split_state = causal_depthwise_conv_reference(inputs[:, 5:], weight, first_state)
+    assert_accurate(
+        full_output,
+        torch.cat((first_output, last_output), dim=1),
+        name="split convolution output",
+        pcc_threshold=0.999999,
+    )
+    assert_equal(full_state, split_state, name="split convolution state")
+
+
+def test_gate_formulas() -> None:
+    raw = torch.tensor([[[[-2.0, 0.5], [1.0, 3.0]]]])
+    a_log = torch.log(torch.tensor([[[[2.0], [4.0]]]]))
+    bias = torch.tensor([0.1, -0.2, 0.3, -0.4])
+    assert_equal(-a_log.exp() * F.softplus(raw + bias.reshape(1, 1, 2, 2)), kda_gate_reference(raw, a_log, bias))
+    bounded = kda_gate_reference(raw, a_log, bias, lower_bound=-5.0)
+    assert_equal(-5.0 * torch.sigmoid(a_log.exp() * (raw + bias.reshape(1, 1, 2, 2))), bounded)
+    assert bool(((-5.0 <= bounded) & (bounded <= 0.0)).all())
+
+
+def test_vector_decay_reduces_to_scalar_recurrence() -> None:
+    generator = torch.Generator().manual_seed(23)
+    q = torch.randn(1, 4, 2, 32, generator=generator)
+    k = torch.randn(1, 4, 2, 32, generator=generator)
+    v = torch.randn(1, 4, 2, 32, generator=generator)
+    beta = torch.sigmoid(torch.randn(1, 4, 2, generator=generator))
+    scalar_gate = -F.softplus(torch.randn(1, 4, 2, generator=generator))
+    initial_state = 0.05 * torch.randn(1, 2, 32, 32, generator=generator)
+    vector_output, vector_state = kda_recurrent_reference(
+        q, k, v, scalar_gate.unsqueeze(-1).expand_as(q), beta, initial_state
+    )
+
+    q_norm = q.float() * torch.rsqrt(q.float().square().sum(-1, keepdim=True) + 1e-6) * (32**-0.5)
+    k_norm = k.float() * torch.rsqrt(k.float().square().sum(-1, keepdim=True) + 1e-6)
+    state = initial_state.float().clone()
+    scalar_outputs = []
+    for token in range(q.shape[1]):
+        state *= scalar_gate[:, token].exp().unsqueeze(-1).unsqueeze(-1)
+        residual = v[:, token] - torch.einsum("bhk,bhkv->bhv", k_norm[:, token], state)
+        state += torch.einsum("bhk,bhv->bhkv", k_norm[:, token], beta[:, token].unsqueeze(-1) * residual)
+        scalar_outputs.append(torch.einsum("bhk,bhkv->bhv", q_norm[:, token], state))
+    scalar_output = torch.stack(scalar_outputs, dim=1)
+    assert_accurate(scalar_output, vector_output, pcc_threshold=0.999999)
+    assert_accurate(state, vector_state, pcc_threshold=0.999999)
+
+
+def test_output_norm_uses_sigmoid_gate() -> None:
+    inputs = torch.tensor([[[[1.0, 2.0, -3.0]]]])
+    gate = torch.tensor([[[[-2.0, 0.0, 2.0]]]])
+    weight = torch.tensor([0.5, 1.0, 1.5])
+    expected = inputs * torch.rsqrt(inputs.square().mean(dim=-1, keepdim=True) + 1e-5)
+    expected = expected * weight * torch.sigmoid(gate)
+    assert_equal(expected, sigmoid_gated_rms_norm_reference(inputs, gate, weight, eps=1e-5))

--- a/models/demos/deepseek_v3_d_p/reference/kda/weights.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/weights.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Canonical host-weight schema for the pure KDA reference."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import torch
+
+from models.demos.deepseek_v3_d_p.reference.kda.config import KDAConfig
+
+KDA_COMMON_WEIGHT_NAMES = (
+    "q_proj.weight",
+    "k_proj.weight",
+    "v_proj.weight",
+    "q_conv1d.weight",
+    "k_conv1d.weight",
+    "v_conv1d.weight",
+    "A_log",
+    "f_a_proj.weight",
+    "f_b_proj.weight",
+    "dt_bias",
+    "b_proj.weight",
+    "o_norm.weight",
+    "o_proj.weight",
+)
+KDA_LOW_RANK_GATE_WEIGHT_NAMES = ("g_a_proj.weight", "g_b_proj.weight")
+KDA_FULL_RANK_GATE_WEIGHT_NAMES = ("g_proj.weight",)
+
+
+def required_kda_weight_names(config: KDAConfig) -> tuple[str, ...]:
+    """Return the canonical layer-local checkpoint keys for ``config``."""
+    gate_names = KDA_FULL_RANK_GATE_WEIGHT_NAMES if config.use_full_rank_gate else KDA_LOW_RANK_GATE_WEIGHT_NAMES
+    return KDA_COMMON_WEIGHT_NAMES + gate_names
+
+
+def expected_kda_weight_shapes(config: KDAConfig) -> dict[str, tuple[int, ...]]:
+    """Return the canonical shape of every host weight for ``config``."""
+    hidden = config.hidden_size
+    key_rank = config.head_k_dim
+    value_rank = config.head_v_dim
+    heads = config.num_heads
+    shapes = {
+        "q_proj.weight": (config.q_dim, hidden),
+        "k_proj.weight": (config.k_dim, hidden),
+        "v_proj.weight": (config.v_dim, hidden),
+        "q_conv1d.weight": (config.q_dim, 1, config.conv_kernel_size),
+        "k_conv1d.weight": (config.k_dim, 1, config.conv_kernel_size),
+        "v_conv1d.weight": (config.v_dim, 1, config.conv_kernel_size),
+        "A_log": (1, 1, heads, 1),
+        "f_a_proj.weight": (key_rank, hidden),
+        "f_b_proj.weight": (heads * key_rank, key_rank),
+        "dt_bias": (heads * key_rank,),
+        "b_proj.weight": (heads, hidden),
+        "o_norm.weight": (value_rank,),
+        "o_proj.weight": (hidden, heads * value_rank),
+    }
+    if config.use_full_rank_gate:
+        shapes["g_proj.weight"] = (heads * value_rank, hidden)
+    else:
+        shapes["g_a_proj.weight"] = (value_rank, hidden)
+        shapes["g_b_proj.weight"] = (heads * value_rank, value_rank)
+    return shapes
+
+
+def validate_kda_weights(weights: Mapping[str, torch.Tensor], config: KDAConfig) -> None:
+    """Validate the presence and shape of every canonical host weight."""
+    for name, expected_shape in expected_kda_weight_shapes(config).items():
+        try:
+            weight = weights[name]
+        except KeyError as error:
+            raise ValueError(f"missing KDA weight: {name}") from error
+        if tuple(weight.shape) != expected_shape:
+            raise ValueError(f"{name} shape {tuple(weight.shape)} != {expected_shape}")

--- a/models/demos/deepseek_v3_d_p/reference/kda/weights.py
+++ b/models/demos/deepseek_v3_d_p/reference/kda/weights.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 """Canonical host-weight schema for the pure KDA reference."""
 

--- a/tests/ttnn/unit_tests/operations/experimental/kda/kda_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/experimental/kda/kda_test_utils.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Dependency-light numerical assertions shared by KDA tests."""
+
+from __future__ import annotations
+
+import torch
+
+
+def _finiteness(name: str, tensor: torch.Tensor) -> tuple[list[str], str]:
+    element_count = tensor.numel()
+    nan_count = int(torch.isnan(tensor).sum().item()) if tensor.dtype.is_floating_point else 0
+    positive_inf_count = int(torch.isposinf(tensor).sum().item()) if tensor.dtype.is_floating_point else 0
+    negative_inf_count = int(torch.isneginf(tensor).sum().item()) if tensor.dtype.is_floating_point else 0
+    non_finite_count = nan_count + positive_inf_count + negative_inf_count
+    summary = (
+        f"{name} finiteness: non_finite={non_finite_count}/{element_count}, "
+        f"nan={nan_count}/{element_count}, +inf={positive_inf_count}/{element_count}, "
+        f"-inf={negative_inf_count}/{element_count}"
+    )
+    failures = [] if non_finite_count == 0 else [summary]
+    return failures, summary
+
+
+def _pcc(expected: torch.Tensor, actual: torch.Tensor) -> float:
+    expected_flat = expected.detach().float().reshape(-1)
+    actual_flat = actual.detach().float().reshape(-1)
+    if torch.equal(expected_flat, actual_flat):
+        return 1.0
+    expected_centered = expected_flat.double() - expected_flat.double().mean()
+    actual_centered = actual_flat.double() - actual_flat.double().mean()
+    denominator = torch.linalg.vector_norm(expected_centered) * torch.linalg.vector_norm(actual_centered)
+    if denominator == 0:
+        return float(torch.allclose(expected_flat, actual_flat, rtol=1e-5, atol=1e-4))
+    return float(torch.dot(expected_centered, actual_centered) / denominator)
+
+
+def assert_accurate(
+    expected: torch.Tensor,
+    actual: torch.Tensor,
+    *,
+    name: str = "accuracy",
+    pcc_threshold: float = 0.999,
+) -> float:
+    """Require matching metadata, finite tensors, and PCC at or above a threshold."""
+    failures = []
+    if expected.shape != actual.shape:
+        failures.append(f"{name} shape {tuple(actual.shape)} != {tuple(expected.shape)}")
+    if expected.dtype != actual.dtype:
+        failures.append(f"{name} dtype {actual.dtype} != {expected.dtype}")
+    expected_failures, expected_summary = _finiteness(f"{name} expected", expected)
+    actual_failures, actual_summary = _finiteness(f"{name} actual", actual)
+    failures.extend(expected_failures)
+    failures.extend(actual_failures)
+    if failures:
+        raise AssertionError("\n".join(failures))
+
+    pcc = _pcc(expected, actual)
+    max_abs = float((expected.float() - actual.float()).abs().max()) if expected.numel() else 0.0
+    print(expected_summary)
+    print(actual_summary)
+    print(f"{name}: PCC={pcc:.6f}, max_abs={max_abs:.6e}")
+    if pcc < pcc_threshold:
+        raise AssertionError(f"{name} PCC {pcc:.6f} < {pcc_threshold}")
+    return pcc
+
+
+def assert_equal(expected: torch.Tensor, actual: torch.Tensor, *, name: str = "equality") -> None:
+    """Require finite tensors with identical metadata and values."""
+    failures = []
+    if expected.shape != actual.shape:
+        failures.append(f"{name} shape {tuple(actual.shape)} != {tuple(expected.shape)}")
+    if expected.dtype != actual.dtype:
+        failures.append(f"{name} dtype {actual.dtype} != {expected.dtype}")
+    failures.extend(_finiteness(f"{name} expected", expected)[0])
+    failures.extend(_finiteness(f"{name} actual", actual)[0])
+    if expected.shape == actual.shape and expected.dtype == actual.dtype and not torch.equal(expected, actual):
+        failures.append(f"{name} values differ")
+    if failures:
+        raise AssertionError("\n".join(failures))
+
+
+def assert_bit_identical(expected: torch.Tensor, actual: torch.Tensor, *, name: str = "determinism") -> None:
+    """Require finite tensors with identical metadata and bit patterns."""
+    assert_equal(expected, actual, name=name)

--- a/tests/ttnn/unit_tests/operations/experimental/kda/kda_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/experimental/kda/kda_test_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 """Dependency-light numerical assertions shared by KDA tests."""
 

--- a/tests/ttnn/unit_tests/operations/experimental/kda/kda_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/experimental/kda/kda_test_utils.py
@@ -83,3 +83,7 @@ def assert_equal(expected: torch.Tensor, actual: torch.Tensor, *, name: str = "e
 def assert_bit_identical(expected: torch.Tensor, actual: torch.Tensor, *, name: str = "determinism") -> None:
     """Require finite tensors with identical metadata and bit patterns."""
     assert_equal(expected, actual, name=name)
+    expected_bytes = expected.detach().contiguous().reshape(-1).view(torch.uint8)
+    actual_bytes = actual.detach().contiguous().reshape(-1).view(torch.uint8)
+    if not torch.equal(expected_bytes, actual_bytes):
+        raise AssertionError(f"{name} bit patterns differ")

--- a/tests/ttnn/unit_tests/operations/experimental/kda/test_kda_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/experimental/kda/test_kda_test_utils.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest

--- a/tests/ttnn/unit_tests/operations/experimental/kda/test_kda_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/experimental/kda/test_kda_test_utils.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import (
+    assert_accurate,
+    assert_bit_identical,
+    assert_equal,
+)
+
+
+@pytest.mark.parametrize(
+    "value,label",
+    [(float("nan"), "nan=1"), (float("inf"), r"\+inf=1"), (-float("inf"), "-inf=1")],
+)
+@pytest.mark.parametrize("assertion", [assert_accurate, assert_equal, assert_bit_identical])
+def test_assertions_reject_nonfinite_values(assertion, value: float, label: str, expect_error) -> None:
+    tensor = torch.tensor([value])
+    with expect_error(AssertionError, label):
+        assertion(tensor, tensor.clone())
+
+
+@pytest.mark.parametrize("assertion", [assert_accurate, assert_equal, assert_bit_identical])
+def test_assertions_reject_shape_metadata_mismatch(assertion, expect_error) -> None:
+    with expect_error(AssertionError, "shape"):
+        assertion(torch.zeros(2), torch.zeros(1, 2))
+
+
+@pytest.mark.parametrize("assertion", [assert_accurate, assert_equal, assert_bit_identical])
+def test_assertions_reject_dtype_metadata_mismatch(assertion, expect_error) -> None:
+    with expect_error(AssertionError, "dtype"):
+        assertion(torch.zeros(2, dtype=torch.float32), torch.zeros(2, dtype=torch.bfloat16))
+
+
+def test_assert_accurate_rejects_pcc_below_threshold(expect_error) -> None:
+    with expect_error(AssertionError, "PCC"):
+        assert_accurate(torch.arange(8.0), torch.arange(7, -1, -1.0), pcc_threshold=0.99)
+
+
+def test_assert_equal_rejects_value_mismatch(expect_error) -> None:
+    with expect_error(AssertionError, "values differ"):
+        assert_equal(torch.tensor([1.0, 2.0]), torch.tensor([1.0, 3.0]))
+
+
+def test_assert_bit_identical_rejects_bit_mismatch(expect_error) -> None:
+    expected = torch.tensor([1.0], dtype=torch.float32)
+    actual = torch.nextafter(expected, torch.tensor([2.0]))
+    with expect_error(AssertionError, "values differ"):
+        assert_bit_identical(expected, actual)
+
+
+def test_assert_accurate_returns_measured_pcc() -> None:
+    expected = torch.arange(8.0)
+    actual = expected + torch.linspace(0.0, 1e-4, 8)
+    pcc = assert_accurate(expected, actual, pcc_threshold=0.999999)
+    assert 0.999999 <= pcc <= 1.0

--- a/tests/ttnn/unit_tests/operations/experimental/kda/test_kda_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/experimental/kda/test_kda_test_utils.py
@@ -51,6 +51,11 @@ def test_assert_bit_identical_rejects_bit_mismatch(expect_error) -> None:
         assert_bit_identical(expected, actual)
 
 
+def test_assert_bit_identical_rejects_signed_zero_mismatch(expect_error) -> None:
+    with expect_error(AssertionError, "bit patterns differ"):
+        assert_bit_identical(torch.tensor([0.0]), torch.tensor([-0.0]))
+
+
 def test_assert_accurate_returns_measured_pcc() -> None:
     expected = torch.arange(8.0)
     actual = expected + torch.linspace(0.0, 1e-4, 8)


### PR DESCRIPTION
Defines the device-independent KDA semantics extracted from the [full change PR #51910](https://github.com/tenstorrent/tt-metal/pull/51910).

The pure-Torch reference covers Kimi-K3 configuration and weight contracts, four-tap causal QKV convolution, gated normalized delta recurrence with explicit state, and sigmoid-gated RMS normalization.

It also adds shared numerical test utilities for PCC, exact equality, bit identity, tensor metadata, and non-finite values. Keeping these utilities independent of the model and device implementation gives the subsequent operation PRs a common correctness contract.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kda-split/00-reference)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kda-split/00-reference)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kda-split/00-reference)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kda-split/00-reference)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=kda-split/00-reference)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:kda-split/00-reference)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kda-split/00-reference)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kda-split/00-reference)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kda-split/00-reference)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kda-split/00-reference)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kda-split/00-reference)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kda-split/00-reference)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kda-split/00-reference)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kda-split/00-reference)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kda-split/00-reference)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kda-split/00-reference)