### PR TITLE
[Bug fix] sampling: TTSampling hands ttnn.topk an indices_tensor half the width of the logits

### DIFF
--- a/models/common/modules/sampling/sampling_1d.py
+++ b/models/common/modules/sampling/sampling_1d.py
@@ -80,9 +80,6 @@ class Sampling1DConfig:
     # --- Persistent buffer specs (LazyBuffer | ttnn.Tensor | None) ---
     # Static index buffers (computed from vocab_size + num_devices, never mutated)
     index_offsets: LazyBuffer | ttnn.Tensor | None = None  # [1,1,32,max_top_k*num_devices], int32, TILE
-    local_indices: LazyBuffer | ttnn.Tensor | None = (
-        None  # [1,1,32,W], uint16, TILE (W=vocab for 1x1, per_dev_vocab otherwise)
-    )
     invalid_vocab_mask: LazyBuffer | ttnn.Tensor | None = None  # Full fallback mask, sharded like logits
     invalid_vocab_tail_mask: LazyBuffer | ttnn.Tensor | None = None  # Compact [1,1,32,tail] local mask
     invalid_vocab_tail_width: int = 0
@@ -103,7 +100,7 @@ class Sampling1DConfig:
             return False
         if self.mesh_device.get_num_devices() > 1 and self.tt_ccl is None:
             return False
-        required_buffers = ["index_offsets", "local_indices", "seeds", "user_ids"]
+        required_buffers = ["index_offsets", "seeds", "user_ids"]
         if not all(self._buf_resolved(getattr(self, f)) for f in required_buffers):
             return False
         if self.valid_vocab_size is not None and self.valid_vocab_size < self.vocab_size:
@@ -195,7 +192,6 @@ class Sampling1D(LightweightModule):
         cfg = self.config
 
         self._index_offsets = _materialize(cfg.index_offsets)
