### PR TITLE
Add blaze-authored SFPU activation/filter LLKs to experimental (batch 3)

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/ckernel_sfpu_clamped_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/ckernel_sfpu_clamped_silu.h
@@ -7,15 +7,17 @@
 
 #pragma once
 
+#include <cstdint>
+
 // Fused activation mode constants for DRAMStreamingMatmul.
-static constexpr uint32_t FUSED_ACT_NONE = 0;
-static constexpr uint32_t FUSED_ACT_SILU = 1;
-static constexpr uint32_t FUSED_ACT_CLAMPED_GATE = 2;
-static constexpr uint32_t FUSED_ACT_CLAMPED_UP = 3;
-static constexpr uint32_t FUSED_ACT_GELU = 4;
-static constexpr uint32_t FUSED_ACT_CLAMP_ONLY = 5;
-static constexpr uint32_t FUSED_ACT_SITU_GATE = 6;
-static constexpr uint32_t FUSED_ACT_SCALED_TANH = 7;
+static constexpr std::uint32_t FUSED_ACT_NONE = 0;
+static constexpr std::uint32_t FUSED_ACT_SILU = 1;
+static constexpr std::uint32_t FUSED_ACT_CLAMPED_GATE = 2;
+static constexpr std::uint32_t FUSED_ACT_CLAMPED_UP = 3;
+static constexpr std::uint32_t FUSED_ACT_GELU = 4;
+static constexpr std::uint32_t FUSED_ACT_CLAMP_ONLY = 5;
+static constexpr std::uint32_t FUSED_ACT_SITU_GATE = 6;
+static constexpr std::uint32_t FUSED_ACT_SCALED_TANH = 7;
 
 #ifdef TRISC_PACK
 #include "ckernel_sfpu_sigmoid.h"
