### PR TITLE
[LLK][test] deepseek_moe_gate: sanitize scratch so GATE stays bit-exact

### DIFF
--- a/tt_metal/tt-llk/tests/sources/deepseek_moe_gate_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/deepseek_moe_gate_test.cpp
@@ -188,7 +188,8 @@ static inline void run_gate()
 // (tt-metal#52699); deepseek_moe_gate is the predecessor primitive and shares the defect.
 //
 // The gate's answer is row 0, columns 0..7 of the SCORES and IDS tiles -- exactly what
-// test_deepseek_moe_gate.py::_assert_gate_output reads (regions[SCORES][0, :8], regions[IDS][0, :8]).
+// test_deepseek_moe_gate.py reads: it slices output_torch[:, 0, :8] and output_indices_torch[:, 0, :8]
+// (test_deepseek_moe_gate), and result_indices[:, 0, :8] (test_deepseek_moe_gate_uint16_high_bit).
 // The sort and the sum_top2 "replicate down the column" broadcast SFPSTORE full 32-lane rows whose
 // non-rank lanes were never written this run, so every other packed lane holds residue. That residue
 // is a fixed point once warm, so run 0 (cold) differs from runs 1..N and the bit-exact check flags the
@@ -206,8 +207,9 @@ static inline void run_gate()
 // whatever produced it. Keep only the answer and zero every other DEST row the packer ships.
 // Validated on both arches at 500 runs -- BH run 31594272654, WH run 31598446222.
 //
-// MODE_GATE only: run_move's output is read cell-by-cell across rows 0..7 (see the step0/step1/step2
-// assertions in the python test), so it must not be sanitized.
+// MODE_GATE only: run_kernel invokes this from the MODE_GATE branch alone. MODE_MOVE and MODE_BINARY
+// are separate branches and are deliberately left untouched -- only the GATE path confines its result
+// to row 0, cols 0..7, so it is the only mode whose scratch can be safely zeroed.
 static inline void dmg_sanitize_scratch()
 {
     // Address everything through sfpi dst_reg -- the mapping generalized_moe_gate proved lands on the

--- a/tt_metal/tt-llk/tests/sources/deepseek_moe_gate_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/deepseek_moe_gate_test.cpp
@@ -184,6 +184,66 @@ static inline void run_gate()
     _llk_math_deepseek_moe_gate_transpose_dest_single_face_step2_<is_fp32_dest_acc_en, IS_32BIT>();
 }
 
