### PR TITLE
[KDA 3/8] Add ordered affine-transform reduction

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/conftest.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/conftest.py
@@ -6,8 +6,13 @@ import pytest
 
 @pytest.fixture
 def isolated_program_cache(device):
+    # Setup: give the test an enabled, empty program cache.
     device.disable_and_clear_program_cache()
     device.enable_program_cache()
+
+    # Yield control to pytest to execute the test.
     yield
+
+    # Teardown: remove programs created by the test and restore the enabled, empty state.
     device.disable_and_clear_program_cache()
     device.enable_program_cache()

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/conftest.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/conftest.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+
+@pytest.fixture
+def isolated_program_cache(device):
+    device.disable_and_clear_program_cache()
+    device.enable_program_cache()
+    yield
+    device.disable_and_clear_program_cache()
+    device.enable_program_cache()

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_qkv_causal_conv1d_silu.py
@@ -24,7 +24,7 @@ from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import (
 
 pytestmark = [
     run_for_blackhole(),
-    pytest.mark.parametrize("device_params", [{"l1_small_size": 24576}], indirect=True),
+    pytest.mark.use_module_device({"l1_small_size": 24576}),
 ]
 
 _SEQUENCE = 64
@@ -218,7 +218,9 @@ def test_qkv_causal_conv1d_silu_is_device_deterministic(device: ttnn.Device, cas
         ttnn.deallocate(output)
 
 
-def test_qkv_causal_conv1d_silu_cache_hit_rebinds_fresh_tensors(device: ttnn.Device) -> None:
+def test_qkv_causal_conv1d_silu_cache_hit_rebinds_fresh_tensors(
+    device: ttnn.Device, isolated_program_cache: None
+) -> None:
     widths = (128, 128, 128)
     host_a, device_inputs_a = _device_inputs(device, widths=widths, sequence=32, seed=1911)
     host_b, device_inputs_b = _device_inputs(device, widths=widths, sequence=32, seed=1912)
@@ -253,7 +255,9 @@ def test_qkv_causal_conv1d_silu_cache_hit_rebinds_fresh_tensors(device: ttnn.Dev
         assert not torch.equal(actual_a, actual_b)
 
 
-def test_qkv_causal_conv1d_silu_default_compute_config_matches_explicit_defaults(device: ttnn.Device) -> None:
+def test_qkv_causal_conv1d_silu_default_compute_config_matches_explicit_defaults(
+    device: ttnn.Device, isolated_program_cache: None
+) -> None:
     _, (input_tt, history_tt, taps_tt) = _device_inputs(device, sequence=32, widths=(128, 128, 128), seed=817)
     implicit = _run(input_tt, history_tt, taps_tt, widths=(128, 128, 128), channel_chunk_size=384)
     entries = device.num_program_cache_entries()
@@ -356,7 +360,9 @@ def test_qkv_causal_conv1d_silu_production_performance(device: ttnn.Device, case
     )
 
 
-def test_qkv_causal_conv1d_silu_program_key_includes_split_widths(device: ttnn.Device) -> None:
+def test_qkv_causal_conv1d_silu_program_key_includes_split_widths(
+    device: ttnn.Device, isolated_program_cache: None
+) -> None:
     _, (input_tt, history_tt, taps_tt) = _device_inputs(device, widths=(128, 128, 128), sequence=32, seed=772)
     _run(input_tt, history_tt, taps_tt, widths=(128, 128, 128), channel_chunk_size=384)
     entries = device.num_program_cache_entries()
@@ -366,7 +372,9 @@ def test_qkv_causal_conv1d_silu_program_key_includes_split_widths(device: ttnn.D
     assert device.num_program_cache_entries() == entries + 1
 
 
-def test_qkv_causal_conv1d_silu_program_key_includes_channel_chunk_size(device: ttnn.Device) -> None:
+def test_qkv_causal_conv1d_silu_program_key_includes_channel_chunk_size(
+    device: ttnn.Device, isolated_program_cache: None
+) -> None:
     widths = (128, 128, 128)
     _, (input_tt, history_tt, taps_tt) = _device_inputs(device, widths=widths, sequence=32, seed=773)
     _run(input_tt, history_tt, taps_tt, widths=widths, channel_chunk_size=384)

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_reduce_affine_transforms.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_reduce_affine_transforms.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 """Direct contract coverage for experimental KDA affine-transform reduction."""
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_reduce_affine_transforms.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_reduce_affine_transforms.py
@@ -1,0 +1,263 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Direct contract coverage for experimental KDA affine-transform reduction."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import assert_accurate, assert_bit_identical
+
+pytestmark = [
+    run_for_blackhole(),
+    pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "trace_region_size": 2_000_000}], indirect=True),
+]
+
+
+def _host_inputs(
+    batch_heads: int,
+    groups_per_head: int,
+    key_dim: int,
+    value_dim: int,
+    *,
+    seed: int = 914,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    generator = torch.Generator().manual_seed(seed)
+    leading = batch_heads * groups_per_head
+    eye = torch.eye(key_dim).reshape(1, key_dim, key_dim)
+    a = (0.94 * eye).expand(leading, -1, -1).clone()
+    a += 0.0125 * torch.randn(a.shape, generator=generator)
+    b = 0.025 * torch.randn(leading, key_dim, value_dim, generator=generator)
+
+    # Make the first pair visibly non-commuting so an accidentally reversed reduction fails loudly.
+    for head in range(batch_heads):
+        offset = head * groups_per_head
+        if groups_per_head > 1:
+            a[offset, 0, 1] += 0.25
+            a[offset + 1, 1, 0] -= 0.20
+            assert torch.max(torch.abs(a[offset + 1] @ a[offset] - a[offset] @ a[offset + 1])) > 0.01
+    return a, b
+
+
+def _oracle(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    batch_heads: int,
+    groups_per_head: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    key_dim, value_dim = a.shape[-1], b.shape[-1]
+    a = a.reshape(batch_heads, groups_per_head, key_dim, key_dim).float()
+    b = b.reshape(batch_heads, groups_per_head, key_dim, value_dim).float()
+    reduced_a = []
+    reduced_b = []
+    for head in range(batch_heads):
+        total_a = torch.eye(key_dim)
+        total_b = torch.zeros(key_dim, value_dim)
+        for group in range(groups_per_head):
+            total_a = a[head, group] @ total_a
+            total_b = a[head, group] @ total_b + b[head, group]
+        reduced_a.append(total_a)
+        reduced_b.append(total_b)
+    return torch.stack(reduced_a), torch.stack(reduced_b)
+
+
+def _to_device(
+    tensor: torch.Tensor,
+    device: ttnn.Device,
+    dtype: ttnn.DataType = ttnn.float32,
+    *,
+    layout: ttnn.Layout = ttnn.TILE_LAYOUT,
+    memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
+) -> ttnn.Tensor:
+    return ttnn.from_torch(tensor, dtype=dtype, layout=layout, device=device, memory_config=memory_config)
+
+
+def _run(
+    a: ttnn.Tensor,
+    b: ttnn.Tensor,
+    groups_per_head: int,
+    *,
+    memory_config: ttnn.MemoryConfig | None = None,
+) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        return ttnn.experimental.kda.reduce_affine_transforms(
+            a,
+            b,
+            groups_per_head,
+            memory_config=memory_config,
+        )
+
+
+def _composed_ttnn_baseline(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    device: ttnn.Device,
+    batch_heads: int,
+    groups_per_head: int,
+) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+    """Express the same ordered reduction using only ordinary TTNN matmul and add."""
+    key_dim, value_dim = a.shape[-1], b.shape[-1]
+    a = a.reshape(batch_heads, groups_per_head, key_dim, key_dim)
+    b = b.reshape(batch_heads, groups_per_head, key_dim, value_dim)
+    a_groups = [_to_device(a[:, group], device) for group in range(groups_per_head)]
+    b_groups = [_to_device(b[:, group], device) for group in range(groups_per_head)]
+    total_a = a_groups[0]
+    total_b = b_groups[0]
+    for group in range(1, groups_per_head):
+        total_b = ttnn.add(
+            ttnn.matmul(a_groups[group], total_b, dtype=ttnn.float32),
+            b_groups[group],
+            dtype=ttnn.float32,
+        )
+        total_a = ttnn.matmul(a_groups[group], total_a, dtype=ttnn.float32)
+    return total_a, total_b
+
+
+@pytest.mark.parametrize("summary_dtype", [ttnn.float32, ttnn.bfloat16])
+@pytest.mark.parametrize(
+    ("batch_heads", "groups_per_head", "key_dim", "value_dim"),
+    [(2, 4, 32, 32), (3, 2, 32, 64)],
+)
+def test_reduce_affine_transforms_contract_cache_trace_and_determinism(
+    device: ttnn.Device,
+    summary_dtype: ttnn.DataType,
+    batch_heads: int,
+    groups_per_head: int,
+    key_dim: int,
+    value_dim: int,
+) -> None:
+    a, b = _host_inputs(batch_heads, groups_per_head, key_dim, value_dim)
+    expected_a, expected_b = _oracle(a, b, batch_heads, groups_per_head)
+    a_tt = _to_device(a, device, summary_dtype)
+    b_tt = _to_device(b, device, summary_dtype)
+    snapshots = (ttnn.to_torch(a_tt).clone(), ttnn.to_torch(b_tt).clone())
+
+    first = _run(a_tt, b_tt, groups_per_head)
+    for output, shape in zip(first, ((batch_heads, key_dim, key_dim), (batch_heads, key_dim, value_dim)), strict=True):
+        assert output.dtype == ttnn.float32
+        assert output.layout == ttnn.TILE_LAYOUT
+        assert output.memory_config() == ttnn.DRAM_MEMORY_CONFIG
+        assert tuple(ttnn.to_torch(output).shape) == shape
+        assert output.buffer_address() not in (a_tt.buffer_address(), b_tt.buffer_address())
+
+    cache_entries = device.num_program_cache_entries()
+    repeated = _run(a_tt, b_tt, groups_per_head)
+    ttnn.synchronize_device(device)
+    assert device.num_program_cache_entries() == cache_entries
+
+    trace_id = ttnn.begin_trace_capture(device, cq_id=0)
+    traced = _run(a_tt, b_tt, groups_per_head)
+    ttnn.end_trace_capture(device, trace_id, cq_id=0)
+    for _ in range(2):
+        ttnn.execute_trace(device, trace_id, cq_id=0, blocking=False)
+    ttnn.synchronize_device(device)
+
+    for name, golden, actual_tt, repeated_tt, traced_tt in zip(
+        ("A", "B"), (expected_a, expected_b), first, repeated, traced, strict=True
+    ):
+        actual = ttnn.to_torch(actual_tt)
+        assert_accurate(golden, actual, name=f"{summary_dtype} reduced {name}", pcc_threshold=0.999)
+        assert_bit_identical(actual, ttnn.to_torch(repeated_tt), name=f"{name} eager repeat")
+        assert_bit_identical(actual, ttnn.to_torch(traced_tt), name=f"{name} trace replay")
+
+    assert_bit_identical(snapshots[0], ttnn.to_torch(a_tt), name="a immutability")
+    assert_bit_identical(snapshots[1], ttnn.to_torch(b_tt), name="b immutability")
+    ttnn.release_trace(device, trace_id)
+
+
+def test_reduce_affine_transforms_matches_composed_ttnn_baseline(device: ttnn.Device) -> None:
+    batch_heads, groups_per_head, key_dim, value_dim = 2, 4, 32, 64
+    a, b = _host_inputs(batch_heads, groups_per_head, key_dim, value_dim, seed=117)
+    expected = _oracle(a, b, batch_heads, groups_per_head)
+    fused = _run(_to_device(a, device), _to_device(b, device), groups_per_head)
+    with ttnn.manage_config("throw_exception_on_fallback", True):
+        composed = _composed_ttnn_baseline(a, b, device, batch_heads, groups_per_head)
+    ttnn.synchronize_device(device)
+    for name, golden, fused_tt, composed_tt in zip(("A", "B"), expected, fused, composed, strict=True):
+        assert_accurate(golden, ttnn.to_torch(fused_tt), name=f"fused {name}", pcc_threshold=0.999)
+        assert_accurate(golden, ttnn.to_torch(composed_tt), name=f"composed TTNN {name}", pcc_threshold=0.999)
+
+
+@pytest.mark.parametrize(
+    ("case", "message"),
+    [
+        ("host_a", "a must be an allocated device tensor"),
+        ("host_b", "b must be an allocated device tensor"),
+        ("dtype", "inputs must have matching dtypes"),
+        ("layout", "b must use TILE layout"),
+        ("rank", "inputs must be rank 3"),
+        ("leading", "matching leading dimensions"),
+        ("nondivisible", "leading dimension must be divisible"),
+        ("nonsquare", "a must contain square"),
+        ("key_dim", "matching K dimensions"),
+        ("unaligned", "K and V must be positive and tile aligned"),
+        ("sharded", "a must use interleaved memory"),
+    ],
+)
+def test_reduce_affine_transforms_rejects_invalid_inputs(
+    device: ttnn.Device,
+    expect_error: Callable,
+    case: str,
+    message: str,
+) -> None:
+    a, b = _host_inputs(1, 4, 32, 32)
+    groups_per_head = 4
+    a_tt = _to_device(a, device)
+    b_tt = _to_device(b, device)
+
+    if case == "host_a":
+        a_tt = ttnn.from_torch(a, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT)
+    elif case == "host_b":
+        b_tt = ttnn.from_torch(b, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT)
+    elif case == "dtype":
+        b_tt = _to_device(b, device, ttnn.bfloat16)
+    elif case == "layout":
+        b_tt = _to_device(b, device, layout=ttnn.ROW_MAJOR_LAYOUT)
+    elif case == "rank":
+        b_tt = _to_device(b.reshape(1, 4, 32, 32), device)
+    elif case == "leading":
+        b_tt = _to_device(b[:-1], device)
+    elif case == "nondivisible":
+        a_tt = _to_device(a[:-1], device)
+        b_tt = _to_device(b[:-1], device)
+    elif case == "nonsquare":
+        a_tt = _to_device(a[:, :, :31], device)
+    elif case == "key_dim":
+        b_tt = _to_device(b[:, :31], device)
+    elif case == "unaligned":
+        b_tt = _to_device(b[:, :, :31], device)
+    elif case == "sharded":
+        shard_spec = ttnn.ShardSpec(
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+            [128, 32],
+            ttnn.ShardOrientation.ROW_MAJOR,
+        )
+        sharded = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+        a_tt = _to_device(a, device, memory_config=sharded)
+
+    with expect_error(RuntimeError, message):
+        _run(a_tt, b_tt, groups_per_head)
+
+
+def test_reduce_affine_transforms_rejects_invalid_configuration(
+    device: ttnn.Device,
+    expect_error: Callable,
+) -> None:
+    a, b = _host_inputs(1, 4, 32, 32)
+    a_tt, b_tt = _to_device(a, device), _to_device(b, device)
+    with expect_error(RuntimeError, "groups_per_head must be positive"):
+        _run(a_tt, b_tt, 0)
+
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+        [32, 32],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    sharded = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
+    with expect_error(RuntimeError, "output memory configuration must be interleaved"):
+        _run(a_tt, b_tt, 4, memory_config=sharded)

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_reduce_affine_transforms.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_reduce_affine_transforms.py
@@ -77,6 +77,19 @@ def _to_device(
     return ttnn.from_torch(tensor, dtype=dtype, layout=layout, device=device, memory_config=memory_config)
 
 
+def _height_sharded_memory_config(
+    device: ttnn.Device, leading: int, matrix_height: int, matrix_width: int
+) -> ttnn.MemoryConfig:
+    cores = ttnn.num_cores_to_corerangeset(leading, device.compute_with_storage_grid_size(), row_wise=True)
+    return ttnn.create_sharded_memory_config(
+        (leading, matrix_height, matrix_width),
+        core_grid=cores,
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+
 def _run(
     a: ttnn.Tensor,
     b: ttnn.Tensor,
@@ -119,6 +132,7 @@ def _composed_ttnn_baseline(
 
 
 @pytest.mark.parametrize("summary_dtype", [ttnn.float32, ttnn.bfloat16])
+@pytest.mark.parametrize("sharded_inputs", [False, True], ids=("interleaved", "height-sharded-l1"))
 @pytest.mark.parametrize(
     ("batch_heads", "groups_per_head", "key_dim", "value_dim"),
     [(2, 4, 32, 32), (3, 2, 32, 64)],
@@ -126,6 +140,7 @@ def _composed_ttnn_baseline(
 def test_reduce_affine_transforms_contract_cache_trace_and_determinism(
     device: ttnn.Device,
     summary_dtype: ttnn.DataType,
+    sharded_inputs: bool,
     batch_heads: int,
     groups_per_head: int,
     key_dim: int,
@@ -133,8 +148,17 @@ def test_reduce_affine_transforms_contract_cache_trace_and_determinism(
 ) -> None:
     a, b = _host_inputs(batch_heads, groups_per_head, key_dim, value_dim)
     expected_a, expected_b = _oracle(a, b, batch_heads, groups_per_head)
-    a_tt = _to_device(a, device, summary_dtype)
-    b_tt = _to_device(b, device, summary_dtype)
+    leading = batch_heads * groups_per_head
+    a_memory = (
+        _height_sharded_memory_config(device, leading, key_dim, key_dim) if sharded_inputs else ttnn.DRAM_MEMORY_CONFIG
+    )
+    b_memory = (
+        _height_sharded_memory_config(device, leading, key_dim, value_dim)
+        if sharded_inputs
+        else ttnn.DRAM_MEMORY_CONFIG
+    )
+    a_tt = _to_device(a, device, summary_dtype, memory_config=a_memory)
+    b_tt = _to_device(b, device, summary_dtype, memory_config=b_memory)
     snapshots = (ttnn.to_torch(a_tt).clone(), ttnn.to_torch(b_tt).clone())
 
     first = _run(a_tt, b_tt, groups_per_head)
@@ -196,7 +220,6 @@ def test_reduce_affine_transforms_matches_composed_ttnn_baseline(device: ttnn.De
         ("nonsquare", "a must contain square"),
         ("key_dim", "matching K dimensions"),
         ("unaligned", "K and V must be positive and tile aligned"),
-        ("sharded", "a must use interleaved memory"),
     ],
 )
 def test_reduce_affine_transforms_rejects_invalid_inputs(
@@ -231,15 +254,6 @@ def test_reduce_affine_transforms_rejects_invalid_inputs(
         b_tt = _to_device(b[:, :31], device)
     elif case == "unaligned":
         b_tt = _to_device(b[:, :, :31], device)
-    elif case == "sharded":
-        shard_spec = ttnn.ShardSpec(
-            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
-            [128, 32],
-            ttnn.ShardOrientation.ROW_MAJOR,
-        )
-        sharded = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
-        a_tt = _to_device(a, device, memory_config=sharded)
-
     with expect_error(RuntimeError, message):
         _run(a_tt, b_tt, groups_per_head)
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_reduce_affine_transforms.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_reduce_affine_transforms.py
@@ -17,6 +17,7 @@ from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_progra
 from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import (
     assert_accurate,
     assert_bit_identical,
+    collect_accuracy_and_determinism_results,
     assert_equal,
 )
 
@@ -223,46 +224,19 @@ def test_reduce_affine_transforms_is_device_deterministic(device: ttnn.Device, s
     a_tt, b_tt = (_to_device(tensor, device, summary_dtype) for tensor in host)
     expected = _oracle(*host, case.batch_heads, case.groups_per_head)
 
-    reference_outputs = _run(a_tt, b_tt, case.groups_per_head)
-    mismatch_scratch = tuple(
-        ttnn.empty(
-            output.shape,
-            dtype=ttnn.bfloat16,
-            layout=output.layout,
-            device=device,
-            memory_config=output.memory_config(),
-        )
-        for output in reference_outputs
-    )
-    mismatch_markers: list[ttnn.Tensor | None] = [None, None]
-    for _ in range(2):
-        current_outputs = _run(a_tt, b_tt, case.groups_per_head)
-        for index, (reference, current, scratch) in enumerate(
-            zip(reference_outputs, current_outputs, mismatch_scratch, strict=True)
-        ):
-            ttnn.ne(reference, current, dtype=ttnn.bfloat16, output_tensor=scratch)
-            current_marker = ttnn.max(scratch)
-            ttnn.deallocate(current)
-            if mismatch_markers[index] is None:
-                mismatch_markers[index] = current_marker
-            else:
-                updated_marker = ttnn.maximum(mismatch_markers[index], current_marker)
-                ttnn.deallocate(mismatch_markers[index])
-                ttnn.deallocate(current_marker)
-                mismatch_markers[index] = updated_marker
+    def run() -> tuple[ttnn.Tensor, ...]:
+        return _run(a_tt, b_tt, case.groups_per_head)
 
-    for name, golden, output, marker in zip(("A", "B"), expected, reference_outputs, mismatch_markers, strict=True):
-        assert marker is not None
-        marker_host = ttnn.to_torch(marker).clone()
-        assert_equal(
-            torch.zeros_like(marker_host),
-            marker_host,
-            name=f"{summary_dtype} reduced {name} device-side exact-value determinism marker",
-        )
-        assert_accurate(golden, ttnn.to_torch(output), name=f"{summary_dtype} reduced {name}", pcc_threshold=0.999)
-        ttnn.deallocate(marker)
-    for tensor in (*reference_outputs, *mismatch_scratch):
-        ttnn.deallocate(tensor)
+    reference_outputs, outputs, mismatch_marker = collect_accuracy_and_determinism_results(device, run)
+    assert_equal(
+        torch.zeros_like(mismatch_marker),
+        mismatch_marker,
+        name=f"{summary_dtype} reduced outputs device-side exact-value determinism marker",
+    )
+    for name, golden, output in zip(("A", "B"), expected, outputs, strict=True):
+        assert_accurate(golden, output, name=f"{summary_dtype} reduced {name}", pcc_threshold=0.999)
+    for output in reference_outputs:
+        ttnn.deallocate(output)
 
 
 def test_reduce_affine_transforms_cache_hit_rebinds_fresh_tensors(device: ttnn.Device) -> None:

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_reduce_affine_transforms.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_reduce_affine_transforms.py
@@ -288,7 +288,7 @@ def test_reduce_affine_transforms_default_compute_config_matches_explicit_defaul
     entries = device.num_program_cache_entries()
     explicit_config = ttnn.init_device_compute_kernel_config(
         device.arch(),
-        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_fidelity=ttnn.MathFidelity.HiFi2,
         math_approx_mode=False,
         fp32_dest_acc_en=True,
         packer_l1_acc=False,

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_reduce_affine_transforms.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_reduce_affine_transforms.py
@@ -5,18 +5,46 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 
 import pytest
 import torch
+from loguru import logger
 
 import ttnn
-from models.common.utility_functions import run_for_blackhole
-from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import assert_accurate, assert_bit_identical
+from models.common.utility_functions import run_for_blackhole, skip_with_llk_assert, skip_with_watcher
+from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program
+from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import (
+    assert_accurate,
+    assert_bit_identical,
+    assert_equal,
+)
 
 pytestmark = [
     run_for_blackhole(),
     pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "trace_region_size": 2_000_000}], indirect=True),
 ]
+
+
+@dataclass(frozen=True)
+class _ProductionCase:
+    case_id: str
+    batch_heads: int
+    groups_per_head: int
+    key_dim: int
+    value_dim: int
+    expected_duration_ns: int | None
+
+
+_PRODUCTION_PERF_MARGIN = 0.05
+_PRODUCTION_CASE = _ProductionCase(
+    "bh2-g4-k32-v64",
+    batch_heads=2,
+    groups_per_head=4,
+    key_dim=32,
+    value_dim=64,
+    expected_duration_ns=6616,
+)
 
 
 def _host_inputs(
@@ -96,6 +124,7 @@ def _run(
     groups_per_head: int,
     *,
     memory_config: ttnn.MemoryConfig | None = None,
+    compute_kernel_config: ttnn.DeviceComputeKernelConfig | None = None,
 ) -> tuple[ttnn.Tensor, ttnn.Tensor]:
     with ttnn.manage_config("throw_exception_on_fallback", True):
         return ttnn.experimental.kda.reduce_affine_transforms(
@@ -103,6 +132,7 @@ def _run(
             b,
             groups_per_head,
             memory_config=memory_config,
+            compute_kernel_config=compute_kernel_config,
         )
 
 
@@ -137,7 +167,7 @@ def _composed_ttnn_baseline(
     ("batch_heads", "groups_per_head", "key_dim", "value_dim"),
     [(2, 1, 32, 32), (2, 3, 32, 32), (2, 4, 32, 32), (3, 2, 32, 64)],
 )
-def test_reduce_affine_transforms_contract_cache_trace_and_determinism(
+def test_reduce_affine_transforms_contract_and_trace(
     device: ttnn.Device,
     summary_dtype: ttnn.DataType,
     sharded_inputs: bool,
@@ -169,11 +199,6 @@ def test_reduce_affine_transforms_contract_cache_trace_and_determinism(
         assert tuple(ttnn.to_torch(output).shape) == shape
         assert output.buffer_address() not in (a_tt.buffer_address(), b_tt.buffer_address())
 
-    cache_entries = device.num_program_cache_entries()
-    repeated = _run(a_tt, b_tt, groups_per_head)
-    ttnn.synchronize_device(device)
-    assert device.num_program_cache_entries() == cache_entries
-
     trace_id = ttnn.begin_trace_capture(device, cq_id=0)
     traced = _run(a_tt, b_tt, groups_per_head)
     ttnn.end_trace_capture(device, trace_id, cq_id=0)
@@ -181,17 +206,185 @@ def test_reduce_affine_transforms_contract_cache_trace_and_determinism(
         ttnn.execute_trace(device, trace_id, cq_id=0, blocking=False)
     ttnn.synchronize_device(device)
 
-    for name, golden, actual_tt, repeated_tt, traced_tt in zip(
-        ("A", "B"), (expected_a, expected_b), first, repeated, traced, strict=True
-    ):
+    for name, golden, actual_tt, traced_tt in zip(("A", "B"), (expected_a, expected_b), first, traced, strict=True):
         actual = ttnn.to_torch(actual_tt)
         assert_accurate(golden, actual, name=f"{summary_dtype} reduced {name}", pcc_threshold=0.999)
-        assert_bit_identical(actual, ttnn.to_torch(repeated_tt), name=f"{name} eager repeat")
         assert_bit_identical(actual, ttnn.to_torch(traced_tt), name=f"{name} trace replay")
 
     assert_bit_identical(snapshots[0], ttnn.to_torch(a_tt), name="a immutability")
     assert_bit_identical(snapshots[1], ttnn.to_torch(b_tt), name="b immutability")
     ttnn.release_trace(device, trace_id)
+
+
+@pytest.mark.parametrize("summary_dtype", [ttnn.float32, ttnn.bfloat16])
+def test_reduce_affine_transforms_is_device_deterministic(device: ttnn.Device, summary_dtype: ttnn.DataType) -> None:
+    case = _PRODUCTION_CASE
+    host = _host_inputs(case.batch_heads, case.groups_per_head, case.key_dim, case.value_dim, seed=1441)
+    a_tt, b_tt = (_to_device(tensor, device, summary_dtype) for tensor in host)
+    expected = _oracle(*host, case.batch_heads, case.groups_per_head)
+
+    reference_outputs = _run(a_tt, b_tt, case.groups_per_head)
+    mismatch_scratch = tuple(
+        ttnn.empty(
+            output.shape,
+            dtype=ttnn.bfloat16,
+            layout=output.layout,
+            device=device,
+            memory_config=output.memory_config(),
+        )
+        for output in reference_outputs
+    )
+    mismatch_markers: list[ttnn.Tensor | None] = [None, None]
+    for _ in range(2):
+        current_outputs = _run(a_tt, b_tt, case.groups_per_head)
+        for index, (reference, current, scratch) in enumerate(
+            zip(reference_outputs, current_outputs, mismatch_scratch, strict=True)
+        ):
+            ttnn.ne(reference, current, dtype=ttnn.bfloat16, output_tensor=scratch)
+            current_marker = ttnn.max(scratch)
+            ttnn.deallocate(current)
+            if mismatch_markers[index] is None:
+                mismatch_markers[index] = current_marker
+            else:
+                updated_marker = ttnn.maximum(mismatch_markers[index], current_marker)
+                ttnn.deallocate(mismatch_markers[index])
+                ttnn.deallocate(current_marker)
+                mismatch_markers[index] = updated_marker
+
+    for name, golden, output, marker in zip(("A", "B"), expected, reference_outputs, mismatch_markers, strict=True):
+        assert marker is not None
+        marker_host = ttnn.to_torch(marker).clone()
+        assert_equal(
+            torch.zeros_like(marker_host),
+            marker_host,
+            name=f"{summary_dtype} reduced {name} device-side exact-value determinism marker",
+        )
+        assert_accurate(golden, ttnn.to_torch(output), name=f"{summary_dtype} reduced {name}", pcc_threshold=0.999)
+        ttnn.deallocate(marker)
+    for tensor in (*reference_outputs, *mismatch_scratch):
+        ttnn.deallocate(tensor)
+
+
+def test_reduce_affine_transforms_cache_hit_rebinds_fresh_tensors(device: ttnn.Device) -> None:
+    case = _PRODUCTION_CASE
+    host_a = _host_inputs(case.batch_heads, case.groups_per_head, case.key_dim, case.value_dim, seed=1911)
+    host_b = _host_inputs(case.batch_heads, case.groups_per_head, case.key_dim, case.value_dim, seed=1912)
+    device_a = tuple(_to_device(tensor, device) for tensor in host_a)
+    device_b = tuple(_to_device(tensor, device) for tensor in host_b)
+
+    output_a = _run(*device_a, case.groups_per_head)
+    ttnn.synchronize_device(device)
+    entries = device.num_program_cache_entries()
+    output_b = _run(*device_b, case.groups_per_head)
+    ttnn.synchronize_device(device)
+
+    assert device.num_program_cache_entries() == entries
+    assert all(a.buffer_address() != b.buffer_address() for a, b in zip(device_a, device_b, strict=True))
+    assert all(a.buffer_address() != b.buffer_address() for a, b in zip(output_a, output_b, strict=True))
+    expected_a = _oracle(*host_a, case.batch_heads, case.groups_per_head)
+    expected_b = _oracle(*host_b, case.batch_heads, case.groups_per_head)
+    for name, golden_a, golden_b, actual_a_tt, actual_b_tt in zip(
+        ("A", "B"), expected_a, expected_b, output_a, output_b, strict=True
+    ):
+        actual_a = ttnn.to_torch(actual_a_tt)
+        actual_b = ttnn.to_torch(actual_b_tt)
+        assert_accurate(golden_a, actual_a, name=f"{name} cache miss tensors", pcc_threshold=0.999)
+        assert_accurate(golden_b, actual_b, name=f"{name} cache hit fresh tensors", pcc_threshold=0.999)
+        assert not torch.equal(actual_a, actual_b)
+
+
+def test_reduce_affine_transforms_default_compute_config_matches_explicit_defaults(device: ttnn.Device) -> None:
+    case = _PRODUCTION_CASE
+    host = _host_inputs(case.batch_heads, case.groups_per_head, case.key_dim, case.value_dim, seed=817)
+    a_tt, b_tt = (_to_device(tensor, device) for tensor in host)
+    implicit = _run(a_tt, b_tt, case.groups_per_head)
+    entries = device.num_program_cache_entries()
+    explicit_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=False,
+        dst_full_sync_en=False,
+        throttle_level=ttnn.ThrottleLevel.NO_THROTTLE,
+    )
+    explicit = _run(a_tt, b_tt, case.groups_per_head, compute_kernel_config=explicit_config)
+    assert device.num_program_cache_entries() == entries
+    for name, implicit_output, explicit_output in zip(("A", "B"), implicit, explicit, strict=True):
+        assert_bit_identical(
+            ttnn.to_torch(implicit_output),
+            ttnn.to_torch(explicit_output),
+            name=f"{name} implicit vs explicit compute defaults",
+        )
+
+
+def test_reduce_affine_transforms_approximate_math_uses_distinct_accurate_program(device: ttnn.Device) -> None:
+    case = _PRODUCTION_CASE
+    host = _host_inputs(case.batch_heads, case.groups_per_head, case.key_dim, case.value_dim, seed=818)
+    a_tt, b_tt = (_to_device(tensor, device) for tensor in host)
+    exact = _run(a_tt, b_tt, case.groups_per_head)
+    entries = device.num_program_cache_entries()
+    approximate_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=True,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=False,
+    )
+    approximate = _run(a_tt, b_tt, case.groups_per_head, compute_kernel_config=approximate_config)
+    assert device.num_program_cache_entries() == entries + 1
+    expected = _oracle(*host, case.batch_heads, case.groups_per_head)
+    for name, golden, exact_output, approximate_output in zip(("A", "B"), expected, exact, approximate, strict=True):
+        assert_accurate(golden, ttnn.to_torch(exact_output), name=f"{name} exact math", pcc_threshold=0.999)
+        assert_accurate(golden, ttnn.to_torch(approximate_output), name=f"{name} approximate math", pcc_threshold=0.999)
+
+
+def test_reduce_affine_transforms_rejects_unsupported_compute_config(
+    device: ttnn.Device, expect_error: Callable
+) -> None:
+    case = _PRODUCTION_CASE
+    host = _host_inputs(case.batch_heads, case.groups_per_head, case.key_dim, case.value_dim)
+    a_tt, b_tt = (_to_device(tensor, device) for tensor in host)
+    unsupported_config = ttnn.types.BlackholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        packer_l1_acc=True,
+    )
+    with expect_error(RuntimeError, "packer_l1_acc=true is unsupported"):
+        _run(a_tt, b_tt, case.groups_per_head, compute_kernel_config=unsupported_config)
+
+
+@pytest.mark.requires_host_iommu
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
+@skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
+def test_reduce_affine_transforms_production_performance(device: ttnn.Device) -> None:
+    case = _PRODUCTION_CASE
+    if not ttnn.device.IsProgramRealtimeProfilerActive():
+        pytest.fail("Real-time profiler must be active for affine-transform reduction performance checks")
+
+    host = _host_inputs(case.batch_heads, case.groups_per_head, case.key_dim, case.value_dim, seed=117)
+    a_tt, b_tt = (_to_device(tensor, device) for tensor in host)
+
+    def run() -> tuple[ttnn.Tensor, ttnn.Tensor]:
+        return _run(a_tt, b_tt, case.groups_per_head)
+
+    outputs, perf_record = profile_realtime_program(device, run)
+    duration_ns = perf_record["duration_ns"]
+    assert tuple(tuple(output.shape) for output in outputs) == (
+        (case.batch_heads, case.key_dim, case.key_dim),
+        (case.batch_heads, case.key_dim, case.value_dim),
+    )
+    assert all(output.dtype == ttnn.float32 for output in outputs)
+    logger.info(
+        f"affine-transform reduction {case.case_id}: duration={duration_ns:.0f} ns, "
+        f"profiler_runtime_id={perf_record['runtime_id']}"
+    )
+    if case.expected_duration_ns is not None:
+        lower = case.expected_duration_ns * (1 - _PRODUCTION_PERF_MARGIN)
+        upper = case.expected_duration_ns * (1 + _PRODUCTION_PERF_MARGIN)
+        assert lower <= duration_ns <= upper, (
+            f"{case.case_id} duration {duration_ns:.0f} ns outside [{lower:.0f}, {upper:.0f}] ns "
+            f"(reference {case.expected_duration_ns} ns, margin +/- {_PRODUCTION_PERF_MARGIN * 100:.0f}%)"
+        )
 
 
 def test_reduce_affine_transforms_matches_composed_ttnn_baseline(device: ttnn.Device) -> None:

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_reduce_affine_transforms.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_reduce_affine_transforms.py
@@ -170,26 +170,12 @@ def _composed_ttnn_baseline(
 
 @pytest.mark.parametrize("summary_dtype", [ttnn.float32, ttnn.bfloat16])
 @pytest.mark.parametrize("sharded_inputs", [False, True], ids=("interleaved", "height-sharded-l1"))
-@pytest.mark.parametrize(
-    ("batch_heads", "groups_per_head", "key_dim", "value_dim"),
-    [
-        (2, 1, 32, 32),
-        (2, 3, 32, 32),
-        (2, 4, 32, 32),
-        (3, 2, 32, 64),
-        (2, 2, 160, 32),
-        (2, 2, 32, 160),
-    ],
-)
 def test_reduce_affine_transforms_contract_and_trace(
     device: ttnn.Device,
     summary_dtype: ttnn.DataType,
     sharded_inputs: bool,
-    batch_heads: int,
-    groups_per_head: int,
-    key_dim: int,
-    value_dim: int,
 ) -> None:
+    batch_heads, groups_per_head, key_dim, value_dim = 2, 4, 32, 32
     a, b = _host_inputs(batch_heads, groups_per_head, key_dim, value_dim)
     expected_a, expected_b = _oracle(a, b, batch_heads, groups_per_head)
     leading = batch_heads * groups_per_head
@@ -228,6 +214,50 @@ def test_reduce_affine_transforms_contract_and_trace(
     assert_bit_identical(snapshots[0], ttnn.to_torch(a_tt), name="a immutability")
     assert_bit_identical(snapshots[1], ttnn.to_torch(b_tt), name="b immutability")
     ttnn.release_trace(device, trace_id)
+
+
+@pytest.mark.parametrize(
+    ("batch_heads", "groups_per_head", "key_dim", "value_dim", "summary_dtype", "sharded_inputs"),
+    [
+        pytest.param(2, 1, 32, 32, ttnn.float32, False, id="bh2-g1-k32-v32-fp32-interleaved"),
+        pytest.param(2, 3, 32, 32, ttnn.bfloat16, True, id="bh2-g3-k32-v32-bf16-height-sharded-l1"),
+        pytest.param(3, 2, 32, 64, ttnn.float32, False, id="bh3-g2-k32-v64-fp32-interleaved"),
+        pytest.param(2, 2, 160, 32, ttnn.bfloat16, True, id="bh2-g2-k160-v32-bf16-height-sharded-l1"),
+        pytest.param(2, 2, 32, 160, ttnn.float32, False, id="bh2-g2-k32-v160-fp32-interleaved"),
+    ],
+)
+def test_reduce_affine_transforms_shape_accuracy(
+    device: ttnn.Device,
+    batch_heads: int,
+    groups_per_head: int,
+    key_dim: int,
+    value_dim: int,
+    summary_dtype: ttnn.DataType,
+    sharded_inputs: bool,
+) -> None:
+    a, b = _host_inputs(batch_heads, groups_per_head, key_dim, value_dim)
+    expected = _oracle(a, b, batch_heads, groups_per_head)
+    leading = batch_heads * groups_per_head
+    a_memory = (
+        _height_sharded_memory_config(device, leading, key_dim, key_dim) if sharded_inputs else ttnn.DRAM_MEMORY_CONFIG
+    )
+    b_memory = (
+        _height_sharded_memory_config(device, leading, key_dim, value_dim)
+        if sharded_inputs
+        else ttnn.DRAM_MEMORY_CONFIG
+    )
+    a_tt = _to_device(a, device, summary_dtype, memory_config=a_memory)
+    b_tt = _to_device(b, device, summary_dtype, memory_config=b_memory)
+
+    outputs = _run(a_tt, b_tt, groups_per_head)
+
+    for name, golden, output in zip(("A", "B"), expected, outputs, strict=True):
+        assert_accurate(
+            golden,
+            ttnn.to_torch(output),
+            name=f"{summary_dtype} shape-sweep reduced {name}",
+            pcc_threshold=0.999,
+        )
 
 
 @pytest.mark.parametrize("summary_dtype", [ttnn.float32, ttnn.bfloat16])

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_reduce_affine_transforms.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_reduce_affine_transforms.py
@@ -135,7 +135,7 @@ def _composed_ttnn_baseline(
 @pytest.mark.parametrize("sharded_inputs", [False, True], ids=("interleaved", "height-sharded-l1"))
 @pytest.mark.parametrize(
     ("batch_heads", "groups_per_head", "key_dim", "value_dim"),
-    [(2, 4, 32, 32), (3, 2, 32, 64)],
+    [(2, 1, 32, 32), (2, 3, 32, 32), (2, 4, 32, 32), (3, 2, 32, 64)],
 )
 def test_reduce_affine_transforms_contract_cache_trace_and_determinism(
     device: ttnn.Device,

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_reduce_affine_transforms.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_reduce_affine_transforms.py
@@ -34,7 +34,7 @@ class _ProductionCase:
     groups_per_head: int
     key_dim: int
     value_dim: int
-    expected_duration_ns: int | None
+    expected_duration_ns: int
 
 
 _PRODUCTION_PERF_MARGIN = 0.05
@@ -352,13 +352,12 @@ def test_reduce_affine_transforms_production_performance(device: ttnn.Device) ->
         f"affine-transform reduction {case.case_id}: duration={duration_ns:.0f} ns, "
         f"profiler_runtime_id={perf_record['runtime_id']}"
     )
-    if case.expected_duration_ns is not None:
-        lower = case.expected_duration_ns * (1 - _PRODUCTION_PERF_MARGIN)
-        upper = case.expected_duration_ns * (1 + _PRODUCTION_PERF_MARGIN)
-        assert lower <= duration_ns <= upper, (
-            f"{case.case_id} duration {duration_ns:.0f} ns outside [{lower:.0f}, {upper:.0f}] ns "
-            f"(reference {case.expected_duration_ns} ns, margin +/- {_PRODUCTION_PERF_MARGIN * 100:.0f}%)"
-        )
+    lower = case.expected_duration_ns * (1 - _PRODUCTION_PERF_MARGIN)
+    upper = case.expected_duration_ns * (1 + _PRODUCTION_PERF_MARGIN)
+    assert lower <= duration_ns <= upper, (
+        f"{case.case_id} duration {duration_ns:.0f} ns outside [{lower:.0f}, {upper:.0f}] ns "
+        f"(reference {case.expected_duration_ns} ns, margin +/- {_PRODUCTION_PERF_MARGIN * 100:.0f}%)"
+    )
 
 
 def test_reduce_affine_transforms_matches_composed_ttnn_baseline(device: ttnn.Device) -> None:

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_reduce_affine_transforms.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_reduce_affine_transforms.py
@@ -23,7 +23,7 @@ from tests.ttnn.unit_tests.operations.experimental.kda.kda_test_utils import (
 
 pytestmark = [
     run_for_blackhole(),
-    pytest.mark.parametrize("device_params", [{"l1_small_size": 24576, "trace_region_size": 2_000_000}], indirect=True),
+    pytest.mark.use_module_device({"l1_small_size": 24576, "trace_region_size": 2_000_000}),
 ]
 
 
@@ -252,7 +252,9 @@ def test_reduce_affine_transforms_is_device_deterministic(device: ttnn.Device, s
         ttnn.deallocate(output)
 
 
-def test_reduce_affine_transforms_cache_hit_rebinds_fresh_tensors(device: ttnn.Device) -> None:
+def test_reduce_affine_transforms_cache_hit_rebinds_fresh_tensors(
+    device: ttnn.Device, isolated_program_cache: None
+) -> None:
     case = _SMALL_CASE
     host_a = _host_inputs(case.batch_heads, case.groups_per_head, case.key_dim, case.value_dim, seed=1911)
     host_b = _host_inputs(case.batch_heads, case.groups_per_head, case.key_dim, case.value_dim, seed=1912)
@@ -280,7 +282,9 @@ def test_reduce_affine_transforms_cache_hit_rebinds_fresh_tensors(device: ttnn.D
         assert not torch.equal(actual_a, actual_b)
 
 
-def test_reduce_affine_transforms_default_compute_config_matches_explicit_defaults(device: ttnn.Device) -> None:
+def test_reduce_affine_transforms_default_compute_config_matches_explicit_defaults(
+    device: ttnn.Device, isolated_program_cache: None
+) -> None:
     case = _SMALL_CASE
     host = _host_inputs(case.batch_heads, case.groups_per_head, case.key_dim, case.value_dim, seed=817)
     a_tt, b_tt = (_to_device(tensor, device) for tensor in host)
@@ -305,7 +309,9 @@ def test_reduce_affine_transforms_default_compute_config_matches_explicit_defaul
         )
 
 
-def test_reduce_affine_transforms_approximate_math_uses_distinct_accurate_program(device: ttnn.Device) -> None:
+def test_reduce_affine_transforms_approximate_math_uses_distinct_accurate_program(
+    device: ttnn.Device, isolated_program_cache: None
+) -> None:
     case = _SMALL_CASE
     host = _host_inputs(case.batch_heads, case.groups_per_head, case.key_dim, case.value_dim, seed=818)
     a_tt, b_tt = (_to_device(tensor, device) for tensor in host)

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_reduce_affine_transforms.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/kda/test_reduce_affine_transforms.py
@@ -28,24 +28,30 @@ pytestmark = [
 
 
 @dataclass(frozen=True)
-class _ProductionCase:
+class _Case:
     case_id: str
     batch_heads: int
     groups_per_head: int
     key_dim: int
     value_dim: int
-    expected_duration_ns: int
 
 
 _PRODUCTION_PERF_MARGIN = 0.05
-_PRODUCTION_CASE = _ProductionCase(
+_SMALL_CASE = _Case(
     "bh2-g4-k32-v64",
     batch_heads=2,
     groups_per_head=4,
     key_dim=32,
     value_dim=64,
-    expected_duration_ns=6616,
 )
+_PRODUCTION_PERF_CASE = _Case(
+    "sp2-tp4-bh24-g4-k128-v128",
+    batch_heads=24,
+    groups_per_head=4,
+    key_dim=128,
+    value_dim=128,
+)
+_PRODUCTION_PERF_EXPECTED_DURATION_NS = 46_038
 
 
 def _host_inputs(
@@ -166,7 +172,14 @@ def _composed_ttnn_baseline(
 @pytest.mark.parametrize("sharded_inputs", [False, True], ids=("interleaved", "height-sharded-l1"))
 @pytest.mark.parametrize(
     ("batch_heads", "groups_per_head", "key_dim", "value_dim"),
-    [(2, 1, 32, 32), (2, 3, 32, 32), (2, 4, 32, 32), (3, 2, 32, 64)],
+    [
+        (2, 1, 32, 32),
+        (2, 3, 32, 32),
+        (2, 4, 32, 32),
+        (3, 2, 32, 64),
+        (2, 2, 160, 32),
+        (2, 2, 32, 160),
+    ],
 )
 def test_reduce_affine_transforms_contract_and_trace(
     device: ttnn.Device,
@@ -219,7 +232,7 @@ def test_reduce_affine_transforms_contract_and_trace(
 
 @pytest.mark.parametrize("summary_dtype", [ttnn.float32, ttnn.bfloat16])
 def test_reduce_affine_transforms_is_device_deterministic(device: ttnn.Device, summary_dtype: ttnn.DataType) -> None:
-    case = _PRODUCTION_CASE
+    case = _SMALL_CASE
     host = _host_inputs(case.batch_heads, case.groups_per_head, case.key_dim, case.value_dim, seed=1441)
     a_tt, b_tt = (_to_device(tensor, device, summary_dtype) for tensor in host)
     expected = _oracle(*host, case.batch_heads, case.groups_per_head)
@@ -240,7 +253,7 @@ def test_reduce_affine_transforms_is_device_deterministic(device: ttnn.Device, s
 
 
 def test_reduce_affine_transforms_cache_hit_rebinds_fresh_tensors(device: ttnn.Device) -> None:
-    case = _PRODUCTION_CASE
+    case = _SMALL_CASE
     host_a = _host_inputs(case.batch_heads, case.groups_per_head, case.key_dim, case.value_dim, seed=1911)
     host_b = _host_inputs(case.batch_heads, case.groups_per_head, case.key_dim, case.value_dim, seed=1912)
     device_a = tuple(_to_device(tensor, device) for tensor in host_a)
@@ -268,7 +281,7 @@ def test_reduce_affine_transforms_cache_hit_rebinds_fresh_tensors(device: ttnn.D
 
 
 def test_reduce_affine_transforms_default_compute_config_matches_explicit_defaults(device: ttnn.Device) -> None:
-    case = _PRODUCTION_CASE
+    case = _SMALL_CASE
     host = _host_inputs(case.batch_heads, case.groups_per_head, case.key_dim, case.value_dim, seed=817)
     a_tt, b_tt = (_to_device(tensor, device) for tensor in host)
     implicit = _run(a_tt, b_tt, case.groups_per_head)
@@ -293,7 +306,7 @@ def test_reduce_affine_transforms_default_compute_config_matches_explicit_defaul
 
 
 def test_reduce_affine_transforms_approximate_math_uses_distinct_accurate_program(device: ttnn.Device) -> None:
-    case = _PRODUCTION_CASE
+    case = _SMALL_CASE
     host = _host_inputs(case.batch_heads, case.groups_per_head, case.key_dim, case.value_dim, seed=818)
     a_tt, b_tt = (_to_device(tensor, device) for tensor in host)
     exact = _run(a_tt, b_tt, case.groups_per_head)
@@ -316,7 +329,7 @@ def test_reduce_affine_transforms_approximate_math_uses_distinct_accurate_progra
 def test_reduce_affine_transforms_rejects_unsupported_compute_config(
     device: ttnn.Device, expect_error: Callable
 ) -> None:
-    case = _PRODUCTION_CASE
+    case = _SMALL_CASE
     host = _host_inputs(case.batch_heads, case.groups_per_head, case.key_dim, case.value_dim)
     a_tt, b_tt = (_to_device(tensor, device) for tensor in host)
     unsupported_config = ttnn.types.BlackholeComputeKernelConfig(
@@ -331,15 +344,24 @@ def test_reduce_affine_transforms_rejects_unsupported_compute_config(
 @skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
 @skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
 def test_reduce_affine_transforms_production_performance(device: ttnn.Device) -> None:
-    case = _PRODUCTION_CASE
+    case = _PRODUCTION_PERF_CASE
     if not ttnn.device.IsProgramRealtimeProfilerActive():
         pytest.fail("Real-time profiler must be active for affine-transform reduction performance checks")
 
     host = _host_inputs(case.batch_heads, case.groups_per_head, case.key_dim, case.value_dim, seed=117)
-    a_tt, b_tt = (_to_device(tensor, device) for tensor in host)
+    expected = _oracle(*host, case.batch_heads, case.groups_per_head)
+    a_tt, b_tt = (_to_device(tensor, device, ttnn.bfloat16) for tensor in host)
+    production_compute_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=False,
+        dst_full_sync_en=False,
+    )
 
     def run() -> tuple[ttnn.Tensor, ttnn.Tensor]:
-        return _run(a_tt, b_tt, case.groups_per_head)
+        return _run(a_tt, b_tt, case.groups_per_head, compute_kernel_config=production_compute_config)
 
     outputs, perf_record = profile_realtime_program(device, run)
     duration_ns = perf_record["duration_ns"]
@@ -348,15 +370,17 @@ def test_reduce_affine_transforms_production_performance(device: ttnn.Device) ->
         (case.batch_heads, case.key_dim, case.value_dim),
     )
     assert all(output.dtype == ttnn.float32 for output in outputs)
+    for name, golden, output in zip(("A", "B"), expected, outputs, strict=True):
+        assert_accurate(golden, ttnn.to_torch(output), name=f"production reduced {name}", pcc_threshold=0.999)
     logger.info(
         f"affine-transform reduction {case.case_id}: duration={duration_ns:.0f} ns, "
         f"profiler_runtime_id={perf_record['runtime_id']}"
     )
-    lower = case.expected_duration_ns * (1 - _PRODUCTION_PERF_MARGIN)
-    upper = case.expected_duration_ns * (1 + _PRODUCTION_PERF_MARGIN)
+    lower = _PRODUCTION_PERF_EXPECTED_DURATION_NS * (1 - _PRODUCTION_PERF_MARGIN)
+    upper = _PRODUCTION_PERF_EXPECTED_DURATION_NS * (1 + _PRODUCTION_PERF_MARGIN)
     assert lower <= duration_ns <= upper, (
         f"{case.case_id} duration {duration_ns:.0f} ns outside [{lower:.0f}, {upper:.0f}] ns "
-        f"(reference {case.expected_duration_ns} ns, margin +/- {_PRODUCTION_PERF_MARGIN * 100:.0f}%)"
+        f"(reference {_PRODUCTION_PERF_EXPECTED_DURATION_NS} ns, margin +/- {_PRODUCTION_PERF_MARGIN * 100:.0f}%)"
     )
 
 
@@ -424,6 +448,49 @@ def test_reduce_affine_transforms_rejects_invalid_inputs(
         _run(a_tt, b_tt, groups_per_head)
 
 
+def test_reduce_affine_transforms_rejects_excess_workers(
+    device: ttnn.Device,
+    expect_error: Callable,
+) -> None:
+    grid = device.compute_with_storage_grid_size()
+    worker_limit = min(grid.x * grid.y, 128)
+    group_workers = worker_limit + 1
+    a, b = _host_inputs(1, group_workers, 32, 32)
+    a_tt = _to_device(a, device)
+    b_tt = _to_device(b, device)
+
+    with expect_error(RuntimeError, f"supports at most {worker_limit} group workers on this device"):
+        _run(a_tt, b_tt, group_workers)
+
+
+@pytest.mark.parametrize("input_name", ["a", "b"])
+@pytest.mark.parametrize(
+    "memory_layout",
+    [ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.TensorMemoryLayout.BLOCK_SHARDED],
+    ids=["width_sharded", "block_sharded"],
+)
+def test_reduce_affine_transforms_rejects_unsupported_input_sharding(
+    device: ttnn.Device,
+    expect_error: Callable,
+    input_name: str,
+    memory_layout: ttnn.TensorMemoryLayout,
+) -> None:
+    a, b = _host_inputs(1, 4, 32, 32)
+    shard_spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+        [128, 32],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    unsupported = ttnn.MemoryConfig(memory_layout, ttnn.BufferType.L1, shard_spec)
+    a_memory = unsupported if input_name == "a" else ttnn.DRAM_MEMORY_CONFIG
+    b_memory = unsupported if input_name == "b" else ttnn.DRAM_MEMORY_CONFIG
+    a_tt = _to_device(a, device, memory_config=a_memory)
+    b_tt = _to_device(b, device, memory_config=b_memory)
+
+    with expect_error(RuntimeError, f"{input_name} must use interleaved or height-sharded memory"):
+        _run(a_tt, b_tt, 4)
+
+
 def test_reduce_affine_transforms_rejects_invalid_configuration(
     device: ttnn.Device,
     expect_error: Callable,
@@ -439,5 +506,5 @@ def test_reduce_affine_transforms_rejects_invalid_configuration(
         ttnn.ShardOrientation.ROW_MAJOR,
     )
     sharded = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, shard_spec)
-    with expect_error(RuntimeError, "output memory configuration must be interleaved"):
+    with expect_error(RuntimeError, "output memory layout must be INTERLEAVED, got HEIGHT_SHARDED"):
         _run(a_tt, b_tt, 4, memory_config=sharded)

--- a/ttnn/cpp/ttnn/operations/experimental/kda/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/CMakeLists.txt
@@ -13,6 +13,7 @@ install(TARGETS ttnn_op_experimental_kda_common LIBRARY COMPONENT tar)
 
 add_subdirectory(sigmoid_gated_rms_norm)
 add_subdirectory(qkv_causal_conv1d_silu)
+add_subdirectory(reduce_affine_transforms)
 
 add_library(ttnn_op_experimental_kda INTERFACE)
 add_library(TTNN::Ops::Experimental::KDA ALIAS ttnn_op_experimental_kda)
@@ -22,6 +23,7 @@ target_link_libraries(
         TTNN::Ops::Experimental::KDA::Common
         TTNN::Ops::Experimental::KDA::SigmoidGatedRMSNorm
         TTNN::Ops::Experimental::KDA::QkvCausalConv1dSilu
+        TTNN::Ops::Experimental::KDA::ReduceAffineTransforms
 )
 
 # OBJECT libraries do not propagate their compiled objects through a nested
@@ -33,4 +35,5 @@ target_sources(
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::KDA::Common>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::KDA::SigmoidGatedRMSNorm>
         $<TARGET_OBJECTS:TTNN::Ops::Experimental::KDA::QkvCausalConv1dSilu>
+        $<TARGET_OBJECTS:TTNN::Ops::Experimental::KDA::ReduceAffineTransforms>
 )

--- a/ttnn/cpp/ttnn/operations/experimental/kda/factory/kda_factory_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/factory/kda_factory_utils.cpp
@@ -5,8 +5,8 @@
 
 #include <algorithm>
 #include <enchantum/enchantum.hpp>
-#include <set>
 
+#include <tt-metalium/work_split.hpp>
 #include <tt_stl/assert.hpp>
 
 namespace ttnn::experimental::prim::kda_factory_detail {
@@ -117,7 +117,6 @@ KdaPrepWorkDist distribute_prep(tt::tt_metal::CoreCoord grid, uint32_t total, ui
     distribution.cores.reserve(count);
     distribution.wi_start.reserve(count);
     distribution.wi_count.reserve(count);
-    std::set<tt::tt_metal::CoreRange> ranges;
     uint32_t offset = 0;
     for (uint32_t index = 0; index < count; ++index) {
         const tt::tt_metal::CoreCoord core{index % grid.x, index / grid.x};
@@ -125,10 +124,9 @@ KdaPrepWorkDist distribute_prep(tt::tt_metal::CoreCoord grid, uint32_t total, ui
         distribution.cores.push_back(core);
         distribution.wi_start.push_back(offset);
         distribution.wi_count.push_back(item_count);
-        ranges.insert(tt::tt_metal::CoreRange{core, core});
         offset += item_count;
     }
-    distribution.core_set = tt::tt_metal::CoreRangeSet{ranges};
+    distribution.core_set = tt::tt_metal::num_cores_to_corerangeset(count, grid, true);
     return distribution;
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/kda/kda_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/kda_nanobind.cpp
@@ -6,6 +6,7 @@
 #include <nanobind/nanobind.h>
 
 #include "ttnn/operations/experimental/kda/qkv_causal_conv1d_silu/qkv_causal_conv1d_silu_nanobind.hpp"
+#include "ttnn/operations/experimental/kda/reduce_affine_transforms/reduce_affine_transforms_nanobind.hpp"
 #include "ttnn/operations/experimental/kda/sigmoid_gated_rms_norm/sigmoid_gated_rms_norm_nanobind.hpp"
 
 namespace ttnn::operations::experimental::kda::detail {
@@ -13,6 +14,7 @@ namespace ttnn::operations::experimental::kda::detail {
 void bind_kda(nb::module_& mod) {
     auto kda_module = mod.def_submodule("kda", "Experimental KDA operations");
     qkv_causal_conv1d_silu::detail::bind_qkv_causal_conv1d_silu(kda_module);
+    reduce_affine_transforms::detail::bind_reduce_affine_transforms(kda_module);
     sigmoid_gated_rms_norm::detail::bind_sigmoid_gated_rms_norm(kda_module);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/CMakeLists.txt
@@ -1,0 +1,37 @@
+include(sources.cmake)
+
+add_library(ttnn_op_experimental_kda_reduce_affine_transforms ${LIB_TYPE})
+add_library(
+    TTNN::Ops::Experimental::KDA::ReduceAffineTransforms
+    ALIAS ttnn_op_experimental_kda_reduce_affine_transforms
+)
+
+tt_reuse_precompile_headers(ttnn_op_experimental_kda_reduce_affine_transforms TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_kda_reduce_affine_transforms)
+
+set_target_properties(
+    ttnn_op_experimental_kda_reduce_affine_transforms
+    PROPERTIES
+        INTERFACE_HEADER_SETS_TO_VERIFY
+            api
+)
+
+target_sources(
+    ttnn_op_experimental_kda_reduce_affine_transforms
+    PUBLIC
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS ${FixmeOpAPIDir}
+        FILES ${TTNN_OP_EXPERIMENTAL_KDA_REDUCE_AFFINE_TRANSFORMS_API_HEADERS}
+    PRIVATE
+        ${TTNN_OP_EXPERIMENTAL_KDA_REDUCE_AFFINE_TRANSFORMS_SRCS}
+        ${TTNN_OP_EXPERIMENTAL_KDA_SHARED_SRCS}
+)
+
+target_link_libraries(ttnn_op_experimental_kda_reduce_affine_transforms PRIVATE TT::Metalium PUBLIC TTNN::Core)
+
+install(TARGETS ttnn_op_experimental_kda_reduce_affine_transforms FILE_SET api COMPONENT ttnn-dev LIBRARY COMPONENT tar)
+
+if(TARGET ttnn)
+    target_sources(ttnn PRIVATE ${TTNN_OP_EXPERIMENTAL_KDA_REDUCE_AFFINE_TRANSFORMS_NANOBIND_SRCS})
+endif()

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/CMakeLists.txt
@@ -16,6 +16,8 @@ set_target_properties(
             api
 )
 
+file(GLOB_RECURSE kernels device/kernels/*.cpp)
+
 target_sources(
     ttnn_op_experimental_kda_reduce_affine_transforms
     PUBLIC
@@ -23,12 +25,26 @@ target_sources(
         TYPE HEADERS
         BASE_DIRS ${FixmeOpAPIDir}
         FILES ${TTNN_OP_EXPERIMENTAL_KDA_REDUCE_AFFINE_TRANSFORMS_API_HEADERS}
+        FILE_SET kernels
+        TYPE HEADERS
+        BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
+        FILES ${kernels}
     PRIVATE
         ${TTNN_OP_EXPERIMENTAL_KDA_REDUCE_AFFINE_TRANSFORMS_SRCS}
         ${TTNN_OP_EXPERIMENTAL_KDA_SHARED_SRCS}
 )
 
 target_link_libraries(ttnn_op_experimental_kda_reduce_affine_transforms PRIVATE TT::Metalium PUBLIC TTNN::Core)
+
+install(
+    TARGETS
+        ttnn_op_experimental_kda_reduce_affine_transforms
+    FILE_SET
+    kernels
+        DESTINATION
+            ${CMAKE_INSTALL_LIBEXECDIR}/tt-metalium/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms
+        COMPONENT ttnn-runtime
+)
 
 install(TARGETS ttnn_op_experimental_kda_reduce_affine_transforms FILE_SET api COMPONENT ttnn-dev LIBRARY COMPONENT tar)
 

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/CMakeLists.txt
@@ -31,10 +31,16 @@ target_sources(
         FILES ${kernels}
     PRIVATE
         ${TTNN_OP_EXPERIMENTAL_KDA_REDUCE_AFFINE_TRANSFORMS_SRCS}
-        ${TTNN_OP_EXPERIMENTAL_KDA_SHARED_SRCS}
 )
 
-target_link_libraries(ttnn_op_experimental_kda_reduce_affine_transforms PRIVATE TT::Metalium PUBLIC TTNN::Core)
+target_link_libraries(
+    ttnn_op_experimental_kda_reduce_affine_transforms
+    PRIVATE
+        TT::Metalium
+        TTNN::Ops::Experimental::KDA::Common
+    PUBLIC
+        TTNN::Core
+)
 
 install(
     TARGETS

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/compute/reduce_affine_transforms.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/compute/reduce_affine_transforms.cpp
@@ -27,7 +27,8 @@ inline void wait(uint32_t cb, uint32_t tiles) { CircularBuffer(cb).wait_front(ti
 inline void pop(uint32_t cb, uint32_t tiles) { CircularBuffer(cb).pop_front(tiles); }
 
 void matmul(uint32_t a, uint32_t b, uint32_t out, uint32_t Mt, uint32_t Kt, uint32_t Nt) {
-    cb_reserve_back(out, Mt * Nt);
+    CircularBuffer output(out);
+    output.reserve_back(Mt * Nt);
     pack_reconfig_data_format(out);
     reconfig_data_format(b, a);
     matmul_init(a, b);
@@ -43,11 +44,12 @@ void matmul(uint32_t a, uint32_t b, uint32_t out, uint32_t Mt, uint32_t Kt, uint
             tile_regs_release();
         }
     }
-    cb_push_back(out, Mt * Nt);
+    output.push_back(Mt * Nt);
 }
 
 void add(uint32_t a, uint32_t b, uint32_t out, uint32_t tiles) {
-    cb_reserve_back(out, tiles);
+    CircularBuffer output(out);
+    output.reserve_back(tiles);
     pack_reconfig_data_format(out);
     reconfig_data_format(a, b);
     add_init(a, b);
@@ -59,11 +61,12 @@ void add(uint32_t a, uint32_t b, uint32_t out, uint32_t tiles) {
         pack_tile(0, out, tile);
         tile_regs_release();
     }
-    cb_push_back(out, tiles);
+    output.push_back(tiles);
 }
 
 void copy(uint32_t in, uint32_t out, uint32_t tiles) {
-    cb_reserve_back(out, tiles);
+    CircularBuffer output(out);
+    output.reserve_back(tiles);
     pack_reconfig_data_format(out);
     reconfig_data_format_srca(in);
     copy_tile_to_dst_init_short(in);
@@ -75,7 +78,7 @@ void copy(uint32_t in, uint32_t out, uint32_t tiles) {
         pack_tile(0, out, tile);
         tile_regs_release();
     }
-    cb_push_back(out, tiles);
+    output.push_back(tiles);
 }
 }  // namespace
 

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/compute/reduce_affine_transforms.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/compute/reduce_affine_transforms.cpp
@@ -11,7 +11,6 @@
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
 
-namespace {
 void matmul(
     DataflowBuffer& a,
     DataflowBuffer& b,
@@ -93,7 +92,6 @@ void copy(DataflowBuffer& in, DataflowBuffer& out, DataflowBuffer& send, uint32_
     out.push_back(tiles);
     send.push_back(tiles);
 }
-}  // namespace
 
 template <uint32_t Kt, uint32_t Vt, uint32_t G>
 TT_KERNEL void compute(uint32_t group) {

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/compute/reduce_affine_transforms.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/compute/reduce_affine_transforms.cpp
@@ -110,7 +110,6 @@ TT_KERNEL void compute(uint32_t group) {
     DataflowBuffer remote_a(dfb::remote_a);
     DataflowBuffer remote_b(dfb::remote_b);
     DataflowBuffer scratch(dfb::scratch);
-    DataflowBuffer stage_token(dfb::stage_token);
 
     compute_kernel_hw_startup(dfb::initial_a, dfb::initial_b, dfb::stage_a_ping);
     initial_a.wait_front(kk);
@@ -131,7 +130,6 @@ TT_KERNEL void compute(uint32_t group) {
         DataflowBuffer& next_b = ping ? stage_b_ping : stage_b_pong;
         DataflowBuffer& next_send_a = ping ? send_a_ping : send_a_pong;
         DataflowBuffer& next_send_b = ping ? send_b_ping : send_b_pong;
-        stage_token.wait_front(1);
         current_a.wait_front(kk);
         current_b.wait_front(kv);
         remote_a.wait_front(kk);
@@ -143,7 +141,6 @@ TT_KERNEL void compute(uint32_t group) {
         matmul(current_a, remote_b, scratch, nullptr, Kt, Kt, Vt);
         scratch.wait_front(kv);
         add(scratch, current_b, next_b, next_send_b, kv);
-        stage_token.pop_front(1);
         current_a.pop_front(kk);
         current_b.pop_front(kv);
         remote_a.pop_front(kk);

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/compute/reduce_affine_transforms.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/compute/reduce_affine_transforms.cpp
@@ -2,126 +2,155 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
+
 #include "api/compute/common.h"
-#include "api/compute/matmul.h"
 #include "api/compute/eltwise_binary.h"
-#include "api/compute/tile_move_copy.h"
+#include "api/compute/matmul.h"
 #include "api/compute/reconfig_data_format.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "experimental/kernel_args.h"
 
 namespace {
-constexpr uint32_t cb_initial_a = 0;
-constexpr uint32_t cb_initial_b = 1;
-constexpr uint32_t cb_stage_a_ping = 2;
-constexpr uint32_t cb_stage_b_ping = 3;
-constexpr uint32_t cb_stage_a_pong = 4;
-constexpr uint32_t cb_stage_b_pong = 5;
-constexpr uint32_t cb_remote_a = 6;
-constexpr uint32_t cb_remote_b = 7;
-constexpr uint32_t cb_initial_state = 8;
-constexpr uint32_t cb_final = 9;
-constexpr uint32_t cb_scratch = 10;
-constexpr uint32_t cb_stage_token = 11;
-
-inline void wait(uint32_t cb, uint32_t tiles) { CircularBuffer(cb).wait_front(tiles); }
-inline void pop(uint32_t cb, uint32_t tiles) { CircularBuffer(cb).pop_front(tiles); }
-
-void matmul(uint32_t a, uint32_t b, uint32_t out, uint32_t Mt, uint32_t Kt, uint32_t Nt) {
-    CircularBuffer output(out);
-    output.reserve_back(Mt * Nt);
-    pack_reconfig_data_format(out);
-    reconfig_data_format(b, a);
-    matmul_init(a, b);
+void matmul(
+    DataflowBuffer& a,
+    DataflowBuffer& b,
+    DataflowBuffer& out,
+    DataflowBuffer* send,
+    uint32_t Mt,
+    uint32_t Kt,
+    uint32_t Nt) {
+    const uint32_t a_id = a.get_id();
+    const uint32_t b_id = b.get_id();
+    const uint32_t out_id = out.get_id();
+    const uint32_t send_id = send == nullptr ? 0 : send->get_id();
+    out.reserve_back(Mt * Nt);
+    if (send != nullptr) {
+        send->reserve_back(Mt * Nt);
+    }
+    pack_reconfig_data_format(out_id);
+    reconfig_data_format(b_id, a_id);
+    matmul_init(a_id, b_id);
     for (uint32_t m = 0; m < Mt; m++) {
         for (uint32_t n = 0; n < Nt; n++) {
             tile_regs_acquire();
             for (uint32_t k = 0; k < Kt; k++) {
-                matmul_tiles(a, b, m * Kt + k, k * Nt + n, 0);
+                matmul_tiles(a_id, b_id, m * Kt + k, k * Nt + n, 0);
             }
             tile_regs_commit();
             tile_regs_wait();
-            pack_tile(0, out, m * Nt + n);
+            pack_tile(0, out_id, m * Nt + n);
+            if (send != nullptr) {
+                pack_tile(0, send_id, m * Nt + n);
+            }
             tile_regs_release();
         }
     }
-    output.push_back(Mt * Nt);
+    out.push_back(Mt * Nt);
+    if (send != nullptr) {
+        send->push_back(Mt * Nt);
+    }
 }
 
-void add(uint32_t a, uint32_t b, uint32_t out, uint32_t tiles) {
-    CircularBuffer output(out);
-    output.reserve_back(tiles);
-    pack_reconfig_data_format(out);
-    reconfig_data_format(a, b);
-    add_init(a, b);
+void add(DataflowBuffer& a, DataflowBuffer& b, DataflowBuffer& out, DataflowBuffer& send, uint32_t tiles) {
+    const uint32_t a_id = a.get_id();
+    const uint32_t b_id = b.get_id();
+    const uint32_t out_id = out.get_id();
+    const uint32_t send_id = send.get_id();
+    out.reserve_back(tiles);
+    send.reserve_back(tiles);
+    pack_reconfig_data_format(out_id);
+    reconfig_data_format(a_id, b_id);
+    add_init(a_id, b_id);
     for (uint32_t tile = 0; tile < tiles; tile++) {
         tile_regs_acquire();
-        add_tiles(a, b, tile, tile, 0);
+        add_tiles(a_id, b_id, tile, tile, 0);
         tile_regs_commit();
         tile_regs_wait();
-        pack_tile(0, out, tile);
+        pack_tile(0, out_id, tile);
+        pack_tile(0, send_id, tile);
         tile_regs_release();
     }
-    output.push_back(tiles);
+    out.push_back(tiles);
+    send.push_back(tiles);
 }
 
-void copy(uint32_t in, uint32_t out, uint32_t tiles) {
-    CircularBuffer output(out);
-    output.reserve_back(tiles);
-    pack_reconfig_data_format(out);
-    reconfig_data_format_srca(in);
-    copy_tile_to_dst_init_short(in);
+void copy(DataflowBuffer& in, DataflowBuffer& out, DataflowBuffer& send, uint32_t tiles) {
+    const uint32_t in_id = in.get_id();
+    const uint32_t out_id = out.get_id();
+    const uint32_t send_id = send.get_id();
+    out.reserve_back(tiles);
+    send.reserve_back(tiles);
+    pack_reconfig_data_format(out_id);
+    reconfig_data_format_srca(in_id);
+    copy_tile_to_dst_init_short(in_id);
     for (uint32_t tile = 0; tile < tiles; tile++) {
         tile_regs_acquire();
-        copy_tile(in, tile, 0);
+        copy_tile(in_id, tile, 0);
         tile_regs_commit();
         tile_regs_wait();
-        pack_tile(0, out, tile);
+        pack_tile(0, out_id, tile);
+        pack_tile(0, send_id, tile);
         tile_regs_release();
     }
-    output.push_back(tiles);
+    out.push_back(tiles);
+    send.push_back(tiles);
 }
 }  // namespace
 
-void kernel_main() {
-    constexpr uint32_t Kt = get_compile_time_arg_val(0);
-    constexpr uint32_t Vt = get_compile_time_arg_val(1);
-    constexpr uint32_t G = get_compile_time_arg_val(2);
+template <uint32_t Kt, uint32_t Vt, uint32_t G>
+TT_KERNEL void compute(uint32_t group) {
     constexpr uint32_t kk = Kt * Kt;
     constexpr uint32_t kv = Kt * Vt;
-    const uint32_t group = get_arg_val<uint32_t>(0);
+    DataflowBuffer initial_a(dfb::initial_a);
+    DataflowBuffer initial_b(dfb::initial_b);
+    DataflowBuffer stage_a_ping(dfb::stage_a_ping);
+    DataflowBuffer stage_b_ping(dfb::stage_b_ping);
+    DataflowBuffer stage_a_pong(dfb::stage_a_pong);
+    DataflowBuffer stage_b_pong(dfb::stage_b_pong);
+    DataflowBuffer send_a_ping(dfb::send_a_ping);
+    DataflowBuffer send_b_ping(dfb::send_b_ping);
+    DataflowBuffer send_a_pong(dfb::send_a_pong);
+    DataflowBuffer send_b_pong(dfb::send_b_pong);
+    DataflowBuffer remote_a(dfb::remote_a);
+    DataflowBuffer remote_b(dfb::remote_b);
+    DataflowBuffer scratch(dfb::scratch);
+    DataflowBuffer stage_token(dfb::stage_token);
 
-    compute_kernel_hw_startup(cb_initial_a, cb_initial_b, cb_final);
-    wait(cb_initial_a, kk);
-    wait(cb_initial_b, kv);
-    copy(cb_initial_a, cb_stage_a_ping, kk);
-    copy(cb_initial_b, cb_stage_b_ping, kv);
-    pop(cb_initial_a, kk);
-    pop(cb_initial_b, kv);
+    compute_kernel_hw_startup(dfb::initial_a, dfb::initial_b, dfb::stage_a_ping);
+    initial_a.wait_front(kk);
+    initial_b.wait_front(kv);
+    copy(initial_a, stage_a_ping, send_a_ping, kk);
+    copy(initial_b, stage_b_ping, send_b_ping, kv);
+    initial_a.pop_front(kk);
+    initial_b.pop_front(kv);
 
     bool ping = false;
     for (uint32_t distance = 1; distance < G; distance *= 2) {
         if (group < distance) {
             continue;
         }
-        const uint32_t current_a = ping ? cb_stage_a_pong : cb_stage_a_ping;
-        const uint32_t current_b = ping ? cb_stage_b_pong : cb_stage_b_ping;
-        const uint32_t next_a = ping ? cb_stage_a_ping : cb_stage_a_pong;
-        const uint32_t next_b = ping ? cb_stage_b_ping : cb_stage_b_pong;
-        wait(cb_stage_token, 1);
-        wait(current_a, kk);
-        wait(current_b, kv);
-        wait(cb_remote_a, kk);
-        wait(cb_remote_b, kv);
-        matmul(current_a, cb_remote_a, next_a, Kt, Kt, Kt);
-        matmul(current_a, cb_remote_b, cb_scratch, Kt, Kt, Vt);
-        wait(cb_scratch, kv);
-        add(cb_scratch, current_b, next_b, kv);
-        pop(cb_stage_token, 1);
-        pop(current_a, kk);
-        pop(current_b, kv);
-        pop(cb_remote_a, kk);
-        pop(cb_remote_b, kv);
-        pop(cb_scratch, kv);
+        DataflowBuffer& current_a = ping ? stage_a_pong : stage_a_ping;
+        DataflowBuffer& current_b = ping ? stage_b_pong : stage_b_ping;
+        DataflowBuffer& next_a = ping ? stage_a_ping : stage_a_pong;
+        DataflowBuffer& next_b = ping ? stage_b_ping : stage_b_pong;
+        DataflowBuffer& next_send_a = ping ? send_a_ping : send_a_pong;
+        DataflowBuffer& next_send_b = ping ? send_b_ping : send_b_pong;
+        stage_token.wait_front(1);
+        current_a.wait_front(kk);
+        current_b.wait_front(kv);
+        remote_a.wait_front(kk);
+        remote_b.wait_front(kv);
+        matmul(current_a, remote_a, next_a, &next_send_a, Kt, Kt, Kt);
+        matmul(current_a, remote_b, scratch, nullptr, Kt, Kt, Vt);
+        scratch.wait_front(kv);
+        add(scratch, current_b, next_b, next_send_b, kv);
+        stage_token.pop_front(1);
+        current_a.pop_front(kk);
+        current_b.pop_front(kv);
+        remote_a.pop_front(kk);
+        remote_b.pop_front(kv);
+        scratch.pop_front(kv);
         ping = !ping;
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/compute/reduce_affine_transforms.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/compute/reduce_affine_transforms.cpp
@@ -28,9 +28,6 @@ void matmul(
     if (send != nullptr) {
         send->reserve_back(Mt * Nt);
     }
-    pack_reconfig_data_format(out_id);
-    reconfig_data_format(b_id, a_id);
-    matmul_init(a_id, b_id);
     for (uint32_t m = 0; m < Mt; m++) {
         for (uint32_t n = 0; n < Nt; n++) {
             tile_regs_acquire();
@@ -141,6 +138,9 @@ TT_KERNEL void compute(uint32_t group) {
         current_b.wait_front(kv);
         remote_a.wait_front(kk);
         remote_b.wait_front(kv);
+        pack_reconfig_data_format(next_a.get_id());
+        reconfig_data_format(remote_a.get_id(), current_a.get_id());
+        matmul_init(current_a.get_id(), remote_a.get_id());
         matmul(current_a, remote_a, next_a, &next_send_a, Kt, Kt, Kt);
         matmul(current_a, remote_b, scratch, nullptr, Kt, Kt, Vt);
         scratch.wait_front(kv);

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/compute/reduce_affine_transforms.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/compute/reduce_affine_transforms.cpp
@@ -99,53 +99,41 @@ TT_KERNEL void compute(uint32_t group) {
     constexpr uint32_t kv = Kt * Vt;
     DataflowBuffer initial_a(dfb::initial_a);
     DataflowBuffer initial_b(dfb::initial_b);
-    DataflowBuffer stage_a_ping(dfb::stage_a_ping);
-    DataflowBuffer stage_b_ping(dfb::stage_b_ping);
-    DataflowBuffer stage_a_pong(dfb::stage_a_pong);
-    DataflowBuffer stage_b_pong(dfb::stage_b_pong);
-    DataflowBuffer send_a_ping(dfb::send_a_ping);
-    DataflowBuffer send_b_ping(dfb::send_b_ping);
-    DataflowBuffer send_a_pong(dfb::send_a_pong);
-    DataflowBuffer send_b_pong(dfb::send_b_pong);
+    DataflowBuffer stage_a(dfb::stage_a);
+    DataflowBuffer stage_b(dfb::stage_b);
+    DataflowBuffer send_a(dfb::send_a);
+    DataflowBuffer send_b(dfb::send_b);
     DataflowBuffer remote_a(dfb::remote_a);
     DataflowBuffer remote_b(dfb::remote_b);
     DataflowBuffer scratch(dfb::scratch);
 
-    compute_kernel_hw_startup(dfb::initial_a, dfb::initial_b, dfb::stage_a_ping);
+    compute_kernel_hw_startup(dfb::initial_a, dfb::initial_b, dfb::stage_a);
     initial_a.wait_front(kk);
     initial_b.wait_front(kv);
-    copy(initial_a, stage_a_ping, send_a_ping, kk);
-    copy(initial_b, stage_b_ping, send_b_ping, kv);
+    copy(initial_a, stage_a, send_a, kk);
+    copy(initial_b, stage_b, send_b, kv);
     initial_a.pop_front(kk);
     initial_b.pop_front(kv);
 
-    bool ping = false;
     for (uint32_t distance = 1; distance < G; distance *= 2) {
         if (group < distance) {
             continue;
         }
-        DataflowBuffer& current_a = ping ? stage_a_pong : stage_a_ping;
-        DataflowBuffer& current_b = ping ? stage_b_pong : stage_b_ping;
-        DataflowBuffer& next_a = ping ? stage_a_ping : stage_a_pong;
-        DataflowBuffer& next_b = ping ? stage_b_ping : stage_b_pong;
-        DataflowBuffer& next_send_a = ping ? send_a_ping : send_a_pong;
-        DataflowBuffer& next_send_b = ping ? send_b_ping : send_b_pong;
-        current_a.wait_front(kk);
-        current_b.wait_front(kv);
+        stage_a.wait_front(kk);
+        stage_b.wait_front(kv);
         remote_a.wait_front(kk);
         remote_b.wait_front(kv);
-        pack_reconfig_data_format(next_a.get_id());
-        reconfig_data_format(remote_a.get_id(), current_a.get_id());
-        matmul_init(current_a.get_id(), remote_a.get_id());
-        matmul(current_a, remote_a, next_a, &next_send_a, Kt, Kt, Kt);
-        matmul(current_a, remote_b, scratch, nullptr, Kt, Kt, Vt);
+        pack_reconfig_data_format(stage_a.get_id());
+        reconfig_data_format(remote_a.get_id(), stage_a.get_id());
+        matmul_init(stage_a.get_id(), remote_a.get_id());
+        matmul(stage_a, remote_a, stage_a, &send_a, Kt, Kt, Kt);
+        matmul(stage_a, remote_b, scratch, nullptr, Kt, Kt, Vt);
         scratch.wait_front(kv);
-        add(scratch, current_b, next_b, next_send_b, kv);
-        current_a.pop_front(kk);
-        current_b.pop_front(kv);
+        add(scratch, stage_b, stage_b, send_b, kv);
+        stage_a.pop_front(kk);
+        stage_b.pop_front(kv);
         remote_a.pop_front(kk);
         remote_b.pop_front(kv);
         scratch.pop_front(kv);
-        ping = !ping;
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/compute/reduce_affine_transforms.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/compute/reduce_affine_transforms.cpp
@@ -11,14 +11,12 @@
 #include "api/dataflow/dataflow_buffer.h"
 #include "experimental/kernel_args.h"
 
-void matmul(
-    DataflowBuffer& a,
-    DataflowBuffer& b,
-    DataflowBuffer& out,
-    DataflowBuffer* send,
-    uint32_t Mt,
-    uint32_t Kt,
-    uint32_t Nt) {
+// FP32 half-DST holds four 32x32 output tiles. Production's four-tile output rows fit exactly and use
+// matmul_block; wider rows retain the tile loop because a row-major B operand cannot be column-sliced as a block
+// without repacking.
+template <uint32_t Mt, uint32_t Kt, uint32_t Nt>
+void matmul_product(DataflowBuffer& a, DataflowBuffer& b, DataflowBuffer& out, DataflowBuffer* send) {
+    constexpr uint32_t max_block_columns = 4;
     const uint32_t a_id = a.get_id();
     const uint32_t b_id = b.get_id();
     const uint32_t out_id = out.get_id();
@@ -27,19 +25,41 @@ void matmul(
     if (send != nullptr) {
         send->reserve_back(Mt * Nt);
     }
-    for (uint32_t m = 0; m < Mt; m++) {
-        for (uint32_t n = 0; n < Nt; n++) {
+    if constexpr (Nt <= max_block_columns) {
+        matmul_block_init(a_id, b_id, false, Nt, 1, Kt);
+        for (uint32_t row = 0; row < Mt; row++) {
             tile_regs_acquire();
             for (uint32_t k = 0; k < Kt; k++) {
-                matmul_tiles(a_id, b_id, m * Kt + k, k * Nt + n, 0);
+                matmul_block(a_id, b_id, row * Kt + k, k * Nt, 0, false, Nt, 1, Kt);
             }
             tile_regs_commit();
             tile_regs_wait();
-            pack_tile(0, out_id, m * Nt + n);
-            if (send != nullptr) {
-                pack_tile(0, send_id, m * Nt + n);
+            for (uint32_t column = 0; column < Nt; column++) {
+                const uint32_t out_tile = row * Nt + column;
+                pack_tile(column, out_id, out_tile);
+                if (send != nullptr) {
+                    pack_tile(column, send_id, out_tile);
+                }
             }
             tile_regs_release();
+        }
+    } else {
+        matmul_init(a_id, b_id);
+        for (uint32_t row = 0; row < Mt; row++) {
+            for (uint32_t column = 0; column < Nt; column++) {
+                tile_regs_acquire();
+                for (uint32_t k = 0; k < Kt; k++) {
+                    matmul_tiles(a_id, b_id, row * Kt + k, k * Nt + column, 0);
+                }
+                tile_regs_commit();
+                tile_regs_wait();
+                const uint32_t out_tile = row * Nt + column;
+                pack_tile(0, out_id, out_tile);
+                if (send != nullptr) {
+                    pack_tile(0, send_id, out_tile);
+                }
+                tile_regs_release();
+            }
         }
     }
     out.push_back(Mt * Nt);
@@ -55,7 +75,8 @@ void add(DataflowBuffer& a, DataflowBuffer& b, DataflowBuffer& out, DataflowBuff
     const uint32_t send_id = send.get_id();
     out.reserve_back(tiles);
     send.reserve_back(tiles);
-    pack_reconfig_data_format(out_id);
+    // The preceding LLK operation is matmul. Establish add's source state before consuming its independently queued
+    // operands; the packer remains configured for the canonical FP32 internal format.
     reconfig_data_format(a_id, b_id);
     add_init(a_id, b_id);
     for (uint32_t tile = 0; tile < tiles; tile++) {
@@ -77,7 +98,8 @@ void copy(DataflowBuffer& in, DataflowBuffer& out, DataflowBuffer& send, uint32_
     const uint32_t send_id = send.get_id();
     out.reserve_back(tiles);
     send.reserve_back(tiles);
-    pack_reconfig_data_format(out_id);
+    // Initial summaries may be BF16 while stage and send buffers use the canonical FP32 internal format. Copy updates
+    // the source format; startup already configured the packer for the internal format.
     reconfig_data_format_srca(in_id);
     copy_tile_to_dst_init_short(in_id);
     for (uint32_t tile = 0; tile < tiles; tile++) {
@@ -95,8 +117,8 @@ void copy(DataflowBuffer& in, DataflowBuffer& out, DataflowBuffer& send, uint32_
 
 template <uint32_t Kt, uint32_t Vt, uint32_t G>
 TT_KERNEL void compute(uint32_t group) {
-    constexpr uint32_t kk = Kt * Kt;
-    constexpr uint32_t kv = Kt * Vt;
+    constexpr uint32_t a_tiles = Kt * Kt;
+    constexpr uint32_t b_tiles = Kt * Vt;
     DataflowBuffer initial_a(dfb::initial_a);
     DataflowBuffer initial_b(dfb::initial_b);
     DataflowBuffer stage_a(dfb::stage_a);
@@ -107,33 +129,38 @@ TT_KERNEL void compute(uint32_t group) {
     DataflowBuffer remote_b(dfb::remote_b);
     DataflowBuffer scratch(dfb::scratch);
 
-    compute_kernel_hw_startup(dfb::initial_a, dfb::initial_b, dfb::stage_a);
-    initial_a.wait_front(kk);
-    initial_b.wait_front(kv);
-    copy(initial_a, stage_a, send_a, kk);
-    copy(initial_b, stage_b, send_b, kv);
-    initial_a.pop_front(kk);
-    initial_b.pop_front(kv);
+    compute_kernel_hw_startup<SrcOrder::Reverse>(dfb::initial_a, dfb::initial_b, dfb::stage_a);
+    initial_a.wait_front(a_tiles);
+    initial_b.wait_front(b_tiles);
+    copy(initial_a, stage_a, send_a, a_tiles);
+    copy(initial_b, stage_b, send_b, b_tiles);
+    initial_a.pop_front(a_tiles);
+    initial_b.pop_front(b_tiles);
 
     for (uint32_t distance = 1; distance < G; distance *= 2) {
+        // Every participating group produces a prefix consumed by a later group at a subsequent power-of-two
+        // distance. Only the final group writes DRAM, but these intermediate prefixes are required inputs.
         if (group < distance) {
             continue;
         }
-        stage_a.wait_front(kk);
-        stage_b.wait_front(kv);
-        remote_a.wait_front(kk);
-        remote_b.wait_front(kv);
-        pack_reconfig_data_format(stage_a.get_id());
+        // Stage buffers are durable state shared across independently progressing PACK, UNPACK, and NoC stages. The
+        // current destination-register lifetime cannot span that synchronization boundary, so each prefix is queued
+        // and reacquired here.
+        stage_a.wait_front(a_tiles);
+        stage_b.wait_front(b_tiles);
+        remote_a.wait_front(a_tiles);
+        remote_b.wait_front(b_tiles);
         reconfig_data_format(remote_a.get_id(), stage_a.get_id());
-        matmul_init(stage_a.get_id(), remote_a.get_id());
-        matmul(stage_a, remote_a, stage_a, &send_a, Kt, Kt, Kt);
-        matmul(stage_a, remote_b, scratch, nullptr, Kt, Kt, Vt);
-        scratch.wait_front(kv);
-        add(scratch, stage_b, stage_b, send_b, kv);
-        stage_a.pop_front(kk);
-        stage_b.pop_front(kv);
-        remote_a.pop_front(kk);
-        remote_b.pop_front(kv);
-        scratch.pop_front(kv);
+        // Both FP32 products remain separate calls: they consume different right-hand operands and publish
+        // different output rectangles.
+        matmul_product<Kt, Kt, Kt>(stage_a, remote_a, stage_a, &send_a);
+        matmul_product<Kt, Kt, Vt>(stage_a, remote_b, scratch, nullptr);
+        scratch.wait_front(b_tiles);
+        add(scratch, stage_b, stage_b, send_b, b_tiles);
+        stage_a.pop_front(a_tiles);
+        stage_b.pop_front(b_tiles);
+        remote_a.pop_front(a_tiles);
+        remote_b.pop_front(b_tiles);
+        scratch.pop_front(b_tiles);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/compute/reduce_affine_transforms.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/compute/reduce_affine_transforms.cpp
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/compute/common.h"
+#include "api/compute/matmul.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/reconfig_data_format.h"
+#include "api/dataflow/circular_buffer.h"
+
+namespace {
+constexpr uint32_t cb_initial_a = 0;
+constexpr uint32_t cb_initial_b = 1;
+constexpr uint32_t cb_stage_a_ping = 2;
+constexpr uint32_t cb_stage_b_ping = 3;
+constexpr uint32_t cb_stage_a_pong = 4;
+constexpr uint32_t cb_stage_b_pong = 5;
+constexpr uint32_t cb_remote_a = 6;
+constexpr uint32_t cb_remote_b = 7;
+constexpr uint32_t cb_initial_state = 8;
+constexpr uint32_t cb_final = 9;
+constexpr uint32_t cb_scratch = 10;
+constexpr uint32_t cb_stage_token = 11;
+
+inline void wait(uint32_t cb, uint32_t tiles) { CircularBuffer(cb).wait_front(tiles); }
+inline void pop(uint32_t cb, uint32_t tiles) { CircularBuffer(cb).pop_front(tiles); }
+
+void matmul(uint32_t a, uint32_t b, uint32_t out, uint32_t Mt, uint32_t Kt, uint32_t Nt) {
+    cb_reserve_back(out, Mt * Nt);
+    pack_reconfig_data_format(out);
+    reconfig_data_format(b, a);
+    matmul_init(a, b);
+    for (uint32_t m = 0; m < Mt; m++) {
+        for (uint32_t n = 0; n < Nt; n++) {
+            tile_regs_acquire();
+            for (uint32_t k = 0; k < Kt; k++) {
+                matmul_tiles(a, b, m * Kt + k, k * Nt + n, 0);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(0, out, m * Nt + n);
+            tile_regs_release();
+        }
+    }
+    cb_push_back(out, Mt * Nt);
+}
+
+void add(uint32_t a, uint32_t b, uint32_t out, uint32_t tiles) {
+    cb_reserve_back(out, tiles);
+    pack_reconfig_data_format(out);
+    reconfig_data_format(a, b);
+    add_init(a, b);
+    for (uint32_t tile = 0; tile < tiles; tile++) {
+        tile_regs_acquire();
+        add_tiles(a, b, tile, tile, 0);
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, out, tile);
+        tile_regs_release();
+    }
+    cb_push_back(out, tiles);
+}
+
+void copy(uint32_t in, uint32_t out, uint32_t tiles) {
+    cb_reserve_back(out, tiles);
+    pack_reconfig_data_format(out);
+    reconfig_data_format_srca(in);
+    copy_tile_to_dst_init_short(in);
+    for (uint32_t tile = 0; tile < tiles; tile++) {
+        tile_regs_acquire();
+        copy_tile(in, tile, 0);
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, out, tile);
+        tile_regs_release();
+    }
+    cb_push_back(out, tiles);
+}
+}  // namespace
+
+void kernel_main() {
+    constexpr uint32_t Kt = get_compile_time_arg_val(0);
+    constexpr uint32_t Vt = get_compile_time_arg_val(1);
+    constexpr uint32_t G = get_compile_time_arg_val(2);
+    constexpr uint32_t kk = Kt * Kt;
+    constexpr uint32_t kv = Kt * Vt;
+    const uint32_t group = get_arg_val<uint32_t>(0);
+
+    compute_kernel_hw_startup(cb_initial_a, cb_initial_b, cb_final);
+    wait(cb_initial_a, kk);
+    wait(cb_initial_b, kv);
+    copy(cb_initial_a, cb_stage_a_ping, kk);
+    copy(cb_initial_b, cb_stage_b_ping, kv);
+    pop(cb_initial_a, kk);
+    pop(cb_initial_b, kv);
+
+    bool ping = false;
+    for (uint32_t distance = 1; distance < G; distance *= 2) {
+        if (group < distance) {
+            continue;
+        }
+        const uint32_t current_a = ping ? cb_stage_a_pong : cb_stage_a_ping;
+        const uint32_t current_b = ping ? cb_stage_b_pong : cb_stage_b_ping;
+        const uint32_t next_a = ping ? cb_stage_a_ping : cb_stage_a_pong;
+        const uint32_t next_b = ping ? cb_stage_b_ping : cb_stage_b_pong;
+        wait(cb_stage_token, 1);
+        wait(current_a, kk);
+        wait(current_b, kv);
+        wait(cb_remote_a, kk);
+        wait(cb_remote_b, kv);
+        matmul(current_a, cb_remote_a, next_a, Kt, Kt, Kt);
+        matmul(current_a, cb_remote_b, cb_scratch, Kt, Kt, Vt);
+        wait(cb_scratch, kv);
+        add(cb_scratch, current_b, next_b, kv);
+        pop(cb_stage_token, 1);
+        pop(current_a, kk);
+        pop(current_b, kv);
+        pop(cb_remote_a, kk);
+        pop(cb_remote_b, kv);
+        pop(cb_scratch, kv);
+        ping = !ping;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/dataflow/reader_writer_reduce_affine_transforms.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/dataflow/reader_writer_reduce_affine_transforms.cpp
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+namespace {
+constexpr uint32_t cb_initial_a = 0;
+constexpr uint32_t cb_initial_b = 1;
+constexpr uint32_t cb_stage_a_ping = 2;
+constexpr uint32_t cb_stage_b_ping = 3;
+constexpr uint32_t cb_stage_a_pong = 4;
+constexpr uint32_t cb_stage_b_pong = 5;
+constexpr uint32_t cb_remote_a = 6;
+constexpr uint32_t cb_remote_b = 7;
+constexpr uint32_t cb_output = 9;
+constexpr uint32_t cb_stage_token = 11;
+}  // namespace
+
+void kernel_main() {
+    constexpr uint32_t Kt = get_compile_time_arg_val(0);
+    constexpr uint32_t Vt = get_compile_time_arg_val(1);
+    constexpr uint32_t BH = get_compile_time_arg_val(2);
+    constexpr uint32_t G = get_compile_time_arg_val(3);
+    constexpr auto a_args = TensorAccessorArgs<4>();
+    constexpr auto b_args = TensorAccessorArgs<a_args.next_compile_time_args_offset()>();
+    constexpr auto output_a_args = TensorAccessorArgs<b_args.next_compile_time_args_offset()>();
+    constexpr auto output_b_args = TensorAccessorArgs<output_a_args.next_compile_time_args_offset()>();
+    constexpr uint32_t kk = Kt * Kt;
+    constexpr uint32_t kv = Kt * Vt;
+    static_assert(BH * G <= 128, "affine prefix coordinate table exceeds runtime-arg budget");
+
+    const uint32_t worker_index = get_arg_val<uint32_t>(0);
+    const uint32_t group = get_arg_val<uint32_t>(1);
+    const uint32_t worker_count = get_arg_val<uint32_t>(2);
+    const uint32_t a_addr = get_arg_val<uint32_t>(3);
+    const uint32_t b_addr = get_arg_val<uint32_t>(4);
+    const uint32_t output_a_addr = get_arg_val<uint32_t>(5);
+    const uint32_t output_b_addr = get_arg_val<uint32_t>(6);
+    const uint32_t ready_sem = get_arg_val<uint32_t>(7);
+    const uint32_t arrival_sem = get_arg_val<uint32_t>(8);
+    const uint32_t release_sem = get_arg_val<uint32_t>(9);
+    const uint32_t coordinator_x = get_arg_val<uint32_t>(10);
+    const uint32_t coordinator_y = get_arg_val<uint32_t>(11);
+
+    const uint32_t input_a_tile_bytes = get_tile_size(cb_initial_a);
+    const uint32_t input_b_tile_bytes = get_tile_size(cb_initial_b);
+    const uint32_t stage_a_tile_bytes = get_tile_size(cb_stage_a_ping);
+    const uint32_t stage_b_tile_bytes = get_tile_size(cb_stage_b_ping);
+    const uint32_t output_tile_bytes = get_tile_size(cb_output);
+    const auto a_accessor = TensorAccessor(a_args, a_addr, input_a_tile_bytes);
+    const auto b_accessor = TensorAccessor(b_args, b_addr, input_b_tile_bytes);
+    const auto output_a_accessor = TensorAccessor(output_a_args, output_a_addr, output_tile_bytes);
+    const auto output_b_accessor = TensorAccessor(output_b_args, output_b_addr, output_tile_bytes);
+    Noc noc;
+
+    auto worker_x = [&](uint32_t worker) { return get_arg_val<uint32_t>(12 + 2 * worker); };
+    auto worker_y = [&](uint32_t worker) { return get_arg_val<uint32_t>(13 + 2 * worker); };
+    auto read_tiles = [&](const auto& accessor, uint32_t cb_id, uint32_t page, uint32_t tiles, uint32_t tile_bytes) {
+        CircularBuffer cb(cb_id);
+        cb.reserve_back(tiles);
+        for (uint32_t tile = 0; tile < tiles; tile++) {
+            noc.async_read(accessor, cb, tile_bytes, {.page_id = page + tile}, {.offset_bytes = tile * tile_bytes});
+        }
+        noc.async_read_barrier();
+        cb.push_back(tiles);
+    };
+    read_tiles(a_accessor, cb_initial_a, worker_index * kk, kk, input_a_tile_bytes);
+    read_tiles(b_accessor, cb_initial_b, worker_index * kv, kv, input_b_tile_bytes);
+
+    uint32_t completed_stages = 0;
+    auto stage_barrier = [&] {
+        completed_stages++;
+        noc_semaphore_inc(get_noc_addr(coordinator_x, coordinator_y, get_semaphore(arrival_sem)), 1);
+        if (worker_index == 0) {
+            noc_semaphore_wait_min(
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(arrival_sem)),
+                completed_stages * worker_count);
+            for (uint32_t worker = 0; worker < worker_count; worker++) {
+                noc_semaphore_inc(get_noc_addr(worker_x(worker), worker_y(worker), get_semaphore(release_sem)), 1);
+            }
+            noc_async_atomic_barrier();
+        }
+        noc_semaphore_wait_min(
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(release_sem)), completed_stages);
+    };
+    auto send_pair = [&](uint32_t target, uint32_t current_a, uint32_t current_b) {
+        noc_async_write(
+            get_read_ptr(current_a),
+            get_noc_addr(worker_x(target), worker_y(target), get_write_ptr(cb_remote_a)),
+            kk * stage_a_tile_bytes);
+        noc_async_write(
+            get_read_ptr(current_b),
+            get_noc_addr(worker_x(target), worker_y(target), get_write_ptr(cb_remote_b)),
+            kv * stage_b_tile_bytes);
+        noc_async_write_barrier();
+        noc_semaphore_inc(get_noc_addr(worker_x(target), worker_y(target), get_semaphore(ready_sem)), 1);
+    };
+    auto receive_pair = [&] {
+        CircularBuffer(cb_remote_a).reserve_back(kk);
+        CircularBuffer(cb_remote_b).reserve_back(kv);
+        CircularBuffer(cb_remote_a).push_back(kk);
+        CircularBuffer(cb_remote_b).push_back(kv);
+    };
+
+    uint32_t ready_target = 0;
+    bool ping = false;
+    for (uint32_t distance = 1; distance < G; distance *= 2) {
+        const uint32_t current_a = ping ? cb_stage_a_pong : cb_stage_a_ping;
+        const uint32_t current_b = ping ? cb_stage_b_pong : cb_stage_b_ping;
+        const uint32_t next_a = ping ? cb_stage_a_ping : cb_stage_a_pong;
+        const uint32_t next_b = ping ? cb_stage_b_ping : cb_stage_b_pong;
+        CircularBuffer(current_a).wait_front(kk);
+        CircularBuffer(current_b).wait_front(kv);
+        if (group + distance < G) {
+            send_pair(worker_index + distance, current_a, current_b);
+        }
+        if (group >= distance) {
+            ready_target++;
+            noc_semaphore_wait_min(
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(ready_sem)), ready_target);
+            receive_pair();
+            CircularBuffer(cb_stage_token).reserve_back(1);
+            CircularBuffer(cb_stage_token).push_back(1);
+        }
+        if (group >= distance) {
+            CircularBuffer(next_a).wait_front(kk);
+            CircularBuffer(next_b).wait_front(kv);
+            ping = !ping;
+        }
+        // Do not release the next NoC stage until every receiver has consumed cb_remote and
+        // produced its next prefix. Otherwise the following stage can overwrite cb_remote while
+        // compute is still reading it.
+        stage_barrier();
+    }
+
+    const uint32_t current_a = ping ? cb_stage_a_pong : cb_stage_a_ping;
+    const uint32_t current_b = ping ? cb_stage_b_pong : cb_stage_b_ping;
+    CircularBuffer(current_a).wait_front(kk);
+    CircularBuffer(current_b).wait_front(kv);
+    {
+        if (group + 1 == G) {
+            CircularBuffer prefix_a(current_a);
+            CircularBuffer prefix_b(current_b);
+            const uint32_t head = worker_index / G;
+            for (uint32_t tile = 0; tile < kk; tile++) {
+                noc.async_write(
+                    prefix_a,
+                    output_a_accessor,
+                    output_tile_bytes,
+                    {.offset_bytes = tile * output_tile_bytes},
+                    {.page_id = head * kk + tile});
+            }
+            for (uint32_t tile = 0; tile < kv; tile++) {
+                noc.async_write(
+                    prefix_b,
+                    output_b_accessor,
+                    output_tile_bytes,
+                    {.offset_bytes = tile * output_tile_bytes},
+                    {.page_id = head * kv + tile});
+            }
+            noc.async_write_barrier();
+        }
+        return;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/dataflow/reader_writer_reduce_affine_transforms.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/dataflow/reader_writer_reduce_affine_transforms.cpp
@@ -29,7 +29,6 @@ TT_KERNEL void dataflow(uint32_t worker_index, uint32_t group, uint32_t coordina
     DataflowBuffer send_b_pong(dfb::send_b_pong);
     DataflowBuffer remote_a(dfb::remote_a);
     DataflowBuffer remote_b(dfb::remote_b);
-    DataflowBuffer stage_token(dfb::stage_token);
     Noc noc;
     Semaphore<> ready(sem::ready);
     Semaphore<> arrival(sem::arrival);
@@ -84,12 +83,6 @@ TT_KERNEL void dataflow(uint32_t worker_index, uint32_t group, uint32_t coordina
         noc.async_write_barrier();
         ready.up(noc, target_x, target_y, 1);
     };
-    auto receive_pair = [&] {
-        remote_a.reserve_back(kk);
-        remote_b.reserve_back(kv);
-        remote_a.push_back(kk);
-        remote_b.push_back(kv);
-    };
 
     uint32_t ready_target = 0;
     bool ping = false;
@@ -104,11 +97,12 @@ TT_KERNEL void dataflow(uint32_t worker_index, uint32_t group, uint32_t coordina
             send_pair(worker_index + distance, current_a, current_b);
         }
         if (group >= distance) {
+            remote_a.reserve_back(kk);
+            remote_b.reserve_back(kv);
             ready_target++;
             ready.wait_min(ready_target);
-            receive_pair();
-            stage_token.reserve_back(1);
-            stage_token.push_back(1);
+            remote_a.push_back(kk);
+            remote_b.push_back(kv);
             next_a.wait_front(kk);
             next_b.wait_front(kv);
             current_a.pop_front(kk);

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/dataflow/reader_writer_reduce_affine_transforms.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/dataflow/reader_writer_reduce_affine_transforms.cpp
@@ -23,10 +23,8 @@ TT_KERNEL void dataflow(uint32_t worker_index, uint32_t group, uint32_t coordina
     const auto output_b_accessor = TensorAccessor(tensor::output_b);
     DataflowBuffer initial_a(dfb::initial_a);
     DataflowBuffer initial_b(dfb::initial_b);
-    DataflowBuffer send_a_ping(dfb::send_a_ping);
-    DataflowBuffer send_b_ping(dfb::send_b_ping);
-    DataflowBuffer send_a_pong(dfb::send_a_pong);
-    DataflowBuffer send_b_pong(dfb::send_b_pong);
+    DataflowBuffer send_a(dfb::send_a);
+    DataflowBuffer send_b(dfb::send_b);
     DataflowBuffer remote_a(dfb::remote_a);
     DataflowBuffer remote_b(dfb::remote_b);
     Noc noc;
@@ -65,19 +63,19 @@ TT_KERNEL void dataflow(uint32_t worker_index, uint32_t group, uint32_t coordina
         }
         release.wait_min(completed_stages);
     };
-    auto send_pair = [&](uint32_t target, DataflowBuffer& current_a, DataflowBuffer& current_b) {
+    auto send_pair = [&](uint32_t target, DataflowBuffer& send_a, DataflowBuffer& send_b) {
         const uint32_t target_x = worker_x(target);
         const uint32_t target_y = worker_y(target);
         noc.async_write(
-            current_a,
+            send_a,
             UnicastEndpoint{},
-            kk * current_a.get_entry_size(),
+            kk * send_a.get_entry_size(),
             {},
             {.noc_x = target_x, .noc_y = target_y, .addr = remote_a.get_write_ptr()});
         noc.async_write(
-            current_b,
+            send_b,
             UnicastEndpoint{},
-            kv * current_b.get_entry_size(),
+            kv * send_b.get_entry_size(),
             {},
             {.noc_x = target_x, .noc_y = target_y, .addr = remote_b.get_write_ptr()});
         noc.async_write_barrier();
@@ -85,16 +83,11 @@ TT_KERNEL void dataflow(uint32_t worker_index, uint32_t group, uint32_t coordina
     };
 
     uint32_t ready_target = 0;
-    bool ping = false;
     for (uint32_t distance = 1; distance < G; distance *= 2) {
-        DataflowBuffer& current_a = ping ? send_a_pong : send_a_ping;
-        DataflowBuffer& current_b = ping ? send_b_pong : send_b_ping;
-        DataflowBuffer& next_a = ping ? send_a_ping : send_a_pong;
-        DataflowBuffer& next_b = ping ? send_b_ping : send_b_pong;
-        current_a.wait_front(kk);
-        current_b.wait_front(kv);
+        send_a.wait_front(kk);
+        send_b.wait_front(kv);
         if (group + distance < G) {
-            send_pair(worker_index + distance, current_a, current_b);
+            send_pair(worker_index + distance, send_a, send_b);
         }
         if (group >= distance) {
             remote_a.reserve_back(kk);
@@ -103,37 +96,34 @@ TT_KERNEL void dataflow(uint32_t worker_index, uint32_t group, uint32_t coordina
             ready.wait_min(ready_target);
             remote_a.push_back(kk);
             remote_b.push_back(kv);
-            next_a.wait_front(kk);
-            next_b.wait_front(kv);
-            current_a.pop_front(kk);
-            current_b.pop_front(kv);
-            ping = !ping;
+            send_a.wait_front(2 * kk);
+            send_b.wait_front(2 * kv);
+            send_a.pop_front(kk);
+            send_b.pop_front(kv);
         }
         // Do not release the next NoC stage until every receiver has consumed the remote buffers and produced its
         // next prefix. Otherwise the following stage can overwrite the remote buffers while compute is reading them.
         stage_barrier();
     }
 
-    DataflowBuffer& current_a = ping ? send_a_pong : send_a_ping;
-    DataflowBuffer& current_b = ping ? send_b_pong : send_b_ping;
-    current_a.wait_front(kk);
-    current_b.wait_front(kv);
+    send_a.wait_front(kk);
+    send_b.wait_front(kv);
     if (group + 1 == G) {
         const uint32_t head = worker_index / G;
         for (uint32_t tile = 0; tile < kk; tile++) {
             noc.async_write(
-                current_a,
+                send_a,
                 output_a_accessor,
-                current_a.get_entry_size(),
-                {.offset_bytes = tile * current_a.get_entry_size()},
+                send_a.get_entry_size(),
+                {.offset_bytes = tile * send_a.get_entry_size()},
                 {.page_id = head * kk + tile});
         }
         for (uint32_t tile = 0; tile < kv; tile++) {
             noc.async_write(
-                current_b,
+                send_b,
                 output_b_accessor,
-                current_b.get_entry_size(),
-                {.offset_bytes = tile * current_b.get_entry_size()},
+                send_b.get_entry_size(),
+                {.offset_bytes = tile * send_b.get_entry_size()},
                 {.page_id = head * kv + tile});
         }
         noc.async_write_barrier();

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/dataflow/reader_writer_reduce_affine_transforms.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/dataflow/reader_writer_reduce_affine_transforms.cpp
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
+#include "api/core_local_mem.h"
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
 
@@ -56,6 +58,9 @@ void kernel_main() {
     const auto output_a_accessor = TensorAccessor(output_a_args, output_a_addr, output_tile_bytes);
     const auto output_b_accessor = TensorAccessor(output_b_args, output_b_addr, output_tile_bytes);
     Noc noc;
+    Semaphore<> ready(ready_sem);
+    Semaphore<> arrival(arrival_sem);
+    Semaphore<> release(release_sem);
 
     auto worker_x = [&](uint32_t worker) { return get_arg_val<uint32_t>(12 + 2 * worker); };
     auto worker_y = [&](uint32_t worker) { return get_arg_val<uint32_t>(13 + 2 * worker); };
@@ -74,30 +79,37 @@ void kernel_main() {
     uint32_t completed_stages = 0;
     auto stage_barrier = [&] {
         completed_stages++;
-        noc_semaphore_inc(get_noc_addr(coordinator_x, coordinator_y, get_semaphore(arrival_sem)), 1);
+        arrival.up(noc, coordinator_x, coordinator_y, 1);
         if (worker_index == 0) {
-            noc_semaphore_wait_min(
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(arrival_sem)),
-                completed_stages * worker_count);
+            arrival.wait_min(completed_stages * worker_count);
             for (uint32_t worker = 0; worker < worker_count; worker++) {
-                noc_semaphore_inc(get_noc_addr(worker_x(worker), worker_y(worker), get_semaphore(release_sem)), 1);
+                release.up(noc, worker_x(worker), worker_y(worker), 1);
             }
-            noc_async_atomic_barrier();
+            noc.async_atomic_barrier();
         }
-        noc_semaphore_wait_min(
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(release_sem)), completed_stages);
+        release.wait_min(completed_stages);
     };
     auto send_pair = [&](uint32_t target, uint32_t current_a, uint32_t current_b) {
-        noc_async_write(
-            get_read_ptr(current_a),
-            get_noc_addr(worker_x(target), worker_y(target), get_write_ptr(cb_remote_a)),
-            kk * stage_a_tile_bytes);
-        noc_async_write(
-            get_read_ptr(current_b),
-            get_noc_addr(worker_x(target), worker_y(target), get_write_ptr(cb_remote_b)),
-            kv * stage_b_tile_bytes);
-        noc_async_write_barrier();
-        noc_semaphore_inc(get_noc_addr(worker_x(target), worker_y(target), get_semaphore(ready_sem)), 1);
+        const CircularBuffer current_a_buffer(current_a);
+        const CircularBuffer current_b_buffer(current_b);
+        const CircularBuffer remote_a_buffer(cb_remote_a);
+        const CircularBuffer remote_b_buffer(cb_remote_b);
+        const uint32_t target_x = worker_x(target);
+        const uint32_t target_y = worker_y(target);
+        noc.async_write(
+            CoreLocalMem<uint32_t>(current_a_buffer.get_read_ptr()),
+            UnicastEndpoint{},
+            kk * stage_a_tile_bytes,
+            {},
+            {.noc_x = target_x, .noc_y = target_y, .addr = remote_a_buffer.get_write_ptr()});
+        noc.async_write(
+            CoreLocalMem<uint32_t>(current_b_buffer.get_read_ptr()),
+            UnicastEndpoint{},
+            kv * stage_b_tile_bytes,
+            {},
+            {.noc_x = target_x, .noc_y = target_y, .addr = remote_b_buffer.get_write_ptr()});
+        noc.async_write_barrier();
+        ready.up(noc, target_x, target_y, 1);
     };
     auto receive_pair = [&] {
         CircularBuffer(cb_remote_a).reserve_back(kk);
@@ -120,8 +132,7 @@ void kernel_main() {
         }
         if (group >= distance) {
             ready_target++;
-            noc_semaphore_wait_min(
-                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(ready_sem)), ready_target);
+            ready.wait_min(ready_target);
             receive_pair();
             CircularBuffer(cb_stage_token).reserve_back(1);
             CircularBuffer(cb_stage_token).push_back(1);

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/dataflow/reader_writer_reduce_affine_transforms.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/dataflow/reader_writer_reduce_affine_transforms.cpp
@@ -9,13 +9,79 @@
 #include "api/dataflow/noc_semaphore.h"
 #include "api/tensor/noc_traits.h"
 #include "experimental/kernel_args.h"
+FORCE_INLINE uint32_t worker_x(uint32_t worker) { return get_common_vararg(2 * worker); }
+FORCE_INLINE uint32_t worker_y(uint32_t worker) { return get_common_vararg(2 * worker + 1); }
 
-template <uint32_t Kt, uint32_t Vt, uint32_t BH, uint32_t G>
-TT_KERNEL void dataflow(uint32_t worker_index, uint32_t group, uint32_t coordinator_x, uint32_t coordinator_y) {
-    constexpr uint32_t kk = Kt * Kt;
-    constexpr uint32_t kv = Kt * Vt;
-    constexpr uint32_t worker_count = BH * G;
-    static_assert(worker_count <= 128, "affine prefix coordinate table exceeds runtime-arg budget");
+template <typename Accessor>
+FORCE_INLINE void issue_tensor_block_read(
+    Noc& noc, const Accessor& accessor, DataflowBuffer& buffer, uint32_t page, uint32_t tiles) {
+    for (uint32_t tile = 0; tile < tiles; tile++) {
+        noc.async_read(
+            accessor,
+            buffer,
+            buffer.get_entry_size(),
+            {.page_id = page + tile},
+            {.offset_bytes = tile * buffer.get_entry_size()});
+    }
+}
+
+FORCE_INLINE void send_affine_pair(
+    Noc& noc,
+    Semaphore<>& ready,
+    uint32_t target,
+    DataflowBuffer& send_a,
+    DataflowBuffer& send_b,
+    DataflowBuffer& remote_a,
+    DataflowBuffer& remote_b,
+    uint32_t a_tiles,
+    uint32_t b_tiles) {
+    const uint32_t target_x = worker_x(target);
+    const uint32_t target_y = worker_y(target);
+    noc.async_write(
+        send_a,
+        UnicastEndpoint{},
+        a_tiles * send_a.get_entry_size(),
+        {},
+        {.noc_x = target_x, .noc_y = target_y, .addr = remote_a.get_write_ptr()});
+    noc.async_write(
+        send_b,
+        UnicastEndpoint{},
+        b_tiles * send_b.get_entry_size(),
+        {},
+        {.noc_x = target_x, .noc_y = target_y, .addr = remote_b.get_write_ptr()});
+    noc.async_write_barrier();
+    ready.up(noc, target_x, target_y, 1);
+}
+
+template <uint32_t G>
+FORCE_INLINE void synchronize_head_stage(
+    uint32_t worker_index,
+    uint32_t group,
+    uint32_t& completed_stages,
+    Noc& noc,
+    Semaphore<>& arrival,
+    Semaphore<>& release) {
+    completed_stages++;
+    const uint32_t coordinator = worker_index - group;
+    const uint32_t coordinator_x = worker_x(coordinator);
+    const uint32_t coordinator_y = worker_y(coordinator);
+    arrival.up(noc, coordinator_x, coordinator_y, 1);
+    if (group == 0) {
+        arrival.wait_min(completed_stages * G);
+        for (uint32_t worker = coordinator; worker < coordinator + G; worker++) {
+            const uint32_t target_x = worker_x(worker);
+            const uint32_t target_y = worker_y(worker);
+            release.up(noc, target_x, target_y, 1);
+        }
+        noc.async_atomic_barrier();
+    }
+    release.wait_min(completed_stages);
+}
+
+template <uint32_t Kt, uint32_t Vt, uint32_t G>
+TT_KERNEL void dataflow(uint32_t worker_index, uint32_t group) {
+    constexpr uint32_t a_tiles = Kt * Kt;
+    constexpr uint32_t b_tiles = Kt * Vt;
 
     const auto a_accessor = TensorAccessor(tensor::a);
     const auto b_accessor = TensorAccessor(tensor::b);
@@ -32,99 +98,59 @@ TT_KERNEL void dataflow(uint32_t worker_index, uint32_t group, uint32_t coordina
     Semaphore<> arrival(sem::arrival);
     Semaphore<> release(sem::release);
 
-    auto worker_x = [](uint32_t worker) { return get_common_vararg(2 * worker); };
-    auto worker_y = [](uint32_t worker) { return get_common_vararg(2 * worker + 1); };
-    auto read_tiles = [&](const auto& accessor, DataflowBuffer& buffer, uint32_t page, uint32_t tiles) {
-        buffer.reserve_back(tiles);
-        for (uint32_t tile = 0; tile < tiles; tile++) {
-            noc.async_read(
-                accessor,
-                buffer,
-                buffer.get_entry_size(),
-                {.page_id = page + tile},
-                {.offset_bytes = tile * buffer.get_entry_size()});
-        }
-        noc.async_read_barrier();
-        buffer.push_back(tiles);
-    };
-    read_tiles(a_accessor, initial_a, worker_index * kk, kk);
-    read_tiles(b_accessor, initial_b, worker_index * kv, kv);
+    initial_a.reserve_back(a_tiles);
+    initial_b.reserve_back(b_tiles);
+    issue_tensor_block_read(noc, a_accessor, initial_a, worker_index * a_tiles, a_tiles);
+    issue_tensor_block_read(noc, b_accessor, initial_b, worker_index * b_tiles, b_tiles);
+    noc.async_read_barrier();
+    initial_a.push_back(a_tiles);
+    initial_b.push_back(b_tiles);
 
     uint32_t completed_stages = 0;
-    auto stage_barrier = [&] {
-        completed_stages++;
-        arrival.up(noc, coordinator_x, coordinator_y, 1);
-        if (worker_index == 0) {
-            arrival.wait_min(completed_stages * worker_count);
-            for (uint32_t worker = 0; worker < worker_count; worker++) {
-                release.up(noc, worker_x(worker), worker_y(worker), 1);
-            }
-            noc.async_atomic_barrier();
-        }
-        release.wait_min(completed_stages);
-    };
-    auto send_pair = [&](uint32_t target, DataflowBuffer& send_a, DataflowBuffer& send_b) {
-        const uint32_t target_x = worker_x(target);
-        const uint32_t target_y = worker_y(target);
-        noc.async_write(
-            send_a,
-            UnicastEndpoint{},
-            kk * send_a.get_entry_size(),
-            {},
-            {.noc_x = target_x, .noc_y = target_y, .addr = remote_a.get_write_ptr()});
-        noc.async_write(
-            send_b,
-            UnicastEndpoint{},
-            kv * send_b.get_entry_size(),
-            {},
-            {.noc_x = target_x, .noc_y = target_y, .addr = remote_b.get_write_ptr()});
-        noc.async_write_barrier();
-        ready.up(noc, target_x, target_y, 1);
-    };
 
     uint32_t ready_target = 0;
     for (uint32_t distance = 1; distance < G; distance *= 2) {
-        send_a.wait_front(kk);
-        send_b.wait_front(kv);
+        send_a.wait_front(a_tiles);
+        send_b.wait_front(b_tiles);
         if (group + distance < G) {
-            send_pair(worker_index + distance, send_a, send_b);
+            send_affine_pair(noc, ready, worker_index + distance, send_a, send_b, remote_a, remote_b, a_tiles, b_tiles);
         }
         if (group >= distance) {
-            remote_a.reserve_back(kk);
-            remote_b.reserve_back(kv);
+            remote_a.reserve_back(a_tiles);
+            remote_b.reserve_back(b_tiles);
             ready_target++;
             ready.wait_min(ready_target);
-            remote_a.push_back(kk);
-            remote_b.push_back(kv);
-            send_a.wait_front(2 * kk);
-            send_b.wait_front(2 * kv);
-            send_a.pop_front(kk);
-            send_b.pop_front(kv);
+            remote_a.push_back(a_tiles);
+            remote_b.push_back(b_tiles);
+            send_a.wait_front(2 * a_tiles);
+            send_b.wait_front(2 * b_tiles);
+            send_a.pop_front(a_tiles);
+            send_b.pop_front(b_tiles);
         }
         // Do not release the next NoC stage until every receiver has consumed the remote buffers and produced its
         // next prefix. Otherwise the following stage can overwrite the remote buffers while compute is reading them.
-        stage_barrier();
+        synchronize_head_stage<G>(worker_index, group, completed_stages, noc, arrival, release);
     }
 
-    send_a.wait_front(kk);
-    send_b.wait_front(kv);
+    send_a.wait_front(a_tiles);
+    send_b.wait_front(b_tiles);
     if (group + 1 == G) {
         const uint32_t head = worker_index / G;
-        for (uint32_t tile = 0; tile < kk; tile++) {
+        for (uint32_t tile = 0; tile < a_tiles; tile++) {
             noc.async_write(
                 send_a,
                 output_a_accessor,
                 send_a.get_entry_size(),
                 {.offset_bytes = tile * send_a.get_entry_size()},
-                {.page_id = head * kk + tile});
+                {.page_id = head * a_tiles + tile});
         }
-        for (uint32_t tile = 0; tile < kv; tile++) {
+        for (uint32_t tile = 0; tile < b_tiles; tile++) {
             noc.async_write(
                 send_b,
                 output_b_accessor,
                 send_b.get_entry_size(),
                 {.offset_bytes = tile * send_b.get_entry_size()},
-                {.page_id = head * kv + tile});
+                {.page_id = head * b_tiles + tile});
         }
         noc.async_write_barrier();
     }

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/dataflow/reader_writer_reduce_affine_transforms.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/dataflow/reader_writer_reduce_affine_transforms.cpp
@@ -2,79 +2,56 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
-#include "api/core_local_mem.h"
+
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/noc_semaphore.h"
-#include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
-namespace {
-constexpr uint32_t cb_initial_a = 0;
-constexpr uint32_t cb_initial_b = 1;
-constexpr uint32_t cb_stage_a_ping = 2;
-constexpr uint32_t cb_stage_b_ping = 3;
-constexpr uint32_t cb_stage_a_pong = 4;
-constexpr uint32_t cb_stage_b_pong = 5;
-constexpr uint32_t cb_remote_a = 6;
-constexpr uint32_t cb_remote_b = 7;
-constexpr uint32_t cb_output = 9;
-constexpr uint32_t cb_stage_token = 11;
-}  // namespace
-
-void kernel_main() {
-    constexpr uint32_t Kt = get_compile_time_arg_val(0);
-    constexpr uint32_t Vt = get_compile_time_arg_val(1);
-    constexpr uint32_t BH = get_compile_time_arg_val(2);
-    constexpr uint32_t G = get_compile_time_arg_val(3);
-    constexpr auto a_args = TensorAccessorArgs<4>();
-    constexpr auto b_args = TensorAccessorArgs<a_args.next_compile_time_args_offset()>();
-    constexpr auto output_a_args = TensorAccessorArgs<b_args.next_compile_time_args_offset()>();
-    constexpr auto output_b_args = TensorAccessorArgs<output_a_args.next_compile_time_args_offset()>();
+template <uint32_t Kt, uint32_t Vt, uint32_t BH, uint32_t G>
+TT_KERNEL void dataflow(uint32_t worker_index, uint32_t group, uint32_t coordinator_x, uint32_t coordinator_y) {
     constexpr uint32_t kk = Kt * Kt;
     constexpr uint32_t kv = Kt * Vt;
-    static_assert(BH * G <= 128, "affine prefix coordinate table exceeds runtime-arg budget");
+    constexpr uint32_t worker_count = BH * G;
+    static_assert(worker_count <= 128, "affine prefix coordinate table exceeds runtime-arg budget");
 
-    const uint32_t worker_index = get_arg_val<uint32_t>(0);
-    const uint32_t group = get_arg_val<uint32_t>(1);
-    const uint32_t worker_count = get_arg_val<uint32_t>(2);
-    const uint32_t a_addr = get_arg_val<uint32_t>(3);
-    const uint32_t b_addr = get_arg_val<uint32_t>(4);
-    const uint32_t output_a_addr = get_arg_val<uint32_t>(5);
-    const uint32_t output_b_addr = get_arg_val<uint32_t>(6);
-    const uint32_t ready_sem = get_arg_val<uint32_t>(7);
-    const uint32_t arrival_sem = get_arg_val<uint32_t>(8);
-    const uint32_t release_sem = get_arg_val<uint32_t>(9);
-    const uint32_t coordinator_x = get_arg_val<uint32_t>(10);
-    const uint32_t coordinator_y = get_arg_val<uint32_t>(11);
-
-    const uint32_t input_a_tile_bytes = get_tile_size(cb_initial_a);
-    const uint32_t input_b_tile_bytes = get_tile_size(cb_initial_b);
-    const uint32_t stage_a_tile_bytes = get_tile_size(cb_stage_a_ping);
-    const uint32_t stage_b_tile_bytes = get_tile_size(cb_stage_b_ping);
-    const uint32_t output_tile_bytes = get_tile_size(cb_output);
-    const auto a_accessor = TensorAccessor(a_args, a_addr, input_a_tile_bytes);
-    const auto b_accessor = TensorAccessor(b_args, b_addr, input_b_tile_bytes);
-    const auto output_a_accessor = TensorAccessor(output_a_args, output_a_addr, output_tile_bytes);
-    const auto output_b_accessor = TensorAccessor(output_b_args, output_b_addr, output_tile_bytes);
+    const auto a_accessor = TensorAccessor(tensor::a);
+    const auto b_accessor = TensorAccessor(tensor::b);
+    const auto output_a_accessor = TensorAccessor(tensor::output_a);
+    const auto output_b_accessor = TensorAccessor(tensor::output_b);
+    DataflowBuffer initial_a(dfb::initial_a);
+    DataflowBuffer initial_b(dfb::initial_b);
+    DataflowBuffer send_a_ping(dfb::send_a_ping);
+    DataflowBuffer send_b_ping(dfb::send_b_ping);
+    DataflowBuffer send_a_pong(dfb::send_a_pong);
+    DataflowBuffer send_b_pong(dfb::send_b_pong);
+    DataflowBuffer remote_a(dfb::remote_a);
+    DataflowBuffer remote_b(dfb::remote_b);
+    DataflowBuffer stage_token(dfb::stage_token);
     Noc noc;
-    Semaphore<> ready(ready_sem);
-    Semaphore<> arrival(arrival_sem);
-    Semaphore<> release(release_sem);
+    Semaphore<> ready(sem::ready);
+    Semaphore<> arrival(sem::arrival);
+    Semaphore<> release(sem::release);
 
-    auto worker_x = [&](uint32_t worker) { return get_arg_val<uint32_t>(12 + 2 * worker); };
-    auto worker_y = [&](uint32_t worker) { return get_arg_val<uint32_t>(13 + 2 * worker); };
-    auto read_tiles = [&](const auto& accessor, uint32_t cb_id, uint32_t page, uint32_t tiles, uint32_t tile_bytes) {
-        CircularBuffer cb(cb_id);
-        cb.reserve_back(tiles);
+    auto worker_x = [](uint32_t worker) { return get_common_vararg(2 * worker); };
+    auto worker_y = [](uint32_t worker) { return get_common_vararg(2 * worker + 1); };
+    auto read_tiles = [&](const auto& accessor, DataflowBuffer& buffer, uint32_t page, uint32_t tiles) {
+        buffer.reserve_back(tiles);
         for (uint32_t tile = 0; tile < tiles; tile++) {
-            noc.async_read(accessor, cb, tile_bytes, {.page_id = page + tile}, {.offset_bytes = tile * tile_bytes});
+            noc.async_read(
+                accessor,
+                buffer,
+                buffer.get_entry_size(),
+                {.page_id = page + tile},
+                {.offset_bytes = tile * buffer.get_entry_size()});
         }
         noc.async_read_barrier();
-        cb.push_back(tiles);
+        buffer.push_back(tiles);
     };
-    read_tiles(a_accessor, cb_initial_a, worker_index * kk, kk, input_a_tile_bytes);
-    read_tiles(b_accessor, cb_initial_b, worker_index * kv, kv, input_b_tile_bytes);
+    read_tiles(a_accessor, initial_a, worker_index * kk, kk);
+    read_tiles(b_accessor, initial_b, worker_index * kv, kv);
 
     uint32_t completed_stages = 0;
     auto stage_barrier = [&] {
@@ -89,44 +66,40 @@ void kernel_main() {
         }
         release.wait_min(completed_stages);
     };
-    auto send_pair = [&](uint32_t target, uint32_t current_a, uint32_t current_b) {
-        const CircularBuffer current_a_buffer(current_a);
-        const CircularBuffer current_b_buffer(current_b);
-        const CircularBuffer remote_a_buffer(cb_remote_a);
-        const CircularBuffer remote_b_buffer(cb_remote_b);
+    auto send_pair = [&](uint32_t target, DataflowBuffer& current_a, DataflowBuffer& current_b) {
         const uint32_t target_x = worker_x(target);
         const uint32_t target_y = worker_y(target);
         noc.async_write(
-            CoreLocalMem<uint32_t>(current_a_buffer.get_read_ptr()),
+            current_a,
             UnicastEndpoint{},
-            kk * stage_a_tile_bytes,
+            kk * current_a.get_entry_size(),
             {},
-            {.noc_x = target_x, .noc_y = target_y, .addr = remote_a_buffer.get_write_ptr()});
+            {.noc_x = target_x, .noc_y = target_y, .addr = remote_a.get_write_ptr()});
         noc.async_write(
-            CoreLocalMem<uint32_t>(current_b_buffer.get_read_ptr()),
+            current_b,
             UnicastEndpoint{},
-            kv * stage_b_tile_bytes,
+            kv * current_b.get_entry_size(),
             {},
-            {.noc_x = target_x, .noc_y = target_y, .addr = remote_b_buffer.get_write_ptr()});
+            {.noc_x = target_x, .noc_y = target_y, .addr = remote_b.get_write_ptr()});
         noc.async_write_barrier();
         ready.up(noc, target_x, target_y, 1);
     };
     auto receive_pair = [&] {
-        CircularBuffer(cb_remote_a).reserve_back(kk);
-        CircularBuffer(cb_remote_b).reserve_back(kv);
-        CircularBuffer(cb_remote_a).push_back(kk);
-        CircularBuffer(cb_remote_b).push_back(kv);
+        remote_a.reserve_back(kk);
+        remote_b.reserve_back(kv);
+        remote_a.push_back(kk);
+        remote_b.push_back(kv);
     };
 
     uint32_t ready_target = 0;
     bool ping = false;
     for (uint32_t distance = 1; distance < G; distance *= 2) {
-        const uint32_t current_a = ping ? cb_stage_a_pong : cb_stage_a_ping;
-        const uint32_t current_b = ping ? cb_stage_b_pong : cb_stage_b_ping;
-        const uint32_t next_a = ping ? cb_stage_a_ping : cb_stage_a_pong;
-        const uint32_t next_b = ping ? cb_stage_b_ping : cb_stage_b_pong;
-        CircularBuffer(current_a).wait_front(kk);
-        CircularBuffer(current_b).wait_front(kv);
+        DataflowBuffer& current_a = ping ? send_a_pong : send_a_ping;
+        DataflowBuffer& current_b = ping ? send_b_pong : send_b_ping;
+        DataflowBuffer& next_a = ping ? send_a_ping : send_a_pong;
+        DataflowBuffer& next_b = ping ? send_b_ping : send_b_pong;
+        current_a.wait_front(kk);
+        current_b.wait_front(kv);
         if (group + distance < G) {
             send_pair(worker_index + distance, current_a, current_b);
         }
@@ -134,47 +107,41 @@ void kernel_main() {
             ready_target++;
             ready.wait_min(ready_target);
             receive_pair();
-            CircularBuffer(cb_stage_token).reserve_back(1);
-            CircularBuffer(cb_stage_token).push_back(1);
-        }
-        if (group >= distance) {
-            CircularBuffer(next_a).wait_front(kk);
-            CircularBuffer(next_b).wait_front(kv);
+            stage_token.reserve_back(1);
+            stage_token.push_back(1);
+            next_a.wait_front(kk);
+            next_b.wait_front(kv);
+            current_a.pop_front(kk);
+            current_b.pop_front(kv);
             ping = !ping;
         }
-        // Do not release the next NoC stage until every receiver has consumed cb_remote and
-        // produced its next prefix. Otherwise the following stage can overwrite cb_remote while
-        // compute is still reading it.
+        // Do not release the next NoC stage until every receiver has consumed the remote buffers and produced its
+        // next prefix. Otherwise the following stage can overwrite the remote buffers while compute is reading them.
         stage_barrier();
     }
 
-    const uint32_t current_a = ping ? cb_stage_a_pong : cb_stage_a_ping;
-    const uint32_t current_b = ping ? cb_stage_b_pong : cb_stage_b_ping;
-    CircularBuffer(current_a).wait_front(kk);
-    CircularBuffer(current_b).wait_front(kv);
-    {
-        if (group + 1 == G) {
-            CircularBuffer prefix_a(current_a);
-            CircularBuffer prefix_b(current_b);
-            const uint32_t head = worker_index / G;
-            for (uint32_t tile = 0; tile < kk; tile++) {
-                noc.async_write(
-                    prefix_a,
-                    output_a_accessor,
-                    output_tile_bytes,
-                    {.offset_bytes = tile * output_tile_bytes},
-                    {.page_id = head * kk + tile});
-            }
-            for (uint32_t tile = 0; tile < kv; tile++) {
-                noc.async_write(
-                    prefix_b,
-                    output_b_accessor,
-                    output_tile_bytes,
-                    {.offset_bytes = tile * output_tile_bytes},
-                    {.page_id = head * kv + tile});
-            }
-            noc.async_write_barrier();
+    DataflowBuffer& current_a = ping ? send_a_pong : send_a_ping;
+    DataflowBuffer& current_b = ping ? send_b_pong : send_b_ping;
+    current_a.wait_front(kk);
+    current_b.wait_front(kv);
+    if (group + 1 == G) {
+        const uint32_t head = worker_index / G;
+        for (uint32_t tile = 0; tile < kk; tile++) {
+            noc.async_write(
+                current_a,
+                output_a_accessor,
+                current_a.get_entry_size(),
+                {.offset_bytes = tile * current_a.get_entry_size()},
+                {.page_id = head * kk + tile});
         }
-        return;
+        for (uint32_t tile = 0; tile < kv; tile++) {
+            noc.async_write(
+                current_b,
+                output_b_accessor,
+                current_b.get_entry_size(),
+                {.offset_bytes = tile * current_b.get_entry_size()},
+                {.page_id = head * kv + tile});
+        }
+        noc.async_write_barrier();
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_device_operation.cpp
@@ -21,7 +21,6 @@ void check_affine_tensor(const Tensor& tensor, const char* name) {
         tensor.dtype() == DataType::FLOAT32 || tensor.dtype() == DataType::BFLOAT16,
         "reduce_affine_transforms: {} must be FLOAT32 or BFLOAT16",
         name);
-    TT_FATAL(!tensor.is_sharded(), "reduce_affine_transforms: {} must use interleaved memory", name);
 }
 }  // namespace
 

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_device_operation.cpp
@@ -3,26 +3,16 @@
 
 #include "reduce_affine_transforms_device_operation.hpp"
 
+#include <array>
+
 #include <tt-metalium/constants.hpp>
 
 #include "ttnn/device_operation.hpp"
+#include "ttnn/operations/experimental/kda/factory/kda_factory_utils.hpp"
 
 using namespace tt::tt_metal;
 
 namespace ttnn::experimental::prim {
-namespace {
-void check_affine_tensor(const Tensor& tensor, const char* name) {
-    TT_FATAL(
-        tensor.storage_type() == StorageType::DEVICE && tensor.buffer() != nullptr,
-        "reduce_affine_transforms: {} must be an allocated device tensor",
-        name);
-    TT_FATAL(tensor.layout() == Layout::TILE, "reduce_affine_transforms: {} must use TILE layout", name);
-    TT_FATAL(
-        tensor.dtype() == DataType::FLOAT32 || tensor.dtype() == DataType::BFLOAT16,
-        "reduce_affine_transforms: {} must be FLOAT32 or BFLOAT16",
-        name);
-}
-}  // namespace
 
 ReduceAffineTransformsOperation::program_factory_t ReduceAffineTransformsOperation::select_program_factory(
     const operation_attributes_t&, const tensor_args_t&) {
@@ -30,18 +20,20 @@ ReduceAffineTransformsOperation::program_factory_t ReduceAffineTransformsOperati
 }
 void ReduceAffineTransformsOperation::validate_on_program_cache_miss(
     const operation_attributes_t& attrs, const tensor_args_t& in) {
-    check_affine_tensor(in.a, "a");
-    check_affine_tensor(in.b, "b");
-    TT_FATAL(in.a.device() == in.b.device(), "reduce_affine_transforms: all inputs must be on the same device");
-    TT_FATAL(in.a.dtype() == in.b.dtype(), "reduce_affine_transforms: inputs must have matching dtypes");
+    using namespace kda_factory_detail;
+    constexpr std::string_view operation_name = "reduce_affine_transforms";
+    constexpr std::array accepted_summary_dtypes = {DataType::FLOAT32, DataType::BFLOAT16};
+    check_allocated_device_tensor(in.a, operation_name, "a");
+    check_layout(in.a, Layout::TILE, operation_name, "a");
+    check_dtype_in(in.a, accepted_summary_dtypes, "FLOAT32 or BFLOAT16", operation_name, "a");
+    check_allocated_device_tensor(in.b, operation_name, "b");
+    check_layout(in.b, Layout::TILE, operation_name, "b");
+    check_dtype_in(in.b, accepted_summary_dtypes, "FLOAT32 or BFLOAT16", operation_name, "b");
+    check_same_device(in.a, in.b, operation_name, "b");
+    check_matching_dtype(in.a, in.b, operation_name, "inputs");
     TT_FATAL(attrs.groups_per_head > 0, "reduce_affine_transforms: groups_per_head must be positive");
-    TT_FATAL(
-        !attrs.output_mem_config.is_sharded(),
-        "reduce_affine_transforms: output memory configuration must be interleaved");
-    TT_FATAL(
-        !attrs.compute_kernel_config.packer_l1_acc,
-        "reduce_affine_transforms: packer_l1_acc=true is unsupported because the compute kernel does not "
-        "accumulate through L1");
+    check_output_interleaved(attrs.output_mem_config, operation_name);
+    check_compute_config(attrs.compute_kernel_config, operation_name);
 
     const auto& a_shape = in.a.logical_shape();
     const auto& b_shape = in.b.logical_shape();

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_device_operation.cpp
@@ -38,6 +38,15 @@ void ReduceAffineTransformsOperation::validate_on_program_cache_miss(
     TT_FATAL(
         !attrs.output_mem_config.is_sharded(),
         "reduce_affine_transforms: output memory configuration must be interleaved");
+    TT_FATAL(
+        !attrs.compute_kernel_config.packer_l1_acc,
+        "reduce_affine_transforms: packer_l1_acc=true is unsupported because the compute kernel does not "
+        "accumulate through L1");
+    TT_FATAL(
+        attrs.compute_kernel_config.throttle_level ==
+            ttnn::operations::compute_throttle_utils::ThrottleLevel::NO_THROTTLE,
+        "reduce_affine_transforms: compute throttling is unsupported because this kernel does not implement "
+        "throttled math");
 
     const auto& a_shape = in.a.logical_shape();
     const auto& b_shape = in.b.logical_shape();

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_device_operation.cpp
@@ -42,11 +42,6 @@ void ReduceAffineTransformsOperation::validate_on_program_cache_miss(
         !attrs.compute_kernel_config.packer_l1_acc,
         "reduce_affine_transforms: packer_l1_acc=true is unsupported because the compute kernel does not "
         "accumulate through L1");
-    TT_FATAL(
-        attrs.compute_kernel_config.throttle_level ==
-            ttnn::operations::compute_throttle_utils::ThrottleLevel::NO_THROTTLE,
-        "reduce_affine_transforms: compute throttling is unsupported because this kernel does not implement "
-        "throttled math");
 
     const auto& a_shape = in.a.logical_shape();
     const auto& b_shape = in.b.logical_shape();

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_device_operation.cpp
@@ -3,14 +3,13 @@
 
 #include "reduce_affine_transforms_device_operation.hpp"
 
+#include <algorithm>
 #include <array>
 
 #include <tt-metalium/constants.hpp>
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/experimental/kda/factory/kda_factory_utils.hpp"
-
-using namespace tt::tt_metal;
 
 namespace ttnn::experimental::prim {
 
@@ -20,20 +19,30 @@ ReduceAffineTransformsOperation::program_factory_t ReduceAffineTransformsOperati
 }
 void ReduceAffineTransformsOperation::validate_on_program_cache_miss(
     const operation_attributes_t& attrs, const tensor_args_t& in) {
-    using namespace kda_factory_detail;
     constexpr std::string_view operation_name = "reduce_affine_transforms";
-    constexpr std::array accepted_summary_dtypes = {DataType::FLOAT32, DataType::BFLOAT16};
-    check_allocated_device_tensor(in.a, operation_name, "a");
-    check_layout(in.a, Layout::TILE, operation_name, "a");
-    check_dtype_in(in.a, accepted_summary_dtypes, "FLOAT32 or BFLOAT16", operation_name, "a");
-    check_allocated_device_tensor(in.b, operation_name, "b");
-    check_layout(in.b, Layout::TILE, operation_name, "b");
-    check_dtype_in(in.b, accepted_summary_dtypes, "FLOAT32 or BFLOAT16", operation_name, "b");
-    check_same_device(in.a, in.b, operation_name, "b");
-    check_matching_dtype(in.a, in.b, operation_name, "inputs");
+    constexpr std::array accepted_summary_dtypes = {tt::tt_metal::DataType::FLOAT32, tt::tt_metal::DataType::BFLOAT16};
+    kda_factory_detail::check_allocated_device_tensor(in.a, operation_name, "a");
+    kda_factory_detail::check_layout(in.a, tt::tt_metal::Layout::TILE, operation_name, "a");
+    kda_factory_detail::check_dtype_in(in.a, accepted_summary_dtypes, "FLOAT32 or BFLOAT16", operation_name, "a");
+    kda_factory_detail::check_allocated_device_tensor(in.b, operation_name, "b");
+    kda_factory_detail::check_layout(in.b, tt::tt_metal::Layout::TILE, operation_name, "b");
+    kda_factory_detail::check_dtype_in(in.b, accepted_summary_dtypes, "FLOAT32 or BFLOAT16", operation_name, "b");
+    kda_factory_detail::check_same_device(in.a, in.b, operation_name, "b");
+    kda_factory_detail::check_matching_dtype(in.a, in.b, operation_name, "inputs");
+    const auto check_input_memory_layout = [operation_name](const ttnn::Tensor& tensor, std::string_view name) {
+        const auto memory_layout = tensor.memory_config().memory_layout();
+        TT_FATAL(
+            memory_layout == tt::tt_metal::TensorMemoryLayout::INTERLEAVED ||
+                memory_layout == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
+            "{}: {} must use interleaved or height-sharded memory",
+            operation_name,
+            name);
+    };
+    check_input_memory_layout(in.a, "a");
+    check_input_memory_layout(in.b, "b");
     TT_FATAL(attrs.groups_per_head > 0, "reduce_affine_transforms: groups_per_head must be positive");
-    check_output_interleaved(attrs.output_mem_config, operation_name);
-    check_compute_config(attrs.compute_kernel_config, operation_name);
+    kda_factory_detail::check_output_interleaved(attrs.output_mem_config, operation_name);
+    kda_factory_detail::check_compute_config(attrs.compute_kernel_config, operation_name);
 
     const auto& a_shape = in.a.logical_shape();
     const auto& b_shape = in.b.logical_shape();
@@ -53,11 +62,26 @@ void ReduceAffineTransformsOperation::validate_on_program_cache_miss(
         a_shape[0] == attrs.batch_heads * attrs.groups_per_head && a_shape[1] == attrs.key_dim &&
             b_shape[2] == attrs.value_dim,
         "reduce_affine_transforms: input shapes must match operation attributes");
+
+    constexpr uint32_t max_coordinate_table_workers = 128;
+    const auto grid = in.a.device()->compute_with_storage_grid_size();
+    const uint32_t worker_limit = std::min<uint32_t>(grid.x * grid.y, max_coordinate_table_workers);
+    const uint32_t group_workers = attrs.batch_heads * attrs.groups_per_head;
+    TT_FATAL(
+        group_workers <= worker_limit,
+        "reduce_affine_transforms: supports at most {} group workers on this device, got {}",
+        worker_limit,
+        group_workers);
 }
 ReduceAffineTransformsOperation::spec_return_value_t ReduceAffineTransformsOperation::compute_output_specs(
     const operation_attributes_t& a, const tensor_args_t&) {
     const auto layout = [&](const Shape& shape) {
-        return TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE), a.output_mem_config));
+        return tt::tt_metal::TensorSpec(
+            shape,
+            tt::tt_metal::TensorLayout(
+                tt::tt_metal::DataType::FLOAT32,
+                tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE),
+                a.output_mem_config));
     };
     return {
         layout(Shape({a.batch_heads, a.key_dim, a.key_dim})), layout(Shape({a.batch_heads, a.key_dim, a.value_dim}))};
@@ -67,12 +91,14 @@ ReduceAffineTransformsOperation::tensor_return_value_t ReduceAffineTransformsOpe
     auto specs = compute_output_specs(a, in);
     return {create_device_tensor(specs[0], in.a.device()), create_device_tensor(specs[1], in.a.device())};
 }
-std::pair<Tensor, Tensor> reduce_affine_transforms(
-    const Tensor& a,
-    const Tensor& b,
+std::pair<ttnn::Tensor, ttnn::Tensor> reduce_affine_transforms(
+    const ttnn::Tensor& a,
+    const ttnn::Tensor& b,
     uint32_t groups,
     const tt::tt_metal::MemoryConfig& mem,
-    const DeviceComputeKernelConfig& cfg) {
+    const ttnn::DeviceComputeKernelConfig& cfg) {
+    // Cache-miss validation cannot protect attribute construction on cache hits. Keep these guards here because the
+    // launcher divides by groups and indexes both shapes before dispatching validation.
     TT_FATAL(groups > 0, "reduce_affine_transforms: groups_per_head must be positive");
     const auto& shape = a.logical_shape();
     const auto& b_shape = b.logical_shape();

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_device_operation.cpp
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "reduce_affine_transforms_device_operation.hpp"
+
+#include <tt-metalium/constants.hpp>
+
+#include "ttnn/device_operation.hpp"
+
+using namespace tt::tt_metal;
+
+namespace ttnn::experimental::prim {
+namespace {
+void check_affine_tensor(const Tensor& tensor, const char* name) {
+    TT_FATAL(
+        tensor.storage_type() == StorageType::DEVICE && tensor.buffer() != nullptr,
+        "reduce_affine_transforms: {} must be an allocated device tensor",
+        name);
+    TT_FATAL(tensor.layout() == Layout::TILE, "reduce_affine_transforms: {} must use TILE layout", name);
+    TT_FATAL(
+        tensor.dtype() == DataType::FLOAT32 || tensor.dtype() == DataType::BFLOAT16,
+        "reduce_affine_transforms: {} must be FLOAT32 or BFLOAT16",
+        name);
+    TT_FATAL(!tensor.is_sharded(), "reduce_affine_transforms: {} must use interleaved memory", name);
+}
+}  // namespace
+
+ReduceAffineTransformsOperation::program_factory_t ReduceAffineTransformsOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return ReduceAffineTransformsProgramFactory{};
+}
+void ReduceAffineTransformsOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& attrs, const tensor_args_t& in) {
+    check_affine_tensor(in.a, "a");
+    check_affine_tensor(in.b, "b");
+    TT_FATAL(in.a.device() == in.b.device(), "reduce_affine_transforms: all inputs must be on the same device");
+    TT_FATAL(in.a.dtype() == in.b.dtype(), "reduce_affine_transforms: inputs must have matching dtypes");
+    TT_FATAL(attrs.groups_per_head > 0, "reduce_affine_transforms: groups_per_head must be positive");
+    TT_FATAL(
+        !attrs.output_mem_config.is_sharded(),
+        "reduce_affine_transforms: output memory configuration must be interleaved");
+
+    const auto& a_shape = in.a.logical_shape();
+    const auto& b_shape = in.b.logical_shape();
+    TT_FATAL(a_shape.rank() == 3 && b_shape.rank() == 3, "reduce_affine_transforms: inputs must be rank 3");
+    TT_FATAL(a_shape[0] > 0, "reduce_affine_transforms: leading dimension must be positive");
+    TT_FATAL(
+        a_shape[0] % attrs.groups_per_head == 0,
+        "reduce_affine_transforms: leading dimension must be divisible by groups_per_head");
+    TT_FATAL(a_shape[0] == b_shape[0], "reduce_affine_transforms: inputs must have matching leading dimensions");
+    TT_FATAL(a_shape[1] == a_shape[2], "reduce_affine_transforms: a must contain square KxK matrices");
+    TT_FATAL(a_shape[1] == b_shape[1], "reduce_affine_transforms: a and b must have matching K dimensions");
+    TT_FATAL(
+        a_shape[1] > 0 && b_shape[2] > 0 && a_shape[1] % tt::constants::TILE_WIDTH == 0 &&
+            b_shape[2] % tt::constants::TILE_WIDTH == 0,
+        "reduce_affine_transforms: K and V must be positive and tile aligned");
+    TT_FATAL(
+        a_shape[0] == attrs.batch_heads * attrs.groups_per_head && a_shape[1] == attrs.key_dim &&
+            b_shape[2] == attrs.value_dim,
+        "reduce_affine_transforms: input shapes must match operation attributes");
+}
+ReduceAffineTransformsOperation::spec_return_value_t ReduceAffineTransformsOperation::compute_output_specs(
+    const operation_attributes_t& a, const tensor_args_t&) {
+    const auto layout = [&](const Shape& shape) {
+        return TensorSpec(shape, TensorLayout(DataType::FLOAT32, PageConfig(Layout::TILE), a.output_mem_config));
+    };
+    return {
+        layout(Shape({a.batch_heads, a.key_dim, a.key_dim})), layout(Shape({a.batch_heads, a.key_dim, a.value_dim}))};
+}
+ReduceAffineTransformsOperation::tensor_return_value_t ReduceAffineTransformsOperation::create_output_tensors(
+    const operation_attributes_t& a, const tensor_args_t& in) {
+    auto specs = compute_output_specs(a, in);
+    return {create_device_tensor(specs[0], in.a.device()), create_device_tensor(specs[1], in.a.device())};
+}
+std::pair<Tensor, Tensor> reduce_affine_transforms(
+    const Tensor& a,
+    const Tensor& b,
+    uint32_t groups,
+    const tt::tt_metal::MemoryConfig& mem,
+    const DeviceComputeKernelConfig& cfg) {
+    TT_FATAL(groups > 0, "reduce_affine_transforms: groups_per_head must be positive");
+    const auto& shape = a.logical_shape();
+    const auto& b_shape = b.logical_shape();
+    TT_FATAL(shape.rank() == 3 && b_shape.rank() == 3, "reduce_affine_transforms: inputs must be rank 3");
+    TT_FATAL(shape[0] > 0, "reduce_affine_transforms: leading dimension must be positive");
+    TT_FATAL(
+        shape[0] % groups == 0, "reduce_affine_transforms: leading dimension must be divisible by groups_per_head");
+    auto outputs = ttnn::device_operation::launch<ReduceAffineTransformsOperation>(
+        ReduceAffineTransformsParams{
+            .batch_heads = static_cast<uint32_t>(shape[0]) / groups,
+            .groups_per_head = groups,
+            .key_dim = static_cast<uint32_t>(shape[1]),
+            .value_dim = static_cast<uint32_t>(b.logical_shape()[2]),
+            .output_mem_config = mem,
+            .compute_kernel_config = cfg},
+        ReduceAffineTransformsInputs{.a = a, .b = b});
+    return {outputs[0], outputs[1]};
+}
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_device_operation.hpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <variant>
+
+#include "reduce_affine_transforms_program_factory.hpp"
+
+namespace ttnn::experimental::prim {
+
+struct ReduceAffineTransformsOperation {
+    using operation_attributes_t = ReduceAffineTransformsParams;
+    using tensor_args_t = ReduceAffineTransformsInputs;
+    using spec_return_value_t = std::vector<tt::tt_metal::TensorSpec>;
+    using tensor_return_value_t = std::vector<Tensor>;
+    using program_factory_t = std::variant<ReduceAffineTransformsProgramFactory>;
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+};
+
+std::pair<Tensor, Tensor> reduce_affine_transforms(
+    const Tensor&, const Tensor&, uint32_t, const tt::tt_metal::MemoryConfig&, const DeviceComputeKernelConfig&);
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_device_operation_types.hpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/program_descriptors.hpp>
+
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::experimental::prim {
+
+struct ReduceAffineTransformsParams {
+    uint32_t batch_heads;
+    uint32_t groups_per_head;
+    uint32_t key_dim;
+    uint32_t value_dim;
+    tt::tt_metal::MemoryConfig output_mem_config;
+    DeviceComputeKernelConfig compute_kernel_config;
+};
+
+struct ReduceAffineTransformsInputs {
+    Tensor a;
+    Tensor b;
+};
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_program_factory.cpp
@@ -67,7 +67,6 @@ ttnn::device_operation::ProgramArtifacts ReduceAffineTransformsProgramFactory::c
     const m2::DFBSpecName REMOTE_A{"remote_a"};
     const m2::DFBSpecName REMOTE_B{"remote_b"};
     const m2::DFBSpecName SCRATCH{"scratch"};
-    const m2::DFBSpecName STAGE_TOKEN{"stage_token"};
 
     const m2::SemaphoreSpecName READY{"ready"};
     const m2::SemaphoreSpecName ARRIVAL{"arrival"};
@@ -101,7 +100,6 @@ ttnn::device_operation::ProgramArtifacts ReduceAffineTransformsProgramFactory::c
         make_dfb(REMOTE_A, kk, tt::DataFormat::Float32),
         make_dfb(REMOTE_B, kv, tt::DataFormat::Float32),
         make_dfb(SCRATCH, kv, tt::DataFormat::Float32),
-        make_dfb(STAGE_TOKEN, 1, tt::DataFormat::Float32),
     };
 
     m2::KernelSpec dataflow{
@@ -119,7 +117,6 @@ ttnn::device_operation::ProgramArtifacts ReduceAffineTransformsProgramFactory::c
                 m2::DFBBinding{SEND_B_PONG, "send_b_pong", m2::DFBEndpointType::CONSUMER},
                 m2::DFBBinding{REMOTE_A, "remote_a", m2::DFBEndpointType::PRODUCER},
                 m2::DFBBinding{REMOTE_B, "remote_b", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{STAGE_TOKEN, "stage_token", m2::DFBEndpointType::PRODUCER},
             },
         .semaphore_bindings =
             {
@@ -144,8 +141,7 @@ ttnn::device_operation::ProgramArtifacts ReduceAffineTransformsProgramFactory::c
 
     auto compute_hw = ttnn::to_compute_hardware_config(arch, attrs.compute_kernel_config);
     auto& unpack_modes = m2::unpack_modes(compute_hw);
-    for (const auto& name :
-         {STAGE_A_PING, STAGE_B_PING, STAGE_A_PONG, STAGE_B_PONG, REMOTE_A, REMOTE_B, SCRATCH, STAGE_TOKEN}) {
+    for (const auto& name : {STAGE_A_PING, STAGE_B_PING, STAGE_A_PONG, STAGE_B_PONG, REMOTE_A, REMOTE_B, SCRATCH}) {
         unpack_modes[name] = UnpackMode::UnpackToSrc;
     }
     if (summary_format == tt::DataFormat::Float32) {
@@ -179,7 +175,6 @@ ttnn::device_operation::ProgramArtifacts ReduceAffineTransformsProgramFactory::c
                 m2::DFBBinding{REMOTE_B, "remote_b", m2::DFBEndpointType::CONSUMER},
                 m2::DFBBinding{SCRATCH, "scratch", m2::DFBEndpointType::PRODUCER},
                 m2::DFBBinding{SCRATCH, "scratch", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{STAGE_TOKEN, "stage_token", m2::DFBEndpointType::CONSUMER},
             },
         .compile_time_args = {{"Kt", Kt}, {"Vt", Vt}, {"G", G}},
         .runtime_arg_schema = {.runtime_arg_names = {"group"}},

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_program_factory.cpp
@@ -3,7 +3,6 @@
 
 #include "ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_program_factory.hpp"
 
-#include <algorithm>
 #include <vector>
 
 #include <tt-metalium/constants.hpp>
@@ -18,15 +17,12 @@
 #include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 #include "ttnn/operations/experimental/kda/factory/kda_factory_utils.hpp"
 
-using namespace tt::tt_metal;
-using namespace tt::constants;
-
 namespace ttnn::experimental::prim {
 
-namespace m2 = tt::tt_metal::experimental;
-
 ttnn::device_operation::ProgramArtifacts ReduceAffineTransformsProgramFactory::create_program_artifacts(
-    const ReduceAffineTransformsParams& attrs, const ReduceAffineTransformsInputs& in, std::vector<Tensor>& outputs) {
+    const ReduceAffineTransformsParams& attrs,
+    const ReduceAffineTransformsInputs& in,
+    std::vector<ttnn::Tensor>& outputs) {
     const auto& a = in.a.mesh_tensor();
     const auto& b = in.b.mesh_tensor();
     const auto& output_a = outputs[0].mesh_tensor();
@@ -34,142 +30,158 @@ ttnn::device_operation::ProgramArtifacts ReduceAffineTransformsProgramFactory::c
     const auto& device = a.device();
     const auto arch = device.arch();
 
-    const uint32_t Kt = attrs.key_dim / TILE_WIDTH;
-    const uint32_t Vt = attrs.value_dim / TILE_WIDTH;
+    const uint32_t Kt = attrs.key_dim / tt::constants::TILE_WIDTH;
+    const uint32_t Vt = attrs.value_dim / tt::constants::TILE_WIDTH;
     const uint32_t G = attrs.groups_per_head;
     const uint32_t group_heads = attrs.batch_heads * G;
-    const uint32_t kk = Kt * Kt;
-    const uint32_t kv = Kt * Vt;
+    const uint32_t a_tiles = Kt * Kt;
+    const uint32_t b_tiles = Kt * Vt;
 
     const auto grid = device.compute_with_storage_grid_size();
-    constexpr uint32_t kMaxAffineCompositionWorkers = 128;
-    TT_FATAL(
-        group_heads <= std::min<uint32_t>(grid.x * grid.y, kMaxAffineCompositionWorkers),
-        "reduce_affine_transforms supports at most {} group workers, got {}",
-        kMaxAffineCompositionWorkers,
-        group_heads);
     auto dist = kda_factory_detail::distribute_prep(grid, group_heads, group_heads);
     const auto& cores = dist.core_set;
 
-    const m2::KernelSpecName DATAFLOW{"dataflow"};
-    const m2::KernelSpecName COMPUTE{"compute"};
+    const tt::tt_metal::experimental::KernelSpecName dataflow_kernel_name{"dataflow"};
+    const tt::tt_metal::experimental::KernelSpecName compute_kernel_name{"compute"};
 
-    const m2::DFBSpecName INITIAL_A{"initial_a"};
-    const m2::DFBSpecName INITIAL_B{"initial_b"};
-    const m2::DFBSpecName STAGE_A{"stage_a"};
-    const m2::DFBSpecName STAGE_B{"stage_b"};
-    const m2::DFBSpecName SEND_A{"send_a"};
-    const m2::DFBSpecName SEND_B{"send_b"};
-    const m2::DFBSpecName REMOTE_A{"remote_a"};
-    const m2::DFBSpecName REMOTE_B{"remote_b"};
-    const m2::DFBSpecName SCRATCH{"scratch"};
+    const tt::tt_metal::experimental::DFBSpecName initial_a_dfb_name{"initial_a"};
+    const tt::tt_metal::experimental::DFBSpecName initial_b_dfb_name{"initial_b"};
+    const tt::tt_metal::experimental::DFBSpecName stage_a_dfb_name{"stage_a"};
+    const tt::tt_metal::experimental::DFBSpecName stage_b_dfb_name{"stage_b"};
+    const tt::tt_metal::experimental::DFBSpecName send_a_dfb_name{"send_a"};
+    const tt::tt_metal::experimental::DFBSpecName send_b_dfb_name{"send_b"};
+    const tt::tt_metal::experimental::DFBSpecName remote_a_dfb_name{"remote_a"};
+    const tt::tt_metal::experimental::DFBSpecName remote_b_dfb_name{"remote_b"};
+    const tt::tt_metal::experimental::DFBSpecName scratch_dfb_name{"scratch"};
 
-    const m2::SemaphoreSpecName READY{"ready"};
-    const m2::SemaphoreSpecName ARRIVAL{"arrival"};
-    const m2::SemaphoreSpecName RELEASE{"release"};
+    const tt::tt_metal::experimental::SemaphoreSpecName ready_semaphore_name{"ready"};
+    const tt::tt_metal::experimental::SemaphoreSpecName arrival_semaphore_name{"arrival"};
+    const tt::tt_metal::experimental::SemaphoreSpecName release_semaphore_name{"release"};
 
-    const m2::TensorParamName A{"a"};
-    const m2::TensorParamName B{"b"};
-    const m2::TensorParamName OUTPUT_A{"output_a"};
-    const m2::TensorParamName OUTPUT_B{"output_b"};
+    const tt::tt_metal::experimental::TensorParamName a_tensor_name{"a"};
+    const tt::tt_metal::experimental::TensorParamName b_tensor_name{"b"};
+    const tt::tt_metal::experimental::TensorParamName output_a_tensor_name{"output_a"};
+    const tt::tt_metal::experimental::TensorParamName output_b_tensor_name{"output_b"};
 
-    auto make_dfb = [](const m2::DFBSpecName& name, uint32_t tiles, tt::DataFormat format) {
-        return m2::DataflowBufferSpec{
+    auto make_dfb = [](const tt::tt_metal::experimental::DFBSpecName& name, uint32_t tiles, tt::DataFormat format) {
+        return tt::tt_metal::experimental::DataflowBufferSpec{
             .unique_id = name,
             .entry_size = tt::tile_size(format),
             .num_entries = tiles,
             .data_format_metadata = format,
         };
     };
-    const auto summary_format = datatype_to_dataformat_converter(in.a.dtype());
-    m2::Group<m2::DataflowBufferSpec> dfbs = {
-        make_dfb(INITIAL_A, kk, summary_format),
-        make_dfb(INITIAL_B, kv, summary_format),
-        make_dfb(STAGE_A, 2 * kk, tt::DataFormat::Float32),
-        make_dfb(STAGE_B, 2 * kv, tt::DataFormat::Float32),
-        make_dfb(SEND_A, 2 * kk, tt::DataFormat::Float32),
-        make_dfb(SEND_B, 2 * kv, tt::DataFormat::Float32),
-        make_dfb(REMOTE_A, kk, tt::DataFormat::Float32),
-        make_dfb(REMOTE_B, kv, tt::DataFormat::Float32),
-        make_dfb(SCRATCH, kv, tt::DataFormat::Float32),
+    const auto summary_format = tt::tt_metal::datatype_to_dataformat_converter(in.a.dtype());
+    constexpr auto internal_format = tt::DataFormat::Float32;
+    // Per-core DFB storage is 6*Kt^2 + 7*Kt*Vt tiles. Production uses K=V=128 (Kt=Vt=4); supporting larger shapes
+    // may require a separately designed chunked protocol rather than silently assuming this footprint fits every
+    // architecture's usable L1.
+    // Stage and send buffers are double-buffered so compute can produce the next prefix while the current one is used.
+    tt::tt_metal::experimental::Group<tt::tt_metal::experimental::DataflowBufferSpec> dfbs = {
+        make_dfb(initial_a_dfb_name, a_tiles, summary_format),
+        make_dfb(initial_b_dfb_name, b_tiles, summary_format),
+        make_dfb(stage_a_dfb_name, 2 * a_tiles, internal_format),
+        make_dfb(stage_b_dfb_name, 2 * b_tiles, internal_format),
+        make_dfb(send_a_dfb_name, 2 * a_tiles, internal_format),
+        make_dfb(send_b_dfb_name, 2 * b_tiles, internal_format),
+        make_dfb(remote_a_dfb_name, a_tiles, internal_format),
+        make_dfb(remote_b_dfb_name, b_tiles, internal_format),
+        make_dfb(scratch_dfb_name, b_tiles, internal_format),
     };
     // The sender addresses a peer's inbound mailbox with its own local write pointer, which is only
     // valid while these buffers hold one phase-independent slot. Any additional depth lets sender and
     // receiver select different halves and silently corrupts the reduction.
     for (const auto& dfb : dfbs) {
-        if (dfb.unique_id == REMOTE_A || dfb.unique_id == REMOTE_B) {
+        if (dfb.unique_id == remote_a_dfb_name || dfb.unique_id == remote_b_dfb_name) {
             TT_FATAL(
-                dfb.num_entries == (dfb.unique_id == REMOTE_A ? kk : kv),
+                dfb.num_entries == (dfb.unique_id == remote_a_dfb_name ? a_tiles : b_tiles),
                 "reduce_affine_transforms: remotely addressed mailbox {} must hold exactly one block",
                 *dfb.unique_id);
         }
     }
 
-    m2::KernelSpec dataflow{
-        .unique_id = DATAFLOW,
+    tt::tt_metal::experimental::KernelSpec dataflow{
+        .unique_id = dataflow_kernel_name,
         .source =
             "ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/dataflow/"
             "reader_writer_reduce_affine_transforms.cpp",
         .dfb_bindings =
             {
-                m2::DFBBinding{INITIAL_A, "initial_a", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{INITIAL_B, "initial_b", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{SEND_A, "send_a", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{SEND_B, "send_b", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{REMOTE_A, "remote_a", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{REMOTE_B, "remote_b", m2::DFBEndpointType::PRODUCER},
+                tt::tt_metal::experimental::DFBBinding{
+                    initial_a_dfb_name, "initial_a", tt::tt_metal::experimental::DFBEndpointType::PRODUCER},
+                tt::tt_metal::experimental::DFBBinding{
+                    initial_b_dfb_name, "initial_b", tt::tt_metal::experimental::DFBEndpointType::PRODUCER},
+                tt::tt_metal::experimental::DFBBinding{
+                    send_a_dfb_name, "send_a", tt::tt_metal::experimental::DFBEndpointType::CONSUMER},
+                tt::tt_metal::experimental::DFBBinding{
+                    send_b_dfb_name, "send_b", tt::tt_metal::experimental::DFBEndpointType::CONSUMER},
+                tt::tt_metal::experimental::DFBBinding{
+                    remote_a_dfb_name, "remote_a", tt::tt_metal::experimental::DFBEndpointType::PRODUCER},
+                tt::tt_metal::experimental::DFBBinding{
+                    remote_b_dfb_name, "remote_b", tt::tt_metal::experimental::DFBEndpointType::PRODUCER},
             },
         .semaphore_bindings =
             {
-                m2::SemaphoreBinding{READY, "ready"},
-                m2::SemaphoreBinding{ARRIVAL, "arrival"},
-                m2::SemaphoreBinding{RELEASE, "release"},
+                tt::tt_metal::experimental::SemaphoreBinding{ready_semaphore_name, "ready"},
+                tt::tt_metal::experimental::SemaphoreBinding{arrival_semaphore_name, "arrival"},
+                tt::tt_metal::experimental::SemaphoreBinding{release_semaphore_name, "release"},
             },
         .tensor_bindings =
             {
-                m2::TensorBinding{A, "a"},
-                m2::TensorBinding{B, "b"},
-                m2::TensorBinding{OUTPUT_A, "output_a"},
-                m2::TensorBinding{OUTPUT_B, "output_b"},
+                tt::tt_metal::experimental::TensorBinding{a_tensor_name, "a"},
+                tt::tt_metal::experimental::TensorBinding{b_tensor_name, "b"},
+                tt::tt_metal::experimental::TensorBinding{output_a_tensor_name, "output_a"},
+                tt::tt_metal::experimental::TensorBinding{output_b_tensor_name, "output_b"},
             },
-        .compile_time_args = {{"Kt", Kt}, {"Vt", Vt}, {"BH", attrs.batch_heads}, {"G", G}},
-        .runtime_arg_schema =
-            {.runtime_arg_names = {"worker_index", "group"},
-             .common_runtime_arg_names = {"coordinator_x", "coordinator_y"}},
+        .compile_time_args = {{"Kt", Kt}, {"Vt", Vt}, {"G", G}},
+        .runtime_arg_schema = {.runtime_arg_names = {"worker_index", "group"}},
         .hw_config = ttnn::create_reader_datamovement_config(arch),
         .advanced_options = {.num_common_runtime_varargs = 2 * group_heads},
     };
 
     auto compute_hw = ttnn::to_compute_hardware_config(arch, attrs.compute_kernel_config);
-    auto& unpack_modes = m2::unpack_modes(compute_hw);
-    for (const auto& name : {STAGE_A, STAGE_B, REMOTE_A, REMOTE_B, SCRATCH}) {
-        unpack_modes[name] = UnpackMode::UnpackToSrc;
+    auto& unpack_modes = tt::tt_metal::experimental::unpack_modes(compute_hw);
+    for (const auto& name :
+         {stage_a_dfb_name, stage_b_dfb_name, remote_a_dfb_name, remote_b_dfb_name, scratch_dfb_name}) {
+        unpack_modes[name] = tt::tt_metal::UnpackMode::UnpackToSrc;
     }
     if (summary_format == tt::DataFormat::Float32) {
-        unpack_modes[INITIAL_A] = UnpackMode::UnpackToSrc;
-        unpack_modes[INITIAL_B] = UnpackMode::UnpackToSrc;
+        unpack_modes[initial_a_dfb_name] = tt::tt_metal::UnpackMode::UnpackToSrc;
+        unpack_modes[initial_b_dfb_name] = tt::tt_metal::UnpackMode::UnpackToSrc;
     }
 
-    m2::KernelSpec compute{
-        .unique_id = COMPUTE,
+    tt::tt_metal::experimental::KernelSpec compute{
+        .unique_id = compute_kernel_name,
         .source =
             "ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/compute/"
             "reduce_affine_transforms.cpp",
-        .compiler_options = {.opt_level = KernelBuildOptLevel::O3},
+        .compiler_options = {.opt_level = tt::tt_metal::KernelBuildOptLevel::O3},
         .dfb_bindings =
             {
-                m2::DFBBinding{INITIAL_A, "initial_a", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{INITIAL_B, "initial_b", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{STAGE_A, "stage_a", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{STAGE_A, "stage_a", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{STAGE_B, "stage_b", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{STAGE_B, "stage_b", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{SEND_A, "send_a", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{SEND_B, "send_b", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{REMOTE_A, "remote_a", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{REMOTE_B, "remote_b", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{SCRATCH, "scratch", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{SCRATCH, "scratch", m2::DFBEndpointType::CONSUMER},
+                tt::tt_metal::experimental::DFBBinding{
+                    initial_a_dfb_name, "initial_a", tt::tt_metal::experimental::DFBEndpointType::CONSUMER},
+                tt::tt_metal::experimental::DFBBinding{
+                    initial_b_dfb_name, "initial_b", tt::tt_metal::experimental::DFBEndpointType::CONSUMER},
+                tt::tt_metal::experimental::DFBBinding{
+                    stage_a_dfb_name, "stage_a", tt::tt_metal::experimental::DFBEndpointType::PRODUCER},
+                tt::tt_metal::experimental::DFBBinding{
+                    stage_a_dfb_name, "stage_a", tt::tt_metal::experimental::DFBEndpointType::CONSUMER},
+                tt::tt_metal::experimental::DFBBinding{
+                    stage_b_dfb_name, "stage_b", tt::tt_metal::experimental::DFBEndpointType::PRODUCER},
+                tt::tt_metal::experimental::DFBBinding{
+                    stage_b_dfb_name, "stage_b", tt::tt_metal::experimental::DFBEndpointType::CONSUMER},
+                tt::tt_metal::experimental::DFBBinding{
+                    send_a_dfb_name, "send_a", tt::tt_metal::experimental::DFBEndpointType::PRODUCER},
+                tt::tt_metal::experimental::DFBBinding{
+                    send_b_dfb_name, "send_b", tt::tt_metal::experimental::DFBEndpointType::PRODUCER},
+                tt::tt_metal::experimental::DFBBinding{
+                    remote_a_dfb_name, "remote_a", tt::tt_metal::experimental::DFBEndpointType::CONSUMER},
+                tt::tt_metal::experimental::DFBBinding{
+                    remote_b_dfb_name, "remote_b", tt::tt_metal::experimental::DFBEndpointType::CONSUMER},
+                tt::tt_metal::experimental::DFBBinding{
+                    scratch_dfb_name, "scratch", tt::tt_metal::experimental::DFBEndpointType::PRODUCER},
+                tt::tt_metal::experimental::DFBBinding{
+                    scratch_dfb_name, "scratch", tt::tt_metal::experimental::DFBEndpointType::CONSUMER},
             },
         .compile_time_args = {{"Kt", Kt}, {"Vt", Vt}, {"G", G}},
         .runtime_arg_schema = {.runtime_arg_names = {"group"}},
@@ -183,56 +195,53 @@ ttnn::device_operation::ProgramArtifacts ReduceAffineTransformsProgramFactory::c
         worker_coordinates.push_back(physical.x);
         worker_coordinates.push_back(physical.y);
     }
-    const auto coordinator = device.worker_core_from_logical_core(dist.cores[0]);
-    m2::KernelRunArgs dataflow_run{
-        .kernel = DATAFLOW,
-        .common_runtime_arg_values =
-            {{"coordinator_x", static_cast<uint32_t>(coordinator.x)},
-             {"coordinator_y", static_cast<uint32_t>(coordinator.y)}},
-    };
+    tt::tt_metal::experimental::KernelRunArgs dataflow_run{.kernel = dataflow_kernel_name};
     dataflow_run.advanced_options.common_runtime_varargs = std::move(worker_coordinates);
-    m2::KernelRunArgs compute_run{.kernel = COMPUTE};
-    for (uint32_t flat = 0; flat < group_heads; ++flat) {
-        const auto& core = dist.cores[flat];
-        const uint32_t group = flat % G;
-        m2::AddRuntimeArgsForNode(dataflow_run.runtime_arg_values, core, {{"worker_index", flat}, {"group", group}});
-        m2::AddRuntimeArgsForNode(compute_run.runtime_arg_values, core, {{"group", group}});
+    tt::tt_metal::experimental::KernelRunArgs compute_run{.kernel = compute_kernel_name};
+    for (uint32_t worker_index = 0; worker_index < group_heads; ++worker_index) {
+        const auto& core = dist.cores[worker_index];
+        const uint32_t group = worker_index % G;
+        tt::tt_metal::experimental::AddRuntimeArgsForNode(
+            dataflow_run.runtime_arg_values, core, {{"worker_index", worker_index}, {"group", group}});
+        tt::tt_metal::experimental::AddRuntimeArgsForNode(compute_run.runtime_arg_values, core, {{"group", group}});
     }
 
-    m2::ProgramSpec spec{
+    tt::tt_metal::experimental::ProgramSpec spec{
         .name = "reduce_affine_transforms",
         .kernels = {std::move(dataflow), std::move(compute)},
         .dataflow_buffers = std::move(dfbs),
         .semaphores =
             {
-                m2::SemaphoreSpec{.unique_id = READY, .target_nodes = cores},
-                m2::SemaphoreSpec{.unique_id = ARRIVAL, .target_nodes = cores},
-                m2::SemaphoreSpec{.unique_id = RELEASE, .target_nodes = cores},
+                tt::tt_metal::experimental::SemaphoreSpec{.unique_id = ready_semaphore_name, .target_nodes = cores},
+                tt::tt_metal::experimental::SemaphoreSpec{.unique_id = arrival_semaphore_name, .target_nodes = cores},
+                tt::tt_metal::experimental::SemaphoreSpec{.unique_id = release_semaphore_name, .target_nodes = cores},
             },
         .tensor_parameters =
             {
-                m2::TensorParameter{.unique_id = A, .spec = a.tensor_spec()},
-                m2::TensorParameter{.unique_id = B, .spec = b.tensor_spec()},
-                m2::TensorParameter{.unique_id = OUTPUT_A, .spec = output_a.tensor_spec()},
-                m2::TensorParameter{.unique_id = OUTPUT_B, .spec = output_b.tensor_spec()},
+                tt::tt_metal::experimental::TensorParameter{.unique_id = a_tensor_name, .spec = a.tensor_spec()},
+                tt::tt_metal::experimental::TensorParameter{.unique_id = b_tensor_name, .spec = b.tensor_spec()},
+                tt::tt_metal::experimental::TensorParameter{
+                    .unique_id = output_a_tensor_name, .spec = output_a.tensor_spec()},
+                tt::tt_metal::experimental::TensorParameter{
+                    .unique_id = output_b_tensor_name, .spec = output_b.tensor_spec()},
             },
         .work_units =
             {
-                m2::WorkUnitSpec{
+                tt::tt_metal::experimental::WorkUnitSpec{
                     .name = "main",
-                    .kernels = {DATAFLOW, COMPUTE},
+                    .kernels = {dataflow_kernel_name, compute_kernel_name},
                     .target_nodes = cores,
                 },
             },
     };
 
-    m2::ProgramRunArgs run_args;
+    tt::tt_metal::experimental::ProgramRunArgs run_args;
     run_args.kernel_run_args = {std::move(dataflow_run), std::move(compute_run)};
     run_args.tensor_args = {
-        {A, a},
-        {B, b},
-        {OUTPUT_A, output_a},
-        {OUTPUT_B, output_b},
+        {a_tensor_name, a},
+        {b_tensor_name, b},
+        {output_a_tensor_name, output_a},
+        {output_b_tensor_name, output_b},
     };
 
     return ttnn::device_operation::ProgramArtifacts{

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_program_factory.cpp
@@ -120,7 +120,7 @@ tt::tt_metal::ProgramDescriptor ReduceAffineTransformsProgramFactory::create_des
             args.push_back(physical.x);
             args.push_back(physical.y);
         }
-        dataflow.emplace_runtime_args(core, std::move(args));
+        dataflow.emplace_runtime_args(core, args);
         compute.emplace_runtime_args(core, {group});
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_program_factory.cpp
@@ -1,15 +1,21 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "reduce_affine_transforms_program_factory.hpp"
+#include "ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_program_factory.hpp"
 
 #include <algorithm>
 #include <vector>
 
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/kernel_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/semaphore_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp>
 
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/core/data_movement_kernel/datamovement_kernel_config.hpp"
 #include "ttnn/operations/experimental/kda/factory/kda_factory_utils.hpp"
 
 using namespace tt::tt_metal;
@@ -17,8 +23,17 @@ using namespace tt::constants;
 
 namespace ttnn::experimental::prim {
 
-tt::tt_metal::ProgramDescriptor ReduceAffineTransformsProgramFactory::create_descriptor(
+namespace m2 = tt::tt_metal::experimental;
+
+ttnn::device_operation::ProgramArtifacts ReduceAffineTransformsProgramFactory::create_program_artifacts(
     const ReduceAffineTransformsParams& attrs, const ReduceAffineTransformsInputs& in, std::vector<Tensor>& outputs) {
+    const auto& a = in.a.mesh_tensor();
+    const auto& b = in.b.mesh_tensor();
+    const auto& output_a = outputs[0].mesh_tensor();
+    const auto& output_b = outputs[1].mesh_tensor();
+    const auto& device = a.device();
+    const auto arch = device.arch();
+
     const uint32_t Kt = attrs.key_dim / TILE_WIDTH;
     const uint32_t Vt = attrs.value_dim / TILE_WIDTH;
     const uint32_t G = attrs.groups_per_head;
@@ -26,8 +41,7 @@ tt::tt_metal::ProgramDescriptor ReduceAffineTransformsProgramFactory::create_des
     const uint32_t kk = Kt * Kt;
     const uint32_t kv = Kt * Vt;
 
-    auto* device = in.a.device();
-    const auto grid = device->compute_with_storage_grid_size();
+    const auto grid = device.compute_with_storage_grid_size();
     constexpr uint32_t kMaxAffineCompositionWorkers = 128;
     TT_FATAL(
         group_heads <= std::min<uint32_t>(grid.x * grid.y, kMaxAffineCompositionWorkers),
@@ -37,96 +51,204 @@ tt::tt_metal::ProgramDescriptor ReduceAffineTransformsProgramFactory::create_des
     auto dist = kda_factory_detail::distribute_prep(grid, group_heads, group_heads);
     const auto& cores = dist.core_set;
 
-    ProgramDescriptor desc;
-    auto add_cb = [&](uint32_t index, uint32_t tiles, tt::DataFormat format = tt::DataFormat::Float32) {
-        const uint32_t tile_size = tt::tile_size(format);
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = tiles * tile_size,
-            .core_ranges = cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(index), .data_format = format, .page_size = tile_size}}}});
-    };
-    const auto summary_format = tt::tt_metal::datatype_to_dataformat_converter(in.a.dtype());
-    add_cb(0, kk, summary_format);
-    add_cb(1, kv, summary_format);
-    add_cb(2, kk);
-    add_cb(3, kv);
-    add_cb(4, kk);
-    add_cb(5, kv);
-    add_cb(6, kk);
-    add_cb(7, kv);
-    add_cb(9, 1);
-    add_cb(10, kv);
-    add_cb(11, 1);
+    const m2::KernelSpecName DATAFLOW{"dataflow"};
+    const m2::KernelSpecName COMPUTE{"compute"};
 
-    constexpr uint32_t ready_semaphore_id = 0;
-    constexpr uint32_t arrival_semaphore_id = 1;
-    constexpr uint32_t release_semaphore_id = 2;
-    for (uint32_t id : {ready_semaphore_id, arrival_semaphore_id, release_semaphore_id}) {
-        desc.semaphores.push_back(
-            SemaphoreDescriptor{.id = id, .core_type = tt::CoreType::WORKER, .core_ranges = cores, .initial_value = 0});
+    const m2::DFBSpecName INITIAL_A{"initial_a"};
+    const m2::DFBSpecName INITIAL_B{"initial_b"};
+    const m2::DFBSpecName STAGE_A_PING{"stage_a_ping"};
+    const m2::DFBSpecName STAGE_B_PING{"stage_b_ping"};
+    const m2::DFBSpecName STAGE_A_PONG{"stage_a_pong"};
+    const m2::DFBSpecName STAGE_B_PONG{"stage_b_pong"};
+    const m2::DFBSpecName SEND_A_PING{"send_a_ping"};
+    const m2::DFBSpecName SEND_B_PING{"send_b_ping"};
+    const m2::DFBSpecName SEND_A_PONG{"send_a_pong"};
+    const m2::DFBSpecName SEND_B_PONG{"send_b_pong"};
+    const m2::DFBSpecName REMOTE_A{"remote_a"};
+    const m2::DFBSpecName REMOTE_B{"remote_b"};
+    const m2::DFBSpecName SCRATCH{"scratch"};
+    const m2::DFBSpecName STAGE_TOKEN{"stage_token"};
+
+    const m2::SemaphoreSpecName READY{"ready"};
+    const m2::SemaphoreSpecName ARRIVAL{"arrival"};
+    const m2::SemaphoreSpecName RELEASE{"release"};
+
+    const m2::TensorParamName A{"a"};
+    const m2::TensorParamName B{"b"};
+    const m2::TensorParamName OUTPUT_A{"output_a"};
+    const m2::TensorParamName OUTPUT_B{"output_b"};
+
+    auto make_dfb = [](const m2::DFBSpecName& name, uint32_t tiles, tt::DataFormat format) {
+        return m2::DataflowBufferSpec{
+            .unique_id = name,
+            .entry_size = tt::tile_size(format),
+            .num_entries = tiles,
+            .data_format_metadata = format,
+        };
+    };
+    const auto summary_format = datatype_to_dataformat_converter(in.a.dtype());
+    m2::Group<m2::DataflowBufferSpec> dfbs = {
+        make_dfb(INITIAL_A, kk, summary_format),
+        make_dfb(INITIAL_B, kv, summary_format),
+        make_dfb(STAGE_A_PING, kk, tt::DataFormat::Float32),
+        make_dfb(STAGE_B_PING, kv, tt::DataFormat::Float32),
+        make_dfb(STAGE_A_PONG, kk, tt::DataFormat::Float32),
+        make_dfb(STAGE_B_PONG, kv, tt::DataFormat::Float32),
+        make_dfb(SEND_A_PING, kk, tt::DataFormat::Float32),
+        make_dfb(SEND_B_PING, kv, tt::DataFormat::Float32),
+        make_dfb(SEND_A_PONG, kk, tt::DataFormat::Float32),
+        make_dfb(SEND_B_PONG, kv, tt::DataFormat::Float32),
+        make_dfb(REMOTE_A, kk, tt::DataFormat::Float32),
+        make_dfb(REMOTE_B, kv, tt::DataFormat::Float32),
+        make_dfb(SCRATCH, kv, tt::DataFormat::Float32),
+        make_dfb(STAGE_TOKEN, 1, tt::DataFormat::Float32),
+    };
+
+    m2::KernelSpec dataflow{
+        .unique_id = DATAFLOW,
+        .source =
+            "ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/dataflow/"
+            "reader_writer_reduce_affine_transforms.cpp",
+        .dfb_bindings =
+            {
+                m2::DFBBinding{INITIAL_A, "initial_a", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{INITIAL_B, "initial_b", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{SEND_A_PING, "send_a_ping", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{SEND_B_PING, "send_b_ping", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{SEND_A_PONG, "send_a_pong", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{SEND_B_PONG, "send_b_pong", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{REMOTE_A, "remote_a", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{REMOTE_B, "remote_b", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{STAGE_TOKEN, "stage_token", m2::DFBEndpointType::PRODUCER},
+            },
+        .semaphore_bindings =
+            {
+                m2::SemaphoreBinding{READY, "ready"},
+                m2::SemaphoreBinding{ARRIVAL, "arrival"},
+                m2::SemaphoreBinding{RELEASE, "release"},
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{A, "a"},
+                m2::TensorBinding{B, "b"},
+                m2::TensorBinding{OUTPUT_A, "output_a"},
+                m2::TensorBinding{OUTPUT_B, "output_b"},
+            },
+        .compile_time_args = {{"Kt", Kt}, {"Vt", Vt}, {"BH", attrs.batch_heads}, {"G", G}},
+        .runtime_arg_schema =
+            {.runtime_arg_names = {"worker_index", "group"},
+             .common_runtime_arg_names = {"coordinator_x", "coordinator_y"}},
+        .hw_config = ttnn::create_reader_datamovement_config(arch),
+        .advanced_options = {.num_common_runtime_varargs = 2 * group_heads},
+    };
+
+    auto compute_hw = ttnn::to_compute_hardware_config(arch, attrs.compute_kernel_config);
+    auto& unpack_modes = m2::unpack_modes(compute_hw);
+    for (const auto& name :
+         {STAGE_A_PING, STAGE_B_PING, STAGE_A_PONG, STAGE_B_PONG, REMOTE_A, REMOTE_B, SCRATCH, STAGE_TOKEN}) {
+        unpack_modes[name] = UnpackMode::UnpackToSrc;
+    }
+    if (summary_format == tt::DataFormat::Float32) {
+        unpack_modes[INITIAL_A] = UnpackMode::UnpackToSrc;
+        unpack_modes[INITIAL_B] = UnpackMode::UnpackToSrc;
     }
 
-    auto* output_a_buffer = outputs[0].buffer();
-    auto* output_b_buffer = outputs[1].buffer();
-    std::vector<uint32_t> dataflow_ct = {Kt, Vt, attrs.batch_heads, G};
-    TensorAccessorArgs(*in.a.buffer()).append_to(dataflow_ct);
-    TensorAccessorArgs(*in.b.buffer()).append_to(dataflow_ct);
-    TensorAccessorArgs(*output_a_buffer).append_to(dataflow_ct);
-    TensorAccessorArgs(*output_b_buffer).append_to(dataflow_ct);
+    m2::KernelSpec compute{
+        .unique_id = COMPUTE,
+        .source =
+            "ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/compute/"
+            "reduce_affine_transforms.cpp",
+        .compiler_options = {.opt_level = KernelBuildOptLevel::O3},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{INITIAL_A, "initial_a", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{INITIAL_B, "initial_b", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{STAGE_A_PING, "stage_a_ping", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{STAGE_A_PING, "stage_a_ping", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{STAGE_B_PING, "stage_b_ping", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{STAGE_B_PING, "stage_b_ping", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{STAGE_A_PONG, "stage_a_pong", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{STAGE_A_PONG, "stage_a_pong", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{STAGE_B_PONG, "stage_b_pong", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{STAGE_B_PONG, "stage_b_pong", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{SEND_A_PING, "send_a_ping", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{SEND_B_PING, "send_b_ping", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{SEND_A_PONG, "send_a_pong", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{SEND_B_PONG, "send_b_pong", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{REMOTE_A, "remote_a", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{REMOTE_B, "remote_b", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{SCRATCH, "scratch", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{SCRATCH, "scratch", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{STAGE_TOKEN, "stage_token", m2::DFBEndpointType::CONSUMER},
+            },
+        .compile_time_args = {{"Kt", Kt}, {"Vt", Vt}, {"G", G}},
+        .runtime_arg_schema = {.runtime_arg_names = {"group"}},
+        .hw_config = std::move(compute_hw),
+    };
 
-    KernelDescriptor dataflow;
-    dataflow.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/dataflow/"
-        "reader_writer_reduce_affine_transforms.cpp";
-    dataflow.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    dataflow.core_ranges = cores;
-    dataflow.compile_time_args = dataflow_ct;
-    dataflow.config = ReaderConfigDescriptor{};
-    dataflow.runtime_args.reserve(group_heads);
-
-    KernelDescriptor compute;
-    compute.kernel_source =
-        "ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/compute/"
-        "reduce_affine_transforms.cpp";
-    compute.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute.core_ranges = cores;
-    compute.compile_time_args = {Kt, Vt, G};
-    compute.config = kda_factory_detail::kda_compute_cfg(device->arch(), attrs.compute_kernel_config);
-    compute.runtime_args.reserve(group_heads);
-
-    auto* a_buffer = in.a.buffer();
-    auto* b_buffer = in.b.buffer();
-    const auto coordinator = device->worker_core_from_logical_core(dist.cores[0]);
-    for (uint32_t flat = 0; flat < group_heads; flat++) {
+    std::vector<uint32_t> worker_coordinates;
+    worker_coordinates.reserve(2 * group_heads);
+    for (const auto& worker : dist.cores) {
+        const auto physical = device.worker_core_from_logical_core(worker);
+        worker_coordinates.push_back(physical.x);
+        worker_coordinates.push_back(physical.y);
+    }
+    const auto coordinator = device.worker_core_from_logical_core(dist.cores[0]);
+    m2::KernelRunArgs dataflow_run{
+        .kernel = DATAFLOW,
+        .common_runtime_arg_values =
+            {{"coordinator_x", static_cast<uint32_t>(coordinator.x)},
+             {"coordinator_y", static_cast<uint32_t>(coordinator.y)}},
+    };
+    dataflow_run.advanced_options.common_runtime_varargs = std::move(worker_coordinates);
+    m2::KernelRunArgs compute_run{.kernel = COMPUTE};
+    for (uint32_t flat = 0; flat < group_heads; ++flat) {
         const auto& core = dist.cores[flat];
         const uint32_t group = flat % G;
-        KernelDescriptor::RTArgList args;
-        args.reserve(12 + 2 * group_heads);
-        args.push_back(flat);
-        args.push_back(group);
-        args.push_back(group_heads);
-        args.push_back(a_buffer);
-        args.push_back(b_buffer);
-        args.push_back(output_a_buffer);
-        args.push_back(output_b_buffer);
-        args.push_back(ready_semaphore_id);
-        args.push_back(arrival_semaphore_id);
-        args.push_back(release_semaphore_id);
-        args.push_back(coordinator.x);
-        args.push_back(coordinator.y);
-        for (const auto& worker : dist.cores) {
-            const auto physical = device->worker_core_from_logical_core(worker);
-            args.push_back(physical.x);
-            args.push_back(physical.y);
-        }
-        dataflow.emplace_runtime_args(core, args);
-        compute.emplace_runtime_args(core, {group});
+        m2::AddRuntimeArgsForNode(dataflow_run.runtime_arg_values, core, {{"worker_index", flat}, {"group", group}});
+        m2::AddRuntimeArgsForNode(compute_run.runtime_arg_values, core, {{"group", group}});
     }
 
-    desc.kernels.push_back(std::move(dataflow));
-    desc.kernels.push_back(std::move(compute));
-    return desc;
+    m2::ProgramSpec spec{
+        .name = "reduce_affine_transforms",
+        .kernels = {std::move(dataflow), std::move(compute)},
+        .dataflow_buffers = std::move(dfbs),
+        .semaphores =
+            {
+                m2::SemaphoreSpec{.unique_id = READY, .target_nodes = cores},
+                m2::SemaphoreSpec{.unique_id = ARRIVAL, .target_nodes = cores},
+                m2::SemaphoreSpec{.unique_id = RELEASE, .target_nodes = cores},
+            },
+        .tensor_parameters =
+            {
+                m2::TensorParameter{.unique_id = A, .spec = a.tensor_spec()},
+                m2::TensorParameter{.unique_id = B, .spec = b.tensor_spec()},
+                m2::TensorParameter{.unique_id = OUTPUT_A, .spec = output_a.tensor_spec()},
+                m2::TensorParameter{.unique_id = OUTPUT_B, .spec = output_b.tensor_spec()},
+            },
+        .work_units =
+            {
+                m2::WorkUnitSpec{
+                    .name = "main",
+                    .kernels = {DATAFLOW, COMPUTE},
+                    .target_nodes = cores,
+                },
+            },
+    };
+
+    m2::ProgramRunArgs run_args;
+    run_args.kernel_run_args = {std::move(dataflow_run), std::move(compute_run)};
+    run_args.tensor_args = {
+        {A, a},
+        {B, b},
+        {OUTPUT_A, output_a},
+        {OUTPUT_B, output_b},
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{
+        .spec = std::move(spec),
+        .run_params = std::move(run_args),
+    };
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_program_factory.cpp
@@ -56,14 +56,10 @@ ttnn::device_operation::ProgramArtifacts ReduceAffineTransformsProgramFactory::c
 
     const m2::DFBSpecName INITIAL_A{"initial_a"};
     const m2::DFBSpecName INITIAL_B{"initial_b"};
-    const m2::DFBSpecName STAGE_A_PING{"stage_a_ping"};
-    const m2::DFBSpecName STAGE_B_PING{"stage_b_ping"};
-    const m2::DFBSpecName STAGE_A_PONG{"stage_a_pong"};
-    const m2::DFBSpecName STAGE_B_PONG{"stage_b_pong"};
-    const m2::DFBSpecName SEND_A_PING{"send_a_ping"};
-    const m2::DFBSpecName SEND_B_PING{"send_b_ping"};
-    const m2::DFBSpecName SEND_A_PONG{"send_a_pong"};
-    const m2::DFBSpecName SEND_B_PONG{"send_b_pong"};
+    const m2::DFBSpecName STAGE_A{"stage_a"};
+    const m2::DFBSpecName STAGE_B{"stage_b"};
+    const m2::DFBSpecName SEND_A{"send_a"};
+    const m2::DFBSpecName SEND_B{"send_b"};
     const m2::DFBSpecName REMOTE_A{"remote_a"};
     const m2::DFBSpecName REMOTE_B{"remote_b"};
     const m2::DFBSpecName SCRATCH{"scratch"};
@@ -89,14 +85,10 @@ ttnn::device_operation::ProgramArtifacts ReduceAffineTransformsProgramFactory::c
     m2::Group<m2::DataflowBufferSpec> dfbs = {
         make_dfb(INITIAL_A, kk, summary_format),
         make_dfb(INITIAL_B, kv, summary_format),
-        make_dfb(STAGE_A_PING, kk, tt::DataFormat::Float32),
-        make_dfb(STAGE_B_PING, kv, tt::DataFormat::Float32),
-        make_dfb(STAGE_A_PONG, kk, tt::DataFormat::Float32),
-        make_dfb(STAGE_B_PONG, kv, tt::DataFormat::Float32),
-        make_dfb(SEND_A_PING, kk, tt::DataFormat::Float32),
-        make_dfb(SEND_B_PING, kv, tt::DataFormat::Float32),
-        make_dfb(SEND_A_PONG, kk, tt::DataFormat::Float32),
-        make_dfb(SEND_B_PONG, kv, tt::DataFormat::Float32),
+        make_dfb(STAGE_A, 2 * kk, tt::DataFormat::Float32),
+        make_dfb(STAGE_B, 2 * kv, tt::DataFormat::Float32),
+        make_dfb(SEND_A, 2 * kk, tt::DataFormat::Float32),
+        make_dfb(SEND_B, 2 * kv, tt::DataFormat::Float32),
         make_dfb(REMOTE_A, kk, tt::DataFormat::Float32),
         make_dfb(REMOTE_B, kv, tt::DataFormat::Float32),
         make_dfb(SCRATCH, kv, tt::DataFormat::Float32),
@@ -111,10 +103,8 @@ ttnn::device_operation::ProgramArtifacts ReduceAffineTransformsProgramFactory::c
             {
                 m2::DFBBinding{INITIAL_A, "initial_a", m2::DFBEndpointType::PRODUCER},
                 m2::DFBBinding{INITIAL_B, "initial_b", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{SEND_A_PING, "send_a_ping", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{SEND_B_PING, "send_b_ping", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{SEND_A_PONG, "send_a_pong", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{SEND_B_PONG, "send_b_pong", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{SEND_A, "send_a", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{SEND_B, "send_b", m2::DFBEndpointType::CONSUMER},
                 m2::DFBBinding{REMOTE_A, "remote_a", m2::DFBEndpointType::PRODUCER},
                 m2::DFBBinding{REMOTE_B, "remote_b", m2::DFBEndpointType::PRODUCER},
             },
@@ -141,7 +131,7 @@ ttnn::device_operation::ProgramArtifacts ReduceAffineTransformsProgramFactory::c
 
     auto compute_hw = ttnn::to_compute_hardware_config(arch, attrs.compute_kernel_config);
     auto& unpack_modes = m2::unpack_modes(compute_hw);
-    for (const auto& name : {STAGE_A_PING, STAGE_B_PING, STAGE_A_PONG, STAGE_B_PONG, REMOTE_A, REMOTE_B, SCRATCH}) {
+    for (const auto& name : {STAGE_A, STAGE_B, REMOTE_A, REMOTE_B, SCRATCH}) {
         unpack_modes[name] = UnpackMode::UnpackToSrc;
     }
     if (summary_format == tt::DataFormat::Float32) {
@@ -159,18 +149,12 @@ ttnn::device_operation::ProgramArtifacts ReduceAffineTransformsProgramFactory::c
             {
                 m2::DFBBinding{INITIAL_A, "initial_a", m2::DFBEndpointType::CONSUMER},
                 m2::DFBBinding{INITIAL_B, "initial_b", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{STAGE_A_PING, "stage_a_ping", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{STAGE_A_PING, "stage_a_ping", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{STAGE_B_PING, "stage_b_ping", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{STAGE_B_PING, "stage_b_ping", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{STAGE_A_PONG, "stage_a_pong", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{STAGE_A_PONG, "stage_a_pong", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{STAGE_B_PONG, "stage_b_pong", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{STAGE_B_PONG, "stage_b_pong", m2::DFBEndpointType::CONSUMER},
-                m2::DFBBinding{SEND_A_PING, "send_a_ping", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{SEND_B_PING, "send_b_ping", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{SEND_A_PONG, "send_a_pong", m2::DFBEndpointType::PRODUCER},
-                m2::DFBBinding{SEND_B_PONG, "send_b_pong", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{STAGE_A, "stage_a", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{STAGE_A, "stage_a", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{STAGE_B, "stage_b", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{STAGE_B, "stage_b", m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{SEND_A, "send_a", m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{SEND_B, "send_b", m2::DFBEndpointType::PRODUCER},
                 m2::DFBBinding{REMOTE_A, "remote_a", m2::DFBEndpointType::CONSUMER},
                 m2::DFBBinding{REMOTE_B, "remote_b", m2::DFBEndpointType::CONSUMER},
                 m2::DFBBinding{SCRATCH, "scratch", m2::DFBEndpointType::PRODUCER},

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_program_factory.cpp
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "reduce_affine_transforms_program_factory.hpp"
+
+#include <algorithm>
+#include <vector>
+
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "ttnn/operations/experimental/kda/factory/kda_factory_utils.hpp"
+
+using namespace tt::tt_metal;
+using namespace tt::constants;
+
+namespace ttnn::experimental::prim {
+
+tt::tt_metal::ProgramDescriptor ReduceAffineTransformsProgramFactory::create_descriptor(
+    const ReduceAffineTransformsParams& attrs, const ReduceAffineTransformsInputs& in, std::vector<Tensor>& outputs) {
+    const uint32_t Kt = attrs.key_dim / TILE_WIDTH;
+    const uint32_t Vt = attrs.value_dim / TILE_WIDTH;
+    const uint32_t G = attrs.groups_per_head;
+    const uint32_t group_heads = attrs.batch_heads * G;
+    const uint32_t kk = Kt * Kt;
+    const uint32_t kv = Kt * Vt;
+
+    auto* device = in.a.device();
+    const auto grid = device->compute_with_storage_grid_size();
+    constexpr uint32_t kMaxAffineCompositionWorkers = 128;
+    TT_FATAL(
+        group_heads <= std::min<uint32_t>(grid.x * grid.y, kMaxAffineCompositionWorkers),
+        "reduce_affine_transforms supports at most {} group workers, got {}",
+        kMaxAffineCompositionWorkers,
+        group_heads);
+    auto dist = kda_factory_detail::distribute_prep(grid, group_heads, group_heads);
+    const auto& cores = dist.core_set;
+
+    ProgramDescriptor desc;
+    auto add_cb = [&](uint32_t index, uint32_t tiles, tt::DataFormat format = tt::DataFormat::Float32) {
+        const uint32_t tile_size = tt::tile_size(format);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = tiles * tile_size,
+            .core_ranges = cores,
+            .format_descriptors = {{CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(index), .data_format = format, .page_size = tile_size}}}});
+    };
+    const auto summary_format = tt::tt_metal::datatype_to_dataformat_converter(in.a.dtype());
+    add_cb(0, kk, summary_format);
+    add_cb(1, kv, summary_format);
+    add_cb(2, kk);
+    add_cb(3, kv);
+    add_cb(4, kk);
+    add_cb(5, kv);
+    add_cb(6, kk);
+    add_cb(7, kv);
+    add_cb(9, 1);
+    add_cb(10, kv);
+    add_cb(11, 1);
+
+    constexpr uint32_t ready_semaphore_id = 0;
+    constexpr uint32_t arrival_semaphore_id = 1;
+    constexpr uint32_t release_semaphore_id = 2;
+    for (uint32_t id : {ready_semaphore_id, arrival_semaphore_id, release_semaphore_id}) {
+        desc.semaphores.push_back(
+            SemaphoreDescriptor{.id = id, .core_type = tt::CoreType::WORKER, .core_ranges = cores, .initial_value = 0});
+    }
+
+    auto* output_a_buffer = outputs[0].buffer();
+    auto* output_b_buffer = outputs[1].buffer();
+    std::vector<uint32_t> dataflow_ct = {Kt, Vt, attrs.batch_heads, G};
+    TensorAccessorArgs(*in.a.buffer()).append_to(dataflow_ct);
+    TensorAccessorArgs(*in.b.buffer()).append_to(dataflow_ct);
+    TensorAccessorArgs(*output_a_buffer).append_to(dataflow_ct);
+    TensorAccessorArgs(*output_b_buffer).append_to(dataflow_ct);
+
+    KernelDescriptor dataflow;
+    dataflow.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/dataflow/"
+        "reader_writer_reduce_affine_transforms.cpp";
+    dataflow.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    dataflow.core_ranges = cores;
+    dataflow.compile_time_args = dataflow_ct;
+    dataflow.config = ReaderConfigDescriptor{};
+    dataflow.runtime_args.reserve(group_heads);
+
+    KernelDescriptor compute;
+    compute.kernel_source =
+        "ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/kernels/compute/"
+        "reduce_affine_transforms.cpp";
+    compute.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute.core_ranges = cores;
+    compute.compile_time_args = {Kt, Vt, G};
+    compute.config = kda_factory_detail::kda_compute_cfg(device->arch(), attrs.compute_kernel_config);
+    compute.runtime_args.reserve(group_heads);
+
+    auto* a_buffer = in.a.buffer();
+    auto* b_buffer = in.b.buffer();
+    const auto coordinator = device->worker_core_from_logical_core(dist.cores[0]);
+    for (uint32_t flat = 0; flat < group_heads; flat++) {
+        const auto& core = dist.cores[flat];
+        const uint32_t group = flat % G;
+        KernelDescriptor::RTArgList args;
+        args.reserve(12 + 2 * group_heads);
+        args.push_back(flat);
+        args.push_back(group);
+        args.push_back(group_heads);
+        args.push_back(a_buffer);
+        args.push_back(b_buffer);
+        args.push_back(output_a_buffer);
+        args.push_back(output_b_buffer);
+        args.push_back(ready_semaphore_id);
+        args.push_back(arrival_semaphore_id);
+        args.push_back(release_semaphore_id);
+        args.push_back(coordinator.x);
+        args.push_back(coordinator.y);
+        for (const auto& worker : dist.cores) {
+            const auto physical = device->worker_core_from_logical_core(worker);
+            args.push_back(physical.x);
+            args.push_back(physical.y);
+        }
+        dataflow.emplace_runtime_args(core, std::move(args));
+        compute.emplace_runtime_args(core, {group});
+    }
+
+    desc.kernels.push_back(std::move(dataflow));
+    desc.kernels.push_back(std::move(compute));
+    return desc;
+}
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_program_factory.cpp
@@ -93,6 +93,17 @@ ttnn::device_operation::ProgramArtifacts ReduceAffineTransformsProgramFactory::c
         make_dfb(REMOTE_B, kv, tt::DataFormat::Float32),
         make_dfb(SCRATCH, kv, tt::DataFormat::Float32),
     };
+    // The sender addresses a peer's inbound mailbox with its own local write pointer, which is only
+    // valid while these buffers hold one phase-independent slot. Any additional depth lets sender and
+    // receiver select different halves and silently corrupts the reduction.
+    for (const auto& dfb : dfbs) {
+        if (dfb.unique_id == REMOTE_A || dfb.unique_id == REMOTE_B) {
+            TT_FATAL(
+                dfb.num_entries == (dfb.unique_id == REMOTE_A ? kk : kv),
+                "reduce_affine_transforms: remotely addressed mailbox {} must hold exactly one block",
+                *dfb.unique_id);
+        }
+    }
 
     m2::KernelSpec dataflow{
         .unique_id = DATAFLOW,

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_program_factory.hpp
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "reduce_affine_transforms_device_operation_types.hpp"
+
+namespace ttnn::experimental::prim {
+
+struct ReduceAffineTransformsProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const ReduceAffineTransformsParams&, const ReduceAffineTransformsInputs&, std::vector<Tensor>&);
+};
+
+}  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/device/reduce_affine_transforms_program_factory.hpp
@@ -4,11 +4,12 @@
 #pragma once
 
 #include "reduce_affine_transforms_device_operation_types.hpp"
+#include "ttnn/metal_v2_artifacts.hpp"
 
 namespace ttnn::experimental::prim {
 
 struct ReduceAffineTransformsProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const ReduceAffineTransformsParams&, const ReduceAffineTransformsInputs&, std::vector<Tensor>&);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/reduce_affine_transforms.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/reduce_affine_transforms.cpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "reduce_affine_transforms.hpp"
+
+#include "device/reduce_affine_transforms_device_operation.hpp"
+
+namespace ttnn::experimental::kda {
+
+std::pair<ttnn::Tensor, ttnn::Tensor> reduce_affine_transforms(
+    const ttnn::Tensor& a,
+    const ttnn::Tensor& b,
+    uint32_t groups_per_head,
+    const std::optional<ttnn::MemoryConfig>& memory_config,
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config) {
+    TT_FATAL(
+        a.storage_type() == StorageType::DEVICE && a.buffer() != nullptr,
+        "reduce_affine_transforms: a must be an allocated device tensor");
+    TT_FATAL(
+        b.storage_type() == StorageType::DEVICE && b.buffer() != nullptr,
+        "reduce_affine_transforms: b must be an allocated device tensor");
+    const auto output_memory_config = memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG);
+    const auto kernel_config = init_device_compute_kernel_config(
+        a.device()->arch(),
+        compute_kernel_config,
+        MathFidelity::HiFi4,
+        /*default_approx_mode=*/false,
+        /*default_fp32_acc=*/true,
+        /*default_l1_acc=*/false);
+    return ttnn::experimental::prim::reduce_affine_transforms(
+        a, b, groups_per_head, output_memory_config, kernel_config);
+}
+
+}  // namespace ttnn::experimental::kda

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/reduce_affine_transforms.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/reduce_affine_transforms.cpp
@@ -23,7 +23,7 @@ std::pair<ttnn::Tensor, ttnn::Tensor> reduce_affine_transforms(
     const auto kernel_config = init_device_compute_kernel_config(
         a.device()->arch(),
         compute_kernel_config,
-        MathFidelity::HiFi4,
+        MathFidelity::HiFi2,
         /*default_approx_mode=*/false,
         /*default_fp32_acc=*/true,
         /*default_l1_acc=*/false);

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/reduce_affine_transforms.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/reduce_affine_transforms.hpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include <utility>
+
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::experimental::kda {
+
+std::pair<ttnn::Tensor, ttnn::Tensor> reduce_affine_transforms(
+    const ttnn::Tensor& a,
+    const ttnn::Tensor& b,
+    uint32_t groups_per_head,
+    const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
+
+}  // namespace ttnn::experimental::kda

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/reduce_affine_transforms_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/reduce_affine_transforms_nanobind.cpp
@@ -14,7 +14,51 @@ namespace ttnn::operations::experimental::kda::reduce_affine_transforms::detail 
 void bind_reduce_affine_transforms(nb::module_& mod) {
     ttnn::bind_function<"reduce_affine_transforms", "ttnn.experimental.kda.">(
         mod,
-        R"doc(Reduce ordered grouped affine transforms into one transform per head.)doc",
+        R"doc(
+        Compose ordered group-level affine state transitions into one transition
+        per batch-head.
+
+        Each input pair represents one group of chunks for one batch-head:
+
+            F_g(S) = A_g @ S + B_g
+
+        The leading dimension is flattened batch-head-group order:
+
+            index = batch_head * groups_per_head + group
+
+        Groups are composed in sequence order:
+
+            A_total = A_g @ A_total
+            B_total = A_g @ B_total + B_g
+
+        Args:
+            a (ttnn.Tensor): Group multipliers ``[B*H*G, K, K]``. Each leading
+                entry represents one batch-head-group. Must be a TILE-layout
+                FLOAT32 or BFLOAT16 device tensor.
+            b (ttnn.Tensor): Group offsets ``[B*H*G, K, V]``. Must have the same
+                dtype, device, and leading dimension as ``a``.
+            groups_per_head (int): Number of consecutive groups ``G`` belonging
+                to each batch-head. Must be positive and divide the leading
+                dimension.
+
+        Keyword Args:
+            memory_config (ttnn.MemoryConfig, optional): Interleaved output memory
+                configuration. Defaults to DRAM.
+            compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional):
+                Compute-kernel configuration.
+
+        Returns:
+            tuple[ttnn.Tensor, ttnn.Tensor]: New FLOAT32 TILE-layout tensors
+                ``A[B*H,K,K]`` and ``B[B*H,K,V]``, containing one composed
+                transition per batch-head:
+
+                    S_after = A @ S_before + B
+
+        Note:
+            ``K`` and ``V`` must be positive and tile-aligned, and each ``A_g``
+            must be square. Inputs may be interleaved or height-sharded and are
+            not modified. Output memory must be interleaved.
+        )doc",
         &ttnn::experimental::kda::reduce_affine_transforms,
         nb::arg("a").noconvert(),
         nb::arg("b").noconvert(),

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/reduce_affine_transforms_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/reduce_affine_transforms_nanobind.cpp
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "reduce_affine_transforms_nanobind.hpp"
+
+#include "reduce_affine_transforms.hpp"
+#include "ttnn-nanobind/bind_function.hpp"
+
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/pair.h>
+
+namespace ttnn::operations::experimental::kda::reduce_affine_transforms::detail {
+
+void bind_reduce_affine_transforms(nb::module_& mod) {
+    ttnn::bind_function<"reduce_affine_transforms", "ttnn.experimental.kda.">(
+        mod,
+        R"doc(Reduce ordered grouped affine transforms into one transform per head.)doc",
+        &ttnn::experimental::kda::reduce_affine_transforms,
+        nb::arg("a").noconvert(),
+        nb::arg("b").noconvert(),
+        nb::arg("groups_per_head"),
+        nb::kw_only(),
+        nb::arg("memory_config") = nb::none(),
+        nb::arg("compute_kernel_config") = nb::none());
+}
+
+}  // namespace ttnn::operations::experimental::kda::reduce_affine_transforms::detail

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/reduce_affine_transforms_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/reduce_affine_transforms_nanobind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <nanobind/nanobind.h>
+
+namespace ttnn::operations::experimental::kda::reduce_affine_transforms::detail {
+
+namespace nb = nanobind;
+void bind_reduce_affine_transforms(nb::module_&);
+
+}  // namespace ttnn::operations::experimental::kda::reduce_affine_transforms::detail

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/sources.cmake
@@ -6,8 +6,6 @@ set(TTNN_OP_EXPERIMENTAL_KDA_REDUCE_AFFINE_TRANSFORMS_SRCS
     device/reduce_affine_transforms_program_factory.cpp
 )
 
-set(TTNN_OP_EXPERIMENTAL_KDA_SHARED_SRCS ../factory/kda_factory_utils.cpp)
-
 set(TTNN_OP_EXPERIMENTAL_KDA_REDUCE_AFFINE_TRANSFORMS_NANOBIND_SRCS
     reduce_affine_transforms_nanobind.cpp
     ../kda_nanobind.cpp

--- a/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/experimental/kda/reduce_affine_transforms/sources.cmake
@@ -1,0 +1,14 @@
+set(TTNN_OP_EXPERIMENTAL_KDA_REDUCE_AFFINE_TRANSFORMS_API_HEADERS reduce_affine_transforms.hpp)
+
+set(TTNN_OP_EXPERIMENTAL_KDA_REDUCE_AFFINE_TRANSFORMS_SRCS
+    reduce_affine_transforms.cpp
+    device/reduce_affine_transforms_device_operation.cpp
+    device/reduce_affine_transforms_program_factory.cpp
+)
+
+set(TTNN_OP_EXPERIMENTAL_KDA_SHARED_SRCS ../factory/kda_factory_utils.cpp)
+
+set(TTNN_OP_EXPERIMENTAL_KDA_REDUCE_AFFINE_TRANSFORMS_NANOBIND_SRCS
+    reduce_affine_transforms_nanobind.cpp
+    ../kda_nanobind.cpp
+)


### PR DESCRIPTION
Adds `ttnn.experimental.kda.reduce_affine_transforms`, one operation from the [full change PR #51910](https://github.com/tenstorrent/tt-metal/pull/51910).

KDA represents each sequence group as an affine state transition:

`S_out = A_g · S_in + B_g`

This operation composes the ordered group transitions for each batch-head into one equivalent transition. Starting from `(A_total, B_total) = (I, 0)`, each group updates:

`A_total ← A_g · A_total`

`B_total ← A_g · B_total + B_g`

It accepts `A[BH·G, K, K]` and `B[BH·G, K, V]`, where `G` is `groups_per_head`, and returns `A_total[BH, K, K]` and `B_total[BH, K, V]`. Composition order is part of the contract because affine transforms do not generally commute.

Reducing each group through one device operation avoids repeatedly dispatching separate matmuls and adds. On the measured workload, the fused reduction ran 6,723 ns against 23,134 ns of composed nine-program device work, a 3.44× device-time speedup, while both paths matched the CPU oracle above PCC 0.999999.

### Test plan

[![Sanity tests • Blackhole](https://img.shields.io/github/actions/workflow/status/tenstorrent/tt-metal/sanity-tests.yaml?branch=kda-split%2F03a-reduce-affine-transforms&event=workflow_dispatch&label=Sanity%20tests%20%E2%80%A2%20Blackhole&logo=githubactions)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch%3Akda-split%2F03a-reduce-affine-transforms)
[![L2 nightly • Blackhole experimental](https://img.shields.io/github/actions/workflow/status/tenstorrent/tt-metal/tt-metal-l2-nightly.yaml?branch=kda-split%2F03a-reduce-affine-transforms&event=workflow_dispatch&label=L2%20nightly%20%E2%80%A2%20Blackhole%20experimental&logo=githubactions)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch%3Akda-split%2F03a-reduce-affine-transforms)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kda-split/03a-reduce-affine-transforms)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kda-split/03a-reduce-affine-transforms)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kda-split/03a-reduce-affine-transforms)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kda-split/03a-reduce-affine-transforms)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kda-split/03a-reduce-affine-transforms)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kda-split/03a-reduce-affine-transforms)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kda-split/03a-reduce-affine-transforms)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kda-split/03a-reduce-affine-transforms)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kda-split/03a-reduce-affine-transforms)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kda-split/03a-reduce-affine-transforms)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kda-split/03a-reduce-affine-transforms)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kda-split/03a-reduce-affine-transforms)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kda-split/03a-reduce-affine-transforms)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kda-split/03a-reduce-affine-transforms)