### PR TITLE
[tt-emule] asan: robustify Illegal-Semaphore tests for the provenance exemption

### DIFF
--- a/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
@@ -224,6 +224,7 @@ TEST_F(MeshDeviceFixture, Semaphore_SemDerivedOutsideRegion_StillChecked) {
             .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = {sem_id}});
 
     EXPECT_DEATH(detail::LaunchProgram(device, program), ".*Out-of-Bounds Write.*");
+    ::unsetenv("TT_METAL_EMULE_ASAN");
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
@@ -86,4 +86,144 @@ TEST_F(MeshDeviceFixture, Semaphore_OutsideRegion_NoViolation) {
     ::unsetenv("TT_METAL_EMULE_ASAN");
 }
 
+// Negative control: the canonical raw-pointer semaphore idiom — a kernel
+// casting its OWN get_semaphore() address and reading/writing the word directly
+// (matmul reader_bmm_tile_layout_in0_receiver.cpp's mcast-payload read,
+// sdpa_decode writer_decode_all.cpp's nibble poll). Legal on silicon (the
+// reserved region is plain L1), so it must NOT trip the Illegal-Semaphore
+// check: the JIT patch pass's semaphore-provenance rules (S1 inline / S2
+// store-then-cast) route these casts through __emule_sem_l1_to_ptr. Exercises
+// both forms through the real JIT pipeline.
+TEST_F(MeshDeviceFixture, Semaphore_RawGetSemaphoreCast_NoViolation) {
+    ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
+
+    auto* device = this->devices_.at(0)->get_devices()[0];
+    CoreCoord logical_core = {0, 0};
+    Program program = CreateProgram();
+    uint32_t sem_id = CreateSemaphore(program, logical_core, /*initial_value=*/3);
+
+    std::string kernel_src = R"(
+        #include "api/dataflow/dataflow_api.h"
+        void kernel_main() {
+            // Inline form (patch-pass rule S1), nested compile-time arg.
+            volatile tt_l1_ptr uint32_t* p =
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(get_compile_time_arg_val(0)));
+            uint32_t v = *p;
+            *p = v + 1;
+            // Store-then-cast form (patch-pass rule S2) — the shape of the
+            // reader_bmm in0_receiver / writer_decode_all kernels.
+            uint32_t sem_addr = get_semaphore(get_compile_time_arg_val(0));
+            volatile tt_l1_ptr uint32_t* q = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sem_addr);
+            *q = v;
+        }
+    )";
+    CreateKernelFromString(
+        program,
+        kernel_src,
+        logical_core,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = {sem_id}});
+
+    // Must NOT abort.
+    detail::LaunchProgram(device, program);
+    SUCCEED();
+
+    ::unsetenv("TT_METAL_EMULE_ASAN");
+}
+
+// Negative control: the sanctioned Semaphore<> API's own remote-relay path
+// (sdpa reader_interleaved.cpp's KV-chain forward). relay_unicast reads the
+// LOCAL semaphore word as its NOC source — emule's noc_semaphore_set_remote
+// must translate that source via the sanctioned-semaphore path, not the
+// checked chokepoint, or the API itself trips the Illegal-Semaphore check.
+TEST_F(MeshDeviceFixture, Semaphore_RelayUnicast_NoViolation) {
+    ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
+
+    auto* device = this->devices_.at(0)->get_devices()[0];
+    CoreCoord sender_core = {0, 0};
+    CoreCoord receiver_core = {1, 0};
+    CoreRange both_cores(sender_core, receiver_core);
+    Program program = CreateProgram();
+    uint32_t src_sem_id = CreateSemaphore(program, both_cores, /*initial_value=*/0);
+    uint32_t dst_sem_id = CreateSemaphore(program, both_cores, /*initial_value=*/0);
+
+    std::string sender_src = R"(
+        #include "api/dataflow/dataflow_api.h"
+        #include "api/dataflow/noc_semaphore.h"
+        void kernel_main() {
+            uint32_t rx_x = get_arg_val<uint32_t>(0);
+            uint32_t rx_y = get_arg_val<uint32_t>(1);
+            Noc noc;
+            Semaphore<> src_sem(get_compile_time_arg_val(0));
+            Semaphore<> dst_sem(get_compile_time_arg_val(1));
+            src_sem.set(7);
+            src_sem.relay_unicast(noc, dst_sem, rx_x, rx_y);
+        }
+    )";
+    std::string receiver_src = R"(
+        #include "api/dataflow/dataflow_api.h"
+        #include "api/dataflow/noc_semaphore.h"
+        void kernel_main() {
+            Semaphore<> dst_sem(get_compile_time_arg_val(0));
+            dst_sem.wait_min(7);
+        }
+    )";
+    auto sender_kernel = CreateKernelFromString(
+        program,
+        sender_src,
+        sender_core,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = {src_sem_id, dst_sem_id}});
+    CreateKernelFromString(
+        program,
+        receiver_src,
+        receiver_core,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = {dst_sem_id}});
+    CoreCoord rx_virtual = device->worker_core_from_logical_core(receiver_core);
+    SetRuntimeArgs(program, sender_kernel, sender_core, {rx_virtual.x, rx_virtual.y});
+
+    // Must NOT abort (and must not hang: the relay's value wakes the waiter).
+    detail::LaunchProgram(device, program);
+    SUCCEED();
+
+    ::unsetenv("TT_METAL_EMULE_ASAN");
+}
+
+// Guard: the semaphore-provenance exemption is REGION-BOUNDED, not a blanket
+// pass for anything derived from get_semaphore. A sem-derived address that
+// wanders out of the reserved region falls through to the full check chain and
+// must still die (here: Out-of-Bounds Write — well above the unreserved base,
+// inside no allocated tensor).
+TEST_F(MeshDeviceFixture, Semaphore_SemDerivedOutsideRegion_StillChecked) {
+    ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
+
+    auto* device = this->devices_.at(0)->get_devices()[0];
+    CoreCoord logical_core = {0, 0};
+    Program program = CreateProgram();
+    uint32_t sem_id = CreateSemaphore(program, logical_core, /*initial_value=*/0);
+    // Allocate a buffer so the live-tensor range set is armed (non-null).
+    auto buf = Buffer::create(device, 1024, 1024, BufferType::L1);
+
+    std::string kernel_src = R"(
+        #include "api/dataflow/dataflow_api.h"
+        void kernel_main() {
+            uint32_t sem_addr = get_semaphore(get_compile_time_arg_val(0));
+            volatile tt_l1_ptr uint32_t* p =
+                reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sem_addr + 0x100000);
+            *p = 1;
+        }
+    )";
+    CreateKernelFromString(
+        program,
+        kernel_src,
+        logical_core,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = {sem_id}});
+
+    EXPECT_DEATH(detail::LaunchProgram(device, program), ".*Out-of-Bounds Write.*");
+}
+
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/emulation/SANITIZER_CHECKS.md
+++ b/tt_metal/impl/emulation/SANITIZER_CHECKS.md
@@ -292,14 +292,27 @@ the actual (row-major / tiled face-aware) pad layout before the test is re-enabl
 **Lives in:** `__emule_asan_check_semaphore` in
 `[emule] include/jit_hw/asan/asan_l1_checks.h`; the reserved range is set by the runner
 (`[metal] emulated_program_runner.cpp`).
