### PR TITLE
[LLK] Re-land BH SFPI comparison kernel rewrites (reverse of #51097)

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_comp_fp32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_comp_fp32.py
@@ -126,6 +126,41 @@ def test_binary_comp_fp32_adjacent_ulps(ttnn_op, device):
     _assert_matches_torch(ttnn_op, a, b, device)
 
 
+@pytest.mark.xfail(
+    strict=False,
+    reason=(
+        "Known Blackhole gap: sfpi lowers the vFloat relational operators to a subtract plus a "
+        "sign test, and a - b underflows into the flushed denormal range for adjacent normals "
+        "near 2^-126, so those pairs read as equal. The raw SFPGT/SFPLE sequences this replaced "
+        "compared sign-magnitude bit patterns and were exact. Wormhole keeps the raw path and "
+        "passes. If this xpasses on Blackhole, revisit the flush note in ckernel_sfpu_binary_comp.h."
+    ),
+)
+@pytest.mark.parametrize(
+    "ttnn_op",
+    (ttnn.gt, ttnn.lt, ttnn.ge, ttnn.le),
+)
+def test_binary_comp_fp32_denormal_window_ties(ttnn_op, device):
+    """Adjacent normals one ULP apart near the bottom of the exponent range, where the ULP itself
+    is subnormal (2^-149 at 2^-126, 2^-143 at 2^-120) so the difference flushes to zero."""
+    f32 = torch.float32
+    pos_inf = torch.tensor(float("inf"), dtype=f32)
+    neg_inf = torch.tensor(float("-inf"), dtype=f32)
+
+    vals_a, vals_b = [], []
+    for magnitude in (2.0**-126, 2.0**-120):
+        v = torch.tensor(magnitude, dtype=f32)
+        v_up = torch.nextafter(v, pos_inf)
+        m_v = -v
+        m_v_dn = torch.nextafter(m_v, neg_inf)
+        vals_a += [v_up, v, m_v, m_v_dn]
+        vals_b += [v, v_up, m_v_dn, m_v]
+
+    a = torch.stack(vals_a).unsqueeze(0).expand(32, -1)
+    b = torch.stack(vals_b).unsqueeze(0).expand(32, -1)
+    _assert_matches_torch(ttnn_op, a, b, device)
+
+
 @pytest.mark.parametrize(
     "ttnn_op",
     (ttnn.eq, ttnn.ne, ttnn.gt, ttnn.lt, ttnn.ge, ttnn.le),

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <type_traits>
+#include <cstdint>
 
 #include "ckernel_addrmod.h"
 #include "sfpi.h"
@@ -22,139 +23,110 @@ template <SfpuType Op>
 inline constexpr bool is_fp32_weak_ordered_compare_v = Op == SfpuType::le || Op == SfpuType::ge;
 
 template <SfpuType Op>
-inline constexpr bool is_fp32_compare_v = is_fp32_equal_compare_v<Op> || is_fp32_strict_ordered_compare_v<Op> || is_fp32_weak_ordered_compare_v<Op>;
+inline constexpr bool is_fp32_compare_v =
+    is_fp32_equal_compare_v<Op> || is_fp32_strict_ordered_compare_v<Op> || is_fp32_weak_ordered_compare_v<Op>;
 
 template <SfpuType>
 inline constexpr bool unsupported_fp32_compare_v = false;
 
+// fp32 total-order comparison helpers. Semantics preserved from the original raw-TTI
+// implementation: |a|+|b| folds ±0/subnormals together (sum == 0) and detects NaN
+// (as<vInt>(sum) > +inf bits). dst_reg[] uses sfpi row units (32/tile) vs the raw 64.
+//
+// NOTE: the fp32 comparison paths have no reliable tt-llk python coverage — the float
+// comparison suite (test_sfpu_binary_float) disables Lt/Gt/Le/Ge/Eq/Ne because the
+// generated stimuli produce near-ties. Validate at the ttnn level.
+constexpr int FP32_INF_BITS = 0x7F800000;
+constexpr std::uint32_t dst_tile_size_sfpi_comp = 32;
+
 template <int ITERATIONS, SfpuType RELATIONAL_OP>
-inline void calculate_binary_comp_fp32_equal(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+inline void calculate_binary_comp_fp32_equal(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
     static_assert(is_fp32_equal_compare_v<RELATIONAL_OP>, "Supported operation types: eq, ne");
 
-    constexpr uint a = p_sfpu::LREG0;
-    constexpr uint b = p_sfpu::LREG1;
-    constexpr uint abs_a = p_sfpu::LREG2;
-    constexpr uint abs_b = p_sfpu::LREG3;
-    constexpr uint sum = p_sfpu::LREG4;
-    constexpr uint inf = p_sfpu::LREG5;
-    constexpr uint default_result = RELATIONAL_OP == SfpuType::eq ? p_sfpu::LCONST_0 : p_sfpu::LCONST_1;
-    constexpr uint equal_result = RELATIONAL_OP == SfpuType::eq ? p_sfpu::LCONST_1 : p_sfpu::LCONST_0;
-    constexpr uint dst_tile_size = 64;
-
-    TTI_SFPLOADI(inf, sfpi::SFPLOADI_MOD0_FLOATB, 0x7f80);
+    constexpr float default_result = RELATIONAL_OP == SfpuType::eq ? 0.0f : 1.0f;
+    constexpr float equal_result = RELATIONAL_OP == SfpuType::eq ? 1.0f : 0.0f;
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        TT_SFPLOAD(a, InstrModLoadStore::DEFAULT, ADDR_MOD_7, dst_index_in0 * dst_tile_size);
-        TT_SFPLOAD(b, InstrModLoadStore::DEFAULT, ADDR_MOD_7, dst_index_in1 * dst_tile_size);
-        TT_SFPSTORE(default_result, InstrModLoadStore::DEFAULT, ADDR_MOD_7, dst_index_out * dst_tile_size);
+        sfpi::vFloat a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi_comp];
+        sfpi::vFloat b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi_comp];
+        sfpi::vFloat sum = sfpi::abs(a) + sfpi::abs(b);
+        sfpi::vInt sum_bits = sfpi::as<sfpi::vInt>(sum);
+        sfpi::vFloat result = default_result;
 
-        TTI_SFPSETSGN(0, b, abs_b, 1); // SFPSETSGN_MOD1_ARG_IMM
-        TTI_SFPSETSGN(0, a, abs_a, 1); // SFPSETSGN_MOD1_ARG_IMM
-        TTI_SFPMAD(p_sfpu::LCONST_1, abs_a, abs_b, sum, 0);
+        // total-order a == b (a <= b && b <= a)
+        v_if(a <= b && b <= a) { result = equal_result; }
+        v_endif;
+        // |a|+|b| == 0 treats all ±0/subnormals as equal
+        v_if(sum == 0.0f) { result = equal_result; }
+        v_endif;
+        // NaN (|a|+|b| > inf) is never equal
+        v_if(sum_bits > FP32_INF_BITS) { result = default_result; }
+        v_endif;
 
-        TTI_SFPLE(0, b, a, 1); // SFPLE_MOD1_SET_CC
-        // if total-order a == b
-        TTI_SFPLE(0, a, b, 1); // SFPLE_MOD1_SET_CC
-        // if abs(a) + abs(b) <= inf; rejects NaN
-        TTI_SFPIADD(0, inf, sum, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_GTE0);
-        TT_SFPSTORE(equal_result, InstrModLoadStore::DEFAULT, ADDR_MOD_7, dst_index_out * dst_tile_size);
-
-        TTI_SFPENCC(0, 0, 0, 0);
-
-        // if abs(a) + abs(b) == 0; this allows us to treat all ±subnormals as equal
-        TTI_SFPSETCC(0, sum, 0, sfpi::SFPSETCC_MOD1_LREG_EQ0);
-        TT_SFPSTORE(equal_result, InstrModLoadStore::DEFAULT, ADDR_MOD_6, dst_index_out * dst_tile_size);
-
-        TTI_SFPENCC(0, 0, 0, 0);
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi_comp] = result;
+        sfpi::dst_reg++;
     }
 }
 
 template <int ITERATIONS, SfpuType RELATIONAL_OP>
 inline void calculate_binary_comp_fp32_strict_ordered(
-    const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
     static_assert(is_fp32_strict_ordered_compare_v<RELATIONAL_OP>, "Supported operation types: lt, gt");
 
-    constexpr uint a = p_sfpu::LREG0;
-    constexpr uint b = p_sfpu::LREG1;
-    constexpr uint abs_a = p_sfpu::LREG2;
-    constexpr uint abs_b = p_sfpu::LREG3;
-    constexpr uint sum = p_sfpu::LREG4;
-    constexpr uint inf = p_sfpu::LREG5;
-    constexpr uint dst_tile_size = 64;
-
+    // gt(a,b) == lt(b,a): swap operands and compute the shared strict-less-than body.
     constexpr bool swap_operands = RELATIONAL_OP == SfpuType::gt;
-    const uint dst_index_a = swap_operands ? dst_index_in1 : dst_index_in0;
-    const uint dst_index_b = swap_operands ? dst_index_in0 : dst_index_in1;
-
-    TTI_SFPLOADI(inf, sfpi::SFPLOADI_MOD0_FLOATB, 0x7f80);
+    const std::uint32_t dst_index_a = swap_operands ? dst_index_in1 : dst_index_in0;
+    const std::uint32_t dst_index_b = swap_operands ? dst_index_in0 : dst_index_in1;
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        TT_SFPLOAD(a, InstrModLoadStore::DEFAULT, ADDR_MOD_7, dst_index_a * dst_tile_size);
-        TT_SFPLOAD(b, InstrModLoadStore::DEFAULT, ADDR_MOD_7, dst_index_b * dst_tile_size);
-        TT_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, dst_index_out * dst_tile_size);
+        sfpi::vFloat a = sfpi::dst_reg[dst_index_a * dst_tile_size_sfpi_comp];
+        sfpi::vFloat b = sfpi::dst_reg[dst_index_b * dst_tile_size_sfpi_comp];
+        sfpi::vFloat sum = sfpi::abs(a) + sfpi::abs(b);
+        sfpi::vInt sum_bits = sfpi::as<sfpi::vInt>(sum);
+        sfpi::vFloat result = 0.0f;
 
