### PR TITLE
Gate Chunked Kimi perf (code_debug 55k, trace) at +/-3% per chunk

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -136,27 +136,23 @@ LAYER_PCC_THRESHOLD = 0.88
 KV_CACHE_PCC_THRESHOLD = 0.85
 INDEXER_K_PCC_THRESHOLD = 0.95
 
-# Per-chunk baseline medians (seconds) for the no-PCC perf gate, pulled from a known-good CI run. Keyed
-# by (num_layers, n_chunks, num_iters, use_trace) so only the exact config we have a CI number for is
-# gated; every other combo in the no-PCC sweep stays record-only. Each list has one entry per chunk
-# (index c == chunk c). A single margin (the perf_margin pytest arg) is applied to every chunk.
-# Recalibrate by re-reading the "chunk timing stats" table from a fresh green CI run.
+# Per-chunk baseline medians (seconds) for the perf gate, pulled from a known-good CI run. Keyed by
+# (num_layers, n_chunks, num_iters) so only the exact config we have a CI number for is gated; every
+# other combo in the sweep stays record-only. Each list has one entry per chunk (index c == chunk c). A
+# single margin (the perf_margin pytest arg) is applied to every chunk. Recalibrate by re-reading the
+# "chunk timing stats" table from a fresh green CI run.
 #
-# use_trace is part of the key because traced replay and eager dispatch are different regimes, not a
-# small delta: the same L61/11-chunk/10-iter config measures 0.6-0.95 s/chunk traced but a flat ~1.10
-# s/chunk untraced (host-dispatch bound, so the depth ramp disappears). One shared baseline would fail
-# whichever half of the pair it was not calibrated on.
+# TRACED ONLY. These are trace-replay numbers, and the gate is hard-wired to use_trace=True at the call
+# site -- the untraced variant is never gated, whatever this table holds. The two are different regimes,
+# not a small delta: this config measures 0.6-0.95 s/chunk traced (a ramp, since chunk c attends to
+# KV[0:c*CHUNK]) but a flat ~1.10 s/chunk untraced, host-dispatch bound so the depth ramp disappears
+# entirely. Untraced per-chunk stddev also reaches 0.22 s within a single run (~20%; run 31670499441
+# job 94387075128), which no meaningful band would survive.
 KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S = {
     # test_kimi_prefill_transformer_chunked_perf[...-L61-preload0-chunks_eleven-ten_iters-traced]
     # (55k / code_debug), from run 31675454129 job 94407856609 -- green, and stable within the run
-    # (per-chunk stddev <= 0.002 s over the 9 post-warmup iterations). The times rise with chunk index
-    # because chunk c attends to KV[0:c*CHUNK], so the MLA gather grows with depth.
-    (61, 11, 10, True): [0.605, 0.606, 0.653, 0.681, 0.711, 0.743, 0.760, 0.793, 0.842, 0.869, 0.905],
-    # The untraced twin (CI job "Blaze - Chunked Kimi perf (code_debug 55k, no trace)") stays
-    # record-only: its medians are a flat ~1.10 s but with per-chunk stddev up to 0.22 s within a single
-    # run (run 31670499441 job 94387075128) -- ~20% spread, which no meaningful band survives. Gate it
-    # once the eager-dispatch path is stable enough to have a real baseline.
-    # (61, 11, 10, False): [...],
+    # (per-chunk stddev <= 0.002 s over the 9 post-warmup iterations).
+    (61, 11, 10): [0.605, 0.606, 0.653, 0.681, 0.711, 0.743, 0.760, 0.793, 0.842, 0.869, 0.905],
 }
 # Default +/- tolerance band around each baseline chunk median (fraction). Overridable per test via the
 # perf_margin pytest argument (see test_prefill_block_perf.py's `margin` column for the design).
