### PR TITLE
Add support to generic moe gate for k=9..15

### DIFF
--- a/tt_metal/hw/inc/api/compute/experimental/generic_moe_gate.h
+++ b/tt_metal/hw/inc/api/compute/experimental/generic_moe_gate.h
@@ -40,12 +40,8 @@ template <
     bool full_sort = false,
     bool generate_indices = true>
 ALWI void generic_moe_gate(uint32_t icb0, uint32_t icb1, uint32_t eps, uint32_t scale) {
-    // NOTE: only num_selected_experts == 16 selects the top-16 SFPU path; every other value routes to
-    // top-8, which emits at most eight winners, so 9..15 silently yield 8 rather than the requested
-    // count. Deliberately not static_assert'd here: callers currently advertise a wider contract (blaze's
-    // gptoss_moe_router validates 1..16 and forwards it straight through), so constraining it here alone
-    // would turn a reachable-but-wrong configuration into a build break. Caller validation and this
-    // template have to be tightened together.
+    static_assert(num_selected_experts >= 1 && num_selected_experts <= 16);
+
     // Copy add (FPU)
     UNPACK((llk_unpack_AB(icb0, icb1, 0, 0)));
     MATH((llk_math_deepseek_moe_gate_eltwise_binary<EltwiseBinaryType::ELWADD, DST_ACCUM_MODE, MATH_FIDELITY>(

--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_generic_moe_gate_topk.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_generic_moe_gate_topk.py
@@ -21,28 +21,24 @@ Layout, for num_total_experts == 256
 The 256 experts occupy face 0 of the tile with id = 16 * row + column -- that is what
 `_topk_moe_generate_indices_` writes (LTILEID-seeded, stored to the even and odd
 column halves of each row band). The winners come back in COLUMN 0 ("lane 0") of DEST
-rows 0-7. `_generic_moe_gate_top8_merge_instances_` is a reduce-to-one-lane
-rotate-and-merge network, not an all-reduce, so the other even columns are left
-holding partial merges (measured: they contain ids outside the top-8) and only lane 0
-is meaningful. The top-8 path never writes the odd columns; the top-16 path does
+rows 0-7 on the top-8 path and rows 0-15 on the top-16 path.
+`_generic_moe_gate_top8_merge_instances_` is a reduce-to-one-lane rotate-and-merge
+network, not an all-reduce, so the other even columns are left holding partial merges
+(measured: they contain ids outside the top-8) and only lane 0 is meaningful. The
+top-8 path never writes the odd columns; the top-16 path does
 (`_generic_moe_gate_store_16_rows_even_odd_split_` stores both halves), which is why
 the odd-column check below is restricted to the top-8 path.
 
 How many winners come back
 --------------------------
-`_generic_moe_gate_topk_` routes num_selected_experts == 16 to the top-16 path, which
-emits 16 winner rows; every other value routes to top-8, which emits eight rows
-regardless of what was asked for. api/compute/experimental/generic_moe_gate.h documents
-that and deliberately does not static_assert it, because blaze's gptoss_moe_router
-validates 1..16 and forwards straight through.
+`_generic_moe_gate_topk_` routes num_selected_experts > 8 to the top-16 path, which
+emits 16 winner rows; values <= 8 route to top-8, which emits eight rows.
 
-On the top-8 path the tail beyond num_selected_experts is blanked -- id 0, score 0.0 --
-exactly when `zero_tail || (normalize && num_selected_experts < 8)`, which is the
-condition on top8.h:245 guarding `_generic_moe_gate_top8_zero_tail_`. So for
-num_selected_experts=4 the live winner count is 4 with either flag set and 8 with
-neither, and with normalize the denominator is the sum over the live winners only --
-which is the point of blanking before `_generic_moe_gate_normalize_` runs. All measured
-on Blackhole; `_expected_live_winners` encodes the rule.
+On either path the tail beyond num_selected_experts is blanked -- id 0, score 0.0 --
+when `zero_tail || normalize`. With neither flag, the entire 8- or 16-row result
+remains live. With normalize, blanking happens before `_generic_moe_gate_normalize_`
+so its denominator contains only the requested winners. `_expected_live_winners`
+encodes this rule.
 
 num_selected_experts=4 is also distinct code beyond the tail: with full_sort=False,
 `_generic_moe_gate_top8_sort_rows_<4, false>` takes the SFPSWAP + TTI_NOP branch that
@@ -50,12 +46,10 @@ num_selected_experts=8 never reaches.
 
 What this test asserts, and why in this form
 --------------------------------------------
-Row order is asserted only on the top-8 path with full_sort=True, where the winner rows
-do come back in descending-key order (measured). full_sort=False gives a partial order
-there -- measured [1, 3, 4, 5, 7, 8, 6, 2] by golden rank -- which is what the flag
-means. The top-16 path returns an unordered set even with full_sort=True (measured
-[1, 3, 4, 5, 7, 8, 9, 10, 16, 15, 14, 13, 12, 11, 6, 2]), so order is not asserted
-there at all. Callers consume the winners as a set either way. The checks are:
+Row order is asserted whenever full_sort=True. full_sort=False gives a partial order
+on the top-8 path; the intermediate 9-15 path still performs the final 16-row sort
+because truncation requires the requested winners to occupy the leading rows. The
+checks are:
   1. the live winner id set == the golden top-N id set, for the N above;
   2. every returned score matches the normalized original score of the id it is
      paired with -- this is the check that would catch a payload/key mix-up, which is
@@ -130,18 +124,15 @@ def _expected_live_winners(
 ) -> tuple[int, int]:
     """(rows the path emits, rows that hold a live winner) for one configuration.
 
-    The top-8 path blanks the tail beyond num_selected_experts exactly when
-    top8.h:245's `zero_tail || (normalize && num_selected_experts < 8)` holds. The
-    top-16 path only runs for num_selected_experts == 16, where there is no tail to
-    blank, so zero_tail does not reach the rows this test reads (it zeroes DEST rows
-    8-15 of the top-8 path's tiles).
+    The top-8 path emits eight rows and the top-16 path emits sixteen. On either
+    path, normalize or zero_tail blanks rows beyond num_selected_experts.
     """
-    if num_selected_experts == TOP16_WINNERS:
-        return TOP16_WINNERS, TOP16_WINNERS
-
-    if num_selected_experts < TOP8_WINNERS and (normalize or zero_tail):
-        return TOP8_WINNERS, num_selected_experts
-    return TOP8_WINNERS, TOP8_WINNERS
+    emitted_rows = (
+        TOP16_WINNERS if num_selected_experts > TOP8_WINNERS else TOP8_WINNERS
+    )
+    if num_selected_experts < emitted_rows and (normalize or zero_tail):
+        return emitted_rows, num_selected_experts
+    return emitted_rows, emitted_rows
 
 
 def _distinct_bf16_keys() -> torch.Tensor:
@@ -202,7 +193,7 @@ def assert_odd_columns_untouched(result_indices, result_scores, scores, rows):
 
 @skip_for_wormhole
 @parametrize(
-    num_selected_experts=[8, 4, 16],
+    num_selected_experts=[4, 8, *range(9, 17)],
     full_sort=[True, False],
     normalize=[True, False],
     zero_tail=[False, True],
@@ -290,7 +281,7 @@ def test_sfpu_generic_moe_gate_topk(
     emitted_rows, num_winners = _expected_live_winners(
         num_selected_experts, normalize, zero_tail
     )
-    is_top16 = num_selected_experts == TOP16_WINNERS
+    is_top16_path = num_selected_experts > TOP8_WINNERS
 
     golden_generator = get_golden_generator(MoeGateTopkGolden)
     scale = _bits_to_float(SCALE_BITS)
@@ -323,10 +314,8 @@ def test_sfpu_generic_moe_gate_topk(
         expected_paired, got_scores, formats.output_format, print_errors=True
     ), "returned scores are not the (normalized) original scores of the returned ids"
 
-    # On the top-8 path full_sort delivers a fully ordered winner set. Without it the
-    # rows come back in a partial order, and on the top-16 path they are unordered even
-    # with full_sort=True (measured), so there only the set above is asserted.
-    if full_sort and not is_top16:
+    # full_sort must keep each score paired with its id while ordering by biased key.
+    if full_sort:
         assert got_ids == golden_ids, (
             f"full_sort=True must return the winners in descending-key order.\n"
             f"  got    {got_ids}\n"
@@ -343,7 +332,7 @@ def test_sfpu_generic_moe_gate_topk(
             f"got id {got_id}, score {got_score}"
         )
 
-    if not is_top16:
+    if not is_top16_path:
         # All eight emitted rows, blanked ones included -- the tail zeroing hits the
         # even-column payload, never the odd columns.
         assert_odd_columns_untouched(

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_generic_moe_gate_topk.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_generic_moe_gate_topk.h
@@ -95,6 +95,51 @@ inline void _generic_moe_gate_store_8_rows_even_odd_split_()
     TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_scores_tile + 4 + offset);
 }
 
+template <int num_selected_experts>
+inline void _generic_moe_gate_zero_tail_lregs_()
+{
+    static_assert(num_selected_experts >= 1 && num_selected_experts <= 8);
+
+    if constexpr (num_selected_experts > 4)
+    {
+        TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_interm_tile);
+        TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_interm_tile + 2);
+    }
+    else
+    {
+        TTI_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_FLOATB, 0);
+    }
+    if constexpr (num_selected_experts != 4 && num_selected_experts != 8)
+    {
+        TTI_SFPTRANSP(0, 0, 0, 0);
+
+        TTI_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_FLOATB, 0);
+        if constexpr (num_selected_experts != 7 && num_selected_experts != 3)
+        {
+            TTI_SFPLOADI(p_sfpu::LREG6, sfpi::SFPLOADI_MOD0_FLOATB, 0);
+            if constexpr (num_selected_experts != 6 && num_selected_experts != 2)
+            {
+                TTI_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_FLOATB, 0);
+            }
+        }
+
+        TTI_SFPTRANSP(0, 0, 0, 0);
+    }
+    if constexpr (num_selected_experts > 4)
+    {
+        TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_interm_tile);
+        TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_interm_tile + 2);
+    }
+}
+
+template <int num_selected_experts, std::uint32_t offset>
+inline void _generic_moe_gate_zero_tail_()
+{
+    _generic_moe_gate_load_8_rows_even_odd_split_<offset>();
+    _generic_moe_gate_zero_tail_lregs_<num_selected_experts>();
+    _generic_moe_gate_store_8_rows_even_odd_split_<offset>();
+}
+
 // Shared P1-P3 network: build a length-16 bitonic sequence in LREG0-3.
 inline void _generic_moe_gate_build_bitonic8_()
 {
@@ -244,9 +289,9 @@ inline void _generic_moe_gate_topk_(std::uint32_t eps, std::uint32_t scale)
     }
     TTI_SFPCONFIG(0x4, 0xF, 1);
 
