### PR TITLE
Add X280 ISS hello world (Spike-backed rv64gcv / VLEN=512)

### DIFF
--- a/tests/tt_metal/tt_metal/x280_iss_hello/README.md
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/README.md
@@ -42,3 +42,18 @@ Success ends with: `The simulated X280 hello world ran. All checks passed.`
 ```bash
 ./run.sh --clean
 ```
+
+## Atomic bench
+
+`src/atomic_bench.c` is the tt-llm-engine AMO micro-benchmark, built for this
+ISS. There is no host/NOC, so `iss_host_stub.c` writes the `AB_CONFIG_READY`
+mailbox before `main`. After that wait succeeds the firmware prints
+`AB_CONFIG_READY: config latched on ISS`, then runs a short `amoadd.d` check
+(the full 4-hart mailbox phases are not driven on Spike).
+
+```bash
+./run_atomic_bench.sh
+```
+
+Success includes `AB_CONFIG_READY: config latched on ISS` and
+`amoadd.d xN -> counter=N OK`.

--- a/tests/tt_metal/tt_metal/x280_iss_hello/README.md
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/README.md
@@ -1,0 +1,44 @@
+<!--
+SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# X280 ISS hello world
+
+Run a LIM-linked hello world on a **simulated X280 cluster**, not on QEMU `sifive_u`.
+
+The ISS is Spike (`riscv-isa-sim`) configured to match Blackhole L2CPU X280:
+
+| Knob | Value | Source |
+| --- | --- | --- |
+| Harts | 4 identical | tt-llm-engine `x280/README.md` |
+| ISA | `rv64gcv` | same |
+| Vector | VLEN=512, ELEN=64 | `vlenb==64`, `vl==16` for e32/m1 |
+| LIM | `0x08000000` size `0x1E0000` | `x280/include/x280.h` |
+| Load address | `0x08001000` | active FW window |
+
+If you have a vendor SiFive X280 ISS, set `X280_ISS=/path/to/iss` and the same `./run.sh` will use it.
+
+This is an **ISA-level** simulator (correct vector/CSRs/4 harts/LIM map). It is not cycle-accurate and does not model Blackhole NOC/DMA.
+
+## Run
+
+```bash
+cd tests/tt_metal/tt_metal/x280_iss_hello
+./run.sh
+```
+
+Needs network on first run (clone Spike) and `riscv64-unknown-elf-gcc` (prefers tt-llm-engine’s toolchain):
+
+```bash
+X280_TOOLCHAIN=/path/to/tt-llm-engine/x280/toolchain ./run.sh
+# or
+TT_LLM_ENGINE=/path/to/tt-llm-engine ./run.sh
+```
+
+Success ends with: `The simulated X280 hello world ran. All checks passed.`
+
+```bash
+./run.sh --clean
+```

--- a/tests/tt_metal/tt_metal/x280_iss_hello/README.md
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/README.md
@@ -57,3 +57,20 @@ mailbox before `main`. After that wait succeeds the firmware prints
 
 Success includes `AB_CONFIG_READY: config latched on ISS` and
 `amoadd.d xN -> counter=N OK`.
+
+## Test harness
+
+`./run_harness.sh` builds a host-side Spike wrapper (`x280_harness`) that
+runs any LIM-linked ELF and can copy host files into guest physical memory
+(`--load FILE@ADDR`) or dump guest memory back to a file (`--dump ADDR+LEN:FILE`).
+
+```bash
+./run_harness.sh                  # bundled C benchmarks + load/dump checks
+./run_harness.sh harness/tests/fib.c
+./run_harness.sh build/out/hello.elf
+./run_harness.sh my.bin.elf --load payload.bin@0x08140000 --dump 0x08140000+256:out.bin
+```
+
+C files are linked with `src/boot.S` + `src/htif.c` at `0x08001000`. Guest
+payloads should use addresses in LIM above the linked image; `harness/guest.h`
+defines `HARNESS_DATA_BASE` (`0x08140000`).

--- a/tests/tt_metal/tt_metal/x280_iss_hello/harness/guest.h
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/harness/guest.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Shared guest addresses for harness tests. Must sit in Spike LIM
+// (0x08000000 + 0x1E0000) and above the linked image (ends 0x08120000).
+
+#ifndef X280_HARNESS_GUEST_H_
+#define X280_HARNESS_GUEST_H_
+
+#define HARNESS_DATA_BASE 0x08140000UL
+#define HARNESS_DATA_SIZE 0x00001000UL
+#define HARNESS_MAGIC 0x48524E53UL /* 'HRNS' */
+
+#endif

--- a/tests/tt_metal/tt_metal/x280_iss_hello/harness/tests/arith.c
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/harness/tests/arith.c
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "htif.h"
+
+int main(void) {
+    unsigned long sum = 0;
+    for (unsigned long i = 1; i <= 100; ++i) {
+        sum += i * i;
+    }
+    /* 100*101*201/6 = 338350 */
+    htif_puts("sum_sq_1_100=");
+    htif_put_u64_dec(sum);
+    htif_puts("\n");
+    if (sum != 338350UL) {
+        htif_puts("FAIL arith\n");
+        return 1;
+    }
+    htif_puts("PASS arith\n");
+    return 0;
+}

--- a/tests/tt_metal/tt_metal/x280_iss_hello/harness/tests/fib.c
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/harness/tests/fib.c
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "htif.h"
+
+static unsigned long fib(unsigned n) {
+    unsigned long a = 0;
+    unsigned long b = 1;
+    for (unsigned i = 0; i < n; ++i) {
+        unsigned long t = a + b;
+        a = b;
+        b = t;
+    }
+    return a;
+}
+
+int main(void) {
+    const unsigned long v = fib(20);
+    htif_puts("fib(20)=");
+    htif_put_u64_dec(v);
+    htif_puts("\n");
+    if (v != 6765UL) {
+        htif_puts("FAIL fib\n");
+        return 1;
+    }
+    htif_puts("PASS fib\n");
+    return 0;
+}

--- a/tests/tt_metal/tt_metal/x280_iss_hello/harness/tests/fill_and_dump.c
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/harness/tests/fill_and_dump.c
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Write a known pattern into HARNESS_DATA_BASE so the harness can --dump it.
+
+#include <stdint.h>
+
+#include "guest.h"
+#include "htif.h"
+
+int main(void) {
+    volatile uint8_t* p = (volatile uint8_t*)HARNESS_DATA_BASE;
+    for (unsigned i = 0; i < 256; ++i) {
+        p[i] = (uint8_t)(0xA5 ^ (uint8_t)i);
+    }
+    __asm__ volatile("fence ow, ow");
+    htif_puts("filled 256 bytes at ");
+    htif_put_u64_hex(HARNESS_DATA_BASE);
+    htif_puts("\nPASS fill_and_dump\n");
+    return 0;
+}

--- a/tests/tt_metal/tt_metal/x280_iss_hello/harness/tests/hello.c
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/harness/tests/hello.c
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "htif.h"
+
+int main(void) {
+    htif_puts("hello from x280 harness\n");
+    return 0;
+}

