### PR TITLE
#52651: Fix TILE slice cache-hit all-zero output on divergent-partition hit

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
@@ -4,6 +4,7 @@
 
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.hpp"
+#include "ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp"
 
 #include <map>
 #include <optional>
@@ -389,19 +390,26 @@ void patch_slice_program_addresses(
                 tt::tt_metal::apply_dynamic_runtime_args(program, dynamic_args);
             } else if constexpr (std::is_same_v<Factory, SliceRmStrideProgramFactory>) {
                 patch_slot0(kReaderKernelIdx, tensor_args.input.buffer()->address());
-            } else {
-                // Tile factories carry the reader's addresses in common args: input, then the
-                // start/end tensors for the tensor-args variant.
-                auto& common = tt::tt_metal::GetCommonRuntimeArgs(program, kReaderKernelIdx);
-                if (common.size() > 0) {
-                    common[0] = tensor_args.input.buffer()->address();
-                }
+            } else if constexpr (
+                std::is_same_v<Factory, SliceTileProgramFactory> ||
+                std::is_same_v<Factory, SliceTileTensorArgsProgramFactory>) {
+                // Divergent-partition hit leaves writer num_pages=0 -> all-zero output (#52651).
+                std::vector<tt::tt_metal::DynamicRuntimeArg> dyn{
+                    {kReaderKernelIdx, {}, 0, tensor_args.input.buffer()->address(), true}};
                 if constexpr (std::is_same_v<Factory, SliceTileTensorArgsProgramFactory>) {
-                    if (common.size() > 2) {
-                        common[1] = tensor_args.start_tensor.value().buffer()->address();
-                        common[2] = tensor_args.end_tensor.value().buffer()->address();
-                    }
+                    dyn.push_back(
+                        {kReaderKernelIdx, {}, 1, tensor_args.start_tensor.value().buffer()->address(), true});
+                    dyn.push_back({kReaderKernelIdx, {}, 2, tensor_args.end_tensor.value().buffer()->address(), true});
                 }
+                tt::tt_metal::apply_dynamic_runtime_args(program, dyn);
+
+                const uint32_t start_offset = std::is_same_v<Factory, SliceTileProgramFactory>
+                                                  ? ttnn::operations::data_movement::get_tiled_start_offset(
+                                                        tensor_args.input, operation_attributes.slice_start)
+                                                  : 0u;
+                const auto per_core = slice_tile_dynamic_args(
+                    operation_attributes, tensor_args, output, start_offset, kReaderKernelIdx, kWriterKernelIdx);
+                tt::tt_metal::apply_dynamic_runtime_args(program, per_core);
             }
         },
         factory);

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
@@ -195,4 +195,89 @@ void SliceTileProgramFactory::override_runtime_arguments(
     patch_slice_program_addresses(program, SliceTileProgramFactory{}, args, tensor_args, output);
 }
 
+std::vector<tt::tt_metal::DynamicRuntimeArg> slice_tile_dynamic_args(
+    const SliceParams& args,
+    const SliceInputs& tensor_args,
+    const Tensor& output,
+    uint32_t start_offset,
+    uint32_t reader_kernel_idx,
+    uint32_t writer_kernel_idx) {
+    // Must reproduce create_descriptor's work split exactly; divergence leaves stale scalars in these slots.
+    const auto& input = tensor_args.input;
+    tt::tt_metal::IDevice* device = input.device();
+    const uint32_t num_unpadded_tiles = output.physical_volume() / TILE_HW;
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        args.sub_core_grids.has_value()
+            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_tiles)
+            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_tiles);
+
+    const auto& input_shape = input.padded_shape();
+    const auto& output_shape = output.padded_shape();
+    const std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+
+    const uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
+    const uint32_t num_total_Xt = input_shape[-1] / TILE_WIDTH;
+    const uint32_t num_unpadded_Yt = output_shape[-2] / TILE_HEIGHT;
+    const uint32_t num_total_Yt = input_shape[-2] / TILE_HEIGHT;
+
+    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+    accumulated_total_per_dim[0] = num_total_Xt;
+    accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
+    std::vector<uint32_t> num_unpadded_tiles_per_dim(num_dims);
+    num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
+    num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
+    for (int32_t i = 2; i < static_cast<int32_t>(num_dims); ++i) {
+        const uint32_t num_unpadded_dim = output_shape[-(i + 1)];
+        const uint32_t num_total_dim = input_shape[-(i + 1)];
+        num_unpadded_tiles_per_dim[i] = num_unpadded_dim;
+        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+    }
+
+    const auto cores = corerange_to_cores(all_cores);
+    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
+    dynamic_args.reserve(cores.size() * (2 + num_dims + 2));
+
+    uint32_t num_tiles_written = 0;
+    for (const auto& core : cores) {
+        uint32_t num_tiles_per_core = 0;
+        bool active = true;
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            active = false;
+        }
+
+        uint32_t id0 = 0, start_id = 0;
+        std::vector<uint32_t> id_per_dim(num_dims, 0);
+        if (active) {
+            id0 = num_tiles_written % num_unpadded_tiles_per_dim[0];
+            uint32_t unpadded_written = num_tiles_written / num_unpadded_tiles_per_dim[0];
+            start_id = id0 + start_offset;
+            for (uint32_t j = 1; j < num_dims; ++j) {
+                id_per_dim[j] = unpadded_written % num_unpadded_tiles_per_dim[j];
+                unpadded_written = unpadded_written / num_unpadded_tiles_per_dim[j];
+                start_id += id_per_dim[j] * accumulated_total_per_dim[j - 1];
+            }
+        }
+
+        dynamic_args.push_back({reader_kernel_idx, core, 0, start_id, false});
+        dynamic_args.push_back({reader_kernel_idx, core, 1, num_tiles_per_core, false});
+        dynamic_args.push_back({reader_kernel_idx, core, 2, id0, false});
+        for (uint32_t j = 1; j < num_dims; ++j) {
+            dynamic_args.push_back({reader_kernel_idx, core, 2 + j, id_per_dim[j], false});
+        }
+        // Writer slot 0 (dst buffer) is patched by patch_slot0; re-emit only slots 1 and 2.
+        dynamic_args.push_back({writer_kernel_idx, core, 1, num_tiles_per_core, false});
+        dynamic_args.push_back({writer_kernel_idx, core, 2, num_tiles_written, false});
+
+        if (active) {
+            num_tiles_written += num_tiles_per_core;
+        }
+    }
+    return dynamic_args;
+}
+
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <optional>
 #include <tt-metalium/program.hpp>
