### PR TITLE
[Bug fix] SFPU: ttnn.erfc returns a constant above |x| = 5

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_erfc.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_erfc.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tail coverage for ttnn.erfc.
+
+`test_math.py::test_erfc` draws random bf16 inputs from [0, 1), which is inside the
+rational fit's accurate first segment. It therefore cannot see either of the two
+things measured here: that the rational's second segment [2.5, 5] is inaccurate,
+and that past the fit domain the op used to return a single constant for every
+input. Both are asserted against a golden computed from the *unclamped* input.
+"""
+
+import torch
+
+import ttnn
+
+# Measured on Blackhole P300, exhaustive over all 65536 bfloat16 patterns:
+# 2.007 max BF16 ULP for |x| <= 5 and 2.686 for the asymptotic tail. 4 leaves
+# headroom without admitting the 197 ULP the rational produced at x = 5.
+_MAX_BF16_ULP = 4.0
+
+# erfc leaves bfloat16 near 9.45, but the last stretch of that is denormal in FP32,
+# where the device flushes to zero. 9.2 is the largest input whose true value is
+# still an FP32 normal.
+_LARGEST_NORMAL_INPUT = 9.2
+
+
+def _run(values, device, dtype=ttnn.bfloat16):
+    padded = torch.zeros((1, 1, 32, 32), dtype=torch.float32)
+    padded[0, 0, 0, : values.numel()] = values
+    t = ttnn.from_torch(padded, layout=ttnn.TILE_LAYOUT, dtype=dtype, device=device)
+    return ttnn.to_torch(ttnn.erfc(t))[0, 0, 0, : values.numel()].float()
+
+
+def _bf16_ulp(got, ref):
+    ulp = torch.exp2(torch.floor(torch.log2(ref.abs())) - 7.0)
+    return ((got - ref).abs() / ulp).max().item()
+
+
+def test_erfc_decays_past_the_fit_domain(device):
+    """erfc keeps decaying past the rational's domain; it must not go flat."""
+    values = torch.arange(2.5, _LARGEST_NORMAL_INPUT + 0.01, 0.25, dtype=torch.float32)
+    ref = torch.special.erfc(values.to(torch.bfloat16).double()).float()
+    assert (ref > 0).all(), "every reference here must still be a normal number"
+
+    got = _run(values, device)
+
+    # Distinctness first: the failure this guards against is a constant, and a
+    # tolerance alone would report it only as a large number.
+    assert got.unique().numel() == values.numel(), (
+        f"erfc returned {got.unique().numel()} distinct values for {values.numel()} distinct "
+        f"inputs in [2.5, {_LARGEST_NORMAL_INPUT}]; it is constant where it should be decaying"
+    )
+    max_ulp = _bf16_ulp(got.double(), ref.double())
+    assert max_ulp <= _MAX_BF16_ULP, f"MaxULP={max_ulp:.2f} exceeds {_MAX_BF16_ULP}"
+
+
+def test_erfc_underflows_to_zero(device):
+    """Past the point erfc leaves the format, the only correct answer is 0."""
+    values = torch.tensor([9.5, 10.0, 20.0, 100.0, 3.0e38, float("inf")], dtype=torch.float32)
+    got = _run(values, device)
+    assert torch.equal(
+        got, torch.zeros_like(got)
+    ), f"erfc must underflow to 0 once it leaves the format; got {got.tolist()} for {values.tolist()}"
+
+
+def test_erfc_negative_tail_is_two(device):
+    """erfc(-x) = 2 - erfc(x), and for x <= -5 that is exactly 2 in both formats."""
+    values = torch.tensor([-5.0, -6.0, -10.0, -20.0, -3.0e38, float("-inf")], dtype=torch.float32)
+    got = _run(values, device)
+    assert torch.equal(got, torch.full_like(got, 2.0)), f"got {got.tolist()}"
+
+
+def test_erfc_bfloat8_b_tail_is_a_format_limit_not_a_kernel_one(device):
+    """erfc's tail is not representable in bfloat8_b, and that is the format's doing.
+
+    bfloat8_b shares one exponent across a block, so a block that contains erfc(0) = 1
+    flushes everything below roughly 2^-8 of it to zero. Measured: the same stimuli that
+    give 4.04e-04 ... 4.16e-23 in bfloat16 give all zeros in bfloat8_b. The op is bound
+    for bfloat8_b, so this is asserted rather than left as folklore -- it is why the
+    decay is checked in bfloat16 only.
+    """
+    values = torch.arange(2.5, 7.01, 0.5, dtype=torch.float32)
+    assert (_run(values, device, dtype=ttnn.bfloat16).unique().numel()) == values.numel()
+    assert torch.equal(_run(values, device, dtype=ttnn.bfloat8_b), torch.zeros(values.numel()))

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfc.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_erfc.h
@@ -4,71 +4,75 @@
 
 #pragma once
 
