### PR TITLE
[Cleanup] Refactoring device ID access in dispatch tests

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -1399,8 +1399,7 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWrapCompletionQOnInsufficien
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToDramBank0) {
     TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::DRAM};
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
+        log_info(tt::LogTest, "Running On Device {}", mesh_device->get_device_ids()[0]);
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
@@ -1411,8 +1410,8 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToDramBank0) {
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllDramBanks) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
+        const auto device_id = mesh_device->get_device_ids()[0];
+        log_info(tt::LogTest, "Running On Device {}", device_id);
         TestBufferConfig config = {
             .num_pages = uint32_t(mesh_device->allocator()->get_num_banks(BufferType::DRAM)),
             .page_size = 2048,
@@ -1423,15 +1422,15 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllDramBanks) {
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
             local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
-            << "Failed on device " << device->id();
+            << "Failed on device " << device_id;
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileAcrossAllDramBanksTwiceRoundRobin) {
     constexpr uint32_t num_round_robins = 2;
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
+        const auto device_id = mesh_device->get_device_ids()[0];
+        log_info(tt::LogTest, "Running On Device {}", device_id);
         TestBufferConfig config = {
             .num_pages = num_round_robins * (mesh_device->allocator()->get_num_banks(BufferType::DRAM)),
             .page_size = 2048,
@@ -1442,28 +1441,28 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileAcrossAllDramBanksTw
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
             local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
-            << "Failed on device " << device->id();
+            << "Failed on device " << device_id;
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, Sending131072Pages) {
     TestBufferConfig config = {.num_pages = 131072, .page_size = 128, .buftype = BufferType::DRAM};
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
+        const auto device_id = mesh_device->get_device_ids()[0];
+        log_info(tt::LogTest, "Running On Device {}", device_id);
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
             local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
-            << "Failed on device " << device->id();
+            << "Failed on device " << device_id;
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDram) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
+        const auto device_id = mesh_device->get_device_ids()[0];
+        log_info(tt::LogTest, "Running On Device {}", device_id);
         TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::DRAM};
 
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
@@ -1471,14 +1470,14 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDram
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
             local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
-            << "Failed on device " << device->id();
+            << "Failed on device " << device_id;
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDram2) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
+        const auto device_id = mesh_device->get_device_ids()[0];
+        log_info(tt::LogTest, "Running On Device {}", device_id);
         TestBufferConfig config = {.num_pages = 8 * 1024, .page_size = 80, .buftype = BufferType::DRAM};
 
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
@@ -1486,14 +1485,15 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDram
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
             local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
-            << "Failed on device " << device->id();
+            << "Failed on device " << device_id;
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestIssueMultipleReadWriteCommandsForOneBuffer) {
     for (const auto& mesh_device : devices_) {
+        const auto device_id = mesh_device->get_device_ids()[0];
         auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
+        log_info(tt::LogTest, "Running On Device {}", device_id);
         uint32_t page_size = 2048;
         uint32_t command_queue_size = device->sysmem_manager().get_cq_size();
         uint32_t num_pages = command_queue_size / page_size;
@@ -1505,7 +1505,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestIssueMultipleReadWriteComman
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
             local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
-            << "Failed on device " << device->id();
+            << "Failed on device " << device_id;
     }
 }
 
@@ -1513,8 +1513,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDram
     constexpr uint32_t page_size = 200;
     const uint32_t max_prefetch_command_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
+        log_info(tt::LogTest, "Running On Device {}", mesh_device->get_device_ids()[0]);
         const uint32_t num_banks = mesh_device->allocator()->get_num_banks(BufferType::DRAM);
         const uint32_t num_pages = std::max(4 * num_banks, (max_prefetch_command_size / page_size) + num_banks);
         TestBufferConfig config = {.num_pages = num_pages, .page_size = page_size, .buftype = BufferType::DRAM};
@@ -1536,8 +1535,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestSubBufferReadCrossesRelayPag
         relay_page_boundary - 1, relay_page_boundary, relay_page_boundary + 1};
 
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
+        log_info(tt::LogTest, "Running On Device {}", mesh_device->get_device_ids()[0]);
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
@@ -1554,14 +1552,14 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestLargeSubBufferReadPastRebase
     constexpr uint32_t region_num_pages = 64;
 
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running on Device {}", device->id());
+        const auto device_id = mesh_device->get_device_ids()[0];
+        log_info(tt::LogTest, "Running on Device {}", device_id);
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         bool pass = local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue_single_sub_buffer(
             mesh_device, cqs, page_size, buffer_num_pages, region_start_page, region_num_pages, BufferType::DRAM);
-        EXPECT_TRUE(pass) << "Large sub-buffer read past rebase boundary failed on device " << device->id();
+        EXPECT_TRUE(pass) << "Large sub-buffer read past rebase boundary failed on device " << device_id;
     }
 }
 
@@ -1709,8 +1707,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestLargeSubBufferReadPastRebas
 
 TEST_F(UnitMeshCQMultiDeviceBufferFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSize) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