@@ -24,5 +25,14 @@ struct SliceTileProgramFactory {
         Tensor& output,
         const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
+
+// Per-core scalars are hash-excluded; a divergent-partition cache hit leaves them stale -> all-zero output (#52651).
+std::vector<tt::tt_metal::DynamicRuntimeArg> slice_tile_dynamic_args(
+    const SliceParams& args,
+    const SliceInputs& tensor_args,
+    const Tensor& output,
+    uint32_t start_offset,
+    uint32_t reader_kernel_idx,
+    uint32_t writer_kernel_idx);
 
 }  // namespace ttnn::prim


### PR DESCRIPTION
### Ticket
Link to Github Issue #52651

### Problem description
`ttnn.split(x, split_size=64128, dim=3)` on `[1,1,32,128256]` bf16 TILE (Llama-3-class vocab split) produces an all-zero **chunk 0** on Blackhole p100a — comp_pcc reports `"One tensor is all zero. PCC undefined; falling back to allclose."` and allclose then returns ~0. `abd9f303e547...` in `model_traced.split_model_traced` reproduces this on every scheduled sweep run since Aug 8 2026 (e.g. run [31990955256](https://github.com/tenstorrent/tt-metal/actions/runs/31990955256/job/95296264471), Aug 17). Chunk 0 shows no slice kernel JIT and ~75 ms E2E — pure program-cache hit.

### Root cause
Pre-#51784, `SliceDeviceOperation::override_runtime_arguments` rebuilt the full `ProgramDescriptor` and called `apply_descriptor_runtime_args`, which incidentally re-applied every kernel × core × arg on every hit. #51784 correctly moved slice off that anti-pattern to in-place address patching (`patch_slot0` + one `apply_dynamic_runtime_args` call for the reader common address), but the replacement only touches addresses. Reader per-core `[start_id, num_tiles, id_per_dim...]` and writer per-core `[num_pages, num_tiles_written]` are work-split-derived, **hash-excluded**, and never re-emitted. On a same-hash cache hit against a program whose per-core partition doesn't match the current dispatch (e.g. cores that had `num_tiles = 0` last time), the writer kernel's `for (i = start_id; i < start_id + num_pages; ++i)` (`writer_unary_interleaved_start_id.cpp:43`) exits immediately and the output stays zero-initialized.

### What changed
Added `slice_tile_dynamic_args()` in `slice_program_factory_tile.hpp/.cpp`, mirroring the existing `slice_rm_reader_dynamic_args()` pattern from the RM factory. It reproduces `SliceTileProgramFactory::create_descriptor`'s work-split + per-core math and returns the scalars as `DynamicRuntimeArg` entries (`{kernel_idx, core, arg_idx, value, is_common=false}`). `patch_slice_program_addresses` calls it on every `SliceTileProgramFactory` and `SliceTileTensorArgsProgramFactory` cache hit, on top of the existing common-arg address patch. Writer slot 0 (dst buffer address) stays on the `patch_slot0` walk. No descriptor rebuild — `scripts/detect_override_rebuild.py` passes.

### Test
Added `test_split_tile_cache_hit_per_core_scalars` in `tests/ttnn/nightly/unit_tests/operations/data_movement/test_split.py` — calls `ttnn.split([1,1,32,128256], 64128, dim=3)` on two distinct input tensors of the same shape, asserts bit-exact match to `torch.split` (`assert_equal`, not PCC — `split` is a copy), and asserts `device.num_program_cache_entries()` doesn't grow between the two dispatches so we're actually exercising the cache-hit path this PR guards. Existing `test_split.py` regressions continue to pass.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/tile_slice_cache_hit)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/tile_slice_cache_hit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/tile_slice_cache_hit)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/tile_slice_cache_hit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/tile_slice_cache_hit)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/tile_slice_cache_hit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/tile_slice_cache_hit)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/tile_slice_cache_hit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/tile_slice_cache_hit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/tile_slice_cache_hit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/tile_slice_cache_hit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/tile_slice_cache_hit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/tile_slice_cache_hit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/tile_slice_cache_hit)