-        self._local_indices = _materialize(cfg.local_indices)
         self._invalid_vocab_mask = _materialize(cfg.invalid_vocab_mask) if cfg.invalid_vocab_mask is not None else None
         self._invalid_vocab_tail_mask = (
             _materialize(cfg.invalid_vocab_tail_mask) if cfg.invalid_vocab_tail_mask is not None else None
@@ -522,7 +518,6 @@ class Sampling1D(LightweightModule):
         """Split vocab in half → two topk → concat. Port of tt_sampling.py:346-371."""
         cfg = self.config
         x_list = ttnn.split(x_bf16, x_bf16.shape[-1] // 2, dim=3)
-        indices_list = ttnn.split(self._local_indices, self._local_indices.shape[-1] // 2, dim=3)
 
         values_parts = []
         indices_parts = []
@@ -532,12 +527,10 @@ class Sampling1D(LightweightModule):
                 k=cfg.max_top_k,
                 dim=-1,
                 sub_core_grids=cfg.sub_core_grid_topk,
-                indices_tensor=indices_list[i],
             )
             values_parts.append(vals)
             indices_parts.append(idxs)
             x_list[i].deallocate()
-            indices_list[i].deallocate()
 
         gathered_values = ttnn.concat(values_parts, dim=3)
         gathered_indices = ttnn.concat(indices_parts, dim=3)
@@ -554,8 +547,7 @@ class Sampling1D(LightweightModule):
         cluster_shape = cfg.mesh_device.shape
 
         # Pad the per-device shard up to the next power of 2 so ttnn.topk hits its fast path.
-        # Padded entries get -inf so they are never selected; the pre-padded _local_indices buffer
-        # is widened to match (see _resolve_sampling1d_config). Mirrors tt_sampling.py:451-458.
+        # Padded entries get -inf so they are never selected. Mirrors tt_sampling.py:451-458.
         if cfg.pad_to_power_of_2 and not _is_power_of_2(x_bf16.shape[-1]):
             padded_width = _upper_power_of_2(x_bf16.shape[-1])
             x_bf16 = ttnn.pad(
@@ -570,7 +562,6 @@ class Sampling1D(LightweightModule):
             k=cfg.max_top_k,
             dim=-1,
             sub_core_grids=cfg.sub_core_grid_topk,
-            indices_tensor=self._local_indices,
         )
 
         # For 1D meshes use cluster_axis=None
@@ -755,40 +746,6 @@ def _resolve_sampling1d_config(config: Sampling1DConfig) -> Sampling1DConfig:
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     to_set["index_offsets"] = _resolve_buf(config.index_offsets, idx_defaults, _make_index_offsets)
-
-    # local_indices: [1, 1, B, local_indices_width]
-    # For multi-device: width = per_device_vocab (each device's shard)
-    # For single-device split (multi_step_reduction): width = V (full vocab), so that
-    #   after ttnn.split(..., V//2, dim=3) each half has width V//2 = per_device_vocab,
-    #   matching the logits half width. Each half contains a 0-based range [0..V//2-1].
-    #   Bug fix: TTTv1 used per_device_vocab here too, causing a 2x width mismatch
-    #   between indices_tensor and logits in ttnn.topk on single-device.
-    local_indices_width = V if multi_step_reduction else per_device_vocab
-
-    def _make_local_indices():
-        if multi_step_reduction:
-            half = local_indices_width // 2
-            r = torch.arange(half, dtype=torch.int32)
-            row = torch.cat([r, r])
-        else:
-            row = torch.arange(local_indices_width, dtype=torch.int32)
-        out = row.unsqueeze(0).unsqueeze(0).expand(1, 1, B, -1).contiguous()
-        # Pad the indices buffer to match the power-of-2-padded topk input width (multi-device
-        # path only — strict TTTv1 parity, so the 1×1 split path is never padded). Fill with -1
-        # (invalid index) so the padded slots are never used. Mirrors tt_sampling.py:277-284.
-        if config.pad_to_power_of_2 and not multi_step_reduction and not _is_power_of_2(local_indices_width):
-            padded_width = _upper_power_of_2(local_indices_width)
-            out = torch.nn.functional.pad(out, (0, padded_width - local_indices_width), mode="constant", value=-1)
-        return out
-
-    local_idx_defaults = dict(
-        dtype=ttnn.uint16,
-        layout=ttnn.TILE_LAYOUT,
-        device=mesh_device,
-        mesh_mapper=replicate_mapper,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-    to_set["local_indices"] = _resolve_buf(config.local_indices, local_idx_defaults, _make_local_indices)
 
     vocab_shard_dims = get_vocab_shard_dims(cluster_shape)
     invalid_vocab_defaults = dict(

--- a/models/common/modules/sampling/sampling_1d.py
+++ b/models/common/modules/sampling/sampling_1d.py
@@ -267,7 +267,7 @@ class Sampling1D(LightweightModule):
         """Dispatcher."""
         return self.decode_forward(logits, **kwargs)
 
-    # -- Argmax path (port from tt_sampling.py:310-341) -----------------------
+    # -- Argmax path (port of the argmax branch of TTSampling.forward) --------
 
     def _sample_argmax(self, logits, tt_out_tok):
         slice_valid_vocab = self._can_slice_valid_vocab_for_argmax()
@@ -364,7 +364,7 @@ class Sampling1D(LightweightModule):
         """DRAM memory config: no extra round-trip needed."""
         return topk_values, topk_indices_int32
 
-    # -- Top-k sampling (port from tt_sampling.py:343-481) --------------------
+    # -- Top-k sampling (port of the top-k branch of TTSampling.forward) ------
 
     def _sample_topk(self, logits, k, p, temp, seeds, tt_out_tok):
         cfg = self.config
@@ -515,7 +515,7 @@ class Sampling1D(LightweightModule):
     # -- Top-k strategies (bound at init, no if-else in forward) --------------
 
     def _topk_single_device(self, x_bf16):
-        """Split vocab in half → two topk → concat. Port of tt_sampling.py:346-371."""
+        """Split vocab in half → two topk → concat. Port of the single-device branch of TTSampling.forward."""
         cfg = self.config
         x_list = ttnn.split(x_bf16, x_bf16.shape[-1] // 2, dim=3)
 
@@ -542,12 +542,12 @@ class Sampling1D(LightweightModule):
         return gathered_values, gathered_indices
 
     def _topk_multi_device(self, x_bf16):
-        """Local topk → all_gather across devices. Port of tt_sampling.py:372-421."""
+        """Local topk → all_gather across devices. Port of the multi-device branch of TTSampling.forward."""
         cfg = self.config
         cluster_shape = cfg.mesh_device.shape
 
         # Pad the per-device shard up to the next power of 2 so ttnn.topk hits its fast path.
-        # Padded entries get -inf so they are never selected. Mirrors tt_sampling.py:451-458.
+        # Padded entries get -inf so they are never selected. Mirrors the padding in TTSampling.forward.
         if cfg.pad_to_power_of_2 and not _is_power_of_2(x_bf16.shape[-1]):
             padded_width = _upper_power_of_2(x_bf16.shape[-1])
             x_bf16 = ttnn.pad(
@@ -597,7 +597,7 @@ class Sampling1D(LightweightModule):
     def _perform_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None, dtype=None):
         """Flexible all-gather: prefer line_all_gather if available, else ttnn.all_gather.
 
-        Port of TTSampling._perform_all_gather (tt_sampling.py:231-259).
+        Port of TTSampling._perform_all_gather.
         """
         if callable(self._line_all_gather):
             kwargs = {

--- a/models/common/modules/sampling/sampling_1d.py
+++ b/models/common/modules/sampling/sampling_1d.py
@@ -167,15 +167,11 @@ class Sampling1D(LightweightModule):
         # CCL introspection (port from TTSampling.__init__ lines 77-91)
         self._line_all_gather = getattr(self.config.tt_ccl, "line_all_gather", None) if self.config.tt_ccl else None
         self._line_all_gather_supports_buffer_key = False
-        self._line_all_gather_supports_dtype = False
         if callable(self._line_all_gather):
             try:
                 sig = inspect.signature(self._line_all_gather)
                 params = sig.parameters
                 self._line_all_gather_supports_buffer_key = "buffer_key" in params or any(
-                    p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
-                )
-                self._line_all_gather_supports_dtype = "dtype" in params or any(
                     p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
                 )
             except (TypeError, ValueError):
@@ -586,7 +582,6 @@ class Sampling1D(LightweightModule):
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             num_links=cfg.num_gather_links,
             buffer_key="SAMPLING_INDICES",
-            dtype=ttnn.uint16,
         )
         ttnn.deallocate(topk_indices)
 
@@ -594,7 +589,7 @@ class Sampling1D(LightweightModule):
 
     # -- CCL helper -----------------------------------------------------------
 
-    def _perform_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None, dtype=None):
+    def _perform_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None):
         """Flexible all-gather: prefer line_all_gather if available, else ttnn.all_gather.
 
         Port of TTSampling._perform_all_gather.
@@ -608,8 +603,6 @@ class Sampling1D(LightweightModule):
             }
             if self._line_all_gather_supports_buffer_key and buffer_key is not None:
                 kwargs["buffer_key"] = buffer_key
-            if self._line_all_gather_supports_dtype and dtype is not None:
-                kwargs["dtype"] = dtype
             return self._line_all_gather(tensor, **kwargs)
 
         return ttnn.all_gather(

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -119,7 +119,6 @@ class TTSampling(LightweightModule):
         self.tt_ccl = tt_ccl
         self._line_all_gather = getattr(self.tt_ccl, "line_all_gather", None)
         self._line_all_gather_supports_buffer_key = False
-        self._line_all_gather_supports_dtype = False
         self.pad_to_power_of_2 = getattr(args, "pad_logits_to_power_of_2", False)
         if callable(self._line_all_gather):
             try:
@@ -128,11 +127,8 @@ class TTSampling(LightweightModule):
                 self._line_all_gather_supports_buffer_key = "buffer_key" in line_all_gather_params or any(
                     param.kind == inspect.Parameter.VAR_KEYWORD for param in line_all_gather_params.values()
                 )
-                self._line_all_gather_supports_dtype = "dtype" in line_all_gather_params or any(
-                    param.kind == inspect.Parameter.VAR_KEYWORD for param in line_all_gather_params.values()
-                )
             except (TypeError, ValueError):
-                logger.warning("Unable to inspect line_all_gather signature; assuming no buffer_key or dtype support.")
+                logger.warning("Unable to inspect line_all_gather signature; assuming no buffer_key support.")
 
         padded_vocab_size = getattr(args, "padded_vocab_size", None)
         self.padded_vocab_size = padded_vocab_size if padded_vocab_size is not None else args.vocab_size
@@ -474,7 +470,7 @@ class TTSampling(LightweightModule):
             sub_core_grids=self.sub_core_grids,
         )
 
-    def _perform_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None, dtype=None):
+    def _perform_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None):
         """
         Flexible all-gather that works across different CCL implementations.
 
@@ -491,8 +487,6 @@ class TTSampling(LightweightModule):
             }
             if self._line_all_gather_supports_buffer_key and buffer_key is not None:
                 line_all_gather_kwargs["buffer_key"] = buffer_key
-            if self._line_all_gather_supports_dtype and dtype is not None:
-                line_all_gather_kwargs["dtype"] = dtype
             return self._line_all_gather(tensor, **line_all_gather_kwargs)
 
         return ttnn.all_gather(

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -855,7 +855,6 @@ class TTSampling(LightweightModule):
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 num_links=self.num_gather_links,
                 buffer_key="SAMPLING_INDICES",
-                dtype=ttnn.uint16,
             )
             ttnn.deallocate(topk_indices)
 

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -93,17 +93,6 @@ class TTSampling(LightweightModule):
             and is_default_value(temp, 1.0)
         )
 
-    def _select_topk_indices_dtype(self, per_device_vocab_size: int, multi_step_reduction: bool):
-        # if vocab is larger than uint16 max, return uint32 for indices
-        if per_device_vocab_size > torch.iinfo(torch.uint16).max:
-            return ttnn.uint32
-
-        # if vocab size is missaligned with tile size and multi-step reduction is used, we need uint32 because of slice op compatibility
-        if multi_step_reduction and (per_device_vocab_size // 2) % ttnn.TILE_SIZE != 0:
-            return ttnn.uint32
-
-        return ttnn.uint16
-
     @property
     def force_argmax_sampling(self) -> bool:
         return self._force_argmax_sampling
@@ -317,12 +306,11 @@ class TTSampling(LightweightModule):
         return self.cluster_shape[self.sampling_all_gather_axis]
 
     def _create_indices_tensors(self):
-        """Create the indices tensors needed for distributed top-k operations."""
+        """Create the per-shard index offsets added to the top-k indices after the gather."""
         num_devices_in_mesh = self._get_num_sampling_shards()
         indices_device_offsets = torch.ones(
             1, 1, self.max_batch_size, self.max_top_k * num_devices_in_mesh, dtype=torch.int64
         )
-        # padded_per_device: tile-aligned width matching actual logit tensors (for indices tensor)
         padded_per_device = self.padded_vocab_size // num_devices_in_mesh
 
         for device_id in range(num_devices_in_mesh):
@@ -334,31 +322,6 @@ class TTSampling(LightweightModule):
             device=self.mesh_device,
             dtype=ttnn.int32,
             layout=ttnn.TILE_LAYOUT,
-            mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=(None, None), mesh_shape=self.cluster_shape),
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        )
-
-        # Create local indices tensor for top-k operations (must match logit width)
-        indices_tensor_torch = torch.zeros(1, 1, self.max_batch_size, padded_per_device, dtype=torch.int32)
-        for i in range(padded_per_device):
-            indices_tensor_torch[:, :, :, i] = i
-
-        # pad to power of 2 if needed
-        if self.pad_to_power_of_2 and not is_power_of_2(indices_tensor_torch.shape[-1]):
-            padded_value = upper_power_of_2(indices_tensor_torch.shape[-1])
-            indices_tensor_torch = torch.nn.functional.pad(
-                indices_tensor_torch,
-                (0, padded_value - indices_tensor_torch.shape[-1]),  # pad only last dim
-                mode="constant",
-                value=-1,  # invalid index to ensure that the padding values are not used
-            )
-
-        indices_dtype = self._select_topk_indices_dtype(padded_per_device, self.multi_step_reduction)
-        self.tt_indices_tensor = ttnn.from_torch(
-            indices_tensor_torch,
-            dtype=indices_dtype,
-            layout=ttnn.Layout.TILE,
-            device=self.mesh_device,
             mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=(None, None), mesh_shape=self.cluster_shape),
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
@@ -799,7 +762,6 @@ class TTSampling(LightweightModule):
 
         if self.multi_step_reduction:
             x_bf16_list = ttnn.split(x_bf16, x_bf16.shape[-1] // 2, dim=3)
-            indices_tensor_list = ttnn.split(self.tt_indices_tensor, self.tt_indices_tensor.shape[-1] // 2, dim=3)
             topk_values_list = []
             topk_indices_list = []
 
@@ -809,7 +771,6 @@ class TTSampling(LightweightModule):
                     k=self.max_top_k,
                     dim=-1,
                     sub_core_grids=self.sub_core_grid_topk,
-                    indices_tensor=indices_tensor_list[i],
                     # Break exact-value ties by lowest index instead of array position, so which
                     # of a set of tied candidates enters the top-k does not depend on placement.
                     # Best effort only, and only where the LLK has the network at all (see
@@ -821,7 +782,6 @@ class TTSampling(LightweightModule):
                 topk_values_list.append(topk_values)
                 topk_indices_list.append(topk_indices)
                 x_bf16_list[i].deallocate()
-                indices_tensor_list[i].deallocate()
 
             topk_values_gathered_bf16_interleaved = ttnn.concat(topk_values_list, dim=3)
             topk_indices_gathered = ttnn.concat(topk_indices_list, dim=3)
@@ -849,7 +809,6 @@ class TTSampling(LightweightModule):
                 k=self.max_top_k,
                 dim=-1,
                 sub_core_grids=self.sub_core_grid_topk,
-                indices_tensor=self.tt_indices_tensor,
                 # Break exact-value ties by lowest index instead of array position, so which
                 # of a set of tied candidates enters the top-k does not depend on placement.
                 # Best effort only, and only where the LLK has the network at all (see

--- a/models/common/tests/modules/sampling/test_sampling_1d.py
+++ b/models/common/tests/modules/sampling/test_sampling_1d.py
@@ -144,7 +144,6 @@ class TestSampling1DDevice:
         sampler.load_device_buffers()
         assert sampler._device_buffers_loaded
         assert isinstance(sampler._index_offsets, ttnn.Tensor)
-        assert isinstance(sampler._local_indices, ttnn.Tensor)
         assert isinstance(sampler._seeds, ttnn.Tensor)
         assert isinstance(sampler._user_ids, ttnn.Tensor)
 

--- a/models/common/tests/modules/sampling/test_sampling_1d.py
+++ b/models/common/tests/modules/sampling/test_sampling_1d.py
@@ -202,23 +202,22 @@ class TestSampling1DDevice:
     # ------------------------------------------------------------------
 
     def test_bind_strategy_ccl_introspection_with_kwargs(self, ttnn_mesh_device):
-        """_bind_strategy correctly detects buffer_key/dtype support on line_all_gather."""
+        """_bind_strategy correctly detects buffer_key support on line_all_gather."""
         from dataclasses import replace
 
         sampler = Sampling1D(vocab_size=1024, mesh_device=ttnn_mesh_device)
 
         class MockCCL:
-            def line_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None, dtype=None):
+            def line_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None):
                 return tensor
 
         sampler.config = replace(sampler.config, tt_ccl=MockCCL())
         sampler._bind_strategy()
 
         assert sampler._line_all_gather_supports_buffer_key
