### PR TITLE
[ttnn] Parse TTNN_CONFIG_OVERRIDES in C++ so pure C++ consumers honor it

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_config.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_config.py
@@ -16,11 +16,7 @@ import ttnn
 @pytest.fixture(autouse=True)
 def restore_config():
     config = ttnn._ttnn.CONFIG
-    original = {
-        key: getattr(config, key)
-        for key in dir(config)
-        if not key.startswith("_") and key != "report_path" and not callable(getattr(config, key))
-    }
+    original = {key: getattr(config, key) for key in ttnn.Config.keys()}
     yield
     for key, value in original.items():
         setattr(config, key, value)
@@ -50,9 +46,14 @@ def test_apply_json_overrides_null_clears_optional():
 
 
 def test_apply_json_overrides_unknown_key(expect_error):
-    with expect_error(RuntimeError, "Unknown configuration key"):
+    with expect_error(RuntimeError, "Unknown configuration key: no_such_key"):
         ttnn.CONFIG.apply_json_overrides('{"no_such_key": 1}')
     ttnn.CONFIG.apply_json_overrides('{"no_such_key": 1}', strict=False)
+
+
+def test_apply_json_overrides_names_the_source(expect_error):
+    with expect_error(RuntimeError, "from /some/config.json"):
+        ttnn.CONFIG.apply_json_overrides('{"no_such_key": 1}', source="/some/config.json")
 
 
 def test_apply_json_overrides_rejects_non_object(expect_error):
@@ -60,12 +61,47 @@ def test_apply_json_overrides_rejects_non_object(expect_error):
         ttnn.CONFIG.apply_json_overrides('["validate_program_args"]')
 
 
+def test_apply_json_overrides_rejects_malformed_json(expect_error):
+    with expect_error(RuntimeError, "not valid JSON"):
+        ttnn.CONFIG.apply_json_overrides('{"validate_program_args": true,}')
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        '{"enable_model_cache": true, "no_such_key": 1}',
+        '{"enable_model_cache": true, "comparison_mode_pcc": "0.5"}',
+    ],
+)
+def test_strict_failure_applies_nothing(bad, expect_error):
+    ttnn.CONFIG.enable_model_cache = False
+    with expect_error(RuntimeError, "configuration key"):
+        ttnn.CONFIG.apply_json_overrides(bad)
+    assert ttnn.CONFIG.enable_model_cache is False
+
+
+def test_non_strict_keeps_the_keys_that_parsed():
+    ttnn.CONFIG.enable_model_cache = False
+    pcc = ttnn.CONFIG.comparison_mode_pcc
+    ttnn.CONFIG.apply_json_overrides(
+        '{"enable_model_cache": true, "comparison_mode_pcc": "0.5", "no_such_key": 1}', strict=False
+    )
+    assert ttnn.CONFIG.enable_model_cache is True
+    assert ttnn.CONFIG.comparison_mode_pcc == pytest.approx(pcc)
+
+
 def test_load_config_from_dictionary(expect_error):
     ttnn.load_config_from_dictionary({"enable_model_cache": True})
     assert ttnn.CONFIG.enable_model_cache is True
-    with expect_error(RuntimeError, "Unknown configuration key"):
+    with expect_error(ValueError, "Unknown configuration key"):
         ttnn.load_config_from_dictionary({"no_such_key": 1})
     ttnn.load_config_from_dictionary({"no_such_key": 1}, from_file=True)
+
+
+def test_saved_config_holds_exactly_the_overridable_keys(tmp_path):
+    path = tmp_path / "config.json"
+    ttnn.save_config_to_json_file(path)
+    assert set(json.loads(path.read_text())) == set(ttnn.Config.keys())
 
 
 def test_config_file_round_trip(tmp_path):
@@ -78,17 +114,25 @@ def test_config_file_round_trip(tmp_path):
     assert ttnn.CONFIG.report_name == saved_report_name
 
 
+def run_python(script, extra_env):
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        env={**os.environ, **extra_env},
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+
+
 def load_raw_ttnn_module(extra_env):
     """Load _ttnn directly, bypassing ttnn/__init__.py, as a pure C++ consumer would."""
