### PR TITLE
[ttnn] Always validate Metal 2.0 program args on cache miss, gate only hit-path re-validation

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
@@ -1798,6 +1798,40 @@ TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_TensorSpecMismatchFails) {
             "TensorArgument for binding 'input_tensor' supplied a MeshTensor whose TensorSpec does not match")));
 }
 
+// Locks the gate's polarity: the three tests above prove UpdateTensorArgs validates by default, so
+// this one proves skip_validation=true is what turns it off — and still performs the address patch.
+TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_SkipValidationBypassesSpecCheck) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    auto binding = MakeMinimalTensorParameter("input_tensor");  // shape {1, 32}
+    spec.tensor_parameters = {binding};
+    BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    MeshTensor tensor = AllocateTensorForBinding(*mesh_device_, binding);
+    auto params = MakeRunArgsForMinimalSpec(node, {}, {});
+    params.tensor_args = {
+        {TensorParamName{"input_tensor"}, TensorArgument{tensor}},
+    };
+    SetProgramRunArgs(program, params);
+
+    auto page_config = tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR);
+    auto memory_config =
+        tt::tt_metal::MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
+    auto tensor_layout = tt::tt_metal::TensorLayout(tt::tt_metal::DataType::BFLOAT16, page_config, memory_config);
+    auto wrong_spec = tt::tt_metal::TensorSpec(tt::tt_metal::Shape{1, 64}, tensor_layout);
+    MeshTensor wrong_tensor = MeshTensor::allocate_on_device(*mesh_device_, wrong_spec);
+
+    Table<TensorParamName, TensorArgument> tensor_args{
+        {TensorParamName{"input_tensor"}, TensorArgument{wrong_tensor}},
+    };
+    EXPECT_NO_THROW(UpdateTensorArgs(program, tensor_args, /*skip_validation=*/true));
+    EXPECT_EQ(
+        ReadBindingAddressFromCRTA(program, "dm_kernel", "input_tensor"), static_cast<uint32_t>(wrong_tensor.address()))
+        << "skip_validation should bypass only the checks, not the address patch";
+}
+
 TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_PatchesBindingAddress) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
@@ -102,9 +102,15 @@ void UpdateProgramRunArgs(Program& program, const ProgramRunArgs& params, bool s
 // ProgramSpec, exactly once. The supplied MeshTensor's TensorSpec must match the
 // TensorParameter's declared spec.
 //
+// PRE-CONDITION: If skip_validation is true, the caller guarantees the completeness and
+// spec-match requirements above.
+//
 // USE CASE: Program re-enqueue loops where the only per-enqueue ProgramRunArgs variation
 // is in the tensor args (i.e. which specific MeshTensors are operated on by the Program).
-void UpdateTensorArgs(Program& program, const Table<TensorParamName, ProgramRunArgs::TensorArgument>& tensor_args);
+void UpdateTensorArgs(
+    Program& program,
+    const Table<TensorParamName, ProgramRunArgs::TensorArgument>& tensor_args,
+    bool skip_validation = false);
 
 }  // namespace tt::tt_metal::experimental
 

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -793,7 +793,8 @@ void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip
     program_impl.mark_program_run_args_initialized();
 }
 
