### PR TITLE
prefill: separate ttrun options from the target program with --

### DIFF
--- a/models/demos/common/prefill/runners/run_pipeline_prefill.sh
+++ b/models/demos/common/prefill/runners/run_pipeline_prefill.sh
@@ -60,8 +60,11 @@ FWD_ENV=""
 # -x PATH/LD_LIBRARY_PATH: ttrun only forwards TT_*/ARCH_*/... prefixed vars, not PATH, so peer ranks
 # would otherwise resolve a bare `python3` to the system interpreter (no ttnn). Forwarding the launch
 # host's PATH works only because every host's venv sits at the identical clone path.
+# `--` terminates ttrun's own option parsing so the target's `python3 -m <module>` reaches the program
+# verbatim; without it ttrun's -m (--mesh-graph-descriptor) short flag swallows the module name and trips
+# the mesh-graph/rank-binding mutual-exclusion check.
 exec python3 ttnn/ttnn/distributed/ttrun.py \
   --tcp-interface "$TCP_IFACE" \
   --rank-binding "$RANK_BINDING" \
   --mpi-args "--host ${HOST_LIST} --map-by slot --bind-to none --tag-output --allow-run-as-root -x PATH -x LD_LIBRARY_PATH${FWD_ENV}" \
-  python3 -m models.demos.common.prefill.runners.prefill_runner
+  -- python3 -m models.demos.common.prefill.runners.prefill_runner


### PR DESCRIPTION
## Problem

Every multi-host pipeline-prefill launch via `run_pipeline_prefill.sh` fails on current `main` with:

```
Do not combine mesh graph options with rank binding
```

The `-m` short flag for `--mesh-graph-descriptor` was added to `ttrun.py` by #43175 (commit `3263bdfc64a`). The launcher's target program is `python3 -m models.demos.common.prefill.runners.prefill_runner` — click parses that trailing `-m` as ttrun's own mesh-graph option, swallowing the module name. Since the launcher already passes `--rank-binding`, the mesh-graph/rank-binding mutual-exclusion check then trips and the launch dies before MPI starts.

## Fix

Insert a `--` separator before the target program. `--` terminates ttrun's option parsing, so the target's `python3 -m <module>` reaches the program verbatim. Standard convention for a wrapper that execs a program taking its own flags — correct regardless of ttrun's short-flag choices.

Verified by isolation A/B: without `--` → the mutual-exclusion error; with `--` → ttrun proceeds past parsing into MPI launch.

## Upstream note

`-m` is an unfortunate short-flag choice: it shadows Python's ubiquitous `-m` for *any* ttrun caller execing `python3 -m …`. This PR fixes our launcher, but dropping the `-m` alias in ttrun (keeping only `-M` / `--mesh-graph-descriptor`) would spare every other caller the same trap. Flagging on #43175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)