### PR TITLE
Feature: add single stage support for pipeline builder

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_pipeline_builder.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_pipeline_builder.cpp
@@ -109,6 +109,17 @@ std::vector<EdgeInputTuple> build_ring_edges(std::size_t num_stages) {
     return edges;
 }
 
+// Declaration-ordered node names for the same ring. resolve_graph_layout takes the node
+// list as authoritative, so every endpoint build_ring_edges() references must appear here.
+std::vector<std::string> build_ring_nodes(std::size_t num_stages) {
+    std::vector<std::string> nodes;
+    nodes.reserve(num_stages);
+    for (std::size_t i = 0; i < num_stages; ++i) {
+        nodes.emplace_back(fmt::format("s{}", i));
+    }
+    return nodes;
+}
+
 FabricNodeId fabric_node_at_local_coord(
     const std::vector<SubmeshLayout>& layouts, std::size_t submesh_idx, uint32_t local_row, uint32_t local_col) {
     const auto& chips = layouts.at(submesh_idx).chips;
@@ -259,7 +270,8 @@ TEST_F(ControlPlaneFixture, TestPipelineBuilderCheck) {
         GTEST_SKIP() << "all-1x1 host-rank slices: resolve_graph_layout requires a distinct exit chip per stage";
     }
 
-    const GraphLayoutResult result = resolve_graph_layout(build_ring_edges(layouts.size()), to_submesh_chips(layouts));
+    const GraphLayoutResult result = resolve_graph_layout(
+        build_ring_nodes(layouts.size()), build_ring_edges(layouts.size()), to_submesh_chips(layouts));
 
     for (const auto& edge : result.resolved_edges) {
         const std::size_t src_sub = result.node_to_submesh.at(edge.src);

--- a/tt_metal/api/tt-metalium/experimental/fabric/pipeline_builder.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/pipeline_builder.hpp
@@ -71,6 +71,11 @@ struct GraphLayoutResult {
 
 /// Auto-discover the physical layout of a pipeline graph.
 ///
+/// @param nodes         All node names in the graph, in declaration order.  This is the
+///                      authoritative node list: it lets the resolver handle graphs whose
+///                      nodes are not all covered by edges — e.g. a single-stage pipeline
+///                      with no edges at all.  Every endpoint referenced by @p edges must
+///                      appear here; a missing endpoint raises std::runtime_error.
 /// @param edges         Graph edges as (src_name, dst_name, is_loopback) tuples.
 ///                      Non-loopback edges define the DAG; the single loopback edge
 ///                      (if present) is the return path from the last stage to stage 0.
@@ -86,6 +91,7 @@ struct GraphLayoutResult {
 /// @returns             GraphLayoutResult with physical coords for every edge and
 ///                      unclaimed H2D/D2H chip coords in stage-0's submesh.
 GraphLayoutResult resolve_graph_layout(
+    const std::vector<std::string>& nodes,
     const std::vector<EdgeInputTuple>& edges,
     const std::vector<std::vector<ChipTuple>>& submesh_chips,
     const std::map<std::string, uint32_t>& node_chip_counts = {});

--- a/tt_metal/fabric/pipeline_builder.cpp
+++ b/tt_metal/fabric/pipeline_builder.cpp
@@ -270,6 +270,7 @@ std::map<std::string, size_t> assign_submeshes(
 }  // anonymous namespace
 
 GraphLayoutResult resolve_graph_layout(
+    const std::vector<std::string>& nodes,
     const std::vector<EdgeInputTuple>& edges,
     const std::vector<std::vector<ChipTuple>>& submesh_chips,
     const std::map<std::string, uint32_t>& node_chip_counts) {
@@ -290,18 +291,23 @@ GraphLayoutResult resolve_graph_layout(
     auto connections = discover_connections(chips);
 
     // ------------------------------------------------------------------
-    // 2. Collect unique node names and separate loopback edges
+    // 2. Collect node names.
+    //
+    // The explicit `nodes` list is authoritative, so graphs whose nodes are
+    // not all covered by edges (e.g. a single-stage pipeline with no edges)
+    // still register every node.  Every endpoint referenced by an edge must
+    // appear in `nodes`; an edge referencing an unlisted node is an error.
     // ------------------------------------------------------------------
-    std::vector<std::string> all_nodes;
-    all_nodes.reserve(edges.size() * 2);
+    std::vector<std::string> all_nodes = nodes;
     {
-        std::set<std::string> seen;
+        // Check all nodes in edges to ensure they are all registered.
+        std::set<std::string> node_set(nodes.begin(), nodes.end());
         for (const auto& [src, dst, is_lb] : edges) {
-            if (seen.insert(src).second) {
-                all_nodes.push_back(src);
+            if (!node_set.contains(src)) {
+                throw std::runtime_error("resolve_graph_layout: node " + src + " not found in the explicit nodes list");
             }
-            if (seen.insert(dst).second) {
-                all_nodes.push_back(dst);
+            if (!node_set.contains(dst)) {
+                throw std::runtime_error("resolve_graph_layout: node " + dst + " not found in the explicit nodes list");
             }
         }
     }

--- a/tt_metal/fabric/pipeline_builder.cpp
+++ b/tt_metal/fabric/pipeline_builder.cpp
@@ -183,6 +183,13 @@ std::map<std::string, size_t> assign_submeshes(
                 if (!is_lb) {
                     continue;
                 }
+                // A self-loop is satisfied trivially: a single-stage graph's return path
+                // never leaves its submesh, so there is no inter-submesh link to require.
+                // discover_connections() skips i == j, so demanding one here would make
+                // every single-stage graph unassignable.
+                if (src == dst) {
+                    continue;
+                }
                 size_t si = node_to_sub.at(src);
                 size_t sj = node_to_sub.at(dst);
                 if (!connections.contains({si, sj})) {
@@ -328,6 +335,12 @@ GraphLayoutResult resolve_graph_layout(
     std::vector<ResolvedEdge> resolved_edges;
     resolved_edges.reserve(edges.size());
     for (const auto& [src, dst, is_lb] : edges) {
+        // Self-loop: no physical hop to resolve (see assign_submeshes). It is left out of
+        // resolved_edges deliberately — a single-stage caller reads its entry/exit from
+        // h2d_entry_* / d2h_exit_* below, not from a per-edge entry.
+        if (src == dst) {
+            continue;
+        }
         size_t si = node_to_sub.at(src);
         size_t sj = node_to_sub.at(dst);
         auto it = connections.find({si, sj});

--- a/tt_metal/fabric/pipeline_builder.cpp
+++ b/tt_metal/fabric/pipeline_builder.cpp
@@ -305,7 +305,7 @@ GraphLayoutResult resolve_graph_layout(
     // still register every node.  Every endpoint referenced by an edge must
     // appear in `nodes`; an edge referencing an unlisted node is an error.
     // ------------------------------------------------------------------
-    std::vector<std::string> all_nodes = nodes;
+    const std::vector<std::string>& all_nodes = nodes;
     {
         // Check all nodes in edges to ensure they are all registered.
         std::set<std::string> node_set(nodes.begin(), nodes.end());

--- a/ttnn/cpp/ttnn-nanobind/pipeline_module_nanobind.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pipeline_module_nanobind.cpp
@@ -235,11 +235,13 @@ void bind_pipeline_builder(nb::module_& mod) {
 
     mod.def(
         "resolve_graph_layout",
-        [](const std::vector<tt::tt_fabric::EdgeInputTuple>& edges,
+        [](const std::vector<std::string>& nodes,
+           const std::vector<tt::tt_fabric::EdgeInputTuple>& edges,
            const std::vector<std::vector<tt::tt_fabric::ChipTuple>>& submesh_chips,
            const std::map<std::string, uint32_t>& node_chip_counts) -> tt::tt_fabric::GraphLayoutResult {
-            return tt::tt_fabric::resolve_graph_layout(edges, submesh_chips, node_chip_counts);
+            return tt::tt_fabric::resolve_graph_layout(nodes, edges, submesh_chips, node_chip_counts);
         },
+        nb::arg("nodes") = std::vector<std::string>{},
         nb::arg("edges"),
         nb::arg("submesh_chips"),
         nb::arg("node_chip_counts") = std::map<std::string, uint32_t>{},
@@ -251,9 +253,15 @@ void bind_pipeline_builder(nb::module_& mod) {
             topological sort and backtracking submesh assignment.
 
             Args:
+                nodes:         List of all node names in declaration order.  Authoritative
+                               node list, so graphs whose nodes are not all covered by
+                               edges (e.g. a single-stage pipeline with no edges) are
+                               handled.  Every endpoint referenced by ``edges`` must appear
+                               here or a RuntimeError is raised.
                 edges:         List of (src_name, dst_name, is_loopback) tuples describing
                                the pipeline graph.  Set is_loopback=True for the return
-                               edge from the last stage back to stage 0.
+                               edge from the last stage back to stage 0.  A self-loop
+                               (src == dst) is allowed and satisfied trivially.
                 submesh_chips: For each submesh, a list of (mesh_id, chip_id, row, col)
                                tuples (obtained from submesh.get_fabric_node_id()).
                 node_chip_counts: Optional {node_name: expected_chip_count} map. When a


### PR DESCRIPTION
### PR Category
Feature

### Summary
Before this change, `resolve_graph_layout` built its node list from the graph edges.
A node existed only if an edge referenced it.

This makes a single-stage pipeline impossible to express. A single stage has no d2d
hop. It therefore has no edges. With no edges, the resolver finds no nodes, and it
places nothing.

This PR adds an explicit `nodes` parameter. The list is in declaration order. It is
now the authoritative node list. Node registration no longer depends on edge coverage.
A graph with one node and no edges now resolves, and the stage receives a submesh
assignment.

Edges keep their current role. The non-loopback edges define the DAG. The loopback
edge is the return path from the last stage to stage 0.

The `nodes` list is authoritative, so an edge can no longer declare a node. The
resolver validates both endpoints of every edge against the list. If an endpoint is
missing, the resolver raises `std::runtime_error`.

This change supports the tt-blaze single-stage runner. That runner drives one
`GenericStage` harness host-to-host on a single-node graph.

### Related

tt-blaze consumer branch:
[`tenstorrent/tt-blaze@mkamran/pipeline_builder_single_stage_support`](https://github.com/tenstorrent/tt-blaze/tree/mkamran/pipeline_builder_single_stage_support)

- `b8281223` — adds `SingleStageRunner` (`blaze/stages/stage.py`), which builds a
  one-node graph and drives a single `GenericStage` harness host-to-host. It is the
  caller that needs this change: with no explicit `nodes` list, its lone node is
  invisible to the resolver.
- `e770e34e` — updates the call site in `pipeline_builder/graph.py` to pass
  `nodes=list(self.nodes.keys())`.

**These must land together.** Before this PR, `nodes=` is an unexpected keyword and
raises `TypeError`. After it, omitting `nodes` binds successfully and then throws
inside the resolver on the first edge. No single tt-blaze revision works against both
tt-metal revisions, so tt-blaze cannot move its submodule pointer to this commit until
this PR merges.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mkamran/pipeline_builder_single_stage_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mkamran/pipeline_builder_single_stage_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mkamran/pipeline_builder_single_stage_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mkamran/pipeline_builder_single_stage_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mkamran/pipeline_builder_single_stage_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mkamran/pipeline_builder_single_stage_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mkamran/pipeline_builder_single_stage_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mkamran/pipeline_builder_single_stage_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mkamran/pipeline_builder_single_stage_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mkamran/pipeline_builder_single_stage_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mkamran/pipeline_builder_single_stage_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mkamran/pipeline_builder_single_stage_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mkamran/pipeline_builder_single_stage_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mkamran/pipeline_builder_single_stage_support)