### PR TITLE
[tt-train] DiT diffusion-model training example (first non-LLM example)

### DIFF
--- a/tt-train/configs/model_configs/dit_s.yaml
+++ b/tt-train/configs/model_configs/dit_s.yaml
@@ -1,0 +1,10 @@
+dit_config:
+  model_type: "dit"
+  embedding_dim: 384
+  num_heads: 6
+  num_blocks: 12
+  mlp_ratio: 4.0
+  patch_size: 4
+  image_size: 32
+  image_channels: 3
+  num_classes: 10

--- a/tt-train/configs/model_configs/dit_s_p2.yaml
+++ b/tt-train/configs/model_configs/dit_s_p2.yaml
@@ -1,0 +1,10 @@
+dit_config:
+  model_type: "dit"
+  embedding_dim: 384
+  num_heads: 6
+  num_blocks: 12
+  mlp_ratio: 4.0
+  patch_size: 2
+  image_size: 32
+  image_channels: 3
+  num_classes: 10

--- a/tt-train/configs/model_configs/dit_tiny.yaml
+++ b/tt-train/configs/model_configs/dit_tiny.yaml
@@ -1,0 +1,10 @@
+dit_config:
+  model_type: "dit"
+  embedding_dim: 128
+  num_heads: 4
+  num_blocks: 4
+  mlp_ratio: 4.0
+  patch_size: 4
+  image_size: 32
+  image_channels: 3
+  num_classes: 10

--- a/tt-train/configs/training_configs/training_cifar10_dit_s.yaml
+++ b/tt-train/configs/training_configs/training_cifar10_dit_s.yaml
@@ -1,0 +1,35 @@
+training_config:
+  project_name: "tt_train_dit"
+  seed: 5489
+  batch_size: 128
+  max_steps: 50000
+  model_save_interval: 5000
+  data_path: "data/cifar-10"
+  output_dir: "runs/dit"
+  model_config: "${TT_METAL_RUNTIME_ROOT}/tt-train/configs/model_configs/dit_s.yaml"
+  optimizer:
+    type: AdamW
+    lr: 0.0002
+    beta1: 0.9
+    beta2: 0.999
+    epsilon: 1.0e-8
+    weight_decay: 0.0
+
+diffusion_config:
+  timesteps: 1000
+  beta_start: 0.0001
+  beta_end: 0.02
+  cfg_drop_prob: 0.1
+
+eval_config:
+  sample_interval: 5000
+  sample_steps: 50
+  cfg_scale: 2.0
+
+logging_config:
+  log_interval: 100
+  wandb: false
+
+device_config:
+  enable_ddp: false
+  mesh_shape: [1, 1]

--- a/tt-train/configs/training_configs/training_cifar10_dit_s_p2_galaxy.yaml
+++ b/tt-train/configs/training_configs/training_cifar10_dit_s_p2_galaxy.yaml
@@ -1,0 +1,39 @@
+training_config:
+  project_name: "tt_train_dit"
+  seed: 5489
+  batch_size: 2048
+  max_steps: 6250
+  model_save_interval: 1000
+  data_path: "data/cifar-10"
+  output_dir: "runs/dit"
+  model_config: "${TT_METAL_RUNTIME_ROOT}/tt-train/configs/model_configs/dit_s_p2.yaml"
+  lr_schedule: cosine
+  warmup_steps: 250
+  ema_decay: 0.9995
+  ema_interval: 25
+  optimizer:
+    type: AdamW
+    lr: 0.0008
+    beta1: 0.9
+    beta2: 0.999
+    epsilon: 1.0e-8
+    weight_decay: 0.0
+
+diffusion_config:
+  timesteps: 1000
+  beta_start: 0.0001
+  beta_end: 0.02
+  cfg_drop_prob: 0.1
+
+eval_config:
+  sample_interval: 0
+  sample_steps: 50
+  cfg_scale: 2.0
+
+logging_config:
+  log_interval: 100
+  wandb: false
+
+device_config:
+  enable_ddp: false
+  mesh_shape: [32, 1]

--- a/tt-train/configs/training_configs/training_cifar10_dit_s_p2_v2.yaml
+++ b/tt-train/configs/training_configs/training_cifar10_dit_s_p2_v2.yaml
@@ -1,0 +1,39 @@
+training_config:
+  project_name: "tt_train_dit"
+  seed: 5489
+  batch_size: 128
+  max_steps: 100000
+  model_save_interval: 10000
+  data_path: "data/cifar-10"
+  output_dir: "runs/dit"
+  model_config: "${TT_METAL_RUNTIME_ROOT}/tt-train/configs/model_configs/dit_s_p2.yaml"
+  lr_schedule: cosine
+  warmup_steps: 1000
+  ema_decay: 0.9999
+  ema_interval: 100
+  optimizer:
+    type: AdamW
+    lr: 0.0002
+    beta1: 0.9
+    beta2: 0.999
+    epsilon: 1.0e-8
+    weight_decay: 0.0
+
+diffusion_config:
+  timesteps: 1000
+  beta_start: 0.0001
+  beta_end: 0.02
+  cfg_drop_prob: 0.1
+
+eval_config:
+  sample_interval: 10000
+  sample_steps: 50
+  cfg_scale: 2.0
+
+logging_config:
+  log_interval: 100
+  wandb: false
+
+device_config:
+  enable_ddp: false
+  mesh_shape: [1, 1]

--- a/tt-train/configs/training_configs/training_cifar10_dit_tiny.yaml
+++ b/tt-train/configs/training_configs/training_cifar10_dit_tiny.yaml
@@ -1,0 +1,35 @@
+training_config:
+  project_name: "tt_train_dit"
+  seed: 5489
+  batch_size: 32
+  max_steps: 5000
+  model_save_interval: 1000
+  data_path: "data/cifar-10"
+  output_dir: "runs/dit"
+  model_config: "${TT_METAL_RUNTIME_ROOT}/tt-train/configs/model_configs/dit_tiny.yaml"
+  optimizer:
+    type: AdamW
+    lr: 0.0001
+    beta1: 0.9
+    beta2: 0.999
+    epsilon: 1.0e-8
+    weight_decay: 0.0
+
+diffusion_config:
+  timesteps: 1000
+  beta_start: 0.0001
+  beta_end: 0.02
+  cfg_drop_prob: 0.1
+
+eval_config:
+  sample_interval: 1000
+  sample_steps: 50
+  cfg_scale: 2.0
+
+logging_config:
+  log_interval: 50
+  wandb: false
+
+device_config:
+  enable_ddp: false
+  mesh_shape: [1, 1]