-        assert sampler._line_all_gather_supports_dtype
 
     def test_bind_strategy_ccl_introspection_no_kwargs(self, ttnn_mesh_device):
-        """_bind_strategy detects when line_all_gather does NOT support buffer_key/dtype."""
+        """_bind_strategy detects when line_all_gather does NOT support buffer_key."""
         from dataclasses import replace
 
         sampler = Sampling1D(vocab_size=1024, mesh_device=ttnn_mesh_device)
@@ -231,7 +230,6 @@ class TestSampling1DDevice:
         sampler._bind_strategy()
 
         assert not sampler._line_all_gather_supports_buffer_key
-        assert not sampler._line_all_gather_supports_dtype
 
     def test_bind_strategy_ccl_introspection_exception(self, ttnn_mesh_device):
         """_bind_strategy handles TypeError from inspect.signature gracefully (lines 125-126)."""
@@ -252,7 +250,6 @@ class TestSampling1DDevice:
             sampler._bind_strategy()
 
         assert not sampler._line_all_gather_supports_buffer_key
-        assert not sampler._line_all_gather_supports_dtype
 
     # ------------------------------------------------------------------
     # Error paths (lines 178, 186)
@@ -285,7 +282,7 @@ class TestSampling1DDevice:
 
     @pytest.mark.parametrize("vocab_size", [1024])
     def test_perform_all_gather_with_mock_ccl(self, ttnn_mesh_device, vocab_size):
-        """_perform_all_gather passes buffer_key/dtype kwargs when line_all_gather supports them."""
+        """_perform_all_gather passes the buffer_key kwarg when line_all_gather supports it."""
         B, K = 32, 32
         sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
         sampler.load_device_buffers()
@@ -298,7 +295,6 @@ class TestSampling1DDevice:
 
         sampler._line_all_gather = mock_line_ag
         sampler._line_all_gather_supports_buffer_key = True
-        sampler._line_all_gather_supports_dtype = True
 
         test_tensor = ttnn.from_torch(
             torch.zeros(1, 1, B, K, dtype=torch.bfloat16),
@@ -315,12 +311,10 @@ class TestSampling1DDevice:
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             num_links=1,
             buffer_key="TEST_KEY",
-            dtype=ttnn.bfloat16,
         )
 
         assert result is test_tensor
         assert captured_kwargs.get("buffer_key") == "TEST_KEY"
-        assert captured_kwargs.get("dtype") == ttnn.bfloat16
 
     # ------------------------------------------------------------------
     # from_model_args model_config branches (lines 406-408, 416-419)

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -13,6 +13,7 @@ from models.common.sampling import (
     SamplingGenerator,
     SamplingParams,
     SeedManager,
+    TTSampling,
     broadcast_sampling_params,
     format_sampling_params,
     scatter_sampling_params_to_slots,
@@ -781,3 +782,85 @@ def test_top_k_logprobs_pcc_torch_vs_tt(shape, mesh_device):
             f"  device: {top_lps_device[:5].tolist()}...\n"
             f"  torch:  {top_lps_torch[:5].tolist()}..."
         )
