### PR TITLE
[Cleanup] Shrink the DRISC mailbox to fit its own mailboxes_t

### DIFF
--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
@@ -326,7 +326,19 @@
 #define MEM_DRISC_LOCAL_SIZE MEM_BRISC_LOCAL_SIZE  // 8KB private data at MEM_LOCAL_BASE (0xFFB00000)
 #define MEM_DRISC_RESERVED_SIZE 64                 // Reserved at address 0 for corruption detection
 #define MEM_DRISC_MAILBOX_BASE MEM_DRISC_RESERVED_SIZE
-#define MEM_DRISC_MAILBOX_SIZE MEM_ERISC_MAILBOX_SIZE
+// Magic size must be big enough to hold mailboxes_t as instantiated for DRISC (PROCESSOR_COUNT == 1); the
+// static_assert in bh_hal_dram.cpp fires if this is too small. Sized tight (not shared with ERISC, which is
+// sized for its 2 processors) to free L1 for the programmable-DRAM-core kernel working region.
+//
+// mailboxes_t is unconditional: every debug/profiling feature that lives in the mailbox reserves its space
+// whether or not the feature is turned on, so this one number covers, simultaneously and regardless of which
+// are enabled at runtime, the watcher (288B: waypoints, NOC sanitize, assert, pause, stack usage,
+// insert-delays, ring buffer), DPRINT (204B = 1 processor * 204) and the kernel profiler (2304B = 256B
+// control vector + 1 processor * 2KB marker buffer). Nothing else in the DRISC map is conditional either:
+// the fabric routing tables/packet-header pool are Tensix/ERISC-only, and the realtime profiler message
+// lives in the CQ region rather than the mailbox. The remaining 1492B is the launch ring (8 * 144B) + go
+// messages + core info + sync/ready flags.
+#define MEM_DRISC_MAILBOX_SIZE 4288
 #define MEM_DRISC_MAILBOX_END (MEM_DRISC_MAILBOX_BASE + MEM_DRISC_MAILBOX_SIZE)
 #define MEM_DRISC_L1_INLINE_BASE MEM_DRISC_MAILBOX_END
 #define MEM_DRISC_L1_INLINE_END (MEM_DRISC_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2) * 2)

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_dram.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_dram.cpp
@@ -40,6 +40,13 @@ namespace dram_realtime_profiler_msgs {
 HalCoreInfoType create_dram_mem_map() {
     static_assert(sizeof(mailboxes_t) <= MEM_DRISC_MAILBOX_SIZE);
     static_assert(MEM_DRISC_FIRMWARE_BASE % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
+    // MEM_DRISC_MAILBOX_SIZE is sized to sizeof(mailboxes_t) exactly, so these members sit where the mailbox
+    // layout puts them. Dispatch NOC-writes the launch message and the profiler results are moved by NOC, and
+    // an unaligned dispatch write is silently dropped, so pin the alignment here rather than in a hang.
+    static_assert((MEM_DRISC_MAILBOX_BASE + offsetof(mailboxes_t, launch)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
+    static_assert((MEM_DRISC_MAILBOX_BASE + offsetof(mailboxes_t, profiler)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
+    static_assert(
+        (MEM_DRISC_MAILBOX_BASE + offsetof(mailboxes_t, go_message_index)) % TT_ARCH_MAX_NOC_WRITE_ALIGNMENT == 0);
 
     std::uint32_t max_alignment = std::max(DRAM_ALIGNMENT, L1_ALIGNMENT);
 


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
`MEM_DRISC_MAILBOX_SIZE` was defined as `MEM_ERISC_MAILBOX_SIZE` (12768 B), a number sized for ERISC's two processors. DRISC instantiates `mailboxes_t` with `PROCESSOR_COUNT == 1`, which needs 4288 B, so every Blackhole DRAM core was reserving 8480 B of L1 that nothing can address.

This sets it to 4288 — exactly `sizeof(mailboxes_t)` for DRISC, matching the Tensix convention where `MEM_MAILBOX_SIZE 13296` is also exact. Everything downstream of the mailbox derives from it, so the DRAM-core kernel working region (`HalL1MemAddrType::UNRESERVED`) grows from 86.4 KB to **94.7 KB** of the 128 KB DRISC L1, and every boundary stays 64 B aligned:

| | before | after |
|---|---|---|
| `MEM_DRISC_FIRMWARE_BASE` | 12896 | 4416 |
| `MEM_DRISC_KERNEL_CONFIG_BASE` | 40544 | 32064 |
| `UNRESERVED` | 42624 (86.4 KB free) | 34112 (94.7 KB free) |

No functional change: the firmware text window stays 24 KB, and the generated `firmware_drisc.ld` / `kernel_drisc.ld` pick up the new base automatically.

Relates to #45751.

### Notes for reviewers

**Why 4288 is safe rather than merely plausible.** `alignof(mailboxes_t)` is 16, so tightness is provable: building `bh_hal` with 4272 fails the pre-existing `static_assert(sizeof(mailboxes_t) <= MEM_DRISC_MAILBOX_SIZE)` in `bh_hal_dram.cpp`, and 4288 passes — there is nothing in between. That assert remains the guard if a future field outgrows the region.

**Debug features are accounted for, and need no headroom.** `mailboxes_t` has no `#ifdef`s, so `watcher_msg_t` (288 B), `dprint_buf` (204 B) and `profiler_msg_t` (2304 B) are always members; the space is reserved whether or not the feature is enabled, which makes 4288 the worst case by construction. Nothing else in the DRISC map is conditional either — the fabric routing tables and packet-header pool are Tensix/ERISC-only, and the realtime-profiler message lives in the CQ region, not the mailbox. `DEVICE_PRINT_BUFFER_SIZE` is the only `-D` that can grow the struct, and only the standalone LLK test harness sets it.

**The new alignment asserts.** The DRAM map had no equivalent of the Tensix/ETH `launch`/`profiler` alignment asserts. Now that the region is sized to the struct exactly, a future reshuffle that misaligned those members would produce a silently-dropped dispatch write and a kernel hung forever, not an error — so they are pinned at compile time.

**Not addressed here, but worth knowing:** `MEM_ERISC_MAILBOX_SIZE` is itself loose. Idle/active ERISC need 6544 B of the 12768 B reserved, so ~6.2 KB of eth L1 is dead, and the `TODO: reduce this when mailbox sizes are core type aware` above the idle-ERISC map is stale (they *are* core-type aware now, via `PROCESSOR_COUNT`). I left it out deliberately: the eth layout is more delicate, since `MEM_AERISC_MAILBOX_BASE` participates in a base-FW/syseng contract. Happy to do it as a follow-up.

**Validation** on an 8x p150b host, firmware 19.12.0.0 (below 19.12.0.0 the DRAM-core gate skips everything, so CI green currently proves nothing here — the BH fleet is on 19.8/19.10):

- `unit_tests_api --gtest_filter='*DramKernel*:*DramSenderGCB*'` with `TT_METAL_SLOW_DISPATCH_MODE=1` — **24/24 passed**, and 24/24 again with `TT_METAL_DEVICE_PROFILER=1`.
- `unit_tests_debug_tools --gtest_filter='*Dram*:*DRAM*:*Drisc*:*DRISC*'` — **9 passed, 1 skipped** (active-eth, expected on this board), covering the watcher ring buffer on DRISC, both DRISC watcher-assert variants, NOC sanitize, and all four DRAM DPRINT tests.

Watcher + profiler cannot be exercised together on Blackhole (the *Tensix* BRISC firmware overflows its 0x2200 window at JIT build time), and DPRINT + profiler is blocked by a `TT_FATAL` in `metal_context.cpp`. Both are pre-existing and independent of this change; the mailbox reserves all three regardless, which is why the sizing does not depend on that combination being reachable.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/drisc-mailbox-shrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/drisc-mailbox-shrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/drisc-mailbox-shrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/drisc-mailbox-shrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jbauman/drisc-mailbox-shrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jbauman/drisc-mailbox-shrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/drisc-mailbox-shrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/drisc-mailbox-shrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/drisc-mailbox-shrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/drisc-mailbox-shrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/drisc-mailbox-shrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/drisc-mailbox-shrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/drisc-mailbox-shrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/drisc-mailbox-shrink)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/drisc-mailbox-shrink)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/drisc-mailbox-shrink)