### PR TITLE
.agents: harden the Claude multigoal runner (crash-resume, timeouts, auth, tests)

### DIFF
--- a/.agents/scripts/multigoal-claude
+++ b/.agents/scripts/multigoal-claude
@@ -23,13 +23,14 @@ import json
 import os
 import pathlib
 import re
+import shutil
 import subprocess
 import sys
 import threading
 import time
 import uuid
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Callable
 
 MAX_GOAL_OBJECTIVE_CHARS = 100_000  # generous; Claude has no app-server cap
 SKILL_RE = re.compile(r"\$([A-Za-z0-9][A-Za-z0-9_-]*)")
@@ -46,6 +47,7 @@ ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 CHECK_PASS = 0
 CHECK_ADVISORY = 1
 CHECK_CRITICAL = 2
+CHECK_TIMEOUT_CODE = 124  # synthesized when a check script exceeds --check-timeout
 
 # Terminal goal statuses. "complete"/"blocked" come from the agent verdict; the
 # rest are runner-classified infra outcomes.
@@ -151,10 +153,13 @@ class ClaudeRunner:
         resume_session: str | None = None,
     ) -> GoalResult:
         cmd = self._base_cmd()
-        if session_id is not None:
-            cmd += ["--session-id", session_id]
+        # Mutually exclusive: the CLI rejects --session-id together with --resume
+        # unless --fork-session is also passed, and it reports that on stderr while
+        # still exiting 0 - which would surface here as an opaque "no result event".
         if resume_session is not None:
             cmd += ["--resume", resume_session]