--- a/tt-train/sources/examples/dit/README.md
+++ b/tt-train/sources/examples/dit/README.md
@@ -1,0 +1,72 @@
+# DiT: Diffusion Transformer training on tt-train
+
+Class-conditional image-generation training (DDPM objective, DiT architecture)
+implemented entirely in Python on `ttml` — the first non-LLM training example
+in tt-train. Trains on CIFAR-10 in pixel space and scales from one chip to a
+32-chip Galaxy via data parallelism.
+
+Measured on Blackhole (p150): DiT-S (32.6M params, patch 4) trains at
+~1,050–1,300 img/s on a single chip (batch 64–256); the patch-2 variant reaches
+~2,380 img/s at global batch 2,048 across a 32-chip Galaxy (DDP).
+
+## Layout
+
+| File | Purpose |
+|---|---|
+| `dit_ttml.py` | The model: DiT blocks (adaLN-zero), non-causal attention, custom `SliceLastDim` autograd op |
+| `diffusion.py` | Host-side (numpy) DDPM schedule, patchify/unpatchify, batch construction |
+| `train_dit_cifar.py` | Config-driven trainer: EMA, cosine LR, DDP, checkpointing |
+| `sample_from_ckpt.py` | Offline DDIM sampling (with CFG) from a saved checkpoint |
+| `test_device_primitives.py` | On-device gate: every primitive the model relies on, cheapest first |
+| `reference_torch.py`, `test_reference.py` | PyTorch golden model (CPU) mirroring the ttml implementation 1:1 |
+
+## Run
+
+```bash
+# gate the device primitives first
+python test_device_primitives.py
+
+# single chip, small model (sanity: ~4 min at ~1.4k img/s)
+python train_dit_cifar.py -c ${TT_METAL_RUNTIME_ROOT}/tt-train/configs/training_configs/training_cifar10_dit_tiny.yaml
+
+# single chip, DiT-S patch-2 with EMA + cosine (the "quality" recipe)
+python train_dit_cifar.py -c .../training_cifar10_dit_s_p2_v2.yaml
+
+# 32-chip Galaxy DDP (set the mesh graph descriptor first)
+export TT_MESH_GRAPH_DESC_PATH=${TT_METAL_RUNTIME_ROOT}/tt-train/configs/mgd/bh_galaxy_32_1_ring_ring.textproto
+python train_dit_cifar.py -c .../training_cifar10_dit_s_p2_galaxy.yaml
+
+# sample a checkpoint
+python sample_from_ckpt.py -c <training_config.yaml> --ckpt runs/dit/<run>/ckpt_ema_XXXXXX.npz
+```
+
+CIFAR-10 downloads automatically to `training_config.data_path` on first run.
+`--overfit-batch --max-steps 300` trains on one fixed batch (bring-up sanity:
+loss must collapse).
+
+## Design notes (framework workarounds, kept intentionally visible)
+
+- **Patchify lives on the host.** There is no autograd permute/transpose, only
+  `reshape` — so images are patchified in the dataloader (leaf tensors need no
+  grad) and the loss is computed in patch-token space, which is mathematically
+  identical. Unpatchify happens only at sampling time, also host-side.
+- **Labels are one-hot through a bias-free linear**, not `Embedding`:
+  `ttnn::embedding_backward` requires the index tensor's last dim to be a
+  multiple of TILE_WIDTH, which a single per-image label cannot satisfy.
+- **Attention uses the composite SDPA with `mask=None`.** The fused SDPA kernel
+  interprets a missing mask as *causal*; full attention via an explicit
+  all-ones Arbitrary mask is numerically correct but showed no speedup at
+  these sequence lengths.
+- **adaLN modulation is n linears sharing one SiLU**, with the scale branch's
+  bias initialized to 1 so the linear emits `(1 + scale)` directly. A fused
+  D→6D linear + `ttnn.slice`/`concat` split (see `SliceLastDim`) is provided
+  and autograd-correct, but measured ~6.5× *slower* — the training step is
+  dispatch/op-count sensitive; prefer fewer, larger ops.
+- **Checkpoint reads use `PreferredPrecision.NATIVE`.** The default
+  `to_numpy()` precision=FULL path caches its first fp32 view and never
+  refreshes it (#41657), which silently freezes checkpoints/EMA at their
+  first-read values.
+- **DDP** shards the global batch over the `dp` mesh axis (`axis_mapper`),
+  averages gradients with `ttml.sync_gradients` after backward, and reads
+  losses/params through a concat composer (first replica kept). In-loop
+  sampling is disabled under DDP; sample offline from checkpoints.

--- a/tt-train/sources/examples/dit/diffusion.py
+++ b/tt-train/sources/examples/dit/diffusion.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Host-side diffusion utilities (numpy) shared by the ttml training loop.
+
+Same math as the torch versions in reference_torch.py; kept torch-free so the
+device training loop only needs numpy on the host.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def patchify(images: np.ndarray, patch: int) -> np.ndarray:
+    """[B, C, H, W] -> [B, 1, T, patch*patch*C]."""
+    b, c, h, w = images.shape
+    gh, gw = h // patch, w // patch
+    x = images.reshape(b, c, gh, patch, gw, patch)
+    x = x.transpose(0, 2, 4, 3, 5, 1)
+    return x.reshape(b, 1, gh * gw, patch * patch * c)
+
+
+def unpatchify(tokens: np.ndarray, patch: int, channels: int, height: int, width: int) -> np.ndarray:
+    """[B, 1, T, patch*patch*C] -> [B, C, H, W]."""
+    b = tokens.shape[0]
+    gh, gw = height // patch, width // patch
+    x = tokens.reshape(b, gh, gw, patch, patch, channels)
+    x = x.transpose(0, 5, 1, 3, 2, 4)
+    return x.reshape(b, channels, height, width)
+
+
+def timestep_features(t: np.ndarray, dim: int, max_period: int = 10000) -> np.ndarray:
+    """[B] int -> [B, 1, 1, dim] fp32 sinusoidal features."""
+    half = dim // 2
+    freqs = np.exp(-np.log(max_period) * np.arange(half, dtype=np.float32) / half)
+    args = t.astype(np.float32)[:, None] * freqs[None]
+    emb = np.concatenate([np.cos(args), np.sin(args)], axis=-1).astype(np.float32)
+    return emb.reshape(t.shape[0], 1, 1, dim)
+
+
+class DiffusionSchedule:
+    """Linear-beta DDPM schedule, fp32."""
+
+    def __init__(self, timesteps: int = 1000, beta_start: float = 1e-4, beta_end: float = 2e-2):
+        self.timesteps = timesteps
+        self.betas = np.linspace(beta_start, beta_end, timesteps, dtype=np.float32)
+        self.alphas_bar = np.cumprod(1.0 - self.betas, axis=0)
+        self.sqrt_alphas_bar = np.sqrt(self.alphas_bar)
+        self.sqrt_one_minus_alphas_bar = np.sqrt(1.0 - self.alphas_bar)
+
+    def add_noise(self, x0: np.ndarray, noise: np.ndarray, t: np.ndarray) -> np.ndarray:
+        a = self.sqrt_alphas_bar[t].reshape(-1, 1, 1, 1)
+        s = self.sqrt_one_minus_alphas_bar[t].reshape(-1, 1, 1, 1)
+        return (a * x0 + s * noise).astype(np.float32)
+
+
+def make_training_batch(
+    images: np.ndarray,  # [B, C, H, W] fp32 in [-1, 1]
+    labels: np.ndarray,  # [B] int
+    schedule: DiffusionSchedule,
+    patch: int,
+    model_dim: int,
+    rng: np.random.Generator,
+    cfg_drop_prob: float = 0.1,
+    null_class: int | None = None,
+):
+    """Returns (tokens, t_feats, labels_onehot, target) as numpy arrays ready
+    for Tensor.from_numpy: [B,1,T,in], [B,1,1,dim], [B,1,1,null_class+1] fp32
+    one-hot, [B,1,T,in]. One-hot (not ids): the model embeds labels via
+    one-hot @ W because ttnn embedding_backward can't take a single id."""
+    b = images.shape[0]
+    t = rng.integers(0, schedule.timesteps, size=b)
+    noise = rng.standard_normal(images.shape).astype(np.float32)
+    noisy = schedule.add_noise(images, noise, t)
+
+    if null_class is not None and cfg_drop_prob > 0:
+        drop = rng.random(b) < cfg_drop_prob
+        labels = np.where(drop, null_class, labels)
+
+    tokens = patchify(noisy, patch)
+    target = patchify(noise, patch)
+    t_feats = timestep_features(t, model_dim)
+    labels_onehot = one_hot(labels, (null_class if null_class is not None else int(labels.max())) + 1)
+    return tokens, t_feats, labels_onehot, target
+
+
+def one_hot(labels: np.ndarray, num_columns: int) -> np.ndarray:
+    """[B] int -> [B, 1, 1, num_columns] fp32 one-hot."""
+    b = labels.shape[0]
+    out = np.zeros((b, num_columns), dtype=np.float32)
+    out[np.arange(b), labels.astype(np.int64)] = 1.0
+    return out.reshape(b, 1, 1, num_columns)

--- a/tt-train/sources/examples/dit/dit_ttml.py
+++ b/tt-train/sources/examples/dit/dit_ttml.py
@@ -1,0 +1,265 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Class-conditional DiT implemented on ttml (pure Python).
+
+Mirrors reference_torch.py 1:1. The model works entirely in patch-token
+space: patchify/unpatchify, the DDPM schedule, and sinusoidal timestep
+features all live on the host (see diffusion.py). Rank-4 shapes throughout:
+
+    tokens  [B, 1, T, in_dim]   noisy patch tokens
+    t_feats [B, 1, 1, dim]      sinusoidal timestep features
+    labels  [B, 1, 1, 1]        uint32 class ids (num_classes = CFG null)
+    output  [B, 1, T, in_dim]   predicted noise tokens
+
+adaLN modulation uses six separate zero-init linears per block (ttml has no
+autograd split). Conditioning tensors are [B, 1, 1, dim] and rely on ttnn
+row-broadcast in binary add/mul against [B, 1, T, dim] activations; if that
+ever regresses, see broadcast_rows() below for a matmul-based fallback.
+"""
+
+from __future__ import annotations
+
+import ttml
+from ttml.modules import AbstractModuleBase, LinearLayer, Parameter
+from ttml.modules.module_base import ModuleList
+
+
+def broadcast_rows(c: "ttml.autograd.Tensor", num_tokens: int) -> "ttml.autograd.Tensor":
+    """[B,1,1,D] -> [B,1,T,D] via ones[T,1] @ c[1,D]; autograd-correct
+    broadcast fallback for platforms where binary-op row broadcast fails."""
+    import numpy as np
+
+    ones = ttml.autograd.Tensor.from_numpy(np.ones((1, 1, num_tokens, 1), dtype=np.float32))
+    return ttml.ops.matmul.matmul_op(ones, c)
+
+
+class LayerNorm(AbstractModuleBase):
+    """LayerNorm with gamma/beta initialized to identity (ones/zeros).
+
+    The torch reference uses no-affine LN; identical at init, and the
+    modulation supplies the effective affine either way.
+    """
+
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+        shape = (1, 1, 1, dim)
+        self.gamma = Parameter(ttml.init.ones()(shape))
+        self.beta = Parameter(ttml.init.zeros()(shape))
+
+    def forward(self, x):
+        return ttml.ops.layernorm.layernorm(x, self.gamma.tensor, self.beta.tensor)
+
+
+class Modulation(AbstractModuleBase):
+    """One adaLN branch: SiLU(c) -> Linear(dim, dim), zero-init."""
+
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+        self.linear = LinearLayer(dim, dim, True, weight_init=ttml.init.zeros(), bias_init=ttml.init.zeros())
+
+    def forward(self, c):
+        return self.linear(ttml.ops.unary.silu(c))
+
+
+class SliceLastDim(ttml.autograd.Function):
+    """Autograd slice on the last dim: ttnn.slice fwd, ttnn.pad bwd.
+
+    Fills the no-autograd-split gap so adaLN can use one fused D->n*D linear
+    (canonical DiT form) instead of n separate linears. Slice boundaries must
+    be tile-aligned (multiples of 32), which holds for any dim % 32 == 0.
+    """
+
+    @staticmethod
+    def forward(ctx, x, start, size):
+        import ttnn
+
+        v = x.get_value()
+        shape = list(v.shape)
+        ctx.start, ctx.size, ctx.total = start, size, shape[-1]
+        begins = [0] * len(shape)
+        ends = shape[:-1] + [0]
+        begins[-1], ends[-1] = start, start + size
+        return ttnn.slice(v, begins, ends)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        import ttnn
+
+        # ttnn.pad on TILE layout cannot front-pad, so place the grad at its
+        # offset via concat with zero blocks. All widths are tile-aligned.
+        def zeros(width):
+            shape = list(grad_output.shape)
+            shape[-1] = width
+            return ttnn.zeros(shape, dtype=grad_output.dtype, layout=grad_output.layout, device=grad_output.device())
+
+        parts = []
+        if ctx.start > 0:
+            parts.append(zeros(ctx.start))
+        parts.append(grad_output)
+        back = ctx.total - ctx.start - ctx.size
+        if back > 0:
+            parts.append(zeros(back))
+        # Exactly one gradient: only x is a tensor input (start/size are ints,
+        # which Function.apply filters out of the tensor-input list).
+        return ttnn.concat(parts, dim=-1) if len(parts) > 1 else grad_output
+
+
+class FusedModulation(AbstractModuleBase):
+    """n adaLN branches sharing one SiLU: SiLU(c) -> n zero-init linears.
+
+    NOTE(perf): a truly fused form (1 linear D->n*D + n slices via SliceLastDim)
+    measured 6.5x SLOWER — the training step is dispatch-bound and eager
+    ttnn.slice/concat/zeros cost more than the small matmuls they replace.
+    Sharing the SiLU keeps op count strictly lower than n full branches.
+    A single fused modulation kernel (tt-lang) is the real fix later.
+    """
+
+    def __init__(self, dim: int, n: int, scale_slots: tuple[int, ...] = ()) -> None:
+        super().__init__()
+        self.dim, self.n = dim, n
+        # Scale branches get bias init = 1 so the linear emits (1 + scale)
+        # directly — saves a broadcast-add (+ its backward) per modulate site.
+        self.branches = ModuleList(
+            [
+                LinearLayer(
+                    dim, dim, True,
+                    weight_init=ttml.init.zeros(),
+                    bias_init=ttml.init.ones() if i in scale_slots else ttml.init.zeros(),
+                )
+                for i in range(n)
+            ]
+        )
+
+    def forward(self, c):
+        s = ttml.ops.unary.silu(c)
+        return [branch(s) for branch in self.branches]
+
+
+class Attention(AbstractModuleBase):
+    """Non-causal MHA.
+
+    Two paths: composite SDPA with mask=None (true non-causal, multi-dispatch)
+    or the fused SDPA kernel with an explicit all-ones Arbitrary mask
+    (validated numerically equal, max err 0.006). The fused kernel treats
+    mask=None as CAUSAL, hence the ones mask.
+    """
+
+    _ones_masks: dict = {}
+
+    def __init__(self, dim: int, num_heads: int, use_fused: bool = False) -> None:
+        super().__init__()
+        self.num_heads = num_heads
+        self.use_fused = use_fused
+        self.qkv = LinearLayer(dim, dim * 3, True, weight_init=ttml.init.normal(0.0, 0.02), bias_init=ttml.init.zeros())
+        self.proj = LinearLayer(dim, dim, True, weight_init=ttml.init.normal(0.0, 0.02), bias_init=ttml.init.zeros())
+
+    def forward(self, x):
+        import numpy as np
+
+        qkv = self.qkv(x)
+        q, k, v = ttml.ops.multi_head_utils.heads_creation(qkv, self.num_heads)
+        if self.use_fused:
+            seq = x.shape()[2]
+            mask = Attention._ones_masks.get(seq)
+            if mask is None:
+                mask = ttml.autograd.Tensor.from_numpy(np.ones((1, 1, seq, seq), dtype=np.float32))
+                Attention._ones_masks[seq] = mask
+            out = ttml.ops.attention.scaled_dot_product_attention(q, k, v, mask)
+        else:
+            out = ttml.ops.attention.scaled_dot_product_attention_composite(q, k, v, None)
+        return self.proj(ttml.ops.multi_head_utils.heads_fusion(out))
+
+
+class MLP(AbstractModuleBase):
+    def __init__(self, dim: int, mlp_ratio: float = 4.0) -> None:
+        super().__init__()
+        hidden = int(dim * mlp_ratio)
+        self.fc1 = LinearLayer(dim, hidden, True, weight_init=ttml.init.normal(0.0, 0.02), bias_init=ttml.init.zeros())
+        self.fc2 = LinearLayer(hidden, dim, True, weight_init=ttml.init.normal(0.0, 0.02), bias_init=ttml.init.zeros())
+
+    def forward(self, x):
+        return self.fc2(ttml.ops.unary.gelu(self.fc1(x)))
+
+
+def _modulate(x_norm, scale1p, shift):
+    """x_norm * scale1p + shift, with scale1p/shift [B,1,1,D].
+
+    scale1p is (1 + scale): the scale branch's bias is initialized to ones,
+    so no explicit +1 op is needed.
+    """
+    add, mul = ttml.ops.binary.add, ttml.ops.binary.mul
+    return add(mul(x_norm, scale1p), shift)
+
+
+class DiTBlock(AbstractModuleBase):
+    def __init__(self, dim: int, num_heads: int, mlp_ratio: float = 4.0, use_fused_sdpa: bool = False) -> None:
+        super().__init__()
+        self.norm1 = LayerNorm(dim)
+        self.attn = Attention(dim, num_heads, use_fused=use_fused_sdpa)
+        self.norm2 = LayerNorm(dim)
+        self.mlp = MLP(dim, mlp_ratio)
+        # order: shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp
+        self.modulation = FusedModulation(dim, 6, scale_slots=(1, 4))
+
+    def forward(self, x, c):
+        add, mul = ttml.ops.binary.add, ttml.ops.binary.mul
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.modulation(c)
+        h = _modulate(self.norm1(x), scale_msa, shift_msa)
+        x = add(x, mul(self.attn(h), gate_msa))
+        h = _modulate(self.norm2(x), scale_mlp, shift_mlp)
+        x = add(x, mul(self.mlp(h), gate_mlp))
+        return x
+
+
+class DiT(AbstractModuleBase):
+    def __init__(
+        self,
+        in_dim: int,
+        dim: int,
+        depth: int,
+        num_heads: int,
+        num_tokens: int,
+        num_classes: int,
+        mlp_ratio: float = 4.0,
+        use_fused_sdpa: bool = False,
+    ) -> None:
+        super().__init__()
+        self.dim = dim
+        self.num_tokens = num_tokens
+        self.num_classes = num_classes
+
+        self.patch_proj = LinearLayer(
+            in_dim, dim, True, weight_init=ttml.init.normal(0.0, 0.02), bias_init=ttml.init.zeros()
+        )
+        self.pos_emb = Parameter(ttml.init.normal(0.0, 0.02)((1, 1, num_tokens, dim)))
+        self.t_fc1 = LinearLayer(dim, dim, True, weight_init=ttml.init.normal(0.0, 0.02), bias_init=ttml.init.zeros())
+        self.t_fc2 = LinearLayer(dim, dim, True, weight_init=ttml.init.normal(0.0, 0.02), bias_init=ttml.init.zeros())
+        # One-hot labels through a bias-free linear (== an embedding table).
+        # ttnn's embedding_backward needs ids' last dim % 32 == 0, which a
+        # single per-image label can't satisfy; one-hot @ W has no such limit.
+        self.label_emb = LinearLayer(num_classes + 1, dim, False, weight_init=ttml.init.normal(0.0, 0.02))
+        self.blocks = ModuleList([DiTBlock(dim, num_heads, mlp_ratio, use_fused_sdpa) for _ in range(depth)])
+        self.final_norm = LayerNorm(dim)
+        self.final_modulation = FusedModulation(dim, 2, scale_slots=(1,))  # (shift, scale1p)
+        self.final_proj = LinearLayer(dim, in_dim, True, weight_init=ttml.init.zeros(), bias_init=ttml.init.zeros())
+
+    def forward(self, tokens, t_feats, labels_onehot):
+        add = ttml.ops.binary.add
+        x = add(self.patch_proj(tokens), self.pos_emb.tensor)
+        t_emb = self.t_fc2(ttml.ops.unary.silu(self.t_fc1(t_feats)))
+        c = add(t_emb, self.label_emb(labels_onehot))
+        for block in self.blocks:
+            x = block(x, c)
+        final_shift, final_scale = self.final_modulation(c)
+        x = _modulate(self.final_norm(x), final_scale, final_shift)
+        return self.final_proj(x)
+
+
+def dit_s(in_dim: int, num_tokens: int, num_classes: int) -> DiT:
+    return DiT(in_dim=in_dim, dim=384, depth=12, num_heads=6, num_tokens=num_tokens, num_classes=num_classes)
+
+
+def dit_tiny(in_dim: int, num_tokens: int, num_classes: int) -> DiT:
+    return DiT(in_dim=in_dim, dim=128, depth=4, num_heads=4, num_tokens=num_tokens, num_classes=num_classes)

--- a/tt-train/sources/examples/dit/reference_torch.py
+++ b/tt-train/sources/examples/dit/reference_torch.py
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Golden PyTorch DiT reference for the ttml bringup.
+
+Deliberately structured to mirror the constraints of the planned ttml
+implementation so layer-by-layer parity checks are 1:1:
+
+- patchify/unpatchify happen on the host (dataloader), never in the graph;
+  the model consumes and predicts patch tokens of shape [B, 1, T, D]
+  (rank-4, matching ttml's tensor convention),
+- adaLN modulation uses six separate zero-init linears per block instead of
+  one chunked 6*D linear (ttml has no autograd split),
+- LayerNorm carries no learnable affine inside blocks (modulation supplies
+  scale/shift),
+- timestep sinusoidal features are computed on the host and fed as an input,
+- loss is MSE in token space (targets are patchified on the host too).
+"""
+
+import math
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+
+
+# ---------------------------------------------------------------------------
+# Host-side (dataloader) utilities — shared verbatim with the ttml pipeline.
+# ---------------------------------------------------------------------------
+
+
+def patchify(images: torch.Tensor, patch: int) -> torch.Tensor:
+    """[B, C, H, W] -> [B, 1, T, patch*patch*C] with T = (H/p)*(W/p)."""
+    b, c, h, w = images.shape
+    gh, gw = h // patch, w // patch
+    x = images.reshape(b, c, gh, patch, gw, patch)
+    x = x.permute(0, 2, 4, 3, 5, 1)  # B, gh, gw, p, p, C
+    return x.reshape(b, 1, gh * gw, patch * patch * c)
+
+
+def unpatchify(tokens: torch.Tensor, patch: int, channels: int, height: int, width: int) -> torch.Tensor:
+    """[B, 1, T, patch*patch*C] -> [B, C, H, W]. Inverse of patchify."""
+    b = tokens.shape[0]
+    gh, gw = height // patch, width // patch
+    x = tokens.reshape(b, gh, gw, patch, patch, channels)
+    x = x.permute(0, 5, 1, 3, 2, 4)
+    return x.reshape(b, channels, height, width)
+
+
+def timestep_features(t: torch.Tensor, dim: int, max_period: int = 10000) -> torch.Tensor:
+    """Sinusoidal features [B] -> [B, 1, 1, dim], fp32 on host."""
+    half = dim // 2
+    freqs = torch.exp(-math.log(max_period) * torch.arange(half, dtype=torch.float32) / half)
+    args = t.float()[:, None] * freqs[None]
+    emb = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+    return emb.reshape(t.shape[0], 1, 1, dim)
+
+
+@dataclass
+class DiffusionSchedule:
+    """Linear-beta DDPM schedule; all tensors precomputed fp32 on host."""
+
+    timesteps: int = 1000
+    beta_start: float = 1e-4
+    beta_end: float = 2e-2
+
+    def __post_init__(self):
+        betas = torch.linspace(self.beta_start, self.beta_end, self.timesteps, dtype=torch.float32)
+        alphas_bar = torch.cumprod(1.0 - betas, dim=0)
+        self.sqrt_alphas_bar = alphas_bar.sqrt()
+        self.sqrt_one_minus_alphas_bar = (1.0 - alphas_bar).sqrt()
+        self.betas = betas
+        self.alphas_bar = alphas_bar
+
+    def add_noise(self, x0: torch.Tensor, noise: torch.Tensor, t: torch.Tensor) -> torch.Tensor:
+        a = self.sqrt_alphas_bar[t].reshape(-1, 1, 1, 1)
+        s = self.sqrt_one_minus_alphas_bar[t].reshape(-1, 1, 1, 1)
+        return a * x0 + s * noise
+
+
+# ---------------------------------------------------------------------------
+# Model — every submodule maps 1:1 onto existing ttml modules/ops.
+# ---------------------------------------------------------------------------
+
+
+class Modulation(nn.Module):
+    """One adaLN modulation branch: SiLU(c) -> Linear (zero-init)."""
+
+    def __init__(self, dim: int, zero_init: bool = True):
+        super().__init__()
+        self.linear = nn.Linear(dim, dim)
+        if zero_init:
+            nn.init.zeros_(self.linear.weight)
+            nn.init.zeros_(self.linear.bias)
+
+    def forward(self, c: torch.Tensor) -> torch.Tensor:
+        return self.linear(torch.nn.functional.silu(c))
+
+
+class Attention(nn.Module):
+    """Non-causal MHA; mirrors ttml MultiHeadAttention (fused qkv, SDPA)."""
+
+    def __init__(self, dim: int, num_heads: int):
+        super().__init__()
+        self.num_heads = num_heads
+        self.qkv = nn.Linear(dim, 3 * dim)
+        self.proj = nn.Linear(dim, dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        b, one, t, d = x.shape
+        qkv = self.qkv(x).reshape(b, t, 3, self.num_heads, d // self.num_heads)
+        q, k, v = (qkv[:, :, i].transpose(1, 2) for i in range(3))
+        out = torch.nn.functional.scaled_dot_product_attention(q, k, v)  # non-causal
+        out = out.transpose(1, 2).reshape(b, 1, t, d)
+        return self.proj(out)
+
+
+class DiTBlock(nn.Module):
+    def __init__(self, dim: int, num_heads: int, mlp_ratio: float = 4.0):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(dim, elementwise_affine=False, eps=1e-6)
+        self.attn = Attention(dim, num_heads)
+        self.norm2 = nn.LayerNorm(dim, elementwise_affine=False, eps=1e-6)
+        hidden = int(dim * mlp_ratio)
+        self.mlp = nn.Sequential(nn.Linear(dim, hidden), nn.GELU(approximate="tanh"), nn.Linear(hidden, dim))
+        # Six separate zero-init modulation linears (no chunk/split in ttml).
+        self.shift_msa = Modulation(dim)
+        self.scale_msa = Modulation(dim)
+        self.gate_msa = Modulation(dim)
+        self.shift_mlp = Modulation(dim)
+        self.scale_mlp = Modulation(dim)
+        self.gate_mlp = Modulation(dim)
+
+    def forward(self, x: torch.Tensor, c: torch.Tensor) -> torch.Tensor:
+        h = self.norm1(x) * (1.0 + self.scale_msa(c)) + self.shift_msa(c)
+        x = x + self.gate_msa(c) * self.attn(h)
+        h = self.norm2(x) * (1.0 + self.scale_mlp(c)) + self.shift_mlp(c)
+        x = x + self.gate_mlp(c) * self.mlp(h)
+        return x
+
+
+class DiT(nn.Module):
+    """Class-conditional pixel/latent-space DiT over pre-patchified tokens.
+
+    Inputs:
+        tokens  [B, 1, T, in_dim]  — patchified noisy images (host-side)
+        t_feats [B, 1, 1, dim]     — sinusoidal timestep features (host-side)
+        labels  [B]                — class ids; num_classes is the CFG null id
+    Output:
+        [B, 1, T, in_dim] predicted noise, in token space.
+    """
+
+    def __init__(self, in_dim: int, dim: int, depth: int, num_heads: int, num_tokens: int, num_classes: int):
+        super().__init__()
+        self.patch_proj = nn.Linear(in_dim, dim)
+        self.pos_emb = nn.Parameter(torch.zeros(1, 1, num_tokens, dim))
+        nn.init.trunc_normal_(self.pos_emb, std=0.02)
+        self.t_mlp = nn.Sequential(nn.Linear(dim, dim), nn.SiLU(), nn.Linear(dim, dim))
+        self.label_emb = nn.Embedding(num_classes + 1, dim)  # +1 = CFG null class
+        self.blocks = nn.ModuleList([DiTBlock(dim, num_heads) for _ in range(depth)])
+        self.final_norm = nn.LayerNorm(dim, elementwise_affine=False, eps=1e-6)
+        self.final_shift = Modulation(dim)
+        self.final_scale = Modulation(dim)
+        self.final_proj = nn.Linear(dim, in_dim)
+        nn.init.zeros_(self.final_proj.weight)
+        nn.init.zeros_(self.final_proj.bias)
+
+    def forward(self, tokens: torch.Tensor, t_feats: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        x = self.patch_proj(tokens) + self.pos_emb
+        c = self.t_mlp(t_feats) + self.label_emb(labels).reshape(labels.shape[0], 1, 1, -1)
+        for block in self.blocks:
+            x = block(x, c)
+        x = self.final_norm(x) * (1.0 + self.final_scale(c)) + self.final_shift(c)
+        return self.final_proj(x)
+
+
+def dit_s(in_dim: int, num_tokens: int, num_classes: int) -> DiT:
+    return DiT(in_dim=in_dim, dim=384, depth=12, num_heads=6, num_tokens=num_tokens, num_classes=num_classes)
+
+
+def dit_tiny(in_dim: int, num_tokens: int, num_classes: int) -> DiT:
+    """Small enough to overfit a batch on CPU in seconds; same topology."""
+    return DiT(in_dim=in_dim, dim=128, depth=4, num_heads=4, num_tokens=num_tokens, num_classes=num_classes)
+
+
+# ---------------------------------------------------------------------------
+# Training step — identical math to the planned ttml loop.
+# ---------------------------------------------------------------------------
+
+
+def training_step(
+    model: DiT,
+    schedule: DiffusionSchedule,
+    images: torch.Tensor,  # [B, C, H, W] in [-1, 1]
+    labels: torch.Tensor,  # [B]
+    patch: int,
+    cfg_drop_prob: float = 0.1,
+    null_class: int | None = None,
+    generator: torch.Generator | None = None,
+) -> torch.Tensor:
+    b = images.shape[0]
+    t = torch.randint(0, schedule.timesteps, (b,), generator=generator)
+    noise = torch.randn(images.shape, generator=generator)
+    noisy = schedule.add_noise(images, noise, t)
+
+    if null_class is not None and cfg_drop_prob > 0:
+        drop = torch.rand(b, generator=generator) < cfg_drop_prob
+        labels = torch.where(drop, torch.full_like(labels, null_class), labels)
+
+    tokens = patchify(noisy, patch)
+    target = patchify(noise, patch)
+    t_feats = timestep_features(t, model.pos_emb.shape[-1])
+    pred = model(tokens, t_feats, labels)
+    return torch.nn.functional.mse_loss(pred, target)
+
+
+@torch.no_grad()
+def sample_ddim(
+    model: DiT,
+    schedule: DiffusionSchedule,
+    labels: torch.Tensor,
+    shape: tuple[int, int, int],  # (C, H, W)
+    patch: int,
+    steps: int = 50,
+    cfg_scale: float = 1.0,
+    null_class: int | None = None,
+    generator: torch.Generator | None = None,
+) -> torch.Tensor:
+    b = labels.shape[0]
+    c, h, w = shape
+    x = torch.randn((b, c, h, w), generator=generator)
+    ts = torch.linspace(schedule.timesteps - 1, 0, steps).long()
+    for i, t in enumerate(ts):
+        t_batch = torch.full((b,), t.item(), dtype=torch.long)
+        t_feats = timestep_features(t_batch, model.pos_emb.shape[-1])
+        tokens = patchify(x, patch)
+        eps = model(tokens, t_feats, labels)
+        if cfg_scale != 1.0 and null_class is not None:
+            null = torch.full_like(labels, null_class)
+            eps_u = model(tokens, t_feats, null)
+            eps = eps_u + cfg_scale * (eps - eps_u)
+        eps = unpatchify(eps, patch, c, h, w)
+
+        ab_t = schedule.alphas_bar[t]
+        x0 = (x - (1 - ab_t).sqrt() * eps) / ab_t.sqrt()
+        x0 = x0.clamp(-1, 1)
+        if i + 1 < len(ts):
+            ab_prev = schedule.alphas_bar[ts[i + 1]]
+            x = ab_prev.sqrt() * x0 + (1 - ab_prev).sqrt() * eps
+        else:
+            x = x0
+    return x

--- a/tt-train/sources/examples/dit/sample_from_ckpt.py
+++ b/tt-train/sources/examples/dit/sample_from_ckpt.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sample a grid from a saved DiT checkpoint (raw or EMA .npz).
+
+    python sample_from_ckpt.py -c <training_config.yaml> --ckpt <ckpt.npz> \
+        [--steps 50] [--cfg-scale 2.0] [--out grid.npy]
+
+Loads weights by parameter name into a freshly built model, then runs the
+DDIM sampler. Works for checkpoints from single-device or DDP runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import numpy as np
+import ttnn
+
+import ttml
+from ttml.common.config import load_config
+
+from diffusion import DiffusionSchedule
+from train_dit_cifar import build_model, sample_grid
+
+
+def load_weights(model, npz_path: str):
+    state = np.load(npz_path)
+    params = model.parameters()
+    missing = [k for k in params if k not in state.files]
+    extra = [k for k in state.files if k not in params]
+    if missing or extra:
+        raise KeyError(f"checkpoint/model mismatch; missing={missing[:3]}... extra={extra[:3]}...")
+    for name, tensor in params.items():
+        loaded = ttml.autograd.Tensor.from_numpy(
+            np.ascontiguousarray(state[name], dtype=np.float32), ttnn.Layout.TILE, ttnn.DataType.BFLOAT16
+        )
+        tensor.set_value(loaded.get_value())
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("-c", "--config", required=True)
+    ap.add_argument("--ckpt", required=True)
+    ap.add_argument("--steps", type=int, default=50)
+    ap.add_argument("--cfg-scale", type=float, default=2.0)
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    ttml.open_device_mesh((1, 1))
+    cfg = load_config(args.config)
+    model_cfg = load_config(cfg["training_config"]["model_config"])["dit_config"]
+    dc = cfg.get("diffusion_config", {})
+
+    model, patch, _ = build_model(model_cfg)
+    load_weights(model, args.ckpt)
+    model.eval()
+
+    schedule = DiffusionSchedule(
+        timesteps=dc.get("timesteps", 1000),
+        beta_start=dc.get("beta_start", 1e-4),
+        beta_end=dc.get("beta_end", 2e-2),
+    )
+    grid = sample_grid(
+        model, schedule, patch, model_cfg["embedding_dim"], model_cfg["num_classes"],
+        model_cfg["image_size"], model_cfg["image_channels"],
+        steps=args.steps, cfg_scale=args.cfg_scale, seed=args.seed,
+    )
+    out = args.out or os.path.splitext(args.ckpt)[0] + f"_samples_s{args.steps}_cfg{args.cfg_scale}.npy"
+    np.save(out, grid)
+    print(f"saved {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tt-train/sources/examples/dit/test_device_primitives.py
+++ b/tt-train/sources/examples/dit/test_device_primitives.py
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""On-device checks for every primitive the DiT relies on, cheapest first.
+
+Run on a machine with a Tenstorrent device:
+    python test_device_primitives.py
+
+Opens a [1,1] mesh explicitly (single chip; avoids multi-chip ethernet paths).
+Backward checks route operands through a LinearLayer so a grad graph exists —
+tensors created via from_numpy are leaves and do not require grad themselves.
+Each check prints OK/FAIL and the script exits nonzero on any failure.
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+
+import numpy as np
+import ttnn
+
+import ttml
+from ttml.modules import LinearLayer
+
+FAILURES = []
+
+
+def check(name):
+    def wrap(fn):
+        def run():
+            try:
+                fn()
+                print(f"OK   {name}", flush=True)
+            except Exception:
+                print(f"FAIL {name}", flush=True)
+                traceback.print_exc()
+                FAILURES.append(name)
+            finally:
+                ttml.autograd.AutoContext.get_instance().reset_graph()
+
+        return run
+
+    return wrap
+
+
+def to_np(t):
+    return t.to_numpy(ttnn.DataType.FLOAT32)
+
+
+def from_np(a):
+    return ttml.autograd.Tensor.from_numpy(np.ascontiguousarray(a, dtype=np.float32))
+
+
+B, T, D = 4, 64, 128
+
+
+@check("roundtrip rank-4 from_numpy/to_numpy")
+def t_roundtrip():
+    a = np.random.randn(B, 1, T, D).astype(np.float32)
+    out = to_np(from_np(a))
+    assert out.shape == (B, 1, T, D), out.shape
+    assert np.allclose(out, a, atol=2e-2), np.abs(out - a).max()  # bf16 tolerance
+
+
+@check("add broadcast pos-emb [1,1,T,D] + [B,1,T,D]")
+def t_add_posemb():
+    x, p = np.random.randn(B, 1, T, D).astype(np.float32), np.random.randn(1, 1, T, D).astype(np.float32)
+    out = to_np(ttml.ops.binary.add(from_np(x), from_np(p)))
+    assert np.allclose(out, x + p, atol=5e-2)
+
+
+@check("mul row-broadcast [B,1,T,D] * [B,1,1,D] fwd+bwd through linear")
+def t_mul_rows():
+    x_np = np.random.randn(B, 1, T, D).astype(np.float32)
+    s_np = np.random.randn(B, 1, 1, D).astype(np.float32)
+    out = ttml.ops.binary.mul(from_np(x_np), from_np(s_np))
+    out_np = to_np(out)
+    # bf16: |err| <= ~1% of |product|; use scaled tolerance
+    tol = 0.02 * np.abs(x_np * s_np) + 5e-2
+    assert (np.abs(out_np - x_np * s_np) <= tol).all(), np.abs(out_np - x_np * s_np).max()
+    # backward: grads must flow through the broadcast into linear params
+    lin = LinearLayer(D, D, True)
+    out2 = ttml.ops.binary.mul(lin(from_np(x_np)), from_np(s_np))
+    loss = ttml.ops.loss.mse_loss(out2, from_np(np.zeros_like(x_np)))
+    loss.backward(False)
+
+
+@check("mul row-broadcast with grad on the [B,1,1,D] side")
+def t_mul_rows_cond_grad():
+    # In adaLN the modulation (small side) is the parameter-dependent branch.
+    x_np = np.random.randn(B, 1, T, D).astype(np.float32)
+    c_np = np.random.randn(B, 1, 1, D).astype(np.float32)
+    lin = LinearLayer(D, D, True)
+    out = ttml.ops.binary.mul(from_np(x_np), lin(from_np(c_np)))
+    loss = ttml.ops.loss.mse_loss(out, from_np(np.zeros_like(x_np)))
+    loss.backward(False)
+
+
+@check("add row-broadcast [B,1,T,D] + [B,1,1,D] fwd+bwd through linear")
+def t_add_rows():
+    x_np = np.random.randn(B, 1, T, D).astype(np.float32)
+    s_np = np.random.randn(B, 1, 1, D).astype(np.float32)
+    out = ttml.ops.binary.add(from_np(x_np), from_np(s_np))
+    assert np.allclose(to_np(out), x_np + s_np, atol=5e-2)
+    lin = LinearLayer(D, D, True)
+    out2 = ttml.ops.binary.add(from_np(x_np), lin(from_np(s_np)))
+    loss = ttml.ops.loss.mse_loss(out2, from_np(np.zeros_like(x_np)))
+    loss.backward(False)
+
+
+@check("one-hot label embed [B,1,1,C] @ linear -> [B,1,1,D] fwd+bwd")
+def t_label_embed():
+    from diffusion import one_hot
+
+    lin = LinearLayer(11, D, False)
+    oh = one_hot(np.array([1, 3, 10, 0]), 11)
+    out = lin(from_np(oh))
+    arr = to_np(out)
+    assert arr.shape[0] == B and arr.shape[-1] == D, arr.shape
+    loss = ttml.ops.loss.mse_loss(out, from_np(np.zeros(arr.shape, dtype=np.float32)))
+    loss.backward(False)
+
+
+@check("composite SDPA non-causal (mask=None) fwd+bwd")
+def t_sdpa():
+    H, hd = 4, D // 4
+    q_np = np.random.randn(B, H, T, hd).astype(np.float32)
+    k_np = np.random.randn(B, H, T, hd).astype(np.float32)
+    v_np = np.random.randn(B, H, T, hd).astype(np.float32)
+    q, k, v = from_np(q_np), from_np(k_np), from_np(v_np)
+    out = ttml.ops.attention.scaled_dot_product_attention_composite(q, k, v, None)
+    att = q_np @ k_np.transpose(0, 1, 3, 2) / np.sqrt(hd)
+    att = np.exp(att - att.max(-1, keepdims=True))
+    att = att / att.sum(-1, keepdims=True)
+    golden = att @ v_np
+    got = to_np(out)
+    assert np.allclose(got, golden, atol=1.5e-1), np.abs(got - golden).max()
+    lin = LinearLayer(hd, hd, True)
+    out2 = ttml.ops.attention.scaled_dot_product_attention_composite(lin(q), k, v, None)
+    loss = ttml.ops.loss.mse_loss(out2, from_np(np.zeros_like(golden)))
+    loss.backward(False)
+
+
+@check("mse_loss value + grad through linear")
+def t_mse():
+    lin = LinearLayer(D, D, True)
+    x = from_np(np.random.randn(B, 1, T, D))
+    tgt = from_np(np.random.randn(B, 1, T, D))
+    loss = ttml.ops.loss.mse_loss(lin(x), tgt)
+    loss.backward(False)
+    val = float(to_np(loss).reshape(-1)[0])
+    assert np.isfinite(val)
+
+
+@check("tiny DiT fwd + bwd + 5 optimizer steps decrease loss")
+def t_dit_end2end():
+    from dit_ttml import dit_tiny
+    from diffusion import DiffusionSchedule, make_training_batch
+
+    rng = np.random.default_rng(0)
+    model = dit_tiny(in_dim=48, num_tokens=64, num_classes=10)
+    sched = DiffusionSchedule()
+    images = (rng.random((B, 3, 32, 32), dtype=np.float32) * 2 - 1).astype(np.float32)
+    labels = rng.integers(0, 10, size=B)
+
+    opt = ttml.optimizers.create_optimizer({"type": "AdamW", "lr": 1e-3}, model.parameters())
+
+    losses = []
+    for step in range(5):
+        rng_step = np.random.default_rng(1)  # fixed batch -> loss must fall
+        tokens, t_feats, onehot, target = make_training_batch(
+            images, labels, sched, patch=4, model_dim=model.dim, rng=rng_step,
+            cfg_drop_prob=0.0, null_class=10,
+        )
+        opt.zero_grad()
+        pred = model(from_np(tokens), from_np(t_feats), from_np(onehot))
+        loss = ttml.ops.loss.mse_loss(pred, from_np(target))
+        loss.backward(False)
+        opt.step()
+        losses.append(float(to_np(loss).reshape(-1)[0]))
+        ttml.autograd.AutoContext.get_instance().reset_graph()
+    print(f"     losses: {[f'{v:.4f}' for v in losses]}", flush=True)
+    assert losses[-1] < losses[0], losses
+
+
+if __name__ == "__main__":
+    ttml.open_device_mesh((1, 1))
+    try:
+        for fn in [
+            t_roundtrip,
+            t_add_posemb,
+            t_mul_rows,
+            t_mul_rows_cond_grad,
+            t_add_rows,
+            t_label_embed,
+            t_sdpa,
+            t_mse,
+            t_dit_end2end,
+        ]:
+            fn()
+    finally:
+        if FAILURES:
+            print("FAILED:", FAILURES, flush=True)
+        else:
+            print("ALL DEVICE PRIMITIVES OK", flush=True)
+    sys.exit(1 if FAILURES else 0)

--- a/tt-train/sources/examples/dit/test_reference.py
+++ b/tt-train/sources/examples/dit/test_reference.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Smoke tests for the golden DiT reference: run `python test_reference.py`."""
+
+import torch
+
+from reference_torch import (
+    DiffusionSchedule,
+    dit_tiny,
+    patchify,
+    sample_ddim,
+    training_step,
+    unpatchify,
+)
+
+
+def test_patchify_roundtrip():
+    x = torch.randn(2, 3, 32, 32)
+    tokens = patchify(x, patch=4)
+    assert tokens.shape == (2, 1, 64, 48)
+    back = unpatchify(tokens, patch=4, channels=3, height=32, width=32)
+    assert torch.equal(x, back)
+    print("patchify roundtrip OK")
+
+
+def test_overfit_single_batch():
+    torch.manual_seed(0)
+    gen = torch.Generator().manual_seed(0)
+    patch, num_classes = 4, 10
+    model = dit_tiny(in_dim=48, num_tokens=64, num_classes=num_classes)
+    schedule = DiffusionSchedule(timesteps=1000)
+    images = torch.rand(8, 3, 32, 32, generator=gen) * 2 - 1
+    labels = torch.randint(0, num_classes, (8,), generator=gen)
+    opt = torch.optim.AdamW(model.parameters(), lr=2e-3)
+
+    first, last = None, None
+    for step in range(150):
+        opt.zero_grad()
+        # fixed sampling seed per step keeps the task deterministic
+        loss = training_step(
+            model, schedule, images, labels, patch,
+            cfg_drop_prob=0.1, null_class=num_classes,
+            generator=torch.Generator().manual_seed(step % 4),
+        )
+        loss.backward()
+        opt.step()
+        first = first if first is not None else loss.item()
+        last = loss.item()
+        if step % 30 == 0:
+            print(f"step {step:4d} loss {loss.item():.4f}")
+    print(f"first {first:.4f} -> last {last:.4f}")
+    assert last < first * 0.5, "did not overfit"
+    print("overfit OK")
+
+
+def test_sampling_runs():
+    torch.manual_seed(0)
+    model = dit_tiny(in_dim=48, num_tokens=64, num_classes=10)
+    schedule = DiffusionSchedule()
+    labels = torch.tensor([0, 1, 2, 3])
+    imgs = sample_ddim(model, schedule, labels, (3, 32, 32), patch=4, steps=8,
+                       cfg_scale=2.0, null_class=10, generator=torch.Generator().manual_seed(1))
+    assert imgs.shape == (4, 3, 32, 32) and torch.isfinite(imgs).all()
+    print("sampling OK")
+
+
+if __name__ == "__main__":
+    test_patchify_roundtrip()
+    test_overfit_single_batch()
+    test_sampling_runs()
+    print("ALL OK")

--- a/tt-train/sources/examples/dit/train_dit_cifar.py
+++ b/tt-train/sources/examples/dit/train_dit_cifar.py
@@ -1,0 +1,324 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Train a class-conditional pixel-space DiT on CIFAR-10 with ttml.
+
+Config-driven like the rest of tt-train:
+
+    python train_dit_cifar.py -c ${TT_METAL_RUNTIME_ROOT}/tt-train/configs/training_configs/training_cifar10_dit_tiny.yaml
+
+Everything host-side is numpy; the model runs on the Tenstorrent device via
+ttml autograd. CIFAR-10 is read from the raw python-pickle tarball (no
+torchvision dependency).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pickle
+import tarfile
+import time
+import urllib.request
+
+import numpy as np
+
+import ttml
+from ttml.common.config import load_config
+
+from diffusion import DiffusionSchedule, make_training_batch, one_hot, timestep_features, patchify, unpatchify
+from dit_ttml import DiT
+
+CIFAR_URL = "https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz"
+
+
+def load_cifar10(data_dir: str) -> tuple[np.ndarray, np.ndarray]:
+    """Returns images [50000, 3, 32, 32] fp32 in [-1, 1] and labels [50000]."""
+    tar_path = os.path.join(data_dir, "cifar-10-python.tar.gz")
+    extract_dir = os.path.join(data_dir, "cifar-10-batches-py")
+    if not os.path.isdir(extract_dir):
+        os.makedirs(data_dir, exist_ok=True)
+        if not os.path.isfile(tar_path):
+            print(f"downloading CIFAR-10 to {tar_path}")
+            urllib.request.urlretrieve(CIFAR_URL, tar_path)
+        with tarfile.open(tar_path, "r:gz") as tar:
+            tar.extractall(data_dir)
+    xs, ys = [], []
+    for i in range(1, 6):
+        # pickle is the official CIFAR-10 distribution format; the tarball is
+        # fetched over HTTPS from the canonical cs.toronto.edu source above.
+        with open(os.path.join(extract_dir, f"data_batch_{i}"), "rb") as f:
+            d = pickle.load(f, encoding="bytes")
+        xs.append(d[b"data"])
+        ys.append(np.array(d[b"labels"]))
+    x = np.concatenate(xs).reshape(-1, 3, 32, 32).astype(np.float32)
+    x = x / 127.5 - 1.0
+    y = np.concatenate(ys).astype(np.int64)
+    return x, y
+
+
+def build_model(model_cfg: dict) -> tuple[DiT, int, int]:
+    patch = model_cfg["patch_size"]
+    image_size = model_cfg["image_size"]
+    channels = model_cfg["image_channels"]
+    in_dim = patch * patch * channels
+    num_tokens = (image_size // patch) ** 2
+    model = DiT(
+        in_dim=in_dim,
+        dim=model_cfg["embedding_dim"],
+        depth=model_cfg["num_blocks"],
+        num_heads=model_cfg["num_heads"],
+        num_tokens=num_tokens,
+        num_classes=model_cfg["num_classes"],
+        mlp_ratio=model_cfg.get("mlp_ratio", 4.0),
+    )
+    return model, patch, num_tokens
+
+
+def _param_to_numpy(t, composer=None, num_devices: int = 1):
+    # precision=NATIVE reads the live bf16 buffer directly. The default
+    # precision=FULL runs a device-side typecast whose fp32 view is CACHED and
+    # never refreshed (tt-train issue #41657) — with it, every checkpoint/EMA
+    # read after the first silently returns stale (init-time) weights.
+    arr = t.to_numpy(None, composer, ttml.autograd.PreferredPrecision.NATIVE).astype(np.float32)
+    if composer is not None and num_devices > 1:
+        # Replicated param read via concat composer stacks the per-device
+        # copies along dim 0; keep the first replica.
+        arr = arr[: arr.shape[0] // num_devices]
+    return arr
+
+
+def save_checkpoint(model, path: str, state: dict | None = None, composer=None, num_devices: int = 1):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    if state is None:
+        state = {name: _param_to_numpy(t, composer, num_devices) for name, t in model.parameters().items()}
+    np.savez(path, **state)
+
+
+class WeightEma:
+    """Host-side EMA of model weights, updated every `interval` steps.
+
+    Per-step decay `decay` is compounded to `decay**interval` so the sparse
+    update matches a per-step EMA. ~130MB host pull per update for DiT-S,
+    amortized to ~1% overhead at interval=100.
+    """
+
+    def __init__(self, model, decay: float = 0.9999, interval: int = 100, composer=None, num_devices: int = 1):
+        self.model, self.interval = model, interval
+        self.composer, self.num_devices = composer, num_devices
+        self.decay_k = decay**interval
+        self.state = {
+            name: _param_to_numpy(t, composer, num_devices) for name, t in model.parameters().items()
+        }
+
+    def maybe_update(self, step: int):
+        if step % self.interval:
+            return
+        for name, t in self.model.parameters().items():
+            cur = _param_to_numpy(t, self.composer, self.num_devices)
+            self.state[name] = self.decay_k * self.state[name] + (1.0 - self.decay_k) * cur
+
+
+def cosine_lr(step: int, max_steps: int, base_lr: float, warmup: int = 500, min_lr_frac: float = 0.05) -> float:
+    if step < warmup:
+        return base_lr * step / max(1, warmup)
+    import math
+
+    t = (step - warmup) / max(1, max_steps - warmup)
+    return base_lr * (min_lr_frac + (1 - min_lr_frac) * 0.5 * (1 + math.cos(math.pi * t)))
+
+
+def sample_grid(model, schedule, patch, dim, num_classes, image_size, channels, steps, cfg_scale, seed=0):
+    """DDIM sampling, one image per class; returns [num_classes, C, H, W]."""
+    rng = np.random.default_rng(seed)
+    b = num_classes
+    labels = np.arange(num_classes, dtype=np.uint32)
+    x = rng.standard_normal((b, channels, image_size, image_size)).astype(np.float32)
+    ts = np.linspace(schedule.timesteps - 1, 0, steps).astype(np.int64)
+
+    ctx = ttml.autograd.AutoContext.get_instance()
+
+    def predict(tokens, t_feats, lbl):
+        import ttnn
+
+        oh = one_hot(lbl, num_classes + 1)
+        pred = model(
+            ttml.autograd.Tensor.from_numpy(tokens),
+            ttml.autograd.Tensor.from_numpy(t_feats),
+            ttml.autograd.Tensor.from_numpy(oh),
+        )
+        out = pred.to_numpy(ttnn.DataType.FLOAT32)
+        ctx.reset_graph()
+        return out
+
+    for i, t in enumerate(ts):
+        t_feats = timestep_features(np.full((b,), t, dtype=np.int64), dim)
+        tokens = patchify(x, patch)
+        eps_tok = predict(tokens, t_feats, labels)
+        if cfg_scale != 1.0:
+            eps_null = predict(tokens, t_feats, np.full((b,), num_classes))
+            eps_tok = eps_null + cfg_scale * (eps_tok - eps_null)
+        eps = unpatchify(eps_tok, patch, channels, image_size, image_size)
+
+        ab_t = schedule.alphas_bar[t]
+        x0 = np.clip((x - np.sqrt(1 - ab_t) * eps) / np.sqrt(ab_t), -1, 1)
+        if i + 1 < len(ts):
+            ab_prev = schedule.alphas_bar[ts[i + 1]]
+            x = np.sqrt(ab_prev) * x0 + np.sqrt(1 - ab_prev) * eps
+        else:
+            x = x0
+    return x
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("-c", "--config", required=True, help="training config yaml")
+    ap.add_argument("--overfit-batch", action="store_true", help="repeat one fixed batch (bringup sanity)")
+    ap.add_argument("--max-steps", type=int, default=None, help="override training_config.max_steps")
+    args = ap.parse_args()
+
+    cfg = load_config(args.config)
+    tc = cfg["training_config"]
+    mesh_shape = tuple(cfg.get("device_config", {}).get("mesh_shape", [1, 1]))
+    ttml.open_device_mesh(ttml.Mesh(mesh_shape, ("dp", "tp")))
+
+    # DDP: shard the (global) batch across the dp axis; grads are averaged
+    # with sync_gradients after backward. Single device -> everything no-ops.
+    dp_size = mesh_shape[0]
+    batch_mapper = ttml.mesh().axis_mapper("dp", tdim=0) if dp_size > 1 else None
+    loss_composer = None
+    if dp_size > 1:
+        device = ttml.autograd.AutoContext.get_instance().get_device()
+        loss_composer = ttml.core.distributed.concat_mesh_to_tensor_composer(device, 0)
+    dc = cfg.get("diffusion_config", {})
+    ec = cfg.get("eval_config", {})
+    lc = cfg.get("logging_config", {})
+    model_cfg = load_config(tc["model_config"])["dit_config"]
+
+    seed = tc.get("seed", 0)
+    batch_size = tc["batch_size"]
+    max_steps = args.max_steps or tc["max_steps"]
+
+    run_name = f"dit_d{model_cfg['embedding_dim']}x{model_cfg['num_blocks']}_p{model_cfg['patch_size']}_b{batch_size}_{int(time.time())}"
+    run_dir = os.path.join(tc["output_dir"], run_name)
+    os.makedirs(run_dir, exist_ok=True)
+
+    wandb_run = None
+    if lc.get("wandb", False):
+        import wandb
+
+        wandb_run = wandb.init(project=tc.get("project_name", "tt_train_dit"), name=run_name, config=cfg)
+
+    images, labels = load_cifar10(tc["data_path"])
+    print(f"CIFAR-10 loaded: {images.shape}, labels {labels.shape}")
+
+    model, patch, num_tokens = build_model(model_cfg)
+    num_classes = model_cfg["num_classes"]
+    n_params = sum(int(np.prod(t.shape())) for t in model.parameters().values())  # .shape() is a method on ttml tensors
+    print(f"model: dim={model_cfg['embedding_dim']} depth={model_cfg['num_blocks']} tokens={num_tokens} params={n_params/1e6:.2f}M")
+
+    schedule = DiffusionSchedule(
+        timesteps=dc.get("timesteps", 1000),
+        beta_start=dc.get("beta_start", 1e-4),
+        beta_end=dc.get("beta_end", 2e-2),
+    )
+    cfg_drop_prob = dc.get("cfg_drop_prob", 0.1)
+
+    opt = ttml.optimizers.create_optimizer(tc["optimizer"], model.parameters())
+    ctx = ttml.autograd.AutoContext.get_instance()
+    rng = np.random.default_rng(seed)
+
+    base_lr = tc["optimizer"]["lr"]
+    use_cosine = tc.get("lr_schedule", "constant") == "cosine"
+    warmup = tc.get("warmup_steps", 500)
+    ema = None
+    if tc.get("ema_decay", 0):
+        ema = WeightEma(
+            model, decay=tc["ema_decay"], interval=tc.get("ema_interval", 100),
+            composer=loss_composer, num_devices=dp_size,
+        )
+
+    log_every = lc.get("log_interval", 50)
+    sample_every = ec.get("sample_interval", 0)
+    ckpt_every = tc.get("model_save_interval", 0)
+
+    model.train()
+    t0 = time.time()
+    ema_loss = None
+    for step in range(1, max_steps + 1):
+        if args.overfit_batch:
+            batch_rng = np.random.default_rng(123)
+            idx = np.arange(batch_size)
+        else:
+            batch_rng = rng
+            idx = rng.integers(0, images.shape[0], size=batch_size)
+
+        tokens, t_feats, onehot, target = make_training_batch(
+            images[idx], labels[idx], schedule, patch, model.dim, batch_rng,
+            cfg_drop_prob=cfg_drop_prob, null_class=num_classes,
+        )
+
+        import ttnn
+
+        def dev(arr):
+            return ttml.autograd.Tensor.from_numpy(
+                arr, ttnn.Layout.TILE, ttnn.DataType.BFLOAT16, batch_mapper
+            )
+
+        if use_cosine:
+            opt.set_lr(cosine_lr(step, max_steps, base_lr, warmup))
+
+        opt.zero_grad()
+        pred = model(dev(tokens), dev(t_feats), dev(onehot))
+        loss = ttml.ops.loss.mse_loss(pred, dev(target))
+        loss.backward(False)
+        if dp_size > 1:
+            ttml.sync_gradients(model.parameters(), ("dp",))
+        opt.step()
+
+        loss_val = float(loss.to_numpy(ttnn.DataType.FLOAT32, composer=loss_composer).mean()) if loss_composer \
+            else float(loss.to_numpy(ttnn.DataType.FLOAT32).reshape(-1)[0])
+        if ema is not None:
+            ema.maybe_update(step)
+        ctx.reset_graph()
+        ema_loss = loss_val if ema_loss is None else 0.98 * ema_loss + 0.02 * loss_val
+
+        if step % log_every == 0:
+            ips = batch_size * log_every / (time.time() - t0)
+            t0 = time.time()
+            print(f"step {step:6d}  loss {loss_val:.4f}  ema {ema_loss:.4f}  {ips:.1f} img/s", flush=True)
+            if wandb_run:
+                wandb_run.log({"loss": loss_val, "ema_loss": ema_loss, "images_per_sec": ips}, step=step)
+
+        if sample_every and step % sample_every == 0 and dp_size == 1:
+            # Sampling is single-device-only for now; on DDP runs, sample
+            # offline from a checkpoint instead.
+            model.eval()
+            grid = sample_grid(
+                model, schedule, patch, model.dim, num_classes,
+                model_cfg["image_size"], model_cfg["image_channels"],
+                steps=ec.get("sample_steps", 50), cfg_scale=ec.get("cfg_scale", 2.0),
+            )
+            np.save(os.path.join(run_dir, f"samples_{step:06d}.npy"), grid)
+            if wandb_run:
+                import wandb
+
+                imgs = ((grid.transpose(0, 2, 3, 1) + 1) * 127.5).clip(0, 255).astype(np.uint8)
+                wandb_run.log({"samples": [wandb.Image(im, caption=f"class {i}") for i, im in enumerate(imgs)]}, step=step)
+            model.train()
+
+        if ckpt_every and step % ckpt_every == 0:
+            save_checkpoint(model, os.path.join(run_dir, f"ckpt_{step:06d}.npz"),
+                            composer=loss_composer, num_devices=dp_size)
+            if ema is not None:
+                save_checkpoint(model, os.path.join(run_dir, f"ckpt_ema_{step:06d}.npz"), state=ema.state)
+
+    save_checkpoint(model, os.path.join(run_dir, "ckpt_final.npz"), composer=loss_composer, num_devices=dp_size)
+    if ema is not None:
+        save_checkpoint(model, os.path.join(run_dir, "ckpt_ema_final.npz"), state=ema.state)
+    print(f"done; artifacts in {run_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Description
Adds a class-conditional **DiT (Diffusion Transformer)** training example to tt-train — the first non-LLM training workload on the stack. The model, DDPM pipeline, trainer, and sampler are implemented entirely in Python on `ttml`; CIFAR-10 pixel-space; scales from one Blackhole chip to a 32-chip Galaxy via DDP.

Measured: DiT-S (32.6M) at ~1,050–1,300 img/s on one chip (batch 64–256); patch-2 variant at ~2,380 img/s at global batch 2,048 on a 32-chip Galaxy (6.9× one chip). A tiny-model 5k-step run and a DiT-S 50k-step run (53 min) complete end-to-end with sample grids and checkpoints.

### Changes Made
- [x] **New Feature:** `tt-train/sources/examples/dit/` — model (`dit_ttml.py`, incl. a custom Python autograd `SliceLastDim` op), host-side diffusion utilities, config-driven trainer (weight EMA, cosine LR, DDP via `dp` mesh axis + `sync_gradients`), offline DDIM sampler with CFG, on-device primitive gate test, and a 1:1 PyTorch golden reference. Configs for tiny/S/patch-2/galaxy variants.

The example README documents the framework workarounds it needed, which double as a gap list: host-side patchify (no autograd permute/transpose), one-hot labels through a linear (`embedding_backward` tile-width constraint on ids), composite SDPA for non-causal attention (fused kernel treats `mask=None` as causal — consider exposing `AttentionMaskType::None`), and checkpoint reads via `PreferredPrecision.NATIVE` because the default `to_numpy` fp32 cache (#41657) silently freezes checkpoint/EMA reads at their first-read values.

### Testing
- [x] Manual testing conducted: `test_device_primitives.py` (9 on-device checks incl. an end-to-end train-step loss-decrease gate) green on Blackhole p150/Galaxy; `test_reference.py` (CPU golden: patchify round-trip, overfit, sampling) green; full training runs on 1/4/32 chips with matching loss trajectories; DDP checkpoint save/load verified.
- [ ] CI integration for the example (suggestions welcome — the primitive gate is designed to be cheap enough for post-commit)

### Review Checklist
- [x] No breaking changes introduced (new files only)
- [x] Code complies with project style guidelines (config-driven like existing examples)

### Additional Context
Perf notes from bringup: the training step is device-bound at batch ≥64 (~7–11% MFU, dispatch fully overlapped), so op fusion is the main lever; a fused adaLN-modulate kernel prototyped in tt-lang measured 1.5–2.6× vs the composed ops and is a candidate follow-up, as is flattening the DDP gradient all-reduce (~150 sequential CCL calls dominate multi-chip step time). Trace-replay of the full training step was validated (1.0× at batch 64, ~1.6× at batch 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tt-train-dit-example)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tt-train-dit-example)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=tt-train-dit-example)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:tt-train-dit-example)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tt-train-dit-example)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tt-train-dit-example)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=tt-train-dit-example)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:tt-train-dit-example)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tt-train-dit-example)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tt-train-dit-example)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tt-train-dit-example)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tt-train-dit-example)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tt-train-dit-example)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tt-train-dit-example)