### PR TITLE
Replace the GMG_UNGROUPED_TOP8 define with a defaultless template parameter

### DIFF
--- a/models/common/tests/modules/moe/test_generalized_moe_gate.py
+++ b/models/common/tests/modules/moe/test_generalized_moe_gate.py
@@ -390,7 +390,7 @@ def test_generalized_moe_gate_512_global(device, batch_size, enable_sigmoid, see
 def test_generalized_moe_gate_grouped(device, batch_size, enable_sigmoid, seed):
     """DeepSeek GROUPED gate via ``generalized_moe_gate(grouped=True)``: 256 experts = 8 groups × 32 ->
     top-2-sum per group -> top-4 groups -> top-8, linear renorm + scale. Confirms the unified op's grouped
-    path (compiled with GMG_UNGROUPED_TOP8=0) matches the grouped golden — the path the standalone
+    path (ungrouped_top8=false via the moe_gate_ungrouped_top8 CT arg) matches the grouped golden — the path the standalone
     ``deepseek_moe_gate`` op used to own. grouped fixes top-8 + linear renorm, so topk / output_softmax are
     not swept (the op rejects other values in that mode)."""
     eps, scaling_factor = 1e-20, 2.5

--- a/models/demos/deepseek_v3_b1/unified_kernels/deepseek_moe_gate.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/deepseek_moe_gate.hpp
@@ -21,10 +21,6 @@
 #include "api/compute/pack.h"
 #include "api/compute/reconfig_data_format.h"
 #include "api/compute/eltwise_binary.h"
-// Canonical generalized_moe_gate requires an explicit path select and hard-errors without
-// one: 0 = grouped DeepSeek gate (top-4 groups, then top-8 within them), 1 = ungrouped
-// global top-8. This is the DeepSeek gate, so 0.
-#define GMG_UNGROUPED_TOP8 0
 #include "api/compute/experimental/generalized_moe_gate.h"
 #endif
 
@@ -133,7 +129,8 @@ struct DeepseekMoeGate {
             reconfig_data_format_srca(CTArgs::input_cb);  // Assumes same tile shape as input indices CB
             generalized_moe_gate_init<CTArgs::enable_sigmoid>(CTArgs::input_cb, CTArgs::bias_cb);
             cb_wait_front(CTArgs::input_cb, 1);
-            generalized_moe_gate<CTArgs::enable_sigmoid>(
+            // Path select: false = the grouped DeepSeek gate (top-4 groups, then top-8 within them).
+            generalized_moe_gate</*ungrouped_top8=*/false, CTArgs::enable_sigmoid>(
                 CTArgs::input_cb, CTArgs::bias_cb, CTArgs::eps, CTArgs::scaling_factor);
             // Pop input tile
             cb_pop_front(CTArgs::input_cb, 1);

--- a/tt_metal/hw/inc/api/compute/experimental/generalized_moe_gate.h
+++ b/tt_metal/hw/inc/api/compute/experimental/generalized_moe_gate.h
@@ -103,10 +103,16 @@ ALWI void generalized_moe_gate_relocate_run() {
         VectorMode::RC_custom)));
 }
 
+// ungrouped_top8: REQUIRED path select, NO default on purpose. true = ungrouped global top-k (every
+// non-DeepSeek model); false = grouped DeepSeek gate (8 groups x 32 -> top-2-sum -> top-4 groups -> top-8).
+// It used to be the GMG_UNGROUPED_TOP8 compile define with a silent grouped fallthrough, which is wrong
+// for every non-DeepSeek model — a defaultless template parameter keeps the choice explicit at every
+// call site with no preprocessor coupling.
 // produce_run: for the multi-block (>256) path, end the ungrouped pipeline at merge16_to_run (a
 // re-mergeable top-8 RUN at {run_store_lo, run_store_hi}, idx += idx_offset) and SKIP normalize+step2.
 // Default (produce_run=false) = the single-256 path: finalize (merge + normalize) + step2.
 template <
+    bool ungrouped_top8,
     bool enable_sigmoid = false,
     bool is_32bit = false,
     bool produce_run = false,
