### PR TITLE
Expand ttsim SKUs to mirror per-topology HW SKUs

### DIFF
--- a/.github/actions/fetch-ttsim/action.yml
+++ b/.github/actions/fetch-ttsim/action.yml
@@ -1,0 +1,86 @@
+name: Fetch TTSim
+description: |
+  Download every simulator binary of the pinned tenstorrent/ttsim release and upload
+  them as one artifact for the sim jobs in the same workflow to consume via
+  .github/actions/setup-ttsim.
+
+  The release tag comes from tt_metal/ttsim-version, and all libttsim_*.so assets are
+  fetched rather than a named subset: which binary a SKU uses is declared by its
+  ttsim_lib in .github/sku_config.yaml, so adding a simulator topology needs no change
+  here. ttsim is a public repo, so the default GITHUB_TOKEN is enough to read its
+  releases and no third-party downloader is involved.
+
+  The caller must have checked out this action's directory and the version file, e.g.
+    sparse-checkout: |
+      .github/actions/fetch-ttsim
+      tt_metal/ttsim-version
+
+inputs:
+  artifact-name:
+    description: Name of the uploaded artifact; must match what setup-ttsim downloads.
+    required: false
+    default: 'ttsim-binaries'
+  version-file:
+    description: File holding the tenstorrent/ttsim release tag to download.
+    required: false
+    default: 'tt_metal/ttsim-version'
+  github-token:
+    description: Token used for the release download. The default is enough for a public repo.
+    required: false
+    default: ${{ github.token }}
+  retention-days:
+    description: Artifact retention. One day by default; it is only consumed within the run.
+    required: false
+    default: '1'
+
+runs:
+  using: composite
+  steps:
+    - name: Download ttsim release binaries
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+        if [[ ! -f "${{ inputs.version-file }}" ]]; then
+          echo "::error::${{ inputs.version-file }} not found. Add it to the job's sparse-checkout."
+          exit 1
+        fi
+        version=$(tr -d '[:space:]' < "${{ inputs.version-file }}")
+        if [[ -z "$version" ]]; then
+          echo "::error::${{ inputs.version-file }} is empty; expected a tenstorrent/ttsim release tag."
+          exit 1
+        fi
+
+        echo "Downloading libttsim_*.so from tenstorrent/ttsim@$version"
+        rm -rf /tmp/ttsim
+        mkdir -p /tmp/ttsim
+        gh release download "$version" \
+          --repo tenstorrent/ttsim \
+          --pattern 'libttsim_*.so' \
+          --dir /tmp/ttsim
+
+        # The release also ships *_aarch64.so builds of each library. Every sim runner is
+        # x86_64 and sku_config's ttsim_lib names the x86 asset, so drop them instead of
+        # doubling the artifact that each sim job downloads. Sim on ARM runners would need
+        # ttsim_lib to become arch-aware first.
+        rm -f /tmp/ttsim/*_aarch64.so
+
+        # --pattern matching nothing is not an error for gh, so check before publishing an
+        # artifact that would fail every sim job later with a missing-binary error instead.
+        shopt -s nullglob
+        libs=(/tmp/ttsim/libttsim_*.so)
+        if [[ ${#libs[@]} -eq 0 ]]; then
+          echo "::error::tenstorrent/ttsim@$version has no libttsim_*.so assets."
+          exit 1
+        fi
+        echo "Fetched ${#libs[@]} simulator binaries:"
+        ls -lh /tmp/ttsim
+
+    - name: Upload ttsim binaries artifact
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: /tmp/ttsim/
+        if-no-files-found: error
+        retention-days: ${{ inputs.retention-days }}

--- a/.github/actions/fetch-ttsim/action.yml
+++ b/.github/actions/fetch-ttsim/action.yml
@@ -4,11 +4,11 @@ description: |
   them as one artifact for the sim jobs in the same workflow to consume via
   .github/actions/setup-ttsim.
 
-  The release tag comes from tt_metal/ttsim-version, and all libttsim_*.so assets are
-  fetched rather than a named subset: which binary a SKU uses is declared by its
-  ttsim_lib in .github/sku_config.yaml, so adding a simulator topology needs no change
-  here. ttsim is a public repo, so the default GITHUB_TOKEN is enough to read its
-  releases and no third-party downloader is involved.
+  The release tag comes from tt_metal/ttsim-version, and the binaries to fetch come from
+  the caller's load-test-matrix job (its sim-libs output, derived from each selected SKU's
+  ttsim_lib in .github/sku_config.yaml), so only the libs the matrix actually needs are
+  downloaded and no workflow names one itself. ttsim is a public repo, so the default
+  GITHUB_TOKEN is enough to read its releases and no third-party downloader is involved.
 
   The caller must have checked out this action's directory and the version file, e.g.
     sparse-checkout: |
@@ -16,6 +16,9 @@ description: |
       tt_metal/ttsim-version
 
 inputs:
+  libs:
+    description: Comma-separated libttsim_*.so asset names to download
+    required: true
   artifact-name:
     description: Name of the uploaded artifact; must match what setup-ttsim downloads.
     required: false
@@ -52,26 +55,34 @@ runs:
           exit 1
         fi
 
-        echo "Downloading libttsim_*.so from tenstorrent/ttsim@$version"
+        if [[ -z "${{ inputs.libs }}" ]]; then
+          echo "::error::No simulator libs requested. This job should be gated on the matrix having sim_* SKUs."
+          exit 1
+        fi
+        # sim-libs is already a clean CSV of asset names, so a plain split is enough.
+        IFS=',' read -r -a libs <<< "${{ inputs.libs }}"
+
+        echo "Downloading ${#libs[@]} simulator binaries from tenstorrent/ttsim@$version: ${libs[*]}"
         rm -rf /tmp/ttsim
         mkdir -p /tmp/ttsim
+        pattern_args=()
+        for lib in "${libs[@]}"; do
+          pattern_args+=(--pattern "$lib")
+        done
         gh release download "$version" \
           --repo tenstorrent/ttsim \
-          --pattern 'libttsim_*.so' \
+          "${pattern_args[@]}" \
           --dir /tmp/ttsim
 
-        # The release also ships *_aarch64.so builds of each library. Every sim runner is
-        # x86_64 and sku_config's ttsim_lib names the x86 asset, so drop them instead of
-        # doubling the artifact that each sim job downloads. Sim on ARM runners would need
-        # ttsim_lib to become arch-aware first.
-        rm -f /tmp/ttsim/*_aarch64.so
-
-        # --pattern matching nothing is not an error for gh, so check before publishing an
-        # artifact that would fail every sim job later with a missing-binary error instead.
-        shopt -s nullglob
-        libs=(/tmp/ttsim/libttsim_*.so)
-        if [[ ${#libs[@]} -eq 0 ]]; then
-          echo "::error::tenstorrent/ttsim@$version has no libttsim_*.so assets."
+        # A --pattern matching no asset is not an error for gh, so verify every requested lib
+        # landed. Failing here names the missing binary; letting it through would fail each sim
+        # job later in setup-ttsim instead.
+        missing=()
+        for lib in "${libs[@]}"; do
+          [[ -f "/tmp/ttsim/$lib" ]] || missing+=("$lib")
+        done
+        if [[ ${#missing[@]} -gt 0 ]]; then
+          echo "::error::tenstorrent/ttsim@$version has no asset(s): ${missing[*]}. Check ttsim_lib in .github/sku_config.yaml against the pinned release."
           exit 1
         fi
         echo "Fetched ${#libs[@]} simulator binaries:"

--- a/.github/actions/fetch-ttsim/action.yml
+++ b/.github/actions/fetch-ttsim/action.yml
@@ -1,6 +1,6 @@
 name: Fetch TTSim
 description: |
-  Download every simulator binary of the pinned tenstorrent/ttsim release and upload
+  Download every simulator binary required by this workflowof the pinned tenstorrent/ttsim release and upload
   them as one artifact for the sim jobs in the same workflow to consume via
   .github/actions/setup-ttsim.
 

--- a/.github/actions/fetch-ttsim/action.yml
+++ b/.github/actions/fetch-ttsim/action.yml
@@ -1,13 +1,21 @@
 name: Fetch TTSim
 description: |
-  Download every simulator binary required by this workflowof the pinned tenstorrent/ttsim release and upload
-  them as one artifact for the sim jobs in the same workflow to consume via
+  Publish one simulator binary of the pinned tenstorrent/ttsim release as a run artifact
+  named ttsim-lib-<library>, for the sim jobs in this run to consume via
   .github/actions/setup-ttsim.
 
-  The release tag comes from tt_metal/ttsim-version, and the binaries to fetch come from
-  the caller's load-test-matrix job (its sim-libs output, derived from each selected SKU's
-  ttsim_lib in .github/sku_config.yaml), so only the libs the matrix actually needs are
-  downloaded and no workflow names one itself. ttsim is a public repo, so the default
+  One library per invocation, so the artifact name identifies its contents. Callers run this
+  as a matrix over their load-test-matrix job's sim-libs output, which means only the
+  libraries that run's matrix actually needs are fetched. Because the name is the same in
+  every pipeline, a library another impl already published in this run is reused instead of
+  downloaded again: sanity runs three sim impls that all need libttsim_bh.so, and only the
+  first one fetches and stores it.
+
+  Pair this with a per-library concurrency group on the calling job so two impls needing the
+  same library cannot both pass the check and upload it. Duplicates are harmless if they do
+  slip through — same release, same bytes, download-by-name returns one of them.
+
+  The release tag comes from tt_metal/ttsim-version. ttsim is a public repo, so the default
   GITHUB_TOKEN is enough to read its releases and no third-party downloader is involved.
 
   The caller must have checked out this action's directory and the version file, e.g.
@@ -16,19 +24,15 @@ description: |
       tt_metal/ttsim-version
 
 inputs:
-  libs:
-    description: Comma-separated libttsim_*.so asset names to download
+  lib:
+    description: A single libttsim_*.so asset name, as emitted per entry by prepare_test_matrix.py's sim-libs output. 
     required: true
-  artifact-name:
-    description: Name of the uploaded artifact; must match what setup-ttsim downloads.
-    required: false
-    default: 'ttsim-binaries'
   version-file:
     description: File holding the tenstorrent/ttsim release tag to download.
     required: false
     default: 'tt_metal/ttsim-version'
   github-token:
-    description: Token used for the release download. The default is enough for a public repo.
+    description: Token used for the release download and the artifact lookup.
     required: false
     default: ${{ github.token }}
   retention-days:
@@ -39,7 +43,31 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Download ttsim release binaries
+    - name: Check whether this library is already published
+      id: check
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+        if [[ -z "${{ inputs.lib }}" ]]; then
+          echo "::error::No library given. Run this as a matrix over the matrix job's sim-libs output."
+          exit 1
+        fi
+        echo "artifact-name=ttsim-lib-${{ inputs.lib }}" >> "$GITHUB_OUTPUT"
+
+        # Another impl in this run may already have published it; the artifact name is the
+        # dedupe key, so an existing one means this download is redundant.
+        if gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" --paginate \
+             --jq '.artifacts[].name' | grep -qxF "ttsim-lib-${{ inputs.lib }}"; then
+          echo "ttsim-lib-${{ inputs.lib }} is already published in this run; skipping the download."
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Download ttsim release binary
+      if: ${{ steps.check.outputs.exists != 'true' }}
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github-token }}
@@ -55,43 +83,27 @@ runs:
           exit 1
         fi
 
-        if [[ -z "${{ inputs.libs }}" ]]; then
-          echo "::error::No simulator libs requested. This job should be gated on the matrix having sim_* SKUs."
-          exit 1
-        fi
-        # sim-libs is already a clean CSV of asset names, so a plain split is enough.
-        IFS=',' read -r -a libs <<< "${{ inputs.libs }}"
-
-        echo "Downloading ${#libs[@]} simulator binaries from tenstorrent/ttsim@$version: ${libs[*]}"
+        echo "Downloading ${{ inputs.lib }} from tenstorrent/ttsim@$version"
         rm -rf /tmp/ttsim
         mkdir -p /tmp/ttsim
-        pattern_args=()
-        for lib in "${libs[@]}"; do
-          pattern_args+=(--pattern "$lib")
-        done
         gh release download "$version" \
           --repo tenstorrent/ttsim \
-          "${pattern_args[@]}" \
+          --pattern '${{ inputs.lib }}' \
           --dir /tmp/ttsim
 
-        # A --pattern matching no asset is not an error for gh, so verify every requested lib
-        # landed. Failing here names the missing binary; letting it through would fail each sim
-        # job later in setup-ttsim instead.
-        missing=()
-        for lib in "${libs[@]}"; do
-          [[ -f "/tmp/ttsim/$lib" ]] || missing+=("$lib")
-        done
-        if [[ ${#missing[@]} -gt 0 ]]; then
-          echo "::error::tenstorrent/ttsim@$version has no asset(s): ${missing[*]}. Check ttsim_lib in .github/sku_config.yaml against the pinned release."
+        # Failing here names the missing binary; letting it through would fail every sim job
+        # later in setup-ttsim instead.
+        if [[ ! -f "/tmp/ttsim/${{ inputs.lib }}" ]]; then
+          echo "::error::tenstorrent/ttsim@$version has no asset ${{ inputs.lib }}. Check ttsim_lib in .github/sku_config.yaml against the pinned release."
           exit 1
         fi
-        echo "Fetched ${#libs[@]} simulator binaries:"
-        ls -lh /tmp/ttsim
+        ls -lh "/tmp/ttsim/${{ inputs.lib }}"
 
-    - name: Upload ttsim binaries artifact
+    - name: Upload ttsim binary artifact
+      if: ${{ steps.check.outputs.exists != 'true' }}
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
-        name: ${{ inputs.artifact-name }}
-        path: /tmp/ttsim/
+        name: ${{ steps.check.outputs.artifact-name }}
+        path: /tmp/ttsim/${{ inputs.lib }}
         if-no-files-found: error
         retention-days: ${{ inputs.retention-days }}

--- a/.github/actions/fetch-ttsim/action.yml
+++ b/.github/actions/fetch-ttsim/action.yml
@@ -25,7 +25,7 @@ description: |
 
 inputs:
   lib:
-    description: A single libttsim_*.so asset name, as emitted per entry by prepare_test_matrix.py's sim-libs output. 
+    description: A single libttsim_*.so asset name, as emitted per entry by prepare_test_matrix.py's sim-libs output.
     required: true
   version-file:
     description: File holding the tenstorrent/ttsim release tag to download.

--- a/.github/actions/fetch-ttsim/action.yml
+++ b/.github/actions/fetch-ttsim/action.yml
@@ -11,9 +11,10 @@ description: |
   downloaded again: sanity runs three sim impls that all need libttsim_bh.so, and only the
   first one fetches and stores it.
 
-  Pair this with a per-library concurrency group on the calling job so two impls needing the
-  same library cannot both pass the check and upload it. Duplicates are harmless if they do
-  slip through — same release, same bytes, download-by-name returns one of them.
+  A library another impl already published in this run is reused rather than downloaded again:
+  the action probes for it first, and the upload replaces rather than duplicates. Pair this with
+  a per-library concurrency group on the calling job so two impls cannot probe before either has
+  published.
 
   The release tag comes from tt_metal/ttsim-version. ttsim is a public repo, so the default
   GITHUB_TOKEN is enough to read its releases and no third-party downloader is involved.
@@ -43,26 +44,39 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Check whether this library is already published
-      id: check
+    - name: Validate input
       shell: bash
-      env:
-        GH_TOKEN: ${{ inputs.github-token }}
       run: |
         set -euo pipefail
         if [[ -z "${{ inputs.lib }}" ]]; then
           echo "::error::No library given. Run this as a matrix over the matrix job's sim-libs output."
           exit 1
         fi
-        echo "artifact-name=ttsim-lib-${{ inputs.lib }}" >> "$GITHUB_OUTPUT"
 
-        # Another impl in this run may already have published it; the artifact name is the
-        # dedupe key, so an existing one means this download is redundant.
-        if gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/artifacts" --paginate \
-             --jq '.artifacts[].name' | grep -qxF "ttsim-lib-${{ inputs.lib }}"; then
+    # Probe by downloading the artifact rather than by listing the run's artifacts:
+    # GET /runs/{id}/artifacts lags unpredictably while a run is in progress (a leg missed an
+    # artifact created 11s earlier while another saw one created 4s later), whereas this is the
+    # read path every sim job uses. A failure means no consumer could read it either, so
+    # fetching is the right response.
+    - name: Probe for a copy a sibling impl already published
+      id: probe
+      # Expected to fail for whichever leg gets there first; that is the signal to fetch.
+      continue-on-error: true
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: ttsim-lib-${{ inputs.lib }}
+        path: /tmp/ttsim
+
+    - name: Report probe result
+      id: check
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ "${{ steps.probe.outcome }}" == "success" && -f "/tmp/ttsim/${{ inputs.lib }}" ]]; then
           echo "ttsim-lib-${{ inputs.lib }} is already published in this run; skipping the download."
           echo "exists=true" >> "$GITHUB_OUTPUT"
         else
+          echo "ttsim-lib-${{ inputs.lib }} is not published yet; fetching it."
           echo "exists=false" >> "$GITHUB_OUTPUT"
         fi
 
@@ -103,7 +117,11 @@ runs:
       if: ${{ steps.check.outputs.exists != 'true' }}
       uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
-        name: ${{ steps.check.outputs.artifact-name }}
+        name: ttsim-lib-${{ inputs.lib }}
         path: /tmp/ttsim/${{ inputs.lib }}
+        # Replace rather than accumulate: if the probe ran before a sibling's copy was visible,
+        # this keeps the run at one artifact per library instead of two. Safe because consumers
+        # need the whole fetch-ttsim job, so none can read during the replace.
+        overwrite: true
         if-no-files-found: error
         retention-days: ${{ inputs.retention-days }}

--- a/.github/actions/setup-ttsim/action.yml
+++ b/.github/actions/setup-ttsim/action.yml
@@ -1,25 +1,25 @@
 name: Setup TTSim
 description: |
-  Install the ttsim simulator binary for a given arch from a pre-uploaded
+  Install the ttsim simulator binary for a given SKU from a pre-uploaded
   artifact, and export the env vars needed to run tests under the simulator
   (TT_METAL_SIMULATOR_HOME, TT_METAL_SIMULATOR, TT_METAL_SLOW_DISPATCH_MODE,
   TT_METAL_DISABLE_SFPLOADMACRO). The caller workflow is expected to have
-  uploaded an artifact containing libttsim_wh.so and libttsim_bh.so (see
-  the fetch-ttsim job pattern in tt-metal-l2-nightly-impl.yaml). This action
-  picks the correct binary based on the SKU and installs it into <root>/sim.
+  uploaded an artifact containing every libttsim_*.so of the pinned ttsim
+  release (see the fetch-ttsim job pattern in ttsim-sanity-tests-impl.yaml).
+  Which binary a SKU gets is declared by that SKU's ttsim_lib in
+  .github/sku_config.yaml, so callers pass only the SKU.
 
 inputs:
   sku:
     description: |
-      Matrix-entry SKU. Used to pick the arch-specific ttsim binary: any SKU
-      containing "blackhole" or "bh_" maps to libttsim_bh.so + blackhole soc
-      descriptor; everything else maps to libttsim_wh.so + wormhole_b0 soc
-      descriptor.
+      Matrix-entry SKU. Must be a sim_* SKU carrying a ttsim_lib field in
+      .github/sku_config.yaml; that field selects the simulator binary and its
+      wh/bh prefix selects the soc descriptor.
     required: true
   artifact-name:
     description: |
-      Name of the artifact containing libttsim_wh.so and libttsim_bh.so,
-      uploaded by an upstream fetch-ttsim job in the calling workflow.
+      Name of the artifact containing the libttsim_*.so set, uploaded by an
+      upstream fetch-ttsim job in the calling workflow.
     required: false
     default: 'ttsim-binaries'
   root:
@@ -35,15 +35,49 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Compute ttsim asset name
+    - name: Resolve ttsim binary for SKU
       id: ttsim-info
       shell: bash
       run: |
-        if [[ "${{ inputs.sku }}" == *blackhole* || "${{ inputs.sku }}" == bh_* ]]; then
-          asset=libttsim_bh.so; soc=blackhole_140_arch.yaml
-        else
-          asset=libttsim_wh.so; soc=wormhole_b0_80_arch.yaml
+        set -euo pipefail
+        # sku_config.yaml sits two levels above this action; resolving it from
+        # GITHUB_ACTION_PATH keeps the lookup working for both full and sparse checkouts,
+        # and for callers that check out into a subdirectory.
+        config="$GITHUB_ACTION_PATH/../../sku_config.yaml"
+        if [[ ! -f "$config" ]]; then
+          echo "::error::sku_config.yaml not found at $config. Add .github/sku_config.yaml to the job's sparse-checkout."
+          exit 1
         fi
+
+        # Read skus.<sku>.ttsim_lib. Scoped to the SKU's own block: the key is matched at
+        # its indent, then the scan stops at the next line indented no deeper.
+        asset=$(awk -v sku="${{ inputs.sku }}" '
+          !found {
+            if ($1 == sku ":") { match($0, /^[[:space:]]*/); found = 1; indent = RLENGTH }
+            next
+          }
+          {
+            if ($0 ~ /^[[:space:]]*(#|$)/) next
+            match($0, /^[[:space:]]*/)
+            if (RLENGTH <= indent) exit
+            if ($1 == "ttsim_lib:") { print $2; exit }
+          }
+        ' "$config")
+
+        if [[ -z "$asset" ]]; then
+          echo "::error::SKU '${{ inputs.sku }}' has no ttsim_lib in .github/sku_config.yaml; add one to run it under the simulator."
+          exit 1
+        fi
+
+        # The binary's arch prefix picks the soc descriptor, so the SKU name needs no
+        # arch parsing of its own.
+        case "$asset" in
+          libttsim_wh*) soc=wormhole_b0_80_arch.yaml ;;
+          libttsim_bh*) soc=blackhole_140_arch.yaml ;;
+          *) echo "::error::Cannot derive an arch from ttsim_lib '$asset' for SKU '${{ inputs.sku }}'."; exit 1 ;;
+        esac
+
+        echo "Resolved ${{ inputs.sku }} -> $asset ($soc)"
         echo "asset_name=$asset" >> "$GITHUB_OUTPUT"
         echo "soc_desc=$soc" >> "$GITHUB_OUTPUT"
 
