### PR TITLE
[Feature] Add Quasar max pool with indices support

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_max_pool_indices.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_max_pool_indices.h
@@ -1,0 +1,477 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_addrmod.h"
+#include "ckernel_instr_params.h"
+#include "ckernel_ops.h"
+#include "ckernel_sfpu.h"
+#include "ckernel_trisc_common.h"
+#include "cmath_common.h"
+#include "llk_defs.h"
+#include "llk_math_eltwise_sfpu_common.h"
+#include "lltt.h"
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+// LaneConfig bit [2]: SFPSWAP mirrors every value swap in LREG0-3 onto LREG4-7 (argmax).
+// Bit [3] (CAPTURE_DEFAULT_DEST_INDEX) must stay clear, or SFPLOAD would overwrite the loaded indices.
+constexpr std::uint32_t LANECFG_ENABLE_DEST_INDEX = 0x4;
+// SFPCONFIG.config_dest value selecting the LaneConfig register.
+constexpr std::uint32_t SFPCFG_DEST_LANECONFIG = 0xF;
+// imm12 bit 11 makes SFPSETCC test the sign bit as INT32. Float values in an LREG
+// use sign-magnitude representation, so this identifies negative FP16B/FP32 lanes.
+constexpr std::uint32_t MAX_POOL_SFPSETCC_SIGNBIT = 0x800;
+
+// SFPLOAD address bit 1 selects the Dest column parity.
+constexpr std::uint32_t EVEN_COL_OFFSET = p_sfpu::col_offset::EVEN_COL;  // columns 0, 2, ..., 14
+constexpr std::uint32_t ODD_COL_OFFSET = p_sfpu::col_offset::ODD_COL;    // columns 1, 3, ..., 15
+// Dest rows covered by one SFPLOAD (4 rows x 8 columns of one parity).
+constexpr std::uint32_t ROW_GROUP = 4;
+// Generic path: 8 logical ROW_MAJOR rows occupy 16 Dest rows.
+constexpr std::uint32_t EIGHT_ROW_OFFSET = 16;
+// Generic path: 16 logical ROW_MAJOR rows occupy 32 Dest rows.
+constexpr std::uint32_t SIXTEEN_ROW_OFFSET = 32;
+
+// TILE-layout replay map. Both faces issue identical SFPLOAD/SFPSTORE words once the Dest counter
+// is advanced by one face, so each memory group is recorded once and replayed per face. Slots 0-15
+// are free on the math thread: the FPU datacopy that stages the tiles programs no replay buffer.
+// The SFPSWAP/SFPTRANSP network deliberately stays inline — TEN-4690 forbids replaying it, and a
+// replayed swap network loses the instruction scheduling the compare chain depends on.
+constexpr std::uint32_t TILE_STAGE_LOAD_COUNT = 8;  // 4 value + 4 index loads, rows 0-7
+constexpr std::uint32_t TILE_ROW8_LOAD_COUNT = 4;   // 2 value + 2 index loads, row 8
+constexpr std::uint32_t TILE_STORE_COUNT = 4;       // 2 value + 2 index stores, row 0
+constexpr std::uint32_t TILE_SLOT_STAGE_LOADS = 0;
+constexpr std::uint32_t TILE_SLOT_ROW8_LOADS = TILE_SLOT_STAGE_LOADS + TILE_STAGE_LOAD_COUNT;
+constexpr std::uint32_t TILE_SLOT_STORES = TILE_SLOT_ROW8_LOADS + TILE_ROW8_LOAD_COUNT;
+
+/**
+ * @brief Set LaneConfig bit [2] (ENABLE_DEST_INDEX) so SFPSWAP swaps LREG4-7 alongside LREG0-3.
+ *
+ * @tparam APPROXIMATION_MODE: Kept for SFPU call-shape parity; unused, values = <true/false>
+ * @tparam layout: Dest row arrangement the execute stage expects, values = <TILE/ROW_MAJOR>
+ * @note Call once before @ref calculate_max_pool_with_indices; the bit persists on Quasar.
+ */
+template <bool APPROXIMATION_MODE, DataLayout layout = DataLayout::TILE>
+inline void init_max_pool_with_indices() {
+    ckernel::math::_sfpu_load_config32_(SFPCFG_DEST_LANECONFIG, 0x0 /* upper16 */, LANECFG_ENABLE_DEST_INDEX);
+    // SFPCONFIG is 2-cycle; errata TEN-4581 requires SFPNOP padding before the first SFPSWAP.
+    TTI_SFPNOP(0 /* srcs_wr_done */, 0 /* srcs_rd_done */, 0 /* dest_done */);
+    TTI_SFPNOP(0 /* srcs_wr_done */, 0 /* srcs_rd_done */, 0 /* dest_done */);
+    // No replay-buffer programming on Quasar: TEN-4690 makes a replayed SFPSWAP network unsafe.
+}
+
+/**
+ * @brief Keep the maximum in VALUE_LREG_A and its paired index in LREG(4 + A).
+ *
+ * Quasar ALL_ROWS_MAX compares sign-magnitude bits as unsigned values. Its first
+ * swap is therefore reversed when both operands are negative. The condition-code
+ * guarded second swap corrects exactly those lanes. LaneConfig index tracking
+ * mirrors both swaps into the corresponding index registers.
+ */
+template <std::uint32_t VALUE_LREG_A, std::uint32_t VALUE_LREG_B>
+inline void _max_pool_swap_max_() {
+    TTI_SFPSWAP(0 /* imm12 */, VALUE_LREG_A, VALUE_LREG_B, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPNOP(0 /* srcs_wr_done */, 0 /* srcs_rd_done */, 0 /* dest_done */);
+    TTI_SFPSETCC(MAX_POOL_SFPSETCC_SIGNBIT, VALUE_LREG_A, sfpi::SFPSETCC_MOD1_LREG_LT0);
+    TTI_SFPSETCC(MAX_POOL_SFPSETCC_SIGNBIT, VALUE_LREG_B, sfpi::SFPSETCC_MOD1_LREG_LT0);
+    TTI_SFPSWAP(0 /* imm12 */, VALUE_LREG_A, VALUE_LREG_B, sfpi::SFPSWAP_MOD1_SWAP);
+    TTI_SFPENCC(0 /* imm12 */, 0 /* mod1: clear CC */);
+}
+
+/**
+ * @brief TILE-layout tournament: max of LREG0..LREG3 lands in LREG0 (even cols) and LREG2 (odd cols).
+ *
+ * @note Both SFPTRANSPs bulk-update LREG4-7 as well, which keeps every index paired with its value.
+ */
+inline void _max_pool_sort4_tile_() {
+    TTI_SFPTRANSP;  // move the 4 Dest rows held per LREG into the lane dimension
+    _max_pool_swap_max_<p_sfpu::LREG0, p_sfpu::LREG1>();
+    _max_pool_swap_max_<p_sfpu::LREG2, p_sfpu::LREG3>();
+    _max_pool_swap_max_<p_sfpu::LREG0, p_sfpu::LREG2>();
+    TTI_SFPTRANSP;                                        // back; row 0 of LREG0..LREG3 now holds the 4 partials
+    _max_pool_swap_max_<p_sfpu::LREG0, p_sfpu::LREG1>();  // even-column partials
+    _max_pool_swap_max_<p_sfpu::LREG2, p_sfpu::LREG3>();  // odd-column partials
+}
+
+/**
+ * @brief ROW_MAJOR tournament: max of the 8 logical rows in LREG0..LREG3 lands in LREG0, its index in LREG4.
+ *
+ * @note Ends on SFPTRANSP, which already drains the preceding SFPSWAP — a following SFPSTORE of
+ *       LREG0-3 needs no SFPNOP.
+ */
+inline void _max_pool_sort4_row_major_() {
+    _max_pool_swap_max_<p_sfpu::LREG0, p_sfpu::LREG1>();
+    _max_pool_swap_max_<p_sfpu::LREG2, p_sfpu::LREG3>();
+    _max_pool_swap_max_<p_sfpu::LREG0, p_sfpu::LREG2>();
+    TTI_SFPTRANSP;
+    _max_pool_swap_max_<p_sfpu::LREG0, p_sfpu::LREG2>();
+    _max_pool_swap_max_<p_sfpu::LREG1, p_sfpu::LREG3>();
+    TTI_SFPTRANSP;
+}
+
+/**
+ * @brief Up-to-9-row column max with argmax. Row 0 of each column holds the result; the rest is scratch.
+ *
+ * @tparam APPROXIMATION_MODE: Kept for SFPU call-shape parity; unused, values = <true/false>
+ * @tparam is_fp32_dest_acc_en: Dest register is in 32-bit mode; picks the index sfpmem mode, values = <true/false>
+ * @tparam num_rows: Rows reduced per column, values = <4/8/9>
+ * @tparam ITERATIONS: Kept for SFPU call-shape parity; this path has no per-row loop
+ * @tparam layout: Dest row arrangement, values = <TILE/ROW_MAJOR>
+ * @tparam accumulate: Must be false; only @ref _calculate_max_pool_with_indices_generic_ accumulates
+ * @tparam TILE_SHAPE: Dest tile shape used to convert a tile index to a Dest row offset
+ * @param values_tile_idx: Dest tile index of the values tile.
+ * @param indices_tile_idx: Dest tile index of the paired index tile.
+ * @param chunk: Unused on this path; only the accumulate fold reads it.
+ * @note Run @ref init_max_pool_with_indices first.
+ * @note The TILE path advances the Dest counter itself to reach face 1, so it must be invoked with
+ *       VectorMode::None; a vector-mode face walk would advance it a second time.
+ */
+template <
+    bool APPROXIMATION_MODE,
+    bool is_fp32_dest_acc_en,
+    int num_rows,
+    int ITERATIONS,
+    DataLayout layout,
+    bool accumulate,
+    trisc::DstTileShape TILE_SHAPE>
+inline void _calculate_max_pool_with_indices_(
+    const std::uint32_t values_tile_idx,
+    const std::uint32_t indices_tile_idx,
+    [[maybe_unused]] const std::uint32_t chunk) {
+    static_assert(num_rows == 4 || num_rows == 8 || num_rows == 9, "short max pool supports 4, 8, or 9 rows");
+    constexpr std::uint32_t VAL_MODE = is_fp32_dest_acc_en ? p_sfpu::sfpmem::FP32 : p_sfpu::sfpmem::FP16B;
+    constexpr std::uint32_t IDX_MODE = is_fp32_dest_acc_en ? p_sfpu::sfpmem::INT32 : p_sfpu::sfpmem::UINT16;
+    constexpr std::uint32_t DST_TILE_ROWS = 1U << trisc::get_dest_tile_size_log2(TILE_SHAPE);
+
+    const std::uint32_t values_tile_offset = values_tile_idx * DST_TILE_ROWS;
+    const std::uint32_t indices_tile_offset = indices_tile_idx * DST_TILE_ROWS;
+
+    if constexpr (layout == DataLayout::ROW_MAJOR) {
+        // Dest is expected to hold F0R0, F1R0, F0R1, F1R1, ... F0R8, F1R8. One pass per column
+        // parity; the parity offset is added to every address instead of using a second LREG pair.
+        auto process_columns = [values_tile_offset,
+                                indices_tile_offset](const std::uint32_t col_offset) __attribute__((always_inline)) {
+            const std::uint32_t val_base = values_tile_offset + col_offset;
+            const std::uint32_t idx_base = indices_tile_offset + col_offset;
+
+            TT_SFPLOAD(p_sfpu::LREG0, VAL_MODE, ADDR_MOD_7, 0 /* done */, val_base + 0 * ROW_GROUP);
+            TT_SFPLOAD(p_sfpu::LREG1, VAL_MODE, ADDR_MOD_7, 0 /* done */, val_base + 1 * ROW_GROUP);
+            TT_SFPLOAD(
+                p_sfpu::LREG2, VAL_MODE, ADDR_MOD_7, 0 /* done */, val_base + (num_rows == 4 ? 0 : 2) * ROW_GROUP);
+            TT_SFPLOAD(
+                p_sfpu::LREG3, VAL_MODE, ADDR_MOD_7, 0 /* done */, val_base + (num_rows == 4 ? 1 : 3) * ROW_GROUP);
+            TT_SFPLOAD(p_sfpu::LREG4, IDX_MODE, ADDR_MOD_7, 0 /* done */, idx_base + 0 * ROW_GROUP);
+            TT_SFPLOAD(p_sfpu::LREG5, IDX_MODE, ADDR_MOD_7, 0 /* done */, idx_base + 1 * ROW_GROUP);
+            TT_SFPLOAD(
+                p_sfpu::LREG6, IDX_MODE, ADDR_MOD_7, 0 /* done */, idx_base + (num_rows == 4 ? 0 : 2) * ROW_GROUP);
+            TT_SFPLOAD(
+                p_sfpu::LREG7, IDX_MODE, ADDR_MOD_7, 0 /* done */, idx_base + (num_rows == 4 ? 1 : 3) * ROW_GROUP);
+
+            _max_pool_sort4_row_major_();  // max of logical rows 0-7 in LREG0 / LREG4
+
+            if constexpr (num_rows == 9) {
+                // Fold in logical row 8.
+                TT_SFPLOAD(p_sfpu::LREG1, VAL_MODE, ADDR_MOD_7, 0 /* done */, val_base + 4 * ROW_GROUP);
+                TT_SFPLOAD(p_sfpu::LREG5, IDX_MODE, ADDR_MOD_7, 0 /* done */, idx_base + 4 * ROW_GROUP);
+                _max_pool_swap_max_<p_sfpu::LREG0, p_sfpu::LREG1>();
+            }
+            // Keep an explicit store separation for the num_rows=9 correction swap.
+            TTI_SFPNOP(0 /* srcs_wr_done */, 0 /* srcs_rd_done */, 0 /* dest_done */);
+
+            TT_SFPSTORE(p_sfpu::LREG4, IDX_MODE, ADDR_MOD_7, 0 /* done */, idx_base);
+            TT_SFPSTORE(p_sfpu::LREG0, VAL_MODE, ADDR_MOD_7, 0 /* done */, val_base);
+        };
+
+        process_columns(EVEN_COL_OFFSET);
+        process_columns(ODD_COL_OFFSET);
+    } else {
+        static_assert(!accumulate, "accumulate mode is not supported for TILE layout");
+
+        // Natural face layout: each face is reduced over the requested 4, 8, or 9 rows. Addresses are face-relative
+        // and face 1 is reached by advancing the Dest counter, so both faces issue the same words
+        // and the memory groups can be replayed.
+        const std::uint32_t val_base = values_tile_offset;
+        const std::uint32_t idx_base = indices_tile_offset;
+
+        lltt::record(TILE_SLOT_STAGE_LOADS, TILE_STAGE_LOAD_COUNT);
+        TT_SFPLOAD(p_sfpu::LREG0, VAL_MODE, ADDR_MOD_7, 0 /* done */, val_base + 0 * ROW_GROUP + EVEN_COL_OFFSET);
+        TT_SFPLOAD(
+            p_sfpu::LREG1,
+            VAL_MODE,
+            ADDR_MOD_7,
+            0 /* done */,
+            val_base + (num_rows == 4 ? 0 : 1) * ROW_GROUP + EVEN_COL_OFFSET);
+        TT_SFPLOAD(p_sfpu::LREG2, VAL_MODE, ADDR_MOD_7, 0 /* done */, val_base + 0 * ROW_GROUP + ODD_COL_OFFSET);
+        TT_SFPLOAD(
+            p_sfpu::LREG3,
+            VAL_MODE,
+            ADDR_MOD_7,
+            0 /* done */,
+            val_base + (num_rows == 4 ? 0 : 1) * ROW_GROUP + ODD_COL_OFFSET);
+        TT_SFPLOAD(p_sfpu::LREG4, IDX_MODE, ADDR_MOD_7, 0 /* done */, idx_base + 0 * ROW_GROUP + EVEN_COL_OFFSET);
+        TT_SFPLOAD(
+            p_sfpu::LREG5,
+            IDX_MODE,
+            ADDR_MOD_7,
+            0 /* done */,
+            idx_base + (num_rows == 4 ? 0 : 1) * ROW_GROUP + EVEN_COL_OFFSET);
+        TT_SFPLOAD(p_sfpu::LREG6, IDX_MODE, ADDR_MOD_7, 0 /* done */, idx_base + 0 * ROW_GROUP + ODD_COL_OFFSET);
+        TT_SFPLOAD(
+            p_sfpu::LREG7,
+            IDX_MODE,
+            ADDR_MOD_7,
+            0 /* done */,
+            idx_base + (num_rows == 4 ? 0 : 1) * ROW_GROUP + ODD_COL_OFFSET);
+
+        if constexpr (num_rows == 9) {
+            // Row 8 arrives in lane row 0 of the third row group.
+            lltt::record(TILE_SLOT_ROW8_LOADS, TILE_ROW8_LOAD_COUNT);
+            TT_SFPLOAD(p_sfpu::LREG1, VAL_MODE, ADDR_MOD_7, 0 /* done */, val_base + 2 * ROW_GROUP + EVEN_COL_OFFSET);
+            TT_SFPLOAD(p_sfpu::LREG3, VAL_MODE, ADDR_MOD_7, 0 /* done */, val_base + 2 * ROW_GROUP + ODD_COL_OFFSET);
+            TT_SFPLOAD(p_sfpu::LREG5, IDX_MODE, ADDR_MOD_7, 0 /* done */, idx_base + 2 * ROW_GROUP + EVEN_COL_OFFSET);
+            TT_SFPLOAD(p_sfpu::LREG7, IDX_MODE, ADDR_MOD_7, 0 /* done */, idx_base + 2 * ROW_GROUP + ODD_COL_OFFSET);
+        }
+
+        lltt::record(TILE_SLOT_STORES, TILE_STORE_COUNT);
+        TT_SFPSTORE(p_sfpu::LREG0, VAL_MODE, ADDR_MOD_7, 0 /* done */, val_base + EVEN_COL_OFFSET);
+        TT_SFPSTORE(p_sfpu::LREG2, VAL_MODE, ADDR_MOD_7, 0 /* done */, val_base + ODD_COL_OFFSET);
+        TT_SFPSTORE(p_sfpu::LREG4, IDX_MODE, ADDR_MOD_7, 0 /* done */, idx_base + EVEN_COL_OFFSET);
+        TT_SFPSTORE(p_sfpu::LREG6, IDX_MODE, ADDR_MOD_7, 0 /* done */, idx_base + ODD_COL_OFFSET);
+
+        auto process_face = []() __attribute__((always_inline)) {
+            lltt::replay(TILE_SLOT_STAGE_LOADS, TILE_STAGE_LOAD_COUNT);
+
+            _max_pool_sort4_tile_();  // max of rows 0-7 in LREG0 (even cols) / LREG2 (odd cols)
+
+            if constexpr (num_rows == 9) {
+                lltt::replay(TILE_SLOT_ROW8_LOADS, TILE_ROW8_LOAD_COUNT);
+                _max_pool_swap_max_<p_sfpu::LREG0, p_sfpu::LREG1>();  // fold row 8, even cols
+                _max_pool_swap_max_<p_sfpu::LREG2, p_sfpu::LREG3>();  // fold row 8, odd cols
+            }
+            // Keep an explicit store separation for the num_rows=9 correction swap.
+            TTI_SFPNOP(0 /* srcs_wr_done */, 0 /* srcs_rd_done */, 0 /* dest_done */);
+
+            lltt::replay(TILE_SLOT_STORES, TILE_STORE_COUNT);
+        };
+
+        process_face();
+        // Advance the Dest counter one face; the same recorded words then address face 1.
+        // _llk_math_eltwise_sfpu_done_ resets the counter once the op finishes.
+        _llk_math_sfpu_inc_dst_face_addr_();
+        process_face();
+    }
+}
+
+/**
+ * @brief Up-to-32-row ROW_MAJOR column max with argmax, optionally folded with a running result.
+ *
+ * @tparam APPROXIMATION_MODE: Kept for SFPU call-shape parity; unused, values = <true/false>
+ * @tparam is_fp32_dest_acc_en: Dest register is in 32-bit mode; picks the index sfpmem mode, values = <true/false>
+ * @tparam num_rows: Rows reduced per column, values = <16/20/32>
+ * @tparam ITERATIONS: Kept for SFPU call-shape parity; this path has no per-row loop
+ * @tparam accumulate: Fold this chunk's result into the running result, values = <true/false>
+ * @tparam TILE_SHAPE: Dest tile shape used to convert a tile index to a Dest row offset
+ * @param values_tile_idx: Dest tile index of the values tile.
+ * @param indices_tile_idx: Dest tile index of the paired index tile.
+ * @param chunk: Chunk counter; chunk 0 seeds the running result, later chunks fold into it.
+ * @note Run @ref init_max_pool_with_indices first.
+ * @note With accumulate=true the caller must also reserve Dest tiles values_tile_idx + 1 and
+ *       indices_tile_idx + 1 — the running result lives there and the kernel cannot check it.
+ */
+template <
+    bool APPROXIMATION_MODE,
+    bool is_fp32_dest_acc_en,
+    int num_rows,
+    int ITERATIONS,
+    bool accumulate,
+    trisc::DstTileShape TILE_SHAPE>
+inline void _calculate_max_pool_with_indices_generic_(
+    const std::uint32_t values_tile_idx,
+    const std::uint32_t indices_tile_idx,
+    [[maybe_unused]] const std::uint32_t chunk) {
+    static_assert(num_rows == 16 || num_rows == 20 || num_rows == 32, "generic max pool supports 16, 20, or 32 rows");
+    constexpr std::uint32_t VAL_MODE = is_fp32_dest_acc_en ? p_sfpu::sfpmem::FP32 : p_sfpu::sfpmem::FP16B;
+    constexpr std::uint32_t IDX_MODE = is_fp32_dest_acc_en ? p_sfpu::sfpmem::INT32 : p_sfpu::sfpmem::UINT16;
+    constexpr std::uint32_t DST_TILE_ROWS = 1U << trisc::get_dest_tile_size_log2(TILE_SHAPE);
+
+    const std::uint32_t values_tile_offset = values_tile_idx * DST_TILE_ROWS;
+    const std::uint32_t indices_tile_offset = indices_tile_idx * DST_TILE_ROWS;
+    const std::uint32_t values_accum_tile_offset = (values_tile_idx + 1) * DST_TILE_ROWS;
+    const std::uint32_t indices_accum_tile_offset = (indices_tile_idx + 1) * DST_TILE_ROWS;
+
+    // Reduce either 4 or 8 logical rows into LREG0 / LREG4. For 4 rows, duplicate
+    // the first two load groups into LREG2/3 so no value outside the requested
+    // window participates in the fixed 8-row tournament.
+    auto reduce_rows =
+        [](const std::uint32_t val_base, const std::uint32_t idx_base, const bool four_rows, const bool store_result)
+            __attribute__((always_inline)) {
+                const std::uint32_t third_group = four_rows ? 0 : 2 * ROW_GROUP;
+                const std::uint32_t fourth_group = four_rows ? ROW_GROUP : 3 * ROW_GROUP;
+
+                TT_SFPLOAD(p_sfpu::LREG0, VAL_MODE, ADDR_MOD_7, 0 /* done */, val_base + 0 * ROW_GROUP);
+                TT_SFPLOAD(p_sfpu::LREG1, VAL_MODE, ADDR_MOD_7, 0 /* done */, val_base + 1 * ROW_GROUP);
+                TT_SFPLOAD(p_sfpu::LREG2, VAL_MODE, ADDR_MOD_7, 0 /* done */, val_base + third_group);
+                TT_SFPLOAD(p_sfpu::LREG3, VAL_MODE, ADDR_MOD_7, 0 /* done */, val_base + fourth_group);
+                TT_SFPLOAD(p_sfpu::LREG4, IDX_MODE, ADDR_MOD_7, 0 /* done */, idx_base + 0 * ROW_GROUP);
+                TT_SFPLOAD(p_sfpu::LREG5, IDX_MODE, ADDR_MOD_7, 0 /* done */, idx_base + 1 * ROW_GROUP);
+                TT_SFPLOAD(p_sfpu::LREG6, IDX_MODE, ADDR_MOD_7, 0 /* done */, idx_base + third_group);
+                TT_SFPLOAD(p_sfpu::LREG7, IDX_MODE, ADDR_MOD_7, 0 /* done */, idx_base + fourth_group);
+
+                _max_pool_sort4_row_major_();
+
+                if (store_result) {
+                    // No SFPNOP: _max_pool_sort4_row_major_ ends on SFPTRANSP.
+                    TT_SFPSTORE(p_sfpu::LREG0, VAL_MODE, ADDR_MOD_7, 0 /* done */, val_base);
+                    TT_SFPSTORE(p_sfpu::LREG4, IDX_MODE, ADDR_MOD_7, 0 /* done */, idx_base);
+                }
+            };
+
+    // Reduce 16 logical rows. The first 8-row block is spilled so its registers can be reused;
+    // the second block's result stays in LREG0 / LREG4 for the closing swap.
+    auto process_16_rows =
+        [&reduce_rows, values_tile_offset, indices_tile_offset](
+            const std::uint32_t base_offset, const std::uint32_t col_offset, const bool store_result)
+            __attribute__((always_inline)) {
+                const std::uint32_t val_base_first = values_tile_offset + base_offset + col_offset;
+                const std::uint32_t idx_base_first = indices_tile_offset + base_offset + col_offset;
+                const std::uint32_t val_base_second = val_base_first + EIGHT_ROW_OFFSET;
+                const std::uint32_t idx_base_second = idx_base_first + EIGHT_ROW_OFFSET;
+
+                reduce_rows(val_base_first, idx_base_first, false /* four_rows */, true /* store_result */);
+                reduce_rows(val_base_second, idx_base_second, false /* four_rows */, false /* store_result */);
+
+                // LREG0 / LREG4 hold Max(R8-15); reload Max(R0-7) to finish the 16-row reduction.
+                TT_SFPLOAD(p_sfpu::LREG1, VAL_MODE, ADDR_MOD_7, 0 /* done */, val_base_first);
+                TT_SFPLOAD(p_sfpu::LREG5, IDX_MODE, ADDR_MOD_7, 0 /* done */, idx_base_first);
+                _max_pool_swap_max_<p_sfpu::LREG0, p_sfpu::LREG1>();
+
+                if (store_result) {
+                    // Drain the SFPSWAP before a store that reads LREG0-3.
+                    TTI_SFPNOP(0 /* srcs_wr_done */, 0 /* srcs_rd_done */, 0 /* dest_done */);
+                    TT_SFPSTORE(p_sfpu::LREG4, IDX_MODE, ADDR_MOD_7, 0 /* done */, idx_base_first);
+                    TT_SFPSTORE(p_sfpu::LREG0, VAL_MODE, ADDR_MOD_7, 0 /* done */, val_base_first);
+                }
+            };
+
+    // Store the completed reduction and optionally fold it into the running result.
+    auto store_result =
+        [values_tile_offset, indices_tile_offset, values_accum_tile_offset, indices_accum_tile_offset, chunk](
+            const std::uint32_t col_offset) __attribute__((always_inline)) {
+            const std::uint32_t val_first = values_tile_offset + col_offset;
+            const std::uint32_t idx_first = indices_tile_offset + col_offset;
+
+            if constexpr (accumulate) {
+                const std::uint32_t val_accum = values_accum_tile_offset + col_offset;
+                const std::uint32_t idx_accum = indices_accum_tile_offset + col_offset;
+                if (chunk > 0) {
+                    // Fold in the running result held in the accumulator tiles.
+                    TT_SFPLOAD(p_sfpu::LREG1, VAL_MODE, ADDR_MOD_7, 0 /* done */, val_accum);
+                    TT_SFPLOAD(p_sfpu::LREG5, IDX_MODE, ADDR_MOD_7, 0 /* done */, idx_accum);
+                    _max_pool_swap_max_<p_sfpu::LREG0, p_sfpu::LREG1>();
+                }
+                TTI_SFPNOP(0 /* srcs_wr_done */, 0 /* srcs_rd_done */, 0 /* dest_done */);
+                TT_SFPSTORE(p_sfpu::LREG4, IDX_MODE, ADDR_MOD_7, 0 /* done */, idx_accum);
+                TT_SFPSTORE(p_sfpu::LREG0, VAL_MODE, ADDR_MOD_7, 0 /* done */, val_accum);
+            }
+
+            TTI_SFPNOP(0 /* srcs_wr_done */, 0 /* srcs_rd_done */, 0 /* dest_done */);
+            TT_SFPSTORE(p_sfpu::LREG4, IDX_MODE, ADDR_MOD_7, 0 /* done */, idx_first);
+            TT_SFPSTORE(p_sfpu::LREG0, VAL_MODE, ADDR_MOD_7, 0 /* done */, val_first);
+        };
+
+    // Finish one column parity completely while its current partial remains in LREG0/LREG4.
+    auto process_column = [&process_16_rows, &reduce_rows, &store_result, values_tile_offset, indices_tile_offset](
+                              const std::uint32_t col_offset) __attribute__((always_inline)) {
+        if constexpr (num_rows == 16) {
+            process_16_rows(0 /* base_offset */, col_offset, false /* store_result */);
+        } else {
+            // Spill Max(R0-15), then reduce exactly the requested remaining rows.
+            process_16_rows(0 /* base_offset */, col_offset, true /* store_result */);
+            if constexpr (num_rows == 20) {
+                reduce_rows(
+                    values_tile_offset + SIXTEEN_ROW_OFFSET + col_offset,
+                    indices_tile_offset + SIXTEEN_ROW_OFFSET + col_offset,
+                    true /* four_rows */,
+                    false /* store_result */);
+            } else {
+                process_16_rows(SIXTEEN_ROW_OFFSET, col_offset, false /* store_result */);
+            }
+
+            // Combine the R0-15 partial with R16-19 or R16-31.
+            TT_SFPLOAD(p_sfpu::LREG1, VAL_MODE, ADDR_MOD_7, 0 /* done */, values_tile_offset + col_offset);
+            TT_SFPLOAD(p_sfpu::LREG5, IDX_MODE, ADDR_MOD_7, 0 /* done */, indices_tile_offset + col_offset);
+            _max_pool_swap_max_<p_sfpu::LREG0, p_sfpu::LREG1>();
+        }
+        store_result(col_offset);
+    };
+
+    process_column(EVEN_COL_OFFSET);
+    process_column(ODD_COL_OFFSET);
+}
+
+/**
+ * @brief Column-wise max with argmax over a Dest tile pair; dispatches on num_rows.
+ *
+ * Row 0 of every column of both tiles receives the result; the remaining rows are scratch.
+ *
+ * @tparam APPROXIMATION_MODE: Kept for SFPU call-shape parity; unused, values = <true/false>
+ * @tparam is_fp32_dest_acc_en: Dest register is in 32-bit mode; picks the index sfpmem mode, values = <true/false>
+ * @tparam num_rows: Rows reduced per column, values = <4/8/9/16/20/32>
+ * @tparam ITERATIONS: Kept for SFPU call-shape parity; neither path has a per-row loop
+ * @tparam layout: Dest row arrangement, values = <TILE/ROW_MAJOR>. num_rows > 9 requires ROW_MAJOR.
+ * @tparam accumulate: Fold this chunk's result into the running result; generic path only, values = <true/false>
+ * @tparam TILE_SHAPE: Dest tile shape used to convert a tile index to a Dest row offset
+ * @param values_tile_idx: Dest tile index of the values tile.
+ * @param indices_tile_idx: Dest tile index of the paired index tile.
+ * @param unused_tile_idx: Ignored; present because the binary SFPU dispatch passes an output slot.
+ * @param chunk: Chunk counter, read only when accumulate is true.
+ * @note Call @ref init_max_pool_with_indices before this function.
+ * @note Invoke with VectorMode::None — the kernel walks both faces itself.
+ */
+template <
+    bool APPROXIMATION_MODE,
+    bool is_fp32_dest_acc_en,
+    int num_rows,
+    int ITERATIONS = SFPU_ITERATIONS,
+    DataLayout layout = DataLayout::TILE,
+    bool accumulate = false,
+    trisc::DstTileShape TILE_SHAPE = trisc::DstTileShape::Tile32x32>
+inline void calculate_max_pool_with_indices(
+    std::uint32_t values_tile_idx,
+    std::uint32_t indices_tile_idx,
+    [[maybe_unused]] std::uint32_t unused_tile_idx,
+    std::uint32_t chunk) {
+    static_assert(
+        num_rows == 4 || num_rows == 8 || num_rows == 9 || num_rows == 16 || num_rows == 20 || num_rows == 32,
+        "num_rows must be 4, 8, 9, 16, 20, or 32");
+
+    if constexpr (num_rows <= 9) {
+        _calculate_max_pool_with_indices_<
+            APPROXIMATION_MODE,
+            is_fp32_dest_acc_en,
+            num_rows,
+            ITERATIONS,
+            layout,
+            accumulate,
+            TILE_SHAPE>(values_tile_idx, indices_tile_idx, chunk);
+    } else {
+        static_assert(
+            layout == DataLayout::ROW_MAJOR, "generic max pool with indices is only implemented for ROW_MAJOR layout");
+        _calculate_max_pool_with_indices_generic_<
+            APPROXIMATION_MODE,
+            is_fp32_dest_acc_en,
+            num_rows,
+            ITERATIONS,
+            accumulate,
+            TILE_SHAPE>(values_tile_idx, indices_tile_idx, chunk);
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/compute_kernel_api.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_api.h
@@ -58,6 +58,8 @@
 #include "ckernel_sfpu_square.h"
 #include "llk_math_eltwise_unary_sfpu_macros.h"
 #include "ckernel_sfpu_binary.h"
+#include "ckernel_sfpu_max_pool_indices.h"
+#include "llk_math_eltwise_binary_sfpu_macros.h"
 #include "llk_math_eltwise_binary_sfpu_add_int.h"
 #include "llk_math_eltwise_binary_sfpu_mul_int.h"
 #include "llk_math_eltwise_binary_sfpu_binary_comp.h"
@@ -834,8 +836,6 @@ ALWI void topk_uint16_prepare_value_tile_for_pack(uint32_t idst) {
     MATH((ckernel::sfpu::topk_uint16_prepare_value_tile_for_pack(idst)));
 }
 
-#ifndef ARCH_QUASAR  // BH/WH-only ops below
-
 // clang-format off
 /**
  * Performs MaxPool with indices algorithm on the data tile and index tile
@@ -848,7 +848,7 @@ ALWI void topk_uint16_prepare_value_tile_for_pack(uint32_t idst) {
  * | idst            | The index of the tile in DST register containing the data to be reduced     | uint32_t   | Must be less than the size of the DST register buffer | True     |
  * | idst_idx        | The index of the tile in DST register containing the indices of the data    | uint32_t   | Must be less than the size of the DST register buffer | True     |
  * | chunk           | The index of the intra-kernel "chunk" of data for large kernel accumulation | uint32_t   | 0 to UINT_MAX                                         | False    |
- * | num_rows        | The number of rows to use for the MaxPool operation                         | uint32_t   | <= 32, but note either 9 or 32 rows will be reduced   | False    |
+ * | num_rows        | The number of rows to use for the MaxPool operation                         | uint32_t   | <= 32 (Quasar: 4, 8, 9, 16, 20, or 32)               | False    |
  * | layout          | The data layout of the data in DST                                          | DataLayout | TILE or ROW_MAJOR                                     | False    |
  * | accumulate      | Whether to accumulate results for large kernels                             | bool       | true, false                                           | False    |
  * | ITERATIONS      | The number of iterations to perform (unused)                                | int        | 1 to 8                                                | False    |
@@ -861,6 +861,11 @@ template <
     int ITERATIONS = 8>
 ALWI void max_reduce_with_indices(uint32_t idst, uint32_t idst_idx, uint32_t chunk = 0) {
     static_assert(num_rows <= 32, "num_rows must be <= 32");
+#ifdef ARCH_QUASAR
+    constexpr VectorMode vector_mode = VectorMode::None;
+#else
+    constexpr VectorMode vector_mode = VectorMode::RC;
+#endif
     MATH((SFPU_BINARY_CALL(
         DST_SYNC_MODE,
         DST_ACCUM_MODE,
@@ -869,7 +874,7 @@ ALWI void max_reduce_with_indices(uint32_t idst, uint32_t idst_idx, uint32_t chu
         idst,
         idst_idx,
         0 /* DST out unused, but required for _llk_math_eltwise_binary_sfpu_params_ */,
-        VectorMode::RC,
+        vector_mode,
         chunk)));
 }
 
