### PR TITLE
ci: use system SFPI toolchain in CI-internal builds to avoid redundant network downloads

### DIFF
--- a/.github/workflows/basic.yaml
+++ b/.github/workflows/basic.yaml
@@ -118,7 +118,12 @@ jobs:
         timeout-minutes: 10
         run: |
           # Ideally only ${{ inputs.product }}-validation, but APT doesn't resolve dependencies from files on disk without being told about them.
-          apt install -y ./pkgs/tt-metalium_*.deb ./pkgs/tt-metalium-jit_*.deb ./pkgs/tt-metalium-validation_*.deb ./pkgs/${{ inputs.product }}_*.deb ./pkgs/${{ inputs.product }}-validation_*.deb
+          # tt-metalium-jit is optional: TT_USE_SYSTEM_SFPI builds don't produce it, since the
+          # dev/ci-test containers this workflow runs in already have /opt/tenstorrent/sfpi for
+          # the JIT-build runtime fallback (see tt_metal/jit_build/build.cpp).
+          shopt -s nullglob
+          pkgs=(./pkgs/tt-metalium_*.deb ./pkgs/tt-metalium-jit_*.deb ./pkgs/tt-metalium-validation_*.deb ./pkgs/${{ inputs.product }}_*.deb ./pkgs/${{ inputs.product }}-validation_*.deb)
+          apt install -y "${pkgs[@]}"
 
       - name: Set up env vars for watcher
         if: ${{ inputs.enable-watcher == true }}

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -648,7 +648,6 @@ jobs:
             ${args_fixme}
             "--enable-ccache"
             "--configure-only"
-            "--use-system-sfpi"
           )
 
           echo "Build tracy: ${{ inputs.tracy }}"

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -48,6 +48,11 @@ on:
         type: boolean
         default: true
         description: "Make resulting debian packages available in the workflow"
+      use-system-sfpi:
+        required: false
+        type: boolean
+        default: false
+        description: "Use the SFPI toolchain already staged in the docker image instead of downloading it. Only safe for internal CI consumption: skips producing the tt-metalium-jit package, so leave false for release/publish builds whose packages need to be self-contained."
       build-ttnn-import-artifact:
         required: false
         type: boolean
@@ -222,6 +227,11 @@ on:
         type: boolean
         default: false
         description: "Package the wheel from the compiled tree (no second compile) instead of the manylinux build-wheel job; in-family CI consumers only"
+      use-system-sfpi:
+        required: false
+        type: boolean
+        default: false
+        description: "Use the SFPI toolchain already staged in the docker image instead of downloading it. Only safe for internal CI consumption: skips producing the tt-metalium-jit package, so leave false for release/publish builds whose packages need to be self-contained."
       architecture:
         required: false
         type: string
@@ -648,8 +658,12 @@ jobs:
             ${args_fixme}
             "--enable-ccache"
             "--configure-only"
-            "--use-system-sfpi"
           )
+
+          echo "Use system SFPI: ${{ inputs.use-system-sfpi }}"
+          if [ "${{ inputs.use-system-sfpi }}" = "true" ]; then
+            build_args+=("--use-system-sfpi")
+          fi
 
           echo "Build tracy: ${{ inputs.tracy }}"
           if [ "${{ inputs.tracy }}" = "false" ]; then

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -648,6 +648,7 @@ jobs:
             ${args_fixme}
             "--enable-ccache"
             "--configure-only"
+            "--use-system-sfpi"
           )
 
           echo "Build tracy: ${{ inputs.tracy }}"

--- a/.github/workflows/clang-tidy-reusable.yaml
+++ b/.github/workflows/clang-tidy-reusable.yaml
@@ -279,7 +279,8 @@ jobs:
           # compile edge; the build preset's -k0 keeps going so all fixes still export.
           cmake --preset clang-tidy-fix-parallel \
             -DCMAKE_CXX_CLANG_TIDY="$(pwd)/cmake/clang-tidy-export-fixes-wrapper.sh;$(pwd)/.build/clang-tidy/fixes;--warnings-as-errors=*" \
-            -DCMAKE_C_CLANG_TIDY="$(pwd)/cmake/clang-tidy-export-fixes-wrapper.sh;$(pwd)/.build/clang-tidy/fixes;--warnings-as-errors=*"
+            -DCMAKE_C_CLANG_TIDY="$(pwd)/cmake/clang-tidy-export-fixes-wrapper.sh;$(pwd)/.build/clang-tidy/fixes;--warnings-as-errors=*" \
+            -DTT_USE_SYSTEM_SFPI=ON
 
       - name: Pack CPM cache
         if: steps.cpm-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -139,6 +139,9 @@ jobs:
       platform: "Ubuntu 22.04"
       enable-lto: false
       skip-tt-train: false