@@ -1758,11 +1754,15 @@ def test_kimi_prefill_transformer_chunked_perf(
     if preload_isl + n_chunks * CHUNK > SEQ_CACHE_NOPCC:
         pytest.skip(f"preload_isl {preload_isl} + {n_chunks} chunks exceeds the {SEQ_CACHE_NOPCC}-token cache")
     # Gate against the CI baseline only for the exact config we have a recorded number for; every other
-    # combo in the sweep stays record-only (baseline None -> print_duration_table does not assert). The
-    # baseline is only meaningful at preload_isl=0 (the recorded runs started from an empty cache).
+    # combo in the sweep stays record-only (baseline None -> print_duration_table does not assert). Two
+    # hard conditions on top of the table lookup:
+    #   use_trace   -- the baselines are trace-replay numbers, and the untraced path is a different
+    #                  regime (flat ~1.10 s/chunk, ~20% within-run spread), so it is NEVER gated. This
+    #                  is the guard, not the table's contents: adding an untraced entry cannot arm it.
+    #   preload_isl -- the baseline only means anything at 0 (the recorded runs started from an empty cache).
     baseline_chunk_times_s = (
-        KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S.get((num_layers, n_chunks, num_iters, use_trace))
-        if preload_isl == 0
+        KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S.get((num_layers, n_chunks, num_iters))
+        if (use_trace and preload_isl == 0)
         else None
     )
     run_chunked_transformer_updated(
@@ -1852,11 +1852,15 @@ def test_kimi_prefill_transformer_chunked(
     if preload_isl + n_chunks * CHUNK > SEQ_CACHE_NOPCC:
         pytest.skip(f"preload_isl {preload_isl} + {n_chunks} chunks exceeds the {SEQ_CACHE_NOPCC}-token cache")
     # Gate against the CI baseline only for the exact config we have a recorded number for; every other
-    # combo in the sweep stays record-only (baseline None -> print_duration_table does not assert). The
-    # baseline is only meaningful at preload_isl=0 (the recorded runs started from an empty cache).
+    # combo in the sweep stays record-only (baseline None -> print_duration_table does not assert). Two
+    # hard conditions on top of the table lookup:
+    #   use_trace   -- the baselines are trace-replay numbers, and the untraced path is a different
+    #                  regime (flat ~1.10 s/chunk, ~20% within-run spread), so it is NEVER gated. This
+    #                  is the guard, not the table's contents: adding an untraced entry cannot arm it.
+    #   preload_isl -- the baseline only means anything at 0 (the recorded runs started from an empty cache).
     baseline_chunk_times_s = (
-        KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S.get((num_layers, n_chunks, num_iters, use_trace))
-        if preload_isl == 0
+        KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S.get((num_layers, n_chunks, num_iters))
+        if (use_trace and preload_isl == 0)
         else None
     )
     run_chunked_transformer_updated(

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -137,21 +137,30 @@ KV_CACHE_PCC_THRESHOLD = 0.85
 INDEXER_K_PCC_THRESHOLD = 0.95
 
 # Per-chunk baseline medians (seconds) for the no-PCC perf gate, pulled from a known-good CI run. Keyed
-# by (num_layers, n_chunks, num_iters) so only the exact config we have a CI number for is gated; every
-# other combo in the no-PCC sweep stays record-only. Each list has one entry per chunk (index c ==
-# chunk c). A single margin (the perf_margin pytest arg) is applied to every chunk. Recalibrate by
-# re-reading the "chunk timing stats" table from a fresh green CI run.
+# by (num_layers, n_chunks, num_iters, use_trace) so only the exact config we have a CI number for is
+# gated; every other combo in the no-PCC sweep stays record-only. Each list has one entry per chunk
+# (index c == chunk c). A single margin (the perf_margin pytest arg) is applied to every chunk.
+# Recalibrate by re-reading the "chunk timing stats" table from a fresh green CI run.
+#
+# use_trace is part of the key because traced replay and eager dispatch are different regimes, not a
+# small delta: the same L61/11-chunk/10-iter config measures 0.6-0.95 s/chunk traced but a flat ~1.10
+# s/chunk untraced (host-dispatch bound, so the depth ramp disappears). One shared baseline would fail
+# whichever half of the pair it was not calibrated on.
 KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S = {
-    # test_kimi_prefill_transformer_chunked_no_pcc[...-L61-chunks_eleven-ten_iters] (55k / code_debug).
-    # TODO: populate the 11 per-chunk medians from the first green code_debug 55k CI run's
-    # "chunk timing stats" table; until then this config runs record-only (no perf gate). The old 5-chunk
-    # longbook baseline was [1.330, 1.326, 1.326, 1.340, 1.369] (run 28753487696) -- chunks 0-4 should be
-    # ~unchanged (chunk c attends to KV[0:c*CHUNK] regardless of n_chunks); chunks 5-10 are new.
-    # (61, 11, 10): [...],
+    # test_kimi_prefill_transformer_chunked_perf[...-L61-preload0-chunks_eleven-ten_iters-traced]
+    # (55k / code_debug), from run 31675454129 job 94407856609 -- green, and stable within the run
+    # (per-chunk stddev <= 0.002 s over the 9 post-warmup iterations). The times rise with chunk index
+    # because chunk c attends to KV[0:c*CHUNK], so the MLA gather grows with depth.
+    (61, 11, 10, True): [0.605, 0.606, 0.653, 0.681, 0.711, 0.743, 0.760, 0.793, 0.842, 0.869, 0.905],
+    # The untraced twin (CI job "Blaze - Chunked Kimi perf (code_debug 55k, no trace)") stays
+    # record-only: its medians are a flat ~1.10 s but with per-chunk stddev up to 0.22 s within a single
+    # run (run 31670499441 job 94387075128) -- ~20% spread, which no meaningful band survives. Gate it
+    # once the eager-dispatch path is stable enough to have a real baseline.
+    # (61, 11, 10, False): [...],
 }
 # Default +/- tolerance band around each baseline chunk median (fraction). Overridable per test via the
 # perf_margin pytest argument (see test_prefill_block_perf.py's `margin` column for the design).
-DEFAULT_PERF_MARGIN = 0.05
+DEFAULT_PERF_MARGIN = 0.03
 
 # Deepest config whose per-layer PCC is asserted; deeper runs (L61) stay record-only until their
 # accumulation headroom is pinned.
@@ -1681,7 +1690,7 @@ def run_chunked_transformer_updated(
 # ids: "traced" not "trace" — "notrace" CONTAINS "trace", so a -k "trace" term would match BOTH
 # modes and silently double a CI job. Matches the padded test's convention.
 @pytest.mark.parametrize("use_trace", [False, True], ids=["notrace", "traced"])
-@pytest.mark.parametrize("perf_margin", [DEFAULT_PERF_MARGIN], ids=["margin5pct"])
+@pytest.mark.parametrize("perf_margin", [DEFAULT_PERF_MARGIN], ids=["margin3pct"])
 @pytest.mark.parametrize(
     "num_iters", [1, 2, 10, 20, 25], ids=["iters1", "two_iters", "ten_iters", "iters20", "iters25"]
 )
@@ -1752,7 +1761,9 @@ def test_kimi_prefill_transformer_chunked_perf(
     # combo in the sweep stays record-only (baseline None -> print_duration_table does not assert). The
     # baseline is only meaningful at preload_isl=0 (the recorded runs started from an empty cache).
     baseline_chunk_times_s = (
-        KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S.get((num_layers, n_chunks, num_iters)) if preload_isl == 0 else None
+        KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S.get((num_layers, n_chunks, num_iters, use_trace))
+        if preload_isl == 0
+        else None
     )
     run_chunked_transformer_updated(
         variant,
@@ -1777,7 +1788,7 @@ def test_kimi_prefill_transformer_chunked_perf(
 # ids: "traced" not "trace" — "notrace" CONTAINS "trace", so a -k "trace" term would match BOTH
 # modes and silently double a CI job. Matches the padded test's convention.
 @pytest.mark.parametrize("use_trace", [False, True], ids=["notrace", "traced"])
-@pytest.mark.parametrize("perf_margin", [DEFAULT_PERF_MARGIN], ids=["margin5pct"])
+@pytest.mark.parametrize("perf_margin", [DEFAULT_PERF_MARGIN], ids=["margin3pct"])
 @pytest.mark.parametrize(
     "num_iters", [1, 2, 10, 20, 25], ids=["iters1", "two_iters", "ten_iters", "iters20", "iters25"]
 )
@@ -1844,7 +1855,9 @@ def test_kimi_prefill_transformer_chunked(
     # combo in the sweep stays record-only (baseline None -> print_duration_table does not assert). The
     # baseline is only meaningful at preload_isl=0 (the recorded runs started from an empty cache).
     baseline_chunk_times_s = (
-        KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S.get((num_layers, n_chunks, num_iters)) if preload_isl == 0 else None
+        KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S.get((num_layers, n_chunks, num_iters, use_trace))
+        if preload_isl == 0
+        else None
     )
     run_chunked_transformer_updated(
         variant,

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -1851,18 +1851,13 @@ def test_kimi_prefill_transformer_chunked(
 ):
     if preload_isl + n_chunks * CHUNK > SEQ_CACHE_NOPCC:
         pytest.skip(f"preload_isl {preload_isl} + {n_chunks} chunks exceeds the {SEQ_CACHE_NOPCC}-token cache")
-    # Gate against the CI baseline only for the exact config we have a recorded number for; every other
-    # combo in the sweep stays record-only (baseline None -> print_duration_table does not assert). Two
-    # hard conditions on top of the table lookup:
-    #   use_trace   -- the baselines are trace-replay numbers, and the untraced path is a different
-    #                  regime (flat ~1.10 s/chunk, ~20% within-run spread), so it is NEVER gated. This
-    #                  is the guard, not the table's contents: adding an untraced entry cannot arm it.
-    #   preload_isl -- the baseline only means anything at 0 (the recorded runs started from an empty cache).
-    baseline_chunk_times_s = (
-        KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S.get((num_layers, n_chunks, num_iters))
-        if (use_trace and preload_isl == 0)
-        else None
-    )
+    # ALWAYS record-only -- this accuracy test is never perf-gated. It shares the perf test's
+    # parametrization but NOT its is_high_power() skipif, so it can run on a standard-power Blackhole,
+    # where KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S -- measured on a >=130W galaxy -- describes nothing. Gating
+    # here would fail an accuracy run for a timing reason, on hardware the baseline never covered, and the
+    # timing table is incidental to this test anyway (see check_pcc below). The perf gate belongs to, and
+    # stays in, test_kimi_prefill_transformer_chunked_perf.
+    baseline_chunk_times_s = None
     run_chunked_transformer_updated(
         variant,
         config_only,
@@ -1876,6 +1871,8 @@ def test_kimi_prefill_transformer_chunked(
         num_iters,
         routing_use_l1_small_for_semaphores=True,
         baseline_chunk_times_s=baseline_chunk_times_s,
+        # Inert while baseline_chunk_times_s is None (print_duration_table only uses the margin when it
+        # has a baseline); kept for id/signature symmetry with the perf test.
         perf_margin=perf_margin,
         preload_isl=preload_isl,
         check_pcc=True,  # this test exists for the KV PCC; the timing table is incidental


### PR DESCRIPTION
### Ticket
Closes #53099

### Problem description
The `Blaze - Chunked Kimi perf (code_debug 55k, trace)` job in [blaze-models-prefill-tests](https://github.com/tenstorrent/tt-metal/actions/runs/31670499441/job/94387075077) printed its per-chunk timing table but never asserted on it: `KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S` was empty, so the lookup returned `None` and the run stayed record-only. A perf regression on the 55k / L61 / 11-chunk chunked-prefill path went green.

### What's changed
- **Populated the per-chunk baseline** for `(num_layers=61, n_chunks=11, num_iters=10)` with the 11 medians from run [31675454129 / job 94407856609](https://github.com/tenstorrent/tt-metal/actions/runs/31675454129) — a green run whose per-chunk stddev is `<= 0.002 s` over the 9 post-warmup iterations.
- **Tightened `DEFAULT_PERF_MARGIN` from 5% to 3%** (parametrize id `margin5pct` -> `margin3pct`). Every chunk's measured median must land inside its own `baseline +/- 3%` band; any single chunk outside fails the test. Baselines and margin live in the test file, not the CI yaml, so recalibration is a reviewed code change.
- **Traced variant only — enforced structurally.** The gate is hard-wired to `use_trace=True` at the call site:
  ```python
  baseline_chunk_times_s = (
      KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S.get((num_layers, n_chunks, num_iters))
      if (use_trace and preload_isl == 0)
      else None
  )
  ```
  The untraced variant is never gated *whatever the baseline table holds* — adding an untraced entry cannot arm it. This is deliberately a guard rather than merely an unpopulated key, so the invariant can't be broken by a later contributor adding a row.

The assert/table machinery in `print_duration_table` already existed and is unchanged; the table now renders the extra `baseline | low | high | status` columns, and the assert fires *after* the table is logged so a failure always shows the full per-chunk breakdown.

<img width="679" height="502" alt="image" src="https://github.com/user-attachments/assets/a03e4ec2-1aad-4da8-aba2-1fa124192153" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## CIs
| run | commit | traced | untraced |
|---|---|---|---|
| [31747876761](https://github.com/tenstorrent/tt-metal/actions/runs/31747876761) | `359c46e` (head) | ✅ `baseline gate +/- 3.0%` | ✅ `record-only (no baseline)` |
| [31745652989](https://github.com/tenstorrent/tt-metal/actions/runs/31745652989) | `fc7fbb1` | ✅ `baseline gate +/- 3.0%` | ✅ `record-only (no baseline)` |

Full CI https://github.com/tenstorrent/tt-metal/actions/runs/31750947443.