### PR TITLE
[Quasar] Consolidate mailbox tests; cover DM->TRISC for all compute threads

### DIFF
--- a/tests/tt_metal/tt_metal/llk/sources.cmake
+++ b/tests/tt_metal/tt_metal/llk/sources.cmake
@@ -15,7 +15,7 @@ set(UNIT_TESTS_LLK_SRC
     test_mxfp8_typecast.cpp
     test_mxint_typecast.cpp
     test_pack_rows.cpp
-    test_quasar_cb_l1_read_api.cpp
+    test_quasar_mailboxes.cpp
     test_reconfig.cpp
     test_reduce.cpp
     test_sfpu_binary_bcast.cpp

--- a/tests/tt_metal/tt_metal/llk/test_quasar_mailboxes.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_quasar_mailboxes.cpp
@@ -17,35 +17,16 @@
 
 namespace tt::tt_metal {
 
-namespace {
-
-constexpr CoreCoord WORKER_CORE = {0, 0};
-// Must match kValue in quasar_mailbox_minimal_compute.cpp -- the kernel and host are separate TUs,
-// so nothing enforces this at compile time.
-constexpr std::uint32_t MAILBOX_MIN_EXPECTED_VALUE = 0xfacefaceu;
-
-using CbApiDataT = std::uint32_t;
-constexpr auto CB_API_DATA_FORMAT = DataFormat::UInt32;
-
-constexpr CbApiDataT CB_API_VAL0 = 0xA5A5A5A5u;
-constexpr CbApiDataT CB_API_VAL1 = 0x11111111u;
-constexpr CbApiDataT CB_API_VAL2 = 0x22222222u;
-constexpr CbApiDataT CB_API_VAL3 = 0x33333333u;
-
-// What each participating thread should observe:
-// {tile0[0], tile0[1], tile1[0], tile1[1], *get_tile_address(1)}.
-const std::vector<CbApiDataT> CB_API_EXPECTED_PER_THREAD = {
-    CB_API_VAL0, CB_API_VAL1, CB_API_VAL2, CB_API_VAL3, CB_API_VAL2};
-// UNPACK, MATH and PACK each record their own copy; ISOLATE_SFPU does not participate.
-constexpr std::uint32_t CB_API_NUM_READER_THREADS = 3;
-
-}  // namespace
-
 // Minimal reproducer for the QuasarCbL1ReadApi fault: a single mailbox_write (UNPACK ->
 // MathThreadId) matched by a single mailbox_read (MATH <- UnpackThreadId). No CB/DFB is
 // involved, isolating whether the mailbox mechanism itself faults independent of the
 // dataflow-buffer address computation in QuasarCbL1ReadApi.
 TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarMailboxMinimal) {
+    constexpr CoreCoord WORKER_CORE = {0, 0};
+    // Must match kValue in quasar_mailbox_minimal_compute.cpp -- the kernel and host are separate
+    // TUs, so nothing enforces this at compile time.
+    constexpr std::uint32_t MAILBOX_MIN_EXPECTED_VALUE = 0xfacefaceu;
+
     auto mesh_device = devices_.at(0);
     auto* device = mesh_device->get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();
@@ -84,6 +65,83 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarMailboxMinimal) {
     EXPECT_EQ(host_buffer[0], MAILBOX_MIN_EXPECTED_VALUE);
 }
 
+// DM -> TRISC mailbox path over plain MMIO, covering all three compute-thread receivers: a
+// data-movement kernel writes one value per receiver into NEO0's TRISC mailbox queues
+// k = reader*4 + writer (reader in {T0=UNPACK, T1=MATH, T2=PACK}, writer slot T3=IsolateSfpu):
+//   UNPACK: k = 0*4+3 = 3  (NEO_REGS_0 TRISC_MAILBOX_3,  0x0180018C)
+//   MATH:   k = 1*4+3 = 7  (NEO_REGS_0 TRISC_MAILBOX_7,  0x0180019C)
+//   PACK:   k = 2*4+3 = 11 (NEO_REGS_0 TRISC_MAILBOX_11, 0x018001AC)
+// A DM core is not a TRISC, so it "impersonates" writer T3 (per the Quasar HW addressing model);
+// each receiving thread drains its queue with ckernel::mailbox_read(IsolateSfpuThreadId) and records
+// what arrived into its own L1 result slot. The host verifies all three values round-tripped.
+//
+// The DM kernel brackets the mailbox stores with sentinel writes to the cluster-control scratch
+// register SCRATCH_16 (0x03000080): 0x00AAAAAA before, 0x0BBBBBBB after -- waveform markers for
+// localizing a hang/fault of the mailbox MMIO accesses on Zebu.
+TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarDmToTriscMailbox) {
+    constexpr CoreCoord WORKER_CORE = {0, 0};
+    // One value per receiving TRISC thread, handed to the DM writer kernel as compile-time args
+    // (SetRuntimeArgs/get_arg_val are not exposed for the Quasar DM kernel path), so there is no
+    // kernel-side duplicate. Distinct per receiver so a queue mix-up is detectable.
+    constexpr std::uint32_t DM_MBX_VAL_UNPACK = 0xC0FFEE01u;
+    constexpr std::uint32_t DM_MBX_VAL_MATH = 0xC0FFEE02u;
+    constexpr std::uint32_t DM_MBX_VAL_PACK = 0xC0FFEE03u;
+
+    auto mesh_device = devices_.at(0);
+    auto* device = mesh_device->get_devices()[0];
+    auto& cq = mesh_device->mesh_command_queue();
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+
+    Program program = CreateProgram();
+    workload.add_program(device_range, std::move(program));
+    auto& program_ = workload.get_programs().at(device_range);
+
+    const std::vector<std::uint32_t> expected_result = {DM_MBX_VAL_UNPACK, DM_MBX_VAL_MATH, DM_MBX_VAL_PACK};
+
+    // Each TRISC thread writes the value it read here; host reads it back after the run.
+    // Round up to the L1 allocation alignment, matching the minimal test above.
+    const std::uint32_t result_size_bytes = expected_result.size() * sizeof(std::uint32_t);
+    const std::uint32_t l1_alignment = device->allocator()->get_alignment(BufferType::L1);
+    const std::uint32_t aligned_result_size = (result_size_bytes + l1_alignment - 1) / l1_alignment * l1_alignment;
+    const std::uint32_t result_l1_addr = static_cast<std::uint32_t>(device->l1_size_per_core()) - aligned_result_size;
+    std::vector<std::uint32_t> result_init(expected_result.size(), 0);
+    detail::WriteToDeviceL1(device, WORKER_CORE, result_l1_addr, result_init);
+
+    // num_threads_per_cluster = 6: the temp-API DM allocator keeps the lowest-numbered DM cores,
+    // and DM0/DM1 are reserved (cluster orchestrator / DFB init) -- user kernels only execute on
+    // DM2..DM7. With 1 the kernel lands on DM0 and never runs. The kernel gates on hartid == 2 so
+    // exactly one DM core performs the writes.
+    experimental::quasar::CreateKernel(
+        program_,
+        "tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/quasar_dm_mailbox_scratch_writer.cpp",
+        WORKER_CORE,
+        experimental::quasar::QuasarDataMovementConfig{
+            .num_threads_per_cluster = 6,
+            .compile_args = {DM_MBX_VAL_UNPACK, DM_MBX_VAL_MATH, DM_MBX_VAL_PACK},
+        });
+
+    // num_threads_per_cluster = 1 places the compute kernel on Tensix engine 0 (NEO0) of the
+    // cluster -- the same NEO whose mailboxes the DM kernel writes.
+    auto compute_kernel = experimental::quasar::CreateKernel(
+        program_,
+        "tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/quasar_dm_mailbox_scratch_compute.cpp",
+        WORKER_CORE,
+        experimental::quasar::QuasarComputeConfig{
+            .num_threads_per_cluster = 1,
+        });
+
+    SetRuntimeArgs(program_, compute_kernel, WORKER_CORE, {result_l1_addr});
+
+    distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/true);
+
+    std::vector<std::uint32_t> host_buffer;
+    detail::ReadFromDeviceL1(device, WORKER_CORE, result_l1_addr, result_size_bytes, host_buffer);
+
+    EXPECT_EQ(host_buffer, expected_result);
+}
+
 // Validates ckernel::read_tile_value and ckernel::get_tile_address on Quasar (cb_api.h). Both are
 // implemented as an UNPACK -> mailbox -> MATH/PACK broadcast, so this is the same handshake as
 // QuasarMailboxMinimal above, exercised through the real compute API instead of raw mailbox calls.
