### PR TITLE
[tt-llk] Add Quasar tests for the 57 SFPI-implemented Blackhole SFPU kernels

### DIFF
--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
@@ -33,6 +33,257 @@
 #include "sfpu/ckernel_sfpu_silu.h"
 #include "sfpu/ckernel_sfpu_sqrt.h"
 
+// ─────────────────────────────────────────────────────────────────────────────
+// SFPU parity set — gated includes
+//
+// These 57 kernels are implemented in pure sfpi:: on Blackhole and are not yet ported to
+// Quasar. Their tests are written ahead of the port, so every include and every dispatch
+// branch below is guarded on the header actually existing. A guard that does not fire
+// costs nothing; a guard that does fire activates the op's full sweep with no test edit.
+//
+// The Python side gates the same ops on the same header basenames via
+// helpers/sfpu_port_quasar.py, so the two cannot disagree about what is available. Bare
+// basenames are used deliberately rather than "llk_sfpu/<name>.h": all three Quasar SFPU
+// trees are on the include path as bare-name roots, so the gate does not care which one a
+// future port lands in.
+//
+// To activate a ported kernel: nothing here needs editing. If its Quasar signature differs
+// from the Blackhole one mirrored below, adjust that branch only.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// clang-format off
+#if __has_include("ckernel_sfpu_activations.h")
+#include "ckernel_sfpu_activations.h"
+#define QSR_HAS_ACTIVATIONS 1
+#endif
+#if __has_include("ckernel_sfpu_add1.h")
+#include "ckernel_sfpu_add1.h"
+#define QSR_HAS_ADD1 1
+#endif
+#if __has_include("ckernel_sfpu_bitwise.h")
+#include "ckernel_sfpu_bitwise.h"
+#define QSR_HAS_BITWISE 1
+#endif
+#if __has_include("ckernel_sfpu_bitwise_not.h")
+#include "ckernel_sfpu_bitwise_not.h"
+#define QSR_HAS_BITWISE_NOT 1
+#endif
+#if __has_include("ckernel_sfpu_cast_fp32_to_fp16a.h")
+#include "ckernel_sfpu_cast_fp32_to_fp16a.h"
+#define QSR_HAS_CAST_FP32_TO_FP16A 1
+#endif
+#if __has_include("ckernel_sfpu_cbrt.h")
+#include "ckernel_sfpu_cbrt.h"
+#define QSR_HAS_CBRT 1
+#endif
+#if __has_include("ckernel_sfpu_celu.h")
+#include "ckernel_sfpu_celu.h"
+#define QSR_HAS_CELU 1
+#endif
+#if __has_include("ckernel_sfpu_digamma.h")
+#include "ckernel_sfpu_digamma.h"
+#define QSR_HAS_DIGAMMA 1
+#endif
+#if __has_include("ckernel_sfpu_elu.h")
+#include "ckernel_sfpu_elu.h"
+#define QSR_HAS_ELU 1
+#endif
+#if __has_include("ckernel_sfpu_erf.h")
+#include "ckernel_sfpu_erf.h"
+#define QSR_HAS_ERF 1
+#endif
+#if __has_include("ckernel_sfpu_erfc.h")
+#include "ckernel_sfpu_erfc.h"
+#define QSR_HAS_ERFC 1
+#endif
+#if __has_include("ckernel_sfpu_erfinv.h")
+#include "ckernel_sfpu_erfinv.h"
+#define QSR_HAS_ERFINV 1
+#endif
+#if __has_include("ckernel_sfpu_exp2.h")
+#include "ckernel_sfpu_exp2.h"
+#define QSR_HAS_EXP2 1
+#endif
+#if __has_include("ckernel_sfpu_expm1.h")
+#include "ckernel_sfpu_expm1.h"
+#define QSR_HAS_EXPM1 1
+#endif
+#if __has_include("ckernel_sfpu_fmod.h")
+#include "ckernel_sfpu_fmod.h"
+#define QSR_HAS_FMOD 1
+#endif
+#if __has_include("ckernel_sfpu_hardmish.h")
+#include "ckernel_sfpu_hardmish.h"
+#define QSR_HAS_HARDMISH 1
+#endif
+#if __has_include("ckernel_sfpu_hardshrink.h")
+#include "ckernel_sfpu_hardshrink.h"
+#define QSR_HAS_HARDSHRINK 1
+#endif
+#if __has_include("ckernel_sfpu_hardtanh.h")
+#include "ckernel_sfpu_hardtanh.h"
+#define QSR_HAS_HARDTANH 1
+#endif
+#if __has_include("ckernel_sfpu_heaviside.h")
+#include "ckernel_sfpu_heaviside.h"
+#define QSR_HAS_HEAVISIDE 1
+#endif
+#if __has_include("ckernel_sfpu_i0.h")
+#include "ckernel_sfpu_i0.h"
+#define QSR_HAS_I0 1
+#endif
+#if __has_include("ckernel_sfpu_i1.h")
+#include "ckernel_sfpu_i1.h"
+#define QSR_HAS_I1 1
+#endif
+#if __has_include("ckernel_sfpu_identity.h")
+#include "ckernel_sfpu_identity.h"
+#define QSR_HAS_IDENTITY 1
+#endif
+#if __has_include("ckernel_sfpu_lgamma.h")
+#include "ckernel_sfpu_lgamma.h"
+#define QSR_HAS_LGAMMA 1
+#endif
+#if __has_include("ckernel_sfpu_logical_not.h")
+#include "ckernel_sfpu_logical_not.h"
+#define QSR_HAS_LOGICAL_NOT 1
+#endif
+#if __has_include("ckernel_sfpu_polygamma.h")
+#include "ckernel_sfpu_polygamma.h"
+#define QSR_HAS_POLYGAMMA 1
+#endif
+#if __has_include("ckernel_sfpu_prelu.h")
+#include "ckernel_sfpu_prelu.h"
+#define QSR_HAS_PRELU 1
+#endif
+#if __has_include("ckernel_sfpu_rdiv.h")
+#include "ckernel_sfpu_rdiv.h"
+#define QSR_HAS_RDIV 1
+#endif
+#if __has_include("ckernel_sfpu_remainder.h")
+#include "ckernel_sfpu_remainder.h"
+#define QSR_HAS_REMAINDER 1
+#endif
+#if __has_include("ckernel_sfpu_rpow.h")
+#include "ckernel_sfpu_rpow.h"
+#define QSR_HAS_RPOW 1
+#endif
+#if __has_include("ckernel_sfpu_selu.h")
+#include "ckernel_sfpu_selu.h"
+#define QSR_HAS_SELU 1
+#endif
+#if __has_include("ckernel_sfpu_sign.h")
+#include "ckernel_sfpu_sign.h"
+#define QSR_HAS_SIGN 1
+#endif
+#if __has_include("ckernel_sfpu_softshrink.h")
+#include "ckernel_sfpu_softshrink.h"
+#define QSR_HAS_SOFTSHRINK 1
+#endif
+#if __has_include("ckernel_sfpu_softsign.h")
+#include "ckernel_sfpu_softsign.h"
+#define QSR_HAS_SOFTSIGN 1
+#endif
+#if __has_include("ckernel_sfpu_tanhshrink.h")
+#include "ckernel_sfpu_tanhshrink.h"
+#define QSR_HAS_TANHSHRINK 1
+#endif
+#if __has_include("ckernel_sfpu_unary_comp.h")
+#include "ckernel_sfpu_unary_comp.h"
+#define QSR_HAS_UNARY_COMP 1
+#endif
+#if __has_include("ckernel_sfpu_unary_power.h")
+#include "ckernel_sfpu_unary_power.h"
+#define QSR_HAS_UNARY_POWER 1
+#endif
+#if __has_include("ckernel_sfpu_unary_shift.h")
+#include "ckernel_sfpu_unary_shift.h"
+#define QSR_HAS_UNARY_SHIFT 1
+#endif
+#if __has_include("ckernel_sfpu_xielu.h")
+#include "ckernel_sfpu_xielu.h"
+#define QSR_HAS_XIELU 1
+#endif
+
+// Binary parity kernels
+#if __has_include("ckernel_sfpu_atan2.h")
+#include "ckernel_sfpu_atan2.h"
+#define QSR_HAS_ATAN2 1
+#endif
+#if __has_include("ckernel_sfpu_binary_bitwise.h")
+#include "ckernel_sfpu_binary_bitwise.h"
+#define QSR_HAS_BINARY_BITWISE 1
+#endif
+#if __has_include("ckernel_sfpu_binary_fmod.h")
+#include "ckernel_sfpu_binary_fmod.h"
+#define QSR_HAS_BINARY_FMOD 1
+#endif
+#if __has_include("ckernel_sfpu_binary_pow.h")
+#include "ckernel_sfpu_binary_pow.h"
+#define QSR_HAS_BINARY_POW 1
+#endif
+#if __has_include("ckernel_sfpu_binary_remainder.h")
+#include "ckernel_sfpu_binary_remainder.h"
+#define QSR_HAS_BINARY_REMAINDER 1
+#endif
+#if __has_include("ckernel_sfpu_div_int32.h")
+#include "ckernel_sfpu_div_int32.h"
+#define QSR_HAS_DIV_INT32 1
+#endif
+#if __has_include("ckernel_sfpu_div_int32_floor.h")
+#include "ckernel_sfpu_div_int32_floor.h"
+#define QSR_HAS_DIV_INT32_FLOOR 1
+#endif
+#if __has_include("ckernel_sfpu_isclose.h")
+#include "ckernel_sfpu_isclose.h"
+#define QSR_HAS_ISCLOSE 1
+#endif
+#if __has_include("ckernel_sfpu_logsigmoid.h")
+#include "ckernel_sfpu_logsigmoid.h"
+#define QSR_HAS_LOGSIGMOID 1
+#endif
+#if __has_include("ckernel_sfpu_mask.h")
+#include "ckernel_sfpu_mask.h"
+#define QSR_HAS_MASK 1
+#endif
+#if __has_include("ckernel_sfpu_rsub_int32.h")
+#include "ckernel_sfpu_rsub_int32.h"
+#define QSR_HAS_RSUB_INT32 1
+#endif
+
+// Ternary parity kernels
+#if __has_include("ckernel_sfpu_addcdiv.h")
+#include "ckernel_sfpu_addcdiv.h"
+#define QSR_HAS_ADDCDIV 1
+#endif
+#if __has_include("ckernel_sfpu_addcmul.h")
+#include "ckernel_sfpu_addcmul.h"
+#define QSR_HAS_ADDCMUL 1
+#endif
+#if __has_include("ckernel_sfpu_lerp.h")
+#include "ckernel_sfpu_lerp.h"
+#define QSR_HAS_LERP 1
+#endif
+#if __has_include("ckernel_sfpu_snake_beta.h")
+#include "ckernel_sfpu_snake_beta.h"
+#define QSR_HAS_SNAKE_BETA 1
+#endif
+
+// Tile-structural parity kernels
+#if __has_include("ckernel_sfpu_alt_complex_rotate90.h")
+#include "ckernel_sfpu_alt_complex_rotate90.h"
+#define QSR_HAS_ALT_COMPLEX_ROTATE90 1
+#endif
+#if __has_include("ckernel_sfpu_int_sum.h")
+#include "ckernel_sfpu_int_sum.h"
+#define QSR_HAS_INT_SUM 1
+#endif
+#if __has_include("ckernel_sfpu_tiled_prod.h")
+#include "ckernel_sfpu_tiled_prod.h"
+#define QSR_HAS_TILED_PROD 1
+#endif
+// clang-format on
+
 // Binary SFPU op headers (consumed by the binary dispatchers below). The op is
 // selected via the LLK ckernel::BinaryOp enum (reused like Blackhole; the
 // comparison and max/min enumerators were added to it in llk_defs.h).
@@ -46,6 +297,9 @@
 #include "llk_sfpu/ckernel_sfpu_binary_max_min.h" // calculate_binary_max_min / _init_binary_max_min_
 #include "llk_sfpu/ckernel_sfpu_quant.h"          // quant_family / quant_family_init (quant/requant/dequant)
 #include "llk_sfpu/llk_math_eltwise_binary_sfpu_macros.h"
+// Ternary plumbing, already present on Quasar for `where`; the four ternary parity ops
+// (addcmul / addcdiv / lerp / snake_beta) reuse it.
+#include "llk_sfpu/llk_math_eltwise_ternary_sfpu_macros.h"
 #include "sfpu/ckernel_sfpu_add.h"         // _add_int_ (int add)
 #include "sfpu/ckernel_sfpu_binary_comp.h" // calculate_binary_comp_int32 (int gt/lt/le/ge)
 #include "sfpu/ckernel_sfpu_mul_int32.h"   // _mul_int32_ (int mul)
@@ -58,6 +312,56 @@ using namespace ckernel::sfpu;
 
 template <auto>
 inline constexpr bool unhandled_op = false;