-void UpdateTensorArgs(Program& program, const Table<TensorParamName, ProgramRunArgs::TensorArgument>& tensor_args) {
+void UpdateTensorArgs(
+    Program& program, const Table<TensorParamName, ProgramRunArgs::TensorArgument>& tensor_args, bool skip_validation) {
     log_debug(tt::LogMetal, "Updating tensor args (partial fast-path)");
 
     detail::ProgramImpl& program_impl = program.impl();
@@ -808,7 +809,9 @@ void UpdateTensorArgs(Program& program, const Table<TensorParamName, ProgramRunA
         "UpdateTensorArgs called on Program before SetProgramRunArgs. Call SetProgramRunArgs at least once first.");
 
     // Validate the TensorArgument list (shared with the full-path validator).
-    ValidateTensorArgs(program, tensor_args);
+    if (!skip_validation) {
+        ValidateTensorArgs(program, tensor_args);
+    }
 
     // Build a tensor_parameter_name -> MeshTensor lookup.
     // As in SetProgramRunArgs, this assumes lockstep mesh allocation:

--- a/ttnn/api/ttnn/config.hpp
+++ b/ttnn/api/ttnn/config.hpp
@@ -26,8 +26,8 @@ struct Config {
         std::filesystem::path tmp_dir = "/tmp/ttnn";
         bool enable_model_cache = false;
         bool enable_fast_runtime_mode = true;
-        // Validate the Metal 2.0 host-side program args: the ProgramSpec on MakeProgramFromSpec and the
-        // ProgramRunArgs on Set/UpdateProgramRunArgs. Off by default; CI turns it on.
+        // Re-validate Metal 2.0 program args on the cache-hit fast path (Update{Tensor,ProgramRun}Args).
+        // The cache-miss build path always validates. Off by default; CI turns it on.
         bool validate_program_args = false;
         bool throw_exception_on_fallback = false;
         bool enable_logging = false;

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -906,13 +906,13 @@ public:
             auto op_owned_tensors =
                 std::make_shared<std::vector<tt::tt_metal::MeshTensor>>(std::move(artifacts.op_owned_tensors));
 
-            const bool skip_validation = !ttnn::CONFIG.get<"validate_program_args">();
+            // Cache miss is the cold path: always validate here, so every cached program was
+            // built from a checked spec. validate_program_args only gates the hit-path re-checks.
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
             for (const auto& range : tensor_coords.ranges()) {
-                auto program =
-                    tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec, skip_validation);
-                tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params, skip_validation);
+                auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
+                tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
                 shared_variables.emplace(
                     range, shared_variables_t{.bindings = bindings, .op_owned_tensors = op_owned_tensors});
                 mesh_workload.add_program(range, std::move(program));
@@ -931,6 +931,7 @@ public:
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
             auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
+            const bool skip_validation = !ttnn::CONFIG.get<"validate_program_args">();
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
                 const auto& sv = cached_workload.shared_variables.at(coordinate_range);
 
@@ -947,7 +948,7 @@ public:
                 for (const auto& b : sv.bindings) {
                     fresh_tensor_args.emplace(b.tensor_parameter_name, TensorArgument{mesh_tensors[b.tensor_idx]});
                 }
-                tt::tt_metal::experimental::UpdateTensorArgs(program, fresh_tensor_args);
+                tt::tt_metal::experimental::UpdateTensorArgs(program, fresh_tensor_args, skip_validation);
             }
         }
     };


### PR DESCRIPTION
### Ticket
Follow-up to #50945.

### Problem description
#50945 added the `validate_program_args` config (off by default, enabled in the sanity pipelines) to keep Metal 2.0 host-side arg validation off the user hot path. As wired, the polarity is inverted on both ends:

- **Cache miss (cold path) was gated.** With the default config, `MakeProgramFromSpec` skips `ValidateProgramSpec` — the semantic legality checks — and `SetProgramRunArgs` skips its validation. A malformed spec goes straight into the program cache at the one point where validation is nearly free (amortized against a full program build).
- **Base-concept cache hit (hot path) was unconditional.** `UpdateTensorArgs` has no skip parameter and calls `ValidateTensorArgs` on every cache hit, so the steady-state dispatch path pays the validation cost everywhere — including off-CI, where the config was meant to remove it. Only the custom-factory hit path (`UpdateProgramRunArgs`) was gated correctly.

### What's changed
- Cache-miss build in `mesh_device_operation_adapter.hpp` always validates: `MakeProgramFromSpec` / `SetProgramRunArgs` are called without `skip_validation`.
- `UpdateTensorArgs` gains a defaulted `bool skip_validation = false` (mirroring `SetProgramRunArgs` / `UpdateProgramRunArgs`), gating only the `ValidateTensorArgs` call; the base-concept cache-hit path passes it from `validate_program_args`, same as the custom-factory hit path already did.
- `validate_program_args` now purely controls hit-path re-validation: CI sanity re-validates every dispatch, everything else validates once per cache entry at build time. All pipelines now get spec validation on cache miss, including those that don't set the config.

### Checklist
- [ ] CI passes

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/validate-args-hit-path-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/validate-args-hit-path-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/validate-args-hit-path-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/validate-args-hit-path-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/validate-args-hit-path-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/validate-args-hit-path-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/validate-args-hit-path-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/validate-args-hit-path-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/validate-args-hit-path-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/validate-args-hit-path-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/validate-args-hit-path-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/validate-args-hit-path-only)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/validate-args-hit-path-only)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/validate-args-hit-path-only)