### PR TITLE
Upgrade mold to v2.42.0

### DIFF
--- a/dockerfile/Dockerfile.tools
+++ b/dockerfile/Dockerfile.tools
@@ -5,7 +5,7 @@
 #
 # Usage:
 #   docker build -f dockerfile/Dockerfile.tools --target ccache -t ghcr.io/.../tool-ccache:v4.13.6 .
-#   docker build -f dockerfile/Dockerfile.tools --target mold -t ghcr.io/.../tool-mold:v2.40.4 .
+#   docker build -f dockerfile/Dockerfile.tools --target mold -t ghcr.io/.../tool-mold:v2.42.0 .
 #
 # The main Dockerfile can then use:
 #   FROM ghcr.io/.../tool-ccache:v4.13.6 AS ccache-layer
@@ -18,8 +18,8 @@
 ARG CCACHE_VERSION=4.13.6
 ARG CCACHE_SHA256=508b2a1217dc6e04a23e967c7b95a0fb45d8a7e16fde9e180919698f2e2be060
 
-ARG MOLD_VERSION=2.40.4
-ARG MOLD_SHA256=4c999e19ffa31afa5aa429c679b665d5e2ca5a6b6832ad4b79668e8dcf3d8ec1
+ARG MOLD_VERSION=2.42.0
+ARG MOLD_SHA256=f5ed2f6e31d1ada4f07fe766fe0de7a73104d1c5cdc59086fcecc16a43720b6d
 
 ARG DOXYGEN_VERSION=1.16.1
 ARG DOXYGEN_SHA256=a56f885d37e3aae08a99f638d17bbb381224c03a878d9e2dda4f9fa4baf1d8bd