+
+/**
+ * @brief Fixed scalar arguments the parity kernels bake in, as fp32 bit patterns.
+ *
+ * Mirrors tests/python_tests/helpers/sfpu_dispatch_constants.py, which the goldens and the
+ * sfpu_domains edge probes read. Two independent copies of one number is a silent-drift
+ * bug rather than duplication: change the threshold here without changing it there and the
+ * golden keeps computing against a value the kernel no longer uses, which reads as a
+ * kernel bug. Keep the two in step.
+ */
+namespace parity_constants
+{
+constexpr std::uint32_t kHalf         = 0x3F000000; // 0.5f  — comp threshold, shrink lambdas, heaviside
+constexpr std::uint32_t kOne          = 0x3F800000; // 1.0f  — elu/celu alpha, polygamma n and scale, xielu alphas
+constexpr std::uint32_t kTwo          = 0x40000000; // 2.0f  — fmod/remainder divisor, rpow base, unary_power exponent
+constexpr std::uint32_t kQuarter      = 0x3E800000; // 0.25f — prelu slope
+constexpr std::uint32_t kSeluScale    = 0x3F867D5F; // 1.0507009873554805f
+constexpr std::uint32_t kSeluAlpha    = 0x3FD62D7D; // 1.6732632423543772f
+constexpr std::uint32_t kBitwiseValue = 0x0F0F0F0F; // unary bitwise mask
+constexpr std::uint32_t kShiftAmount  = 3;          // unary left_shift / right_shift
+// hardtanh takes bf16 half-words rather than fp32 words: p0 = -min, p1 = -(max-min), p2 = max
+// for bounds [-1, +1].
+constexpr std::uint32_t kHardtanhP0 = 0x3F80; // 1.0 (bf16)
+constexpr std::uint32_t kHardtanhP1 = 0xC000; // -2.0 (bf16)
+constexpr std::uint32_t kHardtanhP2 = 0x3F80; // 1.0 (bf16)
+} // namespace parity_constants
+
+/**
+ * @brief Whether OPERATION is one of the six unary comparisons against a fixed scalar.
+ *
+ * Distinct from @ref is_zero_comp_op: those compare against zero and read the SFPU format
+ * at runtime, these compare against UNARY_COMP_THRESHOLD and are float-only.
+ *
+ * @param op The SFPU operation type to classify.
+ */
+inline constexpr bool is_unary_comp_op(SfpuType op)
+{
+    return op == SfpuType::unary_gt || op == SfpuType::unary_lt || op == SfpuType::unary_ge || op == SfpuType::unary_le || op == SfpuType::unary_ne ||
+           op == SfpuType::unary_eq;
+}
+
+/**
+ * @brief Whether OPERATION is one of the three unary bitwise-against-scalar modes.
+ *
+ * @param op The SFPU operation type to classify.
+ */
+inline constexpr bool is_unary_bitwise_op(SfpuType op)
+{
+    return op == SfpuType::bitwise_and || op == SfpuType::bitwise_or || op == SfpuType::bitwise_xor;
+}
 
 /**
  * @brief Whether OPERATION is one of the six comparison-to-zero modes.
@@ -124,6 +428,272 @@ void init_unary_sfpu_operation_quasar()
     {
         init_trigonometry<OPERATION, is_fp32_dest_acc_en>();
     }
+    // ── SFPU parity set ──────────────────────────────────────────────────────────────
+    // Each branch is compiled only when its kernel header resolved above. Ops whose
+    // Blackhole kernel has no init step are absent here by design, not by omission.
+#ifdef QSR_HAS_ACTIVATIONS
+    else if constexpr (OPERATION == SfpuType::hardsigmoid)
+    {
+        hardsigmoid_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_BITWISE
+    else if constexpr (OPERATION == SfpuType::bitwise_and)
+    {
+        bitwise_and_init();
+    }
+    else if constexpr (OPERATION == SfpuType::bitwise_or)
+    {
+        bitwise_or_init();
+    }
+    else if constexpr (OPERATION == SfpuType::bitwise_xor)
+    {
+        bitwise_xor_init();
+    }
+#endif
+#ifdef QSR_HAS_BITWISE_NOT
+    else if constexpr (OPERATION == SfpuType::bitwise_not)
+    {
+        bitwise_not_init();
+    }
+#endif
+#ifdef QSR_HAS_CBRT
+    else if constexpr (OPERATION == SfpuType::cbrt)
+    {
+        cube_root_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_CELU
+    else if constexpr (OPERATION == SfpuType::celu)
+    {
+        celu_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_DIGAMMA
+    else if constexpr (OPERATION == SfpuType::digamma)
+    {
+        digamma_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_ELU
+    else if constexpr (OPERATION == SfpuType::elu)
+    {
+        elu_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_ERF
+    else if constexpr (OPERATION == SfpuType::erf)
+    {
+        erf_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_ERFC
+    else if constexpr (OPERATION == SfpuType::erfc)
+    {
+        erfc_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_ERFINV
+    else if constexpr (OPERATION == SfpuType::erfinv)
+    {
+        erfinv_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_EXP2
+    else if constexpr (OPERATION == SfpuType::exp2)
+    {
+        exp2_init<APPROX, is_fp32_dest_acc_en>();
+    }
+#endif
+#ifdef QSR_HAS_EXPM1
+    else if constexpr (OPERATION == SfpuType::expm1)
+    {
+        expm1_init<APPROX, is_fp32_dest_acc_en>();
+    }
+#endif
+#ifdef QSR_HAS_FMOD
+    else if constexpr (OPERATION == SfpuType::fmod)
+    {
+        // calculate_fmod reads vConstFloatPrgm0/1, so the divisor is programmed here and
+        // not passed at the call site.
+        init_fmod<APPROX>(parity_constants::kTwo, parity_constants::kHalf);
+    }
+#endif
+#ifdef QSR_HAS_HARDMISH
+    else if constexpr (OPERATION == SfpuType::hardmish)
+    {
+        hardmish_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_HARDSHRINK
+    else if constexpr (OPERATION == SfpuType::hardshrink)
+    {
+        hardshrink_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_HARDTANH
+    else if constexpr (OPERATION == SfpuType::hardtanh)
+    {
+        hardtanh_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_HEAVISIDE
+    else if constexpr (OPERATION == SfpuType::heaviside)
+    {
+        heaviside_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_I0
+    else if constexpr (OPERATION == SfpuType::i0)
+    {
+        i0_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_I1
+    else if constexpr (OPERATION == SfpuType::i1)
+    {
+        i1_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_LGAMMA
+    else if constexpr (OPERATION == SfpuType::lgamma)
+    {
+        lgamma_stirling_init<APPROX, is_fp32_dest_acc_en>();
+    }
+#endif
+#ifdef QSR_HAS_LOGICAL_NOT
+    else if constexpr (OPERATION == SfpuType::logical_not_unary)
+    {
+        logical_not_unary_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_POLYGAMMA
+    else if constexpr (OPERATION == SfpuType::polygamma)
+    {
+        polygamma_init<APPROX, is_fp32_dest_acc_en>();
+    }
+#endif
+#ifdef QSR_HAS_PRELU
+    else if constexpr (OPERATION == SfpuType::prelu)
+    {
+        prelu_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_RDIV
+    else if constexpr (OPERATION == SfpuType::rdiv)
+    {
+        rdiv_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_REMAINDER
+    else if constexpr (OPERATION == SfpuType::remainder)
+    {
+        // As with fmod, the divisor lives in vConstFloatPrgm0/1 rather than in the call.
+        init_remainder<APPROX>(parity_constants::kTwo, parity_constants::kHalf);
+    }
+#endif
+#ifdef QSR_HAS_RPOW
+    else if constexpr (OPERATION == SfpuType::rpow)
+    {
+        sfpu_binary_pow_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_SELU
+    else if constexpr (OPERATION == SfpuType::selu)
+    {
+        selu_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_SIGN
+    else if constexpr (OPERATION == SfpuType::sign)
+    {
+        sign_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_SOFTSHRINK
+    else if constexpr (OPERATION == SfpuType::softshrink)
+    {
+        softshrink_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_SOFTSIGN
+    else if constexpr (OPERATION == SfpuType::softsign)
+    {
+        init_softsign<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_TANHSHRINK
+    else if constexpr (OPERATION == SfpuType::tanhshrink)
+    {
+        tanhshrink_init<APPROX, is_fp32_dest_acc_en>();
+    }
+#endif
+#ifdef QSR_HAS_UNARY_COMP
+    else if constexpr (OPERATION == SfpuType::unary_gt)
+    {
+        unary_gt_init<APPROX>();
+    }
+    else if constexpr (OPERATION == SfpuType::unary_lt)
+    {
+        unary_lt_init<APPROX>();
+    }
+    else if constexpr (OPERATION == SfpuType::unary_ge)
+    {
+        unary_ge_init<APPROX>();
+    }
+    else if constexpr (OPERATION == SfpuType::unary_le)
+    {
+        unary_le_init<APPROX>();
+    }
+    else if constexpr (OPERATION == SfpuType::unary_ne)
+    {
+        unary_ne_init<APPROX>();
+    }
+    else if constexpr (OPERATION == SfpuType::unary_eq)
+    {
+        unary_eq_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_UNARY_POWER
+    else if constexpr (OPERATION == SfpuType::power)
+    {
+        sfpu_unary_pow_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_UNARY_SHIFT
+    else if constexpr (OPERATION == SfpuType::left_shift)
+    {
+        left_shift_init<APPROX>();
+    }
+    else if constexpr (OPERATION == SfpuType::right_shift)
+    {
+        right_shift_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_XIELU
+    else if constexpr (OPERATION == SfpuType::xielu)
+    {
+        xielu_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_ALT_COMPLEX_ROTATE90
+    else if constexpr (OPERATION == SfpuType::alt_complex_rotate90)
+    {
+        alt_complex_rotate90_init();
+    }
+#endif
+#ifdef QSR_HAS_INT_SUM
+    else if constexpr (OPERATION == SfpuType::sum_int_row || OPERATION == SfpuType::sum_int_col)
+    {
+        sum_int_init<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_TILED_PROD
+    else if constexpr (OPERATION == SfpuType::tiled_prod)
+    {
+        tiled_prod_init();
+    }
+#endif
 }
 
 /**
@@ -183,6 +753,55 @@ void call_zero_comp_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_fo
             break;
     }
 }
+
+#ifdef QSR_HAS_UNARY_COMP
+/**
+ * @brief Apply a compare-against-scalar SFPU op in-place on one Dest tile.
+ *
+ * The six modes are separate functors rather than one op-templated kernel, so they need a
+ * dispatch of their own; @ref call_unary_sfpu_operation_quasar forwards to it. All six
+ * compare against the same fixed threshold (0.5f), which the goldens and the
+ * sfpu_domains edge probes also read -- see @ref parity_constants.
+ *
+ * @tparam OPERATION One of the six unary-comparison `SfpuType` values.
+ * @tparam DST_SYNC Destination synchronization mode used for bounds checking.
+ * @tparam is_fp32_dest_acc_en Whether Dest is in FP32 mode.
+ * @tparam APPROX Accepted for ABI parity; none of the six branches on it.
+ * @tparam ITERATIONS Number of SFPU loop iterations.
+ * @param dst_index Destination tile index operated on (already offset by DST_INDEX).
+ * @note Must be preceded by @ref init_unary_sfpu_operation_quasar for the same op.
+ */
+template <SfpuType OPERATION, DstSync DST_SYNC, bool is_fp32_dest_acc_en, bool APPROX = false, int ITERATIONS = SFPU_ITERATIONS>
+void call_unary_comp_operation_quasar(std::uint32_t dst_index)
+{
+    static_assert(is_unary_comp_op(OPERATION), "call_unary_comp_operation_quasar: OPERATION must be a unary-comparison SfpuType");
+
+    if constexpr (OPERATION == SfpuType::unary_gt)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_unary_gt, (APPROX, ITERATIONS), dst_index, VectorMode::RC, parity_constants::kHalf);
+    }
+    else if constexpr (OPERATION == SfpuType::unary_lt)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_unary_lt, (APPROX, ITERATIONS), dst_index, VectorMode::RC, parity_constants::kHalf);
+    }
+    else if constexpr (OPERATION == SfpuType::unary_ge)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_unary_ge, (APPROX, ITERATIONS), dst_index, VectorMode::RC, parity_constants::kHalf);
+    }
+    else if constexpr (OPERATION == SfpuType::unary_le)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_unary_le, (APPROX, ITERATIONS), dst_index, VectorMode::RC, parity_constants::kHalf);
+    }
+    else if constexpr (OPERATION == SfpuType::unary_ne)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_unary_ne, (APPROX, ITERATIONS), dst_index, VectorMode::RC, parity_constants::kHalf);
+    }
+    else
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_unary_eq, (APPROX, ITERATIONS), dst_index, VectorMode::RC, parity_constants::kHalf);
+    }
+}
+#endif
 
 /**
  * @brief Apply a Quasar unary SFPU op in-place on one Dest tile.
@@ -308,6 +927,324 @@ void call_unary_sfpu_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_f
     {
         SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_typecast, (TYPECAST_IN_FORMAT, TYPECAST_OUT_FORMAT, ITERATIONS), dst_index, VectorMode::RC);
     }
+    // ── SFPU parity set ──────────────────────────────────────────────────────────────
+    // Signatures mirror the Blackhole dispatcher in sfpu_operations.h, including the baked
+    // scalar arguments (see parity_constants). If a Quasar port lands with a different
+    // signature, this is the only place that needs adjusting.
+#ifdef QSR_HAS_ACTIVATIONS
+    else if constexpr (OPERATION == SfpuType::hardsigmoid)
+    {
+        SFPU_UNARY_CALL(
+            DST_SYNC, is_fp32_dest_acc_en, calculate_activation, (APPROX, ckernel::ActivationType::Hardsigmoid, ITERATIONS), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_ADD1
+    else if constexpr (OPERATION == SfpuType::add1)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_add1, (APPROX, ITERATIONS), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_BITWISE
+    else if constexpr (is_unary_bitwise_op(OPERATION))
+    {
+        constexpr UnaryBitwiseOp kOp = (OPERATION == SfpuType::bitwise_and)  ? UnaryBitwiseOp::AND
+                                       : (OPERATION == SfpuType::bitwise_or) ? UnaryBitwiseOp::OR
+                                                                             : UnaryBitwiseOp::XOR;
+        SFPU_UNARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_sfpu_unary_bitwise,
+            (APPROX, kOp, DataFormat::Int32, ITERATIONS),
+            dst_index,
+            VectorMode::RC,
+            parity_constants::kBitwiseValue);
+    }
+#endif
+#ifdef QSR_HAS_BITWISE_NOT
+    else if constexpr (OPERATION == SfpuType::bitwise_not)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_bitwise_not, (APPROX, ITERATIONS), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_CAST_FP32_TO_FP16A
+    else if constexpr (OPERATION == SfpuType::cast_fp32_to_fp16a)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, cast_fp32_to_fp16a, (APPROX, ITERATIONS), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_CBRT
+    else if constexpr (OPERATION == SfpuType::cbrt)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_cube_root, (APPROX, is_fp32_dest_acc_en, ITERATIONS), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_CELU
+    else if constexpr (OPERATION == SfpuType::celu)
+    {
+        SFPU_UNARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_celu,
+            (APPROX, is_fp32_dest_acc_en, ITERATIONS),
+            dst_index,
+            VectorMode::RC,
+            parity_constants::kOne,  // alpha = 1.0f
+            parity_constants::kOne); // 1/alpha = 1.0f
+    }
+#endif
+#ifdef QSR_HAS_DIGAMMA
+    else if constexpr (OPERATION == SfpuType::digamma)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_digamma, (APPROX, ITERATIONS), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_ELU
+    else if constexpr (OPERATION == SfpuType::elu)
+    {
+        SFPU_UNARY_CALL(
+            DST_SYNC, is_fp32_dest_acc_en, calculate_elu, (APPROX, is_fp32_dest_acc_en, ITERATIONS), dst_index, VectorMode::RC, parity_constants::kOne);
+    }
+#endif
+#ifdef QSR_HAS_ERF
+    else if constexpr (OPERATION == SfpuType::erf)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_erf, (APPROX, ITERATIONS), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_ERFC
+    else if constexpr (OPERATION == SfpuType::erfc)
+    {
+        // calculate_erfc takes ITERATIONS only; APPROX reaches it through erfc_init.
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_erfc, (ITERATIONS), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_ERFINV
+    else if constexpr (OPERATION == SfpuType::erfinv)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_erfinv, (APPROX), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_EXP2
+    else if constexpr (OPERATION == SfpuType::exp2)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_exp2, (APPROX, is_fp32_dest_acc_en, ITERATIONS), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_EXPM1
+    else if constexpr (OPERATION == SfpuType::expm1)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_expm1, (APPROX, is_fp32_dest_acc_en, ITERATIONS), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_FMOD
+    else if constexpr (OPERATION == SfpuType::fmod)
+    {
+        // Divisor comes from vConstFloatPrgm0/1, programmed by init_fmod.
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_fmod, (APPROX, ITERATIONS), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_HARDMISH
+    else if constexpr (OPERATION == SfpuType::hardmish)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, hardmish, (APPROX, ITERATIONS), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_HARDSHRINK
+    else if constexpr (OPERATION == SfpuType::hardshrink)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_hardshrink, (APPROX, ITERATIONS), dst_index, VectorMode::RC, parity_constants::kHalf);
+    }
+#endif
+#ifdef QSR_HAS_HARDTANH
+    else if constexpr (OPERATION == SfpuType::hardtanh)
+    {
+        // Bounds [-1, +1] encoded as bf16 half-words, matching the Blackhole dispatch.
+        SFPU_UNARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_hardtanh,
+            (APPROX, ITERATIONS),
+            dst_index,
+            VectorMode::RC,
+            parity_constants::kHardtanhP0,
+            parity_constants::kHardtanhP1,
+            parity_constants::kHardtanhP2);
+    }
+#endif
+#ifdef QSR_HAS_HEAVISIDE
+    else if constexpr (OPERATION == SfpuType::heaviside)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_heaviside, (APPROX, ITERATIONS), dst_index, VectorMode::RC, parity_constants::kHalf);
+    }
+#endif
+#ifdef QSR_HAS_I0
+    else if constexpr (OPERATION == SfpuType::i0)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_i0, (APPROX, ITERATIONS), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_I1
+    else if constexpr (OPERATION == SfpuType::i1)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_i1, (APPROX, ITERATIONS), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_IDENTITY
+    else if constexpr (OPERATION == SfpuType::identity)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_identity, (APPROX, ITERATIONS), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_LGAMMA
+    else if constexpr (OPERATION == SfpuType::lgamma)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_lgamma_stirling, (APPROX, is_fp32_dest_acc_en, ITERATIONS), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_LOGICAL_NOT
+    else if constexpr (OPERATION == SfpuType::logical_not_unary)
+    {
+        SFPU_UNARY_CALL(
+            DST_SYNC, is_fp32_dest_acc_en, calculate_logical_not, (APPROX, ckernel::InstrModLoadStore::LO16, ITERATIONS), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_POLYGAMMA
+    else if constexpr (OPERATION == SfpuType::polygamma)
+    {
+        // order n = 1 (trigamma); scale = (-1)^(n+1) * n! = 1.0f.
+        SFPU_UNARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_polygamma,
+            (APPROX, is_fp32_dest_acc_en, ITERATIONS),
+            dst_index,
+            VectorMode::RC,
+            parity_constants::kOne,
+            parity_constants::kOne);
+    }
+#endif
+#ifdef QSR_HAS_PRELU
+    else if constexpr (OPERATION == SfpuType::prelu)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_prelu, (APPROX, ITERATIONS), dst_index, VectorMode::RC, parity_constants::kQuarter);
+    }
+#endif
+#ifdef QSR_HAS_RDIV
+    else if constexpr (OPERATION == SfpuType::rdiv)
+    {
+        SFPU_UNARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_rdiv,
+            (APPROX, is_fp32_dest_acc_en, ckernel::RoundingMode::None, ITERATIONS),
+            dst_index,
+            VectorMode::RC,
+            parity_constants::kTwo);
+    }
+#endif
+#ifdef QSR_HAS_REMAINDER
+    else if constexpr (OPERATION == SfpuType::remainder)
+    {
+        // Divisor comes from vConstFloatPrgm0/1, programmed by init_remainder.
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_remainder, (APPROX, ITERATIONS), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_RPOW
+    else if constexpr (OPERATION == SfpuType::rpow)
+    {
+        SFPU_UNARY_CALL(
+            DST_SYNC, is_fp32_dest_acc_en, calculate_rpow, (APPROX, ITERATIONS, is_fp32_dest_acc_en), dst_index, VectorMode::RC, parity_constants::kTwo);
+    }
+#endif
+#ifdef QSR_HAS_SELU
+    else if constexpr (OPERATION == SfpuType::selu)
+    {
+        SFPU_UNARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_selu,
+            (APPROX, is_fp32_dest_acc_en, ITERATIONS),
+            dst_index,
+            VectorMode::RC,
+            parity_constants::kSeluScale,
+            parity_constants::kSeluAlpha);
+    }
+#endif
+#ifdef QSR_HAS_SIGN
+    else if constexpr (OPERATION == SfpuType::sign)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_sign, (APPROX, ITERATIONS), dst_index, VectorMode::RC, 0u /* exponent_size_8 */);
+    }
+#endif
+#ifdef QSR_HAS_SOFTSHRINK
+    else if constexpr (OPERATION == SfpuType::softshrink)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_softshrink, (APPROX, ITERATIONS), dst_index, VectorMode::RC, parity_constants::kHalf);
+    }
+#endif
+#ifdef QSR_HAS_SOFTSIGN
+    else if constexpr (OPERATION == SfpuType::softsign)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_softsign, (APPROX, ITERATIONS), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_TANHSHRINK
+    else if constexpr (OPERATION == SfpuType::tanhshrink)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_tanhshrink, (is_fp32_dest_acc_en, ITERATIONS), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_UNARY_COMP
+    else if constexpr (is_unary_comp_op(OPERATION))
+    {
+        call_unary_comp_operation_quasar<OPERATION, DST_SYNC, is_fp32_dest_acc_en, APPROX, ITERATIONS>(dst_index);
+    }
+#endif
+#ifdef QSR_HAS_UNARY_POWER
+    else if constexpr (OPERATION == SfpuType::power)
+    {
+        SFPU_UNARY_CALL(
+            DST_SYNC, is_fp32_dest_acc_en, calculate_unary_power, (APPROX, is_fp32_dest_acc_en, ITERATIONS), dst_index, VectorMode::RC, parity_constants::kTwo);
+    }
+#endif
+#ifdef QSR_HAS_UNARY_SHIFT
+    else if constexpr (OPERATION == SfpuType::left_shift)
+    {
+        SFPU_UNARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_left_shift,
+            (APPROX, DataFormat::Int32, ITERATIONS),
+            dst_index,
+            VectorMode::RC,
+            parity_constants::kShiftAmount);
+    }
+    else if constexpr (OPERATION == SfpuType::right_shift)
+    {
+        SFPU_UNARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_right_shift,
+            (APPROX, DataFormat::Int32, ITERATIONS),
+            dst_index,
+            VectorMode::RC,
+            parity_constants::kShiftAmount);
+    }
+#endif
+#ifdef QSR_HAS_XIELU
+    else if constexpr (OPERATION == SfpuType::xielu)
+    {
+        SFPU_UNARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_xielu,
+            (APPROX, is_fp32_dest_acc_en, ITERATIONS),
+            dst_index,
+            VectorMode::RC,
+            parity_constants::kOne,  // alpha_p = 1.0f
+            parity_constants::kOne); // alpha_n = 1.0f
+    }
+#endif
     else
     {
         static_assert(unhandled_op<OPERATION>, "call_unary_sfpu_operation_quasar: unhandled Quasar unary SFPU operation");
@@ -377,7 +1314,79 @@ void init_binary_sfpu_operation_quasar([[maybe_unused]] std::uint32_t zero_point
         // One op-templated quant kernel; DEQUANT's caller passes bits of -zero_point.
         quant_family_init<quant_variant_of<OP>(), SIGN_MAGNITUDE_FORMAT>(zero_point);
     }
-    // ADD / SUB / GT / LT / LE / GE are stateless — no init.
+    // ── SFPU parity set ──────────────────────────────────────────────────────────────
+#ifdef QSR_HAS_ATAN2
+    else if constexpr (OP == BinaryOp::ATAN2)
+    {
+        calculate_sfpu_atan2_init<false /*APPROX*/>();
+    }
+#endif
+#ifdef QSR_HAS_BINARY_FMOD
+    else if constexpr (OP == BinaryOp::FMOD)
+    {
+        fmod_binary_init<false /*APPROX*/>();
+    }
+    else if constexpr (OP == BinaryOp::FMOD_INT32)
+    {
+        fmod_int32_init<false /*APPROX*/>();
+    }
+#endif
+#ifdef QSR_HAS_BINARY_POW
+    else if constexpr (OP == BinaryOp::POW)
+    {
+        // POW rides the shared calculate_sfpu_binary dispatch (as on Blackhole); the
+        // gate is on the pow kernel header because that is what the parity set tracks.
+        sfpu_binary_init<false /*APPROX*/, BinaryOp::POW>();
+    }
+#endif
+#ifdef QSR_HAS_BINARY_REMAINDER
+    else if constexpr (OP == BinaryOp::REMAINDER)
+    {
+        remainder_binary_init<false /*APPROX*/, false /*legacy_compat*/>();
+    }
+    else if constexpr (OP == BinaryOp::REMAINDER_INT32)
+    {
+        remainder_int32_init<false /*APPROX*/>();
+    }
+    else if constexpr (OP == BinaryOp::REMAINDER_UINT32)
+    {
+        remainder_uint32_init<false /*APPROX*/>();
+    }
+#endif
+#ifdef QSR_HAS_DIV_INT32
+    else if constexpr (OP == BinaryOp::DIV_INT32)
+    {
+        // Truncating int32 division writes an int32 quotient, so it needs the
+        // reciprocal-polynomial constants from div_trunc_init rather than div_init's.
+        div_trunc_init<false /*APPROX*/>();
+    }
+#endif
+#ifdef QSR_HAS_DIV_INT32_FLOOR
+    else if constexpr (OP == BinaryOp::DIV_INT32_FLOOR)
+    {
+        div_floor_init<false /*APPROX*/>();
+    }
+#endif
+#ifdef QSR_HAS_ISCLOSE
+    else if constexpr (OP == BinaryOp::ISCLOSE)
+    {
+        isclose_init<false /*APPROX*/>();
+    }
+#endif
+#ifdef QSR_HAS_LOGSIGMOID
+    else if constexpr (OP == BinaryOp::LOGSIGMOID)
+    {
+        logsigmoid_init<false /*APPROX*/>();
+    }
+#endif
+#ifdef QSR_HAS_MASK
+    else if constexpr (OP == BinaryOp::MASK)
+    {
+        mask_init<false /*APPROX*/>();
+    }
+#endif
+    // ADD / SUB / GT / LT / LE / GE are stateless — no init. Among the parity ops, the
+    // bitwise family and RSUB_INT32 are likewise stateless.
 }
 
 /**
@@ -530,10 +1539,354 @@ void call_binary_sfpu_operation_quasar(std::uint32_t src0_tile, std::uint32_t sr
                 VectorMode::RC);
         }
     }
+    // ── SFPU parity set ──────────────────────────────────────────────────────────────
+#ifdef QSR_HAS_ATAN2
+    else if constexpr (OP == BinaryOp::ATAN2)
+    {
+        SFPU_BINARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_sfpu_atan2,
+            (false /*APPROX*/, ITERATIONS, is_fp32_dest_acc_en),
+            src0_tile,
+            src1_tile,
+            dst_tile,
+            VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_BINARY_BITWISE
+    else if constexpr (OP == BinaryOp::BITWISE_AND || OP == BinaryOp::BITWISE_OR || OP == BinaryOp::BITWISE_XOR)
+    {
+        // int32 bitwise AND/OR/XOR over the raw two's-complement patterns in Dest.
+        constexpr BinaryBitwiseOp kBw = (OP == BinaryOp::BITWISE_AND)  ? BinaryBitwiseOp::AND
+                                        : (OP == BinaryOp::BITWISE_OR) ? BinaryBitwiseOp::OR
+                                                                       : BinaryBitwiseOp::XOR;
+        SFPU_BINARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_sfpu_binary_bitwise,
+            (false /*APPROX*/, kBw, ckernel::InstrModLoadStore::INT32, ITERATIONS),
+            src0_tile,
+            src1_tile,
+            dst_tile,
+            VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_BINARY_FMOD
+    else if constexpr (OP == BinaryOp::FMOD)
+    {
+        SFPU_BINARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_sfpu_binary_fmod,
+            (false /*APPROX*/, ITERATIONS, is_fp32_dest_acc_en),
+            src0_tile,
+            src1_tile,
+            dst_tile,
+            VectorMode::RC);
+    }
+    else if constexpr (OP == BinaryOp::FMOD_INT32)
+    {
+        SFPU_BINARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_fmod_int32, (false /*APPROX*/, ITERATIONS), src0_tile, src1_tile, dst_tile, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_BINARY_POW
+    else if constexpr (OP == BinaryOp::POW)
+    {
+        SFPU_BINARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_sfpu_binary,
+            (false /*APPROX*/, BinaryOp::POW, is_fp32_dest_acc_en, dst_rounding_mode, ITERATIONS),
+            src0_tile,
+            src1_tile,
+            dst_tile,
+            VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_BINARY_REMAINDER
+    else if constexpr (OP == BinaryOp::REMAINDER)
+    {
+        SFPU_BINARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_sfpu_binary_remainder,
+            (false /*APPROX*/, ITERATIONS, is_fp32_dest_acc_en),
+            src0_tile,
+            src1_tile,
+            dst_tile,
+            VectorMode::RC);
+    }
+    else if constexpr (OP == BinaryOp::REMAINDER_INT32)
+    {
+        SFPU_BINARY_CALL(
+            DST_SYNC, is_fp32_dest_acc_en, calculate_remainder_int32, (false /*APPROX*/, ITERATIONS), src0_tile, src1_tile, dst_tile, VectorMode::RC);
+    }
+    else if constexpr (OP == BinaryOp::REMAINDER_UINT32)
+    {
+        SFPU_BINARY_CALL(
+            DST_SYNC, is_fp32_dest_acc_en, calculate_remainder_uint32, (false /*APPROX*/, ITERATIONS), src0_tile, src1_tile, dst_tile, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_DIV_INT32
+    else if constexpr (OP == BinaryOp::DIV_INT32)
+    {
+        SFPU_BINARY_CALL(
+            DST_SYNC, is_fp32_dest_acc_en, calculate_div_int32_trunc, (false /*APPROX*/, ITERATIONS), src0_tile, src1_tile, dst_tile, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_DIV_INT32_FLOOR
+    else if constexpr (OP == BinaryOp::DIV_INT32_FLOOR)
+    {
+        SFPU_BINARY_CALL(
+            DST_SYNC, is_fp32_dest_acc_en, calculate_div_int32_floor, (false /*APPROX*/, ITERATIONS), src0_tile, src1_tile, dst_tile, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_ISCLOSE
+    else if constexpr (OP == BinaryOp::ISCLOSE)
+    {
+        // out = (|a - b| <= atol + rtol * |b|) ? 1 : 0. rtol/atol are torch's defaults
+        // (1e-5 / 1e-8) as fp32 bit patterns, matching the Blackhole dispatch.
+        SFPU_BINARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_sfpu_isclose,
+            (false /*APPROX*/, ITERATIONS, false /*EQUAL_NAN*/),
+            src0_tile,
+            src1_tile,
+            dst_tile,
+            VectorMode::RC,
+            0x3727C5ACu,  // rtol = 1e-5f
+            0x322BCC77u); // atol = 1e-8f
+    }
+#endif
+#ifdef QSR_HAS_LOGSIGMOID
+    else if constexpr (OP == BinaryOp::LOGSIGMOID)
+    {
+        // logsigmoid(x) = -softplus(-x), with x at src0 and exp(-x) supplied at src1.
+        SFPU_BINARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_logsigmoid, (false /*APPROX*/, ITERATIONS), src0_tile, src1_tile, dst_tile, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_MASK
+    else if constexpr (OP == BinaryOp::MASK)
+    {
+        // out = (mask != 0) ? data : 0, with data at src0 and mask at src1.
+        SFPU_BINARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_mask_binary, (false /*APPROX*/, ITERATIONS), src0_tile, src1_tile, dst_tile, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_RSUB_INT32
+    else if constexpr (OP == BinaryOp::RSUB_INT32)
+    {
+        SFPU_BINARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_rsub_int,
+            (false /*APPROX*/, ckernel::InstrModLoadStore::INT32, ITERATIONS),
+            src0_tile,
+            src1_tile,
+            dst_tile,
+            VectorMode::RC);
+    }
+#endif
     else
     {
         static_assert(unhandled_op<OP>, "call_binary_sfpu_operation_quasar: unhandled Quasar binary SFPU operation");
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Ternary SFPU parity ops (addcmul / addcdiv / lerp / snake_beta)
+//
+// Quasar already carries the ternary plumbing that `where` uses --
+// llk_math_eltwise_ternary_sfpu_macros.h and _llk_math_eltwise_ternary_sfpu_init_ -- so
+// these four need only a dispatch of their own, not new infrastructure.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * @brief Whether OPERATION is one of the four ternary parity ops.
+ *
+ * @param op The SFPU operation type to classify.
+ */
+inline constexpr bool is_ternary_parity_op(SfpuType op)
+{
+    return op == SfpuType::addcmul || op == SfpuType::addcdiv || op == SfpuType::lerp || op == SfpuType::snake_beta;
+}
+
+/**
+ * @brief Run the per-operation init step for a Quasar ternary SFPU op.
+ *
+ * @tparam OPERATION The ternary SFPU op (compile-time `SfpuType` constant).
+ * @tparam APPROX Whether the reciprocal-based ops use the approximate path.
+ * @note Pair with @ref call_ternary_sfpu_operation_quasar for the calculate step.
+ */
+template <SfpuType OPERATION, bool APPROX = false>
+void init_ternary_sfpu_operation_quasar()
+{
+    // Global-namespace init; the `::` is required from inside namespace test_utils.
+    ::_llk_math_eltwise_ternary_sfpu_init_<OPERATION>();
+#ifdef QSR_HAS_ADDCDIV
+    if constexpr (OPERATION == SfpuType::addcdiv)
+    {
+        // addcdiv divides through sfpu_reciprocal, so it needs that polynomial loaded.
+        init_addcdiv<APPROX>();
+    }
+#endif
+#ifdef QSR_HAS_SNAKE_BETA
+    if constexpr (OPERATION == SfpuType::snake_beta)
+    {
+        snake_beta_init<APPROX>();
+    }
+#endif
+    // addcmul and lerp are stateless beyond the shared addrmod setup above.
+}
+
+/**
+ * @brief Apply a Quasar ternary SFPU op over three Dest operands into a result tile.
+ *
+ * @tparam OPERATION The ternary SFPU op (compile-time `SfpuType` constant).
+ * @tparam DST_SYNC Destination synchronization mode used for bounds checking.
+ * @tparam is_fp32_dest_acc_en Whether Dest is in FP32 mode.
+ * @tparam APPROX Whether the reciprocal-based ops use the approximate path.
+ * @tparam ITERATIONS Number of SFPU loop iterations.
+ * @param src0_tile,src1_tile,src2_tile Operand tile indices (a, b, c).
+ * @param dst_tile Result tile index.
+ * @param value_bits fp32 bit pattern of the addc scalar; ignored by lerp and snake_beta.
+ * @note Must be preceded by @ref init_ternary_sfpu_operation_quasar for the same op.
+ */
+template <SfpuType OPERATION, DstSync DST_SYNC, bool is_fp32_dest_acc_en, bool APPROX = false, int ITERATIONS = SFPU_ITERATIONS>
+void call_ternary_sfpu_operation_quasar(
+    [[maybe_unused]] std::uint32_t src0_tile,
+    [[maybe_unused]] std::uint32_t src1_tile,
+    [[maybe_unused]] std::uint32_t src2_tile,
+    [[maybe_unused]] std::uint32_t dst_tile,
+    [[maybe_unused]] std::uint32_t value_bits)
+{
+    static_assert(is_ternary_parity_op(OPERATION), "call_ternary_sfpu_operation_quasar: OPERATION must be a ternary parity SfpuType");
+
+#ifdef QSR_HAS_ADDCMUL
+    if constexpr (OPERATION == SfpuType::addcmul)
+    {
+        SFPU_TERNARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_addcmul,
+            (APPROX, is_fp32_dest_acc_en, ITERATIONS),
+            src0_tile,
+            src1_tile,
+            src2_tile,
+            dst_tile,
+            VectorMode::RC,
+            value_bits);
+    }
+#endif
+#ifdef QSR_HAS_ADDCDIV
+    if constexpr (OPERATION == SfpuType::addcdiv)
+    {
+        SFPU_TERNARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_addcdiv,
+            (APPROX, is_fp32_dest_acc_en, ITERATIONS),
+            src0_tile,
+            src1_tile,
+            src2_tile,
+            dst_tile,
+            VectorMode::RC,
+            value_bits);
+    }
+#endif
+#ifdef QSR_HAS_LERP
+    if constexpr (OPERATION == SfpuType::lerp)
+    {
+        SFPU_TERNARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_lerp,
+            (APPROX, is_fp32_dest_acc_en, ITERATIONS),
+            src0_tile,
+            src1_tile,
+            src2_tile,
+            dst_tile,
+            VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_SNAKE_BETA
+    if constexpr (OPERATION == SfpuType::snake_beta)
+    {
+        SFPU_TERNARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_snake_beta,
+            (APPROX, is_fp32_dest_acc_en, ITERATIONS),
+            src0_tile,
+            src1_tile,
+            src2_tile,
+            dst_tile,
+            VectorMode::RC);
+    }
+#endif
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tile-structural SFPU parity ops (tiled_prod / int_sum / alt_complex_rotate90)
+//
+// These address Dest by slot and combine slots with each other, so unlike every op above
+// they are not element-wise and cannot share the unary dispatch's per-element contract.
+// They take no operand beyond the tile itself. int_sum's two modes read slots in faces 1
+// and 2, so they must be dispatched once per tile (VectorMode::RC_custom) rather than once
+// per face; the other two stay inside their face.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * @brief Whether OPERATION is one of the tile-structural parity ops.
+ *
+ * @param op The SFPU operation type to classify.
+ */
+inline constexpr bool is_structural_parity_op(SfpuType op)
+{
+    return op == SfpuType::tiled_prod || op == SfpuType::sum_int_row || op == SfpuType::sum_int_col || op == SfpuType::alt_complex_rotate90;
+}
+
+/**
+ * @brief Apply a tile-structural SFPU op in-place on one Dest tile.
+ *
+ * @tparam OPERATION The structural SFPU op (compile-time `SfpuType` constant).
+ * @tparam DST_SYNC Destination synchronization mode used for bounds checking.
+ * @tparam is_fp32_dest_acc_en Whether Dest is in FP32 mode.
+ * @tparam ITERATIONS Number of SFPU loop iterations; the rotate kernel halves it because
+ *         it consumes two slots per step.
+ * @param dst_index Destination tile index operated on (already offset by DST_INDEX).
+ * @note Must be preceded by @ref init_unary_sfpu_operation_quasar for the same op, which
+ *       carries these ops' init steps.
+ */
+template <SfpuType OPERATION, DstSync DST_SYNC, bool is_fp32_dest_acc_en, int ITERATIONS = SFPU_ITERATIONS>
+void call_structural_sfpu_operation_quasar([[maybe_unused]] std::uint32_t dst_index)
+{
+    static_assert(is_structural_parity_op(OPERATION), "call_structural_sfpu_operation_quasar: OPERATION must be a structural parity SfpuType");
+
+#ifdef QSR_HAS_TILED_PROD
+    if constexpr (OPERATION == SfpuType::tiled_prod)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_tiled_prod, (false /*APPROX*/, ITERATIONS), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_INT_SUM
+    if constexpr (OPERATION == SfpuType::sum_int_row)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_sum_int_row, (false /*APPROX*/), dst_index, VectorMode::RC);
+    }
+    if constexpr (OPERATION == SfpuType::sum_int_col)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_sum_int_col, (false /*APPROX*/), dst_index, VectorMode::RC);
+    }
+#endif
+#ifdef QSR_HAS_ALT_COMPLEX_ROTATE90
+    if constexpr (OPERATION == SfpuType::alt_complex_rotate90)
+    {
+        // Consumes two slots per step, so it runs half as many iterations as the others.
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_alt_complex_rotate90, (false /*APPROX*/, ITERATIONS / 2), dst_index, VectorMode::RC);
+    }
+#endif
 }
 
 } // namespace test_utils

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -46,6 +46,7 @@ from helpers.sfpu_dispatch_constants import (
     SOFTSHRINK_LAMBDA,
     THRESHOLD_T,
     THRESHOLD_V,
+    UNARY_BITWISE_SCALAR,
     UNARY_COMP_THRESHOLD,
     UNARY_MAX_MIN_VALUE,
 )
@@ -2273,6 +2274,13 @@ class UnarySFPUGolden:
             MathOperation.UnaryMinInt32: self._unary_min_int32,
             MathOperation.UnaryMaxUint32: self._unary_max_int32,
             MathOperation.UnaryMinUint32: self._unary_min_int32,
+            # Unary bitwise against a fixed scalar, and bitwise complement. Both are
+            # exact int32 lane ops (calculate_sfpu_unary_bitwise / calculate_bitwise_not),
+            # so they join the integer path below rather than the float pipeline.
+            MathOperation.BitwiseAnd: self._bitwise_and_scalar,
+            MathOperation.BitwiseOr: self._bitwise_or_scalar,
+            MathOperation.BitwiseXor: self._bitwise_xor_scalar,
+            MathOperation.BitwiseNot: self._bitwise_not,
         }
         # Elementwise integer unary ops that use the dedicated exact-int path in
         # __call__. Only these ops are routed there; other integer-capable ops
