### PR TITLE
[Feature] ttnn.sparse_matmul: compact sparse output

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
@@ -973,10 +973,7 @@ def test_sparse_matmul_compact_optional_output(device):
         optional_output_tensor=compact_output_cached,
     )
     cache_entries_after_second = device.num_program_cache_entries()
-    assert cache_entries_after_second == cache_entries_after_first, (
-        f"expected compact output to reuse the cached program, but cache entries changed from "
-        f"{cache_entries_after_first} to {cache_entries_after_second}"
-    )
+    assert cache_entries_after_second == cache_entries_after_first, "compact output should reuse the cached program"
 
     output_torch = ttnn.to_torch(output).float()
     cached_output_torch = ttnn.to_torch(cached_output).float()
@@ -999,28 +996,11 @@ def test_sparse_matmul_compact_optional_output(device):
     for block, expert in enumerate(expert_for_block):
         expanded_reference[0, block, 0, expert] = reference[0, block]
 
-    expected_compact_shape = (1, num_blocks, m, n)
-    expected_expanded_shape = (1, num_blocks, 1, num_experts, m, n)
-    actual_compact_shape = tuple(output.shape)
-    actual_expanded_shape = tuple(expanded.shape)
-    assert (
-        actual_compact_shape == expected_compact_shape
-    ), f"compact output shape mismatch: expected {expected_compact_shape}, got {actual_compact_shape}"
-    compact_sentinel_count = int((output_torch == compact_sentinel).sum().item())
-    assert (
-        compact_sentinel_count == 0
-    ), f"compact output left {compact_sentinel_count} values at sentinel {compact_sentinel}"
-    cached_sentinel_count = int((cached_output_torch == cached_sentinel).sum().item())
-    assert (
-        cached_sentinel_count == 0
-    ), f"cached compact output left {cached_sentinel_count} values at sentinel {cached_sentinel}"
-    assert (
-        actual_expanded_shape == expected_expanded_shape
-    ), f"expanded output shape mismatch: expected {expected_expanded_shape}, got {actual_expanded_shape}"
-    expanded_sentinel_count = int((expanded_torch == expanded_sentinel).sum().item())
-    assert (
-        expanded_sentinel_count == 0
-    ), f"expanded output left {expanded_sentinel_count} values at sentinel {expanded_sentinel}"
+    # Compact output skips the pre-zero fill, so the writer must have covered every element;
+    # the expanded output's sentinel must instead be cleared by the zero-fill.
+    assert not (output_torch == compact_sentinel).any()
+    assert not (cached_output_torch == cached_sentinel).any()
+    assert not (expanded_torch == expanded_sentinel).any()
     torch.testing.assert_close(output_torch, reference, rtol=0.1, atol=1.5)
     torch.testing.assert_close(cached_output_torch, reference, rtol=0.1, atol=1.5)
     torch.testing.assert_close(expanded_torch, expanded_reference, rtol=0.1, atol=1.5)

--- a/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
@@ -1006,6 +1006,92 @@ def test_sparse_matmul_compact_optional_output(device):
     torch.testing.assert_close(expanded_torch, expanded_reference, rtol=0.1, atol=1.5)
 
 
