### PR TITLE
[group_norm] Mask the tile-padding rows instead of back-correcting for them

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -1896,3 +1896,90 @@ def test_group_norm_sharded_all_config(
         atol=atol,
         frobenius_threshold=frobenius_threshold,
     )
+
+
+@pytest.mark.parametrize("device_params", DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True)
+@pytest.mark.parametrize(
+    # 1.0 is the exp() case, and the worst case for the back-correction this replaced (it drove the
+    # variance negative there, and rsqrt to 786430).
+    "padding_value",
+    [7.0, 1.0, -3.5, 0.5],
+)
+@pytest.mark.parametrize(
+    # grid_x is the M split. With grid_x=2 the batch spans two cores and only the second holds the
+    # padding row-tile; with grid_x=1 every core holds its own batch tail.
+    "grid_y, grid_x",
+    [(2, 1), (2, 2), (2, 4), (4, 2)],
+)
+@pytest.mark.parametrize(
+    # prebuilt_mask=True is what real code should do (free); False makes group_norm derive the
+    # second set per call (~4x slower), covered so the fallback cannot rot.
+    "prebuilt_mask",
+    [True, False],
+)
+def test_group_norm_sharded_dirty_padding(device, grid_y, grid_x, padding_value, prebuilt_mask):
+    # Mirror of test_group_norm_non_tile_aligned_garbage_padding_DRAM for the BLOCK-SHARDED path:
+    # supply non-zero tile padding and require the result to be independent of it.
+    #
+    # A host-side zero-fill of the input only worked interleaved, since fill_implicit_tile_padding
+    # corrupts a block-sharded tensor whose padding tail sits on the last M-core. In-kernel masking
+    # never touches the input, so it covers block-sharded too.
+    if device.core_grid.x < grid_x or device.core_grid.y < grid_y:
+        pytest.skip(f"device grid too small for {grid_x}x{grid_y}")
+
+    torch.manual_seed(0)
+    N, C, HW, G, padded = 1, 256, 100, 32, 128
+    grid_size = ttnn.CoreGrid(y=grid_y, x=grid_x)
+
+    real = torch.rand((N, 1, HW, C), dtype=torch.bfloat16)
+    ref = torch.nn.functional.group_norm(real.view(N, HW, C).permute(0, 2, 1).reshape(N, C, 1, HW).float(), G)
+    ref = ref.permute(0, 2, 3, 1).reshape(N, 1, HW, C)
+
+    buf = torch.zeros((N, 1, padded, C), dtype=torch.bfloat16)
+    buf[:, :, :HW, :] = real
+    buf[:, :, HW:, :] = padding_value  # dirty padding, as reshape / slice / exp would leave
+
+    tt = ttnn.from_torch(
+        buf, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    tt = ttnn.reshape(tt, ttnn.Shape([N, 1, HW, C]), ttnn.Shape([N, 1, padded, C]))
+
+    grid_coord = ttnn.CoreCoord(grid_size.x - 1, grid_size.y - 1)
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), grid_coord)})
+    shard_spec = ttnn.ShardSpec(shard_grid, (padded // grid_size.x, C // grid_size.y), ttnn.ShardOrientation.COL_MAJOR)
+    sharded_mem_config = ttnn.MemoryConfig(
+        ttnn.types.TensorMemoryLayout.BLOCK_SHARDED, ttnn.types.BufferType.L1, shard_spec
+    )
+    tt = ttnn.to_memory_config(tt, sharded_mem_config)
+
+    mask = ttnn.to_device(
+        ttnn.create_group_norm_input_mask(
+            C,
+            G,
+            grid_size.y,
+            ttnn.DataType.BFLOAT8_B,
+            rows_in_last_tile=(HW % 32) if prebuilt_mask else 0,
+        ),
+        device,
+    )
+    out = ttnn.group_norm(
+        tt,
+        num_groups=G,
+        input_mask=mask,
+        memory_config=sharded_mem_config,
+        core_grid=grid_size,
+        inplace=False,
+    )
+    out = ttnn.to_torch(ttnn.from_device(ttnn.to_memory_config(out, ttnn.DRAM_MEMORY_CONFIG))).float()[:, :, :HW, :]
+
+    max_abs_err = (out - ref).abs().max().item()
+    pcc = torch.corrcoef(torch.stack([out.flatten(), ref.flatten()]))[0, 1].item()
+    logger.info(
+        f"block-sharded dirty padding grid={grid_x}x{grid_y} padding={padding_value} "
+        f"prebuilt_mask={prebuilt_mask}: max_abs_err={max_abs_err} pcc={pcc}"
+    )
+    assert max_abs_err < 0.08, (
+        f"max abs error {max_abs_err} with tile padding = {padding_value} on a {grid_x}x{grid_y} "
+        f"block-sharded grid; group_norm must be independent of its padding (see #52685)"
+    )
+    assert pcc > 0.999, f"pcc {pcc} with tile padding = {padding_value} (see #52685)"

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -701,17 +701,9 @@ def test_group_norm_non_tile_aligned_shifted_input_DRAM(device, input_shift, max
 
 
 @pytest.mark.parametrize("device_params", DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True)
-@pytest.mark.xfail(
-    strict=True,
-    reason="tt-metal #50682: the analytical correction requires the tile-padding rows to hold "
-    "exact zeros (every TILE-layout producer supplies them). With garbage in the padding the "
-    "reduce ingests it and the result is meaningless -- measured ~1.92 vs ~0.045. If this XPASSes, "
-    "the padding rows are being masked and the precondition can be dropped from the kernel docs.",
-)
 def test_group_norm_non_tile_aligned_garbage_padding_DRAM(device):
-    # Documents (as a strict xfail) the precondition the correction depends on. The op reduced over
-    # the padding rows before the fix too, so the dependence is not new -- but the fix is what makes
-    # "correct for non-tile-aligned H*W" a claim, and this is its boundary.
+    # Was a strict xfail while group_norm reduced over the tile padding (measured ~1.92 vs ~0.045);
+    # the padding rows are masked out now, so it is a plain test.
     if device.core_grid.y == 7:
         pytest.skip()
 
@@ -737,6 +729,97 @@ def test_group_norm_non_tile_aligned_garbage_padding_DRAM(device):
     max_abs_err = (out - ref).abs().max().item()
     logger.info(f"garbage tile-padding rows: max_abs_err={max_abs_err}")
     assert max_abs_err < 0.08, f"max abs error {max_abs_err} with garbage padding rows (see #50682)"
+
+
+@pytest.mark.parametrize("device_params", DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True)
+@pytest.mark.parametrize(
+    "N, cores_y, num_out_blocks",
+    [
+        # The grid fixes num_virtual_rows, hence whether a batch is split across core rows and so
+        # which cores hold the padding row-tile.
+        pytest.param(1, 1, None, id="N1_grid1x8_whole_batch_per_core"),
+        pytest.param(1, 2, None, id="N1_grid2x8_batch_split_2"),
+        pytest.param(1, 4, None, id="N1_grid4x8_batch_split_4_block_h_1"),
+        pytest.param(2, 1, None, id="N2_grid1x8_two_batches_per_core"),
+        pytest.param(2, 4, None, id="N2_grid4x8_batch_split_2"),
+        # num_out_blocks=3 over block_h=4 leaves the last out-block empty -- the case that breaks a
+        # naive "last block, last row" test.
+        pytest.param(1, 1, 3, id="N1_grid1x8_num_out_blocks_3_empty_last_block"),
+        pytest.param(1, 1, 4, id="N1_grid1x8_num_out_blocks_4"),
+    ],
+)
+def test_group_norm_non_tile_aligned_dirty_padding_grids_DRAM(device, N, cores_y, num_out_blocks):
+    # Which core applies the row mask depends on how the grid splits H*W, and with N > 1 the padding
+    # recurs once per batch on the same core -- a single auto-selected grid reaches neither. Also
+    # pins the out-block indexing: num_out_blocks not dividing block_h can leave the last out-block
+    # with zero rows, so the final row-tile is found by its global index within the batch.
+    cores_x = 8
+    if device.core_grid.y < cores_y or device.core_grid.x < cores_x:
+        pytest.skip(f"device grid too small for {cores_x}x{cores_y}")
+
+    torch.manual_seed(0)
+    C, HW, G, padded = 512, 100, 32, 128
+
+    real = torch.rand((N, 1, HW, C), dtype=torch.bfloat16)
+    ref = torch.nn.functional.group_norm(real.view(N, HW, C).permute(0, 2, 1).reshape(N, C, 1, HW).float(), G)
+    ref = ref.permute(0, 2, 3, 1).reshape(N, 1, HW, C)
+
+    buf = torch.zeros((N, 1, padded, C), dtype=torch.bfloat16)
+    buf[:, :, :HW, :] = real
+    buf[:, :, HW:, :] = 7.0
+
+    tt = ttnn.from_torch(
+        buf, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    tt = ttnn.reshape(tt, ttnn.Shape([N, 1, HW, C]), ttnn.Shape([N, 1, padded, C]))
+    out = ttnn.group_norm(
+        tt,
+        num_groups=G,
+        inplace=False,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        core_grid=ttnn.CoreGrid(y=cores_y, x=cores_x),
+        num_out_blocks=num_out_blocks,
+    )
+    out = ttnn.to_torch(ttnn.from_device(out)).float()[:, :, :HW, :]
+
+    max_abs_err = (out - ref).abs().max().item()
+    pcc = torch.corrcoef(torch.stack([out.flatten(), ref.flatten()]))[0, 1].item()
+    logger.info(f"N={N} grid={cores_x}x{cores_y} num_out_blocks={num_out_blocks}: max_abs_err={max_abs_err} pcc={pcc}")
+    assert max_abs_err < 0.08, (
+        f"max abs error {max_abs_err} with dirty tile padding at N={N} grid={cores_x}x{cores_y} "
+        f"num_out_blocks={num_out_blocks}; group_norm must be independent of its padding (see #52685)"
+    )
+    assert pcc > 0.999, f"pcc {pcc} with dirty tile padding (see #52685)"
+
+
+@pytest.mark.parametrize("device_params", DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True)
+def test_group_norm_non_tile_aligned_dirty_padding_is_ignored_DRAM(device):
+    # The same logical rows with different padding bytes must give bit-identical output -- unlike an
+    # error threshold, this cannot be satisfied by merely keeping the damage small.
+    torch.manual_seed(0)
+    N, C, HW, G, padded = 1, 512, 100, 32, 128
+
+    real = torch.rand((N, 1, HW, C), dtype=torch.bfloat16)
+
+    def run(padding_value):
+        buf = torch.zeros((N, 1, padded, C), dtype=torch.bfloat16)
+        buf[:, :, :HW, :] = real
+        buf[:, :, HW:, :] = padding_value
+        tt = ttnn.from_torch(
+            buf, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+        tt = ttnn.reshape(tt, ttnn.Shape([N, 1, HW, C]), ttnn.Shape([N, 1, padded, C]))
+        out = ttnn.group_norm(tt, num_groups=G, inplace=False, memory_config=ttnn.DRAM_MEMORY_CONFIG, core_grid=None)
+        return ttnn.to_torch(ttnn.from_device(out)).float()[:, :, :HW, :]
+
+    baseline = run(0.0)
+    for padding_value in (7.0, 1.0, -3.5, 0.5, 100.0):
+        other = run(padding_value)
+        assert torch.equal(baseline, other), (
+            f"group_norm output changed when the tile padding changed from 0.0 to {padding_value} "
+            f"(max delta {(baseline - other).abs().max().item()}); the padding rows must not reach "
+            f"either accumulation pass (see #52685)"
+        )
 
 
 @pytest.mark.parametrize("device_params", DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True)

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -194,11 +194,17 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
             input_mask.value().storage_type());
         TT_FATAL(input_mask.value().buffer() != nullptr, "Input mask must be allocated in buffers on device!");
         TT_FATAL(a.device() == input_mask.value().device(), "Input and input mask tensors must be on same device");
+        // For non-tile-aligned H*W on the two-pass path the mask carries a second, row-masked copy
+        // of every group; that is the only reason dim1 may be 2 * num_groups.
+        const bool row_mask_doubled = !args.use_welford && (a.logical_shape()[2] != a.padded_shape()[2]);
+        const uint32_t expected_mask_groups = args.num_groups * (row_mask_doubled ? 2 : 1);
         TT_FATAL(
-            input_mask.value().padded_shape()[1] == args.num_groups,
-            "Input mask dim1 must match number of groups, got: {} vs {}",
-            input_mask.value().padded_shape()[1],
-            args.num_groups);
+            input_mask.value().padded_shape()[1] == expected_mask_groups,
+            "Input mask dim1 must be {} ({}num_groups={}), got: {}",
+            expected_mask_groups,
+            row_mask_doubled ? "2 x " : "",
+            args.num_groups,
+            input_mask.value().padded_shape()[1]);
         TT_FATAL(
             input_mask.value().padded_shape()[2] == tile_height,
             "Input mask height must equal tile height ({}), got: {}",

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_mcast_program_factory.cpp
@@ -300,6 +300,19 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
             block_wt * tile_width);
     }
 
+    // Non-tile-aligned H*W: corrected reduce scaler + the row-masked mask set. See
+    // compute/groupnorm.cpp and GroupNormPadCorrection.
+    const auto pad = make_group_norm_pad_correction(
+        static_cast<uint32_t>(a.logical_shape()[2]),
+        static_cast<uint32_t>(a.padded_shape()[2]),
+        use_welford,
+        tile_height);
+    // The mask carries two sets when the correction is active; cores stride through the first, and
+    // the row-masked one sits mask_set_tiles beyond it.
+    const uint32_t mask_sets = pad.active ? 2 : 1;
+    const uint32_t mask_set_tiles =
+        input_mask.has_value() ? (input_mask.value().physical_volume() / tile_hw) / mask_sets : 0;
+
     uint32_t in0_block_tiles_group_1 = block_ht_group_1 / num_out_blocks * block_wt;
     uint32_t in0_CB_size_group_1 = in0_block_tiles_group_1 * in_single_tile_size;
     uint32_t in_CB_size_group_1 = in0_block_tiles_group_1 * in_single_tile_size;
@@ -309,8 +322,9 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
     uint32_t in5_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
     uint32_t in6_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
     uint32_t input_mask_num_tiles_per_core = block_wt * num_groups_per_core;
+    // The row-masked set shares the CB with the normal one, on top of the double-buffering.
     uint32_t in_mask_CB_size = use_welford ? input_mask.value().physical_volume() * input_mask.value().element_size()
-                                           : block_wt * in_mask_single_tile_size * 2;
+                                           : block_wt * in_mask_single_tile_size * 2 * mask_sets;
     uint32_t repack_CB_size = per_core_Nt * in_single_tile_size * 2;
     uint32_t interm_block_tiles_group_1 = in0_block_tiles_group_1;
     uint32_t x_CB_size_group_1 = interm_block_tiles_group_1 * single_tile_size;
@@ -543,11 +557,6 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
         .noc = reader_noc,
     };
 
-    // Non-tile-aligned H*W (#50682): corrected reduce scaler + K for the variance correction.
-    // Derivation in compute/groupnorm.cpp, `active` semantics in GroupNormPadCorrection.
-    const auto pad = make_group_norm_pad_correction(
-        static_cast<uint32_t>(a.logical_shape()[2]), static_cast<uint32_t>(a.padded_shape()[2]), use_welford);
-
     std::vector<uint32_t> writer_mcast_sender_compile_time_args_group_1 = {};
     std::unordered_map<std::string, uint32_t> writer_named_compile_time_args_group_1 = {
         {"is_mcast_sender", 1},
@@ -579,7 +588,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
         {"logical_hw", pad.kernel_logical_hw},
         {"padded_hw", pad.padded_hw},
         {"pad_scaler_bits", pad.scaler_bits(num_rows_per_batch_per_core_group_1 * num_channels_per_group)},
-        {"pad_k_bits", pad.k_bits},
+        {"has_row_mask", static_cast<uint32_t>(pad.active)},
     };
 
     if (gamma.has_value() && gamma.value().layout() == Layout::ROW_MAJOR) {
@@ -654,7 +663,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
         {"num_groups_per_reset", num_groups_per_reset},
         {"single_tile_size_bytes", single_tile_size},
         {"num_tiles_per_batch", per_core_Mt_group_1 * Wt / num_batches_per_core_group_1},
-        {"num_tiles_input_mask", num_groups_per_core * block_wt},
+        {"num_tiles_input_mask", num_groups_per_core * block_wt * mask_sets},
         {"num_cols_per_group", num_channels_per_group_mod_tile_w},
         {"block_w_last", block_wt_last},
         {"GROUP_SIZE_IS_POWER_OF_2",
@@ -668,6 +677,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
         {"TILE_WIDTH", tile_width},
         {"logical_hw", pad.kernel_logical_hw},
         {"padded_hw", pad.padded_hw},
+        {"has_row_mask", static_cast<uint32_t>(pad.active)},
     };
 
     std::vector<uint32_t> mcast_receiver_compute_compile_time_args_group_1 = {};
@@ -690,7 +700,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
         {"num_groups_per_reset", num_groups_per_reset},
         {"single_tile_size_bytes", single_tile_size},
         {"num_tiles_per_batch", per_core_Mt_group_1 * Wt / num_batches_per_core_group_1},
-        {"num_tiles_input_mask", num_groups_per_core * block_wt},
+        {"num_tiles_input_mask", num_groups_per_core * block_wt * mask_sets},
         {"num_cols_per_group", num_channels_per_group_mod_tile_w},
         {"block_w_last", block_wt_last},
         {"GROUP_SIZE_IS_POWER_OF_2",
@@ -704,6 +714,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
         {"TILE_WIDTH", tile_width},
         {"logical_hw", pad.kernel_logical_hw},
         {"padded_hw", pad.padded_hw},
+        {"has_row_mask", static_cast<uint32_t>(pad.active)},
     };
 
     eltwise_binary_defines["FP32_DEST_ACC"] = fp32_dest_acc_en ? "true" : "false";
@@ -910,15 +921,6 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
             .page_size = single_tile_size,
         }}},
     });
