### PR TITLE
[Feature] Add perf warehouse storage seam (DuckDB stand-in + Snowflake backend)

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/warehouse.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/warehouse.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Storage seam for LLK perf data.
+
+Downstream code (publish, compare, dashboard) depends only on the ``PerfWarehouse``
+interface and ``get_warehouse()`` — never on a concrete database. Two backends:
+
+  ``SnowflakeWarehouse``  the real target (this file).
+  ``DuckDBWarehouse``     a local stand-in for building/testing before the table
+                          exists. It lives in ``warehouse_duckdb.py`` and is
+                          imported lazily by the factory.
+
+    wh = get_warehouse()             # duckdb (default now) | snowflake
+    wh.load("run-wormhole.parquet")  # ingest one run's typed Parquet batch
+    df = wh.query("SELECT ...")      # analytical read (dashboard / compare use this)
+
+Retiring the stand-in once Snowflake is live is a three-line change: delete
+``warehouse_duckdb.py``, drop the ``duckdb`` branch in ``get_warehouse``, and
+remove ``duckdb`` from requirements. Nothing downstream changes.
+"""
+
+import os
+from typing import Optional
+
+import pandas as pd
+
+DEFAULT_TABLE = "llk_perf"
+
+
+class PerfWarehouse:
+    """Interface both backends implement. Downstream code depends only on this."""
+
+    def load(self, parquet_path: str) -> int:  # pragma: no cover - interface
+        """Ingest one run's Parquet batch into the table. Returns total row count."""
+        raise NotImplementedError
+
+    def query(self, sql: str) -> pd.DataFrame:  # pragma: no cover - interface
+        """Run analytical SQL and return the result as a DataFrame."""
+        raise NotImplementedError
+
+
+class SnowflakeWarehouse(PerfWarehouse):
+    """Real backend, using ``snowflake-connector-python`` (imported lazily, so this
+    module loads without it).
+
+    Connection parameters come from the data team (env ``SNOWFLAKE_ACCOUNT`` /
+    ``USER`` / ``PASSWORD`` / ``ROLE`` / ``WAREHOUSE`` / ``DATABASE`` / ``SCHEMA``,
+    or kwargs). ``load`` uses ``write_pandas`` into the pre-created ``llk_perf``
+    table; if the data team prefers a stage + ``COPY INTO`` / Snowpipe, only this
+    one method changes. ``query`` runs analytical SQL against the live table — the
+    same SQL the DuckDB stand-in was validated on.
+    """
+
+    def __init__(self, *, table: str = DEFAULT_TABLE, **creds):
+        self.table = table
+        merged = creds or _snowflake_creds_from_env()
+        self.creds = {k: v for k, v in merged.items() if v is not None}
+
+    def _connect(self):
+        from snowflake.connector import connect  # lazy: only when actually used
+
+        return connect(**self.creds)
+
+    def load(self, parquet_path: str) -> int:
+        import pyarrow.parquet as pq
+        from snowflake.connector.pandas_tools import write_pandas
+
+        df = pq.read_table(parquet_path).to_pandas()
+        with self._connect() as con:
+            _, _, nrows, _ = write_pandas(
+                con,
+                df,
+                self.table.upper(),
+                quote_identifiers=True,
+                auto_create_table=False,
+            )
+        return nrows
+
+    def query(self, sql: str) -> pd.DataFrame:
+        with self._connect() as con:
+            return con.cursor().execute(sql).fetch_pandas_all()
+
+
+def _snowflake_creds_from_env() -> dict:
+    keys = ("account", "user", "password", "role", "warehouse", "database", "schema")
+    return {k: os.environ.get(f"SNOWFLAKE_{k.upper()}") for k in keys}
+
+
+def get_warehouse(kind: Optional[str] = None) -> PerfWarehouse:
+    """Return the configured backend (``PERF_WAREHOUSE`` env, default ``duckdb``)."""
+    kind = (kind or os.environ.get("PERF_WAREHOUSE", "duckdb")).lower()
+    if kind == "snowflake":
+        return SnowflakeWarehouse()
+    if kind == "duckdb":
+        # Lazy import so the deletable stand-in is only loaded when selected.
+        from .warehouse_duckdb import DuckDBWarehouse
+
+        return DuckDBWarehouse()
+    raise ValueError(f"unknown PERF_WAREHOUSE={kind!r}; use 'snowflake' or 'duckdb'")

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/warehouse_duckdb.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/warehouse_duckdb.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Local DuckDB stand-in for ``PerfWarehouse`` — DELETABLE once Snowflake is live.
+
+Nothing in the pipeline imports this directly; ``get_warehouse()`` imports it
+lazily only when ``PERF_WAREHOUSE=duckdb``. DuckDB is a good stand-in for Snowflake
+here: embedded (no server), reads Parquet natively, and its analytical SQL (window
+functions, ``QUALIFY``, CTEs) is close enough that the compare/dashboard queries
+transfer with little change.
+
+To retire it: delete this file, drop the ``duckdb`` branch in ``get_warehouse``, and
+remove ``duckdb`` from requirements. No other code changes.
+"""
+
+import os
+from typing import Optional
+
+import pandas as pd
+
+from .warehouse import DEFAULT_TABLE, PerfWarehouse
+
+
+class DuckDBWarehouse(PerfWarehouse):
+    """One embedded DuckDB file (or in-memory), Parquet-native.
+
+    The table is created from the first Parquet's schema (inference) and appended
+    to on later loads. In production the table is created from DB_SCHEMA / the
+    generated DDL; here inference keeps the stand-in decoupled from schema version.
+    """
+
+    def __init__(self, path: Optional[str] = None, table: str = DEFAULT_TABLE):
+        import duckdb
+
+        self.table = table
+        self.con = duckdb.connect(path or os.environ.get("PERF_DUCKDB", ":memory:"))
+
+    def load(self, parquet_path: str) -> int:
+        # `read_parquet` accepts a single path or a glob; both work here.
+        self.con.execute(
+            f'CREATE TABLE IF NOT EXISTS "{self.table}" AS '
+            "SELECT * FROM read_parquet(?) LIMIT 0",
+            [parquet_path],
+        )
+        self.con.execute(
+            f'INSERT INTO "{self.table}" SELECT * FROM read_parquet(?)', [parquet_path]
+        )
+        return int(
+            self.con.execute(f'SELECT count(*) FROM "{self.table}"').fetchone()[0]
+        )
+
+    def query(self, sql: str) -> pd.DataFrame:
+        return self.con.execute(sql).df()

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_warehouse.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_warehouse.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the storage seam: the factory and the real Snowflake backend.
+
+The Snowflake round-trip runs the *actual* SnowflakeWarehouse.load/query code
+against a local Snowflake emulator (fakesnow, backed by DuckDB) — so the real
+code path is exercised with no Snowflake account. Backend-specific DuckDB tests
+live in test_perf_warehouse_duckdb.py.
+"""
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from helpers.perf.warehouse import PerfWarehouse, SnowflakeWarehouse, get_warehouse
+
+
+def test_factory_selects_snowflake(monkeypatch):
+    monkeypatch.setenv("PERF_WAREHOUSE", "snowflake")
+    wh = get_warehouse()
+    assert isinstance(wh, SnowflakeWarehouse)
+    assert isinstance(wh, PerfWarehouse)
+
+
+def test_factory_rejects_unknown_backend(monkeypatch):
+    monkeypatch.setenv("PERF_WAREHOUSE", "postgres")
+    with pytest.raises(  # allow-pytest.raises: no expect_error in LLK suite
+        ValueError, match="unknown"
+    ):
+        get_warehouse()
+
+
+def test_snowflake_creds_read_from_env(monkeypatch):
+    for key in (
+        "ACCOUNT",
+        "USER",
+        "PASSWORD",
+        "ROLE",
+        "WAREHOUSE",
+        "DATABASE",
+        "SCHEMA",
+    ):
+        monkeypatch.setenv(f"SNOWFLAKE_{key}", key.lower())
+    wh = SnowflakeWarehouse()
+    assert wh.creds["account"] == "account"
+    assert wh.creds["warehouse"] == "warehouse"
+
+
+def test_snowflake_round_trip_on_emulator(tmp_path):
+    """Real SnowflakeWarehouse.load/query, exercised on the fakesnow emulator."""
+    fakesnow = pytest.importorskip("fakesnow")
+
+    run = tmp_path / "run.parquet"
+    pq.write_table(
+        pa.table(
+            {
+                "test_name": ["perf_a", "perf_a"],
+                "marker": ["INIT", "KERNEL"],
+                "mean(MATH_ISOLATE)": [10.0, 20.0],
+            }
+        ),
+        run,
+    )
+
+    with fakesnow.patch():
+        wh = SnowflakeWarehouse(database="LLK", schema="PERF")
+        # In prod the data team creates the table from our DDL; here create the
+        # matching shape so write_pandas(auto_create_table=False) has a target.
+        with wh._connect() as con:
+            cur = con.cursor()
+            cur.execute("CREATE DATABASE IF NOT EXISTS LLK")
+            cur.execute("CREATE SCHEMA IF NOT EXISTS LLK.PERF")
+            cur.execute(
+                "CREATE TABLE IF NOT EXISTS LLK.PERF.LLK_PERF "
+                '("test_name" VARCHAR, "marker" VARCHAR, "mean(MATH_ISOLATE)" FLOAT)'
+            )
+
+        nrows = wh.load(str(run))
+        assert nrows == 2
+
+        # Note: Snowflake folds UNquoted identifiers to upper-case (DuckDB keeps
+        # them as written), so the alias is quoted to stay stable across backends.
+        df = wh.query(
+            'SELECT "test_name", avg("mean(MATH_ISOLATE)") AS "m" '
+            "FROM LLK.PERF.LLK_PERF GROUP BY 1"
+        )
+        assert df.iloc[0]["m"] == 15.0  # avg(10, 20) — the real load+query path

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_warehouse_duckdb.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_warehouse_duckdb.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the DuckDB stand-in backend — DELETABLE with warehouse_duckdb.py.
+
+Proves the local stand-in: load a run's Parquet, accumulate across runs, and read
+it back with analytical SQL (incl. the window-function shape compare uses). Needs
+duckdb + pyarrow, no chip.
+"""
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+from helpers.perf.warehouse import PerfWarehouse, get_warehouse
+from helpers.perf.warehouse_duckdb import DuckDBWarehouse
+
+
+def _write_run(path, *, test_name, math):
+    """A tiny run Parquet: a couple of columns incl. a special-char timing name."""
+    tbl = pa.table(
+        {
+            "test_name": [test_name, test_name],
+            "marker": ["INIT", "KERNEL"],
+            "arch": ["wormhole", "wormhole"],
+            "mean(MATH_ISOLATE)": [math, math + 10.0],
+        }
+    )
+    pq.write_table(tbl, path)
+    return str(path)
+
+
+def test_load_returns_rowcount_and_accumulates(tmp_path):
+    wh = DuckDBWarehouse(path=":memory:")
+    a = _write_run(tmp_path / "run_a.parquet", test_name="perf_a", math=100.0)
+    b = _write_run(tmp_path / "run_b.parquet", test_name="perf_b", math=200.0)
+
+    assert wh.load(a) == 2  # first run
+    assert wh.load(b) == 4  # second run appended, not replaced
+
+
+def test_query_returns_dataframe_with_analytical_sql(tmp_path):
+    wh = DuckDBWarehouse(path=":memory:")
+    wh.load(_write_run(tmp_path / "r.parquet", test_name="perf_a", math=100.0))
+
+    df = wh.query(
+        'SELECT test_name, avg("mean(MATH_ISOLATE)") AS m FROM llk_perf GROUP BY test_name'
+    )
+    assert isinstance(df, pd.DataFrame)
+    assert df.iloc[0]["test_name"] == "perf_a"
+    assert df.iloc[0]["m"] == 105.0  # avg(100, 110)
+
+
+def test_window_function_qualify_runs(tmp_path):
+    # QUALIFY + window fn is the shape compare uses; must run on the stand-in.
+    wh = DuckDBWarehouse(path=":memory:")
+    wh.load(_write_run(tmp_path / "r.parquet", test_name="perf_a", math=100.0))
+    df = wh.query(
+        "SELECT marker FROM llk_perf "
+        'QUALIFY row_number() OVER (ORDER BY "mean(MATH_ISOLATE)" DESC) = 1'
+    )
+    assert list(df["marker"]) == ["KERNEL"]  # the higher value
+
+
+def test_factory_defaults_to_duckdb(monkeypatch):
+    monkeypatch.delenv("PERF_WAREHOUSE", raising=False)
+    wh = get_warehouse()
+    assert isinstance(wh, DuckDBWarehouse)
+    assert isinstance(wh, PerfWarehouse)

--- a/tt_metal/tt-llk/tests/requirements.txt
+++ b/tt_metal/tt-llk/tests/requirements.txt
@@ -9,6 +9,7 @@ tt-exalens==0.3.29
 tt-smi==3.1.1
 
 coverage[toml]==7.10.5
+duckdb==1.5.5
 exceptiongroup==1.3.0
 filelock==3.20.3
 fsspec==2025.7.0


### PR DESCRIPTION
PerfWarehouse = load(parquet) + query(sql), nothing DB-specific. 

Two backends behind get_warehouse(): DuckDBWarehouse (local Parquet-native stand-in, isolated in warehouse_duckdb.py, deletable in 3 lines once Snowflake is live) and SnowflakeWarehouse (real target, lazy connector import). 

Hardware-free tests; the Snowflake round-trip runs the real load/query path on the fakesnow emulator and skips if fakesnow isn't installed (kept out of shared requirements it pulls snowflake-connector-python). 

Adds duckdb==1.5.5.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstojictt/perf-warehouse-seam)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstojictt/perf-warehouse-seam)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstojictt/perf-warehouse-seam)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstojictt/perf-warehouse-seam)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nstojictt/perf-warehouse-seam)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nstojictt/perf-warehouse-seam)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstojictt/perf-warehouse-seam)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstojictt/perf-warehouse-seam)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstojictt/perf-warehouse-seam)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstojictt/perf-warehouse-seam)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstojictt/perf-warehouse-seam)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstojictt/perf-warehouse-seam)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstojictt/perf-warehouse-seam)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstojictt/perf-warehouse-seam)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstojictt/perf-warehouse-seam)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstojictt/perf-warehouse-seam)