### PR TITLE
Disambiguate in-place wheel artifact name by Python version

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -815,11 +815,14 @@ jobs:
           # self-contained; targets manylinux_2_35 (ubuntu 22.04 glibc) = in-family only.
           LD_LIBRARY_PATH=/work/build/lib auditwheel repair -w /work/wheelhouse /work/wheelhouse-raw/*.whl
           echo "Repaired wheel(s):"; ls -1sh /work/wheelhouse/*.whl
-          # Name it like the build-wheel job so consumers treat it identically.
+          # Name it like the build-wheel job so consumers treat it identically. Includes the
+          # Python version so two in-place builds (e.g. Ubuntu 22.04 cp310 + 24.04 cp312) in the
+          # same run don't collide on the same artifact name.
           RAW_REF="${{ inputs.ref || github.sha }}"
           SANITIZED_REF=$(echo "$RAW_REF" | sed 's/[\/:"<>|*?\r\n\\]/-/g')
           TRACY_SUFFIX="${{ (inputs.tracy && '-profiler') || '' }}"
-          ARTIFACT_NAME="ttnn-dist-inplace-${{ inputs.build-type }}${TRACY_SUFFIX}-${SANITIZED_REF}-${{ github.run_id }}"
+          PYTHON_VERSION_NODOT=$(echo "${{ needs.parse-platform.outputs.python-version }}" | tr -d '.')
+          ARTIFACT_NAME="ttnn-dist-inplace-cp${PYTHON_VERSION_NODOT}-${{ inputs.build-type }}${TRACY_SUFFIX}-${SANITIZED_REF}-${{ github.run_id }}"
           echo "artifact_name=${ARTIFACT_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: ☁️ Upload wheel package


### PR DESCRIPTION
## Summary
- The in-place wheel artifact name (`build-artifact.yaml`'s `🐍 Package wheel` step) only encoded build-type, tracy suffix, ref, and run_id — no Python version.
- When two platform legs (e.g. Ubuntu 22.04/cp310 and Ubuntu 24.04/cp312) both use `build-inplace-wheel: true` within the same workflow run, they produce **identical** artifact names and collide. Whichever upload lands last wins the name, so the other platform's downstream test jobs silently download an incompatible wheel and fail at `uv pip install` with "wheel is compatible with CPython 3.12, but you're using CPython 3.10".
- Fix: include `cp<python_version_nodot>` in the in-place wheel's artifact name, matching the naming convention already used by the full manylinux build in `wheels.yaml` (`ttnn-dist-cp<version>-...`).

## Test plan
- [ ] Confirm a workflow run with two platform legs both using `build-inplace-wheel: true` in the same run produces two distinctly-named wheel artifacts
- [ ] Confirm each platform's test jobs install the correctly-versioned wheel

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brain/fix-inplace-wheel-artifact-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brain/fix-inplace-wheel-artifact-collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=brain/fix-inplace-wheel-artifact-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:brain/fix-inplace-wheel-artifact-collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=brain/fix-inplace-wheel-artifact-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:brain/fix-inplace-wheel-artifact-collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brain/fix-inplace-wheel-artifact-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brain/fix-inplace-wheel-artifact-collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=brain/fix-inplace-wheel-artifact-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:brain/fix-inplace-wheel-artifact-collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=brain/fix-inplace-wheel-artifact-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brain/fix-inplace-wheel-artifact-collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=brain/fix-inplace-wheel-artifact-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brain/fix-inplace-wheel-artifact-collision)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=brain/fix-inplace-wheel-artifact-collision)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brain/fix-inplace-wheel-artifact-collision)