@@ -881,6 +886,8 @@ ALWI void max_reduce_with_indices_init() {
     MATH((SFPU_BINARY_INIT_FN(
         max_pool_with_indices, sfpu::init_max_pool_with_indices, (true /* APPROXIMATE */, layout))));
 }
+
+#ifndef ARCH_QUASAR  // BH/WH-only ops below
 
 // clang-format off
 /**

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -5000,6 +5000,45 @@ class SdpaExpUnclampedGolden:
 
 
 @register_golden
+class MaxPoolWithIndicesGolden:
+    """Column-wise max and its carried index over the first ``num_rows`` rows."""
+
+    def __call__(
+        self,
+        values,
+        indices,
+        num_rows: int,
+        data_format: DataFormat,
+        index_encoding: str = "bits",
+        tile_dimensions=TILE_DIMENSIONS,
+    ):
+        torch_format = format_dict[data_format]
+        rows, cols = tile_dimensions
+        values = torch.as_tensor(values, dtype=torch.float32).reshape(rows, cols)
+        indices = torch.as_tensor(indices, dtype=torch.int64).reshape(rows, cols)
+
+        window = values[:num_rows]
+        winner_rows = torch.argmax(window, dim=0)
+        columns = torch.arange(cols)
+        max_values = window[winner_rows, columns].to(torch_format)
+        max_indices = indices[winner_rows, columns]
+
+        if index_encoding == "bits":
+            index_dtype = (
+                torch.int32
+                if torch.empty(0, dtype=torch_format).element_size() == 4
+                else torch.int16
+            )
+            index_part = max_indices.to(index_dtype).contiguous().view(torch_format)
+        elif index_encoding == "value":
+            index_part = max_indices.to(torch_format)
+        else:
+            raise ValueError(f"Unsupported index encoding: {index_encoding}")
+
+        return torch.cat([max_values, index_part])
+
+
+@register_golden
 class SamplingGolden:
     """Golden for the sampling SFPU helpers
     (experimental/llk_sfpu/ckernel_sfpu_sampling.h).

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -5014,7 +5014,12 @@ class MaxPoolWithIndicesGolden:
     ):
         torch_format = format_dict[data_format]
         rows, cols = tile_dimensions
-        values = torch.as_tensor(values, dtype=torch.float32).reshape(rows, cols)
+        values = (
+            torch.as_tensor(values, dtype=torch.float32)
+            .reshape(rows, cols)
+            .to(torch_format)
+            .to(torch.float32)
+        )
         indices = torch.as_tensor(indices, dtype=torch.int64).reshape(rows, cols)
 
         window = values[:num_rows]

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -1478,6 +1478,7 @@ class MAX_POOL_CONFIG(TemplateParameter):
     max_pool_num_rows: int
     row_major: bool
     accumulate: bool = False
+    chunk: int = 0
 
     def convert_to_cpp(self) -> str:
         layout = "ROW_MAJOR" if self.row_major else "TILE"
@@ -1487,5 +1488,6 @@ class MAX_POOL_CONFIG(TemplateParameter):
                 f"constexpr int MAX_POOL_NUM_ROWS = {self.max_pool_num_rows};",
                 f"constexpr auto MAX_POOL_LAYOUT = ckernel::DataLayout::{layout};",
                 f"constexpr bool MAX_POOL_ACCUMULATE = {accumulate};",
+                f"constexpr std::uint32_t MAX_POOL_CHUNK = {self.chunk};",
             ]
         )

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -1469,3 +1469,23 @@ class TYPECAST_FORMATS(TemplateParameter):
             f"constexpr auto TYPECAST_OUT_FORMAT = DataFormat::{self.output_format.name};",
         ]
         return "\n".join(lines)
+
+
+@dataclass
+class MAX_POOL_CONFIG(TemplateParameter):
+    """Compile-time reduction window and Dest layout for max_pool_with_indices."""
+
+    num_rows: int
+    row_major: bool
+    accumulate: bool = False
+
+    def convert_to_cpp(self) -> str:
+        layout = "ROW_MAJOR" if self.row_major else "TILE"
+        accumulate = str(self.accumulate).lower()
+        return "\n".join(
+            [
+                f"constexpr int MAX_POOL_NUM_ROWS = {self.num_rows};",
+                f"constexpr auto MAX_POOL_LAYOUT = ckernel::DataLayout::{layout};",
+                f"constexpr bool MAX_POOL_ACCUMULATE = {accumulate};",
+            ]
+        )

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -1475,7 +1475,7 @@ class TYPECAST_FORMATS(TemplateParameter):
 class MAX_POOL_CONFIG(TemplateParameter):
     """Compile-time reduction window and Dest layout for max_pool_with_indices."""
 
-    num_rows: int
+    max_pool_num_rows: int
     row_major: bool
     accumulate: bool = False
 
@@ -1484,7 +1484,7 @@ class MAX_POOL_CONFIG(TemplateParameter):
         accumulate = str(self.accumulate).lower()
         return "\n".join(
             [
-                f"constexpr int MAX_POOL_NUM_ROWS = {self.num_rows};",
+                f"constexpr int MAX_POOL_NUM_ROWS = {self.max_pool_num_rows};",
                 f"constexpr auto MAX_POOL_LAYOUT = ckernel::DataLayout::{layout};",
                 f"constexpr bool MAX_POOL_ACCUMULATE = {accumulate};",
             ]

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_max_pool_indices_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_max_pool_indices_quasar.py
@@ -6,10 +6,9 @@ import sys
 
 import pytest
 import torch
-from helpers.format_config import DataFormat
+from helpers.format_config import DataFormat, InputOutputFormat
 from helpers.golden_generators import MaxPoolWithIndicesGolden, get_golden_generator
 from helpers.llk_params import DestAccumulation, format_dict
-from helpers.param_config import input_output_formats, parametrize
 from helpers.stimuli_config import StimuliConfig
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
@@ -26,20 +25,60 @@ TILE_ROWS = 32
 TILE_COLS = 32
 FACE_DIM = 16
 OUT_OF_WINDOW_SENTINEL = 100.0
+BF16_FORMATS = InputOutputFormat(DataFormat.Float16_b, DataFormat.Float16_b)
+FP32_FORMATS = InputOutputFormat(DataFormat.Float32, DataFormat.Float32)
 
 # Exercise every supported row count, both short-path layouts, the three generic
-# sizes, and the generic accumulation fold.
+# sizes, both accumulation phases, and 16-bit and 32-bit Dest index transport.
 CASES = [
-    pytest.param(4, False, False, id="tile-4"),
-    pytest.param(8, False, False, id="tile-8"),
-    pytest.param(9, False, False, id="tile-9"),
-    pytest.param(4, True, False, id="row-major-4"),
-    pytest.param(8, True, False, id="row-major-8"),
-    pytest.param(9, True, False, id="row-major-9"),
-    pytest.param(16, True, False, id="row-major-16"),
-    pytest.param(20, True, False, id="row-major-20"),
-    pytest.param(32, True, False, id="row-major-32"),
-    pytest.param(32, True, True, id="row-major-32-accumulate"),
+    pytest.param(BF16_FORMATS, DestAccumulation.No, 4, False, False, 0, id="tile-4"),
+    pytest.param(BF16_FORMATS, DestAccumulation.No, 8, False, False, 0, id="tile-8"),
+    pytest.param(BF16_FORMATS, DestAccumulation.No, 9, False, False, 0, id="tile-9"),
+    pytest.param(
+        BF16_FORMATS, DestAccumulation.No, 4, True, False, 0, id="row-major-4"
+    ),
+    pytest.param(
+        BF16_FORMATS, DestAccumulation.No, 8, True, False, 0, id="row-major-8"
+    ),
+    pytest.param(
+        BF16_FORMATS, DestAccumulation.No, 9, True, False, 0, id="row-major-9"
+    ),
+    pytest.param(
+        BF16_FORMATS, DestAccumulation.No, 16, True, False, 0, id="row-major-16"
+    ),
+    pytest.param(
+        BF16_FORMATS, DestAccumulation.No, 20, True, False, 0, id="row-major-20"
+    ),
+    pytest.param(
+        BF16_FORMATS, DestAccumulation.No, 32, True, False, 0, id="row-major-32"
+    ),
+    pytest.param(
+        BF16_FORMATS,
+        DestAccumulation.No,
+        32,
+        True,
+        True,
+        0,
+        id="row-major-32-accumulate-seed",
+    ),
+    pytest.param(
+        BF16_FORMATS,
+        DestAccumulation.No,
+        32,
+        True,
+        True,
+        1,
+        id="row-major-32-accumulate-fold",
+    ),
+    pytest.param(
+        FP32_FORMATS,
+        DestAccumulation.Yes,
+        32,
+        True,
+        True,
+        1,
+        id="row-major-32-fp32-accumulate-fold",
+    ),
 ]
 
 
@@ -70,11 +109,21 @@ def _result_row0(tile: torch.Tensor, row_major: bool) -> torch.Tensor:
 
 
 def _encode_indices(indices: torch.Tensor, row_major: bool, torch_format):
-    return _stage(indices, row_major).to(torch.int16).contiguous().view(torch_format)
+    index_dtype = (
+        torch.int32
+        if torch.empty(0, dtype=torch_format).element_size() == 4
+        else torch.int16
+    )
+    return _stage(indices, row_major).to(index_dtype).contiguous().view(torch_format)
 
 
-def _decode_indices(indices: torch.Tensor) -> torch.Tensor:
-    return indices.contiguous().view(torch.int16).to(torch.int64)
+def _decode_indices(indices: torch.Tensor, torch_format) -> torch.Tensor:
+    index_dtype = (
+        torch.int32
+        if torch.empty(0, dtype=torch_format).element_size() == 4
+        else torch.int16
+    )
+    return indices.contiguous().view(index_dtype).to(torch.int64)
 
 
 def _make_values(num_rows: int):
@@ -97,33 +146,36 @@ def _make_values(num_rows: int):
     return values
 
 
-def _make_accumulator():
-    """Prior result wins even columns and loses odd columns."""
-    values = torch.full((TILE_ROWS, TILE_COLS), -200.0, dtype=torch.float32)
-    values[0, 0::2] = -0.25
+def _make_accumulator(poison: bool):
+    """Create either a fold input or values that chunk zero must ignore."""
+    fill_value = OUT_OF_WINDOW_SENTINEL if poison else -200.0
+    values = torch.full((TILE_ROWS, TILE_COLS), fill_value, dtype=torch.float32)
+    if not poison:
+        values[0, 0::2] = -0.25
     indices = torch.zeros((TILE_ROWS, TILE_COLS), dtype=torch.int64)
     indices[0] = 2000 + torch.arange(TILE_COLS)
     return values, indices
 
 
 @pytest.mark.quasar
-@pytest.mark.parametrize("num_rows,row_major,accumulate", CASES)
-@parametrize(
-    formats=input_output_formats([DataFormat.Float16_b], same=True),
+@pytest.mark.parametrize(
+    "formats,dest_acc,num_rows,row_major,accumulate,chunk",
+    CASES,
 )
-def test_max_pool_indices_quasar(formats, num_rows, row_major, accumulate):
-    (formats,) = formats
+def test_max_pool_indices_quasar(
+    formats, dest_acc, num_rows, row_major, accumulate, chunk
+):
     torch_format = format_dict[formats.input_format]
 
     values = _make_values(num_rows)
     indices = torch.arange(TILE_ROWS * TILE_COLS, dtype=torch.int64).reshape(
         TILE_ROWS, TILE_COLS
     )
-    accum_values, accum_indices = _make_accumulator()
+    accum_values, accum_indices = _make_accumulator(poison=accumulate and chunk == 0)
 
     # Dest tiles are values/current, values/accumulator, indices/current,
-    # indices/accumulator. This also gives the accumulate=true path a real prior
-    # result to compare against at chunk=1.
+    # indices/accumulator. Chunk zero gets a winning poison value that must be
+    # ignored, while later chunks get a real prior result to fold.
     src_A = torch.cat(
         [
             _stage(values, row_major).to(torch_format),
@@ -139,7 +191,7 @@ def test_max_pool_indices_quasar(formats, num_rows, row_major, accumulate):
         formats,
         templates=[
             DEST_SYNC(),
-            MAX_POOL_CONFIG(num_rows, row_major, accumulate),
+            MAX_POOL_CONFIG(num_rows, row_major, accumulate, chunk),
         ],
         runtimes=[
             TILE_COUNT(4),
@@ -157,7 +209,7 @@ def test_max_pool_indices_quasar(formats, num_rows, row_major, accumulate):
             tile_count_B=1,
             tile_count_res=2,
         ),
-        dest_acc=DestAccumulation.No,
+        dest_acc=dest_acc,
         unpack_to_dest=False,
     )
 
@@ -172,9 +224,9 @@ def test_max_pool_indices_quasar(formats, num_rows, row_major, accumulate):
         "bits",
     )
     golden_values = golden[:TILE_COLS]
-    golden_indices = _decode_indices(golden[TILE_COLS:])
+    golden_indices = _decode_indices(golden[TILE_COLS:], torch_format)
 
-    if accumulate:
+    if accumulate and chunk > 0:
         prior_values = accum_values[0].to(torch_format)
         prior_indices = accum_indices[0]
         prior_wins = prior_values > golden_values
@@ -183,13 +235,14 @@ def test_max_pool_indices_quasar(formats, num_rows, row_major, accumulate):
 
     result_values = _result_row0(result[: TILE_ROWS * TILE_COLS], row_major)
     result_indices = _decode_indices(
-        _result_row0(result[TILE_ROWS * TILE_COLS :], row_major)
+        _result_row0(result[TILE_ROWS * TILE_COLS :], row_major), torch_format
     )
 
     if not torch.equal(result_indices, golden_indices):
         print(
             f"max_pool_with_indices index mismatch: rows={num_rows}, "
-            f"row_major={row_major}, accumulate={accumulate}",
+            f"row_major={row_major}, accumulate={accumulate}, chunk={chunk}, "
+            f"dest_acc={dest_acc.name}",
             file=sys.stderr,
         )
         print(f"got:  {result_indices.tolist()}", file=sys.stderr)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_max_pool_indices_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_max_pool_indices_quasar.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""RTL tests for Quasar max_pool_with_indices."""
+
+import sys
+
+import pytest
+import torch
+from helpers.format_config import DataFormat
+from helpers.golden_generators import MaxPoolWithIndicesGolden, get_golden_generator
+from helpers.llk_params import DestAccumulation, format_dict
+from helpers.param_config import input_output_formats, parametrize
+from helpers.stimuli_config import StimuliConfig
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    DEST_SYNC,
+    MAX_POOL_CONFIG,
+    NUM_FACES,
+    SFPU_TILE_INDICES,
+    TEST_FACE_DIMS,
+    TILE_COUNT,
+)
+from helpers.utils import passed_test
+
+TILE_ROWS = 32
+TILE_COLS = 32
+FACE_DIM = 16
+OUT_OF_WINDOW_SENTINEL = 100.0
+
+# Exercise every supported row count, both short-path layouts, the three generic
+# sizes, and the generic accumulation fold.
+CASES = [
+    pytest.param(4, False, False, id="tile-4"),
+    pytest.param(8, False, False, id="tile-8"),
+    pytest.param(9, False, False, id="tile-9"),
+    pytest.param(4, True, False, id="row-major-4"),
+    pytest.param(8, True, False, id="row-major-8"),
+    pytest.param(9, True, False, id="row-major-9"),
+    pytest.param(16, True, False, id="row-major-16"),
+    pytest.param(20, True, False, id="row-major-20"),
+    pytest.param(32, True, False, id="row-major-32"),
+    pytest.param(32, True, True, id="row-major-32-accumulate"),
+]
+
+
+def _tilize(tile_2d: torch.Tensor) -> torch.Tensor:
+    """Face-major flattening used by the TILE-layout reducer."""
+    return torch.cat(
+        [
+            tile_2d[
+                face_row * FACE_DIM : (face_row + 1) * FACE_DIM,
+                face_col * FACE_DIM : (face_col + 1) * FACE_DIM,
+            ].reshape(-1)
+            for face_row in range(2)
+            for face_col in range(2)
+        ]
+    )
+
+
+def _stage(tile_2d: torch.Tensor, row_major: bool) -> torch.Tensor:
+    """Arrange L1 chunks in the order consumed by the selected Dest layout."""
+    return tile_2d.reshape(-1) if row_major else _tilize(tile_2d)
+
+
+def _result_row0(tile: torch.Tensor, row_major: bool) -> torch.Tensor:
+    """Read the 32 result columns from the physical layout used by the kernel."""
+    if row_major:
+        return tile[:TILE_COLS]
+    return torch.cat([tile[:FACE_DIM], tile[256 : 256 + FACE_DIM]])
+
+
+def _encode_indices(indices: torch.Tensor, row_major: bool, torch_format):
+    return _stage(indices, row_major).to(torch.int16).contiguous().view(torch_format)
+
+
+def _decode_indices(indices: torch.Tensor) -> torch.Tensor:
+    return indices.contiguous().view(torch.int16).to(torch.int64)
+
+
+def _make_values(num_rows: int):
+    """Negative and mixed-sign windows plus a larger out-of-window value.
+
+    Even columns stay entirely negative to expose Quasar's raw SFPSWAP ordering
+    bug. Odd columns contain both signs to cover the uncorrected comparison path.
+    The positive sentinel immediately exposes any row beyond ``num_rows`` being
+    included in the reduction.
+    """
+    generator = torch.Generator().manual_seed(1000 + num_rows)
+    order = torch.argsort(torch.rand(num_rows, TILE_COLS, generator=generator), dim=0)
+    column_fraction = torch.arange(TILE_COLS, dtype=torch.float32).remainder(4) / 8
+
+    values = torch.full(
+        (TILE_ROWS, TILE_COLS), OUT_OF_WINDOW_SENTINEL, dtype=torch.float32
+    )
+    values[:num_rows] = -(order.to(torch.float32) + 1 + column_fraction)
+    values[:num_rows, 1::2] += 2.5
+    return values
+
+
+def _make_accumulator():
+    """Prior result wins even columns and loses odd columns."""
+    values = torch.full((TILE_ROWS, TILE_COLS), -200.0, dtype=torch.float32)
+    values[0, 0::2] = -0.25
+    indices = torch.zeros((TILE_ROWS, TILE_COLS), dtype=torch.int64)
+    indices[0] = 2000 + torch.arange(TILE_COLS)
+    return values, indices
+
+
+@pytest.mark.quasar
+@pytest.mark.parametrize("num_rows,row_major,accumulate", CASES)
+@parametrize(
+    formats=input_output_formats([DataFormat.Float16_b], same=True),
+)
+def test_max_pool_indices_quasar(formats, num_rows, row_major, accumulate):
+    (formats,) = formats
+    torch_format = format_dict[formats.input_format]
+
+    values = _make_values(num_rows)
+    indices = torch.arange(TILE_ROWS * TILE_COLS, dtype=torch.int64).reshape(
+        TILE_ROWS, TILE_COLS
+    )
+    accum_values, accum_indices = _make_accumulator()
+
+    # Dest tiles are values/current, values/accumulator, indices/current,
+    # indices/accumulator. This also gives the accumulate=true path a real prior
+    # result to compare against at chunk=1.
+    src_A = torch.cat(
+        [
+            _stage(values, row_major).to(torch_format),
+            _stage(accum_values, row_major).to(torch_format),
+            _encode_indices(indices, row_major, torch_format),
+            _encode_indices(accum_indices, row_major, torch_format),
+        ]
+    )
+    src_B = torch.zeros(TILE_ROWS * TILE_COLS, dtype=torch_format)
+
+    configuration = TestConfig(
+        "sources/quasar/sfpu_max_pool_indices_quasar_test.cpp",
+        formats,
+        templates=[
+            DEST_SYNC(),
+            MAX_POOL_CONFIG(num_rows, row_major, accumulate),
+        ],
+        runtimes=[
+            TILE_COUNT(4),
+            NUM_FACES(4),
+            TEST_FACE_DIMS(),
+            SFPU_TILE_INDICES(0, 2, 0),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=4,
+            tile_count_B=1,
+            tile_count_res=2,
+        ),
+        dest_acc=DestAccumulation.No,
+        unpack_to_dest=False,
+    )
+
+    result = torch.tensor(configuration.run().result, dtype=torch_format)
+    assert len(result) == 2 * TILE_ROWS * TILE_COLS
+
+    golden = get_golden_generator(MaxPoolWithIndicesGolden)(
+        values.reshape(-1),
+        indices.reshape(-1),
+        num_rows,
+        formats.output_format,
+        "bits",
+    )
+    golden_values = golden[:TILE_COLS]
+    golden_indices = _decode_indices(golden[TILE_COLS:])
+
+    if accumulate:
+        prior_values = accum_values[0].to(torch_format)
+        prior_indices = accum_indices[0]
+        prior_wins = prior_values > golden_values
+        golden_values = torch.where(prior_wins, prior_values, golden_values)
+        golden_indices = torch.where(prior_wins, prior_indices, golden_indices)
+
+    result_values = _result_row0(result[: TILE_ROWS * TILE_COLS], row_major)
+    result_indices = _decode_indices(
+        _result_row0(result[TILE_ROWS * TILE_COLS :], row_major)
+    )
+
+    if not torch.equal(result_indices, golden_indices):
+        print(
+            f"max_pool_with_indices index mismatch: rows={num_rows}, "
+            f"row_major={row_major}, accumulate={accumulate}",
+            file=sys.stderr,
+        )
+        print(f"got:  {result_indices.tolist()}", file=sys.stderr)
+        print(f"want: {golden_indices.tolist()}", file=sys.stderr)
+        assert False, "Winning indices do not match golden"
+
+    assert passed_test(
+        golden_values,
+        result_values,
+        formats.output_format,
+        print_errors=True,
+    ), "Reduced values do not match golden"

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_max_pool_indices_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_max_pool_indices_quasar_test.cpp
@@ -1,0 +1,244 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+// AI-generated — run_id: 2026-08-07_max_pool_indices_quasar_c0c71599
+//
+// Column-wise max reduction with argmax (max_pool_with_indices) on Quasar.
+//
+// The unified binary SFPU harness cannot express this op: it stages one input
+// format for both operands and its golden is element-wise. This op is a
+// reduction over a (values, indices) Dest tile PAIR, staged with two different
+// formats, and it writes both tiles. The staging therefore follows the topk
+// pair (sources/quasar/sfpu_topk_quasar_test.cpp), the only Quasar test that
+// already moves a value tile and an integer index tile through the same
+// pipeline.
+//
+// Buffer layout:
+//   buffer_A[0] -> Dest[0] current values
+//   buffer_A[1] -> Dest[1] prior accumulated values
+//   buffer_A[2] -> Dest[2] current indices
+//   buffer_A[3] -> Dest[3] prior accumulated indices
+//   Dest[0]     -> buffer_Res[0] reduced values, row 0 of every column
+//   Dest[2]     -> buffer_Res[1] winning indices, row 0 of every column
+//
+// Thread flow: T0 unpack (L1 -> SrcA, per-stage format) -> T1 FPU A2D datacopy
+// (SrcA -> Dest) -> T1 SFPU (the reduction) -> T2 pack (Dest -> L1, per-stage
+// format). The FPU datacopy path is used instead of unpack-to-dest because the
+// two staged tiles need two different formats, exactly as in topk.
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "llk_memory_checks.h"
+#include "sfpu_stub.h"
+
+using namespace ckernel;
+#include "params.h" // MAX_POOL_CONFIG, is_fp32_dest_acc_en, dest_sync
+
+// Container the index tags ride in from L1 to Dest and back.
+//
+// 16-bit Dest uses Int16 integer transport, matching the kernel's
+// IDX_MODE = sfpmem::UINT16.
+//
+// 32-bit Dest uses Float32 holding exactly-representable integers. The kernel
+// moves the index datum with sfpmem::INT32, a bit-exact 32-bit carry that does
+// not care which container produced the bits, and Quasar has no proven Int32
+// path through SrcA + FPU datacopy: the Quasar datacopy test sweeps no 32-bit
+// integer format, and an Int32 tag tile staged that way arrives in Dest as
+// zeros (measured on the emulator).
+constexpr DataFormat MAX_POOL_INDEX_FORMAT = is_fp32_dest_acc_en ? DataFormat::Float32 : DataFormat::Int16;
+
+constexpr std::uint32_t MAX_POOL_VALUES_TILE        = 0;
+constexpr std::uint32_t MAX_POOL_VALUES_ACCUM_TILE  = 1;
+constexpr std::uint32_t MAX_POOL_INDICES_TILE       = 2;
+constexpr std::uint32_t MAX_POOL_INDICES_ACCUM_TILE = 3;
+
+// ============================================================================
+// UNPACK TRISC
+// ============================================================================
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_math_common.h"
+#include "llk_unpack_common.h"
+#include "llk_unpack_unary_operand.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t buf_desc_id = 0;
+
+    // Dest dvalid chain: FPU (datacopy) -> SFPU (reduction) -> PACK.
+    set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+
+    buffer_descriptor_u bd_val = {0};
+    bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_A[0]);
+    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim             = params.num_faces;
+
+    tdma_descriptor_t td_val;
+    td_val.buf_desc    = bd_val;
+    td_val.buf_desc_id = buf_desc_id;
+
+    // Quasar's 32-bit A2D datacopy is ELWADD: it consumes SrcA plus the dummy SrcB
+    // dvalid the unpack MOP emits, so UNP_B has to be configured too. Leaving it
+    // unconfigured lets the second staged tile add an undefined SrcB operand.
+    auto configure_unpacker = [](const tdma_descriptor_t& descriptor) __attribute__((always_inline))
+    {
+        if constexpr (is_fp32_dest_acc_en)
+        {
+            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(descriptor, descriptor);
+        }
+        else
+        {
+            _llk_unpack_configure_unary_<p_unpacr::UNP_A>(descriptor);
+        }
+    };
+
+    // Current and prior-accumulator value tiles: the swept L1 format.
+    td_val.buf_desc.f.format = static_cast<std::uint8_t>(formats.unpack_A_src);
+    td_val.reg_data_format   = static_cast<std::uint8_t>(formats.unpack_A_dst);
+    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+    configure_unpacker(td_val);
+    _llk_unpack_unary_operand_init_<p_unpacr::UNP_A, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1);
+    _llk_unpack_unary_operand_<p_unpacr::UNP_A>(MAX_POOL_VALUES_TILE, ckernel::DEFAULT_TENSOR_SHAPE);
+    _llk_unpack_unary_operand_<p_unpacr::UNP_A>(MAX_POOL_VALUES_ACCUM_TILE, ckernel::DEFAULT_TENSOR_SHAPE);
+
+    // Current and prior-accumulator index tags: integer payloads carried bit-exactly.
+    td_val.buf_desc.f.format = static_cast<std::uint8_t>(to_underlying(MAX_POOL_INDEX_FORMAT));
+    td_val.reg_data_format   = static_cast<std::uint8_t>(to_underlying(MAX_POOL_INDEX_FORMAT));
+    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+    configure_unpacker(td_val);
+    _llk_unpack_unary_operand_init_<p_unpacr::UNP_A, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1);
+    _llk_unpack_unary_operand_<p_unpacr::UNP_A>(MAX_POOL_INDICES_TILE, ckernel::DEFAULT_TENSOR_SHAPE);
+    _llk_unpack_unary_operand_<p_unpacr::UNP_A>(MAX_POOL_INDICES_ACCUM_TILE, ckernel::DEFAULT_TENSOR_SHAPE);
+}
+
+#endif // LLK_TRISC_UNPACK
+
+// ============================================================================
+// MATH TRISC
+// ============================================================================
+
+#ifdef LLK_TRISC_MATH
+
+#include "cfg_defines.h"
+#include "ckernel_sfpu.h"
+#include "cmath_common.h"
+#include "llk_math_common.h"
+#include "llk_math_eltwise_sfpu_common.h"
+#include "llk_math_eltwise_unary_datacopy.h"
+#include "llk_sfpu/ckernel_sfpu_max_pool_indices.h"
+#include "llk_sfpu/llk_math_eltwise_binary_sfpu_macros.h"
+#include "params.h"
+
+using namespace ckernel;
+using namespace ckernel::math;
+using namespace ckernel::sfpu;
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    // Math owns both the FPU (datacopy) and SFPU clients of the dvalid chain.
+    set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+
+    const DataFormat value_math_format = static_cast<DataFormat>(formats.math);
+
+    SFPU_BINARY_INIT_FN(max_pool_with_indices, sfpu::init_max_pool_with_indices, (false /*APPROX*/, MAX_POOL_LAYOUT));
+
+    const std::uint32_t num_rows = params.num_faces * params.TEST_FACE_R_DIM;
+    _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(num_rows, 1);
+
+    // Value tiles -> Dest[0:2].
+    _configure_alu_formats_<false /*EN_IMPLIED_MATH_FORMAT*/, is_fp32_dest_acc_en>(
+        value_math_format, value_math_format, false /*en_int32_dest_format*/, DataFormat::Invalid);
+    _llk_math_eltwise_unary_datacopy_(MAX_POOL_VALUES_TILE);
+    _llk_math_eltwise_unary_datacopy_(MAX_POOL_VALUES_ACCUM_TILE);
+
+    // Index-tag tiles -> Dest[2:4], staged in MAX_POOL_INDEX_FORMAT.
+    _configure_alu_formats_<false /*EN_IMPLIED_MATH_FORMAT*/, is_fp32_dest_acc_en>(
+        MAX_POOL_INDEX_FORMAT, MAX_POOL_INDEX_FORMAT, false /*en_int32_dest_format*/, DataFormat::Invalid);
+    _llk_math_eltwise_unary_datacopy_(MAX_POOL_INDICES_TILE);
+    _llk_math_eltwise_unary_datacopy_(MAX_POOL_INDICES_ACCUM_TILE);
+
+    // All four tiles are staged: release the FPU dvalid to the SFPU client.
+    _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+
+    // VectorMode::None: both layouts cover all columns in one call.
+    SFPU_BINARY_CALL(
+        dest_sync,
+        is_fp32_dest_acc_en,
+        calculate_max_pool_with_indices,
+        (false /*APPROX*/, is_fp32_dest_acc_en, MAX_POOL_NUM_ROWS, SFPU_ITERATIONS, MAX_POOL_LAYOUT, MAX_POOL_ACCUMULATE),
+        MAX_POOL_VALUES_TILE,
+        MAX_POOL_INDICES_TILE,
+        MAX_POOL_VALUES_TILE, // unused out slot
+        VectorMode::None,
+        MAX_POOL_ACCUMULATE ? 1 : 0 /*chunk*/);
+
+    wait_sfpu_idle();
+    _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();
+
+    wait_fpu_idle();
+    wait_mop_idle();
+}
+
+#endif // LLK_TRISC_MATH
+
+// ============================================================================
+// PACK TRISC
+// ============================================================================
+
+#ifdef LLK_TRISC_PACK
+
+#include "cfg_defines.h"
+#include "llk_pack.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t buf_desc_id = 8;
+
+    set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+
+    tdma_descriptor_t tdma_desc;
+    tdma_desc.buf_desc         = buffer_descriptor_u {0};
+    tdma_desc.buf_desc.f.x_dim = params.TEST_FACE_C_DIM;
+    tdma_desc.buf_desc.f.y_dim = params.TEST_FACE_R_DIM;
+    tdma_desc.buf_desc.f.z_dim = params.num_faces;
+    tdma_desc.buf_desc_id      = buf_desc_id;
+
+    _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
+
+    // Reduced values tile.
+    tdma_desc.buf_desc.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
+    tdma_desc.buf_desc.f.l1_addr_16B = L1_ADDRESS(params.buffer_Res[0]);
+    tdma_desc.reg_data_format        = static_cast<std::uint8_t>(formats.pack_src);
+    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
+    _llk_pack_(MAX_POOL_VALUES_TILE, 0 /*tile index*/, ckernel::DEFAULT_TENSOR_SHAPE);
+
+    // Winning indices tile, integer transport on both sides.
+    tdma_desc.buf_desc.f.format      = static_cast<std::uint8_t>(to_underlying(MAX_POOL_INDEX_FORMAT));
+    tdma_desc.buf_desc.f.l1_addr_16B = L1_ADDRESS(params.buffer_Res[1]);
+    tdma_desc.reg_data_format        = static_cast<std::uint8_t>(to_underlying(MAX_POOL_INDEX_FORMAT));
+    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
+    _llk_pack_(MAX_POOL_INDICES_TILE, 0 /*tile index*/, ckernel::DEFAULT_TENSOR_SHAPE);
+
+    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+}
+
+#endif // LLK_TRISC_PACK

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_max_pool_indices_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_max_pool_indices_quasar_test.cpp
@@ -21,10 +21,11 @@
 //   Dest[0]     -> buffer_Res[0] reduced values, row 0 of every column
 //   Dest[2]     -> buffer_Res[1] winning indices, row 0 of every column
 //
