### PR TITLE
[LLK][Feature] Implement activations for Quasar

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_activations.h
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel_defs.h"
+#include "ckernel_trisc_common.h"
+#include "cmath_common.h"
+#include "llk_defs.h"
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+// hardsigmoid(x) = clamp(x/6 + 1/2, 0, 1)
+constexpr float HARDSIGMOID_SLOPE = 0.1666666716337204f;  // 1/6 in fp32 (0x3E2AAAAB); not bf16-exact
+constexpr float HARDSIGMOID_SHIFT = 0.5f;
+constexpr float HARDSIGMOID_UPPER = 1.0f;  // clamp ceiling, reached at x = 3
+constexpr float HARDSIGMOID_LOWER = 0.0f;  // clamp floor, reached at x = -3
+
+// General template structure to implement activations. The primary template is left undefined, so an
+// activation without a specialization is a compile error.
+template <bool APPROXIMATION_MODE, ActivationType ACTIVATION_TYPE>
+struct ActivationImpl;
+
+// Two-sided clamp to [0, 1]. Quasar has no equivalent of Blackhole's _relu_max_body_ (its relu family
+// is raw TTI), and sfpi::min / sfpi::max lower to SFPSWAP without the float-compare bit. Compares are
+// strict because a float >= is unreliable at the boundary itself on Quasar (issue #50208); both knees
+// land exactly on 1.0 / 0.0, so > / < are exact there.
+sfpi_inline sfpi::vFloat hardsigmoid_clamp(sfpi::vFloat val) {
+    sfpi::vFloat result = val;
+    v_if(result > HARDSIGMOID_UPPER) { result = HARDSIGMOID_UPPER; }
+    v_endif;
+    v_if(result < HARDSIGMOID_LOWER) { result = HARDSIGMOID_LOWER; }
+    v_endif;
+    return result;
+}
+
+// Specialization for the HARDSIGMOID activation
+template <bool APPROXIMATION_MODE>
+struct ActivationImpl<APPROXIMATION_MODE, ActivationType::Hardsigmoid> {
+    static inline void apply(sfpi::vFloat& v) {
+        // affine ramp x/6 + 1/2 in one SFPMAD over the constants hardsigmoid_init programmed
+        sfpi::vFloat tmp = (v * sfpi::vConstFloatPrgm0) + sfpi::vConstFloatPrgm1;
+        v = hardsigmoid_clamp(tmp);
+    }
+};
+
+// Dispatch wrapper function
+template <bool APPROXIMATION_MODE, ActivationType ACTIVATION_TYPE>
+inline void apply_activation(sfpi::vFloat& v) {
+    ActivationImpl<APPROXIMATION_MODE, ACTIVATION_TYPE>::apply(v);
+}
+
+/**
+ * @brief Program the fp32 ramp constants the Hardsigmoid body reads.
+ *
+ * @tparam APPROXIMATION_MODE: accepted for ABI parity but ignored (hardsigmoid is exact).
+ * @note The surrounding @ref llk_math_eltwise_unary_sfpu_init resets the counters, so unlike the
+ *       Blackhole kernel this init only programs constants.
+ */
+template <bool APPROXIMATION_MODE>
+inline void hardsigmoid_init() {
+    sfpi::vConstFloatPrgm0 = HARDSIGMOID_SLOPE;
+    sfpi::vConstFloatPrgm1 = HARDSIGMOID_SHIFT;
+}
+
+/**
+ * @brief Apply an activation in-place over a Dest tile.
+ *
+ * @tparam APPROXIMATION_MODE: select the approximate body where an activation offers one; Hardsigmoid
+ *         ignores it (it is exact).
+ * @tparam ACTIVATION_TYPE: activation to apply; picks the @ref ActivationImpl body at compile time.
+ * @tparam ITERATIONS: Number of SFPU loop iterations over the Dest tile.
+ * @note For ActivationType::Hardsigmoid, call @ref hardsigmoid_init first — it programs the ramp
+ *       constants (vConstFloatPrgm0/1) the body reads.
+ */
+template <bool APPROXIMATION_MODE, ActivationType ACTIVATION_TYPE, int ITERATIONS = SFPU_ITERATIONS>
+inline void calculate_activation() {
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        apply_activation<APPROXIMATION_MODE, ACTIVATION_TYPE>(v);
+        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
@@ -16,6 +16,7 @@
 //    call_unary_sfpu_operation_quasar() (and to init_unary_sfpu_operation_quasar()
 //    if the op needs an init step).
 #include "experimental/ckernel_sfpu_abs.h"
+#include "llk_sfpu/ckernel_sfpu_activations.h"
 #include "llk_sfpu/ckernel_sfpu_clamp.h"
 #include "llk_sfpu/ckernel_sfpu_comp.h"
 #include "llk_sfpu/ckernel_sfpu_exp.h"
@@ -123,6 +124,10 @@ void init_unary_sfpu_operation_quasar()
     else if constexpr (is_trig_op(OPERATION))
     {
         init_trigonometry<OPERATION, is_fp32_dest_acc_en>();
+    }
+    else if constexpr (OPERATION == SfpuType::hardsigmoid)
+    {
+        hardsigmoid_init<APPROX>();
     }
 }
 