+      # CI-internal only: consumers of these packages all run in docker images that
+      # already stage SFPI, so skip the redundant download. Never set for release builds.
+      use-system-sfpi: true
       ci-build-docker-image: ${{ needs.docker-images.outputs.ubuntu-2204-ci-build-tag }}
       ci-test-docker-image: ${{ needs.docker-images.outputs.ubuntu-2204-ci-test-tag }}
       dev-docker-image: ${{ needs.docker-images.outputs.ubuntu-2204-dev-tag }}
@@ -168,6 +171,9 @@ jobs:
       toolchain: cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake
       skip-tt-train: false
       publish-artifact: false
+      # CI-internal only: consumers of these packages all run in docker images that
+      # already stage SFPI, so skip the redundant download. Never set for release builds.
+      use-system-sfpi: true
       ci-build-docker-image: ${{ needs.docker-images.outputs.ubuntu-2404-ci-build-tag }}
       ci-test-docker-image: ${{ needs.docker-images.outputs.ubuntu-2404-ci-test-tag }}
       dev-docker-image: ${{ needs.docker-images.outputs.ubuntu-2404-dev-tag }}
@@ -197,6 +203,9 @@ jobs:
       toolchain: cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake
       skip-tt-train: false
       publish-artifact: false
+      # CI-internal only: consumers of these packages all run in docker images that
+      # already stage SFPI, so skip the redundant download. Never set for release builds.
+      use-system-sfpi: true
       ci-build-docker-image: ${{ needs.docker-images.outputs.ubuntu-2404-ci-build-tag }}
       ci-test-docker-image: ${{ needs.docker-images.outputs.ubuntu-2404-ci-test-tag }}
       dev-docker-image: ${{ needs.docker-images.outputs.ubuntu-2404-dev-tag }}

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -144,6 +144,9 @@ jobs:
       publish-package: true
       tracy: false
       skip-tt-train: false
+      # CI-internal only: consumers of these packages all run in docker images that
+      # already stage SFPI, so skip the redundant download. Never set for release builds.
+      use-system-sfpi: true
       # Treeless clone: skip the trees/blobs that dominate the tag fetch, but keep commits + tags
       # so git describe still yields a real version. Depth stays at the default.
       checkout-filter: tree:0

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -77,6 +77,9 @@ jobs:
       fetch-depth: 0
       skip-tt-train: false
       enable-lto: false
+      # Released packages must be self-contained (bundle the SFPI JIT toolchain) since
+      # they're installed on machines with no /opt/tenstorrent/sfpi to fall back to.
+      use-system-sfpi: false
 
   build-artifact-tracy:
     name: "Build artifact with tracy (for testing)"
@@ -94,6 +97,9 @@ jobs:
       fetch-depth: 0
       skip-tt-train: false
       enable-lto: false
+      # Released packages must be self-contained (bundle the SFPI JIT toolchain) since
+      # they're installed on machines with no /opt/tenstorrent/sfpi to fall back to.
+      use-system-sfpi: false
 
   build-artifact-release:
     name: "Build artifact for release (without tracy)"
@@ -111,6 +117,9 @@ jobs:
       fetch-depth: 0
       skip-tt-train: false
       enable-lto: false
+      # Released packages must be self-contained (bundle the SFPI JIT toolchain) since
+      # they're installed on machines with no /opt/tenstorrent/sfpi to fall back to.
+      use-system-sfpi: false
 
   determine-test-skus:
     runs-on: ubuntu-slim

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -200,6 +200,9 @@ jobs:
       platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
       skip-tt-train: false
       enable-lto: ${{ inputs.enable-lto || false }}
+      # CI-internal only: consumers of these packages all run in docker images that
+      # already stage SFPI, so skip the redundant download. Never set for release builds.
+      use-system-sfpi: true
       ref: ${{ inputs.ref || github.sha }}
       checkout-filter: tree:0
 

--- a/.github/workflows/sdk-examples.yaml
+++ b/.github/workflows/sdk-examples.yaml
@@ -123,7 +123,12 @@ jobs:
           apt update
           DEBIAN_FRONTEND=noninteractive TZ=UTC apt install -y -q libprotobuf-dev
 