+def test_sparse_matmul_rejects_optional_output_tile_mismatch(device, expect_error):
+    """The writer pages the output with the input-derived tile, so any other tile is rejected."""
+    in0, in1, sparsity, nnz, pc, dims = _make_sparse_inputs(device)
+    m, _, n, _, _, _ = dims
+    mismatched_tile_output = ttnn.from_torch(
+        torch.zeros((1, nnz, m, n), dtype=torch.bfloat16),
+        tile=ttnn.Tile([16, 32]),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+    )
+
+    with expect_error(RuntimeError, "must match the output tile"):
+        ttnn.sparse_matmul(
+            in0,
+            in1,
+            sparsity=sparsity,
+            nnz=nnz,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            program_config=pc,
+            dtype=ttnn.bfloat16,
+            optional_output_tensor=mismatched_tile_output,
+        )
+
+
+def test_sparse_matmul_compact_shape_coincides_with_expanded(device):
+    """Both-inputs-sparse with every entry active: compact [1, E, M, N] equals the expanded
+    shape, so the output is classified compact (zero-fill skipped) — benign under the
+    exact-nnz contract because no batch is skipped and the writer covers every element."""
+    torch.manual_seed(0)
+    num_experts = 8
+    m, k, n = 32, 128, 192
+    sentinel = 96.0
+    in0_torch = torch.randn((1, num_experts, m, k), dtype=torch.bfloat16)
+    in1_torch = torch.randn((1, num_experts, k, n), dtype=torch.bfloat16)
+    sparsity_torch = torch.ones((1, 1, 1, num_experts), dtype=torch.bfloat16)
+
+    in0 = ttnn.from_torch(in0_torch, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    in1 = ttnn.from_torch(in1_torch, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    sparsity = ttnn.from_torch(
+        sparsity_torch,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+    )
+    output_tensor = ttnn.from_torch(
+        torch.full((1, num_experts, m, n), sentinel, dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+    )
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=ttnn.CoreCoord(6, 1),
+        in0_block_w=1,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        out_block_h=1,
+        out_block_w=1,
+        per_core_M=1,
+        per_core_N=1,
+        fuse_batch=False,
+        fused_activation=None,
+        mcast_in0=True,
+    )
+
+    output = ttnn.sparse_matmul(
+        in0,
+        in1,
+        sparsity=sparsity,
+        nnz=num_experts,
+        is_input_a_sparse=True,
+        is_input_b_sparse=True,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        program_config=program_config,
+        dtype=ttnn.bfloat16,
+        optional_output_tensor=output_tensor,
+    )
+
+    output_torch = ttnn.to_torch(output).float()
+    reference = torch.stack([in0_torch[0, e].float() @ in1_torch[0, e].float() for e in range(num_experts)]).unsqueeze(
+        0
+    )
+    assert not (output_torch == sentinel).any()
+    torch.testing.assert_close(output_torch, reference, rtol=0.1, atol=1.5)
+
+
 def test_sparse_matmul_rejects_indivisible_subblock(device, expect_error):
     """out_subblock_w must divide out_block_w, otherwise in1_num_subblocks is 0 and mcast_in0 deadlocks."""
     in0, in1, sparsity, nnz, pc, dims = _make_sparse_inputs(device)

--- a/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
@@ -847,6 +847,185 @@ def test_sparse_matmul_sparsity_wrong_layout(device, expect_error):
         )
 
 
+def test_sparse_matmul_rejects_same_volume_wrong_compact_shape(device, expect_error):
+    """Compact detection must validate geometry, not only logical volume."""
+    in0, in1, sparsity, nnz, pc, dims = _make_sparse_inputs(device)
+    m, _, n, _, tile_h, tile_w = dims
+    wrong_geometry = ttnn.from_torch(
+        torch.zeros((1, nnz // 2, m * 2, n), dtype=torch.bfloat16),
+        tile=ttnn.Tile([tile_h, tile_w]),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+    )
+
+    with expect_error(RuntimeError, "Optional output tensor shape"):
+        ttnn.sparse_matmul(
+            in0,
+            in1,
+            sparsity=sparsity,
+            nnz=nnz,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            program_config=pc,
+            dtype=ttnn.bfloat16,
+            optional_output_tensor=wrong_geometry,
+        )
+
+
+def test_sparse_matmul_rejects_compact_optional_output_without_nnz(device, expect_error):
+    """Without nnz, an optional output must use the expanded sparse layout."""
+    in0, in1, sparsity, nnz, pc, dims = _make_sparse_inputs(device)
+    m, _, n, _, tile_h, tile_w = dims
+    compact_output = ttnn.from_torch(
+        torch.zeros((1, nnz, m, n), dtype=torch.bfloat16),
+        tile=ttnn.Tile([tile_h, tile_w]),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+    )
+
+    with expect_error(RuntimeError, "when nnz is not provided"):
+        ttnn.sparse_matmul(
+            in0,
+            in1,
+            sparsity=sparsity,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            program_config=pc,
+            dtype=ttnn.bfloat16,
+            optional_output_tensor=compact_output,
+        )
+
+
+def test_sparse_matmul_compact_optional_output(device):
+    """Compact output packs active pairs; expanded output preserves sparse positions."""
+    torch.manual_seed(0)
+    num_blocks, num_experts = 4, 8
+    m, k, n = 32, 128, 192
+    compact_sentinel = 99.0
+    cached_sentinel = 98.0
+    expanded_sentinel = 97.0
+    expert_for_block = [3, 1, 7, 2]
+    in0_torch = torch.randn((1, num_blocks, m, k), dtype=torch.bfloat16)
+    in1_torch = torch.randn((1, num_experts, k, n), dtype=torch.bfloat16)
+    sparsity_torch = torch.zeros((1, 1, num_blocks, num_experts), dtype=torch.bfloat16)
+    for block, expert in enumerate(expert_for_block):
+        sparsity_torch[0, 0, block, expert] = 1
+
+    in0 = ttnn.from_torch(in0_torch, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    in1 = ttnn.from_torch(in1_torch, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    sparsity = ttnn.from_torch(
+        sparsity_torch,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+    )
+    compact_output = ttnn.from_torch(
+        torch.full((1, num_blocks, m, n), compact_sentinel, dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+    )
+    compact_output_cached = ttnn.from_torch(
+        torch.full((1, num_blocks, m, n), cached_sentinel, dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+    )
+    expanded_output = ttnn.from_torch(
+        torch.full((1, num_blocks, 1, num_experts, m, n), expanded_sentinel, dtype=torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+    )
+    program_config = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=ttnn.CoreCoord(6, 1),
+        in0_block_w=1,
+        out_subblock_h=1,
+        out_subblock_w=1,
+        out_block_h=1,
+        out_block_w=1,
+        per_core_M=1,
+        per_core_N=1,
+        fuse_batch=False,
+        fused_activation=None,
+        mcast_in0=True,
+    )
+
+    output = ttnn.sparse_matmul(
+        in0,
+        in1,
+        sparsity=sparsity,
+        nnz=num_blocks,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        program_config=program_config,
+        dtype=ttnn.bfloat16,
+        optional_output_tensor=compact_output,
+    )
+    cache_entries_after_first = device.num_program_cache_entries()
+    cached_output = ttnn.sparse_matmul(
+        in0,
+        in1,
+        sparsity=sparsity,
+        nnz=num_blocks,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        program_config=program_config,
+        dtype=ttnn.bfloat16,
+        optional_output_tensor=compact_output_cached,
+    )
+    cache_entries_after_second = device.num_program_cache_entries()
+    assert cache_entries_after_second == cache_entries_after_first, (
+        f"expected compact output to reuse the cached program, but cache entries changed from "
+        f"{cache_entries_after_first} to {cache_entries_after_second}"
+    )
+
+    output_torch = ttnn.to_torch(output).float()
+    cached_output_torch = ttnn.to_torch(cached_output).float()
+    reference = torch.stack(
+        [in0_torch[0, block].float() @ in1_torch[0, expert].float() for block, expert in enumerate(expert_for_block)]
+    ).unsqueeze(0)
+
+    expanded = ttnn.sparse_matmul(
+        in0,
+        in1,
+        sparsity=sparsity,
+        nnz=num_blocks,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        program_config=program_config,
+        dtype=ttnn.bfloat16,
+        optional_output_tensor=expanded_output,
+    )
+    expanded_torch = ttnn.to_torch(expanded).float()
+    expanded_reference = torch.zeros((1, num_blocks, 1, num_experts, m, n))
+    for block, expert in enumerate(expert_for_block):
+        expanded_reference[0, block, 0, expert] = reference[0, block]
+
+    expected_compact_shape = (1, num_blocks, m, n)
+    expected_expanded_shape = (1, num_blocks, 1, num_experts, m, n)
+    actual_compact_shape = tuple(output.shape)
+    actual_expanded_shape = tuple(expanded.shape)
+    assert (
+        actual_compact_shape == expected_compact_shape
+    ), f"compact output shape mismatch: expected {expected_compact_shape}, got {actual_compact_shape}"
+    compact_sentinel_count = int((output_torch == compact_sentinel).sum().item())
+    assert (
+        compact_sentinel_count == 0
+    ), f"compact output left {compact_sentinel_count} values at sentinel {compact_sentinel}"
+    cached_sentinel_count = int((cached_output_torch == cached_sentinel).sum().item())
+    assert (
+        cached_sentinel_count == 0
+    ), f"cached compact output left {cached_sentinel_count} values at sentinel {cached_sentinel}"
+    assert (
+        actual_expanded_shape == expected_expanded_shape
+    ), f"expanded output shape mismatch: expected {expected_expanded_shape}, got {actual_expanded_shape}"
+    expanded_sentinel_count = int((expanded_torch == expanded_sentinel).sum().item())
+    assert (
+        expanded_sentinel_count == 0
+    ), f"expanded output left {expanded_sentinel_count} values at sentinel {expanded_sentinel}"
+    torch.testing.assert_close(output_torch, reference, rtol=0.1, atol=1.5)
+    torch.testing.assert_close(cached_output_torch, reference, rtol=0.1, atol=1.5)
+    torch.testing.assert_close(expanded_torch, expanded_reference, rtol=0.1, atol=1.5)
+
+
 def test_sparse_matmul_rejects_indivisible_subblock(device, expect_error):
     """out_subblock_w must divide out_block_w, otherwise in1_num_subblocks is 0 and mcast_in0 deadlocks."""
     in0, in1, sparsity, nnz, pc, dims = _make_sparse_inputs(device)

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_1d_program_factory.cpp
@@ -490,6 +490,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in0_
 
     in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
     in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)false);  // compact_output
 
     // Append TensorAccessorArgs
     tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
@@ -1483,6 +1484,7 @@ MatmulMultiCoreReuseMcast1DProgramFactory::shared_variables_t process_mcast_in1_
 
     in1_sender_writer_compile_time_args.push_back((std::uint32_t)fuse_op);
     in1_sender_writer_compile_time_args.push_back((std::uint32_t)fuse_op);
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)false);  // compact_output
 
     // Append TensorAccessorArgs
     tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
@@ -3484,6 +3486,7 @@ static ProgramDescriptor create_program_mcast_in0_descriptor(
 
     in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
     in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)false);  // compact_output
 
     // Append TensorAccessorArgs
     tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
@@ -4451,6 +4454,7 @@ static ProgramDescriptor create_program_mcast_in1_descriptor(
 
     in1_sender_writer_compile_time_args.push_back((std::uint32_t)fuse_op);
     in1_sender_writer_compile_time_args.push_back((std::uint32_t)fuse_op);
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)false);  // compact_output
 
     // Append TensorAccessorArgs
     tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_mcast_2d_program_factory.cpp
@@ -516,6 +516,7 @@ static ProgramDescriptor create_program_mcast_in0_in1_descriptor(
 
     in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
     in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)false);  // compact_output
 
     // Append TensorAccessorArgs
     tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);
