### PR TITLE
Enable validate_program_args by default

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_config_defaults.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_config_defaults.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Locks the shipped defaults of ttnn.CONFIG that nothing else would notice being changed."""
+
+import ttnn
+
+
+def test_validate_program_args_defaults_on():
+    # Turning validation off only makes the runtime more permissive, so a revert of this default
+    # would not fail any other test — assert it here instead.
+    assert ttnn.CONFIG.validate_program_args is True
+
+    original = ttnn.CONFIG.validate_program_args
+    try:
+        ttnn.CONFIG.validate_program_args = False
+        assert ttnn.CONFIG.validate_program_args is False
+    finally:
+        ttnn.CONFIG.validate_program_args = original
+    assert ttnn.CONFIG.validate_program_args is True

--- a/ttnn/api/ttnn/config.hpp
+++ b/ttnn/api/ttnn/config.hpp
@@ -27,8 +27,8 @@ struct Config {
         bool enable_model_cache = false;
         bool enable_fast_runtime_mode = true;
         // Validate the Metal 2.0 host-side program args: the ProgramSpec on MakeProgramFromSpec and the
-        // ProgramRunArgs on Set/UpdateProgramRunArgs. Off by default; CI turns it on.
-        bool validate_program_args = false;
+        // ProgramRunArgs on Set/UpdateProgramRunArgs.
+        bool validate_program_args = true;
         bool throw_exception_on_fallback = false;
         bool enable_logging = false;
         bool enable_graph_report = false;


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Metal 2.0 host-side program args validation (the ProgramSpec on `MakeProgramFromSpec`, the ProgramRunArgs on `Set/UpdateProgramRunArgs`) was off by default and only enabled in the sanity pipelines via `TTNN_CONFIG_OVERRIDES`. Every other consumer ran with validation silently disabled.

### What's changed
Flip the `validate_program_args` default in `ttnn::Config` to `true`. Opting out is still available via `TTNN_CONFIG_OVERRIDES='{"validate_program_args": false}'`. The explicit `true` overrides in the sanity workflows are now redundant but left in place.

### Checklist
- [ ] CI passes

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/validate-program-args-default-on)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/validate-program-args-default-on)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/validate-program-args-default-on)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/validate-program-args-default-on)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/validate-program-args-default-on)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/validate-program-args-default-on)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/validate-program-args-default-on)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/validate-program-args-default-on)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/validate-program-args-default-on)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/validate-program-args-default-on)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/validate-program-args-default-on)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/validate-program-args-default-on)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/validate-program-args-default-on)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/validate-program-args-default-on)