### PR TITLE
Fix ring-joint SDPA split-forwarding synchronization

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -35,6 +35,7 @@ constexpr bool direction = get_compile_time_arg_val(9);  // 1 is forward, 0 is b
 constexpr bool fuse_op = get_compile_time_arg_val(10);
 constexpr bool has_metadata = get_compile_time_arg_val(11);
 constexpr uint32_t cb_meta_id = get_compile_time_arg_val(12);
+constexpr bool split_forwarding_enabled = get_compile_time_arg_val(13);
 
 // Prefetch: batch multiple packets of DRAM reads before a single barrier.
 // This keeps more reads in flight across interleaved DRAM banks, hiding latency.
@@ -42,7 +43,7 @@ constexpr uint32_t cb_meta_id = get_compile_time_arg_val(12);
 constexpr uint32_t PREFETCH_PACKETS = 4;
 
 void kernel_main() {
-    constexpr uint32_t page_size_base_idx = 13;
+    constexpr uint32_t page_size_base_idx = 14;
     constexpr auto inputs_args = make_tensor_accessor_args_tuple<num_inputs, page_size_base_idx + num_inputs>();
     constexpr auto outputs_args = make_tensor_accessor_args_tuple<
         num_inputs,
@@ -185,8 +186,7 @@ void kernel_main() {
         }
     }
 