+
+
+# ===========================================================================
+# TTSampling top-k path on a single device
+# ===========================================================================
+
+
+def _single_device_sampling_args(mesh_device, vocab_size, max_top_k=32, max_batch_size=32):
+    """Minimal args for TTSampling on a 1x1 mesh: no vocab padding, no force-argmax."""
+    grid = mesh_device.compute_with_storage_grid_size()
+    sub_core_grids = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))])
+    return SimpleNamespace(
+        vocab_size=vocab_size,
+        padded_vocab_size=vocab_size,
+        max_batch_size=max_batch_size,
+        max_top_k=max_top_k,
+        cluster_shape=(1, 1),
+        sub_core_grids=sub_core_grids,
+        sub_core_grid_topk=sub_core_grids,
+        start_core=ttnn.CoreCoord(0, 0),
+    )
+
+
+@pytest.mark.parametrize(
+    "vocab_size",
+    [
+        # Half the vocab is a power of two >= 8192, so each half reaches the multi-core top-k
+        # factory. Mistral-7B-Instruct-v0.3 has exactly this vocab size.
+        pytest.param(32768, id="v32768_multicore_halves"),
+        # Half the vocab is not a power of two, so each half falls back to the single-core factory.
+        pytest.param(32000, id="v32000_single_core_halves"),
+    ],
+)
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+def test_ttsampling_topk_matches_argmax_on_single_device(vocab_size, mesh_device):
+    """top-k=1 through TTSampling must select the row maximum on a 1x1 mesh.
+
+    On a single device TTSampling splits the logits in half and runs ttnn.topk on each half
+    (``multi_step_reduction``), so this covers the split path end to end for both top-k program
+    factories. Regression test for the half-width local indices buffer, which made the multi-core
+    factory page its index tiles past the end of that buffer and return indices that did not
+    belong to the values it returned.
+    """
+    torch.manual_seed(42)
+    batch_size = 32
+
+    sampler = TTSampling(
+        args=_single_device_sampling_args(mesh_device, vocab_size),
+        mesh_device=mesh_device,
+        tt_ccl=None,
+        k=torch.ones(batch_size),  # top-1
+        p=torch.zeros(batch_size),
+        temp=torch.ones(batch_size),
+    )
+    assert sampler.multi_step_reduction, "a 1x1 mesh is expected to take the split top-k path"
+    assert not sampler.force_argmax_sampling, "this test must exercise the top-k path, not argmax"
+
+    logits_host = torch.randn(1, 1, batch_size, vocab_size)
+    logits_tt = ttnn.from_torch(logits_host, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh_device)
+    # Compare against what the device actually holds: bfloat16 rounding creates ties, so the
+    # sampled token need not be torch.argmax of the fp32 logits, but its value must be the maximum.
+    logits_bf16 = ttnn.to_torch(logits_tt).float().reshape(batch_size, vocab_size)
+
+    tokens_tt, _log_probs = sampler(logits_tt)
+    tokens = ttnn.to_torch(tokens_tt).flatten()[:batch_size].long()
+
+    row_max = logits_bf16.max(dim=-1).values
+    failures = []
+    for user in range(batch_size):
+        token = int(tokens[user])
+        if not 0 <= token < vocab_size:
+            failures.append(f"  user {user}: token {token} outside [0, {vocab_size})")
+            continue
+        value = logits_bf16[user, token].item()
+        if value < row_max[user].item():
+            failures.append(
+                f"  user {user}: token {token} has logit {value:.6f}, but the row maximum is "
+                f"{row_max[user].item():.6f} at index {int(logits_bf16[user].argmax())}"
+            )
+
+    header = f"{len(failures)}/{batch_size} users did not sample the row maximum (vocab_size={vocab_size})"
+    assert not failures, header + ":\n" + "\n".join(failures)

--- a/models/experimental/llama32_1b_quasar/modules/sampling/sampling_1d.py
+++ b/models/experimental/llama32_1b_quasar/modules/sampling/sampling_1d.py
@@ -80,9 +80,6 @@ class Sampling1DConfig:
     # --- Persistent buffer specs (LazyBuffer | ttnn.Tensor | None) ---
     # Static index buffers (computed from vocab_size + num_devices, never mutated)
     index_offsets: LazyBuffer | ttnn.Tensor | None = None  # [1,1,32,max_top_k*num_devices], int32, TILE
-    local_indices: LazyBuffer | ttnn.Tensor | None = (
-        None  # [1,1,32,W], uint16, TILE (W=vocab for 1x1, per_dev_vocab otherwise)
-    )
     invalid_vocab_mask: LazyBuffer | ttnn.Tensor | None = None  # Full fallback mask, sharded like logits
     invalid_vocab_tail_mask: LazyBuffer | ttnn.Tensor | None = None  # Compact [1,1,32,tail] local mask
     invalid_vocab_tail_width: int = 0
@@ -103,7 +100,7 @@ class Sampling1DConfig:
             return False
         if self.mesh_device.get_num_devices() > 1 and self.tt_ccl is None:
             return False
-        required_buffers = ["index_offsets", "local_indices", "seeds", "user_ids"]
+        required_buffers = ["index_offsets", "seeds", "user_ids"]
         if not all(self._buf_resolved(getattr(self, f)) for f in required_buffers):
             return False
         if self.valid_vocab_size is not None and self.valid_vocab_size < self.vocab_size:
@@ -195,7 +192,6 @@ class Sampling1D(LightweightModule):
         cfg = self.config
 
         self._index_offsets = _materialize(cfg.index_offsets)
