### PR TITLE
[Performance] Share a single `dispatch_s` instance across both CQs on Quasar 2CQ

### DIFF
--- a/tools/triage/dump_fast_dispatch.py
+++ b/tools/triage/dump_fast_dispatch.py
@@ -219,10 +219,11 @@ def read_wait_globals(
             command_pointer = int(triage_state.cmd_ptr)
         except TimeoutDeviceRegisterError:
             raise
-        except Exception:
-            last_wait_count = _read_symbol_value(kernel_elf, "last_wait_count", loc_mem_access, check_value=True)
-            last_wait_stream = _read_symbol_value(kernel_elf, "last_wait_stream", loc_mem_access, check_value=True)
-            command_pointer = _read_symbol_value(kernel_elf, "cmd_ptr", loc_mem_access, check_value=True)
+        except Exception as e:
+            log_check(
+                False,
+                f"Failed to read dispatch_s triage state for kernel {dispatcher_core_data.kernel_name} on {risc_name}: {e}",
+            )
     else:
         last_wait_count = _read_symbol_value(
             kernel_elf, "last_wait_count", loc_mem_access, check_value=is_dispatcher_kernel

--- a/tools/triage/dump_fast_dispatch.py
+++ b/tools/triage/dump_fast_dispatch.py
@@ -194,13 +194,51 @@ def read_wait_globals(
         dispatcher_core_data.kernel_name == "cq_dispatch"
         or dispatcher_core_data.kernel_name == "cq_dispatch_subordinate"
     )
-    # Inline: read wait-related globals directly from ELF
-    last_wait_count = _read_symbol_value(
-        kernel_elf, "last_wait_count", loc_mem_access, check_value=is_dispatcher_kernel
-    )
-    last_wait_stream = _read_symbol_value(
-        kernel_elf, "last_wait_stream", loc_mem_access, check_value=is_dispatcher_kernel
-    )
+    last_wait_count: int | None = None
+    last_wait_stream: int | None = None
+    command_pointer: int | None = None
+    if dispatcher_core_data.kernel_name == "cq_dispatch_subordinate":
+        try:
+            # Shared-binary subordinates mirror wait/cmd state by channel. Prefer that when present
+            # so TLS migration does not regress 1CQ triage. Colocated 2CQ Inspector association is
+            # intentionally unchanged from main.
+            processor_index = location.noc_block.risc_names.index(risc_name)
+            triage_states = kernel_elf.get_global("dispatch_s_triage_state", loc_mem_access)
+            triage_state = None
+            for channel_index in range(2):
+                try:
+                    candidate = triage_states[channel_index]
+                except Exception:
+                    break
+                try:
+                    candidate_dm_index = int(candidate.dm_index)
+                except Exception:
+                    # Older one-channel array ELFs do not record the DM index.
+                    triage_state = candidate if channel_index == 0 else None
+                    break
+                if candidate_dm_index == processor_index:
+                    triage_state = candidate
+                    break
+            if triage_state is None:
+                raise ValueError(f"No dispatch_s triage state found for processor {processor_index}")
+            last_wait_count = int(triage_state.last_wait_count)
+            last_wait_stream = int(triage_state.last_wait_stream)
+            command_pointer = int(triage_state.cmd_ptr)
+        except TimeoutDeviceRegisterError:
+            raise
+        except Exception:
+            # Legacy subordinate ELFs expose scalar globals.
+            last_wait_count = _read_symbol_value(kernel_elf, "last_wait_count", loc_mem_access, check_value=True)
+            last_wait_stream = _read_symbol_value(kernel_elf, "last_wait_stream", loc_mem_access, check_value=True)
+            command_pointer = _read_symbol_value(kernel_elf, "cmd_ptr", loc_mem_access, check_value=True)
+    else:
+        last_wait_count = _read_symbol_value(
+            kernel_elf, "last_wait_count", loc_mem_access, check_value=is_dispatcher_kernel
+        )
+        last_wait_stream = _read_symbol_value(
+            kernel_elf, "last_wait_stream", loc_mem_access, check_value=is_dispatcher_kernel
+        )
+        command_pointer = _read_symbol_value(kernel_elf, "cmd_ptr", loc_mem_access, check_value=is_dispatcher_kernel)
     last_event = _read_symbol_value(
         kernel_elf, "last_event", loc_mem_access, check_value=dispatcher_core_data.kernel_name == "cq_dispatch"
     )
@@ -213,7 +251,6 @@ def read_wait_globals(
         if dispatcher_core_data.kernel_name == "cq_dispatch":
             log_check(False, f"Failed to read circular_buffer_fence for kernel {dispatcher_core_data.kernel_name}")
         circular_buffer_fence = None
-    command_pointer = _read_symbol_value(kernel_elf, "cmd_ptr", loc_mem_access, check_value=is_dispatcher_kernel)
 
     def get_const_value(name: str, check_value: bool = True) -> int | None:
         try:

--- a/tools/triage/dump_fast_dispatch.py
+++ b/tools/triage/dump_fast_dispatch.py
@@ -202,11 +202,8 @@ def read_wait_globals(
             processor_index = location.noc_block.risc_names.index(risc_name)
             triage_states = kernel_elf.get_global("dispatch_s_triage_state", loc_mem_access)
             triage_state = None
-            for channel_index in range(2):
-                try:
-                    candidate = triage_states[channel_index]
-                except Exception:
-                    break
+            for channel_index in range(len(triage_states)):
+                candidate = triage_states[channel_index]
                 try:
                     candidate_dm_index = int(candidate.dm_index)
                 except Exception:

--- a/tools/triage/dump_fast_dispatch.py
+++ b/tools/triage/dump_fast_dispatch.py
@@ -199,9 +199,6 @@ def read_wait_globals(
     command_pointer: int | None = None
     if dispatcher_core_data.kernel_name == "cq_dispatch_subordinate":
         try:
-            # Shared-binary subordinates mirror wait/cmd state by channel. Prefer that when present
-            # so TLS migration does not regress 1CQ triage. Colocated 2CQ Inspector association is
-            # intentionally unchanged from main.
             processor_index = location.noc_block.risc_names.index(risc_name)
             triage_states = kernel_elf.get_global("dispatch_s_triage_state", loc_mem_access)
             triage_state = None
@@ -213,7 +210,6 @@ def read_wait_globals(
                 try:
                     candidate_dm_index = int(candidate.dm_index)
                 except Exception:
-                    # Older one-channel array ELFs do not record the DM index.
                     triage_state = candidate if channel_index == 0 else None
                     break
                 if candidate_dm_index == processor_index:
@@ -227,7 +223,6 @@ def read_wait_globals(
         except TimeoutDeviceRegisterError:
             raise
         except Exception:
-            # Legacy subordinate ELFs expose scalar globals.
             last_wait_count = _read_symbol_value(kernel_elf, "last_wait_count", loc_mem_access, check_value=True)
             last_wait_stream = _read_symbol_value(kernel_elf, "last_wait_stream", loc_mem_access, check_value=True)
             command_pointer = _read_symbol_value(kernel_elf, "cmd_ptr", loc_mem_access, check_value=True)

--- a/tt_metal/hw/firmware/src/tt-2xx/dmk.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dmk.cc
@@ -48,8 +48,15 @@ uint32_t _start() {
     launch_msg_t tt_l1_ptr* launch_msg = &(*GET_MAILBOX_ADDRESS_DEV(launch))[launch_idx];
     uint32_t my_kt = launch_msg->kernel_config.kernel_text_offset[hartid];
     uint32_t thread_0_hartid = hartid;
+    // Tensix reserves DM0 and DM1; thread 0 search starts at 2.
+    // Dispatch engine DM cores don't reserve DM0/DM1, so search from 0.
+#if defined(COMPILE_FOR_DISPATCH_ENGINE)
+    constexpr uint32_t first_candidate_hartid = 0;
+#else
+    constexpr uint32_t first_candidate_hartid = 2;
+#endif
     if (launch_msg->kernel_config.enables & (1u << hartid)) {
-        for (uint32_t j = 2; j < MaxDMProcessorsPerCoreType; j++) {
+        for (uint32_t j = first_candidate_hartid; j < MaxDMProcessorsPerCoreType; j++) {
             if ((launch_msg->kernel_config.enables & (1u << j)) &&
                 launch_msg->kernel_config.kernel_text_offset[j] == my_kt) {
                 thread_0_hartid = j;

--- a/tt_metal/impl/dispatch/dispatch_engine_kernel.cpp
+++ b/tt_metal/impl/dispatch/dispatch_engine_kernel.cpp
@@ -5,6 +5,7 @@
 #include "impl/dispatch/dispatch_engine_cores.hpp"
 
 #include <memory>
+#include <set>
 #include <string>
 
 #include <tt-metalium/core_coord.hpp>
@@ -25,15 +26,12 @@ KernelHandle create_dispatch_engine_kernel(
     Program& program,
     const std::string& file_name,
     const CoreCoord& core,
-    DataMovementProcessor dm_processor,
+    const std::set<DataMovementProcessor>& dm_processors,
     const experimental::quasar::QuasarDataMovementConfig& config) {
-    TT_FATAL(
-        config.num_threads_per_cluster == 1,
-        "CreateDispatchEngineKernel requires num_threads_per_cluster=1");
     const CoreRangeSet core_ranges = CoreRangeSet(core);
     const KernelSource kernel_src(file_name, KernelSource::FILE_PATH);
-    std::shared_ptr<Kernel> kernel = std::make_shared<experimental::quasar::DispatchEngineKernel>(
-        kernel_src, core_ranges, config, dm_processor);
+    std::shared_ptr<Kernel> kernel =
+        std::make_shared<experimental::quasar::DispatchEngineKernel>(kernel_src, core_ranges, config, dm_processors);
     return program.impl().add_kernel(kernel, HalProgrammableCoreType::DISPATCH);
 }
 
@@ -49,7 +47,7 @@ KernelHandle CreateDispatchEngineKernel(
     const auto free_dms = experimental::quasar::GetAvailableDataMovementProcessors(
         program, core_ranges, config.num_threads_per_cluster, HalProgrammableCoreType::DISPATCH);
     TT_FATAL(!free_dms.empty(), "No free data-movement processors on dispatch-engine core {}", core.str());
-    return create_dispatch_engine_kernel(program, file_name, core, *free_dms.begin(), config);
+    return create_dispatch_engine_kernel(program, file_name, core, free_dms, config);
 }
 
 KernelHandle CreateDispatchEngineKernel(
@@ -58,7 +56,7 @@ KernelHandle CreateDispatchEngineKernel(
     const CoreCoord& core,
     DataMovementProcessor dm_processor,
     const experimental::quasar::QuasarDataMovementConfig& config) {
-    return create_dispatch_engine_kernel(program, file_name, core, dm_processor, config);
+    return create_dispatch_engine_kernel(program, file_name, core, {dm_processor}, config);
 }
 
 }  // namespace tt::tt_metal::detail

--- a/tt_metal/impl/dispatch/dispatch_mem_map.cpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.cpp
@@ -168,10 +168,9 @@ DispatchMemMap::DispatchMemMap(
         l1_size);
     TT_ASSERT(dispatch_cb_end < l1_size);
 
-    // WORKER and Quasar DISPATCH co-locate dispatch_s on the same core as dispatch; ETH does not.
-    const uint32_t dispatch_s_buffer_base =
+    dispatch_s_buffer_base_ =
         (core_type == CoreType::WORKER || core_type == CoreType::DISPATCH) ? dispatch_cb_end : dispatch_buffer_base_;
-    dispatch_s_buffer_end_ = dispatch_s_buffer_base + settings.dispatch_s_buffer_size_;
+    dispatch_s_buffer_end_ = dispatch_s_buffer_base_ + settings.dispatch_s_buffer_size_;
     TT_FATAL(
         dispatch_s_buffer_end_ <= l1_size,
         "dispatch_s buffer end ({}) extends past L1 end (size {})",
@@ -248,6 +247,10 @@ uint32_t DispatchMemMap::dispatch_buffer_pages() const { return settings.dispatc
 uint32_t DispatchMemMap::prefetch_d_buffer_size() const { return settings.prefetch_d_buffer_size_; }
 
 uint32_t DispatchMemMap::prefetch_d_buffer_pages() const { return settings.prefetch_d_pages_; }
+
+uint32_t DispatchMemMap::dispatch_s_buffer_base(uint8_t cq_id) const {
+    return dispatch_s_buffer_base_ + cq_id * cq_zone_stride_;
+}
 
 uint32_t DispatchMemMap::dispatch_s_buffer_size() const { return settings.dispatch_s_buffer_size_; }
 

--- a/tt_metal/impl/dispatch/dispatch_mem_map.hpp
+++ b/tt_metal/impl/dispatch/dispatch_mem_map.hpp
@@ -71,6 +71,8 @@ public:
 
     uint32_t prefetch_d_buffer_pages() const;
 
+    uint32_t dispatch_s_buffer_base(uint8_t cq_id) const;
+
     uint32_t dispatch_s_buffer_size() const;
 
     uint32_t dispatch_s_buffer_pages() const;
@@ -112,6 +114,7 @@ private:
     uint32_t scratch_db_base_ = 0;
     uint32_t dispatch_buffer_base_ = 0;
     uint32_t dispatch_s_device_print_l1_cache_size_ = 0;
+    uint32_t dispatch_s_buffer_base_ = 0;
     uint32_t dispatch_s_buffer_end_ = 0;
 
     uint32_t dispatch_buffer_block_size_pages_ = 0;

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -307,7 +307,8 @@ void DispatchKernel::GenerateDependentConfigs() {
             auto* dispatch_s_kernel = dynamic_cast<DispatchSKernel*>(downstream_kernels_[0]);
             TT_ASSERT(dispatch_s_kernel);
             dependent_config_.downstream_s_logical_core = dispatch_s_kernel->GetLogicalCore();
-            dependent_config_.dispatch_d_shutdown_sem_id = dispatch_s_kernel->GetDispatchDShutdownSemId(cq_id_);
+            dependent_config_.dispatch_d_shutdown_sem_id =
+                dispatch_s_kernel->GetChannelConfig(cq_id_).dispatch_d_shutdown_sem_id;
         } else {
             // If no dispatch_s, no downstream
             TT_ASSERT(downstream_kernels_.empty());
@@ -409,7 +410,8 @@ void DispatchKernel::GenerateDependentConfigs() {
             if (auto* dispatch_s_kernel = dynamic_cast<DispatchSKernel*>(ds_kernel)) {
                 TT_ASSERT(!found_dispatch_s, "DISPATCH_D has multiple downstream DISPATCH_S kernels.");
                 dependent_config_.downstream_s_logical_core = dispatch_s_kernel->GetLogicalCore();
-                dependent_config_.dispatch_d_shutdown_sem_id = dispatch_s_kernel->GetDispatchDShutdownSemId(cq_id_);
+                dependent_config_.dispatch_d_shutdown_sem_id =
+                    dispatch_s_kernel->GetChannelConfig(cq_id_).dispatch_d_shutdown_sem_id;
                 found_dispatch_s = true;
             } else if (auto* dispatch_h_kernel = dynamic_cast<DispatchKernel*>(ds_kernel)) {
                 TT_ASSERT(!found_dispatch_h, "DISPATCH_D has multiple downstream DISPATCH_H kernels.");

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -307,8 +307,7 @@ void DispatchKernel::GenerateDependentConfigs() {
             auto* dispatch_s_kernel = dynamic_cast<DispatchSKernel*>(downstream_kernels_[0]);
             TT_ASSERT(dispatch_s_kernel);
             dependent_config_.downstream_s_logical_core = dispatch_s_kernel->GetLogicalCore();
-            dependent_config_.dispatch_d_shutdown_sem_id =
-                dispatch_s_kernel->GetStaticConfig().dispatch_d_shutdown_sem_id;
+            dependent_config_.dispatch_d_shutdown_sem_id = dispatch_s_kernel->GetDispatchDShutdownSemId(cq_id_);
         } else {
             // If no dispatch_s, no downstream
             TT_ASSERT(downstream_kernels_.empty());
@@ -410,8 +409,7 @@ void DispatchKernel::GenerateDependentConfigs() {
             if (auto* dispatch_s_kernel = dynamic_cast<DispatchSKernel*>(ds_kernel)) {
                 TT_ASSERT(!found_dispatch_s, "DISPATCH_D has multiple downstream DISPATCH_S kernels.");
                 dependent_config_.downstream_s_logical_core = dispatch_s_kernel->GetLogicalCore();
-                dependent_config_.dispatch_d_shutdown_sem_id =
-                    dispatch_s_kernel->GetStaticConfig().dispatch_d_shutdown_sem_id;
+                dependent_config_.dispatch_d_shutdown_sem_id = dispatch_s_kernel->GetDispatchDShutdownSemId(cq_id_);
                 found_dispatch_s = true;
             } else if (auto* dispatch_h_kernel = dynamic_cast<DispatchKernel*>(ds_kernel)) {
                 TT_ASSERT(!found_dispatch_h, "DISPATCH_D has multiple downstream DISPATCH_H kernels.");

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -165,16 +165,18 @@ void DispatchSKernel::GenerateStaticConfigs() {
         }
     }
 
-    const bool dispatch_s_enabled = get_dispatch_query_manager_ref().dispatch_s_enabled();
-    // dispatch_s shares the core with dispatch_d (Tensix WORKER or Quasar DE): start its CB past dispatch_d's.
-    const uint32_t cb_base_offset =
-        (GetCoreType() == CoreType::WORKER || GetCoreType() == CoreType::DISPATCH)
-            ? (1 << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE) * my_dispatch_constants.dispatch_buffer_pages()
-            : 0;
     for (const uint8_t served_cq_id : served_cq_ids_) {
         auto& channel_config = static_config_.channels[served_cq_id];
-        channel_config.cb_base =
-            dispatch_s_enabled ? my_dispatch_constants.dispatch_buffer_base(served_cq_id) + cb_base_offset : 0xff;
+        if (get_dispatch_query_manager_ref().dispatch_s_enabled()) {
+            // dispatch_s shares the core with dispatch_d (Tensix WORKER or Quasar DE): start its CB past dispatch_d's.
+            const uint32_t cb_base_offset = (GetCoreType() == CoreType::WORKER || GetCoreType() == CoreType::DISPATCH)
+                                                ? (1 << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE) *
+                                                      my_dispatch_constants.dispatch_buffer_pages()
+                                                : 0;
+            channel_config.cb_base = my_dispatch_constants.dispatch_buffer_base(served_cq_id) + cb_base_offset;
+        } else {
+            channel_config.cb_base = 0xff;
+        }
         channel_config.my_dispatch_cb_sem_id = CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
         channel_config.dispatch_d_shutdown_sem_id = CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
         // cq_dispatch.cpp derives dispatch_s_enabled from a non-zero shutdown sem id.

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -8,6 +8,7 @@
 #include "impl/buffers/semaphore.hpp"
 #include <tt-metalium/kernel_types.hpp>
 #include <map>
+#include <set>
 #include <string>
 #include <variant>
 #include <vector>
@@ -118,37 +119,76 @@ DispatchSKernel::DispatchSKernel(
     this->logical_core_ = dispatch_core_manager.dispatcher_s_core(device_id, channel, cq_id_);
     this->kernel_type_ = FDKernelType::DISPATCH;
     // Log dispatch_s core info based on virtual core to inspector
-    auto virtual_core = this->GetVirtualCore();
-    Inspector::set_dispatch_s_core_info(virtual_core, DISPATCH_S, cq_id, device_id, servicing_device_id);
+    Inspector::set_dispatch_s_core_info(this->GetVirtualCore(), DISPATCH_S, cq_id, device_id, servicing_device_id);
 }
 
 void DispatchSKernel::GenerateStaticConfigs() {
     const auto& my_dispatch_constants = get_dispatch_mem_map();
 
-    uint32_t dispatch_s_buffer_base = 0xff;
-    if (get_dispatch_query_manager_ref().dispatch_s_enabled()) {
-        uint32_t dispatch_buffer_base = my_dispatch_constants.dispatch_buffer_base(cq_id_);
-        if (GetCoreType() == CoreType::WORKER || GetCoreType() == CoreType::DISPATCH) {
-            // dispatch_s shares the core with dispatch_d (Tensix WORKER or Quasar DE). Offset CB start idx.
-            dispatch_s_buffer_base = dispatch_buffer_base + (1 << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE) *
-                                                                my_dispatch_constants.dispatch_buffer_pages();
-        } else {
-            // dispatch_d and dispatch_s are on different cores. No shared resources: dispatch_s CB starts at base.
-            dispatch_s_buffer_base = dispatch_buffer_base;
+    std::set<uint8_t> upstream_cq_ids;
+    std::set<uint8_t> downstream_cq_ids;
+    for (const auto* kernel : upstream_kernels_) {
+        TT_FATAL(dynamic_cast<const PrefetchKernel*>(kernel) != nullptr, "DISPATCH_S upstream must be PREFETCH");
+        upstream_cq_ids.insert(kernel->GetCQId());
+    }
+    for (const auto* kernel : downstream_kernels_) {
+        TT_FATAL(dynamic_cast<const DispatchKernel*>(kernel) != nullptr, "DISPATCH_S downstream must be DISPATCH");
+        downstream_cq_ids.insert(kernel->GetCQId());
+    }
+    TT_FATAL(
+        upstream_cq_ids.size() == upstream_kernels_.size() && downstream_cq_ids.size() == downstream_kernels_.size(),
+        "DISPATCH_S requires one peer of each type per CQ");
+    TT_FATAL(upstream_cq_ids == downstream_cq_ids, "DISPATCH_S must have matching PREFETCH and DISPATCH peers by CQ");
+    served_cq_ids_.assign(upstream_cq_ids.begin(), upstream_cq_ids.end());
+
+    const bool serves_one_cq = served_cq_ids_.size() == 1;
+    const bool serves_cq0_and_cq1 = served_cq_ids_.size() == 2 && served_cq_ids_[0] == 0 && served_cq_ids_[1] == 1;
+    TT_FATAL(serves_one_cq || serves_cq0_and_cq1, "DISPATCH_S must serve exactly one CQ, or CQ0 and CQ1 when shared");
+    if (!serves_one_cq) {
+        for (const auto* kernel : upstream_kernels_) {
+            TT_FATAL(kernel->GetLogicalCore() == logical_core_, "Shared DISPATCH_S peers must be colocated");
+        }
+        for (const auto* kernel : downstream_kernels_) {
+            TT_FATAL(kernel->GetLogicalCore() == logical_core_, "Shared DISPATCH_S peers must be colocated");
+        }
+        const uint16_t channel = descriptor_.cluster().get_assigned_channel_for_device(device_id_);
+        for (const uint8_t served_cq_id : served_cq_ids_) {
+            TT_FATAL(
+                dispatch_core_manager_.dispatcher_s_core(device_id_, channel, served_cq_id) == logical_core_,
+                "All CQs served by one DISPATCH_S must resolve to the same core");
         }
     }
 
-    static_config_.cb_base = dispatch_s_buffer_base;
+    const bool dispatch_s_enabled = get_dispatch_query_manager_ref().dispatch_s_enabled();
+    // dispatch_s shares the core with dispatch_d (Tensix WORKER or Quasar DE): start its CB past dispatch_d's.
+    const uint32_t cb_base_offset =
+        (GetCoreType() == CoreType::WORKER || GetCoreType() == CoreType::DISPATCH)
+            ? (1 << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE) * my_dispatch_constants.dispatch_buffer_pages()
+            : 0;
+    for (const uint8_t served_cq_id : served_cq_ids_) {
+        auto& channel_config = static_config_.channels[served_cq_id];
+        channel_config.cb_base =
+            dispatch_s_enabled ? my_dispatch_constants.dispatch_buffer_base(served_cq_id) + cb_base_offset : 0xff;
+        channel_config.my_dispatch_cb_sem_id = CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
+        channel_config.dispatch_d_shutdown_sem_id = CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
+        // cq_dispatch.cpp derives dispatch_s_enabled from a non-zero shutdown sem id.
+        TT_FATAL(
+            channel_config.dispatch_d_shutdown_sem_id.value() != 0,
+            "DISPATCH_S shutdown semaphore for CQ {} must be non-zero",
+            served_cq_id);
+        channel_config.dispatch_s_sync_sem_base_addr = my_dispatch_constants.get_device_command_queue_addr(
+            CommandQueueDeviceAddrType::DISPATCH_S_SYNC_SEM, served_cq_id);
+        channel_config.completion_counter_offset = my_dispatch_constants.get_completion_counter_offset(served_cq_id);
+        channel_config.realtime_profiler_msg_addr = my_dispatch_constants.get_device_command_queue_addr(
+            CommandQueueDeviceAddrType::REALTIME_PROFILER_MSG, served_cq_id);
+        channel_config.dispatch_telemetry_addr = my_dispatch_constants.get_device_command_queue_addr(
+            CommandQueueDeviceAddrType::DISPATCH_TELEMETRY, served_cq_id);
+        channel_config.dispatch_telemetry_control_addr = my_dispatch_constants.get_device_command_queue_addr(
+            CommandQueueDeviceAddrType::DISPATCH_TELEMETRY_CONTROL, served_cq_id);
+    }
+
     static_config_.cb_log_page_size = DispatchSettings::DISPATCH_S_BUFFER_LOG_PAGE_SIZE;
     static_config_.cb_size = my_dispatch_constants.dispatch_s_buffer_size();
-    // used by dispatch_s to sync with prefetch
-    static_config_.my_dispatch_cb_sem_id = CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
-    // used by dispatch_d to signal that its shutdown handoff is ready
-    static_config_.dispatch_d_shutdown_sem_id = CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
-    static_config_.dispatch_s_sync_sem_base_addr =
-        my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_S_SYNC_SEM, cq_id_);
-    // used by dispatch_d to signal that dispatch_s can send go signal
-
     static_config_.mcast_go_signal_addr =
         descriptor_.hal().get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::GO_MSG);
     static_config_.unicast_go_signal_addr =
@@ -157,16 +197,9 @@ void DispatchSKernel::GenerateStaticConfigs() {
             : 0;
     static_config_.distributed_dispatcher = get_dispatch_query_manager_ref().distributed_dispatcher();
     static_config_.first_stream_used = my_dispatch_constants.get_dispatch_stream_index(0);
-    static_config_.completion_counter_offset = my_dispatch_constants.get_completion_counter_offset(cq_id_);
     static_config_.max_num_worker_sems = DispatchSettings::DISPATCH_MESSAGE_ENTRIES;
     static_config_.max_num_go_signal_noc_data_entries = DispatchSettings::DISPATCH_GO_SIGNAL_NOC_DATA_ENTRIES;
-    static_config_.realtime_profiler_msg_addr =
-        my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::REALTIME_PROFILER_MSG, cq_id_);
-    static_config_.dispatch_telemetry_addr =
-        my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::DISPATCH_TELEMETRY, cq_id_);
     static_config_.dispatch_telemetry_disabled = descriptor_.rtoptions().get_dispatch_telemetry_disabled();
-    static_config_.dispatch_telemetry_control_addr = my_dispatch_constants.get_device_command_queue_addr(
-        CommandQueueDeviceAddrType::DISPATCH_TELEMETRY_CONTROL, cq_id_);
 
     // Configuration for DEVICE_PRINT dispatch.
     static_config_.device_print_dispatch_enabled = 0;
@@ -232,18 +265,27 @@ void DispatchSKernel::GenerateStaticConfigs() {
 }
 
 void DispatchSKernel::GenerateDependentConfigs() {
-    // Upstream
-    TT_ASSERT(upstream_kernels_.size() == 1);
-    auto* prefetch_kernel = dynamic_cast<PrefetchKernel*>(upstream_kernels_[0]);
-    TT_ASSERT(prefetch_kernel);
-    dependent_config_.upstream_logical_core = prefetch_kernel->GetLogicalCore();
-    dependent_config_.upstream_dispatch_cb_sem_id = prefetch_kernel->GetStaticConfig().my_dispatch_s_cb_sem_id;
-
-    // Downstream
-    TT_ASSERT(downstream_kernels_.size() == 1);
-    auto* dispatch_kernel = dynamic_cast<DispatchKernel*>(downstream_kernels_[0]);
-    TT_ASSERT(dispatch_kernel);
-    dependent_config_.downstream_logical_core = dispatch_kernel->GetLogicalCore();
+    for (const uint8_t served_cq_id : served_cq_ids_) {
+        auto& channel = dependent_config_.channels[served_cq_id];
+        PrefetchKernel* prefetch_kernel = nullptr;
+        DispatchKernel* dispatch_kernel = nullptr;
+        for (auto* upstream : upstream_kernels_) {
+            if (upstream->GetCQId() == served_cq_id) {
+                TT_ASSERT(prefetch_kernel == nullptr);
+                prefetch_kernel = dynamic_cast<PrefetchKernel*>(upstream);
+            }
+        }
+        for (auto* downstream : downstream_kernels_) {
+            if (downstream->GetCQId() == served_cq_id) {
+                TT_ASSERT(dispatch_kernel == nullptr);
+                dispatch_kernel = dynamic_cast<DispatchKernel*>(downstream);
+            }
+        }
+        TT_ASSERT(prefetch_kernel != nullptr && dispatch_kernel != nullptr);
+        channel.upstream_logical_core = prefetch_kernel->GetLogicalCore();
+        channel.upstream_dispatch_cb_sem_id = prefetch_kernel->GetStaticConfig().my_dispatch_s_cb_sem_id;
+        channel.downstream_logical_core = dispatch_kernel->GetLogicalCore();
+    }
 }
 
 void DispatchSKernel::CreateKernel() {
@@ -266,42 +308,25 @@ void DispatchSKernel::CreateKernel() {
     auto virtual_core_range = CoreRange(virtual_start, virtual_end);
 
     auto my_virtual_core = device_->virtual_core_from_logical_core(logical_core_, GetCoreType());
-    auto upstream_virtual_core =
-        device_->virtual_core_from_logical_core(dependent_config_.upstream_logical_core.value(), GetCoreType());
-    auto downstream_virtual_core =
-        device_->virtual_core_from_logical_core(dependent_config_.downstream_logical_core.value(), GetCoreType());
     auto downstream_s_virtual_core = device_->virtual_core_from_logical_core(UNUSED_LOGICAL_CORE, GetCoreType());
 
     auto my_virtual_noc_coords = device_->virtual_noc0_coordinate(noc_selection_.non_dispatch_noc, my_virtual_core);
-    auto upstream_virtual_noc_coords =
-        device_->virtual_noc0_coordinate(noc_selection_.upstream_noc, upstream_virtual_core);
-    auto downstream_virtual_noc_coords =
-        device_->virtual_noc0_coordinate(noc_selection_.downstream_noc, downstream_virtual_core);
     auto downstream_s_virtual_noc_coords =
         device_->virtual_noc0_coordinate(noc_selection_.downstream_noc, downstream_s_virtual_core);
 
     std::map<std::string, std::string> defines = {
+        {"NUM_DISPATCH_S_CHANNELS", std::to_string(served_cq_ids_.size())},
         {"MY_NOC_X", std::to_string(my_virtual_noc_coords.x)},
         {"MY_NOC_Y", std::to_string(my_virtual_noc_coords.y)},
-        {"UPSTREAM_NOC_INDEX", std::to_string(noc_selection_.upstream_noc)},  // Unused, remove later
-        {"UPSTREAM_NOC_X", std::to_string(upstream_virtual_noc_coords.x)},
-        {"UPSTREAM_NOC_Y", std::to_string(upstream_virtual_noc_coords.y)},
-        {"DOWNSTREAM_NOC_X", std::to_string(downstream_virtual_noc_coords.x)},
-        {"DOWNSTREAM_NOC_Y", std::to_string(downstream_virtual_noc_coords.y)},
+        {"UPSTREAM_NOC_INDEX", std::to_string(noc_selection_.upstream_noc)},                  // Unused, remove later
         {"DOWNSTREAM_SUBORDINATE_NOC_X", std::to_string(downstream_s_virtual_noc_coords.x)},  // Unused, remove later
         {"DOWNSTREAM_SUBORDINATE_NOC_Y", std::to_string(downstream_s_virtual_noc_coords.y)},  // Unused, remove later
-        {"CB_BASE", std::to_string(static_config_.cb_base.value())},
         {"CB_LOG_PAGE_SIZE", std::to_string(static_config_.cb_log_page_size.value())},
         {"CB_SIZE", std::to_string(static_config_.cb_size.value())},
-        {"MY_DISPATCH_CB_SEM_ID", std::to_string(static_config_.my_dispatch_cb_sem_id.value())},
-        {"DISPATCH_D_SHUTDOWN_SEM_ID", std::to_string(static_config_.dispatch_d_shutdown_sem_id.value())},
-        {"UPSTREAM_DISPATCH_CB_SEM_ID", std::to_string(dependent_config_.upstream_dispatch_cb_sem_id.value())},
-        {"DISPATCH_S_SYNC_SEM_BASE_ADDR", std::to_string(static_config_.dispatch_s_sync_sem_base_addr.value())},
         {"MCAST_GO_SIGNAL_ADDR", std::to_string(static_config_.mcast_go_signal_addr.value())},
         {"UNICAST_GO_SIGNAL_ADDR", std::to_string(static_config_.unicast_go_signal_addr.value())},
         {"DISTRIBUTED_DISPATCHER", std::to_string(static_config_.distributed_dispatcher.value())},
         {"FIRST_STREAM_USED", std::to_string(static_config_.first_stream_used.value())},
-        {"COMPLETION_COUNTER_OFFSET", std::to_string(static_config_.completion_counter_offset.value())},
         {"MAX_NUM_WORKER_SEMS", std::to_string(static_config_.max_num_worker_sems.value())},
         {"MAX_NUM_GO_SIGNAL_NOC_DATA_ENTRIES",
          std::to_string(static_config_.max_num_go_signal_noc_data_entries.value())},
@@ -311,10 +336,7 @@ void DispatchSKernel::CreateKernel() {
         {"WORKER_MCAST_GRID",
          std::to_string(device_->get_noc_multicast_encoding(noc_selection_.downstream_noc, virtual_core_range))},
         {"NUM_WORKER_CORES_TO_MCAST", std::to_string(device_worker_cores.size())},
-        {"REALTIME_PROFILER_MSG_ADDR", std::to_string(static_config_.realtime_profiler_msg_addr.value())},
-        {"DISPATCH_TELEMETRY_ADDR", std::to_string(static_config_.dispatch_telemetry_addr.value())},
         {"DISPATCH_TELEMETRY_DISABLED", std::to_string(static_config_.dispatch_telemetry_disabled.value_or(false))},
-        {"DISPATCH_TELEMETRY_CONTROL_ADDR", std::to_string(static_config_.dispatch_telemetry_control_addr.value())},
         {"DEVICE_PRINT_DISPATCH_ENABLED", std::to_string(static_config_.device_print_dispatch_enabled.value_or(0))},
         // For each per-device dispatch_s build, MaxNocLocations equals the actual print-core count
         // for that device — passed as a compile-time #define so DevicePrintDispatch<>'s LDM arrays
@@ -336,18 +358,51 @@ void DispatchSKernel::CreateKernel() {
         {"DEVICE_PRINT_CYCLES_FOR_FULL",
          std::to_string(static_config_.device_print_cycles_for_full.value_or(0)) + "ULL"},
     };
-    configure_kernel_variant(dispatch_kernel_file_names[DISPATCH_S], {}, defines);
+    for (size_t channel_index = 0; channel_index < served_cq_ids_.size(); ++channel_index) {
+        const uint8_t served_cq_id = served_cq_ids_[channel_index];
+        const auto& channel = static_config_.channels.at(served_cq_id);
+        const auto& dependent_channel = dependent_config_.channels.at(served_cq_id);
+        const auto upstream_virtual_core =
+            device_->virtual_core_from_logical_core(dependent_channel.upstream_logical_core.value(), GetCoreType());
+        const auto downstream_virtual_core =
+            device_->virtual_core_from_logical_core(dependent_channel.downstream_logical_core.value(), GetCoreType());
+        const auto upstream_virtual_noc_coords =
+            device_->virtual_noc0_coordinate(noc_selection_.upstream_noc, upstream_virtual_core);
+        const auto downstream_virtual_noc_coords =
+            device_->virtual_noc0_coordinate(noc_selection_.downstream_noc, downstream_virtual_core);
+        const std::string suffix = served_cq_ids_.size() == 1 ? "" : "_" + std::to_string(channel_index);
+        defines["CB_BASE" + suffix] = std::to_string(channel.cb_base.value());
+        defines["MY_DISPATCH_CB_SEM_ID" + suffix] = std::to_string(channel.my_dispatch_cb_sem_id.value());
+        defines["UPSTREAM_DISPATCH_CB_SEM_ID" + suffix] =
+            std::to_string(dependent_channel.upstream_dispatch_cb_sem_id.value());
+        defines["DISPATCH_D_SHUTDOWN_SEM_ID" + suffix] = std::to_string(channel.dispatch_d_shutdown_sem_id.value());
+        defines["DISPATCH_S_SYNC_SEM_BASE_ADDR" + suffix] =
+            std::to_string(channel.dispatch_s_sync_sem_base_addr.value());
+        defines["COMPLETION_COUNTER_OFFSET" + suffix] = std::to_string(channel.completion_counter_offset.value());
+        defines["REALTIME_PROFILER_MSG_ADDR" + suffix] = std::to_string(channel.realtime_profiler_msg_addr.value());
+        defines["DISPATCH_TELEMETRY_ADDR" + suffix] = std::to_string(channel.dispatch_telemetry_addr.value());
+        defines["DISPATCH_TELEMETRY_CONTROL_ADDR" + suffix] =
+            std::to_string(channel.dispatch_telemetry_control_addr.value());
+        defines["UPSTREAM_NOC_X" + suffix] = std::to_string(upstream_virtual_noc_coords.x);
+        defines["UPSTREAM_NOC_Y" + suffix] = std::to_string(upstream_virtual_noc_coords.y);
+        defines["DOWNSTREAM_NOC_X" + suffix] = std::to_string(downstream_virtual_noc_coords.x);
+        defines["DOWNSTREAM_NOC_Y" + suffix] = std::to_string(downstream_virtual_noc_coords.y);
+    }
+    num_threads_ = served_cq_ids_.size();
+    configure_kernel_variant(
+        dispatch_kernel_file_names[DISPATCH_S], {}, defines, tt::tt_metal::KernelBuildOptLevel::Os);
 
     if (GetCoreType() == CoreType::WORKER && device_->arch() != tt::ARCH::QUASAR) {
+        const auto& channel = static_config_.channels.at(served_cq_ids_.front());
         const std::string compute_kernel_path = "tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate_compute.cpp";
         std::map<std::string, std::string> compute_defines = {
             {"FIRST_STREAM_INDEX", std::to_string(static_config_.first_stream_used.value())},
             {"NUM_STREAMS_TO_MONITOR", std::to_string(static_config_.max_num_worker_sems.value())},
-            {"REALTIME_PROFILER_MSG_ADDR", std::to_string(static_config_.realtime_profiler_msg_addr.value())},
-            {"DISPATCH_TELEMETRY_ADDR", std::to_string(static_config_.dispatch_telemetry_addr.value())},
+            {"REALTIME_PROFILER_MSG_ADDR", std::to_string(channel.realtime_profiler_msg_addr.value())},
+            {"DISPATCH_TELEMETRY_ADDR", std::to_string(channel.dispatch_telemetry_addr.value())},
             {"DISPATCH_TELEMETRY_DISABLED", std::to_string(static_config_.dispatch_telemetry_disabled.value_or(false))},
             {"TOTAL_SUB_DEVICES", std::to_string(static_config_.max_num_worker_sems.value())},
-            {"DISPATCH_TELEMETRY_CONTROL_ADDR", std::to_string(static_config_.dispatch_telemetry_control_addr.value())},
+            {"DISPATCH_TELEMETRY_CONTROL_ADDR", std::to_string(channel.dispatch_telemetry_control_addr.value())},
         };
         tt::tt_metal::ComputeConfig compute_config;
         compute_config.defines = compute_defines;
@@ -355,53 +410,53 @@ void DispatchSKernel::CreateKernel() {
     }
 }
 
+uint32_t DispatchSKernel::GetMyDispatchCbSemId(uint8_t cq_id) const {
+    return static_config_.channels.at(cq_id).my_dispatch_cb_sem_id.value();
+}
+
+uint32_t DispatchSKernel::GetDispatchDShutdownSemId(uint8_t cq_id) const {
+    return static_config_.channels.at(cq_id).dispatch_d_shutdown_sem_id.value();
+}
+
 void DispatchSKernel::ConfigureCore() {
-    if (get_dispatch_query_manager_ref().dispatch_s_enabled()) {
-        TT_ASSERT(static_config_.realtime_profiler_msg_addr.has_value());
-        zero_dispatch_s_realtime_profiler_msg_fields(
-            device_,
-            logical_core_,
-            GetCoreType(),
-            descriptor_.hal(),
-            static_config_.realtime_profiler_msg_addr.value());
+    for (const uint8_t served_cq_id : served_cq_ids_) {
+        const auto& channel = static_config_.channels.at(served_cq_id);
+        if (get_dispatch_query_manager_ref().dispatch_s_enabled()) {
+            zero_dispatch_s_realtime_profiler_msg_fields(
+                device_, logical_core_, GetCoreType(), descriptor_.hal(), channel.realtime_profiler_msg_addr.value());
 
-        TT_ASSERT(static_config_.dispatch_telemetry_control_addr.has_value());
-        dispatch_telemetry_types::DispatchTelemetryControl zero_dispatch_telemetry_control{};
-        detail::WriteToDeviceL1(
-            device_,
-            logical_core_,
-            static_config_.dispatch_telemetry_control_addr.value(),
-            std::span<const uint8_t>(
-                reinterpret_cast<const uint8_t*>(&zero_dispatch_telemetry_control),
-                sizeof(zero_dispatch_telemetry_control)),
-            GetCoreType());
-    }
-
-    if (get_dispatch_query_manager_ref().distributed_dispatcher()) {
-        // Dispatch_s needs to init telemetry since it has a dedicated core
-        TT_ASSERT(static_config_.dispatch_telemetry_addr.has_value());
-        TT_ASSERT(static_config_.dispatch_telemetry_disabled.has_value());
-        dispatch_telemetry_types::DispatchCoreTelemetry zero_dispatch_telemetry{};
-        if (static_config_.dispatch_telemetry_disabled.value()) {
-            zero_dispatch_telemetry.signature = dispatch_telemetry_types::INVALID_TELEMETRY_SIGNATURE;
+            dispatch_telemetry_types::DispatchTelemetryControl zero_dispatch_telemetry_control{};
+            detail::WriteToDeviceL1(
+                device_,
+                logical_core_,
+                channel.dispatch_telemetry_control_addr.value(),
+                std::span<const uint8_t>(
+                    reinterpret_cast<const uint8_t*>(&zero_dispatch_telemetry_control),
+                    sizeof(zero_dispatch_telemetry_control)),
+                GetCoreType());
         }
-        detail::WriteToDeviceL1(
-            device_,
-            logical_core_,
-            static_config_.dispatch_telemetry_addr.value(),
-            std::span<const uint8_t>(
-                reinterpret_cast<const uint8_t*>(&zero_dispatch_telemetry), sizeof(zero_dispatch_telemetry)),
-            GetCoreType());
 
-        // Just need to clear the dispatch message
-        std::vector<uint32_t> zero = {0x0};
-        const auto& my_dispatch_constants = get_dispatch_mem_map();
-        uint32_t dispatch_s_sync_sem_base_addr = my_dispatch_constants.get_device_command_queue_addr(
-            CommandQueueDeviceAddrType::DISPATCH_S_SYNC_SEM, cq_id_);
-        for (uint32_t i = 0; i < DispatchSettings::DISPATCH_MESSAGE_ENTRIES; i++) {
-            uint32_t dispatch_s_sync_sem_addr =
-                dispatch_s_sync_sem_base_addr + my_dispatch_constants.get_sync_offset(i);
-            detail::WriteToDeviceL1(device_, logical_core_, dispatch_s_sync_sem_addr, zero, GetCoreType());
+        if (get_dispatch_query_manager_ref().distributed_dispatcher()) {
+            TT_ASSERT(static_config_.dispatch_telemetry_disabled.has_value());
+            dispatch_telemetry_types::DispatchCoreTelemetry zero_dispatch_telemetry{};
+            if (static_config_.dispatch_telemetry_disabled.value()) {
+                zero_dispatch_telemetry.signature = dispatch_telemetry_types::INVALID_TELEMETRY_SIGNATURE;
+            }
+            detail::WriteToDeviceL1(
+                device_,
+                logical_core_,
+                channel.dispatch_telemetry_addr.value(),
+                std::span<const uint8_t>(
+                    reinterpret_cast<const uint8_t*>(&zero_dispatch_telemetry), sizeof(zero_dispatch_telemetry)),
+                GetCoreType());
+
+            std::vector<uint32_t> zero = {0x0};
+            const auto& my_dispatch_constants = get_dispatch_mem_map();
+            for (uint32_t i = 0; i < DispatchSettings::DISPATCH_MESSAGE_ENTRIES; i++) {
+                const uint32_t dispatch_s_sync_sem_addr =
+                    channel.dispatch_s_sync_sem_base_addr.value() + my_dispatch_constants.get_sync_offset(i);
+                detail::WriteToDeviceL1(device_, logical_core_, dispatch_s_sync_sem_addr, zero, GetCoreType());
+            }
         }
     }
 

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -141,10 +141,8 @@ void DispatchSKernel::GenerateStaticConfigs() {
     TT_FATAL(
         upstream_cq_ids == downstream_cq_ids,
         "DISPATCH_S upstream PREFETCH and downstream DISPATCH kernels must cover the same set of CQs");
-    served_cq_ids_.assign(upstream_cq_ids.begin(), upstream_cq_ids.end());
-
-    const bool serves_one_cq = served_cq_ids_.size() == 1;
-    const bool serves_cq0_and_cq1 = served_cq_ids_.size() == 2 && served_cq_ids_[0] == 0 && served_cq_ids_[1] == 1;
+    const bool serves_one_cq = upstream_cq_ids.size() == 1;
+    const bool serves_cq0_and_cq1 = upstream_cq_ids == std::set<uint8_t>{0, 1};
     TT_FATAL(serves_one_cq || serves_cq0_and_cq1, "DISPATCH_S must serve exactly one CQ, or CQ0 and CQ1 when shared");
     if (serves_cq0_and_cq1) {
         for (const auto* kernel : upstream_kernels_) {
@@ -158,25 +156,18 @@ void DispatchSKernel::GenerateStaticConfigs() {
                 "Shared DISPATCH_S requires its downstream DISPATCH kernels to be on the same core");
         }
         const uint16_t channel = descriptor_.cluster().get_assigned_channel_for_device(device_id_);
-        for (const uint8_t served_cq_id : served_cq_ids_) {
+        for (const uint8_t served_cq_id : upstream_cq_ids) {
             TT_FATAL(
                 dispatch_core_manager_.dispatcher_s_core(device_id_, channel, served_cq_id) == logical_core_,
                 "All CQs served by one DISPATCH_S must resolve to the same core");
         }
     }
 
-    for (const uint8_t served_cq_id : served_cq_ids_) {
+    for (const uint8_t served_cq_id : upstream_cq_ids) {
         auto& channel_config = static_config_.channels[served_cq_id];
-        if (get_dispatch_query_manager_ref().dispatch_s_enabled()) {
-            // dispatch_s shares the core with dispatch_d (Tensix WORKER or Quasar DE): start its CB past dispatch_d's.
-            const uint32_t cb_base_offset = (GetCoreType() == CoreType::WORKER || GetCoreType() == CoreType::DISPATCH)
-                                                ? (1 << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE) *
-                                                      my_dispatch_constants.dispatch_buffer_pages()
-                                                : 0;
-            channel_config.cb_base = my_dispatch_constants.dispatch_buffer_base(served_cq_id) + cb_base_offset;
-        } else {
-            channel_config.cb_base = 0xff;
-        }
+        channel_config.cb_base = get_dispatch_query_manager_ref().dispatch_s_enabled()
+                                     ? my_dispatch_constants.dispatch_s_buffer_base(served_cq_id)
+                                     : 0xff;
         channel_config.my_dispatch_cb_sem_id = CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
         channel_config.dispatch_d_shutdown_sem_id = CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
         // cq_dispatch.cpp derives dispatch_s_enabled from a non-zero shutdown sem id.
@@ -273,23 +264,25 @@ void DispatchSKernel::GenerateStaticConfigs() {
 }
 
 void DispatchSKernel::GenerateDependentConfigs() {
-    for (const uint8_t served_cq_id : served_cq_ids_) {
+    // GenerateStaticConfigs already established that each served CQ has exactly one upstream
+    // PREFETCH and one downstream DISPATCH, so a single pass per direction covers every channel.
+    std::map<uint8_t, PrefetchKernel*> prefetch_by_cq_id;
+    for (auto* upstream : upstream_kernels_) {
+        auto* prefetch_kernel = dynamic_cast<PrefetchKernel*>(upstream);
+        TT_ASSERT(prefetch_kernel != nullptr);
+        prefetch_by_cq_id[upstream->GetCQId()] = prefetch_kernel;
+    }
+    std::map<uint8_t, DispatchKernel*> dispatch_by_cq_id;
+    for (auto* downstream : downstream_kernels_) {
+        auto* dispatch_kernel = dynamic_cast<DispatchKernel*>(downstream);
+        TT_ASSERT(dispatch_kernel != nullptr);
+        dispatch_by_cq_id[downstream->GetCQId()] = dispatch_kernel;
+    }
+
+    for (const auto& [served_cq_id, channel_config] : static_config_.channels) {
         auto& channel = dependent_config_.channels[served_cq_id];
-        PrefetchKernel* prefetch_kernel = nullptr;
-        DispatchKernel* dispatch_kernel = nullptr;
-        for (auto* upstream : upstream_kernels_) {
-            if (upstream->GetCQId() == served_cq_id) {
-                TT_ASSERT(prefetch_kernel == nullptr);
-                prefetch_kernel = dynamic_cast<PrefetchKernel*>(upstream);
-            }
-        }
-        for (auto* downstream : downstream_kernels_) {
-            if (downstream->GetCQId() == served_cq_id) {
-                TT_ASSERT(dispatch_kernel == nullptr);
-                dispatch_kernel = dynamic_cast<DispatchKernel*>(downstream);
-            }
-        }
-        TT_ASSERT(prefetch_kernel != nullptr && dispatch_kernel != nullptr);
+        PrefetchKernel* prefetch_kernel = prefetch_by_cq_id.at(served_cq_id);
+        DispatchKernel* dispatch_kernel = dispatch_by_cq_id.at(served_cq_id);
         channel.upstream_logical_core = prefetch_kernel->GetLogicalCore();
         channel.upstream_dispatch_cb_sem_id = prefetch_kernel->GetStaticConfig().my_dispatch_s_cb_sem_id;
         channel.downstream_logical_core = dispatch_kernel->GetLogicalCore();
@@ -322,8 +315,9 @@ void DispatchSKernel::CreateKernel() {
     auto downstream_s_virtual_noc_coords =
         device_->virtual_noc0_coordinate(noc_selection_.downstream_noc, downstream_s_virtual_core);
 
+    const size_t num_channels = static_config_.channels.size();
     std::map<std::string, std::string> defines = {
-        {"NUM_DISPATCH_S_CHANNELS", std::to_string(served_cq_ids_.size())},
+        {"NUM_DISPATCH_S_CHANNELS", std::to_string(num_channels)},
         {"MY_NOC_X", std::to_string(my_virtual_noc_coords.x)},
         {"MY_NOC_Y", std::to_string(my_virtual_noc_coords.y)},
         {"UPSTREAM_NOC_INDEX", std::to_string(noc_selection_.upstream_noc)},                  // Unused, remove later
@@ -366,9 +360,8 @@ void DispatchSKernel::CreateKernel() {
         {"DEVICE_PRINT_CYCLES_FOR_FULL",
          std::to_string(static_config_.device_print_cycles_for_full.value_or(0)) + "ULL"},
     };
-    for (size_t channel_index = 0; channel_index < served_cq_ids_.size(); ++channel_index) {
-        const uint8_t served_cq_id = served_cq_ids_[channel_index];
-        const auto& channel = static_config_.channels.at(served_cq_id);
+    size_t channel_index = 0;
+    for (const auto& [served_cq_id, channel] : static_config_.channels) {
         const auto& dependent_channel = dependent_config_.channels.at(served_cq_id);
         const auto upstream_virtual_core =
             device_->virtual_core_from_logical_core(dependent_channel.upstream_logical_core.value(), GetCoreType());
@@ -378,7 +371,7 @@ void DispatchSKernel::CreateKernel() {
             device_->virtual_noc0_coordinate(noc_selection_.upstream_noc, upstream_virtual_core);
         const auto downstream_virtual_noc_coords =
             device_->virtual_noc0_coordinate(noc_selection_.downstream_noc, downstream_virtual_core);
-        const std::string suffix = served_cq_ids_.size() == 1 ? "" : "_" + std::to_string(channel_index);
+        const std::string suffix = num_channels == 1 ? "" : "_" + std::to_string(channel_index);
         defines["CB_BASE" + suffix] = std::to_string(channel.cb_base.value());
         defines["MY_DISPATCH_CB_SEM_ID" + suffix] = std::to_string(channel.my_dispatch_cb_sem_id.value());
         defines["UPSTREAM_DISPATCH_CB_SEM_ID" + suffix] =
@@ -395,13 +388,16 @@ void DispatchSKernel::CreateKernel() {
         defines["UPSTREAM_NOC_Y" + suffix] = std::to_string(upstream_virtual_noc_coords.y);
         defines["DOWNSTREAM_NOC_X" + suffix] = std::to_string(downstream_virtual_noc_coords.x);
         defines["DOWNSTREAM_NOC_Y" + suffix] = std::to_string(downstream_virtual_noc_coords.y);
+        ++channel_index;
     }
-    num_threads_ = served_cq_ids_.size();
+    num_threads_ = num_channels;
     configure_kernel_variant(
         dispatch_kernel_file_names[DISPATCH_S], {}, defines, tt::tt_metal::KernelBuildOptLevel::Os);
 
     if (GetCoreType() == CoreType::WORKER && device_->arch() != tt::ARCH::QUASAR) {
-        const auto& channel = static_config_.channels.at(served_cq_ids_.front());
+        // Only Quasar shares one dispatch_s across CQs, so the non-Quasar path has a single channel.
+        TT_ASSERT(num_channels == 1);
+        const auto& channel = static_config_.channels.begin()->second;
         const std::string compute_kernel_path = "tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate_compute.cpp";
         std::map<std::string, std::string> compute_defines = {
             {"FIRST_STREAM_INDEX", std::to_string(static_config_.first_stream_used.value())},
@@ -418,17 +414,8 @@ void DispatchSKernel::CreateKernel() {
     }
 }
 
-uint32_t DispatchSKernel::GetMyDispatchCbSemId(uint8_t cq_id) const {
-    return static_config_.channels.at(cq_id).my_dispatch_cb_sem_id.value();
-}
-
-uint32_t DispatchSKernel::GetDispatchDShutdownSemId(uint8_t cq_id) const {
-    return static_config_.channels.at(cq_id).dispatch_d_shutdown_sem_id.value();
-}
-
 void DispatchSKernel::ConfigureCore() {
-    for (const uint8_t served_cq_id : served_cq_ids_) {
-        const auto& channel = static_config_.channels.at(served_cq_id);
+    for (const auto& [served_cq_id, channel] : static_config_.channels) {
         if (get_dispatch_query_manager_ref().dispatch_s_enabled()) {
             zero_dispatch_s_realtime_profiler_msg_fields(
                 device_, logical_core_, GetCoreType(), descriptor_.hal(), channel.realtime_profiler_msg_addr.value());

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -137,19 +137,25 @@ void DispatchSKernel::GenerateStaticConfigs() {
     }
     TT_FATAL(
         upstream_cq_ids.size() == upstream_kernels_.size() && downstream_cq_ids.size() == downstream_kernels_.size(),
-        "DISPATCH_S requires one peer of each type per CQ");
-    TT_FATAL(upstream_cq_ids == downstream_cq_ids, "DISPATCH_S must have matching PREFETCH and DISPATCH peers by CQ");
+        "DISPATCH_S requires exactly one upstream PREFETCH and one downstream DISPATCH per CQ");
+    TT_FATAL(
+        upstream_cq_ids == downstream_cq_ids,
+        "DISPATCH_S upstream PREFETCH and downstream DISPATCH kernels must cover the same set of CQs");
     served_cq_ids_.assign(upstream_cq_ids.begin(), upstream_cq_ids.end());
 
     const bool serves_one_cq = served_cq_ids_.size() == 1;
     const bool serves_cq0_and_cq1 = served_cq_ids_.size() == 2 && served_cq_ids_[0] == 0 && served_cq_ids_[1] == 1;
     TT_FATAL(serves_one_cq || serves_cq0_and_cq1, "DISPATCH_S must serve exactly one CQ, or CQ0 and CQ1 when shared");
-    if (!serves_one_cq) {
+    if (serves_cq0_and_cq1) {
         for (const auto* kernel : upstream_kernels_) {
-            TT_FATAL(kernel->GetLogicalCore() == logical_core_, "Shared DISPATCH_S peers must be colocated");
+            TT_FATAL(
+                kernel->GetLogicalCore() == logical_core_,
+                "Shared DISPATCH_S requires its upstream PREFETCH kernels to be on the same core");
         }
         for (const auto* kernel : downstream_kernels_) {
-            TT_FATAL(kernel->GetLogicalCore() == logical_core_, "Shared DISPATCH_S peers must be colocated");
+            TT_FATAL(
+                kernel->GetLogicalCore() == logical_core_,
+                "Shared DISPATCH_S requires its downstream DISPATCH kernels to be on the same core");
         }
         const uint16_t channel = descriptor_.cluster().get_assigned_channel_for_device(device_id_);
         for (const uint8_t served_cq_id : served_cq_ids_) {

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
@@ -5,7 +5,6 @@
 #include <stdint.h>
 #include <map>
 #include <optional>
-#include <vector>
 
 #include "fd_kernel.hpp"
 #include "impl/context/context_descriptor.hpp"
@@ -83,12 +82,11 @@ public:
     void GenerateStaticConfigs() override;
     void GenerateDependentConfigs() override;
     void ConfigureCore() override;
-    const dispatch_s_static_config_t& GetStaticConfig() { return static_config_; }
-    uint32_t GetMyDispatchCbSemId(uint8_t cq_id) const;
-    uint32_t GetDispatchDShutdownSemId(uint8_t cq_id) const;
+    const dispatch_s_channel_config_t& GetChannelConfig(uint8_t cq_id) const {
+        return static_config_.channels.at(cq_id);
+    }
 
 private:
-    std::vector<uint8_t> served_cq_ids_;
     dispatch_s_static_config_t static_config_;
     dispatch_s_dependent_config_t dependent_config_;
 };

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.hpp
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 #include <stdint.h>
+#include <map>
 #include <optional>
+#include <vector>
 
 #include "fd_kernel.hpp"
 #include "impl/context/context_descriptor.hpp"
@@ -11,31 +13,29 @@
 
 namespace tt::tt_metal {
 
-struct dispatch_s_static_config_t {
+struct dispatch_s_channel_config_t {
     std::optional<uint32_t> cb_base;
-    std::optional<uint32_t> cb_log_page_size;
-    std::optional<uint32_t> cb_size;
     std::optional<uint32_t> my_dispatch_cb_sem_id;
     std::optional<uint32_t> dispatch_d_shutdown_sem_id;
     std::optional<uint32_t> dispatch_s_sync_sem_base_addr;
+    std::optional<uint32_t> completion_counter_offset;
+    std::optional<uint32_t> realtime_profiler_msg_addr;
+    std::optional<uint32_t> dispatch_telemetry_addr;
+    std::optional<uint32_t> dispatch_telemetry_control_addr;
+};
+
+struct dispatch_s_static_config_t {
+    std::optional<uint32_t> cb_log_page_size;
+    std::optional<uint32_t> cb_size;
+    std::map<uint8_t, dispatch_s_channel_config_t> channels;
 
     std::optional<uint32_t> mcast_go_signal_addr;
     std::optional<uint32_t> unicast_go_signal_addr;
     std::optional<uint32_t> distributed_dispatcher;
     std::optional<uint32_t> first_stream_used;
-    std::optional<uint32_t> completion_counter_offset;
     std::optional<uint32_t> max_num_worker_sems;
     std::optional<uint32_t> max_num_go_signal_noc_data_entries;
-
-    // Dispatch-core-local L1 address of the realtime_profiler_msg_t block (includes the
-    // program-id handoff FIFO consumed by this kernel). Assigned by DispatchMemMap via
-    // CommandQueueDeviceAddrType::REALTIME_PROFILER_MSG. Must match the value passed to the
-    // co-located DispatchKernel and to the RT-profiler core kernels.
-    std::optional<uint32_t> realtime_profiler_msg_addr;
-
-    std::optional<uint32_t> dispatch_telemetry_addr;
     std::optional<bool> dispatch_telemetry_disabled;
-    std::optional<uint32_t> dispatch_telemetry_control_addr;
 
     // Configuration for DEVICE_PRINT dispatch. Populated only when the dprint server
     // exists and dispatch_s_enabled() is true. enabled stays 0 otherwise and the kernel
@@ -54,10 +54,14 @@ struct dispatch_s_static_config_t {
     std::optional<uint64_t> device_print_cycles_for_full;
 };
 
-struct dispatch_s_dependent_config_t {
+struct dispatch_s_channel_dependent_config_t {
     std::optional<tt_cxy_pair> upstream_logical_core;     // Dependent
     std::optional<tt_cxy_pair> downstream_logical_core;   // Dependent
     std::optional<uint32_t> upstream_dispatch_cb_sem_id;  // Dependent
+};
+
+struct dispatch_s_dependent_config_t {
+    std::map<uint8_t, dispatch_s_channel_dependent_config_t> channels;
 };
 
 class DispatchSKernel : public FDKernel {
@@ -80,8 +84,11 @@ public:
     void GenerateDependentConfigs() override;
     void ConfigureCore() override;
     const dispatch_s_static_config_t& GetStaticConfig() { return static_config_; }
+    uint32_t GetMyDispatchCbSemId(uint8_t cq_id) const;
+    uint32_t GetDispatchDShutdownSemId(uint8_t cq_id) const;
 
 private:
+    std::vector<uint8_t> served_cq_ids_;
     dispatch_s_static_config_t static_config_;
     dispatch_s_dependent_config_t dependent_config_;
 };

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.cpp
@@ -283,7 +283,7 @@ KernelHandle FDKernel::configure_kernel_variant(
                 path,
                 logical_core_,
                 experimental::quasar::QuasarDataMovementConfig{
-                    .num_threads_per_cluster = 1,
+                    .num_threads_per_cluster = num_threads_,
                     .compile_args = compile_args,
                     .defines = defines,
                     .opt_level = opt_level});
@@ -310,7 +310,7 @@ KernelHandle FDKernel::configure_kernel_variant(
             path,
             CoreCoord(logical_core_.x, logical_core_.y),
             experimental::quasar::QuasarDataMovementConfig{
-                .num_threads_per_cluster = 1,
+                .num_threads_per_cluster = num_threads_,
                 .compile_args = compile_args,
                 .defines = defines,
                 .opt_level = opt_level});

--- a/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
+++ b/tt_metal/impl/dispatch/kernel_config/fd_kernel.hpp
@@ -173,6 +173,7 @@ public:
     }
     ChipId GetDeviceId() const { return device_id_; }  // Since this->device may not exist yet
     int GetNodeId() const { return node_id_; }
+    uint8_t GetCQId() const { return cq_id_; }
     virtual std::optional<tt::tt_metal::TerminationInfo> GetTerminationInfo() const { return std::nullopt; }
 
     // Get the port index for which a given kernel is upstream/downstream of this one
@@ -199,7 +200,7 @@ protected:
         const std::string& path,
         const std::vector<uint32_t>& compile_args,
         std::map<std::string, std::string> defines_in,
-        tt::tt_metal::KernelBuildOptLevel opt_level = tt::tt_metal::KernelBuildOptLevel::Os);
+        tt::tt_metal::KernelBuildOptLevel opt_level);
     int GetPort(const FDKernel* other, const std::vector<FDKernel*>& kernels) const {
         for (int idx = 0; idx < kernels.size(); idx++) {
             if (kernels[idx] == other) {
@@ -230,6 +231,7 @@ protected:
     noc_selection_t noc_selection_;
     bool send_to_brisc_ = false;            // WH/BH only: selects RISCV_0 (true) vs RISCV_1 (false)
     bool force_watcher_no_inline_ = false;  // Prefetcher enables to fit in code region when watcher is enabled
+    uint32_t num_threads_ = 1;              // Quasar only; >1 for shared cq_dispatch_subordinate
 
     std::vector<FDKernel*> upstream_kernels_;
     std::vector<FDKernel*> downstream_kernels_;

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -278,7 +278,8 @@ void PrefetchKernel::GenerateDependentConfigs() {
                 found_dispatch_s = true;
 
                 dependent_config_.downstream_s_logical_core = dispatch_s_kernel->GetLogicalCore();
-                dependent_config_.downstream_dispatch_s_cb_sem_id = dispatch_s_kernel->GetMyDispatchCbSemId(cq_id_);
+                dependent_config_.downstream_dispatch_s_cb_sem_id =
+                    dispatch_s_kernel->GetChannelConfig(cq_id_).my_dispatch_cb_sem_id;
             } else {
                 TT_FATAL(false, "Unrecognized downstream kernel.");
             }
@@ -371,7 +372,8 @@ void PrefetchKernel::GenerateDependentConfigs() {
                 found_dispatch_s = true;
 
                 dependent_config_.downstream_s_logical_core = dispatch_s_kernel->GetLogicalCore();
-                dependent_config_.downstream_dispatch_s_cb_sem_id = dispatch_s_kernel->GetMyDispatchCbSemId(cq_id_);
+                dependent_config_.downstream_dispatch_s_cb_sem_id =
+                    dispatch_s_kernel->GetChannelConfig(cq_id_).my_dispatch_cb_sem_id;
             } else if (auto* relay_mux = dynamic_cast<tt::tt_metal::RelayMux*>(k)) {
                 TT_ASSERT(!found_relay_mux, "PREFETCH_D kernel has multiple downstream RELAY_MUX kernels.");
                 found_relay_mux = true;

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -145,21 +145,9 @@ void PrefetchKernel::GenerateStaticConfigs() {
         dependent_config_.upstream_cb_sem_id = 0;
         static_config_.cmddat_q_log_page_size = DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
 
-        uint32_t dispatch_s_buffer_base = 0xff;
-        if (get_dispatch_query_manager_ref().dispatch_s_enabled()) {
-            uint32_t dispatch_buffer_base = my_dispatch_constants.dispatch_buffer_base(cq_id_);
-            if (GetCoreType() == CoreType::WORKER || GetCoreType() == CoreType::DISPATCH) {
-                // dispatch_s (and on Quasar, prefetch itself) shares a core with dispatch_d
-                // (Tensix WORKER or Quasar DE). Place dispatch_s CB immediately after dispatch_d's CB.
-                dispatch_s_buffer_base =
-                    dispatch_buffer_base + (1 << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE) *
-                                               my_dispatch_constants.dispatch_buffer_pages();
-            } else {
-                // dispatch_d and dispatch_s are on different cores. No shared resources: dispatch_s CB starts at base.
-                dispatch_s_buffer_base = dispatch_buffer_base;
-            }
-        }
-        static_config_.dispatch_s_buffer_base = dispatch_s_buffer_base;
+        static_config_.dispatch_s_buffer_base = get_dispatch_query_manager_ref().dispatch_s_enabled()
+                                                    ? my_dispatch_constants.dispatch_s_buffer_base(cq_id_)
+                                                    : 0xff;
         static_config_.my_dispatch_s_cb_sem_id = tt::tt_metal::CreateSemaphore(
             *program_, logical_core_, my_dispatch_constants.dispatch_s_buffer_pages(), GetCoreType());
         static_config_.dispatch_s_buffer_size = my_dispatch_constants.dispatch_s_buffer_size();
@@ -239,21 +227,8 @@ void PrefetchKernel::GenerateStaticConfigs() {
             tt::tt_metal::CreateSemaphore(*program_, logical_core_, 0, GetCoreType());
         static_config_.cmddat_q_log_page_size = DispatchSettings::PREFETCH_D_BUFFER_LOG_PAGE_SIZE;
 
-        uint32_t dispatch_s_buffer_base = 0xff;
-        {  // Just to make it match previous implementation
-            uint32_t dispatch_buffer_base = my_dispatch_constants.dispatch_buffer_base(cq_id_);
-            if (GetCoreType() == CoreType::WORKER || GetCoreType() == CoreType::DISPATCH) {
-                // dispatch_s (and on Quasar, prefetch itself) shares a core with dispatch_d
-                // (Tensix WORKER or Quasar DE). Place dispatch_s CB immediately after dispatch_d's CB.
-                dispatch_s_buffer_base =
-                    dispatch_buffer_base + (1 << DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE) *
-                                               my_dispatch_constants.dispatch_buffer_pages();
-            } else {
-                // dispatch_d and dispatch_s are on different cores. No shared resources: dispatch_s CB starts at base.
-                dispatch_s_buffer_base = dispatch_buffer_base;
-            }
-        }
-        static_config_.dispatch_s_buffer_base = dispatch_s_buffer_base;
+        // Unlike the PREFETCH_HD case above, this is set unconditionally, even when dispatch_s is disabled.
+        static_config_.dispatch_s_buffer_base = my_dispatch_constants.dispatch_s_buffer_base(cq_id_);
         static_config_.my_dispatch_s_cb_sem_id = tt::tt_metal::CreateSemaphore(
             *program_, logical_core_, my_dispatch_constants.dispatch_s_buffer_pages(), GetCoreType());
         static_config_.dispatch_s_buffer_size = my_dispatch_constants.dispatch_s_buffer_size();

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -303,8 +303,7 @@ void PrefetchKernel::GenerateDependentConfigs() {
                 found_dispatch_s = true;
 
                 dependent_config_.downstream_s_logical_core = dispatch_s_kernel->GetLogicalCore();
-                dependent_config_.downstream_dispatch_s_cb_sem_id =
-                    dispatch_s_kernel->GetStaticConfig().my_dispatch_cb_sem_id;
+                dependent_config_.downstream_dispatch_s_cb_sem_id = dispatch_s_kernel->GetMyDispatchCbSemId(cq_id_);
             } else {
                 TT_FATAL(false, "Unrecognized downstream kernel.");
             }
@@ -397,8 +396,7 @@ void PrefetchKernel::GenerateDependentConfigs() {
                 found_dispatch_s = true;
 
                 dependent_config_.downstream_s_logical_core = dispatch_s_kernel->GetLogicalCore();
-                dependent_config_.downstream_dispatch_s_cb_sem_id =
-                    dispatch_s_kernel->GetStaticConfig().my_dispatch_cb_sem_id;
+                dependent_config_.downstream_dispatch_s_cb_sem_id = dispatch_s_kernel->GetMyDispatchCbSemId(cq_id_);
             } else if (auto* relay_mux = dynamic_cast<tt::tt_metal::RelayMux*>(k)) {
                 TT_ASSERT(!found_relay_mux, "PREFETCH_D kernel has multiple downstream RELAY_MUX kernels.");
                 found_relay_mux = true;

--- a/tt_metal/impl/dispatch/kernel_config/relay_mux.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/relay_mux.cpp
@@ -127,7 +127,8 @@ void RelayMux::GenerateStaticConfigs() {
 void RelayMux::GenerateDependentConfigs() {}
 
 void RelayMux::CreateKernel() {
-    auto mux_kernel = configure_kernel_variant(dispatch_kernel_file_names[FABRIC_MUX], mux_ct_args_, {});
+    auto mux_kernel =
+        configure_kernel_variant(dispatch_kernel_file_names[FABRIC_MUX], mux_ct_args_, {}, KernelBuildOptLevel::Os);
 
     tt::tt_metal::SetRuntimeArgs(*program_, mux_kernel, logical_core_, mux_rt_args_);
 }

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -293,8 +293,7 @@ FORCE_INLINE void cq_noc_inline_dw_write_init_state(
 #endif
 }
 
-template <uint32_t sem_id>
-FORCE_INLINE void cb_wait_all_pages(uint32_t n) {
+FORCE_INLINE void cb_wait_all_pages(uint32_t n, uint32_t sem_id) {
     volatile tt_l1_ptr uint32_t* sem_addr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_uncached_addr(get_semaphore<programmable_core_type>(sem_id)));
 
@@ -731,13 +730,12 @@ FORCE_INLINE uint32_t set_sub_device_worker_counts(
     uintptr_t cmd_ptr,
     std::array<uint32_t, max_num_worker_sems>& workers_per_sub_device,
     volatile tt_l1_ptr uint32_t* sub_device_worker_counts_update,
-    uintptr_t dispatch_telemetry_base) {
+    uintptr_t dispatch_telemetry_base,
+    uint32_t& local_sub_device_worker_counts_update) {
     volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(cmd_ptr);
     uint32_t num_sub_devices = cmd->set_sub_device_worker_counts.num_sub_devices;
     ASSERT(num_sub_devices <= max_num_worker_sems);
     volatile tt_l1_ptr uint32_t* data_ptr = uncached_l1_ptr<uint32_t>(cmd_ptr + sizeof(CQDispatchCmd));
-
-    static uint32_t local_sub_device_worker_counts_update = 0;
 
     for (uint32_t i = 0; i < num_sub_devices; ++i) {
         uint32_t worker_count = *(data_ptr++);

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -105,6 +105,7 @@ constexpr uint32_t is_h_variant = IS_H_VARIANT;
 
 // The dispatch message entry limit also bounds the number of sub-devices.
 static std::array<uint32_t, max_num_worker_sems> workers_per_sub_device = {0};
+static uint32_t local_sub_device_worker_counts_update = 0;
 
 // Read and store telemetry values via local variables to avoid L1 reads
 static uint32_t upstream_blocked_counter = 0;
@@ -1414,7 +1415,8 @@ re_run_command:
                 l1_uncached_addr(cmd_ptr),
                 workers_per_sub_device,
                 &dispatch_telemetry_control->sub_device_worker_counts_update,
-                dispatch_telemetry_base);
+                dispatch_telemetry_base,
+                local_sub_device_worker_counts_update);
             break;
 
         case CQ_DISPATCH_SET_GO_SIGNAL_NOC_DATA: set_go_signal_noc_data(); break;

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -637,6 +637,7 @@ void merge_dispatch_d_noc_counter_deltas() {
 void kernel_main() {
     set_l1_data_cache<true>();
     channel_state.channel_index = get_my_thread_id();
+    DPRINT("dispatch_s : start\n");
     ASSERT(get_num_threads() == NUM_DISPATCH_S_CHANNELS);
     ASSERT(channel_state.channel_index < NUM_DISPATCH_S_CHANNELS);
     const uint32_t hart = internal_::get_hw_thread_idx();
@@ -647,7 +648,6 @@ void kernel_main() {
     channel_state.dispatch_telemetry_control =
         reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchTelemetryControl*>(
             channel_state.config->dispatch_telemetry_control_addr);
-    DPRINT("dispatch_s : start\n");
     // Initialize customized command buffers.
     dispatch_s_wr_reg_cmd_buf_init();
     dispatch_s_atomic_cmd_buf_init();

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -23,6 +23,7 @@
 #include "hostdevcommon/dispatch_telemetry_types.hpp"
 #include "hostdev/dev_msgs.h"
 #include "risc_common.h"
+#include "api/kernel_thread_globals.h"
 
 #include <array>
 
@@ -34,30 +35,19 @@
 // Reads cannot be issued by dispatch_s.
 constexpr uint32_t DISPATCH_S_WR_REG_CMD_BUF = 1;
 constexpr uint32_t DISPATCH_S_ATOMIC_CMD_BUF = 2;
-constexpr uintptr_t cb_base = CB_BASE;
 constexpr uint32_t cb_log_page_size = CB_LOG_PAGE_SIZE;
 constexpr uint32_t cb_size = CB_SIZE;
-constexpr uint32_t my_dispatch_cb_sem_id = MY_DISPATCH_CB_SEM_ID;
-constexpr uint32_t upstream_dispatch_cb_sem_id = UPSTREAM_DISPATCH_CB_SEM_ID;
-constexpr uint32_t dispatch_d_shutdown_sem_id = DISPATCH_D_SHUTDOWN_SEM_ID;
-constexpr uintptr_t dispatch_s_sync_sem_base_addr = DISPATCH_S_SYNC_SEM_BASE_ADDR;
 constexpr uint32_t mcast_go_signal_addr = MCAST_GO_SIGNAL_ADDR;
 constexpr uint32_t unicast_go_signal_addr = UNICAST_GO_SIGNAL_ADDR;
 constexpr uint32_t distributed_dispatcher =
     DISTRIBUTED_DISPATCHER;  // dispatch_s and dispatch_d running on different cores
 constexpr uint32_t first_stream_used = FIRST_STREAM_USED;
-constexpr uint32_t completion_counter_offset = COMPLETION_COUNTER_OFFSET;
 constexpr uint32_t max_num_worker_sems = MAX_NUM_WORKER_SEMS;
 constexpr uint32_t max_num_go_signal_noc_data_entries = MAX_NUM_GO_SIGNAL_NOC_DATA_ENTRIES;
-constexpr uintptr_t dispatch_telemetry_control_addr = DISPATCH_TELEMETRY_CONTROL_ADDR;
 constexpr bool telemetry_enabled = !DISPATCH_TELEMETRY_DISABLED;
-constexpr uintptr_t dispatch_telemetry_base = DISPATCH_TELEMETRY_ADDR;
 constexpr uint32_t virtualize_unicast_cores = VIRTUALIZE_UNICAST_CORES;
 constexpr uint32_t num_virtual_unicast_cores = NUM_VIRTUAL_UNICAST_CORES;
 constexpr uint32_t num_physical_unicast_cores = NUM_PHYSICAL_UNICAST_CORES;
-volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchTelemetryControl* dispatch_telemetry_control =
-    reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchTelemetryControl*>(
-        dispatch_telemetry_control_addr);
 
 constexpr uint32_t worker_mcast_grid = WORKER_MCAST_GRID;
 constexpr uint32_t num_worker_cores_to_mcast = NUM_WORKER_CORES_TO_MCAST;
@@ -132,47 +122,121 @@ void device_print_dispatcher_execute_hook() {
 }
 #endif
 
-constexpr uint32_t upstream_noc_xy = uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X, UPSTREAM_NOC_Y));
-constexpr uint32_t dispatch_d_noc_xy = uint32_t(NOC_XY_ENCODING(DOWNSTREAM_NOC_X, DOWNSTREAM_NOC_Y));
 constexpr uint32_t my_noc_xy = uint32_t(NOC_XY_ENCODING(MY_NOC_X, MY_NOC_Y));
 constexpr uint8_t my_noc_index = NOC_INDEX;
 
 constexpr uint32_t cb_page_size = 1 << cb_log_page_size;
-constexpr uintptr_t cb_end = cb_base + cb_size;
 
-// Dispatch-core-local L1 region assigned by DispatchMemMap via
-// CommandQueueDeviceAddrType::REALTIME_PROFILER_MSG. Address comes from host through the
-// REALTIME_PROFILER_MSG_ADDR compile-time define. See cq_dispatch.cpp for the full mailbox
-// description; this kernel is the consumer side of the embedded program_id_fifo.
-volatile tt_l1_ptr realtime_profiler_msg_t* rt_profiler_msg =
-    reinterpret_cast<volatile tt_l1_ptr realtime_profiler_msg_t*>(REALTIME_PROFILER_MSG_ADDR);
+#ifndef NUM_DISPATCH_S_CHANNELS
+#define NUM_DISPATCH_S_CHANNELS 1
+#endif
+#if NUM_DISPATCH_S_CHANNELS == 2 && !defined(ARCH_QUASAR)
+#error "Two-channel DISPATCH_S is only supported on Quasar"
+#endif
 
-static bool rt_profiler_enabled = false;
+struct ChannelConfig {
+    uintptr_t cb_base;
+    uint32_t my_dispatch_cb_sem_id;
+    uint32_t upstream_dispatch_cb_sem_id;
+    uint32_t dispatch_d_shutdown_sem_id;
+    uintptr_t dispatch_s_sync_sem_base_addr;
+    uint32_t completion_counter_offset;
+    uintptr_t realtime_profiler_msg_addr;
+    uintptr_t dispatch_telemetry_addr;
+    uintptr_t dispatch_telemetry_control_addr;
+    uint32_t upstream_noc_xy;
+    uint32_t dispatch_d_noc_xy;
+};
 
-static uint32_t num_pages_acquired = 0;
-static uint32_t num_mcasts_sent[max_num_worker_sems] = {0};
-static uintptr_t cmd_ptr;
+#if NUM_DISPATCH_S_CHANNELS == 1
+constexpr ChannelConfig kChannelConfigs[] = {{
+    CB_BASE,
+    MY_DISPATCH_CB_SEM_ID,
+    UPSTREAM_DISPATCH_CB_SEM_ID,
+    DISPATCH_D_SHUTDOWN_SEM_ID,
+    DISPATCH_S_SYNC_SEM_BASE_ADDR,
+    COMPLETION_COUNTER_OFFSET,
+    REALTIME_PROFILER_MSG_ADDR,
+    DISPATCH_TELEMETRY_ADDR,
+    DISPATCH_TELEMETRY_CONTROL_ADDR,
+    uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X, UPSTREAM_NOC_Y)),
+    uint32_t(NOC_XY_ENCODING(DOWNSTREAM_NOC_X, DOWNSTREAM_NOC_Y)),
+}};
+#elif NUM_DISPATCH_S_CHANNELS == 2
+constexpr ChannelConfig kChannelConfigs[] = {
+    {
+        CB_BASE_0,
+        MY_DISPATCH_CB_SEM_ID_0,
+        UPSTREAM_DISPATCH_CB_SEM_ID_0,
+        DISPATCH_D_SHUTDOWN_SEM_ID_0,
+        DISPATCH_S_SYNC_SEM_BASE_ADDR_0,
+        COMPLETION_COUNTER_OFFSET_0,
+        REALTIME_PROFILER_MSG_ADDR_0,
+        DISPATCH_TELEMETRY_ADDR_0,
+        DISPATCH_TELEMETRY_CONTROL_ADDR_0,
+        uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X_0, UPSTREAM_NOC_Y_0)),
+        uint32_t(NOC_XY_ENCODING(DOWNSTREAM_NOC_X_0, DOWNSTREAM_NOC_Y_0)),
+    },
+    {
+        CB_BASE_1,
+        MY_DISPATCH_CB_SEM_ID_1,
+        UPSTREAM_DISPATCH_CB_SEM_ID_1,
+        DISPATCH_D_SHUTDOWN_SEM_ID_1,
+        DISPATCH_S_SYNC_SEM_BASE_ADDR_1,
+        COMPLETION_COUNTER_OFFSET_1,
+        REALTIME_PROFILER_MSG_ADDR_1,
+        DISPATCH_TELEMETRY_ADDR_1,
+        DISPATCH_TELEMETRY_CONTROL_ADDR_1,
+        uint32_t(NOC_XY_ENCODING(UPSTREAM_NOC_X_1, UPSTREAM_NOC_Y_1)),
+        uint32_t(NOC_XY_ENCODING(DOWNSTREAM_NOC_X_1, DOWNSTREAM_NOC_Y_1)),
+    },
+};
+#else
+#error "DISPATCH_S supports only one or two channels"
+#endif
+
+struct ChannelState {
+    const ChannelConfig* config = nullptr;
+    uint32_t channel_index = 0;
+    uintptr_t cmd_ptr = 0;
+    uint32_t num_pages_acquired = 0;
+    uint32_t num_mcasts_sent[max_num_worker_sems] = {};
+    uint32_t worker_count_update_for_dispatch_d[max_num_worker_sems] = {};
+    uint32_t go_signal_noc_data[max_num_go_signal_noc_data_entries] = {};
+    uint32_t num_worker_sems = 1;
+    std::array<uint32_t, max_num_worker_sems> workers_per_sub_device = {};
+    bool rt_profiler_enabled = false;
+    uint32_t local_launch_seq_counter = 0;
+    uint32_t local_sub_device_worker_counts_update = 0;
+    volatile tt_l1_ptr realtime_profiler_msg_t* rt_profiler_msg = nullptr;
+    volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchTelemetryControl* dispatch_telemetry_control =
+        nullptr;
+};
+
+struct TriageChannelState {
+    volatile uint32_t dm_index;
+    volatile uint32_t cmd_ptr;
+    volatile uint32_t last_wait_count;
+    volatile uint32_t last_wait_stream;
+};
 
 extern "C" {
 // These variables are used by triage to help report dispatcher state.
-volatile uint32_t last_wait_count = 0;
-volatile uint32_t last_wait_stream = 0;
+volatile TriageChannelState dispatch_s_triage_state[NUM_DISPATCH_S_CHANNELS] = {};
 constexpr uint32_t stream_addr0 = STREAM_REG_ADDR(0, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
 constexpr uint32_t stream_addr1 = STREAM_REG_ADDR(1, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
 constexpr uint32_t stream_width = MEM_WORD_ADDR_WIDTH;
 }
 
-// When dispatch_d and dispatch_s run on separate cores, dispatch_s gets the go signal update from workers.
-// dispatch_s is responsible for sending the latest worker completion count to dispatch_d.
-// To minimize the number of writes from dispatch_s to dispatch_d, locally track dispatch_d's copy.
-static uint32_t worker_count_update_for_dispatch_d[max_num_worker_sems] = {0};
+#if NUM_DISPATCH_S_CHANNELS == 2
+thread_local ChannelState channel_state;
+#else
+static ChannelState channel_state;
+#endif
 
-static uint32_t go_signal_noc_data[max_num_go_signal_noc_data_entries];
-
-static uint32_t num_worker_sems = 1;
-
-// The dispatch message entry limit also bounds the number of sub-devices.
-static std::array<uint32_t, max_num_worker_sems> workers_per_sub_device = {0};
+FORCE_INLINE void update_triage_cmd_ptr() {
+    dispatch_s_triage_state[channel_state.channel_index].cmd_ptr = static_cast<uint32_t>(channel_state.cmd_ptr);
+}
 
 FORCE_INLINE
 void dispatch_s_wr_reg_cmd_buf_init() {
@@ -254,11 +318,11 @@ uint32_t stream_wrap_gt(uint32_t a, uint32_t b) {
 FORCE_INLINE
 void wait_for_workers(uint32_t wait_count, uint32_t wait_stream) {
     WAYPOINT("WCW");
-    last_wait_count = wait_count;
-    last_wait_stream = wait_stream;
+    dispatch_s_triage_state[channel_state.channel_index].last_wait_count = wait_count;
+    dispatch_s_triage_state[channel_state.channel_index].last_wait_stream = wait_stream;
 #ifdef ARCH_QUASAR
     volatile uint32_t* worker_sem =
-        worker_completion_sem_addr(wait_stream, first_stream_used, completion_counter_offset);
+        worker_completion_sem_addr(wait_stream, first_stream_used, channel_state.config->completion_counter_offset);
 #else
     volatile uint32_t* worker_sem = reinterpret_cast<volatile uint32_t*>(
         static_cast<uintptr_t>(STREAM_REG_ADDR(wait_stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX)));
@@ -269,8 +333,8 @@ void wait_for_workers(uint32_t wait_count, uint32_t wait_stream) {
 #else
     while (stream_wrap_gt(wait_count, *worker_sem)) {
 #endif
-        if (rt_profiler_enabled) {
-            record_realtime_timestamp(rt_profiler_msg, false);
+        if (channel_state.rt_profiler_enabled) {
+            record_realtime_timestamp(channel_state.rt_profiler_msg, false);
         }
 #if DEVICE_PRINT_DISPATCH_ENABLED
         device_print_dispatcher.execute();
@@ -284,15 +348,16 @@ template <bool flush_write = false>
 FORCE_INLINE void update_worker_completion_count_on_dispatch_d() {
     if constexpr (distributed_dispatcher) {
         bool write = false;
-        for (uint32_t i = 0; i < num_worker_sems; i++) {
+        for (uint32_t i = 0; i < channel_state.num_worker_sems; i++) {
             uint32_t num_workers_signalling_completion =
                 NOC_STREAM_READ_REG(i + first_stream_used, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX);
-            if (num_workers_signalling_completion != worker_count_update_for_dispatch_d[i]) {
-                worker_count_update_for_dispatch_d[i] = num_workers_signalling_completion;
+            if (num_workers_signalling_completion != channel_state.worker_count_update_for_dispatch_d[i]) {
+                channel_state.worker_count_update_for_dispatch_d[i] = num_workers_signalling_completion;
                 // Writing to STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX sets
                 // STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX (rather than incrementing it).
                 uint64_t dispatch_d_dst = get_noc_addr_helper(
-                    dispatch_d_noc_xy, STREAM_REG_ADDR(i + first_stream_used, STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX));
+                    channel_state.config->dispatch_d_noc_xy,
+                    STREAM_REG_ADDR(i + first_stream_used, STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX));
                 dispatch_s_noc_inline_dw_write(dispatch_d_dst, num_workers_signalling_completion, my_noc_index);
                 write = true;
             }
@@ -305,15 +370,14 @@ FORCE_INLINE void update_worker_completion_count_on_dispatch_d() {
     }
 }
 
-template <uint32_t noc_xy, uint32_t sem_id>
-FORCE_INLINE void cb_acquire_pages_dispatch_s(uint32_t n) {
+FORCE_INLINE void cb_acquire_pages_dispatch_s(uint32_t n, uint32_t sem_id) {
     volatile tt_l1_ptr uint32_t* sem_addr = uncached_l1_ptr<uint32_t>(get_semaphore<programmable_core_type>(sem_id));
 
     WAYPOINT("DAPW");
     uint32_t heartbeat = 0;
     // Stall until the number of pages already acquired + the number that need to be acquired is greater
     // than the number available
-    while (wrap_gt(num_pages_acquired + n, *sem_addr)) {
+    while (wrap_gt(channel_state.num_pages_acquired + n, *sem_addr)) {
         invalidate_l1_cache();
         update_worker_completion_count_on_dispatch_d();
 #if DEVICE_PRINT_DISPATCH_ENABLED
@@ -322,11 +386,10 @@ FORCE_INLINE void cb_acquire_pages_dispatch_s(uint32_t n) {
         IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
     }
     WAYPOINT("DAPD");
-    num_pages_acquired += n;
+    channel_state.num_pages_acquired += n;
 }
 
-template <uint32_t noc_xy, uint32_t sem_id>
-FORCE_INLINE void cb_release_pages_dispatch_s(uint32_t n) {
+FORCE_INLINE void cb_release_pages_dispatch_s(uint32_t n, uint32_t noc_xy, uint32_t sem_id) {
 #ifdef ARCH_QUASAR
     Semaphore<programmable_core_type>(sem_id).up(n);
 #else
@@ -336,16 +399,16 @@ FORCE_INLINE void cb_release_pages_dispatch_s(uint32_t n) {
 
 FORCE_INLINE
 void process_go_signal_mcast_cmd() {
-    volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(cmd_ptr);
+    volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(channel_state.cmd_ptr);
     uint32_t sync_index = cmd->mcast.wait_stream - first_stream_used;
     // Get semaphore that will be update by dispatch_d, signalling that it's safe to send a go signal
 
     volatile tt_l1_ptr uint32_t* sync_sem_addr =
-        uncached_l1_ptr<uint32_t>(dispatch_s_sync_sem_base_addr + sync_index * L1_ALIGNMENT);
+        uncached_l1_ptr<uint32_t>(channel_state.config->dispatch_s_sync_sem_base_addr + sync_index * L1_ALIGNMENT);
 
     WAYPOINT("DCW");
     // Wait for notification from dispatch_d, signalling that it's safe to send the go signal
-    uint32_t& mcasts_sent = num_mcasts_sent[sync_index];
+    uint32_t& mcasts_sent = channel_state.num_mcasts_sent[sync_index];
     while (wrap_ge(mcasts_sent, *sync_sem_addr)) {
         invalidate_l1_cache();
         // Update dispatch_d with the latest num_workers
@@ -357,16 +420,15 @@ void process_go_signal_mcast_cmd() {
     mcasts_sent++;  // Go signal sent -> update counter
 
     // The location of the go signal embedded in the command does not meet NOC alignment requirements.
-    // cmd_ptr is guaranteed to meet the alignment requirements, since it is written to by prefetcher over NOC.
-    // Copy the go signal from an unaligned location to an aligned (cmd_ptr) location. This is safe as long as we
-    // can guarantee that copying the go signal does not corrupt any other command fields, which is true (see
-    // CQDispatchGoSignalMcastCmd).
+    // channel_state.cmd_ptr is guaranteed to meet the alignment requirements, since it is written to by prefetcher
+    // over NOC. Copy the go signal from an unaligned location to an aligned location. This is safe as long as copying
+    // the go signal does not corrupt any other command fields, which is true (see CQDispatchGoSignalMcastCmd).
     // NOC source addresses must be raw L1 byte offsets (cached-alias form), so keep
     // aligned_go_signal_storage at the cached alias for the NOC sources below.
     // CPU writes go through a separate uncached pointer so the value lands in L1 SRAM directly;
     // the NOC then reads the same physical location via the cached-form source address.
-    volatile uint32_t tt_l1_ptr* aligned_go_signal_storage = (volatile uint32_t tt_l1_ptr*)cmd_ptr;
-    volatile uint32_t tt_l1_ptr* aligned_go_signal_storage_uncached = uncached_l1_ptr<uint32_t>(cmd_ptr);
+    volatile uint32_t tt_l1_ptr* aligned_go_signal_storage = (volatile uint32_t tt_l1_ptr*)channel_state.cmd_ptr;
+    volatile uint32_t tt_l1_ptr* aligned_go_signal_storage_uncached = uncached_l1_ptr<uint32_t>(channel_state.cmd_ptr);
     uint32_t go_signal_value = cmd->mcast.go_signal;
     uint8_t go_signal_noc_data_idx = cmd->mcast.noc_data_start_index;
     uint32_t multicast_go_offset = cmd->mcast.multicast_go_offset;
@@ -427,7 +489,8 @@ void process_go_signal_mcast_cmd() {
             // greater than the number of cores actually on the chip, we must account for acks
             // from non-existent cores here.
 #ifdef ARCH_QUASAR
-            *worker_completion_sem_addr(first_stream_used, first_stream_used, completion_counter_offset) +=
+            *worker_completion_sem_addr(
+                first_stream_used, first_stream_used, channel_state.config->completion_counter_offset) +=
                 (num_virtual_unicast_cores - num_physical_unicast_cores);
 #else
             NOC_STREAM_WRITE_REG(
@@ -439,23 +502,25 @@ void process_go_signal_mcast_cmd() {
     }
 
     for (uint32_t i = 0; i < num_unicasts; ++i) {
-        uint64_t dst = get_noc_addr_helper(go_signal_noc_data[go_signal_noc_data_idx++], unicast_go_signal_addr);
+        uint64_t dst =
+            get_noc_addr_helper(channel_state.go_signal_noc_data[go_signal_noc_data_idx++], unicast_go_signal_addr);
         noc_async_write_one_packet(
             static_cast<uint32_t>(reinterpret_cast<uintptr_t>(aligned_go_signal_storage)), dst, sizeof(uint32_t));
     }
 
     if (telemetry_enabled) {
-        static uint32_t local_launch_seq_counter = 0;
         const uint32_t stream_index = wait_stream - first_stream_used;
         ASSERT(stream_index < max_num_worker_sems);
         auto dispatch_telemetry =
             reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchCoreTelemetry*>(
-                dispatch_telemetry_base);
+                channel_state.config->dispatch_telemetry_addr);
 
-        dispatch_telemetry_control->launched_work_sequence_counter[stream_index] = ++local_launch_seq_counter;
+        channel_state.dispatch_telemetry_control->launched_work_sequence_counter[stream_index] =
+            ++channel_state.local_launch_seq_counter;
         dispatch_telemetry->last_work_launch_timestamp[stream_index] = get_timestamp();
-        dispatch_telemetry_control->launched_work_start_stream_sem[stream_index] = wait_count;
-        dispatch_telemetry_control->launched_work_sequence_counter[stream_index] = ++local_launch_seq_counter;
+        channel_state.dispatch_telemetry_control->launched_work_start_stream_sem[stream_index] = wait_count;
+        channel_state.dispatch_telemetry_control->launched_work_sequence_counter[stream_index] =
+            ++channel_state.local_launch_seq_counter;
     }
 
 #if DEVICE_PRINT_DISPATCH_ENABLED
@@ -466,12 +531,13 @@ void process_go_signal_mcast_cmd() {
 #endif
 
     update_worker_completion_count_on_dispatch_d();
-    cmd_ptr += sizeof(CQDispatchCmd);
+    channel_state.cmd_ptr += sizeof(CQDispatchCmd);
+    update_triage_cmd_ptr();
 }
 
 FORCE_INLINE
 void process_dispatch_s_wait_cmd() {
-    volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(cmd_ptr);
+    volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(channel_state.cmd_ptr);
     // Limited Usage of Wait CMD: dispatch_s should get a wait command only if it's not on the
     // same core as dispatch_d and is used to clear the worker count
     ASSERT(
@@ -494,29 +560,32 @@ void process_dispatch_s_wait_cmd() {
     update_worker_completion_count_on_dispatch_d<true>();
     // Reset SPACE_AVAILABLE to 0.
     NOC_STREAM_WRITE_REG(stream, STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX, 0);
-    worker_count_update_for_dispatch_d[index] =
+    channel_state.worker_count_update_for_dispatch_d[index] =
         0;  // Local worker count update for dispatch_d should reflect state of worker semaphore on dispatch_s
-    cmd_ptr += sizeof(CQDispatchCmd);
+    channel_state.cmd_ptr += sizeof(CQDispatchCmd);
+    update_triage_cmd_ptr();
 }
 
 FORCE_INLINE
 void set_num_worker_sems() {
-    volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(cmd_ptr);
-    num_worker_sems = cmd->set_num_worker_sems.num_worker_sems;
-    ASSERT(num_worker_sems <= max_num_worker_sems);
-    cmd_ptr += sizeof(CQDispatchCmd);
+    volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(channel_state.cmd_ptr);
+    channel_state.num_worker_sems = cmd->set_num_worker_sems.num_worker_sems;
+    ASSERT(channel_state.num_worker_sems <= max_num_worker_sems);
+    channel_state.cmd_ptr += sizeof(CQDispatchCmd);
+    update_triage_cmd_ptr();
 }
 
 FORCE_INLINE
 void set_go_signal_noc_data() {
-    volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(cmd_ptr);
+    volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(channel_state.cmd_ptr);
     uint32_t num_words = cmd->set_go_signal_noc_data.num_words;
     ASSERT(num_words <= max_num_go_signal_noc_data_entries);
-    volatile tt_l1_ptr uint32_t* data_ptr = uncached_l1_ptr<uint32_t>(cmd_ptr + sizeof(CQDispatchCmd));
+    volatile tt_l1_ptr uint32_t* data_ptr = uncached_l1_ptr<uint32_t>(channel_state.cmd_ptr + sizeof(CQDispatchCmd));
     for (uint32_t i = 0; i < num_words; ++i) {
-        go_signal_noc_data[i] = *(data_ptr++);
+        channel_state.go_signal_noc_data[i] = *(data_ptr++);
     }
-    cmd_ptr = round_up_pow2(l1_cached_addr(reinterpret_cast<uintptr_t>(data_ptr)), L1_ALIGNMENT);
+    channel_state.cmd_ptr = round_up_pow2(l1_cached_addr(reinterpret_cast<uintptr_t>(data_ptr)), L1_ALIGNMENT);
+    update_triage_cmd_ptr();
 }
 
 // When dispatch_d runs on the same core, it issues transactions on dispatch_s's dedicated NOC
@@ -532,8 +601,8 @@ void merge_dispatch_d_noc_counter_deltas() {
 
     constexpr auto dispatch_d_proc_type = static_cast<decltype(proc_type)>(TensixProcessorTypes::DM0);
 
-    volatile tt_l1_ptr uint32_t* shutdown_sem_addr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<programmable_core_type>(dispatch_d_shutdown_sem_id));
+    volatile tt_l1_ptr uint32_t* shutdown_sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+        get_semaphore<programmable_core_type>(channel_state.config->dispatch_d_shutdown_sem_id));
     noc_semaphore_wait(shutdown_sem_addr, 1);
 
     invalidate_l1_cache();
@@ -567,6 +636,17 @@ void merge_dispatch_d_noc_counter_deltas() {
 
 void kernel_main() {
     set_l1_data_cache<true>();
+    channel_state.channel_index = get_my_thread_id();
+    ASSERT(get_num_threads() == NUM_DISPATCH_S_CHANNELS);
+    ASSERT(channel_state.channel_index < NUM_DISPATCH_S_CHANNELS);
+    const uint32_t hart = internal_::get_hw_thread_idx();
+    dispatch_s_triage_state[channel_state.channel_index].dm_index = hart;
+    channel_state.config = &kChannelConfigs[channel_state.channel_index];
+    channel_state.rt_profiler_msg =
+        reinterpret_cast<volatile tt_l1_ptr realtime_profiler_msg_t*>(channel_state.config->realtime_profiler_msg_addr);
+    channel_state.dispatch_telemetry_control =
+        reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchTelemetryControl*>(
+            channel_state.config->dispatch_telemetry_control_addr);
     DPRINT("dispatch_s : start\n");
     // Initialize customized command buffers.
     dispatch_s_wr_reg_cmd_buf_init();
@@ -586,7 +666,8 @@ void kernel_main() {
     // realtime_profiler_msg_t signalling + FIFO + kernel_* .id fields are zeroed on the host in
     // DispatchSKernel::ConfigureCore() before CQ kernels launch.
 
-    cmd_ptr = cb_base;
+    channel_state.cmd_ptr = channel_state.config->cb_base;
+    update_triage_cmd_ptr();
     bool done = false;
     uint32_t total_pages_acquired = 0;
 #if DEVICE_PRINT_DISPATCH_ENABLED
@@ -607,24 +688,27 @@ void kernel_main() {
 #endif
     while (!done) {
         DeviceZoneScopedN("CQ-DISPATCH-SUBORDINATE");
-        rt_profiler_enabled = (rt_profiler_msg->realtime_profiler_core_noc_xy != 0);
+        channel_state.rt_profiler_enabled = (channel_state.rt_profiler_msg->realtime_profiler_core_noc_xy != 0);
         uint32_t popped_pid = 0;
-        if (rt_profiler_enabled) {
-            record_realtime_timestamp(rt_profiler_msg, true);
-            popped_pid = pop_program_id(rt_profiler_msg);
+        if (channel_state.rt_profiler_enabled) {
+            record_realtime_timestamp(channel_state.rt_profiler_msg, true);
+            popped_pid = pop_program_id(channel_state.rt_profiler_msg);
         }
 #if DEVICE_PRINT_DISPATCH_ENABLED
         device_print_dispatcher.execute();
 #endif
-        cb_acquire_pages_dispatch_s<my_noc_xy, my_dispatch_cb_sem_id>(1);
+        cb_acquire_pages_dispatch_s(1, channel_state.config->my_dispatch_cb_sem_id);
 
-        volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(cmd_ptr);
+        volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(channel_state.cmd_ptr);
+        ASSERT(
+            channel_state.cmd_ptr >= channel_state.config->cb_base &&
+            channel_state.cmd_ptr < channel_state.config->cb_base + cb_size);
         DeviceTimestampedData("process_cmd_d_dispatch_subordinate", (uint32_t)cmd->base.cmd_id);
-        if (rt_profiler_enabled) {
+        if (channel_state.rt_profiler_enabled) {
             const bool is_profiled_cmd = cmd->base.cmd_id == CQ_DISPATCH_CMD_SEND_GO_SIGNAL ||
                                          cmd->base.cmd_id == CQ_DISPATCH_CMD_RT_PROFILER_FLUSH;
             write_buffer_id(
-                rt_profiler_msg,
+                channel_state.rt_profiler_msg,
                 is_profiled_cmd ? popped_pid : static_cast<uint32_t>(REALTIME_PROFILER_UNPROFILED_PROGRAM_HOST_ID));
         }
         switch (cmd->base.cmd_id) {
@@ -642,11 +726,13 @@ void kernel_main() {
                 break;
             case CQ_DISPATCH_SET_SUB_DEVICE_WORKER_COUNTS:
                 DPRINT("CQ_DISPATCH_SET_SUB_DEVICE_WORKER_COUNTS\n");
-                cmd_ptr += set_sub_device_worker_counts<telemetry_enabled>(
-                    cmd_ptr,
-                    workers_per_sub_device,
-                    &dispatch_telemetry_control->sub_device_worker_counts_update,
-                    dispatch_telemetry_base);
+                channel_state.cmd_ptr += set_sub_device_worker_counts<telemetry_enabled>(
+                    channel_state.cmd_ptr,
+                    channel_state.workers_per_sub_device,
+                    &channel_state.dispatch_telemetry_control->sub_device_worker_counts_update,
+                    channel_state.config->dispatch_telemetry_addr,
+                    channel_state.local_sub_device_worker_counts_update);
+                update_triage_cmd_ptr();
                 break;
             case CQ_DISPATCH_CMD_WAIT:
                 DPRINT("CQ_DISPATCH_CMD_WAIT\n");
@@ -655,49 +741,53 @@ void kernel_main() {
             case CQ_DISPATCH_CMD_RT_PROFILER_FLUSH:
                 DPRINT("CQ_DISPATCH_CMD_RT_PROFILER_FLUSH\n");
                 wait_for_workers(cmd->rt_profiler_flush.wait_count, cmd->rt_profiler_flush.wait_stream);
-                cmd_ptr += sizeof(CQDispatchCmd);
+                channel_state.cmd_ptr += sizeof(CQDispatchCmd);
+                update_triage_cmd_ptr();
                 break;
             case CQ_DISPATCH_CMD_TERMINATE:
                 DPRINT("CQ_DISPATCH_CMD_TERMINATE\n");
-                if (rt_profiler_enabled) {
-                    signal_realtime_profiler_and_switch(rt_profiler_msg);
+                if (channel_state.rt_profiler_enabled) {
+                    signal_realtime_profiler_and_switch(channel_state.rt_profiler_msg);
                     noc_async_writes_flushed();
                     for (volatile uint32_t delay = 0; delay < 5000; delay++) {
                     }
                 }
 
-                rt_profiler_msg->realtime_profiler_state = REALTIME_PROFILER_STATE_TERMINATE;
-                if (rt_profiler_enabled) {
+                channel_state.rt_profiler_msg->realtime_profiler_state = REALTIME_PROFILER_STATE_TERMINATE;
+                if (channel_state.rt_profiler_enabled) {
                     uint64_t realtime_profiler_terminate_addr = get_noc_addr_helper(
-                        rt_profiler_msg->realtime_profiler_core_noc_xy,
-                        rt_profiler_msg->realtime_profiler_remote_state_addr);
+                        channel_state.rt_profiler_msg->realtime_profiler_core_noc_xy,
+                        channel_state.rt_profiler_msg->realtime_profiler_remote_state_addr);
                     dispatch_s_noc_inline_dw_write(
                         realtime_profiler_terminate_addr, REALTIME_PROFILER_STATE_TERMINATE, my_noc_index);
                 }
                 if constexpr (telemetry_enabled) {
-                    dispatch_telemetry_control->compute_terminate = 1;
+                    channel_state.dispatch_telemetry_control->compute_terminate = 1;
                 }
                 done = true;
                 break;
             default: DPRINT("dispatcher_s invalid command\n"); ASSERT(0);
         }
         // Dispatch s only supports single page commands for now
-        ASSERT(cmd_ptr <= (l1_cached_addr(reinterpret_cast<uintptr_t>(cmd)) + cb_page_size));
-        cmd_ptr = round_up_pow2(cmd_ptr, cb_page_size);
+        ASSERT(channel_state.cmd_ptr <= (l1_cached_addr(reinterpret_cast<uintptr_t>(cmd)) + cb_page_size));
+        channel_state.cmd_ptr = round_up_pow2(channel_state.cmd_ptr, cb_page_size);
+        update_triage_cmd_ptr();
         // Release a single page to prefetcher. Assumption is that all dispatch_s commands fit inside a single page for
         // now.
-        cb_release_pages_dispatch_s<upstream_noc_xy, upstream_dispatch_cb_sem_id>(1);
-        if (cmd_ptr == cb_end) {
-            cmd_ptr = cb_base;
+        cb_release_pages_dispatch_s(
+            1, channel_state.config->upstream_noc_xy, channel_state.config->upstream_dispatch_cb_sem_id);
+        if (channel_state.cmd_ptr == channel_state.config->cb_base + cb_size) {
+            channel_state.cmd_ptr = channel_state.config->cb_base;
+            update_triage_cmd_ptr();
         }
         total_pages_acquired++;
 
-        if (!done && rt_profiler_enabled) {
-            signal_realtime_profiler_and_switch(rt_profiler_msg);
+        if (!done && channel_state.rt_profiler_enabled) {
+            signal_realtime_profiler_and_switch(channel_state.rt_profiler_msg);
         }
     }
     // Confirm expected number of pages, spinning here is a leak
-    cb_wait_all_pages<my_dispatch_cb_sem_id>(total_pages_acquired);
+    cb_wait_all_pages(total_pages_acquired, channel_state.config->my_dispatch_cb_sem_id);
 
 #ifndef ARCH_QUASAR
     if constexpr (!distributed_dispatcher) {

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch_subordinate.cpp
@@ -196,14 +196,13 @@ constexpr ChannelConfig kChannelConfigs[] = {
 #endif
 
 struct ChannelState {
-    const ChannelConfig* config = nullptr;
     uint32_t channel_index = 0;
     uintptr_t cmd_ptr = 0;
     uint32_t num_pages_acquired = 0;
     uint32_t num_mcasts_sent[max_num_worker_sems] = {};
     uint32_t worker_count_update_for_dispatch_d[max_num_worker_sems] = {};
     uint32_t go_signal_noc_data[max_num_go_signal_noc_data_entries] = {};
-    uint32_t num_worker_sems = 1;
+    uint32_t num_worker_sems = 0;
     std::array<uint32_t, max_num_worker_sems> workers_per_sub_device = {};
     bool rt_profiler_enabled = false;
     uint32_t local_launch_seq_counter = 0;
@@ -228,15 +227,23 @@ constexpr uint32_t stream_addr1 = STREAM_REG_ADDR(1, STREAM_REMOTE_DEST_BUF_SPAC
 constexpr uint32_t stream_width = MEM_WORD_ADDR_WIDTH;
 }
 
-#if NUM_DISPATCH_S_CHANNELS == 2
-thread_local ChannelState channel_state;
-#else
+#if NUM_DISPATCH_S_CHANNELS == 1
 static ChannelState channel_state;
+#else
+thread_local ChannelState channel_state;
 #endif
 
-FORCE_INLINE void update_triage_cmd_ptr() {
-    dispatch_s_triage_state[channel_state.channel_index].cmd_ptr = static_cast<uint32_t>(channel_state.cmd_ptr);
-}
+#if NUM_DISPATCH_S_CHANNELS == 1
+FORCE_INLINE constexpr uint32_t my_channel() { return 0; }
+#else
+FORCE_INLINE uint32_t my_channel() { return channel_state.channel_index; }
+#endif
+
+FORCE_INLINE const ChannelConfig& cfg() { return kChannelConfigs[my_channel()]; }
+
+FORCE_INLINE volatile TriageChannelState& my_triage_state() { return dispatch_s_triage_state[my_channel()]; }
+
+FORCE_INLINE void update_triage_cmd_ptr() { my_triage_state().cmd_ptr = static_cast<uint32_t>(channel_state.cmd_ptr); }
 
 FORCE_INLINE
 void dispatch_s_wr_reg_cmd_buf_init() {
@@ -318,11 +325,11 @@ uint32_t stream_wrap_gt(uint32_t a, uint32_t b) {
 FORCE_INLINE
 void wait_for_workers(uint32_t wait_count, uint32_t wait_stream) {
     WAYPOINT("WCW");
-    dispatch_s_triage_state[channel_state.channel_index].last_wait_count = wait_count;
-    dispatch_s_triage_state[channel_state.channel_index].last_wait_stream = wait_stream;
+    my_triage_state().last_wait_count = wait_count;
+    my_triage_state().last_wait_stream = wait_stream;
 #ifdef ARCH_QUASAR
     volatile uint32_t* worker_sem =
-        worker_completion_sem_addr(wait_stream, first_stream_used, channel_state.config->completion_counter_offset);
+        worker_completion_sem_addr(wait_stream, first_stream_used, cfg().completion_counter_offset);
 #else
     volatile uint32_t* worker_sem = reinterpret_cast<volatile uint32_t*>(
         static_cast<uintptr_t>(STREAM_REG_ADDR(wait_stream, STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX)));
@@ -356,7 +363,7 @@ FORCE_INLINE void update_worker_completion_count_on_dispatch_d() {
                 // Writing to STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX sets
                 // STREAM_REMOTE_DEST_BUF_SPACE_AVAILABLE_REG_INDEX (rather than incrementing it).
                 uint64_t dispatch_d_dst = get_noc_addr_helper(
-                    channel_state.config->dispatch_d_noc_xy,
+                    cfg().dispatch_d_noc_xy,
                     STREAM_REG_ADDR(i + first_stream_used, STREAM_REMOTE_DEST_BUF_SIZE_REG_INDEX));
                 dispatch_s_noc_inline_dw_write(dispatch_d_dst, num_workers_signalling_completion, my_noc_index);
                 write = true;
@@ -404,7 +411,7 @@ void process_go_signal_mcast_cmd() {
     // Get semaphore that will be update by dispatch_d, signalling that it's safe to send a go signal
 
     volatile tt_l1_ptr uint32_t* sync_sem_addr =
-        uncached_l1_ptr<uint32_t>(channel_state.config->dispatch_s_sync_sem_base_addr + sync_index * L1_ALIGNMENT);
+        uncached_l1_ptr<uint32_t>(cfg().dispatch_s_sync_sem_base_addr + sync_index * L1_ALIGNMENT);
 
     WAYPOINT("DCW");
     // Wait for notification from dispatch_d, signalling that it's safe to send the go signal
@@ -489,8 +496,7 @@ void process_go_signal_mcast_cmd() {
             // greater than the number of cores actually on the chip, we must account for acks
             // from non-existent cores here.
 #ifdef ARCH_QUASAR
-            *worker_completion_sem_addr(
-                first_stream_used, first_stream_used, channel_state.config->completion_counter_offset) +=
+            *worker_completion_sem_addr(first_stream_used, first_stream_used, cfg().completion_counter_offset) +=
                 (num_virtual_unicast_cores - num_physical_unicast_cores);
 #else
             NOC_STREAM_WRITE_REG(
@@ -513,7 +519,7 @@ void process_go_signal_mcast_cmd() {
         ASSERT(stream_index < max_num_worker_sems);
         auto dispatch_telemetry =
             reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchCoreTelemetry*>(
-                channel_state.config->dispatch_telemetry_addr);
+                cfg().dispatch_telemetry_addr);
 
         channel_state.dispatch_telemetry_control->launched_work_sequence_counter[stream_index] =
             ++channel_state.local_launch_seq_counter;
@@ -532,7 +538,6 @@ void process_go_signal_mcast_cmd() {
 
     update_worker_completion_count_on_dispatch_d();
     channel_state.cmd_ptr += sizeof(CQDispatchCmd);
-    update_triage_cmd_ptr();
 }
 
 FORCE_INLINE
@@ -563,7 +568,6 @@ void process_dispatch_s_wait_cmd() {
     channel_state.worker_count_update_for_dispatch_d[index] =
         0;  // Local worker count update for dispatch_d should reflect state of worker semaphore on dispatch_s
     channel_state.cmd_ptr += sizeof(CQDispatchCmd);
-    update_triage_cmd_ptr();
 }
 
 FORCE_INLINE
@@ -572,7 +576,6 @@ void set_num_worker_sems() {
     channel_state.num_worker_sems = cmd->set_num_worker_sems.num_worker_sems;
     ASSERT(channel_state.num_worker_sems <= max_num_worker_sems);
     channel_state.cmd_ptr += sizeof(CQDispatchCmd);
-    update_triage_cmd_ptr();
 }
 
 FORCE_INLINE
@@ -585,7 +588,6 @@ void set_go_signal_noc_data() {
         channel_state.go_signal_noc_data[i] = *(data_ptr++);
     }
     channel_state.cmd_ptr = round_up_pow2(l1_cached_addr(reinterpret_cast<uintptr_t>(data_ptr)), L1_ALIGNMENT);
-    update_triage_cmd_ptr();
 }
 
 // When dispatch_d runs on the same core, it issues transactions on dispatch_s's dedicated NOC
@@ -602,7 +604,7 @@ void merge_dispatch_d_noc_counter_deltas() {
     constexpr auto dispatch_d_proc_type = static_cast<decltype(proc_type)>(TensixProcessorTypes::DM0);
 
     volatile tt_l1_ptr uint32_t* shutdown_sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-        get_semaphore<programmable_core_type>(channel_state.config->dispatch_d_shutdown_sem_id));
+        get_semaphore<programmable_core_type>(cfg().dispatch_d_shutdown_sem_id));
     noc_semaphore_wait(shutdown_sem_addr, 1);
 
     invalidate_l1_cache();
@@ -636,18 +638,18 @@ void merge_dispatch_d_noc_counter_deltas() {
 
 void kernel_main() {
     set_l1_data_cache<true>();
-    channel_state.channel_index = get_my_thread_id();
     DPRINT("dispatch_s : start\n");
+    channel_state.channel_index = get_my_thread_id();
     ASSERT(get_num_threads() == NUM_DISPATCH_S_CHANNELS);
     ASSERT(channel_state.channel_index < NUM_DISPATCH_S_CHANNELS);
     const uint32_t hart = internal_::get_hw_thread_idx();
-    dispatch_s_triage_state[channel_state.channel_index].dm_index = hart;
-    channel_state.config = &kChannelConfigs[channel_state.channel_index];
+    my_triage_state().dm_index = hart;
+    channel_state.num_worker_sems = 1;
     channel_state.rt_profiler_msg =
-        reinterpret_cast<volatile tt_l1_ptr realtime_profiler_msg_t*>(channel_state.config->realtime_profiler_msg_addr);
+        reinterpret_cast<volatile tt_l1_ptr realtime_profiler_msg_t*>(cfg().realtime_profiler_msg_addr);
     channel_state.dispatch_telemetry_control =
         reinterpret_cast<volatile tt_l1_ptr tt::tt_metal::dispatch_telemetry_types::DispatchTelemetryControl*>(
-            channel_state.config->dispatch_telemetry_control_addr);
+            cfg().dispatch_telemetry_control_addr);
     // Initialize customized command buffers.
     dispatch_s_wr_reg_cmd_buf_init();
     dispatch_s_atomic_cmd_buf_init();
@@ -666,7 +668,9 @@ void kernel_main() {
     // realtime_profiler_msg_t signalling + FIFO + kernel_* .id fields are zeroed on the host in
     // DispatchSKernel::ConfigureCore() before CQ kernels launch.
 
-    channel_state.cmd_ptr = channel_state.config->cb_base;
+    const uintptr_t cb_base = cfg().cb_base;
+    const uintptr_t cb_end = cb_base + cb_size;
+    channel_state.cmd_ptr = cb_base;
     update_triage_cmd_ptr();
     bool done = false;
     uint32_t total_pages_acquired = 0;
@@ -697,12 +701,10 @@ void kernel_main() {
 #if DEVICE_PRINT_DISPATCH_ENABLED
         device_print_dispatcher.execute();
 #endif
-        cb_acquire_pages_dispatch_s(1, channel_state.config->my_dispatch_cb_sem_id);
+        cb_acquire_pages_dispatch_s(1, cfg().my_dispatch_cb_sem_id);
 
         volatile CQDispatchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQDispatchCmd>(channel_state.cmd_ptr);
-        ASSERT(
-            channel_state.cmd_ptr >= channel_state.config->cb_base &&
-            channel_state.cmd_ptr < channel_state.config->cb_base + cb_size);
+        ASSERT(channel_state.cmd_ptr >= cb_base && channel_state.cmd_ptr < cb_end);
         DeviceTimestampedData("process_cmd_d_dispatch_subordinate", (uint32_t)cmd->base.cmd_id);
         if (channel_state.rt_profiler_enabled) {
             const bool is_profiled_cmd = cmd->base.cmd_id == CQ_DISPATCH_CMD_SEND_GO_SIGNAL ||
@@ -730,9 +732,8 @@ void kernel_main() {
                     channel_state.cmd_ptr,
                     channel_state.workers_per_sub_device,
                     &channel_state.dispatch_telemetry_control->sub_device_worker_counts_update,
-                    channel_state.config->dispatch_telemetry_addr,
+                    cfg().dispatch_telemetry_addr,
                     channel_state.local_sub_device_worker_counts_update);
-                update_triage_cmd_ptr();
                 break;
             case CQ_DISPATCH_CMD_WAIT:
                 DPRINT("CQ_DISPATCH_CMD_WAIT\n");
@@ -742,7 +743,6 @@ void kernel_main() {
                 DPRINT("CQ_DISPATCH_CMD_RT_PROFILER_FLUSH\n");
                 wait_for_workers(cmd->rt_profiler_flush.wait_count, cmd->rt_profiler_flush.wait_stream);
                 channel_state.cmd_ptr += sizeof(CQDispatchCmd);
-                update_triage_cmd_ptr();
                 break;
             case CQ_DISPATCH_CMD_TERMINATE:
                 DPRINT("CQ_DISPATCH_CMD_TERMINATE\n");
@@ -771,15 +771,15 @@ void kernel_main() {
         // Dispatch s only supports single page commands for now
         ASSERT(channel_state.cmd_ptr <= (l1_cached_addr(reinterpret_cast<uintptr_t>(cmd)) + cb_page_size));
         channel_state.cmd_ptr = round_up_pow2(channel_state.cmd_ptr, cb_page_size);
-        update_triage_cmd_ptr();
         // Release a single page to prefetcher. Assumption is that all dispatch_s commands fit inside a single page for
         // now.
-        cb_release_pages_dispatch_s(
-            1, channel_state.config->upstream_noc_xy, channel_state.config->upstream_dispatch_cb_sem_id);
-        if (channel_state.cmd_ptr == channel_state.config->cb_base + cb_size) {
-            channel_state.cmd_ptr = channel_state.config->cb_base;
-            update_triage_cmd_ptr();
+        cb_release_pages_dispatch_s(1, cfg().upstream_noc_xy, cfg().upstream_dispatch_cb_sem_id);
+        if (channel_state.cmd_ptr == cb_end) {
+            channel_state.cmd_ptr = cb_base;
         }
+        // Update the command pointer once per iteration. Every blocking wait runs before the command pointer is
+        // updated.
+        update_triage_cmd_ptr();
         total_pages_acquired++;
 
         if (!done && channel_state.rt_profiler_enabled) {
@@ -787,7 +787,7 @@ void kernel_main() {
         }
     }
     // Confirm expected number of pages, spinning here is a leak
-    cb_wait_all_pages(total_pages_acquired, channel_state.config->my_dispatch_cb_sem_id);
+    cb_wait_all_pages(total_pages_acquired, cfg().my_dispatch_cb_sem_id);
 
 #ifndef ARCH_QUASAR
     if constexpr (!distributed_dispatcher) {

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -162,6 +162,14 @@ static const std::vector<DispatchKernelNode> quasar_single_chip_2cq = {
     {5, 0, 0, 1, DISPATCH_S, {3, x, x, x}, {4, x, x, x}, k_quasar_noc},
 };
 
+static const std::vector<DispatchKernelNode> quasar_single_chip_2cq_colocated = {
+    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {1, 4, x, x}, k_quasar_noc},
+    {1, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {4, x, x, x}, k_quasar_noc},
+    {2, 0, 0, 1, PREFETCH_HD, {x, x, x, x}, {3, 4, x, x}, k_quasar_noc},
+    {3, 0, 0, 1, DISPATCH_HD, {2, x, x, x}, {4, x, x, x}, k_quasar_noc},
+    {4, 0, 0, 0, DISPATCH_S, {0, 2, x, x}, {1, 3, x, x}, k_quasar_noc},
+};
+
 static const std::vector<DispatchKernelNode> two_chip_arch_1cq_fabric = {
     {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {1, 2, x, x}, k_prefetcher_noc},
     {1, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {2, x, x, x}, k_dispatcher_noc},
@@ -467,7 +475,9 @@ std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
             return is_quasar ? quasar_single_chip_1cq : single_chip_arch_1cq;
         }
         if (is_quasar) {
-            return quasar_single_chip_2cq;
+            return this->get_dispatch_query_manager_().cq_dispatch_layout().fd_kernels_on_same_core
+                       ? quasar_single_chip_2cq_colocated
+                       : quasar_single_chip_2cq;
         }
         if (this->get_dispatch_query_manager_().dispatch_s_enabled()) {
             return single_chip_arch_2cq_dispatch_s;

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -153,16 +153,6 @@ static const std::vector<DispatchKernelNode> quasar_single_chip_1cq = {
 };
 
 static const std::vector<DispatchKernelNode> quasar_single_chip_2cq = {
-    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {1, 2, x, x}, k_quasar_noc},
-    {1, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {2, x, x, x}, k_quasar_noc},
-    {2, 0, 0, 0, DISPATCH_S, {0, x, x, x}, {1, x, x, x}, k_quasar_noc},
-
-    {3, 0, 0, 1, PREFETCH_HD, {x, x, x, x}, {4, 5, x, x}, k_quasar_noc},
-    {4, 0, 0, 1, DISPATCH_HD, {3, x, x, x}, {5, x, x, x}, k_quasar_noc},
-    {5, 0, 0, 1, DISPATCH_S, {3, x, x, x}, {4, x, x, x}, k_quasar_noc},
-};
-
-static const std::vector<DispatchKernelNode> quasar_single_chip_2cq_colocated = {
     {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {1, 4, x, x}, k_quasar_noc},
     {1, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {4, x, x, x}, k_quasar_noc},
     {2, 0, 0, 1, PREFETCH_HD, {x, x, x, x}, {3, 4, x, x}, k_quasar_noc},
@@ -475,9 +465,7 @@ std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
             return is_quasar ? quasar_single_chip_1cq : single_chip_arch_1cq;
         }
         if (is_quasar) {
-            return this->get_dispatch_query_manager_().cq_dispatch_layout().fd_kernels_on_same_core
-                       ? quasar_single_chip_2cq_colocated
-                       : quasar_single_chip_2cq;
+            return quasar_single_chip_2cq;
         }
         if (this->get_dispatch_query_manager_().dispatch_s_enabled()) {
             return single_chip_arch_2cq_dispatch_s;

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -1136,7 +1136,7 @@ uint32_t experimental::quasar::DispatchEngineKernel::get_kernel_processor_type(i
 
 std::vector<uint32_t> experimental::quasar::DispatchEngineKernel::get_processor_indices_for_binary(
     int binary_index) const {
-    TT_ASSERT(binary_index == 0, "binary_index out of bounds");
+    TT_ASSERT(0 <= binary_index && binary_index < expected_num_binaries(), "binary_index out of bounds");
     const auto& hal = MetalContext::instance().hal();
     const auto core_type = this->get_kernel_programmable_core_type();
     const auto proc_class = this->get_kernel_processor_class();

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -1134,6 +1134,20 @@ uint32_t experimental::quasar::DispatchEngineKernel::get_kernel_processor_type(i
     return enchantum::to_underlying(this->dm_processors_[0]);
 }
 
+std::vector<uint32_t> experimental::quasar::DispatchEngineKernel::get_processor_indices_for_binary(
+    int binary_index) const {
+    TT_ASSERT(binary_index == 0, "binary_index out of bounds");
+    const auto& hal = MetalContext::instance().hal();
+    const auto core_type = this->get_kernel_programmable_core_type();
+    const auto proc_class = this->get_kernel_processor_class();
+    std::vector<uint32_t> indices;
+    indices.reserve(this->dm_processors_.size());
+    for (const auto& processor : this->dm_processors_) {
+        indices.push_back(hal.get_processor_index(core_type, proc_class, enchantum::to_underlying(processor)));
+    }
+    return indices;
+}
+
 void experimental::quasar::DispatchEngineKernel::generate_binaries(IDevice* device, JitBuildOptions&) const {
     jit_build_genfiles_kernel_include(
         BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_env,
@@ -1205,7 +1219,8 @@ std::string_view experimental::quasar::DispatchEngineKernel::get_linker_opt_leve
 }
 
 std::string experimental::quasar::DispatchEngineKernel::config_hash() const {
-    return fmt::format("dispatch_{}", enchantum::to_string(this->dm_processors_[0]));
+    TT_ASSERT(std::is_sorted(this->dm_processors_.begin(), this->dm_processors_.end()));
+    return fmt::format("dispatch_{}", fmt::join(this->dm_processors_, "_"));
 }
 
 uint8_t experimental::quasar::DispatchEngineKernel::expected_num_binaries() const { return 1; }

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -522,7 +522,7 @@ public:
         const KernelSource& kernel_src,
         const CoreRangeSet& cr_set,
         const QuasarDataMovementConfig& config,
-        DataMovementProcessor dm_processor) :
+        const std::set<DataMovementProcessor>& dm_processors) :
         Kernel(
             HalProgrammableCoreType::DISPATCH,
             HalProcessorClassType::DM,
@@ -532,19 +532,21 @@ public:
             config.defines,
             config.named_compile_args),
         config_(config),
-        dm_processors_{dm_processor} {
+        dm_processors_(dm_processors.begin(), dm_processors.end()) {
         TT_FATAL(
             MetalContext::instance().get_cluster().arch() == ARCH::QUASAR,
             "DispatchEngineKernel is only supported on Quasar");
         TT_FATAL(
-            config.num_threads_per_cluster == 1,
-            "DispatchEngineKernel requires num_threads_per_cluster=1");
+            config.num_threads_per_cluster == dm_processors_.size(),
+            "Number of dispatch engine DM threads specified in config must match the reserved processor count");
+        TT_FATAL(!dm_processors_.empty(), "DispatchEngineKernel requires at least one DM processor");
         this->set_compiler_include_paths(config_.compiler_include_paths);
     }
 
     ~DispatchEngineKernel() override = default;
 
     uint32_t get_kernel_processor_type(int index) const override;
+    std::vector<uint32_t> get_processor_indices_for_binary(int binary_index) const override;
     void generate_binaries(IDevice* device, JitBuildOptions& build_options) const override;
     void read_binaries(IDevice* device, const std::string& binary_root) override;
 

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -898,6 +898,14 @@ KernelGroup::KernelGroup(
                 kernel_config.kernel_thread_id()[processor_index] = thread_idx;
             }
         }
+
+        if (auto* dispatch_kernel = dynamic_cast<experimental::quasar::DispatchEngineKernel*>(kernel.get())) {
+            const std::vector<uint32_t> processor_indices = dispatch_kernel->get_processor_indices_for_binary(0);
+            for (uint32_t thread_idx = 0; thread_idx < processor_indices.size(); thread_idx++) {
+                kernel_config.num_sw_threads()[processor_indices[thread_idx]] = processor_indices.size();
+                kernel_config.kernel_thread_id()[processor_indices[thread_idx]] = thread_idx;
+            }
+        }
         // Quasar: set per-processor num_sw_threads and kernel_thread_id for trisc/runtime access
         if (auto* qk = dynamic_cast<experimental::quasar::QuasarComputeKernel*>(kernel.get())) {
             auto config = std::get<experimental::quasar::QuasarComputeConfig>(qk->config());


### PR DESCRIPTION
### PR Category
Performance

### Summary

Previously, Quasar 2CQ ran a separate `dispatch_s` instance per CQ, each on its own DM processor. This change lets a single `dispatch_s` instance serve both CQs, running one thread per CQ. The DM processor count is unchanged — what collapses is the duplication: one kernel binary and one set of state instead of two.

Supporting changes:

- A dispatch engine kernel can now run across multiple DM processors instead of exactly one, with one software thread per processor.
- A `dispatch_s` instance now manages state for two CQs, emitting a separate set of compile-time definitions per served queue.
- The Quasar 2CQ topology now unconditionally routes both CQs through one shared `dispatch_s` node, replacing the previous layout that kept them separate. New checks confirm each CQ has exactly one upstream prefetch kernel and one downstream dispatch kernel.

1CQ configurations and non-Quasar hardware are unaffected.

Removing the duplicated binary and state lays the groundwork for reclaiming L1 memory space in upcoming PRs.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_dispatch_s_optimize)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/qsr_dispatch_s_optimize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_dispatch_s_optimize)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sagarwal/qsr_dispatch_s_optimize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-unit-tests.yaml/badge.svg?branch=sagarwal/qsr_dispatch_s_optimize)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-unit-tests.yaml?query=branch:sagarwal/qsr_dispatch_s_optimize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-integration-tests.yaml/badge.svg?branch=sagarwal/qsr_dispatch_s_optimize)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-integration-tests.yaml?query=branch:sagarwal/qsr_dispatch_s_optimize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-perf-tests.yaml/badge.svg?branch=sagarwal/qsr_dispatch_s_optimize)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-perf-tests.yaml?query=branch:sagarwal/qsr_dispatch_s_optimize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_dispatch_s_optimize)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:sagarwal/qsr_dispatch_s_optimize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/qsr_dispatch_s_optimize)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/qsr_dispatch_s_optimize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/triage-tests.yaml/badge.svg?branch=sagarwal/qsr_dispatch_s_optimize)](https://github.com/tenstorrent/tt-metal/actions/workflows/triage-tests.yaml?query=branch:sagarwal/qsr_dispatch_s_optimize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sagarwal/qsr_dispatch_s_optimize)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sagarwal/qsr_dispatch_s_optimize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sagarwal/qsr_dispatch_s_optimize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sagarwal/qsr_dispatch_s_optimize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sagarwal/qsr_dispatch_s_optimize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sagarwal/qsr_dispatch_s_optimize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sagarwal/qsr_dispatch_s_optimize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sagarwal/qsr_dispatch_s_optimize)