-        TTI_SFPSETSGN(0, a, abs_a, 1); // SFPSETSGN_MOD1_ARG_IMM
-        TTI_SFPSETSGN(0, b, abs_b, 1); // SFPSETSGN_MOD1_ARG_IMM
+        // a < b, excluding both-±0/subnormal (sum == 0)
+        v_if(a < b && sum != 0.0f) { result = 1.0f; }
+        v_endif;
+        // NaN (|a|+|b| > inf) is never strictly ordered
+        v_if(sum_bits > FP32_INF_BITS) { result = 0.0f; }
+        v_endif;
 
-        TTI_SFPMAD(p_sfpu::LCONST_1, abs_a, abs_b, sum, 0);
-        // if total-order a < b
-        TTI_SFPGT(0, a, b, 1); // SFPGT_MOD1_SET_CC
-
-        // if abs(a) + abs(b) != 0; rejects if both are ±subnormal
-        TTI_SFPSETCC(0, sum, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
-        // if abs(a) + abs(b) <= inf; rejects NaN
-        TTI_SFPIADD(0, inf, sum, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_GTE0);
-        TT_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_6, dst_index_out * dst_tile_size);
-
-        TTI_SFPENCC(0, 0, 0, 0);
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi_comp] = result;
+        sfpi::dst_reg++;
     }
 }
 
 template <int ITERATIONS, SfpuType RELATIONAL_OP>
 inline void calculate_binary_comp_fp32_weak_ordered(
-    const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
     static_assert(is_fp32_weak_ordered_compare_v<RELATIONAL_OP>, "Supported operation types: le, ge");
 
-    constexpr uint a = p_sfpu::LREG0;
-    constexpr uint b = p_sfpu::LREG1;
-    constexpr uint abs_a = p_sfpu::LREG2;
-    constexpr uint abs_b = p_sfpu::LREG3;
-    constexpr uint sum = p_sfpu::LREG4;
-    constexpr uint inf = p_sfpu::LREG5;
-    constexpr uint dst_tile_size = 64;
-
+    // ge(a,b) == le(b,a): swap operands and compute the shared less-than-or-equal body.
     constexpr bool swap_operands = RELATIONAL_OP == SfpuType::ge;
-    const uint dst_index_a = swap_operands ? dst_index_in1 : dst_index_in0;
-    const uint dst_index_b = swap_operands ? dst_index_in0 : dst_index_in1;
-
-    TTI_SFPLOADI(inf, sfpi::SFPLOADI_MOD0_FLOATB, 0x7f80);
+    const std::uint32_t dst_index_a = swap_operands ? dst_index_in1 : dst_index_in0;
+    const std::uint32_t dst_index_b = swap_operands ? dst_index_in0 : dst_index_in1;
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        TT_SFPLOAD(a, InstrModLoadStore::DEFAULT, ADDR_MOD_7, dst_index_a * dst_tile_size);
-        TT_SFPLOAD(b, InstrModLoadStore::DEFAULT, ADDR_MOD_7, dst_index_b * dst_tile_size);
-        TT_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, dst_index_out * dst_tile_size);
+        sfpi::vFloat a = sfpi::dst_reg[dst_index_a * dst_tile_size_sfpi_comp];
+        sfpi::vFloat b = sfpi::dst_reg[dst_index_b * dst_tile_size_sfpi_comp];
+        sfpi::vFloat sum = sfpi::abs(a) + sfpi::abs(b);
+        sfpi::vInt sum_bits = sfpi::as<sfpi::vInt>(sum);
+        sfpi::vFloat result = 1.0f;
 
-        TTI_SFPSETSGN(0, a, abs_a, 1); // SFPSETSGN_MOD1_ARG_IMM
-        TTI_SFPSETSGN(0, b, abs_b, 1); // SFPSETSGN_MOD1_ARG_IMM
+        // a > b (excluding both-±0/subnormal) -> 0
+        v_if(a > b && sum != 0.0f) { result = 0.0f; }
+        v_endif;
+        // NaN (|a|+|b| > inf) -> 0
+        v_if(sum_bits > FP32_INF_BITS) { result = 0.0f; }
+        v_endif;
 
-        TTI_SFPMAD(p_sfpu::LCONST_1, abs_a, abs_b, sum, 0);
-        // if total-order a > b
-        TTI_SFPGT(0, b, a, 1); // SFPGT_MOD1_SET_CC
-
-        // if abs(a) + abs(b) != 0; rejects if both are ±subnormal
-        TTI_SFPSETCC(0, sum, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
-        TT_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, dst_index_out * dst_tile_size);
-
-        TTI_SFPENCC(0, 0, 0, 0);
-
-        // if abs(a) + abs(b) > inf; a or b is NaN
-        TTI_SFPIADD(0, inf, sum, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_LT0);
-        TT_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, dst_index_out * dst_tile_size);
-
-        TTI_SFPENCC(0, 0, 0, 0);
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi_comp] = result;
+        sfpi::dst_reg++;
     }
 }
 
@@ -167,15 +139,15 @@ template <
     int ITERATIONS,
     SfpuType RELATIONAL_OP,
     std::enable_if_t<is_fp32_compare_v<RELATIONAL_OP>, int> = 0>
