### PR TITLE
docs(fabric): enumeration engine benchmark — cold gimsatul vs warm CaDiCaL

### DIFF
--- a/tt_metal/fabric/ENUM_ENGINE_BENCHMARK.md
+++ b/tt_metal/fabric/ENUM_ENGINE_BENCHMARK.md
@@ -1,0 +1,106 @@
+# Enumeration engine benchmark — repeated-cold gimsatul vs warm incremental CaDiCaL
+
+**Question.** For enumerating *N* solutions of the inter-mesh SAT problem, what is fastest and most stable: solving
+each solution **cold** with gimsatul (a purpose-built parallel clause-sharing solver, no incremental API), or keeping
+one/many **warm** incremental CaDiCaL solvers and adding blocking clauses? And do the hybrid / multithreaded variants
+help?
+
+**Method (apples-to-apples, isolates the SAT engine).** Dumped the real **2×4-128 base-embedding CNF** onto SC36 via
+`TT_TOPO_SAT_DUMP_DIMACS` (55,024 vars, 156,936 clauses). Every approach enumerates successive solutions with the same
+**full-model blocking clause** (¬ the entire assignment) so the comparison is purely "how fast does this engine find
+the next satisfying assignment". Solvers: **gimsatul v1.1.3** (built from source, `--threads=8`), **CaDiCaL** (the
+version tt-metal links, via `libcadical.a`). Harnesses in `enum_engine_benchmark_scripts/`. All numbers on base 128;
+the capped/min-host regime is **not yet tested** (see Open).
+
+## Approaches benchmarked
+
+| approach | what it is | harness |
+|---|---|---|
+| **cold gimsatul** | solve → parse model → append blocking clause → re-solve cold, repeat | `cold_enum.sh` |
+| **single warm CaDiCaL** | one incremental solver: solve → block → solve … (learned clauses + phases persist) | `warm_enum.cpp` |
+| **hybrid** | gimsatul finds #1 cold, then hand off to a warm CaDiCaL for the rest | `hybrid_enum.sh` |
+| **MT warm** | 16 incremental CaDiCaL workers sharing learned + blocking clauses (native clause-sharing) | `mt_warm_enum.cpp` |
+
+## Headline results — 10 solutions, base 128
+
+| approach | time (10 sols) | stability (6 runs) | shape |
+|---|---:|---|---|
+| **cold gimsatul** | **~13 s** | **12.8–15.4 s (tight)** | steady ~1–2 s every solution |
+| MT warm (16-way share) | ~40 s median | **16–90 s (very wide)** | #1 dominates; #2 = free *or* 60–65 s thrash; tail free |
+| hybrid (gimsatul #1 → 1 CaDiCaL) | ~33–40 s | ~stable | 0.2 s + one ~32 s solve, then free |
+| single warm CaDiCaL | 70–148 s | **wild seed gamble** | #1 = 42–100 s; #2 = 0.03 s *or* 91 s thrash |
+
+**Winner on base 128: repeated cold gimsatul — fastest and by far the most stable.**
+
+## The per-solution breakdown (where the time goes)
+
+**cold gimsatul** — cost is *evenly spread*, first solution is cheap:
+```
+sol:   1     2     3     4     5     6     7     8     9    10
+delta 0.22  1.13  3.91  2.15  0.33  2.95  2.00  2.86  0.38  2.80   (s)   -> linear, #1 ~2%
+```
+**warm (all CaDiCaL variants)** — cost is *front-loaded on #1*, then the tail is ~free (full-model blocking makes
+near-duplicates trivial), but **#2 is a coin flip**: either ~0.05 s or a **60–90 s phase-thrash**.
+
+## Why warm CaDiCaL thrashes (the key mechanism)
+
+After finding solution #1, CaDiCaL's **saved phases point at exactly #1's assignment**. Searching for a *different*
+solution, it keeps reconstructing #1, slams into the (huge) blocking clause, flips one variable, and phase-saving drags
+it right back — thrashing for up to ~90 s before escaping #1's basin. Once escaped, near-neighbours are free. Whether it
+thrashes is **seed-dependent** (single-thread) or **nondeterministic** (MT) — hence the wild variance.
+
+## What the variants do about it
+
+- **Hybrid** *avoids* the thrash: gimsatul finds #1, so CaDiCaL **never phase-pins to #1** and finds #2 in a clean
+  ~32 s solve (no thrash), then free. 20 sols: **32.6 s** (gimsatul 0.19 s + CaDiCaL 32 s + free tail). Robust.
+- **MT warm (16-way)** *reduces but does not kill* the thrash: with 16 diverse seeds sharing clauses, usually one worker
+  escapes #1 fast — but not always (2 of 6 runs still thrashed 65–90 s). Wide distribution (16–90 s). Native, no
+  external dep, but doesn't catch gimsatul and isn't stable.
+- **Single-thread warm** is a pure seed gamble (70–148 s).
+
+## 20-solution results (base 128)
+
+| approach | 20 sols |
+|---|---:|
+| cold gimsatul | 27 s |
+| hybrid | 33 s |
+| single warm | 110 s (#1+#2 then free) |
+| MT warm | 86–137 s (tail grows as the easy near-#1 region exhausts) |
+
+## Why gimsatul wins (base 128)
+
+gimsatul is a **purpose-built parallel clause-sharing solver**: it does the 16-way sharing *natively and lock-free*,
+and it has **no phase memory to poison itself**. Every cold solve is a clean ~1 s parallel search. MT-warm reimplements
+sharing on top of *incremental* CaDiCaL and inherits (a) CaDiCaL's phase-saving pathology and (b) a coarse lock-based
+pool — so gimsatul does the same trick better and skips the failure mode.
+
+## Caveats
+
+- **Full-model blocking** makes the near-tail "free" (near-duplicate assignments differing in one auxiliary var). Real
+  distinct-*mapping* (shape-dedup) enumeration would not get those for free; the per-solution costs would rise for all
+  approaches. This benchmark measures *engine speed at producing the next assignment*, which is the right comparison
+  for the cold-vs-warm question, but absolute solution counts are not distinct mappings.
+- **Base (easy) regime only.** gimsatul solves base 128 in ~1 s, so repeated-cold is cheap. On the **capped/min-host**
+  regime gimsatul is ~73 s *per solve*, so repeated-cold would be ~73 s × N and the amortizing warm/hybrid approaches
+  should win. **Untested — the decisive next measurement.**
+
+## Candidate directions to implement (for later decision)
+
+1. **Repeated cold gimsatul** — best + simplest on base; external dep; loses on capped (73 s × N).
+2. **Hybrid (gimsatul #1 → warm CaDiCaL)** — robust across regimes: pay the hard solve once, warm cheap tail, and it
+   *structurally avoids the phase-thrash*. Predicted winner on capped. Needs the gimsatul round-trip.
+3. **MT warm clause-sharing (native CaDiCaL)** — no external dep, beats single-thread, but unstable and doesn't catch
+   gimsatul on base. Would benefit from phase-reset to attack the thrash.
+4. **Adaptive portfolio** — race cold + warm + hybrid on one shared frontier, keep whoever produces (see
+   `ADAPTIVE_PORTFOLIO_ENUM_PLAN.md`).
+
+## Reproduce
+
+Build gimsatul (`git clone https://github.com/arminbiere/gimsatul; ./configure && make`). Dump the CNF with
+`TT_TOPO_SAT_DUMP_DIMACS` + `TT_TOPO_SAT_NO_MINHOST=1` on the 2×4-128 pipeline MGD onto SC36. Then:
+```
+# warm single-thread:      warm_enum <cnf> <N> [seed]        (link libcadical.a)
+# cold gimsatul repeated:  cold_enum.sh <cnf> <N> <threads>
+# hybrid:                  hybrid_enum.sh <cnf> <N> <threads> [cadical-seed]
+# MT warm 16-way:          mt_warm_enum <cnf> <N> <workers> <hint:0|1> [seedbase]
+```

--- a/tt_metal/fabric/enum_engine_benchmark_scripts/README.md
+++ b/tt_metal/fabric/enum_engine_benchmark_scripts/README.md
@@ -1,0 +1,19 @@
+# Enumeration-engine benchmark harnesses
+
+Standalone harnesses used for `../ENUM_ENGINE_BENCHMARK.md` (cold gimsatul vs warm incremental CaDiCaL on the dumped
+2×4-128 base CNF). They operate on a plain DIMACS file with **full-model blocking** (¬ the whole assignment) so they
+isolate raw SAT-engine speed, independent of the tt-metal pipeline.
+
+| file | approach | build / run |
+|---|---|---|
+| `warm_enum.cpp` | single warm incremental CaDiCaL | `clang++ -O3 -std=c++17 -I<cadical/src> warm_enum.cpp libcadical.a -lpthread -o warm_enum` → `warm_enum <cnf> <N> [seed]` |
+| `mt_warm_enum.cpp` | 16-way clause-sharing warm CaDiCaL (learned + blocking pools; optional phase hint) | same link → `mt_warm_enum <cnf> <N> <workers> <hint:0|1> [seedbase]` |
+| `cold_enum.sh` | repeated cold gimsatul (DIMACS round-trip + append blocking clause) | `cold_enum.sh <cnf> <N> <threads>` (edit `$GIM` path) |
+| `hybrid_enum.sh` | gimsatul finds #1 cold, then `warm_enum` for the rest | `hybrid_enum.sh <cnf> <N> <threads> [cadical-seed]` |
+
+Dump the CNF: run `generate_rank_bindings` on the 2×4-128 pipeline MGD onto SC36 with `TT_TOPO_SAT_NO_MINHOST=1` and
+`TT_TOPO_SAT_DUMP_DIMACS=<out.cnf>` (the `write_dimacs` hook lives on `ridvan/exp-clause-sharing-portfolio`).
+gimsatul: build v1.1.3 from https://github.com/arminbiere/gimsatul (`./configure && make`).
+
+Note: absolute paths in the shell scripts point at the experiment scratchpad — adjust `SC=`, `$GIM`, and the harness
+paths for your environment.

--- a/tt_metal/fabric/enum_engine_benchmark_scripts/cold_enum.sh
+++ b/tt_metal/fabric/enum_engine_benchmark_scripts/cold_enum.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Repeated-cold-gimsatul enumeration: solve CNF -> parse model -> append full-model blocking clause -> re-solve cold.
+# Usage: cold_enum.sh <cnf> <N> <threads>. Prints per-solution wall time (incl. DIMACS round-trip overhead).
+set -u
+CNF_BASE=$1; N=$2; T=${3:-8}
+GIM=/data/rsong/gimsatul_backup/gimsatul_src/gimsatul
+WORK=$(mktemp --suffix=.cnf); cp "$CNF_BASE" "$WORK"
+t0=$(date +%s.%N); prev=0
+for i in $(seq 1 "$N"); do
+  out=$(mktemp)
+  $GIM --threads=$T "$WORK" > "$out" 2>/dev/null
+  if ! grep -qa '^s SATISFIABLE' "$out"; then echo "cold sol $i: NOT SAT"; rm -f "$out"; break; fi
+  t=$(date +%s.%N); el=$(echo "$t - $t0"|bc); d=$(echo "$el - $prev"|bc)
+  printf "cold sol %d: %.2fs (delta %.2fs)\n" "$i" "$el" "$d"; prev=$el
+  # full-model blocking clause = negate every model literal
+  block=$(grep -a '^v ' "$out" | sed 's/^v//' | tr ' ' '\n' | grep -E '^-?[0-9]+$' | grep -v '^0$' | awk '{print -$1}' | tr '\n' ' ')
+  V=$(head -1 "$WORK"|awk '{print $3}'); C=$(head -1 "$WORK"|awk '{print $4}'); newC=$((C+1))
+  sed -i "1s/.*/p cnf $V $newC/" "$WORK"
+  echo "$block 0" >> "$WORK"
+  rm -f "$out"
+done
+echo "cold TOTAL: $(echo "$(date +%s.%N) - $t0"|bc)s"
+rm -f "$WORK"

--- a/tt_metal/fabric/enum_engine_benchmark_scripts/hybrid_enum.sh
+++ b/tt_metal/fabric/enum_engine_benchmark_scripts/hybrid_enum.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -u
+SC=/tmp/claude-4010/-data-rsong-tt-metal2/b9a92f3d-7cfe-426a-b13a-95af54b11ca9/scratchpad
+CNF=$1; N=$2; T=${3:-8}; SEED=${4:-0}
+GIM=/data/rsong/gimsatul_backup/gimsatul_src/gimsatul
+WORK=$(mktemp --suffix=.cnf); cp "$CNF" "$WORK"
+t0=$(date +%s.%N); out=$(mktemp)
+$GIM --threads=$T "$WORK" > "$out" 2>/dev/null
+grep -qa '^s SATISFIABLE' "$out" || { echo "gimsatul #1 NOT SAT"; exit 1; }
+printf "hybrid sol 1 (gimsatul cold): %.2fs\n" "$(echo "$(date +%s.%N) - $t0"|bc)"
+block=$(grep -a '^v ' "$out" | sed 's/^v//' | tr ' ' '\n' | grep -E '^-?[0-9]+$' | grep -v '^0$' | awk '{print -$1}' | tr '\n' ' ')
+V=$(head -1 "$WORK"|awk '{print $3}'); C=$(head -1 "$WORK"|awk '{print $4}')
+sed -i "1s/.*/p cnf $V $((C+1))/" "$WORK"; echo "$block 0" >> "$WORK"
+"$SC/warm_enum" "$WORK" $((N-1)) "$SEED"
+rm -f "$WORK" "$out"

--- a/tt_metal/fabric/enum_engine_benchmark_scripts/mt_warm_enum.cpp
+++ b/tt_metal/fabric/enum_engine_benchmark_scripts/mt_warm_enum.cpp
@@ -1,0 +1,89 @@
+// Multithreaded warm-incremental CaDiCaL enumeration: W workers, each its own solver + seed, sharing LEARNED clauses
+// (speed) and BLOCKING clauses (distinctness). Optional phase HINT: hint half the workers toward the latest found
+// model (exploit) while the rest stay un-hinted (explore). Tests whether 16-way diversity kills the single-thread
+// #2 phase-thrash. Usage: mt_warm_enum <cnf> <N> <workers> <hint:0|1>
+#include <cadical.hpp>
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <mutex>
+#include <thread>
+#include <unordered_set>
+#include <vector>
+using namespace std::chrono;
+
+struct Pool {
+    std::mutex m;
+    std::vector<std::vector<int>> cl;
+    std::vector<int> prod;
+    void publish(int pid, const std::vector<int>& c) { std::lock_guard<std::mutex> lk(m); cl.push_back(c); prod.push_back(pid); }
+    void drain(int cons, size_t& cur, std::vector<std::vector<int>>& out) {
+        std::lock_guard<std::mutex> lk(m);
+        for (size_t i = cur; i < cl.size(); ++i) if (prod[i] != cons) out.push_back(cl[i]);
+        cur = cl.size();
+    }
+    size_t size() { std::lock_guard<std::mutex> lk(m); return cl.size(); }
+};
+
+struct Learner : CaDiCaL::Learner {
+    Pool* pool; int pid, maxsz; std::vector<int> buf;
+    Learner(Pool* p, int id, int m) : pool(p), pid(id), maxsz(m) {}
+    bool learning(int size) override { return size > 0 && size <= maxsz; }
+    void learn(int lit) override { if (lit) buf.push_back(lit); else if (!buf.empty()) { pool->publish(pid, buf); buf.clear(); } }
+};
+
+std::mutex g_mtx;
+std::unordered_set<size_t> g_seen;
+std::atomic<int> g_found{0};
+int g_target;
+Pool g_learn, g_block;
+steady_clock::time_point g_t0;
+std::vector<double> g_times;
+
+static size_t hashv(const std::vector<int>& m) { size_t h = 1469598103934665603ULL; for (int x : m) { h ^= (size_t)x; h *= 1099511628211ULL; } return h; }
+
+void worker(const char* cnf, int wid, bool hint) {
+    CaDiCaL::Solver s; s.set("quiet", 1); s.set("ilb", 2); s.set("seed", wid);
+    Learner ln(&g_learn, wid, 8); s.connect_learner(&ln);
+    int vars = 0; s.read_dimacs(cnf, vars, 1);
+    size_t lcur = 0, bcur = 0; std::vector<std::vector<int>> imp;
+    for (;;) {
+        if (g_found.load() >= g_target) return;
+        imp.clear(); g_block.drain(wid, bcur, imp); for (auto& c : imp) { for (int l : c) s.add(l); s.add(0); }
+        imp.clear(); g_learn.drain(wid, lcur, imp); for (auto& c : imp) { for (int l : c) s.add(l); s.add(0); }
+        s.limit("conflicts", 20000); int r = s.solve(); s.limit("conflicts", -1);
+        if (r == 20) return;      // exhausted
+        if (r != 10) continue;    // budget window -> re-import, retry
+        std::vector<int> model(vars); for (int v = 1; v <= vars; v++) model[v - 1] = s.val(v);
+        const size_t h = hashv(model);
+        bool rec = false;
+        { std::lock_guard<std::mutex> lk(g_mtx);
+          if (g_found.load() < g_target && g_seen.find(h) == g_seen.end()) {
+              g_seen.insert(h); g_found.fetch_add(1); rec = true;
+              g_times.push_back(duration<double>(steady_clock::now() - g_t0).count());
+          } }
+        std::vector<int> blk; blk.reserve(vars);
+        for (int v = 1; v <= vars; v++) blk.push_back(model[v - 1] > 0 ? -v : v);
+        if (rec) g_block.publish(wid, blk);
+        for (int l : blk) s.add(l); s.add(0);   // block it in my own solver
+        if (hint) for (int v = 1; v <= vars; v++) s.phase(model[v - 1]);  // exploit: bias toward this region
+    }
+}
+
+int main(int argc, char** argv) {
+    if (argc < 3) { fprintf(stderr, "usage: %s cnf N [workers] [hint0/1]\n", argv[0]); return 1; }
+    const char* cnf = argv[1]; g_target = atoi(argv[2]);
+    const int W = argc > 3 ? atoi(argv[3]) : 16;
+    const int hintmode = argc > 4 ? atoi(argv[4]) : 0;
+    const int seedbase = argc > 5 ? atoi(argv[5]) : 0;  // shift the 16 worker seeds to sample a different seed set
+    g_t0 = steady_clock::now();
+    std::vector<std::thread> ts;
+    for (int w = 0; w < W; w++) ts.emplace_back(worker, cnf, seedbase + w + 1, hintmode && (w % 2 == 0));  // half exploit
+    for (auto& t : ts) t.join();
+    double prev = 0;
+    for (size_t i = 0; i < g_times.size(); i++) { printf("mt sol %zu: %.2fs (delta %.2fs)\n", i + 1, g_times[i], g_times[i] - prev); prev = g_times[i]; }
+    printf("mt TOTAL: %.2fs  (%d workers, hint=%d, learn_pool=%zu, block_pool=%zu)\n",
+           duration<double>(steady_clock::now() - g_t0).count(), W, hintmode, g_learn.size(), g_block.size());
+    return 0;
+}

--- a/tt_metal/fabric/enum_engine_benchmark_scripts/warm_enum.cpp
+++ b/tt_metal/fabric/enum_engine_benchmark_scripts/warm_enum.cpp
@@ -1,0 +1,40 @@
+// Warm incremental-CaDiCaL enumeration: read a DIMACS CNF, then solve -> block full model -> solve, N times.
+// One solver kept warm across solutions (learned clauses + phases persist). Prints per-solution wall time.
+#include <cadical.hpp>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+using namespace std::chrono;
+
+int main(int argc, char** argv) {
+    if (argc < 3) { fprintf(stderr, "usage: %s cnf N\n", argv[0]); return 1; }
+    const char* path = argv[1];
+    const int N = atoi(argv[2]);
+    const int seed = (argc > 3) ? atoi(argv[3]) : 0;
+    CaDiCaL::Solver s;
+    s.set("quiet", 1);
+    s.set("ilb", 2);  // incremental lazy backtracking -- the enumeration tuning our solver uses
+    s.set("seed", seed);
+    int vars = 0;
+    const char* err = s.read_dimacs(path, vars, 1);
+    if (err) { fprintf(stderr, "read error: %s\n", err); return 1; }
+    printf("warm: %d vars loaded\n", vars);
+    const auto t0 = steady_clock::now();
+    double prev = 0;
+    for (int i = 1; i <= N; i++) {
+        const int r = s.solve();
+        const double el = duration<double>(steady_clock::now() - t0).count();
+        if (r != 10) { printf("warm sol %d: NOT SAT (r=%d) at %.2fs\n", i, r, el); break; }
+        printf("warm sol %d: %.2fs (delta %.2fs)\n", i, el, el - prev);
+        fflush(stdout);
+        prev = el;
+        // Extract the FULL model first (adding a clause drops the solver out of the satisfied state, after which
+        // val() is invalid), THEN add the blocking clause = negation of the model.
+        std::vector<int> model(vars);
+        for (int v = 1; v <= vars; v++) model[v - 1] = s.val(v);
+        for (int v = 1; v <= vars; v++) s.add(model[v - 1] > 0 ? -v : v);
+        s.add(0);
+    }
+    printf("warm TOTAL: %.2fs\n", duration<double>(steady_clock::now() - t0).count());
+    return 0;
+}


### PR DESCRIPTION
## What
Apples-to-apples benchmark answering: for enumerating N solutions of the inter-mesh SAT problem, is **repeated-cold gimsatul** or **warm incremental CaDiCaL** faster/more stable? Plus the **hybrid** (gimsatul #1 → warm CaDiCaL) and **16-way MT clause-sharing** warm. Run on the real dumped **2×4-128 base CNF** (55,024 vars), full-model blocking, 6-run stability. Doc + the 4 standalone harnesses.

## Headline — 10 solutions, base 128
| approach | time | stability (6 runs) |
|---|---|---|
| **cold gimsatul** | **~13 s** | **12.8–15.4 s (tight) — WINS** |
| MT warm (16-way share) | ~40 s median | 16–90 s (very wide; sometimes thrashes 65 s) |
| hybrid (gimsatul #1 → 1 CaDiCaL) | ~33 s | stable |
| single warm CaDiCaL | 70–148 s | wild seed gamble |

## Key findings
- **Cold gimsatul wins on base** — fastest *and* most stable. It's a purpose-built lock-free parallel clause-sharing solver with no phase memory to poison itself.
- **Warm CaDiCaL has a phase-saving pathology**: after finding #1, its saved phases pin to #1, so finding a *different* solution thrashes (up to 90 s) escaping #1's basin. Seed-dependent (single) / nondeterministic (MT).
- **Hybrid structurally avoids the thrash** — gimsatul finds #1 so CaDiCaL never phase-pins; clean ~32 s escape then free. Robust.
- **MT clause-sharing reduces but doesn't kill the thrash** (2/6 runs still thrashed); native, no dep, but unstable and doesn't catch gimsatul.
- Per-solution: gimsatul spreads cost evenly (~1–2 s each); warm front-loads on #1 then the tail is free.

## Caveats
- **Full-model blocking** makes the near-tail free (near-duplicate assignments); real distinct-mapping enumeration would cost more for all approaches. This measures engine speed at producing the next assignment.
- **Base (easy) regime only.** On the **capped/min-host** regime gimsatul is ~73 s/solve, so repeated-cold ≈ 73 s × N and the amortizing warm/hybrid should win — **untested, the decisive next measurement.**

## Candidate directions (for later decision)
1. Repeated cold gimsatul — best/simplest on base; loses on capped.
2. Hybrid gimsatul-#1 → warm CaDiCaL — robust; predicted capped winner; avoids the thrash by construction.
3. MT warm clause-sharing — native, no dep; needs phase-reset to fix the thrash.
4. Adaptive portfolio — race them, keep whoever produces (see `ADAPTIVE_PORTFOLIO_ENUM_PLAN.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ridvan/exp-enum-engine-benchmark)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ridvan/exp-enum-engine-benchmark)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ridvan/exp-enum-engine-benchmark)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ridvan/exp-enum-engine-benchmark)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ridvan/exp-enum-engine-benchmark)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ridvan/exp-enum-engine-benchmark)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ridvan/exp-enum-engine-benchmark)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ridvan/exp-enum-engine-benchmark)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ridvan/exp-enum-engine-benchmark)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ridvan/exp-enum-engine-benchmark)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ridvan/exp-enum-engine-benchmark)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ridvan/exp-enum-engine-benchmark)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ridvan/exp-enum-engine-benchmark)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ridvan/exp-enum-engine-benchmark)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ridvan/exp-enum-engine-benchmark)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ridvan/exp-enum-engine-benchmark)