### PR TITLE
[fuser] enable layernorm test for quasar

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/unpack_ab.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/unpack_ab.py
@@ -116,7 +116,12 @@ class UnpackerAB(Unpacker):
         buffer_a = compute_unit.src_a.cpp_name
         buffer_b = compute_unit.src_b.cpp_name
         broadcast_type = f"BroadcastType::{compute_unit.broadcast_type.value}"
-        return f"_llk_unpack_AB_<{broadcast_type}>(L1_ADDRESS({buffer_a}[{block.tile_id_global}]), L1_ADDRESS({buffer_b}[{block.tile_id_global}]));\n"
+        tile_id_b = (
+            block.tile_id_global
+            if compute_unit.broadcast_tile is None
+            else compute_unit.broadcast_tile
+        )
+        return f"_llk_unpack_AB_<{broadcast_type}>(L1_ADDRESS({buffer_a}[{block.tile_id_global}]), L1_ADDRESS({buffer_b}[{tile_id_b}]));\n"
 
     def uninit(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/fpu_node.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fpu_node.py
@@ -38,6 +38,7 @@ class FpuNode:
         transpose_faces: Transpose = Transpose.No,
         transpose_within_face: Transpose = Transpose.No,
         broadcast_type: BroadcastType = BroadcastType.None_,
+        broadcast_tile: int = None,
         data_copy_type: DataCopyType = DataCopyType.A2D,
         reuse_dest: EltwiseBinaryReuseDestType = EltwiseBinaryReuseDestType.NONE,
         math_fidelity: MathFidelity = MathFidelity.LoFi,
@@ -54,6 +55,7 @@ class FpuNode:
         self.transpose_faces = transpose_faces
         self.transpose_within_face = transpose_within_face
         self.broadcast_type = broadcast_type
+        self.broadcast_tile = broadcast_tile
         self.reuse_dest = reuse_dest
         self.math_fidelity = math_fidelity
         self.enforce_fp32_accumulation = enforce_fp32_accumulation

--- a/tt_metal/tt-llk/tests/python_tests/fuser/golden.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/golden.py
@@ -130,6 +130,9 @@ class Golden:
             for bx in range(0, operand.tile_count_x, operation.block_tiles_x):
                 block = tiles[:, bx : bx + operation.block_tiles_x]
                 block[:] = block[:, :1]
+        elif node.broadcast_tile is not None:
+            tiles = broadcast.view(operand.tile_count, -1)
+            tiles[:] = tiles[node.broadcast_tile].clone()
 
         return untilize_block(
             broadcast,
@@ -301,7 +304,8 @@ class Golden:
 
         if pool_type == ReducePool.Average:
             span = tile_dims[1] if reduce_dim == ReduceDimension.Row else tile_dims[0]
-            golden_tensor = (src_reduced * span + dest_reduced) / span
+            scaler = tensor_b.flatten()[0].item()
+            golden_tensor = (src_reduced * span + dest_reduced) * scaler
         else:
             golden_tensor = pool(torch.stack((src_reduced, dest_reduced)), dim=0)
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/parser.py
@@ -134,7 +134,7 @@ UNPACKER_MAP = {
         [_broadcast_required, NO_TRANSPOSE, NO_UNPACK_TO_DEST],
     ),
     "UnpackReduceTilize": (
-        lambda s: UnpackReduceTilize(),
+        lambda s: UnpackReduceTilize(s.reduce_dim, s.reduce_pool),
         [
             NO_TRANSPOSE,
             NO_UNPACK_TO_DEST,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/reduce_tilize_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/reduce_tilize_a.py
@@ -16,6 +16,10 @@ from fuser.tile_loop import LoopTileByTile, TileLoop
 class UnpackReduceTilize(Unpacker):
     loop: TileLoop = LoopTileByTile()
 
+    def __init__(self, reduce_dim, reduce_pool):
+        self.reduce_dim = reduce_dim
+        self.reduce_pool = reduce_pool
+
     def get_headers(self) -> List[str]:
         return [
             "llk_unpack_common.h",
@@ -47,12 +51,13 @@ class UnpackReduceTilize(Unpacker):
         desc_a = compute_unit.src_a.cpp_desc_name
         full_ct_dim = compute_unit.src_a.tile_count_x
         tensor_shape = compute_unit.src_a.tile_shape.cpp_value
+        reduce_pool = self.reduce_pool.cpp_enum_value
 
         return (
             f"{desc_a}.buf_desc.f.y_dim = 1;\n"
             f"{desc_a}.buf_desc.f.z_dim = 1;\n"
             f"ckernel::trisc::_configure_buf_desc_table_({buf_desc_id_a}, {desc_a}.buf_desc);\n"
-            f"_llk_unpack_reduce_col_tilizeA_strided_init_"
+            f"_llk_unpack_reduce_col_tilizeA_strided_init_<{reduce_pool}>"
             f"({buf_desc_id_a}, {buf_desc_id_b}, {full_ct_dim}, {tensor_shape});\n"
         )
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/unpack_ab.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/unpack_ab.py
@@ -65,7 +65,12 @@ class UnpackerAB(Unpacker):
         block: BlockData,
     ) -> str:
         if compute_unit.broadcast_type != BroadcastType.None_:
-            return f"_llk_unpack_binary_broadcast_operands_({block.tile_id_global}, {block.tile_id_global});\n"
+            tile_id_b = (
+                block.tile_id_global
+                if compute_unit.broadcast_tile is None
+                else compute_unit.broadcast_tile
+            )
+            return f"_llk_unpack_binary_broadcast_operands_({block.tile_id_global}, {tile_id_b});\n"
 
         return f"_llk_unpack_binary_operands_({block.tile_id_global}, {block.tile_id_global});\n"
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/tests/layernorm_sharded.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/tests/layernorm_sharded.yaml
@@ -4,79 +4,69 @@
 # Pipeline: E[x] partial reduce → x-E[x] → (x-E[x])² → Var partial reduce →
 #           Var+eps → rsqrt → normalize → gamma scale → beta bias.
 #
-# Reduce stages use reduce_to_tile to accumulate all tiles into a single
-# dest tile per block, matching the metal kernel's cross tile reduce behavior.
-# The global allgather reduce is not modeled; ex_global is a pre reduced constant.
-
-supported_archs: ["wormhole", "blackhole"]
+# Reduce stages fold each block into its first dest tile and accumulate the blocks in L1,
+# so the row statistic spans the full shard width. The global allgather reduce folds away
+# on a single core, so E[x] is read straight from ex_partial where the kernel reads cb_ex_global.
 
 operands:
   # x: input tensor
   - name: "x"
-    dims: [64, 128]
+    dims: [32, 1024]
     format: "Float16_b"
 
   # scaler for partial reduce (1/W)
   - name: "scaler"
-    dims: [64, 128]
+    dims: [32, 1024]
     format: "Float16_b"
-    const_value: 0.03125
-
-  # E[x] — pre-reduced mean (models allgather output), single row broadcast
-  - name: "ex_global"
-    dims: [64, 128]
-    format: "Float16_b"
-    const_value: 0.5
+    const_value: 0.0009765625
 
   # eps — small constant for numerical stability
   - name: "eps"
-    dims: [64, 128]
+    dims: [32, 1024]
     format: "Float16_b"
     const_value: 0.001
 
   # gamma — per-column scale
   - name: "gamma"
-    dims: [64, 128]
+    dims: [32, 1024]
     format: "Float16_b"
-    const_value: 1.0
 
   # beta — per-column bias
   - name: "beta"
-    dims: [64, 128]
+    dims: [32, 1024]
     format: "Float16_b"
-    const_value: 0.0
 
   # intermediates
   - name: "ex_partial"
-    dims: [64, 128]
+    dims: [32, 1024]
     format: "Float16_b"
 
   - name: "xmm"
-    dims: [64, 128]
+    dims: [32, 1024]
     format: "Float16_b"
 
   - name: "xmm2"
-    dims: [64, 128]
+    dims: [32, 1024]
     format: "Float16_b"
 
   - name: "var_partial"
-    dims: [64, 128]
+    dims: [32, 1024]
     format: "Float16_b"
 
   - name: "ex2pe"
-    dims: [64, 128]
+    dims: [32, 1024]
     format: "Float16_b"
 
   - name: "normalized"
-    dims: [64, 128]
+    dims: [32, 1024]
     format: "Float16_b"
 
   - name: "gamma_out"
-    dims: [64, 128]
+    dims: [32, 1024]
     format: "Float16_b"
 
   - name: "output"
-    dims: [64, 128]
+    dims: [32, 1024]
     format: "Float16_b"
 
 operations:
@@ -91,21 +81,23 @@ operations:
         reduce_to_tile: true
         unpacker: "ReduceUnpacker"
         math_fidelity: "HiFi4"
-    block_size: [64, 128]
+    block_size: [32, 32]
     pack:
       - output: "ex_partial"
         packer: "Packer"
+        pack_l1_accumulation: 1
 
   # Step 2: x - E[x] — subtract mean (broadcast col)
   - math:
       - type: "Fpu"
         src_a: "x"
-        src_b: "ex_global"
+        src_b: "ex_partial"
         operation: "Elwsub"
         unpacker: "UnpackerAB"
         broadcast_type: "COL"
+        broadcast_tile: 0
         math_fidelity: "LoFi"
-    block_size: [64, 128]
+    block_size: [32, 32]
     pack:
       - output: "xmm"
         packer: "Packer"
@@ -117,8 +109,8 @@ operations:
         src_b: "xmm"
         operation: "Elwmul"
         unpacker: "UnpackerAB"
-        math_fidelity: "LoFi"
-    block_size: [64, 128]
+        math_fidelity: "HiFi4"
+    block_size: [32, 32]
     pack:
       - output: "xmm2"
         packer: "Packer"
@@ -134,10 +126,11 @@ operations:
         reduce_to_tile: true
         unpacker: "ReduceUnpacker"
         math_fidelity: "HiFi4"
-    block_size: [64, 128]
+    block_size: [32, 32]
     pack:
       - output: "var_partial"
         packer: "Packer"
+        pack_l1_accumulation: 1
 
   # Step 5: 1/sqrt(Var + eps) — add eps then rsqrt
   - math:
@@ -149,8 +142,8 @@ operations:
         math_fidelity: "LoFi"
       - type: "UnarySfpu"
         operation: "Rsqrt"
-        iterations: 8
-    block_size: [64, 128]
+        iterations: 32
+    block_size: [32, 32]
     pack:
       - output: "ex2pe"
         packer: "Packer"
@@ -163,8 +156,9 @@ operations:
         operation: "Elwmul"
         unpacker: "UnpackerAB"
         broadcast_type: "COL"
-        math_fidelity: "LoFi"
-    block_size: [64, 128]
+        broadcast_tile: 0
+        math_fidelity: "HiFi4"
+    block_size: [32, 32]
     pack:
       - output: "normalized"
         packer: "Packer"
@@ -177,8 +171,8 @@ operations:
         operation: "Elwmul"
         unpacker: "UnpackerAB"
         broadcast_type: "ROW"
-        math_fidelity: "LoFi"
-    block_size: [64, 128]
+        math_fidelity: "HiFi4"
+    block_size: [32, 32]
     pack:
       - output: "gamma_out"
         packer: "Packer"
@@ -192,7 +186,7 @@ operations:
         unpacker: "UnpackerAB"
         broadcast_type: "ROW"
         math_fidelity: "LoFi"
-    block_size: [64, 128]
+    block_size: [32, 32]
     pack:
       - output: "output"
         packer: "Packer"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/validator.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/validator.py
@@ -357,6 +357,7 @@ class FpuMathSchemaBase(BaseModel):
     operation: str
     unpacker: Optional[str] = None
     broadcast_type: BroadcastType = BroadcastType.None_
+    broadcast_tile: Optional[Annotated[int, Field(ge=0)]] = None
     reuse_dest: EltwiseBinaryReuseDestType = EltwiseBinaryReuseDestType.NONE
     reduce_pool: Optional[ReducePool] = None
     reduce_dim: Optional[ReduceDimension] = None
@@ -383,6 +384,15 @@ class FpuMathSchemaBase(BaseModel):
         if v not in cls._fpu_map:
             raise ValueError(f"Unknown FPU operation: {v}")
         return v
+
+    @model_validator(mode="after")
+    def validate_broadcast_tile(self) -> "FpuMathSchemaBase":
+        if (
+            self.broadcast_tile is not None
+            and self.broadcast_type == BroadcastType.None_
+        ):
+            raise ValueError("broadcast_tile requires a broadcast_type")
+        return self
 
     @field_validator("unpacker", mode="after")
     @classmethod
@@ -436,6 +446,7 @@ class FpuMathSchemaBase(BaseModel):
             "transpose_within_face": self.transpose_within_face,
             "transpose_faces": self.transpose_faces,
             "broadcast_type": self.broadcast_type,
+            "broadcast_tile": self.broadcast_tile,
             "reuse_dest": self.reuse_dest,
             "math_fidelity": self.math_fidelity,
             "enforce_fp32_accumulation": self.enforce_fp32_accumulation,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/unpack_ab.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/unpack_ab.py
@@ -116,7 +116,12 @@ class UnpackerAB(Unpacker):
         broadcast_type = f"BroadcastType::{compute_unit.broadcast_type.value}"
         buffer_a = compute_unit.src_a.cpp_name
         buffer_b = compute_unit.src_b.cpp_name
-        return f"_llk_unpack_AB_<{broadcast_type}>(L1_ADDRESS({buffer_a}[{block.tile_id_global}]), L1_ADDRESS({buffer_b}[{block.tile_id_global}]));\n"
+        tile_id_b = (
+            block.tile_id_global
+            if compute_unit.broadcast_tile is None
+            else compute_unit.broadcast_tile
+        )
+        return f"_llk_unpack_AB_<{broadcast_type}>(L1_ADDRESS({buffer_a}[{block.tile_id_global}]), L1_ADDRESS({buffer_b}[{tile_id_b}]));\n"
 
     def uninit(
         self,


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Add `broadcast_tile` yaml parameter (fixed srcB indexing for broadcast ops) and make the reduce golden read its AVG scale from the src_b scaler tile instead of assuming 1/span.
`layernorm_sharded.yaml` is rewritten to use both, so the test runs on Quasar and matches metal's math.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=marko/quasar-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:marko/quasar-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=marko/quasar-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:marko/quasar-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=marko/quasar-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:marko/quasar-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=marko/quasar-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:marko/quasar-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=marko/quasar-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:marko/quasar-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=marko/quasar-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:marko/quasar-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=marko/quasar-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:marko/quasar-layernorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=marko/quasar-layernorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:marko/quasar-layernorm)