-inline void calculate_binary_comp_fp32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+inline void calculate_binary_comp_fp32(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
     if constexpr (is_fp32_equal_compare_v<RELATIONAL_OP>) {
         calculate_binary_comp_fp32_equal<ITERATIONS, RELATIONAL_OP>(dst_index_in0, dst_index_in1, dst_index_out);
     } else if constexpr (is_fp32_strict_ordered_compare_v<RELATIONAL_OP>) {
         calculate_binary_comp_fp32_strict_ordered<ITERATIONS, RELATIONAL_OP>(
             dst_index_in0, dst_index_in1, dst_index_out);
     } else if constexpr (is_fp32_weak_ordered_compare_v<RELATIONAL_OP>) {
-        calculate_binary_comp_fp32_weak_ordered<ITERATIONS, RELATIONAL_OP>(
-            dst_index_in0, dst_index_in1, dst_index_out);
+        calculate_binary_comp_fp32_weak_ordered<ITERATIONS, RELATIONAL_OP>(dst_index_in0, dst_index_in1, dst_index_out);
     } else {
         static_assert(unsupported_fp32_compare_v<RELATIONAL_OP>, "Unsupported fp32 comparison operation");
     }
@@ -188,37 +160,40 @@ inline void calculate_binary_comp_fp32(const uint dst_index_in0, const uint dst_
 // original sign relationship with the subtraction result. The final shift
 // converts the selected top bit to 0 or 1.
 template <bool APPROXIMATION_MODE, int ITERATIONS, SfpuType RELATIONAL_OP>
-inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+inline void calculate_binary_comp_int32(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
     static_assert(
         RELATIONAL_OP == SfpuType::lt || RELATIONAL_OP == SfpuType::gt || RELATIONAL_OP == SfpuType::le ||
             RELATIONAL_OP == SfpuType::ge,
         "Supported operation types: lt, gt, le, ge");
 
-    constexpr bool use_ge = (RELATIONAL_OP == SfpuType::le || RELATIONAL_OP == SfpuType::ge);
-    constexpr bool swap_operands = (RELATIONAL_OP == SfpuType::gt || RELATIONAL_OP == SfpuType::le);
-    constexpr uint a = p_sfpu::LREG0;
-    constexpr uint b = p_sfpu::LREG1;
-    constexpr uint scratch = p_sfpu::LREG2;
-    constexpr uint sign = use_ge ? 1 : 0;
-    constexpr uint tmp = use_ge ? b : a;
-    constexpr uint xor_src = use_ge ? a : b;
-    constexpr uint dst_tile_size = 64;
-
-    const uint dst_index_a = swap_operands ? dst_index_in1 : dst_index_in0;
-    const uint dst_index_b = swap_operands ? dst_index_in0 : dst_index_in1;
+    // INT32 load layout converts Dest sign-magnitude <-> 2's-complement, so the loaded
+    // vInt lanes are true 2's-complement and sfpi's signed comparisons order them correctly.
+    // dst_reg[] indexes in sfpi row units (32/tile), unlike the raw TT_SFPLOAD immediate (64).
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        TT_SFPLOAD(a, InstrModLoadStore::INT32, ADDR_MOD_7, dst_index_a * dst_tile_size);
-        TT_SFPLOAD(b, InstrModLoadStore::INT32, ADDR_MOD_7, dst_index_b * dst_tile_size);
+        sfpi::vInt a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
+        sfpi::vInt b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
+        sfpi::vInt result = 0;
 
-        TTI_SFPSETSGN(sign, b, scratch, 1); // SFPSETSGN_MOD1_ARG_IMM
-        TTI_SFPIADD(0, a, scratch, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_NONE);
-        TTI_SFPXOR(0, xor_src, tmp, 0);
-        TTI_SFPOR(0, scratch, tmp, 0);
-        TTI_SFPXOR(0, b, a, 0);
-        TTI_SFPSHFT((-31) & 0xfff, a, a, 1); // SFPSHFT_MOD1_ARG_IMM
-        TT_SFPSTORE(a, InstrModLoadStore::INT32, ADDR_MOD_6, dst_index_out * dst_tile_size);
+        if constexpr (RELATIONAL_OP == SfpuType::lt) {
+            v_if(a < b) { result = 1; }
+            v_endif;
+        } else if constexpr (RELATIONAL_OP == SfpuType::gt) {
+            v_if(a > b) { result = 1; }
+            v_endif;
+        } else if constexpr (RELATIONAL_OP == SfpuType::le) {
+            v_if(a <= b) { result = 1; }
+            v_endif;
+        } else if constexpr (RELATIONAL_OP == SfpuType::ge) {
+            v_if(a >= b) { result = 1; }
+            v_endif;
+        }
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>() = result;
+        sfpi::dst_reg++;
     }
 }
 
@@ -227,8 +202,16 @@ inline void calculate_binary_comp_int32(const uint dst_index_in0, const uint dst
 //   ge(a,b) = GE(a,b)           le(a,b) = GE(b,a)
 // UInt32 uses the same subtract/fold structure as Int32. On Blackhole, LO16
 // zero-extends UInt16 values, so sign-magnitude compare matches uint16 order.
+//
+// NOTE (sfpi conversion): still raw TTI. The metal/tt-llk binary-comparison dispatch
+// (sfpu_operations.h) only routes Int32 -> calculate_binary_comp_int32 and everything
+// else -> calculate_binary_comp_fp32, so this uint ordering path (and calculate_binary_eq_int
+// below) are ttnn-only and are neither instantiated nor testable by the tt-llk harness.
+// The uint32 case additionally needs an MSB-fold to emulate unsigned ordering with signed
+// sfpi compares; convert together with ttnn-level validation.
 template <bool APPROXIMATION_MODE, int ITERATIONS, SfpuType RELATIONAL_OP, DataFormat DATA_FORMAT>
-inline void calculate_binary_comp_uint(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+inline void calculate_binary_comp_uint(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
     static_assert(
         DATA_FORMAT == DataFormat::UInt16 || DATA_FORMAT == DataFormat::UInt32,
         "Unsupported data format for calculate_binary_comp_uint(). Supported formats: UInt16, UInt32.");
@@ -241,16 +224,16 @@ inline void calculate_binary_comp_uint(const uint dst_index_in0, const uint dst_
     constexpr bool swap_operands = (RELATIONAL_OP == SfpuType::gt || RELATIONAL_OP == SfpuType::le);
     constexpr bool needs_msb_handling = (DATA_FORMAT == DataFormat::UInt32);
     constexpr InstrModLoadStore ld_st_mod = needs_msb_handling ? InstrModLoadStore::INT32 : InstrModLoadStore::LO16;
-    constexpr uint a = p_sfpu::LREG0;
-    constexpr uint b = p_sfpu::LREG1;
-    constexpr uint scratch = p_sfpu::LREG2;
-    constexpr uint sign = use_ge ? 1 : 0;
-    constexpr uint result = use_ge ? a : b;
-    constexpr uint xor_src = use_ge ? b : a;
-    constexpr uint dst_tile_size = 64;
+    constexpr std::uint32_t a = p_sfpu::LREG0;
+    constexpr std::uint32_t b = p_sfpu::LREG1;
+    constexpr std::uint32_t scratch = p_sfpu::LREG2;
+    constexpr std::uint32_t sign = use_ge ? 1 : 0;
+    constexpr std::uint32_t result = use_ge ? a : b;
+    constexpr std::uint32_t xor_src = use_ge ? b : a;
+    constexpr std::uint32_t dst_tile_size = 64;
 
-    const uint dst_index_a = swap_operands ? dst_index_in1 : dst_index_in0;
-    const uint dst_index_b = swap_operands ? dst_index_in0 : dst_index_in1;
+    const std::uint32_t dst_index_a = swap_operands ? dst_index_in1 : dst_index_in0;
+    const std::uint32_t dst_index_b = swap_operands ? dst_index_in0 : dst_index_in1;
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
@@ -258,20 +241,20 @@ inline void calculate_binary_comp_uint(const uint dst_index_in0, const uint dst_
         TT_SFPLOAD(b, ld_st_mod, ADDR_MOD_7, dst_index_b * dst_tile_size);
 
         if constexpr (needs_msb_handling) {
-            TTI_SFPSETSGN(sign, b, scratch, 1); // SFPSETSGN_MOD1_ARG_IMM
+            TTI_SFPSETSGN(sign, b, scratch, 1);  // SFPSETSGN_MOD1_ARG_IMM
             TTI_SFPIADD(0, a, scratch, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_NONE);
             TTI_SFPXOR(0, xor_src, result, 0);
             TTI_SFPOR(0, scratch, result, 0);
             TTI_SFPXOR(0, xor_src, result, 0);
-            TTI_SFPSHFT((-31) & 0xfff, result, result, 1); // SFPSHFT_MOD1_ARG_IMM
+            TTI_SFPSHFT((-31) & 0xfff, result, result, 1);  // SFPSHFT_MOD1_ARG_IMM
             TT_SFPSTORE(result, ld_st_mod, ADDR_MOD_6, dst_index_out * dst_tile_size);
         } else {
             if constexpr (use_ge) {
-                TTI_SFPLE(0, a, b, 8); // SFPLE_MOD1_SET_VD: b = (a >= b) ? -1 : 0
+                TTI_SFPLE(0, a, b, 8);  // SFPLE_MOD1_SET_VD: b = (a >= b) ? -1 : 0
             } else {
-                TTI_SFPGT(0, a, b, 8); // SFPGT_MOD1_SET_VD: b = (a < b) ? -1 : 0
+                TTI_SFPGT(0, a, b, 8);  // SFPGT_MOD1_SET_VD: b = (a < b) ? -1 : 0
             }
-            TTI_SFPSHFT((-31) & 0xfff, b, b, 1); // SFPSHFT_MOD1_ARG_IMM
+            TTI_SFPSHFT((-31) & 0xfff, b, b, 1);  // SFPSHFT_MOD1_ARG_IMM
             TT_SFPSTORE(b, ld_st_mod, ADDR_MOD_6, dst_index_out * dst_tile_size);
         }
     }
@@ -281,7 +264,8 @@ inline void calculate_binary_comp_uint(const uint dst_index_in0, const uint dst_
 // XOR a and b; the result is zero if a == b. A conditional store writes
 // the appropriate integer 0 or 1 result.
 template <bool APPROXIMATION_MODE, int ITERATIONS, SfpuType RELATIONAL_OP, DataFormat DATA_FORMAT>
-inline void calculate_binary_eq_int(const uint dst_index_in0, const uint dst_index_in1, const uint dst_index_out) {
+inline void calculate_binary_eq_int(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
     static_assert(
         DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt16 || DATA_FORMAT == DataFormat::UInt32,
         "Unsupported data format for calculate_binary_eq_int(). Supported formats: Int32, UInt16, UInt32.");
@@ -289,14 +273,14 @@ inline void calculate_binary_eq_int(const uint dst_index_in0, const uint dst_ind
 
     constexpr InstrModLoadStore ld_st_mod =
         (DATA_FORMAT == DataFormat::UInt16) ? InstrModLoadStore::LO16 : InstrModLoadStore::INT32;
-    constexpr uint a = p_sfpu::LREG0;
-    constexpr uint b = p_sfpu::LREG1;
-    constexpr uint one = p_sfpu::LREG2;
-    constexpr uint dst_tile_size = 64;
+    constexpr std::uint32_t a = p_sfpu::LREG0;
+    constexpr std::uint32_t b = p_sfpu::LREG1;
+    constexpr std::uint32_t one = p_sfpu::LREG2;
+    constexpr std::uint32_t dst_tile_size = 64;
 
     constexpr bool is_eq = (RELATIONAL_OP == SfpuType::eq);
-    constexpr uint default_result = is_eq ? p_sfpu::LCONST_0 : one;
-    constexpr uint equal_result = is_eq ? one : p_sfpu::LCONST_0;
+    constexpr std::uint32_t default_result = is_eq ? p_sfpu::LCONST_0 : one;
+    constexpr std::uint32_t equal_result = is_eq ? one : p_sfpu::LCONST_0;
 
     TTI_SFPLOADI(one, sfpi::SFPLOADI_MOD0_USHORT, 0x0001);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
@@ -33,9 +33,14 @@ inline constexpr bool unsupported_fp32_compare_v = false;
 // implementation: |a|+|b| folds ±0/subnormals together (sum == 0) and detects NaN
 // (as<vInt>(sum) > +inf bits). dst_reg[] uses sfpi row units (32/tile) vs the raw 64.
 //
-// NOTE: the fp32 comparison paths have no reliable tt-llk python coverage — the float
-// comparison suite (test_sfpu_binary_float) disables Lt/Gt/Le/Ge/Eq/Ne because the
-// generated stimuli produce near-ties. Validate at the ttnn level.
+// NOTE: sfpi has no total-order float compare. It lowers every vFloat relational
+// operator to SFPMAD (a - b) followed by SFPSETCC on the sign, where the raw-TTI
+// original used SFPGT/SFPLE, which compare the sign-magnitude bit patterns directly.
+// The equality path below therefore compares bit patterns rather than subtracting.
+// The two ordered paths still subtract, which is exact except when a - b underflows
+// into the flushed denormal range: operands closer together than 2^-126 compare as
+// equal. That window is why test_sfpu_binary_float still disables Lt/Gt/Le/Ge, and
+// closing it needs either an sfpi total-order compare or a return to raw SFPGT/SFPLE.
 constexpr int FP32_INF_BITS = 0x7F800000;
 constexpr std::uint32_t dst_tile_size_sfpi_comp = 32;
 
@@ -55,8 +60,12 @@ inline void calculate_binary_comp_fp32_equal(
         sfpi::vInt sum_bits = sfpi::as<sfpi::vInt>(sum);
         sfpi::vFloat result = default_result;
 
-        // total-order a == b (a <= b && b <= a)
-        v_if(a <= b && b <= a) { result = equal_result; }
+        // Total-order a == b, tested on the raw bit patterns rather than as
+        // (a <= b && b <= a). sfpi lowers vFloat compares to a subtract plus a
+        // sign check, so the pair-of-inequalities form evaluates inf == inf via
+        // inf - inf = NaN and answers "unordered" for two identical operands.
+        // Integer equality is exact under wraparound and needs no such guard.
+        v_if(sfpi::as<sfpi::vInt>(a) == sfpi::as<sfpi::vInt>(b)) { result = equal_result; }
         v_endif;
         // |a|+|b| == 0 treats all ±0/subnormals as equal
         v_if(sum == 0.0f) { result = equal_result; }
@@ -167,32 +176,46 @@ inline void calculate_binary_comp_int32(
             RELATIONAL_OP == SfpuType::ge,
         "Supported operation types: lt, gt, le, ge");
 
-    // INT32 load layout converts Dest sign-magnitude <-> 2's-complement, so the loaded
-    // vInt lanes are true 2's-complement and sfpi's signed comparisons order them correctly.
+    // Do NOT write this as v_if(a < b). sfpi lowers a signed vInt compare to a plain
+    // SFPIADD subtract with the condition code taken from the sign of the difference,
+    // which wraps whenever the operands span the full int32 range: INT32_MAX - (-1)
+    // is 0x80000000, so INT32_MAX > -1 answers false. The branchless fold below is the
+    // overflow-safe form introduced by #27829 (lt/gt) and #28397 (ge/le); it compiles to
+    // the same nine instructions as the raw-TTI sequence it replaces.
+    //
+    // When the signs of a and b disagree, the top bit of a ^ b is set and OR-ing it in
+    // forces the answer to come from the sign of b (LT) or a (GE). When they agree,
+    // a - setsgn(b, sign) cannot overflow and its own sign is the answer.
+    constexpr bool use_ge = (RELATIONAL_OP == SfpuType::le || RELATIONAL_OP == SfpuType::ge);
+    constexpr bool swap_operands = (RELATIONAL_OP == SfpuType::gt || RELATIONAL_OP == SfpuType::le);
+    constexpr int fold_sign = use_ge ? 1 : 0;
+
+    const std::uint32_t dst_index_a = swap_operands ? dst_index_in1 : dst_index_in0;
+    const std::uint32_t dst_index_b = swap_operands ? dst_index_in0 : dst_index_in1;
+
     // dst_reg[] indexes in sfpi row units (32/tile), unlike the raw TT_SFPLOAD immediate (64).
     constexpr std::uint32_t dst_tile_size_sfpi = 32;
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vInt a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
-        sfpi::vInt b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
-        sfpi::vInt result = 0;
+        sfpi::vInt a = sfpi::dst_reg[dst_index_a * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
+        sfpi::vInt b = sfpi::dst_reg[dst_index_b * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
 
-        if constexpr (RELATIONAL_OP == SfpuType::lt) {
-            v_if(a < b) { result = 1; }
-            v_endif;
-        } else if constexpr (RELATIONAL_OP == SfpuType::gt) {
-            v_if(a > b) { result = 1; }
-            v_endif;
-        } else if constexpr (RELATIONAL_OP == SfpuType::le) {
-            v_if(a <= b) { result = 1; }
-            v_endif;
-        } else if constexpr (RELATIONAL_OP == SfpuType::ge) {
-            v_if(a >= b) { result = 1; }
-            v_endif;
+        sfpi::vInt fold = a - sfpi::as<sfpi::vInt>(sfpi::setsgn(sfpi::as<sfpi::vUInt>(b), fold_sign));
+
+        // Accumulate into whichever operand dies last, so no copy is needed.
+        if constexpr (use_ge) {
+            b = b ^ a;
+            b = b | fold;
+            a = a ^ b;
+        } else {
+            a = a ^ b;
+            a = a | fold;
+            a = a ^ b;
         }
 
-        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>() = result;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>() =
+            sfpi::as<sfpi::vInt>(sfpi::as<sfpi::vUInt>(a) >> 31);
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
@@ -44,12 +44,26 @@ inline constexpr bool unsupported_fp32_compare_v = false;
 //     need no such clause only because their answer for a tie is already 0, and the
 //     manufactured NaN has a clear sign bit so it fails their LT0 test.
 //  2. The subtract is exact except when a - b underflows into the flushed denormal
-//     range, so operands that differ by less than 2^-126 compare as equal. This is
-//     the remaining reason test_sfpu_binary_float keeps Lt/Gt/Le/Ge disabled.
+//     range, so operands that differ by less than 2^-126 compare as equal. The
+//     reachable case is adjacent normals near the bottom of the exponent range,
+//     where one ULP is itself subnormal; the raw SFPGT/SFPLE sequences compared
+//     sign-magnitude bit patterns and were exact there, so this is a behaviour
+//     regression against them. Nothing in CI exercises it: the special-float grid in
+//     test_binary_comp_fp32.py has no near-ties, its adjacent-ULP cases sit at ±1.0
+//     (difference 2^-23, subtracts exactly), and tt-llk's
+//     test_sfpu_binary_float_comparison pairs exact ties with ±1.0 gaps. The one
+//     xfail'd case, test_binary_comp_fp32_denormal_window_ties, pins it.
 //
 // Closing both properly needs an sfpi total-order compare or a return to raw
 // SFPGT/SFPLE, which is a perf tradeoff on these hot kernels.
+//
+// On the tt-llk side: test_sfpu_binary_float excludes Eq/Ne and Lt/Gt/Le/Ge from its
+// random sweep for an unrelated reason (independent draws are never equal, so the Eq/Ne
+// golden collapses to a constant). The crafted paired stimuli in test_sfpu_binary_eq_ne
+// and test_sfpu_binary_float_comparison cover all six ops, exact ties included, and both
+// run on Blackhole in the PR-gate llk smoke job.
 constexpr int FP32_INF_BITS = 0x7F800000;
+// dst_reg[] indexes in sfpi row units (32/tile), unlike the raw TT_SFPLOAD immediate (64).
 constexpr std::uint32_t dst_tile_size_sfpi_comp = 32;
 
 // Clear the sign bit at the bit level, as the raw-TTI original did with SFPSETSGN.
@@ -215,13 +229,10 @@ inline void calculate_binary_comp_int32(
     const std::uint32_t dst_index_a = swap_operands ? dst_index_in1 : dst_index_in0;
     const std::uint32_t dst_index_b = swap_operands ? dst_index_in0 : dst_index_in1;
 
-    // dst_reg[] indexes in sfpi row units (32/tile), unlike the raw TT_SFPLOAD immediate (64).
-    constexpr std::uint32_t dst_tile_size_sfpi = 32;
-
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vInt a = sfpi::dst_reg[dst_index_a * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
-        sfpi::vInt b = sfpi::dst_reg[dst_index_b * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
+        sfpi::vInt a = sfpi::dst_reg[dst_index_a * dst_tile_size_sfpi_comp].mode<sfpi::DataLayout::I32>();
+        sfpi::vInt b = sfpi::dst_reg[dst_index_b * dst_tile_size_sfpi_comp].mode<sfpi::DataLayout::I32>();
 
         sfpi::vInt fold = a - sfpi::as<sfpi::vInt>(sfpi::setsgn(sfpi::as<sfpi::vUInt>(b), fold_sign));
 
@@ -236,7 +247,7 @@ inline void calculate_binary_comp_int32(
             a = a ^ b;
         }
 
-        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>() =
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi_comp].mode<sfpi::DataLayout::I32>() =
             sfpi::as<sfpi::vInt>(sfpi::as<sfpi::vUInt>(a) >> 31);
         sfpi::dst_reg++;
     }
@@ -250,10 +261,13 @@ inline void calculate_binary_comp_int32(
 //
 // NOTE (sfpi conversion): still raw TTI. The metal/tt-llk binary-comparison dispatch
 // (sfpu_operations.h) only routes Int32 -> calculate_binary_comp_int32 and everything
-// else -> calculate_binary_comp_fp32, so this uint ordering path (and calculate_binary_eq_int
-// below) are ttnn-only and are neither instantiated nor testable by the tt-llk harness.
-// The uint32 case additionally needs an MSB-fold to emulate unsigned ordering with signed
-// sfpi compares; convert together with ttnn-level validation.
+// else -> calculate_binary_comp_fp32, so this uint ordering path is ttnn-only: the tt-llk
+// harness never instantiates it, at either data format. calculate_binary_eq_int below is
+// different — the harness does instantiate it, but only at DataFormat::Int32 (via
+// BinaryOp::EQ_INT/NE_INT, exercised by test_sfpu_binary_int), so only its UInt16/UInt32
+// instantiations are ttnn-only. The uint32 case here additionally needs an MSB-fold to
+// emulate unsigned ordering with signed sfpi compares; convert together with ttnn-level
+// validation.
 template <bool APPROXIMATION_MODE, int ITERATIONS, SfpuType RELATIONAL_OP, DataFormat DATA_FORMAT>
 inline void calculate_binary_comp_uint(
     const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_comp.h
@@ -36,13 +36,29 @@ inline constexpr bool unsupported_fp32_compare_v = false;
 // NOTE: sfpi has no total-order float compare. It lowers every vFloat relational
 // operator to SFPMAD (a - b) followed by SFPSETCC on the sign, where the raw-TTI
 // original used SFPGT/SFPLE, which compare the sign-magnitude bit patterns directly.
-// The equality path below therefore compares bit patterns rather than subtracting.
-// The two ordered paths still subtract, which is exact except when a - b underflows
-// into the flushed denormal range: operands closer together than 2^-126 compare as
-// equal. That window is why test_sfpu_binary_float still disables Lt/Gt/Le/Ge, and
-// closing it needs either an sfpi total-order compare or a return to raw SFPGT/SFPLE.
+// Two consequences, both worked around below rather than fixed at the root:
+//
+//  1. a - b manufactures a NaN for a == b == ±inf, and SFPSETCC only reads the sign
+//     bit, so that NaN reads as "greater than or equal to zero". The equality and
+//     weak-ordered paths therefore test bitwise equality explicitly. The strict paths
+//     need no such clause only because their answer for a tie is already 0, and the
+//     manufactured NaN has a clear sign bit so it fails their LT0 test.
+//  2. The subtract is exact except when a - b underflows into the flushed denormal
+//     range, so operands that differ by less than 2^-126 compare as equal. This is
+//     the remaining reason test_sfpu_binary_float keeps Lt/Gt/Le/Ge disabled.
+//
+// Closing both properly needs an sfpi total-order compare or a return to raw
+// SFPGT/SFPLE, which is a perf tradeoff on these hot kernels.
 constexpr int FP32_INF_BITS = 0x7F800000;
 constexpr std::uint32_t dst_tile_size_sfpi_comp = 32;
+
+// Clear the sign bit at the bit level, as the raw-TTI original did with SFPSETSGN.
+// sfpi::abs() lowers to SFPABS in float mode, which leaves a NaN's sign bit intact;
+// |a| + |b| could then be a negative NaN, which reads back as a negative vInt and
+// slips past the "> +inf bits" test below.
+inline sfpi::vFloat clear_sign(sfpi::vFloat v) {
+    return sfpi::as<sfpi::vFloat>(sfpi::setsgn(sfpi::as<sfpi::vUInt>(v), 0));
+}
 
 template <int ITERATIONS, SfpuType RELATIONAL_OP>
 inline void calculate_binary_comp_fp32_equal(
@@ -56,7 +72,7 @@ inline void calculate_binary_comp_fp32_equal(
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi_comp];
         sfpi::vFloat b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi_comp];
-        sfpi::vFloat sum = sfpi::abs(a) + sfpi::abs(b);
+        sfpi::vFloat sum = clear_sign(a) + clear_sign(b);
         sfpi::vInt sum_bits = sfpi::as<sfpi::vInt>(sum);
         sfpi::vFloat result = default_result;
 
@@ -93,7 +109,7 @@ inline void calculate_binary_comp_fp32_strict_ordered(
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat a = sfpi::dst_reg[dst_index_a * dst_tile_size_sfpi_comp];
         sfpi::vFloat b = sfpi::dst_reg[dst_index_b * dst_tile_size_sfpi_comp];
-        sfpi::vFloat sum = sfpi::abs(a) + sfpi::abs(b);
+        sfpi::vFloat sum = clear_sign(a) + clear_sign(b);
         sfpi::vInt sum_bits = sfpi::as<sfpi::vInt>(sum);
         sfpi::vFloat result = 0.0f;
 
@@ -123,14 +139,20 @@ inline void calculate_binary_comp_fp32_weak_ordered(
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat a = sfpi::dst_reg[dst_index_a * dst_tile_size_sfpi_comp];
         sfpi::vFloat b = sfpi::dst_reg[dst_index_b * dst_tile_size_sfpi_comp];
-        sfpi::vFloat sum = sfpi::abs(a) + sfpi::abs(b);
+        sfpi::vFloat sum = clear_sign(a) + clear_sign(b);
         sfpi::vInt sum_bits = sfpi::as<sfpi::vInt>(sum);
         sfpi::vFloat result = 1.0f;
 
         // a > b (excluding both-±0/subnormal) -> 0
         v_if(a > b && sum != 0.0f) { result = 0.0f; }
         v_endif;
-        // NaN (|a|+|b| > inf) -> 0
+        // Restore the ties the subtract above cannot see. a > b is evaluated as
+        // (a - b) >= 0 && (a - b) != 0, and for a == b == ±inf that subtract yields a
+        // NaN whose sign bit is clear, so it satisfies both halves and wrongly clears
+        // the result. Bitwise equality is exact and puts identical operands back to 1.
+        v_if(sfpi::as<sfpi::vInt>(a) == sfpi::as<sfpi::vInt>(b)) { result = 1.0f; }
+        v_endif;
+        // NaN (|a|+|b| > inf) -> 0. Must stay last: NaN == NaN is bitwise true above.
         v_if(sum_bits > FP32_INF_BITS) { result = 0.0f; }
         v_endif;
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <cstdint>
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "llk_math_eltwise_unary_sfpu.h"
@@ -48,81 +47,70 @@ inline void not_equal_zero_init() {
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
 inline void calculate_comp() {
-    constexpr std::uint32_t V = p_sfpu::LREG0;
-    constexpr std::uint32_t ABS_V = p_sfpu::LREG2;
-    constexpr std::uint32_t INF = p_sfpu::LREG5;
-    constexpr std::uint32_t BFLOAT16_INF = 0x7f80;
-
-    if constexpr (
-        COMP_MODE == SfpuType::less_than_zero || COMP_MODE == SfpuType::greater_than_equal_zero ||
-        COMP_MODE == SfpuType::greater_than_zero || COMP_MODE == SfpuType::less_than_equal_zero) {
-        TTI_SFPLOADI(INF, sfpi::SFPLOADI_MOD0_FLOATB, BFLOAT16_INF);
-    }
+    // fp32 total-order comparison-to-zero. |v| is used to fold ±0 together and to
+    // detect NaN: a NaN has |v| whose fp32 bit pattern is strictly greater than +inf
+    // (0x7F800000), so `as<vInt>(|v|) > 0x7F800000` isolates it.
+    constexpr int FP32_INF_BITS = 0x7F800000;
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        TTI_SFPLOAD(V, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
-        TTI_SFPSETSGN(0, V, ABS_V, 1);
+        vFloat v = dst_reg[0];
+        vFloat abs_v = sfpi::abs(v);
+        vInt abs_bits = as<vInt>(abs_v);
+        vFloat result;
 
-        // eqz: default 0, set 1 where |v| == 0 (handles ±0; NaN has |v|!=0 → stays 0)
+        // eqz: 1 where |v| == 0 (handles ±0; NaN has |v| != 0 → 0)
         if constexpr (COMP_MODE == SfpuType::equal_zero) {
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
-            TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_EQ0);
-            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
-            TTI_SFPENCC(0, 0, 0, 0);
+            result = 0.0f;
+            v_if(abs_v == 0.0f) { result = 1.0f; }
+            v_endif;
         }
 
-        // nez: default 1, set 0 where |v| == 0 (handles ±0; NaN has |v|!=0 → stays 1)
+        // nez: 0 where |v| == 0 (handles ±0; NaN has |v| != 0 → 1)
         if constexpr (COMP_MODE == SfpuType::not_equal_zero) {
-            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
-            TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_EQ0);
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
-            TTI_SFPENCC(0, 0, 0, 0);
+            result = 1.0f;
+            v_if(abs_v == 0.0f) { result = 0.0f; }
+            v_endif;
         }
 
-        // ltz: default 0; chain: (v < 0) AND (|v| != 0) AND (|v| <= inf) → 1
+        // ltz: (v < 0) AND (|v| != 0) → 1, then NaN → 0
         if constexpr (COMP_MODE == SfpuType::less_than_zero) {
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
-            TTI_SFPSETCC(0, V, 0, sfpi::SFPSETCC_MOD1_LREG_LT0);
-            TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
-            TTI_SFPIADD(0, INF, ABS_V, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_GTE0);
-            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
-            TTI_SFPENCC(0, 0, 0, 0);
+            result = 0.0f;
+            v_if(v < 0.0f && abs_v != 0.0f) { result = 1.0f; }
+            v_endif;
+            v_if(abs_bits > FP32_INF_BITS) { result = 0.0f; }
+            v_endif;
         }
 
-        // gtz: default 0; chain: (v >= 0) AND (|v| != 0) AND (|v| <= inf) → 1
+        // gtz: (v >= 0) AND (|v| != 0) → 1, then NaN → 0
         if constexpr (COMP_MODE == SfpuType::greater_than_zero) {
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
-            TTI_SFPSETCC(0, V, 0, sfpi::SFPSETCC_MOD1_LREG_GTE0);
-            TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
-            TTI_SFPIADD(0, INF, ABS_V, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_GTE0);
-            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
-            TTI_SFPENCC(0, 0, 0, 0);
+            result = 0.0f;
+            v_if(v >= 0.0f && abs_v != 0.0f) { result = 1.0f; }
+            v_endif;
+            v_if(abs_bits > FP32_INF_BITS) { result = 0.0f; }
+            v_endif;
         }
 
-        // gez: default 1; chain1: (v<0) AND (|v|!=0) → 0 (negatives excl. -0); chain2: |v|>inf → 0 (NaN)
+        // gez: default 1; negatives (excl. -0) → 0; NaN → 0
         if constexpr (COMP_MODE == SfpuType::greater_than_equal_zero) {
-            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
-            TTI_SFPSETCC(0, V, 0, sfpi::SFPSETCC_MOD1_LREG_LT0);
-            TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
-            TTI_SFPENCC(0, 0, 0, 0);
-            TTI_SFPIADD(0, INF, ABS_V, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_LT0);
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
-            TTI_SFPENCC(0, 0, 0, 0);
+            result = 1.0f;
+            v_if(v < 0.0f && abs_v != 0.0f) { result = 0.0f; }
+            v_endif;
+            v_if(abs_bits > FP32_INF_BITS) { result = 0.0f; }
+            v_endif;
         }
 
-        // lez: default 1; chain1: (v>=0) AND (|v|!=0) → 0 (positives excl. +0); chain2: |v|>inf → 0 (NaN)
+        // lez: default 1; positives (excl. +0) → 0; NaN → 0
         if constexpr (COMP_MODE == SfpuType::less_than_equal_zero) {
-            TTI_SFPSTORE(p_sfpu::LCONST_1, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
-            TTI_SFPSETCC(0, V, 0, sfpi::SFPSETCC_MOD1_LREG_GTE0);
-            TTI_SFPSETCC(0, ABS_V, 0, sfpi::SFPSETCC_MOD1_LREG_NE0);
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_7, 0);
-            TTI_SFPENCC(0, 0, 0, 0);
-            TTI_SFPIADD(0, INF, ABS_V, sfpi::SFPIADD_MOD1_ARG_2SCOMP_LREG_DST | sfpi::SFPIADD_MOD1_CC_LT0);
-            TTI_SFPSTORE(p_sfpu::LCONST_0, InstrModLoadStore::DEFAULT, ADDR_MOD_6, 0);
-            TTI_SFPENCC(0, 0, 0, 0);
+            result = 1.0f;
+            v_if(v >= 0.0f && abs_v != 0.0f) { result = 0.0f; }
+            v_endif;
+            v_if(abs_bits > FP32_INF_BITS) { result = 0.0f; }
+            v_endif;
         }
+
+        dst_reg[0] = result;
+        dst_reg++;
     }
 }
 
@@ -179,25 +167,26 @@ inline void calculate_comp_int() {
     }
 }
 
+// NOTE: the uint16/uint32 comparison-to-zero paths below have no tt-llk python-test
+// coverage (the comp-to-zero suite only exercises Float16_b/Float32). They mirror the
+// original raw-TTI load/store modes (LO16 for uint16, INT32 for uint32) so behaviour is
+// preserved; validate at the ttnn level before relying on them.
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
 inline void calculate_comp_uint16() {
     static_assert((COMP_MODE == SfpuType::equal_zero) or (COMP_MODE == SfpuType::not_equal_zero));
-    // UInt16 values live in the low 16 bits of the dest word; DataLayout::U16 loads/stores them
-    // directly (SFPLOAD/SFPSTORE mod = UINT16), matching the InstrModLoadStore::LO16 path.
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         vUInt v = dst_reg[0].mode<sfpi::DataLayout::U16>();
+        vUInt result = 0;
         if constexpr (COMP_MODE == SfpuType::equal_zero) {
-            vUInt r = 0;
-            v_if(v == 0) { r = 1; }
+            v_if(v == 0) { result = 1; }
             v_endif;
-            dst_reg[0].mode<sfpi::DataLayout::U16>() = r;
         } else {
-            vUInt r = 1;
-            v_if(v == 0) { r = 0; }
+            v_if(v == 0) { result = 0; }
+            v_else { result = 1; }
             v_endif;
-            dst_reg[0].mode<sfpi::DataLayout::U16>() = r;
         }
+        dst_reg[0].mode<sfpi::DataLayout::U16>() = result;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -47,6 +47,16 @@ inline void not_equal_zero_init() {
 
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
 inline void calculate_comp() {
+    // The store below is unconditional, unlike the raw-TTI original which emitted no
+    // store at all for an unhandled COMP_MODE. Without this assert an unhandled mode
+    // would write the uninitialized `result` LReg into DEST instead of doing nothing.
+    static_assert(
+        COMP_MODE == SfpuType::equal_zero || COMP_MODE == SfpuType::not_equal_zero ||
+            COMP_MODE == SfpuType::less_than_zero || COMP_MODE == SfpuType::greater_than_zero ||
+            COMP_MODE == SfpuType::less_than_equal_zero || COMP_MODE == SfpuType::greater_than_equal_zero,
+        "Supported operation types: equal_zero, not_equal_zero, less_than_zero, greater_than_zero, "
+        "less_than_equal_zero, greater_than_equal_zero");
+
     // fp32 total-order comparison-to-zero. |v| is used to fold ±0 together and to
     // detect NaN: a NaN has |v| whose fp32 bit pattern is strictly greater than +inf
     // (0x7F800000), so `as<vInt>(|v|) > 0x7F800000` isolates it.
@@ -171,13 +181,25 @@ inline void calculate_comp_int() {
     }
 }
 
-// NOTE: the uint16/uint32 comparison-to-zero paths below have no tt-llk python-test
-// coverage (the comp-to-zero suite only exercises Float16_b/Float32). They mirror the
-// original raw-TTI load/store modes (LO16 for uint16, INT32 for uint32) so behaviour is
-// preserved; validate at the ttnn level before relying on them.
+// NOTE on coverage for every comparison-to-zero kernel above and below (calculate_comp,
+// calculate_comp_int, calculate_comp_uint16, calculate_eqz_uint32, calculate_nez_uint32):
+// the tt-llk harness routes the six *_zero SfpuTypes here (sfpu_operations.h dispatches on
+// the runtime math_format), but no functional BH or WH python test enrols those types — the
+// only correctness sweep is quasar/test_eltwise_unary_sfpu_quasar.py, which covers
+// Float16/Float32/Float16_b plus Int32/Int16/Int8/UInt16/UInt8 and does not run on
+// Blackhole, and perf_sfpu_comp.py measures cycles on Wormhole only (and is marker-excluded
+// from correctness runs). BH coverage is ttnn-level only: test_unary_zero_comp_ttnn and
+// test_unary_zero_comp_uint_ttnn in tests/ttnn/unit_tests/operations/eltwise/test_unary.py.
+// (calculate_comp_unary_int at the bottom of this file is the exception — unary_eq/unary_ne
+// on Int32 reach it from tt-llk's test_sfpu_unary.py.)
+//
+// The uint16/uint32 paths mirror the original raw-TTI load/store modes (LO16 for uint16,
+// INT32 for uint32), so behaviour is preserved across the sfpi conversion.
 template <bool APPROXIMATION_MODE, SfpuType COMP_MODE, int ITERATIONS = 8>
 inline void calculate_comp_uint16() {
     static_assert((COMP_MODE == SfpuType::equal_zero) or (COMP_MODE == SfpuType::not_equal_zero));
+    // UInt16 values live in the low 16 bits of the dest word; DataLayout::U16 loads/stores them
+    // directly (SFPLOAD/SFPSTORE mod = UINT16), matching the InstrModLoadStore::LO16 path.
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         vUInt v = dst_reg[0].mode<sfpi::DataLayout::U16>();
@@ -186,8 +208,7 @@ inline void calculate_comp_uint16() {
             v_if(v == 0) { result = 1; }
             v_endif;
         } else {
-            v_if(v == 0) { result = 0; }
-            v_else { result = 1; }
+            v_if(v != 0) { result = 1; }
             v_endif;
         }
         dst_reg[0].mode<sfpi::DataLayout::U16>() = result;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -50,33 +50,37 @@ inline void calculate_comp() {
     // fp32 total-order comparison-to-zero. |v| is used to fold ±0 together and to
     // detect NaN: a NaN has |v| whose fp32 bit pattern is strictly greater than +inf
     // (0x7F800000), so `as<vInt>(|v|) > 0x7F800000` isolates it.
+    //
+    // The sign must be cleared at the bit level, with setsgn (SFPSETSGN), as the
+    // raw-TTI original did. sfpi::abs() lowers to SFPABS in float mode, which leaves
+    // a NaN's sign bit intact: -NaN then reads back as a negative vInt, the test above
+    // never fires, and ltz(-NaN) returns 1 instead of 0.
     constexpr int FP32_INF_BITS = 0x7F800000;
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0];
-        vFloat abs_v = sfpi::abs(v);
-        vInt abs_bits = as<vInt>(abs_v);
+        vInt abs_bits = as<vInt>(sfpi::setsgn(as<vUInt>(v), 0));
         vFloat result;
 
         // eqz: 1 where |v| == 0 (handles ±0; NaN has |v| != 0 → 0)
         if constexpr (COMP_MODE == SfpuType::equal_zero) {
             result = 0.0f;
-            v_if(abs_v == 0.0f) { result = 1.0f; }
+            v_if(abs_bits == 0) { result = 1.0f; }
             v_endif;
         }
 
         // nez: 0 where |v| == 0 (handles ±0; NaN has |v| != 0 → 1)
         if constexpr (COMP_MODE == SfpuType::not_equal_zero) {
             result = 1.0f;
-            v_if(abs_v == 0.0f) { result = 0.0f; }
+            v_if(abs_bits == 0) { result = 0.0f; }
             v_endif;
         }
 
         // ltz: (v < 0) AND (|v| != 0) → 1, then NaN → 0
         if constexpr (COMP_MODE == SfpuType::less_than_zero) {
             result = 0.0f;
-            v_if(v < 0.0f && abs_v != 0.0f) { result = 1.0f; }
+            v_if(v < 0.0f && abs_bits != 0) { result = 1.0f; }
             v_endif;
             v_if(abs_bits > FP32_INF_BITS) { result = 0.0f; }
             v_endif;
@@ -85,7 +89,7 @@ inline void calculate_comp() {
         // gtz: (v >= 0) AND (|v| != 0) → 1, then NaN → 0
         if constexpr (COMP_MODE == SfpuType::greater_than_zero) {
             result = 0.0f;
-            v_if(v >= 0.0f && abs_v != 0.0f) { result = 1.0f; }
+            v_if(v >= 0.0f && abs_bits != 0) { result = 1.0f; }
             v_endif;
             v_if(abs_bits > FP32_INF_BITS) { result = 0.0f; }
             v_endif;
@@ -94,7 +98,7 @@ inline void calculate_comp() {
         // gez: default 1; negatives (excl. -0) → 0; NaN → 0
         if constexpr (COMP_MODE == SfpuType::greater_than_equal_zero) {
             result = 1.0f;
-            v_if(v < 0.0f && abs_v != 0.0f) { result = 0.0f; }
+            v_if(v < 0.0f && abs_bits != 0) { result = 0.0f; }
             v_endif;
             v_if(abs_bits > FP32_INF_BITS) { result = 0.0f; }
             v_endif;
@@ -103,7 +107,7 @@ inline void calculate_comp() {
         // lez: default 1; positives (excl. +0) → 0; NaN → 0
         if constexpr (COMP_MODE == SfpuType::less_than_equal_zero) {
             result = 1.0f;
-            v_if(v >= 0.0f && abs_v != 0.0f) { result = 0.0f; }
+            v_if(v >= 0.0f && abs_bits != 0) { result = 0.0f; }
             v_endif;
             v_if(abs_bits > FP32_INF_BITS) { result = 0.0f; }
             v_endif;


### PR DESCRIPTION
Restores the Blackhole comparison portions of #49926 (ckernel_sfpu_binary_comp.h, ckernel_sfpu_comp.h) that were rolled back by #51097, on top of current main. The other six files from #49926 were never reverted and are already on main.

This is a CI baseline run to re-measure the regressions that caused the rollback. Known suspects, verified by inspecting the sfpi codegen:

* calculate_binary_comp_int32: sfpi's signed vInt compare lowers to a plain SFPIADD subtract + CC-on-sign, which overflows for operands spanning the full int32 range (e.g. INT32_MAX > -1). The raw-TTI sequence it replaced was the overflow-safe sign-fold added by #27829 and #28397.
* calculate_binary_comp_fp32_* / calculate_comp: sfpi's vFloat compare lowers to SFPMAD subtract + SFPSETCC on the sign, not the total-order SFPGT/SFPLE compare the raw-TTI sequences used. Near-ties whose difference flushes to zero, and inf-vs-inf, change behaviour.

Reverts commit 02246470f9966fb091add6a76b84591551794158.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ldjurovic/bh_sfpu_complex_reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ldjurovic/bh_sfpu_complex_reland)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ldjurovic/bh_sfpu_complex_reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ldjurovic/bh_sfpu_complex_reland)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ldjurovic/bh_sfpu_complex_reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ldjurovic/bh_sfpu_complex_reland)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ldjurovic/bh_sfpu_complex_reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ldjurovic/bh_sfpu_complex_reland)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ldjurovic/bh_sfpu_complex_reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ldjurovic/bh_sfpu_complex_reland)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ldjurovic/bh_sfpu_complex_reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ldjurovic/bh_sfpu_complex_reland)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ldjurovic/bh_sfpu_complex_reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ldjurovic/bh_sfpu_complex_reland)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ldjurovic/bh_sfpu_complex_reland)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ldjurovic/bh_sfpu_complex_reland)