-
-    // Pad-correction scalars/scratch: dfb_k written by the writer, dfb_msq / dfb_kmsq scratch.
-    append_group_norm_pad_correction_cbs(
-        desc.cbs,
-        pad,
-        {tt::CBIndex::c_1, tt::CBIndex::c_7, tt::CBIndex::c_11},
-        all_cores,
-        cb_data_format,
-        single_tile_size);
 
     if (gamma.has_value()) {
         constexpr uint32_t in5_cb_index = tt::CBIndex::c_5;
@@ -1261,8 +1263,9 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
                                      (beta.value().physical_volume() / tile_width);
             }
             if (input_mask.has_value()) {
-                input_mask_tile_start_id = (input_mask_tile_start_id + input_mask_num_tiles_per_core) %
-                                           (input_mask.value().physical_volume() / tile_hw);
+                // Wrap on the set size, not the whole tensor: the row-masked set is an offset off this.
+                input_mask_tile_start_id =
+                    (input_mask_tile_start_id + input_mask_num_tiles_per_core) % mask_set_tiles;
             }
         }
 
@@ -1290,6 +1293,12 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormMcastProgramF
         writer_mcast_sender_args.push_back(beta_tile_start_id);
         writer_mcast_sender_args.push_back(input_mask_tile_start_id);
         writer_mcast_sender_args.push_back(Wt);
+        // Where this core reads the row-masked set from. Only the core holding a batch's final
+        // row-tile needs it; the rest get the normal set again, making compute's switch a no-op
+        // there. Deciding it here keeps the compute kernel compile-time-only.
+        writer_mcast_sender_args.push_back(
+            input_mask_tile_start_id +
+            (pad.active && group_norm_core_owns_pad_tile(virtual_core.y, num_cores_per_batch) ? mask_set_tiles : 0));
         writer_desc.emplace_runtime_args(core, writer_mcast_sender_args);
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_no_mcast_program_factory.cpp
@@ -398,6 +398,20 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
             block_wt * tile_width);
     }
 
+    // Non-tile-aligned H*W: corrected reduce scaler + the row-masked mask set. See
+    // compute/groupnorm.cpp and GroupNormPadCorrection. Each core group carries its own scaler: reduce_factor_w
+    // differs.
+    const auto pad = make_group_norm_pad_correction(
+        static_cast<uint32_t>(a.logical_shape()[2]),
+        static_cast<uint32_t>(a.padded_shape()[2]),
+        use_welford,
+        tile_height);
+    // The mask carries two sets when the correction is active; cores stride through the first, and
+    // the row-masked one sits mask_set_tiles beyond it.
+    const uint32_t mask_sets = pad.active ? 2 : 1;
+    const uint32_t mask_set_tiles =
+        input_mask.has_value() ? (input_mask.value().physical_volume() / tile_hw) / mask_sets : 0;
+
     // Parameters Setup
     uint32_t in0_block_tiles_group_1 = block_ht_group_1 / num_out_blocks * block_wt;
     uint32_t in0_block_tiles_group_2 = 0;
@@ -411,8 +425,9 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     uint32_t in5_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
     uint32_t in6_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
     uint32_t input_mask_num_tiles_per_core = block_wt * num_groups_per_core;
+    // The row-masked set shares the CB with the normal one, on top of the double-buffering.
     uint32_t in_mask_CB_size = use_welford ? input_mask.value().physical_volume() * input_mask.value().element_size()
-                                           : block_wt * in_mask_single_tile_size * 2;
+                                           : block_wt * in_mask_single_tile_size * 2 * mask_sets;
     uint32_t repack_CB_size = per_core_Nt * in_single_tile_size * 2;
     uint32_t interm_block_tiles_group_1 = in0_block_tiles_group_1;
     uint32_t interm_block_tiles_group_2 = 0;
@@ -693,12 +708,6 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
     uint32_t reduce_factor_w_group_2 = std::max(1u, num_rows_per_batch_per_core_group_2 * num_channels_per_group);
     uint32_t reduce_factor_c_group_2 = std::max(1u, num_cores_per_batch * num_cores_per_group);
 
