### PR TITLE
[Cleanup] Migrate tile-metadata free calls to Device 2.0 accessors (matmul/reduction/normalization)

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
@@ -37,9 +37,12 @@ void kernel_main() {
     constexpr uint32_t dfb_id_in0 = get_named_compile_time_arg_val("cb_in0");
     constexpr uint32_t dfb_id_in1 = get_named_compile_time_arg_val("cb_in1");
 
+    DataflowBuffer dfb_in0(dfb_id_in0);
+    DataflowBuffer dfb_in1(dfb_id_in1);
+
     constexpr uint32_t onetile = 1;
-    const uint32_t in0_tile_bytes = get_tile_size(dfb_id_in0);
-    const uint32_t in1_tile_bytes = get_tile_size(dfb_id_in1);
+    const uint32_t in0_tile_bytes = dfb_in0.get_tile_size();
+    const uint32_t in1_tile_bytes = dfb_in1.get_tile_size();
 
     uint32_t itileA = output_tile_start_id / Nt * Kt;  // input0 row = output row * input0 width
 
@@ -55,8 +58,6 @@ void kernel_main() {
     const auto s1 = TensorAccessor(src1_args, src1_addr);
 
     Noc noc;
-    DataflowBuffer dfb_in0(dfb_id_in0);
-    DataflowBuffer dfb_in1(dfb_id_in1);
 
     for (uint32_t n = 0; n < num_output_tiles; n++) {
         for (uint32_t kt = 0; kt < Kt; kt++) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout.cpp
@@ -51,15 +51,16 @@ void kernel_main() {
     constexpr uint32_t dfb_id_in0 = get_named_compile_time_arg_val("cb_in0");
     constexpr uint32_t dfb_id_in1 = get_named_compile_time_arg_val("cb_in1");
 
-    const uint32_t in0_single_tile_size_bytes = get_tile_size(dfb_id_in0);
-    const uint32_t in1_single_tile_size_bytes = get_tile_size(dfb_id_in1);
+    DataflowBuffer dfb_in0(dfb_id_in0);
+    DataflowBuffer dfb_in1(dfb_id_in1);
+
+    const uint32_t in0_single_tile_size_bytes = dfb_in0.get_tile_size();
+    const uint32_t in1_single_tile_size_bytes = dfb_in1.get_tile_size();
 
     const auto s0 = TensorAccessor(in0_args, in0_tensor_addr);
     const auto s1 = TensorAccessor(in1_args, in1_tensor_addr);
 
     Noc noc;
-    DataflowBuffer dfb_in0(dfb_id_in0);
-    DataflowBuffer dfb_in1(dfb_id_in1);
 
     for (uint32_t b = 0; b < batch; b++) {
         uint32_t in0_tensor_current_block_start_tile_id = in0_tensor_start_tile_id;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0.cpp
@@ -50,7 +50,6 @@ void kernel_main() {
 #else
 
     constexpr uint32_t in0_single_tile_size_bytes = get_tile_size(dfb_id_in0);
-    constexpr const uint32_t in0_tile_hw = get_tile_hw(dfb_id_in0);
     // Tiles whose size is not a multiple of the DRAM alignment are padded to it in DRAM and the in0
     // CB pages are sized to match (see the program factory), so tiles must be laid out in L1 at the
     // padded stride. The NOC still reads the unpadded tile of data into each padded slot. No-op when

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_receiver_writer_padding.cpp
@@ -90,11 +90,6 @@ void kernel_main() {
     // WRITER
     constexpr uint32_t dfb_id_out0 = get_named_compile_time_arg_val("cb_out");
 
-    // WRITER
-    // single-tile
-    const uint32_t output_single_tile_size_bytes = get_tile_size(dfb_id_out0);
-    constexpr const uint32_t output_tile_hw = get_tile_hw(dfb_id_out0);
-
     Noc noc;
     DataflowBuffer dfb_in1(dfb_id_in1);
     DataflowBuffer dfb_out(dfb_id_out0);
@@ -103,6 +98,10 @@ void kernel_main() {
 #ifdef FUSE_BIAS
     DataflowBuffer dfb_in3(dfb_id_in3);
 #endif
+
+    // WRITER
+    // single-tile
+    const uint32_t output_single_tile_size_bytes = dfb_out.get_tile_size();
 
     // WRITER
     const auto s = TensorAccessor(out_args, out_tensor_addr);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_ring_all_gather.cpp
@@ -115,7 +115,6 @@ void kernel_main() {
     const uint32_t in1_block_num_tiles = in1_block_height_in_tiles * in1_block_width_in_tiles;
 
     // Address setup
-    constexpr const uint32_t in1_tile_hw = get_tile_hw(dfb_id_in1);
     constexpr uint32_t in1_single_tile_size_bytes = get_tile_size(dfb_id_in1);
     const auto s1 = TensorAccessor(in1_args, in1_tensor_addr);
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
@@ -49,8 +49,6 @@ void kernel_main() {
     constexpr uint32_t in3_page_size = get_compile_time_arg_val(9);
     constexpr uint32_t in3_num_pages = get_compile_time_arg_val(10);
     constexpr uint32_t dfb_id_in3 = get_named_compile_time_arg_val("cb_bias");
-    constexpr uint32_t bias_single_tile_size_bytes = get_tile_size(dfb_id_in3);
-    constexpr DataFormat bias_data_format = get_dataformat(dfb_id_in3);
 #endif
 
     constexpr uint32_t dfb_id_in1 = get_named_compile_time_arg_val("cb_in1");
@@ -72,7 +70,6 @@ void kernel_main() {
     //  READER
     uint32_t l1_write_addr_in1;
     uint32_t l1_read_addr_in1 = 0;
-    constexpr DataFormat in1_data_format = get_dataformat(dfb_id_in1);
 
     AllocatorBank<AllocatorBankType::DRAM> dram_bank;
     noc.set_async_read_state<NocOptions::CUSTOM_VC, NOC_MAX_BURST_SIZE>(

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded_height.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded_height.cpp
@@ -110,7 +110,7 @@ void kernel_main() {
         noc.async_read(
             dram_bank,
             dfb_in3,
-            in3_block_tiles * get_tile_size(dfb_id_in3),
+            in3_block_tiles * dfb_in3.get_tile_size(),
             {.bank_id = dram_bank_id, .addr = in3_tensor_addr},
             {.offset_bytes = 0});
         noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -126,7 +126,6 @@ void kernel_main() {
     // equals the tile size, so this is a no-op. Mirrors how in0/in1 readers walk at the
     // aligned stride.
     const uint32_t bias_single_tile_size_bytes = get_local_cb_interface(dfb_id_in3).fifo_page_size;
-    constexpr const uint32_t in3_tile_hw = get_tile_hw(dfb_id_in3);
 
 #ifndef BIAS_SHARDED
     uint32_t l1_write_addr_in3;
@@ -190,7 +189,6 @@ void kernel_main() {
 
     constexpr uint32_t dfb_id_in1 = get_named_compile_time_arg_val("cb_in1");
     constexpr uint32_t in1_single_tile_size_bytes = get_tile_size(dfb_id_in1);
-    constexpr const uint32_t in1_tile_hw = get_tile_hw(dfb_id_in1);
     // Tiles whose size is not a multiple of the DRAM alignment are padded to it in DRAM, and the
     // interleaved in1 CB pages are sized to match (see the program factory). On the plain interleaved
     // path the NOC reads the unpadded tile of data into each padded slot and tiles are laid out /
@@ -207,7 +205,6 @@ void kernel_main() {
 
     constexpr uint32_t dfb_id_out0 = get_named_compile_time_arg_val("cb_out");
     constexpr uint32_t output_single_tile_size_bytes = get_tile_size(dfb_id_out0);
-    constexpr const uint32_t output_tile_hw = get_tile_hw(dfb_id_out0);
 
     Noc noc;
     DataflowBuffer dfb_in1(dfb_id_in1);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_writer_bmm_tile_layout_in1.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_writer_bmm_tile_layout_in1.cpp
@@ -80,8 +80,8 @@ void kernel_main() {
     // Load the whole per-batch [M, N] bias block once.
     // It's reused across all of this core's batch iterations (broadcast over batch).
     constexpr uint32_t bias_block_ntiles = out_subblock_h * out_num_subblocks_h * in1_block_w;  // M*N tiles
-    const uint32_t bias_single_tile_size_bytes = get_tile_size(dfb_id_in3);
     DataflowBuffer dfb_in3(dfb_id_in3);
+    const uint32_t bias_single_tile_size_bytes = dfb_in3.get_tile_size();
     const auto s3 = TensorAccessor(bias_args, in3_tensor_addr);
     dfb_in3.reserve_back(bias_block_ntiles);
     uint32_t in3_write_offset = 0;
@@ -105,7 +105,7 @@ void kernel_main() {
     dfb_in1.reserve_back(in1_num_tiles);
     dfb_in1.push_back(in1_num_tiles);
 #else
-    const uint32_t in1_single_tile_size_bytes = get_tile_size(dfb_id_in1);
+    const uint32_t in1_single_tile_size_bytes = dfb_in1.get_tile_size();
     // Tiles whose size is not a multiple of the DRAM alignment are padded to it in DRAM and the in1
     // CB pages are sized to match (see the program factory), so tiles are laid out in L1 at the
     // padded stride while the NOC reads the unpadded tile of data into each padded slot. No-op when
@@ -116,7 +116,7 @@ void kernel_main() {
 #endif  // IN1_SHARDED
 
 #ifndef OUT_SHARDED
-    const uint32_t output_single_tile_size_bytes = get_tile_size(dfb_id_out0);
+    const uint32_t output_single_tile_size_bytes = dfb_out.get_tile_size();
     const auto s = TensorAccessor(out_args, out_tensor_addr);
 #endif  // OUT_SHARDED
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_bmm_tile_layout.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_bmm_tile_layout.cpp
@@ -29,14 +29,15 @@ void kernel_main() {
 
     constexpr uint32_t dfb_id_out0 = get_named_compile_time_arg_val("cb_out");
 
+    DataflowBuffer dfb_out(dfb_id_out0);
+
     // single-tile
-    const uint32_t single_tile_size_bytes = get_tile_size(dfb_id_out0);
+    const uint32_t single_tile_size_bytes = dfb_out.get_tile_size();
 
     constexpr auto out_args = TensorAccessorArgs<0>();
     const auto s = TensorAccessor(out_args, out_tensor_addr);
 
     Noc noc;
-    DataflowBuffer dfb_out(dfb_id_out0);
 
     bool one_time_profile = true;
     for (uint32_t b = 0; b < batch; b++) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_gn.cpp
@@ -145,8 +145,7 @@ void kernel_main() {
     DataflowBuffer dfb_reread_rm(dfb_reread_rm_id);
 #endif
 
-    const uint32_t single_tile_size_bytes = get_tile_size(dfb_ex_partial_id);
-    const DataFormat out_data_format = get_dataformat(dfb_out0_id);
+    const uint32_t single_tile_size_bytes = dfb_ex_partial.get_tile_size();
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
     uint32_t in0_l1_read_addr = dfb_in0.get_read_ptr();
@@ -219,7 +218,7 @@ void kernel_main() {
                             out_block_hw_normal);
                     }
 #else
-                    const uint32_t src0_tile_bytes = get_tile_size(dfb_in0_id);
+                    const uint32_t src0_tile_bytes = dfb_in0.get_tile_size();
                     const auto src_a = TensorAccessor(src0_args, src_addr);
                     uint32_t l1_write_addr;
                     l1_write_addr = dfb_in0.get_write_ptr();
@@ -279,7 +278,7 @@ void kernel_main() {
                             out_block_h_actual,
                             out_block_hw_normal);
 #else
-                        const uint32_t dst_tile_bytes = get_tile_size(dfb_reread_out_id);
+                        const uint32_t dst_tile_bytes = dfb_reread_out.get_tile_size();
                         uint32_t l1_write_addr;
                         l1_write_addr = dfb_reread_out.get_write_ptr();
                         dfb_reread_out.reserve_back(out_block_hw_normal);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_gn_v2.cpp
@@ -45,9 +45,6 @@ void kernel_main() {
     DataflowBuffer dfb_repack_out(dfb_repack_out_id);
     DataflowBuffer dfb_out0(dfb_out0_id);
 
-    const uint32_t single_tile_size_bytes = get_tile_size(dfb_ex_partial_id);
-    const DataFormat data_format = get_dataformat(dfb_ex_partial_id);
-
 #if defined(READER_REPACK) and defined(TILIZE_IN)
     uint32_t in0_l1_read_addr = dfb_in0.get_read_ptr();
     uint32_t src_addr_in0 = in0_l1_read_addr;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_gn.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_gn.cpp
@@ -227,7 +227,6 @@ void kernel_main() {
 #endif
 
     constexpr uint32_t single_tile_size_bytes = get_tile_size(dfb_ex_partial_id);
-    const DataFormat out_data_format = get_dataformat(dfb_out0_id);
     const uint32_t num_bytes_read = datum_size_bytes;
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)
@@ -348,7 +347,7 @@ void kernel_main() {
                                 out_block_hw_normal);
                         }
 #else
-                        const uint32_t src0_tile_bytes = get_tile_size(dfb_in0_id);
+                        const uint32_t src0_tile_bytes = dfb_in0.get_tile_size();
                         const auto src_a = TensorAccessor(src0_args, src_addr);
                         uint32_t l1_write_addr;
                         l1_write_addr = dfb_in0.get_write_ptr();
@@ -460,7 +459,7 @@ void kernel_main() {
                                 out_block_h_actual,
                                 out_block_hw_normal);
 #else
-                            const uint32_t dst_tile_bytes = get_tile_size(dfb_reread_out_id);
+                            const uint32_t dst_tile_bytes = dfb_reread_out.get_tile_size();
                             uint32_t l1_write_addr;
                             l1_write_addr = dfb_reread_out.get_write_ptr();
                             dfb_reread_out.reserve_back(out_block_hw_normal);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_gn_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_gn_v2.cpp
@@ -129,8 +129,7 @@ void kernel_main() {
     DataflowBuffer dfb_repack_out(dfb_repack_out_id);
     DataflowBuffer dfb_out0(dfb_out0_id);
 
-    const uint32_t single_tile_size_bytes = get_tile_size(dfb_ex_partial_id);
-    const DataFormat data_format = get_dataformat(dfb_ex_partial_id);
+    const uint32_t single_tile_size_bytes = dfb_ex_partial.get_tile_size();
     const uint32_t num_bytes_read = datum_size_bytes;
 
 #if defined(READER_REPACK) and defined(TILIZE_IN)

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_sharded_gn_rm_gb_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_sharded_gn_rm_gb_v2.cpp
@@ -61,8 +61,7 @@ void kernel_main() {
     DataflowBuffer dfb_beta(dfb_beta_id);
     DataflowBuffer dfb_input_mask(dfb_input_mask_id);
 
-    const uint32_t single_tile_size_bytes = get_tile_size(dfb_gamma_id);
-    const uint32_t input_mask_single_tile_size_bytes = get_tile_size(dfb_input_mask_id);
+    const uint32_t input_mask_single_tile_size_bytes = dfb_input_mask.get_tile_size();
 
     const auto mask = TensorAccessor(input_mask_args, input_mask_addr);
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
@@ -130,8 +130,8 @@ void kernel_main() {
     DataflowBuffer dfb_beta(dfb_beta_id);
     DataflowBuffer dfb_out(dfb_out_id);
 
-    const uint32_t single_tile_size_bytes = get_tile_size(dfb_out_id);
-    const uint32_t input_mask_single_tile_size_bytes = get_tile_size(dfb_input_mask_id);
+    const uint32_t single_tile_size_bytes = dfb_out.get_tile_size();
+    const uint32_t input_mask_single_tile_size_bytes = dfb_input_mask.get_tile_size();
 #ifdef UNTILIZE_OUT
     constexpr uint32_t tile_hw = get_named_compile_time_arg_val("TILE_HW");
     constexpr uint32_t tile_height = tile_hw / tile_width;
@@ -284,7 +284,7 @@ void kernel_main() {
                 generate_bcast_col_scalar(CircularBuffer(eps_dfb_id), eps);
 
                 if constexpr (fuse_gamma) {
-                    const uint32_t gamma_tile_bytes = get_tile_size(dfb_gamma_id);
+                    const uint32_t gamma_tile_bytes = dfb_gamma.get_tile_size();
                     const uint32_t gamma_element_bytes = gamma_tile_bytes / tt::constants::TILE_HW;
                     const auto gamma = TensorAccessor(gamma_args, gamma_addr);
 
@@ -309,7 +309,7 @@ void kernel_main() {
                 }
 
                 if constexpr (fuse_beta) {
-                    const uint32_t beta_tile_bytes = get_tile_size(dfb_beta_id);
+                    const uint32_t beta_tile_bytes = dfb_beta.get_tile_size();
                     const uint32_t beta_element_bytes = beta_tile_bytes / tt::constants::TILE_HW;
                     const auto beta = TensorAccessor(beta_args, beta_addr);
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
@@ -119,16 +119,14 @@ void kernel_main() {
     DataflowBuffer dfb_beta(dfb_beta_id);
     DataflowBuffer dfb_input_mask(dfb_input_mask_id);
 
-    const uint32_t single_tile_size_bytes = get_tile_size(dfb_gamma_id);
-    const uint32_t input_mask_single_tile_size_bytes = get_tile_size(dfb_input_mask_id);
+    const uint32_t input_mask_single_tile_size_bytes = dfb_input_mask.get_tile_size();
 
     const auto mask = TensorAccessor(input_mask_args, input_mask_addr);
 
 #if defined(FUSE_NEGATIVE_MASK)
     constexpr uint32_t dfb_input_negative_mask_id = tt::CBIndex::c_14;
-    const uint32_t input_negative_mask_single_tile_size_bytes = get_tile_size(dfb_input_negative_mask_id);
-
     DataflowBuffer dfb_input_negative_mask(dfb_input_negative_mask_id);
+    const uint32_t input_negative_mask_single_tile_size_bytes = dfb_input_negative_mask.get_tile_size();
 
     constexpr auto negative_mask_args = TensorAccessorArgs<input_mask_args.next_compile_time_args_offset()>();
     const auto negative_mask_tensor_accessor = TensorAccessor(negative_mask_args, input_negative_mask_addr);
@@ -276,7 +274,7 @@ void kernel_main() {
                 generate_bcast_col_scalar(CircularBuffer(eps_dfb_id), eps);
 
                 if constexpr (fuse_gamma) {
-                    const uint32_t gamma_tile_bytes = get_tile_size(dfb_gamma_id);
+                    const uint32_t gamma_tile_bytes = dfb_gamma.get_tile_size();
                     const uint32_t gamma_element_bytes = gamma_tile_bytes / tt::constants::TILE_HW;
                     const auto gamma = TensorAccessor(gamma_args, gamma_addr);
 
@@ -292,7 +290,7 @@ void kernel_main() {
                 }
 
                 if constexpr (fuse_beta) {
-                    const uint32_t beta_tile_bytes = get_tile_size(dfb_beta_id);
+                    const uint32_t beta_tile_bytes = dfb_beta.get_tile_size();
                     const uint32_t beta_element_bytes = beta_tile_bytes / tt::constants::TILE_HW;
                     const auto beta = TensorAccessor(beta_args, beta_addr);
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
@@ -89,10 +89,6 @@ void kernel_main() {
     UnicastEndpoint remote_ep;
 
     const uint32_t num_tiles_to_read = is_last_all_to_all_worker ? num_tiles_per_worker_last : num_tiles_per_worker;
-    // Sizing reference for one partial-reduction tile. RMSNorm only allocates cb_ex_partial2
-    // (the host skips cb_ex_partial), so pick whichever buffer exists in the current mode. The
-    // selected buffer is also the one the reduce lambda below is invoked with, so this object
-    // never binds a buffer the kernel would not otherwise touch.
     DataflowBuffer dfb_partial_size_ref(rms_norm ? dfb_ex_partial2 : dfb_ex_partial);
     const uint32_t single_tile_size_bytes = dfb_partial_size_ref.get_tile_size();
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
@@ -89,7 +89,12 @@ void kernel_main() {
     UnicastEndpoint remote_ep;
 
     const uint32_t num_tiles_to_read = is_last_all_to_all_worker ? num_tiles_per_worker_last : num_tiles_per_worker;
-    const uint32_t single_tile_size_bytes = get_tile_size(rms_norm ? dfb_ex_partial2 : dfb_ex_partial);
+    // Sizing reference for one partial-reduction tile. RMSNorm only allocates cb_ex_partial2
+    // (the host skips cb_ex_partial), so pick whichever buffer exists in the current mode. The
+    // selected buffer is also the one the reduce lambda below is invoked with, so this object
+    // never binds a buffer the kernel would not otherwise touch.
+    DataflowBuffer dfb_partial_size_ref(rms_norm ? dfb_ex_partial2 : dfb_ex_partial);
+    const uint32_t single_tile_size_bytes = dfb_partial_size_ref.get_tile_size();
 
     // Compute the NOC coordinates for remote cores that interact with this core
     constexpr df::NumNocAddrs num_remote_noc_addrs_first_stage = is_all_to_all_worker ? num_blocks_first_stage : 1;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
@@ -51,8 +51,8 @@ void kernel_main() {
     Semaphore<> reduce_second_stage_sem(get_compile_time_arg_val(14));
     UnicastEndpoint remote_ep;
 
-    const uint32_t single_tile_size_bytes = get_tile_size(dfb_ex_partial2);
-    const DataFormat data_format = get_dataformat(dfb_ex_partial2);
+    DataflowBuffer dfb_ex_partial2_obj(dfb_ex_partial2);
+    const uint32_t single_tile_size_bytes = dfb_ex_partial2_obj.get_tile_size();
 
     RemoteCoord remote_coords_first_stage[is_all_to_all_worker ? num_blocks_first_stage : 1];
     RemoteCoord remote_coords_second_stage[is_all_to_all_worker ? num_blocks_second_stage : 1];

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
@@ -91,7 +91,9 @@ void kernel_main() {
     UnicastEndpoint remote_ep;
     MulticastEndpoint mcast_ep;
 
-    const uint32_t single_tile_size_bytes = get_tile_size(rms_norm ? dfb_ex_partial2 : dfb_ex_partial);
+    // RMSNorm only allocates cb_ex_partial2; the host skips cb_ex_partial.
+    DataflowBuffer dfb_partial_size_ref(rms_norm ? dfb_ex_partial2 : dfb_ex_partial);
+    const uint32_t single_tile_size_bytes = dfb_partial_size_ref.get_tile_size();
 
     // Compute the NOC coordinates for remote cores that interact with this core
     df::RemoteNocCoords<num_blocks> remote_coords{};

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
@@ -54,8 +54,8 @@ void kernel_main() {
     Semaphore<> reduce_second_stage_sem(get_compile_time_arg_val(16));
     UnicastEndpoint remote_ep;
 
-    const uint32_t single_tile_size_bytes = get_tile_size(dfb_ex_partial2);
-    const DataFormat data_format = get_dataformat(dfb_ex_partial2);
+    DataflowBuffer dfb_ex_partial2_obj(dfb_ex_partial2);
+    const uint32_t single_tile_size_bytes = dfb_ex_partial2_obj.get_tile_size();
 
     RemoteCoord remote_coords[num_blocks];
     uint32_t x = start_x, y = start_y;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln.cpp
@@ -106,21 +106,21 @@ void kernel_main() {
     const uint32_t src0_page_bytes = W * elem_size_bytes;
 #else
     // TILE path: input a is already in tile layout.
-    const uint32_t src0_page_bytes = get_tile_size(dfb_id_in0);
+    const uint32_t src0_page_bytes = dfb_in0.get_tile_size();
 #endif
 
     const auto src_a = TensorAccessor(src0_args, src_addr);
 
 #ifdef FUSE_GAMMA
-    const uint32_t gamma_tile_bytes = get_tile_size(dfb_id_gamma);
+    const uint32_t gamma_tile_bytes = dfb_gamma.get_tile_size();
     const auto addrg = TensorAccessor(gamma_args, gamma_addr);
 #endif
 #ifdef FUSE_BETA
-    const uint32_t beta_tile_bytes = get_tile_size(dfb_id_beta);
+    const uint32_t beta_tile_bytes = dfb_beta.get_tile_size();
     const auto addrb = TensorAccessor(beta_args, beta_addr);
 #endif
 #ifdef FUSE_PRE_ADD
-    const uint32_t src1_tile_bytes = get_tile_size(dfb_id_in1);
+    const uint32_t src1_tile_bytes = dfb_in1.get_tile_size();
     const auto src_b = TensorAccessor(src1_args, b_addr);
 #endif
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_large_tensor.cpp
@@ -98,21 +98,21 @@ void kernel_main() {
     const uint32_t src0_page_bytes = W_logical * elem_size_bytes;
 #else
     // TILE path: input a is already in tile layout.
-    const uint32_t src0_page_bytes = get_tile_size(dfb_id_in0);
+    const uint32_t src0_page_bytes = dfb_in0.get_tile_size();
 #endif
 
     const auto src_a = TensorAccessor(src0_args, src_addr);
 
 #ifdef FUSE_GAMMA
-    const uint32_t gamma_tile_bytes = get_tile_size(dfb_id_gamma);
+    const uint32_t gamma_tile_bytes = dfb_gamma.get_tile_size();
     const auto addrg = TensorAccessor(gamma_args, gamma_addr);
 #endif
 #ifdef FUSE_BETA
-    const uint32_t beta_tile_bytes = get_tile_size(dfb_id_beta);
+    const uint32_t beta_tile_bytes = dfb_beta.get_tile_size();
     const auto addrb = TensorAccessor(beta_args, beta_addr);
 #endif
 #ifdef FUSE_PRE_ADD
-    const uint32_t src1_tile_bytes = get_tile_size(dfb_id_in1);
+    const uint32_t src1_tile_bytes = dfb_in1.get_tile_size();
     const auto src_b = TensorAccessor(src1_args, b_addr);
 #endif
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_large_tensor_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_large_tensor_welford.cpp
@@ -45,7 +45,7 @@ void kernel_main() {
 #endif
 
     // ublocks size defined in tiles
-    const uint32_t src0_tile_bytes = get_tile_size(dfb_id_in0);
+    const uint32_t src0_tile_bytes = dfb_in0.get_tile_size();
 
     constexpr uint32_t blk = get_compile_time_arg_val(0);  // needed for correctness of softmax/LN kernels
     [[maybe_unused]] constexpr uint32_t W = get_compile_time_arg_val(1);
@@ -56,15 +56,15 @@ void kernel_main() {
 
     const auto src_a = TensorAccessor(src0_args, src_addr);
 #ifdef FUSE_GAMMA
-    const uint32_t gamma_tile_bytes = get_tile_size(dfb_id_gamma);
+    const uint32_t gamma_tile_bytes = dfb_gamma.get_tile_size();
     const auto addrg = TensorAccessor(gamma_args, gamma_addr);
 #endif
 #ifdef FUSE_BETA
-    const uint32_t beta_tile_bytes = get_tile_size(dfb_id_beta);
+    const uint32_t beta_tile_bytes = dfb_beta.get_tile_size();
     const auto addrb = TensorAccessor(beta_args, beta_addr);
 #endif
 #ifdef FUSE_PRE_ADD
-    const uint32_t src1_tile_bytes = get_tile_size(dfb_id_in1);
+    const uint32_t src1_tile_bytes = dfb_in1.get_tile_size();
     const auto src_b = TensorAccessor(src1_args, b_addr);
 #endif
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb.cpp
@@ -51,8 +51,7 @@ void kernel_main() {
 #endif
 
     // ublocks size defined in tiles
-    const uint32_t src0_tile_bytes = get_tile_size(dfb_id_in0);
-    const DataFormat src0_data_format = get_dataformat(dfb_id_in0);
+    const uint32_t src0_tile_bytes = dfb_in0.get_tile_size();
 
     constexpr uint32_t blk = get_compile_time_arg_val(0);  // needed for correctness of softmax/LN kernels
     constexpr bool use_welford = get_compile_time_arg_val(1) == 1;
@@ -69,7 +68,7 @@ void kernel_main() {
     //   face_bytes     = one 16x16 tile face = FACE_HW (256) datums; face 1 starts here within the tile
     //   half_row_bytes = first FACE_WIDTH (16) datums of a row = the face boundary in a row-major stick
 #ifdef FUSE_GAMMA
-    const uint32_t gamma_tile_bytes = get_tile_size(dfb_id_gamma);
+    const uint32_t gamma_tile_bytes = dfb_gamma.get_tile_size();
     const uint32_t gamma_datum_bytes = gamma_tile_bytes / tt::constants::TILE_HW;
     const uint32_t gamma_row_bytes = tt::constants::TILE_WIDTH * gamma_datum_bytes;
     const uint32_t gamma_face_bytes = tt::constants::FACE_HW * gamma_datum_bytes;
@@ -77,7 +76,7 @@ void kernel_main() {
     const auto addrg = TensorAccessor(gamma_args, gamma_addr);
 #endif
 #ifdef FUSE_BETA
-    const uint32_t beta_tile_bytes = get_tile_size(dfb_id_beta);
+    const uint32_t beta_tile_bytes = dfb_beta.get_tile_size();
     const uint32_t beta_datum_bytes = beta_tile_bytes / tt::constants::TILE_HW;
     const uint32_t beta_row_bytes = tt::constants::TILE_WIDTH * beta_datum_bytes;
     const uint32_t beta_face_bytes = tt::constants::FACE_HW * beta_datum_bytes;
@@ -85,7 +84,7 @@ void kernel_main() {
     const auto addrb = TensorAccessor(beta_args, beta_addr);
 #endif
 #ifdef FUSE_PRE_ADD
-    const uint32_t src1_tile_bytes = get_tile_size(dfb_id_in1);
+    const uint32_t src1_tile_bytes = dfb_in1.get_tile_size();
     const auto src_b = TensorAccessor(src1_args, b_addr);
 #endif
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reshard_writer.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reshard_writer.hpp
@@ -20,7 +20,7 @@ inline void write_resharded_data(
     uint32_t worker_core_stride_w_bytes,
     uint32_t storage_core_stride_w_bytes,
     uint32_t block_ht) {
-    const uint32_t out_single_tile_size_bytes = get_tile_size(dfb_out.get_id());
+    const uint32_t out_single_tile_size_bytes = dfb_out.get_tile_size();
     uint32_t args_idx = 0;
     uint32_t worker_core_read_offset = 0;
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_interleaved_start_id_blocked.cpp
@@ -21,10 +21,11 @@ void kernel_main() {
     // CB index - configurable via named compile-time args for kernel chaining support
     constexpr uint32_t dfb_id_out0 = get_named_compile_time_arg_val("cb_out");
     constexpr uint32_t onetile = 1;
-    const uint32_t tile_bytes = get_tile_size(dfb_id_out0);
 
     Noc noc;
     DataflowBuffer dfb_out0(dfb_id_out0);
+
+    const uint32_t tile_bytes = dfb_out0.get_tile_size();
 
     const auto s = TensorAccessor(dst_args, dst_addr);
 

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln.cpp
@@ -59,8 +59,6 @@ void kernel_main() {
     DataflowBuffer dfb_out_obj(dfb_out);
     DataflowBuffer dfb_out_resharded_obj(dfb_out_resharded);
 
-    const uint32_t out_single_tile_size_bytes = get_tile_size(dfb_out);
-
     if constexpr (!use_welford) {
         constexpr uint32_t dfb_in_2 = get_named_compile_time_arg_val("cb_in_2");
         const uint32_t scalar_w_bits = get_arg_val<uint32_t>(1);
@@ -90,7 +88,7 @@ void kernel_main() {
     }
 
     if constexpr (fuse_gamma) {
-        const uint32_t gamma_tile_bytes = get_tile_size(dfb_gamma);
+        const uint32_t gamma_tile_bytes = dfb_gamma_obj.get_tile_size();
         const auto gamma = TensorAccessor(gamma_args, gamma_addr);
 
         dfb_gamma_obj.reserve_back(block_w);
@@ -104,7 +102,7 @@ void kernel_main() {
     }
 
     if constexpr (fuse_beta) {
-        const uint32_t beta_tile_bytes = get_tile_size(dfb_beta);
+        const uint32_t beta_tile_bytes = dfb_beta_obj.get_tile_size();
         const auto beta = TensorAccessor(beta_args, beta_addr);
 
         dfb_beta_obj.reserve_back(block_w);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln_rm_gb.cpp
@@ -62,8 +62,6 @@ void kernel_main() {
     DataflowBuffer dfb_out_obj(dfb_out);
     DataflowBuffer dfb_out_resharded_obj(dfb_out_resharded);
 
-    const uint32_t out_single_tile_size_bytes = get_tile_size(dfb_out);
-
     if constexpr (!use_welford) {
         constexpr uint32_t dfb_in_2 = get_named_compile_time_arg_val("cb_in_2");
         const uint32_t scalar_w_bits = get_arg_val<uint32_t>(1);
@@ -93,7 +91,7 @@ void kernel_main() {
     }
 
     if constexpr (fuse_gamma) {
-        const uint32_t gamma_tile_bytes = get_tile_size(dfb_gamma);
+        const uint32_t gamma_tile_bytes = dfb_gamma_obj.get_tile_size();
         const auto gamma = TensorAccessor(gamma_args, gamma_addr);
 
         constexpr uint32_t mask_read_tile_face_bytes = FLOAT32_DTYPE_GAMMA ? 64 : 32;
@@ -124,7 +122,7 @@ void kernel_main() {
     }
 
     if constexpr (fuse_beta) {
-        const uint32_t beta_tile_bytes = get_tile_size(dfb_beta);
+        const uint32_t beta_tile_bytes = dfb_beta_obj.get_tile_size();
         const auto beta = TensorAccessor(beta_args, beta_addr);
 
         uint32_t mask_read_tile_face_bytes = FLOAT32_DTYPE_BETA ? 64 : 32;

--- a/ttnn/cpp/ttnn/operations/pool/device/kernels/pool_kernels_common.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/device/kernels/pool_kernels_common.hpp
@@ -45,8 +45,6 @@ template <uint32_t cb_id, uint32_t clear_value_cb_id>
 ALWI void clear_out_tiles(Noc noc, DataflowBuffer dfb, DataflowBuffer clear_dfb) {
     constexpr uint32_t tile_size = get_tile_size(cb_id);
     const uint32_t num_pages = get_local_cb_interface(cb_id).fifo_num_pages;
-    // Read the entry size from the DFB object rather than poking the raw CB interface
-    // (matches the Quasar sibling of this header, where the raw fifo_page_size is stale).
     const uint32_t num_tiles = dfb.get_entry_size() / tile_size;
 
     UnicastEndpoint self_ep;

--- a/ttnn/cpp/ttnn/operations/pool/device/kernels/pool_kernels_common.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/device/kernels/pool_kernels_common.hpp
@@ -45,7 +45,9 @@ template <uint32_t cb_id, uint32_t clear_value_cb_id>
 ALWI void clear_out_tiles(Noc noc, DataflowBuffer dfb, DataflowBuffer clear_dfb) {
     constexpr uint32_t tile_size = get_tile_size(cb_id);
     const uint32_t num_pages = get_local_cb_interface(cb_id).fifo_num_pages;
-    const uint32_t num_tiles = get_local_cb_interface(cb_id).fifo_page_size / tile_size;
+    // Read the entry size from the DFB object rather than poking the raw CB interface
+    // (matches the Quasar sibling of this header, where the raw fifo_page_size is stale).
+    const uint32_t num_tiles = dfb.get_entry_size() / tile_size;
 
     UnicastEndpoint self_ep;
     const auto src = experimental::local_addr(clear_dfb.get_read_ptr(), noc.get_noc_id());
@@ -126,7 +128,7 @@ ALWI void fill_scalar(
 }
 
 ALWI void zero_out_page(Noc noc, DataflowBuffer dfb) {
-    const uint32_t page_size = get_local_cb_interface(dfb.get_id()).fifo_page_size;
+    const uint32_t page_size = dfb.get_entry_size();
     noc.async_write_zeros(dfb, page_size);
     noc.write_zeros_l1_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/pool/device/kernels/pool_kernels_common.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/device/kernels/pool_kernels_common.hpp
@@ -45,7 +45,7 @@ template <uint32_t cb_id, uint32_t clear_value_cb_id>
 ALWI void clear_out_tiles(Noc noc, DataflowBuffer dfb, DataflowBuffer clear_dfb) {
     constexpr uint32_t tile_size = get_tile_size(cb_id);
     const uint32_t num_pages = get_local_cb_interface(cb_id).fifo_num_pages;
-    const uint32_t num_tiles = dfb.get_entry_size() / tile_size;
+    const uint32_t num_tiles = get_local_cb_interface(cb_id).fifo_page_size / tile_size;
 
     UnicastEndpoint self_ep;
     const auto src = experimental::local_addr(clear_dfb.get_read_ptr(), noc.get_noc_id());
@@ -126,7 +126,7 @@ ALWI void fill_scalar(
 }
 
 ALWI void zero_out_page(Noc noc, DataflowBuffer dfb) {
-    const uint32_t page_size = dfb.get_entry_size();
+    const uint32_t page_size = get_local_cb_interface(dfb.get_id()).fifo_page_size;
     noc.async_write_zeros(dfb, page_size);
     noc.write_zeros_l1_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_nc.cpp
@@ -47,7 +47,7 @@ void kernel_main() {
 
     Noc noc;
     DataflowBuffer dfb(dfb_in0);
-    const uint32_t tile_bytes = get_tile_size(dfb_in0);
+    const uint32_t tile_bytes = dfb.get_tile_size();
 
     for (uint32_t out_i = 0; out_i < num_output_tiles; ++out_i) {
         const uint32_t output_tile_id = start_id + out_i;

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/writer_argmax_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/writer_argmax_nc.cpp
@@ -25,7 +25,7 @@ void kernel_main() {
 
     Noc noc;
     DataflowBuffer dfb(dfb_out0);
-    const uint32_t tile_bytes = get_tile_size(dfb_out0);
+    const uint32_t tile_bytes = dfb.get_tile_size();
 
     for (uint32_t out_i = 0; out_i < num_output_tiles; ++out_i) {
         const uint32_t write_tile_id = start_id + out_i;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_reduce_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_reduce_rm.cpp
@@ -73,7 +73,7 @@ void reduce_rm_reader() {
     dataflow_kernel_lib::prepare_reduce_scaler<cb_id_scaler, REDUCE_OP, DIM>(scaler_f, scaler_valid_for_reduce);
 
     // Identity template — pre-built once, reused as the pad source for every staged slab.
-    const uint32_t clear_template_bytes = get_tile_size(cb_id_clear_value);
+    const uint32_t clear_template_bytes = cb_clear_value.get_tile_size();
     rm_fill_buffer_with_identity_pattern(
         cb_clear_value.get_write_ptr(), clear_template_bytes, elem_bytes, padding_identity_bits);
     cb_clear_value.push_back(onepage);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_reduce_universal_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_reduce_universal_start_id.cpp
@@ -23,12 +23,13 @@ void kernel_main() {
     constexpr uint32_t dfb_id_in0 = 0;
 
     constexpr uint32_t onetile = 1;
-    uint32_t tile_bytes = get_tile_size(dfb_id_in0);
 
     auto tensor_accessor = TensorAccessor(tensor_args, src_addr);
 
     Noc noc;
     DataflowBuffer dfb_in0(dfb_id_in0);
+
+    uint32_t tile_bytes = dfb_in0.get_tile_size();
 
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     for (uint32_t i = start_id; i < start_id + num_tiles; i++) {

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_input_cols_partitioned_sharded.cpp
@@ -41,11 +41,12 @@ void kernel_main() {
         use_sfpu_reduce_path ? (compute_kernel_lib::DEST_AUTO_LIMIT - 1) : compute_kernel_lib::DEST_AUTO_LIMIT;
 
     constexpr uint32_t onetile = 1;
-    uint32_t tile_bytes = get_tile_size(dfb_id_in0);
 
     Noc noc;
     DataflowBuffer dfb_in0(dfb_id_in0);
     DataflowBuffer dfb_in1(dfb_id_in1);
+
+    uint32_t tile_bytes = dfb_in0.get_tile_size();
 
     dfb_in1.reserve_back(num_tiles);
     uint32_t base_l1_addr = dfb_in1.get_write_ptr();

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
@@ -39,7 +39,6 @@ void kernel_main() {
                                                                        : compute_kernel_lib::DEST_AUTO_LIMIT);
 
     constexpr uint32_t onetile = 1;
-    const uint32_t tile_bytes = get_tile_size(dfb_id_in0);
 
     constexpr uint32_t dfb_id_in2 = tt::CBIndex::c_2;
     float scaler_f = __builtin_bit_cast(float, scaler_bits);
@@ -50,6 +49,8 @@ void kernel_main() {
 
     Noc noc;
     DataflowBuffer dfb_in0(dfb_id_in0);
+
+    const uint32_t tile_bytes = dfb_in0.get_tile_size();
 
     uint32_t w = curr_col_in_batch;
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/writer_reduce_rm_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/writer_reduce_rm_scalar.cpp
@@ -60,11 +60,12 @@ void reduce_rm_writer() {
     constexpr uint32_t dfb_id_tile = tt::CBIndex::c_3;
     constexpr uint32_t onetile = 1;
 
-    const uint32_t tile_size_bytes = get_tile_size(dfb_id_tile);
     const auto dst_accessor = TensorAccessor(dst_args, dst_addr);
 
     Noc noc;
     DataflowBuffer dfb_tile(dfb_id_tile);
+
+    const uint32_t tile_size_bytes = dfb_tile.get_tile_size();
 
     if constexpr (DIM == ckernel::ReduceDim::REDUCE_ROW) {
         //

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/writer_welford_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/writer_welford_hw.cpp
@@ -143,13 +143,13 @@ void kernel_main() {
     constexpr std::uint32_t FACE_ELEMENTS = FACE_W * FACE_W;
     constexpr std::uint32_t last_tile_cols = (W % tile_width == 0) ? tile_width : W % tile_width;
 
-    const std::uint32_t partial_tile_size_bytes = get_tile_size(dfb_partial);
-    const std::uint32_t out_tile_size_bytes = get_tile_size(dfb_out);
-
     Noc noc;
     DataflowBuffer dfb_partial_obj(dfb_partial);
     DataflowBuffer dfb_combined_obj(dfb_combined);
     DataflowBuffer dfb_out_obj(dfb_out);
+
+    const std::uint32_t partial_tile_size_bytes = dfb_partial_obj.get_tile_size();
+    const std::uint32_t out_tile_size_bytes = dfb_out_obj.get_tile_size();
 
     const auto tensor_out = TensorAccessor(dst_args, dst_addr);
 


### PR DESCRIPTION
## What

Replaces **non-`constexpr`** legacy tile-metadata free functions with their Device 2.0 member accessors, and deletes dead metadata declarations, across `matmul`, `reduction`, and `normalization`.

```
get_tile_size(dfb_id)   ->  dfb.get_tile_size()
get_dataformat(dfb_id)  ->  dfb.get_dataformat()
```

---

## What could NOT be migrated

### `constexpr` call sites

The single largest category. Sites of the form:

```cpp
constexpr uint32_t tile_bytes = get_tile_size(dfb_id_in0);
```

cannot use the member accessor. `DataflowBuffer::get_tile_size()` *is* marked `constexpr`, but it reads `logical_dfb_id_` through the implicit `this`, so a constant-expression evaluation requires the **object** to be a constant expression — and `DataflowBuffer` is not a literal type. Its constructor is declared without `constexpr` and defined as plain `inline`.

```
error: constexpr variable cannot have non-literal type 'const DataflowBuffer'
note: 'DataflowBuffer' is not literal because it is not an aggregate and has
      no constexpr constructors other than copy or move constructors
```

Adding the keyword would not fix it. On the data-movement path the constructor initializes `local_dfb_interface_(get_local_cb_interface(logical_dfb_id))`, and `get_local_cb_interface` returns a reference into the mutable global `cb_interface[]` array in L1 (`circular_buffer_interface.h:129`), populated at kernel launch — inherently runtime state. On tt-2xx the constructor additionally calls `dfb_ensure_ready()`, a spin-wait on remote producer signals.

`CircularBuffer` is no alternative: its tile accessors are not `constexpr` at all.

Unblocking these requires making `DataflowBuffer` a literal type by separating its compile-time descriptor metadata from its runtime FIFO interface — a change to a core tt_metal type, out of scope here.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/device2-metadata-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/device2-metadata-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/device2-metadata-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/device2-metadata-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/device2-metadata-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/device2-metadata-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/device2-metadata-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/device2-metadata-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/device2-metadata-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/device2-metadata-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/device2-metadata-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/device2-metadata-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/device2-metadata-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/device2-metadata-migration)