### PR TITLE
prefill(unified expert perf tests CI enablement)

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert_perf.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert_perf.py
@@ -2,113 +2,122 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Device performance test for the unified routed expert FFN op.
+"""Device perf gate for UnifiedRoutedExpertFfn: per-case device duration over the kimi/glm ISL sweep
+on the x_rm production path, measured with the real-time program profiler.
 
-Perf counterpart to ``test_single_routed_expert_isl_sweep``: for kimi and glm
-across the exhaustive ISL (active-token) sweep against the fixed 5K allocated
-buffer, spawn one worker per (model, active) that runs ``run_single_routed_expert``
-on device under Tracy, and assert the ``UnifiedRoutedExpertFfnDeviceOperation``
-device time against a per-case baseline. One op per worker, so a regression
-localizes to the FFN kernel.
-
-The ROW_MAJOR x layout (``x_rm``) is measured — the Blackhole fused-tilize
-production fast path (x tilized + bf8-packed inside the op, fresh output).
-
-Baselines in ``_EXPECTED_NS`` were MEASURED LOCALLY on a BH board on 2026-07-27
-and must be RECALIBRATED on the perf CI runner: device times are DDR-speed
-dependent, so the canonical baselines have to come from the CI runner the check
-actually runs on (mirrors the dated recalibration comments in the sibling
-``test_moe_perf`` / ``test_dispatch_combine_perf``).
+Needs a host-IOMMU runner, hence requires_host_iommu: on Blackhole the profiler's D2H socket uses
+64-bit PCIe addressing, which requires IOMMU with no hugepage fallback (realtime_profiler_manager.cpp).
 """
 
 import pytest
 
-from models.demos.deepseek_v3_d_p.utils.perf_utils import run_model_device_perf_test_per_op
+from models.common.utility_functions import is_blackhole, skip_with_llk_assert, skip_with_watcher
 from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import is_p150
+from tests.ttnn.profiling.realtime_profiler_utils import assert_op_duration_merged, require_realtime_profiler
 from tests.ttnn.nightly.unit_tests.operations.experimental.deepseek_prefill.test_single_routed_expert import (
+    _ISL_ALLOCATED_TOKENS,
     _ISL_EXHAUSTIVE_MODELS,
     _ISL_EXHAUSTIVE_SWEEP,
+    SINGLE_EXPERT_MODELS,
+    run_single_routed_expert,
 )
 
-# Device-op code emitted by the routed expert FFN; the harness sums the rows whose
-# OP CODE contains this substring, so incidental setup ops are excluded.
-_OP_CODE = "UnifiedRoutedExpertFfnDeviceOperation"
+# RT records carry kernel sources, not an OP CODE, so identify the op by its kernel directory.
+_OP_KERNEL_DIR = "/unified_routed_expert_ffn/"
 
-# Worker that runs the op on device (its signposts + the op launch land in the
-# Tracy CSV the harness reads back).
-_WORKER = (
-    "tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/"
-    "test_single_routed_expert.py::test_single_routed_expert_isl_sweep"
-)
-_LAYOUT_ID = "x_rm"  # Blackhole fused-tilize production fast path (ROW_MAJOR bf16 input)
+# Median of this many dispatches. A single dispatch throws occasional >3% flyers, so per-case margins
+# turn into whack-a-mole; the median collapses them and keeps _MARGIN meaningful above 256.
+_ITERS = 3
 
-# Per-(model, active) UnifiedRoutedExpertFfnDeviceOperation device time in ns, measured
-# on a Blackhole P150 (2026-07-27). Recalibrate on the perf CI runner (device times are HW-dependent).
-_EXPECTED_NS: dict[tuple[str, int], int] = {
-    ("kimi_k26", 0): 3_962,
-    ("kimi_k26", 128): 209_611,
-    ("kimi_k26", 256): 221_190,
-    ("kimi_k26", 512): 280_076,
-    ("kimi_k26", 1024): 402_655,
-    ("kimi_k26", 2048): 659_392,
-    ("kimi_k26", 4096): 1_294_679,
-    ("kimi_k26", 5120): 1_681_466,
-    ("glm_51", 0): 3_941,
-    ("glm_51", 128): 186_853,
-    ("glm_51", 256): 194_073,
-    ("glm_51", 512): 244_886,
-    ("glm_51", 1024): 351_959,
-    ("glm_51", 2048): 576_561,
-    ("glm_51", 4096): 1_141_564,
-    ("glm_51", 5120): 1_459_484,
-}
+# Log every program in the profiled window, per iteration — use when recalibrating.
+_VERBOSE = False
 
 _MARGIN = 0.03
