### PR TITLE
Stop double-storing BSPM DRAM experts on the cold path

### DIFF
--- a/models/demos/deepseek_v3_b1/weights/cache/bspm_expert_cache.py
+++ b/models/demos/deepseek_v3_b1/weights/cache/bspm_expert_cache.py
@@ -317,15 +317,27 @@ def get_or_create_bspm_expert_tp8(
             keep_packed_data=is_disk_cache,
         )
 
-    ct = cache.get_or_create(
+    if is_disk_cache and packed_artifact_id is not None and packed_fp is not None:
+        # Skip the source-weight store. Once packed artifacts exist the warm lookup above
+        # returns before this point, so ``_store_compressed``'s tiles.bin is written on every
+        # cold expert and then never read: it doubles the cold time (~259 ms of the ~508 ms)
+        # and the on-disk footprint (8.26 MB/expert/projection twice over). An already-present
+        # source entry is still honoured so caches built before this change keep their benefit.
+        source_entry = cache._lookup_compressed(compute_artifact_id(fingerprint))
+        if isinstance(source_entry, PresentCacheEntry):
+            inputs = cache._load_compressed(source_entry.paths.object_dir, target)
+        else:
+            tensors = raw_tensors() if callable(raw_tensors) else raw_tensors
+            inputs = _preprocess_and_slice(tensors)[target.name]
+        ct = _reconstruct(inputs, device)
+        artifacts = ct.extract_packed_artifacts(drop=True)
+        cache._store_sram_compressed(packed_artifact_id, packed_fp, artifacts)
+        return ct
+
+    return cache.get_or_create(
         fingerprint,
         device,
         preprocess=_preprocess_and_slice,
         raw_tensors=raw_tensors,
         reconstruct=_reconstruct,
     )
-
-    if is_disk_cache and packed_artifact_id is not None and packed_fp is not None:
-        artifacts = ct.extract_packed_artifacts(drop=True)
-        cache._store_sram_compressed(packed_artifact_id, packed_fp, artifacts)
-    return ct


### PR DESCRIPTION
get_or_create_bspm_expert_tp8 persisted both the preprocessed source weight (tiles.bin) and the packed BFP artifact (shards.bin), 8,257,536 bytes each, for every cold expert-projection. The packed-artifact lookup added by #44212 returns before the source cache is consulted, so once shards.bin exists the source copy can never be read again.

Measured on one 256-expert DeepSeek layer: the redundant store is ~259 ms of the ~508 ms cold time per expert-projection and half the on-disk footprint, i.e. ~2x on both. An already-present source entry is still honoured so caches built before this change keep their benefit.

Cold build of one layer drops from ~713 s / ~12 GB to ~496 s / 5.6 GB.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kwerblinski/bspm-drop-redundant-source-store)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kwerblinski/bspm-drop-redundant-source-store)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kwerblinski/bspm-drop-redundant-source-store)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kwerblinski/bspm-drop-redundant-source-store)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=kwerblinski/bspm-drop-redundant-source-store)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:kwerblinski/bspm-drop-redundant-source-store)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kwerblinski/bspm-drop-redundant-source-store)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kwerblinski/bspm-drop-redundant-source-store)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kwerblinski/bspm-drop-redundant-source-store)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kwerblinski/bspm-drop-redundant-source-store)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kwerblinski/bspm-drop-redundant-source-store)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kwerblinski/bspm-drop-redundant-source-store)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kwerblinski/bspm-drop-redundant-source-store)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kwerblinski/bspm-drop-redundant-source-store)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kwerblinski/bspm-drop-redundant-source-store)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kwerblinski/bspm-drop-redundant-source-store)