### PR TITLE
[LLK][Bug fix] Fix matmul unpacker miscompares on Wormhole B0 and Blackhole

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
@@ -354,6 +354,8 @@ inline void _llk_unpack_AB_matmul_(
 
     const bool reuse_a        = ct_dim >= rt_dim;
     const std::uint32_t t_dim = reuse_a ? rt_dim : ct_dim;
+    // Number of MOP iterations that must select context 1's replay segment (see zmask use below).
+    const std::uint32_t mop_loop_count = reuse_a ? ct_dim : rt_dim;
 
     if (!reuse_a)
     {
@@ -422,7 +424,11 @@ inline void _llk_unpack_AB_matmul_(
             }
         }
 
-        TT_MOP(0, (reuse_a ? ct_dim : rt_dim) - 1, unp_cfg_context == 0 ? 0 : 0xff); // Run the MOP
+        // zmask selects, per MOP iteration, context 0's replay segment (bit clear) or context 1's
+        // (bit set). A fixed-width mask like 0xff only covers 8 iterations; once mop_loop_count
+        // exceeds that, later iterations silently fall back to context 0's segment while
+        // unp_cfg_context is 1. Build the mask from the actual iteration count instead.
+        TT_MOP(0, mop_loop_count - 1, unp_cfg_context == 0 ? 0 : ((1u << mop_loop_count) - 1)); // Run the MOP
 
         // T6::SEMGET for context release
         t6_semaphore_get(semaphore::UNPACK_SYNC);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_matmul.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_matmul.h
@@ -321,6 +321,8 @@ inline void _llk_unpack_AB_matmul_(
 
     const bool reuse_a        = ct_dim >= rt_dim;
     const std::uint32_t t_dim = reuse_a ? rt_dim : ct_dim;
+    // Number of MOP iterations that must select context 1's replay segment (see zmask use below).
+    const std::uint32_t mop_loop_count = reuse_a ? ct_dim : rt_dim;
 
     if (!reuse_a)
     {
@@ -453,7 +455,11 @@ inline void _llk_unpack_AB_matmul_(
             }
         }
 
-        TT_MOP(0, (reuse_a ? ct_dim : rt_dim) - 1, unp_cfg_context == 0 ? 0 : 0xff); // Run the MOP
+        // zmask selects, per MOP iteration, context 0's replay segment (bit clear) or context 1's
+        // (bit set). A fixed-width mask like 0xff only covers 8 iterations; once mop_loop_count
+        // exceeds that, later iterations silently fall back to context 0's segment while
+        // unp_cfg_context is 1. Build the mask from the actual iteration count instead.
+        TT_MOP(0, mop_loop_count - 1, unp_cfg_context == 0 ? 0 : ((1u << mop_loop_count) - 1)); // Run the MOP
 
         // T6::SEMGET for context release
         t6_semaphore_get(semaphore::UNPACK_SYNC);


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Nightly matmul tests on Wormhole and Blackhole were producing bad results (miscompares), as reported by the failing CI run in issue #53078. The fix applies a small, matching change to the AB matmul unpacker in llk_unpack_AB_matmul.h for both the wormhole_b0 and blackhole LLK backends to correct the faulty unpack behavior causing the incorrect results.

Fixes #53078

### Notes for reviewers

Since the same fix is duplicated across the wormhole_b0 and blackhole variants of llk_unpack_AB_matmul.h, confirm the logic is applied consistently between the two, and check that nightly matmul tests now pass on both architectures.

Diffstat: 2 files changed, 14 insertions(+), 2 deletions(-).

<sub>Opened by the LLK issue-triage board (AI-assisted, draft) — please review the diff before merging.</sub>

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-53078-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk_code_gen/issue-53078-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk_code_gen/issue-53078-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk_code_gen/issue-53078-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk_code_gen/issue-53078-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk_code_gen/issue-53078-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk_code_gen/issue-53078-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk_code_gen/issue-53078-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk_code_gen/issue-53078-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk_code_gen/issue-53078-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk_code_gen/issue-53078-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk_code_gen/issue-53078-v1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk_code_gen/issue-53078-v1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk_code_gen/issue-53078-v1)