### PR TITLE
[Cleanup] Stop ttnn-core owning ttnn/cpp/ttnn/kernel/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -286,6 +286,7 @@ ttnn/ttnn/operations/activations.py @tenstorrent/metalium-developers-mmfusedredu
 ttnn/ttnn/operations/normalization.py @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 ttnn/ttnn/operations/reduction.py @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 ttnn/**/kernels/ @tenstorrent/metalium-developers-ops-leads @tenstorrent/codeowner-bypass # Removes the owners above from owning kernels unless specified afterwards
+ttnn/cpp/ttnn/kernel/ @tenstorrent/metalium-developers-ops-leads @tenstorrent/codeowner-bypass # Same, for the singular kernel/ dir the pattern above misses
 ttnn/core/tensor/ @tenstorrent/metalium-developers-ttnn-core @tenstorrent/codeowner-bypass
 ttnn/**/CMakeLists.txt @tenstorrent/metalium-developers-ttnn-core @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -286,7 +286,7 @@ ttnn/ttnn/operations/activations.py @tenstorrent/metalium-developers-mmfusedredu
 ttnn/ttnn/operations/normalization.py @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 ttnn/ttnn/operations/reduction.py @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 ttnn/**/kernels/ @tenstorrent/metalium-developers-ops-leads @tenstorrent/codeowner-bypass # Removes the owners above from owning kernels unless specified afterwards
-ttnn/cpp/ttnn/kernel/ @tenstorrent/metalium-developers-ops-leads @tenstorrent/codeowner-bypass # Same, for the singular kernel/ dir the pattern above misses
+ttnn/**/kernel/ @tenstorrent/metalium-developers-ops-leads @tenstorrent/codeowner-bypass # Same, for the singular kernel/ dir the pattern above misses
 ttnn/core/tensor/ @tenstorrent/metalium-developers-ttnn-core @tenstorrent/codeowner-bypass
 ttnn/**/CMakeLists.txt @tenstorrent/metalium-developers-ttnn-core @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
CODEOWNERS strips the ttnn/ catch-all owners off kernel directories with `ttnn/**/kernels/` — plural. The `ttnn/cpp/ttnn/kernel/` tree (`compute/`, `dataflow/`, and the two top-level `kernel_*_utils.hpp` headers) is singular, so it never matched and fell through to the catch-all, making ttnn-core a required reviewer on kernel changes. ttnn-core does not own or review kernels.

Adds one rule pointing that directory at ops-leads, mirroring what `ttnn/**/kernels/` already does.

### Notes for reviewers
Owner choice: ops-leads, to match the existing `ttnn/**/kernels/` line, since CODEOWNERS cannot express "no owner". The adjacent `ttnn/cpp/ttnn/kernel_lib/` instead goes to convolutions + mmfusedreduce — happy to use that pair here instead if these shared kernels belong with them.

`ttnn/core/tensor/kernels/` is untouched: the `ttnn/core/tensor/` rule sits after the strip-out line, so it still resolves to ttnn-core, which looks deliberate.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/codeowners-ttnn-kernel-not-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/codeowners-ttnn-kernel-not-core)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/codeowners-ttnn-kernel-not-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/codeowners-ttnn-kernel-not-core)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=dgomez/codeowners-ttnn-kernel-not-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:dgomez/codeowners-ttnn-kernel-not-core)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/codeowners-ttnn-kernel-not-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/codeowners-ttnn-kernel-not-core)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/codeowners-ttnn-kernel-not-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/codeowners-ttnn-kernel-not-core)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/codeowners-ttnn-kernel-not-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/codeowners-ttnn-kernel-not-core)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/codeowners-ttnn-kernel-not-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/codeowners-ttnn-kernel-not-core)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/codeowners-ttnn-kernel-not-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/codeowners-ttnn-kernel-not-core)