@@ -2284,11 +2292,16 @@ class UnarySFPUGolden:
             MathOperation.UnaryMinInt32,
             MathOperation.UnaryMaxUint32,
             MathOperation.UnaryMinUint32,
+            MathOperation.BitwiseAnd,
+            MathOperation.BitwiseOr,
+            MathOperation.BitwiseXor,
+            MathOperation.BitwiseNot,
         }
         # Fixed dispatch constants shared with sfpu_operations.h: unary shift by 3
         # bits, integer unary max/min against the scalar 1000.
         self._int_shift_amount = 3
         self._int_maxmin_scalar = INT_MAXMIN_SCALAR
+        self._unary_bitwise_scalar = UNARY_BITWISE_SCALAR
         self.data_format = None
         # Precision the SFPU actually evaluates at, which is Dest's and not the output
         # format's. The per-element ops below read this rather than data_format: no
@@ -2819,6 +2832,29 @@ class UnarySFPUGolden:
     def _right_shift(self, x):
         # Arithmetic right shift by 3; Python >> on ints is arithmetic (sign-propagating).
         return int(x) >> self._int_shift_amount
+
+    def _to_int32(self, x):
+        """Wrap a Python int into the signed 32-bit range the SFPU lane holds.
+
+        Python ints are unbounded, so ~x and x | scalar would otherwise produce values no
+        int32 Dest lane can represent and the comparison against hardware would fail on
+        the golden's side rather than the kernel's.
+        """
+        return ((int(x) + 0x80000000) & 0xFFFFFFFF) - 0x80000000
+
+    def _bitwise_and_scalar(self, x):
+        # calculate_sfpu_unary_bitwise<UnaryBitwiseOp::AND>: v & scalar, per lane.
+        return self._to_int32(int(x) & self._unary_bitwise_scalar)
+
+    def _bitwise_or_scalar(self, x):
+        return self._to_int32(int(x) | self._unary_bitwise_scalar)
+
+    def _bitwise_xor_scalar(self, x):
+        return self._to_int32(int(x) ^ self._unary_bitwise_scalar)
+
+    def _bitwise_not(self, x):
+        # calculate_bitwise_not: ~v on the I32 layout.
+        return self._to_int32(~int(x))
 
     def _unary_max_int32(self, x):
         return max(int(x), self._int_maxmin_scalar)
@@ -4768,6 +4804,123 @@ class WhereGolden:
         cond = operand1.flatten().to(torch.float32)
         mask = cond != 0.0
         return torch.where(mask, true_value.flatten(), false_value.flatten())