-        self._local_indices = _materialize(cfg.local_indices)
         self._invalid_vocab_mask = _materialize(cfg.invalid_vocab_mask) if cfg.invalid_vocab_mask is not None else None
         self._invalid_vocab_tail_mask = (
             _materialize(cfg.invalid_vocab_tail_mask) if cfg.invalid_vocab_tail_mask is not None else None
@@ -522,7 +518,6 @@ class Sampling1D(LightweightModule):
         """Split vocab in half → two topk → concat. Port of tt_sampling.py:346-371."""
         cfg = self.config
         x_list = ttnn.split(x_bf16, x_bf16.shape[-1] // 2, dim=3)
-        indices_list = ttnn.split(self._local_indices, self._local_indices.shape[-1] // 2, dim=3)
 
         values_parts = []
         indices_parts = []
@@ -532,12 +527,10 @@ class Sampling1D(LightweightModule):
                 k=cfg.max_top_k,
                 dim=-1,
                 sub_core_grids=cfg.sub_core_grid_topk,
-                indices_tensor=indices_list[i],
             )
             values_parts.append(vals)
             indices_parts.append(idxs)
             x_list[i].deallocate()
-            indices_list[i].deallocate()
 
         gathered_values = ttnn.concat(values_parts, dim=3)
         gathered_indices = ttnn.concat(indices_parts, dim=3)
@@ -554,8 +547,7 @@ class Sampling1D(LightweightModule):
         cluster_shape = cfg.mesh_device.shape
 
         # Pad the per-device shard up to the next power of 2 so ttnn.topk hits its fast path.
-        # Padded entries get -inf so they are never selected; the pre-padded _local_indices buffer
-        # is widened to match (see _resolve_sampling1d_config). Mirrors tt_sampling.py:451-458.
+        # Padded entries get -inf so they are never selected. Mirrors tt_sampling.py:451-458.
         if cfg.pad_to_power_of_2 and not _is_power_of_2(x_bf16.shape[-1]):
             padded_width = _upper_power_of_2(x_bf16.shape[-1])
             x_bf16 = ttnn.pad(
@@ -570,7 +562,6 @@ class Sampling1D(LightweightModule):
             k=cfg.max_top_k,
             dim=-1,
             sub_core_grids=cfg.sub_core_grid_topk,
-            indices_tensor=self._local_indices,
         )
 
         # For 1D meshes use cluster_axis=None
@@ -755,40 +746,6 @@ def _resolve_sampling1d_config(config: Sampling1DConfig) -> Sampling1DConfig:
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     to_set["index_offsets"] = _resolve_buf(config.index_offsets, idx_defaults, _make_index_offsets)
-
-    # local_indices: [1, 1, B, local_indices_width]
-    # For multi-device: width = per_device_vocab (each device's shard)
-    # For single-device split (multi_step_reduction): width = V (full vocab), so that
-    #   after ttnn.split(..., V//2, dim=3) each half has width V//2 = per_device_vocab,
-    #   matching the logits half width. Each half contains a 0-based range [0..V//2-1].
-    #   Bug fix: TTTv1 used per_device_vocab here too, causing a 2x width mismatch
-    #   between indices_tensor and logits in ttnn.topk on single-device.
-    local_indices_width = V if multi_step_reduction else per_device_vocab
-
-    def _make_local_indices():
-        if multi_step_reduction:
-            half = local_indices_width // 2
-            r = torch.arange(half, dtype=torch.int32)
-            row = torch.cat([r, r])
-        else:
-            row = torch.arange(local_indices_width, dtype=torch.int32)
-        out = row.unsqueeze(0).unsqueeze(0).expand(1, 1, B, -1).contiguous()
-        # Pad the indices buffer to match the power-of-2-padded topk input width (multi-device
-        # path only — strict TTTv1 parity, so the 1×1 split path is never padded). Fill with -1
-        # (invalid index) so the padded slots are never used. Mirrors tt_sampling.py:277-284.
-        if config.pad_to_power_of_2 and not multi_step_reduction and not _is_power_of_2(local_indices_width):
-            padded_width = _upper_power_of_2(local_indices_width)
-            out = torch.nn.functional.pad(out, (0, padded_width - local_indices_width), mode="constant", value=-1)
-        return out
-
-    local_idx_defaults = dict(
-        dtype=ttnn.uint16,
-        layout=ttnn.TILE_LAYOUT,
-        device=mesh_device,
-        mesh_mapper=replicate_mapper,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
-    )
-    to_set["local_indices"] = _resolve_buf(config.local_indices, local_idx_defaults, _make_local_indices)
 
     vocab_shard_dims = get_vocab_shard_dims(cluster_shape)
     invalid_vocab_defaults = dict(

--- a/models/experimental/llama32_1b_quasar/modules/sampling/sampling_1d.py
+++ b/models/experimental/llama32_1b_quasar/modules/sampling/sampling_1d.py
@@ -267,7 +267,7 @@ class Sampling1D(LightweightModule):
         """Dispatcher."""
         return self.decode_forward(logits, **kwargs)
 
-    # -- Argmax path (port from tt_sampling.py:310-341) -----------------------
+    # -- Argmax path (port of the argmax branch of TTSampling.forward) --------
 
     def _sample_argmax(self, logits, tt_out_tok):
         slice_valid_vocab = self._can_slice_valid_vocab_for_argmax()
@@ -364,7 +364,7 @@ class Sampling1D(LightweightModule):
         """DRAM memory config: no extra round-trip needed."""
         return topk_values, topk_indices_int32
 
-    # -- Top-k sampling (port from tt_sampling.py:343-481) --------------------
+    # -- Top-k sampling (port of the top-k branch of TTSampling.forward) ------
 
     def _sample_topk(self, logits, k, p, temp, seeds, tt_out_tok):
         cfg = self.config
@@ -515,7 +515,7 @@ class Sampling1D(LightweightModule):
     # -- Top-k strategies (bound at init, no if-else in forward) --------------
 
     def _topk_single_device(self, x_bf16):
-        """Split vocab in half → two topk → concat. Port of tt_sampling.py:346-371."""
+        """Split vocab in half → two topk → concat. Port of the single-device branch of TTSampling.forward."""
         cfg = self.config
         x_list = ttnn.split(x_bf16, x_bf16.shape[-1] // 2, dim=3)
 
@@ -542,12 +542,12 @@ class Sampling1D(LightweightModule):
         return gathered_values, gathered_indices
 
     def _topk_multi_device(self, x_bf16):
-        """Local topk → all_gather across devices. Port of tt_sampling.py:372-421."""
+        """Local topk → all_gather across devices. Port of the multi-device branch of TTSampling.forward."""
         cfg = self.config
         cluster_shape = cfg.mesh_device.shape
 
         # Pad the per-device shard up to the next power of 2 so ttnn.topk hits its fast path.
-        # Padded entries get -inf so they are never selected. Mirrors tt_sampling.py:451-458.
+        # Padded entries get -inf so they are never selected. Mirrors the padding in TTSampling.forward.
         if cfg.pad_to_power_of_2 and not _is_power_of_2(x_bf16.shape[-1]):
             padded_width = _upper_power_of_2(x_bf16.shape[-1])
             x_bf16 = ttnn.pad(
@@ -597,7 +597,7 @@ class Sampling1D(LightweightModule):
     def _perform_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None, dtype=None):
         """Flexible all-gather: prefer line_all_gather if available, else ttnn.all_gather.
 
-        Port of TTSampling._perform_all_gather (tt_sampling.py:231-259).
+        Port of TTSampling._perform_all_gather.
         """
         if callable(self._line_all_gather):
             kwargs = {

--- a/models/experimental/llama32_1b_quasar/modules/sampling/sampling_1d.py
+++ b/models/experimental/llama32_1b_quasar/modules/sampling/sampling_1d.py
@@ -167,15 +167,11 @@ class Sampling1D(LightweightModule):
         # CCL introspection (port from TTSampling.__init__ lines 77-91)
         self._line_all_gather = getattr(self.config.tt_ccl, "line_all_gather", None) if self.config.tt_ccl else None
         self._line_all_gather_supports_buffer_key = False
-        self._line_all_gather_supports_dtype = False
         if callable(self._line_all_gather):
             try:
                 sig = inspect.signature(self._line_all_gather)
                 params = sig.parameters
                 self._line_all_gather_supports_buffer_key = "buffer_key" in params or any(
-                    p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
-                )
-                self._line_all_gather_supports_dtype = "dtype" in params or any(
                     p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
                 )
             except (TypeError, ValueError):
@@ -586,7 +582,6 @@ class Sampling1D(LightweightModule):
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             num_links=cfg.num_gather_links,
             buffer_key="SAMPLING_INDICES",
-            dtype=ttnn.uint16,
         )
         ttnn.deallocate(topk_indices)
 
@@ -594,7 +589,7 @@ class Sampling1D(LightweightModule):
 
     # -- CCL helper -----------------------------------------------------------
 
-    def _perform_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None, dtype=None):
+    def _perform_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None):
         """Flexible all-gather: prefer line_all_gather if available, else ttnn.all_gather.
 
         Port of TTSampling._perform_all_gather.
@@ -608,8 +603,6 @@ class Sampling1D(LightweightModule):
             }
             if self._line_all_gather_supports_buffer_key and buffer_key is not None:
                 kwargs["buffer_key"] = buffer_key
-            if self._line_all_gather_supports_dtype and dtype is not None:
-                kwargs["dtype"] = dtype
             return self._line_all_gather(tensor, **kwargs)
 
         return ttnn.all_gather(

--- a/models/experimental/llama32_1b_quasar/sampling/tt_sampling.py
+++ b/models/experimental/llama32_1b_quasar/sampling/tt_sampling.py
@@ -100,7 +100,6 @@ class TTSampling(LightweightModule):
         self.tt_ccl = tt_ccl
         self._line_all_gather = getattr(self.tt_ccl, "line_all_gather", None)
         self._line_all_gather_supports_buffer_key = False
-        self._line_all_gather_supports_dtype = False
         self.pad_to_power_of_2 = getattr(args, "pad_logits_to_power_of_2", False)
         if callable(self._line_all_gather):
             try:
@@ -109,11 +108,8 @@ class TTSampling(LightweightModule):
                 self._line_all_gather_supports_buffer_key = "buffer_key" in line_all_gather_params or any(
                     param.kind == inspect.Parameter.VAR_KEYWORD for param in line_all_gather_params.values()
                 )
-                self._line_all_gather_supports_dtype = "dtype" in line_all_gather_params or any(
-                    param.kind == inspect.Parameter.VAR_KEYWORD for param in line_all_gather_params.values()
-                )
             except (TypeError, ValueError):
-                logger.warning("Unable to inspect line_all_gather signature; assuming no buffer_key or dtype support.")
+                logger.warning("Unable to inspect line_all_gather signature; assuming no buffer_key support.")
 
         padded_vocab_size = getattr(args, "padded_vocab_size", None)
         self.padded_vocab_size = padded_vocab_size if padded_vocab_size is not None else args.vocab_size
@@ -414,7 +410,7 @@ class TTSampling(LightweightModule):
             sub_core_grids=self.sub_core_grids,
         )
 
-    def _perform_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None, dtype=None):
+    def _perform_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None):
         """
         Flexible all-gather that works across different CCL implementations.
 
@@ -431,8 +427,6 @@ class TTSampling(LightweightModule):
             }
             if self._line_all_gather_supports_buffer_key and buffer_key is not None:
                 line_all_gather_kwargs["buffer_key"] = buffer_key
-            if self._line_all_gather_supports_dtype and dtype is not None:
-                line_all_gather_kwargs["dtype"] = dtype
             return self._line_all_gather(tensor, **line_all_gather_kwargs)
 
         return ttnn.all_gather(

--- a/models/experimental/llama32_1b_quasar/sampling/tt_sampling.py
+++ b/models/experimental/llama32_1b_quasar/sampling/tt_sampling.py
@@ -79,17 +79,6 @@ class TTSampling(LightweightModule):
             and is_default_value(temp, 1.0)
         )
 
-    def _select_topk_indices_dtype(self, per_device_vocab_size: int, multi_step_reduction: bool):
-        # if vocab is larger than uint16 max, return uint32 for indices
-        if per_device_vocab_size > torch.iinfo(torch.uint16).max:
-            return ttnn.uint32
-
-        # if vocab size is missaligned with tile size and multi-step reduction is used, we need uint32 because of slice op compatibility
-        if multi_step_reduction and (per_device_vocab_size // 2) % ttnn.TILE_SIZE != 0:
-            return ttnn.uint32
-
-        return ttnn.uint16
-
     @property
     def force_argmax_sampling(self) -> bool:
         return self._force_argmax_sampling
@@ -273,12 +262,11 @@ class TTSampling(LightweightModule):
         return self.cluster_shape[self.sampling_all_gather_axis]
 
     def _create_indices_tensors(self):
-        """Create the indices tensors needed for distributed top-k operations."""
+        """Create the per-shard index offsets added to the top-k indices after the gather."""
         num_devices_in_mesh = self._get_num_sampling_shards()
         indices_device_offsets = torch.ones(
             1, 1, self.max_batch_size, self.max_top_k * num_devices_in_mesh, dtype=torch.int64
         )
-        # padded_per_device: tile-aligned width matching actual logit tensors (for indices tensor)
         padded_per_device = self.padded_vocab_size // num_devices_in_mesh
 
         for device_id in range(num_devices_in_mesh):
@@ -290,31 +278,6 @@ class TTSampling(LightweightModule):
             device=self.mesh_device,
             dtype=ttnn.int32,
             layout=ttnn.TILE_LAYOUT,
-            mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=(None, None), mesh_shape=self.cluster_shape),
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        )
-
-        # Create local indices tensor for top-k operations (must match logit width)
-        indices_tensor_torch = torch.zeros(1, 1, self.max_batch_size, padded_per_device, dtype=torch.int32)
-        for i in range(padded_per_device):
-            indices_tensor_torch[:, :, :, i] = i
-
-        # pad to power of 2 if needed
-        if self.pad_to_power_of_2 and not is_power_of_2(indices_tensor_torch.shape[-1]):
-            padded_value = upper_power_of_2(indices_tensor_torch.shape[-1])
-            indices_tensor_torch = torch.nn.functional.pad(
-                indices_tensor_torch,
-                (0, padded_value - indices_tensor_torch.shape[-1]),  # pad only last dim
-                mode="constant",
-                value=-1,  # invalid index to ensure that the padding values are not used
-            )
-
-        indices_dtype = self._select_topk_indices_dtype(padded_per_device, self.multi_step_reduction)
-        self.tt_indices_tensor = ttnn.from_torch(
-            indices_tensor_torch,
-            dtype=indices_dtype,
-            layout=ttnn.Layout.TILE,
-            device=self.mesh_device,
             mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=(None, None), mesh_shape=self.cluster_shape),
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
@@ -642,7 +605,6 @@ class TTSampling(LightweightModule):
 
         if self.multi_step_reduction:
             x_bf16_list = ttnn.split(x_bf16, x_bf16.shape[-1] // 2, dim=3)
-            indices_tensor_list = ttnn.split(self.tt_indices_tensor, self.tt_indices_tensor.shape[-1] // 2, dim=3)
             topk_values_list = []
             topk_indices_list = []
 
@@ -652,12 +614,10 @@ class TTSampling(LightweightModule):
                     k=self.max_top_k,
                     dim=-1,
                     sub_core_grids=self.sub_core_grid_topk,
-                    indices_tensor=indices_tensor_list[i],
                 )
                 topk_values_list.append(topk_values)
                 topk_indices_list.append(topk_indices)
                 x_bf16_list[i].deallocate()
-                indices_tensor_list[i].deallocate()
 
             topk_values_gathered_bf16_interleaved = ttnn.concat(topk_values_list, dim=3)
             topk_indices_gathered = ttnn.concat(topk_indices_list, dim=3)
@@ -685,7 +645,6 @@ class TTSampling(LightweightModule):
                 k=self.max_top_k,
                 dim=-1,
                 sub_core_grids=self.sub_core_grid_topk,
-                indices_tensor=self.tt_indices_tensor,
             )
 
             # For 1D meshes use `cluster_axis=None`. For 2D meshes, use the configured gather axis.

