### PR TITLE
[Bug fix] Fix use-after-scope and mux core misclassification in UDM tensix connection init

### DIFF
--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -2584,6 +2584,8 @@ void ControlPlane::write_udm_fabric_connections_to_tensix_cores(
     for (const auto& tensix_core : all_tensix_cores) {
         tt::tt_metal::CoreCoord core_coord(tensix_core.x, tensix_core.y);
 
+        tt::tt_fabric::tensix_fabric_connections_l1_info_t worker_connections = {};
+
         // Determine core type
         const void* data_to_write = nullptr;
         if (fabric_mux_cores_translated.contains(core_coord)) {
@@ -2594,8 +2596,6 @@ void ControlPlane::write_udm_fabric_connections_to_tensix_cores(
             data_to_write = &fabric_dispatcher_connections;
         } else {
             // Worker core: build per-worker connection info
-            tt::tt_fabric::tensix_fabric_connections_l1_info_t worker_connections = {};
-
             // Get worker assignment info (tensix core + channel index) with a single lookup
             auto tensix_info = tensix_config.get_worker_tensix_info(physical_chip_id, core_coord);
 

--- a/tt_metal/fabric/fabric_tensix_builder.cpp
+++ b/tt_metal/fabric/fabric_tensix_builder.cpp
@@ -377,16 +377,22 @@ std::vector<tt::tt_metal::CoreCoord> FabricTensixDatamoverConfig::build_workers_
     auto compute_grid = device->compute_with_storage_grid_size();
     uint32_t total_workers = compute_grid.x * compute_grid.y;
 
-    std::vector<tt::tt_metal::CoreCoord> workers_by_column(total_workers);
+    std::vector<tt::tt_metal::CoreCoord> workers_by_column;
+    workers_by_column.reserve(total_workers);
 
     // Sort by column: x first (outer loop), then y within each column (inner loop)
     // This ensures workers in the same column are contiguous and get assigned to the same tensix
-    size_t idx = 0;
     for (uint32_t x = 0; x < compute_grid.x; x++) {
         for (uint32_t y = 0; y < compute_grid.y; y++) {
             tt::tt_metal::CoreCoord logical_worker(x, y);
+            if (std::find(logical_fabric_mux_cores_.begin(), logical_fabric_mux_cores_.end(), logical_worker) !=
+                    logical_fabric_mux_cores_.end() ||
+                std::find(logical_dispatch_mux_cores_.begin(), logical_dispatch_mux_cores_.end(), logical_worker) !=
+                    logical_dispatch_mux_cores_.end()) {
+                continue;
+            }
             tt::tt_metal::CoreCoord translated_worker = device->worker_core_from_logical_core(logical_worker);
-            workers_by_column[idx++] = translated_worker;
+            workers_by_column.push_back(translated_worker);
         }
     }
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Two independent bugs in UDM-mode Tensix fabric connection initialization.

**1. Use-after-scope in `write_udm_fabric_connections_to_tensix_cores`**

`worker_connections` was declared inside the `else` branch, but `data_to_write`
points at it and is dereferenced by `cluster.write_core()` after the branch
closes. Every worker core wrote its connection info from a dangling pointer.
Affects all UDM devices on hardware, not just simulation.

**2. Mux/dispatch cores assigned worker channels in `build_workers_by_column`**

The worker list was built from the full compute grid with no exclusion for
fabric mux or dispatch mux cores. Where the compute grid overlaps the
mux/dispatch row, those cores were given worker channel assignments on top of
their mux role — a double assignment. Reachable today on the Wormhole galaxy
ROW descriptor (compute range covers the mux/dispatch row, 8 cores affected),
and on any slow-dispatch config, where the compute grid expands to the full
Tensix grid and always includes that row.

### Fix

- Hoist `worker_connections` above the branch so it outlives `data_to_write`.
- Skip logical fabric-mux and dispatch-mux cores when building the worker list.
  This requires switching from pre-sized `vector(total_workers)` + `idx++` to
  `reserve()` + `push_back()`; the old sizing would leave default-constructed
  `(0,0)` entries at the tail once the loop can skip.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=micah/tensix-classification)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:micah/tensix-classification)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=micah/tensix-classification)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:micah/tensix-classification)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=micah/tensix-classification)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:micah/tensix-classification)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=micah/tensix-classification)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:micah/tensix-classification)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=micah/tensix-classification)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:micah/tensix-classification)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=micah/tensix-classification)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:micah/tensix-classification)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=micah/tensix-classification)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:micah/tensix-classification)