-// Thread flow: T0 unpack (L1 -> SrcA, per-stage format) -> T1 FPU A2D datacopy
-// (SrcA -> Dest) -> T1 SFPU (the reduction) -> T2 pack (Dest -> L1, per-stage
-// format). The FPU datacopy path is used instead of unpack-to-dest because the
-// two staged tiles need two different formats, exactly as in topk.
+// The 16-bit path follows topk: T0 unpack (L1 -> SrcA, per-stage format) -> T1
+// FPU A2D datacopy (SrcA -> Dest) -> T1 SFPU -> T2 pack. The 32-bit path stages
+// all four tiles as raw Int32 words with UNP_DEST; the SFPU then loads value
+// words as FP32 and index words as INT32. Direct staging avoids the FPU
+// datacopy flushing small index bit patterns as FP32 denormals.
 
 #include <cstdint>
 
@@ -41,18 +42,15 @@ using namespace ckernel;
 // 16-bit Dest uses Int16 integer transport, matching the kernel's
 // IDX_MODE = sfpmem::UINT16.
 //
-// 32-bit Dest uses Float32 holding exactly-representable integers. The kernel
-// moves the index datum with sfpmem::INT32, a bit-exact 32-bit carry that does
-// not care which container produced the bits, and Quasar has no proven Int32
-// path through SrcA + FPU datacopy: the Quasar datacopy test sweeps no 32-bit
-// integer format, and an Int32 tag tile staged that way arrives in Dest as
-// zeros (measured on the emulator).
-constexpr DataFormat MAX_POOL_INDEX_FORMAT = is_fp32_dest_acc_en ? DataFormat::Float32 : DataFormat::Int16;
+// 32-bit Dest uses Int32 raw-word transport, matching sfpmem::INT32. The value
+// tiles share that raw staging format and are reinterpreted by sfpmem::FP32.
+constexpr DataFormat MAX_POOL_INDEX_FORMAT = is_fp32_dest_acc_en ? DataFormat::Int32 : DataFormat::Int16;
 
 constexpr std::uint32_t MAX_POOL_VALUES_TILE        = 0;
 constexpr std::uint32_t MAX_POOL_VALUES_ACCUM_TILE  = 1;
 constexpr std::uint32_t MAX_POOL_INDICES_TILE       = 2;
 constexpr std::uint32_t MAX_POOL_INDICES_ACCUM_TILE = 3;