-    // Non-tile-aligned H*W (#50682): corrected reduce scaler + K for the variance correction.
-    // Derivation in compute/groupnorm.cpp, `active` semantics in GroupNormPadCorrection.
-    // Each core group carries its own scaler: reduce_factor_w differs.
-    const auto pad = make_group_norm_pad_correction(
-        static_cast<uint32_t>(a.logical_shape()[2]), static_cast<uint32_t>(a.padded_shape()[2]), use_welford);
-
     std::unordered_map<std::string, uint32_t> writer_named_compile_time_args_group_1 = {
         {"is_mcast_sender", 1},
         {"fuse_gamma", static_cast<uint32_t>(gamma.has_value())},
@@ -729,7 +738,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         {"logical_hw", pad.kernel_logical_hw},
         {"padded_hw", pad.padded_hw},
         {"pad_scaler_bits", pad.scaler_bits(reduce_factor_w_group_1)},
-        {"pad_k_bits", pad.k_bits},
+        {"has_row_mask", static_cast<uint32_t>(pad.active)},
     };
 
     std::unordered_map<std::string, uint32_t> writer_named_compile_time_args_group_2 = {
@@ -762,7 +771,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         {"logical_hw", pad.kernel_logical_hw},
         {"padded_hw", pad.padded_hw},
         {"pad_scaler_bits", pad.scaler_bits(reduce_factor_w_group_2)},
-        {"pad_k_bits", pad.k_bits},
+        {"has_row_mask", static_cast<uint32_t>(pad.active)},
     };
 
     if (gamma.has_value() && gamma.value().layout() == Layout::ROW_MAJOR) {
@@ -849,7 +858,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         {"num_groups_per_reset", num_groups_per_reset},
         {"single_tile_size_bytes", single_tile_size},
         {"num_tiles_per_batch", per_core_Mt_group_1 * Wt / num_batches_per_core_group_1},
-        {"num_tiles_input_mask", num_groups_per_core * block_wt},
+        {"num_tiles_input_mask", num_groups_per_core * block_wt * mask_sets},
         {"num_cols_per_group", num_channels_per_group_mod_tile_w},
         {"block_w_last", block_wt_last},
         {"GROUP_SIZE_IS_POWER_OF_2",
@@ -863,6 +872,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         {"reciprocal_size", num_reciprocals},
         {"logical_hw", pad.kernel_logical_hw},
         {"padded_hw", pad.padded_hw},
+        {"has_row_mask", static_cast<uint32_t>(pad.active)},
     };
 
     std::unordered_map<std::string, uint32_t> mcast_sender_compute_named_compile_time_args_group_2 = {
@@ -884,7 +894,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         {"num_groups_per_reset", num_groups_per_reset},
         {"single_tile_size_bytes", single_tile_size},
         {"num_tiles_per_batch", per_core_Mt_group_2 * Wt / num_batches_per_core_group_2},
-        {"num_tiles_input_mask", num_groups_per_core * block_wt},
+        {"num_tiles_input_mask", num_groups_per_core * block_wt * mask_sets},
         {"num_cols_per_group", num_channels_per_group_mod_tile_w},
         {"block_w_last", block_wt_last},
         {"GROUP_SIZE_IS_POWER_OF_2",
@@ -898,6 +908,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         {"reciprocal_size", num_reciprocals},
         {"logical_hw", pad.kernel_logical_hw},
         {"padded_hw", pad.padded_hw},
+        {"has_row_mask", static_cast<uint32_t>(pad.active)},
     };
 
     eltwise_binary_defines["FP32_DEST_ACC"] = fp32_dest_acc_en ? "true" : "false";
@@ -1172,15 +1183,6 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
             .page_size = single_tile_size,
         }}},
     });
-
-    // Pad-correction scalars/scratch: dfb_k written by the writer, dfb_msq / dfb_kmsq scratch.
-    append_group_norm_pad_correction_cbs(
-        desc.cbs,
-        pad,
-        {tt::CBIndex::c_1, tt::CBIndex::c_7, tt::CBIndex::c_11},
-        all_cores,
-        cb_data_format,
-        single_tile_size);
 
     if (gamma.has_value()) {
         constexpr uint32_t in5_cb_index = tt::CBIndex::c_5;
@@ -1558,8 +1560,9 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
                                      (beta.value().physical_volume() / tile_width);
             }
             if (input_mask.has_value()) {
-                input_mask_tile_start_id = (input_mask_tile_start_id + input_mask_num_tiles_per_core) %
-                                           (input_mask.value().physical_volume() / tile_hw);
+                // Wrap on the set size, not the whole tensor: the row-masked set is an offset off this.
+                input_mask_tile_start_id =
+                    (input_mask_tile_start_id + input_mask_num_tiles_per_core) % mask_set_tiles;
             }
         }
 
@@ -1587,6 +1590,11 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormNoMcastProgra
         writer_mcast_sender_args.push_back(beta_tile_start_id);
         writer_mcast_sender_args.push_back(input_mask_tile_start_id);
         writer_mcast_sender_args.push_back(Wt);
+        // Where this core reads the row-masked set from. Only the core holding a batch's final
+        // row-tile needs it; the rest get the normal set again, making compute's switch a no-op.
+        writer_mcast_sender_args.push_back(
+            input_mask_tile_start_id +
+            (pad.active && group_norm_core_owns_pad_tile(virtual_core.y, num_cores_per_batch) ? mask_set_tiles : 0));
         if (equal_batches_per_core || (virtual_core.y <= last_row_with_extra_batch)) {
             writer_desc_g1.emplace_runtime_args(core, writer_mcast_sender_args);
         } else {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.cpp
@@ -18,7 +18,8 @@ uint32_t GroupNormPadCorrection::scaler_bits(uint32_t reduce_factor_w) const {
     return std::bit_cast<uint32_t>(sc);
 }
 
-GroupNormPadCorrection make_group_norm_pad_correction(uint32_t logical_hw, uint32_t padded_hw, bool use_welford) {
+GroupNormPadCorrection make_group_norm_pad_correction(
+    uint32_t logical_hw, uint32_t padded_hw, bool use_welford, uint32_t tile_height) {
     // Welford cannot express this: its kernels transpose H*W into the tile columns and track the
     // sample count in tile units, so the padding rows cannot be excluded. ttnn::group_norm routes
     // non-tile-aligned Welford requests to the two-pass path instead.
@@ -27,31 +28,9 @@ GroupNormPadCorrection make_group_norm_pad_correction(uint32_t logical_hw, uint3
     pad.logical_hw = logical_hw;
     pad.padded_hw = padded_hw;
     pad.kernel_logical_hw = pad.active ? logical_hw : padded_hw;
-    pad.k_bits = std::bit_cast<uint32_t>(static_cast<float>(padded_hw) / static_cast<float>(logical_hw) - 1.0f);
+    // padded_hw is logical_hw rounded up to a tile, so active implies a non-zero remainder.
+    pad.rows_in_last_tile = pad.active ? (logical_hw % tile_height) : 0;
     return pad;
-}
-
-void append_group_norm_pad_correction_cbs(
-    tt::tt_metal::ProgramDescriptor::CBDescriptors& cbs,
-    const GroupNormPadCorrection& pad,
-    std::array<uint32_t, 3> cb_indices,
-    const tt::tt_metal::CoreRangeSet& core_ranges,
-    tt::DataFormat data_format,
-    uint32_t single_tile_size) {
-    if (!pad.active) {
-        return;
-    }
-    for (uint32_t cb_index : cb_indices) {
-        cbs.push_back(tt::tt_metal::CBDescriptor{
-            .total_size = single_tile_size,
-            .core_ranges = core_ranges,
-            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(cb_index),
-                .data_format = data_format,
-                .page_size = single_tile_size,
-            }}},
-        });
-    }
 }
 
 bool groupnorm_needs_fp32_reconfig(std::initializer_list<tt::DataFormat> reconfig_formats) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_program_utils.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <array>
 #include <vector>
 #include <cstdint>
 #include <initializer_list>
@@ -17,19 +16,17 @@ namespace ttnn::prim {
 
 enum class GroupNormMode : uint32_t { LEGACY = 0, WELFORD_NATIVE = 1, WELFORD_RECIPROCALS = 2 };
 
-// Non-tile-aligned H*W (#50682): the two-pass path reduces over the tile-padding rows as data, so
-// the scaler must divide by the real element count and the compute kernel must subtract K*E[x]^2.
-// Shared by all three two-pass factories so the scaler formula has one definition. Kernels re-derive
-// `active` from (padded_hw != logical_hw), hence `kernel_logical_hw` reporting padded_hw when off --
-// a disagreeing flag would hang the compute kernel on dfb_k.wait_front. Interleaved ships these as
-// compile-time args, so H*W=200 and H*W=224 (same padded 224) must not share a cached program; they
-// do not, because the default program hash keys on TensorSpec's logical_shape.
+// Non-tile-aligned H*W: the reduce scaler must divide by the real element count (`scaler_bits`),
+// and the padding rows must be excluded from both accumulation passes -- the kernels do that by
+// switching to a row-masked set of input-mask tiles on each batch's final row-tile, of which
+// `rows_in_last_tile` are real. Shared by all three two-pass factories. Kernels re-derive `active`
+// from (padded_hw != logical_hw), hence kernel_logical_hw reporting padded_hw when off.
 struct GroupNormPadCorrection {
     bool active = false;
     uint32_t logical_hw = 0;
     uint32_t padded_hw = 0;
-    uint32_t kernel_logical_hw = 0;  // what the kernels are told: logical when active, else padded
-    uint32_t k_bits = 0;             // K = padded_hw/logical_hw - 1, as float bits
+    uint32_t kernel_logical_hw = 0;  // logical when active, else padded
+    uint32_t rows_in_last_tile = 0;  // logical_hw % tile_height
 
     // Reduce scaler that divides by the real element count rather than the padded one. The sqrt is
     // because the AVG/REDUCE_SCALAR LLK applies the scaler twice (row then col). Scaling the divisor
@@ -39,18 +36,15 @@ struct GroupNormPadCorrection {
     uint32_t scaler_bits(uint32_t reduce_factor_w) const;
 };
 
-GroupNormPadCorrection make_group_norm_pad_correction(uint32_t logical_hw, uint32_t padded_hw, bool use_welford);
+GroupNormPadCorrection make_group_norm_pad_correction(
+    uint32_t logical_hw, uint32_t padded_hw, bool use_welford, uint32_t tile_height = 32);
 
-// Appends the three single-tile pad-correction CBs when the correction is active: dfb_k (written by
-// the writer) plus two scratch tiles. The indices differ per path by what each already occupies.
-// Costs 3 tiles per core when active -- 6KB at bfloat16, 12KB at float32.
-void append_group_norm_pad_correction_cbs(
-    tt::tt_metal::ProgramDescriptor::CBDescriptors& cbs,
-    const GroupNormPadCorrection& pad,
-    std::array<uint32_t, 3> cb_indices,
-    const tt::tt_metal::CoreRangeSet& core_ranges,
-    tt::DataFormat data_format,
-    uint32_t single_tile_size);
+// A batch's padding rows sit in its LAST row-tile, so only the core holding that row-tile applies
+// the row mask. `m_index` is virtual_core.y for the interleaved factories, core_index /
+// num_shards_c for the sharded one.
+inline bool group_norm_core_owns_pad_tile(uint32_t m_index, uint32_t num_cores_per_batch) {
+    return (m_index % num_cores_per_batch) == (num_cores_per_batch - 1);
+}
 
 // True when any reconfig-relevant CB format is fp32, so the compute kernel must run its
 // reconfig_data_format calls. When all are bf16 those calls are no-ops and the kernel skips them.

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -307,6 +307,20 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
             block_wt * tile_width);
     }
 
+    // Non-tile-aligned H*W: corrected reduce scaler + the row-masked mask set. See
+    // compute/groupnorm.cpp and GroupNormPadCorrection. Unlike the interleaved paths the scaler and the
+    // row-masked set's start id ship as RUNTIME args (8, 9).
+    const auto pad = make_group_norm_pad_correction(
+        static_cast<uint32_t>(a.logical_shape()[2]),
+        static_cast<uint32_t>(a.padded_shape()[2]),
+        use_welford,
+        tile_height);
+    // The mask carries two sets when the correction is active; cores stride through the first, and
+    // the row-masked one sits mask_set_tiles beyond it.
+    const uint32_t mask_sets = pad.active ? 2 : 1;
+    const uint32_t mask_set_tiles =
+        input_mask.has_value() ? (input_mask.value().physical_volume() / tile_hw) / mask_sets : 0;
+
     ////////////////////////////////////////////////////////////////////////////
     //                      Grayskull Device Setup
     ////////////////////////////////////////////////////////////////////////////
@@ -337,8 +351,9 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     uint32_t in6_CB_size = gamma_beta_num_cols_tile_per_core * gamma_beta_single_tile_size;
     // input mask
     uint32_t input_mask_num_tiles_per_core = block_wt * num_groups_per_core;
+    // Not welford: double-buffered, doubled again for the row-masked set.
     uint32_t in_mask_CB_size =
