### PR TITLE
Support padding on every dimension of a rank > 4 tensor in ttnn.pad

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
@@ -1341,6 +1341,36 @@ def _ttnn_padding_to_torch(padding):
     return tuple(v for i in reversed(range(len(padding))) for v in padding[i])
 
 
+def _assert_pad_fill_regions(output_tensor, input_shape, padding, value):
+    """Exact check that every padded slice equals the fill value."""
+    for dim, (before, after) in enumerate(padding):
+        if before:
+            slices = [slice(None)] * len(input_shape)
+            slices[dim] = slice(0, before)
+            assert torch.all(output_tensor[tuple(slices)] == value)
+        if after:
+            slices = [slice(None)] * len(input_shape)
+            slices[dim] = slice(before + input_shape[dim], before + input_shape[dim] + after)
+            assert torch.all(output_tensor[tuple(slices)] == value)
+
+
+def _assert_pad_body_matches(output_tensor, input_tensor, padding, *, atol=0.0):
+    """Check the unpadded region matches the input."""
+    slices = []
+    for dim, (before, _after) in enumerate(padding):
+        slices.append(slice(before, before + input_tensor.shape[dim]))
+    body_out = output_tensor[tuple(slices)]
+    if atol == 0.0:
+        assert torch.equal(body_out, input_tensor)
+    else:
+        assert_allclose(body_out.float(), input_tensor.float(), rtol=0, atol=atol)
+
+
+# Rank > 4 regression coverage below exercises ttnn.pad on device. The Quasar mirror
+# (ttnn.experimental.quasar.pad / experimental/quasar/pad/pad.cpp) carries the same
+# logic and is verified-by-inspection, same as the Quasar slice fix in #52902.
+
+
 @pytest.mark.parametrize(
     "shape,padding",
     [
@@ -1480,31 +1510,41 @@ def test_pad_rank_gt4_tile_bfloat8_b(device, padding):
     """bfloat8_b is padded via a bfloat16 round trip; make sure the rank > 4 path preserves that."""
     torch.manual_seed(0)
     shape = (1, 4, 4, 32, 128)
+    value = 7.0
 
     torch_input_tensor = torch.randn(shape, dtype=torch.bfloat16)
-    torch_output_tensor = torch.nn.functional.pad(torch_input_tensor, _ttnn_padding_to_torch(padding), value=0.0)
+    torch_output_tensor = torch.nn.functional.pad(torch_input_tensor, _ttnn_padding_to_torch(padding), value=value)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
-    output_tensor = ttnn.to_torch(ttnn.pad(input_tensor, padding, 0.0))
+    output_tensor = ttnn.to_torch(ttnn.pad(input_tensor, padding, value))
 
     assert output_tensor.shape == torch_output_tensor.shape
-    assert_with_pcc(torch_output_tensor.float(), output_tensor.float(), 0.999)
+    _assert_pad_fill_regions(output_tensor, shape, padding, value)
+    _assert_pad_body_matches(output_tensor, torch_input_tensor, padding, atol=0.05)
 
 
 @pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
 @pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
-def test_pad_rank_gt4_memory_config(device, layout, memory_config):
+@pytest.mark.parametrize(
+    "shape,padding",
+    [
+        # Single leading dim: trailing squeeze path still applies memory_config.
+        ((1, 4, 4, 32, 128), ((0, 0), (0, 1), (0, 0), (0, 0), (0, 0))),
+        # Multiple leading dims only: memory_config must be applied after the reshape passes.
+        ((2, 4, 4, 4, 128), ((0, 1), (0, 2), (0, 0), (0, 0), (0, 0))),
+    ],
+    ids=["single_leading_dim", "all_leading_dims"],
+)
+def test_pad_rank_gt4_memory_config(device, layout, memory_config, shape, padding):
     """The requested output memory config must survive the reshape/pad/reshape round trip."""
     torch.manual_seed(0)
-    shape = (1, 4, 4, 32, 128)
-    # Tile layout does not support front padding on device.
-    padding = ((0, 0), (0, 1), (0, 0), (0, 0), (0, 0))
+    value = 0.0
 
     torch_input_tensor = torch.randn(shape, dtype=torch.bfloat16)
-    torch_output_tensor = torch.nn.functional.pad(torch_input_tensor, _ttnn_padding_to_torch(padding), value=0.0)
+    torch_output_tensor = torch.nn.functional.pad(torch_input_tensor, _ttnn_padding_to_torch(padding), value=value)
 
     input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=layout, device=device)
-    output = ttnn.pad(input_tensor, padding, 0.0, memory_config=memory_config)
+    output = ttnn.pad(input_tensor, padding, value, memory_config=memory_config)
 
     assert output.memory_config().buffer_type == memory_config.buffer_type
     output_tensor = ttnn.to_torch(output)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
@@ -1545,3 +1545,29 @@ def test_pad_rank_gt4_tile_front_padding_not_supported(device, padding, expect_e
 
     with expect_error(RuntimeError, "ttnn.pad: on device tile padding does not support front padding"):
         ttnn.pad(input_tensor, padding, 0.0)
+
+
+@pytest.mark.parametrize("use_multicore", [True, False], ids=["multicore", "singlecore"])
+@pytest.mark.parametrize(
+    "shape,padding",
+    [
+        # Leading dim (reshape path) and dim rank-3 (squeeze-to-4D path).
+        ((2, 4, 4, 4, 128), ((0, 1), (0, 0), (0, 0), (0, 0), (0, 0))),
+        ((2, 4, 4, 4, 128), ((0, 0), (0, 1), (0, 2), (0, 0), (0, 0))),
+    ],
+    ids=["dim0", "dim1_and_dim2"],
+)
+def test_pad_rank_gt4_use_multicore(device, shape, padding, use_multicore):
+    """The rank > 4 path must agree with torch for both the multicore and single-core kernels."""
+    torch.manual_seed(0)
+
+    torch_input_tensor = torch.randn(shape, dtype=torch.bfloat16)
+    torch_output_tensor = torch.nn.functional.pad(
+        torch_input_tensor, _ttnn_padding_to_torch(padding), mode="constant", value=0.0
+    )
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    output_tensor = ttnn.to_torch(ttnn.pad(input_tensor, padding, 0.0, use_multicore=use_multicore))
+
+    assert output_tensor.shape == torch_output_tensor.shape
+    assert torch.equal(torch_output_tensor, output_tensor)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
@@ -665,9 +665,7 @@ def _unsqueeze(smaller, larger, fill):
 )
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32, ttnn.uint16, ttnn.bfloat8_b])
 def test_pad_tile(shape, padding, dtype, device):
-    if (shape, padding) in [([5, 4, 3, 2, 1], [1, 0, 0, 0]), ([5, 4, 3, 2, 1], [32, 32, 32, 64])]:
-        pytest.xfail("Can't pad upper dims with rank>4")
-
+    # Padding upper dims of a rank>4 tensor used to xfail; supported since issue #38144.
     if len(shape) < len(padding):
         shape = _unsqueeze(shape, padding, 1)
     elif len(padding) < len(shape):
@@ -1336,3 +1334,214 @@ def test_pad_nd_sharded_front_padding_tile_layout_not_supported(device, dtype, e
             use_multicore=True,
             memory_config=output_memory_config,
         )