+        elif session_id is not None:
+            cmd += ["--session-id", session_id]
 
         proc = subprocess.Popen(
             cmd,
@@ -201,6 +206,24 @@ class ClaudeRunner:
         hb_thread = threading.Thread(target=heartbeat, daemon=True)
         hb_thread.start()
 
+        # The stage timeout runs on its own timer rather than being checked inside
+        # the stdout loop below: the case it exists for is a child that stops
+        # emitting events entirely, and in that case the loop is blocked in
+        # readline() and would never reach an inline check.
+        timed_out = threading.Event()
+
+        def watchdog() -> None:
+            if self.stage_timeout is None:
+                return
+            if stop_heartbeat.wait(self.stage_timeout):
+                return  # finished normally
+            timed_out.set()
+            print(f"stage exceeded --stage-timeout={self.stage_timeout}s; terminating", file=sys.stderr)
+            proc.kill()
+
+        wd_thread = threading.Thread(target=watchdog, daemon=True)
+        wd_thread.start()
+
         try:
             with output_log.open("w", encoding="utf-8") as log:
                 for line in proc.stdout:
@@ -220,10 +243,6 @@ class ClaudeRunner:
                         seen_session_id = sid
                     if event.get("type") == "result":
                         result_obj = event
-                    if self.stage_timeout is not None and (time.monotonic() - start) > self.stage_timeout:
-                        print(f"stage exceeded --stage-timeout={self.stage_timeout}s; terminating", file=sys.stderr)
-                        proc.kill()
-                        break
         finally:
             stop_heartbeat.set()
             try:
@@ -235,6 +254,17 @@ class ClaudeRunner:
                 writer_thread.join(timeout=1)
             if stderr_thread.is_alive():
                 stderr_thread.join(timeout=1)
+            if wd_thread.is_alive():
+                wd_thread.join(timeout=1)
+
+        if timed_out.is_set():
+            return GoalResult(
+                terminal_status=TERMINAL_TURN_FAILED,
+                session_id=seen_session_id,
+                structured_output=None,
+                result_obj=result_obj,
+                error=f"stage exceeded --stage-timeout={self.stage_timeout}s",
+            )
 
         terminal, structured, error = classify_terminal(result_obj, stderr_tail, returncode)
         if isinstance(result_obj, dict):
@@ -295,16 +325,44 @@ def classify_terminal(
     structured = structured if isinstance(structured, dict) else None
     result_text = result_obj.get("result")
     result_text = result_text if isinstance(result_text, str) else ""
+    # The error variant of the result event has no `result` and no
+    # `structured_output`; its detail lives in an `errors` string array. Without
+    # reading it, every failure detail came out empty or as a bare stderr tail.
+    errors = result_obj.get("errors")
+    error_text = "; ".join(str(e) for e in errors) if isinstance(errors, list) else ""
 
-    error_blob = " ".join(str(x) for x in (subtype, terminal_reason, api_error, result_text, stderr_text))
+    error_blob = " ".join(str(x) for x in (subtype, terminal_reason, api_error, error_text, result_text, stderr_text))
 
     if subtype == "error_max_turns" or terminal_reason == "max_turns":
-        return TERMINAL_MAX_TURNS, structured, "reached max turns before completing the goal"
+        return (
+            TERMINAL_MAX_TURNS,
+            structured,
+            error_text or "reached max turns before completing the goal",
+        )
+
+    # The agent could not produce a schema-conforming verdict within the CLI's
+    # retry budget. The stage work may well be done, so this is recoverable with
+    # --resume-stage rather than a hard failure; the stage check remains the
+    # independent arbiter either way.
+    if subtype == "error_max_structured_output_retries" or terminal_reason == "structured_output_retry_exhausted":
+        return (
+            TERMINAL_BLOCKED,
+            structured,
+            error_text or "agent could not emit a schema-conforming status verdict",
+        )
 
     if is_error or subtype.startswith("error") or api_error:
         if looks_usage_limited(error_blob):
-            return TERMINAL_USAGE_LIMITED, structured, (result_text or stderr_text)[-400:] or "usage/rate limit"
-        return TERMINAL_TURN_FAILED, structured, (result_text or api_error or stderr_text or "turn failed")
+            return (
+                TERMINAL_USAGE_LIMITED,
+                structured,
+                (error_text or result_text or stderr_text)[-400:] or "usage/rate limit",
+            )
+        return (
+            TERMINAL_TURN_FAILED,
+            structured,
+            (error_text or result_text or api_error or stderr_text or "turn failed"),
+        )
 
     # Successful process: trust the agent verdict.
     if structured and structured.get("status") in (TERMINAL_COMPLETE, TERMINAL_BLOCKED):
@@ -417,6 +475,20 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Optional wall-clock seconds after which a stuck stage is killed (default: no limit).",
     )
+    parser.add_argument(
+        "--check-timeout",
+        type=float,
+        default=1800,
+        help=(
+            "Seconds before a stage check script is killed and treated as a broken "
+            "check (default: 1800). Without this a hung check hangs the pipeline."
+        ),
+    )
+    parser.add_argument(
+        "--claude-config-dir",
+        type=pathlib.Path,
+        help="Sets CLAUDE_CONFIG_DIR for the agent processes (auth/config home).",
+    )
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args()
     if args.start_index < 1:
@@ -450,6 +522,38 @@ def replacement_value(replacements: list[tuple[str, str]], name: str) -> str | N
         if old == name:
             value = new
     return value
+
+
+def claude_env(env: dict[str, str], explicit: pathlib.Path | None) -> pathlib.Path:
+    """Pin the agent's auth path and return its config home.
+
+    Unattended bringup runs are hours of high-effort work. An ambient
+    ANTHROPIC_API_KEY takes precedence over the subscription login, so leaving it
+    in the child environment can silently move a whole run onto metered API
+    billing. Mirrors the Codex runner's OPENAI_API_KEY/CODEX_API_KEY hygiene.
+    """
+    env.pop("ANTHROPIC_API_KEY", None)
+    env.pop("ANTHROPIC_AUTH_TOKEN", None)
+    if explicit is not None:
+        home = explicit.expanduser()
+        env["CLAUDE_CONFIG_DIR"] = str(home)
+        return home
+    return pathlib.Path(env.get("CLAUDE_CONFIG_DIR", "~/.claude")).expanduser()
+
+
+def resolve_claude_bin(explicit: str | None) -> str:
+    """Resolve the CLI up front so a bad binary fails at launch, not hours in."""
+    candidate = explicit or "claude"
+    found = shutil.which(candidate)
+    if found:
+        return found
+    path = pathlib.Path(candidate).expanduser()
+    if path.is_file() and os.access(path, os.X_OK):
+        return str(path)
+    raise SystemExit(
+        f"The claude CLI ({candidate}) was not found on PATH or is not executable. "
+        "Install Claude Code or pass --claude-bin/$CLAUDE_BIN."
+    )
 
 
 def load_prompt(path: pathlib.Path, replacements: list[tuple[str, str]]) -> str:
@@ -607,6 +711,7 @@ def write_manifest_header(
     path: pathlib.Path,
     repo: pathlib.Path,
     claude_bin: str,
+    claude_home: pathlib.Path,
     args: argparse.Namespace,
     replacements: list[tuple[str, str]],
     model_dir: str | None,
@@ -618,6 +723,7 @@ def write_manifest_header(
                 f"started_at_utc={timestamp()}",
                 f"repo={repo}",
                 f"claude_bin={claude_bin}",
+                f"claude_config_dir={claude_home}",
                 f"hf_model={hf_model or ''}",
                 f"model_dir={model_dir or ''}",
                 "runner=claude-code",
@@ -669,11 +775,19 @@ def execute_goal(
     objective: str,
     output_log: pathlib.Path,
     stderr_log: pathlib.Path,
+    on_session_id: Callable[[str], None] | None = None,
 ) -> GoalResult:
-    """Run one objective in a fresh session to a terminal verdict."""
+    """Run one objective in a fresh session to a terminal verdict.
+
+    The session id is reported through ``on_session_id`` BEFORE the agent starts.
+    Recording it only after the goal returns loses the resume anchor whenever the
+    runner or host dies mid-stage - exactly the case --resume-stage exists for.
+    """
     skill_context, _missing = build_skill_context(repo, objective)
     prompt_text = wrap_fresh_prompt(objective, skill_context)
     session_id = str(uuid.uuid4())
+    if on_session_id is not None:
+        on_session_id(session_id)
     return runner.run(prompt_text, output_log, stderr_log, session_id=session_id)
 
 
@@ -736,25 +850,37 @@ def run_check_script(
     repo: pathlib.Path,
     extra_env: dict[str, str],
     check_log: pathlib.Path,
+    check_timeout: float,
 ) -> int:
     env = os.environ.copy()
     env.update(extra_env)
-    result = subprocess.run(
-        ["bash", str(script)],
-        cwd=repo,
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-        encoding="utf-8",
-        errors="replace",
-    )
-    check_log.write_text(result.stdout or "", encoding="utf-8")
-    tail = "\n".join((result.stdout or "").splitlines()[-15:])
-    print(f"check {script.name} exited {result.returncode}; log: {check_log}", file=sys.stderr)
+    try:
+        result = subprocess.run(
+            ["bash", str(script)],
+            cwd=repo,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=check_timeout or None,
+        )
+        output = result.stdout or ""
+        returncode = result.returncode
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode("utf-8", errors="replace")
+        output = (stdout or "") + f"\n[multigoal] check killed after --check-timeout {check_timeout:.0f}s\n"
+        # Outside the 0/1/2 contract, so the gate treats it as a broken check.
+        returncode = CHECK_TIMEOUT_CODE
+    check_log.write_text(output, encoding="utf-8")
+    tail = "\n".join(output.splitlines()[-15:])
+    print(f"check {script.name} exited {returncode}; log: {check_log}", file=sys.stderr)
     if tail:
         print(tail, file=sys.stderr)
-    return result.returncode
+    return returncode
 
 
 def remediation_objective(
@@ -823,12 +949,12 @@ def run_stage_checks(
     code = -1
     for attempt in range(args.check_retries + 1):
         check_log = log_dir / f"{name}.check-{attempt + 1}.log"
-        code = run_check_script(script, repo, extra_env, check_log)
+        code = run_check_script(script, repo, extra_env, check_log, args.check_timeout)
         append_manifest(manifest, [f"{manifest_key_prefix}_check_attempt_{attempt + 1}=exit{code}"])
         if code not in (CHECK_PASS, CHECK_ADVISORY, CHECK_CRITICAL):
             # Broken check or environment: retry once for transients.
             check_log = log_dir / f"{name}.check-{attempt + 1}-retry.log"
-            code = run_check_script(script, repo, extra_env, check_log)
+            code = run_check_script(script, repo, extra_env, check_log, args.check_timeout)
             append_manifest(manifest, [f"{manifest_key_prefix}_check_attempt_{attempt + 1}_retry=exit{code}"])
         if code == CHECK_PASS:
             append_manifest(manifest, [f"{manifest_key_prefix}_check=pass"])
@@ -849,11 +975,16 @@ def run_stage_checks(
         remediation_stderr = log_dir / f"{name}.remediation-{attempt + 1}.stderr.log"
         print(f"\n== Stage {index} remediation {attempt + 1}: check failed (exit {code}) ==", file=sys.stderr)
         print(f"+ log: {remediation_log}", file=sys.stderr)
-        result = execute_goal(runner, repo, objective, remediation_log, remediation_stderr)
-        if result.session_id:
-            append_manifest(
-                manifest, [f"{manifest_key_prefix}_remediation_{attempt + 1}_session_id={result.session_id}"]
-            )
+        result = execute_goal(
+            runner,
+            repo,
+            objective,
+            remediation_log,
+            remediation_stderr,
+            on_session_id=lambda sid: append_manifest(
+                manifest, [f"{manifest_key_prefix}_remediation_{attempt + 1}_session_id={sid}"]
+            ),
+        )
         append_manifest(
             manifest,
             [f"{manifest_key_prefix}_remediation_{attempt + 1}_terminal_status={result.terminal_status}"],
@@ -980,9 +1111,14 @@ def run_stage(
         ],
     )
 
-    result = execute_goal(runner, repo, objective, output_log, stderr_log)
-    if result.session_id:
-        append_manifest(manifest, [f"stage_{index}_session_id={result.session_id}"])
+    result = execute_goal(
+        runner,
+        repo,
+        objective,
+        output_log,
+        stderr_log,
+        on_session_id=lambda sid: append_manifest(manifest, [f"stage_{index}_session_id={sid}"]),
+    )
 
     return _finish_stage(
         runner,
@@ -1062,6 +1198,7 @@ def main() -> int:
     args = parse_args()
     repo = args.repo.expanduser().resolve()
     env = os.environ.copy()
+    claude_home = claude_env(env, args.claude_config_dir)
     default_log_root = pathlib.Path(
         os.environ.get(
             "RUN_MULTIGOAL_LOG_DIR",
@@ -1082,9 +1219,9 @@ def main() -> int:
     )
     if model_dir and replacement_value(replacements, "MODEL_DIR") is None:
         replacements.append(("MODEL_DIR", model_dir))
-    claude_bin = args.claude_bin
+    claude_bin = resolve_claude_bin(args.claude_bin)
     if args.resume_stage is None:
-        write_manifest_header(manifest, repo, claude_bin, args, replacements, model_dir)
+        write_manifest_header(manifest, repo, claude_bin, claude_home, args, replacements, model_dir)
     elif model_dir and not manifest_values.get("model_dir"):
         append_manifest(manifest, [f"model_dir={model_dir}"])
 

--- a/.agents/tests/claude
+++ b/.agents/tests/claude
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec python3 "$(dirname "${BASH_SOURCE[0]}")/fake_claude.py" "$@"

--- a/.agents/tests/fake_claude.py
+++ b/.agents/tests/fake_claude.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Fake `claude` CLI for multigoal runner tests.
+
+Driven by $FAKE_CLAUDE_DIR, a directory holding:
+  - responses/001.json, 002.json, ...  one per expected invocation, in order:
+      {
+        "session_id": "sess-1",           # default: the --session-id/--resume value
+        "subtype": "success",             # result event subtype
+        "is_error": false,
+        "terminal_reason": "completed",
+        "verdict": {"status": "complete", "summary": "..."},   # -> structured_output
+        "result_text": "...",             # raw final message (default: verdict JSON)
+        "errors": ["..."],                # error-variant detail array
+        "exit_code": 0,
+        "stderr": "",
+        "sleep": 0,                       # seconds before the result event
+        "no_result_event": false,         # emit init but no result event
+        "hang": false                     # emit init then sleep forever
+      }
+  - calls.jsonl (appended by this shim): argv, stdin, flag values, and whether
+    ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN leaked into the environment.
+  - counter (managed by this shim)
+"""
+import json
+import os
+import pathlib
+import sys
+import time
+
+
+def flag_value(argv: list[str], name: str) -> str | None:
+    return argv[argv.index(name) + 1] if name in argv else None
+
+
+def main() -> int:
+    root = pathlib.Path(os.environ["FAKE_CLAUDE_DIR"])
+    counter_file = root / "counter"
+    n = int(counter_file.read_text()) + 1 if counter_file.exists() else 1
+    counter_file.write_text(str(n))
+
+    stdin_text = sys.stdin.read()
+    argv = sys.argv[1:]
+    resume = flag_value(argv, "--resume")
+    requested_session = flag_value(argv, "--session-id")
+
+    with (root / "calls.jsonl").open("a", encoding="utf-8") as f:
+        f.write(
+            json.dumps(
+                {
+                    "n": n,
+                    "argv": argv,
+                    "stdin": stdin_text,
+                    "stdin_len": len(stdin_text),
+                    "resume": resume,
+                    "session_id_flag": requested_session,
+                    "json_schema": flag_value(argv, "--json-schema"),
+                    "settings": flag_value(argv, "--settings"),
+                    "api_key_leaked": "ANTHROPIC_API_KEY" in os.environ,
+                    "auth_token_leaked": "ANTHROPIC_AUTH_TOKEN" in os.environ,
+                }
+            )
+            + "\n"
+        )
+
+    response_file = root / "responses" / f"{n:03d}.json"
+    spec = json.loads(response_file.read_text()) if response_file.exists() else {}
+    session_id = spec.get("session_id") or requested_session or resume or f"sess-{n}"
+
+    print(json.dumps({"type": "system", "subtype": "init", "session_id": session_id, "model": "fake"}), flush=True)
+
+    if spec.get("hang"):
+        while True:
+            time.sleep(3600)
+    if spec.get("sleep"):
+        time.sleep(spec["sleep"])
+
+    if not spec.get("no_result_event"):
+        subtype = spec.get("subtype", "success")
+        verdict = spec.get("verdict", {"status": "complete", "summary": "done"})
+        event: dict = {
+            "type": "result",
+            "subtype": subtype,
+            "is_error": spec.get("is_error", False),
+            "session_id": session_id,
+            "num_turns": 1,
+            "total_cost_usd": 0.0,
+            "terminal_reason": spec.get("terminal_reason", "completed"),
+        }
+        if subtype == "success" and not spec.get("is_error"):
+            # Success variant: carries result + structured_output.
+            event["api_error_status"] = None
+            if verdict is not None:
+                event["structured_output"] = verdict
+            event["result"] = spec.get("result_text", json.dumps(verdict) if verdict else "")
+        else:
+            # Error variant: no result / structured_output, detail in `errors`.
+            if "errors" in spec:
+                event["errors"] = spec["errors"]
+            if "result_text" in spec:
+                event["result"] = spec["result_text"]
+        print(json.dumps(event), flush=True)
+
+    if spec.get("stderr"):
+        print(spec["stderr"], file=sys.stderr, flush=True)
+    return int(spec.get("exit_code", 0))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/tests/test_multigoal_claude.py
+++ b/.agents/tests/test_multigoal_claude.py
@@ -1,0 +1,440 @@
+#!/usr/bin/env python3
+"""Tests for .agents/scripts/multigoal-claude against a fake `claude` CLI.
+
+No hardware, no API calls, no tokens: tests/claude is a shim that replays canned
+stream-json events (see fake_claude.py) so the runner's state machine, gate
+policy, manifest bookkeeping, and recovery paths can be exercised deterministically.
+
+Run:  python3 .agents/tests/test_multigoal_claude.py
+"""
+import json
+import os
+import pathlib
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+TESTS_DIR = pathlib.Path(__file__).resolve().parent
+AGENTS_DIR = TESTS_DIR.parent
+RUNNER = AGENTS_DIR / "scripts" / "multigoal-claude"
+
+COMPLETE = {"status": "complete", "summary": "all requirements met"}
+BLOCKED = {"status": "blocked", "summary": "cannot proceed", "blocker": "device is on fire"}
+
+
+class MultigoalClaudeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = pathlib.Path(tempfile.mkdtemp(prefix="multigoal-claude-test-"))
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.ws = self.tmp / "ws"
+        (self.ws / ".agents" / "skills").mkdir(parents=True)
+        self.fake_dir = self.tmp / "fake"
+        (self.fake_dir / "responses").mkdir(parents=True)
+        self.log_dir = self.tmp / "logs"
+        self.prompts_dir = self.tmp / "prompts"
+        self.prompts_dir.mkdir()
+
+    # -- helpers -------------------------------------------------------------
+    def add_skill(self, name: str, description: str = "") -> pathlib.Path:
+        skill = self.ws / ".agents" / "skills" / name / "SKILL.md"
+        skill.parent.mkdir(parents=True, exist_ok=True)
+        desc = f"description: {description}\n" if description else ""
+        skill.write_text(f"---\nname: {name}\n{desc}---\n# {name}\n")
+        return skill
+
+    def add_prompt(self, stem: str, body: str, check: str | None = None) -> pathlib.Path:
+        prompt = self.prompts_dir / f"{stem}.txt"
+        prompt.write_text(body)
+        if check is not None:
+            (self.prompts_dir / f"{stem}.check.sh").write_text(check)
+        return prompt
+
+    def queue_response(self, n: int, **spec) -> None:
+        (self.fake_dir / "responses" / f"{n:03d}.json").write_text(json.dumps(spec))
+
+    def calls(self) -> list[dict]:
+        path = self.fake_dir / "calls.jsonl"
+        if not path.exists():
+            return []
+        return [json.loads(line) for line in path.read_text().splitlines()]
+
+    def manifest(self) -> dict[str, str]:
+        values: dict[str, str] = {}
+        for raw in (self.log_dir / "manifest.txt").read_text().splitlines():
+            if "=" in raw and not raw.startswith("- "):
+                key, value = raw.split("=", 1)
+                values[key] = value
+        return values
+
+    def argv_for(self, *stems: str, extra: list[str] | None = None) -> list[str]:
+        argv = [
+            sys.executable,
+            str(RUNNER),
+            "--repo",
+            str(self.ws),
+            "--log-dir",
+            str(self.log_dir),
+            "--claude-bin",
+            str(TESTS_DIR / "claude"),
+            "--replace",
+            "HF_MODEL=org/Test-Model",
+        ]
+        argv.extend(extra or [])
+        argv.extend(str(self.prompts_dir / f"{stem}.txt") for stem in stems)
+        return argv
+
+    def env_for(self) -> dict[str, str]:
+        env = os.environ.copy()
+        env["FAKE_CLAUDE_DIR"] = str(self.fake_dir)
+        env["ANTHROPIC_API_KEY"] = "sk-test-leak-canary"
+        env["ANTHROPIC_AUTH_TOKEN"] = "tok-test-leak-canary"
+        return env
+
+    def run_runner(self, *stems: str, extra: list[str] | None = None) -> subprocess.CompletedProcess:
+        return subprocess.run(self.argv_for(*stems, extra=extra), env=self.env_for(), capture_output=True, text=True)
+
+    # -- core flow -----------------------------------------------------------
+    def test_two_stages_complete(self) -> None:
+        self.add_prompt("01-a", "/goal Stage one for HF_MODEL.\n")
+        self.add_prompt("02-b", "/goal Stage two for HF_MODEL.\n")
+        self.queue_response(1, verdict=COMPLETE)
+        self.queue_response(2, verdict=COMPLETE)
+        proc = self.run_runner("01-a", "02-b")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        manifest = self.manifest()
+        self.assertEqual(manifest["stage_1_terminal_status"], "complete")
+        self.assertEqual(manifest["stage_2_terminal_status"], "complete")
+        self.assertEqual(manifest["runner"], "claude-code")
+        self.assertIn("| 01-01-a | complete | none |", (self.log_dir / "STATUS.md").read_text())
+        stdin = self.calls()[0]["stdin"]
+        self.assertIn("org/Test-Model", stdin)
+        self.assertNotIn("HF_MODEL", stdin)
+
+    def test_prompt_wrapper_and_skill_context(self) -> None:
+        self.add_skill("tt-device-usage", "Use TT devices safely and recover hangs.")
+        self.add_prompt("01-a", "/goal Use $tt-device-usage and $nonexistent-skill for HF_MODEL.\n")
+        self.queue_response(1, verdict=COMPLETE)
+        proc = self.run_runner("01-a")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        stdin = self.calls()[0]["stdin"]
+        self.assertIn("===== GOAL =====", stdin)
+        self.assertIn("- $tt-device-usage: read .agents/skills/tt-device-usage/SKILL.md", stdin)
+        self.assertIn("Use TT devices safely and recover hangs.", stdin)
+        self.assertIn("Referenced skills with no SKILL.md found", stdin)
+        self.assertLess(stdin.index("===== GOAL ====="), stdin.index("Terminal contract"))
+        self.assertEqual(self.manifest()["stage_1_missing_skills"], "nonexistent-skill")
+
+    def test_verdict_schema_is_passed(self) -> None:
+        self.add_prompt("01-a", "/goal Stage one for HF_MODEL.\n")
+        self.queue_response(1, verdict=COMPLETE)
+        self.run_runner("01-a")
+        schema = json.loads(self.calls()[0]["json_schema"])
+        self.assertEqual(schema["properties"]["status"]["enum"], ["complete", "blocked"])
+        self.assertEqual(schema["required"], ["status", "summary"])
+
+    def test_blocked_verdict_stops_with_exit_3(self) -> None:
+        self.add_prompt("01-a", "/goal Stage one for HF_MODEL.\n")
+        self.add_prompt("02-b", "/goal Stage two for HF_MODEL.\n")
+        self.queue_response(1, verdict=BLOCKED)
+        proc = self.run_runner("01-a", "02-b")
+        self.assertEqual(proc.returncode, 3, proc.stderr)
+        self.assertEqual(self.manifest()["stage_1_terminal_status"], "blocked")
+        self.assertIn("device is on fire", proc.stderr)
+        self.assertEqual(len(self.calls()), 1, "stage 2 must not launch")
+
+    def test_missing_verdict_stops_the_pipeline(self) -> None:
+        self.add_prompt("01-a", "/goal Stage one for HF_MODEL.\n")
+        self.queue_response(1, verdict=None, result_text="I did lots of work and it all passed!")
+        proc = self.run_runner("01-a")
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertNotEqual(self.manifest()["stage_1_terminal_status"], "complete")
+
+    # -- auth hygiene --------------------------------------------------------
+    def test_api_key_never_reaches_the_agent(self) -> None:
+        """An ambient key would silently move an unattended run onto metered billing."""
+        self.add_prompt("01-a", "/goal Stage one for HF_MODEL.\n")
+        self.queue_response(1, verdict=COMPLETE)
+        proc = self.run_runner("01-a")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        call = self.calls()[0]
+        self.assertFalse(call["api_key_leaked"])
+        self.assertFalse(call["auth_token_leaked"])
+
+    def test_claude_config_dir_recorded(self) -> None:
+        self.add_prompt("01-a", "/goal Stage one for HF_MODEL.\n")
+        self.queue_response(1, verdict=COMPLETE)
+        home = self.tmp / "claude-home"
+        proc = self.run_runner("01-a", extra=["--claude-config-dir", str(home)])
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(self.manifest()["claude_config_dir"], str(home))
+
+    def test_missing_claude_bin_fails_at_launch(self) -> None:
+        self.add_prompt("01-a", "/goal Stage one for HF_MODEL.\n")
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(RUNNER),
+                "--repo",
+                str(self.ws),
+                "--log-dir",
+                str(self.log_dir),
+                "--claude-bin",
+                "definitely-not-a-real-binary-xyz",
+                "--replace",
+                "HF_MODEL=org/Test-Model",
+                str(self.prompts_dir / "01-a.txt"),
+            ],
+            env=self.env_for(),
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("not found on PATH", proc.stderr)
+        self.assertEqual(self.calls(), [], "no agent should have been launched")
+
+    # -- infra terminal classification ---------------------------------------
+    def test_max_turns_is_distinct_and_resumable(self) -> None:
+        self.add_prompt("01-a", "/goal Stage one for HF_MODEL.\n")
+        self.queue_response(
+            1,
+            subtype="error_max_turns",
+            is_error=True,
+            terminal_reason="max_turns",
+            errors=["Reached maximum number of turns (1)"],
+            exit_code=1,
+        )
+        proc = self.run_runner("01-a")
+        self.assertEqual(proc.returncode, 3, proc.stderr)
+        self.assertEqual(self.manifest()["stage_1_terminal_status"], "maxTurns")
+        # detail must come from the error variant's errors[] array
+        self.assertIn("Reached maximum number of turns", proc.stderr)
+
+    def test_schema_retry_exhausted_is_recoverable(self) -> None:
+        self.add_prompt("01-a", "/goal Stage one for HF_MODEL.\n")
+        self.queue_response(
+            1,
+            subtype="error_max_structured_output_retries",
+            is_error=True,
+            terminal_reason="structured_output_retry_exhausted",
+            errors=["Could not produce conforming output"],
+            exit_code=1,
+        )
+        proc = self.run_runner("01-a")
+        self.assertEqual(proc.returncode, 3, proc.stderr)
+        self.assertEqual(self.manifest()["stage_1_terminal_status"], "blocked")
+        self.assertIn("Could not produce conforming output", proc.stderr)
+
+    def test_usage_limit_maps_to_exit_3(self) -> None:
+        self.add_prompt("01-a", "/goal Stage one for HF_MODEL.\n")
+        self.queue_response(
+            1,
+            subtype="error_during_execution",
+            is_error=True,
+            errors=["Your usage limit reached; resets at 3pm"],
+            exit_code=1,
+        )
+        proc = self.run_runner("01-a")
+        self.assertEqual(proc.returncode, 3, proc.stderr)
+        self.assertEqual(self.manifest()["stage_1_terminal_status"], "usageLimited")
+
+    def test_execution_error_maps_to_exit_5(self) -> None:
+        self.add_prompt("01-a", "/goal Stage one for HF_MODEL.\n")
+        self.queue_response(
+            1,
+            subtype="error_during_execution",
+            is_error=True,
+            errors=["API connection torn down"],
+            exit_code=1,
+        )
+        proc = self.run_runner("01-a")
+        self.assertEqual(proc.returncode, 5, proc.stderr)
+        self.assertEqual(self.manifest()["stage_1_terminal_status"], "turnFailed")
+        self.assertIn("API connection torn down", proc.stderr)
+
+    # -- check gates ---------------------------------------------------------
+    def test_check_passes_after_remediation(self) -> None:
+        check = (
+            "#!/usr/bin/env bash\n"
+            'count_file="$MULTIGOAL_LOG_DIR/check_count"\n'
+            'n=$(cat "$count_file" 2>/dev/null || echo 0); n=$((n+1)); echo $n > "$count_file"\n'
+            "[ $n -ge 2 ] && exit 0\n"
+            "echo 'artifact missing: readiness table' >&2\n"
+            "exit 1\n"
+        )
+        self.add_prompt("01-a", "/goal Stage one for HF_MODEL.\n", check=check)
+        self.queue_response(1, verdict=COMPLETE)
+        self.queue_response(2, verdict=COMPLETE)
+        proc = self.run_runner("01-a", extra=["--replace", "MODEL_DIR=models/autoports/test"])
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        manifest = self.manifest()
+        self.assertEqual(manifest["stage_1_check"], "pass")
+        self.assertEqual(manifest["stage_1_check_attempt_1"], "exit1")
+        self.assertEqual(manifest["stage_1_check_attempt_2"], "exit0")
+        self.assertIn("stage_1_remediation_1_session_id", manifest)
+        remediation_stdin = self.calls()[1]["stdin"]
+        self.assertIn("FAILED (exit 1, ADVISORY)", remediation_stdin)
+        self.assertIn("treat it as a bug report", remediation_stdin)
+
+    def test_critical_check_exits_6(self) -> None:
+        self.add_prompt("01-a", "/goal Stage one for HF_MODEL.\n", check="#!/usr/bin/env bash\nexit 2\n")
+        self.queue_response(1, verdict=COMPLETE)
+        self.queue_response(2, verdict=COMPLETE)
+        proc = self.run_runner("01-a", extra=["--replace", "MODEL_DIR=models/autoports/test"])
+        self.assertEqual(proc.returncode, 6, proc.stderr)
+        self.assertEqual(self.manifest()["stage_1_check"], "critical-fail")
+
+    def test_broken_check_exits_7_after_one_retry(self) -> None:
+        self.add_prompt("01-a", "/goal Stage one for HF_MODEL.\n", check="#!/usr/bin/env bash\nexit 3\n")
+        self.queue_response(1, verdict=COMPLETE)
+        proc = self.run_runner("01-a", extra=["--replace", "MODEL_DIR=models/autoports/test"])
+        self.assertEqual(proc.returncode, 7, proc.stderr)
+        manifest = self.manifest()
+        self.assertEqual(manifest["stage_1_check"], "check-error(exit3)")
+        self.assertEqual(manifest["stage_1_check_attempt_1_retry"], "exit3")
+
+    def test_hung_check_is_killed_and_treated_as_broken(self) -> None:
+        """Without --check-timeout a hung check script hangs the whole pipeline."""
+        self.add_prompt("01-a", "/goal Stage one for HF_MODEL.\n", check="#!/usr/bin/env bash\nsleep 60\n")
+        self.queue_response(1, verdict=COMPLETE)
+        proc = self.run_runner("01-a", extra=["--replace", "MODEL_DIR=models/autoports/test", "--check-timeout", "1"])
+        self.assertEqual(proc.returncode, 7, proc.stderr)
+        self.assertEqual(self.manifest()["stage_1_check"], "check-error(exit124)")
+
+    def test_model_dir_required_when_checks_exist(self) -> None:
+        self.add_prompt("01-a", "/goal Stage one for HF_MODEL.\n", check="#!/usr/bin/env bash\nexit 0\n")
+        proc = self.run_runner("01-a")
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("MODEL_DIR is required", proc.stderr)
+
+    # -- timeouts, resume, crash recovery ------------------------------------
+    def test_stage_timeout_fires_during_total_silence(self) -> None:
+        """The child emits init then stops emitting anything. An inline timeout check
+        inside the stdout loop can never fire here because the loop blocks in
+        readline(); the watchdog must kill the process."""
+        self.add_prompt("01-a", "/goal Stage one for HF_MODEL.\n")
+        self.queue_response(1, hang=True)
+        proc = self.run_runner("01-a", extra=["--stage-timeout", "2"])
+        self.assertEqual(proc.returncode, 5, proc.stderr)
+        self.assertEqual(self.manifest()["stage_1_terminal_status"], "turnFailed")
+        self.assertIn("stage-timeout", proc.stderr)
+
+    def test_session_id_pinned_and_never_combined_with_resume(self) -> None:
+        self.add_prompt("01-a", "/goal Stage one for HF_MODEL.\n")
+        self.queue_response(1, verdict=COMPLETE)
+        proc = self.run_runner("01-a")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        call = self.calls()[0]
+        self.assertIsNotNone(call["session_id_flag"])
+        self.assertIsNone(call["resume"])
+        self.assertEqual(self.manifest()["stage_1_session_id"], call["session_id_flag"])
+
+    def test_crash_mid_stage_still_leaves_a_resume_anchor(self) -> None:
+        """The whole point of --resume-stage is recovering a run that died mid-stage.
+        If the session id is only recorded after the goal returns, a crash leaves
+        nothing to resume from."""
+        self.add_prompt("01-a", "/goal Stage one for HF_MODEL.\n")
+        self.queue_response(1, hang=True)
+        proc = subprocess.Popen(
+            self.argv_for("01-a"),
+            env=self.env_for(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        manifest_path = self.log_dir / "manifest.txt"
+        session_id = None
+        for _ in range(100):  # up to ~10s
+            if manifest_path.exists() and "stage_1_session_id" in self.manifest():
+                session_id = self.manifest()["stage_1_session_id"]
+                break
+            time.sleep(0.1)
+        proc.send_signal(signal.SIGKILL)
+        proc.wait(timeout=10)
+        self.assertIsNotNone(session_id, "manifest had no session id when the runner was killed")
+
+        self.queue_response(2, verdict=COMPLETE)
+        resumed = self.run_runner("01-a", extra=["--resume-stage", "1"])
+        self.assertEqual(resumed.returncode, 0, resumed.stderr)
+        self.assertEqual(self.calls()[1]["resume"], session_id)
+        self.assertIsNone(self.calls()[1]["session_id_flag"])
+        self.assertEqual(self.manifest()["stage_1_resume_1_terminal_status"], "complete")
+
+    def test_resume_stage_continues_recorded_session(self) -> None:
+        self.add_prompt("01-a", "/goal Stage one for HF_MODEL.\n")
+        self.add_prompt("02-b", "/goal Stage two for HF_MODEL.\n")
+        self.queue_response(1, verdict=BLOCKED)
+        proc = self.run_runner("01-a", "02-b")
+        self.assertEqual(proc.returncode, 3, proc.stderr)
+        original = self.manifest()["stage_1_session_id"]
+        self.queue_response(2, verdict=COMPLETE)
+        self.queue_response(3, verdict=COMPLETE)
+        proc = self.run_runner("01-a", "02-b", extra=["--resume-stage", "1"])
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        calls = self.calls()
+        self.assertEqual(calls[1]["resume"], original)
+        self.assertIn("Continue this existing multigoal stage", calls[1]["stdin"])
+        self.assertIn("===== GOAL (original) =====", calls[1]["stdin"])
+        self.assertIsNone(calls[2]["resume"], "later stages get fresh sessions")
+        manifest = self.manifest()
+        self.assertEqual(manifest["stage_1_resume_1_session_id"], original)
+        self.assertEqual(manifest["stage_2_terminal_status"], "complete")
+
+    # -- passthrough and large prompts ---------------------------------------
+    def test_settings_and_claude_arg_passthrough(self) -> None:
+        self.add_prompt("01-a", "/goal Stage one for HF_MODEL.\n")
+        self.queue_response(1, verdict=COMPLETE)
+        proc = self.run_runner(
+            "01-a",
+            # flag-shaped values need the = form, else argparse eats them as options
+            extra=["--settings", '{"env":{"X":"1"}}', "--claude-arg=--max-turns", "--claude-arg=500"],
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        call = self.calls()[0]
+        self.assertEqual(call["settings"], '{"env":{"X":"1"}}')
+        self.assertIn("--max-turns", call["argv"])
+        self.assertIn("500", call["argv"])
+
+    def test_oversized_prompt_does_not_deadlock(self) -> None:
+        # Well past the ~64 KiB OS pipe buffer (writing stdin inline would
+        # deadlock) while staying inside MAX_GOAL_OBJECTIVE_CHARS.
+        filler = "x" * 90_000
+        self.add_prompt("01-a", f"/goal Stage one for HF_MODEL.\n\n{filler}\n")
+        self.queue_response(1, verdict=COMPLETE)
+        proc = self.run_runner("01-a")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertGreater(self.calls()[0]["stdin_len"], 90_000)
+
+    def test_dry_run_over_the_real_stage_prompts(self) -> None:
+        prompts = sorted((AGENTS_DIR / "prompts" / "model_bringup_multigoal").glob("*.txt"))
+        self.assertGreater(len(prompts), 0)
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(RUNNER),
+                "--dry-run",
+                "--repo",
+                str(AGENTS_DIR.parent),
+                "--log-dir",
+                str(self.log_dir),
+                "--replace",
+                "HF_MODEL=org/Test-Model",
+                "--replace",
+                "MODEL_DIR=models/autoports/org_test_model",
+                *[str(p) for p in prompts],
+            ],
+            env=os.environ.copy(),
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        manifest = self.manifest()
+        for index in range(1, len(prompts) + 1):
+            self.assertEqual(manifest[f"stage_{index}_dry_run"], "true")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Stacked on #52354 — targets your branch so it lands with your runner rather than competing with it.

I wrote a Claude port independently (prepping for the Qwen3.8-27B drop), then found yours. We landed on nearly the same design, and several of your mechanisms were better than mine — I've adopted the structured verdict, the stdin writer thread, the max-turns terminal, and the prompt wrapper on my side. This carries the fixes that flow the other way.

Scope: one runner file plus a new tests directory. No prompt, skill, or Codex-runner changes.

**Fixes**

- **A run that dies mid-stage can't be resumed.** The session id is recorded only after a goal finishes, so a crash leaves no anchor — which is the whole point of `--resume-stage`. Now recorded before the agent starts.
- **The stage timeout can't fire on a silent hang.** It's checked inside the output loop, which is blocked waiting for output. Moved to a watchdog thread.
- **A hung check script hangs the pipeline forever.** Added `--check-timeout`.
- **Failure messages come out empty.** Error results carry their detail in a different field than the one being read.
- Handles the "agent couldn't produce a valid verdict" outcome as recoverable rather than fatal.
- Strips API keys from the agent environment, so a stray key can't move a long run onto metered billing.
- Two flag-handling bugs that surfaced as confusing failures.

**Tests**

24 tests against a fake CLI — no hardware, no API calls, ~5s. Covers verdict handling, gate policy, resume, crash recovery, timeouts, and auth.

```
python3 .agents/tests/test_multigoal_claude.py
```

Draft because two classification choices in here are judgment calls I'd rather you make, and you should decide if you want this shape at all. Happy to reshape or drop any part.