@@ -155,96 +161,89 @@ ALWI void generalized_moe_gate(uint32_t icb0, uint32_t icb1, uint32_t eps, uint3
     // Transpose dest step 0 (FPU) — always runs; puts each group g at DEST row g.
     MATH((llk_math_generalized_moe_gate_transpose_dest_single_face_step0_init<is_32bit>()));
     MATH((llk_math_generalized_moe_gate_transpose_dest_single_face_step0<DST_ACCUM_MODE, is_32bit>()));
-    // Path select — REQUIRED, NO silent default. The including kernel (.cpp) must define GMG_UNGROUPED_TOP8
-    // to 1 (ungrouped top-k — every non-DeepSeek model) or 0 (grouped DeepSeek gate). Leaving it undefined is
-    // a hard compile error on purpose: it used to fall through to the grouped path with no diagnostic, which
-    // is wrong for every non-DeepSeek model. (Note `#if`, not `#ifdef`: `=0` selects grouped, `=1` ungrouped.)
-#if !defined(GMG_UNGROUPED_TOP8)
-#error \
-    "generalized_moe_gate(): define GMG_UNGROUPED_TOP8 (to 1 = ungrouped top-k, or 0 = grouped DeepSeek) in the including kernel before this header — the silent grouped default was removed to avoid selecting the wrong HW sequence."
-#endif
-#if GMG_UNGROUPED_TOP8
-    // TRUE GLOBAL TOP-8 over all 256 experts (ungrouped). post-step0: group g at DEST row g.
-    // SFPU merges stay in rows 0-7 (only rows 0-7 are SFPU-addressable); FPU copy4rows (a plain
-    // MOVD2B->MOVB2D copy) stashes 4-row blocks in rows 8-15. topA -> {0,2} (rows 0-3), topB -> {4,6}
-    // (rows 4-7): row-disjoint. Each copy4rows uses a DISJOINT SrcB scratch window (16/20/24/28) so a
-    // later MOVB2D can't read a previous (back-to-back) copy's SrcB leftover.
-    //
-    // save groups 4-7 source (rows 4-7) -> rows 8-11 (step1<0> below clobbers rows 0-7).
-    MATH((llk_math_generalized_moe_gate_copy4rows_init<4, 8, is_32bit, 16>()));
-    MATH((llk_math_generalized_moe_gate_copy4rows<DST_ACCUM_MODE, is_32bit>()));
-    // topA = top8(groups 0-3): step1<d2b_dst=0> -> run at rows 0-7 -> merge -> topA at {0,2}.
-    MATH((llk_math_generalized_moe_gate_transpose_dest_single_face_step1_hi_init<0, 0, is_32bit>()));
-    MATH((llk_math_generalized_moe_gate_transpose_dest_single_face_step1_hi<DST_ACCUM_MODE, is_32bit>()));
-    MATH((SFPU_UNARY_CALL(
-        DST_SYNC_MODE,
-        DST_ACCUM_MODE,
-        generalized_moe_gate_merge4_top8,
-        (APPROX, DST_ACCUM_MODE, 0, 0, 2),
-        0,
-        VectorMode::RC_custom)));
-    // park topA (rows 0-3) -> rows 12-15; restore groups 4-7 (rows 8-11) -> rows 4-7.
-    MATH((llk_math_generalized_moe_gate_copy4rows_init<0, 12, is_32bit, 20>()));
-    MATH((llk_math_generalized_moe_gate_copy4rows<DST_ACCUM_MODE, is_32bit>()));
-    MATH((llk_math_generalized_moe_gate_copy4rows_init<8, 4, is_32bit, 24>()));
-    MATH((llk_math_generalized_moe_gate_copy4rows<DST_ACCUM_MODE, is_32bit>()));
-    // topB = top8(groups 4-7): step1_hi<d2b_dst=4> -> run at rows 0-7 -> merge -> topB at {4,6}.
-    MATH((llk_math_generalized_moe_gate_transpose_dest_single_face_step1_hi_init<4, 0, is_32bit>()));
-    MATH((llk_math_generalized_moe_gate_transpose_dest_single_face_step1_hi<DST_ACCUM_MODE, is_32bit>()));
-    MATH((SFPU_UNARY_CALL(
-        DST_SYNC_MODE,
-        DST_ACCUM_MODE,
-        generalized_moe_gate_merge4_top8,
-        (APPROX, DST_ACCUM_MODE, 0, 4, 6),
-        0,
-        VectorMode::RC_custom)));
-    // restore topA (rows 12-15) -> rows 0-3; now topA@{0,2} (rows 0-3), topB@{4,6} (rows 4-7).
-    MATH((llk_math_generalized_moe_gate_copy4rows_init<12, 0, is_32bit, 28>()));
-    MATH((llk_math_generalized_moe_gate_copy4rows<DST_ACCUM_MODE, is_32bit>()));
-    if constexpr (produce_run) {
-        // Multi-block: emit this block's top-8 as a re-mergeable RUN at {run_store_lo, run_store_hi}
-        // (idx += idx_offset for global ids). No normalize/step2 here — the combine does that.
+    // Path select — the defaultless ungrouped_top8 template parameter (see the doc above the template).
+    if constexpr (ungrouped_top8) {
+        // TRUE GLOBAL TOP-8 over all 256 experts (ungrouped). post-step0: group g at DEST row g.
+        // SFPU merges stay in rows 0-7 (only rows 0-7 are SFPU-addressable); FPU copy4rows (a plain
+        // MOVD2B->MOVB2D copy) stashes 4-row blocks in rows 8-15. topA -> {0,2} (rows 0-3), topB -> {4,6}
+        // (rows 4-7): row-disjoint. Each copy4rows uses a DISJOINT SrcB scratch window (16/20/24/28) so a
+        // later MOVB2D can't read a previous (back-to-back) copy's SrcB leftover.
+        //
+        // save groups 4-7 source (rows 4-7) -> rows 8-11 (step1<0> below clobbers rows 0-7).
+        MATH((llk_math_generalized_moe_gate_copy4rows_init<4, 8, is_32bit, 16>()));
+        MATH((llk_math_generalized_moe_gate_copy4rows<DST_ACCUM_MODE, is_32bit>()));
+        // topA = top8(groups 0-3): step1<d2b_dst=0> -> run at rows 0-7 -> merge -> topA at {0,2}.
+        MATH((llk_math_generalized_moe_gate_transpose_dest_single_face_step1_hi_init<0, 0, is_32bit>()));
+        MATH((llk_math_generalized_moe_gate_transpose_dest_single_face_step1_hi<DST_ACCUM_MODE, is_32bit>()));
         MATH((SFPU_UNARY_CALL(
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
-            generalized_moe_gate_merge16_to_run,
-            (APPROX, DST_ACCUM_MODE, run_store_lo, run_store_hi, idx_offset),
+            generalized_moe_gate_merge4_top8,
+            (APPROX, DST_ACCUM_MODE, 0, 0, 2),
             0,
             VectorMode::RC_custom)));
-    } else {
-        // Single ≤256 block: full bitonic sort of topA{0,2}+topB{4,6} -> global top-8, then keep top-`topk`
-        // (zero ranks >= topk before normalize) + normalize over those (softmax over the kept if output_softmax).
+        // park topA (rows 0-3) -> rows 12-15; restore groups 4-7 (rows 8-11) -> rows 4-7.
+        MATH((llk_math_generalized_moe_gate_copy4rows_init<0, 12, is_32bit, 20>()));
+        MATH((llk_math_generalized_moe_gate_copy4rows<DST_ACCUM_MODE, is_32bit>()));
+        MATH((llk_math_generalized_moe_gate_copy4rows_init<8, 4, is_32bit, 24>()));
+        MATH((llk_math_generalized_moe_gate_copy4rows<DST_ACCUM_MODE, is_32bit>()));
+        // topB = top8(groups 4-7): step1_hi<d2b_dst=4> -> run at rows 0-7 -> merge -> topB at {4,6}.
+        MATH((llk_math_generalized_moe_gate_transpose_dest_single_face_step1_hi_init<4, 0, is_32bit>()));
+        MATH((llk_math_generalized_moe_gate_transpose_dest_single_face_step1_hi<DST_ACCUM_MODE, is_32bit>()));
         MATH((SFPU_UNARY_CALL(
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
-            generalized_moe_gate_finalize_ungrouped,
-            (APPROX, DST_ACCUM_MODE, topk, output_softmax),
+            generalized_moe_gate_merge4_top8,
+            (APPROX, DST_ACCUM_MODE, 0, 4, 6),
+            0,
+            VectorMode::RC_custom)));
+        // restore topA (rows 12-15) -> rows 0-3; now topA@{0,2} (rows 0-3), topB@{4,6} (rows 4-7).
+        MATH((llk_math_generalized_moe_gate_copy4rows_init<12, 0, is_32bit, 28>()));
+        MATH((llk_math_generalized_moe_gate_copy4rows<DST_ACCUM_MODE, is_32bit>()));
+        if constexpr (produce_run) {
+            // Multi-block: emit this block's top-8 as a re-mergeable RUN at {run_store_lo, run_store_hi}
+            // (idx += idx_offset for global ids). No normalize/step2 here — the combine does that.
+            MATH((SFPU_UNARY_CALL(
+                DST_SYNC_MODE,
+                DST_ACCUM_MODE,
+                generalized_moe_gate_merge16_to_run,
+                (APPROX, DST_ACCUM_MODE, run_store_lo, run_store_hi, idx_offset),
+                0,
+                VectorMode::RC_custom)));
+        } else {
+            // Single ≤256 block: full bitonic sort of topA{0,2}+topB{4,6} -> global top-8, then keep top-`topk`
+            // (zero ranks >= topk before normalize) + normalize over those (softmax over the kept if output_softmax).
+            MATH((SFPU_UNARY_CALL(
+                DST_SYNC_MODE,
+                DST_ACCUM_MODE,
+                generalized_moe_gate_finalize_ungrouped,
+                (APPROX, DST_ACCUM_MODE, topk, output_softmax),
+                0,
+                VectorMode::RC_custom,
+                eps,
+                scale)));
+        }
+    } else {
+        // Grouped DeepSeek gate: sort_top4 selects top-4 groups, step1 lays them out, top8 merges.
+        MATH((SFPU_UNARY_CALL(
+            DST_SYNC_MODE,
+            DST_ACCUM_MODE,
+            generalized_moe_gate_sort_top4_groups,
+            (APPROX, DST_ACCUM_MODE),
+            0,
+            VectorMode::RC_custom)));
+        MATH((llk_math_generalized_moe_gate_transpose_dest_single_face_step1_init<is_32bit>()));
+        MATH((llk_math_generalized_moe_gate_transpose_dest_single_face_step1<DST_ACCUM_MODE, is_32bit>()));
+        MATH((SFPU_UNARY_CALL(
+            DST_SYNC_MODE,
+            DST_ACCUM_MODE,
+            generalized_moe_gate_top8,
+            (APPROX, DST_ACCUM_MODE),
             0,
             VectorMode::RC_custom,
             eps,
             scale)));
     }
-#else
-    // Grouped DeepSeek gate: sort_top4 selects top-4 groups, step1 lays them out, top8 merges.
-    MATH((SFPU_UNARY_CALL(
-        DST_SYNC_MODE,
-        DST_ACCUM_MODE,
-        generalized_moe_gate_sort_top4_groups,
-        (APPROX, DST_ACCUM_MODE),
-        0,
-        VectorMode::RC_custom)));
-    MATH((llk_math_generalized_moe_gate_transpose_dest_single_face_step1_init<is_32bit>()));
-    MATH((llk_math_generalized_moe_gate_transpose_dest_single_face_step1<DST_ACCUM_MODE, is_32bit>()));
-    MATH((SFPU_UNARY_CALL(
-        DST_SYNC_MODE,
-        DST_ACCUM_MODE,
-        generalized_moe_gate_top8,
-        (APPROX, DST_ACCUM_MODE),
-        0,
-        VectorMode::RC_custom,
-        eps,
-        scale)));
-#endif  // GMG_UNGROUPED_TOP8
     // Transpose dest step 2 (FPU) — final output layout. Skipped in produce_run mode (the run stays
     // in the SFPU run layout for the combine; step2 runs once after the combine instead).
     if constexpr (!produce_run) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate/device/generalized_moe_gate_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate/device/generalized_moe_gate_device_operation_types.hpp
@@ -20,7 +20,7 @@ struct operation_attributes_t {
     bool grouped{false};         // false = ungrouped global top-k (the generalized kernel path). true = DeepSeek
                                  // grouped gate (8 groups × 32 → top-2-sum → top-4 groups → top-8): single 256-block,
                                  // forced top-8 + linear renorm (topk/output_softmax ignored). Selects the kernel's
-                                 // grouped `#else` path via the GMG_UNGROUPED_TOP8=0 compile define (see builder).
+                                 // grouped path via the moe_gate_ungrouped_top8=0 named compile-time arg (see builder).
 };
 
 struct tensor_args_t {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate/device/generalized_moe_gate_program_descriptor_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate/device/generalized_moe_gate_program_descriptor_builder.cpp
@@ -138,6 +138,7 @@ tt::tt_metal::ProgramDescriptor build_moe_gate_program_descriptor(
         {"moe_gate_enable_sigmoid", operation_attrs.enable_sigmoid ? 1u : 0u},
         {"moe_gate_topk", operation_attrs.topk},
         {"moe_gate_softmax", operation_attrs.output_softmax ? 1u : 0u},
+        {"moe_gate_ungrouped_top8", operation_attrs.grouped ? 0u : 1u},
         {"moe_gate_num_blocks", num_blocks},
         {"moe_gate_run_scores_cb", run_scores_cb},
         {"moe_gate_run_idx_cb", run_idx_cb},
@@ -153,13 +154,6 @@ tt::tt_metal::ProgramDescriptor build_moe_gate_program_descriptor(
     // The multi-block combine parks block0's run in DEST and reads it back in block1's SEPARATE acquire;
     // that only survives if acquire does not swap banks.
     compute_config.dst_full_sync_en = true;
-
-    // Path-select for the unified kernel, injected as a compile DEFINE (NOT a named CT arg): the compute API
-    // picks ungrouped-vs-grouped with `#if GMG_UNGROUPED_TOP8` at PREPROCESS time, before CT-arg constexprs
-    // exist. =1 → ungrouped global top-k; =0 → DeepSeek grouped gate. Set on ALL THREE kernels: the single
-    // .cpp is compiled for every RISC and includes the compute API header, whose `#error` guard requires the
-    // macro to be defined (so a missing define is a hard compile error, never a silent grouped fallthrough).
-    const KernelDescriptor::Defines gmg_defines = {{"GMG_UNGROUPED_TOP8", operation_attrs.grouped ? "0" : "1"}};
 
     KernelDescriptor reader{
         .kernel_source = std::string(kGeneralizedMoeGateKernelPath),
@@ -194,10 +188,6 @@ tt::tt_metal::ProgramDescriptor build_moe_gate_program_descriptor(
         .named_compile_time_args = std::move(trisc_named),
         .config = compute_config,
     };
-
-    reader.defines = gmg_defines;
-    writer.defines = gmg_defines;
-    compute_k.defines = gmg_defines;
 
     tt::tt_metal::ProgramDescriptor program_desc;
     program_desc.kernels.reserve(3);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate/device/kernels/generalized_moe_gate_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate/device/kernels/generalized_moe_gate_kernel.cpp
@@ -9,14 +9,15 @@
 // BRISC: Waits for output CBs
 // TRISC: Computes gate logic (sigmoid, bias add, sorting, normalization)
 
-// MODE SELECT — GMG_UNGROUPED_TOP8 is injected by the device op as a compile DEFINE (NOT hardcoded here):
+// MODE SELECT — moe_gate_ungrouped_top8 is a named compile-time arg set by the device op (NOT hardcoded here):
 //   = 1: true global top-8 over all 256 experts (ungrouped). The proven 4-group merge runs twice
 //        (topA=top8(groups 0-3) at cols {0,2}, topB=top8(groups 4-7) at {4,6}, with FPU copy4rows stashing
 //        the idle half in rows 8-15), then finalize fully bitonic-sorts the 16 candidates -> global top-8.
 //   = 0: the DeepSeek grouped gate (8 groups × 32 -> top-2-sum -> top-4 groups -> top-8).
-// The descriptor builder sets it from operation_attrs.grouped (false -> 1, true -> 0) on all three RISC
-// kernels; the compute API (#if GMG_UNGROUPED_TOP8) #errors if it is undefined, so there is no silent default.
+// The descriptor builder sets it from operation_attrs.grouped (false -> 1, true -> 0); it flows to the
+// compute API as the defaultless `ungrouped_top8` template parameter of generalized_moe_gate<>.
 
+#include <cstdint>
 #include "../unified_kernels/kernel_op_api.hpp"
 #include "../unified_kernels/kernel_utils.hpp"
 #include "../unified_kernels/generalized_moe_gate.hpp"
@@ -34,10 +35,10 @@ void kernel_main() {
     using MoeGateCTArgs = deepseek_v3_ops::GeneralizedMoeGate::ReaderCTArgs;
 
     // Named compile-time args for sharded buffer setup
-    constexpr uint32_t input_cb = get_named_compile_time_arg_val("moe_gate_input_cb");
-    constexpr uint32_t bias_cb = get_named_compile_time_arg_val("moe_gate_bias_cb");
-    constexpr uint32_t input_indices_cb = get_named_compile_time_arg_val("moe_gate_input_indices_cb");
-    constexpr uint32_t num_blocks = get_named_compile_time_arg_val("moe_gate_num_blocks");
+    constexpr std::uint32_t input_cb = get_named_compile_time_arg_val("moe_gate_input_cb");
+    constexpr std::uint32_t bias_cb = get_named_compile_time_arg_val("moe_gate_bias_cb");
+    constexpr std::uint32_t input_indices_cb = get_named_compile_time_arg_val("moe_gate_input_indices_cb");
+    constexpr std::uint32_t num_blocks = get_named_compile_time_arg_val("moe_gate_num_blocks");
 
     // Setup sharded persistent buffers (all tensor-backed). input + bias each have num_blocks tiles/core
     // (one 256-expert block per tile); input_indices likewise has num_blocks tiles/core — block b's tile
@@ -63,6 +64,7 @@ void kernel_main() {
         get_named_compile_time_arg_val("moe_gate_eps"),
         get_named_compile_time_arg_val("moe_gate_scaling_factor"),
         get_named_compile_time_arg_val("moe_gate_enable_sigmoid"),
+        get_named_compile_time_arg_val("moe_gate_ungrouped_top8"),
         get_named_compile_time_arg_val("moe_gate_num_blocks"),
         get_named_compile_time_arg_val("moe_gate_run_scores_cb"),
         get_named_compile_time_arg_val("moe_gate_run_idx_cb"),

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate/device/unified_kernels/generalized_moe_gate.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/generalized_moe_gate/device/unified_kernels/generalized_moe_gate.hpp
@@ -53,48 +53,50 @@ struct GeneralizedMoeGate {
     struct ReaderCTArgs {};
 
     // Writer CTArgs (BRISC)
-    template <uint32_t output_cb_, uint32_t output_indices_cb_>
+    template <std::uint32_t output_cb_, std::uint32_t output_indices_cb_>
     struct WriterCTArgs {
-        static constexpr uint32_t output_cb = output_cb_;
-        static constexpr uint32_t output_indices_cb = output_indices_cb_;
+        static constexpr std::uint32_t output_cb = output_cb_;
+        static constexpr std::uint32_t output_indices_cb = output_indices_cb_;
     };
 
     // Compute CTArgs (TRISC)
     // enable_sigmoid must be compile-time (template parameter for generalized_moe_gate<>)
     template <
-        uint32_t input_cb_,
-        uint32_t bias_cb_,
-        uint32_t input_indices_cb_,
-        uint32_t output_cb_,
-        uint32_t output_indices_cb_,
-        uint32_t eps_,
-        uint32_t scaling_factor_,
-        uint32_t enable_sigmoid_,
-        uint32_t num_blocks_ = 1,
-        uint32_t run_scores_cb_ = 5,
-        uint32_t run_idx_cb_ = 6,
-        uint32_t run_bias_cb_ = 7,
-        uint32_t cb_tilize_ = 8,
-        uint32_t cb_tilize_idx_ = 9,
-        uint32_t topk_ = 8,
-        uint32_t output_softmax_ = 0>
+        std::uint32_t input_cb_,
+        std::uint32_t bias_cb_,
+        std::uint32_t input_indices_cb_,
+        std::uint32_t output_cb_,
+        std::uint32_t output_indices_cb_,
+        std::uint32_t eps_,
+        std::uint32_t scaling_factor_,
+        std::uint32_t enable_sigmoid_,
+        std::uint32_t ungrouped_top8_,
+        std::uint32_t num_blocks_ = 1,
+        std::uint32_t run_scores_cb_ = 5,
+        std::uint32_t run_idx_cb_ = 6,
+        std::uint32_t run_bias_cb_ = 7,
+        std::uint32_t cb_tilize_ = 8,
+        std::uint32_t cb_tilize_idx_ = 9,
+        std::uint32_t topk_ = 8,
+        std::uint32_t output_softmax_ = 0>
     struct ComputeCTArgs {
-        static constexpr uint32_t input_cb = input_cb_;
-        static constexpr uint32_t bias_cb = bias_cb_;
-        static constexpr uint32_t input_indices_cb = input_indices_cb_;
-        static constexpr uint32_t output_cb = output_cb_;
-        static constexpr uint32_t output_indices_cb = output_indices_cb_;
-        static constexpr uint32_t eps = eps_;
-        static constexpr uint32_t scaling_factor = scaling_factor_;
+        static constexpr std::uint32_t input_cb = input_cb_;
+        static constexpr std::uint32_t bias_cb = bias_cb_;
+        static constexpr std::uint32_t input_indices_cb = input_indices_cb_;
+        static constexpr std::uint32_t output_cb = output_cb_;
+        static constexpr std::uint32_t output_indices_cb = output_indices_cb_;
+        static constexpr std::uint32_t eps = eps_;
+        static constexpr std::uint32_t scaling_factor = scaling_factor_;
         static constexpr bool enable_sigmoid = enable_sigmoid_ == 1;
-        static constexpr uint32_t num_blocks = num_blocks_;
-        static constexpr uint32_t run_scores_cb = run_scores_cb_;
-        static constexpr uint32_t run_idx_cb = run_idx_cb_;
-        static constexpr uint32_t run_bias_cb = run_bias_cb_;
-        static constexpr uint32_t cb_tilize = cb_tilize_;
-        static constexpr uint32_t cb_tilize_idx = cb_tilize_idx_;
-        static constexpr uint32_t topk = topk_;
+        static constexpr std::uint32_t num_blocks = num_blocks_;
+        static constexpr std::uint32_t run_scores_cb = run_scores_cb_;
+        static constexpr std::uint32_t run_idx_cb = run_idx_cb_;
+        static constexpr std::uint32_t run_bias_cb = run_bias_cb_;
+        static constexpr std::uint32_t cb_tilize = cb_tilize_;
+        static constexpr std::uint32_t cb_tilize_idx = cb_tilize_idx_;
+        static constexpr std::uint32_t topk = topk_;
         static constexpr bool output_softmax = output_softmax_ == 1;
+        static constexpr bool ungrouped_top8 = ungrouped_top8_ == 1;
         // topk is restricted to {4, 6, 8}: the finalize rank-mask is correct only for these (topk 1-3 leave
         // ranks 0-3 unmasked, 5/7 are untested). The device op rejects other values on the host (TT_FATAL)
         // before this kernel is ever compiled; this static_assert is the compile-time mirror, so a kernel
@@ -120,7 +122,7 @@ struct GeneralizedMoeGate {
         // Run the full per-256 pipeline on block b, ending at merge16_to_run (a re-mergeable top-8
         // RUN at rows {0,2}, idx made global via +b*256), and pack its 3 fields (score/idx/bias)
         // to the L1 stash CBs (page b).
-        template <uint32_t b>
+        template <std::uint32_t b>
         void process_block_to_run() {
             CircularBuffer bias_cb(CTArgs::bias_cb);
             CircularBuffer input_cb(CTArgs::input_cb);
@@ -138,7 +140,7 @@ struct GeneralizedMoeGate {
             copy_tile(CTArgs::input_indices_cb, b, 1);
             reconfig_data_format_srca(CTArgs::input_cb);
             generalized_moe_gate_init<CTArgs::enable_sigmoid>(CTArgs::input_cb, CTArgs::bias_cb);
-            generalized_moe_gate<CTArgs::enable_sigmoid, false, /*produce_run=*/true, 0, 2, 0>(
+            generalized_moe_gate<CTArgs::ungrouped_top8, CTArgs::enable_sigmoid, false, /*produce_run=*/true, 0, 2, 0>(
                 CTArgs::input_cb, CTArgs::bias_cb, CTArgs::eps, CTArgs::scaling_factor);  // math run at {0,2}
             // Relocate {0,2}->{0,4} BEFORE step2: step2 is built for the finalize layout (store8_even_cols
             // at offsets {0,4}); applied to a {0,2} run it mis-strides and 2-period-duplicates col 2 (and
@@ -227,6 +229,7 @@ struct GeneralizedMoeGate {
                 generalized_moe_gate_init<CTArgs::enable_sigmoid>(CTArgs::input_cb, CTArgs::bias_cb);
                 input_cb.wait_front(1);
                 generalized_moe_gate<
+                    CTArgs::ungrouped_top8,
                     CTArgs::enable_sigmoid,
                     false,
                     false,
@@ -270,7 +273,7 @@ struct GeneralizedMoeGate {
                 run_scores_cb.wait_front(CTArgs::num_blocks);
                 reconfig_data_format_srca(CTArgs::run_scores_cb);
                 tilize_init(CTArgs::run_scores_cb, 1, CTArgs::cb_tilize);
-                for (uint32_t b = 0; b < CTArgs::num_blocks; ++b) {
+                for (std::uint32_t b = 0; b < CTArgs::num_blocks; ++b) {
                     cb_tilize.reserve_back(1);
                     tilize_block(CTArgs::run_scores_cb, 1, CTArgs::cb_tilize);
                     cb_tilize.push_back(1);
@@ -280,7 +283,7 @@ struct GeneralizedMoeGate {
                 run_bias_cb.wait_front(CTArgs::num_blocks);
                 reconfig_data_format_srca(CTArgs::run_bias_cb);
                 tilize_init(CTArgs::run_bias_cb, 1, CTArgs::cb_tilize);
-                for (uint32_t b = 0; b < CTArgs::num_blocks; ++b) {
+                for (std::uint32_t b = 0; b < CTArgs::num_blocks; ++b) {
                     cb_tilize.reserve_back(1);
                     tilize_block(CTArgs::run_bias_cb, 1, CTArgs::cb_tilize);
                     cb_tilize.push_back(1);
@@ -291,7 +294,7 @@ struct GeneralizedMoeGate {
                 run_idx_cb.wait_front(CTArgs::num_blocks);
                 reconfig_data_format_srca(CTArgs::run_idx_cb);
                 tilize_init(CTArgs::run_idx_cb, 1, CTArgs::cb_tilize_idx);
-                for (uint32_t b = 0; b < CTArgs::num_blocks; ++b) {
+                for (std::uint32_t b = 0; b < CTArgs::num_blocks; ++b) {
                     cb_tilize_idx.reserve_back(1);
                     tilize_block(CTArgs::run_idx_cb, 1, CTArgs::cb_tilize_idx);
                     cb_tilize_idx.push_back(1);


### PR DESCRIPTION
### PR Category

Cleanup / API improvement

### Summary

Follow-up to #52747: `generalized_moe_gate` path select becomes a **defaultless template parameter** instead of a preprocessor define.

- `generalized_moe_gate<bool ungrouped_top8, ...>` — the `#if GMG_UNGROUPED_TOP8 / #else / #endif` block becomes `if constexpr`. The "no silent default" property is preserved and strengthened: the parameter has no default value, so the choice is enforced by the type system at every call site (the old `#error` guard is gone because it is no longer reachable).
- **ttnn op**: the descriptor builder passes `moe_gate_ungrouped_top8` as a named compile-time arg (replacing the `GMG_UNGROUPED_TOP8` defines injection on all three kernels); the kernel threads it through `ComputeCTArgs` to both call sites.
- **b1 demo**: drops `#define GMG_UNGROUPED_TOP8 0` and passes `/*ungrouped_top8=*/false` explicitly.
- **tt-blaze** keeps its vendored define-based copy until its rewire, which flips call sites the same way (mechanical, tracked in tt-blaze#1971).

**Stacked on #52747** (currently in the merge queue) — this PR shows both commits until it lands, then collapses to one.

### Verification

- **Instruction-identical codegen**: the moe-gate kernel TU was compiled at the base commit (define version) and at this PR's commit (template version) with the production Blackhole JIT flag set, for all three TRISC contexts; the disassemblies are identical to the instruction (the only diff is the object filename in the objdump header). `if constexpr` produces exactly the code `#if` did.
- **Device bit-exact**: raw device outputs across all 12 `test_deepseek_moe_gate` parameter combos (batch × sigmoid × 3 seeds) are bit-identical between the define and template versions on BH p100a.
- No file this PR touches has changed on main since the change was authored (verified per-file).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilenkovic/gmg-template-toggle)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilenkovic/gmg-template-toggle)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilenkovic/gmg-template-toggle)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilenkovic/gmg-template-toggle)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilenkovic/gmg-template-toggle)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilenkovic/gmg-template-toggle)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilenkovic/gmg-template-toggle)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilenkovic/gmg-template-toggle)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilenkovic/gmg-template-toggle)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilenkovic/gmg-template-toggle)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilenkovic/gmg-template-toggle)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilenkovic/gmg-template-toggle)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilenkovic/gmg-template-toggle)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilenkovic/gmg-template-toggle)