### PR TITLE
#51217: Fix shared L1 scratch race in unaligned reshard same-width

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_reshard.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_reshard.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+import ttnn
+
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal
+
+
+@pytest.mark.parametrize("channels", [1, 2, 3, 4, 5, 6, 7, 9, 10, 17, 33, 65])
+@pytest.mark.parametrize("input_buffer_type", [ttnn.BufferType.L1, ttnn.BufferType.DRAM])
+def test_reshard_unaligned_height_sharded_scratch_race(device, channels, input_buffer_type):
+    """Regression for #51217: 32x4 -> 64x2 (L1 output) lands the local split on a remote-shard boundary; fails pre-fix, passes with the disjoint-halves scratch split."""
+    grid_size = device.compute_with_storage_grid_size()
+    if grid_size.x < 4:
+        pytest.skip("Test requires at least 4 cores in the x dimension")
+
+    input_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))})
+    output_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))})
+
+    input_shard_spec = ttnn.ShardSpec(input_shard_grid, (32, channels), ttnn.ShardOrientation.ROW_MAJOR)
+    input_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, input_buffer_type, input_shard_spec)
+    output_shard_spec = ttnn.ShardSpec(output_shard_grid, (64, channels), ttnn.ShardOrientation.ROW_MAJOR)
+    # L1 output is what selects the reader path (use_scratch = unaligned && local_is_output).
+    output_mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec)
+
+    torch_tensor = torch.rand([1, 1, 128, channels]).bfloat16().float()
+    input_tensor = ttnn.Tensor(
+        torch_tensor, ttnn.bfloat16, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, mem_config=input_mem_config
+    )
+
+    output_tensor = ttnn.reshard(input_tensor, output_mem_config)
+    torch_tensor_after_round_trip = ttnn.to_torch(output_tensor)
+
+    assert torch_tensor.shape == torch_tensor_after_round_trip.shape
+    passing, output = comp_equal(torch_tensor, torch_tensor_after_round_trip)
+    assert passing, output

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_width_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_width_reader.cpp
@@ -39,9 +39,13 @@ void kernel_main() {
 #ifdef UNALIGNED
     constexpr uint32_t local_unit_size_padded = get_arg(args::local_unit_size_padded);
     constexpr uint32_t remote_unit_size_padded = get_arg(args::remote_unit_size_padded);
+    constexpr uint32_t remote_units_per_shard = get_arg(args::remote_units_per_shard);
+    constexpr uint32_t is_reader = get_arg(args::is_reader);
+    // Second RISC uses the upper half so both do not write the same scratch bytes.
+    constexpr uint32_t scratch_base_offset = is_reader ? 0 : remote_units_per_shard * remote_unit_size_padded;
     DataflowBuffer dfb_scratch(dfb::scratch);
-    uint32_t l1_scratch_write_addr = dfb_scratch.get_write_ptr();
-    uint32_t l1_scratch_read_addr = dfb_scratch.get_read_ptr();
+    uint32_t l1_scratch_write_addr = dfb_scratch.get_write_ptr() + scratch_base_offset;
+    uint32_t l1_scratch_read_addr = dfb_scratch.get_read_ptr() + scratch_base_offset;
     for (uint32_t i = 0; i < num_reads; ++i) {
         uint32_t bank_id = get_vararg(args_idx++);
         uint32_t src_offset = get_vararg(args_idx++);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_width.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_width.cpp
@@ -184,7 +184,20 @@ ttnn::device_operation::ProgramArtifacts ReshardSameWidthFactory<local_is_output
         {"remote_unit_size_padded", remote_unit_size_padded},
     };
 
-    const auto make_worker = [&](const char* name, DataMovementHardwareConfig hw_config, DFBEndpointType endpoint) {
+    // is_reader splits the two RISCs so each owns its own scratch half.
+    auto make_cta = [&](uint32_t is_reader) {
+        KernelSpec::CompileTimeArgs cta = compile_time_args;
+        if (use_scratch) {
+            cta.insert({"is_reader", is_reader});
+            cta.insert({"remote_units_per_shard", remote_units_per_shard});
+        }
+        return cta;
+    };
+
+    const auto make_worker = [&](const char* name,
+                                 const DataMovementHardwareConfig& hw_config,
+                                 DFBEndpointType endpoint,
+                                 uint32_t is_reader) {
         KernelSpec kernel{
             .unique_id = KernelSpecName{name},
             .source = std::filesystem::path(kernel_path),
@@ -195,9 +208,9 @@ ttnn::device_operation::ProgramArtifacts ReshardSameWidthFactory<local_is_output
             }},
             .tensor_bindings = {TensorBinding{
                 .tensor_parameter_name = TensorParamName{kSWRemoteTensorParam}, .accessor_name = kSWRemoteTensorParam}},
-            .compile_time_args = compile_time_args,
+            .compile_time_args = make_cta(is_reader),
             .runtime_arg_schema = {.runtime_arg_names = {offset_arg_name, count_arg_name}},
-            .hw_config = std::move(hw_config),
+            .hw_config = hw_config,
             .advanced_options = {.num_runtime_varargs = num_varargs},
         };
         // The unaligned re-striding path is gated by a preprocessor flag rather than a compile-time
@@ -220,9 +233,15 @@ ttnn::device_operation::ProgramArtifacts ReshardSameWidthFactory<local_is_output
     // shard (and scratch) DFB. Two role-free touchers over one grid -> assign 1P + 1C.
     spec.kernels = {
         make_worker(
-            kSWReaderKernel, ttnn::create_reader_datamovement_config(device->arch()), DFBEndpointType::PRODUCER),
+            kSWReaderKernel,
+            ttnn::create_reader_datamovement_config(device->arch()),
+            DFBEndpointType::PRODUCER,
+            /*is_reader=*/1),
         make_worker(
-            kSWWriterKernel, ttnn::create_writer_datamovement_config(device->arch()), DFBEndpointType::CONSUMER),
+            kSWWriterKernel,
+            ttnn::create_writer_datamovement_config(device->arch()),
+            DFBEndpointType::CONSUMER,
+            /*is_reader=*/0),
     };
 
     // Local sharded DFB, built on the local buffer's borrowed memory so its backing L1 address is
