### PR TITLE
[LLK][Feature] Implement log1p for Quasar

### DIFF
--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
@@ -20,6 +20,7 @@
 #include "llk_sfpu/ckernel_sfpu_comp.h"
 #include "llk_sfpu/ckernel_sfpu_exp.h"
 #include "llk_sfpu/ckernel_sfpu_gelu.h"
+#include "llk_sfpu/ckernel_sfpu_log1p.h"
 #include "llk_sfpu/ckernel_sfpu_negative.h"
 #include "llk_sfpu/ckernel_sfpu_recip.h"
 #include "llk_sfpu/ckernel_sfpu_rsqrt.h"
@@ -123,6 +124,12 @@ void init_unary_sfpu_operation_quasar()
     else if constexpr (is_trig_op(OPERATION))
     {
         init_trigonometry<OPERATION, is_fp32_dest_acc_en>();
+    }
+    else if constexpr (OPERATION == SfpuType::log1p)
+    {
+        // Loads vConstFloatPrgm0/1/2: the log(2)*2^-23 exponent scale and the two Horner
+        // coefficients, which differ between the fp32 and bf16 polynomials.
+        log1p_init<APPROX, false /* FAST_APPROX */, is_fp32_dest_acc_en>();
     }
 }
 
@@ -266,6 +273,13 @@ void call_unary_sfpu_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_f
         // at compile time. APPROXIMATION_MODE=false selects the full-polynomial (accurate) path;
         // VectorMode::RC (the params default) runs the functor once per face.
         _llk_math_eltwise_unary_sfpu_params_(calculate_trigonometry<OPERATION, false /* APPROX */, is_fp32_dest_acc_en, ITERATIONS>, dst_index);
+    }
+    else if constexpr (OPERATION == SfpuType::log1p)
+    {
+        // APPROX / FAST_APPROX are ignored; is_fp32_dest_acc_en picks the 9-term fp32 polynomial
+        // or the 3-term bf16 one plus its narrowing store.
+        SFPU_UNARY_CALL(
+            DST_SYNC, is_fp32_dest_acc_en, calculate_log1p, (APPROX, false /* FAST_APPROX */, is_fp32_dest_acc_en, ITERATIONS), dst_index, VectorMode::RC);
     }
     else if constexpr (OPERATION == SfpuType::negative)
     {

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
@@ -373,6 +373,13 @@ def prepare_inputs_for_operation(
         max_val = 30.0
         src_A = min_val + src_A.to(torch.float32) * (max_val - min_val)
         src_A = src_A.to(torch_format)
+    elif mathop == MathOperation.Log1p:
+        # Domain is x > -1 (mirrors sfpu_domains' Log1p spec). The lower end keeps 1 + x small,
+        # so the kernel's exponent decomposition is exercised over several values of k.
+        min_val = -0.99
+        max_val = 10.0
+        src_A = min_val + src_A.to(torch.float32) * (max_val - min_val)
+        src_A = src_A.to(torch_format)
     # else: keep src_A as-is
 
     return src_A
@@ -655,6 +662,7 @@ OP_CONFIGS = [
     OpConfig(MathOperation.Clamp, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Neg, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Softplus, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
+    OpConfig(MathOperation.Log1p, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Typecast, TENSOR_DIMS, DEST_SYNC_MODES),
     # Trigonometry / inverse-hyperbolic ops: same matrix as the other transcendentals,
     # fed a uniform [0, 1] stimulus that prepare_trig_inputs maps into each op's domain.
@@ -805,8 +813,8 @@ def test_eltwise_unary_sfpu_quasar(
     """
     Consolidated unary-SFPU test on Quasar. One compile-time-selected op per
     variant (abs, exp, gelu, relu, reciprocal, sqrt, tanh, sigmoid, silu, rsqrt,
-    square, typecast, and the six compare-to-zero modes), validated against the
-    UnarySFPUGolden reference. Typecast sweeps explicit (src, dst) format pairs;
+    square, log1p, typecast, and the six compare-to-zero modes), validated against
+    the UnarySFPUGolden reference. Typecast sweeps explicit (src, dst) format pairs;
     every other op sweeps the shared format matrix.
     """
     (

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
@@ -98,6 +98,7 @@ enum class SfpuType : std::uint32_t
     acosh,
     asinh,
     atanh,
+    log1p,
     fill,
     swiglu,
     where,


### PR DESCRIPTION
### PR Category

Feature

### Summary

Implements the `log1p` kernel for `quasar` from CodeGen run `2026-08-12_log1p_quasar_61d5991f`.

Generated file: `tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_log1p.h`.

CodeGen reported 104/104 tests passing.

### Notes for reviewers

This is an AI-generated draft. Please review the implementation and the recorded verification before marking it ready.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk_code_gen/generated-log1p-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk_code_gen/generated-log1p-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk_code_gen/generated-log1p-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk_code_gen/generated-log1p-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=llk_code_gen/generated-log1p-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:llk_code_gen/generated-log1p-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk_code_gen/generated-log1p-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk_code_gen/generated-log1p-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk_code_gen/generated-log1p-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk_code_gen/generated-log1p-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk_code_gen/generated-log1p-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk_code_gen/generated-log1p-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk_code_gen/generated-log1p-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk_code_gen/generated-log1p-quasar-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk_code_gen/generated-log1p-quasar-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk_code_gen/generated-log1p-quasar-v1)