### PR TITLE
[IGNORE] Mini-recipe test

### DIFF
--- a/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/accumulation/ema/device/ema_program_factory.cpp
@@ -129,14 +129,31 @@ ttnn::device_operation::ProgramArtifacts EmaDeviceOperation::EmaProgramFactory::
 
     // Create kernel specs
     // -------------------
-    // This factory targets Gen1 (Wormhole / Blackhole) only. The two data movement kernels place
-    // the reader on RISCV_0 and the writer on RISCV_1, which is the reverse of the conventional
-    // assignment, so neither matches a role default and neither can go through the
-    // architecture-agnostic reader / writer helpers without changing where they run. Spelling out
-    // the Gen1 config is therefore what preserves the placement, and it pins this whole factory to
-    // Gen1: a Gen2 build would need placement decisions that cannot be derived from these values.
+    // The two data movement kernels place the reader on RISCV_0 and the writer on RISCV_1, which is
+    // the reverse of the conventional assignment, so neither matches a role default and neither can
+    // go through the architecture-agnostic reader / writer helpers without changing where they run.
+    // Spelling out the Gen1 config is what preserves that placement.
+    //
+    // Gen2 (Quasar) has no placement to preserve: RISC core and NOC selection are automatic there,
+    // and DataMovementGen2Config shares no field with the Gen1 config. Its default is therefore the
+    // whole Gen2 answer, and it is the same one the architecture-agnostic helpers give on Quasar.
     tt::tt_metal::NOC writer_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
     tt::tt_metal::NOC reader_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
+
+    DataMovementHardwareConfig reader_hw_config = DataMovementGen1Config{
+        .processor = DataMovementProcessor::RISCV_0,
+        .noc = reader_noc,
+    };
+
+    DataMovementHardwareConfig writer_hw_config = DataMovementGen1Config{
+        .processor = DataMovementProcessor::RISCV_1,
+        .noc = writer_noc,
+    };
+
+    if (device->arch() == tt::ARCH::QUASAR) {
+        reader_hw_config = DataMovementGen2Config{};
+        writer_hw_config = DataMovementGen2Config{};
+    }
 
     KernelSpec reader{
         .unique_id = EMA_READER,
@@ -152,10 +169,7 @@ ttnn::device_operation::ProgramArtifacts EmaDeviceOperation::EmaProgramFactory::
         }},
         .compile_time_args = {{"total_tiles_per_core", total_tiles_per_core}},
         .runtime_arg_schema = {.runtime_arg_names = {"src_start_tile"}},
-        .hw_config = DataMovementHardwareConfig{DataMovementGen1Config{
-            .processor = DataMovementProcessor::RISCV_0,
-            .noc = reader_noc,
-        }},
+        .hw_config = reader_hw_config,
     };
 
     KernelSpec writer{
@@ -172,10 +186,7 @@ ttnn::device_operation::ProgramArtifacts EmaDeviceOperation::EmaProgramFactory::
         }},
         .compile_time_args = {{"total_tiles_per_core", total_tiles_per_core}},
         .runtime_arg_schema = {.runtime_arg_names = {"dst_start_tile"}},
-        .hw_config = DataMovementHardwareConfig{DataMovementGen1Config{
-            .processor = DataMovementProcessor::RISCV_1,
-            .noc = writer_noc,
-        }},
+        .hw_config = writer_hw_config,
     };
 
     KernelSpec compute{
@@ -212,8 +223,8 @@ ttnn::device_operation::ProgramArtifacts EmaDeviceOperation::EmaProgramFactory::
              {"alpha_bits", alpha_bits},
              {"beta_bits", beta_bits}},
         // Translates the TTNN ComputeKernelConfig this op resolves into its Metal 2.0 equivalent.
-        // The helper picks the alternative matching the architecture, but that does not make the
-        // program portable: the data movement kernels above are Gen1-only, so the whole factory is.
+        // The helper picks the alternative matching the architecture and sets every field it owns,
+        // so this spec needs no architecture branch of its own.
         .hw_config = ttnn::to_compute_hardware_config(device->arch(), operation_attributes.compute_kernel_config),
     };
 


### PR DESCRIPTION
ema's reader and writer KernelSpecs carried hand-written DataMovementGen1Config values and no Gen2 alternative, so the op cannot run on Quasar at all. The configs are deliberate: the reader sits on RISCV_0 and the writer on RISCV_1, the reverse of the conventional assignment, which is why the factory does not use the arch-agnostic reader/writer helpers.

Hoist both Gen1 configs to DataMovementHardwareConfig locals -- initializers moved verbatim, not retyped -- and add a single arch branch replacing both with a default-constructed DataMovementGen2Config{}. Gen2 has no field in common with the Gen1 config: RISC core and NOC placement do not exist as concepts there, so there is nothing to map and the default is the whole Gen2 answer. It is also what the arch-agnostic helpers produce on Quasar, so this matches existing behaviour rather than inventing any.

The Gen1 path is textually unchanged -- same fields, same values, same order -- verified by reading the diff, since a config change would show up as a performance or precision shift rather than a test failure. In particular the custom configs were not rerouted through the arch-agnostic helpers to get the Gen2 branch for free, which would have silently flipped the reversed RISC placement this factory exists to preserve.

Implicit sync is left on by default: neither disable_dfb_implicit_sync_for_all nor its per-buffer sibling is set.

Two comments asserting the factory is Gen1-only are falsified by this change and have been rewritten. Note the first one's premise was already wrong: it said a Gen2 build "would need placement decisions that cannot be derived from these values", but Gen2 has no placement concept to decide.

Sentinels: tests/ttnn/unit_tests/operations/reduce/test_ema.py -- 3 passed before and after, same three test IDs. Nothing on Gen1 hardware exercises the Gen2 branch, so its correctness rests on the mapping being mechanical rather than on measurement.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/ema-gen2-hardware-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/ema-gen2-hardware-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/ema-gen2-hardware-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/ema-gen2-hardware-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=akertesz/ema-gen2-hardware-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:akertesz/ema-gen2-hardware-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/ema-gen2-hardware-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/ema-gen2-hardware-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/ema-gen2-hardware-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/ema-gen2-hardware-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/ema-gen2-hardware-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/ema-gen2-hardware-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/ema-gen2-hardware-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/ema-gen2-hardware-config)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/ema-gen2-hardware-config)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/ema-gen2-hardware-config)