+
+
+@register_golden
+class StructuralSFPUGolden:
+    """Golden for the tile-structural SFPU kernels: tiled_prod, int_sum, rotate90.
+
+    These are the only parity kernels that are not element-wise. They address Dest by
+    *slot* -- ``dst_reg[k]`` is one 32-lane SFPU vector -- and combine slots with each
+    other, so a per-element reference cannot express them. The model below is therefore
+    written in slot space and is the one place the Dest layout is spelled out:
+
+        * A 32x32 tile is 4 faces of 16x16, face-major, each face row-major.
+        * One slot is 32 consecutive datums, so a 16x16 face is 8 slots and a tile is 32.
+        * Slot ``k`` of face ``f`` is absolute slot ``8*f + k``.
+        * ``VectorMode::RC`` invokes the functor once per face; a kernel whose loop reaches
+          past slot 7 therefore reads or writes into the *next* face.
+
+    Provenance: derived from the Blackhole kernel sources, not from a passing test --
+    none of these three has a Blackhole tt-llk test, which is why they needed a golden
+    written from scratch. Until a Quasar kernel exists to run against, treat a mismatch
+    here as evidence about the golden as much as about the kernel.
+    """
+
+    #: Datums in one SFPU vector, and so in one Dest slot.
+    SLOT = 32
+    #: Slots in one 16x16 face.
+    SLOTS_PER_FACE = 8
+
+    def __call__(
+        self,
+        operation: MathOperation,
+        operand,
+        data_format: DataFormat,
+        num_faces: int = 4,
+    ):
+        slots = self._to_slots(operand, num_faces)
+
+        if operation == MathOperation.TiledProd:
+            out = self._tiled_prod(slots)
+        elif operation == MathOperation.IntSumRow:
+            out = self._sum_int_row(slots)
+        elif operation == MathOperation.IntSumCol:
+            out = self._sum_int_col(slots)
+        elif operation == MathOperation.AltComplexRotate90:
+            out = self._alt_complex_rotate90(slots)
+        else:
+            raise ValueError(f"Unsupported structural SFPU operation: {operation}")
+
+        return out.reshape(-1).to(format_dict[data_format])
+
+    def _to_slots(self, operand, num_faces: int):
+        """Reshape a flat tile into (num_faces, SLOTS_PER_FACE, SLOT)."""
+        flat = operand.flatten()
+        expected = num_faces * self.SLOTS_PER_FACE * self.SLOT
+        if flat.numel() != expected:
+            raise ValueError(
+                f"structural golden expects one {num_faces}-face tile "
+                f"({expected} elements), got {flat.numel()}"
+            )
+        return flat.reshape(num_faces, self.SLOTS_PER_FACE, self.SLOT)
+
+    def _tiled_prod(self, slots):
+        """Running product across the face: out[d] = prod(in[0..d]), per lane.
+
+        calculate_tiled_prod runs ITERATIONS=8 slots and then does one more unrolled
+        step at dst_reg[8] -- which is slot 0 of the *following* face. For faces 0..2
+        that write is immediately overwritten when the next face runs its own d=0 step,
+        and for the last face it lands outside the tile. Either way it is not observable
+        in the packed tile, so the reference models the in-face cumulative product only.
+        A kernel change that made the ninth write visible would show up here as a
+        mismatch on face 0's first slot, which is the behaviour worth catching.
+        """
+        return torch.cumprod(slots.to(torch.float32), dim=1)
+
+    def _sum_int_row(self, slots):
+        """calculate_sum_int_row: for i in {0,2,4,6}, dst[i] += dst[i+1] + dst[i+8] + dst[i+9].
+
+        The +8 / +9 terms reach slots in face 1, so this kernel spans two faces and must
+        be dispatched once per tile rather than once per face. Only the four even slots
+        of face 0 are written; everything else keeps its input value.
+        """
+        out = slots.clone().to(torch.int64)
+        flat = out.reshape(-1, self.SLOT)
+        for i in (0, 2, 4, 6):
+            flat[i] = flat[i] + flat[i + 1] + flat[i + 8] + flat[i + 9]
+        return flat.reshape(slots.shape)
+
+    def _sum_int_col(self, slots):
+        """calculate_sum_int_col: for i in {0,1}, sum slots i+{0,2,4,6} and i+{16,18,20,22}.
+
+        Reaches slots 16..23, i.e. face 2, so this also spans the whole tile. Only slots
+        0 and 1 are written.
+        """
+        out = slots.clone().to(torch.int64)
+        flat = out.reshape(-1, self.SLOT)
+        for i in (0, 1):
+            acc = flat[i].clone()
+            for j in (2, 4, 6):
+                acc = acc + flat[i + j]
+            for j in (16, 18, 20, 22):
+                acc = acc + flat[i + j]
+            flat[i] = acc
+        return flat.reshape(slots.shape)
+
+    def _alt_complex_rotate90(self, slots):
+        """Rotate interleaved (re, im) slot pairs: (a, b) -> (-b, a).
+
+        ITERATIONS=4 covers the four slot pairs of one face, so unlike the two above this
+        one stays inside its face.
+        """
+        out = slots.clone().to(torch.float32)
+        for k in range(0, self.SLOTS_PER_FACE, 2):
+            re = out[:, k].clone()
+            im = out[:, k + 1].clone()
+            out[:, k] = -im
+            out[:, k + 1] = re
+        return out
 
 
 @register_golden

--- a/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
@@ -225,6 +225,18 @@ class MathOperation(Enum):
     TopKLocalSort = OpSpec("topk_local_sort", MathOpType.SFPU_UNARY)
     TopKMerge = OpSpec("topk_merge", MathOpType.SFPU_UNARY)
     TopKRebuild = OpSpec("topk_rebuild", MathOpType.SFPU_UNARY)
+    # Unary bitwise against a compile-time scalar (ckernel_sfpu_bitwise.h). Distinct from
+    # the SfpuBitwise* BinaryOp entries below, which take two operand tiles.
+    BitwiseAnd = OpSpec("bitwise_and", MathOpType.SFPU_UNARY)
+    BitwiseOr = OpSpec("bitwise_or", MathOpType.SFPU_UNARY)
+    BitwiseXor = OpSpec("bitwise_xor", MathOpType.SFPU_UNARY)
+    # Tile-structural ops: these read or write across the whole tile rather than
+    # element-wise, so they run through the dedicated structural harness
+    # (test_sfpu_structural_quasar) and carry their own goldens.
+    TiledProd = OpSpec("tiled_prod", MathOpType.SFPU_UNARY)
+    AltComplexRotate90 = OpSpec("alt_complex_rotate90", MathOpType.SFPU_UNARY)
+    IntSumRow = OpSpec("sum_int_row", MathOpType.SFPU_UNARY)
+    IntSumCol = OpSpec("sum_int_col", MathOpType.SFPU_UNARY)
     # =============================================================================
     # SFPU BINARY OPERATIONS
     # =============================================================================

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_dispatch_constants.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_dispatch_constants.py
@@ -53,3 +53,25 @@ LRELU_NEGATIVE_SLOPE = 0.1
 
 # UnaryMax/MinInt32 and UnaryMax/MinUint32 compare against this scalar.
 INT_MAXMIN_SCALAR = 1000
+
+# Unary bitwise (calculate_sfpu_unary_bitwise) masks against this scalar. Chosen with bits
+# set in both halves of the word and neither all-ones nor a single bit, so AND, OR and XOR
+# each produce a value distinguishable from the input and from each other.
+UNARY_BITWISE_SCALAR = 0x0F0F0F0F
+
+# Unary left_shift / right_shift shift by this many bits.
+UNARY_SHIFT_AMOUNT = 3
+
+# Unary fmod / remainder divide by this fixed divisor.
+UNARY_MOD_DIVISOR = 2.0
+
+# heaviside(x) returns this when x == 0.
+HEAVISIDE_VALUE = 0.5
+
+# celu / elu negative-branch alpha.
+ELU_ALPHA = 1.0
+CELU_ALPHA = 1.0
+
+# selu's fixed scale and alpha (0x3f867d5f / 0x3fd62d7d as fp32 bit patterns).
+SELU_SCALE = 1.0507009873554805
+SELU_ALPHA = 1.6732632423543772

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -497,6 +497,58 @@ _OP_DOMAIN_REGISTRY: Dict[
     MathOperation.UnaryLe: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-2.0, high=2.0)
     ),
+    # UnaryNe / UnaryEq compare against the same 0.5 threshold as the four above. On
+    # Blackhole they are driven by a crafted-stimuli test rather than the registry sweep,
+    # so they had no domain; the Quasar sweep drives every parity op through the registry,
+    # which needs one. Equality against a threshold only produces a mix of 0/1 outputs if
+    # some stimuli land exactly on it, so _OP_EDGE_POINTS' probe at UNARY_COMP_THRESHOLD
+    # carries the interesting case and the domain just spans it.
+    MathOperation.UnaryNe: OperandSpecs(
+        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-2.0, high=2.0)
+    ),
+    MathOperation.UnaryEq: OperandSpecs(
+        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-2.0, high=2.0)
+    ),
+    # logical_not(x) = (x == 0) ? 1 : 0. Same reasoning as UnaryEq: the answer is only
+    # interesting at exactly zero, which the edge probe supplies; the domain spans it so
+    # the surrounding "not zero -> 0" case is covered densely.
+    MathOperation.LogicalNotUnary: OperandSpecs(
+        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-2.0, high=2.0)
+    ),
+    # Integer-domain parity ops. These run on the integer path (exact int32 lanes), so the
+    # bounds are chosen to keep the *result* representable rather than to explore a curve:
+    #   left_shift by 3 must not overflow int32, so cap the magnitude at 2^27;
+    #   right_shift and the bitwise ops are total on int32, so they span a wide band.
+    MathOperation.LeftShift: OperandSpecs(
+        spec_A=StimuliSpec(
+            distribution=DistributionKind.UNIFORM, low=-(2**27), high=2**27
+        )
+    ),
+    MathOperation.RightShift: OperandSpecs(
+        spec_A=StimuliSpec(
+            distribution=DistributionKind.UNIFORM, low=-(2**30), high=2**30
+        )
+    ),
+    MathOperation.BitwiseAnd: OperandSpecs(
+        spec_A=StimuliSpec(
+            distribution=DistributionKind.UNIFORM, low=-(2**30), high=2**30
+        )
+    ),
+    MathOperation.BitwiseOr: OperandSpecs(
+        spec_A=StimuliSpec(
+            distribution=DistributionKind.UNIFORM, low=-(2**30), high=2**30
+        )
+    ),
+    MathOperation.BitwiseXor: OperandSpecs(
+        spec_A=StimuliSpec(
+            distribution=DistributionKind.UNIFORM, low=-(2**30), high=2**30
+        )
+    ),
+    MathOperation.BitwiseNot: OperandSpecs(
+        spec_A=StimuliSpec(
+            distribution=DistributionKind.UNIFORM, low=-(2**30), high=2**30
+        )
+    ),
     # unary max/min against value 0.0; span both signs
     MathOperation.UnaryMax: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-5.0, high=5.0)