+constexpr std::uint32_t MAX_POOL_STAGED_TILES       = 4;
 
 // ============================================================================
 // UNPACK TRISC
@@ -60,6 +58,7 @@ constexpr std::uint32_t MAX_POOL_INDICES_ACCUM_TILE = 3;
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "cfg_defines.h"
 #include "llk_math_common.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_unary_operand.h"
@@ -72,8 +71,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
     const std::uint32_t buf_desc_id = 0;
 
-    // Dest dvalid chain: FPU (datacopy) -> SFPU (reduction) -> PACK.
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+        _llk_math_upk_to_dest_hw_configure_<false /*implied math*/, true /*fp32 dest*/, false /*int32 dest*/>();
+    }
+    else
+    {
+        // Dest dvalid chain: FPU (datacopy) -> SFPU (reduction) -> PACK.
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
 
     buffer_descriptor_u bd_val = {0};
     bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_A[0]);
@@ -85,38 +92,40 @@ void run_kernel(RUNTIME_PARAMETERS params)
     td_val.buf_desc    = bd_val;
     td_val.buf_desc_id = buf_desc_id;
 
-    // Quasar's 32-bit A2D datacopy is ELWADD: it consumes SrcA plus the dummy SrcB
-    // dvalid the unpack MOP emits, so UNP_B has to be configured too. Leaving it
-    // unconfigured lets the second staged tile add an undefined SrcB operand.
-    auto configure_unpacker = [](const tdma_descriptor_t& descriptor) __attribute__((always_inline))
+    if constexpr (is_fp32_dest_acc_en)
     {
-        if constexpr (is_fp32_dest_acc_en)
-        {
-            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(descriptor, descriptor);
-        }
-        else
-        {
-            _llk_unpack_configure_unary_<p_unpacr::UNP_A>(descriptor);
-        }
-    };
+        // All four 32-bit tiles are raw words. UNP_DEST preserves those words,
+        // while the SFPU's explicit load modes choose FP32 or INT32 semantics.
+        td_val.buf_desc.f.format = static_cast<std::uint8_t>(to_underlying(DataFormat::Int32));
+        td_val.reg_data_format   = static_cast<std::uint8_t>(to_underlying(DataFormat::Int32));
+        _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+        _llk_unpack_configure_unary_<p_unpacr::UNP_DEST>(td_val);
+        _llk_unpack_unary_operand_init_<p_unpacr::UNP_DEST, false /*transpose*/, true /*32b Dest*/, EltwiseBinaryReuseDestType::NONE, true /*unpack_to_dest*/>(
+            buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, MAX_POOL_STAGED_TILES);
+        _llk_unpack_unary_operand_<p_unpacr::UNP_DEST, EltwiseBinaryReuseDestType::NONE, true /*unpack_to_dest*/, dest_sync>(
+            0 /*l1_tile_idx*/, ckernel::DEFAULT_TENSOR_SHAPE);
+        _llk_unpack_dest_dvalid_section_done_<dest_sync>();
+    }
+    else
+    {
+        // Current and prior-accumulator value tiles: the swept L1 format.
+        td_val.buf_desc.f.format = static_cast<std::uint8_t>(formats.unpack_A_src);
+        td_val.reg_data_format   = static_cast<std::uint8_t>(formats.unpack_A_dst);
+        _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+        _llk_unpack_configure_unary_<p_unpacr::UNP_A>(td_val);
+        _llk_unpack_unary_operand_init_<p_unpacr::UNP_A, false /*transpose*/, false /*32b Dest*/>(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1);
+        _llk_unpack_unary_operand_<p_unpacr::UNP_A>(MAX_POOL_VALUES_TILE, ckernel::DEFAULT_TENSOR_SHAPE);
+        _llk_unpack_unary_operand_<p_unpacr::UNP_A>(MAX_POOL_VALUES_ACCUM_TILE, ckernel::DEFAULT_TENSOR_SHAPE);
 
-    // Current and prior-accumulator value tiles: the swept L1 format.
-    td_val.buf_desc.f.format = static_cast<std::uint8_t>(formats.unpack_A_src);
-    td_val.reg_data_format   = static_cast<std::uint8_t>(formats.unpack_A_dst);
-    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
-    configure_unpacker(td_val);
-    _llk_unpack_unary_operand_init_<p_unpacr::UNP_A, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1);
-    _llk_unpack_unary_operand_<p_unpacr::UNP_A>(MAX_POOL_VALUES_TILE, ckernel::DEFAULT_TENSOR_SHAPE);
-    _llk_unpack_unary_operand_<p_unpacr::UNP_A>(MAX_POOL_VALUES_ACCUM_TILE, ckernel::DEFAULT_TENSOR_SHAPE);
-
-    // Current and prior-accumulator index tags: integer payloads carried bit-exactly.
-    td_val.buf_desc.f.format = static_cast<std::uint8_t>(to_underlying(MAX_POOL_INDEX_FORMAT));
-    td_val.reg_data_format   = static_cast<std::uint8_t>(to_underlying(MAX_POOL_INDEX_FORMAT));
-    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
-    configure_unpacker(td_val);
-    _llk_unpack_unary_operand_init_<p_unpacr::UNP_A, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1);
-    _llk_unpack_unary_operand_<p_unpacr::UNP_A>(MAX_POOL_INDICES_TILE, ckernel::DEFAULT_TENSOR_SHAPE);
-    _llk_unpack_unary_operand_<p_unpacr::UNP_A>(MAX_POOL_INDICES_ACCUM_TILE, ckernel::DEFAULT_TENSOR_SHAPE);
+        // Current and prior-accumulator index tags: integer payloads carried bit-exactly.
+        td_val.buf_desc.f.format = static_cast<std::uint8_t>(to_underlying(MAX_POOL_INDEX_FORMAT));
+        td_val.reg_data_format   = static_cast<std::uint8_t>(to_underlying(MAX_POOL_INDEX_FORMAT));
+        _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+        _llk_unpack_configure_unary_<p_unpacr::UNP_A>(td_val);
+        _llk_unpack_unary_operand_init_<p_unpacr::UNP_A, false /*transpose*/, false /*32b Dest*/>(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1);
+        _llk_unpack_unary_operand_<p_unpacr::UNP_A>(MAX_POOL_INDICES_TILE, ckernel::DEFAULT_TENSOR_SHAPE);
+        _llk_unpack_unary_operand_<p_unpacr::UNP_A>(MAX_POOL_INDICES_ACCUM_TILE, ckernel::DEFAULT_TENSOR_SHAPE);
+    }
 }
 
 #endif // LLK_TRISC_UNPACK
