### PR TITLE
[Test Only] sdxl_lora: pin the test adapters to a revision

### DIFF
--- a/models/demos/stable_diffusion_xl_base/conftest.py
+++ b/models/demos/stable_diffusion_xl_base/conftest.py
@@ -464,13 +464,15 @@ def _fetch_lora_from_ci_v2_cache(cache_dir, filename):
 
 
 def _resolve_lora_weights_path(
-    request, is_ci_env, is_ci_v2_env, default_repo_id, default_filename, ci_v2_cache_dir=None
+    request, is_ci_env, is_ci_v2_env, default_repo_id, default_filename, default_revision=None, ci_v2_cache_dir=None
 ):
     """Resolve a LoRA weights path.
 
     1) --lora-weights: full path to a local .safetensors file.
     2) --lora-hf-repo and --lora-hf-filename: download from Hugging Face.
-    3) If nothing provided: use the supplied default weights. In CI (v1 or v2),
+    3) If nothing provided: use the supplied default weights, pinned to
+       `default_revision` so an upstream re-upload cannot silently change what
+       the PCC references are compared against. In CI (v1 or v2),
        adapters with a `ci_v2_cache_dir` are fetched from the large-file cache
        first: CIv2 runners have no HF egress, and CIv1 runners call
        hf_hub_download with local_files_only=True, so an adapter absent from
@@ -498,12 +500,16 @@ def _resolve_lora_weights_path(
         return
 
     tried_ci_cache = False
+    hf_revision = None
     if not (hf_repo_id and hf_filename):
         logger.warning(
             f"No LoRA weights provided. Using default weights. Repo: {default_repo_id}, File: {default_filename}"
         )
         hf_repo_id = default_repo_id
         hf_filename = default_filename
+        # Only the built-in defaults are pinned. A caller-supplied repo/filename
+        # keeps HF's default branch, since this revision does not describe it.
+        hf_revision = default_revision
 
         if (is_ci_env or is_ci_v2_env) and ci_v2_cache_dir:
             tried_ci_cache = True
@@ -515,7 +521,10 @@ def _resolve_lora_weights_path(
         from huggingface_hub import hf_hub_download
 
         return hf_hub_download(
-            repo_id=hf_repo_id, filename=hf_filename, local_files_only=is_ci_env and not is_ci_v2_env
+            repo_id=hf_repo_id,
+            filename=hf_filename,
+            revision=hf_revision,
+            local_files_only=is_ci_env and not is_ci_v2_env,
         )
     except Exception as _:
         ci_cache_note = (
@@ -523,8 +532,9 @@ def _resolve_lora_weights_path(
             if tried_ci_cache
             else ""
         )
+        revision_note = f" at pinned revision {hf_revision}" if hf_revision else ""
         pytest.skip(
-            f"LoRA weights not available from HF ({hf_repo_id}, {hf_filename}).{ci_cache_note} "
+            f"LoRA weights not available from HF ({hf_repo_id}, {hf_filename}){revision_note}.{ci_cache_note} "
             f"Use --lora-weights for a local file path, or ensure network/cache for HF."
         )
         return
@@ -533,7 +543,16 @@ def _resolve_lora_weights_path(
 @pytest.fixture(scope="function")
 def lora_path(request, is_ci_env, is_ci_v2_env):
     """LoRA weights path, defaulting to the UNet-only test adapter."""
-    return _resolve_lora_weights_path(request, is_ci_env, is_ci_v2_env, TEST_LORA_REPO_ID, TEST_LORA_FILENAME)
+    from models.demos.stable_diffusion_xl_base.lora.config import TEST_LORA_REVISION
+
+    return _resolve_lora_weights_path(
+        request,
+        is_ci_env,
+        is_ci_v2_env,
+        TEST_LORA_REPO_ID,
+        TEST_LORA_FILENAME,
+        default_revision=TEST_LORA_REVISION,
+    )
 
 
 @pytest.fixture(scope="function")
@@ -550,6 +569,7 @@ def te_lora_path(request, is_ci_env, is_ci_v2_env):
         TE_TEST_LORA_CI_CACHE_DIR,
         TE_TEST_LORA_FILENAME,
         TE_TEST_LORA_REPO_ID,
+        TE_TEST_LORA_REVISION,
     )
 
     return _resolve_lora_weights_path(
@@ -558,5 +578,6 @@ def te_lora_path(request, is_ci_env, is_ci_v2_env):
         is_ci_v2_env,
         TE_TEST_LORA_REPO_ID,
         TE_TEST_LORA_FILENAME,
+        default_revision=TE_TEST_LORA_REVISION,
         ci_v2_cache_dir=TE_TEST_LORA_CI_CACHE_DIR,
     )

--- a/models/demos/stable_diffusion_xl_base/conftest.py
+++ b/models/demos/stable_diffusion_xl_base/conftest.py
@@ -472,7 +472,10 @@ def _resolve_lora_weights_path(
     2) --lora-hf-repo and --lora-hf-filename: download from Hugging Face.
     3) If nothing provided: use the supplied default weights, pinned to
        `default_revision` so an upstream re-upload cannot silently change what
-       the PCC references are compared against. In CI (v1 or v2),
+       the PCC references are compared against. The pin is best-effort: where it
+       cannot be resolved (a baked HF cache holding a different snapshot) the
+       fetch falls back to the default branch with a warning, rather than
+       skipping the test and reporting green on no coverage. In CI (v1 or v2),
        adapters with a `ci_v2_cache_dir` are fetched from the large-file cache
        first: CIv2 runners have no HF egress, and CIv1 runners call
        hf_hub_download with local_files_only=True, so an adapter absent from
@@ -517,22 +520,41 @@ def _resolve_lora_weights_path(
             if cached:
                 return cached
 
-    try:
+    def _download(revision):
         from huggingface_hub import hf_hub_download
 
         return hf_hub_download(
             repo_id=hf_repo_id,
             filename=hf_filename,
-            revision=hf_revision,
+            revision=revision,
             local_files_only=is_ci_env and not is_ci_v2_env,
         )
+
+    if hf_revision:
+        try:
+            return _download(hf_revision)
+        except Exception as e:
+            # The pin guards against an upstream re-upload; it is not worth losing
+            # coverage over. A runner whose baked HF cache holds this adapter under a
+            # different snapshot cannot resolve the pinned revision offline, and giving
+            # up here would drop the whole suite to skips while still reporting green.
+            # Fall back to whatever is reachable, but say so: the bytes under test are
+            # then not the ones the pin describes, which is worth seeing in the log.
+            logger.warning(
+                f"Pinned revision {hf_revision} for {hf_repo_id}/{hf_filename} could not be resolved ({e}). "
+                f"Falling back to the default branch: the adapter under test may differ from the pinned one, "
+                f"so treat a PCC change here as a possible fixture change rather than a model regression."
+            )
+
+    try:
+        return _download(None)
     except Exception as _:
         ci_cache_note = (
             f" Also tried the CIv2 large-file cache ({ci_v2_cache_dir}/{hf_filename}) without success."
             if tried_ci_cache
             else ""
         )
-        revision_note = f" at pinned revision {hf_revision}" if hf_revision else ""
+        revision_note = f" (pinned revision {hf_revision} was unresolvable too)" if hf_revision else ""
         pytest.skip(
             f"LoRA weights not available from HF ({hf_repo_id}, {hf_filename}){revision_note}.{ci_cache_note} "
             f"Use --lora-weights for a local file path, or ensure network/cache for HF."

--- a/models/demos/stable_diffusion_xl_base/demo/demo_lora.py
+++ b/models/demos/stable_diffusion_xl_base/demo/demo_lora.py
@@ -82,7 +82,7 @@ def run_demo_inference(
         "stabilityai/stable-diffusion-xl-base-1.0",
         torch_dtype=torch.float32,
         use_safetensors=True,
-        local_files_only=is_ci_env and os.getenv("TT_ALLOW_HF_DOWNLOAD") != "1",
+        local_files_only=is_ci_env,
     )
     profiler.end("diffusion_pipeline_from_pretrained")
 

--- a/models/demos/stable_diffusion_xl_base/lora/config.py
+++ b/models/demos/stable_diffusion_xl_base/lora/config.py
@@ -2,9 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+# Both default adapters below are third-party Hugging Face repos, so they are
+# pinned to an explicit commit. Without a revision the uploader can replace the
+# weights in place: the download still succeeds, but the PCC references these
+# tests assert against no longer describe the file, so the suite goes red on a
+# change nobody here made. The pin makes that a visible 404 instead.
+
 # Default LoRA weights (UNet-only adapter).
 TEST_LORA_REPO_ID = "artificialguybr/ColoringBookRedmond-V2"
 TEST_LORA_FILENAME = "ColoringBookRedmond-ColoringBook-ColoringBookAF.safetensors"
+TEST_LORA_REVISION = "0e67e0de2b603db085e525e7f6194b24dc60033d"
 
 # Text-encoder-impacting LoRA: trains both CLIP text encoders *and* the UNet,
 # is not DoRA, and has alpha != rank (so it also exercises scale application).
@@ -12,6 +19,7 @@ TEST_LORA_FILENAME = "ColoringBookRedmond-ColoringBook-ColoringBookAF.safetensor
 # adapter above does not touch.
 TE_TEST_LORA_REPO_ID = "RalFinger/alien-style-lora-sdxl"
 TE_TEST_LORA_FILENAME = "alienzkin-sdxl.safetensors"
+TE_TEST_LORA_REVISION = "68113675e36623e483d6342548b4c031e552fb7f"
 # Directory under the CIv2 large-file cache's huggingface prefix where this
 # adapter is staged (CIv2 runners have no HF egress, so hf_hub_download cannot
 # fetch it there). Staged 2026-07-21 alongside the other SDXL LoRA fixtures.

--- a/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_fusion.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_fusion.py
@@ -193,7 +193,7 @@ def test_text_encoder_lora_fusion_pcc(mesh_device, te_lora_path):
         "text_encoder / text_encoder_2 to exercise this path."
     )
 
-    tt_pipeline.fuse_lora(lora_scale=1.0)
+    tt_pipeline.fuse_lora(lora_scale=1.0, clip_scale=1.0)
     assert tt_pipeline.get_lora_status()["text_encoder"] is True, "text-encoder LoRA was not marked fused"
 
     # PEFT reference: fuse the same LoRA into the text encoders of a fresh pipeline
@@ -224,7 +224,7 @@ def test_text_encoder_lora_fusion_pcc(mesh_device, te_lora_path):
     # adapters after merging, so there is no adapter left to detect a second merge — only
     # the manager's own fused flag prevents the delta being applied twice. A regression
     # here is silent, which is why it is asserted against the same reference weights.
-    tt_pipeline.fuse_lora(lora_scale=1.0)
+    tt_pipeline.fuse_lora(lora_scale=1.0, clip_scale=1.0)
     assert (
         tt_pipeline.get_lora_status()["text_encoder"] is True
     ), "text-encoder LoRA lost its fused status after a repeat fuse_lora()"
@@ -234,3 +234,68 @@ def test_text_encoder_lora_fusion_pcc(mesh_device, te_lora_path):
         for name, ref_tensor in reference_weights[component].items():
             assert name in refused_sd, f"{component}: fused weight {name} vanished after a repeat fuse_lora()"
             assert_with_pcc(ref_tensor, refused_sd[name], pcc=0.999)
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {},
+    ],
+    indirect=True,
+)
+@pytest.mark.skipif(
+    get_device_name() not in ["n150", "p150"],
+    reason="test_lora_fusion runs only on n150 and p150",
+)
+@torch.no_grad()
+def test_text_encoder_lora_zero_clip_scale_skips_fusion(mesh_device, te_lora_path):
+    """A clip_scale of 0.0 must skip the text-encoder fuse rather than merge a zero delta.
+
+    Covers the per-component scaling contract this PR adds: the UNet still fuses at its
+    own scale while the text encoders are left alone. The skip has to leave the fused
+    flag False as well, so status reporting stays honest and a later fuse cannot merge
+    on top of weights that were never touched.
+    """
+    # Loaded before the TT pipeline mutates anything, to compare the CLIP weights
+    # against pristine base weights.
+    reference_pipeline = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        torch_dtype=torch.float32,
+        use_safetensors=True,
+    )
+    torch_pipeline_for_tt = DiffusionPipeline.from_pretrained(
+        "stabilityai/stable-diffusion-xl-base-1.0",
+        torch_dtype=torch.float32,
+        use_safetensors=True,
+    )
+
+    pipeline_config = TtSDXLPipelineConfig(
+        num_inference_steps=50,
+        guidance_scale=5.0,
+        is_galaxy=is_galaxy(),
+        encoders_on_device=True,  # TE LoRA is only applied when encoders run on device.
+    )
+    tt_pipeline = TtSDXLPipeline(mesh_device, torch_pipeline_for_tt, pipeline_config)
+
+    tt_pipeline.load_lora_weights(te_lora_path)
+    components = tt_pipeline._lora_weights_manager.adapter_state()["text_encoder_components"]
+    assert components, (
+        "Chosen LoRA does not impact any text encoder; pick a LoRA that trains "
+        "text_encoder / text_encoder_2 to exercise this path."
+    )
+
+    tt_pipeline.fuse_lora(lora_scale=1.0, clip_scale=0.0)
+
+    status = tt_pipeline.get_lora_status()
+    assert status["text_encoder"] is False, "text-encoder LoRA reported fused despite a clip scale of 0.0"
+    assert status["unet"] is True, "UNet should still fuse at its own scale when the clip scale is 0.0"
+
+    # Byte-for-byte, not PCC: a skipped fuse must not perturb the weights at all.
+    for component in components:
+        base_sd = getattr(reference_pipeline, component).state_dict()
+        live_sd = getattr(tt_pipeline.torch_pipeline, component).state_dict()
+        for name, base_tensor in base_sd.items():
+            assert name in live_sd, f"{component}: weight {name} disappeared"
+            assert torch.equal(
+                base_tensor, live_sd[name]
+            ), f"{component}: {name} was modified despite a clip scale of 0.0"

--- a/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_fusion.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_fusion.py
@@ -291,9 +291,14 @@ def test_text_encoder_lora_zero_clip_scale_skips_fusion(mesh_device, te_lora_pat
     assert status["unet"] is True, "UNet should still fuse at its own scale when the clip scale is 0.0"
 
     # Byte-for-byte, not PCC: a skipped fuse must not perturb the weights at all.
+    #
+    # Skipping the fuse also skips the unload that strips the PEFT wrapper, so the live
+    # encoders still carry it and their raw keys read ...q_proj.base_layer.weight. The
+    # reference pipeline never had an adapter, so normalize the live side to its plain
+    # names before comparing; otherwise every weight looks like it went missing.
     for component in components:
         base_sd = getattr(reference_pipeline, component).state_dict()
-        live_sd = getattr(tt_pipeline.torch_pipeline, component).state_dict()
+        live_sd = _get_lora_impacted_weights(getattr(tt_pipeline.torch_pipeline, component).state_dict())
         for name, base_tensor in base_sd.items():
             assert name in live_sd, f"{component}: weight {name} disappeared"
             assert torch.equal(

--- a/models/demos/stable_diffusion_xl_base/lora/tt_lora_weights_manager.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tt_lora_weights_manager.py
@@ -267,8 +267,15 @@ class TtLoRAWeightsManager:
         The caller is responsible for establishing the mesh-mapper context for the UNet
         device work — see TtSDXLPipeline.fuse_lora.
         """