@@ -981,6 +1033,23 @@ _UNARY_OPS_NOT_SWEPT: Dict[MathOperation, str] = {
     MathOperation.TopKLocalSort: "perf-only; whole-op topk is covered by test_topk.py",
     MathOperation.TopKMerge: "perf-only; whole-op topk is covered by test_topk.py",
     MathOperation.TopKRebuild: "perf-only; whole-op topk is covered by test_topk.py",
+    # ── Registered for the Quasar SFPU parity sweep, exempt from the Blackhole one ──
+    #
+    # These ops needed a registry entry so helpers.sfpu_port_quasar's parity sweep can
+    # resolve a domain through for_op_pipeline, but Blackhole already covers them by
+    # other means and enrolling them in the standard profile would change what the
+    # Blackhole suite runs. Registration and sweeping are separate decisions here:
+    # sfpu_unary_ops() subtracts this table, so the domain is available to any caller
+    # that asks for it by name while the Blackhole sweep stays exactly as it was.
+    MathOperation.UnaryNe: "Blackhole covers it with crafted threshold-tie stimuli in test_sfpu_unary.py",
+    MathOperation.UnaryEq: "Blackhole covers it with crafted threshold-tie stimuli in test_sfpu_unary.py",
+    MathOperation.LogicalNotUnary: "Blackhole covers it with crafted exact-zero stimuli in test_sfpu_unary.py",
+    MathOperation.LeftShift: "integer op; Blackhole covers it through test_eltwise_unary_sfpu_int",
+    MathOperation.RightShift: "integer op; Blackhole covers it through test_eltwise_unary_sfpu_int",
+    MathOperation.BitwiseAnd: "integer op with no Blackhole test; float sweep cannot drive it",
+    MathOperation.BitwiseOr: "integer op with no Blackhole test; float sweep cannot drive it",
+    MathOperation.BitwiseXor: "integer op with no Blackhole test; float sweep cannot drive it",
+    MathOperation.BitwiseNot: "integer op with no Blackhole test; float sweep cannot drive it",
 }
 
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_port_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_port_quasar.py
@@ -1,0 +1,705 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Quasar SFPU port registry for the Blackhole SFPI parity set.
+
+The SFPU parity dashboard (``/api/sfpu-parity``) lists every distinct SFPU compute kernel
+per architecture. Filtering it to "implemented on Blackhole in pure ``sfpi::``" *and*
+"absent on Quasar" yields 57 kernels. This module is the single source of truth for that
+set: what each kernel provides, which header gates it, and whether it has landed on Quasar
+yet.
+
+Why a gate at all
+-----------------
+The tests for these 57 are written *before* the kernels are ported. A test cannot dispatch
+to a kernel that does not exist -- the C++ ``#include`` would not resolve -- so every test
+that drives a parity op filters its sweep through :func:`is_ported`. Today that yields zero
+collected variants and a green suite; the moment a kernel header lands in the Quasar tree,
+its full sweep activates with no test edit.
+
+The gate resolves against the filesystem rather than a hand-maintained flag, so nothing has
+to be flipped when a kernel lands. The C++ dispatcher gates the matching branch on
+``__has_include`` of the *same* header basename, which makes it structurally impossible for
+the Python and C++ sides to disagree about what is available.
+
+Header basenames, not paths
+---------------------------
+Ported Quasar SFPU kernels live in more than one tree -- ``hw/ckernels/quasar/metal/
+llk_api/llk_sfpu/`` (most), ``tt_llk_quasar/common/inc/sfpu/``, and
+``tt_llk_quasar/common/inc/experimental/`` -- and all three are on the compiler's include
+path as bare-name roots (see ``test_config.py``). Since there is no way to know which tree a
+future port will choose, entries record the *basename* and :func:`is_ported` searches every
+root. ``__has_include("ckernel_sfpu_erf.h")`` resolves the same way, so the gate is
+location-independent.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Dict, FrozenSet, Optional, Tuple
+
+from .llk_params import MathOperation
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Where a ported Quasar SFPU kernel may live
+# ─────────────────────────────────────────────────────────────────────────────
+
+# helpers/ -> python_tests/ -> tests/ -> tt-llk/
+_TT_LLK_ROOT = Path(__file__).resolve().parents[3]
+# tt-llk/ -> tt_metal/
+_TT_METAL_ROOT = _TT_LLK_ROOT.parent
+
+# Mirrors the Quasar include roots in test_config.py. Order is the compiler's search order,
+# so the first hit is the header the build would actually pick up.
+QUASAR_SFPU_HEADER_ROOTS: Tuple[Path, ...] = (
+    _TT_METAL_ROOT / "hw" / "ckernels" / "quasar" / "metal" / "llk_api" / "llk_sfpu",
+    _TT_LLK_ROOT / "tt_llk_quasar" / "common" / "inc" / "sfpu",
+    _TT_LLK_ROOT / "tt_llk_quasar" / "common" / "inc" / "experimental",
+)
+
+
+class Arity(Enum):
+    """Which Quasar test harness drives the kernel."""
+
+    UNARY = "unary"  # test_eltwise_unary_sfpu_quasar
+    BINARY = "binary"  # test_eltwise_binary_sfpu_quasar
+    TERNARY = "ternary"  # test_sfpu_ternary_quasar
+    STRUCTURAL = "structural"  # test_sfpu_structural_quasar (not element-wise)
+    HELPER = "helper"  # no entry point of its own; covered through its callers
+
+
+@dataclass(frozen=True)
+class PortEntry:
+    """One row of the parity set.
+
+    Attributes:
+        kernel: Dashboard kernel name. The header is always ``ckernel_sfpu_<kernel>.h``.
+        ops: The MathOperation values this kernel provides. Several kernels provide more
+            than one (``unary_comp`` provides six comparison modes, ``bitwise`` three).
+            Empty only for :attr:`Arity.HELPER` rows.
+        arity: Which harness drives it.
+        call: Calculate-step symbols the C++ dispatcher must reference. The drift-guard
+            test checks each one appears in the dispatcher once the header exists.
+        init: Init-step symbols, empty when the op is stateless.
+        has_approx: Whether ApproximationMode changes the result. Only true where the
+            Blackhole kernel actually branches on APPROXIMATION_MODE or forwards it into
+            ``sfpu_reciprocal`` -- carrying a template parameter it ignores does not count.
+            Ops with this set sweep both modes and so emit twice the variants.
+        int_formats: Whether the op operates on integer rather than float data, and so
+            sweeps the integer format set instead of the float one.
+        covered_by: HELPER rows only -- the ops whose stimuli exercise this header.
+        note: Free text carried into failure messages and review.
+    """
+
+    kernel: str
+    ops: Tuple[MathOperation, ...]
+    arity: Arity
+    call: Tuple[str, ...]
+    init: Tuple[str, ...] = ()
+    has_approx: bool = False
+    int_formats: bool = False
+    covered_by: Tuple[MathOperation, ...] = ()
+    note: str = ""
+
+    @property
+    def header(self) -> str:
+        """Header basename the gate resolves, and the spelling ``__has_include`` uses."""
+        return f"ckernel_sfpu_{self.kernel}.h"
+
+    @property
+    def guard_macro(self) -> str:
+        """The ``QSR_HAS_*`` macro the C++ dispatcher defines when the header resolves."""
+        return f"QSR_HAS_{self.kernel.upper()}"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The parity set: 57 kernels
+#
+# Rows are grouped by arity and alphabetical within a group, matching the dashboard.
+# `call` / `init` names are the Blackhole entry points; a Quasar port is expected to keep
+# them, and the drift guard reports it if one does not.
+# ─────────────────────────────────────────────────────────────────────────────
+
+_UNARY: Tuple[PortEntry, ...] = (
+    # `activations` is an op-templated kernel; Hardsigmoid is its only instantiation today.
+    PortEntry(
+        "activations",
+        (MathOperation.Hardsigmoid,),
+        Arity.UNARY,
+        call=("calculate_activation",),
+        init=("hardsigmoid_init",),
+        note="ActivationType-templated; Hardsigmoid is the only ActivationType implemented",
+    ),
+    PortEntry("add1", (MathOperation.Add1,), Arity.UNARY, call=("calculate_add1",)),
+    PortEntry(
+        "bitwise",
+        (MathOperation.BitwiseAnd, MathOperation.BitwiseOr, MathOperation.BitwiseXor),
+        Arity.UNARY,
+        call=("calculate_sfpu_unary_bitwise",),
+        init=("bitwise_and_init", "bitwise_or_init", "bitwise_xor_init"),
+        int_formats=True,
+        note="unary bitwise against a compile-time scalar; distinct from binary_bitwise",
+    ),
+    PortEntry(
+        "bitwise_not",
+        (MathOperation.BitwiseNot,),
+        Arity.UNARY,
+        call=("calculate_bitwise_not",),
+        init=("bitwise_not_init",),
+        int_formats=True,
+    ),
+    PortEntry(
+        "cast_fp32_to_fp16a",
+        (MathOperation.CastFp32ToFp16a,),
+        Arity.UNARY,
+        call=("cast_fp32_to_fp16a",),
+    ),
+    PortEntry(
+        "cbrt",
+        (MathOperation.Cbrt,),
+        Arity.UNARY,
+        call=("calculate_cube_root",),
+        init=("cube_root_init",),
+    ),
+    PortEntry(
+        "celu",
+        (MathOperation.Celu,),
+        Arity.UNARY,
+        call=("calculate_celu",),
+        init=("celu_init",),
+    ),
+    PortEntry(
+        "digamma",
+        (MathOperation.Digamma,),
+        Arity.UNARY,
+        call=("calculate_digamma",),
+        init=("digamma_init",),
+    ),
+    PortEntry(
+        "elu",
+        (MathOperation.Elu,),
+        Arity.UNARY,
+        call=("calculate_elu",),
+        init=("elu_init",),
+    ),
+    PortEntry(
+        "erf",
+        (MathOperation.Erf,),
+        Arity.UNARY,
+        call=("calculate_erf",),
+        init=("erf_init",),
+        has_approx=True,
+        note="APPROX feeds sfpu_reciprocal's NR iteration count",
+    ),
+    PortEntry(
+        "erfc",
+        (MathOperation.Erfc,),
+        Arity.UNARY,
+        call=("calculate_erfc",),
+        init=("erfc_init",),
+    ),
+    PortEntry(
+        "erfinv",
+        (MathOperation.Erfinv,),
+        Arity.UNARY,
+        call=("calculate_erfinv",),
+        init=("erfinv_init",),
+    ),
+    PortEntry(
+        "exp2",
+        (MathOperation.Exp2,),
+        Arity.UNARY,
+        call=("calculate_exp2",),
+        init=("exp2_init",),
+    ),
+    PortEntry(
+        "expm1",
+        (MathOperation.Expm1,),
+        Arity.UNARY,
+        call=("calculate_expm1",),
+        init=("expm1_init",),
+    ),
+    PortEntry(
+        "fmod",
+        (MathOperation.Fmod,),
+        Arity.UNARY,
+        call=("calculate_fmod",),
+        init=("init_fmod",),
+        note="unary fmod against a fixed divisor (2.0f); binary_fmod takes two tiles",
+    ),
+    PortEntry(
+        "hardmish",
+        (MathOperation.Hardmish,),
+        Arity.UNARY,
+        call=("hardmish",),
+        init=("hardmish_init",),
+    ),
+    PortEntry(
+        "hardshrink",
+        (MathOperation.Hardshrink,),
+        Arity.UNARY,
+        call=("calculate_hardshrink",),
+        init=("hardshrink_init",),
+    ),
+    PortEntry(
+        "hardtanh",
+        (MathOperation.Hardtanh,),
+        Arity.UNARY,
+        call=("calculate_hardtanh",),
+        init=("hardtanh_init",),
+    ),
+    PortEntry(
+        "heaviside",
+        (MathOperation.Heaviside,),
+        Arity.UNARY,
+        call=("calculate_heaviside",),
+        init=("heaviside_init",),
+    ),
+    PortEntry(
+        "i0",
+        (MathOperation.I0,),
+        Arity.UNARY,
+        call=("calculate_i0",),
+        init=("i0_init",),
+    ),
+    PortEntry(
+        "i1",
+        (MathOperation.I1,),
+        Arity.UNARY,
+        call=("calculate_i1",),
+        init=("i1_init",),
+        has_approx=True,
+        note="APPROX feeds sfpu_reciprocal's NR iteration count",
+    ),
+    PortEntry(
+        "identity",
+        (MathOperation.Identity,),
+        Arity.UNARY,
+        call=("calculate_identity", "calculate_identity_uint"),
+        note="float and unsigned-integer entry points; the harness picks by format",
+    ),
+    PortEntry(
+        "lgamma",
+        (MathOperation.Lgamma,),
+        Arity.UNARY,
+        call=("calculate_lgamma_stirling",),
+        init=("lgamma_stirling_init",),
+    ),
+    PortEntry(
+        "logical_not",
+        (MathOperation.LogicalNotUnary,),
+        Arity.UNARY,
+        call=("calculate_logical_not",),
+        init=("logical_not_unary_init",),
+    ),
+    PortEntry(
+        "polygamma",
+        (MathOperation.Polygamma,),
+        Arity.UNARY,
+        call=("calculate_polygamma",),
+        init=("polygamma_init",),
+        has_approx=True,
+        note="APPROX selects the RECIP mode constant",
+    ),
+    PortEntry(
+        "prelu",
+        (MathOperation.Prelu,),
+        Arity.UNARY,
+        call=("calculate_prelu",),
+        init=("prelu_init",),
+    ),
+    PortEntry(
+        "rdiv",
+        (MathOperation.Rdiv,),
+        Arity.UNARY,
+        call=("calculate_rdiv",),
+        init=("rdiv_init",),
+        has_approx=True,
+        note="the only parity kernel with a literal if constexpr (APPROXIMATION_MODE) branch",
+    ),
+    PortEntry(
+        "remainder",
+        (MathOperation.Remainder,),
+        Arity.UNARY,
+        call=("calculate_remainder",),
+        init=("init_remainder",),
+        note="unary remainder against a fixed divisor (2.0f)",
+    ),
+    PortEntry(
+        "rpow",
+        (MathOperation.Rpow,),
+        Arity.UNARY,
+        call=("calculate_rpow",),
+        init=("sfpu_binary_pow_init",),
+    ),
+    PortEntry(
+        "selu",
+        (MathOperation.Selu,),
+        Arity.UNARY,
+        call=("calculate_selu",),
+        init=("selu_init",),
+    ),
+    PortEntry(
+        "sign",
+        (MathOperation.Sign,),
+        Arity.UNARY,
+        call=("calculate_sign",),
+        init=("sign_init",),
+    ),
+    PortEntry(
+        "softshrink",
+        (MathOperation.Softshrink,),
+        Arity.UNARY,
+        call=("calculate_softshrink",),
+        init=("softshrink_init",),
+    ),
+    PortEntry(
+        "softsign",
+        (MathOperation.Softsign,),
+        Arity.UNARY,
+        call=("calculate_softsign",),
+        init=("init_softsign",),
+        has_approx=True,
+        note="APPROX feeds sfpu_reciprocal's NR iteration count",
+    ),
+    PortEntry(
+        "tanhshrink",
+        (MathOperation.Tanhshrink,),
+        Arity.UNARY,
+        call=("calculate_tanhshrink",),
+        init=("tanhshrink_init",),
+    ),
+    PortEntry(
+        "unary_comp",
+        (
+            MathOperation.UnaryGt,
+            MathOperation.UnaryLt,
+            MathOperation.UnaryGe,
+            MathOperation.UnaryLe,
+            MathOperation.UnaryNe,
+            MathOperation.UnaryEq,
+        ),
+        Arity.UNARY,
+        call=(
+            "calculate_unary_gt",
+            "calculate_unary_lt",
+            "calculate_unary_ge",
+            "calculate_unary_le",
+            "calculate_unary_ne",
+            "calculate_unary_eq",
+        ),
+        init=(
+            "unary_gt_init",
+            "unary_lt_init",
+            "unary_ge_init",
+            "unary_le_init",
+            "unary_ne_init",
+            "unary_eq_init",
+        ),
+        note="compare against a fixed scalar (UNARY_COMP_THRESHOLD = 0.5)",
+    ),
+    PortEntry(
+        "unary_power",
+        (MathOperation.UnaryPower,),
+        Arity.UNARY,
+        call=("calculate_unary_power",),
+        init=("sfpu_unary_pow_init",),
+        note="carries _float_to_int32_positive_ coverage for the conversions helper",
+    ),
+    PortEntry(
+        "unary_shift",
+        (MathOperation.LeftShift, MathOperation.RightShift),
+        Arity.UNARY,
+        call=("calculate_left_shift", "calculate_right_shift"),
+        init=("left_shift_init", "right_shift_init"),
+        int_formats=True,
+    ),
+    PortEntry(
+        "xielu",
+        (MathOperation.Xielu,),
+        Arity.UNARY,
+        call=("calculate_xielu",),
+        init=("xielu_init",),
+    ),
+)
+
+_BINARY: Tuple[PortEntry, ...] = (
+    PortEntry(
+        "atan2",
+        (MathOperation.SfpuAtan2,),
+        Arity.BINARY,
+        call=("calculate_sfpu_atan2",),
+        init=("calculate_sfpu_atan2_init",),
+    ),
+    PortEntry(
+        "binary_bitwise",
+        (
+            MathOperation.SfpuBitwiseAnd,
+            MathOperation.SfpuBitwiseOr,
+            MathOperation.SfpuBitwiseXor,
+        ),
+        Arity.BINARY,
+        call=("calculate_sfpu_binary_bitwise",),
+        int_formats=True,
+    ),
+    PortEntry(
+        "binary_fmod",
+        (MathOperation.SfpuBinaryFmod, MathOperation.SfpuFmodInt32),
+        Arity.BINARY,
+        call=("calculate_sfpu_binary_fmod", "calculate_fmod_int32"),
+        init=("fmod_binary_init", "fmod_int32_init"),
+        has_approx=True,
+        note="APPROX reaches the shared div_floor_init",
+    ),
+    PortEntry(
+        "binary_pow",
+        (MathOperation.SfpuElwpow,),
+        Arity.BINARY,
+        call=("calculate_sfpu_binary_pow",),
+        init=("sfpu_binary_pow_init",),
+        note="carries _float_to_int32_positive_ coverage for the conversions helper",
+    ),
+    PortEntry(
+        "binary_remainder",
+        (
+            MathOperation.SfpuBinaryRemainder,
+            MathOperation.SfpuRemainderInt32,
+            MathOperation.SfpuRemainderUint32,
+        ),
+        Arity.BINARY,
+        call=(
+            "calculate_sfpu_binary_remainder",
+            "calculate_remainder_int32",
+            "calculate_remainder_uint32",
+        ),
+        init=("remainder_binary_init", "remainder_int32_init", "remainder_uint32_init"),
+        has_approx=True,
+        note="APPROX reaches the shared div_floor_init",
+    ),
+    PortEntry(
+        "div_int32",
+        (MathOperation.SfpuDivInt32,),
+        Arity.BINARY,
+        call=("calculate_div_int32",),
+        init=("div_init",),
+        int_formats=True,
+    ),
+    PortEntry(
+        "div_int32_floor",
+        (MathOperation.SfpuDivInt32Floor,),
+        Arity.BINARY,
+        call=("calculate_div_int32_floor", "calculate_div_int32_trunc"),
+        init=("div_floor_init", "div_trunc_init"),
+        has_approx=True,
+        int_formats=True,
+    ),
+    PortEntry(
+        "isclose",
+        (MathOperation.SfpuIsclose,),
+        Arity.BINARY,
+        call=("calculate_sfpu_isclose",),
+        init=("isclose_init",),
+    ),
+    PortEntry(
+        "logsigmoid",
+        (MathOperation.SfpuLogsigmoid,),
+        Arity.BINARY,
+        call=("calculate_logsigmoid",),
+        init=("logsigmoid_init",),
+        note="registered as a BinaryOp on Blackhole even though the math is unary",
+    ),
+    PortEntry(
+        "mask",
+        (MathOperation.SfpuMask,),
+        Arity.BINARY,
+        call=("calculate_mask", "calculate_int_mask", "calculate_mask_posinf"),
+        init=("mask_init",),
+    ),
+    PortEntry(
+        "rsub_int32",
+        (MathOperation.SfpuRsubInt32,),
+        Arity.BINARY,
+        call=("calculate_rsub_int",),
+        int_formats=True,
+    ),
+)
+
+_TERNARY: Tuple[PortEntry, ...] = (
+    PortEntry(
+        "addcdiv",
+        (MathOperation.SfpuAddcdiv,),
+        Arity.TERNARY,
+        call=("calculate_addcdiv",),
+        init=("init_addcdiv",),
+        has_approx=True,
+        note="uses sfpu_reciprocal internally; carries float32_to_bf16_rne coverage",
+    ),
+    PortEntry(
+        "addcmul",
+        (MathOperation.SfpuAddcmul,),
+        Arity.TERNARY,
+        call=("calculate_addcmul",),
+    ),
+    PortEntry(
+        "lerp",
+        (MathOperation.SfpuLerp,),
+        Arity.TERNARY,
+        call=("calculate_lerp",),
+        note="carries float32_to_bf16_rne coverage for the conversions helper",
+    ),
+    PortEntry(
+        "snake_beta",
+        (MathOperation.SfpuSnakeBeta,),
+        Arity.TERNARY,
+        call=("calculate_snake_beta",),
+        init=("snake_beta_init",),
+    ),
+)
+
+_STRUCTURAL: Tuple[PortEntry, ...] = (
+    PortEntry(
+        "alt_complex_rotate90",
+        (MathOperation.AltComplexRotate90,),
+        Arity.STRUCTURAL,
+        call=("calculate_alt_complex_rotate90",),
+        init=("alt_complex_rotate90_init",),
+        note="rotates interleaved (re, im) pairs; reads a neighbouring lane, not element-wise",
+    ),
+    PortEntry(
+        "int_sum",
+        (MathOperation.IntSumRow, MathOperation.IntSumCol),
+        Arity.STRUCTURAL,
+        call=("calculate_sum_int_row", "calculate_sum_int_col"),
+        init=("sum_int_init",),
+        int_formats=True,
+        note="reduction along a tile axis",
+    ),
+    PortEntry(
+        "tiled_prod",
+        (MathOperation.TiledProd,),
+        Arity.STRUCTURAL,
+        call=("calculate_tiled_prod",),
+        init=("tiled_prod_init",),
+        note="running product across the tile",
+    ),
+)
+
+_HELPER: Tuple[PortEntry, ...] = (
+    # ckernel_sfpu_conversions.h holds exactly two sfpi helpers and no entry point of its
+    # own, so it has no test of its own either. Its callers -- all of them inside the
+    # parity set -- carry targeted stimuli that drive both helpers; see the
+    # CONVERSIONS_COVERAGE table below for what each contributes.
+    PortEntry(
+        "conversions",
+        (),
+        Arity.HELPER,
+        call=("_float_to_int32_positive_", "float32_to_bf16_rne"),
+        covered_by=(
+            MathOperation.UnaryPower,
+            MathOperation.SfpuElwpow,
+            MathOperation.SfpuLerp,
+            MathOperation.SfpuAddcdiv,
+        ),
+        note="helper-only header: no dispatchable entry point",
+    ),
+)
+
+QUASAR_SFPU_PARITY: Tuple[PortEntry, ...] = (
+    _UNARY + _BINARY + _TERNARY + _STRUCTURAL + _HELPER
+)
+
+# What each carrier op must inject so the conversions helpers are genuinely exercised
+# rather than merely reachable. Consumed by the harnesses to seed extra stimuli, and by
+# the drift guard to check the claim is still backed by a live op.
+CONVERSIONS_COVERAGE: Dict[MathOperation, str] = {
+    MathOperation.UnaryPower: "_float_to_int32_positive_ -- integer-valued and near-half exponents",
+    MathOperation.SfpuElwpow: "_float_to_int32_positive_ -- integer-valued and near-half exponents",
+    MathOperation.SfpuLerp: "float32_to_bf16_rne -- round-nearest-even ties at a Float16_b output",
+    MathOperation.SfpuAddcdiv: "float32_to_bf16_rne -- round-nearest-even ties at a Float16_b output",
+}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Derived lookups
+# ─────────────────────────────────────────────────────────────────────────────
+
+_ENTRY_BY_OP: Dict[MathOperation, PortEntry] = {
+    op: entry for entry in QUASAR_SFPU_PARITY for op in entry.ops
+}
+
+_ENTRY_BY_KERNEL: Dict[str, PortEntry] = {e.kernel: e for e in QUASAR_SFPU_PARITY}
+
+
+def entry_for(op: MathOperation) -> Optional[PortEntry]:
+    """The parity entry providing *op*, or None when *op* is not in the parity set."""
+    return _ENTRY_BY_OP.get(op)
+
+
+def entry_for_kernel(kernel: str) -> Optional[PortEntry]:
+    """The parity entry for a dashboard kernel name, or None."""
+    return _ENTRY_BY_KERNEL.get(kernel)
+
+
+def resolve_header(entry: PortEntry) -> Optional[Path]:
+    """Where *entry*'s header actually is, searching the include roots in compiler order.
+
+    Returns None when the kernel has not been ported to Quasar yet.
+    """
+    for root in QUASAR_SFPU_HEADER_ROOTS:
+        candidate = root / entry.header
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def is_ported(op: MathOperation) -> bool:
+    """Whether the Quasar kernel providing *op* exists in the tree.
+
+    Ops outside the parity set are reported as ported: they are not gated by this module,
+    and answering False would silently drop sweeps that already run today.
+    """
+    entry = entry_for(op)
+    if entry is None:
+        return True
+    return resolve_header(entry) is not None
+
+
+def ported_ops() -> FrozenSet[MathOperation]:
+    """Every parity op whose Quasar kernel is present."""
+    return frozenset(op for op in _ENTRY_BY_OP if is_ported(op))
+
+
+def unported_ops() -> FrozenSet[MathOperation]:
+    """Every parity op still waiting on its Quasar kernel."""
+    return frozenset(op for op in _ENTRY_BY_OP if not is_ported(op))
+
+
+def parity_ops(arity: Optional[Arity] = None) -> FrozenSet[MathOperation]:
+    """Every parity op, optionally restricted to one harness."""
+    return frozenset(
+        op
+        for entry in QUASAR_SFPU_PARITY
+        if arity is None or entry.arity is arity
+        for op in entry.ops
+    )
+
+
+def entries(arity: Optional[Arity] = None) -> Tuple[PortEntry, ...]:
+    """Parity entries, optionally restricted to one harness."""
+    if arity is None:
+        return QUASAR_SFPU_PARITY
+    return tuple(e for e in QUASAR_SFPU_PARITY if e.arity is arity)
+
+
+def port_status_summary() -> str:
+    """One line per unported kernel, for a skip reason or a failure message."""
+    missing = sorted(
+        e.kernel for e in QUASAR_SFPU_PARITY if e.ops and resolve_header(e) is None
+    )
+    if not missing:
+        return "all parity kernels ported"
+    return (
+        f"{len(missing)} parity kernels not yet ported to Quasar: {', '.join(missing)}"
+    )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_sfpu_quasar.py
@@ -31,6 +31,7 @@ from helpers.param_config import (
     runtime,
 )
 from helpers.perf.core import create_test_or_perf_config