-          apt install -y ./pkgs/tt-metalium_*.deb ./pkgs/tt-metalium-jit_*.deb ./pkgs/tt-metalium-dev_*.deb
+          # tt-metalium-jit is optional: TT_USE_SYSTEM_SFPI builds don't produce it, since this
+          # container already has /opt/tenstorrent/sfpi for the JIT-build runtime fallback
+          # (see tt_metal/jit_build/build.cpp).
+          shopt -s nullglob
+          pkgs=(./pkgs/tt-metalium_*.deb ./pkgs/tt-metalium-jit_*.deb ./pkgs/tt-metalium-dev_*.deb)
+          apt install -y "${pkgs[@]}"
 
           if [ "${{ inputs.product }}" == "tt-metalium" ]; then
             apt install -y ./pkgs/tt-metalium-examples_*.deb

--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -168,7 +168,12 @@ jobs:
         timeout-minutes: 10
         run: |
           # Ideally only ${{ inputs.product }}-validation, but APT doesn't resolve dependencies from files on disk without being told about them.
-          apt install -y ./pkgs/tt-metalium_*.deb ./pkgs/tt-metalium-jit_*.deb ./pkgs/tt-metalium-validation_*.deb ./pkgs/${{ inputs.product }}_*.deb ./pkgs/${{ inputs.product }}-validation_*.deb
+          # tt-metalium-jit is optional: TT_USE_SYSTEM_SFPI builds don't produce it, since this
+          # container already has /opt/tenstorrent/sfpi for the JIT-build runtime fallback
+          # (see tt_metal/jit_build/build.cpp).
+          shopt -s nullglob
+          pkgs=(./pkgs/tt-metalium_*.deb ./pkgs/tt-metalium-jit_*.deb ./pkgs/tt-metalium-validation_*.deb ./pkgs/${{ inputs.product }}_*.deb ./pkgs/${{ inputs.product }}-validation_*.deb)
+          apt install -y "${pkgs[@]}"
 
       - name: Prepare coverage directory
         run: |

--- a/.github/workflows/ttsim-sanity-tests-impl.yaml
+++ b/.github/workflows/ttsim-sanity-tests-impl.yaml
@@ -134,7 +134,12 @@ jobs:
         run: |
           set -euo pipefail
           apt update
-          apt install -y ./pkgs/tt-metalium_*.deb ./pkgs/tt-metalium-jit_*.deb ./pkgs/tt-metalium-dev_*.deb ./pkgs/tt-metalium-examples_*.deb
+          # tt-metalium-jit is optional: TT_USE_SYSTEM_SFPI builds don't produce it, since this
+          # container already has /opt/tenstorrent/sfpi for the JIT-build runtime fallback
+          # (see tt_metal/jit_build/build.cpp).
+          shopt -s nullglob
+          pkgs=(./pkgs/tt-metalium_*.deb ./pkgs/tt-metalium-jit_*.deb ./pkgs/tt-metalium-dev_*.deb ./pkgs/tt-metalium-examples_*.deb)
+          apt install -y "${pkgs[@]}"
 
       - name: ⬇️  Setup TTSim
         uses: ./.github/actions/setup-ttsim

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -51,6 +51,7 @@ show_help() {
     echo "  --cpm-source-cache               Set path to CPM Source Cache."
     echo "  --cpm-use-local-packages         Attempt to use locally installed dependencies."
     echo "  --ttnn-shared-sub-libs           Use shared libraries for ttnn."
+    echo "  --use-system-sfpi                Use the SFPI toolchain already installed on the system/image instead of downloading it."
     echo "  --toolchain-path                 Set path to CMake toolchain file."
     echo "  --configure-only                 Only configure the project, do not build."
     echo "  --without-distributed            Disable distributed compute support (OpenMPI dependency). Enabled by default."
@@ -93,6 +94,7 @@ cxx_compiler_path=""
 cpm_source_cache=""
 c_compiler_path=""
 ttnn_shared_sub_libs="OFF"
+use_system_sfpi="OFF"
 toolchain_path="cmake/x86_64-linux-clang-20-libstdcpp-toolchain.cmake"
 
 
@@ -137,6 +139,7 @@ cpm-source-cache:
 cpm-use-local-packages
 c-compiler-path:
 ttnn-shared-sub-libs
+use-system-sfpi
 toolchain-path:
 configure-only
 without-distributed
@@ -201,6 +204,8 @@ while true; do
             build_all="ON";;
         --ttnn-shared-sub-libs)
             ttnn_shared_sub_libs="ON";;
+        --use-system-sfpi)
+            use_system_sfpi="ON";;
         --configure-only)
             configure_only="ON";;
         --without-python-bindings)
@@ -372,6 +377,10 @@ fi
 
 if [ "$ttnn_shared_sub_libs" = "ON" ]; then
     cmake_args+=("-DENABLE_TTNN_SHARED_SUBLIBS=ON")