+# active=0 is ~4us of launch overhead; margin=1.0 zeroes the floor and leaves only a ceiling.
+_CEILING_ONLY = 1.0
+# At 128/256 of 5120 allocated rows the kernel skips most chunks, so fixed overhead dominates and the
+# median still has a long right tail (glm-256 spans 192-208us over 15 runs); >=512 holds inside 1.5%.
+_LOW_ISL_MARGIN = 0.08
 
-
-def _k_filter(model: str, active: int) -> str:
-    """Pin exactly one ``test_single_routed_expert_isl_sweep`` case: model + isl +
-    layout. Disambiguate substring collisions in the pytest ``-k`` match — e.g.
-    ``isl-512`` is a substring of ``isl-5120`` — by excluding any other sweep value
-    whose id contains this one."""
-    parts = [f"{model}-isl-{active}", _LAYOUT_ID]
-    parts += [
-        f"not isl-{other}" for other in _ISL_EXHAUSTIVE_SWEEP if other != active and f"isl-{active}" in f"isl-{other}"
-    ]
-    return " and ".join(parts)
+# Device duration in ns per (model, active), x_rm layout: median of 5 sweeps on a BH p150b at
+# origin/main (2026-08-11). Recalibrate on the perf runner (DDR-speed dependent): each case logs an
+# "RT-CAL" line in this dict's format, so one run regenerates the table.
+_EXPECTED_NS: dict[tuple[str, int], int] = {
+    ("kimi_k26", 0): 3_836,
+    ("kimi_k26", 128): 209_393,
+    ("kimi_k26", 256): 220_181,
+    ("kimi_k26", 512): 280_262,
+    ("kimi_k26", 1024): 403_174,
+    ("kimi_k26", 2048): 659_044,
+    ("kimi_k26", 4096): 1_301_367,
+    ("kimi_k26", 5120): 1_685_241,
+    ("glm_51", 0): 3_902,
+    ("glm_51", 128): 186_733,
+    ("glm_51", 256): 194_294,
+    ("glm_51", 512): 245_483,
+    ("glm_51", 1024): 352_270,
+    ("glm_51", 2048): 576_240,
+    ("glm_51", 4096): 1_129_544,
+    ("glm_51", 5120): 1_462_299,
+}
 
 
 def _perf_params():
+    """Baseline and margin per (model, active) over the exhaustive ISL sweep, dims from
+    SINGLE_EXPERT_MODELS. No extended_model mark: the markers below already scope where these run."""
     params = []
-    for model in _ISL_EXHAUSTIVE_MODELS:
+    for name, config, _extended in SINGLE_EXPERT_MODELS:
+        if name not in _ISL_EXHAUSTIVE_MODELS:
+            continue
         for active in _ISL_EXHAUSTIVE_SWEEP:
-            command = f"pytest {_WORKER} -k '{_k_filter(model, active)}'"
             params.append(
                 pytest.param(
-                    command,
-                    {_OP_CODE: _EXPECTED_NS[(model, active)]},
-                    f"single_routed_expert_{model}_isl{active}_{_LAYOUT_ID}",
-                    id=f"{model}-isl-{active}",
+                    name,
+                    active,
+                    config.EMB_SIZE,
+                    config.MOE_INTERMEDIATE_SIZE,
+                    _EXPECTED_NS[(name, active)],
+                    _CEILING_ONLY if active == 0 else _LOW_ISL_MARGIN if active <= 256 else _MARGIN,
+                    # "-perf" keeps ids collision-free under -k: "512-perf" is not in "5120-perf".
+                    id=f"{name}-isl-{active}-perf",
                 )
             )
     return params
 
 