--- a/models/experimental/llama32_1b_quasar/sampling/tt_sampling.py
+++ b/models/experimental/llama32_1b_quasar/sampling/tt_sampling.py
@@ -684,7 +684,6 @@ class TTSampling(LightweightModule):
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 num_links=self.num_gather_links,
                 buffer_key="SAMPLING_INDICES",
-                dtype=ttnn.uint16,
             )
             ttnn.deallocate(topk_indices)
 

--- a/models/experimental/llama32_1b_quasar/tests/modules/sampling/test_sampling_1d.py
+++ b/models/experimental/llama32_1b_quasar/tests/modules/sampling/test_sampling_1d.py
@@ -148,7 +148,6 @@ class TestSampling1DDevice:
         sampler.load_device_buffers()
         assert sampler._device_buffers_loaded
         assert isinstance(sampler._index_offsets, ttnn.Tensor)
-        assert isinstance(sampler._local_indices, ttnn.Tensor)
         assert isinstance(sampler._seeds, ttnn.Tensor)
         assert isinstance(sampler._user_ids, ttnn.Tensor)
 

--- a/models/experimental/llama32_1b_quasar/tests/modules/sampling/test_sampling_1d.py
+++ b/models/experimental/llama32_1b_quasar/tests/modules/sampling/test_sampling_1d.py
@@ -206,23 +206,22 @@ class TestSampling1DDevice:
     # ------------------------------------------------------------------
 
     def test_bind_strategy_ccl_introspection_with_kwargs(self, ttnn_mesh_device):
