### PR TITLE
[Cleanup] DFB tests modernization

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
@@ -468,7 +468,7 @@ inline void run_single_dfb_program_2_0(distributed::MeshDevice& mesh_device, con
         slow_dispatch::WriteToL1(mesh_device, CoreCoord(0, 0), dfb_l1_addr, slice);
     }
 
-    slow_dispatch::LaunchProgram(mesh_device, program);
+    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     // Verify (DM consumer only — Tensix consumer doesn't write DRAM).
     if (p.consumer_type == M2PorCType::DM) {

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
@@ -28,6 +28,7 @@
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "device_fixture.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "tt_metal/hw/inc/internal/tt-2xx/dataflow_buffer/dataflow_buffer_config.h"
 #include "impl/dataflow_buffer/dataflow_buffer.hpp"
@@ -59,7 +60,9 @@ struct LiveTcSnapshot {
     std::vector<uint32_t> space_available;
 };
 
-inline LiveTcSnapshot read_live_tcs(IDevice* device, const CoreCoord& logical_core, uint32_t neo_id) {
+inline LiveTcSnapshot read_live_tcs(
+    distributed::MeshDevice& unit_mesh, const CoreCoord& logical_core, uint32_t neo_id) {
+    IDevice* device = slow_dispatch::physical_device_from_unit_mesh(unit_mesh);
     const auto& hal = MetalContext::instance().hal();
     const uint32_t base = hal.get_neo_tile_counters_base_addr() + neo_id * hal.get_neo_tile_counters_stride();
     const uint32_t size = hal.get_neo_tile_counters_size();
@@ -94,8 +97,8 @@ enum class DFBPorCType : uint8_t { DM, TENSIX };
 enum class M2PorCType : uint8_t { DM, TENSIX };
 
 // ---- parameterized fixtures (legacy + Metal 2.0) ----
-class DFBImplicitSyncParamFixture : public MeshDeviceFixture, public ::testing::WithParamInterface<bool> {};
-class DFBImplicitSyncParamFixture_2_0 : public MeshDeviceFixture, public ::testing::WithParamInterface<bool> {};
+class DFBImplicitSyncParamFixture : public UnitMeshFixture, public ::testing::WithParamInterface<bool> {};
+class DFBImplicitSyncParamFixture_2_0 : public UnitMeshFixture, public ::testing::WithParamInterface<bool> {};
 
 // ---- shared kernel / tensor factory helpers (Metal 2.0) ----
 // Default dtype UINT32 keeps the legacy two-argument call sites (entry_size, total_entries)
@@ -112,13 +115,14 @@ inline TensorSpec make_flat_dram_tensor_spec(
 }
 
 template <typename T>
-inline void m2_writeshard_barrier_uint32(IDevice* device, const MeshTensor& in_tensor, const std::vector<T>& input) {
-    if (device->arch() != ARCH::QUASAR) {
+inline void m2_writeshard_barrier_uint32(
+    distributed::MeshDevice& unit_mesh, const MeshTensor& in_tensor, const std::vector<T>& input) {
+    if (unit_mesh.arch() != ARCH::QUASAR) {
         return;
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
     std::vector<T> rdback;
-    detail::ReadFromBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), rdback);
+    slow_dispatch::ReadFromBuffer(in_tensor.mesh_buffer(), rdback);
     tt_driver_atomics::mfence();
     ASSERT_EQ(rdback, input) << "M2: WriteShard did not complete before LaunchProgram (Quasar emu #38042)";
 }
@@ -228,22 +232,20 @@ inline uint32_t default_num_entries(uint32_t num_p, uint32_t num_c) {
 }
 
 // ---- shared skip macros + ring-size helper (used by base + overrides) ----
-#define DFB_SKIP_IF_UNSUPPORTED(num_p, num_c)                                                   \
-    if (devices_.at(0)->arch() != ARCH::QUASAR && (GetParam() || (num_p) > 1 || (num_c) > 1)) { \
-        GTEST_SKIP();                                                                           \
+#define DFB_SKIP_IF_UNSUPPORTED(num_p, num_c)                                                  \
+    if (this->device().arch() != ARCH::QUASAR && (GetParam() || (num_p) > 1 || (num_c) > 1)) { \
+        GTEST_SKIP();                                                                          \
     }
 
 // ---- single-DFB program driver ----
 
-inline void run_single_dfb_program_2_0(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const M2SingleDFBParams& p) {
+inline void run_single_dfb_program_2_0(distributed::MeshDevice& mesh_device, const M2SingleDFBParams& p) {
     // The DFB 2.0 host/device path is arch-abstracted: on WH/BH a DFB has no tile-counter
     // registers so it lowers to a 4-word circular-buffer config, and the _2_0 kernels' explicit
     // path is arch-agnostic (only the implicit async_read/write<TXN_ID> path is #ifdef ARCH_QUASAR).
     // So the simple 1x1 explicit-sync cases run on WH/BH too; only implicit-sync and multi-core
     // are Quasar-only (mirrors the legacy DFB_SKIP_IF_UNSUPPORTED gate).
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR &&
-        (p.implicit_sync || p.num_producers > 1 || p.num_consumers > 1)) {
+    if (mesh_device.arch() != ARCH::QUASAR && (p.implicit_sync || p.num_producers > 1 || p.num_consumers > 1)) {
         GTEST_SKIP() << "M2 non-Quasar: only 1x1 explicit-sync DFB runs on WH/BH "
                         "(implicit-sync + multi-core are Quasar-only)";
     }
@@ -262,7 +264,6 @@ inline void run_single_dfb_program_2_0(
         GTEST_SKIP() << "ALL DM consumer with implicit_sync not supported (legacy parity)";
     }
 
-    IDevice* device = mesh_device->get_devices()[0];
     const m2::NodeCoord node{0, 0};
     const uint32_t entries_per_core = p.num_entries_in_buffer.value_or(p.num_entries);
     const bool is_all = (p.cap == m2::DFBAccessPattern::ALL);
@@ -279,10 +280,10 @@ inline void run_single_dfb_program_2_0(
     std::optional<MeshTensor> in_tensor;
     std::optional<MeshTensor> out_tensor;
     if (p.producer_type == M2PorCType::DM) {
-        in_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
+        in_tensor = MeshTensor::allocate_on_device(mesh_device, tensor_spec);
     }
     if (p.consumer_type == M2PorCType::DM) {
-        out_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
+        out_tensor = MeshTensor::allocate_on_device(mesh_device, tensor_spec);
     }
 
     m2::DataflowBufferSpec dfb_spec{
@@ -348,7 +349,7 @@ inline void run_single_dfb_program_2_0(
     // a Gen2 config, so mirror the legacy driver -- DM producer -> RISCV_0, DM consumer ->
     // RISCV_1/NOC_1, Tensix -> ComputeGen1. The make_*_kernel helpers default to Gen2; override
     // to Gen1 on WH/BH here (only 1x1 explicit-sync cases reach WH/BH per the skip gate above).
-    if (mesh_device->get_devices()[0]->arch() == ARCH::QUASAR) {
+    if (mesh_device.arch() == ARCH::QUASAR) {
         // Gen2 implicit-sync opt-out (#45160): only DM endpoints carry the per-kernel flag; for
         // ImplicitSyncFalse it keeps the host from programming implicit ISR/txn metadata over the
         // kernels' explicit credit-flow path. Tensix endpoints have no DM side.
@@ -392,7 +393,7 @@ inline void run_single_dfb_program_2_0(
         .work_units = {wu},
     };
 
-    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = m2::MakeProgramFromSpec(mesh_device, spec);
 
     m2::ProgramRunArgs params;
     if (p.producer_type == M2PorCType::DM) {
@@ -425,8 +426,8 @@ inline void run_single_dfb_program_2_0(
     const uint32_t total_words = p.entry_size * entries_per_core / sizeof(uint32_t);
     auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 1000000, total_words);
     if (in_tensor) {
-        detail::WriteToBuffer(*in_tensor->mesh_buffer().get_reference_buffer(), input);
-        m2_writeshard_barrier_uint32(device, *in_tensor, input);
+        slow_dispatch::WriteToBuffer(in_tensor->mesh_buffer(), input);
+        m2_writeshard_barrier_uint32(mesh_device, *in_tensor, input);
     }
 
     // For Tensix producer: host-prefill the DFB L1 ring with the input data so the
@@ -444,7 +445,7 @@ inline void run_single_dfb_program_2_0(
     //            transpose of the input.
     if (p.producer_type == M2PorCType::TENSIX) {
         const uint32_t dfb_l1_addr =
-            static_cast<uint32_t>(device->allocator()->get_base_allocator_addr(HalMemType::L1));
+            static_cast<uint32_t>(mesh_device.allocator()->get_base_allocator_addr(HalMemType::L1));
         const uint32_t wpe = p.entry_size / sizeof(uint32_t);
         const uint32_t ring_words = p.num_entries * wpe;
         std::vector<uint32_t> slice(ring_words, 0u);
@@ -464,15 +465,15 @@ inline void run_single_dfb_program_2_0(
                     input.begin() + page_id * wpe, input.begin() + (page_id + 1) * wpe, slice.begin() + dst_slot * wpe);
             }
         }
-        detail::WriteToDeviceL1(device, CoreCoord(0, 0), dfb_l1_addr, slice);
+        slow_dispatch::WriteToL1(mesh_device, CoreCoord(0, 0), dfb_l1_addr, slice);
     }
 
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(mesh_device, program);
 
     // Verify (DM consumer only — Tensix consumer doesn't write DRAM).
     if (p.consumer_type == M2PorCType::DM) {
         std::vector<uint32_t> output;
-        detail::ReadFromBuffer(*out_tensor->mesh_buffer().get_reference_buffer(), output);
+        slow_dispatch::ReadFromBuffer(out_tensor->mesh_buffer(), output);
         // For Tensix→DM ring-pressure with STRIDED, each consumer reads ring slot
         // (c % num_entries), so expected output is the corresponding input slice.
         if (p.producer_type == M2PorCType::TENSIX && entries_per_core > p.num_entries &&

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/dfb_test_common.hpp
@@ -62,7 +62,7 @@ struct LiveTcSnapshot {
 
 inline LiveTcSnapshot read_live_tcs(
     distributed::MeshDevice& unit_mesh, const CoreCoord& logical_core, uint32_t neo_id) {
-    IDevice* device = slow_dispatch::physical_device_from_unit_mesh(unit_mesh);
+    IDevice* device = unit_mesh.get_devices()[0];
     const auto& hal = MetalContext::instance().hal();
     const uint32_t base = hal.get_neo_tile_counters_base_addr() + neo_id * hal.get_neo_tile_counters_stride();
     const uint32_t size = hal.get_neo_tile_counters_size();

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -439,7 +439,7 @@ TEST_F(UnitMeshFixture, AliasDFBAddressEquality1Sx1S) {
 
     slow_dispatch::CompileProgram(this->device(), program);
     program.impl().finalize_dataflow_buffer_configs();
-    program.impl().allocate_dataflow_buffers(slow_dispatch::physical_device_from_unit_mesh(this->device()));
+    program.impl().allocate_dataflow_buffers(this->device().get_devices()[0]);
 
     const uint32_t id_a = program.impl().get_dfb_handle("dfb_a");
     const uint32_t id_b = program.impl().get_dfb_handle("dfb_b");
@@ -672,7 +672,7 @@ TEST_F(UnitMeshFixture, AliasDFBAllocSecondarySkipped) {
 
     program.impl().set_dfb_alias(id_a, id_b);
     program.impl().finalize_dataflow_buffer_configs();
-    program.impl().allocate_dataflow_buffers(slow_dispatch::physical_device_from_unit_mesh(this->device()));
+    program.impl().allocate_dataflow_buffers(this->device().get_devices()[0]);
 
     const uint32_t addr_a = program.impl().get_dataflow_buffer(id_a)->uniform_alloc_addr();
     const uint32_t addr_b = program.impl().get_dataflow_buffer(id_b)->uniform_alloc_addr();
@@ -703,7 +703,7 @@ TEST_F(UnitMeshFixture, AliasDFBAlloc3Way) {
     program.impl().set_dfb_alias(id_a, id_b);
     program.impl().set_dfb_alias(id_a, id_c);
     program.impl().finalize_dataflow_buffer_configs();
-    program.impl().allocate_dataflow_buffers(slow_dispatch::physical_device_from_unit_mesh(this->device()));
+    program.impl().allocate_dataflow_buffers(this->device().get_devices()[0]);
 
     const uint32_t addr_a = program.impl().get_dataflow_buffer(id_a)->uniform_alloc_addr();
     const uint32_t addr_b = program.impl().get_dataflow_buffer(id_b)->uniform_alloc_addr();
@@ -734,7 +734,7 @@ TEST_F(UnitMeshFixture, AliasDFBAgreedGroupResize) {
     program.impl().set_dfb_alias(id_a, id_b);
 
     program.impl().finalize_dataflow_buffer_configs();
-    program.impl().allocate_dataflow_buffers(slow_dispatch::physical_device_from_unit_mesh(this->device()));
+    program.impl().allocate_dataflow_buffers(this->device().get_devices()[0]);
 
     const uint32_t addr_a0 = program.impl().get_dataflow_buffer(id_a)->uniform_alloc_addr();
     EXPECT_EQ(addr_a0, program.impl().get_dataflow_buffer(id_b)->uniform_alloc_addr())
@@ -748,7 +748,7 @@ TEST_F(UnitMeshFixture, AliasDFBAgreedGroupResize) {
         {.dfb_id = id_b, .entry_size = 1024u, .num_entries = 8u},  // 8192
     };
     EXPECT_NO_THROW(program.impl().apply_dfb_size_overrides(overrides));
-    program.impl().allocate_dataflow_buffers(slow_dispatch::physical_device_from_unit_mesh(this->device()));
+    program.impl().allocate_dataflow_buffers(this->device().get_devices()[0]);
 
     auto dfb_a = program.impl().get_dataflow_buffer(id_a);
     auto dfb_b = program.impl().get_dataflow_buffer(id_b);
@@ -773,7 +773,7 @@ TEST_F(UnitMeshFixture, AliasDFBBorrowedMemoryAddressEquality) {
 
     slow_dispatch::CompileProgram(this->device(), program);
     program.impl().finalize_dataflow_buffer_configs();
-    program.impl().allocate_dataflow_buffers(slow_dispatch::physical_device_from_unit_mesh(this->device()));
+    program.impl().allocate_dataflow_buffers(this->device().get_devices()[0]);
 
     auto rtas = [&]() {
         return MakeRuntimeArgsForSingleNode(

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -280,7 +280,7 @@ void run_alias_dfb_program(
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 
-    slow_dispatch::LaunchProgram(mesh_device, program);
+    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_a, result_b;
     slow_dispatch::ReadFromBuffer(out_a.mesh_buffer(), result_a);
@@ -614,7 +614,7 @@ TEST_F(UnitMeshFixture, AliasDFBDisjointHalvesDataFlow) {
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 
-    slow_dispatch::LaunchProgram(this->device(), program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> out_la, out_lb, out_ra, out_rb;
     slow_dispatch::ReadFromBuffer(left.out_a.mesh_buffer(), out_la);
@@ -874,7 +874,7 @@ TEST_F(UnitMeshFixture, AliasDFBBorrowedMemoryDataFlow1Sx1S) {
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 
-    slow_dispatch::LaunchProgram(this->device(), program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_a, result_b;
     slow_dispatch::ReadFromBuffer(out_a.mesh_buffer(), result_a);

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_alias_dataflow_buffer.cpp
@@ -31,6 +31,7 @@
 #include <tt-metalium/tensor/spec/layout/page_config.hpp>
 
 #include "device_fixture.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include "impl/dataflow_buffer/dataflow_buffer_impl.hpp"
 #include "impl/program/program_impl.hpp"
@@ -87,33 +88,32 @@ struct AliasDFBProgramComponents {
 };
 
 AliasDFBProgramComponents make_alias_dfb_program_spec(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     const NodeCoord& node,
     uint32_t entry_size_a,
     uint32_t num_entries_a,
     uint32_t entry_size_b,
     uint32_t num_entries_b,
-    uint8_t  num_producers,
-    uint8_t  num_consumers) {
-
+    uint8_t num_producers,
+    uint8_t num_consumers) {
     const uint32_t epp_a = (num_entries_a + num_producers - 1) / num_producers;
     const uint32_t epp_b = (num_entries_b + num_producers - 1) / num_producers;
     const uint32_t epc_a = (num_entries_a + num_consumers - 1) / num_consumers;
     const uint32_t epc_b = (num_entries_b + num_consumers - 1) / num_consumers;
 
     MeshTensor in_a =
-        MeshTensor::allocate_on_device(*mesh_device, make_alias_dram_tensor_spec(entry_size_a, num_entries_a));
+        MeshTensor::allocate_on_device(mesh_device, make_alias_dram_tensor_spec(entry_size_a, num_entries_a));
     MeshTensor in_b =
-        MeshTensor::allocate_on_device(*mesh_device, make_alias_dram_tensor_spec(entry_size_b, num_entries_b));
+        MeshTensor::allocate_on_device(mesh_device, make_alias_dram_tensor_spec(entry_size_b, num_entries_b));
     MeshTensor out_a =
-        MeshTensor::allocate_on_device(*mesh_device, make_alias_dram_tensor_spec(entry_size_a, num_entries_a));
+        MeshTensor::allocate_on_device(mesh_device, make_alias_dram_tensor_spec(entry_size_a, num_entries_a));
     MeshTensor out_b =
-        MeshTensor::allocate_on_device(*mesh_device, make_alias_dram_tensor_spec(entry_size_b, num_entries_b));
+        MeshTensor::allocate_on_device(mesh_device, make_alias_dram_tensor_spec(entry_size_b, num_entries_b));
 
     // DM kernel configs (Gen1 + Gen2 variants so the same spec runs everywhere).
     DataMovementHardwareConfig producer_cfg;
     DataMovementHardwareConfig consumer_cfg;
-    if (mesh_device->arch() == ARCH::QUASAR) {
+    if (mesh_device.arch() == ARCH::QUASAR) {
         producer_cfg = DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
         consumer_cfg = DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
     } else {
@@ -220,22 +220,21 @@ AliasDFBProgramComponents make_alias_dfb_program_spec(
 }
 
 void run_alias_dfb_program(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     const NodeCoord& node,
     uint32_t entry_size_a,
     uint32_t num_entries_a,
     uint32_t entry_size_b,
     uint32_t num_entries_b,
-    uint8_t  num_producers = 1,
-    uint8_t  num_consumers = 1) {
-
+    uint8_t num_producers = 1,
+    uint8_t num_consumers = 1) {
     auto [spec, in_a, in_b, out_a, out_b] = make_alias_dfb_program_spec(
         mesh_device, node,
         entry_size_a, num_entries_a,
         entry_size_b, num_entries_b,
         num_producers, num_consumers);
 
-    Program program = MakeProgramFromSpec(*mesh_device, spec);
+    Program program = MakeProgramFromSpec(mesh_device, spec);
 
     auto rtas = [&](uint32_t epc_a, uint32_t epc_b) {
         return MakeRuntimeArgsForSingleNode(
@@ -273,20 +272,19 @@ void run_alias_dfb_program(
     auto input_a = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words_a);
     auto input_b = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words_b);
 
-    detail::WriteToBuffer(*in_a.mesh_buffer().get_reference_buffer(), input_a);
-    detail::WriteToBuffer(*in_b.mesh_buffer().get_reference_buffer(), input_b);
+    slow_dispatch::WriteToBuffer(in_a.mesh_buffer(), input_a);
+    slow_dispatch::WriteToBuffer(in_b.mesh_buffer(), input_b);
 
-    if (mesh_device->arch() == ARCH::QUASAR) {
+    if (mesh_device.arch() == ARCH::QUASAR) {
         // TODO #38042: barrier for Quasar DRAM write visibility.
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 
-    IDevice* device = mesh_device->get_devices()[0];
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(mesh_device, program);
 
     std::vector<uint32_t> result_a, result_b;
-    detail::ReadFromBuffer(*out_a.mesh_buffer().get_reference_buffer(), result_a);
-    detail::ReadFromBuffer(*out_b.mesh_buffer().get_reference_buffer(), result_b);
+    slow_dispatch::ReadFromBuffer(out_a.mesh_buffer(), result_a);
+    slow_dispatch::ReadFromBuffer(out_b.mesh_buffer(), result_b);
 
     EXPECT_EQ(result_a, input_a)
         << "Phase A output mismatch: DFB_A data did not round-trip correctly";
@@ -304,27 +302,21 @@ struct AliasBorrowedDFBComponents {
 };
 
 AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    const NodeCoord& node,
-    uint32_t entry_size,
-    uint32_t num_entries) {
-
+    distributed::MeshDevice& mesh_device, const NodeCoord& node, uint32_t entry_size, uint32_t num_entries) {
     const uint32_t epp = num_entries;
     const uint32_t epc = num_entries;
 
-    MeshTensor in_a =
-        MeshTensor::allocate_on_device(*mesh_device, make_alias_dram_tensor_spec(entry_size, num_entries));
-    MeshTensor in_b =
-        MeshTensor::allocate_on_device(*mesh_device, make_alias_dram_tensor_spec(entry_size, num_entries));
+    MeshTensor in_a = MeshTensor::allocate_on_device(mesh_device, make_alias_dram_tensor_spec(entry_size, num_entries));
+    MeshTensor in_b = MeshTensor::allocate_on_device(mesh_device, make_alias_dram_tensor_spec(entry_size, num_entries));
     MeshTensor out_a =
-        MeshTensor::allocate_on_device(*mesh_device, make_alias_dram_tensor_spec(entry_size, num_entries));
+        MeshTensor::allocate_on_device(mesh_device, make_alias_dram_tensor_spec(entry_size, num_entries));
     MeshTensor out_b =
-        MeshTensor::allocate_on_device(*mesh_device, make_alias_dram_tensor_spec(entry_size, num_entries));
-    MeshTensor ring = MeshTensor::allocate_on_device(*mesh_device, make_alias_l1_tensor_spec(entry_size, num_entries));
+        MeshTensor::allocate_on_device(mesh_device, make_alias_dram_tensor_spec(entry_size, num_entries));
+    MeshTensor ring = MeshTensor::allocate_on_device(mesh_device, make_alias_l1_tensor_spec(entry_size, num_entries));
 
     DataMovementHardwareConfig producer_cfg;
     DataMovementHardwareConfig consumer_cfg;
-    if (mesh_device->arch() == ARCH::QUASAR) {
+    if (mesh_device.arch() == ARCH::QUASAR) {
         producer_cfg = DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
         consumer_cfg = DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
     } else {
@@ -437,18 +429,17 @@ AliasBorrowedDFBComponents make_alias_borrowed_dfb_program_spec(
     return {std::move(spec), std::move(in_a), std::move(in_b), std::move(out_a), std::move(out_b), std::move(ring)};
 }
 
-TEST_F(MeshDeviceFixture, AliasDFBAddressEquality1Sx1S) {
+TEST_F(UnitMeshFixture, AliasDFBAddressEquality1Sx1S) {
     const NodeCoord node{0, 0};
 
-    [[maybe_unused]] auto [spec, in_a, in_b, out_a, out_b] = make_alias_dfb_program_spec(
-        devices_.at(0), node, 512, 8, 256, 16, 1, 1);
+    [[maybe_unused]] auto [spec, in_a, in_b, out_a, out_b] =
+        make_alias_dfb_program_spec(this->device(), node, 512, 8, 256, 16, 1, 1);
 
-    Program program = MakeProgramFromSpec(*devices_.at(0), spec);
+    Program program = MakeProgramFromSpec(this->device(), spec);
 
-    IDevice* device = devices_.at(0)->get_devices()[0];
-    detail::CompileProgram(device, program);
+    slow_dispatch::CompileProgram(this->device(), program);
     program.impl().finalize_dataflow_buffer_configs();
-    program.impl().allocate_dataflow_buffers(device);
+    program.impl().allocate_dataflow_buffers(slow_dispatch::physical_device_from_unit_mesh(this->device()));
 
     const uint32_t id_a = program.impl().get_dfb_handle("dfb_a");
     const uint32_t id_b = program.impl().get_dfb_handle("dfb_b");
@@ -464,19 +455,20 @@ TEST_F(MeshDeviceFixture, AliasDFBAddressEquality1Sx1S) {
         addr_a, addr_b);
 }
 
-TEST_F(MeshDeviceFixture, AliasDFBDataFlow1Sx1S) {
+TEST_F(UnitMeshFixture, AliasDFBDataFlow1Sx1S) {
     run_alias_dfb_program(
-        devices_.at(0), NodeCoord{0, 0},
-        /*entry_size_a=*/512, /*num_entries_a=*/8,
-        /*entry_size_b=*/256, /*num_entries_b=*/16);
+        this->device(),
+        NodeCoord{0, 0},
+        /*entry_size_a=*/512,
+        /*num_entries_a=*/8,
+        /*entry_size_b=*/256,
+        /*num_entries_b=*/16);
 }
 
 // Two WorkUnits on disjoint halves, each with its own aliased DFB pair. Slot packing must reuse
 // low slots across halves on WH/BH, and each half's alias pair must still share L1 and round-trip.
-TEST_F(MeshDeviceFixture, AliasDFBDisjointHalvesDataFlow) {
-    auto& mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
-    if (device->compute_with_storage_grid_size().x < 2) {
+TEST_F(UnitMeshFixture, AliasDFBDisjointHalvesDataFlow) {
+    if (this->device().compute_with_storage_grid_size().x < 2) {
         GTEST_SKIP() << "Needs at least two worker nodes in a row";
     }
 
@@ -488,9 +480,9 @@ TEST_F(MeshDeviceFixture, AliasDFBDisjointHalvesDataFlow) {
     constexpr uint32_t kEntriesB = 16;
 
     auto left = make_alias_dfb_program_spec(
-        mesh_device, node_a, kEntryA, kEntriesA, kEntryB, kEntriesB, /*num_producers=*/1, /*num_consumers=*/1);
+        this->device(), node_a, kEntryA, kEntriesA, kEntryB, kEntriesB, /*num_producers=*/1, /*num_consumers=*/1);
     auto right = make_alias_dfb_program_spec(
-        mesh_device, node_b, kEntryA, kEntriesA, kEntryB, kEntriesB, /*num_producers=*/1, /*num_consumers=*/1);
+        this->device(), node_b, kEntryA, kEntriesA, kEntryB, kEntriesB, /*num_producers=*/1, /*num_consumers=*/1);
 
     // Rename right-half entities so the combined ProgramSpec has unique ids.
     auto rename_dfb = [](DataflowBufferSpec& dfb, const std::string& new_name, const std::string& alias_name) {
@@ -568,9 +560,9 @@ TEST_F(MeshDeviceFixture, AliasDFBDisjointHalvesDataFlow) {
     left.spec.work_units.push_back(right.spec.work_units[0]);
 
     // Point tensor_parameters specs at the right-half MeshTensors' layouts (already set from right).
-    Program program = MakeProgramFromSpec(*mesh_device, left.spec);
+    Program program = MakeProgramFromSpec(this->device(), left.spec);
 
-    const bool is_quasar = device->arch() == ARCH::QUASAR;
+    const bool is_quasar = this->device().arch() == ARCH::QUASAR;
     // Each half has two aliased DFBs that conflict with each other → slots 0 and 1, reused across halves.
     EXPECT_EQ(program.impl().get_dataflow_buffer(program.impl().get_dfb_handle("dfb_a"))->device_slot, 0u);
     EXPECT_EQ(program.impl().get_dataflow_buffer(program.impl().get_dfb_handle("dfb_b"))->device_slot, 1u);
@@ -614,21 +606,21 @@ TEST_F(MeshDeviceFixture, AliasDFBDisjointHalvesDataFlow) {
     auto input_ra = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words_a);
     auto input_rb = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words_b);
 
-    detail::WriteToBuffer(*left.in_a.mesh_buffer().get_reference_buffer(), input_la);
-    detail::WriteToBuffer(*left.in_b.mesh_buffer().get_reference_buffer(), input_lb);
-    detail::WriteToBuffer(*right.in_a.mesh_buffer().get_reference_buffer(), input_ra);
-    detail::WriteToBuffer(*right.in_b.mesh_buffer().get_reference_buffer(), input_rb);
+    slow_dispatch::WriteToBuffer(left.in_a.mesh_buffer(), input_la);
+    slow_dispatch::WriteToBuffer(left.in_b.mesh_buffer(), input_lb);
+    slow_dispatch::WriteToBuffer(right.in_a.mesh_buffer(), input_ra);
+    slow_dispatch::WriteToBuffer(right.in_b.mesh_buffer(), input_rb);
     if (is_quasar) {
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(this->device(), program);
 
     std::vector<uint32_t> out_la, out_lb, out_ra, out_rb;
-    detail::ReadFromBuffer(*left.out_a.mesh_buffer().get_reference_buffer(), out_la);
-    detail::ReadFromBuffer(*left.out_b.mesh_buffer().get_reference_buffer(), out_lb);
-    detail::ReadFromBuffer(*right.out_a.mesh_buffer().get_reference_buffer(), out_ra);
-    detail::ReadFromBuffer(*right.out_b.mesh_buffer().get_reference_buffer(), out_rb);
+    slow_dispatch::ReadFromBuffer(left.out_a.mesh_buffer(), out_la);
+    slow_dispatch::ReadFromBuffer(left.out_b.mesh_buffer(), out_lb);
+    slow_dispatch::ReadFromBuffer(right.out_a.mesh_buffer(), out_ra);
+    slow_dispatch::ReadFromBuffer(right.out_b.mesh_buffer(), out_rb);
 
     EXPECT_EQ(out_la, input_la) << "left half DFB_A round-trip mismatch";
     EXPECT_EQ(out_lb, input_lb) << "left half DFB_B (alias) round-trip mismatch";
@@ -636,30 +628,37 @@ TEST_F(MeshDeviceFixture, AliasDFBDisjointHalvesDataFlow) {
     EXPECT_EQ(out_rb, input_rb) << "right half DFB_D (alias) round-trip mismatch";
 }
 
-TEST_F(MeshDeviceFixture, AliasDFBDataFlow2Sx4S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, AliasDFBDataFlow2Sx4S) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Multi-producer DFB requires Quasar TC hardware";
     }
     run_alias_dfb_program(
-        devices_.at(0), NodeCoord{0, 0},
-        /*entry_size_a=*/512, /*num_entries_a=*/8,
-        /*entry_size_b=*/256, /*num_entries_b=*/16,
-        /*num_producers=*/2, /*num_consumers=*/4);
+        this->device(),
+        NodeCoord{0, 0},
+        /*entry_size_a=*/512,
+        /*num_entries_a=*/8,
+        /*entry_size_b=*/256,
+        /*num_entries_b=*/16,
+        /*num_producers=*/2,
+        /*num_consumers=*/4);
 }
 
-TEST_F(MeshDeviceFixture, AliasDFBDataFlow4Sx2S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, AliasDFBDataFlow4Sx2S) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Multi-producer DFB requires Quasar TC hardware";
     }
     run_alias_dfb_program(
-        devices_.at(0), NodeCoord{0, 0},
-        /*entry_size_a=*/512, /*num_entries_a=*/8,
-        /*entry_size_b=*/256, /*num_entries_b=*/16,
-        /*num_producers=*/4, /*num_consumers=*/2);
+        this->device(),
+        NodeCoord{0, 0},
+        /*entry_size_a=*/512,
+        /*num_entries_a=*/8,
+        /*entry_size_b=*/256,
+        /*num_entries_b=*/16,
+        /*num_producers=*/4,
+        /*num_consumers=*/2);
 }
 
-TEST_F(MeshDeviceFixture, AliasDFBAllocSecondarySkipped) {
-    IDevice* device = devices_.at(0)->get_devices()[0];
+TEST_F(UnitMeshFixture, AliasDFBAllocSecondarySkipped) {
     const CoreCoord core{0, 0};
 
     const auto cfg_a = make_1sx1s_config(512, 8);
@@ -673,7 +672,7 @@ TEST_F(MeshDeviceFixture, AliasDFBAllocSecondarySkipped) {
 
     program.impl().set_dfb_alias(id_a, id_b);
     program.impl().finalize_dataflow_buffer_configs();
-    program.impl().allocate_dataflow_buffers(device);
+    program.impl().allocate_dataflow_buffers(slow_dispatch::physical_device_from_unit_mesh(this->device()));
 
     const uint32_t addr_a = program.impl().get_dataflow_buffer(id_a)->uniform_alloc_addr();
     const uint32_t addr_b = program.impl().get_dataflow_buffer(id_b)->uniform_alloc_addr();
@@ -689,8 +688,7 @@ TEST_F(MeshDeviceFixture, AliasDFBAllocSecondarySkipped) {
         << "Allocator double-counted the secondary: addr_c is too far";
 }
 
-TEST_F(MeshDeviceFixture, AliasDFBAlloc3Way) {
-    IDevice* device = devices_.at(0)->get_devices()[0];
+TEST_F(UnitMeshFixture, AliasDFBAlloc3Way) {
     const CoreCoord core{0, 0};
 
     const auto cfg_a = make_1sx1s_config(512,  8);
@@ -705,7 +703,7 @@ TEST_F(MeshDeviceFixture, AliasDFBAlloc3Way) {
     program.impl().set_dfb_alias(id_a, id_b);
     program.impl().set_dfb_alias(id_a, id_c);
     program.impl().finalize_dataflow_buffer_configs();
-    program.impl().allocate_dataflow_buffers(device);
+    program.impl().allocate_dataflow_buffers(slow_dispatch::physical_device_from_unit_mesh(this->device()));
 
     const uint32_t addr_a = program.impl().get_dataflow_buffer(id_a)->uniform_alloc_addr();
     const uint32_t addr_b = program.impl().get_dataflow_buffer(id_b)->uniform_alloc_addr();
@@ -720,8 +718,7 @@ TEST_F(MeshDeviceFixture, AliasDFBAlloc3Way) {
         addr_a, addr_b, addr_c);
 }
 
-TEST_F(MeshDeviceFixture, AliasDFBAgreedGroupResize) {
-    IDevice* device = devices_.at(0)->get_devices()[0];
+TEST_F(UnitMeshFixture, AliasDFBAgreedGroupResize) {
     const CoreCoord core{0, 0};
 
     // Two aliased DFBs starting at equal total size (4096 B), plus a trailing non-aliased DFB to
@@ -737,7 +734,7 @@ TEST_F(MeshDeviceFixture, AliasDFBAgreedGroupResize) {
     program.impl().set_dfb_alias(id_a, id_b);
 
     program.impl().finalize_dataflow_buffer_configs();
-    program.impl().allocate_dataflow_buffers(device);
+    program.impl().allocate_dataflow_buffers(slow_dispatch::physical_device_from_unit_mesh(this->device()));
 
     const uint32_t addr_a0 = program.impl().get_dataflow_buffer(id_a)->uniform_alloc_addr();
     EXPECT_EQ(addr_a0, program.impl().get_dataflow_buffer(id_b)->uniform_alloc_addr())
@@ -751,7 +748,7 @@ TEST_F(MeshDeviceFixture, AliasDFBAgreedGroupResize) {
         {.dfb_id = id_b, .entry_size = 1024u, .num_entries = 8u},  // 8192
     };
     EXPECT_NO_THROW(program.impl().apply_dfb_size_overrides(overrides));
-    program.impl().allocate_dataflow_buffers(device);
+    program.impl().allocate_dataflow_buffers(slow_dispatch::physical_device_from_unit_mesh(this->device()));
 
     auto dfb_a = program.impl().get_dataflow_buffer(id_a);
     auto dfb_b = program.impl().get_dataflow_buffer(id_b);
@@ -764,20 +761,19 @@ TEST_F(MeshDeviceFixture, AliasDFBAgreedGroupResize) {
         << "Trailing DFB_C must follow the resized (8192 B) alias group footprint";
 }
 
-TEST_F(MeshDeviceFixture, AliasDFBBorrowedMemoryAddressEquality) {
+TEST_F(UnitMeshFixture, AliasDFBBorrowedMemoryAddressEquality) {
     const NodeCoord node{0, 0};
     constexpr uint32_t kEntrySize   = 512;
     constexpr uint32_t kNumEntries  = 8;
 
-    auto [spec, in_a, in_b, out_a, out_b, ring] = make_alias_borrowed_dfb_program_spec(
-        devices_.at(0), node, kEntrySize, kNumEntries);
+    auto [spec, in_a, in_b, out_a, out_b, ring] =
+        make_alias_borrowed_dfb_program_spec(this->device(), node, kEntrySize, kNumEntries);
 
-    Program program = MakeProgramFromSpec(*devices_.at(0), spec);
+    Program program = MakeProgramFromSpec(this->device(), spec);
 
-    IDevice* device = devices_.at(0)->get_devices()[0];
-    detail::CompileProgram(device, program);
+    slow_dispatch::CompileProgram(this->device(), program);
     program.impl().finalize_dataflow_buffer_configs();
-    program.impl().allocate_dataflow_buffers(device);
+    program.impl().allocate_dataflow_buffers(slow_dispatch::physical_device_from_unit_mesh(this->device()));
 
     auto rtas = [&]() {
         return MakeRuntimeArgsForSingleNode(
@@ -814,8 +810,7 @@ TEST_F(MeshDeviceFixture, AliasDFBBorrowedMemoryAddressEquality) {
 
     const uint32_t addr_borrowed = program.impl().get_dataflow_buffer(id_borrowed)->uniform_alloc_addr();
     const uint32_t addr_alias    = program.impl().get_dataflow_buffer(id_alias)->uniform_alloc_addr();
-    const uint32_t ring_addr     =
-        static_cast<uint32_t>(ring.mesh_buffer().get_reference_buffer()->address());
+    const uint32_t ring_addr = static_cast<uint32_t>(ring.mesh_buffer().address());
 
     EXPECT_EQ(addr_borrowed, ring_addr)
         << "dfb_borrowed must resolve to the ring tensor's L1 address";
@@ -828,15 +823,15 @@ TEST_F(MeshDeviceFixture, AliasDFBBorrowedMemoryAddressEquality) {
         addr_borrowed, addr_alias, ring_addr);
 }
 
-TEST_F(MeshDeviceFixture, AliasDFBBorrowedMemoryDataFlow1Sx1S) {
+TEST_F(UnitMeshFixture, AliasDFBBorrowedMemoryDataFlow1Sx1S) {
     const NodeCoord node{0, 0};
     constexpr uint32_t kEntrySize  = 512;
     constexpr uint32_t kNumEntries = 8;
 
-    auto [spec, in_a, in_b, out_a, out_b, ring] = make_alias_borrowed_dfb_program_spec(
-        devices_.at(0), node, kEntrySize, kNumEntries);
+    auto [spec, in_a, in_b, out_a, out_b, ring] =
+        make_alias_borrowed_dfb_program_spec(this->device(), node, kEntrySize, kNumEntries);
 
-    Program program = MakeProgramFromSpec(*devices_.at(0), spec);
+    Program program = MakeProgramFromSpec(this->device(), spec);
 
     auto rtas = [&]() {
         return MakeRuntimeArgsForSingleNode(
@@ -872,19 +867,18 @@ TEST_F(MeshDeviceFixture, AliasDFBBorrowedMemoryDataFlow1Sx1S) {
     auto input_a = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words);
     auto input_b = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, words);
 
-    detail::WriteToBuffer(*in_a.mesh_buffer().get_reference_buffer(), input_a);
-    detail::WriteToBuffer(*in_b.mesh_buffer().get_reference_buffer(), input_b);
+    slow_dispatch::WriteToBuffer(in_a.mesh_buffer(), input_a);
+    slow_dispatch::WriteToBuffer(in_b.mesh_buffer(), input_b);
 
-    if (devices_.at(0)->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         std::this_thread::sleep_for(std::chrono::milliseconds(500));
     }
 
-    IDevice* device = devices_.at(0)->get_devices()[0];
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(this->device(), program);
 
     std::vector<uint32_t> result_a, result_b;
-    detail::ReadFromBuffer(*out_a.mesh_buffer().get_reference_buffer(), result_a);
-    detail::ReadFromBuffer(*out_b.mesh_buffer().get_reference_buffer(), result_b);
+    slow_dispatch::ReadFromBuffer(out_a.mesh_buffer(), result_a);
+    slow_dispatch::ReadFromBuffer(out_b.mesh_buffer(), result_b);
 
     EXPECT_EQ(result_a, input_a)
         << "Phase A (dfb_borrowed) data did not round-trip correctly";

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
@@ -260,7 +260,7 @@ void run_borrowed_memory_dfb_program(
     std::iota(input.begin(), input.end(), 0u);
     slow_dispatch::WriteToBuffer(src_tensor.mesh_buffer(), input);
 
-    slow_dispatch::LaunchProgram(mesh_device, program);
+    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     // Assert the borrowed tensor's L1 address was used for the DFB ring. For a borrowed DFB this
     // stays PINNED across a size override (no reallocation).
@@ -401,7 +401,7 @@ void run_update_address_test(
         {experimental::TensorParamName{"dfb_ring_tensor"}, TensorArgument{ring_tensor_a}},
     };
     SetProgramRunArgs(program, params1);
-    slow_dispatch::LaunchProgram(mesh_device, program);
+    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     EXPECT_EQ(
         program.impl().dataflow_buffers()[0]->uniform_alloc_addr(),
@@ -448,7 +448,7 @@ void run_update_address_test(
                 {experimental::TensorParamName{"dfb_ring_tensor"}, TensorArgument{ring_tensor_b}},
             });
     }
-    slow_dispatch::LaunchProgram(mesh_device, program);
+    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     EXPECT_EQ(
         program.impl().dataflow_buffers()[0]->uniform_alloc_addr(),

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
@@ -27,6 +27,7 @@
 #include <tt-metalium/tensor/spec/layout/page_config.hpp>
 
 #include "device_fixture.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include "impl/dataflow_buffer/dataflow_buffer_impl.hpp"
 #include "impl/program/program_impl.hpp"
 #include "metal2_host_api/test_helpers.hpp"
@@ -85,12 +86,8 @@ struct BorrowedDFBTestConfig {
 //   1. The DFB ring was allocated at the borrowed MeshTensor's L1 address.
 //   2. (Optional) DRAM output == DRAM input.
 void run_borrowed_memory_dfb_program(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    const NodeCoord& node,
-    const BorrowedDFBTestConfig& cfg) {
-
-    IDevice* device = mesh_device->get_devices()[0];
-    const ARCH arch = device->arch();
+    distributed::MeshDevice& mesh_device, const NodeCoord& node, const BorrowedDFBTestConfig& cfg) {
+    const ARCH arch = mesh_device.arch();
     const bool is_all = (cfg.cap == DFBAccessPattern::ALL);
 
     constexpr uint32_t implicit_sync = 0;
@@ -204,14 +201,14 @@ void run_borrowed_memory_dfb_program(
     // -----------------------------------------------------------------------
     // Create program and allocate tensors
     // -----------------------------------------------------------------------
-    Program program = MakeProgramFromSpec(*mesh_device, spec);
+    Program program = MakeProgramFromSpec(mesh_device, spec);
 
-    MeshTensor src_tensor = MeshTensor::allocate_on_device(*mesh_device, src_spec);
+    MeshTensor src_tensor = MeshTensor::allocate_on_device(mesh_device, src_spec);
     std::optional<MeshTensor> dst_tensor;
     if (!cfg.tensix_consumer) {
-        dst_tensor.emplace(MeshTensor::allocate_on_device(*mesh_device, dst_spec));
+        dst_tensor.emplace(MeshTensor::allocate_on_device(mesh_device, dst_spec));
     }
-    MeshTensor ring_tensor = MeshTensor::allocate_on_device(*mesh_device, ring_spec);
+    MeshTensor ring_tensor = MeshTensor::allocate_on_device(mesh_device, ring_spec);
 
     // -----------------------------------------------------------------------
     // Build and apply run params
@@ -261,9 +258,9 @@ void run_borrowed_memory_dfb_program(
     // -----------------------------------------------------------------------
     std::vector<uint32_t> input(cfg.num_entries * cfg.entry_size / sizeof(uint32_t));
     std::iota(input.begin(), input.end(), 0u);
-    detail::WriteToBuffer(*src_tensor.mesh_buffer().get_reference_buffer(), input);
+    slow_dispatch::WriteToBuffer(src_tensor.mesh_buffer(), input);
 
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(mesh_device, program);
 
     // Assert the borrowed tensor's L1 address was used for the DFB ring. For a borrowed DFB this
     // stays PINNED across a size override (no reallocation).
@@ -278,7 +275,7 @@ void run_borrowed_memory_dfb_program(
 
     if (cfg.verify_data && !cfg.tensix_consumer) {
         std::vector<uint32_t> output;
-        detail::ReadFromBuffer(*dst_tensor->mesh_buffer().get_reference_buffer(), output);
+        slow_dispatch::ReadFromBuffer(dst_tensor->mesh_buffer(), output);
         EXPECT_EQ(input, output);
     }
 }
@@ -286,11 +283,10 @@ void run_borrowed_memory_dfb_program(
 // Verifies that UpdateTensorArgs can redirect a borrowed DFB ring to a different
 // L1 tensor between runs on the same compiled program.
 void run_update_address_test(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     const NodeCoord& node,
     std::optional<uint32_t> reentry_num_entries_override = std::nullopt) {
-    IDevice* device = mesh_device->get_devices()[0];
-    const ARCH arch = device->arch();
+    const ARCH arch = mesh_device.arch();
 
     constexpr uint32_t num_entries  = 16;
     constexpr uint32_t entry_size   = 256;
@@ -369,14 +365,14 @@ void run_update_address_test(
     spec.dataflow_buffers = {dfb_spec};
     spec.work_units       = {MakeMinimalWorkUnit("work_unit", node, {"producer", "consumer"})};
 
-    Program program = MakeProgramFromSpec(*mesh_device, spec);
+    Program program = MakeProgramFromSpec(mesh_device, spec);
 
-    MeshTensor src_tensor = MeshTensor::allocate_on_device(*mesh_device, src_spec);
-    MeshTensor dst_tensor = MeshTensor::allocate_on_device(*mesh_device, dst_spec);
+    MeshTensor src_tensor = MeshTensor::allocate_on_device(mesh_device, src_spec);
+    MeshTensor dst_tensor = MeshTensor::allocate_on_device(mesh_device, dst_spec);
 
     // Two distinct L1 ring tensors - swapped between runs.
-    MeshTensor ring_tensor_a = MeshTensor::allocate_on_device(*mesh_device, ring_spec);
-    MeshTensor ring_tensor_b = MeshTensor::allocate_on_device(*mesh_device, ring_spec);
+    MeshTensor ring_tensor_a = MeshTensor::allocate_on_device(mesh_device, ring_spec);
+    MeshTensor ring_tensor_b = MeshTensor::allocate_on_device(mesh_device, ring_spec);
     ASSERT_NE(ring_tensor_a.address(), ring_tensor_b.address())
         << "Test pre-condition: two separate L1 allocations must have distinct addresses";
 
@@ -386,7 +382,7 @@ void run_update_address_test(
     // --- Run 1: ring at ring_tensor_a ---
     std::vector<uint32_t> input_a(total_words);
     std::iota(input_a.begin(), input_a.end(), 0u);
-    detail::WriteToBuffer(*src_tensor.mesh_buffer().get_reference_buffer(), input_a);
+    slow_dispatch::WriteToBuffer(src_tensor.mesh_buffer(), input_a);
 
     ProgramRunArgs params1;
     params1.kernel_run_args = {
@@ -405,14 +401,14 @@ void run_update_address_test(
         {experimental::TensorParamName{"dfb_ring_tensor"}, TensorArgument{ring_tensor_a}},
     };
     SetProgramRunArgs(program, params1);
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(mesh_device, program);
 
     EXPECT_EQ(
         program.impl().dataflow_buffers()[0]->uniform_alloc_addr(),
         static_cast<uint32_t>(ring_tensor_a.address()));
     {
         std::vector<uint32_t> output;
-        detail::ReadFromBuffer(*dst_tensor.mesh_buffer().get_reference_buffer(), output);
+        slow_dispatch::ReadFromBuffer(dst_tensor.mesh_buffer(), output);
         EXPECT_EQ(input_a, output);
     }
 
@@ -422,7 +418,7 @@ void run_update_address_test(
     // UpdateTensorArgs fast-path (address only).
     std::vector<uint32_t> input_b(total_words);
     std::iota(input_b.begin(), input_b.end(), total_words);  // distinct from run 1
-    detail::WriteToBuffer(*src_tensor.mesh_buffer().get_reference_buffer(), input_b);
+    slow_dispatch::WriteToBuffer(src_tensor.mesh_buffer(), input_b);
 
     if (reentry_num_entries_override.has_value()) {
         // Combined re-bind + resize in ONE SetProgramRunArgs: point the borrowed ring at a different
@@ -452,7 +448,7 @@ void run_update_address_test(
                 {experimental::TensorParamName{"dfb_ring_tensor"}, TensorArgument{ring_tensor_b}},
             });
     }
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(mesh_device, program);
 
     EXPECT_EQ(
         program.impl().dataflow_buffers()[0]->uniform_alloc_addr(),
@@ -463,7 +459,7 @@ void run_update_address_test(
     }
     {
         std::vector<uint32_t> output;
-        detail::ReadFromBuffer(*dst_tensor.mesh_buffer().get_reference_buffer(), output);
+        slow_dispatch::ReadFromBuffer(dst_tensor.mesh_buffer(), output);
         EXPECT_EQ(input_b, output);
     }
 }
@@ -474,29 +470,32 @@ void run_update_address_test(
 // All-architecture tests (Quasar, Wormhole, Blackhole)
 // =============================================================================
 
-TEST_F(MeshDeviceFixture, BorrowedMemoryDMDM1Sx1S) {
-    run_borrowed_memory_dfb_program(devices_.at(0), NodeCoord{0, 0}, {
-        .num_entries     = 16,
-        .entry_size      = 256,
-        .num_producers   = 1,
-        .num_consumers   = 1,
-        .cap             = DFBAccessPattern::STRIDED,
-        .tensix_consumer = false,
-        .verify_data     = true,
-    });
-}
-
-TEST_F(MeshDeviceFixture, BorrowedMemoryDMDM1Sx1S_UpdateAddress) {
-    run_update_address_test(devices_.at(0), NodeCoord{0, 0});
-}
-
-TEST_F(MeshDeviceFixture, BorrowedMemoryDMDM1Sx1S_UpdateAddressAndSize) {
-    run_update_address_test(devices_.at(0), NodeCoord{0, 0}, /*reentry_num_entries_override=*/8);
-}
-
-TEST_F(MeshDeviceFixture, BorrowedMemoryDMDM1Sx1S_NumEntriesOverride) {
+TEST_F(UnitMeshFixture, BorrowedMemoryDMDM1Sx1S) {
     run_borrowed_memory_dfb_program(
-        devices_.at(0),
+        this->device(),
+        NodeCoord{0, 0},
+        {
+            .num_entries = 16,
+            .entry_size = 256,
+            .num_producers = 1,
+            .num_consumers = 1,
+            .cap = DFBAccessPattern::STRIDED,
+            .tensix_consumer = false,
+            .verify_data = true,
+        });
+}
+
+TEST_F(UnitMeshFixture, BorrowedMemoryDMDM1Sx1S_UpdateAddress) {
+    run_update_address_test(this->device(), NodeCoord{0, 0});
+}
+
+TEST_F(UnitMeshFixture, BorrowedMemoryDMDM1Sx1S_UpdateAddressAndSize) {
+    run_update_address_test(this->device(), NodeCoord{0, 0}, /*reentry_num_entries_override=*/8);
+}
+
+TEST_F(UnitMeshFixture, BorrowedMemoryDMDM1Sx1S_NumEntriesOverride) {
+    run_borrowed_memory_dfb_program(
+        this->device(),
         NodeCoord{0, 0},
         {
             .num_entries = 16,
@@ -510,9 +509,9 @@ TEST_F(MeshDeviceFixture, BorrowedMemoryDMDM1Sx1S_NumEntriesOverride) {
         });
 }
 
-TEST_F(MeshDeviceFixture, BorrowedMemoryDMDM1Sx1S_SizeOverrideExceedsBackingFails) {
+TEST_F(UnitMeshFixture, BorrowedMemoryDMDM1Sx1S_SizeOverrideExceedsBackingFails) {
     run_borrowed_memory_dfb_program(
-        devices_.at(0),
+        this->device(),
         NodeCoord{0, 0},
         {
             .num_entries = 16,
@@ -531,49 +530,58 @@ TEST_F(MeshDeviceFixture, BorrowedMemoryDMDM1Sx1S_SizeOverrideExceedsBackingFail
 // Quasar-only tests (multi-producer / multi-consumer, explicit sync)
 // =============================================================================
 
-TEST_F(MeshDeviceFixture, BorrowedMemoryDMDM2Sx4S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, BorrowedMemoryDMDM2Sx4S) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Multi-producer DFB requires Quasar";
     }
-    run_borrowed_memory_dfb_program(devices_.at(0), NodeCoord{0, 0}, {
-        .num_entries     = 16,
-        .entry_size      = 256,
-        .num_producers   = 2,
-        .num_consumers   = 4,
-        .cap             = DFBAccessPattern::STRIDED,
-        .tensix_consumer = false,
-        .verify_data     = true,
-    });
+    run_borrowed_memory_dfb_program(
+        this->device(),
+        NodeCoord{0, 0},
+        {
+            .num_entries = 16,
+            .entry_size = 256,
+            .num_producers = 2,
+            .num_consumers = 4,
+            .cap = DFBAccessPattern::STRIDED,
+            .tensix_consumer = false,
+            .verify_data = true,
+        });
 }
 
-TEST_F(MeshDeviceFixture, BorrowedMemoryDMDM4Sx2S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, BorrowedMemoryDMDM4Sx2S) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Multi-producer DFB requires Quasar";
     }
-    run_borrowed_memory_dfb_program(devices_.at(0), NodeCoord{0, 0}, {
-        .num_entries     = 16,
-        .entry_size      = 256,
-        .num_producers   = 4,
-        .num_consumers   = 2,
-        .cap             = DFBAccessPattern::STRIDED,
-        .tensix_consumer = false,
-        .verify_data     = true,
-    });
+    run_borrowed_memory_dfb_program(
+        this->device(),
+        NodeCoord{0, 0},
+        {
+            .num_entries = 16,
+            .entry_size = 256,
+            .num_producers = 4,
+            .num_consumers = 2,
+            .cap = DFBAccessPattern::STRIDED,
+            .tensix_consumer = false,
+            .verify_data = true,
+        });
 }
 
-TEST_F(MeshDeviceFixture, BorrowedMemoryDMTensix2Sx4B) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, BorrowedMemoryDMTensix2Sx4B) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Multi-producer DFB requires Quasar";
     }
-    run_borrowed_memory_dfb_program(devices_.at(0), NodeCoord{0, 0}, {
-        .num_entries     = 16,
-        .entry_size      = 256,
-        .num_producers   = 2,
-        .num_consumers   = 4,
-        .cap             = DFBAccessPattern::ALL,
-        .tensix_consumer = true,
-        .verify_data     = false,
-    });
+    run_borrowed_memory_dfb_program(
+        this->device(),
+        NodeCoord{0, 0},
+        {
+            .num_entries = 16,
+            .entry_size = 256,
+            .num_producers = 2,
+            .num_consumers = 4,
+            .cap = DFBAccessPattern::ALL,
+            .tensix_consumer = true,
+            .verify_data = false,
+        });
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_apis.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_apis.cpp
@@ -181,7 +181,7 @@ TEST_F(UnitMeshFixture, DataflowBufferReadTileValue) {
     std::vector<DataT> result_init(expected_scalar_reads.size(), 0u);
     slow_dispatch::WriteToL1(this->device(), CoreCoord(0, 0), result_l1_addr, result_init);
 
-    slow_dispatch::LaunchProgram(this->device(), program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     tt_driver_atomics::mfence();
     std::vector<DataT> scalar_results;
@@ -471,7 +471,7 @@ void run_extent_probe(distributed::MeshDevice& mesh_device, const ExtentProbePar
     };
     m2::SetProgramRunArgs(program, run_args);
 
-    slow_dispatch::LaunchProgram(mesh_device, program);
+    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
     tt_driver_atomics::mfence();
 
     const CoreCoord core{0, 0};

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_apis.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_apis.cpp
@@ -31,6 +31,7 @@
 #include <tt-metalium/tensor/spec/layout/page_config.hpp>
 
 #include "dfb_test_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include "device_fixture.hpp"
 #include "llrt/rtoptions.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
@@ -40,12 +41,10 @@ namespace tt::tt_metal {
 
 namespace m2 = experimental;
 
-TEST_F(MeshDeviceFixture, DataflowBufferReadTileValue) {
+TEST_F(UnitMeshFixture, DataflowBufferReadTileValue) {
     using DataT = std::uint32_t;
 
-    auto mesh_device = devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
-    if (device->arch() == ARCH::QUASAR) {
+    if (this->device().arch() == ARCH::QUASAR) {
         GTEST_SKIP() << "Quasar read_tile_value / get_tile_address on DFB is under debug; run on WH/BH";
     }
     if (MetalContext::instance().rtoptions().get_simulator_enabled()) {
@@ -96,7 +95,7 @@ TEST_F(MeshDeviceFixture, DataflowBufferReadTileValue) {
     const uint32_t words_per_entry = entry_size / sizeof(DataT);
 
     const auto tensor_spec = make_flat_dram_tensor_spec(entry_size, num_entries);
-    auto in_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
+    auto in_tensor = MeshTensor::allocate_on_device(this->device(), tensor_spec);
 
     m2::DataflowBufferSpec dfb_spec{
         .unique_id = DFB,
@@ -149,12 +148,12 @@ TEST_F(MeshDeviceFixture, DataflowBufferReadTileValue) {
         .work_units = {wu},
     };
 
-    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = m2::MakeProgramFromSpec(this->device(), spec);
 
     const uint32_t result_size_bytes = static_cast<uint32_t>(expected_scalar_reads.size() * sizeof(DataT));
-    const uint32_t l1_alignment = device->allocator()->get_alignment(BufferType::L1);
+    const uint32_t l1_alignment = this->device().allocator()->get_alignment(BufferType::L1);
     const uint32_t aligned_result_size = (result_size_bytes + l1_alignment - 1) / l1_alignment * l1_alignment;
-    const uint32_t result_l1_addr = static_cast<uint32_t>(device->l1_size_per_core()) - aligned_result_size;
+    const uint32_t result_l1_addr = static_cast<uint32_t>(this->device().l1_size_per_core()) - aligned_result_size;
 
     m2::ProgramRunArgs params;
     params.kernel_run_args = {
@@ -177,16 +176,16 @@ TEST_F(MeshDeviceFixture, DataflowBufferReadTileValue) {
     input[1] = tile0_val1;
     input[words_per_entry + 0] = tile1_val0;
     input[words_per_entry + 1] = tile1_val1;
-    detail::WriteToBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), input);
+    slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
 
     std::vector<DataT> result_init(expected_scalar_reads.size(), 0u);
-    detail::WriteToDeviceL1(device, CoreCoord(0, 0), result_l1_addr, result_init);
+    slow_dispatch::WriteToL1(this->device(), CoreCoord(0, 0), result_l1_addr, result_init);
 
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(this->device(), program);
 
     tt_driver_atomics::mfence();
     std::vector<DataT> scalar_results;
-    detail::ReadFromDeviceL1(device, CoreCoord(0, 0), result_l1_addr, result_size_bytes, scalar_results);
+    slow_dispatch::ReadFromL1(this->device(), CoreCoord(0, 0), result_l1_addr, result_size_bytes, scalar_results);
     ASSERT_EQ(scalar_results.size(), expected_scalar_reads.size());
     for (uint32_t thread = 0; thread < num_trisc_threads; ++thread) {
         const auto begin = scalar_results.begin() + thread * num_results_per_thread;
@@ -329,17 +328,17 @@ inline void expect_wh_bh_aliases(const ExtentRecord& rec) {
     EXPECT_EQ(rec[StrideSize], rec[EntrySize]);
 }
 
-inline uint32_t allocate_l1_result_region(IDevice* device, uint32_t bytes) {
-    const uint32_t alignment = device->allocator()->get_alignment(BufferType::L1);
+inline uint32_t allocate_l1_result_region(distributed::MeshDevice& mesh_device, uint32_t bytes) {
+    const uint32_t alignment = mesh_device.allocator()->get_alignment(BufferType::L1);
     const uint32_t aligned = (bytes + alignment - 1u) / alignment * alignment;
-    return static_cast<uint32_t>(device->l1_size_per_core()) - aligned;
+    return static_cast<uint32_t>(mesh_device.l1_size_per_core()) - aligned;
 }
 
-inline ExtentRecord read_extent_record(IDevice* device, CoreCoord core, uint32_t l1_addr) {
+inline ExtentRecord read_extent_record(distributed::MeshDevice& mesh_device, CoreCoord core, uint32_t l1_addr) {
     constexpr uint32_t num_fields = 8;
     constexpr uint32_t record_bytes = num_fields * sizeof(uint32_t);
     std::vector<uint32_t> words(num_fields, 0u);
-    detail::ReadFromDeviceL1(device, core, l1_addr, record_bytes, words);
+    slow_dispatch::ReadFromL1(mesh_device, core, l1_addr, record_bytes, words);
     ExtentRecord rec{};
     for (uint32_t i = 0; i < num_fields; ++i) {
         rec[i] = words[i];
@@ -370,11 +369,10 @@ struct ExtentProbeParams {
     ConsumerProbeConfig consumer{};
 };
 
-void run_extent_probe(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const ExtentProbeParams& params) {
+void run_extent_probe(distributed::MeshDevice& mesh_device, const ExtentProbeParams& params) {
     constexpr uint32_t extent_record_bytes = 8 * sizeof(uint32_t);
 
-    IDevice* device = mesh_device->get_devices()[0];
-    const bool is_quasar = device->arch() == ARCH::QUASAR;
+    const bool is_quasar = mesh_device.arch() == ARCH::QUASAR;
 
     if (!is_quasar && (params.num_producers > 1 || params.num_consumers > 1)) {
         GTEST_SKIP() << "WH/BH supports 1Sx1S only";
@@ -451,13 +449,13 @@ void run_extent_probe(const std::shared_ptr<distributed::MeshDevice>& mesh_devic
         .work_units = {wu},
     };
 
-    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = m2::MakeProgramFromSpec(mesh_device, spec);
 
     const uint32_t producer_records =
         params.num_producers * params.producer.num_tc_snapshots;
     const uint32_t consumer_records = params.consumer.num_tc_snapshots;
     const uint32_t producer_result_l1 =
-        allocate_l1_result_region(device, (producer_records + consumer_records) * extent_record_bytes);
+        allocate_l1_result_region(mesh_device, (producer_records + consumer_records) * extent_record_bytes);
     const uint32_t consumer_result_l1 = producer_result_l1 + producer_records * extent_record_bytes;
 
     m2::ProgramRunArgs run_args;
@@ -473,7 +471,7 @@ void run_extent_probe(const std::shared_ptr<distributed::MeshDevice>& mesh_devic
     };
     m2::SetProgramRunArgs(program, run_args);
 
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(mesh_device, program);
     tt_driver_atomics::mfence();
 
     const CoreCoord core{0, 0};
@@ -496,7 +494,7 @@ void run_extent_probe(const std::shared_ptr<distributed::MeshDevice>& mesh_devic
         for (uint32_t s = 0; s < params.producer.num_tc_snapshots; ++s) {
             const uint32_t l1_addr =
                 producer_result_l1 + (t * params.producer.num_tc_snapshots + s) * extent_record_bytes;
-            const ExtentRecord rec = read_extent_record(device, core, l1_addr);
+            const ExtentRecord rec = read_extent_record(mesh_device, core, l1_addr);
             if (is_quasar) {
                 expect_extent_record(rec, expected_producer);
             } else {
@@ -509,7 +507,7 @@ void run_extent_probe(const std::shared_ptr<distributed::MeshDevice>& mesh_devic
     }
 
     for (uint32_t s = 0; s < params.consumer.num_tc_snapshots; ++s) {
-        const ExtentRecord rec = read_extent_record(device, core, consumer_result_l1 + s * extent_record_bytes);
+        const ExtentRecord rec = read_extent_record(mesh_device, core, consumer_result_l1 + s * extent_record_bytes);
         if (is_quasar) {
             expect_extent_record(rec, expected_consumer);
         } else {
@@ -521,19 +519,19 @@ void run_extent_probe(const std::shared_ptr<distributed::MeshDevice>& mesh_devic
     }
 
     if (is_quasar && params.producer.num_tc_snapshots == 1 && params.num_producers > params.num_consumers) {
-        const ExtentRecord consumer_rec = read_extent_record(device, core, consumer_result_l1);
+        const ExtentRecord consumer_rec = read_extent_record(mesh_device, core, consumer_result_l1);
         EXPECT_LT(consumer_rec[LocalSizeBytes], consumer_rec[RingSpanBytes])
             << "multi-TC consumer RISC: local ring < bounding span";
     }
     if (is_quasar && params.producer.num_tc_snapshots == 1 && params.num_consumers > params.num_producers &&
         params.consumer_access_pattern == m2::DFBAccessPattern::STRIDED) {
-        const ExtentRecord producer_rec = read_extent_record(device, core, producer_result_l1);
+        const ExtentRecord producer_rec = read_extent_record(mesh_device, core, producer_result_l1);
         EXPECT_LT(producer_rec[LocalSizeBytes], producer_rec[RingSpanBytes])
             << "multi-TC producer RISC: local ring < bounding span";
     }
     if (is_quasar && params.producer.num_tc_snapshots == 1 &&
         params.consumer_access_pattern == m2::DFBAccessPattern::ALL && params.num_producers > 1) {
-        const ExtentRecord consumer_rec = read_extent_record(device, core, consumer_result_l1);
+        const ExtentRecord consumer_rec = read_extent_record(mesh_device, core, consumer_result_l1);
         EXPECT_LT(consumer_rec[LocalSizeBytes], consumer_rec[RingSpanBytes])
             << "ALL consumer multi-TC RISC: local ring < bounding span";
     }
@@ -541,13 +539,11 @@ void run_extent_probe(const std::shared_ptr<distributed::MeshDevice>& mesh_devic
 
 }  // namespace
 
-TEST_F(MeshDeviceFixture, DataflowBufferExtentApis_1Sx1S) {
-    run_extent_probe(devices_.at(0), {});
-}
+TEST_F(UnitMeshFixture, DataflowBufferExtentApis_1Sx1S) { run_extent_probe(this->device(), {}); }
 
-TEST_F(MeshDeviceFixture, DataflowBufferExtentApis_4Sx1S) {
+TEST_F(UnitMeshFixture, DataflowBufferExtentApis_4Sx1S) {
     run_extent_probe(
-        devices_.at(0),
+        this->device(),
         {
             .num_producers = 4,
             .num_consumers = 1,
@@ -555,9 +551,9 @@ TEST_F(MeshDeviceFixture, DataflowBufferExtentApis_4Sx1S) {
 }
 
 // 2Sx4S: each producer RISC round-robins 2 TCs (push advances tc_idx between snapshots).
-TEST_F(MeshDeviceFixture, DataflowBufferExtentApis_2Sx4S_ProducerEachTC) {
+TEST_F(UnitMeshFixture, DataflowBufferExtentApis_2Sx4S_ProducerEachTC) {
     run_extent_probe(
-        devices_.at(0),
+        this->device(),
         {
             .num_producers = 2,
             .num_consumers = 4,
@@ -575,9 +571,9 @@ TEST_F(MeshDeviceFixture, DataflowBufferExtentApis_2Sx4S_ProducerEachTC) {
 }
 
 // 2Sx4A: each consumer RISC round-robins 2 TCs (pop advances tc_idx between snapshots).
-TEST_F(MeshDeviceFixture, DataflowBufferExtentApis_2Sx4A_ConsumerEachTC) {
+TEST_F(UnitMeshFixture, DataflowBufferExtentApis_2Sx4A_ConsumerEachTC) {
     run_extent_probe(
-        devices_.at(0),
+        this->device(),
         {
             .num_producers = 2,
             .num_consumers = 4,

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_base.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_base.cpp
@@ -5,6 +5,7 @@
 // Base single-DFB config sweep (full Metal 2.0 matrix).
 
 #include "dfb_test_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
 
@@ -37,7 +38,7 @@ static std::string M2ImplicitSyncParamName(const ::testing::TestParamInfo<bool>&
             .implicit_sync = GetParam(),                                       \
             .num_entries = default_num_entries((num_p), (num_c)),              \
         };                                                                     \
-        run_single_dfb_program_2_0(this->devices_.at(0), params);              \
+        run_single_dfb_program_2_0(this->device(), params);                    \
     }
 
 DFB_TEST_2_0(DMTest1xDFB1Sx1S, DM, DM, 1, STRIDED, 1, STRIDED)

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
@@ -36,6 +36,7 @@
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "../metal2_host_api/test_helpers.hpp"
 #include "dfb_test_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
 
@@ -243,8 +244,8 @@ void validate_dfb_tile_counters(
     }
 }
 
-TEST_F(MeshDeviceFixture, DMTensixTest1xDFB1Sx1SConfig) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, DMTensixTest1xDFB1Sx1SConfig) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
     experimental::dfb::DataflowBufferConfig config{
@@ -274,8 +275,8 @@ TEST_F(MeshDeviceFixture, DMTensixTest1xDFB1Sx1SConfig) {
 }
 
 // Host-only: validates Quasar L1 packing (96B header + per-hart blobs + producer-ready region).
-TEST_F(MeshDeviceFixture, DfbSerializeGlobalHeader1Sx1S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, DfbSerializeGlobalHeader1Sx1S) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
     experimental::dfb::DataflowBufferConfig config{
@@ -294,7 +295,7 @@ TEST_F(MeshDeviceFixture, DfbSerializeGlobalHeader1Sx1S) {
     CoreCoord logical_core = CoreCoord(0, 0);
     experimental::dfb::CreateDataflowBuffer(program, logical_core, config);
     program.impl().finalize_dataflow_buffer_configs();
-    program.impl().allocate_dataflow_buffers(this->devices_.at(0)->get_devices()[0]);
+    program.impl().allocate_dataflow_buffers(slow_dispatch::physical_device_from_unit_mesh(this->device()));
 
     const auto& dfbs = program.impl().dataflow_buffers_on_core(logical_core);
     ASSERT_EQ(dfbs.size(), 1u);
@@ -370,8 +371,8 @@ TEST_F(MeshDeviceFixture, DfbSerializeGlobalHeader1Sx1S) {
     EXPECT_EQ(nbytes, experimental::dfb::detail::compute_dfb_config_serialized_size(dfbs));
 }
 
-TEST_F(MeshDeviceFixture, DfbSerializeTxnCentricImplicitSync1Sx1S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, DfbSerializeTxnCentricImplicitSync1Sx1S) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
     experimental::dfb::DataflowBufferConfig config{
@@ -390,7 +391,7 @@ TEST_F(MeshDeviceFixture, DfbSerializeTxnCentricImplicitSync1Sx1S) {
     CoreCoord logical_core = CoreCoord(0, 0);
     experimental::dfb::CreateDataflowBuffer(program, logical_core, config);
     program.impl().finalize_dataflow_buffer_configs();
-    program.impl().allocate_dataflow_buffers(this->devices_.at(0)->get_devices()[0]);
+    program.impl().allocate_dataflow_buffers(slow_dispatch::physical_device_from_unit_mesh(this->device()));
 
     const auto& dfbs = program.impl().dataflow_buffers_on_core(logical_core);
     ASSERT_EQ(dfbs.size(), 1u);
@@ -451,8 +452,8 @@ TEST_F(MeshDeviceFixture, DfbSerializeTxnCentricImplicitSync1Sx1S) {
     }
 }
 
-TEST_F(MeshDeviceFixture, DMTest1xDFB1Sx4SConfig) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, DMTest1xDFB1Sx4SConfig) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
     experimental::dfb::DataflowBufferConfig config{
@@ -486,8 +487,8 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB1Sx4SConfig) {
     validate_dfb_tile_counters(program, logical_core, config, expectation);
 }
 
-TEST_F(MeshDeviceFixture, DMTensixTest1xDFB4Sx1SConfig) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, DMTensixTest1xDFB4Sx1SConfig) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
     experimental::dfb::DataflowBufferConfig config{
@@ -519,8 +520,8 @@ TEST_F(MeshDeviceFixture, DMTensixTest1xDFB4Sx1SConfig) {
     validate_dfb_tile_counters(program, logical_core, config, expectation);
 }
 
-TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx1SConfig) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, DMTest1xDFB4Sx1SConfig) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
     experimental::dfb::DataflowBufferConfig config{
@@ -552,8 +553,8 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx1SConfig) {
     validate_dfb_tile_counters(program, logical_core, config, expectation);
 }
 
-TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx4SConfig) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, DMTest1xDFB4Sx4SConfig) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
     experimental::dfb::DataflowBufferConfig config{
@@ -585,8 +586,8 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx4SConfig) {
     validate_dfb_tile_counters(program, logical_core, config, expectation);
 }
 
-TEST_F(MeshDeviceFixture, DMTest1xDFB2Sx4SConfig) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, DMTest1xDFB2Sx4SConfig) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
     experimental::dfb::DataflowBufferConfig config{
@@ -624,8 +625,8 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB2Sx4SConfig) {
     validate_dfb_tile_counters(program, logical_core, config, expectation);
 }
 
-TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx2SConfig) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, DMTest1xDFB4Sx2SConfig) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
     experimental::dfb::DataflowBufferConfig config{
@@ -657,8 +658,8 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx2SConfig) {
     validate_dfb_tile_counters(program, logical_core, config, expectation);
 }
 
-TEST_F(MeshDeviceFixture, DMTest1xDFB1Sx1BConfig) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, DMTest1xDFB1Sx1BConfig) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
     experimental::dfb::DataflowBufferConfig config{
@@ -687,8 +688,8 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB1Sx1BConfig) {
     validate_dfb_tile_counters(program, logical_core, config, expectation);
 }
 
-TEST_F(MeshDeviceFixture, DMTest1xDFB1Sx4BConfig) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, DMTest1xDFB1Sx4BConfig) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
     experimental::dfb::DataflowBufferConfig config{
@@ -722,8 +723,8 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB1Sx4BConfig) {
     validate_dfb_tile_counters(program, logical_core, config, expectation);
 }
 
-TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx1BConfig) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, DMTest1xDFB4Sx1BConfig) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
     experimental::dfb::DataflowBufferConfig config{
@@ -755,8 +756,8 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx1BConfig) {
     validate_dfb_tile_counters(program, logical_core, config, expectation);
 }
 
-TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx4BConfig) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, DMTest1xDFB4Sx4BConfig) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
     experimental::dfb::DataflowBufferConfig config{
@@ -812,8 +813,8 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx4BConfig) {
     validate_dfb_tile_counters(program, logical_core, config, expectation);
 }
 
-TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx2BConfig) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, DMTest1xDFB4Sx2BConfig) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
     experimental::dfb::DataflowBufferConfig config{
@@ -864,8 +865,8 @@ TEST_F(MeshDeviceFixture, DMTest1xDFB4Sx2BConfig) {
 // 2S x 4B: 2 producers (riscs 0,1) with 4 blocked consumers (riscs 2,3,4,5)
 // Each producer has 1 TC, each consumer has 2 TCs (num_producers TCs)
 // ALL: Each consumer's TC[i] pairs with producer[i]
-TEST_F(MeshDeviceFixture, DMTest1xDFB2Sx4BConfig) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, DMTest1xDFB2Sx4BConfig) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
     experimental::dfb::DataflowBufferConfig config{
@@ -953,8 +954,8 @@ static void validate_multicore_dfb_groups(
 
 // Multi-core DFB, no implicit sync: 2 cores, 1 producer, 1 consumer, STRIDED.
 // Expected: 1 DfbGroup (homogeneous HW config) with 2 cores.
-TEST_F(MeshDeviceFixture, MultiCoreDFB_1P1C_Strided_NoImplicitSync) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, MultiCoreDFB_1P1C_Strided_NoImplicitSync) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
     experimental::dfb::DataflowBufferConfig config{
@@ -1015,8 +1016,8 @@ TEST_F(MeshDeviceFixture, MultiCoreDFB_1P1C_Strided_NoImplicitSync) {
 
 // Multi-core DFB, with implicit sync: 2 cores, 1 producer, 1 consumer, STRIDED.
 // Txn IDs should be allocated once (core-invariant) and identical across cores.
-TEST_F(MeshDeviceFixture, MultiCoreDFB_1P1C_Strided_ImplicitSync) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, MultiCoreDFB_1P1C_Strided_ImplicitSync) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
     experimental::dfb::DataflowBufferConfig config{
@@ -1053,8 +1054,8 @@ TEST_F(MeshDeviceFixture, MultiCoreDFB_1P1C_Strided_ImplicitSync) {
 }
 
 // Identical-config multi-core: assert one DfbGroup is produced (multicast-ready).
-TEST_F(MeshDeviceFixture, MultiCoreDFB_HomogeneousGrid_SingleGroup) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, MultiCoreDFB_HomogeneousGrid_SingleGroup) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
     experimental::dfb::DataflowBufferConfig config{
@@ -1145,8 +1146,8 @@ void validate_intra_tensix_dfb(
         (int)rc.config.remapper_pair_index);
 }
 
-TEST_F(MeshDeviceFixture, TensixIntraTest1xDFB1Sx1SConfig) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, TensixIntraTest1xDFB1Sx1SConfig) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping DFB test for WH/BH until DFB is backported";
     }
     // Intra-tensix: pack TRISC (producer) → unpack TRISC (consumer) on Neo0.
@@ -1188,13 +1189,13 @@ inline experimental::ProgramRunArgs MakeMinimalRunArgs(const experimental::NodeC
 
 // num_entries override on a finalized DFB recomputes the txn descriptor in place while PRESERVING the
 // TC assignment and transaction IDs (only the threshold changes for the new ring depth).
-TEST_F(MeshDeviceFixture, DFBReentryOverridePreservesTcAndRecomputesTxn) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, DFBReentryOverridePreservesTcAndRecomputesTxn) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "DFB transaction IDs / tile counters require Quasar";
     }
     const experimental::NodeCoord node{0, 0};
     experimental::ProgramSpec spec = experimental::test_helpers::MakeMinimalValidProgramSpec();
-    Program program = experimental::MakeProgramFromSpec(*devices_.at(0), spec);
+    Program program = experimental::MakeProgramFromSpec(this->device(), spec);
 
     program.impl().finalize_dataflow_buffer_configs();
 
@@ -1245,13 +1246,13 @@ TEST_F(MeshDeviceFixture, DFBReentryOverridePreservesTcAndRecomputesTxn) {
 
 // On re-entry the txn-id count is preserved, so a num_entries override that breaks the preserved divisor
 // is rejected up front with an actionable message.
-TEST_F(MeshDeviceFixture, DFBReentryNumEntriesViolatesTxnDivisorFails) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, DFBReentryNumEntriesViolatesTxnDivisorFails) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "DFB transaction-id divisor check requires Quasar";
     }
     const experimental::NodeCoord node{0, 0};
     experimental::ProgramSpec spec = experimental::test_helpers::MakeMinimalValidProgramSpec();
-    Program program = experimental::MakeProgramFromSpec(*devices_.at(0), spec);
+    Program program = experimental::MakeProgramFromSpec(this->device(), spec);
     program.impl().finalize_dataflow_buffer_configs();
 
     auto params = MakeMinimalRunArgs(node);
@@ -1265,13 +1266,13 @@ TEST_F(MeshDeviceFixture, DFBReentryNumEntriesViolatesTxnDivisorFails) {
 
 // Ring extent past Tensix unreserved L1 is rejected. entry_size stays within the TRISC uint16
 // L1-unit field so this hits the L1 check rather than the entry_size width check.
-TEST_F(MeshDeviceFixture, DFBReentryEntrySizeRingExtentFails) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, DFBReentryEntrySizeRingExtentFails) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "DFB ring-extent check requires Quasar";
     }
     const experimental::NodeCoord node{0, 0};
     experimental::ProgramSpec spec = experimental::test_helpers::MakeMinimalValidProgramSpec();
-    Program program = experimental::MakeProgramFromSpec(*devices_.at(0), spec);
+    Program program = experimental::MakeProgramFromSpec(this->device(), spec);
     program.impl().finalize_dataflow_buffer_configs();
 
     auto params = MakeMinimalRunArgs(node);
@@ -1285,13 +1286,13 @@ TEST_F(MeshDeviceFixture, DFBReentryEntrySizeRingExtentFails) {
 }
 
 // TRISC stores entry_size in uint16 L1 units; 1 MiB is 65536 units and must fail before init truncates.
-TEST_F(MeshDeviceFixture, DFBReentryEntrySizeExceedsUint16Fails) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, DFBReentryEntrySizeExceedsUint16Fails) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "DFB TRISC entry_size check requires Quasar";
     }
     const experimental::NodeCoord node{0, 0};
     experimental::ProgramSpec spec = experimental::test_helpers::MakeMinimalValidProgramSpec();
-    Program program = experimental::MakeProgramFromSpec(*devices_.at(0), spec);
+    Program program = experimental::MakeProgramFromSpec(this->device(), spec);
     program.impl().finalize_dataflow_buffer_configs();
 
     auto params = MakeMinimalRunArgs(node);
@@ -1304,13 +1305,13 @@ TEST_F(MeshDeviceFixture, DFBReentryEntrySizeExceedsUint16Fails) {
 
 // capacity (num_entries / max(producers, consumers)) is stored as uint16_t (the tile-counter register
 // width); an override that pushes it past the max is rejected rather than silently truncated.
-TEST_F(MeshDeviceFixture, DFBOverrideCapacityExceedsUint16Fails) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, DFBOverrideCapacityExceedsUint16Fails) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "DFB capacity / tile-counter limit requires Quasar";
     }
     const experimental::NodeCoord node{0, 0};
     experimental::ProgramSpec spec = experimental::test_helpers::MakeMinimalValidProgramSpec();
-    Program program = experimental::MakeProgramFromSpec(*devices_.at(0), spec);
+    Program program = experimental::MakeProgramFromSpec(this->device(), spec);
 
     auto params = MakeMinimalRunArgs(node);
     params.dfb_run_overrides.push_back(
@@ -1319,7 +1320,6 @@ TEST_F(MeshDeviceFixture, DFBOverrideCapacityExceedsUint16Fails) {
         [&] { experimental::SetProgramRunArgs(program, params); },
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("capacity 70000 exceeds the maximum 65535")));
 }
-
 
 // ============================================================================
 // Metal 2.0 config/validation ports (folded from test_dataflow_buffer_2_0.cpp
@@ -1366,8 +1366,7 @@ struct M2ConfigDFBParams {
     std::optional<m2::NodeRange> target_nodes = std::nullopt;  // override single-core default
 };
 
-static inline Program build_single_dfb_program_2_0(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const M2ConfigDFBParams& p) {
+static inline Program build_single_dfb_program_2_0(distributed::MeshDevice& mesh_device, const M2ConfigDFBParams& p) {
     const m2::NodeCoord node{0, 0};
     const m2::DFBSpecName DFB{"dfb"};
     const m2::KernelSpecName PRODUCER{"producer"};
@@ -1473,7 +1472,7 @@ static inline Program build_single_dfb_program_2_0(
         .tensor_parameters = tensor_parameters,
         .work_units = {wu},
     };
-    return m2::MakeProgramFromSpec(*mesh_device, spec);
+    return m2::MakeProgramFromSpec(mesh_device, spec);
 }
 
 // Semantic TC-pairing check (M2 doesn't expose explicit risc masks, so we don't
@@ -1618,14 +1617,13 @@ static inline void validate_multicore_dfb_groups_2_0(
 // Group 5 M2: 2-core homogeneous-grid checks (legacy: MultiCoreDFB_1P1C_Strided_*)
 // =====================================================================================
 
-TEST_F(MeshDeviceFixture, MultiCoreDFB_1P1C_Strided_NoImplicitSync_2_0) {
-    auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, MultiCoreDFB_1P1C_Strided_NoImplicitSync_2_0) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "M2 path is Quasar-only";
     }
     // 2-core test (nodes (0,0)..(1,0)): the Quasar 1x3 emu reports a 1x1
     // compute grid, so skip there.
-    CoreCoord grid = mesh_device->get_devices()[0]->compute_with_storage_grid_size();
+    CoreCoord grid = this->device().compute_with_storage_grid_size();
     if (grid.x < 2) {
         GTEST_SKIP() << "2-core test requires grid.x >= 2 (got " << grid.x << "x" << grid.y << ")";
     }
@@ -1638,7 +1636,7 @@ TEST_F(MeshDeviceFixture, MultiCoreDFB_1P1C_Strided_NoImplicitSync_2_0) {
         .implicit_sync = false,
         .target_nodes = m2::NodeRange{m2::NodeCoord{0, 0}, m2::NodeCoord{1, 0}},
     };
-    Program program = build_single_dfb_program_2_0(mesh_device, p);
+    Program program = build_single_dfb_program_2_0(this->device(), p);
     program.impl().finalize_dataflow_buffer_configs();
     validate_multicore_dfb_groups_2_0(
         program, *p.target_nodes, /*expected_num_groups=*/1, /*expected_cores_per_group=*/2);
@@ -1665,14 +1663,13 @@ TEST_F(MeshDeviceFixture, MultiCoreDFB_1P1C_Strided_NoImplicitSync_2_0) {
     }
 }
 
-TEST_F(MeshDeviceFixture, MultiCoreDFB_1P1C_Strided_ImplicitSync_2_0) {
-    auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, MultiCoreDFB_1P1C_Strided_ImplicitSync_2_0) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "M2 path is Quasar-only";
     }
     // 2-core test (nodes (0,0)..(1,0)): the Quasar 1x3 emu reports a 1x1
     // compute grid, so skip there.
-    CoreCoord grid = mesh_device->get_devices()[0]->compute_with_storage_grid_size();
+    CoreCoord grid = this->device().compute_with_storage_grid_size();
     if (grid.x < 2) {
         GTEST_SKIP() << "2-core test requires grid.x >= 2 (got " << grid.x << "x" << grid.y << ")";
     }
@@ -1685,7 +1682,7 @@ TEST_F(MeshDeviceFixture, MultiCoreDFB_1P1C_Strided_ImplicitSync_2_0) {
         .implicit_sync = true,
         .target_nodes = m2::NodeRange{m2::NodeCoord{0, 0}, m2::NodeCoord{1, 0}},
     };
-    Program program = build_single_dfb_program_2_0(mesh_device, p);
+    Program program = build_single_dfb_program_2_0(this->device(), p);
     program.impl().finalize_dataflow_buffer_configs();
     validate_multicore_dfb_groups_2_0(
         program, *p.target_nodes, /*expected_num_groups=*/1, /*expected_cores_per_group=*/2);
@@ -1708,9 +1705,8 @@ TEST_F(MeshDeviceFixture, MultiCoreDFB_1P1C_Strided_ImplicitSync_2_0) {
 // =====================================================================================
 
 #define CONFIG_TC_TEST_2_0(name, prod, cons, num_p, num_c, pap_kind, cap_kind, exp_prod_tc, exp_cons_tc) \
-    TEST_F(MeshDeviceFixture, name##_2_0) {                                                              \
-        auto& mesh_device = this->devices_.at(0);                                                        \
-        if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {                                     \
+    TEST_F(UnitMeshFixture, name##_2_0) {                                                                \
+        if (this->device().arch() != ARCH::QUASAR) {                                                     \
             GTEST_SKIP() << "M2 path is Quasar-only";                                                    \
         }                                                                                                \
         using namespace m2_config_test_helpers;                                                          \
@@ -1723,7 +1719,7 @@ TEST_F(MeshDeviceFixture, MultiCoreDFB_1P1C_Strided_ImplicitSync_2_0) {
             .cap = m2::DFBAccessPattern::cap_kind,                                                       \
             .implicit_sync = false,                                                                      \
         };                                                                                               \
-        Program program = build_single_dfb_program_2_0(mesh_device, p);                                  \
+        Program program = build_single_dfb_program_2_0(this->device(), p);                               \
         program.impl().finalize_dataflow_buffer_configs();                                               \
         validate_dfb_tile_counters_2_0(                                                                  \
             program,                                                                                     \
@@ -1799,9 +1795,8 @@ TEST(TxnIdAllocatorTest, AllocatesTopDownFromDfbPool) {
 
 // B2: For num_entries in {16, 15, 7}, producer_txn_descriptor.num_txn_ids should
 // land on {2, 3, 1} (divisibility-based selection).
-TEST_F(MeshDeviceFixture, B2_TxnIdAllocator_Boundaries_Config_2_0) {
-    auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, B2_TxnIdAllocator_Boundaries_Config_2_0) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Implicit sync (and therefore the txn-id allocator) is Quasar-only";
     }
     using namespace m2_config_test_helpers;
@@ -1827,7 +1822,7 @@ TEST_F(MeshDeviceFixture, B2_TxnIdAllocator_Boundaries_Config_2_0) {
             .num_entries = c.num_entries,
             .implicit_sync = true,
         };
-        Program program = build_single_dfb_program_2_0(mesh_device, p);
+        Program program = build_single_dfb_program_2_0(this->device(), p);
         program.impl().finalize_dataflow_buffer_configs();
         auto dfbs = program.impl().dataflow_buffers_on_core(CoreCoord(0, 0));
         ASSERT_EQ(dfbs.size(), 1u);
@@ -1857,9 +1852,8 @@ TEST_F(MeshDeviceFixture, B2_TxnIdAllocator_Boundaries_Config_2_0) {
 // B4: Verifies the cached `num_entries_to_process_threshold` field:
 //   STRIDED: threshold = num_entries / num_txn_ids
 //   ALL:     threshold = num_consumers * (num_entries / num_txn_ids)
-TEST_F(MeshDeviceFixture, B4_CachedThreshold_Config_2_0) {
-    auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, B4_CachedThreshold_Config_2_0) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Implicit sync (and therefore threshold caching) is Quasar-only";
     }
     using namespace m2_config_test_helpers;
@@ -1875,7 +1869,7 @@ TEST_F(MeshDeviceFixture, B4_CachedThreshold_Config_2_0) {
             .num_entries = 16,
             .implicit_sync = true,
         };
-        Program program = build_single_dfb_program_2_0(mesh_device, p);
+        Program program = build_single_dfb_program_2_0(this->device(), p);
         program.impl().finalize_dataflow_buffer_configs();
         auto dfbs = program.impl().dataflow_buffers_on_core(CoreCoord(0, 0));
         ASSERT_EQ(dfbs.size(), 1u);
@@ -1900,7 +1894,7 @@ TEST_F(MeshDeviceFixture, B4_CachedThreshold_Config_2_0) {
             .cap = m2::DFBAccessPattern::ALL,
             .implicit_sync = true,
         };
-        Program program = build_single_dfb_program_2_0(mesh_device, p);
+        Program program = build_single_dfb_program_2_0(this->device(), p);
         program.impl().finalize_dataflow_buffer_configs();
         auto dfbs = program.impl().dataflow_buffers_on_core(CoreCoord(0, 0));
         ASSERT_EQ(dfbs.size(), 1u);
@@ -1912,9 +1906,8 @@ TEST_F(MeshDeviceFixture, B4_CachedThreshold_Config_2_0) {
 
 // B10: divisibility — (a) pathological num_entries should fail at MakeProgramFromSpec/finalize;
 // (b) barely-divisible (only n=1 works) should succeed.
-TEST_F(MeshDeviceFixture, B10_NumEntriesDivisibility_2_0) {
-    auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, B10_NumEntriesDivisibility_2_0) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Txn-id allocator is Quasar-only";
     }
     using namespace m2_config_test_helpers;
@@ -1933,7 +1926,7 @@ TEST_F(MeshDeviceFixture, B10_NumEntriesDivisibility_2_0) {
         };
         EXPECT_THROW(
             {
-                Program program = build_single_dfb_program_2_0(mesh_device, p);
+                Program program = build_single_dfb_program_2_0(this->device(), p);
                 program.impl().finalize_dataflow_buffer_configs();
             },
             std::exception);
@@ -1952,7 +1945,7 @@ TEST_F(MeshDeviceFixture, B10_NumEntriesDivisibility_2_0) {
             .implicit_sync = false,
         };
         EXPECT_NO_THROW({
-            Program program = build_single_dfb_program_2_0(mesh_device, p);
+            Program program = build_single_dfb_program_2_0(this->device(), p);
             program.impl().finalize_dataflow_buffer_configs();
         });
     }
@@ -1971,9 +1964,8 @@ TEST_F(MeshDeviceFixture, B10_NumEntriesDivisibility_2_0) {
 // 8-DM > 6-DM-cap omissions in the CONFIG_TC_TEST_2_0 list above.
 
 // INTRA self-loop config probe (legacy: TensixIntraTest1xDFB1Sx1SConfig).
-TEST_F(MeshDeviceFixture, TensixIntraTest1xDFB1Sx1SConfig_2_0) {
-    auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, TensixIntraTest1xDFB1Sx1SConfig_2_0) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "INTRA scope is Quasar-only";
     }
     const m2::DFBSpecName DFB{"intra_dfb"};
@@ -2010,7 +2002,7 @@ TEST_F(MeshDeviceFixture, TensixIntraTest1xDFB1Sx1SConfig_2_0) {
         .tensor_parameters = {},
         .work_units = {m2::WorkUnitSpec{.name = "wu", .kernels = {COMPUTE}, .target_nodes = node}},
     };
-    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = m2::MakeProgramFromSpec(this->device(), spec);
     m2_config_test_helpers::validate_intra_tensix_dfb_2_0(program, CoreCoord(0, 0));
 }
 
@@ -2022,9 +2014,8 @@ TEST_F(MeshDeviceFixture, TensixIntraTest1xDFB1Sx1SConfig_2_0) {
 // =====================================================================================
 
 // B6 — Producer access pattern = ALL is rejected.
-TEST_F(MeshDeviceFixture, B6_AllProducer_Rejected_2_0) {
-    auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, B6_AllProducer_Rejected_2_0) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "DFB validation tested on Quasar";
     }
     using namespace m2_config_test_helpers;
@@ -2039,7 +2030,7 @@ TEST_F(MeshDeviceFixture, B6_AllProducer_Rejected_2_0) {
     };
     EXPECT_THROW(
         {
-            Program program = build_single_dfb_program_2_0(mesh_device, p);
+            Program program = build_single_dfb_program_2_0(this->device(), p);
             program.impl().finalize_dataflow_buffer_configs();
         },
         std::exception);
@@ -2050,14 +2041,13 @@ TEST_F(MeshDeviceFixture, B6_AllProducer_Rejected_2_0) {
 // (CircularBufferConfig is a legacy host-API construct). M2 programs are
 // purely DFB-based; the legacy CB-then-DFB rejection path can't be exercised
 // through the M2 spec model.
-TEST_F(MeshDeviceFixture, B7_CB_DFB_Mix_Rejected_2_0) {
+TEST_F(UnitMeshFixture, B7_CB_DFB_Mix_Rejected_2_0) {
     GTEST_SKIP() << "Not applicable: M2 ProgramSpec has no CB construct";
 }
 
 // B8 — ALL consumer with num_consumers > 4 is rejected (Remapper has 4 clientR slots).
-TEST_F(MeshDeviceFixture, B8_FiveAllConsumers_Rejected_2_0) {
-    auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, B8_FiveAllConsumers_Rejected_2_0) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Remapper limit tested on Quasar";
     }
     using namespace m2_config_test_helpers;
@@ -2073,7 +2063,7 @@ TEST_F(MeshDeviceFixture, B8_FiveAllConsumers_Rejected_2_0) {
     };
     EXPECT_THROW(
         {
-            Program program = build_single_dfb_program_2_0(mesh_device, p);
+            Program program = build_single_dfb_program_2_0(this->device(), p);
             program.impl().finalize_dataflow_buffer_configs();
         },
         std::exception);
@@ -2085,13 +2075,13 @@ TEST_F(MeshDeviceFixture, B8_FiveAllConsumers_Rejected_2_0) {
 // binds the DFB as both PRODUCER and CONSUMER). There's no way to construct an
 // INTER-scope spec through the M2 API, so the legacy rejection path has no
 // direct equivalent.
-TEST_F(MeshDeviceFixture, B9_InterTensixScope_Rejected_2_0) {
+TEST_F(UnitMeshFixture, B9_InterTensixScope_Rejected_2_0) {
     GTEST_SKIP() << "Not applicable: M2 DataflowBufferSpec has no tensix_scope field";
 }
 
 // Host-only: packer INTRA pairs allocate top-down from 63; DM1 1:m pairs stay in [0,16).
-TEST_F(MeshDeviceFixture, IntraPackerRemapperPairsTopDownConfig) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, IntraPackerRemapperPairsTopDownConfig) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Quasar-only remapper pool split";
     }
 
@@ -2167,8 +2157,8 @@ TEST_F(MeshDeviceFixture, IntraPackerRemapperPairsTopDownConfig) {
 // T7: one INTRA DFB past what a Neo's Tensix-only TC pool can back must fail. The limit is per Neo:
 // each INTRA DFB spends a ClientL + shadow pair out of that Neo's 16 Tensix-only TCs, so 8 fit and the
 // 9th exhausts the pool (and its packer remapper pair).
-TEST_F(MeshDeviceFixture, MaxEightIntraPerNeoConfig) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, MaxEightIntraPerNeoConfig) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Quasar-only INTRA TC pool limit";
     }
 
@@ -2195,7 +2185,6 @@ TEST_F(MeshDeviceFixture, MaxEightIntraPerNeoConfig) {
 
     EXPECT_THROW(program.impl().finalize_dataflow_buffer_configs(), std::exception);
 }
-
 
 // =====================================================================================
 // Device slot assignment
@@ -2237,10 +2226,8 @@ void expect_no_slot_collision_on_any_core(Program& program, const CoreRange& cor
 // A DFB created late (high program-wide id) that shares no core with the earlier DFBs should reuse a
 // low slot instead of extending the per-core config table. This is the shape that overflowed the
 // dispatch payload when the slot was just a creation counter (issue #51409).
-TEST_F(MeshDeviceFixture, DFBDeviceSlotsReusedAcrossDisjointCores) {
-    auto& mesh_device = this->devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
-    const CoreCoord grid = device->compute_with_storage_grid_size();
+TEST_F(UnitMeshFixture, DFBDeviceSlotsReusedAcrossDisjointCores) {
+    const CoreCoord grid = this->device().compute_with_storage_grid_size();
     // Coordinator at (0,0) plus workers spanning (1,0)..(4,0).
     if (grid.x < 5) {
         GTEST_SKIP() << "Needs at least 5 worker cores in a row (got " << grid.x << "x" << grid.y << ")";
@@ -2280,13 +2267,11 @@ TEST_F(MeshDeviceFixture, DFBDeviceSlotsReusedAcrossDisjointCores) {
 
 // The per-core slot limit is on how many DFBs share a core, not on how many exist in the program:
 // DFBs on disjoint cores all fit at slot 0.
-TEST_F(MeshDeviceFixture, DFBDeviceSlotLimitIsPerCoreNotPerProgram) {
-    auto& mesh_device = this->devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
-    const bool is_quasar = device->arch() == ARCH::QUASAR;
+TEST_F(UnitMeshFixture, DFBDeviceSlotLimitIsPerCoreNotPerProgram) {
+    const bool is_quasar = this->device().arch() == ARCH::QUASAR;
     const uint32_t max_slots =
         is_quasar ? static_cast<uint32_t>(::dfb::NUM_DFBS) : hal::get_arch_num_circular_buffers();
-    const CoreCoord grid = device->compute_with_storage_grid_size();
+    const CoreCoord grid = this->device().compute_with_storage_grid_size();
     const uint32_t num_dfbs = max_slots + 4;
     if (grid.x * grid.y < num_dfbs) {
         GTEST_SKIP() << "Needs at least " << num_dfbs << " cores to place one DFB per core";

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_configs.cpp
@@ -295,7 +295,7 @@ TEST_F(UnitMeshFixture, DfbSerializeGlobalHeader1Sx1S) {
     CoreCoord logical_core = CoreCoord(0, 0);
     experimental::dfb::CreateDataflowBuffer(program, logical_core, config);
     program.impl().finalize_dataflow_buffer_configs();
-    program.impl().allocate_dataflow_buffers(slow_dispatch::physical_device_from_unit_mesh(this->device()));
+    program.impl().allocate_dataflow_buffers(this->device().get_devices()[0]);
 
     const auto& dfbs = program.impl().dataflow_buffers_on_core(logical_core);
     ASSERT_EQ(dfbs.size(), 1u);
@@ -391,7 +391,7 @@ TEST_F(UnitMeshFixture, DfbSerializeTxnCentricImplicitSync1Sx1S) {
     CoreCoord logical_core = CoreCoord(0, 0);
     experimental::dfb::CreateDataflowBuffer(program, logical_core, config);
     program.impl().finalize_dataflow_buffer_configs();
-    program.impl().allocate_dataflow_buffers(slow_dispatch::physical_device_from_unit_mesh(this->device()));
+    program.impl().allocate_dataflow_buffers(this->device().get_devices()[0]);
 
     const auto& dfbs = program.impl().dataflow_buffers_on_core(logical_core);
     ASSERT_EQ(dfbs.size(), 1u);

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_disjoint_slots.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_disjoint_slots.cpp
@@ -303,7 +303,7 @@ TEST_F(UnitMeshFixture, HalfGrid3Plus3DFBsOnDevice) {
     }
     m2::SetProgramRunArgs(program, params);
 
-    slow_dispatch::LaunchProgram(this->device(), program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     for (uint32_t i = 0; i < per_half * 2; ++i) {
         std::vector<uint32_t> got;
@@ -339,7 +339,7 @@ TEST_F(UnitMeshFixture, HalfGrid16Plus16DFBsOnDevice) {
         {.kernel = m2::KernelSpecName{"cons_b"}, .runtime_arg_values = cons_rtas(m2::NodeCoord{1, 0})},
     };
     m2::SetProgramRunArgs(program, params);
-    slow_dispatch::LaunchProgram(this->device(), program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> left_slots(per_half), right_slots(per_half);
     for (uint32_t i = 0; i < per_half; ++i) {
@@ -449,7 +449,7 @@ TEST_F(UnitMeshFixture, HalfGridOnDeviceDataflow1DFBEach) {
     m2_writeshard_barrier_uint32(this->device(), in_a, input_a);
     m2_writeshard_barrier_uint32(this->device(), in_b, input_b);
 
-    slow_dispatch::LaunchProgram(this->device(), program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_a, result_b;
     slow_dispatch::ReadFromBuffer(out_a.mesh_buffer(), result_a);
@@ -528,7 +528,7 @@ TEST_F(UnitMeshFixture, CoordinatorWorkerSlotReuseOnDevice) {
         {.kernel = m2::KernelSpecName{"worker_cons"}, .runtime_arg_values = std::move(worker_cons_rtas)},
     };
     m2::SetProgramRunArgs(program, params);
-    slow_dispatch::LaunchProgram(this->device(), program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     expect_touch_results(
         this->device(),

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_disjoint_slots.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_disjoint_slots.cpp
@@ -22,6 +22,7 @@
 
 #include "device_fixture.hpp"
 #include "dfb_test_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include "impl/dataflow_buffer/dataflow_buffer_impl.hpp"
 #include "impl/program/program_impl.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
@@ -34,15 +35,16 @@ namespace m2 = experimental;
 using experimental::test_helpers::MakeMinimalDFB;
 using experimental::test_helpers::MakeMinimalWorkUnit;
 
-void require_at_least_two_nodes(IDevice* device) {
-    if (device->compute_with_storage_grid_size().x < 2) {
-        GTEST_SKIP() << "Needs at least two worker nodes in a row (got " << device->compute_with_storage_grid_size().x
-                     << "x" << device->compute_with_storage_grid_size().y << ")";
+void require_at_least_two_nodes(distributed::MeshDevice& mesh_device) {
+    if (mesh_device.compute_with_storage_grid_size().x < 2) {
+        GTEST_SKIP() << "Needs at least two worker nodes in a row (got "
+                     << mesh_device.compute_with_storage_grid_size().x << "x"
+                     << mesh_device.compute_with_storage_grid_size().y << ")";
     }
 }
 
-void apply_gen1_dm_configs(m2::KernelSpec& producer, m2::KernelSpec& consumer, IDevice* device) {
-    if (device->arch() == ARCH::QUASAR) {
+void apply_gen1_dm_configs(m2::KernelSpec& producer, m2::KernelSpec& consumer, distributed::MeshDevice& mesh_device) {
+    if (mesh_device.arch() == ARCH::QUASAR) {
         return;
     }
     producer.hw_config = m2::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0};
@@ -68,8 +70,8 @@ void expect_no_slot_collision_on_core(Program& program, const CoreCoord& core) {
     }
 }
 
-m2::KernelSpec make_touch_producer(const std::string& name, uint32_t num_dfbs, IDevice* device) {
-    const bool implicit_sync = device->arch() == ARCH::QUASAR;
+m2::KernelSpec make_touch_producer(const std::string& name, uint32_t num_dfbs, distributed::MeshDevice& mesh_device) {
+    const bool implicit_sync = mesh_device.arch() == ARCH::QUASAR;
     auto kernel = make_dm_kernel(
         m2::KernelSpecName{name}, "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_touch_producer.cpp");
     kernel.compiler_options = {.defines = {{"TEST_NUM_DFBS", std::to_string(num_dfbs)}}};
@@ -81,8 +83,8 @@ m2::KernelSpec make_touch_producer(const std::string& name, uint32_t num_dfbs, I
 }
 
 m2::KernelSpec make_touch_consumer(
-    const std::string& name, uint32_t num_dfbs, uint32_t touched_magic, IDevice* device) {
-    const bool implicit_sync = device->arch() == ARCH::QUASAR;
+    const std::string& name, uint32_t num_dfbs, uint32_t touched_magic, distributed::MeshDevice& mesh_device) {
+    const bool implicit_sync = mesh_device.arch() == ARCH::QUASAR;
     auto kernel = make_dm_kernel(
         m2::KernelSpecName{name}, "tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_touch_consumer.cpp");
     kernel.compiler_options = {.defines = {{"TEST_NUM_DFBS", std::to_string(num_dfbs)}}};
@@ -94,15 +96,15 @@ m2::KernelSpec make_touch_consumer(
     return kernel;
 }
 
-uint32_t touch_result_l1_addr(IDevice* device, uint32_t num_dfbs) {
+uint32_t touch_result_l1_addr(distributed::MeshDevice& mesh_device, uint32_t num_dfbs) {
     const uint32_t bytes = num_dfbs * 3 * sizeof(uint32_t);
-    const uint32_t align = device->allocator()->get_alignment(BufferType::L1);
+    const uint32_t align = mesh_device.allocator()->get_alignment(BufferType::L1);
     const uint32_t aligned = (bytes + align - 1) / align * align;
-    return static_cast<uint32_t>(device->l1_size_per_core()) - aligned;
+    return static_cast<uint32_t>(mesh_device.l1_size_per_core()) - aligned;
 }
 
 void expect_touch_results(
-    IDevice* device,
+    distributed::MeshDevice& mesh_device,
     const CoreCoord& core,
     uint32_t result_l1_addr,
     uint32_t num_dfbs,
@@ -111,7 +113,7 @@ void expect_touch_results(
     const std::vector<uint32_t>& expected_device_slots) {
     ASSERT_EQ(expected_device_slots.size(), num_dfbs);
     std::vector<uint32_t> got;
-    detail::ReadFromDeviceL1(device, core, result_l1_addr, num_dfbs * 3 * sizeof(uint32_t), got);
+    slow_dispatch::ReadFromL1(mesh_device, core, result_l1_addr, num_dfbs * 3 * sizeof(uint32_t), got);
     ASSERT_EQ(got.size(), num_dfbs * 3);
     for (uint32_t i = 0; i < num_dfbs; ++i) {
         EXPECT_EQ(got[i * 3 + 0], expected_entry_size) << "DFB local " << i << " entry_size";
@@ -142,19 +144,19 @@ void bind_touch_dfbs(
 // Quasar TxnIdAllocator is program-wide over DFB pool [8, 31] (24 IDs); each implicit-sync
 // DFB takes 4 IDs. Large programs (16+16) disable host implicit sync entirely and keep the
 // kernel on the probe path so we never exhaust the pool or hang in finish()/ISR drain.
-m2::ProgramSpec make_split_touch_spec(IDevice* device, uint32_t num_dfbs_per_half) {
+m2::ProgramSpec make_split_touch_spec(distributed::MeshDevice& mesh_device, uint32_t num_dfbs_per_half) {
     const m2::NodeCoord node_a{0, 0};
     const m2::NodeCoord node_b{1, 0};
     constexpr uint32_t touched_magic = 0xA11CED00u;
 
-    auto prod_a = make_touch_producer("prod_a", num_dfbs_per_half, device);
-    auto cons_a = make_touch_consumer("cons_a", num_dfbs_per_half, touched_magic, device);
-    auto prod_b = make_touch_producer("prod_b", num_dfbs_per_half, device);
-    auto cons_b = make_touch_consumer("cons_b", num_dfbs_per_half, touched_magic, device);
+    auto prod_a = make_touch_producer("prod_a", num_dfbs_per_half, mesh_device);
+    auto cons_a = make_touch_consumer("cons_a", num_dfbs_per_half, touched_magic, mesh_device);
+    auto prod_b = make_touch_producer("prod_b", num_dfbs_per_half, mesh_device);
+    auto cons_b = make_touch_consumer("cons_b", num_dfbs_per_half, touched_magic, mesh_device);
 
     m2::ProgramSpec spec;
     spec.name = "dfb_disjoint_split_touch";
-    const bool is_quasar = device->arch() == ARCH::QUASAR;
+    const bool is_quasar = mesh_device.arch() == ARCH::QUASAR;
     for (uint32_t i = 0; i < num_dfbs_per_half * 2; ++i) {
         const std::string name = "dfb_" + std::to_string(i);
         auto dfb = MakeMinimalDFB(name, /*entry_size=*/32, /*num_entries=*/2);
@@ -181,11 +183,9 @@ m2::ProgramSpec make_split_touch_spec(IDevice* device, uint32_t num_dfbs_per_hal
     return spec;
 }
 
-TEST_F(MeshDeviceFixture, HalfGrid3Plus3DFBsOnDevice) {
-    auto& mesh_device = this->devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
-    require_at_least_two_nodes(device);
-    const bool is_quasar = device->arch() == ARCH::QUASAR;
+TEST_F(UnitMeshFixture, HalfGrid3Plus3DFBsOnDevice) {
+    require_at_least_two_nodes(this->device());
+    const bool is_quasar = this->device().arch() == ARCH::QUASAR;
 
     constexpr uint32_t per_half = 3;
     constexpr uint32_t entry_size = 256;
@@ -199,8 +199,8 @@ TEST_F(MeshDeviceFixture, HalfGrid3Plus3DFBsOnDevice) {
     inputs.reserve(per_half * 2);
     outputs.reserve(per_half * 2);
     for (uint32_t i = 0; i < per_half * 2; ++i) {
-        inputs.push_back(MeshTensor::allocate_on_device(*mesh_device, tensor_spec));
-        outputs.push_back(MeshTensor::allocate_on_device(*mesh_device, tensor_spec));
+        inputs.push_back(MeshTensor::allocate_on_device(this->device(), tensor_spec));
+        outputs.push_back(MeshTensor::allocate_on_device(this->device(), tensor_spec));
     }
 
     auto make_triple_prod = [&](const std::string& name) {
@@ -222,8 +222,8 @@ TEST_F(MeshDeviceFixture, HalfGrid3Plus3DFBsOnDevice) {
     auto cons_a = make_triple_cons("cons_a");
     auto prod_b = make_triple_prod("prod_b");
     auto cons_b = make_triple_cons("cons_b");
-    apply_gen1_dm_configs(prod_a, cons_a, device);
-    apply_gen1_dm_configs(prod_b, cons_b, device);
+    apply_gen1_dm_configs(prod_a, cons_a, this->device());
+    apply_gen1_dm_configs(prod_b, cons_b, this->device());
 
     m2::ProgramSpec spec;
     spec.name = "half_grid_3plus3_dataflow";
@@ -277,7 +277,7 @@ TEST_F(MeshDeviceFixture, HalfGrid3Plus3DFBsOnDevice) {
          .target_nodes = node_b},
     };
 
-    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = m2::MakeProgramFromSpec(this->device(), spec);
     expect_half_grid_slots_packed(program, per_half, is_quasar);
     expect_no_slot_collision_on_core(program, CoreCoord{0, 0});
     expect_no_slot_collision_on_core(program, CoreCoord{1, 0});
@@ -296,40 +296,38 @@ TEST_F(MeshDeviceFixture, HalfGrid3Plus3DFBsOnDevice) {
     std::vector<std::vector<uint32_t>> expected(per_half * 2);
     for (uint32_t i = 0; i < per_half * 2; ++i) {
         expected[i] = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 1000000, words);
-        detail::WriteToBuffer(*inputs[i].mesh_buffer().get_reference_buffer(), expected[i]);
-        m2_writeshard_barrier_uint32(device, inputs[i], expected[i]);
+        slow_dispatch::WriteToBuffer(inputs[i].mesh_buffer(), expected[i]);
+        m2_writeshard_barrier_uint32(this->device(), inputs[i], expected[i]);
         params.tensor_args.insert({m2::TensorParamName{"in_" + std::to_string(i)}, std::cref(inputs[i])});
         params.tensor_args.insert({m2::TensorParamName{"out_" + std::to_string(i)}, std::cref(outputs[i])});
     }
     m2::SetProgramRunArgs(program, params);
 
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(this->device(), program);
 
     for (uint32_t i = 0; i < per_half * 2; ++i) {
         std::vector<uint32_t> got;
-        detail::ReadFromBuffer(*outputs[i].mesh_buffer().get_reference_buffer(), got);
+        slow_dispatch::ReadFromBuffer(outputs[i].mesh_buffer(), got);
         EXPECT_EQ(got, expected[i]) << "DFB " << i << " round-trip mismatch";
     }
 }
 
 // Stress: 16+16 DFBs. Credit-handshake over every buffer; host checks entry_size + device slot
 // written back from each consumer.
-TEST_F(MeshDeviceFixture, HalfGrid16Plus16DFBsOnDevice) {
-    auto& mesh_device = this->devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
-    require_at_least_two_nodes(device);
-    const bool is_quasar = device->arch() == ARCH::QUASAR;
+TEST_F(UnitMeshFixture, HalfGrid16Plus16DFBsOnDevice) {
+    require_at_least_two_nodes(this->device());
+    const bool is_quasar = this->device().arch() == ARCH::QUASAR;
 
     constexpr uint32_t per_half = 16;
     constexpr uint32_t touched_magic = 0xA11CED00u;
-    m2::ProgramSpec spec = make_split_touch_spec(device, per_half);
-    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    m2::ProgramSpec spec = make_split_touch_spec(this->device(), per_half);
+    Program program = m2::MakeProgramFromSpec(this->device(), spec);
 
     expect_half_grid_slots_packed(program, per_half, is_quasar);
     expect_no_slot_collision_on_core(program, CoreCoord{0, 0});
     expect_no_slot_collision_on_core(program, CoreCoord{1, 0});
 
-    const uint32_t result_addr = touch_result_l1_addr(device, per_half);
+    const uint32_t result_addr = touch_result_l1_addr(this->device(), per_half);
     auto cons_rtas = [&](const m2::NodeCoord& node) {
         return m2::MakeRuntimeArgsForSingleNode(node, {{"result_l1_addr", result_addr}});
     };
@@ -341,7 +339,7 @@ TEST_F(MeshDeviceFixture, HalfGrid16Plus16DFBsOnDevice) {
         {.kernel = m2::KernelSpecName{"cons_b"}, .runtime_arg_values = cons_rtas(m2::NodeCoord{1, 0})},
     };
     m2::SetProgramRunArgs(program, params);
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(this->device(), program);
 
     std::vector<uint32_t> left_slots(per_half), right_slots(per_half);
     for (uint32_t i = 0; i < per_half; ++i) {
@@ -352,17 +350,15 @@ TEST_F(MeshDeviceFixture, HalfGrid16Plus16DFBsOnDevice) {
                              ->device_slot;
     }
     expect_touch_results(
-        device, CoreCoord{0, 0}, result_addr, per_half, /*expected_entry_size=*/32, touched_magic, left_slots);
+        this->device(), CoreCoord{0, 0}, result_addr, per_half, /*expected_entry_size=*/32, touched_magic, left_slots);
     expect_touch_results(
-        device, CoreCoord{1, 0}, result_addr, per_half, /*expected_entry_size=*/32, touched_magic, right_slots);
+        this->device(), CoreCoord{1, 0}, result_addr, per_half, /*expected_entry_size=*/32, touched_magic, right_slots);
 }
 
 // End-to-end identity across two disjoint halves: one DFB + producer/consumer pair per half.
-TEST_F(MeshDeviceFixture, HalfGridOnDeviceDataflow1DFBEach) {
-    auto& mesh_device = this->devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
-    require_at_least_two_nodes(device);
-    const bool is_quasar = device->arch() == ARCH::QUASAR;
+TEST_F(UnitMeshFixture, HalfGridOnDeviceDataflow1DFBEach) {
+    require_at_least_two_nodes(this->device());
+    const bool is_quasar = this->device().arch() == ARCH::QUASAR;
 
     constexpr uint32_t entry_size = 1024;
     constexpr uint32_t num_entries = 8;
@@ -370,10 +366,10 @@ TEST_F(MeshDeviceFixture, HalfGridOnDeviceDataflow1DFBEach) {
     const m2::NodeCoord node_b{1, 0};
 
     const auto tensor_spec = make_flat_dram_tensor_spec(entry_size, num_entries, DataType::UINT32);
-    auto in_a = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
-    auto out_a = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
-    auto in_b = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
-    auto out_b = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
+    auto in_a = MeshTensor::allocate_on_device(this->device(), tensor_spec);
+    auto out_a = MeshTensor::allocate_on_device(this->device(), tensor_spec);
+    auto in_b = MeshTensor::allocate_on_device(this->device(), tensor_spec);
+    auto out_b = MeshTensor::allocate_on_device(this->device(), tensor_spec);
 
     const m2::DFBSpecName dfb_a{"dfb_a"};
     const m2::DFBSpecName dfb_b{"dfb_b"};
@@ -392,8 +388,8 @@ TEST_F(MeshDeviceFixture, HalfGridOnDeviceDataflow1DFBEach) {
     auto producer_b = make_dm_dfb_producer(prod_b, dfb_b, in_b_name, num_entries, is_quasar);
     auto consumer_b =
         make_dm_dfb_consumer(cons_b, dfb_b, out_b_name, num_entries, /*blocked_consumer=*/false, is_quasar);
-    apply_gen1_dm_configs(producer_a, consumer_a, device);
-    apply_gen1_dm_configs(producer_b, consumer_b, device);
+    apply_gen1_dm_configs(producer_a, consumer_a, this->device());
+    apply_gen1_dm_configs(producer_b, consumer_b, this->device());
 
     m2::ProgramSpec spec{
         .name = "half_grid_dataflow_1dfb",
@@ -423,7 +419,7 @@ TEST_F(MeshDeviceFixture, HalfGridOnDeviceDataflow1DFBEach) {
             },
     };
 
-    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = m2::MakeProgramFromSpec(this->device(), spec);
     EXPECT_EQ(program.impl().get_dataflow_buffer(program.impl().get_dfb_handle("dfb_a"))->device_slot, 0u);
     EXPECT_EQ(program.impl().get_dataflow_buffer(program.impl().get_dfb_handle("dfb_b"))->device_slot, 0u);
 
@@ -448,24 +444,22 @@ TEST_F(MeshDeviceFixture, HalfGridOnDeviceDataflow1DFBEach) {
     const uint32_t words = num_entries * entry_size / sizeof(uint32_t);
     auto input_a = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 1000000, words);
     auto input_b = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 1000000, words);
-    detail::WriteToBuffer(*in_a.mesh_buffer().get_reference_buffer(), input_a);
-    detail::WriteToBuffer(*in_b.mesh_buffer().get_reference_buffer(), input_b);
-    m2_writeshard_barrier_uint32(device, in_a, input_a);
-    m2_writeshard_barrier_uint32(device, in_b, input_b);
+    slow_dispatch::WriteToBuffer(in_a.mesh_buffer(), input_a);
+    slow_dispatch::WriteToBuffer(in_b.mesh_buffer(), input_b);
+    m2_writeshard_barrier_uint32(this->device(), in_a, input_a);
+    m2_writeshard_barrier_uint32(this->device(), in_b, input_b);
 
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(this->device(), program);
 
     std::vector<uint32_t> result_a, result_b;
-    detail::ReadFromBuffer(*out_a.mesh_buffer().get_reference_buffer(), result_a);
-    detail::ReadFromBuffer(*out_b.mesh_buffer().get_reference_buffer(), result_b);
+    slow_dispatch::ReadFromBuffer(out_a.mesh_buffer(), result_a);
+    slow_dispatch::ReadFromBuffer(out_b.mesh_buffer(), result_b);
     EXPECT_EQ(result_a, input_a) << "left-half DFB round-trip mismatch";
     EXPECT_EQ(result_b, input_b) << "right-half DFB round-trip mismatch";
 }
 
-TEST_F(MeshDeviceFixture, CoordinatorWorkerSlotReuseOnDevice) {
-    auto& mesh_device = this->devices_.at(0);
-    IDevice* device = mesh_device->get_devices()[0];
-    const CoreCoord grid = device->compute_with_storage_grid_size();
+TEST_F(UnitMeshFixture, CoordinatorWorkerSlotReuseOnDevice) {
+    const CoreCoord grid = this->device().compute_with_storage_grid_size();
     if (grid.x < 3) {
         GTEST_SKIP() << "Needs at least coordinator + 2 workers (got " << grid.x << "x" << grid.y << ")";
     }
@@ -476,10 +470,10 @@ TEST_F(MeshDeviceFixture, CoordinatorWorkerSlotReuseOnDevice) {
 
     // Coordinator: wide + coord-only (2). Workers: wide + 3 worker-only (4).
     constexpr uint32_t touched_magic = 0xA11CED00u;
-    auto coord_prod = make_touch_producer("coord_prod", 2, device);
-    auto coord_cons = make_touch_consumer("coord_cons", 2, touched_magic, device);
-    auto worker_prod = make_touch_producer("worker_prod", 4, device);
-    auto worker_cons = make_touch_consumer("worker_cons", 4, touched_magic, device);
+    auto coord_prod = make_touch_producer("coord_prod", 2, this->device());
+    auto coord_cons = make_touch_consumer("coord_cons", 2, touched_magic, this->device());
+    auto worker_prod = make_touch_producer("worker_prod", 4, this->device());
+    auto worker_cons = make_touch_consumer("worker_cons", 4, touched_magic, this->device());
 
     m2::ProgramSpec spec;
     spec.name = "dfb_sort_shape_touch";
@@ -508,7 +502,7 @@ TEST_F(MeshDeviceFixture, CoordinatorWorkerSlotReuseOnDevice) {
         MakeMinimalWorkUnit("wu_workers", m2::NodeRange{worker_start, worker_end}, {"worker_prod", "worker_cons"}),
     };
 
-    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = m2::MakeProgramFromSpec(this->device(), spec);
     const auto& impl = program.impl();
     EXPECT_EQ(impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_coord"))->id, 4u);
     EXPECT_EQ(impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_wide"))->device_slot, 0u);
@@ -520,8 +514,8 @@ TEST_F(MeshDeviceFixture, CoordinatorWorkerSlotReuseOnDevice) {
     expect_no_slot_collision_on_core(program, CoreCoord{1, 0});
 
     m2::ProgramRunArgs params;
-    const uint32_t coord_result_addr = touch_result_l1_addr(device, 2);
-    const uint32_t worker_result_addr = touch_result_l1_addr(device, 4);
+    const uint32_t coord_result_addr = touch_result_l1_addr(this->device(), 2);
+    const uint32_t worker_result_addr = touch_result_l1_addr(this->device(), 4);
     m2::KernelRunArgs::RuntimeArgValues worker_cons_rtas;
     for (size_t x = worker_start.x; x <= worker_end.x; ++x) {
         m2::AddRuntimeArgsForNode(worker_cons_rtas, m2::NodeCoord{x, 0}, {{"result_l1_addr", worker_result_addr}});
@@ -534,10 +528,10 @@ TEST_F(MeshDeviceFixture, CoordinatorWorkerSlotReuseOnDevice) {
         {.kernel = m2::KernelSpecName{"worker_cons"}, .runtime_arg_values = std::move(worker_cons_rtas)},
     };
     m2::SetProgramRunArgs(program, params);
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(this->device(), program);
 
     expect_touch_results(
-        device,
+        this->device(),
         CoreCoord{0, 0},
         coord_result_addr,
         2,
@@ -546,7 +540,7 @@ TEST_F(MeshDeviceFixture, CoordinatorWorkerSlotReuseOnDevice) {
         {impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_wide"))->device_slot,
          impl.get_dataflow_buffer(impl.get_dfb_handle("dfb_coord"))->device_slot});
     expect_touch_results(
-        device,
+        this->device(),
         CoreCoord{1, 0},
         worker_result_addr,
         4,

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_edge_cases.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_edge_cases.cpp
@@ -126,7 +126,7 @@ static void run_a1_pipeline(distributed::MeshDevice& mesh_device, A1Transform tr
     slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
     m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
-    slow_dispatch::LaunchProgram(mesh_device, program);
+    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
     slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
@@ -226,7 +226,7 @@ static void run_dm_dfb_dm_implicit_sync_2_0(
     m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
     for (uint32_t iter = 0; iter < num_iterations; ++iter) {
-        slow_dispatch::LaunchProgram(mesh_device, program);
+        slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
     }
 
     std::vector<uint32_t> output;
@@ -362,7 +362,7 @@ TEST_F(UnitMeshFixture, D1_2_0_LongImplicitSync_PostCounterWrap) {
     slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
     m2_writeshard_barrier_uint32(this->device(), in_tensor, input);
 
-    slow_dispatch::LaunchProgram(this->device(), program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
     slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
@@ -593,7 +593,7 @@ TEST_F(UnitMeshFixture, D3_2_0_MultiCoreDFB_TwoGroupsViaDecoy) {
     slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
     m2_writeshard_barrier_uint32(this->device(), in_tensor, input);
 
-    slow_dispatch::LaunchProgram(this->device(), program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
     slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_edge_cases.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_edge_cases.cpp
@@ -5,6 +5,7 @@
 // Edge-case coverage: counter-wrap, ring-pressure, decoy, long-run (Metal 2.0).
 
 #include "dfb_test_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
 
@@ -12,20 +13,19 @@ namespace tt::tt_metal {
 // A1: DM->Tensix->DM decoy pipeline
 enum class A1Transform { Identity, Relu };
 
-static void run_a1_pipeline(const std::shared_ptr<distributed::MeshDevice>& mesh_device, A1Transform transform) {
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+static void run_a1_pipeline(distributed::MeshDevice& mesh_device, A1Transform transform) {
+    if (mesh_device.arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "M2 path is Quasar-only (Gen2Config)";
     }
 
-    IDevice* device = mesh_device->get_devices()[0];
     constexpr uint32_t entry_size = 2 * 32 * 32;  // bf16 tile = 2048 B
     constexpr uint32_t num_entries = 4;
     const m2::NodeCoord node{0, 0};
 
     // Tensors
     const auto tensor_spec = make_flat_dram_tensor_spec(entry_size, num_entries, DataType::BFLOAT16);
-    auto in_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
-    auto out_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
+    auto in_tensor = MeshTensor::allocate_on_device(mesh_device, tensor_spec);
+    auto out_tensor = MeshTensor::allocate_on_device(mesh_device, tensor_spec);
 
     const m2::DFBSpecName DFB_IN{"dfb_in"};
     const m2::DFBSpecName DFB_OUT{"dfb_out"};
@@ -96,7 +96,7 @@ static void run_a1_pipeline(const std::shared_ptr<distributed::MeshDevice>& mesh
         .work_units = {wu},
     };
 
-    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = m2::MakeProgramFromSpec(mesh_device, spec);
 
     m2::ProgramRunArgs params;
     params.kernel_run_args = {
@@ -123,13 +123,13 @@ static void run_a1_pipeline(const std::shared_ptr<distributed::MeshDevice>& mesh
     auto input = (transform == A1Transform::Relu)
                      ? create_random_vector_of_bfloat16(total_bytes, 1.0f, 0xA1A1)   // positive only
                      : create_random_vector_of_bfloat16(total_bytes, 2.0f, 0xA1A1);  // [-1,1]
-    detail::WriteToBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), input);
-    m2_writeshard_barrier_uint32(device, in_tensor, input);
+    slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
+    m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(mesh_device, program);
 
     std::vector<uint32_t> output;
-    detail::ReadFromBuffer(*out_tensor.mesh_buffer().get_reference_buffer(), output);
+    slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
 
     if (transform == A1Transform::Relu) {
         // Positive bf16 inputs → relu identity, allow bf16 tolerance.
@@ -140,27 +140,22 @@ static void run_a1_pipeline(const std::shared_ptr<distributed::MeshDevice>& mesh
     }
 }
 
-TEST_F(MeshDeviceFixture, A1_2_0_DMTensixDMTest2xDFB1Sx1S) {
-    run_a1_pipeline(this->devices_.at(0), A1Transform::Identity);
-}
+TEST_F(UnitMeshFixture, A1_2_0_DMTensixDMTest2xDFB1Sx1S) { run_a1_pipeline(this->device(), A1Transform::Identity); }
 
-TEST_F(MeshDeviceFixture, A1_2_0_DMTensixDMTest2xDFB1Sx1S_Relu) {
-    run_a1_pipeline(this->devices_.at(0), A1Transform::Relu);
-}
+TEST_F(UnitMeshFixture, A1_2_0_DMTensixDMTest2xDFB1Sx1S_Relu) { run_a1_pipeline(this->device(), A1Transform::Relu); }
 
 // B: implicit-sync edge-case regressions
 static void run_dm_dfb_dm_implicit_sync_2_0(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t num_iterations,
     bool implicit_sync,
     uint32_t entry_size = 1024,
     uint32_t num_entries = 16,
     uint32_t total_tiles = 16) {
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device.arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Implicit sync is Quasar-only";
     }
 
-    IDevice* device = mesh_device->get_devices()[0];
     const m2::NodeCoord node{0, 0};
 
     const m2::DFBSpecName DFB{"dfb"};
@@ -170,8 +165,8 @@ static void run_dm_dfb_dm_implicit_sync_2_0(
     const m2::TensorParamName OUT_TENSOR{"out_tensor"};
 
     const auto tensor_spec = make_flat_dram_tensor_spec(entry_size, total_tiles, DataType::UINT32);
-    auto in_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
-    auto out_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
+    auto in_tensor = MeshTensor::allocate_on_device(mesh_device, tensor_spec);
+    auto out_tensor = MeshTensor::allocate_on_device(mesh_device, tensor_spec);
 
     // DFB-level implicit_sync must match the kernels' CTA (inverted polarity).
     m2::DataflowBufferSpec dfb{
@@ -204,7 +199,7 @@ static void run_dm_dfb_dm_implicit_sync_2_0(
         .work_units = {wu},
     };
 
-    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = m2::MakeProgramFromSpec(mesh_device, spec);
 
     m2::ProgramRunArgs params;
     params.kernel_run_args = {
@@ -227,43 +222,41 @@ static void run_dm_dfb_dm_implicit_sync_2_0(
 
     const uint32_t total_words = entry_size * total_tiles / sizeof(uint32_t);
     auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 1000000, total_words);
-    detail::WriteToBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), input);
-    m2_writeshard_barrier_uint32(device, in_tensor, input);
+    slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
+    m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
     for (uint32_t iter = 0; iter < num_iterations; ++iter) {
-        detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+        slow_dispatch::LaunchProgram(mesh_device, program);
     }
 
     std::vector<uint32_t> output;
-    detail::ReadFromBuffer(*out_tensor.mesh_buffer().get_reference_buffer(), output);
+    slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
     EXPECT_EQ(input, output) << "M2 DM→DFB→DM identity mismatch";
 }
 
-TEST_F(MeshDeviceFixture, B1_2_0_DM0NoKernel_TensixDMImplicitSync) {
+TEST_F(UnitMeshFixture, B1_2_0_DM0NoKernel_TensixDMImplicitSync) {
     // B1 = single-iteration implicit-sync DM→DFB→DM. DM0-no-kernel coverage is
     // an internal-state regression that fires whether or not we explicitly
     // skip DM0; the helper produces the same wire-level traffic.
-    run_dm_dfb_dm_implicit_sync_2_0(this->devices_.at(0), /*num_iterations=*/1, /*implicit_sync=*/true);
+    run_dm_dfb_dm_implicit_sync_2_0(this->device(), /*num_iterations=*/1, /*implicit_sync=*/true);
 }
 
-TEST_F(MeshDeviceFixture, B1b_2_0_DM0IdleSubordinateRuns_TensixDMImplicitSync) {
+TEST_F(UnitMeshFixture, B1b_2_0_DM0IdleSubordinateRuns_TensixDMImplicitSync) {
     // B1b same shape as B1 with an extra iter to expose stale-credit edge.
-    run_dm_dfb_dm_implicit_sync_2_0(this->devices_.at(0), /*num_iterations=*/2, /*implicit_sync=*/true);
+    run_dm_dfb_dm_implicit_sync_2_0(this->device(), /*num_iterations=*/2, /*implicit_sync=*/true);
 }
 
-TEST_F(MeshDeviceFixture, B3_2_0_TailCreditRace_RepeatedImplicitSync_DMDM) {
+TEST_F(UnitMeshFixture, B3_2_0_TailCreditRace_RepeatedImplicitSync_DMDM) {
     // B3: 3 repeated implicit-sync iterations exercise the tail-credit race.
-    run_dm_dfb_dm_implicit_sync_2_0(this->devices_.at(0), /*num_iterations=*/3, /*implicit_sync=*/true);
+    run_dm_dfb_dm_implicit_sync_2_0(this->device(), /*num_iterations=*/3, /*implicit_sync=*/true);
 }
 
 // D1: long implicit-sync run past counter wrap
-TEST_F(MeshDeviceFixture, D1_2_0_LongImplicitSync_PostCounterWrap) {
-    auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, D1_2_0_LongImplicitSync_PostCounterWrap) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Implicit sync is Quasar-only";
     }
 
-    IDevice* device = mesh_device->get_devices()[0];
     constexpr uint32_t kPreloadValue = 65528;
     constexpr uint32_t kPushTiles = 32;
     constexpr uint32_t kEntrySize = 1024;
@@ -282,8 +275,8 @@ TEST_F(MeshDeviceFixture, D1_2_0_LongImplicitSync_PostCounterWrap) {
     const m2::SemaphoreSpecName SEM_CONS_READY{"sem_cons_ready"};
 
     const auto tensor_spec = make_flat_dram_tensor_spec(kEntrySize, kPushTiles, DataType::UINT32);
-    auto in_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
-    auto out_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
+    auto in_tensor = MeshTensor::allocate_on_device(this->device(), tensor_spec);
+    auto out_tensor = MeshTensor::allocate_on_device(this->device(), tensor_spec);
 
     m2::DataflowBufferSpec dfb{
         .unique_id = DFB,
@@ -344,7 +337,7 @@ TEST_F(MeshDeviceFixture, D1_2_0_LongImplicitSync_PostCounterWrap) {
         .work_units = {wu},
     };
 
-    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = m2::MakeProgramFromSpec(this->device(), spec);
 
     m2::ProgramRunArgs params;
     params.kernel_run_args = {
@@ -366,13 +359,13 @@ TEST_F(MeshDeviceFixture, D1_2_0_LongImplicitSync_PostCounterWrap) {
     m2::SetProgramRunArgs(program, params);
 
     auto input = create_random_vector_of_bfloat16(kPushTiles * kEntrySize, 1.0f, 0xD1D1);
-    detail::WriteToBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), input);
-    m2_writeshard_barrier_uint32(device, in_tensor, input);
+    slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
+    m2_writeshard_barrier_uint32(this->device(), in_tensor, input);
 
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(this->device(), program);
 
     std::vector<uint32_t> output;
-    detail::ReadFromBuffer(*out_tensor.mesh_buffer().get_reference_buffer(), output);
+    slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
 
     // Diagnostic: on mismatch, dump first divergent tile + per-tile histogram so
     // we can characterize the failure mode (all-zeros from start, wrap-point only, etc.).
@@ -419,8 +412,7 @@ TEST_F(MeshDeviceFixture, D1_2_0_LongImplicitSync_PostCounterWrap) {
 }
 
 // D2: all-DMs-concurrent ring saturation
-static void run_d2_all_dms_concurrent_2_0(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, bool implicit_sync) {
+static void run_d2_all_dms_concurrent_2_0(distributed::MeshDevice& mesh_device, bool implicit_sync) {
     run_dm_dfb_dm_implicit_sync_2_0(
         mesh_device,
         /*num_iterations=*/1,
@@ -430,23 +422,21 @@ static void run_d2_all_dms_concurrent_2_0(
         /*total_tiles=*/96);
 }
 
-TEST_F(MeshDeviceFixture, D2_2_0_AllDMsConcurrent_6Sx2S_ImplicitOff) {
-    run_d2_all_dms_concurrent_2_0(this->devices_.at(0), /*implicit_sync=*/false);
+TEST_F(UnitMeshFixture, D2_2_0_AllDMsConcurrent_6Sx2S_ImplicitOff) {
+    run_d2_all_dms_concurrent_2_0(this->device(), /*implicit_sync=*/false);
 }
 
-TEST_F(MeshDeviceFixture, D2_2_0_AllDMsConcurrent_6Sx2S_ImplicitOn) {
-    run_d2_all_dms_concurrent_2_0(this->devices_.at(0), /*implicit_sync=*/true);
+TEST_F(UnitMeshFixture, D2_2_0_AllDMsConcurrent_6Sx2S_ImplicitOn) {
+    run_d2_all_dms_concurrent_2_0(this->device(), /*implicit_sync=*/true);
 }
 
 // D3: multi-core two-groups-via-decoy
-TEST_F(MeshDeviceFixture, D3_2_0_MultiCoreDFB_TwoGroupsViaDecoy) {
-    auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, D3_2_0_MultiCoreDFB_TwoGroupsViaDecoy) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "TC-based grouping is Quasar-only";
     }
 
-    IDevice* device = mesh_device->get_devices()[0];
-    CoreCoord grid = device->compute_with_storage_grid_size();
+    CoreCoord grid = this->device().compute_with_storage_grid_size();
     const uint32_t num_workers = grid.x * grid.y;
     if (num_workers < 2) {
         GTEST_SKIP() << "Need >= 2 Tensix cores; device has " << num_workers
@@ -469,8 +459,8 @@ TEST_F(MeshDeviceFixture, D3_2_0_MultiCoreDFB_TwoGroupsViaDecoy) {
     const m2::TensorParamName OUT_TENSOR{"out_tensor"};
 
     const auto tensor_spec = make_flat_dram_tensor_spec(entry_size, 2 * entries_per_core, DataType::UINT32);
-    auto in_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
-    auto out_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
+    auto in_tensor = MeshTensor::allocate_on_device(this->device(), tensor_spec);
+    auto out_tensor = MeshTensor::allocate_on_device(this->device(), tensor_spec);
 
     // Decoy DFB: lives on core A only.
     m2::DataflowBufferSpec decoy_dfb{
@@ -568,7 +558,7 @@ TEST_F(MeshDeviceFixture, D3_2_0_MultiCoreDFB_TwoGroupsViaDecoy) {
         .work_units = {decoy_wu, shared_wu},
     };
 
-    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = m2::MakeProgramFromSpec(this->device(), spec);
 
     m2::ProgramRunArgs params;
     params.kernel_run_args = {
@@ -600,13 +590,13 @@ TEST_F(MeshDeviceFixture, D3_2_0_MultiCoreDFB_TwoGroupsViaDecoy) {
     m2::SetProgramRunArgs(program, params);
 
     auto input = create_constant_vector_of_bfloat16(2 * entries_per_core * entry_size, 1.0f);
-    detail::WriteToBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), input);
-    m2_writeshard_barrier_uint32(device, in_tensor, input);
+    slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
+    m2_writeshard_barrier_uint32(this->device(), in_tensor, input);
 
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(this->device(), program);
 
     std::vector<uint32_t> output;
-    detail::ReadFromBuffer(*out_tensor.mesh_buffer().get_reference_buffer(), output);
+    slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
     // For the m2 version we just verify the shared DFB ran end-to-end on core B.
     // The "two DfbGroups" assertion from the legacy test depends on inspecting
     // program.impl() before LaunchProgram; we keep that for the legacy test and
@@ -633,7 +623,7 @@ TEST_P(DFBImplicitSyncParamFixture_2_0, DMTest1xDFB_RingPressure_1Sx1S_2_0) {
         .num_entries = 16,
         .num_entries_in_buffer = 32,
     };
-    run_single_dfb_program_2_0(this->devices_.at(0), params);
+    run_single_dfb_program_2_0(this->device(), params);
 }
 
 TEST_P(DFBImplicitSyncParamFixture_2_0, DMTest1xDFB_RingPressure_3Sx3S_2_0) {
@@ -647,7 +637,7 @@ TEST_P(DFBImplicitSyncParamFixture_2_0, DMTest1xDFB_RingPressure_3Sx3S_2_0) {
         .num_entries = default_num_entries(3, 3),
         .num_entries_in_buffer = 27,
     };
-    run_single_dfb_program_2_0(this->devices_.at(0), params);
+    run_single_dfb_program_2_0(this->device(), params);
 }
 
 TEST_P(DFBImplicitSyncParamFixture_2_0, TensixDMTest1xDFB_RingPressure_2Sx4S_2_0) {
@@ -660,7 +650,7 @@ TEST_P(DFBImplicitSyncParamFixture_2_0, TensixDMTest1xDFB_RingPressure_2Sx4S_2_0
         .num_entries = 16,
         .num_entries_in_buffer = 32,
     };
-    run_single_dfb_program_2_0(this->devices_.at(0), params);
+    run_single_dfb_program_2_0(this->device(), params);
 }
 
 // 4 DM producers + 4 Tensix consumers ALL, num_entries=4 → capacity=1: maximum
@@ -677,7 +667,7 @@ TEST_P(DFBImplicitSyncParamFixture_2_0, DMTensixTest1xDFB_RingPressure_4Sx4A_2_0
         .num_entries = 4,
         .num_entries_in_buffer = 64,
     };
-    run_single_dfb_program_2_0(this->devices_.at(0), params);
+    run_single_dfb_program_2_0(this->device(), params);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_intra.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_intra.cpp
@@ -5,6 +5,7 @@
 // Intra-scope (self-loop) DFB tests.
 
 #include "dfb_test_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 #include <array>
 #include <map>
@@ -14,12 +15,7 @@ namespace tt::tt_metal {
 
 // legacy intra-Tensix self-loop harness + test
 static void run_intra_tensix_dfb_program(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    uint32_t entry_size,
-    uint32_t num_entries,
-    uint32_t num_threads) {
-    IDevice* device = mesh_device->get_devices()[0];
-
+    distributed::MeshDevice& mesh_device, uint32_t entry_size, uint32_t num_entries, uint32_t num_threads) {
     experimental::dfb::DataflowBufferConfig dfb_config{
         .entry_size = entry_size,
         .num_entries = num_entries,
@@ -97,7 +93,7 @@ static void run_intra_tensix_dfb_program(
         .work_units = {wu},
     };
 
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
     experimental::ProgramRunArgs run_params;
     run_params.kernel_run_args = {experimental::ProgramRunArgs::KernelRunArgs{.kernel = COMPUTE}};
@@ -106,11 +102,12 @@ static void run_intra_tensix_dfb_program(
     const uint32_t total_size = num_entries * entry_size;
     auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, total_size / sizeof(uint32_t));
 
-    const uint32_t dfb_l1_addr = static_cast<uint32_t>(device->allocator()->get_base_allocator_addr(HalMemType::L1));
+    const uint32_t dfb_l1_addr =
+        static_cast<uint32_t>(mesh_device.allocator()->get_base_allocator_addr(HalMemType::L1));
 
-    detail::WriteToDeviceL1(device, logical_core, dfb_l1_addr, input);
+    slow_dispatch::WriteToL1(mesh_device, logical_core, dfb_l1_addr, input);
 
-    detail::LaunchProgram(device, program, true /*wait_until_cores_done*/);
+    slow_dispatch::LaunchProgram(mesh_device, program);
 
     // Packer increments each word by 1, then unpacker increments it by 1 → +2 per word.
     // This holds for every Neo's ring independently, so the entire L1 region is input + 2.
@@ -120,25 +117,23 @@ static void run_intra_tensix_dfb_program(
     }
 
     std::vector<uint32_t> l1_data;
-    detail::ReadFromDeviceL1(device, logical_core, dfb_l1_addr, total_size, l1_data);
+    slow_dispatch::ReadFromL1(mesh_device, logical_core, dfb_l1_addr, total_size, l1_data);
     EXPECT_EQ(expected, l1_data) << "Intra-tensix DFB L1 mismatch";
 }
 
-TEST_F(MeshDeviceFixture, TensixIntraTest1xDFB4Sx4S) {
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, TensixIntraTest1xDFB4Sx4S) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Skipping intra-tensix DFB test for WH/BH until DFB is backported";
     }
-    run_intra_tensix_dfb_program(this->devices_.at(0), /*entry_size=*/1024, /*num_entries=*/16, /*num_threads=*/4);
+    run_intra_tensix_dfb_program(this->device(), /*entry_size=*/1024, /*num_entries=*/16, /*num_threads=*/4);
 }
 
 // Metal 2.0 intra: DM->Trisc self-loop double-relu
-TEST_F(MeshDeviceFixture, C2_2_0_DMTriscSelfLoopDM_DoubleRelu) {
-    auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, C2_2_0_DMTriscSelfLoopDM_DoubleRelu) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "C2 INTRA-scope DFB self-loop requires Quasar";
     }
 
-    IDevice* device = mesh_device->get_devices()[0];
     constexpr uint32_t entry_size = 2 * 32 * 32;  // bf16 tile = 2048 B
     constexpr uint32_t num_entries = 4;
     const m2::NodeCoord node{0, 0};
@@ -153,8 +148,8 @@ TEST_F(MeshDeviceFixture, C2_2_0_DMTriscSelfLoopDM_DoubleRelu) {
     const m2::TensorParamName OUT_TENSOR{"out_tensor"};
 
     const auto tensor_spec = make_flat_dram_tensor_spec(entry_size, num_entries, DataType::BFLOAT16);
-    auto in_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
-    auto out_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
+    auto in_tensor = MeshTensor::allocate_on_device(this->device(), tensor_spec);
+    auto out_tensor = MeshTensor::allocate_on_device(this->device(), tensor_spec);
 
     m2::DataflowBufferSpec dfb_in{
         .unique_id = DFB_IN,
@@ -220,7 +215,7 @@ TEST_F(MeshDeviceFixture, C2_2_0_DMTriscSelfLoopDM_DoubleRelu) {
         .work_units = {wu},
     };
 
-    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = m2::MakeProgramFromSpec(this->device(), spec);
 
     m2::ProgramRunArgs params;
     params.kernel_run_args = {
@@ -245,8 +240,8 @@ TEST_F(MeshDeviceFixture, C2_2_0_DMTriscSelfLoopDM_DoubleRelu) {
     // Positive bf16 inputs → double-relu identity.
     const uint32_t total_bytes = entry_size * num_entries;
     auto input = create_random_vector_of_bfloat16(total_bytes, 1.0f, 0xC2C2);
-    detail::WriteToBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), input);
-    m2_writeshard_barrier_uint32(device, in_tensor, input);
+    slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
+    m2_writeshard_barrier_uint32(this->device(), in_tensor, input);
 
     // Finalize early so host can assert INTRA remapper assignment before launch.
     program.impl().finalize_dataflow_buffer_configs();
@@ -262,17 +257,17 @@ TEST_F(MeshDeviceFixture, C2_2_0_DMTriscSelfLoopDM_DoubleRelu) {
     EXPECT_NE(self_rc.config.intra_shadow_tc_id, self_tc);
     EXPECT_GE(self_rc.config.remapper_pair_index, ::dfb::REMAPPER_ONE_TO_ONE_PAIR_START);
 
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(this->device(), program);
 
     std::vector<uint32_t> output;
-    detail::ReadFromBuffer(*out_tensor.mesh_buffer().get_reference_buffer(), output);
+    slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
     EXPECT_TRUE(packed_uint32_t_vector_comparison(output, input, [](float a, float b) {
         return std::abs(a - b) < 0.01f;
     })) << "M2 C2 double-relu identity mismatch";
 
     // Capacity is shared (all DFBs use num_entries=4), so only assert the INTRA ClientL/shadow
     // programming — not overlay isolation by capacity fingerprint.
-    const auto live = read_live_tcs(device, CoreCoord(0, 0), /*neo_id=*/0);
+    const auto live = read_live_tcs(this->device(), CoreCoord(0, 0), /*neo_id=*/0);
     ASSERT_GT(live.capacity.size(), self_rc.config.intra_shadow_tc_id);
     EXPECT_EQ(live.capacity[self_tc], num_entries);
     EXPECT_EQ(live.capacity[self_rc.config.intra_shadow_tc_id], 0u);
@@ -280,11 +275,10 @@ TEST_F(MeshDeviceFixture, C2_2_0_DMTriscSelfLoopDM_DoubleRelu) {
 
 // Metal 2.0 intra-Tensix self-loop harness + test
 static void run_intra_tensix_dfb_program_2_0(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, uint32_t entry_size, uint32_t num_threads) {
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    distributed::MeshDevice& mesh_device, uint32_t entry_size, uint32_t num_threads) {
+    if (mesh_device.arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "M2 INTRA test is Quasar-only";
     }
-    IDevice* device = mesh_device->get_devices()[0];
 
     constexpr uint32_t num_entries = 16;  // matches legacy
     TT_FATAL(num_entries % num_threads == 0, "num_entries must be divisible by num_threads");
@@ -335,7 +329,7 @@ static void run_intra_tensix_dfb_program_2_0(
         .work_units = {m2::WorkUnitSpec{.name = "main", .kernels = {COMPUTE}, .target_nodes = node_set}},
     };
 
-    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = m2::MakeProgramFromSpec(mesh_device, spec);
 
     // Kernel has no runtime args; pass kernel_spec_name only (matches legacy
     // pattern in main's run_intra_tensix_dfb_program).
@@ -345,31 +339,30 @@ static void run_intra_tensix_dfb_program_2_0(
 
     // DFB is the first L1 allocation in the program → lands at the base L1
     // allocator address. Same trick the legacy intra test uses.
-    const uint32_t dfb_l1_addr = static_cast<uint32_t>(device->allocator()->get_base_allocator_addr(HalMemType::L1));
+    const uint32_t dfb_l1_addr =
+        static_cast<uint32_t>(mesh_device.allocator()->get_base_allocator_addr(HalMemType::L1));
 
     auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, total_bytes / sizeof(uint32_t));
-    detail::WriteToDeviceL1(device, CoreCoord(0, 0), dfb_l1_addr, input);
+    slow_dispatch::WriteToL1(mesh_device, CoreCoord(0, 0), dfb_l1_addr, input);
 
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(mesh_device, program);
 
     std::vector<uint32_t> expected(input.size());
     std::transform(input.begin(), input.end(), expected.begin(), [](uint32_t v) { return v + 2; });
     std::vector<uint32_t> output;
-    detail::ReadFromDeviceL1(device, CoreCoord(0, 0), dfb_l1_addr, total_bytes, output);
+    slow_dispatch::ReadFromL1(mesh_device, CoreCoord(0, 0), dfb_l1_addr, total_bytes, output);
     EXPECT_EQ(expected, output) << "M2 intra-tensix DFB +2 per word mismatch (num_threads=" << num_threads << ")";
 }
 
-TEST_F(MeshDeviceFixture, TensixIntraTest1xDFB1Sx1S_2_0) {
-    run_intra_tensix_dfb_program_2_0(this->devices_.at(0), /*entry_size=*/1024, /*num_threads=*/1);
+TEST_F(UnitMeshFixture, TensixIntraTest1xDFB1Sx1S_2_0) {
+    run_intra_tensix_dfb_program_2_0(this->device(), /*entry_size=*/1024, /*num_threads=*/1);
 }
 
 // Metal 2.0 intra + remapper coexistence
-TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4B_2_0) {
-    auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4B_2_0) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "M2 path is Quasar-only (Gen2Config)";
     }
-    IDevice* device = mesh_device->get_devices()[0];
 
     constexpr uint32_t entry_size = 1024;
     constexpr uint32_t num_entries = 16;
@@ -401,7 +394,7 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4B_2_0) {
 
     // DRAM input tensor for the DM producer.
     const auto tensor_spec = make_flat_dram_tensor_spec(entry_size, num_entries, DataType::UINT32);
-    auto in_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
+    auto in_tensor = MeshTensor::allocate_on_device(this->device(), tensor_spec);
 
     // DM producer: implicit-sync path feeds the remapper ring.
     auto producer = make_dm_dfb_producer(PRODUCER, DFB_REMAPPER, IN_TENSOR, num_entries, /*implicit_sync=*/true);
@@ -445,7 +438,7 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4B_2_0) {
         }},
     };
 
-    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = m2::MakeProgramFromSpec(this->device(), spec);
 
     m2::ProgramRunArgs params;
     params.kernel_run_args = {
@@ -528,28 +521,28 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4B_2_0) {
     // claim must come out of the run bit-identical to this snapshot no matter what earlier programs left in
     // them. Comparing against the snapshot is what makes the isolation check exact instead of a guess about
     // which values look like INTRA state.
-    const auto before = read_live_tcs(device, CoreCoord(0, 0), /*neo_id=*/0);
+    const auto before = read_live_tcs(this->device(), CoreCoord(0, 0), /*neo_id=*/0);
     ASSERT_GE(before.capacity.size(), ::dfb::NUM_TILE_COUNTERS_PER_TENSIX);
 
     // Fill DRAM input; DM NOC-reads this into the remapper ring's L1.
     auto input_remapper =
         tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, num_entries * entry_size / sizeof(uint32_t));
-    detail::WriteToBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), input_remapper);
-    m2_writeshard_barrier_uint32(device, in_tensor, input_remapper);
+    slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input_remapper);
+    m2_writeshard_barrier_uint32(this->device(), in_tensor, input_remapper);
 
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(this->device(), program);
 
     // Verify remapper ring L1: DM wrote input_remapper; Tensix consumed credits
     // (ALL pattern) but did not overwrite the ring's data.
     const uint32_t remapper_l1_addr =
         program.impl().get_dataflow_buffer(program.impl().get_dfb_handle(*DFB_REMAPPER))->uniform_alloc_addr();
     std::vector<uint32_t> l1_remapper;
-    detail::ReadFromDeviceL1(device, CoreCoord(0, 0), remapper_l1_addr, num_entries * entry_size, l1_remapper);
+    slow_dispatch::ReadFromL1(this->device(), CoreCoord(0, 0), remapper_l1_addr, num_entries * entry_size, l1_remapper);
     EXPECT_EQ(input_remapper, l1_remapper) << "M2 DM->Tensix strided x ALL remapper ring L1 mismatch";
 
     // space_available is the free-space view (capacity - tiles_available), so a fully drained counter reads
     // tiles_available == 0 and space_available == capacity.
-    const auto live = read_live_tcs(device, CoreCoord(0, 0), /*neo_id=*/0);
+    const auto live = read_live_tcs(this->device(), CoreCoord(0, 0), /*neo_id=*/0);
     ASSERT_GE(live.capacity.size(), ::dfb::NUM_TILE_COUNTERS_PER_TENSIX);
     for (const auto& [tc_id, expected] : claims) {
         EXPECT_EQ(live.capacity[tc_id], expected.capacity) << expected.owner << " TC" << (int)tc_id << " capacity";
@@ -570,12 +563,10 @@ TEST_F(MeshDeviceFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4B_2_0) {
 }
 
 // T1: pure INTRA must not corrupt DM-visible overlay tile counters 0-15.
-TEST_F(MeshDeviceFixture, TensixIntraIsolatesOverlayTCs) {
-    auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, TensixIntraIsolatesOverlayTCs) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Overlay TC isolation is Quasar-only";
     }
-    IDevice* device = mesh_device->get_devices()[0];
 
     constexpr uint32_t entry_size = 1024;
     constexpr uint32_t num_entries = 8;
@@ -610,7 +601,8 @@ TEST_F(MeshDeviceFixture, TensixIntraIsolatesOverlayTCs) {
     constexpr uint32_t done_idx = final_base + num_mirrored_dm_tcs * words_per_tc;
     constexpr uint32_t scratch_words = done_idx + 1;
 
-    const uint32_t dfb_l1_addr = static_cast<uint32_t>(device->allocator()->get_base_allocator_addr(HalMemType::L1));
+    const uint32_t dfb_l1_addr =
+        static_cast<uint32_t>(this->device().allocator()->get_base_allocator_addr(HalMemType::L1));
     const uint32_t scratch_l1_addr = dfb_l1_addr + total_bytes;
 
     const m2::DFBSpecName DFB{"intra_dfb"};
@@ -668,7 +660,7 @@ TEST_F(MeshDeviceFixture, TensixIntraIsolatesOverlayTCs) {
         .work_units = {m2::WorkUnitSpec{.name = "main", .kernels = {COMPUTE}, .target_nodes = node_set}},
     };
 
-    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = m2::MakeProgramFromSpec(this->device(), spec);
     program.impl().finalize_dataflow_buffer_configs();
 
     auto intra_dfb = program.impl().get_dataflow_buffer(program.impl().get_dfb_handle(*DFB));
@@ -690,18 +682,19 @@ TEST_F(MeshDeviceFixture, TensixIntraIsolatesOverlayTCs) {
 
     // Kernel only exercises TC push/pop credits; L1 payload is untouched.
     std::vector<uint32_t> scratch_zero(scratch_words, 0);
-    detail::WriteToDeviceL1(device, CoreCoord(0, 0), scratch_l1_addr, scratch_zero);
+    slow_dispatch::WriteToL1(this->device(), CoreCoord(0, 0), scratch_l1_addr, scratch_zero);
 
     // This program owns only Tensix-only counters (ClientL + shadow), so every DM-visible counter must survive
     // the run untouched. The kernel's own baseline is sampled after DFB init; snapshotting here additionally
     // covers init-time aliasing, and comparing exact values avoids inferring corruption from a magic capacity.
-    const auto before = read_live_tcs(device, CoreCoord(0, 0), /*neo_id=*/0);
+    const auto before = read_live_tcs(this->device(), CoreCoord(0, 0), /*neo_id=*/0);
     ASSERT_GE(before.capacity.size(), ::dfb::NUM_TILE_COUNTERS_PER_TENSIX);
 
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(this->device(), program);
 
     std::vector<uint32_t> scratch;
-    detail::ReadFromDeviceL1(device, CoreCoord(0, 0), scratch_l1_addr, scratch_words * sizeof(uint32_t), scratch);
+    slow_dispatch::ReadFromL1(
+        this->device(), CoreCoord(0, 0), scratch_l1_addr, scratch_words * sizeof(uint32_t), scratch);
     ASSERT_EQ(scratch.size(), scratch_words);
     EXPECT_EQ(scratch[0], scratch_magic) << "Pack never wrote overlay isolation scratch";
     EXPECT_EQ(scratch[done_idx], scratch_done) << "Pack never finished overlay isolation scratch";
@@ -745,7 +738,7 @@ TEST_F(MeshDeviceFixture, TensixIntraIsolatesOverlayTCs) {
     // Host-side NEO mirror readback after the drained series: ClientL must be empty, and every DM-visible
     // counter must match the pre-launch snapshot — init sized and reset only ClientL, so anything else moving
     // means a T6 update aliased into the overlay pool.
-    const auto live = read_live_tcs(device, CoreCoord(0, 0), /*neo_id=*/0);
+    const auto live = read_live_tcs(this->device(), CoreCoord(0, 0), /*neo_id=*/0);
     ASSERT_GT(live.capacity.size(), client_l_tc);
     EXPECT_EQ(live.capacity[client_l_tc], entries_per_neo);
     EXPECT_EQ(live.tiles_available[client_l_tc], 0u)

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_intra.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_intra.cpp
@@ -107,7 +107,7 @@ static void run_intra_tensix_dfb_program(
 
     slow_dispatch::WriteToL1(mesh_device, logical_core, dfb_l1_addr, input);
 
-    slow_dispatch::LaunchProgram(mesh_device, program);
+    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     // Packer increments each word by 1, then unpacker increments it by 1 → +2 per word.
     // This holds for every Neo's ring independently, so the entire L1 region is input + 2.
@@ -257,7 +257,7 @@ TEST_F(UnitMeshFixture, C2_2_0_DMTriscSelfLoopDM_DoubleRelu) {
     EXPECT_NE(self_rc.config.intra_shadow_tc_id, self_tc);
     EXPECT_GE(self_rc.config.remapper_pair_index, ::dfb::REMAPPER_ONE_TO_ONE_PAIR_START);
 
-    slow_dispatch::LaunchProgram(this->device(), program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
     slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
@@ -345,7 +345,7 @@ static void run_intra_tensix_dfb_program_2_0(
     auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, total_bytes / sizeof(uint32_t));
     slow_dispatch::WriteToL1(mesh_device, CoreCoord(0, 0), dfb_l1_addr, input);
 
-    slow_dispatch::LaunchProgram(mesh_device, program);
+    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> expected(input.size());
     std::transform(input.begin(), input.end(), expected.begin(), [](uint32_t v) { return v + 2; });
@@ -530,7 +530,7 @@ TEST_F(UnitMeshFixture, TensixIntraAndRemapperTest_4Neo_DM1Sx4B_2_0) {
     slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input_remapper);
     m2_writeshard_barrier_uint32(this->device(), in_tensor, input_remapper);
 
-    slow_dispatch::LaunchProgram(this->device(), program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     // Verify remapper ring L1: DM wrote input_remapper; Tensix consumed credits
     // (ALL pattern) but did not overwrite the ring's data.
@@ -690,7 +690,7 @@ TEST_F(UnitMeshFixture, TensixIntraIsolatesOverlayTCs) {
     const auto before = read_live_tcs(this->device(), CoreCoord(0, 0), /*neo_id=*/0);
     ASSERT_GE(before.capacity.size(), ::dfb::NUM_TILE_COUNTERS_PER_TENSIX);
 
-    slow_dispatch::LaunchProgram(this->device(), program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> scratch;
     slow_dispatch::ReadFromL1(

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_multinode.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_multinode.cpp
@@ -544,7 +544,7 @@ TEST_P(DFBImplicitSyncParamFixture_2_0, TensixDMTest4xDFB_1Sx1S_2_0) {
     // kernel is TRISC-only and can't carry tensor bindings.
     slow_dispatch::CompileProgram(this->device(), program);
     program.impl().finalize_dataflow_buffer_configs();
-    program.impl().allocate_dataflow_buffers(slow_dispatch::physical_device_from_unit_mesh(this->device()));
+    program.impl().allocate_dataflow_buffers(this->device().get_devices()[0]);
 
     std::vector<std::vector<uint32_t>> inputs(num_dfbs);
     for (uint32_t i = 0; i < num_dfbs; ++i) {

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_multinode.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_multinode.cpp
@@ -5,23 +5,23 @@
 // Multi-core and multi-DFB (concurrent/sequential) tests (Metal 2.0).
 
 #include "dfb_test_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
 
 
 // multi-core + concurrent/sequential multi-DFB harnesses (Metal 2.0)
 static void run_single_dfb_multicore_2_0(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t num_producers,
     uint32_t num_consumers,
     m2::DFBAccessPattern pap,
     m2::DFBAccessPattern cap,
     bool implicit_sync) {
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device.arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "M2 path is Quasar-only";
     }
-    IDevice* device = mesh_device->get_devices()[0];
-    CoreCoord grid = device->compute_with_storage_grid_size();
+    CoreCoord grid = mesh_device.compute_with_storage_grid_size();
     if (grid.x * grid.y < 2) {
         GTEST_SKIP() << "Multi-core test requires >= 2 Tensix cores";
     }
@@ -46,8 +46,8 @@ static void run_single_dfb_multicore_2_0(
 
     // Each core owns num_entries slots → total = 2 * num_entries.
     const auto tensor_spec = make_flat_dram_tensor_spec(entry_size, 2 * num_entries, DataType::UINT32);
-    auto in_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
-    auto out_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
+    auto in_tensor = MeshTensor::allocate_on_device(mesh_device, tensor_spec);
+    auto out_tensor = MeshTensor::allocate_on_device(mesh_device, tensor_spec);
 
     m2::DataflowBufferSpec dfb_spec{
         .unique_id = DFB,
@@ -87,7 +87,7 @@ static void run_single_dfb_multicore_2_0(
         .work_units = {wu},
     };
 
-    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = m2::MakeProgramFromSpec(mesh_device, spec);
 
     m2::ProgramRunArgs params;
     params.kernel_run_args = {
@@ -108,37 +108,36 @@ static void run_single_dfb_multicore_2_0(
 
     auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(
         0, 1000000, 2 * num_entries * entry_size / sizeof(uint32_t));
-    detail::WriteToBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), input);
-    m2_writeshard_barrier_uint32(device, in_tensor, input);
+    slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
+    m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(mesh_device, program);
 
     std::vector<uint32_t> output;
-    detail::ReadFromBuffer(*out_tensor.mesh_buffer().get_reference_buffer(), output);
+    slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
     EXPECT_EQ(input, output) << "M2 multi-core DFB identity mismatch";
 }
 
 static void run_concurrent_dfbs_program_2_0(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     uint32_t num_dfbs,
     uint32_t entry_size,
     uint32_t entries_per_dfb,
     bool implicit_sync) {
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device.arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Concurrent DFB tests require Quasar";
     }
     if (2 * num_dfbs > 6) {
         GTEST_SKIP() << "2*num_dfbs must fit in 6 Quasar DM threads";
     }
 
-    IDevice* device = mesh_device->get_devices()[0];
     const m2::NodeCoord node{0, 0};
 
     // One big DRAM tensor sliced num_dfbs ways for input + same for output.
     const uint32_t total_entries = num_dfbs * entries_per_dfb;
     const auto tensor_spec = make_flat_dram_tensor_spec(entry_size, total_entries, DataType::UINT32);
-    auto in_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
-    auto out_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
+    auto in_tensor = MeshTensor::allocate_on_device(mesh_device, tensor_spec);
+    auto out_tensor = MeshTensor::allocate_on_device(mesh_device, tensor_spec);
 
     // Build N DFBs + N producer kernels + N consumer kernels.
     std::vector<m2::DataflowBufferSpec> dfbs;
@@ -201,7 +200,7 @@ static void run_concurrent_dfbs_program_2_0(
         .work_units = {wu},
     };
 
-    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = m2::MakeProgramFromSpec(mesh_device, spec);
 
     m2::ProgramRunArgs params;
     for (const auto& name : kernel_names) {
@@ -215,13 +214,13 @@ static void run_concurrent_dfbs_program_2_0(
 
     auto input = tt::test_utils::generate_uniform_random_vector<uint32_t>(
         0, 1000000, total_entries * entry_size / sizeof(uint32_t));
-    detail::WriteToBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), input);
-    m2_writeshard_barrier_uint32(device, in_tensor, input);
+    slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
+    m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(mesh_device, program);
 
     std::vector<uint32_t> output;
-    detail::ReadFromBuffer(*out_tensor.mesh_buffer().get_reference_buffer(), output);
+    slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
     EXPECT_EQ(input, output) << "M2 concurrent DFBs mismatch";
 }
 
@@ -230,18 +229,17 @@ struct M2SeqDFBSpec {
 };
 
 static void run_sequential_4_dfbs_2_0(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     const std::array<M2SeqDFBSpec, 4>& dfb_specs,
     uint32_t num_producers,
     uint32_t num_consumers,
     bool implicit_sync) {
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (mesh_device.arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "Sequential 4-DFB test requires Quasar";
     }
     if (num_producers + num_consumers > 6) {
         GTEST_SKIP() << "num_p + num_c must fit in 6 Quasar DM threads";
     }
-    IDevice* device = mesh_device->get_devices()[0];
 
     constexpr uint32_t entry_size = 1024;
     // num_entries must be divisible by both num_producers and num_consumers.
@@ -263,8 +261,8 @@ static void run_sequential_4_dfbs_2_0(
     in_tensors.reserve(4);
     out_tensors.reserve(4);
     for (uint32_t i = 0; i < 4; ++i) {
-        in_tensors.push_back(MeshTensor::allocate_on_device(*mesh_device, tensor_spec));
-        out_tensors.push_back(MeshTensor::allocate_on_device(*mesh_device, tensor_spec));
+        in_tensors.push_back(MeshTensor::allocate_on_device(mesh_device, tensor_spec));
+        out_tensors.push_back(MeshTensor::allocate_on_device(mesh_device, tensor_spec));
     }
 
     std::vector<m2::DataflowBufferSpec> dfbs;
@@ -339,7 +337,7 @@ static void run_sequential_4_dfbs_2_0(
         }},
     };
 
-    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = m2::MakeProgramFromSpec(mesh_device, spec);
 
     m2::ProgramRunArgs params;
     // Kernels with no runtime args still need a KernelRunArgs entry so the
@@ -359,15 +357,15 @@ static void run_sequential_4_dfbs_2_0(
     for (uint32_t i = 0; i < 4; ++i) {
         inputs[i] = tt::test_utils::generate_uniform_random_vector<uint32_t>(
             0, 100, num_entries * entry_size / sizeof(uint32_t));
-        detail::WriteToBuffer(*in_tensors[i].mesh_buffer().get_reference_buffer(), inputs[i]);
-        m2_writeshard_barrier_uint32(device, in_tensors[i], inputs[i]);
+        slow_dispatch::WriteToBuffer(in_tensors[i].mesh_buffer(), inputs[i]);
+        m2_writeshard_barrier_uint32(mesh_device, in_tensors[i], inputs[i]);
     }
 
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(mesh_device, program);
 
     for (uint32_t i = 0; i < 4; ++i) {
         std::vector<uint32_t> output;
-        detail::ReadFromBuffer(*out_tensors[i].mesh_buffer().get_reference_buffer(), output);
+        slow_dispatch::ReadFromBuffer(out_tensors[i].mesh_buffer(), output);
         EXPECT_EQ(inputs[i], output) << "M2 sequential 4xDFB[" << i << "] output mismatch";
     }
 }
@@ -375,21 +373,21 @@ static void run_sequential_4_dfbs_2_0(
 // multi-core tests
 TEST_P(DFBImplicitSyncParamFixture_2_0, MultiCoreDMTest2Core_1Sx1S_2_0) {
     run_single_dfb_multicore_2_0(
-        this->devices_.at(0), 1, 1, m2::DFBAccessPattern::STRIDED, m2::DFBAccessPattern::STRIDED, GetParam());
+        this->device(), 1, 1, m2::DFBAccessPattern::STRIDED, m2::DFBAccessPattern::STRIDED, GetParam());
 }
 TEST_P(DFBImplicitSyncParamFixture_2_0, MultiCoreDMTest2Core_2Sx2S_2_0) {
     run_single_dfb_multicore_2_0(
-        this->devices_.at(0), 2, 2, m2::DFBAccessPattern::STRIDED, m2::DFBAccessPattern::STRIDED, GetParam());
+        this->device(), 2, 2, m2::DFBAccessPattern::STRIDED, m2::DFBAccessPattern::STRIDED, GetParam());
 }
 TEST_P(DFBImplicitSyncParamFixture_2_0, MultiCoreDMTest2Core_1Sx4A_2_0) {
     run_single_dfb_multicore_2_0(
-        this->devices_.at(0), 1, 4, m2::DFBAccessPattern::STRIDED, m2::DFBAccessPattern::ALL, GetParam());
+        this->device(), 1, 4, m2::DFBAccessPattern::STRIDED, m2::DFBAccessPattern::ALL, GetParam());
 }
 
 // concurrent / sequential multi-DFB tests
 TEST_P(DFBImplicitSyncParamFixture_2_0, DMTest3xDFB_1Sx1S_2_0) {
     run_concurrent_dfbs_program_2_0(
-        this->devices_.at(0),
+        this->device(),
         /*num_dfbs=*/3,
         /*entry_size=*/1024,
         /*entries_per_dfb=*/16,
@@ -403,7 +401,7 @@ TEST_P(DFBImplicitSyncParamFixture_2_0, DMTest4xDFB_3Sx3S_2_0) {
         M2SeqDFBSpec{m2::DFBAccessPattern::STRIDED},
         M2SeqDFBSpec{m2::DFBAccessPattern::STRIDED},
         M2SeqDFBSpec{m2::DFBAccessPattern::STRIDED}};
-    run_sequential_4_dfbs_2_0(this->devices_.at(0), dfbs, /*num_producers=*/3, /*num_consumers=*/3, GetParam());
+    run_sequential_4_dfbs_2_0(this->device(), dfbs, /*num_producers=*/3, /*num_consumers=*/3, GetParam());
 }
 
 TEST_P(DFBImplicitSyncParamFixture_2_0, DMTest4xDFB_Mixed_2_0) {
@@ -417,16 +415,14 @@ TEST_P(DFBImplicitSyncParamFixture_2_0, DMTest4xDFB_Mixed_2_0) {
         M2SeqDFBSpec{m2::DFBAccessPattern::STRIDED},
         M2SeqDFBSpec{m2::DFBAccessPattern::ALL},
         M2SeqDFBSpec{m2::DFBAccessPattern::ALL}};
-    run_sequential_4_dfbs_2_0(this->devices_.at(0), dfbs, /*num_producers=*/3, /*num_consumers=*/3, GetParam());
+    run_sequential_4_dfbs_2_0(this->device(), dfbs, /*num_producers=*/3, /*num_consumers=*/3, GetParam());
 }
 
 TEST_P(DFBImplicitSyncParamFixture_2_0, TensixDMTest4xDFB_1Sx1S_2_0) {
-    auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "M2 path is Quasar-only";
     }
     const bool implicit_sync = GetParam();
-    IDevice* device = mesh_device->get_devices()[0];
 
     constexpr uint32_t num_dfbs = 4;
     constexpr uint32_t entry_size = 1024;
@@ -444,7 +440,7 @@ TEST_P(DFBImplicitSyncParamFixture_2_0, TensixDMTest4xDFB_1Sx1S_2_0) {
     std::vector<MeshTensor> out_tensors;
     out_tensors.reserve(4);
     for (uint32_t i = 0; i < num_dfbs; ++i) {
-        out_tensors.push_back(MeshTensor::allocate_on_device(*mesh_device, dram_spec));
+        out_tensors.push_back(MeshTensor::allocate_on_device(this->device(), dram_spec));
     }
 
     std::vector<m2::DataflowBufferSpec> dfbs;
@@ -526,7 +522,7 @@ TEST_P(DFBImplicitSyncParamFixture_2_0, TensixDMTest4xDFB_1Sx1S_2_0) {
         }},
     };
 
-    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = m2::MakeProgramFromSpec(this->device(), spec);
 
     m2::ProgramRunArgs params;
     // Producer has no runtime args but still needs a KernelRunArgs entry to be
@@ -546,35 +542,33 @@ TEST_P(DFBImplicitSyncParamFixture_2_0, TensixDMTest4xDFB_1Sx1S_2_0) {
     // Pre-fill each DFB's L1 ring directly via uniform_alloc_addr after manual
     // finalize+allocate. No borrowed_from / ring tensor needed; the compute
     // kernel is TRISC-only and can't carry tensor bindings.
-    detail::CompileProgram(device, program);
+    slow_dispatch::CompileProgram(this->device(), program);
     program.impl().finalize_dataflow_buffer_configs();
-    program.impl().allocate_dataflow_buffers(device);
+    program.impl().allocate_dataflow_buffers(slow_dispatch::physical_device_from_unit_mesh(this->device()));
 
     std::vector<std::vector<uint32_t>> inputs(num_dfbs);
     for (uint32_t i = 0; i < num_dfbs; ++i) {
         const uint32_t dfb_l1_addr =
             program.impl().get_dataflow_buffer(program.impl().get_dfb_handle(DFB_NAMES[i]))->uniform_alloc_addr();
         inputs[i] = tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, total_bytes / sizeof(uint32_t));
-        detail::WriteToDeviceL1(device, CoreCoord(0, 0), dfb_l1_addr, inputs[i]);
+        slow_dispatch::WriteToL1(this->device(), CoreCoord(0, 0), dfb_l1_addr, inputs[i]);
     }
 
-    detail::LaunchProgram(device, program, /*wait_until_cores_done=*/true);
+    slow_dispatch::LaunchProgram(this->device(), program);
 
     for (uint32_t i = 0; i < num_dfbs; ++i) {
         std::vector<uint32_t> output;
-        detail::ReadFromBuffer(*out_tensors[i].mesh_buffer().get_reference_buffer(), output);
+        slow_dispatch::ReadFromBuffer(out_tensors[i].mesh_buffer(), output);
         EXPECT_EQ(inputs[i], output) << "M2 concurrent Tensix→DM 4xDFB[" << i << "] mismatch";
     }
 }
 
 // homogeneous-grid multi-core group test
-TEST_F(MeshDeviceFixture, MultiCoreDFB_HomogeneousGrid_SingleGroup_2_0) {
-    auto& mesh_device = this->devices_.at(0);
-    if (mesh_device->get_devices()[0]->arch() != ARCH::QUASAR) {
+TEST_F(UnitMeshFixture, MultiCoreDFB_HomogeneousGrid_SingleGroup_2_0) {
+    if (this->device().arch() != ARCH::QUASAR) {
         GTEST_SKIP() << "M2 path is Quasar-only (Gen2Config)";
     }
-    IDevice* device = mesh_device->get_devices()[0];
-    CoreCoord grid = device->compute_with_storage_grid_size();
+    CoreCoord grid = this->device().compute_with_storage_grid_size();
     if (grid.x < 2 || grid.y < 2) {
         GTEST_SKIP() << "Homogeneous-grid test requires >= 2x2 Tensix grid";
     }
@@ -591,8 +585,8 @@ TEST_F(MeshDeviceFixture, MultiCoreDFB_HomogeneousGrid_SingleGroup_2_0) {
 
     // Each core owns num_entries slots → 4 cores × num_entries pages total.
     const auto tensor_spec = make_flat_dram_tensor_spec(entry_size, 4 * num_entries, DataType::UINT32);
-    auto in_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
-    auto out_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
+    auto in_tensor = MeshTensor::allocate_on_device(this->device(), tensor_spec);
+    auto out_tensor = MeshTensor::allocate_on_device(this->device(), tensor_spec);
 
     m2::DataflowBufferSpec dfb_spec{
         .unique_id = DFB,
@@ -627,7 +621,7 @@ TEST_F(MeshDeviceFixture, MultiCoreDFB_HomogeneousGrid_SingleGroup_2_0) {
         }},
     };
 
-    Program program = m2::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = m2::MakeProgramFromSpec(this->device(), spec);
     program.impl().finalize_dataflow_buffer_configs();
 
     // Identical HW config across the 4 cores → must collapse into 1 DfbGroup.

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_multinode.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_multinode.cpp
@@ -111,7 +111,7 @@ static void run_single_dfb_multicore_2_0(
     slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
     m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
-    slow_dispatch::LaunchProgram(mesh_device, program);
+    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
     slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
@@ -217,7 +217,7 @@ static void run_concurrent_dfbs_program_2_0(
     slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
     m2_writeshard_barrier_uint32(mesh_device, in_tensor, input);
 
-    slow_dispatch::LaunchProgram(mesh_device, program);
+    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> output;
     slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
@@ -361,7 +361,7 @@ static void run_sequential_4_dfbs_2_0(
         m2_writeshard_barrier_uint32(mesh_device, in_tensors[i], inputs[i]);
     }
 
-    slow_dispatch::LaunchProgram(mesh_device, program);
+    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     for (uint32_t i = 0; i < 4; ++i) {
         std::vector<uint32_t> output;
@@ -554,7 +554,7 @@ TEST_P(DFBImplicitSyncParamFixture_2_0, TensixDMTest4xDFB_1Sx1S_2_0) {
         slow_dispatch::WriteToL1(this->device(), CoreCoord(0, 0), dfb_l1_addr, inputs[i]);
     }
 
-    slow_dispatch::LaunchProgram(this->device(), program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     for (uint32_t i = 0; i < num_dfbs; ++i) {
         std::vector<uint32_t> output;

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_overrides.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_overrides.cpp
@@ -5,6 +5,7 @@
 // DFB re-entry / entry-size / num-entries override runtime tests (legacy-only).
 
 #include "dfb_test_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
 
@@ -15,7 +16,7 @@ struct DfbSizeOverride {
 };
 
 static void run_dfb_size_override_test(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    distributed::MeshDevice& mesh_device,
     bool implicit_sync_param,
     uint32_t data_entry_size,   // bound-tensor page size == effective entry_size for every launch
     uint32_t entry_size_spec,   // DFB-declared entry_size
@@ -24,8 +25,7 @@ static void run_dfb_size_override_test(
     const std::vector<DfbSizeOverride>& launches,
     uint8_t num_producers = 1,
     uint8_t num_consumers = 1) {
-    IDevice* device = mesh_device->get_devices()[0];
-    const bool implicit_sync = (device->arch() == ARCH::QUASAR) && implicit_sync_param;
+    const bool implicit_sync = (mesh_device.arch() == ARCH::QUASAR) && implicit_sync_param;
 
     // Per-thread compile-time loop bounds; the strided kernels split `workload` across the threads
     // (ceiling division, with a runtime entries_per_core bound to skip the tail).
@@ -39,12 +39,12 @@ static void run_dfb_size_override_test(
     const experimental::TensorParamName OUT_TENSOR{"out_tensor"};
 
     const auto tensor_spec = make_flat_dram_tensor_spec(data_entry_size, workload);
-    MeshTensor in_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
-    MeshTensor out_tensor = MeshTensor::allocate_on_device(*mesh_device, tensor_spec);
+    MeshTensor in_tensor = MeshTensor::allocate_on_device(mesh_device, tensor_spec);
+    MeshTensor out_tensor = MeshTensor::allocate_on_device(mesh_device, tensor_spec);
 
     experimental::DataMovementHardwareConfig dm_producer_cfg;
     experimental::DataMovementHardwareConfig dm_consumer_cfg;
-    if (device->arch() == ARCH::QUASAR) {
+    if (mesh_device.arch() == ARCH::QUASAR) {
         dm_producer_cfg = experimental::DataMovementGen2Config{};
         dm_consumer_cfg = experimental::DataMovementGen2Config{};
     } else {
@@ -87,7 +87,7 @@ static void run_dfb_size_override_test(
         .hw_config = dm_consumer_cfg,
     };
     // Implicit sync is gen2 only
-    if (device->arch() == ARCH::QUASAR && !implicit_sync) {
+    if (mesh_device.arch() == ARCH::QUASAR && !implicit_sync) {
         auto& producer_hw_config = std::get<experimental::DataMovementGen2Config>(
             std::get<experimental::DataMovementHardwareConfig>(producer_spec.hw_config));
         auto& consumer_hw_config = std::get<experimental::DataMovementGen2Config>(
@@ -116,7 +116,7 @@ static void run_dfb_size_override_test(
         .work_units = {wu},
     };
 
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
     const auto input =
         tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, workload * data_entry_size / sizeof(uint32_t));
@@ -159,19 +159,19 @@ static void run_dfb_size_override_test(
         EXPECT_EQ(dfb->config.entry_size, eff_entry_size);
         EXPECT_EQ(dfb->config.num_entries, eff_num_entries);
 
-        detail::WriteToBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), input);
-        if (device->arch() == ARCH::QUASAR) {
+        slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), input);
+        if (mesh_device.arch() == ARCH::QUASAR) {
             // TODO #38042: barrier not yet uplifted for Quasar; wait for the DRAM write to land.
             std::this_thread::sleep_for(std::chrono::milliseconds(500));
             std::vector<uint32_t> rdback;
-            detail::ReadFromBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), rdback);
+            slow_dispatch::ReadFromBuffer(in_tensor.mesh_buffer(), rdback);
             tt_driver_atomics::mfence();
             ASSERT_EQ(rdback, input);
         }
-        detail::LaunchProgram(device, program, true /*wait_until_cores_done*/);
+        slow_dispatch::LaunchProgram(mesh_device, program);
 
         std::vector<uint32_t> output;
-        detail::ReadFromBuffer(*out_tensor.mesh_buffer().get_reference_buffer(), output);
+        slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);
         EXPECT_EQ(output, input);
     }
 }
@@ -179,7 +179,7 @@ static void run_dfb_size_override_test(
 // Gen1-only override / re-entry runtime tests (no 2.0 twin)
 TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB_NumEntriesOverride_ReEntry) {
     run_dfb_size_override_test(
-        this->devices_.at(0),
+        this->device(),
         GetParam(),
         /*data_entry_size=*/64,
         /*entry_size_spec=*/64,
@@ -192,7 +192,7 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB_NumEntriesOverride_ReEntry) {
 // use page size 64; the override raises entry_size to 64 (matching the tensors) before launch.
 TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB_EntrySizeOverride) {
     run_dfb_size_override_test(
-        this->devices_.at(0),
+        this->device(),
         GetParam(),
         /*data_entry_size=*/64,
         /*entry_size_spec=*/32,
@@ -206,7 +206,7 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB_EntrySizeOverride) {
 // capacity, plus reallocation for the new total_size.
 TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB_BothOverride) {
     run_dfb_size_override_test(
-        this->devices_.at(0),
+        this->device(),
         GetParam(),
         /*data_entry_size=*/64,
         /*entry_size_spec=*/32,
@@ -219,7 +219,7 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB_BothOverride) {
 TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB_NumEntriesOverride_ReEntry_3Sx3S) {
     DFB_SKIP_IF_UNSUPPORTED(3, 3);
     run_dfb_size_override_test(
-        this->devices_.at(0),
+        this->device(),
         GetParam(),
         /*data_entry_size=*/64,
         /*entry_size_spec=*/64,
@@ -234,7 +234,7 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB_NumEntriesOverride_ReEntry_3Sx3S
 TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB_NumEntriesOverride_ReEntry_1Sx4S) {
     DFB_SKIP_IF_UNSUPPORTED(1, 4);
     run_dfb_size_override_test(
-        this->devices_.at(0),
+        this->device(),
         GetParam(),
         /*data_entry_size=*/64,
         /*entry_size_spec=*/64,
@@ -249,7 +249,7 @@ TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB_NumEntriesOverride_ReEntry_1Sx4S
 TEST_P(DFBImplicitSyncParamFixture, DMTest1xDFB_NumEntriesOverride_ReEntry_4Sx1S) {
     DFB_SKIP_IF_UNSUPPORTED(4, 1);
     run_dfb_size_override_test(
-        this->devices_.at(0),
+        this->device(),
         GetParam(),
         /*data_entry_size=*/64,
         /*entry_size_spec=*/64,

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_overrides.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_overrides.cpp
@@ -168,7 +168,7 @@ static void run_dfb_size_override_test(
             tt_driver_atomics::mfence();
             ASSERT_EQ(rdback, input);
         }
-        slow_dispatch::LaunchProgram(mesh_device, program);
+        slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
         std::vector<uint32_t> output;
         slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), output);

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_scoped_lock_cache.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_scoped_lock_cache.cpp
@@ -10,6 +10,7 @@
 // a write lock flushes on release.
 
 #include "dfb_test_common.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include "tt_metal/tt_metal/test_kernels/dataflow/dfb_scoped_lock_cache_common.h"
 
 namespace tt::tt_metal {
@@ -72,10 +73,8 @@ std::vector<uint32_t> dfb_cache_expected(const DfbCacheParams& p) {
 }
 
 // Builds the DFB, enqueues the cache-op kernel, and returns the per-slot read-back.
-std::vector<uint32_t> run_dfb_scoped_lock_cache_test(
-    const std::shared_ptr<distributed::MeshDevice>& mesh_device, const DfbCacheParams& p) {
-    IDevice* device = mesh_device->get_devices()[0];
-    const uint32_t ring_base = static_cast<uint32_t>(device->allocator()->get_base_allocator_addr(HalMemType::L1));
+std::vector<uint32_t> run_dfb_scoped_lock_cache_test(distributed::MeshDevice& mesh_device, const DfbCacheParams& p) {
+    const uint32_t ring_base = static_cast<uint32_t>(mesh_device.allocator()->get_base_allocator_addr(HalMemType::L1));
     const uint32_t result_addr = ring_base + DFB_CACHE_RESULT_OFFSET;
     const CoreCoord core{0, 0};
     const CoreRangeSet crs(CoreRange(core, core));
@@ -151,7 +150,7 @@ std::vector<uint32_t> run_dfb_scoped_lock_cache_test(
         .semaphores = semaphores,  // empty unless multi-consumer-ALL
         .work_units = {wu},
     };
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
 
     auto make_node_args = [&](bool active) {
         return experimental::MakeRuntimeArgsForSingleNode(
@@ -184,13 +183,10 @@ std::vector<uint32_t> run_dfb_scoped_lock_cache_test(
         for (uint32_t s = 0; s < p.num_entries; ++s) {
             prefill[s * wpe] = DFB_CACHE_OLD_BASE + s;
         }
-        detail::WriteToDeviceL1(device, core, ring_base, prefill);
+        slow_dispatch::WriteToL1(mesh_device, core, ring_base, prefill);
     }
 
-    distributed::MeshWorkload workload;
-    const distributed::MeshCoordinateRange device_range(mesh_device->shape());
-    workload.add_program(device_range, std::move(program));
-    distributed::EnqueueMeshWorkload(mesh_device->mesh_command_queue(), workload, /*blocking=*/true);
+    slow_dispatch::LaunchProgram(mesh_device, program);
 
     // Kernels write their in-kernel verification read-back (via the non-cacheable alias so the result lands
     // in TL1) to the scratch region; the host reads it directly. Layout: handshake -> num_rounds words (one
@@ -203,12 +199,12 @@ std::vector<uint32_t> run_dfb_scoped_lock_cache_test(
         result_words = (p.multi_all ? p.num_consumers : 1u) * p.num_entries;
     }
     std::vector<uint32_t> result;
-    detail::ReadFromDeviceL1(device, core, result_addr, result_words * sizeof(uint32_t), result);
+    slow_dispatch::ReadFromL1(mesh_device, core, result_addr, result_words * sizeof(uint32_t), result);
     return result;
 }
 
 #define DFB_CACHE_SKIP_IF_NOT_QUASAR()                                                               \
-    if (devices_.at(0)->arch() != ARCH::QUASAR) {                                                    \
+    if (this->devices_.at(0)->arch() != ARCH::QUASAR) {                                              \
         GTEST_SKIP() << "scoped-lock cache ops are Quasar-only; the WH/BH path is the lock tracker"; \
     }
 
@@ -227,7 +223,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheFlushProducerStrided1Sx
         /*producer=*/true,
         /*mode=*/DfbCacheTestMode::FlushOnRelease,
         /*lock_n=*/4};
-    EXPECT_EQ(run_dfb_scoped_lock_cache_test(this->devices_.at(0), p), dfb_cache_expected(p));
+    EXPECT_EQ(run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p), dfb_cache_expected(p));
 }
 
 // Same baseline but lock_n=1: only the head entry {0} is held/flushed.
@@ -242,7 +238,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheFlushProducerStrided1Sx
         /*producer=*/true,
         /*mode=*/DfbCacheTestMode::FlushOnRelease,
         /*lock_n=*/1};
-    EXPECT_EQ(run_dfb_scoped_lock_cache_test(this->devices_.at(0), p), dfb_cache_expected(p));
+    EXPECT_EQ(run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p), dfb_cache_expected(p));
 }
 
 // 2 producers (stride==2): only this producer's held {0,2,4,6} flush; interleaved neighbours {1,3,5,7} untouched.
@@ -257,7 +253,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheFlushProducerStrided2Sx
         /*producer=*/true,
         /*mode=*/DfbCacheTestMode::FlushOnRelease,
         /*lock_n=*/4};
-    EXPECT_EQ(run_dfb_scoped_lock_cache_test(this->devices_.at(0), p), dfb_cache_expected(p));
+    EXPECT_EQ(run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p), dfb_cache_expected(p));
 }
 
 // ALL pattern (broadcast, stride==1) instead of STRIDED; held = {0..3}.
@@ -272,7 +268,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheFlushProducerAll) {
         /*producer=*/true,
         /*mode=*/DfbCacheTestMode::FlushOnRelease,
         /*lock_n=*/4};
-    EXPECT_EQ(run_dfb_scoped_lock_cache_test(this->devices_.at(0), p), dfb_cache_expected(p));
+    EXPECT_EQ(run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p), dfb_cache_expected(p));
 }
 
 // Wrap: held window {0,2,0} crosses the ring end -> exercises the wrap-to-base branch (idempotent); {0,2}=NEW.
@@ -287,7 +283,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheFlushProducerWrap) {
         /*producer=*/true,
         /*mode=*/DfbCacheTestMode::FlushOnRelease,
         /*lock_n=*/3};
-    EXPECT_EQ(run_dfb_scoped_lock_cache_test(this->devices_.at(0), p), dfb_cache_expected(p));
+    EXPECT_EQ(run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p), dfb_cache_expected(p));
 }
 
 // Consumer release must NOT flush -> every slot reads back OLD.
@@ -302,7 +298,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheFlushConsumerDoesNotFlu
         /*producer=*/false,
         /*mode=*/DfbCacheTestMode::FlushOnRelease,
         /*lock_n=*/4};
-    EXPECT_EQ(run_dfb_scoped_lock_cache_test(this->devices_.at(0), p), dfb_cache_expected(p));
+    EXPECT_EQ(run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p), dfb_cache_expected(p));
 }
 
 // ---- Invalidate-on-acquire (both lock kinds) -------------------------------------------
@@ -320,7 +316,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheInvalidateProducerStrid
         /*producer=*/true,
         /*mode=*/DfbCacheTestMode::InvalidateOnAcquire,
         /*lock_n=*/4};
-    EXPECT_EQ(run_dfb_scoped_lock_cache_test(this->devices_.at(0), p), dfb_cache_expected(p));
+    EXPECT_EQ(run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p), dfb_cache_expected(p));
 }
 
 // 2 producers (stride==2): only held {0,2,4,6} invalidated; interleaved neighbours {1,3,5,7} keep stale OLD.
@@ -335,7 +331,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheInvalidateProducerStrid
         /*producer=*/true,
         /*mode=*/DfbCacheTestMode::InvalidateOnAcquire,
         /*lock_n=*/4};
-    EXPECT_EQ(run_dfb_scoped_lock_cache_test(this->devices_.at(0), p), dfb_cache_expected(p));
+    EXPECT_EQ(run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p), dfb_cache_expected(p));
 }
 
 // A read lock also invalidates on acquire -> held {0,1,2,3}=NEW, rest OLD.
@@ -350,7 +346,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheInvalidateConsumer) {
         /*producer=*/false,
         /*mode=*/DfbCacheTestMode::InvalidateOnAcquire,
         /*lock_n=*/4};
-    EXPECT_EQ(run_dfb_scoped_lock_cache_test(this->devices_.at(0), p), dfb_cache_expected(p));
+    EXPECT_EQ(run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p), dfb_cache_expected(p));
 }
 
 // 1 producer + 4 ALL consumers sharing entries: producer seeds shared-L2=OLD/TL1=NEW + signals, then all 4
@@ -368,7 +364,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheInvalidateMultiConsumer
         /*mode=*/DfbCacheTestMode::InvalidateOnAcquire,
         /*lock_n=*/2,
         /*multi_all=*/true};
-    const auto result = run_dfb_scoped_lock_cache_test(this->devices_.at(0), p);
+    const auto result = run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p);
     const auto expected = dfb_cache_expected(p);  // held {0,1} -> NEW, {2,3} -> OLD
     ASSERT_EQ(result.size(), static_cast<size_t>(p.num_consumers) * p.num_entries);
     for (uint32_t c = 0; c < p.num_consumers; ++c) {
@@ -392,7 +388,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheHandshakeDmToDmWrap) {
         /*lock_n=*/1};
     p.handshake = true;
     p.num_rounds = 12;  // > capacity (4) so each slot is reused ~3x
-    const auto result = run_dfb_scoped_lock_cache_test(this->devices_.at(0), p);
+    const auto result = run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p);
     ASSERT_EQ(result.size(), p.num_rounds);
     std::vector<uint32_t> expected(p.num_rounds);
     for (uint32_t r = 0; r < p.num_rounds; ++r) {
@@ -417,7 +413,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ScopedLockCacheHandshakeNonSnoopingPro
     p.handshake = true;
     p.num_rounds = 12;
     p.nonsnoop_producer = true;
-    const auto result = run_dfb_scoped_lock_cache_test(this->devices_.at(0), p);
+    const auto result = run_dfb_scoped_lock_cache_test(*this->devices_.at(0), p);
     ASSERT_EQ(result.size(), p.num_rounds);
     std::vector<uint32_t> expected(p.num_rounds);
     for (uint32_t r = 0; r < p.num_rounds; ++r) {

--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_scoped_lock_cache.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer_scoped_lock_cache.cpp
@@ -186,7 +186,7 @@ std::vector<uint32_t> run_dfb_scoped_lock_cache_test(distributed::MeshDevice& me
         slow_dispatch::WriteToL1(mesh_device, core, ring_base, prefill);
     }
 
-    slow_dispatch::LaunchProgram(mesh_device, program);
+    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     // Kernels write their in-kernel verification read-back (via the non-cacheable alias so the result lands
     // in TL1) to the scratch region; the host reads it directly. Layout: handshake -> num_rounds words (one

--- a/tests/tt_metal/tt_metal/common/device_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/device_fixture.hpp
@@ -169,27 +169,16 @@ protected:
 
 class MeshDeviceSingleCardBufferFixture : public MeshDeviceSingleCardFixture {};
 
-// Single unit-mesh fixture: always owns exactly one MeshDevice and exposes
-// RunProgram / FinishCommands overloads that do not take a device arg.
+// Single unit-mesh fixture: always owns exactly one unit MeshDevice.
 class UnitMeshFixture : public MeshDeviceSingleCardFixture {
 public:
-    distributed::MeshDevice& device() { return *device_; }
+    distributed::MeshDevice& device() { return *devices_.front(); }
 
-    void RunProgram(Program program, bool skip_finish = false) {
-        distributed::MeshWorkload workload;
-        workload.add_program(distributed::MeshCoordinateRange(distributed::MeshCoordinate(0, 0)), std::move(program));
-        MeshDispatchFixture::RunProgram(device_, workload, skip_finish);
-    }
-    void FinishCommands() { MeshDispatchFixture::FinishCommands(device_); }
-
-private:
+protected:
     void create_devices() override {
         const ChipId mmio_device_id = *tt::tt_metal::MetalContext::instance().get_cluster().mmio_chip_ids().begin();
         AnyDispatchMeshDeviceSingleCardFixture::create_devices({mmio_device_id});
-        device_ = devices_.front();
     }
-
-    std::shared_ptr<distributed::MeshDevice> device_;
 };
 
 class BlackholeSingleCardFixture : public MeshDeviceSingleCardFixture {

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
@@ -116,7 +116,7 @@ TEST_F(UnitMeshFixture, MatmulSingleTileOutputInL1) {
         core,
         {dst_l1_buffer->address(), (std::uint32_t)l1_dst_noc_xy.x, (std::uint32_t)l1_dst_noc_xy.y, num_tiles});
 
-    slow_dispatch::LaunchProgram(this->device(), std::move(program));
+    slow_dispatch::LaunchProgram(this->device(), program);
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*dst_l1_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
@@ -116,7 +116,7 @@ TEST_F(UnitMeshFixture, MatmulSingleTileOutputInL1) {
         core,
         {dst_l1_buffer->address(), (std::uint32_t)l1_dst_noc_xy.x, (std::uint32_t)l1_dst_noc_xy.y, num_tiles});
 
-    slow_dispatch::LaunchProgram(this->device(), program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*dst_l1_buffer, result_vec);

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_output_in_l1.cpp
@@ -116,7 +116,7 @@ TEST_F(UnitMeshFixture, MatmulSingleTileOutputInL1) {
         core,
         {dst_l1_buffer->address(), (std::uint32_t)l1_dst_noc_xy.x, (std::uint32_t)l1_dst_noc_xy.y, num_tiles});
 
-    this->RunProgram(std::move(program));
+    slow_dispatch::LaunchProgram(this->device(), std::move(program));
 
     std::vector<uint32_t> result_vec;
     slow_dispatch::ReadFromBuffer(*dst_l1_buffer, result_vec);

--- a/tt_metal/impl/dispatch/slow_dispatch.hpp
+++ b/tt_metal/impl/dispatch/slow_dispatch.hpp
@@ -116,10 +116,8 @@ inline void CompileProgram(distributed::MeshDevice& unit_mesh, Program& program)
     detail::CompileProgram(physical_device_from_unit_mesh(unit_mesh), program);
 }
 
-inline void LaunchProgram(distributed::MeshDevice& mesh_device, Program program, bool wait_until_cores_done = true) {
-    distributed::MeshWorkload workload;
-    workload.add_program(distributed::MeshCoordinateRange{mesh_device.shape()}, std::move(program));
-    distributed::EnqueueMeshWorkload(mesh_device.mesh_command_queue(), workload, wait_until_cores_done);
+inline void LaunchProgram(distributed::MeshDevice& unit_mesh, Program& program, bool wait_until_cores_done = true) {
+    detail::LaunchProgram(physical_device_from_unit_mesh(unit_mesh), program, wait_until_cores_done);
 }
 
 }  // namespace tt::tt_metal::slow_dispatch

--- a/tt_metal/impl/dispatch/slow_dispatch.hpp
+++ b/tt_metal/impl/dispatch/slow_dispatch.hpp
@@ -112,4 +112,14 @@ inline bool ReadFromDRAMChannel(
         physical_device_from_unit_mesh(unit_mesh), dram_channel, address, host_buffer);
 }
 
+inline void CompileProgram(distributed::MeshDevice& unit_mesh, Program& program) {
+    detail::CompileProgram(physical_device_from_unit_mesh(unit_mesh), program);
+}
+
+inline void LaunchProgram(distributed::MeshDevice& mesh_device, Program program, bool wait_until_cores_done = true) {
+    distributed::MeshWorkload workload;
+    workload.add_program(distributed::MeshCoordinateRange{mesh_device.shape()}, std::move(program));
+    distributed::EnqueueMeshWorkload(mesh_device.mesh_command_queue(), workload, wait_until_cores_done);
+}
+
 }  // namespace tt::tt_metal::slow_dispatch

--- a/tt_metal/impl/dispatch/slow_dispatch.hpp
+++ b/tt_metal/impl/dispatch/slow_dispatch.hpp
@@ -116,7 +116,7 @@ inline void CompileProgram(distributed::MeshDevice& unit_mesh, Program& program)
     detail::CompileProgram(physical_device_from_unit_mesh(unit_mesh), program);
 }
 
-inline void LaunchProgram(distributed::MeshDevice& unit_mesh, Program& program, bool wait_until_cores_done = true) {
+inline void LaunchProgram(distributed::MeshDevice& unit_mesh, Program& program, bool wait_until_cores_done) {
     detail::LaunchProgram(physical_device_from_unit_mesh(unit_mesh), program, wait_until_cores_done);
 }
 


### PR DESCRIPTION
### PR Category
Cleanup, Test Only

### Summary

Advances https://github.com/tenstorrent/tt-metal/issues/51835

Legacy API usage related to `IDevice` and `Buffer` is removed from single-device DFB tests.
In particular, 50 usages of `get_devices()` and `get_reference_buffer()` are encapsulated in the common wrappers.

`LaunchProgram` and `CompileProgram` wrappers are added for `MeshDevice`.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

Tested by running locally: `./build/test/tt_metal/unit_tests_api`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov-dataflow-buffer-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov-dataflow-buffer-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov-dataflow-buffer-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov-dataflow-buffer-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=obacherikov-dataflow-buffer-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:obacherikov-dataflow-buffer-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov-dataflow-buffer-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov-dataflow-buffer-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov-dataflow-buffer-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov-dataflow-buffer-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov-dataflow-buffer-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov-dataflow-buffer-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov-dataflow-buffer-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov-dataflow-buffer-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov-dataflow-buffer-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov-dataflow-buffer-tests)