### PR TITLE
[Cleanup] MeshDeviceSingleCardFixture-based tests modernization

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_stream_scratch_register.cpp
+++ b/tests/tt_metal/tt_metal/api/test_stream_scratch_register.cpp
@@ -32,14 +32,15 @@ TEST_F(UnitMeshFixture, StreamScratchRegisterTensixCores) {
 // Test stream scratch register APIs on Erisc cores
 TEST_F(UnitMeshFixture, StreamScratchRegisterEriscCores) {
     // Check if device has active ethernet cores
-    if (this->device().get_active_ethernet_cores(true).empty()) {
+    auto ethernet_cores = this->device().get_devices()[0]->get_active_ethernet_cores(true);
+    if (ethernet_cores.empty()) {
         GTEST_SKIP() << "No active ethernet cores available on this device";
     }
 
     Program program = CreateProgram();
 
     // Get first available ethernet core
-    auto eth_core = *this->device().get_active_ethernet_cores(true).begin();
+    auto eth_core = *ethernet_cores.begin();
 
     // Create CoreRangeSet for this single ethernet core
     std::set<CoreRange> eth_core_ranges;

--- a/tests/tt_metal/tt_metal/api/test_stream_scratch_register.cpp
+++ b/tests/tt_metal/tt_metal/api/test_stream_scratch_register.cpp
@@ -7,57 +7,39 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include "impl/kernels/kernel.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 namespace tt::tt_metal {
 
 // Test stream scratch register APIs on Tensix cores (both RISC0 and RISC1)
-TEST_F(MeshDeviceSingleCardFixture, StreamScratchRegisterTensixCores) {
-    // Get device from fixture
-    auto mesh_device = this->devices_[0];
-
-    // Create workload for mesh device
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+TEST_F(UnitMeshFixture, StreamScratchRegisterTensixCores) {
     Program program = CreateProgram();
-    workload.add_program(device_range, std::move(program));
-    auto& program_ = workload.get_programs().at(device_range);
 
     // Use core (0,0) for testing
     CoreCoord test_core = {0, 0};
 
     // Create kernel for RISC0 (DataMovementProcessor::RISCV_0)
     CreateKernel(
-        program_,
+        program,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/test_stream_scratch_register.cpp",
         test_core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Execute the program
-    this->RunProgram(mesh_device, workload);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 }
 
 // Test stream scratch register APIs on Erisc cores
-TEST_F(MeshDeviceSingleCardFixture, StreamScratchRegisterEriscCores) {
-    // Get device from fixture
-    auto mesh_device = this->devices_[0];
-    auto* device = mesh_device->get_devices()[0];
-
+TEST_F(UnitMeshFixture, StreamScratchRegisterEriscCores) {
     // Check if device has active ethernet cores
-    if (device->get_active_ethernet_cores(true).empty()) {
+    if (this->device().get_active_ethernet_cores(true).empty()) {
         GTEST_SKIP() << "No active ethernet cores available on this device";
     }
 
-    // Create workload for mesh device
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = CreateProgram();
-    workload.add_program(device_range, std::move(program));
-    auto& program_ = workload.get_programs().at(device_range);
 
     // Get first available ethernet core
-    auto eth_core = *device->get_active_ethernet_cores(true).begin();
+    auto eth_core = *this->device().get_active_ethernet_cores(true).begin();
 
     // Create CoreRangeSet for this single ethernet core
     std::set<CoreRange> eth_core_ranges;
@@ -65,13 +47,13 @@ TEST_F(MeshDeviceSingleCardFixture, StreamScratchRegisterEriscCores) {
 
     // Create kernel for ethernet core with EthernetConfig
     CreateKernel(
-        program_,
+        program,
         "tests/tt_metal/tt_metal/test_kernels/dataflow/test_stream_scratch_register.cpp",
         eth_core_ranges,
         EthernetConfig{.noc = NOC::NOC_0});
 
     // Execute the program
-    this->RunProgram(mesh_device, workload);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/test_zero_memory_api.cpp
+++ b/tests/tt_metal/tt_metal/api/test_zero_memory_api.cpp
@@ -44,6 +44,7 @@
 #include <tt-metalium/experimental/metal2_host_api/data_movement_hardware_config.hpp>
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 #include <tt-metalium/tensor/mesh_tensor.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 #include "gtest/gtest.h"
 
@@ -84,10 +85,7 @@ experimental::DataMovementHardwareConfig make_dm_config(tt::ARCH arch, DataMovem
 
 namespace tt::tt_metal {
 
-TEST_F(MeshDeviceSingleCardFixture, ZeroMemoryApi) {
-    auto& mesh_device = *devices_[0];
-    IDevice* dev = mesh_device.get_devices()[0];
-
+TEST_F(UnitMeshFixture, ZeroMemoryApi) {
     constexpr uint32_t scratch_bytes = 8 * 1024;
     constexpr uint32_t num_pages = 4;
     constexpr uint32_t page_size_bytes = 4 * 1024;
@@ -98,16 +96,17 @@ TEST_F(MeshDeviceSingleCardFixture, ZeroMemoryApi) {
     // ----- Host stamps -----
     // L1 status flag: sentinel that the kernel demotes to kStatusOk on success.
     std::vector<uint32_t> flag_init{0xBAADF00Du};
-    tt_metal::detail::WriteToDeviceL1(dev, node, flag_addr, flag_init);
+    slow_dispatch::WriteToL1(this->device(), node, flag_addr, flag_init);
 
     // DRAM tensor: 0xFF everywhere, so a no-op kernel can't pass the post-zero check.
-    auto tensor = MeshTensor::allocate_on_device(mesh_device, make_flat_dram_tensor_spec(page_size_bytes, num_pages));
+    auto tensor =
+        MeshTensor::allocate_on_device(this->device(), make_flat_dram_tensor_spec(page_size_bytes, num_pages));
     std::vector<uint32_t> stamped(total_words, 0xFFFFFFFFu);
-    detail::WriteToBuffer(*tensor.mesh_buffer().get_reference_buffer(), stamped);
+    slow_dispatch::WriteToBuffer(tensor.mesh_buffer(), stamped);
 
     // Pre-write verify: confirm the DRAM stamp landed so the post-zero check is meaningful.
     std::vector<uint32_t> stamp_check;
-    detail::ReadFromBuffer(*tensor.mesh_buffer().get_reference_buffer(), stamp_check);
+    slow_dispatch::ReadFromBuffer(tensor.mesh_buffer(), stamp_check);
     ASSERT_EQ(stamp_check.size(), total_words);
     for (uint32_t i = 0; i < total_words; ++i) {
         ASSERT_EQ(stamp_check[i], 0xFFFFFFFFu) << "Pre-write 0xFF stamp did not land at DRAM word " << i;
@@ -133,7 +132,7 @@ TEST_F(MeshDeviceSingleCardFixture, ZeroMemoryApi) {
               .endpoint_type = experimental::DFBEndpointType::PRODUCER,
               .access_pattern = experimental::DFBAccessPattern::STRIDED}},
         .runtime_arg_schema = {.runtime_arg_names = {"total_bytes", "flag_addr"}},
-        .hw_config = make_dm_config(mesh_device.arch(), DataMovementProcessor::RISCV_0, NOC::RISCV_0_default),
+        .hw_config = make_dm_config(this->device().arch(), DataMovementProcessor::RISCV_0, NOC::RISCV_0_default),
     };
 
     // Consumer: wait_fronts on the L1-zeroed DFB entry, uses it as DRAM scratch for overload (2).
@@ -149,7 +148,7 @@ TEST_F(MeshDeviceSingleCardFixture, ZeroMemoryApi) {
               .access_pattern = experimental::DFBAccessPattern::STRIDED}},
         .tensor_bindings = {{.tensor_parameter_name = OUT_TENSOR, .accessor_name = "out"}},
         .runtime_arg_schema = {.runtime_arg_names = {"page_start", "page_end", "page_size"}},
-        .hw_config = make_dm_config(mesh_device.arch(), DataMovementProcessor::RISCV_1, NOC::RISCV_1_default),
+        .hw_config = make_dm_config(this->device().arch(), DataMovementProcessor::RISCV_1, NOC::RISCV_1_default),
     };
 
     experimental::ProgramSpec spec{
@@ -159,7 +158,7 @@ TEST_F(MeshDeviceSingleCardFixture, ZeroMemoryApi) {
         .tensor_parameters = {{.unique_id = OUT_TENSOR, .spec = tensor.tensor_spec()}},
         .work_units = {{.name = "main", .kernels = {L1_PRODUCER, DRAM_CONSUMER}, .target_nodes = node}},
     };
-    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(this->device(), spec);
 
     experimental::ProgramRunArgs params;
     params.kernel_run_args = {
@@ -177,23 +176,19 @@ TEST_F(MeshDeviceSingleCardFixture, ZeroMemoryApi) {
     params.tensor_args = {{OUT_TENSOR, experimental::ProgramRunArgs::TensorArgument{tensor}}};
     experimental::SetProgramRunArgs(program, params);
 
-    distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range(mesh_device.shape());
-    workload.add_program(device_range, std::move(program));
-    auto& cq = mesh_device.mesh_command_queue();
-    distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/true);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     // ----- Host verifies -----
     // L1: kernel reports its in-kernel verify result via the flag word.
     std::vector<uint32_t> flag_out;
-    tt_metal::detail::ReadFromDeviceL1(dev, node, flag_addr, sizeof(uint32_t), flag_out);
+    slow_dispatch::ReadFromL1(this->device(), node, flag_addr, sizeof(uint32_t), flag_out);
     ASSERT_EQ(flag_out.size(), 1u);
     EXPECT_EQ(flag_out[0], kStatusOk) << "L1 zero test status word was 0x" << std::hex << flag_out[0] << " (expected 0x"
                                       << kStatusOk << ")";
 
     // DRAM: every word should be zero after overload (2).
     std::vector<uint32_t> result;
-    detail::ReadFromBuffer(*tensor.mesh_buffer().get_reference_buffer(), result);
+    slow_dispatch::ReadFromBuffer(tensor.mesh_buffer(), result);
     ASSERT_EQ(result.size(), total_words);
     for (uint32_t i = 0; i < total_words; ++i) {
         EXPECT_EQ(result[i], 0u) << "DRAM word " << i << " not zeroed; got 0x" << std::hex << result[i];
@@ -205,10 +200,7 @@ TEST_F(MeshDeviceSingleCardFixture, ZeroMemoryApi) {
 
 // Batched L1 zeroing: a kernel issues several noc.async_write_zeros() calls into disjoint
 // chunks of one DFB entry and then barriers once.
-TEST_F(MeshDeviceSingleCardFixture, ZeroMemoryApiBatchedL1) {
-    auto& mesh_device = *devices_[0];
-    IDevice* dev = mesh_device.get_devices()[0];
-
+TEST_F(UnitMeshFixture, ZeroMemoryApiBatchedL1) {
     constexpr uint32_t scratch_bytes = 32 * 1024;
     constexpr uint32_t num_chunks = 4;  // 4 disjoint 8 KB L1 zeros, then a single barrier
     constexpr uint32_t num_pages = 4;
@@ -219,11 +211,12 @@ TEST_F(MeshDeviceSingleCardFixture, ZeroMemoryApiBatchedL1) {
 
     // L1 status flag: sentinel that the batched producer demotes to kStatusOk on success.
     std::vector<uint32_t> flag_init{0xBAADF00Du};
-    tt_metal::detail::WriteToDeviceL1(dev, node, flag_addr, flag_init);
+    slow_dispatch::WriteToL1(this->device(), node, flag_addr, flag_init);
 
-    auto tensor = MeshTensor::allocate_on_device(mesh_device, make_flat_dram_tensor_spec(page_size_bytes, num_pages));
+    auto tensor =
+        MeshTensor::allocate_on_device(this->device(), make_flat_dram_tensor_spec(page_size_bytes, num_pages));
     std::vector<uint32_t> stamped(total_words, 0xFFFFFFFFu);
-    detail::WriteToBuffer(*tensor.mesh_buffer().get_reference_buffer(), stamped);
+    slow_dispatch::WriteToBuffer(tensor.mesh_buffer(), stamped);
 
     experimental::DataflowBufferSpec scratch_spec{
         .unique_id = SCRATCH_DFB,
@@ -244,7 +237,7 @@ TEST_F(MeshDeviceSingleCardFixture, ZeroMemoryApiBatchedL1) {
               .endpoint_type = experimental::DFBEndpointType::PRODUCER,
               .access_pattern = experimental::DFBAccessPattern::STRIDED}},
         .runtime_arg_schema = {.runtime_arg_names = {"total_bytes", "flag_addr"}},
-        .hw_config = make_dm_config(mesh_device.arch(), DataMovementProcessor::RISCV_0, NOC::RISCV_0_default),
+        .hw_config = make_dm_config(this->device().arch(), DataMovementProcessor::RISCV_0, NOC::RISCV_0_default),
     };
 
     experimental::KernelSpec consumer_spec{
@@ -259,7 +252,7 @@ TEST_F(MeshDeviceSingleCardFixture, ZeroMemoryApiBatchedL1) {
               .access_pattern = experimental::DFBAccessPattern::STRIDED}},
         .tensor_bindings = {{.tensor_parameter_name = OUT_TENSOR, .accessor_name = "out"}},
         .runtime_arg_schema = {.runtime_arg_names = {"page_start", "page_end", "page_size"}},
-        .hw_config = make_dm_config(mesh_device.arch(), DataMovementProcessor::RISCV_1, NOC::RISCV_1_default),
+        .hw_config = make_dm_config(this->device().arch(), DataMovementProcessor::RISCV_1, NOC::RISCV_1_default),
     };
 
     experimental::ProgramSpec spec{
@@ -269,7 +262,7 @@ TEST_F(MeshDeviceSingleCardFixture, ZeroMemoryApiBatchedL1) {
         .tensor_parameters = {{.unique_id = OUT_TENSOR, .spec = tensor.tensor_spec()}},
         .work_units = {{.name = "main", .kernels = {L1_BATCHED_PRODUCER, DRAM_CONSUMER}, .target_nodes = node}},
     };
-    Program program = experimental::MakeProgramFromSpec(mesh_device, spec);
+    Program program = experimental::MakeProgramFromSpec(this->device(), spec);
 
     experimental::ProgramRunArgs params;
     params.kernel_run_args = {
@@ -287,16 +280,12 @@ TEST_F(MeshDeviceSingleCardFixture, ZeroMemoryApiBatchedL1) {
     params.tensor_args = {{OUT_TENSOR, experimental::ProgramRunArgs::TensorArgument{tensor}}};
     experimental::SetProgramRunArgs(program, params);
 
-    distributed::MeshWorkload workload;
-    distributed::MeshCoordinateRange device_range(mesh_device.shape());
-    workload.add_program(device_range, std::move(program));
-    auto& cq = mesh_device.mesh_command_queue();
-    distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/true);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     // The batched producer's in-kernel verify is the primary signal: kStatusOk only if
     // every byte across all chunks is zero after the single barrier.
     std::vector<uint32_t> flag_out;
-    tt_metal::detail::ReadFromDeviceL1(dev, node, flag_addr, sizeof(uint32_t), flag_out);
+    slow_dispatch::ReadFromL1(this->device(), node, flag_addr, sizeof(uint32_t), flag_out);
     ASSERT_EQ(flag_out.size(), 1u);
     EXPECT_EQ(flag_out[0], kStatusOk) << "Batched L1 zero status word was 0x" << std::hex << flag_out[0]
                                       << " (expected 0x" << kStatusOk << "); a non-OK value means a batched zero was "

--- a/tests/tt_metal/tt_metal/test_add_two_ints.cpp
+++ b/tests/tt_metal/tt_metal/test_add_two_ints.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <tt-logger/tt-logger.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -21,9 +22,8 @@ using namespace tt::tt_metal;
 // Runs the add_two_ints kernel on BRISC to add two ints in L1
 // Result is read from L1
 ////////////////////////////////////////////////////////////////////////////
-TEST_F(MeshDeviceSingleCardFixture, AddTwoInts) {
-    IDevice* dev = devices_[0]->get_devices()[0];
-    uint32_t l1_unreserved_base = dev->allocator()->get_base_allocator_addr(HalMemType::L1);
+TEST_F(UnitMeshFixture, AddTwoInts) {
+    uint32_t l1_unreserved_base = this->device().allocator()->get_base_allocator_addr(HalMemType::L1);
 
     Program program = CreateProgram();
     CoreCoord core = {0, 0};
@@ -41,18 +41,18 @@ TEST_F(MeshDeviceSingleCardFixture, AddTwoInts) {
 
     // First run
     SetRuntimeArgs(program, add_two_ints_kernel, core, first_runtime_args);
-    detail::LaunchProgram(dev, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> first_kernel_result;
-    detail::ReadFromDeviceL1(dev, core, l1_unreserved_base, sizeof(int), first_kernel_result);
+    slow_dispatch::ReadFromL1(this->device(), core, l1_unreserved_base, sizeof(int), first_kernel_result);
     log_info(LogVerif, "first kernel result = {}", first_kernel_result[0]);
 
     // Second run with updated args
     SetRuntimeArgs(program, add_two_ints_kernel, core, second_runtime_args);
-    detail::LaunchProgram(dev, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> second_kernel_result;
-    detail::ReadFromDeviceL1(dev, core, l1_unreserved_base, sizeof(int), second_kernel_result);
+    slow_dispatch::ReadFromL1(this->device(), core, l1_unreserved_base, sizeof(int), second_kernel_result);
     log_info(LogVerif, "second kernel result = {}", second_kernel_result[0]);
 
     // Validation

--- a/tests/tt_metal/tt_metal/test_bcast.cpp
+++ b/tests/tt_metal/tt_metal/test_bcast.cpp
@@ -15,11 +15,11 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tilize_utils.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-logger/tt-logger.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include "test_gold_impls.hpp"
 #include "impl/data_format/bfloat16_utils.hpp"
 
@@ -65,7 +65,7 @@ const char* op_id_to_llkop_define[] = {
 const char* bdim_to_llkdim_define[] = {"", "BroadcastType::ROW", "BroadcastType::COL", "", "BroadcastType::SCALAR"};
 const char* op_id_to_op_name[] = {"ADD", "SUB", "MUL"};
 
-void run_bcast_test(IDevice* dev, BcastDim::Enum bcast_dim, BcastOp::Enum bcast_op) {
+void run_bcast_test(distributed::MeshDevice& mesh_device, BcastDim::Enum bcast_dim, BcastOp::Enum bcast_op) {
     bool multibank = true;
 
     log_info(LogTest, "=============================================================");
@@ -95,12 +95,12 @@ void run_bcast_test(IDevice* dev, BcastDim::Enum bcast_dim, BcastOp::Enum bcast_
         page_size = dram_buffer_bytes;
     }
 
-    InterleavedBufferConfig buff_config{
-        .device = dev, .size = dram_buffer_bytes, .page_size = page_size, .buffer_type = BufferType::DRAM};
+    distributed::DeviceLocalBufferConfig dram_config{.page_size = page_size, .buffer_type = BufferType::DRAM};
+    distributed::ReplicatedBufferConfig buffer_config{.size = dram_buffer_bytes};
 
-    auto src0_dram_buffer = CreateBuffer(buff_config);
+    auto src0_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &mesh_device);
     uint32_t dram_buffer_src0_addr = src0_dram_buffer->address();
-    auto dst_dram_buffer = CreateBuffer(buff_config);
+    auto dst_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &mesh_device);
     uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
 
     uint32_t src0_cb_index = 0;
@@ -187,12 +187,12 @@ void run_bcast_test(IDevice* dev, BcastDim::Enum bcast_dim, BcastOp::Enum bcast_
         src1_page_size = bcast_vals_nbytes;
     }
 
-    InterleavedBufferConfig src1_config{
-        .device = dev, .size = bcast_vals_nbytes, .page_size = src1_page_size, .buffer_type = BufferType::DRAM};
-
-    auto src1_dram_buffer = CreateBuffer(src1_config);
+    auto src1_dram_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = bcast_vals_nbytes},
+        {.page_size = src1_page_size, .buffer_type = BufferType::DRAM},
+        &mesh_device);
     uint32_t dram_buffer_src1_addr = src1_dram_buffer->address();
-    detail::WriteToBuffer(src1_dram_buffer, bcast_tiled_u32);
+    slow_dispatch::WriteToBuffer(*src1_dram_buffer, bcast_tiled_u32);
 
     std::vector<uint32_t> reader_compile_time_args;
     TensorAccessorArgs(src0_dram_buffer).append_to(reader_compile_time_args);
@@ -253,12 +253,12 @@ void run_bcast_test(IDevice* dev, BcastDim::Enum bcast_dim, BcastOp::Enum bcast_
 
     // Execute
     vector<uint32_t> src0_vec = create_random_vector_of_bfloat16(dram_buffer_bytes, 10.0f, 0x1234);
-    detail::WriteToBuffer(src0_dram_buffer, src0_vec);
+    slow_dispatch::WriteToBuffer(*src0_dram_buffer, src0_vec);
 
-    detail::LaunchProgram(dev, program);
+    slow_dispatch::LaunchProgram(mesh_device, program, /*wait_until_cores_done=*/true);
 
     vector<uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_dram_buffer, result_vec);
+    slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);
 
     // Validation
     auto comparison_function = [](float a, float b) {
@@ -285,32 +285,14 @@ void run_bcast_test(IDevice* dev, BcastDim::Enum bcast_dim, BcastOp::Enum bcast_
 
 }  // namespace
 
-TEST_F(MeshDeviceSingleCardFixture, BcastHAdd) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::H, BcastOp::ADD);
-}
-TEST_F(MeshDeviceSingleCardFixture, BcastHSub) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::H, BcastOp::SUB);
-}
-TEST_F(MeshDeviceSingleCardFixture, BcastHMul) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::H, BcastOp::MUL);
-}
+TEST_F(UnitMeshFixture, BcastHAdd) { run_bcast_test(this->device(), BcastDim::H, BcastOp::ADD); }
+TEST_F(UnitMeshFixture, BcastHSub) { run_bcast_test(this->device(), BcastDim::H, BcastOp::SUB); }
+TEST_F(UnitMeshFixture, BcastHMul) { run_bcast_test(this->device(), BcastDim::H, BcastOp::MUL); }
 
-TEST_F(MeshDeviceSingleCardFixture, BcastWAdd) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::W, BcastOp::ADD);
-}
-TEST_F(MeshDeviceSingleCardFixture, BcastWSub) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::W, BcastOp::SUB);
-}
-TEST_F(MeshDeviceSingleCardFixture, BcastWMul) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::W, BcastOp::MUL);
-}
+TEST_F(UnitMeshFixture, BcastWAdd) { run_bcast_test(this->device(), BcastDim::W, BcastOp::ADD); }
+TEST_F(UnitMeshFixture, BcastWSub) { run_bcast_test(this->device(), BcastDim::W, BcastOp::SUB); }
+TEST_F(UnitMeshFixture, BcastWMul) { run_bcast_test(this->device(), BcastDim::W, BcastOp::MUL); }
 
-TEST_F(MeshDeviceSingleCardFixture, BcastHWAdd) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::HW, BcastOp::ADD);
-}
-TEST_F(MeshDeviceSingleCardFixture, BcastHWSub) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::HW, BcastOp::SUB);
-}
-TEST_F(MeshDeviceSingleCardFixture, BcastHWMul) {
-    run_bcast_test(devices_[0]->get_devices()[0], BcastDim::HW, BcastOp::MUL);
-}
+TEST_F(UnitMeshFixture, BcastHWAdd) { run_bcast_test(this->device(), BcastDim::HW, BcastOp::ADD); }
+TEST_F(UnitMeshFixture, BcastHWSub) { run_bcast_test(this->device(), BcastDim::HW, BcastOp::SUB); }
+TEST_F(UnitMeshFixture, BcastHWMul) { run_bcast_test(this->device(), BcastDim::HW, BcastOp::MUL); }

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -59,11 +59,11 @@ void check_program_is_mapped_to_correct_cores(
 }
 
 void check_semaphores_are_initialized(
-    distributed::MeshDevice& mesh_device,
+    distributed::MeshDevice& unit_mesh,
     Program& program,
     const CoreRangeSet& core_range_set,
     const std::vector<uint32_t>& golden_sem_values) {
-    IDevice* device = slow_dispatch::physical_device_from_unit_mesh(mesh_device);
+    IDevice* device = unit_mesh.get_devices()[0];
     for (auto core_range : core_range_set.ranges()) {
         for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
             for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
@@ -71,7 +71,7 @@ void check_semaphores_are_initialized(
                 std::vector<uint32_t> res;
                 auto sem_base_addr = program.impl().get_sem_base_addr(device, logical_core, CoreType::WORKER);
                 slow_dispatch::ReadFromL1(
-                    mesh_device,
+                    unit_mesh,
                     logical_core,
                     sem_base_addr,
                     program.impl().get_sem_size(device, logical_core, CoreType::WORKER),

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -17,10 +17,10 @@
 #include "impl/buffers/circular_buffer.hpp"
 #include "impl/buffers/semaphore.hpp"
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <umd/device/types/core_coordinates.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 // Access to internal API: ProgramImpl::get_sem_base_addr, get_sem_size, num_kernels, get_kernel
 #include "impl/program/program_impl.hpp"
@@ -59,18 +59,19 @@ void check_program_is_mapped_to_correct_cores(
 }
 
 void check_semaphores_are_initialized(
-    IDevice* device,
+    distributed::MeshDevice& mesh_device,
     Program& program,
     const CoreRangeSet& core_range_set,
     const std::vector<uint32_t>& golden_sem_values) {
+    IDevice* device = slow_dispatch::physical_device_from_unit_mesh(mesh_device);
     for (auto core_range : core_range_set.ranges()) {
         for (auto x = core_range.start_coord.x; x <= core_range.end_coord.x; x++) {
             for (auto y = core_range.start_coord.y; y <= core_range.end_coord.y; y++) {
                 auto logical_core = CoreCoord{x, y};
                 std::vector<uint32_t> res;
                 auto sem_base_addr = program.impl().get_sem_base_addr(device, logical_core, CoreType::WORKER);
-                detail::ReadFromDeviceL1(
-                    device,
+                slow_dispatch::ReadFromL1(
+                    mesh_device,
                     logical_core,
                     sem_base_addr,
                     program.impl().get_sem_size(device, logical_core, CoreType::WORKER),
@@ -90,8 +91,7 @@ void check_semaphores_are_initialized(
 
 }  // namespace
 
-TEST_F(MeshDeviceSingleCardFixture, CoreRangeSet) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+TEST_F(UnitMeshFixture, CoreRangeSet) {
     Program program = CreateProgram();
 
     CoreRange core_range_one({0, 0}, {1, 1});
@@ -102,21 +102,19 @@ TEST_F(MeshDeviceSingleCardFixture, CoreRangeSet) {
     uint32_t num_tiles = 4;
     uint32_t buffer_size = single_tile_size * num_tiles;
 
-    InterleavedBufferConfig dram_config{
-        .device = dev, .size = buffer_size, .page_size = buffer_size, .buffer_type = BufferType::DRAM};
+    distributed::ReplicatedBufferConfig buffer_config{.size = buffer_size};
+    auto src_dram_buffer = distributed::MeshBuffer::create(
+        buffer_config, {.page_size = buffer_size, .buffer_type = BufferType::DRAM}, &this->device());
 
-    auto src_dram_buffer = CreateBuffer(dram_config);
-
-    std::map<CoreCoord, std::shared_ptr<Buffer>> core_to_l1_buffer;
+    std::map<CoreCoord, std::shared_ptr<distributed::MeshBuffer>> core_to_l1_buffer;
     for (auto core_range : core_ranges.ranges()) {
         auto start = core_range.start_coord;
         auto end = core_range.end_coord;
         for (auto x = start.x; x <= end.x; x++) {
             for (auto y = start.y; y <= end.y; y++) {
                 CoreCoord logical_core(x, y);
-                InterleavedBufferConfig l1_config{
-                    .device = dev, .size = buffer_size, .page_size = buffer_size, .buffer_type = BufferType::L1};
-                auto dst_l1_buffer = CreateBuffer(l1_config);
+                auto dst_l1_buffer = distributed::MeshBuffer::create(
+                    buffer_config, {.page_size = buffer_size, .buffer_type = BufferType::L1}, &this->device());
                 core_to_l1_buffer.emplace(logical_core, dst_l1_buffer);
             }
         }
@@ -165,18 +163,18 @@ TEST_F(MeshDeviceSingleCardFixture, CoreRangeSet) {
 
     check_program_is_mapped_to_correct_cores(program, core_ranges, compute_kernel_args);
 
-    detail::CompileProgram(dev, program);
+    slow_dispatch::CompileProgram(this->device(), program);
 
     std::vector<uint32_t> src_vec =
         create_random_vector_of_bfloat16(buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-    detail::WriteToBuffer(src_dram_buffer, src_vec);
+    slow_dispatch::WriteToBuffer(*src_dram_buffer, src_vec);
 
-    const std::array reader_rt_args = {src_dram_buffer->address(), uint(0), num_tiles};
+    const std::array reader_rt_args = {(uint32_t)src_dram_buffer->address(), uint(0), num_tiles};
     for (const auto& [core, dst_l1_buffer] : core_to_l1_buffer) {
         SetRuntimeArgs(program, unary_reader_kernel, core, reader_rt_args);
 
-        auto l1_dst_noc_xy = dev->virtual_core_from_logical_core(
-            dst_l1_buffer->allocator()->get_logical_core_from_bank_id(0), CoreType::WORKER);
+        auto l1_dst_noc_xy = this->device().virtual_core_from_logical_core(
+            dst_l1_buffer->get_reference_buffer()->allocator()->get_logical_core_from_bank_id(0), CoreType::WORKER);
 
         SetRuntimeArgs(
             program,
@@ -185,13 +183,13 @@ TEST_F(MeshDeviceSingleCardFixture, CoreRangeSet) {
             {dst_l1_buffer->address(), (std::uint32_t)l1_dst_noc_xy.x, (std::uint32_t)l1_dst_noc_xy.y, num_tiles});
     }
 
-    detail::LaunchProgram(dev, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
-    check_semaphores_are_initialized(dev, program, core_ranges, golden_sem_values);
+    check_semaphores_are_initialized(this->device(), program, core_ranges, golden_sem_values);
 
     for (const auto& [core, dst_l1_buffer] : core_to_l1_buffer) {
         std::vector<uint32_t> result_vec;
-        detail::ReadFromBuffer(dst_l1_buffer, result_vec);
+        slow_dispatch::ReadFromBuffer(*dst_l1_buffer, result_vec);
         EXPECT_EQ(src_vec, result_vec) << "Mismatch on core " << core.x << "," << core.y;
     }
 }

--- a/tests/tt_metal/tt_metal/test_core_range_set.cpp
+++ b/tests/tt_metal/tt_metal/test_core_range_set.cpp
@@ -180,7 +180,10 @@ TEST_F(UnitMeshFixture, CoreRangeSet) {
             program,
             unary_writer_kernel,
             core,
-            {dst_l1_buffer->address(), (std::uint32_t)l1_dst_noc_xy.x, (std::uint32_t)l1_dst_noc_xy.y, num_tiles});
+            {(std::uint32_t)dst_l1_buffer->address(),
+             (std::uint32_t)l1_dst_noc_xy.x,
+             (std::uint32_t)l1_dst_noc_xy.y,
+             num_tiles});
     }
 
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);

--- a/tests/tt_metal/tt_metal/test_datacopy.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy.cpp
@@ -11,14 +11,14 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+
 using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;
 
-TEST_F(MeshDeviceSingleCardFixture, Datacopy) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+TEST_F(UnitMeshFixture, Datacopy) {
     Program program = CreateProgram();
 
     CoreCoord core = {0, 0};
@@ -27,11 +27,12 @@ TEST_F(MeshDeviceSingleCardFixture, Datacopy) {
     uint32_t num_tiles = 2048;
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
-    InterleavedBufferConfig dram_config{
-        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
-    auto src_dram_buffer = CreateBuffer(dram_config);
+    distributed::DeviceLocalBufferConfig dram_config{.page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+    distributed::ReplicatedBufferConfig buffer_config{.size = dram_buffer_size};
+
+    auto src_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &this->device());
+    auto dst_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &this->device());
     uint32_t dram_buffer_src_addr = src_dram_buffer->address();
-    auto dst_dram_buffer = CreateBuffer(dram_config);
     uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
 
     // input CB is larger than the output CB, to test the backpressure from the output CB all the way into the input
@@ -74,15 +75,15 @@ TEST_F(MeshDeviceSingleCardFixture, Datacopy) {
     // Execute
     std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
         dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-    detail::WriteToBuffer(src_dram_buffer, src_vec);
+    slow_dispatch::WriteToBuffer(*src_dram_buffer, src_vec);
 
     SetRuntimeArgs(program, unary_reader_kernel, core, {dram_buffer_src_addr, 0, num_tiles});
     SetRuntimeArgs(program, unary_writer_kernel, core, {dram_buffer_dst_addr, 0, num_tiles});
 
-    detail::LaunchProgram(dev, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_dram_buffer, result_vec);
+    slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);
 
     // Validation
     EXPECT_EQ(src_vec, result_vec);

--- a/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_bfp8b.cpp
@@ -11,16 +11,15 @@
 #include <tt-metalium/bfloat8.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include "tt_metal/test_utils/bfloat_utils.hpp"
 
 using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;
 
-TEST_F(MeshDeviceSingleCardFixture, DatacopyBfp8b) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+TEST_F(UnitMeshFixture, DatacopyBfp8b) {
     Program program = CreateProgram();
 
     CoreCoord core = {0, 0};
@@ -30,11 +29,12 @@ TEST_F(MeshDeviceSingleCardFixture, DatacopyBfp8b) {
     uint32_t num_tiles = 2048;
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
-    InterleavedBufferConfig dram_config{
-        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
-    auto src_dram_buffer = CreateBuffer(dram_config);
+    distributed::DeviceLocalBufferConfig dram_config{.page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+    distributed::ReplicatedBufferConfig buffer_config{.size = dram_buffer_size};
+
+    auto src_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &this->device());
+    auto dst_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &this->device());
     uint32_t dram_buffer_src_addr = src_dram_buffer->address();
-    auto dst_dram_buffer = CreateBuffer(dram_config);
     uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
 
     uint32_t src0_cb_index = 0;
@@ -77,15 +77,15 @@ TEST_F(MeshDeviceSingleCardFixture, DatacopyBfp8b) {
         /*is_exp_a=*/false,
         100,
         std::chrono::system_clock::now().time_since_epoch().count());
-    detail::WriteToBuffer(src_dram_buffer, src_vec);
+    slow_dispatch::WriteToBuffer(*src_dram_buffer, src_vec);
 
     SetRuntimeArgs(program, unary_reader_kernel, core, {dram_buffer_src_addr, 0, num_tiles});
     SetRuntimeArgs(program, unary_writer_kernel, core, {dram_buffer_dst_addr, 0, num_tiles});
 
-    detail::LaunchProgram(dev, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_dram_buffer, result_vec);
+    slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);
 
     // Validation
     EXPECT_EQ(src_vec, result_vec);

--- a/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
@@ -78,12 +78,15 @@ TEST_F(UnitMeshFixture, DatacopyOutputInL1) {
         create_random_vector_of_bfloat16(buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
     slow_dispatch::WriteToBuffer(*src_dram_buffer, src_vec);
 
-    SetRuntimeArgs(program, unary_reader_kernel, core, {src_dram_buffer->address(), 0, num_tiles});
+    SetRuntimeArgs(program, unary_reader_kernel, core, {(std::uint32_t)src_dram_buffer->address(), 0, num_tiles});
     SetRuntimeArgs(
         program,
         unary_writer_kernel,
         core,
-        {dst_l1_buffer->address(), (std::uint32_t)l1_dst_noc_xy.x, (std::uint32_t)l1_dst_noc_xy.y, num_tiles});
+        {(std::uint32_t)dst_l1_buffer->address(),
+         (std::uint32_t)l1_dst_noc_xy.x,
+         (std::uint32_t)l1_dst_noc_xy.y,
+         num_tiles});
 
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 

--- a/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
+++ b/tests/tt_metal/tt_metal/test_datacopy_output_in_l1.cpp
@@ -12,16 +12,15 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 
 using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;
 
-TEST_F(MeshDeviceSingleCardFixture, DatacopyOutputInL1) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+TEST_F(UnitMeshFixture, DatacopyOutputInL1) {
     Program program = CreateProgram();
 
     CoreCoord core = {0, 0};
@@ -30,17 +29,15 @@ TEST_F(MeshDeviceSingleCardFixture, DatacopyOutputInL1) {
     uint32_t num_tiles = 32;
     uint32_t buffer_size = single_tile_size * num_tiles;
 
-    InterleavedBufferConfig dram_config{
-        .device = dev, .size = buffer_size, .page_size = buffer_size, .buffer_type = BufferType::DRAM};
+    distributed::ReplicatedBufferConfig buffer_config{.size = buffer_size};
 
-    InterleavedBufferConfig l1_config{
-        .device = dev, .size = buffer_size, .page_size = buffer_size, .buffer_type = BufferType::L1};
+    auto src_dram_buffer = distributed::MeshBuffer::create(
+        buffer_config, {.page_size = buffer_size, .buffer_type = BufferType::DRAM}, &this->device());
+    auto dst_l1_buffer = distributed::MeshBuffer::create(
+        buffer_config, {.page_size = buffer_size, .buffer_type = BufferType::L1}, &this->device());
 
-    auto src_dram_buffer = CreateBuffer(dram_config);
-    auto dst_l1_buffer = CreateBuffer(l1_config);
-
-    auto l1_dst_noc_xy = dev->virtual_core_from_logical_core(
-        dst_l1_buffer->allocator()->get_logical_core_from_bank_id(0), CoreType::WORKER);
+    auto l1_dst_noc_xy = this->device().virtual_core_from_logical_core(
+        this->device().allocator()->get_logical_core_from_bank_id(0), CoreType::WORKER);
 
     uint32_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t num_input_tiles = 8;
@@ -79,7 +76,7 @@ TEST_F(MeshDeviceSingleCardFixture, DatacopyOutputInL1) {
     // Execute
     std::vector<uint32_t> src_vec =
         create_random_vector_of_bfloat16(buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-    detail::WriteToBuffer(src_dram_buffer, src_vec);
+    slow_dispatch::WriteToBuffer(*src_dram_buffer, src_vec);
 
     SetRuntimeArgs(program, unary_reader_kernel, core, {src_dram_buffer->address(), 0, num_tiles});
     SetRuntimeArgs(
@@ -88,10 +85,10 @@ TEST_F(MeshDeviceSingleCardFixture, DatacopyOutputInL1) {
         core,
         {dst_l1_buffer->address(), (std::uint32_t)l1_dst_noc_xy.x, (std::uint32_t)l1_dst_noc_xy.y, num_tiles});
 
-    detail::LaunchProgram(dev, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_l1_buffer, result_vec);
+    slow_dispatch::ReadFromBuffer(*dst_l1_buffer, result_vec);
 
     // Validation
     EXPECT_EQ(src_vec, result_vec);

--- a/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_copy_sticks_multi_core.cpp
@@ -21,7 +21,6 @@
 #include <variant>
 #include <vector>
 
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
@@ -29,6 +28,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include <umd/device/types/xy_pair.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // TODO: explain what test does
@@ -44,9 +44,8 @@ struct hlk_args_t {
 };
 }  // namespace unary_datacopy
 
-TEST_F(MeshDeviceSingleCardFixture, DramCopySticksMultiCore) {
+TEST_F(UnitMeshFixture, DramCopySticksMultiCore) {
     bool pass = true;
-    IDevice* dev = devices_[0]->get_devices()[0];
 
     try {
         tt_metal::Program program = tt_metal::CreateProgram();
@@ -61,13 +60,10 @@ TEST_F(MeshDeviceSingleCardFixture, DramCopySticksMultiCore) {
         int stick_size = num_elements_in_stick * 2;
         uint32_t dram_buffer_size =
             num_sticks * stick_size;  // num_tiles of FP16_B, hard-coded in the reader/writer kernels
-        tt_metal::InterleavedBufferConfig dram_config{
-            .device = dev,
-            .size = dram_buffer_size,
-            .page_size = dram_buffer_size,
-            .buffer_type = tt_metal::BufferType::DRAM};
-
-        auto src_dram_buffer = CreateBuffer(dram_config);
+        auto src_dram_buffer = distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = dram_buffer_size},
+            {.page_size = dram_buffer_size, .buffer_type = BufferType::DRAM},
+            &this->device());
         uint32_t dram_buffer_src_addr = src_dram_buffer->address();
 
         ASSERT_EQ(src_dram_buffer->size() % (num_cores_r * num_cores_c), 0)
@@ -77,12 +73,10 @@ TEST_F(MeshDeviceSingleCardFixture, DramCopySticksMultiCore) {
         for (int i = start_core.y; i < start_core.y + num_cores_r; i++) {
             for (int j = start_core.x; j < start_core.x + num_cores_c; j++) {
                 CoreCoord core = {(std::size_t)j, (std::size_t)i};
-                tt_metal::InterleavedBufferConfig l1_config{
-                    .device = dev,
-                    .size = per_core_l1_size,
-                    .page_size = per_core_l1_size,
-                    .buffer_type = tt_metal::BufferType::L1};
-                auto l1_b0 = CreateBuffer(l1_config);
+                auto l1_b0 = distributed::MeshBuffer::create(
+                    distributed::ReplicatedBufferConfig{.size = per_core_l1_size},
+                    {.page_size = per_core_l1_size, .buffer_type = BufferType::L1},
+                    &this->device());
                 core_to_l1_addr[core] = l1_b0->address();
             }
         }
@@ -102,7 +96,7 @@ TEST_F(MeshDeviceSingleCardFixture, DramCopySticksMultiCore) {
         ////////////////////////////////////////////////////////////////////////////
         std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
             dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-        tt_metal::detail::WriteToBuffer(src_dram_buffer, src_vec);
+        slow_dispatch::WriteToBuffer(*src_dram_buffer, src_vec);
 
         std::cout << "Num cores " << num_cores_r * num_cores_c << std::endl;
         uint32_t core_index = 0;
@@ -122,9 +116,9 @@ TEST_F(MeshDeviceSingleCardFixture, DramCopySticksMultiCore) {
             }
         }
 
-        tt_metal::detail::LaunchProgram(dev, program);
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
         // std::vector<uint32_t> result_vec;
-        // tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
+        // slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
+++ b/tests/tt_metal/tt_metal/test_dram_loopback_single_core.cpp
@@ -11,7 +11,8 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/buffer.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+
 using namespace tt;
 using namespace tt::tt_metal;
 
@@ -21,8 +22,7 @@ using namespace tt::tt_metal;
 //      in step 1. to buffer in L1 and back to another buffer in DRAM
 // 4. Host reads from buffer written to in step 2.
 //////////////////////////////////////////////////////////////////////////////////////////
-TEST_F(MeshDeviceSingleCardFixture, DramLoopbackSingleCore) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+TEST_F(UnitMeshFixture, DramLoopbackSingleCore) {
     Program program = CreateProgram();
 
     CoreCoord core = {0, 0};
@@ -32,12 +32,12 @@ TEST_F(MeshDeviceSingleCardFixture, DramLoopbackSingleCore) {
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
     uint32_t l1_buffer_addr = 400 * 1024;
 
-    InterleavedBufferConfig dram_config{
-        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
-    auto input_dram_buffer = CreateBuffer(dram_config);
-    uint32_t input_dram_buffer_addr = input_dram_buffer->address();
+    distributed::DeviceLocalBufferConfig dram_config{.page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+    distributed::ReplicatedBufferConfig buffer_config{.size = dram_buffer_size};
 
-    auto output_dram_buffer = CreateBuffer(dram_config);
+    auto input_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &this->device());
+    auto output_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &this->device());
+    uint32_t input_dram_buffer_addr = input_dram_buffer->address();
     uint32_t output_dram_buffer_addr = output_dram_buffer->address();
 
     auto dram_copy_kernel = CreateKernel(
@@ -49,7 +49,7 @@ TEST_F(MeshDeviceSingleCardFixture, DramLoopbackSingleCore) {
     // Execute
     std::vector<uint32_t> input_vec = create_random_vector_of_bfloat16(
         dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-    detail::WriteToBuffer(input_dram_buffer, input_vec);
+    slow_dispatch::WriteToBuffer(*input_dram_buffer, input_vec);
 
     SetRuntimeArgs(
         program,
@@ -57,10 +57,10 @@ TEST_F(MeshDeviceSingleCardFixture, DramLoopbackSingleCore) {
         core,
         {l1_buffer_addr, input_dram_buffer_addr, 0, output_dram_buffer_addr, 0, dram_buffer_size});
 
-    detail::LaunchProgram(dev, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    detail::ReadFromBuffer(output_dram_buffer, result_vec);
+    slow_dispatch::ReadFromBuffer(*output_dram_buffer, result_vec);
 
     // Validation
     EXPECT_EQ(input_vec, result_vec);

--- a/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
@@ -123,7 +123,7 @@ TEST_F(UnitMeshFixture, GenericBinaryReaderMatmulLargeBlock) {
         uint32_t dram_buffer_size_out =
             single_tile_size * M * N;  // num_tiles of FP16_B, hard-coded in the reader/writer kernels
 
-        // page_size must match each buffer's size (same as previous InterleavedBufferConfig)
+        // The kernels treat each buffer as one page, so each page size must equal its buffer size.
         auto src0_dram_buffer = distributed::MeshBuffer::create(
             distributed::ReplicatedBufferConfig{.size = dram_buffer_size_act},
             {.page_size = dram_buffer_size_act, .buffer_type = BufferType::DRAM},

--- a/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
+++ b/tests/tt_metal/tt_metal/test_generic_binary_reader_matmul_large_block.cpp
@@ -30,7 +30,6 @@
 #include <vector>
 
 #include <tt_stl/assert.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/core_coord.hpp>
@@ -40,6 +39,7 @@
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -98,8 +98,7 @@ std::vector<std::uint32_t> transpose_tiles(
 
 }  // namespace
 
-TEST_F(MeshDeviceSingleCardFixture, GenericBinaryReaderMatmulLargeBlock) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+TEST_F(UnitMeshFixture, GenericBinaryReaderMatmulLargeBlock) {
     bool pass = true;
 
     try {
@@ -124,26 +123,19 @@ TEST_F(MeshDeviceSingleCardFixture, GenericBinaryReaderMatmulLargeBlock) {
         uint32_t dram_buffer_size_out =
             single_tile_size * M * N;  // num_tiles of FP16_B, hard-coded in the reader/writer kernels
 
-        tt_metal::InterleavedBufferConfig act_config{
-            .device = dev,
-            .size = dram_buffer_size_act,
-            .page_size = dram_buffer_size_act,
-            .buffer_type = tt_metal::BufferType::DRAM};
-
-        tt_metal::InterleavedBufferConfig weights_config{
-            .device = dev,
-            .size = dram_buffer_size_weights,
-            .page_size = dram_buffer_size_weights,
-            .buffer_type = tt_metal::BufferType::DRAM};
-
-        tt_metal::InterleavedBufferConfig dst_config{
-            .device = dev,
-            .size = dram_buffer_size_out,
-            .page_size = dram_buffer_size_out,
-            .buffer_type = tt_metal::BufferType::DRAM};
-        auto src0_dram_buffer = CreateBuffer(act_config);
-        auto src1_dram_buffer = CreateBuffer(weights_config);
-        auto dst_dram_buffer = CreateBuffer(dst_config);
+        // page_size must match each buffer's size (same as previous InterleavedBufferConfig)
+        auto src0_dram_buffer = distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = dram_buffer_size_act},
+            {.page_size = dram_buffer_size_act, .buffer_type = BufferType::DRAM},
+            &this->device());
+        auto src1_dram_buffer = distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = dram_buffer_size_weights},
+            {.page_size = dram_buffer_size_weights, .buffer_type = BufferType::DRAM},
+            &this->device());
+        auto dst_dram_buffer = distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = dram_buffer_size_out},
+            {.page_size = dram_buffer_size_out, .buffer_type = BufferType::DRAM},
+            &this->device());
 
         uint32_t src0_cb_index = 0;
         uint32_t cb0_tiles = M * in0_block_w * 2;
@@ -192,20 +184,17 @@ TEST_F(MeshDeviceSingleCardFixture, GenericBinaryReaderMatmulLargeBlock) {
         uint32_t src1_num_bytes_per_block = src1_num_tiles_per_block * single_tile_size;
         TT_FATAL(source_addresses.size() == num_blocks * src0_num_reads_per_block, "Error");
 
-        tt_metal::InterleavedBufferConfig l1_config{
-            .device = dev,
-            .size = source_addresses.size() * sizeof(uint32_t),
-            .page_size = source_addresses.size() * sizeof(uint32_t),
-            .buffer_type = tt_metal::BufferType::L1};
-
-        auto source_addresses_in_l1 = CreateBuffer(l1_config);
+        auto source_addresses_in_l1 = distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = source_addresses.size() * sizeof(uint32_t)},
+            {.page_size = source_addresses.size() * sizeof(uint32_t), .buffer_type = BufferType::L1},
+            &this->device());
         auto source_addresses_in_l1_addr = source_addresses_in_l1->address();
 
         const std::array generic_binary_reader_args{
-            src0_dram_buffer->address(),
-            (uint32_t) 0,
-            src1_dram_buffer->address(),
-            (uint32_t) 0,
+            (uint32_t)src0_dram_buffer->address(),
+            (uint32_t)0,
+            (uint32_t)src1_dram_buffer->address(),
+            (uint32_t)0,
             (uint32_t)source_addresses.size(),
             (uint32_t)source_addresses_in_l1_addr,
             (uint32_t)num_blocks,
@@ -223,15 +212,17 @@ TEST_F(MeshDeviceSingleCardFixture, GenericBinaryReaderMatmulLargeBlock) {
                 .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default});
 
         const std::array writer_rt_args{
-            dst_dram_buffer->address(),
-            (std::uint32_t) 0,
-            (std::uint32_t)out_subblock_h, // num tiles per sub block m
-            (std::uint32_t)out_subblock_w, // num tiles per sub block n
-            (std::uint32_t)M/out_subblock_h, // num sub blocks m
-            (std::uint32_t)N/out_subblock_w, // num sub blocks n
-            (std::uint32_t)out_subblock_w * single_tile_size * (N/out_subblock_w), // bytes offset to next row within sub-block
-            (std::uint32_t)out_subblock_h * out_subblock_w * single_tile_size * (N/out_subblock_w), // bytes offset to next row of sub-blocks
-            (std::uint32_t)out_subblock_w*single_tile_size}; // bytes offset to next sub-block
+            (std::uint32_t)dst_dram_buffer->address(),
+            (std::uint32_t)0,
+            (std::uint32_t)out_subblock_h,      // num tiles per sub block m
+            (std::uint32_t)out_subblock_w,      // num tiles per sub block n
+            (std::uint32_t)M / out_subblock_h,  // num sub blocks m
+            (std::uint32_t)N / out_subblock_w,  // num sub blocks n
+            (std::uint32_t)out_subblock_w * single_tile_size *
+                (N / out_subblock_w),  // bytes offset to next row within sub-block
+            (std::uint32_t)out_subblock_h * out_subblock_w * single_tile_size *
+                (N / out_subblock_w),                           // bytes offset to next row of sub-blocks
+            (std::uint32_t)out_subblock_w * single_tile_size};  // bytes offset to next sub-block
 
         auto unary_writer_kernel = tt_metal::CreateKernel(
             program,
@@ -291,24 +282,24 @@ TEST_F(MeshDeviceSingleCardFixture, GenericBinaryReaderMatmulLargeBlock) {
             convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(activations_tilized));
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
         auto activations_tile_transposed = transpose_tiles(activations, M, K, in0_block_w);
-        tt_metal::detail::WriteToBuffer(src0_dram_buffer, activations_tile_transposed);
+        slow_dispatch::WriteToBuffer(*src0_dram_buffer, activations_tile_transposed);
 
         auto identity = create_identity_matrix(K * 32, N * 32, std::min(K, N) * 32);  // bflaot16 32x32 identity
         auto identity_tilized = tilize_swizzled(identity, K * 32, N * 32);
         auto weights_tile_layout =
             convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(identity_tilized));
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-        tt_metal::detail::WriteToBuffer(src1_dram_buffer, weights);
-        tt_metal::detail::WriteToDeviceL1(dev, core, source_addresses_in_l1_addr, source_addresses);
+        slow_dispatch::WriteToBuffer(*src1_dram_buffer, weights);
+        slow_dispatch::WriteToL1(this->device(), core, source_addresses_in_l1_addr, source_addresses);
 
         tt_metal::SetRuntimeArgs(program, generic_binary_reader_kernel, core, generic_binary_reader_args);
 
         tt_metal::SetRuntimeArgs(program, unary_writer_kernel, core, writer_rt_args);
 
-        tt_metal::detail::LaunchProgram(dev, program);
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
         std::vector<uint32_t> result_vec;
-        tt_metal::detail::ReadFromBuffer(dst_dram_buffer, result_vec);
+        slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Validation & Teardown

--- a/tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_l1_buffer.cpp
@@ -11,53 +11,55 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/buffer.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 using namespace tt;
 using namespace tt::tt_metal;
 
 namespace {
 
-void test_interleaved_l1_buffer_impl(IDevice* dev, int num_pages_one, int num_pages_two, uint32_t page_size) {
+void test_interleaved_l1_buffer_impl(
+    distributed::MeshDevice& device, int num_pages_one, int num_pages_two, uint32_t page_size) {
     uint32_t buffer_size = num_pages_one * page_size;
 
-    InterleavedBufferConfig buff_config_0{
-        .device = dev, .size = buffer_size, .page_size = page_size, .buffer_type = BufferType::L1};
-    auto interleaved_buffer = CreateBuffer(buff_config_0);
+    auto interleaved_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = buffer_size},
+        {.page_size = page_size, .buffer_type = BufferType::L1},
+        &device);
 
     std::vector<uint32_t> host_buffer =
         create_random_vector_of_bfloat16(buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
 
-    detail::WriteToBuffer(interleaved_buffer, host_buffer);
+    slow_dispatch::WriteToBuffer(*interleaved_buffer, host_buffer);
 
     std::vector<uint32_t> readback_buffer;
-    detail::ReadFromBuffer(interleaved_buffer, readback_buffer);
+    slow_dispatch::ReadFromBuffer(*interleaved_buffer, readback_buffer);
 
     EXPECT_EQ(host_buffer, readback_buffer);
 
     uint32_t second_buffer_size = num_pages_two * page_size;
 
-    InterleavedBufferConfig buff_config_1{
-        .device = dev, .size = second_buffer_size, .page_size = page_size, .buffer_type = BufferType::L1};
-
-    auto second_interleaved_buffer = CreateBuffer(buff_config_1);
+    auto second_interleaved_buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = second_buffer_size},
+        {.page_size = page_size, .buffer_type = BufferType::L1},
+        &device);
 
     std::vector<uint32_t> second_host_buffer = create_random_vector_of_bfloat16(
         second_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
 
-    detail::WriteToBuffer(second_interleaved_buffer, second_host_buffer);
+    slow_dispatch::WriteToBuffer(*second_interleaved_buffer, second_host_buffer);
 
     std::vector<uint32_t> second_readback_buffer;
-    detail::ReadFromBuffer(second_interleaved_buffer, second_readback_buffer);
+    slow_dispatch::ReadFromBuffer(*second_interleaved_buffer, second_readback_buffer);
 
     EXPECT_EQ(second_host_buffer, second_readback_buffer);
 }
 
 }  // namespace
 
-TEST_F(MeshDeviceSingleCardFixture, InterleavedL1Buffer) {
+TEST_F(UnitMeshFixture, InterleavedL1Buffer) {
     uint32_t page_size = 2 * 1024;
     int num_bank_pages_one = 258;
     int num_bank_pages_two = 378;
 
-    test_interleaved_l1_buffer_impl(devices_[0]->get_devices()[0], num_bank_pages_one, num_bank_pages_two, page_size);
+    test_interleaved_l1_buffer_impl(this->device(), num_bank_pages_one, num_bank_pages_two, page_size);
 }

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
@@ -11,16 +11,15 @@
 #include <tt-metalium/bfloat8.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include "tt_metal/test_utils/bfloat_utils.hpp"
 
 using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;
 
-TEST_F(MeshDeviceSingleCardFixture, MatmulSingleTileBfp8b) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+TEST_F(UnitMeshFixture, MatmulSingleTileBfp8b) {
     Program program = CreateProgram();
 
     CoreCoord core = {0, 0};
@@ -30,12 +29,12 @@ TEST_F(MeshDeviceSingleCardFixture, MatmulSingleTileBfp8b) {
     uint32_t num_tiles = 1;
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
-    InterleavedBufferConfig dram_config{
-        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+    distributed::DeviceLocalBufferConfig dram_config{.page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+    distributed::ReplicatedBufferConfig buffer_config{.size = dram_buffer_size};
 
-    auto src0_dram_buffer = CreateBuffer(dram_config);
-    auto src1_dram_buffer = CreateBuffer(dram_config);
-    auto dst_dram_buffer = CreateBuffer(dram_config);
+    auto src0_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &this->device());
+    auto src1_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &this->device());
+    auto dst_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &this->device());
 
     uint32_t src0_cb_index = 0;
     uint32_t num_input_tiles = 1;
@@ -83,7 +82,7 @@ TEST_F(MeshDeviceSingleCardFixture, MatmulSingleTileBfp8b) {
         /*is_exp_a=*/false,
         100,
         std::chrono::system_clock::now().time_since_epoch().count());
-    detail::WriteToBuffer(src0_dram_buffer, activations);
+    slow_dispatch::WriteToBuffer(*src0_dram_buffer, activations);
 
     int num_float_in_tile = 32 * 32;
     std::vector<float> vec(num_float_in_tile, (float)0);
@@ -93,7 +92,7 @@ TEST_F(MeshDeviceSingleCardFixture, MatmulSingleTileBfp8b) {
     std::vector<uint32_t> weights =
         pack_as_bfp8_tiles(ttsl::make_const_span(vec), /*row_major_input=*/true, /*is_exp_a=*/false);
 
-    detail::WriteToBuffer(src1_dram_buffer, weights);
+    slow_dispatch::WriteToBuffer(*src1_dram_buffer, weights);
 
     SetRuntimeArgs(
         program,
@@ -111,10 +110,10 @@ TEST_F(MeshDeviceSingleCardFixture, MatmulSingleTileBfp8b) {
 
     SetRuntimeArgs(program, unary_writer_kernel, core, {dst_dram_buffer->address(), 0, num_tiles});
 
-    detail::LaunchProgram(dev, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_dram_buffer, result_vec);
+    slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);
 
     // Validation - matmul with identity should return same result
     EXPECT_EQ(activations, result_vec);

--- a/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
+++ b/tests/tt_metal/tt_metal/test_matmul_single_tile_bfp8b.cpp
@@ -98,9 +98,9 @@ TEST_F(UnitMeshFixture, MatmulSingleTileBfp8b) {
         program,
         mm_reader_kernel,
         core,
-        {src0_dram_buffer->address(),
+        {(uint32_t)src0_dram_buffer->address(),
          0,
-         src1_dram_buffer->address(),
+         (uint32_t)src1_dram_buffer->address(),
          0,
          1,
          1,
@@ -108,7 +108,7 @@ TEST_F(UnitMeshFixture, MatmulSingleTileBfp8b) {
          1 * single_tile_size,
          1 * single_tile_size});
 
-    SetRuntimeArgs(program, unary_writer_kernel, core, {dst_dram_buffer->address(), 0, num_tiles});
+    SetRuntimeArgs(program, unary_writer_kernel, core, {(uint32_t)dst_dram_buffer->address(), 0, num_tiles});
 
     slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 

--- a/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
+++ b/tests/tt_metal/tt_metal/test_multi_core_kernel.cpp
@@ -14,8 +14,8 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;
@@ -23,10 +23,7 @@ using namespace tt::tt_metal;
 namespace {
 
 std::tuple<Program, KernelHandle, KernelHandle> create_program(
-    IDevice* /*device*/,
-    uint32_t single_tile_size,
-    const CoreRange& all_cores,
-    const std::vector<uint32_t>& eltwise_unary_args) {
+    uint32_t single_tile_size, const CoreRange& all_cores, const std::vector<uint32_t>& eltwise_unary_args) {
     Program program = CreateProgram();
 
     CoreCoord start_core = all_cores.start_coord;
@@ -83,9 +80,7 @@ void set_rt_args(
 
 }  // namespace
 
-TEST_F(MeshDeviceSingleCardFixture, MultiCoreKernelSameRuntimeArgs) {
-    IDevice* dev = devices_[0]->get_devices()[0];
-
+TEST_F(UnitMeshFixture, MultiCoreKernelSameRuntimeArgs) {
     CoreCoord start_core = {0, 0};
     CoreCoord end_core = {2, 2};
     CoreRange all_cores(start_core, end_core);
@@ -93,39 +88,39 @@ TEST_F(MeshDeviceSingleCardFixture, MultiCoreKernelSameRuntimeArgs) {
     uint32_t single_tile_size = 2 * 1024;
     int32_t num_tiles = 2048;
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
-    InterleavedBufferConfig dram_config{
-        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+    distributed::DeviceLocalBufferConfig dram_config{.page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+    distributed::ReplicatedBufferConfig buffer_config{.size = dram_buffer_size};
 
-    auto src_dram_buffer = CreateBuffer(dram_config);
-    auto dst_dram_buffer = CreateBuffer(dram_config);
+    auto src_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &this->device());
+    auto dst_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &this->device());
 
     vector<uint32_t> compute_kernel_args = {uint(num_tiles), /*use_dfbs=*/false};
 
     auto [program, reader_kernel_id, writer_kernel_id] =
-        create_program(dev, single_tile_size, all_cores, compute_kernel_args);
+        create_program(single_tile_size, all_cores, compute_kernel_args);
 
     std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
         src_dram_buffer->size(), 100, std::chrono::system_clock::now().time_since_epoch().count());
 
-    detail::WriteToBuffer(src_dram_buffer, src_vec);
+    slow_dispatch::WriteToBuffer(*src_dram_buffer, src_vec);
 
-    const std::array unary_reader_args{src_dram_buffer->address(), (std::uint32_t)0, (std::uint32_t)num_tiles};
-    const std::array unary_writer_args{dst_dram_buffer->address(), (std::uint32_t)0, (std::uint32_t)num_tiles};
+    const std::array unary_reader_args{
+        (std::uint32_t)src_dram_buffer->address(), (std::uint32_t)0, (std::uint32_t)num_tiles};
+    const std::array unary_writer_args{
+        (std::uint32_t)dst_dram_buffer->address(), (std::uint32_t)0, (std::uint32_t)num_tiles};
 
     set_rt_args(program, reader_kernel_id, all_cores, unary_reader_args);
     set_rt_args(program, writer_kernel_id, all_cores, unary_writer_args);
 
-    detail::LaunchProgram(dev, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_dram_buffer, result_vec);
+    slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);
 
     EXPECT_EQ(src_vec, result_vec);
 }
 
-TEST_F(MeshDeviceSingleCardFixture, MultiCoreKernelUniqueRuntimeArgs) {
-    IDevice* dev = devices_[0]->get_devices()[0];
-
+TEST_F(UnitMeshFixture, MultiCoreKernelUniqueRuntimeArgs) {
     CoreCoord start_core = {0, 0};
     CoreCoord end_core = {1, 1};
     CoreRange start_core_range(start_core, start_core);
@@ -138,28 +133,32 @@ TEST_F(MeshDeviceSingleCardFixture, MultiCoreKernelUniqueRuntimeArgs) {
     int32_t num_tiles = 2048;
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
-    InterleavedBufferConfig dram_config{
-        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+    distributed::DeviceLocalBufferConfig dram_config{.page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+    distributed::ReplicatedBufferConfig buffer_config{.size = dram_buffer_size};
 
-    auto src_dram_buffer = CreateBuffer(dram_config);
-    auto dst_dram_buffer_1 = CreateBuffer(dram_config);
-    auto dst_dram_buffer_2 = CreateBuffer(dram_config);
-    auto dst_dram_buffer_3 = CreateBuffer(dram_config);
+    auto src_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &this->device());
+    auto dst_dram_buffer_1 = distributed::MeshBuffer::create(buffer_config, dram_config, &this->device());
+    auto dst_dram_buffer_2 = distributed::MeshBuffer::create(buffer_config, dram_config, &this->device());
+    auto dst_dram_buffer_3 = distributed::MeshBuffer::create(buffer_config, dram_config, &this->device());
 
     vector<uint32_t> compute_kernel_args = {uint(num_tiles), /*use_dfbs=*/false};
 
     auto [program, reader_kernel_id, writer_kernel_id] =
-        create_program(dev, single_tile_size, all_cores, compute_kernel_args);
+        create_program(single_tile_size, all_cores, compute_kernel_args);
 
     std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
         src_dram_buffer->size(), 100, std::chrono::system_clock::now().time_since_epoch().count());
 
-    detail::WriteToBuffer(src_dram_buffer, src_vec);
+    slow_dispatch::WriteToBuffer(*src_dram_buffer, src_vec);
 
-    const std::array unary_reader_args{src_dram_buffer->address(), (std::uint32_t)0, (std::uint32_t)num_tiles};
-    const std::array unary_writer_args_1{dst_dram_buffer_1->address(), (std::uint32_t)0, (std::uint32_t)num_tiles};
-    const std::array unary_writer_args_2{dst_dram_buffer_2->address(), (std::uint32_t)0, (std::uint32_t)num_tiles};
-    const std::array unary_writer_args_3{dst_dram_buffer_3->address(), (std::uint32_t)0, (std::uint32_t)num_tiles};
+    const std::array unary_reader_args{
+        (std::uint32_t)src_dram_buffer->address(), (std::uint32_t)0, (std::uint32_t)num_tiles};
+    const std::array unary_writer_args_1{
+        (std::uint32_t)dst_dram_buffer_1->address(), (std::uint32_t)0, (std::uint32_t)num_tiles};
+    const std::array unary_writer_args_2{
+        (std::uint32_t)dst_dram_buffer_2->address(), (std::uint32_t)0, (std::uint32_t)num_tiles};
+    const std::array unary_writer_args_3{
+        (std::uint32_t)dst_dram_buffer_3->address(), (std::uint32_t)0, (std::uint32_t)num_tiles};
 
     set_rt_args(program, reader_kernel_id, all_cores, unary_reader_args);
     int core_range_idx = 0;
@@ -168,16 +167,16 @@ TEST_F(MeshDeviceSingleCardFixture, MultiCoreKernelUniqueRuntimeArgs) {
         set_rt_args(program, writer_kernel_id, core_range, rt_args.at(core_range_idx++));
     }
 
-    detail::LaunchProgram(dev, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec_1;
-    detail::ReadFromBuffer(dst_dram_buffer_1, result_vec_1);
+    slow_dispatch::ReadFromBuffer(*dst_dram_buffer_1, result_vec_1);
 
     std::vector<uint32_t> result_vec_2;
-    detail::ReadFromBuffer(dst_dram_buffer_2, result_vec_2);
+    slow_dispatch::ReadFromBuffer(*dst_dram_buffer_2, result_vec_2);
 
     std::vector<uint32_t> result_vec_3;
-    detail::ReadFromBuffer(dst_dram_buffer_3, result_vec_3);
+    slow_dispatch::ReadFromBuffer(*dst_dram_buffer_3, result_vec_3);
 
     EXPECT_EQ(src_vec, result_vec_1);
     EXPECT_EQ(src_vec, result_vec_2);

--- a/tests/tt_metal/tt_metal/test_multiple_programs.cpp
+++ b/tests/tt_metal/tt_metal/test_multiple_programs.cpp
@@ -160,9 +160,13 @@ void write_program_runtime_args_to_device(
         program,
         reader_kernel_id,
         core,
-        {src0_dram_buffer.address(), (uint32_t)0, src1_dram_buffer.address(), (uint32_t)0, num_tiles});
+        {(uint32_t)src0_dram_buffer.address(),
+         (uint32_t)0,
+         (uint32_t)src1_dram_buffer.address(),
+         (uint32_t)0,
+         num_tiles});
 
-    SetRuntimeArgs(program, writer_kernel_id, core, {dst_dram_buffer.address(), (uint32_t)0, num_tiles});
+    SetRuntimeArgs(program, writer_kernel_id, core, {(uint32_t)dst_dram_buffer.address(), (uint32_t)0, num_tiles});
 }
 
 }  // namespace

--- a/tests/tt_metal/tt_metal/test_multiple_programs.cpp
+++ b/tests/tt_metal/tt_metal/test_multiple_programs.cpp
@@ -15,8 +15,8 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tilize_utils.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 
 using std::vector;
@@ -52,8 +52,7 @@ std::map<std::string, std::string> get_defines(BinaryOpType::Enum op_type) {
     return defines;
 }
 
-std::tuple<Program, KernelHandle, KernelHandle> setup_program_one(
-    IDevice* /*device*/, const CoreCoord& core, uint32_t single_tile_size) {
+std::tuple<Program, KernelHandle, KernelHandle> setup_program_one(const CoreCoord& core, uint32_t single_tile_size) {
     Program program = CreateProgram();
 
     uint32_t src0_cb_index = 0;
@@ -102,8 +101,7 @@ std::tuple<Program, KernelHandle, KernelHandle> setup_program_one(
     return {std::move(program), binary_reader_kernel, unary_writer_kernel};
 }
 
-std::tuple<Program, KernelHandle, KernelHandle> setup_program_two(
-    IDevice* /*device*/, const CoreCoord& core, uint32_t single_tile_size) {
+std::tuple<Program, KernelHandle, KernelHandle> setup_program_two(const CoreCoord& core, uint32_t single_tile_size) {
     Program program = CreateProgram();
 
     uint32_t src0_cb_index = 0;
@@ -150,15 +148,14 @@ std::tuple<Program, KernelHandle, KernelHandle> setup_program_two(
 }
 
 void write_program_runtime_args_to_device(
-    IDevice* /*device*/,
     Program& program,
     KernelHandle reader_kernel_id,
     KernelHandle writer_kernel_id,
     const CoreCoord& core,
     uint32_t num_tiles,
-    Buffer& src0_dram_buffer,
-    Buffer& src1_dram_buffer,
-    Buffer& dst_dram_buffer) {
+    distributed::MeshBuffer& src0_dram_buffer,
+    distributed::MeshBuffer& src1_dram_buffer,
+    distributed::MeshBuffer& dst_dram_buffer) {
     SetRuntimeArgs(
         program,
         reader_kernel_id,
@@ -175,22 +172,21 @@ void write_program_runtime_args_to_device(
 // 2. Host read the results from eltwise binary
 // 3. Second program runs matmul, using results from step 2 as input activation
 //////////////////////////////////////////////////////////////////////////////////////////
-TEST_F(MeshDeviceSingleCardFixture, MultiplePrograms) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+TEST_F(UnitMeshFixture, MultiplePrograms) {
     CoreCoord core = {0, 0};
     uint32_t single_tile_size = 2 * 1024;
     uint32_t num_tiles = 1;
 
     uint32_t dram_buffer_size = single_tile_size * num_tiles;
-    InterleavedBufferConfig dram_config{
-        .device = dev, .size = dram_buffer_size, .page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+    distributed::DeviceLocalBufferConfig dram_config{.page_size = dram_buffer_size, .buffer_type = BufferType::DRAM};
+    distributed::ReplicatedBufferConfig buffer_config{.size = dram_buffer_size};
 
-    auto src0_dram_buffer = CreateBuffer(dram_config);
-    auto src1_dram_buffer = CreateBuffer(dram_config);
-    auto dst_dram_buffer = CreateBuffer(dram_config);
+    auto src0_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &this->device());
+    auto src1_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &this->device());
+    auto dst_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &this->device());
 
-    auto [program1, reader1_kernel_id, writer1_kernel_id] = setup_program_one(dev, core, single_tile_size);
-    auto [program2, reader2_kernel_id, writer2_kernel_id] = setup_program_two(dev, core, single_tile_size);
+    auto [program1, reader1_kernel_id, writer1_kernel_id] = setup_program_one(core, single_tile_size);
+    auto [program2, reader2_kernel_id, writer2_kernel_id] = setup_program_two(core, single_tile_size);
 
     // Execute Program One
     SHAPE shape = {1, 1, 32, 32};
@@ -199,17 +195,16 @@ TEST_F(MeshDeviceSingleCardFixture, MultiplePrograms) {
     auto src0_activations_tile_layout =
         convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(src0_tensor.get_values()));
     auto src0_activations = pack_bfloat16_vec_into_uint32_vec(src0_activations_tile_layout);
-    detail::WriteToBuffer(src0_dram_buffer, src0_activations);
+    slow_dispatch::WriteToBuffer(*src0_dram_buffer, src0_activations);
 
     tt::deprecated::Tensor<bfloat16> src1_tensor = tt::deprecated::initialize_tensor<bfloat16>(
         shape, tt::deprecated::Initialize::ZEROS, 0, 100, std::chrono::system_clock::now().time_since_epoch().count());
     auto src1_activations_tile_layout =
         convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(src1_tensor.get_values()));
     auto src1_activations = pack_bfloat16_vec_into_uint32_vec(src1_activations_tile_layout);
-    detail::WriteToBuffer(src1_dram_buffer, src1_activations);
+    slow_dispatch::WriteToBuffer(*src1_dram_buffer, src1_activations);
 
     write_program_runtime_args_to_device(
-        dev,
         program1,
         reader1_kernel_id,
         writer1_kernel_id,
@@ -219,10 +214,10 @@ TEST_F(MeshDeviceSingleCardFixture, MultiplePrograms) {
         *src1_dram_buffer,
         *dst_dram_buffer);
 
-    detail::LaunchProgram(dev, program1);
+    slow_dispatch::LaunchProgram(this->device(), program1, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> intermediate_result_vec;
-    detail::ReadFromBuffer(dst_dram_buffer, intermediate_result_vec);
+    slow_dispatch::ReadFromBuffer(*dst_dram_buffer, intermediate_result_vec);
 
     // Validate Intermediate Result
     EXPECT_EQ(src0_activations, intermediate_result_vec) << "Eltwise binary did not produce expected result";
@@ -231,10 +226,9 @@ TEST_F(MeshDeviceSingleCardFixture, MultiplePrograms) {
     auto identity = create_identity_matrix(32, 32, 32);
     auto weights_tile_layout = convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(identity));
     auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-    detail::WriteToBuffer(src1_dram_buffer, weights);
+    slow_dispatch::WriteToBuffer(*src1_dram_buffer, weights);
 
     write_program_runtime_args_to_device(
-        dev,
         program2,
         reader2_kernel_id,
         writer2_kernel_id,
@@ -244,10 +238,10 @@ TEST_F(MeshDeviceSingleCardFixture, MultiplePrograms) {
         *src1_dram_buffer,
         *dst_dram_buffer);
 
-    detail::LaunchProgram(dev, program2);
+    slow_dispatch::LaunchProgram(this->device(), program2, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_dram_buffer, result_vec);
+    slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);
 
     // Validate - matmul with identity should give same result
     EXPECT_EQ(intermediate_result_vec, result_vec);

--- a/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
+++ b/tests/tt_metal/tt_metal/test_stress_noc_mcast.cpp
@@ -36,6 +36,7 @@
 #include "impl/context/metal_context.hpp"
 #include <umd/device/types/xy_pair.hpp>
 #include <llrt/tt_cluster.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -50,10 +51,8 @@ const uint32_t N_RANDS = 512;
 }  // namespace
 
 // Disabled because this test can hang the NoC due to hardware issues.
-// Uses detail::LaunchProgram which requires slow dispatch mode
-TEST_F(MeshDeviceSingleCardFixture, DISABLED_StressNocMcast) {
-    IDevice* dev = devices_[0]->get_devices()[0];
-
+// Uses slow_dispatch::LaunchProgram which requires slow dispatch mode
+TEST_F(UnitMeshFixture, DISABLED_StressNocMcast) {
     // Use default test parameters
     uint32_t time_secs = DEFAULT_SECONDS;
     uint32_t tlx = 0;
@@ -74,13 +73,13 @@ TEST_F(MeshDeviceSingleCardFixture, DISABLED_StressNocMcast) {
 
     CoreRange workers_logical({tlx, tly}, {tlx + width - 1, tly + height - 1});
     CoreCoord mcast_logical(mcast_x, mcast_y);
-    CoreCoord tl_core = dev->worker_core_from_logical_core({tlx, tly});
+    CoreCoord tl_core = this->device().worker_core_from_logical_core({tlx, tly});
 
-    CoreCoord mcast_end = dev->worker_core_from_logical_core(workers_logical.end_coord);
+    CoreCoord mcast_end = this->device().worker_core_from_logical_core(workers_logical.end_coord);
     bool virtualization_enabled = tt::tt_metal::MetalContext::instance().hal().is_coordinate_virtualization_enabled();
     uint32_t num_dests = workers_logical.size();
     CoreCoord virtual_offset = virtualization_enabled
-                                   ? dev->worker_core_from_logical_core({0, 0})
+                                   ? this->device().worker_core_from_logical_core({0, 0})
                                    : CoreCoord(0, 0);  // In this case pass physical coordinates as runtime args
 
     std::vector<uint32_t> compile_args = {
@@ -97,8 +96,8 @@ TEST_F(MeshDeviceSingleCardFixture, DISABLED_StressNocMcast) {
         virtual_offset.y,
         N_RANDS,
         rnd_delay,
-        dev->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1),
-        dev->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1),
+        this->device().allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1),
+        this->device().allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1),
     };
 
     KernelHandle ucast_kernel = tt_metal::CreateKernel(
@@ -115,14 +114,14 @@ TEST_F(MeshDeviceSingleCardFixture, DISABLED_StressNocMcast) {
         std::vector<uint32_t> runtime_args;
         // Not particularly random since all cores are getting the same data
         // N_RANDS in bytes
-        CoreCoord grid_size = dev->logical_grid_size();
+        CoreCoord grid_size = this->device().logical_grid_size();
         for (int i = 0; i < N_RANDS / sizeof(uint32_t); i++) {
             uint32_t rnd = 0;
             for (int j = 0; j < sizeof(uint32_t); j++) {
                 uint32_t x = rand() % grid_size.x;
                 uint32_t y = rand() % grid_size.y;
                 if (!virtualization_enabled) {
-                    CoreCoord physical_coord = dev->worker_core_from_logical_core(CoreCoord(x, y));
+                    CoreCoord physical_coord = this->device().worker_core_from_logical_core(CoreCoord(x, y));
                     x = physical_coord.x;
                     y = physical_coord.y;
                 }
@@ -148,5 +147,5 @@ TEST_F(MeshDeviceSingleCardFixture, DISABLED_StressNocMcast) {
     }
     log_info(LogTest, "Running for {} seconds", time_secs);
 
-    tt::tt_metal::detail::LaunchProgram(dev, program, true);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 }

--- a/tests/tt_metal/tt_metal/test_transpose_hc.cpp
+++ b/tests/tt_metal/tt_metal/test_transpose_hc.cpp
@@ -14,18 +14,17 @@
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
-#include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/tilize_utils.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include "test_gold_impls.hpp"
 #include "impl/data_format/bfloat16_utils.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
 
-TEST_F(MeshDeviceSingleCardFixture, TransposeHC) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+TEST_F(UnitMeshFixture, TransposeHC) {
     Program program = CreateProgram();
     constexpr bool multibank = true;
 
@@ -47,14 +46,14 @@ TEST_F(MeshDeviceSingleCardFixture, TransposeHC) {
     const uint32_t dram_buffer_bytes = single_tile_bytes * num_tensor_tiles;
     const uint32_t page_size = (!multibank) ? dram_buffer_bytes : single_tile_bytes;
 
-    const InterleavedBufferConfig dram_config = {
-        .device = dev, .size = dram_buffer_bytes, .page_size = page_size, .buffer_type = BufferType::DRAM};
+    distributed::DeviceLocalBufferConfig dram_config{.page_size = page_size, .buffer_type = BufferType::DRAM};
+    distributed::ReplicatedBufferConfig buffer_config{.size = dram_buffer_bytes};
 
-    auto src0_dram_buffer = CreateBuffer(dram_config);
+    auto src0_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &this->device());
     const uint32_t dram_buffer_src0_addr = src0_dram_buffer->address();
-    auto dst_dram_buffer = CreateBuffer(dram_config);
+    auto dst_dram_buffer = distributed::MeshBuffer::create(buffer_config, dram_config, &this->device());
     const uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
-    const uint32_t alignment = dst_dram_buffer->alignment();
+    const uint32_t alignment = dst_dram_buffer->get_reference_buffer()->alignment();
     const bool misaligned = alignment > subtile_line_bytes;
 
     const uint32_t src0_cb_index = 0U;
@@ -120,15 +119,15 @@ TEST_F(MeshDeviceSingleCardFixture, TransposeHC) {
     // Execute
     std::vector<uint32_t> src0_vec = create_random_vector_of_bfloat16(dram_buffer_bytes, 100U, 0x1234);
     auto src_4f_16 = u16_from_u32_vector(src0_vec);
-    detail::WriteToBuffer(src0_dram_buffer, src0_vec);
+    slow_dispatch::WriteToBuffer(*src0_dram_buffer, src0_vec);
 
     SetRuntimeArgs(program, reader_kernel, core, {dram_buffer_src0_addr, 0U, W, H, C, HW, N, CHW});
     SetRuntimeArgs(program, unary_writer_kernel, core, {dram_buffer_dst_addr, 0U, num_tensor_tiles});
 
-    detail::LaunchProgram(dev, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
 
     std::vector<uint32_t> result_vec;
-    detail::ReadFromBuffer(dst_dram_buffer, result_vec);
+    slow_dispatch::ReadFromBuffer(*dst_dram_buffer, result_vec);
 
     // Validation
     auto comparison_function = [](float a, float b) {

--- a/tests/tt_metal/tt_metal/test_unaligned_read_write_core.cpp
+++ b/tests/tt_metal/tt_metal/test_unaligned_read_write_core.cpp
@@ -31,6 +31,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/span.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // This test verifies that the slow dispatch path can perform device reads and writes when the page size is not a
@@ -40,8 +41,7 @@ using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;
 
-TEST_F(MeshDeviceSingleCardFixture, UnalignedReadWriteCore) {
-    IDevice* dev = devices_[0]->get_devices()[0];
+TEST_F(UnitMeshFixture, UnalignedReadWriteCore) {
     bool pass = true;
 
     try {
@@ -54,20 +54,18 @@ TEST_F(MeshDeviceSingleCardFixture, UnalignedReadWriteCore) {
             (single_tile_size * num_tiles) +
             2; /*** Non 4-byte aligned buffer size for BFLOAT16s. This is the point of this unaligned test. ***/
 
-        tt_metal::InterleavedBufferConfig dram_interleaved_buffer_config{
-            .device = dev,
-            .size = dram_buffer_size,
-            .page_size = dram_buffer_size,
-            .buffer_type = tt_metal::BufferType::DRAM};
-        auto device_dram_interleaved_buffer = CreateBuffer(dram_interleaved_buffer_config);
+        auto device_dram_interleaved_buffer = distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = dram_buffer_size},
+            {.page_size = dram_buffer_size, .buffer_type = BufferType::DRAM},
+            &this->device());
 
         std::vector<uint8_t> src_vec_dram_interleaved_case(dram_buffer_size);
         for (auto& v : src_vec_dram_interleaved_case) {
             v = static_cast<uint8_t>(std::rand() % 256);
         }
-        tt_metal::detail::WriteToBuffer(device_dram_interleaved_buffer, src_vec_dram_interleaved_case);
+        slow_dispatch::WriteToBuffer(*device_dram_interleaved_buffer, src_vec_dram_interleaved_case);
         std::vector<uint8_t> result_vec_dram_interleaved_case;
-        tt_metal::detail::ReadFromBuffer(device_dram_interleaved_buffer, result_vec_dram_interleaved_case);
+        slow_dispatch::ReadFromBuffer(*device_dram_interleaved_buffer, result_vec_dram_interleaved_case);
         pass &= (src_vec_dram_interleaved_case == result_vec_dram_interleaved_case);
         TT_FATAL(pass, "Error");
         log_info(LogTest, "Passed Non-4-byte-aligned Read Write DRAM Interleaved Buffer Test");
@@ -82,23 +80,22 @@ TEST_F(MeshDeviceSingleCardFixture, UnalignedReadWriteCore) {
             tt_metal::ShardOrientation::ROW_MAJOR,
             {1, dram_buffer_size / sizeof(uint16_t)},
             {1, 1});
-        auto device_dram_sharded_buffer = CreateBuffer(tt_metal::ShardedBufferConfig{
-            .device = dev,
-            .size = dram_buffer_size,
-            .page_size = dram_buffer_size,
-            .buffer_type = tt_metal::BufferType::DRAM,
-            .buffer_layout = tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
-            .shard_parameters = shard_spec});
+        auto device_dram_sharded_buffer = distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = dram_buffer_size},
+            {.page_size = dram_buffer_size,
+             .buffer_type = BufferType::DRAM,
+             .sharding_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED)},
+            &this->device());
 
         std::vector<uint8_t> src_vec_dram_sharded_case(dram_buffer_size);
         for (auto& v : src_vec_dram_sharded_case) {
             v = static_cast<uint8_t>(std::rand() % 256);
         }
 
-        tt_metal::detail::WriteToBuffer(device_dram_sharded_buffer, src_vec_dram_sharded_case);
+        slow_dispatch::WriteToBuffer(*device_dram_sharded_buffer, src_vec_dram_sharded_case);
 
         std::vector<uint8_t> result_vec_dram_sharded_case;
-        tt_metal::detail::ReadFromBuffer(device_dram_sharded_buffer, result_vec_dram_sharded_case);
+        slow_dispatch::ReadFromBuffer(*device_dram_sharded_buffer, result_vec_dram_sharded_case);
         pass &= (src_vec_dram_sharded_case == result_vec_dram_sharded_case);
         TT_FATAL(pass, "Error");
         log_info(LogTest, "Passed Non-4-byte-aligned Read Write DRAM Sharded Buffer Test");
@@ -109,22 +106,20 @@ TEST_F(MeshDeviceSingleCardFixture, UnalignedReadWriteCore) {
         uint32_t l1_buffer_size =
             (single_tile_size * 4) +
             2; /*** Non 4-byte aligned buffer size for BFLOAT16s. This is the point of this unaligned test. ***/
-        tt_metal::InterleavedBufferConfig l1_interleaved_buffer_config{
-            .device = dev,
-            .size = l1_buffer_size,
-            .page_size = l1_buffer_size,
-            .buffer_type = tt_metal::BufferType::L1};
-        auto device_l1_interleaved_buffer = CreateBuffer(l1_interleaved_buffer_config);
+        auto device_l1_interleaved_buffer = distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = l1_buffer_size},
+            {.page_size = l1_buffer_size, .buffer_type = BufferType::L1},
+            &this->device());
 
         std::vector<uint8_t> src_vec_l1_interleaved_case(l1_buffer_size);
         for (auto& v : src_vec_l1_interleaved_case) {
             v = static_cast<uint8_t>(std::rand() % 256);
         }
 
-        tt_metal::detail::WriteToBuffer(device_l1_interleaved_buffer, src_vec_l1_interleaved_case);
+        slow_dispatch::WriteToBuffer(*device_l1_interleaved_buffer, src_vec_l1_interleaved_case);
 
         std::vector<uint8_t> result_vec_l1_interleaved_case;
-        tt_metal::detail::ReadFromBuffer(device_l1_interleaved_buffer, result_vec_l1_interleaved_case);
+        slow_dispatch::ReadFromBuffer(*device_l1_interleaved_buffer, result_vec_l1_interleaved_case);
         pass &= (src_vec_l1_interleaved_case == result_vec_l1_interleaved_case);
         TT_FATAL(pass, "Error");
         log_info(LogTest, "Passed Non-4-byte-aligned Read Write L1 Interleaved Buffer Test");
@@ -139,23 +134,22 @@ TEST_F(MeshDeviceSingleCardFixture, UnalignedReadWriteCore) {
             tt_metal::ShardOrientation::ROW_MAJOR,
             {1, l1_buffer_size / sizeof(uint16_t)},
             {1, 1});
-        auto device_l1_sharded_buffer = CreateBuffer(tt_metal::ShardedBufferConfig{
-            .device = dev,
-            .size = l1_buffer_size,
-            .page_size = l1_buffer_size,
-            .buffer_type = tt_metal::BufferType::L1,
-            .buffer_layout = tt_metal::TensorMemoryLayout::HEIGHT_SHARDED,
-            .shard_parameters = l1_shard_spec});
+        auto device_l1_sharded_buffer = distributed::MeshBuffer::create(
+            distributed::ReplicatedBufferConfig{.size = l1_buffer_size},
+            {.page_size = l1_buffer_size,
+             .buffer_type = BufferType::L1,
+             .sharding_args = BufferShardingArgs(l1_shard_spec, TensorMemoryLayout::HEIGHT_SHARDED)},
+            &this->device());
 
         std::vector<uint8_t> src_vec_l1_sharded_case(l1_buffer_size);
         for (auto& v : src_vec_l1_sharded_case) {
             v = static_cast<uint8_t>(std::rand() % 256);
         }
 
-        tt_metal::detail::WriteToBuffer(device_l1_sharded_buffer, src_vec_l1_sharded_case);
+        slow_dispatch::WriteToBuffer(*device_l1_sharded_buffer, src_vec_l1_sharded_case);
 
         std::vector<uint8_t> result_vec_l1_sharded_case;
-        tt_metal::detail::ReadFromBuffer(device_l1_sharded_buffer, result_vec_l1_sharded_case);
+        slow_dispatch::ReadFromBuffer(*device_l1_sharded_buffer, result_vec_l1_sharded_case);
         pass &= (src_vec_l1_sharded_case == result_vec_l1_sharded_case);
         TT_FATAL(pass, "Error");
         log_info(LogTest, "Passed Non-4-byte-aligned Read Write L1 Sharded Buffer Test");


### PR DESCRIPTION
### PR Category
Cleanup, Test Only

### Summary

Advances https://github.com/tenstorrent/tt-metal/issues/51835

Legacy API usage related to `IDevice` and `Buffer` is replaced with mesh-based alternatives in single-device tests that are based on MeshDeviceSingleCardFixture.
These tests now use UnitMeshFixture instead.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov-MeshDeviceSingleCardFixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov-MeshDeviceSingleCardFixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov-MeshDeviceSingleCardFixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov-MeshDeviceSingleCardFixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=obacherikov-MeshDeviceSingleCardFixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:obacherikov-MeshDeviceSingleCardFixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov-MeshDeviceSingleCardFixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov-MeshDeviceSingleCardFixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov-MeshDeviceSingleCardFixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov-MeshDeviceSingleCardFixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov-MeshDeviceSingleCardFixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov-MeshDeviceSingleCardFixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov-MeshDeviceSingleCardFixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov-MeshDeviceSingleCardFixture)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov-MeshDeviceSingleCardFixture)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov-MeshDeviceSingleCardFixture)