### PR TITLE
[Cleanup] Surface Area Distributed headers

### DIFF
--- a/tests/tt_eager/ops/test_sfpu.cpp
+++ b/tests/tt_eager/ops/test_sfpu.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <chrono>
+#include <type_traits>
 #include <cctype>
 #include <cerrno>
 #include <fmt/base.h>
@@ -42,7 +43,6 @@
 #include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "impl/data_format/bfloat16_utils.hpp"
-
 namespace tt::tt_metal {
 class IDevice;
 }  // namespace tt::tt_metal
@@ -194,8 +194,11 @@ bool run_sfpu_test(const std::string& sfpu_name, int tile_factor = 1, bool use_D
         std::vector<uint32_t> src_vec = sfpu_op_to_init_func.at(sfpu_name)(
             dram_buffer_size, std::chrono::system_clock::now().time_since_epoch().count());
 
-        tt_metal::distributed::WriteShard(
-            device->mesh_command_queue(0), src_dram_buffer, src_vec, tt::tt_metal::distributed::MeshCoordinate(0, 0));
+        device->mesh_command_queue(0).enqueue_write_shards(
+            src_dram_buffer,
+            {tt_metal::distributed::ShardDataTransfer{tt::tt_metal::distributed::MeshCoordinate(0, 0)}.host_data(
+                src_vec.data())},
+            false);
 
         tt_metal::SetRuntimeArgs(
             program,

--- a/tests/tt_metal/distributed/benchmark_hd_sockets.cpp
+++ b/tests/tt_metal/distributed/benchmark_hd_sockets.cpp
@@ -12,7 +12,6 @@
 #include <fstream>
 #include <numeric>
 #include <sstream>
-
 namespace tt::tt_metal::distributed {
 
 namespace {
@@ -247,7 +246,8 @@ std::pair<double, double> run_d2h_throughput(
     std::vector<uint32_t> src_vec(page_size / sizeof(uint32_t));
     std::vector<uint32_t> dst_vec(page_size / sizeof(uint32_t));
     std::iota(src_vec.begin(), src_vec.end(), 0);
-    WriteShard(mesh_device->mesh_command_queue(), sender_data_buffer, src_vec, sender_core.device_coord, true);
+    mesh_device->mesh_command_queue().enqueue_write_shards(
+        sender_data_buffer, {ShardDataTransfer{sender_core.device_coord}.host_data(src_vec.data())}, true);
     execute_program_on_device(*mesh_device, sender_core.device_coord, std::move(send_program));
 
     for (uint32_t i = 0; i < num_iterations; i++) {

--- a/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
+++ b/tests/tt_metal/distributed/multiprocess/test_sanity.cpp
@@ -22,6 +22,7 @@
 #include "tt_metal/distributed/dummy_mesh_command_queue.hpp"
 
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
+#include "tt_metal/distributed/mesh_buffer_impl.hpp"
 
 namespace tt::tt_metal::distributed {
 
@@ -195,11 +196,12 @@ TEST_F(BigMeshDualRankTest2x4, SimpleShardedBufferTest) {
     std::iota(src_vec.begin(), src_vec.end(), 0);
 
     // Write and read back
-    EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), mesh_buffer, src_vec);
+    mesh_device_->mesh_command_queue().enqueue_write_mesh_buffer(mesh_buffer, src_vec.data(), false);
     std::vector<uint32_t> dst_vec;
-    EnqueueReadMeshBuffer(mesh_device_->mesh_command_queue(), dst_vec, mesh_buffer);
+    dst_vec.resize(mesh_buffer->size() / sizeof(typename std::decay_t<decltype(dst_vec)>::value_type));
+    mesh_device_->mesh_command_queue().enqueue_read_mesh_buffer((dst_vec).data(), mesh_buffer, true);
 
-    // The expectation is that EnqueueWriteMeshBuffer/EnqueueReadMeshBuffer
+    // The expectation is that enqueue_write/read_mesh_buffer
     // should handle sharding/unsharding transparently, so dst should equal src
     for (int i = 0; i < dst_vec.size(); i++) {
         auto shard_row = i / global_buffer_shape.width();

--- a/tests/tt_metal/distributed/test_dispatch_context.cpp
+++ b/tests/tt_metal/distributed/test_dispatch_context.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <type_traits>
 
 #include <cstdint>
 #include <memory>
@@ -27,7 +28,6 @@
 #include "llrt/tt_cluster.hpp"
 #include "tests/tt_metal/distributed/utils.hpp"
 #include <umd/device/types/arch.hpp>
-
 namespace tt::tt_metal::distributed::test {
 
 class DispatchContextFixture : public ::testing::Test {
@@ -71,7 +71,10 @@ TEST_F(DispatchContextFixture, TestWritesAndWorkloads) {
 
     for (std::size_t logical_x = 0; logical_x < mesh_buffer->device()->num_cols(); logical_x++) {
         for (std::size_t logical_y = 0; logical_y < mesh_buffer->device()->num_rows(); logical_y++) {
-            WriteShard(mesh_device_->mesh_command_queue(), mesh_buffer, src_vec, MeshCoordinate(logical_y, logical_x));
+            mesh_device_->mesh_command_queue().enqueue_write_shards(
+                mesh_buffer,
+                {ShardDataTransfer{MeshCoordinate(logical_y, logical_x)}.host_data(src_vec.data())},
+                false);
         }
     }
     Finish(mesh_device_->mesh_command_queue());
@@ -207,7 +210,7 @@ TEST_F(DispatchContextFixture, RepeatedFdSdTransitionStress) {
         auto fd_buf = MeshBuffer::create(fd_l1_global, fd_l1_config, mesh_device_.get());
         std::vector<uint32_t> fd_src_vec(num_tiles * single_tile_size / sizeof(uint32_t));
         std::iota(fd_src_vec.begin(), fd_src_vec.end(), base + 100);
-        EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), fd_buf, fd_src_vec);
+        mesh_device_->mesh_command_queue().enqueue_write_mesh_buffer(fd_buf, fd_src_vec.data(), false);
         Finish(mesh_device_->mesh_command_queue());
 
         for (const auto& coord : MeshCoordinateRange(mesh_device_->shape())) {
@@ -228,11 +231,11 @@ TEST_F(DispatchContextFixture, RepeatedFdSdTransitionStress) {
         }
 
         // Write and verify interleaved L1 buffer in SD mode. Validated shard-by-shard because
-        // EnqueueReadMeshBuffer is only defined for sharded global layouts on multi-device meshes.
+        // enqueue_read_mesh_buffer is only defined for sharded global layouts on multi-device meshes.
         auto sd_buf = MeshBuffer::create(sd_l1_global, sd_l1_config, mesh_device_.get());
         std::vector<uint32_t> sd_src_vec(num_tiles * single_tile_size / sizeof(uint32_t));
         std::iota(sd_src_vec.begin(), sd_src_vec.end(), base + 200);
-        EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), sd_buf, sd_src_vec);
+        mesh_device_->mesh_command_queue().enqueue_write_mesh_buffer(sd_buf, sd_src_vec.data(), false);
         Finish(mesh_device_->mesh_command_queue());
 
         for (const auto& coord : MeshCoordinateRange(mesh_device_->shape())) {
@@ -270,7 +273,8 @@ TEST_F(DispatchContextFixture, RepeatedFdSdTransitionStress) {
         std::iota(fd2_src_vec.begin(), fd2_src_vec.end(), base + 300);
         for (std::size_t y = 0; y < mesh_device_->num_rows(); y++) {
             for (std::size_t x = 0; x < mesh_device_->num_cols(); x++) {
-                WriteShard(mesh_device_->mesh_command_queue(), fd2_buf, fd2_src_vec, MeshCoordinate(y, x));
+                mesh_device_->mesh_command_queue().enqueue_write_shards(
+                    fd2_buf, {ShardDataTransfer{MeshCoordinate(y, x)}.host_data(fd2_src_vec.data())}, false);
             }
         }
         Finish(mesh_device_->mesh_command_queue());

--- a/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
+++ b/tests/tt_metal/distributed/test_end_to_end_eltwise.cpp
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <functional>
 
-
 #include <tt-metalium/distributed.hpp>
+#include <distributed/mesh_workload_impl.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/sub_device.hpp>
 
@@ -17,6 +17,7 @@
 #include "host_api.hpp"
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include "tt_metal/distributed/mesh_buffer_impl.hpp"
 
 namespace tt::tt_metal {
 
@@ -156,7 +157,7 @@ TEST_F(MeshEndToEnd2x4Tests, ProgramDispatchTest) {
 
     EnqueueMeshWorkload(cq, mesh_workload, false /* blocking */);
 
-    EXPECT_EQ(mesh_workload.get_last_used_command_queue()->id(), cq_id);
+    EXPECT_EQ(mesh_workload.impl().get_last_used_command_queue()->id(), cq_id);
 
     Finish(cq);
 }
@@ -188,10 +189,12 @@ TEST_F(MeshEndToEnd2x4Tests, BufferRoundtripTest) {
 
     std::vector<uint32_t> src_data = create_random_vector_of_bfloat16(
         distributed_buffer_size_bytes, 1, std::chrono::system_clock::now().time_since_epoch().count());
-    EnqueueWriteMeshBuffer(cq, mesh_buffer, src_data);
+    cq.enqueue_write_mesh_buffer(mesh_buffer, src_data.data(), false);
 
     std::vector<uint32_t> read_back_data{};
-    EnqueueReadMeshBuffer(cq, read_back_data, mesh_buffer, true /* blocking */);
+    (read_back_data)
+        .resize((mesh_buffer)->size() / sizeof(typename std::decay_t<decltype(read_back_data)>::value_type));
+    cq.enqueue_read_mesh_buffer((read_back_data).data(), mesh_buffer, true /* blocking */);
 
     EXPECT_THAT(read_back_data, Pointwise(Eq(), src_data));
 }
@@ -225,8 +228,8 @@ TEST_F(MeshEndToEnd2x4Tests, UntracedEltwiseAddTest) {
 
     auto& cq = mesh_device_->mesh_command_queue();
 
-    EnqueueWriteMeshBuffer(cq, a_buffer, a_data, false /* blocking */);
-    EnqueueWriteMeshBuffer(cq, b_buffer, b_data, true /* blocking */);
+    cq.enqueue_write_mesh_buffer(a_buffer, a_data.data(), false /* blocking */);
+    cq.enqueue_write_mesh_buffer(b_buffer, b_data.data(), true /* blocking */);
 
     auto program = EltwiseBinaryProgramGenerator(a_buffer, b_buffer, out_buffer, num_tiles, tile_size_bytes, kAddOpId);
 
@@ -237,7 +240,8 @@ TEST_F(MeshEndToEnd2x4Tests, UntracedEltwiseAddTest) {
     EnqueueMeshWorkload(cq, mesh_workload, false /* blocking */);
 
     std::vector<uint32_t> result_data(a_data.size(), 0);
-    EnqueueReadMeshBuffer(cq, result_data, out_buffer, true /* blocking */);
+    (result_data).resize((out_buffer)->size() / sizeof(typename std::decay_t<decltype(result_data)>::value_type));
+    cq.enqueue_read_mesh_buffer((result_data).data(), out_buffer, true /* blocking */);
 
     auto transform_to_golden = [](const bfloat16& a) { return bfloat16(static_cast<float>(a) + kValToAdd); };
     std::vector<bfloat16> result_vec = unpack_uint32_vec_into_bfloat16_vec(result_data, bfloat16_identity_transform);
@@ -301,16 +305,17 @@ TEST_F(MeshEndToEnd2x4TraceTests, EltwiseAddTest) {
     EnqueueMeshWorkload(cq, mesh_workload, false /* blocking */);
     mesh_device_->end_mesh_trace(cq, trace_id);
 
-    EnqueueWriteMeshBuffer(cq, a_buffer, a_data, false /* blocking */);
+    cq.enqueue_write_mesh_buffer(a_buffer, a_data.data(), false /* blocking */);
     // Block to prevent wriitng during trace, which is illegal
-    EnqueueWriteMeshBuffer(cq, b_buffer, b_data, true /* blocking */);
+    cq.enqueue_write_mesh_buffer(b_buffer, b_data.data(), true /* blocking */);
 
     mesh_device_->replay_mesh_trace(cq, trace_id, false);
 
     mesh_device_->release_mesh_trace(trace_id);
 
     std::vector<uint32_t> result_data(a_data.size(), 0);
-    EnqueueReadMeshBuffer(cq, result_data, out_buffer, true /* blocking */);
+    (result_data).resize((out_buffer)->size() / sizeof(typename std::decay_t<decltype(result_data)>::value_type));
+    cq.enqueue_read_mesh_buffer((result_data).data(), out_buffer, true /* blocking */);
 
     auto transform_to_golden = [](const bfloat16& a) { return bfloat16(static_cast<float>(a) + kValToAdd); };
 
@@ -365,16 +370,17 @@ TEST_F(MeshEndToEnd2x4TraceTests, EltwiseMulTest) {
     EnqueueMeshWorkload(cq, mesh_workload, false /* blocking */);
     mesh_device_->end_mesh_trace(cq, trace_id);
 
-    EnqueueWriteMeshBuffer(cq, a_buffer, a_data, false /* blocking */);
+    cq.enqueue_write_mesh_buffer(a_buffer, a_data.data(), false /* blocking */);
     // Block to prevent wriitng during trace, which is illegal
-    EnqueueWriteMeshBuffer(cq, b_buffer, b_data, true /* blocking */);
+    cq.enqueue_write_mesh_buffer(b_buffer, b_data.data(), true /* blocking */);
 
     mesh_device_->replay_mesh_trace(cq, trace_id, false);
 
     mesh_device_->release_mesh_trace(trace_id);
 
     std::vector<uint32_t> result_data(a_data.size(), 0);
-    EnqueueReadMeshBuffer(cq, result_data, out_buffer, true /* blocking */);
+    (result_data).resize((out_buffer)->size() / sizeof(typename std::decay_t<decltype(result_data)>::value_type));
+    cq.enqueue_read_mesh_buffer((result_data).data(), out_buffer, true /* blocking */);
 
     auto transform_to_golden = [](const bfloat16 a) { return bfloat16(a * bfloat16(kValToMul)); };
     std::vector<bfloat16> result_vec = unpack_uint32_vec_into_bfloat16_vec(result_data, bfloat16_identity_transform);
@@ -499,10 +505,10 @@ TEST_F(MeshEndToEnd2x4TraceTests, SimulEltwiseTest) {
     std::vector<uint32_t> mul_sub_src1_vec =
         create_constant_vector_of_bfloat16(mul_sub_src1_buf->size(), workload_1_src1_val);
 
-    EnqueueWriteMeshBuffer(data_movement_cq, add_src0_buf, add_src0_vec);
-    EnqueueWriteMeshBuffer(data_movement_cq, add_src1_buf, add_src1_vec);
-    EnqueueWriteMeshBuffer(data_movement_cq, mul_sub_src0_buf, mul_sub_src0_vec);
-    EnqueueWriteMeshBuffer(data_movement_cq, mul_sub_src1_buf, mul_sub_src1_vec);
+    data_movement_cq.enqueue_write_mesh_buffer(add_src0_buf, add_src0_vec.data(), false);
+    data_movement_cq.enqueue_write_mesh_buffer(add_src1_buf, add_src1_vec.data(), false);
+    data_movement_cq.enqueue_write_mesh_buffer(mul_sub_src0_buf, mul_sub_src0_vec.data(), false);
+    data_movement_cq.enqueue_write_mesh_buffer(mul_sub_src1_buf, mul_sub_src1_vec.data(), false);
 
     MeshEvent write_event = data_movement_cq.enqueue_record_event();
     workload_cq.enqueue_wait_for_event(write_event);
@@ -515,8 +521,11 @@ TEST_F(MeshEndToEnd2x4TraceTests, SimulEltwiseTest) {
 
     std::vector<bfloat16> add_dst_vec = {};
     std::vector<bfloat16> mul_sub_dst_vec = {};
-    EnqueueReadMeshBuffer(data_movement_cq, add_dst_vec, add_output_buf);
-    EnqueueReadMeshBuffer(data_movement_cq, mul_sub_dst_vec, mul_sub_output_buf);
+    (add_dst_vec).resize((add_output_buf)->size() / sizeof(typename std::decay_t<decltype(add_dst_vec)>::value_type));
+    data_movement_cq.enqueue_read_mesh_buffer((add_dst_vec).data(), add_output_buf, true);
+    (mul_sub_dst_vec)
+        .resize((mul_sub_output_buf)->size() / sizeof(typename std::decay_t<decltype(mul_sub_dst_vec)>::value_type));
+    data_movement_cq.enqueue_read_mesh_buffer((mul_sub_dst_vec).data(), mul_sub_output_buf, true);
 
     EXPECT_THAT(add_dst_vec, Each(Bfloat16Eq(workload_0_src0_val + workload_0_src1_val)));
 

--- a/tests/tt_metal/distributed/test_hd_sockets.cpp
+++ b/tests/tt_metal/distributed/test_hd_sockets.cpp
@@ -153,7 +153,8 @@ void test_d2h_socket(
     std::vector<uint32_t> src_vec(data_size / sizeof(uint32_t));
     std::vector<uint32_t> dst_vec(data_size / sizeof(uint32_t));
     std::iota(src_vec.begin(), src_vec.end(), 0);
-    WriteShard(mesh_device->mesh_command_queue(), sender_data_buffer, src_vec, sender_core.device_coord);
+    mesh_device->mesh_command_queue().enqueue_write_shards(
+        sender_data_buffer, {ShardDataTransfer{sender_core.device_coord}.host_data(src_vec.data())}, false);
 
     auto mesh_workload = MeshWorkload();
     MeshCoordinateRange devices = MeshCoordinateRange(sender_core.device_coord);

--- a/tests/tt_metal/distributed/test_maybe_remote.cpp
+++ b/tests/tt_metal/distributed/test_maybe_remote.cpp
@@ -10,6 +10,7 @@
 #include <sstream>
 
 #include <tt-metalium/maybe_remote.hpp>
+#include <distributed/maybe_remote_utils.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 
 namespace tt::tt_metal::distributed {

--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -54,6 +54,7 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/distributed/pinned_memory_cache.hpp"
 #include "tt_metal/distributed/mesh_device_impl.hpp"
+#include "tt_metal/distributed/mesh_buffer_impl.hpp"
 #include "tt_metal/impl/dispatch/vector_aligned.hpp"
 
 namespace tt::tt_metal::distributed::test {
@@ -247,22 +248,6 @@ TEST_F(MeshBufferTest2x4, ReplicatedBufferInitialization) {
     EXPECT_EQ(replicated_buffer->device_local_size(), 16 << 10);
 }
 
-TEST_F(MeshBufferTestSuite, EnqueueWriteMeshBufferValidSrcSize) {
-    constexpr size_t buffer_size = 16;
-
-    const DeviceLocalBufferConfig device_local_config{
-        .page_size = buffer_size, .buffer_type = BufferType::DRAM, .bottom_up = false};
-    const ReplicatedBufferConfig buffer_config{.size = buffer_size};
-    auto mesh_buffer = MeshBuffer::create(buffer_config, device_local_config, mesh_device_.get());
-    std::vector<uint8_t> small_src_vec(buffer_size / 2, 0);
-    std::vector<uint8_t> exact_src_vec(buffer_size, 0);
-    std::vector<uint8_t> large_src_vec(buffer_size * 2, 0);
-
-    EXPECT_THROW(EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), mesh_buffer, small_src_vec), std::exception);
-    EXPECT_NO_THROW(EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), mesh_buffer, exact_src_vec, true));
-    EXPECT_NO_THROW(EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), mesh_buffer, large_src_vec, true));
-}
-
 TEST_F(MeshBufferTest2x4, Deallocation) {
     // Verify that a buffer is deallocated on the MeshDevice when it goes
     // out of scope on host. Create a buffer with a certain config in limited
@@ -376,7 +361,8 @@ TEST_F(MeshBufferTestSuite, MoveConstructor) {
     EXPECT_EQ(moved_buffer.size(), original_size);
     EXPECT_EQ(moved_buffer.device_local_size(), original_device_local_size);
 
-    EXPECT_FALSE(original_buffer->is_allocated());
+    // The moved-from MeshBuffer no longer owns an implementation.
+    EXPECT_ANY_THROW(original_buffer->impl());
 }
 
 TEST_F(MeshBufferTestSuite, MoveAssignment) {
@@ -406,7 +392,8 @@ TEST_F(MeshBufferTestSuite, MoveAssignment) {
     EXPECT_EQ(target_buffer->size(), source_size);
     EXPECT_EQ(target_buffer->device_local_size(), source_device_local_size);
 
-    EXPECT_FALSE(source_buffer->is_allocated());
+    // The moved-from MeshBuffer no longer owns an implementation.
+    EXPECT_ANY_THROW(source_buffer->impl());
 
     auto new_buffer = MeshBuffer::create(target_buffer_config, device_local_config, mesh_device_.get());
     EXPECT_EQ(new_buffer->address(), target_original_address);
@@ -443,7 +430,8 @@ TEST_P(DeviceLocalMeshBufferShardingTest, ShardingTest) {
 
     for (std::size_t logical_x = 0; logical_x < buf->device()->num_cols(); logical_x++) {
         for (std::size_t logical_y = 0; logical_y < buf->device()->num_rows(); logical_y++) {
-            WriteShard(mesh_device_->mesh_command_queue(), buf, src_vec, MeshCoordinate(logical_y, logical_x));
+            mesh_device_->mesh_command_queue().enqueue_write_shards(
+                buf, {ShardDataTransfer{MeshCoordinate(logical_y, logical_x)}.host_data(src_vec.data())}, false);
         }
     }
 
@@ -504,9 +492,10 @@ TEST_F(MeshBufferTest2x4, SweepShardAndConcat) {
             std::vector<uint32_t> src_vec =
                 std::vector<uint32_t>(global_buffer_shape.height() * global_buffer_shape.width(), 0);
             std::iota(src_vec.begin(), src_vec.end(), 0);
-            EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), mesh_buffer, src_vec);
+            mesh_device_->mesh_command_queue().enqueue_write_mesh_buffer(mesh_buffer, src_vec.data(), false);
             std::vector<uint32_t> dst_vec = {};
-            EnqueueReadMeshBuffer(mesh_device_->mesh_command_queue(), dst_vec, mesh_buffer);
+            (dst_vec).resize((mesh_buffer)->size() / sizeof(typename std::decay_t<decltype(dst_vec)>::value_type));
+            mesh_device_->mesh_command_queue().enqueue_read_mesh_buffer((dst_vec).data(), mesh_buffer, true);
 
             EXPECT_EQ(dst_vec, src_vec);
         }
@@ -563,7 +552,10 @@ TEST_F(MeshBufferTestSuite, InterleavedShardsReadWrite) {
             std::iota(src_vec.begin(), src_vec.end(), i);
             for (std::size_t logical_x = 0; logical_x < buf->device()->num_cols(); logical_x++) {
                 for (std::size_t logical_y = 0; logical_y < buf->device()->num_rows(); logical_y++) {
-                    WriteShard(mesh_device_->mesh_command_queue(), buf, src_vec, MeshCoordinate(logical_y, logical_x));
+                    mesh_device_->mesh_command_queue().enqueue_write_shards(
+                        buf,
+                        {ShardDataTransfer{MeshCoordinate(logical_y, logical_x)}.host_data(src_vec.data())},
+                        false);
                 }
             }
 
@@ -620,10 +612,12 @@ TEST_F(MeshBufferTestSuite, RowMajorShardingAndReplication) {
 
         auto mesh_buffer_read_view = MeshBuffer::create(
             sharded_read_view_config, per_device_buffer_config, mesh_device_.get(), mesh_buffer->address());
-        EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), mesh_buffer, src_vec);
+        mesh_device_->mesh_command_queue().enqueue_write_mesh_buffer(mesh_buffer, src_vec.data(), false);
         std::vector<uint32_t> dst_vec =
             std::vector<uint32_t>(global_buffer_read_shape.height() * global_buffer_read_shape.width(), 0);
-        EnqueueReadMeshBuffer(mesh_device_->mesh_command_queue(), dst_vec, mesh_buffer_read_view);
+        (dst_vec).resize(
+            (mesh_buffer_read_view)->size() / sizeof(typename std::decay_t<decltype(dst_vec)>::value_type));
+        mesh_device_->mesh_command_queue().enqueue_read_mesh_buffer((dst_vec).data(), mesh_buffer_read_view, true);
 
         for (int i = 0; i < dst_vec.size(); i++) {
             EXPECT_EQ(dst_vec[i], i % (src_vec.size()));
@@ -670,10 +664,12 @@ TEST_F(MeshBufferTestSuite, ColMajorShardingAndReplication) {
         auto mesh_buffer_read_view = MeshBuffer::create(
             sharded_read_view_config, per_device_buffer_config, mesh_device_.get(), mesh_buffer->address());
 
-        EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), mesh_buffer, src_vec);
+        mesh_device_->mesh_command_queue().enqueue_write_mesh_buffer(mesh_buffer, src_vec.data(), false);
         std::vector<uint32_t> dst_vec =
             std::vector<uint32_t>(global_buffer_read_shape.height() * global_buffer_read_shape.width(), 0);
-        EnqueueReadMeshBuffer(mesh_device_->mesh_command_queue(), dst_vec, mesh_buffer_read_view);
+        (dst_vec).resize(
+            (mesh_buffer_read_view)->size() / sizeof(typename std::decay_t<decltype(dst_vec)>::value_type));
+        mesh_device_->mesh_command_queue().enqueue_read_mesh_buffer((dst_vec).data(), mesh_buffer_read_view, true);
         for (int i = 0; i < dst_vec.size(); i++) {
             EXPECT_EQ(
                 (i / global_buffer_read_shape.width()) * global_buffer_shape.width() + i % global_buffer_shape.width(),
@@ -1445,7 +1441,7 @@ TEST_F(MeshBufferTestSuite, EnqueueProgramAfterPinnedMemoryWriteRerunsCorrectly)
     auto output_buffer = MeshBuffer::create(tile_mesh_config, tile_buffer_config, mesh_device_.get());
 
     std::vector<uint16_t> input(single_tile_size / sizeof(uint16_t), 1);
-    EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), input_buffer, input, /*blocking=*/true);
+    mesh_device_->mesh_command_queue().enqueue_write_mesh_buffer(input_buffer, input.data(), /*blocking=*/true);
 
     Program program = CreateProgram();
     auto kernel = CreateKernel(
@@ -1700,7 +1696,10 @@ TEST_F(MeshBufferTestSuite, EnqueueWriteDeviceLocalShardedBufferWithCoreFilter) 
     constexpr uint32_t k_new = 0x44444444u;
     const uint32_t num_u32 = buf_size / sizeof(uint32_t);
     std::vector<uint32_t> sentinel_vec(num_u32, k_sentinel);
-    WriteShard(mesh_device_->mesh_command_queue(), buf, sentinel_vec, coord, /*blocking=*/true);
+    mesh_device_->mesh_command_queue().enqueue_write_shards(
+        buf,
+        {ShardDataTransfer{coord}.host_data(sentinel_vec.data())},
+        /*blocking=*/true);
 
     std::vector<uint32_t> newest(num_u32, k_new);
     CoreRangeSet filter(CoreRange(CoreCoord(0, 0), CoreCoord(0, 0)));
@@ -1806,10 +1805,11 @@ TEST_F(SDMeshBufferFixture, ShardedBufferWriteReadRoundtrip) {
     std::vector<uint32_t> src(global_buffer_shape.height() * global_buffer_shape.width());
     std::iota(src.begin(), src.end(), 0);
 
-    EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), mesh_buffer, src);
+    mesh_device_->mesh_command_queue().enqueue_write_mesh_buffer(mesh_buffer, src.data(), false);
 
     std::vector<uint32_t> dst;
-    EnqueueReadMeshBuffer(mesh_device_->mesh_command_queue(), dst, mesh_buffer);
+    (dst).resize((mesh_buffer)->size() / sizeof(typename std::decay_t<decltype(dst)>::value_type));
+    mesh_device_->mesh_command_queue().enqueue_read_mesh_buffer((dst).data(), mesh_buffer, true);
 
     EXPECT_EQ(dst, src);
 }

--- a/tests/tt_metal/distributed/test_mesh_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device.cpp
@@ -79,7 +79,7 @@ TEST_F(MeshDevice2x4Test, ViewIs2D) {
     std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids;
     for (const auto& coord : MeshCoordinateRange(mesh_device_->shape())) {
         devices.push_back(mesh_device_->get_view().impl().get_device(coord));
-        fabric_node_ids.push_back(mesh_device_->get_view().get_fabric_node_id(coord));
+        fabric_node_ids.push_back(mesh_device_->get_view().impl().get_fabric_node_id(coord));
     }
 
     MeshDeviceView view_1d(MeshShape(8), devices, fabric_node_ids);

--- a/tests/tt_metal/distributed/test_mesh_device_view.cpp
+++ b/tests/tt_metal/distributed/test_mesh_device_view.cpp
@@ -23,20 +23,20 @@ using ::testing::SizeIs;
 
 TEST(MeshDeviceViewTest, GetRingCoordinatesRingShapeEmpty) {
     EXPECT_ANY_THROW(
-        (void)MeshDeviceView::get_ring_coordinates(/*ring_shape*/ Shape2D(1, 0), /*mesh_shape*/ Shape2D(2, 4)));
+        (void)MeshDeviceViewImpl::get_ring_coordinates(/*ring_shape*/ Shape2D(1, 0), /*mesh_shape*/ Shape2D(2, 4)));
     EXPECT_ANY_THROW(
-        (void)MeshDeviceView::get_ring_coordinates(/*ring_shape*/ Shape2D(0, 1), /*mesh_shape*/ Shape2D(2, 4)));
+        (void)MeshDeviceViewImpl::get_ring_coordinates(/*ring_shape*/ Shape2D(0, 1), /*mesh_shape*/ Shape2D(2, 4)));
 }
 
 TEST(MeshDeviceViewTest, GetRingCoordinatesRingShapeTooBig) {
     EXPECT_ANY_THROW(
-        (void)MeshDeviceView::get_ring_coordinates(/*ring_shape*/ Shape2D(2, 4), /*mesh_shape*/ Shape2D(2, 2)));
+        (void)MeshDeviceViewImpl::get_ring_coordinates(/*ring_shape*/ Shape2D(2, 4), /*mesh_shape*/ Shape2D(2, 2)));
     EXPECT_ANY_THROW(
-        (void)MeshDeviceView::get_ring_coordinates(/*ring_shape*/ Shape2D(4, 2), /*mesh_shape*/ Shape2D(2, 2)));
+        (void)MeshDeviceViewImpl::get_ring_coordinates(/*ring_shape*/ Shape2D(4, 2), /*mesh_shape*/ Shape2D(2, 2)));
 }
 
 TEST(MeshDeviceViewTest, GetRingCoordinates) {
-    auto ring_coords = MeshDeviceView::get_ring_coordinates(Shape2D(2, 2), Shape2D(2, 2));
+    auto ring_coords = MeshDeviceViewImpl::get_ring_coordinates(Shape2D(2, 2), Shape2D(2, 2));
     ASSERT_THAT(ring_coords, SizeIs(4));
     EXPECT_EQ(ring_coords[0], MeshCoordinate(0, 0));
     EXPECT_EQ(ring_coords[1], MeshCoordinate(0, 1));
@@ -45,7 +45,7 @@ TEST(MeshDeviceViewTest, GetRingCoordinates) {
 }
 
 TEST(MeshDeviceViewTest, GetRingCoordinatesDonut) {
-    auto ring_coords = MeshDeviceView::get_ring_coordinates(Shape2D(3, 3), Shape2D(4, 4));
+    auto ring_coords = MeshDeviceViewImpl::get_ring_coordinates(Shape2D(3, 3), Shape2D(4, 4));
     ASSERT_THAT(ring_coords, SizeIs(8));
     EXPECT_EQ(ring_coords[0], MeshCoordinate(0, 0));
     EXPECT_EQ(ring_coords[1], MeshCoordinate(0, 1));
@@ -58,13 +58,13 @@ TEST(MeshDeviceViewTest, GetRingCoordinatesDonut) {
 }
 
 TEST(MeshDeviceViewTest, GetLineCoordinatesLineTooBig) {
-    EXPECT_ANY_THROW((void)MeshDeviceView::get_line_coordinates(
+    EXPECT_ANY_THROW((void)MeshDeviceViewImpl::get_line_coordinates(
         /*length*/ 10, /*mesh_shape*/ Shape2D(2, 2), /*mesh_offset*/ Shape2D(0, 0)));
 }
 
 TEST(MeshDeviceViewTest, GetLineCoordinatesWithShorterLine) {
-    auto line_coords =
-        MeshDeviceView::get_line_coordinates(/*length*/ 3, /*mesh_shape*/ Shape2D(2, 2), /*mesh_offset*/ Shape2D(0, 0));
+    auto line_coords = MeshDeviceViewImpl::get_line_coordinates(
+        /*length*/ 3, /*mesh_shape*/ Shape2D(2, 2), /*mesh_offset*/ Shape2D(0, 0));
     ASSERT_THAT(line_coords, SizeIs(3));
     EXPECT_EQ(line_coords[0], MeshCoordinate(0, 0));
     EXPECT_EQ(line_coords[1], MeshCoordinate(0, 1));
@@ -72,8 +72,8 @@ TEST(MeshDeviceViewTest, GetLineCoordinatesWithShorterLine) {
 }
 
 TEST(MeshDeviceViewTest, GetLineCoordinates2x2) {
-    auto line_coords =
-        MeshDeviceView::get_line_coordinates(/*length*/ 4, /*mesh_shape*/ Shape2D(2, 2), /*mesh_offset*/ Shape2D(0, 0));
+    auto line_coords = MeshDeviceViewImpl::get_line_coordinates(
+        /*length*/ 4, /*mesh_shape*/ Shape2D(2, 2), /*mesh_offset*/ Shape2D(0, 0));
     ASSERT_THAT(line_coords, SizeIs(4));
     EXPECT_EQ(line_coords[0], MeshCoordinate(0, 0));
     EXPECT_EQ(line_coords[1], MeshCoordinate(0, 1));
@@ -82,16 +82,16 @@ TEST(MeshDeviceViewTest, GetLineCoordinates2x2) {
 }
 
 TEST(MeshDeviceViewTest, GetLineCoordinates2x2WithOffset) {
-    auto line_coords =
-        MeshDeviceView::get_line_coordinates(/*length*/ 2, /*mesh_shape*/ Shape2D(2, 2), /*mesh_offset*/ Shape2D(1, 0));
+    auto line_coords = MeshDeviceViewImpl::get_line_coordinates(
+        /*length*/ 2, /*mesh_shape*/ Shape2D(2, 2), /*mesh_offset*/ Shape2D(1, 0));
     ASSERT_THAT(line_coords, SizeIs(2));
     EXPECT_EQ(line_coords[0], MeshCoordinate(1, 0));
     EXPECT_EQ(line_coords[1], MeshCoordinate(1, 1));
 }
 
 TEST(MeshDeviceViewTest, GetLineCoordinates3x3) {
-    auto line_coords =
-        MeshDeviceView::get_line_coordinates(/*length*/ 9, /*mesh_shape*/ Shape2D(3, 3), /*mesh_offset*/ Shape2D(0, 0));
+    auto line_coords = MeshDeviceViewImpl::get_line_coordinates(
+        /*length*/ 9, /*mesh_shape*/ Shape2D(3, 3), /*mesh_offset*/ Shape2D(0, 0));
     ASSERT_THAT(line_coords, SizeIs(9));
     // Actual path produced by DFS algorithm (prefers ring but falls back if not possible)
     EXPECT_EQ(line_coords[0], MeshCoordinate(0, 0));
@@ -106,8 +106,8 @@ TEST(MeshDeviceViewTest, GetLineCoordinates3x3) {
 }
 
 TEST(MeshDeviceViewTest, GetLineCoordinates3x3WithOffset) {
-    auto line_coords =
-        MeshDeviceView::get_line_coordinates(/*length*/ 5, /*mesh_shape*/ Shape2D(3, 3), /*mesh_offset*/ Shape2D(1, 1));
+    auto line_coords = MeshDeviceViewImpl::get_line_coordinates(
+        /*length*/ 5, /*mesh_shape*/ Shape2D(3, 3), /*mesh_offset*/ Shape2D(1, 1));
     ASSERT_THAT(line_coords, SizeIs(5));
     EXPECT_EQ(line_coords[0], MeshCoordinate(1, 1));
     EXPECT_EQ(line_coords[1], MeshCoordinate(1, 2));
@@ -130,13 +130,13 @@ TEST(MeshDeviceViewTest, GetLineCoordinatesRingFormation) {
     };
 
     // Test small length (2 nodes)
-    auto line_coords_2 = MeshDeviceView::get_line_coordinates(
+    auto line_coords_2 = MeshDeviceViewImpl::get_line_coordinates(
         /*length*/ 2, /*mesh_shape*/ Shape2D(3, 3), /*mesh_offset*/ Shape2D(1, 1));
     ASSERT_THAT(line_coords_2, SizeIs(2));
     verify_ring(line_coords_2);
 
     // Test visiting all nodes in 2x2 mesh
-    auto line_coords_4 = MeshDeviceView::get_line_coordinates(
+    auto line_coords_4 = MeshDeviceViewImpl::get_line_coordinates(
         /*length*/ 4, /*mesh_shape*/ Shape2D(2, 2), /*mesh_offset*/ Shape2D(0, 0));
     ASSERT_THAT(line_coords_4, SizeIs(4));
     std::set<MeshCoordinate> unique_coords_4(line_coords_4.begin(), line_coords_4.end());
@@ -150,24 +150,24 @@ TEST(MeshDeviceViewTest, GetLineCoordinatesRingPreferredButNotRequired) {
 
     // Helper lambda to check if path forms a ring
     // Requesting more nodes than exist in the mesh should still fail
-    EXPECT_ANY_THROW((void)MeshDeviceView::get_line_coordinates(
+    EXPECT_ANY_THROW((void)MeshDeviceViewImpl::get_line_coordinates(
         /*length*/ 10, /*mesh_shape*/ Shape2D(2, 2), /*mesh_offset*/ Shape2D(0, 0)));
 
     // Cases where ring may not be possible - function should still succeed
     // Visiting 3 nodes from corner (0,0) in 3x3 mesh - may or may not form a ring
-    auto line_coords_3_corner = MeshDeviceView::get_line_coordinates(
+    auto line_coords_3_corner = MeshDeviceViewImpl::get_line_coordinates(
         /*length*/ 3, /*mesh_shape*/ Shape2D(3, 3), /*mesh_offset*/ Shape2D(0, 0));
     ASSERT_THAT(line_coords_3_corner, SizeIs(3));
     // Function succeeds, ring formation is preferred but not required
 
     // Visiting 3 nodes from center (1,1) in 3x3 mesh - may or may not form a ring
-    auto line_coords_3_center = MeshDeviceView::get_line_coordinates(
+    auto line_coords_3_center = MeshDeviceViewImpl::get_line_coordinates(
         /*length*/ 3, /*mesh_shape*/ Shape2D(3, 3), /*mesh_offset*/ Shape2D(1, 1));
     ASSERT_THAT(line_coords_3_center, SizeIs(3));
     // Function succeeds, ring formation is preferred but not required
 
     // Visiting all nodes in 3x3 mesh from corner - may or may not form a ring
-    auto line_coords_9 = MeshDeviceView::get_line_coordinates(
+    auto line_coords_9 = MeshDeviceViewImpl::get_line_coordinates(
         /*length*/ 9, /*mesh_shape*/ Shape2D(3, 3), /*mesh_offset*/ Shape2D(0, 0));
     ASSERT_THAT(line_coords_9, SizeIs(9));
     std::set<MeshCoordinate> unique_coords_9(line_coords_9.begin(), line_coords_9.end());
@@ -180,14 +180,14 @@ using MeshDeviceView2x4Test = MeshDevice2x4Fixture;
 TEST_F(MeshDeviceView2x4Test, MeshId) {
     const auto& view = mesh_device_->get_view();
     EXPECT_EQ(view.shape(), MeshShape(2, 4));
-    EXPECT_EQ(view.mesh_id(), tt::tt_fabric::MeshId(0));
+    EXPECT_EQ(view.impl().mesh_id(), tt::tt_fabric::MeshId(0));
 }
 
 TEST_F(MeshDeviceView2x4Test, ViewBasicProperties) {
     const auto& view = mesh_device_->get_view();
 
-    EXPECT_FALSE(view.empty());
-    EXPECT_EQ(view.size(), 8);
+    EXPECT_FALSE(view.impl().empty());
+    EXPECT_EQ(view.impl().size(), 8);
     EXPECT_EQ(view.num_devices(), 8);
     EXPECT_EQ(view.shape(), MeshShape(2, 4));
     EXPECT_TRUE(view.is_mesh_2d());
@@ -224,13 +224,13 @@ TEST_F(MeshDeviceView2x4Test, ViewGetDevice) {
 TEST_F(MeshDeviceView2x4Test, ViewGetFabricNodeId) {
     const auto& view = mesh_device_->get_view();
 
-    auto fabric_id_00 = view.get_fabric_node_id(MeshCoordinate{0, 0});
-    auto fabric_id_13 = view.get_fabric_node_id(MeshCoordinate{1, 3});
+    auto fabric_id_00 = view.impl().get_fabric_node_id(MeshCoordinate{0, 0});
+    auto fabric_id_13 = view.impl().get_fabric_node_id(MeshCoordinate{1, 3});
 
     EXPECT_NE(fabric_id_00, fabric_id_13);
 
     // Out of bounds throws
-    EXPECT_ANY_THROW((void)view.get_fabric_node_id(MeshCoordinate{2, 0}));
+    EXPECT_ANY_THROW((void)view.impl().get_fabric_node_id(MeshCoordinate{2, 0}));
 }
 
 TEST_F(MeshDeviceView2x4Test, ViewGetDevices) {
@@ -279,7 +279,7 @@ TEST_F(MeshDeviceView2x4Test, ViewGetFabricNodeIdsInRange) {
     const auto& view = mesh_device_->get_view();
 
     MeshCoordinateRange range(MeshCoordinate{0, 0}, MeshCoordinate(1, 1));
-    auto fabric_ids = view.get_fabric_node_ids(range);
+    auto fabric_ids = view.impl().get_fabric_node_ids(range);
     EXPECT_THAT(fabric_ids, SizeIs(4));
 }
 
@@ -351,7 +351,7 @@ TEST_F(MeshDeviceView2x4Test, ViewFindDevice) {
 TEST_F(MeshDeviceView2x4Test, ViewLineCoordinates) {
     const auto& view = mesh_device_->get_view();
 
-    auto line_coords = view.get_line_coordinates();
+    auto line_coords = view.impl().get_line_coordinates();
     EXPECT_THAT(line_coords, SizeIs(8));
 
     // Verify zigzag pattern: row 0 left-to-right, row 1 right-to-left
@@ -368,7 +368,7 @@ TEST_F(MeshDeviceView2x4Test, ViewLineCoordinates) {
 TEST_F(MeshDeviceView2x4Test, ViewRingCoordinates) {
     const auto& view = mesh_device_->get_view();
 
-    auto ring_coords = view.get_ring_coordinates();
+    auto ring_coords = view.impl().get_ring_coordinates();
     EXPECT_THAT(ring_coords, SizeIs(8));
 
     // Verify ring traversal (clockwise from top-left)
@@ -397,7 +397,7 @@ TEST_F(MeshDeviceView2x4Test, ViewIterator) {
     const auto& view = mesh_device_->get_view();
 
     std::vector<IDevice*> iterated_devices;
-    for (auto device : view) {
+    for (auto device : view.impl()) {
         iterated_devices.push_back(*device);
     }
 
@@ -411,7 +411,7 @@ TEST_F(MeshDeviceView2x4Test, ViewIterator) {
 TEST_F(MeshDeviceView2x4Test, ViewMeshId) {
     const auto& view = mesh_device_->get_view();
 
-    auto mesh_id = view.mesh_id();
+    auto mesh_id = view.impl().mesh_id();
 
     // All fabric node IDs should have the same mesh ID
     for (const auto& fabric_id : view.get_fabric_node_ids()) {
@@ -424,7 +424,7 @@ TEST_F(MeshDeviceView2x4Test, View2DMethodsThrowOnNon2DMesh) {
     std::vector<tt::tt_fabric::FabricNodeId> fabric_node_ids;
     for (const auto& coord : MeshCoordinateRange(mesh_device_->shape())) {
         devices.push_back(mesh_device_->get_view().impl().get_device(coord));
-        fabric_node_ids.push_back(mesh_device_->get_view().get_fabric_node_id(coord));
+        fabric_node_ids.push_back(mesh_device_->get_view().impl().get_fabric_node_id(coord));
     }
 
     MeshDeviceView view_1d(MeshShape(8), devices, fabric_node_ids);
@@ -435,11 +435,11 @@ TEST_F(MeshDeviceView2x4Test, View2DMethodsThrowOnNon2DMesh) {
     EXPECT_ANY_THROW((void)view_1d.get_devices_on_column(0));
     EXPECT_ANY_THROW((void)view_1d.get_fabric_node_ids_on_row(0));
     EXPECT_ANY_THROW((void)view_1d.get_fabric_node_ids_on_column(0));
-    EXPECT_ANY_THROW((void)view_1d.get_line_coordinates());
-    EXPECT_ANY_THROW((void)view_1d.get_ring_coordinates());
-    EXPECT_ANY_THROW((void)view_1d.get_line_devices());
+    EXPECT_ANY_THROW((void)view_1d.impl().get_line_coordinates());
+    EXPECT_ANY_THROW((void)view_1d.impl().get_ring_coordinates());
+    EXPECT_ANY_THROW((void)view_1d.impl().get_line_devices());
     EXPECT_ANY_THROW((void)view_1d.get_ring_devices());
-    EXPECT_ANY_THROW((void)view_1d.get_line_fabric_node_ids());
+    EXPECT_ANY_THROW((void)view_1d.impl().get_line_fabric_node_ids());
     EXPECT_ANY_THROW((void)view_1d.get_ring_fabric_node_ids());
 }
 

--- a/tests/tt_metal/distributed/test_mesh_events.cpp
+++ b/tests/tt_metal/distributed/test_mesh_events.cpp
@@ -3,10 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <boost/move/utility_core.hpp>
+#include <type_traits>
 #include <gtest/gtest.h>
 #include <cstdint>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/distributed.hpp>
+#include "tt_metal/distributed/event_query_impl.hpp"
 #include <cstddef>
 #include <memory>
 #include <numeric>
@@ -18,6 +20,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/mesh_command_queue.hpp>
+#include "tt_metal/distributed/mesh_command_queue_base.hpp"
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/mesh_event.hpp>
@@ -26,7 +29,6 @@
 #include "tests/tt_metal/distributed/utils.hpp"
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
-
 namespace tt::tt_metal::distributed::test {
 namespace {
 
@@ -53,7 +55,7 @@ TEST_F(MeshEventsTestSuite, ReplicatedAsyncIO) {
 
         std::vector<std::vector<uint32_t>> readback_vecs = {};
         // Writes on CQ 0
-        EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(0), buf, src_vec);
+        mesh_device_->mesh_command_queue(0).enqueue_write_mesh_buffer(buf, src_vec.data(), false);
         // Device to Device Synchronization
         auto write_event = mesh_device_->mesh_command_queue(0).enqueue_record_event();
         mesh_device_->mesh_command_queue(1).enqueue_wait_for_event(write_event);
@@ -95,7 +97,7 @@ TEST_F(MeshEventsTest2x4, ShardedAsyncIO) {
             std::vector<uint32_t>(global_buffer_shape.height() * global_buffer_shape.width(), 0);
         std::iota(src_vec.begin(), src_vec.end(), i);
         // Writes on CQ 0
-        EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(0), mesh_buffer, src_vec);
+        mesh_device_->mesh_command_queue(0).enqueue_write_mesh_buffer(mesh_buffer, src_vec.data(), false);
         if (i % 2) {
             // Test Host <-> Device synchronization
             auto write_event = mesh_device_->mesh_command_queue(0).enqueue_record_event_to_host();
@@ -106,8 +108,9 @@ TEST_F(MeshEventsTest2x4, ShardedAsyncIO) {
             mesh_device_->mesh_command_queue(1).enqueue_wait_for_event(write_event);
         }
         // Reads on CQ 1
-        std::vector<uint32_t> dst_vec = {};
-        EnqueueReadMeshBuffer(mesh_device_->mesh_command_queue(1), dst_vec, mesh_buffer);
+        const size_t dst_num_elements = mesh_buffer->size() / sizeof(uint32_t);
+        std::vector<uint32_t> dst_vec(dst_num_elements);
+        mesh_device_->mesh_command_queue(1).enqueue_read_mesh_buffer(dst_vec.data(), mesh_buffer, true);
 
         EXPECT_EQ(dst_vec, src_vec);
     }
@@ -153,10 +156,10 @@ TEST_F(MeshEventsTestSuite, AsyncWorkloadAndIO) {
         // Issue writes on MeshCQ 1
         for (std::size_t col_idx = 0; col_idx < worker_grid_size.x; col_idx++) {
             for (std::size_t row_idx = 0; row_idx < worker_grid_size.y; row_idx++) {
-                EnqueueWriteMeshBuffer(
-                    mesh_device_->mesh_command_queue(1), src0_bufs[(col_idx * worker_grid_size.y) + row_idx], src0_vec);
-                EnqueueWriteMeshBuffer(
-                    mesh_device_->mesh_command_queue(1), src1_bufs[(col_idx * worker_grid_size.y) + row_idx], src1_vec);
+                mesh_device_->mesh_command_queue(1).enqueue_write_mesh_buffer(
+                    src0_bufs[(col_idx * worker_grid_size.y) + row_idx], src0_vec.data(), false);
+                mesh_device_->mesh_command_queue(1).enqueue_write_mesh_buffer(
+                    src1_bufs[(col_idx * worker_grid_size.y) + row_idx], src1_vec.data(), false);
             }
         }
         if (iter % 2) {
@@ -231,7 +234,8 @@ TEST_F(MeshEventsTestSuite, CustomDeviceRanges) {
 
         std::vector<std::vector<uint32_t>> readback_vecs = {};
 
-        mesh_device_->mesh_command_queue(1).enqueue_write_shard_to_sub_grid(*buf, src_vec.data(), devices_0, false);
+        ::tt::tt_metal::distributed::as_mesh_command_queue_base(mesh_device_->mesh_command_queue(1))
+            .enqueue_write_shard_to_sub_grid(*buf, src_vec.data(), devices_0, false);
         auto event0 = mesh_device_->mesh_command_queue(1).enqueue_record_event({}, devices_0);
         mesh_device_->mesh_command_queue(0).enqueue_wait_for_event(event0);
 
@@ -240,7 +244,8 @@ TEST_F(MeshEventsTestSuite, CustomDeviceRanges) {
             ReadShard(mesh_device_->mesh_command_queue(0), readback_vecs.back(), buf, coord);
         }
 
-        mesh_device_->mesh_command_queue(1).enqueue_write_shard_to_sub_grid(*buf, src_vec.data(), devices_1, false);
+        ::tt::tt_metal::distributed::as_mesh_command_queue_base(mesh_device_->mesh_command_queue(1))
+            .enqueue_write_shard_to_sub_grid(*buf, src_vec.data(), devices_1, false);
         auto event1 = mesh_device_->mesh_command_queue(1).enqueue_record_event_to_host({}, devices_1);
         EventSynchronize(event1);
 
@@ -305,7 +310,7 @@ TEST_F(MeshEventsTestSuite, MultiCQNonBlockingReads) {
             // buffer is used across iterations
             write_cq.enqueue_wait_for_event(read_events.back());
         }
-        EnqueueWriteMeshBuffer(write_cq, buffer, input_shard_data[i], true);
+        write_cq.enqueue_write_mesh_buffer(buffer, input_shard_data[i].data(), true);
         write_events.push_back(write_cq.enqueue_record_event_to_host());
         // Wait for write to complete before reading
         read_cq.enqueue_wait_for_event(write_events.back());

--- a/tests/tt_metal/distributed/test_mesh_socket.cpp
+++ b/tests/tt_metal/distributed/test_mesh_socket.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/distributed.hpp>
+#include <type_traits>
 #include <tt-metalium/sub_device.hpp>
 #include <tt-metalium/sub_device_types.hpp>
 #include <tt-metalium/work_split.hpp>
@@ -23,7 +24,6 @@
 #include <cstring>
 #include <tt-metalium/tt_align.hpp>
 #include <distributed/mesh_device_impl.hpp>
-
 namespace tt::tt_metal::distributed {
 
 using MeshSocketTest = MeshDevice2x4Fixture;
@@ -173,7 +173,8 @@ void test_single_connection_single_device_socket(
     std::vector<uint32_t> src_vec(data_size / sizeof(uint32_t));
     std::iota(src_vec.begin(), src_vec.end(), 0);
 
-    WriteShard(md0->mesh_command_queue(), sender_data_buffer, src_vec, MeshCoordinate(0, 0));
+    md0->mesh_command_queue().enqueue_write_shards(
+        sender_data_buffer, {ShardDataTransfer{MeshCoordinate(0, 0)}.host_data(src_vec.data())}, false);
 
     auto send_recv_program = CreateProgram();
     CreateKernel(
@@ -365,7 +366,8 @@ void test_single_device_socket_with_workers(
     std::vector<uint32_t> src_vec(sender_buffer_config.size / sizeof(uint32_t));
     std::iota(src_vec.begin(), src_vec.end(), 0);
 
-    WriteShard(md0->mesh_command_queue(), sender_data_buffer, src_vec, MeshCoordinate(0, 0));
+    md0->mesh_command_queue().enqueue_write_shards(
+        sender_data_buffer, {ShardDataTransfer{MeshCoordinate(0, 0)}.host_data(src_vec.data())}, false);
 
     auto send_recv_program = CreateProgram();
 
@@ -631,7 +633,8 @@ void test_single_connection_multi_device_socket(
 
     std::vector<uint32_t> src_vec(data_size / sizeof(uint32_t));
     std::iota(src_vec.begin(), src_vec.end(), 0);
-    WriteShard(md0->mesh_command_queue(), sender_data_buffer, src_vec, MeshCoordinate(0, 0));
+    md0->mesh_command_queue().enqueue_write_shards(
+        sender_data_buffer, {ShardDataTransfer{MeshCoordinate(0, 0)}.host_data(src_vec.data())}, false);
 
     auto sender_program = CreateProgram();
     auto sender_kernel = CreateKernel(
@@ -803,7 +806,8 @@ void test_single_connection_multi_device_socket_with_workers(
     std::vector<uint32_t> src_vec(data_size / sizeof(uint32_t));
     std::iota(src_vec.begin(), src_vec.end(), std::chrono::system_clock::now().time_since_epoch().count());
 
-    WriteShard(md0->mesh_command_queue(), sender_data_buffer, src_vec, MeshCoordinate(0, 0));
+    md0->mesh_command_queue().enqueue_write_shards(
+        sender_data_buffer, {ShardDataTransfer{MeshCoordinate(0, 0)}.host_data(src_vec.data())}, false);
 
     auto sender_program = CreateProgram();
     auto sender_kernel = CreateKernel(
@@ -1432,8 +1436,10 @@ void test_multi_sender_single_recv(
         std::vector<uint32_t> src_vec =
             tt::test_utils::generate_uniform_random_vector<uint32_t>(0, UINT16_MAX, data_size / sizeof(uint32_t));
         // Write data to both senders
-        WriteShard(sender_0->mesh_command_queue(), sender_data_buffer_0, src_vec, MeshCoordinate(0, 0));
-        WriteShard(sender_1->mesh_command_queue(), sender_data_buffer_1, src_vec, MeshCoordinate(0, 0));
+        sender_0->mesh_command_queue().enqueue_write_shards(
+            sender_data_buffer_0, {ShardDataTransfer{MeshCoordinate(0, 0)}.host_data(src_vec.data())}, false);
+        sender_1->mesh_command_queue().enqueue_write_shards(
+            sender_data_buffer_1, {ShardDataTransfer{MeshCoordinate(0, 0)}.host_data(src_vec.data())}, false);
 
         EnqueueMeshWorkload(sender_0->mesh_command_queue(), sender_0_mesh_workload, false);
         EnqueueMeshWorkload(sender_1->mesh_command_queue(), sender_1_mesh_workload, false);
@@ -1507,7 +1513,7 @@ void test_multi_connection_multi_device_data_copy(
     std::vector<uint32_t> src_vec(data_size / sizeof(uint32_t));
     std::iota(src_vec.begin(), src_vec.end(), 0);
 
-    EnqueueWriteMeshBuffer(sender_mesh->mesh_command_queue(), sender_data_buffer, src_vec);
+    sender_mesh->mesh_command_queue().enqueue_write_mesh_buffer(sender_data_buffer, src_vec.data(), false);
 
     auto sender_mesh_workload = MeshWorkload();
     auto recv_mesh_workload = MeshWorkload();

--- a/tests/tt_metal/distributed/test_mesh_sub_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_sub_device.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <type_traits>
 #include <cstdint>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/host_api.hpp>
@@ -36,7 +37,6 @@
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include "tests/tt_metal/tt_metal/dispatch/sub_device_test_utils.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
-
 namespace tt::tt_metal::distributed::test {
 namespace {
 
@@ -143,7 +143,7 @@ TEST_F(MeshSubDeviceTestSuite, DataCopyOnSubDevices) {
         // Block after this write on host, since the global semaphore update starting the
         // program goes through an independent path (UMD) and can go out of order wrt the
         // buffer data
-        EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), input_buf, src_vec, true);
+        mesh_device_->mesh_command_queue().enqueue_write_mesh_buffer(input_buf, src_vec.data(), true);
 
         for (auto* device : mesh_device_->get_devices()) {
             MetalContext::instance().get_cluster().write_core(

--- a/tests/tt_metal/distributed/test_mesh_trace.cpp
+++ b/tests/tt_metal/distributed/test_mesh_trace.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <boost/move/utility_core.hpp>
+#include <type_traits>
 #include <fmt/base.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -49,7 +50,6 @@
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include "tests/tt_metal/tt_metal/dispatch/sub_device_test_utils.hpp"
 #include <tt-metalium/tt_backend_api_types.hpp>
-
 namespace tt::tt_metal::distributed::test {
 namespace {
 
@@ -194,10 +194,10 @@ TEST_F(MeshTraceTest2x4, EltwiseBinaryMeshTrace) {
     // Write inputs for all cores across the Mesh
     for (std::size_t col_idx = 0; col_idx < worker_grid_size.x; col_idx++) {
         for (std::size_t row_idx = 0; row_idx < worker_grid_size.y; row_idx++) {
-            EnqueueWriteMeshBuffer(
-                mesh_device_->mesh_command_queue(), src0_bufs[(col_idx * worker_grid_size.y) + row_idx], src0_vec);
-            EnqueueWriteMeshBuffer(
-                mesh_device_->mesh_command_queue(), src1_bufs[(col_idx * worker_grid_size.y) + row_idx], src1_vec);
+            mesh_device_->mesh_command_queue().enqueue_write_mesh_buffer(
+                src0_bufs[(col_idx * worker_grid_size.y) + row_idx], src0_vec.data(), false);
+            mesh_device_->mesh_command_queue().enqueue_write_mesh_buffer(
+                src1_bufs[(col_idx * worker_grid_size.y) + row_idx], src1_vec.data(), false);
         }
     }
     // Compile workloads
@@ -481,7 +481,7 @@ TEST_F(MeshTraceTestSuite, DataCopyOnSubDevicesTrace) {
         // program goes through an independent path (UMD) and can go out of order wrt the
         // buffer data
         mesh_device_->set_sub_device_stall_group({{SubDeviceId{2}}});
-        EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), input_buf, src_vec, true);
+        mesh_device_->mesh_command_queue().enqueue_write_mesh_buffer(input_buf, src_vec.data(), true);
 
         for (auto* device : mesh_device_->get_devices()) {
             tt::tt_metal::MetalContext::instance().get_cluster().write_core(

--- a/tests/tt_metal/distributed/test_mesh_workload.cpp
+++ b/tests/tt_metal/distributed/test_mesh_workload.cpp
@@ -3,11 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <fmt/base.h>
+#include <type_traits>
 #include <gtest/gtest.h>
 #include <cstdint>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/distributed.hpp>
+#include <distributed/mesh_workload_impl.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/tt_metal.hpp>
@@ -51,8 +53,8 @@
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <distributed/mesh_device_impl.hpp>
+#include "tt_metal/distributed/mesh_buffer_impl.hpp"
 #include <tt-metalium/experimental/dispatch_context.hpp>
-
 namespace tt::tt_metal::distributed::test {
 namespace {
 
@@ -136,7 +138,7 @@ void verify_cb_config(
                     ::tt::tt_metal::detail::ReadFromDeviceL1(
                         device,
                         core_coord,
-                        workload.get_cb_base_addr(mesh_device, core_coord, CoreType::WORKER),
+                        workload.impl().get_cb_base_addr(mesh_device, core_coord, CoreType::WORKER),
                         cb_config_buffer_size,
                         cb_config_vector);
 
@@ -166,8 +168,8 @@ void validate_sems(
     MeshWorkload& mesh_workload,
     std::vector<uint32_t>& expected_semaphore_values) {
     for (const auto& core : crs) {
-        const uint32_t sem_buffer_size = mesh_workload.get_sem_size(mesh_device, core, CoreType::WORKER);
-        const uint32_t sem_buffer_base = mesh_workload.get_sem_base_addr(mesh_device, core, CoreType::WORKER);
+        const uint32_t sem_buffer_size = mesh_workload.impl().get_sem_size(mesh_device, core, CoreType::WORKER);
+        const uint32_t sem_buffer_base = mesh_workload.impl().get_sem_base_addr(mesh_device, core, CoreType::WORKER);
         std::vector<uint32_t> readback_sem_vals;
         ::tt::tt_metal::detail::ReadFromDeviceL1(device, core, sem_buffer_base, sem_buffer_size, readback_sem_vals);
         uint32_t sem_idx = 0;
@@ -574,10 +576,10 @@ TEST_F(MeshWorkloadTestSuite, EltwiseBinaryMeshWorkload) {
 
     for (std::size_t col_idx = 0; col_idx < worker_grid_size.x; col_idx++) {
         for (std::size_t row_idx = 0; row_idx < worker_grid_size.y; row_idx++) {
-            EnqueueWriteMeshBuffer(
-                mesh_device_->mesh_command_queue(), src0_bufs[(col_idx * worker_grid_size.y) + row_idx], src0_vec);
-            EnqueueWriteMeshBuffer(
-                mesh_device_->mesh_command_queue(), src1_bufs[(col_idx * worker_grid_size.y) + row_idx], src1_vec);
+            mesh_device_->mesh_command_queue().enqueue_write_mesh_buffer(
+                src0_bufs[(col_idx * worker_grid_size.y) + row_idx], src0_vec.data(), false);
+            mesh_device_->mesh_command_queue().enqueue_write_mesh_buffer(
+                src1_bufs[(col_idx * worker_grid_size.y) + row_idx], src1_vec.data(), false);
         }
     }
 
@@ -683,8 +685,8 @@ TEST_F(MeshWorkloadTestSuite, MeshWorkloadSanity) {
 
     for (std::size_t col_idx = 0; col_idx < worker_grid_size.x; col_idx++) {
         for (std::size_t row_idx = 0; row_idx < worker_grid_size.y; row_idx++) {
-            EnqueueWriteMeshBuffer(
-                mesh_device_->mesh_command_queue(), input_buffers[(col_idx * worker_grid_size.y) + row_idx], src_vec);
+            mesh_device_->mesh_command_queue().enqueue_write_mesh_buffer(
+                input_buffers[(col_idx * worker_grid_size.y) + row_idx], src_vec.data(), false);
         }
     }
 

--- a/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/socket_send_recv_utils.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <chrono>
+#include <type_traits>
 #include <cstdint>
 #include <cmath>
 #include <cstddef>
@@ -19,7 +20,6 @@
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include "impl/context/metal_context.hpp"
 #include <tt-logger/tt-logger.hpp>
-
 namespace tt::tt_fabric::fabric_router_tests::multihost::multihost_utils {
 
 std::string get_system_config_name(SystemConfig system_config) {
@@ -157,11 +157,10 @@ bool test_socket_send_recv(
                 }
                 mesh_core_coords.insert(connection.sender_core);
                 auto sender_core = connection.sender_core.core_coord;
-                WriteShard(
-                    mesh_device_->mesh_command_queue(),
+                mesh_device_->mesh_command_queue().enqueue_write_shards(
                     sender_data_buffer,
-                    src_vec,
-                    connection.sender_core.device_coord);
+                    {ShardDataTransfer{connection.sender_core.device_coord}.host_data(src_vec.data())},
+                    false);
 
                 auto sender_fabric_node_id = mesh_device_->get_fabric_node_id(connection.sender_core.device_coord);
                 auto recv_fabric_node_id =

--- a/tests/tt_metal/multihost/socket_pipeline/multiprocess/multi_host_pipeline.cpp
+++ b/tests/tt_metal/multihost/socket_pipeline/multiprocess/multi_host_pipeline.cpp
@@ -22,7 +22,6 @@
 #include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
 #include "tt_metal/fabric/physical_system_discovery.hpp"
 #include "tt_metal/llrt/tt_cluster.hpp"
-
 namespace tt::tt_metal {
 
 // Pipeline config structs.
@@ -846,8 +845,8 @@ void run_single_galaxy_pipeline(
         mesh_device.get());
     // Write 0 to latency measurement buffer (initializes credit/barrier to 0)
     std::vector<uint32_t> latency_init_data(latency_measurement_buffer_size / sizeof(uint32_t), 0);
-    distributed::EnqueueWriteMeshBuffer(
-        mesh_device->mesh_command_queue(), latency_measurement_buffer, latency_init_data, true);
+    mesh_device->mesh_command_queue().enqueue_write_mesh_buffer(
+        latency_measurement_buffer, latency_init_data.data(), true);
 
     const uint32_t latency_measurement_address = latency_measurement_buffer->address();
 
@@ -896,7 +895,7 @@ void run_single_galaxy_pipeline(
         std::iota(host_data.begin(), host_data.end(), 0u);
 
         // Write data to device buffer
-        distributed::EnqueueWriteMeshBuffer(mesh_device->mesh_command_queue(), input_mesh_buffer, host_data, true);
+        mesh_device->mesh_command_queue().enqueue_write_mesh_buffer(input_mesh_buffer, host_data.data(), true);
 
         // Extract buffer pointer for metal-level operations
         Buffer* input_buffer = input_mesh_buffer->get_reference_buffer();
@@ -1098,7 +1097,7 @@ void run_single_galaxy_rate_pipeline(
             distributed::ReplicatedBufferConfig{.size = buffer_size}, buffer_config, mesh_device.get());
         std::vector<uint32_t> host_data(num_elems);
         std::iota(host_data.begin(), host_data.end(), 0u);
-        distributed::EnqueueWriteMeshBuffer(mesh_device->mesh_command_queue(), input_mesh_buffer, host_data, true);
+        mesh_device->mesh_command_queue().enqueue_write_mesh_buffer(input_mesh_buffer, host_data.data(), true);
         Buffer* input_buffer = input_mesh_buffer->get_reference_buffer();
 
         // Warmup: run a small number of iterations to trigger kernel compilation and caching.

--- a/tests/tt_metal/multihost/socket_pipeline/multiprocess/single_host_pipeline_tests.cpp
+++ b/tests/tt_metal/multihost/socket_pipeline/multiprocess/single_host_pipeline_tests.cpp
@@ -17,7 +17,6 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include "tt_metal/llrt/tt_cluster.hpp"
-
 namespace tt::tt_metal {
 
 // Single-host loopback pipeline test using metal-level APIs (send_async/socket_forward).
@@ -105,7 +104,8 @@ void run_single_host_loopback_pipeline(
         mesh_device.get());
     // Write 0 to latency measurement buffer (initializes credit/barrier to 0)
     std::vector<uint32_t> latency_init_data(latency_measurement_buffer_size / sizeof(uint32_t), 0);
-    EnqueueWriteMeshBuffer(mesh_device->mesh_command_queue(), latency_measurement_buffer, latency_init_data, true);
+    mesh_device->mesh_command_queue().enqueue_write_mesh_buffer(
+        latency_measurement_buffer, latency_init_data.data(), true);
     const uint32_t latency_measurement_address = latency_measurement_buffer->address();
     log_info(tt::LogTest, "Latency measurement buffer address: {}", latency_measurement_address);
 
@@ -128,7 +128,7 @@ void run_single_host_loopback_pipeline(
     }
 
     // Write data to device buffer
-    EnqueueWriteMeshBuffer(mesh_device->mesh_command_queue(), input_mesh_buffer, host_data, true);
+    mesh_device->mesh_command_queue().enqueue_write_mesh_buffer(input_mesh_buffer, host_data.data(), true);
 
     // Extract buffer pointer for metal-level operations
     Buffer* input_buffer = input_mesh_buffer->get_reference_buffer();
@@ -251,7 +251,7 @@ void run_single_host_rate_pipeline(
     for (uint32_t j = 0; j < num_elems; j++) {
         host_data[j] = j;
     }
-    EnqueueWriteMeshBuffer(mesh_device->mesh_command_queue(), input_mesh_buffer, host_data, true);
+    mesh_device->mesh_command_queue().enqueue_write_mesh_buffer(input_mesh_buffer, host_data.data(), true);
     Buffer* input_buffer = input_mesh_buffer->get_reference_buffer();
 
     // Warmup: run the full pipeline with a small iteration count to trigger kernel compilation

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <type_traits>
 #include <fmt/format.h>
 #include <algorithm>
 #include <chrono>
@@ -22,7 +23,6 @@
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/mesh_device_view.hpp>
 #include <distributed/mesh_device_view_impl.hpp>
-
 namespace tt::tt_fabric::bench {
 
 // ---------- helpers (validation / utilities) ----------
@@ -147,8 +147,14 @@ PerfPoint run_unicast_once(HelpersFixture* fixture, const PerfParams& p) {
     // Mesh CQ (needed for shard I/O and later trace)
     auto& mcq = mesh->mesh_command_queue();
     // Initialize shards on specific src/dst devices (pass CQ, use vectors)
-    Dist::WriteShard(mcq, src_buf, tx, src_coord, /*blocking=*/true);
-    Dist::WriteShard(mcq, dst_buf, zeros, dst_coord, /*blocking=*/true);
+    mcq.enqueue_write_shards(
+        src_buf,
+        {Dist::ShardDataTransfer{src_coord}.host_data(tx.data())},
+        /*blocking=*/true);
+    mcq.enqueue_write_shards(
+        dst_buf,
+        {Dist::ShardDataTransfer{dst_coord}.host_data(zeros.data())},
+        /*blocking=*/true);
 
     // ---------------------------- PROGRAM FACTORY ----------------------------
     /*

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/multicast_runner.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/multicast_runner.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <type_traits>
 #include <fmt/format.h>
 #include <algorithm>
 #include <filesystem>
@@ -24,7 +25,6 @@
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/mesh_device_view.hpp>
 #include <distributed/mesh_device_view_impl.hpp>
-
 namespace tt::tt_fabric::test {
 
 // Import needed types
@@ -127,8 +127,14 @@ void run_multicast_write_test(tt::tt_metal::MeshDeviceFixtureBase* fixture, cons
 
     // Blocking writes so data is resident before kernels run
     auto& mcq = mesh->mesh_command_queue();
-    Dist::WriteShard(mcq, src_buf, tx, src_coord, /*blocking=*/true);
-    Dist::WriteShard(mcq, dst_buf, zeros, dst_coord, /*blocking=*/true);
+    mcq.enqueue_write_shards(
+        src_buf,
+        {Dist::ShardDataTransfer{src_coord}.host_data(tx.data())},
+        /*blocking=*/true);
+    mcq.enqueue_write_shards(
+        dst_buf,
+        {Dist::ShardDataTransfer{dst_coord}.host_data(zeros.data())},
+        /*blocking=*/true);
 
     // === Build the multicast receiver set from a rectangular sub-mesh ===
     std::vector<Dist::MeshCoordinate> dst_coords;
@@ -157,9 +163,15 @@ void run_multicast_write_test(tt::tt_metal::MeshDeviceFixtureBase* fixture, cons
         return;
     }
     for (const auto& c : dst_coords) {
-        Dist::WriteShard(mcq, dst_buf, zeros, c, /*blocking=*/true);
+        mcq.enqueue_write_shards(
+            dst_buf,
+            {Dist::ShardDataTransfer{c}.host_data(zeros.data())},
+            /*blocking=*/true);
     }
-    Dist::WriteShard(mcq, dst_buf, zeros, src_coord, /*blocking=*/true);
+    mcq.enqueue_write_shards(
+        dst_buf,
+        {Dist::ShardDataTransfer{src_coord}.host_data(zeros.data())},
+        /*blocking=*/true);
 
     // Build RX programs: one per receiver chip
     std::vector<tt::tt_metal::Program> receiver_progs;

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/unicast_runner.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/unicast_runner.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <type_traits>
 #include <fmt/format.h>
 #include <algorithm>
 #include <filesystem>
@@ -24,7 +25,6 @@
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/mesh_device_view.hpp>
 #include <distributed/mesh_device_view_impl.hpp>
-
 namespace tt::tt_fabric::test {
 
 // Import needed types from test and bench namespaces
@@ -162,8 +162,14 @@ void run_unicast_write_test(HelpersFixture* fixture, const AddrgenTestParams& p)
     // Mesh CQ (needed for shard I/O and later trace)
     auto& mcq = mesh->mesh_command_queue();
     // Initialize shards on specific src/dst devices (pass CQ, use vectors)
-    Dist::WriteShard(mcq, src_buf, tx, src_coord, /*blocking=*/true);
-    Dist::WriteShard(mcq, dst_buf, zeros, dst_coord, /*blocking=*/true);
+    mcq.enqueue_write_shards(
+        src_buf,
+        {Dist::ShardDataTransfer{src_coord}.host_data(tx.data())},
+        /*blocking=*/true);
+    mcq.enqueue_write_shards(
+        dst_buf,
+        {Dist::ShardDataTransfer{dst_coord}.host_data(zeros.data())},
+        /*blocking=*/true);
 
     // ---------------------------- PROGRAM FACTORY ----------------------------
     /*

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <fmt/base.h>
+#include <type_traits>
 #include <gtest/gtest.h>
 #include <cstdint>
 #include "hostdevcommon/fabric_common.h"
@@ -43,7 +44,6 @@
 #include <umd/device/types/xy_pair.hpp>
 #include "tt_metal/fabric/fabric_context.hpp"
 #include "test_host_kernel_common.hpp"
-
 namespace tt::tt_fabric::fabric_router_tests {
 
 // hack to let topology.cpp to know the binary is a unit test
@@ -73,8 +73,11 @@ std::shared_ptr<tt_metal::distributed::MeshBuffer> PrepareBuffer(
         .size = size,
     };
     auto buffer = tt_metal::distributed::MeshBuffer::create(global_buffer_config, device_local_config, device.get());
-    tt_metal::distributed::WriteShard(
-        device->mesh_command_queue(), buffer, fill_data, tt::tt_metal::distributed::MeshCoordinate({0, 0}), true);
+    device->mesh_command_queue().enqueue_write_shards(
+        buffer,
+        {tt_metal::distributed::ShardDataTransfer{tt::tt_metal::distributed::MeshCoordinate({0, 0})}.host_data(
+            fill_data.data())},
+        true);
     return buffer;
 }
 

--- a/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_common.hpp
+++ b/tests/tt_metal/tt_fabric/test_infra/tt_fabric_test_common.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <type_traits>
 #include <vector>
 #include <unordered_map>
 #include <algorithm>
@@ -33,7 +34,6 @@
 #include "tt_fabric_test_common_types.hpp"
 #include "tt_metal/distributed/fd_mesh_command_queue.hpp"
 #include "tt_metal/distributed/mesh_device_impl.hpp"
-
 using MeshDevice = tt::tt_metal::distributed::MeshDevice;
 using MeshCoordinate = tt::tt_metal::distributed::MeshCoordinate;
 using MeshShape = tt::tt_metal::distributed::MeshShape;
@@ -645,8 +645,10 @@ public:
 
         const auto total_size = size_bytes * cores.size();
         std::vector<uint32_t> zero_buffer(total_size / sizeof(uint32_t), 0);
-        tt::tt_metal::distributed::WriteShard(
-            mesh_device_->mesh_command_queue(), mesh_buffer, zero_buffer, device_coord, true);
+        mesh_device_->mesh_command_queue().enqueue_write_shards(
+            mesh_buffer,
+            {tt::tt_metal::distributed::ShardDataTransfer{device_coord}.host_data(zero_buffer.data())},
+            true);
     }
 
     // Local runtime args function - writes args to local args buffer instead of using SetRuntimeArgs
@@ -662,8 +664,10 @@ public:
         all_args_buffer.reserve(total_size / sizeof(uint32_t));
         all_args_buffer.insert(all_args_buffer.end(), args.begin(), args.end());
 
-        tt::tt_metal::distributed::WriteShard(
-            mesh_device_->mesh_command_queue(), mesh_buffer, all_args_buffer, device_coord, true);
+        mesh_device_->mesh_command_queue().enqueue_write_shards(
+            mesh_buffer,
+            {tt::tt_metal::distributed::ShardDataTransfer{device_coord}.host_data(all_args_buffer.data())},
+            true);
     }
 
     // ======================================================================================

--- a/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
@@ -6,6 +6,7 @@
 // These tests require a real device (slow dispatch).
 
 #include <cstdlib>
+#include <type_traits>
 #include <cstring>
 #include <utility>
 #include <vector>
@@ -19,7 +20,6 @@
 #include <tt-metalium/mesh_device.hpp>
 #include "tests/tt_metal/tt_metal/common/device_fixture.hpp"
 #include "tt_metal/hw/inc/hostdev/socket.h"
-
 namespace tt::tt_metal {
 
 namespace per_core = experimental::per_core_allocation;

--- a/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_wrapping.cpp
+++ b/tests/tt_metal/tt_metal/api/circular_buffer/test_CircularBuffer_wrapping.cpp
@@ -58,8 +58,10 @@ std::shared_ptr<distributed::MeshBuffer> create_result_buffer(
     };
     auto result_buffer = distributed::MeshBuffer::create(buffer_config, local_config, mesh_device.get());
     std::vector<DataT> init_data(RESULT_BUFFER_SIZE / sizeof(DataT), 0);
-    distributed::WriteShard(
-        mesh_device->mesh_command_queue(), result_buffer, init_data, distributed::MeshCoordinate(0, 0));
+    mesh_device->mesh_command_queue().enqueue_write_shards(
+        result_buffer,
+        {distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(init_data.data())},
+        false);
     return result_buffer;
 }
 

--- a/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "gtest/gtest.h"
+#include <type_traits>
 #include "tests/tt_metal/tt_metal/common/multi_device_fixture.hpp"
 #include "dispatch/system_memory_manager.hpp"
 #include "allocator/allocator.hpp"
@@ -13,7 +14,6 @@
 #include <tt-metalium/buffer_distribution_spec.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <impl/dispatch/dispatch_mem_map.hpp>
-
 namespace distribution_spec_tests {
 using tt::tt_metal::BufferDistributionSpec;  // NOLINT(misc-unused-using-decls)
 constexpr uint32_t PADDING = tt::tt_metal::UncompressedBufferPageMapping::PADDING;
@@ -275,7 +275,7 @@ TEST_P(MeshBufferReadWriteTests, WriteReadLoopback) {
      * Here, buffer refers to local device buffer or shard view
      * - Initialize buffer and command queue state to 0
      * - Initialize src vector
-     * - Write to buffer (with either EnqueueWriteMeshBuffer or WriteToBuffer)
+     * - Write to buffer (with either enqueue_write_mesh_buffer or WriteToBuffer)
      * - Validate written results are correct per core (using explicitly hard-coded core mapping)
      * - Read from buffer (with either ReadShard or ReadFromBuffer)
      */
@@ -326,8 +326,8 @@ TEST_P(MeshBufferReadWriteTests, WriteReadLoopback) {
         tt::test_utils::generate_uniform_random_vector<uint8_t>(0, UINT8_MAX, host_size_in_bytes / sizeof(uint8_t));
 
     if (cq_write) {
-        log_info(tt::LogTest, "Writing with: FDMeshCommandQueue EnqueueWriteMeshBuffer");
-        EnqueueWriteMeshBuffer(mesh_device_->mesh_command_queue(), mesh_buffer, src, /*blocking=*/false);
+        log_info(tt::LogTest, "Writing with: FDMeshCommandQueue enqueue_write_mesh_buffer");
+        mesh_device_->mesh_command_queue().enqueue_write_mesh_buffer(mesh_buffer, src.data(), /*blocking=*/false);
         Finish(mesh_device_->mesh_command_queue());
     } else {
         log_info(tt::LogTest, "Writing with: WriteToBuffer (equivalent to SDMeshCommandQueue enqueue_write_shards)");

--- a/tests/tt_metal/tt_metal/api/tensor/test_tensor_nd_sharding.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_tensor_nd_sharding.cpp
@@ -14,6 +14,7 @@
 // MeshTensor/HostTensor API on a single-device mesh via MeshDevice1x1Fixture.
 
 #include <gtest/gtest.h>
+#include <type_traits>
 #include <gmock/gmock.h>
 
 #include <functional>
@@ -47,11 +48,9 @@
 #include <tt-metalium/tensor/tensor_apis.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/distributed.hpp>
-
 #include "impl/tensor/mesh_tensor_impl.hpp"
 
 #include "tt_metal/tt_metal/common/multi_device_fixture.hpp"
-
 namespace tt::tt_metal {
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {

--- a/tests/tt_metal/tt_metal/api/test_banked.cpp
+++ b/tests/tt_metal/tt_metal/api/test_banked.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <chrono>
+#include <type_traits>
 #include <fmt/base.h>
 #include <cstdint>
 #include <sys/types.h>
@@ -31,7 +32,6 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
-
 using std::vector;
 using namespace tt::tt_metal;
 
@@ -182,17 +182,16 @@ bool reader_cb_writer(
     ////////////////////////////////////////////////////////////////////////////
     auto input_packed =
         tt::test_utils::generate_uniform_random_vector<uint32_t>(0, 100, cfg.size_bytes / sizeof(uint32_t));
-    distributed::WriteShard(cq, input_buffer, input_packed, zero_coord, false);
+    cq.enqueue_write_shards(
+        input_buffer, {distributed::ShardDataTransfer{zero_coord}.host_data(input_packed.data())}, false);
     SetRuntimeArgs(program_, reader_kernel, cfg.logical_core, reader_runtime_args);
     SetRuntimeArgs(program_, writer_kernel, cfg.logical_core, writer_runtime_args);
 
     distributed::EnqueueMeshWorkload(cq, workload, false);
     std::vector<uint32_t> reread_input_packed;
     distributed::ReadShard(cq, reread_input_packed, input_buffer, zero_coord, false);
-
     std::vector<uint32_t> output_packed;
     distributed::ReadShard(cq, output_packed, output_buffer, zero_coord, false);
-
     pass &= (output_packed == input_packed);
 
     return pass;
@@ -287,7 +286,8 @@ bool reader_datacopy_writer(const std::shared_ptr<distributed::MeshDevice>& mesh
     //                      Compile and Execute Appli   cation
     ////////////////////////////////////////////////////////////////////////////
 
-    distributed::WriteShard(cq, input_buffer, input_packed, zero_coord, false);
+    cq.enqueue_write_shards(
+        input_buffer, {distributed::ShardDataTransfer{zero_coord}.host_data(input_packed.data())}, false);
 
     SetRuntimeArgs(
         program_,

--- a/tests/tt_metal/tt_metal/api/test_cross_node_dfb.cpp
+++ b/tests/tt_metal/tt_metal/api/test_cross_node_dfb.cpp
@@ -1741,7 +1741,7 @@ TEST_F(CrossNodeDFBTraceFixture, CaptureReplay_OrdersConfigRewrite) {
     distributed::EnqueueMeshWorkload(cq, ctx.workload, true);
 
     cross_node_dfb_test::zero_receiver_ring(*mesh_device, *ctx.gdfb, ctx.receiver_core);
-    const auto tid = distributed::BeginTraceCapture(mesh_device.get(), cq.id());
+    const auto tid = mesh_device->begin_mesh_trace(cq);
     distributed::EnqueueMeshWorkload(cq, ctx.workload, false);
     // Second enqueue of the same CrossNode program inside the capture: the
     // allocator must stall_first on the prior launch before rewriting credits.
@@ -1764,7 +1764,7 @@ TEST_F(CrossNodeDFBTraceFixture, ReplayThenRelaunch_OrdersConfigRewrite) {
 
     distributed::EnqueueMeshWorkload(cq, ctx.workload, true);
 
-    const auto tid = distributed::BeginTraceCapture(mesh_device.get(), cq.id());
+    const auto tid = mesh_device->begin_mesh_trace(cq);
     distributed::EnqueueMeshWorkload(cq, ctx.workload, false);
     mesh_device->end_mesh_trace(cq.id(), tid);
 
@@ -1844,7 +1844,7 @@ TEST_F(CrossNodeDFBTraceFixture, CaptureReplay_UpdateDynamicSnapshot) {
     cross_node_dfb_test::zero_receiver_ring(*mesh_device, gdfb_a, receiver_core);
     cross_node_dfb_test::zero_receiver_ring(*mesh_device, gdfb_b, receiver_core);
 
-    const auto tid = distributed::BeginTraceCapture(mesh_device.get(), cq.id());
+    const auto tid = mesh_device->begin_mesh_trace(cq);
     distributed::EnqueueMeshWorkload(cq, workload, false);
     mesh_device->end_mesh_trace(cq.id(), tid);
 

--- a/tests/tt_metal/tt_metal/api/test_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_semaphores.cpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include "device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
+#include <distributed/mesh_workload_impl.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include "hostdevcommon/kernel_structs.h"
@@ -115,7 +116,7 @@ void create_and_read_max_num_semaphores(
             for (uint32_t i = 0; i < tt::tt_metal::NUM_SEMAPHORES; i++) {
                 std::vector<uint32_t> single_val;
                 uint32_t semaphore_addr =
-                    workload.get_sem_base_addr(mesh_device, logical_core, CoreType::WORKER) +
+                    workload.impl().get_sem_base_addr(mesh_device, logical_core, CoreType::WORKER) +
                     (tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1) * i);
                 uint32_t semaphore_size = sizeof(uint32_t);
                 slow_dispatch::ReadFromL1(*mesh_device, logical_core, semaphore_addr, semaphore_size, single_val);

--- a/tests/tt_metal/tt_metal/common/matmul_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/common/matmul_test_utils.hpp
@@ -154,7 +154,8 @@ inline bool move_tiles_to_dram(
         }
     }
 
-    distributed::WriteShard(cq, buffer, tiles, distributed::MeshCoordinate(0, 0));
+    cq.enqueue_write_shards(
+        buffer, {distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(tiles.data())}, false);
     return pass;
 }
 

--- a/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
+++ b/tests/tt_metal/tt_metal/common/mesh_dispatch_fixture.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <umd/device/types/cluster_descriptor_types.hpp>
+#include <type_traits>
 #include "gtest/gtest.h"
 #include <functional>
 #include <map>
@@ -20,7 +21,6 @@
 #include "llrt.hpp"
 #include "common/tt_backend_api_types.hpp"
 #include <llrt/tt_cluster.hpp>
-
 namespace tt::tt_metal {
 
 struct SharedDevices {
@@ -52,8 +52,10 @@ public:
         const std::shared_ptr<distributed::MeshDevice>& mesh_device,
         const std::shared_ptr<distributed::MeshBuffer>& in_buffer,
         std::vector<uint32_t>& src_vec) {
-        distributed::WriteShard(
-            mesh_device->mesh_command_queue(), in_buffer, src_vec, distributed::MeshCoordinate(0, 0));
+        mesh_device->mesh_command_queue().enqueue_write_shards(
+            in_buffer,
+            {distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(src_vec.data())},
+            false);
     }
     void ReadBuffer(
         const std::shared_ptr<distributed::MeshDevice>& mesh_device,

--- a/tests/tt_metal/tt_metal/context/test_integration.cpp
+++ b/tests/tt_metal/tt_metal/context/test_integration.cpp
@@ -50,6 +50,7 @@
 #include <limits>
 #include <optional>
 #include <string>
+#include "tt_metal/distributed/mesh_buffer_impl.hpp"
 
 namespace tt::tt_metal {
 
@@ -90,10 +91,11 @@ void PerformDeviceWork(
     std::iota(write_data.begin(), write_data.end(), data_pattern);
 
     auto& mesh_cq = mesh_device->mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(mesh_cq, mesh_buffer, write_data, false);
+    mesh_cq.enqueue_write_mesh_buffer(mesh_buffer, write_data.data(), false);
 
     std::vector<uint32_t> read_data;
-    distributed::EnqueueReadMeshBuffer(mesh_cq, read_data, mesh_buffer, true);
+    read_data.resize(mesh_buffer->size() / sizeof(typename std::decay_t<decltype(read_data)>::value_type));
+    mesh_cq.enqueue_read_mesh_buffer((read_data).data(), mesh_buffer, true);
 
     if (read_data != write_data) {
         throw std::runtime_error("Buffer read/write verification failed");
@@ -486,17 +488,18 @@ TEST(MetalContextIntegrationTest, MockDeviceOnly) {
         ASSERT_FALSE(buffer->is_allocated());
 
         // Test command queue operations. Source vector is sized to fill the entire buffer so
-        // EnqueueWriteMeshBuffer's precondition (src bytes >= mesh buffer bytes, added in #43429)
+        // enqueue_write_mesh_buffer's precondition (src bytes >= mesh buffer bytes, added in #43429)
         // is satisfied; the prior 16-element vector was a pre-#43429 leftover.
         auto& cq = mock_device->mesh_command_queue();
         constexpr size_t num_elements = buffer_size / sizeof(uint32_t);
         std::vector<uint32_t> write_data(num_elements);
         std::iota(write_data.begin(), write_data.end(), 0xDEADBEEFu);
 
-        distributed::EnqueueWriteMeshBuffer(cq, buffer, write_data, true);
+        cq.enqueue_write_mesh_buffer(buffer, write_data.data(), true);
 
         std::vector<uint32_t> read_data;
-        distributed::EnqueueReadMeshBuffer(cq, read_data, buffer, true);
+        read_data.resize(buffer->size() / sizeof(typename std::decay_t<decltype(read_data)>::value_type));
+        cq.enqueue_read_mesh_buffer((read_data).data(), buffer, true);
 
         auto program = CreateProgram();
         distributed::MeshCoordinateRange device_range = distributed::MeshCoordinateRange(mock_device->shape());

--- a/tests/tt_metal/tt_metal/data_movement/dram_neighbour/test_dram_neighbour.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_neighbour/test_dram_neighbour.cpp
@@ -14,7 +14,6 @@
 #include <distributed/mesh_device_impl.hpp>
 #include "tt_metal/impl/allocator/allocator.hpp"
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
-
 namespace tt::tt_metal {
 
 using namespace std;
@@ -179,7 +178,7 @@ bool run_dm_neighbour(const shared_ptr<distributed::MeshDevice>& mesh_device, co
 
     // LAUNCH PROGRAM - Use mesh workload approach
     auto& cq = mesh_device->mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, mesh_buffer, packed_input);
+    cq.enqueue_write_mesh_buffer(mesh_buffer, packed_input.data(), false);
 
     auto mesh_workload = distributed::MeshWorkload();
     vector<uint32_t> coord_data = {0, 0};

--- a/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/dram_sharded/test_dram_sharded.cpp
@@ -18,7 +18,6 @@
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include <distributed/mesh_device_impl.hpp>
-
 namespace tt::tt_metal {
 
 using namespace std;
@@ -159,7 +158,7 @@ bool run_dm(const shared_ptr<distributed::MeshDevice>& mesh_device, const DramSh
     vector<uint32_t> packed_output;
 
     auto& cq = mesh_device->mesh_command_queue();
-    distributed::EnqueueWriteMeshBuffer(cq, mesh_buffer, packed_input);
+    cq.enqueue_write_mesh_buffer(mesh_buffer, packed_input.data(), false);
 
     auto mesh_workload = distributed::MeshWorkload();
     vector<uint32_t> coord_data = {0, 0};

--- a/tests/tt_metal/tt_metal/data_movement/pcie_read_bw/test_pcie_read_bw.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/pcie_read_bw/test_pcie_read_bw.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "multi_device_fixture.hpp"
+#include <type_traits>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
@@ -12,7 +13,6 @@
 #include "dm_common.hpp"
 #include <distributed/mesh_device_impl.hpp>
 #include <chrono>
-
 namespace tt::tt_metal {
 
 using namespace std;
@@ -193,7 +193,7 @@ TEST_F(GenericMeshDeviceFixture, PCIeHostReadBandwidthSweep) {
 
         // Seed device buffer
         vector<uint32_t> src(buf_size / sizeof(uint32_t), 0xDEADBEEF);
-        distributed::WriteShard(cq, buffer, src, device_coord, false);
+        cq.enqueue_write_shards(buffer, {distributed::ShardDataTransfer{device_coord}.host_data(src.data())}, false);
         distributed::Finish(cq);
 
         vector<uint32_t> dst;

--- a/tests/tt_metal/tt_metal/data_movement/pcie_write_bw/test_pcie_write_bw.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/pcie_write_bw/test_pcie_write_bw.cpp
@@ -163,13 +163,14 @@ TEST_F(GenericMeshDeviceFixture, PCIeHostWriteBandwidthSweep) {
         vector<uint32_t> src(buf_size / sizeof(uint32_t), 0xDEADBEEF);
 
         // Warmup
-        distributed::WriteShard(cq, buffer, src, device_coord, false);
+        cq.enqueue_write_shards(buffer, {distributed::ShardDataTransfer{device_coord}.host_data(src.data())}, false);
         distributed::Finish(cq);
 
         // Timed
         auto start = chrono::high_resolution_clock::now();
         for (uint32_t i = 0; i < num_iterations; i++) {
-            distributed::WriteShard(cq, buffer, src, device_coord, false);
+            cq.enqueue_write_shards(
+                buffer, {distributed::ShardDataTransfer{device_coord}.host_data(src.data())}, false);
         }
         distributed::Finish(cq);
         auto end = chrono::high_resolution_clock::now();

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_cb_hash.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_cb_hash.cpp
@@ -16,6 +16,7 @@
 //   3. Distinct inputs produce distinct fingerprints (discrimination).
 
 #include <cstdint>
+#include <type_traits>
 #include <fstream>
 #include <regex>
 #include <sstream>
@@ -36,7 +37,6 @@
 #include "tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp"
 #include "gtest/gtest.h"
 #include "tt_metal/test_utils/stimulus.hpp"
-
 using namespace tt;
 using namespace tt::tt_metal;
 
@@ -151,7 +151,10 @@ uint32_t run_once(
         s.core,
         {static_cast<uint32_t>(s.output_dram->address()), 0u, static_cast<uint32_t>(NUM_TILES)});
 
-    distributed::WriteShard(cq, s.input_dram, const_cast<std::vector<uint32_t>&>(input), s.zero);
+    cq.enqueue_write_shards(
+        s.input_dram,
+        {distributed::ShardDataTransfer{s.zero}.host_data(const_cast<std::vector<uint32_t>&>(input).data())},
+        false);
     fixture->RunProgram(mesh_device, s.workload);
 
     return extract_hash(fixture->dprint_file_name, LABEL, INPUT_CB, NUM_TILES);
@@ -191,7 +194,10 @@ uint32_t run_once_sfpu(
     SetRuntimeArgs(
         *s.program, writer, s.core, {static_cast<uint32_t>(s.output_dram->address()), 0u, static_cast<uint32_t>(NUM_TILES)});
 
-    distributed::WriteShard(cq, s.input_dram, const_cast<std::vector<uint32_t>&>(input), s.zero);
+    cq.enqueue_write_shards(
+        s.input_dram,
+        {distributed::ShardDataTransfer{s.zero}.host_data(const_cast<std::vector<uint32_t>&>(input).data())},
+        false);
     fixture->RunProgram(mesh_device, s.workload);
 
     std::vector<uint32_t> result(NUM_TILES * 1024, 0u);

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_checkpoint.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_checkpoint.cpp
@@ -7,6 +7,7 @@
 // checkpoint, debug_dump_cb, debug_dump_l1, debug_dump_cb_typed.
 
 #include <cstdint>
+#include <type_traits>
 #include <string>
 #include <vector>
 
@@ -26,7 +27,6 @@
 #include "debug_tools_test_utils.hpp"
 #include "gtest/gtest.h"
 #include "tt_metal/test_utils/stimulus.hpp"
-
 using namespace tt;
 using namespace tt::tt_metal;
 
@@ -116,7 +116,7 @@ static void run_basic_checkpoint(
 
     auto input =
         tt::test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, NUM_TILES * 1024);
-    distributed::WriteShard(cq, s.input_dram, input, s.zero);
+    cq.enqueue_write_shards(s.input_dram, {distributed::ShardDataTransfer{s.zero}.host_data(input.data())}, false);
     fixture->RunProgram(mesh_device, s.workload);
 
     std::vector<uint32_t> output;
@@ -170,7 +170,7 @@ static void run_checkpoint_loop(
 
     auto input =
         tt::test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, NUM_TILES * 1024);
-    distributed::WriteShard(cq, s.input_dram, input, s.zero);
+    cq.enqueue_write_shards(s.input_dram, {distributed::ShardDataTransfer{s.zero}.host_data(input.data())}, false);
     fixture->RunProgram(mesh_device, s.workload);
 
     std::vector<uint32_t> output;
@@ -274,8 +274,8 @@ static void run_global_checkpoint(
         tt::test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, NUM_TILES * 1024);
     auto data1 =
         tt::test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, NUM_TILES * 1024);
-    distributed::WriteShard(cq, in0, data0, zero);
-    distributed::WriteShard(cq, in1, data1, zero);
+    cq.enqueue_write_shards(in0, {distributed::ShardDataTransfer{zero}.host_data(data0.data())}, false);
+    cq.enqueue_write_shards(in1, {distributed::ShardDataTransfer{zero}.host_data(data1.data())}, false);
     fixture->RunProgram(mesh_device, workload);
 
     std::vector<uint32_t> o0, o1;
@@ -334,7 +334,7 @@ static void run_dump_cb(DevicePrintFixture* fixture, const std::shared_ptr<distr
 
     auto input =
         tt::test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, NUM_TILES * 1024);
-    distributed::WriteShard(cq, s.input_dram, input, s.zero);
+    cq.enqueue_write_shards(s.input_dram, {distributed::ShardDataTransfer{s.zero}.host_data(input.data())}, false);
     fixture->RunProgram(mesh_device, s.workload);
 
     std::vector<uint32_t> output;
@@ -390,7 +390,7 @@ static void run_dump_l1(DevicePrintFixture* fixture, const std::shared_ptr<distr
 
     auto input =
         tt::test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, NUM_TILES * 1024);
-    distributed::WriteShard(cq, s.input_dram, input, s.zero);
+    cq.enqueue_write_shards(s.input_dram, {distributed::ShardDataTransfer{s.zero}.host_data(input.data())}, false);
     fixture->RunProgram(mesh_device, s.workload);
 
     std::vector<uint32_t> output;
@@ -446,7 +446,7 @@ static void run_dump_typed(DevicePrintFixture* fixture, const std::shared_ptr<di
 
     auto input =
         tt::test_utils::generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, NUM_TILES * 1024);
-    distributed::WriteShard(cq, s.input_dram, input, s.zero);
+    cq.enqueue_write_shards(s.input_dram, {distributed::ShardDataTransfer{s.zero}.host_data(input.data())}, false);
     fixture->RunProgram(mesh_device, s.workload);
 
     std::vector<uint32_t> output;

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_tensix_dest.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_tensix_dest.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
+#include <type_traits>
 #include <cstring>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/host_api.hpp>
@@ -32,7 +33,6 @@
 #include "tt_metal/test_utils/df/float32.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <umd/device/types/arch.hpp>
-
 namespace tt::tt_metal {
 class IDevice;
 }  // namespace tt::tt_metal
@@ -481,7 +481,8 @@ static bool reader_datacopy_writer(
     auto input_data = generate_inputs(config);
 
     // Write input data to input DRAM buffer
-    distributed::WriteShard(cq, input_dram_buffer, input_data, zero_coord);
+    cq.enqueue_write_shards(
+        input_dram_buffer, {distributed::ShardDataTransfer{zero_coord}.host_data(input_data.data())}, false);
 
     // Run the program
     fixture->RunProgram(mesh_device, workload);

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_tile.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_tile.cpp
@@ -118,7 +118,8 @@ void RunTest(
     std::vector<uint32_t> u32_vec = GenerateInputTile(data_format);
 
     // Send input tile to dram
-    distributed::WriteShard(cq, src_dram_buffer, u32_vec, zero_coord);
+    cq.enqueue_write_shards(
+        src_dram_buffer, {distributed::ShardDataTransfer{zero_coord}.host_data(u32_vec.data())}, false);
 
     // Run the program
     fixture->RunProgram(mesh_device, workload);

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_tiles_multiple.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_tiles_multiple.cpp
@@ -107,7 +107,8 @@ void RunTest(
         expected_output_read += fmt::format("Read tile {}:{}\n", i, golden_output);
     }
 
-    distributed::WriteShard(cq, src_dram_buffer, u32_vec, zero_coord, true);
+    cq.enqueue_write_shards(
+        src_dram_buffer, {distributed::ShardDataTransfer{zero_coord}.host_data(u32_vec.data())}, true);
     fixture->RunProgram(mesh_device, workload);
 
     auto filename = tt::tt_metal::MetalContext::instance().rtoptions().get_logs_dir() +

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_noc_sanitize_delays.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <fmt/base.h>
+#include <type_traits>
 #include <fmt/ranges.h>
 #include <gtest/gtest.h>
 #include <tt-metalium/bfloat16.hpp>
@@ -31,7 +32,6 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <umd/device/types/core_coordinates.hpp>
-
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking watcher NOC sanitization.
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -134,8 +134,10 @@ void RunDelayTestOnCore(
     std::vector<uint32_t> expected_vec = create_constant_vector_of_bfloat16(DRAM_BUFFER_SIZE, 0.0f);
     inc_populate(expected_vec, start_from + constant);
 
-    distributed::WriteShard(cq, src0_dram_buffer, src0_vec, zero_coord);
-    distributed::WriteShard(cq, src1_dram_buffer, src1_vec, zero_coord);
+    cq.enqueue_write_shards(
+        src0_dram_buffer, {distributed::ShardDataTransfer{zero_coord}.host_data(src0_vec.data())}, false);
+    cq.enqueue_write_shards(
+        src1_dram_buffer, {distributed::ShardDataTransfer{zero_coord}.host_data(src1_vec.data())}, false);
 
     vector<uint32_t> reader_args = {
         dram_buffer_src0_addr, (std::uint32_t)0, NUM_TILES, dram_buffer_src1_addr, (std::uint32_t)0, NUM_TILES, 0};

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_sanitize.cpp
@@ -319,7 +319,8 @@ void RunTestOnCore(
     // Write to the input buffer
     std::vector<uint32_t> input_vec =
         create_random_vector_of_bfloat16(buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-    distributed::WriteShard(cq, input_buffer, input_vec, zero_coord);
+    cq.enqueue_write_shards(
+        input_buffer, {distributed::ShardDataTransfer{zero_coord}.host_data(input_vec.data())}, false);
 
     // Write runtime args - update to a core that doesn't exist or an improperly aligned address,
     // depending on the flags passed in.

--- a/tests/tt_metal/tt_metal/device/test_device.cpp
+++ b/tests/tt_metal/tt_metal/device/test_device.cpp
@@ -41,6 +41,7 @@
 #include "math.hpp"
 #include <impl/dispatch/dispatch_mem_map.hpp>
 #include <distributed/mesh_device_impl.hpp>
+#include "tt_metal/distributed/mesh_buffer_impl.hpp"
 
 namespace tt::tt_metal {
 
@@ -605,11 +606,12 @@ TEST_F(MeshDeviceFixture, SlowDispatchFullGridAccess) {
 
         std::vector<uint32_t> src_vec(num_tiles * single_tile_size / sizeof(uint32_t), 0);
         std::iota(src_vec.begin(), src_vec.end(), 42);
-        EnqueueWriteMeshBuffer(mesh_device->mesh_command_queue(), mesh_buffer, src_vec);
+        mesh_device->mesh_command_queue().enqueue_write_mesh_buffer(mesh_buffer, src_vec.data(), false);
         Finish(mesh_device->mesh_command_queue());
 
-        std::vector<uint32_t> dst_vec = {};
-        EnqueueReadMeshBuffer(mesh_device->mesh_command_queue(), dst_vec, mesh_buffer, true);
+        const size_t dst_vec_n = mesh_buffer->size() / sizeof(uint32_t);
+        std::vector<uint32_t> dst_vec(dst_vec_n);
+        mesh_device->mesh_command_queue().enqueue_read_mesh_buffer((dst_vec).data(), mesh_buffer, true);
         EXPECT_EQ(dst_vec, src_vec) << "Buffer operations failed with full grid in slow dispatch mode";
     }
 }

--- a/tests/tt_metal/tt_metal/device/test_mock_allocator.cpp
+++ b/tests/tt_metal/tt_metal/device/test_mock_allocator.cpp
@@ -21,7 +21,6 @@
 #include <umd/device/types/arch.hpp>
 
 #include "impl/device/mock_device_util.hpp"
-
 namespace tt::tt_metal {
 
 // ============================================================================

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_EnqueueWriteBuffer_and_EnqueueReadBuffer.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <chrono>
+#include <type_traits>
 #include <fmt/base.h>
 #include <enchantum/enchantum.hpp>
 #include <cstdlib>
@@ -50,6 +51,7 @@
 
 #include <umd/device/types/core_coordinates.hpp>
 #include <impl/dispatch/dispatch_mem_map.hpp>
+#include "tt_metal/distributed/mesh_buffer_impl.hpp"
 
 namespace tt::tt_metal {
 
@@ -144,7 +146,8 @@ vector<uint32_t> generate_arange_vector(uint32_t size_bytes) {
 void clear_buffer(distributed::MeshCommandQueue& cq, const std::shared_ptr<distributed::MeshBuffer>& buffer) {
     TT_FATAL(buffer->size() % sizeof(uint32_t) == 0, "Error");
     vector<uint32_t> zeroes(buffer->size() / sizeof(uint32_t), 0);
-    distributed::WriteShard(cq, buffer, zeroes, distributed::MeshCoordinate(0, 0));
+    cq.enqueue_write_shards(
+        buffer, {distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(zeroes.data())}, false);
 }
 
 vector<ShardedSubBufferStressTestConfig> generate_sharded_sub_buffer_test_configs(uint32_t max_buffer_size) {
@@ -237,7 +240,8 @@ void WriteToUnitMeshBuffer(
     auto* device = mesh_device->get_devices()[0];
     std::shared_ptr<Buffer> slow_dispatch_buffer;
     if (sharding_args.has_value()) {
-        slow_dispatch_buffer = Buffer::create(device, buf->address(), buf->size(), config.page_size, config.buftype, sharding_args.value());
+        slow_dispatch_buffer = Buffer::create(
+            device, buf->address(), buf->size(), config.page_size, config.buftype, sharding_args.value());
     } else {
         slow_dispatch_buffer = Buffer::create(device, buf->address(), buf->size(), config.page_size, config.buftype);
     }
@@ -253,7 +257,8 @@ void ReadFromUnitMeshBuffer(
     auto* device = mesh_device->get_devices()[0];
     std::shared_ptr<Buffer> slow_dispatch_buffer;
     if (sharding_args.has_value()) {
-        slow_dispatch_buffer = Buffer::create(device, buf->address(), buf->size(), config.page_size, config.buftype, sharding_args.value());
+        slow_dispatch_buffer = Buffer::create(
+            device, buf->address(), buf->size(), config.page_size, config.buftype, sharding_args.value());
     } else {
         slow_dispatch_buffer = Buffer::create(device, buf->address(), buf->size(), config.page_size, config.buftype);
     }
@@ -356,7 +361,8 @@ void test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
             vector<uint32_t> src = generate_arange_vector(bufa->size());
 
             if (cq_write) {
-                distributed::WriteShard(cq, bufa, src, device_coord);
+                cq.enqueue_write_shards(
+                    bufa, {distributed::ShardDataTransfer{device_coord}.host_data(src.data())}, false);
             } else {
                 WriteToUnitMeshBuffer(mesh_device, config, src, bufa, config.sharding_args);
                 if (config.buftype == BufferType::DRAM) {
@@ -433,7 +439,7 @@ bool stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer(
             buf = distributed::MeshBuffer::create(buffer_config, local_config, mesh_device.get());
         }
         auto coord = distributed::MeshCoordinate(0, 0);
-        distributed::WriteShard(cq, buf, src, coord);
+        cq.enqueue_write_shards(buf, {distributed::ShardDataTransfer{coord}.host_data(src.data())}, false);
         vector<uint32_t> dst;
         if constexpr (blocking) {
             distributed::ReadShard(cq, dst, buf, coord);
@@ -500,7 +506,8 @@ void stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer_sharded(
 
                 vector<uint32_t> src2 = src;
                 if (cq_write) {
-                    distributed::WriteShard(cq, buf, src, device_coord, false);
+                    cq.enqueue_write_shards(
+                        buf, {distributed::ShardDataTransfer{device_coord}.host_data(src.data())}, false);
                 } else {
                     local_test_functions::WriteToUnitMeshBuffer(mesh_device, test_config, src, buf, std::nullopt);
                     if (buftype == BufferType::DRAM) {
@@ -543,7 +550,8 @@ std::pair<std::shared_ptr<distributed::MeshBuffer>, std::vector<uint32_t>> Enque
     std::vector<uint32_t> src =
         create_random_vector_of_bfloat16(buf_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
 
-    distributed::WriteShard(cq, buffer, src, distributed::MeshCoordinate(0, 0), false);
+    cq.enqueue_write_shards(
+        buffer, {distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(src.data())}, false);
     return std::make_pair(std::move(buffer), src);
 }
 
@@ -588,11 +596,10 @@ bool stress_test_EnqueueWriteBuffer_and_EnqueueReadBuffer_wrap(
             start = i;
             bufs = {distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get())};
         }
-        distributed::WriteShard(
-            cq,
+        cq.enqueue_write_shards(
             bufs[bufs.size() - 1],
-            unique_vectors[i % unique_vectors.size()],
-            distributed::MeshCoordinate(0, 0),
+            {distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(
+                unique_vectors[i % unique_vectors.size()].data())},
             false);
     }
 
@@ -620,15 +627,15 @@ bool test_EnqueueWriteBuffer_and_EnqueueReadBuffer_multi_queue(
         std::vector<std::vector<uint32_t>> srcs;
         for (uint i = 0; i < cqs.size(); i++) {
             distributed::DeviceLocalBufferConfig dram_config{
-                .page_size = config.page_size,
-                .buffer_type = config.buftype,
-                .bottom_up = false};
-            const distributed::ReplicatedBufferConfig buffer_config{
-                .size = buf_size};
+                .page_size = config.page_size, .buffer_type = config.buftype, .bottom_up = false};
+            const distributed::ReplicatedBufferConfig buffer_config{.size = buf_size};
 
             buffers.push_back(distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get()));
             srcs.push_back(generate_arange_vector(buffers[i]->size()));
-            distributed::WriteShard(cqs[i], buffers[i], srcs[i], distributed::MeshCoordinate(0, 0), false);
+            cqs[i].get().enqueue_write_shards(
+                buffers[i],
+                {distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(srcs[i].data())},
+                false);
         }
 
         for (uint i = 0; i < cqs.size(); i++) {
@@ -1140,8 +1147,8 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWrapCompletionQOnInsufficien
         auto buff_1 = distributed::MeshBuffer::create(buffer_config1, dram_config1, mesh_device.get());
 
         auto src_1 = local_test_functions::generate_arange_vector(buff_1->size());
-        distributed::WriteShard(
-            mesh_device->mesh_command_queue(), buff_1, src_1, distributed::MeshCoordinate(0, 0), false);
+        mesh_device->mesh_command_queue().enqueue_write_shards(
+            buff_1, {distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(src_1.data())}, false);
         vector<uint32_t> result_1(first_buffer_size / sizeof(uint32_t));
         distributed::ReadShard(
             mesh_device->mesh_command_queue(), result_1, buff_1, distributed::MeshCoordinate(0, 0), true);
@@ -1154,8 +1161,8 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWrapCompletionQOnInsufficien
         auto buff_2 = distributed::MeshBuffer::create(buffer_config2, dram_config2, mesh_device.get());
         auto src_2 = local_test_functions::generate_arange_vector(buff_2->size());
 
-        distributed::WriteShard(
-            mesh_device->mesh_command_queue(), buff_2, src_2, distributed::MeshCoordinate(0, 0), false);
+        mesh_device->mesh_command_queue().enqueue_write_shards(
+            buff_2, {distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(src_2.data())}, false);
         vector<uint32_t> result_2(num_pages_second_buffer * small_page_size / sizeof(uint32_t));
         distributed::ReadShard(
             mesh_device->mesh_command_queue(), result_2, buff_2, distributed::MeshCoordinate(0, 0), true);
@@ -1168,8 +1175,8 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWrapCompletionQOnInsufficien
         auto buff_3 = distributed::MeshBuffer::create(buffer_config3, dram_config3, mesh_device.get());
         auto src_3 = local_test_functions::generate_arange_vector(buff_3->size());
 
-        distributed::WriteShard(
-            mesh_device->mesh_command_queue(), buff_3, src_3, distributed::MeshCoordinate(0, 0), false);
+        mesh_device->mesh_command_queue().enqueue_write_shards(
+            buff_3, {distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(src_3.data())}, false);
         vector<uint32_t> result_3(32 * large_page_size / sizeof(uint32_t));
         distributed::ReadShard(
             mesh_device->mesh_command_queue(), result_3, buff_3, distributed::MeshCoordinate(0, 0), true);
@@ -1302,8 +1309,8 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestReadSubBufferWriteBuffer) {
 
         auto buffer = distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
         auto src = local_test_functions::generate_arange_vector(buffer_size);
-        distributed::WriteShard(
-            mesh_device->mesh_command_queue(), buffer, src, distributed::MeshCoordinate(0, 0), false);
+        mesh_device->mesh_command_queue().enqueue_write_shards(
+            buffer, {distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(src.data())}, false);
         vector<uint32_t> result(buffer_region_size / sizeof(uint32_t));
         local_test_functions::EnqueueReadMeshSubBuffer(mesh_device->mesh_command_queue(), result, buffer, region, true);
         vector<uint32_t> expected_result;
@@ -1372,8 +1379,8 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWrapCompletionQOnInsufficien
         uint32_t num_pages_for_wrapping_buffer = (avail_space_for_wrapping_buffer / page_size) + 4;
 
         auto src_1 = local_test_functions::generate_arange_vector(buff_1->size());
-        distributed::WriteShard(
-            mesh_device->mesh_command_queue(), buff_1, src_1, distributed::MeshCoordinate(0, 0), false);
+        mesh_device->mesh_command_queue().enqueue_write_shards(
+            buff_1, {distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(src_1.data())}, false);
         vector<uint32_t> result_1(buff_1->size() / sizeof(uint32_t));
         distributed::ReadShard(
             mesh_device->mesh_command_queue(), result_1, buff_1, distributed::MeshCoordinate(0, 0), true);
@@ -1385,8 +1392,10 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestWrapCompletionQOnInsufficien
 
         auto wrap_buff = distributed::MeshBuffer::create(buffer_config2, dram_config2, mesh_device.get());
         auto src_2 = local_test_functions::generate_arange_vector(wrap_buff->size());
-        distributed::WriteShard(
-            mesh_device->mesh_command_queue(), wrap_buff, src_2, distributed::MeshCoordinate(0, 0), false);
+        mesh_device->mesh_command_queue().enqueue_write_shards(
+            wrap_buff,
+            {distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(src_2.data())},
+            false);
         vector<uint32_t> result_2(wrap_buff->size() / sizeof(uint32_t));
         distributed::ReadShard(
             mesh_device->mesh_command_queue(), result_2, wrap_buff, distributed::MeshCoordinate(0, 0), true);
@@ -1975,8 +1984,10 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestMultipleNonOverlappingReadsS
         auto buffer = distributed::MeshBuffer::create(buffer_config, l1_config, mesh_device.get());
 
         vector<uint32_t> expected = local_test_functions::generate_arange_vector(buffer_size);
-        distributed::WriteShard(
-            mesh_device->mesh_command_queue(), buffer, expected, distributed::MeshCoordinate(0, 0), true);
+        mesh_device->mesh_command_queue().enqueue_write_shards(
+            buffer,
+            {distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(expected.data())},
+            true);
 
         vector<uint32_t> first_read(buffer_region_size / sizeof(uint32_t));
         BufferRegion region(0, buffer_region_size);
@@ -2134,15 +2145,15 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestBackToBackNon32BAlignedPageS
         const distributed::ReplicatedBufferConfig buffer_config1{.size = 125000};
         auto bufa = distributed::MeshBuffer::create(buffer_config1, l1_config1, mesh_device.get());
         auto src_a = local_test_functions::generate_arange_vector(bufa->size());
-        distributed::WriteShard(
-            mesh_device->mesh_command_queue(), bufa, src_a, distributed::MeshCoordinate(0, 0), false);
+        mesh_device->mesh_command_queue().enqueue_write_shards(
+            bufa, {distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(src_a.data())}, false);
 
         distributed::DeviceLocalBufferConfig l1_config2{.page_size = 152, .buffer_type = buff_type, .bottom_up = false};
         const distributed::ReplicatedBufferConfig buffer_config2{.size = 152000};
         auto bufb = distributed::MeshBuffer::create(buffer_config2, l1_config2, mesh_device.get());
         auto src_b = local_test_functions::generate_arange_vector(bufb->size());
-        distributed::WriteShard(
-            mesh_device->mesh_command_queue(), bufb, src_b, distributed::MeshCoordinate(0, 0), false);
+        mesh_device->mesh_command_queue().enqueue_write_shards(
+            bufb, {distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(src_b.data())}, false);
 
         vector<uint32_t> result_a(bufa->size() / sizeof(uint32_t));
         distributed::ReadShard(
@@ -2289,8 +2300,8 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestNonblockingReads) {
         const distributed::ReplicatedBufferConfig buffer_config1{.size = 2048};
         auto bufa = distributed::MeshBuffer::create(buffer_config1, l1_config1, mesh_device.get());
         auto src_a = local_test_functions::generate_arange_vector(bufa->size());
-        distributed::WriteShard(
-            mesh_device->mesh_command_queue(), bufa, src_a, distributed::MeshCoordinate(0, 0), false);
+        mesh_device->mesh_command_queue().enqueue_write_shards(
+            bufa, {distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(src_a.data())}, false);
 
         distributed::DeviceLocalBufferConfig l1_config2{
             .page_size = 2048, .buffer_type = buff_type, .bottom_up = false};
@@ -2298,8 +2309,8 @@ TEST_F(UnitMeshCQSingleCardSharedBufferFixture, TestNonblockingReads) {
         auto bufb = distributed::MeshBuffer::create(buffer_config2, l1_config2, mesh_device.get());
 
         auto src_b = local_test_functions::generate_arange_vector(bufb->size());
-        distributed::WriteShard(
-            mesh_device->mesh_command_queue(), bufb, src_b, distributed::MeshCoordinate(0, 0), false);
+        mesh_device->mesh_command_queue().enqueue_write_shards(
+            bufb, {distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(src_b.data())}, false);
 
         vector<uint32_t> result_a(bufa->size() / sizeof(uint32_t));
         distributed::ReadShard(mesh_device->mesh_command_queue(), result_a, bufa, distributed::MeshCoordinate(0, 0));
@@ -2333,10 +2344,11 @@ TEST_F(UnitMeshCQSingleCardBufferFixture, EnqueueBufferVariousDims) {
             auto buf = distributed::MeshBuffer::create(buffer_config, local_config, mesh_device.get());
             auto src = local_test_functions::generate_arange_vector(buf->size());
 
-            EXPECT_NO_THROW(distributed::EnqueueWriteMeshBuffer(mesh_device->mesh_command_queue(), buf, src, false));
+            EXPECT_NO_THROW(mesh_device->mesh_command_queue().enqueue_write_mesh_buffer(buf, src.data(), false));
 
             std::vector<uint32_t> dst;
-            EXPECT_NO_THROW(distributed::EnqueueReadMeshBuffer(mesh_device->mesh_command_queue(), dst, buf, true));
+            dst.resize(buf->size() / sizeof(uint32_t));
+            EXPECT_NO_THROW(mesh_device->mesh_command_queue().enqueue_read_mesh_buffer(dst.data(), buf, true));
 
             EXPECT_EQ(src, dst);
         }

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_large_mesh_buffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_large_mesh_buffer.cpp
@@ -30,7 +30,6 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/api/tt-metalium/math.hpp"
 #include <enchantum/enchantum.hpp>
-
 namespace tt::tt_metal::distributed::test {
 namespace {
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_sub_device.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/allocator.hpp>
+#include <type_traits>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/sub_device.hpp>
@@ -28,7 +29,6 @@
 #include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
-
 namespace tt::tt_metal {
 
 TEST_F(UnitMeshCQSingleCardFixture, TensixTestSubDeviceAllocations) {
@@ -106,7 +106,7 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestSubDeviceAllocations) {
 
     auto buffer_1 = distributed::MeshBuffer::create(replicated_config_1, local_config_1, mesh_device.get());
     EXPECT_TRUE(buffer_1->address() <= max_addr - buffer_1->get_backing_buffer()->aligned_page_size());
-    distributed::EnqueueWriteMeshBuffer(mesh_device->mesh_command_queue(), buffer_1, input_1, false);
+    mesh_device->mesh_command_queue().enqueue_write_mesh_buffer(buffer_1, input_1.data(), false);
     std::vector<uint32_t> output_1;
     distributed::ReadShard(mesh_device->mesh_command_queue(), output_1, buffer_1, zero_coord_, true);
     EXPECT_EQ(input_1, output_1);
@@ -131,7 +131,7 @@ TEST_F(UnitMeshCQSingleCardFixture, TensixTestSubDeviceAllocations) {
 
     auto buffer_3 = distributed::MeshBuffer::create(replicated_config_2, local_config_2, mesh_device.get());
     EXPECT_TRUE(buffer_3->address() <= max_addr - buffer_3->get_backing_buffer()->aligned_page_size());
-    distributed::EnqueueWriteMeshBuffer(mesh_device->mesh_command_queue(), buffer_3, input_2, false);
+    mesh_device->mesh_command_queue().enqueue_write_mesh_buffer(buffer_3, input_2.data(), false);
     std::vector<uint32_t> output_2;
     distributed::ReadShard(mesh_device->mesh_command_queue(), output_2, buffer_3, zero_coord_, true);
     EXPECT_EQ(input_2, output_2);

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_EnqueueWaitForEvent.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt_stl/reflection.hpp>
+#include <type_traits>
 #include <chrono>
 #include <fmt/base.h>
 #include <cstdint>
@@ -26,7 +27,6 @@
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
 #include <umd/device/types/arch.hpp>
-
 namespace tt::tt_metal {
 
 using std::vector;
@@ -73,7 +73,8 @@ bool RunCrossCqReadWriteWithWaitForEvent(
                 distributed::MeshBuffer::create(global_buffer_config, device_local_config, mesh_device.get()));
             srcs.push_back(generate_arange_vector(buffers[i]->size(), wr_data_base));
 
-            distributed::WriteShard(cq_write, buffers[i], srcs[i], zero_coord, false);
+            cq_write.get().enqueue_write_shards(
+                buffers[i], {distributed::ShardDataTransfer{zero_coord}.host_data(srcs[i].data())}, false);
             auto event =
                 notify_host ? cq_write.get().enqueue_record_event_to_host() : cq_write.get().enqueue_record_event();
             cq_read.get().enqueue_wait_for_event(event);
@@ -110,7 +111,8 @@ bool RunBurstWritesThenSingleCrossCqEvent(
         buffers.push_back(
             distributed::MeshBuffer::create(global_buffer_config, device_local_config, mesh_device.get()));
         srcs.push_back(generate_arange_vector(buffers.back()->size(), buf_idx * 100));
-        distributed::WriteShard(cq_write, buffers.back(), srcs.back(), zero_coord, false);
+        cq_write.get().enqueue_write_shards(
+            buffers.back(), {distributed::ShardDataTransfer{zero_coord}.host_data(srcs.back().data())}, false);
     }
 
     auto event = cq_write.get().enqueue_record_event();
@@ -146,7 +148,8 @@ bool RunDeviceOnlyEventChainWithPerIterationValidation(
         auto& cq_read = cqs[(iter + 1) % 2];
 
         auto src = generate_arange_vector(buf_size, iter * 1000);
-        distributed::WriteShard(cq_write, buffer, src, zero_coord, false);
+        cq_write.get().enqueue_write_shards(
+            buffer, {distributed::ShardDataTransfer{zero_coord}.host_data(src.data())}, false);
         auto event = cq_write.get().enqueue_record_event();
         cq_read.get().enqueue_wait_for_event(event);
 
@@ -194,7 +197,8 @@ bool RunHeavyBurstWritesThenDeviceOnlyEvent(
         buffers.push_back(
             distributed::MeshBuffer::create(global_buffer_config, device_local_config, mesh_device.get()));
         srcs.push_back(generate_arange_vector(buffers.back()->size(), buf_idx * 10000));
-        distributed::WriteShard(cq_write, buffers.back(), srcs.back(), zero_coord, false);
+        cq_write.get().enqueue_write_shards(
+            buffers.back(), {distributed::ShardDataTransfer{zero_coord}.host_data(srcs.back().data())}, false);
     }
 
     auto event = cq_write.get().enqueue_record_event();
@@ -407,7 +411,10 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
                 srcs.push_back(generate_arange_vector(buffers[i]->size(), wr_data_base));
                 log_debug(tt::LogTest, "buf_idx: {} Doing Write to cq_id: {} of data: {}", buf_idx, i, srcs[i]);
 
-                distributed::WriteShard(cqs[i], buffers[i], srcs[i], distributed::MeshCoordinate(0, 0), false);
+                cqs[i].get().enqueue_write_shards(
+                    buffers[i],
+                    {distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(srcs[i].data())},
+                    false);
                 auto event = sync_events[i].emplace_back(cqs[i].get().enqueue_record_event());
             }
 
@@ -415,7 +422,8 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
                 auto event = sync_events[i][buf_idx];
                 cqs[i].get().enqueue_wait_for_event(event);
                 vector<uint32_t> result;
-                distributed::ReadShard(cqs[i], result, buffers[i], zero_coord_, true);  // Blocking.
+                distributed::ReadShard(cqs[i], result, buffers[i], zero_coord_, true);
+                // Blocking.
                 bool local_pass = (srcs[i] == result);
                 log_debug(
                     tt::LogTest,
@@ -582,7 +590,10 @@ TEST_F(UnitMeshMultiCQMultiDeviceEventFixture, TestEventsReadWriteWithWaitForEve
                         cq_write.get().id(),
                         write_data.back());
 
-                    distributed::WriteShard(cq_write, buffers.back(), write_data.back(), zero_coord_, false);
+                    cq_write.get().enqueue_write_shards(
+                        buffers.back(),
+                        {distributed::ShardDataTransfer{zero_coord_}.host_data(write_data.back().data())},
+                        false);
                     if (use_events) {
                         distributed::MeshEvent event_sync_read_after_write = cq_write.get().enqueue_record_event();
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_event/test_events.cpp
@@ -3,10 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <chrono>
+#include <type_traits>
 #include <fmt/base.h>
 #include <cstddef>
 #include <cstdint>
 #include <tt-metalium/host_api.hpp>
+#include "tt_metal/distributed/event_query_impl.hpp"
 #include <memory>
 #include <vector>
 
@@ -22,7 +24,6 @@
 #include <tt-logger/tt-logger.hpp>
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/impl/dispatch/kernels/cq_commands.hpp"
-
 namespace tt::tt_metal {
 
 using std::vector;
@@ -73,7 +74,10 @@ TEST_F(UnitMeshCQEventFixture, TestEventsDataMovementWrittenToCompletionQueueInO
             buffers.push_back(distributed::MeshBuffer::create(buffer_config, local_config, mesh_device.get()));
 
             if (data_movement_mode == DataMovementMode::WRITE) {
-                distributed::WriteShard(cq, buffers.back(), page, distributed::MeshCoordinate(0, 0), true);
+                cq.enqueue_write_shards(
+                    buffers.back(),
+                    {distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(page.data())},
+                    true);
             } else if (data_movement_mode == DataMovementMode::READ) {
                 distributed::ReadShard(cq, page, buffers.back(), distributed::MeshCoordinate(0, 0), true);
             }
@@ -266,7 +270,8 @@ TEST_F(UnitMeshCQEventFixture, TestEventsMixedWriteBufferRecordWaitSynchronize) 
         distributed::ReplicatedBufferConfig buffer_config{.size = page_size};
         std::shared_ptr<distributed::MeshBuffer> buf =
             distributed::MeshBuffer::create(buffer_config, local_config, mesh_device.get());
-        distributed::WriteShard(cq, buf, page, distributed::MeshCoordinate(0, 0), true);
+        cq.enqueue_write_shards(
+            buf, {distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(page.data())}, true);
         cq.enqueue_wait_for_event(*event);
 
         if (i % 10 == 0) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_EnqueueProgram.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <algorithm>
+#include <type_traits>
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
@@ -34,6 +35,7 @@
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/hal_types.hpp>
 #include <tt-metalium/host_api.hpp>
+#include <distributed/mesh_workload_impl.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/runtime_args_data.hpp>
 #include "impl/buffers/semaphore.hpp"
@@ -57,7 +59,6 @@
 // Access to internal API: ProgramImpl::get_cb_base_addr, get_kernel
 #include "impl/program/program_impl.hpp"
 #include "impl/kernels/kernel.hpp"
-
 namespace tt::tt_metal {
 
 using std::vector;
@@ -204,7 +205,7 @@ bool cb_config_successful(
             tt::tt_metal::detail::ReadFromDeviceL1(
                 device,
                 core_coord,
-                workload.get_cb_base_addr(mesh_device, core_coord, CoreType::WORKER),
+                workload.impl().get_cb_base_addr(mesh_device, core_coord, CoreType::WORKER),
                 cb_config_buffer_size,
                 cb_config_vector);
 
@@ -365,7 +366,7 @@ bool test_dummy_EnqueueProgram_with_sems(
             uint32_t expected_semaphore_vals_for_core_idx = 0;
             const uint32_t semaphore_buffer_size =
                 program_config.num_sems * MetalContext::instance().hal().get_alignment(HalMemType::L1);
-            uint32_t semaphore_base = workload.get_sem_base_addr(mesh_device, core_coord, CoreType::WORKER);
+            uint32_t semaphore_base = workload.impl().get_sem_base_addr(mesh_device, core_coord, CoreType::WORKER);
             tt::tt_metal::detail::ReadFromDeviceL1(
                 device, core_coord, semaphore_base, semaphore_buffer_size, semaphore_vals);
             for (uint32_t i = 0; i < semaphore_vals.size();
@@ -933,11 +934,11 @@ void test_basic_dispatch_functions(const std::shared_ptr<distributed::MeshDevice
 
             std::vector<uint32_t> dst_data;
             if (i & 1) {
-                distributed::EnqueueWriteMeshBuffer(cq, buffer, src_data_1, false);
+                cq.enqueue_write_mesh_buffer(buffer, src_data_1.data(), false);
                 distributed::ReadShard(cq, dst_data, buffer, distributed::MeshCoordinate{0, 0}, true);
                 EXPECT_EQ(src_data_1, dst_data);
             } else {
-                distributed::EnqueueWriteMeshBuffer(cq, dram_buffer, src_data_2, false);
+                cq.enqueue_write_mesh_buffer(dram_buffer, src_data_2.data(), false);
                 distributed::ReadShard(cq, dst_data, dram_buffer, distributed::MeshCoordinate{0, 0}, true);
                 EXPECT_EQ(src_data_2, dst_data);
             }
@@ -947,7 +948,7 @@ void test_basic_dispatch_functions(const std::shared_ptr<distributed::MeshDevice
     // non blocking fast data movement APIs
     for (int iteration = 0; iteration < k_Iterations; ++iteration) {
         for (int i = 0; i < k_LoopPerDev; ++i) {
-            distributed::EnqueueWriteMeshBuffer(cq, buffer, src_data_1, false);
+            cq.enqueue_write_mesh_buffer(buffer, src_data_1.data(), false);
         }
     }
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
@@ -18,6 +18,7 @@
 #include <tt-metalium/device.hpp>
 #include "mesh_dispatch_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
+#include <distributed/mesh_workload_impl.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
@@ -190,7 +191,7 @@ TEST_F(MeshDispatchFixture, TensixProgramClearsStaleRemoteCircularBufferConfig) 
     this->RunProgram(mesh_device, sparse_workload);
 
     const uint32_t remote_config_address =
-        sparse_workload.get_cb_base_addr(mesh_device, idle_core, CoreType::WORKER) +
+        sparse_workload.impl().get_cb_base_addr(mesh_device, idle_core, CoreType::WORKER) +
         sparse_program_in_workload.impl().get_program_config(programmable_core_index).local_cb_size;
     std::vector<uint32_t> remote_config;
     detail::ReadFromDeviceL1(

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_sub_device.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstddef>
+#include <type_traits>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/device.hpp>
@@ -43,10 +44,8 @@
 #include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <tt-metalium/distributed.hpp>
-
 // Access to internal API: ProgramImpl::validate_circular_buffer_region
 #include "tt_metal/impl/program/program_impl.hpp"
-
 namespace tt::tt_metal {
 
 constexpr uint32_t k_local_l1_size = 3200;
@@ -154,7 +153,7 @@ void test_sub_device_synchronization(distributed::MeshDevice* device) {
     distributed::Synchronize(*device, std::nullopt);
 
     // Test blocking write buffer doesn't stall
-    distributed::EnqueueWriteMeshBuffer(device->mesh_command_queue(), buffer_1, input_1, true);
+    device->mesh_command_queue().enqueue_write_mesh_buffer(buffer_1, input_1.data(), true);
 
     // Test record event won't cause a stall
 

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_telemetry.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_util/test_dispatch_telemetry.cpp
@@ -36,7 +36,6 @@
 #include "impl/dispatch/dispatch_query_manager.hpp"
 #include "distributed/mesh_trace.hpp"
 #include "llrt/core_descriptor.hpp"
-
 namespace tt::tt_metal {
 namespace {
 

--- a/tests/tt_metal/tt_metal/dispatch/test_service_core_manager.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/test_service_core_manager.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <type_traits>
 
 #include <chrono>
 #include <cstdint>
@@ -31,7 +32,6 @@
 #include "llrt/llrt.hpp"
 #include "llrt/tt_cluster.hpp"
 #include "mesh_dispatch_fixture.hpp"
-
 namespace tt::tt_metal::distributed::test {
 
 static void assert_counter_incrementing(const std::function<uint32_t()>& read_fn, const std::string& label) {
@@ -254,7 +254,7 @@ TEST_F(ServiceCoreSdFixture, PersistentServiceMultiCycle) {
         auto fd_buf = MeshBuffer::create(fd_l1_global, fd_l1_config, mesh_device.get());
         std::vector<uint32_t> fd_src_vec(num_tiles * single_tile_size / sizeof(uint32_t));
         std::iota(fd_src_vec.begin(), fd_src_vec.end(), 100);
-        EnqueueWriteMeshBuffer(mesh_device->mesh_command_queue(), fd_buf, fd_src_vec);
+        mesh_device->mesh_command_queue().enqueue_write_mesh_buffer(fd_buf, fd_src_vec.data(), false);
         Finish(mesh_device->mesh_command_queue());
 
         for (const auto& coord : MeshCoordinateRange(mesh_device->shape())) {

--- a/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_basic_eth.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <fmt/base.h>
+#include <type_traits>
 #include <gtest/gtest.h>
 #include <cstddef>
 #include <umd/device/types/core_coordinates.hpp>
@@ -35,7 +36,6 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <umd/device/types/arch.hpp>
 #include "eth_test_common.hpp"
-
 using namespace tt;
 using namespace tt::tt_metal;
 using namespace tt::test_utils;
@@ -290,7 +290,8 @@ bool noc_reader_and_writer_kernels(
         });
 
     auto reader_inputs = generate_uniform_random_vector<uint32_t>(0, 100, byte_size / sizeof(uint32_t));
-    distributed::WriteShard(cq, reader_dram_buffer, reader_inputs, zero_coord);
+    cq.enqueue_write_shards(
+        reader_dram_buffer, {distributed::ShardDataTransfer{zero_coord}.host_data(reader_inputs.data())}, false);
 
     auto writer_inputs = generate_uniform_random_vector<uint32_t>(0, 100, byte_size / sizeof(uint32_t));
     tt::tt_metal::MetalContext::instance().get_cluster().write_core(
@@ -300,7 +301,8 @@ bool noc_reader_and_writer_kernels(
     std::vector<uint32_t> all_zeros(byte_size / sizeof(uint32_t), 0);
     tt::tt_metal::MetalContext::instance().get_cluster().write_core(
         device->id(), eth_noc_xy, all_zeros, eth_dst_l1_address);
-    distributed::WriteShard(cq, writer_dram_buffer, all_zeros, zero_coord);
+    cq.enqueue_write_shards(
+        writer_dram_buffer, {distributed::ShardDataTransfer{zero_coord}.host_data(all_zeros.data())}, false);
 
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);

--- a/tests/tt_metal/tt_metal/integration/test_basic_pipeline.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_basic_pipeline.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <chrono>
+#include <type_traits>
 #include <fmt/base.h>
 //////////////////////////////////////////////////////////////////////////////////////////
 // Tests data movement between N cores with proper use of semaphores for sync
@@ -38,7 +39,6 @@
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <umd/device/types/arch.hpp>
 #include <tt-metalium/distributed.hpp>
-
 namespace tt::tt_metal {
 
 using std::map;
@@ -244,7 +244,7 @@ void create_and_run_row_pipeline(
         create_random_vector_of_bfloat16(buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
 
     log_info(LogTest, "Writing to device buffer->..");
-    distributed::EnqueueWriteMeshBuffer(cq, src_buffer, src_vec);
+    cq.enqueue_write_mesh_buffer(src_buffer, src_vec.data(), false);
     log_info(LogTest, "Writing to device buffer Done.");
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     distributed::Finish(cq);

--- a/tests/tt_metal/tt_metal/integration/test_flatten.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_flatten.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <chrono>
+#include <type_traits>
 #include <fmt/base.h>
 #include <gtest/gtest.h>
 #include <cstdint>
@@ -30,7 +31,6 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "impl/data_format/bfloat16_utils.hpp"
-
 namespace tt::tt_metal {
 
 using std::vector;
@@ -285,7 +285,7 @@ bool flatten_stress(
         SetRuntimeArgs(program_on_workload, unary_writer_kernel, core, writer_runtime_args);
 
         // Async write input
-        distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, *src_vec, false);
+        cq.enqueue_write_mesh_buffer(src_dram_buffer, src_vec->data(), false);
         // Share ownership of buffer with program
         AssignGlobalBufferToProgram(
             std::shared_ptr<Buffer>(src_dram_buffer->get_backing_buffer()), program_on_workload);

--- a/tests/tt_metal/tt_metal/integration/test_sfpu_compute.cpp
+++ b/tests/tt_metal/tt_metal/integration/test_sfpu_compute.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <chrono>
+#include <type_traits>
 #include <fmt/base.h>
 #include <gtest/gtest.h>
 #include <cstddef>
@@ -37,7 +38,6 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <umd/device/types/arch.hpp>
 #include <tt-metalium/distributed.hpp>
-
 namespace tt::tt_metal {
 
 using std::map;
@@ -246,7 +246,8 @@ bool run_sfpu_all_same_buffer(distributed::MeshCommandQueue& cq, const SfpuConfi
 
     mesh_workload.add_program(device_range, std::move(program));
 
-    distributed::WriteShard(cq, input_dram_buffer, packed_input, local_coord);
+    cq.enqueue_write_shards(
+        input_dram_buffer, {distributed::ShardDataTransfer{local_coord}.host_data(packed_input.data())}, false);
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     distributed::Finish(cq);
 

--- a/tests/tt_metal/tt_metal/integration/vecadd/test_vecadd_multi_core.cpp
+++ b/tests/tt_metal/tt_metal/integration/vecadd/test_vecadd_multi_core.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <fmt/base.h>
+#include <type_traits>
 #include <gtest/gtest.h>
 #include <cstddef>
 #include <tt-metalium/bfloat16.hpp>
@@ -30,7 +31,6 @@
 #include <tt_stl/span.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include "tt_metal/test_utils/comparison.hpp"
-
 namespace tt::tt_metal {
 
 using namespace tt;
@@ -139,8 +139,8 @@ bool vecadd_multi_core(
         SetRuntimeArgs(program, compute, core, {tiles_per_core, i});
     }
 
-    distributed::WriteShard(cq, a, a_data, zero_coord);
-    distributed::WriteShard(cq, b, b_data, zero_coord);
+    cq.enqueue_write_shards(a, {distributed::ShardDataTransfer{zero_coord}.host_data(a_data.data())}, false);
+    cq.enqueue_write_shards(b, {distributed::ShardDataTransfer{zero_coord}.host_data(b_data.data())}, false);
     // Enqueue the program
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);

--- a/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt_stl/reflection.hpp>
+#include <type_traits>
 #include <chrono>
 #include <fmt/base.h>
 #include <gtest/gtest.h>
@@ -37,7 +38,6 @@
 #include "tt_metal/test_utils/df/float32.hpp"
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
-
 namespace tt::tt_metal {
 class IDevice;
 }  // namespace tt::tt_metal
@@ -483,8 +483,10 @@ void run_single_core_broadcast(
     auto tilized_input0 = ::unit_tests::compute::gold_standard_tilize(packed_input0, config);
     auto tilized_input1 = ::unit_tests::compute::gold_standard_tilize(packed_input1, config);
 
-    distributed::WriteShard(cq, src_a_dram_buffer, tilized_input0, zero_coord);
-    distributed::WriteShard(cq, src_b_dram_buffer, tilized_input1, zero_coord);
+    cq.enqueue_write_shards(
+        src_a_dram_buffer, {distributed::ShardDataTransfer{zero_coord}.host_data(tilized_input0.data())}, false);
+    cq.enqueue_write_shards(
+        src_b_dram_buffer, {distributed::ShardDataTransfer{zero_coord}.host_data(tilized_input1.data())}, false);
 
     distributed::EnqueueMeshWorkload(cq, workload, is_quasar);
     distributed::Finish(cq);
@@ -757,8 +759,10 @@ void run_sub_bcast_col_custom(
     auto tilized_input0 = ::unit_tests::compute::gold_standard_tilize(packed_input0, grid_config);
     auto tilized_input1 = ::unit_tests::compute::gold_standard_tilize(packed_input1, bcast_config);
 
-    distributed::WriteShard(cq, src_a_dram_buffer, tilized_input0, zero_coord);
-    distributed::WriteShard(cq, src_b_dram_buffer, tilized_input1, zero_coord);
+    cq.enqueue_write_shards(
+        src_a_dram_buffer, {distributed::ShardDataTransfer{zero_coord}.host_data(tilized_input0.data())}, false);
+    cq.enqueue_write_shards(
+        src_b_dram_buffer, {distributed::ShardDataTransfer{zero_coord}.host_data(tilized_input1.data())}, false);
 
     distributed::EnqueueMeshWorkload(cq, workload, is_quasar);
     distributed::Finish(cq);

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <fmt/base.h>
+#include <type_traits>
 #include <gtest/gtest.h>
 #include <cstdint>
 #include <sys/types.h>
@@ -30,7 +31,6 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <umd/device/types/arch.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
-
 namespace tt::tt_metal {
 class IDevice;
 }  // namespace tt::tt_metal
@@ -224,7 +224,8 @@ void run_single_core_copy_block_matmul_partials(
     auto& program_run = workload.get_programs().at(device_range);
 
     std::vector<uint32_t> src_vec = generate_copy_block_stimulus(dram_buffer_size, test_config);
-    distributed::WriteShard(cq, src_dram_buffer, src_vec, zero_coord);
+    cq.enqueue_write_shards(
+        src_dram_buffer, {distributed::ShardDataTransfer{zero_coord}.host_data(src_vec.data())}, false);
 
     experimental::ProgramRunArgs params;
     params.kernel_run_args = {

--- a/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <type_traits>
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
@@ -39,7 +40,6 @@
 #include <umd/device/types/arch.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
-
 namespace tt::tt_metal {
 class IDevice;
 }  // namespace tt::tt_metal
@@ -535,12 +535,12 @@ bool single_core_unpack_reconfig_quasar(const std::shared_ptr<distributed::MeshD
     auto src4 = create_random_vector_of_bfloat16(f16_tile_size, kRandMax, /*seed=*/0x1005);
     auto src5 = create_random_vector_of_bfloat16(f16_tile_size, kRandMax, /*seed=*/0x1006);
 
-    distributed::WriteShard(cq, inp0_dram, src0, zero_coord, false);
-    distributed::WriteShard(cq, inp1_dram, src1, zero_coord, false);
-    distributed::WriteShard(cq, inp2_dram, src2, zero_coord, false);
-    distributed::WriteShard(cq, inp3_dram, src3, zero_coord, false);
-    distributed::WriteShard(cq, inp4_dram, src4, zero_coord, false);
-    distributed::WriteShard(cq, inp5_dram, src5, zero_coord, false);
+    cq.enqueue_write_shards(inp0_dram, {distributed::ShardDataTransfer{zero_coord}.host_data(src0.data())}, false);
+    cq.enqueue_write_shards(inp1_dram, {distributed::ShardDataTransfer{zero_coord}.host_data(src1.data())}, false);
+    cq.enqueue_write_shards(inp2_dram, {distributed::ShardDataTransfer{zero_coord}.host_data(src2.data())}, false);
+    cq.enqueue_write_shards(inp3_dram, {distributed::ShardDataTransfer{zero_coord}.host_data(src3.data())}, false);
+    cq.enqueue_write_shards(inp4_dram, {distributed::ShardDataTransfer{zero_coord}.host_data(src4.data())}, false);
+    cq.enqueue_write_shards(inp5_dram, {distributed::ShardDataTransfer{zero_coord}.host_data(src5.data())}, false);
 
     auto in0 = unpack_uint32_vec_into_bfloat16_vec(src0);
     auto in1 = unpack_uint32_vec_into_bfloat16_vec(src1);
@@ -872,12 +872,12 @@ bool single_core_pack_reconfig_quasar(const std::shared_ptr<distributed::MeshDev
     auto src4 = create_random_vector_of_bfloat16(f16_tile_size, kRandMax, /*seed=*/0x2005);
     auto src5 = create_random_vector_of_bfloat16(f16_tile_size, kRandMax, /*seed=*/0x2006);
 
-    distributed::WriteShard(cq, inp0_dram, src0, zero_coord, false);
-    distributed::WriteShard(cq, inp1_dram, src1, zero_coord, false);
-    distributed::WriteShard(cq, inp2_dram, src2, zero_coord, false);
-    distributed::WriteShard(cq, inp3_dram, src3, zero_coord, false);
-    distributed::WriteShard(cq, inp4_dram, src4, zero_coord, false);
-    distributed::WriteShard(cq, inp5_dram, src5, zero_coord, false);
+    cq.enqueue_write_shards(inp0_dram, {distributed::ShardDataTransfer{zero_coord}.host_data(src0.data())}, false);
+    cq.enqueue_write_shards(inp1_dram, {distributed::ShardDataTransfer{zero_coord}.host_data(src1.data())}, false);
+    cq.enqueue_write_shards(inp2_dram, {distributed::ShardDataTransfer{zero_coord}.host_data(src2.data())}, false);
+    cq.enqueue_write_shards(inp3_dram, {distributed::ShardDataTransfer{zero_coord}.host_data(src3.data())}, false);
+    cq.enqueue_write_shards(inp4_dram, {distributed::ShardDataTransfer{zero_coord}.host_data(src4.data())}, false);
+    cq.enqueue_write_shards(inp5_dram, {distributed::ShardDataTransfer{zero_coord}.host_data(src5.data())}, false);
 
     auto in0 = unpack_uint32_vec_into_bfloat16_vec(src0);
     auto in1 = unpack_uint32_vec_into_bfloat16_vec(src1);

--- a/tests/tt_metal/tt_metal/llk/test_sfpu_binary_bcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_sfpu_binary_bcast.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <fmt/base.h>
+#include <type_traits>
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -31,7 +32,6 @@
 
 #include "device_fixture.hpp"
 #include "test_golden_impls.hpp"
-
 namespace tt::tt_metal {
 
 namespace unit_tests::compute::sfpu_binary_bcast {
@@ -265,8 +265,10 @@ bool run_sfpu_binary_bcast(const std::shared_ptr<distributed::MeshDevice>& mesh_
     auto src_b_tiled = ::unit_tests::compute::gold_standard_tilize(to_tile_input(src_b_rm), gc);
     auto golden_tiled = ::unit_tests::compute::gold_standard_tilize(to_tile_input(golden_rm), gc);
 
-    distributed::WriteShard(cq, src_data_buffer, src_a_tiled, zero_coord);
-    distributed::WriteShard(cq, src_bcast_buffer, src_b_tiled, zero_coord);
+    cq.enqueue_write_shards(
+        src_data_buffer, {distributed::ShardDataTransfer{zero_coord}.host_data(src_a_tiled.data())}, false);
+    cq.enqueue_write_shards(
+        src_bcast_buffer, {distributed::ShardDataTransfer{zero_coord}.host_data(src_b_tiled.data())}, false);
 
     tt_metal::SetRuntimeArgs(
         program_,
@@ -294,7 +296,6 @@ bool run_sfpu_binary_bcast(const std::shared_ptr<distributed::MeshDevice>& mesh_
 
     std::vector<uint32_t> device_tiled;
     distributed::ReadShard(cq, device_tiled, dst_buffer, zero_coord);
-
     if (device_tiled.size() != golden_tiled.size()) {
         log_error(tt::LogTest, "Size mismatch: device={} golden={}", device_tiled.size(), golden_tiled.size());
         return false;

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt_stl/reflection.hpp>
+#include <type_traits>
 #include <fmt/base.h>
 #include <gtest/gtest.h>
 #include <cstddef>
@@ -39,7 +40,6 @@
 #include <umd/device/types/arch.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/distributed.hpp>
-
 namespace tt::tt_metal {
 class IDevice;
 }  // namespace tt::tt_metal
@@ -338,9 +338,12 @@ static BinaryBuffers create_and_populate_binary_buffers(
     buffers.input2 = distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
     buffers.output = distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());
 
-    distributed::WriteShard(cq, buffers.input0, stimulus.packed_input0, zero_coord, false);
-    distributed::WriteShard(cq, buffers.input1, stimulus.packed_input1, zero_coord, false);
-    distributed::WriteShard(cq, buffers.input2, stimulus.packed_input2, zero_coord, false);
+    cq.enqueue_write_shards(
+        buffers.input0, {distributed::ShardDataTransfer{zero_coord}.host_data(stimulus.packed_input0.data())}, false);
+    cq.enqueue_write_shards(
+        buffers.input1, {distributed::ShardDataTransfer{zero_coord}.host_data(stimulus.packed_input1.data())}, false);
+    cq.enqueue_write_shards(
+        buffers.input2, {distributed::ShardDataTransfer{zero_coord}.host_data(stimulus.packed_input2.data())}, false);
 
     return buffers;
 }

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_int8.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_int8.cpp
@@ -33,7 +33,6 @@
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
-
 namespace tt::tt_metal {
 
 using namespace tt;
@@ -181,9 +180,9 @@ bool single_tile_matmul_int8(const std::shared_ptr<distributed::MeshDevice>& mes
     ////////////////////////////////////////////////////////////////////////////
 
     convert_to_sign_mag(input_0);
-    distributed::EnqueueWriteMeshBuffer(cq, input0_dram_buffer, input_0);
+    cq.enqueue_write_mesh_buffer(input0_dram_buffer, input_0.data(), false);
     convert_to_sign_mag(input_1);
-    distributed::EnqueueWriteMeshBuffer(cq, input1_dram_buffer, input_1);
+    cq.enqueue_write_mesh_buffer(input1_dram_buffer, input_1.data(), false);
 
     tt_metal::SetRuntimeArgs(
         program,
@@ -213,7 +212,9 @@ bool single_tile_matmul_int8(const std::shared_ptr<distributed::MeshDevice>& mes
     //                      Comparison Checking
     ////////////////////////////////////////////////////////////////////////////
     std::vector<int8_t> dest_buffer_data;
-    distributed::EnqueueReadMeshBuffer(cq, dest_buffer_data, output_dram_buffer);
+    (dest_buffer_data)
+        .resize((output_dram_buffer)->size() / sizeof(typename std::decay_t<decltype(dest_buffer_data)>::value_type));
+    cq.enqueue_read_mesh_buffer((dest_buffer_data).data(), output_dram_buffer, true);
     pass = dest_buffer_data == golden_output;
 
     for (int i = 0; i < 1024; i++) {

--- a/tests/tt_metal/tt_metal/llk/test_stochastic_rounding.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_stochastic_rounding.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <bit>
+#include <type_traits>
 #include <cmath>
 #include <gtest/gtest.h>
 #include <map>
@@ -21,7 +22,6 @@
 #include <tt-logger/tt-logger.hpp>
 #include "tt_metal/test_utils/packing.hpp"
 #include <umd/device/types/arch.hpp>
-
 namespace tt::tt_metal {
 
 using namespace tt::test_utils;
@@ -174,7 +174,7 @@ StochasticRoundingResult run_stochastic_rounding(
 
     mesh_workload.add_program(distributed::MeshCoordinateRange(cq.device()->shape()), std::move(program));
 
-    distributed::EnqueueWriteMeshBuffer(cq, input_dram_buffer, packed_input, false);
+    cq.enqueue_write_mesh_buffer(input_dram_buffer, packed_input.data(), false);
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     distributed::Finish(cq);
 

--- a/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
@@ -48,7 +48,6 @@
 #include <tt-metalium/tensor/mesh_tensor.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/buffer.hpp>
-
 namespace tt::tt_metal {
 class IDevice;
 }  // namespace tt::tt_metal
@@ -548,14 +547,14 @@ void run_single_core_unary_broadcast(
     std::vector<uint32_t> golden_packed_tilized_output;
     get_packed_tilized_input_output_pair(
         in_t, out_t, num_tiles, test_config.broadcast_dim, packed_tilized_input, golden_packed_tilized_output);
-    distributed::WriteShard(cq, src_dram_buffer, packed_tilized_input, zero_coord);
+    cq.enqueue_write_shards(
+        src_dram_buffer, {distributed::ShardDataTransfer{zero_coord}.host_data(packed_tilized_input.data())}, false);
 
     distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
     distributed::Finish(cq);
 
     std::vector<uint32_t> dest_buffer_data;
     distributed::ReadShard(cq, dest_buffer_data, dst_dram_buffer, zero_coord);
-
     ASSERT_TRUE(check_is_close(golden_packed_tilized_output, dest_buffer_data, out_t, "unary_broadcast_dram_out"));
 }
 }  // namespace unit_tests::compute::unary_broadcast

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
@@ -54,7 +54,6 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"
-
 using std::vector;
 using namespace tt;
 using std::chrono::microseconds;
@@ -628,7 +627,7 @@ std::shared_ptr<tt_metal::distributed::MeshBuffer> create_and_transfer_data_shar
     } else {
         input_buffer = tt_metal::distributed::MeshBuffer::create(global_buf, device_local_config, device);
     }
-    tt_metal::distributed::EnqueueWriteMeshBuffer(device->mesh_command_queue(), input_buffer, input_vec, false);
+    device->mesh_command_queue().enqueue_write_mesh_buffer(input_buffer, input_vec.data(), false);
     tt_metal::distributed::Finish(device->mesh_command_queue());
 
     log_info(tt::LogTest, "created sharded tensor");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
@@ -55,7 +55,6 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"
-
 using std::vector;
 using namespace tt;
 using std::chrono::microseconds;
@@ -600,7 +599,7 @@ std::shared_ptr<tt_metal::distributed::MeshBuffer> create_and_transfer_data_shar
     } else {
         input_buffer = tt_metal::distributed::MeshBuffer::create(global_buf, device_local_config, device);
     }
-    tt_metal::distributed::EnqueueWriteMeshBuffer(device->mesh_command_queue(), input_buffer, input_vec, false);
+    device->mesh_command_queue().enqueue_write_mesh_buffer(input_buffer, input_vec.data(), false);
     tt_metal::distributed::Finish(device->mesh_command_queue());
 
     log_info(tt::LogTest, "created sharded tensor");

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/test_compute_mm.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt_stl/reflection.hpp>
+#include <type_traits>
 #include <chrono>
 #include <cerrno>
 #include <fmt/base.h>
@@ -56,7 +57,6 @@
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
 #include <umd/device/types/arch.hpp>
-
 using std::vector;
 using namespace tt;
 ////////////////////////////////////////////////////////////////////////////////
@@ -1664,7 +1664,7 @@ std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> create_and_transfer_data_
 
     // Write data to the mesh buffer
     auto& mesh_cq = device->mesh_command_queue();
-    tt::tt_metal::distributed::EnqueueWriteMeshBuffer(mesh_cq, input_buffer, activations, true);
+    mesh_cq.enqueue_write_mesh_buffer(input_buffer, activations.data(), true);
 
     return input_buffer;
 }
@@ -1695,7 +1695,7 @@ std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> create_and_transfer_data_
 
     // Write data to the mesh buffer
     auto& mesh_cq = device->mesh_command_queue();
-    tt::tt_metal::distributed::EnqueueWriteMeshBuffer(mesh_cq, input_buffer, activations, true);
+    mesh_cq.enqueue_write_mesh_buffer(input_buffer, activations.data(), true);
 
     return input_buffer;
 }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/3_pcie_transfer/test_rw_buffer.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <chrono>
+#include <type_traits>
 #include <cerrno>
 #include <fmt/base.h>
 #include <cstdint>
@@ -29,7 +30,6 @@
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
-
 using namespace tt;
 using namespace tt::tt_metal;
 using std::chrono::duration_cast;
@@ -37,8 +37,8 @@ using std::chrono::microseconds;
 
 ////////////////////////////////////////////////////////////////////////////////
 // This test measures the bandwidth of host-to-device data transfer and
-// device-to-host data transfer. It uses EnqueueReadMeshBuffer and
-// EnqueueWriteMeshBuffer APIs to transfer the data. The device memory object
+// device-to-host data transfer. It uses enqueue_read_mesh_buffer and
+// enqueue_write_mesh_buffer APIs to transfer the data. The device memory object
 // (buffer) can be resident in DRAM or L1.
 //
 // Usage example:
@@ -145,7 +145,7 @@ int main(int argc, char** argv) {
             // Execute application
             if (!skip_write) {
                 auto t_begin = std::chrono::steady_clock::now();
-                tt_metal::distributed::EnqueueWriteMeshBuffer(device->mesh_command_queue(), buffer, src_vec, false);
+                device->mesh_command_queue().enqueue_write_mesh_buffer(buffer, src_vec.data(), false);
                 tt_metal::distributed::Finish(device->mesh_command_queue());
                 auto t_end = std::chrono::steady_clock::now();
                 auto elapsed_us = duration_cast<microseconds>(t_end - t_begin).count();
@@ -154,7 +154,7 @@ int main(int argc, char** argv) {
                 best_write_bw = std::fmax(best_write_bw, write_bw);
                 log_info(
                     LogTest,
-                    "EnqueueWriteMeshBuffer to {} (H2D): {:.3f}ms, {:.3f}GB/s",
+                    "enqueue_write_mesh_buffer to {} (H2D): {:.3f}ms, {:.3f}GB/s",
                     buffer_type == 0 ? "DRAM" : "L1",
                     elapsed_us / 1000.0,
                     h2d_bandwidth[i]);
@@ -175,7 +175,7 @@ int main(int argc, char** argv) {
                 best_read_bw = std::fmax(best_read_bw, read_bw);
                 log_info(
                     LogTest,
-                    "EnqueueReadMeshBuffer from {} (D2H): {:.3f}ms, {:.3f}GB/s",
+                    "enqueue_read_mesh_buffer from {} (D2H): {:.3f}ms, {:.3f}GB/s",
                     buffer_type == 0 ? "DRAM" : "L1",
                     elapsed_us / 1000.0,
                     d2h_bandwidth[i]);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/6_dram_offchip/test_dram_offchip.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <chrono>
+#include <type_traits>
 #include <cerrno>
 #include <fmt/base.h>
 #include <cstdlib>
@@ -45,7 +46,6 @@
 #include <umd/device/types/arch.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
-
 using namespace tt;
 using std::chrono::duration_cast;
 using std::chrono::microseconds;
@@ -243,7 +243,7 @@ int main(int argc, char** argv) {
         //                      Copy Input To DRAM or L1
         ////////////////////////////////////////////////////////////////////////////
         if (access_type == 0) {
-            tt_metal::distributed::EnqueueWriteMeshBuffer(device->mesh_command_queue(), input_buffer, input_vec, false);
+            device->mesh_command_queue().enqueue_write_mesh_buffer(input_buffer, input_vec.data(), false);
             tt_metal::distributed::Finish(device->mesh_command_queue());
         } else {
             uint64_t input_offset = 0;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/8_dram_adjacent_core_read/test_dram_read.cpp
@@ -45,7 +45,6 @@
 #include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/distributed.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"
-
 using namespace tt;
 using std::chrono::duration_cast;
 using std::chrono::microseconds;
@@ -492,7 +491,7 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Copy Input To DRAM or L1
         ////////////////////////////////////////////////////////////////////////////
-        tt_metal::distributed::EnqueueWriteMeshBuffer(device->mesh_command_queue(), input_buffer, input_vec, false);
+        device->mesh_command_queue().enqueue_write_mesh_buffer(input_buffer, input_vec.data(), false);
         tt_metal::distributed::Finish(device->mesh_command_queue());
 
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/9_dram_adjacent_read_remote_l1_write/test_dram_read_l1_write.cpp
@@ -46,7 +46,6 @@
 #include <umd/device/types/xy_pair.hpp>
 #include <tt-metalium/distributed.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"
-
 using namespace tt;
 using std::chrono::duration_cast;
 using std::chrono::microseconds;
@@ -618,7 +617,7 @@ int main(int argc, char** argv) {
         ////////////////////////////////////////////////////////////////////////////
         //                      Copy Input To DRAM or L1
         ////////////////////////////////////////////////////////////////////////////
-        tt_metal::distributed::EnqueueWriteMeshBuffer(device->mesh_command_queue(), input_buffer, input_vec, false);
+        device->mesh_command_queue().enqueue_write_mesh_buffer(input_buffer, input_vec.data(), false);
         tt_metal::distributed::Finish(device->mesh_command_queue());
 
         ////////////////////////////////////////////////////////////////////////////

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/benchmark_rw_buffer.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <chrono>
+#include <type_traits>
 #include <fmt/base.h>
 #include <fmt/format.h>
 #include <cstdint>
@@ -28,14 +29,13 @@
 #include "context/metal_context.hpp"
 #include "mesh_coord.hpp"
 #include <llrt/tt_cluster.hpp>
-
 using namespace tt;
 using namespace tt::tt_metal;
 using namespace tt::tt_metal::distributed;
 
 ////////////////////////////////////////////////////////////////////////////////
 // This test measures the bandwidth of host-to-device data transfer and
-// device-to-host data transfer. It uses EnqueueWriteMeshBuffer and
+// device-to-host data transfer. It uses enqueue_write_mesh_buffer and
 // ReadShard APIs to transfer the data. The device memory object
 // (mesh buffer) will be in DRAM.
 //
@@ -96,7 +96,7 @@ static void BM_write(
         mesh_device.get());
 
     for ([[maybe_unused]] auto _ : state) {
-        EnqueueWriteMeshBuffer(mesh_device->mesh_command_queue(), device_buffer, host_buffer, true);
+        mesh_device->mesh_command_queue().enqueue_write_mesh_buffer(device_buffer, host_buffer.data(), true);
     }
 
     state.SetBytesProcessed(transfer_size * state.iterations());
@@ -354,7 +354,6 @@ static void BM_read(benchmark::State& state, const std::shared_ptr<MeshDevice>& 
     std::vector<ElementType> host_buffer(transfer_size / ElementSize);
 
     for ([[maybe_unused]] auto _ : state) {
-        // EnqueueReadMeshBuffer cannot read from a replicated buffer yet, have to use ReadShard
         ReadShard(mesh_device->mesh_command_queue(), host_buffer, device_buffer, MeshCoordinate(0, 0), true);
     }
 

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_bw_and_latency.cpp
@@ -23,6 +23,7 @@
 #include <variant>
 #include <vector>
 #include <tt-metalium/distributed.hpp>
+#include "tt_metal/distributed/event_query_impl.hpp"
 
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/ethernet/test_all_ethernet_links.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <algorithm>
+#include <type_traits>
 #include <tuple>
 #include <map>
 #include <set>
@@ -37,7 +38,6 @@
 
 #include <enchantum/enchantum.hpp>
 #include <llrt/tt_cluster.hpp>
-
 using namespace tt;
 using namespace tt::test_utils;
 using namespace tt::test_utils::df;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/matmul/matmul_global_l1.cpp
@@ -45,7 +45,6 @@
 #include "tt_metal/test_utils/deprecated/tensor.hpp"
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/distributed.hpp>
-
 using std::vector;
 using namespace tt;
 
@@ -1050,11 +1049,10 @@ int main(int argc, char** argv) {
         auto activations_tile_layout =
             convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(activations_tilized));
         auto activations = pack_bfloat16_vec_into_uint32_vec(activations_tile_layout);
-        tt_metal::distributed::WriteShard(
-            device->mesh_command_queue(0),
+        device->mesh_command_queue(0).enqueue_write_shards(
             in0_buffer,
-            activations,
-            tt::tt_metal::distributed::MeshCoordinate(0, 0),
+            {tt_metal::distributed::ShardDataTransfer{tt::tt_metal::distributed::MeshCoordinate(0, 0)}.host_data(
+                activations.data())},
             true);
 
         auto identity = create_identity_matrix(Kt * 32, Nt * 32, std::min(Kt, Nt) * 32);
@@ -1062,8 +1060,11 @@ int main(int argc, char** argv) {
         auto weights_tile_layout =
             convert_layout_tile_swizzled_to_tile_nfaces(ttsl::make_const_span(identity_tilized));
         auto weights = pack_bfloat16_vec_into_uint32_vec(weights_tile_layout);
-        tt_metal::distributed::WriteShard(
-            device->mesh_command_queue(0), in1_buffer, weights, tt::tt_metal::distributed::MeshCoordinate(0, 0), true);
+        device->mesh_command_queue(0).enqueue_write_shards(
+            in1_buffer,
+            {tt_metal::distributed::ShardDataTransfer{tt::tt_metal::distributed::MeshCoordinate(0, 0)}.host_data(
+                weights.data())},
+            true);
 
         ////////////////////////////////////////////////////////////////////////////
         //                      Matmul Parameters Setup

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/noc/test_noc_read_global_l1.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <chrono>
+#include <type_traits>
 #include <cerrno>
 #include <fmt/base.h>
 #include <cstdint>
@@ -38,7 +39,6 @@
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/distributed.hpp>
 #include "impl/data_format/bfloat16_utils.hpp"
-
 using namespace tt;
 using std::chrono::duration_cast;
 using std::chrono::microseconds;
@@ -221,11 +221,10 @@ int main(int argc, char** argv) {
                     .page_size = single_tile_size, .buffer_type = tt_metal::BufferType::L1};
                 l1_buffers.push_back(
                     tt_metal::distributed::MeshBuffer::create(replicated_config, local_config, device.get()));
-                tt_metal::distributed::WriteShard(
-                    device->mesh_command_queue(0),
+                device->mesh_command_queue(0).enqueue_write_shards(
                     l1_buffers[(r * num_cores_c) + c],
-                    packed_tensors[(r * num_cores_c) + c],
-                    tt::tt_metal::distributed::MeshCoordinate(0, 0),
+                    {tt_metal::distributed::ShardDataTransfer{tt::tt_metal::distributed::MeshCoordinate(0, 0)}
+                         .host_data(packed_tensors[(r * num_cores_c) + c].data())},
                     true);
 
                 if (single_read || one_buffer_share) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_enqueue_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_enqueue_rw_buffer.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <chrono>
+#include <type_traits>
 #include <cerrno>
 #include <fmt/base.h>
 #include <cstdint>
@@ -24,7 +25,6 @@
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include "test_common.hpp"
-
 using namespace tt;
 using namespace tt::tt_metal;
 using std::chrono::duration_cast;
@@ -94,7 +94,10 @@ int main(int argc, char** argv) {
 
             for (int i = 0; i < iter; i++) {
                 begin = std::chrono::steady_clock::now();
-                distributed::WriteShard(cq, buffer, src_vec, distributed::MeshCoordinate(0, 0));
+                cq.enqueue_write_shards(
+                    buffer,
+                    {distributed::ShardDataTransfer{distributed::MeshCoordinate(0, 0)}.host_data(src_vec.data())},
+                    false);
                 distributed::Finish(cq);
                 end = std::chrono::steady_clock::now();
                 elapsed_sum += end - begin;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_buffer.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/old/pcie/test_rw_buffer.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <chrono>
+#include <type_traits>
 #include <cerrno>
 #include <fmt/base.h>
 #include <cstdint>
@@ -23,7 +24,6 @@
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include "test_common.hpp"
-
 using namespace tt;
 using namespace tt::tt_metal;
 using std::chrono::duration_cast;
@@ -89,11 +89,10 @@ int main(int argc, char** argv) {
 
             for (int i = 0; i < iter; i++) {
                 begin = std::chrono::steady_clock::now();
-                tt_metal::distributed::WriteShard(
-                    device->mesh_command_queue(0),
+                device->mesh_command_queue(0).enqueue_write_shards(
                     buffer,
-                    src_vec,
-                    tt::tt_metal::distributed::MeshCoordinate(0, 0),
+                    {tt_metal::distributed::ShardDataTransfer{tt::tt_metal::distributed::MeshCoordinate(0, 0)}
+                         .host_data(src_vec.data())},
                     true);
                 end = std::chrono::steady_clock::now();
                 elapsed_sum += end - begin;

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/op_to_op_latency/test_op_to_op_latency.cpp
@@ -102,7 +102,6 @@
 #include "tt_metal/tt_metal/perf_microbenchmark/common/util.hpp"
 
 #include "test_common.hpp"
-
 using namespace tt;
 using namespace tt::tt_metal;
 
@@ -1049,7 +1048,7 @@ int main(int argc, char** argv) {
             create_random_vector_of_bfloat16(buffer_size_bytes, /*rand_max_float=*/100, seed);
 
         auto& cq = mesh_device->mesh_command_queue();
-        distributed::EnqueueWriteMeshBuffer(cq, input_buffer, input_data, /*blocking=*/false);
+        cq.enqueue_write_mesh_buffer(input_buffer, input_data.data(), /*blocking=*/false);
         // Drain the input upload before trace capture: host writes are not allowed while
         // a trace is being recorded (see FDMeshCommandQueue "Writes are not supported
         // during trace capture"). Warmup's Finish used to hide this; --no-warmup needs
@@ -1185,7 +1184,9 @@ int main(int argc, char** argv) {
 
         if (!cfg.read_only && !cfg.skip_output_validation) {
             std::vector<uint32_t> output_data;
-            distributed::EnqueueReadMeshBuffer(cq, output_data, output_buffer, /*blocking=*/true);
+            (output_data)
+                .resize((output_buffer)->size() / sizeof(typename std::decay_t<decltype(output_data)>::value_type));
+            cq.enqueue_read_mesh_buffer((output_data).data(), output_buffer, /*blocking=*/true);
 
             if (output_data.size() != input_data.size()) {
                 log_error(

--- a/tests/tt_metal/tt_metal/test_clean_init.cpp
+++ b/tests/tt_metal/tt_metal/test_clean_init.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <chrono>
+#include <type_traits>
 #include <fmt/base.h>
 #include <cstdint>
 #include <cstdlib>
@@ -27,7 +28,6 @@
 #include <tt_stl/span.hpp>
 #include "impl/context/metal_context.hpp"
 #include <tt-metalium/distributed.hpp>
-
 /*
  * Similar to loopback programming example, except run on al devices and skip device teardown to check if we can
  * recover from a "bad" state.
@@ -110,7 +110,7 @@ int main(int argc, char** /*argv*/) {
              */
             std::vector<uint32_t> input_vec = create_random_vector_of_bfloat16(
                 dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-            distributed::EnqueueWriteMeshBuffer(cq, input_dram_buffer, input_vec, false);
+            cq.enqueue_write_mesh_buffer(input_dram_buffer, input_vec.data(), false);
 
             const std::array<uint32_t, 4> runtime_args = {
                 l1_buffer->address(),

--- a/tests/tt_metal/tt_metal/test_eltwise_binary.cpp
+++ b/tests/tt_metal/tt_metal/test_eltwise_binary.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "common/command_queue_fixture.hpp"
+#include <type_traits>
 
 #include <chrono>
 #include <cstdint>
@@ -18,7 +19,6 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include "test_gold_impls.hpp"
-
 using std::vector;
 using namespace tt;
 using namespace tt::tt_metal;
@@ -137,7 +137,7 @@ void run_eltwise_binary_test(
     // Execute
     std::vector<uint32_t> src0_vec = create_random_vector_of_bfloat16(
         dram_buffer_size, 100, std::chrono::system_clock::now().time_since_epoch().count());
-    distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, src0_vec, false);
+    cq.enqueue_write_mesh_buffer(src0_dram_buffer, src0_vec.data(), false);
 
     std::vector<uint32_t> src1_vec;
     if (eltwise_op == static_cast<int>(EltwiseOp::MUL)) {
@@ -145,7 +145,7 @@ void run_eltwise_binary_test(
     } else {
         src1_vec = create_constant_vector_of_bfloat16(dram_buffer_size, 0.0f);
     }
-    distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, src1_vec, false);
+    cq.enqueue_write_mesh_buffer(src1_dram_buffer, src1_vec.data(), false);
 
     distributed::EnqueueMeshWorkload(cq, mesh_workload, false);
     std::vector<uint32_t> result_vec;

--- a/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
+++ b/tests/tt_metal/tt_metal/test_interleaved_layouts.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "common/command_queue_fixture.hpp"
+#include <type_traits>
 
 #include <chrono>
 #include <cerrno>
@@ -30,7 +31,6 @@
 #include "test_common.hpp"
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "impl/data_format/bfloat16_utils.hpp"
-
 //////////////////////////////////////////////////////////////////////////////////////////
 // TODO: explain what test does
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -68,7 +68,7 @@ bool test_write_interleaved_sticks_and_then_read_interleaved_sticks(
 
         auto sticks_buffer = distributed::MeshBuffer::create(buffer_config, device_local_config, mesh_device.get());
 
-        distributed::EnqueueWriteMeshBuffer(cq, sticks_buffer, src_vec, false);
+        cq.enqueue_write_mesh_buffer(sticks_buffer, src_vec.data(), false);
 
         vector<uint32_t> dst_vec;
         distributed::ReadShard(cq, dst_vec, sticks_buffer, distributed::MeshCoordinate(0, 0));
@@ -185,7 +185,7 @@ bool interleaved_stick_reader_single_bank_tilized_writer_datacopy_test(
         ////////////////////////////////////////////////////////////////////////////
         std::vector<uint32_t> src_vec = create_arange_vector_of_bfloat16(dram_buffer_size, false);
 
-        distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, src_vec, false);
+        cq.enqueue_write_mesh_buffer(src_dram_buffer, src_vec.data(), false);
 
         tt_metal::SetRuntimeArgs(
             program,
@@ -331,7 +331,7 @@ bool interleaved_tilized_reader_interleaved_stick_writer_datacopy_test(
         ////////////////////////////////////////////////////////////////////////////
         std::vector<uint32_t> src_vec = create_arange_vector_of_bfloat16(dram_buffer_size, false);
 
-        distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, src_vec, false);
+        cq.enqueue_write_mesh_buffer(src_dram_buffer, src_vec.data(), false);
 
         tt_metal::SetRuntimeArgs(
             program,
@@ -434,7 +434,7 @@ bool test_interleaved_l1_datacopy(
             num_l1_banks);
 
         src = distributed::MeshBuffer::create(buffer_config, l1_local_config, mesh_device.get());
-        distributed::EnqueueWriteMeshBuffer(cq, src, host_buffer, false);
+        cq.enqueue_write_mesh_buffer(src, host_buffer.data(), false);
 
     } else {
         TT_FATAL(
@@ -444,7 +444,7 @@ bool test_interleaved_l1_datacopy(
             num_dram_banks);
 
         src = distributed::MeshBuffer::create(buffer_config, dram_local_config, mesh_device.get());
-        distributed::EnqueueWriteMeshBuffer(cq, src, host_buffer, false);
+        cq.enqueue_write_mesh_buffer(src, host_buffer.data(), false);
     }
 
     // Create destination buffer prior to kernels to build compile-time args

--- a/tests/tt_metal/tt_metal/test_quasar_events.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_events.cpp
@@ -7,6 +7,7 @@
 
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
+#include "tt_metal/distributed/event_query_impl.hpp"
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/mesh_event.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>

--- a/tests/tt_metal/tt_metal/test_quasar_mesh_buffers.cpp
+++ b/tests/tt_metal/tt_metal/test_quasar_mesh_buffers.cpp
@@ -16,7 +16,6 @@
 #include <memory>
 #include <numeric>
 #include <vector>
-
 using namespace tt;
 using namespace tt::tt_metal;
 
@@ -50,10 +49,11 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, MeshBufferWriteReadDRAM) {
     std::vector<uint32_t> src(num_elems);
     std::iota(src.begin(), src.end(), 0xabcd0000u);
 
-    distributed::EnqueueWriteMeshBuffer(cq, buf, src);
+    cq.enqueue_write_mesh_buffer(buf, src.data(), false);
 
-    std::vector<uint32_t> dst;
-    distributed::EnqueueReadMeshBuffer(cq, dst, buf, /*blocking=*/true);
+    const size_t dst_n = buf->size() / sizeof(uint32_t);
+    std::vector<uint32_t> dst(dst_n);
+    cq.enqueue_read_mesh_buffer((dst).data(), buf, /*blocking=*/true);
 
     ASSERT_EQ(dst.size(), src.size());
     ASSERT_EQ(dst, src);
@@ -72,10 +72,11 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, MeshBufferMultipleWriteReadRoundsDRAM)
         std::vector<uint32_t> src(num_elems);
         std::iota(src.begin(), src.end(), round * 1000u);
 
-        distributed::EnqueueWriteMeshBuffer(cq, buf, src);
+        cq.enqueue_write_mesh_buffer(buf, src.data(), false);
 
-        std::vector<uint32_t> dst;
-        distributed::EnqueueReadMeshBuffer(cq, dst, buf, /*blocking=*/true);
+        const size_t dst_n = buf->size() / sizeof(uint32_t);
+        std::vector<uint32_t> dst(dst_n);
+        cq.enqueue_read_mesh_buffer((dst).data(), buf, /*blocking=*/true);
 
         ASSERT_EQ(dst, src);
     }
@@ -93,10 +94,11 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, MeshBufferWriteReadL1) {
     std::vector<uint32_t> src(num_elems);
     std::iota(src.begin(), src.end(), 0xabcd0000u);
 
-    distributed::EnqueueWriteMeshBuffer(cq, buf, src);
+    cq.enqueue_write_mesh_buffer(buf, src.data(), false);
 
-    std::vector<uint32_t> dst;
-    distributed::EnqueueReadMeshBuffer(cq, dst, buf, /*blocking=*/true);
+    const size_t dst_n = buf->size() / sizeof(uint32_t);
+    std::vector<uint32_t> dst(dst_n);
+    cq.enqueue_read_mesh_buffer((dst).data(), buf, /*blocking=*/true);
 
     ASSERT_EQ(dst.size(), src.size());
     ASSERT_EQ(dst, src);
@@ -115,10 +117,11 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, MeshBufferMultipleWriteReadRoundsL1) {
         std::vector<uint32_t> src(num_elems);
         std::iota(src.begin(), src.end(), round * 1000u);
 
-        distributed::EnqueueWriteMeshBuffer(cq, buf, src);
+        cq.enqueue_write_mesh_buffer(buf, src.data(), false);
 
-        std::vector<uint32_t> dst;
-        distributed::EnqueueReadMeshBuffer(cq, dst, buf, /*blocking=*/true);
+        const size_t dst_n = buf->size() / sizeof(uint32_t);
+        std::vector<uint32_t> dst(dst_n);
+        cq.enqueue_read_mesh_buffer((dst).data(), buf, /*blocking=*/true);
 
         ASSERT_EQ(dst, src);
     }
@@ -138,12 +141,13 @@ TEST_F(QuasarMultiCQMeshDeviceSingleCardFixture, MeshBufferCrossCQWriteReadRound
         std::vector<uint32_t> src(num_elems);
         std::iota(src.begin(), src.end(), round * 1000u);
 
-        distributed::EnqueueWriteMeshBuffer(cq0, buf, src);
+        cq0.enqueue_write_mesh_buffer(buf, src.data(), false);
         distributed::MeshEvent write_event = cq0.enqueue_record_event();
         cq1.enqueue_wait_for_event(write_event);
 
-        std::vector<uint32_t> dst;
-        distributed::EnqueueReadMeshBuffer(cq1, dst, buf, /*blocking=*/true);
+        const size_t dst_n = buf->size() / sizeof(uint32_t);
+        std::vector<uint32_t> dst(dst_n);
+        cq1.enqueue_read_mesh_buffer((dst).data(), buf, /*blocking=*/true);
 
         ASSERT_EQ(dst, src);
     }

--- a/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
+++ b/tests/ttnn/unit_tests/gtests/ccl/test_erisc_data_mover_with_workers.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <fmt/base.h>
+#include <type_traits>
 #include <cstdint>
 // #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/core_coord.hpp>
@@ -50,7 +51,6 @@
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/xy_pair.hpp>
 #include "common/tt_backend_api_types.hpp"
-
 using namespace tt;
 using namespace tt::tt_metal;
 using namespace tt::test_utils;
@@ -404,8 +404,10 @@ bool RunWriteBWTest(
     auto remote_input_buffer =
         distributed::MeshBuffer::create(buffer_config, local_input_config, receiver_mesh_device.get());
 
-    distributed::WriteShard(sender_cq, local_input_buffer, inputs, zero_coord);
-    distributed::WriteShard(receiver_cq, remote_input_buffer, inputs, zero_coord);
+    sender_cq.enqueue_write_shards(
+        local_input_buffer, {distributed::ShardDataTransfer{zero_coord}.host_data(inputs.data())}, false);
+    receiver_cq.enqueue_write_shards(
+        remote_input_buffer, {distributed::ShardDataTransfer{zero_coord}.host_data(inputs.data())}, false);
 
     std::vector<uint32_t> local_input_buffer_addresses(num_local_sender_channels, local_input_buffer->address());
     std::vector<uint32_t> remote_input_buffer_addresses(num_remote_sender_channels, remote_input_buffer->address());
@@ -437,10 +439,12 @@ bool RunWriteBWTest(
     }
 
     for (const auto& buffer_id : local_output_buffers) {
-        distributed::WriteShard(sender_cq, buffer_id, all_zeros, zero_coord);
+        sender_cq.enqueue_write_shards(
+            buffer_id, {distributed::ShardDataTransfer{zero_coord}.host_data(all_zeros.data())}, false);
     }
     for (const auto& buffer_id : remote_output_buffers) {
-        distributed::WriteShard(receiver_cq, buffer_id, all_zeros, zero_coord);
+        receiver_cq.enqueue_write_shards(
+            buffer_id, {distributed::ShardDataTransfer{zero_coord}.host_data(all_zeros.data())}, false);
     }
 
     uint32_t erisc_handshake_address = tt::tt_metal::hal::get_erisc_l1_unreserved_base();

--- a/tests/ttnn/unit_tests/gtests/tensor/test_d2d_stream_service.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_d2d_stream_service.cpp
@@ -27,6 +27,7 @@
 //     (1x1<->1x1 for single-chip cases; 1x2<->1x2 for multi-socket cases).
 
 #include <algorithm>
+#include <type_traits>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -67,7 +68,6 @@
 #include "ttnn/tensor/types.hpp"
 
 #include "stream_service_test_utils.hpp"  // replicate_all
-
 namespace ttnn::distributed::test {
 namespace {
 
@@ -101,9 +101,8 @@ using ::tt::tt_metal::distributed::MeshDevice;
 using ::tt::tt_metal::distributed::MeshMapperConfig;
 using ::tt::tt_metal::distributed::MeshShape;
 using ::tt::tt_metal::distributed::MeshWorkload;
-using ::tt::tt_metal::distributed::ReadShard;
+using ::tt::tt_metal::distributed::ShardDataTransfer;
 using ::tt::tt_metal::distributed::SocketMemoryConfig;
-using ::tt::tt_metal::distributed::WriteShard;
 using ttnn::D2DStreamConfig;
 using ttnn::D2DStreamService;
 using ttnn::D2DStreamServiceReceiver;
@@ -254,7 +253,8 @@ void verify_transfer(
     // Load the sender backing tensor on every participating coord and make sure
     // the writes land before we trigger the sender.
     for (const auto& coord : coords) {
-        WriteShard(sender_mesh->mesh_command_queue(), sender_mesh_buffer, iota, coord);
+        sender_mesh->mesh_command_queue().enqueue_write_shards(
+            sender_mesh_buffer, {ShardDataTransfer{coord}.host_data(iota.data())}, false);
     }
     Finish(sender_mesh->mesh_command_queue());
 

--- a/tools/tests/triage/hang_apps/add_2_integers_hang/add_2_integers_hang.cpp
+++ b/tools/tests/triage/hang_apps/add_2_integers_hang/add_2_integers_hang.cpp
@@ -9,7 +9,6 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-
 using namespace tt;
 using namespace tt::tt_metal;
 #ifndef OVERRIDE_KERNEL_PREFIX
@@ -132,8 +131,8 @@ int main() {
     // is not released before the operation is complete.
     // In this case, we will wait for the program to finish eventually in the same scope, so we can set it
     // to false safely.
-    EnqueueWriteMeshBuffer(cq, src0_dram_buffer, src0_vec, false);
-    EnqueueWriteMeshBuffer(cq, src1_dram_buffer, src1_vec, false);
+    cq.enqueue_write_mesh_buffer(src0_dram_buffer, src0_vec.data(), false);
+    cq.enqueue_write_mesh_buffer(src1_dram_buffer, src1_vec.data(), false);
 
     // Setup arguments for the kernels in the program.
     // Unlike OpenCL/CUDA, every kernel can have its own set of arguments.
@@ -164,7 +163,8 @@ int main() {
     // specific shard of a MeshBuffer. The shard is specified by the MeshCoordinate. The last argument indicates if the
     // operation is blocking or not.
     std::vector<bfloat16> result_vec;
-    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, true);
+    (result_vec).resize((dst_dram_buffer)->size() / sizeof(typename std::decay_t<decltype(result_vec)>::value_type));
+    cq.enqueue_read_mesh_buffer((result_vec).data(), dst_dram_buffer, true);
 
     // compare the results with the expected values.
     bool success = true;

--- a/tt_metal/api/tt-metalium/distributed.hpp
+++ b/tt_metal/api/tt-metalium/distributed.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include <vector>
 
+#include <tt_stl/assert.hpp>
 #include <tt_stl/optional_reference.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/buffer.hpp>
@@ -17,7 +18,6 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/mesh_event.hpp>
 #include <tt-metalium/experimental/sockets/mesh_socket.hpp>
-#include <tt-metalium/mesh_trace_id.hpp>
 #include <tt-metalium/mesh_workload.hpp>
 #include <tt-metalium/sub_device_types.hpp>
 
@@ -35,17 +35,6 @@ class IDevice;
 namespace distributed {
 
 void EnqueueMeshWorkload(MeshCommandQueue& mesh_cq, MeshWorkload& mesh_workload, bool blocking);
-
-template <typename DType>
-void WriteShard(
-    MeshCommandQueue& mesh_cq,
-    const std::shared_ptr<MeshBuffer>& mesh_buffer,
-    std::vector<DType>& src,
-    const MeshCoordinate& coord,
-    bool blocking = false) {
-    std::vector<ShardDataTransfer> shard_data_transfers = {ShardDataTransfer{coord}.host_data(src.data())};
-    mesh_cq.enqueue_write_shards(mesh_buffer, shard_data_transfers, blocking);
-}
 
 template <typename DType>
 void ReadShard(
@@ -74,7 +63,8 @@ void EnqueueWriteMeshBuffer(
     std::shared_ptr<MeshBuffer>& mesh_buffer,
     const std::vector<DType>& src,
     bool blocking = false) {
-    TT_FATAL(src.size() * sizeof(DType) >= mesh_buffer->size(),
+    TT_FATAL(
+        src.size() * sizeof(DType) >= mesh_buffer->size(),
         "Source vector is too small for mesh buffer: mesh buffer size={} bytes, source size={} * {} bytes",
         mesh_buffer->size(),
         src.size(),
@@ -92,7 +82,7 @@ void EnqueueReadMeshBuffer(
     // This API supports reading MeshBuffers sharded across devices
     // and a Unit-MeshBuffer with a replicated layout.
     if (mesh_buffer->global_layout() == MeshBufferLayout::SHARDED) {
-        dst.resize(mesh_buffer->global_shard_spec().global_size / sizeof(DType));
+        dst.resize(std::get<ShardedBufferConfig>(mesh_buffer->global_config()).global_size / sizeof(DType));
     } else {
         dst.resize(mesh_buffer->size() / sizeof(DType));
     }
@@ -102,19 +92,10 @@ void EnqueueReadMeshBuffer(
 // Make the current thread block until the event is recorded by the associated MeshCommandQueue.
 void EventSynchronize(const MeshEvent& event);
 
-// Query the status of an event tied to a MeshCommandQueue.
-// Returns true if the CQ has completed recording the event, false otherwise.
-bool EventQuery(const MeshEvent& event);
-
 void Synchronize(
     MeshDevice& device,
     ttsl::optional_reference<MeshCommandQueue> mesh_cq,
     ttsl::Span<const SubDeviceId> sub_device_ids = {});
-
-[[deprecated(
-    "Use MeshDevice::begin_mesh_trace(MeshCommandQueue&) instead. BeginTraceCapture(MeshDevice*, uint8_t) will be "
-    "removed after September 9th, 2026.")]]
-MeshTraceId BeginTraceCapture(MeshDevice* device, uint8_t cq_id);
 
 // Takes the device by pointer, so the reference-taking overload above is the only candidate for a MeshDevice lvalue
 // and this one the only candidate for a MeshDevice*. That keeps Synchronize(device, std::nullopt, ...) unambiguous

--- a/tt_metal/api/tt-metalium/maybe_remote.hpp
+++ b/tt_metal/api/tt-metalium/maybe_remote.hpp
@@ -15,28 +15,7 @@
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 
-namespace tt::tt_metal {
-
-class IDevice;
-
-}  // namespace tt::tt_metal
-
 namespace tt::tt_metal::distributed {
-
-/**
- * Concept to check if a type behaves like MaybeRemote.
- *
- * A type satisfies MaybeRemoteLike if it has:
- * - A nested value_type type alias
- * - An is_local() method that returns something convertible to bool
- * - A value() method that returns exactly the value_type
- */
-template <typename T>
-concept MaybeRemoteLike = requires(T t) {
-    typename T::value_type;
-    { t.is_local() } -> std::convertible_to<bool>;
-    { t.value() } -> std::same_as<typename T::value_type&>;
-};
 
 /**
  * Empty marker type to represent a remote device or coordinate.
@@ -124,10 +103,6 @@ public:
     // Debugging support
     [[nodiscard]] std::string to_string() const;
 };
-
-// Type aliases for common use cases
-using MaybeRemoteDeviceId = MaybeRemote<int>;
-using MaybeRemoteDevice = MaybeRemote<IDevice*>;
 
 // ============================================================================
 // MaybeRemote Implementation
@@ -261,55 +236,6 @@ std::string MaybeRemote<T>::to_string() const {
             return oss.str();
         },
         []() -> std::string { return "MaybeRemote{remote}"; });
-}
-
-// ============================================================================
-// Utility Functions
-// ============================================================================
-
-/**
- * Extract all local values from a container of MaybeRemote objects.
- *
- * This function filters out remote devices and returns only the local values
- * in a new vector.
- *
- * @tparam Container Any container type whose value_type satisfies MaybeRemoteLike
- * @param container The container of MaybeRemote objects
- * @return std::vector<T> containing only the local values
- */
-template <typename Container>
-    requires MaybeRemoteLike<typename Container::value_type>
-[[nodiscard]] auto extract_locals(const Container& container) {
-    using MaybeRemoteType = typename Container::value_type;
-    using ValueType = typename MaybeRemoteType::value_type;
-
-    std::vector<ValueType> locals;
-    locals.reserve(container.size());
-
-    for (const auto& maybe : container) {
-        if (maybe.is_local()) {
-            locals.push_back(maybe.value());
-        }
-    }
-    return locals;
-}
-
-/**
- * Wraps all local values from a container to a container with MaybeRemote objects.
- *
- * @tparam Container Any container type
- * @param container The container of objects of type T
- * @return std::vector<MaybeRemote<T>> containing the local values wrapped in MaybeRemote
- */
-template <typename Container>
-[[nodiscard]] auto wrap_to_maybe_remote(const Container& container) {
-    using T = typename Container::value_type;
-    std::vector<MaybeRemote<T>> wrapped;
-    wrapped.reserve(container.size());
-    for (const auto& local : container) {
-        wrapped.push_back(MaybeRemote<T>::local(local));
-    }
-    return wrapped;
 }
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/api/tt-metalium/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/mesh_buffer.hpp
@@ -74,18 +74,8 @@ using MeshBufferConfig = std::variant<ReplicatedBufferConfig, ShardedBufferConfi
 
 class MeshBuffer;
 
-}  // namespace tt::tt_metal::distributed
-
-// Forward declaration for experimental per-core allocation friend
-namespace tt::tt_metal::experimental::per_core_allocation {
-std::shared_ptr<tt::tt_metal::distributed::MeshBuffer> create_on_single_device(
-    const tt::tt_metal::distributed::MeshBufferConfig& mesh_buffer_config,
-    const tt::tt_metal::distributed::DeviceLocalBufferConfig& device_local_config,
-    tt::tt_metal::distributed::MeshDevice* mesh_device,
-    const tt::tt_metal::distributed::MeshCoordinate& coord);
-}  // namespace tt::tt_metal::experimental::per_core_allocation
-
-namespace tt::tt_metal::distributed {
+// Internal state and implementation of `MeshBuffer`; defined in `tt_metal/distributed/mesh_buffer_impl.hpp`.
+class MeshBufferImpl;
 
 // MeshBuffer allocates a buffer across a mesh of devices according to the specified configuration: either full
 // replication, or 2D sharding. The allocation is done in lock-step across all devices in the mesh.
@@ -96,6 +86,8 @@ public:
         const DeviceLocalBufferConfig& device_local_config,
         MeshDevice* mesh_device,
         std::optional<DeviceAddr> address = std::nullopt);
+
+    explicit MeshBuffer(MeshBufferImpl impl);
     ~MeshBuffer();
 
     // MeshBuffer manages device memory and owns the backing allocation. Copying would create
@@ -104,6 +96,10 @@ public:
     MeshBuffer& operator=(const MeshBuffer&) = delete;
     MeshBuffer(MeshBuffer&& other) noexcept;
     MeshBuffer& operator=(MeshBuffer&& other) noexcept;
+
+    // Accessors for the internal implementation. Throw if this MeshBuffer was moved from.
+    const MeshBufferImpl& impl() const;
+    MeshBufferImpl& impl();
 
     // Returns true if the MeshBuffer is allocated. Note that MeshBuffer is created in the allocated state; either the
     // destructor or the `deallocate` method deallocate the MeshBuffer.
@@ -117,14 +113,12 @@ public:
     // Throws an exception if the corresponding MeshDevice is already deallocated
     MeshDevice* device() const;
     DeviceAddr size() const;
-    DeviceAddr device_local_size() const { return device_local_size_; }
-    DeviceAddr address() const { return address_; };
+    DeviceAddr device_local_size() const;
+    DeviceAddr address() const;
 
     MeshBufferLayout global_layout() const;
-    const MeshBufferConfig& global_config() const { return config_; }
-
-    const ShardedBufferConfig& global_shard_spec() const;
-    const DeviceLocalBufferConfig& device_local_config() const { return device_local_config_; }
+    const MeshBufferConfig& global_config() const;
+    const DeviceLocalBufferConfig& device_local_config() const;
 
     Buffer* get_device_buffer(const MeshCoordinate& device_coord) const;
 
@@ -138,69 +132,11 @@ public:
     // into the creation API.
     Buffer* get_backing_buffer() const;
 
-    uint32_t datum_size_bytes() const;
-    Shape2D physical_shard_shape() const;
-    std::pair<bool, bool> replicated_dims() const;
-    uint32_t page_size() const { return device_local_config_.page_size; }
-    uint32_t num_pages() const { return page_size() == 0 ? 0 : device_local_size_ / page_size(); }
+    uint32_t page_size() const;
+    uint32_t num_pages() const;
 
 private:
-    // Creates an owning `MeshBuffer`, backed by an allocation made through `backing_buffer`.
-    MeshBuffer(
-        const MeshBufferConfig& config,
-        const DeviceLocalBufferConfig& device_local_config,
-        DeviceAddr device_local_size,
-        MeshDevice* mesh_device,
-        std::shared_ptr<Buffer> backing_buffer) :
-        config_(config),
-        device_local_config_(device_local_config),
-        mesh_device_(mesh_device->shared_from_this()),
-        address_(backing_buffer->address()),
-        device_local_size_(device_local_size),
-        buffers_(MeshShape(mesh_device->shape())),
-        state_(OwnedBufferState{std::move(backing_buffer)}) {}
-
-    // Creates a non-owning `MeshBuffer` as "view" over an existing `address`.
-    MeshBuffer(
-        const MeshBufferConfig& config,
-        const DeviceLocalBufferConfig& device_local_config,
-        DeviceAddr address,
-        DeviceAddr device_local_size,
-        MeshDevice* mesh_device) :
-        config_(config),
-        device_local_config_(device_local_config),
-        mesh_device_(mesh_device->shared_from_this()),
-        address_(address),
-        device_local_size_(device_local_size),
-        buffers_(MeshShape(mesh_device->shape())),
-        state_(ExternallyOwnedState{}) {}
-
-    void initialize_device_buffers();
-    MeshBufferConfig config_;
-    DeviceLocalBufferConfig device_local_config_;
-    std::weak_ptr<MeshDevice> mesh_device_;
-    DeviceAddr address_ = 0;
-    DeviceAddr device_local_size_ = 0;
-
-    DistributedMeshContainer<std::shared_ptr<Buffer>> buffers_;
-
-    // `MeshBufferState` specifies the state of the MeshBuffer. It can either be:
-    // 1. Owned - a single device buffer is responsible for providing the address for the entire mesh buffer.
-    // 2. Externally owned - the MeshBuffer was created as a view over an existing address.
-    // 3. Deallocated - the MeshBuffer is in the deallocated state.
-    struct OwnedBufferState {
-        std::shared_ptr<Buffer> backing_buffer;
-    };
-    struct ExternallyOwnedState {};
-    struct DeallocatedState {};
-    using MeshBufferState = std::variant<OwnedBufferState, ExternallyOwnedState, DeallocatedState>;
-    MeshBufferState state_;
-
-    friend std::shared_ptr<MeshBuffer> tt::tt_metal::experimental::per_core_allocation::create_on_single_device(
-        const tt::tt_metal::distributed::MeshBufferConfig&,
-        const tt::tt_metal::distributed::DeviceLocalBufferConfig&,
-        tt::tt_metal::distributed::MeshDevice*,
-        const tt::tt_metal::distributed::MeshCoordinate&);
+    std::unique_ptr<MeshBufferImpl> impl_;
 };
 
 class AnyBuffer {
@@ -220,7 +156,7 @@ private:
     AnyBuffer(std::shared_ptr<MeshBuffer> buffer);
 
     Buffer* buffer_ = nullptr;
-    std::variant<std::shared_ptr<Buffer>, std::shared_ptr<distributed::MeshBuffer>> holder_;
+    std::variant<std::shared_ptr<Buffer>, std::shared_ptr<MeshBuffer>> holder_;
 };
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/api/tt-metalium/mesh_command_queue.hpp
+++ b/tt_metal/api/tt-metalium/mesh_command_queue.hpp
@@ -5,58 +5,35 @@
 #pragma once
 
 #include <stdint.h>
-#include <atomic>
-#include <condition_variable>
 #include <memory>
-#include <mutex>
 #include <optional>
-#include <queue>
-#include <thread>
-#include <unordered_map>
 #include <unordered_set>
-#include <variant>
 #include <vector>
 
 #include <tt_stl/span.hpp>
 #include <tt-metalium/buffer.hpp>
-#include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/mesh_coord.hpp>
-#include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/mesh_trace_id.hpp>
-#include <tt-metalium/distributed_host_buffer.hpp>
 #include <tt-metalium/mesh_workload.hpp>
 #include <tt-metalium/sub_device_types.hpp>
 
 namespace tt::tt_metal {
+class DistributedHostBuffer;
 class HostTensor;
-class IDevice;
 class MemoryConfig;
 class MeshTensor;
-class SystemMemoryManager;
-class WorkerConfigBufferMgr;
-namespace distributed {
-class MeshDevice;
-class MeshWorkload;
-}  // namespace distributed
-struct ProgramCommandSequence;
 namespace experimental {
-
+class PinnedMemory;
 class ShardDataTransferHelper;
 }  // namespace experimental
 }  // namespace tt::tt_metal
 
 namespace tt::tt_metal::distributed {
 
+class MeshDevice;
 class MeshEvent;
-class MeshTraceDescriptor;
-struct MeshBufferReadDescriptor;
-struct MeshReadEventDescriptor;
-struct MeshCoreDataReadDescriptor;
-
-using MeshCompletionReaderVariant =
-    std::variant<MeshBufferReadDescriptor, MeshReadEventDescriptor, MeshCoreDataReadDescriptor>;
-
+class MeshWorkload;
 class ShardDataTransfer;
 
 // THREAD SAFETY: All methods are thread safe.
@@ -77,33 +54,8 @@ public:
     MeshDevice* device() const { return mesh_device_; }
     uint32_t id() const { return id_; }
     virtual std::optional<MeshTraceId> trace_id() const = 0;
-    virtual WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) = 0;
     virtual void enqueue_mesh_workload(MeshWorkload& mesh_workload, bool blocking) = 0;
 
-    // Specifies host data to be written to or read from a MeshBuffer shard.
-    struct [[deprecated("Use distributed::ShardDataTransfer instead.")]] ShardDataTransfer {
-        MeshCoordinate shard_coord;
-        void* host_data = nullptr;
-        std::optional<BufferRegion> region;
-    };
-
-    // MeshBuffer Write APIs
-    virtual void enqueue_write_shard_to_sub_grid(
-        const MeshBuffer& buffer,
-        const void* host_data,
-        const MeshCoordinateRange& device_range,
-        bool blocking,
-        std::optional<BufferRegion> region = std::nullopt) = 0;
-    virtual void enqueue_write_mesh_buffer(
-        const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) = 0;
-    // If PinnedMemory is attached to a HostBuffer used within the enqueue_write, the contents of the memory must not be
-    // modified until the enqueue_write has completed on the device. This may be checked by any of
-    // * calling lock() on the PinnedMemory
-    // * setting the blocking parameter to true
-    // * calling finish() on the MeshCommandQueue
-    // * calling enqueue_record_event_to_host() and then waiting for the event to complete on the host.
-    virtual void enqueue_write(
-        const std::shared_ptr<MeshBuffer>& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) = 0;
     // If PinnedMemory is set on a ShardDataTransfer, the contents of the memory must not be modified until the
     // enqueue_write has completed on the device. This may be checked by any of
     // * calling lock() on the PinnedMemory
@@ -114,25 +66,19 @@ public:
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
         bool blocking) = 0;
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-    [[deprecated("Use enqueue_write_shards with distributed::ShardDataTransfer instead.")]]
-    void enqueue_write_shards(
-        const std::shared_ptr<MeshBuffer>& mesh_buffer,
-        const std::vector<ShardDataTransfer>& shard_data_transfers,
-        bool blocking);
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
 
-    // MeshBuffer Read APIs
+    // MeshBuffer Read/Write APIs
+    virtual void enqueue_write_mesh_buffer(
+        const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) = 0;
+    // If PinnedMemory is attached to a HostBuffer used within the enqueue_write, the contents of the memory must not be
+    // modified until the enqueue_write has completed on the device. This may be checked by any of
+    // * calling lock() on the PinnedMemory
+    // * setting the blocking parameter to true
+    // * calling finish() on the MeshCommandQueue
+    // * calling enqueue_record_event_to_host() and then waiting for the event to complete on the host.
+    virtual void enqueue_write(
+        const std::shared_ptr<MeshBuffer>& mesh_buffer, const DistributedHostBuffer& host_buffer, bool blocking) = 0;
+
     virtual void enqueue_read_mesh_buffer(
         void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) = 0;
     virtual void enqueue_read_shards(
@@ -145,23 +91,6 @@ public:
         DistributedHostBuffer& host_buffer,
         const std::optional<std::unordered_set<MeshCoordinate>>& shards,
         bool blocking) = 0;
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-    [[deprecated("Use enqueue_read_shards with distributed::ShardDataTransfer instead.")]]
-    void enqueue_read_shards(
-        const std::vector<ShardDataTransfer>& shard_data_transfers,
-        const std::shared_ptr<MeshBuffer>& mesh_buffer,
-        bool blocking);
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
 
     // MeshTensor Read/Write APIs
     tt::tt_metal::HostTensor enqueue_read_tensor(const tt::tt_metal::MeshTensor& device_tensor, bool blocking = true);
@@ -180,9 +109,6 @@ public:
         const std::optional<MeshCoordinateRange>& device_range = std::nullopt) = 0;
     virtual void enqueue_wait_for_event(const MeshEvent& sync_event) = 0;
     virtual void finish(ttsl::Span<const SubDeviceId> sub_device_ids = {}) = 0;
-    virtual void record_begin(const MeshTraceId& trace_id, const std::shared_ptr<MeshTraceDescriptor>& ctx) = 0;
-    virtual void record_end() = 0;
-    virtual void enqueue_trace(const MeshTraceId& trace_id, bool blocking) = 0;
 };
 
 // Specifies host data to be written to or read from a MeshBuffer shard.
@@ -196,22 +122,6 @@ private:
 
 public:
     explicit ShardDataTransfer(const MeshCoordinate& shard_coord) : shard_coord_(shard_coord) {}
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#elif defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-    explicit ShardDataTransfer(const MeshCommandQueue::ShardDataTransfer& shard_data_transfer) :
-        shard_coord_(shard_data_transfer.shard_coord),
-        host_data_(shard_data_transfer.host_data),
-        region_(shard_data_transfer.region) {}
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif
 
     MeshCoordinate shard_coord() const { return shard_coord_; }
     void* host_data() const { return host_data_; }

--- a/tt_metal/api/tt-metalium/mesh_device_view.hpp
+++ b/tt_metal/api/tt-metalium/mesh_device_view.hpp
@@ -14,7 +14,6 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/mesh_config.hpp>
 #include <tt-metalium/mesh_coord.hpp>
-#include <tt-metalium/shape2d.hpp>
 #include <tt-metalium/maybe_remote.hpp>
 #include <tt-metalium/experimental/fabric/routing_table_generator.hpp>
 
@@ -56,14 +55,10 @@ public:
     // Get devices spanning the region defined by `range` in row-major order with start/end coordinates inclusive
     [[nodiscard]] std::vector<IDevice*> get_devices(const MeshCoordinateRange& range) const;
     [[nodiscard]] std::vector<IDevice*> get_devices() const;
-    [[nodiscard]] std::vector<tt::tt_fabric::FabricNodeId> get_fabric_node_ids(const MeshCoordinateRange& range) const;
     [[nodiscard]] std::vector<tt::tt_fabric::FabricNodeId> get_fabric_node_ids() const;
     [[nodiscard]] size_t num_devices() const;
 
-    [[nodiscard]] bool empty() const noexcept;
-    [[nodiscard]] size_t size() const noexcept;
     [[nodiscard]] const MeshShape& shape() const noexcept;
-    [[nodiscard]] tt::tt_fabric::MeshId mesh_id() const noexcept;
     [[nodiscard]] bool contains(const MeshCoordinate& coord) const noexcept;
 
     // Returns `IDevice*` instance for `coord`.
@@ -72,13 +67,6 @@ public:
         "Deprecated, retrieving physical devices can fail in distributed contexts. This will be removed after "
         "28-02-2026.")]] [[nodiscard]] IDevice*
     get_device(const MeshCoordinate& coord) const;
-
-    // Returns `tt::tt_fabric::FabricNodeId` for `coord`.
-    // In multi-host context, fabric node IDs are always available, even for remote devices.
-    [[nodiscard]] tt::tt_fabric::FabricNodeId get_fabric_node_id(const MeshCoordinate& coord) const;
-
-    std::vector<MaybeRemote<IDevice*>>::const_iterator begin() const;
-    std::vector<MaybeRemote<IDevice*>>::const_iterator end() const;
 
     // Throws if no device corresponds to `device_id`.
     [[nodiscard]] MeshCoordinate find_device(ChipId device_id) const;
@@ -92,26 +80,8 @@ public:
     [[nodiscard]] std::vector<tt::tt_fabric::FabricNodeId> get_fabric_node_ids_on_row(size_t row) const;
     [[nodiscard]] std::vector<tt::tt_fabric::FabricNodeId> get_fabric_node_ids_on_column(size_t col) const;
 
-    // These utility methods linearize the set of devices in a mesh into a line or ring.
-    // Linearizing a mesh into a line asserts the condition that device[i-1] is connected to device[i].
-    // Linearizing a mesh into a ring asserts the condition that device[i-1] is connected to device[i] and device[0] is
-    // connected to device[-1].
-    //
-    // Given a starting coordinate, get the coordinates of a line of devices where device[i-1] is connected to device[i]
-    // The current support only provides left-to-right and right-to-left snaking of the line.
-    //
-    // Important: these utilities currently only support 2D meshes.
-    // TODO: #17477 - Remove the methods that assume 2D mesh.
-    [[nodiscard]] static std::vector<MeshCoordinate> get_line_coordinates(
-        size_t length, const Shape2D& mesh_shape, const Shape2D& mesh_offset);
-    [[nodiscard]] std::vector<MeshCoordinate> get_line_coordinates() const;
-    [[nodiscard]] static std::vector<MeshCoordinate> get_ring_coordinates(
-        const Shape2D& ring_shape, const Shape2D& mesh_shape);
-    [[nodiscard]] std::vector<MeshCoordinate> get_ring_coordinates() const;
     [[nodiscard]] std::vector<IDevice*> get_ring_devices() const;
-    [[nodiscard]] std::vector<IDevice*> get_line_devices() const;
     [[nodiscard]] std::vector<tt::tt_fabric::FabricNodeId> get_ring_fabric_node_ids() const;
-    [[nodiscard]] std::vector<tt::tt_fabric::FabricNodeId> get_line_fabric_node_ids() const;
 
     // Returns true if the view is fully local, i.e. all devices in the view are local.
     // Throws if the coordinate is out of bounds of this view.
@@ -119,10 +89,6 @@ public:
         "Deprecated, is_local should be avoided as it is likely to cause issues in distributed contexts. This will be "
         "removed after 28-02-2026.")]]
     bool is_local(const MeshCoordinate& coord) const;
-
-    // Returns the coordinate range of all local devices in this view.
-    // The range is a bounding box that encompasses all local coordinates.
-    MeshCoordinateRange get_local_mesh_coord_range() const;
 
     // Destructor
     ~MeshDeviceView();

--- a/tt_metal/api/tt-metalium/mesh_workload.hpp
+++ b/tt_metal/api/tt-metalium/mesh_workload.hpp
@@ -36,14 +36,8 @@ public:
     std::unordered_map<MeshCoordinateRange, Program>& get_programs();
     const std::unordered_map<MeshCoordinateRange, Program>& get_programs() const;
 
-    // For testing purposes only
-    void set_last_used_command_queue_for_testing(MeshCommandQueue* mesh_cq);
-    MeshCommandQueue* get_last_used_command_queue() const;
-    uint32_t get_sem_base_addr(std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type);
-    uint32_t get_sem_size(std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type);
-    uint32_t get_cb_base_addr(std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type);
-    uint32_t get_cb_size(std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type);
     MeshWorkloadImpl& impl() { return *pimpl_; }
+    const MeshWorkloadImpl& impl() const { return *pimpl_; }
 
 private:
     std::unique_ptr<MeshWorkloadImpl> pimpl_;

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -4,6 +4,8 @@
 
 #include <tt-metalium/experimental/sockets/d2h_socket.hpp>
 #include <internal/service/service_core_manager.hpp>
+#include <tt-metalium/host_buffer.hpp>
+#include <tt-metalium/memory_pin.hpp>
 #include "tt_metal/distributed/mesh_socket_utils.hpp"
 #include "tt_metal/distributed/named_shm.hpp"
 #include "tt_metal/distributed/hd_socket_connector_state.hpp"
@@ -236,8 +238,10 @@ void D2HSocket::write_socket_metadata(
     // External-config ctor skips MeshBuffer allocation; use direct L1 write. Standard
     // ctor owns config_buffer_; use fast-dispatch WriteShard like pre-RT-profiler path.
     if (config_buffer_) {
-        distributed::WriteShard(
-            mesh_device->mesh_command_queue(0), config_buffer_, config_data, sender_core_.device_coord, true);
+        mesh_device->mesh_command_queue(0).enqueue_write_shards(
+            config_buffer_,
+            {distributed::ShardDataTransfer{sender_core_.device_coord}.host_data(config_data.data())},
+            true);
     } else {
         IDevice* device = mesh_device->get_device(sender_core_.device_coord);
         tt::tt_metal::detail::WriteToDeviceL1(

--- a/tt_metal/distributed/distributed.cpp
+++ b/tt_metal/distributed/distributed.cpp
@@ -5,6 +5,7 @@
 #include <tt_stl/assert.hpp>
 #include <tt_stl/fmt.hpp>
 #include <tt-metalium/distributed.hpp>
+#include "event_query_impl.hpp"
 #include <utility>
 
 #include "device.hpp"
@@ -177,10 +178,6 @@ void Synchronize(MeshDevice* device, std::optional<uint8_t> cq_id, ttsl::Span<co
     } else {
         Synchronize(*device, std::nullopt, sub_device_ids);
     }
-}
-
-MeshTraceId BeginTraceCapture(MeshDevice* device, uint8_t cq_id) {
-    return device->begin_mesh_trace(device->mesh_command_queue(cq_id));
 }
 
 void Finish(MeshCommandQueue& mesh_cq, ttsl::Span<const SubDeviceId> sub_device_ids) {

--- a/tt_metal/distributed/distributed_host_buffer.cpp
+++ b/tt_metal/distributed/distributed_host_buffer.cpp
@@ -16,6 +16,7 @@
 #include "common/executor.hpp"
 #include "impl/context/metal_context.hpp"
 #include "tt_metal/distributed/distributed_coordinate_translator.hpp"
+#include "tt_metal/distributed/mesh_device_view_impl.hpp"
 
 namespace tt::tt_metal {
 
@@ -54,11 +55,11 @@ DistributedHostBuffer DistributedHostBuffer::create(const distributed::MeshDevic
     std::vector<distributed::MaybeRemote<Shard>> shards(
         mesh_device_view.shape().mesh_size(), distributed::MaybeRemote<Shard>::remote());
 
-    auto distributed_context =
-        tt::tt_metal::MetalContext::instance().get_control_plane().get_distributed_context(mesh_device_view.mesh_id());
+    auto distributed_context = tt::tt_metal::MetalContext::instance().get_control_plane().get_distributed_context(
+        mesh_device_view.impl().mesh_id());
 
     int shard_index = 0;
-    for (auto maybe_device : mesh_device_view) {
+    for (auto maybe_device : mesh_device_view.impl()) {
         maybe_device.if_local([&](const auto&) {
             shards[shard_index] = distributed::MaybeRemote<Shard>::local(Shard{.is_populated = false});
         });

--- a/tt_metal/distributed/event_query_impl.hpp
+++ b/tt_metal/distributed/event_query_impl.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/mesh_event.hpp>
+
+namespace tt::tt_metal::distributed {
+
+// Internal: no MeshCommandQueue equivalent yet (#26591).
+bool EventQuery(const MeshEvent& event);
+
+}  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -36,6 +36,7 @@
 #include "mesh_coord.hpp"
 #include "mesh_workload.hpp"
 #include "mesh_workload_impl.hpp"
+#include "mesh_device_view_impl.hpp"
 #include "sub_device/sub_device_manager_tracker.hpp"
 #include "tt-metalium/program.hpp"
 #include "shape2d.hpp"
@@ -575,7 +576,7 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     }
     // From the dispatcher's perspective, binaries are now committed to DRAM
     mesh_workload.impl().set_program_binary_status(mesh_device_id, ProgramBinaryStatus::Committed);
-    mesh_workload.set_last_used_command_queue_for_testing(this);
+    mesh_workload.impl().set_last_used_command_queue_for_testing(this);
 
     if (blocking) {
         this->finish_nolock({{sub_device_id}});
@@ -1330,7 +1331,7 @@ void FDMeshCommandQueue::record_end() {
 
     // Calculate device ranges that have an identical set of programs that run on them (including no programs at all).
     // Restrict to the local mesh partition so that multi-host traces only process locally-owned devices.
-    auto local_mesh_range = mesh_device_->get_view().get_local_mesh_coord_range();
+    auto local_mesh_range = mesh_device_->get_view().impl().get_local_mesh_coord_range();
     std::vector<MeshCoordinateRange> device_ranges{local_mesh_range};
     for (auto& trace_node : trace_nodes_) {
         for (auto& [device_range, program] : trace_node.trace_nodes) {

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -4,6 +4,8 @@
 
 #include <tt-metalium/experimental/sockets/h2d_socket.hpp>
 #include <internal/service/service_core_manager.hpp>
+#include <tt-metalium/host_buffer.hpp>
+#include <tt-metalium/memory_pin.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include "tt_metal/distributed/mesh_socket_utils.hpp"
 #include "tt_metal/distributed/named_shm.hpp"
@@ -258,8 +260,10 @@ void H2DSocket::write_socket_metadata(
         tt::tt_metal::detail::WriteToDeviceL1(
             device, recv_core_.core_coord, static_cast<uint32_t>(config_buffer_->address()), bytes);
     } else {
-        distributed::WriteShard(
-            mesh_device->mesh_command_queue(0), config_buffer_, config_data, recv_core_.device_coord, true);
+        mesh_device->mesh_command_queue(0).enqueue_write_shards(
+            config_buffer_,
+            {distributed::ShardDataTransfer{recv_core_.device_coord}.host_data(config_data.data())},
+            true);
     }
 }
 

--- a/tt_metal/distributed/maybe_remote_utils.hpp
+++ b/tt_metal/distributed/maybe_remote_utils.hpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <vector>
+
+#include <tt-metalium/maybe_remote.hpp>
+
+namespace tt::tt_metal {
+class IDevice;
+}  // namespace tt::tt_metal
+
+namespace tt::tt_metal::distributed {
+
+/**
+ * Concept to check if a type behaves like MaybeRemote.
+ *
+ * A type satisfies MaybeRemoteLike if it has:
+ * - A nested value_type type alias
+ * - An is_local() method that returns something convertible to bool
+ * - A value() method that returns exactly the value_type
+ */
+template <typename T>
+concept MaybeRemoteLike = requires(T t) {
+    typename T::value_type;
+    { t.is_local() } -> std::convertible_to<bool>;
+    { t.value() } -> std::same_as<typename T::value_type&>;
+};
+
+using MaybeRemoteDeviceId = MaybeRemote<int>;
+using MaybeRemoteDevice = MaybeRemote<IDevice*>;
+
+/**
+ * Extract all local values from a container of MaybeRemote objects.
+ *
+ * This function filters out remote devices and returns only the local values
+ * in a new vector.
+ *
+ * @tparam Container Any container type whose value_type satisfies MaybeRemoteLike
+ * @param container The container of MaybeRemote objects
+ * @return std::vector<T> containing only the local values
+ */
+template <typename Container>
+    requires MaybeRemoteLike<typename Container::value_type>
+[[nodiscard]] auto extract_locals(const Container& container) {
+    using MaybeRemoteType = typename Container::value_type;
+    using ValueType = typename MaybeRemoteType::value_type;
+
+    std::vector<ValueType> locals;
+    locals.reserve(container.size());
+
+    for (const auto& maybe : container) {
+        if (maybe.is_local()) {
+            locals.push_back(maybe.value());
+        }
+    }
+    return locals;
+}
+
+/**
+ * Wraps all local values from a container to a container with MaybeRemote objects.
+ *
+ * @tparam Container Any container type
+ * @param container The container of objects of type T
+ * @return std::vector<MaybeRemote<T>> containing the local values wrapped in MaybeRemote
+ */
+template <typename Container>
+[[nodiscard]] auto wrap_to_maybe_remote(const Container& container) {
+    using T = typename Container::value_type;
+    std::vector<MaybeRemote<T>> wrapped;
+    wrapped.reserve(container.size());
+    for (const auto& local : container) {
+        wrapped.push_back(MaybeRemote<T>::local(local));
+    }
+    return wrapped;
+}
+
+}  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -1,4 +1,3 @@
-
 // SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -15,6 +14,7 @@
 #include <tt-metalium/experimental/per_core_allocation/allocator_mode.hpp>
 #include "device.hpp"
 #include "impl/allocator/allocator.hpp"
+#include "mesh_buffer_impl.hpp"
 #include "mesh_device_impl.hpp"
 #include "impl/context/metal_context.hpp"
 
@@ -98,22 +98,18 @@ std::shared_ptr<MeshBuffer> MeshBuffer::create(
         mesh_buffer_config);
 
     if (mesh_device->get_view().get_devices().empty()) {
-        auto mesh_buffer =
-            std::shared_ptr<MeshBuffer>(new MeshBuffer(mesh_buffer_config, device_local_config, 0, 0, mesh_device));
-        mesh_buffer->initialize_device_buffers();
-        return mesh_buffer;
+        MeshBufferImpl impl(mesh_buffer_config, device_local_config, 0, 0, mesh_device);
+        impl.initialize_device_buffers();
+        return std::make_shared<MeshBuffer>(std::move(impl));
     }
-
-    std::shared_ptr<MeshBuffer> mesh_buffer;
 
     // Per-core allocation path: each device allocates independently
     if (per_core_allocation::is_per_core_allocation(device_local_config.sharding_args)) {
         TT_FATAL(!address.has_value(), "Per-core allocation does not support explicit address");
-        mesh_buffer = std::shared_ptr<MeshBuffer>(
-            new MeshBuffer(mesh_buffer_config, device_local_config, /*address=*/0, device_local_size, mesh_device));
+        MeshBufferImpl impl(mesh_buffer_config, device_local_config, /*address=*/0, device_local_size, mesh_device);
         // Per-core: each device allocates independently. The mesh-level lockstep allocator queries
         // device per-bank ranges at allocation time, so no explicit mirroring is needed.
-        for (auto& [coord, device_buffer] : mesh_buffer->buffers_) {
+        for (auto& [coord, device_buffer] : impl.buffers()) {
             if (!mesh_device->impl().is_local(coord)) {
                 continue;
             }
@@ -128,7 +124,10 @@ std::shared_ptr<MeshBuffer> MeshBuffer::create(
                 device_local_config.sub_device_id);
             device_buffer = MaybeRemote<std::shared_ptr<Buffer>>::local(std::move(buffer));
         }
-    } else if (!address.has_value()) {
+        return std::make_shared<MeshBuffer>(std::move(impl));
+    }
+
+    if (!address.has_value()) {
         // In HYBRID mode, set device-level allocators on the mesh allocator so it
         // can query their per-bank ranges and avoid regions occupied on any device.
         auto* mesh_allocator = mesh_device->allocator_impl().get();
@@ -157,19 +156,18 @@ std::shared_ptr<MeshBuffer> MeshBuffer::create(
             mesh_allocator->clear_hybrid_device_allocators();
         }
 
-        mesh_buffer = std::shared_ptr<MeshBuffer>(new MeshBuffer(
-            mesh_buffer_config, device_local_config, device_local_size, mesh_device, std::move(backing_buffer)));
-        mesh_buffer->initialize_device_buffers();
-    } else {
-        mesh_buffer = std::shared_ptr<MeshBuffer>(
-            new MeshBuffer(mesh_buffer_config, device_local_config, address.value(), device_local_size, mesh_device));
-        mesh_buffer->initialize_device_buffers();
+        MeshBufferImpl impl(
+            mesh_buffer_config, device_local_config, device_local_size, mesh_device, std::move(backing_buffer));
+        impl.initialize_device_buffers();
+        return std::make_shared<MeshBuffer>(std::move(impl));
     }
 
-    return mesh_buffer;
+    MeshBufferImpl impl(mesh_buffer_config, device_local_config, address.value(), device_local_size, mesh_device);
+    impl.initialize_device_buffers();
+    return std::make_shared<MeshBuffer>(std::move(impl));
 }
 
-void MeshBuffer::initialize_device_buffers() {
+void MeshBufferImpl::initialize_device_buffers() {
     auto init_device_buffer_at_address = [this](const MeshCoordinate& coord) {
         std::shared_ptr<Buffer> buffer = Buffer::create(
             device()->impl().get_device(coord),
@@ -219,7 +217,7 @@ void MeshBuffer::initialize_device_buffers() {
     }
 }
 
-bool MeshBuffer::is_allocated() const {
+bool MeshBufferImpl::is_allocated() const {
     if (std::holds_alternative<DeallocatedState>(state_)) {
         return false;
     }
@@ -229,9 +227,9 @@ bool MeshBuffer::is_allocated() const {
     return true;
 }
 
-MeshBuffer::~MeshBuffer() { deallocate(); }
+MeshBufferImpl::~MeshBufferImpl() { deallocate(); }
 
-MeshBuffer::MeshBuffer(MeshBuffer&& other) noexcept :
+MeshBufferImpl::MeshBufferImpl(MeshBufferImpl&& other) noexcept :
     config_(other.config_),
     device_local_config_(std::move(other.device_local_config_)),
     mesh_device_(std::move(other.mesh_device_)),
@@ -244,7 +242,7 @@ MeshBuffer::MeshBuffer(MeshBuffer&& other) noexcept :
     other.device_local_size_ = 0;
 }
 
-MeshBuffer& MeshBuffer::operator=(MeshBuffer&& other) noexcept {
+MeshBufferImpl& MeshBufferImpl::operator=(MeshBufferImpl&& other) noexcept {
     if (this != &other) {
         deallocate();
         config_ = other.config_;
@@ -262,7 +260,7 @@ MeshBuffer& MeshBuffer::operator=(MeshBuffer&& other) noexcept {
     return *this;
 }
 
-void MeshBuffer::deallocate() {
+void MeshBufferImpl::deallocate() {
     auto mesh_device = mesh_device_.lock();
     if (mesh_device) {
         // Check HYBRID mode via rtoptions rather than mesh_device->allocator_impl() because:
@@ -307,17 +305,17 @@ void MeshBuffer::deallocate() {
     state_ = DeallocatedState{};
 }
 
-MeshDevice* MeshBuffer::device() const {
+MeshDevice* MeshBufferImpl::device() const {
     auto device = mesh_device_.lock();
     TT_FATAL(device, "Can't get device from mesh buffer, already deallocated");
     return device.get();
 }
 
-Buffer* MeshBuffer::get_device_buffer(const MeshCoordinate& device_coord) const {
+Buffer* MeshBufferImpl::get_device_buffer(const MeshCoordinate& device_coord) const {
     return buffers_.at(device_coord).value().get();
 }
 
-Buffer* MeshBuffer::get_reference_buffer() const {
+Buffer* MeshBufferImpl::get_reference_buffer() const {
     for (const auto& buffer : buffers_.values()) {
         if (buffer.is_local()) {
             return buffer.value().get();
@@ -326,14 +324,14 @@ Buffer* MeshBuffer::get_reference_buffer() const {
     TT_THROW("MeshBuffer: Tried to get reference buffer, but no local buffer found");
 }
 
-Buffer* MeshBuffer::get_backing_buffer() const {
+Buffer* MeshBufferImpl::get_backing_buffer() const {
     if (const auto* owned_state = std::get_if<OwnedBufferState>(&state_)) {
         return owned_state->backing_buffer.get();
     }
     return nullptr;
 }
 
-DeviceAddr MeshBuffer::size() const {
+DeviceAddr MeshBufferImpl::size() const {
     return std::visit(
         ttsl::overloaded{
             [&](const ReplicatedBufferConfig& config) { return config.size; },
@@ -341,19 +339,19 @@ DeviceAddr MeshBuffer::size() const {
         config_);
 }
 
-MeshBufferLayout MeshBuffer::global_layout() const {
+MeshBufferLayout MeshBufferImpl::global_layout() const {
     return std::holds_alternative<ReplicatedBufferConfig>(config_) ? MeshBufferLayout::REPLICATED
                                                                    : MeshBufferLayout::SHARDED;
 }
 
-const ShardedBufferConfig& MeshBuffer::global_shard_spec() const {
+const ShardedBufferConfig& MeshBufferImpl::global_shard_spec() const {
     TT_FATAL(
         (global_layout() == MeshBufferLayout::SHARDED),
         "Can only query the global shard spec for a sharded MeshBuffer");
     return std::get<ShardedBufferConfig>(config_);
 }
 
-uint32_t MeshBuffer::datum_size_bytes() const {
+uint32_t MeshBufferImpl::datum_size_bytes() const {
     // Limitation for now.
     TT_FATAL(
         this->global_layout() == MeshBufferLayout::SHARDED,
@@ -361,7 +359,7 @@ uint32_t MeshBuffer::datum_size_bytes() const {
     return this->global_shard_spec().compute_datum_size_bytes();
 }
 
-Shape2D MeshBuffer::physical_shard_shape() const {
+Shape2D MeshBufferImpl::physical_shard_shape() const {
     TT_FATAL(
         this->global_layout() == MeshBufferLayout::SHARDED,
         "Can only query physical shard shape for buffers sharded across the Mesh");
@@ -369,12 +367,60 @@ Shape2D MeshBuffer::physical_shard_shape() const {
     return sharded_config.physical_shard_shape();
 }
 
-std::pair<bool, bool> MeshBuffer::replicated_dims() const {
+std::pair<bool, bool> MeshBufferImpl::replicated_dims() const {
     TT_FATAL(
         this->global_layout() == MeshBufferLayout::SHARDED,
         "Can only query replicated dims for buffers sharded across the Mesh");
     return this->global_shard_spec().replicated_dims();
 }
+
+MeshBuffer::MeshBuffer(MeshBufferImpl impl) : impl_(std::make_unique<MeshBufferImpl>(std::move(impl))) {}
+
+MeshBuffer::~MeshBuffer() = default;
+
+MeshBuffer::MeshBuffer(MeshBuffer&& other) noexcept = default;
+
+MeshBuffer& MeshBuffer::operator=(MeshBuffer&& other) noexcept = default;
+
+const MeshBufferImpl& MeshBuffer::impl() const {
+    TT_FATAL(impl_ != nullptr, "MeshBuffer has been moved from");
+    return *impl_;
+}
+
+MeshBufferImpl& MeshBuffer::impl() {
+    TT_FATAL(impl_ != nullptr, "MeshBuffer has been moved from");
+    return *impl_;
+}
+
+bool MeshBuffer::is_allocated() const { return impl().is_allocated(); }
+
+void MeshBuffer::deallocate() { impl().deallocate(); }
+
+MeshDevice* MeshBuffer::device() const { return impl().device(); }
+
+DeviceAddr MeshBuffer::size() const { return impl().size(); }
+
+DeviceAddr MeshBuffer::device_local_size() const { return impl().device_local_size(); }
+
+DeviceAddr MeshBuffer::address() const { return impl().address(); }
+
+MeshBufferLayout MeshBuffer::global_layout() const { return impl().global_layout(); }
+
+const MeshBufferConfig& MeshBuffer::global_config() const { return impl().global_config(); }
+
+const DeviceLocalBufferConfig& MeshBuffer::device_local_config() const { return impl().device_local_config(); }
+
+Buffer* MeshBuffer::get_device_buffer(const MeshCoordinate& device_coord) const {
+    return impl().get_device_buffer(device_coord);
+}
+
+Buffer* MeshBuffer::get_reference_buffer() const { return impl().get_reference_buffer(); }
+
+Buffer* MeshBuffer::get_backing_buffer() const { return impl().get_backing_buffer(); }
+
+uint32_t MeshBuffer::page_size() const { return impl().page_size(); }
+
+uint32_t MeshBuffer::num_pages() const { return impl().num_pages(); }
 
 AnyBuffer::AnyBuffer(std::shared_ptr<Buffer> buffer) : buffer_(buffer.get()), holder_(std::move(buffer)) {}
 AnyBuffer::AnyBuffer(std::shared_ptr<MeshBuffer> buffer) :

--- a/tt_metal/distributed/mesh_buffer_impl.hpp
+++ b/tt_metal/distributed/mesh_buffer_impl.hpp
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <stdint.h>
+#include <memory>
+#include <utility>
+#include <variant>
+
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/hal_types.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
+#include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/shape2d.hpp>
+
+namespace tt::tt_metal::distributed {
+
+// Implementation of `MeshBuffer`; owns the per-device buffers and the allocation state.
+// Only reachable through `MeshBuffer::impl()`.
+class MeshBufferImpl {
+public:
+    // Creates an owning `MeshBufferImpl`, backed by an allocation made through `backing_buffer`.
+    MeshBufferImpl(
+        const MeshBufferConfig& config,
+        const DeviceLocalBufferConfig& device_local_config,
+        DeviceAddr device_local_size,
+        MeshDevice* mesh_device,
+        std::shared_ptr<Buffer> backing_buffer) :
+        config_(config),
+        device_local_config_(device_local_config),
+        mesh_device_(mesh_device->shared_from_this()),
+        address_(backing_buffer->address()),
+        device_local_size_(device_local_size),
+        buffers_(MeshShape(mesh_device->shape())),
+        state_(OwnedBufferState{std::move(backing_buffer)}) {}
+
+    // Creates a non-owning `MeshBufferImpl` as "view" over an existing `address`.
+    MeshBufferImpl(
+        const MeshBufferConfig& config,
+        const DeviceLocalBufferConfig& device_local_config,
+        DeviceAddr address,
+        DeviceAddr device_local_size,
+        MeshDevice* mesh_device) :
+        config_(config),
+        device_local_config_(device_local_config),
+        mesh_device_(mesh_device->shared_from_this()),
+        address_(address),
+        device_local_size_(device_local_size),
+        buffers_(MeshShape(mesh_device->shape())),
+        state_(ExternallyOwnedState{}) {}
+
+    ~MeshBufferImpl();
+
+    MeshBufferImpl(const MeshBufferImpl&) = delete;
+    MeshBufferImpl& operator=(const MeshBufferImpl&) = delete;
+    MeshBufferImpl(MeshBufferImpl&& other) noexcept;
+    MeshBufferImpl& operator=(MeshBufferImpl&& other) noexcept;
+
+    // Creates the per-device buffers at `address_`. Must be called exactly once, right after construction.
+    void initialize_device_buffers();
+
+    // Returns true if the MeshBuffer is allocated. Note that MeshBuffer is created in the allocated state; either the
+    // destructor or the `deallocate` method deallocate the MeshBuffer.
+    bool is_allocated() const;
+
+    // Deallocates the MeshBuffer.
+    // TODO: Re-consider a need for explicit deallocation methods, as opposed to relying on RAII to clean up the
+    // resources.
+    void deallocate();
+
+    // Throws an exception if the corresponding MeshDevice is already deallocated
+    MeshDevice* device() const;
+    DeviceAddr size() const;
+    DeviceAddr device_local_size() const { return device_local_size_; }
+    DeviceAddr address() const { return address_; }
+
+    MeshBufferLayout global_layout() const;
+    const MeshBufferConfig& global_config() const { return config_; }
+
+    const ShardedBufferConfig& global_shard_spec() const;
+    const DeviceLocalBufferConfig& device_local_config() const { return device_local_config_; }
+
+    Buffer* get_device_buffer(const MeshCoordinate& device_coord) const;
+    Buffer* get_reference_buffer() const;
+    Buffer* get_backing_buffer() const;
+
+    uint32_t datum_size_bytes() const;
+    Shape2D physical_shard_shape() const;
+    std::pair<bool, bool> replicated_dims() const;
+    uint32_t page_size() const { return device_local_config_.page_size; }
+    uint32_t num_pages() const { return page_size() == 0 ? 0 : device_local_size_ / page_size(); }
+
+    // Direct access to the per-device buffers, for creation paths that populate them selectively.
+    DistributedMeshContainer<std::shared_ptr<Buffer>>& buffers() { return buffers_; }
+    const DistributedMeshContainer<std::shared_ptr<Buffer>>& buffers() const { return buffers_; }
+
+private:
+    MeshBufferConfig config_;
+    DeviceLocalBufferConfig device_local_config_;
+    std::weak_ptr<MeshDevice> mesh_device_;
+    DeviceAddr address_ = 0;
+    DeviceAddr device_local_size_ = 0;
+
+    DistributedMeshContainer<std::shared_ptr<Buffer>> buffers_;
+
+    // `MeshBufferState` specifies the state of the MeshBuffer. It can either be:
+    // 1. Owned - a single device buffer is responsible for providing the address for the entire mesh buffer.
+    // 2. Externally owned - the MeshBuffer was created as a view over an existing address.
+    // 3. Deallocated - the MeshBuffer is in the deallocated state.
+    struct OwnedBufferState {
+        std::shared_ptr<Buffer> backing_buffer;
+    };
+    struct ExternallyOwnedState {};
+    struct DeallocatedState {};
+    using MeshBufferState = std::variant<OwnedBufferState, ExternallyOwnedState, DeallocatedState>;
+    MeshBufferState state_;
+};
+
+}  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_command_queue_base.cpp
+++ b/tt_metal/distributed/mesh_command_queue_base.cpp
@@ -19,7 +19,9 @@
 #include "tt_metal/impl/dispatch/dispatch_query_manager.hpp"
 #include "tt_metal/impl/threading/thread_pool.hpp"
 #include "tt_cluster.hpp"
+#include "tt_target_device.hpp"
 #include "dispatch/dispatch_settings.hpp"
+#include "tt_metal/distributed/mesh_buffer_impl.hpp"
 #include "tt_metal/distributed/mesh_device_impl.hpp"
 
 namespace tt::tt_metal::distributed {
@@ -31,10 +33,10 @@ tt::TargetDevice MeshCommandQueueBase::get_target_device_type() const {
 }
 
 void MeshCommandQueueBase::write_sharded_buffer(const MeshBuffer& buffer, const void* src) {
-    auto global_buffer_shape = buffer.global_shard_spec().global_buffer_shape;
+    auto global_buffer_shape = buffer.impl().global_shard_spec().global_buffer_shape;
 
-    auto shard_shape = buffer.physical_shard_shape();
-    auto datum_size_bytes = buffer.datum_size_bytes();
+    auto shard_shape = buffer.impl().physical_shard_shape();
+    auto datum_size_bytes = buffer.impl().datum_size_bytes();
 
     auto stride_size_bytes = datum_size_bytes * global_buffer_shape.width();
     auto single_read_size = datum_size_bytes * shard_shape.width();
@@ -49,7 +51,7 @@ void MeshCommandQueueBase::write_sharded_buffer(const MeshBuffer& buffer, const 
     uint32_t device_x = 0;
     uint32_t device_y = 0;
     std::vector<uint32_t> shard_data = std::vector<uint32_t>(total_read_size_per_shard / sizeof(uint32_t), 0);
-    const auto& [height_replicated, width_replicated] = buffer.replicated_dims();
+    const auto& [height_replicated, width_replicated] = buffer.impl().replicated_dims();
     for (std::size_t shard_y = 0; shard_y < num_shards_y; shard_y++) {
         for (std::size_t shard_x = 0; shard_x < num_shards_x; shard_x++) {
             auto read_offset = (shard_x * single_read_size) + (shard_y * stride_size_bytes * shard_shape.height());
@@ -76,7 +78,7 @@ void MeshCommandQueueBase::write_sharded_buffer(const MeshBuffer& buffer, const 
                     }
                 }
             } else if (height_replicated or width_replicated) {
-                if (buffer.global_shard_spec().shard_orientation == ShardOrientation::ROW_MAJOR) {
+                if (buffer.impl().global_shard_spec().shard_orientation == ShardOrientation::ROW_MAJOR) {
                     for (auto replicated_device_y = 0; replicated_device_y < num_devices_y; replicated_device_y++) {
                         this->write_shard_to_device(
                             buffer,
@@ -98,7 +100,7 @@ void MeshCommandQueueBase::write_sharded_buffer(const MeshBuffer& buffer, const 
             } else {
                 this->write_shard_to_device(
                     buffer, MeshCoordinate(device_y, device_x), shard_data.data(), /*region=*/std::nullopt);
-                if (buffer.global_shard_spec().shard_orientation == ShardOrientation::ROW_MAJOR) {
+                if (buffer.impl().global_shard_spec().shard_orientation == ShardOrientation::ROW_MAJOR) {
                     if (++device_x == num_devices_x) {
                         device_x = 0;
                         ++device_y;
@@ -115,12 +117,12 @@ void MeshCommandQueueBase::write_sharded_buffer(const MeshBuffer& buffer, const 
 }
 
 void MeshCommandQueueBase::read_sharded_buffer(MeshBuffer& buffer, void* dst) {
-    const auto& [height_replicated, width_replicated] = buffer.replicated_dims();
+    const auto& [height_replicated, width_replicated] = buffer.impl().replicated_dims();
     TT_FATAL(
         not(height_replicated or width_replicated), "Cannot read a MeshBuffer that is replicated along any dimension.");
-    auto global_buffer_shape = buffer.global_shard_spec().global_buffer_shape;
-    auto shard_shape = buffer.physical_shard_shape();
-    auto datum_size_bytes = buffer.datum_size_bytes();
+    auto global_buffer_shape = buffer.impl().global_shard_spec().global_buffer_shape;
+    auto shard_shape = buffer.impl().physical_shard_shape();
+    auto datum_size_bytes = buffer.impl().datum_size_bytes();
 
     const auto stride_size_bytes = datum_size_bytes * global_buffer_shape.width();
     const auto single_write_size = datum_size_bytes * shard_shape.width();
@@ -157,7 +159,7 @@ void MeshCommandQueueBase::read_sharded_buffer(MeshBuffer& buffer, void* dst) {
                 local_offset++;
                 size_to_write -= single_write_size;
             }
-            if (buffer.global_shard_spec().shard_orientation == ShardOrientation::ROW_MAJOR) {
+            if (buffer.impl().global_shard_spec().shard_orientation == ShardOrientation::ROW_MAJOR) {
                 if (++device_x == num_devices_x) {
                     device_x = 0;
                     ++device_y;
@@ -402,34 +404,6 @@ void MeshCommandQueueBase::enqueue_read(
     }
 
     this->enqueue_read_shards_nolock(shard_data_transfers, buffer, blocking, std::move(memory_pins));
-}
-
-void MeshCommandQueue::enqueue_write_shards(
-    const std::shared_ptr<MeshBuffer>& mesh_buffer,
-    const std::vector<ShardDataTransfer>& shard_data_transfers,
-    bool blocking) {
-    std::vector<distributed::ShardDataTransfer> distributed_shard_data_transfers;
-    distributed_shard_data_transfers.reserve(shard_data_transfers.size());
-    for (const auto& shard_data_transfer : shard_data_transfers) {
-        distributed_shard_data_transfers.push_back(distributed::ShardDataTransfer{shard_data_transfer.shard_coord}
-                                                       .host_data(shard_data_transfer.host_data)
-                                                       .region(shard_data_transfer.region));
-    }
-    this->enqueue_write_shards(mesh_buffer, distributed_shard_data_transfers, blocking);
-}
-
-void MeshCommandQueue::enqueue_read_shards(
-    const std::vector<ShardDataTransfer>& shard_data_transfers,
-    const std::shared_ptr<MeshBuffer>& mesh_buffer,
-    bool blocking) {
-    std::vector<distributed::ShardDataTransfer> distributed_shard_data_transfers;
-    distributed_shard_data_transfers.reserve(shard_data_transfers.size());
-    for (const auto& shard_data_transfer : shard_data_transfers) {
-        distributed_shard_data_transfers.push_back(distributed::ShardDataTransfer{shard_data_transfer.shard_coord}
-                                                       .host_data(shard_data_transfer.host_data)
-                                                       .region(shard_data_transfer.region));
-    }
-    this->enqueue_read_shards(distributed_shard_data_transfers, mesh_buffer, blocking);
 }
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_command_queue_base.hpp
+++ b/tt_metal/distributed/mesh_command_queue_base.hpp
@@ -4,8 +4,10 @@
 
 #pragma once
 
-#include "mesh_command_queue.hpp"
+#include <tt-metalium/mesh_command_queue.hpp>
 
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/distributed_host_buffer.hpp>
 #include <tt-metalium/experimental/core_subset_write/mesh_command_queue.hpp>
 
 #include "tt_metal/impl/dispatch/vector_aligned.hpp"
@@ -14,10 +16,26 @@
 
 #include <tt_stl/assert.hpp>
 
-#include <mutex>
+#include <cstdint>
 #include <functional>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace tt {
+enum class TargetDevice : std::uint8_t;
+}  // namespace tt
+
+namespace tt::tt_metal {
+class IDevice;
+class ThreadPool;
+class WorkerConfigBufferMgr;
+}  // namespace tt::tt_metal
 
 namespace tt::tt_metal::distributed {
+
+class MeshTraceDescriptor;
 
 // Identifies one L1 location on one device of the mesh: (mesh coord, virtual
 // core, device address). Used by per-core enqueue APIs.
@@ -105,24 +123,25 @@ public:
         dispatch_thread_pool_(std::move(dispatch_thread_pool)),
         lock_api_function_(std::move(lock_api_function)) {}
 
+    virtual WorkerConfigBufferMgr& get_config_buffer_mgr(uint32_t index) = 0;
+
     void enqueue_write_shard_to_sub_grid(
         const MeshBuffer& buffer,
         const void* host_data,
         const MeshCoordinateRange& device_range,
         bool blocking,
-        std::optional<BufferRegion> region = std::nullopt) override;
+        std::optional<BufferRegion> region = std::nullopt);
     void enqueue_write_mesh_buffer(
         const std::shared_ptr<MeshBuffer>& buffer, const void* host_data, bool blocking) override;
-    void enqueue_write_shards(
-        const std::shared_ptr<MeshBuffer>& mesh_buffer,
-        const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
-        bool blocking) override;
     void enqueue_write(
         const std::shared_ptr<MeshBuffer>& mesh_buffer,
         const DistributedHostBuffer& host_buffer,
         bool blocking) override;
+    void enqueue_write_shards(
+        const std::shared_ptr<MeshBuffer>& mesh_buffer,
+        const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
+        bool blocking) override;
 
-    // MeshBuffer Read APIs
     void enqueue_read_mesh_buffer(void* host_data, const std::shared_ptr<MeshBuffer>& buffer, bool blocking) override;
     void enqueue_read_shards(
         const std::vector<distributed::ShardDataTransfer>& shard_data_transfers,
@@ -133,6 +152,10 @@ public:
         DistributedHostBuffer& host_buffer,
         const std::optional<std::unordered_set<MeshCoordinate>>& shards,
         bool blocking) override;
+
+    virtual void record_begin(const MeshTraceId& trace_id, const std::shared_ptr<MeshTraceDescriptor>& ctx) = 0;
+    virtual void record_end() = 0;
+    virtual void enqueue_trace(const MeshTraceId& trace_id, bool blocking) = 0;
 
     // Returns true if the CQ is in use (has had commands enqueued).
     virtual bool in_use() { return false; }
@@ -162,5 +185,9 @@ public:
     // May only be called after wait_for_completion has been called on both command queues on the device.
     virtual void finish_and_reset_in_use() {}
 };
+
+inline MeshCommandQueueBase& as_mesh_command_queue_base(MeshCommandQueue& cq) {
+    return static_cast<MeshCommandQueueBase&>(cq);
+}
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -15,6 +15,7 @@
 #include "impl/sub_device/sub_device_impl.hpp"
 #include <system_mesh.hpp>
 #include <maybe_remote.hpp>
+#include "maybe_remote_utils.hpp"
 #include <tt_metal.hpp>
 #include <tt-metalium/experimental/inspector.hpp>
 #include <tt-metalium/distributed.hpp>
@@ -148,7 +149,8 @@ decltype(auto) validate_and_get_reference_value(
 
 // Returns offset of the mesh device view in the system mesh.
 MeshCoordinate compute_system_mesh_offset(const MeshDeviceView& view) {
-    const auto origin_fabric_node_id = view.get_fabric_node_id(MeshCoordinate::zero_coordinate(view.shape().dims()));
+    const auto origin_fabric_node_id =
+        view.impl().get_fabric_node_id(MeshCoordinate::zero_coordinate(view.shape().dims()));
     const auto system_mesh_shape = MetalContext::instance().get_system_mesh().shape();
     for (const auto& coord : MeshCoordinateRange(system_mesh_shape)) {
         if (coord.to_linear_index(system_mesh_shape) == origin_fabric_node_id.chip_id) {
@@ -287,8 +289,9 @@ MeshDeviceImpl::MeshDeviceImpl(
     reader_thread_pool_(create_default_thread_pool(context_id_, extract_locals(scoped_devices_->root_devices()))),
     program_cache_(std::make_unique<program_cache::detail::ProgramCache>()) {
     Inspector::mesh_device_created(this, parent_mesh_ ? std::make_optional(parent_mesh_->id()) : std::nullopt);
-    const auto& mpi_context =
-        tt::tt_metal::MetalContext::instance(context_id_).get_control_plane().get_distributed_context(view_->mesh_id());
+    const auto& mpi_context = tt::tt_metal::MetalContext::instance(context_id_)
+                                  .get_control_plane()
+                                  .get_distributed_context(view_->impl().mesh_id());
     distributed_context_ =
         mpi_context->split(distributed::multihost::Color(id()), distributed::multihost::Key(*mpi_context->rank()));
 }
@@ -659,7 +662,7 @@ std::shared_ptr<MeshDevice> MeshDeviceImpl::create_submesh(
         } else {
             submesh_devices.push_back(MaybeRemote<IDevice*>::remote());
         }
-        submesh_fabric_node_ids.push_back(view_->get_fabric_node_id(coord));
+        submesh_fabric_node_ids.push_back(view_->impl().get_fabric_node_id(coord));
     }
 
     auto submesh = std::shared_ptr<MeshDevice>(new MeshDevice());
@@ -765,7 +768,7 @@ IDevice* MeshDeviceImpl::get_device(size_t row_idx, size_t col_idx) const {
 IDevice* MeshDeviceImpl::get_device(const MeshCoordinate& coord) const { return view_->impl().get_device(coord); }
 
 tt_fabric::FabricNodeId MeshDeviceImpl::get_fabric_node_id(const MeshCoordinate& coord) const {
-    return view_->get_fabric_node_id(coord);
+    return view_->impl().get_fabric_node_id(coord);
 }
 
 MeshCommandQueue& MeshDeviceImpl::mesh_command_queue(std::optional<uint8_t> cq_id) const {
@@ -843,7 +846,7 @@ void MeshDeviceImpl::reshape(const MeshShape& new_shape) {
     // - Row-major order will be: [0,1,3,2]
     std::unordered_set<tt::tt_fabric::FabricNodeId> current_fabric_nodes;
     for (const auto& coord : MeshCoordinateRange(view_->shape())) {
-        current_fabric_nodes.insert(view_->get_fabric_node_id(coord));
+        current_fabric_nodes.insert(view_->impl().get_fabric_node_id(coord));
     }
 
     // From an MxN mesh, we can always reduce rank to a 1xM*N Line mesh.
@@ -853,12 +856,12 @@ void MeshDeviceImpl::reshape(const MeshShape& new_shape) {
     new_device_order.reserve(num_devices);
     new_fabric_node_ids.reserve(num_devices);
     if (new_shape.is_line_topology()) {
-        auto line_coords = view_->get_line_coordinates();
+        auto line_coords = view_->impl().get_line_coordinates();
         for (const auto& coord : line_coords) {
             new_device_order.push_back(
                 view_->impl().is_local(coord) ? MaybeRemote<IDevice*>::local(this->get_device(coord))
                                               : MaybeRemote<IDevice*>::remote());
-            new_fabric_node_ids.push_back(view_->get_fabric_node_id(coord));
+            new_fabric_node_ids.push_back(view_->impl().get_fabric_node_id(coord));
         }
     } else {
         // Do our best at requesting a new set of mapped devices from system mesh, starting at the offset of the first
@@ -1940,7 +1943,7 @@ bool MeshDevice::is_local(const MeshCoordinate& coord) const { return pimpl_->is
 const MeshShape& MeshDevice::shape() const { return pimpl_->shape(); }
 void MeshDevice::reshape(const MeshShape& new_shape) { pimpl_->reshape(new_shape); }
 const MeshDeviceView& MeshDevice::get_view() const { return pimpl_->get_view(); }
-uint32_t MeshDevice::get_system_mesh_id() const { return *get_view().mesh_id(); }
+uint32_t MeshDevice::get_system_mesh_id() const { return *get_view().impl().mesh_id(); }
 std::string MeshDevice::to_string() const { return pimpl_->to_string(); }
 bool MeshDevice::is_parent_mesh() const { return pimpl_->is_parent_mesh(); }
 const std::shared_ptr<MeshDevice>& MeshDevice::get_parent_mesh() const { return pimpl_->get_parent_mesh(); }

--- a/tt_metal/distributed/mesh_device_view.cpp
+++ b/tt_metal/distributed/mesh_device_view.cpp
@@ -25,6 +25,7 @@
 #include "shape2d.hpp"
 #include "shape_base.hpp"
 #include <tt-metalium/maybe_remote.hpp>
+#include "maybe_remote_utils.hpp"
 
 namespace tt::tt_metal::distributed {
 namespace {
@@ -481,10 +482,6 @@ std::vector<IDevice*> MeshDeviceView::get_devices(const MeshCoordinateRange& ran
 
 std::vector<IDevice*> MeshDeviceView::get_devices() const { return pimpl_->get_devices(); }
 
-std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_fabric_node_ids(const MeshCoordinateRange& range) const {
-    return pimpl_->get_fabric_node_ids(range);
-}
-
 std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_fabric_node_ids() const {
     return pimpl_->get_fabric_node_ids();
 }
@@ -503,21 +500,11 @@ std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_fabric_node_ids_on_
     return pimpl_->get_fabric_node_ids_on_column(col);
 }
 
-bool MeshDeviceView::empty() const noexcept { return pimpl_->empty(); }
-
-size_t MeshDeviceView::size() const noexcept { return pimpl_->size(); }
-
 const MeshShape& MeshDeviceView::shape() const noexcept { return pimpl_->shape(); }
-
-tt::tt_fabric::MeshId MeshDeviceView::mesh_id() const noexcept { return pimpl_->mesh_id(); }
 
 bool MeshDeviceView::contains(const MeshCoordinate& coord) const noexcept { return pimpl_->contains(coord); }
 
 IDevice* MeshDeviceView::get_device(const MeshCoordinate& coord) const { return pimpl_->get_device(coord); }
-
-tt::tt_fabric::FabricNodeId MeshDeviceView::get_fabric_node_id(const MeshCoordinate& coord) const {
-    return pimpl_->get_fabric_node_id(coord);
-}
 
 size_t MeshDeviceView::num_rows() const { return pimpl_->num_rows(); }
 
@@ -529,37 +516,12 @@ MeshCoordinate MeshDeviceView::find_device(ChipId device_id) const { return pimp
 
 bool MeshDeviceView::is_mesh_2d() const { return pimpl_->is_mesh_2d(); }
 
-std::vector<MeshCoordinate> MeshDeviceView::get_line_coordinates(
-    size_t length, const Shape2D& mesh_shape, const Shape2D& mesh_offset) {
-    return MeshDeviceViewImpl::get_line_coordinates(length, mesh_shape, mesh_offset);
-}
-
-std::vector<MeshCoordinate> MeshDeviceView::get_line_coordinates() const { return pimpl_->get_line_coordinates(); }
-
-std::vector<MeshCoordinate> MeshDeviceView::get_ring_coordinates(const Shape2D& ring_shape, const Shape2D& mesh_shape) {
-    return MeshDeviceViewImpl::get_ring_coordinates(ring_shape, mesh_shape);
-}
-
-std::vector<MeshCoordinate> MeshDeviceView::get_ring_coordinates() const { return pimpl_->get_ring_coordinates(); }
-
-std::vector<IDevice*> MeshDeviceView::get_line_devices() const { return pimpl_->get_line_devices(); }
-
 std::vector<IDevice*> MeshDeviceView::get_ring_devices() const { return pimpl_->get_ring_devices(); }
-
-std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_line_fabric_node_ids() const {
-    return pimpl_->get_line_fabric_node_ids();
-}
 
 std::vector<tt::tt_fabric::FabricNodeId> MeshDeviceView::get_ring_fabric_node_ids() const {
     return pimpl_->get_ring_fabric_node_ids();
 }
 
 bool MeshDeviceView::is_local(const MeshCoordinate& coord) const { return pimpl_->is_local(coord); }
-
-MeshCoordinateRange MeshDeviceView::get_local_mesh_coord_range() const { return pimpl_->get_local_mesh_coord_range(); }
-
-std::vector<MaybeRemote<IDevice*>>::const_iterator MeshDeviceView::begin() const { return pimpl_->begin(); }
-
-std::vector<MaybeRemote<IDevice*>>::const_iterator MeshDeviceView::end() const { return pimpl_->end(); }
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/mesh_device_view_impl.hpp
+++ b/tt_metal/distributed/mesh_device_view_impl.hpp
@@ -16,6 +16,7 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/shape2d.hpp>
 #include <tt-metalium/maybe_remote.hpp>
+#include "maybe_remote_utils.hpp"
 #include <tt-metalium/experimental/fabric/routing_table_generator.hpp>
 
 namespace tt::tt_metal::distributed {

--- a/tt_metal/distributed/mesh_socket_utils.cpp
+++ b/tt_metal/distributed/mesh_socket_utils.cpp
@@ -434,7 +434,8 @@ void write_socket_configs(
                     config_data[receiver_enc_offset + 3] = recv_virtual_core.x;  // downstream_noc_x
                 }
             }
-            distributed::WriteShard(mesh_device->mesh_command_queue(0), config_buffer, config_data, device_coord, true);
+            mesh_device->mesh_command_queue(0).enqueue_write_shards(
+                config_buffer, {distributed::ShardDataTransfer{device_coord}.host_data(config_data.data())}, true);
         }
     } else {
         std::vector<receiver_socket_md> config_data(
@@ -479,7 +480,8 @@ void write_socket_configs(
                 md.d2d.upstream_bytes_acked_addr = peer_config_buf_addr + sender_size.md_size_bytes +
                                                    sender_size.ack_size_bytes * receiver_ids_per_sender.at(connection);
             }
-            distributed::WriteShard(mesh_device->mesh_command_queue(0), config_buffer, config_data, device_coord, true);
+            mesh_device->mesh_command_queue(0).enqueue_write_shards(
+                config_buffer, {distributed::ShardDataTransfer{device_coord}.host_data(config_data.data())}, true);
         }
     }
 }

--- a/tt_metal/distributed/mesh_trace.cpp
+++ b/tt_metal/distributed/mesh_trace.cpp
@@ -5,6 +5,7 @@
 #include "mesh_trace.hpp"
 
 #include <mesh_command_queue.hpp>
+#include "tt_metal/distributed/mesh_command_queue_base.hpp"
 #include <mesh_coord.hpp>
 #include <cstdint>
 #include <tt-metalium/allocator.hpp>
@@ -33,8 +34,8 @@
 #include "tt_metal/impl/dispatch/device_command.hpp"
 #include "tt_metal/impl/trace/dispatch.hpp"
 #include "impl/allocator/allocator.hpp"
+#include <distributed/mesh_buffer_impl.hpp>
 #include <distributed/mesh_device_impl.hpp>
-
 namespace tt::tt_metal::distributed {
 
 MeshTraceId MeshTrace::next_id() {
@@ -159,7 +160,7 @@ void MeshTrace::populate_mesh_buffer(
         }
         auto write_region =
             BufferRegion(write_offset_per_device_range.at(device_range), write_data.size() * sizeof(uint32_t));
-        mesh_cq.enqueue_write_shard_to_sub_grid(
+        as_mesh_command_queue_base(mesh_cq).enqueue_write_shard_to_sub_grid(
             *(trace_buffer->mesh_buffer), write_data.data(), device_range, true, write_region);
         write_offset_per_device_range.at(device_range) += mesh_trace_data.data.size() * sizeof(uint32_t);
     }

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -5,6 +5,7 @@
 #include <mesh_buffer.hpp>
 #include <tt_stl/fmt.hpp>
 #include <mesh_command_queue.hpp>
+#include "tt_metal/distributed/mesh_command_queue_base.hpp"
 #include <mesh_workload.hpp>
 #include <cstdint>
 #include <tt_metal/impl/program/program_command_sequence.hpp>
@@ -44,7 +45,6 @@
 #include <umd/device/types/core_coordinates.hpp>
 #include <impl/dispatch/dispatch_core_manager.hpp>
 #include <impl/dispatch/dispatch_mem_map.hpp>
-
 namespace tt::tt_metal {
 class IDevice;
 class Kernel;
@@ -163,7 +163,7 @@ void MeshWorkloadImpl::load_binaries(MeshCommandQueue& mesh_cq) {
             };
             kernel_bin_buf_ =
                 MeshBuffer::create(global_kernel_bin_buf_config, device_local_kernel_bin_buf_config, mesh_device);
-            // Iterate over the sub-grids and EnqueueWriteMeshBuffer to each sub-grid that runs an individual program
+            // Iterate over the sub-grids and write to each sub-grid that runs an individual program
             for (auto& [device_range, program] : this->programs_) {
                 std::size_t kernel_bin_size =
                     program.impl().get_program_transfer_info().binary_data.size() * sizeof(uint32_t);
@@ -174,7 +174,7 @@ void MeshWorkloadImpl::load_binaries(MeshCommandQueue& mesh_cq) {
                     mesh_device,
                     kernel_bin_buf_->address());
 
-                mesh_cq.enqueue_write_shard_to_sub_grid(
+                as_mesh_command_queue_base(mesh_cq).enqueue_write_shard_to_sub_grid(
                     *kernel_bin_buf_view,
                     program.impl().get_program_transfer_info().binary_data.data(),
                     device_range,
@@ -436,33 +436,6 @@ std::unordered_map<MeshCoordinateRange, Program>& MeshWorkload::get_programs() {
 
 const std::unordered_map<MeshCoordinateRange, Program>& MeshWorkload::get_programs() const {
     return pimpl_->get_programs();
-}
-
-// For testing purposes only
-void MeshWorkload::set_last_used_command_queue_for_testing(MeshCommandQueue* mesh_cq) {
-    pimpl_->set_last_used_command_queue_for_testing(mesh_cq);
-}
-
-MeshCommandQueue* MeshWorkload::get_last_used_command_queue() const { return pimpl_->get_last_used_command_queue(); }
-
-uint32_t MeshWorkload::get_sem_base_addr(
-    std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type) {
-    return pimpl_->get_sem_base_addr(mesh_device, logical_core, core_type);
-}
-
-uint32_t MeshWorkload::get_sem_size(
-    std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type) {
-    return pimpl_->get_sem_size(mesh_device, logical_core, core_type);
-}
-
-uint32_t MeshWorkload::get_cb_base_addr(
-    std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type) {
-    return pimpl_->get_cb_base_addr(mesh_device, logical_core, core_type);
-}
-
-uint32_t MeshWorkload::get_cb_size(
-    std::shared_ptr<MeshDevice>& mesh_device, CoreCoord logical_core, CoreType core_type) {
-    return pimpl_->get_cb_size(mesh_device, logical_core, core_type);
 }
 
 }  // namespace tt::tt_metal::distributed

--- a/tt_metal/distributed/pinned_memory.cpp
+++ b/tt_metal/distributed/pinned_memory.cpp
@@ -14,6 +14,7 @@
 #include <unistd.h>
 
 #include <tt-metalium/device.hpp>
+#include <tt-metalium/host_buffer.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/mesh_event.hpp>
 #include <tt-metalium/distributed.hpp>

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <system_mesh.hpp>
 #include <tt-metalium/mesh_device_view.hpp>
+#include "mesh_device_view_impl.hpp"
 #include <tt-metalium/shape2d.hpp>
 #include <tt-metalium/distributed_context.hpp>
 #include <algorithm>
@@ -185,7 +186,7 @@ SystemMesh::MappedDevices SystemMesh::Impl::get_mapped_devices(
 
         auto line_length = requested_shape.mesh_size();
         for (const auto& logical_coordinate :
-             MeshDeviceView::get_line_coordinates(line_length, system_mesh_2d, system_offset_2d)) {
+             MeshDeviceViewImpl::get_line_coordinates(line_length, system_mesh_2d, system_offset_2d)) {
             const auto mapped_device = get_system_mapped_device(logical_coordinate);
             mapped_devices.device_ids.push_back(mapped_device.device_id);
             mapped_devices.fabric_node_ids.push_back(mapped_device.fabric_node_id);

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -32,15 +32,14 @@
 #include <vector>
 
 #include "distributed.hpp"
+#include <tt-metalium/mesh_buffer.hpp>
 #include "hal_types.hpp"
-#include "mesh_buffer.hpp"
 #include "mesh_device.hpp"
 #include <tt_stl/reflection.hpp>
 #include "impl/context/metal_context.hpp"
 #include "llrt/metal_soc_descriptor.hpp"
 #include "llrt/tt_cluster.hpp"
 #include <umd/device/types/xy_pair.hpp>
-
 namespace tt::tt_metal::experimental {
 
 namespace {
@@ -247,7 +246,7 @@ void GlobalCircularBuffer::initialize_dram_sender_state_block(
 
     // Host writes to a DRAM core's L1 go over NOC and need the DRAM-L1 NOC offset
     // added on top of the local L1 address. (Worker L1 has local==NOC space so the
-    // EnqueueWriteMeshBuffer path used for the receiver-side config buffer doesn't
+    // enqueue_write_mesh_buffer path used for the receiver-side config buffer doesn't
     // need this; DRAM-core L1 sits at a high NOC offset on Blackhole.)
     auto& metal_ctx = MetalContext::instance(context_id);
     const uint64_t dram_l1_noc_offset = metal_ctx.hal().get_l1_noc_offset(HalProgrammableCoreType::DRAM);
@@ -406,8 +405,8 @@ void GlobalCircularBuffer::setup_cb_buffers(BufferType buffer_type, uint32_t max
         }
     }
     auto mesh_buffer = cb_config_buffer_.get_mesh_buffer();
-    distributed::EnqueueWriteMeshBuffer(
-        mesh_buffer->device()->mesh_command_queue(), mesh_buffer, cb_config_host_buffer, false);
+    mesh_buffer->device()->mesh_command_queue().enqueue_write_mesh_buffer(
+        mesh_buffer, cb_config_host_buffer.data(), false);
 }
 
 const Buffer& GlobalCircularBuffer::cb_buffer() const { return *cb_buffer_.get_buffer(); }

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -17,11 +17,11 @@
 #include <variant>
 #include <vector>
 
+#include <tt-metalium/mesh_buffer.hpp>
 #include "global_semaphore_impl.hpp"
 #include "mesh_device.hpp"
 #include <tt_stl/reflection.hpp>
 #include "impl/context/metal_context.hpp"
-
 namespace tt::tt_metal {
 
 // GlobalSemaphoreImpl implementation
@@ -66,8 +66,7 @@ void GlobalSemaphoreImpl::reset_semaphore_value(uint32_t reset_value) const {
     bool using_fast_dispatch = MetalContext::instance().rtoptions().get_fast_dispatch();
     bool using_simulator = MetalContext::instance().rtoptions().get_simulator_enabled();
     if (using_fast_dispatch && !using_simulator) {
-        distributed::EnqueueWriteMeshBuffer(
-            mesh_buffer->device()->mesh_command_queue(), mesh_buffer, host_buffer, true);
+        mesh_buffer->device()->mesh_command_queue().enqueue_write_mesh_buffer(mesh_buffer, host_buffer.data(), true);
     } else {
         auto* mesh_device = mesh_buffer->device();
         for (const auto& coord : distributed::MeshCoordinateRange(mesh_device->shape())) {

--- a/tt_metal/impl/buffers/global_semaphore_impl.hpp
+++ b/tt_metal/impl/buffers/global_semaphore_impl.hpp
@@ -10,6 +10,7 @@
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/hal_types.hpp>
+
 #include <tt-metalium/mesh_buffer.hpp>
 
 namespace tt::tt_metal {

--- a/tt_metal/impl/per_core_allocation/mesh_buffer.cpp
+++ b/tt_metal/impl/per_core_allocation/mesh_buffer.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt_stl/overloaded.hpp>
+#include "distributed/mesh_buffer_impl.hpp"
 #include "distributed/mesh_device_impl.hpp"
 
 namespace tt::tt_metal::experimental::per_core_allocation {
@@ -47,8 +48,8 @@ std::shared_ptr<distributed::MeshBuffer> create_on_single_device(
         mesh_buffer_config);
 
     // Create a non-owning MeshBuffer — each device buffer will own its own allocation.
-    auto mesh_buffer = std::shared_ptr<distributed::MeshBuffer>(new distributed::MeshBuffer(
-        mesh_buffer_config, device_local_config, /*address=*/0, device_local_size, mesh_device));
+    distributed::MeshBufferImpl impl(
+        mesh_buffer_config, device_local_config, /*address=*/0, device_local_size, mesh_device);
 
     // Only allocate on the target device.
     TT_FATAL(mesh_device->impl().is_local(coord), "Target device coordinate must be local");
@@ -62,8 +63,8 @@ std::shared_ptr<distributed::MeshBuffer> create_on_single_device(
         device_local_config.bottom_up,
         device_local_config.sub_device_id);
 
-    mesh_buffer->buffers_.at(coord) = distributed::MaybeRemote<std::shared_ptr<Buffer>>::local(std::move(buffer));
-    return mesh_buffer;
+    impl.buffers().at(coord) = distributed::MaybeRemote<std::shared_ptr<Buffer>>::local(std::move(buffer));
+    return std::make_shared<distributed::MeshBuffer>(std::move(impl));
 }
 
 }  // namespace tt::tt_metal::experimental::per_core_allocation

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -14,6 +14,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/mesh_command_queue.hpp>
+#include "tt_metal/distributed/mesh_command_queue_base.hpp"
 #include <tt_align.hpp>
 #include <algorithm>
 #include <cstdint>
@@ -3414,7 +3415,9 @@ uint32_t program_base_addr_on_core(
         sub_device_ids.size() == 1, "get_sem_base_addr currently only supports programs spanning a single sub-device");
     auto sub_device_index = **sub_device_ids.begin();
     auto* cq = mesh_workload.get_last_used_command_queue();
-    return cq ? (cq->get_config_buffer_mgr(sub_device_index).get_last_slot_addr(programmable_core_type))
+    return cq ? (distributed::as_mesh_command_queue_base(*cq)
+                     .get_config_buffer_mgr(sub_device_index)
+                     .get_last_slot_addr(programmable_core_type))
               : MetalContext::instance().hal().get_dev_addr(programmable_core_type, HalL1MemAddrType::KERNEL_CONFIG);
 }
 

--- a/tt_metal/impl/tensor/byte_based_data_transfer_apis.cpp
+++ b/tt_metal/impl/tensor/byte_based_data_transfer_apis.cpp
@@ -5,7 +5,6 @@
 #include <tt-metalium/experimental/byte_based_tensor_transfers.hpp>
 
 #include "mesh_tensor_impl.hpp"
-
 namespace tt::tt_metal {
 
 void enqueue_read_tensor(

--- a/tt_metal/impl/tensor/distributed_tensor_apis.cpp
+++ b/tt_metal/impl/tensor/distributed_tensor_apis.cpp
@@ -16,7 +16,6 @@
 #include <tt-metalium/mesh_device.hpp>
 #include "tt_metal/distributed/pinned_memory_cache.hpp"
 #include "tt_metal/distributed/mesh_device_view_impl.hpp"
-
 namespace tt::tt_metal {
 
 // ======================================================================================

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -70,7 +70,7 @@ HostTensor distributed::MeshCommandQueue::enqueue_read_tensor(const MeshTensor& 
         },
         DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
 
-    enqueue_read(mesh_buffer, distributed_host_buffer, /*shards=*/std::nullopt, blocking);
+    this->enqueue_read(mesh_buffer, distributed_host_buffer, /*shards=*/std::nullopt, blocking);
 
     return host_tensor_from_buffer_with_topology(
         std::move(distributed_host_buffer), device_tensor.tensor_spec(), get_tensor_topology(device_tensor));
@@ -145,7 +145,7 @@ void distributed::MeshCommandQueue::enqueue_read_tensor(
         });
     }
 
-    enqueue_read(mesh_buffer, dst_distributed_host_buffer, /*shards=*/std::nullopt, blocking);
+    this->enqueue_read(mesh_buffer, dst_distributed_host_buffer, /*shards=*/std::nullopt, blocking);
     update_tensor_topology(host_tensor, get_tensor_topology(device_tensor));
 }
 
@@ -212,10 +212,10 @@ void distributed::MeshCommandQueue::enqueue_write_tensor(const HostTensor& host_
         if (any_pinned) {
             enqueue_write_shards(mesh_buffer, transfers, /*blocking=*/true);
         } else {
-            enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
+            this->enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
         }
     } else {
-        enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
+        this->enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
     }
 
     device_tensor = mesh_tensor_from_buffer_with_topology(

--- a/tt_metal/programming_examples/NoC_tile_transfer/noc_tile_transfer.cpp
+++ b/tt_metal/programming_examples/NoC_tile_transfer/noc_tile_transfer.cpp
@@ -8,7 +8,6 @@
 
 #include <cstdint>
 #include <vector>
-
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
 #endif
@@ -59,7 +58,7 @@ int main() {
     // Source data preparation and DRAM transfer
     const uint16_t input_data = 14;  // Example input data
     std::vector<uint16_t> src_vec(buffer_config.size / sizeof(uint16_t), input_data);
-    distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, src_vec, false);
+    cq.enqueue_write_mesh_buffer(src_dram_buffer, src_vec.data(), false);
 
     // L1 circular buffer setup
     constexpr uint32_t src0_cb_index = CBIndex::c_0;
@@ -115,8 +114,8 @@ int main() {
     distributed::Finish(cq);
 
     // Data transfer back to host machine
-    std::vector<uint16_t> result_vec;
-    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, true);
+    std::vector<uint16_t> result_vec(dst_dram_buffer->device_local_size() / sizeof(uint16_t));
+    cq.enqueue_read_mesh_buffer((result_vec).data(), dst_dram_buffer, true);
 
     fmt::print("Result = {} : Expected = {}\n", result_vec[0], input_data);
 

--- a/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_compute/add_2_integers_in_compute.cpp
@@ -8,7 +8,6 @@
 #include <tt-metalium/bfloat16.hpp>
 #include "tt-metalium/constants.hpp"
 #include <tt-metalium/distributed.hpp>
-
 using namespace tt;
 using namespace tt::tt_metal;
 #ifndef OVERRIDE_KERNEL_PREFIX
@@ -133,8 +132,8 @@ int main() {
     // is not released before the operation is complete.
     // In this case, we will wait for the program to finish eventually in the same scope, so we can set it
     // to false safely.
-    EnqueueWriteMeshBuffer(cq, src0_dram_buffer, src0_vec, false);
-    EnqueueWriteMeshBuffer(cq, src1_dram_buffer, src1_vec, false);
+    cq.enqueue_write_mesh_buffer(src0_dram_buffer, src0_vec.data(), false);
+    cq.enqueue_write_mesh_buffer(src1_dram_buffer, src1_vec.data(), false);
 
     // Setup arguments for the kernels in the program.
     // Unlike OpenCL/CUDA, every kernel can have its own set of arguments.
@@ -151,11 +150,9 @@ int main() {
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::Finish(cq);
 
-    // Data can be read from a MeshBuffer using the ReadShard function. This function is used to read data from a
-    // specific shard of a MeshBuffer. The shard is specified by the MeshCoordinate. The last argument indicates if the
-    // operation is blocking or not.
-    std::vector<bfloat16> result_vec;
-    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, true);
+    // Read the destination MeshBuffer back to host (blocking).
+    std::vector<bfloat16> result_vec(dst_dram_buffer->device_local_size() / sizeof(bfloat16));
+    cq.enqueue_read_mesh_buffer((result_vec).data(), dst_dram_buffer, true);
 
     // compare the results with the expected values.
     bool success = true;

--- a/tt_metal/programming_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.cpp
+++ b/tt_metal/programming_examples/add_2_integers_in_riscv/add_2_integers_in_riscv.cpp
@@ -7,7 +7,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
-
 using namespace tt;
 using namespace tt::tt_metal;
 #ifndef OVERRIDE_KERNEL_PREFIX
@@ -79,8 +78,8 @@ int main() {
     // write operation should block until the data is written to the device. In this case, we set it to false for
     // asynchronous writes, allowing the program to continue executing while the data is being written. This is
     // recommended for most writes to device in applications to improve performance.
-    EnqueueWriteMeshBuffer(cq, src0_dram_buffer, src0_vec, /*blocking=*/false);
-    EnqueueWriteMeshBuffer(cq, src1_dram_buffer, src1_vec, /*blocking=*/false);
+    cq.enqueue_write_mesh_buffer(src0_dram_buffer, src0_vec.data(), false);
+    cq.enqueue_write_mesh_buffer(src1_dram_buffer, src1_vec.data(), false);
 
     // Create the kernel (code that runs on the Tensix core) that will perform the addition of the 2 integers.
     // The Data Movement cores are the only cores that can read/write data from/to DRAM. Thus we use them for
@@ -113,12 +112,11 @@ int main() {
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
 
-    // Read a shard of the destination MeshBuffer back to host.
-    // ReadShard reads from a specific device identified by MeshCoordinate; the last argument controls blocking.
+    // Read the destination MeshBuffer back to host.
     // This time we set blocking=true since we must have the data before comparing.
     // NOTE: Everything on the command queue executes in order; a read will not run before the prior kernel finishes.
-    std::vector<uint32_t> result_vec;
-    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);
+    std::vector<uint32_t> result_vec(dst_dram_buffer->device_local_size() / sizeof(uint32_t));
+    cq.enqueue_read_mesh_buffer((result_vec).data(), dst_dram_buffer, true);
     if (result_vec.size() != 1) {
         std::cout << "Error: Expected result vector size of 1, got " << result_vec.size() << std::endl;
         mesh_device->close();

--- a/tt_metal/programming_examples/contributed/multicast/multicast.cpp
+++ b/tt_metal/programming_examples/contributed/multicast/multicast.cpp
@@ -26,7 +26,6 @@
 // Optional: For a delay between device kernel's termination and host kernel's tile verification prints (clean output).
 #include <thread>
 #include <chrono>
-
 using namespace tt;
 using namespace tt::tt_metal;
 using namespace tt::constants;
@@ -240,7 +239,7 @@ int main(int /*argc*/, char** argv) {
 
         ////////// IDENTITY MATRIX TILE SETUP //////////
         std::vector<bfloat16> identity_tile = create_identity_matrix(TILE_WIDTH, TILE_HEIGHT, TILE_WIDTH);
-        distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, identity_tile);
+        cq.enqueue_write_mesh_buffer(src0_dram_buffer, identity_tile.data(), false);
 
         ////////// RUNTIME ARGS SETUP //////////
         // Args for the sender core to multicast tile.
@@ -298,11 +297,9 @@ int main(int /*argc*/, char** argv) {
         this_thread::sleep_for(chrono::milliseconds(200));
 
         ////////// TILE MULTICAST VERIFICATION //////////
-        std::vector<bfloat16> received_tiles(num_dests * TILE_HW);
-
-        // We're reading from a shard allocated on Device Coordinate 0, 0, since this is a 1x1
-        //  When the MeshDevice is 2 dimensional, this API can be used to target specific physical devices
-        distributed::EnqueueReadMeshBuffer(cq, received_tiles, output_dram_buffer, true);
+        // Read from shard on Device Coordinate 0,0 (unit mesh). On a 2D mesh this can target a specific device.
+        std::vector<bfloat16> received_tiles(output_dram_buffer->device_local_size() / sizeof(bfloat16));
+        cq.enqueue_read_mesh_buffer((received_tiles).data(), output_dram_buffer, true);
         bool verbose_verify =
             false;  // if enabled, the original and all multicast-received tiles are printed in full (32x32).
         verify_tiles(identity_tile, received_tiles, num_dests, verbose_verify);

--- a/tt_metal/programming_examples/contributed/vecadd/vecadd.cpp
+++ b/tt_metal/programming_examples/contributed/vecadd/vecadd.cpp
@@ -14,7 +14,6 @@
 #include <random>
 #include <string_view>
 #include <vector>
-
 using namespace tt::tt_metal;
 using CoreSpec = std::variant<CoreCoord, CoreRange, CoreRangeSet>;
 
@@ -139,8 +138,8 @@ int main(int argc, char** argv) {
     // We're writing to a shard allocated on MeshCoordinate 0, 0, since this is a 1x1 MeshDevice
     //  When the MeshDevice is 2 dimensional, this API can be used to target specific physical devices
     // The last argument indicates if the operation is blocking or not.
-    distributed::WriteShard(cq, a, a_data, device_coord, false);
-    distributed::WriteShard(cq, b, b_data, device_coord, false);
+    cq.enqueue_write_shards(a, {distributed::ShardDataTransfer{device_coord}.host_data(a_data.data())}, false);
+    cq.enqueue_write_shards(b, {distributed::ShardDataTransfer{device_coord}.host_data(b_data.data())}, false);
 
     // A Tensix core is made up with 5 processors. 2 data movement processors, and 3 compute processors. The 2 data
     // movement processors act independent to other cores. And the 3 compute processors act together (hence 1 kernel for
@@ -203,7 +202,8 @@ int main(int argc, char** argv) {
 
     // We're reading from a shard allocated on Device Coordinate 0, 0, since this is a 1x1
     //  When the MeshDevice is 2 dimensional, this API can be used to target specific physical devices
-    distributed::EnqueueReadMeshBuffer(cq, c_data, c, true);
+    c_data.resize(c->device_local_size() / sizeof(uint32_t));
+    cq.enqueue_read_mesh_buffer((c_data).data(), c, true);
 
     // Print partial results so we can see the output is correct (plus or minus some error due to BFP16 precision)
     std::cout << "Partial results: (note we are running under BFP16. It's going to be less accurate)\n";

--- a/tt_metal/programming_examples/custom_sfpi_add/custom_sfpi_add.cpp
+++ b/tt_metal/programming_examples/custom_sfpi_add/custom_sfpi_add.cpp
@@ -16,7 +16,6 @@
 #include <string_view>
 #include <vector>
 #include "tt-metalium/base_types.hpp"
-
 using namespace tt::tt_metal;
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -146,8 +145,8 @@ int main() {
         // upload is complete. This is useful for performance reasons, as it allows the host to continue while the
         // upload is in progress. Note that the host is responsible for ensuring that the upload is complete before the
         // memory holding the data is freed.
-        distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, a_data, /*blocking=*/false);
-        distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, b_data, /*blocking=*/false);
+        cq.enqueue_write_mesh_buffer(src0_dram_buffer, a_data.data(), false);
+        cq.enqueue_write_mesh_buffer(src1_dram_buffer, b_data.data(), false);
 
         // Set the runtime arguments for the kernels. This also registers the kernels with the program.
         SetRuntimeArgs(program, reader, core, {src0_dram_buffer->address(), src1_dram_buffer->address(), n_tiles});
@@ -161,13 +160,12 @@ int main() {
         distributed::Finish(cq);
         // NOTE: The above is equivalent to a blocking enqueue of the workload.
 
-        // Read the result back from the shard at mesh coordinate {0,0}. Use blocking=true to wait for completion.
-        // The vector is automatically resized to fit the data.
-        std::vector<bfloat16> result_vec;
-        distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking*/ true);
+        // Read the result back. Use blocking=true to wait for completion.
+        std::vector<bfloat16> result_vec(dst_dram_buffer->device_local_size() / sizeof(bfloat16));
+        cq.enqueue_read_mesh_buffer((result_vec).data(), dst_dram_buffer, true);
 
         // Compare the result with the input. The result should be the input plus val_to_add.
-        constexpr float eps = 1e-2f; // loose tolerance because of the nature of bfloat16
+        constexpr float eps = 1e-2f;  // loose tolerance because of the nature of bfloat16
         TT_FATAL(result_vec.size() == a_data.size(), "Result vector size mismatch");
         for (size_t i = 0; i < result_vec.size(); ++i) {
             const float expected = static_cast<float>(a_data[i]) + val_to_add;

--- a/tt_metal/programming_examples/custom_sfpi_smoothstep/custom_sfpi_smoothstep.cpp
+++ b/tt_metal/programming_examples/custom_sfpi_smoothstep/custom_sfpi_smoothstep.cpp
@@ -13,7 +13,6 @@
 #include <memory>
 #include <random>
 #include <vector>
-
 using namespace tt::tt_metal;
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -70,7 +69,7 @@ int main(int /*argc*/, char** /*argv*/) {
 
 
         // Upload the data from host to the device.
-        distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, a_data, false);
+        cq.enqueue_write_mesh_buffer(src0_dram_buffer, a_data.data(), false);
 
         // Create 3 circular buffers. Think them like pipes moving data from one core to another. cb_src0 and cb_src1 are used to
         // move data from the reader kernel to the compute kernel. cb_dst is used to move data from the compute kernel to the writer
@@ -142,8 +141,8 @@ int main(int /*argc*/, char** /*argv*/) {
         // NOTE: The above is equivalent to a blocking enqueue of the workload.
 
         // Read the output buffer and compare it with the expected output.
-        std::vector<bfloat16> result_vec;
-        distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking*/ true);
+        std::vector<bfloat16> result_vec(dst_dram_buffer->device_local_size() / sizeof(bfloat16));
+        cq.enqueue_read_mesh_buffer((result_vec).data(), dst_dram_buffer, true);
 
         constexpr float eps = 1e-2f; // loose tolerance because of the nature of bfloat16
         TT_FATAL(result_vec.size() == a_data.size(), "Result vector size mismatch");

--- a/tt_metal/programming_examples/distributed/2_distributed_buffer_rw/distributed_buffer_rw.cpp
+++ b/tt_metal/programming_examples/distributed/2_distributed_buffer_rw/distributed_buffer_rw.cpp
@@ -4,7 +4,6 @@
 
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
-
 // Stand-alone example demonstrating usage of native multi-device TT-Metalium APIs
 // for issuing Read and Write commands to a distributed memory buffer spanning
 // multiple devices in a mesh.
@@ -43,11 +42,11 @@ int main() {
     // Enqueue a write to the distributed buffer (L1 banks across devices) with random data.
     std::vector<uint32_t> src_data = create_random_vector_of_bfloat16(
         distributed_buffer_size_bytes, 1, std::chrono::system_clock::now().time_since_epoch().count());
-    EnqueueWriteMeshBuffer(cq, mesh_buffer, src_data);
+    cq.enqueue_write_mesh_buffer(mesh_buffer, src_data.data(), false);
 
     // Enqueue a read from the distributed buffer (L1 banks across devices) to a local buffer.
-    std::vector<uint32_t> read_back_data{};
-    EnqueueReadMeshBuffer(cq, read_back_data, mesh_buffer, true /* blocking */);
+    std::vector<uint32_t> read_back_data(distributed_buffer_size_bytes / sizeof(uint32_t));
+    cq.enqueue_read_mesh_buffer((read_back_data).data(), mesh_buffer, true);
 
     // Data read back across all devices in the mesh should match the original data.
     assert(src_data == read_back_data);

--- a/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
+++ b/tt_metal/programming_examples/distributed/3_distributed_eltwise_add/distributed_eltwise_add.cpp
@@ -7,7 +7,6 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-
 using namespace tt;
 using namespace tt::tt_metal;
 using namespace tt::tt_metal::distributed;
@@ -129,8 +128,8 @@ int main() {
 
     // Write data to distributed buffers
     auto& cq = mesh_device->mesh_command_queue();
-    EnqueueWriteMeshBuffer(cq, a, a_data, false /* blocking */);
-    EnqueueWriteMeshBuffer(cq, b, b_data, false /* blocking */);
+    cq.enqueue_write_mesh_buffer(a, a_data.data(), false);
+    cq.enqueue_write_mesh_buffer(b, b_data.data(), false);
 
     // Create program for distributed computation
     auto program = CreateEltwiseAddProgram(a, b, c, tile_size_bytes, num_tiles);
@@ -143,8 +142,8 @@ int main() {
     EnqueueMeshWorkload(cq, mesh_workload, false /* blocking */);
 
     // Read back results
-    std::vector<uint32_t> result_data(a_data.size(), 0);
-    EnqueueReadMeshBuffer(cq, result_data, c, true /* blocking */);
+    std::vector<uint32_t> result_data(distributed_buffer_config.global_size / sizeof(uint32_t));
+    cq.enqueue_read_mesh_buffer((result_data).data(), c, true);
 
     // Verify results
     auto transform_to_golden = [](const bfloat16& a) { return bfloat16(static_cast<float>(a) + val_to_add); };

--- a/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
+++ b/tt_metal/programming_examples/distributed/4_distributed_trace_and_events/distributed_trace_and_events.cpp
@@ -7,7 +7,6 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/sub_device.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-
 using namespace tt;
 using namespace tt::tt_metal;
 using namespace tt::tt_metal::distributed;
@@ -235,22 +234,24 @@ int main() {
     uint32_t workload_1_src0_val = 7;
     uint32_t workload_1_src1_val = 5;
     // Uniform values passed to the add operation
-    std::vector<uint32_t> add_src0_vec = create_constant_vector_of_bfloat16(add_src0_buf->size(), workload_0_src0_val);
-    std::vector<uint32_t> add_src1_vec = create_constant_vector_of_bfloat16(add_src1_buf->size(), workload_0_src1_val);
+    std::vector<uint32_t> add_src0_vec =
+        create_constant_vector_of_bfloat16(global_buffer_config.global_size, workload_0_src0_val);
+    std::vector<uint32_t> add_src1_vec =
+        create_constant_vector_of_bfloat16(global_buffer_config.global_size, workload_0_src1_val);
     // Uniform values passed to the multiply and subtract operations (the top row runs multiplication with subtraction
     // on the bottom row of the Virtual Mesh)
     std::vector<uint32_t> mul_sub_src0_vec =
-        create_constant_vector_of_bfloat16(mul_sub_src0_buf->size(), workload_1_src0_val);
+        create_constant_vector_of_bfloat16(global_buffer_config.global_size, workload_1_src0_val);
     std::vector<uint32_t> mul_sub_src1_vec =
-        create_constant_vector_of_bfloat16(mul_sub_src1_buf->size(), workload_1_src1_val);
+        create_constant_vector_of_bfloat16(global_buffer_config.global_size, workload_1_src1_val);
 
     // =========== Step 7: Write inputs on MeshCQ1 ===========
     // IO is done through MeshCQ1 and Workload dispatch is done through MeshCQ0. Use MeshEvents to synchronize the
     // independent MeshCQs.
-    EnqueueWriteMeshBuffer(data_movement_cq, add_src0_buf, add_src0_vec);
-    EnqueueWriteMeshBuffer(data_movement_cq, add_src1_buf, add_src1_vec);
-    EnqueueWriteMeshBuffer(data_movement_cq, mul_sub_src0_buf, mul_sub_src0_vec);
-    EnqueueWriteMeshBuffer(data_movement_cq, mul_sub_src1_buf, mul_sub_src1_vec);
+    data_movement_cq.enqueue_write_mesh_buffer(add_src0_buf, add_src0_vec.data(), false);
+    data_movement_cq.enqueue_write_mesh_buffer(add_src1_buf, add_src1_vec.data(), false);
+    data_movement_cq.enqueue_write_mesh_buffer(mul_sub_src0_buf, mul_sub_src0_vec.data(), false);
+    data_movement_cq.enqueue_write_mesh_buffer(mul_sub_src1_buf, mul_sub_src1_vec.data(), false);
     // Synchronize
     MeshEvent write_event = data_movement_cq.enqueue_record_event();
     workload_cq.enqueue_wait_for_event(write_event);
@@ -260,10 +261,10 @@ int main() {
     MeshEvent trace_event = workload_cq.enqueue_record_event();
     data_movement_cq.enqueue_wait_for_event(trace_event);
     // =========== Step 9: Read Outputs on MeshCQ1 ===========
-    std::vector<bfloat16> add_dst_vec = {};
-    std::vector<bfloat16> mul_sub_dst_vec = {};
-    EnqueueReadMeshBuffer(data_movement_cq, add_dst_vec, add_output_buf);
-    EnqueueReadMeshBuffer(data_movement_cq, mul_sub_dst_vec, mul_sub_output_buf);
+    std::vector<bfloat16> add_dst_vec(global_buffer_config.global_size / sizeof(bfloat16));
+    std::vector<bfloat16> mul_sub_dst_vec(global_buffer_config.global_size / sizeof(bfloat16));
+    data_movement_cq.enqueue_read_mesh_buffer((add_dst_vec).data(), add_output_buf, true);
+    data_movement_cq.enqueue_read_mesh_buffer((mul_sub_dst_vec).data(), mul_sub_output_buf, true);
 
     // =========== Step 10: Verify Outputs ===========
     bool pass = true;

--- a/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
+++ b/tt_metal/programming_examples/eltwise_binary/eltwise_binary.cpp
@@ -15,7 +15,6 @@
 #include <string_view>
 #include <vector>
 #include "tt-metalium/base_types.hpp"
-
 using namespace tt::tt_metal;
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
@@ -77,8 +76,8 @@ int main(int /*argc*/, char** /*argv*/) {
         std::vector<bfloat16> b_data(elements_per_tile * n_tiles, bfloat16(val_to_add));
 
         // Upload host vectors into the mesh buffers.
-        distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, a_data, false);
-        distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, b_data, false);
+        cq.enqueue_write_mesh_buffer(src0_dram_buffer, a_data.data(), false);
+        cq.enqueue_write_mesh_buffer(src1_dram_buffer, b_data.data(), false);
 
         // Create 3 circular buffers. Think them like pipes moving data from one core to another. cb_src0 and cb_src1 are used to
         // move data from the reader kernel to the compute kernel. cb_dst is used to move data from the compute kernel to the writer
@@ -157,8 +156,8 @@ int main(int /*argc*/, char** /*argv*/) {
         // distributed::EnqueueMeshWorkload(cq, workload, true);
 
         // Read the output buffer (from shard at mesh coordinate {0,0} on a unit mesh) and validate.
-        std::vector<bfloat16> result_vec;
-        distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, true);
+        std::vector<bfloat16> result_vec(dst_dram_buffer->device_local_size() / sizeof(bfloat16));
+        cq.enqueue_read_mesh_buffer((result_vec).data(), dst_dram_buffer, true);
 
         constexpr float eps = 1e-2f; // loose tolerance because of the nature of bfloat16
         TT_FATAL(result_vec.size() == a_data.size(), "Result vector size mismatch");

--- a/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
+++ b/tt_metal/programming_examples/eltwise_sfpu/eltwise_sfpu.cpp
@@ -9,7 +9,6 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-
 using namespace tt;
 using namespace tt::tt_metal;
 
@@ -116,7 +115,7 @@ int main() {
         // Write the data on host to the input buffer on the device.
         // setting blocking to false allows us to overlap the data movement and following host operations (
         // setting kerenel args) in this case
-        distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, src0_vec, /*blocking=*/false);
+        cq.enqueue_write_mesh_buffer(src0_dram_buffer, src0_vec.data(), false);
 
         // Set up the runtime arguments for the kernels.
         SetRuntimeArgs(program, eltwise_sfpu_kernel_id, core, {n_tiles});
@@ -137,8 +136,8 @@ int main() {
         distributed::Finish(cq);
 
         // Read the result (from shard at mesh coordinate {0,0} on a unit mesh) and compare to our expected result.
-        std::vector<bfloat16> result_vec;
-        distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, true);
+        std::vector<bfloat16> result_vec(dst_dram_buffer->device_local_size() / sizeof(bfloat16));
+        cq.enqueue_read_mesh_buffer((result_vec).data(), dst_dram_buffer, true);
 
         // Compute the same thing on CPU for comparison
 

--- a/tt_metal/programming_examples/hello_world_datatypes_kernel/hello_world_datatypes_kernel.cpp
+++ b/tt_metal/programming_examples/hello_world_datatypes_kernel/hello_world_datatypes_kernel.cpp
@@ -5,7 +5,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/distributed.hpp>
-
 using namespace tt;
 using namespace tt::tt_metal;
 
@@ -62,7 +61,7 @@ int main() {
 
     // Initialize Float data on host and upload to the DRAM buffer (non-blocking upload)
     std::vector<float> init_data(buffer_size / sizeof(float), 1.23);
-    distributed::EnqueueWriteMeshBuffer(cq, dram_buffer, init_data, false);
+    cq.enqueue_write_mesh_buffer(dram_buffer, init_data.data(), false);
 
     // Set runtime args, add program to mesh workload, and enqueue (non-blocking)
     SetRuntimeArgs(program, data_reader_kernel_id, core, {dram_buffer->address()});

--- a/tt_metal/programming_examples/loopback/loopback.cpp
+++ b/tt_metal/programming_examples/loopback/loopback.cpp
@@ -10,7 +10,6 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
-
 // This example demonstrates a simple data copy from DRAM into L1(SRAM) and to another place in DRAM.
 // The general flow is as follows:
 // 1. Initialize the device
@@ -103,7 +102,7 @@ int main() {
         // upload is complete. This is useful for performance reasons, as it allows the host to continue while the
         // upload is in progress. Note that the host is responsible for ensuring that the upload is complete before the
         // memory holding the data is freed.
-        distributed::EnqueueWriteMeshBuffer(cq, input_dram_buffer, input_vec, /*blocking=*/false);
+        cq.enqueue_write_mesh_buffer(input_dram_buffer, input_vec.data(), false);
 
         // Set runtime arguments for the kernel.
         const std::vector<uint32_t> runtime_args = {
@@ -118,10 +117,9 @@ int main() {
         distributed::Finish(cq);
         // NOTE: The above is equivalent to a blocking enqueue of the workload.
 
-        // Read the result back from the shard at mesh coordinate {0,0}. Use blocking=true to wait for completion.
-        // The vector is automatically resized to fit the data.
-        std::vector<bfloat16> result_vec;
-        distributed::EnqueueReadMeshBuffer(cq, result_vec, output_dram_buffer, /*blocking*/ true);
+        // Read the result back. Use blocking=true to wait for completion.
+        std::vector<bfloat16> result_vec(output_dram_buffer->device_local_size() / sizeof(bfloat16));
+        cq.enqueue_read_mesh_buffer((result_vec).data(), output_dram_buffer, true);
 
         // Compare the result with the input. The result should be the same as the input.
         TT_FATAL(

--- a/tt_metal/programming_examples/matmul/matmul_multi_core/matmul_multi_core.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_multi_core/matmul_multi_core.cpp
@@ -13,7 +13,6 @@
 #include <bmm_op.hpp>
 #include <tt-metalium/device.hpp>
 #include <fmt/core.h>
-
 using namespace tt::constants;
 using namespace std;
 using namespace tt;
@@ -254,14 +253,15 @@ void matmul_multi_core(
     // 1. Upload input data to DRAM buffers
     // 2. Execute the program (all kernels run in parallel across cores)
     // 3. Read back the result from DRAM to host memory
-    // The 'true' parameter in EnqueueReadMeshBuffer ensures we wait for completion (so when the function
+    // The blocking read ensures we wait for completion (so when the function
     // returns, the output vector is fully populated).
-    distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, a, false);
-    distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, b, false);
+    cq.enqueue_write_mesh_buffer(src0_dram_buffer, a.data(), false);
+    cq.enqueue_write_mesh_buffer(src1_dram_buffer, b.data(), false);
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
-    // Blocking read waits for completion before returning and resizes 'output' as needed
-    distributed::EnqueueReadMeshBuffer(cq, output, dst_dram_buffer, true);
+    // Blocking read waits for completion before returning
+    output.resize(dst_dram_buffer->device_local_size() / sizeof(bfloat16));
+    cq.enqueue_read_mesh_buffer((output).data(), dst_dram_buffer, true);
 }
 
 ///////////////////////////////////////

--- a/tt_metal/programming_examples/matmul/matmul_multicore_reuse/matmul_multicore_reuse.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_multicore_reuse/matmul_multicore_reuse.cpp
@@ -13,7 +13,6 @@
 #include <bmm_op.hpp>
 #include <fmt/core.h>
 #include <iostream>
-
 using namespace tt::constants;
 using namespace std;
 using namespace tt;
@@ -332,12 +331,13 @@ void matmul_multicore_reuse(
     /* Launch program & read back results */
 
     // Non-blocking uploads allow overlapping host setup with device transfers
-    distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, a, false);
-    distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, b, false);
+    cq.enqueue_write_mesh_buffer(src0_dram_buffer, a.data(), false);
+    cq.enqueue_write_mesh_buffer(src1_dram_buffer, b.data(), false);
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
-    // Blocking read from shard {0,0} waits for completion and populates 'output'
-    distributed::EnqueueReadMeshBuffer(cq, output, dst_dram_buffer, true);
+    // Blocking read waits for completion and populates 'output'
+    output.resize(dst_dram_buffer->device_local_size() / sizeof(bfloat16));
+    cq.enqueue_read_mesh_buffer((output).data(), dst_dram_buffer, true);
 }
 
 ///////////////////////////////////////

--- a/tt_metal/programming_examples/matmul/matmul_multicore_reuse_mcast/matmul_multicore_reuse_mcast.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_multicore_reuse_mcast/matmul_multicore_reuse_mcast.cpp
@@ -13,7 +13,6 @@
 #include <bmm_op.hpp>
 #include <algorithm>
 #include "tt-metalium/core_coord.hpp"
-
 using namespace tt::constants;
 using namespace std;
 using namespace tt;
@@ -440,11 +439,12 @@ void matmul_multicore_reuse_mcast(
 
     /* Launch program & read in output buffer result into the host vector */
 
-    distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, a, false);
-    distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, b, false);
+    cq.enqueue_write_mesh_buffer(src0_dram_buffer, a.data(), false);
+    cq.enqueue_write_mesh_buffer(src1_dram_buffer, b.data(), false);
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::EnqueueReadMeshBuffer(cq, output, dst_dram_buffer, true);
+    output.resize(dst_dram_buffer->device_local_size() / sizeof(bfloat16));
+    cq.enqueue_read_mesh_buffer((output).data(), dst_dram_buffer, true);
 }
 
 ///////////////////////////////////////

--- a/tt_metal/programming_examples/matmul/matmul_single_core/matmul_single_core.cpp
+++ b/tt_metal/programming_examples/matmul/matmul_single_core/matmul_single_core.cpp
@@ -12,7 +12,6 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "tt-metalium/core_coord.hpp"
-
 using namespace tt::constants;
 using namespace std;
 using namespace tt;
@@ -173,11 +172,12 @@ void matmul_single_core(
 
     // Upload the input data to the DRAM buffers, execute the kernels, wait for the result to be read into the output
     // buffer
-    distributed::EnqueueWriteMeshBuffer(cq, src0_dram_buffer, a, false);
-    distributed::EnqueueWriteMeshBuffer(cq, src1_dram_buffer, b, false);
+    cq.enqueue_write_mesh_buffer(src0_dram_buffer, a.data(), false);
+    cq.enqueue_write_mesh_buffer(src1_dram_buffer, b.data(), false);
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::EnqueueReadMeshBuffer(cq, output, dst_dram_buffer, true);
+    output.resize(dst_dram_buffer->device_local_size() / sizeof(bfloat16));
+    cq.enqueue_read_mesh_buffer((output).data(), dst_dram_buffer, true);
 }
 
 ///////////////////////////////////////

--- a/tt_metal/programming_examples/pad_multi_core/pad_multi_core.cpp
+++ b/tt_metal/programming_examples/pad_multi_core/pad_multi_core.cpp
@@ -8,7 +8,6 @@
 #include <tt-metalium/device.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/distributed.hpp>
-
 using namespace tt;
 using namespace tt::tt_metal;
 
@@ -188,11 +187,12 @@ int main() {
     printf("\n");
 
     // Upload inputs (non-blocking), enqueue mesh workload (non-blocking), read back result, then wait for completion
-    distributed::EnqueueWriteMeshBuffer(cq, src_buffer, src_vec, false);
-    distributed::EnqueueWriteMeshBuffer(cq, pad_buffer, pad_vec, false);
+    cq.enqueue_write_mesh_buffer(src_buffer, src_vec.data(), false);
+    cq.enqueue_write_mesh_buffer(pad_buffer, pad_vec.data(), false);
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
-    distributed::EnqueueReadMeshBuffer(cq, dst_vec, dst_buffer, true);
+    dst_vec.resize(dst_buffer->device_local_size() / sizeof(typename std::decay_t<decltype(dst_vec)>::value_type));
+    cq.enqueue_read_mesh_buffer((dst_vec).data(), dst_buffer, true);
     distributed::Finish(cq);
 
     printf("Padded tensor with shape (%d, %d):\n", dst_M, dst_N);

--- a/tt_metal/programming_examples/profiler/test_noc_event_profiler/test_noc_event_profiler.cpp
+++ b/tt_metal/programming_examples/profiler/test_noc_event_profiler/test_noc_event_profiler.cpp
@@ -68,7 +68,7 @@ int main() {
             input_bank_id,
             output_dram_buffer->address(),
             output_bank_id,
-            l1_buffer->size()};
+            l1_buffer->device_local_size()};
         SetRuntimeArgs(program, dram_copy_kernel_id, core, runtime_args);
 
         workload.add_program(device_range, std::move(program));

--- a/tt_metal/programming_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.cpp
+++ b/tt_metal/programming_examples/sfpu_eltwise_chain/sfpu_eltwise_chain.cpp
@@ -12,7 +12,6 @@
 #include <random>
 #include <cstdint>
 #include <vector>
-
 #ifndef OVERRIDE_KERNEL_PREFIX
 #define OVERRIDE_KERNEL_PREFIX ""
 #endif
@@ -142,7 +141,7 @@ int main() {
         distributed::MeshBuffer::create(buffer_config, dram_config, mesh_device.get());  // Output buffer
 
     // DRAM transfer
-    distributed::EnqueueWriteMeshBuffer(cq, src_dram_buffer, src_vec, false);
+    cq.enqueue_write_mesh_buffer(src_dram_buffer, src_vec.data(), false);
 
     // L1 circular buffer setup
     constexpr uint32_t src_cb_index = CBIndex::c_0;
@@ -198,8 +197,8 @@ int main() {
     distributed::Finish(cq);
 
     // Data transfer back to host machine
-    std::vector<bfloat16> result_vec(constants::TILE_HW, 0);
-    distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, true);
+    std::vector<bfloat16> result_vec(dst_dram_buffer->device_local_size() / sizeof(bfloat16));
+    cq.enqueue_read_mesh_buffer((result_vec).data(), dst_dram_buffer, true);
 
     // Reverse the tilization to get the result in the row-major format that the CPU expects
     result_vec = untilize_nfaces(result_vec, constants::TILE_WIDTH, constants::TILE_HEIGHT);

--- a/tt_metal/programming_examples/shard_data_rm/shard_data_rm.cpp
+++ b/tt_metal/programming_examples/shard_data_rm/shard_data_rm.cpp
@@ -10,7 +10,6 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/tt_align.hpp>
-
 using namespace tt;
 using namespace tt::tt_metal;
 
@@ -98,7 +97,7 @@ int main() {
     std::shared_ptr<distributed::MeshBuffer> src_buffer =
         distributed::MeshBuffer::create(buffer_config, input_dram_config, mesh_device.get());
     const uint32_t src_addr = src_buffer->address();
-    distributed::EnqueueWriteMeshBuffer(cq, src_buffer, src_vec, false);
+    cq.enqueue_write_mesh_buffer(src_buffer, src_vec.data(), false);
 
     // configure and create circular buffers with the same address on each of the designated cores
     // Create a circular buffer on each core to hold its shard of data

--- a/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
+++ b/tt_metal/programming_examples/vecadd_multi_core/vecadd_multi_core.cpp
@@ -19,7 +19,6 @@
 #include <random>
 #include <string_view>
 #include <vector>
-
 using namespace tt;
 using namespace tt::tt_metal;
 
@@ -241,8 +240,8 @@ int main(int argc, char** argv) {
         }
     }
 
-    EnqueueWriteMeshBuffer(cq, a, a_data, false);
-    EnqueueWriteMeshBuffer(cq, b, b_data, false);
+    cq.enqueue_write_mesh_buffer(a, a_data.data(), false);
+    cq.enqueue_write_mesh_buffer(b, b_data.data(), false);
     // Enqueue the program
     workload.add_program(device_range, std::move(program));
     distributed::EnqueueMeshWorkload(cq, workload, false);
@@ -250,8 +249,8 @@ int main(int argc, char** argv) {
     std::cout << "Kernel execution finished" << std::endl;
 
     // Read the output buffer.
-    std::vector<bfloat16> c_data;
-    distributed::EnqueueReadMeshBuffer(cq, c_data, c, true);
+    std::vector<bfloat16> c_data(c->device_local_size() / sizeof(bfloat16));
+    cq.enqueue_read_mesh_buffer((c_data).data(), c, true);
 
     // Print partial results so we can see the output is correct (plus or minus
     // some error due to BFP16 precision)

--- a/tt_metal/programming_examples/vecadd_sharding/vecadd_sharding.cpp
+++ b/tt_metal/programming_examples/vecadd_sharding/vecadd_sharding.cpp
@@ -24,7 +24,6 @@
 #include <random>
 #include <string_view>
 #include <vector>
-
 using namespace tt::tt_metal;
 
 using CoreSpec = std::variant<CoreCoord, CoreRange, CoreRangeSet>;
@@ -221,8 +220,8 @@ int main(int argc, char** argv) {
 
     // copy data from host to L1 directly
     distributed::MeshCommandQueue& cq = mesh_device->mesh_command_queue();
-    EnqueueWriteMeshBuffer(cq, a, a_data, false);
-    EnqueueWriteMeshBuffer(cq, b, b_data, false);
+    cq.enqueue_write_mesh_buffer(a, a_data.data(), false);
+    cq.enqueue_write_mesh_buffer(b, b_data.data(), false);
 
     // Setup arguments and run the program.
     SetRuntimeArgs(program, compute, cores, {num_tiles_per_core});
@@ -232,8 +231,8 @@ int main(int argc, char** argv) {
     fmt::print("Kernel execution finished. Reading results...\n");
 
     // Read the output buffer.
-    std::vector<bfloat16> c_data;
-    distributed::EnqueueReadMeshBuffer(cq, c_data, c, true);
+    std::vector<bfloat16> c_data(c->device_local_size() / sizeof(bfloat16));
+    cq.enqueue_read_mesh_buffer((c_data).data(), c, true);
 
     // Print partial results so we can see the output is correct (plus or minus
     // some error due to BFP16 precision)


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  / Relates to #<number> -->

Runtime team is performing surface area reduction to cleanup our api surface (`api/tt-metalium`).
The goal of the surface area reduction project is to remove internal functions unintentionally made public. The litmus test for identifying internal vs public functions is based on usage within tenstorrent repos.

This PR cleans up the unused surface area for distributed-related Metalium headers.
Removal of these function out of public surface area without deprecation per the surface area reduction exception.

### Enumeration of headers

- `distributed.hpp`
- `distributed_context.hpp`
- `maybe_remote.hpp`
- `mesh_command_queue.hpp`
- `mesh_config.hpp`
- `mesh_device_view.hpp`
- `mesh_trace_id.hpp`
- `mesh_workload.hpp`
- `mesh_buffer.hpp`

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

> A function is internal if and only if:
> - There are no usage of this function within tenstorrent repos outside of the
>   `tt_metal` folder and the `tests` folder.
> - The function is not a known externally used function

Some MeshBuffer r/w APIs stay on public API despite lack of usage `MeshCommandQueue`:  `enqueue_write_mesh_buffer`, `enqueue_write` (`DistributedHostBuffer`), `enqueue_read_mesh_buffer`, `enqueue_read` (`DistributedHostBuffer`), `enqueue_read_shards`.

`MeshBuffer::is_allocated`, `MeshBuffer::deallocate`,`EnqueueWriteMeshBuffer` / `EnqueueReadMeshBuffer` stay on as there are other non tt-metal repos using them.

Functions cleaned up in the `distributed.hpp` header has been inlined in favor of their cq centric alternative whenever possible per #26591. `ReadShard` function is left in as it has special handling around local vs remote shard that is not emulatable using public functions.

#### Member functions hidden via pimpl

| Class | Member functions | Destination |
|---|---|---|
| `MeshWorkload` | `set_last_used_command_queue_for_testing`<br>`get_last_used_command_queue`<br>`get_sem_base_addr`<br>`get_sem_size`<br>`get_cb_base_addr`<br>`get_cb_size` | `MeshWorkloadImpl` (`tt_metal/distributed/mesh_workload_impl.hpp`) |
| `MeshDeviceView` | `get_fabric_node_ids` (range overload)<br>`empty`<br>`size`<br>`mesh_id`<br>`get_fabric_node_id`<br>`begin` / `end`<br>`get_line_coordinates` (static + instance)<br>`get_ring_coordinates` (static + instance)<br>`get_line_devices`<br>`get_line_fabric_node_ids`<br>`get_local_mesh_coord_range` | `MeshDeviceViewImpl` (`tt_metal/distributed/mesh_device_view_impl.hpp`) |
| `MeshCommandQueue` | `get_config_buffer_mgr`<br>`record_begin`<br>`record_end`<br>`enqueue_trace` | `MeshCommandQueueBase` (`tt_metal/distributed/mesh_command_queue_base.hpp`) |
| `MeshBuffer` | `size`<br>`global_shard_spec`<br>`datum_size_bytes`<br>`physical_shard_shape`<br>`replicated_dims` | `MeshBufferImpl` (`tt_metal/distributed/mesh_buffer_impl.hpp`) |

#### Free functions

| Function | Destination |
|---|---|
| `EventQuery` | `tt_metal/distributed/mesh_io.hpp` |
| `MaybeRemoteLike` | `tt_metal/distributed/maybe_remote_utils.hpp` |
| `extract_locals` | `tt_metal/distributed/maybe_remote_utils.hpp` |
| `wrap_to_maybe_remote` | `tt_metal/distributed/maybe_remote_utils.hpp` |
| `MaybeRemoteDeviceId` | `tt_metal/distributed/maybe_remote_utils.hpp` |
| `MaybeRemoteDevice` | `tt_metal/distributed/maybe_remote_utils.hpp` |

#### Removed / inlined

| Function | What happened |
|---|---|
| `WriteShard` | inlined → `MeshCommandQueue::enqueue_write_shards` |
| `BeginTraceCapture` | inlined → `MeshDevice::begin_mesh_trace` |
| `MeshCommandQueue::ShardDataTransfer` (deprecated nested) | deleted → `distributed::ShardDataTransfer` |
| deprecated `enqueue_write_shards` / `enqueue_read_shards` overloads taking nested `ShardDataTransfer` | deleted |
| `MeshCompletionReaderVariant` (+ related forward decls) | removed from public header (FD-internal) |

#### Still used in production (kept public)

All free functions / public symbols remaining in the targeted headers:

<details>
<summary>Full public usage</summary>

Member functions:

| Class | Member functions | Example use site |
|---|---|---|
| `MeshWorkload` | ctor / move / dtor<br>`add_program` (54)<br>`get_programs` (61)<br>`impl` | `ttnn/api/ttnn/device_operation.hpp:105` |
| `MeshDeviceView` | ctors / copy / move / dtor<br>`get_devices` (1)<br>`get_devices` (range) (1)<br>`get_fabric_node_ids` (2)<br>`num_devices` (11)<br>`shape` (9)<br>`contains` (4)<br>`get_device` (1)<br>`find_device` (1)<br>`is_mesh_2d` (15)<br>`num_rows` (35)<br>`num_cols` (37)<br>`get_devices_on_row` (7)<br>`get_devices_on_column` (7)<br>`get_fabric_node_ids_on_row` (7)<br>`get_fabric_node_ids_on_column` (7)<br>`get_ring_devices` (1)<br>`get_ring_fabric_node_ids` (1)<br>`is_local` (2)<br>`impl` | `ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.cpp:36` |
| `MeshDeviceConfig` | ctor<br>`mesh_shape`<br>`offset`<br>`physical_device_ids` | `ttnn/core/distributed/api.cpp:38` |
| `MaybeRemote` | `local` / `remote`<br>`is_local` / `is_remote`<br>`value` / `operator*` / `operator->`<br>`when` / `if_local` / `if_remote`<br>`operator==`<br>`to_string`<br>`RemoteDevice` | `ttnn/core/distributed/distributed_nanobind.cpp:62` |
| `DistributedContext` | `create`<br>`get_current_world`<br>`get_world_context`<br>`set_current_world`<br>`is_initialized`<br>`id`<br>`rank` / `size`<br>`supports_fault_tolerance`<br>`subcontext_id` / `subcontext_count` / `subcontext_size` / `subcontext_sizes`<br>`local_to_world_rank`<br>`barrier`<br>`send` / `ssend` / `recv`<br>`isend` / `irecv`<br>`broadcast` / `gather` / `scatter` / `all_gather` / `all_to_all`<br>`all_reduce` / `reduce` / `reduce_scatter` / `scan`<br>`duplicate` / `split` / `create_sub_context`<br>`translate_ranks_to_other_ctx`<br>`abort` / `revoke_and_shrink` / `is_revoked`<br>`snoop_incoming_msg_size` | `ttnn/core/tensor/serialization.cpp:65` |
| `Request` | `wait` / `test` / `cancel` / `active` | `ttnn/core/distributed/distributed_nanobind.cpp` |
| `DistributedException` | `rank` / `error_code` / `message` / `error_string` / `what` | `tt-train/sources/ttml/nanobind/nb_core.cpp:54` |
| `MeshCommandQueue` | `enqueue_write_shards` (1)<br>`enqueue_write_shard_to_sub_grid`<br>`enqueue_write_mesh_buffer`<br>`enqueue_write` (`DistributedHostBuffer`)<br>`enqueue_read_mesh_buffer`<br>`enqueue_read` (`DistributedHostBuffer`)<br>`enqueue_read_shards`<br>`enqueue_read_tensor` (1)<br>`enqueue_write_tensor` (5)<br>`enqueue_record_event` (1)<br>`enqueue_record_event_to_host` (2)<br>`enqueue_wait_for_event` (2)<br>`finish` (1)<br>`device`<br>`id`<br>`trace_id`<br>`enqueue_mesh_workload` | `ttnn/core/async_runtime.cpp:41` |
| `MeshBuffer` | `create` (8)<br>`explicit MeshBuffer(MeshBufferImpl)` / move / dtor<br>`impl`<br>`is_allocated`<br>`deallocate`<br>`device` (5)<br>`device_local_size` (8)<br>`address` (8)<br>`global_layout` (1)<br>`global_config` (5)<br>`device_local_config` (10)<br>`get_device_buffer` (4)<br>`get_reference_buffer` (3)<br>`get_backing_buffer` (1)<br>`page_size` (2)<br>`num_pages` (1) | `ttnn/core/tensor/tensor_ops.cpp:398` |
| `DeviceLocalBufferConfig` | fields | `ttnn/core/services/h2d_socket_service.cpp:621` |
| `ReplicatedBufferConfig` | fields | `ttnn/cpp/ttnn/operations/data_movement/narrow/narrow.cpp:77` |
| `ShardedBufferConfig` | fields<br>`compute_datum_size_bytes`<br>`replicated_dims`<br>`physical_shard_shape` | (type required by public `MeshBufferConfig` variant) |
| `MeshBufferLayout` / `MeshBufferConfig` | enum / alias | `ttnn/cpp/ttnn/operations/data_movement/narrow/narrow.cpp:74` |
| `AnyBuffer` | `create`<br>`get_buffer`<br>`is_mesh_buffer`<br>`get_mesh_buffer` | (complete type required by public `GlobalCircularBuffer` members) |
| `ShardDataTransfer` | ctor<br>`host_data` (1)<br>`region` (1)<br>`shard_coord` | `ttnn/cpp/ttnn-nanobind/pytensor.cpp:1742` |

Free functions / constants:

| Function | Header | Usages[^usages] | Example use site |
|---|---|---:|---|
| `EnqueueMeshWorkload` | `distributed.hpp` | 6 | `ttnn/api/ttnn/device_operation.hpp:210` |
| `EnqueueWriteMeshBuffer` | `distributed.hpp` | 0 | |
| `EnqueueReadMeshBuffer` | `distributed.hpp` | 0 | |
| `EventSynchronize` | `distributed.hpp` | 2 | `ttnn/core/events.cpp:29` |
| `Synchronize` | `distributed.hpp` | 25 | `ttnn/cpp/ttnn/operations/point_to_point/device/host/point_to_point_device_op.cpp:230` |
| `Finish` | `distributed.hpp` | 3 | `ttnn/core/tensor/d2d_stream_service.cpp:501` |
| `UsingDistributedEnvironment` | `distributed.hpp` | 1 | `ttnn/core/distributed/distributed_nanobind.cpp:1015` |
| `MeshTraceId` | `mesh_trace_id.hpp` | 3 | `ttnn/cpp/ttnn/operations/trace.cpp:16` |
| `ReduceOp` / `DType` / `dtype_of` / `Rank` / `Tag` / `Color` / `Key` / `Size` / `SubcontextId` / `DistributedContextId` / `Status` / `RequestPtr` / `ContextPtr` | `distributed_context.hpp` | 23 | `ttnn/core/tensor/serialization.cpp:65` |

</details>

[^usages]: Number of unique files in `ttnn/` + `tt-train/` (excluding `tests/`) that reference the symbol via a C++ call (`Name(`) or nanobind binding (`&Name`). Parenthesized counts in the member-function table use the same definition.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/sr-distributed)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/sr-distributed)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/sr-distributed)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/sr-distributed)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/sr-distributed)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/sr-distributed)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/sr-distributed)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/sr-distributed)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/sr-distributed)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/sr-distributed)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/sr-distributed)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/sr-distributed)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/sr-distributed)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/sr-distributed)