@@ -25,7 +27,7 @@ namespace sfpu {
 
 // Gate activation: clamp(x, max=limit) * sigmoid(alpha * clamp(x, max=limit))
 template <bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_clamped_silu_gate(uint32_t limit_bits, uint32_t alpha_bits) {
+inline void calculate_clamped_silu_gate(std::uint32_t limit_bits, std::uint32_t alpha_bits) {
     sfpi::vFloat alpha_f = sfpi::as<sfpi::vFloat>(sfpi::vInt(alpha_bits));
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
@@ -48,7 +50,7 @@ inline void calculate_clamped_silu_gate(uint32_t limit_bits, uint32_t alpha_bits
 
 // Up activation: clamp(x, -limit, limit) + 1.0
 template <bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_clamped_up(uint32_t limit_bits) {
+inline void calculate_clamped_up(std::uint32_t limit_bits) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
@@ -70,7 +72,7 @@ inline void calculate_clamped_up(uint32_t limit_bits) {
 
 // Clamp-only activation: clamp(x, -limit, limit).
 template <bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_clamped(uint32_t limit_bits) {
+inline void calculate_clamped(std::uint32_t limit_bits) {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
@@ -92,7 +94,7 @@ inline void calculate_clamped(uint32_t limit_bits) {
 
 // Kimi K3 SiTU gate: beta * tanh(x / beta) * sigmoid(x).
 template <bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_situ_gate(uint32_t beta_bits, uint32_t beta_reciprocal_bits) {
+inline void calculate_situ_gate(std::uint32_t beta_bits, std::uint32_t beta_reciprocal_bits) {
     sfpi::vFloat beta = sfpi::as<sfpi::vFloat>(sfpi::vInt(beta_bits));
     sfpi::vFloat beta_reciprocal = sfpi::as<sfpi::vFloat>(sfpi::vInt(beta_reciprocal_bits));
 #pragma GCC unroll 8
@@ -113,7 +115,7 @@ inline void calculate_situ_gate(uint32_t beta_bits, uint32_t beta_reciprocal_bit
 
 // Optional Kimi K3 SiTU up transform: beta * tanh(x / beta).
 template <bool is_fp32_dest_acc_en, int ITERATIONS>
-inline void calculate_scaled_tanh(uint32_t beta_bits, uint32_t beta_reciprocal_bits) {
+inline void calculate_scaled_tanh(std::uint32_t beta_bits, std::uint32_t beta_reciprocal_bits) {
     sfpi::vFloat beta = sfpi::as<sfpi::vFloat>(sfpi::vInt(beta_bits));
     sfpi::vFloat beta_reciprocal = sfpi::as<sfpi::vFloat>(sfpi::vInt(beta_reciprocal_bits));
 #pragma GCC unroll 8

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/ckernel_sfpu_clamped_silu.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/ckernel_sfpu_clamped_silu.h
@@ -1,0 +1,136 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared SFPU activation functions for clamped SiLU (GPT-OSS SwiGLU).
+// Used by both the standalone ClampedSilu micro-op and fused activation
+// inside DRAMStreamingMatmul.
+
+#pragma once
+
+// Fused activation mode constants for DRAMStreamingMatmul.
+static constexpr uint32_t FUSED_ACT_NONE = 0;
+static constexpr uint32_t FUSED_ACT_SILU = 1;
+static constexpr uint32_t FUSED_ACT_CLAMPED_GATE = 2;
+static constexpr uint32_t FUSED_ACT_CLAMPED_UP = 3;
+static constexpr uint32_t FUSED_ACT_GELU = 4;
+static constexpr uint32_t FUSED_ACT_CLAMP_ONLY = 5;
+static constexpr uint32_t FUSED_ACT_SITU_GATE = 6;
+static constexpr uint32_t FUSED_ACT_SCALED_TANH = 7;
+
+#ifdef TRISC_PACK
+#include "ckernel_sfpu_sigmoid.h"
+
+namespace ckernel {
+namespace sfpu {
+
+// Gate activation: clamp(x, max=limit) * sigmoid(alpha * clamp(x, max=limit))
+template <bool is_fp32_dest_acc_en, int ITERATIONS>
+inline void calculate_clamped_silu_gate(uint32_t limit_bits, uint32_t alpha_bits) {
+    sfpi::vFloat alpha_f = sfpi::as<sfpi::vFloat>(sfpi::vInt(alpha_bits));
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat limit_f = sfpi::as<sfpi::vFloat>(sfpi::vInt(limit_bits));
+
+        x = sfpi::min(x, limit_f);
+
+        sfpi::vFloat sig = _sfpu_sigmoid_<is_fp32_dest_acc_en>(alpha_f * x);
+        sfpi::vFloat result = x * sig;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::as<sfpi::vFloat>(sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest));
+        }
+
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+// Up activation: clamp(x, -limit, limit) + 1.0
+template <bool is_fp32_dest_acc_en, int ITERATIONS>
+inline void calculate_clamped_up(uint32_t limit_bits) {
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat limit_f = sfpi::as<sfpi::vFloat>(sfpi::vInt(limit_bits));
+        sfpi::vFloat neg_limit = sfpi::setsgn(limit_f, 1);
+
+        x = sfpi::clamp(x, neg_limit, limit_f);
+
+        sfpi::vFloat result = x + 1.0f;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::as<sfpi::vFloat>(sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest));
+        }
+
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+// Clamp-only activation: clamp(x, -limit, limit).
+template <bool is_fp32_dest_acc_en, int ITERATIONS>
+inline void calculate_clamped(uint32_t limit_bits) {
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat limit_f = sfpi::as<sfpi::vFloat>(sfpi::vInt(limit_bits));
+        sfpi::vFloat neg_limit = sfpi::setsgn(limit_f, 1);
+
+        x = sfpi::clamp(x, neg_limit, limit_f);
+
+        sfpi::vFloat result = x;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::as<sfpi::vFloat>(sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest));
+        }
+
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+// Kimi K3 SiTU gate: beta * tanh(x / beta) * sigmoid(x).
+template <bool is_fp32_dest_acc_en, int ITERATIONS>
+inline void calculate_situ_gate(uint32_t beta_bits, uint32_t beta_reciprocal_bits) {
+    sfpi::vFloat beta = sfpi::as<sfpi::vFloat>(sfpi::vInt(beta_bits));
+    sfpi::vFloat beta_reciprocal = sfpi::as<sfpi::vFloat>(sfpi::vInt(beta_reciprocal_bits));
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat tanh_x = 2.0f * _sfpu_sigmoid_<is_fp32_dest_acc_en>(2.0f * x * beta_reciprocal) - 1.0f;
+        sfpi::vFloat result = beta * tanh_x;
+        result *= _sfpu_sigmoid_<is_fp32_dest_acc_en>(x);
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::as<sfpi::vFloat>(sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest));
+        }
+
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+// Optional Kimi K3 SiTU up transform: beta * tanh(x / beta).
+template <bool is_fp32_dest_acc_en, int ITERATIONS>
+inline void calculate_scaled_tanh(uint32_t beta_bits, uint32_t beta_reciprocal_bits) {
+    sfpi::vFloat beta = sfpi::as<sfpi::vFloat>(sfpi::vInt(beta_bits));
+    sfpi::vFloat beta_reciprocal = sfpi::as<sfpi::vFloat>(sfpi::vInt(beta_reciprocal_bits));
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat result = 2.0f * _sfpu_sigmoid_<is_fp32_dest_acc_en>(2.0f * x * beta_reciprocal) - 1.0f;
+        result *= beta;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::as<sfpi::vFloat>(sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest));
+        }
+
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel
+#endif  // TRISC_PACK

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/ckernel_sfpu_logit_softcap.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/ckernel_sfpu_logit_softcap.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// SFPU helper for Gemma-style final logit softcapping:
+//   y = cap * tanh(x)
+// The caller pre-scales x by folding 1 / cap into the vocab weights.
+
+#pragma once
+
+#ifdef TRISC_PACK
+#include "ckernel_sfpu_tanh.h"
+
+namespace ckernel {
+namespace sfpu {
+
+template <int ITERATIONS>
+inline void calculate_logit_softcap(uint32_t cap_bits, uint32_t) {
+    for (int d = 0; d < ITERATIONS; d++) {
+        // ponytail: compute tanh first, load cap after -> cap not live across the
+        // register-heavy tanh (was an SFPI reload ICE at -O3). Algebraically identical.
+        sfpi::vFloat t = _sfpu_tanh_fp32_accurate_(sfpi::dst_reg[0]);
+        sfpi::vFloat cap = sfpi::as<sfpi::vFloat>(sfpi::vInt(cap_bits));
+        sfpi::dst_reg[0] = cap * t;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel
+#endif  // TRISC_PACK

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/ckernel_sfpu_logit_softcap.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/ckernel_sfpu_logit_softcap.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #ifdef TRISC_PACK
 #include "ckernel_sfpu_tanh.h"
 
@@ -14,7 +16,7 @@ namespace ckernel {
 namespace sfpu {
 
 template <int ITERATIONS>
-inline void calculate_logit_softcap(uint32_t cap_bits, uint32_t) {
+inline void calculate_logit_softcap(std::uint32_t cap_bits, std::uint32_t) {
     for (int d = 0; d < ITERATIONS; d++) {
         // ponytail: compute tanh first, load cap after -> cap not live across the
         // register-heavy tanh (was an SFPI reload ICE at -O3). Algebraically identical.

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_sparse_k_filter.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_sparse_k_filter.h
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// SFPU kernel: per-bank index filter + encode for SparseKDramReader.
+//
+// The index list is BANK-ADDRESSED: each uint32 already carries the token's
+// (global bank, within-bank position) directly — the indexer stamps it that way,
+// and its round-robin granularity is aligned to the main KV tokens_per_page — so
+// there is NO round-robin reconstruction here:
+//
+//   bits [0, WITHIN_BANK_BITS)                within-bank position  (-> local)
+//   bits [GLOBAL_BANK_SHIFT, +6-bit field)    global bank id (local_bank | device<<3)
+//
+// Each DST lane holds one uint32 index. Keep only tokens whose global-bank field
+// matches this core's bank, and encode each match as local + 1:
+//
+//   local = idx & WITHIN_BANK_MASK
+//   enc   = ((idx >> GLOBAL_BANK_SHIFT) & BANK_MASK) == MY_BANK
+//             ? ((local + 1) << OUT_SHIFT) : 0
+//
+// The +1 keeps a real match at within-bank position 0 from colliding with the
+// non-match sentinel 0. DM0 recovers local = enc - 1, then decodes the byte
+// address with tokens_per_page (in_bank_page = local >> log_tpp, offset =
+// local & tpp_mask) — that decode is unchanged; only the bank/local extraction
+// here is a direct field read (no round-robin reconstruction).
+//
+// BANK_MASK         = num_global_banks - 1  (the 6-bit global-bank mask, 0x3F for 64 banks)
+// MY_BANK           = this core's global_bank_id (device*num_local_banks + local_bank)
+// GLOBAL_BANK_SHIFT = bit offset of the global-bank field (distributed_indexer config: 14)
+// WITHIN_BANK_MASK  = (1 << WITHIN_BANK_BITS) - 1 (config: 0x3FFF)
+// OUT_SHIFT         = 0 or 16 — packs two tiles two-per-uint32 (one in the low 16
+//                     bits, one in the high 16) before OR-ing the dest tiles. enc
+//                     fits 16 bits (op.py asserts), so the halves don't overlap.
+
+#pragma once
+
+#include <cstdint>
+
+#include "sfpi.h"
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+// ITERATIONS rows of the current DST tile (32 lanes each); pass 32 for a full
+// 32x32 tile with VectorMode::RC_custom.
+//
+// Requires a 32-bit integer DST (op runs with fp32_dest_acc_en, indices CB
+// unpacked in UnpackToDestFp32), so `vInt idx = dst_reg[0]` loads the raw
+// int32 page_id — the idiom the stock integer SFPU ops use.
+template <
+    int ITERATIONS,
+    std::uint32_t BANK_MASK,
+    std::uint32_t MY_BANK,
+    std::uint32_t GLOBAL_BANK_SHIFT,
+    std::uint32_t WITHIN_BANK_MASK,
+    std::uint32_t OUT_SHIFT = 0>
+inline void _sparse_k_filter_tile_()
+{
+    using namespace sfpi;
+    // Bank-addressed index: bits [0, WITHIN_BANK_BITS) are the within-bank slot
+    // (== DM0 `local`, decoded to page/offset via tokens_per_page), and the
+    // 6-bit global-bank field sits at GLOBAL_BANK_SHIFT (local_bank | device<<3).
+    // Test the bank field in place (constants shifted at compile time) so the
+    // hot predicate stays a single AND + compare — no per-lane shift of idx.
+    constexpr int BANK_FIELD = static_cast<int>(BANK_MASK) << static_cast<int>(GLOBAL_BANK_SHIFT);
+    constexpr int MY_FIELD   = static_cast<int>(MY_BANK) << static_cast<int>(GLOBAL_BANK_SHIFT);
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        vInt idx = dst_reg[0];
+        vInt enc = 0;
+        v_if ((idx & BANK_FIELD) == MY_FIELD)
+        {
+            vInt local = idx & static_cast<int>(WITHIN_BANK_MASK);
+            enc        = (local + 1) << static_cast<int>(OUT_SHIFT);
+        }
+        v_endif;
+        dst_reg[0] = enc;
+        dst_reg++;
+    }
+}
+
+} // namespace sfpu
+} // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_sparse_k_filter.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_sparse_k_filter.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 // SPDX-License-Identifier: Apache-2.0
 
 // SFPU kernel: per-bank index filter + encode for SparseKDramReader.

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_sparse_k_filter.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_sparse_k_filter.h
@@ -36,6 +36,7 @@
 
 #include <cstdint>
 
+#include "ckernel.h"
 #include "sfpi.h"
 
 namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_zero_pad.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_zero_pad.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// SFPU kernel: zero padding rows in a dest register tile.
+//
+// After squaring, the last tile may contain garbage in the padding region.
+// This kernel zeros those rows so the subsequent reduction is correct.
+// Each SFPU iteration processes 32 bf16 elements (64 bytes) in 1 cycle.
+
+#pragma once
+
+#include "sfpi.h"
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+// Zero rows [VALID_ROWS, TOTAL_ROWS) in the current dest tile.
+// VALID_ROWS: SFPU rows containing real squared data.
+// TOTAL_ROWS: total SFPU rows per tile (16 for HALF, 32 for FULL).
+template <bool is_fp32_dest_acc_en, int VALID_ROWS, int TOTAL_ROWS>
+inline void _zero_pad_tile_()
+{
+    // Advance past valid rows without writing.
+    for (int d = 0; d < VALID_ROWS; d++)
+    {
+        sfpi::dst_reg++;
+    }
+    // Zero the padding rows.
+    sfpi::vFloat zero = 0.0f;
+    for (int d = VALID_ROWS; d < TOTAL_ROWS; d++)
+    {
+        sfpi::dst_reg[0] = zero;
+        sfpi::dst_reg++;
+    }
+}
+
+} // namespace sfpu
+} // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_zero_pad.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_zero_pad.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "ckernel.h"
 #include "sfpi.h"
 
 namespace ckernel


### PR DESCRIPTION
### PR Category

Cross-repo clean-up

### Summary

Adds **4 blaze-authored SFPU LLKs** under `experimental/`, batch 3 of the blaze→metal LLK migration (after #51361 batch 1 and the `sum_reduce_scalar` port #52076), spread across the layers exactly as tt-metal does for its own experimental LLKs:

| layer | dir | files |
|---|---|---|
| L2S llk_api SFPU | `tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/` | 2 |
| L4 SFPU functor | `tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/` | 2 |

Families:

- `ckernel_sfpu_clamped_silu.h` — GPT-OSS SwiGLU activations plus the `DRAMStreamingMatmul` fused-activation mode family (`SILU`, `CLAMPED_GATE`, `CLAMPED_UP`, `GELU`, `CLAMP_ONLY`, `SITU_GATE`, `SCALED_TANH`).
- `ckernel_sfpu_logit_softcap.h` — Gemma-style final logit softcapping, `y = cap * tanh(x)`.
- `ckernel_sfpu_sparse_k_filter.h` — per-bank index filter + encode for `SparseKDramReader` (consumer: `glm_sparse_read_sdpa`).
- `ckernel_sfpu_zero_pad.h` — zero padding rows in a DEST tile ahead of a reduction.

None of the four has a counterpart anywhere in tt-metal — neither in the canonical LLK directories nor in `models/demos/deepseek_v3_b1/kernel_includes/`.

**Additive only.** No existing file is modified, and no new directory is created — both destinations already exist and contain files.

### Relationship to blaze's copies

All four are token-identical to blaze's originals once the following are normalised away: tt-llk clang-format style, the `llk-fix-cstdint` hook (`std::uint*_t` + `<cstdint>`, applies to `sparse_k_filter`), and added comments.

The only code changes are self-containment hardening (blaze's copies rely on the including kernel's include order; these compile independently in every TRISC context):

- `ckernel_sfpu_clamped_silu.h` — adds `#include "ckernel_sfpu_sigmoid.h"` for `_sfpu_sigmoid_`, plus `<cstdint>` + `std::uint32_t` so the file-scope `FUSED_ACT_*` constants (parsed in every TRISC context, ahead of the `TRISC_PACK`-guarded section) are order-independent. Same `<cstdint>` hardening on `ckernel_sfpu_logit_softcap.h`.
- `ckernel_sfpu_sparse_k_filter.h` / `ckernel_sfpu_zero_pad.h` — add `#include "ckernel.h"` + `#include "sfpi.h"` (the sibling convention, cf. `ckernel_sfpu_softmax_k.h`). Without them they fail `-Wtemplate-body` in UNPACK TRISC TUs.

**Compile-verified:** all four headers were syntax-compiled with the production Blackhole JIT flag set (`-Wall -Werror`, `-mcpu=tt-bh-tensix`) in all three TRISC contexts (MATH, PACK, UNPACK), spliced into a known-good kernel TU against a green baseline.

Kept verbatim on purpose (documented rather than "fixed"):

- The `TRISC_PACK` guards on `clamped_silu` / `logit_softcap` — blaze applies these activations on the packer TRISC (fused into pack), and the guard is part of that contract.
- `clamped_silu`'s file-scope `FUSED_ACT_*` mode-selector constants — consumed by `DRAMStreamingMatmul`'s fused-activation dispatch; they move with the functors they select between.

### Notes for reviewers

Not in this PR:

- **LLK tests / goldens** — tracked separately as tt-blaze#2003, as with batch 1.
- **blaze's `sampling_sfpu.hpp` / `run_top32_llk.hpp` wrapper headers** — they live in `namespace blaze` and lean on blaze's SFPU macro compat shims, so they cannot be promoted verbatim; they are rewire-time work.
- **The SFPU macro compat shims** (`SFPU_CALL` / `SFPU_CALL_FN` restoration) — upstreaming them modifies `llk_math_eltwise_unary_sfpu_macros.h`, which would break this PR's additive-only contract; separate small PR.

Relates to tt-blaze#1971 / tt-blaze#2002.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch3)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch3)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch3)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch3)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch3)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilenkovic/blaze-llk-experimental-batch3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilenkovic/blaze-llk-experimental-batch3)