### PR TITLE
[Cleanup] Surface Area Memory headers

### DIFF
--- a/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
+++ b/tests/tt_metal/tt_metal/api/allocator/test_per_core_allocation.cpp
@@ -5,6 +5,7 @@
 // Integration tests for per-core L1 allocation via experimental::per_core_allocation.
 // These tests require a real device (slow dispatch).
 
+#include "impl/buffers/buffer_impl.hpp"
 #include <cstdlib>
 #include <cstring>
 #include <numeric>
@@ -87,7 +88,7 @@ TEST_F(PerCoreAllocationTest, BasicPerCoreAllocation) {
     auto shard_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED);
     experimental::per_core_allocation::set_per_core_allocation(shard_args, true);
 
-    auto buf = Buffer::create(device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
+    auto buf = BufferImpl::create(device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
 
     ASSERT_TRUE(per_core::is_per_core_allocation(*buf));
 
@@ -119,11 +120,11 @@ TEST_F(PerCoreAllocationTest, PerCoreAndLockstepCoexist) {
     // Create per-core buffer
     auto shard_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED);
     experimental::per_core_allocation::set_per_core_allocation(shard_args, true);
-    auto per_core_buf = Buffer::create(device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
+    auto per_core_buf = BufferImpl::create(device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
 
     // Create lockstep buffer on same cores
     auto lockstep_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED);
-    auto lockstep_buf = Buffer::create(device, total_size, PAGE_SIZE, BufferType::L1, lockstep_args);
+    auto lockstep_buf = BufferImpl::create(device, total_size, PAGE_SIZE, BufferType::L1, lockstep_args);
 
     // Both should be allocated successfully
     EXPECT_TRUE(per_core_buf->is_allocated());
@@ -155,7 +156,7 @@ TEST_F(PerCoreAllocationTest, PerCoreSkipsPersistentL1OnSameCore) {
     auto shard_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED);
     experimental::per_core_allocation::set_per_core_allocation(shard_args, true);
     // Allocate through the MeshDevice allocator that owns the pipe's persistent L1.
-    auto buf = Buffer::create(mesh_device, 2 * PAGE_SIZE, PAGE_SIZE, BufferType::L1, shard_args);
+    auto buf = BufferImpl::create(mesh_device, 2 * PAGE_SIZE, PAGE_SIZE, BufferType::L1, shard_args);
 
     const DeviceAddr per_core_size = buf->aligned_size_per_bank();
     const DeviceAddr ring_begin = pipe.buffer_address();
@@ -195,13 +196,13 @@ TEST_F(PerCoreAllocationTest, DeallocationFreesPerCoreSpace) {
 
     // Create and destroy a buffer
     {
-        auto buf1 = Buffer::create(device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
+        auto buf1 = BufferImpl::create(device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
         EXPECT_TRUE(per_core::is_per_core_allocation(*buf1));
         // buf1 destroyed here, freeing per-core allocations
     }
 
     // Create another buffer on same cores — should succeed (space was freed)
-    auto buf2 = Buffer::create(device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
+    auto buf2 = BufferImpl::create(device, total_size, PAGE_SIZE, BufferType::L1, shard_args);
     EXPECT_TRUE(per_core::is_per_core_allocation(*buf2));
     EXPECT_TRUE(buf2->is_allocated());
 }
@@ -272,7 +273,7 @@ TEST_F(PerCoreAllocationTest, PerCoreSocketCoexistsWithLockstep) {
     CoreRange grid(CoreCoord(0, 0), CoreCoord(1, 0));
     ShardSpecBuffer shard_spec(CoreRangeSet(grid), {32, 32}, ShardOrientation::ROW_MAJOR, {32, 32}, {2, 1});
     auto lockstep_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED);
-    auto lockstep_buf = Buffer::create(device, 2 * PAGE_SIZE, PAGE_SIZE, BufferType::L1, lockstep_args);
+    auto lockstep_buf = BufferImpl::create(device, 2 * PAGE_SIZE, PAGE_SIZE, BufferType::L1, lockstep_args);
     EXPECT_TRUE(lockstep_buf->is_allocated());
     EXPECT_NE(lockstep_buf->address(), pc_addr) << "Lockstep buffer aliases the per-core socket FIFO";
 }
@@ -415,7 +416,7 @@ TEST_F(PerCoreAllocationTest, H2DSocketPerCoreFifoDoesNotAliasLockstep) {
     CoreRange grid(CoreCoord(0, 0), CoreCoord(0, 1));
     ShardSpecBuffer shard_spec(CoreRangeSet(grid), {32, 32}, ShardOrientation::ROW_MAJOR, {32, 32}, {2, 1});
     auto lockstep_args = BufferShardingArgs(shard_spec, TensorMemoryLayout::HEIGHT_SHARDED);
-    auto lockstep_buf = Buffer::create(device, 2 * PAGE_SIZE, PAGE_SIZE, BufferType::L1, lockstep_args);
+    auto lockstep_buf = BufferImpl::create(device, 2 * PAGE_SIZE, PAGE_SIZE, BufferType::L1, lockstep_args);
     ASSERT_TRUE(lockstep_buf->is_allocated());
 
     const DeviceAddr lockstep_base = lockstep_buf->address();

--- a/tests/tt_metal/tt_metal/api/cross_node_dfb_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/api/cross_node_dfb_test_utils.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "impl/buffers/buffer_impl.hpp"
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
@@ -53,7 +54,7 @@ inline std::shared_ptr<Buffer> make_cross_node_data_buffer(
     BufferType buffer_type = BufferType::L1) {
     const uint32_t ring_size = entry_size * num_entries;
     const uint32_t num_cores = all_cores.num_cores();
-    return Buffer::create(
+    return BufferImpl::create(
         &device,
         ring_size * num_cores,
         ring_size,

--- a/tests/tt_metal/tt_metal/api/tensor/test_tensor_nd_sharding.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_tensor_nd_sharding.cpp
@@ -13,6 +13,7 @@
 // (loopback/region/BDS-creation/perf/buffer-size) that exercise the runtime
 // MeshTensor/HostTensor API on a single-device mesh via MeshDevice1x1Fixture.
 
+#include "impl/buffers/compute_page_mapping.hpp"
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 

--- a/tests/tt_metal/tt_metal/api/test_buffer_region.cpp
+++ b/tests/tt_metal/tt_metal/api/test_buffer_region.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "impl/buffers/buffer_impl.hpp"
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <memory>
@@ -19,13 +20,13 @@ TEST_F(MeshDeviceSingleCardBufferFixture, TestInvalidBufferRegion) {
         distributed::MeshBuffer::create(buffer_config, local_config, this->devices_[0].get());
 
     const BufferRegion buffer_region1(512, 4096);
-    EXPECT_FALSE(buffer->get_backing_buffer()->is_valid_region(buffer_region1));
+    EXPECT_FALSE(buffer->get_backing_buffer()->impl().is_valid_region(buffer_region1));
 
     const BufferRegion buffer_region2(3072, 4096);
-    EXPECT_FALSE(buffer->get_backing_buffer()->is_valid_region(buffer_region2));
+    EXPECT_FALSE(buffer->get_backing_buffer()->impl().is_valid_region(buffer_region2));
 
     const BufferRegion buffer_region3(0, 4096);
-    EXPECT_FALSE(buffer->get_backing_buffer()->is_valid_region(buffer_region3));
+    EXPECT_FALSE(buffer->get_backing_buffer()->impl().is_valid_region(buffer_region3));
 }
 
 TEST_F(MeshDeviceSingleCardBufferFixture, TestValidBufferRegion) {
@@ -35,16 +36,16 @@ TEST_F(MeshDeviceSingleCardBufferFixture, TestValidBufferRegion) {
         distributed::MeshBuffer::create(buffer_config, local_config, this->devices_[0].get());
 
     const BufferRegion buffer_region1(1024, 1024);
-    EXPECT_TRUE(buffer->get_backing_buffer()->is_valid_region(buffer_region1));
+    EXPECT_TRUE(buffer->get_backing_buffer()->impl().is_valid_region(buffer_region1));
 
     const BufferRegion buffer_region2(0, 2048);
-    EXPECT_TRUE(buffer->get_backing_buffer()->is_valid_region(buffer_region2));
+    EXPECT_TRUE(buffer->get_backing_buffer()->impl().is_valid_region(buffer_region2));
 
     const BufferRegion buffer_region3(0, 512);
-    EXPECT_TRUE(buffer->get_backing_buffer()->is_valid_region(buffer_region3));
+    EXPECT_TRUE(buffer->get_backing_buffer()->impl().is_valid_region(buffer_region3));
 
     const BufferRegion buffer_region4(512, 512);
-    EXPECT_TRUE(buffer->get_backing_buffer()->is_valid_region(buffer_region4));
+    EXPECT_TRUE(buffer->get_backing_buffer()->impl().is_valid_region(buffer_region4));
 }
 
 TEST_F(MeshDeviceSingleCardBufferFixture, TestPartialBufferRegion) {
@@ -54,13 +55,13 @@ TEST_F(MeshDeviceSingleCardBufferFixture, TestPartialBufferRegion) {
         distributed::MeshBuffer::create(buffer_config, local_config, this->devices_[0].get());
 
     const BufferRegion buffer_region1(1024, 1024);
-    EXPECT_TRUE(buffer->get_backing_buffer()->is_valid_partial_region(buffer_region1));
+    EXPECT_TRUE(buffer->get_backing_buffer()->impl().is_valid_partial_region(buffer_region1));
 
     const BufferRegion buffer_region2(0, 1024);
-    EXPECT_TRUE(buffer->get_backing_buffer()->is_valid_partial_region(buffer_region2));
+    EXPECT_TRUE(buffer->get_backing_buffer()->impl().is_valid_partial_region(buffer_region2));
 
     const BufferRegion buffer_region3(512, 1024);
-    EXPECT_TRUE(buffer->get_backing_buffer()->is_valid_partial_region(buffer_region3));
+    EXPECT_TRUE(buffer->get_backing_buffer()->impl().is_valid_partial_region(buffer_region3));
 }
 
 TEST_F(MeshDeviceSingleCardBufferFixture, TestFullBufferRegion) {
@@ -70,7 +71,7 @@ TEST_F(MeshDeviceSingleCardBufferFixture, TestFullBufferRegion) {
         distributed::MeshBuffer::create(buffer_config, local_config, this->devices_[0].get());
 
     const BufferRegion buffer_region(0, 2048);
-    EXPECT_FALSE(buffer->get_backing_buffer()->is_valid_partial_region(buffer_region));
+    EXPECT_FALSE(buffer->get_backing_buffer()->impl().is_valid_partial_region(buffer_region));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/test_cross_node_dfb.cpp
+++ b/tests/tt_metal/tt_metal/api/test_cross_node_dfb.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "impl/buffers/buffer_impl.hpp"
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <array>
@@ -1198,7 +1199,7 @@ TEST_F(CrossNodeDFBFixture, CreateCrossNodeDFB_BorrowedMismatch_PageSize) {
     const CoreRangeSet receiver_cores(CoreRange({1, 0}, {1, 0}));
     CoreRangeSet all_cores = CoreRangeSet(CoreRange({0, 0}, {0, 0})).merge(receiver_cores);
 
-    auto bad = Buffer::create(
+    auto bad = BufferImpl::create(
         &device,
         128 * 2,
         128,  // should be entry_size * num_entries = 256 * 4
@@ -1216,7 +1217,7 @@ TEST_F(CrossNodeDFBFixture, CreateCrossNodeDFB_BorrowedMismatch_Cores) {
     const CoreCoord sender_core(0, 0);
     const CoreRangeSet receiver_cores(CoreRange({1, 0}, {1, 0}));
     CoreRangeSet wrong_cores = CoreRangeSet(CoreRange({2, 0}, {2, 0})).merge(CoreRangeSet(CoreRange({3, 0}, {3, 0})));
-    auto bad = Buffer::create(
+    auto bad = BufferImpl::create(
         &device,
         256 * 4 * 2,
         256 * 4,
@@ -1233,7 +1234,7 @@ TEST_F(CrossNodeDFBFixture, CreateCrossNodeDFB_BorrowedMismatch_BufferType) {
     const CoreCoord sender_core(0, 0);
     const CoreRangeSet receiver_cores(CoreRange({1, 0}, {1, 0}));
 
-    auto bad = Buffer::create(&device, 256 * 4, 256 * 4, BufferType::DRAM);
+    auto bad = BufferImpl::create(&device, 256 * 4, 256 * 4, BufferType::DRAM);
     EXPECT_THROW(experimental::CrossNodeDFB(&device, sender_core, receiver_cores, 256, 4, *bad), std::exception);
 }
 
@@ -1246,7 +1247,7 @@ TEST_F(CrossNodeDFBFixture, CreateCrossNodeDFB_BorrowedMismatch_Size) {
 
     // page_size and grid match, but size is larger than page_size * num_all_cores.
     const uint32_t ring_size = 256 * 4;
-    auto bad = Buffer::create(
+    auto bad = BufferImpl::create(
         &device,
         ring_size * 4,
         ring_size,

--- a/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
+++ b/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
@@ -15,6 +15,7 @@
 //      - Two buffers at distinct positions in the same kernel
 //      - Error path: buffer not enumerated in tensor_buffers
 
+#include "impl/buffers/buffer_impl.hpp"
 #include <gtest/gtest.h>
 
 #include <cstdint>
@@ -59,11 +60,11 @@ KernelDescriptor MakeBlankReaderKernel(CoreCoord core = {0, 0}) {
 }
 
 std::shared_ptr<Buffer> MakeDramBuffer(IDevice* device, uint32_t size = 2048) {
-    return Buffer::create(device, size, size, BufferType::DRAM);
+    return BufferImpl::create(device, size, size, BufferType::DRAM);
 }
 
 std::shared_ptr<Buffer> MakeL1Buffer(IDevice* device, uint32_t size = 2048) {
-    return Buffer::create(device, size, size, BufferType::L1);
+    return BufferImpl::create(device, size, size, BufferType::L1);
 }
 
 MeshTensor MakeSingleTileL1MeshTensor(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {

--- a/tests/tt_metal/tt_metal/api/test_shard_grid_validation.cpp
+++ b/tests/tt_metal/tt_metal/api/test_shard_grid_validation.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "impl/buffers/buffer_impl.hpp"
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
@@ -54,7 +55,7 @@ ShardedBufferConfig one_shard_config(IDevice* device, BufferType buffer_type, co
 
 std::shared_ptr<Buffer> make_width_sharded_buffer(IDevice* device, BufferType buffer_type, const CoreCoord& core) {
     const auto config = one_shard_config(device, buffer_type, core);
-    return Buffer::create(
+    return BufferImpl::create(
         config.device,
         config.size,
         config.page_size,
@@ -70,7 +71,7 @@ std::shared_ptr<Buffer> make_width_sharded_buffer(IDevice* device, BufferType bu
 std::shared_ptr<Buffer> make_unallocated_width_sharded_buffer(
     IDevice* device, BufferType buffer_type, const CoreCoord& core) {
     const auto config = one_shard_config(device, buffer_type, core);
-    return Buffer::create(
+    return BufferImpl::create(
         config.device,
         device->allocator()->get_base_allocator_addr(HalMemType::L1),
         config.size,

--- a/tests/tt_metal/tt_metal/dispatch/test_service_core_manager.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/test_service_core_manager.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "impl/buffers/buffer_impl.hpp"
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -371,7 +372,7 @@ TEST_F(ServiceCoreFdFixture, ServiceCoreShardedL1BufferOnClaimedCore) {
 
     // Unclaimed, it is just a core the allocator knows nothing about.
     auto create_buffer = [&] {
-        return Buffer::create(
+        return BufferImpl::create(
             config.device,
             config.size,
             config.page_size,

--- a/tt_metal/api/tt-metalium/allocator.hpp
+++ b/tt_metal/api/tt-metalium/allocator.hpp
@@ -22,7 +22,6 @@ struct Statistics {
 
 class Buffer;
 enum class BufferType;
-class AllocatorState;
 
 // This is the internal representation for Allocator, not exposed for general usage.
 class AllocatorImpl;
@@ -49,14 +48,13 @@ public:
     // this helper function is made for reports.cpp in TTNN and act as a transient member function.
     size_t get_worker_l1_size() const;
     Statistics get_statistics(const BufferType& buffer_type) const;
-    // AllocatorState Methods
-    // Extracts the current state of the allocator.
-    AllocatorState extract_state() const;
-    // Overrides the current state with the given state, deallocating all of existing buffers.
-    void override_state(const AllocatorState& state);
+
+    // debug/test/internal usage.
+    AllocatorImpl& impl() { return *impl_; }
+    const AllocatorImpl& impl() const { return *impl_; }
 
 private:
-    AllocatorImpl* impl;
+    AllocatorImpl* impl_;
 };
 
 namespace detail {

--- a/tt_metal/api/tt-metalium/buffer.hpp
+++ b/tt_metal/api/tt-metalium/buffer.hpp
@@ -6,22 +6,14 @@
 
 #include <nlohmann/json_fwd.hpp>
 #include <array>
-#include <atomic>
-#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
-#include <functional>
-#include <map>
 #include <memory>
-#include <mutex>
 #include <optional>
 #include <ostream>
 #include <tuple>
-#include <unordered_map>
-#include <variant>
 #include <vector>
 
-#include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/buffer_distribution_spec.hpp>
 #include <tt-metalium/core_coord.hpp>
@@ -39,21 +31,9 @@ struct from_json_t;
 namespace tt::tt_metal {
 
 class Allocator;
-class AllocatorImpl;
+class BufferImpl;
+class BufferShardingArgsImpl;
 class IDevice;
-
-// Forward declarations for friended free functions in the experimental namespace.
-// These are used to access experimental config params, which are not part of the official public API.
-class Buffer;
-class BufferShardingArgs;
-namespace experimental::per_core_allocation {
-bool is_per_core_allocation(const Buffer& buffer);
-DeviceAddr get_per_core_address(const Buffer& buffer, CoreCoord core);
-const std::unordered_map<CoreCoord, DeviceAddr>& get_per_core_addresses(const Buffer& buffer);
-void copy_per_core_addresses(Buffer& dst, const Buffer& src);
-BufferShardingArgs& set_per_core_allocation(BufferShardingArgs& args, bool enable);
-bool is_per_core_allocation(const BufferShardingArgs& args);
-}  // namespace experimental::per_core_allocation
 
 struct ShardSpec {
     /* The individual cores the shard grid is mapped to */
@@ -106,7 +86,6 @@ struct ShardSpecBuffer {
     CoreRangeSet grid() const { return tensor_shard_spec.grid; }
     std::array<uint32_t, 2> shape() const { return tensor_shard_spec.shape; }
     ShardOrientation orientation() const { return tensor_shard_spec.orientation; }
-    void set_shard_spec(const ShardSpec& shard_spec) { tensor_shard_spec = shard_spec; };
 
     /* Shape in pages of the full shard */
     std::array<uint32_t, 2> shape_in_pages() const;
@@ -136,49 +115,34 @@ struct ShardedBufferConfig {
 
 class BufferShardingArgs {
 public:
-    BufferShardingArgs() = default;
-    BufferShardingArgs(std::nullopt_t) {}
+    explicit BufferShardingArgs(BufferShardingArgsImpl impl);
+    BufferShardingArgs();
+    BufferShardingArgs(std::nullopt_t);
 
-    BufferShardingArgs(BufferDistributionSpec buffer_distribution_spec) :
-        buffer_distribution_spec_(std::move(buffer_distribution_spec)),
-        buffer_layout_(TensorMemoryLayout::BLOCK_SHARDED) {}
-    BufferShardingArgs(std::optional<BufferDistributionSpec> buffer_distribution_spec) :
-        buffer_distribution_spec_(std::move(buffer_distribution_spec)),
-        buffer_layout_(
-            buffer_distribution_spec_.has_value() ? TensorMemoryLayout::BLOCK_SHARDED
-                                                  : TensorMemoryLayout::INTERLEAVED) {}
-
-    BufferShardingArgs(ShardSpecBuffer shard_spec, TensorMemoryLayout buffer_layout) :
-        shard_spec_(std::move(shard_spec)), buffer_layout_(buffer_layout) {}
-    BufferShardingArgs(std::optional<ShardSpecBuffer> shard_spec, TensorMemoryLayout buffer_layout) :
-        shard_spec_(std::move(shard_spec)), buffer_layout_(buffer_layout) {}
-
+    BufferShardingArgs(BufferDistributionSpec buffer_distribution_spec);
+    BufferShardingArgs(std::optional<BufferDistributionSpec> buffer_distribution_spec);
+    BufferShardingArgs(ShardSpecBuffer shard_spec, TensorMemoryLayout buffer_layout);
+    BufferShardingArgs(std::optional<ShardSpecBuffer> shard_spec, TensorMemoryLayout buffer_layout);
     BufferShardingArgs(
         std::optional<BufferDistributionSpec> buffer_distribution_spec,
         std::optional<ShardSpecBuffer> shard_spec,
-        TensorMemoryLayout buffer_layout) :
-        buffer_distribution_spec_(std::move(buffer_distribution_spec)),
-        shard_spec_(std::move(shard_spec)),
-        buffer_layout_(buffer_layout) {}
+        TensorMemoryLayout buffer_layout);
 
-    const std::optional<BufferDistributionSpec>& buffer_distribution_spec() const { return buffer_distribution_spec_; }
+    BufferShardingArgs(const BufferShardingArgs&);
+    BufferShardingArgs& operator=(const BufferShardingArgs&);
+    BufferShardingArgs(BufferShardingArgs&&) noexcept;
+    BufferShardingArgs& operator=(BufferShardingArgs&&) noexcept;
+    ~BufferShardingArgs();
 
-    const std::optional<ShardSpecBuffer>& shard_spec() const { return shard_spec_; }
+    const std::optional<BufferDistributionSpec>& buffer_distribution_spec() const;
+    const std::optional<ShardSpecBuffer>& shard_spec() const;
+    TensorMemoryLayout buffer_layout() const;
 
-    TensorMemoryLayout buffer_layout() const { return buffer_layout_; }
-
-    // per_core_allocation is experimental functionality
-    // access is through experimental::per_core_allocation free functions
-    friend BufferShardingArgs& experimental::per_core_allocation::set_per_core_allocation(BufferShardingArgs&, bool);
-    friend bool experimental::per_core_allocation::is_per_core_allocation(const BufferShardingArgs&);
+    const BufferShardingArgsImpl& impl() const;
+    BufferShardingArgsImpl& impl();
 
 private:
-    std::optional<BufferDistributionSpec> buffer_distribution_spec_;
-    std::optional<ShardSpecBuffer> shard_spec_;
-    TensorMemoryLayout buffer_layout_ = TensorMemoryLayout::INTERLEAVED;
-    // per_core_allocation is experimental functionality
-    // access is through experimental::per_core_allocation free functions
-    bool per_core_allocation_ = false;
+    std::unique_ptr<BufferShardingArgsImpl> impl_;
 };
 
 bool is_sharded(const TensorMemoryLayout& layout);
@@ -192,35 +156,8 @@ struct BufferRegion {
 };
 
 class Buffer final : public std::enable_shared_from_this<Buffer> {
-    // Used in public Buffer constructors so they are only callable within Buffer
-    // Buffer constructors are public so we can call std::make_shared on Buffer
-    struct Private {
-        explicit Private() = default;
-    };
-
 public:
-    static std::shared_ptr<Buffer> create(
-        IDevice* device,
-        DeviceAddr size,
-        DeviceAddr page_size,
-        BufferType buffer_type,
-        const BufferShardingArgs& sharding_args = std::nullopt,
-        std::optional<bool> bottom_up = std::nullopt,
-        std::optional<SubDeviceId> sub_device_id = std::nullopt);
-    static std::shared_ptr<Buffer> create(
-        IDevice* device,
-        DeviceAddr address,
-        DeviceAddr size,
-        DeviceAddr page_size,
-        BufferType buffer_type,
-        const BufferShardingArgs& sharding_args = std::nullopt,
-        std::optional<bool> bottom_up = std::nullopt,
-        std::optional<SubDeviceId> sub_device_id = std::nullopt);
-
-    // Creates a view of the region of the buffer.
-    // The view is a new buffer (unless the region is the entire buffer) that shares the same underlying device memory.
-    // The view keeps the underlying buffer alive as long as the view is alive.
-    std::shared_ptr<Buffer> view(const BufferRegion& region);
+    explicit Buffer(BufferImpl impl);
 
     Buffer(const Buffer& other) = delete;
     Buffer& operator=(const Buffer& other) = delete;
@@ -228,34 +165,26 @@ public:
     Buffer& operator=(Buffer&& other) = delete;
     ~Buffer();
 
-    IDevice* device() const { return device_; }
+    IDevice* device() const;
     Allocator* allocator() const;
-    DeviceAddr size() const { return size_; }
+    DeviceAddr size() const;
     bool is_allocated() const;
 
     // Returns address of buffer in the first bank
     uint32_t address() const;
 
     DeviceAddr page_size() const;
-    void set_page_size(DeviceAddr page_size);
 
     uint32_t num_pages() const;
     uint32_t num_dev_pages() const;
 
-    BufferType buffer_type() const { return buffer_type_; }
-    HalMemType memory_type() const;
+    BufferType buffer_type() const;
     CoreType core_type() const;
 
     bool is_l1() const;
     bool is_dram() const;
-    bool is_trace() const;
 
-    bool is_valid_region(const BufferRegion& region) const;
-    bool is_valid_partial_region(const BufferRegion& region) const;
-
-    TensorMemoryLayout buffer_layout() const { return buffer_layout_; }
-
-    bool bottom_up() const { return bottom_up_; }
+    TensorMemoryLayout buffer_layout() const;
 
     DeviceAddr page_address(DeviceAddr bank_id, DeviceAddr page_index) const;
 
@@ -264,107 +193,20 @@ public:
     DeviceAddr aligned_size() const;
     DeviceAddr aligned_size_per_bank() const;
 
-    // SHARDED API STARTS HERE
     const std::optional<BufferDistributionSpec>& buffer_distribution_spec() const;
-    bool has_shard_spec() const { return shard_spec_.has_value(); }
+    bool has_shard_spec() const;
     ShardSpecBuffer shard_spec() const;
-    void set_shard_spec(const ShardSpecBuffer& shard_spec);
     std::optional<uint32_t> num_cores() const;
     const std::shared_ptr<const BufferPageMapping>& get_buffer_page_mapping();
 
-    // Returns the buffer that owns the underlying device memory.
-    // Typically returns itself unless the buffer was created with a view method.
-    std::shared_ptr<Buffer> root_buffer();
-    BufferRegion root_buffer_region() const { return BufferRegion(root_buffer_offset_, size_); }
+    size_t unique_id() const;
 
-    std::optional<SubDeviceId> sub_device_id() const { return sub_device_id_; }
-
-    size_t unique_id() const { return unique_id_; }
-
-    // Mark the buffer as deallocated, without releasing underlying device memory
-    void mark_as_deallocated();
-
-    Buffer(
-        IDevice* device,
-        DeviceAddr size,
-        DeviceAddr page_size,
-        BufferType buffer_type,
-        const BufferShardingArgs& sharding_args,
-        std::optional<bool> bottom_up,
-        std::optional<SubDeviceId> sub_device_id,
-        bool owns_data,
-        Private);
+    const BufferImpl& impl() const;
+    BufferImpl& impl();
 
 private:
-    enum class AllocationStatus : uint8_t {
-        ALLOCATION_REQUESTED,
-        ALLOCATED,
-        DEALLOCATED,
-    };
-
-    void allocate_impl();
-
-    // Deallocate is allowed to be called multiple times on the same buffer
-    void deallocate();
-    void deallocate_impl();
-    friend class AllocatorImpl;
-    friend void DeallocateBuffer(Buffer& buffer);
-    friend bool experimental::per_core_allocation::is_per_core_allocation(const Buffer&);
-    friend DeviceAddr experimental::per_core_allocation::get_per_core_address(const Buffer&, CoreCoord);
-    friend const std::unordered_map<CoreCoord, DeviceAddr>& experimental::per_core_allocation::get_per_core_addresses(
-        const Buffer&);
-    friend void experimental::per_core_allocation::copy_per_core_addresses(Buffer&, const Buffer&);
-
-    void set_per_core_addresses(std::unordered_map<CoreCoord, DeviceAddr> addrs);
-
-    DeviceAddr translate_page_address(DeviceAddr offset, uint32_t bank_id) const;
-
-    IDevice* const device_;
-    const DeviceAddr size_;  // Size in bytes
-    const BufferType buffer_type_;
-    const TensorMemoryLayout buffer_layout_;
-    const bool bottom_up_;
-    const std::optional<SubDeviceId> sub_device_id_;
-    const bool owns_data_;
-
-    std::optional<SubDeviceManagerId> sub_device_manager_id_;
-    AllocatorImpl* allocator_;
-
-    AllocationStatus allocation_status_ = AllocationStatus::ALLOCATION_REQUESTED;
-    bool hooked_allocation_ = false;
-    DeviceAddr address_ = 0;
-
-    // These members must be only accessed on the device worker thread
-    DeviceAddr page_size_;  // Size of unit being interleaved. For non-interleaved buffers: size == page_size
-    std::optional<ShardSpecBuffer> shard_spec_;
-    std::shared_ptr<const BufferPageMapping> buffer_page_mapping_;
-
-    std::optional<BufferDistributionSpec> buffer_distribution_spec_;
-
-    // Per-core allocation state
-    bool per_core_allocation_ = false;
-    std::unordered_map<CoreCoord, DeviceAddr> per_core_addresses_;
-
-    // The root buffer is the buffer that owns the underlying device memory.
-    // The root buffer is populated only when the buffer was created with a view method.
-    std::shared_ptr<Buffer> root_buffer_;
-    // Offset of the current view buffer in the root buffer
-    DeviceAddr root_buffer_offset_ = 0;
-
-    size_t unique_id_ = 0;
-    static std::atomic<size_t> next_unique_id;
+    std::unique_ptr<BufferImpl> impl_;
 };
-
-UncompressedBufferPageMapping generate_buffer_page_mapping(const Buffer& buffer);
-
-using HostDataType = std::variant<
-    const std::shared_ptr<std::vector<uint8_t>>,
-    const std::shared_ptr<std::vector<uint16_t>>,
-    const std::shared_ptr<std::vector<int32_t>>,
-    const std::shared_ptr<std::vector<uint32_t>>,
-    const std::shared_ptr<std::vector<float>>,
-    const std::shared_ptr<std::vector<bfloat16>>,
-    const void*>;
 
 }  // namespace tt::tt_metal
 

--- a/tt_metal/api/tt-metalium/buffer_distribution_spec.hpp
+++ b/tt_metal/api/tt-metalium/buffer_distribution_spec.hpp
@@ -13,18 +13,10 @@
 namespace tt::tt_metal {
 
 namespace detail {
-// TODO: These functions in the detail namespace are sharding utility functions and should be moved to a separate
-// header.
-UncompressedBufferPageMapping compute_page_mapping(
-    const Shape& tensor_shape,
-    const Shape& shard_shape,
-    const std::vector<CoreCoord>& cores,
-    ShardDistributionStrategy shard_distribution_strategy = ShardDistributionStrategy::ROUND_ROBIN_1D);
-
 // Squeezes tensor and shard shapes to minimize rank while preserving sharding semantics.
 // The returned shapes are guaranteed to have the same rank.
 std::pair<Shape, Shape> squeeze_shape_ranks(const Shape& tensor_shape, const Shape& shard_shape);
-}
+}  // namespace detail
 
 class BufferDistributionSpec {
 public:
@@ -75,10 +67,7 @@ public:
     // number of shards per core in group 1, number of shards per core in group 2.
     std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> core_groups_tuple() const;
 
-    UncompressedBufferPageMapping compute_page_mapping() const {
-        return detail::compute_page_mapping(
-            tensor_shape_in_pages_, shard_shape_in_pages_, cores_, shard_distribution_strategy_);
-    }
+    UncompressedBufferPageMapping compute_page_mapping() const;
 
 private:
     static std::vector<CoreCoord> compute_core_list(

--- a/tt_metal/api/tt-metalium/host_buffer.hpp
+++ b/tt_metal/api/tt-metalium/host_buffer.hpp
@@ -49,7 +49,6 @@ public:
     HostBuffer& operator=(const HostBuffer& other);
     HostBuffer(HostBuffer&& other) noexcept;
     HostBuffer& operator=(HostBuffer&& other) noexcept;
-    void swap(HostBuffer& other) noexcept;
 
     ttsl::Span<std::byte> view_bytes() & noexcept;
     ttsl::Span<const std::byte> view_bytes() const& noexcept;
@@ -73,6 +72,7 @@ public:
 
 private:
     friend class experimental::HostBufferPinnedMemoryHelper;
+    void swap(HostBuffer& other) noexcept;
     void register_pinned_memory_cache_release_callback();
 
     MemoryPin pin_;
@@ -120,7 +120,5 @@ ttsl::Span<const T> HostBuffer::view_as() const& {
 // Compares data buffers by their data.
 bool operator==(const HostBuffer& a, const HostBuffer& b) noexcept;
 bool operator!=(const HostBuffer& buffer_a, const HostBuffer& buffer_b) noexcept;
-
-void swap(HostBuffer& lhs, HostBuffer& rhs) noexcept;
 
 }  // namespace tt::tt_metal

--- a/tt_metal/api/tt-metalium/tensor_accessor_args.hpp
+++ b/tt_metal/api/tt-metalium/tensor_accessor_args.hpp
@@ -56,8 +56,6 @@ public:
     std::vector<uint32_t> get_compile_time_args() const;
     std::vector<uint32_t> get_common_runtime_args() const;
 
-    static constexpr size_t MAX_NUM_DIMENSIONS = 8;
-
 private:
     void update_args_config();
 

--- a/tt_metal/common/host_buffer.cpp
+++ b/tt_metal/common/host_buffer.cpp
@@ -70,6 +70,4 @@ bool operator==(const HostBuffer& a, const HostBuffer& b) noexcept {
 
 bool operator!=(const HostBuffer& a, const HostBuffer& b) noexcept { return !(a == b); }
 
-void swap(HostBuffer& lhs, HostBuffer& rhs) noexcept { lhs.swap(rhs); }
-
 }  // namespace tt::tt_metal

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "impl/buffers/buffer_impl.hpp"
 #include <tt_stl/fmt.hpp>
 #include "fd_mesh_command_queue.hpp"
 
@@ -791,7 +792,7 @@ bool FDMeshCommandQueue::write_shard_to_device(
 
     auto* device_buffer = buffer.get_device_buffer(device_coord);
     auto region_value = region.value_or(BufferRegion(0, device_buffer->size()));
-    auto shard_view = device_buffer->view(region_value);
+    auto shard_view = device_buffer->impl().view(*device_buffer, region_value);
 
 #if defined(TT_UMD_BUILD_SIMULATION)
     const tt_sim::DirectWriteGuard tt_sim_direct_write_guard{
@@ -837,7 +838,8 @@ void FDMeshCommandQueue::read_shard_from_device(
     TT_FATAL(!trace_id_.has_value(), "Reads are not supported during trace capture.");
 
     auto* device_buffer = buffer.get_device_buffer(device_coord);
-    auto shard_view = device_buffer->view(region.value_or(BufferRegion(0, device_buffer->size())));
+    auto shard_view =
+        device_buffer->impl().view(*device_buffer, region.value_or(BufferRegion(0, device_buffer->size())));
 
     auto* device = shard_view->device();
     sub_device_ids = buffer_dispatch::select_sub_device_ids(mesh_device_, sub_device_ids);

--- a/tt_metal/distributed/mesh_buffer.cpp
+++ b/tt_metal/distributed/mesh_buffer.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <host_api.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 #include <mesh_buffer.hpp>
 #include <mesh_coord.hpp>
 #include <tt_stl/overloaded.hpp>
@@ -227,7 +228,7 @@ std::shared_ptr<MeshBuffer> MeshBuffer::create(
                 continue;
             }
             auto* device = mesh_device->impl().get_device(coord);
-            auto buffer = Buffer::create(
+            auto buffer = BufferImpl::create(
                 device,
                 device_local_size,
                 device_local_config.page_size,
@@ -269,7 +270,7 @@ std::shared_ptr<MeshBuffer> MeshBuffer::create(
 
         // Rely on the MeshDevice allocator to provide the address for the entire mesh buffer.
         // The address provided to the backing buffer is used as the address for the MeshBuffer object.
-        std::shared_ptr<Buffer> backing_buffer = Buffer::create(
+        std::shared_ptr<Buffer> backing_buffer = BufferImpl::create(
             mesh_device,
             device_local_size,
             device_local_config.page_size,
@@ -295,7 +296,7 @@ std::shared_ptr<MeshBuffer> MeshBuffer::create(
 
 void MeshBuffer::initialize_device_buffers() {
     auto init_device_buffer_at_address = [this](const MeshCoordinate& coord) {
-        std::shared_ptr<Buffer> buffer = Buffer::create(
+        std::shared_ptr<Buffer> buffer = BufferImpl::create(
             device()->impl().get_device(coord),
             address_,
             device_local_size_,
@@ -435,7 +436,7 @@ void MeshBuffer::deallocate() {
     // Special handling is required if MeshDevice is already deallocated
     if (std::holds_alternative<OwnedBufferState>(state_)) {
         auto& owned_state = std::get<OwnedBufferState>(state_);
-        owned_state.backing_buffer->mark_as_deallocated();
+        owned_state.backing_buffer->impl().mark_as_deallocated();
     }
     state_ = DeallocatedState{};
 }
@@ -519,11 +520,11 @@ AnyBuffer AnyBuffer::create(const tt::tt_metal::ShardedBufferConfig& config, std
     if (!mesh_device) {
         const auto sharding_args = BufferShardingArgs(config.shard_parameters, config.buffer_layout);
         if (address.has_value()) {
-            return AnyBuffer{Buffer::create(
+            return AnyBuffer{BufferImpl::create(
                 config.device, *address, config.size, config.page_size, config.buffer_type, sharding_args)};
         }
         return AnyBuffer{
-            Buffer::create(config.device, config.size, config.page_size, config.buffer_type, sharding_args)};
+            BufferImpl::create(config.device, config.size, config.page_size, config.buffer_type, sharding_args)};
     }
     MeshBufferConfig mesh_config = ReplicatedBufferConfig{
         .size = config.size,
@@ -542,9 +543,9 @@ AnyBuffer AnyBuffer::create(const tt::tt_metal::BufferConfig& config, std::optio
     if (!mesh_device) {
         if (address.has_value()) {
             return AnyBuffer{
-                Buffer::create(config.device, *address, config.size, config.page_size, config.buffer_type)};
+                BufferImpl::create(config.device, *address, config.size, config.page_size, config.buffer_type)};
         }
-        return AnyBuffer{Buffer::create(config.device, config.size, config.page_size, config.buffer_type)};
+        return AnyBuffer{BufferImpl::create(config.device, config.size, config.page_size, config.buffer_type)};
     }
     MeshBufferConfig mesh_config = ReplicatedBufferConfig{
         .size = config.size,

--- a/tt_metal/distributed/mesh_workload.cpp
+++ b/tt_metal/distributed/mesh_workload.cpp
@@ -8,6 +8,7 @@
 #include <mesh_command_queue.hpp>
 #include <mesh_workload.hpp>
 #include <cstdint>
+#include "impl/buffers/buffer_impl.hpp"
 #include <tt_metal/impl/program/program_command_sequence.hpp>
 #include "distributed/mesh_device_impl.hpp"
 #include "tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp"
@@ -195,7 +196,7 @@ void MeshWorkloadImpl::load_binaries(MeshCommandQueue& mesh_cq) {
                     device_range,
                     false);
 
-                std::shared_ptr<Buffer> buffer_view = Buffer::create(
+                std::shared_ptr<Buffer> buffer_view = BufferImpl::create(
                     mesh_device,
                     kernel_bin_buf_->address(),
                     kernel_bin_size,

--- a/tt_metal/distributed/sd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/sd_mesh_command_queue.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "impl/buffers/buffer_impl.hpp"
 #include <tt_stl/fmt.hpp>
 #include "sd_mesh_command_queue.hpp"
 #include "impl/context/metal_context.hpp"
@@ -119,7 +120,7 @@ bool SDMeshCommandQueue::write_shard_to_device(
 
     auto* device_buffer = buffer.get_device_buffer(device_coord);
     auto region_value = region.value_or(BufferRegion(0, device_buffer->size()));
-    auto shard_view = device_buffer->view(region_value);
+    auto shard_view = device_buffer->impl().view(*device_buffer, region_value);
 
     TT_FATAL(sub_device_ids.empty(), "Sub-device IDs are not supported for slow dispatch");
     if (tt::tt_metal::GraphTracker::instance().hook_write_to_device(&buffer)) {
@@ -154,7 +155,8 @@ void SDMeshCommandQueue::read_shard_from_device(
     drain_emule_run(mesh_device_, get_target_device_type());
     wait_for_cores_idle();
     auto* device_buffer = buffer.get_device_buffer(device_coord);
-    auto shard_view = device_buffer->view(region.value_or(BufferRegion(0, device_buffer->size())));
+    auto shard_view =
+        device_buffer->impl().view(*device_buffer, region.value_or(BufferRegion(0, device_buffer->size())));
 
     TT_FATAL(sub_device_ids.empty(), "Sub-device IDs are not supported for slow dispatch");
     if (tt::tt_metal::GraphTracker::instance().hook_read_from_device(&buffer)) {

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/experimental/allocation_context.hpp>
 #include "allocator_types.hpp"
 #include <tt-metalium/buffer.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 #include <enchantum/enchantum.hpp>
 #include <functional>
 #include <algorithm>
@@ -142,7 +143,7 @@ DeviceAddr AllocatorImpl::allocate_buffer(Buffer* buffer) {
     auto size = buffer->aligned_size();
     auto page_size = buffer->aligned_page_size();
     auto buffer_type = buffer->buffer_type();
-    auto bottom_up = buffer->bottom_up();
+    auto bottom_up = buffer->impl().bottom_up();
     auto num_cores = buffer->num_cores();
     this->verify_safe_allocation();
     if (config_->disable_interleaved) {
@@ -150,7 +151,7 @@ DeviceAddr AllocatorImpl::allocate_buffer(Buffer* buffer) {
     }
 
     // Per-core allocation path: each core gets an independent address
-    if (buffer->per_core_allocation_) {
+    if (buffer->impl().per_core_allocation_) {
         TT_FATAL(
             config_->allocator_mode == AllocatorMode::HYBRID,
             "Per-core allocation requires AllocatorMode::HYBRID when opening the device");
@@ -178,12 +179,12 @@ DeviceAddr AllocatorImpl::allocate_buffer(Buffer* buffer) {
                 AllocatorID{bank_id + 1},
                 persistent_l1_.occupied_ranges(core));
         }
-        buffer->set_per_core_addresses(std::move(addrs));
+        buffer->impl().set_per_core_addresses(std::move(addrs));
         allocated_buffers_.insert(buffer);
         if (tracking_enabled_) [[unlikely]] {
             this->record_allocation_if_unsafe(buffer);
         }
-        return buffer->per_core_addresses_.at(cores[0]);
+        return buffer->impl().per_core_addresses_.at(cores[0]);
     }
 
     switch (buffer_type) {
@@ -245,10 +246,10 @@ void AllocatorImpl::deallocate_buffer(Buffer* buffer) {
     auto buffer_type = buffer->buffer_type();
 
     // Per-core deallocation path
-    if (buffer->per_core_allocation_) {
+    if (buffer->impl().per_core_allocation_) {
         TT_FATAL(buffer_type == BufferType::L1, "per_core_allocation is only supported for L1 buffers");
         using AllocatorID = BankManager::AllocatorDependencies::AllocatorID;
-        for (const auto& [core, addr] : buffer->per_core_addresses_) {
+        for (const auto& [core, addr] : buffer->impl().per_core_addresses_) {
             auto bank_id = logical_core_to_bank_ids_.at(BufferType::L1).at(core).at(0);
             l1_manager_->deallocate_buffer(addr, AllocatorID{bank_id + 1});
         }
@@ -586,7 +587,7 @@ AllocatorImpl::~AllocatorImpl() {
 AllocatorState AllocatorImpl::extract_state() const {
     std::lock_guard<std::mutex> lock(mutex_);
     for (auto* buf : allocated_buffers_) {
-        TT_FATAL(!buf->per_core_allocation_, "extract_state does not yet support per-core L1 allocations");
+        TT_FATAL(!buf->impl().per_core_allocation_, "extract_state does not yet support per-core L1 allocations");
     }
 
     std::unordered_map<BufferType, AllocatorState::BufferTypeState> states_per_buffer_type;
@@ -619,7 +620,7 @@ AllocatorState AllocatorImpl::extract_state() const {
 void AllocatorImpl::override_state(const AllocatorState& state) {
     std::lock_guard<std::mutex> lock(mutex_);
     for (auto* buf : allocated_buffers_) {
-        TT_FATAL(!buf->per_core_allocation_, "override_state does not yet support per-core L1 allocations");
+        TT_FATAL(!buf->impl().per_core_allocation_, "override_state does not yet support per-core L1 allocations");
     }
 
     // Clear all buffer types
@@ -665,42 +666,38 @@ DeviceAddr calculate_bank_size_spread(
 }  // namespace detail
 
 // External facing Allocator
-Allocator::Allocator(AllocatorImpl* _impl) : impl(_impl) {}
+Allocator::Allocator(AllocatorImpl* _impl) : impl_(_impl) {}
 
-void Allocator::deallocate_buffers() { impl->deallocate_buffers(); }
+void Allocator::deallocate_buffers() { impl_->deallocate_buffers(); }
 
-std::unordered_set<Buffer*> Allocator::get_allocated_buffers() const { return impl->get_allocated_buffers(); }
+std::unordered_set<Buffer*> Allocator::get_allocated_buffers() const { return impl_->get_allocated_buffers(); }
 
-uint32_t Allocator::get_num_banks(const BufferType& buffer_type) const { return impl->get_num_banks(buffer_type); }
+uint32_t Allocator::get_num_banks(const BufferType& buffer_type) const { return impl_->get_num_banks(buffer_type); }
 
-DeviceAddr Allocator::get_bank_size(const BufferType& buffer_type) const { return impl->get_bank_size(buffer_type); }
+DeviceAddr Allocator::get_bank_size(const BufferType& buffer_type) const { return impl_->get_bank_size(buffer_type); }
 
 CoreCoord Allocator::get_logical_core_from_bank_id(uint32_t bank_id) const {
-    return impl->get_logical_core_from_bank_id(bank_id);
+    return impl_->get_logical_core_from_bank_id(bank_id);
 }
 
 int32_t Allocator::get_bank_offset(BufferType buffer_type, uint32_t bank_id) const {
-    return impl->get_bank_offset(buffer_type, bank_id);
+    return impl_->get_bank_offset(buffer_type, bank_id);
 }
 
 const std::vector<uint32_t>& Allocator::get_bank_ids_from_logical_core(
     BufferType buffer_type, const CoreCoord& logical_core) const {
-    return impl->get_bank_ids_from_logical_core(buffer_type, logical_core);
+    return impl_->get_bank_ids_from_logical_core(buffer_type, logical_core);
 }
 
 DeviceAddr Allocator::get_base_allocator_addr(const HalMemType& mem_type) const {
-    return impl->get_base_allocator_addr(mem_type);
+    return impl_->get_base_allocator_addr(mem_type);
 }
 
-uint32_t Allocator::get_alignment(BufferType buffer_type) const { return impl->get_alignment(buffer_type); }
+uint32_t Allocator::get_alignment(BufferType buffer_type) const { return impl_->get_alignment(buffer_type); }
 
-Statistics Allocator::get_statistics(const BufferType& buffer_type) const { return impl->get_statistics(buffer_type); }
+Statistics Allocator::get_statistics(const BufferType& buffer_type) const { return impl_->get_statistics(buffer_type); }
 
-AllocatorState Allocator::extract_state() const { return impl->extract_state(); }
-
-void Allocator::override_state(const AllocatorState& state) { impl->override_state(state); }
-
-size_t Allocator::get_worker_l1_size() const { return impl->get_worker_l1_size(); }
+size_t Allocator::get_worker_l1_size() const { return impl_->get_worker_l1_size(); }
 
 }  // namespace tt::tt_metal
 
@@ -709,9 +706,9 @@ namespace tt::tt_metal::experimental {
 void synchronize_allocator_state(Allocator* target, const std::vector<Allocator*>& sources) {
     AllocatorState merged_state;
     for (auto* source : sources) {
-        merged_state.merge(source->extract_state());
+        merged_state.merge(source->impl().extract_state());
     }
-    target->override_state(merged_state);
+    target->impl().override_state(merged_state);
 }
 
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/impl/buffers/buffer.cpp
+++ b/tt_metal/impl/buffers/buffer.cpp
@@ -37,8 +37,79 @@
 #include <tt-metalium/allocator.hpp>
 
 #include "impl/emulation/emule_live_ranges.hpp"
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/buffers/buffer_sharding_args_impl.hpp"
+#include "impl/buffers/generate_buffer_page_mapping.hpp"
+#include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
 
 namespace tt::tt_metal {
+namespace {
+
+BufferShardingArgsImpl make_sharding_args_impl(std::optional<BufferDistributionSpec> spec) {
+    const auto layout = spec.has_value() ? TensorMemoryLayout::BLOCK_SHARDED : TensorMemoryLayout::INTERLEAVED;
+    return BufferShardingArgsImpl{std::move(spec), std::nullopt, layout};
+}
+
+}  // namespace
+
+BufferShardingArgs::BufferShardingArgs(BufferShardingArgsImpl impl) :
+    impl_(std::make_unique<BufferShardingArgsImpl>(std::move(impl))) {}
+
+BufferShardingArgs::BufferShardingArgs() : BufferShardingArgs(BufferShardingArgsImpl{}) {}
+
+BufferShardingArgs::BufferShardingArgs(std::nullopt_t) : BufferShardingArgs(BufferShardingArgsImpl{}) {}
+
+BufferShardingArgs::BufferShardingArgs(BufferDistributionSpec buffer_distribution_spec) :
+    BufferShardingArgs(
+        BufferShardingArgsImpl{std::move(buffer_distribution_spec), std::nullopt, TensorMemoryLayout::BLOCK_SHARDED}) {}
+
+BufferShardingArgs::BufferShardingArgs(std::optional<BufferDistributionSpec> buffer_distribution_spec) :
+    BufferShardingArgs(make_sharding_args_impl(std::move(buffer_distribution_spec))) {}
+
+BufferShardingArgs::BufferShardingArgs(ShardSpecBuffer shard_spec, TensorMemoryLayout buffer_layout) :
+    BufferShardingArgs(BufferShardingArgsImpl{std::nullopt, std::move(shard_spec), buffer_layout}) {}
+
+BufferShardingArgs::BufferShardingArgs(std::optional<ShardSpecBuffer> shard_spec, TensorMemoryLayout buffer_layout) :
+    BufferShardingArgs(BufferShardingArgsImpl{std::nullopt, std::move(shard_spec), buffer_layout}) {}
+
+BufferShardingArgs::BufferShardingArgs(
+    std::optional<BufferDistributionSpec> buffer_distribution_spec,
+    std::optional<ShardSpecBuffer> shard_spec,
+    TensorMemoryLayout buffer_layout) :
+    BufferShardingArgs(
+        BufferShardingArgsImpl{std::move(buffer_distribution_spec), std::move(shard_spec), buffer_layout}) {}
+
+BufferShardingArgs::BufferShardingArgs(const BufferShardingArgs& other) : BufferShardingArgs(other.impl()) {}
+
+BufferShardingArgs& BufferShardingArgs::operator=(const BufferShardingArgs& other) {
+    if (this != &other) {
+        impl_ = std::make_unique<BufferShardingArgsImpl>(other.impl());
+    }
+    return *this;
+}
+
+BufferShardingArgs::BufferShardingArgs(BufferShardingArgs&&) noexcept = default;
+BufferShardingArgs& BufferShardingArgs::operator=(BufferShardingArgs&&) noexcept = default;
+BufferShardingArgs::~BufferShardingArgs() = default;
+
+const std::optional<BufferDistributionSpec>& BufferShardingArgs::buffer_distribution_spec() const {
+    return impl().buffer_distribution_spec_;
+}
+
+const std::optional<ShardSpecBuffer>& BufferShardingArgs::shard_spec() const { return impl().shard_spec_; }
+
+TensorMemoryLayout BufferShardingArgs::buffer_layout() const { return impl().buffer_layout_; }
+
+const BufferShardingArgsImpl& BufferShardingArgs::impl() const {
+    TT_FATAL(impl_ != nullptr, "BufferShardingArgs is in a moved-from state.");
+    return *impl_;
+}
+
+BufferShardingArgsImpl& BufferShardingArgs::impl() {
+    TT_FATAL(impl_ != nullptr, "BufferShardingArgs is in a moved-from state.");
+    return *impl_;
+}
+
 namespace {
 
 #if defined(TRACY_ENABLE)
@@ -316,7 +387,7 @@ void validate_sub_device_manager_id(std::optional<SubDeviceManagerId> sub_device
 
 }  // namespace
 
-std::atomic<size_t> Buffer::next_unique_id = 0;
+std::atomic<size_t> BufferImpl::next_unique_id = 0;
 
 std::ostream& operator<<(std::ostream& os, const ShardSpec& spec) {
     os << "ShardSpec{";
@@ -409,7 +480,7 @@ UncompressedBufferPageMapping generate_buffer_page_mapping(const Buffer& buffer)
     return buffer_page_mapping;
 }
 
-Buffer::Buffer(
+BufferImpl::BufferImpl(
     IDevice* device,
     DeviceAddr size,
     DeviceAddr page_size,
@@ -417,13 +488,12 @@ Buffer::Buffer(
     const BufferShardingArgs& sharding_args,
     const std::optional<bool> bottom_up,
     const std::optional<SubDeviceId> sub_device_id,
-    const bool owns_data,
-    Private) :
+    const bool owns_data) :
     device_(device),
     size_(size),
     buffer_type_(buffer_type),
     buffer_layout_(sharding_args.buffer_layout()),
-    bottom_up_(bottom_up.value_or(this->is_dram())),
+    bottom_up_(bottom_up.value_or(buffer_type == BufferType::DRAM || buffer_type == BufferType::TRACE)),
     sub_device_id_(sub_device_id),
     owns_data_(owns_data),
     page_size_(page_size),
@@ -450,7 +520,19 @@ Buffer::Buffer(
     unique_id_ = next_unique_id.fetch_add(1);
 }
 
-std::shared_ptr<Buffer> Buffer::create(
+Buffer::Buffer(BufferImpl impl) : impl_(std::make_unique<BufferImpl>(std::move(impl))) {}
+
+const BufferImpl& Buffer::impl() const {
+    TT_FATAL(impl_ != nullptr, "Buffer is in a moved-from state.");
+    return *impl_;
+}
+
+BufferImpl& Buffer::impl() {
+    TT_FATAL(impl_ != nullptr, "Buffer is in a moved-from state.");
+    return *impl_;
+}
+
+std::shared_ptr<Buffer> BufferImpl::create(
     IDevice* device,
     DeviceAddr size,
     DeviceAddr page_size,
@@ -460,15 +542,15 @@ std::shared_ptr<Buffer> Buffer::create(
     const std::optional<SubDeviceId> sub_device_id) {
     LIGHT_METAL_TRACE_FUNCTION_ENTRY();
 
-    auto buffer = std::make_shared<Buffer>(
-        device, size, page_size, buffer_type, sharding_args, bottom_up, sub_device_id, true /* owns data */, Private());
+    auto buffer = std::make_shared<Buffer>(BufferImpl(
+        device, size, page_size, buffer_type, sharding_args, bottom_up, sub_device_id, true /* owns data */));
 
-    if (buffer->size_ == 0) {
-        buffer->allocation_status_ = AllocationStatus::ALLOCATED;
+    if (buffer->impl().size_ == 0) {
+        buffer->impl().allocation_status_ = BufferImpl::AllocationStatus::ALLOCATED;
         return buffer;
     }
 
-    buffer->allocate_impl();
+    buffer->impl().allocate_impl(*buffer);
 
     LIGHT_METAL_TRACE_FUNCTION_CALL(
         CaptureBufferCreate,
@@ -485,7 +567,7 @@ std::shared_ptr<Buffer> Buffer::create(
     return buffer;
 }
 
-std::shared_ptr<Buffer> Buffer::create(
+std::shared_ptr<Buffer> BufferImpl::create(
     IDevice* device,
     DeviceAddr address,
     DeviceAddr size,
@@ -495,36 +577,28 @@ std::shared_ptr<Buffer> Buffer::create(
     const std::optional<bool> bottom_up,
     const std::optional<SubDeviceId> sub_device_id) {
     LIGHT_METAL_TRACE_FUNCTION_ENTRY();
-    auto buffer = std::make_shared<Buffer>(
-        device,
-        size,
-        page_size,
-        buffer_type,
-        sharding_args,
-        bottom_up,
-        sub_device_id,
-        false /* owns data */,
-        Private());
+    auto buffer = std::make_shared<Buffer>(BufferImpl(
+        device, size, page_size, buffer_type, sharding_args, bottom_up, sub_device_id, false /* owns data */));
 
-    buffer->address_ = address;
-    buffer->allocation_status_ = AllocationStatus::ALLOCATED;
+    buffer->impl().address_ = address;
+    buffer->impl().allocation_status_ = BufferImpl::AllocationStatus::ALLOCATED;
 
     // Explicit-address (non-owning) buffers skip allocate_impl(), so register their
     // extent here (removed in deallocate()): per-core for L1 (SANITIZER_CHECKS.md §4),
     // full size for DRAM — mirroring the allocate_impl() registration.
-    if (is_emule_device(device) && buffer->size_ != 0) {
+    if (is_emule_device(device) && buffer->impl().size_ != 0) {
         if (buffer_type == BufferType::L1 || buffer_type == BufferType::L1_SMALL) {
             tt::tt_metal::emule::LiveL1Ranges::add(
                 device->id(),
                 static_cast<uint32_t>(address),
                 static_cast<uint32_t>(address + buffer->aligned_size_per_bank()),
-                buffer->unique_id_);
+                buffer->impl().unique_id_);
         } else if (buffer_type == BufferType::DRAM) {
             tt::tt_metal::emule::LiveDramRanges::add(
                 device->id(),
                 static_cast<uint32_t>(address),
                 static_cast<uint32_t>(address + size),
-                buffer->unique_id_);
+                buffer->impl().unique_id_);
         }
     }
 
@@ -543,18 +617,18 @@ std::shared_ptr<Buffer> Buffer::create(
     return buffer;
 }
 
-std::shared_ptr<Buffer> Buffer::view(const BufferRegion& region) {
-    TT_FATAL(region.offset % page_size() == 0, "Region offset must be a multiple of page size");
-    TT_FATAL(region.size % page_size() == 0, "Region size must be a multiple of page size");
-    TT_FATAL(region.offset + region.size <= size(), "Region must be within buffer");
+std::shared_ptr<Buffer> BufferImpl::view(Buffer& self, const BufferRegion& region) {
+    TT_FATAL(region.offset % self.page_size() == 0, "Region offset must be a multiple of page size");
+    TT_FATAL(region.size % self.page_size() == 0, "Region size must be a multiple of page size");
+    TT_FATAL(region.offset + region.size <= self.size(), "Region must be within buffer");
 
-    if (region.offset == 0 && region.size == size()) {
-        return shared_from_this();
+    if (region.offset == 0 && region.size == self.size()) {
+        return self.shared_from_this();
     }
 
     TT_FATAL(!per_core_allocation_, "Buffer::view() with sub-regions is not supported for per-core allocated buffers");
 
-    auto buffer = Buffer::create(
+    auto buffer = BufferImpl::create(
         device_,
         address_,
         region.size,
@@ -566,27 +640,28 @@ std::shared_ptr<Buffer> Buffer::view(const BufferRegion& region) {
 
     std::shared_ptr<const BufferPageMapping> new_page_mapping;
     if (is_sharded(buffer_layout_)) {
-        new_page_mapping = std::make_shared<const BufferPageMapping>(get_buffer_page_mapping()->filter_by_host_range(
-            region.offset / page_size(), (region.offset + region.size) / page_size()));
+        new_page_mapping =
+            std::make_shared<const BufferPageMapping>(self.get_buffer_page_mapping()->filter_by_host_range(
+                region.offset / self.page_size(), (region.offset + region.size) / self.page_size()));
     }
 
-    buffer->root_buffer_ = root_buffer();
-    buffer->root_buffer_offset_ = root_buffer_offset_ + region.offset;
-    buffer->buffer_page_mapping_ = new_page_mapping;
+    buffer->impl().root_buffer_ = root_buffer(self);
+    buffer->impl().root_buffer_offset_ = root_buffer_offset_ + region.offset;
+    buffer->impl().buffer_page_mapping_ = new_page_mapping;
 
     return buffer;
 }
 
-Allocator* Buffer::allocator() const { return allocator_->view().get(); }
+Allocator* Buffer::allocator() const { return impl_->allocator_->view().get(); }
 
-void Buffer::allocate_impl() {
-    if (GraphTracker::instance().hook_allocate(this)) {
+void BufferImpl::allocate_impl(Buffer& self) {
+    if (GraphTracker::instance().hook_allocate(&self)) {
         address_ = 0;
         hooked_allocation_ = true;
     } else {
         validate_sub_device_manager_id(sub_device_manager_id_, device_);
 
-        address_ = allocator_->allocate_buffer(this);
+        address_ = allocator_->allocate_buffer(&self);
 
         // Assertion here because buffer class returns a u32 when address is queried
         // Requires updating all use cases of buffer address to accept a u64 to remove
@@ -598,7 +673,7 @@ void Buffer::allocate_impl() {
                 tt::tt_metal::emule::LiveL1Ranges::add(
                     device_->id(),
                     static_cast<uint32_t>(address_),
-                    static_cast<uint32_t>(address_ + aligned_size_per_bank()),
+                    static_cast<uint32_t>(address_ + self.aligned_size_per_bank()),
                     unique_id_);
             } else if (buffer_type_ == BufferType::DRAM) {
                 tt::tt_metal::emule::LiveDramRanges::add(
@@ -622,10 +697,10 @@ void Buffer::allocate_impl() {
     // Important! Graph tracker must called after the allocation status is updated.
     allocation_status_ = AllocationStatus::ALLOCATED;
 
-    GraphTracker::instance().track_allocate(this);
+    GraphTracker::instance().track_allocate(&self);
 }
 
-void Buffer::deallocate() {
+void BufferImpl::deallocate(Buffer& self) {
     if (!owns_data_) {
         // device_ may be dangling here during teardown, so read the latch instead of touching it.
         if (emule_device_seen.load(std::memory_order_relaxed)) {
@@ -642,26 +717,25 @@ void Buffer::deallocate() {
         }
         return;
     }
-    this->deallocate_impl();
+    this->deallocate_impl(self);
 }
 
-void Buffer::mark_as_deallocated() { allocation_status_ = AllocationStatus::DEALLOCATED; }
-
-void Buffer::deallocate_impl() {
+void BufferImpl::deallocate_impl(Buffer& self) {
     if (allocation_status_ != AllocationStatus::ALLOCATED) {
         return;
     }
 
     if (device_->is_initialized() && size_ != 0) {
         // address_ is only modified from this thread, no sync required
-        GraphTracker::instance().track_deallocate(this);
-        if (!GraphTracker::instance().hook_deallocate(this) && !hooked_allocation_) {
+        GraphTracker::instance().track_deallocate(&self);
+        if (!GraphTracker::instance().hook_deallocate(&self) && !hooked_allocation_) {
 #if defined(TRACY_ENABLE)
             if (tt::tt_metal::MetalContext::instance(extract_context_id(device_))
                     .rtoptions()
                     .get_profiler_buffer_usage_enabled()) {
                 TracyFreeN(
-                    reinterpret_cast<const void*>(address()), get_buffer_location_name(buffer_type_, device_->id()));
+                    reinterpret_cast<const void*>(self.address()),
+                    get_buffer_location_name(buffer_type_, device_->id()));
             }
 #endif
             validate_sub_device_manager_id(sub_device_manager_id_, device_);
@@ -673,12 +747,12 @@ void Buffer::deallocate_impl() {
                     tt::tt_metal::emule::LiveDramRanges::remove(device_->id(), unique_id_);
                 }
             }
-            allocator_->deallocate_buffer(this);
+            allocator_->deallocate_buffer(&self);
         }
 
         // Capture deallocates here instead of higher levels.
         LIGHT_METAL_TRACE_FUNCTION_ENTRY();
-        LIGHT_METAL_TRACE_FUNCTION_CALL(CaptureBufferDeallocate, *this);
+        LIGHT_METAL_TRACE_FUNCTION_CALL(CaptureBufferDeallocate, self);
     }
 
     allocation_status_ = AllocationStatus::DEALLOCATED;
@@ -687,138 +761,126 @@ void Buffer::deallocate_impl() {
 Buffer::~Buffer() {
     LIGHT_METAL_TRACE_FUNCTION_ENTRY();
     LIGHT_METAL_TRACE_FUNCTION_CALL(CaptureBufferDelete, *this);
-    if (this->allocation_status_ != AllocationStatus::DEALLOCATED) {
-        this->deallocate();
+    if (impl_ && impl_->allocation_status_ != BufferImpl::AllocationStatus::DEALLOCATED) {
+        impl_->deallocate(*this);
     }
 }
 
-bool Buffer::is_allocated() const { return allocation_status_ == AllocationStatus::ALLOCATED; }
+IDevice* Buffer::device() const { return impl_->device_; }
+DeviceAddr Buffer::size() const { return impl_->size_; }
+bool Buffer::is_allocated() const { return impl_->is_allocated(); }
+BufferType Buffer::buffer_type() const { return impl_->buffer_type_; }
+TensorMemoryLayout Buffer::buffer_layout() const { return impl_->buffer_layout_; }
+bool Buffer::has_shard_spec() const { return impl_->shard_spec_.has_value(); }
+size_t Buffer::unique_id() const { return impl_->unique_id_; }
 
 uint32_t Buffer::address() const {
     TT_FATAL(
-        allocation_status_ != AllocationStatus::ALLOCATION_REQUESTED,
+        impl_->allocation_status_ != BufferImpl::AllocationStatus::ALLOCATION_REQUESTED,
         "Can only query the address of a buffer that has been allocated");
-    return address_;
+    return impl_->address_;
 }
 
-DeviceAddr Buffer::page_size() const { return page_size_; }
-
-void Buffer::set_page_size(DeviceAddr page_size) {
-    TT_FATAL(page_size == 0 ? size_ == 0 : size_ % page_size == 0, "buffer size must be divisible by new page size");
-    page_size_ = page_size;
-    this->buffer_distribution_spec_ = std::nullopt;
-    this->buffer_page_mapping_ = nullptr;
-}
+DeviceAddr Buffer::page_size() const { return impl_->page_size_; }
 
 uint32_t Buffer::num_pages() const { return page_size() == 0 ? 0 : size() / page_size(); }
 
 uint32_t Buffer::num_dev_pages() const {
-    if (!is_sharded(this->buffer_layout_)) {
+    if (!is_sharded(impl_->buffer_layout_)) {
         return this->num_pages();
     }
-    if (shard_spec_.has_value()) {
-        return shard_spec_->num_pages() * this->num_cores().value();
+    if (impl_->shard_spec_.has_value()) {
+        return impl_->shard_spec_->num_pages() * this->num_cores().value();
     }
-    return buffer_distribution_spec_.value().max_num_dev_pages_per_core() * num_cores().value();
+    return impl_->buffer_distribution_spec_.value().max_num_dev_pages_per_core() * num_cores().value();
 }
 
-HalMemType Buffer::memory_type() const {
-    if (this->is_dram()) {
+HalMemType BufferImpl::memory_type() const {
+    if (buffer_type_ == BufferType::DRAM || buffer_type_ == BufferType::TRACE) {
         return HalMemType::DRAM;
     }
-    if (this->is_l1()) {
+    if (is_l1_impl(buffer_type_)) {
         return HalMemType::L1;
     }
-    TT_THROW("Unknown HAL memory type for {} buffer type", this->buffer_type());
+    TT_THROW("Unknown HAL memory type for {} buffer type", buffer_type_);
 }
 
 CoreType Buffer::core_type() const {
-    switch (this->buffer_type_) {
+    switch (impl_->buffer_type_) {
         case BufferType::DRAM: return CoreType::DRAM;
         case BufferType::L1:
         case BufferType::L1_SMALL: return CoreType::WORKER;
-        default: TT_THROW("Unknown CoreType {} for buffer", this->buffer_type_);
+        default: TT_THROW("Unknown CoreType {} for buffer", impl_->buffer_type_);
     }
 }
 
 bool Buffer::is_l1() const { return is_l1_impl(buffer_type()); }
 bool Buffer::is_dram() const { return buffer_type() == BufferType::DRAM || buffer_type() == BufferType::TRACE; }
-bool Buffer::is_trace() const { return buffer_type() == BufferType::TRACE; }
 
-bool Buffer::is_valid_region(const BufferRegion& region) const { return region.offset + region.size <= this->size(); }
+bool BufferImpl::is_valid_region(const BufferRegion& region) const { return region.offset + region.size <= size_; }
 
-bool Buffer::is_valid_partial_region(const BufferRegion& region) const {
-    return this->is_valid_region(region) && (region.offset > 0 || region.size != this->size());
+bool BufferImpl::is_valid_partial_region(const BufferRegion& region) const {
+    return is_valid_region(region) && (region.offset > 0 || region.size != size_);
 }
 
 DeviceAddr Buffer::page_address(DeviceAddr bank_id, DeviceAddr page_index) const {
-    DeviceAddr num_banks = static_cast<DeviceAddr>(allocator_->get_num_banks(buffer_type_));
+    DeviceAddr num_banks = static_cast<DeviceAddr>(impl_->allocator_->get_num_banks(impl_->buffer_type_));
     TT_FATAL(bank_id < num_banks, "Invalid Bank ID: {} exceeds total numbers of banks ({})!", bank_id, num_banks);
     DeviceAddr pages_offset_within_bank = page_index / num_banks;
     auto offset = (round_up(this->page_size(), static_cast<DeviceAddr>(this->alignment())) * pages_offset_within_bank);
-    return translate_page_address(offset, bank_id);
+    return impl_->translate_page_address(*this, offset, bank_id);
 }
 
-uint32_t Buffer::alignment() const { return allocator_->get_alignment(this->buffer_type()); }
+uint32_t Buffer::alignment() const { return impl_->allocator_->get_alignment(this->buffer_type()); }
 
 DeviceAddr Buffer::aligned_page_size() const { return align(page_size(), this->alignment()); }
 DeviceAddr Buffer::aligned_size() const { return this->num_dev_pages() * this->aligned_page_size(); }
 
 DeviceAddr Buffer::aligned_size_per_bank() const {
-    uint32_t num_banks =
-        is_sharded(this->buffer_layout_) ? this->num_cores().value() : allocator_->get_num_banks(this->buffer_type());
+    uint32_t num_banks = is_sharded(impl_->buffer_layout_) ? this->num_cores().value()
+                                                           : impl_->allocator_->get_num_banks(this->buffer_type());
     return tt::tt_metal::detail::calculate_bank_size_spread(
         this->aligned_size(), this->aligned_page_size(), num_banks, this->alignment());
 }
 
-void Buffer::set_per_core_addresses(std::unordered_map<CoreCoord, DeviceAddr> addrs) {
-    per_core_addresses_ = std::move(addrs);
-}
-
 ShardSpecBuffer Buffer::shard_spec() const {
-    TT_FATAL(is_sharded(this->buffer_layout_), "Buffer not sharded");
-    TT_FATAL(shard_spec_.has_value(), "Buffer is sharded, but no shard parameters specified");
-    return this->shard_spec_.value();
-}
-
-void Buffer::set_shard_spec(const ShardSpecBuffer& shard_spec) {
-    this->shard_spec_ = shard_spec;
-    this->buffer_distribution_spec_ = std::nullopt;
-    this->buffer_page_mapping_ = nullptr;
+    TT_FATAL(is_sharded(impl_->buffer_layout_), "Buffer not sharded");
+    TT_FATAL(impl_->shard_spec_.has_value(), "Buffer is sharded, but no shard parameters specified");
+    return impl_->shard_spec_.value();
 }
 
 std::optional<uint32_t> Buffer::num_cores() const {
-    if (!is_sharded(this->buffer_layout_)) {
+    if (!is_sharded(impl_->buffer_layout_)) {
         return std::nullopt;
     }
-    if (buffer_distribution_spec_.has_value()) {
-        return buffer_distribution_spec_.value().num_cores_with_data();
+    if (impl_->buffer_distribution_spec_.has_value()) {
+        return impl_->buffer_distribution_spec_.value().num_cores_with_data();
     }
-    return shard_spec_->tensor_shard_spec.grid.num_cores();
+    return impl_->shard_spec_->tensor_shard_spec.grid.num_cores();
 }
 
-DeviceAddr Buffer::translate_page_address(DeviceAddr offset, uint32_t bank_id) const {
-    DeviceAddr base_page_address = this->address() + allocator_->get_bank_offset(buffer_type_, bank_id);
+DeviceAddr BufferImpl::translate_page_address(const Buffer& self, DeviceAddr offset, uint32_t bank_id) const {
+    DeviceAddr base_page_address = self.address() + allocator_->get_bank_offset(buffer_type_, bank_id);
     return base_page_address + offset;
 }
 
 const std::shared_ptr<const BufferPageMapping>& Buffer::get_buffer_page_mapping() {
-    TT_FATAL(is_sharded(this->buffer_layout_), "Buffer not sharded");
-    if (!this->buffer_page_mapping_) {
-        this->buffer_page_mapping_ = std::make_shared<const BufferPageMapping>(generate_buffer_page_mapping(*this));
+    TT_FATAL(is_sharded(impl_->buffer_layout_), "Buffer not sharded");
+    if (!impl_->buffer_page_mapping_) {
+        impl_->buffer_page_mapping_ = std::make_shared<const BufferPageMapping>(generate_buffer_page_mapping(*this));
     }
-    return this->buffer_page_mapping_;
+    return impl_->buffer_page_mapping_;
 }
 
-std::shared_ptr<Buffer> Buffer::root_buffer() {
+std::shared_ptr<Buffer> BufferImpl::root_buffer(Buffer& self) {
     if (root_buffer_) {
         return root_buffer_;
     }
-    return shared_from_this();
+    return self.shared_from_this();
 }
 
 const std::optional<BufferDistributionSpec>& Buffer::buffer_distribution_spec() const {
-    return this->buffer_distribution_spec_;
+    return impl_->buffer_distribution_spec_;
 }
 
 bool ShardSpec::operator==(const ShardSpec&) const = default;

--- a/tt_metal/impl/buffers/buffer_distribution_spec.cpp
+++ b/tt_metal/impl/buffers/buffer_distribution_spec.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "buffer_distribution_spec.hpp"
+#include "impl/buffers/compute_page_mapping.hpp"
 #include <tt_stl/assert.hpp>
 
 #include <tt-metalium/math.hpp>
@@ -260,6 +261,11 @@ void BufferDistributionSpec::init_precomputed_data() {
             };
         }
     }
+}
+
+UncompressedBufferPageMapping BufferDistributionSpec::compute_page_mapping() const {
+    return detail::compute_page_mapping(
+        tensor_shape_in_pages_, shard_shape_in_pages_, cores_, shard_distribution_strategy_);
 }
 
 namespace detail {

--- a/tt_metal/impl/buffers/buffer_impl.hpp
+++ b/tt_metal/impl/buffers/buffer_impl.hpp
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/hal_types.hpp>
+#include <tt-metalium/sub_device_types.hpp>
+
+#include <atomic>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+
+namespace tt::tt_metal {
+
+class AllocatorImpl;
+class IDevice;
+
+class BufferImpl {
+public:
+    enum class AllocationStatus : uint8_t {
+        ALLOCATION_REQUESTED,
+        ALLOCATED,
+        DEALLOCATED,
+    };
+
+    BufferImpl(
+        IDevice* device,
+        DeviceAddr size,
+        DeviceAddr page_size,
+        BufferType buffer_type,
+        const BufferShardingArgs& sharding_args,
+        std::optional<bool> bottom_up,
+        std::optional<SubDeviceId> sub_device_id,
+        bool owns_data);
+
+    static std::shared_ptr<Buffer> create(
+        IDevice* device,
+        DeviceAddr size,
+        DeviceAddr page_size,
+        BufferType buffer_type,
+        const BufferShardingArgs& sharding_args = std::nullopt,
+        std::optional<bool> bottom_up = std::nullopt,
+        std::optional<SubDeviceId> sub_device_id = std::nullopt);
+    static std::shared_ptr<Buffer> create(
+        IDevice* device,
+        DeviceAddr address,
+        DeviceAddr size,
+        DeviceAddr page_size,
+        BufferType buffer_type,
+        const BufferShardingArgs& sharding_args = std::nullopt,
+        std::optional<bool> bottom_up = std::nullopt,
+        std::optional<SubDeviceId> sub_device_id = std::nullopt);
+
+    std::shared_ptr<Buffer> view(Buffer& self, const BufferRegion& region);
+
+    bool is_allocated() const { return allocation_status_ == AllocationStatus::ALLOCATED; }
+    HalMemType memory_type() const;
+    bool is_valid_region(const BufferRegion& region) const;
+    bool is_valid_partial_region(const BufferRegion& region) const;
+    bool bottom_up() const { return bottom_up_; }
+
+    std::shared_ptr<Buffer> root_buffer(Buffer& self);
+    BufferRegion root_buffer_region() const { return BufferRegion(root_buffer_offset_, size_); }
+    std::optional<SubDeviceId> sub_device_id() const { return sub_device_id_; }
+    void mark_as_deallocated() { allocation_status_ = AllocationStatus::DEALLOCATED; }
+
+    void allocate_impl(Buffer& self);
+    void deallocate(Buffer& self);
+    void deallocate_impl(Buffer& self);
+    DeviceAddr translate_page_address(const Buffer& self, DeviceAddr offset, uint32_t bank_id) const;
+
+    void set_per_core_addresses(std::unordered_map<CoreCoord, DeviceAddr> addrs) {
+        per_core_addresses_ = std::move(addrs);
+    }
+
+    IDevice* const device_;
+    const DeviceAddr size_;
+    const BufferType buffer_type_;
+    const TensorMemoryLayout buffer_layout_;
+    const bool bottom_up_;
+    const std::optional<SubDeviceId> sub_device_id_;
+    const bool owns_data_;
+
+    std::optional<SubDeviceManagerId> sub_device_manager_id_;
+    AllocatorImpl* allocator_ = nullptr;
+
+    AllocationStatus allocation_status_ = AllocationStatus::ALLOCATION_REQUESTED;
+    bool hooked_allocation_ = false;
+    DeviceAddr address_ = 0;
+
+    DeviceAddr page_size_;
+    std::optional<ShardSpecBuffer> shard_spec_;
+    std::shared_ptr<const BufferPageMapping> buffer_page_mapping_;
+
+    std::optional<BufferDistributionSpec> buffer_distribution_spec_;
+
+    bool per_core_allocation_ = false;
+    std::unordered_map<CoreCoord, DeviceAddr> per_core_addresses_;
+
+    std::shared_ptr<Buffer> root_buffer_;
+    DeviceAddr root_buffer_offset_ = 0;
+
+    size_t unique_id_ = 0;
+    static std::atomic<size_t> next_unique_id;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/buffers/buffer_sharding_args_impl.hpp
+++ b/tt_metal/impl/buffers/buffer_sharding_args_impl.hpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/buffer.hpp>
+
+#include <optional>
+
+namespace tt::tt_metal {
+
+class BufferShardingArgsImpl {
+public:
+    BufferShardingArgsImpl() = default;
+    BufferShardingArgsImpl(
+        std::optional<BufferDistributionSpec> buffer_distribution_spec,
+        std::optional<ShardSpecBuffer> shard_spec,
+        TensorMemoryLayout buffer_layout,
+        bool per_core_allocation = false) :
+        buffer_distribution_spec_(std::move(buffer_distribution_spec)),
+        shard_spec_(std::move(shard_spec)),
+        buffer_layout_(buffer_layout),
+        per_core_allocation_(per_core_allocation) {}
+
+    std::optional<BufferDistributionSpec> buffer_distribution_spec_;
+    std::optional<ShardSpecBuffer> shard_spec_;
+    TensorMemoryLayout buffer_layout_ = TensorMemoryLayout::INTERLEAVED;
+    bool per_core_allocation_ = false;
+};
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/buffers/compute_page_mapping.hpp
+++ b/tt_metal/impl/buffers/compute_page_mapping.hpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/buffer_page_mapping.hpp>
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/shape.hpp>
+
+#include <vector>
+
+namespace tt::tt_metal::detail {
+
+UncompressedBufferPageMapping compute_page_mapping(
+    const Shape& tensor_shape,
+    const Shape& shard_shape,
+    const std::vector<CoreCoord>& cores,
+    ShardDistributionStrategy shard_distribution_strategy = ShardDistributionStrategy::ROUND_ROBIN_1D);
+
+}  // namespace tt::tt_metal::detail

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -5,6 +5,7 @@
 #include <tt_stl/span.hpp>
 #include <device.hpp>
 #include <tt-metalium/allocator.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 #include <algorithm>
 #include <optional>
 #include <stack>
@@ -446,7 +447,7 @@ bool are_pages_larger_than_max_prefetch_cmd_size(const Buffer& buffer, uint32_t 
 }
 
 uint32_t calculate_partial_page_size(const Buffer& buffer) {
-    const HalMemType buffer_mem_type = buffer.memory_type();
+    const HalMemType buffer_mem_type = buffer.impl().memory_type();
     const uint32_t partial_page_size = tt::align(
         DispatchSettings::BASE_PARTIAL_PAGE_SIZE_DISPATCH,
         MetalContext::instance(extract_context_id(buffer.device()))
@@ -1190,7 +1191,7 @@ bool write_to_device_buffer(
             const uint8_t* pinned_host_base = static_cast<const uint8_t*>(pinned_memory->get_host_ptr());
             const uint8_t* src_ptr = static_cast<const uint8_t*>(src);
             const uint64_t pinned_size = pinned_memory->get_buffer_size();
-            auto region = buffer.root_buffer_region();
+            auto region = buffer.impl().root_buffer_region();
             const uint8_t* src_region_start = src_ptr + region.offset;
             const uint8_t* src_region_end = src_region_start + region.size;
             // Check against L1 alignment because we need the copy from the prefetcher to the dispatcher to be aligned.
@@ -1352,8 +1353,8 @@ bool write_to_device_buffer(
         // Empty filter -> no-op (consistent with the sharded path); nothing was actually written.
         return false;
     }
-    auto root_buffer = buffer.root_buffer();
-    auto region = buffer.root_buffer_region();
+    auto root_buffer = buffer.impl().root_buffer(buffer);
+    auto region = buffer.impl().root_buffer_region();
     InterleavedBufferWriteDispatchParamsVariant dispatch_params_variant = initialize_interleaved_buf_dispatch_params(
         *root_buffer,
         cq_id,
@@ -1403,8 +1404,8 @@ ShardedBufferReadDispatchParams initialize_sharded_buf_read_dispatch_params(
 
 BufferReadDispatchParams initialize_interleaved_buf_read_dispatch_params(
     Buffer& buffer, uint32_t cq_id, ttsl::Span<const uint32_t> expected_num_workers_completed) {
-    auto root_buffer = buffer.root_buffer();
-    const BufferRegion region = buffer.root_buffer_region();
+    auto root_buffer = buffer.impl().root_buffer(buffer);
+    const BufferRegion region = buffer.impl().root_buffer_region();
     IDevice* device = root_buffer->device();
 
     BufferReadDispatchParams dispatch_params;

--- a/tt_metal/impl/buffers/generate_buffer_page_mapping.hpp
+++ b/tt_metal/impl/buffers/generate_buffer_page_mapping.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/buffer_page_mapping.hpp>
+
+namespace tt::tt_metal {
+
+UncompressedBufferPageMapping generate_buffer_page_mapping(const Buffer& buffer);
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/buffers/tensor_accessor_args.cpp
+++ b/tt_metal/impl/buffers/tensor_accessor_args.cpp
@@ -11,6 +11,8 @@
 namespace tt::tt_metal {
 
 namespace {
+constexpr size_t kMaxNumDimensions = 8;
+
 namespace CMAKE_UNIQUE_NAMESPACE {
 void append_sharded_args(
     const Buffer& buffer, tensor_accessor::ArgsConfig args_config, std::vector<uint32_t>& args, bool is_runtime) {
@@ -29,10 +31,7 @@ void append_sharded_args(
 
     size_t rank = tensor_shape.size();
     size_t n_banks = bank_coords.size();
-    TT_FATAL(
-        rank <= TensorAccessorArgs::MAX_NUM_DIMENSIONS,
-        "Rank must be less than or equal to {}",
-        TensorAccessorArgs::MAX_NUM_DIMENSIONS);
+    TT_FATAL(rank <= kMaxNumDimensions, "Rank must be less than or equal to {}", kMaxNumDimensions);
 
     size_t n_args =
         add_rank + add_num_banks + (rank * add_tensor_shape) + (rank * add_shard_shape) + (n_banks * add_bank_coords);

--- a/tt_metal/impl/dispatch/host_runtime_commands.cpp
+++ b/tt_metal/impl/dispatch/host_runtime_commands.cpp
@@ -5,6 +5,7 @@
 #include <tt_stl/fmt.hpp>
 #include <tt_stl/assert.hpp>
 #include <buffer.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 #include <host_api.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt_metal.hpp>
@@ -51,7 +52,7 @@ void ValidateBufferRegion(
     Buffer& buffer_obj = GetBufferObject(buffer);
 
     TT_FATAL(
-        buffer_obj.is_valid_region(region),
+        buffer_obj.impl().is_valid_region(region),
         "Buffer region with offset {} and size {} is invalid.",
         region.offset,
         region.size);

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <allocator.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 #include <circular_buffer.hpp>
 #include <circular_buffer_constants.h>
 #include <tt_stl/assert.hpp>
@@ -1791,17 +1792,17 @@ GlobalSemaphore CreateGlobalSemaphore(
 }
 
 std::shared_ptr<Buffer> CreateBuffer(const BufferConfig& config) {
-    return Buffer::create(config.device, config.size, config.page_size, config.buffer_type);
+    return BufferImpl::create(config.device, config.size, config.page_size, config.buffer_type);
 }
 std::shared_ptr<Buffer> CreateBuffer(const BufferConfig& config, DeviceAddr address) {
-    return Buffer::create(config.device, address, config.size, config.page_size, config.buffer_type);
+    return BufferImpl::create(config.device, address, config.size, config.page_size, config.buffer_type);
 }
 std::shared_ptr<Buffer> CreateBuffer(const BufferConfig& config, SubDeviceId sub_device_id) {
-    return Buffer::create(
+    return BufferImpl::create(
         config.device, config.size, config.page_size, config.buffer_type, std::nullopt, std::nullopt, sub_device_id);
 }
 std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config) {
-    return Buffer::create(
+    return BufferImpl::create(
         config.device,
         config.size,
         config.page_size,
@@ -1809,7 +1810,7 @@ std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config) {
         BufferShardingArgs(config.shard_parameters, config.buffer_layout));
 }
 std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config, DeviceAddr address) {
-    return Buffer::create(
+    return BufferImpl::create(
         config.device,
         address,
         config.size,
@@ -1818,7 +1819,7 @@ std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config, DeviceAd
         BufferShardingArgs(config.shard_parameters, config.buffer_layout));
 }
 std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config, SubDeviceId sub_device_id) {
-    return Buffer::create(
+    return BufferImpl::create(
         config.device,
         config.size,
         config.page_size,
@@ -1828,7 +1829,7 @@ std::shared_ptr<Buffer> CreateBuffer(const ShardedBufferConfig& config, SubDevic
         sub_device_id);
 }
 
-void DeallocateBuffer(Buffer& buffer) { buffer.deallocate(); }
+void DeallocateBuffer(Buffer& buffer) { buffer.impl().deallocate(buffer); }
 
 void AssignGlobalBufferToProgram(const std::shared_ptr<Buffer>& buffer, Program& program) {
     const MetalContext& metal_ctx = MetalContext::instance(program.impl().get_context_id());

--- a/tt_metal/impl/lightmetal/host_api_capture_helpers.hpp
+++ b/tt_metal/impl/lightmetal/host_api_capture_helpers.hpp
@@ -8,6 +8,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <tt_stl/span.hpp>
 #include <tt-metalium/buffer.hpp>
+#include "impl/lightmetal/host_data_type.hpp"
 #include <kernel_types.hpp>
 
 namespace tt::tt_metal {

--- a/tt_metal/impl/lightmetal/host_data_type.hpp
+++ b/tt_metal/impl/lightmetal/host_data_type.hpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <variant>
+#include <vector>
+
+#include <tt-metalium/bfloat16.hpp>
+
+namespace tt::tt_metal {
+
+using HostDataType = std::variant<
+    const std::shared_ptr<std::vector<uint8_t>>,
+    const std::shared_ptr<std::vector<uint16_t>>,
+    const std::shared_ptr<std::vector<int32_t>>,
+    const std::shared_ptr<std::vector<uint32_t>>,
+    const std::shared_ptr<std::vector<float>>,
+    const std::shared_ptr<std::vector<bfloat16>>,
+    const void*>;
+
+}  // namespace tt::tt_metal

--- a/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
+++ b/tt_metal/impl/lightmetal/lightmetal_replay_impl.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "lightmetal_replay_impl.hpp"
+#include "impl/buffers/buffer_impl.hpp"
 
 #include <iostream>
 #include "light_metal_binary_generated.h"
@@ -425,7 +426,7 @@ void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::BufferCreateC
 
     // This API is overloaded with and without address field.
     if (cmd->address()) {
-        auto buffer = Buffer::create(
+        auto buffer = BufferImpl::create(
             this->device_,
             cmd->address()->value(),
             cmd->size(),
@@ -437,7 +438,7 @@ void LightMetalReplayImpl::execute(const tt::tt_metal::flatbuffer::BufferCreateC
         add_buffer_to_map(cmd->global_id(), buffer);
 
     } else {
-        auto buffer = Buffer::create(
+        auto buffer = BufferImpl::create(
             this->device_,
             cmd->size(),
             cmd->page_size(),

--- a/tt_metal/impl/per_core_allocation/buffer.cpp
+++ b/tt_metal/impl/per_core_allocation/buffer.cpp
@@ -3,22 +3,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
+#include "impl/buffers/buffer_impl.hpp"
+#include "impl/buffers/buffer_sharding_args_impl.hpp"
 #include <tt_stl/assert.hpp>
 
 namespace tt::tt_metal::experimental::per_core_allocation {
 
-bool is_per_core_allocation(const Buffer& buffer) { return buffer.per_core_allocation_; }
+bool is_per_core_allocation(const Buffer& buffer) { return buffer.impl().per_core_allocation_; }
 
 DeviceAddr get_per_core_address(const Buffer& buffer, CoreCoord core) {
     TT_FATAL(
-        buffer.per_core_allocation_, "get_per_core_address() called on buffer without per-core allocation enabled");
-    auto it = buffer.per_core_addresses_.find(core);
-    TT_FATAL(it != buffer.per_core_addresses_.end(), "No per-core address for core ({}, {})", core.x, core.y);
+        buffer.impl().per_core_allocation_,
+        "get_per_core_address() called on buffer without per-core allocation enabled");
+    auto it = buffer.impl().per_core_addresses_.find(core);
+    TT_FATAL(it != buffer.impl().per_core_addresses_.end(), "No per-core address for core ({}, {})", core.x, core.y);
     return it->second;
 }
 
 const std::unordered_map<CoreCoord, DeviceAddr>& get_per_core_addresses(const Buffer& buffer) {
-    return buffer.per_core_addresses_;
+    return buffer.impl().per_core_addresses_;
 }
 
 DeviceAddr get_shard_base_address(const Buffer& buffer, CoreCoord core) {
@@ -30,16 +33,16 @@ DeviceAddr get_shard_base_address(const Buffer& buffer, CoreCoord core) {
 
 void copy_per_core_addresses(Buffer& dst, const Buffer& src) {
     TT_FATAL(
-        dst.per_core_allocation_ && src.per_core_allocation_,
+        dst.impl().per_core_allocation_ && src.impl().per_core_allocation_,
         "copy_per_core_addresses requires both buffers to use per-core allocation");
-    dst.per_core_addresses_ = src.per_core_addresses_;
+    dst.impl().per_core_addresses_ = src.impl().per_core_addresses_;
 }
 
 BufferShardingArgs& set_per_core_allocation(BufferShardingArgs& args, bool enable) {
-    args.per_core_allocation_ = enable;
+    args.impl().per_core_allocation_ = enable;
     return args;
 }
 
-bool is_per_core_allocation(const BufferShardingArgs& args) { return args.per_core_allocation_; }
+bool is_per_core_allocation(const BufferShardingArgs& args) { return args.impl().per_core_allocation_; }
 
 }  // namespace tt::tt_metal::experimental::per_core_allocation

--- a/tt_metal/impl/per_core_allocation/mesh_buffer.cpp
+++ b/tt_metal/impl/per_core_allocation/mesh_buffer.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt-metalium/experimental/per_core_allocation/mesh_buffer.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 #include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt_stl/assert.hpp>
@@ -53,7 +54,7 @@ std::shared_ptr<distributed::MeshBuffer> create_on_single_device(
     // Only allocate on the target device.
     TT_FATAL(mesh_device->impl().is_local(coord), "Target device coordinate must be local");
     auto* device = mesh_device->impl().get_device(coord);
-    auto buffer = Buffer::create(
+    auto buffer = BufferImpl::create(
         device,
         device_local_size,
         device_local_config.page_size,

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <allocator.hpp>
+#include "impl/buffers/buffer_impl.hpp"
 #include <circular_buffer.hpp>
 #include <circular_buffer_config.hpp>
 #include <device.hpp>
@@ -2587,7 +2588,7 @@ void detail::ProgramImpl::allocate_kernel_bin_buf_on_device(IDevice* device) {
     // allocated bottom up
     std::size_t binary_data_size_bytes = this->program_transfer_info.binary_data.size() * sizeof(uint32_t);
     if (!this->kernels_buffer_.contains(device->id()) and binary_data_size_bytes) {
-        std::shared_ptr<Buffer> kernel_bin_buf = Buffer::create(
+        std::shared_ptr<Buffer> kernel_bin_buf = BufferImpl::create(
             device,
             binary_data_size_bytes,
             HostMemDeviceCommand::PROGRAM_PAGE_SIZE,

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -54,6 +54,7 @@
 
 #include <tt-metalium/bfloat4.hpp>
 #include <tt-metalium/bfloat8.hpp>
+#include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
 #include <tt-metalium/experimental/per_core_allocation/mesh_buffer.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/mesh_command_queue.hpp>

--- a/ttnn/cpp/ttnn/operations/experimental/fusion/device/fusion_semaphore_bank.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/fusion/device/fusion_semaphore_bank.hpp
@@ -13,6 +13,7 @@
 #include <tt_stl/assert.hpp>
 
 #include "tt-metalium/buffer.hpp"
+#include <tt-metalium/experimental/per_core_allocation/buffer.hpp>
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
 


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  / Relates to #<number> -->

Runtime team is performing surface area reduction to cleanup our api surface (`api/tt-metalium`).
The goal of the surface area reduction project is to remove internal functions unintentionally made public. The litmus test for candidate functions is based on internal usage.

This PR cleans up the unused surface area for memory-related Metalium headers.
Removal of these function out of public surface area without deprecation per the surface area reduction exception.

### Enumeration of headers impacted

#### Buffer
- `buffer.hpp`
- `buffer_types.hpp`
- `buffer_distribution_spec.hpp`
- `buffer_page_mapping.hpp`

(note that `MeshBuffer` will be processed in https://github.com/tenstorrent/tt-metal/pull/53015 )

#### Allocator
- `allocator.hpp`

#### Host buffer
- `host_buffer.hpp`
- `distributed_host_buffer.hpp`

#### Tensor accessor / memory reporter
- `tensor_accessor_args.hpp`
- `memory_reporter.hpp`

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

The litmus test we use to determine if a function is an internal function is:

A function is internal if and only if:
- There are no usage of this function within tenstorrent repos outside of the tt_metal folder and the tests folder.
- The function is not a known externally used function

#### Member functions hidden via pimpl

| Class | Member functions | Destination |
|---|---|---|
| `Allocator` | `extract_state`<br>`override_state` | `AllocatorImpl` (`tt_metal/impl/allocator/allocator.hpp`) |
| `Buffer` | `create` (both overloads)<br>`view`<br>`deallocate`<br>`memory_type`<br>`is_valid_region`<br>`is_valid_partial_region`<br>`bottom_up`<br>`root_buffer`<br>`root_buffer_region`<br>`sub_device_id`<br>`mark_as_deallocated` | `BufferImpl` (`tt_metal/impl/buffers/buffer_impl.hpp`) |

#### Free functions

| Function | Destination |
|---|---|
| `generate_buffer_page_mapping` | `tt_metal/impl/buffers/generate_buffer_page_mapping.hpp` |
| `detail::compute_page_mapping` | `tt_metal/impl/buffers/compute_page_mapping.hpp` |
| `HostDataType` | `tt_metal/impl/lightmetal/host_data_type.hpp` |

#### Removed / inlined

| Function | What happened |
|---|---|
| `ShardSpecBuffer::set_shard_spec` | deleted (unused) |
| `Buffer::set_page_size` | deleted (unused) |
| `Buffer::set_shard_spec` | deleted (unused) |
| `Buffer::is_trace` | deleted (unused) |
| `swap(HostBuffer&, HostBuffer&)` | deleted; member `HostBuffer::swap` made private |
| `TensorAccessorArgs::MAX_NUM_DIMENSIONS` | removed from public header → TU-local `kMaxNumDimensions` in `tensor_accessor_args.cpp` |

#### Still used in production (kept public)

All free functions / public symbols remaining in the targeted headers:

<details>
<summary>Full public usage</summary>

Member functions:

| Class | Member functions | Example use site |
|---|---|---|
| `Allocator` | `Allocator(AllocatorImpl*)`<br>`deallocate_buffers` (3)<br>`get_allocated_buffers` (1)<br>`get_num_banks` (11)<br>`get_bank_size` (7)<br>`get_logical_core_from_bank_id` (1)<br>`get_bank_offset` (2)<br>`get_bank_ids_from_logical_core` (7)<br>`get_base_allocator_addr` (64)<br>`get_alignment` (21)<br>`get_worker_l1_size` (2)<br>`get_statistics` (10)<br>`impl` | `ttnn/core/reports.cpp:92` (`get_num_banks`) |
| `Buffer` | `size` | sane to leave |
| `Buffer` | `is_allocated` | Given buffer can be deallocated, is_allocated should stay |
| `Buffer` | `Buffer(BufferImpl)`<br>`device`<br>`allocator`<br>`address` (107)<br>`page_size` (84)<br>`num_pages` (51)<br>`num_dev_pages` (1)<br>`buffer_type` (53)<br>`core_type` (5)<br>`is_l1` (2)<br>`is_dram` (8)<br>`buffer_layout` (7)<br>`page_address` (1)<br>`alignment` (41)<br>`aligned_page_size` (75)<br>`aligned_size` (1)<br>`aligned_size_per_bank` (13)<br>`buffer_distribution_spec` (18)<br>`has_shard_spec` (1)<br>`shard_spec` (13)<br>`num_cores` (1)<br>`get_buffer_page_mapping` (6)<br>`unique_id` (1)<br>`impl` | `ttnn/cpp/ttnn/operations/experimental/quasar/move/move.cpp:82` (`size`)<br>`unique_id` / `num_cores`: `ttnn/core/graph/graph_processor.cpp` |
| `ShardSpec` | ctors<br>`num_cores`<br>`numel`<br>`operator==` / `operator!=`<br>`attribute_names` / `attribute_values` | `ttnn/core/tensor/tensor.cpp:55` |
| `ShardSpecBuffer` | ctors<br>`grid` / `shape` / `orientation`<br>`shape_in_pages`<br>`num_pages` | `ttnn/core/tensor/d2d_stream_service.cpp:1232` |
| `BufferShardingArgs` | ctors<br>`buffer_distribution_spec`<br>`shard_spec`<br>`buffer_layout` | `ttnn/core/tensor/d2d_stream_service.cpp:1231` |
| `BufferDistributionSpec` | `from_shard_spec`<br>ctors<br>`tensor_shape_in_pages` / `shard_shape_in_pages`<br>`num_shards` / `max_num_shards_per_core` / `max_num_dev_pages_per_core`<br>`num_cores` / `num_cores_with_data`<br>`cores` / `cores_with_data`<br>`num_shards_per_core` / `num_dev_pages_per_core`<br>`shard_distribution_strategy`<br>`core_groups` / `core_groups_tuple`<br>`compute_page_mapping` | `ttnn/cpp/ttnn-nanobind/bfp_utils.cpp:141` (`from_shard_spec`)<br>`ttnn/cpp/ttnn/operations/data_movement/untilize/device/factories/untilize_multi_core_nd_shard_input_program_factory.cpp:57` (`compute_page_mapping`) |
| `HostBuffer` | ctors / copy / move<br>`view_bytes`<br>`view_as`<br>`pin`<br>`operator==` / `operator!=` | `ttnn/cpp/ttnn-nanobind/tensor.cpp:160` |
| `DistributedHostBuffer` | `create` (overloads)<br>`get_shard`<br>`emplace_shard` / `emplace_shards`<br>`is_local`<br>`transform` / `apply`<br>`shape` / `shard_coords`<br>`context` | `ttnn/core/distributed/host_ccl.cpp:28` (`context`)<br>`ttnn/core/distributed/api.cpp:98` (`create`) |
| `TensorAccessorArgs` | ctors (Buffer / MeshBuffer / MeshTensor / optional)<br>`create_dram_interleaved`<br>`create_l1_interleaved`<br>`append_to`<br>`get_compile_time_args`<br>`get_common_runtime_args` | `ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.cpp` (`create_dram_interleaved`) |

Free functions / constants:

| Function | Header | Usages[^usages] | Example use site |
|---|---|---:|---|
| `operator<<` (`ShardSpec`) | `buffer.hpp` | 0 | known external usage |
| `is_sharded` | `buffer.hpp` | 270 | `ttnn/core/reports.cpp:128` |
| `detail::calculate_bank_size_spread` | `allocator.hpp` | 4 | `ttnn/cpp/ttnn/operations/experimental/quasar/move/move.cpp` |
| `detail::squeeze_shape_ranks` | `buffer_distribution_spec.hpp` | 2 | `ttnn/cpp/ttnn/operations/data_movement/untilize/device/untilize_device_operation.cpp:35` |
| `detail::EnableMemoryReports` | `memory_reporter.hpp` | 1 | `ttnn/cpp/ttnn-nanobind/device.cpp:481` |
| `detail::DisableMemoryReports` | `memory_reporter.hpp` | 1 | `ttnn/cpp/ttnn-nanobind/device.cpp:484` |
| `detail::DumpDeviceMemoryState` | `memory_reporter.hpp` | 1 | `ttnn/cpp/ttnn-nanobind/device.cpp:502` |
| `detail::GetMemoryView` | `memory_reporter.hpp` | 2 | `tt-train/sources/examples/nano_gpt/main.cpp:141` |
| `MemoryBlockTable` | `memory_reporter.hpp` | 1 | `ttnn/cpp/ttnn-nanobind/device.cpp` |
| `BufferType` / `TensorMemoryLayout` / `ShardOrientation` / `ShardDistributionStrategy` | `buffer_types.hpp` | many | `ttnn/core/tensor/tensor.cpp` |
| `BufferConfig` / `InterleavedBufferConfig` | `buffer.hpp` | 1 | `tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_program_factory.cpp:356` |
| `ShardedBufferConfig` (metal) | `buffer.hpp` | 2 | `ttnn/cpp/ttnn/operations/experimental/ccl/strided_reduce_scatter_async/device/strided_reduce_scatter_async_program.cpp:489` |
| `BufferRegion` | `buffer.hpp` | 5 | `ttnn/core/async_runtime.cpp:14` |
| `BufferPageMapping` / `BufferCorePageMapping` / `UncompressedBufferPageMapping` | `buffer_page_mapping.hpp` | 6 | `ttnn/core/reports.cpp:72` (`get_buffer_page_mapping`) |
| `Statistics` | `allocator.hpp` | 10 | `ttnn/cpp/ttnn/operations/reduction/topk/device/topk_device_operation.cpp` |

</details>

[^usages]: Number of unique files in `ttnn/` + `tt-train/` (excluding `tests/`) that reference the symbol via a C++ call (`Name(`) or nanobind binding (`&Name`)). Parenthesized counts in the member-function table use the same definition.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/sr-memory)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/sr-memory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/sr-memory)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/sr-memory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/sr-memory)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/sr-memory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/sr-memory)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/sr-memory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/sr-memory)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/sr-memory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/sr-memory)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/sr-memory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/sr-memory)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/sr-memory)