+
+
+def _ttnn_padding_to_torch(padding):
+    """Convert ttnn per-dim (before, after) padding to torch.nn.functional.pad format."""
+    return tuple(v for i in reversed(range(len(padding))) for v in padding[i])
+
+
+@pytest.mark.parametrize(
+    "shape,padding",
+    [
+        # Issue #38144 repro: rank 5, pad dim 1 (reshape path)
+        ((1, 4, 4, 4, 128), ((0, 0), (1, 1), (0, 0), (0, 0), (0, 0))),
+        # Rank 5: leading dims (reshape path)
+        ((2, 4, 4, 4, 128), ((1, 0), (0, 0), (0, 0), (0, 0), (0, 0))),
+        ((1, 4, 4, 4, 128), ((0, 0), (0, 2), (0, 0), (0, 0), (0, 0))),
+        # Rank 5: dim rank-3 is the first dim surviving squeeze-to-4D; the old shape
+        # restoration dropped padding on every dim above the last two.
+        ((1, 4, 4, 4, 128), ((0, 0), (0, 0), (1, 2), (0, 0), (0, 0))),
+        # Rank 5: trailing dims (squeeze-to-4D path)
+        ((1, 4, 4, 4, 128), ((0, 0), (0, 0), (0, 0), (0, 2), (0, 0))),
+        ((1, 4, 4, 4, 128), ((0, 0), (0, 0), (0, 0), (0, 0), (0, 3))),
+        # Rank 6: leading dims (reshape path)
+        ((1, 2, 3, 4, 4, 128), ((0, 0), (1, 0), (0, 0), (0, 0), (0, 0), (0, 0))),
+        ((1, 2, 3, 4, 4, 128), ((0, 0), (0, 0), (0, 2), (0, 0), (0, 0), (0, 0))),
+        # Rank 6: trailing dims (squeeze-to-4D path)
+        ((1, 2, 3, 4, 4, 128), ((0, 0), (0, 0), (0, 0), (0, 1), (0, 0), (0, 0))),
+        ((1, 2, 3, 4, 4, 128), ((0, 0), (0, 0), (0, 0), (0, 0), (0, 2), (0, 0))),
+        ((1, 2, 3, 4, 4, 128), ((0, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 1))),
+        # Several dims at once: each leading dim is padded by its own reshape pass,
+        # so later passes must see the shape produced by the earlier ones.
+        ((2, 4, 4, 4, 128), ((1, 1), (0, 2), (0, 0), (0, 0), (0, 0))),
+        ((2, 3, 4, 5, 8), ((1, 1), (0, 1), (2, 0), (0, 2), (1, 1))),
+        ((2, 2, 3, 4, 4, 16), ((0, 1), (0, 0), (1, 0), (0, 0), (0, 0), (0, 2))),
+        # Rank 7/8, and shapes that are not tile/page aligned.
+        ((2, 2, 2, 2, 2, 4, 16), ((0, 0), (0, 0), (1, 1), (0, 0), (0, 0), (0, 0), (0, 0))),
+        ((2, 2, 2, 2, 2, 2, 2, 8), ((0, 0), (1, 1), (0, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 0))),
+        ((2, 2, 2, 2, 2, 2, 2, 8), ((0, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 1), (0, 0), (0, 0))),
+        ((3, 3, 5, 7, 13), ((0, 0), (1, 2), (0, 0), (0, 0), (0, 0))),
+    ],
+    ids=[
+        "rank5_dim1_issue38144",
+        "rank5_dim0",
+        "rank5_dim1_after_only",
+        "rank5_dim2",
+        "rank5_dim3",
+        "rank5_dim4",
+        "rank6_dim1",
+        "rank6_dim2",
+        "rank6_dim3",
+        "rank6_dim4",
+        "rank6_dim5",
+        "rank5_dim0_and_dim1",
+        "rank5_all_dims",
+        "rank6_dim0_dim2_dim5",
+        "rank7_dim2",
+        "rank8_dim1",
+        "rank8_dim5",
+        "rank5_unaligned",
+    ],
+)
+@pytest.mark.parametrize("value", [0.0, 3.5])
+def test_pad_rank_gt4_all_dimensions(device, shape, padding, value):
+    """Regression test for issue #38144: ttnn.pad must support padding across ranks > 4."""
+    torch.manual_seed(0)
+
+    torch_padding = _ttnn_padding_to_torch(padding)
+    torch_input_tensor = torch.randn(shape, dtype=torch.bfloat16)
+    torch_output_tensor = torch.nn.functional.pad(torch_input_tensor, torch_padding, mode="constant", value=value)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=ttnn.DataType.BFLOAT16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device
+    )
+    output_tensor = ttnn.pad(input_tensor, padding, value)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert output_tensor.shape == torch_output_tensor.shape
+    assert torch.equal(torch_output_tensor, output_tensor)
+
+
+@pytest.mark.parametrize(
+    "shape,padding",
+    [
+        # Leading dims (reshape path). Tile layout has no front-padding support on device,
+        # so these only exercise back padding.
+        ((1, 4, 4, 32, 128), ((0, 0), (0, 1), (0, 0), (0, 0), (0, 0))),
+        ((2, 4, 4, 32, 128), ((0, 1), (0, 0), (0, 0), (0, 0), (0, 0))),
+        ((1, 2, 3, 4, 32, 128), ((0, 0), (0, 0), (0, 2), (0, 0), (0, 0), (0, 0))),
+        # dim rank-3 (squeeze-to-4D path) and a combination across both paths.
+        ((1, 4, 4, 32, 128), ((0, 0), (0, 0), (0, 2), (0, 0), (0, 0))),
+        ((2, 4, 4, 32, 128), ((0, 1), (0, 2), (0, 1), (0, 0), (0, 0))),
+        # Height/width padding must stay tile aligned.
+        ((1, 4, 4, 32, 128), ((0, 0), (0, 1), (0, 0), (0, 32), (0, 64))),
+    ],
+    ids=[
+        "rank5_dim1",
+        "rank5_dim0",
+        "rank6_dim2",
+        "rank5_dim2",
+        "rank5_dim0_dim1_dim2",
+        "rank5_dim1_with_hw",
+    ],
+)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
+def test_pad_rank_gt4_tile_layout(device, shape, padding, dtype):
+    """Issue #38144 for tile layout: rank > 4 upper dims must round-trip through the 4D kernel."""
+    torch.manual_seed(0)
+    value = 0.0
+
+    torch_padding = _ttnn_padding_to_torch(padding)
+    if dtype == ttnn.int32:
+        torch_input_tensor = torch.randint(-100, 100, shape, dtype=torch.int32)
+    else:
+        torch_input_tensor = torch.randn(shape, dtype=torch.bfloat16)
+    torch_output_tensor = torch.nn.functional.pad(torch_input_tensor, torch_padding, mode="constant", value=value)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.to_torch(ttnn.pad(input_tensor, padding, value))
+
+    assert output_tensor.shape == torch_output_tensor.shape
+    assert torch.equal(torch_output_tensor, output_tensor)
+
+
+@pytest.mark.parametrize("dtype", [ttnn.uint16, ttnn.int32, ttnn.uint32])
+def test_pad_rank_gt4_row_major_integer_dtypes(device, dtype):
+    """Leading-dim padding of a rank > 4 tensor must not depend on the element type."""
+    torch.manual_seed(0)
+    shape = (2, 4, 4, 4, 128)
+    padding = ((1, 0), (1, 1), (0, 0), (0, 0), (0, 2))
+
+    torch_input_tensor = torch.randint(0, 100, shape, dtype=torch.int32)
+    torch_output_tensor = torch.nn.functional.pad(torch_input_tensor, _ttnn_padding_to_torch(padding), value=0)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    output_tensor = ttnn.to_torch(ttnn.pad(input_tensor, padding, 0.0)).to(torch.int32)
+
+    assert output_tensor.shape == torch_output_tensor.shape
+    assert torch.equal(torch_output_tensor, output_tensor)
+
+
+@pytest.mark.parametrize(
+    "padding", [((0, 0), (0, 1), (0, 0), (0, 0), (0, 0)), ((0, 0), (0, 0), (0, 1), (0, 0), (0, 0))]
+)
+def test_pad_rank_gt4_tile_bfloat8_b(device, padding):
+    """bfloat8_b is padded via a bfloat16 round trip; make sure the rank > 4 path preserves that."""
+    torch.manual_seed(0)
+    shape = (1, 4, 4, 32, 128)
+
+    torch_input_tensor = torch.randn(shape, dtype=torch.bfloat16)
+    torch_output_tensor = torch.nn.functional.pad(torch_input_tensor, _ttnn_padding_to_torch(padding), value=0.0)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat8_b, layout=ttnn.TILE_LAYOUT, device=device)
+    output_tensor = ttnn.to_torch(ttnn.pad(input_tensor, padding, 0.0))
+
+    assert output_tensor.shape == torch_output_tensor.shape
+    assert_with_pcc(torch_output_tensor.float(), output_tensor.float(), 0.999)
+
+
+@pytest.mark.parametrize("layout", [ttnn.ROW_MAJOR_LAYOUT, ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("memory_config", [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG])
+def test_pad_rank_gt4_memory_config(device, layout, memory_config):
+    """The requested output memory config must survive the reshape/pad/reshape round trip."""
+    torch.manual_seed(0)
+    shape = (1, 4, 4, 32, 128)
+    # Tile layout does not support front padding on device.
+    padding = ((0, 0), (0, 1), (0, 0), (0, 0), (0, 0))
+
+    torch_input_tensor = torch.randn(shape, dtype=torch.bfloat16)
+    torch_output_tensor = torch.nn.functional.pad(torch_input_tensor, _ttnn_padding_to_torch(padding), value=0.0)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=layout, device=device)
+    output = ttnn.pad(input_tensor, padding, 0.0, memory_config=memory_config)
+
+    assert output.memory_config().buffer_type == memory_config.buffer_type
+    output_tensor = ttnn.to_torch(output)
+    assert output_tensor.shape == torch_output_tensor.shape
+    assert torch.equal(torch_output_tensor, output_tensor)
+
+
+def test_pad_rank_gt4_padding_shorter_than_rank(device):
+    """A padding spec shorter than the rank is left-filled with zeros, as for rank <= 4."""
+    torch.manual_seed(0)
+    shape = (1, 4, 4, 4, 128)
+
+    torch_input_tensor = torch.randn(shape, dtype=torch.bfloat16)
+    full_padding = ((0, 0), (0, 0), (0, 2), (0, 0), (0, 0))
+    torch_output_tensor = torch.nn.functional.pad(torch_input_tensor, _ttnn_padding_to_torch(full_padding), value=0.0)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    output_tensor = ttnn.to_torch(ttnn.pad(input_tensor, [(0, 2), (0, 0), (0, 0)], 0.0))
+
+    assert output_tensor.shape == torch_output_tensor.shape
+    assert torch.equal(torch_output_tensor, output_tensor)
+
+
+@pytest.mark.parametrize(
+    "padding",
+    [
+        ((1, 0), (0, 0), (0, 0), (0, 0), (0, 0)),
+        ((0, 0), (1, 0), (0, 0), (0, 0), (0, 0)),
+        ((0, 0), (0, 0), (1, 0), (0, 0), (0, 0)),
+    ],
+    ids=["dim0", "dim1", "dim2"],
+)
+def test_pad_rank_gt4_tile_front_padding_not_supported(device, padding, expect_error):
+    """Front padding stays unsupported in tile layout, on upper dims of rank > 4 as well."""
+    torch.manual_seed(0)
+    torch_input_tensor = torch.randn((2, 4, 4, 32, 128), dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    with expect_error(RuntimeError, "ttnn.pad: on device tile padding does not support front padding"):
+        ttnn.pad(input_tensor, padding, 0.0)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_pad.py
@@ -665,7 +665,6 @@ def _unsqueeze(smaller, larger, fill):
 )
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32, ttnn.uint16, ttnn.bfloat8_b])
 def test_pad_tile(shape, padding, dtype, device):