@@ -146,31 +155,41 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    // Math owns both the FPU (datacopy) and SFPU clients of the dvalid chain.
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+    else
+    {
+        // Math owns both the FPU (datacopy) and SFPU clients of the dvalid chain.
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
 
     const DataFormat value_math_format = static_cast<DataFormat>(formats.math);
 
     SFPU_BINARY_INIT_FN(max_pool_with_indices, sfpu::init_max_pool_with_indices, (false /*APPROX*/, MAX_POOL_LAYOUT));
 
-    const std::uint32_t num_rows = params.num_faces * params.TEST_FACE_R_DIM;
-    _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(num_rows, 1);
+    if constexpr (!is_fp32_dest_acc_en)
+    {
+        const std::uint32_t num_rows = params.num_faces * params.TEST_FACE_R_DIM;
+        _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, false /*32b Dest*/>(num_rows, 1);
 
-    // Value tiles -> Dest[0:2].
-    _configure_alu_formats_<false /*EN_IMPLIED_MATH_FORMAT*/, is_fp32_dest_acc_en>(
-        value_math_format, value_math_format, false /*en_int32_dest_format*/, DataFormat::Invalid);
-    _llk_math_eltwise_unary_datacopy_(MAX_POOL_VALUES_TILE);
-    _llk_math_eltwise_unary_datacopy_(MAX_POOL_VALUES_ACCUM_TILE);
+        // Value tiles -> Dest[0:2].
+        _configure_alu_formats_<false /*EN_IMPLIED_MATH_FORMAT*/, false /*32b Dest*/>(
+            value_math_format, value_math_format, false /*en_int32_dest_format*/, DataFormat::Invalid);
+        _llk_math_eltwise_unary_datacopy_(MAX_POOL_VALUES_TILE);
+        _llk_math_eltwise_unary_datacopy_(MAX_POOL_VALUES_ACCUM_TILE);
 
-    // Index-tag tiles -> Dest[2:4], staged in MAX_POOL_INDEX_FORMAT.
-    _configure_alu_formats_<false /*EN_IMPLIED_MATH_FORMAT*/, is_fp32_dest_acc_en>(
-        MAX_POOL_INDEX_FORMAT, MAX_POOL_INDEX_FORMAT, false /*en_int32_dest_format*/, DataFormat::Invalid);
-    _llk_math_eltwise_unary_datacopy_(MAX_POOL_INDICES_TILE);
-    _llk_math_eltwise_unary_datacopy_(MAX_POOL_INDICES_ACCUM_TILE);
+        // Index-tag tiles -> Dest[2:4], staged in MAX_POOL_INDEX_FORMAT.
+        _configure_alu_formats_<false /*EN_IMPLIED_MATH_FORMAT*/, false /*32b Dest*/>(
+            MAX_POOL_INDEX_FORMAT, MAX_POOL_INDEX_FORMAT, false /*en_int32_dest_format*/, DataFormat::Invalid);
+        _llk_math_eltwise_unary_datacopy_(MAX_POOL_INDICES_TILE);
+        _llk_math_eltwise_unary_datacopy_(MAX_POOL_INDICES_ACCUM_TILE);
 
-    // All four tiles are staged: release the FPU dvalid to the SFPU client.
-    _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+        // All four tiles are staged: release the FPU dvalid to the SFPU client.
+        _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+    }
 
     // VectorMode::None: both layouts cover all columns in one call.
     SFPU_BINARY_CALL(
@@ -182,12 +201,15 @@ void run_kernel(RUNTIME_PARAMETERS params)
         MAX_POOL_INDICES_TILE,
         MAX_POOL_VALUES_TILE, // unused out slot
         VectorMode::None,
-        MAX_POOL_ACCUMULATE ? 1 : 0 /*chunk*/);
+        MAX_POOL_CHUNK);
 
     wait_sfpu_idle();
     _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();
 