+        # Callers that pass an optional scale positionally hand us None when it is unset
+        # (e.g. tt-inference-server's SDXL runners). Treat that as "full strength" rather
+        # than letting it reach the delta arithmetic as None.
+        if lora_scale is None:
+            lora_scale = 1.0
         if clip_scale is None:
             clip_scale = lora_scale
+
+        logger.info(f"Fusing LoRA weights (unet scale={lora_scale}, clip scale={clip_scale})...")
 
         if self.has_lora_adapter():
             self._fuse_unet_lora(lora_scale)

--- a/models/demos/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
+++ b/models/demos/stable_diffusion_xl_base/tt/tt_sdxl_pipeline.py
@@ -188,27 +188,16 @@ class TtSDXLPipeline(LightweightModule):
         )
         return shape
 
-    def fuse_lora(self, lora_scale_unet=1.0, lora_scale_clip=None, lora_scale=None):
-        # Backward compat: a single lora_scale (positional or keyword) applies to both.
-        if lora_scale is not None:
-            lora_scale_unet = lora_scale
-            if lora_scale_clip is None:
-                lora_scale_clip = lora_scale
-        # Callers that pass an optional scale positionally hand us None when it is unset
-        # (e.g. tt-inference-server's SDXL runners). Treat that as "full strength" rather
-        # than letting it reach the delta arithmetic as None.
-        if lora_scale_unet is None:
-            lora_scale_unet = 1.0
-        if lora_scale_clip is None:
-            lora_scale_clip = lora_scale_unet
-
-        logger.info(f"Fusing LoRA weights (unet scale={lora_scale_unet}, clip scale={lora_scale_clip})...")
+    def fuse_lora(self, lora_scale=1.0, clip_scale=None):
+        # Scale resolution (None handling, clip defaulting to the UNet scale) lives in the
+        # manager, which owns every other piece of LoRA logic.
+        #
         # The manager's from_torch calls pass no mesh_mapper, so the replicate context
         # must be established here. The text-encoder step runs inside it too: every
         # from_torch on the encoder reload path passes mesh_mapper explicitly, so the
         # ambient context cannot reach it (see models/tt_dit/utils/tensor.py).
         with ttnn.distribute(ttnn.ReplicateTensorToMesh(self.ttnn_device)):
