### PR TITLE
[Device 2.0] Add Semaphore::read() and drop matmul's last raw get_semaphore()

### DIFF
--- a/tt_metal/hw/inc/api/dataflow/noc_semaphore.h
+++ b/tt_metal/hw/inc/api/dataflow/noc_semaphore.h
@@ -29,6 +29,7 @@
  *  - wait(value): Block until the semaphore is set to the specified value.  Does not decrement the semaphore.
  *  - wait_min(value): Block until the semaphore is at least the specified value.  Does not decrement the semaphore.
  *  - set(value): Set the semaphore to the specified value.
+ *  - read(): Return the current semaphore value without blocking or modifying it.
  *  - set_multicast(...): Set the semaphore value on multiple cores.
  *  - set_multicast_loopback_src(...): Set the semaphore value on multiple cores including the source.
  *  - relay_unicast(dst_sem, ...): Set a different remote semaphore on one core to this semaphore's local value.
@@ -115,6 +116,19 @@ public:
      */
     void set(uint32_t value) {
         noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_l1_addr_), value);
+    }
+
+    /**
+     * @brief Read the current value of the semaphore.
+     * @note Non-blocking, and does not modify the semaphore. The L1 cache is invalidated before the
+     *       load so that remote updates are observed, matching the read semantics of wait()/wait_min().
+     *
+     * @return The current semaphore value.
+     */
+    uint32_t read() const {
+        auto* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_l1_addr_);
+        invalidate_l1_cache();
+        return *sem_addr;
     }
 
     /**

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_receiver.cpp
@@ -23,8 +23,6 @@ void kernel_main() {
     constexpr uint32_t num_blocks_inner_dim = get_compile_time_arg_val(1);
     constexpr uint32_t num_blocks_w_dim = get_compile_time_arg_val(2);
     constexpr uint32_t num_blocks_h_dim = get_compile_time_arg_val(3);
-    // in0 mcast args
-    uint32_t in0_mcast_receiver_semaphore_addr = get_semaphore(get_compile_time_arg_val(5));
     // batch args
     constexpr uint32_t batch = get_compile_time_arg_val(6);
     // sparsity args
@@ -37,9 +35,6 @@ void kernel_main() {
     DataflowBuffer dfb_in0(dfb_id_in0);
     Semaphore<> sender_sem(get_compile_time_arg_val(4));
     Semaphore<> receiver_sem(get_compile_time_arg_val(5));
-
-    volatile tt_l1_ptr uint32_t* in0_mcast_receiver_semaphore_addr_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_mcast_receiver_semaphore_addr);
 
     for (uint32_t b = 0; b < batch; ++b) {
         if constexpr (get_batch_from_reader) {
@@ -54,7 +49,7 @@ void kernel_main() {
             // wait on in0 semaphore value to become VALID (set by mcast sender after it multicasts data)
             receiver_sem.wait_min(VALID);
 
-            const auto is_batch_valid = *in0_mcast_receiver_semaphore_addr_ptr == VALID;
+            const auto is_batch_valid = receiver_sem.read() == VALID;
 
             // We need to pass the value to compute cores regardless of the value of is_batch_valid
             ckernel::mailbox_write(ckernel::ThreadId::UnpackThreadId, is_batch_valid);


### PR DESCRIPTION
## What

Adds a single public accessor to `Semaphore<core_type>` and uses it to remove the last raw `get_semaphore()` call in `ttnn/operations/matmul`.

```cpp
uint32_t read() const;   // tt_metal/hw/inc/api/dataflow/noc_semaphore.h
```

**Purely additive** — 14 insertions, 0 deletions in the header. No existing signature or behavior changes; all 146 files constructing `Semaphore<>` are unaffected. It is a member on a class template, so `read()` is only instantiated where called.

## Why

`Semaphore<>` exposes `up`/`down`/`wait`/`wait_min`/`set`/`relay_*`/`inc_multicast`/`set_multicast`, but no way to observe the current value — `local_l1_addr_` and `get_l1_addr()` are private. A kernel that needs to *read* a semaphore must therefore keep a raw `get_semaphore()` alias alongside its `Semaphore` object.

`reader_bmm_tile_layout_in0_receiver.cpp` was exactly this case: it already built `Semaphore<> receiver_sem` from compile-time arg 5 and routed every control operation through it, but kept a duplicate `get_semaphore()` alias and `volatile tt_l1_ptr` cast solely to test the value for the unstructured-sparsity path. That alias and cast are now gone.

This is the only legacy call in matmul/reduction/normalization with a replacement **documented** in the Device 2.0 migration guide (guide lines 412 → 419).

## Design decisions worth review

- **`invalidate_l1_cache()` before the volatile load.** Matches the read semantics already used by `down()` and by `noc_semaphore_wait`/`noc_semaphore_wait_min` (`dataflow_api.h:1939,1965`). Without it the load could return a stale cached value when the update came from a remote core.
- **Uses `local_l1_addr_`, not `get_l1_addr()`.** Consistent with `up`/`down`/`wait`/`set`. On `ARCH_QUASAR` the constructor adds `MEM_L1_UNCACHED_BASE` so local access goes through the uncached alias; `get_l1_addr()` strips it and is for NoC-addressable use only.
- **Encapsulation direction.** The class deliberately keeps the *address* private. Exposing the *value* is a narrower concession, but it is still a call for the API owners — hence this is split out of the ttnn migration PR.
- **Naming.** `read()` vs `value()` vs `get()`. Once shipped, kernels will depend on it.

## Testing

Blackhole p100a: `tests/ttnn/unit_tests/operations/matmul/test_matmul.py` — **838 passed, 310 skipped, 2 xfailed**. Kernels were JIT-recompiled from source (verified 0% JIT cache hits), so the change was genuinely exercised.

## Relationship to the other PR

Split out of the tile-metadata migration (companion PR). The two are independent and can land in either order; the companion touches 39 different files and no `tt_metal/` header.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/semaphore-read-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/semaphore-read-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/semaphore-read-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/semaphore-read-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/semaphore-read-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/semaphore-read-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/semaphore-read-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/semaphore-read-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/semaphore-read-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/semaphore-read-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/semaphore-read-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/semaphore-read-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/semaphore-read-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/semaphore-read-api)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/semaphore-read-api)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/semaphore-read-api)