@@ -67,6 +101,12 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        asset="/tmp/ttsim/${{ steps.ttsim-info.outputs.asset_name }}"
+        if [[ ! -f "$asset" ]]; then
+          echo "::error::${{ steps.ttsim-info.outputs.asset_name }} is not in the '${{ inputs.artifact-name }}' artifact. Available:"
+          ls -1 /tmp/ttsim
+          exit 1
+        fi
         mkdir -p "${{ inputs.root }}/sim"
-        mv "/tmp/ttsim/${{ steps.ttsim-info.outputs.asset_name }}" "${{ inputs.root }}/sim/libttsim.so"
+        mv "$asset" "${{ inputs.root }}/sim/libttsim.so"
         cp "${{ inputs.root }}/tt_metal/soc_descriptors/${{ steps.ttsim-info.outputs.soc_desc }}" "${{ inputs.root }}/sim/soc_descriptor.yaml"

--- a/.github/actions/setup-ttsim/action.yml
+++ b/.github/actions/setup-ttsim/action.yml
@@ -4,10 +4,10 @@ description: |
   artifact, and export the env vars needed to run tests under the simulator
   (TT_METAL_SIMULATOR_HOME, TT_METAL_SIMULATOR, TT_METAL_SLOW_DISPATCH_MODE,
   TT_METAL_DISABLE_SFPLOADMACRO). The caller workflow is expected to have
-  uploaded an artifact containing every libttsim_*.so of the pinned ttsim
-  release (see the fetch-ttsim job pattern in ttsim-sanity-tests-impl.yaml).
-  Which binary a SKU gets is declared by that SKU's ttsim_lib in
-  .github/sku_config.yaml, so callers pass only the SKU.
+  published each simulator binary as its own ttsim-lib-<library> artifact (see the
+  fetch-ttsim job pattern in ttsim-sanity-tests-impl.yaml). Which binary a SKU gets is
+  declared by that SKU's ttsim_lib in .github/sku_config.yaml, so callers pass only the
+  SKU and this action downloads the single artifact holding that library.
 
 inputs:
   sku:
@@ -16,12 +16,6 @@ inputs:
       .github/sku_config.yaml; that field selects the simulator binary and its
       wh/bh prefix selects the soc descriptor.
     required: true
-  artifact-name:
-    description: |
-      Name of the artifact containing the libttsim_*.so set, uploaded by an
-      upstream fetch-ttsim job in the calling workflow.
-    required: false
-    default: 'ttsim-binaries'
   root:
     description: |
       Root directory containing tt_metal/soc_descriptors/. The simulator install
@@ -80,6 +74,9 @@ runs:
         echo "Resolved ${{ inputs.sku }} -> $asset ($soc)"
         echo "asset_name=$asset" >> "$GITHUB_OUTPUT"
         echo "soc_desc=$soc" >> "$GITHUB_OUTPUT"
+        # fetch-ttsim publishes one artifact per library under this name, so the SKU's lib
+        # is all that is needed to find it — nothing to pass in from the workflow.
+        echo "artifact_name=ttsim-lib-$asset" >> "$GITHUB_OUTPUT"
 
     - name: Configure ttsim env vars
       shell: bash
@@ -94,7 +91,7 @@ runs:
     - name: Download ttsim binaries artifact
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
-        name: ${{ inputs.artifact-name }}
+        name: ${{ steps.ttsim-info.outputs.artifact_name }}
         path: /tmp/ttsim
 
     - name: Install ttsim
@@ -103,7 +100,7 @@ runs:
         set -euo pipefail
         asset="/tmp/ttsim/${{ steps.ttsim-info.outputs.asset_name }}"
         if [[ ! -f "$asset" ]]; then
-          echo "::error::${{ steps.ttsim-info.outputs.asset_name }} is not in the '${{ inputs.artifact-name }}' artifact. Available:"
+          echo "::error::${{ steps.ttsim-info.outputs.asset_name }} is not in the '${{ steps.ttsim-info.outputs.artifact_name }}' artifact. Available:"
           ls -1 /tmp/ttsim
           exit 1
         fi