+        log_info(tt::LogTest, "Running On Device {}", mesh_device->get_device_ids()[0]);
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
         TestBufferConfig config = {
@@ -2223,8 +2220,7 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestNon32BAlignedPageSizeForL1)
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToL1Bank0) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
+        log_info(tt::LogTest, "Running On Device {}", mesh_device->get_device_ids()[0]);
         TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::L1};
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
@@ -2236,8 +2232,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToL1Bank0) {
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllL1Banks) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
+        log_info(tt::LogTest, "Running On Device {}", mesh_device->get_device_ids()[0]);
         auto compute_with_storage_grid = mesh_device->compute_with_storage_grid_size();
         TestBufferConfig config = {
             .num_pages = uint32_t(compute_with_storage_grid.x * compute_with_storage_grid.y),
@@ -2254,8 +2249,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllL1Banks) {
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllL1BanksTwiceRoundRobin) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
+        log_info(tt::LogTest, "Running On Device {}", mesh_device->get_device_ids()[0]);
         auto compute_with_storage_grid = mesh_device->compute_with_storage_grid_size();
 
         TestBufferConfig config = {
@@ -2273,8 +2267,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllL1BanksTwiceRou
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForL1) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
+        log_info(tt::LogTest, "Running On Device {}", mesh_device->get_device_ids()[0]);
         TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::L1};
 
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -1399,6 +1399,8 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWrapCompletionQOnInsufficien
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToDramBank0) {
     TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::DRAM};
     for (const auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running On Device {}", device->id());
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
@@ -1409,6 +1411,8 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToDramBank0) {
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllDramBanks) {
     for (const auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running On Device {}", device->id());
         TestBufferConfig config = {
             .num_pages = uint32_t(mesh_device->allocator()->get_num_banks(BufferType::DRAM)),
             .page_size = 2048,
@@ -1418,13 +1422,16 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllDramBanks) {
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
-            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config));
+            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
+            << "Failed on device " << device->id();
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileAcrossAllDramBanksTwiceRoundRobin) {
     constexpr uint32_t num_round_robins = 2;
     for (const auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running On Device {}", device->id());
         TestBufferConfig config = {
             .num_pages = num_round_robins * (mesh_device->allocator()->get_num_banks(BufferType::DRAM)),
             .page_size = 2048,
@@ -1434,48 +1441,59 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileAcrossAllDramBanksTw
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
-            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config));
+            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
+            << "Failed on device " << device->id();
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, Sending131072Pages) {
     TestBufferConfig config = {.num_pages = 131072, .page_size = 128, .buftype = BufferType::DRAM};
     for (const auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running On Device {}", device->id());
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
-            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config));
+            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
+            << "Failed on device " << device->id();
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDram) {
     for (const auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running On Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::DRAM};
 
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
-            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config));
+            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
+            << "Failed on device " << device->id();
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDram2) {
     for (const auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running On Device {}", device->id());
         TestBufferConfig config = {.num_pages = 8 * 1024, .page_size = 80, .buftype = BufferType::DRAM};
 
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
-            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config));
+            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
+            << "Failed on device " << device->id();
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestIssueMultipleReadWriteCommandsForOneBuffer) {
     for (const auto& mesh_device : devices_) {
         auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running On Device {}", device->id());
         uint32_t page_size = 2048;
         uint32_t command_queue_size = device->sysmem_manager().get_cq_size();
         uint32_t num_pages = command_queue_size / page_size;
@@ -1486,7 +1504,8 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestIssueMultipleReadWriteComman
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
-            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config));
+            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
+            << "Failed on device " << device->id();
     }
 }
 
@@ -1494,6 +1513,8 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDram
     constexpr uint32_t page_size = 200;
     const uint32_t max_prefetch_command_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
     for (const auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running On Device {}", device->id());
         const uint32_t num_banks = mesh_device->allocator()->get_num_banks(BufferType::DRAM);
         const uint32_t num_pages = std::max(4 * num_banks, (max_prefetch_command_size / page_size) + num_banks);
         TestBufferConfig config = {.num_pages = num_pages, .page_size = page_size, .buftype = BufferType::DRAM};
@@ -1515,6 +1536,8 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestSubBufferReadCrossesRelayPag
         relay_page_boundary - 1, relay_page_boundary, relay_page_boundary + 1};
 
     for (const auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running On Device {}", device->id());
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
@@ -1531,12 +1554,14 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestLargeSubBufferReadPastRebase
     constexpr uint32_t region_num_pages = 64;
 
     for (const auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running on Device {}", device->id());
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         bool pass = local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue_single_sub_buffer(
             mesh_device, cqs, page_size, buffer_num_pages, region_start_page, region_num_pages, BufferType::DRAM);
-        EXPECT_TRUE(pass);
+        EXPECT_TRUE(pass) << "Large sub-buffer read past rebase boundary failed on device " << device->id();
     }
 }
 
