### PR TITLE
[Performance] Qwen3.6-27B: Added bucketing fix and TP=8 support

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -748,6 +748,8 @@ jobs:
           # decode trace) still returns deterministic, well-formed-but-garbage
           # tokens, so those checks pass while the model emits gibberish. Requiring
           # a verbatim echo of a simple sentence catches that class of bug directly.
+          # Thinking off per-request and a budget that fits it anyway: a <think> preamble
+          # would eat the tokens and fail the grep for reasons unrelated to coherence.
           SENTENCE="The quick brown fox jumps over the lazy dog."
           curl http://localhost:8000/v1/chat/completions \
             -H "Content-Type: application/json" \
@@ -760,7 +762,8 @@ jobs:
                   \"content\": \"Repeat the following sentence exactly, with no extra words, no quotes, and no commentary: $SENTENCE\"
                 }
               ],
-              \"max_tokens\": 32,
+              \"chat_template_kwargs\": {\"enable_thinking\": false},
+              \"max_tokens\": 512,
               \"temperature\": 0.0,
               \"stream\": false,
               \"ignore_eos\": false

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -23,6 +23,19 @@ DEVICE_SEED_MAX = 1_000_000
 _UINT64_MASK = (1 << 64) - 1
 
 
+def _mark_trace_buffers_corruptible(bucket, value):
+    """Acknowledge bucketed trace I/O that another live trace may overwrite."""
+    if bucket is None or value is None:
+        return
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            _mark_trace_buffers_corruptible(bucket, item)
+        return
+    mark_corruptible = getattr(ttnn, "mark_corruptible", None)
+    if mark_corruptible is not None:
+        mark_corruptible(value)
+
+
 def _hash_request_seed_to_device_seed(seed: int, counter: int) -> int:
     """Derive a stable per-token device seed from a request seed.
 
@@ -68,6 +81,7 @@ class _TraceKey:
     penalties_on: bool
     log_probs_on: bool
     force_argmax: bool
+    bucket: int | None = None
 
 
 class SamplingGenerator:
@@ -105,6 +119,7 @@ class SamplingGenerator:
         self._penalties_active = False
 
         self._trace_states: dict[_TraceKey, dict] = {}
+        self._active_trace_bucket = None
         seed_batch_size = self.tt_sampling.max_batch_size * self.tt_sampling._sampling_dp
         self.seed_manager = SeedManager(
             self.tt_sampling,
@@ -114,8 +129,19 @@ class SamplingGenerator:
     def _new_trace_state(self):
         return {"id": None, "input": None, "output": None, "kwargs": {}}
 
+    def set_trace_bucket(self, bucket: int | None):
+        """Select the trace namespace for subsequent capture/replay. Callers that multiplex the
+        decode-output logits tensor per batch width (decode bucketing) set this to the width, so a
+        sampling trace captured at width B is only ever replayed against width-B logits."""
+        self._active_trace_bucket = bucket
+
     def _trace_slot(self, penalties_on: bool, log_probs_on: bool, force_argmax: bool):
-        key = _TraceKey(penalties_on=penalties_on, log_probs_on=log_probs_on, force_argmax=force_argmax)
+        key = _TraceKey(
+            penalties_on=penalties_on,
+            log_probs_on=log_probs_on,
+            force_argmax=force_argmax,
+            bucket=self._active_trace_bucket,
+        )
         slot = self._trace_states.get(key)
         if slot is None:
             slot = self._new_trace_state()
@@ -124,13 +150,13 @@ class SamplingGenerator:
 
     def reset_trace(self):
         """
-        Drop any cached trace metadata for both penalties/no-penalties and log-probs/no-log-probs paths.
+        Drop any cached trace metadata for all sampling configurations and bucket widths.
         """
         for key, slot in self._trace_states.items():
             if slot["id"] is None:
                 continue
             logger.debug(
-                f"Resetting sampling trace (penalties={key.penalties_on}, log_probs={key.log_probs_on}, force_argmax={key.force_argmax}, trace_id={slot['id']})"
+                f"Resetting sampling trace (bucket={key.bucket}, penalties={key.penalties_on}, log_probs={key.log_probs_on}, force_argmax={key.force_argmax}, trace_id={slot['id']})"
             )
             try:
                 ttnn.release_trace(self.mesh_device, slot["id"])
@@ -334,6 +360,7 @@ class SamplingGenerator:
         slot["input"] = logits
         slot["output"] = output
         slot["kwargs"] = {"tt_out_tok": tt_out_tok}
+        _mark_trace_buffers_corruptible(self._active_trace_bucket, (logits, output))
 
         return slot["output"]
 

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -10,13 +10,50 @@ import torch.nn.functional as F
 import ttnn
 from models.common.sampling import (
     LogProbsCalculator,
+    SamplingGenerator,
     SamplingParams,
     SeedManager,
     broadcast_sampling_params,
     format_sampling_params,
 )
+from models.common.sampling.generator import _mark_trace_buffers_corruptible
 from models.common.sampling.tt_log_probs import MAX_TOP_LOGPROBS, LogProbsResult
 from models.common.utility_functions import comp_pcc
+
+
+def test_sampling_trace_buffer_reuse_is_bucket_only(monkeypatch):
+    marked = []
+    monkeypatch.setattr(ttnn, "mark_corruptible", marked.append, raising=False)
+
+    _mark_trace_buffers_corruptible(None, ["default"])
+    _mark_trace_buffers_corruptible(1, ["input", None, ("output",)])
+
+    assert marked == ["input", "output"]
+
+
+def test_sampling_trace_bucket_isolation():
+    """Default users keep one flat namespace; Qwen bucket widths get distinct slots."""
+    sampling = SamplingGenerator.__new__(SamplingGenerator)
+    sampling._trace_states = {}
+    sampling._active_trace_bucket = None
+
+    default_key, default_slot = sampling._trace_slot(False, False, True)
+    assert default_key.bucket is None
+    assert sampling._trace_slot(False, False, True)[1] is default_slot
+
+    sampling.set_trace_bucket(1)
+    width1_key, width1_slot = sampling._trace_slot(False, False, True)
+    sampling.set_trace_bucket(8)
+    width8_key, width8_slot = sampling._trace_slot(False, False, True)
+
+    assert width1_key.bucket == 1 and width8_key.bucket == 8
+    assert width1_slot is not default_slot
+    assert width8_slot is not default_slot
+    assert width8_slot is not width1_slot
+
+    sampling.set_trace_bucket(None)
+    assert sampling._trace_slot(False, False, True)[1] is default_slot
+    assert len(sampling._trace_states) == 3
 
 
 # ---------------------------------------------------------------------------

--- a/models/common/warmup/warmup_utils.py
+++ b/models/common/warmup/warmup_utils.py
@@ -103,6 +103,7 @@ class WarmupForwardMixin:
         can_sample_on_device,
         read_from_device=True,
         greedy_only: bool = False,
+        skip_trace_precompile: bool = False,
     ):
         """
         This function is called by vLLM
@@ -118,7 +119,7 @@ class WarmupForwardMixin:
 
         for param in sampling_params:
             logger.info(f"Warming up decode for sampling params: {param}")