-**What it catches:** a kernel doing a raw scalar L1 access into the reserved
-semaphore region (semaphores must go through the semaphore API).
+**What it catches:** a kernel access that strays into the reserved semaphore
+region **without semaphore provenance** — a computed offset, an overrun from an
+adjacent region, or a raw address smuggled through a runtime arg.
 **How it works:** the runner passes the semaphore L1 range
 (`__emule_sem_l1_range_start/end`) to the kernel. It's the **first** test in
 `__emule_local_l1_to_ptr`: if the address is in that range, abort.
+Addresses that provably derive from `get_semaphore()` are exempt by
+provenance: the kernel patch pass's S1/S2 rules (`[emule]
+tt_emule/detail/kernel_patcher.hpp`) and the semaphore API's own local-source
+reads (`noc_semaphore_set_remote` / `_set_multicast*`, reached by
+`Semaphore::relay_unicast`/`relay_multicast`) translate via
+`__emule_sem_l1_to_ptr`, which skips only this check and only inside the
+region — raw access to your own semaphore word is legal on silicon (the mcast
+VALID/INVALID payload read, sdpa_decode's packed-nibble poll) and must not
+false-positive. A sem-derived address that leaves the region falls through to
+the full check chain.
 *Diagnostic:* `Illegal Semaphore Access: Offset 0x… is inside the reserved Semaphore region [start, end)`.
-*Exercised by:* `test_semaphore_write.cpp` (an in-region write death test + an
-outside-region positive control).
+*Exercised by:* `test_semaphore_write.cpp` (an in-region stray-write death test,
+an outside-region positive control, raw-`get_semaphore`-cast and
+`relay_unicast` no-violation controls, and a sem-derived-but-out-of-region
+death test guarding that the exemption stays region-bounded).
 
 ### 7. CB Boundary Violation
 **Lives in:** `__emule_asan_cb_resolve` in


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The Illegal-Semaphore check treated *any* access landing in the reserved semaphore region as a violation. That is too strict: reading or writing your own semaphore word through a raw `get_semaphore()` cast is legal on silicon, the region is plain L1, and real kernels do it (matmul `reader_bmm_tile_layout_in0_receiver.cpp`'s mcast VALID/INVALID payload read, sdpa_decode `writer_decode_all.cpp`'s packed-nibble poll). The check also fired on the sanctioned `Semaphore<>` API itself, whose `relay_unicast` reads the local semaphore word as its NOC source.

The check now exempts addresses with **semaphore provenance**, those that provably derive from `get_semaphore()` — and only inside the reserved region. Everything else in that region still aborts.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=smeydanshahiTT/sem-check-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:smeydanshahiTT/sem-check-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=smeydanshahiTT/sem-check-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:smeydanshahiTT/sem-check-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=smeydanshahiTT/sem-check-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:smeydanshahiTT/sem-check-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=smeydanshahiTT/sem-check-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:smeydanshahiTT/sem-check-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=smeydanshahiTT/sem-check-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:smeydanshahiTT/sem-check-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=smeydanshahiTT/sem-check-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:smeydanshahiTT/sem-check-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=smeydanshahiTT/sem-check-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:smeydanshahiTT/sem-check-fix)