--- a/tests/tt_metal/tt_metal/x280_iss_hello/harness/tests/load_and_check.c
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/harness/tests/load_and_check.c
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Expects the harness to --load a file at HARNESS_DATA_BASE whose first
+// word is HARNESS_MAGIC and whose remaining bytes are 0x00, 0x01, ...
+
+#include <stdint.h>
+
+#include "guest.h"
+#include "htif.h"
+
+int main(void) {
+    const volatile uint8_t* p = (volatile const uint8_t*)HARNESS_DATA_BASE;
+    const uint32_t magic = (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+    htif_puts("loaded magic=");
+    htif_put_u64_hex(magic);
+    htif_puts("\n");
+    if (magic != HARNESS_MAGIC) {
+        htif_puts("FAIL load magic\n");
+        return 1;
+    }
+    for (unsigned i = 4; i < 256; ++i) {
+        if (p[i] != (uint8_t)i) {
+            htif_puts("FAIL load byte at ");
+            htif_put_u64_dec(i);
+            htif_puts("\n");
+            return 1;
+        }
+    }
+    htif_puts("PASS load_and_check\n");
+    return 0;
+}

--- a/tests/tt_metal/tt_metal/x280_iss_hello/harness/tests/mem_rw.c
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/harness/tests/mem_rw.c
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Guest-side transform: invert every preloaded byte so the host dump can
+// prove both load and store through the harness.
+
+#include <stdint.h>
+
+#include "guest.h"
+#include "htif.h"
+
+int main(void) {
+    volatile uint8_t* p = (volatile uint8_t*)HARNESS_DATA_BASE;
+    const uint32_t magic = (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+    if (magic != HARNESS_MAGIC) {
+        htif_puts("FAIL mem_rw magic\n");
+        return 1;
+    }
+    for (unsigned i = 0; i < 256; ++i) {
+        p[i] = (uint8_t)(p[i] ^ 0xFFu);
+    }
+    __asm__ volatile("fence ow, ow");
+    htif_puts("PASS mem_rw invert\n");
+    return 0;
+}

--- a/tests/tt_metal/tt_metal/x280_iss_hello/harness/tests/vector.c
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/harness/tests/vector.c
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "htif.h"
+
+#define READ_CSR(name)                                      \
+    ({                                                      \
+        unsigned long __v;                                  \
+        __asm__ __volatile__("csrr %0, " name : "=r"(__v)); \
+        __v;                                                \
+    })
+
+int main(void) {
+    const unsigned long misa = READ_CSR("misa");
+    const int has_v = (int)((misa >> 21) & 1);
+    unsigned long vlenb = 0;
+    unsigned long vl = 0;
+    if (has_v) {
+        __asm__ __volatile__("csrr %0, vlenb" : "=r"(vlenb));
+        __asm__ __volatile__("vsetvli %0, %1, e32, m1, ta, ma" : "=r"(vl) : "r"(32));
+    }
+    htif_puts("misa.V=");
+    htif_puts(has_v ? "yes" : "no");
+    htif_puts(" vlenb=");
+    htif_put_u64_dec(vlenb);
+    htif_puts(" vl=");
+    htif_put_u64_dec(vl);
+    htif_puts("\n");
+    if (!has_v || vlenb != 64UL || vl != 16UL) {
+        htif_puts("FAIL vector\n");
+        return 1;
+    }
+    htif_puts("PASS vector\n");
+    return 0;
+}

--- a/tests/tt_metal/tt_metal/x280_iss_hello/harness/x280_harness.cpp
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/harness/x280_harness.cpp
@@ -1,0 +1,320 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Host-side X280 ISS test harness. Embeds Spike's sim_t with the same
+// Blackhole L2CPU map as scripts/x280_iss.sh, then:
+//   * loads any RISC-V ELF and runs it to HTIF exit
+//   * copies host files into guest physical memory after ELF load
+//   * dumps guest physical memory to host files after the run
+//
+// Usage:
+//   x280_harness [options] <elf>
+//   --load  FILE@ADDR       write FILE bytes to guest physical ADDR
+//   --dump  ADDR+LEN:FILE   after run, write LEN bytes from ADDR to FILE
+//   --dump  ADDR:LEN:FILE   same (alternate spelling)
+
+#include <riscv/cfg.h>
+#include <riscv/debug_module.h>
+#include <riscv/devices.h>
+#include <riscv/sim.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr const char* kDefaultIsa = "rv64gcv_zicsr_zifencei_zvl512b";
+constexpr const char* kDefaultPriv = "MSU";
+constexpr size_t kDefaultHarts = 4;
+constexpr uint64_t kDefaultMemBase = 0x08000000ULL;
+constexpr uint64_t kDefaultMemSize = 0x001E0000ULL;
+constexpr uint64_t kDefaultPc = 0x08001000ULL;
+constexpr unsigned long long kDefaultInsnLimit = 100000000ULL;
+
+struct LoadOp {
+    std::string path;
+    uint64_t addr = 0;
+    std::vector<uint8_t> bytes;
+};
+
+struct DumpOp {
+    std::string path;
+    uint64_t addr = 0;
+    uint64_t len = 0;
+};
+
+struct Options {
+    std::string elf;
+    std::string isa = kDefaultIsa;
+    std::string priv = kDefaultPriv;
+    size_t nprocs = kDefaultHarts;
+    uint64_t mem_base = kDefaultMemBase;
+    uint64_t mem_size = kDefaultMemSize;
+    uint64_t pc = kDefaultPc;
+    unsigned long long insn_limit = kDefaultInsnLimit;
+    bool has_insn_limit = true;
+    std::vector<LoadOp> loads;
+    std::vector<DumpOp> dumps;
+};
+
+void usage(const char* argv0, int rc) {
+    std::cerr << "Usage: " << argv0 << " [options] <elf>\n"
+              << "\n"
+              << "Run a RISC-V ELF on a simulated Blackhole L2CPU X280 (Spike).\n"
+              << "Host files can be copied into guest physical memory, and guest\n"
+              << "memory can be dumped to host files after HTIF exit.\n"
+              << "\n"
+              << "Options:\n"
+              << "  --load FILE@ADDR         Copy FILE into guest memory at ADDR\n"
+              << "                           (applied after the ELF is loaded)\n"
+              << "  --dump ADDR+LEN:FILE     After run, write LEN bytes at ADDR to FILE\n"
+              << "  --dump ADDR:LEN:FILE     Same as ADDR+LEN:FILE\n"
+              << "  --isa STRING             ISA string [" << kDefaultIsa << "]\n"
+              << "  --priv STRING            Privilege modes [" << kDefaultPriv << "]\n"
+              << "  -p N                     Hart count [" << kDefaultHarts << "]\n"
+              << "  -m BASE:SIZE             Physical memory map ["
+              << "0x" << std::hex << kDefaultMemBase << ":0x" << kDefaultMemSize << std::dec << "]\n"
+              << "  --pc ADDR                Start PC [0x" << std::hex << kDefaultPc << std::dec << "]\n"
+              << "  --instructions N         Retire at most N instructions [" << kDefaultInsnLimit << "]\n"
+              << "  --no-instruction-limit   Run until HTIF exit\n"
+              << "  -h, --help               This help\n"
+              << "\n"
+              << "ADDR/LEN/N accept decimal or 0x-prefixed hex.\n";
+    std::exit(rc);
+}
+
+uint64_t parse_u64(const std::string& s, const char* what) {
+    if (s.empty()) {
+        throw std::runtime_error(std::string("empty ") + what);
+    }
+    char* end = nullptr;
+    const unsigned long long v = std::strtoull(s.c_str(), &end, 0);
+    if (end == s.c_str() || *end != '\0') {
+        throw std::runtime_error(std::string("invalid ") + what + ": " + s);
+    }
+    return static_cast<uint64_t>(v);
+}
+
+std::vector<uint8_t> read_file(const std::string& path) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) {
+        throw std::runtime_error("cannot open file for read: " + path);
+    }
+    in.seekg(0, std::ios::end);
+    const std::streamoff n = in.tellg();
+    if (n < 0) {
+        throw std::runtime_error("cannot stat file: " + path);
+    }
+    in.seekg(0, std::ios::beg);
+    std::vector<uint8_t> buf(static_cast<size_t>(n));
+    if (n > 0 && !in.read(reinterpret_cast<char*>(buf.data()), n)) {
+        throw std::runtime_error("short read: " + path);
+    }
+    return buf;
+}
+
+void write_file(const std::string& path, const std::vector<uint8_t>& buf) {
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    if (!out) {
+        throw std::runtime_error("cannot open file for write: " + path);
+    }
+    if (!buf.empty() &&
+        !out.write(reinterpret_cast<const char*>(buf.data()), static_cast<std::streamsize>(buf.size()))) {
+        throw std::runtime_error("short write: " + path);
+    }
+}
+
+LoadOp parse_load(const std::string& spec) {
+    const auto at = spec.rfind('@');
+    if (at == std::string::npos || at == 0 || at + 1 == spec.size()) {
+        throw std::runtime_error("--load expects FILE@ADDR, got: " + spec);
+    }
+    LoadOp op;
+    op.path = spec.substr(0, at);
+    op.addr = parse_u64(spec.substr(at + 1), "load address");
+    op.bytes = read_file(op.path);
+    return op;
+}
+
+DumpOp parse_dump(const std::string& spec) {
+    // ADDR+LEN:FILE  or  ADDR:LEN:FILE
+    const auto colon = spec.rfind(':');
+    if (colon == std::string::npos || colon + 1 == spec.size()) {
+        throw std::runtime_error("--dump expects ADDR+LEN:FILE or ADDR:LEN:FILE, got: " + spec);
+    }
+    DumpOp op;
+    op.path = spec.substr(colon + 1);
+    const std::string left = spec.substr(0, colon);
+    const auto plus = left.find('+');
+    const auto mid = left.find(':');
+    if (plus != std::string::npos) {
+        op.addr = parse_u64(left.substr(0, plus), "dump address");
+        op.len = parse_u64(left.substr(plus + 1), "dump length");
+    } else if (mid != std::string::npos) {
+        op.addr = parse_u64(left.substr(0, mid), "dump address");
+        op.len = parse_u64(left.substr(mid + 1), "dump length");
+    } else {
+        throw std::runtime_error("--dump expects ADDR+LEN:FILE or ADDR:LEN:FILE, got: " + spec);
+    }
+    if (op.len == 0) {
+        throw std::runtime_error("--dump length must be > 0");
+    }
+    return op;
+}
+
+void parse_mem(const std::string& spec, Options& opt) {
+    const auto colon = spec.find(':');
+    if (colon == std::string::npos) {
+        throw std::runtime_error("-m expects BASE:SIZE, got: " + spec);
+    }
+    opt.mem_base = parse_u64(spec.substr(0, colon), "memory base");
+    opt.mem_size = parse_u64(spec.substr(colon + 1), "memory size");
+}
+
+Options parse_args(int argc, char** argv) {
+    Options opt;
+    for (int i = 1; i < argc; ++i) {
+        const std::string a = argv[i];
+        auto need = [&](const char* name) -> std::string {
+            if (i + 1 >= argc) {
+                throw std::runtime_error(std::string(name) + " requires an argument");
+            }
+            return argv[++i];
+        };
+        if (a == "-h" || a == "--help") {
+            usage(argv[0], 0);
+        } else if (a == "--load") {
+            opt.loads.push_back(parse_load(need("--load")));
+        } else if (a == "--dump") {
+            opt.dumps.push_back(parse_dump(need("--dump")));
+        } else if (a == "--isa") {
+            opt.isa = need("--isa");
+        } else if (a == "--priv") {
+            opt.priv = need("--priv");
+        } else if (a == "-p") {
+            opt.nprocs = static_cast<size_t>(parse_u64(need("-p"), "hart count"));
+            if (opt.nprocs == 0) {
+                throw std::runtime_error("hart count must be > 0");
+            }
+        } else if (a == "-m") {
+            parse_mem(need("-m"), opt);
+        } else if (a == "--pc") {
+            opt.pc = parse_u64(need("--pc"), "pc");
+        } else if (a == "--instructions") {
+            opt.insn_limit = parse_u64(need("--instructions"), "instructions");
+            opt.has_insn_limit = true;
+        } else if (a == "--no-instruction-limit") {
+            opt.has_insn_limit = false;
+        } else if (!a.empty() && a[0] == '-') {
+            throw std::runtime_error("unknown option: " + a);
+        } else if (opt.elf.empty()) {
+            opt.elf = a;
+        } else {
+            throw std::runtime_error("unexpected extra argument: " + a);
+        }
+    }
+    if (opt.elf.empty()) {
+        usage(argv[0], 1);
+    }
+    return opt;
+}
+
+class x280_sim_t : public sim_t {
+public:
+    using sim_t::sim_t;
+    std::vector<LoadOp> loads;
+
+    void start() override {
+        htif_t::start();
+        for (const auto& load : loads) {
+            if (load.bytes.empty()) {
+                continue;
+            }
+            memif().write(load.addr, load.bytes.size(), load.bytes.data());
+            std::cerr << "[harness] loaded " << load.bytes.size() << " bytes from " << load.path << " @ 0x" << std::hex
+                      << load.addr << std::dec << "\n";
+        }
+    }
+};
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    try {
+        Options opt = parse_args(argc, argv);
+
+        cfg_t cfg;
+        cfg.isa = opt.isa.c_str();
+        cfg.priv = opt.priv.c_str();
+        cfg.mem_layout = {mem_cfg_t(opt.mem_base, opt.mem_size)};
+        cfg.start_pc.set_global(opt.pc);
+        cfg.explicit_hartids = false;
+        cfg.hartids.clear();
+        cfg.hartids.reserve(opt.nprocs);
+        for (size_t i = 0; i < opt.nprocs; ++i) {
+            cfg.hartids.push_back(i);
+        }
+
+        std::vector<std::unique_ptr<mem_t>> owned_mems;
+        std::vector<std::pair<reg_t, abstract_mem_t*>> mems;
+        for (const auto& region : cfg.mem_layout) {
+            owned_mems.emplace_back(std::make_unique<mem_t>(region.get_size()));
+            mems.emplace_back(region.get_base(), owned_mems.back().get());
+        }
+
+        debug_module_config_t dm_config;
+        const std::vector<device_factory_sargs_t> plugins;
+        std::vector<std::string> htif_args = {opt.elf};
+        std::optional<unsigned long long> insn_limit;
+        if (opt.has_insn_limit) {
+            insn_limit = opt.insn_limit;
+        }
+
+        std::cerr << "[harness] elf=" << opt.elf << " isa=" << opt.isa << " harts=" << opt.nprocs << " mem=0x"
+                  << std::hex << opt.mem_base << "+0x" << opt.mem_size << " pc=0x" << opt.pc << std::dec
+                  << " loads=" << opt.loads.size() << " dumps=" << opt.dumps.size() << "\n";
+
+        x280_sim_t sim(
+            &cfg,
+            false,
+            mems,
+            plugins,
+            false,
+            htif_args,
+            dm_config,
+            nullptr,
+            false,
+            nullptr,
+            false,
+            nullptr,
+            insn_limit);
+        sim.loads = std::move(opt.loads);
+
+        const int rc = sim.run();
+
+        for (const auto& dump : opt.dumps) {
+            std::vector<uint8_t> buf(static_cast<size_t>(dump.len));
+            sim.memif().read(dump.addr, buf.size(), buf.data());
+            write_file(dump.path, buf);
+            std::cerr << "[harness] dumped " << buf.size() << " bytes @ 0x" << std::hex << dump.addr << std::dec
+                      << " -> " << dump.path << "\n";
+        }
+
+        std::cerr << "[harness] exit=" << rc << "\n";
+        return rc;
+    } catch (const std::exception& e) {
+        std::cerr << "x280_harness: " << e.what() << "\n";
+        return 2;
+    }
+}

--- a/tests/tt_metal/tt_metal/x280_iss_hello/include/rt/x280_atomic.h
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/include/rt/x280_atomic.h
@@ -1,0 +1,34 @@
+/*
+ * rt/x280_atomic.h -- RISC-V AMOs for the X280 baremetal firmware.
+ *
+ * Both helpers return the old value: a producer does
+ * `my_slot = amoadd(&write_ptr, 1)` and the returned value is the slot claimed.
+ * The volatile and the "memory" clobber keep the compiler from eliding the op,
+ * hoisting it out of a loop, or dropping the result.
+ *
+ * amoadd works against LIM. LR/SC does not -- reservations are not tracked on
+ * uncached LIM, so sc.d never succeeds and the retry loop live-locks, stranding
+ * the hart, since an X280 cannot re-enter reset without a chip-level reset.
+ * Hence no compare-and-swap helper; CAS semantics have to be expressed as a
+ * fetch-and-add.
+ */
+#ifndef X280_RT_ATOMIC_H
+#define X280_RT_ATOMIC_H
+
+#include <stdint.h>
+
+/* amoadd.w rd, rs2, (rs1): rd = *p (old, 32-bit), then *p += v. */
+static inline uint32_t x280_amoadd_w(volatile uint32_t* p, uint32_t v) {
+    uint32_t old;
+    __asm__ volatile("amoadd.w %0, %2, (%1)" : "=r"(old) : "r"(p), "r"(v) : "memory");
+    return old;
+}
+
+/* amoadd.d rd, rs2, (rs1): rd = *p (old, 64-bit), then *p += v. */
+static inline uint64_t x280_amoadd_d(volatile uint64_t* p, uint64_t v) {
+    uint64_t old;
+    __asm__ volatile("amoadd.d %0, %2, (%1)" : "=r"(old) : "r"(p), "r"(v) : "memory");
+    return old;
+}
+
+#endif /* X280_RT_ATOMIC_H */

--- a/tests/tt_metal/tt_metal/x280_iss_hello/include/rt/x280_hw.h
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/include/rt/x280_hw.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ISS stand-in for rt/x280_hw.h. Spike is not given a Blackhole CLINT, so
+// mtime is rdcycle (ordering only — not a 50 MHz wall clock).
+
+#ifndef X280_RT_HW_H
+#define X280_RT_HW_H
+
+#include <stdint.h>
+
+static inline uint64_t x280_rdcycle(void) {
+    uint64_t c;
+    __asm__ volatile("rdcycle %0" : "=r"(c));
+    return c;
+}
+
+#define X280_MTIME_HZ 50000000ULL
+
+static inline uint64_t x280_mtime(void) { return x280_rdcycle(); }
+
+static inline void x280_pause(void) { __asm__ volatile("nop" ::: "memory"); }
+
+static inline __attribute__((noreturn)) void x280_cease(void) {
+    for (;;) {
+        __asm__ volatile("wfi");
+    }
+}
+
+#endif

--- a/tests/tt_metal/tt_metal/x280_iss_hello/include/rt/x280_idle.h
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/include/rt/x280_idle.h
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ISS stand-in for the idle-FW ping-pong exit. There is no resident idle
+// image at 0x08000000, so hart 0 HTIF-exits and helpers park.
+
+#ifndef X280_RT_IDLE_H
+#define X280_RT_IDLE_H
+
+#include <stdint.h>
+
+#include "htif.h"
+
+extern volatile uint64_t tohost;
+
+static inline __attribute__((noreturn)) void x280_helper_to_idle(void) {
+    for (;;) {
+        __asm__ volatile("wfi");
+    }
+}
+
+static inline __attribute__((noreturn)) void x280_hart0_to_idle(void) {
+    *SENTINEL_ADDR = SENTINEL_VALUE;
+    __asm__ volatile("fence ow, ow");
+    *(volatile uint64_t*)X280_BOOT_PHASE_ADDR = X280_BOOT_PHASE_RETURNED_TO_IDLE;
+    __asm__ volatile("fence ow, ow");
+    htif_puts("atomic_bench: hart0 returned to idle (ISS)\n");
+    while (tohost) {
+    }
+    tohost = 1; /* HTIF exit 0 */
+    for (;;) {
+        __asm__ volatile("wfi");
+    }
+}
+
+#endif

--- a/tests/tt_metal/tt_metal/x280_iss_hello/include/rt/x280_pll.h
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/include/rt/x280_pll.h
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ISS stub: no 50 MHz CLINT, so do not run the 8M-iteration silicon loop.
+
+#ifndef X280_RT_PLL_H
+#define X280_RT_PLL_H
+
+#include <stdint.h>
+
+static uint32_t __attribute__((unused)) x280_measure_pll_khz(void) { return 1000000u; }
+
+#endif

--- a/tests/tt_metal/tt_metal/x280_iss_hello/include/x280.h
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/include/x280.h
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// ISS subset of tt-llm-engine x280/include/x280.h — addresses the bench uses.
+
+#ifndef X280_H
+#define X280_H
+
+#include <stdint.h>
+
+#define LIM_BASE 0x08000000UL
+#define LIM_SIZE 0x1E0000UL
+
+#define SENTINEL_ADDR ((volatile uint64_t*)0x08100000UL)
+#define SENTINEL_VALUE 0xDEADBEEFCAFEBABEULL
+
+#define X280_IDLE_FW_LOAD_ADDR 0x08000000UL
+#define X280_ACTIVE_FW_LOAD_ADDR 0x08001000UL
+
+#define X280_BOOT_HANDSHAKE_BASE 0x08130200UL
+#define X280_BOOT_PHASE_ADDR (X280_BOOT_HANDSHAKE_BASE + 0xC0UL)
+#define X280_BOOT_PHASE_IDLE 0x000000001D1E0001ULL
+#define X280_BOOT_PHASE_RUNNING_ACTIVE_FW 0x000000007E570001ULL
+#define X280_BOOT_PHASE_RETURNED_TO_IDLE 0x000000001D1E0002ULL
+
+#define CLINT_BASE 0x02000000UL
+#define NUM_HARTS 4
+
+extern uint64_t _probe_active;
+
+#endif