+from helpers.sfpu_port_quasar import Arity, entries, is_ported
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import (
     StimuliSpec,
@@ -958,3 +959,211 @@ def test_eltwise_binary_sfpu_quant_quasar(binary_op, sign_magnitude, tile_indice
     (dequant). Exercised on both the 2's-complement and SIGN_MAGNITUDE_FORMAT
     (SMAG32) datapaths."""
     _run_quant(binary_op, tile_indices, sign_magnitude)
+
+
+# ===========================================================================
+# Family 5 — the SFPU parity set (binary half)
+#
+# The Blackhole binary kernels written in pure sfpi:: that Quasar has not received yet.
+# The op list is generated from helpers/sfpu_port_quasar.py and every op is filtered
+# through is_ported(), so until a kernel header lands the family contributes no variants
+# and the suite stays green. Nothing here needs editing when a port arrives.
+#
+# Stimuli live in the local table below rather than in sfpu_domains: this file already
+# owns its per-family stimuli (_prepare_int_stimuli, _prepare_float_inputs), and the
+# shared registry's OperandSpecs carries only spec_A/spec_B for the *unary* sweep --
+# registering binary ops there would also enrol them in the Blackhole unary sweep, which
+# this work is not meant to change.
+# ===========================================================================
+
+# Per-op operand domains, as (low_A, high_A, low_B, high_B). Chosen so the *result* is
+# representable and the kernel's own preconditions hold, not to explore a curve:
+#   binary_pow  -- base > 0, because the implementation is exp(b * log(a));
+#   fmod / remainder / div -- divisor bounded away from zero;
+#   isclose     -- both operands over the same narrow band, so the tolerance compare
+#                  produces a mix of 0 and 1 rather than a constant;
+#   mask        -- operand B spans zero, since it is the mask and only its zero-ness matters.
+_PARITY_BINARY_FLOAT_DOMAINS = {
+    MathOperation.SfpuAtan2: (-8.0, 8.0, -8.0, 8.0),
+    MathOperation.SfpuElwpow: (0.25, 8.0, -3.0, 3.0),
+    MathOperation.SfpuBinaryFmod: (-64.0, 64.0, 0.5, 8.0),
+    MathOperation.SfpuBinaryRemainder: (-64.0, 64.0, 0.5, 8.0),
+    MathOperation.SfpuIsclose: (-2.0, 2.0, -2.0, 2.0),
+    MathOperation.SfpuLogsigmoid: (-8.0, 8.0, -8.0, 8.0),
+    MathOperation.SfpuMask: (-8.0, 8.0, -1.0, 1.0),
+}
+
+# Integer parity ops. Bounds keep products and quotients inside int32 and keep divisors
+# away from zero; the div/rem families would otherwise trap on a zero divisor.
+_PARITY_BINARY_INT_DOMAINS = {
+    MathOperation.SfpuBitwiseAnd: (-(2**30), 2**30, -(2**30), 2**30),
+    MathOperation.SfpuBitwiseOr: (-(2**30), 2**30, -(2**30), 2**30),
+    MathOperation.SfpuBitwiseXor: (-(2**30), 2**30, -(2**30), 2**30),
+    MathOperation.SfpuFmodInt32: (-(2**20), 2**20, 1, 2**10),
+    MathOperation.SfpuRemainderInt32: (-(2**20), 2**20, 1, 2**10),
+    MathOperation.SfpuRemainderUint32: (0, 2**20, 1, 2**10),
+    MathOperation.SfpuDivInt32: (-(2**20), 2**20, 1, 2**10),
+    MathOperation.SfpuDivInt32Floor: (-(2**20), 2**20, 1, 2**10),
+    MathOperation.SfpuRsubInt32: (-(2**20), 2**20, -(2**20), 2**20),
+}
+
+
+def _parity_binary_domain(mathop):
+    """The (low_A, high_A, low_B, high_B) band for a parity op, and whether it is integer."""
+    if mathop in _PARITY_BINARY_INT_DOMAINS:
+        return _PARITY_BINARY_INT_DOMAINS[mathop], True
+    return _PARITY_BINARY_FLOAT_DOMAINS[mathop], False
+
+
+def _prepare_parity_binary_stimuli(
+    formats, input_dimensions, src0_idx, src1_idx, mathop
+):
+    """Stage both operands of a parity op into src_A at their tile indices.
+
+    Mirrors _prepare_int_stimuli / _prepare_float_stimuli: the shared driver expects both
+    operands inside src_A, one per tile index, because the Quasar binary path unpacks
+    straight to Dest.
+    """
+    (lo_a, hi_a, lo_b, hi_b), _is_int = _parity_binary_domain(mathop)
+
+    src_A, tile_cnt_A, src_B, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+        spec_A=StimuliSpec.uniform(low=0.0, high=1.0),
+        spec_B=StimuliSpec.uniform(low=0.0, high=1.0),
+    )
+
+    torch_format = format_dict[formats.input_format]
+    unit = src_A.to(torch.float32)
+    flat = unit.flatten().clone()
+
+    a_start = src0_idx * MAX_TILE_ELEMENTS
+    b_start = src1_idx * MAX_TILE_ELEMENTS
+    flat[a_start : a_start + MAX_TILE_ELEMENTS] = lo_a + flat[
+        a_start : a_start + MAX_TILE_ELEMENTS
+    ] * (hi_a - lo_a)
+    flat[b_start : b_start + MAX_TILE_ELEMENTS] = lo_b + flat[
+        b_start : b_start + MAX_TILE_ELEMENTS
+    ] * (hi_b - lo_b)
+
+    if _is_int:
+        flat = flat.round()
+        # A zero divisor is undefined for the div / fmod / remainder families, and the
+        # rounding above can land on one even though the band starts at 1.
+        if mathop in (
+            MathOperation.SfpuFmodInt32,
+            MathOperation.SfpuRemainderInt32,
+            MathOperation.SfpuRemainderUint32,
+            MathOperation.SfpuDivInt32,
+            MathOperation.SfpuDivInt32Floor,
+        ):
+            divisor = flat[b_start : b_start + MAX_TILE_ELEMENTS]
+            flat[b_start : b_start + MAX_TILE_ELEMENTS] = torch.where(
+                divisor == 0, torch.ones_like(divisor), divisor
+            )
+    elif mathop == MathOperation.SfpuLogsigmoid:
+        # logsigmoid(x) = -softplus(-x) with x at src0 and exp(-x) expected at src1, so
+        # operand B is not free: it is derived from A. Passing an independent random tile
+        # would test an identity the kernel never computes.
+        x = flat[a_start : a_start + MAX_TILE_ELEMENTS]
+        flat[b_start : b_start + MAX_TILE_ELEMENTS] = torch.exp(-x)
+    elif mathop == MathOperation.SfpuElwpow:
+        # binary_pow reaches _float_to_int32_positive_ from ckernel_sfpu_conversions.h,
+        # which has no kernel of its own and is covered through its callers (see
+        # CONVERSIONS_COVERAGE in helpers/sfpu_port_quasar.py). Seed integer-valued and
+        # near-half exponents so the float-to-int rounding boundary is crossed in both
+        # directions rather than being reached only by chance.
+        exps = flat[b_start : b_start + MAX_TILE_ELEMENTS]
+        seeds = [
+            0.0,
+            1.0,
+            2.0,
+            3.0,
+            -1.0,
+            -2.0,
+            0.5,
+            1.5,
+            2.5,
+            -0.5,
+            1.4999999,
+            1.5000001,
+        ]
+        for lane, value in enumerate(seeds):
+            if lane < exps.numel():
+                exps[lane] = value
+
+    src_A = flat.reshape(unit.shape).to(torch_format)
+    return src_A, tile_cnt_A, src_B
+
+
+def _parity_binary_formats_dest_acc(is_int: bool):
+    """Format x dest_acc matrix for a parity op, filtered for Quasar."""
+    if is_int:
+        # The integer kernels declare the I32 Dest layout only, which forces a 32-bit dest.
+        return [
+            (fmt, DestAccumulation.Yes)
+            for fmt in input_output_formats([DataFormat.Int32], same=True)
+        ]
+    return _get_valid_float_formats_dest_acc()
+
+
+def _parity_binary_cases():
+    """(binary_op, mathop, formats, dest_acc) for every ported binary parity op.
+
+    Empty while the parity kernels are unported, which is the normal state today.
+    """
+    cases = []
+    for entry in entries(Arity.BINARY):
+        for mathop in entry.ops:
+            if not is_ported(mathop):
+                continue
+            _domain, is_int = _parity_binary_domain(mathop)
+            for fmt, dest_acc in _parity_binary_formats_dest_acc(is_int):
+                cases.append((mathop.cpp_enum_value, mathop, fmt, dest_acc))
+    return cases
+
+
+_PARITY_BINARY_CASES = _parity_binary_cases()
+
+
+@pytest.mark.quasar
+@pytest.mark.skipif(
+    not _PARITY_BINARY_CASES,
+    reason="no binary SFPU parity kernel is ported to Quasar yet",
+)
+@parametrize(
+    parity_case=_PARITY_BINARY_CASES,
+    implied_math_format=[ImpliedMathFormat.No, ImpliedMathFormat.Yes],
+    tile_indices=runtime(_TILE_INDEX_VARIANTS),
+)
+def test_eltwise_binary_sfpu_parity_quasar(
+    parity_case,
+    implied_math_format,
+    tile_indices,
+    *,
+    run_types=(PerfRunType.L1_TO_L1,),
+    loop_factor=1,
+    is_perf=False,
+    perf_report=None,
+):
+    """Binary half of the SFPU parity set, validated against BinarySFPUGolden.
+
+    One compile-time-selected BinaryOp per variant. Each op activates only once its
+    Quasar kernel header exists; see helpers/sfpu_port_quasar.py.
+    """
+    binary_op, mathop, formats, dest_acc = parity_case
+    _run_sfpu_binary_llk_golden(
+        formats,
+        dest_acc,
+        implied_math_format,
+        tile_indices,
+        mathop,
+        binary_op,
+        prepare_stimuli=_prepare_parity_binary_stimuli,
+        run_types=run_types,
+        loop_factor=loop_factor,
+        is_perf=is_perf,
+        perf_report=perf_report,
+    )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
@@ -27,6 +27,12 @@ from helpers.param_config import (
     runtime,
 )
 from helpers.perf.core import create_test_or_perf_config
+from helpers.sfpu_domains import for_op_pipeline
+from helpers.sfpu_port_quasar import (
+    Arity,
+    entries,
+    is_ported,
+)
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import (
     StimuliSpec,
@@ -417,7 +423,11 @@ def prepare_unary_inputs(
     input_format: DataFormat,
     output_format: DataFormat,
 ) -> torch.Tensor:
-    """Dispatch to the op-specific input-preparation routine."""
+    """Dispatch to the op-specific input-preparation routine.
+
+    Parity ops never reach here: their stimuli are already in-domain, because
+    generate_stimuli was handed the spec that sfpu_domains resolved for them.
+    """
     if mathop == MathOperation.Abs:
         return prepare_abs_inputs(src_A, src_B, input_format, output_format)
     if mathop == MathOperation.Square:
@@ -634,6 +644,12 @@ class OpConfig:
     input_dims: tuple  # list of [H, W] dimensions
     dest_sync_modes: tuple  # DestSync values to sweep
     uniform_spec: bool = False
+    # Parity ops (see helpers/sfpu_port_quasar.py) draw their stimuli from the shared
+    # sfpu_domains registry rather than from a bespoke prepare_* routine in this file, and
+    # carry their approximation / integer-format facts from the port table.
+    parity: bool = False
+    has_approx: bool = False
+    int_formats: bool = False
 
 
 TENSOR_DIMS = ([32, 32], [64, 64])
@@ -664,7 +680,41 @@ OP_CONFIGS = [
     ],
 ] + [OpConfig(op, TENSOR_DIMS, DEST_SYNC_MODES) for op in COMP_OPS]
 
+
+# ---------------------------------------------------------------------------
+# SFPU parity set — the Blackhole kernels written in pure sfpi:: that Quasar does not
+# have yet (helpers/sfpu_port_quasar.py). Their configs are generated from the port
+# table rather than listed here, so adding an op to the parity set is a one-line change
+# in one place, and every op is filtered through is_ported(): until its Quasar kernel
+# header exists, the op contributes no variants and the suite stays green. Nothing needs
+# editing when a kernel lands.
+#
+# Stimuli come from sfpu_domains.for_op_pipeline rather than a prepare_* routine above:
+# the registry already carries a safe domain per (op, input format, output format) for
+# every one of these, and duplicating that judgement here for ~46 more ops would be a
+# second copy to drift.
+# ---------------------------------------------------------------------------
+PARITY_OP_CONFIGS = [
+    OpConfig(
+        op,
+        TENSOR_DIMS,
+        DEST_SYNC_MODES,
+        parity=True,
+        has_approx=entry.has_approx,
+        int_formats=entry.int_formats,
+    )
+    for entry in entries(Arity.UNARY)
+    for op in entry.ops
+    if is_ported(op)
+]
+
+OP_CONFIGS += PARITY_OP_CONFIGS
+
 OP_CONFIG_BY_MATHOP = {cfg.mathop: cfg for cfg in OP_CONFIGS}
+
+# Integer formats for the integer-domain parity ops (bitwise, bitwise_not, unary_shift).
+# Int32 is the only width their kernels declare on the I32 Dest layout.
+SFPU_PARITY_INT_FORMATS = input_output_formats([DataFormat.Int32], same=True)
 
 
 def formats_for_op(cfg: OpConfig) -> List[InputOutputFormat]:
@@ -673,6 +723,10 @@ def formats_for_op(cfg: OpConfig) -> List[InputOutputFormat]:
         return [InputOutputFormat(case.src, case.dst) for case in TYPECAST_CASES]
     if cfg.mathop in COMP_OPS:
         return SFPU_UNARY_FORMATS + SFPU_COMP_EXTRA_FORMATS
+    if cfg.parity and cfg.int_formats:
+        # An integer-domain parity op has no float path at all, so it replaces the float
+        # matrix rather than extending it.
+        return SFPU_PARITY_INT_FORMATS
     return SFPU_UNARY_FORMATS
 
 
@@ -730,14 +784,21 @@ def generate_sfpu_unary_combinations(*, is_perf=False):
     for cfg in OP_CONFIGS:
         # Ops that expose both a non-approximate and an approximate kernel are swept over both
         # ApproximationMode values; every other op has a single implementation (ApproximationMode.No).
+        # A parity op sweeps both modes only when its kernel actually branches on
+        # APPROXIMATION_MODE (or forwards it into sfpu_reciprocal); carrying a template
+        # parameter it ignores would double the variant count for an identical result.
+        # The port table records which ones those are.
         approx_modes = (
             (ApproximationMode.No, ApproximationMode.Yes)
-            if cfg.mathop
-            in (
-                MathOperation.Exp,
-                MathOperation.Gelu,
-                MathOperation.Reciprocal,
-                MathOperation.Rsqrt,
+            if (
+                cfg.has_approx
+                or cfg.mathop
+                in (
+                    MathOperation.Exp,
+                    MathOperation.Gelu,
+                    MathOperation.Reciprocal,
+                    MathOperation.Rsqrt,
+                )
             )
             else (ApproximationMode.No,)
         )
@@ -808,6 +869,11 @@ def test_eltwise_unary_sfpu_quasar(
     square, typecast, and the six compare-to-zero modes), validated against the
     UnarySFPUGolden reference. Typecast sweeps explicit (src, dst) format pairs;
     every other op sweeps the shared format matrix.
+
+    Also drives the unary half of the SFPU parity set — the Blackhole kernels written
+    in pure sfpi:: that Quasar has not received yet. Those ops are generated from
+    helpers/sfpu_port_quasar.py and gated on their kernel header existing, so they
+    contribute no variants until the port lands and need no edit when it does.
     """
     (
         mathop,
@@ -822,11 +888,17 @@ def test_eltwise_unary_sfpu_quasar(
     is_typecast = mathop == MathOperation.Typecast
 
     cfg = OP_CONFIG_BY_MATHOP[mathop]
-    spec = (
-        StimuliSpec.uniform(low=0.0, high=1.0)
-        if (cfg.uniform_spec and not is_typecast)
-        else None
-    )
+    if cfg.parity:
+        # The registry resolves the domain across the whole input->output pipeline, so a
+        # narrowing output format tightens the input range rather than being discovered
+        # as an overflow later.
+        spec = for_op_pipeline(
+            mathop, formats.input_format, formats.output_format
+        ).spec_A
+    elif cfg.uniform_spec and not is_typecast:
+        spec = StimuliSpec.uniform(low=0.0, high=1.0)
+    else:
+        spec = None
     src_A, tile_cnt_A, src_B, _ = generate_stimuli(
         stimuli_format_A=formats.input_format,
         input_dimensions_A=input_dimensions,
@@ -841,7 +913,7 @@ def test_eltwise_unary_sfpu_quasar(
         src_A = _prepare_typecast_input(
             src_A, src_B, formats.input_format, formats.output_format
         )
-    else:
+    elif not cfg.parity:
         src_A = prepare_unary_inputs(
             mathop, src_A, src_B, formats.input_format, formats.output_format
         )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_port_status_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_port_status_quasar.py
@@ -1,0 +1,196 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Drift guard for the Quasar SFPU parity gate. Host-only: no kernel, no device.
+
+The parity tests are written ahead of the kernels they exercise, and each op is gated on
+its header existing. That gate is only trustworthy if two things stay true, and neither is
+checked by any test that runs a kernel:
+
+  * a kernel that lands must actually turn its tests on -- if the header appears but the
+    C++ dispatcher has no branch for it, the op silently stays untested while the Python
+    side reports it as ported;
+  * a parity header name must not collide with an unrelated Quasar kernel -- a collision
+    would open the gate for an op nobody ported, and the dispatch would reference symbols
+    that do not exist.
+
+Both are cheap to assert and expensive to notice by hand, so they are pinned here. These
+tests pass today with zero kernels ported, and keep passing as kernels arrive; they fail
+only when the table and the tree disagree.
+"""
+
+import re
+
+import pytest
+from helpers.sfpu_port_quasar import (
+    CONVERSIONS_COVERAGE,
+    QUASAR_SFPU_PARITY,
+    Arity,
+    entry_for,
+    resolve_header,
+)
+
+# The dispatcher whose branches the gate switches on.
+_DISPATCHER = (
+    __import__("pathlib").Path(__file__).resolve().parents[2]
+    / "helpers"
+    / "include"
+    / "sfpu_operations_quasar.h"
+)
+
+# The parity set as published by the SFPU parity dashboard at the commit the table was
+# built from. Pinned so that trimming an op out of the table is a deliberate edit here
+# rather than a silent loss of coverage.
+_EXPECTED_KERNEL_COUNT = 57
+
+
+@pytest.fixture(scope="module")
+def dispatcher_source() -> str:
+    assert _DISPATCHER.is_file(), f"dispatcher not found at {_DISPATCHER}"
+    return _DISPATCHER.read_text()
+
+
+def test_parity_table_matches_the_published_set():
+    """The table still describes the full parity set, with no duplicates."""
+    assert len(QUASAR_SFPU_PARITY) == _EXPECTED_KERNEL_COUNT, (
+        f"parity table has {len(QUASAR_SFPU_PARITY)} kernels, expected "
+        f"{_EXPECTED_KERNEL_COUNT}. If the dashboard's set genuinely changed, update "
+        "_EXPECTED_KERNEL_COUNT along with the table."
+    )
+
+    kernels = [e.kernel for e in QUASAR_SFPU_PARITY]
+    duplicates = sorted({k for k in kernels if kernels.count(k) > 1})
+    assert (
+        not duplicates
+    ), f"kernels listed more than once in the parity table: {duplicates}"
+
+    ops = [op for e in QUASAR_SFPU_PARITY for op in e.ops]
+    dup_ops = sorted({o.name for o in ops if ops.count(o) > 1})
+    assert not dup_ops, (
+        "these MathOperations are claimed by more than one parity kernel, so "
+        f"entry_for() would resolve one of them arbitrarily: {dup_ops}"
+    )
+
+
+def test_only_the_helper_row_has_no_ops():
+    """Every dispatchable entry names at least one op; only HELPER rows may be empty."""
+    empty = [
+        e.kernel
+        for e in QUASAR_SFPU_PARITY
+        if not e.ops and e.arity is not Arity.HELPER
+    ]
+    assert not empty, (
+        "these parity entries declare no MathOperation but are not marked "
+        f"Arity.HELPER, so nothing can ever drive them: {empty}"
+    )
+
+
+def test_conversions_coverage_points_at_live_parity_ops():
+    """The helper header's coverage claim must be backed by ops that still exist.
+
+    ckernel_sfpu_conversions.h has no entry point of its own and is covered through its
+    callers. If one of those callers left the parity set, the claim would be quietly
+    false -- the helper would be listed as covered by a test that no longer runs.
+    """
+    for op in CONVERSIONS_COVERAGE:
+        assert entry_for(op) is not None, (
+            f"{op.name} is named as a conversions-helper carrier but is no longer in "
+            "the parity set, so ckernel_sfpu_conversions.h would be uncovered"
+        )
+
+    helper_rows = [e for e in QUASAR_SFPU_PARITY if e.arity is Arity.HELPER]
+    for entry in helper_rows:
+        assert entry.covered_by, (
+            f"helper row {entry.kernel} declares no covered_by, so nothing records how "
+            "it is exercised"
+        )
+        for op in entry.covered_by:
+            assert op in CONVERSIONS_COVERAGE, (
+                f"{entry.kernel} names {op.name} as a carrier but CONVERSIONS_COVERAGE "
+                "does not say what that op injects, so the claim is unauditable"
+            )
+
+
+def test_parity_headers_do_not_collide_with_existing_quasar_kernels():
+    """No parity header name may already be taken by an unrelated Quasar kernel.
+
+    A collision opens the gate for an op nobody ported: the Python side would start
+    emitting variants and the C++ dispatcher would compile a branch against symbols the
+    colliding header does not define.
+    """
+    collisions = []
+    for entry in QUASAR_SFPU_PARITY:
+        found = resolve_header(entry)
+        if found is None:
+            continue
+        # The header exists. That is legitimate only if it really is the ported kernel,
+        # which we approximate by requiring it to define at least one of the entry's
+        # expected calculate symbols.
+        text = found.read_text()
+        if not any(sym in text for sym in entry.call):
+            collisions.append(
+                f"{entry.kernel}: {found} exists but defines none of {list(entry.call)}"
+            )
+    assert not collisions, (
+        "these parity header names are already taken by something that is not the "
+        "ported kernel, so the gate would open spuriously:\n  "
+        + "\n  ".join(collisions)
+    )
+
+
+def test_ported_kernels_have_a_dispatch_branch(dispatcher_source):
+    """A kernel that landed must actually be reachable from the dispatcher.
+
+    Without this, a port that adds the header but forgets the dispatch branch leaves the
+    op reported as ported and silently untested.
+    """
+    missing = []
+    for entry in QUASAR_SFPU_PARITY:
+        if entry.arity is Arity.HELPER or resolve_header(entry) is None:
+            continue
+        if f"#define {entry.guard_macro}" not in dispatcher_source:
+            missing.append(f"{entry.kernel}: no '#define {entry.guard_macro}' guard")
+            continue
+        for sym in entry.call:
+            if sym not in dispatcher_source:
+                missing.append(
+                    f"{entry.kernel}: header is present but the dispatcher never "
+                    f"calls {sym}"
+                )
+    assert (
+        not missing
+    ), "ported parity kernels are not wired into the dispatcher:\n  " + "\n  ".join(
+        missing
+    )
+
+
+def test_every_dispatchable_entry_has_a_guard(dispatcher_source):
+    """Each non-helper entry has a guard defined and consumed in the dispatcher.
+
+    This is the structural half of the gate, and unlike the test above it holds whether or
+    not the kernel exists yet -- so it catches a table entry added without the matching
+    C++ plumbing at the moment it is added, rather than months later when the port lands.
+    """
+    defined = set(re.findall(r"#define (QSR_HAS_\w+)", dispatcher_source))
+    used = set(re.findall(r"#ifdef (QSR_HAS_\w+)", dispatcher_source))
+
+    for entry in QUASAR_SFPU_PARITY:
+        if entry.arity is Arity.HELPER:
+            assert entry.guard_macro not in defined, (
+                f"{entry.kernel} is a helper-only header with no entry point, so it must "
+                "not have a dispatch guard"
+            )
+            continue
+        assert entry.guard_macro in defined, (
+            f"parity kernel {entry.kernel} has no '#define {entry.guard_macro}' in "
+            f"{_DISPATCHER.name}; its tests could never activate"
+        )
+        assert entry.guard_macro in used, (
+            f"{entry.guard_macro} is defined but never consumed by an #ifdef, so the "
+            f"{entry.kernel} dispatch branch is unreachable"
+        )
+
+    orphans = sorted(defined - {e.guard_macro for e in QUASAR_SFPU_PARITY})
+    assert (
+        not orphans
+    ), f"{_DISPATCHER.name} defines guards with no parity table entry: {orphans}"

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_structural_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_structural_quasar.py
@@ -1,0 +1,232 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tile-structural half of the SFPU parity set on Quasar.
+
+Three kernels -- ``tiled_prod``, ``int_sum`` (row and column) and
+``alt_complex_rotate90`` -- take one tile in and one tile out like a unary op, but are
+*not* element-wise: they address Dest by slot and combine slots with each other. That is
+why they sit here rather than in the consolidated unary harness, whose golden contract is
+per element.
+
+They are also the only parity ops with no Blackhole tt-llk test to mirror, so their
+goldens (``StructuralSFPUGolden``) were written from the Blackhole kernel sources rather
+than validated against a passing run. Until a Quasar kernel exists, a mismatch here is
+evidence about the golden as much as about the kernel -- see the class docstring.
+
+Every op is gated on its kernel header through ``helpers/sfpu_port_quasar.py``, so this
+module collects nothing today.
+"""
+
+import pytest
+import torch
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.golden_generators import StructuralSFPUGolden, get_golden_generator
+from helpers.llk_params import (
+    ApproximationMode,
+    DataCopyType,
+    DestAccumulation,
+    ImpliedMathFormat,
+    MathOperation,
+    UnpackerEngine,
+    format_dict,
+)
+from helpers.param_config import (
+    generate_sfpu_format_dest_acc_combinations,
+    input_output_formats,
+    parametrize,
+    runtime,
+)
+from helpers.sfpu_port_quasar import Arity, entries, is_ported
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import StimuliSpec, generate_stimuli
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    APPROX_MODE,
+    DATA_COPY_TYPE,
+    DEST_INDEX,
+    DEST_SYNC,
+    IMPLIED_MATH_FORMAT,
+    MATH_OP,
+    NUM_FACES,
+    TEST_FACE_DIMS,
+    TILE_COUNT,
+    TYPECAST_FORMATS,
+    UNPACKER_ENGINE_SEL,
+)
+from helpers.tile_constants import MAX_NUM_FACES
+from helpers.utils import passed_test
+
+_CPP_SOURCE = "sources/quasar/sfpu_structural_quasar_test.cpp"
+
+# Integer-domain structural ops. int_sum accumulates in int32 Dest; the other two are
+# float. Kept as a set rather than read from the port entry because int_sum's two modes
+# share one entry and both are integer.
+_INT_STRUCTURAL_OPS = (MathOperation.IntSumRow, MathOperation.IntSumCol)
+
+# Per-op stimulus band. Bounds are picked so the *accumulated* result stays representable,
+# which for these ops is a much tighter constraint than for an element-wise op:
+#   tiled_prod  -- a running product over 8 slots, so |x| must stay near 1 or the eighth
+#                  partial product overflows even fp32; [0.5, 1.5] keeps 1.5**8 ~= 25;
+#   int_sum     -- sums 8 slots, so cap at 2**24 to stay well inside int32;
+#   rotate90    -- a permutation with a sign flip, exact for anything representable.
+_STRUCTURAL_DOMAINS = {
+    MathOperation.TiledProd: (0.5, 1.5),
+    MathOperation.IntSumRow: (-(2**24), 2**24),
+    MathOperation.IntSumCol: (-(2**24), 2**24),
+    MathOperation.AltComplexRotate90: (-8.0, 8.0),
+}
+
+
+def _float_formats_dest_acc():
+    formats = input_output_formats(
+        [DataFormat.Float16, DataFormat.Float16_b, DataFormat.Float32]
+    )
+    return [
+        (fmt, dest_acc)
+        for fmt, dest_acc in generate_sfpu_format_dest_acc_combinations(formats)
+        if not (
+            fmt.input_format == DataFormat.Float16 and dest_acc == DestAccumulation.Yes
+        )
+    ]
+
+
+def _int_formats_dest_acc():
+    """int_sum runs on the I32 Dest layout, which forces a 32-bit dest."""
+    return [
+        (fmt, DestAccumulation.Yes)
+        for fmt in input_output_formats([DataFormat.Int32], same=True)
+    ]
+
+
+def _get_valid_implied_math_formats(fmt: FormatConfig):
+    if fmt.input_format.is_mx_format():
+        return [ImpliedMathFormat.Yes]
+    return [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
+
+
+def _is_unpack_to_dest(fmt: FormatConfig, dest_acc: DestAccumulation) -> bool:
+    return fmt.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
+
+
+def _structural_cases():
+    """(mathop, formats, dest_acc) for every ported structural parity op.
+
+    Empty while the parity kernels are unported, which is the normal state today.
+    """
+    cases = []
+    for entry in entries(Arity.STRUCTURAL):
+        for mathop in entry.ops:
+            if not is_ported(mathop):
+                continue
+            matrix = (
+                _int_formats_dest_acc()
+                if mathop in _INT_STRUCTURAL_OPS
+                else _float_formats_dest_acc()
+            )
+            for fmt, dest_acc in matrix:
+                cases.append((mathop, fmt, dest_acc))
+    return cases
+
+
+_STRUCTURAL_CASES = _structural_cases()
+
+
+@pytest.mark.quasar
+@pytest.mark.skipif(
+    not _STRUCTURAL_CASES,
+    reason="no tile-structural SFPU parity kernel is ported to Quasar yet",
+)
+@parametrize(
+    structural_case=_STRUCTURAL_CASES,
+    implied_math_format=lambda structural_case: _get_valid_implied_math_formats(
+        structural_case[1]
+    ),
+    input_dimensions=runtime([[32, 32]]),
+)
+def test_sfpu_structural_quasar(structural_case, implied_math_format, input_dimensions):
+    """Tile-structural SFPU parity ops on Quasar, against StructuralSFPUGolden.
+
+    One tile in, one tile out. The sweep is pinned to a single 32x32 tile because these
+    kernels' slot arithmetic is defined against exactly one tile's worth of Dest: int_sum
+    reads slots in faces 1 and 2, and tiled_prod's final unrolled step reaches the slot
+    after the face. Sweeping a larger input would not exercise more of the kernel, it
+    would change what the kernel means.
+    """
+    mathop, formats, dest_acc = structural_case
+    low, high = _STRUCTURAL_DOMAINS[mathop]
+    is_int = mathop in _INT_STRUCTURAL_OPS
+
+    torch.manual_seed(42)
+    src_raw, tile_cnt_A, src_B, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+        spec_A=StimuliSpec.uniform(low=0.0, high=1.0),
+        spec_B=StimuliSpec.uniform(low=0.0, high=1.0),
+    )
+    scaled = low + src_raw.to(torch.float32) * (high - low)
+    if is_int:
+        scaled = scaled.round()
+    src_A = scaled.to(format_dict[formats.input_format])
+
+    num_faces = MAX_NUM_FACES
+
+    generate_golden = get_golden_generator(StructuralSFPUGolden)
+    golden_tensor = generate_golden(
+        mathop, src_A, formats.output_format, num_faces=num_faces
+    )
+
+    unpack_to_dest = _is_unpack_to_dest(formats, dest_acc)
+
+    configuration = TestConfig(
+        _CPP_SOURCE,
+        formats,
+        templates=[
+            MATH_OP(mathop=mathop),
+            APPROX_MODE(ApproximationMode.No),
+            IMPLIED_MATH_FORMAT(implied_math_format),
+            DATA_COPY_TYPE(DataCopyType.A2D),
+            UNPACKER_ENGINE_SEL(
+                UnpackerEngine.UnpDest if unpack_to_dest else UnpackerEngine.UnpA
+            ),
+            DEST_SYNC(),
+            # The shared unary dispatch in sfpu_operations_quasar.h has a typecast branch
+            # referencing these non-dependent globals, so every build defining that header
+            # must define them too.
+            TYPECAST_FORMATS(),
+        ],
+        runtimes=[
+            TILE_COUNT(tile_cnt_A),
+            NUM_FACES(num_faces),
+            TEST_FACE_DIMS(),
+            DEST_INDEX(0),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_A,
+            tile_count_res=tile_cnt_A,
+            num_faces=num_faces,
+            twos_complement=formats.input_format.is_integer(),
+        ),
+        unpack_to_dest=unpack_to_dest,
+        dest_acc=dest_acc,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), "Result tensor and golden tensor are not of the same length"
+
+    torch_format_out = format_dict[formats.output_format]
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format_out)
+    assert passed_test(
+        golden_tensor, res_tensor, formats.output_format
+    ), "Assert against golden failed"

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_ternary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_ternary_quasar.py
@@ -1,0 +1,272 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Ternary half of the SFPU parity set on Quasar: addcmul / addcdiv / lerp / snake_beta.
+
+These four are Blackhole kernels written in pure ``sfpi::`` that Quasar has not received
+yet. The op list comes from ``helpers/sfpu_port_quasar.py`` and every op is filtered
+through :func:`is_ported`, so until a kernel header lands this module collects nothing and
+the suite stays green; when one lands, its full sweep activates with no edit here.
+
+Quasar already carries the ternary plumbing that ``where`` uses
+(``llk_math_eltwise_ternary_sfpu_macros.h``, ``_llk_math_eltwise_ternary_sfpu_init_``), so
+this is harness assembly rather than new infrastructure. The C++ side is
+``sources/quasar/sfpu_ternary_quasar_test.cpp``, structurally a copy of the ``where`` test
+with the op selected at compile time.
+"""
+
+import pytest
+import torch
+from helpers.format_config import DataFormat, FormatConfig
+from helpers.golden_generators import TernarySFPUGolden, get_golden_generator
+from helpers.llk_params import (
+    ApproximationMode,
+    DataCopyType,
+    DestAccumulation,
+    ImpliedMathFormat,
+    MathOperation,
+    UnpackerEngine,
+    format_dict,
+)
+from helpers.param_config import (
+    generate_sfpu_format_dest_acc_combinations,
+    input_output_formats,
+    parametrize,
+    runtime,
+)
+from helpers.sfpu_port_quasar import Arity, entries, is_ported
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import StimuliSpec, generate_stimuli
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    APPROX_MODE,
+    DATA_COPY_TYPE,
+    DEST_INDEX,
+    DEST_SYNC,
+    IMPLIED_MATH_FORMAT,
+    NUM_FACES,
+    SFPU_TERNARY_OP,
+    SFPU_TERNARY_SCALAR,
+    TEST_FACE_DIMS,
+    TILE_COUNT,
+    UNPACKER_ENGINE_SEL,
+)
+from helpers.utils import passed_test
+
+_CPP_SOURCE = "sources/quasar/sfpu_ternary_quasar_test.cpp"
+
+# The addc kernels' fp32 multiplier. 2.0 rather than 1.0 so a kernel that ignored the
+# scalar entirely would still fail: with 1.0, addcmul(a, b, c) and a + b * c coincide.
+_TERNARY_SCALAR = 2.0
+_TERNARY_SCALAR_BITS = 0x40000000
+
+# Per-operand domains, as (low, high) per operand (a, b, c). Chosen so the result stays
+# representable and each kernel's preconditions hold:
+#   addcdiv    -- operand c is a divisor, so it must stay away from zero;
+#   lerp       -- operand c is the interpolation weight, natural range [0, 1];
+#   snake_beta -- operand c divides sin(b*a)^2, so it too must avoid zero.
+_TERNARY_DOMAINS = {
+    MathOperation.SfpuAddcmul: ((-8.0, 8.0), (-4.0, 4.0), (-4.0, 4.0)),
+    MathOperation.SfpuAddcdiv: ((-8.0, 8.0), (-4.0, 4.0), (0.5, 4.0)),
+    MathOperation.SfpuLerp: ((-8.0, 8.0), (-8.0, 8.0), (0.0, 1.0)),
+    MathOperation.SfpuSnakeBeta: ((-4.0, 4.0), (-2.0, 2.0), (0.5, 4.0)),
+}
+
+# Ops that carry coverage for ckernel_sfpu_conversions.h, which has no kernel of its own
+# (see CONVERSIONS_COVERAGE in helpers/sfpu_port_quasar.py). Both reach
+# float32_to_bf16_rne when narrowing their fp32 result, so their stimuli seed exact
+# round-nearest-even ties -- values whose fp32 -> bf16 rounding is decided by the
+# even-mantissa rule rather than by magnitude. Without seeding, a tie is vanishingly
+# unlikely to appear in random stimuli and the rounding path would go untested.
+_RNE_TIE_OPS = (MathOperation.SfpuAddcdiv, MathOperation.SfpuLerp)
+
+# fp32 values sitting exactly halfway between two bf16 neighbours: mantissa bit 16 set,
+# all lower bits clear. RNE must round each to the neighbour with an even mantissa.
+_RNE_TIE_BITS = (
+    0x3F808000,  # 1.00390625  -> ties between 1.0 and 1.0078125
+    0x3F818000,  # 1.01171875
+    0x40008000,  # 2.00390625
+    0x40808000,  # 4.0078125
+    0xBF808000,  # -1.00390625 (sign must not change the tie decision)
+    0xBF818000,  # -1.01171875
+)
+
+
+def _rne_tie_values(dtype: torch.dtype) -> torch.Tensor:
+    """The tie values above, as a tensor of *dtype*."""
+    bits = torch.tensor(list(_RNE_TIE_BITS), dtype=torch.int64).to(torch.int32)
+    return bits.view(torch.float32).to(dtype)
+
+
+def _get_valid_formats_dest_acc():
+    """Float format x dest_acc matrix, minus the combination Quasar does not support."""
+    formats = input_output_formats(
+        [DataFormat.Float16, DataFormat.Float16_b, DataFormat.Float32]
+    )
+    return [
+        (fmt, dest_acc)
+        for fmt, dest_acc in generate_sfpu_format_dest_acc_combinations(formats)
+        if not (
+            fmt.input_format == DataFormat.Float16 and dest_acc == DestAccumulation.Yes
+        )
+    ]
+
+
+def _get_valid_implied_math_formats(fmt: FormatConfig):
+    if fmt.input_format.is_mx_format():
+        return [ImpliedMathFormat.Yes]
+    return [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
+
+
+def _is_unpack_to_dest(fmt: FormatConfig, dest_acc: DestAccumulation) -> bool:
+    """UNPACK->DEST is selected only for 32-bit inputs with dest_acc=Yes."""
+    return fmt.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes
+
+
+def _operand(
+    mathop: MathOperation,
+    which: int,
+    input_format: DataFormat,
+    input_dimensions,
+    seed: int,
+):
+    """One operand tile, drawn uniformly from this op's band for that operand."""
+    low, high = _TERNARY_DOMAINS[mathop][which]
+    torch.manual_seed(seed)
+    src, tile_cnt, _, _ = generate_stimuli(
+        stimuli_format_A=input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=input_format,
+        input_dimensions_B=input_dimensions,
+        spec_A=StimuliSpec.uniform(low=0.0, high=1.0),
+        spec_B=StimuliSpec.uniform(low=0.0, high=1.0),
+    )
+    scaled = low + src.to(torch.float32) * (high - low)
+    return scaled.to(format_dict[input_format]), tile_cnt
+
+
+def _ternary_cases():
+    """(mathop, formats, dest_acc) for every ported ternary parity op.
+
+    Empty while the parity kernels are unported, which is the normal state today.
+    """
+    cases = []
+    for entry in entries(Arity.TERNARY):
+        for mathop in entry.ops:
+            if not is_ported(mathop):
+                continue
+            for fmt, dest_acc in _get_valid_formats_dest_acc():
+                cases.append((mathop, fmt, dest_acc, entry.has_approx))
+    return cases
+
+
+_TERNARY_CASES = _ternary_cases()
+
+
+@pytest.mark.quasar
+@pytest.mark.skipif(
+    not _TERNARY_CASES,
+    reason="no ternary SFPU parity kernel is ported to Quasar yet",
+)
+@parametrize(
+    ternary_case=_TERNARY_CASES,
+    implied_math_format=lambda ternary_case: _get_valid_implied_math_formats(
+        ternary_case[1]
+    ),
+    approx_mode=lambda ternary_case: (
+        [ApproximationMode.No, ApproximationMode.Yes]
+        if ternary_case[3]
+        else [ApproximationMode.No]
+    ),
+    input_dimensions=runtime([[32, 32], [64, 64]]),
+)
+def test_sfpu_ternary_quasar(
+    ternary_case, implied_math_format, approx_mode, input_dimensions
+):
+    """Ternary SFPU parity ops on Quasar, validated against TernarySFPUGolden.
+
+    Three operand tiles are staged into buffer_A, datacopied into Dest at tile indices
+    0/1/2, and the compile-time-selected op writes its result to Dest tile 0, which PACK
+    writes back. Only ops whose Quasar kernel header exists are collected.
+    """
+    mathop, formats, dest_acc, _has_approx = ternary_case
+    torch_format_in = format_dict[formats.input_format]
+
+    operand_a, tile_cnt_single = _operand(
+        mathop, 0, formats.input_format, input_dimensions, seed=42
+    )
+    operand_b, _ = _operand(mathop, 1, formats.input_format, input_dimensions, seed=43)
+    operand_c, _ = _operand(mathop, 2, formats.input_format, input_dimensions, seed=44)
+
+    if mathop in _RNE_TIE_OPS:
+        # Seed the fp32->bf16 round-nearest-even ties that exercise
+        # ckernel_sfpu_conversions.h's float32_to_bf16_rne through this carrier op.
+        ties = _rne_tie_values(torch_format_in)
+        flat_a = operand_a.flatten()
+        n = min(ties.numel(), flat_a.numel())
+        flat_a[:n] = ties[:n]
+        operand_a = flat_a.reshape(operand_a.shape)
+
+    src_A = torch.cat([operand_a, operand_b, operand_c])
+    tile_cnt_A = tile_cnt_single * 3
+    num_faces = 4
+
+    generate_golden = get_golden_generator(TernarySFPUGolden)
+    golden_tensor = generate_golden(
+        mathop,
+        operand_a,
+        operand_b,
+        operand_c,
+        _TERNARY_SCALAR_BITS,
+        formats.output_format,
+    )
+
+    unpack_to_dest = _is_unpack_to_dest(formats, dest_acc)
+    src_B_dummy = torch.zeros_like(operand_a)
+
+    configuration = TestConfig(
+        _CPP_SOURCE,
+        formats,
+        templates=[
+            SFPU_TERNARY_OP(ternary_mathop=mathop),
+            SFPU_TERNARY_SCALAR(ternary_scalar_bits=_TERNARY_SCALAR_BITS),
+            APPROX_MODE(approx_mode),
+            IMPLIED_MATH_FORMAT(implied_math_format),
+            DATA_COPY_TYPE(DataCopyType.A2D),
+            UNPACKER_ENGINE_SEL(
+                UnpackerEngine.UnpDest if unpack_to_dest else UnpackerEngine.UnpA
+            ),
+            DEST_SYNC(),
+        ],
+        runtimes=[
+            TILE_COUNT(tile_cnt_A),
+            NUM_FACES(num_faces),
+            TEST_FACE_DIMS(),
+            DEST_INDEX(0),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B_dummy,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_single,
+            tile_count_res=tile_cnt_single,
+            num_faces=num_faces,
+        ),
+        unpack_to_dest=unpack_to_dest,
+        dest_acc=dest_acc,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), "Result tensor and golden tensor are not of the same length"
+
+    torch_format_out = format_dict[formats.output_format]
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format_out)
+    assert passed_test(
+        golden_tensor, res_tensor, formats.output_format
+    ), "Assert against golden failed"

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_structural_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_structural_quasar_test.cpp
@@ -1,0 +1,192 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Tile-structural half of the SFPU parity set: tiled_prod, int_sum (row and column) and
+// alt_complex_rotate90.
+//
+// These take one tile in and write one tile out, like a unary op, but they are not
+// element-wise: they address Dest by slot and combine slots with each other. That is why
+// they do not ride the consolidated unary harness -- its golden contract is per element,
+// and int_sum in particular reads slots belonging to faces 1 and 2, so it must be
+// dispatched once per tile rather than once per face.
+//
+// Which ops compile is decided by the __has_include gates in sfpu_operations_quasar.h;
+// the Python side emits no variant for an unported op, so this file builds cleanly
+// whether or not any structural parity kernel exists yet.
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "llk_memory_checks.h"
+#include "sfpu_stub.h"
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_math_common.h"
+#include "llk_unpack_common.h"
+#include "llk_unpack_unary_operand.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t buf_desc_id          = 0;
+    const std::uint32_t num_tiles_per_unpack = params.TILE_CNT;
+
+    constexpr auto unpack_dest = unpack_to_dest ? dest_dvalid_client::UNPACK : dest_dvalid_client::FPU;
+    set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({unpack_dest, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+
+    if constexpr (unpack_to_dest)
+    {
+        _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*is_int_fpu_en*/>();
+    }
+
+    buffer_descriptor_u bd_val = {0};
+    bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_A[0]);
+    bd_val.f.format            = static_cast<std::uint8_t>(formats.unpack_A_src);
+    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim             = params.num_faces;
+
+    tdma_descriptor_t td_val;
+    td_val.buf_desc        = bd_val;
+    td_val.buf_desc_id     = buf_desc_id;
+    td_val.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
+    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+
+    if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
+    {
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val, td_val);
+    }
+    else
+    {
+        _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val);
+    }
+
+    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
+        buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_unpack);
+
+    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0 /*l1_tile_idx*/, ckernel::DEFAULT_TENSOR_SHAPE);
+
+    if constexpr (unpack_to_dest)
+    {
+        _llk_unpack_dest_dvalid_section_done_<dest_sync>();
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+const bool is_int_fpu_en = false;
+
+#include "cfg_defines.h"
+#include "cmath_common.h"
+#include "llk_math_common.h"
+#include "llk_math_eltwise_unary_datacopy.h"
+#include "params.h"
+#include "sfpu_operations_quasar.h"
+
+using namespace ckernel;
+using namespace ckernel::math;
+using namespace ckernel::sfpu;
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    if constexpr (unpack_to_dest)
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+    else
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+
+    const DataFormat src_format = static_cast<DataFormat>(formats.math);
+    if (src_format == DataFormat::Int32)
+    {
+        // int_sum accumulates integers in Dest, which needs the INT8 math path enabled.
+        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(src_format, src_format);
+    }
+    else
+    {
+        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, is_int_fpu_en>(src_format, src_format);
+    }
+
+    if constexpr (!unpack_to_dest)
+    {
+        const std::uint32_t num_rows = params.num_faces * params.TEST_FACE_R_DIM;
+        _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(num_rows, 1);
+
+        for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+        {
+            _llk_math_eltwise_unary_datacopy_(params.DST_INDEX + i);
+        }
+
+        _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+    }
+
+    _llk_math_eltwise_sfpu_init_();
+    // The structural ops' init steps live in the shared unary initializer, which already
+    // knows each op's init symbol; only the calculate step needs a separate dispatch.
+    test_utils::init_unary_sfpu_operation_quasar<SFPU_UNARY_OPERATION, is_fp32_dest_acc_en, APPROX_MODE>();
+
+    test_utils::call_structural_sfpu_operation_quasar<SFPU_UNARY_OPERATION, dest_sync, is_fp32_dest_acc_en, SFPU_ITERATIONS>(params.DST_INDEX);
+
+    _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();
+
+    // Drain every unit T1 drives before PACK takes over.
+    wait_sfpu_idle();
+    wait_fpu_idle();
+    wait_mop_idle();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "cfg_defines.h"
+#include "llk_pack.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t buf_desc_id        = 8;
+    const std::uint32_t num_tiles_per_pack = 1;
+
+    constexpr auto unpack_dest = unpack_to_dest ? dest_dvalid_client::UNPACK : dest_dvalid_client::FPU;
+    set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({unpack_dest, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+
+    buffer_descriptor_u bd_val = {0};
+    bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_Res[0]);
+    bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
+    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim             = params.num_faces;
+
+    tdma_descriptor_t tdma_desc;
+    tdma_desc.buf_desc        = bd_val;
+    tdma_desc.buf_desc_id     = buf_desc_id;
+    tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
+    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+
+    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
+    _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+
+    _llk_pack_(params.DST_INDEX, 0, ckernel::DEFAULT_TENSOR_SHAPE);
+    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+}
+
+#endif

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_ternary_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_ternary_quasar_test.cpp
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Ternary half of the SFPU parity set: addcmul / addcdiv / lerp / snake_beta.
+//
+// Structurally identical to sfpu_where_quasar_test.cpp -- three operand tiles unpacked
+// into Dest, one result tile packed back -- differing only in that the op is selected at
+// compile time via SFPU_TERNARY_OPERATION and dispatched through
+// call_ternary_sfpu_operation_quasar rather than calling one kernel directly. Which ops
+// actually compile is decided by the __has_include gates in sfpu_operations_quasar.h; the
+// Python side never emits a variant for an unported op, so this file builds cleanly
+// whether or not any ternary parity kernel exists yet.
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "llk_memory_checks.h"
+#include "sfpu_stub.h"
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_math_common.h"
+#include "llk_unpack_common.h"
+#include "llk_unpack_unary_operand.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t buf_desc_id          = 0;
+    const std::uint32_t num_tiles_per_unpack = params.TILE_CNT;
+
+    // UNPACK-to-DEST path: UNPACK writes DEST; SFPU reads/writes DEST; PACK reads DEST.
+    // FPU path: UNPACK writes SrcA; FPU datacopy writes DEST; SFPU reads/writes DEST.
+    constexpr auto unpack_dest = unpack_to_dest ? dest_dvalid_client::UNPACK : dest_dvalid_client::FPU;
+    set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({unpack_dest, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+
+    if constexpr (unpack_to_dest)
+    {
+        _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*is_int_fpu_en*/>();
+    }
+
+    buffer_descriptor_u bd_val = {0};
+    bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_A[0]);
+    bd_val.f.format            = static_cast<std::uint8_t>(formats.unpack_A_src);
+    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim             = params.num_faces;
+
+    tdma_descriptor_t td_val;
+    td_val.buf_desc        = bd_val;
+    td_val.buf_desc_id     = buf_desc_id;
+    td_val.reg_data_format = static_cast<std::uint8_t>(formats.unpack_A_dst);
+    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+
+    if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
+    {
+        // 32-bit Dest reached through the FPU datacopy (MOVA2D -> ELWADD fallback) needs
+        // both SrcA and SrcB formats configured.
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val, td_val);
+    }
+    else
+    {
+        _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val);
+    }
+
+    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
+        buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_unpack);
+
+    // Unpacks all three operand tiles (a, b, c) from buffer_A in one call; the tile count
+    // comes from num_tiles_per_unpack set during init.
+    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0 /*l1_tile_idx*/, ckernel::DEFAULT_TENSOR_SHAPE);
+
+    if constexpr (unpack_to_dest)
+    {
+        _llk_unpack_dest_dvalid_section_done_<dest_sync>();
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+const bool is_int_fpu_en = false;
+
+#include "cfg_defines.h"
+#include "cmath_common.h"
+#include "llk_math_common.h"
+#include "llk_math_eltwise_unary_datacopy.h"
+#include "params.h"
+#include "sfpu_operations_quasar.h"
+
+using namespace ckernel;
+using namespace ckernel::math;
+using namespace ckernel::sfpu;
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    if constexpr (unpack_to_dest)
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+    else
+    {
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+        set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+    }
+
+    const DataFormat src_format = static_cast<DataFormat>(formats.math);
+    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, is_int_fpu_en>(src_format, src_format);
+
+    if constexpr (!unpack_to_dest)
+    {
+        const std::uint32_t num_rows = params.num_faces * params.TEST_FACE_R_DIM;
+        _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(num_rows, 1);
+
+        for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+        {
+            _llk_math_eltwise_unary_datacopy_(params.DST_INDEX + i);
+        }
+
+        _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+    }
+
+    test_utils::init_ternary_sfpu_operation_quasar<SFPU_TERNARY_OPERATION, APPROX_MODE>();
+
+    // Operands a = base+0, b = base+1, c = base+2; the result overwrites base+0, which is
+    // what PACK reads back. SFPU_TERNARY_SCALAR is the addc kernels' fp32 multiplier and
+    // is ignored by lerp and snake_beta.
+    test_utils::call_ternary_sfpu_operation_quasar<SFPU_TERNARY_OPERATION, dest_sync, is_fp32_dest_acc_en, APPROX_MODE>(
+        params.DST_INDEX + 0u /*a*/, params.DST_INDEX + 1u /*b*/, params.DST_INDEX + 2u /*c*/, params.DST_INDEX + 0u /*out*/, SFPU_TERNARY_SCALAR);
+
+    _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "cfg_defines.h"
+#include "llk_pack.h"
+#include "llk_pack_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t buf_desc_id        = 8;
+    const std::uint32_t num_tiles_per_pack = 1;
+
+    constexpr auto unpack_dest = unpack_to_dest ? dest_dvalid_client::UNPACK : dest_dvalid_client::FPU;
+    set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({unpack_dest, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+
+    buffer_descriptor_u bd_val = {0};
+    bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_Res[0]);
+    bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
+    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
+    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
+    bd_val.f.z_dim             = params.num_faces;
+
+    tdma_descriptor_t tdma_desc;
+    tdma_desc.buf_desc        = bd_val;
+    tdma_desc.buf_desc_id     = buf_desc_id;
+    tdma_desc.reg_data_format = static_cast<std::uint8_t>(formats.pack_src);
+    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+
+    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc, ckernel::ReluConfig::none());
+    _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+
+    // Packs only the result tile; a ternary op produces one output tile regardless of how
+    // many operand tiles were loaded.
+    _llk_pack_(params.DST_INDEX, 0, ckernel::DEFAULT_TENSOR_SHAPE);
+    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+}
+
+#endif

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_defs.h
@@ -76,6 +76,29 @@ enum class BinaryOp : std::uint8_t
     QUANT,
     REQUANT,
     DEQUANT,
