### PR TITLE
[Bug fix] lgamma: the bridge guards exclude their own closed boundary

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_lgamma.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_lgamma.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Boundary coverage for lgamma's two Taylor bridges.
+
+The fp32 arm evaluates a series around z = 1 while |z-1| is inside 0.25, and one around z = 2
+while |z-2| is inside 0.25. Both series are fitted on the closed interval, so the four inputs
+that sit exactly on |d| = 0.25 belong to a bridge; a strict guard sends them to the Stirling
+arm instead, which is an asymptotic expansion for large z.
+
+The assertion is scale-free on purpose: a boundary input must be no worse than the input one
+step inside the bridge it belongs to. Absolute bounds would have to be re-tuned every time the
+bridge coefficients move, and the property being tested is the branch selection, not the fit.
+"""
+
+import pytest
+import torch
+
+import ttnn
+
+# (boundary, the neighbour just inside the bridge it belongs to)
+_BOUNDARIES = [
+    (0.75, 0.7500001),
+    (1.25, 1.2499999),
+    (1.75, 1.7500001),
+    (2.25, 2.2499999),
+]
+
+
+@pytest.mark.parametrize("z, inside", _BOUNDARIES)
+def test_lgamma_bridge_boundary_is_no_worse_than_the_bridge(device, z, inside):
+    values = torch.tensor([z, inside], dtype=torch.float32)
+    padded = torch.zeros((1, 1, 32, 32), dtype=torch.float32)
+    padded.view(-1)[: values.numel()] = values
+
+    tt_in = ttnn.from_torch(padded, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device)
+    got = ttnn.to_torch(ttnn.lgamma(tt_in)).view(-1)[: values.numel()].double()
+    ref = torch.lgamma(values.double())
+
+    err_boundary = abs(got[0] - ref[0]).item()
+    err_inside = abs(got[1] - ref[1]).item()
+
+    assert err_boundary <= 2.0 * err_inside, (
+        f"lgamma({z}) is off by {err_boundary:.4e} while lgamma({inside}) is off by "
+        f"{err_inside:.4e} ({err_boundary / err_inside:.1f}x). The boundary is being sent to "
+        f"the Stirling arm instead of the bridge it belongs to."
+    )

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
@@ -123,7 +123,7 @@ inline void calculate_lgamma_stirling_fp32(
 
         // Polynomial bridge for small range inputs (z near 1 or 2 only)
 
-        v_if(abs_range1 < 0.25f) {
+        v_if(abs_range1 <= 0.25f) {
             // Taylor Expansion around z=1 (d = z - 1.0)
             constexpr float p0 = -0.57721566f;  // -gamma
             constexpr float p1 = 0.82246703f;   // zeta(2)/2
@@ -133,7 +133,7 @@ inline void calculate_lgamma_stirling_fp32(
             // res = d * (p0 + d * (p1 + d * (p2 + d * (p3 + d * p4))));
             res = d1 * PolynomialEvaluator::eval(d1, p0, p1, p2, p3, p4);
         }
-        v_elseif(abs_range2 < 0.25f) {
+        v_elseif(abs_range2 <= 0.25f) {
             // Taylor Expansion around z=2 (d = z - 2.0)
             constexpr float q0 = 0.42278434f;   // 1 - gamma
             constexpr float q1 = 0.32246703f;   // (zeta(2)-1)/2

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
@@ -84,7 +84,7 @@ inline void calculate_lgamma_stirling_fp32(
 
         // Polynomial bridge for small range inputs (z near 1 or 2 only)
 
-        v_if(abs_range1 < 0.25f) {
+        v_if(abs_range1 <= 0.25f) {
             // Taylor Expansion around z=1 (d = z - 1.0)
             constexpr float p0 = -0.57721566f;  // -gamma
             constexpr float p1 = 0.82246703f;   // zeta(2)/2
@@ -94,7 +94,7 @@ inline void calculate_lgamma_stirling_fp32(
             // res = d * (p0 + d * (p1 + d * (p2 + d * (p3 + d * p4))));
             res = d1 * PolynomialEvaluator::eval(d1, p0, p1, p2, p3, p4);
         }
-        v_elseif(abs_range2 < 0.25f) {
+        v_elseif(abs_range2 <= 0.25f) {
             // Taylor Expansion around z=2 (d = z - 2.0)
             constexpr float q0 = 0.42278434f;   // 1 - gamma
             constexpr float q1 = 0.32246703f;   // (zeta(2)-1)/2


### PR DESCRIPTION
### PR Category

Bug fix.

### Summary

Closes #53046.

The two bridge guards become `<=`, and a boundary test is added.

The series are fitted on the closed interval, so `<=` is the comparison they were written for. Four fp32 values sit exactly on `|d| = 0.25`; all four were taking the Stirling arm, which is an asymptotic expansion for large `z`.

### Accuracy

Blackhole P300 at `1227e18213e`, fp32, absolute error against `torch.lgamma` in float64. "inside" is the input one step further into the bridge, which is what the boundary should be no worse than:

| z | main | with `<=` | inside | |
|---|---|---|---|---|
| 0.75 | 2.8510e-03 | 5.2657e-05 | 5.2661e-05 | **54x** |
| 1.25 | 5.2284e-05 | 3.4179e-05 | 3.4176e-05 | 1.5x |
| 1.75 | 3.3475e-06 | 7.8452e-07 | 7.9167e-07 | 4.3x |
| 2.25 | 4.7583e-07 | 6.3974e-07 | 6.3974e-07 | **0.74x** |

Every boundary now matches its neighbour.

`z = 2.25` gets slightly worse, 4.7583e-07 → 6.3974e-07. Stirling was the better approximation at that argument, and the change moves it onto the series with everything else. That is 1.3x on a quantity four orders of magnitude below the defect being fixed, and the alternative is a guard that is closed at one end and open at the other.

### Tests

`test_unary_lgamma.py` asserts that a boundary input is no worse than the input one step inside the bridge it belongs to. The bound is a ratio rather than an absolute figure on purpose: an absolute one would need re-tuning every time the bridge coefficients move, and the property under test is which branch the input takes, not how good the fit is. On unmodified `main` it fails at `z = 0.75` and `z = 1.75` and passes at the other two; with the change all four pass.

`test_math.py::test_lgamma` draws random inputs and checks PCC at 0.99, so it cannot see this and passes either way.

### Notes for reviewers

- **This overlaps #51991 and needs coordinating with it.** That PR adds a bridge around `z = 0.625` guarded by `v_if(z < 0.75f)` and turns the first guard here into a `v_elseif`, so it touches the same two lines. Its guard is strict too and also stops at 0.75, which is why `z = 0.75` survives it — see #53046. Whichever lands first, the other needs a rebase, and if that one goes in first the right fix here may be `z <= 0.75f` on the new bridge rather than `<=` on this one, depending on which bridge is more accurate at exactly 0.75. Happy to rebase onto it and re-measure.
- **Wormhole gets the same change, and is not measured** — there is no Wormhole hardware on this host. Its copy of the file is not identical to Blackhole's, which carries an extra `calculate_lgamma_adjusted`, but the two guards are the same and sit at `:87` and `:97`.
- **The strict guard is not wrong everywhere.** `ckernel_sfpu_trigonometry.h:1118` has the same shape — a strict `<` selecting a fit its own comment describes as being on the closed `[0, 0.75]`. Sweeping `asinh` across that bound gives 0.85 fp32 ULP on the series side, 0.02 for the fall-through value itself and 0.95 on the `log1p` side, so nothing is lost there and this PR leaves it alone. What is specific to `lgamma` is what its fall-through lands on.
