### PR TITLE
[vllm] Tear down the whole server process tree and verify the device is released

### DIFF
--- a/.github/workflows/vllm-model-tests-impl.yaml
+++ b/.github/workflows/vllm-model-tests-impl.yaml
@@ -603,21 +603,77 @@ jobs:
       - name: 🧹 Cleanup server process
         if: always()
         run: |
-          if [ -f "${FILE_SERVER_PID}" ]; then
-            pid=$(cat "${FILE_SERVER_PID}")
-            if kill -0 "$pid" 2>/dev/null; then
-              kill "$pid"
-              echo "✅ Server process with PID $pid terminated."
-              rm -f "${FILE_SERVER_PID}"
-            else
-              echo "❌ Server process already down!"
-              echo "Check out the server log in a step below."
-              exit 1
-            fi
-          else
+          if [ ! -f "${FILE_SERVER_PID}" ]; then
             echo "❌ PID file not found. Server may not have started correctly."
             exit 1
           fi
+
+          pid=$(cat "${FILE_SERVER_PID}")
+
+          # PIDs of every process still holding a /dev/tenstorrent fd. These, not
+          # the launcher, are what must be gone before the next job opens the
+          # device: with VLLM_ENABLE_V1_MULTIPROCESSING the engine cores are
+          # forked children and they own the handles. Scanning is safe because
+          # the job's container has its own PID namespace.
+          device_holders() {
+            local fd_dir holder found=""
+            for fd_dir in /proc/[0-9]*/fd; do
+              holder=${fd_dir#/proc/}
+              holder=${holder%/fd}
+              if readlink "${fd_dir}"/* 2>/dev/null | grep -q tenstorrent; then
+                found="${found} ${holder}"
+              fi
+            done
+            echo "${found}"
+          }
+
+          # Signal the launcher's whole process group, so the engine cores go with
+          # it. Fields shift when comm contains spaces, so parse /proc stat after
+          # the closing paren; pgrp is then the third field.
+          if [ -r "/proc/${pid}/stat" ]; then
+            pgid=$(sed 's/.*) //' "/proc/${pid}/stat" | awk '{print $3}')
+            kill -TERM "-${pgid}" 2>/dev/null || true
+            echo "✅ Sent SIGTERM to server process group ${pgid}."
+          else
+            # Not an error on its own: whichever step observed the server dying
+            # has already failed and reported it. The sweep below still runs,
+            # because a dead launcher is exactly when engine cores are orphaned.
+            echo "⚠️ Server launcher (pid=${pid}) was already down before cleanup."
+            echo "Check out the server log in a step below."
+          fi
+
+          rm -f "${FILE_SERVER_PID}"
+
+          # Graceful first: the engine cores need to unwind their device handles.
+          for _ in $(seq 1 30); do
+            [ -n "$(device_holders)" ] || break
+            sleep 1
+          done
+
+          holders=$(device_holders)
+          if [ -n "${holders}" ]; then
+            echo "⚠️ Still holding /dev/tenstorrent after SIGTERM, escalating to SIGKILL:${holders}"
+            for holder in ${holders}; do
+              kill -KILL "${holder}" 2>/dev/null || true
+            done
+            sleep 5
+          fi
+
+          # A surviving holder hands a dirty device to the next job on this
+          # runner, where it surfaces as an unrelated "Failed to allocate TLB
+          # window". Fail here instead, while it is still attributable. A process
+          # wedged in an uninterruptible driver call outlives SIGKILL, and no
+          # amount of retrying in this container will free it.
+          holders=$(device_holders)
+          if [ -n "${holders}" ]; then
+            echo "❌ Processes still holding /dev/tenstorrent after SIGKILL:${holders}"
+            for holder in ${holders}; do
+              echo "  ${holder}: $(tr '\0' ' ' < "/proc/${holder}/cmdline" 2>/dev/null || true)"
+            done
+            exit 1
+          fi
+
+          echo "✅ No process is holding /dev/tenstorrent."
 
       - name: Show server log
         if: always()


### PR DESCRIPTION
### Problem

`🧹 Cleanup server process` sends a bare `SIGTERM` to the launcher PID only:

```bash
pid=$(cat "${FILE_SERVER_PID}")
if kill -0 "$pid" 2>/dev/null; then kill "$pid"
```

With `VLLM_ENABLE_V1_MULTIPROCESSING` (default on) the `EngineCore_DP*` children are the processes that actually hold `/dev/tenstorrent`. Signalling the launcher does not touch them, so they keep the device claimed through the remaining post-steps (`Show server log`, `Show report`, `AI job summary`, artifact upload, cleanup) and are reaped only later by `docker rm --force`.

Two consequences:

1. Teardown is not deterministic. It relies on container removal, which is a side effect of the runner, not something this job asserts. Nothing in the job verifies the device was ever released.
2. The `else` branch turns "server already down" into `exit 1`. The step that observed the death has already failed and reported it, so cleanup fails a second time and misattributes the failure to itself.

### Change

- SIGTERM the launcher's **process group** instead of the launcher, so the engine cores go with it. The group is read from `/proc/<pid>/stat`, parsed after the closing paren because the fields shift when `comm` contains spaces.
- Wait up to 30s for holders to unwind their device handles, then escalate to `SIGKILL` per holder.
- Re-check afterwards and **fail the step if anything still holds `/dev/tenstorrent`**, printing the PIDs and cmdlines. A holder wedged in an uninterruptible driver call survives `SIGKILL`, and no retry inside this container frees it, so failing loudly is the useful outcome.
- Downgrade "server was already down" to a warning. The sweep still runs, because a dead launcher is precisely when engine cores get orphaned.

Holder detection scans `/proc/[0-9]*/fd` for symlinks pointing at `tenstorrent`, the same mechanism `tests/sweep_framework/framework/tt_smi_util.py` uses in `_device_holder_pids()`. It is safe to sweep unconditionally because the job's container has its own PID namespace.

The launch step is unchanged. `setsid` was considered and rejected: it forks rather than exec-ing when the launcher is already a process-group leader, which would change what `$!` refers to and make `⏰ Wait for server to be ready` fast-fail spuriously on its `kill -0 "$server_pid"` check. Resolving the group from `/proc` at teardown time gets the same result without touching `$!` semantics.

### Scope

This is not the fix for the `Failed to allocate TLB window` failures currently hitting `wh_galaxy_perf`. Those trace to wedged runners (example: `OM1-01A01-STGWH03`, wedged 2026-08-09 by a bare-metal `Galaxy DiT SD3.5 model perf tests` job that hit its step timeout and was SIGKILLed), and every galaxy pipeline fails identically on it, not just vLLM. Because these vLLM jobs are containerized, `docker rm --force` does reap their tree, so they are a weak cross-job leak source.

What this PR buys is determinism and attribution: the device is verified released while the job that used it is still on screen, rather than the next job on the runner reporting a confusing TLB allocation error. It also removes a spurious `exit 1`.

### Behavior change to note in review

A leaked holder that survives `SIGKILL` now fails the job even when the tests passed. That is intentional: the device is dirty and the next job on that runner will break. If reviewers prefer a warning, say so and I will downgrade it.

### Testing

- `yaml.safe_load` parses the workflow; `check yaml` and `yamllint` pre-commit hooks pass.
- Cleanup `run:` block extracted and checked with `bash -n` and `shellcheck -s bash -S warning` (clean).
- `/proc/<pid>/stat` pgrp parsing unit-checked against both a plain `comm` and a `comm` containing spaces and parens.
- Holder detection exercised against a fixture `/proc` tree under `set -e -o pipefail`: detects a process holding a `tenstorrent` fd, reports clean when it is removed, and does not abort on a pid directory with no fds.
- CI: https://github.com/tenstorrent/tt-metal/actions/runs/31585157005

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=viktorpus/vllm-server-teardown-process-group)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:viktorpus/vllm-server-teardown-process-group)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=viktorpus/vllm-server-teardown-process-group)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:viktorpus/vllm-server-teardown-process-group)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=viktorpus/vllm-server-teardown-process-group)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:viktorpus/vllm-server-teardown-process-group)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/vllm-server-teardown-process-group)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/vllm-server-teardown-process-group)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=viktorpus/vllm-server-teardown-process-group)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:viktorpus/vllm-server-teardown-process-group)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/vllm-server-teardown-process-group)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/vllm-server-teardown-process-group)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/vllm-server-teardown-process-group)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/vllm-server-teardown-process-group)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/vllm-server-teardown-process-group)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/vllm-server-teardown-process-group)