### PR TITLE
[Quasar] Add MOP double-buffering repro

### DIFF
--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -7,6 +7,7 @@
 #include "internal/firmware_common.h"
 #include "risc_common.h"
 #include <tensix.h>
+#include <cstdint>
 #include "hostdev/dev_msgs.h"
 
 #include "tools/profiler/kernel_profiler.hpp"
@@ -27,31 +28,31 @@
 
 #if defined(PROFILE_KERNEL)
 namespace kernel_profiler {
-uint32_t wIndex __attribute__((used));
-uint32_t stackSize __attribute__((used));
-uint32_t sums[SUM_COUNT] __attribute__((used));
-uint32_t sumIDs[SUM_COUNT] __attribute__((used));
+std::uint32_t wIndex __attribute__((used));
+std::uint32_t stackSize __attribute__((used));
+std::uint32_t sums[SUM_COUNT] __attribute__((used));
+std::uint32_t sumIDs[SUM_COUNT] __attribute__((used));
 }  // namespace kernel_profiler
 #endif
 
-thread_local uint32_t tt_l1_ptr* rta_l1_base __attribute__((used));
-thread_local uint32_t tt_l1_ptr* crta_l1_base __attribute__((used));
-thread_local uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
+thread_local std::uint32_t tt_l1_ptr* rta_l1_base __attribute__((used));
+thread_local std::uint32_t tt_l1_ptr* crta_l1_base __attribute__((used));
+thread_local std::uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
 
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_ASSERT)
-thread_local uint32_t rta_count __attribute__((used));
-thread_local uint32_t crta_count __attribute__((used));
+thread_local std::uint32_t rta_count __attribute__((used));
+thread_local std::uint32_t crta_count __attribute__((used));
 #endif
 
-uint8_t my_logical_x_ __attribute__((used));
-uint8_t my_logical_y_ __attribute__((used));
-uint8_t my_relative_x_ __attribute__((used));
-uint8_t my_relative_y_ __attribute__((used));
+std::uint8_t my_logical_x_ __attribute__((used));
+std::uint8_t my_logical_y_ __attribute__((used));
+std::uint8_t my_relative_x_ __attribute__((used));
+std::uint8_t my_relative_y_ __attribute__((used));
 
 #if defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK)
 #if defined(UCK_CHLKC_PACK)
 thread_local LocalDFBInterface g_dfb_interface[dfb::MAX_ACTIVE_DFBS_PACK] __attribute__((used));
-thread_local uint8_t g_dfb_logical_to_compact[dfb::NUM_DFBS] __attribute__((used));
+thread_local std::uint8_t g_dfb_logical_to_compact[dfb::NUM_DFBS] __attribute__((used));
 #else
 thread_local LocalDFBInterface g_dfb_interface[dfb::NUM_DFBS] __attribute__((used));
 #endif
@@ -71,11 +72,13 @@ namespace ckernel {
 #undef PTR_CONST
 
 // Flip between 0 and 1 to keep state between kernel calls
-thread_local uint32_t cfg_state_id __attribute__((used)) = 0;
-thread_local uint32_t op_info_offset __attribute__((used)) = 0;
+thread_local std::uint32_t cfg_state_id __attribute__((used)) = 0;
+thread_local std::uint32_t op_info_offset __attribute__((used)) = 0;
 namespace trisc {
 // Flip between 0 and 1 to keep dest pointer between kernel calls
-thread_local uint32_t dest_register_offset __attribute__((used)) = 0;
+thread_local std::uint32_t dest_register_offset __attribute__((used)) = 0;
+thread_local mop_bank_tracker_t mop_bank_tracker __attribute__((used)) = {0, 0};
+thread_local replay_bank_tracker_t replay_bank_tracker __attribute__((used)) = {0, 0, 0};
 }  // namespace trisc
 
 tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE + MEM_L1_UNCACHED_BASE);
