### PR TITLE
#51235: Fix reduce_to_root intermediate tensor spec and c_18 circular buffer overflow

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_to_root_trace.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_to_root_trace.py
@@ -91,7 +91,9 @@ def compute_reference_reduce_to_root(
 @pytest.mark.parametrize(
     "device_params",
     [
-        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 225280}),
+        # The warmup (15 iters) and perf (30 iters) traces are both live at end_trace_capture,
+        # which needs 36864 B per bank; 225280 only budgets 32768 B per bank.
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 524288}),
     ],
     indirect=["device_params"],
     ids=["fabric_1d_linear_trace"],

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_to_root_trace.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_to_root_trace.py
@@ -91,8 +91,6 @@ def compute_reference_reduce_to_root(
 @pytest.mark.parametrize(
     "device_params",
     [
-        # The warmup (15 iters) and perf (30 iters) traces are both live at end_trace_capture,
-        # which needs 36864 B per bank; 225280 only budgets 32768 B per bank.
         ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 524288}),
     ],
     indirect=["device_params"],

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_to_root_trace.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_to_root_trace.py
@@ -9,6 +9,7 @@ from loguru import logger
 from tracy import signpost
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.common.utility_functions import skip_for_wormhole_b0
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
 from tests.ttnn.unit_tests.operations.ccl.blackhole_CI.box.nightly.test_all_gather_nightly import validate_test
 
 