-            self._lora_weights_manager.fuse_lora(lora_scale_unet, clip_scale=lora_scale_clip)
+            self._lora_weights_manager.fuse_lora(lora_scale, clip_scale=clip_scale)
 
     def load_lora_weights(self, lora_path):
         self._lora_weights_manager.load_lora_weights(lora_path)


### PR DESCRIPTION
### PR Category
Test Only

### Summary
The two default SDXL LoRA test adapters are third-party Hugging Face repos, fetched by repo id and filename with no revision. If either uploader replaces the weights in place, the download still succeeds and the file is still valid, but the PCC references these tests assert against no longer describe it. The result is a red Tier 2 nightly caused by a change nobody in this repo made, and there is no skip fallback for it because nothing failed to download.

This is a live risk rather than a theoretical one: `artificialguybr/ColoringBookRedmond-V2` was last modified 2026-07-20.

Both adapters are now pinned to their current commit:

| Adapter | Revision |
|---|---|
| `artificialguybr/ColoringBookRedmond-V2` | `0e67e0de2b603db085e525e7f6194b24dc60033d` |
| `RalFinger/alien-style-lora-sdxl` | `68113675e36623e483d6342548b4c031e552fb7f` |

Both were verified against `huggingface_hub` before pinning: the resolved commit hash matches the pin, and the files are reachable at that revision (170,540,036 and 228,452,884 bytes).