@@ -299,6 +304,12 @@ void call_unary_sfpu_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_f
             VectorMode::RC,
             static_cast<std::uint32_t>(0xBF800000),  // min = -1.0 (fp32)
             static_cast<std::uint32_t>(0x3F800000)); // max = +1.0 (fp32)
+    }
+    else if constexpr (OPERATION == SfpuType::hardsigmoid)
+    {
+        // One op-templated activations kernel; ActivationType picks the body at compile time.
+        SFPU_UNARY_CALL(
+            DST_SYNC, is_fp32_dest_acc_en, calculate_activation, (APPROX, ckernel::ActivationType::Hardsigmoid, ITERATIONS), dst_index, VectorMode::RC);
     }
     else if constexpr (is_zero_comp_op(OPERATION))
     {

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
@@ -373,6 +373,14 @@ def prepare_inputs_for_operation(
         max_val = 30.0
         src_A = min_val + src_A.to(torch.float32) * (max_val - min_val)
         src_A = src_A.to(torch_format)
+    elif mathop == MathOperation.Hardsigmoid:
+        # hardsigmoid(x) = clamp(x/6 + 1/2, 0, 1): span past both knees (x = -3 and x = +3) so the
+        # lower clamp, the affine ramp, and the upper clamp are all covered (mirrors sfpu_domains'
+        # Hardsigmoid spec).
+        min_val = -4.0
+        max_val = 4.0
+        src_A = min_val + src_A.to(torch.float32) * (max_val - min_val)
+        src_A = src_A.to(torch_format)
     # else: keep src_A as-is
 
     return src_A
@@ -655,6 +663,9 @@ OP_CONFIGS = [
     OpConfig(MathOperation.Clamp, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Neg, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Softplus, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
+    OpConfig(
+        MathOperation.Hardsigmoid, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True
+    ),
     OpConfig(MathOperation.Typecast, TENSOR_DIMS, DEST_SYNC_MODES),
     # Trigonometry / inverse-hyperbolic ops: same matrix as the other transcendentals,
     # fed a uniform [0, 1] stimulus that prepare_trig_inputs maps into each op's domain.

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_defs.h
@@ -78,6 +78,16 @@ enum class BinaryOp : std::uint8_t
     DEQUANT,
 };
 
+// Activation selected by the activations kernel; values mirror the other architectures.
+enum class ActivationType
+{
+    Celu        = 0,
+    Elu         = 1,
+    Gelu        = 2,
+    Hardtanh    = 3,
+    Hardsigmoid = 4,
+};
+
 // For instructions that address lower/upper 16 bits of a register
 #define LO_16(REG) (2 * (REG))
 #define HI_16(REG) (2 * (REG) + 1)

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
@@ -120,6 +120,7 @@ enum class SfpuType : std::uint32_t
     greater_than_zero,
     less_than_equal_zero,
     greater_than_equal_zero,
+    hardsigmoid,
 };
 
 enum class DstSync : std::uint8_t


### PR DESCRIPTION
### PR Category

Feature

### Summary

Implements the `activations` kernel for `quasar` from CodeGen run `2026-08-12_activations_quasar_dc6291f7`.

Generated file: `tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_activations.h`.

CodeGen reported 104/104 tests passing.

### Notes for reviewers

This is an AI-generated draft. Please review the implementation and the recorded verification before marking it ready.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk_code_gen/generated-activations-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk_code_gen/generated-activations-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk_code_gen/generated-activations-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk_code_gen/generated-activations-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk_code_gen/generated-activations-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk_code_gen/generated-activations-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk_code_gen/generated-activations-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk_code_gen/generated-activations-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk_code_gen/generated-activations-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk_code_gen/generated-activations-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk_code_gen/generated-activations-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk_code_gen/generated-activations-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk_code_gen/generated-activations-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk_code_gen/generated-activations-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk_code_gen/generated-activations-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk_code_gen/generated-activations-quasar-v1)