@@ -1684,6 +1709,8 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestLargeSubBufferReadPastRebas
 
 TEST_F(UnitMeshCQMultiDeviceBufferFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSize) {
     for (const auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running On Device {}", device->id());
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
         TestBufferConfig config = {
@@ -2196,6 +2223,8 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestNon32BAlignedPageSizeForL1)
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToL1Bank0) {
     for (const auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running On Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::L1};
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
@@ -2207,6 +2236,8 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToL1Bank0) {
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllL1Banks) {
     for (const auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running On Device {}", device->id());
         auto compute_with_storage_grid = mesh_device->compute_with_storage_grid_size();
         TestBufferConfig config = {
             .num_pages = uint32_t(compute_with_storage_grid.x * compute_with_storage_grid.y),
@@ -2223,6 +2254,8 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllL1Banks) {
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllL1BanksTwiceRoundRobin) {
     for (const auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running On Device {}", device->id());
         auto compute_with_storage_grid = mesh_device->compute_with_storage_grid_size();
 
         TestBufferConfig config = {
@@ -2240,6 +2273,8 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllL1BanksTwiceRou
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForL1) {
     for (const auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running On Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::L1};
 
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -715,7 +715,6 @@ namespace dram_tests {
 TEST_F(UnitMeshCQSingleCardSharedBufferFixture, WriteOneTileToDramBank0) {
     TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::DRAM};
     for (const auto& mesh_device : devices_) {
-        log_info(tt::LogTest, "Running On Device {}", mesh_device->id());
         local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
             mesh_device, mesh_device->mesh_command_queue(), config);
     }
@@ -748,7 +747,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, WriteOneTileAcrossAllDramBanksTw
 TEST_F(UnitMeshCQSingleCardSharedBufferFixture, Sending131072Pages) {
     for (const auto& mesh_device : devices_) {
         TestBufferConfig config = {.num_pages = 131072, .page_size = 128, .buftype = BufferType::DRAM};
-        log_info(tt::LogTest, "Running On Device {}", mesh_device->id());
         local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
             mesh_device, mesh_device->mesh_command_queue(), config);
     }
@@ -852,7 +850,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestPagesAtRelayPagedScratchThre
 TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestSinglePageLargerThanMaxPrefetchCommandSizeShardedBuffer) {
     const uint32_t page_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size() + 2048;
     for (const auto& mesh_device : devices_) {
-        log_info(tt::LogTest, "Running On Device {}", mesh_device->id());
         CoreCoord start(0, 0);
         CoreCoord end(0, 0);
         CoreRange cores(start, end);
@@ -875,7 +872,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestSinglePageLargerThanMaxPrefe
 TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultiplePagesLargerThanMaxPrefetchCommandSizeShardedBuffer) {
     const uint32_t page_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size() + 2048;
     for (const auto& mesh_device : devices_) {
-        log_info(tt::LogTest, "Running On Device {}", mesh_device->get_devices()[0]->id());
         CoreCoord start(0, 0);
         CoreCoord end(3, 0);
         CoreRange cores(start, end);
@@ -899,7 +895,6 @@ TEST_F(
     UnitMeshCQSingleCardSharedBufferFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSizeShardedBuffer) {
     const uint32_t page_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size() + 4;
     for (const auto& mesh_device : devices_) {
-        log_info(tt::LogTest, "Running On Device {}", mesh_device->id());
         CoreCoord start(0, 0);
         CoreCoord end(3, 0);
         CoreRange cores(start, end);
@@ -921,9 +916,6 @@ TEST_F(
 
 TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultiplePagesLargerThanMaxPrefetchCommandSizeSubBuffer) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
-
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
         const uint32_t page_size = max_prefetch_command_size + 2048;
@@ -969,9 +961,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultipleUnalignedPagesLarger
 
 TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSizeSubBuffer) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
-
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
         const uint32_t page_size = max_prefetch_command_size + 4;
@@ -999,8 +988,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultiplePagesLargerThanMaxPr
     const uint32_t region_size = 5 * page_size;
     const uint32_t region_offset = 9 * page_size;
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         CoreCoord start(0, 0);
         CoreCoord end(4, 0);
         CoreRange cores(start, end);
@@ -1044,8 +1031,6 @@ TEST_F(
     const uint32_t region_size = 5 * page_size;
     const uint32_t region_offset = 9 * page_size;
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         CoreCoord start(0, 0);
         CoreCoord end(4, 0);
         CoreRange cores(start, end);
@@ -1102,7 +1087,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestNon32BAlignedPageSizeForDram
 TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWrapHostHugepageOnEnqueueReadBuffer) {
     for (const auto& mesh_device : devices_) {
         auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         uint32_t page_size = 2048;
         uint32_t command_issue_region_size = device->sysmem_manager().get_issue_queue_size(0);
         uint32_t cq_start = MetalContext::instance().dispatch_mem_map().get_host_command_queue_addr(
@@ -1122,7 +1106,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWrapHostHugepageOnEnqueueRea
 TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestIssueMultipleReadWriteCommandsForOneBuffer) {
     for (const auto& mesh_device : devices_) {
         auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", mesh_device->id());
         uint32_t page_size = 2048;
         uint32_t command_queue_size = device->sysmem_manager().get_cq_size();
         uint32_t num_pages = command_queue_size / page_size;
@@ -1141,7 +1124,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWrapCompletionQOnInsufficien
 
     for (const auto& mesh_device : devices_) {
         auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         uint32_t command_completion_region_size = device->sysmem_manager().get_completion_queue_size(0);
 
         uint32_t first_buffer_size =
@@ -1200,8 +1182,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadWriteShardedSubBuffer) {
     const uint32_t buffer_size = 64 * page_size;
     const BufferRegion region(256, 512);
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         CoreCoord start(0, 0);
         CoreCoord end(5, 0);
         CoreRange cores(start, end);
@@ -1239,9 +1219,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadWriteSubBuffer) {
     const uint32_t buffer_size = 64 * page_size;
     const BufferRegion region(256, 512);
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
-
         distributed::DeviceLocalBufferConfig dram_config{
             .page_size = page_size, .buffer_type = BufferType::DRAM, .bottom_up = false};
         const distributed::ReplicatedBufferConfig buffer_config{.size = buffer_size};
@@ -1265,8 +1242,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadWriteSubBufferLargeOffse
     const uint32_t buffer_size = (0xFFFF + 50000) * 2 * page_size;
     const BufferRegion region(((2 * 0xFFFF) + 25000) * page_size, 32);
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         distributed::DeviceLocalBufferConfig dram_config{
             .page_size = page_size, .buffer_type = BufferType::DRAM, .bottom_up = false};
         const distributed::ReplicatedBufferConfig buffer_config{.size = buffer_size};
@@ -1291,8 +1266,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadBufferWriteSubBuffer) {
     const uint32_t buffer_region_size = 128;
     const BufferRegion region(buffer_region_offset, buffer_region_size);
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         distributed::DeviceLocalBufferConfig dram_config{
             .page_size = page_size, .buffer_type = BufferType::DRAM, .bottom_up = false};
         const distributed::ReplicatedBufferConfig buffer_config{.size = buffer_size};
@@ -1323,8 +1296,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadSubBufferWriteBuffer) {
     const uint32_t buffer_region_size = 128;
     const BufferRegion region(buffer_region_offset, buffer_region_size);
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         distributed::DeviceLocalBufferConfig dram_config{
             .page_size = page_size, .buffer_type = BufferType::DRAM, .bottom_up = false};
         const distributed::ReplicatedBufferConfig buffer_config{.size = buffer_size};
@@ -1352,8 +1323,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadSubBufferInvalidRegion) 
     const uint32_t buffer_region_size = buffer_size;
     const BufferRegion region(buffer_region_offset, buffer_region_size);
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         distributed::DeviceLocalBufferConfig dram_config{
             .page_size = page_size, .buffer_type = BufferType::DRAM, .bottom_up = false};
         const distributed::ReplicatedBufferConfig buffer_config{.size = buffer_size};
@@ -1371,8 +1340,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWriteSubBufferInvalidRegion)
     const uint32_t buffer_region_size = buffer_size;
     const BufferRegion region(buffer_region_offset, buffer_region_size);
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         distributed::DeviceLocalBufferConfig dram_config{
             .page_size = page_size, .buffer_type = BufferType::DRAM, .bottom_up = false};
         const distributed::ReplicatedBufferConfig buffer_config{.size = buffer_size};
@@ -1389,7 +1356,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWrapCompletionQOnInsufficien
     // Using default 75-25 issue and completion queue split
     for (const auto& mesh_device : devices_) {
         auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         uint32_t command_completion_region_size = device->sysmem_manager().get_completion_queue_size(0);
 
         uint32_t num_pages_buff_1 = 9;
@@ -1433,8 +1399,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWrapCompletionQOnInsufficien
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToDramBank0) {
     TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::DRAM};
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
@@ -1445,8 +1409,6 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToDramBank0) {
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllDramBanks) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         TestBufferConfig config = {
             .num_pages = uint32_t(mesh_device->allocator()->get_num_banks(BufferType::DRAM)),
             .page_size = 2048,
@@ -1456,16 +1418,13 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllDramBanks) {
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
-            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
-            << "Failed on device " << device->id();
+            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config));
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileAcrossAllDramBanksTwiceRoundRobin) {
     constexpr uint32_t num_round_robins = 2;
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         TestBufferConfig config = {
             .num_pages = num_round_robins * (mesh_device->allocator()->get_num_banks(BufferType::DRAM)),
             .page_size = 2048,
@@ -1475,59 +1434,48 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileAcrossAllDramBanksTw
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
-            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
-            << "Failed on device " << device->id();
+            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config));
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, Sending131072Pages) {
     TestBufferConfig config = {.num_pages = 131072, .page_size = 128, .buftype = BufferType::DRAM};
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
-            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
-            << "Failed on device " << device->id();
+            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config));
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDram) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::DRAM};
 
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
-            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
-            << "Failed on device " << device->id();
+            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config));
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDram2) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         TestBufferConfig config = {.num_pages = 8 * 1024, .page_size = 80, .buftype = BufferType::DRAM};
 
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
-            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
-            << "Failed on device " << device->id();
+            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config));
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestIssueMultipleReadWriteCommandsForOneBuffer) {
     for (const auto& mesh_device : devices_) {
         auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         uint32_t page_size = 2048;
         uint32_t command_queue_size = device->sysmem_manager().get_cq_size();
         uint32_t num_pages = command_queue_size / page_size;
@@ -1538,8 +1486,7 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestIssueMultipleReadWriteComman
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         EXPECT_TRUE(
-            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config))
-            << "Failed on device " << device->id();
+            local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(mesh_device, cqs, config));
     }
 }
 