@@ -93,6 +151,22 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarMailboxMinimal) {
 // buffer. Checking all three slices (rather than only UNPACK's) is what makes this cover the
 // mailbox delivery -- verifying UNPACK alone would pass even if MATH/PACK received nothing.
 TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarCbL1ReadApi) {
+    constexpr CoreCoord WORKER_CORE = {0, 0};
+    using CbApiDataT = std::uint32_t;
+    constexpr auto CB_API_DATA_FORMAT = DataFormat::UInt32;
+
+    constexpr CbApiDataT CB_API_VAL0 = 0xA5A5A5A5u;
+    constexpr CbApiDataT CB_API_VAL1 = 0x11111111u;
+    constexpr CbApiDataT CB_API_VAL2 = 0x22222222u;
+    constexpr CbApiDataT CB_API_VAL3 = 0x33333333u;
+
+    // What each participating thread should observe:
+    // {tile0[0], tile0[1], tile1[0], tile1[1], *get_tile_address(1)}.
+    const std::vector<CbApiDataT> CB_API_EXPECTED_PER_THREAD = {
+        CB_API_VAL0, CB_API_VAL1, CB_API_VAL2, CB_API_VAL3, CB_API_VAL2};
+    // UNPACK, MATH and PACK each record their own copy; ISOLATE_SFPU does not participate.
+    constexpr std::uint32_t CB_API_NUM_READER_THREADS = 3;
+
     auto mesh_device = devices_.at(0);
     auto* device = mesh_device->get_devices()[0];
     auto& cq = mesh_device->mesh_command_queue();

--- a/tests/tt_metal/tt_metal/llk/test_quasar_mailboxes.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_quasar_mailboxes.cpp
@@ -109,16 +109,16 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, QuasarDmToTriscMailbox) {
     std::vector<std::uint32_t> result_init(expected_result.size(), 0);
     detail::WriteToDeviceL1(device, WORKER_CORE, result_l1_addr, result_init);
 
-    // num_threads_per_cluster = 6: the temp-API DM allocator keeps the lowest-numbered DM cores,
-    // and DM0/DM1 are reserved (cluster orchestrator / DFB init) -- user kernels only execute on
-    // DM2..DM7. With 1 the kernel lands on DM0 and never runs. The kernel gates on hartid == 2 so
-    // exactly one DM core performs the writes.
+    // num_threads_per_cluster = 1: the temp-API DM allocator skips reserved DM0/DM1 (cluster
+    // orchestrator / DFB init -- see GetProcessorsPerClusterQuasar) and hands out the lowest free
+    // DM core, i.e. DM2. The kernel gates on hartid == 2 so exactly that one core performs the
+    // writes.
     experimental::quasar::CreateKernel(
         program_,
         "tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/quasar_dm_mailbox_scratch_writer.cpp",
         WORKER_CORE,
         experimental::quasar::QuasarDataMovementConfig{
-            .num_threads_per_cluster = 6,
+            .num_threads_per_cluster = 1,
             .compile_args = {DM_MBX_VAL_UNPACK, DM_MBX_VAL_MATH, DM_MBX_VAL_PACK},
         });
 

--- a/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/quasar_dm_mailbox_scratch_compute.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/quasar_dm_mailbox_scratch_compute.cpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/common.h"
+#include "dev_mem_map.h"
+
+// Consumer half of the QuasarDmToTriscMailbox test: UNPACK (T0), MATH (T1) and PACK (T2) each
+// blocking-read their mailbox queue from writer slot IsolateSfpu/T3 -- the slot the DM writer
+// kernel impersonates -- and record what arrived into their own slice of the L1 result buffer
+// ([0]=UNPACK, [1]=MATH, [2]=PACK) for the host to check. ISOLATE_SFPU participates in neither
+// half.
+void kernel_main() {
+    UNPACK({
+        const std::uint32_t result_l1_addr = get_arg_val<std::uint32_t>(0);
+        const std::uint32_t v = ckernel::mailbox_read(ckernel::ThreadId::IsolateSfpuThreadId);
+        volatile tt_l1_ptr std::uint32_t* const result =
+            reinterpret_cast<volatile tt_l1_ptr std::uint32_t*>(result_l1_addr);
+        result[0] = v;
+    })
+
+    MATH({
+        const std::uint32_t result_l1_addr = get_arg_val<std::uint32_t>(0);
+        const std::uint32_t v = ckernel::mailbox_read(ckernel::ThreadId::IsolateSfpuThreadId);
+        volatile tt_l1_ptr std::uint32_t* const result =
+            reinterpret_cast<volatile tt_l1_ptr std::uint32_t*>(result_l1_addr);
+        result[1] = v;
+    })
+
+    PACK({
+        const std::uint32_t result_l1_addr = get_arg_val<std::uint32_t>(0);
+        const std::uint32_t v = ckernel::mailbox_read(ckernel::ThreadId::IsolateSfpuThreadId);
+        volatile tt_l1_ptr std::uint32_t* const result =
+            reinterpret_cast<volatile tt_l1_ptr std::uint32_t*>(result_l1_addr);
+        result[2] = v;
+    })
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/quasar_dm_mailbox_scratch_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/quasar_dm_mailbox_scratch_writer.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/dataflow/dataflow_api.h"
+#include "dev_mem_map.h"
+#include "internal/hw_thread.h"
+#include "internal/tt-2xx/risc_common.h"
+#include "internal/tt-2xx/quasar/tensix_neo_reg.h"
+#include "internal/tt-2xx/quasar/overlay/meta/registers/overlay_reg_defines_core.h"
+
+// DM-side producer for the QuasarDmToTriscMailbox test. Writes one value per receiving TRISC
+// thread into the TRISC mailbox queues of this cluster's NEO0 Tensix engine:
+// queue k = reader*4 + writer, reader in {T0=UNPACK, T1=MATH, T2=PACK}, writer slot T3=IsolateSfpu:
+//   UNPACK: k = 0*4+3 = 3  (TRISC_MAILBOX_3,  0x0180018C)
+//   MATH:   k = 1*4+3 = 7  (TRISC_MAILBOX_7,  0x0180019C)
+//   PACK:   k = 2*4+3 = 11 (TRISC_MAILBOX_11, 0x018001AC)
+// A DM core is not a TRISC, so it "impersonates" writer T3 (per the Quasar HW addressing model);
+// each receiving thread reads its queue back with mailbox_read(IsolateSfpuThreadId). The writes
+// are plain MMIO stores to the queues' NEO0 DM/NOC addresses -- that address view is directly
+// load/store-accessible from the DM core.
+//
+// The mailbox stores are bracketed by two sentinel writes to the cluster-control scratch register
+// SCRATCH_16 (0x03000080): 0x00AAAAAA before and 0x0BBBBBBB after. These act as waveform markers
+// on Zebu: if a mailbox MMIO store hangs or faults, the missing 0x0BBBBBBB localizes the failure
+// to the mailbox accesses themselves.
+void kernel_main() {
+    // The Quasar DM allocator (GetProcessorsPerClusterQuasar) keeps the lowest-numbered DM
+    // cores, so the host asks for 6 threads to place this kernel on DM0..DM5. DM0 is the
+    // cluster orchestrator and DM1 runs DFB init only -- neither executes user kernels
+    // (dm.cc). Gate on DM2 so exactly one core performs the writes.
+    if (internal_::get_hw_thread_idx() != 2) {
+        return;
+    }
+    constexpr std::uint32_t value_unpack = get_compile_time_arg_val(0);
+    constexpr std::uint32_t value_math = get_compile_time_arg_val(1);
+    constexpr std::uint32_t value_pack = get_compile_time_arg_val(2);
+    volatile tt_l1_ptr std::uint32_t* const scratch = reinterpret_cast<volatile tt_l1_ptr std::uint32_t*>(
+        TT_CLUSTER_CTRL_SCRATCH_16__REG_ADDR);  // Address 0x03000080
+    volatile tt_l1_ptr std::uint32_t* const queue_unpack = reinterpret_cast<volatile tt_l1_ptr std::uint32_t*>(
+        NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_TRISC_MAILBOX_3__REG_ADDR);  // Address 0x0180018C
+    volatile tt_l1_ptr std::uint32_t* const queue_math = reinterpret_cast<volatile tt_l1_ptr std::uint32_t*>(
+        NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_TRISC_MAILBOX_7__REG_ADDR);  // Address 0x0180019C
+    volatile tt_l1_ptr std::uint32_t* const queue_pack = reinterpret_cast<volatile tt_l1_ptr std::uint32_t*>(
+        NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_TRISC_MAILBOX_11__REG_ADDR);  // Address 0x018001AC
+
+    scratch[0] = 0x00AAAAAA;
+
+    queue_unpack[0] = value_unpack;
+    queue_math[0] = value_math;
+    queue_pack[0] = value_pack;
+
+    scratch[0] = 0x0BBBBBBB;
+}

--- a/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/quasar_dm_mailbox_scratch_writer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/circular_buffer/quasar_dm_mailbox_scratch_writer.cpp
@@ -27,10 +27,9 @@
 // on Zebu: if a mailbox MMIO store hangs or faults, the missing 0x0BBBBBBB localizes the failure
 // to the mailbox accesses themselves.
 void kernel_main() {
-    // The Quasar DM allocator (GetProcessorsPerClusterQuasar) keeps the lowest-numbered DM
-    // cores, so the host asks for 6 threads to place this kernel on DM0..DM5. DM0 is the
-    // cluster orchestrator and DM1 runs DFB init only -- neither executes user kernels
-    // (dm.cc). Gate on DM2 so exactly one core performs the writes.
+    // The Quasar DM allocator (GetProcessorsPerClusterQuasar) skips reserved DM0/DM1, so the
+    // host's request for one DM thread places this kernel on DM2 only. Gate on hartid == 2
+    // defensively so exactly one core performs the writes even if the allocation grows.
     if (internal_::get_hw_thread_idx() != 2) {
         return;
     }


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/49608
 ## Summary
  - Rename `test_quasar_cb_l1_read_api.cpp` to `test_quasar_mailboxes.cpp` and merge the DM->TRISC mailbox test into it, alongside `QuasarMailboxMinimal` and `QuasarCbL1ReadApi`.
  - Extend the DM->TRISC test to all three compute-thread receivers: the DM writer (gated to DM2; DM0/DM1 are reserved orchestrator/DFB-init cores) writes distinct values into mailbox queues k =
  reader*4+3 (UNPACK=3, MATH=7, PACK=11), impersonating writer slot IsolateSfpu/T3. Each TRISC thread drains its queue with `mailbox_read(IsolateSfpuThreadId)` and the host verifies all three values
  round-tripped.
  - Move test constants from the anonymous namespace into the TEST_F bodies that use them (removes unity-build name-collision exposure).
  ## Test plan
  - [x] `unit_tests_llk` builds clean (Release, unity build)
  - [x] `QuasarMailboxMinimal` and the single-receiver `QuasarDmToTriscMailbox` pass on emu-quasar 1x3 (verified with temporary DEVICE_PRINT instrumentation, removed before opening this PR)
  - [x] Re-run all three tests on emu-quasar 1x3 on the final code (mailbox logic unchanged since the passing runs)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rtawfik/quasar-dm-trisc-mailbox-scratch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rtawfik/quasar-dm-trisc-mailbox-scratch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rtawfik/quasar-dm-trisc-mailbox-scratch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rtawfik/quasar-dm-trisc-mailbox-scratch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=rtawfik/quasar-dm-trisc-mailbox-scratch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:rtawfik/quasar-dm-trisc-mailbox-scratch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rtawfik/quasar-dm-trisc-mailbox-scratch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rtawfik/quasar-dm-trisc-mailbox-scratch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rtawfik/quasar-dm-trisc-mailbox-scratch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rtawfik/quasar-dm-trisc-mailbox-scratch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rtawfik/quasar-dm-trisc-mailbox-scratch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rtawfik/quasar-dm-trisc-mailbox-scratch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rtawfik/quasar-dm-trisc-mailbox-scratch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rtawfik/quasar-dm-trisc-mailbox-scratch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rtawfik/quasar-dm-trisc-mailbox-scratch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rtawfik/quasar-dm-trisc-mailbox-scratch)