-    wait_fpu_idle();
+    if constexpr (!is_fp32_dest_acc_en)
+    {
+        wait_fpu_idle();
+    }
     wait_mop_idle();
 }
 
@@ -211,7 +233,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
     const std::uint32_t buf_desc_id = 8;
 
-    set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+    else
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
 
     tdma_descriptor_t tdma_desc;
     tdma_desc.buf_desc         = buffer_descriptor_u {0};

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
@@ -71,6 +71,14 @@ enum class Transpose : std::uint8_t
     Both      = 3,
 };
 
+// Dest row arrangement an SFPU reduction expects. TILE = natural face layout;
+// ROW_MAJOR = face-interleaved (F0R0, F1R0, F0R1, F1R1, ...).
+enum class DataLayout : std::uint8_t
+{
+    TILE      = 0,
+    ROW_MAJOR = 1,
+};
+
 enum class SfpuType : std::uint32_t
 {
     tanh,
@@ -120,6 +128,7 @@ enum class SfpuType : std::uint32_t
     greater_than_zero,
     less_than_equal_zero,
     greater_than_equal_zero,
+    max_pool_with_indices,
 };
 
 enum class DstSync : std::uint8_t


### PR DESCRIPTION
### PR Category
Feature

### Summary
Adds Quasar LLK support for max-pool reduction with indices and connects it to the Metal compute API.