@@ -1547,8 +1494,6 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForDram
     constexpr uint32_t page_size = 200;
     const uint32_t max_prefetch_command_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         const uint32_t num_banks = mesh_device->allocator()->get_num_banks(BufferType::DRAM);
         const uint32_t num_pages = std::max(4 * num_banks, (max_prefetch_command_size / page_size) + num_banks);
         TestBufferConfig config = {.num_pages = num_pages, .page_size = page_size, .buftype = BufferType::DRAM};
@@ -1570,8 +1515,6 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestSubBufferReadCrossesRelayPag
         relay_page_boundary - 1, relay_page_boundary, relay_page_boundary + 1};
 
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
@@ -1588,14 +1531,12 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestLargeSubBufferReadPastRebase
     constexpr uint32_t region_num_pages = 64;
 
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running on Device {}", device->id());
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {a, b};
         bool pass = local_test_functions::test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue_single_sub_buffer(
             mesh_device, cqs, page_size, buffer_num_pages, region_start_page, region_num_pages, BufferType::DRAM);
-        EXPECT_TRUE(pass) << "Large sub-buffer read past rebase boundary failed on device " << device->id();
+        EXPECT_TRUE(pass);
     }
 }
 
@@ -1743,8 +1684,6 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestLargeSubBufferReadPastRebas
 
 TEST_F(UnitMeshCQMultiDeviceBufferFixture, TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSize) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         const uint32_t max_prefetch_command_size =
             MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
         TestBufferConfig config = {
@@ -1766,14 +1705,11 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadWriteShardedSubBufferFor
     const std::vector<ShardedSubBufferStressTestConfig>& configs =
         local_test_functions::generate_sharded_sub_buffer_test_configs(max_buffer_size);
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running on Device {}", device->id());
         for (const ShardedSubBufferStressTestConfig& config : configs) {
             log_debug(
                 tt::LogTest,
-                "Device: {} buffer_size: {} page_size: {} region_offset: {} region_size: {} shard_shape: [{}, {}] "
+                "buffer_size: {} page_size: {} region_offset: {} region_size: {} shard_shape: [{}, {}] "
                 "page_shape: [{}, {}] tensor2d_shape_in_pages: [{}, {}] layout: {} orientation: {} cores: {}",
-                device->id(),
                 config.buffer_size,
                 config.page_size,
                 config.region_offset,
@@ -1819,8 +1755,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultipleNonOverlappingWrites
     const uint32_t buffer_size = 16 * page_size;
     const uint32_t buffer_region_size = 4 * page_size;
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running on Device {}", device->id());
         CoreCoord start_coord = {0, 0};
         CoreCoord end_coord = {5, 5};
         CoreRange cores(start_coord, end_coord);
@@ -1889,7 +1823,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultiplePagesLargerThanMaxPr
 TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultiplePagesLargerThanMaxPrefetchCommandSizeForL1ShardedBuffer) {
     const uint32_t page_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size() + 2048;
     for (const auto& mesh_device : devices_) {
-        log_info(tt::LogTest, "Running On Device {}", mesh_device->id());
         CoreCoord start(0, 0);
         CoreCoord end(4, 4);
         CoreRange cores(start, end);
@@ -1936,7 +1869,6 @@ TEST_F(
     TestMultipleUnalignedPagesLargerThanMaxPrefetchCommandSizeForL1ShardedBuffer) {
     const uint32_t page_size = MetalContext::instance().dispatch_mem_map().max_prefetch_command_size() + 4;
     for (const auto& mesh_device : devices_) {
-        log_info(tt::LogTest, "Running On Device {}", mesh_device->id());
         CoreCoord start(0, 0);
         CoreCoord end(3, 3);
         CoreRange cores(start, end);
@@ -1964,8 +1896,6 @@ TEST_F(
     const uint32_t region_offset = 16 * page_size;
     const uint32_t region_size = 16 * page_size;
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         CoreCoord start(0, 0);
         CoreCoord end(3, 3);
         CoreRange cores(start, end);
@@ -2002,8 +1932,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultipleNonOverlappingReadsS
     const uint32_t buffer_size = 16 * page_size;
     const uint32_t buffer_region_size = buffer_size / 4;
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running on Device {}", device->id());
         CoreCoord start_coord = {0, 0};
         CoreCoord end_coord = {5, 5};
         CoreRange cores(start_coord, end_coord);
@@ -2067,8 +1995,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadWriteShardedSubBufferMul
     const uint32_t buffer_region_size = page_size * 7;
     vector<uint32_t> src = local_test_functions::generate_arange_vector(buffer_region_size);
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running on Device {}", device->id());
         CoreCoord start_coord = {0, 0};
         CoreCoord end_coord = {3, 3};
         CoreRange cores(start_coord, end_coord);
@@ -2100,9 +2026,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadWriteSubBufferForL1) {
     const uint32_t buffer_size = 128 * page_size;
     const BufferRegion region(2 * page_size, 2048);
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
-
         distributed::DeviceLocalBufferConfig l1_config{
             .page_size = page_size, .buffer_type = BufferType::L1, .bottom_up = false};
         const distributed::ReplicatedBufferConfig buffer_config{.size = buffer_size};
@@ -2120,9 +2043,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadWriteSubBufferLargeOffse
     const uint32_t buffer_size = 512 * page_size;
     const BufferRegion region(400 * page_size, 2048);
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
-
         distributed::DeviceLocalBufferConfig l1_config{
             .page_size = page_size, .buffer_type = BufferType::L1, .bottom_up = false};
         const distributed::ReplicatedBufferConfig buffer_config{.size = buffer_size};
@@ -2276,8 +2196,6 @@ TEST_F(UnitMeshMultiCQSingleDeviceBufferFixture, TestNon32BAlignedPageSizeForL1)
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToL1Bank0) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1, .page_size = 2048, .buftype = BufferType::L1};
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
         distributed::MeshCommandQueue& b = mesh_device->mesh_command_queue(1);
@@ -2289,8 +2207,6 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToL1Bank0) {
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllL1Banks) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         auto compute_with_storage_grid = mesh_device->compute_with_storage_grid_size();
         TestBufferConfig config = {
             .num_pages = uint32_t(compute_with_storage_grid.x * compute_with_storage_grid.y),
@@ -2307,8 +2223,6 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllL1Banks) {
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllL1BanksTwiceRoundRobin) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         auto compute_with_storage_grid = mesh_device->compute_with_storage_grid_size();
 
         TestBufferConfig config = {
@@ -2326,8 +2240,6 @@ TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, WriteOneTileToAllL1BanksTwiceRou
 
 TEST_F(UnitMeshMultiCQMultiDeviceBufferFixture, TestNon32BAlignedPageSizeForL1) {
     for (const auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running On Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1250, .page_size = 200, .buftype = BufferType::L1};
 
         distributed::MeshCommandQueue& a = mesh_device->mesh_command_queue(0);
@@ -2417,7 +2329,6 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, WritesToRandomBufferTypeAndThenR
         .seed = 0, .num_pages_total = 50000, .page_size = 2048, .max_num_pages_per_buffer = 16};
 
     for (const auto& mesh_device : devices_) {
-        log_info(tt::LogTest, "Running on Device {}", mesh_device->id());
         EXPECT_TRUE(local_test_functions::stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer<true>(
             mesh_device, mesh_device->mesh_command_queue(), config));
     }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
@@ -222,7 +222,7 @@ namespace basic_tests {
 // wrap issue queue)
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsEventSynchronizeSanity) {
     for (auto& mesh_device : devices_) {
-        log_info(tt::LogTest, "Running On Device {}", mesh_device->get_devices()[0]->id());
+        log_info(tt::LogTest, "Running On Device {}", mesh_device->get_device_ids()[0]);
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {
             mesh_device->mesh_command_queue(0), mesh_device->mesh_command_queue(1)};
         vector<uint32_t> cmds_issued_per_cq = {0, 0};
@@ -441,8 +441,8 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
 // Ensure read back data is correct, data is different for each write.
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQs) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running on Device {}", device->id());
+        const auto device_id = mesh_device->get_device_ids()[0];
+        log_info(tt::LogTest, "Running on Device {}", device_id);
         TestBufferConfig config = {.num_pages = 1, .page_size = 32, .buftype = BufferType::DRAM};
         auto start = std::chrono::system_clock::now();
         bool pass = local_test_functions::RunCrossCqReadWriteWithWaitForEvent(
@@ -455,15 +455,15 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
 
         auto end = std::chrono::system_clock::now();
         std::chrono::duration<double> elapsed_seconds = (end - start);
-        log_info(tt::LogTest, "Device {} finished in {}us", device->id(), elapsed_seconds.count() * 1000 * 1000);
-        EXPECT_TRUE(pass) << "Cross-CQ event read/write failed on device " << device->id();
+        log_info(tt::LogTest, "Device {} finished in {}us", device_id, elapsed_seconds.count() * 1000 * 1000);
+        EXPECT_TRUE(pass) << "Cross-CQ event read/write failed on device " << device_id;
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQsDeterministic) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running on Device {}", device->id());
+        const auto device_id = mesh_device->get_device_ids()[0];
+        log_info(tt::LogTest, "Running on Device {}", device_id);
         TestBufferConfig config = {.num_pages = 4, .page_size = 256, .buftype = BufferType::DRAM};
         bool pass = local_test_functions::RunCrossCqReadWriteWithWaitForEvent(
             mesh_device,
@@ -472,14 +472,14 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
             /*num_buffers_per_cq=*/8,
             /*vary_buffer_sizes=*/false,
             /*notify_host=*/false);
-        EXPECT_TRUE(pass) << "Deterministic cross-CQ event failed on device " << device->id();
+        EXPECT_TRUE(pass) << "Deterministic cross-CQ event failed on device " << device_id;
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQsHostVisibleControl) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running on Device {}", device->id());
+        const auto device_id = mesh_device->get_device_ids()[0];
+        log_info(tt::LogTest, "Running on Device {}", device_id);
         TestBufferConfig config = {.num_pages = 1, .page_size = 32, .buftype = BufferType::DRAM};
         bool pass = local_test_functions::RunCrossCqReadWriteWithWaitForEvent(
             mesh_device,
@@ -488,39 +488,39 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
             /*num_buffers_per_cq=*/50,
             /*vary_buffer_sizes=*/true,
             /*notify_host=*/true);
-        EXPECT_TRUE(pass) << "Host-visible cross-CQ event failed on device " << device->id();
+        EXPECT_TRUE(pass) << "Host-visible cross-CQ event failed on device " << device_id;
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsBurstWritesThenSingleCrossCqEvent) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running on Device {}", device->id());
+        const auto device_id = mesh_device->get_device_ids()[0];
+        log_info(tt::LogTest, "Running on Device {}", device_id);
         TestBufferConfig config = {.num_pages = 4, .page_size = 256, .buftype = BufferType::DRAM};
         bool pass = local_test_functions::RunBurstWritesThenSingleCrossCqEvent(
             mesh_device, zero_coord_, config, /*num_buffers=*/6);
-        EXPECT_TRUE(pass) << "Burst writes + event ordering failed on device " << device->id();
+        EXPECT_TRUE(pass) << "Burst writes + event ordering failed on device " << device_id;
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsDeviceOnlyEventChainWithPerIterationValidation) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running on Device {}", device->id());
+        const auto device_id = mesh_device->get_device_ids()[0];
+        log_info(tt::LogTest, "Running on Device {}", device_id);
         TestBufferConfig config = {.num_pages = 4, .page_size = 256, .buftype = BufferType::DRAM};
         bool pass = local_test_functions::RunDeviceOnlyEventChainWithPerIterationValidation(
             mesh_device, zero_coord_, config, /*num_iterations=*/16);
-        EXPECT_TRUE(pass) << "Device-only event chain failed on device " << device->id();
+        EXPECT_TRUE(pass) << "Device-only event chain failed on device " << device_id;
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsHeavyBurstWritesThenDeviceOnlyEvent) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running on Device {}", device->id());
+        const auto device_id = mesh_device->get_device_ids()[0];
+        log_info(tt::LogTest, "Running on Device {}", device_id);
         bool pass =
             local_test_functions::RunHeavyBurstWritesThenDeviceOnlyEvent(mesh_device, zero_coord_, /*num_buffers=*/12);
-        EXPECT_TRUE(pass) << "Heavy burst event ordering failed on device " << device->id();
+        EXPECT_TRUE(pass) << "Heavy burst event ordering failed on device " << device_id;
     }
 }
 