-            self.decode_forward(
+            decode_kwargs = dict(
                 tokens=tokens,
                 start_pos=start_pos,
                 page_table=page_table,
@@ -127,5 +128,8 @@ class WarmupForwardMixin:
                 read_from_device=read_from_device,
                 sampling_params=param,
             )
+            if skip_trace_precompile:
+                decode_kwargs["skip_trace_precompile"] = True
+            self.decode_forward(**decode_kwargs)
 
         logger.info("Decode warmup completed")

--- a/models/demos/blackhole/qwen36/README.md
+++ b/models/demos/blackhole/qwen36/README.md
@@ -1,14 +1,14 @@
 # Qwen3.5 / Qwen3.6 on Blackhole
 
 This directory implements Tenstorrent Blackhole inference for the hybrid
-**Gated DeltaNet + Gated Full Attention** Qwen3.5/3.6 family. Despite the
-`qwen3_5_9b` directory name, the same code path serves three checkpoints:
+**Gated DeltaNet + Gated Full Attention** Qwen3.5/3.6 family. The same code path serves three checkpoints:
 
 | Model            | `HF_MODEL`             | Mesh / `MESH_DEVICE` | Parallelism            |
 | ---------------- | ---------------------- | -------------------- | ---------------------- |
 | Qwen3.5-9B       | `Qwen/Qwen3.5-9B`      | single P150 — `P150` | single device          |
 | Qwen3.5-27B      | `Qwen/Qwen3.5-27B`     | P150x4 — `P150x4`    | 4-way tensor parallel  |
 | Qwen3.6-27B      | `Qwen/Qwen3.6-27B`     | P150x4 — `P150x4`    | 4-way tensor parallel  |
+| Qwen3.6-27B      | `Qwen/Qwen3.6-27B`     | P150x8 — `P150x8`    | 8-way tensor parallel  |
 
 - The **9B** runs on a **single Blackhole P150** device. It uses the validated
   single-device forward path (no collectives).
@@ -16,6 +16,13 @@ This directory implements Tenstorrent Blackhole inference for the hybrid
   (a `(1, 4)` Blackhole mesh) using **4-way tensor parallelism (TP)**. The TP
   path needs `FABRIC_1D` for the cross-device collectives (all-reduce /
   reduce-scatter) and a trace region for the captured chunk-outer prefill trace.
+- **Qwen3.6-27B additionally runs at TP=8** on a `(1, 8)` mesh (`P150x8`).
+  Because it has only **4 KV heads**, TP=8 cannot give each device its own head:
+  each head is instead **replicated across the device pair holding its GQA query
+  group** (devices 0-1 share KV head 0, 2-3 head 1, and so on), so
+  `n_local_kv_heads` is 1 at both TP=4 and TP=8 and the whole runtime KV path is
+  unchanged. See `tp_common.replicate_kv_weight` and
+  `ModelArgs.SUPPORTS_KV_REPLICATION`.
 
 Everything model-specific (hybrid layer dispatch, DeltaNet head/conv dims,
 partial rotary factor, vocab, layer count) is read from the parsed HF config, so
@@ -59,7 +66,8 @@ export MESH_DEVICE=P150x4
 
 `HF_MODEL` is the single source of truth for the checkpoint — it may be a Hugging
 Face hub id (resolved via `snapshot_download`) or a local checkpoint directory.
-`MESH_DEVICE` selects the mesh shape (`P150` → `(1,1)`, `P150x4` → `(1,4)`).
+`MESH_DEVICE` selects the mesh shape (`P150` → `(1,1)`, `P150x4` → `(1,4)`,
+`P150x8` → `(1,8)`).
 
 Optional flags:
 
@@ -88,14 +96,14 @@ Run the preferred traced cases (the env vars above must already be exported):
 
 ```bash
 # All traced ISLs
-pytest models/demos/blackhole/qwen3_5_9b/demo/text_demo.py -v -s -k "traced"
+pytest models/demos/blackhole/qwen36/demo/text_demo.py -v -s -k "traced"
 
 # A single ISL, e.g. the short 128-token traced case
-pytest models/demos/blackhole/qwen3_5_9b/demo/text_demo.py -v -s -k "traced_128"
+pytest models/demos/blackhole/qwen36/demo/text_demo.py -v -s -k "traced_128"
 
 # Medium / long traced ISLs
-pytest models/demos/blackhole/qwen3_5_9b/demo/text_demo.py -v -s -k "traced_4k"
-pytest models/demos/blackhole/qwen3_5_9b/demo/text_demo.py -v -s -k "traced_64k"
+pytest models/demos/blackhole/qwen36/demo/text_demo.py -v -s -k "traced_4k"
+pytest models/demos/blackhole/qwen36/demo/text_demo.py -v -s -k "traced_64k"
 ```
 
 The **same command works for both 9B and 27B** — only the exported `HF_MODEL` /
@@ -142,9 +150,9 @@ per-test thresholds.
 Run the 9B unit suite (with `HF_MODEL=Qwen/Qwen3.5-9B`, `MESH_DEVICE=P150`):
 
 ```bash
-pytest models/demos/blackhole/qwen3_5_9b/tests/unit/ -v -s
-pytest models/demos/blackhole/qwen3_5_9b/tests/test_prefill.py -v -s
-pytest models/demos/blackhole/qwen3_5_9b/tests/test_weight_mapping.py -v -s
+pytest models/demos/blackhole/qwen36/tests/unit/ -v -s
+pytest models/demos/blackhole/qwen36/tests/test_prefill.py -v -s
+pytest models/demos/blackhole/qwen36/tests/test_weight_mapping.py -v -s
 ```
 
 > `test_prefill.py` auto-skips cases longer than `--max-prefill` (default 8192).
@@ -169,11 +177,11 @@ Run the 27B TP suite (with `HF_MODEL=Qwen/Qwen3.6-27B` or `Qwen/Qwen3.5-27B`,
 `MESH_DEVICE=P150x4`):
 
 ```bash
-pytest models/demos/blackhole/qwen3_5_9b/tests/test_mlp_tp.py -v -s
-pytest models/demos/blackhole/qwen3_5_9b/tests/test_attention_tp.py -v -s
-pytest models/demos/blackhole/qwen3_5_9b/tests/test_gdn_tp.py -v -s
-pytest models/demos/blackhole/qwen3_5_9b/tests/test_model_tp.py -svq
-pytest models/demos/blackhole/qwen3_5_9b/tests/test_generate_tp.py -v -s
+pytest models/demos/blackhole/qwen36/tests/test_mlp_tp.py -v -s
+pytest models/demos/blackhole/qwen36/tests/test_attention_tp.py -v -s
+pytest models/demos/blackhole/qwen36/tests/test_gdn_tp.py -v -s
+pytest models/demos/blackhole/qwen36/tests/test_model_tp.py -svq
+pytest models/demos/blackhole/qwen36/tests/test_generate_tp.py -v -s
 ```
 
 > `test_substate.py` and `test_weight_mapping.py` are pure-CPU and need no device.

--- a/models/demos/blackhole/qwen36/demo/text_demo.py
+++ b/models/demos/blackhole/qwen36/demo/text_demo.py
@@ -38,7 +38,7 @@ from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.tt_transformers.tt.generator import Generator
 from models.tt_transformers.tt.model_config import determine_device_name
 
-_MESH_SHAPE = {"P150": (1, 1), "P150x4": (1, 4)}.get(os.environ.get("MESH_DEVICE"), (1, 4))
+_MESH_SHAPE = {"P150": (1, 1), "P150x4": (1, 4), "P150x8": (1, 8)}.get(os.environ.get("MESH_DEVICE"), (1, 4))
 _MULTI = _MESH_SHAPE != (1, 1)
 _TP_TRACE_REGION_SIZE = 1024 * 1024 * 1024
 DEVICE_PARAMS = [
@@ -242,7 +242,7 @@ def test_demo_text(
 
     device = mesh_device
     if batch > 1 and not _MULTI:
-        pytest.skip("batched decode is the TP (multi-device) path; run with MESH_DEVICE=P150x4")
+        pytest.skip("batched decode is the TP (multi-device) path; run with MESH_DEVICE=P150x4 or P150x8")
     device.enable_program_cache()
     # Block budget → max_seq_len, KV cache, and RoPE table
     num_blocks = _blocks_for(seqlen, max_generated_tokens)

--- a/models/demos/blackhole/qwen36/tests/test_attention_tp.py
+++ b/models/demos/blackhole/qwen36/tests/test_attention_tp.py
@@ -411,6 +411,10 @@ def test_attention_tp_qknorm_offset(mesh_device):
     class _Args:
         n_local_heads = NH // nd
         n_local_kv_heads = max(1, NKV // nd)
+        # Global KV-head count + device count: the loader needs both to replicate K/V when
+        # TP > n_kv_heads (tp_common.replicate_kv_weight); a no-op at TP <= n_kv_heads.
+        n_kv_heads = NKV
+        num_devices = nd
         head_dim = HD
         rope_head_dim = 64
         max_batch_size = 1

--- a/models/demos/blackhole/qwen36/tests/test_decode_bucketing.py
+++ b/models/demos/blackhole/qwen36/tests/test_decode_bucketing.py
@@ -1,0 +1,913 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Verification for the qwen36 decode-batch bucketing fix (branch atupe/qwen36-bucketing-fix).
+
+1. ``test_bucket_selection`` (no device): bucket-picking arithmetic for padded vLLM batches.
+2. ``test_bucketed_decode_matches_full_width`` (device): width-B matches full-width rows.
+3. ``test_decode_width_scaling_traced`` (device): traced step time vs decode width.
+"""
+
+import os
+import statistics
+import time
+from types import SimpleNamespace
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import comp_pcc
+from models.demos.blackhole.qwen36.tests.test_factory import parametrize_mesh_tp
+from models.demos.blackhole.qwen36.tt.model import Qwen36Model
+
+N_LAYERS = 8
+
+BLOCK = 64
+# ISL under test. Override with QWEN36_BUCKET_TEST_CTX to compare against a server run at a
+# different ISL (the benchmark sweep was trimmed to 4096).
+CTX = int(os.environ.get("QWEN36_BUCKET_TEST_CTX", "8192"))
+BPU = CTX // BLOCK  # blocks per user
+
+
+def _pick_bucket(tokens, start_pos, width):
+    """Bucket arithmetic lifted verbatim from qwen36_vllm.decode_forward (the code under test)."""
+    num_active = int((start_pos != -1).sum()) if start_pos is not None else width
+    num_active = max(1, min(num_active, width))
+    return min(width, 1 << max(0, (num_active - 1).bit_length()))
+
+
+def _padded_decode_batch(num_active, width):
+    """Reproduce what tt_model_runner.py:907-926 hands to decode_forward."""
+    tokens = torch.cat(
+        [
+            torch.randint(1, 1000, (num_active, 1), dtype=torch.int32),
+            torch.zeros(width - num_active, 1, dtype=torch.int32),
+        ]
+    )
+    positions = torch.cat(
+        [torch.full((num_active,), 4096, dtype=torch.int32), torch.ones(width - num_active, dtype=torch.int32) * -1]
+    )
+    return tokens, positions
+
+
+def test_bucket_selection():
+    """The runner pads to max_num_seqs and marks pad rows with position -1."""
+    for width in (8, 32):
+        for num_active in range(1, width + 1):
+            tokens, positions = _padded_decode_batch(num_active, width)
+            got = _pick_bucket(tokens, positions, width)
+            expect = min(width, 1 << max(0, (num_active - 1).bit_length()))
+            assert got == expect, f"width={width} active={num_active}: bucket {got} != {expect}"
+            assert got >= num_active, f"bucket {got} drops active rows (active={num_active})"
+    # The case this whole exercise is about.
+    tokens, positions = _padded_decode_batch(1, 8)
+    assert _pick_bucket(tokens, positions, 8) == 1
+    logger.info("PASSED: bucket selection picks smallest pow2 >= num_active and never drops active rows")
+
+
+def test_unsupported_device_sampling_fails_at_startup(expect_error):
+    from models.demos.blackhole.qwen36.tt.qwen36_vllm import Qwen36ForCausalLM
+
+    model = SimpleNamespace(
+        sampling=None,
+        mesh_device=SimpleNamespace(shape=(1, 1)),
+        num_devices=1,
+        args=SimpleNamespace(vocab_size=248320),
+    )
+    wrapper = SimpleNamespace(model=[model])
+
+    Qwen36ForCausalLM._validate_device_sampling_request(wrapper, False)
+    with expect_error(RuntimeError, "requires a certified TP topology"):
+        Qwen36ForCausalLM._validate_device_sampling_request(wrapper, True)
+
+
+def test_trace_buffer_reuse_is_opt_in(monkeypatch):
+    from models.tt_transformers.tt.generator import _mark_trace_buffers_corruptible
+
+    marked = []
+    monkeypatch.setattr(ttnn, "mark_corruptible", marked.append, raising=False)
+    _mark_trace_buffers_corruptible(SimpleNamespace(), ["default"])
+    _mark_trace_buffers_corruptible(
+        SimpleNamespace(_tt_allow_decode_trace_buffer_reuse=True),
+        ["input", None, ("output",)],
+    )
+    assert marked == ["input", "output"]
+
+
+def test_bucket_warmup_compiles_all_widths_before_capture(monkeypatch):
+    from models.demos.blackhole.qwen36.tt.generator_interface import warmup_decode_buckets
+
+    calls = []
+
+    def record_warmup(*args, **kwargs):
+        calls.append(
+            (
+                kwargs["max_batch_size"],
+                kwargs["enable_trace"],
+                kwargs.get("skip_trace_precompile", False),
+            )
+        )
+
+    monkeypatch.setattr(ttnn, "synchronize_device", lambda *_: None)
+    monkeypatch.setenv("TT_DECODE_BUCKETING", "1")
+    generator = SimpleNamespace(mesh_device=object())
+
+    warmup_decode_buckets(
+        generator,
+        record_warmup,
+        kv_cache=None,
+        enable_trace=False,
+        max_batch_size=8,
+        num_blocks=1,
+        can_sample_on_device=True,
+    )
+    warmup_decode_buckets(
+        generator,
+        record_warmup,
+        kv_cache=None,
+        enable_trace=True,
+        max_batch_size=8,
+        num_blocks=1,
+        can_sample_on_device=True,
+    )
+
+    assert calls == [
+        (1, False, False),
+        (2, False, False),
+        (4, False, False),
+        (8, False, False),
+        (1, True, True),
+        (2, True, True),
+        (4, True, True),
+        (8, True, True),
+    ]
+
+
+def test_bucket_trace_teardown_releases_all_stores(monkeypatch):
+    from models.tt_transformers.tt.generator import Generator
+
+    released = []
+    sampling_resets = []
+    monkeypatch.setattr(ttnn, "release_trace", lambda device, trace_id: released.append((device, trace_id)))
+
+    sampling = SimpleNamespace(reset_trace=lambda: sampling_resets.append(True))
+    generator = object.__new__(Generator)
+    generator.model = [SimpleNamespace(sampling=sampling)]
+    generator.model_args = [SimpleNamespace(mesh_device="mesh")]
+    generator.mesh_device = "mesh"
+    generator.data_parallel = 1
+    width1 = ({True: {0: 11}}, {}, {})
+    width8 = ({True: {0: 88}}, {}, {})
+    generator._bucket_trace_store = {1: width1, 8: width8}
+    generator.trace_ids_decode = width8[0]
+
+    generator.__del__()
+
+    assert sampling_resets == [True]
+    assert released == [("mesh", 11), ("mesh", 88)]
+
+    generator._bucket_trace_store = {}
+    generator.trace_ids_decode = {}
+    generator.model = []
+    del generator
+
+
+@pytest.mark.parametrize("width", [1, 2, 4, 8])
+def test_bucketed_host_logits_are_padded_to_serving_width(monkeypatch, width):
+    """Host sampling must keep one complete vocabulary vector per active row."""
+    serving_width, vocab = 8, 16
+    device_logits = torch.arange(width * vocab, dtype=torch.float32).reshape(1, 1, width, vocab)
+    opaque = object()
+    monkeypatch.setattr(ttnn, "get_device_tensors", lambda tensor: [device_logits])
+    monkeypatch.setattr(ttnn, "to_torch", lambda tensor: tensor)
+    model = SimpleNamespace(num_devices=4, args=SimpleNamespace(vocab_size=vocab))
+
+    got = Qwen36Model.process_output_decode(model, opaque, serving_width, S=1)
+
+    assert got.shape == (serving_width, 1, vocab)
+    assert torch.equal(got[:width, 0], device_logits.reshape(width, vocab))
+    assert torch.count_nonzero(got[width:]) == 0
+
+
+def test_tp8_device_logprobs_complete_full_decode_warmup(monkeypatch):
+    """TP8 returns old-path sampled-token log-probs that Qwen must read from one replica."""
+    from models.common.warmup import WarmupForwardMixin
+    from models.tt_transformers.tt.generator import Generator
+
+    batch_size, sampler_batch = 4, 32
+    token_output, logprob_output = object(), object()
+    device_outputs = {
+        token_output: torch.arange(sampler_batch, dtype=torch.int32).reshape(1, 1, sampler_batch, 1),
+        logprob_output: torch.linspace(-1.0, -2.0, sampler_batch).reshape(1, 1, 1, sampler_batch),
+    }
+    monkeypatch.setattr(ttnn, "get_device_tensors", lambda tensor: [device_outputs[tensor]])
+    monkeypatch.setattr(ttnn, "to_torch", lambda tensor: tensor)
+    monkeypatch.delenv("TT_LEAN_DECODE_WARMUP", raising=False)
+
+    model = SimpleNamespace(num_devices=8)
+
+    def process_output_decode(tt_out, B, S=1, is_tokens=False, is_log_probs=False):
+        return Qwen36Model.process_output_decode(
+            model,
+            tt_out,
+            B,
+            S=S,
+            is_tokens=is_tokens,
+            is_log_probs=is_log_probs,
+        )
+
+    model.process_output_decode = process_output_decode
+    generator = object.__new__(Generator)
+    generator.model = [model]
+    generator.model_args = [SimpleNamespace(max_batch_size=batch_size)]
+    generator.data_parallel = 1
+
+    class WarmupHarness(WarmupForwardMixin):
+        def __init__(self):
+            self.logprob_outputs = []
+
+        def decode_forward(self, sampling_params=None, **_):
+            enabled = sampling_params is not None and sampling_params.enable_log_probs
+            if isinstance(enabled, list):
+                enabled = any(enabled)
+            if enabled:
+                self.logprob_outputs.append(
+                    generator.process_decode_output_host(
+                        [(token_output, logprob_output)],
+                        is_tokens=True,
+                    )
+                )
+
+    harness = WarmupHarness()
+    harness.warmup_model_decode(
+        kv_cache=None,
+        enable_trace=False,
+        max_batch_size=batch_size,
+        num_blocks=1,
+        can_sample_on_device=True,
+    )
+
+    # Full warmup covers log-probs with penalties both enabled and disabled.
+    assert len(harness.logprob_outputs) == 2
+    for sampled_tokens, sampled_logprobs in harness.logprob_outputs:
+        assert torch.equal(sampled_tokens, device_outputs[token_output].reshape(-1)[:batch_size])
+        assert torch.equal(sampled_logprobs, device_outputs[logprob_output].reshape(-1)[:batch_size])
+
+
+def _build(mesh_device, bmax):
+    model = Qwen36Model.from_pretrained(
+        mesh_device, max_batch_size=bmax, max_seq_len=CTX, n_layers=N_LAYERS, hf_model="Qwen/Qwen3.6-27B"
+    )
+    num_blocks = bmax * BPU
+    kv_shape = (num_blocks, model.args.n_local_kv_heads, BLOCK, model.args.head_dim)
+    model.allocate_kv_caches(kv_shape, ttnn.bfloat16, batch_size=bmax)
+    page_table = torch.stack(
+        [torch.arange(u * BPU, (u + 1) * BPU, dtype=torch.int32) for u in range(bmax)]
+    )  # [bmax, BPU]
+    return model, page_table
+
+
+def _decode_once(model, tokens, positions, page_table):
+    dev = model.prepare_inputs_decode(tokens, positions, page_table)
+    out, _ = model.ttnn_decode_forward(dev[0], dev[1], rot_mat_idxs=dev[2], page_table=dev[3])
+    return out
+
+
+@torch.no_grad()
+@parametrize_mesh_tp()
+def test_bucketed_decode_matches_full_width(mesh_device, reset_seeds, ensure_gc):
+    """Each bucket must equal the same rows of a width-8 decode.
+
+    Every run starts from zeroed GDN state and uses the same token, position,
+    and page-table row for each active user. This is the correctness
+    precondition for bucketing and for active-prefix recurrent-state writes.
+    """
+    BMAX = 8
+    model, page_table = _build(mesh_device, BMAX)
+    vocab = model.args.vocab_size
+
+    tok0, pos0 = 42, 4096
+    # --- width-8 reference: user 0 real, users 1..7 also real (distinct tokens) ---
+    model.reset_tp()
+    tokens8 = torch.tensor([[tok0]] + [[100 + u] for u in range(1, BMAX)], dtype=torch.int32)
+    pos8 = torch.full((BMAX,), pos0, dtype=torch.int32)
+    out8 = _decode_once(model, tokens8, pos8, page_table)
+    lg8 = model.process_output_decode(out8, BMAX)[:, 0, :vocab].float()
+
+    for width in (1, 2, 4):
+        model.reset_tp()
+        out = _decode_once(model, tokens8[:width], pos8[:width], page_table[:width])
+        lg = model.process_output_decode(out, width)[:, 0, :vocab].float()
+        _, pcc = comp_pcc(lg8[:width], lg, 0.99)
+        logger.info(f"width-{width} vs width-8 rows [0:{width}] logits PCC = {pcc}")
+        assert float(pcc) >= 0.99, f"bucketed width-{width} does not match full-width rows [0:{width}]: PCC {pcc}"
+    logger.info("PASSED: bucket widths 1, 2, and 4 are numerically equivalent to full width")
+
+
+def _parametrize_traced(max_tp=8, trace_bytes=1073741824):
+    """Same mesh/fabric params as parametrize_mesh_tp, plus a trace region (needed to capture)."""
+    from models.demos.blackhole.qwen36.tests.test_factory import _resolve_mesh_shape
+    from models.demos.blackhole.qwen36.tt.model_config import GDN_CONV1D_L1_SMALL_SIZE
+
+    shape = _resolve_mesh_shape(max_tp)
+
+    def decorator(fn):
+        fn = pytest.mark.parametrize(
+            "device_params",
+            [
+                {
+                    "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                    "l1_small_size": GDN_CONV1D_L1_SMALL_SIZE,
+                    "trace_region_size": trace_bytes,
+                }
+            ],
+            indirect=True,
+        )(fn)
+        fn = pytest.mark.parametrize("mesh_device", [pytest.param(shape, id=f"{shape[0]}x{shape[1]}")], indirect=True)(
+            fn
+        )
+        return fn
+
+    return decorator
+
+
+def _mark_trace_buffers_corruptible(value):
+    mark_corruptible = getattr(ttnn, "mark_corruptible", None)
+    if mark_corruptible is None or value is None:
+        return
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            _mark_trace_buffers_corruptible(item)
+        return
+    mark_corruptible(value)
+
+
+@torch.no_grad()
+@_parametrize_traced()
+def test_gdn_prefix_write_trace(mesh_device, reset_seeds, ensure_gc):
+    """Prove a trace-safe prefix update for the fixed-capacity GDN state.
+
+    The recurrent state is TILE/DRAM ``[Bmax,Nv,Dk,Dv]``. A bucketed decode
+    produces only ``[B,Nv,Dk,Dv]``. The current model preserves idle rows by
+    slicing them, concatenating them with the new active state, and copying the
+    complete Bmax tensor. This test instead height-shards the active state in L1
+    and uses ``slice_write`` to update only rows ``[0:B]`` of the original
+    fixed-address TILE buffer.
+
+    The sharded input is important: the non-sharded TILE slice_write wrapper
+    converts the output through ROW_MAJOR buffers, which is not suitable for a
+    trace-persistent state address. The tiled-sharded path writes directly into
+    the supplied interleaved TILE output.
+    """
+    BMAX, NV, DK, DV = 8, 12, 128, 128
+    B = int(os.environ.get("QWEN36_PREFIX_WRITE_WIDTH", "1"))
+    assert B in (1, 2, 4, 8), f"QWEN36_PREFIX_WRITE_WIDTH must be 1, 2, 4, or 8; got {B}"
+    iters = int(os.environ.get("QWEN36_PREFIX_WRITE_ITERS", "100"))
+    assert iters > 0
+
+    # 48 cores make every supported width tile-aligned:
+    # flattened NHW = B*12*128, shard height = NHW/48 = B*32.
+    grid = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(
+                ttnn.CoreCoord(0, 0),
+                ttnn.CoreCoord(7, 5),
+            )
+        }
+    )
+    nhw = B * NV * DK
+    assert nhw % 48 == 0
+    shard_memcfg = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(grid, (nhw // 48, DV), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+
+    # Give every inactive row a distinct value so an accidental overwrite is
+    # visible. Use fp32 because that is the production recurrent-state dtype.
+    baseline = torch.arange(BMAX, dtype=torch.float32).reshape(BMAX, 1, 1, 1).expand(BMAX, NV, DK, DV).contiguous()
+    active = (100.0 + torch.arange(B, dtype=torch.float32)).reshape(B, 1, 1, 1).expand(B, NV, DK, DV).contiguous()
+    expected = baseline.clone()
+    expected[:B] = active
+
+    rep = ttnn.ReplicateTensorToMesh(mesh_device)
+    state = ttnn.from_torch(
+        baseline,
+        dtype=ttnn.float32,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=rep,
+    )
+    active_interleaved = ttnn.from_torch(
+        active,
+        dtype=ttnn.float32,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+        mesh_mapper=rep,
+    )
+    active_sharded = ttnn.to_memory_config(active_interleaved, shard_memcfg)
+    baseline_host = ttnn.from_torch(
+        baseline,
+        dtype=ttnn.float32,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=rep,
+    )
+
+    start = [0, 0, 0, 0]
+    end = [B, NV, DK, DV]
+    step = [1, 1, 1, 1]
+
+    # Compile and check the eager operation first.
+    ttnn.experimental.slice_write(active_sharded, state, start, end, step)
+    ttnn.synchronize_device(mesh_device)
+    eager = ttnn.to_torch(ttnn.get_device_tensors(state)[0]).reshape(BMAX, NV, DK, DV)
+    assert torch.equal(eager, expected), "eager prefix write changed active or inactive GDN rows"
+
+    # Reset the same output buffer, capture against its stable address, then
+    # reset once more so correctness depends on the replay.
+    ttnn.copy_host_to_device_tensor(baseline_host, state)
+    ttnn.synchronize_device(mesh_device)
+    tid = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    ttnn.experimental.slice_write(active_sharded, state, start, end, step)
+    ttnn.end_trace_capture(mesh_device, tid, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
+    ttnn.copy_host_to_device_tensor(baseline_host, state)
+    ttnn.synchronize_device(mesh_device)
+
+    ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)
+    ttnn.synchronize_device(mesh_device)
+    replay = ttnn.to_torch(ttnn.get_device_tensors(state)[0]).reshape(BMAX, NV, DK, DV)
+    assert torch.equal(replay, expected), "trace replay changed active or inactive GDN rows"
+
+    # Time only replay of the prefix-write trace. Rewriting the same prefix is
+    # idempotent, so no reset is needed between iterations.
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)
+    ttnn.synchronize_device(mesh_device)
+    prefix_ms = (time.perf_counter() - t0) * 1000.0 / iters
+    logger.info(f"GDN_PREFIX_WRITE_RESULT width={B} bmax={BMAX} dtype=fp32 " f"cores=48 ms_per_write={prefix_ms:.6f}")
+
+    ttnn.release_trace(mesh_device, tid)
+
+
+@torch.no_grad()
+@_parametrize_traced()
+@pytest.mark.parametrize("n_layers", [None], ids=["all64"])
+def test_decode_width_scaling_traced(mesh_device, n_layers, reset_seeds, ensure_gc):
+    """DEVICE time vs decode width on the traced path. Full layer count for served tok/s compare."""
+    from models.tt_transformers.tt.common import copy_host_to_device
+
+    BMAX = 8
+    ITERS = 50
+    model = Qwen36Model.from_pretrained(
+        mesh_device, max_batch_size=BMAX, max_seq_len=CTX, n_layers=n_layers, hf_model="Qwen/Qwen3.6-27B"
+    )
+    num_blocks = BMAX * BPU
+    kv_shape = (num_blocks, model.args.n_local_kv_heads, BLOCK, model.args.head_dim)
+    model.allocate_kv_caches(kv_shape, ttnn.bfloat16, batch_size=BMAX)
+    page_table_full = torch.stack([torch.arange(u * BPU, (u + 1) * BPU, dtype=torch.int32) for u in range(BMAX)])
+    n_layers_actual = len(model.layers)
+    logger.info(f"model built with {n_layers_actual} layers, ctx={CTX}, Bmax={BMAX}")
+
+    out = {}
+    # QWEN36_BUCKET_TEST_WIDTHS restricts the widths measured. Needed to run this harness against a
+    # tree WITHOUT the bucketing change, whose decode graph only accepts the full width: width 1
+    # there dies in reshape (new_volume == old_volume). "8" then yields the full-width baseline the
+    # bucketing saving must be measured against.
+    widths = tuple(int(w) for w in os.environ.get("QWEN36_BUCKET_TEST_WIDTHS", "1,8").split(","))
+    for width in widths:
+        model.reset_tp()
+        tokens = torch.tensor([[100 + u] for u in range(width)], dtype=torch.int32)
+        positions = torch.full((width,), CTX - 64, dtype=torch.int32)
+        pt = page_table_full[:width]
+
+        # compile run (eager) so trace capture records only pre-compiled programs
+        dev0 = model.prepare_inputs_decode(tokens, positions, pt)
+        model.ttnn_decode_forward(dev0[0], dev0[1], rot_mat_idxs=dev0[2], page_table=dev0[3])
+        ttnn.synchronize_device(mesh_device)
+
+        host = model.prepare_decode_inputs_host(tokens, positions, page_table=pt)
+        dev = copy_host_to_device(host, mesh_device=mesh_device)
+        tid = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        model.ttnn_decode_forward(dev[0], dev[1], rot_mat_idxs=dev[2], page_table=dev[3])
+        ttnn.end_trace_capture(mesh_device, tid, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+
+        ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)  # warm replay
+        ttnn.synchronize_device(mesh_device)
+        t0 = time.perf_counter()
+        for _ in range(ITERS):
+            ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)
+        ttnn.synchronize_device(mesh_device)
+        ms = (time.perf_counter() - t0) * 1000.0 / ITERS
+        out[width] = ms
+        logger.info(f"TRACED width={width}: {ms:.3f} ms/step device time  ({1000.0 / ms:.2f} tok/s ceiling)")
+        ttnn.release_trace(mesh_device, tid)
+
+    if 1 in out and 8 in out:
+        d = out[8] - out[1]
+        logger.info(
+            f"RESULT ({n_layers_actual} layers): traced device step width8={out[8]:.3f} ms, width1={out[1]:.3f} ms, "
+            f"saving={d:.3f} ms ({100.0 * d / out[8]:.1f}%)  -> tok/s {1000.0 / out[8]:.2f} vs {1000.0 / out[1]:.2f}"
+        )
+    assert all(v > 0 for v in out.values())
+
+
+@torch.no_grad()
+@_parametrize_traced()
+def test_decode_capacity_width1_traced(mesh_device, reset_seeds, ensure_gc):
+    """Capacity-only device cost at live width 1 (true Bmax=1 vs Bmax=8).
+
+    Set ``QWEN36_CAPACITY_TEST_BMAX`` to 1 or 8 in separate pytest processes.
+    On-device logits; no sampling replay (both round to 32 slots). Optional:
+    ``N_LAYERS``, ``LAYER_INDEX`` (3 = first full-attn), ``EAGER_PROFILE=1``
+    for per-op Tracy rows instead of aggregate trace time.
+    """
+    from tracy import signpost
+
+    from models.tt_transformers.tt.common import copy_host_to_device
+
+    bmax = int(os.environ.get("QWEN36_CAPACITY_TEST_BMAX", "8"))
+    assert bmax in (1, 8), f"QWEN36_CAPACITY_TEST_BMAX must be 1 or 8, got {bmax}"
+    n_layers_env = os.environ.get("QWEN36_CAPACITY_TEST_N_LAYERS")
+    n_layers = int(n_layers_env) if n_layers_env is not None else None
+    assert n_layers is None or 1 <= n_layers <= 64, f"QWEN36_CAPACITY_TEST_N_LAYERS must be in [1,64], got {n_layers}"
+    layer_index_env = os.environ.get("QWEN36_CAPACITY_TEST_LAYER_INDEX")
+    layer_indices = [int(layer_index_env)] if layer_index_env is not None else None
+    assert not (n_layers is not None and layer_indices is not None), (
+        "Set only one of QWEN36_CAPACITY_TEST_N_LAYERS or " "QWEN36_CAPACITY_TEST_LAYER_INDEX"
+    )
+    assert (
+        layer_indices is None or 0 <= layer_indices[0] < 64
+    ), f"QWEN36_CAPACITY_TEST_LAYER_INDEX must be in [0,63], got {layer_indices}"
+    trials = int(os.environ.get("QWEN36_CAPACITY_TEST_TRIALS", "5"))
+    iters = int(os.environ.get("QWEN36_CAPACITY_TEST_ITERS", "20"))
+    warmup = int(os.environ.get("QWEN36_CAPACITY_TEST_WARMUP", "3"))
+    eager_profile = os.environ.get("QWEN36_CAPACITY_TEST_EAGER_PROFILE") == "1"
+    assert trials > 0 and iters > 0 and warmup >= 0
+
+    # Start decode at CTX and leave enough RoPE/KV capacity for every captured,
+    # warmup, and measured replay. Round the page-table width to 8 blocks because
+    # each int32 row-major stick must be 32-byte aligned for paged SDPA.
+    max_seq_len = CTX + 1 + warmup + trials * iters + 8
+    blocks_per_user = (max_seq_len + BLOCK - 1) // BLOCK
+    blocks_per_user = ((blocks_per_user + 7) // 8) * 8
+
+    model = Qwen36Model.from_pretrained(
+        mesh_device,
+        max_batch_size=bmax,
+        max_seq_len=max_seq_len,
+        n_layers=n_layers,
+        layer_indices=layer_indices,
+        hf_model="Qwen/Qwen3.6-27B",
+    )
+    assert model.sampling is not None, "on-device logits require the sampling module"
+    sampler_batch = model.sampling.tt_sampling.max_batch_size
+    assert sampler_batch == 32, (
+        f"capacity comparison expects the same 32-slot sampler, got {sampler_batch} " f"for model capacity {bmax}"
+    )
+
+    num_blocks = bmax * blocks_per_user
+    kv_shape = (num_blocks, model.args.n_local_kv_heads, BLOCK, model.args.head_dim)
+    model.allocate_kv_caches(kv_shape, ttnn.bfloat16, batch_size=bmax)
+    page_table_full = torch.stack(
+        [torch.arange(u * blocks_per_user, (u + 1) * blocks_per_user, dtype=torch.int32) for u in range(bmax)]
+    )
+    page_table = page_table_full[:1]
+    tokens = torch.tensor([[100]], dtype=torch.int32)
+    positions = torch.tensor([CTX], dtype=torch.int32)
+
+    model.reset_tp()
+    dev0 = model.prepare_inputs_decode(tokens, positions, page_table)
+    model.ttnn_decode_forward(
+        dev0[0],
+        dev0[1],
+        rot_mat_idxs=dev0[2],
+        page_table=dev0[3],
+        on_device_logits=True,
+    )
+    ttnn.synchronize_device(mesh_device)
+
+    if eager_profile:
+        # Use fresh inputs after the compile run, then profile exactly one eager
+        # decode. No sampler is invoked: this produces one logits row, not a
+        # generated output-token sequence.
+        profile_positions = torch.tensor([CTX + 1], dtype=torch.int32)
+        profile_dev = model.prepare_inputs_decode(tokens, profile_positions, page_table)
+        ttnn.synchronize_device(mesh_device)
+        signpost("start")
+        t0 = time.perf_counter()
+        model.ttnn_decode_forward(
+            profile_dev[0],
+            profile_dev[1],
+            rot_mat_idxs=profile_dev[2],
+            page_table=profile_dev[3],
+            on_device_logits=True,
+        )
+        ttnn.synchronize_device(mesh_device)
+        elapsed_ms = (time.perf_counter() - t0) * 1000.0
+        signpost("stop")
+        logger.info(
+            f"CAPACITY_EAGER_PROFILE_RESULT bmax={bmax} live_width=1 ctx={CTX} "
+            f"layer_indices={model.layer_indices} sampler_batch={sampler_batch} elapsed_ms={elapsed_ms:.3f}"
+        )
+        return
+
+    host = model.prepare_decode_inputs_host(tokens, positions, page_table=page_table)
+    dev = copy_host_to_device(host, mesh_device=mesh_device)
+    tid = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    model.ttnn_decode_forward(
+        dev[0],
+        dev[1],
+        rot_mat_idxs=dev[2],
+        page_table=dev[3],
+        on_device_logits=True,
+    )
+    ttnn.end_trace_capture(mesh_device, tid, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
+
+    for _ in range(warmup):
+        ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)
+    ttnn.synchronize_device(mesh_device)
+
+    samples_ms = []
+    # These markers isolate only the measured trace replays in Tracy's ops CSV;
+    # compile, capture, and warmup operations remain outside the comparison.
+    signpost("start")
+    for _ in range(trials):
+        t0 = time.perf_counter()
+        for _ in range(iters):
+            ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)
+        ttnn.synchronize_device(mesh_device)
+        samples_ms.append((time.perf_counter() - t0) * 1000.0 / iters)
+    signpost("stop")
+
+    median_ms = statistics.median(samples_ms)
+    stdev_ms = statistics.pstdev(samples_ms)
+    logger.info(
+        f"CAPACITY_RESULT bmax={bmax} live_width=1 ctx={CTX} layer_indices={model.layer_indices} "
+        f"sampler_batch={sampler_batch} trials={trials} iters_per_trial={iters} "
+        f"samples_ms={[round(v, 3) for v in samples_ms]} median_ms={median_ms:.3f} "
+        f"stdev_ms={stdev_ms:.3f} range_ms={max(samples_ms) - min(samples_ms):.3f}"
+    )
+
+    ttnn.release_trace(mesh_device, tid)
+    assert all(v > 0 for v in samples_ms)
+
+
+@torch.no_grad()
+@_parametrize_traced()
+def test_decode_step_host_overhead(mesh_device, reset_seeds, ensure_gc):
+    """Time per-step host preparation and H2D copy against device replay."""
+    from models.tt_transformers.tt.common import copy_host_to_device
+
+    BMAX, ITERS, WIDTH = 8, 50, 1
+    model = Qwen36Model.from_pretrained(
+        mesh_device, max_batch_size=BMAX, max_seq_len=CTX, n_layers=None, hf_model="Qwen/Qwen3.6-27B"
+    )
+    num_blocks = BMAX * BPU
+    kv_shape = (num_blocks, model.args.n_local_kv_heads, BLOCK, model.args.head_dim)
+    model.allocate_kv_caches(kv_shape, ttnn.bfloat16, batch_size=BMAX)
+    page_table = torch.stack([torch.arange(u * BPU, (u + 1) * BPU, dtype=torch.int32) for u in range(BMAX)])[:WIDTH]
+    tokens = torch.tensor([[100 + u] for u in range(WIDTH)], dtype=torch.int32)
+    positions = torch.full((WIDTH,), CTX - 64, dtype=torch.int32)
+
+    model.reset_tp()
+    dev0 = model.prepare_inputs_decode(tokens, positions, page_table)
+    model.ttnn_decode_forward(dev0[0], dev0[1], rot_mat_idxs=dev0[2], page_table=dev0[3])
+    ttnn.synchronize_device(mesh_device)
+
+    host = model.prepare_decode_inputs_host(tokens, positions, page_table=page_table)
+    dev = copy_host_to_device(host, mesh_device=mesh_device)
+    tid = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    model.ttnn_decode_forward(dev[0], dev[1], rot_mat_idxs=dev[2], page_table=dev[3])
+    ttnn.end_trace_capture(mesh_device, tid, cq_id=0)
+    ttnn.synchronize_device(mesh_device)
+
+    # (a) pure device: replay only
+    ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)
+    ttnn.synchronize_device(mesh_device)
+    t0 = time.perf_counter()
+    for _ in range(ITERS):
+        ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)
+    ttnn.synchronize_device(mesh_device)
+    replay_ms = (time.perf_counter() - t0) * 1000.0 / ITERS
+
+    # (b) device + our per-step host input prep, exactly as always-refresh does it
+    t0 = time.perf_counter()
+    for k in range(ITERS):
+        pos_k = torch.full((WIDTH,), CTX - 64 + k, dtype=torch.int32)
+        host_k = model.prepare_decode_inputs_host(tokens, pos_k, page_table=page_table)
+        copy_host_to_device(host_tensors=host_k, device_tensors=dev)
+        ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)
+    ttnn.synchronize_device(mesh_device)
+    full_ms = (time.perf_counter() - t0) * 1000.0 / ITERS
+
+    ours = full_ms - replay_ms
+    logger.info(f"replay only            : {replay_ms:.2f} ms/step")
+    logger.info(f"replay + our host prep : {full_ms:.2f} ms/step   (our host cost = {ours:.2f} ms)")
+    logger.info(f"SERVER TPOT was 46.7 ms at 4k/conc-1 -> vLLM-side overhead ~= {46.7 - full_ms:.2f} ms")
+    ttnn.release_trace(mesh_device, tid)
+    assert replay_ms > 0 and full_ms >= replay_ms
+
+
+@torch.no_grad()
+@_parametrize_traced()
+def test_bucketed_on_device_sampling_traces(mesh_device, reset_seeds, ensure_gc):
+    """Bucketing + ON-DEVICE sampling, alternating widths. This is the SERVED config.
+
+    The served spec sets ``sample_on_device_mode: decode_only``, and the bucketing branch's
+    own comment says this combination is untested. The stated failure mode is that
+    ``SamplingGenerator._validate_trace_inputs`` binds a captured sampling trace to ONE logits
+    tensor by IDENTITY (generator.py:298), so a per-bucket decode trace (each with its own
+    logits tensor) needs a per-bucket sampling trace. ``set_trace_bucket`` is meant to provide
+    that. Alternating 1 -> 8 -> 1 -> 8 is what would trip it.
+    """
+    from models.tt_transformers.tt.common import copy_host_to_device
+
+    BMAX = 8
+    model = Qwen36Model.from_pretrained(
+        mesh_device, max_batch_size=BMAX, max_seq_len=CTX, n_layers=N_LAYERS, hf_model="Qwen/Qwen3.6-27B"
+    )
+    if model.sampling is None:
+        pytest.skip("on-device sampling unsupported on this mesh/vocab; nothing to verify")
+    if not hasattr(model.sampling, "set_trace_bucket"):
+        pytest.fail("SamplingGenerator lacks set_trace_bucket -- the bucketing branch is not applied")
+
+    num_blocks = BMAX * BPU
+    kv_shape = (num_blocks, model.args.n_local_kv_heads, BLOCK, model.args.head_dim)
+    model.allocate_kv_caches(kv_shape, ttnn.bfloat16, batch_size=BMAX)
+    page_table_full = torch.stack([torch.arange(u * BPU, (u + 1) * BPU, dtype=torch.int32) for u in range(BMAX)])
+
+    # Allocate GDN state ONCE, up front, at Bmax. reset_tp() -> TPGatedDeltaNet.reset_state()
+    # REALLOCATES the state buffers (ttnn.from_torch), which would invalidate the baked addresses
+    # of any already-captured trace and hang the device on replay. Both traces must stay live here,
+    # so state is allocated once and only ever zeroed in place afterwards.
+    model.reset_tp()
+    _warm = model.prepare_inputs_decode(
+        torch.tensor([[7]] * BMAX, dtype=torch.int32),
+        torch.full((BMAX,), CTX - 64, dtype=torch.int32),
+        page_table_full,
+    )
+    model.ttnn_decode_forward(_warm[0], _warm[1], rot_mat_idxs=_warm[2], page_table=_warm[3], on_device_logits=True)
+    ttnn.synchronize_device(mesh_device)
+
+    # Compile every width before capturing the first trace.
+    case_of = {}
+    for width in (1, BMAX):
+        model._reset_gdn_state_for_new_sequence()  # in-place; preserves baked trace addresses
+        tokens = torch.tensor([[100 + u] for u in range(width)], dtype=torch.int32)
+        positions = torch.full((width,), CTX - 64, dtype=torch.int32)
+        pt = page_table_full[:width]
+        case_of[width] = (tokens, positions, pt)
+
+        dev0 = model.prepare_inputs_decode(tokens, positions, pt)
+        lg0 = model.ttnn_decode_forward(
+            dev0[0], dev0[1], rot_mat_idxs=dev0[2], page_table=dev0[3], on_device_logits=True
+        )
+        ttnn.synchronize_device(mesh_device)
+        model.sampling.set_trace_bucket(width)
+        model.sampling.sample(lg0, enable_trace=False)
+        ttnn.synchronize_device(mesh_device)
+
+    # Per-width: a decode trace (stable logits tensor) + a sampling trace bound to it.
+    logits_of, dtrace_of, host_of, dev_of = {}, {}, {}, {}
+    for width in (1, BMAX):
+        model._reset_gdn_state_for_new_sequence()
+        tokens, positions, pt = case_of[width]
+        host = model.prepare_decode_inputs_host(tokens, positions, page_table=pt)
+        dev = copy_host_to_device(host, mesh_device=mesh_device)
+        _mark_trace_buffers_corruptible(dev)
+        tid = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        lg = model.ttnn_decode_forward(dev[0], dev[1], rot_mat_idxs=dev[2], page_table=dev[3], on_device_logits=True)
+        ttnn.end_trace_capture(mesh_device, tid, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+        _mark_trace_buffers_corruptible(lg)
+        logits_of[width], dtrace_of[width] = lg, tid
+        host_of[width], dev_of[width] = host, dev
+
+        # capture the sampling trace for THIS bucket
+        model.sampling.set_trace_bucket(width)
+        ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)
+        ttnn.synchronize_device(mesh_device)
+        model.sampling.sample(lg, enable_trace=True, skip_precompile=True)
+        ttnn.synchronize_device(mesh_device)
+        logger.info(f"captured decode+sampling trace for bucket width={width} (logits shape {list(lg.shape)})")
+
+    # Alternate widths. Without per-bucket namespacing this raises on the first switch.
+    for step, width in enumerate((1, BMAX, 1, BMAX, 1)):
+        model.sampling.set_trace_bucket(width)
+        copy_host_to_device(host_tensors=host_of[width], device_tensors=dev_of[width])
+        ttnn.execute_trace(mesh_device, dtrace_of[width], cq_id=0, blocking=False)
+        tok = model.sampling.sample(logits_of[width], enable_trace=True)
+        ttnn.synchronize_device(mesh_device)
+        if isinstance(tok, tuple):  # (tokens, log_probs) when log-probs are on
+            tok = tok[0]
+        t = ttnn.to_torch(tok, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0)).reshape(-1)
+        ids = t[:width].to(torch.int64)
+        assert (
+            int(ids.min()) >= 0 and int(ids.max()) < model.args.vocab_size
+        ), f"step {step} width {width}: sampled ids out of range: {ids.tolist()}"
+        logger.info(f"step {step} width={width}: sampled ids {ids.tolist()[: min(4, width)]} OK")
+
+    model.sampling.reset_trace()
+    for tid in dtrace_of.values():
+        ttnn.release_trace(mesh_device, tid)
+    logger.info("PASSED: per-bucket sampling traces survive alternating widths with on-device sampling")
+
+
+@torch.no_grad()
+@_parametrize_traced(trace_bytes=1073741824)  # exactly the b8 model spec's trace_region_size
+def test_all_buckets_fit_trace_region(mesh_device, reset_seeds, ensure_gc):
+    """Four live decode and sampling traces fit in 1 GB and remain replay-safe."""
+    from models.tt_transformers.tt.common import copy_host_to_device
+
+    BMAX = 8
+    model = Qwen36Model.from_pretrained(
+        mesh_device, max_batch_size=BMAX, max_seq_len=CTX, n_layers=None, hf_model="Qwen/Qwen3.6-27B"
+    )
+    num_blocks = BMAX * BPU
+    kv_shape = (num_blocks, model.args.n_local_kv_heads, BLOCK, model.args.head_dim)
+    model.allocate_kv_caches(kv_shape, ttnn.bfloat16, batch_size=BMAX)
+    page_table_full = torch.stack([torch.arange(u * BPU, (u + 1) * BPU, dtype=torch.int32) for u in range(BMAX)])
+    on_dev = model.sampling is not None
+
+    # Allocate GDN state once (reset_state reallocates and would invalidate live traces).
+    model.reset_tp()
+    widths = (1, 2, 4, BMAX)
+    case_of = {}
+
+    # Compile all program-cache shapes before the first trace exists.
+    for width in widths:
+        model._reset_gdn_state_for_new_sequence()
+        tokens = torch.tensor([[100 + u] for u in range(width)], dtype=torch.int32)
+        positions = torch.full((width,), CTX - 64, dtype=torch.int32)
+        pt = page_table_full[:width]
+        case_of[width] = (tokens, positions, pt)
+
+        dev0 = model.prepare_inputs_decode(tokens, positions, pt)
+        lg0 = model.ttnn_decode_forward(
+            dev0[0], dev0[1], rot_mat_idxs=dev0[2], page_table=dev0[3], on_device_logits=on_dev
+        )
+        ttnn.synchronize_device(mesh_device)
+        if on_dev:
+            model.sampling.set_trace_bucket(width)
+            model.sampling.sample(lg0, enable_trace=False)
+            ttnn.synchronize_device(mesh_device)
+
+    tids, host_of, dev_of, logits_of = {}, {}, {}, {}
+    for width in (1, 2, 4, BMAX):
+        model._reset_gdn_state_for_new_sequence()
+        tokens, positions, pt = case_of[width]
+        host = model.prepare_decode_inputs_host(tokens, positions, page_table=pt)
+        dev = copy_host_to_device(host, mesh_device=mesh_device)
+        _mark_trace_buffers_corruptible(dev)
+        tid = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        lg = model.ttnn_decode_forward(dev[0], dev[1], rot_mat_idxs=dev[2], page_table=dev[3], on_device_logits=on_dev)
+        ttnn.end_trace_capture(mesh_device, tid, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+        _mark_trace_buffers_corruptible(lg)
+        tids[width], host_of[width], dev_of[width], logits_of[width] = tid, host, dev, lg
+        if on_dev:
+            model.sampling.set_trace_bucket(width)
+            ttnn.execute_trace(mesh_device, tid, cq_id=0, blocking=False)
+            ttnn.synchronize_device(mesh_device)
+            model.sampling.sample(lg, enable_trace=True, skip_precompile=True)
+            ttnn.synchronize_device(mesh_device)
+        logger.info(f"bucket width={width}: decode{'+sampling' if on_dev else ''} trace captured and live")
+
+    # Re-copy each acknowledged input before use. This replays B1 only after every later
+    # compilation, allocation, and capture has completed.
+    for width in widths:
+        copy_host_to_device(host_tensors=host_of[width], device_tensors=dev_of[width])
+        ttnn.execute_trace(mesh_device, tids[width], cq_id=0, blocking=False)
+        if on_dev:
+            model.sampling.set_trace_bucket(width)
+            tok = model.sampling.sample(logits_of[width], enable_trace=True)
+            ttnn.synchronize_device(mesh_device)
+            if isinstance(tok, tuple):
+                tok = tok[0]
+            ids = (
+                ttnn.to_torch(tok, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0))
+                .reshape(-1)
+                .to(torch.int64)
+            )
+            assert torch.all((ids[:width] >= 0) & (ids[:width] < model.args.vocab_size))
+        else:
+            ttnn.synchronize_device(mesh_device)
+            logits = logits_of[width][0] if isinstance(logits_of[width], tuple) else logits_of[width]
+            assert model.process_output_decode(logits, width).shape == (width, 1, model.args.vocab_size)
+
+    assert len(tids) == 4
+    logger.info(
+        f"PASSED: all {len(tids)} bucket decode traces (+ sampling traces) captured inside the "
+        f"1 GB trace_region_size and replayed after all later allocations"
+    )
+    if on_dev:
+        model.sampling.reset_trace()
+    for tid in tids.values():
+        ttnn.release_trace(mesh_device, tid)

--- a/models/demos/blackhole/qwen36/tests/test_factory.py
+++ b/models/demos/blackhole/qwen36/tests/test_factory.py
@@ -11,7 +11,7 @@ Centralizes what used to be copy-pasted across the per-test files:
                                        FP8 (or bf16) safetensors checkpoint
 * ``compute_pcc`` / ``compare_tensors`` — single PCC implementation
 * ``get_pcc_threshold(request)``   — per-test threshold from ``pcc_thresholds.json``
-* ``parametrize_mesh_tp()``        — the env-driven (1,4)/(1,1) mesh + FABRIC_1D idiom
+* ``parametrize_mesh_tp()``        — the env-driven (1,8)/(1,4)/(1,1) mesh + FABRIC_1D idiom
 * ``tp_composer`` / ``replicate_to_device`` — shared TP tensor helpers
 
 Heavy imports (ttnn weight loaders, ``Qwen36ModelArgs``) are kept lazy / local so
@@ -164,17 +164,23 @@ def get_pcc_threshold(request, default=0.99):
 # --------------------------------------------------------------------------- #
 # Mesh / device helpers
 # --------------------------------------------------------------------------- #
-def _resolve_mesh_shape(max_tp=4):
-    return {"P150": (1, 1), "P150x4": (1, 4)}.get(
-        os.environ.get("MESH_DEVICE"), (1, min(len(ttnn.get_device_ids()), max_tp))
-    )
+def _resolve_mesh_shape(max_tp=8):
+    # MESH_DEVICE wins outright. The device-count fallback is computed lazily (not as a
+    # ``dict.get`` default, which Python evaluates eagerly) so an explicit MESH_DEVICE never
+    # touches ttnn.get_device_ids() -- that call raises on clusters whose ClusterType lookup
+    # fails, which would otherwise break collection even for a fully-specified mesh.
+    shape = {"P150": (1, 1), "P150x4": (1, 4), "P150x8": (1, 8)}.get(os.environ.get("MESH_DEVICE"))
+    if shape is not None:
+        return shape
+    return (1, min(len(ttnn.get_device_ids()), max_tp))
 
 
-def parametrize_mesh_tp(max_tp=4):
+def parametrize_mesh_tp(max_tp=8):
     """Parametrize a TP test over the env-selected mesh shape + FABRIC_1D.
 
     Mirrors the idiom the qwen TP tests used inline: ``MESH_DEVICE=P150`` -> (1,1),
-    ``P150x4`` -> (1,4); otherwise (1, min(num_devices, max_tp)). The mesh shape
+    ``P150x4`` -> (1,4), ``P150x8`` -> (1,8); otherwise (1, min(num_devices, max_tp)).
+    The mesh shape
     gets an explicit ``RxC`` id so node names (and ``pcc_thresholds.json`` mesh
     keys) are readable.
     """
@@ -208,7 +214,7 @@ def parametrize_batch(batches=(1, 8, 32)):
     return pytest.mark.parametrize("B", [pytest.param(b, id=f"B{b}") for b in batches])
 
 
-def parametrize_mesh_only(max_tp=4):
+def parametrize_mesh_only(max_tp=8):
     """Parametrize over just the env-selected mesh shape (no device_params / fabric).
 
     For mesh tests that don't run fabric CCL ops (e.g. pure weight-loading checks),

--- a/models/demos/blackhole/qwen36/tests/test_model.py
+++ b/models/demos/blackhole/qwen36/tests/test_model.py
@@ -23,9 +23,15 @@ from models.tt_transformers.tt.load_checkpoints import (
 @pytest.mark.parametrize(
     "mesh_device",
     [
-        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4), "P150x4": (1, 4), "P150": (1, 1)}.get(
-            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
-        )
+        {
+            "N150": (1, 1),
+            "N300": (1, 2),
+            "T3K": (1, 8),
+            "TG": (8, 4),
+            "P150x4": (1, 4),
+            "P150x8": (1, 8),
+            "P150": (1, 1),
+        }.get(os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids()))
     ],
     indirect=True,
 )

--- a/models/demos/blackhole/qwen36/tests/test_model_tp.py
+++ b/models/demos/blackhole/qwen36/tests/test_model_tp.py
@@ -231,7 +231,9 @@ def test_prefill_warmup_no_recompile(mesh_device, reset_seeds, ensure_gc):
 
 @torch.no_grad()
 @parametrize_mesh_tp()
-@pytest.mark.parametrize("B", [8, 32], ids=["B8", "B32"])
+# B32 dropped (#50969 CI budget): width 32 reaches no branch B8 misses, and the oracle runs B
+# independent B=1 chains. Width 32 stays covered by test_model_tp_prefill_chunked_batched.
+@pytest.mark.parametrize("B", [8], ids=["B8"])
 def test_model_tp_decode_batched(mesh_device, B, reset_seeds, ensure_gc):
     """Batched per-user decode contract (TP): higher-batch serving acceptance test.
 
@@ -562,7 +564,8 @@ def test_model_tp_prefill_paged_slots_long(mesh_device, T, traced, reset_seeds, 
 
 @torch.no_grad()
 @parametrize_mesh_tp()
-@pytest.mark.parametrize("B", [8, 32], ids=["B8", "B32"])
+# B32 dropped (#50969 CI budget): same reason as test_model_tp_decode_batched.
+@pytest.mark.parametrize("B", [8], ids=["B8"])
 def test_model_tp_prefill_traced_bucket(mesh_device, B, reset_seeds, ensure_gc, request):
     """Traced batched short-prompt prefill (TP): traced-bucket-prefill acceptance test.
 
@@ -702,8 +705,10 @@ def test_model_tp_prefill_traced_bucket(mesh_device, B, reset_seeds, ensure_gc, 
 
 @torch.no_grad()
 @parametrize_mesh_tp()
-@pytest.mark.parametrize("B", [8, 32], ids=["B8", "B32"])
-@pytest.mark.parametrize("seqlen", [2048, 4096, "mixed"], ids=["isl2048", "isl4096", "mixed"])
+# Two cases, not the 2x3 cross product (#50969 CI budget): "mixed" already cycles
+# {128,1024,2048,4096}, so it covers the short-via-masked-bucket + 1-chunk + 2-chunk branches in one
+# batch; isl4096-B32 keeps the uniform-long, max-width capacity case that "mixed" does not reach.
+@pytest.mark.parametrize("seqlen, B", [("mixed", 8), (4096, 32)], ids=["mixed-B8", "isl4096-B32"])
 def test_model_tp_prefill_chunked_batched(mesh_device, B, seqlen, reset_seeds, ensure_gc, request):
     """Batched per-user long prefill (TP): chunked-batched-prefill acceptance test.
 

--- a/models/demos/blackhole/qwen36/tests/test_sampling.py
+++ b/models/demos/blackhole/qwen36/tests/test_sampling.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qwen3.6 on-device sampling integration regressions.
+
+Run:
+  MESH_DEVICE=P150x4 HF_MODEL=Qwen/Qwen3.6-27B \
+    pytest -svq models/demos/blackhole/qwen36/tests/test_sampling.py
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import ttnn
+from models.common.sampling.generator import SamplingGenerator, SamplingParams, format_sampling_params
+from models.demos.blackhole.qwen36.tests.test_factory import parametrize_mesh_tp
+from models.demos.blackhole.qwen36.tt.model_config import Qwen36ModelArgs
+from models.tt_transformers.tt.generator import Generator
+
+
+def _make_hot_logits(args, mesh_device, num_hot=20):
+    """Build fixed, vocab-sharded logits with equiprobable hot tokens."""
+    num_devices = mesh_device.get_num_devices()
+    per_device_vocab = args.padded_vocab_size // num_devices
+    hot_tokens = []
+    for index in range(num_hot):
+        shard = index % num_devices
+        token = shard * per_device_vocab + 128 + index
+        assert token < args.vocab_size
+        hot_tokens.append(token)
+
+    sampling_batch = max(32, args.max_batch_size)
+    logits = torch.zeros(1, 1, sampling_batch, args.padded_vocab_size)
+    logits[:, :, :, hot_tokens] = 10.0
+    logits[:, :, :, args.vocab_size :] = -float("inf")
+    tt_logits = ttnn.from_torch(
+        logits,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device,
+            dims=(None, 3),
+            mesh_shape=args.cluster_shape,
+        ),
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        layout=ttnn.TILE_LAYOUT,
+    )
+    return tt_logits, set(hot_tokens)
+
+
+def _extract_user_zero_token(tt_tokens):
+    device_tensor = ttnn.get_device_tensors(tt_tokens)[0]
+    return int(ttnn.to_torch(device_tensor).reshape(-1)[0].item())
+
+
+@torch.no_grad()
+@parametrize_mesh_tp()
+def test_decode_only_unseeded_sampling_initializes_rng(mesh_device, reset_seeds, ensure_gc):
+    """Host prefill followed by device decode must not reuse seed zero.
+
+    This reproduces the vLLM ``sample_on_device_mode=decode_only`` lifecycle:
+    device prefill sampling state is deliberately skipped, then the first
+    device decode arrives with ``reset_batch=True`` and no request seed.
+    Sampling traces are disabled so this test isolates seed initialization
+    from the separate sampling-trace correctness issue.
+    """
+    if mesh_device.get_num_devices() == 1:
+        pytest.skip("Qwen3.6-27B sampling is the TP path; run with MESH_DEVICE=P150x4 or P150x8")
+    args = Qwen36ModelArgs(mesh_device, max_batch_size=1, max_seq_len=128)
+    args.sampling_dp = 1
+
+    sampling = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=None)
+    model = SimpleNamespace(sampling=sampling, sampling_dp=1)
+    generator = Generator([model], [args], mesh_device)
+
+    tt_logits, hot_tokens = _make_hot_logits(args, mesh_device)
+    sampling_batch = sampling.tt_sampling.max_batch_size
+    params = format_sampling_params(
+        SamplingParams(
+            temperature=1.0,
+            top_k=20,
+            top_p=0.95,
+            seed=None,
+        ),
+        sampling_batch,
+    )
+    positions = torch.full((sampling_batch,), -1, dtype=torch.int32)
+    positions[0] = 0
+
+    sampled_tokens = []
+    for step in range(100):
+        outputs = generator.sample_decode_on_device(
+            [tt_logits],
+            sampling_params=params,
+            start_pos=[positions],
+            reset_batch=step == 0,
+            enable_trace=False,
+        )
+        tt_tokens, _ = outputs[0]
+        sampled_tokens.append(_extract_user_zero_token(tt_tokens))
+        ttnn.deallocate(tt_tokens)
+        positions[0] += 1
+
+    sampled_set = set(sampled_tokens)
+    assert sampled_set <= hot_tokens
+    assert len(sampled_set) >= 2, (
+        "Unseeded decode-only sampling reused one random draw for all 100 "
+        f"steps: token counts={torch.tensor(sampled_tokens).unique(return_counts=True)}"
+    )

--- a/models/demos/blackhole/qwen36/tests/test_weight_mapping.py
+++ b/models/demos/blackhole/qwen36/tests/test_weight_mapping.py
@@ -3,8 +3,10 @@
 
 """Tests for Qwen3.5-9B HF -> internal weight remapping."""
 import pytest
+import torch
 
 from models.demos.blackhole.qwen36.tt.model_config import Qwen36ModelArgs
+from models.demos.blackhole.qwen36.tt.tp_common import replicate_kv_weight
 from models.demos.blackhole.qwen36.tt.weight_mapping import remap_qwen36_state_dict
 
 HIDDEN_SIZE = 4096
@@ -164,3 +166,57 @@ class TestAllLayersPresent:
         expected = [3, 7, 11, 15, 19, 23, 27, 31]
         for i in expected:
             assert f"layers.{i}.self_attn.q_proj.weight" in remapped, f"Layer {i} should be full attention"
+
+
+class TestReplicateKVWeight:
+    """KV-head replication for TP > n_kv_heads (27B: 4 KV heads on TP=8).
+
+    No fixtures / no checkpoint / no device — pure host tensor reshaping, so this runs
+    anywhere. Guards the invariant the TP attention loader depends on: device ``d`` must
+    receive exactly the KV head that its GQA query group attends to.
+    """
+
+    # Qwen3.6-27B full-attention geometry.
+    N_HEADS = 24
+    N_KV_HEADS = 4
+    HEAD_DIM = 256
+    IN_DIM = 512  # narrowed from 5120; the helper is agnostic to the input width
+
+    def _kv_weight(self):
+        """[n_kv_heads*head_dim, in] where every row of head h holds the value h."""
+        return torch.cat([torch.full((self.HEAD_DIM, self.IN_DIM), float(h)) for h in range(self.N_KV_HEADS)], dim=0)
+
+    def _heads_per_device(self, replicated, tp):
+        """The KV head index each device ends up with."""
+        rows = max(1, self.N_KV_HEADS // tp) * self.HEAD_DIM
+        return [int(replicated[d * rows : (d + 1) * rows].unique().item()) for d in range(tp)]
+
+    @pytest.mark.parametrize("tp", [1, 2, 4])
+    def test_noop_when_tp_fits_kv_heads(self, tp):
+        """tp <= n_kv_heads needs no replication — must return the very same object, so
+        TP<=4 weight prep stays bit-identical."""
+        w = self._kv_weight()
+        assert replicate_kv_weight(w, self.N_KV_HEADS, tp, self.HEAD_DIM) is w
+
+    def test_tp8_shape(self):
+        out = replicate_kv_weight(self._kv_weight(), self.N_KV_HEADS, 8, self.HEAD_DIM)
+        assert out.shape == (8 * self.HEAD_DIM, self.IN_DIM)
+
+    def test_tp8_pairs_devices_on_one_head(self):
+        out = replicate_kv_weight(self._kv_weight(), self.N_KV_HEADS, 8, self.HEAD_DIM)
+        assert self._heads_per_device(out, 8) == [0, 0, 1, 1, 2, 2, 3, 3]
+
+    @pytest.mark.parametrize("tp", [4, 8])
+    def test_matches_gqa_query_grouping(self, tp):
+        """The head each device gets must be the one its local query heads map to under
+        GQA — otherwise attention silently reads the wrong K/V."""
+        out = replicate_kv_weight(self._kv_weight(), self.N_KV_HEADS, tp, self.HEAD_DIM)
+        q_per_device = self.N_HEADS // tp
+        heads_per_kv = self.N_HEADS // self.N_KV_HEADS
+        expected = [(d * q_per_device) // heads_per_kv for d in range(tp)]
+        assert self._heads_per_device(out, tp) == expected
+
+    def test_every_head_still_reachable(self):
+        """Replication must not drop a head: all n_kv_heads appear across the mesh."""
+        out = replicate_kv_weight(self._kv_weight(), self.N_KV_HEADS, 8, self.HEAD_DIM)
+        assert sorted(set(self._heads_per_device(out, 8))) == list(range(self.N_KV_HEADS))

--- a/models/demos/blackhole/qwen36/tests/test_wrapped_model.py
+++ b/models/demos/blackhole/qwen36/tests/test_wrapped_model.py
@@ -18,9 +18,14 @@ from models.tt_transformers.tt.ccl import TT_CCL
 @pytest.mark.parametrize(
     "mesh_device",
     [
-        {"N150": (1, 1), "N300": (1, 2), "T3K": (1, 8), "TG": (8, 4), "P150x4": (1, 4)}.get(
-            os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())
-        )
+        {
+            "N150": (1, 1),
+            "N300": (1, 2),
+            "T3K": (1, 8),
+            "TG": (8, 4),
+            "P150x4": (1, 4),
+            "P150x8": (1, 8),
+        }.get(os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids()))
     ],
     indirect=True,
 )

--- a/models/demos/blackhole/qwen36/tt/attention/tp.py
+++ b/models/demos/blackhole/qwen36/tt/attention/tp.py
@@ -30,12 +30,20 @@ def load_attention_weights_tp(mesh, state_dict, args, cache_dir=None):
     fused_qkv = getattr(args, "attn_qkv_fused_weight_memcfg", None) is not None
     # De-interleave [q,gate] per head → contiguous q/gate slices (avoids ~5.3ms relayout).
     qg_deint = fused_qkv
+
+    # TP > n_kv_heads (e.g. 27B's 4 KV heads on TP=8): there is no whole KV head per device, so
+    # pre-expand K/V to tp*head_dim rows where device d holds the head its GQA query group maps
+    # to (devices 2d, 2d+1 share head d at TP=8). The per-device slicing below is then uniform.
+    # No-op when tp <= n_kv_heads, so TP=4 weights stay bit-identical.
+    kv_rep = lambda w: tpc.replicate_kv_weight(w, args.n_kv_heads, args.num_devices, args.head_dim)
+    k_proj, v_proj = kv_rep(state_dict["k_proj.weight"]), kv_rep(state_dict["v_proj.weight"])
+
     if fused_qkv:
         if qg_deint:
             fused = tpc.prepare_attn_qkv_deint(
                 state_dict["q_proj.weight"],
-                state_dict["k_proj.weight"],
-                state_dict["v_proj.weight"],
+                k_proj,
+                v_proj,
                 args.n_local_heads,
                 args.head_dim,
                 args.n_local_kv_heads * args.head_dim,
@@ -44,8 +52,8 @@ def load_attention_weights_tp(mesh, state_dict, args, cache_dir=None):
         else:
             fused = tpc.prepare_attn_qkv(
                 state_dict["q_proj.weight"],
-                state_dict["k_proj.weight"],
-                state_dict["v_proj.weight"],
+                k_proj,
+                v_proj,
                 args.n_local_heads * args.head_dim * 2,
                 args.n_local_kv_heads * args.head_dim,
                 args.num_devices,
@@ -76,8 +84,10 @@ def load_attention_weights_tp(mesh, state_dict, args, cache_dir=None):
             cache_path=c("wqkv" + tag),
             dtype=ttnn.bfloat8_b,
         )
+        # k_proj/v_proj are the KV-replicated weights: shard_w splits tp*head_dim rows evenly, so
+        # each device lands on its GQA-assigned head instead of a fraction of one.
         tw["wk"] = tpc.shard_w(
-            state_dict["k_proj.weight"],
+            k_proj,
             mesh,
             dim=-1,
             memory_config=k_mc,
@@ -85,7 +95,7 @@ def load_attention_weights_tp(mesh, state_dict, args, cache_dir=None):
             dtype=ttnn.bfloat8_b,
         )
         tw["wv"] = tpc.shard_w(
-            state_dict["v_proj.weight"],
+            v_proj,
             mesh,
             dim=-1,
             memory_config=v_mc,
@@ -117,6 +127,7 @@ class TPAttention:
         self.tw = tw
         self.tt_ccl = tt_ccl
         self.B = args.max_batch_size
+        self._kv_shard_cfg_cache = {}  # active-width B -> KV-update height shard cfg (bucketed decode)
         self.NH = args.n_local_heads
         self.NKV = args.n_local_kv_heads
         self.HD = args.head_dim
@@ -225,6 +236,7 @@ class TPAttention:
                     weight.shape[-2],
                     weight.shape[-1],
                     max_cols=getattr(self.args, "decode_grid_w", 8),
+                    tuning=getattr(self.args, "prefill_tuning", None),
                 )
                 return ttnn.linear(
                     x,
@@ -467,8 +479,32 @@ class TPAttention:
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
 
+    def _kv_shard_cfg(self, B):
+        """Height shard for paged_update_cache (one user per core), sized to the ACTIVE width B.
+        Returns the precomputed max-batch config unchanged when B==self.B (byte-identical prod path);
+        builds a width-B config (B cores) for bucketed decode. Mirrors model_config.kv_update_shard_cfg."""
+        if B == self.B:
+            return self.args.kv_update_shard_cfg
+        cfg = self._kv_shard_cfg_cache.get(B)
+        if cfg is None:
+            cols = next(c for c in range(min(8, B), 0, -1) if B % c == 0)
+            cfg = ttnn.create_sharded_memory_config(
+                shape=(ttnn.TILE_SIZE, self.HD),
+                core_grid=ttnn.CoreGrid(x=cols, y=B // cols),
+                strategy=ttnn.ShardStrategy.HEIGHT,
+                orientation=ttnn.ShardOrientation.ROW_MAJOR,
+                use_height_and_width_as_shard_shape=True,
+            )
+            self._kv_shard_cfg_cache[B] = cfg
+        return cfg
+
     def forward_decode(self, x, cur_pos_tt, cos_tt, sin_tt, page_table=None):
-        tw, B, NH, NKV, HD = self.tw, self.B, self.NH, self.NKV, self.HD
+        tw, NH, NKV, HD = self.tw, self.NH, self.NKV, self.HD
+        # Active decode width, taken from the input (x is [1,1,B,dim_frac]). Normally == self.B.
+        # BUCKETED decode: a request feeds B<self.B users; every shape/reshape/rope/head-split and
+        # the KV-update shard config below run at this width, and the paged SDPA reads only these B
+        # users' pages via the width-B page_table. The B==self.B path is byte-identical to before.
+        B = x.shape[-2]
         _L1 = ttnn.L1_MEMORY_CONFIG  # keep decode head-prep + attn output L1-resident
         use_paged = self.use_paged and page_table is not None
         if not use_paged and self.k_caches is None:
@@ -538,8 +574,9 @@ class TPAttention:
             v_p = ttnn.pad(v, [1, B, 32, HD], [0, 0, 0, 0], 0.0, memory_config=_L1)
             ttnn.deallocate(k)
             ttnn.deallocate(v)
-            k_sh = ttnn.to_memory_config(k_p, self.args.kv_update_shard_cfg)
-            v_sh = ttnn.to_memory_config(v_p, self.args.kv_update_shard_cfg)
+            _kv_cfg = self._kv_shard_cfg(B)
+            k_sh = ttnn.to_memory_config(k_p, _kv_cfg)
+            v_sh = ttnn.to_memory_config(v_p, _kv_cfg)
             ttnn.deallocate(k_p)
             ttnn.deallocate(v_p)
             # paged_update_cache takes bf16/fp32 and casts to bf8 cache; decode K/V stay bf16 (prefill fill needs bf8)
@@ -569,8 +606,9 @@ class TPAttention:
                 v_hp = ttnn.pad(v_h, [1, B, 32, HD], [0, 0, 0, 0], 0.0)
                 ttnn.deallocate(k_h)
                 ttnn.deallocate(v_h)
-                k_sh = ttnn.to_memory_config(k_hp, self.args.kv_update_shard_cfg)
-                v_sh = ttnn.to_memory_config(v_hp, self.args.kv_update_shard_cfg)
+                _kv_cfg = self._kv_shard_cfg(B)
+                k_sh = ttnn.to_memory_config(k_hp, _kv_cfg)
+                v_sh = ttnn.to_memory_config(v_hp, _kv_cfg)
                 ttnn.deallocate(k_hp)
                 ttnn.deallocate(v_hp)
                 ttnn.experimental.paged_update_cache(self.k_caches[h], k_sh, update_idxs_tensor=cur_pos_tt)

--- a/models/demos/blackhole/qwen36/tt/gdn/tp.py
+++ b/models/demos/blackhole/qwen36/tt/gdn/tp.py
@@ -385,6 +385,7 @@ class TPGatedDeltaNet:
                     weight.shape[-2],
                     weight.shape[-1],
                     max_cols=getattr(self.args, "decode_grid_w", 8),
+                    tuning=getattr(self.args, "prefill_tuning", None),
                 )
                 return ttnn.linear(
                     x, weight, compute_kernel_config=self.cfg, program_config=pc, memory_config=ttnn.DRAM_MEMORY_CONFIG
@@ -734,6 +735,55 @@ class TPGatedDeltaNet:
         end[dim] = hi
         return ttnn.slice(buf, tuple(start), tuple(end))
 
+    def _write_recurrent_state_prefix(self, new_rec, B):
+        """Write active rows [0:B] without reading or copying idle rows."""
+        grid_size = self.mesh.compute_with_storage_grid_size()
+        assert (
+            grid_size.x >= 8 and grid_size.y >= 6
+        ), f"GDN prefix state write needs an 8x6 core rectangle, got {grid_size.x}x{grid_size.y}"
+        nhw = B * self.Nv * self.Dk
+        assert (
+            nhw % ttnn.TILE_SIZE == 0
+        ), f"GDN prefix state rows B={B}, Nv={self.Nv}, Dk={self.Dk} -> {nhw} is not tile-aligned"
+        n_tiles = nhw // ttnn.TILE_SIZE
+
+        # Prefer the tuned 8x6=48-core rectangle, which every TP=4 shape hits (Nv=12 -> nhw=B*1536
+        # -> 48*B tiles). At TP=8 Nv halves to 6, so B=1 gives only 24 tiles and cannot fill 48
+        # cores with tile-aligned shards — fall back to the largest core count that divides evenly.
+        if n_tiles % 48 == 0:
+            num_cores = 48
+            grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 5))})
+        else:
+            num_cores = max(c for c in range(1, min(48, grid_size.x * grid_size.y) + 1) if n_tiles % c == 0)
+            grid = ttnn.num_cores_to_corerangeset(num_cores, grid_size, row_wise=True)
+
+        shard_memcfg = ttnn.MemoryConfig(
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.BufferType.L1,
+            ttnn.ShardSpec(
+                grid,
+                (nhw // num_cores, self.Dv),
+                ttnn.ShardOrientation.ROW_MAJOR,
+            ),
+        )
+        src = (
+            new_rec
+            if new_rec.dtype == self.rec_state.dtype
+            else ttnn.typecast(new_rec, self.rec_state.dtype, memory_config=ttnn.L1_MEMORY_CONFIG)
+        )
+        sharded = ttnn.to_memory_config(src, shard_memcfg)
+        ttnn.experimental.slice_write(
+            sharded,
+            self.rec_state,
+            [0, 0, 0, 0],
+            [B, self.Nv, self.Dk, self.Dv],
+            [1, 1, 1, 1],
+        )
+        ttnn.deallocate(sharded)
+        if src is not new_rec:
+            ttnn.deallocate(src)
+        ttnn.deallocate(new_rec)
+
     def _write_index(self, buf, src, idx, dim):
         """Replace slice `idx` of `buf` along `dim` with `src` (extent 1 along `dim`), preserving
         the other slices, via an in-place copy into `buf`. Consumes `src` (and the temporary
@@ -971,17 +1021,34 @@ class TPGatedDeltaNet:
         )
 
     def forward_decode(self, x):
-        tw, B, Nk, Nv, Dk, Dv = self.tw, self.B, self.Nk, self.Nv, self.Dk, self.Dv
+        tw, Nk, Nv, Dk, Dv = self.tw, self.Nk, self.Nv, self.Dk, self.Dv
+        Bmax = self.B
         _L1 = ttnn.L1_MEMORY_CONFIG  # keep decode conv→recurrence→norm/gate chain L1-resident
         if self.conv_states is None:
             self.reset_state()
         if len(x.shape) == 4:
             x = ttnn.reshape(x, (1, x.shape[-2], x.shape[-1]))
 
+        # Active decode width, taken from the input. Normally == Bmax. BUCKETED decode: a request
+        # feeds B<Bmax tokens and the whole step runs on state rows [0:B]; idle rows [B:Bmax] are
+        # preserved. Conv taps are per-channel (broadcast over batch), so the conv weighted-sum
+        # works at any width. The B==Bmax path is byte-identical to before.
+        B = x.shape[-2]
+
         qkv, z, a, b = self._project_qkvzab(x, B, out_mc=_L1)
 
         # Conv1d shift-register + weighted sum + SiLU
         st = self.conv_states
+        if B < Bmax:
+            # Bucketed decode: active requests occupy a contiguous prefix [0:B]; idle rows [B:Bmax]
+            # hold no live request (a slot is re-initialized by prefill/write_slot when reused), so
+            # they are don't-care. Pad the width-B new input up to Bmax and run the SAME full-width
+            # shift-register as below -- the conv sum's active rows [0:B] are exact and the downstream
+            # q/k/v slices take [0:B]. This keeps the op COUNT identical to the baseline path (just a
+            # single pad), vs a per-row slice/concat that added ~4*K ops/layer and erased the width win.
+            qkv_p = ttnn.pad(qkv, [(0, 0), (0, Bmax - B), (0, 0)], value=0.0, memory_config=_L1)
+            ttnn.deallocate(qkv)
+            qkv = qkv_p
         for j in range(self.K - 1):
             ttnn.copy(st[j + 1], st[j])
         ttnn.copy(qkv, st[self.K - 1])
@@ -1015,6 +1082,7 @@ class TPGatedDeltaNet:
         g = ttnn.reshape(g, (B, 1, Nv))
 
         # fp32 decode step by default (QWEN35_GDN_DECODE_BF16=1 reverts)
+        init_state = self.rec_state if B == Bmax else self._slice_along(self.rec_state, 0, 0, B)
         o, new_rec = recurrent_gated_delta_rule_decode_ttnn(
             q,
             k,
@@ -1022,14 +1090,19 @@ class TPGatedDeltaNet:
             beta,
             g,
             scale=self.scale,
-            initial_state=self.rec_state,
+            initial_state=init_state,
             device=self.mesh,
             high_precision=(os.environ.get("QWEN35_GDN_DECODE_BF16") != "1"),
         )
+        if init_state is not self.rec_state:
+            ttnn.deallocate(init_state)
         if self._stable_state:
             # In-place update preserves rec_state address for decode trace replay
-            ttnn.copy(new_rec, self.rec_state)
-            ttnn.deallocate(new_rec)
+            if B == Bmax:
+                ttnn.copy(new_rec, self.rec_state)
+                ttnn.deallocate(new_rec)
+            else:
+                self._write_recurrent_state_prefix(new_rec, B)
         else:
             self.rec_state = new_rec
 
@@ -1045,7 +1118,7 @@ class TPGatedDeltaNet:
         partial = self._row_proj(gated, tw["out"])
         ttnn.deallocate(gated)
         partial = ttnn.reshape(partial, (1, 1, B, partial.shape[-1]))
-        return tt_all_reduce(
+        out = tt_all_reduce(
             partial,
             self.mesh,
             self.tt_ccl,
@@ -1054,3 +1127,4 @@ class TPGatedDeltaNet:
             topology=self.args.ccl_topology(),
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
+        return out

--- a/models/demos/blackhole/qwen36/tt/generator_interface.py
+++ b/models/demos/blackhole/qwen36/tt/generator_interface.py
@@ -1,11 +1,58 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
-"""Helpers for the Generator contract: pack the (cos,sin) rope pair into one
-tensor (copy_host_to_device cannot carry a nested tuple), and the shared
-short/long prefill dispatch (so the wrapper and demo define the seam once)."""
+"""Helpers for the Generator contract: RoPE packing, prefill dispatch, and decode warmup."""
+import gc
+import os
+
 import torch
+from loguru import logger
 
 import ttnn
+
+
+def warmup_decode_buckets(generator, warmup, *args, **kwargs):
+    """Compile every decode width before capturing any bucket trace."""
+    max_batch_size = kwargs.get("max_batch_size")
+    if os.environ.get("TT_DECODE_BUCKETING", "1") != "1" or not isinstance(max_batch_size, int) or max_batch_size <= 1:
+        return warmup(*args, **kwargs)
+
+    widths = []
+    width = 1
+    while width < max_batch_size:
+        widths.append(width)
+        width *= 2
+    widths.append(max_batch_size)
+
+    result = None
+    compile_key = (
+        tuple(widths),
+        kwargs.get("num_blocks"),
+        kwargs.get("can_sample_on_device"),
+        kwargs.get("greedy_only", False),
+    )
+    trace_enabled = kwargs.get("enable_trace", False)
+    if getattr(generator, "_decode_bucket_compile_key", None) != compile_key:
+        for width in widths:
+            bucket_kwargs = dict(kwargs, max_batch_size=width, enable_trace=False)
+            logger.info(f"Qwen decode compile warmup: bucket width={width}")
+            result = warmup(*args, **bucket_kwargs)
+        generator._decode_bucket_compile_key = compile_key
+
+    if not trace_enabled:
+        return result
+
+    ttnn.synchronize_device(generator.mesh_device)
+    gc.collect()
+    for width in widths:
+        bucket_kwargs = dict(
+            kwargs,
+            max_batch_size=width,
+            enable_trace=True,
+            skip_trace_precompile=True,
+        )
+        logger.info(f"Qwen decode trace capture: bucket width={width}")
+        result = warmup(*args, **bucket_kwargs)
+    return result
 
 
 def pack_rope_host(cos_host, sin_host):

--- a/models/demos/blackhole/qwen36/tt/mlp.py
+++ b/models/demos/blackhole/qwen36/tt/mlp.py
@@ -277,10 +277,14 @@ class Qwen36MLP:
             seq = x.shape[-2]
             # max_cols = device worker-grid width (11 on BH): wide grid (gate/up -> 9x10) vs old 8-wide.
             _gw = getattr(args, "decode_grid_w", 8)
+            # TP-selected prefill tuning; absent (single-device 9B) => frozen TP=4 behavior.
+            _pt = getattr(args, "prefill_tuning", None)
             pc_gate = tpc.create_prefill_mlp_matmul_program_config(
-                seq, args.dim, w.w1.shape[-1], fused_activation=ttnn.UnaryOpType.SILU, max_cols=_gw
+                seq, args.dim, w.w1.shape[-1], fused_activation=ttnn.UnaryOpType.SILU, max_cols=_gw, tuning=_pt
             )
-            pc_up = tpc.create_prefill_mlp_matmul_program_config(seq, args.dim, w.w3.shape[-1], max_cols=_gw)
+            pc_up = tpc.create_prefill_mlp_matmul_program_config(
+                seq, args.dim, w.w3.shape[-1], max_cols=_gw, tuning=_pt
+            )
             # L1 output (gate/up outputs; down output via mc_out below): +FPU, avoids the DRAM round-trip
             # (test_mlp_matmul_sweep_prefill *_outL1). The [seq,N] tensors fit L1 at the prefill chunk.
             w1_out = ttnn.linear(
@@ -321,7 +325,11 @@ class Qwen36MLP:
             # Prefill down-proj: subblock-tuned 2D config with the wide grid (max_cols=device width),
             # off the generic 8-wide prefill_progcfg. Output L1 via mc_w2_out below.
             w2_pc = tpc.create_prefill_mlp_matmul_program_config(
-                hidden.shape[-2], hidden.shape[-1], w.w2.shape[-1], max_cols=getattr(args, "decode_grid_w", 8)
+                hidden.shape[-2],
+                hidden.shape[-1],
+                w.w2.shape[-1],
+                max_cols=getattr(args, "decode_grid_w", 8),
+                tuning=getattr(args, "prefill_tuning", None),
             )
         # down-proj OUTPUT in L1 for the tuned prefill path (DRAM input `hidden` + L1 output = the
         # validated sweep outL1 config; tt_all_reduce already consumes an L1 partial).

--- a/models/demos/blackhole/qwen36/tt/model.py
+++ b/models/demos/blackhole/qwen36/tt/model.py
@@ -5,6 +5,7 @@
 tok_embeddings -> 32 x Qwen36DecoderLayer -> RMSNorm -> LM Head.
 Hybrid state: KV cache (8 attn layers) + recurrent state (24 DeltaNet layers).
 """
+
 import math
 import os
 
@@ -37,11 +38,12 @@ class Qwen36Model:
             self.tt_ccl = None
         self.configuration = args  # Generator reads model.configuration.max_seq_len
         self.sampling_dp = 1
-        # Rope is host-recomputed each step (not advanced on-device) → force the trace to refresh decode inputs (else stale rope).
+        # RoPE is host-recomputed each step, so refresh all decode trace inputs.
         self._tt_vllm_always_refresh_decode_trace_inputs = True
-        # Reuses the vocab-sharded lm_head as the sampler's shard: needs divisible vocab; 64K = top-k limit.
+        # On-device sampling: allowlist 1x4/1x8 TP only — vocab/TP must fit Top-K's 64K shard limit (TP=2 does not).
+        mesh_shape = tuple(int(dim) for dim in mesh_device.shape)
         self._supports_on_device_sampling = (
-            self.num_devices > 1
+            mesh_shape in ((1, 4), (1, 8))
             and args.vocab_size % self.num_devices == 0
             and (args.vocab_size // self.num_devices <= 64 * 1024)
         )
@@ -50,6 +52,11 @@ class Qwen36Model:
 
             # vocab/num_devices isn't a power of 2; the multi-device TopK kernel needs it padded.
             args.pad_logits_to_power_of_2 = True
+            # force_argmax (the cheap 1-all-gather greedy path) is enabled on the base
+            # SAMPLING_AG_CONFIG in model_config.py and runs IN-TRACE (faster than eager). Decode
+            # bucketing is made compatible with the in-trace sampler by namespacing the sampling
+            # trace per bucket width (SamplingGenerator.set_trace_bucket, driven from
+            # qwen36_vllm.decode_forward) — see generator._validate_trace_inputs.
             self.sampling = SamplingGenerator(args=args, mesh_device=mesh_device, tt_ccl=self.tt_ccl)
         else:
             self.sampling = None
@@ -3253,20 +3260,26 @@ class Qwen36Model:
 
     def process_output_decode(self, tt_out, B, S=1, is_tokens=False, is_log_probs=False):
         """Convert decode output to host torch. Host-sampling returns logits [B,S,vocab];
-        on-device sampling (is_tokens) returns sampled token ids. Log-probs out of scope.
+        on-device sampling returns sampled token ids or sampled-token log-probs.
         """
-        assert not is_log_probs, "on-device log-probs unsupported"
-        if is_tokens:
-            # Sampled ids are identical across devices; read one, flatten, take B.
+        if is_tokens or is_log_probs:
+            # Sampled ids and old-path sampled-token log-probs are replicated across devices.
             if self.num_devices > 1:
                 return ttnn.to_torch(ttnn.get_device_tensors(tt_out)[0]).reshape(-1)[:B]
             return ttnn.to_torch(tt_out).reshape(-1)[:B]
         if self.num_devices > 1:
             # TP: read one replica (get_device_tensors[0]), not ConcatMeshToTensor (~4x readback).
             full = ttnn.to_torch(ttnn.get_device_tensors(tt_out)[0]).float()
-            return full.reshape(-1, self.args.vocab_size)[: B * S].view(B, S, -1)
-        out = ttnn.to_torch(tt_out).float()
-        return out[:B, :S, : self.args.vocab_size].view(B, S, -1)
+        else:
+            full = ttnn.to_torch(tt_out).float()
+        rows = full.reshape(-1, self.args.vocab_size)
+        required_rows = B * S
+        if rows.shape[0] < required_rows:
+            # Decode bucketing returns only the active prefix. The shared
+            # generator requests the fixed serving width, so add neutral rows
+            # instead of splitting each vocabulary row during ``view(B, S, -1)``.
+            rows = torch.nn.functional.pad(rows, (0, 0, 0, required_rows - rows.shape[0]))
+        return rows[:required_rows].view(B, S, self.args.vocab_size)
 
     def _save_deltanet_states(self):
         """Snapshot GDN state to host (guard across decode-trace capture's double forward)."""

--- a/models/demos/blackhole/qwen36/tt/model_config.py
+++ b/models/demos/blackhole/qwen36/tt/model_config.py
@@ -19,6 +19,9 @@ GDN_CONV1D_L1_SMALL_SIZE = 24576
 class Qwen36ModelArgs(ModelArgs):
     """Qwen3.5-9B ModelArgs for Blackhole P150."""
 
+    # Opt into base ModelArgs TP > n_kv_heads path; attention/tp.py replicates via replicate_kv_weight.
+    SUPPORTS_KV_REPLICATION = True
+
     def __init__(
         self,
         mesh_device=None,
@@ -227,8 +230,9 @@ class Qwen36ModelArgs(ModelArgs):
 
         # Prefill matmul factory (M = seq_len)
         self._prefill_grid = tpc.prefill_grid_default()
+        self.prefill_tuning = tpc.prefill_tuning(tp)
         self.prefill_progcfg = lambda seq_len, k, n: tpc.create_prefill_matmul_program_config(
-            seq_len, k, n, grid_size=self._prefill_grid
+            seq_len, k, n, grid_size=self._prefill_grid, tuning=self.prefill_tuning
         )
 
         # Activation shard configs

--- a/models/demos/blackhole/qwen36/tt/qwen36_vllm.py
+++ b/models/demos/blackhole/qwen36/tt/qwen36_vllm.py
@@ -7,8 +7,10 @@ isn't position-general, so prefill is model-owned (masked-bucket for short promp
 trace for long, via prefill_dispatch) while Generator drives decode only. GDN + KV state is
 model-bound, so the kv_cache contract param is accepted but unused.
 """
+
 import math
 import os
+from collections import defaultdict
 from typing import Mapping, Optional
 
 import torch
@@ -23,7 +25,7 @@ from vllm.multimodal import MULTIMODAL_REGISTRY
 
 import ttnn
 from models.demos.blackhole.qwen36.tt.common import create_tt_model
-from models.demos.blackhole.qwen36.tt.generator_interface import prefill_dispatch
+from models.demos.blackhole.qwen36.tt.generator_interface import prefill_dispatch, warmup_decode_buckets
 from models.tt_transformers.tt.generator import Generator
 
 _PREFILL_WARMUP_CHUNK = 2048
@@ -46,6 +48,10 @@ class TT_Qwen3_5ProcessingInfo(Qwen3_5ProcessingInfo):
 class Qwen36ForCausalLM(Generator, SupportsMultiModal):
     """vLLM-compatible wrapper for Qwen3.5-9B on Blackhole P150."""
 
+    # Decode bucketing keeps several traces live and refreshes the selected
+    # bucket's inputs before replay, so their I/O buffers may safely overlap.
+    _tt_allow_decode_trace_buffer_reuse = True
+
     # supports_async_decode=False: async decode assumes on-device token/position continuity, which
     # corrupts Qwen's GDN scan. supports_sample_on_device=True: on-device sampling is decode-only.
     model_capabilities = {
@@ -53,6 +59,21 @@ class Qwen36ForCausalLM(Generator, SupportsMultiModal):
         "supports_async_decode": False,
         "supports_sample_on_device": True,
     }
+
+    def _validate_device_sampling_request(self, requested):
+        if not requested:
+            return
+        for model in self.model:
+            if model.sampling is not None:
+                continue
+            mesh_shape = tuple(int(dim) for dim in model.mesh_device.shape)
+            logits_per_device = math.ceil(model.args.vocab_size / model.num_devices)
+            raise RuntimeError(
+                "Qwen3.6 on-device sampling requires a certified TP topology (1x4 or 1x8) "
+                f"with at most 65536 logits/device; got mesh={mesh_shape}, "
+                f"vocab={model.args.vocab_size}, logits/device={logits_per_device}. "
+                "Unset sample_on_device_mode for host sampling."
+            )
 
     @classmethod
     def get_max_tokens_all_users(
@@ -183,11 +204,8 @@ class Qwen36ForCausalLM(Generator, SupportsMultiModal):
         """All prefill is model-owned (Generator drives decode only)."""
         model = self.model[0]
         if model.num_devices > 1 and model.args.max_batch_size > 1:
-            # Batched serving (max_num_seqs > 1): prefill each request in this step into its decode
-            # slot. Text-only — multimodal is single-sequence (get_supported_mm_limits: B=1). Check
-            # for REAL visual data (not just non-None): vLLM passes an empty pixel_values placeholder
-            # on text requests to a multimodal-registered model, which a bare `is None` check would
-            # misflag and crash the engine on every text request.
+            # Batched text prefill into decode slots (MM is B=1). Require real visual data, not a
+            # non-None empty pixel_values placeholder from vLLM on text requests.
             assert not self._has_visual(kwargs, "pixel_values") and not self._has_visual(
                 kwargs, "pixel_values_videos"
             ), (
@@ -291,6 +309,57 @@ class Qwen36ForCausalLM(Generator, SupportsMultiModal):
             slot_remap = kwargs.get("slot_remap")
             if slot_remap is not None:
                 model._remap_gdn_slots(slot_remap)
+        # Decode bucketing (default on; TT_DECODE_BUCKETING=0 off): slice host inputs to the
+        # smallest power-of-2 width >= active prefix [0:num_active) before the base forward.
+        # No runner edit / output re-pad — plugin reads unpadded_batch_size in slot order.
+        # Each width keeps its own trace metadata, inputs, and output.
+        args = list(args)
+
+        def _read(name, pos):
+            if name in kwargs:
+                return kwargs[name]
+            return args[pos] if pos < len(args) else None
+
+        def _write(name, pos, val):
+            if name in kwargs:
+                kwargs[name] = val
+            elif pos < len(args):
+                args[pos] = val
+
+        tokens = _read("tokens", 0)
+        if os.environ.get("TT_DECODE_BUCKETING", "1") == "1" and tokens is not None:
+            start_pos = _read("start_pos", 1)
+            width = int(tokens.shape[0])
+            num_active = int((start_pos != -1).sum()) if start_pos is not None else width
+            num_active = max(1, min(num_active, width))
+            bucket = min(width, 1 << max(0, (num_active - 1).bit_length()))  # smallest pow2 >= num_active
+            # Keep full width when slot_remap is set: remap indexes the full slot space (tokens /
+            # GDN). Rare (row moves only); bucketing resumes next step. Check kw + positional #10.
+            if _read("slot_remap", 10) is not None:
+                bucket = width
+            if bucket < width:
+                _write("tokens", 0, tokens[:bucket])
+                if start_pos is not None:
+                    _write("start_pos", 1, start_pos[:bucket])
+                page_table = _read("page_table", 2)
+                if page_table is not None:
+                    _write("page_table", 2, page_table[:bucket])
+                tokens = tokens[:bucket]
+
+        if tokens is not None:
+            B = int(tokens.shape[0])
+            store = getattr(self, "_bucket_trace_store", None)
+            if store is None:
+                store = self._bucket_trace_store = {}
+            if B not in store:
+                store[B] = (defaultdict(lambda: None), defaultdict(lambda: None), defaultdict(lambda: None))
+            self.trace_ids_decode, self.trace_inputs_decode, self.trace_output_decode = store[B]
+            # Key the sampling trace by bucket width too: Generator binds it to one logits tensor
+            # by identity, and each decode-bucket width has its own.
+            for _m in self.model:
+                _sm = getattr(_m, "sampling", None)
+                if _sm is not None and hasattr(_sm, "set_trace_bucket"):
+                    _sm.set_trace_bucket(B)
         return super().decode_forward(*args, **kwargs)
 
     def warmup_model_prefill(self, kv_cache, enable_trace, *args, **kwargs):
@@ -330,7 +399,8 @@ class Qwen36ForCausalLM(Generator, SupportsMultiModal):
                 model._unbind_gdn_prefill_scratch(prev)
 
     def warmup_model_decode(self, *args, **kwargs):
-        # Defer to WarmupForwardMixin, which captures the paged-SDPA + GDN decode trace at pos 0.
+        # Defer to WarmupForwardMixin, which warms the paged-SDPA + GDN decode path at pos 0.
         # Drop stale `non_greedy_decoding_on_device` from the old vLLM plugin; no-op for Qwen.
         kwargs.pop("non_greedy_decoding_on_device", None)
-        return super().warmup_model_decode(*args, **kwargs)
+        self._validate_device_sampling_request(kwargs.get("can_sample_on_device", False))
+        return warmup_decode_buckets(self, super().warmup_model_decode, *args, **kwargs)

--- a/models/demos/blackhole/qwen36/tt/tp_common.py
+++ b/models/demos/blackhole/qwen36/tt/tp_common.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
-"""TP helpers for Qwen3.5 on Blackhole (9B single-device + 27B TP=4).
+"""TP helpers for Qwen3.5/3.6 on Blackhole (9B single-device + 27B TP=4 / TP=8).
 
 Used only when num_devices > 1. DRAM-sharded matmul cfgs, prefill progcfgs,
 mesh shard/replicate, FP8 dequant, HF weight reorder for per-device sharding.
@@ -31,6 +31,41 @@ COMPUTE_HIFI2 = ttnn.WormholeComputeKernelConfig(
 def prefill_grid_default():
     """BH P150: (8,10); WH: (8,8). y capped at 10 on BH (grid_x=10 breaks matmul)."""
     return (8, 10) if is_blackhole() else (8, 8)
+
+
+# Max grid COLUMNS a tuned prefill config may use. A Blackhole galaxy reports a 12-wide worker
+# grid, but harvested P150s expose only 11, so tuning to 12 would not port. 11 x 10 = 110 cores.
+PREFILL_MAX_COLS_PORTABLE = 11
+
+# Why TP=8 wants different values (measured at S=2048, 27B, 1x8 Ring):
+#   * widest_cols -- `_best_prefill_cols` ranks candidate widths by (out_subblock_w, cols), i.e.
+#     subblock first. At TP=8 the halved N makes wide grids yield a small per_core_N and hence a
+#     narrow subblock, so that ranking retreats to fewer columns and leaves cores idle. Measured
+#     device time is monotonically decreasing in column count instead: attn_wo went 1944us @ 60
+#     cores -> 700us @ 110, and mlp_gate 2943us @ 60 -> 1935us @ 110. So take the width.
+#   * in0_block_w_divisor -- `min(cap, k_tiles // grid_x)` is a function of the per-device K, which
+#     halves. attn_wo/gdn_out go k_tiles 48 -> 24 and `24 // 11 = 2`, but in0_block_w only has to
+#     DIVIDE k_tiles, so a larger block is legal and much faster (attn_wo @ 11 cols, from the sweep:
+#     bw2 786us, bw4 719us, bw6 700us, bw8 705us).
+#
+# in0_block_w_cap is L1-BOUND, NOT just a legality bound. in0_block_w sizes the in0 circular
+# buffer, and `_wo_proj` / the MLP prefill arm write their OUTPUT to L1 (attention/tp.py:246,
+# mlp.py:284) -- so the CBs and a resident L1 output tensor compete for the same 1536 KB. Measured
+# on the real model: cap=8 overflows and test_model_tp_long_prefill dies with
+#   "Statically allocated circular buffers in program N clash with L1 buffers on core range
+#    [0-0 - 10-8]. L1 buffer allocated at 1314560 and static circular buffer region ends at 1372032"
+# from attention/tp.py:241. A standalone per-op sweep CANNOT see this: in isolation the only L1
+# tenant is the op under test, so it reports a win that the full model has no room for. Any future
+# raise of this cap must be validated by test_model_tp_long_prefill, not by the sweep alone.
+_PREFILL_TUNING = {
+    4: dict(widest_cols=False, in0_block_w_divisor=False, in0_block_w_cap=4),
+    8: dict(widest_cols=True, in0_block_w_divisor=True, in0_block_w_cap=4),
+}
+
+
+def prefill_tuning(num_devices):
+    """Prefill matmul tuning for this TP; unknown TP falls back to the frozen TP=4 values."""
+    return _PREFILL_TUNING.get(num_devices, _PREFILL_TUNING[4])
 
 
 def _roundup(a, b):
@@ -176,12 +211,14 @@ def _full_grid_crs(grid):
     return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(gx - 1, gy - 1))})
 
 
-def create_prefill_matmul_program_config(m, k, n, grid_size=None, fused_activation=None):
+def create_prefill_matmul_program_config(m, k, n, grid_size=None, fused_activation=None, tuning=None):
     """2D prefill matmul progcfg (DRAM-interleaved).
 
-    fused_activation in packer; sharded kernel rejects ttnn.linear(activation=...) with progcfg."""
+    fused_activation in packer; sharded kernel rejects ttnn.linear(activation=...) with progcfg.
+    tuning: a `_PREFILL_TUNING` entry (see `prefill_tuning`); None = the frozen TP=4 behavior."""
     if grid_size is None:
         grid_size = prefill_grid_default()
+    tuning = tuning or _PREFILL_TUNING[4]
     per_core_M = max(1, math.ceil(m / TILE_SIZE / grid_size[1]))
     per_core_N = max(1, math.ceil(n / TILE_SIZE / grid_size[0]))
 
@@ -189,7 +226,13 @@ def create_prefill_matmul_program_config(m, k, n, grid_size=None, fused_activati
     out_subblock_w = _get_out_subblock_w(per_core_N, out_subblock_h)
 
     k_tiles = math.ceil(k / TILE_SIZE)
-    in0_block_w = min(4, max(1, k_tiles // grid_size[0]))
+    cap = tuning["in0_block_w_cap"]
+    if tuning["in0_block_w_divisor"]:
+        # in0_block_w only has to divide k_tiles (no K tail in the 2D mcast kernel), so take the
+        # largest legal block rather than scaling with grid width -- see _PREFILL_TUNING.
+        in0_block_w = _find_largest_divisor(k_tiles, cap)
+    else:
+        in0_block_w = min(cap, max(1, k_tiles // grid_size[0]))
 
     return ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=grid_size,
@@ -202,6 +245,27 @@ def create_prefill_matmul_program_config(m, k, n, grid_size=None, fused_activati
         fused_activation=fused_activation,
         fuse_batch=False,
     )
+
+
+def _widest_prefill_cols(n, max_cols, subblock_slack=1):
+    """Widest grid whose output subblock stays within `subblock_slack` of the best achievable.
+
+    The TP=8 counterpart to `_best_prefill_cols`. More columns is usually a win at TP=8 (the halved
+    per-device N leaves cores idle), but NOT when the extra width collapses the subblock: measured
+    at S=2048, mlp_gate (N=2176 -> 68 tiles) goes cols 9 -> 11, per_core_N 8 -> 7, and 7 is prime so
+    out_subblock_w drops 4 -> 1 -- a 2058us -> 2118us REGRESSION, i.e. the subblock-first ranking
+    was right for that shape. Guarding on the subblock keeps the wide grid exactly where it pays:
+
+        matmul     default        this rule       measured
+        attn_wo    c10_bw2_sw4    c11_bw4_sw3     803.5 -> 718.7us
+        gdn_out    c10_bw2_sw4    c11_bw4_sw3     802.3 -> 719.9us
+        mlp_down   c10_bw4_sw4    c11_bw4_sw3    1787.4 -> 1724.9us
+        mlp_gate   c9_bw4_sw4     c9_bw4_sw4     2058.1us (unchanged -- already optimal)
+    """
+    n_tiles = math.ceil(n / TILE_SIZE)
+    sw = {cols: _get_out_subblock_w(math.ceil(n_tiles / cols), 1) for cols in range(1, max_cols + 1)}
+    floor = max(sw.values()) - subblock_slack
+    return max((cols for cols, w in sw.items() if w >= floor), default=1)
 
 
 def _best_prefill_cols(n, max_cols):
@@ -217,17 +281,31 @@ def _best_prefill_cols(n, max_cols):
     return best_cols
 
 
-def create_prefill_mlp_matmul_program_config(m, k, n, fused_activation=None, max_cols=None):
+def create_prefill_mlp_matmul_program_config(m, k, n, fused_activation=None, max_cols=None, tuning=None):
     """FPU-tuned 2D prefill progcfg for MLP matmuls: picks the grid width that maximizes the output
     subblock (drives prefill FPU) instead of the default full width.
 
     max_cols caps the grid width. Default = prefill_grid_default()[0] (8). Pass the device worker-grid
     width (11 on BH P150) to let the subblock heuristic go wide -> the measured prefill winners
     (gate 9-wide, down/wo 10-wide, gdn_qkvz 11-wide; test_mlp_matmul_sweep_prefill). Fused AG/RS paths
-    pin 8-wide separately and are unaffected."""
+    pin 8-wide separately and are unaffected.
+
+    tuning: a `_PREFILL_TUNING` entry. With `widest_cols` (TP=8) the subblock-first width heuristic
+    is replaced by "take the width, clamped to PREFILL_MAX_COLS_PORTABLE" -- measured device time at
+    TP=8 falls monotonically with column count, so trading cores for a wider subblock loses."""
     grid = prefill_grid_default()
-    cols = _best_prefill_cols(n, max_cols or grid[0])
-    return create_prefill_matmul_program_config(m, k, n, grid_size=(cols, grid[1]), fused_activation=fused_activation)
+    tuning = tuning or _PREFILL_TUNING[4]
+    limit = max_cols or grid[0]
+    if tuning["widest_cols"]:
+        # Cap the width at PREFILL_MAX_COLS_PORTABLE (harvested parts expose 11, not 12) and never
+        # exceed the output tile count -- columns beyond it get per_core_N=1 with nothing to compute,
+        # paying mcast cost for no work.
+        cols = _widest_prefill_cols(n, max(1, min(limit, PREFILL_MAX_COLS_PORTABLE, math.ceil(n / TILE_SIZE))))
+    else:
+        cols = _best_prefill_cols(n, limit)
+    return create_prefill_matmul_program_config(
+        m, k, n, grid_size=(cols, grid[1]), fused_activation=fused_activation, tuning=tuning
+    )
 
 
 # Mesh tensor helpers
@@ -243,6 +321,18 @@ def shard_w(torch_tensor, mesh, dim, memory_config, cache_path, dtype=ttnn.bfloa
         memory_config=memory_config,
         cache_file_name=cache_path,
     )
+
+
+def agmm_k_block_size(k_local, default=8):
+    """Largest power-of-2 K_block_size <= `default` that divides K_tiles/device (AGMM Ring has no tail).
+
+    TP=4: 1280->40 tiles->8; TP=8: 640->20 tiles->4. Odd divisors (e.g. 5|20) are unsafe on Ring.
+    """
+    k_tiles = k_local // TILE_SIZE
+    b = 1 << (min(default, max(1, k_tiles)).bit_length() - 1)
+    while b > 1 and k_tiles % b:
+        b //= 2
+    return b
 
 
 def all_gather_matmul_prefill(
@@ -271,7 +361,7 @@ def all_gather_matmul_prefill(
     workers = grid[0] // num_links
     cfg = ttnn.MinimalMatmulConfig(
         M_block_size=4,
-        K_block_size=8,
+        K_block_size=agmm_k_block_size(K_local),
         N_block_size=8,
         subblock_h=1,
         subblock_w=4,
@@ -315,7 +405,7 @@ def all_gather_swiglu_prefill(
     workers = grid[0] // num_links
     cfg = ttnn.MinimalMatmulConfig(
         M_block_size=8,
-        K_block_size=8,
+        K_block_size=agmm_k_block_size(K_local),
         N_block_size=16,
         subblock_h=1,
         subblock_w=4,

--- a/models/demos/blackhole/qwen36/tt/vision/vision_model_config.py
+++ b/models/demos/blackhole/qwen36/tt/vision/vision_model_config.py
@@ -21,6 +21,10 @@ class ModelOptimizations:
 
 
 class VisionModelArgs(ModelArgs):
+    # Base __init__ checks the TEXT config's 4 KV heads; the vision tower's own 16 MHA heads
+    # (set below) shard exactly at TP=8, so only the base check needs relaxing.
+    SUPPORTS_KV_REPLICATION = True
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/models/demos/utils/device_sku.py
+++ b/models/demos/utils/device_sku.py
@@ -25,6 +25,7 @@ def cluster_type_to_sku_name(cluster_type: ttnn.cluster.ClusterType) -> str:
         ttnn.cluster.ClusterType.P150: "bh_p150",
         ttnn.cluster.ClusterType.P300: "bh_p300",
         ttnn.cluster.ClusterType.P300_X2: "bh_quietbox_2",
+        ttnn.cluster.ClusterType.P150_X8: "bh_loudbox",
         ttnn.cluster.ClusterType.BLACKHOLE_GALAXY: "bh_galaxy_perf",
     }
 

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -49,6 +49,19 @@ SUPPORTED_PREFILL_BATCH_SIZES = (1, 2, 4, 8, 16, 32)
 DECODE_PAGE_TABLE_INPUT_IDX = 3
 
 
+def _mark_trace_buffers_corruptible(owner, value):
+    """Acknowledge opt-in trace I/O that another live trace may overwrite."""
+    if not getattr(owner, "_tt_allow_decode_trace_buffer_reuse", False) or value is None:
+        return
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            _mark_trace_buffers_corruptible(owner, item)
+        return
+    mark_corruptible = getattr(ttnn, "mark_corruptible", None)
+    if mark_corruptible is not None:
+        mark_corruptible(value)
+
+
 def max_prefill_chunk_size_cutoff(sequence_length, max_prefill_chunk_size):
     return sequence_length > max_prefill_chunk_size
 
@@ -1269,6 +1282,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         output_tokens: torch.Tensor | None = None,
         slot_remap=None,
         defer_device_sampling: bool = False,
+        skip_trace_precompile: bool = False,
         **kwargs,
     ):
         mode_switched = False
@@ -1382,6 +1396,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             tt_decode_output = self._decode_forward_trace_text(
                 **decode_kwargs,
                 reset_batch=reset_batch or mode_switched,
+                skip_precompile=skip_trace_precompile,
             )
         else:
             tt_decode_output = self._decode_forward_no_trace_text(
@@ -1402,6 +1417,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 output_tokens=output_tokens,
                 slot_remap=slot_remap,
                 enable_trace=enable_trace,
+                skip_precompile=skip_trace_precompile,
             )
         # Host sampling
         if read_from_device:
@@ -1470,20 +1486,21 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         page_table=None,
         kv_cache=None,
         on_device_sampling=False,
+        skip_precompile=False,
     ):
         """
         Captures a trace for the decode_forward method.
         """
 
-        # Compile run
-        self._decode_forward_no_trace_text(
-            tokens,
-            current_pos,
-            page_table=page_table,
-            kv_cache=kv_cache,
-            on_device_sampling=on_device_sampling,
-        )
-        logger.info("Done Compiling Model")
+        if not skip_precompile:
+            self._decode_forward_no_trace_text(
+                tokens,
+                current_pos,
+                page_table=page_table,
+                kv_cache=kv_cache,
+                on_device_sampling=on_device_sampling,
+            )
+            logger.info("Done Compiling Model")
 
         # Get inputs ready for trace run
         device_inputs = []
@@ -1495,8 +1512,8 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             host_inputs = self.model[i].prepare_decode_inputs_host(
                 tokens[i], current_pos[i], page_table=user_page_table
             )
-
             device_inputs_i = copy_host_to_device(host_inputs, mesh_device=self.model_args[i].mesh_device)
+            _mark_trace_buffers_corruptible(self, device_inputs_i)
             device_inputs.append(device_inputs_i)
 
         for i in range(self.data_parallel):
@@ -1527,6 +1544,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 )
             )
             ttnn.end_trace_capture(self.model_args[i].mesh_device, trace_id, cq_id=0)
+            _mark_trace_buffers_corruptible(self, tt_out_trace[-1])
 
             if sampling_trace_enabled:
                 # NOTE: sampling trace can be keyed depending on sampling params,
@@ -1540,7 +1558,11 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 # rank-2; ttnn.sampling requires a rank-4 preallocated output) —
                 # pass None so sampling allocates its own output.
                 tt_out_tok = self._decode_token_feedback_buffer(self.model[i], device_inputs[i])
-                sampling_module.capture_trace(logits=tt_out_trace[i], tt_out_tok=tt_out_tok)
+                sampling_module.capture_trace(
+                    logits=tt_out_trace[i],
+                    tt_out_tok=tt_out_tok,
+                    skip_precompile=skip_precompile,
+                )
         logger.info("Done Capturing Decode Trace")
 
         return trace_ids, tt_out_trace, *device_inputs
@@ -1553,6 +1575,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         kv_cache=None,
         on_device_sampling=False,
         reset_batch=False,
+        skip_precompile=False,
     ):
         """
         Run decode forward text with tracing
@@ -1560,7 +1583,12 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         # The trace is different depending on whether we are doing device sampling or not
         if not self.trace_ids_decode[on_device_sampling]:
             trace_ids, tt_out_trace, *device_inputs = self._capture_decode_trace_text(
-                tokens, current_pos, page_table=page_table, kv_cache=kv_cache, on_device_sampling=on_device_sampling
+                tokens,
+                current_pos,
+                page_table=page_table,
+                kv_cache=kv_cache,
+                on_device_sampling=on_device_sampling,
+                skip_precompile=skip_precompile,
             )
             self.trace_ids_decode[on_device_sampling] = trace_ids
             self.trace_inputs_decode[on_device_sampling] = device_inputs
@@ -1620,6 +1648,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         output_tokens: torch.Tensor | None = None,
         slot_remap=None,
         enable_trace=False,
+        skip_precompile=False,
     ):
         # sampling_dp may differ from data_parallel for models that internally
         # shard users across mesh rows (users_row_sharded) — each row samples
@@ -1695,7 +1724,13 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                     for chunk in model_chunks:
                         s = format_sampling_params(chunk, seed_bs).seed
                         seed_values += s if isinstance(s, list) else [s] * seed_bs
-                sampling_module.seed_manager.reset_seed_from_slots_if_needed(seed_values, active_seed_slots)
+                # reset_batch = first decode after prefill or a layout change: seed unconditionally,
+                # even for seed=None. ``decode_only`` mode never seeded the device, so the if_needed
+                # path matches the manager's initial None, early-returns, and replays one draw.
+                if reset_batch:
+                    sampling_module.seed_manager.reset_seed_from_slots(seed_values, active_seed_slots)
+                else:
+                    sampling_module.seed_manager.reset_seed_from_slots_if_needed(seed_values, active_seed_slots)
                 sampling_module.seed_manager.align_seed_counters_to_positions(
                     seed_values, active_seed_slots, start_values
                 )
@@ -1730,6 +1765,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                     logits=logits_i,
                     tt_out_tok=tt_out_tok,
                     enable_trace=sampling_enable_trace,
+                    skip_precompile=skip_precompile,
                 )
             )
         return sampled_outputs
@@ -2895,12 +2931,31 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                         except Exception:
                             pass
 
+            # Release all sampling traces, including every decode-bucket namespace.
+            for model in getattr(self, "model", []):
+                sampling_module = getattr(model, "sampling", None)
+                if sampling_module is not None and hasattr(sampling_module, "reset_trace"):
+                    try:
+                        sampling_module.reset_trace()
+                    except Exception:
+                        pass
+
             # Release decode traces
+            decode_trace_stores = []
+            for bucket_store in getattr(self, "_bucket_trace_store", {}).values():
+                if bucket_store is not None:
+                    decode_trace_stores.append(bucket_store[0])
             if hasattr(self, "trace_ids_decode"):
-                for sampling_key, trace_ids_dict in self.trace_ids_decode.items():
+                decode_trace_stores.append(self.trace_ids_decode)
+
+            released_decode_traces = set()
+            for trace_store in decode_trace_stores:
+                for sampling_key, trace_ids_dict in trace_store.items():
                     if trace_ids_dict is not None:
                         for model_id, trace_id in trace_ids_dict.items():
-                            if trace_id is not None:
+                            trace_key = (model_id, trace_id)
+                            if trace_id is not None and trace_key not in released_decode_traces:
+                                released_decode_traces.add(trace_key)
                                 try:
                                     ttnn.release_trace(self.model_args[model_id].mesh_device, trace_id)
                                 except Exception:

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -511,6 +511,9 @@ class ModelArgs:
 
     MAX_QKV_MM_SEQ_LEN = 2048
 
+    # Opt-in: False so TP > n_kv_heads stays a hard error unless a subclass implements KV replication.
+    SUPPORTS_KV_REPLICATION = False
+
     def __init__(
         self,
         mesh_device,
@@ -690,10 +693,22 @@ class ModelArgs:
                 self.n_heads % self.cluster_shape[1] == 0
             ), f"n_heads must be divisible by num_devices: {self.n_heads} % {self.cluster_shape[1]}"
 
-            assert self.n_kv_heads % self.cluster_shape[1] == 0, "n_kv_heads must be divisible by num_devices"
+            # KV heads normally split one-or-more per device. SUPPORTS_KV_REPLICATION models
+            # instead replicate a head across the devices holding its GQA query group, so they
+            # only need TP to be a whole multiple of n_kv_heads (e.g. 4 KV heads on TP=8 -> each
+            # head shared by a device pair). n_local_kv_heads is then 1, hence the max() below.
+            if self.SUPPORTS_KV_REPLICATION and self.cluster_shape[1] > self.n_kv_heads:
+                assert self.cluster_shape[1] % self.n_kv_heads == 0, (
+                    f"with KV replication, num_devices must be a multiple of n_kv_heads: "
+                    f"{self.cluster_shape[1]} % {self.n_kv_heads}"
+                )
+            else:
+                assert self.n_kv_heads % self.cluster_shape[1] == 0, "n_kv_heads must be divisible by num_devices"
             self.n_local_heads = self.n_heads // self.cluster_shape[1]
             self.qkv_size = self.head_dim * (2 * self.n_kv_heads + self.n_heads)
-            self.min_kv_prefill_shard_seqlen = (ttnn.TILE_SIZE * 8 * 8) / (self.n_kv_heads // self.cluster_shape[1])
+            self.min_kv_prefill_shard_seqlen = (ttnn.TILE_SIZE * 8 * 8) / max(
+                1, self.n_kv_heads // self.cluster_shape[1]
+            )
 
             # All Gather Matmul for Dense Out (DO) - computed flag stored as instance attribute
             # NOTE: Fused all gather matmul only supports a core grid of size num_devices x 1

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -194,6 +194,7 @@
     pytest --timeout 90 models/demos/blackhole/qwen36/tests/test_gdn_tp.py
     pytest --timeout 60 models/demos/blackhole/qwen36/tests/test_mlp_tp.py
     pytest --timeout 300 models/demos/blackhole/qwen36/tests/test_model_tp.py
+    pytest --timeout 300 models/demos/blackhole/qwen36/tests/test_decode_bucketing.py -k "test_bucket_warmup_compiles_all_widths_before_capture or test_all_buckets_fit_trace_region or test_bucket_trace_teardown_releases_all_stores"
     pytest --timeout 120 models/demos/blackhole/qwen36/tests/test_mlp.py
     pytest --timeout 120 models/demos/blackhole/qwen36/tests/test_patch_merger.py
     pytest --timeout 120 models/demos/blackhole/qwen36/tests/test_vision_attention.py


### PR DESCRIPTION
### Summary

- ~~Added async scheduling~~ - removed since it is dependent on vLLM PRs that are not yet merged
- Adds decode batch bucketing for Qwen3.6-27B. The model uses the smallest suitable batch size, so a single request stays fast even when the server supports high concurrency.
- Compiles all batch sizes before trace capture and safely keeps separate traces for each size.
- Preserves shared GDN and device state when the batch size changes.
- Fixes unseeded on-device sampling, which could repeat the same random result.
- Adds TP=8 support, including KV-head replication and TP-specific prefill tuning.
- Adds regression tests and CI coverage.
- Async scheduling is deferred until the required vLLM changes are ready.

### Changes to common files

- `models/common/sampling/generator.py`: Adds optional batch-size keys for sampling traces. Models that do not use bucketing keep the existing behavior.
- `models/tt_transformers/tt/generator.py`: Adds optional two-stage trace setup, correct seed initialization, and cleanup for all bucket traces. Buffer reuse is opt-in for Qwen.
- `models/common/warmup/warmup_utils.py`: Lets Qwen compile all batch sizes before trace capture. The default path is unchanged.
- `models/tt_transformers/tt/model_config.py`: Adds opt-in KV-head replication for TP configurations with more devices than KV heads. Other models still use the existing validation.
- `models/demos/utils/device_sku.py`: Adds the P150×8 LoudBox SKU mapping.
- `.github/workflows/vllm-model-tests-impl.yaml`: Disables thinking in the coherence check and increases its output limit.
- Common sampling tests verify that bucketed traces stay isolated without changing other models.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=atupe/qwen36-bucketing-fix-stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:atupe/qwen36-bucketing-fix-stable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=atupe/qwen36-bucketing-fix-stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:atupe/qwen36-bucketing-fix-stable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=atupe/qwen36-bucketing-fix-stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:atupe/qwen36-bucketing-fix-stable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=atupe/qwen36-bucketing-fix-stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:atupe/qwen36-bucketing-fix-stable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=atupe/qwen36-bucketing-fix-stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:atupe/qwen36-bucketing-fix-stable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=atupe/qwen36-bucketing-fix-stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:atupe/qwen36-bucketing-fix-stable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=atupe/qwen36-bucketing-fix-stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:atupe/qwen36-bucketing-fix-stable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=atupe/qwen36-bucketing-fix-stable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:atupe/qwen36-bucketing-fix-stable)
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
