### PR TITLE
Promote the SFPU RoPE LLK to experimental

### DIFF
--- a/tt_metal/hw/inc/api/compute/experimental/rope_sfpu.h
+++ b/tt_metal/hw/inc/api/compute/experimental/rope_sfpu.h
@@ -6,11 +6,14 @@
 #include <cstdint>
 #include "api/compute/common.h"
 
-#ifdef TRISC_MATH
+// Blackhole-only: the SFPU rope LLK lives only in the Blackhole llk_lib.
+#if defined(TRISC_MATH) && defined(ARCH_BLACKHOLE)
 #include "sfpu/experimental/ckernel_sfpu_rope.h"
 #endif
 
 namespace ckernel {
+
+#if defined(ARCH_BLACKHOLE)
 
 // Kept for callers that size DEST slots against the rope's tile geometry.
 constexpr std::uint32_t ROPE_SFPU_TILE_ROWS = 64;
@@ -22,7 +25,9 @@ ALWI void rope_sfpu_init() { MATH((sfpu::sfpu_rope_configure_addrmod())); }
  * Requires rope_sfpu_init(). See sfpu_rope_all_rows for the operand layout.
  *
  * With has_scale, scale_fp32 (an fp32 bit pattern, read from L1 at runtime) is
- * folded into cos/sin for a deferred normalization.
+ * folded into cos/sin for a deferred normalization. scale_fp32 is required, not
+ * defaulted: a missing value under has_scale would scale cos/sin by zero and
+ * silently zero every output. Pass 0 explicitly when has_scale is false.
  */
 template <
     std::uint32_t Ht,
@@ -33,7 +38,7 @@ template <
     std::uint32_t sin_base,
     std::uint32_t cs_stride,
     bool has_scale = false>
-ALWI void rope_sfpu_inplace_rows(const std::uint32_t scale_fp32 = 0) {
+ALWI void rope_sfpu_inplace_rows(const std::uint32_t scale_fp32) {
     static_assert(Wt == 1 || Wt == 2, "rope_sfpu: Wt must be 1 or 2 (decode rotary head_dim <= 64)");
     static_assert((x_base % 4) == 0 && (x_stride % 4) == 0, "x rows must be 4-row aligned");
     MATH((sfpu::sfpu_rope_dest_setup()));
@@ -48,7 +53,9 @@ template <std::uint32_t Ht, std::uint32_t Wt>
 ALWI void rope_sfpu_inplace() {
     static_assert(Ht * Wt + 2 * Wt <= 8, "rope_sfpu: x + cos + sin must fit the 8 Tile32x32 slots of half DEST");
     constexpr std::uint32_t T = ROPE_SFPU_TILE_ROWS;
-    rope_sfpu_inplace_rows<Ht, Wt, 0, T, (Ht * Wt) * T, (Ht * Wt + Wt) * T, T>();
+    rope_sfpu_inplace_rows<Ht, Wt, 0, T, (Ht * Wt) * T, (Ht * Wt + Wt) * T, T>(/*scale_fp32=*/0);
 }
+
+#endif  // ARCH_BLACKHOLE
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/rope_sfpu.h
+++ b/tt_metal/hw/inc/api/compute/experimental/rope_sfpu.h
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/common.h"
+
+#ifdef TRISC_MATH
+#include "sfpu/experimental/ckernel_sfpu_rope.h"
+#endif
+
+namespace ckernel {
+
+// Kept for callers that size DEST slots against the rope's tile geometry.
+constexpr std::uint32_t ROPE_SFPU_TILE_ROWS = 64;
+
+ALWI void rope_sfpu_init() { MATH((sfpu::sfpu_rope_configure_addrmod())); }
+
+/**
+ * Rotate in place, x tiles laid out at an arbitrary DEST stride.
+ * Requires rope_sfpu_init(). See sfpu_rope_all_rows for the operand layout.
+ *
+ * With has_scale, scale_fp32 (an fp32 bit pattern, read from L1 at runtime) is
+ * folded into cos/sin for a deferred normalization.
+ */
+template <
+    std::uint32_t Ht,
+    std::uint32_t Wt,
+    std::uint32_t x_base,
+    std::uint32_t x_stride,
+    std::uint32_t cos_base,
+    std::uint32_t sin_base,
+    std::uint32_t cs_stride,
+    bool has_scale = false>
+ALWI void rope_sfpu_inplace_rows(const std::uint32_t scale_fp32 = 0) {
+    static_assert(Wt == 1 || Wt == 2, "rope_sfpu: Wt must be 1 or 2 (decode rotary head_dim <= 64)");
+    static_assert((x_base % 4) == 0 && (x_stride % 4) == 0, "x rows must be 4-row aligned");
+    MATH((sfpu::sfpu_rope_dest_setup()));
+    MATH((sfpu::sfpu_rope_all_rows<Ht, Wt, x_base, x_stride, cos_base, sin_base, cs_stride, has_scale>(scale_fp32)));
+}
+
+/**
+ * Standalone form: x in Tile32x32 slots [0, Ht*Wt), cos in [Ht*Wt, +Wt), sin in
+ * [Ht*Wt+Wt, +Wt) — the layout the RopeSfpu micro-op copy_tile's into DEST.
+ */
+template <std::uint32_t Ht, std::uint32_t Wt>
+ALWI void rope_sfpu_inplace() {
+    static_assert(Ht * Wt + 2 * Wt <= 8, "rope_sfpu: x + cos + sin must fit the 8 Tile32x32 slots of half DEST");
+    constexpr std::uint32_t T = ROPE_SFPU_TILE_ROWS;
+    rope_sfpu_inplace_rows<Ht, Wt, 0, T, (Ht * Wt) * T, (Ht * Wt + Wt) * T, T>();
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -105,6 +105,7 @@ set(HW_JIT_API_HEADERS
     inc/api/compute/experimental/fast_untilize.h
     inc/api/compute/experimental/mul_reduce_scalar.h
     inc/api/compute/experimental/rmsnorm.h
+    inc/api/compute/experimental/rope_sfpu.h
     inc/api/compute/experimental/semaphore.h
     inc/api/compute/experimental/sum_reduce_scalar.h
     inc/api/compute/binary_fmod.h

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_rope.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_rope.h
@@ -124,6 +124,10 @@ inline void sfpu_rope_face(const std::uint32_t x_addr)
  *
  * x_stride is 64 when x came from copy_tile (Tile32x32 slots) and 32 when it is
  * a custom_mm<dense_packing> result still sitting in DEST.
+ *
+ * scale_fp32 is required rather than defaulted: under has_scale a missing value
+ * would scale cos/sin by zero and silently zero every output. Callers with
+ * has_scale=false pass 0.
  */
 template <
     std::uint32_t Ht,
@@ -134,7 +138,7 @@ template <
     std::uint32_t sin_base,
     std::uint32_t cs_stride,
     bool has_scale = false>
-inline void sfpu_rope_all_rows(const std::uint32_t scale_fp32 = 0)
+inline void sfpu_rope_all_rows(const std::uint32_t scale_fp32)
 {
     constexpr std::uint32_t F = rope::FACE_ROWS;
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_rope.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_rope.h
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// SFPU RoPE for [1, 32] tiny tiles.
+//
+// Addressing (BlackholeA0 ISA, SFPLOAD):
+//     Row    = (Addr & ~3) + Lane/8
+//     Column = (Lane & 7) * 2 + (Addr & 2 ? 1 : 0)
+// so one vector is 4 rows x 8 columns of ONE column parity, Addr>>2 selects the
+// row group, and bit 1 selects even/odd columns.  For a [1, 32] tile only DEST
+// row 0 of each face is live, so lanes 0..7 carry the data and lanes 8..31 read
+// the zeros custom_mm's clear_src left in rows 1..3.  Those lanes are computed
+// and stored back too, but a [1, 32] tile only ever packs row 0, so they are
+// inert.
+//
+// cos/sin are in the interleaved (Meta) layout, each angle duplicated across
+// the two slots of its pair: cos = (c0,c0,c1,c1,...).  A single even-parity
+// load therefore serves BOTH x_even and x_odd.
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_addrmod.h"
+#include "ckernel_instr_params.h"
+#include "lltt.h"
+#include "sfpi.h"
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+namespace rope
+{
+// DEST rows per Tile32x32 slot (copy_tile / pack_tile addressing) and per face.
+constexpr std::uint32_t TILE_ROWS = 64;
+constexpr std::uint32_t FACE_ROWS = 16;
+// Mod1 bit that negates the VA operand of SFPMAD (VD = -(VA*VB) + VC).
+constexpr std::uint32_t NEGATE_VA = 1;
+
+constexpr std::uint8_t ZERO_ADDR_MOD = ADDR_MOD_7;
+} // namespace rope
+
+inline void sfpu_rope_configure_addrmod()
+{
+    addr_mod_t {
+        .srca = {.incr = 0},
+        .srcb = {.incr = 0},
+        .dest = {.incr = 0},
+    }
+        .set(rope::ZERO_ADDR_MOD);
+}
+
+inline void sfpu_rope_dest_setup()
+{
+    TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, get_dest_buffer_base());
+    TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+}
+
+/**
+ * cos/sin for one face into LREG0/LREG1.  Every head shares them at a given width
+ * tile, so the load is hoisted out of the head loop.  A single even-parity load
+ * serves both x parities (see the layout note at the top).
+ */
+inline void sfpu_rope_load_cos_sin(const std::uint32_t cos_addr, const std::uint32_t sin_addr)
+{
+    constexpr std::uint32_t FMT = static_cast<std::uint32_t>(InstrModLoadStore::FP16B);
+    TT_SFPLOAD(p_sfpu::LREG0, FMT, rope::ZERO_ADDR_MOD, cos_addr);
+    TT_SFPLOAD(p_sfpu::LREG1, FMT, rope::ZERO_ADDR_MOD, sin_addr);
+}
+
+/**
+ * Scales the cos/sin in LREG0/LREG1 by ``scale_fp32``, an fp32 bit pattern.
+ */
+inline void sfpu_rope_scale_cos_sin(const std::uint32_t scale_fp32)
+{
+    TT_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_LOWER, scale_fp32 & 0xFFFFu);
+    TT_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_UPPER, scale_fp32 >> 16);
+    TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG2, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
+    TTI_SFPMAD(p_sfpu::LREG1, p_sfpu::LREG2, p_sfpu::LCONST_0, p_sfpu::LREG1, 0);
+}
+
+/**
+ * One face: 8 complex pairs of a [1, 32] tile, rotated by the cos/sin already in
+ * LREG0/LREG1.
+ *
+ *   x'_even = cos*x_even - sin*x_odd
+ *   x'_odd  = sin*x_even + cos*x_odd
+ *
+ * x_addr is the absolute DEST row of the face's first row, and must be 4-row aligned
+ * (the caller's x_base/x_stride asserts guarantee it).  Only the address-bearing
+ * instructions take the runtime TT_ form; the multiplies keep their inline encoding.
+ */
+inline void sfpu_rope_face(const std::uint32_t x_addr)
+{
+    constexpr std::uint32_t FMT = static_cast<std::uint32_t>(InstrModLoadStore::FP16B);
+    constexpr std::uint8_t AM   = rope::ZERO_ADDR_MOD;
+
+    TT_SFPLOAD(p_sfpu::LREG4, FMT, AM, x_addr);     // x_even
+    TT_SFPLOAD(p_sfpu::LREG5, FMT, AM, x_addr + 2); // x_odd
+
+    // No SFPNOPs: hardware auto-stalls a dependent SFPMAD read, and both products
+    // are computed before either is consumed, so each pair is already a cycle apart.
+    // LREG2 = cos*x_even ; LREG3 = sin*x_even
+    TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG2, 0);
+    TTI_SFPMAD(p_sfpu::LREG1, p_sfpu::LREG4, p_sfpu::LCONST_0, p_sfpu::LREG3, 0);
+    // LREG6 = LREG2 - sin*x_odd ; LREG7 = LREG3 + cos*x_odd
+    TTI_SFPMAD(p_sfpu::LREG1, p_sfpu::LREG5, p_sfpu::LREG2, p_sfpu::LREG6, rope::NEGATE_VA);
+    TTI_SFPMAD(p_sfpu::LREG0, p_sfpu::LREG5, p_sfpu::LREG3, p_sfpu::LREG7, 0);
+
+    TT_SFPSTORE(p_sfpu::LREG6, FMT, AM, x_addr);
+    TT_SFPSTORE(p_sfpu::LREG7, FMT, AM, x_addr + 2);
+}
+
+/**
+ * Ht*Wt x-tiles starting at DEST row ``x_base``, ``x_stride`` rows apart, against
+ * Wt cos tiles at ``cos_base`` and Wt sin tiles at ``sin_base`` (``cs_stride``
+ * apart). cos/sin are shared by every head — decode rotates all heads at one
+ * position — so the nesting is (width tile, face) outer and head inner, and each
+ * cos/sin pair is loaded once rather than per tile.
+ *
+ * x_stride is 64 when x came from copy_tile (Tile32x32 slots) and 32 when it is
+ * a custom_mm<dense_packing> result still sitting in DEST.
+ */
+template <
+    std::uint32_t Ht,
+    std::uint32_t Wt,
+    std::uint32_t x_base,
+    std::uint32_t x_stride,
+    std::uint32_t cos_base,
+    std::uint32_t sin_base,
+    std::uint32_t cs_stride,
+    bool has_scale = false>
+inline void sfpu_rope_all_rows(const std::uint32_t scale_fp32 = 0)
+{
+    constexpr std::uint32_t F = rope::FACE_ROWS;
+
+    static_assert((F & 3) == 0, "face stride must keep rows 4-row aligned");
+    static_assert((x_base & 3) == 0 && (x_stride & 3) == 0, "x rows must be 4-row aligned");
+    static_assert((cos_base & 3) == 0 && (sin_base & 3) == 0 && (cs_stride & 3) == 0, "cos/sin rows must be 4-row aligned");
+
+    constexpr std::uint32_t head_stride = Wt * x_stride;
+
+    for (std::uint32_t w = 0; w < Wt; w++)
+    {
+        for (std::uint32_t f = 0; f < 2; f++)
+        {
+            const std::uint32_t cs_off = w * cs_stride + f * F;
+            sfpu_rope_load_cos_sin(cos_base + cs_off, sin_base + cs_off);
+            if constexpr (has_scale)
+            {
+                // Amortized over the Ht heads that reuse this cos/sin pair.
+                sfpu_rope_scale_cos_sin(scale_fp32);
+            }
+            std::uint32_t x_addr = x_base + w * x_stride + f * F;
+            for (std::uint32_t h = 0; h < Ht; h++)
+            {
+                sfpu_rope_face(x_addr);
+                x_addr += head_stride;
+            }
+        }
+    }
+}
+
+} // namespace sfpu
+} // namespace ckernel


### PR DESCRIPTION
### PR Category

LLK promotion (additive)

### Summary

Promotes tt-blaze's SFPU RoPE into the experimental LLK / compute API so blaze can drop its vendored copy:

- `tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_rope.h` — the SFPU rotary itself: addrmod configuration, `sfpu_rope_all_rows`, in-place rotation of x tiles at an arbitrary DEST stride, with an optional scale folded into cos/sin for a deferred normalization.
- `tt_metal/hw/inc/api/compute/experimental/rope_sfpu.h` — the compute-API wrapper (`rope_sfpu_init`, `rope_sfpu_inplace_rows`, `rope_sfpu_inplace`).

Copied from blaze, with three edits: the vendored include rewritten to the canonical `sfpu/experimental/` form (matching `llk_math_deepseek_top32_rm.h`), plus two review-driven hardening changes described below. Registered in `tt_metal/hw/sources.cmake`.

### Review-driven changes on top of the blaze source

1. **Blackhole guard.** The SFPU rope LLK exists only in `tt_llk_blackhole`, but the compute header ships in `HW_JIT_API_HEADERS` for every arch, so a Wormhole or Quasar math kernel that included it would fail preprocessing. Both the math-thread include and the API bodies are now behind `ARCH_BLACKHOLE`, matching `experimental/hadamard.h` and `experimental/softmax_k.h`. Blaze is Blackhole-only and already compiles its kernels with `ARCH_BLACKHOLE` defined, so this is a no-op there.
2. **`scale_fp32` is required, not defaulted.** Under `has_scale`, a defaulted `0` scales cos/sin by zero and silently zeroes every output. The default is dropped at both the LLK and compute-API surface; the one internal caller (`rope_sfpu_inplace`, `has_scale=false`) passes `0` explicitly. Blaze's only call site already passed the scale explicitly, so no caller churn.

### This does not duplicate an existing metal path

tt-metal has no LLK-level rope. Both existing rotary paths compose the rotation from generic ops — the `deepseek_v3_b1` rope micro-op (`unified_kernels/rope.hpp`) and the ttnn `rotary_embedding_llama` compute kernel both use `matmul` + `bcast` + `eltwise_binary`. There is no SFPU rotation anywhere in `tt_metal/hw` or `tt_metal/tt-llk`.

The two are not equivalent: this rotates complex pairs in place in DEST via SFPLOAD/SFPMAD under a custom addrmod, with no rotation-matrix operand and no extra CB traffic, which is what lets blaze fuse it into a matmul epilogue.

**Additive only:** no metal callers yet — nothing existing changes behaviour or codegen.

### Tests

Not included in this PR by design. The kernels are currently exercised by blaze (`tests/blaze/micro_ops/mla/test_rope.py`, plus the `matmul_epilogue` op that calls `rope_sfpu.h`); dedicated tt-llk tests are planned as a follow-up by the LLK team. Same shape as #52709, which promoted the rmsnorm / add_rsqrt / eltwise_mul_scalar family additively.

Part of the tt-blaze <-> tt-metal LLK reconciliation (tt-blaze#1971).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilenkovic/promote-rope-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilenkovic/promote-rope-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilenkovic/promote-rope-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilenkovic/promote-rope-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilenkovic/promote-rope-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilenkovic/promote-rope-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilenkovic/promote-rope-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilenkovic/promote-rope-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilenkovic/promote-rope-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilenkovic/promote-rope-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilenkovic/promote-rope-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilenkovic/promote-rope-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilenkovic/promote-rope-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilenkovic/promote-rope-sfpu)