### PR TITLE
[KDA 2/8] Add causal QKV Conv1D with SiLU

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
@@ -32,9 +32,10 @@ _DEFAULT_WIDTHS = (512, 512, 512)
 
 
 @dataclass(frozen=True)
-class _ProductionCase:
+class _BenchmarkCase:
     case_id: str
     widths: tuple[int, int, int]
+    channel_chunk_size: int
     expected_duration_ns: int
 
 
@@ -50,9 +51,9 @@ _PRODUCTION_PERF_MARGIN = 0.05
 # the inline references are their medians. The 5% symmetric margin now leaves
 # 2.2-4.4 us on both sides, against an observed spread of 85-305 ns.
 _PRODUCTION_CASES = (
-    _ProductionCase("single-block", widths=(512, 512, 512), expected_duration_ns=88_383),
-    _ProductionCase("multiple-blocks", widths=(1024, 1024, 1024), expected_duration_ns=48_090),
-    _ProductionCase("asymmetric-split", widths=(512, 256, 128), expected_duration_ns=53_270),
+    _BenchmarkCase("single-block", widths=(512, 512, 512), channel_chunk_size=1536, expected_duration_ns=88_383),
+    _BenchmarkCase("multiple-blocks", widths=(1024, 1024, 1024), channel_chunk_size=768, expected_duration_ns=48_090),
+    _BenchmarkCase("asymmetric-split", widths=(512, 256, 128), channel_chunk_size=896, expected_duration_ns=53_270),
 )
 
 