-        """_bind_strategy correctly detects buffer_key/dtype support on line_all_gather."""
+        """_bind_strategy correctly detects buffer_key support on line_all_gather."""
         from dataclasses import replace
 
         sampler = Sampling1D(vocab_size=1024, mesh_device=ttnn_mesh_device)
 
         class MockCCL:
-            def line_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None, dtype=None):
+            def line_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None):
                 return tensor
 
         sampler.config = replace(sampler.config, tt_ccl=MockCCL())
         sampler._bind_strategy()
 
         assert sampler._line_all_gather_supports_buffer_key
-        assert sampler._line_all_gather_supports_dtype
 
     def test_bind_strategy_ccl_introspection_no_kwargs(self, ttnn_mesh_device):
-        """_bind_strategy detects when line_all_gather does NOT support buffer_key/dtype."""
+        """_bind_strategy detects when line_all_gather does NOT support buffer_key."""
         from dataclasses import replace
 
         sampler = Sampling1D(vocab_size=1024, mesh_device=ttnn_mesh_device)
@@ -235,7 +234,6 @@ class TestSampling1DDevice:
         sampler._bind_strategy()
 
         assert not sampler._line_all_gather_supports_buffer_key
-        assert not sampler._line_all_gather_supports_dtype
 
     def test_bind_strategy_ccl_introspection_exception(self, ttnn_mesh_device):
         """_bind_strategy handles TypeError from inspect.signature gracefully (lines 125-126)."""
@@ -257,7 +255,6 @@ class TestSampling1DDevice:
             sampler._bind_strategy()
 
         assert not sampler._line_all_gather_supports_buffer_key
-        assert not sampler._line_all_gather_supports_dtype
 
     # ------------------------------------------------------------------
     # Error paths (lines 178, 186)
@@ -290,7 +287,7 @@ class TestSampling1DDevice:
 
     @pytest.mark.parametrize("vocab_size", [1024])
     def test_perform_all_gather_with_mock_ccl(self, ttnn_mesh_device, vocab_size):
-        """_perform_all_gather passes buffer_key/dtype kwargs when line_all_gather supports them."""
+        """_perform_all_gather passes the buffer_key kwarg when line_all_gather supports it."""
         B, K = 32, 32
         sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
         sampler.load_device_buffers()
@@ -303,7 +300,6 @@ class TestSampling1DDevice:
 
         sampler._line_all_gather = mock_line_ag
         sampler._line_all_gather_supports_buffer_key = True
-        sampler._line_all_gather_supports_dtype = True
 
         test_tensor = ttnn.from_torch(
             torch.zeros(1, 1, B, K, dtype=torch.bfloat16),
@@ -320,12 +316,10 @@ class TestSampling1DDevice:
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
             num_links=1,
             buffer_key="TEST_KEY",
-            dtype=ttnn.bfloat16,
         )
 
         assert result is test_tensor
         assert captured_kwargs.get("buffer_key") == "TEST_KEY"
-        assert captured_kwargs.get("dtype") == ttnn.bfloat16
 
     # ------------------------------------------------------------------
     # from_model_args model_config branches (lines 406-408, 416-419)

--- a/models/model_targets.yaml
+++ b/models/model_targets.yaml
@@ -958,7 +958,7 @@ targets:
             seq_len: 744
             status: active
             perf:
-              decode_t/s/u: 21.9
+              decode_t/s/u: 25.3
               prefill_time_to_first_token: 118
               prefill_time_to_first_token_tolerance: 0.2
             accuracy: {}

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -31,8 +31,7 @@ from models.tt_transformers.tt.generator import Generator, SamplingParams, creat
 from models.tt_transformers.tt.model_config import DecodersPrecision, determine_device_name, parse_decoder_json
 from models.tt_transformers.tt.prefetcher import is_prefetcher_supported
 
-# Issue: https://github.com/tenstorrent/tt-metal/issues/34763
-models_not_supported_for_device_sampling = ["Mistral-7B"]
+models_not_supported_for_device_sampling = []
 
 
 class TokenAccuracy:
@@ -1203,8 +1202,7 @@ def test_demo_text(
             else None
         )
 
-        # Override the sampling params for some models
-        # Issue: https://github.com/tenstorrent/tt-metal/issues/34763
+        # Fall back to host sampling for any model listed above
         if model_args[0].base_model_name in models_not_supported_for_device_sampling:
             device_sampling_params = None
 

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -31,8 +31,6 @@ from models.tt_transformers.tt.generator import Generator, SamplingParams, creat
 from models.tt_transformers.tt.model_config import DecodersPrecision, determine_device_name, parse_decoder_json
 from models.tt_transformers.tt.prefetcher import is_prefetcher_supported
 
-models_not_supported_for_device_sampling = []
-
 
 class TokenAccuracy:
     def __init__(self, model_name):
@@ -1201,10 +1199,6 @@ def test_demo_text(
             if model[0]._supports_on_device_sampling
             else None
         )
-
-        # Fall back to host sampling for any model listed above
-        if model_args[0].base_model_name in models_not_supported_for_device_sampling:
-            device_sampling_params = None
 
         if device_sampling_params is None and isinstance(sampling_params["temperature"], List):
             # host sampling only supports single sample param for all users in a batch

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -405,6 +405,23 @@ def test_topk_fp32_input_with_uint16_indices_tensor_raise(device, expect_error):
         ttnn.topk(ttnn_input, k=k, dim=-1, largest=True, sorted=True, indices_tensor=indices_tensor)
 
 