@@ -85,6 +86,24 @@ def compute_reference_reduce_to_root(
         m_final_cores.append(m_final)
 
     return torch.cat(l_final_cores, dim=1), torch.cat(s_final_cores, dim=1), torch.cat(m_final_cores, dim=1)
+
+
+# Tolerances for bfloat16 with exponentials.
+RTOL = 0.01
+ATOL = 0.06
+PCC = 0.99
+
+
+def assert_output_matches(name, output, reference, context=""):
+    """Element-wise closeness plus PCC, so a systematic shift and a few corrupted elements both fail."""
+    suffix = f" {context}" if context else ""
+    assert torch.allclose(
+        output, reference, rtol=RTOL, atol=ATOL
+    ), f"{name} tensor output does not match reference{suffix}"
+
+    passing, message = comp_pcc(reference, output, PCC)
+    logger.info(f"{name} tensor{suffix}: {message}")
+    assert passing, f"{name} tensor output failed PCC check{suffix}: {message}"
 
 
 @skip_for_wormhole_b0("This test is for blackhole")
@@ -308,27 +327,12 @@ def test_reduce_to_root_with_trace(bh_2d_mesh_device):
     out_s_root = out_s_torch[root_device_idx]
     out_m_root = out_m_torch[root_device_idx]
 
-    # Tolerances for bfloat16 with exponentials
-    rtol = 0.01
-    atol = 0.06
+    # S and M only carry a meaningful value in the first column of each core's shard.
+    cols_to_check = [i * 32 for i in range(num_cores)]
 
-    # Check L tensor
-    l_match = torch.allclose(out_l_root, l_ref, rtol=rtol, atol=atol)
-    assert l_match, "L tensor output does not match reference after trace execution"
-
-    # Check S tensor (only column 0)
-    s_cols_to_check = [i * 32 for i in range(8)]
-    s_output_col0 = out_s_root[:, s_cols_to_check]
-    s_ref_col0 = s_ref[:, s_cols_to_check]
-    s_match = torch.allclose(s_output_col0, s_ref_col0, rtol=rtol, atol=atol)
-    assert s_match, "S tensor output does not match reference after trace execution"
-
-    # Check M tensor (only column 0)
-    m_cols_to_check = [i * 32 for i in range(8)]
-    m_output_col0 = out_m_root[:, m_cols_to_check]
-    m_ref_col0 = m_ref[:, m_cols_to_check]
-    m_match = torch.allclose(m_output_col0, m_ref_col0, rtol=rtol, atol=atol)
-    assert m_match, "M tensor output does not match reference after trace execution"
+    assert_output_matches("L", out_l_root, l_ref, "after trace execution")
+    assert_output_matches("S", out_s_root[:, cols_to_check], s_ref[:, cols_to_check], "after trace execution")
+    assert_output_matches("M", out_m_root[:, cols_to_check], m_ref[:, cols_to_check], "after trace execution")
 
 
 @skip_for_wormhole_b0("This test is for blackhole")
@@ -427,14 +431,8 @@ def test_reduce_to_root_auto_intermediate(bh_2d_mesh_device):
     out_s_root = ttnn.to_torch(out_s, mesh_composer=composer)[root_device_idx]
     out_m_root = ttnn.to_torch(out_m, mesh_composer=composer)[root_device_idx]
 
-    rtol = 0.01
-    atol = 0.06
     cols_to_check = [i * 32 for i in range(num_cores)]
 
-    assert torch.allclose(out_l_root, l_ref, rtol=rtol, atol=atol), "L tensor output does not match reference"
-    assert torch.allclose(
-        out_s_root[:, cols_to_check], s_ref[:, cols_to_check], rtol=rtol, atol=atol
-    ), "S tensor output does not match reference"
-    assert torch.allclose(
-        out_m_root[:, cols_to_check], m_ref[:, cols_to_check], rtol=rtol, atol=atol
-    ), "M tensor output does not match reference"
+    assert_output_matches("L", out_l_root, l_ref)
+    assert_output_matches("S", out_s_root[:, cols_to_check], s_ref[:, cols_to_check])
+    assert_output_matches("M", out_m_root[:, cols_to_check], m_ref[:, cols_to_check])

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_to_root_trace.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_reduce_to_root_trace.py
@@ -87,9 +87,6 @@ def compute_reference_reduce_to_root(
     return torch.cat(l_final_cores, dim=1), torch.cat(s_final_cores, dim=1), torch.cat(m_final_cores, dim=1)
 
 
-@pytest.mark.skip(
-    reason="Consistently failing with data mismatch after trace replay on all BH multi-chip setups. See #39098"
-)
 @skip_for_wormhole_b0("This test is for blackhole")
 @pytest.mark.parametrize(
     "device_params",
@@ -332,3 +329,112 @@ def test_reduce_to_root_with_trace(bh_2d_mesh_device):
     m_ref_col0 = m_ref[:, m_cols_to_check]
     m_match = torch.allclose(m_output_col0, m_ref_col0, rtol=rtol, atol=atol)
     assert m_match, "M tensor output does not match reference after trace execution"
+
+
+@skip_for_wormhole_b0("This test is for blackhole")
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D}),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_1d_linear"],
+)
+def test_reduce_to_root_auto_intermediate(bh_2d_mesh_device):
+    """Same reduction without an intermediate_tensor, so the op computes the intermediate spec itself."""
+
+    num_devices = 4
+    root_coord = (1, 0)
+    root_device_idx = root_coord[0]
+    num_cores = 8
+
+    topology = ttnn.Topology.Linear
+    validate_test(num_devices, topology, bh_2d_mesh_device.shape, 0)
+    submesh_device = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
+
+    l_shape = [8, 128 * num_cores]
+    s_shape = [8, 32 * num_cores]
+    dtype = ttnn.bfloat16
+    layout = ttnn.TILE_LAYOUT
+    tile = ttnn.Tile((8, 32))
+
+    mux_cores = [ttnn.CoreCoord(2, 0), ttnn.CoreCoord(2, 1), ttnn.CoreCoord(2, 2), ttnn.CoreCoord(2, 3)]
+
+    shard_grid = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 3)),
+            ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(1, 3)),
+        }
+    )
+    mem_config_l = ttnn.MemoryConfig(
+        ttnn.types.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.types.BufferType.L1,
+        ttnn.ShardSpec(shard_grid, [8, 128], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    mem_config_s = ttnn.MemoryConfig(
+        ttnn.types.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.types.BufferType.L1,
+        ttnn.ShardSpec(shard_grid, [8, 32], ttnn.ShardOrientation.ROW_MAJOR),
+    )
+
+    mesh_mapper = ttnn.create_mesh_mapper(
+        submesh_device,
+        ttnn.MeshMapperConfig([ttnn.PlacementShard(0), ttnn.PlacementReplicate()], submesh_device.shape),
+    )
+
+    torch.manual_seed(42)
+    l_data_per_device = []
+    s_data_per_device = []
+    m_data_per_device = []
+    for device_idx in range(num_devices):
+        l_data_per_device.append(torch.randn(l_shape, dtype=torch.bfloat16) * 0.5 + device_idx)
+        s_data_per_device.append(torch.rand(s_shape, dtype=torch.bfloat16) * 0.5 + 1.0 + device_idx * 0.1)
+        m_data_per_device.append(torch.randn(s_shape, dtype=torch.bfloat16) * 0.5 + device_idx)
+
+    def to_device(per_device, mem_config):
+        return ttnn.from_torch(
+            torch.stack(per_device, dim=0),
+            device=submesh_device,
+            layout=layout,
+            tile=tile,
+            dtype=dtype,
+            memory_config=mem_config,
+            mesh_mapper=mesh_mapper,
+        )
+
+    l_tensor = to_device(l_data_per_device, mem_config_l)
+    s_tensor = to_device(s_data_per_device, mem_config_s)
+    m_tensor = to_device(m_data_per_device, mem_config_s)
+
+    scale_value = float(1)
+    l_ref, s_ref, m_ref = compute_reference_reduce_to_root(
+        l_data_per_device, s_data_per_device, m_data_per_device, root_device_idx, num_cores, scale_value
+    )
+
+    out_l, out_s, out_m = ttnn.reduce_to_root(
+        l_tensor,
+        s_tensor,
+        m_tensor,
+        root_coord=ttnn.MeshCoordinate(root_coord),
+        scale_fp32=scale_value,
+        topology=topology,
+        input_mux_cores=mux_cores,
+    )
+    ttnn.synchronize_device(submesh_device)
+
+    composer = ttnn.ConcatMeshToTensor(submesh_device, dim=0)
+    out_l_root = ttnn.to_torch(out_l, mesh_composer=composer)[root_device_idx]
+    out_s_root = ttnn.to_torch(out_s, mesh_composer=composer)[root_device_idx]
+    out_m_root = ttnn.to_torch(out_m, mesh_composer=composer)[root_device_idx]
+
+    rtol = 0.01
+    atol = 0.06
+    cols_to_check = [i * 32 for i in range(num_cores)]
+
+    assert torch.allclose(out_l_root, l_ref, rtol=rtol, atol=atol), "L tensor output does not match reference"
+    assert torch.allclose(
+        out_s_root[:, cols_to_check], s_ref[:, cols_to_check], rtol=rtol, atol=atol
+    ), "S tensor output does not match reference"
+    assert torch.allclose(
+        out_m_root[:, cols_to_check], m_ref[:, cols_to_check], rtol=rtol, atol=atol
+    ), "M tensor output does not match reference"

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/reduce_to_root_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/reduce_to_root_op.cpp
@@ -63,6 +63,21 @@ void ReduceToRootOp::validate(const operation_attributes_t& operation_attributes
             optional_output_tensor_m.value().device() == mesh_device,
             "Output tensor must be allocated on same mesh device as input tensor");
     }
+    const auto& input_s = tensor_args.input_tensor_s;
+    const auto& input_m = tensor_args.input_tensor_m;
+
+    TT_FATAL(
+        input_l.layout() == tt::tt_metal::Layout::TILE && input_s.layout() == tt::tt_metal::Layout::TILE &&
+            input_m.layout() == tt::tt_metal::Layout::TILE,
+        "ReduceToRoot requires TILE layout for all three input tensors, got l: {}, s: {}, m: {}",
+        input_l.layout(),
+        input_s.layout(),
+        input_m.layout());
+
+    TT_FATAL(
+        input_l.is_sharded() && input_s.is_sharded() && input_m.is_sharded(),
+        "ReduceToRoot requires all three input tensors to be sharded");
+
     const uint32_t l1_alignment = tt::tt_metal::hal::get_l1_alignment();
     const uint32_t input_page_size_bytes = input_l.tensor_spec().compute_page_size_bytes();
 

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/reduce_to_root_op.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/reduce_to_root_op.cpp
@@ -92,12 +92,23 @@ ReduceToRootOp::spec_return_value_t ReduceToRootOp::compute_output_specs(
         intermediate_specs.push_back(tensor_args.optional_intermediate_tensor.value().tensor_spec());
         return {intermediate_specs, final_output_spec};
     }
-    // intermediate shape is the shape of the 3 tenssors combined so that we can send them all in a single packet
-    uint32_t shape_0 = final_output_spec[0].memory_config().shard_spec()->shape[0];
-    uint32_t shape_1 = final_output_spec[0].memory_config().shard_spec()->shape[1] +
-                       (2 * final_output_spec[1].memory_config().shard_spec()->shape[1]);
-    Shape intermediate_shape = Shape{shape_0, shape_1};
-    tt::tt_metal::TensorSpec intermediate_spec(intermediate_shape, final_output_spec[0].tensor_layout());
+    // Every shard core receives one packet holding its l shard plus the matching s and m pages, so each core needs a
+    // shard of (l shard width + 2 * s shard width) and the tensor spans that shard on every core of the l grid.
+    const auto& l_memory_config = final_output_spec[0].memory_config();
+    const auto& l_shard_spec = l_memory_config.shard_spec().value();
+    const auto& s_shard_spec = final_output_spec[1].memory_config().shard_spec().value();
+
+    const uint32_t shard_height = l_shard_spec.shape[0];
+    const uint32_t intermediate_shard_width = l_shard_spec.shape[1] + (2 * s_shard_spec.shape[1]);
+    const uint32_t num_shard_cores = l_shard_spec.num_cores();
+
+    Shape intermediate_shape = Shape{shard_height, intermediate_shard_width * num_shard_cores};
+    tt::tt_metal::ShardSpec intermediate_shard_spec(
+        l_shard_spec.grid, {shard_height, intermediate_shard_width}, l_shard_spec.orientation);
+    tt::tt_metal::MemoryConfig intermediate_memory_config(
+        l_memory_config.memory_layout(), l_memory_config.buffer_type(), intermediate_shard_spec);
+    tt::tt_metal::TensorSpec intermediate_spec(
+        intermediate_shape, final_output_spec[0].tensor_layout().with_memory_config(intermediate_memory_config));
     intermediate_specs.push_back(intermediate_spec);
 
     return {intermediate_specs, final_output_spec};

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/reduce_to_root_program.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/reduce_to_root_program.cpp
@@ -278,6 +278,18 @@ ttnn::device_operation::CachedProgram<ReduceToRootOp::ReduceToRoot::shared_varia
 
     // The writers append the s and m pages after the l payload, so a packet is 2 aligned pages larger than the payload.
     const uint32_t total_pkt_size = packet_size_bytes + (2 * aligned_input_page_size_bytes);
+
+    const uint32_t fabric_max_payload_size_bytes = tt::tt_fabric::get_tt_fabric_max_payload_size_bytes();
+    TT_FATAL(
+        total_pkt_size <= fabric_max_payload_size_bytes,
+        "ReduceToRoot needs to send {} B per shard core ({} B of l payload plus 2 x {} B for the s and m pages), which "
+        "exceeds the fabric maximum payload of {} B. Use a narrower l shard or a smaller page size, or raise "
+        "max_packet_payload_size_bytes in FabricRouterConfig.",
+        total_pkt_size,
+        packet_size_bytes,
+        aligned_input_page_size_bytes,
+        fabric_max_payload_size_bytes);
+
     constexpr auto packet_cb_id = tt::CBIndex::c_7;
     tt::tt_metal::CircularBufferConfig cb_packet_config =
         tt::tt_metal::CircularBufferConfig(2 * total_pkt_size, {{packet_cb_id, input_dataformat}})

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/reduce_to_root_program.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/reduce_to_root_program.cpp
@@ -276,7 +276,8 @@ ttnn::device_operation::CachedProgram<ReduceToRootOp::ReduceToRoot::shared_varia
             .set_page_size(packet_header_cb_id, packet_header_size_bytes)
             .set_tile_dims(packet_header_cb_id, stats_tile);
 
-    auto total_pkt_size = packet_size_bytes + 1024;
+    // The writers append the s and m pages after the l payload, so a packet is 2 aligned pages larger than the payload.
+    const uint32_t total_pkt_size = packet_size_bytes + (2 * aligned_input_page_size_bytes);
     constexpr auto packet_cb_id = tt::CBIndex::c_7;
     tt::tt_metal::CircularBufferConfig cb_packet_config =
         tt::tt_metal::CircularBufferConfig(2 * total_pkt_size, {{packet_cb_id, input_dataformat}})
@@ -356,8 +357,8 @@ ttnn::device_operation::CachedProgram<ReduceToRootOp::ReduceToRoot::shared_varia
 
     constexpr auto packet_cb_id_2 = tt::CBIndex::c_18;
     tt::tt_metal::CircularBufferConfig cb_packet_config_2 =
-        tt::tt_metal::CircularBufferConfig(packet_size_bytes, {{packet_cb_id_2, input_dataformat}})
-            .set_page_size(packet_cb_id_2, packet_size_bytes)
+        tt::tt_metal::CircularBufferConfig(total_pkt_size, {{packet_cb_id_2, input_dataformat}})
+            .set_page_size(packet_cb_id_2, total_pkt_size)
             .set_tile_dims(packet_cb_id_2, stats_tile);
 
     constexpr auto cb_s_temp = tt::CBIndex::c_19;

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/reduce_to_root_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/reduce_to_root_nanobind.cpp
@@ -54,6 +54,8 @@ void bind_reduce_to_root(nb::module_& mod) {
 
                 reduce_to_root operates on a fixed 4-device line topology with the root at (1, 0). All three input tensors must be sharded; each output preserves the spec of its corresponding input.
 
+                Each shard core is moved in a single fabric packet holding its l shard plus one s and one m page, so ``l_shard_pages * page_size + 2 * page_size`` must not exceed the fabric maximum payload size (4352 B by default). Wider shards need ``max_packet_payload_size_bytes`` raised in the ``FabricRouterConfig``.
+
             Memory Support:
                 - Sharded: required (L1)
             )doc";


### PR DESCRIPTION
### Ticket
Closes #51235

### Problem description
`reduce_to_root` moves one packet per shard core, and every producer sizes that packet as
`packet_size_bytes + 2 * aligned_page_size_bytes` (the l payload plus the s and m pages) —
3072 B for the shipped 4-device bf16 config with `(8,32)` tiles. Two destinations reserved
only `packet_size_bytes` (2048 B), so on each of the 8 shard cores 1 KB was written past
the end of a live L1 region, silently corrupting whatever followed:

1. `compute_output_specs` built the auto-computed intermediate tensor from *shard*
   dimensions with no `num_cores` factor, and passed `final_output_spec[0].tensor_layout()`
   straight through, so the tensor was `[8, 192]` carrying l's `[8, 128]` shard spec.
   That reserves 2048 B per bank on 2 of the 8 cores, while the fabric fused write
   (`sender_writer_kernel.cpp:53`) and the receive readers
   (`root_receive_reader_kernel.cpp:95`) use 3072 B at `intermediate_tensor.buffer()->address()`
   on all 8 cores.
2. CB `c_18` (`packet_cb_id_2`) was created with `packet_size_bytes`, while
   `root2_writer_kernel` fills it with `payload_size_bytes + 2 * aligned_page_size_bytes`
   and sends from its base, overrunning it by 2 pages into the next CB created for the
   root2 device, `c_11` / `compute_out_cb_l`.

### What's changed
- `reduce_to_root_op.cpp`: build the intermediate spec for the whole per-device tensor —
  `{shard_h, (shard_w + 2 * s_shard_w) * num_shard_cores}` — with its own
  `{shard_h, shard_w + 2 * s_shard_w}` shard spec on the l grid, keeping l's dtype, page
  config and buffer type via `TensorLayout::with_memory_config`. The result is identical to
  the intermediate `test_reduce_to_root_trace.py` passes in explicitly, so the
  caller-supplied and auto-computed paths now agree.
- `reduce_to_root_program.cpp`: size `c_18` for a full packet (`total_pkt_size`), the way
  its sibling `c_7` already was, and derive `total_pkt_size` from
  `2 * aligned_input_page_size_bytes` rather than a hard-coded `+ 1024`. The constant is
  unchanged for bf16 `(8,32)` tiles and now also correct for other dtypes and tile sizes.

No kernel, API or tensor-spec change is visible to callers; the op needs 1 KB more L1 per
shard core for the intermediate and 1 KB more for `c_18` on root2 devices.

**Proof the fix works**
(TM-Fabric) Fabric Tests:

Result before fix (main @ 06aaedf1f): [run 31446969553](https://github.com/tenstorrent/tt-metal/actions/runs/31446969553) — [BH-LoudBox ccl nightly](https://github.com/tenstorrent/tt-metal/actions/runs/31446969553/job/93848739913) 193 passed, 159 skipped, [BH-Quietbox-2](https://github.com/tenstorrent/tt-metal/actions/runs/31446969553/job/93848739234), [P300-viommu](https://github.com/tenstorrent/tt-metal/actions/runs/31446969553/job/93848739387). The op had no live coverage:
test_reduce_to_root_trace.py::test_reduce_to_root_with_trace[...fabric_1d_linear_trace] SKIPPED
SKIPPED [1] test_reduce_to_root_trace.py:90: Consistently failing with data mismatch after trace replay on all BH multi-chip setups. See #39098
Results after fix (tree ca8333c7e, run on 1b2cb3343): [run 31588558302](https://github.com/tenstorrent/tt-metal/actions/runs/31588558302) — [BH-LoudBox ccl nightly](https://github.com/tenstorrent/tt-metal/actions/runs/31588558302/job/94091046207) 195 passed, 158 skipped, [P300-viommu ccl nightly](https://github.com/tenstorrent/tt-metal/actions/runs/31588558302/job/94091015927) 54 passed, 299 skipped:
PASSED test_reduce_to_root_trace.py::test_reduce_to_root_with_trace[...fabric_1d_linear_trace]
PASSED test_reduce_to_root_trace.py::test_reduce_to_root_auto_intermediate[...fabric_1d_linear]

Nightly tt-metal L2 tests, same SKU before and after — [ccl nightly tests [bh_quietbox_2]](https://github.com/tenstorrent/tt-metal/actions/runs/31597345244/job/94118661339) went from **1 failed, 280 passed** on `dc23d69` to **281 passed** on `38b3c7f`. On `dc23d69` the re-enabled trace test aborted in `end_trace_capture` with `Out of Memory: Not enough space to allocate 139264 B TRACE buffer across 8 banks, where each bank needs to store 24576 B, but bank size is 32768 B`, before it could compare any output. That was the test's own budget, not the fix: it keeps the 15-iteration warmup trace (12288 B/bank) and the 30-iteration perf trace (24576 B/bank) live simultaneously, needing 36864 B/bank against the 32768 B/bank that `trace_region_size: 225280` provides. The trace buffer is in DRAM while this fix only grows L1, and the CB portion of a dispatch command is sized by CB index count rather than CB bytes (`tt_metal/impl/program/dispatch.cpp:319`), so bytes-per-captured-op are identical either way. `38b3c7f` raises the region to 524288, after which the test passes its data comparison — so the mismatch reported in #39098 no longer reproduces.

Remaining red on this branch is pre-existing on `main` or infrastructure, none of it touching `reduce_to_root`: `Galaxy CCL tests [wh_galaxy]` and `BH Galaxy CCL tests [bh_galaxy]` fail identically on the `main` nightly ([run 31569965089](https://github.com/tenstorrent/tt-metal/actions/runs/31569965089)) — the former on `strided_reduce_scatter_async` ncrisc build errors, the latter requesting a 32-device mesh on a 16-device host; the BH-Quietbox-2 fabric jobs never started (`Value cannot be null. (Parameter 'ContainerId')`); and `wh-6u-fabric-tests` plus the T3K throughput ubench are unrelated Wormhole failures.

### Verification pipelines

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/51235_bug_reduce_to_root)](https://github.com/tenstorrent/tt-metal/actions/workflows/tm-fabric-tests.yaml?query=branch:AlexeyZaytsev-epam/51235_bug_reduce_to_root)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/51235_bug_reduce_to_root)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/51235_bug_reduce_to_root)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pr-gate.yaml/badge.svg?branch=AlexeyZaytsev-epam/51235_bug_reduce_to_root)](https://github.com/tenstorrent/tt-metal/actions/workflows/pr-gate.yaml?query=branch:AlexeyZaytsev-epam/51235_bug_reduce_to_root)

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-static-checks.yaml/badge.svg?branch=AlexeyZaytsev-epam/51235_bug_reduce_to_root)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-static-checks.yaml?query=branch:AlexeyZaytsev-epam/51235_bug_reduce_to_root)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/merge-gate.yaml/badge.svg?branch=AlexeyZaytsev-epam/51235_bug_reduce_to_root)](https://github.com/tenstorrent/tt-metal/actions/workflows/merge-gate.yaml?query=branch:AlexeyZaytsev-epam/51235_bug_reduce_to_root)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/51235_bug_reduce_to_root)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/51235_bug_reduce_to_root)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/51235_bug_reduce_to_root)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/51235_bug_reduce_to_root)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/51235_bug_reduce_to_root)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/51235_bug_reduce_to_root)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/51235_bug_reduce_to_root)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/51235_bug_reduce_to_root)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/51235_bug_reduce_to_root)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/51235_bug_reduce_to_root)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/51235_bug_reduce_to_root)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/51235_bug_reduce_to_root)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/51235_bug_reduce_to_root)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/51235_bug_reduce_to_root)