+    // ─────────────────────────────────────────────────────────────────────────
+    // SFPU parity set: binary kernels written in pure sfpi:: on Blackhole that
+    // are not yet ported to Quasar. Names match the Blackhole BinaryOp /
+    // SfpuType spellings so a ported kernel needs no rename. Declaring the
+    // enumerator does not imply a kernel exists; the test dispatcher gates each
+    // branch on __has_include of the kernel header.
+    // ─────────────────────────────────────────────────────────────────────────
+    ATAN2,
+    BITWISE_AND,
+    BITWISE_OR,
+    BITWISE_XOR,
+    DIV_INT32,
+    DIV_INT32_FLOOR,
+    FMOD,
+    FMOD_INT32,
+    ISCLOSE,
+    LOGSIGMOID,
+    MASK,
+    POW,
+    REMAINDER,
+    REMAINDER_INT32,
+    REMAINDER_UINT32,
+    RSUB_INT32,
 };
 
 // For instructions that address lower/upper 16 bits of a register

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
@@ -120,6 +120,74 @@ enum class SfpuType : std::uint32_t
     greater_than_zero,
     less_than_equal_zero,
     greater_than_equal_zero,
+    // ─────────────────────────────────────────────────────────────────────────
+    // SFPU parity set: kernels written in pure sfpi:: on Blackhole that are not
+    // yet ported to Quasar. The enumerator names match the Blackhole
+    // llk_sfpu_types.h names exactly, so a ported kernel needs no rename and the
+    // shared test harness resolves SfpuType::<op> identically on both
+    // architectures. Declaring the enumerator does not imply a kernel exists;
+    // the test dispatcher gates each branch on __has_include of the kernel
+    // header (see tests/helpers/include/sfpu_operations_quasar.h).
+    // ─────────────────────────────────────────────────────────────────────────
+    // Unary
+    add1,
+    bitwise_and,
+    bitwise_not,
+    bitwise_or,
+    bitwise_xor,
+    cast_fp32_to_fp16a,
+    cbrt,
+    celu,
+    digamma,
+    elu,
+    erf,
+    erfc,
+    erfinv,
+    exp2,
+    expm1,
+    fmod,
+    hardmish,
+    hardshrink,
+    hardsigmoid,
+    hardtanh,
+    heaviside,
+    i0,
+    i1,
+    identity,
+    left_shift,
+    lgamma,
+    logical_not_unary,
+    polygamma,
+    power,
+    prelu,
+    rdiv,
+    remainder,
+    right_shift,
+    rpow,
+    selu,
+    sign,
+    softshrink,
+    softsign,
+    tanhshrink,
+    unary_eq,
+    unary_ge,
+    unary_gt,
+    unary_le,
+    unary_lt,
+    unary_ne,
+    xielu,
+    // Ternary
+    addcdiv,
+    addcmul,
+    lerp,
+    snake_beta,
+    // Tile-structural / reduction. sum_int_row / sum_int_col have no Blackhole
+    // enumerator (the kernel exposes calculate_sum_int_row / _col directly); the
+    // names follow those entry points.
+    alt_complex_rotate90,
+    sum_int_col,
+    sum_int_row,
+    tiled_prod,
 };
 
 enum class DstSync : std::uint8_t