-    if constexpr (num_selected_experts == 16)
+    if constexpr (num_selected_experts > 8)
     {
-        _generic_moe_gate_top16_<normalize, num_total_experts>(eps, scale);
+        _generic_moe_gate_top16_<normalize, num_selected_experts, num_total_experts, zero_tail, full_sort>(eps, scale);
     }
     else
     {

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_generic_moe_gate_topk_top16.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_generic_moe_gate_topk_top16.h
@@ -259,11 +259,24 @@ inline void _generic_moe_gate_top16_merge_instances_()
     _generic_moe_gate_top16_store_outputs_();
 }
 
-template <bool normalize, int num_total_experts>
+template <bool normalize, int num_selected_experts, int num_total_experts, bool zero_tail, bool full_sort>
 inline void _generic_moe_gate_top16_(std::uint32_t eps, std::uint32_t scale)
 {
+    static_assert(num_selected_experts >= 9 && num_selected_experts <= 16);
+
     _generic_moe_gate_top16_sort_to_instance_<num_total_experts>();
     _generic_moe_gate_top16_merge_instances_();
+
+    if constexpr (num_selected_experts < 16 || full_sort)
+    {
+        _generic_moe_gate_top16_bitonic16_directional_<0>();
+        _generic_moe_gate_top16_store_outputs_();
+    }
+
+    if constexpr (num_selected_experts < 16 && (zero_tail || normalize))
+    {
+        _generic_moe_gate_zero_tail_<num_selected_experts - 8, 8>();
+    }
 
     if constexpr (normalize)
     {

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_generic_moe_gate_topk_top8.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_generic_moe_gate_topk_top8.h
@@ -149,41 +149,6 @@ inline void _generic_moe_gate_top8_sort_half_face_()
     }
 }
 
