### PR TITLE
generator: fix batched prefill's slot vs prefill-order index spaces

### DIFF
--- a/models/common/sampling/__init__.py
+++ b/models/common/sampling/__init__.py
@@ -12,6 +12,7 @@ from .generator import (
     format_sampling_params,
     broadcast_sampling_params,
     scatter_sampling_params_to_slots,
+    slice_sampling_params,
     chunk_sampling_params,
     SeedManager,
 )
@@ -29,6 +30,7 @@ __all__ = [
     "format_sampling_params",
     "broadcast_sampling_params",
     "scatter_sampling_params_to_slots",
+    "slice_sampling_params",
     "chunk_sampling_params",
     "SeedManager",
     "split_list",

--- a/models/common/sampling/__init__.py
+++ b/models/common/sampling/__init__.py
@@ -11,6 +11,7 @@ from .generator import (
     SAMPLING_PARAM_FIELDS,
     format_sampling_params,
     broadcast_sampling_params,
+    scatter_sampling_params_to_slots,
     chunk_sampling_params,
     SeedManager,
 )
@@ -27,6 +28,7 @@ __all__ = [
     "SAMPLING_PARAM_FIELDS",
     "format_sampling_params",
     "broadcast_sampling_params",
+    "scatter_sampling_params_to_slots",
     "chunk_sampling_params",
     "SeedManager",
     "split_list",

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -583,6 +583,29 @@ def scatter_sampling_params_to_slots(
     return SamplingParams(**kwargs)
 
 
+def slice_sampling_params(sampling_params, start: int, stop: int):
+    """Take the ``[start, stop)`` requests out of a prefill-ordered SamplingParams.
+
+    For callers that split one prefill batch into several forward passes: each pass
+    must carry its own requests' params, not the first ``stop - start`` of the batch.
+    List fields are sliced, scalars are shared. Falls back to dataclass defaults for
+    missing attributes so vLLM's ``TTSamplingParams`` works transparently.
+    """
+    if sampling_params is None:
+        return None
+    sliced = {}
+    for field_name in SAMPLING_PARAM_FIELDS:
+        try:
+            value = getattr(sampling_params, field_name)
+        except AttributeError:
+            if hasattr(SamplingParams, field_name):
+                value = getattr(SamplingParams, field_name)
+            else:
+                raise
+        sliced[field_name] = value[start:stop] if isinstance(value, list) else value
+    return SamplingParams(**sliced)
+
+
 def chunk_sampling_params(sampling_params, sampling_dp: int) -> list:
     """
     Chunk a SamplingParams (or duck-type-compatible object) into ``sampling_dp`` pieces.

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -538,6 +538,51 @@ def broadcast_sampling_params(
     return SamplingParams(**kwargs)
 
 
+def scatter_sampling_params_to_slots(
+    formatted_sampling_params,
+    empty_slots,
+    slot_len: int = 32,
+):
+    """Move each request's params from its prefill position to its slot row.
+
+    A batched prefill lays its device rows out by physical slot, so the sampling
+    rows must be too: row ``empty_slots[i]`` samples request ``i``'s logits and
+    needs request ``i``'s temperature/top_k/top_p/penalties. Callers receive
+    params in prefill order, which only coincides with the slot order when the
+    slots happen to be ``range(len(empty_slots))``.
+
+    ``seed`` is left in prefill order: ``SeedManager.reset_seed`` takes the slot
+    list separately and does its own mapping. Rows no request occupies inherit the
+    last real request's values rather than the formatter's padding, so they stay
+    valid instead of sampling from a default row. Does not mutate the input.
+    """
+    if not empty_slots:
+        return formatted_sampling_params
+    slots = [int(s) for s in empty_slots]
+
+    def _scatter(values):
+        if not isinstance(values, List):
+            return values
+        values = list(values)
+        if len(values) == 1 and len(slots) > 1:
+            values = values * len(slots)
+        request_values = values[: len(slots)]
+        if not request_values:
+            return values
+        filler = request_values[-1]
+        scattered = [filler] * slot_len
+        for value, slot in zip(request_values, slots):
+            if 0 <= slot < slot_len:
+                scattered[slot] = value
+        return scattered
+
+    kwargs = {}
+    for f in fields(formatted_sampling_params):
+        value = getattr(formatted_sampling_params, f.name)
+        kwargs[f.name] = value if f.name == "seed" else _scatter(value)
+    return SamplingParams(**kwargs)
+
+
 def chunk_sampling_params(sampling_params, sampling_dp: int) -> list:
     """
     Chunk a SamplingParams (or duck-type-compatible object) into ``sampling_dp`` pieces.

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -14,6 +14,7 @@ from models.common.sampling import (
     SeedManager,
     broadcast_sampling_params,
     format_sampling_params,
+    scatter_sampling_params_to_slots,
 )
 from models.common.sampling.tt_log_probs import MAX_TOP_LOGPROBS, LogProbsResult
 from models.common.utility_functions import comp_pcc
@@ -145,6 +146,34 @@ def test_format_sampling_params_uses_device_argmax_sentinel_for_greedy_rows():
     assert params.temperature[0] == 1.0
     assert params.top_k[0] == 1
     assert params.top_p[0] == 0.0
+
+
+def test_scatter_sampling_params_to_slots_moves_params_to_their_slot_row():
+    """A batched prefill samples slot row s with the params of the request there."""
+    params = SamplingParams(temperature=[0.1, 0.2, 0.3], top_k=[1, 2, 3], top_p=[0.5, 0.6, 0.7], seed=[7, 8, 9])
+
+    scattered = scatter_sampling_params_to_slots(params, [2, 0, 5], slot_len=8)
+
+    assert scattered.temperature[2] == 0.1 and scattered.temperature[0] == 0.2
+    assert scattered.temperature[5] == 0.3
+    assert scattered.top_k[2] == 1 and scattered.top_k[0] == 2 and scattered.top_k[5] == 3
+    assert scattered.top_p[2] == 0.5 and scattered.top_p[0] == 0.6 and scattered.top_p[5] == 0.7
+    # Unoccupied rows carry the last request's values, so they stay valid instead of
+    # sampling from a formatter default.
+    assert scattered.temperature[1] == 0.3
+    # SeedManager.reset_seed is given the slot list separately and maps seeds itself.
+    assert scattered.seed == [7, 8, 9]
+    # The input is never mutated.
+    assert params.temperature == [0.1, 0.2, 0.3]
+
+
+def test_scatter_sampling_params_to_slots_is_identity_for_dense_slots():
+    params = format_sampling_params(SamplingParams(temperature=[0.5, 0.5], top_k=[4, 4], top_p=[0.9, 0.9]), 32)
+
+    scattered = scatter_sampling_params_to_slots(params, list(range(2)), slot_len=32)
+
+    assert scattered.temperature[:2] == params.temperature[:2]
+    assert scattered.top_k[:2] == params.top_k[:2]
 
 
 def _skip_if_not_galaxy(mesh_device):

--- a/models/demos/gemma4/tt/generator.py
+++ b/models/demos/gemma4/tt/generator.py
@@ -19,7 +19,7 @@ from models.demos.gemma4.tt.generator_trace import (
     warmup_gemma4_model_prefill,
 )
 from models.tt_transformers.tt.common import get_block_size, get_padded_prefill_len, num_blocks_in_seq
-from models.tt_transformers.tt.generator import MAX_BATCHED_PREFILL_SEQ_LEN, SUPPORTED_PREFILL_BATCH_SIZES, Generator
+from models.tt_transformers.tt.generator import MAX_BATCHED_PREFILL_SEQ_LEN, Generator, batched_prefill_padded_batch
 from models.tt_transformers.tt.model_config import determine_device_name
 
 # Same 128k batched-prefill token ceiling as the shared Generator
@@ -355,10 +355,7 @@ class Gemma4Generator(ChunkedPrefillPageTableGuardMixin, Generator):
                 can_batch_prefill = False
 
         if can_batch_prefill:
-            padded_batch = next(
-                (b for b in SUPPORTED_PREFILL_BATCH_SIZES if b >= batch_size),
-                self.model_args[0].max_batch_size,
-            )
+            padded_batch = batched_prefill_padded_batch(batch_size, empty_slots, self.model_args[0].max_batch_size)
             if (
                 padded_batch <= self.model_args[0].max_batch_size
                 and padded_batch * prefill_seq_lens[0] >= GEMMA4_MAX_BATCHED_PREFILL_SEQ_LEN
@@ -398,7 +395,15 @@ class Gemma4Generator(ChunkedPrefillPageTableGuardMixin, Generator):
                         page_table=page_table[chunk_start:chunk_end] if page_table is not None else None,
                         kv_cache=kv_cache,
                         prompt_lens=prompt_lens_list[chunk_start:chunk_end],
-                        empty_slots=list(range(chunk_size)),
+                        # The chunk's requests keep the slots the caller assigned:
+                        # per-slot device state (seed RNG, row-sharded user id) is
+                        # addressed by slot, so renumbering the chunk would write it
+                        # to slots other requests own.
+                        empty_slots=(
+                            list(empty_slots[chunk_start:chunk_end])
+                            if empty_slots is not None
+                            else list(range(chunk_start, chunk_end))
+                        ),
                         enable_trace=chunk_enable_trace,
                         model_id_warmup=model_id_warmup,
                         sampling_params=sampling_params,
@@ -462,6 +467,7 @@ class Gemma4Generator(ChunkedPrefillPageTableGuardMixin, Generator):
             batch_size=batch_size,
             prefill_seq_lens=prefill_seq_lens,
             can_batch_prefill=can_batch_prefill,
+            empty_slots=empty_slots,
         )
 
         return super().prefill_forward_text(

--- a/models/demos/gemma4/tt/generator.py
+++ b/models/demos/gemma4/tt/generator.py
@@ -8,6 +8,7 @@ import torch
 from loguru import logger
 from transformers import AutoTokenizer
 
+from models.common.sampling import slice_sampling_params
 from models.demos.gemma4.tt.common import create_tt_model
 from models.demos.gemma4.tt.generator_trace import (
     apply_gemma4_prefill_trace_policy,
@@ -384,10 +385,23 @@ class Gemma4Generator(ChunkedPrefillPageTableGuardMixin, Generator):
                 for chunk_start in range(0, batch_size, max_users_per_chunk):
                     chunk_end = min(chunk_start + max_users_per_chunk, batch_size)
                     chunk_size = chunk_end - chunk_start
+                    # The chunk's requests keep the slots the caller assigned:
+                    # per-slot device state (seed RNG, row-sharded user id) is
+                    # addressed by slot, so renumbering the chunk would write it
+                    # to slots other requests own.
+                    chunk_slots = (
+                        list(empty_slots[chunk_start:chunk_end])
+                        if empty_slots is not None
+                        else list(range(chunk_start, chunk_end))
+                    )
                     chunk_enable_trace = apply_gemma4_prefill_trace_policy(
                         enable_trace,
                         prefill_seq_lens[0],
-                        chunk_size,
+                        # Keeping the real slots means the chunk runs as many rows as
+                        # its highest slot needs, so the policy has to weigh that span
+                        # and not the request count, or it captures a trace whose real
+                        # token count is past the documented OOM-risk limit.
+                        batched_prefill_padded_batch(chunk_size, chunk_slots, self.model_args[0].max_batch_size),
                         self.model[0],
                     )
                     chunk_result = super().prefill_forward_text(
@@ -395,18 +409,13 @@ class Gemma4Generator(ChunkedPrefillPageTableGuardMixin, Generator):
                         page_table=page_table[chunk_start:chunk_end] if page_table is not None else None,
                         kv_cache=kv_cache,
                         prompt_lens=prompt_lens_list[chunk_start:chunk_end],
-                        # The chunk's requests keep the slots the caller assigned:
-                        # per-slot device state (seed RNG, row-sharded user id) is
-                        # addressed by slot, so renumbering the chunk would write it
-                        # to slots other requests own.
-                        empty_slots=(
-                            list(empty_slots[chunk_start:chunk_end])
-                            if empty_slots is not None
-                            else list(range(chunk_start, chunk_end))
-                        ),
+                        empty_slots=chunk_slots,
                         enable_trace=chunk_enable_trace,
                         model_id_warmup=model_id_warmup,
-                        sampling_params=sampling_params,
+                        # Each chunk carries its own requests' params. Passing the whole
+                        # prefill-ordered set gave every chunk the first ``chunk_size``
+                        # temperatures, penalties and seeds instead of its own.
+                        sampling_params=slice_sampling_params(sampling_params, chunk_start, chunk_end),
                         start_pos=num_cached_per_user[chunk_start:chunk_end] if start_pos is not None else None,
                         return_hidden_states=return_hidden_states,
                         warmup_prefill=warmup_prefill and chunk_start == 0,

--- a/models/demos/gemma4/tt/generator_trace.py
+++ b/models/demos/gemma4/tt/generator_trace.py
@@ -11,6 +11,7 @@ from loguru import logger
 from models.tt_transformers.tt.generator import (
     MAX_BATCHED_PREFILL_SEQ_LEN,
     SUPPORTED_PREFILL_BATCH_SIZES,
+    batched_prefill_padded_batch,
     max_prefill_chunk_size_cutoff,
 )
 
@@ -348,6 +349,7 @@ def resolve_gemma4_prefill_trace_enable(
     batch_size: int,
     prefill_seq_lens: list[int],
     can_batch_prefill: bool,
+    empty_slots=None,
 ) -> bool:
     """Resolve whether prefill trace stays enabled for this batch/prefill shape."""
     # Batched + bounded: the fill-cap device tensor is a single scalar, so a
@@ -362,10 +364,9 @@ def resolve_gemma4_prefill_trace_enable(
         return False
     trace_batch_size = batch_size
     if can_batch_prefill:
-        trace_batch_size = next(
-            (b for b in SUPPORTED_PREFILL_BATCH_SIZES if b >= batch_size),
-            model_args.max_batch_size,
-        )
+        # Must match the padded_batch the batched prefill will actually run, which
+        # spans the physical slots rather than just the request count.
+        trace_batch_size = batched_prefill_padded_batch(batch_size, empty_slots, model_args.max_batch_size)
     return apply_gemma4_prefill_trace_policy(
         enable_trace,
         prefill_seq_lens[0],

--- a/models/demos/gemma4/tt/generator_vllm.py
+++ b/models/demos/gemma4/tt/generator_vllm.py
@@ -249,6 +249,7 @@ class Gemma4ForCausalLM(ChunkedPrefillPageTableGuardMixin, HybridAttentionForCau
                 batch_size=batch_size,
                 prefill_seq_lens=prefill_seq_lens,
                 can_batch_prefill=can_batch_prefill,
+                empty_slots=kwargs.get("empty_slots"),
             )
         return super().prefill_forward_text(*args, enable_trace=enable_trace, **kwargs)
 

--- a/models/demos/multimodal/gemma3/tt/gemma_multimodal_generator.py
+++ b/models/demos/multimodal/gemma3/tt/gemma_multimodal_generator.py
@@ -29,6 +29,7 @@ from models.tt_transformers.tt.generator import (
     MAX_BATCHED_PREFILL_SEQ_LEN,
     Generator,
     batched_prefill_padded_batch,
+    gather_batched_prefill_samples,
     max_prefill_chunk_size_cutoff,
 )
 
@@ -466,12 +467,14 @@ class GemmaMultimodalGenerator(Generator):
                         if tt_log_probs is not None
                         else None
                     )
-                    # Device rows are physical slots; the returned arrays are in the
-                    # caller's prefill order, so read by slot and write by local_idx.
-                    for local_idx, slot in enumerate(empty_slots):
-                        output_tokens[local_idx] = tokens_host[slot]
-                        if log_probs_host is not None:
-                            output_log_probs[local_idx] = log_probs_host[slot]
+                    gather_batched_prefill_samples(
+                        empty_slots,
+                        tokens_host,
+                        None,
+                        log_probs_host,
+                        output_tokens,
+                        output_log_probs,
+                    )
                 else:
                     for local_idx, slot in enumerate(empty_slots):
                         user_logits = logits[slot : slot + 1, :, :, :]

--- a/models/demos/multimodal/gemma3/tt/gemma_multimodal_generator.py
+++ b/models/demos/multimodal/gemma3/tt/gemma_multimodal_generator.py
@@ -17,13 +17,18 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.common.sampling import SamplingParams, broadcast_sampling_params, format_sampling_params
+from models.common.sampling import (
+    SamplingParams,
+    broadcast_sampling_params,
+    format_sampling_params,
+    scatter_sampling_params_to_slots,
+)
 from models.common.sampling.tt_log_probs import LogProbsResult, reformat_logprobs
 from models.tt_transformers.tt.common import Mode, get_padded_prefill_len
 from models.tt_transformers.tt.generator import (
     MAX_BATCHED_PREFILL_SEQ_LEN,
-    SUPPORTED_PREFILL_BATCH_SIZES,
     Generator,
+    batched_prefill_padded_batch,
     max_prefill_chunk_size_cutoff,
 )
 
@@ -220,10 +225,7 @@ class GemmaMultimodalGenerator(Generator):
                 use_batched_prefill = False
 
         if use_batched_prefill:
-            padded_batch = next(
-                (b for b in SUPPORTED_PREFILL_BATCH_SIZES if b >= batch_size),
-                self.model_args[0].max_batch_size,
-            )
+            padded_batch = batched_prefill_padded_batch(batch_size, empty_slots, self.model_args[0].max_batch_size)
             if padded_batch > self.model_args[0].max_batch_size:
                 logger.info(
                     f"Batched prefill disabled: padded_batch {padded_batch} exceeds "
@@ -399,7 +401,13 @@ class GemmaMultimodalGenerator(Generator):
                     sampling_module, sampling_dp, sampling_batch, _ = self._get_sampling_contract(model_id)
                     assert sampling_module is not None
                     assert sampling_batch is not None
-                    combined_params = format_sampling_params(sampling_params, sampling_batch)
+                    # ``combined_prompt_tokens`` below and the extracted hidden states
+                    # are both laid out by slot, so the params have to be as well.
+                    combined_params = scatter_sampling_params_to_slots(
+                        format_sampling_params(sampling_params, sampling_batch),
+                        empty_slots,
+                        sampling_batch,
+                    )
                     max_prompt_len = max(int(prompt_lens[i]) for i in range(len(empty_slots)))
                     combined_prompt_tokens = torch.zeros(sampling_batch, max_prompt_len, dtype=torch.long)
                     for local_idx, slot in enumerate(empty_slots):
@@ -458,10 +466,12 @@ class GemmaMultimodalGenerator(Generator):
                         if tt_log_probs is not None
                         else None
                     )
+                    # Device rows are physical slots; the returned arrays are in the
+                    # caller's prefill order, so read by slot and write by local_idx.
                     for local_idx, slot in enumerate(empty_slots):
-                        output_tokens[slot] = tokens_host[slot]
+                        output_tokens[local_idx] = tokens_host[slot]
                         if log_probs_host is not None:
-                            output_log_probs[slot] = log_probs_host[slot]
+                            output_log_probs[local_idx] = log_probs_host[slot]
                 else:
                     for local_idx, slot in enumerate(empty_slots):
                         user_logits = logits[slot : slot + 1, :, :, :]
@@ -469,7 +479,7 @@ class GemmaMultimodalGenerator(Generator):
                             user_logits, last_token_idx[slot]
                         )
                         _logits = ttnn.to_layout(_logits, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
-                        output_tensor[slot] = self.model[model_id].process_output_prefill(
+                        output_tensor[local_idx] = self.model[model_id].process_output_prefill(
                             _logits.cpu(), last_token_idx=(last_token_idx[slot] % 32)
                         )
                 break

--- a/models/tt_transformers/tests/test_batched_prefill_slots.py
+++ b/models/tt_transformers/tests/test_batched_prefill_slots.py
@@ -7,10 +7,16 @@
 every slot-indexed buffer the batched path builds (``prefill_ids``,
 ``padded_last_token_idx``, the padded page table) is bounded by ``padded_batch``. vLLM
 hands out the slot a request already owns, so a batch of N requests can land on slots
-above N and the device batch has to span them. Pure index arithmetic, no device.
+above N and the device batch has to span them. The arrays handed back to the caller
+stay in prefill order, so the readback reads by slot and writes by position. Pure host
+index bookkeeping, no device execution.
 """
 
-from models.tt_transformers.tt.generator import batched_prefill_padded_batch
+import torch
+
+from models.common.sampling import SamplingParams, slice_sampling_params
+from models.common.sampling.tt_log_probs import LogProbsResult
+from models.tt_transformers.tt.generator import batched_prefill_padded_batch, gather_batched_prefill_samples
 
 
 def test_dense_slots_keep_todays_batch_shape():
@@ -35,6 +41,82 @@ def test_no_slots_means_the_request_count_is_the_span():
     assert batched_prefill_padded_batch(4, [], 32) == 4
 
 
-def test_a_slot_past_capacity_reports_the_fallback_value():
-    """Over capacity the caller disables batched prefill on the returned value."""
-    assert batched_prefill_padded_batch(2, [40], 32) == 32
+class _SlotTaggedLogProbs(LogProbsResult):
+    """Stands in for a device top-k result: reports which slot it was read from."""
+
+    def __init__(self):
+        super().__init__(topk_logprobs=None, topk_indices=None, topk_logprobs_host=None, topk_indices_host=None)
+
+    def extract_user(self, user_batch_idx: int):
+        return f"slot{int(user_batch_idx)}"
+
+
+def test_samples_come_back_in_prefill_order_not_slot_order():
+    """Read the device row by slot, write the caller's row by position.
+
+    Row i of the device batch holds slot i's sample, so a request on slot 5 has to
+    end up at output row 0 if it prefilled first.
+    """
+    slots = [5, 0, 3]
+    # Device rows: index == slot, so slot 5 sampled token 105, slot 0 token 100, ...
+    tokens_host = torch.tensor([100, 101, 102, 103, 104, 105, 106, 107])
+    plain_log_probs_host = torch.tensor([-0.0, -0.1, -0.2, -0.3, -0.4, -0.5, -0.6, -0.7])
+    output_tokens = torch.zeros(len(slots), 1, dtype=torch.int64)
+    output_log_probs = [None] * len(slots)
+
+    gather_batched_prefill_samples(slots, tokens_host, None, plain_log_probs_host, output_tokens, output_log_probs)
+
+    assert [int(t) for t in output_tokens.reshape(-1)] == [105, 100, 103]
+    assert [round(float(lp), 1) for lp in output_log_probs] == [-0.5, -0.0, -0.3]
+
+
+def test_a_slot_at_the_request_count_does_not_overflow_the_output():
+    """THE CRASH: three requests reaching slot 7 wrote past a 3-row output."""
+    slots = [0, 1, 7]
+    tokens_host = torch.tensor([200, 201, 202, 203, 204, 205, 206, 207])
+    output_tokens = torch.zeros(len(slots), 1, dtype=torch.int64)
+    output_log_probs = [None] * len(slots)
+
+    gather_batched_prefill_samples(slots, tokens_host, None, None, output_tokens, output_log_probs)
+
+    assert [int(t) for t in output_tokens.reshape(-1)] == [200, 201, 207]
+    assert output_log_probs == [None, None, None]
+
+
+def test_topk_logprobs_are_extracted_from_the_slot_row():
+    slots = [4, 1]
+    tokens_host = torch.arange(8)
+    output_tokens = torch.zeros(len(slots), 1, dtype=torch.int64)
+    output_log_probs = [None] * len(slots)
+
+    gather_batched_prefill_samples(slots, tokens_host, _SlotTaggedLogProbs(), None, output_tokens, output_log_probs)
+
+    assert output_log_probs == ["slot4", "slot1"]
+
+
+def test_slice_sampling_params_gives_each_chunk_its_own_requests():
+    """A chunked prefill must not hand every chunk the first N requests' params."""
+    params = SamplingParams(
+        temperature=[0.1, 0.2, 0.3, 0.4], top_k=[1, 2, 3, 4], top_p=[0.5, 0.6, 0.7, 0.8], seed=[11, 12, 13, 14]
+    )
+
+    second = slice_sampling_params(params, 2, 4)
+
+    assert second.temperature == [0.3, 0.4]
+    assert second.top_k == [3, 4]
+    assert second.top_p == [0.7, 0.8]
+    assert second.seed == [13, 14]
+    assert params.temperature == [0.1, 0.2, 0.3, 0.4]
+    assert slice_sampling_params(None, 0, 2) is None
+
+
+def test_a_span_no_bucket_covers_reports_the_span():
+    """The caller's ``> max_batch_size`` guard has to fire and pick sequential prefill.
+
+    Reporting ``max_batch_size`` instead would leave batched prefill enabled and
+    scatter into a row the buffers do not have.
+    """
+    assert batched_prefill_padded_batch(2, [40], 32) == 41
+    assert batched_prefill_padded_batch(2, [40], 32) > 32
+    # A wider model still covers the slot, so batching stays on as it did before.
+    assert batched_prefill_padded_batch(2, [40], 64) == 64

--- a/models/tt_transformers/tests/test_batched_prefill_slots.py
+++ b/models/tt_transformers/tests/test_batched_prefill_slots.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Batched prefill lays its device rows out by physical slot, not by prefill position.
+
+``empty_slots[i]`` is the device slot that owns request ``i``'s per-slot state, and
+every slot-indexed buffer the batched path builds (``prefill_ids``,
+``padded_last_token_idx``, the padded page table) is bounded by ``padded_batch``. vLLM
+hands out the slot a request already owns, so a batch of N requests can land on slots
+above N and the device batch has to span them. Pure index arithmetic, no device.
+"""
+
+from models.tt_transformers.tt.generator import batched_prefill_padded_batch
+
+
+def test_dense_slots_keep_todays_batch_shape():
+    """The common case is unchanged, so existing shapes and traces are reused."""
+    assert batched_prefill_padded_batch(7, list(range(7)), 32) == 8
+    assert batched_prefill_padded_batch(2, [0, 1], 32) == 2
+    assert batched_prefill_padded_batch(32, list(range(32)), 32) == 32
+
+
+def test_batch_spans_the_highest_slot_in_use():
+    """A live off-batch request holding a low slot pushes a prefill onto a high one."""
+    # THE BUG: seven requests whose slots reach 7. The count-based rule returned 8,
+    # which is fine here, but a request on slot 20 got a 1-row batch.
+    assert batched_prefill_padded_batch(7, [0, 1, 2, 3, 4, 5, 7], 32) == 8
+    assert batched_prefill_padded_batch(1, [20], 32) == 32
+    assert batched_prefill_padded_batch(3, [3, 4, 5], 32) == 8
+
+
+def test_no_slots_means_the_request_count_is_the_span():
+    """Callers that omit the slots get ``range(N)``, so N bounds the rows."""
+    assert batched_prefill_padded_batch(4, None, 32) == 4
+    assert batched_prefill_padded_batch(4, [], 32) == 4
+
+
+def test_a_slot_past_capacity_reports_the_fallback_value():
+    """Over capacity the caller disables batched prefill on the returned value."""
+    assert batched_prefill_padded_batch(2, [40], 32) == 32

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -24,6 +24,7 @@ from models.common.sampling import (
     broadcast_sampling_params,
     chunk_sampling_params,
     format_sampling_params,
+    scatter_sampling_params_to_slots,
 )
 from models.common.sampling.tt_log_probs import LogProbsResult, reformat_logprobs
 from models.common.warmup import WarmupForwardMixin
@@ -42,6 +43,23 @@ MAX_BATCHED_PREFILL_SEQ_LEN = 128 * 1024
 
 # Power-of-2 batch sizes supported by trace caching for batched prefill.
 SUPPORTED_PREFILL_BATCH_SIZES = (1, 2, 4, 8, 16, 32)
+
+
+def batched_prefill_padded_batch(batch_size, empty_slots, max_batch_size):
+    """Rows the batched-prefill device batch needs for ``empty_slots``.
+
+    A batched prefill places request ``i`` at device row ``empty_slots[i]``, its
+    physical slot, and every slot-indexed buffer (``prefill_ids``,
+    ``padded_last_token_idx``, the padded page table) is bounded by the returned
+    value. The batch must therefore span the highest slot in use, not just the
+    request count: vLLM hands out the slot that already owns a request's per-slot
+    state, so a batch of N requests can legitimately land on slots above N.
+    """
+    span = batch_size
+    if empty_slots is not None and len(empty_slots) > 0:
+        span = max(span, max(int(s) for s in empty_slots) + 1)
+    return next((b for b in SUPPORTED_PREFILL_BATCH_SIZES if b >= span), max_batch_size)
+
 
 # Position of the page table within the decode input tuple produced by
 # Transformer.prepare_decode_inputs_host: (tokens, current_pos, rope_idxs, page_table).
@@ -677,10 +695,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 use_batched_prefill = False
 
         if use_batched_prefill:
-            padded_batch = next(
-                (b for b in SUPPORTED_PREFILL_BATCH_SIZES if b >= batch_size),
-                self.model_args[0].max_batch_size,
-            )
+            padded_batch = batched_prefill_padded_batch(batch_size, empty_slots, self.model_args[0].max_batch_size)
             if padded_batch > self.model_args[0].max_batch_size:
                 logger.info(
                     f"Batched prefill disabled: padded_batch {padded_batch} exceeds "
@@ -877,7 +892,13 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                         plen = int(prompt_lens[local_idx])
                         combined_prompt_tokens[slot, :plen] = prefill_ids[slot, :plen]
 
-                    combined_params = format_sampling_params(sampling_params, sampling_batch)
+                    # ``combined_prompt_tokens`` above and the extracted hidden states
+                    # are both laid out by slot, so the params have to be as well.
+                    combined_params = scatter_sampling_params_to_slots(
+                        format_sampling_params(sampling_params, sampling_batch),
+                        empty_slots,
+                        sampling_batch,
+                    )
                     sampling_module.apply_prefill_state(
                         sampling_params=combined_params,
                         prompt_tokens=combined_prompt_tokens,
@@ -933,12 +954,14 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                         if tt_log_probs is not None and not isinstance(tt_log_probs, LogProbsResult)
                         else None
                     )
+                    # Device rows are physical slots; the returned arrays are in the
+                    # caller's prefill order, so read by slot and write by local_idx.
                     for local_idx, slot in enumerate(empty_slots):
-                        output_tokens[slot] = tokens_host[slot]
+                        output_tokens[local_idx] = tokens_host[slot]
                         if isinstance(tt_log_probs, LogProbsResult):
-                            output_log_probs[slot] = tt_log_probs.extract_user(slot)
+                            output_log_probs[local_idx] = tt_log_probs.extract_user(slot)
                         elif plain_log_probs_host is not None:
-                            output_log_probs[slot] = plain_log_probs_host[slot]
+                            output_log_probs[local_idx] = plain_log_probs_host[slot]
                 else:
                     if return_hidden_states:
                         # Embedding models: trace returns hidden states; extract last-token hidden per slot
@@ -948,16 +971,16 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                             slot_hidden = self.model[model_id].process_hidden_states_after_prefill_trace(
                                 user_hidden, last_token_idx[slot]
                             )
-                            slot_hidden_list.append((slot, slot_hidden, last_token_idx[slot]))
+                            slot_hidden_list.append((local_idx, slot_hidden, last_token_idx[slot]))
                         ttnn.synchronize_device(self.model[model_id].mesh_device)
                         dim = self.model[model_id].args.dim
-                        for slot, slot_hidden, lt_idx in slot_hidden_list:
+                        for local_idx, slot_hidden, lt_idx in slot_hidden_list:
                             slot_hidden_torch = ttnn.to_torch(ttnn.get_device_tensors(slot_hidden)[0]).float()
                             pos = int(lt_idx % 32)
                             out = slot_hidden_torch[0, 0, pos, :dim].clone()
                             if out.device.type != "cpu":
                                 out = out.cpu()
-                            output_tensor[slot] = out
+                            output_tensor[local_idx] = out
                     else:
                         for local_idx, slot in enumerate(empty_slots):
                             user_logits = logits[slot : slot + 1, :, :, :]
@@ -967,7 +990,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                             _logits = ttnn.to_layout(
                                 _logits, ttnn.ROW_MAJOR_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG
                             )
-                            output_tensor[slot] = self.model[model_id].process_output_prefill(
+                            output_tensor[local_idx] = self.model[model_id].process_output_prefill(
                                 _logits.cpu(), last_token_idx=(last_token_idx[slot] % 32)
                             )
                 break

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -54,11 +54,41 @@ def batched_prefill_padded_batch(batch_size, empty_slots, max_batch_size):
     value. The batch must therefore span the highest slot in use, not just the
     request count: vLLM hands out the slot that already owns a request's per-slot
     state, so a batch of N requests can legitimately land on slots above N.
+
+    A span no bucket covers returns at least the span itself, so the caller's
+    ``padded_batch > max_batch_size`` guard fires and sends the batch down the
+    sequential path. Reporting ``max_batch_size`` there would re-enable the very
+    out-of-bounds slot write this bound exists to prevent.
     """
     span = batch_size
     if empty_slots is not None and len(empty_slots) > 0:
         span = max(span, max(int(s) for s in empty_slots) + 1)
-    return next((b for b in SUPPORTED_PREFILL_BATCH_SIZES if b >= span), max_batch_size)
+    return next((b for b in SUPPORTED_PREFILL_BATCH_SIZES if b >= span), max(span, max_batch_size))
+
+
+def gather_batched_prefill_samples(
+    empty_slots,
+    tokens_host,
+    tt_log_probs,
+    plain_log_probs_host,
+    output_tokens,
+    output_log_probs,
+):
+    """Move a batched prefill's sampled rows back into the caller's prefill order.
+
+    The device sampled row ``empty_slots[i]`` for request ``i`` (batched prefill is
+    laid out by physical slot), while ``output_tokens``/``output_log_probs`` are sized
+    by the request count and returned in prefill order. Read by slot, write by
+    position: indexing the outputs by slot overflows them once a slot reaches the
+    request count, and silently hands one request another's token before that.
+    """
+    for local_idx, slot in enumerate(empty_slots):
+        slot = int(slot)
+        output_tokens[local_idx] = tokens_host[slot]
+        if isinstance(tt_log_probs, LogProbsResult):
+            output_log_probs[local_idx] = tt_log_probs.extract_user(slot)
+        elif plain_log_probs_host is not None:
+            output_log_probs[local_idx] = plain_log_probs_host[slot]
 
 
 # Position of the page table within the decode input tuple produced by
@@ -954,14 +984,14 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                         if tt_log_probs is not None and not isinstance(tt_log_probs, LogProbsResult)
                         else None
                     )
-                    # Device rows are physical slots; the returned arrays are in the
-                    # caller's prefill order, so read by slot and write by local_idx.
-                    for local_idx, slot in enumerate(empty_slots):
-                        output_tokens[local_idx] = tokens_host[slot]
-                        if isinstance(tt_log_probs, LogProbsResult):
-                            output_log_probs[local_idx] = tt_log_probs.extract_user(slot)
-                        elif plain_log_probs_host is not None:
-                            output_log_probs[local_idx] = plain_log_probs_host[slot]
+                    gather_batched_prefill_samples(
+                        empty_slots,
+                        tokens_host,
+                        tt_log_probs,
+                        plain_log_probs_host,
+                        output_tokens,
+                        output_log_probs,
+                    )
                 else:
                     if return_hidden_states:
                         # Embedding models: trace returns hidden states; extract last-token hidden per slot


### PR DESCRIPTION
### Ticket

None. Found while porting [tenstorrent/vllm#454](https://github.com/tenstorrent/vllm/pull/454) into the standalone plugin ([tenstorrent/vllm-tt-plugin#33](https://github.com/tenstorrent/vllm-tt-plugin/pull/33)), which is the first caller to hand tt-metal non-identity prefill slots. That branch fails `vllm-tests / Llama-3.1-8B-Instruct DP=4 [wh_galaxy_perf]` on this bug ([run 31467940142](https://github.com/tenstorrent/tt-metal/actions/runs/31467940142/job/93710695971)); the same job is green on plugin `main` ([run 31137103537](https://github.com/tenstorrent/tt-metal/actions/runs/31137103537)).

### Problem description

Batched prefill mixes two index spaces:

- **prefill order** `local_idx` in `[0, N)`: the caller's batch. `tokens`, `prompt_lens`, `page_table` and the returned `output_tokens` / `output_log_probs` / `output_tensor` all live here.
- **physical slot** `slot = empty_slots[local_idx]`: the device row that owns the request's per-slot state (seed RNG, recurrent/conv state, row-sharded user id).

They coincide only when `empty_slots == range(N)`, which was always true until now: `empty_slots` was either omitted, so `prefill_forward_text` defaulted it to `list(range(batch_size))`, or supplied dense. Three consequences once a caller supplies real slots:

**1. The readback writes at the slot.** `output_tokens = torch.zeros(batch_size, 1)` is sized by the request count and returned in prefill order (the sequential path writes `output_tokens[idx]`), but the batched path wrote `output_tokens[slot]`. A slot at or above `batch_size` raises `IndexError: index 7 is out of bounds for dimension 0 with size 7`. Worse, an in-range non-identity slot does **not** raise: it hands one request another request's token, silently.

**2. The slot-indexed buffers are bounded by the request count.** `padded_batch` came from `next(b for b in SUPPORTED_PREFILL_BATCH_SIZES if b >= batch_size)`, yet `prefill_ids[slot]`, `padded_last_token_idx[slot]` and `_get_prefill_user_page_table`'s `padded_page_table[user]` are all scattered by slot and bounded by it. One request on slot 20 gives `padded_batch = 1` and dies in the scatter.

**3. Sampling params arrive in prefill order.** `format_sampling_params` pads the caller's prefill-ordered params, and `TTSampling.reset_params` writes `k`/`p`/`temp` to device rows positionally (it consumes `empty_slots` only for the logprobs calculator). The rows those params configure are slot-indexed, as `combined_prompt_tokens[slot]` in the same block and `extract_last_tokens_batched_prefill` (row identity preserved into the sampling batch) both show. So request X's logits were sampled with whichever request's temperature/top_k/top_p/penalties sat at that list index.

### What's changed

- **`models/tt_transformers/tt/generator.py`**: new `batched_prefill_padded_batch(batch_size, empty_slots, max_batch_size)` spans the highest slot in use; the three batched readback loops write at `local_idx` and read at `slot`; the batched sampling params are scattered to slot rows.
- **`models/common/sampling/generator.py`**: new `scatter_sampling_params_to_slots`, exported from `models.common.sampling`. `seed` is deliberately left in prefill order because `SeedManager.reset_seed` takes the slot list separately and maps it itself. Unoccupied rows inherit the last real request's values rather than formatter padding, matching the inline helper `llama3_70b_galaxy` already uses.
- **`models/demos/multimodal/gemma3/tt/gemma_multimodal_generator.py`**: same three fixes; this file carries its own copy of the batched path.
- **`models/demos/gemma4/tt/generator.py`**, **`generator_trace.py`**, **`generator_vllm.py`**: use the shared sizing rule so the chunking decision and the trace policy match the `padded_batch` that actually runs, and thread `empty_slots` into `resolve_gemma4_prefill_trace_enable`. The chunked path also stopped renumbering its chunk to `range(chunk_size)`, which wrote each chunk's per-slot state over slots other requests own.
- Tests: `models/tt_transformers/tests/test_batched_prefill_slots.py` (new, host-only) and two cases in `models/common/tests/test_sampling.py`.

**Dense slots return exactly what they did before**, so the common case keeps today's shapes, traces and performance.

### Deliberately not changed

`models/demos/llama3_70b_galaxy/tt/generator.py` and `models/common/models/executor.py` (plus its `llama32_1b_quasar` copy) are already correct and were used as the reference. Galaxy 70B gathers with `tt_tok_tensor[empty_slots]` and sizes `slot_output_tokens` to `max_batch`; the TTTv2 executor keeps device rows local (`row i = that user's physical blocks`) so the two spaces never meet. Galaxy 70B's inline `_scatter_params_to_slots` duplicates the new shared helper and could be de-duplicated later; I left it alone rather than refactor working code in a bug fix.

### Known cost

Widening `padded_batch` to span the slots is the minimal fix for a design where the device row *is* the physical slot, which is what the sampling module requires. When slots are scattered, `padded_batch` grows and can cross the `MAX_BATCHED_PREFILL_SEQ_LEN` ceiling, at which point batched prefill disables itself and the correct sequential per-user path runs. Correct, sometimes slower. The alternative that keeps both is the TTTv2 executor's shape: compact device rows plus an explicit slot scatter of only the per-slot state. That needs an audit of every consumer of the device row inside `prefill_forward_single_user_text`, so it does not belong in the unblocking change.

### Review follow-up (828b80d)

All three Copilot findings plus the suppressed one were real and are fixed:

- An over-capacity span reported `max_batch_size`, slipping past the caller's `padded_batch > max_batch_size` guard and re-enabling the out-of-bounds slot write. It now reports the span.
- Gemma4's chunked path handed every chunk the whole prefill-ordered `sampling_params`, so chunks after the first sampled with the first chunk's settings. New `slice_sampling_params` in `models/common/sampling/generator.py`. This one predates this PR: the old `empty_slots=list(range(chunk_size))` made the child read rows `0..chunk_size-1` and pick up the batch's first `chunk_size` params.
- That chunk's trace policy weighed `chunk_size` rather than the rows its slots need, which could capture a trace whose real token count is past the documented OOM-risk limit. It now uses `batched_prefill_padded_batch(chunk_size, chunk_slots, max_batch_size)`.
- The sampled readback moved into `gather_batched_prefill_samples`, shared with the Gemma3 copy, so the primary fix is covered by host tests. Verified by mutation on a Galaxy host: restoring `output_tokens[slot]` fails 3 of 8 tests; reverting the padded-batch fallback fails 1 of 8.

Still uncovered, deliberately: the `output_tensor[local_idx]` writes on the hidden-states and logits paths interleave per-row device calls and stay one-line index fixes; and the Gemma4 chunk call site is not exercised by a test (reverting it to the full `sampling_params` still passes, since only `slice_sampling_params` is unit-tested), because driving the chunking needs a real model.

### Checklist

- [x] New/existing tests pass on a Wormhole Galaxy host (`g10glx02`): 8 new `test_batched_prefill_slots.py` cases and 2 new `test_sampling.py` cases pass, alongside the 6 pre-existing host-side `test_sampling.py` cases. Every touched module imports cleanly.
- [x] vLLM tests with [vllm-tt-plugin#33](https://github.com/tenstorrent/vllm-tt-plugin/pull/33): https://github.com/tenstorrent/tt-metal/actions/runs/31479124493/job/93743930643
- [x] `pre-commit` clean.
- [x] Tier1 models E2E (to check for new breakages): https://github.com/tenstorrent/tt-metal/actions/runs/31493494417 (all failures seem unrelated - infra, timeouts)