-    // Mirror the writer's split-forwarding (see ring_attention_all_gather_writer.cpp): on an even ring the diametric
-    const bool split_forwarding_enabled = (topology == Topology::Ring) && (ring_size % 2 == 0) && (ring_size > 2);
+    // The parent fused op passes this gate so the all-gather and its consumer share one protocol decision.
     if (split_forwarding_enabled && direction == 1) {
         slices_expected++;
         writes_expected++;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
@@ -48,9 +48,10 @@ constexpr uint32_t unicast_route_arg1 = get_compile_time_arg_val(15);
 // metadata accessor is emitted.
 constexpr bool has_metadata = get_compile_time_arg_val(16);
 constexpr uint32_t cb_meta_id = get_compile_time_arg_val(17);
+constexpr bool split_forwarding_enabled = get_compile_time_arg_val(18);
 
 void kernel_main() {
-    constexpr uint32_t page_size_base_idx = 18;
+    constexpr uint32_t page_size_base_idx = 19;
     constexpr auto outputs_args = make_tensor_accessor_args_tuple<num_inputs, page_size_base_idx + num_inputs>();
     // Metadata accessor follows the output accessors (metadata path only); fall back to a valid (unused)
     // accessor offset when absent so TensorAccessorArgs<> never names a non-accessor compile arg.
@@ -294,8 +295,7 @@ void kernel_main() {
         }
     }
 
-    // On an even ring the terminal relayed slice
-    const bool split_forwarding_enabled = (topology == Topology::Ring) && (ring_size % 2 == 0) && (ring_size > 2);
+    // The parent fused op passes this gate so the all-gather and its consumer share one protocol decision.
     if (split_forwarding_enabled && direction == 1) {
         writes_expected++;
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -370,7 +370,8 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     std::optional<Tensor> kv_actual_isl,
     uint32_t chunk_local_tiles,
     uint32_t kv_cache_num_layers,
-    uint32_t kv_cache_layer_idx) {
+    uint32_t kv_cache_layer_idx,
+    bool split_forwarding_enabled) {
     using tt::tt_metal::CBDescriptor;
     using tt::tt_metal::CBFormatDescriptor;
     using tt::tt_metal::KernelDescriptor;
@@ -519,6 +520,8 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
 
     // Tensor Info
     const uint32_t num_inputs = input_tensor.size();
+    const bool effective_split_forwarding =
+        split_forwarding_enabled && topology == ttnn::ccl::Topology::Ring && ring_size % 2 == 0 && ring_size > 2;
     constexpr const char* exchange_writer_kernel_source =
         "ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/"
         "ring_attention_all_gather_writer.cpp";
@@ -548,6 +551,7 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         fuse_op,                          // fused op
         static_cast<uint32_t>(has_metadata),
         meta_cb_index,
+        static_cast<uint32_t>(effective_split_forwarding),
     };
     for (uint32_t i = 0; i < num_inputs; i++) {
         sender_reader_forward_kernel.compile_time_args.push_back(op_config.get_page_size());
@@ -591,6 +595,7 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         unicast_backward_args[1],                 // unicast route arg1 (dst_chip_id or distance_in_hops)
         static_cast<uint32_t>(has_metadata),
         meta_cb_index,
+        static_cast<uint32_t>(effective_split_forwarding),
     };
     for (uint32_t i = 0; i < num_inputs; i++) {
         sender_writer_forward_kernel.compile_time_args.push_back(op_config.get_page_size());
@@ -627,6 +632,7 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         fuse_op,                          // fused op
         static_cast<uint32_t>(has_metadata),
         meta_cb_index,
+        static_cast<uint32_t>(effective_split_forwarding),
     };
     for (uint32_t i = 0; i < num_inputs; i++) {
         sender_reader_backward_kernel.compile_time_args.push_back(op_config.get_page_size());
@@ -670,6 +676,7 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
         unicast_forward_args[1],                   // unicast route arg1 (dst_chip_id or distance_in_hops)
         static_cast<uint32_t>(has_metadata),
         meta_cb_index,
+        static_cast<uint32_t>(effective_split_forwarding),
     };
     for (uint32_t i = 0; i < num_inputs; i++) {
         sender_writer_backward_kernel.compile_time_args.push_back(op_config.get_page_size());

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
@@ -129,7 +129,10 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     // cache slot as slot * kv_cache_num_layers + kv_cache_layer_idx (slot = slot_id[0]), matching
     // update_padded_kv_cache. Defaults (1, 0) reduce to slot, so single-layer callers are unaffected.
     uint32_t kv_cache_num_layers = 1,
-    uint32_t kv_cache_layer_idx = 0);
+    uint32_t kv_cache_layer_idx = 0,
+    // The parent fused op owns this protocol decision. The helper still applies the legacy
+    // even-ring topology/size gate, so standalone callers retain their prior behavior.
+    bool split_forwarding_enabled = true);
 
 void ring_attention_neighbor_halo_exchange_helper(
     tt::tt_metal::ProgramDescriptor& desc,

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/ring_indexer_score_dsa_program_factory.cpp
@@ -481,7 +481,7 @@ ProgramDescriptor build_ring_program_descriptor(
     const uint32_t kv_len_tiles = pcache.kv_len_tiles;
 
     std::vector<uint32_t> fused_rt;
-    sdpa_sig.push_ring_sdpa_fused_op_rt_args(fused_rt);  // {ring_size, ring_index, fwd, bwd, sem0, sem1}
+    sdpa_sig.push_ring_sdpa_fused_op_rt_args(fused_rt);
 
     // ---- Step E: band-visit reorder (local-first, then remote by ring arrival) --------------------------
     // shard_order / band_readiness are computed above (hoisted so the band->column assignment can balance
@@ -626,7 +626,14 @@ ProgramDescriptor build_ring_program_descriptor(
             // (compute_cols_x,1), ...) instead of running off the right grid edge as row-major would.
             ttnn::ccl::CoreAllocationStrategy::COL_MAJOR,
             args.cache_batch_idx,
-            gather_valid_height_tiles(args, k_local));
+            gather_valid_height_tiles(args, k_local),
+            std::nullopt,
+            std::nullopt,
+            0,
+            1,
+            0,
+            // This fused consumer has no split-shard second-half wait.
+            false);
     }
 
     log_debug(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.cpp
@@ -73,6 +73,8 @@ void RingSDPAFusedOpSignaler::push_ring_sdpa_fused_op_rt_args(std::vector<uint32
     // Even-ring split-forwarding: the diametric shard S arrives split across both links
     const uint32_t split_shard_id =
         this->ring_size ? ((this->ring_index + this->backward_writes_expected + 1) % this->ring_size) : 0;
+    // The all-gather signals this semaphore only for remote slices. The diametric shard's second
+    // half is direction 1's final remote slice, so its signal count is backward_writes_expected + 1.
     const uint32_t split_second_half_wait = this->backward_writes_expected + 1;
     out_rt_args.push_back(static_cast<uint32_t>(this->split_forwarding_enabled ? 1 : 0));
     out_rt_args.push_back(static_cast<uint32_t>(split_shard_id));

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -897,6 +897,7 @@ ttsl::hash::hash_t RingJointSDPADeviceOperation::compute_program_hash(
         args.is_causal,
         args.is_balanced,
         args.is_cross,
+        args.sliding_window_size,
         cache_key_logical_n,
         args.logical_l,
         tensor_args.joint_is_sharded(),

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -1186,7 +1186,9 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
     sdpa_fused_op_signaler->split_forwarding_enabled =
         (args.all_gather_operation_attributes.topology == ttnn::ccl::Topology::Ring) &&
         (args.all_gather_operation_attributes.ring_size % 2 == 0) &&
-        (args.all_gather_operation_attributes.ring_size > 2);
+        // Latent-V uses the single-payload gather layout, which remains on the established unsplit
+        // consumer protocol. Sliding routes through the neighbor-halo exchange rather than this all-gather.
+        (args.all_gather_operation_attributes.ring_size > 2) && !v_shares_k_buffer && !has_sliding_window;
 
     log_debug(tt::LogOp, "num_cores: {}", num_cores);
     log_debug(
@@ -2864,7 +2866,8 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
             // (user, layer)-major KV-cache batch factor: the all-gather reader computes the gathered slot as
             // slot_id[0] * kv_cache_num_layers + kv_cache_layer_idx. Defaults (1, 0) keep callers unaffected.
             args.kv_cache_num_layers,
-            args.kv_cache_layer_idx);
+            args.kv_cache_layer_idx,
+            sdpa_fused_op_signaler->split_forwarding_enabled);
     }
 
     return desc;


### PR DESCRIPTION
## Summary

Fixes the even-ring split-forwarding synchronization introduced by PR #52730 (`c080ab0cfc94`, Ring joint SDPA and the LTX-2.3 distilled AV pipeline).

The feature splits the diametric KV shard across both fabric links so ring-joint SDPA can overlap communication and compute. The fused receiver waited for `backward_writes_expected + 1` direction-1 signals, but that semaphore includes an initial local-write signal. This released the diametric shard one remote arrival early, allowing SDPA to consume it while its second half was still being written.

This change waits for `backward_writes_expected + 2`, then makes the split-forwarding decision a single host-derived compile-time protocol flag shared by the ring-joint receiver and both all-gather directions. It keeps latent-V, sliding-window, and indexer-score paths on their established unsplit protocols, preserves legacy standalone all-gather gating, and keys sliding-window configuration in the program cache.

## CI failures

The regression first appeared after `c080ab0cfc94` in scheduled Blackhole sanity runs. The representative failure was [run 31699848471, job 94452565434](https://github.com/tenstorrent/tt-metal/actions/runs/31699848471/job/94452565434):

- `test_ring_joint_attention_chunked_nd_sharded_indexed_kv_cache_accuracy[bf16_acc]`
- `test_ring_joint_attention_chunked_nd_sharded_indexed_kv_cache_accuracy[fp32_acc]`

Both failed on the first chunk with PCC around 0.979 in CI. The same split protocol could deadlock latent-V cache replay in `test_ring_mla_chunked_kv_actual_isl_indexed_reuse_max_accuracy_and_determinism`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-split-forwarding)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-split-forwarding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-split-forwarding)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-split-forwarding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-split-forwarding)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-split-forwarding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-split-forwarding)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-split-forwarding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-split-forwarding)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-split-forwarding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-split-forwarding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-split-forwarding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-split-forwarding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-split-forwarding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-ring-joint-sdpa-split-forwarding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-ring-joint-sdpa-split-forwarding)