-template <int num_selected_experts>
-inline void _generic_moe_gate_top8_zero_tail_()
-{
-    if constexpr (num_selected_experts > 4)
-    {
-        TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_interm_tile);
-        TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_interm_tile + 2);
-    }
-    else if (num_selected_experts <= 4)
-    {
-        TTI_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_FLOATB, 0);
-    }
-    if constexpr (num_selected_experts != 4 && num_selected_experts != 8)
-    {
-        TTI_SFPTRANSP(0, 0, 0, 0);
-
-        TTI_SFPLOADI(p_sfpu::LREG7, sfpi::SFPLOADI_MOD0_FLOATB, 0);
-        if constexpr (num_selected_experts != 7 && num_selected_experts != 3)
-        {
-            TTI_SFPLOADI(p_sfpu::LREG6, sfpi::SFPLOADI_MOD0_FLOATB, 0);
-            if constexpr (num_selected_experts != 6 && num_selected_experts != 2)
-            {
-                TTI_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_FLOATB, 0);
-            }
-        }
-
-        TTI_SFPTRANSP(0, 0, 0, 0);
-    }
-    if constexpr (num_selected_experts > 4)
-    {
-        TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::LO16_ONLY, ADDR_MOD_7, generic_moe_gate_interm_tile);
-        TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::HI16_ONLY, ADDR_MOD_7, generic_moe_gate_interm_tile + 2);
-    }
-}
-
 template <std::uint32_t face_idx, bool full_face, bool store_result>
 inline void _generic_moe_gate_top8_accumulate_face_()
 {
@@ -244,7 +209,7 @@ inline void _generic_moe_gate_top8_(std::uint32_t eps, std::uint32_t scale)
 
     if constexpr (zero_tail || (normalize && num_selected_experts < 8))
     {
-        _generic_moe_gate_top8_zero_tail_<num_selected_experts>();
+        _generic_moe_gate_zero_tail_lregs_<num_selected_experts>();
     }
 
     _generic_moe_gate_store_8_rows_even_odd_split_<0>();


### PR DESCRIPTION
### PR Category
Feature

### Summary
topk moe generic gate only supports k=1..8,16 right now. Needed to add k=9..15 also with full support for full_sort and zero_tail flags

### Notes for reviewers
Porting this over

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pgardner/topk-9-15-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pgardner/topk-9-15-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pgardner/topk-9-15-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pgardner/topk-9-15-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pgardner/topk-9-15-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pgardner/topk-9-15-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pgardner/topk-9-15-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pgardner/topk-9-15-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pgardner/topk-9-15-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pgardner/topk-9-15-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pgardner/topk-9-15-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pgardner/topk-9-15-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pgardner/topk-9-15-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pgardner/topk-9-15-metal)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pgardner/topk-9-15-metal)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pgardner/topk-9-15-metal)