### PR TITLE
Fix AllGather BH CI machine requirement

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_all_gather_2d_fabric.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit/test_all_gather_2d_fabric.py
@@ -65,7 +65,13 @@ def test_all_gather_2d_fabric(
 @pytest.mark.parametrize("mesh_device", [(1, 4)], indirect=True)
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D, "trace_region_size": 90112}],
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+            "trace_region_size": 90112,
+            "require_exact_physical_num_devices": True,
+        }
+    ],
     indirect=True,
 )
 def test_all_gather_async_fabric_2d_folded_line(mesh_device):


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Fixes https://github.com/tenstorrent/tt-metal/issues/52628

The failing test was only intended to run on a 4-device machine (Quietbox), so adding that restriction.

Passing test: https://github.com/tenstorrent/tt-metal/actions/runs/31518292637

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=scardoza/fix-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:scardoza/fix-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=scardoza/fix-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:scardoza/fix-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=scardoza/fix-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:scardoza/fix-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=scardoza/fix-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:scardoza/fix-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=scardoza/fix-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:scardoza/fix-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=scardoza/fix-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:scardoza/fix-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=scardoza/fix-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:scardoza/fix-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=scardoza/fix-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:scardoza/fix-ci)