### PR TITLE
Bump up l1_small_size for failing tests

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -1063,8 +1063,8 @@ def test_kimi_prefill_transformer_chunked_padded(
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
                 "fabric_router_config": create_fabric_router_config(max_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE),
-                # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores.
-                "l1_small_size": 768,
+                # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores and rest for other needs.
+                "l1_small_size": 1152,
             },
             2,
             ttnn.Topology.Linear,
@@ -1964,8 +1964,8 @@ def test_ds_prefill_transformer_chunked_no_pcc(
                 "fabric_config": ttnn.FabricConfig.FABRIC_2D,
                 "fabric_router_config": create_fabric_router_config(max_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE),
                 "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-                # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores.
-                "l1_small_size": 768,
+                # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores and rest for other needs.
+                "l1_small_size": 1152,
             },
             2,
             ttnn.Topology.Linear,

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_1.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_1.py
@@ -39,9 +39,8 @@ class GLM51Adapter(MLAPrefillAdapter):
     default_gate_mode = "DEVICE_FP32"  # GLM: single expert group
     prefill_trace_default = "/mnt/models/deepseek-prefill-cache/golden/structured_traces/glm_51_code_debug_55k_vllm"
 
-    # Single expert group + device gate: route routing-all-gather semaphores to L1_SMALL.
-    # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores.
-    l1_small_size = 768
+    # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores and rest for other needs.
+    l1_small_size = 1152
     routing_use_l1_small_for_semaphores = True
 
     def load_hf_config(self):

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_2.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_2.py
@@ -39,9 +39,8 @@ class GLM52Adapter(MLAPrefillAdapter):
     default_gate_mode = "DEVICE_FP32"
     prefill_trace_default = "/mnt/models/deepseek-prefill-cache/golden/structured_traces/glm_52_55k_vllm"
 
-    # Single expert group + device gate: route routing-all-gather semaphores to L1_SMALL.
-    # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores.
-    l1_small_size = 768
+    # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores and rest for other needs.
+    l1_small_size = 1152
     routing_use_l1_small_for_semaphores = True
 
     def load_hf_config(self):

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k2_6.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k2_6.py
@@ -31,9 +31,8 @@ class KimiK26Adapter(MLAPrefillAdapter):
     default_gate_mode = "DEVICE_FP32"  # Kimi (1 expert group)
     prefill_trace_default = "/mnt/models/deepseek-prefill-cache/golden/kimi-26/kimi_longbook_56320"
 
-    # Single expert group + device gate: route routing-all-gather semaphores to L1_SMALL.
-    # Routing consumes 512 B; leave 256 B for MLA high-bandwidth-gather semaphores.
-    l1_small_size = 768
+    # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores and rest for other needs.
+    l1_small_size = 1152
     routing_use_l1_small_for_semaphores = True
 
     # --- test metadata (HF download coordinates + PCC thresholds) ---

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k2_6.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k2_6.py
@@ -31,8 +31,9 @@ class KimiK26Adapter(MLAPrefillAdapter):
     default_gate_mode = "DEVICE_FP32"  # Kimi (1 expert group)
     prefill_trace_default = "/mnt/models/deepseek-prefill-cache/golden/kimi-26/kimi_longbook_56320"
 
-    # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores and rest for other needs.
-    l1_small_size = 1152
+    # Single expert group + device gate: route routing-all-gather semaphores to L1_SMALL.
+    # Routing consumes 512 B; leave 256 B for MLA high-bandwidth-gather semaphores.
+    l1_small_size = 768
     routing_use_l1_small_for_semaphores = True
 
     # --- test metadata (HF download coordinates + PCC thresholds) ---


### PR DESCRIPTION
CI runs:
Blaze - https://github.com/tenstorrent/tt-metal/actions/runs/31601945903
BH e2e - https://github.com/tenstorrent/tt-metal/actions/runs/31601655750

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nostojic/glm-chunked-l1-small-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nostojic/glm-chunked-l1-small-bump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nostojic/glm-chunked-l1-small-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nostojic/glm-chunked-l1-small-bump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nostojic/glm-chunked-l1-small-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nostojic/glm-chunked-l1-small-bump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nostojic/glm-chunked-l1-small-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nostojic/glm-chunked-l1-small-bump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nostojic/glm-chunked-l1-small-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nostojic/glm-chunked-l1-small-bump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nostojic/glm-chunked-l1-small-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nostojic/glm-chunked-l1-small-bump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nostojic/glm-chunked-l1-small-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nostojic/glm-chunked-l1-small-bump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nostojic/glm-chunked-l1-small-bump)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nostojic/glm-chunked-l1-small-bump)