### PR TITLE
Add the RNE-rounded softplus SFPU variant to experimental (batch 4)

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/ckernel_sfpu_softplus_rne.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/ckernel_sfpu_softplus_rne.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_sfpu_softplus.h"
+#include "sfpi.h"
+#include "sfpu/ckernel_sfpu_converter.h"
+
+namespace ckernel {
+namespace sfpu {
+
+// RNE-rounded softplus body: ``is_fp32_dest_acc_en=false`` forces an
+// explicit RNE round to bf16 via ``convert<vFloat16b>`` after the SFPU
+// compute (fp32 in LRegs; the default SFPSTORE truncates and is
+// downward-biased ~0.5 ULP vs torch's ``F.softplus(bf16(x)).to(bf16)``).
+// Empirically more accurate for the DeepSeek-V4 router gate-MM's
+// bf16-tied top-k picks than the fp32-dst store path.
+template <bool APPROXIMATION_MODE>
+inline void calculate_softplus_body_rne(const float beta, const float beta_reciprocal, const float threshold) {
+    calculate_softplus_body<APPROXIMATION_MODE, /*is_fp32_dest_acc_en=*/false>(beta, beta_reciprocal, threshold);
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_softplus_rne(std::uint32_t param0, std::uint32_t param1, std::uint32_t param2) {
+    const auto beta = Converter::as_float(param0);
+    const auto beta_reciprocal = Converter::as_float(param1);
+    const auto threshold = Converter::as_float(param2);
+    for (int d = 0; d < ITERATIONS; d++) {
+        calculate_softplus_body_rne<APPROXIMATION_MODE>(beta, beta_reciprocal, threshold);
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel


### PR DESCRIPTION
### PR Category

Cross-repo clean-up

### Summary

Adds **1 blaze-authored SFPU functor variant** under `experimental/` — batch 4 of the blaze→metal LLK migration (#51361 batch 1, #52076 sum_reduce_scalar, #53025 batch 3), **rescoped** (see below):

| layer | dir | files |
|---|---|---|
| L2S llk_api SFPU | `tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/` | 1 |

- `ckernel_sfpu_softplus_rne.h` — `calculate_softplus_rne` (+ body helper), extracted from `blaze/ops/matmul_fused_act/kernels/op.hpp` (the only blaze op carrying LLK-level code inline). It forces an explicit RNE round to bf16 after the SFPU compute: the default SFPSTORE truncation is downward-biased ~0.5 ULP vs torch's `F.softplus(bf16(x)).to(bf16)`, which matters for the DeepSeek-V4 router gate's bf16-tied top-k picks. Wraps the existing canonical `calculate_softplus_body` — no duplicated math.

**Additive only.** No existing file is modified.

### Rescope note

The original draft also resurrected the four classic `llk_math_eltwise_unary_sfpu_{sigmoid,silu,softplus,sqrt}` wrapper headers that blaze's pack-thread fused-activation kernels use (metal removed that dispatch layer deliberately in the macro-era refactor; blaze kept two vendored copies and inlined two). Review discussion concluded the better direction is converting blaze's call sites to the macro style (`SFPU_UNARY_CALL`) at rewire time — blaze already uses macros everywhere else, and both forms expand to the same `_llk_math_eltwise_unary_sfpu_params_` call, so the conversion is codegen-neutral and bit-exact-verifiable. This PR now carries only the piece with no upstream home: the RNE functor variant.

### Relationship to blaze's original

Changes enumerated: hoisted from `namespace ckernel::matmul_fused_act_detail` into `ckernel::sfpu`; `uint` → `std::uint32_t`; self-containment includes (`<cstdint>`, `sfpi.h`, `ckernel_sfpu_softplus.h`, converter).

**Compile-verified:** compiles clean as a bare, unguarded include in MATH, PACK and UNPACK TRISC contexts with the production Blackhole JIT flag set (`-Wall -Werror`, `-mcpu=tt-bh-tensix`).

### Notes for reviewers

Not in this PR:

- **LLK tests / goldens** — tracked separately as tt-blaze#2003, as with the previous batches.
- **The blaze-side rewire** — at the next uplift, `matmul_fused_act` converts its wrapper-style call sites to the retained macro forms this header's siblings already use (`SFPU_UNARY_CALL` / `SFPU_UNARY_INIT_FN` — no new metal-side macros needed) and deletes ~60 lines of inline LLK code plus blaze's two vendored wrapper headers.

Relates to tt-blaze#1971 / tt-blaze#2002.
