### PR TITLE
[LLK][Feature] Implement lerp for Quasar

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_lerp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_lerp.h
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_sfpu_binary.h"
+#include "ckernel_trisc_common.h"
+#include "llk_defs.h"
+#include "sfpi.h"
+
+namespace ckernel::sfpu {
+
+/**
+ * @brief Per-lane linear interpolation: @c out = start + weight * (end - start).
+ *
+ * On a 16-bit DEST the fp32 result is narrowed with @ref float32_to_bf16_rne before the
+ * store, because SFPSTORE truncates instead of rounding. That narrowing is bf16-specific,
+ * so the static_assert admits Float32 and Float16_b only.
+ *
+ * @tparam APPROXIMATION_MODE: unused, preserved to match the BH metal signature
+ * @tparam is_fp32_dest_acc_en: set when DEST is 32-bit; skips the bf16 narrowing
+ * @tparam data_format: DEST register format, values = <Float32/Float16_b>
+ * @tparam ITERATIONS: number of sfpi row-pairs to process (one call per face)
+ * @tparam TILE_SHAPE: destination tile shape used to calculate operand offsets
+ * @param dst_index_in0: DEST tile index holding the interpolation start point
+ * @param dst_index_in1: DEST tile index holding the interpolation end point
+ * @param dst_index_in2: DEST tile index holding the per-lane weight
+ * @param dst_index_out: DEST tile index that receives the result
+ * @note Run @c SFPU_TERNARY_INIT(lerp) before this function, and drive it through
+ *       @c SFPU_TERNARY_CALL so the per-face loop and section base setup are owned by
+ *       @ref _llk_math_eltwise_ternary_sfpu_params_.
+ */
+template <
+    [[maybe_unused]] bool APPROXIMATION_MODE,
+    bool is_fp32_dest_acc_en,
+    DataFormat data_format,
+    int ITERATIONS = SFPU_ITERATIONS,
+    trisc::DstTileShape TILE_SHAPE = trisc::DstTileShape::Tile32x32>
+inline void calculate_lerp(
+    const std::uint32_t dst_index_in0,
+    const std::uint32_t dst_index_in1,
+    const std::uint32_t dst_index_in2,
+    const std::uint32_t dst_index_out) {
+    static_assert(
+        data_format == DataFormat::Float32 || data_format == DataFormat::Float16_b,
+        "Unsupported data format for calculate_lerp(). Supported data formats are: Float32, Float16_b.");
+
+    constexpr std::uint32_t dst_tile_size_sfpi = 1U << (trisc::get_dest_tile_size_log2(TILE_SHAPE) - 1);
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat start = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat end = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        sfpi::vFloat weight = sfpi::dst_reg[dst_index_in2 * dst_tile_size_sfpi];
+        sfpi::vFloat result = start + weight * (end - start);
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = float32_to_bf16_rne(result);
+        }
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_lerp_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_lerp_quasar.py
@@ -1,0 +1,319 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import struct
+
+import pytest
+import torch
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.golden_generators import TernarySFPUGolden, get_golden_generator
+from helpers.llk_params import (
+    DataCopyType,
+    DestAccumulation,
+    ImpliedMathFormat,
+    MathOperation,
+    UnpackerEngine,
+    VectorMode,
+    format_dict,
+)
+from helpers.param_config import (
+    generate_sfpu_format_dest_acc_combinations,
+    input_output_formats,
+    parametrize,
+)
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import StimuliSpec, generate_stimuli
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    DATA_COPY_TYPE,
+    DEST_INDEX,
+    DEST_SYNC,
+    IMPLIED_MATH_FORMAT,
+    MATH_OP,
+    NUM_FACES,
+    TEST_FACE_DIMS,
+    TILE_COUNT,
+    UNPACKER_ENGINE_SEL,
+    VECTOR_MODE,
+)
+from helpers.utils import passed_test
+
+FACE_SIZE = 16 * 16
+
+# TernarySFPUGolden takes the addcmul/addcdiv scalar as a raw fp32 bit pattern; lerp
+# ignores it, so pass a well-formed 1.0f rather than an undecodable value.
+_UNUSED_SCALAR_BITS = struct.unpack("<I", struct.pack("<f", 1.0))[0]
+
+# Map each VectorMode to the set of face indices the LLK dispatch processes.
+# Faces outside the set keep whatever the producer left in Dest (the start tile
+# in this test), so the per-mode assertion is restricted to processed faces.
+_PROCESSED_FACES = {
+    VectorMode.None_: (0,),
+    VectorMode.R: (0, 1),
+    VectorMode.C: (0, 2),
+    VectorMode.RC: (0, 1, 2, 3),
+}
+
+
+def _processed_face_mask(vector_mode: VectorMode, num_faces: int) -> torch.Tensor:
+    """1-D bool mask selecting the elements of a flat tile that ``vector_mode`` writes."""
+    mask = torch.zeros(num_faces * FACE_SIZE, dtype=torch.bool)
+    for face in _PROCESSED_FACES[vector_mode]:
+        mask[face * FACE_SIZE : (face + 1) * FACE_SIZE] = True
+    return mask
+
+
+def _get_valid_formats_dest_acc():
+    """Float32 / Float16_b only — calculate_lerp() static_asserts on that pair.
+
+    Float16 (fp16a) is a legal Quasar Dest format but is rejected by the kernel: its
+    16-bit-Dest arm narrows with float32_to_bf16_rne(), a bf16 rounding that would
+    corrupt an E5M10 store. Integer and MX formats are out for a float-only op.
+    """
+    formats = input_output_formats(
+        [
+            DataFormat.Float16_b,
+            DataFormat.Float32,
+        ]
+    )
+    return generate_sfpu_format_dest_acc_combinations(formats)
+
+
+def _get_valid_implied_math_formats(fmt: FormatConfig):
+    if fmt.input_format.is_mx_format():
+        return [ImpliedMathFormat.Yes]
+    return [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
+
+
+def _is_unpack_to_dest(fmt: FormatConfig, dest_acc: DestAccumulation) -> bool:
+    """UNPACK→DEST is selected only for 32-bit inputs with dest_acc=Yes."""
+    return fmt.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
+
+
+def _weight_for_test_case(
+    base: torch.Tensor, input_format: DataFormat, test_case: str
+) -> torch.Tensor:
+    """Apply the weight regime (mixed / weight_zero / weight_one) for a variant."""
+    torch_format = format_dict[input_format]
+    if test_case == "weight_zero":
+        # out must reduce to the start tensor exactly.
+        return torch.zeros_like(base, dtype=torch_format)
+    if test_case == "weight_one":
+        # out must reduce to the end tensor exactly.
+        return torch.ones_like(base, dtype=torch_format)
+    # "mixed" — interior weights in [0, 1], the actual interpolation regime.
+    return base.to(torch_format)
+
+
+def _run_lerp(
+    formats,
+    dest_acc,
+    implied_math_format,
+    vector_mode,
+    start,
+    end,
+    weight,
+    dest_index,
+):
+    """Stage start/end/weight into Dest tiles base+0/1/2, run lerp, assert on Dest tile base+0."""
+    torch_format_out = format_dict[formats.output_format]
+
+    src_A = torch.cat([start, end, weight])
+    tile_cnt_A = 3
+    num_faces = 4
+
+    generate_golden = get_golden_generator(TernarySFPUGolden)
+    golden_tensor = generate_golden(
+        MathOperation.SfpuLerp,
+        start,
+        end,
+        weight,
+        _UNUSED_SCALAR_BITS,
+        formats.output_format,
+    )
+    golden_tensor = golden_tensor.to(torch_format_out)
+
+    unpack_to_dest = _is_unpack_to_dest(formats, dest_acc)
+    src_B_dummy = torch.zeros_like(start)
+
+    configuration = TestConfig(
+        "sources/quasar/sfpu_lerp_quasar_test.cpp",
+        formats,
+        templates=[
+            MATH_OP(mathop=MathOperation.SfpuLerp),
+            IMPLIED_MATH_FORMAT(implied_math_format),
+            DATA_COPY_TYPE(DataCopyType.A2D),
+            UNPACKER_ENGINE_SEL(
+                UnpackerEngine.UnpDest if unpack_to_dest else UnpackerEngine.UnpA
+            ),
+            DEST_SYNC(),
+            VECTOR_MODE(vector_mode),
+        ],
+        runtimes=[
+            TILE_COUNT(tile_cnt_A),
+            NUM_FACES(num_faces),
+            TEST_FACE_DIMS(),
+            DEST_INDEX(dest_index),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B_dummy,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=1,
+            tile_count_res=1,
+            num_faces=num_faces,
+        ),
+        unpack_to_dest=unpack_to_dest,
+        dest_acc=dest_acc,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), "Result tensor and golden tensor are not of the same length"
+
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format_out)
+    mask = _processed_face_mask(vector_mode, num_faces)
+    assert passed_test(
+        golden_tensor[mask], res_tensor[mask], formats.output_format
+    ), "Assert against golden failed"
+
+
+@pytest.mark.quasar
+@parametrize(
+    formats_dest_acc=_get_valid_formats_dest_acc(),
+    implied_math_format=lambda formats_dest_acc: _get_valid_implied_math_formats(
+        formats_dest_acc[0]
+    ),
+    # `test_case` is a stimulus-only axis and could carry runtime(), but leaving every
+    # axis compile-time keeps the collected variant count equal to the executed one, which
+    # the codegen verification schema requires.
+    test_case=["mixed", "weight_zero", "weight_one"],
+    vector_mode=[VectorMode.None_, VectorMode.R, VectorMode.C, VectorMode.RC],
+)
+def test_sfpu_lerp_quasar(
+    formats_dest_acc, implied_math_format, test_case, vector_mode
+):
+    """
+    Test ternary `lerp(start, end, weight) -> start + weight * (end - start)` on Quasar.
+
+    The C++ test source packs 3 input tiles (start, end, weight) into `buffer_A`,
+    stages them into DEST tile indices 0, 1, 2 (UNPACK→DEST for 32-bit inputs,
+    FPU datacopy otherwise), runs the SFPU `lerp` kernel over the faces selected by
+    `vector_mode` writing output to DEST tile 0, and PACK writes DEST tile 0 out to
+    `buffer_Res`.
+
+    `test_case` pins the weight regime: `weight_zero` and `weight_one` collapse the
+    interpolation onto a single endpoint, so a bad operand order or a dropped term
+    shows up as an exact-tensor mismatch rather than a small PCC drift; `mixed`
+    exercises real interpolation. Unprocessed faces are excluded from the golden
+    assertion since Dest retains the producer-written start tile there.
+    """
+    formats, dest_acc = formats_dest_acc
+    input_dimensions = [32, 32]
+    torch_format_in = format_dict[formats.input_format]
+
+    # start/end in [-1, 1] and weight in [0, 1] keep `start + weight * (end - start)`
+    # inside [-1, 1] — no overflow or catastrophic cancellation on either dest_acc arm.
+    endpoint_spec = StimuliSpec.uniform(low=-1.0, high=1.0)
+    weight_spec = StimuliSpec.uniform(low=0.0, high=1.0)
+
+    torch.manual_seed(42)
+    start_raw, _, _, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+        spec_A=endpoint_spec,
+        spec_B=endpoint_spec,
+    )
+    torch.manual_seed(43)
+    end_raw, _, _, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+        spec_A=endpoint_spec,
+        spec_B=endpoint_spec,
+    )
+    torch.manual_seed(44)
+    weight_raw, _, _, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+        spec_A=weight_spec,
+        spec_B=weight_spec,
+    )
+
+    start = start_raw.to(torch_format_in)
+    end = end_raw.to(torch_format_in)
+    weight = _weight_for_test_case(weight_raw, formats.input_format, test_case)
+
+    _run_lerp(
+        formats,
+        dest_acc,
+        implied_math_format,
+        vector_mode,
+        start,
+        end,
+        weight,
+        dest_index=0,
+    )
+
+
+@pytest.mark.quasar
+@parametrize(
+    formats_dest_acc=_get_valid_formats_dest_acc(),
+    implied_math_format=lambda formats_dest_acc: _get_valid_implied_math_formats(
+        formats_dest_acc[0]
+    ),
+    vector_mode=[VectorMode.RC],
+    dest_index=[0, 1],
+)
+def test_sfpu_lerp_mcw_quasar(
+    formats_dest_acc, implied_math_format, vector_mode, dest_index
+):
+    """
+    Deterministic lerp test — start=2, end=10 and a repeating weight ramp
+    (0, 0.25, 0.5, 0.75) so every element has a hand-checkable answer
+    (2, 4, 6, 8).
+
+    Runs through the same C++ harness as `test_sfpu_lerp_quasar`, including a
+    nonzero Dest tile offset. If this fails but the stimulus-driven test passes,
+    the problem is in stimulus generation rather than the kernel. Only
+    `VectorMode.RC` is swept here — face selection is already covered in full by
+    `test_sfpu_lerp_quasar`; this test adds the Dest-offset axis.
+    """
+    formats, dest_acc = formats_dest_acc
+    if dest_index != 0 and _is_unpack_to_dest(formats, dest_acc):
+        pytest.skip(
+            "UNPACK→DEST always lands the three staged tiles at Dest 0/1/2 — "
+            "_llk_unpack_unary_operand_ takes no Dest tile-offset argument — so a "
+            "nonzero DEST_INDEX would make MATH read one tile past the staged set. "
+            "The Dest-offset axis is exercised on the FPU datacopy path instead, "
+            "which writes DST_INDEX + i explicitly."
+        )
+
+    torch_format_in = format_dict[formats.input_format]
+    height, width = 32, 32
+
+    start = (torch.ones(height * width, dtype=torch_format_in) * 2).flatten()
+    end = (torch.ones(height * width, dtype=torch_format_in) * 10).flatten()
+    ramp = (torch.arange(height * width) % 4).to(torch.float32) * 0.25
+    weight = ramp.to(torch_format_in).flatten()
+
+    _run_lerp(
+        formats,
+        dest_acc,
+        implied_math_format,
+        vector_mode,
+        start,
+        end,
+        weight,
+        dest_index=dest_index,
+    )

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_lerp_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_lerp_quasar_test.cpp
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "llk_memory_checks.h"
+#include "sfpu_stub.h"
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_math_common.h"
+#include "llk_unpack_common.h"
+#include "llk_unpack_unary_operand.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t buf_desc_id          = 0;
+    const std::uint32_t num_tiles_per_unpack = params.TILE_CNT;
+
+    // UNPACK-to-DEST path: UNPACK writes DEST; SFPU reads/writes DEST; PACK reads DEST.
+    // FPU path: UNPACK writes SrcA; FPU datacopy writes DEST; SFPU reads/writes DEST; PACK reads DEST.
+    constexpr auto unpack_dest = unpack_to_dest ? dest_dvalid_client::UNPACK : dest_dvalid_client::FPU;
+    set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({unpack_dest, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+
+    if constexpr (unpack_to_dest)
+    {
+        _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*is_int_fpu_en*/>();
+    }
+
+    buffer_descriptor_u bd_val = {0};
+    bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_A[0]);
+    bd_val.f.format            = static_cast<std::uint8_t>(formats.unpack_A_src);
+    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim             = params.num_faces;
+
+    tdma_descriptor_t td_val;
+    td_val.buf_desc        = bd_val;
+    td_val.buf_desc_id     = buf_desc_id;
+    td_val.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
+    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+
+    if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
+    {
+        // If Dst is 32b and MATH uses FPU datacopy (MOVA2D → ELWADD fallback), we need both SrcA and SrcB formats configured.
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val, td_val);
+    }
+    else
+    {
+        _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val);
+    }
+
+    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
+        buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_unpack);
+
+    // Unpacks all three input tiles (start, end, weight) from buffer_A in one call;
+    // tile count is taken from num_tiles_per_unpack set during init.
+    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0 /*l1_tile_idx*/, ckernel::DEFAULT_TENSOR_SHAPE);
+
+    if constexpr (unpack_to_dest)
+    {
+        // Signals DEST writes are done; not called on the FPU path since UNPACK doesn't touch DEST there.
+        _llk_unpack_dest_dvalid_section_done_<dest_sync>();
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+const bool is_int_fpu_en = false;
+
+#include "cfg_defines.h"
+#include "cmath_common.h"
+#include "llk_math_common.h"
+#include "llk_math_eltwise_unary_datacopy.h"
+#include "llk_sfpu/ckernel_sfpu_lerp.h"
+#include "llk_sfpu/llk_math_eltwise_ternary_sfpu_macros.h"
+#include "params.h"
+
+using namespace ckernel;
+using namespace ckernel::math;
+using namespace ckernel::sfpu;
+
+// calculate_lerp()'s data_format names the DEST register format, which dest_acc alone decides:
+// dest_acc=Yes is a 32-bit Float32 DEST, dest_acc=No a 16-bit Float16_b DEST. Float16 never
+// reaches here — the kernel's static_assert rejects it.
+constexpr DataFormat LERP_DEST_FORMAT = is_fp32_dest_acc_en ? DataFormat::Float32 : DataFormat::Float16_b;
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    if constexpr (unpack_to_dest)
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+    else
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+
+    DataFormat src_format = static_cast<DataFormat>(formats.math);
+    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, is_int_fpu_en>(src_format, src_format);
+
+    if constexpr (!unpack_to_dest)
+    {
+        const std::uint32_t num_rows = params.num_faces * params.TEST_FACE_R_DIM;
+        _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(num_rows, 1 /*num_matrices*/);
+
+        for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+        {
+            _llk_math_eltwise_unary_datacopy_(params.DST_INDEX + i);
+        }
+
+        _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+    }
+
+    _llk_math_eltwise_ternary_sfpu_init_<SfpuType::lerp>();
+
+    // Runs calculate_lerp over the faces selected by VECTOR_MODE: start=base+0, end=base+1,
+    // weight=base+2, result to base+0. Unselected faces keep the producer-written start
+    // tile, so Python asserts only processed faces.
+    SFPU_TERNARY_CALL(
+        dest_sync,
+        is_fp32_dest_acc_en,
+        calculate_lerp,
+        (false /*APPROXIMATION_MODE*/, is_fp32_dest_acc_en, LERP_DEST_FORMAT, static_cast<int>(ckernel::SFPU_ITERATIONS)),
+        params.DST_INDEX + 0u /*DST_IN0*/,
+        params.DST_INDEX + 1u /*DST_IN1*/,
+        params.DST_INDEX + 2u /*DST_IN2*/,
+        params.DST_INDEX + 0u /*DST_OUT*/,
+        VECTOR_MODE);
+
+    _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "cfg_defines.h"
+#include "llk_pack.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t buf_desc_id        = 8;
+    const std::uint32_t num_tiles_per_pack = 1;
+
+    constexpr auto unpack_dest = unpack_to_dest ? dest_dvalid_client::UNPACK : dest_dvalid_client::FPU;
+    set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({unpack_dest, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+
+    buffer_descriptor_u bd_val = {0};
+    bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_Res[0]);
+    bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
+    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim             = params.num_faces;
+
+    tdma_descriptor_t tdma_desc;
+    tdma_desc.buf_desc        = bd_val;
+    tdma_desc.buf_desc_id     = buf_desc_id;
+    tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
+    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+
+    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
+    _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+
+    // Packs only the result tile (DEST[DST_INDEX]); lerp produces one output tile
+    // regardless of how many input tiles were loaded.
+    _llk_pack_(params.DST_INDEX, 0 /*start_l1_tile_idx*/, ckernel::DEFAULT_TENSOR_SHAPE);
+    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+}
+
+#endif

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
@@ -101,6 +101,7 @@ enum class SfpuType : std::uint32_t
     fill,
     swiglu,
     where,
+    lerp,
     unused,
     lt,
     gt,


### PR DESCRIPTION
### PR Category

Feature

### Summary

Implements the `lerp` kernel for `quasar` from CodeGen run `2026-08-12_lerp_quasar_d0d573b4`.

Generated file: `tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_lerp.h`.

CodeGen reported 136/136 tests passing.

### Notes for reviewers

This is an AI-generated draft. Please review the implementation and the recorded verification before marking it ready.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk_code_gen/generated-lerp-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk_code_gen/generated-lerp-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk_code_gen/generated-lerp-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk_code_gen/generated-lerp-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk_code_gen/generated-lerp-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk_code_gen/generated-lerp-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk_code_gen/generated-lerp-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk_code_gen/generated-lerp-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk_code_gen/generated-lerp-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk_code_gen/generated-lerp-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk_code_gen/generated-lerp-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk_code_gen/generated-lerp-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk_code_gen/generated-lerp-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk_code_gen/generated-lerp-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk_code_gen/generated-lerp-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk_code_gen/generated-lerp-quasar-v1)