### PR TITLE
[DCAMP-1206] Add `--exclude` flag to keep dev end-to-end health-check runs out of dashboards

### DIFF
--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/analyze_health_check_results.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/analyze_health_check_results.py
@@ -508,28 +508,48 @@ def _normalize(report):
     return normalize_health_report(report)
 
 
-def analyze(report, csv_output_dir, hostname, slurm_job_id, jira_ticket="", versions=None, telemetry=None):
+def analyze(
+    report,
+    csv_output_dir,
+    hostname,
+    slurm_job_id,
+    jira_ticket="",
+    versions=None,
+    telemetry=None,
+    discard=None,
+    discard_reason=None,
+):
     """Translate a normalized diag_report.json dict into runs.csv (+ checks.csv).
 
     report must already be normalized by the caller so the verdict reflects
     post-reset state. A missing/empty report (None) yields a lone ERROR runs.csv.
     Returns the list of CSV paths written.
+
+    A truthy ``discard`` (e.g. run_health_check --exclude) forces discard=1 with
+    ``discard_reason`` so a full end-to-end dev run still uploads but stays out of
+    the fleet dashboards; it takes precedence over the report's own dry_run flag.
     """
     os.makedirs(csv_output_dir, exist_ok=True)
     ts = now_iso()
     base = os.path.join(csv_output_dir, f"health_check_{hostname}_{slurm_job_id}")
     runs_path, checks_path = base + ".runs.csv", base + ".checks.csv"
 
+    def _apply_exclusion(row):
+        if discard:
+            row["discard"] = 1
+            row["discard_reason"] = discard_reason or row.get("discard_reason") or "excluded"
+        return row
+
     if not report:
         print("WARNING: no diag_report.json - writing fail-closed ERROR runs row")
-        row = error_runs_row(hostname, slurm_job_id, ts, "no diag_report.json", jira_ticket)
+        row = _apply_exclusion(error_runs_row(hostname, slurm_job_id, ts, "no diag_report.json", jira_ticket))
         _validate([row], [])
         _write_csv(runs_path, RUNS_COLS, [row])
         return [runs_path]
 
     meta = machine_meta(report, hostname, slurm_job_id, jira_ticket, ts, versions)
     checks = checks_rows(report, meta)
-    runs = runs_row(report, meta, checks, telemetry)
+    runs = _apply_exclusion(runs_row(report, meta, checks, telemetry))
     _validate([runs], checks)
     _write_csv(runs_path, RUNS_COLS, [runs])
     _write_csv(checks_path, CHECKS_COLS, checks)
@@ -544,6 +564,12 @@ def main():
     p.add_argument("--hostname", required=True)
     p.add_argument("--slurm-job-id", required=True)
     p.add_argument("--jira-ticket", default="")
+    p.add_argument(
+        "--discard",
+        action="store_true",
+        help="Mark the run as discarded (discard=1) so it is excluded from fleet dashboards.",
+    )
+    p.add_argument("--discard-reason", default="", help="Reason recorded in discard_reason when --discard is set.")
     args = p.parse_args()
 
     report = None
@@ -562,6 +588,8 @@ def main():
         hostname=args.hostname,
         slurm_job_id=args.slurm_job_id,
         jira_ticket=args.jira_ticket,
+        discard=1 if args.discard else None,
+        discard_reason=args.discard_reason or None,
     )
 
 

--- a/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
+++ b/tools/scaleout/exabox/health_check_test_suite/test_infrastructure/run_health_check.py
@@ -148,6 +148,17 @@ def parse_args() -> argparse.Namespace:
         default="true",
         help="Delete the log and results directory after the run",
     )
+    p.add_argument(
+        "--exclude",
+        action="store_true",
+        help="Run the full workflow (JIRA + SFTP upload) but flag the results discard=1 so "
+        "they are excluded from the production dashboards. Intended for dev end-to-end testing.",
+    )
+    p.add_argument(
+        "--exclude-reason",
+        default="",
+        help="Reason recorded in discard_reason when --exclude is set (defaults to 'dev-run').",
+    )
 
     args = p.parse_args()
     # node is used to build filesystem paths (log/results dirs); constrain it to a
@@ -172,6 +183,8 @@ def run_csv_analysis(
     ticket_key: str | None,
     versions: dict[str, str],
     telemetry: dict | None = None,
+    discard: int | None = None,
+    discard_reason: str | None = None,
 ) -> str | None:
     """Translate the diag_report.json into the runs/checks CSVs for Superset.
 
@@ -206,6 +219,8 @@ def run_csv_analysis(
                 "fw_bundle_version": _clean_version(versions.get("fw_bundle")),
             },
             telemetry=telemetry,
+            discard=discard,
+            discard_reason=discard_reason,
         )
     except Exception as exc:
         log.warning("CSV analysis failed: %s", exc)
@@ -255,6 +270,12 @@ def main() -> int:
     launch_mode = args.launch_mode
     jira_bearer_token = load_jira_secrets(log_dir, launch_mode)
     sftp_user, sftp_host = load_sftp_secrets(log_dir, launch_mode)
+
+    # Dev end-to-end runs: keep the full workflow but flag the results so they
+    # never land in the fleet dashboards.
+    exclude_reason = (args.exclude_reason or "dev-run") if args.exclude else None
+    if args.exclude:
+        log.info("Run marked --exclude: results will upload but are flagged discard=1 (reason: %s)", exclude_reason)
 
     # Collect version info
     versions = collect_version_info()
@@ -480,6 +501,8 @@ def main() -> int:
         ticket_key=ticket_key,
         versions=versions,
         telemetry=telemetry_summary,
+        discard=1 if args.exclude else None,
+        discard_reason=exclude_reason,
     )
 
     # SFTP upload


### PR DESCRIPTION
### PR Category
Feature

### Summary

Adds `--exclude` to the health-check pipeline so devs can run the **full** workflow (diag + JIRA + SFTP upload) while flagging results `discard=1` to exclude them from the production dashboards. Uses existing `discard` / `discard_reason` fields — no schema change. Default stays `false`, so cron/normal runs are unaffected.

**Changes:** `run-health-check.py` (new `--exclude` / `--exclude-reason` args), `analyze_health_check_results.py` (threads `discard` into run + ERROR rows), Ansible role vars + `sbatch` wiring, and `workflow_dispatch` inputs `exclude` / `exclude_reason`.

**Verified end-to-end on exabox-infra PR** - ran the real workflow from this PR https://github.com/tenstorrent/exabox-infra/pull/1535 with `exclude=true` on two idle nodes; both landed in Snowflake with `discard=1` / `discard_reason=test` (excluded), while a prior no-flag run of the same hosts ingested with `discard=0`:

| Host | Job | Status | `discard` |
|---|---|---|---|
| `bh-glx-110-d05u14` | 30794 | PASS | **1** (`test`) |
| `bh-glx-110-c07u02` | 30795 | PASS | **1** (`test`) |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/hc-exclude-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/hc-exclude-flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/hc-exclude-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/hc-exclude-flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jpanasiuk/hc-exclude-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jpanasiuk/hc-exclude-flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/hc-exclude-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/hc-exclude-flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/hc-exclude-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/hc-exclude-flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/hc-exclude-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/hc-exclude-flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/hc-exclude-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/hc-exclude-flag)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/hc-exclude-flag)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/hc-exclude-flag)