@@ -98,29 +101,30 @@ void init_sync_registers() {
 
 inline void enable_cc_stack() {
 #if defined(UCK_CHLKC_MATH)
-    constexpr uint32_t SFPENCC_IMM12_BOTH = 3;
-    constexpr uint32_t SFPENCC_MOD1_EI_RI = 10;
+    constexpr std::uint32_t SFPENCC_IMM12_BOTH = 3;
+    constexpr std::uint32_t SFPENCC_MOD1_EI_RI = 10;
     TTI_SFPENCC(SFPENCC_IMM12_BOTH, SFPENCC_MOD1_EI_RI);  // Enable all the SFPU lanes
 #endif
 }
 
-extern "C" uint32_t _start1() {
+extern "C" std::uint32_t _start1() {
     configure_csr();
-    uint32_t hartid = internal_::get_hw_thread_idx();
-    uint32_t neo_id = internal_::get_neo_id();
-    uint32_t trisc_id = internal_::get_trisc_id();
+    std::uint32_t hartid = internal_::get_hw_thread_idx();
+    std::uint32_t neo_id = internal_::get_neo_id();
+    std::uint32_t trisc_id = internal_::get_trisc_id();
     DEVICE_PRINT("hartid: {}\n", hartid);
-    volatile tt_l1_ptr uint8_t* const trisc_run = &((tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE + MEM_L1_UNCACHED_BASE))
-                                                       ->subordinate_sync.map[hartid];  // first entry is for NCRISC
+    volatile tt_l1_ptr std::uint8_t* const trisc_run =
+        &((tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE + MEM_L1_UNCACHED_BASE))
+             ->subordinate_sync.map[hartid];  // first entry is for NCRISC
     WAYPOINT("I");
 
     if (neo_id == 0) {
-        extern uint32_t __ldm_data_start[];
+        extern std::uint32_t __ldm_data_start[];
         do_crt1(__ldm_data_start);
         (*GET_MAILBOX_ADDRESS_DEV(fw_shared_globals_ready))[MaxDMProcessorsPerCoreType + trisc_id] =
             SHARED_GLOBALS_READY_GO;
     }
-    extern uint32_t __ldm_tdata_init[];
+    extern std::uint32_t __ldm_tdata_init[];
     do_thread_crt1(__ldm_tdata_init);
 
     while ((*GET_MAILBOX_ADDRESS_DEV(fw_shared_globals_ready))[MaxDMProcessorsPerCoreType + trisc_id] !=
@@ -152,28 +156,29 @@ extern "C" uint32_t _start1() {
         // RUN_SYNC_MSG_DONE is signaled.
         {
             DeviceZoneScopedMainN("TRISC-FW");
-            uint32_t launch_msg_rd_ptr = mailboxes->launch_msg_rd_ptr;
+            std::uint32_t launch_msg_rd_ptr = mailboxes->launch_msg_rd_ptr;
             launch_msg_t* launch_msg = &(mailboxes->launch[launch_msg_rd_ptr]);
 
             uintptr_t kernel_config_base = launch_msg->kernel_config.kernel_config_base[ProgrammableCoreType::TENSIX];
 
 #if defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_PACK)
-            uint32_t tt_l1_ptr* dfb_l1_base = (uint32_t tt_l1_ptr*)(MEM_L1_UNCACHED_BASE + kernel_config_base +
-                                                                    launch_msg->kernel_config.local_cb_offset);
-            uint32_t num_local_dfbs = launch_msg->kernel_config.local_cb_mask;
+            std::uint32_t tt_l1_ptr* dfb_l1_base =
+                (std::uint32_t tt_l1_ptr*)(MEM_L1_UNCACHED_BASE + kernel_config_base +
+                                           launch_msg->kernel_config.local_cb_offset);
+            std::uint32_t num_local_dfbs = launch_msg->kernel_config.local_cb_mask;
             setup_local_dfb_interfaces(dfb_l1_base, num_local_dfbs);
 #endif
 
             // TODO: Remove MEM_L1_UNCACHED_BASE here and invalidate cache lines when PR #38124 is merged
-            rta_l1_base =
-                (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.rta_offset[hartid].rta_offset +
-                                      MEM_L1_UNCACHED_BASE);
-            crta_l1_base =
-                (uint32_t tt_l1_ptr*)(kernel_config_base + launch_msg->kernel_config.rta_offset[hartid].crta_offset +
-                                      MEM_L1_UNCACHED_BASE);
+            rta_l1_base = (std::uint32_t tt_l1_ptr*)(kernel_config_base +
+                                                     launch_msg->kernel_config.rta_offset[hartid].rta_offset +
+                                                     MEM_L1_UNCACHED_BASE);
+            crta_l1_base = (std::uint32_t tt_l1_ptr*)(kernel_config_base +
+                                                      launch_msg->kernel_config.rta_offset[hartid].crta_offset +
+                                                      MEM_L1_UNCACHED_BASE);
             sem_l1_base[ProgrammableCoreType::TENSIX] =
-                (uint32_t tt_l1_ptr*)(kernel_config_base +
-                                      launch_msg->kernel_config.sem_offset[ProgrammableCoreType::TENSIX]);
+                (std::uint32_t tt_l1_ptr*)(kernel_config_base +
+                                           launch_msg->kernel_config.sem_offset[ProgrammableCoreType::TENSIX]);
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_ASSERT)
             // Initialize RTA count from L1 memory
             // Set to 0 if: 1. offset is sentinel (no args set)
@@ -205,16 +210,16 @@ extern "C" uint32_t _start1() {
             uintptr_t kernel_lma =
                 (kernel_config_base +
                  launch_msg->kernel_config.kernel_text_offset[hartid]);  // TODO verify if depends on kernel
-            auto stack_free = reinterpret_cast<uint32_t (*)()>(kernel_lma)();
+            auto stack_free = reinterpret_cast<std::uint32_t (*)()>(kernel_lma)();
             record_stack_usage(stack_free);
             WAYPOINT("D");
             DEVICE_PRINT_KERNEL_FINISHED();
 
             // Signal completion
-            DPRINT("SIGNALING COMPLETION {:x}\n", (uint32_t)*trisc_run);
+            DPRINT("SIGNALING COMPLETION {:x}\n", (std::uint32_t)*trisc_run);
             tensix_sync();
         }
         *trisc_run = RUN_SYNC_MSG_DONE;
-        DPRINT("COMPLETION SIGNED OFF {:x}\n", (uint32_t)*trisc_run);
+        DPRINT("COMPLETION SIGNED OFF {:x}\n", (std::uint32_t)*trisc_run);
     }
 }

--- a/tt_metal/tt-llk/tests/python_tests/helpers/exalens_server.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/exalens_server.py
@@ -120,9 +120,11 @@ class ExalensServer:
                     )
                     pytest.exit(returncode=1)
 
-                if self._log_contains_ready_pattern():
+                readiness_mode = self._get_readiness_mode()
+                if readiness_mode:
                     logger.info(
-                        "tt-exalens ready (PID {}, took ~{}s)",
+                        "tt-exalens ready via {} readiness (PID {}, took ~{}s)",
+                        readiness_mode,
                         self._process.pid,
                         elapsed,
                     )
@@ -201,17 +203,24 @@ class ExalensServer:
             return f"(from {latest})\n" + "\n".join(error_lines)
         return None
 
-    def _log_contains_ready_pattern(self) -> bool:
+    def _get_readiness_mode(self) -> Optional[str]:
         if not self._log_path or not os.path.exists(self._log_path):
-            return False
+            return None
         try:
             with open(self._log_path, "r") as f:
                 f.seek(self._log_read_offset)
                 new_data = f.read()
                 self._log_read_offset = f.tell()
-                return self.READY_PATTERN in new_data
+                if self.READY_PATTERN in new_data:
+                    return "4B"
+                legacy_ready_pattern = (
+                    f"ttexalens-server listening on port {self._port}"
+                )
+                if legacy_ready_pattern in new_data:
+                    return "legacy server-listening"
+                return None
         except OSError:
-            return False
+            return None
 
     def _read_log_tail(self, lines: int = 30) -> str:
         if not self._log_path or not os.path.exists(self._log_path):

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_template.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_template.h
@@ -393,7 +393,7 @@ void ckernel_template::program_bank0_sw_cntl([[maybe_unused]] volatile std::uint
 {
     volatile mop_config_regs_t *mop_cfg = reinterpret_cast<volatile mop_config_regs_t *>(MOP_CFG_BASE);
 
-    // Caller is responsible for ensuring bank0 is safe to overwrite (see _llk_mop_bank_reclaim_if_full_)
+    // Caller is responsible for ensuring bank0 is safe to overwrite (see _llk_mop_bank_acquire_)
     // before calling this -- no blanket mop_sync() drain here.
 
     mop_cfg->MOP_CONFIG              = 2;
@@ -413,7 +413,7 @@ void ckernel_template::program_bank1_sw_cntl([[maybe_unused]] volatile std::uint
 {
     volatile mop_config_regs_t *mop_cfg = reinterpret_cast<volatile mop_config_regs_t *>(MOP_CFG_BASE);
 
-    // Caller is responsible for ensuring bank1 is safe to overwrite (see _llk_mop_bank_reclaim_if_full_)
+    // Caller is responsible for ensuring bank1 is safe to overwrite (see _llk_mop_bank_acquire_)
     // before calling this -- no blanket mop_sync() drain here.
 
     mop_cfg->MOP_CONFIG              = 2;

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_template.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_template.h
@@ -393,7 +393,8 @@ void ckernel_template::program_bank0_sw_cntl([[maybe_unused]] volatile std::uint
 {
     volatile mop_config_regs_t *mop_cfg = reinterpret_cast<volatile mop_config_regs_t *>(MOP_CFG_BASE);
 
-    mop_sync(); // wait until previous mops have completed
+    // Caller is responsible for ensuring bank0 is safe to overwrite (see _llk_mop_bank_reclaim_if_full_)
+    // before calling this -- no blanket mop_sync() drain here.
 
     mop_cfg->MOP_CONFIG              = 2;
     mop_cfg->BANK0_LOOP0_LEN         = m_outer_loop_len;
@@ -412,7 +413,8 @@ void ckernel_template::program_bank1_sw_cntl([[maybe_unused]] volatile std::uint
 {
     volatile mop_config_regs_t *mop_cfg = reinterpret_cast<volatile mop_config_regs_t *>(MOP_CFG_BASE);
 
-    mop_sync(); // wait until previous mops have completed
+    // Caller is responsible for ensuring bank1 is safe to overwrite (see _llk_mop_bank_reclaim_if_full_)
+    // before calling this -- no blanket mop_sync() drain here.
 
     mop_cfg->MOP_CONFIG              = 2;
     mop_cfg->BANK1_LOOP0_LEN         = m_outer_loop_len;

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
@@ -108,22 +108,133 @@ static std::uint32_t dest_register_offset = 0;
 extern thread_local std::uint32_t dest_register_offset;
 #endif
 
-// Tracks which MOP config bank (0 or 1) the next _llk_*_mop_config_ call on this thread should
-// program into. Toggles after each program so the paired execute function can infer which bank
-// just got a fresh program (the opposite of the now-current value) vs which one is still running.
+// Per-TRISC software state for the two MOP config banks. Semaphores cannot track these claims
+// because semaphore IDs are shared across TRISCs.
+struct mop_bank_tracker_t
+{
+    std::uint32_t next_program_bank_id;
+    std::uint32_t num_claimed_banks;
+};
+
 #ifdef ENV_LLK_INFRA
-static std::uint32_t current_program_mop_bank_id = 0;
+static mop_bank_tracker_t mop_bank_tracker = {0, 0};
 #else
-extern thread_local std::uint32_t current_program_mop_bank_id;
+extern thread_local mop_bank_tracker_t mop_bank_tracker;
 #endif
 
+// Per-TRISC software tracking for the two instruction replay banks. Claims
+// count outstanding replay-bank uses; hardware mutex ownership is established
+// later by an execute REPLAY with set_mutex=1. The replay load and execute
+// cursors are distinct hardware state and need not match the MOP bank selected
+// by _mop_bank_program_.
+struct replay_bank_tracker_t
+{
+    std::uint32_t next_load_bank_id;
+    std::uint32_t next_execute_bank_id;
+    std::uint32_t num_claimed_banks;
+};
+
+#ifdef ENV_LLK_INFRA
+static replay_bank_tracker_t replay_bank_tracker = {0, 0, 0};
+#else
+extern thread_local replay_bank_tracker_t replay_bank_tracker;
+#endif
+
+inline void _replay_bank_tracker_reset_from_hw_()
+{
+    replay_bank_tracker.next_load_bank_id    = replay_mmap[replay_write_id];
+    replay_bank_tracker.next_execute_bank_id = replay_mmap[replay_read_id];
+    replay_bank_tracker.num_claimed_banks    = 0;
+}
+
+inline void _replay_bank_clear_mutexes_()
+{
+    replay_mmap[mutex_0_unbanked] = 0;
+    replay_mmap[mutex_1_unbanked] = 0;
+}
+
+inline void _replay_bank_align_load_execute_cursors_()
+{
+    if (replay_mmap[replay_write_id] != replay_mmap[replay_read_id])
+    {
+        // Preserve finish_using_replay_mmio_load()'s established alignment
+        // sequence: done=1 flips the instruction-load cursor after the NOP.
+        TTI_REPLAY(0, 1, 1, 0, 0, 1);
+        TTI_NOP;
+        wait_replay_idle();
+    }
+}
+
 /**
- * @brief Program `temp` into whichever MOP bank current_program_mop_bank_id designates, then toggle it.
- * @note Caller must have already acquired semaphore::MOP_BANK (see _llk_mop_bank_reclaim_if_full_ in llk_sync.h).
+ * @brief Normalize replay ownership when configuring a kernel on this TRISC.
+ *
+ * Drains replay before immediate RISC MMIO mutex writes, releases both banks,
+ * aligns the instruction load cursor with the execute cursor, and snapshots
+ * both hardware cursors into an empty local tracker.
+ */
+inline void _replay_bank_tracker_configure_()
+{
+    wait_replay_idle();
+    _replay_bank_clear_mutexes_();
+    _replay_bank_align_load_execute_cursors_();
+    _replay_bank_tracker_reset_from_hw_();
+}
+
+/**
+ * @brief Record a claim against the hardware instruction-load cursor.
+ *
+ * The first two claims use the two replay banks without draining. Before a
+ * third claim, replay is actively drained, mutexes returned by completed
+ * execute REPLAY instructions are released through MMIO, and local credits
+ * are reset. Hardware load/read IDs are re-read for every claim and remain the
+ * source of truth. This helper intentionally does not lock the load bank:
+ * mutex=1 denotes software ownership and would block the instruction REPLAY
+ * load that follows this claim.
+ *
+ * @return The replay bank id to which the next instruction replay load writes.
+ */
+inline std::uint32_t _replay_bank_acquire_()
+{
+    if (replay_bank_tracker.num_claimed_banks == 2)
+    {
+        wait_replay_idle();
+        _replay_bank_clear_mutexes_();
+        replay_bank_tracker.num_claimed_banks = 0;
+    }
+
+    replay_bank_tracker.next_load_bank_id    = replay_mmap[replay_write_id];
+    replay_bank_tracker.next_execute_bank_id = replay_mmap[replay_read_id];
+    ++replay_bank_tracker.num_claimed_banks;
+    return replay_bank_tracker.next_load_bank_id;
+}
+
+/**
+ * @brief Return replay to the normalized single-bank legacy boundary.
+ *
+ * If this TRISC has no outstanding double-bank claims, this is a no-op.
+ * Otherwise, actively drains replay before releasing mutexes, aligns the
+ * instruction load and execute cursors, and clears all local claims.
+ */
+inline void _replay_bank_legacy_boundary_()
+{
+    if (replay_bank_tracker.num_claimed_banks == 0)
+    {
+        return;
+    }
+
+    wait_replay_idle();
+    _replay_bank_clear_mutexes_();
+    _replay_bank_align_load_execute_cursors_();
+    _replay_bank_tracker_reset_from_hw_();
+}
+
+/**
+ * @brief Program `temp` into the next MOP bank, then toggle the local bank selection.
+ * @note Caller must have already claimed a bank with _llk_mop_bank_acquire_ in llk_sync.h.
  */
 inline void _mop_bank_program_(ckernel_template& temp, volatile std::uint32_t* instrn_buffer)
 {
-    if (current_program_mop_bank_id == 0)
+    if (mop_bank_tracker.next_program_bank_id == 0)
     {
         temp.program_bank0_sw_cntl(instrn_buffer);
     }
@@ -131,7 +242,7 @@ inline void _mop_bank_program_(ckernel_template& temp, volatile std::uint32_t* i
     {
         temp.program_bank1_sw_cntl(instrn_buffer);
     }
-    current_program_mop_bank_id ^= 1;
+    mop_bank_tracker.next_program_bank_id ^= 1;
 }
 
 /**
@@ -140,7 +251,7 @@ inline void _mop_bank_program_(ckernel_template& temp, volatile std::uint32_t* i
  */
 inline void _mop_bank_run_(volatile std::uint32_t* instrn_buffer)
 {
-    if (current_program_mop_bank_id == 0)
+    if (mop_bank_tracker.next_program_bank_id == 0)
     {
         ckernel_template::run_bank1_sw_cntl(instrn_buffer);
     }
@@ -343,7 +454,6 @@ struct semaphore
     // - UNPACK_MATH = unpack->math
     constexpr static std::uint32_t MATH_PACK   = 1; // math <-> pack sync on dest register
     constexpr static std::uint32_t UNPACK_MATH = 4; // unpack <-> math sync on dest register
-    constexpr static std::uint32_t MOP_BANK    = 2; // caps concurrent in-flight MOP bank programming at 2 (one per physical bank)
 
     constexpr static std::uint16_t t6_sem(const std::uint8_t sem_index)
     {

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
@@ -108,6 +108,48 @@ static std::uint32_t dest_register_offset = 0;
 extern thread_local std::uint32_t dest_register_offset;
 #endif
 
+// Tracks which MOP config bank (0 or 1) the next _llk_*_mop_config_ call on this thread should
+// program into. Toggles after each program so the paired execute function can infer which bank
+// just got a fresh program (the opposite of the now-current value) vs which one is still running.
+#ifdef ENV_LLK_INFRA
+static std::uint32_t current_program_mop_bank_id = 0;
+#else
+extern thread_local std::uint32_t current_program_mop_bank_id;
+#endif
+
+/**
+ * @brief Program `temp` into whichever MOP bank current_program_mop_bank_id designates, then toggle it.
+ * @note Caller must have already acquired semaphore::MOP_BANK (see _llk_mop_bank_reclaim_if_full_ in llk_sync.h).
+ */
+inline void _mop_bank_program_(ckernel_template& temp, volatile std::uint32_t* instrn_buffer)
+{
+    if (current_program_mop_bank_id == 0)
+    {
+        temp.program_bank0_sw_cntl(instrn_buffer);
+    }
+    else
+    {
+        temp.program_bank1_sw_cntl(instrn_buffer);
+    }
+    current_program_mop_bank_id ^= 1;
+}
+
+/**
+ * @brief Run whichever MOP bank was just programmed for this op (the opposite of the now-current bank id,
+ *        since _mop_bank_program_ already toggled it).
+ */
+inline void _mop_bank_run_(volatile std::uint32_t* instrn_buffer)
+{
+    if (current_program_mop_bank_id == 0)
+    {
+        ckernel_template::run_bank1_sw_cntl(instrn_buffer);
+    }
+    else
+    {
+        ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    }
+}
+
 /**
 * @brief Check divisibility by power of 2
 * @param value: input value to check divisibility
@@ -301,6 +343,7 @@ struct semaphore
     // - UNPACK_MATH = unpack->math
     constexpr static std::uint32_t MATH_PACK   = 1; // math <-> pack sync on dest register
     constexpr static std::uint32_t UNPACK_MATH = 4; // unpack <-> math sync on dest register
+    constexpr static std::uint32_t MOP_BANK    = 2; // caps concurrent in-flight MOP bank programming at 2 (one per physical bank)
 
     constexpr static std::uint16_t t6_sem(const std::uint8_t sem_index)
     {

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
@@ -35,11 +35,9 @@ inline void _llk_math_srcAB_hw_configure_(DataFormat srcA_format, DataFormat src
     // RT: This is turned on by default by HW, this should be removed
     set_ttsync_enables<TRACK_ALL>(TRISC_ID);
 
-    // Both MOP config banks start free; _llk_mop_bank_reclaim_if_full_ blocks once both are claimed.
-    // Lives here (once per kernel) rather than in each op's own _init_, so it isn't re-initialized
-    // mid-kernel if a kernel uses multiple different ops on this thread.
-    _llk_sync_init_(semaphore::MOP_BANK, 2, 2);
-    current_program_mop_bank_id = 0;
+    // Both local MOP config bank claims start free. Initialize once per kernel rather than
+    // in each op's own _init_, so multiple ops on this TRISC share the same local tracker.
+    _llk_mop_bank_tracker_init_();
 
     static_assert(!(EN_FP32_MATH_FORMAT && EN_INT32_MATH_FORMAT), "Cannot have Int32 dest & Float32 dest at the same time");
 

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_common.h
@@ -8,6 +8,7 @@
 
 #include "cmath_common.h"
 #include "llk_defs.h"
+#include "llk_sync.h"
 using namespace ckernel;
 using namespace ckernel::trisc;
 using namespace ckernel::math;
@@ -20,9 +21,12 @@ static DataFormatConfigSet data_format_config_set = DataFormatConfigSet::UNCONFI
  * @tparam EN_IMPLIED_MATH_FORMAT: If set to true, will imply math dest format from SrcA reg format
  * @tparam EN_FP32_MATH_FORMAT: Set to true to use math dest in Float32, otherwise default behaviour is Float16/Float16_b depending on input format exponent
  * width
- * @tparam EN_INT32_MATH_FORMAT: Set to true to use math dest in Int32, otherwise default behaviour is Float16/Float16_b depending on input format exponent width
- * @param srcA_format: Input srcA format, used to set ALU configs if not implied math format, values = DataFormat enum, ex: <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
- * @param srcB_format: Input srcB format, used to set ALU configs if not implied math format, values = DataFormat enum, ex: <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
+ * @tparam EN_INT32_MATH_FORMAT: Set to true to use math dest in Int32, otherwise default behaviour is Float16/Float16_b depending on input format exponent
+ * width
+ * @param srcA_format: Input srcA format, used to set ALU configs if not implied math format, values = DataFormat enum, ex:
+ * <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
+ * @param srcB_format: Input srcB format, used to set ALU configs if not implied math format, values = DataFormat enum, ex:
+ * <Float16/Float16_b/Tf32/Int8/Int16/UInt8>
  */
 template <bool EN_IMPLIED_MATH_FORMAT, bool EN_FP32_MATH_FORMAT, bool EN_INT32_MATH_FORMAT>
 inline void _llk_math_srcAB_hw_configure_(DataFormat srcA_format, DataFormat srcB_format)
@@ -30,6 +34,12 @@ inline void _llk_math_srcAB_hw_configure_(DataFormat srcA_format, DataFormat src
     // Turn on automatic Tensix-TRISC synchronization
     // RT: This is turned on by default by HW, this should be removed
     set_ttsync_enables<TRACK_ALL>(TRISC_ID);
+
+    // Both MOP config banks start free; _llk_mop_bank_reclaim_if_full_ blocks once both are claimed.
+    // Lives here (once per kernel) rather than in each op's own _init_, so it isn't re-initialized
+    // mid-kernel if a kernel uses multiple different ops on this thread.
+    _llk_sync_init_(semaphore::MOP_BANK, 2, 2);
+    current_program_mop_bank_id = 0;
 
     static_assert(!(EN_FP32_MATH_FORMAT && EN_INT32_MATH_FORMAT), "Cannot have Int32 dest & Float32 dest at the same time");
 
@@ -80,7 +90,8 @@ inline void _llk_math_srcAB_hw_configure_(DataFormat srcA_format, DataFormat src
  * @tparam EN_IMPLIED_MATH_FORMAT: If set to true, will imply math dest format from SrcA reg format
  * @tparam EN_FP32_MATH_FORMAT: Set to true to use math dest in Float32, otherwise default behaviour is Float16/Float16_b depending on input format exponent
  * width
- * @tparam EN_INT32_MATH_FORMAT: Set to true to use math dest in Int32, otherwise default behaviour is Float16/Float16_b depending on input format exponent width
+ * @tparam EN_INT32_MATH_FORMAT: Set to true to use math dest in Int32, otherwise default behaviour is Float16/Float16_b depending on input format exponent
+ * width
  */
 template <bool EN_IMPLIED_MATH_FORMAT, bool EN_FP32_MATH_FORMAT, bool EN_INT32_MATH_FORMAT>
 inline void _llk_math_upk_to_dest_hw_configure_()

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -30,8 +30,7 @@ inline void _llk_math_eltwise_unary_datacopy_mop_config_(
 {
     // Divide number of rows by how many rows are output per fpu instruction
     // Each FPU instruction moves 8 rows at a time
-    _llk_mop_bank_reclaim_if_full_<p_stall::MATH, p_stall::WAIT_SFPU>();
-    _llk_sync_get_(semaphore::MOP_BANK);
+    _llk_mop_bank_acquire_<p_stall::MATH, p_stall::WAIT_SFPU>();
 
     const std::uint32_t MOP_INNER_LOOP = num_rows_inner_loop >> rows_log2(num_rows_per_move_instrn);
     const std::uint32_t mov_rows_instn = p_mov_src_to_dest::MOV_8_ROWS;

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 
 #include "llk_math_common.h"
+#include "llk_sync.h"
 using namespace ckernel;
 using namespace ckernel::trisc;
 using namespace ckernel::math;
@@ -29,6 +30,9 @@ inline void _llk_math_eltwise_unary_datacopy_mop_config_(
 {
     // Divide number of rows by how many rows are output per fpu instruction
     // Each FPU instruction moves 8 rows at a time
+    _llk_mop_bank_reclaim_if_full_<p_stall::MATH, p_stall::WAIT_SFPU>();
+    _llk_sync_get_(semaphore::MOP_BANK);
+
     const std::uint32_t MOP_INNER_LOOP = num_rows_inner_loop >> rows_log2(num_rows_per_move_instrn);
     const std::uint32_t mov_rows_instn = p_mov_src_to_dest::MOV_8_ROWS;
 
@@ -62,7 +66,7 @@ inline void _llk_math_eltwise_unary_datacopy_mop_config_(
 
     temp.set_last_inner_loop_instr(datacopy_func(ADDR_MOD_1));
 
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    _mop_bank_program_(temp, instrn_buffer);
 }
 
 /**
@@ -151,7 +155,7 @@ inline void _llk_math_eltwise_unary_datacopy_(const std::uint32_t tile_idx)
     _set_dst_write_addr_by_rows_(tile_idx);
 
     // Run MOP
-    ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    _mop_bank_run_(instrn_buffer);
 
     // Reset all counters
     _reset_counters_<p_setrwc::SET_ABD_F>();

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack.h
@@ -27,8 +27,7 @@ using namespace ckernel;
  */
 inline void _llk_pack_mop_config_(const std::uint8_t buf_desc_id, const std::uint32_t num_tiles, const TensorShape& tensor_shape)
 {
-    _llk_mop_bank_reclaim_if_full_<p_stall::PACK0>();
-    _llk_sync_get_(semaphore::MOP_BANK);
+    _llk_mop_bank_acquire_<p_stall::PACK0>();
 
     const std::uint32_t MOP_OUTER_LOOP = num_tiles;
     const std::uint32_t MOP_INNER_LOOP =

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack.h
@@ -9,6 +9,7 @@
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
 #include "llk_pack_common.h"
+#include "llk_sync.h"
 #include "tensor_shape.h"
 
 using namespace ckernel;
@@ -26,6 +27,9 @@ using namespace ckernel;
  */
 inline void _llk_pack_mop_config_(const std::uint8_t buf_desc_id, const std::uint32_t num_tiles, const TensorShape& tensor_shape)
 {
+    _llk_mop_bank_reclaim_if_full_<p_stall::PACK0>();
+    _llk_sync_get_(semaphore::MOP_BANK);
+
     const std::uint32_t MOP_OUTER_LOOP = num_tiles;
     const std::uint32_t MOP_INNER_LOOP =
         (static_cast<std::uint32_t>(tensor_shape.total_num_faces()) == NUM_FACES) ? 1 : static_cast<std::uint32_t>(tensor_shape.total_num_faces());
@@ -45,7 +49,7 @@ inline void _llk_pack_mop_config_(const std::uint8_t buf_desc_id, const std::uin
     }
 
     ckernel_template temp(MOP_OUTER_LOOP, MOP_INNER_LOOP, pack_instrn, incr_to_next_face);
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    _mop_bank_program_(temp, instrn_buffer);
 }
 
 /**
@@ -103,5 +107,5 @@ inline void _llk_pack_(const std::uint32_t start_math_dest_tile_idx, const std::
     TT_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_pacr::PACK0, l1_tile_idx);
 
     // Runs MOP
-    ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    _mop_bank_run_(instrn_buffer);
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack_common.h
@@ -77,11 +77,9 @@ inline void _llk_pack_hw_configure_(const tdma_descriptor_t& tdma_desc, const ck
 {
     static_assert((PACK_SEL == p_pacr::PACK0) || (PACK_SEL == p_pacr::PACK1), "PACK_SEL can only be set to p_pacr::PACK0/PACK1");
 
-    // Both MOP config banks start free; _llk_mop_bank_reclaim_if_full_ blocks once both are claimed.
-    // Lives here (once per kernel) rather than in each op's own _init_, so it isn't re-initialized
-    // mid-kernel if a kernel uses multiple different ops on this thread.
-    _llk_sync_init_(semaphore::MOP_BANK, 2, 2);
-    current_program_mop_bank_id = 0;
+    // Both local MOP config bank claims start free. Initialize once per kernel rather than
+    // in each op's own _init_, so multiple ops on this TRISC share the same local tracker.
+    _llk_mop_bank_tracker_init_();
 
     // RT: make defines to aggregate the packer input format address, to make the below a single function
     // Program math destination register format

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack_common.h
@@ -10,6 +10,7 @@
 #include "cpack_common.h"
 #include "llk_assert.h"
 #include "llk_defs.h"
+#include "llk_sync.h"
 #include "tensor_shape.h"
 
 using namespace ckernel;
@@ -75,6 +76,12 @@ template <std::uint32_t PACK_SEL, bool EN_32BIT_DEST>
 inline void _llk_pack_hw_configure_(const tdma_descriptor_t& tdma_desc, const ckernel::ReluConfig& relu_config)
 {
     static_assert((PACK_SEL == p_pacr::PACK0) || (PACK_SEL == p_pacr::PACK1), "PACK_SEL can only be set to p_pacr::PACK0/PACK1");
+
+    // Both MOP config banks start free; _llk_mop_bank_reclaim_if_full_ blocks once both are claimed.
+    // Lives here (once per kernel) rather than in each op's own _init_, so it isn't re-initialized
+    // mid-kernel if a kernel uses multiple different ops on this thread.
+    _llk_sync_init_(semaphore::MOP_BANK, 2, 2);
+    current_program_mop_bank_id = 0;
 
     // RT: make defines to aggregate the packer input format address, to make the below a single function
     // Program math destination register format

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_sync.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_sync.h
@@ -114,26 +114,36 @@ inline void _llk_stall_cfg_on_()
 }
 
 /**
- * @brief If both MOP config banks are already claimed, block until the oldest one
- *        drains on this thread's own engine, then release its claim.
+ * @brief Reset this TRISC's local MOP bank selection and claim count.
+ */
+inline void _llk_mop_bank_tracker_init_()
+{
+    mop_bank_tracker.next_program_bank_id = 0;
+    mop_bank_tracker.num_claimed_banks    = 0;
+}
+
+/**
+ * @brief Claim one of this TRISC's two MOP config banks, draining the engine before reuse.
  *
- * Call this immediately before acquiring semaphore::MOP_BANK in a _llk_*_mop_config_
- * function. When at least one of the 2 banks has never been claimed yet, this is a
- * no-op (the semaphore read is non-blocking) -- the stall only fires once a third
- * distinct op needs to reclaim a bank that a still-outstanding op is using.
+ * The first two claims use the two physical banks without a stall. A third claim queues
+ * STALL_CFG on this thread's engine, which orders the following bank-program CFG writes
+ * after all prior engine work has drained. Both earlier local claims are therefore retired
+ * before the new claim is recorded.
  *
  * @tparam DrainRes0  Primary resource to drain (e.g. p_stall::UNPACK0, p_stall::PACK0, p_stall::MATH).
  * @tparam DrainRes1  Optional second drain resource (e.g. p_stall::WAIT_SFPU for the math thread).
  * @tparam DrainRes2  Optional third drain resource.
  */
 template <std::uint32_t DrainRes0, std::uint32_t DrainRes1 = p_stall::NOTHING, std::uint32_t DrainRes2 = p_stall::NOTHING>
-inline void _llk_mop_bank_reclaim_if_full_()
+inline void _llk_mop_bank_acquire_()
 {
-    if (semaphore_read(semaphore::MOP_BANK) == 0)
+    if (mop_bank_tracker.num_claimed_banks == 2)
     {
         _llk_stall_cfg_on_<DrainRes0, DrainRes1, DrainRes2>();
-        _llk_sync_post_(semaphore::MOP_BANK);
+        mop_bank_tracker.num_claimed_banks = 0;
     }
+
+    ++mop_bank_tracker.num_claimed_banks;
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_sync.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_sync.h
@@ -114,6 +114,29 @@ inline void _llk_stall_cfg_on_()
 }
 
 /**
+ * @brief If both MOP config banks are already claimed, block until the oldest one
+ *        drains on this thread's own engine, then release its claim.
+ *
+ * Call this immediately before acquiring semaphore::MOP_BANK in a _llk_*_mop_config_
+ * function. When at least one of the 2 banks has never been claimed yet, this is a
+ * no-op (the semaphore read is non-blocking) -- the stall only fires once a third
+ * distinct op needs to reclaim a bank that a still-outstanding op is using.
+ *
+ * @tparam DrainRes0  Primary resource to drain (e.g. p_stall::UNPACK0, p_stall::PACK0, p_stall::MATH).
+ * @tparam DrainRes1  Optional second drain resource (e.g. p_stall::WAIT_SFPU for the math thread).
+ * @tparam DrainRes2  Optional third drain resource.
+ */
+template <std::uint32_t DrainRes0, std::uint32_t DrainRes1 = p_stall::NOTHING, std::uint32_t DrainRes2 = p_stall::NOTHING>
+inline void _llk_mop_bank_reclaim_if_full_()
+{
+    if (semaphore_read(semaphore::MOP_BANK) == 0)
+    {
+        _llk_stall_cfg_on_<DrainRes0, DrainRes1, DrainRes2>();
+        _llk_sync_post_(semaphore::MOP_BANK);
+    }
+}
+
+/**
  * @brief Advance the calling thread's dest bank section in SyncHalf mode.
  *
  * Each thread (math, pack, unpack) keeps its own view of which dest bank it is

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_common.h
@@ -61,11 +61,10 @@ inline void _llk_unpack_configure_unary_(const tdma_descriptor_t& tdma_desc_src)
 {
     _llk_unpack_hw_configure_<UNP_SEL>(tdma_desc_src);
 
-    // Both MOP config banks start free; _llk_mop_bank_reclaim_if_full_ blocks once both are claimed.
-    // Lives here (once per kernel) rather than in each op's own _init_, so it isn't re-initialized
-    // mid-kernel if a kernel uses multiple different ops on this thread.
-    _llk_sync_init_(semaphore::MOP_BANK, 2, 2);
-    current_program_mop_bank_id = 0;
+    // Local MOP and replay bank claims start free. Initialize once per unary kernel rather
+    // than in each op's own _init_, so multiple ops on this TRISC share the same trackers.
+    _llk_mop_bank_tracker_init_();
+    _replay_bank_tracker_configure_();
 }
 
 /**
@@ -80,11 +79,9 @@ inline void _llk_unpack_configure_binary_(const tdma_descriptor_t& tdma_desc_src
     _llk_unpack_hw_configure_<UNP_SEL_0>(tdma_desc_src0);
     _llk_unpack_hw_configure_<UNP_SEL_1>(tdma_desc_src1);
 
-    // Both MOP config banks start free; _llk_mop_bank_reclaim_if_full_ blocks once both are claimed.
-    // Lives here (once per kernel) rather than in each op's own _init_, so it isn't re-initialized
-    // mid-kernel if a kernel uses multiple different ops on this thread.
-    _llk_sync_init_(semaphore::MOP_BANK, 2, 2);
-    current_program_mop_bank_id = 0;
+    // Both local MOP config bank claims start free. Initialize once per kernel rather than
+    // in each op's own _init_, so multiple ops on this TRISC share the same local tracker.
+    _llk_mop_bank_tracker_init_();
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_common.h
@@ -10,6 +10,7 @@
 #include "cmath_common.h"
 #include "cunpack_common.h"
 #include "llk_assert.h"
+#include "llk_sync.h"
 using namespace ckernel;
 using namespace ckernel::trisc;
 
@@ -59,6 +60,12 @@ template <std::uint32_t UNP_SEL>
 inline void _llk_unpack_configure_unary_(const tdma_descriptor_t& tdma_desc_src)
 {
     _llk_unpack_hw_configure_<UNP_SEL>(tdma_desc_src);
+
+    // Both MOP config banks start free; _llk_mop_bank_reclaim_if_full_ blocks once both are claimed.
+    // Lives here (once per kernel) rather than in each op's own _init_, so it isn't re-initialized
+    // mid-kernel if a kernel uses multiple different ops on this thread.
+    _llk_sync_init_(semaphore::MOP_BANK, 2, 2);
+    current_program_mop_bank_id = 0;
 }
 
 /**
@@ -72,6 +79,12 @@ inline void _llk_unpack_configure_binary_(const tdma_descriptor_t& tdma_desc_src
 {
     _llk_unpack_hw_configure_<UNP_SEL_0>(tdma_desc_src0);
     _llk_unpack_hw_configure_<UNP_SEL_1>(tdma_desc_src1);
+
+    // Both MOP config banks start free; _llk_mop_bank_reclaim_if_full_ blocks once both are claimed.
+    // Lives here (once per kernel) rather than in each op's own _init_, so it isn't re-initialized
+    // mid-kernel if a kernel uses multiple different ops on this thread.
+    _llk_sync_init_(semaphore::MOP_BANK, 2, 2);
+    current_program_mop_bank_id = 0;
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_unary_operand.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_unary_operand.h
@@ -47,8 +47,7 @@ inline void _llk_unpack_unary_operand_variable_tile_size_mop_config_(
     // TODO: Implement Unpack to dest for tiny tiles
     static_assert((UNP_SEL == p_unpacr::UNP_A) || (UNP_SEL == p_unpacr::UNP_B), "UNP_SEL can only be set to p_unpacr::UNP_A/UNP_B");
 
-    _llk_mop_bank_reclaim_if_full_<p_stall::UNPACK0>();
-    _llk_sync_get_(semaphore::MOP_BANK);
+    _llk_mop_bank_acquire_<p_stall::UNPACK0>();
 
     const std::uint32_t MOP_OUTER_LOOP = num_tiles;
     const std::uint32_t MOP_INNER_LOOP = tensor_shape.total_num_faces();
@@ -110,8 +109,7 @@ inline void _llk_unpack_unary_operand_mop_config_(const std::uint32_t buf_desc_i
         (UNP_SEL == p_unpacr::UNP_A) || (UNP_SEL == p_unpacr::UNP_B) || (UNP_SEL == p_unpacr::UNP_DEST),
         "UNP_SEL can only be set to p_unpacr::UNP_A/UNP_B/UNP_DEST");
 
-    _llk_mop_bank_reclaim_if_full_<p_stall::UNPACK0>();
-    _llk_sync_get_(semaphore::MOP_BANK);
+    _llk_mop_bank_acquire_<p_stall::UNPACK0>();
 
     const std::uint32_t MOP_OUTER_LOOP     = num_tiles;
     constexpr std::uint32_t MOP_INNER_LOOP = 1;
@@ -162,15 +160,17 @@ inline void _llk_unpack_unary_operand_transpose_mop_config_(const std::uint32_t 
 
     LLK_ASSERT(tensor_shape.total_num_faces() == NUM_FACES, "Transpose is only supported for regular tile dimensions with 4 faces");
 
-    _llk_mop_bank_reclaim_if_full_<p_stall::UNPACK0>();
-    _llk_sync_get_(semaphore::MOP_BANK);
+    _llk_mop_bank_acquire_<p_stall::UNPACK0>();
 
     const std::uint32_t MOP_OUTER_LOOP = num_tiles;
     const std::uint32_t MOP_INNER_LOOP = 1;
 
     constexpr std::uint32_t replay_buf_len = NUM_FACES;
 
-    load_replay_buf<0, replay_buf_len>(
+    // Claim the bank selected by the hardware load cursor without taking its
+    // mutex; last=1 advances that cursor after this instruction load.
+    (void)_replay_bank_acquire_();
+    load_replay_buf<0, replay_buf_len, false, 0, 1>(
         [buf_desc_id]
         {
             if constexpr (UNP_SEL == p_unpacr::UNP_A)
@@ -219,7 +219,7 @@ inline void _llk_unpack_unary_operand_transpose_mop_config_(const std::uint32_t 
     ckernel_template temp(
         MOP_OUTER_LOOP,
         MOP_INNER_LOOP,
-        TT_OP_REPLAY(0 /*start_idx*/, replay_buf_len, 0 /*last*/, 0 /*set_mutex*/, 0 /*execute_while_loading*/, 0 /*load_mode*/),
+        TT_OP_REPLAY(0 /*start_idx*/, replay_buf_len, 1 /*last*/, 1 /*set_mutex*/, 0 /*execute_while_loading*/, 0 /*load_mode*/),
         TT_OP_INC_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, UNP_SEL, 1 /*Value*/)); // Inc Src by 1 tile, because above UNPACR0/1_FACE do not inc counters
 
     // 32-bit datacopy uses ELWADD, which requires datavalid from both SrcA and SrcB
@@ -249,8 +249,7 @@ inline void _llk_unpack_unary_operand_reuse_dest_mop_config_(const std::uint32_t
 {
     static_assert(reuse_dest != EltwiseBinaryReuseDestType::NONE, "reuse_dest must be DEST_TO_SRCA or DEST_TO_SRCB");
 
-    _llk_mop_bank_reclaim_if_full_<p_stall::UNPACK0>();
-    _llk_sync_get_(semaphore::MOP_BANK);
+    _llk_mop_bank_acquire_<p_stall::UNPACK0>();
 
     // CB_UNP: the unpacker that reads real data from the Circular Buffer
     // DUMMY_UNP: the unpacker that gets a dummy dvalid (its source register is filled by MOVD2A/B on the math side)
@@ -327,6 +326,13 @@ template <
 inline void _llk_unpack_unary_operand_init_(const std::uint32_t buf_desc_id, const TensorShape& tensor_shape, const std::uint32_t num_tiles)
 {
     static_assert(!(TRANSPOSE_EN && reuse_dest != EltwiseBinaryReuseDestType::NONE), "Transpose is not supported with reuse_dest");
+
+    if constexpr (!TRANSPOSE_EN)
+    {
+        // Normalize only when this kernel previously claimed replay banks for
+        // transpose; the helper is a no-op for ordinary legacy configurations.
+        _replay_bank_legacy_boundary_();
+    }
 
     if constexpr (unpack_to_dest)
     {

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_unary_operand.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_unary_operand.h
@@ -47,6 +47,9 @@ inline void _llk_unpack_unary_operand_variable_tile_size_mop_config_(
     // TODO: Implement Unpack to dest for tiny tiles
     static_assert((UNP_SEL == p_unpacr::UNP_A) || (UNP_SEL == p_unpacr::UNP_B), "UNP_SEL can only be set to p_unpacr::UNP_A/UNP_B");
 
+    _llk_mop_bank_reclaim_if_full_<p_stall::UNPACK0>();
+    _llk_sync_get_(semaphore::MOP_BANK);
+
     const std::uint32_t MOP_OUTER_LOOP = num_tiles;
     const std::uint32_t MOP_INNER_LOOP = tensor_shape.total_num_faces();
 
@@ -86,7 +89,7 @@ inline void _llk_unpack_unary_operand_variable_tile_size_mop_config_(
         temp.set_start_op(clr_unused_unpacr_engine);
     }
 
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    _mop_bank_program_(temp, instrn_buffer);
 }
 
 /**
@@ -106,6 +109,9 @@ inline void _llk_unpack_unary_operand_mop_config_(const std::uint32_t buf_desc_i
     static_assert(
         (UNP_SEL == p_unpacr::UNP_A) || (UNP_SEL == p_unpacr::UNP_B) || (UNP_SEL == p_unpacr::UNP_DEST),
         "UNP_SEL can only be set to p_unpacr::UNP_A/UNP_B/UNP_DEST");
+
+    _llk_mop_bank_reclaim_if_full_<p_stall::UNPACK0>();
+    _llk_sync_get_(semaphore::MOP_BANK);
 
     const std::uint32_t MOP_OUTER_LOOP     = num_tiles;
     constexpr std::uint32_t MOP_INNER_LOOP = 1;
@@ -135,7 +141,7 @@ inline void _llk_unpack_unary_operand_mop_config_(const std::uint32_t buf_desc_i
         temp.set_end_op(clr_unused_unpacr_engine);
     }
 
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    _mop_bank_program_(temp, instrn_buffer);
 }
 
 /**
@@ -155,6 +161,9 @@ inline void _llk_unpack_unary_operand_transpose_mop_config_(const std::uint32_t 
     static_assert((UNP_SEL == p_unpacr::UNP_A) || (UNP_SEL == p_unpacr::UNP_B), "UNP_SEL can only be p_unpacr::UNP_A or p_unpacr::UNP_B for unpack transpose");
 
     LLK_ASSERT(tensor_shape.total_num_faces() == NUM_FACES, "Transpose is only supported for regular tile dimensions with 4 faces");
+
+    _llk_mop_bank_reclaim_if_full_<p_stall::UNPACK0>();
+    _llk_sync_get_(semaphore::MOP_BANK);
 
     const std::uint32_t MOP_OUTER_LOOP = num_tiles;
     const std::uint32_t MOP_INNER_LOOP = 1;
@@ -220,7 +229,7 @@ inline void _llk_unpack_unary_operand_transpose_mop_config_(const std::uint32_t 
         temp.set_end_op(clr_unused_unpacr_engine);
     }
 
-    temp.program_bank0_sw_cntl(instrn_buffer);
+    _mop_bank_program_(temp, instrn_buffer);
 }
 
 /**
@@ -239,6 +248,9 @@ template <std::uint32_t UNP_SEL, EltwiseBinaryReuseDestType reuse_dest>
 inline void _llk_unpack_unary_operand_reuse_dest_mop_config_(const std::uint32_t buf_desc_id, const std::uint32_t num_tiles, const TensorShape& tensor_shape)
 {
     static_assert(reuse_dest != EltwiseBinaryReuseDestType::NONE, "reuse_dest must be DEST_TO_SRCA or DEST_TO_SRCB");
+
+    _llk_mop_bank_reclaim_if_full_<p_stall::UNPACK0>();
+    _llk_sync_get_(semaphore::MOP_BANK);
 
     // CB_UNP: the unpacker that reads real data from the Circular Buffer
     // DUMMY_UNP: the unpacker that gets a dummy dvalid (its source register is filled by MOVD2A/B on the math side)
@@ -273,7 +285,7 @@ inline void _llk_unpack_unary_operand_reuse_dest_mop_config_(const std::uint32_t
         // END_OP: increment CB tile counter after all faces of a tile are processed
         ckernel_template temp(num_tiles, tensor_shape.total_num_faces(), nop_op, face_inc_op);
         temp.set_end_op(TT_OP_INC_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, CB_UNP, 1 /*Value*/));
-        temp.program_bank0_sw_cntl(instrn_buffer);
+        _mop_bank_program_(temp, instrn_buffer);
     }
     else // Using tiny-tiles
     {
@@ -283,7 +295,7 @@ inline void _llk_unpack_unary_operand_reuse_dest_mop_config_(const std::uint32_t
         // MOP: outer=num_tiles, inner=num_faces
         // Each inner iteration: NOP (dvalid for dummy src) + FACE_INC (unpack face + inc src face)
         ckernel_template temp(num_tiles, tensor_shape.total_num_faces(), nop_op, face_inc_op);
-        temp.program_bank0_sw_cntl(instrn_buffer);
+        _mop_bank_program_(temp, instrn_buffer);
     }
 }
 
@@ -406,7 +418,7 @@ inline void _llk_unpack_unary_operand_(const std::uint32_t l1_tile_idx, const Te
         TTI_SET_DST_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_A, 0);
 
         // Drain UNPACK0 before posting "filled" so the post does not race the writes math reads.
-        ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+        _mop_bank_run_(instrn_buffer);
         _llk_sync_post_<p_stall::UNPACK0>(semaphore::UNPACK_MATH);
 
         // Unpack owns the DEST section base, so it flips to the other bank for the next iteration
@@ -446,5 +458,5 @@ inline void _llk_unpack_unary_operand_(const std::uint32_t l1_tile_idx, const Te
     }
 
     // Runs MOP
-    ckernel::ckernel_template::run_bank0_sw_cntl(instrn_buffer);
+    _mop_bank_run_(instrn_buffer);
 }


### PR DESCRIPTION
Recover software-tracked MOP bank alternation so the accumulated transpose hang can be reproduced and investigated.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