@@ -529,8 +529,8 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsHeavyBurstWritesThenDev
 // write and write after read before checking correct data read at the end after all cmds finished on device.
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQsPingPong) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running on Device {}", device->id());
+        const auto device_id = mesh_device->get_device_ids()[0];
+        log_info(tt::LogTest, "Running on Device {}", device_id);
         TestBufferConfig config = {.num_pages = 1, .page_size = 16, .buftype = BufferType::DRAM};
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {
             mesh_device->mesh_command_queue(0), mesh_device->mesh_command_queue(1)};
@@ -645,9 +645,9 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
 
         auto end = std::chrono::system_clock::now();
         std::chrono::duration<double> elapsed_seconds = (end - start);
-        log_info(tt::LogTest, "Device {} finished in {}us", device->id(), elapsed_seconds.count() * 1000 * 1000);
+        log_info(tt::LogTest, "Device {} finished in {}us", device_id, elapsed_seconds.count() * 1000 * 1000);
 
-        EXPECT_TRUE(pass) << "PingPong event chain failed on device " << device->id();
+        EXPECT_TRUE(pass) << "PingPong event chain failed on device " << device_id;
     }
 }
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
@@ -222,7 +222,6 @@ namespace basic_tests {
 // wrap issue queue)
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsEventSynchronizeSanity) {
     for (auto& mesh_device : devices_) {
-        log_info(tt::LogTest, "Running On Device {}", mesh_device->get_devices()[0]->id());
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {
             mesh_device->mesh_command_queue(0), mesh_device->mesh_command_queue(1)};
         vector<uint32_t> cmds_issued_per_cq = {0, 0};
@@ -441,8 +440,6 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
 // Ensure read back data is correct, data is different for each write.
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQs) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running on Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1, .page_size = 32, .buftype = BufferType::DRAM};
         auto start = std::chrono::system_clock::now();
         bool pass = local_test_functions::RunCrossCqReadWriteWithWaitForEvent(
@@ -455,15 +452,13 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
 
         auto end = std::chrono::system_clock::now();
         std::chrono::duration<double> elapsed_seconds = (end - start);
-        log_info(tt::LogTest, "Device {} finished in {}us", device->id(), elapsed_seconds.count() * 1000 * 1000);
-        EXPECT_TRUE(pass) << "Cross-CQ event read/write failed on device " << device->id();
+        log_info(tt::LogTest, "Test finished in {}us", elapsed_seconds.count() * 1000 * 1000);
+        EXPECT_TRUE(pass);
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQsDeterministic) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running on Device {}", device->id());
         TestBufferConfig config = {.num_pages = 4, .page_size = 256, .buftype = BufferType::DRAM};
         bool pass = local_test_functions::RunCrossCqReadWriteWithWaitForEvent(
             mesh_device,
@@ -472,14 +467,12 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
             /*num_buffers_per_cq=*/8,
             /*vary_buffer_sizes=*/false,
             /*notify_host=*/false);