-#include <array>
-
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "cmath_common.h"
-#include "sfpu/ckernel_sfpu_converter.h"
-
-#include "ckernel_sfpu_piecewise_rational.h"
+#include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_recip.h"
+#include "sfpu/ckernel_sfpu_polyval.h"
 
 namespace ckernel::sfpu {
 
 // ======================================================================
-// LUT-based erfc via piecewise rational P(x)/Q(x)
+// erfc(x), two plain polynomials and no rational.
 //
-// Uses abs(x) symmetry: erfc(-x) = 2 - erfc(x)
-// Fit on [0, 5.0] only, 2 segments with n4/d5 rational per segment.
-// BF16 MaxULP=118 (was 128 with 3-seg n4/d4 on [-5,5])
-// FP32 MaxULP≈9M  (was 1.47B)
-// 18 FMAs          (was 24)
+// Uses abs(x) symmetry: erfc(-x) = 2 - erfc(x).
+//   |x| <  1.5:  erfc(x) = 1 - x*g(x^2), g a degree-5 minimax in x^2
+//   |x| >= 1.5:  erfc(x) = exp(-x^2)/x * P(1/x^2), P absorbing 1/sqrt(pi)
+//
+// The asymptotic is accurate far below where an asymptotic expansion is
+// normally trusted: measured in float64 it holds to 0.0073 BF16 ULP from 1.5,
+// and still to 0.27 BF16 ULP from 1.0. Letting it take everything above 1.5
+// leaves the low region an easy fit, which is what removes the piecewise
+// rational and its LUT.
+//
+// Inputs are clamped to 9.3 before squaring, so every lane -- including the ones
+// whose branch result is discarded -- satisfies the unsafe exp's precondition,
+// which holds while -x^2 stays above -88.03. Past ~9.25 the result underflows to
+// 0 on its own, which is the correct saturation for a function decaying to 0, so
+// the bound costs nothing: erfc(9.3) is already below the smallest FP32 normal.
 // ======================================================================
 
-constexpr uint32_t ERFC_NUM_DEGREE = 4;
-constexpr uint32_t ERFC_DEN_DEGREE = 5;
-constexpr uint32_t ERFC_NUM_SEGMENTS = 2;
-constexpr uint32_t ERFC_LUT_SIZE = 25;
-constexpr std::array<float, ERFC_LUT_SIZE> ERFC_LUT = {{// Breakpoints
-                                             0.0000000000e+00f,
-                                             2.5000000000e+00f,
-                                             5.0000000000e+00f,
-                                             // Segment 0 [0, 2.5]: numerator (degree 4)
-                                             1.0000233650e+00f,
-                                             -1.3375675678e+00f,
-                                             6.8185544014e-01f,
-                                             -1.5691982210e-01f,
-                                             1.3746744953e-02f,
-                                             // Segment 0 [0, 2.5]: denominator (degree 5)
-                                             1.0000000000e+00f,
-                                             -2.0801517367e-01f,
-                                             4.3667086959e-01f,
-                                             -3.4568668343e-03f,
-                                             2.5104774162e-02f,
-                                             2.8375532478e-02f,
-                                             // Segment 1 [2.5, 5.0]: numerator (degree 4)
-                                             -2.5655237550e-05f,
-                                             2.1275576728e-05f,
-                                             -6.6162156145e-06f,
-                                             9.1439767402e-07f,
-                                             -4.7387182178e-08f,
-                                             // Segment 1 [2.5, 5.0]: denominator (degree 5)
-                                             1.0000000000e+00f,
-                                             -1.6457208991e-01f,
-                                             -2.0572184026e-01f,
-                                             -1.3888636231e-01f,
-                                             1.2677097321e-01f,
-                                             -2.1375391632e-02f}};
+constexpr float ERFC_ASYMPTOTIC_THRESHOLD = 1.5f;
+constexpr float ERFC_MAX_INPUT = 9.3f;
+
+// Asymptotic branch, outlined so its intermediates do not stay live across the
+// polynomial path.
+sfpi_inline sfpi::vFloat calculate_erfc_asymptotic_(const sfpi::vFloat abs_x) {
+    const sfpi::vFloat axc = sfpi::min(abs_x, ERFC_MAX_INPUT);
+    const sfpi::vFloat neg_x2 = -(axc * axc);
+    const sfpi::vFloat exp_value = _sfpu_exp_21f_bf16_unsafe_<true>(neg_x2);
+    // Zero Newton iterations, spelled as the iteration count rather than as
+    // sfpu_reciprocal<true>: the reciprocal refines an asymptotic whose residual is set by
+    // other terms, so the approximate seed costs ~2 ULP rather than orders of magnitude.
+    const sfpi::vFloat inv = sfpu_reciprocal_iter<0>(axc);
+    // P(t), t = 1/x^2, degree 4, minimax on [1/100, 1/2.25]; 0.0073 BF16 ULP
+    // measured after rounding the coefficients to float32. Carries 1/sqrt(pi).
+    const sfpi::vFloat correction = PolynomialEvaluator::eval(
+        inv * inv, 5.6414234638e-01f, -2.7857559919e-01f, 3.5396602750e-01f, -4.4328993559e-01f, 2.8342172503e-01f);
+    return exp_value * inv * correction;
+}
 
 template <int ITERATIONS = 8>
 inline void calculate_erfc() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
-        // Clamp |x| to 5.0 before evaluation (avoids extrapolation, saves one branch)
-        sfpi::vFloat ax = sfpi::min(sfpi::abs(x), 5.0f);
-        sfpi::vFloat r =
-            piecewise_rational_eval<ERFC_NUM_DEGREE, ERFC_DEN_DEGREE, ERFC_NUM_SEGMENTS, ERFC_LUT_SIZE, false, true>(
-                ERFC_LUT, ax);
+        const sfpi::vFloat abs_x = sfpi::abs(x);
+
+        // Low path, computed unconditionally: erfc(x) = 1 - x*g(x^2).
+        // g is fitted on [0, 2.25] in x^2; 0.0035 BF16 ULP measured.
+        const sfpi::vFloat x2 = x * x;
+        sfpi::vFloat r = 1.0f - abs_x * PolynomialEvaluator::eval(
+                                            x2,
+                                            1.1283125367e+00f,
+                                            -3.7556339817e-01f,
+                                            1.1125811263e-01f,
+                                            -2.4775019023e-02f,
+                                            3.7510146011e-03f,
+                                            -2.8441375985e-04f);
+
+        v_if(abs_x >= ERFC_ASYMPTOTIC_THRESHOLD) { r = calculate_erfc_asymptotic_(abs_x); }
+        v_endif;
         // erfc(-x) = 2 - erfc(x)
         v_if(x < 0.0f) { r = 2.0f - r; }
         v_endif;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfc.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_erfc.h
@@ -4,71 +4,75 @@
 
 #pragma once
 
-#include <array>
-
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "cmath_common.h"
-#include "sfpu/ckernel_sfpu_converter.h"
-
-#include "ckernel_sfpu_piecewise_rational.h"
+#include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_recip.h"
+#include "sfpu/ckernel_sfpu_polyval.h"
 
 namespace ckernel::sfpu {
 
 // ======================================================================
-// LUT-based erfc via piecewise rational P(x)/Q(x)
+// erfc(x), two plain polynomials and no rational.
 //
-// Uses abs(x) symmetry: erfc(-x) = 2 - erfc(x)
-// Fit on [0, 5.0] only, 2 segments with n4/d5 rational per segment.
-// BF16 MaxULP=118 (was 128 with 3-seg n4/d4 on [-5,5])
-// FP32 MaxULP≈9M  (was 1.47B)
-// 18 FMAs          (was 24)
+// Uses abs(x) symmetry: erfc(-x) = 2 - erfc(x).
+//   |x| <  1.5:  erfc(x) = 1 - x*g(x^2), g a degree-5 minimax in x^2
+//   |x| >= 1.5:  erfc(x) = exp(-x^2)/x * P(1/x^2), P absorbing 1/sqrt(pi)
+//
+// The asymptotic is accurate far below where an asymptotic expansion is
+// normally trusted: measured in float64 it holds to 0.0073 BF16 ULP from 1.5,
+// and still to 0.27 BF16 ULP from 1.0. Letting it take everything above 1.5
+// leaves the low region an easy fit, which is what removes the piecewise
+// rational and its LUT.
+//
+// Inputs are clamped to 9.3 before squaring, so every lane -- including the ones
+// whose branch result is discarded -- satisfies the unsafe exp's precondition,
+// which holds while -x^2 stays above -88.03. Past ~9.25 the result underflows to
+// 0 on its own, which is the correct saturation for a function decaying to 0, so
+// the bound costs nothing: erfc(9.3) is already below the smallest FP32 normal.
 // ======================================================================
 
-constexpr uint32_t ERFC_NUM_DEGREE = 4;
-constexpr uint32_t ERFC_DEN_DEGREE = 5;
-constexpr uint32_t ERFC_NUM_SEGMENTS = 2;
-constexpr uint32_t ERFC_LUT_SIZE = 25;
-constexpr std::array<float, ERFC_LUT_SIZE> ERFC_LUT = {{// Breakpoints
-                                             0.0000000000e+00f,
-                                             2.5000000000e+00f,
-                                             5.0000000000e+00f,
-                                             // Segment 0 [0, 2.5]: numerator (degree 4)
-                                             1.0000233650e+00f,
-                                             -1.3375675678e+00f,
-                                             6.8185544014e-01f,
-                                             -1.5691982210e-01f,
-                                             1.3746744953e-02f,
-                                             // Segment 0 [0, 2.5]: denominator (degree 5)
-                                             1.0000000000e+00f,
-                                             -2.0801517367e-01f,
-                                             4.3667086959e-01f,
-                                             -3.4568668343e-03f,
-                                             2.5104774162e-02f,
-                                             2.8375532478e-02f,
-                                             // Segment 1 [2.5, 5.0]: numerator (degree 4)
-                                             -2.5655237550e-05f,
-                                             2.1275576728e-05f,
-                                             -6.6162156145e-06f,
-                                             9.1439767402e-07f,
-                                             -4.7387182178e-08f,
-                                             // Segment 1 [2.5, 5.0]: denominator (degree 5)
-                                             1.0000000000e+00f,
-                                             -1.6457208991e-01f,
-                                             -2.0572184026e-01f,
-                                             -1.3888636231e-01f,
-                                             1.2677097321e-01f,
-                                             -2.1375391632e-02f}};
+constexpr float ERFC_ASYMPTOTIC_THRESHOLD = 1.5f;
+constexpr float ERFC_MAX_INPUT = 9.3f;
+
+// Asymptotic branch, outlined so its intermediates do not stay live across the
+// polynomial path.
+sfpi_inline sfpi::vFloat calculate_erfc_asymptotic_(const sfpi::vFloat abs_x) {
+    const sfpi::vFloat axc = sfpi::min(abs_x, ERFC_MAX_INPUT);
+    const sfpi::vFloat neg_x2 = -(axc * axc);
+    const sfpi::vFloat exp_value = _sfpu_exp_21f_bf16_unsafe_<true>(neg_x2);
+    // Zero Newton iterations, spelled as the iteration count rather than as
+    // sfpu_reciprocal<true>: the reciprocal refines an asymptotic whose residual is set by
+    // other terms, so the approximate seed costs ~2 ULP rather than orders of magnitude.
+    const sfpi::vFloat inv = sfpu_reciprocal_iter<0>(axc);
+    // P(t), t = 1/x^2, degree 4, minimax on [1/100, 1/2.25]; 0.0073 BF16 ULP
+    // measured after rounding the coefficients to float32. Carries 1/sqrt(pi).
+    const sfpi::vFloat correction = PolynomialEvaluator::eval(
+        inv * inv, 5.6414234638e-01f, -2.7857559919e-01f, 3.5396602750e-01f, -4.4328993559e-01f, 2.8342172503e-01f);
+    return exp_value * inv * correction;
+}
 
 template <int ITERATIONS = 8>
 inline void calculate_erfc() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
-        // Clamp |x| to 5.0 before evaluation (avoids extrapolation, saves one branch)
-        sfpi::vFloat ax = sfpi::min(sfpi::abs(x), 5.0f);
-        sfpi::vFloat r =
-            piecewise_rational_eval<ERFC_NUM_DEGREE, ERFC_DEN_DEGREE, ERFC_NUM_SEGMENTS, ERFC_LUT_SIZE, false, true>(
-                ERFC_LUT, ax);
+        const sfpi::vFloat abs_x = sfpi::abs(x);
+
+        // Low path, computed unconditionally: erfc(x) = 1 - x*g(x^2).
+        // g is fitted on [0, 2.25] in x^2; 0.0035 BF16 ULP measured.
+        const sfpi::vFloat x2 = x * x;
+        sfpi::vFloat r = 1.0f - abs_x * PolynomialEvaluator::eval(
+                                            x2,
+                                            1.1283125367e+00f,
+                                            -3.7556339817e-01f,
+                                            1.1125811263e-01f,
+                                            -2.4775019023e-02f,
+                                            3.7510146011e-03f,
+                                            -2.8441375985e-04f);
+
+        v_if(abs_x >= ERFC_ASYMPTOTIC_THRESHOLD) { r = calculate_erfc_asymptotic_(abs_x); }
+        v_endif;
         // erfc(-x) = 2 - erfc(x)
         v_if(x < 0.0f) { r = 2.0f - r; }
         v_endif;


### PR DESCRIPTION
### PR Category

Bug fix.

### Summary

Closes #51137.

The rational and its 25-entry LUT are replaced by a degree-5 polynomial in `x²` below 1.5 and the asymptotic `exp(-x²)/x · P(1/x²)` above it, and the input clamp moves from 5 to 9.3.

The handover sits at 1.5 rather than at 5 because the rational's second piece is already wrong before its own boundary — 50.6 BF16 ULP at 2.5 and 197.6 at 5, against 1.07 for the first piece — so extending it would have shipped a 1.9× step at the seam. The asymptotic holds far below where one is normally trusted: 0.0073 BF16 ULP from 1.5, and still 0.27 from 1.0, measured in float64.

The clamp at 9.3 is not a smaller version of the reported defect. The discriminator is whether the true function still moves by more than one output ULP across the clamped run, and `erfc` leaves the smallest FP32 normal at about 9.25 and is 2.1e-45 at 10, so every input above the bound has the same correct answer, 0. `ckernel_sfpu_erf.h` clamps at 10 on the same grounds.

### Accuracy

Blackhole P300, exhaustive over all 65536 bfloat16 patterns, reference `torch.special` in float64, max BF16 ULP:

| region | before | after |
|---|---|---|
| `\|x\| <= 5` | 197.6 | 2.007 |
| `5 < x <= 9.1945` | 3.2e28 | 2.686 |
| `x < -5` | 1.4e-10 | 1.4e-10 (unchanged) |
| true value underflows | 0 of 15976 correct | 15976 of 15976 |
| distinct outputs above 5 | 1 | 116 |

Known residual: for `x` in `(9.25, 9.45]` the true value is an FP32 denormal and the device flushes it, so 4 bfloat16 patterns return 0 where a vanishingly small answer exists.

### Cost

JIT-compiled TRISC1 math ELF `.text`, each arm built in its own `TT_METAL_CACHE` and compared with `objcopy --only-section=.text` (a whole-ELF hash is useless here — the ELF embeds its own build path, which differs between the two caches):

| kernel | main | this PR | |
|---|---|---|---|
| `erfc` BF16 | 1080 B | 1056 B | **−24 B** |
| `erfc` FP32 | 1148 B | 1124 B | **−24 B** |

Smaller in both, because the rational and its 25-entry LUT go away. Wall clock at `[16, 8, 192, 384]`, 200 reps × 5 runs: 170.3 → 172.9 µs. `grep -rn "ttnn.erfc" models/` returns 0.

### Tests

`erfc`'s existing coverage draws from `[0, 1)`, inside the accurate first segment, so it could not see this; the new `test_unary_erfc.py` covers the decay, the underflow and the negative tail, and fails on unmodified `main`. `test_math.py` already checks `ttnn.erfc` at `ulp=1` and still passes. The two files give 49 passed, 0 failures.

### One accuracy/speed knob

The asymptotic takes the reciprocal at zero Newton iterations. That, not the polynomial fits, is what sets the residual: the low path uses no reciprocal and measures 186 FP32 ULP, while the asymptotic sits at 8.9e4. Two iterations measure:

| | this PR | 2 iterations |
|---|---|---|
| BF16 max ULP, `\|x\| <= 5` | 2.007 | 1.261 |
| BF16 max ULP, `5 < x <= 9.19` | 2.686 | 1.349 |
| FP32 max ULP, `5 <= x <= 9.19` | 1.15e5 | 2.88e4 |
| wall clock | 173.5 µs | 182.4 µs |
| `.text`, FP32 kernel | 1124 B | 1160 B |

Two iterations buy 1.6x on the BF16 tail and 4x on FP32, for +5% of wall clock and +36 bytes of `.text`. The cheaper one is in because the reported defect is a constant tail rather than an accuracy shortfall, and 2 ULP is already 100x better than the 197.6 it replaces. Happy to switch.

### Notes for reviewers

- **Wormhole is not measured** — there is no Wormhole hardware on this host. The kernel changes identically and the WH copy stays byte-equivalent to the BH one.