+// Determinism sanitize (test-only). Port of gmg_sanitize_scratch from generalized_moe_gate_test.cpp
+// (tt-metal#52699); deepseek_moe_gate is the predecessor primitive and shares the defect.
+//
+// The gate's answer is row 0, columns 0..7 of the SCORES and IDS tiles -- exactly what
+// test_deepseek_moe_gate.py::_assert_gate_output reads (regions[SCORES][0, :8], regions[IDS][0, :8]).
+// The sort and the sum_top2 "replicate down the column" broadcast SFPSTORE full 32-lane rows whose
+// non-rank lanes were never written this run, so every other packed lane holds residue. That residue
+// is a fixed point once warm, so run 0 (cold) differs from runs 1..N and the bit-exact check flags the
+// variant even though the answer is stable (run 31583572316: 7 variants, offsets 40/42/43).
+//
+// WHERE THE RESIDUE COMES FROM IS NOT KNOWN. #52699 states the carrier is the SFPU LReg file; that
+// does not hold for this primitive. Zeroing LREG0-7 in _init_deepseek_moe_gate_topk, with all 32 lanes
+// enabled first (SFPMOV is condition-code gated), left the failing set byte-for-byte unchanged --
+// run 31594274508, same 7 variants, same offsets. Since that clears a superset of the registers any
+// individual load helper could leave undefined, "make the topk load helpers total" is ruled out as a
+// fix too. The remaining candidates are DEST scratch the gate re-reads mid-sequence, or SFPU state
+// outside LREG0-7; neither has been instrumented.
+//
+// This sanitize works because it is carrier-agnostic: it zeroes the junk after it is produced,
+// whatever produced it. Keep only the answer and zero every other DEST row the packer ships.
+// Validated on both arches at 500 runs -- BH run 31594272654, WH run 31598446222.
+//
+// MODE_GATE only: run_move's output is read cell-by-cell across rows 0..7 (see the step0/step1/step2
+// assertions in the python test), so it must not be sanitized.
+static inline void dmg_sanitize_scratch()
+{
+    // Address everything through sfpi dst_reg -- the mapping generalized_moe_gate proved lands on the
+    // right rows here (raw SFP offsets / ZEROACC start mid-tile). dst_reg[k] maps to TTI address 2k, so
+    // each packed DEST tile is 32 dst_reg rows and the 4 tiles span dst_reg[0..127]. A packed 16-col row
+    // is split across TWO dst_reg rows -- even columns in dst_reg[2r], odd columns in dst_reg[2r+1] --
+    // so the answer (packed row 0 of SCORES/IDS) lives in dst_reg pairs {0,1} and {32,33}.
+    constexpr int DREG_PER_TILE = ckernel::sfpu::dst_tile_offset / 2; // 32
+    constexpr int SCORES_LO     = SCORES_TILE * DREG_PER_TILE;        // 0  (even cols of SCORES row 0)
+    constexpr int SCORES_HI     = SCORES_LO + 1;                      // 1  (odd  cols)
+    constexpr int IDS_LO        = IDS_TILE * DREG_PER_TILE;           // 32 (even cols of IDS row 0)
+    constexpr int IDS_HI        = IDS_LO + 1;                         // 33 (odd  cols)
+    constexpr int NUM_DREG      = NUM_DEST_TILES * DREG_PER_TILE;     // 128
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+    for (int k = 0; k < NUM_DREG; ++k)
+    {
+        if (k == SCORES_LO || k == SCORES_HI || k == IDS_LO || k == IDS_HI)
+        {
+            continue;
+        }
+        sfpi::dst_reg[k] = 0.0f;
+    }
+    // Mask each answer row-half to the top-8: with columns split even/odd, cols 0..7 are the first four
+    // even and first four odd columns -> lanes 0..3 -> vConstTileId < 8; zero the residue past them.
+    for (const int dreg : {SCORES_LO, SCORES_HI, IDS_LO, IDS_HI})
+    {
+        sfpi::vFloat v = sfpi::dst_reg[dreg];
+        v_if (sfpi::vConstTileId >= 8)
+        {
+            v = 0.0f;
+        }
+        v_endif;
+        sfpi::dst_reg[dreg] = v;
+    }
+}
+
 static inline void run_move()
 {
     if constexpr (DMG_SUB_OP == MOVE_STEP0)
@@ -290,6 +350,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     if constexpr (DMG_MODE == MODE_GATE)
     {
         run_gate();
+        dmg_sanitize_scratch();
     }
     else if constexpr (DMG_MODE == MODE_MOVE)
     {


### PR DESCRIPTION
Ports `gmg_sanitize_scratch` from `generalized_moe_gate_test.cpp` (#52699) to the sibling `deepseek_moe_gate` test, which shares the same SFPU `sum_top2` / sort / `top8` stages and never received that fix.

## Read this before merging — what this does and does not do

**This does not make anything more deterministic in any real sense.** The gate's answer — row 0, cols 0..7 — was always correct and always stable. What was unstable was the junk in the padding lanes, which the op's contract already declares invalid (`generalized_moe_gate_nanobind.cpp`: *"Only the first k entries of row 0 are valid ... the rest of the tile is padding"*) and which `TTMoEGate` slices away (`tt_moe_gate.py:594-595`, `[:total_batch, 0, :k]`) before anything downstream sees it.

So what merging this actually buys you is: **the bit-exact CI job goes green.** That's it. It stops the 03:00 UTC nightly on main going red, which it otherwise will, since these tests reached main untested.

It buys **nothing** for #51333 or any model-level nondeterminism — the residue never escapes the op. And it does not fix the LLK defect that produces the residue; we do not currently know what the carrier is.

If what you are chasing is real determinism in the DS prefill path, this branch is not it — that is still #51333, and still unexplained.

## Why this surfaced now

`test_deepseek_moe_gate` was added to main by #52827 (`55aede79fd7`) at **07:12 UTC on Aug 12**. The last bit-exact run on main was the **03:00 UTC** nightly, four hours earlier. The job is `schedule` + `workflow_dispatch` only and never runs on a merge gate, so these tests reached main without ever executing under the bit-exact harness.

[Run 31583572316](https://github.com/tenstorrent/tt-metal/actions/runs/31583572316) is their first execution anywhere: 7 variants, *"499 of 499 re-runs differed from run 0"*, first diffs at result-buffer offsets 40/42/43.

## The change

The sort and the `sum_top2` broadcast `SFPSTORE` full 32-lane rows whose non-rank lanes were never written this run, so every packed lane outside the answer holds residue. That residue is a fixed point once warm, so run 0 (cold) differs from every later run while the answer stays correct — and the harness compares the whole result buffer, padding included.

`dmg_sanitize_scratch()` keeps the answer (row 0, cols 0..7 of SCORES and IDS — exactly what `test_deepseek_moe_gate.py` reads, via `output_torch[:, 0, :8]` / `output_indices_torch[:, 0, :8]` and `result_indices[:, 0, :8]` in the `uint16_high_bit` test) and zeros every other DEST row the packer ships.

`MODE_GATE` only: `dmg_sanitize_scratch()` is invoked from the `MODE_GATE` branch of `run_kernel` alone; `MODE_MOVE` and `MODE_BINARY` are separate branches, left untouched. Unlike generalized — which needed an in-GATE `produce_run` carve-out — deepseek's move path is its own top-level mode (`MODE_MOVE`), so no carve-out inside GATE is required.

Layout matches generalized exactly — `dst_tile_offset` 64, `NUM_DEST_TILES` 4, `SCORES_TILE` 0, `IDS_TILE` 1 — so the `dst_reg` pairs `{0,1}` and `{32,33}` carry over unchanged.

## Validation

500 runs, both architectures, on tree-identical `5e9f6042b74` (the only later change was to comments and the commit message):

| Run | Arch | Result |
|---|---|---|
| [31594272654](https://github.com/tenstorrent/tt-metal/actions/runs/31594272654) | Blackhole | green, both groups |
| [31598446222](https://github.com/tenstorrent/tt-metal/actions/runs/31598446222) | Wormhole | green |

## What is ruled out, so nobody repeats it

**The carrier is NOT the SFPU LReg file.** #52699 states that it is; that does not hold for this primitive.

Zeroing LREG0-7 in `_init_deepseek_moe_gate_topk`, with all 32 lanes enabled first via `SFPENCC` (`SFPMOV` is condition-code gated, so a first attempt without it silently skipped the disabled lanes), left the failing set **byte-for-byte unchanged** — [run 31594274508](https://github.com/tenstorrent/tt-metal/actions/runs/31594274508): same 7 variants, same offsets, nothing flipped.

That also rules out *"make the topk load helpers total"*. `bitonic_topk_load8_even_cols_*` populates only LREG0/1/4/5 while `bitonic_top8_ph3_st4_to_1` `SFPSWAP`s against LREG2/3 and `SFPTRANSP`s across LREG0-3 — a genuine read-before-write worth fixing on its own merits, but defining LREG2/3/6/7 there is a strict subset of the zeroing that demonstrably had no effect, so it cannot be the cure here.

Remaining candidates, none instrumented: DEST scratch the gate re-reads mid-sequence, or SFPU state outside LREG0-7.

This sanitize is carrier-agnostic — it zeros the junk after it is produced, whatever produced it.

## Follow-ups (not in this PR)

1. **The library defect is still open.** Both this and `gmg_sanitize_scratch` are test-level containment. Anything that consumes these tiles without slicing to the valid region still sees junk.
2. **Bit-exact cannot catch this pre-merge.** #52827 had no way to know — the job never gates a merge. Worth either adding it to the LLK merge gate for changed test sources, or requiring a manual dispatch on PRs that add SFPU tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ldjurovic/deepseek-moe-gate-sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ldjurovic/deepseek-moe-gate-sanitize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ldjurovic/deepseek-moe-gate-sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ldjurovic/deepseek-moe-gate-sanitize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ldjurovic/deepseek-moe-gate-sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ldjurovic/deepseek-moe-gate-sanitize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ldjurovic/deepseek-moe-gate-sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ldjurovic/deepseek-moe-gate-sanitize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ldjurovic/deepseek-moe-gate-sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ldjurovic/deepseek-moe-gate-sanitize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ldjurovic/deepseek-moe-gate-sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ldjurovic/deepseek-moe-gate-sanitize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ldjurovic/deepseek-moe-gate-sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ldjurovic/deepseek-moe-gate-sanitize)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ldjurovic/deepseek-moe-gate-sanitize)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ldjurovic/deepseek-moe-gate-sanitize)