-        EXPECT_TRUE(pass) << "Deterministic cross-CQ event failed on device " << device->id();
+        EXPECT_TRUE(pass);
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQsHostVisibleControl) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running on Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1, .page_size = 32, .buftype = BufferType::DRAM};
         bool pass = local_test_functions::RunCrossCqReadWriteWithWaitForEvent(
             mesh_device,
@@ -488,39 +481,33 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
             /*num_buffers_per_cq=*/50,
             /*vary_buffer_sizes=*/true,
             /*notify_host=*/true);
-        EXPECT_TRUE(pass) << "Host-visible cross-CQ event failed on device " << device->id();
+        EXPECT_TRUE(pass);
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsBurstWritesThenSingleCrossCqEvent) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running on Device {}", device->id());
         TestBufferConfig config = {.num_pages = 4, .page_size = 256, .buftype = BufferType::DRAM};
         bool pass = local_test_functions::RunBurstWritesThenSingleCrossCqEvent(
             mesh_device, zero_coord_, config, /*num_buffers=*/6);
-        EXPECT_TRUE(pass) << "Burst writes + event ordering failed on device " << device->id();
+        EXPECT_TRUE(pass);
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsDeviceOnlyEventChainWithPerIterationValidation) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running on Device {}", device->id());
         TestBufferConfig config = {.num_pages = 4, .page_size = 256, .buftype = BufferType::DRAM};
         bool pass = local_test_functions::RunDeviceOnlyEventChainWithPerIterationValidation(
             mesh_device, zero_coord_, config, /*num_iterations=*/16);
-        EXPECT_TRUE(pass) << "Device-only event chain failed on device " << device->id();
+        EXPECT_TRUE(pass);
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsHeavyBurstWritesThenDeviceOnlyEvent) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running on Device {}", device->id());
         bool pass =
             local_test_functions::RunHeavyBurstWritesThenDeviceOnlyEvent(mesh_device, zero_coord_, /*num_buffers=*/12);
-        EXPECT_TRUE(pass) << "Heavy burst event ordering failed on device " << device->id();
+        EXPECT_TRUE(pass);
     }
 }
 