-    script = (
+    return run_python(
         "import importlib.util, sys\n"
         f"spec = importlib.util.spec_from_file_location('_ttnn', {ttnn._ttnn.__file__!r})\n"
         "m = importlib.util.module_from_spec(spec)\n"
         "spec.loader.exec_module(m)\n"
-        "print(m.CONFIG.validate_program_args)\n"
-    )
-    return subprocess.run(
-        [sys.executable, "-c", script], env={**os.environ, **extra_env}, capture_output=True, text=True, timeout=120
+        "print(m.CONFIG.validate_program_args)\n",
+        extra_env,
     )
 
 
@@ -98,6 +142,72 @@ def test_env_overrides_apply_without_python_init():
     assert result.stdout.strip() == "True"
 
 
-def test_env_overrides_unknown_key_fails_at_load():
-    result = load_raw_ttnn_module({"TTNN_CONFIG_OVERRIDES": '{"no_such_key": true}'})
-    assert result.returncode != 0
+@pytest.mark.parametrize(
+    "overrides, message",
+    [
+        ('{"no_such_key": true}', "Unknown configuration key: no_such_key"),
+        ('{"validate_program_args": true,}', "not valid JSON"),
+        ('{"validate_program_args": 1}', "Bad value for configuration key validate_program_args"),
+    ],
+)
+def test_bad_env_overrides_exit_cleanly_at_load(overrides, message):
+    result = load_raw_ttnn_module({"TTNN_CONFIG_OVERRIDES": overrides})
+    # Exit code, not a signal: the load-time throw must not reach std::terminate/SIGABRT.
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert message in result.stdout
+    assert "TTNN_CONFIG_OVERRIDES" in result.stdout
+
+
+def test_config_file_applies_without_python_init(tmp_path):
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"validate_program_args": True}))
+    result = load_raw_ttnn_module({"TTNN_CONFIG_PATH": str(path)})
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert result.stdout.strip().splitlines()[-1] == "True"
+
+
+def test_missing_config_file_is_seeded_with_defaults_without_python_init(tmp_path):
+    path = tmp_path / "nested" / "config.json"
+    result = load_raw_ttnn_module(
+        {"TTNN_CONFIG_PATH": str(path), "TTNN_CONFIG_OVERRIDES": '{"validate_program_args": true}'}
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    saved = json.loads(path.read_text())
+    assert set(saved) == set(ttnn.Config.keys())
+    # The env override applies to the process but must not be baked into the file as a default.
+    assert saved["validate_program_args"] is False
+    assert result.stdout.strip().splitlines()[-1] == "True"
+
+
+def test_stale_config_file_key_warns_and_keeps_the_rest(tmp_path):
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"report_path": "generated", "validate_program_args": True}))
+    result = load_raw_ttnn_module({"TTNN_CONFIG_PATH": str(path)})
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Unknown configuration key: report_path" in result.stdout
+    assert result.stdout.strip().splitlines()[-1] == "True"
+
+
+def test_corrupt_config_file_does_not_fail_the_load(tmp_path):
+    path = tmp_path / "config.json"
+    path.write_text("{not json")
+    result = load_raw_ttnn_module({"TTNN_CONFIG_PATH": str(path)})
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Failed to load ttnn configuration" in result.stdout
+
+
+def test_env_overrides_take_precedence_over_the_config_file(tmp_path):
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps({"enable_model_cache": True, "validate_program_args": True}))
+    result = run_python(
+        "import ttnn; print(ttnn.CONFIG.enable_model_cache, ttnn.CONFIG.validate_program_args)",
+        {"TTNN_CONFIG_PATH": str(path), "TTNN_CONFIG_OVERRIDES": '{"enable_model_cache": false}'},
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip().splitlines()[-1] == "False True"
+
+
+def test_env_overrides_are_validated_once_per_process():
+    result = run_python("import ttnn", {"TTNN_CONFIG_OVERRIDES": '{"enable_logging": true}'})
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.count("Logging cannot be enabled in fast runtime mode") == 1

--- a/tests/ttnn/unit_tests/base_functionality/test_config.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_config.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+import ttnn
+
+
+@pytest.fixture(autouse=True)
+def restore_config():
+    config = ttnn._ttnn.CONFIG
+    original = {
+        key: getattr(config, key)
+        for key in dir(config)
+        if not key.startswith("_") and key != "report_path" and not callable(getattr(config, key))
+    }
+    yield
+    for key, value in original.items():
+        setattr(config, key, value)
+
+
+def test_apply_json_overrides():
+    ttnn.CONFIG.apply_json_overrides(
+        json.dumps(
+            {
+                "validate_program_args": True,
+                "comparison_mode_pcc": 0.5,
+                "tmp_dir": "/tmp/ttnn-test",
+                "report_name": "config test",
+            }
+        )
+    )
+    assert ttnn.CONFIG.validate_program_args is True
+    assert ttnn.CONFIG.comparison_mode_pcc == pytest.approx(0.5)
+    assert ttnn.CONFIG.tmp_dir == pathlib.Path("/tmp/ttnn-test")
+    assert ttnn.CONFIG.report_name == pathlib.Path("config test")
+
+
+def test_apply_json_overrides_null_clears_optional():
+    ttnn.CONFIG.apply_json_overrides('{"report_name": "something"}')
+    ttnn.CONFIG.apply_json_overrides('{"report_name": null}')
+    assert ttnn.CONFIG.report_name is None
+
+
+def test_apply_json_overrides_unknown_key(expect_error):
+    with expect_error(RuntimeError, "Unknown configuration key"):
+        ttnn.CONFIG.apply_json_overrides('{"no_such_key": 1}')
+    ttnn.CONFIG.apply_json_overrides('{"no_such_key": 1}', strict=False)
+
+
+def test_apply_json_overrides_rejects_non_object(expect_error):
+    with expect_error(RuntimeError, "must be a JSON object"):
+        ttnn.CONFIG.apply_json_overrides('["validate_program_args"]')
+
+
+def test_load_config_from_dictionary(expect_error):
+    ttnn.load_config_from_dictionary({"enable_model_cache": True})
+    assert ttnn.CONFIG.enable_model_cache is True
+    with expect_error(RuntimeError, "Unknown configuration key"):
+        ttnn.load_config_from_dictionary({"no_such_key": 1})
+    ttnn.load_config_from_dictionary({"no_such_key": 1}, from_file=True)
+
+
+def test_config_file_round_trip(tmp_path):
+    path = tmp_path / "config.json"
+    ttnn.save_config_to_json_file(path)
+    saved_report_name = ttnn.CONFIG.report_name
+    ttnn.CONFIG.enable_model_cache = True
+    ttnn.load_config_from_json_file(path)
+    assert ttnn.CONFIG.enable_model_cache is False
+    assert ttnn.CONFIG.report_name == saved_report_name
+
+
+def load_raw_ttnn_module(extra_env):
+    """Load _ttnn directly, bypassing ttnn/__init__.py, as a pure C++ consumer would."""
+    script = (
+        "import importlib.util, sys\n"
+        f"spec = importlib.util.spec_from_file_location('_ttnn', {ttnn._ttnn.__file__!r})\n"
+        "m = importlib.util.module_from_spec(spec)\n"
+        "spec.loader.exec_module(m)\n"
+        "print(m.CONFIG.validate_program_args)\n"
+    )
+    return subprocess.run(
+        [sys.executable, "-c", script], env={**os.environ, **extra_env}, capture_output=True, text=True, timeout=120
+    )
+
+
+def test_env_overrides_apply_without_python_init():
+    result = load_raw_ttnn_module({"TTNN_CONFIG_OVERRIDES": '{"validate_program_args": true}'})
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "True"
+
+
+def test_env_overrides_unknown_key_fails_at_load():
+    result = load_raw_ttnn_module({"TTNN_CONFIG_OVERRIDES": '{"no_such_key": true}'})
+    assert result.returncode != 0

--- a/ttnn/api/ttnn/config.hpp
+++ b/ttnn/api/ttnn/config.hpp
@@ -87,6 +87,10 @@ public:
     // Defined in config.cpp (uses tt-logger).
     void validate(std::string_view name) const;
 
+    // Applies a JSON object of attribute overrides (the TTNN_CONFIG_OVERRIDES format).
+    // Unknown keys throw when strict, warn otherwise. Defined in config.cpp.
+    void apply_json_overrides(const std::string& json_text, bool strict = true);
+
     // Returns all config attributes as key-value pairs for Inspector.
     // Defined in config.cpp (uses reflection for_each).
     std::vector<std::pair<std::string, std::string>> get_config_entries() const;

--- a/ttnn/api/ttnn/config.hpp
+++ b/ttnn/api/ttnn/config.hpp
@@ -87,9 +87,20 @@ public:
     // Defined in config.cpp (uses tt-logger).
     void validate(std::string_view name) const;
 
-    // Applies a JSON object of attribute overrides (the TTNN_CONFIG_OVERRIDES format).
-    // Unknown keys throw when strict, warn otherwise. Defined in config.cpp.
-    void apply_json_overrides(const std::string& json_text, bool strict = true);
+    // Applies a JSON object of attribute overrides (the TTNN_CONFIG_OVERRIDES format). Unknown keys and
+    // bad values throw when strict (applying nothing) and are skipped with a warning otherwise.
+    // `source` names the origin (env var, file path) in those messages. Defined in config.cpp.
+    void apply_json_overrides(const std::string& json_text, bool strict = true, const std::string& source = {});
+
+    // Names of the overridable attributes, so callers need not filter dir(CONFIG). Defined in config.cpp.
+    static std::vector<std::string> keys();
+
+    // Applies a config file written by save_to_file (the TTNN_CONFIG_PATH format). A stale or corrupt file
+    // warns and leaves the parsed keys applied rather than failing the process. Defined in config.cpp.
+    void load_from_file(const std::filesystem::path& path);
+
+    // Writes the overridable attributes as JSON, in the format load_from_file reads. Defined in config.cpp.
+    void save_to_file(const std::filesystem::path& path) const;
 
     // Returns all config attributes as key-value pairs for Inspector.
     // Defined in config.cpp (uses reflection for_each).

--- a/ttnn/core/config.cpp
+++ b/ttnn/core/config.cpp
@@ -24,33 +24,50 @@ namespace ttnn::core {
 Config CONFIG{};
 
 void Config::apply_json_overrides(const std::string& json_text, bool strict) {
-    auto json = nlohmann::json::parse(json_text);
+    nlohmann::json json;
+    try {
+        json = nlohmann::json::parse(json_text);
+    } catch (const nlohmann::json::exception& e) {
+        // Reached from a static initializer, so name the source instead of surfacing a bare parser error.
+        TT_THROW("TTNN config overrides are not valid JSON: {} (input: {})", e.what(), json_text);
+    }
     TT_FATAL(json.is_object(), "TTNN config overrides must be a JSON object, got: {}", json_text);
-    reflect::for_each(
-        [&](auto I) {
-            auto name = reflect::member_name<I>(this->attributes);
-            auto it = json.find(std::string(name));
-            if (it == json.end()) {
-                return;
+
+    // Restore on any failure: a rejected override must not leave process-wide settings half applied.
+    attributes_t previous = this->attributes;
+    try {
+        reflect::for_each(
+            [&](auto I) {
+                auto name = reflect::member_name<I>(this->attributes);
+                auto it = json.find(std::string(name));
+                if (it == json.end()) {
+                    return;
+                }
+                auto& member = reflect::get<I>(this->attributes);
+                using T = std::decay_t<decltype(member)>;
+                if constexpr (std::is_same_v<T, bool> || std::is_same_v<T, float>) {
+                    member = it->template get<T>();
+                } else if constexpr (std::is_same_v<T, std::optional<std::filesystem::path>>) {
+                    member = it->is_null() ? T{} : T{it->template get<std::string>()};
+                } else {
+                    member = std::filesystem::path(it->template get<std::string>());
+                }
+                this->validate(name);
+                json.erase(it);
+            },
+            this->attributes);
+        for (const auto& [key, value] : json.items()) {
+            if (strict) {
+                TT_THROW("Unknown configuration key: {}", key);
             }
-            auto& member = reflect::get<I>(this->attributes);
-            using T = std::decay_t<decltype(member)>;
-            if constexpr (std::is_same_v<T, bool> || std::is_same_v<T, float>) {
-                member = it->template get<T>();
-            } else if constexpr (std::is_same_v<T, std::optional<std::filesystem::path>>) {
-                member = it->is_null() ? T{} : T{it->template get<std::string>()};
-            } else {
-                member = std::filesystem::path(it->template get<std::string>());
-            }
-            this->validate(name);
-            json.erase(it);
-        },
-        this->attributes);
-    for (const auto& [key, value] : json.items()) {
-        if (strict) {
-            TT_THROW("Unknown configuration key: {}", key);
+            log_warning(tt::LogAlways, "Unknown configuration key: {}", key);
         }
-        log_warning(tt::LogAlways, "Unknown configuration key: {}", key);
+    } catch (const nlohmann::json::exception& e) {
+        this->attributes = std::move(previous);
+        TT_THROW("TTNN config override has a bad value: {} (input: {})", e.what(), json_text);
+    } catch (...) {
+        this->attributes = std::move(previous);
+        throw;
     }
 }
 

--- a/ttnn/core/config.cpp
+++ b/ttnn/core/config.cpp
@@ -6,19 +6,62 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdlib>
 #include <iomanip>
 #include <ostream>
 #include <sstream>
 
 #include <fmt/format.h>
+#include <nlohmann/json.hpp>
 #include <reflect>
 #include <tt-logger/tt-logger.hpp>
+#include <tt_stl/assert.hpp>
 #include <tt_stl/reflection.hpp>
 #include <tt-metalium/experimental/inspector_config.hpp>
 
 namespace ttnn::core {
 
 Config CONFIG{};
+
+void Config::apply_json_overrides(const std::string& json_text, bool strict) {
+    auto json = nlohmann::json::parse(json_text);
+    TT_FATAL(json.is_object(), "TTNN config overrides must be a JSON object, got: {}", json_text);
+    reflect::for_each(
+        [&](auto I) {
+            auto name = reflect::member_name<I>(this->attributes);
+            auto it = json.find(std::string(name));
+            if (it == json.end()) {
+                return;
+            }
+            auto& member = reflect::get<I>(this->attributes);
+            using T = std::decay_t<decltype(member)>;
+            if constexpr (std::is_same_v<T, bool> || std::is_same_v<T, float>) {
+                member = it->template get<T>();
+            } else if constexpr (std::is_same_v<T, std::optional<std::filesystem::path>>) {
+                member = it->is_null() ? T{} : T{it->template get<std::string>()};
+            } else {
+                member = std::filesystem::path(it->template get<std::string>());
+            }
+            this->validate(name);
+            json.erase(it);
+        },
+        this->attributes);
+    for (const auto& [key, value] : json.items()) {
+        if (strict) {
+            TT_THROW("Unknown configuration key: {}", key);
+        }
+        log_warning(tt::LogAlways, "Unknown configuration key: {}", key);
+    }
+}
+
+// Parse TTNN_CONFIG_OVERRIDES at load so pure C++ consumers (e.g. the sanity-pipeline gtests) honor
+// it too; ttnn/__init__.py applies overrides through the same function.
+static const int apply_env_config_overrides = [] {
+    if (const char* overrides = std::getenv("TTNN_CONFIG_OVERRIDES")) {
+        CONFIG.apply_json_overrides(overrides, /*strict=*/true);
+    }
+    return 0;
+}();
 
 std::vector<std::pair<std::string, std::string>> Config::get_config_entries() const {
     std::vector<std::pair<std::string, std::string>> entries;

--- a/ttnn/core/config.cpp
+++ b/ttnn/core/config.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdlib>
+#include <fstream>
 #include <iomanip>
 #include <ostream>
 #include <sstream>
@@ -23,59 +24,137 @@ namespace ttnn::core {
 
 Config CONFIG{};
 
-void Config::apply_json_overrides(const std::string& json_text, bool strict) {
+void Config::apply_json_overrides(const std::string& json_text, bool strict, const std::string& source) {
+    const std::string from = source.empty() ? std::string{} : fmt::format(" (from {})", source);
     nlohmann::json json;
     try {
         json = nlohmann::json::parse(json_text);
     } catch (const nlohmann::json::exception& e) {
-        // Reached from a static initializer, so name the source instead of surfacing a bare parser error.
-        TT_THROW("TTNN config overrides are not valid JSON: {} (input: {})", e.what(), json_text);
+        // Wrapped: a bare nlohmann parse error does not say that TTNN config is what failed.
+        TT_THROW("TTNN config overrides are not valid JSON: {}{}", e.what(), from);
     }
-    TT_FATAL(json.is_object(), "TTNN config overrides must be a JSON object, got: {}", json_text);
+    TT_FATAL(json.is_object(), "TTNN config overrides must be a JSON object, got: {}{}", json_text, from);
 
-    // Restore on any failure: a rejected override must not leave process-wide settings half applied.
-    attributes_t previous = this->attributes;
-    try {
+    // Apply into a copy so a strict rejection leaves process-wide settings untouched.
+    attributes_t next = this->attributes;
+    std::vector<std::string_view> applied;
+    for (const auto& [key, value] : json.items()) {
+        bool known = false;
         reflect::for_each(
             [&](auto I) {
-                auto name = reflect::member_name<I>(this->attributes);
-                auto it = json.find(std::string(name));
-                if (it == json.end()) {
+                auto name = reflect::member_name<I>(next);
+                if (name != key) {
                     return;
                 }
-                auto& member = reflect::get<I>(this->attributes);
+                known = true;
+                auto& member = reflect::get<I>(next);
                 using T = std::decay_t<decltype(member)>;
-                if constexpr (std::is_same_v<T, bool> || std::is_same_v<T, float>) {
-                    member = it->template get<T>();
-                } else if constexpr (std::is_same_v<T, std::optional<std::filesystem::path>>) {
-                    member = it->is_null() ? T{} : T{it->template get<std::string>()};
-                } else {
-                    member = std::filesystem::path(it->template get<std::string>());
+                try {
+                    if constexpr (std::is_same_v<T, std::filesystem::path>) {
+                        member = T{value.get<std::string>()};
+                    } else if constexpr (std::is_same_v<T, std::optional<std::filesystem::path>>) {
+                        member = value.is_null() ? T{} : T{value.get<std::string>()};
+                    } else {
+                        static_assert(
+                            std::is_arithmetic_v<T> || std::is_same_v<T, std::string>,
+                            "Config attribute type needs a JSON conversion in apply_json_overrides");
+                        member = value.get<T>();
+                    }
+                } catch (const nlohmann::json::exception& e) {
+                    // Strict callers get nothing applied; a config file keeps the keys that did parse.
+                    if (strict) {
+                        TT_THROW("Bad value for configuration key {}: {}{}", key, e.what(), from);
+                    }
+                    log_warning(tt::LogAlways, "Ignoring configuration key {}: {}{}", key, e.what(), from);
+                    return;
                 }
-                this->validate(name);
-                json.erase(it);
+                applied.push_back(name);
             },
-            this->attributes);
-        for (const auto& [key, value] : json.items()) {
+            next);
+        if (!known) {
             if (strict) {
-                TT_THROW("Unknown configuration key: {}", key);
+                TT_THROW("Unknown configuration key: {}{}", key, from);
             }
-            log_warning(tt::LogAlways, "Unknown configuration key: {}", key);
+            log_warning(tt::LogAlways, "Unknown configuration key: {}{}", key, from);
         }
-    } catch (const nlohmann::json::exception& e) {
-        this->attributes = std::move(previous);
-        TT_THROW("TTNN config override has a bad value: {} (input: {})", e.what(), json_text);
-    } catch (...) {
-        this->attributes = std::move(previous);
-        throw;
+    }
+
+    this->attributes = std::move(next);
+    for (std::string_view name : applied) {
+        this->validate(name);
     }
 }
 
-// Parse TTNN_CONFIG_OVERRIDES at load so pure C++ consumers (e.g. the sanity-pipeline gtests) honor
-// it too; ttnn/__init__.py applies overrides through the same function.
-static const int apply_env_config_overrides = [] {
-    if (const char* overrides = std::getenv("TTNN_CONFIG_OVERRIDES")) {
-        CONFIG.apply_json_overrides(overrides, /*strict=*/true);
+std::vector<std::string> Config::keys() {
+    std::vector<std::string> names;
+    reflect::for_each<attributes_t>([&](auto I) { names.emplace_back(reflect::member_name<I, attributes_t>()); });
+    return names;
+}
+
+void Config::load_from_file(const std::filesystem::path& path) {
+    std::ifstream file(path);
+    if (!file.is_open()) {
+        log_warning(tt::LogAlways, "Failed to load ttnn configuration from {}: cannot open the file", path.string());
+        return;
+    }
+    std::stringstream text;
+    text << file.rdbuf();
+    try {
+        this->apply_json_overrides(
+            text.str(),
+            /*strict=*/false,
+            fmt::format("{}; update or delete it to get the new default config", path.string()));
+    } catch (const std::exception& e) {
+        // A stale or corrupt file must not fail the process, and this also runs at library load.
+        log_warning(tt::LogAlways, "Failed to load ttnn configuration from {}: {}", path.string(), e.what());
+    }
+}
+
+void Config::save_to_file(const std::filesystem::path& path) const {
+    nlohmann::ordered_json json;
+    reflect::for_each(
+        [&](auto I) {
+            const auto& member = reflect::get<I>(this->attributes);
+            using T = std::decay_t<decltype(member)>;
+            auto name = std::string(reflect::member_name<I>(this->attributes));
+            if constexpr (std::is_same_v<T, std::filesystem::path>) {
+                json[name] = member.string();
+            } else if constexpr (std::is_same_v<T, std::optional<std::filesystem::path>>) {
+                json[name] = member.has_value() ? nlohmann::ordered_json(member->string()) : nlohmann::ordered_json();
+            } else {
+                json[name] = member;
+            }
+        },
+        this->attributes);
+    std::ofstream file(path);
+    TT_FATAL(file.is_open(), "Failed to open {} to save the TTNN configuration", path.string());
+    file << json.dump(4);
+}
+
+// Apply both config sources at load so pure C++ consumers (e.g. the sanity-pipeline gtests) honor them
+// too, in the order ttnn/__init__.py used to: the file first, then the env var on top.
+static const int apply_env_config = [] {
+    try {
+        if (const char* config_path = std::getenv("TTNN_CONFIG_PATH")) {
+            const std::filesystem::path path{config_path};
+            if (std::filesystem::exists(path)) {
+                CONFIG.load_from_file(path);
+            } else {
+                if (path.has_parent_path()) {
+                    std::filesystem::create_directories(path.parent_path());
+                }
+                Config{}.save_to_file(path);
+            }
+        }
+        if (const char* overrides = std::getenv("TTNN_CONFIG_OVERRIDES")) {
+            CONFIG.apply_json_overrides(overrides, /*strict=*/true, "TTNN_CONFIG_OVERRIDES");
+        }
+    } catch (const std::exception& e) {
+        // Nothing can catch this early (dlopen, pre-main), so fail here with the reason.
+        // _Exit, not exit: running atexit handlers here deadlocks against the loader lock.
+        log_critical(tt::LogAlways, "Cannot apply the TTNN configuration: {}", e.what());
+        std::fflush(nullptr);
+        std::_Exit(1);
     }
     return 0;
 }();

--- a/ttnn/cpp/ttnn-nanobind/core.cpp
+++ b/ttnn/cpp/ttnn-nanobind/core.cpp
@@ -73,6 +73,8 @@ void py_module(nb::module_& mod) {
             &ttnn::Config::set<I>);
     });
     py_config.def_prop_ro("report_path", &ttnn::Config::get<"report_path">);
+    py_config.def(
+        "apply_json_overrides", &ttnn::Config::apply_json_overrides, nb::arg("json_text"), nb::arg("strict") = true);
 
     nb::class_<lightmetal::LightMetalBinary>(mod, "LightMetalBinary")
         .def(nb::init<>())

--- a/ttnn/cpp/ttnn-nanobind/core.cpp
+++ b/ttnn/cpp/ttnn-nanobind/core.cpp
@@ -63,7 +63,7 @@ void py_module(nb::module_& mod) {
     namespace lightmetal = tt::tt_metal::experimental::lightmetal;
 
     auto py_config = static_cast<nb::class_<ttnn::Config>>(mod.attr("Config"));
-    py_config.def(nb::init<const ttnn::Config&>()).def("__repr__", [](const ttnn::Config& config) {
+    py_config.def(nb::init<>()).def(nb::init<const ttnn::Config&>()).def("__repr__", [](const ttnn::Config& config) {
         return fmt::format("{}", config);
     });
     reflect::for_each<ttnn::Config::attributes_t>([&py_config](auto I) {
@@ -74,7 +74,14 @@ void py_module(nb::module_& mod) {
     });
     py_config.def_prop_ro("report_path", &ttnn::Config::get<"report_path">);
     py_config.def(
-        "apply_json_overrides", &ttnn::Config::apply_json_overrides, nb::arg("json_text"), nb::arg("strict") = true);
+        "apply_json_overrides",
+        &ttnn::Config::apply_json_overrides,
+        nb::arg("json_text"),
+        nb::arg("strict") = true,
+        nb::arg("source") = "");
+    py_config.def_static("keys", &ttnn::Config::keys);
+    py_config.def("load_from_file", &ttnn::Config::load_from_file, nb::arg("path"));
+    py_config.def("save_to_file", &ttnn::Config::save_to_file, nb::arg("path"));
 
     nb::class_<lightmetal::LightMetalBinary>(mod, "LightMetalBinary")
         .def(nb::init<>())

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -8,7 +8,6 @@ import importlib
 import os
 import pathlib
 import pkgutil
-import re
 import sys
 from types import ModuleType
 
@@ -25,48 +24,24 @@ if "TTNN_CONFIG_PATH" in os.environ:
 CONFIG_OVERRIDES = os.environ.get("TTNN_CONFIG_OVERRIDES", None)
 
 
-def load_config_from_dictionary(config, from_file=False):
-    CONFIG.apply_json_overrides(json.dumps(config, default=str), strict=not from_file)
+def load_config_from_dictionary(config, from_file=False, source=None):
+    try:
+        CONFIG.apply_json_overrides(json.dumps(config, default=str), strict=not from_file, source=str(source or ""))
+    except RuntimeError as e:
+        # Keep raising ValueError as this function always has; TT_THROW surfaces as RuntimeError.
+        raise ValueError(str(e)) from e
 
 
 def load_config_from_json_file(json_path):
-    global CONFIG
-    try:
-        with open(json_path, "r") as f:
-            config = json.load(f)
-        load_config_from_dictionary(config, from_file=True)
-    except Exception as e:
-        logger.warning(f"Failed to load ttnn configuration from {json_path}: {e}")
+    CONFIG.load_from_file(pathlib.Path(json_path))
 
 
 def save_config_to_json_file(json_path):
-    with open(json_path, "w") as f:
-        normalized_config = {}
-        for key in dir(CONFIG):
-            if re.match("^_.+_$", key):
-                continue
-            value = getattr(CONFIG, key)
-            if callable(value):
-                continue
-            if isinstance(value, pathlib.Path):
-                value = str(value)
-            normalized_config[key] = value
-        json.dump(normalized_config, f, indent=4)
+    CONFIG.save_to_file(pathlib.Path(json_path))
 
 
-if CONFIG_PATH is not None:
-    if CONFIG_PATH.exists():
-        logger.debug(f"Loading ttnn configuration from {CONFIG_PATH}")
-        load_config_from_json_file(CONFIG_PATH)
-    else:
-        CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-        save_config_to_json_file(CONFIG_PATH)
-
-if CONFIG_OVERRIDES is not None:
-    # Already applied at _ttnn load; re-applied here so the env keeps precedence over TTNN_CONFIG_PATH.
-    logger.debug(f"Loading ttnn configuration overrides from environment variable TTNN_CONFIG_OVERRIDES")
-    CONFIG.apply_json_overrides(CONFIG_OVERRIDES)
-
+# TTNN_CONFIG_PATH and TTNN_CONFIG_OVERRIDES are applied in C++ at _ttnn load, so that pure C++
+# consumers get the same configuration as Python; see ttnn/core/config.cpp.
 logger.debug(f"Initial ttnn.CONFIG:\n{CONFIG}")
 
 

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -26,18 +26,7 @@ CONFIG_OVERRIDES = os.environ.get("TTNN_CONFIG_OVERRIDES", None)
 
 
 def load_config_from_dictionary(config, from_file=False):
-    global CONFIG
-    for key, value in config.items():
-        if hasattr(CONFIG, key):
-            if getattr(CONFIG, key) is not None:
-                value = type(getattr(CONFIG, key))(value)
-            setattr(CONFIG, key, value)
-        elif from_file:
-            logger.warning(
-                f"Unknown configuration key: {key}. Please update your configuration file: {CONFIG_PATH}. Or delete it to get the new default config"
-            )
-        else:
-            raise ValueError(f"Unknown configuration key: {key}")
+    CONFIG.apply_json_overrides(json.dumps(config, default=str), strict=not from_file)
 
 
 def load_config_from_json_file(json_path):
@@ -57,6 +46,8 @@ def save_config_to_json_file(json_path):
             if re.match("^_.+_$", key):
                 continue
             value = getattr(CONFIG, key)
+            if callable(value):
+                continue
             if isinstance(value, pathlib.Path):
                 value = str(value)
             normalized_config[key] = value
@@ -72,8 +63,9 @@ if CONFIG_PATH is not None:
         save_config_to_json_file(CONFIG_PATH)
 
 if CONFIG_OVERRIDES is not None:
+    # Already applied at _ttnn load; re-applied here so the env keeps precedence over TTNN_CONFIG_PATH.
     logger.debug(f"Loading ttnn configuration overrides from environment variable TTNN_CONFIG_OVERRIDES")
-    load_config_from_dictionary(json.loads(CONFIG_OVERRIDES))
+    CONFIG.apply_json_overrides(CONFIG_OVERRIDES)
 
 logger.debug(f"Initial ttnn.CONFIG:\n{CONFIG}")
 


### PR DESCRIPTION
### What

`TTNN_CONFIG_PATH` and `TTNN_CONFIG_OVERRIDES` were both handled in `ttnn/__init__.py`, so they only ever
applied to Python processes. The five device-sanity workflows set
`TTNN_CONFIG_OVERRIDES='{"validate_program_args": true}'` (#50945) at job level — but the C++ gtests in those
same jobs silently ran with validation off. Same trap for the pre-existing `fast_runtime_mode_off` wiring, and
for any C++ consumer of a `TTNN_CONFIG_PATH` file.

This moves both configuration sources into C++ and has Python consume them:

- **`Config::apply_json_overrides(json_text, strict, source)`** in `ttnn/core/config.cpp`: nlohmann parse plus
  the same `reflect::for_each` walk the class already uses for printing/Inspector. Keys are applied into a copy
  of `attributes_t` and committed once, so a strict rejection changes nothing at all, while a non-strict caller
  (a config file) keeps every key that parsed and warns about the rest. `validate()` runs once per applied key.
  `source` names the env var or file path in every message.
- **`Config::load_from_file` / `Config::save_to_file`**: the reader/writer pair for the `TTNN_CONFIG_PATH`
  format. Serialization used to exist only in Python; it now has one owner.
- **`Config::keys()`**: the single enumeration of overridable attributes, so nothing has to filter
  `dir(CONFIG)` to find them.
- A static initializer applies the file first and the env var on top — the order `__init__.py` used — so pure
  C++ consumers (gtests, standalone binaries) get the same configuration as Python.
- nanobind exposes all four. `load_config_from_dictionary` becomes a one-line delegation that keeps raising
  `ValueError`; `load_config_from_json_file` / `save_config_to_json_file` delegate too, and the whole
  `if CONFIG_PATH ... / if CONFIG_OVERRIDES ...` block in `__init__.py` is gone.

### Behavior changes

- A bad `TTNN_CONFIG_OVERRIDES` (malformed JSON, unknown key, wrong-typed value) fails the process at library
  load: the reason is logged and the process exits `1`. Previously this was a Python exception at
  `import ttnn`, and C++-only processes ignored the variable entirely. Deliberate: a typo in a workflow file
  must not silently disable the validation safety net. The exit is `_Exit`, not a throw — an escaping throw
  ends in SIGABRT before `main`, and a plain `std::exit` deadlocks against the loader lock.
- A `TTNN_CONFIG_PATH` file is now read and written by any process that links ttnn, not just Python. In
  particular, pointing it at a missing path makes that process create the file, seeded from default
  configuration values. Nothing in CI sets `TTNN_CONFIG_PATH` (only the visualizer and model-bringup docs).
- A stale or corrupt config file warns and applies whatever parsed, rather than failing the load — including
  the computed `report_path` entry that older saved files contain. Newly saved files no longer contain it.
- Config attributes are typed strictly now: `{"enable_model_cache": 1}` is rejected instead of coerced. Every
  `TTNN_CONFIG_OVERRIDES` value in the repo (workflows, scripts, docs) was audited and parses.

### Testing

`tests/ttnn/unit_tests/base_functionality/test_config.py`, 22 tests: parser semantics (types, `null` →
`nullopt`, unknown-key strict/non-strict, non-object, malformed JSON, source naming), strict-applies-nothing
vs non-strict-keeps-what-parsed, the `ValueError` contract, saved keys == `Config.keys()`, and a
`TTNN_CONFIG_PATH` round trip. Seven subprocess tests load `_ttnn.so` directly via `spec_from_file_location`,
bypassing `ttnn/__init__.py`, to pin the pure-C++ path: env override applies, config file applies, a missing
file is seeded with defaults (and the env override is *not* baked into it), a stale key warns and the rest
applies, a corrupt file does not fail the load, and a bad env var exits `1` with the message.

Also verified against a real pure-C++ binary rather than only through `dlopen`:
`unit_tests_ttnn --gtest_list_tests` reads a `TTNN_CONFIG_PATH` file, seeds a missing nested path with all 17
keys at their defaults, still lets the env var win over the file, and exits `1` on a bad env var with no core
dump.

Full `test_graph_report.py` (exercises the delegation and `save_config_to_json_file`): 158 passed, 1 skipped.
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/ttnn-config-overrides-cpp)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/ttnn-config-overrides-cpp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/ttnn-config-overrides-cpp)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/ttnn-config-overrides-cpp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/ttnn-config-overrides-cpp)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/ttnn-config-overrides-cpp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/ttnn-config-overrides-cpp)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/ttnn-config-overrides-cpp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/ttnn-config-overrides-cpp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/ttnn-config-overrides-cpp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/ttnn-config-overrides-cpp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/ttnn-config-overrides-cpp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/ttnn-config-overrides-cpp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/ttnn-config-overrides-cpp)
