### PR TITLE
[Cleanup] Deprecate CreateDevices and CloseDevices

### DIFF
--- a/.github/deprecations.json
+++ b/.github/deprecations.json
@@ -53,7 +53,7 @@
       "id": "create-devices-close-devices",
       "description": "detail::CreateDevices / CloseDevices in tt_metal.hpp deprecated in favor of MeshDevice::create_unit_meshes / create_unit_mesh (and RAII / device->close()). See tech_reports/TT-Distributed/TTMeshMigrationGuide.md. Remove the declarations and definitions after the grace period once external callers have migrated. In-tree FabricSwitchManager may keep suppressed calls until switch meshes have a supported Mesh path.",
       "files": ["tt_metal/api/tt-metalium/tt_metal.hpp", "tt_metal/impl/host_api/tt_metal.cpp"],
-      "introduced_by_pr": 0,
+      "introduced_by_pr": 52982,
       "grace": "5w",
       "owners": ["riverwuTT"]
     }

--- a/.github/deprecations.json
+++ b/.github/deprecations.json
@@ -48,6 +48,14 @@
       "introduced_by_pr": 49119,
       "grace": "30d",
       "owners": ["ncvetkovicTT"]
+    },
+    {
+      "id": "create-devices-close-devices",
+      "description": "detail::CreateDevices / CloseDevices in tt_metal.hpp deprecated in favor of MeshDevice::create_unit_meshes / create_unit_mesh (and RAII / device->close()). See tech_reports/TT-Distributed/TTMeshMigrationGuide.md. Remove the declarations and definitions after the grace period once external callers have migrated. In-tree FabricSwitchManager may keep suppressed calls until switch meshes have a supported Mesh path.",
+      "files": ["tt_metal/api/tt-metalium/tt_metal.hpp", "tt_metal/impl/host_api/tt_metal.cpp"],
+      "introduced_by_pr": 0,
+      "grace": "5w",
+      "owners": ["riverwuTT"]
     }
   ]
 }

--- a/tests/tt_metal/tt_metal/api/test_soc_descriptor.cpp
+++ b/tests/tt_metal/tt_metal/api/test_soc_descriptor.cpp
@@ -12,6 +12,7 @@
 
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/mesh_device.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include "llrt/metal_soc_descriptor.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
@@ -65,9 +66,9 @@ TEST(SOC, TensixValidateLogicalToPhysicalCoreCoordHostMapping) {
     for (int device_id : tt::tt_metal::MetalContext::instance().get_cluster().user_exposed_chip_ids()) {
         devices_to_open.push_back(device_id);
     }
-    auto devices = detail::CreateDevices(devices_to_open);
+    auto devices = distributed::MeshDevice::create_unit_meshes(devices_to_open);
     for (int device_id = 0; device_id < num_devices; device_id++) {
-        tt_metal::IDevice* device = devices[device_id];
+        const auto& device = devices.at(device_id);
         uint32_t harvested_rows_mask =
             tt::tt_metal::MetalContext::instance().get_cluster().get_harvesting_mask(device_id);
         const metal_SocDescriptor& soc_desc =
@@ -86,8 +87,6 @@ TEST(SOC, TensixValidateLogicalToPhysicalCoreCoordHostMapping) {
             }
         }
     }
-
-    tt::tt_metal::detail::CloseDevices(devices);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/device/test_device_pool.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device_pool.cpp
@@ -13,7 +13,6 @@
 #include "hostdevcommon/common_values.hpp"
 #include "context/metal_context.hpp"
 #include "impl/allocator/allocator.hpp"
