### PR TITLE
#53090: Fix fold BLOCK_SHARDED specless-override grid for COL_MAJOR

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_fold.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_fold.py
@@ -763,15 +763,28 @@ def test_fold_specless_matching_layout_preserves_input_geometry(
 
 # COL_MAJOR sharded input + cross-layout specless override — fresh-synth inherits input's orientation (was silently ROW_MAJOR before).
 @pytest.mark.parametrize(
-    "override_layout",
+    "override_layout, shape",
     [
-        pytest.param(ttnn.TensorMemoryLayout.WIDTH_SHARDED, id="H_col_major_in_W_override"),
-        pytest.param(ttnn.TensorMemoryLayout.BLOCK_SHARDED, id="H_col_major_in_B_override"),
+        pytest.param(
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            (1, 16, 16, 64),
+            id="H_col_major_in_W_override",
+        ),
+        pytest.param(
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            (1, 16, 16, 64),
+            id="H_col_major_in_B_override",
+        ),
+        # Produces an asymmetric block-shard grid, making a COL_MAJOR axis swap observable on both WH and BH.
+        pytest.param(
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+            (1, 4, 4, 64),
+            id="H_col_major_in_B_override_asymmetric_grid",
+        ),
     ],
 )
-def test_fold_specless_cross_layout_override_inherits_input_orientation(override_layout, device):
+def test_fold_specless_cross_layout_override_inherits_input_orientation(override_layout, shape, device):
     """Cross-layout fresh-synth branch must inherit input's orientation, not silently emit ROW_MAJOR."""
-    shape = (1, 16, 16, 64)
     in_mc = _height_shard_rm(shape, device, orientation=ttnn.ShardOrientation.COL_MAJOR)
     out_mc = ttnn.MemoryConfig(override_layout, ttnn.BufferType.L1)
     torch.manual_seed(0)

--- a/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fold/device/fold_device_op.cpp
@@ -21,6 +21,11 @@ tt::tt_metal::ShardSpec synthesize_fold_output_shard_spec(
     auto* device = input_tensor.device();
     const auto grid = device->compute_with_storage_grid_size();
     const uint32_t max_cores = grid.x * grid.y;
+    // Inherit input's orientation when available (mirrors generate_transpose_shard_spec); ROW_MAJOR fallback for
+    // non-sharded inputs.
+    const tt::tt_metal::ShardOrientation orientation = input_tensor.shard_spec().has_value()
+                                                           ? input_tensor.shard_spec()->orientation
+                                                           : tt::tt_metal::ShardOrientation::ROW_MAJOR;
     std::array<uint32_t, 2> shape = {0, 0};
     CoreRangeSet cores;
     switch (layout) {
@@ -35,18 +40,21 @@ tt::tt_metal::ShardSpec synthesize_fold_output_shard_spec(
             break;
         }
         default: {  // BLOCK_SHARDED
-            shape = {tt::div_up(rows, grid.y), tt::div_up(cols, grid.x)};
-            const uint32_t n_rows = tt::div_up(rows, shape[0]);
-            const uint32_t n_cols = tt::div_up(cols, shape[1]);
-            cores = CoreRangeSet(CoreRange({0, 0}, {n_cols - 1, n_rows - 1}));
+            // COL_MAJOR flips axis→core mapping (see TensorSpec validation + conv2d_utils::determine_parallel_config):
+            // height splits across grid.x, width across grid.y — asymmetric grids (e.g. bh_p100 11×10) otherwise
+            // overshoot num_shards_along_width vs shard_grid.y for COL_MAJOR.
+            const bool col_major = orientation == tt::tt_metal::ShardOrientation::COL_MAJOR;
+            const uint32_t h_divisor = col_major ? grid.x : grid.y;
+            const uint32_t w_divisor = col_major ? grid.y : grid.x;
+            shape = {tt::div_up(rows, h_divisor), tt::div_up(cols, w_divisor)};
+            const uint32_t n_shards_h = tt::div_up(rows, shape[0]);
+            const uint32_t n_shards_w = tt::div_up(cols, shape[1]);
+            const uint32_t grid_x = col_major ? n_shards_h : n_shards_w;
+            const uint32_t grid_y = col_major ? n_shards_w : n_shards_h;
+            cores = CoreRangeSet(CoreRange({0, 0}, {grid_x - 1, grid_y - 1}));
             break;
         }
     }
-    // Inherit input's orientation when available (mirrors generate_transpose_shard_spec); ROW_MAJOR fallback for
-    // non-sharded inputs.
-    tt::tt_metal::ShardOrientation orientation = input_tensor.shard_spec().has_value()
-                                                     ? input_tensor.shard_spec()->orientation
-                                                     : tt::tt_metal::ShardOrientation::ROW_MAJOR;
     return tt::tt_metal::ShardSpec(cores, shape, orientation);
 }
 


### PR DESCRIPTION
### Ticket
Link to Github Issue #53090
closes #53090
closes #53115

### Problem
`synthesize_fold_output_shard_spec` built BLOCK_SHARDED shard specs with a ROW_MAJOR axis→core mapping unconditionally; on asymmetric grids (e.g. BH `bh_p100` 11×10) a COL_MAJOR input made `num_shards_along_width` overshoot `shard_grid.y`, tripping `TT_FATAL !shard_grid_fit_error.has_value()` in `tensor_spec.cpp`.

### Fix
Derive `orientation` before the switch, and for BLOCK_SHARDED swap the `grid.x`/`grid.y` roles when COL_MAJOR — `h_divisor`, `w_divisor`, and the resulting `CoreRange` now mirror `conv2d_utils::determine_parallel_config`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/fold_rework_bh_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/fold_rework_bh_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/fold_rework_bh_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/fold_rework_bh_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/fold_rework_bh_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/fold_rework_bh_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/fold_rework_bh_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/fold_rework_bh_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/fold_rework_bh_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/fold_rework_bh_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/fold_rework_bh_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/fold_rework_bh_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/fold_rework_bh_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/fold_rework_bh_fix)