@@ -529,8 +516,6 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsHeavyBurstWritesThenDev
 // write and write after read before checking correct data read at the end after all cmds finished on device.
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQsPingPong) {
     for (auto& mesh_device : devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        log_info(tt::LogTest, "Running on Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1, .page_size = 16, .buftype = BufferType::DRAM};
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {
             mesh_device->mesh_command_queue(0), mesh_device->mesh_command_queue(1)};
@@ -645,9 +630,9 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
 
         auto end = std::chrono::system_clock::now();
         std::chrono::duration<double> elapsed_seconds = (end - start);
-        log_info(tt::LogTest, "Device {} finished in {}us", device->id(), elapsed_seconds.count() * 1000 * 1000);
+        log_info(tt::LogTest, "Test finished in {}us", elapsed_seconds.count() * 1000 * 1000);
 
-        EXPECT_TRUE(pass) << "PingPong event chain failed on device " << device->id();
+        EXPECT_TRUE(pass);
     }
 }
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
@@ -222,6 +222,7 @@ namespace basic_tests {
 // wrap issue queue)
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsEventSynchronizeSanity) {
     for (auto& mesh_device : devices_) {
+        log_info(tt::LogTest, "Running On Device {}", mesh_device->get_devices()[0]->id());
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {
             mesh_device->mesh_command_queue(0), mesh_device->mesh_command_queue(1)};
         vector<uint32_t> cmds_issued_per_cq = {0, 0};
@@ -440,6 +441,8 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
 // Ensure read back data is correct, data is different for each write.
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQs) {
     for (auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running on Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1, .page_size = 32, .buftype = BufferType::DRAM};
         auto start = std::chrono::system_clock::now();
         bool pass = local_test_functions::RunCrossCqReadWriteWithWaitForEvent(
@@ -452,13 +455,15 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
 
         auto end = std::chrono::system_clock::now();
         std::chrono::duration<double> elapsed_seconds = (end - start);
-        log_info(tt::LogTest, "Test finished in {}us", elapsed_seconds.count() * 1000 * 1000);
-        EXPECT_TRUE(pass);
+        log_info(tt::LogTest, "Device {} finished in {}us", device->id(), elapsed_seconds.count() * 1000 * 1000);
+        EXPECT_TRUE(pass) << "Cross-CQ event read/write failed on device " << device->id();
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQsDeterministic) {
     for (auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running on Device {}", device->id());
         TestBufferConfig config = {.num_pages = 4, .page_size = 256, .buftype = BufferType::DRAM};
         bool pass = local_test_functions::RunCrossCqReadWriteWithWaitForEvent(
             mesh_device,
@@ -467,12 +472,14 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
             /*num_buffers_per_cq=*/8,
             /*vary_buffer_sizes=*/false,
             /*notify_host=*/false);
-        EXPECT_TRUE(pass);
+        EXPECT_TRUE(pass) << "Deterministic cross-CQ event failed on device " << device->id();
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQsHostVisibleControl) {
     for (auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running on Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1, .page_size = 32, .buftype = BufferType::DRAM};
         bool pass = local_test_functions::RunCrossCqReadWriteWithWaitForEvent(
             mesh_device,
@@ -481,33 +488,39 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
             /*num_buffers_per_cq=*/50,
             /*vary_buffer_sizes=*/true,
             /*notify_host=*/true);
-        EXPECT_TRUE(pass);
+        EXPECT_TRUE(pass) << "Host-visible cross-CQ event failed on device " << device->id();
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsBurstWritesThenSingleCrossCqEvent) {
     for (auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running on Device {}", device->id());
         TestBufferConfig config = {.num_pages = 4, .page_size = 256, .buftype = BufferType::DRAM};
         bool pass = local_test_functions::RunBurstWritesThenSingleCrossCqEvent(
             mesh_device, zero_coord_, config, /*num_buffers=*/6);
-        EXPECT_TRUE(pass);
+        EXPECT_TRUE(pass) << "Burst writes + event ordering failed on device " << device->id();
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsDeviceOnlyEventChainWithPerIterationValidation) {
     for (auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running on Device {}", device->id());
         TestBufferConfig config = {.num_pages = 4, .page_size = 256, .buftype = BufferType::DRAM};
         bool pass = local_test_functions::RunDeviceOnlyEventChainWithPerIterationValidation(
             mesh_device, zero_coord_, config, /*num_iterations=*/16);
-        EXPECT_TRUE(pass);
+        EXPECT_TRUE(pass) << "Device-only event chain failed on device " << device->id();
     }
 }
 
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsHeavyBurstWritesThenDeviceOnlyEvent) {
     for (auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running on Device {}", device->id());
         bool pass =
             local_test_functions::RunHeavyBurstWritesThenDeviceOnlyEvent(mesh_device, zero_coord_, /*num_buffers=*/12);
-        EXPECT_TRUE(pass);
+        EXPECT_TRUE(pass) << "Heavy burst event ordering failed on device " << device->id();
     }
 }
 
@@ -516,6 +529,8 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsHeavyBurstWritesThenDev
 // write and write after read before checking correct data read at the end after all cmds finished on device.
 TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEventCrossCQsPingPong) {
     for (auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        log_info(tt::LogTest, "Running on Device {}", device->id());
         TestBufferConfig config = {.num_pages = 1, .page_size = 16, .buftype = BufferType::DRAM};
         vector<std::reference_wrapper<distributed::MeshCommandQueue>> cqs = {
             mesh_device->mesh_command_queue(0), mesh_device->mesh_command_queue(1)};
@@ -630,9 +645,9 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
 
         auto end = std::chrono::system_clock::now();
         std::chrono::duration<double> elapsed_seconds = (end - start);
-        log_info(tt::LogTest, "Test finished in {}us", elapsed_seconds.count() * 1000 * 1000);
+        log_info(tt::LogTest, "Device {} finished in {}us", device->id(), elapsed_seconds.count() * 1000 * 1000);
 
-        EXPECT_TRUE(pass);
+        EXPECT_TRUE(pass) << "PingPong event chain failed on device " << device->id();
     }
 }
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -910,8 +910,6 @@ void test_basic_dispatch_functions(const std::shared_ptr<distributed::MeshDevice
     auto* device = mesh_device->get_devices()[0];
     log_info(tt::LogTest, "Running On Device {} CQ{}", mesh_device->id(), cq_id);
 
-    log_info(tt::LogTest, "Running On Device {} CQ{}", device->id(), cq_id);
-
     // Alternate write patterns
     std::vector<uint32_t> src_data_1(k_DataSize / sizeof(uint32_t));
     std::vector<uint32_t> src_data_2(k_DataSize / sizeof(uint32_t));
@@ -1789,8 +1787,7 @@ TEST_F(UnitMeshCQFixture, TestLogicalCoordinatesEth) {
     GTEST_SKIP() << "Mesh device does not support logical / relative coordinates on Eth";
     for (const auto& device : devices_) {
         if (!does_device_have_active_eth_cores(device->get_devices()[0])) {
-            GTEST_SKIP() << "Skipping test because device " << device->id()
-                         << " does not have any active ethernet cores";
+            GTEST_SKIP() << "Skipping test because device does not have any active ethernet cores";
         }
         const auto erisc_count =
             tt::tt_metal::MetalContext::instance().hal().get_num_risc_processors(HalProgrammableCoreType::ACTIVE_ETH);
@@ -2380,8 +2377,7 @@ TEST_F(UnitMeshRandomProgramFixture, TensixTestSimplePrograms) {
 TEST_F(UnitMeshRandomProgramFixture, TensixActiveEthTestSimplePrograms) {
     for (const auto& device : device_->get_devices()) {
         if (!does_device_have_active_eth_cores(device)) {
-            GTEST_SKIP() << "Skipping test because device " << device->id()
-                         << " does not have any active ethernet cores";
+            GTEST_SKIP() << "Skipping test because device does not have any active ethernet cores";
         }
     }
 
@@ -2412,8 +2408,7 @@ TEST_F(UnitMeshRandomProgramFixture, TensixActiveEthTestSimplePrograms) {
 TEST_F(UnitMeshRandomProgramFixture, ActiveEthTestPrograms) {
     for (const auto& device : device_->get_devices()) {
         if (!does_device_have_active_eth_cores(device)) {
-            GTEST_SKIP() << "Skipping test because device " << device->id()
-                         << " does not have any active ethernet cores";
+            GTEST_SKIP() << "Skipping test because device does not have any active ethernet cores";
         }
     }
 
@@ -2440,8 +2435,7 @@ TEST_F(UnitMeshRandomProgramFixture, ActiveEthTestPrograms) {
 TEST_F(UnitMeshRandomProgramFixture, TensixActiveEthTestPrograms) {
     for (const auto& device : device_->get_devices()) {
         if (!does_device_have_active_eth_cores(device)) {
-            GTEST_SKIP() << "Skipping test because device " << device->id()
-                         << " does not have any active ethernet cores";
+            GTEST_SKIP() << "Skipping test because device does not have any active ethernet cores";
         }
     }
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_stress.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_dispatch_stress.cpp
@@ -136,7 +136,6 @@ TEST(DispatchStress, TensixRunManyTimes) {
 
         // Run the test on each device
         for (auto& device : devices_) {
-            log_info(LogTest, "Running on device {}", device->get_devices()[0]->id());
             RunTest(device);
         }
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_trace/test_EnqueueTrace.cpp
@@ -658,8 +658,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, TensixTestSimpleProgramsTrace) {
 
 TEST_F(UnitMeshRandomProgramTraceFixture, ActiveEthTestSimpleProgramsTrace) {
     if (!does_device_have_active_eth_cores(this->device_->get_devices()[0])) {
-        GTEST_SKIP() << "Skipping test because device " << this->device_->get_devices()[0]->id()
-                     << " does not have any active ethernet cores";
+        GTEST_SKIP() << "Skipping test because device does not have any active ethernet cores";
     }
 
     auto& mesh_command_queue = this->device_->mesh_command_queue();
@@ -682,8 +681,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, ActiveEthTestSimpleProgramsTrace) {
 
 TEST_F(UnitMeshRandomProgramTraceFixture, TensixActiveEthTestSimpleProgramsTrace) {
     if (!does_device_have_active_eth_cores(this->device_->get_devices()[0])) {
-        GTEST_SKIP() << "Skipping test because device " << this->device_->get_devices()[0]->id()
-                     << " does not have any active ethernet cores";
+        GTEST_SKIP() << "Skipping test because device does not have any active ethernet cores";
     }
 
     auto& mesh_command_queue = this->device_->mesh_command_queue();
@@ -734,8 +732,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, NIGHTLY_TensixTestProgramsTrace) {
 
 TEST_F(UnitMeshRandomProgramTraceFixture, ActiveEthTestProgramsTrace) {
     if (!does_device_have_active_eth_cores(this->device_->get_devices()[0])) {
-        GTEST_SKIP() << "Skipping test because device " << this->device_->get_devices()[0]->id()
-                     << " does not have any active ethernet cores";
+        GTEST_SKIP() << "Skipping test because device does not have any active ethernet cores";
     }
 
     auto& mesh_command_queue = this->device_->mesh_command_queue();
@@ -763,8 +760,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, ActiveEthTestProgramsTrace) {
 
 TEST_F(UnitMeshRandomProgramTraceFixture, TensixActiveEthTestProgramsTrace) {
     if (!does_device_have_active_eth_cores(this->device_->get_devices()[0])) {
-        GTEST_SKIP() << "Skipping test because device " << this->device_->get_devices()[0]->id()
-                     << " does not have any active ethernet cores";
+        GTEST_SKIP() << "Skipping test because device does not have any active ethernet cores";
     }
 
     auto& mesh_command_queue = this->device_->mesh_command_queue();
@@ -929,8 +925,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, TensixTestProgramsTraceAndNoTrace) {
 
 TEST_F(UnitMeshRandomProgramTraceFixture, ActiveEthTestProgramsTraceAndNoTrace) {
     if (!does_device_have_active_eth_cores(this->device_->get_devices()[0])) {
-        GTEST_SKIP() << "Skipping test because device " << this->device_->get_devices()[0]->id()
-                     << " does not have any active ethernet cores";
+        GTEST_SKIP() << "Skipping test because device does not have any active ethernet cores";
     }
 
     auto& mesh_command_queue = this->device_->mesh_command_queue();
@@ -984,8 +979,7 @@ TEST_F(UnitMeshRandomProgramTraceFixture, ActiveEthTestProgramsTraceAndNoTrace) 
 
 TEST_F(UnitMeshRandomProgramTraceFixture, TensixActiveEthTestProgramsTraceAndNoTrace) {
     if (!does_device_have_active_eth_cores(this->device_->get_devices()[0])) {
-        GTEST_SKIP() << "Skipping test because device " << this->device_->get_devices()[0]->id()
-                     << " does not have any active ethernet cores";
+        GTEST_SKIP() << "Skipping test because device does not have any active ethernet cores";
     }
 
     auto& mesh_command_queue = this->device_->mesh_command_queue();


### PR DESCRIPTION
### PR Category
Cleanup, Test Only

### Summary

Advances https://github.com/tenstorrent/tt-metal/issues/51835

We're aiming to remove `IDevice` from the public API.
It's used, in particular, in `MeshDevice::get_devices()` method.
A lot of its usage appears in tests just to log the device ID.

To reduce the scope of the complete cleanup, we:
- Remove the device ID logs from a single-device tests.
- Switch to `get_device_ids()[0]` in multi-device tests.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov-device-id-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov-device-id-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov-device-id-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov-device-id-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov-device-id-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov-device-id-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov-device-id-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov-device-id-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov-device-id-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov-device-id-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov-device-id-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov-device-id-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov-device-id-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov-device-id-logs)