-#include "tt_metal.hpp"
 #include <llrt/tt_cluster.hpp>
 
 namespace tt::tt_metal {
@@ -21,12 +20,8 @@ namespace tt::tt_metal {
 using namespace tt;
 
 void CloseDevicesInPool() {
-    auto devices = MetalContext::instance().device_manager()->get_all_active_devices();
-    std::map<ChipId, IDevice*> chip_id_to_device;
-    for (const auto& dev : devices) {
-        chip_id_to_device[dev->id()] = dev;
-    }
-    detail::CloseDevices(chip_id_to_device);
+    auto* device_manager = MetalContext::instance().device_manager();
+    device_manager->close_devices(device_manager->get_all_active_devices());
 }
 
 TEST(DevicePool, DevicePoolOpenClose) {

--- a/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
@@ -178,7 +178,7 @@ TEST_F(MockDeviceProfilerFixture, DeviceProfilerIsNotStartedOnMockDevice) {
         << "getDeviceProfilerState() must be false for a mock context even when profiling is "
            "requested";
 
-    auto devices = detail::CreateDevices({0});
+    auto devices = distributed::MeshDevice::create_unit_meshes({0});
     ASSERT_FALSE(devices.empty());
     const ChipId mock_device_id = devices.begin()->first;
 
@@ -188,8 +188,6 @@ TEST_F(MockDeviceProfilerFixture, DeviceProfilerIsNotStartedOnMockDevice) {
     EXPECT_FALSE(profiler_state_manager->device_profiler_map.contains(mock_device_id))
         << "Device profiler was started on mock device " << mock_device_id
         << " -- the profiler must be skipped for mock/emulated clusters";
-
-    detail::CloseDevices(devices);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -8,11 +8,13 @@
 #include <cstdint>
 #include <filesystem>
 #include <map>
+#include <memory>
 #include <string>
 #include <thread>
 #include <vector>
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
@@ -108,16 +110,12 @@ protected:
         for (int id = 0; id < num_devices_; id++) {
             ids.push_back(id);
         }
-        devices_ = detail::CreateDevices(ids);
+        devices_ = distributed::MeshDevice::create_unit_meshes(ids);
     }
 
-    void TearDown() override {
-        if (!devices_.empty()) {
-            detail::CloseDevices(devices_);
-        }
-    }
+    void TearDown() override { devices_.clear(); }
 
-    std::map<int, IDevice*> devices_;
+    std::map<int, std::shared_ptr<distributed::MeshDevice>> devices_;
     int num_devices_ = 0;
 };
 
@@ -129,7 +127,7 @@ TEST_F(CompileSetsKernelBinariesFixture, CompileSetsKernelBinaries) {
     std::map<uint64_t, std::vector<const ll_api::memory*>> ncrisc_binaries;
 
     for (int i = 0; i < num_devices_; i++) {
-        auto* device = devices_[i];
+        auto* device = devices_[i].get();
 
         programs.push_back(Program());
         Program& program = programs.back();
@@ -175,10 +173,11 @@ TEST_F(CompileSetsKernelBinariesFixture, CompileSetsKernelBinaries) {
     for (int iter = 0; iter < 3; iter++) {
         std::vector<std::string> kernel_names = {"reader_unary_push_4", "writer_unary", "eltwise_copy_3m"};
         for (int i = 0; i < num_devices_; i++) {
+            auto* device = devices_[i].get();
             for (const auto& kernel_name : kernel_names) {
                 std::filesystem::remove_all(
-                    BuildEnvManager::get_instance(extract_context_id(devices_[i]))
-                        .get_device_build_env(devices_[i]->id())
+                    BuildEnvManager::get_instance(extract_context_id(device))
+                        .get_device_build_env(device->id())
                         .build_env.get_out_kernel_root_path() +
                     kernel_name);
             }
@@ -186,7 +185,7 @@ TEST_F(CompileSetsKernelBinariesFixture, CompileSetsKernelBinaries) {
         jit_build_cache_clear();
         std::vector<Program> new_programs;
         for (int i = 0; i < num_devices_; i++) {
-            auto& device = devices_[i];
+            auto* device = devices_[i].get();
             new_programs.push_back(Program());
             Program& program = new_programs.back();
             construct_program(program, device, core);
@@ -197,7 +196,7 @@ TEST_F(CompileSetsKernelBinariesFixture, CompileSetsKernelBinaries) {
         uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
         uint32_t compute_class_idx = enchantum::to_underlying(HalProcessorClassType::COMPUTE);
         for (int i = 0; i < num_devices_; i++) {
-            auto& device = devices_[i];
+            auto* device = devices_[i].get();
             auto& program = new_programs[i];
             ths.emplace_back([&] {
                 for (int j = 0; j < num_compiles; j++) {

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -141,7 +141,8 @@ struct FabricEriscDatamoverKernelConfig {
 tt::tt_metal::KernelHandle generate_erisc_datamover_kernel(const FabricEriscDatamoverKernelConfig& edm_kernel_config);
 
 /**
- * Call before CreateDevices to enable fabric, which uses the specified number of routing planes.
+ * Call before opening devices (e.g. MeshDevice::create_unit_meshes) to enable fabric, which uses the specified number
+ * of routing planes.
  * Currently, setting num_routing_planes dictates how many routing planes the fabric should be active on
  * for that init sequence. The number of routing planes fabric will be initialized on will be the max
  * of all the values specified by different clients. If a client wants to initialize fabric on all the

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric_switch_manager.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric_switch_manager.hpp
@@ -69,7 +69,8 @@ private:
     FabricSwitchManager() = default;
     ~FabricSwitchManager() = default;
 
-    // Cache the device map returned by CreateDevices to use directly in CloseDevices
+    // Cached device map from detail::CreateDevices for CloseDevices teardown.
+    // Cannot migrate to MeshDevice::create_unit_meshes (fatals on tt-switch meshes).
     std::map<tt::ChipId, tt::tt_metal::IDevice*> switch_devices_;
 };
 

--- a/tt_metal/api/tt-metalium/tt_metal.hpp
+++ b/tt_metal/api/tt-metalium/tt_metal.hpp
@@ -35,6 +35,10 @@ namespace detail {
 
 bool DispatchStateCheck(bool isFastDispatch);
 
+[[deprecated(
+    "CreateDevices is deprecated and will be removed after 2026-09-16. "
+    "See tech_reports/TT-Distributed/TTMeshMigrationGuide.md for migration "
+    "(use MeshDevice::create_unit_meshes / create_unit_mesh; prefer RAII instead of CloseDevices).")]]
 std::map<ChipId, IDevice*> CreateDevices(
     // TODO: delete this in favour of DeviceManager
     const std::vector<ChipId>& device_ids,
@@ -56,6 +60,10 @@ std::map<ChipId, IDevice*> CreateDevices(
  *
  * Return value: void
  */
+[[deprecated(
+    "CloseDevices is deprecated and will be removed after 2026-09-16. "
+    "See tech_reports/TT-Distributed/TTMeshMigrationGuide.md for migration "
+    "(prefer MeshDevice RAII or device->close() instead of CloseDevices).")]]
 void CloseDevices(const std::map<ChipId, IDevice*>& devices);
 
 /**

--- a/tt_metal/fabric/fabric_switch_manager.cpp
+++ b/tt_metal/fabric/fabric_switch_manager.cpp
@@ -39,6 +39,14 @@ void FabricSwitchManager::setup(FabricConfig fabric_config, FabricReliabilityMod
     // Cache the device map returned by CreateDevices to use directly in CloseDevices
     // TODO: Issue #34040 - If routers are in standby mode, we could skip full reinitialization
     // and just reactivate them instead of calling CreateDevices.
+    //
+    // Cannot migrate to MeshDevice::create_unit_mesh / create_unit_meshes:
+    // those APIs fatal on tt-switch meshes (see MeshDeviceImpl::create_unit_meshes).
+    // FabricSwitchManager must open physical switch devices via CreateDevices.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     switch_devices_ = tt::tt_metal::detail::CreateDevices(
         switch_device_ids,
         1,  // num_command_queues
@@ -51,6 +59,8 @@ void FabricSwitchManager::setup(FabricConfig fabric_config, FabricReliabilityMod
         true,                    // use_max_eth_core_count_on_all_devices
         // TOD: for future optimization, switch meshes don't need dispatch fw.
         true);  // initialize_fabric_and_dispatch_fw
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop
 }
 
 void FabricSwitchManager::teardown() {
@@ -63,8 +73,16 @@ void FabricSwitchManager::teardown() {
     // In the future, we could keep routers in standby mode instead of fully terminating
     // them, allowing faster reactivation without recompilation and re-handshake overhead.
     if (!switch_devices_.empty()) {
-        // Use the cached device map returned by CreateDevices
+        // Cannot migrate to MeshDevice::create_unit_mesh / create_unit_meshes:
+        // those APIs fatal on tt-switch meshes (see MeshDeviceImpl::create_unit_meshes).
+        // FabricSwitchManager must close physical switch devices via CloseDevices.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         tt::tt_metal::detail::CloseDevices(switch_devices_);
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop
         tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
 
         switch_devices_.clear();

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -261,7 +261,7 @@ void DeviceManager::open_devices(const std::vector<ChipId>& device_ids) {
         log_warning(
             tt::LogMetal,
             "Opening subset of mmio devices slows down UMD read/write to remote chips. If opening more devices, "
-            "consider using CreateDevices API.");
+            "consider using MeshDevice::create_unit_meshes.");
     }
 
     // Need to reserve eth cores for fabric before we initialize individual devices to maintain consistent state

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -1311,22 +1311,21 @@ IDevice* CreateDevice(
     ZoneScoped;
 
     // MMIO devices do not support dispatch on galaxy cluster
-    // Suggest the user to use the CreateDevices API
+    // Suggest the user to use MeshDevice::create_unit_meshes
     if (MetalContext::instance().rtoptions().get_fast_dispatch()) {
         TT_FATAL(
             !(MetalContext::instance().get_cluster().is_galaxy_cluster() &&
               MetalContext::instance().get_cluster().get_cluster_desc()->is_chip_mmio_capable(device_id)),
-            "Galaxy cluster does not support dispatch on mmio devices. Please use CreateDevices API to open all "
-            "devices for dispatch.");
+            "Galaxy cluster does not support dispatch on mmio devices. Please use MeshDevice::create_unit_meshes to "
+            "open all devices for dispatch.");
     }
 
     // This API may not be used to create single remote device or multi chip clusters
-    // CreateDevices should be used instead to ensure proper init/teardown
+    // MeshDevice::create_unit_meshes should be used instead to ensure proper init/teardown
     TT_FATAL(
         MetalContext::instance().get_cluster().get_associated_mmio_device(device_id) == device_id,
         "CreateDevice(device_id={}) may only be used for opening single MMIO capable devices. For multi chip clusters, "
-        "must use "
-        "CreateDevices().",
+        "must use MeshDevice::create_unit_meshes().",
         device_id);
 
     MetalContext::instance().initialize_device_manager(
@@ -1353,12 +1352,11 @@ bool CloseDevice(IDevice* device) {
     auto device_id = device->id();
 
     // This API may not be used to close single remote device or multi chip clusters
-    // CloseDevices should be used instead to ensure proper init/teardown
+    // Prefer MeshDevice RAII or device->close() for multi-device teardown
     TT_FATAL(
         MetalContext::instance().get_cluster().get_associated_mmio_device(device_id) == device_id,
-        "CloseDevice(device_id={}) may only be used for opening single MMIO capable devices. For multi chip clusters, "
-        "must use "
-        "CloseDevices().",
+        "CloseDevice(device_id={}) may only be used for closing single MMIO capable devices. For multi chip clusters, "
+        "prefer MeshDevice RAII or device->close().",
         device_id);
 
     return MetalContext::instance().device_manager()->close_device(device_id);

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
@@ -240,18 +240,30 @@ void LightMetalReplayImpl::remove_cb_handle_from_map(uint32_t global_id) { cb_ha
 // TODO (kmabee) - Hardcode for now, eventually capture/replay "systemdesc" from binary.
 // Alternatively, user can manage device open/close and pass to replay library.
 void LightMetalReplayImpl::setup_devices() {
-    log_debug(tt::LogMetalTrace, "LightMetalReplay(setup_devices) - Using hardcoded CreateDevices() as temp hack.");
+    log_debug(tt::LogMetalTrace, "LightMetalReplay(setup_devices) - Using hardcoded create_unit_mesh() as temp hack.");
     TT_FATAL(!device_, "Device already setup in LightMetalReplay, no need to call setup_devices()");
     const size_t trace_region_size = 4096;  // Default is 0
-    const auto dispatch_core_type = tt_metal::DispatchCoreType::WORKER;
     const ChipId mmio_device_id = 0;
-    auto devices_map = tt::tt_metal::detail::CreateDevices(
-        {mmio_device_id}, 1, DEFAULT_L1_SMALL_SIZE, trace_region_size, dispatch_core_type);
-    this->device_ = devices_map.at(mmio_device_id);
+    owned_device_ = tt::tt_metal::distributed::MeshDevice::create_unit_mesh(
+        mmio_device_id,
+        DEFAULT_L1_SMALL_SIZE,
+        trace_region_size,
+        /*num_command_queues=*/1,
+        tt_metal::DispatchCoreConfig{tt_metal::DispatchCoreType::WORKER});
+    this->device_ = owned_device_.get();
 }
 
 // TODO (kmabee) - Hardcode for now, eventually capture/replay "systemdesc" from binary or let user call.
-void LightMetalReplayImpl::close_devices() { CloseDevice(this->device_); }
+void LightMetalReplayImpl::close_devices() {
+    if (owned_device_) {
+        owned_device_->close();
+        owned_device_.reset();
+        device_ = nullptr;
+    } else if (device_) {
+        CloseDevice(device_);
+        device_ = nullptr;
+    }
+}
 
 // Clear object maps for items not deallocated/destroyed naturally during replay.
 // Later can update these to be asserts once all paths covered properly.

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <flatbuffers/flatbuffers.h>
+#include <memory>
 #include <string>
 #include <vector>
 #include <optional>
@@ -12,6 +13,7 @@
 
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/circular_buffer.hpp>
 
 #include "impl/kernels/kernel.hpp"
@@ -133,6 +135,8 @@ private:
     bool disable_checking_ = false;
 
     tt::tt_metal::IDevice* device_ = nullptr;
+    // Owns the device when setup_devices() creates it; keeps MeshDevice alive for device_.
+    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> owned_device_;
 
     // Object maps for storing objects by global_id
     std::unordered_map<uint32_t, std::shared_ptr<::tt::tt_metal::Buffer>> buffer_map_;

--- a/tt_metal/tools/mem_bench/mem_bench.cpp
+++ b/tt_metal/tools/mem_bench/mem_bench.cpp
@@ -6,10 +6,12 @@
 #include <cstdint>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include "impl/context/metal_context.hpp"
 #include <iostream>
 #include <map>
+#include <memory>
 #include <numeric>
 #include <optional>
 #include <span>
@@ -33,6 +35,17 @@ using namespace tt::tt_metal::tools::mem_bench;
 
 // Global variable to store user-specified device ID
 std::optional<int> g_user_device_id;
+
+namespace {
+std::map<ChipId, IDevice*> device_ptrs_from_meshes(
+    const std::map<int, std::shared_ptr<distributed::MeshDevice>>& mesh_devices) {
+    std::map<ChipId, IDevice*> devices;
+    for (const auto& [id, mesh] : mesh_devices) {
+        devices[id] = mesh.get();
+    }
+    return devices;
+}
+}  // namespace
 
 // Read L1 counters (cycles, bytes rd, bytes wr) and increment test_results
 void read_inc_data_from_cores(const Context& ctx, IDevice* device, const CoreRange& cores, TestResult& test_results) {
@@ -162,7 +175,8 @@ TestResult mem_bench_copy_multithread(benchmark::State& state) {
 TestResult mem_bench_copy_with_active_kernel(benchmark::State& state) {
     TestResult results;
     auto device_ids = get_device_ids_for_single_device(g_user_device_id);
-    auto devices = tt::tt_metal::detail::CreateDevices(device_ids);
+    auto mesh_devices = distributed::MeshDevice::create_unit_meshes(device_ids);
+    auto devices = device_ptrs_from_meshes(mesh_devices);
     const uint32_t device_id = device_ids.empty() ? 0 : device_ids[0];
     IDevice* device = devices[device_id];
     Context ctx{
@@ -224,7 +238,6 @@ TestResult mem_bench_copy_with_active_kernel(benchmark::State& state) {
     }
 
     report_device_bw(state, results);
-    tt::tt_metal::detail::CloseDevices(devices);
     return results;
 }
 
@@ -233,7 +246,8 @@ TestResult mem_bench_copy_with_active_kernel(benchmark::State& state) {
 TestResult mem_bench_copy_active_kernel_different_page(benchmark::State& state) {
     TestResult results;
     auto device_ids = get_device_ids_for_single_device(g_user_device_id);
-    auto devices = tt::tt_metal::detail::CreateDevices(device_ids);
+    auto mesh_devices = distributed::MeshDevice::create_unit_meshes(device_ids);
+    auto devices = device_ptrs_from_meshes(mesh_devices);
     const uint32_t device_id = device_ids.empty() ? 0 : device_ids[0];
     IDevice* device = devices[device_id];
     Context ctx{
@@ -284,7 +298,6 @@ TestResult mem_bench_copy_active_kernel_different_page(benchmark::State& state) 
     state.SetBytesProcessed(ctx.total_size * state.iterations());
 
     report_device_bw(state, results);
-    tt::tt_metal::detail::CloseDevices(devices);
     return results;
 }
 
@@ -343,7 +356,8 @@ TestResult mem_bench_multi_mmio_devices(
 TestResult mem_bench_multi_mmio_devices_reading_same_node(benchmark::State& state) {
     // Node 0
     auto device_ids = get_device_ids_for_multi_device_same_node(g_user_device_id);
-    auto devices = tt::tt_metal::detail::CreateDevices(device_ids);
+    auto mesh_devices = distributed::MeshDevice::create_unit_meshes(device_ids);
+    auto devices = device_ptrs_from_meshes(mesh_devices);
 
     Context ctx{
         devices,
@@ -356,16 +370,14 @@ TestResult mem_bench_multi_mmio_devices_reading_same_node(benchmark::State& stat
         0,                                      // Iterations is managed by the benchmark framework
     };
 
-    TestResult results = mem_bench_multi_mmio_devices(state, devices, ctx);
-    tt::tt_metal::detail::CloseDevices(devices);
-
-    return results;
+    return mem_bench_multi_mmio_devices(state, devices, ctx);
 }
 
 // Multi MMIO devices reading on different NUMA nodes.
 TestResult mem_bench_multi_mmio_devices_reading_different_node(benchmark::State& state) {
     auto device_ids = get_device_ids_for_multi_device_different_nodes(g_user_device_id);
-    auto devices = tt::tt_metal::detail::CreateDevices(device_ids);
+    auto mesh_devices = distributed::MeshDevice::create_unit_meshes(device_ids);
+    auto devices = device_ptrs_from_meshes(mesh_devices);
 
     Context ctx{
         devices,
@@ -378,10 +390,7 @@ TestResult mem_bench_multi_mmio_devices_reading_different_node(benchmark::State&
         0,                                      // Iterations is managed by the benchmark framework
     };
 
-    TestResult results = mem_bench_multi_mmio_devices(state, devices, ctx);
-    tt::tt_metal::detail::CloseDevices(devices);
-
-    return results;
+    return mem_bench_multi_mmio_devices(state, devices, ctx);
 }
 
 // Benchmark memcpy_to_device while device is reading (prefetching) and writing (dispatching data back to host)
@@ -389,7 +398,8 @@ TestResult mem_bench_multi_mmio_devices_reading_different_node(benchmark::State&
 // Second half will be written to by device
 TestResult mem_bench_copy_with_read_and_write_kernel(benchmark::State& state) {
     auto device_ids = get_device_ids_for_single_device(g_user_device_id);
-    auto devices = tt::tt_metal::detail::CreateDevices(device_ids);
+    auto mesh_devices = distributed::MeshDevice::create_unit_meshes(device_ids);
+    auto devices = device_ptrs_from_meshes(mesh_devices);
     const uint32_t device_id = device_ids.empty() ? 0 : device_ids[0];
     IDevice* device = devices[device_id];
     Context ctx{
@@ -448,7 +458,6 @@ TestResult mem_bench_copy_with_read_and_write_kernel(benchmark::State& state) {
 
     state.SetBytesProcessed(ctx.total_size * state.iterations());
     report_device_bw(state, results);
-    tt::tt_metal::detail::CloseDevices(devices);
     return results;
 }
 


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Deprecate public `detail::CreateDevices` / `CloseDevices` (removal after 2026-09-16) in favor of `MeshDevice::create_unit_meshes` / RAII per TTMeshMigrationGuide. Migrates Mesh-eligible call sites, keeps FabricSwitchManager on the deprecated API with suppressions (cannot use unit meshes for switch devices), and tracks the deprecation in `.github/deprecations.json`.

### Notes for reviewers
- FabricSwitchManager intentionally retains suppressed `CreateDevices`/`CloseDevices` calls; `create_unit_meshes` fatals on tt-switch meshes.
- `introduced_by_pr` in `deprecations.json` will be updated to this PR number after opening.
- Python `ttnn.CreateDevices` / `CloseDevices` aliases are intentionally left alone.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/no-create-devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/no-create-devices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/no-create-devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/no-create-devices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=riverwu/no-create-devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:riverwu/no-create-devices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/no-create-devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/no-create-devices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/no-create-devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/no-create-devices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/no-create-devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/no-create-devices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/no-create-devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/no-create-devices)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/no-create-devices)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/no-create-devices)