+fi
+
+if [ "$use_system_sfpi" = "ON" ]; then
+    cmake_args+=("-DTT_USE_SYSTEM_SFPI=ON")
 fi
 
 if [ "$build_tests" = "ON" ]; then

--- a/dockerfile/Dockerfile.basic-dev
+++ b/dockerfile/Dockerfile.basic-dev
@@ -137,8 +137,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# SFPI is already staged in the base image (inherited from the base stage).
-
 # Set up virtual environment using uv
 ENV PYTHON_ENV_DIR=/opt/venv
 

--- a/dockerfile/Dockerfile.basic-dev
+++ b/dockerfile/Dockerfile.basic-dev
@@ -59,21 +59,21 @@ ENV CPATH=${OMPI_PREFIX}/include
 ENV PKG_CONFIG_PATH=${OMPI_PREFIX}/lib/pkgconfig
 
 # Copy uv from official distroless image
-COPY --from=uv-layer /uv /uvx /usr/local/bin/
+COPY --from=uv-layer --link /uv /uvx /usr/local/bin/
 
 # Copy cmake from pre-built tool image
-COPY --from=cmake-layer /install/ /usr/local/
+COPY --from=cmake-layer --link /install/ /usr/local/
 
 # Copy OpenMPI from pre-built tool image
-COPY --from=openmpi-layer /install/ /opt/
+COPY --from=openmpi-layer --link /install/ /opt/
 
 # Copy ccache from pre-built tool image
-COPY --from=ccache-layer /install/ /usr/local/
+COPY --from=ccache-layer --link /install/ /usr/local/
 
-# Copy SFPI from pre-built tool image
-RUN --mount=from=sfpi-layer,source=/install,target=/sfpi-staging \
-    mkdir -p /opt/tenstorrent && \
-    cp -a /sfpi-staging/opt/tenstorrent/sfpi /opt/tenstorrent/
+# Copy SFPI from pre-built tool image.
+# COPY --link makes this an independent merge layer whose blob depends only on
+# the sfpi content, not on upstream base-stage churn (decouples registry cache).
+COPY --from=sfpi-layer --link /install/opt/tenstorrent/sfpi /opt/tenstorrent/sfpi
 
 RUN test -x /usr/local/bin/cmake || { echo "ERROR: cmake not found in cmake-layer" >&2; exit 1; } && \
     test -d "${OMPI_PREFIX}/bin" || { echo "ERROR: OpenMPI not found in openmpi-layer" >&2; exit 1; } && \

--- a/dockerfile/Dockerfile.basic-dev
+++ b/dockerfile/Dockerfile.basic-dev
@@ -70,9 +70,15 @@ COPY --from=openmpi-layer /install/ /opt/
 # Copy ccache from pre-built tool image
 COPY --from=ccache-layer /install/ /usr/local/
 
+# Copy SFPI from pre-built tool image
+RUN --mount=from=sfpi-layer,source=/install,target=/sfpi-staging \
+    mkdir -p /opt/tenstorrent && \
+    cp -a /sfpi-staging/opt/tenstorrent/sfpi /opt/tenstorrent/
+
 RUN test -x /usr/local/bin/cmake || { echo "ERROR: cmake not found in cmake-layer" >&2; exit 1; } && \
     test -d "${OMPI_PREFIX}/bin" || { echo "ERROR: OpenMPI not found in openmpi-layer" >&2; exit 1; } && \
-    test -x /usr/local/bin/ccache || { echo "ERROR: ccache not found in ccache-layer" >&2; exit 1; }
+    test -x /usr/local/bin/ccache || { echo "ERROR: ccache not found in ccache-layer" >&2; exit 1; } && \
+    test -d /opt/tenstorrent/sfpi || { echo "ERROR: sfpi not found in sfpi-layer" >&2; exit 1; }
 
 # Install basic tools to build
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -131,11 +137,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Copy SFPI from pre-built tool image
-RUN --mount=from=sfpi-layer,source=/install,target=/sfpi-staging \
-    mkdir -p /opt/tenstorrent && \
-    cp -a /sfpi-staging/opt/tenstorrent/sfpi /opt/tenstorrent/
-RUN test -d /opt/tenstorrent/sfpi || { echo "ERROR: sfpi not found in sfpi-layer" >&2; exit 1; }
+# SFPI is already staged in the base image (inherited from the base stage).
 
 # Set up virtual environment using uv
 ENV PYTHON_ENV_DIR=/opt/venv


### PR DESCRIPTION
## Summary