+def test_topk_narrower_indices_tensor_raise(device, expect_error):
+    # The indices are streamed with the input's page stride, so a narrower indices tensor is read at
+    # the wrong pages and produces wrong indices rather than an error.
+    torch.manual_seed(0)
+    k = 32
+    shape = [1, 1, 32, 8192]
+
+    input_torch = torch.randn(shape, dtype=torch.bfloat16)
+    ttnn_input = ttnn.from_torch(input_torch, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
+
+    indices_torch = torch.zeros([1, 1, 32, shape[3] // 2], dtype=torch.uint16)
+    indices_tensor = ttnn.from_torch(indices_torch, ttnn.uint16, layout=ttnn.Layout.TILE, device=device)
+
+    with expect_error(RuntimeError, "Indices tensor has incorrect shape"):
+        ttnn.topk(ttnn_input, k=k, dim=-1, largest=True, sorted=True, indices_tensor=indices_tensor)
+
+
 @pytest.mark.parametrize("largest", [True, False])
 def test_topk_multicore_local_write_correctness(largest, device):
     """

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -422,6 +422,25 @@ def test_topk_narrower_indices_tensor_raise(device, expect_error):
         ttnn.topk(ttnn_input, k=k, dim=-1, largest=True, sorted=True, indices_tensor=indices_tensor)
 
 
+def test_topk_indices_tensor_on_non_last_dim_raise(device, expect_error):
+    # The front end transposes the reduced dim to last and leaves the indices tensor alone, so the
+    # indices are paged in the input's post-transpose layout and come back rounded to a tile.
+    torch.manual_seed(0)
+    k = 32
+    shape = [1, 1, 8192, 32]
+
+    input_torch = torch.randn(shape, dtype=torch.bfloat16)
+    ttnn_input = ttnn.from_torch(input_torch, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
+
+    indices_torch = torch.zeros(shape, dtype=torch.uint16)
+    for i in range(shape[2]):
+        indices_torch[:, :, i, :] = i
+    indices_tensor = ttnn.from_torch(indices_torch, ttnn.uint16, layout=ttnn.Layout.TILE, device=device)
+
+    with expect_error(RuntimeError, "only supported for a reduction on the last dimension"):
+        ttnn.topk(ttnn_input, k=k, dim=2, largest=True, sorted=True, indices_tensor=indices_tensor)
+
+
 @pytest.mark.parametrize("largest", [True, False])
 def test_topk_multicore_local_write_correctness(largest, device):
     """

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp
@@ -184,6 +184,19 @@ void TopKDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(
             !(input_tensor_dtype == DataType::FLOAT32 && indices_tensor_dtype == DataType::UINT16),
             "Optional indices tensor must be UINT32 when input tensor is FLOAT32, got UINT16");
+        // The reader kernels page a caller-supplied indices tensor with the input's page index
+        // (page_id = i * Wt + j), so the two must describe the same tile grid: same padded width
+        // and same total number of tiles. A narrower indices tensor is read past the end of its
+        // buffer and returns indices that do not belong to the returned values. The composite
+        // topk() front-end checks the logical shapes too, but ttnn::prim::topk is a public entry
+        // point of its own. Ranks may legitimately differ (the front-end normalizes only the input
+        // to 4D), so compare the tile grid rather than the full shape.
+        TT_FATAL(
+            indices_tensor->padded_shape()[-1] == input_tensor.padded_shape()[-1] &&
+                indices_tensor->physical_volume() == input_tensor.physical_volume(),
+            "Optional indices tensor must span the same tile grid as the input tensor, got shape: {}, expected: {}",
+            indices_tensor->padded_shape(),
+            input_tensor.padded_shape());
     }
 
     // Preallocated output tensor validation

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -257,6 +257,15 @@ std::vector<Tensor> topk(
             "Indices tensor has incorrect shape! Got : {}, expected: {}",
             indices_tensor->logical_shape(),
             input_tensor.logical_shape());
+        // Matching shapes are not enough when the reduced dim is not already last: the transpose
+        // below is applied to the input and not to the indices tensor, so the reader pages the
+        // indices in the input's post-transpose layout. At [1, 1, 8192, 32] with dim=2 that returns
+        // every index rounded down to a multiple of the tile height.
+        TT_FATAL(
+            is_dim_last_idx,
+            "Indices tensor is only supported for a reduction on the last dimension, got dim={} for rank {}",
+            dim,
+            rank);
     }
 
     // When input is a scalar, PyTorch returns the copy of the input tensor (that is the 1 top element)

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -361,6 +361,10 @@ std::vector<Tensor> topk(
     // Choose padding value based on whether we want largest or smallest values
     const auto pad_val = largest ? -std::numeric_limits<float>::infinity() : std::numeric_limits<float>::infinity();
 
+    // A caller-supplied indices tensor must keep describing the same tile grid as the input the
+    // device op actually sees, so it is padded in lockstep. The pad slots hold +/-inf values and
+    // can never be selected, so the index value used to pad is irrelevant.
+    auto padded_indices_tensor = indices_tensor;
     if (pad_amount > 0) {
         ttsl::SmallVector<std::array<uint32_t, 2>> padding = {{0, 0}, {0, 0}, {0, 0}, {0, pad_amount}};
 
@@ -368,6 +372,9 @@ std::vector<Tensor> topk(
         const bool pad_multicore = transformed_tensor.dtype() == DataType::BFLOAT16 &&
                                    transformed_tensor.memory_config().buffer_type() != BufferType::L1;
         padded_tensor = ttnn::pad(transformed_tensor, padding, pad_val, pad_multicore);
+        if (padded_indices_tensor.has_value()) {
+            padded_indices_tensor = ttnn::pad(padded_indices_tensor.value(), padding, 0.0f, false);
+        }
     }
 
     // Fill any implicit tile padding with appropriate values
@@ -396,7 +403,7 @@ std::vector<Tensor> topk(
         stable,
         input_memory_config,
         used_sub_core_grids,
-        indices_tensor,
+        padded_indices_tensor,
         output_tensors);
 
     // Package results into vector format expected by post-processing

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -247,6 +247,18 @@ std::vector<Tensor> topk(
             desired_final_shape);
     }
 
+    if (indices_tensor.has_value()) {
+        // The reader streams a caller-supplied indices tensor with the input's page index, so the
+        // two have to describe the same grid. Only the dtype was checked, and a narrower indices
+        // tensor read at the input's stride returned indices from the wrong pages rather than
+        // failing.
+        TT_FATAL(
+            indices_tensor->logical_shape() == input_tensor.logical_shape(),
+            "Indices tensor has incorrect shape! Got : {}, expected: {}",
+            indices_tensor->logical_shape(),
+            input_tensor.logical_shape());
+    }
+
     // When input is a scalar, PyTorch returns the copy of the input tensor (that is the 1 top element)
     // as values. This happens when k = 1 (which makes sense), but also when k = 0 (which is unusual,
     // but for now we simply match its behavior).


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Closes #52928, which carries the full analysis and the measurements.

On a 1×1 mesh both samplers hand `ttnn.topk` an iota `indices_tensor` half the width of the logits, and nothing validates the two shapes against each other, so the multi-core reader pages index tiles past the end of the buffer and returns indices that do not belong to the values beside them. 126 of 256 sampled tokens are wrong at `padded_vocab_size` 32768. End to end, `Mistral-7B-Instruct-v0.3` on the top-k path drops from 96.40% to 83.20% Top-1 against the repo's own reference tokens.

The buffer holds exactly what `generate_index_tile()` writes when the argument is absent, so it is dropped rather than widened.

Two commits, separable:

1. **the fix**, plus a 1×1 top-k-vs-argmax regression test — `TTSampling`'s single-device top-k path had no test at all, which is how this survived.
2. **`Re-enable on-device sampling for Mistral-7B`** — one line off the demo's skip list, which #35153 added to contain #34763 and called a hack at the time. Drop this commit if CI disagrees; the fix does not depend on it.

### Notes for reviewers

**This is invisible in CI today.** Since #48886 routed single-chip greedy to the argmax fast path, the committed `ci-token-matching` config (`temperature=0`) never reaches the broken path. Reproducing it needs `p ∉ {0.0, 1.0}` so `_is_force_argmax_sampling` declines — `k=1, p=0.5, temp=1` keeps the result deterministic and gives the 83.20% above. What stays exposed is non-greedy sampling on a single chip, which is the ordinary vLLM path.

**Cost.** On today's main, generating the index tile is dearer than reading it: +18.8% on `ttnn.topk` at `[1, 1, 32, 16384]`, which is +7.2% on `Sampling1D.decode_forward` at vocab 32768 and −1.6% at vocab 1024. At the model level it vanishes into the step — Mistral-7B batch-1 decode on the top-k path is 24.71 ms/token before and 24.73 after, +0.08%. #52909 inverts the op-level number to −3.6%.

Verified on Blackhole P150, main at `03b9d08219`:

- [x] New test `test_ttsampling_topk_matches_argmax_on_single_device`, vocab 32768 and 32000 to cover both program factories. Fails 21/32 users at 32768 without the fix.
- [x] `test_sampling_1d.py`: 92 passed / 48 skipped, identical before and after. `test_topk.py`, `test_sampling.py`, `test_sort.py`: 345 passed, 8 skipped, 80 xfailed.
- [x] Generated index tile bit-identical to the iota buffer at twelve widths — both factories, the UINT16→UINT32 boundary at 65535, non-power-of-2 widths.
- [x] `simple_text_demo.py` end to end on the real model: 83.20% → 96.40% Top-1.
- [ ] **1×8 / 4×8 unmeasured** — 1×2 is the largest mesh I have, and multi-device is where the buffer is largest.
- [ ] **N150 unverified** — #34763's failures were N150 and N300. CI is what confirms commit 2.
- [ ] **The N300 report is not explained by this defect** — on 1×2 the buffer width already matches the input width, and 1×2 measures 0 mismatches before and after.