--- a/dockerfile/README.md
+++ b/dockerfile/README.md
@@ -174,7 +174,7 @@ Tool image tags are passed between workflows as a single JSON bundle instead of 
 ```json
 {
   "ccache-tag": "ghcr.io/.../tools/ccache:4.10.2-<hash>",
-  "mold-tag": "ghcr.io/.../tools/mold:2.40.4-<hash>",
+  "mold-tag": "ghcr.io/.../tools/mold:2.42.0-<hash>",
   "doxygen-tag": "ghcr.io/.../tools/doxygen:1.16.1-<hash>",
   "clangbuildanalyzer-tag": "ghcr.io/.../tools/clangbuildanalyzer:1.6.0-<hash>",
   "gdb-tag": "ghcr.io/.../tools/gdb:14.2-<hash>",

--- a/dockerfile/scripts/compute-hashes.sh
+++ b/dockerfile/scripts/compute-hashes.sh
@@ -31,7 +31,7 @@ echo "CCACHE_SHA256=$($SHA_CMD "$TMPDIR/ccache.tar.xz" | cut -d' ' -f1)"
 echo ""
 
 # mold
-MOLD_VERSION="${MOLD_VERSION:-2.40.4}"
+MOLD_VERSION="${MOLD_VERSION:-2.42.0}"
 echo "Downloading mold ${MOLD_VERSION}..."
 curl -fsSL -o "$TMPDIR/mold.tar.gz" \
     "https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-x86_64-linux.tar.gz"

--- a/dockerfile/scripts/install-mold.sh
+++ b/dockerfile/scripts/install-mold.sh
@@ -2,10 +2,10 @@
 # Install mold linker from upstream binary release for faster linking
 set -euo pipefail
 
-MOLD_VERSION="${MOLD_VERSION:-2.40.4}"
-# SHA256 for mold-2.40.4-x86_64-linux.tar.gz
+MOLD_VERSION="${MOLD_VERSION:-2.42.0}"
+# SHA256 for mold-2.42.0-x86_64-linux.tar.gz
 # Verified from GitHub release
-MOLD_SHA256="${MOLD_SHA256:-4c999e19ffa31afa5aa429c679b665d5e2ca5a6b6832ad4b79668e8dcf3d8ec1}"
+MOLD_SHA256="${MOLD_SHA256:-f5ed2f6e31d1ada4f07fe766fe0de7a73104d1c5cdc59086fcecc16a43720b6d}"
 
 INSTALL_DIR="${INSTALL_DIR:-/usr/local}"
 DOWNLOAD_URL="https://github.com/rui314/mold/releases/download/v${MOLD_VERSION}/mold-${MOLD_VERSION}-x86_64-linux.tar.gz"


### PR DESCRIPTION
## Summary
- Bump pinned mold linker version from 2.40.4 to 2.42.0 wherever referenced in tt-metal:
  - `dockerfile/Dockerfile.tools` (version + SHA256 hash)
  - `dockerfile/scripts/install-mold.sh` (version + SHA256 hash)
  - `dockerfile/scripts/compute-hashes.sh` (version default)
  - `dockerfile/README.md` (example tool-tag JSON bundle)
- `.github/scripts/compute-tool-tags.sh` derives the version dynamically from `Dockerfile.tools`, so no change needed there.
- Verified no remaining references to `2.40.4` or the old SHA256 anywhere in the repo.

## References
- https://github.com/rui314/mold/releases/tag/v2.42.0
- https://github.com/rui314/mold/releases/download/v2.42.0/mold-2.42.0-x86_64-linux.tar.gz
- `sha256:f5ed2f6e31d1ada4f07fe766fe0de7a73104d1c5cdc59086fcecc16a43720b6d`

## Release notes (2.40.4 → 2.42.0)

Two releases in this range: [v2.41.0](https://github.com/rui314/mold/releases/tag/v2.41.0) and [v2.42.0](https://github.com/rui314/mold/releases/tag/v2.42.0).

### v2.41.0 highlights
- New `--zero-to-bss` option to convert all-zero data sections to BSS, shrinking output size.
- `--print-gc-sections`/`--print-icf-sections` can now write to a file via `=FILE`.
- `--gdb-index` generation is faster (parallelized, fewer needless zero-inits).
- Fixed spurious "duplicate symbol" errors when linking with LTO.
- Fixed `--separate-debug-file` string-table corruption that made GDB refuse to load debug files.
- Fixed a `fallocate` slowdown on tmpfs (was costing ~1s on large files).
- Various arch-specific relocation fixes (AArch64, RISC-V, PPC32, SPARC64/SPARC).

### v2.42.0 highlights
- **General perf**: broad optimizations across the linker — noticeably faster on large links, especially multi-core machines.
- New `--pack-dyn-relocs=android[+relr]` for Android's packed relocation format (APS2).
- `--compress-debug-sections` now accepts a compression level (e.g. `zstd:9`).
- New `-w`/`--no-warnings` and `-Ttext-segment` options (GNU ld/lld compatibility).
- New support for the SFrame v3 stack-unwinding format (`.sframe` sections).
- Compiler-internal temporary local symbols (e.g. `.L.str.42`) are now discarded by default, shrinking debug builds a few percent (opt-out via `--discard-none`).
- Multiple correctness fixes: an ICF bug that could fold functions with different exception tables/personality routines; ICF folding across misaligned sections breaking member-function-pointer semantics on x86; several symbol-versioning edge cases now correctly rejected/resolved; `--gc-sections` no longer over-roots sections named as valid C identifiers.
- Fixed a v2.41.0 regression: relative-path response files (`@file`) failed to open when `-C` was also given.
- **Build change**: mold now requires mimalloc v3 (bundled/built statically by default). This only affects building mold from source — our install script pulls the prebuilt release binary, so it's not a concern here, but worth knowing if this ever changes to a source build.

## Test plan
- [ ] CI builds the `mold` tool image target successfully
- [ ] Verify `mold --version` reports 2.42.0 in the built image

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsexton/0-upgrade-mold)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsexton/0-upgrade-mold)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsexton/0-upgrade-mold)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsexton/0-upgrade-mold)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nsexton/0-upgrade-mold)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nsexton/0-upgrade-mold)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsexton/0-upgrade-mold)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsexton/0-upgrade-mold)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsexton/0-upgrade-mold)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsexton/0-upgrade-mold)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsexton/0-upgrade-mold)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsexton/0-upgrade-mold)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsexton/0-upgrade-mold)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsexton/0-upgrade-mold)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsexton/0-upgrade-mold)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsexton/0-upgrade-mold)