### PR TITLE
[tt-train] Add Megatron sequence parallelism

### DIFF
--- a/tt-train/configs/README.md
+++ b/tt-train/configs/README.md
@@ -81,11 +81,13 @@ Device mesh and distributed training configuration.
 |-----------|------|---------|-------------|
 | `enable_ddp` | bool | false | Enable Distributed Data Parallelism |
 | `enable_tp` | bool | false | Enable Tensor Parallelism |
+| `enable_sp` | bool | false | Megatron sequence parallelism on top of TP: the residual stream is sharded along the sequence across the TP axis. Requires `enable_tp`; Llama only |
 
 ### Constraints
 - DDP and TP can be combined on a 2D mesh (e.g. `mesh_shape: [4, 8]` with `enable_ddp: true` and `enable_tp: true`)
 - For DDP: batch_size must be divisible by number of DDP devices
 - For TP: vocab_size is automatically rounded up to be divisible by (num_devices * 32)
+- For SP: the sequence length must be divisible by (TP devices * 32)
 
 ### Device Mesh Shapes
 - Single-device (N150, P150): [1, 1]

--- a/tt-train/configs/model_configs/llama8b.yaml
+++ b/tt-train/configs/model_configs/llama8b.yaml
@@ -7,6 +7,7 @@ transformer_config:
   dropout_prob: 0.0
   num_blocks: 32
   vocab_size: 128256
+  embedding_placement: "vocab_parallel"
   weight_tying: "disabled"
   max_sequence_length: 2048
   runner_type: default

--- a/tt-train/configs/model_configs/llama8b.yaml
+++ b/tt-train/configs/model_configs/llama8b.yaml
@@ -7,7 +7,6 @@ transformer_config:
   dropout_prob: 0.0
   num_blocks: 32
   vocab_size: 128256
-  embedding_placement: "vocab_parallel"
   weight_tying: "disabled"
   max_sequence_length: 2048
   runner_type: default

--- a/tt-train/configs/training_configs/training_llama8b_tp4.yaml
+++ b/tt-train/configs/training_configs/training_llama8b_tp4.yaml
@@ -22,6 +22,7 @@ training_config:
 
 device_config:
   enable_tp: true
+  enable_sp: true
   enable_ddp: false
   mesh_shape: [1, 4]  # mirrors MGD device_topology [1, 4]; axis 1 = tp (size 4)
 

--- a/tt-train/configs/training_configs/training_llama8b_tp4_sp.yaml
+++ b/tt-train/configs/training_configs/training_llama8b_tp4_sp.yaml
@@ -1,6 +1,7 @@
 # MGD: tt-train/configs/mgd/bh_qb_1_4_ring_ring.textproto (Blackhole QuietBox, device_topology [1, 4])
+# training_llama8b_tp4.yaml plus Megatron sequence parallelism on the tp axis.
 training_config:
-  project_name: "tt_train_llama8b_tp4"
+  project_name: "tt_train_llama8b_tp4_sp"
   seed: 5489
   batch_size: 1
   gradient_accumulation_steps: 4
@@ -22,6 +23,7 @@ training_config:
 
 device_config:
   enable_tp: true
+  enable_sp: true
   enable_ddp: false
   mesh_shape: [1, 4]  # mirrors MGD device_topology [1, 4]; axis 1 = tp (size 4)
 

--- a/tt-train/docs/DISTRIBUTED_TRAINING.md
+++ b/tt-train/docs/DISTRIBUTED_TRAINING.md
@@ -475,6 +475,7 @@ device_config:
 In the device config, you can specify which parallelism strategies to use:
 
 - **`enable_tp`**: Enable tensor parallelism (shard model parameters)
+- **`enable_sp`**: Enable Megatron sequence parallelism on top of TP (norms, dropout and residual adds run on a sequence-sharded stream; requires `enable_tp`, Llama only)
 - **`enable_ddp`**: Enable data parallelism (replicate model, shard data)
 - **`enable_pp`**: Enable pipeline parallelism (shard layers sequentially)
 - **`enable_cp`**: Enable context parallelism (shard input along sequence dimension)

--- a/tt-train/docs/FSDP.md
+++ b/tt-train/docs/FSDP.md
@@ -75,7 +75,7 @@ logits = model(input_tokens, mask)
 loss = ttml.ops.loss.cross_entropy_loss(logits, targets, reduce=ttml.ops.ReduceType.MEAN)
 loss.backward(False)
 
