### PR TITLE
Promote pack_block_contiguous_uninit to the experimental compute API

### DIFF
--- a/tt_metal/hw/inc/api/compute/experimental/pack_block_uninit.h
+++ b/tt_metal/hw/inc/api/compute/experimental/pack_block_uninit.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+// Restore PackMode::Default packer MOP after pack_block_contiguous_* completes.
+// pack_block_contiguous_init replaces the tile-pack MOP template.
+
+#pragma once
+
+#include "api/compute/common.h"
+
+namespace ckernel {
+
+ALWI void pack_block_contiguous_uninit() { PACK((_llk_pack_mop_config_<PackMode::Default>())); }
+
+}  // namespace ckernel

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -104,6 +104,7 @@ set(HW_JIT_API_HEADERS
     inc/api/compute/experimental/eltwise_mul_scalar.h
     inc/api/compute/experimental/fast_untilize.h
     inc/api/compute/experimental/mul_reduce_scalar.h
+    inc/api/compute/experimental/pack_block_uninit.h
     inc/api/compute/experimental/rmsnorm.h
     inc/api/compute/experimental/semaphore.h
     inc/api/compute/experimental/sum_reduce_scalar.h


### PR DESCRIPTION
### PR Category

LLK / compute API promotion (additive)

### Summary

Promotes tt-blaze's `pack_block_contiguous_uninit()` into the experimental compute API, so blaze can drop its vendored copy of the header. **Additive only** — 15 lines, one new file, no metal callers, no existing kernel's codegen changes.

`pack_block_contiguous_init` replaces the tile-pack MOP template; this helper restores `PackMode::Default`. Blaze's convention (tt-blaze#2938) is that ops restore the Default MOP on exit so light follow-on ops can pack without re-initing — blaze's `rmsnorm` and `residual_add` kernels call it.

### Why no new test

There is no new LLK here: the helper wraps `_llk_pack_mop_config_<PackMode::Default>()`, which is already canonical in `tt_llk_blackhole/llk_lib/llk_pack.h` and exercised by the existing pack-block tests. It follows the established shape of the canonical `*_uninit` wrappers — `pack_rows_uninit` (pack.h), `pack_untilize_uninit` (pack_untilize.h), `reduce_uninit` (reduce.h), `unary_bcast_uninit` (bcast.h) — none of which carry dedicated tests either.

### Note for reviewers who also saw #52727

#52727 makes a pack-MOP restore an explicit **opt-in** on `custom_mm`'s `*_block_uninit`, because there the restore was a clobber of state the caller still needed, and metal's callers do not want it. That is the opposite situation from this PR, where restoring the Default MOP is the helper's entire and only purpose, invoked deliberately by the caller. The two are consistent: neither imposes a restore on a caller that did not ask for one.

Part of the tt-blaze ↔ tt-metal LLK reconciliation (tt-blaze#1971).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilenkovic/promote-pack-block-uninit)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilenkovic/promote-pack-block-uninit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilenkovic/promote-pack-block-uninit)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilenkovic/promote-pack-block-uninit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilenkovic/promote-pack-block-uninit)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilenkovic/promote-pack-block-uninit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilenkovic/promote-pack-block-uninit)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilenkovic/promote-pack-block-uninit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilenkovic/promote-pack-block-uninit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilenkovic/promote-pack-block-uninit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilenkovic/promote-pack-block-uninit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilenkovic/promote-pack-block-uninit)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilenkovic/promote-pack-block-uninit)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilenkovic/promote-pack-block-uninit)