### PR DESCRIPTION
## What

The [SFPU parity dashboard](http://tensix-l-03:8089/static/sfpu_parity.html) lists **57** kernels that are implemented on Blackhole in pure `sfpi::` and absent on Quasar. This adds their Quasar tests **ahead of the port**.

**No kernel is implemented here.** Every op is gated on its kernel header existing, so today this collects zero parity variants and leaves the suite exactly as it was. When a kernel lands, its full sweep activates with no test edit and no flag to flip.

## How the gate works

`helpers/sfpu_port_quasar.py` is the single source of truth — one row per kernel, resolved against the filesystem:

```python
def is_ported(op) -> bool:
    """True when the entry's header exists in the Quasar tree."""
```

The C++ dispatcher gates the matching branch on `__has_include` of the **same header basename**, which makes it structurally impossible for the Python and C++ sides to disagree about what is available:

```cpp
#if __has_include("ckernel_sfpu_erf.h")
#include "ckernel_sfpu_erf.h"
#define QSR_HAS_ERF 1
#endif
```

Bare basenames are deliberate: all three Quasar SFPU trees are on the include path as bare-name roots, so the gate does not care which one a future port lands in.

## Coverage

57 kernels / 70 `MathOperation` values:

| Harness | Kernels | Ops | Where |
|---|---:|---:|---|
| unary | 38 | 46 | extends `test_eltwise_unary_sfpu_quasar` |
| binary | 11 | 16 | extends `test_eltwise_binary_sfpu_quasar` |
| ternary | 4 | 4 | **new** `test_sfpu_ternary_quasar` |
| structural | 3 | 4 | **new** `test_sfpu_structural_quasar` |
| helper | 1 | 0 | `conversions` — covered through its callers |

`ckernel_sfpu_conversions.h` holds two `sfpi` helpers and no entry point, so it has no test of its own. It is covered through carriers already in the set — `unary_power`/`binary_pow` seed integer-valued and near-half exponents for `_float_to_int32_positive_`; `lerp`/`addcdiv` seed round-nearest-even ties at a bf16 output for `float32_to_bf16_rne`. The mapping is recorded in `CONVERSIONS_COVERAGE` so the claim is auditable rather than asserted.

## Sweep

Per op, the full matrix the Quasar unary harness already uses:

```
formats  : Float16, Float16_b, Float32 (in x out) -> 13 valid (format, dest_acc) pairs
dest_sync: Half, Full
implied  : ImpliedMathFormat No, Yes
dims     : [32,32], [64,64]
= 104 variants, x2 for the nine ops that really branch on APPROXIMATION_MODE
```

filtered by `is_invalid_quasar_sfpu_format_combination`. Integer-domain ops sweep Int32 instead of the float matrix.

Only `rdiv` has a literal `if constexpr (APPROXIMATION_MODE)`; eight more reach it through `sfpu_reciprocal`'s iteration count. The other 48 carry the template parameter and ignore it, so they sweep one mode — doubling them would double the variants for an identical result.

MX formats and tiny-tile shapes are **out of scope**: no Quasar SFPU test sweeps either today, and adding a new format family alongside 57 new ops would make any failure ambiguous.

## Please look at these three

**1. Two non-test files are touched.** Quasar's `SfpuType` had 46 enumerators and *none* of the 57 ops were among them; `BinaryOp` lacked all 16 binary ones — `SfpuType::erf` simply did not compile. Both enums gain **declarations only, no kernel code**, which is the path `sfpu_operations_quasar.h` already documents ("Add the enumerator to `ckernel::BinaryOp` … if it is not there"). Happy to move these if you'd rather they live elsewhere.

**2. The three tile-structural goldens are unvalidated.** `tiled_prod`, `int_sum` and `alt_complex_rotate90` are the only parity ops with no Blackhole tt-llk test, so `StructuralSFPUGolden` was derived from the Blackhole kernel sources rather than from a passing run. Worth a look: `calculate_tiled_prod`'s 9th unrolled step writes `dst_reg[8]` — past the face — which I model as unobservable (overwritten when the next face runs its own `d=0` step) and documented rather than silently encoded.

**3. Nine ops needed a domain registered but are exempt from the Blackhole sweep.** `sfpu_domains` auto-enrols any registered op into Blackhole's `STANDARD_SWEEP_OPS`, which this PR is not meant to change. They are registered (so `for_op_pipeline` resolves) and listed in `_UNARY_OPS_NOT_SWEPT` with a per-op reason. Verified: Blackhole's swept-op set is byte-identical before and after.

## Verification

Done without hardware:

- unary variant count **byte-identical to main (3560)**; parity adds 0
- Blackhole's swept-op set **byte-identical** before and after
- gate proven both directions: 0 headers → 0 guards; 3 stub headers → exactly those 3
- stub `erf`/`rdiv` yield **208 variants each**, bitwise 8 — matching the sweep math above
- **12/12 clean compiles**: 4 Quasar sources × UNPACK/MATH/PACK with the real `riscv-tt-elf-g++`
- drift guard 6/6, and it correctly rejects a header that is not the real kernel
- new bitwise and structural goldens checked against hand-computed values
- all 14 pre-commit hooks pass

**Not run: pytest.** `conftest.py` calls `init_ttexalens()` in `pytest_configure` and my host has no Tenstorrent device, so the counts above come from importing the modules directly with `CHIP_ARCH=quasar`. **This needs a run on a Quasar target before merge** — in particular to confirm the parity families collect zero variants under real collection and that the existing suite is untouched.

Separately, and unrelated to this change: `helpers/device.py` on `main` does `from ttexalens.elf import CallstackEntry`, which the pinned `tt-exalens==0.3.29` does not export. It will bite anyone setting up a fresh environment.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vvukomanovic/quasar-sfpu-parity-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vvukomanovic/quasar-sfpu-parity-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vvukomanovic/quasar-sfpu-parity-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vvukomanovic/quasar-sfpu-parity-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vvukomanovic/quasar-sfpu-parity-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanovic/quasar-sfpu-parity-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vvukomanovic/quasar-sfpu-parity-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vvukomanovic/quasar-sfpu-parity-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vvukomanovic/quasar-sfpu-parity-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanovic/quasar-sfpu-parity-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vvukomanovic/quasar-sfpu-parity-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanovic/quasar-sfpu-parity-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vvukomanovic/quasar-sfpu-parity-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanovic/quasar-sfpu-parity-tests)