### PR TITLE
[CI] Emit Parquet alongside CSVs in perf artifacts

### DIFF
--- a/.github/workflows/llk-perf-impl.yaml
+++ b/.github/workflows/llk-perf-impl.yaml
@@ -126,9 +126,6 @@ jobs:
         run: |
           ${{ matrix.test-group.cmd }}
 
-      # Write a typed Parquet next to the CSVs so the zip below ships both.
-      # Best-effort (strict=False): a single dirty test logs and is skipped, it
-      # never fails the run. Provenance comes from the GitHub context.
       - name: Publish Parquet from CSVs
         if: always() && hashFiles('tt_metal/tt-llk/perf_data/**/*.csv') != ''
         shell: bash

--- a/.github/workflows/llk-perf-impl.yaml
+++ b/.github/workflows/llk-perf-impl.yaml
@@ -126,6 +126,24 @@ jobs:
         run: |
           ${{ matrix.test-group.cmd }}
 
+      # Write a typed Parquet next to the CSVs so the zip below ships both.
+      # Best-effort (strict=False): a single dirty test logs and is skipped, it
+      # never fails the run. Provenance comes from the GitHub context.
+      - name: Publish Parquet from CSVs
+        if: always() && hashFiles('tt_metal/tt-llk/perf_data/**/*.csv') != ''
+        shell: bash
+        working-directory: ${{ env.LLK_PATH }}/tests/python_tests
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          RUN_ID: ${{ github.run_id }}
+          PIPELINE: ${{ github.event_name == 'schedule' && 'nightly' || 'PR' }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          python3 -m helpers.perf.publish_run \
+            --csv-dir ../../perf_data \
+            --out ../../perf_data/run-${{ env.CHIP_ARCH }}-${{ matrix.test-group.split_group }}.parquet \
+            --arch ${{ env.CHIP_ARCH }}
+
       - name: Zip performance data
         if: always() && hashFiles('tt_metal/tt-llk/perf_data/**') != ''
         shell: bash


### PR DESCRIPTION
Add one step to the LLK perf matrix job: after the sweep writes CSVs, run helpers.perf.publish_run to write a typed run-<arch>-<group>.parquet into perf_data/. The existing "Zip performance data" step already zips that folder, so the uploaded artifact now carries both CSV and Parquet. The zip and upload steps are unchanged.

Best-effort (strict=False) so a dirty test never fails the run
provenance (commit_sha / run_id / pipeline / pr_number) comes from the GitHub context.
pyarrow/pandas are already in tests/requirements.txt.

Reason for adding parquet in the first place is that we plan to switch to it once the full DB pipeline is ready, since it saves a lot of space (approximately 18x less space used), but for now we need both csv and parquet.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstojictt/perf-ci-parquet-artifact)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstojictt/perf-ci-parquet-artifact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstojictt/perf-ci-parquet-artifact)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstojictt/perf-ci-parquet-artifact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nstojictt/perf-ci-parquet-artifact)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nstojictt/perf-ci-parquet-artifact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstojictt/perf-ci-parquet-artifact)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstojictt/perf-ci-parquet-artifact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstojictt/perf-ci-parquet-artifact)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstojictt/perf-ci-parquet-artifact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstojictt/perf-ci-parquet-artifact)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstojictt/perf-ci-parquet-artifact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstojictt/perf-ci-parquet-artifact)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstojictt/perf-ci-parquet-artifact)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstojictt/perf-ci-parquet-artifact)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstojictt/perf-ci-parquet-artifact)