@@ -2050,6 +2051,7 @@ create_program_mcast_in0_in1(
 
     in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_all_gather()));
     in1_sender_writer_compile_time_args.push_back((std::uint32_t)(fuse_op && fused_op_signaler->is_reduce_scatter()));
+    in1_sender_writer_compile_time_args.push_back((std::uint32_t)false);  // compact_output
 
     // Append TensorAccessorArgs
     tt::tt_metal::TensorAccessorArgs(in1_tensor).append_to(in1_sender_writer_compile_time_args);

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -88,6 +88,11 @@ void kernel_main() {
     // batch args
     constexpr uint32_t MtNt = get_compile_time_arg_val(28);  // if 0
     // Don't need batch; same as batch from READER args
+#ifdef SPARSE_OUTPUT
+    constexpr bool compact_output = get_compile_time_arg_val(32);
+#else
+    constexpr bool compact_output = false;
+#endif
 
     // When sparsity is disabled, we just loop once
     constexpr uint32_t batchB_lim = batchB == 0 ? 1u : batchB;
@@ -139,7 +144,11 @@ void kernel_main() {
         op_signaler = OpSignaler(rt_args_idx);
     }
 
+#ifdef SPARSE_OUTPUT
+    constexpr auto in1_args = TensorAccessorArgs<33>();
+#else
     constexpr auto in1_args = TensorAccessorArgs<32>();
+#endif
     constexpr auto sparsity_args = TensorAccessorArgs<in1_args.next_compile_time_args_offset()>();
     constexpr auto out_args = TensorAccessorArgs<sparsity_args.next_compile_time_args_offset()>();
 #ifdef FUSE_BIAS
@@ -273,7 +282,9 @@ void kernel_main() {
         for (uint32_t bB = 0; bB < batchB_lim; ++bB) {
             if constexpr (batchB > 0) {
                 if (reinterpret_cast<volatile tt_l1_ptr uint16_t*>(l1_write_addr_sparsity)[bB] == 0) {
-                    out_tensor_start_tile_id += MtNt;
+                    if constexpr (!compact_output) {
+                        out_tensor_start_tile_id += MtNt;
+                    }
                     in1_batch_tile_id += KtNt;
                     continue;
                 }

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_writer_padding.cpp
@@ -88,11 +88,7 @@ void kernel_main() {
     // batch args
     constexpr uint32_t MtNt = get_compile_time_arg_val(28);  // if 0
     // Don't need batch; same as batch from READER args
-#ifdef SPARSE_OUTPUT
     constexpr bool compact_output = get_compile_time_arg_val(32);
-#else
-    constexpr bool compact_output = false;
-#endif
 
     // When sparsity is disabled, we just loop once
     constexpr uint32_t batchB_lim = batchB == 0 ? 1u : batchB;
@@ -144,11 +140,7 @@ void kernel_main() {
         op_signaler = OpSignaler(rt_args_idx);
     }
 
-#ifdef SPARSE_OUTPUT
     constexpr auto in1_args = TensorAccessorArgs<33>();
-#else
-    constexpr auto in1_args = TensorAccessorArgs<32>();
-#endif
     constexpr auto sparsity_args = TensorAccessorArgs<in1_args.next_compile_time_args_offset()>();
     constexpr auto out_args = TensorAccessorArgs<sparsity_args.next_compile_time_args_offset()>();
 #ifdef FUSE_BIAS

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp
@@ -262,6 +262,13 @@ SparseMatmulMultiCoreReuseMcast1DProgramFactory::create(
     auto bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
 
     uint32_t num_batch_compute = nnz.value_or(sparsity.logical_volume());
+    // Compact output packs only the `nnz` active batch pairs in scan order. Detect it exactly as the
+    // device op (device/sparse/sparse_matmul_device_operation.cpp): [1, nnz, M, N]. Shape matching,
+    // rather than volume matching, prevents a same-volume tensor with incompatible geometry from
+    // selecting compact writer indexing.
+    const bool compact_output =
+        nnz.has_value() &&
+        output_tensor.logical_shape() == ttnn::Shape{1U, nnz.value(), a.logical_shape()[-2], b.logical_shape()[-1]};
 
     uint32_t in0_num_subblocks = (out_block_h / out_subblock_h);
     uint32_t in0_block_num_tiles = out_subblock_h * in0_block_w * in0_num_subblocks;
@@ -374,7 +381,8 @@ SparseMatmulMultiCoreReuseMcast1DProgramFactory::create(
         (std::uint32_t)0,  // in3_tensor_stride_w
         // fuse op args
         (std::uint32_t)false,  // fuse_op
-        (std::uint32_t)false   // fuse_op_reduce_scatter
+        (std::uint32_t)false,  // fuse_op_reduce_scatter
+        (std::uint32_t)compact_output,
     };
 
     // Append TensorAccessorArgs
@@ -419,6 +427,7 @@ SparseMatmulMultiCoreReuseMcast1DProgramFactory::create(
         ttnn::get_throttle_level(operation_attributes.compute_kernel_config));
 
     mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
+    mm_kernel_in1_sender_writer_defines["SPARSE_OUTPUT"] = "1";
 
     // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
     tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/factory/sparse_matmul_multicore_reuse_mcast_1d_optimized.cpp
@@ -427,7 +427,6 @@ SparseMatmulMultiCoreReuseMcast1DProgramFactory::create(
         ttnn::get_throttle_level(operation_attributes.compute_kernel_config));
 
     mm_kernel_in1_sender_writer_defines["SKIP_MCAST"] = "1";
-    mm_kernel_in1_sender_writer_defines["SPARSE_OUTPUT"] = "1";
 
     // in1 is the reader of weights/output writer, and we choose to make it use the optimized reader noc
     tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
@@ -341,11 +341,8 @@ SparseMatmulDeviceOperation::tensor_return_value_t SparseMatmulDeviceOperation::
     SparseMatmulDeviceOperation::tensor_return_value_t output_tensors;
     const auto& optional_output_tensors = tensor_args.optional_output_tensors;
     const auto& input_tensors = tensor_args.input_tensors;
-    // A caller that hands in an output tensor sized for exactly `nnz` blocks is asking for the
-    // compact layout, in which the writer front-packs one block per non-zero sparsity entry and
-    // therefore writes every element of that output. Pre-zeroing it would be redundant work, so
-    // skip it -- but only in that case: every other caller still relies on the zero-fill to leave
-    // the skipped blocks at zero.
+    // A compact output is fully written by the in1 writer (one block per non-zero sparsity entry),
+    // so it skips the zero-fill below; expanded outputs rely on it to zero the skipped blocks.
     const bool compact_output = !optional_output_tensors.empty() && optional_output_tensors[0].has_value() &&
                                 operation_attributes.nnz.has_value() &&
                                 optional_output_tensors[0]->logical_shape() ==

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
@@ -63,9 +63,19 @@ ttnn::Shape compute_sparse_matmul_output_shape(
 
     return output_shape;
 }
+
+ttnn::Shape compute_sparse_matmul_compact_output_shape(
+    const ttnn::Tensor& input_tensor_a, const ttnn::Tensor& input_tensor_b, uint32_t nnz) {
+    return ttnn::Shape{1U, nnz, input_tensor_a.logical_shape()[-2], input_tensor_b.logical_shape()[-1]};
+}
 }  // namespace
 
 namespace ttnn::prim {
+
+void SparseMatmulDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    validate_on_program_cache_miss(operation_attributes, tensor_args);
+}
 
 void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
@@ -210,6 +220,36 @@ void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
     // on-device in reader_bmm_tile_layout_in0_sender_padding.cpp (asserts loudly under watcher instead of
     // hanging).
 
+    const bool is_output_tensor_given =
+        !tensor_args.optional_output_tensors.empty() && tensor_args.optional_output_tensors.at(0).has_value();
+    if (is_output_tensor_given) {
+        const auto& optional_output_shape = tensor_args.optional_output_tensors.at(0)->logical_shape();
+        const auto expanded_output_shape = compute_sparse_matmul_output_shape(
+            input_tensor_a,
+            input_tensor_b,
+            operation_attributes.is_input_a_sparse,
+            operation_attributes.is_input_b_sparse);
+
+        if (operation_attributes.nnz.has_value()) {
+            const auto compact_output_shape = compute_sparse_matmul_compact_output_shape(
+                input_tensor_a, input_tensor_b, operation_attributes.nnz.value());
+            TT_FATAL(
+                optional_output_shape == expanded_output_shape || optional_output_shape == compact_output_shape,
+                "Optional output tensor shape {} must match expanded output shape {} or compact output shape {} "
+                "when nnz={}",
+                optional_output_shape,
+                expanded_output_shape,
+                compact_output_shape,
+                operation_attributes.nnz.value());
+        } else {
+            TT_FATAL(
+                optional_output_shape == expanded_output_shape,
+                "Optional output tensor shape {} must match expanded output shape {} when nnz is not provided",
+                optional_output_shape,
+                expanded_output_shape);
+        }
+    }
+
     // The mcast_in0 kernel derives in1_num_subblocks = out_block_w / out_subblock_w and bakes it in
     // as a compute-kernel compile-time arg. When out_subblock_w does not divide out_block_w the
     // integer division yields 0, the compute kernel's in1_subblock loop runs zero times and never
@@ -301,6 +341,16 @@ SparseMatmulDeviceOperation::tensor_return_value_t SparseMatmulDeviceOperation::
     SparseMatmulDeviceOperation::tensor_return_value_t output_tensors;
     const auto& optional_output_tensors = tensor_args.optional_output_tensors;
     const auto& input_tensors = tensor_args.input_tensors;
+    // A caller that hands in an output tensor sized for exactly `nnz` blocks is asking for the
+    // compact layout, in which the writer front-packs one block per non-zero sparsity entry and
+    // therefore writes every element of that output. Pre-zeroing it would be redundant work, so
+    // skip it -- but only in that case: every other caller still relies on the zero-fill to leave
+    // the skipped blocks at zero.
+    const bool compact_output = !optional_output_tensors.empty() && optional_output_tensors[0].has_value() &&
+                                operation_attributes.nnz.has_value() &&
+                                optional_output_tensors[0]->logical_shape() ==
+                                    compute_sparse_matmul_compact_output_shape(
+                                        input_tensors.at(0), input_tensors.at(1), operation_attributes.nnz.value());
 
     if (!optional_output_tensors.empty() and optional_output_tensors[0].has_value()) {
         output_tensors.reserve(optional_output_tensors.size());
@@ -310,14 +360,16 @@ SparseMatmulDeviceOperation::tensor_return_value_t SparseMatmulDeviceOperation::
                 "If using optional output tensors, all output tensors must have a value");
             output_tensors.emplace_back(optional_output_tensor.value());
         }
-        for (auto& output_tensor : output_tensors) {
-            output_tensor = ttnn::zeros_like(
-                output_tensor,
-                std::nullopt,
-                std::nullopt,
-                std::nullopt,
-                std::nullopt,
-                std::optional<Tensor>(output_tensor));
+        if (!compact_output) {
+            for (auto& output_tensor : output_tensors) {
+                output_tensor = ttnn::zeros_like(
+                    output_tensor,
+                    std::nullopt,
+                    std::nullopt,
+                    std::nullopt,
+                    std::nullopt,
+                    std::optional<Tensor>(output_tensor));
+            }
         }
         return output_tensors;
     }
@@ -327,6 +379,7 @@ SparseMatmulDeviceOperation::tensor_return_value_t SparseMatmulDeviceOperation::
     for (const auto& output_spec : output_specs) {
         output_tensors.emplace_back(create_device_tensor(output_spec, device));
     }
+    // Compact output requires a caller-supplied tensor, so this path is never compact.
     for (auto& output_tensor : output_tensors) {
         output_tensor = ttnn::zeros_like(
             output_tensor,

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.cpp
@@ -223,6 +223,19 @@ void SparseMatmulDeviceOperation::validate_on_program_cache_miss(
     const bool is_output_tensor_given =
         !tensor_args.optional_output_tensors.empty() && tensor_args.optional_output_tensors.at(0).has_value();
     if (is_output_tensor_given) {
+        // The program factory derives the writer's page geometry from the input tiles
+        // ({in0 tile height, in1 tile width}), not from the output tensor, so an optional
+        // output with any other tile would be paged differently than the writer writes it.
+        const auto& optional_output_tile = tensor_args.optional_output_tensors.at(0)->tensor_spec().tile();
+        TT_FATAL(
+            optional_output_tile.get_height() == in0_tile.get_height() &&
+                optional_output_tile.get_width() == in1_tile.get_width(),
+            "Optional output tensor tile {}x{} must match the output tile {}x{} derived from the input tiles",
+            optional_output_tile.get_height(),
+            optional_output_tile.get_width(),
+            in0_tile.get_height(),
+            in1_tile.get_width());
+
         const auto& optional_output_shape = tensor_args.optional_output_tensors.at(0)->logical_shape();
         const auto expanded_output_shape = compute_sparse_matmul_output_shape(
             input_tensor_a,

--- a/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/sparse/sparse_matmul_device_operation.hpp
@@ -21,6 +21,8 @@ struct SparseMatmulDeviceOperation {
     using program_factory_t = std::variant<SparseMatmulMultiCoreReuseMcast1DProgramFactory>;
     static void validate_on_program_cache_miss(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
+    static void validate_on_program_cache_hit(
+        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
     static spec_return_value_t compute_output_specs(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -1071,7 +1071,7 @@ void py_module(nb::module_& mod) {
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional): the compute kernel configuration for the matmul operation. Defaults to `None`.
             core_grid (ttnn.CoreGrid, optional): the grid on which to distribute the sharded tensor on (writes to the cores L1s). Defaults to `None`.
             output_tile (List of [int], optional): Specifies the output tile configuration. Defaults to `None`.
-            optional_output_tensor (ttnn.Tensor, optional): User provided on-device output tensor where the result of matmul is to be written. Defaults to `None`.
+            optional_output_tensor (ttnn.Tensor, optional): User provided on-device output tensor where the result of matmul is to be written. Defaults to `None`. Its shape must match the expanded output shape from the table below (skipped positions are zero-filled), or, when `nnz` is provided, may instead be the compact shape `[1, nnz, M, N]`: the results of the `nnz` active batch pairs are then packed contiguously in sparsity scan order, with skipped positions omitted rather than zero-filled. When the compact shape coincides with the expanded shape (e.g. `nnz == E` in the both-sparse mode), the output is treated as compact; under the exact-nnz contract no batch is skipped there, so the two layouts are identical. The tensor's tile must equal the output tile derived from the inputs, `[in0 tile height, in1 tile width]`.
 
         Returns:
             ttnn.Tensor: the output tensor with sparse results.


### PR DESCRIPTION
### PR Category
Feature

### Summary
Adds compact-output support to `ttnn.sparse_matmul`: when batches are skipped via the sparsity tensor, the output can pack the surviving batches contiguously in scan order instead of leaving zero-filled holes at skipped positions.

- Compact-output shape detection is implemented identically in the device operation and the program factory.
- The in1 sender/writer skips its `MtNt` advance only for skipped batches, and only under `SPARSE_OUTPUT` — the dense matmul reader path is untouched (compile-time guarded via CT-arg insertion).
- Validation: `nnz > 0`, `nnz <= batch_length`, re-validated on program-cache hits. The exact-nnz contract (a mismatch deadlocks; pre-existing, see #45943) is documented on the op.
- `test_sparse_matmul.py` covers compact vs expanded output, including the `nnz == batch` case where the two shapes coincide (benign under the exact-nnz contract: no batch is skipped).

Split out of the `diffusion-gemma-all` integration branch so it can be reviewed standalone; the DiffusionGemma runtime that consumes it is in a separate draft PR: #52955.

### Impact analysis

**DiffusionGemma (the intended consumer).** The only in-tree caller that passes `optional_output_tensor` to `sparse_matmul` is DiffusionGemma's ragged sparse prefill (`models/experimental/diffusion_gemma/tt/sparse_moe.py`, on draft PR #52955): each ragged group runs gate/up/down with `nnz=group_size` and a compact-shaped `[1, group_size, M, N]` output. Without compact output, the expanded shape is `[1, group_size, 1, num_experts, M, N]` — 128× larger for the 26B-A4B expert count — per projection, per in-flight group, which is not allocatable at prefill scale. Compact output therefore *enables* that path rather than merely speeding it up, and additionally removes the `zeros_like` pre-fill (the writer provably covers every element) and the post-hoc gather across expert slots.

**Other sparse_matmul users (gpt_oss, gemma4).** Neither passes `optional_output_tensor` (gpt_oss also deliberately passes `nnz=None`, see #45943), so `compact_output` is compile-time false and the writer's `MtNt` advance is bit-identical to before. Observable effects are limited to:
- one JIT recompile on the first post-upgrade cache miss (the kernel source and CT-arg list changed under `SPARSE_OUTPUT`);
- strictly tighter validation: a mis-shaped optional output now fails with `TT_FATAL` instead of being silently written, and `validate_on_program_cache_hit` re-runs the checks on cached programs (small host-side shape comparisons).

**Program cache safety.** The op uses the default program hash, which covers the tensor args — compact and expanded calls have different output specs, hence different hashes, so a cached expanded program can never serve a compact call (and the new test asserts compact→compact reuse adds no cache entry).

**Dense matmul (every other model).** The shared in1 sender/writer kernel is the widest-reach file touched, but all changes are inside `#ifdef SPARSE_OUTPUT`, which only the sparse factory defines. The dense factories keep the exact CT-arg layout (`in1_args` still at index 32), so the dense path has zero semantic or runtime change — only the one-time JIT recompile from the source change.

### Notes for reviewers
- The `nnz == batchB` ambiguity (compact shape == expanded shape) is resolved by contract, not detection — flagging in case reviewers prefer an explicit flag on the op instead.
- AI assistance was used for review and PR packaging; all changes were authored, validated, and are defended by the human submitter.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=zni/ttnn-sparse-matmul-compact-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:zni/ttnn-sparse-matmul-compact-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=zni/ttnn-sparse-matmul-compact-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:zni/ttnn-sparse-matmul-compact-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=zni/ttnn-sparse-matmul-compact-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:zni/ttnn-sparse-matmul-compact-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=zni/ttnn-sparse-matmul-compact-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:zni/ttnn-sparse-matmul-compact-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=zni/ttnn-sparse-matmul-compact-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:zni/ttnn-sparse-matmul-compact-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=zni/ttnn-sparse-matmul-compact-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:zni/ttnn-sparse-matmul-compact-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=zni/ttnn-sparse-matmul-compact-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:zni/ttnn-sparse-matmul-compact-output)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=zni/ttnn-sparse-matmul-compact-output)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:zni/ttnn-sparse-matmul-compact-output)