-ttml.sync_gradients(model.parameters())  # no-op on a pure-FSDP mesh
+ttml.sync_gradients(model.parameters())  # managed params are already reduce-scattered; averages only unsharded ones
 optimizer.step()
 ```
 
@@ -231,10 +231,9 @@ host-roundtrip:
 
 ### Gradient sync
 
-`ttml.sync_gradients(model.parameters(), axis_names=("dp",))` continues to
-work exactly like in DDP. For pure-FSDP runs (no `"dp"` axis on the mesh)
-it is a no-op: gradients have already been reduce-scattered in
-`backward_post`. For a hybrid mesh (`"fsdp"` and `"dp"`), each parameter
+`ttml.sync_gradients(model.parameters())` continues to work exactly like in
+DDP. For pure-FSDP runs it leaves FSDP-managed parameters alone: their
+gradients have already been reduce-scattered in `backward_post`. For a hybrid mesh (`"fsdp"` and `"dp"`), each parameter
 is filtered per-axis: FSDP-sharded params skip the `"fsdp"` axis (already
 reduce-scattered) but still all-reduce on the `"dp"` axis (replicated
 across DP groups). The same call covers both cases, no rewrites needed.
@@ -296,7 +295,7 @@ In this layout:
 - During backward:
   - The FSDP backward-post hook reduce-scatters grads across the
     `"fsdp"` axis (size F) — same as pure FSDP.
-  - `ttml.sync_gradients(params, axis_names=("dp", "fsdp"))` then runs
+  - `ttml.sync_gradients(params)` then runs
     a per-param filter: FSDP-managed grads skip the `"fsdp"` axis
     (already reduce-scattered) but all-reduce across `"dp"` to average
     each shard over DP replicas. Any non-FSDP / replicated parameter
@@ -335,7 +334,7 @@ In this layout:
   outside the training loop.
 - **`ttml.fsdp.is_fsdp_managed(param.tensor)`** returns `True` for any
   parameter `fully_shard` has touched. The marker is what
-  `sync_gradients` uses to decide which axes to skip per parameter.
+  `average_gradients` uses to decide which axes to skip per parameter.
 
 ---
 

--- a/tt-train/sources/examples/grpo/GRPO_TRAINER.md
+++ b/tt-train/sources/examples/grpo/GRPO_TRAINER.md
@@ -430,7 +430,7 @@ When the completer opens a named mesh with an `"fsdp"` axis (size > 1), the
    `per_device_train_batch_size` landing on each device.
    `per_device_train_batch_size * num_devices` must be divisible by
    `num_generations` so each prompt's GRPO group stays intact within the batch.
-2. Synchronizes gradients with `ttml.sync_gradients(params, axis_names=("dp", "fsdp"))`
+2. Synchronizes gradients with `ttml.sync_gradients(params)`
    each optimizer step. FSDP-managed parameters skip the `"fsdp"` axis (their
    gradients were already reduce-scattered by the FSDP backward hook); any
    replicated parameter is all-reduced across the axis.

--- a/tt-train/sources/examples/lora_llama/train_lora_llama.py
+++ b/tt-train/sources/examples/lora_llama/train_lora_llama.py
@@ -30,6 +30,7 @@ from ttml.models.llama import (
     LlamaRopeScalingConfig,
     load_from_safetensors,
 )
+from ttml.parallel import TPStrategy
 from ttml.modules import LoraConfig, LoraModel
 
 MemoryUsageTracker = ttml.core.utils.MemoryUsageTracker
@@ -87,7 +88,7 @@ def llama_config_from_yaml(yaml_config: dict, vocab_size: int, use_tp: bool = Fa
         runner_type=runner_type,
         weight_tying=weight_tying,
         rope_scaling=rope_scaling,
-        use_tp=use_tp,
+        tp_strategy=TPStrategy.from_flags(use_tp),
     )
 
 
@@ -292,7 +293,7 @@ def main():
             vocab_size=vocab_size,
             max_position_embeddings=256,
             rope_theta=500000.0,
-            use_tp=use_tp,
+            tp_strategy=TPStrategy.from_flags(use_tp),
         )
 
     seq_len = llama_cfg.max_position_embeddings

--- a/tt-train/sources/examples/lora_llama/train_lora_llama_sft.py
+++ b/tt-train/sources/examples/lora_llama/train_lora_llama_sft.py
@@ -27,6 +27,7 @@ from ttml.models.llama import (
     LlamaRopeScalingConfig,
     load_from_safetensors,
 )
+from ttml.parallel import TPStrategy
 from ttml.modules import LoraConfig
 from ttml.trainers import SFTConfig, SFTTrainer, TrainerCallback
 
@@ -128,7 +129,7 @@ def llama_config_from_yaml(yaml_config: dict, vocab_size: int, use_tp: bool = Fa
         runner_type=runner_type,
         weight_tying=weight_tying,
         rope_scaling=rope_scaling,
-        use_tp=use_tp,
+        tp_strategy=TPStrategy.from_flags(use_tp),
     )
 
 
@@ -296,7 +297,7 @@ def main():
             vocab_size=vocab_size,
             max_position_embeddings=256,
             rope_theta=500000.0,
-            use_tp=use_tp,
+            tp_strategy=TPStrategy.from_flags(use_tp),
         )
 
     seq_len = llama_cfg.max_position_embeddings

--- a/tt-train/sources/examples/train/checkpointing.py
+++ b/tt-train/sources/examples/train/checkpointing.py
@@ -109,7 +109,7 @@ def load_for_inference(
     """Restore `(model, tokenizer, model_cfg, step)` from a checkpoint. Used to seed inference mode."""
     header = read_header(path)
     model_cfg: ModelConfig = header["model_config"]
-    model = create_model(model_cfg, use_tp=False)
+    model = create_model(model_cfg)  # inference: no tensor parallelism (TPStrategy.NONE)
     load_checkpoint(path, model_params=model.parameters())  # "optimizer" group present in the file is skipped
     return model, header["tokenizer"], model_cfg, int(header["step"])
 

--- a/tt-train/sources/examples/train/model_builders.py
+++ b/tt-train/sources/examples/train/model_builders.py
@@ -14,6 +14,7 @@ from ttml.common.utils import round_up_to_tile
 from ttml.models.deepseek import DeepSeek, DeepSeekConfig
 from ttml.models.deepseek.flops import calculate_flops_per_token as _deepseek_flops
 from ttml.models.llama import Llama, LlamaConfig, LlamaRopeScalingConfig
+from ttml.parallel import TPStrategy
 from ttml.models.llama.flops import calculate_flops_per_token as _llama_flops
 from ttml.models.nanogpt import NanoGPT, NanoGPTConfig, NanoGPTExperimentalConfig, create_nanogpt
 from ttml.models.nanogpt.flops import calculate_flops_per_token as _gpt2_flops
@@ -142,8 +143,8 @@ def _parse_gpt2(tc: dict) -> GPT2Spec:
     return spec
 
 
-def _build_gpt2(cfg: ModelConfig, use_tp: bool) -> Model:
-    if use_tp:
+def _build_gpt2(cfg: ModelConfig, tp_strategy: TPStrategy) -> Model:
+    if tp_strategy.tensor_parallel:
         raise ValueError("model_type=gpt2 has no TP path; use model_type=llama for DP+TP")
     assert isinstance(cfg.spec, GPT2Spec)
     spec = cfg.spec
@@ -181,7 +182,7 @@ def _parse_llama(tc: dict) -> LlamaSpec:
     return spec
 
 
-def _build_llama(cfg: ModelConfig, use_tp: bool) -> Model:
+def _build_llama(cfg: ModelConfig, tp_strategy: TPStrategy) -> Model:
     assert isinstance(cfg.spec, LlamaSpec)
     spec = cfg.spec
     if spec.num_groups <= 0:
@@ -208,7 +209,7 @@ def _build_llama(cfg: ModelConfig, use_tp: bool) -> Model:
                 low_freq_factor=spec.low_freq_factor,
                 original_context_length=spec.original_context_length,
             ),
-            use_tp=use_tp,
+            tp_strategy=tp_strategy,
             embedding_placement=spec.embedding_placement,
         )
     )
@@ -244,10 +245,11 @@ def _parse_deepseek(tc: dict) -> DeepSeekSpec:
 _MOE_TYPES = ("dense", "sparse_ep")
 
 
-def _build_deepseek(cfg: ModelConfig, use_tp: bool) -> Model:
+def _build_deepseek(cfg: ModelConfig, tp_strategy: TPStrategy) -> Model:
     # DeepSeek integrates with the named-mesh TP path (MLA, dense MLP, LM head, and — under
     # full-model TP — sparse MoE all shard across the "tp" axis). moe_type selects the MoE FFN
     # variant; sparse_ep additionally partitions experts across a mesh axis.
+    use_tp = tp_strategy.tensor_parallel
     assert isinstance(cfg.spec, DeepSeekSpec)
     spec = cfg.spec
     if spec.moe_type not in _MOE_TYPES:
@@ -309,8 +311,8 @@ def _parse_qwen3(tc: dict) -> Qwen3Spec:
     return spec
 
 
-def _build_qwen3(cfg: ModelConfig, use_tp: bool) -> Model:
-    if use_tp:
+def _build_qwen3(cfg: ModelConfig, tp_strategy: TPStrategy) -> Model:
+    if tp_strategy.tensor_parallel:
         raise ValueError("model_type=qwen3 has no TP path; use model_type=llama for DP+TP")
     assert isinstance(cfg.spec, Qwen3Spec)
     spec = cfg.spec
@@ -343,12 +345,12 @@ def _build_qwen3(cfg: ModelConfig, use_tp: bool) -> Model:
 
 
 ParseFn = Callable[[dict], ModelSpec]
-BuildFn = Callable[[ModelConfig, bool], Model]
+BuildFn = Callable[[ModelConfig, TPStrategy], Model]
 
 
 class ModelAdapter(NamedTuple):
-    # parse builds a spec from YAML; build consumes `cfg` + `cfg.spec`
-    # and returns the constructed model.
+    # parse builds a spec from YAML; build consumes `cfg` + `cfg.spec` + the
+    # tensor-parallel strategy and returns the model.
     parse: ParseFn
     build: BuildFn
 
@@ -387,19 +389,23 @@ def parse_model_config(yaml_config: dict) -> ModelConfig:
     return cfg
 
 
-def create_model(cfg: ModelConfig, use_tp: bool = False) -> Model:
+def create_model(cfg: ModelConfig, tp_strategy: TPStrategy = TPStrategy.NONE) -> Model:
     """Dispatch on `cfg.model_type` to the registered builder.
 
     `cfg.vocab_size` is the raw (unpadded) vocab; each builder tile-pads it to a 32-multiple
     for the model, since the embedding/LM-head weights must be tile-aligned.
+
+    ``tp_strategy`` selects tensor / sequence parallelism (llama only; see ``TPStrategy``).
     """
     adapter = MODEL_ADAPTERS.get(cfg.model_type)
     if adapter is None:
         raise ValueError(f"Unsupported model type: {cfg.model_type}")
-    return adapter.build(cfg, use_tp)
+    return adapter.build(cfg, tp_strategy)
 
 
-def instantiate_model_from_config(cfg: ModelConfig, lazy_init: bool, *, use_tp: bool = False) -> Model:
+def instantiate_model_from_config(
+    cfg: ModelConfig, lazy_init: bool, *, tp_strategy: TPStrategy = TPStrategy.NONE
+) -> Model:
     """Create the model, deferring Parameter allocation when ``lazy_init`` is True.
 
     With ``lazy_init`` the returned model holds ``TensorMetadata`` for every parameter; the caller
@@ -409,5 +415,5 @@ def instantiate_model_from_config(cfg: ModelConfig, lazy_init: bool, *, use_tp: 
     """
     if lazy_init:
         with ttml.lazy_init():
-            return create_model(cfg, use_tp=use_tp)
-    return create_model(cfg, use_tp=use_tp)
+            return create_model(cfg, tp_strategy=tp_strategy)
+    return create_model(cfg, tp_strategy=tp_strategy)

--- a/tt-train/sources/examples/train/model_builders.py
+++ b/tt-train/sources/examples/train/model_builders.py
@@ -249,6 +249,8 @@ def _build_deepseek(cfg: ModelConfig, tp_strategy: TPStrategy) -> Model:
     # DeepSeek integrates with the named-mesh TP path (MLA, dense MLP, LM head, and — under
     # full-model TP — sparse MoE all shard across the "tp" axis). moe_type selects the MoE FFN
     # variant; sparse_ep additionally partitions experts across a mesh axis.
+    if tp_strategy.sequence_parallel:
+        raise ValueError("model_type=deepseek has no sequence-parallel path; enable_sp needs model_type=llama")
     use_tp = tp_strategy.tensor_parallel
     assert isinstance(cfg.spec, DeepSeekSpec)
     spec = cfg.spec

--- a/tt-train/sources/examples/train/train.py
+++ b/tt-train/sources/examples/train/train.py
@@ -421,11 +421,12 @@ def run_training(
     if tokenizer is not None:
         model_cfg.vocab_size = tokenizer.vocab_size
 
+    # from_flags rejects enable_sp without enable_tp (sequence parallelism rides the tp axis).
+    tp_strategy = TPStrategy.from_flags(device_cfg.enable_tp, enable_sp=device_cfg.enable_sp)
+
     # Lazy alloc only helps when sharding, so default it on under FSDP (--no-lazy to disable).
     lazy_init = device_cfg.enable_fsdp and not args.no_lazy
     print("Building model...", flush=True)
-    tp_strategy = TPStrategy.from_flags(device_cfg.enable_tp)
-
     model = instantiate_model_from_config(model_cfg, lazy_init=lazy_init, tp_strategy=tp_strategy)
 
     flops_per_token = 0
@@ -526,6 +527,7 @@ def run_training(
         checkpoint_prefix=args.checkpoint_prefix,
         max_grad_norm=(training_cfg.clip_grad_norm_max_norm if training_cfg.use_clip_grad_norm else 0.0),
         disable_progress_bar=True,
+        sequence_parallel=tp_strategy.sequence_parallel,
     )
 
     def _causal_lm_loss(logits, batch):

--- a/tt-train/sources/examples/train/train.py
+++ b/tt-train/sources/examples/train/train.py
@@ -62,6 +62,7 @@ from model_builders import (
     instantiate_model_from_config,
     parse_model_config,
 )
+from ttml.parallel import TPStrategy
 from callbacks import (
     AverageLossCallback,
     MemoryTrackerCallback,
@@ -423,7 +424,9 @@ def run_training(
     # Lazy alloc only helps when sharding, so default it on under FSDP (--no-lazy to disable).
     lazy_init = device_cfg.enable_fsdp and not args.no_lazy
     print("Building model...", flush=True)
-    model = instantiate_model_from_config(model_cfg, lazy_init=lazy_init, use_tp=device_cfg.enable_tp)
+    tp_strategy = TPStrategy.from_flags(device_cfg.enable_tp)
+
+    model = instantiate_model_from_config(model_cfg, lazy_init=lazy_init, tp_strategy=tp_strategy)
 
     flops_per_token = 0
     flops_fn = FLOPS_REGISTRY.get(model_cfg.model_type)

--- a/tt-train/sources/examples/train/train.py
+++ b/tt-train/sources/examples/train/train.py
@@ -527,7 +527,6 @@ def run_training(
         checkpoint_prefix=args.checkpoint_prefix,
         max_grad_norm=(training_cfg.clip_grad_norm_max_norm if training_cfg.use_clip_grad_norm else 0.0),
         disable_progress_bar=True,
-        sequence_parallel=tp_strategy.sequence_parallel,
     )
 
     def _causal_lm_loss(logits, batch):

--- a/tt-train/sources/ttml/ops/distributed/comm_ops.cpp
+++ b/tt-train/sources/ttml/ops/distributed/comm_ops.cpp
@@ -7,7 +7,6 @@
 #include "autograd/auto_context.hpp"
 #include "autograd/graph.hpp"
 #include "autograd/graph_utils.hpp"
-#include "ttnn/operations/eltwise/binary/binary.hpp"
 #include "ttnn_fixed/distributed/ttnn_ops.hpp"
 
 namespace ttml::ops::distributed {
@@ -27,16 +26,7 @@ autograd::TensorPtr reduce_scatter(
 
 autograd::TensorPtr scatter(
     const autograd::TensorPtr& tensor, const int dim, const std::optional<uint32_t> cluster_axis) {
-    auto* device = &autograd::ctx().get_device();
-    auto mesh_shape = device->shape();
-    uint32_t tp_size =
-        cluster_axis.has_value() ? mesh_shape[cluster_axis.value()] : static_cast<uint32_t>(device->num_devices());
-
-    auto scattered = ttnn_fixed::distributed::reduce_scatter(tensor->get_value(), dim, cluster_axis);
-    /* average across TP as input is assumed to be replicated across TP axis*/
-    auto out = autograd::create_tensor(ttnn::multiply(scattered, 1.F / static_cast<float>(tp_size)));
-
-    /* input is replicated across TP axis, so d(nx/n) / dx = dx / dx = 1 for i=0,1,...,n and 0 otherwise */
+    auto out = autograd::create_tensor(ttnn_fixed::distributed::mesh_partition(tensor->get_value(), dim, cluster_axis));
     autograd::GradFunction grad = [tensor, out, dim, cluster_axis]() {
         if (out->is_grad_initialized()) {
             tensor->add_grad(ttnn_fixed::distributed::all_gather(out->get_grad(), dim, cluster_axis));

--- a/tt-train/sources/ttml/ttml/__init__.py
+++ b/tt-train/sources/ttml/ttml/__init__.py
@@ -54,6 +54,8 @@ from . import fsdp
 
 from .sharding import Sharding
 
+from .parallel import TPStrategy
+
 
 def manual_seed(seed: int) -> None:
     """Seed all of ttml's RNGs from a single call."""

--- a/tt-train/sources/ttml/ttml/__init__.py
+++ b/tt-train/sources/ttml/ttml/__init__.py
@@ -48,7 +48,15 @@ sys.modules[f"{__name__}.core"] = core
 optimizers = _ttml.optimizers
 sys.modules[f"{__name__}.optimizers"] = optimizers
 
-from ._mesh import Mesh, open_device_mesh, close_device_mesh, maybe_mesh, mesh, sync_gradients
+from ._mesh import (
+    Mesh,
+    open_device_mesh,
+    close_device_mesh,
+    maybe_mesh,
+    mesh,
+    sync_gradients,
+    sync_sequence_parallel_gradients,
+)
 
 from . import fsdp
 

--- a/tt-train/sources/ttml/ttml/__init__.py
+++ b/tt-train/sources/ttml/ttml/__init__.py
@@ -55,7 +55,8 @@ from ._mesh import (
     maybe_mesh,
     mesh,
     sync_gradients,
-    sync_sequence_parallel_gradients,
+    average_gradients,
+    sum_sp_gradients,
 )
 
 from . import fsdp

--- a/tt-train/sources/ttml/ttml/_mesh.py
+++ b/tt-train/sources/ttml/ttml/_mesh.py
@@ -288,3 +288,56 @@ def _param_is_fsdp_sharded(param, axis_index: int) -> bool:
     if getattr(param, "_fsdp_managed", False) and getattr(param, "_fsdp_axis", None) == axis_index:
         return True
     return False
+
+
+def _param_is_sharded_on_axis(param, axis_index: int, name: str) -> bool:
+    """True if ``param`` is Shard (not Replicate) on the given mesh axis.
+
+    Raises when the topology could not be read.
+    """
+    sharding = ttml.Sharding.from_tensor(param)
+    placements = sharding.placements
+    if placements is None:
+        raise RuntimeError(
+            f"{name}: could not read mesh placements; cannot tell whether it is sharded."
+        ) from sharding.read_error
+    if axis_index >= len(placements):
+        return False  # short placements == fully replicated, not unknown
+    return isinstance(placements[axis_index], ttnn.PlacementShard)
+
+
+def sync_sequence_parallel_gradients(parameters, axis_name: str = "tp"):
+    """Sum the gradients of TP-replicated parameters across the tensor-parallel axis.
+
+    Under Megatron sequence parallelism the residual stream is sharded along the
+    sequence across ``axis_name`` (the TP axis), so a parameter that is *replicated*
+    on that axis -- the RMSNorm ``gamma`` weights, and any bias added in a
+    sequence-sharded region -- only accumulates the gradient from its rank's slice of
+    the sequence. The full gradient is the SUM over ranks, so we all-reduce with **no
+    averaging** (unlike :func:`sync_gradients`, which means-reduces over the data
+    axes). TP-*sharded* parameters are skipped: each rank already holds the correct grad
+    for its shard.
+
+    Orthogonal to :func:`sync_gradients` (dp/fsdp): the reductions are over disjoint
+    axes and commute, so both may be called. No-op when ``axis_name`` has size 1.
+
+    Args:
+        parameters: A ``NamedParameters`` mapping (e.g. ``model.parameters()``).
+        axis_name: The tensor-parallel mesh axis name (default ``"tp"``).
+
+    Raises:
+        RuntimeError: if a parameter reports no placement on the axis -- neither
+            choice is safe to assume. See :func:`_param_is_sharded_on_axis`.
+    """
+    m = maybe_mesh()
+    if m is None or not m.has_axis(axis_name) or m.axis_size(axis_name) == 1:
+        return
+    axis = m.axis_index(axis_name)
+
+    for name, param in parameters.items():
+        if not param.is_grad_initialized():
+            continue
+        if _param_is_sharded_on_axis(param, axis, name):
+            continue
+        # SUM across TP (no division): reconstruct the full-sequence gradient.
+        param.set_grad(ttml.core.distributed.all_reduce(param.get_grad(), cluster_axis=axis))

--- a/tt-train/sources/ttml/ttml/_mesh.py
+++ b/tt-train/sources/ttml/ttml/_mesh.py
@@ -6,6 +6,7 @@ import functools, operator, os, re
 from typing import Iterable
 import ttnn
 import ttml
+from .parallel import is_sequence_parallel
 
 
 def prod(x: Iterable[int]) -> int:
@@ -231,20 +232,18 @@ def mesh() -> Mesh:
     return _mesh
 
 
-def sync_gradients(parameters, axis_names: tuple[str, ...] = ("dp",)):
+def sync_gradients(parameters):
+    """Turn each device's local gradient into the global one; call once per step."""
+    average_gradients(parameters, axis_names=("dp", "fsdp"))
+    sum_sp_gradients(parameters, axis_name="tp")
+
+
+def average_gradients(parameters, axis_names: tuple[str, ...]):
     """Average parameter gradients across one or more mesh axes.
 
-    For each parameter with an initialized gradient, the grad is all-reduced
-    (summed) across every axis in ``axis_names`` and then divided by the
-    product of those axis sizes, leaving each device with the mean grad.
-
     Axes listed in ``axis_names`` but not present on the active mesh are
-    silently skipped — if none are present (or ``axis_names`` is empty, or
-    no mesh is open), the function is a no-op. The default ``("dp",)``
-    matches the common DDP case. TP is intentionally excluded: sharded
-    parameters already hold per-shard-correct grads, and replicated
-    parameters see identical inputs on every TP rank so their grads match
-    without a reduce.
+    silently skipped. If none are present (or ``axis_names`` is empty, or
+    no mesh is open), the function is a no-op.
 
     FSDP interaction: parameters sharded by ``ttml.fsdp.fully_shard`` on a
     mesh axis listed in ``axis_names`` are skipped for that axis — the FSDP
@@ -290,54 +289,19 @@ def _param_is_fsdp_sharded(param, axis_index: int) -> bool:
     return False
 
 
-def _param_is_sharded_on_axis(param, axis_index: int, name: str) -> bool:
-    """True if ``param`` is Shard (not Replicate) on the given mesh axis.
-
-    Raises when the topology could not be read.
-    """
-    sharding = ttml.Sharding.from_tensor(param)
-    placements = sharding.placements
-    if placements is None:
-        raise RuntimeError(
-            f"{name}: could not read mesh placements; cannot tell whether it is sharded."
-        ) from sharding.read_error
-    if axis_index >= len(placements):
-        return False  # short placements == fully replicated, not unknown
-    return isinstance(placements[axis_index], ttnn.PlacementShard)
-
-
-def sync_sequence_parallel_gradients(parameters, axis_name: str = "tp"):
-    """Sum the gradients of TP-replicated parameters across the tensor-parallel axis.
-
-    Under Megatron sequence parallelism the residual stream is sharded along the
-    sequence across ``axis_name`` (the TP axis), so a parameter that is *replicated*
-    on that axis -- the RMSNorm ``gamma`` weights, and any bias added in a
-    sequence-sharded region -- only accumulates the gradient from its rank's slice of
-    the sequence. The full gradient is the SUM over ranks, so we all-reduce with **no
-    averaging** (unlike :func:`sync_gradients`, which means-reduces over the data
-    axes). TP-*sharded* parameters are skipped: each rank already holds the correct grad
-    for its shard.
-
-    Orthogonal to :func:`sync_gradients` (dp/fsdp): the reductions are over disjoint
-    axes and commute, so both may be called. No-op when ``axis_name`` has size 1.
+def sum_sp_gradients(parameters, axis_name: str):
+    """Sum the gradients of sequence-parallel parameters across the tensor-parallel axis.
+    No-op when ``axis_name`` is absent or has size 1.
 
     Args:
         parameters: A ``NamedParameters`` mapping (e.g. ``model.parameters()``).
-        axis_name: The tensor-parallel mesh axis name (default ``"tp"``).
-
-    Raises:
-        RuntimeError: if a parameter reports no placement on the axis -- neither
-            choice is safe to assume. See :func:`_param_is_sharded_on_axis`.
+        axis_name: The tensor-parallel mesh axis name.
     """
     m = maybe_mesh()
     if m is None or not m.has_axis(axis_name) or m.axis_size(axis_name) == 1:
         return
     axis = m.axis_index(axis_name)
 
-    for name, param in parameters.items():
-        if not param.is_grad_initialized():
-            continue
-        if _param_is_sharded_on_axis(param, axis, name):
-            continue
-        # SUM across TP (no division): reconstruct the full-sequence gradient.
-        param.set_grad(ttml.core.distributed.all_reduce(param.get_grad(), cluster_axis=axis))
+    for _, param in parameters.items():
+        if is_sequence_parallel(param) and param.is_grad_initialized():
+            param.set_grad(ttml.core.distributed.all_reduce(param.get_grad(), cluster_axis=axis))

--- a/tt-train/sources/ttml/ttml/common/config.py
+++ b/tt-train/sources/ttml/ttml/common/config.py
@@ -35,6 +35,10 @@ class DeviceConfig:
         # "moe_ep" and is used by sparse_ep (SparseMoEEP).
         self.moe_axis = int(device_config.get("moe_axis", -1))
         self.enable_fsdp = device_config.get("enable_fsdp", False)
+        # Megatron sequence parallelism rides the "tp" axis (it is not a separate mesh
+        # dimension), so it does not affect mesh construction -- it only toggles the
+        # model's sequence-sharded residual path. Requires enable_tp.
+        self.enable_sp = device_config.get("enable_sp", False)
         # Defaults to True: build as deferred metadata -> fully_shard -> materialize already-sharded,
         # so large models (e.g. 32B) never materialize a full replicated copy on one chip.
         # Set to false to opt into the eager (full-replicated, then shard) path.

--- a/tt-train/sources/ttml/ttml/models/llama/__init__.py
+++ b/tt-train/sources/ttml/ttml/models/llama/__init__.py
@@ -38,16 +38,15 @@ class LlamaRopeScalingConfig:
 class LlamaConfig:
     """Llama model hyper-parameters.
 
-    When ``use_tp=True`` the mesh must already be open and the ``"tp"`` axis
-    size must evenly divide ``num_attention_heads``, ``num_key_value_heads``,
-    and ``intermediate_size`` — this is validated in ``__post_init__``.  The
-    vocab does *not* need to be TP-divisible: the embedding and LM-head
-    weights are padded internally to a multiple of ``32 * tp_size``, exposed as
-    ``Llama.padded_vocab_size``.
+    When ``tp_strategy`` enables tensor parallelism the mesh must already be open and the
+    ``"tp"`` axis size must evenly divide ``num_attention_heads``, ``num_key_value_heads``,
+    and ``intermediate_size`` — this is validated in ``__post_init__``.  The vocab does
+    *not* need to be TP-divisible: the embedding and LM-head weights are padded internally
+    to a multiple of ``32 * tp_size``, exposed as ``Llama.padded_vocab_size``.
 
     ``embedding_placement`` selects how the token-embedding table is placed across the
     TP axis (see :class:`EmbeddingPlacement`); it defaults to ``Replicated`` (no
-    sharding) and is ignored when ``use_tp=False``.
+    sharding) and is ignored when tensor parallelism is disabled.
     """
 
     hidden_size: int = 384
@@ -64,7 +63,7 @@ class LlamaConfig:
     runner_type: RunnerType = RunnerType.Default
     weight_tying: WeightTyingType = WeightTyingType.Disabled
     rope_scaling: LlamaRopeScalingConfig = field(default_factory=LlamaRopeScalingConfig)
-    use_tp: bool = False
+    tp_strategy: TPStrategy = TPStrategy.NONE
     embedding_placement: EmbeddingPlacement = EmbeddingPlacement.Replicated
 
     def __post_init__(self):
@@ -98,7 +97,7 @@ class LlamaConfig:
                 "Number of attention heads must be divisible by the number of key/value heads. "
                 f"Provided num_attention_heads={self.num_attention_heads}, num_key_value_heads={self.num_key_value_heads}"
             )
-        if self.use_tp:
+        if self.tp_strategy.tensor_parallel:
             if (
                 self.weight_tying == WeightTyingType.Enabled
                 and self.embedding_placement != EmbeddingPlacement.VocabParallel
@@ -138,7 +137,7 @@ class Llama(AbstractModuleBase):
 
         self.config = config
 
-        if config.use_tp:
+        if config.tp_strategy.tensor_parallel:
             # Pad the vocab so the LM head's sharded output rows are
             # tile-aligned: ColumnParallelLinear shards dim 2 across TP, so
             # each shard needs to be divisible by 32 -- i.e. the padded global
@@ -224,7 +223,7 @@ class Llama(AbstractModuleBase):
                     mlp_dropout=config.mlp_dropout,
                     intermediate_size=config.intermediate_size,
                     attention_bias=config.attention_bias,
-                    use_tp=config.use_tp,
+                    tp_strategy=config.tp_strategy,
                 )
                 for _ in range(config.num_hidden_layers)
             ]
@@ -282,7 +281,7 @@ class Llama(AbstractModuleBase):
         # padded columns are handled by vocab_parallel_cross_entropy_loss.
         # The non-TP path returns full-vocab logits, so we still need to drop
         # the tile-alignment padding before handing them off to the caller.
-        if not self.config.use_tp and self.padded_vocab_size != self.config.vocab_size:
+        if not self.config.tp_strategy.tensor_parallel and self.padded_vocab_size != self.config.vocab_size:
             logits = SliceLastDim.apply(logits, self.config.vocab_size)
         return logits
 

--- a/tt-train/sources/ttml/ttml/models/llama/__init__.py
+++ b/tt-train/sources/ttml/ttml/models/llama/__init__.py
@@ -21,6 +21,7 @@ from ttml.modules import (
 
 from .. import EmbeddingPlacement, RunnerType, WeightTyingType, memory_efficient_runner
 from .autograd_ops import SliceLastDim
+from ttml.parallel import TPStrategy
 from .transformer import LlamaBlock, RMSNormLayer, compute_swiglu_intermediate_size
 
 
@@ -46,7 +47,8 @@ class LlamaConfig:
 
     ``embedding_placement`` selects how the token-embedding table is placed across the
     TP axis (see :class:`EmbeddingPlacement`); it defaults to ``Replicated`` (no
-    sharding) and is ignored when tensor parallelism is disabled.
+    sharding) and is ignored when tensor parallelism is disabled. ``Replicated`` is
+    incompatible with ``TPStrategy.TENSOR_SEQUENCE``.
     """
 
     hidden_size: int = 384
@@ -128,6 +130,22 @@ class LlamaConfig:
                     f"intermediate_size={intermediate_size}, tp_size={tp_size}"
                 )
 
+        if self.tp_strategy.sequence_parallel:
+            if self.embedding_placement == EmbeddingPlacement.Replicated:
+                raise ValueError(
+                    "sequence parallelism needs the embedding output sharded along the sequence, "
+                    "which the replicated embedding cannot produce. Set embedding_placement to "
+                    "VocabParallel or FeatureParallel, or use TPStrategy.TENSOR."
+                )
+            # Each TP rank owns S/tp_size sequence positions and the sequence
+            # reduce-scatter requires the per-shard tile count to divide the ring.
+            tp_size = ttml.mesh().axis_size("tp")
+            if self.max_position_embeddings % (32 * tp_size) != 0:
+                raise ValueError(
+                    "sequence_parallel requires max_position_embeddings divisible by 32*tp_size "
+                    f"(got max_position_embeddings={self.max_position_embeddings}, tp_size={tp_size})"
+                )
+
 
 class Llama(AbstractModuleBase):
     """Llama decoder-only transformer (Python implementation)."""
@@ -148,29 +166,39 @@ class Llama(AbstractModuleBase):
             tp_size = ttml.mesh().axis_size("tp")
             align = 32 * tp_size
             self.padded_vocab_size = ((config.vocab_size + align - 1) // align) * align
-            # gather_output=False: keep the LM head output vocab-sharded
-            # ([B,1,S,padded_V/tp_size] per device) so callers can route through
-            # ttml.ops.distributed.vocab_parallel_cross_entropy_loss without an
-            # all-gather of the full vocab dimension.
+            # No gather after LM head, because vocab_parallel_cross_entropy_loss
+            # expects a vocab-sharded tensor.
             self.fc = ColumnParallelLinear(
                 config.hidden_size,
                 self.padded_vocab_size,
                 has_bias=False,
                 gather_output=False,
+                # Under SP the head input (ln_fc output) is sequence-sharded; the
+                # column-parallel gather restores the full sequence, yielding
+                # full-sequence vocab-sharded logits -- exactly what the classic-TP
+                # path produces, so vocab_parallel_cross_entropy_loss is unchanged.
+                sequence_parallel=config.tp_strategy.sequence_parallel,
                 axis_name="tp",
             )
             if config.embedding_placement == EmbeddingPlacement.VocabParallel:
+                # Under SP the embedding output is reduce-scattered along the
+                # sequence so the first block receives a sequence-sharded residual.
                 self.tok_emb = VocabParallelEmbedding(
                     self.padded_vocab_size,
                     config.hidden_size,
                     weight_init=ttml.init.normal(0.0, 0.02),
+                    sequence_parallel=config.tp_strategy.sequence_parallel,
                     axis_name="tp",
                 )
             elif config.embedding_placement == EmbeddingPlacement.FeatureParallel:
+                # Under SP the gathered full-hidden embedding is additionally
+                # scattered along the sequence, so the first block receives a
+                # sequence-sharded residual.
                 self.tok_emb = FeatureParallelEmbedding(
                     self.padded_vocab_size,
                     config.hidden_size,
                     weight_init=ttml.init.normal(0.0, 0.02),
+                    sequence_parallel=config.tp_strategy.sequence_parallel,
                     axis_name="tp",
                 )
             else:
@@ -245,6 +273,14 @@ class Llama(AbstractModuleBase):
         actual_seq_len = input_shape[-1]
         padded_seq_len = ((actual_seq_len + TILE_SIZE - 1) // TILE_SIZE) * TILE_SIZE
 
+        if self.config.tp_strategy.sequence_parallel:
+            tp_size = ttml.mesh().axis_size("tp")
+            if actual_seq_len % (TILE_SIZE * tp_size) != 0:
+                raise ValueError(
+                    "sequence_parallel requires the input sequence length divisible by 32*tp_size "
+                    f"(got seq_len={actual_seq_len}, tp_size={tp_size})"
+                )
+
         input_padded = input
         if padded_seq_len != actual_seq_len:
             padding = [(0, 0), (0, 0), (0, 0), (0, padded_seq_len - actual_seq_len)]
@@ -277,10 +313,8 @@ class Llama(AbstractModuleBase):
 
         out = self.ln_fc(out)
         logits = self.fc(out)
-        # In TP mode the LM head output stays vocab-sharded; the trailing
-        # padded columns are handled by vocab_parallel_cross_entropy_loss.
-        # The non-TP path returns full-vocab logits, so we still need to drop
-        # the tile-alignment padding before handing them off to the caller.
+        # Under TP the padding is handled inside
+        # vocab_parallel_cross_entropy_loss.
         if not self.config.tp_strategy.tensor_parallel and self.padded_vocab_size != self.config.vocab_size:
             logits = SliceLastDim.apply(logits, self.config.vocab_size)
         return logits

--- a/tt-train/sources/ttml/ttml/models/llama/__init__.py
+++ b/tt-train/sources/ttml/ttml/models/llama/__init__.py
@@ -21,7 +21,7 @@ from ttml.modules import (
 
 from .. import EmbeddingPlacement, RunnerType, WeightTyingType, memory_efficient_runner
 from .autograd_ops import SliceLastDim
-from ttml.parallel import TPStrategy
+from ttml.parallel import SEQUENCE_DIM, TPStrategy
 from .transformer import LlamaBlock, RMSNormLayer, compute_swiglu_intermediate_size
 
 
@@ -47,8 +47,7 @@ class LlamaConfig:
 
     ``embedding_placement`` selects how the token-embedding table is placed across the
     TP axis (see :class:`EmbeddingPlacement`); it defaults to ``Replicated`` (no
-    sharding) and is ignored when tensor parallelism is disabled. ``Replicated`` is
-    incompatible with ``TPStrategy.TENSOR_SEQUENCE``.
+    sharding) and is ignored when tensor parallelism is disabled.
     """
 
     hidden_size: int = 384
@@ -130,22 +129,6 @@ class LlamaConfig:
                     f"intermediate_size={intermediate_size}, tp_size={tp_size}"
                 )
 
-        if self.tp_strategy.sequence_parallel:
-            if self.embedding_placement == EmbeddingPlacement.Replicated:
-                raise ValueError(
-                    "sequence parallelism needs the embedding output sharded along the sequence, "
-                    "which the replicated embedding cannot produce. Set embedding_placement to "
-                    "VocabParallel or FeatureParallel, or use TPStrategy.TENSOR."
-                )
-            # Each TP rank owns S/tp_size sequence positions and the sequence
-            # reduce-scatter requires the per-shard tile count to divide the ring.
-            tp_size = ttml.mesh().axis_size("tp")
-            if self.max_position_embeddings % (32 * tp_size) != 0:
-                raise ValueError(
-                    "sequence_parallel requires max_position_embeddings divisible by 32*tp_size "
-                    f"(got max_position_embeddings={self.max_position_embeddings}, tp_size={tp_size})"
-                )
-
 
 class Llama(AbstractModuleBase):
     """Llama decoder-only transformer (Python implementation)."""
@@ -154,6 +137,7 @@ class Llama(AbstractModuleBase):
         super().__init__()
 
         self.config = config
+        sequence_parallel = config.tp_strategy.sequence_parallel
 
         if config.tp_strategy.tensor_parallel:
             # Pad the vocab so the LM head's sharded output rows are
@@ -163,42 +147,36 @@ class Llama(AbstractModuleBase):
             # columns are kept on-device and handled by the downstream
             # vocab_parallel_cross_entropy_loss, so ``config.vocab_size`` is
             # free to be arbitrary.
-            tp_size = ttml.mesh().axis_size("tp")
-            align = 32 * tp_size
+            mesh = ttml.mesh()
+            self.tp_size = mesh.axis_size("tp")
+            self._tp_axis = mesh.axis_index("tp")
+            align = 32 * self.tp_size
             self.padded_vocab_size = ((config.vocab_size + align - 1) // align) * align
             # No gather after LM head, because vocab_parallel_cross_entropy_loss
-            # expects a vocab-sharded tensor.
+            # expects a vocab-sharded tensor. Under SP the head input is sequence-sharded
+            # and the column-parallel input gather restores the full sequence, so the
+            # logits come out exactly as in classic TP.
             self.fc = ColumnParallelLinear(
                 config.hidden_size,
                 self.padded_vocab_size,
                 has_bias=False,
                 gather_output=False,
-                # Under SP the head input (ln_fc output) is sequence-sharded; the
-                # column-parallel gather restores the full sequence, yielding
-                # full-sequence vocab-sharded logits -- exactly what the classic-TP
-                # path produces, so vocab_parallel_cross_entropy_loss is unchanged.
-                sequence_parallel=config.tp_strategy.sequence_parallel,
+                sequence_parallel=sequence_parallel,
                 axis_name="tp",
             )
             if config.embedding_placement == EmbeddingPlacement.VocabParallel:
-                # Under SP the embedding output is reduce-scattered along the
-                # sequence so the first block receives a sequence-sharded residual.
                 self.tok_emb = VocabParallelEmbedding(
                     self.padded_vocab_size,
                     config.hidden_size,
                     weight_init=ttml.init.normal(0.0, 0.02),
-                    sequence_parallel=config.tp_strategy.sequence_parallel,
+                    sequence_parallel=sequence_parallel,
                     axis_name="tp",
                 )
             elif config.embedding_placement == EmbeddingPlacement.FeatureParallel:
-                # Under SP the gathered full-hidden embedding is additionally
-                # scattered along the sequence, so the first block receives a
-                # sequence-sharded residual.
                 self.tok_emb = FeatureParallelEmbedding(
                     self.padded_vocab_size,
                     config.hidden_size,
                     weight_init=ttml.init.normal(0.0, 0.02),
-                    sequence_parallel=config.tp_strategy.sequence_parallel,
                     axis_name="tp",
                 )
             else:
@@ -208,6 +186,7 @@ class Llama(AbstractModuleBase):
                     weight_init=ttml.init.normal(0.0, 0.02),
                 )
         else:
+            self.tp_size = 1
             self.padded_vocab_size = ((config.vocab_size + 31) // 32) * 32
             self.fc = LinearLayer(
                 config.hidden_size,
@@ -222,6 +201,10 @@ class Llama(AbstractModuleBase):
 
         if config.weight_tying == ttml.models.WeightTyingType.Enabled:
             self.tok_emb.weight = self.fc.weight
+
+        # Block 0 needs a sequence-sharded residual. Embeddings that emit the full sequence
+        # on every rank are sliced locally; the vocab-parallel one already lands sharded.
+        self._slice_sequence = sequence_parallel and not isinstance(self.tok_emb, VocabParallelEmbedding)
 
         head_dim = config.hidden_size // config.num_attention_heads
 
@@ -257,7 +240,7 @@ class Llama(AbstractModuleBase):
             ]
         )
 
-        self.ln_fc = RMSNormLayer(config.hidden_size)
+        self.ln_fc = RMSNormLayer(config.hidden_size, sequence_parallel=sequence_parallel)
 
     def forward(
         self,
@@ -274,11 +257,15 @@ class Llama(AbstractModuleBase):
         padded_seq_len = ((actual_seq_len + TILE_SIZE - 1) // TILE_SIZE) * TILE_SIZE
 
         if self.config.tp_strategy.sequence_parallel:
-            tp_size = ttml.mesh().axis_size("tp")
-            if actual_seq_len % (TILE_SIZE * tp_size) != 0:
+            if kv_cache is not None:
+                raise NotImplementedError(
+                    "sequence_parallel does not support the KV-cache path: single-token decode has "
+                    "no sequence to shard. Run inference with TPStrategy.TENSOR."
+                )
+            if actual_seq_len % (TILE_SIZE * self.tp_size) != 0:
                 raise ValueError(
                     "sequence_parallel requires the input sequence length divisible by 32*tp_size "
-                    f"(got seq_len={actual_seq_len}, tp_size={tp_size})"
+                    f"(got seq_len={actual_seq_len}, tp_size={self.tp_size})"
                 )
 
         input_padded = input
@@ -301,6 +288,9 @@ class Llama(AbstractModuleBase):
             step = [1, 1, 1, 1]
             out_val = ttnn.slice(tok_emb_out.get_value(), slice_start, slice_end, step)
             out = ttml.autograd.create_tensor(out_val)
+
+        if self._slice_sequence:
+            out = ttml.ops.distributed.scatter(out, SEQUENCE_DIM, self._tp_axis)
 
         for layer_idx, block in enumerate(self.blocks):
             extra_args = () if kv_cache is None else (kv_cache, layer_idx, new_tokens)

--- a/tt-train/sources/ttml/ttml/models/llama/autograd_ops.py
+++ b/tt-train/sources/ttml/ttml/models/llama/autograd_ops.py
@@ -11,12 +11,7 @@ import ttml
 
 
 class SliceLastDim(ttml.autograd.Function):
-    """Slice ``x[..., :width]`` with gradient zero-padded back to the full width.
-
-    Used to drop padded logit columns in the TP LM head — the padding rows are
-    never looked up as embeddings and never appear as labels, so a zero grad
-    for those positions is the correct upstream signal.
-    """
+    """Differentiable truncation of the last dimension: ``y = x[..., :width]``."""
 
     @staticmethod
     def forward(ctx, x, width):

--- a/tt-train/sources/ttml/ttml/models/llama/gqattn.py
+++ b/tt-train/sources/ttml/ttml/models/llama/gqattn.py
@@ -12,6 +12,8 @@ import ttnn
 import ttml
 from ttml.modules import AbstractModuleBase, LinearLayer, ColumnParallelLinear, RowParallelLinear, RunMode
 
+from ttml.parallel import TPStrategy
+
 
 class GroupedQueryAttention(AbstractModuleBase):
     """Grouped-query attention (GQA) with optional tensor-parallel linear layers.
@@ -30,7 +32,7 @@ class GroupedQueryAttention(AbstractModuleBase):
         dropout: float,
         rope_params: ttml.ops.rope.RotaryEmbeddingParams,
         bias_linears: bool = False,
-        use_tp: bool = False,
+        tp_strategy: TPStrategy = TPStrategy.NONE,
     ) -> None:
         super().__init__()
 
@@ -39,6 +41,8 @@ class GroupedQueryAttention(AbstractModuleBase):
                 "Embedding size must be divisible by the number of attention heads. "
                 f"Provided embedding_size={embedding_size}, num_heads={num_heads}"
             )
+
+        use_tp = tp_strategy.tensor_parallel
 
         self.embedding_size = embedding_size
         self.dropout_prob = dropout

--- a/tt-train/sources/ttml/ttml/models/llama/gqattn.py
+++ b/tt-train/sources/ttml/ttml/models/llama/gqattn.py
@@ -43,10 +43,12 @@ class GroupedQueryAttention(AbstractModuleBase):
             )
 
         use_tp = tp_strategy.tensor_parallel
+        sequence_parallel = tp_strategy.sequence_parallel
 
         self.embedding_size = embedding_size
         self.dropout_prob = dropout
         self.rope_params = rope_params
+        self.sequence_parallel = sequence_parallel
 
         head_dim = embedding_size // num_heads
         qkv_dim = (num_heads + 2 * num_groups) * head_dim  # == embedding_size + 2 * num_groups * head_dim
@@ -70,6 +72,7 @@ class GroupedQueryAttention(AbstractModuleBase):
                 has_bias=bias_linears,
                 bias_init=ttml.init.zeros(),
                 gather_output=False,
+                sequence_parallel=sequence_parallel,
                 axis_name="tp",
             )
             self.out_linear = RowParallelLinear(
@@ -78,6 +81,7 @@ class GroupedQueryAttention(AbstractModuleBase):
                 has_bias=bias_linears,
                 bias_init=ttml.init.zeros(),
                 input_is_parallel=True,
+                sequence_parallel=sequence_parallel,
                 axis_name="tp",
             )
         else:
@@ -180,6 +184,11 @@ class GroupedQueryAttention(AbstractModuleBase):
     ) -> ttml.autograd.Tensor:
         if kv_cache is None:
             return self.forward_no_kv(input, mask)
+        if self.sequence_parallel:
+            # SP shards the residual stream along the sequence; single-token decode
+            # (seq=1, not divisible by tp) has nothing to shard. Decode runs with the
+            # classic-TP model instead.
+            raise NotImplementedError("sequence_parallel does not support the KV-cache decode path")
         if layer_idx is None or new_tokens is None:
             raise ValueError("forward with kv_cache requires layer_idx and new_tokens to be set")
         return self.forward_kv(input, mask, kv_cache, layer_idx, new_tokens)

--- a/tt-train/sources/ttml/ttml/models/llama/gqattn.py
+++ b/tt-train/sources/ttml/ttml/models/llama/gqattn.py
@@ -49,6 +49,9 @@ class GroupedQueryAttention(AbstractModuleBase):
         self.dropout_prob = dropout
         self.rope_params = rope_params
         self.sequence_parallel = sequence_parallel
+        # Identical masks across tp ranks that hold identical activations,
+        # per-device masks once SP gives each rank its own tokens.
+        self._per_device_dropout_seed = not use_tp or sequence_parallel
 
         head_dim = embedding_size // num_heads
         qkv_dim = (num_heads + 2 * num_groups) * head_dim  # == embedding_size + 2 * num_groups * head_dim
@@ -121,9 +124,8 @@ class GroupedQueryAttention(AbstractModuleBase):
 
         out = self.out_linear(attention)
 
-        # Apply dropout if in training mode (using RunMode from AbstractModuleBase)
         if self.get_run_mode() == RunMode.TRAIN and self.dropout_prob > 0.0:
-            out = ttml.ops.dropout.dropout(out, self.dropout_prob)
+            out = ttml.ops.dropout.dropout(out, self.dropout_prob, use_per_device_seed=self._per_device_dropout_seed)
 
         return out
 
@@ -168,9 +170,8 @@ class GroupedQueryAttention(AbstractModuleBase):
 
         out = self.out_linear(attention)
 
-        # Apply dropout if in training mode (using RunMode from AbstractModuleBase)
         if self.get_run_mode() == RunMode.TRAIN and self.dropout_prob > 0.0:
-            out = ttml.ops.dropout.dropout(out, self.dropout_prob)
+            out = ttml.ops.dropout.dropout(out, self.dropout_prob, use_per_device_seed=self._per_device_dropout_seed)
 
         return out
 
@@ -185,10 +186,8 @@ class GroupedQueryAttention(AbstractModuleBase):
         if kv_cache is None:
             return self.forward_no_kv(input, mask)
         if self.sequence_parallel:
-            # SP shards the residual stream along the sequence; single-token decode
-            # (seq=1, not divisible by tp) has nothing to shard. Decode runs with the
-            # classic-TP model instead.
-            raise NotImplementedError("sequence_parallel does not support the KV-cache decode path")
+            # Single-token decode has no sequence to shard.
+            raise NotImplementedError("sequence_parallel does not support the KV-cache path")
         if layer_idx is None or new_tokens is None:
             raise ValueError("forward with kv_cache requires layer_idx and new_tokens to be set")
         return self.forward_kv(input, mask, kv_cache, layer_idx, new_tokens)

--- a/tt-train/sources/ttml/ttml/models/llama/transformer.py
+++ b/tt-train/sources/ttml/ttml/models/llama/transformer.py
@@ -12,6 +12,7 @@ import ttml
 from ttml.modules import AbstractModuleBase, Parameter, RunMode, LinearLayer, ColumnParallelLinear, RowParallelLinear
 
 from .gqattn import GroupedQueryAttention
+from ttml.parallel import TPStrategy
 
 
 def compute_swiglu_intermediate_size(hidden_size: int, multiple_of: int = 256) -> int:
@@ -67,9 +68,11 @@ class LlamaMLP(AbstractModuleBase):
         embedding_size: int,
         intermediate_size: Optional[int] = None,
         dropout: float = 0.0,
-        use_tp: bool = False,
+        tp_strategy: TPStrategy = TPStrategy.NONE,
     ) -> None:
         super().__init__()
+
+        use_tp = tp_strategy.tensor_parallel
 
         self.embedding_size = embedding_size
         self.dropout_prob = dropout
@@ -155,7 +158,7 @@ class LlamaBlock(AbstractModuleBase):
         mlp_dropout: float = 0.0,
         intermediate_size: Optional[int] = None,
         attention_bias: bool = False,
-        use_tp: bool = False,
+        tp_strategy: TPStrategy = TPStrategy.NONE,
     ) -> None:
         super().__init__()
 
@@ -163,7 +166,7 @@ class LlamaBlock(AbstractModuleBase):
             hidden_size,
             intermediate_size,
             mlp_dropout,
-            use_tp=use_tp,
+            tp_strategy=tp_strategy,
         )
         self.attention_norm = RMSNormLayer(hidden_size)
         self.mlp_norm = RMSNormLayer(hidden_size)
@@ -174,7 +177,7 @@ class LlamaBlock(AbstractModuleBase):
             dropout=attention_dropout,
             rope_params=rope_params,
             bias_linears=attention_bias,
-            use_tp=use_tp,
+            tp_strategy=tp_strategy,
         )
 
     def forward(

--- a/tt-train/sources/ttml/ttml/models/llama/transformer.py
+++ b/tt-train/sources/ttml/ttml/models/llama/transformer.py
@@ -73,6 +73,7 @@ class LlamaMLP(AbstractModuleBase):
         super().__init__()
 
         use_tp = tp_strategy.tensor_parallel
+        sequence_parallel = tp_strategy.sequence_parallel
 
         self.embedding_size = embedding_size
         self.dropout_prob = dropout
@@ -103,6 +104,7 @@ class LlamaMLP(AbstractModuleBase):
                 gate_up_size,
                 has_bias=False,
                 gather_output=False,
+                sequence_parallel=sequence_parallel,
                 axis_name="tp",
             )
             self.w2 = RowParallelLinear(
@@ -110,6 +112,7 @@ class LlamaMLP(AbstractModuleBase):
                 embedding_size,
                 has_bias=False,
                 input_is_parallel=True,
+                sequence_parallel=sequence_parallel,
                 axis_name="tp",
             )
         else:
@@ -162,6 +165,10 @@ class LlamaBlock(AbstractModuleBase):
     ) -> None:
         super().__init__()
 
+        # Under sequence parallelism the residual stream (and hence the two RMSNorm
+        # inputs) is sequence-sharded across the TP axis; the norms are per-token so
+        # they need no change. The attention/MLP linears gather to full sequence for
+        # their matmuls and reduce-scatter back, so the block wiring is unchanged.
         self.mlp = LlamaMLP(
             hidden_size,
             intermediate_size,

--- a/tt-train/sources/ttml/ttml/models/llama/transformer.py
+++ b/tt-train/sources/ttml/ttml/models/llama/transformer.py
@@ -12,7 +12,7 @@ import ttml
 from ttml.modules import AbstractModuleBase, Parameter, RunMode, LinearLayer, ColumnParallelLinear, RowParallelLinear
 
 from .gqattn import GroupedQueryAttention
-from ttml.parallel import TPStrategy
+from ttml.parallel import TPStrategy, mark_sequence_parallel
 
 
 def compute_swiglu_intermediate_size(hidden_size: int, multiple_of: int = 256) -> int:
@@ -33,6 +33,7 @@ class RMSNormLayer(AbstractModuleBase):
         features: int,
         epsilon: float = 1e-5,
         use_composite: bool = False,
+        sequence_parallel: bool = False,
     ) -> None:
         super().__init__()
 
@@ -41,6 +42,8 @@ class RMSNormLayer(AbstractModuleBase):
 
         gamma_shape = (1, 1, 1, features)
         self.gamma = Parameter(ttml.init.ones()(gamma_shape))
+        if sequence_parallel:
+            mark_sequence_parallel(self.gamma)
 
     def forward(self, x: ttml.autograd.Tensor) -> ttml.autograd.Tensor:
         """Forward pass of RMSNorm.
@@ -77,7 +80,10 @@ class LlamaMLP(AbstractModuleBase):
 
         self.embedding_size = embedding_size
         self.dropout_prob = dropout
-        self.use_tp = use_tp
+        # Classic TP replicates activations across tp ranks, which must then drop the same units; one
+        # boolean cannot also decorrelate DP groups: https://github.com/tenstorrent/tt-metal/issues/55947.
+        # Under SP every rank holds different tokens.
+        self._per_device_dropout_seed = not use_tp or sequence_parallel
 
         if intermediate_size is None:
             intermediate_size = compute_swiglu_intermediate_size(embedding_size)
@@ -141,9 +147,7 @@ class LlamaMLP(AbstractModuleBase):
         x = self.w2(h)
 
         if self.get_run_mode() == RunMode.TRAIN and self.dropout_prob > 0.0:
-            # One boolean cannot decorrelate DP groups, leaving a DP+TP mesh
-            # on a single mask: https://github.com/tenstorrent/tt-metal/issues/55947
-            x = ttml.ops.dropout.dropout(x, self.dropout_prob, use_per_device_seed=not self.use_tp)
+            x = ttml.ops.dropout.dropout(x, self.dropout_prob, use_per_device_seed=self._per_device_dropout_seed)
 
         return x
 
@@ -165,18 +169,15 @@ class LlamaBlock(AbstractModuleBase):
     ) -> None:
         super().__init__()
 
-        # Under sequence parallelism the residual stream (and hence the two RMSNorm
-        # inputs) is sequence-sharded across the TP axis; the norms are per-token so
-        # they need no change. The attention/MLP linears gather to full sequence for
-        # their matmuls and reduce-scatter back, so the block wiring is unchanged.
+        sequence_parallel = tp_strategy.sequence_parallel
         self.mlp = LlamaMLP(
             hidden_size,
             intermediate_size,
             mlp_dropout,
             tp_strategy=tp_strategy,
         )
-        self.attention_norm = RMSNormLayer(hidden_size)
-        self.mlp_norm = RMSNormLayer(hidden_size)
+        self.attention_norm = RMSNormLayer(hidden_size, sequence_parallel=sequence_parallel)
+        self.mlp_norm = RMSNormLayer(hidden_size, sequence_parallel=sequence_parallel)
         self.attention = GroupedQueryAttention(
             embedding_size=hidden_size,
             num_heads=num_attention_heads,

--- a/tt-train/sources/ttml/ttml/modules/embedding.py
+++ b/tt-train/sources/ttml/ttml/modules/embedding.py
@@ -18,7 +18,7 @@ from .parameter import Parameter
 
 
 class Embedding(AbstractModuleBase):
-    """Embedding layer implemented in Python using ttml operations."""
+    """Embedding layer."""
 
     def __init__(self, num_embeddings: int, embedding_dim: int, weight_init=None) -> None:
         """Initialize embedding layer.
@@ -55,11 +55,16 @@ class VocabParallelEmbedding(AbstractModuleBase):
     looks up the ids that fall in its slice, zeroes the rest, and an all-reduce
     then sums the per-device contributions — each token is owned by exactly one
     device, so the sum reconstructs the full, replicated embedding.
+    With ``sequence_parallel`` the all-reduce becomes a reduce-scatter along the
+    sequence, so the first block receives a sequence-sharded residual.
 
     Args:
         num_embeddings: Vocabulary size. Must be divisible by ``tp_size``.
         embedding_dim: Dimension of embeddings.
         weight_init: Initializer for the weight tensor. Defaults to normal(0, 0.02).
+        sequence_parallel: If ``True`` (Megatron sequence parallelism) the cross-TP sum
+            is a reduce-scatter along the sequence, so the output is
+            ``[batch, 1, seq/tp, embedding_dim]`` instead of a replicated full sequence.
         axis_name: Mesh axis used for tensor parallelism.
 
     Note:
@@ -79,6 +84,7 @@ class VocabParallelEmbedding(AbstractModuleBase):
         num_embeddings: int,
         embedding_dim: int,
         weight_init: Optional[Callable] = None,
+        sequence_parallel: bool = False,
         axis_name: str = "tp",
     ) -> None:
         super().__init__()
@@ -87,6 +93,7 @@ class VocabParallelEmbedding(AbstractModuleBase):
         self.axis_name = axis_name
         self.cluster_axis = mesh.axis_index(axis_name)
         self.tp_size = mesh.axis_size(axis_name)
+        self.sequence_parallel = sequence_parallel
 
         if num_embeddings % self.tp_size != 0:
             raise ValueError(
@@ -186,6 +193,10 @@ class VocabParallelEmbedding(AbstractModuleBase):
         mask = ttnn.transpose(ttnn.to_layout(ttnn.typecast(in_range, ttnn.DataType.FLOAT32), ttnn.Layout.TILE), 2, 3)
         emb = ttml.ops.binary.mul(emb, ttml.autograd.create_tensor(mask, requires_grad=False))
 
+        # Each token is nonzero on exactly one device, so summing across TP reconstructs it.
+        if self.sequence_parallel:
+            # Same sum, but leaves the result sequence-sharded for the first block.
+            return ttml.ops.distributed.reduce_scatter(emb, 2, self.cluster_axis)
         return ttml.ops.distributed.all_reduce(emb, noop_backward=True, cluster_axis=self.cluster_axis)
 
 
@@ -193,17 +204,20 @@ class FeatureParallelEmbedding(AbstractModuleBase):
     """Embedding whose table is sharded along the embedding (hidden) dimension.
 
     Each device holds the *entire* vocabulary but only an ``embedding_dim //
-    tp_size`` slice of every row. Versus :class:`VocabParallelEmbedding` this
-    makes the lookup fully local — no vocab offset, range mask, or out-of-range
-    handling — and replaces the full-hidden all-reduce with a single all-gather
-    over the embedding dim (roughly half the bandwidth), mirroring
-    ``ColumnParallelLinear(gather_output=True)``. The trade-off: its layout does
-    not match the vocab-parallel LM head, so weight tying is unavailable.
+    tp_size`` slice of every row. The lookup stays fully local.
+    The trade-off: its layout does not match the vocab-parallel LM head, so weight tying is unavailable.
+    With ``sequence_parallel`` the gathered embedding is then sliced along the sequence.
+    That slice is local, but its backward adds a sequence all-gather on top of the hidden
+    reduce-scatter, making :class:`VocabParallelEmbedding` cheaper under SP.
 
     Args:
-        num_embeddings: Vocabulary size (rows). Held in full on every device.
+        num_embeddings: Vocabulary size.
         embedding_dim: Embedding width. Sharded across ``tp_size``.
         weight_init: Initializer for the weight tensor. Defaults to normal(0, 0.02).
+        sequence_parallel: If ``True`` (Megatron sequence parallelism) the gathered
+            full-hidden embedding is additionally scattered along the sequence
+            across the TP axis, so the output is ``[batch, 1, seq/tp, embedding_dim]``.
+            Requires ``gather_output=True``.
         axis_name: Mesh axis used for tensor parallelism.
         gather_output: If ``True`` (default) an all-gather reconstructs the full
             TP-replicated embedding. If ``False`` the hidden-sharded slice
@@ -213,7 +227,8 @@ class FeatureParallelEmbedding(AbstractModuleBase):
         The shard must be tile-width aligned: ``embedding_dim`` divisible by
         ``tp_size`` and ``embedding_dim // tp_size`` a multiple of 32 (the
         embedding kernel's last-dim requirement). Backward also needs ``seq_len``
-        tile-aligned.
+        tile-aligned; under ``sequence_parallel`` the sequence scatter additionally
+        needs ``seq_len`` divisible by ``32 * tp_size``.
     """
 
     def __init__(
@@ -221,6 +236,7 @@ class FeatureParallelEmbedding(AbstractModuleBase):
         num_embeddings: int,
         embedding_dim: int,
         weight_init: Optional[Callable] = None,
+        sequence_parallel: bool = False,
         axis_name: str = "tp",
         gather_output: bool = True,
     ) -> None:
@@ -231,6 +247,10 @@ class FeatureParallelEmbedding(AbstractModuleBase):
         self.cluster_axis = mesh.axis_index(axis_name)
         self.tp_size = mesh.axis_size(axis_name)
         self.gather_output = gather_output
+        self.sequence_parallel = sequence_parallel
+
+        if sequence_parallel and not gather_output:
+            raise ValueError("FeatureParallelEmbedding: sequence_parallel requires gather_output=True")
 
         if embedding_dim % self.tp_size != 0:
             raise ValueError(
@@ -278,7 +298,9 @@ class FeatureParallelEmbedding(AbstractModuleBase):
             x: Token indices ``[batch_size, 1, 1, seq_len]``, replicated across TP.
 
         Returns:
-            ``gather_output`` (default): full embedding
+            ``sequence_parallel``: the full embedding sharded along the sequence,
+            ``[batch_size, 1, seq_len/tp, embedding_dim]``.
+            ``gather_output`` (default, non-SP): full embedding
             ``[batch_size, 1, seq_len, embedding_dim]`` replicated across TP.
             Otherwise the hidden-sharded slice
             ``[batch_size, 1, seq_len, embedding_dim/tp]``.
@@ -294,9 +316,14 @@ class FeatureParallelEmbedding(AbstractModuleBase):
         # GradOutputType.REPLICATED divides the backward reduce_scatter by tp_size
         # (output is replicated, consumed replicated), matching
         # ColumnParallelLinear(gather_output=True).
-        return ttml.ops.distributed.all_gather(
+        emb = ttml.ops.distributed.all_gather(
             emb,
             3,
             self.cluster_axis,
             ttml.ops.distributed.GradOutputType.REPLICATED,
         )
+
+        if self.sequence_parallel:
+            emb = ttml.ops.distributed.scatter(emb, 2, self.cluster_axis)
+
+        return emb

--- a/tt-train/sources/ttml/ttml/modules/embedding.py
+++ b/tt-train/sources/ttml/ttml/modules/embedding.py
@@ -12,6 +12,7 @@ import numpy as np
 
 import ttnn
 import ttml
+from ttml.parallel import SEQUENCE_DIM
 
 from .module_base import AbstractModuleBase
 from .parameter import Parameter
@@ -119,8 +120,9 @@ class VocabParallelEmbedding(AbstractModuleBase):
         # per-device (rather than sharding a global tensor) may round the shard up
         # to a tile boundary, which silently shifts every rank after the first by
         # the difference -- so check the tensor we actually got.
-        local_rows = self.weight.tensor.shape()[2]
-        if local_rows != self.num_embeddings_per_partition:
+        # A lazy weight is sharded from its global shape at materialization, so only an eager one can differ.
+        local_rows = None if self.weight.is_lazy else self.weight.tensor.shape()[2]
+        if local_rows is not None and local_rows != self.num_embeddings_per_partition:
             raise ValueError(
                 f"VocabParallelEmbedding weight has {local_rows} rows per device but ownership "
                 f"offsets assume {self.num_embeddings_per_partition} "
@@ -162,8 +164,9 @@ class VocabParallelEmbedding(AbstractModuleBase):
                 row-major), replicated across the TP axis.
 
         Returns:
-            Embeddings ``[batch_size, 1, seq_len, embedding_dim]``, replicated
-            across the TP axis.
+            Embeddings ``[batch_size, 1, seq_len, embedding_dim]`` replicated across the TP
+            axis, or ``[batch_size, 1, seq_len / tp_size, embedding_dim]`` sequence-sharded
+            across it under ``sequence_parallel``.
         """
         self._check_tp_replicated(x)
 
@@ -195,8 +198,8 @@ class VocabParallelEmbedding(AbstractModuleBase):
 
         # Each token is nonzero on exactly one device, so summing across TP reconstructs it.
         if self.sequence_parallel:
-            # Same sum, but leaves the result sequence-sharded for the first block.
-            return ttml.ops.distributed.reduce_scatter(emb, 2, self.cluster_axis)
+            # Same sum, landing sequence-sharded for the first block.
+            return ttml.ops.distributed.reduce_scatter(emb, SEQUENCE_DIM, self.cluster_axis)
         return ttml.ops.distributed.all_reduce(emb, noop_backward=True, cluster_axis=self.cluster_axis)
 
 
@@ -204,20 +207,17 @@ class FeatureParallelEmbedding(AbstractModuleBase):
     """Embedding whose table is sharded along the embedding (hidden) dimension.
 
     Each device holds the *entire* vocabulary but only an ``embedding_dim //
-    tp_size`` slice of every row. The lookup stays fully local.
-    The trade-off: its layout does not match the vocab-parallel LM head, so weight tying is unavailable.
-    With ``sequence_parallel`` the gathered embedding is then sliced along the sequence.
-    That slice is local, but its backward adds a sequence all-gather on top of the hidden
-    reduce-scatter, making :class:`VocabParallelEmbedding` cheaper under SP.
+    tp_size`` slice of every row. Versus :class:`VocabParallelEmbedding` this
+    makes the lookup fully local — no vocab offset, range mask, or out-of-range
+    handling — and replaces the full-hidden all-reduce with a single all-gather
+    over the embedding dim (roughly half the bandwidth), mirroring
+    ``ColumnParallelLinear(gather_output=True)``. The trade-off: its layout does
+    not match the vocab-parallel LM head, so weight tying is unavailable.
 
     Args:
-        num_embeddings: Vocabulary size.
+        num_embeddings: Vocabulary size (rows). Held in full on every device.
         embedding_dim: Embedding width. Sharded across ``tp_size``.
         weight_init: Initializer for the weight tensor. Defaults to normal(0, 0.02).
-        sequence_parallel: If ``True`` (Megatron sequence parallelism) the gathered
-            full-hidden embedding is additionally scattered along the sequence
-            across the TP axis, so the output is ``[batch, 1, seq/tp, embedding_dim]``.
-            Requires ``gather_output=True``.
         axis_name: Mesh axis used for tensor parallelism.
         gather_output: If ``True`` (default) an all-gather reconstructs the full
             TP-replicated embedding. If ``False`` the hidden-sharded slice
@@ -227,8 +227,7 @@ class FeatureParallelEmbedding(AbstractModuleBase):
         The shard must be tile-width aligned: ``embedding_dim`` divisible by
         ``tp_size`` and ``embedding_dim // tp_size`` a multiple of 32 (the
         embedding kernel's last-dim requirement). Backward also needs ``seq_len``
-        tile-aligned; under ``sequence_parallel`` the sequence scatter additionally
-        needs ``seq_len`` divisible by ``32 * tp_size``.
+        tile-aligned.
     """
 
     def __init__(
@@ -236,7 +235,6 @@ class FeatureParallelEmbedding(AbstractModuleBase):
         num_embeddings: int,
         embedding_dim: int,
         weight_init: Optional[Callable] = None,
-        sequence_parallel: bool = False,
         axis_name: str = "tp",
         gather_output: bool = True,
     ) -> None:
@@ -247,10 +245,6 @@ class FeatureParallelEmbedding(AbstractModuleBase):
         self.cluster_axis = mesh.axis_index(axis_name)
         self.tp_size = mesh.axis_size(axis_name)
         self.gather_output = gather_output
-        self.sequence_parallel = sequence_parallel
-
-        if sequence_parallel and not gather_output:
-            raise ValueError("FeatureParallelEmbedding: sequence_parallel requires gather_output=True")
 
         if embedding_dim % self.tp_size != 0:
             raise ValueError(
@@ -298,9 +292,7 @@ class FeatureParallelEmbedding(AbstractModuleBase):
             x: Token indices ``[batch_size, 1, 1, seq_len]``, replicated across TP.
 
         Returns:
-            ``sequence_parallel``: the full embedding sharded along the sequence,
-            ``[batch_size, 1, seq_len/tp, embedding_dim]``.
-            ``gather_output`` (default, non-SP): full embedding
+            ``gather_output`` (default): full embedding
             ``[batch_size, 1, seq_len, embedding_dim]`` replicated across TP.
             Otherwise the hidden-sharded slice
             ``[batch_size, 1, seq_len, embedding_dim/tp]``.
@@ -316,14 +308,9 @@ class FeatureParallelEmbedding(AbstractModuleBase):
         # GradOutputType.REPLICATED divides the backward reduce_scatter by tp_size
         # (output is replicated, consumed replicated), matching
         # ColumnParallelLinear(gather_output=True).
-        emb = ttml.ops.distributed.all_gather(
+        return ttml.ops.distributed.all_gather(
             emb,
             3,
             self.cluster_axis,
             ttml.ops.distributed.GradOutputType.REPLICATED,
         )
-
-        if self.sequence_parallel:
-            emb = ttml.ops.distributed.scatter(emb, 2, self.cluster_axis)
-
-        return emb

--- a/tt-train/sources/ttml/ttml/modules/linear.py
+++ b/tt-train/sources/ttml/ttml/modules/linear.py
@@ -13,6 +13,11 @@ import ttml
 from .module_base import AbstractModuleBase
 from .parameter import Parameter
 
+# Activations flow as 4-D tensors ``(B, 1, S, H)``; the sequence dimension is axis 2.
+# Under Megatron sequence parallelism the residual stream is sharded along this axis
+# across the tensor-parallel mesh axis, so the SP collectives target dim 2.
+_SEQUENCE_DIM = 2
+
 
 class LinearLayer(AbstractModuleBase):
     """Fully-connected linear layer: y = x @ W^T + b."""
@@ -92,6 +97,10 @@ class ColumnParallelLinear(AbstractModuleBase):
         gather_output: If ``True`` an all-gather is inserted after the matmul so
             the output is replicated across TP devices (needed when the consumer
             expects an un-sharded tensor, e.g. the final LM-head projection).
+        sequence_parallel: If ``True`` the input arrives sharded along the sequence
+            dimension across the TP axis (Megatron sequence parallelism). An
+            all-gather over the sequence dim reconstructs the full sequence before
+            the matmul.
         axis_name: Mesh axis used for tensor parallelism.
     """
 
@@ -103,6 +112,7 @@ class ColumnParallelLinear(AbstractModuleBase):
         weight_init: Callable | None = None,
         bias_init: Callable | None = None,
         gather_output: bool = False,
+        sequence_parallel: bool = False,
         axis_name: str = "tp",
     ) -> None:
         super().__init__()
@@ -110,6 +120,7 @@ class ColumnParallelLinear(AbstractModuleBase):
         self.in_features = in_features
         self.out_features = out_features
         self.gather_output = gather_output
+        self.sequence_parallel = sequence_parallel
         self.axis_name = axis_name
         self.cluster_axis = ttml.mesh().axis_index(axis_name)
 
@@ -133,8 +144,13 @@ class ColumnParallelLinear(AbstractModuleBase):
             self.bias = None
 
     def forward(self, x):
-        # Broadcast ensures the input is replicated across all TP devices.
-        x = ttml.ops.distributed.broadcast(x, self.cluster_axis)
+        if self.sequence_parallel:
+            x = ttml.ops.distributed.all_gather(
+                x, _SEQUENCE_DIM, self.cluster_axis, ttml.ops.distributed.GradOutputType.SHARDED
+            )
+        else:
+            # Broadcast ensures the input is replicated across all TP devices.
+            x = ttml.ops.distributed.broadcast(x, self.cluster_axis)
         bias_t = self.bias.tensor if self.bias is not None else None
         x = ttml.ops.linear.linear(x, self.weight.tensor, bias_t)
         if self.gather_output:
@@ -157,6 +173,10 @@ class RowParallelLinear(AbstractModuleBase):
             sharded along the feature dimension (e.g. the output of a
             ``ColumnParallelLinear`` with ``gather_output=False``).  When ``False``
             a scatter is inserted to partition the input.
+        sequence_parallel: If ``True`` the partial matmul outputs are combined with a
+            sequence reduce-scatter (Megatron sequence parallelism) instead of an
+            all-reduce: this sums the partial products across TP *and* shards the
+            result along the sequence, leaving the residual stream sequence-sharded.
         axis_name: Mesh axis used for tensor parallelism.
     """
 
@@ -168,14 +188,23 @@ class RowParallelLinear(AbstractModuleBase):
         weight_init: Callable | None = None,
         bias_init: Callable | None = None,
         input_is_parallel: bool = False,
+        sequence_parallel: bool = False,
         axis_name: str = "tp",
     ) -> None:
         super().__init__()
+
+        if sequence_parallel and not input_is_parallel:
+            # SP RowParallel always follows an SP ColumnParallel, whose output is
+            # already feature-sharded. A non-parallel (replicated) SP input would
+            # need a simultaneous sequence-gather + feature-scatter that Llama never
+            # exercises; reject it rather than emit a subtly wrong graph.
+            raise ValueError("RowParallelLinear: sequence_parallel requires input_is_parallel=True")
 
         self.in_features = in_features
         self.out_features = out_features
         # TODO: use ttnn.Tensor.tensor_topology() once CCL ops will properly update this property
         self.input_is_parallel = input_is_parallel
+        self.sequence_parallel = sequence_parallel
         self.axis_name = axis_name
         self.cluster_axis = ttml.mesh().axis_index(axis_name)
 
@@ -201,9 +230,12 @@ class RowParallelLinear(AbstractModuleBase):
             # Split the input along the feature dimension across TP devices.
             x = ttml.ops.distributed.scatter(x, 3, self.cluster_axis)
         x = ttml.ops.linear.linear(x, self.weight.tensor, None)
-        # Sum partial products across TP devices to obtain the full result.
-        x = ttml.ops.distributed.all_reduce(x, self.input_is_parallel, self.cluster_axis)
-        # Bias is replicated, so it is safe to add after the all-reduce.
+        if self.sequence_parallel:
+            # SP: sum partial products across TP and re-shard along the sequence in one step.
+            x = ttml.ops.distributed.reduce_scatter(x, _SEQUENCE_DIM, self.cluster_axis)
+        else:
+            # Sum partial products across TP devices to obtain the full result.
+            x = ttml.ops.distributed.all_reduce(x, self.input_is_parallel, self.cluster_axis)
         if self.bias is not None:
             x = ttml.ops.binary.add(x, self.bias.tensor)
         return x

--- a/tt-train/sources/ttml/ttml/modules/linear.py
+++ b/tt-train/sources/ttml/ttml/modules/linear.py
@@ -10,13 +10,26 @@ import ml_dtypes
 import ttnn
 import ttml
 
+from ttml.parallel import SEQUENCE_DIM, mark_sequence_parallel
+
 from .module_base import AbstractModuleBase
 from .parameter import Parameter
 
-# Activations flow as 4-D tensors ``(B, 1, S, H)``; the sequence dimension is axis 2.
-# Under Megatron sequence parallelism the residual stream is sharded along this axis
-# across the tensor-parallel mesh axis, so the SP collectives target dim 2.
-_SEQUENCE_DIM = 2
+
+def column_parallel_input(x, cluster_axis: int, sequence_parallel: bool):
+    """The input of a column-parallel matmul: the full sequence, replicated on every TP rank."""
+    if sequence_parallel:
+        return ttml.ops.distributed.all_gather(
+            x, SEQUENCE_DIM, cluster_axis, ttml.ops.distributed.GradOutputType.SHARDED
+        )
+    return ttml.ops.distributed.broadcast(x, cluster_axis)
+
+
+def row_parallel_output(x, cluster_axis: int, sequence_parallel: bool, input_is_parallel: bool):
+    """The output of a row-parallel matmul: the partial products summed across TP ranks."""
+    if sequence_parallel:
+        return ttml.ops.distributed.reduce_scatter(x, SEQUENCE_DIM, cluster_axis)
+    return ttml.ops.distributed.all_reduce(x, input_is_parallel, cluster_axis)
 
 
 class LinearLayer(AbstractModuleBase):
@@ -144,13 +157,7 @@ class ColumnParallelLinear(AbstractModuleBase):
             self.bias = None
 
     def forward(self, x):
-        if self.sequence_parallel:
-            x = ttml.ops.distributed.all_gather(
-                x, _SEQUENCE_DIM, self.cluster_axis, ttml.ops.distributed.GradOutputType.SHARDED
-            )
-        else:
-            # Broadcast ensures the input is replicated across all TP devices.
-            x = ttml.ops.distributed.broadcast(x, self.cluster_axis)
+        x = column_parallel_input(x, self.cluster_axis, self.sequence_parallel)
         bias_t = self.bias.tensor if self.bias is not None else None
         x = ttml.ops.linear.linear(x, self.weight.tensor, bias_t)
         if self.gather_output:
@@ -222,6 +229,8 @@ class RowParallelLinear(AbstractModuleBase):
         if has_bias:
             bias_shape = (1, 1, 1, out_features)
             self.bias = Parameter(bias_init(bias_shape))
+            if sequence_parallel:
+                mark_sequence_parallel(self.bias)
         else:
             self.bias = None
 
@@ -230,12 +239,7 @@ class RowParallelLinear(AbstractModuleBase):
             # Split the input along the feature dimension across TP devices.
             x = ttml.ops.distributed.scatter(x, 3, self.cluster_axis)
         x = ttml.ops.linear.linear(x, self.weight.tensor, None)
-        if self.sequence_parallel:
-            # SP: sum partial products across TP and re-shard along the sequence in one step.
-            x = ttml.ops.distributed.reduce_scatter(x, _SEQUENCE_DIM, self.cluster_axis)
-        else:
-            # Sum partial products across TP devices to obtain the full result.
-            x = ttml.ops.distributed.all_reduce(x, self.input_is_parallel, self.cluster_axis)
+        x = row_parallel_output(x, self.cluster_axis, self.sequence_parallel, self.input_is_parallel)
         if self.bias is not None:
             x = ttml.ops.binary.add(x, self.bias.tensor)
         return x

--- a/tt-train/sources/ttml/ttml/modules/lora.py
+++ b/tt-train/sources/ttml/ttml/modules/lora.py
@@ -116,6 +116,9 @@ class LoraColumnParallelLinear(AbstractModuleBase):
     def __init__(self, base_layer: ColumnParallelLinear, config: LoraConfig):
         super().__init__()
 
+        if base_layer.sequence_parallel:
+            raise NotImplementedError("LoraColumnParallelLinear does not support sequence parallelism.")
+
         self.in_features = base_layer.in_features
         self.out_features = base_layer.out_features
         self.gather_output = base_layer.gather_output
@@ -169,6 +172,9 @@ class LoraRowParallelLinear(AbstractModuleBase):
 
     def __init__(self, base_layer: RowParallelLinear, config: LoraConfig):
         super().__init__()
+
+        if base_layer.sequence_parallel:
+            raise NotImplementedError("LoraRowParallelLinear does not support sequence parallelism.")
 
         self.in_features = base_layer.in_features
         self.out_features = base_layer.out_features

--- a/tt-train/sources/ttml/ttml/modules/lora.py
+++ b/tt-train/sources/ttml/ttml/modules/lora.py
@@ -12,7 +12,15 @@ import numpy as np
 import ttnn
 import ttml
 
-from .linear import LinearLayer, ColumnParallelLinear, RowParallelLinear
+from ttml.parallel import mark_sequence_parallel
+
+from .linear import (
+    ColumnParallelLinear,
+    LinearLayer,
+    RowParallelLinear,
+    column_parallel_input,
+    row_parallel_output,
+)
 from .module_base import AbstractModuleBase, ModuleDict, ModuleList
 from .parameter import Parameter
 from _ttml.modules import RunMode
@@ -116,12 +124,10 @@ class LoraColumnParallelLinear(AbstractModuleBase):
     def __init__(self, base_layer: ColumnParallelLinear, config: LoraConfig):
         super().__init__()
 
-        if base_layer.sequence_parallel:
-            raise NotImplementedError("LoraColumnParallelLinear does not support sequence parallelism.")
-
         self.in_features = base_layer.in_features
         self.out_features = base_layer.out_features
         self.gather_output = base_layer.gather_output
+        self.sequence_parallel = base_layer.sequence_parallel
         self.axis_name = base_layer.axis_name
         self.cluster_axis = base_layer.cluster_axis
 
@@ -142,7 +148,7 @@ class LoraColumnParallelLinear(AbstractModuleBase):
 
     def forward(self, x):
         bias_t = self.bias.tensor if self.bias is not None else None
-        x = ttml.ops.distributed.broadcast(x, self.cluster_axis)
+        x = column_parallel_input(x, self.cluster_axis, self.sequence_parallel)
         base = ttml.ops.linear.linear(x, self.weight.tensor, bias_t)
         if self.gather_output:
             base = ttml.ops.distributed.all_gather(
@@ -173,12 +179,10 @@ class LoraRowParallelLinear(AbstractModuleBase):
     def __init__(self, base_layer: RowParallelLinear, config: LoraConfig):
         super().__init__()
 
-        if base_layer.sequence_parallel:
-            raise NotImplementedError("LoraRowParallelLinear does not support sequence parallelism.")
-
         self.in_features = base_layer.in_features
         self.out_features = base_layer.out_features
         self.input_is_parallel = base_layer.input_is_parallel
+        self.sequence_parallel = base_layer.sequence_parallel
         self.axis_name = base_layer.axis_name
         self.cluster_axis = base_layer.cluster_axis
 
@@ -196,22 +200,24 @@ class LoraRowParallelLinear(AbstractModuleBase):
         lora_A_mapper = ttml.mesh().axis_mapper(self.axis_name, tdim=3)
         self.lora_A = Parameter(_create_lora_A(self.in_features, config.rank, mapper=lora_A_mapper))
         self.lora_B = Parameter(_create_lora_B(config.rank, self.out_features))
+        if self.sequence_parallel:
+            # lora_B multiplies the sequence-sharded sum, so its grad is per-rank partial like the base bias.
+            mark_sequence_parallel(self.lora_B)
 
     def forward(self, x):
         if not self.input_is_parallel:
             x = ttml.ops.distributed.scatter(x, 3, self.cluster_axis)
         base = ttml.ops.linear.linear(x, self.weight.tensor, None)
-        base = ttml.ops.distributed.all_reduce(base, self.input_is_parallel, self.cluster_axis)
+        base = row_parallel_output(base, self.cluster_axis, self.sequence_parallel, self.input_is_parallel)
         if self.bias is not None:
             base = ttml.ops.binary.add(base, self.bias.tensor)
-        # lora_A is row-sharded (each device sees a slice of in_features), so
-        # an all_reduce is needed after lora_A to sum partial projections before
-        # the replicated lora_B can be applied.
+        # lora_A is row-sharded (each device sees a slice of in_features), so its partial
+        # projections are summed exactly like the base path's before the replicated lora_B.
         lora_input = x
         if self.get_run_mode() == RunMode.TRAIN and self.dropout_prob > 0.0:
             lora_input = ttml.ops.dropout.dropout(x, self.dropout_prob)
         h = ttml.ops.linear.linear(lora_input, self.lora_A.tensor, None)
-        h = ttml.ops.distributed.all_reduce(h, self.input_is_parallel, self.cluster_axis)
+        h = row_parallel_output(h, self.cluster_axis, self.sequence_parallel, self.input_is_parallel)
         lora_update = ttml.ops.linear.linear(h, self.lora_B.tensor, None)
         return base + lora_update * self.scaling
 

--- a/tt-train/sources/ttml/ttml/parallel.py
+++ b/tt-train/sources/ttml/ttml/parallel.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tensor-parallel strategy for TTML models."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class TPStrategy(Enum):
+    """How tensor parallelism is applied to a model.
+
+    - ``NONE``            -- no tensor parallelism (single device / DP / FSDP only).
+    - ``TENSOR``          -- Megatron tensor parallelism: activations are replicated across
+      the ``tp`` axis between the sharded matmuls (all-reduce / broadcast).
+    - ``TENSOR_SEQUENCE`` -- tensor parallelism **plus** Megatron sequence parallelism: the
+      residual stream is sharded along the sequence across the ``tp`` axis in the
+      norm/dropout/residual regions (reduce-scatter / all-gather). Requires a ``tp`` axis.
+    """
+
+    NONE = "none"
+    TENSOR = "tensor"
+    TENSOR_SEQUENCE = "tensor_sequence"
+
+    @classmethod
+    def from_flags(cls, enable_tp: bool, *, enable_sp: bool = False) -> "TPStrategy":
+        """Map the ``(enable_tp, enable_sp)`` device-config flags to a strategy.
+
+        Sequence parallelism shards the tensor-parallel residual stream, so it requires
+        tensor parallelism; ``enable_sp`` without ``enable_tp`` is rejected here.
+        """
+        if enable_sp and not enable_tp:
+            raise ValueError("enable_sp (sequence parallelism) requires enable_tp (tensor parallelism)")
+        if not enable_tp:
+            return cls.NONE
+        return cls.TENSOR_SEQUENCE if enable_sp else cls.TENSOR
+
+    @property
+    def tensor_parallel(self) -> bool:
+        """True if any tensor parallelism is active (``TENSOR`` or ``TENSOR_SEQUENCE``)."""
+        return self is not TPStrategy.NONE
+
+    @property
+    def sequence_parallel(self) -> bool:
+        """True if Megatron sequence parallelism is active (``TENSOR_SEQUENCE``)."""
+        return self is TPStrategy.TENSOR_SEQUENCE

--- a/tt-train/sources/ttml/ttml/parallel.py
+++ b/tt-train/sources/ttml/ttml/parallel.py
@@ -2,11 +2,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tensor-parallel strategy for TTML models."""
+"""Tensor-parallel strategy for TTML models, and the marker for sequence-parallel parameters."""
 
 from __future__ import annotations
 
 from enum import Enum
+from typing import Any
+
+# Activations flow as 4-D ``(B, 1, S, H)`` tensors; sequence parallelism shards dim 2 across the tp axis.
+SEQUENCE_DIM = 2
 
 
 class TPStrategy(Enum):
@@ -46,3 +50,13 @@ class TPStrategy(Enum):
     def sequence_parallel(self) -> bool:
         """True if Megatron sequence parallelism is active (``TENSOR_SEQUENCE``)."""
         return self is TPStrategy.TENSOR_SEQUENCE
+
+
+def mark_sequence_parallel(parameter) -> None:
+    """Flag a parameter that is applied to the sequence-sharded residual stream."""
+    parameter.add_post_materialize_callback(lambda p: setattr(p.tensor, "_sequence_parallel", True))
+
+
+def is_sequence_parallel(param_tensor: Any) -> bool:
+    """True if :func:`mark_sequence_parallel` flagged this parameter tensor."""
+    return getattr(param_tensor, "_sequence_parallel", False)

--- a/tt-train/sources/ttml/ttml/trainers/grpo_trainer.py
+++ b/tt-train/sources/ttml/ttml/trainers/grpo_trainer.py
@@ -669,7 +669,7 @@ class GRPOTrainer:
                 optimizer.set_lr(base_lr * warmup_factor)
 
                 if fsdp_enabled:
-                    ttml.sync_gradients(tt_model.parameters(), axis_names=fsdp_sync_axes)
+                    ttml.sync_gradients(tt_model.parameters())
                 elif ddp_context_enabled:
                     # Parallelism-context DDP (Llama completer): a parallelism
                     # context is initialized, so use its gradient sync.
@@ -684,7 +684,7 @@ class GRPOTrainer:
                     # axis — the same primitive FSDP uses. The loss normalization
                     # divides by ``grad_sync_world_size`` (= the "dp" axis size
                     # here), matched to this reduction.
-                    ttml.sync_gradients(tt_model.parameters(), axis_names=("dp",))
+                    ttml.sync_gradients(tt_model.parameters())
 
                 for cb in self.callbacks:
                     cb.on_before_optimizer_step(self)

--- a/tt-train/sources/ttml/ttml/trainers/sft_trainer.py
+++ b/tt-train/sources/ttml/ttml/trainers/sft_trainer.py
@@ -505,7 +505,7 @@ class SFTTrainer:
         """Pick the cross-entropy variant matching the LM head's logit sharding.
 
         When the active mesh has a TP axis with size > 1 the conventional
-        SFTTrainer model shape (Llama with ``use_tp=True`` or
+        SFTTrainer model shape (a tensor-parallel Llama, or
         ``models.distributed.{llama,gpt2}``) emits vocab-sharded logits via
         ``ColumnParallelLinear(gather_output=False)``.  Plain
         ``cross_entropy_loss`` would compute its softmax denominator over each

--- a/tt-train/sources/ttml/ttml/trainers/sft_trainer.py
+++ b/tt-train/sources/ttml/ttml/trainers/sft_trainer.py
@@ -56,6 +56,9 @@ class SFTConfig:
         gradient_checkpointing: Enable activation recomputation to reduce
             memory usage at the cost of ~30 % extra compute.  Sets the
             model's ``runner_type`` to ``MemoryEfficient``.
+        sequence_parallel: Sum the gradients of tp-replicated params (RMSNorm gammas)
+            over the ``tp`` axis each step, since each tp rank saw only its slice of
+            the sequence.  Requires a model built with ``sequence_parallel=True``.
     """
 
     # ---- loop ----
@@ -76,6 +79,7 @@ class SFTConfig:
     gradient_checkpointing: bool = False
     # If True, tqdm progress bar (and its loss/lr postfix) is suppressed.
     disable_progress_bar: bool = False
+    sequence_parallel: bool = False
 
 
 class SFTTrainer:
@@ -173,6 +177,15 @@ class SFTTrainer:
         if config.seed is not None:
             ttml.autograd.AutoContext.get_instance().set_seed(config.seed)
 
+        # Read the strategy before any wrapping: LoraModel holds the real model at .model and
+        # forwards no attributes, so this has to happen while `model` is still the model itself.
+        # Models that expose no tp_strategy (every non-Llama one) leave the check inactive.
+        strategy = getattr(getattr(model, "config", None), "tp_strategy", None)
+        if strategy is not None and config.sequence_parallel != strategy.sequence_parallel:
+            raise ValueError(
+                f"SFTConfig.sequence_parallel={config.sequence_parallel} disagrees with the model's {strategy}."
+            )
+
         if peft_config is not None:
             from ttml.modules.lora import LoraModel
 
@@ -263,6 +276,9 @@ class SFTTrainer:
 
             if self._grad_sync_axes:
                 ttml.sync_gradients(self.model.parameters(), axis_names=self._grad_sync_axes)
+
+            if cfg.sequence_parallel:
+                ttml.sync_sequence_parallel_gradients(self.model.parameters(), "tp")
 
             for cb in list(self._callbacks):
                 cb.on_before_optimizer_step(self)

--- a/tt-train/sources/ttml/ttml/trainers/sft_trainer.py
+++ b/tt-train/sources/ttml/ttml/trainers/sft_trainer.py
@@ -56,9 +56,6 @@ class SFTConfig:
         gradient_checkpointing: Enable activation recomputation to reduce
             memory usage at the cost of ~30 % extra compute.  Sets the
             model's ``runner_type`` to ``MemoryEfficient``.
-        sequence_parallel: Sum the gradients of tp-replicated params (RMSNorm gammas)
-            over the ``tp`` axis each step, since each tp rank saw only its slice of
-            the sequence.  Requires a model built with ``sequence_parallel=True``.
     """
 
     # ---- loop ----
@@ -79,7 +76,6 @@ class SFTConfig:
     gradient_checkpointing: bool = False
     # If True, tqdm progress bar (and its loss/lr postfix) is suppressed.
     disable_progress_bar: bool = False
-    sequence_parallel: bool = False
 
 
 class SFTTrainer:
@@ -177,15 +173,6 @@ class SFTTrainer:
         if config.seed is not None:
             ttml.autograd.AutoContext.get_instance().set_seed(config.seed)
 
-        # Read the strategy before any wrapping: LoraModel holds the real model at .model and
-        # forwards no attributes, so this has to happen while `model` is still the model itself.
-        # Models that expose no tp_strategy (every non-Llama one) leave the check inactive.
-        strategy = getattr(getattr(model, "config", None), "tp_strategy", None)
-        if strategy is not None and config.sequence_parallel != strategy.sequence_parallel:
-            raise ValueError(
-                f"SFTConfig.sequence_parallel={config.sequence_parallel} disagrees with the model's {strategy}."
-            )
-
         if peft_config is not None:
             from ttml.modules.lora import LoraModel
 
@@ -199,8 +186,6 @@ class SFTTrainer:
         self.eval_dataloader = eval_dataloader
         self.config = config
         self.step = 0  # 0-based; incremented after each optimizer step
-        # Axes to all-reduce gradients across each step; empty (single-device / TP-only) = no-op.
-        self._grad_sync_axes = self._resolve_grad_sync_axes()
         self._validate_clip_grad_norm()
 
         self._optimizer = self._build_optimizer(optimizer)
@@ -274,11 +259,7 @@ class SFTTrainer:
                     cb.on_after_backward(self, batch)
                 ttml.autograd.AutoContext.get_instance().reset_graph()
 
-            if self._grad_sync_axes:
-                ttml.sync_gradients(self.model.parameters(), axis_names=self._grad_sync_axes)
-
-            if cfg.sequence_parallel:
-                ttml.sync_sequence_parallel_gradients(self.model.parameters(), "tp")
+            ttml.sync_gradients(self.model.parameters())
 
             for cb in list(self._callbacks):
                 cb.on_before_optimizer_step(self)
@@ -577,17 +558,3 @@ class SFTTrainer:
                 "clip_grad_norm is not supported with sharded parameters (FSDP/TP): each device holds "
                 "only a shard, so the per-shard norm is wrong"
             )
-
-    @staticmethod
-    def _resolve_grad_sync_axes() -> tuple[str, ...]:
-        """Mesh axes to all-reduce gradients across each step.
-
-        The subset of ``("dp", "fsdp")`` present on the active mesh with size > 1; empty otherwise
-        (single device / TP-only). FSDP-sharded params are skipped per-axis by ``ttml.sync_gradients``
-        (``fully_shard``'s backward hooks already reduce-scattered them), so this covers DDP, the dp axis
-        of HSDP, and non-sharded params on the fsdp axis.
-        """
-        mesh = ttml.maybe_mesh()
-        if mesh is None:
-            return ()
-        return tuple(name for name in ("dp", "fsdp") if mesh.has_axis(name) and mesh.axis_size(name) > 1)

--- a/tt-train/tests/python/test_llama_safetensors_loader.py
+++ b/tt-train/tests/python/test_llama_safetensors_loader.py
@@ -479,6 +479,7 @@ class TestCoverageAgainstRealModels:
             (TPStrategy.TENSOR, EmbeddingPlacement.VocabParallel, WeightTyingType.Disabled),
             (TPStrategy.TENSOR, EmbeddingPlacement.VocabParallel, WeightTyingType.Enabled),
             (TPStrategy.TENSOR, EmbeddingPlacement.FeatureParallel, WeightTyingType.Disabled),
+            (TPStrategy.TENSOR_SEQUENCE, EmbeddingPlacement.VocabParallel, WeightTyingType.Disabled),
         ],
         ids=lambda v: v.name,
     )
@@ -539,6 +540,28 @@ class TestLoadIntoModel:
         }[placement]
         got = read_param(params, "Llama/tok_emb/weight", embedding_shard)
         assert np.array_equal(got, as_bf16(hf["model.embed_tokens.weight"])), "token embedding"
+
+    def test_sequence_parallel_layout_matches_tensor_parallel(self, tmp_path):
+        """SP changes the collectives, not the weight sharding, so the loader needs no SP path."""
+        write_hf_checkpoint(tmp_path)
+        weights = {}
+        for strategy in (TPStrategy.TENSOR, TPStrategy.TENSOR_SEQUENCE):
+            config = e2e_config(strategy, EmbeddingPlacement.VocabParallel)
+            model = Llama(config)
+            load_from_safetensors(model, tmp_path, config)
+            params = model.parameters()
+            weights[strategy] = {
+                name: read_param(params, name, shard_dim)
+                for name, shard_dim in (
+                    ("Llama/blocks/0/attention/qkv_linear/weight", ROW_DIM),
+                    ("Llama/blocks/0/mlp/w_gate_up/weight", ROW_DIM),
+                    ("Llama/blocks/0/attention/out_linear/weight", COL_DIM),
+                    ("Llama/tok_emb/weight", ROW_DIM),
+                )
+            }
+
+        for name, tp_weight in weights[TPStrategy.TENSOR].items():
+            assert np.array_equal(weights[TPStrategy.TENSOR_SEQUENCE][name], tp_weight), f"{name}: SP layout differs"
 
     @pytest.mark.parametrize("dtype", [np.float32, ml_dtypes.bfloat16], ids=["f32", "bf16"])
     def test_reports_a_clean_load(self, tmp_path, capsys, dtype):

--- a/tt-train/tests/python/test_llama_safetensors_loader.py
+++ b/tt-train/tests/python/test_llama_safetensors_loader.py
@@ -31,6 +31,7 @@ from ttml.models.llama.safetensors_loader import (
     _tp_axis,
     _unpermute_proj_rows,
 )
+from ttml.parallel import TPStrategy
 
 HEAD_DIM = 8  # even: RoPE splits each head into two halves
 HIDDEN = 16
@@ -362,9 +363,9 @@ class TestCoverage:
 # ── End-to-end: a synthetic HF checkpoint through the real loader ──
 
 
-def e2e_config(use_tp: bool, placement: EmbeddingPlacement, **overrides) -> LlamaConfig:
+def e2e_config(tp_strategy: TPStrategy, placement: EmbeddingPlacement, **overrides) -> LlamaConfig:
     return coverage_config(
-        use_tp=use_tp,
+        tp_strategy=tp_strategy,
         embedding_placement=placement,
         weight_tying=WeightTyingType.Disabled,
         **overrides,
@@ -470,24 +471,24 @@ class TestConsumerContract:
 @pytest.mark.usefixtures("tp_mesh")
 class TestCoverageAgainstRealModels:
     @pytest.mark.parametrize(
-        "use_tp,placement,tying",
+        "tp_strategy,placement,tying",
         [
-            (False, EmbeddingPlacement.Replicated, WeightTyingType.Disabled),
-            (False, EmbeddingPlacement.Replicated, WeightTyingType.Enabled),
-            (True, EmbeddingPlacement.Replicated, WeightTyingType.Disabled),
-            (True, EmbeddingPlacement.VocabParallel, WeightTyingType.Disabled),
-            (True, EmbeddingPlacement.VocabParallel, WeightTyingType.Enabled),
-            (True, EmbeddingPlacement.FeatureParallel, WeightTyingType.Disabled),
+            (TPStrategy.NONE, EmbeddingPlacement.Replicated, WeightTyingType.Disabled),
+            (TPStrategy.NONE, EmbeddingPlacement.Replicated, WeightTyingType.Enabled),
+            (TPStrategy.TENSOR, EmbeddingPlacement.Replicated, WeightTyingType.Disabled),
+            (TPStrategy.TENSOR, EmbeddingPlacement.VocabParallel, WeightTyingType.Disabled),
+            (TPStrategy.TENSOR, EmbeddingPlacement.VocabParallel, WeightTyingType.Enabled),
+            (TPStrategy.TENSOR, EmbeddingPlacement.FeatureParallel, WeightTyingType.Disabled),
         ],
-        ids=lambda v: getattr(v, "name", str(v)),
+        ids=lambda v: v.name,
     )
-    def test_rules_cover_the_model(self, use_tp, placement, tying):
-        config = coverage_config(use_tp=use_tp, embedding_placement=placement, weight_tying=tying)
+    def test_rules_cover_the_model(self, tp_strategy, placement, tying):
+        config = coverage_config(tp_strategy=tp_strategy, embedding_placement=placement, weight_tying=tying)
         names = set(Llama(config).parameters())
         _check_coverage(names, list(_rules(config, names)), frozenset())
 
     def test_biased_attention_is_coverable(self):
-        config = coverage_config(use_tp=True, attention_bias=True)
+        config = coverage_config(tp_strategy=TPStrategy.TENSOR, attention_bias=True)
         names = set(Llama(config).parameters())
         _check_coverage(names, list(_rules(config, names)), frozenset())
 
@@ -502,7 +503,7 @@ class TestLoadIntoModel:
     )
     def test_tensor_parallel_layout(self, tmp_path, placement):
         hf = write_hf_checkpoint(tmp_path)
-        config = e2e_config(True, placement)
+        config = e2e_config(TPStrategy.TENSOR, placement)
         model = Llama(config)
         load_from_safetensors(model, tmp_path, config)
 
@@ -542,7 +543,7 @@ class TestLoadIntoModel:
     @pytest.mark.parametrize("dtype", [np.float32, ml_dtypes.bfloat16], ids=["f32", "bf16"])
     def test_reports_a_clean_load(self, tmp_path, capsys, dtype):
         hf = write_hf_checkpoint(tmp_path, dtype=dtype)
-        config = e2e_config(True, EmbeddingPlacement.VocabParallel)
+        config = e2e_config(TPStrategy.TENSOR, EmbeddingPlacement.VocabParallel)
         model = Llama(config)
         load_from_safetensors(model, tmp_path, config)
 
@@ -557,13 +558,13 @@ class TestLoadIntoModel:
         tensors = {k: v for k, v in write_hf_checkpoint(tmp_path).items() if "v_proj" not in k}
         save_checkpoint(tmp_path, tensors)
 
-        config = e2e_config(True, EmbeddingPlacement.VocabParallel)
+        config = e2e_config(TPStrategy.TENSOR, EmbeddingPlacement.VocabParallel)
         with expect_error(RuntimeError, "the checkpoint has no"):
             load_from_safetensors(Llama(config), tmp_path, config)
 
     def test_without_tensor_parallelism_is_a_plain_concat(self, tmp_path):
         hf = write_hf_checkpoint(tmp_path)
-        config = e2e_config(False, EmbeddingPlacement.Replicated)
+        config = e2e_config(TPStrategy.NONE, EmbeddingPlacement.Replicated)
         model = Llama(config)
         load_from_safetensors(model, tmp_path, config)
 
@@ -588,7 +589,7 @@ class TestLoadIntoModel:
         """The one end-to-end vocab that is not tile-aligned: 120 rounds up to 128, and the pad rows shard too."""
         vocab = VOCAB - 8
         hf = write_hf_checkpoint(tmp_path, vocab=vocab)
-        config = e2e_config(True, EmbeddingPlacement.VocabParallel, vocab_size=vocab)
+        config = e2e_config(TPStrategy.TENSOR, EmbeddingPlacement.VocabParallel, vocab_size=vocab)
         model = Llama(config)
         load_from_safetensors(model, tmp_path, config)
 
@@ -600,14 +601,14 @@ class TestLoadIntoModel:
     def test_rejects_a_checkpoint_whose_vocab_disagrees_with_the_config(self, tmp_path, expect_error):
         """A short checkpoint must not load with noise where its missing tokens should be."""
         write_hf_checkpoint(tmp_path, vocab=VOCAB - 8)
-        config = e2e_config(True, EmbeddingPlacement.VocabParallel)
+        config = e2e_config(TPStrategy.TENSOR, EmbeddingPlacement.VocabParallel)
         with expect_error(RuntimeError, "does not match the config-implied shape"):
             load_from_safetensors(Llama(config), tmp_path, config)
 
     def test_forward_runs_on_loaded_weights(self, tmp_path):
         """Loaded weights must actually drive the fused ops, not just sit at the right shape."""
         write_hf_checkpoint(tmp_path)
-        config = e2e_config(True, EmbeddingPlacement.VocabParallel)
+        config = e2e_config(TPStrategy.TENSOR, EmbeddingPlacement.VocabParallel)
         model = Llama(config)
         load_from_safetensors(model, tmp_path, config)
         model.eval()

--- a/tt-train/tests/python/test_sequence_parallel.py
+++ b/tt-train/tests/python/test_sequence_parallel.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Megatron sequence parallelism (``TPStrategy.TENSOR_SEQUENCE``) on Llama.
+The oracle is classic tensor parallelism.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import ttnn
+import ttml
+from ttml.models import EmbeddingPlacement, WeightTyingType
+from ttml.models.llama import Llama, LlamaConfig
+from ttml.models.llama.gqattn import GroupedQueryAttention
+from ttml.parallel import TPStrategy
+from ttml.testing import assert_within_ulp, read_mesh_tensor
+
+pytestmark = pytest.mark.requires_device
+
+TP_AXIS_SIZE = 2  # the 'tp' extent of conftest's tp_mesh fixture
+
+# Logits agree bitwise at tp=2 and the worst gradient disagreement is 1 ULP, entirely in the
+# norm gammas. The limit stays above both so that summing more than two ranks, whose rounding
+# genuinely is order-dependent, does not become flaky.
+MAX_ULP = 2.0
+
+# Two tiles of sequence per rank; one tile would not exercise a multi-tile shard.
+SEQ_LEN = 32 * TP_AXIS_SIZE * 2
+HIDDEN = 128
+N_HEADS = 4
+N_KV_HEADS = 2
+N_LAYERS = 2
+INTERMEDIATE = 128
+VOCAB = 128
+NATIVE = ttml.autograd.PreferredPrecision.NATIVE
+
+
+def config(tp_strategy: TPStrategy, seq_len: int = SEQ_LEN) -> LlamaConfig:
+    return LlamaConfig(
+        hidden_size=HIDDEN,
+        num_attention_heads=N_HEADS,
+        num_key_value_heads=N_KV_HEADS,
+        num_hidden_layers=N_LAYERS,
+        intermediate_size=INTERMEDIATE,
+        vocab_size=VOCAB,
+        max_position_embeddings=seq_len,
+        tp_strategy=tp_strategy,
+        embedding_placement=EmbeddingPlacement.VocabParallel,
+        weight_tying=WeightTyingType.Disabled,
+    )
+
+
+def paired_models() -> tuple[Llama, Llama]:
+    """A TP model and an SP model holding bitwise-identical weights."""
+    tp_model, sp_model = Llama(config(TPStrategy.TENSOR)), Llama(config(TPStrategy.TENSOR_SEQUENCE))
+    source, destination = tp_model.parameters(), sp_model.parameters()
+    assert set(source.keys()) == set(destination.keys())
+    for name in source.keys():
+        destination[name].set_value(source[name].get_value(NATIVE))
+        assert destination[name].get_value(NATIVE).dtype == source[name].get_value(NATIVE).dtype, name
+    return tp_model, sp_model
+
+
+def token_ids(batch: int, seq_len: int, seed: int):
+    ids = np.random.default_rng(seed).integers(0, VOCAB, (batch, 1, 1, seq_len)).astype(np.uint32)
+    return ttml.autograd.Tensor.from_numpy(ids, ttnn.Layout.ROW_MAJOR, ttnn.DataType.UINT32)
+
+
+def causal_mask(seq_len: int):
+    mask = np.tril(np.ones((1, 1, seq_len, seq_len), dtype=np.float32))
+    return ttml.autograd.Tensor.from_numpy(mask, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16)
+
+
+def rope_params(seq_len: int = SEQ_LEN):
+    return ttml.ops.rope.build_rope_params(seq_len, HIDDEN // N_HEADS, 500000.0, ttml.ops.rope.RopeScalingParams())
+
+
+@pytest.mark.usefixtures("tp_mesh")
+class TestMatchesTensorParallel:
+    @pytest.mark.parametrize("batch", [1, 2])
+    def test_logits(self, batch):
+        tp_model, sp_model = paired_models()
+        tp_model.eval()
+        sp_model.eval()
+
+        ids, mask = token_ids(batch, SEQ_LEN, seed=1234 + batch), causal_mask(SEQ_LEN)
+        # Logits stay vocab-sharded under both strategies (gather_output=False).
+        tp_logits = read_mesh_tensor(tp_model(ids, mask), {"tp": 3})
+        sp_logits = read_mesh_tensor(sp_model(ids, mask), {"tp": 3})
+
+        assert tp_logits.std() > 1e-3, "logits are ~constant; agreement would prove nothing"
+        assert_within_ulp(sp_logits, tp_logits, f"logits batch={batch}", MAX_ULP)
+
+    def test_gradients_after_sequence_parallel_sync(self):
+        tp_model, sp_model = paired_models()
+        ids, mask = token_ids(1, SEQ_LEN, seed=77), causal_mask(SEQ_LEN)
+        for model in (tp_model, sp_model):
+            model.train()
+            model(ids, mask).backward(retain_graph=False)
+
+        ttml.sync_sequence_parallel_gradients(sp_model.parameters(), "tp")
+
+        tp_params, sp_params = tp_model.parameters(), sp_model.parameters()
+        for name in tp_params.keys():
+            assert tp_params[name].is_grad_initialized(), f"{name}: TP grad missing"
+            assert sp_params[name].is_grad_initialized(), f"{name}: SP grad missing"
+            assert_within_ulp(
+                read_mesh_tensor(sp_params[name].get_grad_tensor()),
+                read_mesh_tensor(tp_params[name].get_grad_tensor()),
+                f"grad {name}",
+                MAX_ULP,
+            )
+
+
+@pytest.mark.usefixtures("tp_mesh")
+class TestValidation:
+    def test_rejects_replicated_embedding(self, expect_error):
+        with expect_error(ValueError, "sequence parallelism needs the embedding"):
+            LlamaConfig(
+                hidden_size=HIDDEN,
+                num_attention_heads=N_HEADS,
+                num_key_value_heads=N_KV_HEADS,
+                intermediate_size=INTERMEDIATE,
+                max_position_embeddings=SEQ_LEN,
+                tp_strategy=TPStrategy.TENSOR_SEQUENCE,
+                embedding_placement=EmbeddingPlacement.Replicated,
+            )
+
+    def test_rejects_max_positions_not_divisible_by_32_tp(self, expect_error):
+        with expect_error(ValueError, "max_position_embeddings divisible by"):
+            config(TPStrategy.TENSOR_SEQUENCE, seq_len=32)
+
+    def test_rejects_input_sequence_not_divisible_by_32_tp(self, expect_error):
+        """The config gate covers max_position_embeddings; a shorter input needs its own."""
+        model = Llama(config(TPStrategy.TENSOR_SEQUENCE))
+        with expect_error(ValueError, "input sequence length divisible by"):
+            model(token_ids(1, 32, seed=5), causal_mask(32))
+
+    def test_rejects_kv_cache_decode(self, expect_error):
+        """Single-token decode has nothing to shard along the sequence."""
+        attention = GroupedQueryAttention(
+            embedding_size=HIDDEN,
+            num_heads=N_HEADS,
+            num_groups=N_KV_HEADS,
+            dropout=0.0,
+            rope_params=rope_params(),
+            tp_strategy=TPStrategy.TENSOR_SEQUENCE,
+        )
+        hidden = ttml.autograd.Tensor.from_numpy(
+            np.zeros((1, 1, SEQ_LEN, HIDDEN), np.float32), ttnn.Layout.TILE, ttnn.DataType.BFLOAT16
+        )
+        kv_cache = ttml.models.KvCache(
+            num_layers=N_LAYERS,
+            batch_size=1,
+            num_groups=attention.num_groups,
+            max_seq_len=SEQ_LEN,
+            head_dim=HIDDEN // N_HEADS,
+        )
+        with expect_error(NotImplementedError, "sequence_parallel does not support"):
+            attention(hidden, causal_mask(SEQ_LEN), kv_cache=kv_cache, layer_idx=0, new_tokens=1)
+
+
+class TestTPStrategy:
+    def test_from_flags(self):
+        assert TPStrategy.from_flags(False) is TPStrategy.NONE
+        assert TPStrategy.from_flags(True) is TPStrategy.TENSOR
+        assert TPStrategy.from_flags(True, enable_sp=True) is TPStrategy.TENSOR_SEQUENCE
+
+    def test_rejects_sp_without_tp(self, expect_error):
+        with expect_error(ValueError, "requires enable_tp"):
+            TPStrategy.from_flags(False, enable_sp=True)
+
+    def test_enable_sp_is_keyword_only(self, expect_error):
+        with expect_error(TypeError, "positional argument"):
+            TPStrategy.from_flags(True, True)  # type: ignore
+
+    @pytest.mark.parametrize(
+        "strategy,tensor,sequence",
+        [
+            (TPStrategy.NONE, False, False),
+            (TPStrategy.TENSOR, True, False),
+            (TPStrategy.TENSOR_SEQUENCE, True, True),
+        ],
+    )
+    def test_properties(self, strategy, tensor, sequence):
+        assert strategy.tensor_parallel is tensor
+        assert strategy.sequence_parallel is sequence
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tt-train/tests/python/test_sequence_parallel.py
+++ b/tt-train/tests/python/test_sequence_parallel.py
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for Megatron sequence parallelism (``TPStrategy.TENSOR_SEQUENCE``) on Llama.
-The oracle is classic tensor parallelism.
+"""Megatron sequence parallelism (``TPStrategy.TENSOR_SEQUENCE``) on Llama.
+The oracle is classic tensor parallelism on the same weights.
 """
 
 from __future__ import annotations
@@ -15,11 +15,9 @@ import ttnn
 import ttml
 from ttml.models import EmbeddingPlacement, WeightTyingType
 from ttml.models.llama import Llama, LlamaConfig
-from ttml.models.llama.gqattn import GroupedQueryAttention
-from ttml.parallel import TPStrategy
-from ttml.testing import assert_within_ulp, read_mesh_tensor
-
-pytestmark = pytest.mark.requires_device
+from ttml.modules import LoraConfig, LoraModel
+from ttml.parallel import TPStrategy, is_sequence_parallel
+from ttml.testing import assert_within_ulp
 
 TP_AXIS_SIZE = 2  # the 'tp' extent of conftest's tp_mesh fixture
 
@@ -36,10 +34,11 @@ N_KV_HEADS = 2
 N_LAYERS = 2
 INTERMEDIATE = 128
 VOCAB = 128
-NATIVE = ttml.autograd.PreferredPrecision.NATIVE
+TP, SP = TPStrategy.TENSOR, TPStrategy.TENSOR_SEQUENCE
+PLACEMENTS = list(EmbeddingPlacement)
 
 
-def config(tp_strategy: TPStrategy, seq_len: int = SEQ_LEN) -> LlamaConfig:
+def config(tp_strategy: TPStrategy, placement=EmbeddingPlacement.VocabParallel, **overrides) -> LlamaConfig:
     return LlamaConfig(
         hidden_size=HIDDEN,
         num_attention_heads=N_HEADS,
@@ -47,22 +46,25 @@ def config(tp_strategy: TPStrategy, seq_len: int = SEQ_LEN) -> LlamaConfig:
         num_hidden_layers=N_LAYERS,
         intermediate_size=INTERMEDIATE,
         vocab_size=VOCAB,
-        max_position_embeddings=seq_len,
+        max_position_embeddings=SEQ_LEN,
         tp_strategy=tp_strategy,
-        embedding_placement=EmbeddingPlacement.VocabParallel,
+        embedding_placement=placement,
         weight_tying=WeightTyingType.Disabled,
+        **overrides,
     )
 
 
-def paired_models() -> tuple[Llama, Llama]:
-    """A TP model and an SP model holding bitwise-identical weights."""
-    tp_model, sp_model = Llama(config(TPStrategy.TENSOR)), Llama(config(TPStrategy.TENSOR_SEQUENCE))
-    source, destination = tp_model.parameters(), sp_model.parameters()
-    assert set(source.keys()) == set(destination.keys())
-    for name in source.keys():
-        destination[name].set_value(source[name].get_value(NATIVE))
-        assert destination[name].get_value(NATIVE).dtype == source[name].get_value(NATIVE).dtype, name
-    return tp_model, sp_model
+def paired_models(placement=EmbeddingPlacement.VocabParallel, **overrides) -> tuple[Llama, Llama]:
+    """A TP model and an SP model built from one seed: the same weights in independent storage."""
+    models = []
+    for strategy in (TP, SP):
+        ttml.manual_seed(0)
+        models.append(Llama(config(strategy, placement, **overrides)))
+    return tuple(models)
+
+
+def adamw(model):
+    return ttml.optimizers.AdamW(model.parameters(), ttml.optimizers.AdamWConfig.make(1e-2, 0.9, 0.999, 1e-8, 0.0))
 
 
 def token_ids(batch: int, seq_len: int, seed: int):
@@ -75,93 +77,137 @@ def causal_mask(seq_len: int):
     return ttml.autograd.Tensor.from_numpy(mask, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16)
 
 
-def rope_params(seq_len: int = SEQ_LEN):
-    return ttml.ops.rope.build_rope_params(seq_len, HIDDEN // N_HEADS, 500000.0, ttml.ops.rope.RopeScalingParams())
+def per_rank(tensor) -> np.ndarray:
+    """Every tp rank's copy of ``tensor`` stacked along dim 1, which is 1 on every tensor here, so SP
+    and TP tensors compare rank by rank whatever their placement. The layout is imposed by a composer
+    rather than read off the tensor: activation and gradient topologies are stale after collectives."""
+    mesh = ttml.mesh()
+    dims = [0] * len(mesh.shape)
+    dims[mesh.axis_index("tp")] = 1
+    device = ttml.autograd.AutoContext.get_instance().get_device()
+    composer = ttnn.create_mesh_composer(device, ttnn.MeshComposerConfig(dims))
+    return tensor.to_numpy(ttnn.DataType.FLOAT32, composer=composer).astype(np.float64)
 
 
+def backward(model, ids, mask) -> None:
+    model.train()
+    model(ids, mask).backward(retain_graph=False)
+    ttml.autograd.AutoContext.get_instance().reset_graph()
+
+
+def assert_same_grads(sp_model, tp_model, label: str = "") -> None:
+    tp_params, sp_params = tp_model.parameters(), sp_model.parameters()
+    assert set(tp_params.keys()) == set(sp_params.keys())
+    for name, tp_param in tp_params.items():
+        if not tp_param.get_requires_grad():
+            continue
+        assert sp_params[name].is_grad_initialized(), f"{name}: SP grad missing"
+        assert_within_ulp(
+            per_rank(sp_params[name].get_grad_tensor()),
+            per_rank(tp_param.get_grad_tensor()),
+            f"grad {name} {label}",
+            MAX_ULP,
+        )
+
+
+@pytest.fixture(autouse=True)
+def reset_graph():
+    yield
+    ttml.autograd.AutoContext.get_instance().reset_graph()
+
+
+@pytest.mark.requires_device
 @pytest.mark.usefixtures("tp_mesh")
 class TestMatchesTensorParallel:
+    @pytest.mark.parametrize("placement", PLACEMENTS, ids=lambda p: p.name)
     @pytest.mark.parametrize("batch", [1, 2])
-    def test_logits(self, batch):
-        tp_model, sp_model = paired_models()
+    def test_logits(self, placement, batch):
+        tp_model, sp_model = paired_models(placement)
         tp_model.eval()
         sp_model.eval()
-
         ids, mask = token_ids(batch, SEQ_LEN, seed=1234 + batch), causal_mask(SEQ_LEN)
+
         # Logits stay vocab-sharded under both strategies (gather_output=False).
-        tp_logits = read_mesh_tensor(tp_model(ids, mask), {"tp": 3})
-        sp_logits = read_mesh_tensor(sp_model(ids, mask), {"tp": 3})
+        tp_logits, sp_logits = per_rank(tp_model(ids, mask)), per_rank(sp_model(ids, mask))
 
         assert tp_logits.std() > 1e-3, "logits are ~constant; agreement would prove nothing"
-        assert_within_ulp(sp_logits, tp_logits, f"logits batch={batch}", MAX_ULP)
+        assert_within_ulp(sp_logits, tp_logits, f"logits {placement.name} batch={batch}", MAX_ULP)
 
-    def test_gradients_after_sequence_parallel_sync(self):
-        tp_model, sp_model = paired_models()
+    @pytest.mark.parametrize("placement", PLACEMENTS, ids=lambda p: p.name)
+    def test_gradients_after_sync(self, placement):
+        tp_model, sp_model = paired_models(placement, attention_bias=True)
         ids, mask = token_ids(1, SEQ_LEN, seed=77), causal_mask(SEQ_LEN)
         for model in (tp_model, sp_model):
-            model.train()
-            model(ids, mask).backward(retain_graph=False)
+            backward(model, ids, mask)
 
-        ttml.sync_sequence_parallel_gradients(sp_model.parameters(), "tp")
+        ttml.sync_gradients(sp_model.parameters())
 
-        tp_params, sp_params = tp_model.parameters(), sp_model.parameters()
-        for name in tp_params.keys():
-            assert tp_params[name].is_grad_initialized(), f"{name}: TP grad missing"
-            assert sp_params[name].is_grad_initialized(), f"{name}: SP grad missing"
-            assert_within_ulp(
-                read_mesh_tensor(sp_params[name].get_grad_tensor()),
-                read_mesh_tensor(tp_params[name].get_grad_tensor()),
-                f"grad {name}",
-                MAX_ULP,
-            )
+        assert_same_grads(sp_model, tp_model)
+
+    def test_gradients_after_an_optimizer_step(self):
+        """The optimizer rewrites each parameter's mesh topology in place; the sync must not read it."""
+        tp_model, sp_model = paired_models()
+        optimizers = [adamw(model) for model in (tp_model, sp_model)]
+        for step in range(2):
+            ids, mask = token_ids(1, SEQ_LEN, seed=step), causal_mask(SEQ_LEN)
+            for model, optimizer in zip((tp_model, sp_model), optimizers):
+                optimizer.zero_grad()
+                backward(model, ids, mask)
+            ttml.sync_gradients(sp_model.parameters())
+            assert_same_grads(sp_model, tp_model, f"step {step}")
+            for optimizer in optimizers:
+                optimizer.step()
+
+    def test_lora(self):
+        """The adapters reuse the base layers' collectives, so SP needs no LoRA-specific math."""
+        tp_model, sp_model = paired_models()
+        lora = LoraConfig(
+            rank=8, target_modules=["qkv_linear", "out_linear", "w_gate_up", "w2"], trainable_modules=["_norm", "ln_fc"]
+        )
+        wrapped = []
+        for model in (tp_model, sp_model):
+            np.random.seed(0)  # lora_A is drawn from numpy's global RNG
+            wrapped.append(LoraModel(model, lora))
+        tp_lora, sp_lora = wrapped
+        ids, mask = token_ids(1, SEQ_LEN, seed=9), causal_mask(SEQ_LEN)
+        for model in (tp_lora, sp_lora):
+            backward(model, ids, mask)
+
+        ttml.sync_gradients(sp_lora.parameters())
+
+        assert_same_grads(sp_lora, tp_lora)
+
+    def test_marks_the_parameters_of_the_sequence_sharded_region(self):
+        """Exactly the norm gains and the row-parallel bias see a per-rank slice of the sequence."""
+        tp_model, sp_model = paired_models(attention_bias=True)
+        assert not any(is_sequence_parallel(p) for _, p in tp_model.parameters().items())
+
+        marked = {name for name, p in sp_model.parameters().items() if is_sequence_parallel(p)}
+        per_block = ("attention_norm/gamma", "mlp_norm/gamma", "attention/out_linear/bias")
+        expected = {f"Llama/blocks/{i}/{suffix}" for i in range(N_LAYERS) for suffix in per_block}
+        assert marked == expected | {"Llama/ln_fc/gamma"}
 
 
+@pytest.mark.requires_device
 @pytest.mark.usefixtures("tp_mesh")
 class TestValidation:
-    def test_rejects_replicated_embedding(self, expect_error):
-        with expect_error(ValueError, "sequence parallelism needs the embedding"):
-            LlamaConfig(
-                hidden_size=HIDDEN,
-                num_attention_heads=N_HEADS,
-                num_key_value_heads=N_KV_HEADS,
-                intermediate_size=INTERMEDIATE,
-                max_position_embeddings=SEQ_LEN,
-                tp_strategy=TPStrategy.TENSOR_SEQUENCE,
-                embedding_placement=EmbeddingPlacement.Replicated,
-            )
-
-    def test_rejects_max_positions_not_divisible_by_32_tp(self, expect_error):
-        with expect_error(ValueError, "max_position_embeddings divisible by"):
-            config(TPStrategy.TENSOR_SEQUENCE, seq_len=32)
-
     def test_rejects_input_sequence_not_divisible_by_32_tp(self, expect_error):
-        """The config gate covers max_position_embeddings; a shorter input needs its own."""
-        model = Llama(config(TPStrategy.TENSOR_SEQUENCE))
+        model = Llama(config(SP))
         with expect_error(ValueError, "input sequence length divisible by"):
             model(token_ids(1, 32, seed=5), causal_mask(32))
 
-    def test_rejects_kv_cache_decode(self, expect_error):
-        """Single-token decode has nothing to shard along the sequence."""
-        attention = GroupedQueryAttention(
-            embedding_size=HIDDEN,
-            num_heads=N_HEADS,
-            num_groups=N_KV_HEADS,
-            dropout=0.0,
-            rope_params=rope_params(),
-            tp_strategy=TPStrategy.TENSOR_SEQUENCE,
-        )
-        hidden = ttml.autograd.Tensor.from_numpy(
-            np.zeros((1, 1, SEQ_LEN, HIDDEN), np.float32), ttnn.Layout.TILE, ttnn.DataType.BFLOAT16
-        )
+    def test_rejects_kv_cache(self, expect_error):
+        """Single-token decode has no sequence to shard, so the model refuses before any collective."""
+        model = Llama(config(SP))
         kv_cache = ttml.models.KvCache(
             num_layers=N_LAYERS,
             batch_size=1,
-            num_groups=attention.num_groups,
+            num_groups=N_KV_HEADS // TP_AXIS_SIZE,
             max_seq_len=SEQ_LEN,
             head_dim=HIDDEN // N_HEADS,
         )
         with expect_error(NotImplementedError, "sequence_parallel does not support"):
-            attention(hidden, causal_mask(SEQ_LEN), kv_cache=kv_cache, layer_idx=0, new_tokens=1)
+            model(token_ids(1, SEQ_LEN, seed=5), causal_mask(SEQ_LEN), kv_cache=kv_cache, new_tokens=SEQ_LEN)
 
 
 class TestTPStrategy:

--- a/tt-train/tests/python/test_tp_vocab_padding.py
+++ b/tt-train/tests/python/test_tp_vocab_padding.py
@@ -63,6 +63,7 @@ _saved_utils = {k: sys.modules.pop(k) for k in list(sys.modules) if k == "utils"
 try:
     from ttml.models.qwen3 import Qwen3Config  # noqa: E402
     from ttml.models.llama import EmbeddingPlacement, Llama, LlamaConfig  # noqa: E402
+    from ttml.parallel import TPStrategy  # noqa: E402
     from utils.context_managers import empty_init  # noqa: E402
     from model_qwen3_distributed import (  # noqa: E402
         DistributedQwen3ForCausalLM,
@@ -130,7 +131,7 @@ def test_llama_padded_vocab_gives_tile_aligned_shards(tp_mesh, vocab):
         intermediate_size=128,
         vocab_size=vocab,
         max_position_embeddings=32,
-        use_tp=True,
+        tp_strategy=TPStrategy.TENSOR,
         embedding_placement=EmbeddingPlacement.VocabParallel,
     )
     _assert_shards_tile_aligned(Llama(cfg).padded_vocab_size, vocab, tp_mesh.axis_size("tp"))


### PR DESCRIPTION
Part of #52951.

Adds Megatron sequence parallelism to the Python Llama model as `TPStrategy.TENSOR_SEQUENCE`, enabled with `enable_sp: true` (requires `enable_tp`). Between the tensor-parallel matmuls the residual stream is sharded along the sequence instead of replicated: the column-parallel input becomes an all-gather over the sequence, the row-parallel output a reduce-scatter, and the norms, dropout and residual adds run on `S / tp` tokens per rank. Same bytes on the fabric, `tp` times less activation memory in that region.

SP also puts a collective directly on both sides of every matmul, an all-gather before the column-parallel one and a reduce-scatter after the row-parallel one, so both can be fused into matmul+CCL kernels; classic TP has one only on the output side.

- `TPStrategy` (`NONE` / `TENSOR` / `TENSOR_SEQUENCE`) replaces `use_tp` on `LlamaConfig`, the Llama modules and the train-script builders.
- `ColumnParallelLinear` and `RowParallelLinear` take `sequence_parallel`. LoRA reuses their collectives and works unchanged.
- `VocabParallelEmbedding` reduce-scatters into the sharded layout; the other placements emit the full sequence and the model slices it locally.
- Parameters on the sharded stream (RMSNorm gains, row-parallel bias, `lora_B`) get partial gradients. They are flagged with `mark_sequence_parallel`, and `ttml.sync_gradients` averages over `dp`/`fsdp` then sums the flagged ones over `tp`.
- `scatter` is now a local `mesh_partition`; it was a reduce-scatter plus `1/n` on a replicated input.

Llama only. Sequence length must be divisible by `32 * tp`; the KV-cache path is refused.

## Tests

`test_sequence_parallel.py` compares SP against TP built from one seed: logits and synced gradients for all three embedding placements, two AdamW steps (the optimizer rewrites parameter topology in place, which broke an earlier topology-based sync), LoRA, and the exact set of flagged parameters. At tp=2 logits match bitwise and gradients within 1 ULP.

## Benchmarks

Llama 3 8B, `tp=4` on 2×p300 (1×4 ring), seq 2048, bs 1 × 4 grad-accum, AdamW 3e-5, seed 5489, no grad checkpointing, replicated embeddings. `training_llama8b_tp4.yaml` vs `training_llama8b_tp4_sp.yaml`, 15 steps.

| Metric (steady state) | `tp=4` | `tp=4` + SP | Δ |
| --- | --: | --: | --: |
| Step time | 2454.2 ± 6.5 ms | 2321.8 ± 7.3 ms | **−5.4 %** |
| Throughput | 3338 tok/s | 3528 tok/s | **+5.7 %** |
| Achieved TFLOPS | 161.2 | 170.3 | +5.6 % |
| MFU (of 594 TFLOPS bf16) | 27.12 % | 28.67 % | **+1.55 pp** |
| Peak DRAM per chip | 25 611 MB | 24 333 MB | **−1 278 MB (−5.0 %)** |
| Average loss (15 steps) | 9.876042 | 9.862500 | −0.0135 |

`MemoryUsageTracker` over the first step, per chip. Weights, gradients and optimizer state are identical; only activations move.

| DRAM snapshot | `tp=4` | `tp=4` + SP | Δ |
| --- | --: | --: | --: |
| `MODEL_CREATION` | 4606.18 MB | 4606.18 MB | identical |
| `OPTIMIZER_CREATION` | 9193.53 MB | 9193.53 MB | identical |
| Resident, steady | 18 390.11 MB | 18 390.11 MB | identical |
| Forward-pass segment peak | 6738.32 MB | 5460.23 MB | **−19.0 %** |
| Backward-pass allocations | 18 781.05 MB | 13 333.05 MB | **−29.0 %** |
| Cumulative peak | 25 611.37 MB | 24 333.28 MB | **−5.0 %** |

The reduction is smaller than the sharded region predicts. Every collective strands its full-size input until the autograd graph unwinds (#52851), about 1 GB per chip here, and SP has the same number of them.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=imichalak/llama-sp/5-seq-parallelism)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:imichalak/llama-sp/5-seq-parallelism)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=imichalak/llama-sp/5-seq-parallelism)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:imichalak/llama-sp/5-seq-parallelism)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=imichalak/llama-sp/5-seq-parallelism)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:imichalak/llama-sp/5-seq-parallelism)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=imichalak/llama-sp/5-seq-parallelism)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:imichalak/llama-sp/5-seq-parallelism)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=imichalak/llama-sp/5-seq-parallelism)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:imichalak/llama-sp/5-seq-parallelism)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=imichalak/llama-sp/5-seq-parallelism)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:imichalak/llama-sp/5-seq-parallelism)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=imichalak/llama-sp/5-seq-parallelism)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:imichalak/llama-sp/5-seq-parallelism)



