### PR TITLE
sdpa: revert even-ring split forwarding from ring-joint SDPA

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -185,13 +185,6 @@ void kernel_main() {
         }
     }
 
-    // Mirror the writer's split-forwarding (see ring_attention_all_gather_writer.cpp): on an even ring the diametric
-    const bool split_forwarding_enabled = (topology == Topology::Ring) && (ring_size % 2 == 0) && (ring_size > 2);
-    if (split_forwarding_enabled && direction == 1) {
-        slices_expected++;
-        writes_expected++;
-    }
-
     while (slices_received < slices_expected) {
         // Do i expect more from the backward direction?
         // In the linear case, I expect num_targets_backward_direction slices from the left
@@ -231,32 +224,16 @@ void kernel_main() {
         // In the ring case, if I have received on the right less than my targets on the left, forward
         if ((topology == Topology::Linear && writes_expected > 0) ||
             (topology == Topology::Ring && (slices_received < (writes_expected + 1)))) {
-            // The last slice we relay is the diametric shard of our downstream neighbor
-            const bool is_split_forwarded_slice = split_forwarding_enabled && (slices_received == writes_expected);
             for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
+                uint32_t tiles_read = input_tile_id_start[input_idx];
+                uint32_t tiles_to_read = input_tile_id_end[input_idx];
+
+                uint32_t output_tile_id_start = 0;
+                uint32_t pages_read_in_row = input_tile_id_start[input_idx] % input_tensor_Wt[input_idx];
+                uint32_t row_offset =
+                    (input_tile_id_start[input_idx] / input_tensor_Wt[input_idx]) * output_tensor_Wt[input_idx];
                 uint32_t slice_Wt = input_tensor_Wt[input_idx];
                 uint32_t stride_Wt = output_tensor_Wt[input_idx];
-
-                // Packet-aligned midpoint of this input's per-batch-head page range (matches the writer)
-                const uint32_t total_pages = input_tile_id_end[input_idx] - input_tile_id_start[input_idx];
-                const uint32_t num_packets = (total_pages + packet_size_in_pages - 1) / packet_size_in_pages;
-                const uint32_t first_half_pages = (num_packets / 2) * packet_size_in_pages;
-                const bool split_this_input = is_split_forwarded_slice;
-                uint32_t relay_start = input_tile_id_start[input_idx];
-                uint32_t relay_end = input_tile_id_end[input_idx];
-                if (split_this_input) {
-                    if (direction == 0) {
-                        relay_end = input_tile_id_start[input_idx] + first_half_pages;
-                    } else {
-                        relay_start = input_tile_id_start[input_idx] + first_half_pages;
-                    }
-                }
-
-                uint32_t tiles_read = relay_start;
-                uint32_t tiles_to_read = relay_end;
-                uint32_t output_tile_id_start = 0;
-                uint32_t pages_read_in_row = relay_start % slice_Wt;
-                uint32_t row_offset = (relay_start / slice_Wt) * stride_Wt;
                 if (gather_dim == 3) {
                     output_tile_id_start = actual_sender_chip_id * input_tensor_Wt[input_idx];
                 } else {
@@ -285,10 +262,11 @@ void kernel_main() {
                             }
                             return pid;
                         });
-                    pages_read_in_row = relay_start % slice_Wt;
-                    row_offset = (relay_start / slice_Wt) * stride_Wt;
-                    tiles_read = relay_start;
-                    tiles_to_read = relay_end;
+                    pages_read_in_row = input_tile_id_start[input_idx] % input_tensor_Wt[input_idx];
+                    row_offset =
+                        (input_tile_id_start[input_idx] / input_tensor_Wt[input_idx]) * output_tensor_Wt[input_idx];
+                    tiles_read = input_tile_id_start[input_idx];
+                    tiles_to_read = input_tile_id_end[input_idx];
                     output_tile_id_start += output_tensor_Wt[input_idx] * output_tensor_Ht[input_idx];
                 }
             }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
@@ -294,12 +294,6 @@ void kernel_main() {
         }
     }
 
