### PR TITLE
ds_prefill(k3_mla_gate) - route K3 output gate through high_bw_all_gather

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -996,6 +996,10 @@ _CHUNKED_SCENARIOS = (
             "fabric_config": ttnn.FabricConfig.FABRIC_2D,
             "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
+            # high_bw_all_gather parks its readiness/completion semaphores in L1_SMALL when the device
+            # reserves one, and falls back to general L1 otherwise. On the 8x4 grid the fallback
+            # fragments L1 enough that a later op's static circular buffers collide with it.
+            "l1_small_size": 1152,
         },
     ],
     ids=["line", "ring", "fabric2d"],
@@ -1084,6 +1088,7 @@ def test_mla_chunked_prefill(
             "fabric_config": ttnn.FabricConfig.FABRIC_2D,
             "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
             "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
+            "l1_small_size": 1152,
         }
     ],
     ids=["fabric2d"],

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -425,6 +425,7 @@ class ttMLA:
         # across serial MLA layers through TT_CCL; forward only reuses these stable addresses.
         self._q_a_latent_gather_output = None
         self._kv_stem_gather_output = None
+        self._output_gate_gather_output = None
         if self.tp_factor > 1:
             if not self.kv_only:
                 self._q_a_latent_gather_output = self.tt_ccl.get_mla_high_bw_all_gather_buffer(
@@ -439,6 +440,13 @@ class ttMLA:
                 dtype=ttnn.bfloat16,
                 layout=ttnn.TILE_LAYOUT,
             )
+            if self._use_gate and not self.kv_only:
+                self._output_gate_gather_output = self.tt_ccl.get_mla_high_bw_all_gather_buffer(
+                    name="output_gate",
+                    shape=[1, 1, self.active_seq_len_local, self.hidden_size],
+                    dtype=ttnn.bfloat16,
+                    layout=ttnn.TILE_LAYOUT,
+                )
 
         # Per-axis CCL topology, named symmetrically by axis. The q/kv/wo collectives run on the TP
         # axis (cluster_axis=tp_axis) and use tp_ccl_topology; the ring-attention SDPA (ring_mla /
@@ -1193,15 +1201,29 @@ class ttMLA:
         12288-wide partial: less traffic, no wide intermediate, and g is complete per device so sigmoid
         can fuse into the matmul (measured ~292 us less collective at FABRIC_2D).
         """
-        h = self._all_gather(hidden_states, dim=3, cluster_axis=self.tp_axis)
+        if self.tp_factor > 1:
+            assert self._output_gate_gather_output is not None
+            assert seq_len_local == self.active_seq_len_local, (
+                f"output-gate gather was preallocated for {self.active_seq_len_local} local tokens, "
+                f"got {seq_len_local}"
+            )
+            h = ttnn.experimental.high_bw_all_gather(
+                hidden_states,
+                dim=3,
+                output_tensor=self._output_gate_gather_output,
+                cluster_axis=self.tp_axis,
+                num_links=self.ccl_num_links,
+            )
+        else:
+            h = hidden_states
         g = ttnn.linear(
             h,
             self.g_proj_weight,
             compute_kernel_config=self.default_compute_kernel_config,
             **self._get_mm_kwargs("g_proj", seq_len_local),
         )
-        if h is not hidden_states:
-            ttnn.deallocate(h)
+        # The TP gather aliases a construction-time persistent output buffer shared across serial MLA
+        # instances/layers. Keep it allocated; deallocating the returned wrapper invalidates later users.
         # Fused only when a tuned config supplied fused_activation; otherwise a standalone sigmoid.
         # Keyed off the resolved config so the two paths can't silently drift into double-sigmoid.
         if not self._gate_sigmoid_fused(seq_len_local):


### PR DESCRIPTION
## Summary

Fixes two nightly-CI failures in K3 MLA chunked prefill.

**1. `AttributeError: 'ttMLA' object has no attribute '_all_gather'`**

Semantic merge race. #52606 deleted the `_all_gather` helper and moved every MLA gather to `high_bw_all_gather` with a construction-time persistent buffer. #52068 (K3 output gate) was written before that and added a *new* call to `_all_gather`. Textually disjoint, so both merged clean — it only blew up at runtime when a K3 test hit the output-gate path.

Fix: preallocate `_output_gate_gather_output` at construction and gather into it via `high_bw_all_gather`, same as the q/kv gathers. Dropped the `ttnn.deallocate(h)` — that buffer is now shared across MLA layers, so freeing it corrupts later users.

**2. `Statically allocated circular buffers ... clash with L1 buffers`**

Only visible once (1) was fixed, since CI had never reached this code. `high_bw_all_gather` puts its semaphores in `L1_SMALL` when the device reserves one and falls back to general L1 otherwise. The fabric2d test config reserved none; on the 8x4 grid the fallback fragmented L1 and a later op's static CBs collided.

Fix: `l1_small_size: 1152` in the fabric2d `device_params`. Test config only, no model change.

## Before / after

Red on `main`:

- [Blaze - K3 MLA](https://github.com/tenstorrent/tt-metal/actions/runs/31566695337/job/94051385125) — 2 failed, 7x `AttributeError: 'ttMLA' object has no attribute '_all_gather'`
- [bh_qb_DeepSeek_PREFILL](https://github.com/tenstorrent/tt-metal/actions/runs/31616677628/job/94183681788) — same AttributeError, 4x

## Test plan

Both previously-red pipelines are green on this branch (`55bcf0e97db`):

- [Blaze Models Prefill](https://github.com/tenstorrent/tt-metal/actions/runs/31610534228) — `Blaze - K3 MLA` 2 passed, `Blaze - K3 MLA perf` 1 passed
- [(Blackhole) e2e](https://github.com/tenstorrent/tt-metal/actions/runs/31626662857) — `bh_qb_DeepSeek_PREFILL`, `OP_TESTS`, `D2D_SOCKET_SYNC` all pass

Local 8xP150 LoudBox, k3 chunked-prefill sweep: 24 passed / 2 failed. The 2 failures are `k3-production-50k+5k` at 2x4 — dsv3 fails the same scenario too (no output gate there), PCC decays monotonically with KV depth and crosses the 0.98 gate near iter 10. Pre-existing, unrelated to this change, and not a scenario either CI job runs.

### DeepSeek Prefill CI
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=nmilicevic/mla-ag-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:nmilicevic/mla-ag-fix) Galaxy
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=nmilicevic/mla-ag-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:nmilicevic/mla-ag-fix) T3K
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=nmilicevic/mla-ag-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:nmilicevic/mla-ag-fix) Single Card
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=nmilicevic/mla-ag-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:nmilicevic/mla-ag-fix) Blackhole