CMake only skips downloading the SFPI toolchain from `github.com/tenstorrent/sfpi/releases` (via `FetchContent`) when `-DTT_USE_SYSTEM_SFPI=ON` is passed, in which case it uses the copy already staged at `/opt/tenstorrent/sfpi` in the docker image instead. Before this PR, no CI workflow set that flag (only `setup.py`'s pip/wheel path did), so every CMake-driven CI build silently re-downloaded the identical, version-pinned SFPI tarball on every run. That download flaking on a proxy blip is what originally broke [run 31637228026](https://github.com/tenstorrent/tt-metal/actions/runs/31637228026/job/94251823873?pr=52977) (PR #52977).

This PR wires `-DTT_USE_SYSTEM_SFPI=ON` into CI-internal builds only, and fixes the fallout that surfaced along the way.

## What changed

**Core plumbing:**
- `build_metal.sh`: new `--use-system-sfpi` flag (mirrors the existing `--ttnn-shared-sub-libs` pattern).
- `clang-tidy-reusable.yaml`: passes `-DTT_USE_SYSTEM_SFPI=ON` directly to its `cmake --preset` call (never packages, so no downstream impact).
- `build-artifact.yaml`: new opt-in `use-system-sfpi` `workflow_call`/`workflow_dispatch` boolean input (**default `false`**, preserving the original download behavior for every caller unless explicitly opted in — this workflow is called from ~70 other workflows, so a global default flip was not safe).

**Opted in** (CI-internal only — packages only ever consumed inside docker images that stage SFPI):
- `pr-gate.yaml`: `asan-build`
- `merge-gate.yaml`: `build`, `build-tsan`, `build-asan`
- `sanity-tests.yaml`: `build-artifact`

**Explicitly left off:**
- `release-build-test-publish.yaml`'s three build jobs (feeding `package-and-release.yaml`) are explicitly set to `use-system-sfpi: false`, with a comment. Released packages get installed on arbitrary external machines with no `/opt/tenstorrent/sfpi` to fall back to, so they must bundle the SFPI JIT toolchain themselves.
- Every other `build-artifact.yaml` caller not listed above is unaffected (stays on the default).

**Packaging fallout, fixed:**
`CMakeLists.txt:333`'s `install(DIRECTORY runtime/sfpi ...)` — which populates the `jit-build` CPack component (`tt-metalium-jit` .deb) — only runs `if(NOT TT_USE_SYSTEM_SFPI)`. `tt_metal/jit_build/build.cpp:148` already has a documented runtime fallback to `/opt/tenstorrent/sfpi` when that package isn't bundled, so the missing `.deb` is harmless **in containers that stage SFPI**. A repo-wide grep found four workflow call sites that hard-required `tt-metalium-jit_*.deb` to exist:

| File | Fix |
|---|---|
| `smoke.yaml` | tolerant glob (`shopt -s nullglob`) |
| `basic.yaml` | tolerant glob |
| `sdk-examples.yaml` | tolerant glob (needed the Dockerfile fix below first) |
| `ttsim-sanity-tests-impl.yaml` | tolerant glob (needed the Dockerfile fix below first) |

`sdk-examples.yaml`/`ttsim-sanity-tests-impl.yaml` run in `basic-dev-docker-image`, which — unlike `ci-build`/`ci-test`/`dev` — deliberately didn't stage SFPI (only its sibling `basic-ttnn-runtime` stage did), so the runtime fallback couldn't apply there and a workflow-level glob fix alone wasn't enough. Fixed in `dockerfile/Dockerfile.basic-dev` by moving the SFPI copy step from `basic-ttnn-runtime` up into the shared `base` stage, so every `basic-dev`-derived image inherits it. Also brought all of `Dockerfile.basic-dev`'s tool-layer `COPY` instructions (uv, cmake, openmpi, ccache, sfpi) in line with the `--link` pattern already used in the main `Dockerfile`, for cache-layer independence.

## Test plan
- [x] `bash -n build_metal.sh` passes.
- [x] YAML syntax validated for every workflow file touched.
- [x] Traced Dockerfile / docker-bake stage inheritance for `ci-build`, `ci-test`, `dev`, `basic-dev`, `basic-ttnn-runtime`.
- [x] `runtime-smoke-tests` + `ttnn-smoke-tests` passed on this PR with `tt-metalium-jit` legitimately absent ([run 31647896511](https://github.com/tenstorrent/tt-metal/actions/runs/31647896511?pr=52999)).
- [ ] CI re-running with the full `merge-gate`/`sanity-tests`/`basic-dev` changes — confirming clean end-to-end.

🤖 Generated with BrAIn