### PR TITLE
[LLK][Feature] Implement addcmul for Quasar

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_addcmul.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_addcmul.h
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "ckernel_addrmod.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_converter.h"
+#include "ckernel_trisc_common.h"
+#include "cmath_common.h"
+#include "lltt.h"
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+/**
+ * @brief Per-lane fused multiply-add: @c out = a + value * b * c.
+ *
+ * Each lane costs one SFPMUL (@c value * b) feeding one SFPMAD (@c (value*b) * c + a).
+ *
+ * @tparam APPROXIMATION_MODE: Unused for @c addcmul; kept for API parity with other
+ *         SFPU kernels.
+ * @tparam is_fp32_dest_acc_en: Whether Dest is 32-bit. When false the fp32 result is
+ *         rounded down to the Dest width before the store.
+ * @tparam DST_FORMAT: Dest data format, values = <Float32/Float16_b/Float16>. Selects
+ *         the 16-bit rounding target; ignored when @c is_fp32_dest_acc_en is true.
+ * @tparam ITERATIONS: Inner SFPU row-pair count per face. Defaults to 8 for the
+ *         standard 16-row face. The outer per-face loop and section base setup are
+ *         owned by @c _llk_math_eltwise_ternary_sfpu_params_.
+ * @tparam TILE_SHAPE: Destination tile shape used to calculate operand offsets.
+ *
+ * @param dst_index_in0: DEST tile index holding @c a, the addend.
+ * @param dst_index_in1: DEST tile index holding @c b, the first multiplicand.
+ * @param dst_index_in2: DEST tile index holding @c c, the second multiplicand.
+ * @param dst_index_out: DEST tile index that receives the result; may alias an input.
+ * @param value: Scalar multiplier as a raw fp32 bit pattern, broadcast to every lane.
+ * @note Call @ref _llk_math_eltwise_ternary_sfpu_init_ with @c SfpuType::addcmul before
+ *       this function.
+ */
+template <
+    bool APPROXIMATION_MODE,
+    bool is_fp32_dest_acc_en,
+    DataFormat DST_FORMAT,
+    int ITERATIONS = SFPU_ITERATIONS,
+    trisc::DstTileShape TILE_SHAPE = trisc::DstTileShape::Tile32x32>
+inline void calculate_addcmul(
+    const std::uint32_t dst_index_in0,
+    const std::uint32_t dst_index_in1,
+    const std::uint32_t dst_index_in2,
+    const std::uint32_t dst_index_out,
+    const std::uint32_t value) {
+    static_assert(
+        DST_FORMAT == DataFormat::Float32 || DST_FORMAT == DataFormat::Float16_b || DST_FORMAT == DataFormat::Float16,
+        "calculate_addcmul() is lanewise FP32 math; only Float32, Float16_b and Float16 Dest formats are supported.");
+
+    constexpr std::uint32_t dst_tile_size_sfpi = 1U << (trisc::get_dest_tile_size_log2(TILE_SHAPE) - 1);
+
+    const std::uint32_t off_in0 = dst_index_in0 * dst_tile_size_sfpi;
+    const std::uint32_t off_in1 = dst_index_in1 * dst_tile_size_sfpi;
+    const std::uint32_t off_in2 = dst_index_in2 * dst_tile_size_sfpi;
+    const std::uint32_t off_out = dst_index_out * dst_tile_size_sfpi;
+
+    // Loop-invariant, so it is decoded once and stays in one LREG.
+    const sfpi::vFloat value_float = Converter::as_float(value);
+
+    // Full unroll hands the scheduler eight independent MUL->MAD chains to interleave,
+    // covering the MAD latency shadow without hand-placed NOPs.
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat in0 = sfpi::dst_reg[off_in0];
+        sfpi::vFloat in1 = sfpi::dst_reg[off_in1];
+        sfpi::vFloat in2 = sfpi::dst_reg[off_in2];
+
+        sfpi::vFloat prod = value_float * in1;
+        sfpi::vFloat result = prod * in2 + in0;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            // SFPSTORE truncates, so round to nearest before narrowing to a 16-bit Dest.
+            if constexpr (DST_FORMAT == DataFormat::Float16) {
+                result = sfpi::convert<sfpi::vFloat16a>(result, sfpi::RoundMode::Nearest);
+            } else {
+                result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
+            }
+        }
+
+        sfpi::dst_reg[off_out] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_addcmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_addcmul_quasar.py
@@ -1,0 +1,318 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.golden_generators import TernarySFPUGolden, get_golden_generator
+from helpers.llk_params import (
+    DataCopyType,
+    DestAccumulation,
+    ImpliedMathFormat,
+    MathOperation,
+    UnpackerEngine,
+    VectorMode,
+    format_dict,
+)
+from helpers.param_config import (
+    generate_sfpu_format_dest_acc_combinations,
+    input_output_formats,
+    parametrize,
+)
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import generate_stimuli
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    DATA_COPY_TYPE,
+    DEST_INDEX,
+    DEST_SYNC,
+    IMPLIED_MATH_FORMAT,
+    MATH_OP,
+    NUM_FACES,
+    SFPU_TERNARY_SCALAR,
+    TEST_FACE_DIMS,
+    TILE_COUNT,
+    UNPACKER_ENGINE_SEL,
+    VECTOR_MODE,
+)
+from helpers.utils import passed_test
+
+FACE_SIZE = 16 * 16
+
+# Scalar multipliers, as raw fp32 bit patterns (the kernel takes `std::uint32_t value`
+# and reinterprets it). 1.5f is deliberately not a power of two so a botched scalar
+# decode cannot pass; -1.0f additionally covers a negative multiplier.
+_SCALAR_BITS_1_5 = 0x3FC00000
+_SCALAR_BITS_NEG_1 = 0xBF800000
+
+# Map each VectorMode to the set of face indices the LLK dispatch processes.
+# Faces outside the set keep whatever the producer left in Dest (the `a` tile
+# in this test, since the output aliases it), so the per-mode assertion is
+# restricted to processed faces.
+_PROCESSED_FACES = {
+    VectorMode.None_: (0,),
+    VectorMode.R: (0, 1),
+    VectorMode.C: (0, 2),
+    VectorMode.RC: (0, 1, 2, 3),
+}
+
+
+def _processed_face_mask(vector_mode: VectorMode, num_faces: int) -> torch.Tensor:
+    """1-D bool mask selecting the elements of a flat tile that ``vector_mode`` writes."""
+    mask = torch.zeros(num_faces * FACE_SIZE, dtype=torch.bool)
+    for face in _PROCESSED_FACES[vector_mode]:
+        mask[face * FACE_SIZE : (face + 1) * FACE_SIZE] = True
+    return mask
+
+
+def _get_valid_formats_dest_acc():
+    # addcmul is lanewise FP32 math (SFPMUL + SFPMAD) with an fp32 scalar, so the
+    # kernel's static_assert allows only Float32 / Float16_b / Float16 Dest formats.
+    formats = input_output_formats(
+        [
+            DataFormat.Float16,
+            DataFormat.Float16_b,
+            DataFormat.Float32,
+        ]
+    )
+    return [
+        (fmt, dest_acc)
+        for fmt, dest_acc in generate_sfpu_format_dest_acc_combinations(formats)
+        if not (
+            fmt.input_format == DataFormat.Float16 and dest_acc == DestAccumulation.Yes
+        )
+    ]
+
+
+def _get_valid_implied_math_formats(fmt: FormatConfig):
+    if fmt.input_format.is_mx_format():
+        return [ImpliedMathFormat.Yes]
+    return [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
+
+
+def _is_unpack_to_dest(fmt: FormatConfig, dest_acc: DestAccumulation) -> bool:
+    """UNPACK→DEST is selected only for 32-bit inputs with dest_acc=Yes."""
+    return fmt.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
+
+
+@pytest.mark.quasar
+@parametrize(
+    formats_dest_acc=_get_valid_formats_dest_acc(),
+    implied_math_format=lambda formats_dest_acc: _get_valid_implied_math_formats(
+        formats_dest_acc[0]
+    ),
+    vector_mode=[VectorMode.None_, VectorMode.R, VectorMode.C, VectorMode.RC],
+)
+def test_sfpu_addcmul_quasar(formats_dest_acc, implied_math_format, vector_mode):
+    """
+    Test ternary `addcmul(a, b, c, value) -> a + value * b * c` on Quasar.
+
+    The C++ test source packs 3 input tiles (a, b, c) into `buffer_A`, gets them
+    into DEST at tile indices 0, 1, 2 (FPU datacopy, or UNPACK→DEST for 32-bit
+    inputs), then runs the SFPU `addcmul` kernel over the faces selected by
+    `vector_mode`, writing output back to DEST tile 0. PACK writes DEST tile 0
+    out to `buffer_Res`.
+
+    `vector_mode` covers all four face-selection modes; unprocessed faces are
+    excluded from the golden assertion since Dest retains the `a` tile there.
+    Both `dest_acc` arms are swept: `dest_acc=No` is the only path that emits the
+    kernel's SFP_STOCH_RND narrowing, and Float16 vs Float16_b inputs select its
+    two different rounding modes (fp32→fp16a vs fp32→fp16b).
+    """
+    formats, dest_acc = formats_dest_acc
+    input_dimensions = [32, 32]
+    torch_format_in = format_dict[formats.input_format]
+
+    # Default float stimuli are uniform in [0.1, 1.1], so a + 1.5*b*c stays inside
+    # [0.11, 2.92] — no overflow/underflow in any of the three swept Dest formats.
+    torch.manual_seed(42)
+    src_a_raw, tile_cnt_single, _, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+    )
+    torch.manual_seed(43)
+    src_b_raw, _, _, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+    )
+    torch.manual_seed(44)
+    src_c_raw, _, _, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+    )
+
+    operand_a = src_a_raw.to(torch_format_in)
+    operand_b = src_b_raw.to(torch_format_in)
+    operand_c = src_c_raw.to(torch_format_in)
+
+    src_A = torch.cat([operand_a, operand_b, operand_c])
+    tile_cnt_A = tile_cnt_single * 3
+    num_faces = 4
+
+    generate_golden = get_golden_generator(TernarySFPUGolden)
+    golden_tensor = generate_golden(
+        MathOperation.SfpuAddcmul,
+        operand_a,
+        operand_b,
+        operand_c,
+        _SCALAR_BITS_1_5,
+        formats.output_format,
+    )
+    torch_format_out = format_dict[formats.output_format]
+
+    unpack_to_dest = _is_unpack_to_dest(formats, dest_acc)
+    src_B_dummy = torch.zeros_like(operand_a)
+
+    configuration = TestConfig(
+        "sources/quasar/sfpu_addcmul_quasar_test.cpp",
+        formats,
+        templates=[
+            MATH_OP(mathop=MathOperation.SfpuAddcmul),
+            IMPLIED_MATH_FORMAT(implied_math_format),
+            DATA_COPY_TYPE(DataCopyType.A2D),
+            UNPACKER_ENGINE_SEL(
+                UnpackerEngine.UnpDest if unpack_to_dest else UnpackerEngine.UnpA
+            ),
+            DEST_SYNC(),
+            VECTOR_MODE(vector_mode),
+            SFPU_TERNARY_SCALAR(ternary_scalar_bits=_SCALAR_BITS_1_5),
+        ],
+        runtimes=[
+            TILE_COUNT(tile_cnt_A),
+            NUM_FACES(num_faces),
+            TEST_FACE_DIMS(),
+            DEST_INDEX(0),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B_dummy,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_single,
+            tile_count_res=1,
+            num_faces=num_faces,
+        ),
+        unpack_to_dest=unpack_to_dest,
+        dest_acc=dest_acc,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), "Result tensor and golden tensor are not of the same length"
+
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format_out)
+    mask = _processed_face_mask(vector_mode, num_faces)
+    assert passed_test(
+        golden_tensor[mask], res_tensor[mask], formats.output_format
+    ), "Assert against golden failed"
+
+
+@pytest.mark.quasar
+@parametrize(
+    formats_dest_acc=_get_valid_formats_dest_acc()[:3],
+    implied_math_format=lambda formats_dest_acc: _get_valid_implied_math_formats(
+        formats_dest_acc[0]
+    ),
+    vector_mode=[VectorMode.None_, VectorMode.R, VectorMode.C, VectorMode.RC],
+    # Not wrapped in runtime(): the compile-producer collection must select the same
+    # variant count the simulator executes, or run_test.sh classifies the run
+    # `execution_count_exceeds_selection` (infra_error) even when every variant passes.
+    dest_index=[0, 1],
+)
+def test_sfpu_addcmul_mcw_quasar(
+    formats_dest_acc, implied_math_format, vector_mode, dest_index
+):
+    """
+    Deterministic addcmul test — alternating 0/1 `a` pattern with known b and c
+    scalars (2 and 11) and a negative multiplier (-1.0f), so every output is an
+    exactly representable -22 / -21.
+
+    Runs through the same C++ harness as `test_sfpu_addcmul_quasar`, including a
+    nonzero Dest tile offset. If this fails but the stimulus-driven test passes,
+    the problem is in stimulus generation rather than the kernel.
+    """
+    formats, dest_acc = formats_dest_acc
+    torch_format_in = format_dict[formats.input_format]
+    input_dimensions = [32, 32]
+    height, width = input_dimensions
+
+    pattern = torch.arange(height * width) % 2
+    operand_a = pattern.view(height, width).to(torch_format_in).flatten()
+    operand_b = (torch.ones(height, width, dtype=torch_format_in) * 2).flatten()
+    operand_c = (torch.ones(height, width, dtype=torch_format_in) * 11).flatten()
+
+    tile_cnt_single = 1
+    src_A = torch.cat([operand_a, operand_b, operand_c])
+    tile_cnt_A = tile_cnt_single * 3
+    num_faces = 4
+
+    generate_golden = get_golden_generator(TernarySFPUGolden)
+    golden_tensor = generate_golden(
+        MathOperation.SfpuAddcmul,
+        operand_a,
+        operand_b,
+        operand_c,
+        _SCALAR_BITS_NEG_1,
+        formats.output_format,
+    )
+    torch_format_out = format_dict[formats.output_format]
+
+    unpack_to_dest = _is_unpack_to_dest(formats, dest_acc)
+    src_B_dummy = torch.zeros_like(operand_a)
+
+    configuration = TestConfig(
+        "sources/quasar/sfpu_addcmul_quasar_test.cpp",
+        formats,
+        templates=[
+            MATH_OP(mathop=MathOperation.SfpuAddcmul),
+            IMPLIED_MATH_FORMAT(implied_math_format),
+            DATA_COPY_TYPE(DataCopyType.A2D),
+            UNPACKER_ENGINE_SEL(
+                UnpackerEngine.UnpDest if unpack_to_dest else UnpackerEngine.UnpA
+            ),
+            DEST_SYNC(),
+            VECTOR_MODE(vector_mode),
+            SFPU_TERNARY_SCALAR(ternary_scalar_bits=_SCALAR_BITS_NEG_1),
+        ],
+        runtimes=[
+            TILE_COUNT(tile_cnt_A),
+            NUM_FACES(num_faces),
+            TEST_FACE_DIMS(),
+            DEST_INDEX(dest_index),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B_dummy,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_single,
+            tile_count_res=1,
+            num_faces=num_faces,
+        ),
+        unpack_to_dest=unpack_to_dest,
+        dest_acc=dest_acc,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), "Result tensor and golden tensor are not of the same length"
+
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format_out)
+    mask = _processed_face_mask(vector_mode, num_faces)
+    assert passed_test(
+        golden_tensor[mask], res_tensor[mask], formats.output_format
+    ), "Assert against golden failed"

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_addcmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_addcmul_quasar_test.cpp
@@ -1,0 +1,208 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "llk_memory_checks.h"
+#include "sfpu_stub.h"
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_math_common.h"
+#include "llk_unpack_common.h"
+#include "llk_unpack_unary_operand.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t buf_desc_id          = 0;
+    const std::uint32_t num_tiles_per_unpack = params.TILE_CNT;
+
+    // UNPACK-to-DEST path: UNPACK writes DEST; SFPU reads/writes DEST; PACK reads DEST.
+    // FPU path: UNPACK writes SrcA; FPU datacopy writes DEST; SFPU reads/writes DEST; PACK reads DEST.
+    constexpr auto unpack_dest = unpack_to_dest ? dest_dvalid_client::UNPACK : dest_dvalid_client::FPU;
+    set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({unpack_dest, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+
+    if constexpr (unpack_to_dest)
+    {
+        _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*is_int_fpu_en*/>();
+    }
+
+    buffer_descriptor_u bd_val = {0};
+    bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_A[0]);
+    bd_val.f.format            = static_cast<std::uint8_t>(formats.unpack_A_src);
+    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim             = params.num_faces;
+
+    tdma_descriptor_t td_val;
+    td_val.buf_desc        = bd_val;
+    td_val.buf_desc_id     = buf_desc_id;
+    td_val.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
+    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+
+    if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
+    {
+        // If Dst is 32b and MATH uses FPU datacopy (MOVA2D → ELWADD fallback), we need both SrcA and SrcB formats configured.
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val, td_val);
+    }
+    else
+    {
+        _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val);
+    }
+
+    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
+        buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_unpack);
+
+    // Unpacks all three input tiles (a, b, c) from buffer_A in one call;
+    // tile count is taken from num_tiles_per_unpack set during init.
+    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0 /*l1_tile_idx*/, ckernel::DEFAULT_TENSOR_SHAPE);
+
+    if constexpr (unpack_to_dest)
+    {
+        // Signals DEST writes are done; not called on the FPU path since UNPACK doesn't touch DEST there.
+        _llk_unpack_dest_dvalid_section_done_<dest_sync>();
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+const bool is_int_fpu_en = false;
+
+#include "cfg_defines.h"
+#include "cmath_common.h"
+#include "llk_math_common.h"
+#include "llk_math_eltwise_unary_datacopy.h"
+#include "llk_sfpu/ckernel_sfpu_addcmul.h"
+#include "llk_sfpu/llk_math_eltwise_ternary_sfpu_macros.h"
+#include "params.h"
+
+using namespace ckernel;
+using namespace ckernel::math;
+using namespace ckernel::sfpu;
+
+// Runs calculate_addcmul over the faces selected by VECTOR_MODE: a=base+0, b=base+1,
+// c=base+2, result written back to base+0. Faces outside the selected set keep whatever
+// the producer wrote into Dest before SFPU ran (the `a` tile, here), so Python asserts
+// only processed faces.
+template <DataFormat DST_FORMAT>
+inline void call_addcmul(const std::uint32_t dst_base)
+{
+    SFPU_TERNARY_CALL(
+        dest_sync,
+        is_fp32_dest_acc_en,
+        calculate_addcmul,
+        (false /*APPROXIMATION_MODE*/, is_fp32_dest_acc_en, DST_FORMAT, SFPU_ITERATIONS),
+        dst_base + 0u /*DST_IN0*/,
+        dst_base + 1u /*DST_IN1*/,
+        dst_base + 2u /*DST_IN2*/,
+        dst_base + 0u /*DST_OUT*/,
+        VECTOR_MODE,
+        SFPU_TERNARY_SCALAR);
+}
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    if constexpr (unpack_to_dest)
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+    else
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+
+    DataFormat src_format = static_cast<DataFormat>(formats.math);
+    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, is_int_fpu_en>(src_format, src_format);
+
+    if constexpr (!unpack_to_dest)
+    {
+        const std::uint32_t num_rows = params.num_faces * params.TEST_FACE_R_DIM;
+        _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(num_rows, 1 /*num_matrices*/);
+
+        for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+        {
+            _llk_math_eltwise_unary_datacopy_(params.DST_INDEX + i);
+        }
+
+        _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+    }
+
+    SFPU_TERNARY_INIT(addcmul);
+
+    // calculate_addcmul takes the Dest format as a template argument (it picks the 16-bit
+    // rounding mode), so switch the runtime format into a compile-time instantiation.
+    const DataFormat sfpu_format = static_cast<DataFormat>(formats.sfpu_math);
+    switch (sfpu_format)
+    {
+        case DataFormat::Float32:
+            call_addcmul<DataFormat::Float32>(params.DST_INDEX);
+            break;
+
+        case DataFormat::Float16:
+            call_addcmul<DataFormat::Float16>(params.DST_INDEX);
+            break;
+
+        default:
+            call_addcmul<DataFormat::Float16_b>(params.DST_INDEX);
+            break;
+    }
+
+    _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "cfg_defines.h"
+#include "llk_pack.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t buf_desc_id        = 8;
+    const std::uint32_t num_tiles_per_pack = 1;
+
+    constexpr auto unpack_dest = unpack_to_dest ? dest_dvalid_client::UNPACK : dest_dvalid_client::FPU;
+    set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({unpack_dest, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+
+    buffer_descriptor_u bd_val = {0};
+    bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_Res[0]);
+    bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
+    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim             = params.num_faces;
+
+    tdma_descriptor_t tdma_desc;
+    tdma_desc.buf_desc        = bd_val;
+    tdma_desc.buf_desc_id     = buf_desc_id;
+    tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
+    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+
+    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
+    _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+
+    // Packs only the result tile (DEST[DST_INDEX]); addcmul produces one output tile
+    // regardless of how many input tiles were loaded.
+    _llk_pack_(params.DST_INDEX, 0 /*start_l1_tile_idx*/, ckernel::DEFAULT_TENSOR_SHAPE);
+    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+}
+
+#endif

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
@@ -120,6 +120,7 @@ enum class SfpuType : std::uint32_t
     greater_than_zero,
     less_than_equal_zero,
     greater_than_equal_zero,
+    addcmul,
 };
 
 enum class DstSync : std::uint8_t


### PR DESCRIPTION
### PR Category

Feature

### Summary

Implements the `addcmul` kernel for `quasar` from CodeGen run `2026-08-12_addcmul_quasar_10b99e00`.

Generated file: `tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_addcmul.h`.

CodeGen reported 128/128 tests passing.

### Notes for reviewers

This is an AI-generated draft. Please review the implementation and the recorded verification before marking it ready.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk_code_gen/generated-addcmul-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk_code_gen/generated-addcmul-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk_code_gen/generated-addcmul-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk_code_gen/generated-addcmul-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk_code_gen/generated-addcmul-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk_code_gen/generated-addcmul-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk_code_gen/generated-addcmul-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk_code_gen/generated-addcmul-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk_code_gen/generated-addcmul-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk_code_gen/generated-addcmul-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk_code_gen/generated-addcmul-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk_code_gen/generated-addcmul-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk_code_gen/generated-addcmul-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk_code_gen/generated-addcmul-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk_code_gen/generated-addcmul-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk_code_gen/generated-addcmul-quasar-v1)