### PR TITLE
third_party: upgrade nanobind pin 2.12.0 -> 2.14.0

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -228,7 +228,15 @@ CPMAddPackage(
 # target already in scope, nanobind skips its own find_package(Python) call and fails when
 # nanobind-config.cmake asserts that Python::Module also exists. Find both components explicitly
 # here so nanobind sees a complete target set.
-find_package(Python REQUIRED COMPONENTS Interpreter Development.Module OPTIONAL_COMPONENTS Development.SABIModule)
+find_package(
+    Python
+    REQUIRED
+    COMPONENTS
+        Interpreter
+        Development.Module
+    OPTIONAL_COMPONENTS
+        Development.SABIModule
+)
 
 CPMAddPackage(
     NAME nanobind

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -228,7 +228,7 @@ CPMAddPackage(
 # target already in scope, nanobind skips its own find_package(Python) call and fails when
 # nanobind-config.cmake asserts that Python::Module also exists. Find both components explicitly
 # here so nanobind sees a complete target set.
-find_package(Python 3.9 REQUIRED COMPONENTS Interpreter Development.Module OPTIONAL_COMPONENTS Development.SABIModule)
+find_package(Python REQUIRED COMPONENTS Interpreter Development.Module OPTIONAL_COMPONENTS Development.SABIModule)
 
 CPMAddPackage(
     NAME nanobind

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -221,6 +221,15 @@ CPMAddPackage(
 # nanobind : https://github.com/wjakob/nanobind
 ############################################################################################################################
 
+# GTest's own CMake (googletest/cmake/internal_utils.cmake) already calls
+# find_package(Python COMPONENTS Interpreter), which defines a Python::Interpreter target but no
+# Python::Module target. nanobind >= 2.13 only self-detects Python when *both* Python::Interpreter
+# and Python::Module are missing (previously: *either*), so with a partial Python::Interpreter
+# target already in scope, nanobind skips its own find_package(Python) call and fails when
+# nanobind-config.cmake asserts that Python::Module also exists. Find both components explicitly
+# here so nanobind sees a complete target set.
+find_package(Python 3.9 REQUIRED COMPONENTS Interpreter Development.Module OPTIONAL_COMPONENTS Development.SABIModule)
+
 CPMAddPackage(
     NAME nanobind
     GITHUB_REPOSITORY wjakob/nanobind

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -225,7 +225,7 @@ CPMAddPackage(
     NAME nanobind
     GITHUB_REPOSITORY wjakob/nanobind
     GIT_TAG
-        2a61ad2494d09fecb2e13322c1383342c299900d # 2.12.0
+        86e5626728fc282637a6c338597120913dded1bb # 2.14.0
     OPTIONS
         "CMAKE_MESSAGE_LOG_LEVEL NOTICE"
         "NB_USE_SUBMODULE_DEPS ON"

--- a/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
+++ b/ttnn/cpp/ttnn-nanobind/program_descriptors.cpp
@@ -720,11 +720,22 @@ void py_module_types(nb::module_& mod) {
                tt::tt_metal::KernelDescriptor::CompileTimeArgs compile_time_args,
                tt::tt_metal::KernelDescriptor::NamedCompileTimeArgs named_compile_time_args,
                tt::tt_metal::KernelDescriptor::Defines defines,
-               tt::tt_metal::KernelDescriptor::RuntimeArgs runtime_args,
+               const nb::object& runtime_args,
                tt::tt_metal::KernelDescriptor::CommonRuntimeArgs common_runtime_args,
                std::optional<tt::tt_metal::KernelBuildOptLevel> opt_level,
                tt::tt_metal::KernelDescriptor::ConfigDescriptor config,
                tt::tt_metal::KernelDescriptor::IncludePaths compiler_include_paths) {
+                // Accept RuntimeArgsWrapper, RuntimeArgsView, or the raw RuntimeArgs type, mirroring
+                // the .runtime_args property setter rather than relying on the generic sequence
+                // caster falling back to the wrapper's __iter__.
+                tt::tt_metal::KernelDescriptor::RuntimeArgs runtime_args_cpp;
+                if (nb::isinstance<RuntimeArgsWrapper>(runtime_args)) {
+                    runtime_args_cpp = nb::cast<RuntimeArgsWrapper&>(runtime_args).get();
+                } else if (nb::isinstance<RuntimeArgsView>(runtime_args)) {
+                    runtime_args_cpp = nb::cast<RuntimeArgsView&>(runtime_args).get_ref();
+                } else {
+                    runtime_args_cpp = nb::cast<tt::tt_metal::KernelDescriptor::RuntimeArgs>(runtime_args);
+                }
                 new (self) tt::tt_metal::KernelDescriptor{
                     kernel_source,
                     source_type,
@@ -732,7 +743,7 @@ void py_module_types(nb::module_& mod) {
                     std::move(compile_time_args),
                     std::move(named_compile_time_args),
                     std::move(defines),
-                    std::move(runtime_args),
+                    std::move(runtime_args_cpp),
                     std::move(common_runtime_args),
                     ////////////////////////////////////////////////////////////
                     // Blaze-only experimental named args


### PR DESCRIPTION
## Summary

Upgrade the `nanobind` third-party pin in `third_party/CMakeLists.txt`. Also fixed casting issue that came up testing the new version in ttnn/cpp/ttnn-nanobind/program_descriptors.cpp.

| | Version | Commit |
|---|---|---|
| Before | 2.12.0 | `2a61ad2494d09fecb2e13322c1383342c299900d` |
| After | 2.14.0 | `86e5626728fc282637a6c338597120913dded1bb` |

Source repo: https://github.com/wjakob/nanobind

Tracked by [MINFRA-1566](https://tenstorrent.atlassian.net/browse/MINFRA-1566).

## Changelog (2.12.0 → 2.14.0)

Summarized from [nanobind's changelog](https://github.com/wjakob/nanobind/blob/master/docs/changelog.rst).

### 2.14.0 (Aug 7, 2026)

- Implicit conversion to integer-typed arguments now requires the input implement `__index__`; previously `float`-like types (e.g. `np.float32`) and numeric strings were incorrectly accepted/truncated. Bugfix, but observable from Python.
- STL set/map/enum casters now check convertibility up front instead of raising-and-discarding a Python exception on the overload-resolution hot path.
- Fixed reference leaks: nanobind's internal type objects were never deallocated, and the `typing.py` leak workaround is now active on all CPython versions (previously only < 3.12).
- Stubgen: read-only static properties now annotate as `Final[T]`, read-write as `ClassVar[T]` (the old `ClassVar[Final[T]]` combo is rejected by type checkers). Overriding a read-only static property in a subclass now works.

### 2.13.0 (Jun 18, 2026)

Performance-focused release: **1.42×–3.2× faster object construction, 1.2×–1.5× faster function dispatch, up to 2.4× faster ndarray exchange**, plus hardening against a large batch of AI-assisted-audit findings and free-threading race fixes.

- **Performance**
  - New `nb::pooled()` class annotation — per-type instance pooling for short-lived objects
  - New "medium" function dispatcher for functions with named/default args (no `*args`/`**kwargs`, ≤8 args) — ~32% faster positional calls 
  - Fast path for simple two-argument calls (binary operators, copy ctors) 
  - General call/construction critical-path tuning: 6.2%–16.4% faster 
  - `nb::ndarray` import/export optimization: ~58% faster returns, ~21% faster consumption; `__dlpack__()` kwarg parsing ~8% faster
  - Faster non-ndarray argument rejection during overload resolution 
  - Reduced free-threaded TLS access overhead (2.8% → 0.3% of a call microbenchmark) 
  - New specialized `nb::dict` accessor for faster read/write/delete.
  - Free-threaded builds skip refcounting on known-immortal type/enum/function objects 
  - `nb::supplement<T>` moved outside the Python type object, speeding up nanobind-type checks
  - Linear (was quadratic) `repr()` for `bind_vector`/`bind_map` containers.
  - Pre-interned strings for hot-path attribute access (`__name__`, `__new__`, etc.).
  - Stack protector disabled for `libnanobind` release builds (already true for extensions) and on MSVC
- **Safety audit hardening** : fixed numerous crashes/UB (static property deletion, `self`-as-kwarg, `nb::eval`/`nb::exec` default scope, enum out-of-range construction, etc.), several use-after-free/dangling-reference bugs in type casters (`pair`/`tuple`, `set`, `shared_ptr`, `bind_vector`/`bind_map` self-aliasing), memory leaks (STL container ctor failures, method reference cycles not tracked by GC), and free-threading data races (`nb::list` iteration, accessor caching, exception-translator registration, `shared_ptr`'s `enable_shared_from_this` path, trampoline critical sections). Also fixes to the `ndarray` exporter (`copy`/`dl_device` handling, buffer-protocol flags, ownerless-array export safety) and Eigen casters (sparse matrix copy/abort, stride handling).
- **Stub generation**: dedup repeated overload docstrings, correct `classmethod`/`staticmethod` recognition, static properties wrapped in `ClassVar`/`Final`, `typing_extensions` `from`-imports, nested-type name resolution fixes, pattern-application counter fix, new `\import` pattern directive.
- `nb::init<...>` now uses direct- instead of list-initialization, avoiding spurious selection of an `initializer_list` constructor over the intended overload 
- Added `nb::DRef1`/`nb::DMap1` Eigen `Ref`/`Map` variants with compile-time unit inner stride for better auto-vectorization 
- `nb::ndarray` can now export to Apple's MLX array framework via `nb::mlx`
- ABI version bumped to 20.

- [x] Sanity https://github.com/tenstorrent/tt-metal/actions/runs/31718987892/job/94534318338

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsexton/0-upgrade-nanobind)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsexton/0-upgrade-nanobind)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsexton/0-upgrade-nanobind)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsexton/0-upgrade-nanobind)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nsexton/0-upgrade-nanobind)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nsexton/0-upgrade-nanobind)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsexton/0-upgrade-nanobind)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsexton/0-upgrade-nanobind)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsexton/0-upgrade-nanobind)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsexton/0-upgrade-nanobind)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsexton/0-upgrade-nanobind)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsexton/0-upgrade-nanobind)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsexton/0-upgrade-nanobind)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsexton/0-upgrade-nanobind)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsexton/0-upgrade-nanobind)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsexton/0-upgrade-nanobind)