--- a/tests/tt_metal/tt_metal/x280_iss_hello/ld/x280_iss.ld
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/ld/x280_iss.ld
@@ -13,6 +13,7 @@ ENTRY(_start)
 LIM_BASE  = 0x08001000;
 LIM_SIZE  = 0x0011F000;
 STACK_SIZE = 0x4000;
+NUM_HARTS = 4;
 
 MEMORY {
     lim (rwx) : ORIGIN = LIM_BASE, LENGTH = LIM_SIZE
@@ -46,7 +47,7 @@ SECTIONS {
         *(COMMON)
         . = ALIGN(16);
         _stack_bottom = .;
-        . += STACK_SIZE;
+        . += STACK_SIZE * NUM_HARTS;
         _stack_top = .;
     } > lim
 

--- a/tests/tt_metal/tt_metal/x280_iss_hello/ld/x280_iss.ld
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/ld/x280_iss.ld
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Active-FW LIM window matching tt-llm-engine x280/ld/x280.ld.
+ * Image is linked at 0x08001000 so the ISS can execute at the real X280
+ * load address (idle FW keeps 0x08000000..0x08000FFF).
+ */
+OUTPUT_ARCH(riscv)
+ENTRY(_start)
+
+LIM_BASE  = 0x08001000;
+LIM_SIZE  = 0x0011F000;
+STACK_SIZE = 0x4000;
+
+MEMORY {
+    lim (rwx) : ORIGIN = LIM_BASE, LENGTH = LIM_SIZE
+}
+
+SECTIONS {
+    .text LIM_BASE : {
+        KEEP(*(.text.start))
+        *(.text .text.*)
+        *(.rodata .rodata.*)
+        . = ALIGN(8);
+    } > lim
+
+    PROVIDE(__global_pointer$ = . + 0x7f0);
+
+    .data : {
+        *(.data .data.*)
+        *(.sdata .sdata.*)
+        . = ALIGN(8);
+    } > lim
+
+    .tohost : {
+        . = ALIGN(64);
+        KEEP(*(.tohost))
+        . = ALIGN(64);
+    } > lim
+
+    .bss (NOLOAD) : {
+        *(.bss .bss.*)
+        *(.sbss .sbss.*)
+        *(COMMON)
+        . = ALIGN(16);
+        _stack_bottom = .;
+        . += STACK_SIZE;
+        _stack_top = .;
+    } > lim
+
+    /DISCARD/ : { *(.comment) *(.note*) *(.eh_frame*) }
+}

--- a/tests/tt_metal/tt_metal/x280_iss_hello/run.sh
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/run.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# End-to-end: fetch the X280 ISS, build hello_x280, run it, verify output.
+# Usage: ./run.sh [--clean]
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="${WORK:-$HERE/build}"
+OUT="$WORK/out"
+
+if [[ "${1:-}" == "--clean" ]]; then
+    rm -rf "$WORK"
+    echo "cleaned $WORK"
+    exit 0
+fi
+
+say() { printf '\n\033[1m== %s\033[0m\n' "$*"; }
+die() { printf '\033[31mERROR: %s\033[0m\n' "$*" >&2; exit 1; }
+
+find_toolchain() {
+    if [[ -n "${X280_TOOLCHAIN:-}" && -x "${X280_TOOLCHAIN}/bin/riscv64-unknown-elf-gcc" ]]; then
+        echo "$X280_TOOLCHAIN"
+        return
+    fi
+    if [[ -n "${TT_LLM_ENGINE:-}" && -x "${TT_LLM_ENGINE}/x280/toolchain/bin/riscv64-unknown-elf-gcc" ]]; then
+        echo "${TT_LLM_ENGINE}/x280/toolchain"
+        return
+    fi
+    for cand in /data/*/tt-llm-engine*/x280/toolchain "$HOME"/tt-llm-engine*/x280/toolchain; do
+        [[ -x "$cand/bin/riscv64-unknown-elf-gcc" ]] && { echo "$cand"; return; }
+    done
+    if command -v riscv64-unknown-elf-gcc >/dev/null; then
+        echo "$(dirname "$(dirname "$(command -v riscv64-unknown-elf-gcc)")")"
+        return
+    fi
+    return 1
+}
+
+TC="$(find_toolchain)" || die "no riscv64-unknown-elf toolchain.
+Set X280_TOOLCHAIN=<dir> or TT_LLM_ENGINE=<tt-llm-engine checkout>."
+GCC="$TC/bin/riscv64-unknown-elf-gcc"
+OBJCOPY="$TC/bin/riscv64-unknown-elf-objcopy"
+OBJDUMP="$TC/bin/riscv64-unknown-elf-objdump"
+READELF="$TC/bin/riscv64-unknown-elf-readelf"
+
+say "0. toolchain"
+"$GCC" --version | head -1
+echo "toolchain: $TC"
+
+say "1. X280 ISS"
+"$HERE/scripts/fetch_iss.sh"
+
+mkdir -p "$OUT"
+ARCH=rv64gcv_zicsr_zifencei
+ABI=lp64d
+FLAGS=(-march="$ARCH" -mabi="$ABI" -mcmodel=medany -Os -g -ffreestanding
+    -fno-builtin -nostdlib -nostartfiles -Wall -I "$HERE/src")
+
+say "2. build hello_x280 (linked at 0x08001000)"
+"$GCC" "${FLAGS[@]}" -c "$HERE/src/boot.S" -o "$OUT/boot.o"
+"$GCC" "${FLAGS[@]}" -std=gnu11 -c "$HERE/src/htif.c" -o "$OUT/htif.o"
+"$GCC" "${FLAGS[@]}" -std=gnu11 -c "$HERE/src/hello_x280.c" -o "$OUT/hello_x280.o"
+"$GCC" "${FLAGS[@]}" -T "$HERE/ld/x280_iss.ld" -Wl,-Map,"$OUT/hello_x280.map" \
+    -Wl,--no-warn-rwx-segments \
+    "$OUT/boot.o" "$OUT/htif.o" "$OUT/hello_x280.o" -o "$OUT/hello_x280.elf"
+"$OBJCOPY" -O binary "$OUT/hello_x280.elf" "$OUT/hello_x280.bin"
+"$OBJDUMP" -d --demangle "$OUT/hello_x280.elf" >"$OUT/hello_x280.lst"
+
+entry=$("$READELF" -h "$OUT/hello_x280.elf" | sed -n 's/.*Entry point address:.*0x//p')
+echo "entry: 0x$entry"
+[[ "$entry" == "8001000" || "$entry" == "08001000" ]] || \
+    die "entry 0x$entry is not X280_ACTIVE_FW_LOAD_ADDR 0x08001000"
+
+say "3. run on X280 ISS"
+LOG="$OUT/iss.log"
+set +e
+"$HERE/scripts/x280_iss.sh" "$OUT/hello_x280.elf" >"$LOG" 2>&1
+rc=$?
+set -e
+cat "$LOG"
+echo "iss exit: $rc"
+
+say "4. verify"
+fails=0
+check() {
+    if grep -qF "$2" "$LOG"; then
+        printf '  \033[32m[ ok ]\033[0m %s\n' "$1"
+    else
+        printf '  \033[31m[FAIL]\033[0m %s\n' "$1"
+        fails=$((fails + 1))
+    fi
+}
+check "printed Hello, World!" "Hello, World!"
+check "misa.V is set" "misa.V (vector) = yes"
+check "VLEN=512 (vlenb=64)" "vlenb   = 64 bytes -> VLEN=512"
+check "vsetvli e32/m1 vl=16" "vsetvli e32/m1 vl = 16"
+check "linked at active-FW address" "_start                   = 0x0000000008001000"
+check "ISS checks passed" "The X280 ISS hello world ran. All checks passed."
+
+if ((fails == 0 && rc == 0)); then
+    printf '\n\033[32mThe simulated X280 hello world ran. All checks passed.\033[0m\n'
+    echo "  elf  $OUT/hello_x280.elf"
+    echo "  log  $LOG"
+    exit 0
+fi
+printf '\n\033[31m%d check(s) failed (iss exit %d).\033[0m\n' "$fails" "$rc"
+exit 1

--- a/tests/tt_metal/tt_metal/x280_iss_hello/run_atomic_bench.sh
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/run_atomic_bench.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build atomic_bench.c for the X280 ISS and run it.
+# Usage: ./run_atomic_bench.sh [--clean]
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="${WORK:-$HERE/build}"
+OUT="$WORK/out"
+
+if [[ "${1:-}" == "--clean" ]]; then
+    rm -rf "$WORK"
+    echo "cleaned $WORK"
+    exit 0
+fi
+
+say() { printf '\n\033[1m== %s\033[0m\n' "$*"; }
+die() { printf '\033[31mERROR: %s\033[0m\n' "$*" >&2; exit 1; }
+
+find_toolchain() {
+    if [[ -n "${X280_TOOLCHAIN:-}" && -x "${X280_TOOLCHAIN}/bin/riscv64-unknown-elf-gcc" ]]; then
+        echo "$X280_TOOLCHAIN"
+        return
+    fi
+    if [[ -n "${TT_LLM_ENGINE:-}" && -x "${TT_LLM_ENGINE}/x280/toolchain/bin/riscv64-unknown-elf-gcc" ]]; then
+        echo "${TT_LLM_ENGINE}/x280/toolchain"
+        return
+    fi
+    for cand in /data/*/tt-llm-engine*/x280/toolchain "$HOME"/tt-llm-engine*/x280/toolchain; do
+        [[ -x "$cand/bin/riscv64-unknown-elf-gcc" ]] && { echo "$cand"; return; }
+    done
+    if command -v riscv64-unknown-elf-gcc >/dev/null; then
+        echo "$(dirname "$(dirname "$(command -v riscv64-unknown-elf-gcc)")")"
+        return
+    fi
+    return 1
+}
+
+TC="$(find_toolchain)" || die "no riscv64-unknown-elf toolchain.
+Set X280_TOOLCHAIN=<dir> or TT_LLM_ENGINE=<tt-llm-engine checkout>."
+GCC="$TC/bin/riscv64-unknown-elf-gcc"
+OBJCOPY="$TC/bin/riscv64-unknown-elf-objcopy"
+OBJDUMP="$TC/bin/riscv64-unknown-elf-objdump"
+
+say "0. toolchain"
+"$GCC" --version | head -1
+
+say "1. X280 ISS"
+"$HERE/scripts/fetch_iss.sh"
+
+mkdir -p "$OUT"
+ARCH=rv64gcv_zicsr_zifencei
+ABI=lp64d
+ITERS="${AB_ISS_ITERS:-5}"
+FLAGS=(-march="$ARCH" -mabi="$ABI" -mcmodel=medany -Os -g -ffreestanding
+    -fno-builtin -nostdlib -nostartfiles -msmall-data-limit=0 -Wall
+    -I "$HERE/src" -I "$HERE/include" -DX280_ISS -DAB_ISS_ITERS="${ITERS}ULL")
+
+say "2. build atomic_bench (linked at 0x08001000, iters=$ITERS)"
+"$GCC" "${FLAGS[@]}" -c "$HERE/src/boot_atomic.S" -o "$OUT/boot_atomic.o"
+"$GCC" "${FLAGS[@]}" -std=gnu11 -c "$HERE/src/htif.c" -o "$OUT/htif.o"
+"$GCC" "${FLAGS[@]}" -std=gnu11 -c "$HERE/src/iss_printf.c" -o "$OUT/iss_printf.o"
+"$GCC" "${FLAGS[@]}" -std=gnu11 -c "$HERE/src/iss_host_stub.c" -o "$OUT/iss_host_stub.o"
+"$GCC" "${FLAGS[@]}" -std=gnu11 -c "$HERE/src/iss_runtime.c" -o "$OUT/iss_runtime.o"
+"$GCC" "${FLAGS[@]}" -std=gnu11 -c "$HERE/src/atomic_bench.c" -o "$OUT/atomic_bench.o"
+"$GCC" "${FLAGS[@]}" -T "$HERE/ld/x280_iss.ld" -Wl,-Map,"$OUT/atomic_bench.map" \
+    -Wl,--no-warn-rwx-segments \
+    "$OUT/boot_atomic.o" "$OUT/htif.o" "$OUT/iss_printf.o" \
+    "$OUT/iss_host_stub.o" "$OUT/iss_runtime.o" "$OUT/atomic_bench.o" \
+    -o "$OUT/atomic_bench.elf"
+"$OBJCOPY" -O binary "$OUT/atomic_bench.elf" "$OUT/atomic_bench.bin"
+"$OBJDUMP" -d --demangle "$OUT/atomic_bench.elf" >"$OUT/atomic_bench.lst"
+
+say "3. run on X280 ISS"
+LOG="$OUT/atomic_bench.log"
+set +e
+"$HERE/scripts/x280_iss.sh" "$OUT/atomic_bench.elf" >"$LOG" 2>&1
+rc=$?
+set -e
+cat "$LOG"
+echo "iss exit: $rc"
+
+say "4. verify"
+fails=0
+check() {
+    if grep -qF "$2" "$LOG"; then
+        printf '  \033[32m[ ok ]\033[0m %s\n' "$1"
+    else
+        printf '  \033[31m[FAIL]\033[0m %s\n' "$1"
+        fails=$((fails + 1))
+    fi
+}
+check "reached AB_CONFIG_READY" "AB_CONFIG_READY: config latched on ISS"
+check "latched config" "iters=$ITERS op=1"
+check "amoadd.d check" "amoadd.d x$ITERS -> counter=$ITERS OK"
+check "returned to idle" "atomic_bench: hart0 returned to idle (ISS)"
+
+if ((fails == 0 && rc == 0)); then
+    printf '\n\033[32matomic_bench ran on the X280 ISS. All checks passed.\033[0m\n'
+    echo "  elf  $OUT/atomic_bench.elf"
+    echo "  log  $LOG"
+    exit 0
+fi
+printf '\n\033[31m%d check(s) failed (iss exit %d).\033[0m\n' "$fails" "$rc"
+exit 1

--- a/tests/tt_metal/tt_metal/x280_iss_hello/run_harness.sh
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/run_harness.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build the X280 ISS harness and run C / ELF workloads end-to-end.
+#
+# Usage:
+#   ./run_harness.sh                  # build + run the bundled C benchmarks
+#   ./run_harness.sh path/to/foo.c    # compile one C file against the ISS runtime and run
+#   ./run_harness.sh path/to/foo.elf  # run a prebuilt ELF
+#   ./run_harness.sh --clean
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORK="${WORK:-$HERE/build}"
+OUT="$WORK/out"
+PREFIX="$WORK/iss-prefix"
+HARNESS_BIN="$WORK/x280_harness"
+
+if [[ "${1:-}" == "--clean" ]]; then
+    rm -rf "$WORK"
+    echo "cleaned $WORK"
+    exit 0
+fi
+
+say() { printf '\n\033[1m== %s\033[0m\n' "$*"; }
+die() { printf '\033[31mERROR: %s\033[0m\n' "$*" >&2; exit 1; }
+
+find_toolchain() {
+    if [[ -n "${X280_TOOLCHAIN:-}" && -x "${X280_TOOLCHAIN}/bin/riscv64-unknown-elf-gcc" ]]; then
+        echo "$X280_TOOLCHAIN"
+        return
+    fi
+    if [[ -n "${TT_LLM_ENGINE:-}" && -x "${TT_LLM_ENGINE}/x280/toolchain/bin/riscv64-unknown-elf-gcc" ]]; then
+        echo "${TT_LLM_ENGINE}/x280/toolchain"
+        return
+    fi
+    for cand in /data/*/tt-llm-engine*/x280/toolchain "$HOME"/tt-llm-engine*/x280/toolchain; do
+        [[ -x "$cand/bin/riscv64-unknown-elf-gcc" ]] && { echo "$cand"; return; }
+    done
+    if command -v riscv64-unknown-elf-gcc >/dev/null; then
+        echo "$(dirname "$(dirname "$(command -v riscv64-unknown-elf-gcc)")")"
+        return
+    fi
+    return 1
+}
+
+build_harness() {
+    say "build x280_harness (host, links Spike)"
+    [[ -x "$PREFIX/bin/spike" ]] || die "Spike missing. Run scripts/fetch_iss.sh first."
+    mkdir -p "$WORK"
+    g++ -std=c++17 -O2 -Wall -Wextra \
+        -I "$PREFIX/include" \
+        "$HERE/harness/x280_harness.cpp" \
+        -o "$HARNESS_BIN" \
+        -L "$PREFIX/lib" -Wl,-rpath,"$PREFIX/lib" \
+        -lriscv -lfesvr -ldisasm -lsoftfloat -ldl -lpthread
+    echo "harness: $HARNESS_BIN"
+}
+
+compile_c() {
+    local src="$1"
+    local name="$2"
+    local elf="$OUT/${name}.elf"
+    mkdir -p "$OUT"
+    "$GCC" "${FLAGS[@]}" -c "$HERE/src/boot.S" -o "$OUT/boot.o"
+    "$GCC" "${FLAGS[@]}" -std=gnu11 -c "$HERE/src/htif.c" -o "$OUT/htif.o"
+    "$GCC" "${FLAGS[@]}" -std=gnu11 -c "$HERE/src/iss_printf.c" -o "$OUT/iss_printf.o"
+    "$GCC" "${FLAGS[@]}" -std=gnu11 -c "$src" -o "$OUT/${name}.o"
+    "$GCC" "${FLAGS[@]}" -T "$HERE/ld/x280_iss.ld" -Wl,--no-warn-rwx-segments \
+        "$OUT/boot.o" "$OUT/htif.o" "$OUT/iss_printf.o" "$OUT/${name}.o" \
+        -o "$elf"
+    echo "$elf"
+}
+
+run_elf() {
+    local elf="$1"
+    shift
+    local log="${elf%.elf}.log"
+    set +e
+    "$HARNESS_BIN" "$elf" "$@" >"$log" 2>&1
+    local rc=$?
+    set -e
+    cat "$log"
+    echo "harness exit: $rc"
+    return "$rc"
+}
+
+expect_in() {
+    local log="$1"
+    local needle="$2"
+    if grep -qF "$needle" "$log"; then
+        printf '  \033[32m[ ok ]\033[0m %s\n' "$needle"
+        return 0
+    fi
+    printf '  \033[31m[FAIL]\033[0m missing: %s\n' "$needle"
+    return 1
+}
+
+# --- setup ---
+TC="$(find_toolchain)" || die "no riscv64-unknown-elf toolchain.
+Set X280_TOOLCHAIN=<dir> or TT_LLM_ENGINE=<tt-llm-engine checkout>."
+GCC="$TC/bin/riscv64-unknown-elf-gcc"
+
+say "0. toolchain"
+"$GCC" --version | head -1
+echo "toolchain: $TC"
+
+say "1. X280 ISS"
+"$HERE/scripts/fetch_iss.sh"
+if [[ -x "$WORK/dtc/usr/bin/dtc" ]]; then
+    export PATH="$WORK/dtc/usr/bin:$PATH"
+    export LD_LIBRARY_PATH="$WORK/dtc/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH:-}"
+fi
+
+build_harness
+
+mkdir -p "$OUT"
+ARCH=rv64gcv_zicsr_zifencei
+ABI=lp64d
+FLAGS=(-march="$ARCH" -mabi="$ABI" -mcmodel=medany -Os -g -ffreestanding
+    -fno-builtin -nostdlib -nostartfiles -Wall
+    -I "$HERE/src" -I "$HERE/harness")
+
+# Single-target mode: a C file or an ELF.
+if [[ $# -ge 1 ]]; then
+    target="$1"
+    shift
+    if [[ "$target" == *.elf ]]; then
+        say "run $target"
+        run_elf "$target" "$@"
+        exit $?
+    fi
+    if [[ "$target" == *.c ]]; then
+        name="$(basename "$target" .c)"
+        say "compile $target"
+        elf="$(compile_c "$target" "$name")"
+        say "run $elf"
+        run_elf "$elf" "$@"
+        exit $?
+    fi
+    die "expected a .c or .elf, got: $target"
+fi
+
+# --- bundled e2e suite ---
+fails=0
+pass() { printf '  \033[32m[PASS]\033[0m %s\n' "$1"; }
+fail() { printf '  \033[31m[FAIL]\033[0m %s\n' "$1"; fails=$((fails + 1)); }
+
+run_named_c() {
+    local src="$1"
+    local name="$2"
+    local expect="$3"
+    say "bench $name"
+    local elf
+    elf="$(compile_c "$src" "$name")"
+    if run_elf "$elf"; then
+        if expect_in "$OUT/${name}.log" "$expect"; then
+            pass "$name"
+        else
+            fail "$name (output)"
+        fi
+    else
+        fail "$name (exit $?)"
+    fi
+}
+
+run_named_c "$HERE/harness/tests/hello.c" hello "hello from x280 harness"
+run_named_c "$HERE/harness/tests/arith.c" arith "PASS arith"
+run_named_c "$HERE/harness/tests/fib.c" fib "PASS fib"
+run_named_c "$HERE/harness/tests/vector.c" vector "PASS vector"
+
+say "bench load_and_check (host file -> guest memory)"
+python3 - "$OUT/load.bin" <<'PY'
+import sys
+path = sys.argv[1]
+data = bytearray(256)
+magic = 0x48524E53
+data[0] = magic & 0xFF
+data[1] = (magic >> 8) & 0xFF
+data[2] = (magic >> 16) & 0xFF
+data[3] = (magic >> 24) & 0xFF
+for i in range(4, 256):
+    data[i] = i & 0xFF
+open(path, "wb").write(data)
+PY
+elf="$(compile_c "$HERE/harness/tests/load_and_check.c" load_and_check)"
+if run_elf "$elf" --load "$OUT/load.bin@0x08140000"; then
+    if expect_in "$OUT/load_and_check.log" "PASS load_and_check"; then
+        pass "load_and_check"
+    else
+        fail "load_and_check (output)"
+    fi
+else
+    fail "load_and_check (exit)"
+fi
+
+say "bench fill_and_dump (guest memory -> host file)"
+elf="$(compile_c "$HERE/harness/tests/fill_and_dump.c" fill_and_dump)"
+if run_elf "$elf" --dump "0x08140000+256:$OUT/fill.bin"; then
+    python3 - "$OUT/fill.bin" <<'PY'
+import sys
+data = open(sys.argv[1], "rb").read()
+assert len(data) == 256, len(data)
+for i, b in enumerate(data):
+    expect = (0xA5 ^ i) & 0xFF
+    assert b == expect, (i, b, expect)
+print("dump bytes match 0xA5^i")
+PY
+    if expect_in "$OUT/fill_and_dump.log" "PASS fill_and_dump"; then
+        pass "fill_and_dump"
+    else
+        fail "fill_and_dump (output)"
+    fi
+else
+    fail "fill_and_dump (exit)"
+fi
+
+say "bench mem_rw (host file -> guest invert -> host file)"
+python3 - "$OUT/mem_rw_in.bin" <<'PY'
+import sys
+data = bytearray(256)
+magic = 0x48524E53
+data[0] = magic & 0xFF
+data[1] = (magic >> 8) & 0xFF
+data[2] = (magic >> 16) & 0xFF
+data[3] = (magic >> 24) & 0xFF
+for i in range(4, 256):
+    data[i] = i & 0xFF
+open(sys.argv[1], "wb").write(data)
+PY
+elf="$(compile_c "$HERE/harness/tests/mem_rw.c" mem_rw)"
+if run_elf "$elf" --load "$OUT/mem_rw_in.bin@0x08140000" --dump "0x08140000+256:$OUT/mem_rw_out.bin"; then
+    python3 - "$OUT/mem_rw_in.bin" "$OUT/mem_rw_out.bin" <<'PY'
+import sys
+inp = open(sys.argv[1], "rb").read()
+out = open(sys.argv[2], "rb").read()
+assert len(inp) == len(out) == 256
+assert bytes(b ^ 0xFF for b in inp) == out
+print("dump is bitwise invert of loaded file")
+PY
+    if expect_in "$OUT/mem_rw.log" "PASS mem_rw invert"; then
+        pass "mem_rw"
+    else
+        fail "mem_rw (output)"
+    fi
+else
+    fail "mem_rw (exit)"
+fi
+
+say "summary"
+if ((fails == 0)); then
+    printf '\n\033[32mX280 harness e2e: all benchmarks passed.\033[0m\n'
+    echo "  harness  $HARNESS_BIN"
+    echo "  logs     $OUT/*.log"
+    exit 0
+fi
+printf '\n\033[31m%d benchmark(s) failed.\033[0m\n' "$fails"
+exit 1

--- a/tests/tt_metal/tt_metal/x280_iss_hello/scripts/fetch_iss.sh
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/scripts/fetch_iss.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Fetch/build the X280 ISS. Prefers a vendor binary at $X280_ISS.
+# Otherwise builds Spike (riscv-isa-sim) configured as an X280-class
+# rv64gcv / VLEN=512 instruction-set simulator.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+WORK="${WORK:-$ROOT/build}"
+PREFIX="$WORK/iss-prefix"
+SRC="$WORK/riscv-isa-sim"
+
+say() { printf '\n== %s\n' "$*"; }
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+if [[ -n "${X280_ISS:-}" && -x "${X280_ISS}" ]]; then
+    echo "vendor X280 ISS: $X280_ISS"
+    exit 0
+fi
+
+if [[ -x "$PREFIX/bin/spike" ]]; then
+    echo "spike: $PREFIX/bin/spike"
+    exit 0
+fi
+
+if command -v spike >/dev/null; then
+    echo "system spike: $(command -v spike)"
+    exit 0
+fi
+
+mkdir -p "$WORK"
+
+# dtc is required to configure Spike. Unpack the Ubuntu package locally (no root).
+if ! command -v dtc >/dev/null; then
+    say "device-tree-compiler"
+    DTC_DIR="$WORK/dtc"
+    mkdir -p "$DTC_DIR"
+    if [[ ! -x "$DTC_DIR/usr/bin/dtc" ]]; then
+        (
+            cd "$DTC_DIR"
+            apt-get download device-tree-compiler 2>&1 | tail -3
+            for d in device-tree-compiler_*.deb; do
+                dpkg-deb -x "$d" .
+            done
+        )
+    fi
+    export PATH="$DTC_DIR/usr/bin:$PATH"
+    export LD_LIBRARY_PATH="$DTC_DIR/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH:-}"
+fi
+command -v dtc >/dev/null || die "dtc not available (needed to build Spike)"
+
+say "clone riscv-isa-sim (Spike ISS)"
+if [[ ! -d "$SRC/.git" ]]; then
+    git clone --depth 1 https://github.com/riscv-software-src/riscv-isa-sim.git "$SRC"
+fi
+
+say "configure + build Spike"
+mkdir -p "$SRC/build" "$PREFIX"
+(
+    cd "$SRC/build"
+    if [[ ! -f Makefile ]]; then
+        ../configure --prefix="$PREFIX"
+    fi
+    make -j"$(nproc)"
+    make install
+)
+
+[[ -x "$PREFIX/bin/spike" ]] || die "spike did not install to $PREFIX/bin/spike"
+echo "spike: $PREFIX/bin/spike"

--- a/tests/tt_metal/tt_metal/x280_iss_hello/scripts/x280_iss.sh
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/scripts/x280_iss.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Launch the X280 ISS.
+#
+# Blackhole L2CPU X280 cluster (ISA-level):
+#   4 identical harts, rv64gcv, VLEN=512, ELEN=64
+#   LIM SRAM at 0x08000000 (1.875 MiB), matching tt-llm-engine x280.h
+#
+# If X280_ISS is set to a vendor SiFive ISS binary, that is used instead.
+# Otherwise Spike is invoked with the X280 ISA/memory configuration.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+WORK="${WORK:-$ROOT/build}"
+PREFIX="$WORK/iss-prefix"
+
+# SiFive X280 on Blackhole: rv64gcv, VLEN=512 (coreip_21G3 / llm-engine x280).
+# zvl512b sets VLEN>=512 on modern Spike (no --varch flag).
+X280_ISA="${X280_ISA:-rv64gcv_zicsr_zifencei_zvl512b}"
+X280_HARTS="${X280_HARTS:-4}"
+# LIM_BASE=0x08000000, LIM_SIZE=0x1E0000 (1.875 MiB)
+X280_MEM="${X280_MEM:-0x8000000:0x1E0000}"
+
+if [[ -n "${X280_ISS:-}" && -x "${X280_ISS}" ]]; then
+    exec "$X280_ISS" "$@"
+fi
+
+SPIKE=""
+if [[ -x "$PREFIX/bin/spike" ]]; then
+    SPIKE="$PREFIX/bin/spike"
+elif command -v spike >/dev/null; then
+    SPIKE="$(command -v spike)"
+else
+    printf 'ERROR: no ISS. Run scripts/fetch_iss.sh or set X280_ISS.\n' >&2
+    exit 1
+fi
+
+# Local dtc from fetch_iss.sh, if present.
+if [[ -x "$WORK/dtc/usr/bin/dtc" ]]; then
+    export PATH="$WORK/dtc/usr/bin:$PATH"
+    export LD_LIBRARY_PATH="$WORK/dtc/usr/lib/x86_64-linux-gnu:${LD_LIBRARY_PATH:-}"
+fi
+
+exec "$SPIKE" \
+    --isa="$X280_ISA" \
+    --disable-dtb \
+    -p"$X280_HARTS" \
+    -m"$X280_MEM" \
+    --pc=0x8001000 \
+    "$@"

--- a/tests/tt_metal/tt_metal/x280_iss_hello/src/atomic_bench.c
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/src/atomic_bench.c
@@ -1,0 +1,735 @@
+/*
+ * atomic_bench.c - X280 cross-hart atomic-increment micro-benchmark.
+ *
+ * ======================================================================
+ * WHAT THIS IS FOR
+ * ======================================================================
+ *
+ * Prototype for the real use case: 4 X280 harts on one L2CPU tile all
+ * pushing packets into a *single* downstream queue (e.g. an erisc queue)
+ * and each needing to bump a shared write-pointer without colliding.
+ * The correctness primitive for that is an atomic read-modify-write:
+ * each producer atomically adds its packet count to the shared write
+ * pointer and gets back a unique, non-overlapping slot range.
+ *
+ * Here we boil that down to the simplest measurable kernel: N harts each
+ * atomically increment ONE shared memory location 1,000,000 times. From
+ * that we learn three things:
+ *
+ *   1. CORRECTNESS. With true atomics the final value must equal
+ *      N * iterations exactly (no lost updates). We also run a
+ *      deliberately NON-atomic (racy) mode so you can *see* updates get
+ *      lost when the atomic guarantee is removed -- that's the "why we
+ *      need atomics" demonstration.
+ *
+ *   2. UNCONTENDED COST. Phase 1 runs a single hart alone. Its
+ *      cycles/increment is the baseline: the raw cost of one atomic op
+ *      with zero contention.
+ *
+ *   3. CONTENTION / STALL OVERHEAD. Phases with 2/3/4 harts hammer the
+ *      same address concurrently. The memory subsystem must serialize
+ *      the atomics, so each hart's cycles/increment rises above the
+ *      baseline. The increase is the contention (stall) overhead, and it
+ *      tells you how the write-pointer scheme will scale with producers.
+ *
+ * ======================================================================
+ * TWO HARDWARE FACTS THAT SHAPE THIS BENCHMARK
+ * ======================================================================
+ *
+ * (A) The 4 X280 harts are a *cache-coherent cluster*, but LIM is
+ *     *uncached scratchpad* (L3 configured as SRAM). See the Tenstorrent
+ *     tt-isa-documentation, BlackholeA0/L2CPUTile/README.md + Caches.md.
+ *     Because LIM is uncached, an atomic to a LIM address does NOT bounce
+ *     a cache line between harts -- every hart's AMO goes straight to the
+ *     LIM/L3 controller, which serializes them. That makes LIM a clean,
+ *     predictable place to measure raw atomic serialization (no MESI
+ *     line-migration noise). Whether the L2CPU actually implements AMOs
+ *     against uncached LIM is silicon-specific, so we PROBE for it at
+ *     startup (see amo_probe below) instead of assuming it.
+ *
+ * (B) TIMING -- CLINT mtime (true wall-clock).
+ *     Per hart we bracket the timed loop with the CLINT `mtime` counter, a
+ *     true 50 MHz wall-clock (20 ns/tick) that keeps ticking through
+ *     stalls:
+ *         wall_ticks = mtime_end - mtime_start
+ *     This is what a producer actually pays, including time blocked waiting
+ *     for the atomic subsystem to serialize it. The host converts ticks to
+ *     microseconds (ticks/50e6) and, using the PLL frequency, to
+ *     cycles-per-op. We deliberately do NOT use rdcycle: on this X280 it
+ *     only counts active-pipeline cycles and freezes during memory stalls
+ *     (see x280_mtime in rt/x280_hw.h), so it would hide exactly the
+ *     atomic-latency cost we want to see. mtime has no such gap.
+ *
+ * ======================================================================
+ * EXECUTION MODEL (ping-pong active FW, LIM mode)
+ * ======================================================================
+ *
+ * This is an *active* firmware in the resident-idle / active-FW ping-pong
+ * scheme (see x280/MIGRATION_WORKER_LAYOUT.md §5.0 and x280/src/lim_idle.c).
+ * The host never touches the L2CPU reset bit; the idle FW indirect-jumps
+ * here and all 4 harts land in main(hartid) via entry.S.
+ *
+ *   hart 0  = orchestrator. Talks to the host over LIM mailboxes, runs
+ *             each phase, collects results, and (unlike socket_echo)
+ *             KEEPS harts 1-3 resident so they can participate.
+ *   hart 1-3 = workers. They enter atomic_worker_loop() and wait for
+ *             hart 0 to hand them per-phase work via WORK[h]. They only
+ *             return to the idle FW when hart 0 posts WORK_SHUTDOWN.
+ *
+ * Per phase (num = 1..4 participating harts), the barrier is:
+ *   hart 0: zero counter; clear GATE; post WORK[h]=iters to helpers;
+ *           wait until every helper set ARMED[h]=1 (spinning on GATE);
+ *           flip GATE=GO; run its OWN timed loop; wait every DONE[h];
+ *           record results; read final counter.
+ *   helper: sees WORK[h]=iters; sets ARMED[h]=1; spins on GATE; on GO,
+ *           runs its timed loop; publishes (active,wall) to DONE[h].
+ * The GATE gives all participants a near-simultaneous start so the
+ * contention window overlaps.
+ *
+ * Linker: ld/x280.ld (active-FW LIM region at 0x08001000).
+ * Build:  make -C x280 atomic-bench  ->  build/firmware-atomic-bench.bin
+ *
+ * NOTE ON RECOVERY: if AMOs against LIM are unsupported, the amo_probe
+ * step detects it *without* faulting the core (it arms entry.S probe
+ * mode), reports AMO_UNSUPPORTED, and cleanly returns to the idle FW.
+ * We never let an unprobed AMO hit the normal trap handler, which would
+ * CEASE (permanently halt) the hart and strand the L2CPU until a chip
+ * reset.
+ */
+#include "x280.h"
+
+#include "iss_printf.h"
+#include "rt/x280_atomic.h"
+#include "rt/x280_hw.h"
+#include "rt/x280_idle.h"
+#include "rt/x280_pll.h"
+/* ======================================================================
+ * LIM control / result layout  (WIRE CONTRACT with the host driver)
+ * ----------------------------------------------------------------------
+ * A dedicated region well clear of everything else in LIM:
+ *   - firmware .text/.data/.bss           < 0x120000
+ *   - migration control + boot handshake  0x130000..0x131FFF
+ *   - bank table / slots / staging / fifo  0x132000..0x153FFF
+ * We claim [0x160000, 0x163000). It is below the stack (0x1D8000) and
+ * does NOT overlap the idle-FW boot-handshake mailboxes (0x130200..),
+ * so priming these lines can never wipe the idle heartbeat.
+ *
+ * Every field lives on its OWN 64-byte cache line. Two reasons, both the
+ * same as the migration worker's mailboxes:
+ *   - ECC: LIM SRAM is ECC-protected; a partial-word write to a cold
+ *     line needs valid ECC in the rest of the line. The host primes each
+ *     line with a full 64 B zero write before any partial write.
+ *   - No false sharing: control words written by different harts, and
+ *     especially the hot shared COUNTER, must not share a line or the
+ *     measurement would pick up incidental line traffic.
+ *
+ * If you change any offset here, change it in
+ * x280/host/experiment_atomic_bench.py in the SAME commit.
+ * ====================================================================== */
+#define ATOMIC_BASE (LIM_BASE + 0x00160000UL)
+
+/* --- control mailboxes -------------------------------------------- */
+#define AB_STATUS_ADDR ((volatile uint32_t*)(ATOMIC_BASE + 0x000UL))       /* fw->host */
+#define AB_STOP_ADDR ((volatile uint32_t*)(ATOMIC_BASE + 0x040UL))         /* host->fw */
+#define AB_CONFIG_READY_ADDR ((volatile uint32_t*)(ATOMIC_BASE + 0x080UL)) /* host->fw */
+#define AB_CUR_PHASE_ADDR ((volatile uint32_t*)(ATOMIC_BASE + 0x0C0UL))    /* fw->host progress */
+
+/* --- config block (host->fw, latched after CONFIG_READY) ---------- */
+#define AB_ITERATIONS_ADDR ((volatile uint64_t*)(ATOMIC_BASE + 0x100UL))   /* per-hart iters */
+#define AB_OP_MODE_ADDR ((volatile uint32_t*)(ATOMIC_BASE + 0x140UL))      /* AB_OP_* */
+#define AB_PHASE_MASK_ADDR ((volatile uint32_t*)(ATOMIC_BASE + 0x180UL))   /* bit p => run (p+1) harts */
+#define AB_COUNTER_ADDR_ADDR ((volatile uint64_t*)(ATOMIC_BASE + 0x1C0UL)) /* LIM addr of shared counter */
+
+/* --- per-hart barrier mailboxes (each on its own line) ------------ */
+/* WORK[h]: hart0 -> hart h.  0 = idle, N = run N iters, 0xFFFFFFFF = shutdown. */
+#define AB_WORK_BASE (ATOMIC_BASE + 0x200UL)
+#define AB_WORK_ADDR(h) ((volatile uint32_t*)(AB_WORK_BASE + (uint64_t)(h) * 0x40UL))
+/* ARMED[h]: hart h -> hart0.  1 = latched work and spinning on GATE. */
+#define AB_ARMED_BASE (ATOMIC_BASE + 0x300UL)
+#define AB_ARMED_ADDR(h) ((volatile uint32_t*)(AB_ARMED_BASE + (uint64_t)(h) * 0x40UL))
+/* DONE[h] line: hart h -> hart0.  wall_ticks(u64)@+0, slot_sum(u64)@+8,
+ * flag(u32)@+16 (written last). */
+#define AB_DONE_BASE (ATOMIC_BASE + 0x400UL)
+#define AB_DONE_ADDR(h) (AB_DONE_BASE + (uint64_t)(h) * 0x40UL)
+#define AB_DONE_WALL(h) ((volatile uint64_t*)(AB_DONE_ADDR(h) + 0x00UL))
+#define AB_DONE_SLOTSUM(h) ((volatile uint64_t*)(AB_DONE_ADDR(h) + 0x08UL))
+#define AB_DONE_FLAG(h) ((volatile uint32_t*)(AB_DONE_ADDR(h) + 0x10UL))
+/* Absolute mtime timestamps (same global 50 MHz counter every hart reads,
+ * so they are comparable ACROSS harts). Used to verify the harts actually
+ * overlapped -- see the per-phase span table below. */
+#define AB_DONE_T0(h) ((volatile uint64_t*)(AB_DONE_ADDR(h) + 0x18UL))
+#define AB_DONE_T1(h) ((volatile uint64_t*)(AB_DONE_ADDR(h) + 0x20UL))
+
+/* GATE: hart0 -> all participants. Flipped to AB_GATE_GO to release. */
+#define AB_GATE_ADDR ((volatile uint32_t*)(ATOMIC_BASE + 0x600UL))
+
+/* --- results tables (fw->host) ------------------------------------ *
+ * The benchmark runs TWO sections, each with its own results table:
+ *   Section 0 "constant":  every participating hart does `iters`, so the
+ *                          total work grows with hart count (N*iters).
+ *   Section 1 "split":     the SAME total `iters` is divided evenly, so
+ *                          N harts do ~iters/N each (strong scaling).
+ *
+ * One 32 B record per (phase p in 0..3, hart h in 0..3):
+ *   wall_ticks(u64) @ +0, iters_done(u64) @ +8, slot_sum(u64) @ +16.
+ * iters_done lets the host compute per-op costs without re-deriving the
+ * (uneven) split; slot_sum (sum of the old values this hart got back)
+ * feeds the slot-uniqueness check. Record address =
+ * <section_base> + (p*4 + h) * 32. */
+#define AB_RESULT_REC_SIZE 32u
+#define AB_RESULT_BASE (ATOMIC_BASE + 0x1000UL)  /* section 0 records */
+#define AB_RESULT2_BASE (ATOMIC_BASE + 0x1200UL) /* section 1 records */
+#define AB_REC_WALL(base, p, h) ((volatile uint64_t*)((base) + ((uint64_t)(p) * 4 + (h)) * AB_RESULT_REC_SIZE + 0))
+#define AB_REC_ITERS(base, p, h) ((volatile uint64_t*)((base) + ((uint64_t)(p) * 4 + (h)) * AB_RESULT_REC_SIZE + 8))
+#define AB_REC_SLOTSUM(base, p, h) ((volatile uint64_t*)((base) + ((uint64_t)(p) * 4 + (h)) * AB_RESULT_REC_SIZE + 16))
+/* Per-phase final counter + expected value: 16 B per phase, per section. */
+#define AB_FINAL_BASE (ATOMIC_BASE + 0x1400UL)  /* section 0 finals */
+#define AB_FINAL2_BASE (ATOMIC_BASE + 0x1440UL) /* section 1 finals */
+#define AB_FGOT(base, p) ((volatile uint64_t*)((base) + (uint64_t)(p) * 16 + 0))
+#define AB_FEXP(base, p) ((volatile uint64_t*)((base) + (uint64_t)(p) * 16 + 8))
+/* Per-phase concurrency span (fw->host): the earliest loop-start and latest
+ * loop-end absolute mtime across the phase's participating harts. The host
+ * uses (max_end - min_start) as the TRUE concurrent wall-clock and compares
+ * it to the slowest single-hart delta -- if they match, the harts really
+ * overlapped and the reported throughput is honest; if max_end-min_start is
+ * much larger, the harts were staggered/serialized and throughput was
+ * over-stated. 16 B per phase (min_start@0, max_end@8), per section. */
+#define AB_SPAN_BASE (ATOMIC_BASE + 0x1480UL)  /* section 0 spans */
+#define AB_SPAN2_BASE (ATOMIC_BASE + 0x14C0UL) /* section 1 spans */
+#define AB_SPAN_START(base, p) ((volatile uint64_t*)((base) + (uint64_t)(p) * 16 + 0))
+#define AB_SPAN_END(base, p) ((volatile uint64_t*)((base) + (uint64_t)(p) * 16 + 8))
+/* AMO-to-LIM probe result: 1 = AMOs work, 0 = they fault. */
+#define AB_AMO_SUPPORTED_ADDR ((volatile uint32_t*)(ATOMIC_BASE + 0x1500UL))
+/* Firmware-measured X280 PLL frequency in kHz (fw->host). Measured once at
+ * startup by counting rdcycle ticks against the fixed 50 MHz CLINT mtime
+ * reference -- so the host can convert cycle counts and CONFIRM the real
+ * clock instead of trusting --mhz. Its own 64 B line. */
+#define AB_MEASURED_PLL_KHZ_ADDR ((volatile uint32_t*)(ATOMIC_BASE + 0x1540UL))
+
+/* --- protocol constants ------------------------------------------- */
+#define AB_WORK_IDLE 0x00000000u
+#define AB_WORK_SHUTDOWN 0xFFFFFFFFu
+#define AB_GATE_GO 0x600D600Du /* "GOOD GOOD" */
+#define AB_DONE_FLAG_VAL 0xD01E0001u
+#define AB_STOP_VALUE 0x0000DEADu
+#define AB_CONFIG_READY_VALUE 0x000C0FFEu
+
+/* Op modes: what "increment" means. Host selects via AB_OP_MODE.
+ * (Value 2 was LR/SC; removed -- reservations don't work on uncached LIM,
+ * so sc.d never succeeds and the retry loop live-locks / strands the core.
+ * NONATOMIC keeps value 3 so the wire codes stay stable.) */
+#define AB_OP_AMOADD_W 0u    /* amoadd.w  (32-bit atomic)          */
+#define AB_OP_AMOADD_D 1u    /* amoadd.d  (64-bit atomic)          */
+#define AB_OP_NONATOMIC_D 3u /* ld/add/sd (racy, NOT atomic)       */
+
+/* Status lifecycle (fw->host). Monotonic-ish; host polls to sequence. */
+#define AB_STATUS_INIT 0xFFFFFFFFu      /* main() up, before config   */
+#define AB_STATUS_READY 0x10000001u     /* config latched, probing    */
+#define AB_STATUS_RUNNING 0x10000002u   /* phases executing           */
+#define AB_STATUS_DONE 0x10000003u      /* all phases done, clean exit */
+#define AB_STATUS_AMO_UNSUP 0xE0000001u /* AMO probe failed; aborting  */
+
+/* NUM_HARTS (== 4) comes from x280.h. */
+/* ======================================================================
+ * Low-level primitives
+ * ====================================================================== */
+
+/* Measure the X280 PLL frequency (kHz) by counting rdcycle ticks over a
+ * fixed mtime window. PLL_hz = (dcyc / dtick) * 50e6, so
+ * PLL_kHz = dcyc * 50000 / dtick. Window = 100000 mtime ticks (~2 ms at
+ * 50 MHz) -- long enough that fixed read overhead is negligible. Same trick
+ * idle.c / read_x280_clock.py use. Called once by hart 0 before the phases;
+ * cost (~2 ms) is outside every timed region. */
+
+/* ---- the increment kernels ---------------------------------------- *
+ * Each does exactly ONE increment-by-1 of *p and RETURNS THE OLD VALUE
+ * (the value before the add). This mirrors the real use case: a producer
+ * does `my_slot = atomic_add(&write_ptr, 1)` and the returned old pointer
+ * IS the slot it just claimed. We deliberately do NOT discard it (no
+ * rd=x0) -- the loop below accumulates the returned slots, both to model
+ * the real "use the value" cost and to enable the slot-sum correctness
+ * check (see run_increment_loop).
+ *
+ * They take a uintptr_t rather than a typed pointer because the op is
+ * selected at run time from AB_OP_MODE, so one address feeds both widths.
+ *
+ * Each is force-inlined so per-call overhead is identical across harts;
+ * the "memory" clobber + volatile stop the compiler reordering/eliding
+ * the op or the load of its result.                                    */
+
+static inline uint64_t inc_amoadd_w(uintptr_t p) { return x280_amoadd_w((volatile uint32_t*)p, 1u); }
+
+static inline uint64_t inc_amoadd_d(uintptr_t p) { return x280_amoadd_d((volatile uint64_t*)p, 1u); }
+
+static inline uint64_t inc_nonatomic_d(uintptr_t p) {
+    /* Deliberately racy: plain load, add, store. With multiple harts, two
+     * can read the same old value and both write old+1, LOSING one update
+     * AND handing the SAME slot to two producers. Used to demonstrate why
+     * atomics are required -- the final count comes out LESS than expected
+     * and the slot-sum check fails (duplicate/again-issued slots). */
+    uint64_t old, newv;
+    __asm__ volatile(
+        "  ld   %0, 0(%2)\n"
+        "  addi %1, %0, 1\n"
+        "  sd   %1, 0(%2)\n"
+        : "=&r"(old), "=&r"(newv)
+        : "r"(p)
+        : "memory");
+    return old;
+}
+
+/* Run `iters` increments of the given op against `counter_addr`, and
+ * return the SUM of all the old values returned (the slots this hart
+ * claimed). Kept in one place so hart 0 and the helpers execute
+ * byte-identical loops.
+ *
+ * Why sum the slots: with a correct atomic increment-by-1, the old values
+ * returned across ALL harts over the whole phase are exactly the set
+ * {0, 1, ..., total-1}, each handed out once. So the sum of every hart's
+ * partial slot-sum must equal total*(total-1)/2. That single number is a
+ * strong end-to-end proof that no slot was ever issued twice (the exact
+ * property the downstream-queue write pointer needs) -- stronger than just
+ * "final counter == total". The non-atomic mode breaks it (duplicated
+ * slots), which is the point. Summing also gives the compiler a reason to
+ * keep each returned value, faithfully modelling code that USES the slot.*/
+static uint64_t run_increment_loop(unsigned op, uintptr_t counter_addr, uint64_t iters) {
+#ifdef X280_ISS
+    if (iters > 10000ULL) {
+        iters = 10000ULL;
+    }
+    uint64_t slot_sum = 0;
+    volatile uint64_t* p = (volatile uint64_t*)counter_addr;
+    for (uint64_t i = 0; i < iters; i++) {
+        uint64_t old;
+        if (op == AB_OP_AMOADD_W) {
+            old = x280_amoadd_w((volatile uint32_t*)p, 1u);
+        } else if (op == AB_OP_AMOADD_D) {
+            __asm__ volatile("amoadd.d %0, %2, (%1)" : "=r"(old) : "r"(p), "r"(1ULL) : "memory");
+        } else {
+            old = *p;
+            *p = old + 1;
+        }
+        slot_sum += old;
+    }
+    return slot_sum;
+#else
+    uint64_t slot_sum = 0;
+    switch (op) {
+        case AB_OP_AMOADD_W:
+            for (uint64_t i = 0; i < iters; i++) {
+                slot_sum += inc_amoadd_w(counter_addr);
+            }
+            break;
+        case AB_OP_AMOADD_D:
+            for (uint64_t i = 0; i < iters; i++) {
+                slot_sum += inc_amoadd_d(counter_addr);
+            }
+            break;
+        case AB_OP_NONATOMIC_D:
+        default:
+            for (uint64_t i = 0; i < iters; i++) {
+                slot_sum += inc_nonatomic_d(counter_addr);
+            }
+            break;
+    }
+    return slot_sum;
+#endif
+}
+
+/* ======================================================================
+ * AMO-to-LIM support probe (fault-safe)
+ * ----------------------------------------------------------------------
+ * We must NOT let an unsupported AMO hit entry.S's normal trap handler:
+ * that writes mcause/mepc/mtval and executes CEASE, permanently halting
+ * the hart (only a chip reset recovers). entry.S has a "probe mode":
+ * while _probe_active != 0, load/store/AMO access faults (cause 5/7) and
+ * illegal-instruction (cause 2) are skipped (mepc+=4) and _probe_active
+ * is set to 2. So: arm probe mode, attempt one op, and check whether it
+ * faulted. Returns 1 if the op executed cleanly, 0 if it faulted.
+ * ====================================================================== */
+static int amo_probe(unsigned op, uintptr_t counter_addr) {
+    _probe_active = 1; /* arm: entry.S will skip faults */
+    __asm__ volatile("fence ow, ow");
+    switch (op) {
+        case AB_OP_AMOADD_W: inc_amoadd_w(counter_addr); break;
+        case AB_OP_AMOADD_D: inc_amoadd_d(counter_addr); break;
+        default: inc_nonatomic_d(counter_addr); break; /* always OK */
+    }
+    __asm__ volatile("fence iorw, iorw");
+    int faulted = (_probe_active == 2);
+    _probe_active = 0; /* disarm */
+    __asm__ volatile("fence ow, ow");
+    return faulted ? 0 : 1;
+}
+
+/* ======================================================================
+ * Exit paths (ping-pong: hand control back to the resident idle FW)
+ * ====================================================================== */
+
+/* hart 0 clean exit: stamp the legacy sentinel + PHASE=RETURNED_TO_IDLE
+ * (so the host's poll_sentinel / wait_active_fw_returned works), then
+ * indirect-jump to the idle FW _start. Mirrors socket_echo.cpp. */
+
+/* helper exit: jump straight back to the idle FW's wake-poll loop WITHOUT
+ * touching the sentinel/phase (those are hart 0's job). WFI is not an
+ * option -- it hard-stalls this core forever (host NOC writes raise no
+ * interrupt), stranding the L2CPU. */
+
+static inline void set_status(uint32_t s) {
+    *AB_STATUS_ADDR = s;
+    __asm__ volatile("fence ow, ow");
+}
+
+/* ======================================================================
+ * Helper hart (1..3) main loop
+ * ----------------------------------------------------------------------
+ * Park polling WORK[h]. On a positive iteration count, do the barrier
+ * handshake and one timed run; on SHUTDOWN, go home. All mailbox lines
+ * were host-primed to 0 before the handoff, so an initial WORK[h]==0
+ * (idle) read is well-defined -- no init-order dependency on hart 0.
+ * ====================================================================== */
+static void atomic_worker_loop(uint32_t hartid) {
+    volatile uint32_t* my_work = AB_WORK_ADDR(hartid);
+    volatile uint32_t* my_armed = AB_ARMED_ADDR(hartid);
+    volatile uint64_t* my_wall = AB_DONE_WALL(hartid);
+    volatile uint32_t* my_flag = AB_DONE_FLAG(hartid);
+    volatile uint64_t* my_slotsum = AB_DONE_SLOTSUM(hartid);
+    volatile uint64_t* my_t0 = AB_DONE_T0(hartid);
+    volatile uint64_t* my_t1 = AB_DONE_T1(hartid);
+
+    for (;;) {
+#ifndef X280_ISS
+        __asm__ volatile("fence ir, ir");
+#endif
+        uint32_t work = *my_work;
+
+        if (work == AB_WORK_IDLE) {
+            x280_pause();
+            continue;
+        }
+        if (work == AB_WORK_SHUTDOWN) {
+            x280_helper_to_idle(); /* noreturn */
+        }
+
+        /* work is a positive iteration count. Latch the run parameters
+         * (op + counter address were published by hart 0 with the config
+         * and never change during a run). */
+        uint64_t iters = *my_work; /* == work */
+        unsigned op = *AB_OP_MODE_ADDR;
+        uintptr_t caddr = (uintptr_t)*AB_COUNTER_ADDR_ADDR;
+
+        /* Announce we are armed and about to spin on the gate, so hart 0
+         * only releases once every participant is ready (a tight start
+         * window => the contention actually overlaps). */
+        *my_armed = 1u;
+        __asm__ volatile("fence ow, ow");
+
+        /* Spin on the gate. Tight (no pause) so we react to GO with
+         * minimum latency, minimizing start skew vs the other harts. */
+        for (;;) {
+#ifndef X280_ISS
+            __asm__ volatile("fence ir, ir");
+#endif
+            if (*AB_GATE_ADDR == AB_GATE_GO) {
+                break;
+            }
+        }
+
+        /* --- timed region --- */
+        uint64_t t0 = x280_mtime();
+        uint64_t slot_sum = run_increment_loop(op, caddr, iters);
+        uint64_t t1 = x280_mtime();
+
+        /* Publish (wall, slot_sum, absolute t0/t1) BEFORE the done flag so
+         * hart 0 sees valid numbers the instant it observes the flag. */
+        *my_wall = t1 - t0;
+        *my_slotsum = slot_sum;
+        *my_t0 = t0;
+        *my_t1 = t1;
+        __asm__ volatile("fence ow, ow");
+        *my_armed = 0u;
+        *my_work = AB_WORK_IDLE; /* return to idle-poll for next phase */
+        __asm__ volatile("fence ow, ow");
+        *my_flag = AB_DONE_FLAG_VAL;
+        __asm__ volatile("fence ow, ow");
+    }
+}
+
+/* ======================================================================
+ * hart 0: run one phase with `num` participating harts (0..num-1)
+ * ----------------------------------------------------------------------
+ * iters_arr[h] is the per-hart iteration count (they may differ, e.g. the
+ * "split" section gives hart 0 the remainder). `expected` is the total the
+ * counter should reach. `result_base` / `final_base` / `span_base` select
+ * which section's tables this phase writes into.
+ * ====================================================================== */
+static void run_phase(
+    unsigned phase_idx,
+    unsigned num,
+    unsigned op,
+    uintptr_t caddr,
+    const uint64_t iters_arr[NUM_HARTS],
+    uint64_t expected,
+    uintptr_t result_base,
+    uintptr_t final_base,
+    uintptr_t span_base) {
+    const unsigned n = num;
+    volatile uint64_t* counter = (volatile uint64_t*)caddr;
+
+    *AB_CUR_PHASE_ADDR = phase_idx;
+    __asm__ volatile("fence ow, ow");
+
+    /* Reset the shared counter (line already ECC-primed by the host, so a
+     * plain 8-byte store is safe). Zero it fully as u64 even for the
+     * 32-bit amoadd.w mode so stale high bits can't confuse the check. */
+    *counter = 0;
+    *AB_GATE_ADDR = 0u;
+    __asm__ volatile("fence ow, ow");
+
+    /* Arm helpers 1..num-1 with their individual iteration counts. Clear
+     * DONE flag first so a stale flag from a previous phase can't be
+     * mistaken for this phase's completion. */
+    for (unsigned h = 1; h < n; h++) {
+        *AB_DONE_FLAG(h) = 0u;
+        *AB_ARMED_ADDR(h) = 0u;
+        __asm__ volatile("fence ow, ow");
+        *AB_WORK_ADDR(h) = (uint32_t)iters_arr[h];
+    }
+    __asm__ volatile("fence ow, ow");
+
+    /* Wait until every participating helper is armed & spinning on GATE. */
+    for (unsigned h = 1; h < n; h++) {
+        for (;;) {
+#ifndef X280_ISS
+            __asm__ volatile("fence ir, ir");
+#endif
+            if (*AB_ARMED_ADDR(h) == 1u) {
+                break;
+            }
+        }
+    }
+
+    /* Release everyone, then immediately run hart 0's own timed loop. */
+    *AB_GATE_ADDR = AB_GATE_GO;
+    __asm__ volatile("fence ow, ow");
+
+    uint64_t t0 = x280_mtime();
+    uint64_t slot_sum0 = run_increment_loop(op, caddr, iters_arr[0]);
+    uint64_t t1 = x280_mtime();
+
+    *AB_REC_WALL(result_base, phase_idx, 0) = t1 - t0;
+    *AB_REC_ITERS(result_base, phase_idx, 0) = iters_arr[0];
+    *AB_REC_SLOTSUM(result_base, phase_idx, 0) = slot_sum0;
+
+    /* Track the true concurrent window across all participants: earliest
+     * start and latest end on the shared mtime timebase. Seed with hart 0. */
+    uint64_t span_start = t0;
+    uint64_t span_end = t1;
+
+    /* Collect helper results. */
+    for (unsigned h = 1; h < n; h++) {
+        for (;;) {
+#ifndef X280_ISS
+            __asm__ volatile("fence ir, ir");
+#endif
+            if (*AB_DONE_FLAG(h) == AB_DONE_FLAG_VAL) {
+                break;
+            }
+        }
+        *AB_REC_WALL(result_base, phase_idx, h) = *AB_DONE_WALL(h);
+        *AB_REC_ITERS(result_base, phase_idx, h) = iters_arr[h];
+        *AB_REC_SLOTSUM(result_base, phase_idx, h) = *AB_DONE_SLOTSUM(h);
+        uint64_t h_t0 = *AB_DONE_T0(h);
+        uint64_t h_t1 = *AB_DONE_T1(h);
+        if (h_t0 < span_start) {
+            span_start = h_t0;
+        }
+        if (h_t1 > span_end) {
+            span_end = h_t1;
+        }
+    }
+
+    /* Publish the concurrent span so the host can check real overlap. */
+    *AB_SPAN_START(span_base, phase_idx) = span_start;
+    *AB_SPAN_END(span_base, phase_idx) = span_end;
+
+    /* Correctness: read back the final counter and record expected. For
+     * amoadd.w only the low 32 bits are meaningful; mask so the host
+     * compares apples to apples. */
+    uint64_t got = *counter;
+    if (op == AB_OP_AMOADD_W) {
+        got &= 0xFFFFFFFFULL;
+    }
+    *AB_FGOT(final_base, phase_idx) = got;
+    *AB_FEXP(final_base, phase_idx) = expected;
+    __asm__ volatile("fence ow, ow");
+}
+
+/* Fill iters_arr[0..num-1] for a section and return the expected total.
+ *   section 0 (constant): every hart does `iters`; total = num*iters.
+ *   section 1 (split):    the SAME `iters` total split evenly; hart h does
+ *                         iters/num, with the remainder handed to the low
+ *                         harts so the shares sum EXACTLY to `iters`. */
+static uint64_t fill_iters(unsigned section, unsigned num, uint64_t iters, uint64_t iters_arr[NUM_HARTS]) {
+    if (section == 0) {
+        for (unsigned h = 0; h < num; h++) {
+            iters_arr[h] = iters;
+        }
+        return iters * (uint64_t)num;
+    }
+    uint64_t base = iters / num;
+    uint64_t rem = iters % num;
+    for (unsigned h = 0; h < num; h++) {
+        iters_arr[h] = base + (h < rem ? 1u : 0u);
+    }
+    return iters; /* == base*num + rem */
+}
+
+/* ======================================================================
+ * main -- entry.S calls this on ALL harts with a0 = mhartid
+ * ====================================================================== */
+int main(uint64_t hartid) {
+    /* Workers peel off immediately into their wait loop. */
+    if (hartid != 0) {
+        atomic_worker_loop((uint32_t)hartid); /* noreturn */
+        return 0;                             /* unreachable */
+    }
+
+    /* --- hart 0 --- */
+
+    /* Announce the active FW is running (host handoff waits on this). */
+    *(volatile uint64_t*)X280_BOOT_PHASE_ADDR = X280_BOOT_PHASE_RUNNING_ACTIVE_FW;
+    __asm__ volatile("fence ow, ow");
+
+    set_status(AB_STATUS_INIT);
+
+    /* Wait for the host to publish config (iterations, op, counter addr,
+     * phase mask). STOP-interruptible so an aborted run never strands
+     * the core out of reset. */
+    for (;;) {
+        __asm__ volatile("fence ir, ir");
+        if (*AB_CONFIG_READY_ADDR == AB_CONFIG_READY_VALUE) {
+            break;
+        }
+        if (*AB_STOP_ADDR == AB_STOP_VALUE) {
+            /* Release helpers, then go home. */
+            for (unsigned h = 1; h < NUM_HARTS; h++) {
+                *AB_WORK_ADDR(h) = AB_WORK_SHUTDOWN;
+            }
+            __asm__ volatile("fence ow, ow");
+            set_status(AB_STATUS_DONE);
+            x280_hart0_to_idle();
+        }
+    }
+
+    printf("AB_CONFIG_READY: config latched on ISS\n");
+
+    /* Latch config. */
+    uint64_t iters = *AB_ITERATIONS_ADDR;
+    unsigned op = *AB_OP_MODE_ADDR;
+    unsigned phase_mask = *AB_PHASE_MASK_ADDR;
+    uintptr_t caddr = (uintptr_t)*AB_COUNTER_ADDR_ADDR;
+    if (iters == 0) {
+        iters = 1000000ULL; /* default 1M */
+    }
+    if (phase_mask == 0) {
+        phase_mask = 0xF; /* default: 1,2,3,4 harts */
+    }
+    if (caddr == 0) {
+        caddr = ATOMIC_BASE + 0x2000UL; /* default counter slot */
+    }
+
+    printf("  iters=%lu op=%u phase_mask=0x%x\n", (unsigned long)iters, op, phase_mask);
+
+#ifdef X280_ISS
+    {
+        volatile uint64_t* p = (volatile uint64_t*)caddr;
+        uint64_t n = iters < 8ULL ? iters : 8ULL;
+        *p = 0;
+        for (uint64_t i = 0; i < n; i++) {
+            uint64_t old;
+            __asm__ volatile("amoadd.d %0, %2, (%1)" : "=r"(old) : "r"(p), "r"(1ULL) : "memory");
+            (void)old;
+        }
+        printf("  amoadd.d x%lu -> counter=%lu %s\n", (unsigned long)n, (unsigned long)*p, *p == n ? "OK" : "FAIL");
+        set_status(AB_STATUS_DONE);
+        x280_hart0_to_idle();
+    }
+#endif
+
+    set_status(AB_STATUS_READY);
+
+    /* Probe AMO-to-LIM support before we run any untrapped atomic. If the
+     * selected op is atomic and faults, report and bail cleanly. */
+    int amo_ok = amo_probe(op, caddr);
+    *AB_AMO_SUPPORTED_ADDR = (uint32_t)amo_ok;
+    __asm__ volatile("fence ow, ow");
+    if (!amo_ok && op != AB_OP_NONATOMIC_D) {
+        for (unsigned h = 1; h < NUM_HARTS; h++) {
+            *AB_WORK_ADDR(h) = AB_WORK_SHUTDOWN;
+        }
+        __asm__ volatile("fence ow, ow");
+        set_status(AB_STATUS_AMO_UNSUP);
+        x280_hart0_to_idle();
+    }
+
+    /* Measure the actual PLL (against the 50 MHz mtime ref) and publish it,
+     * so the host converts cycle counts with the REAL clock and can confirm
+     * whether we're at 1000 or 1750 MHz -- no reliance on --mhz. One-time,
+     * before any timed region. */
+    *AB_MEASURED_PLL_KHZ_ADDR = x280_measure_pll_khz();
+    __asm__ volatile("fence ow, ow");
+
+    set_status(AB_STATUS_RUNNING);
+
+    /* Run both sections over the enabled phases (phase index p => p+1
+     * participating harts):
+     *   section 0 "constant": each hart does `iters`  (total grows N*iters)
+     *   section 1 "split":    total `iters` split evenly (each does iters/N)
+     * The split section answers strong scaling: with a FIXED amount of work,
+     * does spreading it across more harts finish faster, or does atomic
+     * contention on the one address eat the parallelism? */
+    for (unsigned section = 0; section < 2u; section++) {
+        uintptr_t rbase = (section == 0) ? AB_RESULT_BASE : AB_RESULT2_BASE;
+        uintptr_t fbase = (section == 0) ? AB_FINAL_BASE : AB_FINAL2_BASE;
+        uintptr_t sbase = (section == 0) ? AB_SPAN_BASE : AB_SPAN2_BASE;
+        for (unsigned p = 0; p < NUM_HARTS; p++) {
+            if (((phase_mask >> p) & 1u) == 0u) {
+                continue;
+            }
+            unsigned num = p + 1u;
+            uint64_t iters_arr[NUM_HARTS];
+            uint64_t expected = fill_iters(section, num, iters, iters_arr);
+            run_phase(p, num, op, caddr, iters_arr, expected, rbase, fbase, sbase);
+        }
+    }
+
+    printf("atomic_bench phases done\n");
+    for (unsigned section = 0; section < 2u; section++) {
+        uintptr_t fbase = (section == 0) ? AB_FINAL_BASE : AB_FINAL2_BASE;
+        for (unsigned p = 0; p < NUM_HARTS; p++) {
+            if (((phase_mask >> p) & 1u) == 0u) {
+                continue;
+            }
+            uint64_t got = *AB_FGOT(fbase, p);
+            uint64_t exp = *AB_FEXP(fbase, p);
+            printf(
+                "  section %u phase %u harts: got=%lu expected=%lu %s\n",
+                section,
+                p + 1u,
+                (unsigned long)got,
+                (unsigned long)exp,
+                got == exp ? "OK" : "MISMATCH");
+        }
+    }
+
+    /* Shut the helpers down and hand the L2CPU back to the idle FW. */
+    for (unsigned h = 1; h < NUM_HARTS; h++) {
+        *AB_WORK_ADDR(h) = AB_WORK_SHUTDOWN;
+    }
+    __asm__ volatile("fence ow, ow");
+
+    set_status(AB_STATUS_DONE);
+    x280_hart0_to_idle();
+    return 0; /* unreachable */
+}

--- a/tests/tt_metal/tt_metal/x280_iss_hello/src/boot.S
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/src/boot.S
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * X280-cluster boot for the ISS: park harts 1..3, enable mstatus.FS and
+ * mstatus.VS (both Off at reset; required before FP / RVV), then call main.
+ */
+
+    .section .text.start, "ax"
+    .globl _start
+    .globl tohost
+    .globl fromhost
+
+_start:
+    csrr  t0, mhartid
+    bnez  t0, park
+
+    /* mstatus.FS = Dirty [14:13]=11, mstatus.VS = Initial [10:9]=01 */
+    li    t1, (3 << 13) | (1 << 9)
+    csrs  mstatus, t1
+
+    la    sp, _stack_top
+    la    gp, __global_pointer$
+    call  main
+
+    /* HTIF exit: (code << 1) | 1. main returns 0 on success. */
+    slli  a0, a0, 1
+    ori   a0, a0, 1
+    la    t0, tohost
+    sd    a0, 0(t0)
+1:  wfi
+    j     1b
+
+park:
+    wfi
+    j     park
+
+    .section .tohost, "aw", @progbits
+    .align 6
+tohost:
+    .dword 0
+    .align 6
+fromhost:
+    .dword 0

--- a/tests/tt_metal/tt_metal/x280_iss_hello/src/boot_atomic.S
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/src/boot_atomic.S
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Hart 0 publishes the host config block, then enters main(0).
+ * Harts 1..3 park. 1-hart phases do not need helpers.
+ */
+
+    .section .text.start, "ax"
+    .globl _start
+    .globl tohost
+    .globl fromhost
+    .globl iss_publish_config
+
+_start:
+    csrr  t0, mhartid
+    bnez  t0, park
+
+    li    t1, (3 << 13) | (1 << 9)
+    csrs  mstatus, t1
+
+    la    sp, _stack_top
+    la    gp, __global_pointer$
+    call  iss_publish_config
+    li    a0, 0
+    call  main
+
+    slli  a0, a0, 1
+    ori   a0, a0, 1
+    la    t1, tohost
+    sd    a0, 0(t1)
+park:
+    wfi
+    j     park
+
+    .section .tohost, "aw", @progbits
+    .align 6
+tohost:
+    .dword 0
+    .align 6
+fromhost:
+    .dword 0

--- a/tests/tt_metal/tt_metal/x280_iss_hello/src/hello_x280.c
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/src/hello_x280.c
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Hello world for a simulated Blackhole L2CPU X280 (4-hart rv64gcv, VLEN=512).
+// Proves the ISS is X280-shaped: misa.V, vlenb==64, vsetvli vl==16 for e32/m1.
+
+#include "htif.h"
+
+#include <stdint.h>
+
+#define X280_LIM_BASE 0x08000000UL
+#define X280_ACTIVE_FW_LOAD_ADDR 0x08001000UL
+#define X280_SENTINEL_ADDR ((volatile uint64_t*)0x08100000UL)
+#define X280_SENTINEL_VALUE 0xDEADBEEFCAFEBABEULL
+#define VEC_EXPECTED_VLENB 64UL /* VLEN=512 */
+#define VEC_EXPECTED_VL 16UL    /* VLEN/SEW = 512/32, LMUL=1 */
+
+#define READ_CSR(name)                                      \
+    ({                                                      \
+        uintptr_t __v;                                      \
+        __asm__ __volatile__("csrr %0, " name : "=r"(__v)); \
+        __v;                                                \
+    })
+
+extern char _start[];
+
+static void line(const char* k, const char* v) {
+    htif_puts("  ");
+    htif_puts(k);
+    htif_puts(" = ");
+    htif_puts(v);
+    htif_puts("\n");
+}
+
+int main(void) {
+    htif_puts("\n");
+    htif_puts("=====================================================================\n");
+    htif_puts(" hello_x280 -- X280 ISS (rv64gcv, VLEN=512, 4 harts, LIM @ 0x08000000)\n");
+    htif_puts("=====================================================================\n\n");
+
+    const uintptr_t hartid = READ_CSR("mhartid");
+    const uintptr_t misa = READ_CSR("misa");
+    const int has_v = (int)((misa >> 21) & 1);
+
+    htif_puts("[1] core identity\n");
+    htif_puts("  mhartid = ");
+    htif_put_u64_dec((unsigned long)hartid);
+    htif_puts("\n  misa    = ");
+    htif_put_u64_hex((unsigned long)misa);
+    htif_puts("\n");
+    line("misa.V (vector)", has_v ? "yes" : "no");
+
+    unsigned long vlenb = 0;
+    unsigned long vl = 0;
+    if (has_v) {
+        __asm__ __volatile__("csrr %0, vlenb" : "=r"(vlenb));
+        __asm__ __volatile__("vsetvli %0, %1, e32, m1, ta, ma" : "=r"(vl) : "r"(32));
+        htif_puts("  vlenb   = ");
+        htif_put_u64_dec(vlenb);
+        htif_puts(" bytes -> VLEN=");
+        htif_put_u64_dec(vlenb * 8);
+        htif_puts("\n  vsetvli e32/m1 vl = ");
+        htif_put_u64_dec(vl);
+        htif_puts(" (expect 16)\n");
+    }
+
+    htif_puts("\n[2] LIM layout (tt-llm-engine x280.h)\n");
+    htif_puts("  X280_LIM_BASE            = ");
+    htif_put_u64_hex(X280_LIM_BASE);
+    htif_puts("\n  X280_ACTIVE_FW_LOAD_ADDR = ");
+    htif_put_u64_hex(X280_ACTIVE_FW_LOAD_ADDR);
+    htif_puts("\n  _start                   = ");
+    htif_put_u64_hex((unsigned long)(uintptr_t)_start);
+    htif_puts("\n");
+
+    volatile double a = 1.0;
+    volatile double b = 3.0;
+    const double q = a / b;
+    (void)q;
+    htif_puts("[3] hardware FP (lp64d)\n");
+    htif_puts("  1.0/3.0 computed with F/D (no trap)\n\n");
+
+    *X280_SENTINEL_ADDR = X280_SENTINEL_VALUE;
+    htif_puts("[4] sentinel 0xDEADBEEFCAFEBABE written at 0x08100000\n\n");
+
+    htif_puts("---------------------------------------------------------------------\n");
+    htif_puts(" Hello, World!\n");
+    htif_puts("---------------------------------------------------------------------\n\n");
+
+    int fails = 0;
+    if (hartid != 0) {
+        htif_puts("FAIL: expected boot hart 0\n");
+        fails++;
+    }
+    if (!has_v) {
+        htif_puts("FAIL: misa.V is clear (not an X280-class core)\n");
+        fails++;
+    }
+    if (vlenb != VEC_EXPECTED_VLENB) {
+        htif_puts("FAIL: vlenb is not 64 (VLEN!=512)\n");
+        fails++;
+    }
+    if (vl != VEC_EXPECTED_VL) {
+        htif_puts("FAIL: vsetvli e32/m1 did not return vl=16\n");
+        fails++;
+    }
+    if ((uintptr_t)_start != X280_ACTIVE_FW_LOAD_ADDR) {
+        htif_puts("FAIL: _start is not 0x08001000\n");
+        fails++;
+    }
+    if (*X280_SENTINEL_ADDR != X280_SENTINEL_VALUE) {
+        htif_puts("FAIL: sentinel readback mismatch\n");
+        fails++;
+    }
+
+    if (fails == 0) {
+        htif_puts("The X280 ISS hello world ran. All checks passed.\n");
+        return 0;
+    }
+    htif_puts("X280 ISS hello world failed.\n");
+    return 1;
+}

--- a/tests/tt_metal/tt_metal/x280_iss_hello/src/htif.c
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/src/htif.c
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "htif.h"
+
+#include <stdint.h>
+
+extern volatile uint64_t tohost;
+
+#define HTIF_DEV_CONSOLE 1ULL
+#define HTIF_CMD_WRITE 1ULL
+
+// BCD write (dev 1, cmd 1) does not respond on fromhost; Spike clears tohost
+// after consuming the command.
+static void htif_send(uint64_t payload) {
+    while (tohost) {
+    }
+    tohost = payload;
+    while (tohost) {
+    }
+}
+
+void htif_putc(char c) { htif_send((HTIF_DEV_CONSOLE << 56) | (HTIF_CMD_WRITE << 48) | (uint8_t)c); }
+
+void htif_puts(const char* s) {
+    while (*s) {
+        htif_putc(*s++);
+    }
+}
+
+void htif_put_u64_hex(unsigned long v) {
+    htif_puts("0x");
+    for (int i = 15; i >= 0; --i) {
+        unsigned d = (unsigned)((v >> (i * 4)) & 0xfu);
+        htif_putc((char)(d < 10 ? '0' + d : 'a' + (d - 10)));
+    }
+}
+
+void htif_put_u64_dec(unsigned long v) {
+    char buf[32];
+    int n = 0;
+    if (v == 0) {
+        htif_putc('0');
+        return;
+    }
+    while (v && n < (int)sizeof(buf)) {
+        buf[n++] = (char)('0' + (v % 10));
+        v /= 10;
+    }
+    while (n--) {
+        htif_putc(buf[n]);
+    }
+}

--- a/tests/tt_metal/tt_metal/x280_iss_hello/src/htif.h
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/src/htif.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Spike / X280 ISS HTIF console (device 1, cmd PUTCHAR).
+
+#ifndef X280_ISS_HTIF_H_
+#define X280_ISS_HTIF_H_
+
+void htif_putc(char c);
+void htif_puts(const char* s);
+void htif_put_u64_hex(unsigned long v);
+void htif_put_u64_dec(unsigned long v);
+
+#endif

--- a/tests/tt_metal/tt_metal/x280_iss_hello/src/iss_host_stub.c
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/src/iss_host_stub.c
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Spike has no host/NOC. Publish the same LIM config block that
+// experiment_atomic_bench.py would write, so hart 0's AB_CONFIG_READY wait
+// completes.
+
+#include <stdint.h>
+
+#define LIM_BASE 0x08000000UL
+#define ATOMIC_BASE (LIM_BASE + 0x00160000UL)
+
+#define AB_STOP_ADDR ((volatile uint32_t*)(ATOMIC_BASE + 0x040UL))
+#define AB_CONFIG_READY_ADDR ((volatile uint32_t*)(ATOMIC_BASE + 0x080UL))
+#define AB_ITERATIONS_ADDR ((volatile uint64_t*)(ATOMIC_BASE + 0x100UL))
+#define AB_OP_MODE_ADDR ((volatile uint32_t*)(ATOMIC_BASE + 0x140UL))
+#define AB_PHASE_MASK_ADDR ((volatile uint32_t*)(ATOMIC_BASE + 0x180UL))
+#define AB_COUNTER_ADDR_ADDR ((volatile uint64_t*)(ATOMIC_BASE + 0x1C0UL))
+
+#define AB_OP_AMOADD_D 1u
+#define AB_CONFIG_READY_VALUE 0x000C0FFEu
+
+#ifndef AB_ISS_ITERS
+#define AB_ISS_ITERS 1000ULL
+#endif
+
+void iss_publish_config(void) {
+    *AB_STOP_ADDR = 0;
+    *AB_ITERATIONS_ADDR = AB_ISS_ITERS;
+    *AB_OP_MODE_ADDR = AB_OP_AMOADD_D;
+    *AB_PHASE_MASK_ADDR = 0x1u; /* 1-hart phase; multi-hart is a follow-up */
+    *AB_COUNTER_ADDR_ADDR = ATOMIC_BASE + 0x2000UL;
+    __asm__ volatile("fence ow, ow");
+    *AB_CONFIG_READY_ADDR = AB_CONFIG_READY_VALUE;
+    __asm__ volatile("fence ow, ow");
+}

--- a/tests/tt_metal/tt_metal/x280_iss_hello/src/iss_printf.c
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/src/iss_printf.c
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Minimal HTIF printf: %s %c %d %u %x %lx %lu %%
+
+#include "iss_printf.h"
+
+#include <stdarg.h>
+#include <stdint.h>
+
+#include "htif.h"
+
+static void put_signed(long v) {
+    if (v < 0) {
+        htif_putc('-');
+        htif_put_u64_dec((unsigned long)(-v));
+    } else {
+        htif_put_u64_dec((unsigned long)v);
+    }
+}
+
+int printf(const char* fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    for (const char* p = fmt; *p; p++) {
+        if (*p != '%') {
+            htif_putc(*p);
+            continue;
+        }
+        p++;
+        int is_long = 0;
+        while (*p == 'l') {
+            is_long = 1;
+            p++;
+        }
+        switch (*p) {
+            case 's': htif_puts(va_arg(ap, const char*)); break;
+            case 'c': htif_putc((char)va_arg(ap, int)); break;
+            case 'd': put_signed(is_long ? va_arg(ap, long) : (long)va_arg(ap, int)); break;
+            case 'u':
+                htif_put_u64_dec(is_long ? va_arg(ap, unsigned long) : (unsigned long)va_arg(ap, unsigned));
+                break;
+            case 'x':
+            case 'p': {
+                unsigned long v = is_long ? va_arg(ap, unsigned long) : (unsigned long)va_arg(ap, unsigned);
+                for (int i = 7; i >= 0; --i) {
+                    unsigned d = (unsigned)((v >> (i * 4)) & 0xfu);
+                    htif_putc((char)(d < 10 ? '0' + d : 'a' + (d - 10)));
+                }
+                break;
+            }
+            case '%': htif_putc('%'); break;
+            case '\0': va_end(ap); return 0;
+            default:
+                htif_putc('%');
+                htif_putc(*p);
+                break;
+        }
+    }
+    va_end(ap);
+    return 0;
+}

--- a/tests/tt_metal/tt_metal/x280_iss_hello/src/iss_printf.h
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/src/iss_printf.h
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef X280_ISS_PRINTF_H_
+#define X280_ISS_PRINTF_H_
+
+int printf(const char* fmt, ...);
+
+#endif

--- a/tests/tt_metal/tt_metal/x280_iss_hello/src/iss_runtime.c
+++ b/tests/tt_metal/tt_metal/x280_iss_hello/src/iss_runtime.c
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+uint64_t _probe_active;


### PR DESCRIPTION
## Summary
- Runs a LIM-linked hello world on a simulated X280 cluster (Spike ISS: 4 harts, `rv64gcv`, VLEN=512) instead of QEMU `sifive_u`, so vector and the real X280 load address (`0x08001000`) are exercised without a card.
- Self-checks `misa.V`, `vlenb==64` (VLEN=512), `vsetvli` vl==16, link address, and the tt-llm-engine LIM sentinel at `0x08100000`.
- Supports swapping in a vendor SiFive X280 ISS via `X280_ISS=/path/to/iss` (same firmware, no code changes).
- ISA-level only: not cycle-accurate, no Blackhole NOC/DMA modeling.

## Test plan
- [x] `cd tests/tt_metal/tt_metal/x280_iss_hello && ./run.sh` — builds Spike + firmware, runs on the ISS, verifies output. Ran locally end-to-end: `The simulated X280 hello world ran. All checks passed.`


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sanjaysundaram/x280-iss-hello)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sanjaysundaram/x280-iss-hello)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sanjaysundaram/x280-iss-hello)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sanjaysundaram/x280-iss-hello)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sanjaysundaram/x280-iss-hello)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sanjaysundaram/x280-iss-hello)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sanjaysundaram/x280-iss-hello)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sanjaysundaram/x280-iss-hello)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sanjaysundaram/x280-iss-hello)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sanjaysundaram/x280-iss-hello)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sanjaysundaram/x280-iss-hello)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sanjaysundaram/x280-iss-hello)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sanjaysundaram/x280-iss-hello)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sanjaysundaram/x280-iss-hello)