### PR TITLE
Let wget show status when getting sfpi

### DIFF
--- a/dockerfile/scripts/install-sfpi.sh
+++ b/dockerfile/scripts/install-sfpi.sh
@@ -61,7 +61,7 @@ mkdir -p "${TMPDIR}"
 
 # Download (use curl if wget not available)
 if command -v wget &> /dev/null; then
-    wget -q -O "${DEB_FILE}" "${DOWNLOAD_URL}"
+    wget -nv -O "${DEB_FILE}" "${DOWNLOAD_URL}"
 else
     curl -fsSL -o "${DEB_FILE}" "${DOWNLOAD_URL}"
 fi


### PR DESCRIPTION
### PR Category
Bug Fix

### Summary
I typoed an sfpi version, and got a completely uninformative error from CI's log:
```
  0.048 Installing SFPI 7.68.0-pred-43896 for x86_64/debian...
  0.048 Download URL: https://github.com/tenstorrent/sfpi/releases/download/7.68.0-pred-43896/sfpi_7.68.0-pred-43896_x86_64_debian.deb
  0.048 Expected sha256 hash: c2bda99ebd79a965c594c0610b69a24022f2e7b541231ccbc904371610b7b3de
  ------
  Dockerfile.tools:418
  --------------------
   417 |     # Install SFPI - version/hash are read from sfpi-version file
   418 | >>> RUN SFPI_INFO_SCRIPT=/tmp/sfpi-info.sh \
   419 | >>>     SFPI_VERSION_FILE=/tmp/sfpi-version \
   420 | >>>     INSTALL_DIR=/install \
   421 | >>>     /bin/bash /tmp/install-sfpi.sh
   422 |     
  --------------------
  ERROR: failed to solve: process "/bin/bash -euo pipefail -c SFPI_INFO_SCRIPT=/tmp/sfpi-info.sh     SFPI_VERSION_FILE=/tmp/sfpi-version     INSTALL_DIR=/install     /bin/bash /tmp/install-sfpi.sh" did not complete successfully: exit code: 8
```

Use `-nv` not `-q` so it spits out something like:
```
https://github.com/tenstorrent/sfpi/releases/download/7.68.0-pred-43893/sfpi_7.68.0-pred-43896_x86_64_debian.deb:
2026-08-13 14:26:45 ERROR 404: Not Found.
```

or, more usually, something like:
```
2026-08-13 14:26:34 URL:https://release-assets.githubusercontent.com/github-production-release-asset/747374069/9192ba5d-8a8b-4d88-a204-600a7a58c0bf?sp=r&sv=2018-11-09&sr=b&spr=https&se=2026-08-13T15%3A18%3A36Z&rscd=attachment%3B+filename%3Dsfpi_7.68.0-pred-43896_x86_64_debian.deb&rsct=application%2Foctet-stream&skoid=96c2d410-5711-43a1-aedd-ab1947aa7ab0&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skt=2026-08-13T14%3A18%3A29Z&ske=2026-08-13T15%3A18%3A36Z&sks=b&skv=2018-11-09&sig=9qCDyDsRxruwunXjlIuWFYfFspVuT6JvVZ6KHoy4Dug%3D&jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmVsZWFzZS1hc3NldHMuZ2l0aHVidXNlcmNvbnRlbnQuY29tIiwia2V5Ijoia2V5MSIsImV4cCI6MTc4NjYzNDc5MiwibmJmIjoxNzg2NjMxMTkyLCJwYXRoIjoicmVsZWFzZWFzc2V0cHJvZHVjdGlvbi5ibG9iLmNvcmUud2luZG93cy5uZXQifQ.5H6Jg1yfec8bdBBDIGEjPj1hdhVd7ldPqDuMB7Gr_b0&response-content-disposition=attachment%3B%20filename%3Dsfpi_7.68.0-pred-43896_x86_64_debian.deb&response-content-type=application%2Foctet-stream [134583618/134583618] -> "sfpi_7.68.0-pred-43896_x86_64_debian.deb" [1]
```

The curl invocation already does something like this.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/wget)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/wget)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/wget)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/wget)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nsidwell/wget)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nsidwell/wget)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/wget)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/wget)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/wget)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/wget)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/wget)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/wget)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/wget)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/wget)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/wget)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/wget)