The initial implementation came from LLK code-generation dashboard run `2026-08-07_max_pool_indices_quasar_c0c71599`. We subsequently modified it to:

- apply sign correction to every `SFPSWAP` max comparison so negative inputs produce the correct value and index;
- reduce exactly the requested `num_rows` for 4, 8, 9, 16, 20, and 32-row windows;
- support both TILE and ROW_MAJOR destination layouts where applicable;
- support accumulation for large reduction windows;
- explicitly select FP16B or FP32 SFPU memory modes for values instead of relying on the previous ALU configuration; and
- expose the operation through `max_reduce_with_indices` and `max_reduce_with_indices_init` in the compute API.

Adds Quasar Metal-layer tests covering values and indices across positive, negative, and mixed-sign inputs, including sentinel rows outside the selected reduction window.

### Notes for reviewers

Please focus on the Quasar-specific signed comparison sequence, destination row addressing for TILE versus ROW_MAJOR layouts, and the accumulation path.

Validation completed:

- all 10 Quasar max-pool-with-indices variants compiled and passed on the RTL emulator twice;
- TILE coverage: 4, 8, and 9 rows;
- ROW_MAJOR coverage: 4, 8, 9, 16, 20, and 32 rows, plus 32-row accumulation;
- `unit_tests_llk` built successfully; and
- scoped pre-commit checks passed.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk_code_gen/fix-max-pool-indices-quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk_code_gen/fix-max-pool-indices-quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk_code_gen/fix-max-pool-indices-quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk_code_gen/fix-max-pool-indices-quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk_code_gen/fix-max-pool-indices-quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk_code_gen/fix-max-pool-indices-quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk_code_gen/fix-max-pool-indices-quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk_code_gen/fix-max-pool-indices-quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk_code_gen/fix-max-pool-indices-quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk_code_gen/fix-max-pool-indices-quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk_code_gen/fix-max-pool-indices-quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk_code_gen/fix-max-pool-indices-quasar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk_code_gen/fix-max-pool-indices-quasar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk_code_gen/fix-max-pool-indices-quasar)