@@ -248,12 +267,11 @@ ttnn::device_operation::ProgramArtifacts ReshardSameWidthFactory<local_is_output
         .borrowed_from = TensorParamName{kSWLocalTensorParam},
     }};
     if (use_scratch) {
-        // Scratch DFB used only by the reader path (local_is_output): the entry size is the
-        // remote-aligned stride, so the DFB spans remote rows at their padded stride.
+        // entry_size = remote-aligned stride; 2x entries so the two RISCs get disjoint halves.
         spec.dataflow_buffers.push_back(DataflowBufferSpec{
             .unique_id = DFBSpecName{kSWScratchDfbName},
             .entry_size = remote_unit_size_padded,
-            .num_entries = remote_units_per_shard,
+            .num_entries = 2 * remote_units_per_shard,
             .data_format_metadata = data_format,
         });
     }


### PR DESCRIPTION
### Ticket
Link to Github Issue #51217

### Problem
Unaligned HEIGHT→HEIGHT `ttnn.reshard` with L1 output runs the same reader kernel on both data-movement RISCs of each core. They stage remote rows through one shared scratch DFB with no FIFO handshake. When the local-row split crosses a remote-shard boundary, both RISCs write `scratch_base + src_offset=0` at the same time. Last write wins, so one half of the output shard can silently get the other kernel's rows. Timing-dependent; existing unaligned tests go large-input-shard → small-output-shard and do not overlap scratch.

Sibling TM dual-RISC paths do not have this: fold / same-height / generic split disjoint dest columns, sticks, or pages and need no scratch. The same-width writer copies row-by-row from L1 with no scratch.

### What this PR does
- **Size the existing scratch DFB 2×** — `num_entries = 2 * remote_units_per_shard` so each RISC has a full remote-shard half.
- **Reuse fold's `is_reader` CTA** — `make_cta(is_reader)` on the two same-source instances (`1` / `0`); kernel offsets scratch by `is_reader ? 0 : remote_units_per_shard * remote_unit_size_padded`.
- **Leave writer / aligned / same-height / generic untouched** — scratch is only on the unaligned reader path.
- **Regression test** — `test_reshard_unaligned_height_sharded_scratch_race` in `test_reshard.py` uses the inverted `32×4 → 64×2` shape (L1 output) that lands the local-row split on a remote-shard boundary. 24 param cases; 72/72 fail pre-fix and 72/72 pass post-fix on WH B0.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/reshard-same-width-scratch-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/reshard-same-width-scratch-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/reshard-same-width-scratch-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/reshard-same-width-scratch-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/reshard-same-width-scratch-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/reshard-same-width-scratch-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/reshard-same-width-scratch-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/reshard-same-width-scratch-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/reshard-same-width-scratch-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/reshard-same-width-scratch-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/reshard-same-width-scratch-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/reshard-same-width-scratch-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/reshard-same-width-scratch-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/reshard-same-width-scratch-race)