-        block_wt * in_mask_single_tile_size * (use_welford ? num_groups_per_core : 2);  // double buffer
+        block_wt * in_mask_single_tile_size * (use_welford ? num_groups_per_core : 2 * mask_sets);
     // negative mask
     uint32_t in_negative_mask_CB_size = block_wt * in_negative_mask_single_tile_size * 2;  // double buffer
     // repack cb
@@ -575,11 +590,6 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         };
     }
 
-    // Non-tile-aligned H*W (#50682): corrected reduce scaler + K for the variance correction.
-    // Derivation in compute/groupnorm.cpp, `active` semantics in GroupNormPadCorrection.
-    // Unlike the interleaved paths these ship as RUNTIME args (8, 9).
-    const auto pad = make_group_norm_pad_correction(
-        static_cast<uint32_t>(a.logical_shape()[2]), static_cast<uint32_t>(a.padded_shape()[2]), use_welford);
     const uint32_t pad_scaler_bits = pad.scaler_bits(num_rows_per_batch_per_core * num_datum_row_per_group);
 
     // writer defines
@@ -690,7 +700,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         num_groups_per_reset,
         single_tile_size,
         per_core_Mt * per_core_Nt / num_batches_per_core,
-        num_groups_per_core * block_wt,
+        num_groups_per_core * block_wt * mask_sets,
         block_wt_last,
         static_cast<uint32_t>((num_datum_row_per_group_mod_tile_w & (num_datum_row_per_group_mod_tile_w - 1)) == 0),
         static_cast<uint32_t>(num_datum_row_per_group < tile_width),
@@ -703,6 +713,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     // above shifts them). Only the two-pass kernel reads them.
     mcast_sender_compute_compile_time_args.push_back(pad.kernel_logical_hw);
     mcast_sender_compute_compile_time_args.push_back(pad.padded_hw);
+    mcast_sender_compute_compile_time_args.push_back(static_cast<uint32_t>(pad.active));
     std::vector<uint32_t> mcast_receiver_compute_compile_time_args = {
         0,
         static_cast<uint32_t>(gamma.has_value()),
@@ -728,7 +739,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         num_groups_per_reset,
         single_tile_size,
         per_core_Mt * per_core_Nt / num_batches_per_core,
-        num_groups_per_core * block_wt,
+        num_groups_per_core * block_wt * mask_sets,
         block_wt_last,
         static_cast<uint32_t>((num_datum_row_per_group_mod_tile_w & (num_datum_row_per_group_mod_tile_w - 1)) == 0),
         static_cast<uint32_t>(num_datum_row_per_group < tile_width),
@@ -739,6 +750,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     mcast_receiver_compute_compile_time_args.push_back(tile_width);
     mcast_receiver_compute_compile_time_args.push_back(pad.kernel_logical_hw);
     mcast_receiver_compute_compile_time_args.push_back(pad.padded_hw);
+    mcast_receiver_compute_compile_time_args.push_back(static_cast<uint32_t>(pad.active));
     // compute kernel
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), compute_kernel_config);
@@ -1147,15 +1159,6 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         }}},
     });
 
-    // Pad-correction scalars/scratch: dfb_k written by the writer, dfb_msq / dfb_kmsq scratch.
-    append_group_norm_pad_correction_cbs(
-        desc.cbs,
-        pad,
-        {tt::CBIndex::c_18, tt::CBIndex::c_19, tt::CBIndex::c_20},
-        all_cores,
-        cb_data_format,
-        single_tile_size);
-
     // Runtime Args
     uint32_t eps_u = std::bit_cast<uint32_t>(eps);
 
@@ -1282,7 +1285,12 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     uint32_t gamma_tile_start_id = 0;
     uint32_t beta_tile_start_id = 0;
     uint32_t input_mask_tile_start_id = 0;