-    // On an even ring the terminal relayed slice
-    const bool split_forwarding_enabled = (topology == Topology::Ring) && (ring_size % 2 == 0) && (ring_size > 2);
-    if (split_forwarding_enabled && direction == 1) {
-        writes_expected++;
-    }
-
     while (slice_writes < writes_expected) {
         // Direction == backward
         // Did I get something from my left to send to my right?
@@ -321,7 +315,6 @@ void kernel_main() {
             slice_chip_id = my_chip_id - slice_writes - 1;
             actual_slice_chip_id = (slice_chip_id < 0) ? ring_size + slice_chip_id : slice_chip_id;
         }
-        const bool is_split_forwarded_slice = split_forwarding_enabled && (slice_writes == writes_expected - 1);
         for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
             uint32_t tiles_read = input_tile_id_start[input_idx];
             uint32_t tiles_to_read = input_tile_id_end[input_idx];
@@ -337,63 +330,47 @@ void kernel_main() {
             } else {
                 tile_id_start = actual_slice_chip_id * input_tensor_Ht[input_idx] * input_tensor_Wt[input_idx];
             }
-
-            // Packet-aligned midpoint of this input's per-batch-head page range
-            const uint32_t total_pages = tiles_to_read - input_tile_id_start[input_idx];
-            const uint32_t num_packets = (total_pages + packet_size_in_pages - 1) / packet_size_in_pages;
-            const uint32_t first_half_pages = (num_packets / 2) * packet_size_in_pages;
-            const bool split_this_input = is_split_forwarded_slice;
-
             for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {
                 while (tiles_read < tiles_to_read) {
                     uint32_t num_pages_to_read = std::min(tiles_to_read - tiles_read, packet_size_in_pages);
-                    uint32_t page_in_bh = tiles_read - input_tile_id_start[input_idx];
-                    bool relay_this_packet =
-                        !split_this_input ||
-                        (direction == 0 ? (page_in_bh < first_half_pages) : (page_in_bh >= first_half_pages));
-
+                    cb_output.wait_front(packet_size_in_pages);
+                    size_t l1_read_addr = cb_output.get_read_ptr();
                     uint32_t first_tile_id = tile_id_start + row_offset + pages_read_in_row;
                     pages_read_in_row++;
                     if (pages_read_in_row >= slice_Wt) {
                         row_offset += stride_Wt;
                         pages_read_in_row = 0;
                     }
-                    uint32_t second_tile_id = 0;
+
                     if (num_pages_to_read == 2) {
-                        second_tile_id = tile_id_start + row_offset + pages_read_in_row;
+                        uint32_t second_tile_id = tile_id_start + row_offset + pages_read_in_row;
                         pages_read_in_row++;
                         if (pages_read_in_row >= slice_Wt) {
                             row_offset += stride_Wt;
                             pages_read_in_row = 0;
                         }
-                    }
 
-                    if (relay_this_packet) {
-                        cb_output.wait_front(packet_size_in_pages);
-                        size_t l1_read_addr = cb_output.get_read_ptr();
-                        if (num_pages_to_read == 2) {
-                            scatter_fabric_write_unidir(
-                                first_tile_id,
-                                second_tile_id,
-                                output_addrgens[input_idx],
-                                pkt_hdr,
-                                *fabric_direction_connection,
-                                l1_read_addr,
-                                output_page_size);
-                        } else {
-                            ASSERT(num_pages_to_read == 1);
-                            fabric_write_unidir(
-                                first_tile_id,
-                                output_addrgens[input_idx],
-                                pkt_hdr,
-                                *fabric_direction_connection,
-                                l1_read_addr,
-                                output_page_size);
-                        }
-                        cb_output.pop_front(packet_size_in_pages);
+                        scatter_fabric_write_unidir(
+                            first_tile_id,
+                            second_tile_id,
+                            output_addrgens[input_idx],
+                            pkt_hdr,
+                            *fabric_direction_connection,
+                            l1_read_addr,
+                            output_page_size);
+                    } else {
+                        ASSERT(num_pages_to_read == 1);
+                        fabric_write_unidir(
+                            first_tile_id,
+                            output_addrgens[input_idx],
+                            pkt_hdr,
+                            *fabric_direction_connection,
+                            l1_read_addr,
+                            output_page_size);
                     }
 
                     tiles_read += num_pages_to_read;
+                    cb_output.pop_front(packet_size_in_pages);
                 }
                 tile_id_start += output_tensor_Wt[input_idx] * output_tensor_Ht[input_idx];
                 tiles_read = input_tile_id_start[input_idx];

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/fused_op_receiver.hpp
@@ -16,11 +16,6 @@ struct RingSDPAOpReceiver {
     std::array<uint32_t, 2> signal_op_semaphore_ids = {0, 0};
     bool initialized = false;
 
-    // Even-ring split-forwarding: the diametric shard arrives split across both links and is signaled on both
-    bool split_forwarding_enabled = false;
-    uint32_t split_shard_id = 0;
-    uint32_t split_second_half_wait = 0;
-
     RingSDPAOpReceiver() {}
 
     RingSDPAOpReceiver(bool wait_for_op_signal, uint32_t& rt_args_idx) : wait_for_op_signal(wait_for_op_signal) {
@@ -34,9 +29,6 @@ struct RingSDPAOpReceiver {
             signal_op_semaphore_ids[1] = get_arg_val<uint32_t>(rt_args_idx++);
             // Second is AllGather's FWD semaphore. It belongs to direction 0.
             signal_op_semaphore_ids[0] = get_arg_val<uint32_t>(rt_args_idx++);
-            split_forwarding_enabled = get_arg_val<uint32_t>(rt_args_idx++) == 1;
-            split_shard_id = get_arg_val<uint32_t>(rt_args_idx++);
-            split_second_half_wait = get_arg_val<uint32_t>(rt_args_idx++);
         }
 
         seq = RingIdSequencer(ring_index, ring_size, backward_writes_expected, forward_writes_expected);
@@ -45,16 +37,11 @@ struct RingSDPAOpReceiver {
 
     uint32_t get_next_ring_id_and_sync() {
         ASSERT(initialized);
-        uint32_t ring_id = seq.get_next_ring_id([&](uint32_t dir, uint32_t val) {
+        return seq.get_next_ring_id([&](uint32_t dir, uint32_t val) {
             if (this->wait_for_op_signal) {
                 Semaphore<>(this->signal_op_semaphore_ids[dir]).wait_min(val);
             }
         });
-        // The split shard's second half lands via direction 1 (all-gather semaphore index 0)
-        if (this->wait_for_op_signal && this->split_forwarding_enabled && ring_id == this->split_shard_id) {
-            Semaphore<>(this->signal_op_semaphore_ids[0]).wait_min(this->split_second_half_wait);
-        }
-        return ring_id;
     }
 
     uint32_t get_next_ring_id_and_consume_one_signal() {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.cpp
@@ -69,13 +69,5 @@ void RingSDPAFusedOpSignaler::push_ring_sdpa_fused_op_rt_args(std::vector<uint32
     out_rt_args.push_back(static_cast<uint32_t>(this->backward_writes_expected));
     out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_receiver_signal_semaphores[0]));
     out_rt_args.push_back(static_cast<uint32_t>(this->fused_op_receiver_signal_semaphores[1]));
-
-    // Even-ring split-forwarding: the diametric shard S arrives split across both links
-    const uint32_t split_shard_id =
-        this->ring_size ? ((this->ring_index + this->backward_writes_expected + 1) % this->ring_size) : 0;
-    const uint32_t split_second_half_wait = this->backward_writes_expected + 1;
-    out_rt_args.push_back(static_cast<uint32_t>(this->split_forwarding_enabled ? 1 : 0));
-    out_rt_args.push_back(static_cast<uint32_t>(split_shard_id));
-    out_rt_args.push_back(static_cast<uint32_t>(split_second_half_wait));
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_fusion.hpp
@@ -24,9 +24,6 @@ struct RingSDPAFusedOpSignaler {
     uint32_t forward_writes_expected = 0;
     uint32_t backward_writes_expected = 0;
 
-    // Set by the program factory when the all-gather relays the diametric slice split across both links
-    bool split_forwarding_enabled = false;
-
     bool initialized_all_gather = false;
     bool initialized_fused_op = false;
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -1182,12 +1182,6 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         sdpa_fused_op_signaler->initialized_fused_op = true;
     }
 
-    // Must match the all-gather kernels' split-forwarding gate exactly
-    sdpa_fused_op_signaler->split_forwarding_enabled =
-        (args.all_gather_operation_attributes.topology == ttnn::ccl::Topology::Ring) &&
-        (args.all_gather_operation_attributes.ring_size % 2 == 0) &&
-        (args.all_gather_operation_attributes.ring_size > 2);
-
     log_debug(tt::LogOp, "num_cores: {}", num_cores);
     log_debug(
         tt::LogOp, "mesh_device->compute_with_storage_grid_size(): {}", mesh_device->compute_with_storage_grid_size());


### PR DESCRIPTION
## Summary

Reverts the even-ring **split-forwarding** feature that #52730 (`c080ab0cfc94`) added to ring-joint SDPA. This is the surgical alternative to #53053, which Pavle has handed off to us.

Split-forwarding is the *entirety* of what #52730 changed in these 6 files (3 hunks per all-gather kernel, all split-related; the metadata / KV-cache-slot features in the same files predate it), and **nothing has touched them since** on `main`. So the revert is `git checkout c080ab0cfc94~1 -- <6 files>`: an exact, conflict-free inverse, `+35/-110` against `+110/-35`.

## What was failing

`blackhole-multi-card-fast-sanity-tests / sdpa nightly tests (QB2 only)` — 10 test failures, which are **2 real bugs plus 8 consequences**:

| Group | Tests | Signature |
|---|---|---|
| Hang | `test_ring_mla_chunked_accuracy[kimi_k3, kimi50k]` | `TIMEOUT: device timeout ... device is unrecoverable` |
| Cascade | 6 tests | `Device 0 init: failed to initialize FW!` — downstream of the hang |
| PCC | `..._chunked_nd_sharded_indexed_kv_cache_accuracy[fp32_acc, bf16_acc]` | PCC 0.9794 / 0.9796 vs 0.997 / 0.994 |

The PCC failures sit earlier in the file than the hang, so they ran before the device died and are independent of it. `fp32` and `bf16` give near-identical PCC (0.97944 / 0.97957), which reads as systematic error rather than a race.

## Why revert rather than patch again

1. **The design requires a cross-op mirror.** The all-gather in `experimental/ccl` decides to split; a consumer in `transformer/sdpa` must independently reproduce that decision. #52730's own comment says it: *"Must match the all-gather kernels' split-forwarding gate exactly."* #53053 improves this by passing the flag instead of re-deriving it, but the underlying wait is still a single coarse threshold (`split_second_half_wait = backward_writes_expected + 1`) for the whole shard rather than a per-chunk event count — which is exactly why `+1` vs `+2` was an open question that consumed two CI cycles.

2. **Two further consumers of the same rt-arg block were never updated**, both currently latent:
   - `fused_op_indexer.hpp:36` advances `rt_args_idx += 2` while `push_ring_sdpa_fused_op_rt_args` now pushes 5. Harmless only because that constructor has no callers.
   - `get_next_ring_id_and_consume_one_signal()` never received the split-shard second-half wait its sibling `get_next_ring_id_and_sync()` got, and it uses `down(1)` rather than `wait_min`. Masked because only the sliding-window path calls it, which #53053 gates off.

   Same shape of defect twice: the feature added protocol state that not every consumer learned about.

3. **Prior art keeps failing.** The optimization originated as Ligang Long's AG-minimal balanced traffic pattern and was **reverted twice** (`#36607` → `#37832`, `#37878` → `#38202`) before landing on the third attempt in `#38256`.

## What is NOT reverted

**#52513's split forwarding in strided AGMM stays**, and it is a genuinely independent, correct implementation — not a copy. It splits at *chunk* granularity with byte-identical producer/consumer predicates (`minimal_default_writer.cpp:330` vs `minimal_default_mm_signal_aggregator.cpp:81`) and waits on a monotonic event counter (`event_target++` then `noc_semaphore_wait_min` per worker per band). There is no threshold to get wrong, so the miscount here cannot occur there. LTX's strided-AGMM path is therefore unaffected by this revert.

## Verification status — please read

**This revert cannot be verified outside CI, and is not yet verified.**

The suite runs on exactly one SKU (`tests/pipeline_reorg/blackhole_multi_card_sanity_tests.yaml:51`, `skus:` lists only `bh_quietbox_2`), and the failing shapes require `sp=4`:

| | QB2 (fails) | 4x8 galaxy (dev box) |
|---|---|---|
| devices | 4 | 32 |
| ring (`sp_size`) | 4 | 8 |
| `tp_size` | 1 | 4 |
| SDPA cores | 100 | 110 |
| chunk-0 `logical_n` | **256** | 512 |

`MeshConfig.detect()` derives all of this from the `/dev/tenstorrent` count with no override, and sequence length scales as `128 x sp_size`. CI's failing case `test_ring_mla_chunked_accuracy[kimi_k3-all-qk-chunk2560]` **does not exist** on a galaxy — it parametrizes as `[kimi_k3-q32-k512-chunk5120]`. The failing shape is unreachable there.

What local galaxy testing *can* show is absence of ring8 regression:

- `determinism or nd_sharded_indexed_kv_cache_accuracy`: **27/27 passed** (720s)
- chunked accuracy batch: in progress at time of opening
- non-chunked accuracy batch: pending
- LTX distilled e2e vs a 26.9 s/gen baseline: pending

Caveat: there is **no pre-revert ring8 baseline** for those 27 (the baseline job was lost to a tooling error on my side). They pass with the revert applied; that is not the same claim as "unchanged by the revert".

**The gate is a `workflow_dispatch` of `blackhole-sanity-tests.yaml` against this branch with `run-blackhole-multi-card-fast-unit-tests` enabled.** It does not fire automatically on PRs. Pass condition: the 2 real failures go green, the 6 cascade failures recover, and Minimax reuse-KV does not regress (that is what #53053's `+2` experiment broke, per QB2 job 94493466874).

## Follow-ups (not in this PR)

- Fix the two latent defects above so they cannot bite whoever reintroduces split forwarding.
- If split forwarding is wanted back, the AGMM shape is the model: per-chunk split, monotonic event counter, producer and consumer deriving the predicate from the same constants in the same op.
- No galaxy SKU runs `tests/nightly/blackhole/sdpa/`, which is how this reached `main`. Worth deciding whether that suite should also run on a 4x8.

cc @cglagovichTT @pavlejosipovic @nwoodallTT

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rsalman/revert-ring-joint-split-forwarding-2026-08-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rsalman/revert-ring-joint-split-forwarding-2026-08-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rsalman/revert-ring-joint-split-forwarding-2026-08-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rsalman/revert-ring-joint-split-forwarding-2026-08-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rsalman/revert-ring-joint-split-forwarding-2026-08-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rsalman/revert-ring-joint-split-forwarding-2026-08-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rsalman/revert-ring-joint-split-forwarding-2026-08-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rsalman/revert-ring-joint-split-forwarding-2026-08-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rsalman/revert-ring-joint-split-forwarding-2026-08-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rsalman/revert-ring-joint-split-forwarding-2026-08-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rsalman/revert-ring-joint-split-forwarding-2026-08-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rsalman/revert-ring-joint-split-forwarding-2026-08-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rsalman/revert-ring-joint-split-forwarding-2026-08-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rsalman/revert-ring-joint-split-forwarding-2026-08-13)