-@pytest.mark.parametrize("command, expected_per_op, model_name", _perf_params())
-@pytest.mark.models_device_performance_bare_metal
-# Gate to P150 via tt-smi board telemetry (SMBus). This also skips Wormhole and any
-# other board. Do NOT use ttnn.cluster.get_cluster_type() here: it opens and locks the
-# chip, and since skipif is evaluated at collection time in the parent process, the
-# spawned Tracy worker then deadlocks on CHIP_IN_USE. is_p150() reads tt-smi only, so
-# it takes no device lock.
+@pytest.mark.parametrize("model_name, active_tokens, emb_dim, hidden_dim, expected_ns, margin", _perf_params())
+@pytest.mark.requires_host_iommu
+@pytest.mark.skipif(not is_blackhole(), reason="the measured fused FFN path is Blackhole-only")
 @pytest.mark.skipif(not is_p150(), reason="perf baselines are P150-specific; skip on any other board")
-def test_single_routed_expert_perf(command, expected_per_op, model_name):
-    run_model_device_perf_test_per_op(
-        command=command,
-        expected_per_op=expected_per_op,
-        subdir="prefill_single_routed_expert",
-        model_name=model_name,
-        margin=_MARGIN,
-        comments=model_name,
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
+@skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
+def test_single_routed_expert_perf(
+    device,
+    model_name: str,
+    active_tokens: int,
+    emb_dim: int,
+    hidden_dim: int,
+    expected_ns: int,
+    margin: float,
+):
+    require_realtime_profiler("single routed expert perf checks")
+
+    # run_single_routed_expert also PCC-checks, so a case that gets fast by computing the wrong thing
+    # fails on correctness rather than passing the band.
+    assert_op_duration_merged(
+        device,
+        lambda: run_single_routed_expert(
+            device,
+            _ISL_ALLOCATED_TOKENS,
+            emb_dim,
+            hidden_dim,
+            active_tokens=active_tokens,
+            x_row_major=True,  # x_rm: the Blackhole fused-tilize production fast path
+        ),
+        _OP_KERNEL_DIR,
+        expected_ns=expected_ns,
+        margin=margin,
+        label=f'("{model_name}", {active_tokens})',
+        iters=_ITERS,
+        verbose=_VERBOSE,
     )

--- a/tests/ttnn/profiling/realtime_profiler_utils.py
+++ b/tests/ttnn/profiling/realtime_profiler_utils.py
@@ -2,7 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import statistics
 import time
+
+from loguru import logger
 
 
 DEFAULT_RT_PROFILER_RECORD_TIMEOUT_SECONDS = 1.0
@@ -77,3 +80,83 @@ def profile_realtime_program(
         )
 
     return result, profile_records if collect_all else profile_records[0]
+
+
+def require_realtime_profiler(what: str) -> None:
+    """Fail (not skip) if the profiler is inactive — an unmeasured perf run must not report green.
+    Needs an open device: IsProgramRealtimeProfilerActive segfaults if called at collection time."""
+    import pytest
+
+    import ttnn
+
+    if not ttnn.device.IsProgramRealtimeProfilerActive():
+        pytest.fail(f"Real-time profiler must be active for {what}")
+
+
+def profile_realtime_program_merged(
+    device, run_fn, *, record_timeout_seconds=DEFAULT_RT_PROFILER_RECORD_TIMEOUT_SECONDS
+) -> tuple:
+    """profile_realtime_program with the per-chip records merged per program: returns (result,
+    {runtime_id -> {"duration_ns" (max across chips = critical path), "kernel_sources"}}) in dispatch
+    order. Callers identify their own program, by kernel path or as the only entry."""
+    result, records = profile_realtime_program(
+        device, run_fn, collect_all=True, record_timeout_seconds=record_timeout_seconds
+    )
+
+    per_program: dict = {}
+    for record in records:
+        runtime_id = record["runtime_id"]
+        if not runtime_id:
+            continue
+        entry = per_program.setdefault(runtime_id, {"duration_ns": 0.0, "kernel_sources": record["kernel_sources"]})
+        entry["duration_ns"] = max(entry["duration_ns"], record["duration_ns"])
+
+    assert per_program, "real-time profiler returned no valid program records for the measured region"
+    return result, per_program
+
+
+def assert_op_duration_merged(
+    device, run_fn, kernel_path, *, expected_ns, margin, label, iters=1, verbose=False
+) -> float:
+    """Median device duration of the one program whose kernel sources contain ``kernel_path``, over
+    ``iters`` runs of ``run_fn`` in a single profiler window, asserted within +/-``margin`` of
+    ``expected_ns``. Requires one match per run so the number is attributable to that op; ``verbose``
+    logs every program in the window, and a wrong match count dumps them and fails."""
+
+    def run_all():
+        for _ in range(iters):
+            run_fn()
+
+    _, per_program = profile_realtime_program_merged(device, run_all)
+
+    def dump(log):
+        for seq, (runtime_id, entry) in enumerate(per_program.items()):  # arrival = dispatch order
+            log(
+                f"  [{seq}] runtime_id={runtime_id} duration_ns={entry['duration_ns']:.0f} "
+                f"kernels={sorted({source.rsplit('/', 1)[-1] for source in entry['kernel_sources']})}"
+            )
+
+    if verbose:
+        dump(logger.info)
+
+    matched = [
+        entry["duration_ns"]
+        for entry in per_program.values()
+        if any(kernel_path in source.replace("\\", "/") for source in entry["kernel_sources"])
+    ]
+    if len(matched) != iters:
+        if not verbose:
+            dump(logger.error)
+        raise AssertionError(f"expected {iters} programs matching {kernel_path}, got {len(matched)}")
+
+    median_ns = statistics.median(matched)
+    lower, upper = expected_ns * (1 - margin), expected_ns * (1 + margin)
+    logger.info(
+        f"RT-CAL {label}: {round(median_ns):_} ns  # median of {iters}, expected {expected_ns:_}, "
+        f"band [{lower:.0f}, {upper:.0f}]"
+    )
+    assert lower <= median_ns <= upper, (
+        f"{label} device time {median_ns:.0f} ns outside band [{lower:.0f}, {upper:.0f}] ns "
+        f"(expected {expected_ns} ns, margin +/- {margin * 100:.0f}%)"
+    )
+    return median_ns

--- a/tests/ttnn/profiling/realtime_profiler_utils.py
+++ b/tests/ttnn/profiling/realtime_profiler_utils.py
@@ -29,8 +29,10 @@ def profile_realtime_program(
     import ttnn
 
     profile_records = []
+    dropped = [0]
 
     def collect_records(batch):
+        dropped[0] += int(batch.dropped)
         for record in batch.records:
             if profile_records and not collect_all:
                 return
@@ -72,6 +74,14 @@ def profile_realtime_program(
             time.sleep(0.01)
     finally:
         ttnn.device.UnregisterProgramRealtimeProfilerCallback(handle)
+
+    # Dropped records make the set partial: on a mesh, losing the slowest chip's record silently
+    # under-reports a program's critical path, so a perf gate could read green off incomplete data.
+    if dropped[0]:
+        raise RuntimeError(
+            f"Real-time profiler dropped {dropped[0]} record(s) — the receiver could not keep up, so the "
+            "record set is incomplete and durations may under-report."
+        )
 
     if not profile_records:
         raise RuntimeError(


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Enables the unified routed expert FFN device-perf sweep in CI. Timing comes from the
real-time program profiler instead of Tracy, so it runs in-process on the plain build
(no ENABLE_TRACY, no worker subprocess): 16 cases in ~70s vs ~216s.

### Notes for reviewers
Tested under the L2 nightly experimental **viommu** test group — the RT profiler needs
host IOMMU on Blackhole, so the test carries `requires_host_iommu` and the non-IOMMU
suites deselect it. No pipeline changes needed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/rt-profiler-routed-expert)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/rt-profiler-routed-expert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mbezulj/rt-profiler-routed-expert)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mbezulj/rt-profiler-routed-expert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/rt-profiler-routed-expert)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/rt-profiler-routed-expert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/rt-profiler-routed-expert)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/rt-profiler-routed-expert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/rt-profiler-routed-expert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/rt-profiler-routed-expert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/rt-profiler-routed-expert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/rt-profiler-routed-expert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/rt-profiler-routed-expert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/rt-profiler-routed-expert)