-    for (const auto& core : core_coords) {
+    for (uint32_t core_index = 0; core_index < core_coords.size(); ++core_index) {
+        const auto& core = core_coords[core_index];
+        // Which shard of the height dimension this core holds. core_coords is ordered row-wise for
+        // ROW_MAJOR shards and column-wise for COL_MAJOR, and in both cases the N dimension is the
+        // fast axis, so dividing by the number of N-shards recovers the M index.
+        const uint32_t m_index = core_index / num_shards_c;
         tt::tt_metal::KernelDescriptor::RTArgList writer_mcast_sender_args;
         // 8 base args plus the two #50682 pad-correction args pushed unconditionally below.
         writer_mcast_sender_args.reserve(10);
@@ -1312,7 +1320,12 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
         writer_mcast_sender_args.push_back(input_mask_tile_start_id);
         // args 8, 9: only read when PAD_CORRECTION.
         writer_mcast_sender_args.push_back(pad_scaler_bits);
-        writer_mcast_sender_args.push_back(pad.k_bits);
+        // Where this core reads the row-masked set from. Only the core holding a batch's final
+        // row-tile needs it; the rest get the normal set again, making compute's switch a no-op
+        // there. Deciding it here keeps the compute kernel compile-time-only.
+        writer_mcast_sender_args.push_back(
+            input_mask_tile_start_id +
+            (pad.active && group_norm_core_owns_pad_tile(m_index, num_cores_per_batch) ? mask_set_tiles : 0));
         writer_desc.emplace_runtime_args(core, writer_mcast_sender_args);
 
         if (gamma.has_value()) {
@@ -1324,9 +1337,10 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
                                  (beta.value().physical_volume() / tile_width);
         }
         if (input_mask.has_value()) {
-            // Tile id for negative mask is same as input mask
-            input_mask_tile_start_id = (input_mask_tile_start_id + input_mask_num_tiles_per_core) %
-                                       (input_mask.value().physical_volume() / tile_hw);
+            // Tile id for negative mask is same as input mask. Wrap on the set size, not the whole
+            // tensor: the row-masked set is an offset off this.
+            input_mask_tile_start_id =
+                (input_mask_tile_start_id + input_mask_num_tiles_per_core) % mask_set_tiles;
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm.cpp
@@ -129,15 +129,17 @@ void kernel_main() {
     constexpr uint32_t num_out_blocks = get_named_compile_time_arg_val("num_out_blocks");
     constexpr uint32_t tile_width = get_named_compile_time_arg_val("TILE_WIDTH");
 
-    // Non-tile-aligned H*W (#50682), L = logical_hw, P = padded_hw, K = P/L - 1. The P - L padding
-    // rows are reduced over as data; they hold zeros, so pass 1's sum is right and only the divisor
-    // is wrong -- the writer rescales the scaler by sqrt(P/L). Pass 2 centers each padding row to
-    // (0 - E[x]) and squares it, biasing the variance by exactly K*E[x]^2, subtracted below.
-    // P == L compiles the whole path out. Cost: the subtraction cancels in bfloat16, so accuracy
-    // degrades as K and E[x]^2/v grow (real shapes at K <= 0.6 stay in tolerance).
-    constexpr uint32_t logical_hw = get_named_compile_time_arg_val("logical_hw");
-    constexpr uint32_t padded_hw = get_named_compile_time_arg_val("padded_hw");
-    constexpr bool has_pad_correction = padded_hw != logical_hw;
+    // Non-tile-aligned H*W: the tile-padding rows are excluded from both accumulation passes by
+    // switching to a second, row-masked set of mask tiles on the batch's final row-tile. The writer
+    // gives cores that do not hold that row-tile a copy of the normal set, so the switch here is
+    // unconditional. The divisor is corrected separately, in the reduce scaler.
+    // logical_hw / padded_hw are carried only so two shapes padding to the same size cannot share a
+    // cached program; has_row_mask is what this kernel branches on.
+    constexpr uint32_t logical_hw [[maybe_unused]] = get_named_compile_time_arg_val("logical_hw");
+    constexpr uint32_t padded_hw [[maybe_unused]] = get_named_compile_time_arg_val("padded_hw");
+    constexpr bool has_row_mask = get_named_compile_time_arg_val("has_row_mask") == 1;
+    constexpr uint32_t mask_tiles_per_group = has_row_mask ? 2 * block_w : block_w;
+    constexpr uint32_t last_row_tile = block_h - 1;
 
     constexpr uint32_t block_w_minus_one = block_w - 1;
     constexpr uint32_t block_w_minus_two = block_w - 2;
@@ -160,12 +162,6 @@ void kernel_main() {
     constexpr uint32_t dfb_gamma_id = tt::CBIndex::c_5;
     constexpr uint32_t dfb_beta_id = tt::CBIndex::c_6;
     constexpr uint32_t dfb_input_mask_id = tt::CBIndex::c_28;
-
-    // #50682 pad-correction CBs, allocated only when has_pad_correction. dfb_k holds K from the
-    // writer; dfb_msq / dfb_kmsq are single-tile scratch.
-    constexpr uint32_t dfb_k_id = tt::CBIndex::c_1;
-    constexpr uint32_t dfb_msq_id = tt::CBIndex::c_7;
-    constexpr uint32_t dfb_kmsq_id = tt::CBIndex::c_11;
 
     // interm cbs
     constexpr uint32_t dfb_repack_id = tt::CBIndex::c_26;
@@ -254,9 +250,6 @@ void kernel_main() {
     DataflowBuffer dfb_scaler_global(dfb_scaler_global_id);
     DataflowBuffer dfb_x(dfb_x_id);
     DataflowBuffer dfb_xmm(dfb_xmm_id);
-    DataflowBuffer dfb_k(dfb_k_id);
-    DataflowBuffer dfb_msq(dfb_msq_id);
-    DataflowBuffer dfb_kmsq(dfb_kmsq_id);
 
 #ifdef TILIZE_IN
 #ifdef READER_REPACK
@@ -307,7 +300,7 @@ void kernel_main() {
         for (uint32_t g = 0; g < group; ++g) {
             // Start Average Calc
             // Start Local Reduce
-            dfb_input_mask.wait_front(block_w);
+            dfb_input_mask.wait_front(mask_tiles_per_group);
             for (uint32_t out_block_index = 0; out_block_index < num_out_blocks_padded; out_block_index++) {
                 uint32_t out_block_h_actual, out_block_hw_actual;
                 if (extra_out_block && (out_block_index == (num_out_blocks_padded - 1))) {
@@ -335,17 +328,26 @@ void kernel_main() {
 #endif
 
                 index_h_offset = 0;
+                // Row-tile index within the batch; derived from out_block_index because the final
+                // out-block can be empty when num_out_blocks does not divide block_h.
+                uint32_t row_tile_base = out_block_index * out_block_h_normal;
                 reconfig_data_format_srcb(dfb_in0_id, dfb_input_mask_id);
                 // mask input
                 mul_init(dfb_input_id, dfb_input_mask_id);
                 dfb_x.reserve_back(out_block_hw_normal);
                 for (uint32_t i = 0; i < out_block_h_actual; ++i) {
+                    // Row-masked set on the batch's final row-tile, so the padding contributes
+                    // nothing to E[x]. if constexpr keeps tile-aligned codegen unchanged.
+                    uint32_t mask_set_offset = 0;
+                    if constexpr (has_row_mask) {
+                        mask_set_offset = ((row_tile_base + i) == last_row_tile) ? block_w : 0;
+                    }
                     index_subblock_w_offset = 0;
                     for (uint32_t j = 0; j < num_subblocks_w; ++j) {
                         tile_regs_acquire();
                         for (uint32_t w = 0; w < subblock_w; ++w) {
                             uint32_t index = w + index_subblock_w_offset + index_h_offset + out_block_base;
-                            uint32_t index_mask = w + index_subblock_w_offset;
+                            uint32_t index_mask = w + index_subblock_w_offset + mask_set_offset;
                             mul_tiles(dfb_input_id, dfb_input_mask_id, index, index_mask, w);
                         }
                         tile_regs_commit();
@@ -411,6 +413,7 @@ void kernel_main() {
                     out_block_h_actual = out_block_h_normal;
                     out_block_hw_actual = out_block_hw_normal;
                 }
+                uint32_t row_tile_base = out_block_index * out_block_h_normal;
 
                 // The resident group is already there; only the tiled path waits on new rows.
 #ifndef TILIZE_IN
@@ -464,12 +467,18 @@ void kernel_main() {
                 dfb_x.reserve_back(out_block_hw_normal);
                 dfb_xmm.wait_front(out_block_hw_normal);
                 for (uint32_t i = 0; i < out_block_h_actual; i++) {
+                    // Same switch as pass 1; otherwise each padding row is centered to
+                    // (garbage - E[x]) and squared into the variance.
+                    uint32_t mask_set_offset = 0;
+                    if constexpr (has_row_mask) {
+                        mask_set_offset = ((row_tile_base + i) == last_row_tile) ? block_w : 0;
+                    }
                     index_subblock_w_offset = 0;
                     for (uint32_t j = 0; j < num_subblocks_w; ++j) {
                         tile_regs_acquire();
                         for (uint32_t w = 0; w < subblock_w; ++w) {
                             uint32_t index = w + index_subblock_w_offset;
-                            uint32_t index_mask = index;
+                            uint32_t index_mask = index + mask_set_offset;
                             mul_tiles(dfb_xmm_id, dfb_input_mask_id, index, index_mask, w);
                         }
                         tile_regs_commit();
@@ -552,58 +561,17 @@ void kernel_main() {
             dfb_ex2_global.wait_front(1);
             dfb_ex2pe.reserve_back(1);
 
-            // Var := Var - K*E[x]^2, staged through dfb_msq so (Var + eps) is unchanged when aligned.
-            // cb_ex_global still holds E[x] (popped after the output loop). Binary ops read from CBs,
-            // hence the round trips.
-            constexpr uint32_t dfb_var_src_id = has_pad_correction ? dfb_msq_id : dfb_ex2_global_id;
-            if constexpr (has_pad_correction) {
-                dfb_k.wait_front(1);
-                // dfb_msq = E[x]^2
-                dfb_msq.reserve_back(1);
-                tile_regs_acquire();
-                mul_init(dfb_ex_global_id, dfb_ex_global_id);
-                mul_tiles(dfb_ex_global_id, dfb_ex_global_id, 0, 0, dst0);
-                tile_regs_commit();
-                tile_regs_wait();
-                pack_tile(dst0, dfb_msq_id);
-                tile_regs_release();
-                dfb_msq.push_back(1);
-                // dfb_kmsq = K * E[x]^2
-                dfb_msq.wait_front(1);
-                dfb_kmsq.reserve_back(1);
-                tile_regs_acquire();
-                mul_init(dfb_msq_id, dfb_k_id);
-                mul_tiles(dfb_msq_id, dfb_k_id, 0, 0, dst0);
-                tile_regs_commit();
-                tile_regs_wait();
-                pack_tile(dst0, dfb_kmsq_id);
-                tile_regs_release();
-                dfb_msq.pop_front(1);
-                dfb_kmsq.push_back(1);
-                // dfb_msq (reused) = Var - K * E[x]^2
-                dfb_kmsq.wait_front(1);
-                dfb_msq.reserve_back(1);
-                tile_regs_acquire();
-                sub_init(dfb_ex2_global_id, dfb_kmsq_id);
-                sub_tiles(dfb_ex2_global_id, dfb_kmsq_id, 0, 0, dst0);
-                tile_regs_commit();
-                tile_regs_wait();
-                pack_tile(dst0, dfb_msq_id);
-                tile_regs_release();
-                dfb_kmsq.pop_front(1);
-                dfb_msq.push_back(1);
-                dfb_msq.wait_front(1);
-            }
-
+            // The row mask keeps the padding out of both sums, so this is already the variance over
+            // the real rows; no back-correction needed.
             // (Var + eps)
             tile_regs_acquire();
-            add_init(dfb_var_src_id, dfb_eps_id);
+            add_init(dfb_ex2_global_id, dfb_eps_id);
             // fp32: reset both srcs so fp32 variance / bf16 eps aren't read through the stale square/reduce format.
             if constexpr (enable_fp32_reconfig) {
-                reconfig_data_format_srca(dfb_var_src_id);
+                reconfig_data_format_srca(dfb_ex2_global_id);
                 reconfig_data_format_srcb(dfb_eps_id);
             }
-            add_tiles(dfb_var_src_id, dfb_eps_id, 0, 0, dst0);
+            add_tiles(dfb_ex2_global_id, dfb_eps_id, 0, 0, dst0);
             tile_regs_wait();
             // 1/[sqrt(Var + eps)]
             rsqrt_tile_init<true>();
@@ -614,9 +582,6 @@ void kernel_main() {
             tile_regs_release();
             dfb_ex2pe.push_back(1);
             dfb_ex2_global.pop_front(1);
-            if constexpr (has_pad_correction) {
-                dfb_msq.pop_front(1);
-            }
             // End Variance Calc
 
             bool start_copy_or_add = copy_or_add;
@@ -945,7 +910,7 @@ void kernel_main() {
             }
             dfb_ex_global.pop_front(1);
             dfb_ex2pe.pop_front(1);
-            dfb_input_mask.pop_front(block_w);
+            dfb_input_mask.pop_front(mask_tiles_per_group);
         }
         // End Group Loop
         index_b_offset += num_tiles_per_batch;

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/compute/groupnorm_sharded_v2.cpp
@@ -58,12 +58,12 @@ void kernel_main() {
     constexpr uint32_t group_row_offset = get_compile_time_arg_val(23);
     constexpr uint32_t tile_width = get_compile_time_arg_val(24);
 
-    // Non-tile-aligned H*W (#50682); derivation and precision caveat in compute/groupnorm.cpp.
-    // Unlike the interleaved kernel this one consumes the mean during centering, so K*E[x]^2 is
-    // computed before centering and stashed in dfb_kmsq until the rsqrt step.
-    constexpr uint32_t logical_hw = get_compile_time_arg_val(25);
-    constexpr uint32_t padded_hw = get_compile_time_arg_val(26);
-    constexpr bool has_pad_correction = padded_hw != logical_hw;
+    // Non-tile-aligned H*W; see compute/groupnorm.cpp. logical_hw / padded_hw only keep two shapes
+    // padding to the same size out of one cached program; has_row_mask is what this branches on.
+    constexpr uint32_t logical_hw [[maybe_unused]] = get_compile_time_arg_val(25);
+    constexpr uint32_t padded_hw [[maybe_unused]] = get_compile_time_arg_val(26);
+    constexpr bool has_row_mask = get_compile_time_arg_val(27) == 1;
+    constexpr uint32_t mask_tiles_per_group = has_row_mask ? 2 * block_w : block_w;
 
     constexpr uint32_t block_w_minus_one = block_w - 1;
     constexpr uint32_t block_w_minus_two = block_w - 2;
@@ -93,12 +93,6 @@ void kernel_main() {
     constexpr uint32_t dfb_ex_global_id = num_cores_per_mcast_group == 1 ? dfb_ex_partial_id : tt::CBIndex::c_15;
     constexpr uint32_t dfb_ex2pe_id = tt::CBIndex::c_17;
     constexpr uint32_t dfb_ones_id = tt::CBIndex::c_26;
-
-    // #50682 pad-correction CBs. dfb_k holds K from the writer; dfb_msq is transient scratch;
-    // dfb_kmsq carries K*E[x]^2 across the centering loop.
-    constexpr uint32_t dfb_k_id = tt::CBIndex::c_18;
-    constexpr uint32_t dfb_msq_id = tt::CBIndex::c_19;
-    constexpr uint32_t dfb_kmsq_id = tt::CBIndex::c_20;
 
     // output cb
     constexpr uint32_t dfb_out0_id = tt::CBIndex::c_16;
@@ -185,9 +179,6 @@ void kernel_main() {
     DataflowBuffer dfb_scaler(dfb_scaler_id);
     DataflowBuffer dfb_scaler_global(dfb_scaler_global_id);
     DataflowBuffer dfb_x(dfb_x_id);
-    DataflowBuffer dfb_k(dfb_k_id);
-    DataflowBuffer dfb_msq(dfb_msq_id);
-    DataflowBuffer dfb_kmsq(dfb_kmsq_id);
 
 // tilize input from RM to tile layout
 #ifdef TILIZE_IN
@@ -226,8 +217,14 @@ void kernel_main() {
             reconfig_data_format_srcb(dfb_in0_id, dfb_input_mask_id);
             mul_init(dfb_in0_id, dfb_input_mask_id);
             dfb_x.reserve_back(block_hw);
-            dfb_input_mask.wait_front(block_w);
+            dfb_input_mask.wait_front(mask_tiles_per_group);
             for (uint32_t i = 0; i < block_h; ++i) {
+                // Row-masked set on the batch's final row-tile, so the padding contributes nothing
+                // to E[x]. if constexpr keeps tile-aligned codegen unchanged.
+                uint32_t mask_set_offset = 0;
+                if constexpr (has_row_mask) {
+                    mask_set_offset = (i == block_h - 1) ? block_w : 0;
+                }
                 index_subblock_w_offset = 0;
                 for (uint32_t j = 0; j < num_subblocks_w; ++j) {
                     tile_regs_acquire();
@@ -239,7 +236,7 @@ void kernel_main() {
                         if (index >= per_core_MN) {
                             index = per_core_MN - 1;
                         }
-                        uint32_t index_mask = w + index_subblock_w_offset;
+                        uint32_t index_mask = w + index_subblock_w_offset + mask_set_offset;
 #ifdef TILIZE_IN
                         mul_tiles(dfb_in_id, dfb_input_mask_id, index, index_mask, w);
 #else
@@ -315,33 +312,6 @@ void kernel_main() {
             }
             dfb_ex_global.wait_front(1);
 
-            // Stash K*E[x]^2 while cb_ex_global still holds E[x]; centering below consumes it.
-            if constexpr (has_pad_correction) {
-                dfb_k.wait_front(1);
-                // dfb_msq = E[x]^2
-                dfb_msq.reserve_back(1);
-                tile_regs_acquire();
-                mul_init(dfb_ex_global_id, dfb_ex_global_id);
-                mul_tiles(dfb_ex_global_id, dfb_ex_global_id, 0, 0, dst0);
-                tile_regs_commit();
-                tile_regs_wait();
-                pack_tile(dst0, dfb_msq_id);
-                tile_regs_release();
-                dfb_msq.push_back(1);
-                // dfb_kmsq = K * E[x]^2 (persists until the rsqrt step)
-                dfb_msq.wait_front(1);
-                dfb_kmsq.reserve_back(1);
-                tile_regs_acquire();
-                mul_init(dfb_msq_id, dfb_k_id);
-                mul_tiles(dfb_msq_id, dfb_k_id, 0, 0, dst0);
-                tile_regs_commit();
-                tile_regs_wait();
-                pack_tile(dst0, dfb_kmsq_id);
-                tile_regs_release();
-                dfb_msq.pop_front(1);
-                dfb_kmsq.push_back(1);
-            }
-
             // x - E[x]
             sub_bcast_scalar_init(dfb_x_id, dfb_ex_global_id);
             // fp32: reset both srcs so fp32 x/mean aren't read through the partial-E[x] bf16 dfb_ones format.
@@ -376,12 +346,18 @@ void kernel_main() {
             dfb_x.wait_front(block_hw);
 
             for (uint32_t i = 0; i < block_h; i++) {
+                // Same switch as pass 1; otherwise each padding row is centered to
+                // (garbage - E[x]) and squared into the variance.
+                uint32_t mask_set_offset = 0;
+                if constexpr (has_row_mask) {
+                    mask_set_offset = (i == block_h - 1) ? block_w : 0;
+                }
                 index_subblock_w_offset = 0;
                 for (uint32_t j = 0; j < num_subblocks_w; ++j) {
                     tile_regs_acquire();
                     for (uint32_t w = 0; w < subblock_w; ++w) {
                         uint32_t index = w + index_subblock_w_offset;
-                        uint32_t index_mask = index;
+                        uint32_t index_mask = index + mask_set_offset;
                         mul_tiles(dfb_x_id, dfb_input_mask_id, index, index_mask, w);
                     }
                     tile_regs_commit();
@@ -397,7 +373,7 @@ void kernel_main() {
                     tile_regs_release();
                 }
             }
-            dfb_input_mask.pop_front(block_w);
+            dfb_input_mask.pop_front(mask_tiles_per_group);
             reconfig_data_format_srcb(dfb_input_mask_id, dfb_x_id);
 
             // (x - E[x])^2
@@ -456,32 +432,17 @@ void kernel_main() {
             dfb_ex_global.wait_front(1);
             dfb_ex2pe.reserve_back(1);
 
-            // Var := Var - K*E[x]^2, staged through dfb_msq so (Var + eps) is unchanged when aligned.
-            constexpr uint32_t dfb_var_src_id = has_pad_correction ? dfb_msq_id : dfb_ex_global_id;
-            if constexpr (has_pad_correction) {
-                dfb_kmsq.wait_front(1);
-                dfb_msq.reserve_back(1);
-                tile_regs_acquire();
-                sub_init(dfb_ex_global_id, dfb_kmsq_id);
-                sub_tiles(dfb_ex_global_id, dfb_kmsq_id, 0, 0, dst0);
-                tile_regs_commit();
-                tile_regs_wait();
-                pack_tile(dst0, dfb_msq_id);
-                tile_regs_release();
-                dfb_kmsq.pop_front(1);
-                dfb_msq.push_back(1);
-                dfb_msq.wait_front(1);
-            }
-
+            // The row mask keeps the padding out of both sums, so this is already the variance over
+            // the real rows; no back-correction needed.
             // (Var + eps)
             tile_regs_acquire();
-            add_init(dfb_var_src_id, dfb_eps_id);
+            add_init(dfb_ex_global_id, dfb_eps_id);
             // fp32: reset both srcs so bf16 eps isn't read through the (x-Ex)^2 fp32 format (else garbage var+eps).
             if constexpr (enable_fp32_reconfig) {
-                reconfig_data_format_srca(dfb_var_src_id);
+                reconfig_data_format_srca(dfb_ex_global_id);
                 reconfig_data_format_srcb(dfb_eps_id);
             }
-            add_tiles(dfb_var_src_id, dfb_eps_id, 0, 0, dst0);
+            add_tiles(dfb_ex_global_id, dfb_eps_id, 0, 0, dst0);
             // 1/[sqrt(Var + eps)]
             rsqrt_tile_init<true>();
             rsqrt_tile<true>(dst0);
@@ -491,9 +452,6 @@ void kernel_main() {
             tile_regs_release();
             dfb_ex2pe.push_back(1);
             dfb_ex_global.pop_front(1);
-            if constexpr (has_pad_correction) {
-                dfb_msq.pop_front(1);
-            }
             //  (x - Ex) * 1/[sqrt(Var + eps)]
             index_h_offset = 0;
             mul_bcast_scalar_init(dfb_x_id, dfb_ex2pe_id);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
@@ -68,14 +68,14 @@ void kernel_main() {
 
     constexpr uint32_t use_welford = get_named_compile_time_arg_val("groupnorm_mode") > 0;
 
-    // Non-tile-aligned H*W (#50682): host-precomputed corrected reduce scaler, and K for the
-    // compute kernel's variance correction. See compute/groupnorm.cpp for the derivation.
+    // Non-tile-aligned H*W: host-precomputed corrected reduce scaler, plus a second, row-masked set
+    // of mask tiles streamed behind the normal one. See compute/groupnorm.cpp.
     constexpr uint32_t logical_hw = get_named_compile_time_arg_val("logical_hw");
     constexpr uint32_t padded_hw = get_named_compile_time_arg_val("padded_hw");
     constexpr bool has_pad_correction = padded_hw != logical_hw;
-    constexpr uint32_t dfb_k_id = tt::CBIndex::c_1;
     constexpr uint32_t pad_scaler_bits = get_named_compile_time_arg_val("pad_scaler_bits");
-    constexpr uint32_t pad_k_bits = get_named_compile_time_arg_val("pad_k_bits");
+    constexpr bool has_row_mask = get_named_compile_time_arg_val("has_row_mask") == 1;
+    constexpr uint32_t mask_tiles_per_group = has_row_mask ? 2 * block_w : block_w;
 
     constexpr auto out_args = TensorAccessorArgs<0>();
     constexpr auto gamma_args = TensorAccessorArgs<out_args.next_compile_time_args_offset()>();
@@ -99,6 +99,9 @@ void kernel_main() {
     const uint32_t beta_tile_start_id = get_arg_val<uint32_t>(7);
     const uint32_t input_mask_tile_start_id = get_arg_val<uint32_t>(8);
     const uint32_t num_channels_tiles = get_arg_val<uint32_t>(9);
+    // Only read when has_row_mask; equals input_mask_tile_start_id on cores that do not hold a
+    // batch's final row-tile.
+    const uint32_t input_mask_row_tile_start_id = get_arg_val<uint32_t>(10);
 
     constexpr uint32_t dfb_gamma_id = tt::CBIndex::c_5;
     constexpr uint32_t dfb_beta_id = tt::CBIndex::c_6;
@@ -146,11 +149,12 @@ void kernel_main() {
 
     for (uint32_t b = 0; b < num_batches_per_core; ++b) {
         uint32_t input_mask_tile_id = input_mask_tile_start_id;
+        uint32_t input_mask_row_tile_id = input_mask_row_tile_start_id;
         index_g_offset = 0;
         row_offset = num_cols_per_group;
 
         for (uint32_t i = 0; i < num_groups_per_core; ++i) {
-            dfb_input_mask.reserve_back(block_w);
+            dfb_input_mask.reserve_back(mask_tiles_per_group);
             uint32_t l1_write_addr_input_mask = dfb_input_mask.get_write_ptr();
             for (uint32_t j = 0; j < block_w; ++j) {
                 noc.async_read(
@@ -162,21 +166,33 @@ void kernel_main() {
                 l1_write_addr_input_mask += input_mask_single_tile_size_bytes;
                 input_mask_tile_id += 1;
             }
+            // Row-masked set, immediately behind the normal one: compute selects it with +block_w.
+            if constexpr (has_row_mask) {
+                for (uint32_t j = 0; j < block_w; ++j) {
+                    noc.async_read(
+                        mask,
+                        CoreLocalMem<uint32_t>(l1_write_addr_input_mask),
+                        input_mask_single_tile_size_bytes,
+                        {.page_id = input_mask_row_tile_id},
+                        {});
+                    l1_write_addr_input_mask += input_mask_single_tile_size_bytes;
+                    input_mask_row_tile_id += 1;
+                }
+            }
             noc.async_read_barrier();
-            dfb_input_mask.push_back(block_w);
+            dfb_input_mask.push_back(mask_tiles_per_group);
 
             if (i == 0 and b == 0) {
                 if constexpr (!use_welford) {
                     constexpr uint32_t dfb_in_2 = tt::CBIndex::c_2;
                     if constexpr (has_pad_correction) {
-                        // Corrected scaler = 1 / sqrt(reduce_factor_w * logical_hw / padded_hw),
-                        // precomputed on host to avoid a device-side sqrt.
+                        // 1 / sqrt(reduce_factor_w * logical_hw / padded_hw), precomputed on host.
+                        // The row mask fixes the numerator; this fixes the denominator.
                         const float pad_corrected_scaler = __builtin_bit_cast(float, pad_scaler_bits);
                         dataflow_kernel_lib::prepare_reduce_scaler<
                             dfb_in_2,
                             ckernel::PoolType::AVG,
                             ckernel::ReduceDim::REDUCE_SCALAR>(pad_corrected_scaler);
-                        generate_bcast_col_scalar(CircularBuffer(dfb_k_id), pad_k_bits);
                     } else {
                         constexpr uint32_t reduce_factor_w = get_named_compile_time_arg_val("reduce_factor_w");
                         dataflow_kernel_lib::calculate_and_prepare_reduce_scaler<

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
@@ -91,6 +91,16 @@ void kernel_main() {
     const uint32_t beta_tile_start_id = get_arg_val<uint32_t>(6);
     const uint32_t input_mask_tile_start_id = get_arg_val<uint32_t>(7);
 
+#ifdef PAD_CORRECTION
+    // Non-tile-aligned H*W: a second, row-masked set of mask tiles is streamed behind the normal
+    // one, which compute selects with +block_w. Arg 9 equals input_mask_tile_start_id on cores that
+    // do not hold a batch's final row-tile, making their second set a copy of the first.
+    constexpr uint32_t mask_tiles_per_group = 2 * block_w;
+    const uint32_t input_mask_row_tile_start_id = get_arg_val<uint32_t>(9);
+#else
+    constexpr uint32_t mask_tiles_per_group = block_w;
+#endif
+
     constexpr uint32_t dfb_gamma_id = tt::CBIndex::c_5;
     constexpr uint32_t dfb_beta_id = tt::CBIndex::c_6;
     constexpr uint32_t dfb_out0_id = tt::CBIndex::c_16;
@@ -120,11 +130,14 @@ void kernel_main() {
 
     for (uint32_t b = 0; b < num_batches_per_core; ++b) {
         uint32_t input_mask_tile_id = input_mask_tile_start_id;
+#ifdef PAD_CORRECTION
+        uint32_t input_mask_row_tile_id = input_mask_row_tile_start_id;
+#endif
 #if defined(FUSE_NEGATIVE_MASK)
         uint32_t input_negative_mask_tile_id = input_mask_tile_start_id;
 #endif
         for (uint32_t i = 0; i < num_groups_per_core; ++i) {
-            dfb_input_mask.reserve_back(block_w);
+            dfb_input_mask.reserve_back(mask_tiles_per_group);
             uint32_t l1_write_addr_input_mask = dfb_input_mask.get_write_ptr();
             for (uint32_t j = 0; j < block_w; ++j) {
                 noc.async_read(
@@ -136,8 +149,20 @@ void kernel_main() {
                 l1_write_addr_input_mask += input_mask_single_tile_size_bytes;
                 input_mask_tile_id += 1;
             }
+#ifdef PAD_CORRECTION
+            for (uint32_t j = 0; j < block_w; ++j) {
+                noc.async_read(
+                    mask,
+                    CoreLocalMem<uint32_t>(l1_write_addr_input_mask),
+                    input_mask_single_tile_size_bytes,
+                    {.page_id = input_mask_row_tile_id},
+                    {});
+                l1_write_addr_input_mask += input_mask_single_tile_size_bytes;
+                input_mask_row_tile_id += 1;
+            }
+#endif
             noc.async_read_barrier();
-            dfb_input_mask.push_back(block_w);
+            dfb_input_mask.push_back(mask_tiles_per_group);
 
 #if defined(FUSE_NEGATIVE_MASK)
             dfb_input_negative_mask.reserve_back(block_w);
@@ -159,15 +184,13 @@ void kernel_main() {
             if (i == 0 and b == 0) {
                 constexpr uint32_t dfb_in_2 = tt::CBIndex::c_2;
 #ifdef PAD_CORRECTION
-                // Non-tile-aligned H*W (#50682): host-precomputed corrected reduce scaler, plus
-                // K into dfb_k for the compute kernel's variance correction.
-                constexpr uint32_t dfb_k_id = tt::CBIndex::c_18;
+                // Host-precomputed corrected reduce scaler: the row mask fixes the numerator,
+                // this fixes the denominator.
                 const float pad_corrected_scaler = __builtin_bit_cast(float, get_arg_val<uint32_t>(8));
                 dataflow_kernel_lib::prepare_reduce_scaler<
                     dfb_in_2,
                     ckernel::PoolType::AVG,
                     ckernel::ReduceDim::REDUCE_SCALAR>(pad_corrected_scaler);
-                generate_bcast_col_scalar(CircularBuffer(dfb_k_id), get_arg_val<uint32_t>(9));
 #else
                 dataflow_kernel_lib::calculate_and_prepare_reduce_scaler<
                     dfb_in_2,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -14,6 +14,8 @@
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/clone/clone.hpp"
 #include "ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.hpp"
+#include "ttnn/operations/data_movement/concat/concat.hpp"
+#include "ttnn/operations/eltwise/binary/binary.hpp"
 
 namespace {
 
@@ -111,7 +113,8 @@ ttnn::Tensor get_mask_tensor(
     const std::optional<ttnn::Tensor>& input_mask,
     const std::optional<ttnn::Tensor>& negative_mask,
     const CoreGrid& core_grid,
-    const int num_groups) {
+    const int num_groups,
+    const int64_t rows_in_last_tile) {
     ttnn::Tensor mask = input_mask.value_or(ttnn::Tensor());
     if (!input_mask.has_value() and !negative_mask.has_value()) {
         // create input mask
@@ -138,13 +141,16 @@ ttnn::Tensor get_mask_tensor(
                 num_channel);
             num_cores_across_channel = static_cast<int64_t>(num_virtual_cols);
         }
+        // rows_in_last_tile != 0 builds the doubled mask; free here, since the mask is assembled
+        // on host and uploaded once either way.
         mask = create_group_norm_input_mask(
             num_channel,
             num_groups,
             num_cores_across_channel,
             tt::tt_metal::DataType::BFLOAT16,
             input_tensor.tensor_spec().tile().get_height(),
-            input_tensor.tensor_spec().tile().get_width());
+            input_tensor.tensor_spec().tile().get_width(),
+            rows_in_last_tile);
         mask = mask.to_device(input_tensor.device());
     }
     return mask;
@@ -404,9 +410,34 @@ Tensor group_norm(
         validate_dram_grid(core_grid.value(), W, Ht, num_groups, input_padded_shape[0]);
     }
 
+    // Non-tile-aligned H*W: the tile-padding rows are not guaranteed to hold zeros (reshape, slice
+    // and exp all leave non-zero bytes there), so they must be excluded from both accumulation
+    // passes. The input mask is already multiplied into both, so carry a second set of mask tiles
+    // with those rows zeroed; the kernels select it on the final row-tile of each batch. Nothing
+    // writes to the input tensor, which is what makes this work for sharded too. See #52685.
+    // Welford is unaffected: non-tile-aligned H*W already fell back to the two-pass path above.
+    const uint32_t rows_in_last_tile =
+        (input_padded_shape[2] != input_shape[2] && !use_welford) ? (input_shape[2] % tile_height_align) : 0;
+
     // auto generate mask tensor if both input_mask and negative_mask are not provided
     ttnn::Tensor mask = operations::normalization::get_mask_tensor(
-        input_tensor, input_mask, negative_mask, core_grid.value(), num_groups);
+        input_tensor, input_mask, negative_mask, core_grid.value(), num_groups, rows_in_last_tile);
+
+    // Fallback for a caller-supplied mask not built with rows_in_last_tile: derive the second set
+    // here. Costs a host build, an upload, a multiply and a concat per call, so prefer passing
+    // rows_in_last_tile to create_group_norm_input_mask instead.
+    if (rows_in_last_tile != 0 && input_mask.has_value() &&
+        mask.padded_shape()[1] == static_cast<uint32_t>(num_groups)) {
+        const auto row_mask = operations::normalization::create_group_norm_row_mask(
+                                  rows_in_last_tile,
+                                  mask.padded_shape()[1],
+                                  mask.padded_shape()[3],
+                                  mask.dtype(),
+                                  tile_height_align)
+                                  .to_device(mask.device());
+        const auto row_masked = ttnn::multiply(mask, row_mask, mask.dtype());
+        mask = ttnn::concat({mask, row_masked}, 1);
+    }
 
     if (input_tensor.is_sharded()) {
         const ttnn::prim::GroupNormShardedMultiCoreProgramConfig program_config = {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_input_mask.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_input_mask.cpp
@@ -37,7 +37,8 @@ ttnn::Tensor create_group_norm_input_mask_impl(
     DataType data_type,
     bool is_negative_mask,
     int64_t tile_height,
-    int64_t tile_width) {
+    int64_t tile_width,
+    int64_t rows_in_last_tile) {
     TT_FATAL(num_cores_across_channel > 0, "create_group_norm_input_mask: num_cores_across_channel must be > 0.");
     TT_FATAL(
         num_groups % num_cores_across_channel == 0,
@@ -48,7 +49,17 @@ ttnn::Tensor create_group_norm_input_mask_impl(
         num_cores_across_channel);
     int64_t block_wt = find_max_tile_span(num_channel, num_channel / num_groups, tile_width);
 
-    const int64_t out_num_groups = num_groups;
+    // rows_in_last_tile > 0 appends a second copy of every group with the padding rows zeroed.
+    // Free here: the mask is assembled on host and uploaded once either way.
+    TT_FATAL(
+        rows_in_last_tile >= 0 && rows_in_last_tile < tile_height,
+        "create_group_norm_input_mask: rows_in_last_tile ({}) must be in [0, tile_height={})",
+        rows_in_last_tile,
+        tile_height);
+    const bool has_row_mask = rows_in_last_tile > 0;
+    const int64_t mask_sets = has_row_mask ? 2 : 1;
+
+    const int64_t out_num_groups = num_groups * mask_sets;
     const int64_t out_tile_height = tile_height;
     const int64_t out_mask_width = block_wt * tile_width;
 
@@ -82,10 +93,14 @@ ttnn::Tensor create_group_norm_input_mask_impl(
                                 is_negative_mask ? 1.0f : 0.0f);
 
     for (int64_t group = 0; group < out_num_groups; ++group) {
-        int64_t start_stride = start_strides[group];
-        int64_t end_stride = std::min(end_strides[group], out_mask_width);
+        // Second set repeats the first but stops at rows_in_last_tile.
+        const bool is_row_masked_set = group >= num_groups;
+        const int64_t src_group = group % num_groups;
+        const int64_t row_limit = is_row_masked_set ? rows_in_last_tile : out_tile_height;
+        int64_t start_stride = start_strides[src_group];
+        int64_t end_stride = std::min(end_strides[src_group], out_mask_width);
         const int64_t group_base = group * out_tile_height * out_mask_width;
-        for (int64_t h = 0; h < out_tile_height; ++h) {
+        for (int64_t h = 0; h < row_limit; ++h) {
             const int64_t row_base = group_base + (h * out_mask_width);
             for (int64_t w = start_stride; w < end_stride; ++w) {
                 mask_vec[row_base + w] = mask_value;
@@ -110,9 +125,44 @@ ttnn::Tensor create_group_norm_input_mask(
     int64_t num_cores_across_channel,
     DataType data_type,
     int64_t tile_height,
-    int64_t tile_width) {
+    int64_t tile_width,
+    int64_t rows_in_last_tile) {
     return create_group_norm_input_mask_impl(
-        num_channel, num_groups, num_cores_across_channel, data_type, false, tile_height, tile_width);
+        num_channel,
+        num_groups,
+        num_cores_across_channel,
+        data_type,
+        false,
+        tile_height,
+        tile_width,
+        rows_in_last_tile);
+}
+
+ttnn::Tensor create_group_norm_row_mask(
+    int64_t rows_valid, int64_t num_groups, int64_t mask_width, DataType data_type, int64_t tile_height) {
+    TT_FATAL(
+        rows_valid > 0 && rows_valid < tile_height,
+        "create_group_norm_row_mask: rows_valid ({}) must be in (0, tile_height={})",
+        rows_valid,
+        tile_height);
+    TT_FATAL(num_groups > 0, "create_group_norm_row_mask: num_groups ({}) must be > 0", num_groups);
+    std::vector<float> v(num_groups * tile_height * mask_width, 0.0f);
+    for (int64_t g = 0; g < num_groups; ++g) {
+        const int64_t group_base = g * tile_height * mask_width;
+        for (int64_t h = 0; h < rows_valid; ++h) {
+            const int64_t row_base = group_base + (h * mask_width);
+            for (int64_t w = 0; w < mask_width; ++w) {
+                v[row_base + w] = 1.0f;
+            }
+        }
+    }
+    const ttnn::Shape shape{
+        1,
+        static_cast<uint32_t>(num_groups),
+        static_cast<uint32_t>(tile_height),
+        static_cast<uint32_t>(mask_width)};
+    const tt::tt_metal::TensorLayout layout(data_type, Layout::TILE, ttnn::DRAM_MEMORY_CONFIG);
+    return ttnn::Tensor::from_vector(v, tt::tt_metal::TensorSpec(shape, layout), nullptr);
 }
 
 ttnn::Tensor create_group_norm_input_negative_mask(
@@ -123,6 +173,6 @@ ttnn::Tensor create_group_norm_input_negative_mask(
     int64_t tile_height,
     int64_t tile_width) {
     return create_group_norm_input_mask_impl(
-        num_channel, num_groups, num_cores_across_channel, data_type, true, tile_height, tile_width);
+        num_channel, num_groups, num_cores_across_channel, data_type, true, tile_height, tile_width, 0);
 }
 }  // namespace normalization

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_input_mask.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_input_mask.hpp
@@ -14,13 +14,31 @@ namespace ttnn::operations::normalization {
 // Create 4D mask [1, num_groups, 32, 32*block_wt] used by group norm.
 // block_wt is computed from worst-case tile span across groups.
 // num_cores_across_channel splits groups evenly across cores (must divide num_groups).
+//
+// rows_in_last_tile (= logical_hw % 32) is for non-tile-aligned H*W. It appends a second set of
+// groups -- shape becomes [1, 2*num_groups, 32, 32*block_wt] -- identical to the first but with
+// rows >= rows_in_last_tile zeroed; group_norm selects it on each batch's final row-tile. Leave at
+// 0 for tile-aligned H*W. Callers supplying their own mask to a non-tile-aligned group_norm should
+// set it, else group_norm derives the second set with a device-side multiply+concat per call.
 ttnn::Tensor create_group_norm_input_mask(
     int64_t num_channel,
     int64_t num_groups,
     int64_t num_cores_across_channel,
     tt::tt_metal::DataType data_type = tt::tt_metal::DataType::BFLOAT16,
     int64_t tile_height = 32,
-    int64_t tile_width = 32);
+    int64_t tile_width = 32,
+    int64_t rows_in_last_tile = 0);
+
+// [1, num_groups, tile_height, mask_width], 1.0 on rows [0, rows_valid) and 0.0 above, identical
+// per group. Multiplying the input mask by this gives the variant used on the final row-tile.
+// Replicated across dim 1 so the multiply is plain elementwise and stays in the mask's dtype.
+// Only the fallback for a mask not built with create_group_norm_input_mask's rows_in_last_tile.
+ttnn::Tensor create_group_norm_row_mask(
+    int64_t rows_valid,
+    int64_t num_groups,
+    int64_t mask_width,
+    tt::tt_metal::DataType data_type = tt::tt_metal::DataType::BFLOAT16,
+    int64_t tile_height = 32);
 
 ttnn::Tensor create_group_norm_input_negative_mask(
     int64_t num_channel,

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_nanobind.cpp
@@ -152,9 +152,16 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
            int64_t num_cores_across_channel,
            DataType data_type,
            int64_t tile_height,
-           int64_t tile_width) {
+           int64_t tile_width,
+           int64_t rows_in_last_tile) {
             return create_group_norm_input_mask(
-                num_channel, num_groups, num_cores_across_channel, data_type, tile_height, tile_width);
+                num_channel,
+                num_groups,
+                num_cores_across_channel,
+                data_type,
+                tile_height,
+                tile_width,
+                rows_in_last_tile);
         },
         nb::arg("num_channel"),
         nb::arg("num_groups"),
@@ -162,9 +169,16 @@ void bind_normalization_group_norm_operation(nb::module_& mod) {
         nb::arg("data_type") = DataType::BFLOAT16,
         nb::arg("tile_height") = 32,
         nb::arg("tile_width") = 32,
+        nb::arg("rows_in_last_tile") = 0,
         R"doc(
             C++ implementation of create_group_norm_input_mask.
             Returns a ttnn.Tensor of shape [1, num_groups, 32, 32*block_wt], dtype=ttnn.DataType.BFLOAT16.
+
+            rows_in_last_tile (= ``logical_hw % 32``) is for non-tile-aligned H*W. It appends a
+            second set of groups -- shape becomes [1, 2*num_groups, 32, 32*block_wt] -- identical
+            to the first but with rows >= rows_in_last_tile zeroed, which group_norm selects on
+            each batch's final row-tile. Leave at 0 for tile-aligned H*W; without it, group_norm
+            derives the second set with a device-side multiply+concat on every call.
         )doc");
     mod.def(
         "create_group_norm_input_negative_mask",


### PR DESCRIPTION
### Ticket
Closes #52685 (follow-up on #50682 / #51159)

### Summary

- The non-tile-aligned correction added in #51159 reduces over the implicit tile-padding rows and back-corrects for them **assuming they hold zeros**. ttnn does not guarantee that, and no producer can reasonably be asked to.

- Measured by poisoning DRAM and reading each producer's output padded region:

| producer | H\*W=259 | H\*W=100 | verdict |
|---|---|---|---|
| `from_torch`, `tilize_with_zero_padding` | 0.0% | 0.0% | clean |
| `reshape` (2D→2D) | **4.0%** | 0.0% | dirty, shape-dependent |
| `reshape` (split dim) | **32.5%** | **41.7%** | dirty |
| `slice` | **100%** | **100%** | dirty (retains the sliced-away rows) |
| `exp` | **100%** | **100%** | exactly 1.0 — the *correct* elementwise result |
| `softmax` | **100%** | **100%** | uniform weight — also correct |
| `permute`, `typecast`, `concat`, `add`, `matmul`, `layer_norm` | 0.0% | 0.0% | clean |

- `exp` and `softmax` are not defects: `exp(0) = 1` is the right answer on zero padding. Producer-side filling is also known-harmful — `reshape` deliberately fills only when the caller passes `pad_value`, because a default-on fill "can be a zero-cost alias of the input buffer … clobbers logical lanes of aliased tensors" (see `reshape.cpp`'s fill rules). **Tile padding is de facto "don't care", so `group_norm` must own its precondition.**

- Every existing group_norm test builds its input via `from_torch` / `tilize_with_zero_padding` — the two producers that *do* zero padding — which is why the whole suite passed against this.

- **Fix: exclude the padding rows instead of back-correcting for them.** The input mask is already multiplied into both accumulation passes and its tile index depends only on the column, never the row-tile. So `create_group_norm_input_mask` gained an optional `rows_in_last_tile` that appends a **second set of groups** — the mask becomes `[1, 2*num_groups, 32, 32*block_wt]`, identical to the first with rows `>= logical_hw % 32` zeroed — and the kernels select it on the final row-tile of each batch.

### Results

- **Padding independence is bit-exact.** Output is *identical*, not merely within tolerance, for tile padding `0.0 / 7.0 / 1.0 / -3.5 / 0.5 / 100.0`, on both interleaved and block-sharded.

| case | max abs err | PCC |
|---|---|---|
| interleaved, tile-aligned control H\*W=128 | 0.047208 | 0.999981 |
| interleaved non-aligned H\*W=100 (any padding value) | 0.036495 | 0.999987 |
| block-sharded, tile-aligned control H\*W=128 | 0.047620 | 0.999981 |
| block-sharded non-aligned H\*W=100 (any padding value) | 0.050061 | 0.999980 |

Non-aligned now sits **at or below** its tile-aligned control.

- **The K-dependent error term is gone.** #51159's correction scaled with the padding fraction `K = padded/logical - 1`; that subtraction no longer exists. Re-measured on `wormhole_b0` at input mean 0, against tile-aligned controls:

| H\*W (K) | measured | aligned control |
|---|---|---|
| 16 (1.00) | 0.0447 | 0.0436 |
| 17 (0.88) | 0.0473 | 0.0436 |
| 24 (0.33) | 0.0415 | 0.0436 |
| 33 (0.94) | 0.0456 | 0.0488 |
| 50 (0.28) | 0.0507 | 0.0488 |
| 100 (0.28) | 0.0406 | 0.0549 |

- Error no longer tracks K at all — H\*W=16 at K=1.00 beats H\*W=50 at K=0.28 — so #51159's "only H\*W ≤ 16 exceeds tolerance" caveat is obsolete.

- **Downstream:** the XTTS-v2 conditioning encoder (`GroupNorm(32,1024)`, `H*W=259`, fed from `reshape`) recovered from PCC **0.822335 → 0.999100**, against a decomposed reference of 0.999552.

- **This flips a strict xfail that main added to pin this defect.** `test_group_norm_non_tile_aligned_garbage_padding_DRAM` was `@pytest.mark.xfail(strict=True)` with the reason *"…measured ~1.92 vs ~0.045. If this XPASSes, the padding rows are being masked and the precondition can be dropped from the kernel docs."* It now passes, and is converted to a plain test.

- **Perf:** block-sharded non-aligned is **108.9 µs/call vs 108.5 µs aligned** — no cost, provided the mask is built with `rows_in_last_tile`. Interleaved with an auto-created mask is 157.9 → 254.7 µs/call for non-aligned; that is the pre-existing per-call mask rebuild now carrying 2× the bytes, and callers in a hot loop should hoist the mask. A caller-supplied mask *without* `rows_in_last_tile` still works — group_norm derives the second set with a device-side multiply+concat — but pays ~4× per call, so both paths are test-covered.

### Caveats

- **Tile-aligned shapes are unchanged.** Everything is gated on `pad.active`; with it false, `mask_sets = 1` keeps `in_mask_CB_size` and `num_tiles_input_mask` byte-identical, and the kernel branch is an `if constexpr` rather than a foldable ternary, so aligned shapes emit the same instructions rather than relying on the optimizer.
- **Welford is unaffected**, worth stating explicitly since all three program factories are shared with it: `pad.active` is false whenever `use_welford` is true (`ttnn::group_norm` already routes non-tile-aligned Welford to the two-pass path); the Welford sharded compute kernel reads positional compile args up to index 25 while the new `has_row_mask` lands at 26–28; the Welford writers read runtime args up to 7 (sharded) and 9 (interleaved) while the new ones are 9 and 10. No Welford kernel file is touched.
- **New rejection:** the device op now requires mask `dim1 == 2*num_groups` for non-tile-aligned two-pass. Deliberate — fail loud rather than read past the mask. No in-tree caller can hit it: there are no direct `ttnn::prim::group_norm` callers and it is not exposed to Python.
- **`create_group_norm_input_mask` gained a trailing optional `rows_in_last_tile = 0`.** All 42 existing call sites pass at most 4 positional args and are unaffected.
- **Non-tile-aligned models cannot regress** — that path was silently wrong before whenever the producer left dirty padding, so only improvement is available there.

### Implementation notes

- Nothing writes to the input tensor, which is what makes this layout-independent. A host-side zero-fill was tried first and only works interleaved: `fill_implicit_tile_padding` addresses padding from the logical shape and corrupts a BLOCK_SHARDED tensor whose padding tail sits on the last M-core (took `test_group_norm_block_sharded_non_tile_aligned` from 6 passed to 3 failed). Zeroing inside the kernel is also unsafe — a sharded input CB can alias the caller's shard.

- Which core applies the row mask is a **per-core** property (only the last core row holds the batch tail when a batch is split across rows), and these compute kernels take no runtime args. So the **writer** selects the set from a per-core runtime offset and hands non-owning cores a duplicate of the normal set, keeping the compute-side switch compile-time and unconditional. Uniform rule across all three factories: `owns = (m_index % num_cores_per_batch) == num_cores_per_batch - 1`.

- The final row-tile is identified by its **global index within the batch**, not by "last out-block, last row": `num_out_blocks` need not divide `block_h`, and the last out-block can legitimately have zero rows.

- Removes the `Var - K*E[x]^2` back-correction and its three scratch CBs per path — that subtraction was a bfloat16 catastrophic cancellation which, on a block-sharded input with padding `1.0`, drove the variance negative and `rsqrt` to **786430**. The corrected reduce scaler (divisor `L`, not `P`) is now the only remaining correction.

### Coverage notes

Run locally on `wormhole_b0` — **1,281 passed, 0 regressions**:

| suite | result |
|---|---|
| `unit_tests/…/test_group_norm_DRAM.py` | 193 passed, 2 skipped |
| `unit_tests/…/test_group_norm.py` | 358 passed, 29 skipped |
| `nightly/…/test_group_norm{,_DRAM}.py` + `operations_compute_only` | 566 passed, 19 skipped |
| `docs_examples/test_normalization_examples.py` | 13 passed |
| `models/tt_dit/tests/unit/test_normalization.py` | 117 passed, 214 skipped |
| `models/experimental/retinanet/tests` | 22 passed |
| `tests/tt_eager/…/fallback_ops/test_group_norm.py` | 12 passed |

New coverage targets what the old suite structurally could not reach:
- interleaved dirty padding over **7 grid / batch / `num_out_blocks` combinations** — this is what exercises the per-core ownership rule and the empty-last-out-block case, and it hits all three program factories (no_mcast at grid 1x8, mcast at 2x8 and 4x8);
- sharded dirty padding over **4 grids × 4 padding values × 2 mask-construction paths**;
- a bit-exactness test asserting the output is *identical* across padding values rather than merely within tolerance.

### CI runs

Single-card SKUs only — galaxy / llmbox / loudbox, T3000 and multichip legs were deliberately left off, since this is an op-level change with no multi-device behaviour.

| workflow | result |
|---|---|
| Sanity tests | pass — https://github.com/tenstorrent/tt-metal/actions/runs/31594923582 |
| (Runtime) Sanity Tests | pass — https://github.com/tenstorrent/tt-metal/actions/runs/31594928368 |
| Nightly tt-metal L2 tests | pass — https://github.com/tenstorrent/tt-metal/actions/runs/31594935663 |
| Blackhole sanity tests | pass — https://github.com/tenstorrent/tt-metal/actions/runs/31671123487 |
| All Model Tests | pass — https://github.com/tenstorrent/tt-metal/actions/runs/31671126991 |
| (Single-card) Frequent model and ttnn tests | `bge_m3` x2 only — https://github.com/tenstorrent/tt-metal/actions/runs/31676768042 |

**All results match main.** *All Model Tests* covers the model consumers and is green, including 26 Stable Diffusion XL jobs (base / VAE / LoRA / refiner / unet-loop / img2img / tensor-parallel) across `wh_n150`, `wh_n300`, `bh_p150` and `bh_p150b_civ2`.

The only red is `bge_m3` on n150 and n300, and it fails identically **on main at the same commit**: main's nightly for `556a284a809` — the exact base this branch sits on — fails those two jobs and passes `efficientdetd0`, which is precisely what this branch reports. `bge_m3` references `group_norm` in zero files.

Nothing red is attributable to this PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=groupnorm-dirty-padding-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:groupnorm-dirty-padding-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=groupnorm-dirty-padding-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:groupnorm-dirty-padding-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=groupnorm-dirty-padding-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:groupnorm-dirty-padding-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=groupnorm-dirty-padding-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:groupnorm-dirty-padding-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=groupnorm-dirty-padding-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:groupnorm-dirty-padding-fix)