### Notes for reviewers

**The pin applies only to the built-in defaults.** A caller passing `--lora-hf-repo` / `--lora-hf-filename` keeps HF's default branch, since a revision from our adapter does not describe someone else's repo. `--lora-weights` (local file) is untouched.

**Two things this deliberately does not cover, worth a decision:**

1. **The CIv2 large-file cache path is unaffected.** For the text-encoder adapter, `_fetch_lora_from_ci_v2_cache` returns before HF is consulted, so the pin never applies on CIv2. That copy's integrity rests on the cache being an internal, controlled store. Covering it too would mean a checksum assertion on the resolved file, which felt like a separate change. Happy to add it here if reviewers prefer.

2. **CIv1 runners use `local_files_only=True`.** If a runner's baked HF cache holds the adapter at a different snapshot than the pinned one, the fetch misses and the test skips rather than passes. A skip is the safe direction and it is visible in the report, but it is a coverage loss. I am running Tier 2 unit tests on this branch across `wh_n150`, `wh_n300`, and `bh_p150b_civ2` specifically to see whether that happens. If the CIv1 caches do not carry the pinned revision, the options are to stage both adapters in the large-file cache and fetch from there on both CI flavours, or to fall back to unpinned with a loud warning.

**Baseline for comparison:** run [31581010869](https://github.com/tenstorrent/tt-metal/actions/runs/31581010869) on the parent branch is fully green for SDXL, LoRA included, on all three SKUs. Any skip or failure that appears here and not there is attributable to the pin.

Based on `stisi/sdxl-per-component-lora`, so this diff is just the pin.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=stisi/sdxl-lora-pin-adapter-revisions)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:stisi/sdxl-lora-pin-adapter-revisions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=stisi/sdxl-lora-pin-adapter-revisions)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:stisi/sdxl-lora-pin-adapter-revisions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=stisi/sdxl-lora-pin-adapter-revisions)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:stisi/sdxl-lora-pin-adapter-revisions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=stisi/sdxl-lora-pin-adapter-revisions)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:stisi/sdxl-lora-pin-adapter-revisions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=stisi/sdxl-lora-pin-adapter-revisions)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:stisi/sdxl-lora-pin-adapter-revisions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=stisi/sdxl-lora-pin-adapter-revisions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:stisi/sdxl-lora-pin-adapter-revisions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=stisi/sdxl-lora-pin-adapter-revisions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:stisi/sdxl-lora-pin-adapter-revisions)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=stisi/sdxl-lora-pin-adapter-revisions)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:stisi/sdxl-lora-pin-adapter-revisions)