-    # Padding upper dims of a rank>4 tensor used to xfail; supported since issue #38144.
     if len(shape) < len(padding):
         shape = _unsqueeze(shape, padding, 1)
     elif len(padding) < len(shape):
@@ -1338,6 +1337,7 @@ def test_pad_nd_sharded_front_padding_tile_layout_not_supported(device, dtype, e
 
 def _ttnn_padding_to_torch(padding):
     """Convert ttnn per-dim (before, after) padding to torch.nn.functional.pad format."""
+    # torch.nn.functional.pad expects (last_dim_before, last_dim_after, ..., first_dim_before, first_dim_after).
     return tuple(v for i in reversed(range(len(padding))) for v in padding[i])
 
 
@@ -1366,45 +1366,30 @@ def _assert_pad_body_matches(output_tensor, input_tensor, padding, *, atol=0.0):
         assert_allclose(body_out.float(), input_tensor.float(), rtol=0, atol=atol)
 
 
-# Rank > 4 regression coverage below exercises ttnn.pad on device. The Quasar mirror
-# (ttnn.experimental.quasar.pad / experimental/quasar/pad/pad.cpp) carries the same
-# logic and is verified-by-inspection, same as the Quasar slice fix in #52902.
-
-
 @pytest.mark.parametrize(
     "shape,padding",
     [
-        # Issue #38144 repro: rank 5, pad dim 1 (reshape path)
         ((1, 4, 4, 4, 128), ((0, 0), (1, 1), (0, 0), (0, 0), (0, 0))),
-        # Rank 5: leading dims (reshape path)
         ((2, 4, 4, 4, 128), ((1, 0), (0, 0), (0, 0), (0, 0), (0, 0))),
         ((1, 4, 4, 4, 128), ((0, 0), (0, 2), (0, 0), (0, 0), (0, 0))),
-        # Rank 5: dim rank-3 is the first dim surviving squeeze-to-4D; the old shape
-        # restoration dropped padding on every dim above the last two.
         ((1, 4, 4, 4, 128), ((0, 0), (0, 0), (1, 2), (0, 0), (0, 0))),
-        # Rank 5: trailing dims (squeeze-to-4D path)
         ((1, 4, 4, 4, 128), ((0, 0), (0, 0), (0, 0), (0, 2), (0, 0))),
         ((1, 4, 4, 4, 128), ((0, 0), (0, 0), (0, 0), (0, 0), (0, 3))),
-        # Rank 6: leading dims (reshape path)
         ((1, 2, 3, 4, 4, 128), ((0, 0), (1, 0), (0, 0), (0, 0), (0, 0), (0, 0))),
         ((1, 2, 3, 4, 4, 128), ((0, 0), (0, 0), (0, 2), (0, 0), (0, 0), (0, 0))),
-        # Rank 6: trailing dims (squeeze-to-4D path)
         ((1, 2, 3, 4, 4, 128), ((0, 0), (0, 0), (0, 0), (0, 1), (0, 0), (0, 0))),
         ((1, 2, 3, 4, 4, 128), ((0, 0), (0, 0), (0, 0), (0, 0), (0, 2), (0, 0))),
         ((1, 2, 3, 4, 4, 128), ((0, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 1))),
-        # Several dims at once: each leading dim is padded by its own reshape pass,
-        # so later passes must see the shape produced by the earlier ones.
         ((2, 4, 4, 4, 128), ((1, 1), (0, 2), (0, 0), (0, 0), (0, 0))),
         ((2, 3, 4, 5, 8), ((1, 1), (0, 1), (2, 0), (0, 2), (1, 1))),
         ((2, 2, 3, 4, 4, 16), ((0, 1), (0, 0), (1, 0), (0, 0), (0, 0), (0, 2))),
-        # Rank 7/8, and shapes that are not tile/page aligned.
         ((2, 2, 2, 2, 2, 4, 16), ((0, 0), (0, 0), (1, 1), (0, 0), (0, 0), (0, 0), (0, 0))),
         ((2, 2, 2, 2, 2, 2, 2, 8), ((0, 0), (1, 1), (0, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 0))),
         ((2, 2, 2, 2, 2, 2, 2, 8), ((0, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 1), (0, 0), (0, 0))),
         ((3, 3, 5, 7, 13), ((0, 0), (1, 2), (0, 0), (0, 0), (0, 0))),
     ],
     ids=[
-        "rank5_dim1_issue38144",
+        "rank5_dim1",
         "rank5_dim0",
         "rank5_dim1_after_only",
         "rank5_dim2",
@@ -1426,7 +1411,6 @@ def _assert_pad_body_matches(output_tensor, input_tensor, padding, *, atol=0.0):
 )
 @pytest.mark.parametrize("value", [0.0, 3.5])
 def test_pad_rank_gt4_all_dimensions(device, shape, padding, value):
-    """Regression test for issue #38144: ttnn.pad must support padding across ranks > 4."""
     torch.manual_seed(0)
 
     torch_padding = _ttnn_padding_to_torch(padding)
@@ -1468,7 +1452,6 @@ def test_pad_rank_gt4_all_dimensions(device, shape, padding, value):
 )
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
 def test_pad_rank_gt4_tile_layout(device, shape, padding, dtype):
-    """Issue #38144 for tile layout: rank > 4 upper dims must round-trip through the 4D kernel."""
     torch.manual_seed(0)
     value = 0.0
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
@@ -331,6 +331,22 @@ ttnn::Tensor pad_impl(
         padding_size = padding.size();
         extra_index = 0;
     }
+    if (original_rank > 4) {
+        // Only padding[extra_index .. extra_index + 3] reaches the 4D kernel. Dims below extra_index have no
+        // slot in the 4D spec at all, and axis 0 of the squeezed tensor may be several original dims folded
+        // together -- padding applied there would stretch the whole merged axis instead of one dimension.
+        // pad_leading_dimensions() consumes those dims before we get here; this guard is what the removed
+        // "only supports padding on the lowest 3 dimensions" TT_FATAL used to provide.
+        const auto is_unpadded = [](const PadSpecDim& p) { return p.before_elements == 0 && p.after_elements == 0; };
+        const bool axis0_is_merged =
+            input_tensor_4D.logical_shape()[0] != input_tensor.logical_shape()[static_cast<int>(extra_index)];
+        TT_FATAL(
+            std::all_of(padding.begin(), padding.begin() + static_cast<std::ptrdiff_t>(extra_index), is_unpadded) &&
+                (!axis0_is_merged || is_unpadded(padding[extra_index])),
+            "ttnn.pad: padding on the leading dimensions of a rank {} tensor must be consumed before the squeeze "
+            "to 4D; got a non-zero pad on a dimension that the 4D kernel cannot address",
+            original_rank);
+    }
     auto input_shape_with_tile_padding =
         (input_tensor_4D.layout() == Layout::TILE) ? input_tensor_4D.padded_shape() : input_tensor_4D.logical_shape();
     // For tilized tensors, we want the shape padded to the nearest tile. For row major, we just want the row size
@@ -403,9 +419,18 @@ ttnn::Tensor invoke_rm(
             output_tensor = ttnn::reshape(output_tensor, ttnn::Shape(padded_shape));
         }
     } else {
+        // invoke_rm only ever sees row-major tensors, and pad_impl sizes the 4D output from the *logical*
+        // shape in that case (input_shape_with_tile_padding). The padded output therefore carries no
+        // alignment padding of its own, so the restored rank-N padded shape is the padded logical shape.
+        // Deriving it from input_tensor.padded_shape() instead would disagree with the buffer whenever an
+        // input arrives with padded_shape != logical_shape (e.g. an explicit two-shape reshape).
         const auto output_logical_shape = compute_padded_logical_shape(input_tensor.logical_shape(), padding_vec);
-        const auto output_padded_shape = compute_padded_logical_shape(input_tensor.padded_shape(), padding_vec);
-        output_tensor = ttnn::reshape(output_tensor, output_logical_shape, output_padded_shape);
+        TT_FATAL(
+            output_logical_shape.volume() == output_tensor.padded_shape().volume(),
+            "ttnn.pad: restored shape {} does not match the padded output volume of {}",
+            output_logical_shape,
+            output_tensor.padded_shape());
+        output_tensor = ttnn::reshape(output_tensor, output_logical_shape, output_logical_shape);
     }
     return output_tensor;
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
@@ -85,15 +85,78 @@ ttnn::Tensor pad_via_interleaved_composite(
 
 bool eq_spans(const auto a, const auto b) { return std::equal(a.begin(), a.end(), b.begin(), b.end()); }
 
-ttnn::Shape update_original_shape(const ttnn::Shape& padded_shape, const ttnn::Shape& input_shape) {
-    ttsl::SmallVector<uint32_t> updated_shape;
-    size_t input_rank = input_shape.rank();
-    for (size_t i = 0; i < input_rank - 2; i++) {
-        updated_shape.push_back(input_shape[i]);
+ttnn::Shape compute_padded_logical_shape(const ttnn::Shape& input_shape, const ttsl::SmallVector<PadSpecDim>& padding) {
+    ttsl::SmallVector<uint32_t> output_shape(input_shape.rank());
+    for (size_t i = 0; i < input_shape.rank(); i++) {
+        output_shape[i] = padding[i].before_elements + input_shape[i] + padding[i].after_elements;
     }
-    updated_shape.push_back(padded_shape[-2]);
-    updated_shape.push_back(padded_shape[-1]);
-    return ttnn::Shape(std::move(updated_shape));
+    return ttnn::Shape(std::move(output_shape));
+}
+
+// For rank > 4, leading dimensions [0, rank-3) are merged into a single axis by squeeze_from_ND_to_4D and
+// cannot be padded through the 4D kernel directly. Reshape to 4D, pad the collapsed axis, reshape back.
+ttnn::Tensor pad_leading_dimension_via_reshape(
+    const ttnn::Tensor& input_tensor,
+    int dim,
+    const PadSpecDim& pad_spec,
+    const float value,
+    const bool use_multicore,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    const auto& shape = input_tensor.logical_shape();
+    const int rank = static_cast<int>(shape.rank());
+    TT_FATAL(
+        rank > 4 && dim >= 0 && dim < rank - 3,
+        "pad_leading_dimension_via_reshape: expected dim in [0, rank-3), got dim {} for rank {}",
+        dim,
+        rank);
+
+    uint32_t before = 1;
+    for (int i = 0; i < dim; i++) {
+        before *= shape[i];
+    }
+
+    uint32_t middle = 1;
+    for (int i = dim; i < rank - 2; i++) {
+        middle *= shape[i];
+    }
+
+    auto reshaped = ttnn::reshape(input_tensor, ttnn::Shape({before, middle, shape[-2], shape[-1]}));
+
+    uint32_t inner_extent = 1;
+    for (int i = dim + 1; i < rank - 2; i++) {
+        inner_extent *= shape[i];
+    }
+
+    ttsl::SmallVector<PadSpecDim> padding_4d = {
+        {0, 0}, {pad_spec.before_elements * inner_extent, pad_spec.after_elements * inner_extent}, {0, 0}, {0, 0}};
+
+    auto padded = ttnn::pad(reshaped, padding_4d, value, use_multicore, memory_config_arg, sub_core_grids);
+
+    ttsl::SmallVector<uint32_t> output_shape(shape.view().begin(), shape.view().end());
+    output_shape[dim] += pad_spec.before_elements + pad_spec.after_elements;
+    return ttnn::reshape(padded, ttnn::Shape(output_shape));
+}
+
+ttnn::Tensor pad_leading_dimensions(
+    const ttnn::Tensor& input_tensor,
+    ttsl::SmallVector<PadSpecDim>& padding,
+    const float value,
+    const bool use_multicore,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    auto result = input_tensor;
+    const int rank = static_cast<int>(input_tensor.logical_shape().rank());
+    const int leading_dims_end = rank - 3;
+    for (int dim = 0; dim < leading_dims_end; dim++) {
+        if (padding[dim].before_elements == 0 && padding[dim].after_elements == 0) {
+            continue;
+        }
+        result = pad_leading_dimension_via_reshape(
+            result, dim, padding[dim], value, use_multicore, memory_config_arg, sub_core_grids);
+        padding[dim] = {0, 0};
+    }
+    return result;
 }
 
 ttnn::Tensor pad_impl(
@@ -340,8 +403,9 @@ ttnn::Tensor invoke_rm(
             output_tensor = ttnn::reshape(output_tensor, ttnn::Shape(padded_shape));
         }
     } else {
-        output_tensor = ttnn::reshape(
-            output_tensor, update_original_shape(output_tensor.padded_shape(), input_tensor.logical_shape()));
+        const auto output_logical_shape = compute_padded_logical_shape(input_tensor.logical_shape(), padding_vec);
+        const auto output_padded_shape = compute_padded_logical_shape(input_tensor.padded_shape(), padding_vec);
+        output_tensor = ttnn::reshape(output_tensor, output_logical_shape, output_padded_shape);
     }
     return output_tensor;
 }
@@ -454,23 +518,23 @@ ttnn::Tensor pad(
         return input_tensor;
     }
 
+    ttnn::Tensor working_tensor = input_tensor;
     if (original_rank > 4) {
-        const auto first_pad_idx =
-            std::find_if(
-                working_padding.begin(), working_padding.end(), [](auto& p) { return p.after_elements != 0; }) -
-            working_padding.begin();
-        TT_FATAL(
-            first_pad_idx >= original_rank - 3,
-            "ttnn::pad only supports padding on the lowest 3 dimensions for tensors with rank > 4 {}",
-            first_pad_idx);
+        working_tensor = operations::data_movement::detail::pad_leading_dimensions(
+            working_tensor, working_padding, value, use_multicore, memory_config_arg, sub_core_grids);
+        if (std::all_of(working_padding.begin(), working_padding.end(), [](auto& p) {
+                return p.before_elements == 0 && p.after_elements == 0;
+            })) {
+            return working_tensor;
+        }
     }
 
-    if (input_tensor.layout() == ttnn::TILE_LAYOUT) {
+    if (working_tensor.layout() == ttnn::TILE_LAYOUT) {
         return operations::data_movement::detail::invoke_tile(
-            input_tensor, working_padding, value, use_multicore, memory_config_arg, sub_core_grids);
+            working_tensor, working_padding, value, use_multicore, memory_config_arg, sub_core_grids);
     }
     return operations::data_movement::detail::invoke_rm(
-        input_tensor, working_padding, value, use_multicore, memory_config_arg, sub_core_grids);
+        working_tensor, working_padding, value, use_multicore, memory_config_arg, sub_core_grids);
 }
 
 ttnn::Tensor pad(

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
@@ -101,7 +101,6 @@ ttnn::Tensor pad_leading_dimension_via_reshape(
     const PadSpecDim& pad_spec,
     const float value,
     const bool use_multicore,
-    const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     const auto& shape = input_tensor.logical_shape();
     const int rank = static_cast<int>(shape.rank());
@@ -131,7 +130,7 @@ ttnn::Tensor pad_leading_dimension_via_reshape(
     ttsl::SmallVector<PadSpecDim> padding_4d = {
         {0, 0}, {pad_spec.before_elements * inner_extent, pad_spec.after_elements * inner_extent}, {0, 0}, {0, 0}};
 
-    auto padded = ttnn::pad(reshaped, padding_4d, value, use_multicore, memory_config_arg, sub_core_grids);
+    auto padded = ttnn::pad(reshaped, padding_4d, value, use_multicore, std::nullopt, sub_core_grids);
 
     ttsl::SmallVector<uint32_t> output_shape(shape.view().begin(), shape.view().end());
     output_shape[dim] += pad_spec.before_elements + pad_spec.after_elements;
@@ -143,7 +142,6 @@ ttnn::Tensor pad_leading_dimensions(
     ttsl::SmallVector<PadSpecDim>& padding,
     const float value,
     const bool use_multicore,
-    const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     auto result = input_tensor;
     const int rank = static_cast<int>(input_tensor.logical_shape().rank());
@@ -152,8 +150,7 @@ ttnn::Tensor pad_leading_dimensions(
         if (padding[dim].before_elements == 0 && padding[dim].after_elements == 0) {
             continue;
         }
-        result = pad_leading_dimension_via_reshape(
-            result, dim, padding[dim], value, use_multicore, memory_config_arg, sub_core_grids);
+        result = pad_leading_dimension_via_reshape(result, dim, padding[dim], value, use_multicore, sub_core_grids);
         padding[dim] = {0, 0};
     }
     return result;
@@ -546,10 +543,13 @@ ttnn::Tensor pad(
     ttnn::Tensor working_tensor = input_tensor;
     if (original_rank > 4) {
         working_tensor = operations::data_movement::detail::pad_leading_dimensions(
-            working_tensor, working_padding, value, use_multicore, memory_config_arg, sub_core_grids);
+            working_tensor, working_padding, value, use_multicore, sub_core_grids);
         if (std::all_of(working_padding.begin(), working_padding.end(), [](auto& p) {
                 return p.before_elements == 0 && p.after_elements == 0;
             })) {
+            if (memory_config_arg.has_value()) {
+                return ttnn::to_memory_config(working_tensor, memory_config_arg.value());
+            }
             return working_tensor;
         }
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
@@ -82,8 +82,6 @@ ttnn::Tensor pad_via_interleaved_composite(
     return padded;
 }
 
-}  // namespace
-
 bool eq_spans(const auto a, const auto b) { return std::equal(a.begin(), a.end(), b.begin(), b.end()); }
 
 ttnn::Shape compute_padded_logical_shape(const ttnn::Shape& input_shape, const ttsl::SmallVector<PadSpecDim>& padding) {
@@ -141,14 +139,34 @@ ttnn::Tensor pad_leading_dimensions(
     auto result = input_tensor;
     const int rank = static_cast<int>(input_tensor.logical_shape().rank());
     const int leading_dims_end = rank - 3;
+    const int defer_dim = rank - 4;
     for (int dim = 0; dim < leading_dims_end; dim++) {
         if (padding[dim].before_elements == 0 && padding[dim].after_elements == 0) {
             continue;
+        }
+        if (dim == defer_dim) {
+            const auto shape_view = result.logical_shape().view();
+            const uint32_t squeezed_axis0 = std::accumulate(
+                shape_view.begin(), shape_view.begin() + leading_dims_end, 1u, std::multiplies<uint32_t>());
+            if (squeezed_axis0 == shape_view[defer_dim]) {
+                continue;
+            }
         }
         result = pad_leading_dimension_via_reshape(result, dim, padding[dim], value, use_multicore, sub_core_grids);
         padding[dim] = {0, 0};
     }
     return result;
+}
+
+}  // namespace
+
+ttnn::Tensor apply_leading_dimension_padding(
+    const ttnn::Tensor& input_tensor,
+    ttsl::SmallVector<PadSpecDim>& padding,
+    const float value,
+    const bool use_multicore,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    return pad_leading_dimensions(input_tensor, padding, value, use_multicore, sub_core_grids);
 }
 
 ttnn::Tensor pad_impl(
@@ -534,15 +552,27 @@ ttnn::Tensor pad(
 
     ttnn::Tensor working_tensor = input_tensor;
     if (original_rank > 4) {
-        working_tensor = operations::data_movement::detail::pad_leading_dimensions(
-            working_tensor, working_padding, value, use_multicore, sub_core_grids);
-        if (std::all_of(working_padding.begin(), working_padding.end(), [](auto& p) {
-                return p.before_elements == 0 && p.after_elements == 0;
-            })) {
-            if (memory_config_arg.has_value()) {
-                return ttnn::to_memory_config(working_tensor, memory_config_arg.value());
+        if (input_tensor.storage_type() != StorageType::DEVICE) {
+            const auto first_pad_idx = static_cast<int>(
+                std::find_if(
+                    working_padding.begin(),
+                    working_padding.end(),
+                    [](const PadSpecDim& p) { return p.after_elements != 0; }) -
+                working_padding.begin());
+            TT_FATAL(
+                first_pad_idx >= original_rank - 3,
+                "ttnn::pad only supports padding on the lowest 3 dimensions for host tensors with rank > 4");
+        } else {
+            working_tensor = operations::data_movement::detail::apply_leading_dimension_padding(
+                working_tensor, working_padding, value, use_multicore, sub_core_grids);
+            if (std::all_of(working_padding.begin(), working_padding.end(), [](auto& p) {
+                    return p.before_elements == 0 && p.after_elements == 0;
+                })) {
+                if (memory_config_arg.has_value()) {
+                    return ttnn::to_memory_config(working_tensor, memory_config_arg.value());
+                }
+                return working_tensor;
             }
-            return working_tensor;
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp
@@ -10,6 +10,7 @@
 #include "ttnn/operations/experimental/reshape/view.hpp"
 #include "ttnn/operations/copy/typecast/typecast.hpp"
 #include "ttnn/operation.hpp"
+#include <numeric>
 #include <ttnn/tensor/types.hpp>
 
 #include "pad.hpp"
@@ -110,22 +111,16 @@ ttnn::Tensor pad_leading_dimension_via_reshape(
         dim,
         rank);
 
-    uint32_t before = 1;
-    for (int i = 0; i < dim; i++) {
-        before *= shape[i];
-    }
-
-    uint32_t middle = 1;
-    for (int i = dim; i < rank - 2; i++) {
-        middle *= shape[i];
-    }
+    const auto shape_view = shape.view();
+    const uint32_t before =
+        std::accumulate(shape_view.begin(), shape_view.begin() + dim, 1u, std::multiplies<uint32_t>());
+    const uint32_t middle =
+        std::accumulate(shape_view.begin() + dim, shape_view.begin() + rank - 2, 1u, std::multiplies<uint32_t>());
 
     auto reshaped = ttnn::reshape(input_tensor, ttnn::Shape({before, middle, shape[-2], shape[-1]}));
 
-    uint32_t inner_extent = 1;
-    for (int i = dim + 1; i < rank - 2; i++) {
-        inner_extent *= shape[i];
-    }
+    const uint32_t inner_extent =
+        std::accumulate(shape_view.begin() + dim + 1, shape_view.begin() + rank - 2, 1u, std::multiplies<uint32_t>());
 
     ttsl::SmallVector<PadSpecDim> padding_4d = {
         {0, 0}, {pad_spec.before_elements * inner_extent, pad_spec.after_elements * inner_extent}, {0, 0}, {0, 0}};
@@ -330,10 +325,7 @@ ttnn::Tensor pad_impl(
     }
     if (original_rank > 4) {
         // Only padding[extra_index .. extra_index + 3] reaches the 4D kernel. Dims below extra_index have no
-        // slot in the 4D spec at all, and axis 0 of the squeezed tensor may be several original dims folded
-        // together -- padding applied there would stretch the whole merged axis instead of one dimension.
-        // pad_leading_dimensions() consumes those dims before we get here; this guard is what the removed
-        // "only supports padding on the lowest 3 dimensions" TT_FATAL used to provide.
+        // slot in the 4D spec, and axis 0 of the squeezed tensor may fold several original dims together.
         const auto is_unpadded = [](const PadSpecDim& p) { return p.before_elements == 0 && p.after_elements == 0; };
         const bool axis0_is_merged =
             input_tensor_4D.logical_shape()[0] != input_tensor.logical_shape()[static_cast<int>(extra_index)];

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/pad_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/pad_nanobind.cpp
@@ -22,7 +22,7 @@ namespace ttnn::operations::data_movement::detail {
 void bind_pad(nb::module_& mod) {
     const auto* doc = R"doc(
         Returns a padded tensor, with a specified value at the specified location. If the input tensor is on host, the pad will be performed on host, and if its on device it will be performed on device.
-        Any rank of tensor is supported, however tensors with rank > 4 can only apply padding to the lower 3 dimensions.
+        Any rank of tensor is supported. For rank > 4, leading dimensions are padded via a reshape path before the 4D device kernel; tile layout still does not support front padding on device.
 
         Args:
             * :attr:`input_tensor`: (ttnn.Tensor): the input tensor.

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad.cpp
@@ -28,15 +28,80 @@ using ttnn::operations::data_movement::squeeze_or_unsqueeze_shape_to_ND;
 
 bool eq_spans(const auto a, const auto b) { return std::equal(a.begin(), a.end(), b.begin(), b.end()); }
 
-ttnn::Shape update_original_shape(const ttnn::Shape& padded_shape, const ttnn::Shape& input_shape) {
-    ttsl::SmallVector<uint32_t> updated_shape;
-    size_t input_rank = input_shape.rank();
-    for (size_t i = 0; i < input_rank - 2; i++) {
-        updated_shape.push_back(input_shape[i]);
+ttnn::Shape compute_padded_logical_shape(const ttnn::Shape& input_shape, const ttsl::SmallVector<PadSpecDim>& padding) {
+    ttsl::SmallVector<uint32_t> output_shape(input_shape.rank());
+    for (size_t i = 0; i < input_shape.rank(); i++) {
+        output_shape[i] = padding[i].before_elements + input_shape[i] + padding[i].after_elements;
     }
-    updated_shape.push_back(padded_shape[-2]);
-    updated_shape.push_back(padded_shape[-1]);
-    return ttnn::Shape(std::move(updated_shape));
+    return ttnn::Shape(std::move(output_shape));
+}
+
+// For rank > 4, leading dimensions [0, rank-3) are merged into a single axis by squeeze_from_ND_to_4D and
+// cannot be padded through the 4D kernel directly. Reshape to 4D, pad the collapsed axis, reshape back.
+ttnn::Tensor pad_leading_dimension_via_reshape(
+    const ttnn::Tensor& input_tensor,
+    int dim,
+    const PadSpecDim& pad_spec,
+    const float value,
+    const bool use_multicore,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    const auto& shape = input_tensor.logical_shape();
+    const int rank = static_cast<int>(shape.rank());
+    TT_FATAL(
+        rank > 4 && dim >= 0 && dim < rank - 3,
+        "pad_leading_dimension_via_reshape: expected dim in [0, rank-3), got dim {} for rank {}",
+        dim,
+        rank);
+
+    uint32_t before = 1;
+    for (int i = 0; i < dim; i++) {
+        before *= shape[i];
+    }
+
+    uint32_t middle = 1;
+    for (int i = dim; i < rank - 2; i++) {
+        middle *= shape[i];
+    }
+
+    auto reshaped = ttnn::operations::experimental::quasar::reshape(
+        input_tensor, ttnn::Shape({before, middle, shape[-2], shape[-1]}));
+
+    uint32_t inner_extent = 1;
+    for (int i = dim + 1; i < rank - 2; i++) {
+        inner_extent *= shape[i];
+    }
+
+    ttsl::SmallVector<PadSpecDim> padding_4d = {
+        {0, 0}, {pad_spec.before_elements * inner_extent, pad_spec.after_elements * inner_extent}, {0, 0}, {0, 0}};
+
+    auto padded = ttnn::operations::experimental::quasar::pad(
+        reshaped, padding_4d, value, use_multicore, memory_config_arg, sub_core_grids);
+
+    ttsl::SmallVector<uint32_t> output_shape(shape.view().begin(), shape.view().end());
+    output_shape[dim] += pad_spec.before_elements + pad_spec.after_elements;
+    return ttnn::operations::experimental::quasar::reshape(padded, ttnn::Shape(output_shape));
+}
+
+ttnn::Tensor pad_leading_dimensions(
+    const ttnn::Tensor& input_tensor,
+    ttsl::SmallVector<PadSpecDim>& padding,
+    const float value,
+    const bool use_multicore,
+    const std::optional<MemoryConfig>& memory_config_arg,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    auto result = input_tensor;
+    const int rank = static_cast<int>(input_tensor.logical_shape().rank());
+    const int leading_dims_end = rank - 3;
+    for (int dim = 0; dim < leading_dims_end; dim++) {
+        if (padding[dim].before_elements == 0 && padding[dim].after_elements == 0) {
+            continue;
+        }
+        result = pad_leading_dimension_via_reshape(
+            result, dim, padding[dim], value, use_multicore, memory_config_arg, sub_core_grids);
+        padding[dim] = {0, 0};
+    }
+    return result;
 }
 
 ttnn::Tensor pad_impl(
@@ -272,8 +337,10 @@ ttnn::Tensor invoke_rm(
             output_tensor = ttnn::operations::experimental::quasar::reshape(output_tensor, ttnn::Shape(padded_shape));
         }
     } else {
-        output_tensor = ttnn::operations::experimental::quasar::reshape(
-            output_tensor, update_original_shape(output_tensor.padded_shape(), input_tensor.logical_shape()));
+        const auto output_logical_shape = compute_padded_logical_shape(input_tensor.logical_shape(), padding_vec);
+        const auto output_padded_shape = compute_padded_logical_shape(input_tensor.padded_shape(), padding_vec);
+        output_tensor =
+            ttnn::operations::experimental::quasar::reshape(output_tensor, output_logical_shape, output_padded_shape);
     }
     return output_tensor;
 }
@@ -388,23 +455,23 @@ ttnn::Tensor pad(
         return input_tensor;
     }
 
+    ttnn::Tensor working_tensor = input_tensor;
     if (original_rank > 4) {
-        const auto first_pad_idx =
-            std::find_if(
-                working_padding.begin(), working_padding.end(), [](auto& p) { return p.after_elements != 0; }) -
-            working_padding.begin();
-        TT_FATAL(
-            first_pad_idx >= original_rank - 3,
-            "ttnn::pad only supports padding on the lowest 3 dimensions for tensors with rank > 4 {}",
-            first_pad_idx);
+        working_tensor = operations::experimental::quasar::detail::pad_leading_dimensions(
+            working_tensor, working_padding, value, use_multicore, memory_config_arg, sub_core_grids);
+        if (std::all_of(working_padding.begin(), working_padding.end(), [](auto& p) {
+                return p.before_elements == 0 && p.after_elements == 0;
+            })) {
+            return working_tensor;
+        }
     }
 
-    if (input_tensor.layout() == ttnn::TILE_LAYOUT) {
+    if (working_tensor.layout() == ttnn::TILE_LAYOUT) {
         return operations::experimental::quasar::detail::invoke_tile(
-            input_tensor, working_padding, value, use_multicore, memory_config_arg, sub_core_grids);
+            working_tensor, working_padding, value, use_multicore, memory_config_arg, sub_core_grids);
     }
     return operations::experimental::quasar::detail::invoke_rm(
-        input_tensor, working_padding, value, use_multicore, memory_config_arg, sub_core_grids);
+        working_tensor, working_padding, value, use_multicore, memory_config_arg, sub_core_grids);
 }
 
 ttnn::Tensor pad(

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad.cpp
@@ -27,6 +27,8 @@ using ttnn::operations::data_movement::ShardStrategy;
 using ttnn::operations::data_movement::squeeze_from_ND_to_4D;
 using ttnn::operations::data_movement::squeeze_or_unsqueeze_shape_to_ND;
 
+namespace {
+
 bool eq_spans(const auto a, const auto b) { return std::equal(a.begin(), a.end(), b.begin(), b.end()); }
 
 ttnn::Shape compute_padded_logical_shape(const ttnn::Shape& input_shape, const ttsl::SmallVector<PadSpecDim>& padding) {
@@ -86,14 +88,34 @@ ttnn::Tensor pad_leading_dimensions(
     auto result = input_tensor;
     const int rank = static_cast<int>(input_tensor.logical_shape().rank());
     const int leading_dims_end = rank - 3;
+    const int defer_dim = rank - 4;
     for (int dim = 0; dim < leading_dims_end; dim++) {
         if (padding[dim].before_elements == 0 && padding[dim].after_elements == 0) {
             continue;
+        }
+        if (dim == defer_dim) {
+            const auto shape_view = result.logical_shape().view();
+            const uint32_t squeezed_axis0 = std::accumulate(
+                shape_view.begin(), shape_view.begin() + leading_dims_end, 1u, std::multiplies<uint32_t>());
+            if (squeezed_axis0 == shape_view[defer_dim]) {
+                continue;
+            }
         }
         result = pad_leading_dimension_via_reshape(result, dim, padding[dim], value, use_multicore, sub_core_grids);
         padding[dim] = {0, 0};
     }
     return result;
+}
+
+}  // namespace
+
+ttnn::Tensor apply_leading_dimension_padding(
+    const ttnn::Tensor& input_tensor,
+    ttsl::SmallVector<PadSpecDim>& padding,
+    const float value,
+    const bool use_multicore,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    return pad_leading_dimensions(input_tensor, padding, value, use_multicore, sub_core_grids);
 }
 
 ttnn::Tensor pad_impl(
@@ -471,18 +493,28 @@ ttnn::Tensor pad(
 
     ttnn::Tensor working_tensor = input_tensor;
     if (original_rank > 4) {
-        // Mirror of ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp. Rank > 4 coverage is exercised
-        // through ttnn.pad device tests(see #52870).
-        working_tensor = operations::experimental::quasar::detail::pad_leading_dimensions(
-            working_tensor, working_padding, value, use_multicore, sub_core_grids);
-        if (std::all_of(working_padding.begin(), working_padding.end(), [](auto& p) {
-                return p.before_elements == 0 && p.after_elements == 0;
-            })) {
-            if (memory_config_arg.has_value()) {
-                return ttnn::operations::experimental::quasar::to_memory_config(
-                    working_tensor, memory_config_arg.value());
+        if (input_tensor.storage_type() != StorageType::DEVICE) {
+            const auto first_pad_idx = static_cast<int>(
+                std::find_if(
+                    working_padding.begin(),
+                    working_padding.end(),
+                    [](const PadSpecDim& p) { return p.after_elements != 0; }) -
+                working_padding.begin());
+            TT_FATAL(
+                first_pad_idx >= original_rank - 3,
+                "ttnn::pad only supports padding on the lowest 3 dimensions for host tensors with rank > 4");
+        } else {
+            working_tensor = operations::experimental::quasar::detail::apply_leading_dimension_padding(
+                working_tensor, working_padding, value, use_multicore, sub_core_grids);
+            if (std::all_of(working_padding.begin(), working_padding.end(), [](auto& p) {
+                    return p.before_elements == 0 && p.after_elements == 0;
+                })) {
+                if (memory_config_arg.has_value()) {
+                    return ttnn::operations::experimental::quasar::to_memory_config(
+                        working_tensor, memory_config_arg.value());
+                }
+                return working_tensor;
             }
-            return working_tensor;
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad.cpp
@@ -44,7 +44,6 @@ ttnn::Tensor pad_leading_dimension_via_reshape(
     const PadSpecDim& pad_spec,
     const float value,
     const bool use_multicore,
-    const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     const auto& shape = input_tensor.logical_shape();
     const int rank = static_cast<int>(shape.rank());
@@ -76,7 +75,7 @@ ttnn::Tensor pad_leading_dimension_via_reshape(
         {0, 0}, {pad_spec.before_elements * inner_extent, pad_spec.after_elements * inner_extent}, {0, 0}, {0, 0}};
 
     auto padded = ttnn::operations::experimental::quasar::pad(
-        reshaped, padding_4d, value, use_multicore, memory_config_arg, sub_core_grids);
+        reshaped, padding_4d, value, use_multicore, std::nullopt, sub_core_grids);
 
     ttsl::SmallVector<uint32_t> output_shape(shape.view().begin(), shape.view().end());
     output_shape[dim] += pad_spec.before_elements + pad_spec.after_elements;
@@ -88,7 +87,6 @@ ttnn::Tensor pad_leading_dimensions(
     ttsl::SmallVector<PadSpecDim>& padding,
     const float value,
     const bool use_multicore,
-    const std::optional<MemoryConfig>& memory_config_arg,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     auto result = input_tensor;
     const int rank = static_cast<int>(input_tensor.logical_shape().rank());
@@ -97,8 +95,7 @@ ttnn::Tensor pad_leading_dimensions(
         if (padding[dim].before_elements == 0 && padding[dim].after_elements == 0) {
             continue;
         }
-        result = pad_leading_dimension_via_reshape(
-            result, dim, padding[dim], value, use_multicore, memory_config_arg, sub_core_grids);
+        result = pad_leading_dimension_via_reshape(result, dim, padding[dim], value, use_multicore, sub_core_grids);
         padding[dim] = {0, 0};
     }
     return result;
@@ -482,11 +479,17 @@ ttnn::Tensor pad(
 
     ttnn::Tensor working_tensor = input_tensor;
     if (original_rank > 4) {
+        // Mirror of ttnn/cpp/ttnn/operations/data_movement/pad/pad.cpp. Rank > 4 coverage is exercised
+        // through ttnn.pad device tests(see #52870).
         working_tensor = operations::experimental::quasar::detail::pad_leading_dimensions(
-            working_tensor, working_padding, value, use_multicore, memory_config_arg, sub_core_grids);
+            working_tensor, working_padding, value, use_multicore, sub_core_grids);
         if (std::all_of(working_padding.begin(), working_padding.end(), [](auto& p) {
                 return p.before_elements == 0 && p.after_elements == 0;
             })) {
+            if (memory_config_arg.has_value()) {
+                return ttnn::operations::experimental::quasar::to_memory_config(
+                    working_tensor, memory_config_arg.value());
+            }
             return working_tensor;
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad.cpp
@@ -264,6 +264,22 @@ ttnn::Tensor pad_impl(
         padding_size = padding.size();
         extra_index = 0;
     }
+    if (original_rank > 4) {
+        // Only padding[extra_index .. extra_index + 3] reaches the 4D kernel. Dims below extra_index have no
+        // slot in the 4D spec at all, and axis 0 of the squeezed tensor may be several original dims folded
+        // together -- padding applied there would stretch the whole merged axis instead of one dimension.
+        // pad_leading_dimensions() consumes those dims before we get here; this guard is what the removed
+        // "only supports padding on the lowest 3 dimensions" TT_FATAL used to provide.
+        const auto is_unpadded = [](const PadSpecDim& p) { return p.before_elements == 0 && p.after_elements == 0; };
+        const bool axis0_is_merged =
+            input_tensor_4D.logical_shape()[0] != input_tensor.logical_shape()[static_cast<int>(extra_index)];
+        TT_FATAL(
+            std::all_of(padding.begin(), padding.begin() + static_cast<std::ptrdiff_t>(extra_index), is_unpadded) &&
+                (!axis0_is_merged || is_unpadded(padding[extra_index])),
+            "ttnn.pad: padding on the leading dimensions of a rank {} tensor must be consumed before the squeeze "
+            "to 4D; got a non-zero pad on a dimension that the 4D kernel cannot address",
+            original_rank);
+    }
     auto input_shape_with_tile_padding =
         (input_tensor_4D.layout() == Layout::TILE) ? input_tensor_4D.padded_shape() : input_tensor_4D.logical_shape();
     // For tilized tensors, we want the shape padded to the nearest tile. For row major, we just want the row size
@@ -337,10 +353,19 @@ ttnn::Tensor invoke_rm(
             output_tensor = ttnn::operations::experimental::quasar::reshape(output_tensor, ttnn::Shape(padded_shape));
         }
     } else {
+        // invoke_rm only ever sees row-major tensors, and pad_impl sizes the 4D output from the *logical*
+        // shape in that case (input_shape_with_tile_padding). The padded output therefore carries no
+        // alignment padding of its own, so the restored rank-N padded shape is the padded logical shape.
+        // Deriving it from input_tensor.padded_shape() instead would disagree with the buffer whenever an
+        // input arrives with padded_shape != logical_shape (e.g. an explicit two-shape reshape).
         const auto output_logical_shape = compute_padded_logical_shape(input_tensor.logical_shape(), padding_vec);
-        const auto output_padded_shape = compute_padded_logical_shape(input_tensor.padded_shape(), padding_vec);
+        TT_FATAL(
+            output_logical_shape.volume() == output_tensor.padded_shape().volume(),
+            "ttnn.pad: restored shape {} does not match the padded output volume of {}",
+            output_logical_shape,
+            output_tensor.padded_shape());
         output_tensor =
-            ttnn::operations::experimental::quasar::reshape(output_tensor, output_logical_shape, output_padded_shape);
+            ttnn::operations::experimental::quasar::reshape(output_tensor, output_logical_shape, output_logical_shape);
     }
     return output_tensor;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad.cpp
@@ -11,6 +11,7 @@
 #include "ttnn/operations/experimental/reshape/view.hpp"
 #include "ttnn/operations/experimental/quasar/typecast/typecast.hpp"
 #include "ttnn/operation.hpp"
+#include <numeric>
 #include <ttnn/tensor/types.hpp>
 
 #include "pad.hpp"
@@ -53,23 +54,17 @@ ttnn::Tensor pad_leading_dimension_via_reshape(
         dim,
         rank);
 
-    uint32_t before = 1;
-    for (int i = 0; i < dim; i++) {
-        before *= shape[i];
-    }
-
-    uint32_t middle = 1;
-    for (int i = dim; i < rank - 2; i++) {
-        middle *= shape[i];
-    }
+    const auto shape_view = shape.view();
+    const uint32_t before =
+        std::accumulate(shape_view.begin(), shape_view.begin() + dim, 1u, std::multiplies<uint32_t>());
+    const uint32_t middle =
+        std::accumulate(shape_view.begin() + dim, shape_view.begin() + rank - 2, 1u, std::multiplies<uint32_t>());
 
     auto reshaped = ttnn::operations::experimental::quasar::reshape(
         input_tensor, ttnn::Shape({before, middle, shape[-2], shape[-1]}));
 
-    uint32_t inner_extent = 1;
-    for (int i = dim + 1; i < rank - 2; i++) {
-        inner_extent *= shape[i];
-    }
+    const uint32_t inner_extent =
+        std::accumulate(shape_view.begin() + dim + 1, shape_view.begin() + rank - 2, 1u, std::multiplies<uint32_t>());
 
     ttsl::SmallVector<PadSpecDim> padding_4d = {
         {0, 0}, {pad_spec.before_elements * inner_extent, pad_spec.after_elements * inner_extent}, {0, 0}, {0, 0}};
@@ -263,10 +258,7 @@ ttnn::Tensor pad_impl(
     }
     if (original_rank > 4) {
         // Only padding[extra_index .. extra_index + 3] reaches the 4D kernel. Dims below extra_index have no
-        // slot in the 4D spec at all, and axis 0 of the squeezed tensor may be several original dims folded
-        // together -- padding applied there would stretch the whole merged axis instead of one dimension.
-        // pad_leading_dimensions() consumes those dims before we get here; this guard is what the removed
-        // "only supports padding on the lowest 3 dimensions" TT_FATAL used to provide.
+        // slot in the 4D spec, and axis 0 of the squeezed tensor may fold several original dims together.
         const auto is_unpadded = [](const PadSpecDim& p) { return p.before_elements == 0 && p.after_elements == 0; };
         const bool axis0_is_merged =
             input_tensor_4D.logical_shape()[0] != input_tensor.logical_shape()[static_cast<int>(extra_index)];

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/pad/pad_nanobind.cpp
@@ -22,7 +22,7 @@ namespace ttnn::operations::experimental::quasar::detail {
 void bind_pad(nb::module_& mod) {
     const auto* doc = R"doc(
         Returns a padded tensor, with a specified value at the specified location. If the input tensor is on host, the pad will be performed on host, and if its on device it will be performed on device.
-        Any rank of tensor is supported, however tensors with rank > 4 can only apply padding to the lower 3 dimensions.
+        Any rank of tensor is supported. For rank > 4, leading dimensions are padded via a reshape path before the 4D device kernel; tile layout still does not support front padding on device.
 
         Args:
             * :attr:`input_tensor`: (ttnn.Tensor): the input tensor.


### PR DESCRIPTION
Fixes https://github.com/tenstorrent/tt-metal/issues/38144.

`ttnn.pad` rejected padding on any dimension above the lowest three once rank exceeded four, even though the op is documented as rank-generic. The device path already squeezed to 4D; the real gaps were (1) leading dimensions merged by `squeeze_from_ND_to_4D` had no padding mechanism, and (2) ND shape restore dropped padding on upper dims. This PR removes the rank > 4 restriction for device tensors, adds a reshape-based path for leading dims, fixes logical shape restore, and keeps the Quasar mirror in sync.

Host tensors with rank > 4 still only support padding on the lowest three dimensions (`TT_FATAL`), since host tile padding is not fixed here. When dim `rank-4` maps cleanly to 4D axis 0 after squeeze, that dim is handled in the final 4D pass to avoid an extra copy; otherwise it goes through the reshape path. Added rank > 4 unit tests (row-major, tile, dtypes, memory configs, multicore).

Pipeline status

- [x]  Sanity
- [x]  (Runtime) Sanity Test
- [x]  BHPC
- [x]  Nightly for DM Category
- [x]  All model test
- [x]  Single card
- [x]  T3K
- [x]  Galaxy
- [x]  (Tier 1) Models Device Perf Tests
- [x]  (TM-DM) Data Movement Test Suite

 
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/38144)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/38144)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/38144)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/38144)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/38144)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/38144)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/38144)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/38144)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/38144)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/38144)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/38144)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/38144)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/38144)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/38144)