@@ -126,6 +127,7 @@ def _run(
     history_tt: ttnn.Tensor,
     taps_tt: tuple[ttnn.Tensor, ...],
     *,
+    channel_chunk_size: int,
     widths: tuple[int, int, int] = _DEFAULT_WIDTHS,
     memory_config: ttnn.MemoryConfig | None = None,
     compute_kernel_config: ttnn.DeviceComputeKernelConfig | None = None,
@@ -135,13 +137,19 @@ def _run(
         history_tt,
         *taps_tt,
         *widths,
+        program_config=ttnn.QkvCausalConv1dSiluProgramConfig(channel_chunk_size=channel_chunk_size),
         memory_config=memory_config,
         compute_kernel_config=compute_kernel_config,
     )
 
 
-@pytest.mark.parametrize("widths", [(512, 512, 512), (1024, 1024, 1024), (512, 256, 128)])
-def test_qkv_causal_conv1d_silu_contract(device: ttnn.Device, widths: tuple[int, int, int]) -> None:
+@pytest.mark.parametrize(
+    ("widths", "channel_chunk_size"),
+    [((512, 512, 512), 1536), ((1024, 1024, 1024), 768), ((512, 256, 128), 896)],
+)
+def test_qkv_causal_conv1d_silu_contract(
+    device: ttnn.Device, widths: tuple[int, int, int], channel_chunk_size: int
+) -> None:
     """Cover one/multiple channel blocks, split widths, tap order, and runtime gates."""
     host, device_inputs = _device_inputs(device, widths=widths)
     inputs, history, taps = host
@@ -152,7 +160,7 @@ def test_qkv_causal_conv1d_silu_contract(device: ttnn.Device, widths: tuple[int,
 
     def run() -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
         with ttnn.manage_config("throw_exception_on_fallback", True):
-            return _run(input_tt, history_tt, taps_tt, widths=widths)
+            return _run(input_tt, history_tt, taps_tt, widths=widths, channel_chunk_size=channel_chunk_size)
 
     outputs = run()
     for output, width in zip(outputs, widths, strict=True):
@@ -183,14 +191,20 @@ def test_qkv_causal_conv1d_silu_contract(device: ttnn.Device, widths: tuple[int,
 
 
 @pytest.mark.parametrize("case", _PRODUCTION_CASES, ids=lambda case: case.case_id)
-def test_qkv_causal_conv1d_silu_is_device_deterministic(device: ttnn.Device, case: _ProductionCase) -> None:
+def test_qkv_causal_conv1d_silu_is_device_deterministic(device: ttnn.Device, case: _BenchmarkCase) -> None:
     """Compare repeated large outputs on device; cache behavior is tested separately."""
     host, (input_tt, history_tt, taps_tt) = _device_inputs(device, widths=case.widths)
     expected = _reference(*host, case.widths)
 
     def run() -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
         with ttnn.manage_config("throw_exception_on_fallback", True):
-            return _run(input_tt, history_tt, taps_tt, widths=case.widths)
+            return _run(
+                input_tt,
+                history_tt,
+                taps_tt,
+                widths=case.widths,
+                channel_chunk_size=case.channel_chunk_size,
+            )
 
     output_tensors, outputs, mismatch_marker = collect_accuracy_and_determinism_results(device, run)
     assert_equal(
@@ -209,10 +223,10 @@ def test_qkv_causal_conv1d_silu_cache_hit_rebinds_fresh_tensors(device: ttnn.Dev
     host_a, device_inputs_a = _device_inputs(device, widths=widths, sequence=32, seed=1911)
     host_b, device_inputs_b = _device_inputs(device, widths=widths, sequence=32, seed=1912)
 
-    output_a = _run(*device_inputs_a, widths=widths)
+    output_a = _run(*device_inputs_a, widths=widths, channel_chunk_size=384)
     ttnn.synchronize_device(device)
     entries = device.num_program_cache_entries()
-    output_b = _run(*device_inputs_b, widths=widths)
+    output_b = _run(*device_inputs_b, widths=widths, channel_chunk_size=384)
     ttnn.synchronize_device(device)
 
     flat_inputs_a = (device_inputs_a[0], device_inputs_a[1], *device_inputs_a[2])
@@ -241,7 +255,7 @@ def test_qkv_causal_conv1d_silu_cache_hit_rebinds_fresh_tensors(device: ttnn.Dev
 
 def test_qkv_causal_conv1d_silu_default_compute_config_matches_explicit_defaults(device: ttnn.Device) -> None:
     _, (input_tt, history_tt, taps_tt) = _device_inputs(device, sequence=32, widths=(128, 128, 128), seed=817)
-    implicit = _run(input_tt, history_tt, taps_tt, widths=(128, 128, 128))
+    implicit = _run(input_tt, history_tt, taps_tt, widths=(128, 128, 128), channel_chunk_size=384)
     entries = device.num_program_cache_entries()
     explicit_config = ttnn.init_device_compute_kernel_config(
         device.arch(),
@@ -257,6 +271,7 @@ def test_qkv_causal_conv1d_silu_default_compute_config_matches_explicit_defaults
         history_tt,
         taps_tt,
         widths=(128, 128, 128),
+        channel_chunk_size=384,
         compute_kernel_config=explicit_config,
     )
     assert device.num_program_cache_entries() == entries
@@ -270,7 +285,13 @@ def test_qkv_causal_conv1d_silu_default_compute_config_matches_explicit_defaults
 
 def test_qkv_causal_conv1d_silu_exact_math_uses_distinct_accurate_program(device: ttnn.Device) -> None:
     host, (input_tt, history_tt, taps_tt) = _device_inputs(device, sequence=32, widths=(128, 128, 128), seed=818)
-    approximate = _run(input_tt, history_tt, taps_tt, widths=(128, 128, 128))
+    approximate = _run(
+        input_tt,
+        history_tt,
+        taps_tt,
+        widths=(128, 128, 128),
+        channel_chunk_size=384,
+    )
     entries = device.num_program_cache_entries()
     exact_config = ttnn.init_device_compute_kernel_config(
         device.arch(),
@@ -284,6 +305,7 @@ def test_qkv_causal_conv1d_silu_exact_math_uses_distinct_accurate_program(device
         history_tt,
         taps_tt,
         widths=(128, 128, 128),
+        channel_chunk_size=384,
         compute_kernel_config=exact_config,
     )
     assert device.num_program_cache_entries() == entries + 1
@@ -307,6 +329,7 @@ def test_qkv_causal_conv1d_silu_rejects_unsupported_compute_config(device: ttnn.
             history_tt,
             taps_tt,
             widths=(128, 128, 128),
+            channel_chunk_size=384,
             compute_kernel_config=unsupported_config,
         )
 
@@ -315,14 +338,20 @@ def test_qkv_causal_conv1d_silu_rejects_unsupported_compute_config(device: ttnn.
 @pytest.mark.parametrize("case", _PRODUCTION_CASES, ids=lambda case: case.case_id)
 @skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
 @skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
-def test_qkv_causal_conv1d_silu_production_performance(device: ttnn.Device, case: _ProductionCase) -> None:
+def test_qkv_causal_conv1d_silu_production_performance(device: ttnn.Device, case: _BenchmarkCase) -> None:
     if not ttnn.device.IsProgramRealtimeProfilerActive():
         pytest.fail("Real-time profiler must be active for QKV causal Conv1D plus SiLU performance checks")
 
     _, (input_tt, history_tt, taps_tt) = _device_inputs(device, widths=case.widths)
 
     def run() -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
-        return _run(input_tt, history_tt, taps_tt, widths=case.widths)
+        return _run(
+            input_tt,
+            history_tt,
+            taps_tt,
+            widths=case.widths,
+            channel_chunk_size=case.channel_chunk_size,
+        )
 
     outputs, perf_record = profile_realtime_program(device, run)
     duration_ns = perf_record["duration_ns"]
@@ -341,12 +370,47 @@ def test_qkv_causal_conv1d_silu_production_performance(device: ttnn.Device, case
 
 def test_qkv_causal_conv1d_silu_program_key_includes_split_widths(device: ttnn.Device) -> None:
     _, (input_tt, history_tt, taps_tt) = _device_inputs(device, widths=(128, 128, 128), sequence=32, seed=772)
-    _run(input_tt, history_tt, taps_tt, widths=(128, 128, 128))
+    _run(input_tt, history_tt, taps_tt, widths=(128, 128, 128), channel_chunk_size=384)
     entries = device.num_program_cache_entries()
-    _run(input_tt, history_tt, taps_tt, widths=(64, 128, 192))
+    _run(input_tt, history_tt, taps_tt, widths=(64, 128, 192), channel_chunk_size=384)
     assert device.num_program_cache_entries() == entries + 1
-    _run(input_tt, history_tt, taps_tt, widths=(64, 128, 192))
+    _run(input_tt, history_tt, taps_tt, widths=(64, 128, 192), channel_chunk_size=384)
     assert device.num_program_cache_entries() == entries + 1
+
+
+def test_qkv_causal_conv1d_silu_program_key_includes_channel_chunk_size(device: ttnn.Device) -> None:
+    widths = (128, 128, 128)
+    _, (input_tt, history_tt, taps_tt) = _device_inputs(device, widths=widths, sequence=32, seed=773)
+    _run(input_tt, history_tt, taps_tt, widths=widths, channel_chunk_size=384)
+    entries = device.num_program_cache_entries()
+    _run(input_tt, history_tt, taps_tt, widths=widths, channel_chunk_size=192)
+    assert device.num_program_cache_entries() == entries + 1
+    _run(input_tt, history_tt, taps_tt, widths=widths, channel_chunk_size=192)
+    assert device.num_program_cache_entries() == entries + 1
+
+
+@pytest.mark.parametrize(
+    ("channel_chunk_size", "message"),
+    [
+        (0, "channel_chunk_size must be positive"),
+        (16, "channel_chunk_size must be tile aligned"),
+        (416, r"channel_chunk_size must not exceed Q\+K\+V width"),
+        (160, r"channel_chunk_size must divide Q\+K\+V width exactly"),
+    ],
+)
+def test_qkv_causal_conv1d_silu_rejects_invalid_channel_chunk_size(
+    device: ttnn.Device, expect_error: Callable, channel_chunk_size: int, message: str
+) -> None:
+    widths = (128, 128, 128)
+    _, (input_tt, history_tt, taps_tt) = _device_inputs(device, widths=widths, sequence=32)
+    with expect_error(RuntimeError, message):
+        _run(
+            input_tt,
+            history_tt,
+            taps_tt,
+            widths=widths,
+            channel_chunk_size=channel_chunk_size,
+        )
 
 
 @pytest.mark.parametrize(
@@ -413,7 +477,7 @@ def test_qkv_causal_conv1d_silu_rejects_invalid_tensors(
         history_tt = _to_device(history, device, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=sharded_config)
 
     with expect_error(RuntimeError, message):
-        _run(input_tt, history_tt, tuple(taps_list), widths=(128, 128, 128))
+        _run(input_tt, history_tt, tuple(taps_list), widths=(128, 128, 128), channel_chunk_size=384)
 
 
 @pytest.mark.parametrize(
@@ -429,7 +493,7 @@ def test_qkv_causal_conv1d_silu_rejects_invalid_widths(
 ) -> None:
     _, (input_tt, history_tt, taps_tt) = _device_inputs(device, widths=(128, 128, 128), sequence=32)
     with expect_error(RuntimeError, message):
-        _run(input_tt, history_tt, taps_tt, widths=widths)
+        _run(input_tt, history_tt, taps_tt, widths=widths, channel_chunk_size=sum(widths))
 
 
 def test_qkv_causal_conv1d_silu_rejects_sharded_output(device: ttnn.Device, expect_error: Callable) -> None:
@@ -441,4 +505,11 @@ def test_qkv_causal_conv1d_silu_rejects_sharded_output(device: ttnn.Device, expe
     )
     sharded_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
     with expect_error(RuntimeError, "output memory layout must be INTERLEAVED, got HEIGHT_SHARDED"):
-        _run(input_tt, history_tt, taps_tt, widths=(128, 128, 128), memory_config=sharded_config)
+        _run(
+            input_tt,
+            history_tt,
+            taps_tt,
+            widths=(128, 128, 128),
+            channel_chunk_size=384,
+            memory_config=sharded_config,
+        )

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
@@ -260,7 +260,7 @@ def test_qkv_causal_conv1d_silu_default_compute_config_matches_explicit_defaults
     explicit_config = ttnn.init_device_compute_kernel_config(
         device.arch(),
         math_fidelity=ttnn.MathFidelity.HiFi4,
-        math_approx_mode=True,
+        math_approx_mode=False,
         fp32_dest_acc_en=False,
         packer_l1_acc=False,
         dst_full_sync_en=False,
@@ -283,38 +283,26 @@ def test_qkv_causal_conv1d_silu_default_compute_config_matches_explicit_defaults
         )
 
 
-def test_qkv_causal_conv1d_silu_exact_math_uses_distinct_accurate_program(device: ttnn.Device) -> None:
-    host, (input_tt, history_tt, taps_tt) = _device_inputs(device, sequence=32, widths=(128, 128, 128), seed=818)
-    approximate = _run(
-        input_tt,
-        history_tt,
-        taps_tt,
-        widths=(128, 128, 128),
-        channel_chunk_size=384,
-    )
-    entries = device.num_program_cache_entries()
-    exact_config = ttnn.init_device_compute_kernel_config(
+def test_qkv_causal_conv1d_silu_rejects_approximate_math(device: ttnn.Device, expect_error: Callable) -> None:
+    _, (input_tt, history_tt, taps_tt) = _device_inputs(device, sequence=32, widths=(128, 128, 128), seed=818)
+    approximate_config = ttnn.init_device_compute_kernel_config(
         device.arch(),
         math_fidelity=ttnn.MathFidelity.HiFi4,
-        math_approx_mode=False,
+        math_approx_mode=True,
         fp32_dest_acc_en=False,
         packer_l1_acc=False,
     )
-    exact = _run(
-        input_tt,
-        history_tt,
-        taps_tt,
-        widths=(128, 128, 128),
-        channel_chunk_size=384,
-        compute_kernel_config=exact_config,
-    )
-    assert device.num_program_cache_entries() == entries + 1
-    expected = _reference(*host, (128, 128, 128))
-    for name, golden, approximate_output, exact_output in zip(
-        ("q", "k", "v"), expected, approximate, exact, strict=True
+    with expect_error(
+        RuntimeError, "math_approx_mode=true is unsupported because silu_tile always uses precise sigmoid"
     ):
-        assert_accurate(golden, ttnn.to_torch(approximate_output), name=f"{name} approximate math", pcc_threshold=0.999)
-        assert_accurate(golden, ttnn.to_torch(exact_output), name=f"{name} exact math", pcc_threshold=0.999)
+        _run(
+            input_tt,
+            history_tt,
+            taps_tt,
+            widths=(128, 128, 128),
+            channel_chunk_size=384,
+            compute_kernel_config=approximate_config,
+        )
 
 
 def test_qkv_causal_conv1d_silu_rejects_unsupported_compute_config(device: ttnn.Device, expect_error: Callable) -> None:

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 """Direct contract coverage for experimental KDA QKV causal Conv1D plus SiLU."""
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
@@ -171,6 +171,7 @@ def test_qkv_causal_conv1d_silu_program_key_includes_split_widths(device: ttnn.D
         ("host_input", "allocated device tensor"),
         ("batch", r"input must be \[1,T,Q\+K\+V\]"),
         ("history_shape", r"history must be \[1,3,Q\+K\+V\]"),
+        ("tap_last_dimension", r"tap2 last dimension must equal Q\+K\+V"),
         ("tap_volume", "tap2 logical volume must equal"),
         ("input_layout", "input has unsupported layout"),
         ("history_layout", "history has unsupported layout"),
@@ -202,8 +203,10 @@ def test_qkv_causal_conv1d_silu_rejects_invalid_tensors(
 
     if case == "host_input":
         input_tt = ttnn.from_torch(inputs, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+    elif case == "tap_last_dimension":
+        taps_list[2] = _to_device(taps[2].reshape(-1, 1), device, layout=ttnn.TILE_LAYOUT)
     elif case == "tap_volume":
-        taps_list[2] = _to_device(taps[2][..., :-32], device, layout=ttnn.TILE_LAYOUT)
+        taps_list[2] = _to_device(torch.cat((taps[2], taps[2]), dim=0), device, layout=ttnn.TILE_LAYOUT)
     elif case == "input_layout":
         input_tt = _to_device(inputs, device, layout=ttnn.TILE_LAYOUT)
     elif case == "history_layout":

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
@@ -115,9 +115,13 @@ def test_qkv_causal_conv1d_silu_contract(device: ttnn.Device, widths: tuple[int,
     input_tensors = (input_tt, history_tt, *taps_tt)
     snapshots = tuple(ttnn.to_torch(tensor).clone() for tensor in input_tensors)
 
-    def run() -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
+    def run(
+        current_input: ttnn.Tensor = input_tt,
+        current_history: ttnn.Tensor = history_tt,
+        current_taps: tuple[ttnn.Tensor, ...] = taps_tt,
+    ) -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
         with ttnn.manage_config("throw_exception_on_fallback", True):
-            return _run(input_tt, history_tt, taps_tt, widths=widths)
+            return _run(current_input, current_history, current_taps, widths=widths)
 
     outputs = run()
     for name, output, width in zip(("q", "k", "v"), outputs, widths, strict=True):
@@ -128,7 +132,9 @@ def test_qkv_causal_conv1d_silu_contract(device: ttnn.Device, widths: tuple[int,
         assert all(output.buffer_address() != tensor.buffer_address() for tensor in input_tensors)
 
     cache_entries = device.num_program_cache_entries()
-    repeated_outputs = run()
+    repeated_host, repeated_device = _device_inputs(device, widths=widths, seed=224)
+    repeated_expected = _reference(*repeated_host, widths)
+    repeated_outputs = run(*repeated_device)
     ttnn.synchronize_device(device)
     assert device.num_program_cache_entries() == cache_entries
 
@@ -139,12 +145,12 @@ def test_qkv_causal_conv1d_silu_contract(device: ttnn.Device, widths: tuple[int,
         ttnn.execute_trace(device, trace_id, cq_id=0, blocking=False)
     ttnn.synchronize_device(device)
 
-    for name, golden, output, repeated, traced in zip(
-        ("q", "k", "v"), expected, outputs, repeated_outputs, traced_outputs, strict=True
+    for name, golden, repeated_golden, output, repeated, traced in zip(
+        ("q", "k", "v"), expected, repeated_expected, outputs, repeated_outputs, traced_outputs, strict=True
     ):
         actual = ttnn.to_torch(output)
         assert_accurate(golden, actual, name=name, pcc_threshold=0.999)
-        assert_bit_identical(actual, ttnn.to_torch(repeated), name=f"{name} eager repeat")
+        assert_accurate(repeated_golden, ttnn.to_torch(repeated), name=f"{name} cache hit", pcc_threshold=0.999)
         assert_bit_identical(actual, ttnn.to_torch(traced), name=f"{name} trace replay")
 
     for name, before, tensor in zip(

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
@@ -1,0 +1,257 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Direct contract coverage for experimental KDA QKV causal Conv1D plus SiLU."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import assert_accurate, assert_bit_identical
+
+pytestmark = [
+    run_for_blackhole(),
+    pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True),
+]
+
+_SEQUENCE = 64
+_DEFAULT_WIDTHS = (512, 512, 512)
+
+
+def _host_inputs(
+    *,
+    sequence: int = _SEQUENCE,
+    widths: tuple[int, int, int] = _DEFAULT_WIDTHS,
+    batch: int = 1,
+    history_rows: int = 3,
+    seed: int = 223,
+) -> tuple[torch.Tensor, torch.Tensor, tuple[torch.Tensor, ...]]:
+    generator = torch.Generator().manual_seed(seed)
+    channels = sum(widths)
+    inputs = torch.randn(batch, sequence, channels, generator=generator, dtype=torch.bfloat16)
+    history = torch.randn(batch, history_rows, channels, generator=generator, dtype=torch.bfloat16)
+    taps = tuple(torch.randn(1, 1, channels, generator=generator, dtype=torch.bfloat16) for _ in range(4))
+    return inputs, history, taps
+
+
+def _to_device(
+    tensor: torch.Tensor,
+    device: ttnn.Device,
+    *,
+    dtype: ttnn.DataType = ttnn.bfloat16,
+    layout: ttnn.Layout,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+) -> ttnn.Tensor:
+    return ttnn.from_torch(tensor, dtype=dtype, layout=layout, device=device, memory_config=memory_config)
+
+
+def _device_inputs(
+    device: ttnn.Device,
+    *,
+    sequence: int = _SEQUENCE,
+    widths: tuple[int, int, int] = _DEFAULT_WIDTHS,
+    batch: int = 1,
+    history_rows: int = 3,
+    seed: int = 223,
+) -> tuple[
+    tuple[torch.Tensor, torch.Tensor, tuple[torch.Tensor, ...]],
+    tuple[ttnn.Tensor, ttnn.Tensor, tuple[ttnn.Tensor, ...]],
+]:
+    host = _host_inputs(
+        sequence=sequence,
+        widths=widths,
+        batch=batch,
+        history_rows=history_rows,
+        seed=seed,
+    )
+    inputs, history, taps = host
+    return host, (
+        _to_device(inputs, device, layout=ttnn.ROW_MAJOR_LAYOUT),
+        _to_device(history, device, layout=ttnn.ROW_MAJOR_LAYOUT),
+        tuple(_to_device(tap, device, layout=ttnn.TILE_LAYOUT) for tap in taps),
+    )
+
+
+def _reference(
+    inputs: torch.Tensor,
+    history: torch.Tensor,
+    taps: tuple[torch.Tensor, ...],
+    widths: tuple[int, int, int],
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    window = torch.cat((history, inputs), dim=1)
+    convolved = sum(window[:, tap : tap + inputs.shape[1]] * taps[tap] for tap in range(4))
+    return F.silu(convolved).split(widths, dim=-1)
+
+
+def _run(
+    input_tt: ttnn.Tensor,
+    history_tt: ttnn.Tensor,
+    taps_tt: tuple[ttnn.Tensor, ...],
+    *,
+    widths: tuple[int, int, int] = _DEFAULT_WIDTHS,
+    memory_config: ttnn.MemoryConfig | None = None,
+) -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
+    return ttnn.experimental.kda.qkv_causal_conv1d_silu(
+        input_tt,
+        history_tt,
+        *taps_tt,
+        *widths,
+        memory_config=memory_config,
+    )
+
+
+@pytest.mark.parametrize("widths", [(512, 512, 512), (1024, 1024, 1024), (512, 256, 128)])
+def test_qkv_causal_conv1d_silu_contract(device: ttnn.Device, widths: tuple[int, int, int]) -> None:
+    """Cover one/multiple channel blocks, split widths, tap order, and runtime gates."""
+    host, device_inputs = _device_inputs(device, widths=widths)
+    inputs, history, taps = host
+    input_tt, history_tt, taps_tt = device_inputs
+    expected = _reference(inputs, history, taps, widths)
+    input_tensors = (input_tt, history_tt, *taps_tt)
+    snapshots = tuple(ttnn.to_torch(tensor).clone() for tensor in input_tensors)
+
+    def run() -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
+        with ttnn.manage_config("throw_exception_on_fallback", True):
+            return _run(input_tt, history_tt, taps_tt, widths=widths)
+
+    outputs = run()
+    for name, output, width in zip(("q", "k", "v"), outputs, widths, strict=True):
+        assert output.dtype == ttnn.bfloat16
+        assert output.layout == ttnn.TILE_LAYOUT
+        assert output.memory_config() == ttnn.DRAM_MEMORY_CONFIG
+        assert tuple(ttnn.to_torch(output).shape) == (1, _SEQUENCE, width)
+        assert all(output.buffer_address() != tensor.buffer_address() for tensor in input_tensors)
+
+    cache_entries = device.num_program_cache_entries()
+    repeated_outputs = run()
+    ttnn.synchronize_device(device)
+    assert device.num_program_cache_entries() == cache_entries
+
+    trace_id = ttnn.begin_trace_capture(device, cq_id=0)
+    traced_outputs = run()
+    ttnn.end_trace_capture(device, trace_id, cq_id=0)
+    for _ in range(2):
+        ttnn.execute_trace(device, trace_id, cq_id=0, blocking=False)
+    ttnn.synchronize_device(device)
+
+    for name, golden, output, repeated, traced in zip(
+        ("q", "k", "v"), expected, outputs, repeated_outputs, traced_outputs, strict=True
+    ):
+        actual = ttnn.to_torch(output)
+        assert_accurate(golden, actual, name=name, pcc_threshold=0.999)
+        assert_bit_identical(actual, ttnn.to_torch(repeated), name=f"{name} eager repeat")
+        assert_bit_identical(actual, ttnn.to_torch(traced), name=f"{name} trace replay")
+
+    for name, before, tensor in zip(
+        ("input", "history", "tap0", "tap1", "tap2", "tap3"), snapshots, input_tensors, strict=True
+    ):
+        assert_bit_identical(before, ttnn.to_torch(tensor), name=f"{name} immutability")
+
+    ttnn.release_trace(device, trace_id)
+
+
+def test_qkv_causal_conv1d_silu_program_key_includes_split_widths(device: ttnn.Device) -> None:
+    _, (input_tt, history_tt, taps_tt) = _device_inputs(device, widths=(128, 128, 128), sequence=32, seed=772)
+    _run(input_tt, history_tt, taps_tt, widths=(128, 128, 128))
+    entries = device.num_program_cache_entries()
+    _run(input_tt, history_tt, taps_tt, widths=(64, 128, 192))
+    assert device.num_program_cache_entries() == entries + 1
+    _run(input_tt, history_tt, taps_tt, widths=(64, 128, 192))
+    assert device.num_program_cache_entries() == entries + 1
+
+
+@pytest.mark.parametrize(
+    ("case", "message"),
+    [
+        ("host_input", "allocated device tensor"),
+        ("batch", r"input must be \[1,T,Q\+K\+V\]"),
+        ("history_shape", r"history must be \[1,3,Q\+K\+V\]"),
+        ("tap_volume", "tap2 logical volume must equal"),
+        ("input_layout", "input has unsupported layout"),
+        ("history_layout", "history has unsupported layout"),
+        ("tap_layout", "tap1 has unsupported layout"),
+        ("input_dtype", "input must be BFLOAT16"),
+        ("history_dtype", "history must be BFLOAT16"),
+        ("tap_dtype", "tap3 must be BFLOAT16"),
+        ("sequence_alignment", "sequence must be positive and tile aligned"),
+        ("sharded_history", "history must use interleaved memory"),
+    ],
+)
+def test_qkv_causal_conv1d_silu_rejects_invalid_tensors(
+    device: ttnn.Device, expect_error: Callable, case: str, message: str
+) -> None:
+    batch = 2 if case == "batch" else 1
+    history_rows = 2 if case == "history_shape" else 3
+    sequence = 33 if case == "sequence_alignment" else 32
+    host, device_inputs = _device_inputs(
+        device,
+        widths=(128, 128, 128),
+        batch=batch,
+        history_rows=history_rows,
+        sequence=sequence,
+        seed=991,
+    )
+    inputs, history, taps = host
+    input_tt, history_tt, taps_tt = device_inputs
+    taps_list = list(taps_tt)
+
+    if case == "host_input":
+        input_tt = ttnn.from_torch(inputs, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+    elif case == "tap_volume":
+        taps_list[2] = _to_device(taps[2][..., :-32], device, layout=ttnn.TILE_LAYOUT)
+    elif case == "input_layout":
+        input_tt = _to_device(inputs, device, layout=ttnn.TILE_LAYOUT)
+    elif case == "history_layout":
+        history_tt = _to_device(history, device, layout=ttnn.TILE_LAYOUT)
+    elif case == "tap_layout":
+        taps_list[1] = _to_device(taps[1], device, layout=ttnn.ROW_MAJOR_LAYOUT)
+    elif case == "input_dtype":
+        input_tt = _to_device(inputs.float(), device, dtype=ttnn.float32, layout=ttnn.ROW_MAJOR_LAYOUT)
+    elif case == "history_dtype":
+        history_tt = _to_device(history.float(), device, dtype=ttnn.float32, layout=ttnn.ROW_MAJOR_LAYOUT)
+    elif case == "tap_dtype":
+        taps_list[3] = _to_device(taps[3].float(), device, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT)
+    elif case == "sharded_history":
+        shard_spec = ttnn.ShardSpec(
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+            [history.shape[0] * history.shape[1], history.shape[2]],
+            ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        sharded_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+        history_tt = _to_device(history, device, layout=ttnn.ROW_MAJOR_LAYOUT, memory_config=sharded_config)
+
+    with expect_error(RuntimeError, message):
+        _run(input_tt, history_tt, tuple(taps_list), widths=(128, 128, 128))
+
+
+@pytest.mark.parametrize(
+    ("widths", "message"),
+    [
+        ((0, 128, 256), "Q/K/V widths must be positive"),
+        ((100, 128, 156), "Q/K/V widths must be tile aligned"),
+        ((128, 128, 64), r"input must be \[1,T,Q\+K\+V\]"),
+    ],
+)
+def test_qkv_causal_conv1d_silu_rejects_invalid_widths(
+    device: ttnn.Device, expect_error: Callable, widths: tuple[int, int, int], message: str
+) -> None:
+    _, (input_tt, history_tt, taps_tt) = _device_inputs(device, widths=(128, 128, 128), sequence=32)
+    with expect_error(RuntimeError, message):
+        _run(input_tt, history_tt, taps_tt, widths=widths)
+
+
+def test_qkv_causal_conv1d_silu_rejects_sharded_output(device: ttnn.Device, expect_error: Callable) -> None:
+    _, (input_tt, history_tt, taps_tt) = _device_inputs(device, widths=(128, 128, 128), sequence=32)
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+        [32, 128],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    sharded_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+    with expect_error(RuntimeError, "output memory configuration must be interleaved"):
+        _run(input_tt, history_tt, taps_tt, widths=(128, 128, 128), memory_config=sharded_config)

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
@@ -18,6 +18,7 @@ from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_progra
 from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import (
     assert_accurate,
     assert_bit_identical,
+    collect_accuracy_and_determinism_results,
     assert_equal,
 )
 
@@ -188,51 +189,23 @@ def test_qkv_causal_conv1d_silu_contract(device: ttnn.Device, widths: tuple[int,
 @pytest.mark.parametrize("case", _PRODUCTION_CASES, ids=lambda case: case.case_id)
 def test_qkv_causal_conv1d_silu_is_device_deterministic(device: ttnn.Device, case: _ProductionCase) -> None:
     """Compare repeated large outputs on device; cache behavior is tested separately."""
-    _, (input_tt, history_tt, taps_tt) = _device_inputs(device, widths=case.widths)
+    host, (input_tt, history_tt, taps_tt) = _device_inputs(device, widths=case.widths)
+    expected = _reference(*host, case.widths)
 
     def run() -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
         with ttnn.manage_config("throw_exception_on_fallback", True):
             return _run(input_tt, history_tt, taps_tt, widths=case.widths)
 
-    reference_outputs = run()
-    mismatch_scratch = tuple(
-        ttnn.empty(
-            output.shape,
-            dtype=ttnn.bfloat16,
-            layout=output.layout,
-            device=device,
-            memory_config=output.memory_config(),
-        )
-        for output in reference_outputs
+    output_tensors, outputs, mismatch_marker = collect_accuracy_and_determinism_results(device, run)
+    assert_equal(
+        torch.zeros_like(mismatch_marker),
+        mismatch_marker,
+        name=f"{case.case_id} device-side exact-value determinism marker",
     )
-    mismatch_markers: list[ttnn.Tensor | None] = [None, None, None]
-    for _ in range(2):
-        current_outputs = run()
-        for index, (reference, current, scratch) in enumerate(
-            zip(reference_outputs, current_outputs, mismatch_scratch, strict=True)
-        ):
-            ttnn.ne(reference, current, dtype=ttnn.bfloat16, output_tensor=scratch)
-            current_marker = ttnn.max(scratch)
-            ttnn.deallocate(current)
-            if mismatch_markers[index] is None:
-                mismatch_markers[index] = current_marker
-            else:
-                updated_marker = ttnn.maximum(mismatch_markers[index], current_marker)
-                ttnn.deallocate(mismatch_markers[index])
-                ttnn.deallocate(current_marker)
-                mismatch_markers[index] = updated_marker
-
-    for name, marker in zip(("q", "k", "v"), mismatch_markers, strict=True):
-        assert marker is not None
-        marker_host = ttnn.to_torch(marker).clone()
-        assert_equal(
-            torch.zeros_like(marker_host),
-            marker_host,
-            name=f"{case.case_id} {name} device-side exact-value determinism marker",
-        )
-        ttnn.deallocate(marker)
-    for tensor in (*reference_outputs, *mismatch_scratch):
-        ttnn.deallocate(tensor)
+    for name, golden, output in zip(("q", "k", "v"), expected, outputs, strict=True):
+        assert_accurate(golden, output, name=f"{case.case_id} {name}", pcc_threshold=0.999)
+    for output in output_tensors:
+        ttnn.deallocate(output)
 
 
 def test_qkv_causal_conv1d_silu_cache_hit_rebinds_fresh_tensors(device: ttnn.Device) -> None:

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
@@ -39,15 +39,19 @@ class _ProductionCase:
 
 _PRODUCTION_PERF_MARGIN = 0.05
 
-# Calibrated 2026-08-18 on bh_loudbox host bh-lb-42, P150b firmware 19.5.0.0.
-# Seven real-time-profiler samples produced 92583-92681 ns, 50089-50210 ns,
-# and 55299-55348 ns respectively; the inline references are their medians.
-# The 5% symmetric margin covers the <1% observed spread plus board/thermal
-# variance while retaining a meaningful regression gate.
+# Recalibrated 2026-08-19 on Blackhole P150b device 0, firmware 19.5.0.0. The
+# previous references (92_606, 50_123, 55_324) were calibrated before the
+# hoisted unpack/init optimization, which made every shape 3.7-4.6% faster with
+# bit-identical outputs. Against a symmetric band that left each case only
+# 335-672 ns above its lower bound, so a further improvement would have failed
+# the gate for being too fast. Seven real-time-profiler samples of the current
+# implementation produced 88358-88443 ns, 47952-48257 ns, and 53230-53373 ns;
+# the inline references are their medians. The 5% symmetric margin now leaves
+# 2.2-4.4 us on both sides, against an observed spread of 85-305 ns.
 _PRODUCTION_CASES = (
-    _ProductionCase("single-block", widths=(512, 512, 512), expected_duration_ns=92_606),
-    _ProductionCase("multiple-blocks", widths=(1024, 1024, 1024), expected_duration_ns=50_123),
-    _ProductionCase("asymmetric-split", widths=(512, 256, 128), expected_duration_ns=55_324),
+    _ProductionCase("single-block", widths=(512, 512, 512), expected_duration_ns=88_383),
+    _ProductionCase("multiple-blocks", widths=(1024, 1024, 1024), expected_duration_ns=48_090),
+    _ProductionCase("asymmetric-split", widths=(512, 256, 128), expected_duration_ns=53_270),
 )
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
@@ -357,9 +357,9 @@ def test_qkv_causal_conv1d_silu_program_key_includes_split_widths(device: ttnn.D
         ("history_shape", r"history must be \[1,3,Q\+K\+V\]"),
         ("tap_last_dimension", r"tap2 last dimension must equal Q\+K\+V"),
         ("tap_volume", "tap2 logical volume must equal"),
-        ("input_layout", "input has unsupported layout"),
-        ("history_layout", "history has unsupported layout"),
-        ("tap_layout", "tap1 has unsupported layout"),
+        ("input_layout", "input must use ROW_MAJOR layout, got Layout::TILE"),
+        ("history_layout", "history must use ROW_MAJOR layout, got Layout::TILE"),
+        ("tap_layout", "tap1 must use TILE layout, got Layout::ROW_MAJOR"),
         ("input_dtype", "input must be BFLOAT16"),
         ("history_dtype", "history must be BFLOAT16"),
         ("tap_dtype", "tap3 must be BFLOAT16"),
@@ -440,5 +440,5 @@ def test_qkv_causal_conv1d_silu_rejects_sharded_output(device: ttnn.Device, expe
         ttnn.ShardOrientation.ROW_MAJOR,
     )
     sharded_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
-    with expect_error(RuntimeError, "output memory configuration must be interleaved"):
+    with expect_error(RuntimeError, "output memory layout must be INTERLEAVED, got HEIGHT_SHARDED"):
         _run(input_tt, history_tt, taps_tt, widths=(128, 128, 128), memory_config=sharded_config)

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
@@ -5,14 +5,21 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 
 import pytest
 import torch
 import torch.nn.functional as F
+from loguru import logger
 
 import ttnn
-from models.common.utility_functions import run_for_blackhole
-from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import assert_accurate, assert_bit_identical
+from models.common.utility_functions import run_for_blackhole, skip_with_llk_assert, skip_with_watcher
+from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program
+from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import (
+    assert_accurate,
+    assert_bit_identical,
+    assert_equal,
+)
 
 pytestmark = [
     run_for_blackhole(),
@@ -21,6 +28,27 @@ pytestmark = [
 
 _SEQUENCE = 64
 _DEFAULT_WIDTHS = (512, 512, 512)
+
+
+@dataclass(frozen=True)
+class _ProductionCase:
+    case_id: str
+    widths: tuple[int, int, int]
+    expected_duration_ns: int
+
+
+_PRODUCTION_PERF_MARGIN = 0.05
+
+# Calibrated 2026-08-18 on bh_loudbox host bh-lb-42, P150b firmware 19.5.0.0.
+# Seven real-time-profiler samples produced 92583-92681 ns, 50089-50210 ns,
+# and 55299-55348 ns respectively; the inline references are their medians.
+# The 5% symmetric margin covers the <1% observed spread plus board/thermal
+# variance while retaining a meaningful regression gate.
+_PRODUCTION_CASES = (
+    _ProductionCase("single-block", widths=(512, 512, 512), expected_duration_ns=92_606),
+    _ProductionCase("multiple-blocks", widths=(1024, 1024, 1024), expected_duration_ns=50_123),
+    _ProductionCase("asymmetric-split", widths=(512, 256, 128), expected_duration_ns=55_324),
+)
 
 
 def _host_inputs(
@@ -95,6 +123,7 @@ def _run(
     *,
     widths: tuple[int, int, int] = _DEFAULT_WIDTHS,
     memory_config: ttnn.MemoryConfig | None = None,
+    compute_kernel_config: ttnn.DeviceComputeKernelConfig | None = None,
 ) -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
     return ttnn.experimental.kda.qkv_causal_conv1d_silu(
         input_tt,
@@ -102,6 +131,7 @@ def _run(
         *taps_tt,
         *widths,
         memory_config=memory_config,
+        compute_kernel_config=compute_kernel_config,
     )
 
 
@@ -131,13 +161,6 @@ def test_qkv_causal_conv1d_silu_contract(device: ttnn.Device, widths: tuple[int,
         assert tuple(ttnn.to_torch(output).shape) == (1, _SEQUENCE, width)
         assert all(output.buffer_address() != tensor.buffer_address() for tensor in input_tensors)
 
-    cache_entries = device.num_program_cache_entries()
-    repeated_host, repeated_device = _device_inputs(device, widths=widths, seed=224)
-    repeated_expected = _reference(*repeated_host, widths)
-    repeated_outputs = run(*repeated_device)
-    ttnn.synchronize_device(device)
-    assert device.num_program_cache_entries() == cache_entries
-
     trace_id = ttnn.begin_trace_capture(device, cq_id=0)
     traced_outputs = run()
     ttnn.end_trace_capture(device, trace_id, cq_id=0)
@@ -145,12 +168,9 @@ def test_qkv_causal_conv1d_silu_contract(device: ttnn.Device, widths: tuple[int,
         ttnn.execute_trace(device, trace_id, cq_id=0, blocking=False)
     ttnn.synchronize_device(device)
 
-    for name, golden, repeated_golden, output, repeated, traced in zip(
-        ("q", "k", "v"), expected, repeated_expected, outputs, repeated_outputs, traced_outputs, strict=True
-    ):
+    for name, golden, output, traced in zip(("q", "k", "v"), expected, outputs, traced_outputs, strict=True):
         actual = ttnn.to_torch(output)
         assert_accurate(golden, actual, name=name, pcc_threshold=0.999)
-        assert_accurate(repeated_golden, ttnn.to_torch(repeated), name=f"{name} cache hit", pcc_threshold=0.999)
         assert_bit_identical(actual, ttnn.to_torch(traced), name=f"{name} trace replay")
 
     for name, before, tensor in zip(
@@ -159,6 +179,191 @@ def test_qkv_causal_conv1d_silu_contract(device: ttnn.Device, widths: tuple[int,
         assert_bit_identical(before, ttnn.to_torch(tensor), name=f"{name} immutability")
 
     ttnn.release_trace(device, trace_id)
+
+
+@pytest.mark.parametrize("case", _PRODUCTION_CASES, ids=lambda case: case.case_id)
+def test_qkv_causal_conv1d_silu_is_device_deterministic(device: ttnn.Device, case: _ProductionCase) -> None:
+    """Compare repeated large outputs on device; cache behavior is tested separately."""
+    _, (input_tt, history_tt, taps_tt) = _device_inputs(device, widths=case.widths)
+
+    def run() -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
+        with ttnn.manage_config("throw_exception_on_fallback", True):
+            return _run(input_tt, history_tt, taps_tt, widths=case.widths)
+
+    reference_outputs = run()
+    mismatch_scratch = tuple(
+        ttnn.empty(
+            output.shape,
+            dtype=ttnn.bfloat16,
+            layout=output.layout,
+            device=device,
+            memory_config=output.memory_config(),
+        )
+        for output in reference_outputs
+    )
+    mismatch_markers: list[ttnn.Tensor | None] = [None, None, None]
+    for _ in range(2):
+        current_outputs = run()
+        for index, (reference, current, scratch) in enumerate(
+            zip(reference_outputs, current_outputs, mismatch_scratch, strict=True)
+        ):
+            ttnn.ne(reference, current, dtype=ttnn.bfloat16, output_tensor=scratch)
+            current_marker = ttnn.max(scratch)
+            ttnn.deallocate(current)
+            if mismatch_markers[index] is None:
+                mismatch_markers[index] = current_marker
+            else:
+                updated_marker = ttnn.maximum(mismatch_markers[index], current_marker)
+                ttnn.deallocate(mismatch_markers[index])
+                ttnn.deallocate(current_marker)
+                mismatch_markers[index] = updated_marker
+
+    for name, marker in zip(("q", "k", "v"), mismatch_markers, strict=True):
+        assert marker is not None
+        marker_host = ttnn.to_torch(marker).clone()
+        assert_equal(
+            torch.zeros_like(marker_host),
+            marker_host,
+            name=f"{case.case_id} {name} device-side exact-value determinism marker",
+        )
+        ttnn.deallocate(marker)
+    for tensor in (*reference_outputs, *mismatch_scratch):
+        ttnn.deallocate(tensor)
+
+
+def test_qkv_causal_conv1d_silu_cache_hit_rebinds_fresh_tensors(device: ttnn.Device) -> None:
+    widths = (128, 128, 128)
+    host_a, device_inputs_a = _device_inputs(device, widths=widths, sequence=32, seed=1911)
+    host_b, device_inputs_b = _device_inputs(device, widths=widths, sequence=32, seed=1912)
+
+    output_a = _run(*device_inputs_a, widths=widths)
+    ttnn.synchronize_device(device)
+    entries = device.num_program_cache_entries()
+    output_b = _run(*device_inputs_b, widths=widths)
+    ttnn.synchronize_device(device)
+
+    flat_inputs_a = (device_inputs_a[0], device_inputs_a[1], *device_inputs_a[2])
+    flat_inputs_b = (device_inputs_b[0], device_inputs_b[1], *device_inputs_b[2])
+    assert device.num_program_cache_entries() == entries
+    assert all(
+        tensor_a.buffer_address() != tensor_b.buffer_address()
+        for tensor_a, tensor_b in zip(flat_inputs_a, flat_inputs_b, strict=True)
+    )
+    assert all(
+        tensor_a.buffer_address() != tensor_b.buffer_address()
+        for tensor_a, tensor_b in zip(output_a, output_b, strict=True)
+    )
+
+    expected_a = _reference(*host_a, widths)
+    expected_b = _reference(*host_b, widths)
+    for name, golden_a, golden_b, actual_a_tt, actual_b_tt in zip(
+        ("q", "k", "v"), expected_a, expected_b, output_a, output_b, strict=True
+    ):
+        actual_a = ttnn.to_torch(actual_a_tt)
+        actual_b = ttnn.to_torch(actual_b_tt)
+        assert_accurate(golden_a, actual_a, name=f"{name} cache miss tensors", pcc_threshold=0.999)
+        assert_accurate(golden_b, actual_b, name=f"{name} cache hit fresh tensors", pcc_threshold=0.999)
+        assert not torch.equal(actual_a, actual_b)
+
+
+def test_qkv_causal_conv1d_silu_default_compute_config_matches_explicit_defaults(device: ttnn.Device) -> None:
+    _, (input_tt, history_tt, taps_tt) = _device_inputs(device, sequence=32, widths=(128, 128, 128), seed=817)
+    implicit = _run(input_tt, history_tt, taps_tt, widths=(128, 128, 128))
+    entries = device.num_program_cache_entries()
+    explicit_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=True,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+        dst_full_sync_en=False,
+        throttle_level=ttnn.ThrottleLevel.NO_THROTTLE,
+    )
+    explicit = _run(
+        input_tt,
+        history_tt,
+        taps_tt,
+        widths=(128, 128, 128),
+        compute_kernel_config=explicit_config,
+    )
+    assert device.num_program_cache_entries() == entries
+    for name, implicit_output, explicit_output in zip(("q", "k", "v"), implicit, explicit, strict=True):
+        assert_bit_identical(
+            ttnn.to_torch(implicit_output),
+            ttnn.to_torch(explicit_output),
+            name=f"{name} implicit vs explicit production compute defaults",
+        )
+
+
+def test_qkv_causal_conv1d_silu_exact_math_uses_distinct_accurate_program(device: ttnn.Device) -> None:
+    host, (input_tt, history_tt, taps_tt) = _device_inputs(device, sequence=32, widths=(128, 128, 128), seed=818)
+    approximate = _run(input_tt, history_tt, taps_tt, widths=(128, 128, 128))
+    entries = device.num_program_cache_entries()
+    exact_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+    exact = _run(
+        input_tt,
+        history_tt,
+        taps_tt,
+        widths=(128, 128, 128),
+        compute_kernel_config=exact_config,
+    )
+    assert device.num_program_cache_entries() == entries + 1
+    expected = _reference(*host, (128, 128, 128))
+    for name, golden, approximate_output, exact_output in zip(
+        ("q", "k", "v"), expected, approximate, exact, strict=True
+    ):
+        assert_accurate(golden, ttnn.to_torch(approximate_output), name=f"{name} approximate math", pcc_threshold=0.999)
+        assert_accurate(golden, ttnn.to_torch(exact_output), name=f"{name} exact math", pcc_threshold=0.999)
+
+
+def test_qkv_causal_conv1d_silu_rejects_unsupported_compute_config(device: ttnn.Device, expect_error: Callable) -> None:
+    _, (input_tt, history_tt, taps_tt) = _device_inputs(device, sequence=32, widths=(128, 128, 128))
+    unsupported_config = ttnn.types.BlackholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        packer_l1_acc=True,
+    )
+    with expect_error(RuntimeError, "packer_l1_acc=true is unsupported"):
+        _run(
+            input_tt,
+            history_tt,
+            taps_tt,
+            widths=(128, 128, 128),
+            compute_kernel_config=unsupported_config,
+        )
+
+
+@pytest.mark.requires_host_iommu
+@pytest.mark.parametrize("case", _PRODUCTION_CASES, ids=lambda case: case.case_id)
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
+@skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
+def test_qkv_causal_conv1d_silu_production_performance(device: ttnn.Device, case: _ProductionCase) -> None:
+    if not ttnn.device.IsProgramRealtimeProfilerActive():
+        pytest.fail("Real-time profiler must be active for QKV causal Conv1D plus SiLU performance checks")
+
+    _, (input_tt, history_tt, taps_tt) = _device_inputs(device, widths=case.widths)
+
+    def run() -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
+        return _run(input_tt, history_tt, taps_tt, widths=case.widths)
+
+    outputs, perf_record = profile_realtime_program(device, run)
+    duration_ns = perf_record["duration_ns"]
+    assert tuple(tuple(output.shape) for output in outputs) == tuple((1, _SEQUENCE, width) for width in case.widths)
+    logger.info(
+        f"QKV causal Conv1D plus SiLU {case.case_id}: duration={duration_ns:.0f} ns, "
+        f"profiler_runtime_id={perf_record['runtime_id']}"
+    )
+    lower = case.expected_duration_ns * (1 - _PRODUCTION_PERF_MARGIN)
+    upper = case.expected_duration_ns * (1 + _PRODUCTION_PERF_MARGIN)
+    assert lower <= duration_ns <= upper, (
+        f"{case.case_id} duration {duration_ns:.0f} ns outside [{lower:.0f}, {upper:.0f}] ns "
+        f"(reference {case.expected_duration_ns} ns, margin +/- {_PRODUCTION_PERF_MARGIN * 100:.0f}%)"
+    )
 
 
 def test_qkv_causal_conv1d_silu_program_key_includes_split_widths(device: ttnn.Device) -> None:

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
@@ -150,16 +150,12 @@ def test_qkv_causal_conv1d_silu_contract(device: ttnn.Device, widths: tuple[int,
     input_tensors = (input_tt, history_tt, *taps_tt)
     snapshots = tuple(ttnn.to_torch(tensor).clone() for tensor in input_tensors)
 
-    def run(
-        current_input: ttnn.Tensor = input_tt,
-        current_history: ttnn.Tensor = history_tt,
-        current_taps: tuple[ttnn.Tensor, ...] = taps_tt,
-    ) -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
+    def run() -> tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]:
         with ttnn.manage_config("throw_exception_on_fallback", True):
-            return _run(current_input, current_history, current_taps, widths=widths)
+            return _run(input_tt, history_tt, taps_tt, widths=widths)
 
     outputs = run()
-    for name, output, width in zip(("q", "k", "v"), outputs, widths, strict=True):
+    for output, width in zip(outputs, widths, strict=True):
         assert output.dtype == ttnn.bfloat16
         assert output.layout == ttnn.TILE_LAYOUT
         assert output.memory_config() == ttnn.DRAM_MEMORY_CONFIG

--- a/tests/ttnn/unit_tests/operations/experimental/kda/kda_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/experimental/kda/kda_test_utils.py
@@ -3,8 +3,10 @@
 """Dependency-light numerical assertions shared by KDA tests."""
 
 from __future__ import annotations
+from collections.abc import Callable, Sequence
 
 import torch
+import ttnn
 
 
 def _finiteness(name: str, tensor: torch.Tensor) -> tuple[list[str], str]:
@@ -87,3 +89,63 @@ def assert_bit_identical(expected: torch.Tensor, actual: torch.Tensor, *, name: 
     actual_bytes = actual.detach().contiguous().reshape(-1).view(torch.uint8)
     if not torch.equal(expected_bytes, actual_bytes):
         raise AssertionError(f"{name} bit patterns differ")
+
+
+def collect_accuracy_and_determinism_results(
+    device: ttnn.Device,
+    run: Callable[[], Sequence[ttnn.Tensor]],
+    *,
+    count: int = 3,
+) -> tuple[tuple[ttnn.Tensor, ...], tuple[torch.Tensor, ...], torch.Tensor]:
+    """Run repeatedly, retaining only first outputs and one device-side mismatch marker."""
+    if count <= 1:
+        raise ValueError("count must be greater than one")
+
+    reference_outputs = tuple(run())
+    if not reference_outputs:
+        raise ValueError("run must return at least one output")
+    mismatch_scratch = tuple(
+        ttnn.empty(
+            output.shape,
+            dtype=ttnn.bfloat16,
+            layout=output.layout,
+            device=device,
+            memory_config=output.memory_config(),
+        )
+        for output in reference_outputs
+    )
+    mismatch_marker = None
+    for _ in range(1, count):
+        outputs = tuple(run())
+        if len(outputs) != len(reference_outputs):
+            for output in outputs:
+                ttnn.deallocate(output)
+            raise ValueError("run returned a different number of outputs")
+        for reference, output, scratch in zip(reference_outputs, outputs, mismatch_scratch, strict=True):
+            if (
+                output.shape != reference.shape
+                or output.dtype != reference.dtype
+                or output.layout != reference.layout
+                or output.memory_config() != reference.memory_config()
+            ):
+                for repeat_output in outputs:
+                    ttnn.deallocate(repeat_output)
+                raise ValueError("run returned output with different metadata")
+            ttnn.ne(reference, output, dtype=ttnn.bfloat16, output_tensor=scratch)
+            current_mismatch = ttnn.max(scratch)
+            ttnn.deallocate(output)
+            if mismatch_marker is None:
+                mismatch_marker = current_mismatch
+            else:
+                updated_marker = ttnn.maximum(mismatch_marker, current_mismatch)
+                ttnn.deallocate(mismatch_marker)
+                ttnn.deallocate(current_mismatch)
+                mismatch_marker = updated_marker
+
+    assert mismatch_marker is not None
+    reference_outputs_host = tuple(ttnn.to_torch(output).clone() for output in reference_outputs)
+    mismatch_marker_host = ttnn.to_torch(mismatch_marker).clone()
+    for scratch in mismatch_scratch:
+        ttnn.deallocate(scratch)
+    ttnn.deallocate(mismatch_marker)
+    return reference_outputs, reference_outputs_host, mismatch_marker_host

--- a/tests/ttnn/unit_tests/operations/experimental/kda/test_kda_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/experimental/kda/test_kda_test_utils.py
@@ -3,11 +3,13 @@
 
 import pytest
 import torch
+import ttnn
 
 from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import (
     assert_accurate,
     assert_bit_identical,
     assert_equal,
+    collect_accuracy_and_determinism_results,
 )
 
 
@@ -61,3 +63,140 @@ def test_assert_accurate_returns_measured_pcc() -> None:
     actual = expected + torch.linspace(0.0, 1e-4, 8)
     pcc = assert_accurate(expected, actual, pcc_threshold=0.999999)
     assert 0.999999 <= pcc <= 1.0
+
+
+class _FakeDeviceTensor:
+    def __init__(
+        self,
+        values: torch.Tensor,
+        *,
+        dtype: object = "float32",
+        layout: object = "tile",
+        memory_config: object = "dram",
+    ) -> None:
+        self.values = values.clone()
+        self.shape = self.values.shape
+        self.dtype = dtype
+        self.layout = layout
+        self._memory_config = memory_config
+
+    def memory_config(self) -> object:
+        return self._memory_config
+
+
+@pytest.fixture
+def fake_device_ttnn(monkeypatch):
+    calls = {"empty": [], "deallocate": [], "to_torch": []}
+
+    def make(
+        values: list[float],
+        *,
+        shape: tuple[int, ...] | None = None,
+        dtype: object = "float32",
+        layout: object = "tile",
+        memory_config: object = "dram",
+    ) -> _FakeDeviceTensor:
+        tensor = torch.tensor(values, dtype=torch.float32)
+        return _FakeDeviceTensor(
+            tensor.reshape(shape or tensor.shape), dtype=dtype, layout=layout, memory_config=memory_config
+        )
+
+    def empty(shape, *, dtype, layout, device, memory_config):
+        del device
+        output = _FakeDeviceTensor(torch.zeros(tuple(shape)), dtype=dtype, layout=layout, memory_config=memory_config)
+        calls["empty"].append(output)
+        return output
+
+    def ne(reference, actual, *, dtype, output_tensor):
+        del dtype
+        output_tensor.values.copy_(reference.values.ne(actual.values))
+        return output_tensor
+
+    def maximum(lhs, rhs):
+        return make([max(lhs.values.item(), rhs.values.item())])
+
+    def to_torch(tensor):
+        calls["to_torch"].append(tensor)
+        return tensor.values
+
+    monkeypatch.setattr(ttnn, "empty", empty)
+    monkeypatch.setattr(ttnn, "ne", ne)
+    monkeypatch.setattr(ttnn, "max", lambda tensor: make([tensor.values.max().item()]))
+    monkeypatch.setattr(ttnn, "maximum", maximum)
+    monkeypatch.setattr(ttnn, "deallocate", calls["deallocate"].append)
+    monkeypatch.setattr(ttnn, "to_torch", to_torch)
+    return make, calls
+
+
+def test_collect_accuracy_and_determinism_rejects_invalid_count_before_run(fake_device_ttnn, expect_error) -> None:
+    del fake_device_ttnn
+    invoked = False
+
+    def run():
+        nonlocal invoked
+        invoked = True
+        return ()
+
+    with expect_error(ValueError, "greater than one"):
+        collect_accuracy_and_determinism_results(object(), run, count=1)
+    assert not invoked
+
+
+def test_collect_accuracy_and_determinism_rejects_empty_outputs(fake_device_ttnn, expect_error) -> None:
+    del fake_device_ttnn
+    with expect_error(ValueError, "at least one"):
+        collect_accuracy_and_determinism_results(object(), lambda: ())
+
+
+def test_collect_accuracy_and_determinism_rejects_changed_arity(fake_device_ttnn, expect_error) -> None:
+    make, calls = fake_device_ttnn
+    repeat_outputs = (make([1.0]), make([2.0]))
+    runs = iter(((make([1.0]),), repeat_outputs))
+    with expect_error(ValueError, "different number"):
+        collect_accuracy_and_determinism_results(object(), lambda: next(runs), count=2)
+    assert all(output in calls["deallocate"] for output in repeat_outputs)
+
+
+@pytest.mark.parametrize("field", ["shape", "dtype", "layout", "memory_config"])
+def test_collect_accuracy_and_determinism_rejects_changed_metadata(fake_device_ttnn, field: str, expect_error) -> None:
+    make, calls = fake_device_ttnn
+    reference = make([1.0, 2.0])
+    kwargs = {}
+    values = [1.0, 2.0]
+    if field == "shape":
+        values = [1.0]
+    else:
+        kwargs[field] = "different"
+    repeat = make(values, **kwargs)
+    runs = iter(((reference,), (repeat,)))
+    with expect_error(ValueError, "different metadata"):
+        collect_accuracy_and_determinism_results(object(), lambda: next(runs), count=2)
+    assert repeat in calls["deallocate"]
+
+
+def test_collect_accuracy_and_determinism_aggregates_multiple_outputs(fake_device_ttnn) -> None:
+    make, calls = fake_device_ttnn
+    reference = (make([1.0, 2.0]), make([3.0], shape=(1, 1)))
+    repeat_one = (make([1.0, 2.0]), make([3.0], shape=(1, 1)))
+    repeat_two = (make([1.0, 2.0]), make([3.0], shape=(1, 1)))
+    runs = iter((reference, repeat_one, repeat_two))
+
+    device_outputs, host_outputs, marker = collect_accuracy_and_determinism_results(
+        object(), lambda: next(runs), count=3
+    )
+
+    assert device_outputs == reference
+    assert all(torch.equal(host, expected.values) for host, expected in zip(host_outputs, reference, strict=True))
+    assert marker.item() == 0
+    assert len(calls["empty"]) == len(reference)
+    assert calls["to_torch"][: len(reference)] == list(reference)
+    assert all(output in calls["deallocate"] for output in (*repeat_one, *repeat_two))
+
+
+def test_collect_accuracy_and_determinism_reports_any_output_mismatch(fake_device_ttnn) -> None:
+    make, _ = fake_device_ttnn
+    runs = iter(((make([1.0]), make([2.0])), (make([1.0]), make([3.0]))))
+
+    _, _, marker = collect_accuracy_and_determinism_results(object(), lambda: next(runs), count=2)
+
+    assert marker.item() == 1

--- a/ttnn/cpp/ttnn/operations/experimental/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/CMakeLists.txt
@@ -34,6 +34,7 @@ add_subdirectory(reduction)
 add_subdirectory(high_bw_all_gather)
 add_subdirectory(indexer_score)
 add_subdirectory(kda/sigmoid_gated_rms_norm)
+add_subdirectory(kda/qkv_causal_conv1d_silu)
 add_subdirectory(topk_large_indices)
 
 # metallium-maintainers-llama-models
@@ -92,6 +93,7 @@ target_link_libraries(
         TTNN::Ops::Experimental::HighBwAllGather
         TTNN::Ops::Experimental::IndexerScore
         TTNN::Ops::Experimental::KDA::SigmoidGatedRMSNorm
+        TTNN::Ops::Experimental::KDA::QkvCausalConv1dSilu
         TTNN::Ops::Experimental::TopkLargeIndices
         TTNN::Ops::Experimental::PagedCache
         TTNN::Ops::Experimental::IsIn
@@ -143,6 +145,7 @@ target_sources(
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::HighBwAllGather>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::IndexerScore>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::KDA::SigmoidGatedRMSNorm>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::KDA::QkvCausalConv1dSilu>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::TopkLargeIndices>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::PagedCache>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::IsIn>

--- a/ttnn/cpp/ttnn/operations/experimental/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/CMakeLists.txt
@@ -33,8 +33,7 @@ add_subdirectory(reduction)
 # metalium-developers-sdpa
 add_subdirectory(high_bw_all_gather)
 add_subdirectory(indexer_score)
-add_subdirectory(kda/sigmoid_gated_rms_norm)
-add_subdirectory(kda/qkv_causal_conv1d_silu)
+add_subdirectory(kda)
 add_subdirectory(topk_large_indices)
 
 # metallium-maintainers-llama-models
@@ -92,8 +91,7 @@ target_link_libraries(
         TTNN::Ops::Experimental::Reduction
         TTNN::Ops::Experimental::HighBwAllGather
         TTNN::Ops::Experimental::IndexerScore
-        TTNN::Ops::Experimental::KDA::SigmoidGatedRMSNorm
-        TTNN::Ops::Experimental::KDA::QkvCausalConv1dSilu
+        TTNN::Ops::Experimental::KDA
         TTNN::Ops::Experimental::TopkLargeIndices
         TTNN::Ops::Experimental::PagedCache
         TTNN::Ops::Experimental::IsIn
@@ -144,8 +142,6 @@ target_sources(
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::Reduction>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::HighBwAllGather>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::IndexerScore>
-        $<TARGET_OBJECTS:TTNN::Ops::Experimental::KDA::SigmoidGatedRMSNorm>
-        $<TARGET_OBJECTS:TTNN::Ops::Experimental::KDA::QkvCausalConv1dSilu>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::TopkLargeIndices>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::PagedCache>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::IsIn>

--- a/ttnn/cpp/ttnn/operations/experimental/kda/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/CMakeLists.txt
@@ -1,0 +1,36 @@
+# KDA-domain build ownership. Shared utilities are compiled once in Common;
+# operation leaves consume Common and are exported through one domain umbrella.
+add_library(ttnn_op_experimental_kda_common ${LIB_TYPE})
+add_library(TTNN::Ops::Experimental::KDA::Common ALIAS ttnn_op_experimental_kda_common)
+
+tt_reuse_precompile_headers(ttnn_op_experimental_kda_common TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_kda_common)
+
+target_sources(ttnn_op_experimental_kda_common PRIVATE factory/kda_factory_utils.cpp)
+target_include_directories(ttnn_op_experimental_kda_common PRIVATE ${FixmeOpAPIDir})
+target_link_libraries(ttnn_op_experimental_kda_common PRIVATE TT::Metalium PUBLIC TTNN::Core)
+install(TARGETS ttnn_op_experimental_kda_common LIBRARY COMPONENT tar)
+
+add_subdirectory(sigmoid_gated_rms_norm)
+add_subdirectory(qkv_causal_conv1d_silu)
+
+add_library(ttnn_op_experimental_kda INTERFACE)
+add_library(TTNN::Ops::Experimental::KDA ALIAS ttnn_op_experimental_kda)
+target_link_libraries(
+    ttnn_op_experimental_kda
+    INTERFACE
+        TTNN::Ops::Experimental::KDA::Common
+        TTNN::Ops::Experimental::KDA::SigmoidGatedRMSNorm
+        TTNN::Ops::Experimental::KDA::QkvCausalConv1dSilu
+)
+
+# OBJECT libraries do not propagate their compiled objects through a nested
+# INTERFACE link. Inject each KDA object set here exactly once; these generator
+# expressions are empty when the corresponding target is a shared library.
+target_sources(
+    ttnn_op_experimental_kda
+    INTERFACE
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::KDA::Common>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::KDA::SigmoidGatedRMSNorm>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::KDA::QkvCausalConv1dSilu>
+)

--- a/ttnn/cpp/ttnn/operations/experimental/kda/factory/kda_factory_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/factory/kda_factory_utils.cpp
@@ -5,25 +5,10 @@
 
 #include <algorithm>
 #include <set>
-#include <tuple>
 
 #include <tt_stl/assert.hpp>
 
 namespace ttnn::experimental::prim::kda_factory_detail {
-
-tt::tt_metal::ComputeConfigDescriptor kda_compute_cfg(
-    tt::ARCH arch, const DeviceComputeKernelConfig& config, bool honor_caller_config) {
-    if (!honor_caller_config) {
-        return tt::tt_metal::ComputeConfigDescriptor{
-            .math_fidelity = tt::tt_metal::MathFidelity::HiFi4, .fp32_dest_acc_en = true, .math_approx_mode = false};
-    }
-    const auto args = get_compute_kernel_config_args(arch, config);
-    return tt::tt_metal::ComputeConfigDescriptor{
-        .math_fidelity = std::get<0>(args),
-        .fp32_dest_acc_en = std::get<2>(args),
-        .dst_full_sync_en = std::get<4>(args),
-        .math_approx_mode = std::get<1>(args)};
-}
 
 KdaPrepWorkDist distribute_prep(tt::tt_metal::CoreCoord grid, uint32_t total, uint32_t core_cap) {
     const uint32_t max_cores = std::min<uint32_t>(grid.x * grid.y, core_cap);

--- a/ttnn/cpp/ttnn/operations/experimental/kda/factory/kda_factory_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/factory/kda_factory_utils.cpp
@@ -4,11 +4,107 @@
 #include "kda_factory_utils.hpp"
 
 #include <algorithm>
+#include <enchantum/enchantum.hpp>
 #include <set>
 
 #include <tt_stl/assert.hpp>
 
 namespace ttnn::experimental::prim::kda_factory_detail {
+
+void check_allocated_device_tensor(
+    const Tensor& tensor, std::string_view operation_name, std::string_view tensor_name) {
+    TT_FATAL(
+        tensor.storage_type() == StorageType::DEVICE && tensor.buffer() != nullptr,
+        "{}: {} must be an allocated device tensor",
+        operation_name,
+        tensor_name);
+}
+
+void check_layout(
+    const Tensor& tensor,
+    tt::tt_metal::Layout required_layout,
+    std::string_view operation_name,
+    std::string_view tensor_name) {
+    TT_FATAL(
+        tensor.layout() == required_layout,
+        "{}: {} must use {} layout, got {}",
+        operation_name,
+        tensor_name,
+        enchantum::to_string(required_layout),
+        tensor.layout());
+}
+
+void check_dtype(
+    const Tensor& tensor,
+    tt::tt_metal::DataType required_dtype,
+    std::string_view operation_name,
+    std::string_view tensor_name) {
+    TT_FATAL(
+        tensor.dtype() == required_dtype,
+        "{}: {} must be {}, got {}",
+        operation_name,
+        tensor_name,
+        enchantum::to_string(required_dtype),
+        tensor.dtype());
+}
+
+void check_dtype_in(
+    const Tensor& tensor,
+    std::span<const tt::tt_metal::DataType> accepted_dtypes,
+    std::string_view accepted_dtype_names,
+    std::string_view operation_name,
+    std::string_view tensor_name) {
+    TT_FATAL(!accepted_dtypes.empty(), "{}: accepted dtype set must not be empty", operation_name);
+    TT_FATAL(
+        std::find(accepted_dtypes.begin(), accepted_dtypes.end(), tensor.dtype()) != accepted_dtypes.end(),
+        "{}: {} must be {}, got {}",
+        operation_name,
+        tensor_name,
+        accepted_dtype_names,
+        tensor.dtype());
+}
+
+void check_matching_dtype(
+    const Tensor& lhs, const Tensor& rhs, std::string_view operation_name, std::string_view tensor_group_name) {
+    TT_FATAL(
+        lhs.dtype() == rhs.dtype(),
+        "{}: {} must have matching dtypes, got {} and {}",
+        operation_name,
+        tensor_group_name,
+        lhs.dtype(),
+        rhs.dtype());
+}
+
+void check_same_device(
+    const Tensor& reference,
+    const Tensor& candidate,
+    std::string_view operation_name,
+    std::string_view candidate_name) {
+    TT_FATAL(
+        candidate.device() == reference.device(),
+        "{}: {} must be on the same device as the other inputs",
+        operation_name,
+        candidate_name);
+}
+
+void check_interleaved(const Tensor& tensor, std::string_view operation_name, std::string_view tensor_name) {
+    TT_FATAL(!tensor.is_sharded(), "{}: {} must use interleaved memory", operation_name, tensor_name);
+}
+
+void check_output_interleaved(const tt::tt_metal::MemoryConfig& memory_config, std::string_view operation_name) {
+    TT_FATAL(
+        !memory_config.is_sharded(),
+        "{}: output memory layout must be INTERLEAVED, got {}",
+        operation_name,
+        enchantum::to_string(memory_config.memory_layout()));
+}
+
+void check_compute_config(const DeviceComputeKernelConfig& config, std::string_view operation_name) {
+    TT_FATAL(
+        !config.packer_l1_acc,
+        "{}: packer_l1_acc=true is unsupported because the compute kernel does not accumulate through L1",
+        operation_name);
+}
 
 KdaPrepWorkDist distribute_prep(tt::tt_metal::CoreCoord grid, uint32_t total, uint32_t core_cap) {
     const uint32_t max_cores = std::min<uint32_t>(grid.x * grid.y, core_cap);

--- a/ttnn/cpp/ttnn/operations/experimental/kda/factory/kda_factory_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/factory/kda_factory_utils.cpp
@@ -21,6 +21,7 @@ tt::tt_metal::ComputeConfigDescriptor kda_compute_cfg(
     return tt::tt_metal::ComputeConfigDescriptor{
         .math_fidelity = std::get<0>(args),
         .fp32_dest_acc_en = std::get<2>(args),
+        .dst_full_sync_en = std::get<4>(args),
         .math_approx_mode = std::get<1>(args)};
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/kda/factory/kda_factory_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/factory/kda_factory_utils.cpp
@@ -5,10 +5,24 @@
 
 #include <algorithm>
 #include <set>
+#include <tuple>
 
 #include <tt_stl/assert.hpp>
 
 namespace ttnn::experimental::prim::kda_factory_detail {
+
+tt::tt_metal::ComputeConfigDescriptor kda_compute_cfg(
+    tt::ARCH arch, const DeviceComputeKernelConfig& config, bool honor_caller_config) {
+    if (!honor_caller_config) {
+        return tt::tt_metal::ComputeConfigDescriptor{
+            .math_fidelity = tt::tt_metal::MathFidelity::HiFi4, .fp32_dest_acc_en = true, .math_approx_mode = false};
+    }
+    const auto args = get_compute_kernel_config_args(arch, config);
+    return tt::tt_metal::ComputeConfigDescriptor{
+        .math_fidelity = std::get<0>(args),
+        .fp32_dest_acc_en = std::get<2>(args),
+        .math_approx_mode = std::get<1>(args)};
+}
 
 KdaPrepWorkDist distribute_prep(tt::tt_metal::CoreCoord grid, uint32_t total, uint32_t core_cap) {
     const uint32_t max_cores = std::min<uint32_t>(grid.x * grid.y, core_cap);

--- a/ttnn/cpp/ttnn/operations/experimental/kda/factory/kda_factory_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/factory/kda_factory_utils.hpp
@@ -3,11 +3,41 @@
 
 #pragma once
 
+#include <span>
+#include <string_view>
 #include <vector>
 
 #include <tt-metalium/core_coord.hpp>
 
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
 namespace ttnn::experimental::prim::kda_factory_detail {
+
+void check_allocated_device_tensor(const Tensor& tensor, std::string_view operation_name, std::string_view tensor_name);
+void check_layout(
+    const Tensor& tensor,
+    tt::tt_metal::Layout required_layout,
+    std::string_view operation_name,
+    std::string_view tensor_name);
+void check_dtype(
+    const Tensor& tensor,
+    tt::tt_metal::DataType required_dtype,
+    std::string_view operation_name,
+    std::string_view tensor_name);
+void check_dtype_in(
+    const Tensor& tensor,
+    std::span<const tt::tt_metal::DataType> accepted_dtypes,
+    std::string_view accepted_dtype_names,
+    std::string_view operation_name,
+    std::string_view tensor_name);
+void check_matching_dtype(
+    const Tensor& lhs, const Tensor& rhs, std::string_view operation_name, std::string_view tensor_group_name);
+void check_same_device(
+    const Tensor& reference, const Tensor& candidate, std::string_view operation_name, std::string_view candidate_name);
+void check_interleaved(const Tensor& tensor, std::string_view operation_name, std::string_view tensor_name);
+void check_output_interleaved(const tt::tt_metal::MemoryConfig& memory_config, std::string_view operation_name);
+void check_compute_config(const DeviceComputeKernelConfig& config, std::string_view operation_name);
 
 struct KdaPrepWorkDist {
     std::vector<tt::tt_metal::CoreCoord> cores;

--- a/ttnn/cpp/ttnn/operations/experimental/kda/factory/kda_factory_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/factory/kda_factory_utils.hpp
@@ -6,14 +6,8 @@
 #include <vector>
 
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-
-#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 namespace ttnn::experimental::prim::kda_factory_detail {
-
-tt::tt_metal::ComputeConfigDescriptor kda_compute_cfg(
-    tt::ARCH arch, const DeviceComputeKernelConfig& config, bool honor_caller_config = true);
 
 struct KdaPrepWorkDist {
     std::vector<tt::tt_metal::CoreCoord> cores;

--- a/ttnn/cpp/ttnn/operations/experimental/kda/factory/kda_factory_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/factory/kda_factory_utils.hpp
@@ -6,8 +6,14 @@
 #include <vector>
 
 #include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
 namespace ttnn::experimental::prim::kda_factory_detail {
+
+tt::tt_metal::ComputeConfigDescriptor kda_compute_cfg(
+    tt::ARCH arch, const DeviceComputeKernelConfig& config, bool honor_caller_config = true);
 
 struct KdaPrepWorkDist {
     std::vector<tt::tt_metal::CoreCoord> cores;

--- a/ttnn/cpp/ttnn/operations/experimental/kda/kda_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/kda_nanobind.cpp
@@ -5,12 +5,14 @@
 
 #include <nanobind/nanobind.h>
 
+#include "ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/qkv_causal_conv1d_silu_nanobind.hpp"
 #include "ttnn/operations/experimental/kda/sigmoid_gated_rms_norm/sigmoid_gated_rms_norm_nanobind.hpp"
 
 namespace ttnn::operations::experimental::kda::detail {
 
 void bind_kda(nb::module_& mod) {
     auto kda_module = mod.def_submodule("kda", "Experimental KDA operations");
+    qkv_causal_conv1d_silu::detail::bind_qkv_causal_conv1d_silu(kda_module);
     sigmoid_gated_rms_norm::detail::bind_sigmoid_gated_rms_norm(kda_module);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/CMakeLists.txt
@@ -13,6 +13,8 @@ set_target_properties(
             api
 )
 
+file(GLOB_RECURSE kernels device/kernels/*.cpp)
+
 target_sources(
     ttnn_op_experimental_kda_qkv_causal_conv1d_silu
     PUBLIC
@@ -20,12 +22,26 @@ target_sources(
         TYPE HEADERS
         BASE_DIRS ${FixmeOpAPIDir}
         FILES ${TTNN_OP_EXPERIMENTAL_KDA_QKV_CAUSAL_CONV1D_SILU_API_HEADERS}
+        FILE_SET kernels
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        FILES ${kernels}
     PRIVATE
         ${TTNN_OP_EXPERIMENTAL_KDA_QKV_CAUSAL_CONV1D_SILU_SRCS}
         ${TTNN_OP_EXPERIMENTAL_KDA_SHARED_SRCS}
 )
 
 target_link_libraries(ttnn_op_experimental_kda_qkv_causal_conv1d_silu PRIVATE TT::Metalium PUBLIC TTNN::Core)
+
+install(
+    TARGETS
+        ttnn_op_experimental_kda_qkv_causal_conv1d_silu
+    FILE_SET
+    kernels
+        DESTINATION
+            ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu
+        COMPONENT ttnn-runtime
+)
 
 install(TARGETS ttnn_op_experimental_kda_qkv_causal_conv1d_silu FILE_SET api COMPONENT ttnn-dev LIBRARY COMPONENT tar)
 

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/CMakeLists.txt
@@ -1,0 +1,34 @@
+include(sources.cmake)
+
+add_library(ttnn_op_experimental_kda_qkv_causal_conv1d_silu ${LIB_TYPE})
+add_library(TTNN::Ops::Experimental::KDA::QkvCausalConv1dSilu ALIAS ttnn_op_experimental_kda_qkv_causal_conv1d_silu)
+
+tt_reuse_precompile_headers(ttnn_op_experimental_kda_qkv_causal_conv1d_silu TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_kda_qkv_causal_conv1d_silu)
+
+set_target_properties(
+    ttnn_op_experimental_kda_qkv_causal_conv1d_silu
+    PROPERTIES
+        INTERFACE_HEADER_SETS_TO_VERIFY
+            api
+)
+
+target_sources(
+    ttnn_op_experimental_kda_qkv_causal_conv1d_silu
+    PUBLIC
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS ${FixmeOpAPIDir}
+        FILES ${TTNN_OP_EXPERIMENTAL_KDA_QKV_CAUSAL_CONV1D_SILU_API_HEADERS}
+    PRIVATE
+        ${TTNN_OP_EXPERIMENTAL_KDA_QKV_CAUSAL_CONV1D_SILU_SRCS}
+        ${TTNN_OP_EXPERIMENTAL_KDA_SHARED_SRCS}
+)
+
+target_link_libraries(ttnn_op_experimental_kda_qkv_causal_conv1d_silu PRIVATE TT::Metalium PUBLIC TTNN::Core)
+
+install(TARGETS ttnn_op_experimental_kda_qkv_causal_conv1d_silu FILE_SET api COMPONENT ttnn-dev LIBRARY COMPONENT tar)
+
+if(TARGET ttnn)
+    target_sources(ttnn PRIVATE ${TTNN_OP_EXPERIMENTAL_KDA_QKV_CAUSAL_CONV1D_SILU_NANOBIND_SRCS})
+endif()

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/CMakeLists.txt
@@ -28,10 +28,16 @@ target_sources(
         FILES ${kernels}
     PRIVATE
         ${TTNN_OP_EXPERIMENTAL_KDA_QKV_CAUSAL_CONV1D_SILU_SRCS}
-        ${TTNN_OP_EXPERIMENTAL_KDA_SHARED_SRCS}
 )
 
-target_link_libraries(ttnn_op_experimental_kda_qkv_causal_conv1d_silu PRIVATE TT::Metalium PUBLIC TTNN::Core)
+target_link_libraries(
+    ttnn_op_experimental_kda_qkv_causal_conv1d_silu
+    PRIVATE
+        TT::Metalium
+        TTNN::Ops::Experimental::KDA::Common
+    PUBLIC
+        TTNN::Core
+)
 
 install(
     TARGETS

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/compute/qkv_causal_conv1d_silu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/compute/qkv_causal_conv1d_silu.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/compute/tilize.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/bcast.h"
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/reconfig_data_format.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
+
+void kernel_main() {
+    constexpr uint32_t block_ct = get_compile_time_arg_val(0);
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(1);
+    constexpr uint32_t act_rm_cb = 0;
+    constexpr uint32_t act_tile_cb = 1;
+    constexpr uint32_t weights_cb = 2;
+    constexpr uint32_t partial_a_cb = 3;
+    constexpr uint32_t partial_b_cb = 4;
+    constexpr uint32_t output_cb = 5;
+    const uint32_t mt_count = get_arg_val<uint32_t>(0);
+
+    DataflowBuffer activation(act_tile_cb);
+    DataflowBuffer weights(weights_cb);
+    DataflowBuffer partial_a(partial_a_cb);
+    DataflowBuffer partial_b(partial_b_cb);
+    DataflowBuffer output(output_cb);
+    binary_op_init_common(act_tile_cb, weights_cb, partial_a_cb);
+    silu_tile_init();
+
+    if constexpr (num_blocks == 1) {
+        weights.wait_front(4 * block_ct);
+    }
+    for (uint32_t item = 0; item < mt_count; ++item) {
+        if constexpr (num_blocks > 1) {
+            weights.wait_front(4 * block_ct);
+        }
+        for (uint32_t tap = 0; tap < 4; ++tap) {
+            compute_kernel_lib::tilize<block_ct, act_rm_cb, act_tile_cb>(1);
+            activation.wait_front(block_ct);
+
+            DataflowBuffer source_partial = (tap == 1 || tap == 3) ? partial_a : partial_b;
+            DataflowBuffer destination = tap == 0 || tap == 2 ? partial_a : (tap == 1 ? partial_b : output);
+            const uint32_t source_partial_cb = source_partial.get_id();
+            const uint32_t destination_cb = destination.get_id();
+            if (tap != 0) {
+                source_partial.wait_front(block_ct);
+            }
+
+            for (uint32_t ct = 0; ct < block_ct; ++ct) {
+                tile_regs_acquire();
+                reconfig_data_format_srca(act_tile_cb);
+                reconfig_data_format_srcb(weights_cb);
+                mul_bcast_rows_init_short(act_tile_cb, weights_cb);
+                mul_tiles_bcast_rows(act_tile_cb, weights_cb, ct, tap * block_ct + ct, 0);
+
+                if (tap != 0) {
+                    reconfig_data_format_srca(source_partial_cb);
+                    binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
+                        source_partial_cb);
+                    binary_dest_reuse_tiles<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
+                        source_partial_cb, 0, 0);
+                    source_partial.pop_front(1);
+                    reconfig_data_format_srca(act_tile_cb);
+                }
+                if (tap == 3) {
+                    silu_tile(0);
+                }
+                tile_regs_commit();
+
+                destination.reserve_back(1);
+                tile_regs_wait();
+                pack_tile(0, destination_cb);
+                destination.push_back(1);
+                tile_regs_release();
+            }
+            activation.pop_front(block_ct);
+        }
+        if constexpr (num_blocks > 1) {
+            weights.pop_front(4 * block_ct);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/compute/qkv_causal_conv1d_silu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/compute/qkv_causal_conv1d_silu.cpp
@@ -12,6 +12,8 @@
 
 template <uint32_t block_ct, uint32_t num_blocks>
 TT_KERNEL void compute(uint32_t wi_count) {
+    // Kimi-K3 uses a fixed four-tap causal convolution, with three preceding rows supplied by history.
+    constexpr uint32_t tap_count = 4;
     compute_kernel_hw_startup(dfb::act_rm, dfb::act_tile, dfb::output);
     DataflowBuffer activation(dfb::act_tile);
     DataflowBuffer weights(dfb::weights);
@@ -20,17 +22,18 @@ TT_KERNEL void compute(uint32_t wi_count) {
     silu_tile_init();
 
     if constexpr (num_blocks == 1) {
-        weights.wait_front(4 * block_ct);
+        weights.wait_front(tap_count * block_ct);
     }
     for (uint32_t item = 0; item < wi_count; ++item) {
         if constexpr (num_blocks > 1) {
-            weights.wait_front(4 * block_ct);
+            weights.wait_front(tap_count * block_ct);
         }
-        for (uint32_t tap = 0; tap < 4; ++tap) {
+        for (uint32_t tap = 0; tap < tap_count; ++tap) {
             compute_kernel_lib::tilize<block_ct, dfb::act_rm, dfb::act_tile>(1);
             activation.wait_front(block_ct);
 
-            const uint32_t destination_dfb = tap == 3 ? dfb::output : dfb::partial;
+            const bool is_final_tap = tap + 1 == tap_count;
+            const uint32_t destination_dfb = is_final_tap ? dfb::output : dfb::partial;
             if (tap != 0) {
                 partial.wait_front(block_ct);
             }
@@ -41,7 +44,7 @@ TT_KERNEL void compute(uint32_t wi_count) {
                 mul_bcast_rows_init(dfb::act_tile, dfb::weights);
             }
             for (uint32_t ct = 0; ct < block_ct; ++ct) {
-                if (tap == 3) {
+                if (is_final_tap) {
                     output.reserve_back(1);
                 } else {
                     partial.reserve_back(1);
@@ -56,16 +59,17 @@ TT_KERNEL void compute(uint32_t wi_count) {
                     reconfig_data_format_srca(dfb::partial);
                     add_reuse_dest_init<EltwiseBinaryReuseDestType::DEST_TO_SRCB>(dfb::partial);
                     add_reuse_dest_tiles<EltwiseBinaryReuseDestType::DEST_TO_SRCB>(dfb::partial, 0, 0);
+                    // The partial add binds srcA to the accumulator; restore activation for the next multiply.
                     reconfig_data_format_srca(dfb::act_tile);
                 }
-                if (tap == 3) {
+                if (is_final_tap) {
                     silu_tile(0);
                 }
                 tile_regs_commit();
 
                 tile_regs_wait();
                 pack_tile(0, destination_dfb);
-                if (tap == 3) {
+                if (is_final_tap) {
                     output.push_back(1);
                 } else {
                     partial.push_back(1);
@@ -78,7 +82,7 @@ TT_KERNEL void compute(uint32_t wi_count) {
             activation.pop_front(block_ct);
         }
         if constexpr (num_blocks > 1) {
-            weights.pop_front(4 * block_ct);
+            weights.pop_front(tap_count * block_ct);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/compute/qkv_causal_conv1d_silu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/compute/qkv_causal_conv1d_silu.cpp
@@ -20,12 +20,12 @@ void kernel_main() {
     constexpr uint32_t output_cb = 5;
     const uint32_t mt_count = get_arg_val<uint32_t>(0);
 
+    compute_kernel_hw_startup(act_rm_cb, act_tile_cb);
     DataflowBuffer activation(act_tile_cb);
     DataflowBuffer weights(weights_cb);
     DataflowBuffer partial_a(partial_a_cb);
     DataflowBuffer partial_b(partial_b_cb);
     DataflowBuffer output(output_cb);
-    binary_op_init_common(act_tile_cb, weights_cb, partial_a_cb);
     silu_tile_init();
 
     if constexpr (num_blocks == 1) {

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/compute/qkv_causal_conv1d_silu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/compute/qkv_causal_conv1d_silu.cpp
@@ -1,77 +1,84 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "api/compute/tilize.h"
-#include "api/compute/eltwise_binary.h"
 #include "api/compute/bcast.h"
 #include "api/compute/compute_kernel_api.h"
+#include "api/compute/eltwise_binary.h"
 #include "api/compute/reconfig_data_format.h"
+#include "api/compute/tilize.h"
 #include "api/dataflow/dataflow_buffer.h"
+#include "experimental/kernel_args.h"
 #include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
 
-void kernel_main() {
-    constexpr uint32_t block_ct = get_compile_time_arg_val(0);
-    constexpr uint32_t num_blocks = get_compile_time_arg_val(1);
-    constexpr uint32_t act_rm_cb = 0;
-    constexpr uint32_t act_tile_cb = 1;
-    constexpr uint32_t weights_cb = 2;
-    constexpr uint32_t partial_a_cb = 3;
-    constexpr uint32_t partial_b_cb = 4;
-    constexpr uint32_t output_cb = 5;
-    const uint32_t mt_count = get_arg_val<uint32_t>(0);
-
-    compute_kernel_hw_startup(act_rm_cb, act_tile_cb);
-    DataflowBuffer activation(act_tile_cb);
-    DataflowBuffer weights(weights_cb);
-    DataflowBuffer partial_a(partial_a_cb);
-    DataflowBuffer partial_b(partial_b_cb);
-    DataflowBuffer output(output_cb);
+template <uint32_t block_ct, uint32_t num_blocks>
+TT_KERNEL void compute(uint32_t wi_count) {
+    compute_kernel_hw_startup(dfb::act_rm, dfb::act_tile, dfb::output);
+    DataflowBuffer activation(dfb::act_tile);
+    DataflowBuffer weights(dfb::weights);
+    DataflowBuffer partial_a(dfb::partial_a);
+    DataflowBuffer partial_b(dfb::partial_b);
+    DataflowBuffer output(dfb::output);
     silu_tile_init();
 
     if constexpr (num_blocks == 1) {
         weights.wait_front(4 * block_ct);
     }
-    for (uint32_t item = 0; item < mt_count; ++item) {
+    for (uint32_t item = 0; item < wi_count; ++item) {
         if constexpr (num_blocks > 1) {
             weights.wait_front(4 * block_ct);
         }
         for (uint32_t tap = 0; tap < 4; ++tap) {
-            compute_kernel_lib::tilize<block_ct, act_rm_cb, act_tile_cb>(1);
+            compute_kernel_lib::tilize<block_ct, dfb::act_rm, dfb::act_tile>(1);
             activation.wait_front(block_ct);
 
-            DataflowBuffer source_partial = (tap == 1 || tap == 3) ? partial_a : partial_b;
-            DataflowBuffer destination = tap == 0 || tap == 2 ? partial_a : (tap == 1 ? partial_b : output);
-            const uint32_t source_partial_cb = source_partial.get_id();
-            const uint32_t destination_cb = destination.get_id();
-            if (tap != 0) {
-                source_partial.wait_front(block_ct);
+            const uint32_t source_partial_dfb = (tap == 1 || tap == 3) ? dfb::partial_a : dfb::partial_b;
+            const uint32_t destination_dfb =
+                (tap == 0 || tap == 2) ? dfb::partial_a : (tap == 1 ? dfb::partial_b : dfb::output);
+            if (tap == 1 || tap == 3) {
+                partial_a.wait_front(block_ct);
+            } else if (tap == 2) {
+                partial_b.wait_front(block_ct);
             }
 
             for (uint32_t ct = 0; ct < block_ct; ++ct) {
                 tile_regs_acquire();
-                reconfig_data_format_srca(act_tile_cb);
-                reconfig_data_format_srcb(weights_cb);
-                mul_bcast_rows_init_short(act_tile_cb, weights_cb);
-                mul_tiles_bcast_rows(act_tile_cb, weights_cb, ct, tap * block_ct + ct, 0);
+                reconfig_data_format_srca(dfb::act_tile);
+                reconfig_data_format_srcb(dfb::weights);
+                mul_bcast_rows_init(dfb::act_tile, dfb::weights);
+                mul_tiles_bcast_rows(dfb::act_tile, dfb::weights, ct, tap * block_ct + ct, 0);
 
                 if (tap != 0) {
-                    reconfig_data_format_srca(source_partial_cb);
-                    binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
-                        source_partial_cb);
-                    binary_dest_reuse_tiles<EltwiseBinaryType::ELWADD, EltwiseBinaryReuseDestType::DEST_TO_SRCB>(
-                        source_partial_cb, 0, 0);
-                    source_partial.pop_front(1);
-                    reconfig_data_format_srca(act_tile_cb);
+                    reconfig_data_format_srca(source_partial_dfb);
+                    add_reuse_dest_init<EltwiseBinaryReuseDestType::DEST_TO_SRCB>(source_partial_dfb);
+                    add_reuse_dest_tiles<EltwiseBinaryReuseDestType::DEST_TO_SRCB>(source_partial_dfb, 0, 0);
+                    if (tap == 1 || tap == 3) {
+                        partial_a.pop_front(1);
+                    } else {
+                        partial_b.pop_front(1);
+                    }
+                    reconfig_data_format_srca(dfb::act_tile);
                 }
                 if (tap == 3) {
                     silu_tile(0);
                 }
                 tile_regs_commit();
 
-                destination.reserve_back(1);
+                if (tap == 0 || tap == 2) {
+                    partial_a.reserve_back(1);
+                } else if (tap == 1) {
+                    partial_b.reserve_back(1);
+                } else {
+                    output.reserve_back(1);
+                }
                 tile_regs_wait();
-                pack_tile(0, destination_cb);
-                destination.push_back(1);
+                pack_tile(0, destination_dfb);
+                if (tap == 0 || tap == 2) {
+                    partial_a.push_back(1);
+                } else if (tap == 1) {
+                    partial_b.push_back(1);
+                } else {
+                    output.push_back(1);
+                }
                 tile_regs_release();
             }
             activation.pop_front(block_ct);

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/compute/qkv_causal_conv1d_silu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/compute/qkv_causal_conv1d_silu.cpp
@@ -15,8 +15,7 @@ TT_KERNEL void compute(uint32_t wi_count) {
     compute_kernel_hw_startup(dfb::act_rm, dfb::act_tile, dfb::output);
     DataflowBuffer activation(dfb::act_tile);
     DataflowBuffer weights(dfb::weights);
-    DataflowBuffer partial_a(dfb::partial_a);
-    DataflowBuffer partial_b(dfb::partial_b);
+    DataflowBuffer partial(dfb::partial);
     DataflowBuffer output(dfb::output);
     silu_tile_init();
 
@@ -31,13 +30,9 @@ TT_KERNEL void compute(uint32_t wi_count) {
             compute_kernel_lib::tilize<block_ct, dfb::act_rm, dfb::act_tile>(1);
             activation.wait_front(block_ct);
 
-            const uint32_t source_partial_dfb = (tap == 1 || tap == 3) ? dfb::partial_a : dfb::partial_b;
-            const uint32_t destination_dfb =
-                (tap == 0 || tap == 2) ? dfb::partial_a : (tap == 1 ? dfb::partial_b : dfb::output);
-            if (tap == 1 || tap == 3) {
-                partial_a.wait_front(block_ct);
-            } else if (tap == 2) {
-                partial_b.wait_front(block_ct);
+            const uint32_t destination_dfb = tap == 3 ? dfb::output : dfb::partial;
+            if (tap != 0) {
+                partial.wait_front(block_ct);
             }
 
             reconfig_data_format_srca(dfb::act_tile);
@@ -46,6 +41,11 @@ TT_KERNEL void compute(uint32_t wi_count) {
                 mul_bcast_rows_init(dfb::act_tile, dfb::weights);
             }
             for (uint32_t ct = 0; ct < block_ct; ++ct) {
+                if (tap == 3) {
+                    output.reserve_back(1);
+                } else {
+                    partial.reserve_back(1);
+                }
                 tile_regs_acquire();
                 if (tap != 0) {
                     mul_bcast_rows_init(dfb::act_tile, dfb::weights);
@@ -53,14 +53,9 @@ TT_KERNEL void compute(uint32_t wi_count) {
                 mul_tiles_bcast_rows(dfb::act_tile, dfb::weights, ct, tap * block_ct + ct, 0);
 
                 if (tap != 0) {
-                    reconfig_data_format_srca(source_partial_dfb);
-                    add_reuse_dest_init<EltwiseBinaryReuseDestType::DEST_TO_SRCB>(source_partial_dfb);
-                    add_reuse_dest_tiles<EltwiseBinaryReuseDestType::DEST_TO_SRCB>(source_partial_dfb, 0, 0);
-                    if (tap == 1 || tap == 3) {
-                        partial_a.pop_front(1);
-                    } else {
-                        partial_b.pop_front(1);
-                    }
+                    reconfig_data_format_srca(dfb::partial);
+                    add_reuse_dest_init<EltwiseBinaryReuseDestType::DEST_TO_SRCB>(dfb::partial);
+                    add_reuse_dest_tiles<EltwiseBinaryReuseDestType::DEST_TO_SRCB>(dfb::partial, 0, 0);
                     reconfig_data_format_srca(dfb::act_tile);
                 }
                 if (tap == 3) {
@@ -68,21 +63,15 @@ TT_KERNEL void compute(uint32_t wi_count) {
                 }
                 tile_regs_commit();
 
-                if (tap == 0 || tap == 2) {
-                    partial_a.reserve_back(1);
-                } else if (tap == 1) {
-                    partial_b.reserve_back(1);
-                } else {
-                    output.reserve_back(1);
-                }
                 tile_regs_wait();
                 pack_tile(0, destination_dfb);
-                if (tap == 0 || tap == 2) {
-                    partial_a.push_back(1);
-                } else if (tap == 1) {
-                    partial_b.push_back(1);
-                } else {
+                if (tap == 3) {
                     output.push_back(1);
+                } else {
+                    partial.push_back(1);
+                }
+                if (tap != 0) {
+                    partial.pop_front(1);
                 }
                 tile_regs_release();
             }

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/compute/qkv_causal_conv1d_silu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/compute/qkv_causal_conv1d_silu.cpp
@@ -40,11 +40,16 @@ TT_KERNEL void compute(uint32_t wi_count) {
                 partial_b.wait_front(block_ct);
             }
 
+            reconfig_data_format_srca(dfb::act_tile);
+            reconfig_data_format_srcb(dfb::weights);
+            if (tap == 0) {
+                mul_bcast_rows_init(dfb::act_tile, dfb::weights);
+            }
             for (uint32_t ct = 0; ct < block_ct; ++ct) {
                 tile_regs_acquire();
-                reconfig_data_format_srca(dfb::act_tile);
-                reconfig_data_format_srcb(dfb::weights);
-                mul_bcast_rows_init(dfb::act_tile, dfb::weights);
+                if (tap != 0) {
+                    mul_bcast_rows_init(dfb::act_tile, dfb::weights);
+                }
                 mul_tiles_bcast_rows(dfb::act_tile, dfb::weights, ct, tap * block_ct + ct, 0);
 
                 if (tap != 0) {

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/reader_qkv_causal_conv1d_silu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/reader_qkv_causal_conv1d_silu.cpp
@@ -7,6 +7,32 @@
 #include "api/tensor/noc_traits.h"
 #include "experimental/kernel_args.h"
 
+template <uint32_t block_ct, typename Tap0Accessor, typename Tap1Accessor, typename Tap2Accessor, typename Tap3Accessor>
+FORCE_INLINE void load_weight_block(
+    Noc& noc,
+    DataflowBuffer& weights,
+    const Tap0Accessor& tap0,
+    const Tap1Accessor& tap1,
+    const Tap2Accessor& tap2,
+    const Tap3Accessor& tap3,
+    uint32_t tile_bytes,
+    uint32_t ct_start) {
+    weights.reserve_back(4 * block_ct);
+    for (uint32_t ct = 0; ct < block_ct; ++ct) {
+        const uint32_t source_ct = ct_start + ct;
+        // The weight DFB is laid out as [tap][channel tile].
+        noc.async_read(tap0, weights, tile_bytes, {.page_id = source_ct}, {.offset_bytes = ct * tile_bytes});
+        noc.async_read(
+            tap1, weights, tile_bytes, {.page_id = source_ct}, {.offset_bytes = (block_ct + ct) * tile_bytes});
+        noc.async_read(
+            tap2, weights, tile_bytes, {.page_id = source_ct}, {.offset_bytes = (2 * block_ct + ct) * tile_bytes});
+        noc.async_read(
+            tap3, weights, tile_bytes, {.page_id = source_ct}, {.offset_bytes = (3 * block_ct + ct) * tile_bytes});
+    }
+    noc.async_read_barrier();
+    weights.push_back(4 * block_ct);
+}
+
 template <uint32_t block_ct, uint32_t num_blocks>
 TT_KERNEL void reader(uint32_t wi_start, uint32_t wi_count) {
     const auto input = TensorAccessor(tensor::input);
@@ -20,23 +46,8 @@ TT_KERNEL void reader(uint32_t wi_start, uint32_t wi_count) {
     Noc noc;
 
     const uint32_t tile_bytes = weights.get_entry_size();
-    auto load_weights = [&](uint32_t ct_start) {
-        weights.reserve_back(4 * block_ct);
-        for (uint32_t ct = 0; ct < block_ct; ++ct) {
-            const uint32_t source_ct = ct_start + ct;
-            noc.async_read(tap0, weights, tile_bytes, {.page_id = source_ct}, {.offset_bytes = ct * tile_bytes});
-            noc.async_read(
-                tap1, weights, tile_bytes, {.page_id = source_ct}, {.offset_bytes = (block_ct + ct) * tile_bytes});
-            noc.async_read(
-                tap2, weights, tile_bytes, {.page_id = source_ct}, {.offset_bytes = (2 * block_ct + ct) * tile_bytes});
-            noc.async_read(
-                tap3, weights, tile_bytes, {.page_id = source_ct}, {.offset_bytes = (3 * block_ct + ct) * tile_bytes});
-        }
-        noc.async_read_barrier();
-        weights.push_back(4 * block_ct);
-    };
     if constexpr (num_blocks == 1) {
-        load_weights(0);
+        load_weight_block<block_ct>(noc, weights, tap0, tap1, tap2, tap3, tile_bytes, 0);
     }
 
     constexpr uint32_t tile_width = 32;
@@ -49,7 +60,7 @@ TT_KERNEL void reader(uint32_t wi_start, uint32_t wi_count) {
         const uint32_t ct_start = (work % num_blocks) * block_ct;
 
         if constexpr (num_blocks > 1) {
-            load_weights(ct_start);
+            load_weight_block<block_ct>(noc, weights, tap0, tap1, tap2, tap3, tile_bytes, ct_start);
         }
 
         for (uint32_t tap = 0; tap < 4; ++tap) {

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/reader_qkv_causal_conv1d_silu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/reader_qkv_causal_conv1d_silu.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    constexpr uint32_t block_ct = get_compile_time_arg_val(0);
+    constexpr uint32_t channels = get_compile_time_arg_val(1);
+    constexpr uint32_t row_bytes = get_compile_time_arg_val(2);
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(3);
+    constexpr auto input_a = TensorAccessorArgs<4>();
+    constexpr auto history_a = TensorAccessorArgs<input_a.next_compile_time_args_offset()>();
+    constexpr auto tap0_a = TensorAccessorArgs<history_a.next_compile_time_args_offset()>();
+    constexpr auto tap1_a = TensorAccessorArgs<tap0_a.next_compile_time_args_offset()>();
+    constexpr auto tap2_a = TensorAccessorArgs<tap1_a.next_compile_time_args_offset()>();
+    constexpr auto tap3_a = TensorAccessorArgs<tap2_a.next_compile_time_args_offset()>();
+    static_assert(row_bytes == channels * sizeof(uint16_t));
+
+    const uint32_t mt_start = get_arg_val<uint32_t>(0);
+    const uint32_t mt_count = get_arg_val<uint32_t>(1);
+    const uint32_t input_addr = get_arg_val<uint32_t>(2);
+    const uint32_t history_addr = get_arg_val<uint32_t>(3);
+    const uint32_t tap0_addr = get_arg_val<uint32_t>(4);
+    const uint32_t tap1_addr = get_arg_val<uint32_t>(5);
+    const uint32_t tap2_addr = get_arg_val<uint32_t>(6);
+    const uint32_t tap3_addr = get_arg_val<uint32_t>(7);
+
+    constexpr uint32_t tile_bytes = 2048;
+    const auto input = TensorAccessor(input_a, input_addr, row_bytes);
+    const auto history = TensorAccessor(history_a, history_addr, row_bytes);
+    const auto tap0 = TensorAccessor(tap0_a, tap0_addr, tile_bytes);
+    const auto tap1 = TensorAccessor(tap1_a, tap1_addr, tile_bytes);
+    const auto tap2 = TensorAccessor(tap2_a, tap2_addr, tile_bytes);
+    const auto tap3 = TensorAccessor(tap3_a, tap3_addr, tile_bytes);
+    Noc noc;
+
+    CircularBuffer weights(2);
+    CircularBuffer activation(0);
+    auto load_weights = [&](uint32_t ct_start) {
+        weights.reserve_back(4 * block_ct);
+        auto weight_dst = use<CircularBuffer::AddrSelector::WRITE_PTR>(weights);
+        for (uint32_t ct = 0; ct < block_ct; ++ct) {
+            const uint32_t source_ct = ct_start + ct;
+            noc.async_read(tap0, weight_dst, tile_bytes, {.page_id = source_ct}, {.offset_bytes = ct * tile_bytes});
+            noc.async_read(
+                tap1, weight_dst, tile_bytes, {.page_id = source_ct}, {.offset_bytes = (block_ct + ct) * tile_bytes});
+            noc.async_read(
+                tap2,
+                weight_dst,
+                tile_bytes,
+                {.page_id = source_ct},
+                {.offset_bytes = (2 * block_ct + ct) * tile_bytes});
+            noc.async_read(
+                tap3,
+                weight_dst,
+                tile_bytes,
+                {.page_id = source_ct},
+                {.offset_bytes = (3 * block_ct + ct) * tile_bytes});
+        }
+        noc.async_read_barrier();
+        weights.push_back(4 * block_ct);
+    };
+    if constexpr (num_blocks == 1) {
+        load_weights(0);
+    }
+    constexpr uint32_t block_row_bytes = block_ct * 32 * sizeof(uint16_t);
+    constexpr uint32_t block_offset_scale = 32 * sizeof(uint16_t);
+    for (uint32_t item = 0; item < mt_count; ++item) {
+        const uint32_t work = mt_start + item;
+        const uint32_t mt = work / num_blocks;
+        const uint32_t ct_start = (work % num_blocks) * block_ct;
+
+        if constexpr (num_blocks > 1) {
+            load_weights(ct_start);
+        }
+
+        for (uint32_t tap = 0; tap < 4; ++tap) {
+            activation.reserve_back(block_ct);
+            auto activation_dst = use<CircularBuffer::AddrSelector::WRITE_PTR>(activation);
+            for (uint32_t row = 0; row < 32; ++row) {
+                const int32_t source_row = static_cast<int32_t>(mt * 32 + row + tap) - 3;
+                if (source_row < 0) {
+                    noc.async_read(
+                        history,
+                        activation_dst,
+                        block_row_bytes,
+                        {.page_id = static_cast<uint32_t>(source_row + 3),
+                         .offset_bytes = ct_start * block_offset_scale},
+                        {.offset_bytes = row * block_row_bytes});
+                } else {
+                    noc.async_read(
+                        input,
+                        activation_dst,
+                        block_row_bytes,
+                        {.page_id = static_cast<uint32_t>(source_row), .offset_bytes = ct_start * block_offset_scale},
+                        {.offset_bytes = row * block_row_bytes});
+                }
+            }
+            noc.async_read_barrier();
+            activation.push_back(block_ct);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/reader_qkv_causal_conv1d_silu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/reader_qkv_causal_conv1d_silu.cpp
@@ -28,7 +28,8 @@ void kernel_main() {
     const uint32_t tap2_addr = get_arg_val<uint32_t>(6);
     const uint32_t tap3_addr = get_arg_val<uint32_t>(7);
 
-    constexpr uint32_t tile_bytes = 2048;
+    constexpr uint32_t weights_cb = 2;
+    constexpr uint32_t tile_bytes = get_tile_size(weights_cb);
     const auto input = TensorAccessor(input_a, input_addr, row_bytes);
     const auto history = TensorAccessor(history_a, history_addr, row_bytes);
     const auto tap0 = TensorAccessor(tap0_a, tap0_addr, tile_bytes);
@@ -37,7 +38,7 @@ void kernel_main() {
     const auto tap3 = TensorAccessor(tap3_a, tap3_addr, tile_bytes);
     Noc noc;
 
-    CircularBuffer weights(2);
+    CircularBuffer weights(weights_cb);
     CircularBuffer activation(0);
     auto load_weights = [&](uint32_t ct_start) {
         weights.reserve_back(4 * block_ct);

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/reader_qkv_causal_conv1d_silu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/reader_qkv_causal_conv1d_silu.cpp
@@ -2,64 +2,37 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
-void kernel_main() {
-    constexpr uint32_t block_ct = get_compile_time_arg_val(0);
-    constexpr uint32_t channels = get_compile_time_arg_val(1);
-    constexpr uint32_t row_bytes = get_compile_time_arg_val(2);
-    constexpr uint32_t num_blocks = get_compile_time_arg_val(3);
-    constexpr auto input_a = TensorAccessorArgs<4>();
-    constexpr auto history_a = TensorAccessorArgs<input_a.next_compile_time_args_offset()>();
-    constexpr auto tap0_a = TensorAccessorArgs<history_a.next_compile_time_args_offset()>();
-    constexpr auto tap1_a = TensorAccessorArgs<tap0_a.next_compile_time_args_offset()>();
-    constexpr auto tap2_a = TensorAccessorArgs<tap1_a.next_compile_time_args_offset()>();
-    constexpr auto tap3_a = TensorAccessorArgs<tap2_a.next_compile_time_args_offset()>();
+template <uint32_t block_ct, uint32_t channels, uint32_t row_bytes, uint32_t num_blocks>
+TT_KERNEL void reader(uint32_t wi_start, uint32_t wi_count) {
     static_assert(row_bytes == channels * sizeof(uint16_t));
 
-    const uint32_t mt_start = get_arg_val<uint32_t>(0);
-    const uint32_t mt_count = get_arg_val<uint32_t>(1);
-    const uint32_t input_addr = get_arg_val<uint32_t>(2);
-    const uint32_t history_addr = get_arg_val<uint32_t>(3);
-    const uint32_t tap0_addr = get_arg_val<uint32_t>(4);
-    const uint32_t tap1_addr = get_arg_val<uint32_t>(5);
-    const uint32_t tap2_addr = get_arg_val<uint32_t>(6);
-    const uint32_t tap3_addr = get_arg_val<uint32_t>(7);
-
-    constexpr uint32_t weights_cb = 2;
-    constexpr uint32_t tile_bytes = get_tile_size(weights_cb);
-    const auto input = TensorAccessor(input_a, input_addr, row_bytes);
-    const auto history = TensorAccessor(history_a, history_addr, row_bytes);
-    const auto tap0 = TensorAccessor(tap0_a, tap0_addr, tile_bytes);
-    const auto tap1 = TensorAccessor(tap1_a, tap1_addr, tile_bytes);
-    const auto tap2 = TensorAccessor(tap2_a, tap2_addr, tile_bytes);
-    const auto tap3 = TensorAccessor(tap3_a, tap3_addr, tile_bytes);
+    const auto input = TensorAccessor(tensor::input);
+    const auto history = TensorAccessor(tensor::history);
+    const auto tap0 = TensorAccessor(tensor::tap0);
+    const auto tap1 = TensorAccessor(tensor::tap1);
+    const auto tap2 = TensorAccessor(tensor::tap2);
+    const auto tap3 = TensorAccessor(tensor::tap3);
+    DataflowBuffer weights(dfb::weights);
+    DataflowBuffer activation(dfb::act_rm);
     Noc noc;
 
-    CircularBuffer weights(weights_cb);
-    CircularBuffer activation(0);
+    const uint32_t tile_bytes = weights.get_entry_size();
     auto load_weights = [&](uint32_t ct_start) {
         weights.reserve_back(4 * block_ct);
-        auto weight_dst = use<CircularBuffer::AddrSelector::WRITE_PTR>(weights);
         for (uint32_t ct = 0; ct < block_ct; ++ct) {
             const uint32_t source_ct = ct_start + ct;
-            noc.async_read(tap0, weight_dst, tile_bytes, {.page_id = source_ct}, {.offset_bytes = ct * tile_bytes});
+            noc.async_read(tap0, weights, tile_bytes, {.page_id = source_ct}, {.offset_bytes = ct * tile_bytes});
             noc.async_read(
-                tap1, weight_dst, tile_bytes, {.page_id = source_ct}, {.offset_bytes = (block_ct + ct) * tile_bytes});
+                tap1, weights, tile_bytes, {.page_id = source_ct}, {.offset_bytes = (block_ct + ct) * tile_bytes});
             noc.async_read(
-                tap2,
-                weight_dst,
-                tile_bytes,
-                {.page_id = source_ct},
-                {.offset_bytes = (2 * block_ct + ct) * tile_bytes});
+                tap2, weights, tile_bytes, {.page_id = source_ct}, {.offset_bytes = (2 * block_ct + ct) * tile_bytes});
             noc.async_read(
-                tap3,
-                weight_dst,
-                tile_bytes,
-                {.page_id = source_ct},
-                {.offset_bytes = (3 * block_ct + ct) * tile_bytes});
+                tap3, weights, tile_bytes, {.page_id = source_ct}, {.offset_bytes = (3 * block_ct + ct) * tile_bytes});
         }
         noc.async_read_barrier();
         weights.push_back(4 * block_ct);
@@ -67,10 +40,13 @@ void kernel_main() {
     if constexpr (num_blocks == 1) {
         load_weights(0);
     }
-    constexpr uint32_t block_row_bytes = block_ct * 32 * sizeof(uint16_t);
-    constexpr uint32_t block_offset_scale = 32 * sizeof(uint16_t);
-    for (uint32_t item = 0; item < mt_count; ++item) {
-        const uint32_t work = mt_start + item;
+
+    constexpr uint32_t tile_width = 32;
+    constexpr uint32_t tile_height = 32;
+    constexpr uint32_t block_row_bytes = block_ct * tile_width * sizeof(uint16_t);
+    constexpr uint32_t block_offset_scale = tile_width * sizeof(uint16_t);
+    for (uint32_t item = 0; item < wi_count; ++item) {
+        const uint32_t work = wi_start + item;
         const uint32_t mt = work / num_blocks;
         const uint32_t ct_start = (work % num_blocks) * block_ct;
 
@@ -80,13 +56,12 @@ void kernel_main() {
 
         for (uint32_t tap = 0; tap < 4; ++tap) {
             activation.reserve_back(block_ct);
-            auto activation_dst = use<CircularBuffer::AddrSelector::WRITE_PTR>(activation);
-            for (uint32_t row = 0; row < 32; ++row) {
-                const int32_t source_row = static_cast<int32_t>(mt * 32 + row + tap) - 3;
+            for (uint32_t row = 0; row < tile_height; ++row) {
+                const int32_t source_row = static_cast<int32_t>(mt * tile_height + row + tap) - 3;
                 if (source_row < 0) {
                     noc.async_read(
                         history,
-                        activation_dst,
+                        activation,
                         block_row_bytes,
                         {.page_id = static_cast<uint32_t>(source_row + 3),
                          .offset_bytes = ct_start * block_offset_scale},
@@ -94,7 +69,7 @@ void kernel_main() {
                 } else {
                     noc.async_read(
                         input,
-                        activation_dst,
+                        activation,
                         block_row_bytes,
                         {.page_id = static_cast<uint32_t>(source_row), .offset_bytes = ct_start * block_offset_scale},
                         {.offset_bytes = row * block_row_bytes});

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/reader_qkv_causal_conv1d_silu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/reader_qkv_causal_conv1d_silu.cpp
@@ -7,10 +7,8 @@
 #include "api/tensor/noc_traits.h"
 #include "experimental/kernel_args.h"
 
-template <uint32_t block_ct, uint32_t channels, uint32_t row_bytes, uint32_t num_blocks>
+template <uint32_t block_ct, uint32_t num_blocks>
 TT_KERNEL void reader(uint32_t wi_start, uint32_t wi_count) {
-    static_assert(row_bytes == channels * sizeof(uint16_t));
-
     const auto input = TensorAccessor(tensor::input);
     const auto history = TensorAccessor(tensor::history);
     const auto tap0 = TensorAccessor(tensor::tap0);

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/writer_qkv_causal_conv1d_silu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/writer_qkv_causal_conv1d_silu.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    constexpr uint32_t Qt = get_compile_time_arg_val(0);
+    constexpr uint32_t Kt = get_compile_time_arg_val(1);
+    constexpr uint32_t Vt = get_compile_time_arg_val(2);
+    constexpr uint32_t block_ct = get_compile_time_arg_val(3);
+    constexpr uint32_t num_blocks = get_compile_time_arg_val(4);
+    constexpr auto q_a = TensorAccessorArgs<5>();
+    constexpr auto k_a = TensorAccessorArgs<q_a.next_compile_time_args_offset()>();
+    constexpr auto v_a = TensorAccessorArgs<k_a.next_compile_time_args_offset()>();
+    const uint32_t mt_start = get_arg_val<uint32_t>(0);
+    const uint32_t mt_count = get_arg_val<uint32_t>(1);
+    const uint32_t q_addr = get_arg_val<uint32_t>(2);
+    const uint32_t k_addr = get_arg_val<uint32_t>(3);
+    const uint32_t v_addr = get_arg_val<uint32_t>(4);
+    const uint32_t tile_bytes = get_tile_size(5);
+    const auto q = TensorAccessor(q_a, q_addr, tile_bytes);
+    const auto k = TensorAccessor(k_a, k_addr, tile_bytes);
+    const auto v = TensorAccessor(v_a, v_addr, tile_bytes);
+    Noc noc;
+    CircularBuffer out(5);
+
+    for (uint32_t item = 0; item < mt_count; ++item) {
+        const uint32_t work = mt_start + item;
+        const uint32_t mt = work / num_blocks;
+        const uint32_t ct_start = (work % num_blocks) * block_ct;
+        out.wait_front(block_ct);
+        auto src = use<CircularBuffer::AddrSelector::READ_PTR>(out);
+        for (uint32_t local_ct = 0; local_ct < block_ct; ++local_ct) {
+            const uint32_t ct = ct_start + local_ct;
+            if (ct < Qt) {
+                noc.async_write(src, q, tile_bytes, {.offset_bytes = local_ct * tile_bytes}, {.page_id = mt * Qt + ct});
+            } else if (ct < Qt + Kt) {
+                const uint32_t kt = ct - Qt;
+                noc.async_write(src, k, tile_bytes, {.offset_bytes = local_ct * tile_bytes}, {.page_id = mt * Kt + kt});
+            } else {
+                const uint32_t vt = ct - Qt - Kt;
+                noc.async_write(src, v, tile_bytes, {.offset_bytes = local_ct * tile_bytes}, {.page_id = mt * Vt + vt});
+            }
+        }
+        noc.async_write_barrier();
+        out.pop_front(block_ct);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/writer_qkv_causal_conv1d_silu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/writer_qkv_causal_conv1d_silu.cpp
@@ -2,50 +2,41 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
-void kernel_main() {
-    constexpr uint32_t Qt = get_compile_time_arg_val(0);
-    constexpr uint32_t Kt = get_compile_time_arg_val(1);
-    constexpr uint32_t Vt = get_compile_time_arg_val(2);
-    constexpr uint32_t block_ct = get_compile_time_arg_val(3);
-    constexpr uint32_t num_blocks = get_compile_time_arg_val(4);
-    constexpr auto q_a = TensorAccessorArgs<5>();
-    constexpr auto k_a = TensorAccessorArgs<q_a.next_compile_time_args_offset()>();
-    constexpr auto v_a = TensorAccessorArgs<k_a.next_compile_time_args_offset()>();
-    const uint32_t mt_start = get_arg_val<uint32_t>(0);
-    const uint32_t mt_count = get_arg_val<uint32_t>(1);
-    const uint32_t q_addr = get_arg_val<uint32_t>(2);
-    const uint32_t k_addr = get_arg_val<uint32_t>(3);
-    const uint32_t v_addr = get_arg_val<uint32_t>(4);
-    const uint32_t tile_bytes = get_tile_size(5);
-    const auto q = TensorAccessor(q_a, q_addr, tile_bytes);
-    const auto k = TensorAccessor(k_a, k_addr, tile_bytes);
-    const auto v = TensorAccessor(v_a, v_addr, tile_bytes);
+template <uint32_t Qt, uint32_t Kt, uint32_t Vt, uint32_t block_ct, uint32_t num_blocks>
+TT_KERNEL void writer(uint32_t wi_start, uint32_t wi_count) {
+    const auto q = TensorAccessor(tensor::q);
+    const auto k = TensorAccessor(tensor::k);
+    const auto v = TensorAccessor(tensor::v);
+    DataflowBuffer output(dfb::output);
     Noc noc;
-    CircularBuffer out(5);
 
-    for (uint32_t item = 0; item < mt_count; ++item) {
-        const uint32_t work = mt_start + item;
+    const uint32_t tile_bytes = output.get_entry_size();
+    for (uint32_t item = 0; item < wi_count; ++item) {
+        const uint32_t work = wi_start + item;
         const uint32_t mt = work / num_blocks;
         const uint32_t ct_start = (work % num_blocks) * block_ct;
-        out.wait_front(block_ct);
-        auto src = use<CircularBuffer::AddrSelector::READ_PTR>(out);
+        output.wait_front(block_ct);
         for (uint32_t local_ct = 0; local_ct < block_ct; ++local_ct) {
             const uint32_t ct = ct_start + local_ct;
             if (ct < Qt) {
-                noc.async_write(src, q, tile_bytes, {.offset_bytes = local_ct * tile_bytes}, {.page_id = mt * Qt + ct});
+                noc.async_write(
+                    output, q, tile_bytes, {.offset_bytes = local_ct * tile_bytes}, {.page_id = mt * Qt + ct});
             } else if (ct < Qt + Kt) {
                 const uint32_t kt = ct - Qt;
-                noc.async_write(src, k, tile_bytes, {.offset_bytes = local_ct * tile_bytes}, {.page_id = mt * Kt + kt});
+                noc.async_write(
+                    output, k, tile_bytes, {.offset_bytes = local_ct * tile_bytes}, {.page_id = mt * Kt + kt});
             } else {
                 const uint32_t vt = ct - Qt - Kt;
-                noc.async_write(src, v, tile_bytes, {.offset_bytes = local_ct * tile_bytes}, {.page_id = mt * Vt + vt});
+                noc.async_write(
+                    output, v, tile_bytes, {.offset_bytes = local_ct * tile_bytes}, {.page_id = mt * Vt + vt});
             }
         }
         noc.async_write_barrier();
-        out.pop_front(block_ct);
+        output.pop_front(block_ct);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation.cpp
@@ -85,7 +85,7 @@ void QkvCausalConv1dSiluOperation::validate_on_program_cache_miss(
         attrs.sequence > 0 && attrs.sequence % tt::constants::TILE_HEIGHT == 0,
         "qkv_causal_conv1d_silu: sequence must be positive and tile aligned");
 
-    for (const auto [tensor, name] : std::array{
+    for (const auto& [tensor, name] : std::array{
              std::pair{&in.tap0, "tap0"},
              std::pair{&in.tap1, "tap1"},
              std::pair{&in.tap2, "tap2"},

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation.cpp
@@ -62,6 +62,15 @@ void QkvCausalConv1dSiluOperation::validate_on_program_cache_miss(
         "qkv_causal_conv1d_silu: Q/K/V widths must be tile aligned");
     const uint64_t channels =
         static_cast<uint64_t>(attrs.q_width) + static_cast<uint64_t>(attrs.k_width) + attrs.v_width;
+    TT_FATAL(attrs.channel_chunk_size > 0, "qkv_causal_conv1d_silu: channel_chunk_size must be positive");
+    TT_FATAL(
+        attrs.channel_chunk_size % tt::constants::TILE_WIDTH == 0,
+        "qkv_causal_conv1d_silu: channel_chunk_size must be tile aligned");
+    TT_FATAL(
+        attrs.channel_chunk_size <= channels, "qkv_causal_conv1d_silu: channel_chunk_size must not exceed Q+K+V width");
+    TT_FATAL(
+        channels % attrs.channel_chunk_size == 0,
+        "qkv_causal_conv1d_silu: channel_chunk_size must divide Q+K+V width exactly");
 
     const auto& input_shape = in.input.logical_shape();
     const auto& history_shape = in.history.logical_shape();
@@ -120,6 +129,7 @@ std::vector<Tensor> qkv_causal_conv1d_silu(
     uint32_t q_width,
     uint32_t k_width,
     uint32_t v_width,
+    uint32_t channel_chunk_size,
     const tt::tt_metal::MemoryConfig& output_mem_config,
     const DeviceComputeKernelConfig& compute_kernel_config) {
     const auto& input_shape = input.logical_shape();
@@ -130,6 +140,7 @@ std::vector<Tensor> qkv_causal_conv1d_silu(
             .q_width = q_width,
             .k_width = k_width,
             .v_width = v_width,
+            .channel_chunk_size = channel_chunk_size,
             .output_mem_config = output_mem_config,
             .compute_kernel_config = compute_kernel_config},
         QkvCausalConv1dSiluInputs{

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation.cpp
@@ -99,6 +99,9 @@ void QkvCausalConv1dSiluOperation::validate_on_program_cache_miss(
     }
     check_output_interleaved(attrs.output_mem_config, operation_name);
     check_compute_config(attrs.compute_kernel_config, operation_name);
+    TT_FATAL(
+        !attrs.compute_kernel_config.math_approx_mode,
+        "qkv_causal_conv1d_silu: math_approx_mode=true is unsupported because silu_tile always uses precise sigmoid");
 }
 
 QkvCausalConv1dSiluOperation::spec_return_value_t QkvCausalConv1dSiluOperation::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation.cpp
@@ -74,6 +74,10 @@ void QkvCausalConv1dSiluOperation::validate_on_program_cache_miss(
              std::pair{&in.tap2, "tap2"},
              std::pair{&in.tap3, "tap3"}}) {
         TT_FATAL(
+            tensor->logical_shape()[-1] == channels,
+            "qkv_causal_conv1d_silu: {} last dimension must equal Q+K+V",
+            name);
+        TT_FATAL(
             tensor->logical_volume() == channels, "qkv_causal_conv1d_silu: {} logical volume must equal Q+K+V", name);
     }
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation.cpp
@@ -40,7 +40,7 @@ void QkvCausalConv1dSiluOperation::validate_on_program_cache_miss(
     check_device_tensor(in.tap2, "tap2", Layout::TILE);
     check_device_tensor(in.tap3, "tap3", Layout::TILE);
 
-    const auto input_device = in.input.device();
+    auto* const input_device = in.input.device();
     for (const auto* tensor : std::array{&in.history, &in.tap0, &in.tap1, &in.tap2, &in.tap3}) {
         TT_FATAL(tensor->device() == input_device, "qkv_causal_conv1d_silu: all inputs must be on the same device");
     }

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation.cpp
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "qkv_causal_conv1d_silu_device_operation.hpp"
+
+#include <array>
+
+#include <tt-metalium/constants.hpp>
+
+#include "ttnn/device_operation.hpp"
+
+using namespace tt::tt_metal;
+
+namespace ttnn::experimental::prim {
+namespace {
+
+void check_device_tensor(const Tensor& tensor, const char* name, Layout layout) {
+    TT_FATAL(
+        tensor.storage_type() == StorageType::DEVICE && tensor.buffer() != nullptr,
+        "qkv_causal_conv1d_silu: {} must be an allocated device tensor",
+        name);
+    TT_FATAL(tensor.layout() == layout, "qkv_causal_conv1d_silu: {} has unsupported layout", name);
+    TT_FATAL(tensor.dtype() == DataType::BFLOAT16, "qkv_causal_conv1d_silu: {} must be BFLOAT16", name);
+    TT_FATAL(!tensor.is_sharded(), "qkv_causal_conv1d_silu: {} must use interleaved memory", name);
+}
+
+}  // namespace
+
+QkvCausalConv1dSiluOperation::program_factory_t QkvCausalConv1dSiluOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return QkvCausalConv1dSiluProgramFactory{};
+}
+
+void QkvCausalConv1dSiluOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& attrs, const tensor_args_t& in) {
+    check_device_tensor(in.input, "input", Layout::ROW_MAJOR);
+    check_device_tensor(in.history, "history", Layout::ROW_MAJOR);
+    check_device_tensor(in.tap0, "tap0", Layout::TILE);
+    check_device_tensor(in.tap1, "tap1", Layout::TILE);
+    check_device_tensor(in.tap2, "tap2", Layout::TILE);
+    check_device_tensor(in.tap3, "tap3", Layout::TILE);
+
+    const auto input_device = in.input.device();
+    for (const auto* tensor : std::array{&in.history, &in.tap0, &in.tap1, &in.tap2, &in.tap3}) {
+        TT_FATAL(tensor->device() == input_device, "qkv_causal_conv1d_silu: all inputs must be on the same device");
+    }
+
+    TT_FATAL(
+        attrs.q_width > 0 && attrs.k_width > 0 && attrs.v_width > 0,
+        "qkv_causal_conv1d_silu: Q/K/V widths must be positive");
+    TT_FATAL(
+        attrs.q_width % tt::constants::TILE_WIDTH == 0 && attrs.k_width % tt::constants::TILE_WIDTH == 0 &&
+            attrs.v_width % tt::constants::TILE_WIDTH == 0,
+        "qkv_causal_conv1d_silu: Q/K/V widths must be tile aligned");
+    const uint64_t channels =
+        static_cast<uint64_t>(attrs.q_width) + static_cast<uint64_t>(attrs.k_width) + attrs.v_width;
+
+    const auto& input_shape = in.input.logical_shape();
+    const auto& history_shape = in.history.logical_shape();
+    TT_FATAL(
+        input_shape.rank() == 3 && input_shape[0] == 1 && input_shape[1] == attrs.sequence &&
+            input_shape[2] == channels,
+        "qkv_causal_conv1d_silu: input must be [1,T,Q+K+V]");
+    TT_FATAL(
+        history_shape.rank() == 3 && history_shape[0] == 1 && history_shape[1] == 3 && history_shape[2] == channels,
+        "qkv_causal_conv1d_silu: history must be [1,3,Q+K+V]");
+    TT_FATAL(
+        attrs.sequence > 0 && attrs.sequence % tt::constants::TILE_HEIGHT == 0,
+        "qkv_causal_conv1d_silu: sequence must be positive and tile aligned");
+
+    for (const auto [tensor, name] : std::array{
+             std::pair{&in.tap0, "tap0"},
+             std::pair{&in.tap1, "tap1"},
+             std::pair{&in.tap2, "tap2"},
+             std::pair{&in.tap3, "tap3"}}) {
+        TT_FATAL(
+            tensor->logical_volume() == channels, "qkv_causal_conv1d_silu: {} logical volume must equal Q+K+V", name);
+    }
+    TT_FATAL(
+        !attrs.output_mem_config.is_sharded(),
+        "qkv_causal_conv1d_silu: output memory configuration must be interleaved");
+}
+
+QkvCausalConv1dSiluOperation::spec_return_value_t QkvCausalConv1dSiluOperation::compute_output_specs(
+    const operation_attributes_t& attrs, const tensor_args_t&) {
+    const auto layout = TensorLayout(DataType::BFLOAT16, PageConfig(Layout::TILE), attrs.output_mem_config);
+    return {
+        TensorSpec(Shape({1, attrs.sequence, attrs.q_width}), layout),
+        TensorSpec(Shape({1, attrs.sequence, attrs.k_width}), layout),
+        TensorSpec(Shape({1, attrs.sequence, attrs.v_width}), layout)};
+}
+
+QkvCausalConv1dSiluOperation::tensor_return_value_t QkvCausalConv1dSiluOperation::create_output_tensors(
+    const operation_attributes_t& attrs, const tensor_args_t& in) {
+    auto specs = compute_output_specs(attrs, in);
+    return {
+        create_device_tensor(specs[0], in.input.device()),
+        create_device_tensor(specs[1], in.input.device()),
+        create_device_tensor(specs[2], in.input.device())};
+}
+
+std::vector<Tensor> qkv_causal_conv1d_silu(
+    const Tensor& input,
+    const Tensor& history,
+    const Tensor& tap0,
+    const Tensor& tap1,
+    const Tensor& tap2,
+    const Tensor& tap3,
+    uint32_t q_width,
+    uint32_t k_width,
+    uint32_t v_width,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const DeviceComputeKernelConfig& compute_kernel_config) {
+    const auto& input_shape = input.logical_shape();
+    TT_FATAL(input_shape.rank() == 3, "qkv_causal_conv1d_silu: input must be [1,T,Q+K+V]");
+    return ttnn::device_operation::launch<QkvCausalConv1dSiluOperation>(
+        QkvCausalConv1dSiluParams{
+            .sequence = static_cast<uint32_t>(input_shape[1]),
+            .q_width = q_width,
+            .k_width = k_width,
+            .v_width = v_width,
+            .output_mem_config = output_mem_config,
+            .compute_kernel_config = compute_kernel_config},
+        QkvCausalConv1dSiluInputs{
+            .input = input, .history = history, .tap0 = tap0, .tap1 = tap1, .tap2 = tap2, .tap3 = tap3});
+}
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation.cpp
@@ -8,23 +8,11 @@
 #include <tt-metalium/constants.hpp>
 
 #include "ttnn/device_operation.hpp"
+#include "ttnn/operations/experimental/kda/factory/kda_factory_utils.hpp"
 
 using namespace tt::tt_metal;
 
 namespace ttnn::experimental::prim {
-namespace {
-
-void check_device_tensor(const Tensor& tensor, const char* name, Layout layout) {
-    TT_FATAL(
-        tensor.storage_type() == StorageType::DEVICE && tensor.buffer() != nullptr,
-        "qkv_causal_conv1d_silu: {} must be an allocated device tensor",
-        name);
-    TT_FATAL(tensor.layout() == layout, "qkv_causal_conv1d_silu: {} has unsupported layout", name);
-    TT_FATAL(tensor.dtype() == DataType::BFLOAT16, "qkv_causal_conv1d_silu: {} must be BFLOAT16", name);
-    TT_FATAL(!tensor.is_sharded(), "qkv_causal_conv1d_silu: {} must use interleaved memory", name);
-}
-
-}  // namespace
 
 QkvCausalConv1dSiluOperation::program_factory_t QkvCausalConv1dSiluOperation::select_program_factory(
     const operation_attributes_t&, const tensor_args_t&) {
@@ -33,17 +21,37 @@ QkvCausalConv1dSiluOperation::program_factory_t QkvCausalConv1dSiluOperation::se
 
 void QkvCausalConv1dSiluOperation::validate_on_program_cache_miss(
     const operation_attributes_t& attrs, const tensor_args_t& in) {
-    check_device_tensor(in.input, "input", Layout::ROW_MAJOR);
-    check_device_tensor(in.history, "history", Layout::ROW_MAJOR);
-    check_device_tensor(in.tap0, "tap0", Layout::TILE);
-    check_device_tensor(in.tap1, "tap1", Layout::TILE);
-    check_device_tensor(in.tap2, "tap2", Layout::TILE);
-    check_device_tensor(in.tap3, "tap3", Layout::TILE);
-
-    auto* const input_device = in.input.device();
-    for (const auto* tensor : std::array{&in.history, &in.tap0, &in.tap1, &in.tap2, &in.tap3}) {
-        TT_FATAL(tensor->device() == input_device, "qkv_causal_conv1d_silu: all inputs must be on the same device");
-    }
+    using namespace kda_factory_detail;
+    constexpr std::string_view operation_name = "qkv_causal_conv1d_silu";
+    check_allocated_device_tensor(in.input, operation_name, "input");
+    check_layout(in.input, Layout::ROW_MAJOR, operation_name, "input");
+    check_dtype(in.input, DataType::BFLOAT16, operation_name, "input");
+    check_interleaved(in.input, operation_name, "input");
+    check_allocated_device_tensor(in.history, operation_name, "history");
+    check_layout(in.history, Layout::ROW_MAJOR, operation_name, "history");
+    check_dtype(in.history, DataType::BFLOAT16, operation_name, "history");
+    check_interleaved(in.history, operation_name, "history");
+    check_allocated_device_tensor(in.tap0, operation_name, "tap0");
+    check_layout(in.tap0, Layout::TILE, operation_name, "tap0");
+    check_dtype(in.tap0, DataType::BFLOAT16, operation_name, "tap0");
+    check_interleaved(in.tap0, operation_name, "tap0");
+    check_allocated_device_tensor(in.tap1, operation_name, "tap1");
+    check_layout(in.tap1, Layout::TILE, operation_name, "tap1");
+    check_dtype(in.tap1, DataType::BFLOAT16, operation_name, "tap1");
+    check_interleaved(in.tap1, operation_name, "tap1");
+    check_allocated_device_tensor(in.tap2, operation_name, "tap2");
+    check_layout(in.tap2, Layout::TILE, operation_name, "tap2");
+    check_dtype(in.tap2, DataType::BFLOAT16, operation_name, "tap2");
+    check_interleaved(in.tap2, operation_name, "tap2");
+    check_allocated_device_tensor(in.tap3, operation_name, "tap3");
+    check_layout(in.tap3, Layout::TILE, operation_name, "tap3");
+    check_dtype(in.tap3, DataType::BFLOAT16, operation_name, "tap3");
+    check_interleaved(in.tap3, operation_name, "tap3");
+    check_same_device(in.input, in.history, operation_name, "history");
+    check_same_device(in.input, in.tap0, operation_name, "tap0");
+    check_same_device(in.input, in.tap1, operation_name, "tap1");
+    check_same_device(in.input, in.tap2, operation_name, "tap2");
+    check_same_device(in.input, in.tap3, operation_name, "tap3");
 
     TT_FATAL(
         attrs.q_width > 0 && attrs.k_width > 0 && attrs.v_width > 0,
@@ -80,13 +88,8 @@ void QkvCausalConv1dSiluOperation::validate_on_program_cache_miss(
         TT_FATAL(
             tensor->logical_volume() == channels, "qkv_causal_conv1d_silu: {} logical volume must equal Q+K+V", name);
     }
-    TT_FATAL(
-        !attrs.output_mem_config.is_sharded(),
-        "qkv_causal_conv1d_silu: output memory configuration must be interleaved");
-    TT_FATAL(
-        !attrs.compute_kernel_config.packer_l1_acc,
-        "qkv_causal_conv1d_silu: packer_l1_acc=true is unsupported because the compute kernel does not accumulate "
-        "through L1");
+    check_output_interleaved(attrs.output_mem_config, operation_name);
+    check_compute_config(attrs.compute_kernel_config, operation_name);
 }
 
 QkvCausalConv1dSiluOperation::spec_return_value_t QkvCausalConv1dSiluOperation::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation.cpp
@@ -87,11 +87,6 @@ void QkvCausalConv1dSiluOperation::validate_on_program_cache_miss(
         !attrs.compute_kernel_config.packer_l1_acc,
         "qkv_causal_conv1d_silu: packer_l1_acc=true is unsupported because the compute kernel does not accumulate "
         "through L1");
-    TT_FATAL(
-        attrs.compute_kernel_config.throttle_level ==
-            ttnn::operations::compute_throttle_utils::ThrottleLevel::NO_THROTTLE,
-        "qkv_causal_conv1d_silu: compute throttling is unsupported because this kernel does not implement throttled "
-        "math");
 }
 
 QkvCausalConv1dSiluOperation::spec_return_value_t QkvCausalConv1dSiluOperation::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation.cpp
@@ -83,6 +83,15 @@ void QkvCausalConv1dSiluOperation::validate_on_program_cache_miss(
     TT_FATAL(
         !attrs.output_mem_config.is_sharded(),
         "qkv_causal_conv1d_silu: output memory configuration must be interleaved");
+    TT_FATAL(
+        !attrs.compute_kernel_config.packer_l1_acc,
+        "qkv_causal_conv1d_silu: packer_l1_acc=true is unsupported because the compute kernel does not accumulate "
+        "through L1");
+    TT_FATAL(
+        attrs.compute_kernel_config.throttle_level ==
+            ttnn::operations::compute_throttle_utils::ThrottleLevel::NO_THROTTLE,
+        "qkv_causal_conv1d_silu: compute throttling is unsupported because this kernel does not implement throttled "
+        "math");
 }
 
 QkvCausalConv1dSiluOperation::spec_return_value_t QkvCausalConv1dSiluOperation::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation.hpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <variant>
+
+#include "qkv_causal_conv1d_silu_device_operation_types.hpp"
+#include "qkv_causal_conv1d_silu_program_factory.hpp"
+
+namespace ttnn::experimental::prim {
+
+struct QkvCausalConv1dSiluOperation {
+    using operation_attributes_t = QkvCausalConv1dSiluParams;
+    using tensor_args_t = QkvCausalConv1dSiluInputs;
+    using spec_return_value_t = std::vector<tt::tt_metal::TensorSpec>;
+    using tensor_return_value_t = std::vector<Tensor>;
+    using program_factory_t = std::variant<QkvCausalConv1dSiluProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+};
+
+std::vector<Tensor> qkv_causal_conv1d_silu(
+    const Tensor&,
+    const Tensor&,
+    const Tensor&,
+    const Tensor&,
+    const Tensor&,
+    const Tensor&,
+    uint32_t,
+    uint32_t,
+    uint32_t,
+    const tt::tt_metal::MemoryConfig&,
+    const DeviceComputeKernelConfig&);
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation.hpp
@@ -33,6 +33,7 @@ std::vector<Tensor> qkv_causal_conv1d_silu(
     uint32_t,
     uint32_t,
     uint32_t,
+    uint32_t,
     const tt::tt_metal::MemoryConfig&,
     const DeviceComputeKernelConfig&);
 

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation_types.hpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <vector>
+
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::experimental::prim {
+
+struct QkvCausalConv1dSiluParams {
+    uint32_t sequence;
+    uint32_t q_width;
+    uint32_t k_width;
+    uint32_t v_width;
+    tt::tt_metal::MemoryConfig output_mem_config;
+    DeviceComputeKernelConfig compute_kernel_config;
+};
+
+struct QkvCausalConv1dSiluInputs {
+    Tensor input;
+    Tensor history;
+    Tensor tap0;
+    Tensor tap1;
+    Tensor tap2;
+    Tensor tap3;
+};
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_device_operation_types.hpp
@@ -16,6 +16,7 @@ struct QkvCausalConv1dSiluParams {
     uint32_t q_width;
     uint32_t k_width;
     uint32_t v_width;
+    uint32_t channel_chunk_size;
     tt::tt_metal::MemoryConfig output_mem_config;
     DeviceComputeKernelConfig compute_kernel_config;
 };

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
@@ -83,13 +83,14 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
     const m2::TensorParamName K{"k"};
     const m2::TensorParamName V{"v"};
 
-    const uint32_t tile_size = tt::tile_size(tt::DataFormat::Float16_b);
-    auto make_dfb = [tile_size](const m2::DFBSpecName& name, uint32_t tiles) {
+    const auto input_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    const uint32_t tile_size = tt::tile_size(input_data_format);
+    auto make_dfb = [input_data_format, tile_size](const m2::DFBSpecName& name, uint32_t tiles) {
         return m2::DataflowBufferSpec{
             .unique_id = name,
             .entry_size = tile_size,
             .num_entries = tiles,
-            .data_format_metadata = tt::DataFormat::Float16_b,
+            .data_format_metadata = input_data_format,
         };
     };
 

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
@@ -26,16 +26,6 @@ namespace m2 = tt::tt_metal::experimental;
 
 namespace {
 
-uint32_t choose_channel_block_tiles(uint32_t channel_tiles) {
-    constexpr uint32_t max_single_block_channel_tiles = 48;
-    constexpr uint32_t wide_channel_block_tiles = 24;
-    uint32_t block_tiles = channel_tiles <= max_single_block_channel_tiles ? channel_tiles : wide_channel_block_tiles;
-    while (channel_tiles % block_tiles != 0) {
-        --block_tiles;
-    }
-    return block_tiles;
-}
-
 }  // namespace
 
 ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::create_program_artifacts(
@@ -57,7 +47,7 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
     const uint32_t Kt = attrs.k_width / TILE_WIDTH;
     const uint32_t Vt = attrs.v_width / TILE_WIDTH;
     const uint32_t Ct = Qt + Kt + Vt;
-    const uint32_t block_ct = choose_channel_block_tiles(Ct);
+    const uint32_t block_ct = attrs.channel_chunk_size / tt::constants::TILE_WIDTH;
     const uint32_t num_blocks = Ct / block_ct;
     auto dist = kda_factory_detail::distribute_prep(
         device.compute_with_storage_grid_size(), Mt * num_blocks, std::numeric_limits<uint32_t>::max());

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
@@ -63,25 +63,25 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
         device.compute_with_storage_grid_size(), Mt * num_blocks, std::numeric_limits<uint32_t>::max());
     const auto& cores = dist.core_set;
 
-    const m2::KernelSpecName READER{"reader"};
-    const m2::KernelSpecName WRITER{"writer"};
-    const m2::KernelSpecName COMPUTE{"compute"};
+    const m2::KernelSpecName reader_kernel_name{"reader"};
+    const m2::KernelSpecName writer_kernel_name{"writer"};
+    const m2::KernelSpecName compute_kernel_name{"compute"};
 
-    const m2::DFBSpecName ACT_RM_DFB{"act_rm"};
-    const m2::DFBSpecName ACT_TILE_DFB{"act_tile"};
-    const m2::DFBSpecName WEIGHTS_DFB{"weights"};
-    const m2::DFBSpecName PARTIAL_DFB{"partial"};
-    const m2::DFBSpecName OUTPUT_DFB{"output"};
+    const m2::DFBSpecName act_rm_dfb_name{"act_rm"};
+    const m2::DFBSpecName act_tile_dfb_name{"act_tile"};
+    const m2::DFBSpecName weights_dfb_name{"weights"};
+    const m2::DFBSpecName partial_dfb_name{"partial"};
+    const m2::DFBSpecName output_dfb_name{"output"};
 
-    const m2::TensorParamName INPUT{"input"};
-    const m2::TensorParamName HISTORY{"history"};
-    const m2::TensorParamName TAP0{"tap0"};
-    const m2::TensorParamName TAP1{"tap1"};
-    const m2::TensorParamName TAP2{"tap2"};
-    const m2::TensorParamName TAP3{"tap3"};
-    const m2::TensorParamName Q{"q"};
-    const m2::TensorParamName K{"k"};
-    const m2::TensorParamName V{"v"};
+    const m2::TensorParamName input_tensor_name{"input"};
+    const m2::TensorParamName history_tensor_name{"history"};
+    const m2::TensorParamName tap0_tensor_name{"tap0"};
+    const m2::TensorParamName tap1_tensor_name{"tap1"};
+    const m2::TensorParamName tap2_tensor_name{"tap2"};
+    const m2::TensorParamName tap3_tensor_name{"tap3"};
+    const m2::TensorParamName q_tensor_name{"q"};
+    const m2::TensorParamName k_tensor_name{"k"};
+    const m2::TensorParamName v_tensor_name{"v"};
 
     const auto input_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     const uint32_t tile_size = tt::tile_size(input_data_format);
@@ -95,31 +95,31 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
     };
 
     m2::Group<m2::DataflowBufferSpec> dfbs = {
-        make_dfb(ACT_RM_DFB, 2 * block_ct),
-        make_dfb(ACT_TILE_DFB, block_ct),
-        make_dfb(WEIGHTS_DFB, 4 * block_ct),
-        make_dfb(PARTIAL_DFB, 2 * block_ct),
-        make_dfb(OUTPUT_DFB, 2 * block_ct),
+        make_dfb(act_rm_dfb_name, 2 * block_ct),
+        make_dfb(act_tile_dfb_name, block_ct),
+        make_dfb(weights_dfb_name, 4 * block_ct),
+        make_dfb(partial_dfb_name, 2 * block_ct),
+        make_dfb(output_dfb_name, 2 * block_ct),
     };
 
     m2::KernelSpec reader{
-        .unique_id = READER,
+        .unique_id = reader_kernel_name,
         .source =
             "ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/"
             "reader_qkv_causal_conv1d_silu.cpp",
         .dfb_bindings =
             {
-                m2::DFBBinding{ACT_RM_DFB, "act_rm", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{WEIGHTS_DFB, "weights", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{act_rm_dfb_name, "act_rm", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{weights_dfb_name, "weights", m2::DFBEndpointType::PRODUCER},
             },
         .tensor_bindings =
             {
-                m2::TensorBinding{INPUT, "input"},
-                m2::TensorBinding{HISTORY, "history"},
-                m2::TensorBinding{TAP0, "tap0"},
-                m2::TensorBinding{TAP1, "tap1"},
-                m2::TensorBinding{TAP2, "tap2"},
-                m2::TensorBinding{TAP3, "tap3"},
+                m2::TensorBinding{input_tensor_name, "input"},
+                m2::TensorBinding{history_tensor_name, "history"},
+                m2::TensorBinding{tap0_tensor_name, "tap0"},
+                m2::TensorBinding{tap1_tensor_name, "tap1"},
+                m2::TensorBinding{tap2_tensor_name, "tap2"},
+                m2::TensorBinding{tap3_tensor_name, "tap3"},
             },
         .compile_time_args = {{"block_ct", block_ct}, {"num_blocks", num_blocks}},
         .runtime_arg_schema = {.runtime_arg_names = {"wi_start", "wi_count"}},
@@ -127,16 +127,16 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
     };
 
     m2::KernelSpec writer{
-        .unique_id = WRITER,
+        .unique_id = writer_kernel_name,
         .source =
             "ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/"
             "writer_qkv_causal_conv1d_silu.cpp",
-        .dfb_bindings = {m2::DFBBinding{OUTPUT_DFB, "output", m2::DFBEndpointType::CONSUMER}},
+        .dfb_bindings = {m2::DFBBinding{output_dfb_name, "output", m2::DFBEndpointType::CONSUMER}},
         .tensor_bindings =
             {
-                m2::TensorBinding{Q, "q"},
-                m2::TensorBinding{K, "k"},
-                m2::TensorBinding{V, "v"},
+                m2::TensorBinding{q_tensor_name, "q"},
+                m2::TensorBinding{k_tensor_name, "k"},
+                m2::TensorBinding{v_tensor_name, "v"},
             },
         .compile_time_args = {{"Qt", Qt}, {"Kt", Kt}, {"Vt", Vt}, {"block_ct", block_ct}, {"num_blocks", num_blocks}},
         .runtime_arg_schema = {.runtime_arg_names = {"wi_start", "wi_count"}},
@@ -144,29 +144,29 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
     };
 
     m2::KernelSpec compute{
-        .unique_id = COMPUTE,
+        .unique_id = compute_kernel_name,
         .source =
             "ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/compute/"
             "qkv_causal_conv1d_silu.cpp",
         .compiler_options = {.opt_level = KernelBuildOptLevel::O3},
         .dfb_bindings =
             {
-                m2::DFBBinding{ACT_RM_DFB, "act_rm", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{ACT_TILE_DFB, "act_tile", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{ACT_TILE_DFB, "act_tile", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{WEIGHTS_DFB, "weights", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{PARTIAL_DFB, "partial", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{PARTIAL_DFB, "partial", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{OUTPUT_DFB, "output", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{act_rm_dfb_name, "act_rm", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{act_tile_dfb_name, "act_tile", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{act_tile_dfb_name, "act_tile", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{weights_dfb_name, "weights", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{partial_dfb_name, "partial", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{partial_dfb_name, "partial", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{output_dfb_name, "output", m2::DFBEndpointType::PRODUCER},
             },
         .compile_time_args = {{"block_ct", block_ct}, {"num_blocks", num_blocks}},
         .runtime_arg_schema = {.runtime_arg_names = {"wi_count"}},
         .hw_config = ttnn::to_compute_hardware_config(arch, attrs.compute_kernel_config),
     };
 
-    m2::KernelRunArgs reader_run_args{.kernel = READER};
-    m2::KernelRunArgs writer_run_args{.kernel = WRITER};
-    m2::KernelRunArgs compute_run_args{.kernel = COMPUTE};
+    m2::KernelRunArgs reader_run_args{.kernel = reader_kernel_name};
+    m2::KernelRunArgs writer_run_args{.kernel = writer_kernel_name};
+    m2::KernelRunArgs compute_run_args{.kernel = compute_kernel_name};
     for (uint32_t i = 0; i < dist.cores.size(); ++i) {
         const auto& core = dist.cores[i];
         m2::AddRuntimeArgsForNode(
@@ -182,21 +182,21 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
         .dataflow_buffers = std::move(dfbs),
         .tensor_parameters =
             {
-                m2::TensorParameter{.unique_id = INPUT, .spec = input.tensor_spec()},
-                m2::TensorParameter{.unique_id = HISTORY, .spec = history.tensor_spec()},
-                m2::TensorParameter{.unique_id = TAP0, .spec = tap0.tensor_spec()},
-                m2::TensorParameter{.unique_id = TAP1, .spec = tap1.tensor_spec()},
-                m2::TensorParameter{.unique_id = TAP2, .spec = tap2.tensor_spec()},
-                m2::TensorParameter{.unique_id = TAP3, .spec = tap3.tensor_spec()},
-                m2::TensorParameter{.unique_id = Q, .spec = q.tensor_spec()},
-                m2::TensorParameter{.unique_id = K, .spec = k.tensor_spec()},
-                m2::TensorParameter{.unique_id = V, .spec = v.tensor_spec()},
+                m2::TensorParameter{.unique_id = input_tensor_name, .spec = input.tensor_spec()},
+                m2::TensorParameter{.unique_id = history_tensor_name, .spec = history.tensor_spec()},
+                m2::TensorParameter{.unique_id = tap0_tensor_name, .spec = tap0.tensor_spec()},
+                m2::TensorParameter{.unique_id = tap1_tensor_name, .spec = tap1.tensor_spec()},
+                m2::TensorParameter{.unique_id = tap2_tensor_name, .spec = tap2.tensor_spec()},
+                m2::TensorParameter{.unique_id = tap3_tensor_name, .spec = tap3.tensor_spec()},
+                m2::TensorParameter{.unique_id = q_tensor_name, .spec = q.tensor_spec()},
+                m2::TensorParameter{.unique_id = k_tensor_name, .spec = k.tensor_spec()},
+                m2::TensorParameter{.unique_id = v_tensor_name, .spec = v.tensor_spec()},
             },
         .work_units =
             {
                 m2::WorkUnitSpec{
                     .name = "main",
-                    .kernels = {READER, WRITER, COMPUTE},
+                    .kernels = {reader_kernel_name, writer_kernel_name, compute_kernel_name},
                     .target_nodes = cores,
                 },
             },
@@ -208,15 +208,15 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
     run_args.kernel_run_args.push_back(std::move(writer_run_args));
     run_args.kernel_run_args.push_back(std::move(compute_run_args));
     run_args.tensor_args = {
-        {INPUT, input},
-        {HISTORY, history},
-        {TAP0, tap0},
-        {TAP1, tap1},
-        {TAP2, tap2},
-        {TAP3, tap3},
-        {Q, q},
-        {K, k},
-        {V, v},
+        {input_tensor_name, input},
+        {history_tensor_name, history},
+        {tap0_tensor_name, tap0},
+        {tap1_tensor_name, tap1},
+        {tap2_tensor_name, tap2},
+        {tap3_tensor_name, tap3},
+        {q_tensor_name, q},
+        {k_tensor_name, k},
+        {v_tensor_name, v},
     };
 
     return ttnn::device_operation::ProgramArtifacts{

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
@@ -3,6 +3,7 @@
 
 #include "ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.hpp"
 
+#include <limits>
 #include <vector>
 
 #include <tt-metalium/constants.hpp>
@@ -23,6 +24,20 @@ namespace ttnn::experimental::prim {
 
 namespace m2 = tt::tt_metal::experimental;
 
+namespace {
+
+uint32_t choose_channel_block_tiles(uint32_t channel_tiles) {
+    constexpr uint32_t max_single_block_channel_tiles = 48;
+    constexpr uint32_t wide_channel_block_tiles = 24;
+    uint32_t block_tiles = channel_tiles <= max_single_block_channel_tiles ? channel_tiles : wide_channel_block_tiles;
+    while (channel_tiles % block_tiles != 0) {
+        --block_tiles;
+    }
+    return block_tiles;
+}
+
+}  // namespace
+
 ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::create_program_artifacts(
     const QkvCausalConv1dSiluParams& attrs, const QkvCausalConv1dSiluInputs& in, std::vector<Tensor>& outputs) {
     const auto& input = in.input.mesh_tensor();
@@ -42,12 +57,10 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
     const uint32_t Kt = attrs.k_width / TILE_WIDTH;
     const uint32_t Vt = attrs.v_width / TILE_WIDTH;
     const uint32_t Ct = Qt + Kt + Vt;
-    uint32_t block_ct = Ct <= 48 ? Ct : 24u;
-    while (Ct % block_ct != 0) {
-        --block_ct;
-    }
+    const uint32_t block_ct = choose_channel_block_tiles(Ct);
     const uint32_t num_blocks = Ct / block_ct;
-    auto dist = kda_factory_detail::distribute_prep(device.compute_with_storage_grid_size(), Mt * num_blocks, ~0u);
+    auto dist = kda_factory_detail::distribute_prep(
+        device.compute_with_storage_grid_size(), Mt * num_blocks, std::numeric_limits<uint32_t>::max());
     const auto& cores = dist.core_set;
 
     const m2::KernelSpecName READER{"reader"};
@@ -70,10 +83,11 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
     const m2::TensorParamName K{"k"};
     const m2::TensorParamName V{"v"};
 
-    auto make_dfb = [](const m2::DFBSpecName& name, uint32_t tiles) {
+    const uint32_t tile_size = tt::tile_size(tt::DataFormat::Float16_b);
+    auto make_dfb = [tile_size](const m2::DFBSpecName& name, uint32_t tiles) {
         return m2::DataflowBufferSpec{
             .unique_id = name,
-            .entry_size = tt::tile_size(tt::DataFormat::Float16_b),
+            .entry_size = tile_size,
             .num_entries = tiles,
             .data_format_metadata = tt::DataFormat::Float16_b,
         };

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
@@ -21,6 +21,9 @@ namespace ttnn::experimental::prim {
 
 namespace {
 
+// Kimi-K3 supplies four learned causal-convolution taps; one channel block of weights is queued per tap.
+constexpr uint32_t tap_count = 4;
+
 }  // namespace
 
 ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::create_program_artifacts(
@@ -83,7 +86,7 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
     tt::tt_metal::experimental::Group<tt::tt_metal::experimental::DataflowBufferSpec> dfbs = {
         make_dfb(act_rm_dfb_name, 2 * block_ct),
         make_dfb(act_tile_dfb_name, block_ct),
-        make_dfb(weights_dfb_name, 4 * block_ct),
+        make_dfb(weights_dfb_name, tap_count * block_ct),
         make_dfb(partial_dfb_name, 2 * block_ct),
         make_dfb(output_dfb_name, 2 * block_ct),
     };

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
@@ -17,12 +17,7 @@
 #include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 #include "ttnn/operations/experimental/kda/factory/kda_factory_utils.hpp"
 
-using namespace tt::tt_metal;
-using namespace tt::constants;
-
 namespace ttnn::experimental::prim {
-
-namespace m2 = tt::tt_metal::experimental;
 
 namespace {
 
@@ -42,10 +37,10 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
     const auto& device = input.device();
     const auto arch = device.arch();
 
-    const uint32_t Mt = attrs.sequence / TILE_HEIGHT;
-    const uint32_t Qt = attrs.q_width / TILE_WIDTH;
-    const uint32_t Kt = attrs.k_width / TILE_WIDTH;
-    const uint32_t Vt = attrs.v_width / TILE_WIDTH;
+    const uint32_t Mt = attrs.sequence / tt::constants::TILE_HEIGHT;
+    const uint32_t Qt = attrs.q_width / tt::constants::TILE_WIDTH;
+    const uint32_t Kt = attrs.k_width / tt::constants::TILE_WIDTH;
+    const uint32_t Vt = attrs.v_width / tt::constants::TILE_WIDTH;
     const uint32_t Ct = Qt + Kt + Vt;
     const uint32_t block_ct = attrs.channel_chunk_size / tt::constants::TILE_WIDTH;
     const uint32_t num_blocks = Ct / block_ct;
@@ -53,30 +48,31 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
         device.compute_with_storage_grid_size(), Mt * num_blocks, std::numeric_limits<uint32_t>::max());
     const auto& cores = dist.core_set;
 
-    const m2::KernelSpecName reader_kernel_name{"reader"};
-    const m2::KernelSpecName writer_kernel_name{"writer"};
-    const m2::KernelSpecName compute_kernel_name{"compute"};
+    const tt::tt_metal::experimental::KernelSpecName reader_kernel_name{"reader"};
+    const tt::tt_metal::experimental::KernelSpecName writer_kernel_name{"writer"};
+    const tt::tt_metal::experimental::KernelSpecName compute_kernel_name{"compute"};
 
-    const m2::DFBSpecName act_rm_dfb_name{"act_rm"};
-    const m2::DFBSpecName act_tile_dfb_name{"act_tile"};
-    const m2::DFBSpecName weights_dfb_name{"weights"};
-    const m2::DFBSpecName partial_dfb_name{"partial"};
-    const m2::DFBSpecName output_dfb_name{"output"};
+    const tt::tt_metal::experimental::DFBSpecName act_rm_dfb_name{"act_rm"};
+    const tt::tt_metal::experimental::DFBSpecName act_tile_dfb_name{"act_tile"};
+    const tt::tt_metal::experimental::DFBSpecName weights_dfb_name{"weights"};
+    const tt::tt_metal::experimental::DFBSpecName partial_dfb_name{"partial"};
+    const tt::tt_metal::experimental::DFBSpecName output_dfb_name{"output"};
 
-    const m2::TensorParamName input_tensor_name{"input"};
-    const m2::TensorParamName history_tensor_name{"history"};
-    const m2::TensorParamName tap0_tensor_name{"tap0"};
-    const m2::TensorParamName tap1_tensor_name{"tap1"};
-    const m2::TensorParamName tap2_tensor_name{"tap2"};
-    const m2::TensorParamName tap3_tensor_name{"tap3"};
-    const m2::TensorParamName q_tensor_name{"q"};
-    const m2::TensorParamName k_tensor_name{"k"};
-    const m2::TensorParamName v_tensor_name{"v"};
+    const tt::tt_metal::experimental::TensorParamName input_tensor_name{"input"};
+    const tt::tt_metal::experimental::TensorParamName history_tensor_name{"history"};
+    const tt::tt_metal::experimental::TensorParamName tap0_tensor_name{"tap0"};
+    const tt::tt_metal::experimental::TensorParamName tap1_tensor_name{"tap1"};
+    const tt::tt_metal::experimental::TensorParamName tap2_tensor_name{"tap2"};
+    const tt::tt_metal::experimental::TensorParamName tap3_tensor_name{"tap3"};
+    const tt::tt_metal::experimental::TensorParamName q_tensor_name{"q"};
+    const tt::tt_metal::experimental::TensorParamName k_tensor_name{"k"};
+    const tt::tt_metal::experimental::TensorParamName v_tensor_name{"v"};
 
     const auto input_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
     const uint32_t tile_size = tt::tile_size(input_data_format);
-    auto make_dfb = [input_data_format, tile_size](const m2::DFBSpecName& name, uint32_t tiles) {
-        return m2::DataflowBufferSpec{
+    auto make_dfb = [input_data_format, tile_size](
+                        const tt::tt_metal::experimental::DFBSpecName& name, uint32_t tiles) {
+        return tt::tt_metal::experimental::DataflowBufferSpec{
             .unique_id = name,
             .entry_size = tile_size,
             .num_entries = tiles,
@@ -84,7 +80,7 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
         };
     };
 
-    m2::Group<m2::DataflowBufferSpec> dfbs = {
+    tt::tt_metal::experimental::Group<tt::tt_metal::experimental::DataflowBufferSpec> dfbs = {
         make_dfb(act_rm_dfb_name, 2 * block_ct),
         make_dfb(act_tile_dfb_name, block_ct),
         make_dfb(weights_dfb_name, 4 * block_ct),
@@ -92,99 +88,112 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
         make_dfb(output_dfb_name, 2 * block_ct),
     };
 
-    m2::KernelSpec reader{
+    tt::tt_metal::experimental::KernelSpec reader{
         .unique_id = reader_kernel_name,
         .source =
             "ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/"
             "reader_qkv_causal_conv1d_silu.cpp",
         .dfb_bindings =
             {
-                m2::DFBBinding{act_rm_dfb_name, "act_rm", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{weights_dfb_name, "weights", m2::DFBEndpointType::PRODUCER},
+                tt::tt_metal::experimental::DFBBinding{
+                    act_rm_dfb_name, "act_rm", tt::tt_metal::experimental::DFBEndpointType::PRODUCER},
+                tt::tt_metal::experimental::DFBBinding{
+                    weights_dfb_name, "weights", tt::tt_metal::experimental::DFBEndpointType::PRODUCER},
             },
         .tensor_bindings =
             {
-                m2::TensorBinding{input_tensor_name, "input"},
-                m2::TensorBinding{history_tensor_name, "history"},
-                m2::TensorBinding{tap0_tensor_name, "tap0"},
-                m2::TensorBinding{tap1_tensor_name, "tap1"},
-                m2::TensorBinding{tap2_tensor_name, "tap2"},
-                m2::TensorBinding{tap3_tensor_name, "tap3"},
+                tt::tt_metal::experimental::TensorBinding{input_tensor_name, "input"},
+                tt::tt_metal::experimental::TensorBinding{history_tensor_name, "history"},
+                tt::tt_metal::experimental::TensorBinding{tap0_tensor_name, "tap0"},
+                tt::tt_metal::experimental::TensorBinding{tap1_tensor_name, "tap1"},
+                tt::tt_metal::experimental::TensorBinding{tap2_tensor_name, "tap2"},
+                tt::tt_metal::experimental::TensorBinding{tap3_tensor_name, "tap3"},
             },
         .compile_time_args = {{"block_ct", block_ct}, {"num_blocks", num_blocks}},
         .runtime_arg_schema = {.runtime_arg_names = {"wi_start", "wi_count"}},
         .hw_config = ttnn::create_reader_datamovement_config(arch),
     };
 
-    m2::KernelSpec writer{
+    tt::tt_metal::experimental::KernelSpec writer{
         .unique_id = writer_kernel_name,
         .source =
             "ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/"
             "writer_qkv_causal_conv1d_silu.cpp",
-        .dfb_bindings = {m2::DFBBinding{output_dfb_name, "output", m2::DFBEndpointType::CONSUMER}},
+        .dfb_bindings = {tt::tt_metal::experimental::DFBBinding{
+            output_dfb_name, "output", tt::tt_metal::experimental::DFBEndpointType::CONSUMER}},
         .tensor_bindings =
             {
-                m2::TensorBinding{q_tensor_name, "q"},
-                m2::TensorBinding{k_tensor_name, "k"},
-                m2::TensorBinding{v_tensor_name, "v"},
+                tt::tt_metal::experimental::TensorBinding{q_tensor_name, "q"},
+                tt::tt_metal::experimental::TensorBinding{k_tensor_name, "k"},
+                tt::tt_metal::experimental::TensorBinding{v_tensor_name, "v"},
             },
         .compile_time_args = {{"Qt", Qt}, {"Kt", Kt}, {"Vt", Vt}, {"block_ct", block_ct}, {"num_blocks", num_blocks}},
         .runtime_arg_schema = {.runtime_arg_names = {"wi_start", "wi_count"}},
         .hw_config = ttnn::create_writer_datamovement_config(arch),
     };
 
-    m2::KernelSpec compute{
+    tt::tt_metal::experimental::KernelSpec compute{
         .unique_id = compute_kernel_name,
         .source =
             "ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/compute/"
             "qkv_causal_conv1d_silu.cpp",
-        .compiler_options = {.opt_level = KernelBuildOptLevel::O3},
+        .compiler_options = {.opt_level = tt::tt_metal::KernelBuildOptLevel::O3},
         .dfb_bindings =
             {
-                m2::DFBBinding{act_rm_dfb_name, "act_rm", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{act_tile_dfb_name, "act_tile", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{act_tile_dfb_name, "act_tile", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{weights_dfb_name, "weights", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{partial_dfb_name, "partial", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{partial_dfb_name, "partial", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{output_dfb_name, "output", m2::DFBEndpointType::PRODUCER},
+                tt::tt_metal::experimental::DFBBinding{
+                    act_rm_dfb_name, "act_rm", tt::tt_metal::experimental::DFBEndpointType::CONSUMER},
+                tt::tt_metal::experimental::DFBBinding{
+                    act_tile_dfb_name, "act_tile", tt::tt_metal::experimental::DFBEndpointType::PRODUCER},
+                tt::tt_metal::experimental::DFBBinding{
+                    act_tile_dfb_name, "act_tile", tt::tt_metal::experimental::DFBEndpointType::CONSUMER},
+                tt::tt_metal::experimental::DFBBinding{
+                    weights_dfb_name, "weights", tt::tt_metal::experimental::DFBEndpointType::CONSUMER},
+                tt::tt_metal::experimental::DFBBinding{
+                    partial_dfb_name, "partial", tt::tt_metal::experimental::DFBEndpointType::PRODUCER},
+                tt::tt_metal::experimental::DFBBinding{
+                    partial_dfb_name, "partial", tt::tt_metal::experimental::DFBEndpointType::CONSUMER},
+                tt::tt_metal::experimental::DFBBinding{
+                    output_dfb_name, "output", tt::tt_metal::experimental::DFBEndpointType::PRODUCER},
             },
         .compile_time_args = {{"block_ct", block_ct}, {"num_blocks", num_blocks}},
         .runtime_arg_schema = {.runtime_arg_names = {"wi_count"}},
         .hw_config = ttnn::to_compute_hardware_config(arch, attrs.compute_kernel_config),
     };
 
-    m2::KernelRunArgs reader_run_args{.kernel = reader_kernel_name};
-    m2::KernelRunArgs writer_run_args{.kernel = writer_kernel_name};
-    m2::KernelRunArgs compute_run_args{.kernel = compute_kernel_name};
+    tt::tt_metal::experimental::KernelRunArgs reader_run_args{.kernel = reader_kernel_name};
+    tt::tt_metal::experimental::KernelRunArgs writer_run_args{.kernel = writer_kernel_name};
+    tt::tt_metal::experimental::KernelRunArgs compute_run_args{.kernel = compute_kernel_name};
     for (uint32_t i = 0; i < dist.cores.size(); ++i) {
         const auto& core = dist.cores[i];
-        m2::AddRuntimeArgsForNode(
+        tt::tt_metal::experimental::AddRuntimeArgsForNode(
             reader_run_args.runtime_arg_values, core, {{"wi_start", dist.wi_start[i]}, {"wi_count", dist.wi_count[i]}});
-        m2::AddRuntimeArgsForNode(
+        tt::tt_metal::experimental::AddRuntimeArgsForNode(
             writer_run_args.runtime_arg_values, core, {{"wi_start", dist.wi_start[i]}, {"wi_count", dist.wi_count[i]}});
-        m2::AddRuntimeArgsForNode(compute_run_args.runtime_arg_values, core, {{"wi_count", dist.wi_count[i]}});
+        tt::tt_metal::experimental::AddRuntimeArgsForNode(
+            compute_run_args.runtime_arg_values, core, {{"wi_count", dist.wi_count[i]}});
     }
 
-    m2::ProgramSpec spec{
+    tt::tt_metal::experimental::ProgramSpec spec{
         .name = "qkv_causal_conv1d_silu",
         .kernels = {std::move(reader), std::move(writer), std::move(compute)},
         .dataflow_buffers = std::move(dfbs),
         .tensor_parameters =
             {
-                m2::TensorParameter{.unique_id = input_tensor_name, .spec = input.tensor_spec()},
-                m2::TensorParameter{.unique_id = history_tensor_name, .spec = history.tensor_spec()},
-                m2::TensorParameter{.unique_id = tap0_tensor_name, .spec = tap0.tensor_spec()},
-                m2::TensorParameter{.unique_id = tap1_tensor_name, .spec = tap1.tensor_spec()},
-                m2::TensorParameter{.unique_id = tap2_tensor_name, .spec = tap2.tensor_spec()},
-                m2::TensorParameter{.unique_id = tap3_tensor_name, .spec = tap3.tensor_spec()},
-                m2::TensorParameter{.unique_id = q_tensor_name, .spec = q.tensor_spec()},
-                m2::TensorParameter{.unique_id = k_tensor_name, .spec = k.tensor_spec()},
-                m2::TensorParameter{.unique_id = v_tensor_name, .spec = v.tensor_spec()},
+                tt::tt_metal::experimental::TensorParameter{
+                    .unique_id = input_tensor_name, .spec = input.tensor_spec()},
+                tt::tt_metal::experimental::TensorParameter{
+                    .unique_id = history_tensor_name, .spec = history.tensor_spec()},
+                tt::tt_metal::experimental::TensorParameter{.unique_id = tap0_tensor_name, .spec = tap0.tensor_spec()},
+                tt::tt_metal::experimental::TensorParameter{.unique_id = tap1_tensor_name, .spec = tap1.tensor_spec()},
+                tt::tt_metal::experimental::TensorParameter{.unique_id = tap2_tensor_name, .spec = tap2.tensor_spec()},
+                tt::tt_metal::experimental::TensorParameter{.unique_id = tap3_tensor_name, .spec = tap3.tensor_spec()},
+                tt::tt_metal::experimental::TensorParameter{.unique_id = q_tensor_name, .spec = q.tensor_spec()},
+                tt::tt_metal::experimental::TensorParameter{.unique_id = k_tensor_name, .spec = k.tensor_spec()},
+                tt::tt_metal::experimental::TensorParameter{.unique_id = v_tensor_name, .spec = v.tensor_spec()},
             },
         .work_units =
             {
-                m2::WorkUnitSpec{
+                tt::tt_metal::experimental::WorkUnitSpec{
                     .name = "main",
                     .kernels = {reader_kernel_name, writer_kernel_name, compute_kernel_name},
                     .target_nodes = cores,
@@ -192,7 +201,7 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
             },
     };
 
-    m2::ProgramRunArgs run_args;
+    tt::tt_metal::experimental::ProgramRunArgs run_args;
     run_args.kernel_run_args.reserve(3);
     run_args.kernel_run_args.push_back(std::move(reader_run_args));
     run_args.kernel_run_args.push_back(std::move(writer_run_args));

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "qkv_causal_conv1d_silu_program_factory.hpp"
+
+#include <vector>
+
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "ttnn/operations/experimental/kda/factory/kda_factory_utils.hpp"
+
+using namespace tt::tt_metal;
+using namespace tt::constants;
+
+namespace ttnn::experimental::prim {
+
+tt::tt_metal::ProgramDescriptor QkvCausalConv1dSiluProgramFactory::create_descriptor(
+    const QkvCausalConv1dSiluParams& attrs, const QkvCausalConv1dSiluInputs& in, std::vector<Tensor>& outputs) {
+    constexpr uint32_t act_rm_cb = tt::CBIndex::c_0;
+    constexpr uint32_t act_tile_cb = tt::CBIndex::c_1;
+    constexpr uint32_t weights_cb = tt::CBIndex::c_2;
+    constexpr uint32_t partial_a_cb = tt::CBIndex::c_3;
+    constexpr uint32_t partial_b_cb = tt::CBIndex::c_4;
+    constexpr uint32_t output_cb = tt::CBIndex::c_5;
+    const uint32_t Mt = attrs.sequence / TILE_HEIGHT;
+    const uint32_t Qt = attrs.q_width / TILE_WIDTH;
+    const uint32_t Kt = attrs.k_width / TILE_WIDTH;
+    const uint32_t Vt = attrs.v_width / TILE_WIDTH;
+    const uint32_t Ct = Qt + Kt + Vt;
+    const uint32_t channels = attrs.q_width + attrs.k_width + attrs.v_width;
+    const uint32_t row_bytes = channels * sizeof(uint16_t);
+    // Preserve the single-block TP8 case. Wider local head shards use smaller blocks so the nine CBs coexist in L1.
+    uint32_t block_ct = Ct <= 48 ? Ct : 24u;
+    while (Ct % block_ct != 0) {
+        --block_ct;
+    }
+    const uint32_t num_blocks = Ct / block_ct;
+    auto dist =
+        kda_factory_detail::distribute_prep(in.input.device()->compute_with_storage_grid_size(), Mt * num_blocks, ~0u);
+    const auto& cores = dist.core_set;
+
+    ProgramDescriptor desc;
+    auto add_tile_cb = [&](uint32_t idx, uint32_t tiles) {
+        const uint32_t tile_size = tt::tile_size(tt::DataFormat::Float16_b);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = tiles * tile_size,
+            .core_ranges = cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(idx),
+                .data_format = tt::DataFormat::Float16_b,
+                .page_size = tile_size}}}});
+    };
+    add_tile_cb(act_rm_cb, block_ct);
+    add_tile_cb(act_tile_cb, block_ct);
+    add_tile_cb(weights_cb, 4 * block_ct);
+    add_tile_cb(partial_a_cb, block_ct);
+    add_tile_cb(partial_b_cb, block_ct);
+    add_tile_cb(output_cb, block_ct);
+
+    std::vector<uint32_t> reader_ct = {block_ct, channels, row_bytes, num_blocks};
+    TensorAccessorArgs(*in.input.buffer()).append_to(reader_ct);
+    TensorAccessorArgs(*in.history.buffer()).append_to(reader_ct);
+    TensorAccessorArgs(*in.tap0.buffer()).append_to(reader_ct);
+    TensorAccessorArgs(*in.tap1.buffer()).append_to(reader_ct);
+    TensorAccessorArgs(*in.tap2.buffer()).append_to(reader_ct);
+    TensorAccessorArgs(*in.tap3.buffer()).append_to(reader_ct);
+    std::vector<uint32_t> writer_ct = {Qt, Kt, Vt, block_ct, num_blocks};
+    TensorAccessorArgs(*outputs[0].buffer()).append_to(writer_ct);
+    TensorAccessorArgs(*outputs[1].buffer()).append_to(writer_ct);
+    TensorAccessorArgs(*outputs[2].buffer()).append_to(writer_ct);
+
+    KernelDescriptor reader;
+    reader.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/"
+        "reader_qkv_causal_conv1d_silu.cpp";
+    reader.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader.core_ranges = cores;
+    reader.compile_time_args = reader_ct;
+    reader.config = ReaderConfigDescriptor{};
+    KernelDescriptor writer;
+    writer.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/"
+        "writer_qkv_causal_conv1d_silu.cpp";
+    writer.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer.core_ranges = cores;
+    writer.compile_time_args = writer_ct;
+    writer.config = WriterConfigDescriptor{};
+    KernelDescriptor compute;
+    compute.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/compute/"
+        "qkv_causal_conv1d_silu.cpp";
+    compute.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute.core_ranges = cores;
+    compute.compile_time_args = {block_ct, num_blocks};
+    compute.config = kda_factory_detail::kda_compute_cfg(in.input.device()->arch(), attrs.compute_kernel_config);
+
+    for (uint32_t i = 0; i < dist.cores.size(); ++i) {
+        const auto& core = dist.cores[i];
+        reader.emplace_runtime_args(
+            core,
+            {dist.wi_start[i],
+             dist.wi_count[i],
+             in.input.buffer(),
+             in.history.buffer(),
+             in.tap0.buffer(),
+             in.tap1.buffer(),
+             in.tap2.buffer(),
+             in.tap3.buffer()});
+        writer.emplace_runtime_args(
+            core, {dist.wi_start[i], dist.wi_count[i], outputs[0].buffer(), outputs[1].buffer(), outputs[2].buffer()});
+        compute.emplace_runtime_args(core, {dist.wi_count[i]});
+    }
+    desc.kernels.push_back(std::move(reader));
+    desc.kernels.push_back(std::move(writer));
+    desc.kernels.push_back(std::move(compute));
+    return desc;
+}
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
@@ -42,8 +42,6 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
     const uint32_t Kt = attrs.k_width / TILE_WIDTH;
     const uint32_t Vt = attrs.v_width / TILE_WIDTH;
     const uint32_t Ct = Qt + Kt + Vt;
-    const uint32_t channels = attrs.q_width + attrs.k_width + attrs.v_width;
-    const uint32_t row_bytes = channels * sizeof(uint16_t);
     uint32_t block_ct = Ct <= 48 ? Ct : 24u;
     while (Ct % block_ct != 0) {
         --block_ct;
@@ -110,8 +108,7 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
                 m2::TensorBinding{TAP2, "tap2"},
                 m2::TensorBinding{TAP3, "tap3"},
             },
-        .compile_time_args =
-            {{"block_ct", block_ct}, {"channels", channels}, {"row_bytes", row_bytes}, {"num_blocks", num_blocks}},
+        .compile_time_args = {{"block_ct", block_ct}, {"num_blocks", num_blocks}},
         .runtime_arg_schema = {.runtime_arg_names = {"wi_start", "wi_count"}},
         .hw_config = ttnn::create_reader_datamovement_config(arch),
     };

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
@@ -80,11 +80,11 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
     };
 
     m2::Group<m2::DataflowBufferSpec> dfbs = {
-        make_dfb(ACT_RM_DFB, block_ct),
+        make_dfb(ACT_RM_DFB, 2 * block_ct),
         make_dfb(ACT_TILE_DFB, block_ct),
         make_dfb(WEIGHTS_DFB, 4 * block_ct),
         make_dfb(PARTIAL_DFB, 2 * block_ct),
-        make_dfb(OUTPUT_DFB, block_ct),
+        make_dfb(OUTPUT_DFB, 2 * block_ct),
     };
 
     m2::KernelSpec reader{

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
@@ -1,14 +1,19 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "qkv_causal_conv1d_silu_program_factory.hpp"
+#include "ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.hpp"
 
 #include <vector>
 
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/kernel_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp>
 
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 #include "ttnn/operations/experimental/kda/factory/kda_factory_utils.hpp"
 
 using namespace tt::tt_metal;
@@ -16,14 +21,22 @@ using namespace tt::constants;
 
 namespace ttnn::experimental::prim {
 
-tt::tt_metal::ProgramDescriptor QkvCausalConv1dSiluProgramFactory::create_descriptor(
+namespace m2 = tt::tt_metal::experimental;
+
+ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::create_program_artifacts(
     const QkvCausalConv1dSiluParams& attrs, const QkvCausalConv1dSiluInputs& in, std::vector<Tensor>& outputs) {
-    constexpr uint32_t act_rm_cb = tt::CBIndex::c_0;
-    constexpr uint32_t act_tile_cb = tt::CBIndex::c_1;
-    constexpr uint32_t weights_cb = tt::CBIndex::c_2;
-    constexpr uint32_t partial_a_cb = tt::CBIndex::c_3;
-    constexpr uint32_t partial_b_cb = tt::CBIndex::c_4;
-    constexpr uint32_t output_cb = tt::CBIndex::c_5;
+    const auto& input = in.input.mesh_tensor();
+    const auto& history = in.history.mesh_tensor();
+    const auto& tap0 = in.tap0.mesh_tensor();
+    const auto& tap1 = in.tap1.mesh_tensor();
+    const auto& tap2 = in.tap2.mesh_tensor();
+    const auto& tap3 = in.tap3.mesh_tensor();
+    const auto& q = outputs[0].mesh_tensor();
+    const auto& k = outputs[1].mesh_tensor();
+    const auto& v = outputs[2].mesh_tensor();
+    const auto& device = input.device();
+    const auto arch = device.arch();
+
     const uint32_t Mt = attrs.sequence / TILE_HEIGHT;
     const uint32_t Qt = attrs.q_width / TILE_WIDTH;
     const uint32_t Kt = attrs.k_width / TILE_WIDTH;
@@ -31,91 +44,177 @@ tt::tt_metal::ProgramDescriptor QkvCausalConv1dSiluProgramFactory::create_descri
     const uint32_t Ct = Qt + Kt + Vt;
     const uint32_t channels = attrs.q_width + attrs.k_width + attrs.v_width;
     const uint32_t row_bytes = channels * sizeof(uint16_t);
-    // Preserve the single-block TP8 case. Wider local head shards use smaller blocks so the nine CBs coexist in L1.
     uint32_t block_ct = Ct <= 48 ? Ct : 24u;
     while (Ct % block_ct != 0) {
         --block_ct;
     }
     const uint32_t num_blocks = Ct / block_ct;
-    auto dist =
-        kda_factory_detail::distribute_prep(in.input.device()->compute_with_storage_grid_size(), Mt * num_blocks, ~0u);
+    auto dist = kda_factory_detail::distribute_prep(device.compute_with_storage_grid_size(), Mt * num_blocks, ~0u);
     const auto& cores = dist.core_set;
 
-    ProgramDescriptor desc;
-    auto add_tile_cb = [&](uint32_t idx, uint32_t tiles) {
-        const uint32_t tile_size = tt::tile_size(tt::DataFormat::Float16_b);
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = tiles * tile_size,
-            .core_ranges = cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(idx),
-                .data_format = tt::DataFormat::Float16_b,
-                .page_size = tile_size}}}});
+    const m2::KernelSpecName READER{"reader"};
+    const m2::KernelSpecName WRITER{"writer"};
+    const m2::KernelSpecName COMPUTE{"compute"};
+
+    const m2::DFBSpecName ACT_RM_DFB{"act_rm"};
+    const m2::DFBSpecName ACT_TILE_DFB{"act_tile"};
+    const m2::DFBSpecName WEIGHTS_DFB{"weights"};
+    const m2::DFBSpecName PARTIAL_A_DFB{"partial_a"};
+    const m2::DFBSpecName PARTIAL_B_DFB{"partial_b"};
+    const m2::DFBSpecName OUTPUT_DFB{"output"};
+
+    const m2::TensorParamName INPUT{"input"};
+    const m2::TensorParamName HISTORY{"history"};
+    const m2::TensorParamName TAP0{"tap0"};
+    const m2::TensorParamName TAP1{"tap1"};
+    const m2::TensorParamName TAP2{"tap2"};
+    const m2::TensorParamName TAP3{"tap3"};
+    const m2::TensorParamName Q{"q"};
+    const m2::TensorParamName K{"k"};
+    const m2::TensorParamName V{"v"};
+
+    auto make_dfb = [](const m2::DFBSpecName& name, uint32_t tiles) {
+        return m2::DataflowBufferSpec{
+            .unique_id = name,
+            .entry_size = tt::tile_size(tt::DataFormat::Float16_b),
+            .num_entries = tiles,
+            .data_format_metadata = tt::DataFormat::Float16_b,
+        };
     };
-    add_tile_cb(act_rm_cb, block_ct);
-    add_tile_cb(act_tile_cb, block_ct);
-    add_tile_cb(weights_cb, 4 * block_ct);
-    add_tile_cb(partial_a_cb, block_ct);
-    add_tile_cb(partial_b_cb, block_ct);
-    add_tile_cb(output_cb, block_ct);
 
-    std::vector<uint32_t> reader_ct = {block_ct, channels, row_bytes, num_blocks};
-    TensorAccessorArgs(*in.input.buffer()).append_to(reader_ct);
-    TensorAccessorArgs(*in.history.buffer()).append_to(reader_ct);
-    TensorAccessorArgs(*in.tap0.buffer()).append_to(reader_ct);
-    TensorAccessorArgs(*in.tap1.buffer()).append_to(reader_ct);
-    TensorAccessorArgs(*in.tap2.buffer()).append_to(reader_ct);
-    TensorAccessorArgs(*in.tap3.buffer()).append_to(reader_ct);
-    std::vector<uint32_t> writer_ct = {Qt, Kt, Vt, block_ct, num_blocks};
-    TensorAccessorArgs(*outputs[0].buffer()).append_to(writer_ct);
-    TensorAccessorArgs(*outputs[1].buffer()).append_to(writer_ct);
-    TensorAccessorArgs(*outputs[2].buffer()).append_to(writer_ct);
+    m2::Group<m2::DataflowBufferSpec> dfbs = {
+        make_dfb(ACT_RM_DFB, block_ct),
+        make_dfb(ACT_TILE_DFB, block_ct),
+        make_dfb(WEIGHTS_DFB, 4 * block_ct),
+        make_dfb(PARTIAL_A_DFB, block_ct),
+        make_dfb(PARTIAL_B_DFB, block_ct),
+        make_dfb(OUTPUT_DFB, block_ct),
+    };
 
-    KernelDescriptor reader;
-    reader.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/"
-        "reader_qkv_causal_conv1d_silu.cpp";
-    reader.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader.core_ranges = cores;
-    reader.compile_time_args = reader_ct;
-    reader.config = ReaderConfigDescriptor{};
-    KernelDescriptor writer;
-    writer.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/"
-        "writer_qkv_causal_conv1d_silu.cpp";
-    writer.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer.core_ranges = cores;
-    writer.compile_time_args = writer_ct;
-    writer.config = WriterConfigDescriptor{};
-    KernelDescriptor compute;
-    compute.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/compute/"
-        "qkv_causal_conv1d_silu.cpp";
-    compute.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute.core_ranges = cores;
-    compute.compile_time_args = {block_ct, num_blocks};
-    compute.config = kda_factory_detail::kda_compute_cfg(in.input.device()->arch(), attrs.compute_kernel_config);
+    m2::KernelSpec reader{
+        .unique_id = READER,
+        .source =
+            "ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/"
+            "reader_qkv_causal_conv1d_silu.cpp",
+        .dfb_bindings =
+            {
+                m2::DFBBinding{ACT_RM_DFB, "act_rm", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{WEIGHTS_DFB, "weights", m2::DFBEndpointType::PRODUCER},
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{INPUT, "input"},
+                m2::TensorBinding{HISTORY, "history"},
+                m2::TensorBinding{TAP0, "tap0"},
+                m2::TensorBinding{TAP1, "tap1"},
+                m2::TensorBinding{TAP2, "tap2"},
+                m2::TensorBinding{TAP3, "tap3"},
+            },
+        .compile_time_args =
+            {{"block_ct", block_ct}, {"channels", channels}, {"row_bytes", row_bytes}, {"num_blocks", num_blocks}},
+        .runtime_arg_schema = {.runtime_arg_names = {"wi_start", "wi_count"}},
+        .hw_config = ttnn::create_reader_datamovement_config(arch),
+    };
 
+    m2::KernelSpec writer{
+        .unique_id = WRITER,
+        .source =
+            "ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/dataflow/"
+            "writer_qkv_causal_conv1d_silu.cpp",
+        .dfb_bindings = {m2::DFBBinding{OUTPUT_DFB, "output", m2::DFBEndpointType::CONSUMER}},
+        .tensor_bindings =
+            {
+                m2::TensorBinding{Q, "q"},
+                m2::TensorBinding{K, "k"},
+                m2::TensorBinding{V, "v"},
+            },
+        .compile_time_args = {{"Qt", Qt}, {"Kt", Kt}, {"Vt", Vt}, {"block_ct", block_ct}, {"num_blocks", num_blocks}},
+        .runtime_arg_schema = {.runtime_arg_names = {"wi_start", "wi_count"}},
+        .hw_config = ttnn::create_writer_datamovement_config(arch),
+    };
+
+    m2::KernelSpec compute{
+        .unique_id = COMPUTE,
+        .source =
+            "ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/kernels/compute/"
+            "qkv_causal_conv1d_silu.cpp",
+        .compiler_options = {.opt_level = KernelBuildOptLevel::O3},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{ACT_RM_DFB, "act_rm", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{ACT_TILE_DFB, "act_tile", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{ACT_TILE_DFB, "act_tile", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{WEIGHTS_DFB, "weights", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{PARTIAL_A_DFB, "partial_a", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{PARTIAL_A_DFB, "partial_a", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{PARTIAL_B_DFB, "partial_b", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{PARTIAL_B_DFB, "partial_b", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{OUTPUT_DFB, "output", m2::DFBEndpointType::PRODUCER},
+            },
+        .compile_time_args = {{"block_ct", block_ct}, {"num_blocks", num_blocks}},
+        .runtime_arg_schema = {.runtime_arg_names = {"wi_count"}},
+        .hw_config = ttnn::to_compute_hardware_config(arch, attrs.compute_kernel_config),
+    };
+
+    m2::KernelRunArgs reader_run_args{.kernel = READER};
+    m2::KernelRunArgs writer_run_args{.kernel = WRITER};
+    m2::KernelRunArgs compute_run_args{.kernel = COMPUTE};
     for (uint32_t i = 0; i < dist.cores.size(); ++i) {
         const auto& core = dist.cores[i];
-        reader.emplace_runtime_args(
-            core,
-            {dist.wi_start[i],
-             dist.wi_count[i],
-             in.input.buffer(),
-             in.history.buffer(),
-             in.tap0.buffer(),
-             in.tap1.buffer(),
-             in.tap2.buffer(),
-             in.tap3.buffer()});
-        writer.emplace_runtime_args(
-            core, {dist.wi_start[i], dist.wi_count[i], outputs[0].buffer(), outputs[1].buffer(), outputs[2].buffer()});
-        compute.emplace_runtime_args(core, {dist.wi_count[i]});
+        m2::AddRuntimeArgsForNode(
+            reader_run_args.runtime_arg_values, core, {{"wi_start", dist.wi_start[i]}, {"wi_count", dist.wi_count[i]}});
+        m2::AddRuntimeArgsForNode(
+            writer_run_args.runtime_arg_values, core, {{"wi_start", dist.wi_start[i]}, {"wi_count", dist.wi_count[i]}});
+        m2::AddRuntimeArgsForNode(compute_run_args.runtime_arg_values, core, {{"wi_count", dist.wi_count[i]}});
     }
-    desc.kernels.push_back(std::move(reader));
-    desc.kernels.push_back(std::move(writer));
-    desc.kernels.push_back(std::move(compute));
-    return desc;
+
+    m2::ProgramSpec spec{
+        .name = "qkv_causal_conv1d_silu",
+        .kernels = {std::move(reader), std::move(writer), std::move(compute)},
+        .dataflow_buffers = std::move(dfbs),
+        .tensor_parameters =
+            {
+                m2::TensorParameter{.unique_id = INPUT, .spec = input.tensor_spec()},
+                m2::TensorParameter{.unique_id = HISTORY, .spec = history.tensor_spec()},
+                m2::TensorParameter{.unique_id = TAP0, .spec = tap0.tensor_spec()},
+                m2::TensorParameter{.unique_id = TAP1, .spec = tap1.tensor_spec()},
+                m2::TensorParameter{.unique_id = TAP2, .spec = tap2.tensor_spec()},
+                m2::TensorParameter{.unique_id = TAP3, .spec = tap3.tensor_spec()},
+                m2::TensorParameter{.unique_id = Q, .spec = q.tensor_spec()},
+                m2::TensorParameter{.unique_id = K, .spec = k.tensor_spec()},
+                m2::TensorParameter{.unique_id = V, .spec = v.tensor_spec()},
+            },
+        .work_units =
+            {
+                m2::WorkUnitSpec{
+                    .name = "main",
+                    .kernels = {READER, WRITER, COMPUTE},
+                    .target_nodes = cores,
+                },
+            },
+    };
+
+    m2::ProgramRunArgs run_args;
+    run_args.kernel_run_args.reserve(3);
+    run_args.kernel_run_args.push_back(std::move(reader_run_args));
+    run_args.kernel_run_args.push_back(std::move(writer_run_args));
+    run_args.kernel_run_args.push_back(std::move(compute_run_args));
+    run_args.tensor_args = {
+        {INPUT, input},
+        {HISTORY, history},
+        {TAP0, tap0},
+        {TAP1, tap1},
+        {TAP2, tap2},
+        {TAP3, tap3},
+        {Q, q},
+        {K, k},
+        {V, v},
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{
+        .spec = std::move(spec),
+        .run_params = std::move(run_args),
+    };
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.cpp
@@ -57,8 +57,7 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
     const m2::DFBSpecName ACT_RM_DFB{"act_rm"};
     const m2::DFBSpecName ACT_TILE_DFB{"act_tile"};
     const m2::DFBSpecName WEIGHTS_DFB{"weights"};
-    const m2::DFBSpecName PARTIAL_A_DFB{"partial_a"};
-    const m2::DFBSpecName PARTIAL_B_DFB{"partial_b"};
+    const m2::DFBSpecName PARTIAL_DFB{"partial"};
     const m2::DFBSpecName OUTPUT_DFB{"output"};
 
     const m2::TensorParamName INPUT{"input"};
@@ -84,8 +83,7 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
         make_dfb(ACT_RM_DFB, block_ct),
         make_dfb(ACT_TILE_DFB, block_ct),
         make_dfb(WEIGHTS_DFB, 4 * block_ct),
-        make_dfb(PARTIAL_A_DFB, block_ct),
-        make_dfb(PARTIAL_B_DFB, block_ct),
+        make_dfb(PARTIAL_DFB, 2 * block_ct),
         make_dfb(OUTPUT_DFB, block_ct),
     };
 
@@ -142,10 +140,8 @@ ttnn::device_operation::ProgramArtifacts QkvCausalConv1dSiluProgramFactory::crea
                 m2::DFBBinding{ACT_TILE_DFB, "act_tile", m2::DFBEndpointType::PRODUCER},
                 m2::DFBBinding{ACT_TILE_DFB, "act_tile", m2::DFBEndpointType::CONSUMER},
                 m2::DFBBinding{WEIGHTS_DFB, "weights", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{PARTIAL_A_DFB, "partial_a", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{PARTIAL_A_DFB, "partial_a", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{PARTIAL_B_DFB, "partial_b", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{PARTIAL_B_DFB, "partial_b", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{PARTIAL_DFB, "partial", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{PARTIAL_DFB, "partial", m2::DFBEndpointType::CONSUMER},
                 m2::DFBBinding{OUTPUT_DFB, "output", m2::DFBEndpointType::PRODUCER},
             },
         .compile_time_args = {{"block_ct", block_ct}, {"num_blocks", num_blocks}},

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.hpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "qkv_causal_conv1d_silu_device_operation_types.hpp"
+
+namespace ttnn::experimental::prim {
+
+struct QkvCausalConv1dSiluProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const QkvCausalConv1dSiluParams&, const QkvCausalConv1dSiluInputs&, std::vector<Tensor>&);
+};
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/device/qkv_causal_conv1d_silu_program_factory.hpp
@@ -4,11 +4,12 @@
 #pragma once
 
 #include "qkv_causal_conv1d_silu_device_operation_types.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
 
 namespace ttnn::experimental::prim {
 
 struct QkvCausalConv1dSiluProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const QkvCausalConv1dSiluParams&, const QkvCausalConv1dSiluInputs&, std::vector<Tensor>&);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/qkv_causal_conv1d_silu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/qkv_causal_conv1d_silu.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "qkv_causal_conv1d_silu.hpp"
+#include "device/qkv_causal_conv1d_silu_device_operation.hpp"
+
+namespace ttnn::experimental::kda {
+
+std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> qkv_causal_conv1d_silu(
+    const ttnn::Tensor& input,
+    const ttnn::Tensor& history,
+    const ttnn::Tensor& tap0,
+    const ttnn::Tensor& tap1,
+    const ttnn::Tensor& tap2,
+    const ttnn::Tensor& tap3,
+    uint32_t q_width,
+    uint32_t k_width,
+    uint32_t v_width,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config) {
+    TT_FATAL(
+        input.storage_type() == StorageType::DEVICE && input.buffer() != nullptr,
+        "qkv_causal_conv1d_silu: input must be an allocated device tensor");
+    const auto output_memory_config = memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG);
+    const auto kernel_config = init_device_compute_kernel_config(
+        input.device()->arch(),
+        compute_kernel_config,
+        MathFidelity::HiFi4,
+        /*default_approx_mode=*/true,
+        /*default_fp32_acc=*/false,
+        /*default_l1_acc=*/false);
+    auto outputs = ttnn::experimental::prim::qkv_causal_conv1d_silu(
+        input, history, tap0, tap1, tap2, tap3, q_width, k_width, v_width, output_memory_config, kernel_config);
+    return {outputs[0], outputs[1], outputs[2]};
+}
+
+}  // namespace ttnn::experimental::kda

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/qkv_causal_conv1d_silu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/qkv_causal_conv1d_silu.cpp
@@ -27,7 +27,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> qkv_causal_conv1d_silu(
         input.device()->arch(),
         compute_kernel_config,
         MathFidelity::HiFi4,
-        /*default_approx_mode=*/true,
+        /*default_approx_mode=*/false,
         /*default_fp32_acc=*/false,
         /*default_l1_acc=*/false);
     auto outputs = ttnn::experimental::prim::qkv_causal_conv1d_silu(

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/qkv_causal_conv1d_silu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/qkv_causal_conv1d_silu.cpp
@@ -16,6 +16,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> qkv_causal_conv1d_silu(
     uint32_t q_width,
     uint32_t k_width,
     uint32_t v_width,
+    const QkvCausalConv1dSiluProgramConfig& program_config,
     const std::optional<ttnn::MemoryConfig>& memory_config,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config) {
     TT_FATAL(
@@ -30,7 +31,18 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> qkv_causal_conv1d_silu(
         /*default_fp32_acc=*/false,
         /*default_l1_acc=*/false);
     auto outputs = ttnn::experimental::prim::qkv_causal_conv1d_silu(
-        input, history, tap0, tap1, tap2, tap3, q_width, k_width, v_width, output_memory_config, kernel_config);
+        input,
+        history,
+        tap0,
+        tap1,
+        tap2,
+        tap3,
+        q_width,
+        k_width,
+        v_width,
+        program_config.channel_chunk_size,
+        output_memory_config,
+        kernel_config);
     return {outputs[0], outputs[1], outputs[2]};
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/qkv_causal_conv1d_silu.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/qkv_causal_conv1d_silu.hpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include <tuple>
+
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::experimental::kda {
+
+std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> qkv_causal_conv1d_silu(
+    const ttnn::Tensor& input,
+    const ttnn::Tensor& history,
+    const ttnn::Tensor& tap0,
+    const ttnn::Tensor& tap1,
+    const ttnn::Tensor& tap2,
+    const ttnn::Tensor& tap3,
+    uint32_t q_width,
+    uint32_t k_width,
+    uint32_t v_width,
+    const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
+
+}  // namespace ttnn::experimental::kda

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/qkv_causal_conv1d_silu.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/qkv_causal_conv1d_silu.hpp
@@ -12,6 +12,10 @@
 
 namespace ttnn::experimental::kda {
 
+struct QkvCausalConv1dSiluProgramConfig {
+    uint32_t channel_chunk_size;
+};
+
 std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> qkv_causal_conv1d_silu(
     const ttnn::Tensor& input,
     const ttnn::Tensor& history,
@@ -22,6 +26,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> qkv_causal_conv1d_silu(
     uint32_t q_width,
     uint32_t k_width,
     uint32_t v_width,
+    const QkvCausalConv1dSiluProgramConfig& program_config,
     const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
 

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/qkv_causal_conv1d_silu_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/qkv_causal_conv1d_silu_nanobind.cpp
@@ -5,6 +5,13 @@
 #include "ttnn-nanobind/bind_function.hpp"
 namespace ttnn::operations::experimental::kda::qkv_causal_conv1d_silu::detail {
 void bind_qkv_causal_conv1d_silu(nb::module_& mod) {
+    nb::class_<ttnn::experimental::kda::QkvCausalConv1dSiluProgramConfig>(mod, "QkvCausalConv1dSiluProgramConfig")
+        .def(nb::init<uint32_t>(), nb::kw_only(), nb::arg("channel_chunk_size").noconvert())
+        .def_ro("channel_chunk_size", &ttnn::experimental::kda::QkvCausalConv1dSiluProgramConfig::channel_chunk_size)
+        .def("__repr__", [](const ttnn::experimental::kda::QkvCausalConv1dSiluProgramConfig& config) {
+            return fmt::format("QkvCausalConv1dSiluProgramConfig(channel_chunk_size={})", config.channel_chunk_size);
+        });
+
     ttnn::bind_function<"qkv_causal_conv1d_silu", "ttnn.experimental.kda.">(
         mod,
         R"doc(
@@ -32,6 +39,8 @@ void bind_qkv_causal_conv1d_silu(nb::module_& mod) {
             v_width (int): Output V width.
 
         Keyword Args:
+            program_config (QkvCausalConv1dSiluProgramConfig): Required program tuning;
+                ``channel_chunk_size`` is expressed in logical channels.
             memory_config (ttnn.MemoryConfig, optional): Interleaved output memory
                 configuration. Defaults to DRAM.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional):
@@ -57,6 +66,7 @@ void bind_qkv_causal_conv1d_silu(nb::module_& mod) {
         nb::arg("k_width"),
         nb::arg("v_width"),
         nb::kw_only(),
+        nb::arg("program_config").noconvert(),
         nb::arg("memory_config") = nb::none(),
         nb::arg("compute_kernel_config") = nb::none());
 }

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/qkv_causal_conv1d_silu_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/qkv_causal_conv1d_silu_nanobind.cpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#include "qkv_causal_conv1d_silu_nanobind.hpp"
+#include "qkv_causal_conv1d_silu.hpp"
+#include "ttnn-nanobind/bind_function.hpp"
+namespace ttnn::operations::experimental::kda::qkv_causal_conv1d_silu::detail {
+void bind_qkv_causal_conv1d_silu(nb::module_& mod) {
+    ttnn::bind_function<"qkv_causal_conv1d_silu", "ttnn.experimental.kda.">(
+        mod,
+        R"doc(Four-tap KDA causal convolution with direct tiled Q/K/V outputs.)doc",
+        &ttnn::experimental::kda::qkv_causal_conv1d_silu,
+        nb::arg("input").noconvert(),
+        nb::arg("history").noconvert(),
+        nb::arg("tap0").noconvert(),
+        nb::arg("tap1").noconvert(),
+        nb::arg("tap2").noconvert(),
+        nb::arg("tap3").noconvert(),
+        nb::arg("q_width"),
+        nb::arg("k_width"),
+        nb::arg("v_width"),
+        nb::kw_only(),
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("compute_kernel_config") = nb::none());
+}
+}  // namespace ttnn::operations::experimental::kda::qkv_causal_conv1d_silu::detail

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/qkv_causal_conv1d_silu_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/qkv_causal_conv1d_silu_nanobind.cpp
@@ -7,7 +7,45 @@ namespace ttnn::operations::experimental::kda::qkv_causal_conv1d_silu::detail {
 void bind_qkv_causal_conv1d_silu(nb::module_& mod) {
     ttnn::bind_function<"qkv_causal_conv1d_silu", "ttnn.experimental.kda.">(
         mod,
-        R"doc(Four-tap KDA causal convolution with direct tiled Q/K/V outputs.)doc",
+        R"doc(
+        Apply a four-tap depthwise causal convolution with SiLU and split the
+        result directly into Q, K, and V tensors.
+
+        Let ``x[-3:-1]`` be the supplied history and ``x[0:T]`` the current input.
+        For each token and channel:
+
+            convolved[t] =
+                tap0 * x[t-3] + tap1 * x[t-2] + tap2 * x[t-1] + tap3 * x[t]
+            q, k, v = split(silu(convolved), [q_width, k_width, v_width])
+
+        Args:
+            input (ttnn.Tensor): Current tokens ``[1, T, Q+K+V]``. Must be an
+                interleaved ROW_MAJOR BFLOAT16 device tensor.
+            history (ttnn.Tensor): The three tokens preceding ``input``, shaped
+                ``[1, 3, Q+K+V]``. Must be an interleaved ROW_MAJOR BFLOAT16
+                device tensor.
+            tap0, tap1, tap2, tap3 (ttnn.Tensor): Per-channel convolution taps.
+                Each must have logical volume ``Q+K+V`` and be an interleaved
+                TILE-layout BFLOAT16 device tensor.
+            q_width (int): Output Q width.
+            k_width (int): Output K width.
+            v_width (int): Output V width.
+
+        Keyword Args:
+            memory_config (ttnn.MemoryConfig, optional): Interleaved output memory
+                configuration. Defaults to DRAM.
+            compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional):
+                Compute-kernel configuration.
+
+        Returns:
+            tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]: New TILE-layout BFLOAT16
+                tensors ``q[1,T,Q]``, ``k[1,T,K]``, and ``v[1,T,V]``.
+
+        Note:
+            ``T``, ``Q``, ``K``, and ``V`` must be positive and tile-aligned.
+            All inputs must be allocated on the same device. Inputs, including
+            ``history``, are not modified; the caller owns history updates.
+        )doc",
         &ttnn::experimental::kda::qkv_causal_conv1d_silu,
         nb::arg("input").noconvert(),
         nb::arg("history").noconvert(),

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/qkv_causal_conv1d_silu_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/qkv_causal_conv1d_silu_nanobind.hpp
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+#include <nanobind/nanobind.h>
+namespace nb = nanobind;
+namespace ttnn::operations::experimental::kda::qkv_causal_conv1d_silu::detail {
+void bind_qkv_causal_conv1d_silu(nb::module_&);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/sources.cmake
@@ -6,8 +6,6 @@ set(TTNN_OP_EXPERIMENTAL_KDA_QKV_CAUSAL_CONV1D_SILU_SRCS
     device/qkv_causal_conv1d_silu_program_factory.cpp
 )
 
-set(TTNN_OP_EXPERIMENTAL_KDA_SHARED_SRCS ../factory/kda_factory_utils.cpp)
-
 set(TTNN_OP_EXPERIMENTAL_KDA_QKV_CAUSAL_CONV1D_SILU_NANOBIND_SRCS
     qkv_causal_conv1d_silu_nanobind.cpp
     ../kda_nanobind.cpp

--- a/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/sources.cmake
@@ -1,0 +1,14 @@
+set(TTNN_OP_EXPERIMENTAL_KDA_QKV_CAUSAL_CONV1D_SILU_API_HEADERS qkv_causal_conv1d_silu.hpp)
+
+set(TTNN_OP_EXPERIMENTAL_KDA_QKV_CAUSAL_CONV1D_SILU_SRCS
+    qkv_causal_conv1d_silu.cpp
+    device/qkv_causal_conv1d_silu_device_operation.cpp
+    device/qkv_causal_conv1d_silu_program_factory.cpp
+)
+
+set(TTNN_OP_EXPERIMENTAL_KDA_SHARED_SRCS ../factory/kda_factory_utils.cpp)
+
+set(TTNN_OP_EXPERIMENTAL_KDA_QKV_CAUSAL_CONV1D_SILU_NANOBIND_SRCS
+    qkv_causal_conv1d_silu_nanobind.cpp
+    ../kda_nanobind.cpp
+)

--- a/ttnn/cpp/ttnn/operations/experimental/kda/sigmoid_gated_rms_norm/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/sigmoid_gated_rms_norm/CMakeLists.txt
@@ -28,10 +28,16 @@ target_sources(
         FILES ${kernels}
     PRIVATE
         ${TTNN_OP_EXPERIMENTAL_KDA_SIGMOID_GATED_RMS_NORM_SRCS}
-        ${TTNN_OP_EXPERIMENTAL_KDA_SHARED_SRCS}
 )
 
-target_link_libraries(ttnn_op_experimental_kda_sigmoid_gated_rms_norm PRIVATE TT::Metalium PUBLIC TTNN::Core)
+target_link_libraries(
+    ttnn_op_experimental_kda_sigmoid_gated_rms_norm
+    PRIVATE
+        TT::Metalium
+        TTNN::Ops::Experimental::KDA::Common
+    PUBLIC
+        TTNN::Core
+)
 
 install(
     TARGETS

--- a/ttnn/cpp/ttnn/operations/experimental/kda/sigmoid_gated_rms_norm/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/sigmoid_gated_rms_norm/sources.cmake
@@ -6,8 +6,6 @@ set(TTNN_OP_EXPERIMENTAL_KDA_SIGMOID_GATED_RMS_NORM_SRCS
     device/sigmoid_gated_rms_norm_program_factory.cpp
 )
 
-set(TTNN_OP_EXPERIMENTAL_KDA_SHARED_SRCS ../factory/kda_factory_utils.cpp)
-
 set(TTNN_OP_EXPERIMENTAL_KDA_SIGMOID_GATED_RMS_NORM_NANOBIND_SRCS
     sigmoid_gated_rms_norm_nanobind.cpp
     ../kda_nanobind.cpp

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -596,6 +596,8 @@ from ttnn.operations.transformer import SDPAProgramConfig, PagedCacheGeometryOve
 
 transformer.SparseKVFormat = SparseKVFormat
 
+QkvCausalConv1dSiluProgramConfig = ttnn._ttnn.operations.experimental.kda.QkvCausalConv1dSiluProgramConfig
+
 IndexerScoreProgramConfig = ttnn._ttnn.operations.experimental.IndexerScoreProgramConfig
 
 import ttnn.graph


### PR DESCRIPTION
Adds `ttnn.experimental.kda.qkv_causal_conv1d_silu`, one operation from the [full change PR #51910](https://github.com/tenstorrent/tt-metal/pull/51910).

The operation applies a four-tap depthwise causal convolution to the combined QKV projection, applies SiLU, and splits the result into Q, K, and V:

`z[t] = SiLU(Σᵢ₌₀³ tapᵢ · concat(history, x)[t+i])`

`(q, k, v) = split(z, Q, K, V)`

It accepts `x[1, T, Q+K+V]`, three history rows `history[1, 3, Q+K+V]`, and four channel-wise taps. It returns tiled `q[1,T,Q]`, `k[1,T,K]`, and `v[1,T,V]`.

History is explicit, read-only, and caller-owned so the operation remains stateless and independent of sequence-parallel halo orchestration. Producing split tiled outputs directly avoids materializing a combined convolution result and running separate activation, layout-conversion, and split operations.

The fused implementation measured a 74.36–75.76% latency reduction over the equivalent unfused operations (historical #51910 A/B evidence, accepted by the approved split plan; not re-measured under the device profiler), with direct Q/K/V PCC 0.999986–0.999988.

### Test plan

[![Sanity tests • Blackhole](https://img.shields.io/github/actions/workflow/status/tenstorrent/tt-metal/sanity-tests.yaml?branch=kda-split%2F02-qkv-causal-conv1d-silu&event=workflow_dispatch&label=Sanity%20tests%20%E2%80%A2%20Blackhole&logo=githubactions)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch%3Akda-split%2F02-qkv-causal-conv1d-silu)
[![L2 nightly • Blackhole experimental](https://img.shields.io/github/actions/workflow/status/tenstorrent/tt-metal/tt-metal-l2-nightly.yaml?branch=kda-split%2F02-qkv-causal-conv1d-silu&event=workflow_dispatch&label=L2%20nightly%20%E2%80%A2%20Blackhole%20experimental&logo=githubactions)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch%3Akda-split%2F02-qkv-causal-conv1d-silu)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kda-split/02-qkv-causal-conv1d-silu)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kda-split/02-qkv-causal-conv1d-silu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kda-split/02-qkv-causal-conv1d-silu)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kda-split/02-qkv-causal-conv1d-silu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kda-split/02-qkv-causal-conv1d-silu)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kda-split/02-qkv-causal-conv1d-silu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kda-split/02-qkv-causal-conv1d-silu)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kda-split/02-qkv-causal-conv1d-silu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kda-split/02-qkv-causal-conv1d-silu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kda-split/02-qkv-causal-conv1d-silu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kda-split/02-qkv-causal-conv1d-silu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kda-split/02-qkv-causal-conv1d-silu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kda-split/02-qkv-causal-conv1d-silu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kda-split/02-qkv-causal-conv1d-silu)