### PR TITLE
[Quasar] Add static asserts to dest dvalid sync functions on llk api level

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_common_api.h
@@ -83,14 +83,20 @@ inline constexpr MathFidelity get_effective_math_fidelity() {
  * @brief Sets the dest dvalid for FPU/SFPU
  *
  * @tparam SET_DEST_DVALID: which client to set data valid for, values = p_cleardvalid::FPU/SFPU
+ * @tparam DST: Destination register banking mode: SyncHalf = double banked (math/pack overlap), SyncFull = one bank
+ *(serialized)
  *
  * @warning SYNC SCHEME: dest-dvalid. There are two mutually exclusive Dest register synchronization schemes: the
  * dest-dvalid scheme and the semaphore scheme. Never mix them. Currently the semaphore scheme is used in llk and
  * compute APIs.
  **/
-template <std::uint8_t SET_DEST_DVALID>
+template <std::uint8_t SET_DEST_DVALID, DstSync DST, typename Blocked_ = void>
 inline void llk_math_set_dvalid() {
-    _llk_math_set_dvalid_<SET_DEST_DVALID>();
+    static_assert(
+        sizeof(Blocked_) == 0,
+        "llk_math_set_dvalid belongs to the dest-dvalid sync scheme, should not be mixed with semaphores which are "
+        "currently used in tt-metal.");
+    _llk_math_set_dvalid_<SET_DEST_DVALID, DST>();
 }
 
 /**

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_common_api.h
@@ -14,6 +14,11 @@
 #include "llk_operands.h"
 #include "llk_sync.h"
 
+namespace llk_math_detail {
+template <auto...>
+inline constexpr bool always_false_v = false;
+}  // namespace llk_math_detail
+
 /*************************************************************************
  * LLK MATH COMMON
  *************************************************************************/
@@ -90,10 +95,10 @@ inline constexpr MathFidelity get_effective_math_fidelity() {
  * dest-dvalid scheme and the semaphore scheme. Never mix them. Currently the semaphore scheme is used in llk and
  * compute APIs.
  **/
-template <std::uint8_t SET_DEST_DVALID, DstSync DST, typename Blocked_ = void>
+template <std::uint8_t SET_DEST_DVALID, DstSync DST>
 inline void llk_math_set_dvalid() {
     static_assert(
-        sizeof(Blocked_) == 0,
+        llk_math_detail::always_false_v<SET_DEST_DVALID, DST>,
         "llk_math_set_dvalid belongs to the dest-dvalid sync scheme, should not be mixed with semaphores which are "
         "currently used in tt-metal.");
     _llk_math_set_dvalid_<SET_DEST_DVALID, DST>();

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
@@ -11,6 +11,11 @@
 #include "llk_defs.h"
 #include "api/dataflow/dataflow_buffer.h"
 
+namespace llk_pack_detail {
+template <auto...>
+inline constexpr bool always_false_v = false;
+}  // namespace llk_pack_detail
+
 /*************************************************************************
  * LLK PACK COMMON
  *************************************************************************/
@@ -93,10 +98,10 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t old_output, const 
  * dest-dvalid scheme and the semaphore scheme. Never mix them. Currently the semaphore scheme is used in llk and
  * compute APIs.
  **/
-template <DstSync DST, bool EN_32BIT_DEST, typename Blocked_ = void>
+template <DstSync DST, bool EN_32BIT_DEST>
 inline void llk_pack_dest_dvalid_section_done() {
     static_assert(
-        sizeof(Blocked_) == 0,
+        llk_pack_detail::always_false_v<DST, EN_32BIT_DEST>,
         "llk_pack_dest_dvalid_section_done belongs to the dest-dvalid sync scheme, should not be mixed with "
         "semaphores which are currently used in tt-metal.");
     _llk_pack_dest_dvalid_section_done_<DST, EN_32BIT_DEST>();

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
@@ -85,16 +85,21 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t old_output, const 
  * @brief Clears the data valid for destination register after Packer 0 is done packing
  * and zeroes out the dest bank(s) used by packer 0
  *
- * @tparam DST: Destination register buffering mode, values = [DstSync::SyncHalf, DstSync::SyncFull]
- * @tparam IS_FP32_MATH_DEST_EN: flag to show if math destination register is set to float32 mode
+ * @tparam DST: Destination register banking mode: SyncHalf = double banked (math/pack overlap), SyncFull = one bank
+ *(serialized)
+ * @tparam EN_32BIT_DEST: flag to show if Destination register is set to 32-bit mode
  *
  * @warning SYNC SCHEME: dest-dvalid. There are two mutually exclusive Dest register synchronization schemes: the
  * dest-dvalid scheme and the semaphore scheme. Never mix them. Currently the semaphore scheme is used in llk and
  * compute APIs.
  **/
-template <DstSync DST, bool IS_FP32_MATH_DEST_EN>
+template <DstSync DST, bool EN_32BIT_DEST, typename Blocked_ = void>
 inline void llk_pack_dest_dvalid_section_done() {
-    _llk_pack_dest_dvalid_section_done_<DST, IS_FP32_MATH_DEST_EN>();
+    static_assert(
+        sizeof(Blocked_) == 0,
+        "llk_pack_dest_dvalid_section_done belongs to the dest-dvalid sync scheme, should not be mixed with "
+        "semaphores which are currently used in tt-metal.");
+    _llk_pack_dest_dvalid_section_done_<DST, EN_32BIT_DEST>();
 }
 
 /**


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Adds static asserts to dest dvalid sync functions on LLK api level in order to guard against their use since semaphores are used instead in metal, and the two should not be used at the same time.
Updates `_llk_math_set_dvalid_` signature in one callsite.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/dest_dvalid_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/dest_dvalid_asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amokan/dest_dvalid_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amokan/dest_dvalid_asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=amokan/dest_dvalid_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:amokan/dest_dvalid_asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/dest_dvalid_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/dest_dvalid_asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amokan/dest_dvalid_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amokan/dest_dvalid_asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/dest_dvalid_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/dest_dvalid_asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/dest_dvalid_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/dest_dvalid_asserts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/dest_dvalid_asserts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/dest_dvalid_asserts)