--- a/.github/scripts/utils/prepare_test_matrix.py
+++ b/.github/scripts/utils/prepare_test_matrix.py
@@ -286,6 +286,10 @@ def build_test_matrix(tests, enabled_skus, sku_config, event=None, allow_missing
             sku_entry = sku_config[concrete_sku]
             if "weights-cache-mode" in sku_entry:
                 entry["weights-cache-mode"] = sku_entry["weights-cache-mode"]
+            # Simulator SKUs name the libttsim binary they run on; carrying it here lets the
+            # impl's fetch-ttsim job download only the libs this matrix actually needs.
+            if "ttsim_lib" in sku_entry:
+                entry["ttsim_lib"] = sku_entry["ttsim_lib"]
             # Exabox multihost SKUs: runs_on contains an exabox-multihost* label
             # (e.g. exabox-multihost-ci-sc4). The multihost-ci runner hook provisions
             # workers from container.image. A legacy `allocation` block also marks
@@ -298,25 +302,30 @@ def build_test_matrix(tests, enabled_skus, sku_config, event=None, allow_missing
             filtered_tests.append(entry)
 
     if not filtered_tests:
-        print(f"::error::No tests selected for enabled SKUs '{','.join(enabled_skus)}'. Failing pipeline.")
-        sys.exit(1)
+        print(f"::warning::No tests selected for enabled SKUs '{','.join(enabled_skus)}'.")
 
     return filtered_tests
 
 
 def write_matrix_output(filtered_matrix):
-    """Print and optionally write matrix to GITHUB_OUTPUT."""
+    """Print and optionally write matrix + sim-libs to GITHUB_OUTPUT."""
     print(f"\nFiltered test matrix ({len(filtered_matrix)} tests):")
     json_output_pretty = json.dumps(filtered_matrix, indent=2)
     print(json_output_pretty)
 
     json_output_compact = json.dumps(filtered_matrix)
+    # Simulator binaries this matrix needs, for the caller's fetch-ttsim job. Empty when the
+    # matrix has no sim SKUs, which is also how impls tell whether to run that job at all.
+    sim_libs = ",".join(sorted({entry["ttsim_lib"] for entry in filtered_matrix if entry.get("ttsim_lib")}))
+
     github_output = os.environ.get("GITHUB_OUTPUT")
     if github_output:
         with open(github_output, "a") as f:
             f.write(f"matrix<<EOF\n{json_output_compact}\nEOF\n")
+            f.write(f"sim-libs={sim_libs}\n")
     else:
         print(f"\nmatrix={json_output_compact}")
+        print(f"sim-libs={sim_libs}")
 
 
 def main(argv=None):

--- a/.github/scripts/utils/prepare_test_matrix.py
+++ b/.github/scripts/utils/prepare_test_matrix.py
@@ -30,6 +30,9 @@ exit 0); otherwise comma-separated logical SKUs intersected with coverage.
 `weights-cache-mode` is an optional per-SKU field in sku_config.yaml; when present,
 it is copied into each output matrix entry.
 
+`ttsim_lib` is likewise copied through, and the distinct values are emitted as the JSON-array
+`sim-libs` output so a caller can run one fetch-ttsim leg per simulator binary it needs.
+
 Examples:
     python prepare_test_matrix.py tests/pipeline_reorg/galaxy_e2e_tests.yaml "wh_galaxy,bh_galaxy" .github/sku_config.yaml
     python prepare_test_matrix.py tests/pipeline_reorg/galaxy_demo_tests.yaml ALL_SKUS_IN_TESTS .github/sku_config.yaml
@@ -314,9 +317,10 @@ def write_matrix_output(filtered_matrix):
     print(json_output_pretty)
 
     json_output_compact = json.dumps(filtered_matrix)
-    # Simulator binaries this matrix needs, for the caller's fetch-ttsim job. Empty when the
-    # matrix has no sim SKUs, which is also how impls tell whether to run that job at all.
-    sim_libs = ",".join(sorted({entry["ttsim_lib"] for entry in filtered_matrix if entry.get("ttsim_lib")}))
+    # Simulator binaries this matrix needs, as a JSON array so the caller can feed it straight
+    # to a fetch-ttsim matrix. "[]" when the matrix has no sim SKUs, which is also how impls
+    # tell whether to run that job at all.
+    sim_libs = json.dumps(sorted({entry["ttsim_lib"] for entry in filtered_matrix if entry.get("ttsim_lib")}))
 
     github_output = os.environ.get("GITHUB_OUTPUT")
     if github_output:

--- a/.github/scripts/utils/prepare_test_matrix.py
+++ b/.github/scripts/utils/prepare_test_matrix.py
@@ -304,8 +304,11 @@ def build_test_matrix(tests, enabled_skus, sku_config, event=None, allow_missing
             substitute_cmd_placeholders(entry, allow_missing_cmd=allow_missing_cmd)
             filtered_tests.append(entry)
 
-    if not filtered_tests:
-        print(f"::warning::No tests selected for enabled SKUs '{','.join(enabled_skus)}'.")
+    if not tests:
+        return []
+    elif not filtered_tests:
+        print(f"::error::No tests selected for enabled SKUs '{','.join(enabled_skus)}'.")
+        sys.exit(1)
 
     return filtered_tests
 
@@ -394,6 +397,10 @@ def main(argv=None):
     filtered_matrix = build_test_matrix(
         tests, enabled_skus, sku_config, event=args.event, allow_missing_cmd=args.allow_missing_cmd
     )
+
+    if not filtered_matrix:
+        print(f"::warning::No tests present in test YAML '{args.tests_yaml_path}'.")
+
     write_matrix_output(filtered_matrix)
     return 0
 

--- a/.github/scripts/utils/test_prepare_test_matrix.py
+++ b/.github/scripts/utils/test_prepare_test_matrix.py
@@ -680,3 +680,81 @@ def test_present_but_empty_cmd_is_always_rejected(tmp_path: Path, empty_cmd: str
     result = _run_matrix_raw(path, *extra)
     assert result.returncode != 0, result.stdout
     assert "cmd is present but empty" in result.stdout + result.stderr
+
+
+def _run_with_skus(tests_yaml: Path, enabled: str, *extra: str) -> subprocess.CompletedProcess:
+    """Invoke the script with an explicit enabled-SKU list, without asserting success."""
+    run_env = os.environ.copy()
+    run_env.pop("GITHUB_OUTPUT", None)
+    run_env.pop("MATRIX_EVENT_NAME", None)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(tests_yaml), enabled, str(SKU_CONFIG), *extra],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=run_env,
+    )
+
+
+def sim_libs_line(result) -> str:
+    """The sim-libs value the script printed (stdout form, no GITHUB_OUTPUT)."""
+    for line in reversed(result.stdout.splitlines()):
+        if line.startswith("sim-libs="):
+            return line[len("sim-libs=") :]
+    raise AssertionError(f"No sim-libs= in output:\n{result.stdout}")
+
+
+def test_sim_libs_lists_only_selected_sim_skus(tmp_path: Path):
+    """sim-libs carries each selected sim SKU's ttsim_lib, deduped, and nothing for HW SKUs."""
+    path = tmp_path / "tests.yaml"
+    path.write_text(
+        textwrap.dedent(
+            """\
+            - name: sim and hw test
+              cmd: echo ok
+              skus:
+                wh_n300_civ2:
+                  timeout: 15
+                sim_wh_n300:
+                  timeout: 15
+                sim_bh_p150:
+                  timeout: 15
+              team: runtime
+              owner_id: U000
+            - name: second test on the same sim sku
+              cmd: echo ok
+              skus:
+                sim_wh_n300:
+                  timeout: 15
+              team: runtime
+              owner_id: U000
+            """
+        )
+    )
+    result = _run_with_skus(path, "wh_n300_civ2,sim_wh_n300,sim_bh_p150")
+    assert result.returncode == 0, result.stdout + result.stderr
+    # sorted + unique, despite sim_wh_n300 appearing in two entries
+    assert sim_libs_line(result) == "libttsim_bh.so,libttsim_wh_x2.so"
+
+    # Every sim leg also carries its own lib, which is what setup-ttsim installs.
+    matrix = json.loads(re.search(r"^matrix=(.*)$", result.stdout, re.M).group(1))
+    libs = {e["sku"]: e.get("ttsim_lib") for e in matrix}
+    assert libs["sim_wh_n300"] == "libttsim_wh_x2.so"
+    assert libs["sim_bh_p150"] == "libttsim_bh.so"
+    assert libs["wh_n300_civ2"] is None
+
+
+def test_sim_libs_empty_for_hardware_only_matrix(tmp_path: Path, tests_yaml: Path):
+    """No sim SKUs selected -> empty sim-libs, which is how impls skip fetch-ttsim."""
+    result = _run_with_skus(tests_yaml, "wh_n150_civ2")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert sim_libs_line(result) == ""
+
+
+def test_empty_matrix_is_not_fatal(tmp_path: Path, tests_yaml: Path):
+    """A SKU set that matches nothing warns and emits matrix=[]; impls gate on '[]'."""
+    result = _run_with_skus(tests_yaml, "bh_galaxy")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "No tests selected" in result.stdout
+    assert re.search(r"^matrix=\[\]$", result.stdout, re.M)
+    assert sim_libs_line(result) == ""

--- a/.github/scripts/utils/test_prepare_test_matrix.py
+++ b/.github/scripts/utils/test_prepare_test_matrix.py
@@ -751,10 +751,26 @@ def test_sim_libs_empty_for_hardware_only_matrix(tmp_path: Path, tests_yaml: Pat
     assert sim_libs_line(result) == "[]"
 
 
-def test_empty_matrix_is_not_fatal(tmp_path: Path, tests_yaml: Path):
-    """A SKU set that matches nothing warns and emits matrix=[]; impls gate on '[]'."""
+def test_tests_present_but_no_enabled_sku_is_fatal(tests_yaml: Path):
+    """Tests exist and the SKU set cannot run any of them: a miswired pipeline, so fail."""
     result = _run_with_skus(tests_yaml, "bh_galaxy")
+    assert result.returncode != 0, result.stdout
+    assert "No tests selected for enabled SKUs" in result.stdout
+
+
+@pytest.mark.parametrize("body", ["", "# placeholder, no tests yet\n"])
+@pytest.mark.parametrize("enabled", ["wh_n150_civ2", "ALL_SKUS_IN_TESTS"])
+def test_no_tests_in_yaml_warns_and_passes(tmp_path: Path, body: str, enabled: str):
+    """An empty / placeholder tests YAML is vacuously correct: warn, emit matrix=[], exit 0.
+
+    Covers both SKU forms because the explicit-list form reaches build_test_matrix while
+    ALL_SKUS_IN_TESTS short-circuits in main; e.g. l2-nightly drives the placeholder
+    ttsim_unit_tests.yaml with an explicit list.
+    """
+    path = tmp_path / "tests.yaml"
+    path.write_text(body)
+    result = _run_with_skus(path, enabled)
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "No tests selected" in result.stdout
+    assert "Traceback" not in result.stderr
     assert re.search(r"^matrix=\[\]$", result.stdout, re.M)
     assert sim_libs_line(result) == "[]"

--- a/.github/scripts/utils/test_prepare_test_matrix.py
+++ b/.github/scripts/utils/test_prepare_test_matrix.py
@@ -734,7 +734,7 @@ def test_sim_libs_lists_only_selected_sim_skus(tmp_path: Path):
     result = _run_with_skus(path, "wh_n300_civ2,sim_wh_n300,sim_bh_p150")
     assert result.returncode == 0, result.stdout + result.stderr
     # sorted + unique, despite sim_wh_n300 appearing in two entries
-    assert sim_libs_line(result) == "libttsim_bh.so,libttsim_wh_x2.so"
+    assert json.loads(sim_libs_line(result)) == ["libttsim_bh.so", "libttsim_wh_x2.so"]
 
     # Every sim leg also carries its own lib, which is what setup-ttsim installs.
     matrix = json.loads(re.search(r"^matrix=(.*)$", result.stdout, re.M).group(1))
@@ -748,7 +748,7 @@ def test_sim_libs_empty_for_hardware_only_matrix(tmp_path: Path, tests_yaml: Pat
     """No sim SKUs selected -> empty sim-libs, which is how impls skip fetch-ttsim."""
     result = _run_with_skus(tests_yaml, "wh_n150_civ2")
     assert result.returncode == 0, result.stdout + result.stderr
-    assert sim_libs_line(result) == ""
+    assert sim_libs_line(result) == "[]"
 
 
 def test_empty_matrix_is_not_fatal(tmp_path: Path, tests_yaml: Path):
@@ -757,4 +757,4 @@ def test_empty_matrix_is_not_fatal(tmp_path: Path, tests_yaml: Path):
     assert result.returncode == 0, result.stdout + result.stderr
     assert "No tests selected" in result.stdout
     assert re.search(r"^matrix=\[\]$", result.stdout, re.M)
-    assert sim_libs_line(result) == ""
+    assert sim_libs_line(result) == "[]"

--- a/.github/sku_config.yaml
+++ b/.github/sku_config.yaml
@@ -219,20 +219,50 @@ skus:
     runs_on:
       - tt-ubuntu-2204-medium-prio-stable
 
-  # Synthetic CPU SKUs for ttsim simulator jobs. Tests using these SKUs run on
-  # ubuntu-latest; the impl is expected to invoke .github/actions/setup-ttsim
-  # gated on `startsWith(sku, 'sim_')` to download the matching libttsim_<arch>.so
-  # and export the simulator env vars. The arch suffix on the SKU name selects
-  # the ttsim binary (sim_wormhole_b0 → libttsim_wh.so, sim_blackhole → libttsim_bh.so).
-  sim_wormhole_b0:
+  # Synthetic CPU SKUs for ttsim simulator jobs. The impl invokes
+  # .github/actions/setup-ttsim gated on `startsWith(sku, 'sim_')`; that action reads
+  # ttsim_lib below to pick which simulator binary to install, and derives the soc
+  # descriptor from its wh/bh prefix. Workflows never name a libttsim binary — add or
+  # retarget a SKU here and every pipeline that uses it follows.
+  #
+  # Each sim SKU mirrors one HW SKU's processor count, so a test can list the sim SKU
+  # alongside the HW SKU it stands in for:
+  #   ttsim_lib: (Required) libttsim binary from the tenstorrent/ttsim release pinned
+  #     in tt_metal/ttsim-version. The fetch-ttsim job downloads libttsim_*.so wholesale,
+  #     so a new lib needs no workflow change.
+  sim_wh_n150:
     runs_on:
       - ubuntu-latest
-  sim_blackhole:
+    ttsim_lib: libttsim_wh.so
+  sim_wh_n300:
     runs_on:
       - ubuntu-latest
-  sim_wormhole_b0_galaxy:
+    ttsim_lib: libttsim_wh_x2.so
+  sim_wh_llmbox:
     runs_on:
       - tt-ubuntu-2204-large-stable
-  sim_blackhole_galaxy:
+    ttsim_lib: libttsim_wh_x8.so
+  sim_wh_galaxy:
     runs_on:
       - tt-ubuntu-2204-large-stable
+    ttsim_lib: libttsim_wh_x32.so
+  sim_bh_p150:
+    runs_on:
+      - ubuntu-latest
+    ttsim_lib: libttsim_bh.so
+  sim_bh_p300:
+    runs_on:
+      - ubuntu-latest
+    ttsim_lib: libttsim_bh_x2.so
+  sim_bh_quietbox_2:
+    runs_on:
+      - tt-ubuntu-2204-large-stable
+    ttsim_lib: libttsim_bh_x4.so
+  sim_bh_loudbox:
+    runs_on:
+      - tt-ubuntu-2204-large-stable
+    ttsim_lib: libttsim_bh_x8.so
+  sim_bh_galaxy:
+    runs_on:
+      - tt-ubuntu-2204-large-stable
+    ttsim_lib: libttsim_bh_x32.so

--- a/.github/sku_config.yaml
+++ b/.github/sku_config.yaml
@@ -258,10 +258,6 @@ skus:
     runs_on:
       - tt-ubuntu-2204-large-stable
     ttsim_lib: libttsim_bh_x4.so
-  sim_bh_loudbox:
-    runs_on:
-      - tt-ubuntu-2204-large-stable
-    ttsim_lib: libttsim_bh_x8.so
   sim_bh_galaxy:
     runs_on:
       - tt-ubuntu-2204-large-stable

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -75,8 +75,8 @@ ttnn:
     wh_n300_civ2: 55
     wh_llmbox_civ2_viommu: 15
     bh_p150b_civ2_viommu: 45
-    sim_wormhole_b0: 40
-    sim_blackhole: 40
+    sim_wh_n300: 40
+    sim_bh_p150: 40
   sanity:
     wh_n300_civ2: 545
     bh_p100: 545
@@ -84,8 +84,8 @@ ttnn:
     bh_quietbox_2: 65
     bh_p300: 15
     wh_llmbox_civ2: 40
-    sim_wormhole_b0: 680
-    sim_blackhole: 680
+    sim_wh_n300: 680
+    sim_bh_p150: 680
   unit:
     wh_llmbox: 50
     wh_galaxy: 120
@@ -161,11 +161,11 @@ train:
 
 ttsim:
   unit:
-    sim_wormhole_b0: 15
-    sim_blackhole: 15
+    sim_wh_n150: 15
+    sim_bh_p150: 15
   sanity:
-    sim_wormhole_b0: 30
-    sim_blackhole: 30
+    sim_wh_n150: 30
+    sim_bh_p150: 30
 
 shield:
   e2e_tier2:
@@ -231,10 +231,10 @@ runtime:
     wh_n150_civ2: 13
     bh_p150b_civ2: 13
     bh_loudbox: 5
-    sim_wormhole_b0: 30
-    sim_blackhole: 30
-    sim_wormhole_b0_galaxy: 10
-    sim_blackhole_galaxy: 10
+    sim_wh_n150: 30
+    sim_bh_p150: 30
+    sim_wh_galaxy: 10
+    sim_bh_galaxy: 10
   unit:
     wh_n150_civ2: 232
     wh_n300_civ2: 99

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -75,7 +75,7 @@ ttnn:
     wh_n300_civ2: 55
     wh_llmbox_civ2_viommu: 15
     bh_p150b_civ2_viommu: 45
-    sim_wh_n300: 40
+    sim_wh_n150: 40
     sim_bh_p150: 40
   sanity:
     wh_n300_civ2: 545
@@ -84,7 +84,7 @@ ttnn:
     bh_quietbox_2: 65
     bh_p300: 15
     wh_llmbox_civ2: 40
-    sim_wh_n300: 680
+    sim_wh_n150: 680
     sim_bh_p150: 680
   unit:
     wh_llmbox: 50

--- a/.github/workflows/runtime-sanity-tests-impl.yaml
+++ b/.github/workflows/runtime-sanity-tests-impl.yaml
@@ -69,36 +69,18 @@ jobs:
     if: ${{ needs.load-test-matrix.outputs.has-sim == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout ttsim version
+      - name: Checkout fetch-ttsim action and pinned ttsim version
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
-          sparse-checkout: tt_metal/ttsim-version
+          sparse-checkout: |
+            .github/actions/fetch-ttsim
+            tt_metal/ttsim-version
           sparse-checkout-cone-mode: false
-      - name: Read ttsim version
-        id: ttsim-version
-        run: echo "version=$(cat tt_metal/ttsim-version)" >> "$GITHUB_OUTPUT"
-      - name: Download wormhole_b0 ttsim binary
-        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
-        with:
-          repository: tenstorrent/ttsim
-          tag: ${{ steps.ttsim-version.outputs.version }}
-          fileName: libttsim_wh.so
-          out-file-path: /tmp/ttsim
-      - name: Download blackhole ttsim binary
-        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
-        with:
-          repository: tenstorrent/ttsim
-          tag: ${{ steps.ttsim-version.outputs.version }}
-          fileName: libttsim_bh.so
-          out-file-path: /tmp/ttsim
-      - name: Upload ttsim binaries artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: ttsim-binaries
-          path: /tmp/ttsim/
-          if-no-files-found: error
-          retention-days: 1
+          ref: ${{ inputs.ref || github.sha }}
+      - name: ⬇️  Fetch ttsim
+        uses: ./.github/actions/fetch-ttsim
+        timeout-minutes: 10
 
   runtime-sanity-tests:
     needs: [load-test-matrix, fetch-ttsim]

--- a/.github/workflows/runtime-sanity-tests-impl.yaml
+++ b/.github/workflows/runtime-sanity-tests-impl.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-slim
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
-      has-sim: ${{ steps.detect-sim.outputs.has-sim }}
+      sim-libs: ${{ steps.build-matrix.outputs.sim-libs }}
     env:
       TESTS_YAML_PATH: ./tests/pipeline_reorg/runtime_sanity_tests.yaml
     steps:
@@ -56,17 +56,10 @@ jobs:
             ${{ env.TESTS_YAML_PATH }} \
             "${{ inputs.enabled-skus }}" \
             ./.github/sku_config.yaml
-      - name: Detect sim SKUs in matrix
-        id: detect-sim
-        run: |
-          matrix='${{ steps.build-matrix.outputs.matrix }}'
-          has_sim=$(echo "$matrix" | jq -r 'any(.[]; .sku | startswith("sim_"))')
-          echo "has-sim=$has_sim" >> "$GITHUB_OUTPUT"
-
   # Fetch ttsim simulator binaries once; only needed when the matrix has sim_* SKUs.
   fetch-ttsim:
     needs: load-test-matrix
-    if: ${{ needs.load-test-matrix.outputs.has-sim == 'true' }}
+    if: ${{ needs.load-test-matrix.outputs.sim-libs != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout fetch-ttsim action and pinned ttsim version
@@ -81,11 +74,13 @@ jobs:
       - name: ⬇️  Fetch ttsim
         uses: ./.github/actions/fetch-ttsim
         timeout-minutes: 10
+        with:
+          libs: ${{ needs.load-test-matrix.outputs.sim-libs }}
 
   runtime-sanity-tests:
     needs: [load-test-matrix, fetch-ttsim]
     # fetch-ttsim is skipped when the matrix has no sim_* SKUs; allow that.
-    if: ${{ !cancelled() && (needs.fetch-ttsim.result == 'success' || needs.fetch-ttsim.result == 'skipped') }}
+    if: ${{ needs.load-test-matrix.outputs.matrix != '[]' && !cancelled() && (needs.fetch-ttsim.result == 'success' || needs.fetch-ttsim.result == 'skipped') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/runtime-sanity-tests-impl.yaml
+++ b/.github/workflows/runtime-sanity-tests-impl.yaml
@@ -68,6 +68,10 @@ jobs:
     concurrency:
       group: ttsim-lib-${{ github.run_id }}-${{ matrix.lib }}
       cancel-in-progress: false
+      queue: max
+    permissions:
+      actions: read # the existence check reads this run's artifact list
+      contents: read
     steps:
       - name: Checkout fetch-ttsim action and pinned ttsim version
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/runtime-sanity-tests-impl.yaml
+++ b/.github/workflows/runtime-sanity-tests-impl.yaml
@@ -69,8 +69,10 @@ jobs:
       group: ttsim-lib-${{ github.run_id }}-${{ matrix.lib }}
       cancel-in-progress: false
       queue: max
+    # The probe and upload talk to the artifact service with the runtime token, not
+    # GITHUB_TOKEN, so no actions: scope is needed — and requesting one fails for callers that
+    # run with the default actions: none (a nested job cannot exceed its caller's grant).
     permissions:
-      actions: read # the existence check reads this run's artifact list
       contents: read
     steps:
       - name: Checkout fetch-ttsim action and pinned ttsim version

--- a/.github/workflows/runtime-sanity-tests-impl.yaml
+++ b/.github/workflows/runtime-sanity-tests-impl.yaml
@@ -60,7 +60,7 @@ jobs:
   fetch-ttsim:
     needs: load-test-matrix
     if: ${{ needs.load-test-matrix.outputs.sim-libs != '[]' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/runtime-sanity-tests-impl.yaml
+++ b/.github/workflows/runtime-sanity-tests-impl.yaml
@@ -76,6 +76,9 @@ jobs:
         timeout-minutes: 10
         with:
           libs: ${{ needs.load-test-matrix.outputs.sim-libs }}
+          # Suffixed per impl: artifact names are per-run and sanity-tests runs several of
+          # these impls in one run. Must match the setup-ttsim step below.
+          artifact-name: ttsim-binaries-runtime-sanity
 
   runtime-sanity-tests:
     needs: [load-test-matrix, fetch-ttsim]
@@ -126,6 +129,7 @@ jobs:
         timeout-minutes: 5
         with:
           sku: ${{ matrix.test-group.sku }}
+          artifact-name: ttsim-binaries-runtime-sanity
       - name: Ensure BH links online
         if: ${{ contains(matrix.test-group.sku, 'bh_loudbox') }}
         uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main

--- a/.github/workflows/runtime-sanity-tests-impl.yaml
+++ b/.github/workflows/runtime-sanity-tests-impl.yaml
@@ -59,8 +59,15 @@ jobs:
   # Fetch ttsim simulator binaries once; only needed when the matrix has sim_* SKUs.
   fetch-ttsim:
     needs: load-test-matrix
-    if: ${{ needs.load-test-matrix.outputs.sim-libs != '' }}
+    if: ${{ needs.load-test-matrix.outputs.sim-libs != '[]' }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lib: ${{ fromJson(needs.load-test-matrix.outputs.sim-libs) }}
+    concurrency:
+      group: ttsim-lib-${{ github.run_id }}-${{ matrix.lib }}
+      cancel-in-progress: false
     steps:
       - name: Checkout fetch-ttsim action and pinned ttsim version
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -75,10 +82,7 @@ jobs:
         uses: ./.github/actions/fetch-ttsim
         timeout-minutes: 10
         with:
-          libs: ${{ needs.load-test-matrix.outputs.sim-libs }}
-          # Suffixed per impl: artifact names are per-run and sanity-tests runs several of
-          # these impls in one run. Must match the setup-ttsim step below.
-          artifact-name: ttsim-binaries-runtime-sanity
+          lib: ${{ matrix.lib }}
 
   runtime-sanity-tests:
     needs: [load-test-matrix, fetch-ttsim]
@@ -129,7 +133,6 @@ jobs:
         timeout-minutes: 5
         with:
           sku: ${{ matrix.test-group.sku }}
-          artifact-name: ttsim-binaries-runtime-sanity
       - name: Ensure BH links online
         if: ${{ contains(matrix.test-group.sku, 'bh_loudbox') }}
         uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -313,7 +313,7 @@ jobs:
             sanity_skus+=("${bh_skus[@]}")
           fi
           if [[ "$run_sim" == "true" ]]; then
-            sim_skus+=("sim_wormhole_b0" "sim_wormhole_b0_galaxy" "sim_blackhole" "sim_blackhole_galaxy")
+            sim_skus+=("sim_wh_n150" "sim_wh_n300" "sim_wh_galaxy" "sim_bh_p150" "sim_bh_galaxy")
             sanity_skus+=("${sim_skus[@]}")
           fi
 

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -313,7 +313,7 @@ jobs:
             sanity_skus+=("${bh_skus[@]}")
           fi
           if [[ "$run_sim" == "true" ]]; then
-            sim_skus+=("sim_wh_n150" "sim_wh_n300" "sim_wh_galaxy" "sim_bh_p150" "sim_bh_galaxy")
+            sim_skus+=("sim_wh_n150" "sim_wh_galaxy" "sim_bh_p150" "sim_bh_galaxy")
             sanity_skus+=("${sim_skus[@]}")
           fi
 

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -152,10 +152,10 @@ jobs:
           # SKU coverage spanning every L2 nightly test yaml entry.
           l2_nightly_skus=()
           if [[ "$run_wormhole" == "true" ]]; then
-            l2_nightly_skus+=("wh_n150" "wh_n300" "wh_n150_civ2" "wh_n300_civ2" "sim_wormhole_b0" "wh_galaxy")
+            l2_nightly_skus+=("wh_n150" "wh_n300" "wh_n150_civ2" "wh_n300_civ2" "sim_wh_n150" "wh_galaxy")
           fi
           if [[ "$run_blackhole" == "true" ]]; then
-            l2_nightly_skus+=("bh_p100" "bh_p150b_civ2" "bh_p150b_civ2_viommu" "sim_blackhole" "bh_p300" "bh_quietbox_2" "bh_galaxy")
+            l2_nightly_skus+=("bh_p100" "bh_p150b_civ2" "bh_p150b_civ2_viommu" "sim_bh_p150" "bh_p300" "bh_quietbox_2" "bh_galaxy")
           fi
           l2_nightly_skus_str=$(IFS=,; echo "${l2_nightly_skus[*]}")
           echo "l2-nightly-skus=$l2_nightly_skus_str" >> $GITHUB_OUTPUT

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -134,36 +134,18 @@ jobs:
     if: ${{ needs.load-test-matrix.outputs.has-sim == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout ttsim version
+      - name: Checkout fetch-ttsim action and pinned ttsim version
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
-          sparse-checkout: tt_metal/ttsim-version
+          sparse-checkout: |
+            .github/actions/fetch-ttsim
+            tt_metal/ttsim-version
           sparse-checkout-cone-mode: false
-      - name: Read ttsim version
-        id: ttsim-version
-        run: echo "version=$(cat tt_metal/ttsim-version)" >> "$GITHUB_OUTPUT"
-      - name: Download wormhole_b0 ttsim binary
-        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
-        with:
-          repository: tenstorrent/ttsim
-          tag: ${{ steps.ttsim-version.outputs.version }}
-          fileName: libttsim_wh.so
-          out-file-path: /tmp/ttsim
-      - name: Download blackhole ttsim binary
-        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
-        with:
-          repository: tenstorrent/ttsim
-          tag: ${{ steps.ttsim-version.outputs.version }}
-          fileName: libttsim_bh.so
-          out-file-path: /tmp/ttsim
-      - name: Upload ttsim binaries artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: ttsim-binaries
-          path: /tmp/ttsim/
-          if-no-files-found: error
-          retention-days: 1
+          ref: ${{ inputs.ref || github.sha }}
+      - name: ⬇️  Fetch ttsim
+        uses: ./.github/actions/fetch-ttsim
+        timeout-minutes: 10
 
   ttnn:
     needs: [load-test-matrix, fetch-ttsim]
@@ -228,7 +210,7 @@ jobs:
       # header before kernels are JIT-compiled. Wormhole sim only; this patches the runner's
       # /opt/venv (so it must run here, not in load-test-matrix). Remove once LLK ships a fix.
       - name: Apply ttsim wormhole workaround patches
-        if: ${{ matrix.test-group.sku == 'sim_wormhole_b0' }}
+        if: ${{ startsWith(matrix.test-group.sku, 'sim_wh') }}
         run: |
           HEADER=$(find /opt/venv -name "cunpack_common.h" -path "*wormhole_b0*" 2>/dev/null | head -1)
           echo "Patching: $HEADER"
@@ -376,7 +358,7 @@ jobs:
         if: ${{ startsWith(matrix.test-group.sku, 'sim_') }}
         timeout-minutes: ${{ inputs.timeout-minutes-override > 0 && inputs.timeout-minutes-override || matrix.test-group.timeout }}
         env:
-          PYTEST_ADDOPTS: "-p no:timeout -n 4 ${{ matrix.test-group.sku == 'sim_wormhole_b0' && needs.load-test-matrix.outputs.skip-args-wormhole_b0 || matrix.test-group.sku == 'sim_blackhole' && needs.load-test-matrix.outputs.skip-args-blackhole || '' }}"
+          PYTEST_ADDOPTS: "-p no:timeout -n 4 ${{ startsWith(matrix.test-group.sku, 'sim_wh') && needs.load-test-matrix.outputs.skip-args-wormhole_b0 || startsWith(matrix.test-group.sku, 'sim_bh') && needs.load-test-matrix.outputs.skip-args-blackhole || '' }}"
           # Cap PyTorch/ATen host-side OpenMP threads and use passive waiting. A brief host
           # reference-tensor op is enough to spin up the OpenMP/MKL thread pool; its worker
           # threads then busy-wait for the rest of the job, which is where most of the CPU
@@ -392,7 +374,7 @@ jobs:
           # with --lf for actionable diagnostics.
           export cmd=$(printf '%s' '${{ matrix.test-group.cmd }}' | sed -E 's/[[:space:]]+--timeout[[:space:]]+[0-9]+//g')
           # PYTEST_ADDOPTS for the serial fallback re-run (drops -n 4); applied only on retry.
-          export SERIAL_ADDOPTS="-p no:timeout ${{ matrix.test-group.sku == 'sim_wormhole_b0' && needs.load-test-matrix.outputs.skip-args-wormhole_b0 || matrix.test-group.sku == 'sim_blackhole' && needs.load-test-matrix.outputs.skip-args-blackhole || '' }}"
+          export SERIAL_ADDOPTS="-p no:timeout ${{ startsWith(matrix.test-group.sku, 'sim_wh') && needs.load-test-matrix.outputs.skip-args-wormhole_b0 || startsWith(matrix.test-group.sku, 'sim_bh') && needs.load-test-matrix.outputs.skip-args-blackhole || '' }}"
           # Wrap the whole sim run in the host-load sidecar so its usage report covers both
           # the parallel run and any serial re-run. Written to /work/mem_report.json (even
           # on failure — emitted before the sidecar exits) so the Upload mem report step

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-slim
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
-      has-sim: ${{ steps.detect-sim.outputs.has-sim }}
+      sim-libs: ${{ steps.build-matrix.outputs.sim-libs }}
       skip-args-wormhole_b0: ${{ steps.skip-list.outputs.skip-args-wormhole_b0 }}
       skip-args-blackhole: ${{ steps.skip-list.outputs.skip-args-blackhole }}
     env:
@@ -105,13 +105,6 @@ jobs:
             "${{ inputs.enabled-skus }}" \
             ./.github/sku_config.yaml
 
-      - name: Detect sim SKUs in matrix
-        id: detect-sim
-        run: |
-          matrix='${{ steps.build-matrix.outputs.matrix }}'
-          has_sim=$(echo "$matrix" | jq -r 'any(.[]; .sku | startswith("sim_"))')
-          echo "has-sim=$has_sim" >> "$GITHUB_OUTPUT"
-
       # Load the TTSim skip list ONCE for the whole matrix and expose per-arch --deselect
       # args. The ttnn job applies these (via PYTEST_ADDOPTS) on every sim_* entry so the
       # simulator runs the same cmd as hardware minus the tests that don't yet work on ttsim.
@@ -131,7 +124,7 @@ jobs:
   # the resolved matrix contains sim_* SKUs. Consumed by setup-ttsim below.
   fetch-ttsim:
     needs: load-test-matrix
-    if: ${{ needs.load-test-matrix.outputs.has-sim == 'true' }}
+    if: ${{ needs.load-test-matrix.outputs.sim-libs != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout fetch-ttsim action and pinned ttsim version
@@ -146,11 +139,13 @@ jobs:
       - name: ⬇️  Fetch ttsim
         uses: ./.github/actions/fetch-ttsim
         timeout-minutes: 10
+        with:
+          libs: ${{ needs.load-test-matrix.outputs.sim-libs }}
 
   ttnn:
     needs: [load-test-matrix, fetch-ttsim]
     # fetch-ttsim is skipped when the matrix has no sim_* SKUs; allow that.
-    if: ${{ !cancelled() && (needs.fetch-ttsim.result == 'success' || needs.fetch-ttsim.result == 'skipped') }}
+    if: ${{ needs.load-test-matrix.outputs.matrix != '[]' && !cancelled() && (needs.fetch-ttsim.result == 'success' || needs.fetch-ttsim.result == 'skipped') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -141,6 +141,9 @@ jobs:
         timeout-minutes: 10
         with:
           libs: ${{ needs.load-test-matrix.outputs.sim-libs }}
+          # Suffixed per impl: artifact names are per-run and sanity-tests runs several of
+          # these impls in one run. Must match the setup-ttsim step below.
+          artifact-name: ttsim-binaries-ttnn-sanity
 
   ttnn:
     needs: [load-test-matrix, fetch-ttsim]
@@ -197,6 +200,7 @@ jobs:
         timeout-minutes: 5
         with:
           sku: ${{ matrix.test-group.sku }}
+          artifact-name: ttsim-binaries-ttnn-sanity
 
       # WORKAROUND (TEN-3868 / https://github.com/tenstorrent/tt-metal/issues/38246):
       # unpack_to_dest_tile_done() issues TT_UNPACR(SrcA, INT32), which is UndefinedBehavior

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -124,8 +124,15 @@ jobs:
   # the resolved matrix contains sim_* SKUs. Consumed by setup-ttsim below.
   fetch-ttsim:
     needs: load-test-matrix
-    if: ${{ needs.load-test-matrix.outputs.sim-libs != '' }}
+    if: ${{ needs.load-test-matrix.outputs.sim-libs != '[]' }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lib: ${{ fromJson(needs.load-test-matrix.outputs.sim-libs) }}
+    concurrency:
+      group: ttsim-lib-${{ github.run_id }}-${{ matrix.lib }}
+      cancel-in-progress: false
     steps:
       - name: Checkout fetch-ttsim action and pinned ttsim version
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -140,10 +147,7 @@ jobs:
         uses: ./.github/actions/fetch-ttsim
         timeout-minutes: 10
         with:
-          libs: ${{ needs.load-test-matrix.outputs.sim-libs }}
-          # Suffixed per impl: artifact names are per-run and sanity-tests runs several of
-          # these impls in one run. Must match the setup-ttsim step below.
-          artifact-name: ttsim-binaries-ttnn-sanity
+          lib: ${{ matrix.lib }}
 
   ttnn:
     needs: [load-test-matrix, fetch-ttsim]
@@ -200,7 +204,6 @@ jobs:
         timeout-minutes: 5
         with:
           sku: ${{ matrix.test-group.sku }}
-          artifact-name: ttsim-binaries-ttnn-sanity
 
       # WORKAROUND (TEN-3868 / https://github.com/tenstorrent/tt-metal/issues/38246):
       # unpack_to_dest_tile_done() issues TT_UNPACR(SrcA, INT32), which is UndefinedBehavior

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -125,7 +125,7 @@ jobs:
   fetch-ttsim:
     needs: load-test-matrix
     if: ${{ needs.load-test-matrix.outputs.sim-libs != '[]' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -133,6 +133,10 @@ jobs:
     concurrency:
       group: ttsim-lib-${{ github.run_id }}-${{ matrix.lib }}
       cancel-in-progress: false
+      queue: max
+    permissions:
+      actions: read # the existence check reads this run's artifact list
+      contents: read
     steps:
       - name: Checkout fetch-ttsim action and pinned ttsim version
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -134,8 +134,10 @@ jobs:
       group: ttsim-lib-${{ github.run_id }}-${{ matrix.lib }}
       cancel-in-progress: false
       queue: max
+    # The probe and upload talk to the artifact service with the runtime token, not
+    # GITHUB_TOKEN, so no actions: scope is needed — and requesting one fails for callers that
+    # run with the default actions: none (a nested job cannot exceed its caller's grant).
     permissions:
-      actions: read # the existence check reads this run's artifact list
       contents: read
     steps:
       - name: Checkout fetch-ttsim action and pinned ttsim version

--- a/.github/workflows/ttnn-smoke-tests-impl.yaml
+++ b/.github/workflows/ttnn-smoke-tests-impl.yaml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-slim
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
-      has-sim: ${{ steps.detect-sim.outputs.has-sim }}
+      sim-libs: ${{ steps.build-matrix.outputs.sim-libs }}
       skip-args-wormhole_b0: ${{ steps.skip-list.outputs.skip-args-wormhole_b0 }}
       skip-args-blackhole: ${{ steps.skip-list.outputs.skip-args-blackhole }}
     env:
@@ -100,13 +100,6 @@ jobs:
             ./.github/sku_config.yaml \
             --event "${{ github.event_name }}"
 
-      - name: Detect sim SKUs in matrix
-        id: detect-sim
-        run: |
-          matrix='${{ steps.build-matrix.outputs.matrix }}'
-          has_sim=$(echo "$matrix" | jq -r 'any(.[]; .sku | startswith("sim_"))')
-          echo "has-sim=$has_sim" >> "$GITHUB_OUTPUT"
-
       # Load the TTSim skip list ONCE for the whole matrix and expose per-arch --deselect
       # args. The ttnn job applies these (via PYTEST_ADDOPTS) on every sim_* entry so the
       # simulator runs the same cmd as hardware minus the tests that don't yet work on ttsim.
@@ -126,7 +119,7 @@ jobs:
   # the resolved matrix contains sim_* SKUs. Consumed by setup-ttsim below.
   fetch-ttsim:
     needs: load-test-matrix
-    if: ${{ needs.load-test-matrix.outputs.has-sim == 'true' }}
+    if: ${{ needs.load-test-matrix.outputs.sim-libs != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout fetch-ttsim action and pinned ttsim version
@@ -141,11 +134,13 @@ jobs:
       - name: ⬇️  Fetch ttsim
         uses: ./.github/actions/fetch-ttsim
         timeout-minutes: 10
+        with:
+          libs: ${{ needs.load-test-matrix.outputs.sim-libs }}
 
   ttnn:
     needs: [load-test-matrix, fetch-ttsim]
     # fetch-ttsim is skipped when the matrix has no sim_* SKUs; allow that.
-    if: ${{ !cancelled() && (needs.fetch-ttsim.result == 'success' || needs.fetch-ttsim.result == 'skipped') }}
+    if: ${{ needs.load-test-matrix.outputs.matrix != '[]' && !cancelled() && (needs.fetch-ttsim.result == 'success' || needs.fetch-ttsim.result == 'skipped') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ttnn-smoke-tests-impl.yaml
+++ b/.github/workflows/ttnn-smoke-tests-impl.yaml
@@ -129,36 +129,18 @@ jobs:
     if: ${{ needs.load-test-matrix.outputs.has-sim == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout ttsim version
+      - name: Checkout fetch-ttsim action and pinned ttsim version
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
-          sparse-checkout: tt_metal/ttsim-version
+          sparse-checkout: |
+            .github/actions/fetch-ttsim
+            tt_metal/ttsim-version
           sparse-checkout-cone-mode: false
-      - name: Read ttsim version
-        id: ttsim-version
-        run: echo "version=$(cat tt_metal/ttsim-version)" >> "$GITHUB_OUTPUT"
-      - name: Download wormhole_b0 ttsim binary
-        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
-        with:
-          repository: tenstorrent/ttsim
-          tag: ${{ steps.ttsim-version.outputs.version }}
-          fileName: libttsim_wh.so
-          out-file-path: /tmp/ttsim
-      - name: Download blackhole ttsim binary
-        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
-        with:
-          repository: tenstorrent/ttsim
-          tag: ${{ steps.ttsim-version.outputs.version }}
-          fileName: libttsim_bh.so
-          out-file-path: /tmp/ttsim
-      - name: Upload ttsim binaries artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: ttsim-binaries
-          path: /tmp/ttsim/
-          if-no-files-found: error
-          retention-days: 1
+          ref: ${{ inputs.ref || github.sha }}
+      - name: ⬇️  Fetch ttsim
+        uses: ./.github/actions/fetch-ttsim
+        timeout-minutes: 10
 
   ttnn:
     needs: [load-test-matrix, fetch-ttsim]
@@ -222,7 +204,7 @@ jobs:
       # header before kernels are JIT-compiled. Wormhole sim only; this patches the runner's
       # /opt/venv (so it must run here, not in load-test-matrix). Remove once LLK ships a fix.
       - name: Apply ttsim wormhole workaround patches
-        if: ${{ matrix.test-group.sku == 'sim_wormhole_b0' }}
+        if: ${{ startsWith(matrix.test-group.sku, 'sim_wh') }}
         run: |
           HEADER=$(find /opt/venv -name "cunpack_common.h" -path "*wormhole_b0*" 2>/dev/null | head -1)
           echo "Patching: $HEADER"
@@ -259,7 +241,7 @@ jobs:
         if: ${{ startsWith(matrix.test-group.sku, 'sim_') }}
         timeout-minutes: ${{ inputs.timeout-minutes-override > 0 && inputs.timeout-minutes-override || matrix.test-group.timeout }}
         env:
-          PYTEST_ADDOPTS: "-p no:timeout -n 4 ${{ matrix.test-group.sku == 'sim_wormhole_b0' && needs.load-test-matrix.outputs.skip-args-wormhole_b0 || matrix.test-group.sku == 'sim_blackhole' && needs.load-test-matrix.outputs.skip-args-blackhole || '' }}"
+          PYTEST_ADDOPTS: "-p no:timeout -n 4 ${{ startsWith(matrix.test-group.sku, 'sim_wh') && needs.load-test-matrix.outputs.skip-args-wormhole_b0 || startsWith(matrix.test-group.sku, 'sim_bh') && needs.load-test-matrix.outputs.skip-args-blackhole || '' }}"
         run: |
           # Strip the per-test `pytest --timeout N` from the cmd: the simulator is ~10-50x slower than
           # HW, so that per-op limit kills slow-but-correct ops (the job timeout-minutes is the backstop;
@@ -271,7 +253,7 @@ jobs:
             exit 0
           fi
           echo "::warning::Parallel run failed. Re-running failed tests serially for clear diagnostics..."
-          export PYTEST_ADDOPTS="-p no:timeout ${{ matrix.test-group.sku == 'sim_wormhole_b0' && needs.load-test-matrix.outputs.skip-args-wormhole_b0 || matrix.test-group.sku == 'sim_blackhole' && needs.load-test-matrix.outputs.skip-args-blackhole || '' }}"
+          export PYTEST_ADDOPTS="-p no:timeout ${{ startsWith(matrix.test-group.sku, 'sim_wh') && needs.load-test-matrix.outputs.skip-args-wormhole_b0 || startsWith(matrix.test-group.sku, 'sim_bh') && needs.load-test-matrix.outputs.skip-args-blackhole || '' }}"
           eval "$cmd --lf --lfnf=all --tb=long -v" || true
           exit 1
 

--- a/.github/workflows/ttnn-smoke-tests-impl.yaml
+++ b/.github/workflows/ttnn-smoke-tests-impl.yaml
@@ -119,8 +119,15 @@ jobs:
   # the resolved matrix contains sim_* SKUs. Consumed by setup-ttsim below.
   fetch-ttsim:
     needs: load-test-matrix
-    if: ${{ needs.load-test-matrix.outputs.sim-libs != '' }}
+    if: ${{ needs.load-test-matrix.outputs.sim-libs != '[]' }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lib: ${{ fromJson(needs.load-test-matrix.outputs.sim-libs) }}
+    concurrency:
+      group: ttsim-lib-${{ github.run_id }}-${{ matrix.lib }}
+      cancel-in-progress: false
     steps:
       - name: Checkout fetch-ttsim action and pinned ttsim version
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -135,10 +142,7 @@ jobs:
         uses: ./.github/actions/fetch-ttsim
         timeout-minutes: 10
         with:
-          libs: ${{ needs.load-test-matrix.outputs.sim-libs }}
-          # Suffixed per impl: artifact names are per-run and sanity-tests runs several of
-          # these impls in one run. Must match the setup-ttsim step below.
-          artifact-name: ttsim-binaries-ttnn-smoke
+          lib: ${{ matrix.lib }}
 
   ttnn:
     needs: [load-test-matrix, fetch-ttsim]
@@ -194,7 +198,6 @@ jobs:
         timeout-minutes: 5
         with:
           sku: ${{ matrix.test-group.sku }}
-          artifact-name: ttsim-binaries-ttnn-smoke
 
       # WORKAROUND (TEN-3868 / https://github.com/tenstorrent/tt-metal/issues/38246):
       # unpack_to_dest_tile_done() issues TT_UNPACR(SrcA, INT32), which is UndefinedBehavior

--- a/.github/workflows/ttnn-smoke-tests-impl.yaml
+++ b/.github/workflows/ttnn-smoke-tests-impl.yaml
@@ -128,6 +128,10 @@ jobs:
     concurrency:
       group: ttsim-lib-${{ github.run_id }}-${{ matrix.lib }}
       cancel-in-progress: false
+      queue: max
+    permissions:
+      actions: read # the existence check reads this run's artifact list
+      contents: read
     steps:
       - name: Checkout fetch-ttsim action and pinned ttsim version
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ttnn-smoke-tests-impl.yaml
+++ b/.github/workflows/ttnn-smoke-tests-impl.yaml
@@ -136,6 +136,9 @@ jobs:
         timeout-minutes: 10
         with:
           libs: ${{ needs.load-test-matrix.outputs.sim-libs }}
+          # Suffixed per impl: artifact names are per-run and sanity-tests runs several of
+          # these impls in one run. Must match the setup-ttsim step below.
+          artifact-name: ttsim-binaries-ttnn-smoke
 
   ttnn:
     needs: [load-test-matrix, fetch-ttsim]
@@ -191,6 +194,7 @@ jobs:
         timeout-minutes: 5
         with:
           sku: ${{ matrix.test-group.sku }}
+          artifact-name: ttsim-binaries-ttnn-smoke
 
       # WORKAROUND (TEN-3868 / https://github.com/tenstorrent/tt-metal/issues/38246):
       # unpack_to_dest_tile_done() issues TT_UNPACR(SrcA, INT32), which is UndefinedBehavior

--- a/.github/workflows/ttnn-smoke-tests-impl.yaml
+++ b/.github/workflows/ttnn-smoke-tests-impl.yaml
@@ -129,8 +129,10 @@ jobs:
       group: ttsim-lib-${{ github.run_id }}-${{ matrix.lib }}
       cancel-in-progress: false
       queue: max
+    # The probe and upload talk to the artifact service with the runtime token, not
+    # GITHUB_TOKEN, so no actions: scope is needed — and requesting one fails for callers that
+    # run with the default actions: none (a nested job cannot exceed its caller's grant).
     permissions:
-      actions: read # the existence check reads this run's artifact list
       contents: read
     steps:
       - name: Checkout fetch-ttsim action and pinned ttsim version

--- a/.github/workflows/ttnn-smoke-tests-impl.yaml
+++ b/.github/workflows/ttnn-smoke-tests-impl.yaml
@@ -120,7 +120,7 @@ jobs:
   fetch-ttsim:
     needs: load-test-matrix
     if: ${{ needs.load-test-matrix.outputs.sim-libs != '[]' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ttsim-sanity-tests-impl.yaml
+++ b/.github/workflows/ttsim-sanity-tests-impl.yaml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-slim
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
+      sim-libs: ${{ steps.build-matrix.outputs.sim-libs }}
     env:
       TESTS_YAML_PATH: ./tests/pipeline_reorg/ttsim_sanity_tests.yaml
     steps:
@@ -50,7 +51,7 @@ jobs:
 
   fetch-ttsim:
     needs: load-test-matrix
-    if: ${{ needs.load-test-matrix.outputs.matrix != '[]' }}
+    if: ${{ needs.load-test-matrix.outputs.sim-libs != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout fetch-ttsim action and pinned ttsim version
@@ -65,6 +66,8 @@ jobs:
       - name: ⬇️  Fetch ttsim
         uses: ./.github/actions/fetch-ttsim
         timeout-minutes: 10
+        with:
+          libs: ${{ needs.load-test-matrix.outputs.sim-libs }}
 
   ttsim-sanity-tests:
     needs: [load-test-matrix, fetch-ttsim]

--- a/.github/workflows/ttsim-sanity-tests-impl.yaml
+++ b/.github/workflows/ttsim-sanity-tests-impl.yaml
@@ -53,37 +53,18 @@ jobs:
     if: ${{ needs.load-test-matrix.outputs.matrix != '[]' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout ttsim version
+      - name: Checkout fetch-ttsim action and pinned ttsim version
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
-          sparse-checkout: tt_metal/ttsim-version
+          sparse-checkout: |
+            .github/actions/fetch-ttsim
+            tt_metal/ttsim-version
           sparse-checkout-cone-mode: false
           ref: ${{ inputs.ref || github.sha }}
-      - name: Read ttsim version
-        id: ttsim-version
-        run: echo "version=$(cat tt_metal/ttsim-version)" >> "$GITHUB_OUTPUT"
-      - name: Download wormhole_b0 ttsim binary
-        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
-        with:
-          repository: tenstorrent/ttsim
-          tag: ${{ steps.ttsim-version.outputs.version }}
-          fileName: libttsim_wh.so
-          out-file-path: /tmp/ttsim
-      - name: Download blackhole ttsim binary
-        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
-        with:
-          repository: tenstorrent/ttsim
-          tag: ${{ steps.ttsim-version.outputs.version }}
-          fileName: libttsim_bh.so
-          out-file-path: /tmp/ttsim
-      - name: Upload ttsim binaries artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: ttsim-binaries
-          path: /tmp/ttsim/
-          if-no-files-found: error
-          retention-days: 1
+      - name: ⬇️  Fetch ttsim
+        uses: ./.github/actions/fetch-ttsim
+        timeout-minutes: 10
 
   ttsim-sanity-tests:
     needs: [load-test-matrix, fetch-ttsim]
@@ -118,6 +99,7 @@ jobs:
           sparse-checkout: |
             .github/actions/download-artifact-with-retry
             .github/actions/setup-ttsim
+            .github/sku_config.yaml
             .github/scripts/utils/host-load-sidecar.sh
           sparse-checkout-cone-mode: false
           ref: ${{ inputs.ref || github.sha }}

--- a/.github/workflows/ttsim-sanity-tests-impl.yaml
+++ b/.github/workflows/ttsim-sanity-tests-impl.yaml
@@ -68,6 +68,9 @@ jobs:
         timeout-minutes: 10
         with:
           libs: ${{ needs.load-test-matrix.outputs.sim-libs }}
+          # Suffixed per impl: artifact names are per-run and sanity-tests runs several of
+          # these impls in one run. Must match the setup-ttsim step below.
+          artifact-name: ttsim-binaries-ttsim-sanity
 
   ttsim-sanity-tests:
     needs: [load-test-matrix, fetch-ttsim]
@@ -132,6 +135,7 @@ jobs:
         with:
           sku: ${{ matrix.test-group.sku }}
           root: ${{ env.TT_METAL_HOME }}
+          artifact-name: ttsim-binaries-ttsim-sanity
 
       # ttsim examples run on the simulator (no hardware power telemetry); wrap the run in the
       # host-load sidecar to capture host CPU/memory/disk/network usage.

--- a/.github/workflows/ttsim-sanity-tests-impl.yaml
+++ b/.github/workflows/ttsim-sanity-tests-impl.yaml
@@ -60,6 +60,10 @@ jobs:
     concurrency:
       group: ttsim-lib-${{ github.run_id }}-${{ matrix.lib }}
       cancel-in-progress: false
+      queue: max
+    permissions:
+      actions: read # the existence check reads this run's artifact list
+      contents: read
     steps:
       - name: Checkout fetch-ttsim action and pinned ttsim version
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ttsim-sanity-tests-impl.yaml
+++ b/.github/workflows/ttsim-sanity-tests-impl.yaml
@@ -52,7 +52,7 @@ jobs:
   fetch-ttsim:
     needs: load-test-matrix
     if: ${{ needs.load-test-matrix.outputs.sim-libs != '[]' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ttsim-sanity-tests-impl.yaml
+++ b/.github/workflows/ttsim-sanity-tests-impl.yaml
@@ -51,8 +51,15 @@ jobs:
 
   fetch-ttsim:
     needs: load-test-matrix
-    if: ${{ needs.load-test-matrix.outputs.sim-libs != '' }}
+    if: ${{ needs.load-test-matrix.outputs.sim-libs != '[]' }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lib: ${{ fromJson(needs.load-test-matrix.outputs.sim-libs) }}
+    concurrency:
+      group: ttsim-lib-${{ github.run_id }}-${{ matrix.lib }}
+      cancel-in-progress: false
     steps:
       - name: Checkout fetch-ttsim action and pinned ttsim version
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -67,10 +74,7 @@ jobs:
         uses: ./.github/actions/fetch-ttsim
         timeout-minutes: 10
         with:
-          libs: ${{ needs.load-test-matrix.outputs.sim-libs }}
-          # Suffixed per impl: artifact names are per-run and sanity-tests runs several of
-          # these impls in one run. Must match the setup-ttsim step below.
-          artifact-name: ttsim-binaries-ttsim-sanity
+          lib: ${{ matrix.lib }}
 
   ttsim-sanity-tests:
     needs: [load-test-matrix, fetch-ttsim]
@@ -135,7 +139,6 @@ jobs:
         with:
           sku: ${{ matrix.test-group.sku }}
           root: ${{ env.TT_METAL_HOME }}
-          artifact-name: ttsim-binaries-ttsim-sanity
 
       # ttsim examples run on the simulator (no hardware power telemetry); wrap the run in the
       # host-load sidecar to capture host CPU/memory/disk/network usage.

--- a/.github/workflows/ttsim-sanity-tests-impl.yaml
+++ b/.github/workflows/ttsim-sanity-tests-impl.yaml
@@ -61,8 +61,10 @@ jobs:
       group: ttsim-lib-${{ github.run_id }}-${{ matrix.lib }}
       cancel-in-progress: false
       queue: max
+    # The probe and upload talk to the artifact service with the runtime token, not
+    # GITHUB_TOKEN, so no actions: scope is needed — and requesting one fails for callers that
+    # run with the default actions: none (a nested job cannot exceed its caller's grant).
     permissions:
-      actions: read # the existence check reads this run's artifact list
       contents: read
     steps:
       - name: Checkout fetch-ttsim action and pinned ttsim version

--- a/.github/workflows/ttsim-unit-tests-impl.yaml
+++ b/.github/workflows/ttsim-unit-tests-impl.yaml
@@ -75,36 +75,17 @@ jobs:
     if: ${{ needs.load-test-matrix.outputs.matrix != '[]' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout ttsim version
+      - name: Checkout fetch-ttsim action and pinned ttsim version
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
-          sparse-checkout: tt_metal/ttsim-version
+          sparse-checkout: |
+            .github/actions/fetch-ttsim
+            tt_metal/ttsim-version
           sparse-checkout-cone-mode: false
-      - name: Read ttsim version
-        id: ttsim-version
-        run: echo "version=$(cat tt_metal/ttsim-version)" >> "$GITHUB_OUTPUT"
-      - name: Download wormhole_b0 ttsim binary
-        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
-        with:
-          repository: tenstorrent/ttsim
-          tag: ${{ steps.ttsim-version.outputs.version }}
-          fileName: libttsim_wh.so
-          out-file-path: /tmp/ttsim
-      - name: Download blackhole ttsim binary
-        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1.12
-        with:
-          repository: tenstorrent/ttsim
-          tag: ${{ steps.ttsim-version.outputs.version }}
-          fileName: libttsim_bh.so
-          out-file-path: /tmp/ttsim
-      - name: Upload ttsim binaries artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: ttsim-binaries
-          path: /tmp/ttsim/
-          if-no-files-found: error
-          retention-days: 1
+      - name: ⬇️  Fetch ttsim
+        uses: ./.github/actions/fetch-ttsim
+        timeout-minutes: 10
 
   ttsim-unit-tests:
     needs: [load-test-matrix, fetch-ttsim]

--- a/.github/workflows/ttsim-unit-tests-impl.yaml
+++ b/.github/workflows/ttsim-unit-tests-impl.yaml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-slim
     outputs:
       matrix: ${{ steps.filter-categories.outputs.matrix }}
+      sim-libs: ${{ steps.filter-categories.outputs.sim-libs }}
     env:
       TESTS_YAML_PATH: ./tests/pipeline_reorg/ttsim_unit_tests.yaml
     steps:
@@ -69,10 +70,13 @@ jobs:
             echo "$filtered"
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
+          # prepare_test_matrix.py's sim-libs covers the pre-filter matrix; recompute from the
+          # filtered one so fetch-ttsim does not download libs for legs this run dropped.
+          echo "sim-libs=$(echo "$filtered" | jq -r '[.[].ttsim_lib // empty] | unique | join(",")')" >> "$GITHUB_OUTPUT"
 
   fetch-ttsim:
     needs: load-test-matrix
-    if: ${{ needs.load-test-matrix.outputs.matrix != '[]' }}
+    if: ${{ needs.load-test-matrix.outputs.sim-libs != '' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout fetch-ttsim action and pinned ttsim version
@@ -86,6 +90,8 @@ jobs:
       - name: ⬇️  Fetch ttsim
         uses: ./.github/actions/fetch-ttsim
         timeout-minutes: 10
+        with:
+          libs: ${{ needs.load-test-matrix.outputs.sim-libs }}
 
   ttsim-unit-tests:
     needs: [load-test-matrix, fetch-ttsim]

--- a/.github/workflows/ttsim-unit-tests-impl.yaml
+++ b/.github/workflows/ttsim-unit-tests-impl.yaml
@@ -85,6 +85,10 @@ jobs:
     concurrency:
       group: ttsim-lib-${{ github.run_id }}-${{ matrix.lib }}
       cancel-in-progress: false
+      queue: max
+    permissions:
+      actions: read # the existence check reads this run's artifact list
+      contents: read
     steps:
       - name: Checkout fetch-ttsim action and pinned ttsim version
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -115,7 +119,7 @@ jobs:
         TT_METAL_HOME: /work
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
-        ARCH_NAME: ${{ contains(matrix.test-group.sku, 'blackhole') && 'blackhole' || 'wormhole_b0' }}
+        ARCH_NAME: ${{ contains(matrix.test-group.sku, 'bh_') && 'blackhole' || 'wormhole_b0' }}
         LOGURU_LEVEL: INFO
       volumes:
         - ${{ github.workspace }}/docker-job:/work

--- a/.github/workflows/ttsim-unit-tests-impl.yaml
+++ b/.github/workflows/ttsim-unit-tests-impl.yaml
@@ -77,7 +77,7 @@ jobs:
   fetch-ttsim:
     needs: load-test-matrix
     if: ${{ needs.load-test-matrix.outputs.sim-libs != '[]' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ttsim-unit-tests-impl.yaml
+++ b/.github/workflows/ttsim-unit-tests-impl.yaml
@@ -92,6 +92,9 @@ jobs:
         timeout-minutes: 10
         with:
           libs: ${{ needs.load-test-matrix.outputs.sim-libs }}
+          # Suffixed per impl: artifact names are per-run and sanity-tests runs several of
+          # these impls in one run. Must match the setup-ttsim step below.
+          artifact-name: ttsim-binaries-ttsim-unit
 
   ttsim-unit-tests:
     needs: [load-test-matrix, fetch-ttsim]
@@ -135,6 +138,7 @@ jobs:
         timeout-minutes: 5
         with:
           sku: ${{ matrix.test-group.sku }}
+          artifact-name: ttsim-binaries-ttsim-unit
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |

--- a/.github/workflows/ttsim-unit-tests-impl.yaml
+++ b/.github/workflows/ttsim-unit-tests-impl.yaml
@@ -72,12 +72,19 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           # prepare_test_matrix.py's sim-libs covers the pre-filter matrix; recompute from the
           # filtered one so fetch-ttsim does not download libs for legs this run dropped.
-          echo "sim-libs=$(echo "$filtered" | jq -r '[.[].ttsim_lib // empty] | unique | join(",")')" >> "$GITHUB_OUTPUT"
+          echo "sim-libs=$(echo "$filtered" | jq -c '[.[].ttsim_lib // empty] | unique')" >> "$GITHUB_OUTPUT"
 
   fetch-ttsim:
     needs: load-test-matrix
-    if: ${{ needs.load-test-matrix.outputs.sim-libs != '' }}
+    if: ${{ needs.load-test-matrix.outputs.sim-libs != '[]' }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        lib: ${{ fromJson(needs.load-test-matrix.outputs.sim-libs) }}
+    concurrency:
+      group: ttsim-lib-${{ github.run_id }}-${{ matrix.lib }}
+      cancel-in-progress: false
     steps:
       - name: Checkout fetch-ttsim action and pinned ttsim version
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -91,10 +98,7 @@ jobs:
         uses: ./.github/actions/fetch-ttsim
         timeout-minutes: 10
         with:
-          libs: ${{ needs.load-test-matrix.outputs.sim-libs }}
-          # Suffixed per impl: artifact names are per-run and sanity-tests runs several of
-          # these impls in one run. Must match the setup-ttsim step below.
-          artifact-name: ttsim-binaries-ttsim-unit
+          lib: ${{ matrix.lib }}
 
   ttsim-unit-tests:
     needs: [load-test-matrix, fetch-ttsim]
@@ -138,7 +142,6 @@ jobs:
         timeout-minutes: 5
         with:
           sku: ${{ matrix.test-group.sku }}
-          artifact-name: ttsim-binaries-ttsim-unit
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |

--- a/.github/workflows/ttsim-unit-tests-impl.yaml
+++ b/.github/workflows/ttsim-unit-tests-impl.yaml
@@ -86,8 +86,10 @@ jobs:
       group: ttsim-lib-${{ github.run_id }}-${{ matrix.lib }}
       cancel-in-progress: false
       queue: max
+    # The probe and upload talk to the artifact service with the runtime token, not
+    # GITHUB_TOKEN, so no actions: scope is needed — and requesting one fails for callers that
+    # run with the default actions: none (a nested job cannot exceed its caller's grant).
     permissions:
-      actions: read # the existence check reads this run's artifact list
       contents: read
     steps:
       - name: Checkout fetch-ttsim action and pinned ttsim version

--- a/tests/pipeline_reorg/runtime_sanity_tests.yaml
+++ b/tests/pipeline_reorg/runtime_sanity_tests.yaml
@@ -81,9 +81,9 @@
     ./build/test/tt_metal/unit_tests_eth &&
     ./build/test/tt_metal/unit_tests_legacy
   skus:
-    sim_wormhole_b0:
+    sim_wh_n150:
       timeout: 30
-    sim_blackhole:
+    sim_bh_p150:
       timeout: 30
   owner_id: U08PR765YJ1 # Matt Craighead
   team: runtime
@@ -95,7 +95,7 @@
     TT_METAL_MOCK_CLUSTER_DESC_PATH=tt_metal/third_party/tt-cluster-descriptors/wormhole/6u_cluster_desc/6u_cluster_desc.yaml
     ./build/test/tt_metal/unit_tests_api --gtest_filter='*InlineWrite*'
   skus:
-    sim_wormhole_b0_galaxy:
+    sim_wh_galaxy:
       timeout: 10
   owner_id: U08PR765YJ1 # Matt Craighead
   team: runtime
@@ -107,7 +107,7 @@
     TT_METAL_MOCK_CLUSTER_DESC_PATH=tt_metal/third_party/tt-cluster-descriptors/blackhole/bh_6u_cluster_desc/bh_6u_cluster_desc.yaml
     ./build/test/tt_metal/unit_tests_api --gtest_filter='*InlineWrite*'
   skus:
-    sim_blackhole_galaxy:
+    sim_bh_galaxy:
       timeout: 10
   owner_id: U08PR765YJ1 # Matt Craighead
   team: runtime

--- a/tests/pipeline_reorg/ttnn_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_merge_gate_tests.yaml
@@ -2,7 +2,7 @@
 #
 # Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, owner_id.
 #
-# sim_wormhole_b0 / sim_blackhole SKUs run the same cmd under the ttsim simulator
+# sim_wh_n300 / sim_bh_p150 SKUs run the same cmd under the ttsim simulator
 # on ubuntu-latest; ttnn-smoke-tests-impl.yaml invokes setup-ttsim for these.
 # See .github/actions/setup-ttsim/action.yml.
 # Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
@@ -12,9 +12,9 @@
   skus:
     wh_n300_civ2:
       timeout: 15
-    sim_wormhole_b0:
+    sim_wh_n300:
       timeout: 15
-    sim_blackhole:
+    sim_bh_p150:
       timeout: 15
   team: ttnn
   owner_id: U076Z1JJUQZ # Artem Yerofieiev

--- a/tests/pipeline_reorg/ttnn_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_merge_gate_tests.yaml
@@ -2,7 +2,7 @@
 #
 # Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, owner_id.
 #
-# sim_wh_n300 / sim_bh_p150 SKUs run the same cmd under the ttsim simulator
+# sim_wh_n150 / sim_bh_p150 SKUs run the same cmd under the ttsim simulator
 # on ubuntu-latest; ttnn-smoke-tests-impl.yaml invokes setup-ttsim for these.
 # See .github/actions/setup-ttsim/action.yml.
 # Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
@@ -12,7 +12,7 @@
   skus:
     wh_n300_civ2:
       timeout: 15
-    sim_wh_n300:
+    sim_wh_n150:
       timeout: 15
     sim_bh_p150:
       timeout: 15

--- a/tests/pipeline_reorg/ttnn_sanity_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_sanity_tests.yaml
@@ -5,7 +5,7 @@
 # Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, owner_id.
 # Optional: fast_runtime_mode_off.
 #
-# sim_wormhole_b0 / sim_blackhole SKUs run the same cmd under the ttsim simulator
+# sim_wh_n300 / sim_bh_p150 SKUs run the same cmd under the ttsim simulator
 # on ubuntu-latest; ttnn-sanity-tests-impl.yaml invokes setup-ttsim for these.
 # See .github/actions/setup-ttsim/action.yml.
 
@@ -44,9 +44,9 @@
       timeout: 5
     bh_p150b_civ2:
       timeout: 5
-    sim_wormhole_b0:
+    sim_wh_n300:
       timeout: 40
-    sim_blackhole:
+    sim_bh_p150:
       timeout: 40
   team: ttnn
   owner_id: U05ACKAJTHS # Naif Tarafdar
@@ -60,9 +60,9 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wormhole_b0:
+    sim_wh_n300:
       timeout: 40
-    sim_blackhole:
+    sim_bh_p150:
       timeout: 40
   team: ttnn
   owner_id: U09BX3N0N95 # Mateusz Nowak
@@ -76,9 +76,9 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wormhole_b0:
+    sim_wh_n300:
       timeout: 40
-    sim_blackhole:
+    sim_bh_p150:
       timeout: 40
   team: ttnn
   owner_id: U09BX3N0N95 # Mateusz Nowak
@@ -92,9 +92,9 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wormhole_b0:
+    sim_wh_n300:
       timeout: 40
-    sim_blackhole:
+    sim_bh_p150:
       timeout: 40
   team: ttnn
   owner_id: U09BX3N0N95 # Mateusz Nowak
@@ -108,9 +108,9 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wormhole_b0:
+    sim_wh_n300:
       timeout: 40
-    sim_blackhole:
+    sim_bh_p150:
       timeout: 40
   team: ttnn
   owner_id: U09BX3N0N95 # Mateusz Nowak
@@ -124,9 +124,9 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wormhole_b0:
+    sim_wh_n300:
       timeout: 60
-    sim_blackhole:
+    sim_bh_p150:
       timeout: 60
   team: ttnn
   owner_id: U085GDCAZTN # Pavle Josipovic
@@ -140,9 +140,9 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wormhole_b0:
+    sim_wh_n300:
       timeout: 40
-    sim_blackhole:
+    sim_bh_p150:
       timeout: 40
   team: ttnn
   owner_id: U085GDCAZTN # Pavle Josipovic
@@ -156,9 +156,9 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wormhole_b0:
+    sim_wh_n300:
       timeout: 60
-    sim_blackhole:
+    sim_bh_p150:
       timeout: 60
   team: ttnn
   owner_id: U084B1CES7M # Borys Bradel
@@ -172,9 +172,9 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wormhole_b0:
+    sim_wh_n300:
       timeout: 60
-    sim_blackhole:
+    sim_bh_p150:
       timeout: 60
   team: ttnn
   owner_id: U084B1CES7M # Borys Bradel
@@ -188,9 +188,9 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wormhole_b0:
+    sim_wh_n300:
       timeout: 60
-    sim_blackhole:
+    sim_bh_p150:
       timeout: 60
   team: ttnn
   owner_id: U084B1CES7M # Borys Bradel
@@ -204,9 +204,9 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wormhole_b0:
+    sim_wh_n300:
       timeout: 40
-    sim_blackhole:
+    sim_bh_p150:
       timeout: 40
   team: ttnn
   owner_id: U08JFM3CFA4 # Gongyu Wang
@@ -220,9 +220,9 @@
       timeout: 15
     bh_p150b_civ2:
       timeout: 15
-    sim_wormhole_b0:
+    sim_wh_n300:
       timeout: 40
-    sim_blackhole:
+    sim_bh_p150:
       timeout: 40
   team: ttnn
   owner_id: U085GDCAZTN # Pavle Josipovic
@@ -239,9 +239,9 @@
       timeout: 10
     bh_p150b_civ2:
       timeout: 10
-    sim_wormhole_b0:
+    sim_wh_n300:
       timeout: 40
-    sim_blackhole:
+    sim_bh_p150:
       timeout: 40
   team: ttnn
   owner_id: U085GDCAZTN # Pavle Josipovic
@@ -255,9 +255,9 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wormhole_b0:
+    sim_wh_n300:
       timeout: 40
-    sim_blackhole:
+    sim_bh_p150:
       timeout: 40
   team: ttnn
   owner_id: U084B1CES7M # Borys Bradel
@@ -275,9 +275,9 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wormhole_b0:
+    sim_wh_n300:
       timeout: 40
-    sim_blackhole:
+    sim_bh_p150:
       timeout: 40
   team: ttnn
   owner_id: U076Z1JJUQZ # Artem Yerofieiev

--- a/tests/pipeline_reorg/ttnn_sanity_tests.yaml
+++ b/tests/pipeline_reorg/ttnn_sanity_tests.yaml
@@ -5,7 +5,7 @@
 # Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, owner_id.
 # Optional: fast_runtime_mode_off.
 #
-# sim_wh_n300 / sim_bh_p150 SKUs run the same cmd under the ttsim simulator
+# sim_wh_n150 / sim_bh_p150 SKUs run the same cmd under the ttsim simulator
 # on ubuntu-latest; ttnn-sanity-tests-impl.yaml invokes setup-ttsim for these.
 # See .github/actions/setup-ttsim/action.yml.
 
@@ -44,7 +44,7 @@
       timeout: 5
     bh_p150b_civ2:
       timeout: 5
-    sim_wh_n300:
+    sim_wh_n150:
       timeout: 40
     sim_bh_p150:
       timeout: 40
@@ -60,7 +60,7 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wh_n300:
+    sim_wh_n150:
       timeout: 40
     sim_bh_p150:
       timeout: 40
@@ -76,7 +76,7 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wh_n300:
+    sim_wh_n150:
       timeout: 40
     sim_bh_p150:
       timeout: 40
@@ -92,7 +92,7 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wh_n300:
+    sim_wh_n150:
       timeout: 40
     sim_bh_p150:
       timeout: 40
@@ -108,7 +108,7 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wh_n300:
+    sim_wh_n150:
       timeout: 40
     sim_bh_p150:
       timeout: 40
@@ -124,7 +124,7 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wh_n300:
+    sim_wh_n150:
       timeout: 60
     sim_bh_p150:
       timeout: 60
@@ -140,7 +140,7 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wh_n300:
+    sim_wh_n150:
       timeout: 40
     sim_bh_p150:
       timeout: 40
@@ -156,7 +156,7 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wh_n300:
+    sim_wh_n150:
       timeout: 60
     sim_bh_p150:
       timeout: 60
@@ -172,7 +172,7 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wh_n300:
+    sim_wh_n150:
       timeout: 60
     sim_bh_p150:
       timeout: 60
@@ -188,7 +188,7 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wh_n300:
+    sim_wh_n150:
       timeout: 60
     sim_bh_p150:
       timeout: 60
@@ -204,7 +204,7 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wh_n300:
+    sim_wh_n150:
       timeout: 40
     sim_bh_p150:
       timeout: 40
@@ -220,7 +220,7 @@
       timeout: 15
     bh_p150b_civ2:
       timeout: 15
-    sim_wh_n300:
+    sim_wh_n150:
       timeout: 40
     sim_bh_p150:
       timeout: 40
@@ -239,7 +239,7 @@
       timeout: 10
     bh_p150b_civ2:
       timeout: 10
-    sim_wh_n300:
+    sim_wh_n150:
       timeout: 40
     sim_bh_p150:
       timeout: 40
@@ -255,7 +255,7 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wh_n300:
+    sim_wh_n150:
       timeout: 40
     sim_bh_p150:
       timeout: 40
@@ -275,7 +275,7 @@
       timeout: 40
     bh_p150b_civ2:
       timeout: 40
-    sim_wh_n300:
+    sim_wh_n150:
       timeout: 40
     sim_bh_p150:
       timeout: 40

--- a/tests/pipeline_reorg/ttsim_sanity_tests.yaml
+++ b/tests/pipeline_reorg/ttsim_sanity_tests.yaml
@@ -32,9 +32,9 @@
     do "$exe" || exit 1; done;
     done
   skus:
-    sim_wormhole_b0:
+    sim_wh_n150:
       timeout: 30
-    sim_blackhole:
+    sim_bh_p150:
       timeout: 30
   team: ttsim
   owner_id: U08PR765YJ1 # Matt Craighead

--- a/tests/pipeline_reorg/ttsim_unit_tests.yaml
+++ b/tests/pipeline_reorg/ttsim_unit_tests.yaml
@@ -13,7 +13,7 @@
 #     category appears in the comma-separated list; on schedule the filter is
 #     bypassed and every entry runs.
 
-# Entries use sim_<arch> SKUs (sim_wormhole_b0, sim_blackhole) and run under
+# Entries use sim_<arch> SKUs (sim_wh_n150, sim_bh_p150) and run under
 # the ttsim simulator on ubuntu-latest; the impl invokes setup-ttsim.
 # See .github/actions/setup-ttsim/action.yml.
 
@@ -23,9 +23,9 @@
 # - name: ttnn compute-fused validation tests
 #   cmd: 'pytest tests/ttnn/nightly/unit_tests/operations_compute_only/fused -xv --timeout=600'
 #   skus:
-#     sim_wormhole_b0:
+#     sim_wh_n150:
 #       timeout: 15
-#     sim_blackhole:
+#     sim_bh_p150:
 #       timeout: 15
 #   owner_id: U076Z1JJUQZ # Edwin Lee
 #   team: ttsim


### PR DESCRIPTION
### PR Category
Feature

### Summary
Closes: #52627

Expand the synthetic ttsim SKUs from 4 generic ones (`sim_wormhole_b0`, `sim_blackhole`, `sim_wormhole_b0_galaxy`, `sim_blackhole_galaxy`) to 10 that each mirror a specific HW SKU's processor count (`sim_wh_n150`, `sim_wh_n300`, `sim_wh_llmbox`, `sim_wh_galaxy`, `sim_bh_p150`, `sim_bh_p300`, `sim_bh_quietbox_2`, `sim_bh_loudbox`, `sim_bh_galaxy`), so a test can list a sim SKU alongside the HW SKU it stands in for.

To support this without every workflow needing arch-parsing logic per SKU, `sku_config.yaml` gains a `ttsim_lib` field per sim SKU naming the exact `libttsim_*.so` it needs. `setup-ttsim` now resolves the binary (and soc descriptor) by reading that field instead of pattern-matching the SKU name for `blackhole`/`bh_`. A new `fetch-ttsim` composite action replaces the per-workflow copy-pasted download-and-upload steps (previously via `robinraju/release-downloader`, one step per arch): it fetches every `libttsim_*.so` asset required by the workflow (produced by `prepare_test_matrix`) from the pinned release wholesale via `gh release download`, so adding a new simulator topology needs no workflow change, only a `sku_config.yaml` entry. The `fetch-ttsim` job uses Github concurrency to ensure that only one version of each simulator library is downloaded per workflow run.

Additionally fixes a bug where an empty test matrix causes the `prepare-test-matrix` job to fail.

### Notes for reviewers
- `setup-ttsim`'s SKU → binary lookup is a small `awk` script scoped to the SKU's own block in `sku_config.yaml`; worth double-checking the indent-scoping logic if you're not familiar with awk.
- `fetch-ttsim` drops `*_aarch64.so` release assets since all current sim runners are x86_64; sim on ARM runners would need `ttsim_lib` to become arch-aware.
- `ttnn-sanity-tests-impl.yaml` / `ttnn-smoke-tests-impl.yaml`: the wormhole workaround patch and skip-args lookups switch from exact SKU match (`sku == 'sim_wormhole_b0'`) to prefix match (`startsWith(sku, 'sim_wh')`) to cover the new `sim_wh_*` variants.
- `time_budget.yaml` entries are renamed 1:1 to the new SKU names; no budget values changed.
 
### Test Plan

- [x] Run CI and confirm new load works
   - [x] [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tdowdall/sim-sku-expansion)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tdowdall/sim-sku-expansion)
   - [x] [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tdowdall/sim-sku-expansion)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tdowdall/sim-sku-expansion)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tdowdall/sim-sku-expansion)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tdowdall/sim-sku-expansion)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=tdowdall/sim-sku-expansion)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:tdowdall/sim-sku-expansion)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tdowdall/sim-sku-expansion)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tdowdall/sim-sku-expansion)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=tdowdall/sim-sku-expansion)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:tdowdall/sim-sku-expansion)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tdowdall/sim-sku-expansion)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tdowdall/sim-sku-expansion)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tdowdall/sim-sku-expansion)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tdowdall/sim-sku-expansion)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tdowdall/sim-sku-expansion)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tdowdall/sim-sku-expansion)