### PR TITLE
[Test Only] Improve Quasar LLK perf coverage and stability

### DIFF
--- a/tt_metal/tt-llk/.claude/CLAUDE.md
+++ b/tt_metal/tt-llk/.claude/CLAUDE.md
@@ -43,7 +43,7 @@ Execution model: RISC-V cores push instructions to corresponding coprocessor thr
 | Debugging kernel errors | `debug-kernel` (`.claude/skills/debug-kernel/SKILL.md`) | Dispatches llk-debugger with inferred arch/kernel type |
 | Inspecting VCS/FSDB waves for a Quasar runtime failure | `llk-wave-debug` (`.claude/skills/llk-wave-debug/SKILL.md`) | Runs deterministic private waveform diagnosis and reports evidence (Quasar only) |
 | Porting kernels between architectures | `port-kernel` (`.claude/skills/port-kernel/SKILL.md`) | Launches source + target sages, reads test harness |
-| Creating or repairing Quasar perf tests | `quasar-perf-test` (`.claude/skills/quasar-perf-test/SKILL.md`) | Reuses correctness tests, wires `PerfConfig`, and implements balanced `PerfRunType` paths |
+| Creating or repairing Quasar perf tests | `quasar-perf-test` (`.claude/skills/quasar-perf-test/SKILL.md`) | Reuses correctness tests, wires `PerfConfig`, implements `PerfRunType` paths, and selects tile/dimension coverage via `PERF_TILE_SIZES` |
 | Generating or refreshing a performance report | `perf-report` (`.claude/skills/perf-report/SKILL.md`) | Runs the producer/consumer perf sweep, combines `perf_data` CSVs, and validates schema, coverage, and metric plausibility |
 | Analyzing performance-report CSV parameter impact | `perf-parameter-impact` (`.claude/skills/perf-parameter-impact/SKILL.md`) | Builds paired, bottleneck-aware Canvas reports for formats, fidelity, dimensions, accumulation, indexing, and related parameters |
 | TensorShape / tile-size API conversion or coverage | `tensor-shape` (`.claude/skills/tensor-shape/SKILL.md`) | Plumbs `TensorShape` through lib/API, TRISC coverage, review checklist |

--- a/tt_metal/tt-llk/.claude/skills/perf-parameter-impact/SKILL.md
+++ b/tt_metal/tt-llk/.claude/skills/perf-parameter-impact/SKILL.md
@@ -110,10 +110,12 @@ cases:
   Dropping it manufactures pairs across unlike configurations and charges their
   combined difference to `P`.
 
-Quasar matmul is the standing example: `matmul_dimensions()` halves the
-destination tile budget when `dest_acc=Yes`, so geometry is not free to match
-across `dest_acc`. Pairing while ignoring geometry compares different shapes
-and calls the difference a `dest_acc` effect.
+Quasar matmul is the standing example: `matmul_dimensions()` still halves the
+destination tile budget when `dest_acc=Yes`. Perf keeps dest-full tall and
+wide (`(1, max_tiles)` and `(max_tiles, 1)` × `kt={1, 4}`), so dest_acc=No
+is an 8-tile grid and dest_acc=Yes is a 4-tile grid. Geometry is not free to
+match across `dest_acc`. Pairing while ignoring geometry compares different
+shapes and calls the difference a `dest_acc` effect.
 
 For a linked axis, do one of the following, in order of preference:
 
@@ -229,20 +231,25 @@ Order the report:
 For matmul-style reports with format, fidelity, and destination-accumulation
 axes, use this design unless the user requests another:
 
-1. Add four clickable fidelity options: `LoFi`, `HiFi2`, `HiFi3`, and `HiFi4`.
+1. Add clickable fidelity options for values the **current sweep actually
+   emits**. Quasar matmul keeps LoFi–HiFi4 for Float16 / Float16_b and
+   LoFi-only for MX; do not show empty HiFi2/3/4 MX panels as if they were
+   measured.
 2. Under the selected fidelity, show absolute cycles by composite
    input/register mode, output format, and geometry/destination accumulation.
+   Geometry labels should name dest-full **tall vs wide** and `kt=1` vs
+   `kt=4`, not the old 12/9 dest-fill factorization set.
 3. Before placing `dest_acc=No` and `Yes` bars side by side, audit whether both
    arms contain identical geometries and other relevant configurations.
 4. If common geometry exists, restrict the split bars to that common support,
    state the reduced coverage, and use the same color for each metric pair with
    `dest_acc` distinguished by opacity or another restrained treatment.
-5. If no common geometry exists, as in the current Quasar matmul sweep, do not
-   split input/register or output-format categories into adjacent `dest_acc`
-   bars. Either omit that split in favor of the geometry chart or use separate
-   panels labeled **observed bundled population: dest_acc + geometry**. Explicitly
-   state that gaps between panels are descriptive and are not a `dest_acc`
-   effect.
+5. If no common geometry exists, as in the current Quasar matmul sweep (8-tile
+   vs 4-tile dest-full), do not split input/register or output-format
+   categories into adjacent `dest_acc` bars. Either omit that split in favor of
+   the geometry chart or use separate panels labeled **observed bundled
+   population: dest_acc + geometry**. Explicitly state that gaps between
+   panels are descriptive and are not a `dest_acc` effect.
 6. In the geometry chart, encode both geometry and destination accumulation in
    the x-axis label. Keep four metric bars per composite category and do not
    split them again.

--- a/tt_metal/tt-llk/.claude/skills/perf-report/SKILL.md
+++ b/tt_metal/tt-llk/.claude/skills/perf-report/SKILL.md
@@ -18,8 +18,8 @@ commit, and the exact command that produced it. Record all four.
 ## Related skills
 
 - `quasar-perf-test` — create or repair the perf test and its `PerfRunType`
-  paths. Use it first when the test does not exist, hangs, or reports
-  implausible metrics.
+  paths, and choose tile/dimension coverage. Use it first when the test does
+  not exist, hangs, reports implausible metrics, or needs sweep-axis changes.
 - `perf-parameter-impact` — analyze a finished `.post.csv`.
 - `run-test` — the repository test-runner workflow.
 
@@ -33,6 +33,10 @@ Read the perf test — `tests/python_tests/perf_[op].py` or
 - how many variants `@parametrize` produces;
 - the architecture: the `quasar/` directory or a `*_[arch].py` suffix implies
   it, otherwise ask.
+
+For Quasar, `compare_test_and_perf.py --dir quasar` is the sweep-audit against
+the functional counterpart (composite `list` = matrix, `tuple` = tile shape).
+Flag stale-report risk when current test axes are absent from the CSV.
 
 Decide scope before running. A narrowed sweep (`-k`, `--op`) is right for
 debugging; a report meant for analysis must cover the full intended sweep.

--- a/tt_metal/tt-llk/.claude/skills/perf-report/SKILL.md
+++ b/tt_metal/tt-llk/.claude/skills/perf-report/SKILL.md
@@ -34,9 +34,10 @@ Read the perf test — `tests/python_tests/perf_[op].py` or
 - the architecture: the `quasar/` directory or a `*_[arch].py` suffix implies
   it, otherwise ask.
 
-For Quasar, `compare_test_and_perf.py --dir quasar` is the sweep-audit against
-the functional counterpart (composite `list` = matrix, `tuple` = tile shape).
-Flag stale-report risk when current test axes are absent from the CSV.
+For Quasar, `compare_test_and_perf.py --dir quasar --arch quasar` is the
+sweep-audit against the functional counterpart (composite `list` = matrix,
+`tuple` = tile shape). Flag stale-report risk when current test axes are absent
+from the CSV.
 
 Decide scope before running. A narrowed sweep (`-k`, `--op`) is right for
 debugging; a report meant for analysis must cover the full intended sweep.

--- a/tt_metal/tt-llk/.claude/skills/quasar-perf-test/SKILL.md
+++ b/tt_metal/tt-llk/.claude/skills/quasar-perf-test/SKILL.md
@@ -112,7 +112,8 @@ Dest-full tall/wide is the unary throughput case. Skip dest index and SFPU
 `ct<rt` addr_mod branches and unpack-heavy vs math-heavy K are covered. MX
 inputs are LoFi-only; Float16 / Float16_b still sweep LoFi–HiFi4.
 
-**Check coverage** with `compare_test_and_perf.py --dir quasar`. Composite
+**Check coverage** with
+`compare_test_and_perf.py --dir quasar --arch quasar`. Composite
 splits name `list` as the input matrix and `tuple` as `tile_dimensions`.
 Ignore `DestSync.Full`, `implied_math_format`, `run_types`, `loop_factor`,
 and `is_perf` when judging coverage.
@@ -264,8 +265,9 @@ From the `tt-llk` root:
 5. Run the shared non-perf correctness test, including unpack-to-dest and
    destination-accumulation variants when applicable.
 6. If tile sizes or dimensions changed, run
-   `compare_test_and_perf.py --dir quasar` and confirm the composite `tuple`
-   (tile) and `list` (matrix) axes match **Perf sweep coverage**.
+   `compare_test_and_perf.py --dir quasar --arch quasar` and confirm the
+   composite `tuple` (tile) and `list` (matrix) axes match
+   **Perf sweep coverage**.
 7. Check edited files for lint errors and run `git diff --check`.
 
 Do not:

--- a/tt_metal/tt-llk/.claude/skills/quasar-perf-test/SKILL.md
+++ b/tt_metal/tt-llk/.claude/skills/quasar-perf-test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quasar-perf-test
-description: Create, extend, debug, and validate Quasar LLK performance tests and their PerfRunType kernel paths. Use when adding perf_[op]_quasar.py, wiring PerfConfig, implementing UNPACK_ISOLATE / MATH_ISOLATE / PACK_ISOLATE / L1_CONGESTION, or investigating implausible Quasar perf metrics and dvalid handshakes.
+description: Create, extend, debug, and validate Quasar LLK performance tests, their PerfRunType kernel paths, and tile/dimension sweep coverage. Use when adding perf_[op]_quasar.py, wiring PerfConfig, implementing UNPACK_ISOLATE / MATH_ISOLATE / PACK_ISOLATE / L1_CONGESTION, choosing PERF_TILE_SIZES or dest-fill matrices, or investigating implausible Quasar perf metrics and dvalid handshakes.
 user_invocable: true
 ---
 
@@ -13,11 +13,13 @@ Create or repair a Quasar performance test while preserving its functional
 `PerfConfig`, and give every applicable `PerfRunType` a balanced single-stage
 or congestion path.
 
-This skill covers two related workflows:
+This skill covers three related workflows:
 
 - **Create**: add a perf harness for an existing correctness test.
 - **Repair or extend**: implement or debug run-type behavior in an existing
   Quasar kernel.
+- **Sweep coverage**: choose tile shapes and dest-fill matrices with the
+  shared helpers in `helpers/param_config.py`.
 
 ## Choose the workflow
 
@@ -25,7 +27,9 @@ This skill covers two related workflows:
    **Create a perf test**.
 2. If the perf harness exists but run types are missing, hanging, or producing
    implausible metrics, follow **Repair PerfRunType paths**.
-3. In either case, finish with **Validation**.
+3. If adding or changing tile sizes, input dimensions, or fidelity, follow
+   **Perf sweep coverage**.
+4. In all cases, finish with **Validation**.
 
 ## Create a perf test
 
@@ -47,8 +51,9 @@ This skill covers two related workflows:
    - `run_types=PERF_RUN_TYPES_QUASAR` from `helpers.llk_params`
    - a fixed `loop_factor=32`, unless the operation has an established value
    - a fixed `is_perf=True`
-   - stable dimensions and exact destination fill when normalization depends
-     on shape
+   - `DestSync.Half` and `ImpliedMathFormat.Yes` only
+   - tile sizes and dest-fill matrices from **Perf sweep coverage**, not a
+     single hardcoded tile or the full functional dimension grid
 7. Pass `perf_report` and `is_perf=True` to the correctness helper.
 8. Add keyword-only `is_perf=False` and `perf_report=None` to that helper.
    Build shared `test_config_kwargs`, then:
@@ -57,14 +62,60 @@ This skill covers two related workflows:
    if is_perf:
        if perf_report is None:
            raise ValueError("perf_report must be provided when is_perf=True")
-       PerfConfig(run_types=run_types, **test_config_kwargs).run(perf_report)
+   configuration = create_test_or_perf_config(
+       is_perf=is_perf,
+       run_types=run_types,
+       test_config_kwargs=test_config_kwargs,
+   )
+   if is_perf:
+       configuration.run(perf_report)
        return
    ```
 
 9. Keep the correctness path on `TestConfig` with an explicit
    `PERF_RUN_TYPE(PerfRunType.L1_TO_L1)`.
-10. Preserve dynamic shape coverage in correctness tests. Use fixed,
-    comparable workloads only for the perf path.
+10. Preserve dynamic shape coverage in correctness tests. Perf reuses the
+    functional generator with `is_perf=True`; it must not pin one tile shape.
+
+## Perf sweep coverage
+
+Helpers live in `tests/python_tests/helpers/param_config.py`. Drive every
+`is_perf` composite generator through them. Do not hardcode `(16, 16)` or
+`(32, 32)` as the only perf tile.
+
+**Tile shapes.** Intersect the functional tile-size list with `PERF_TILE_SIZES`
+via `select_perf_tile_sizes()`:
+
+| Class | Size | Why |
+|---|---|---|
+| 4-face | `(32, 32)` | Default FPU/pack/unpack path |
+| 1-face | `(16, 16)` | MX-legal single-face path |
+| 2-face narrow | `(32, 16)` | Different face grid / strides |
+| Tiny | `(1, 32)` | Tiny-tile MOP (shared with 2/4/8×32) |
+
+Skip sizes the functional set does not include (for example `pack_untilize`
+keeps `(32, 32)` and `(1, 32)`). Keep existing MX, unpack-to-dest, and 32-bit
+dest filters. Do not add all of `(1, 2, 4, 8, 16)×32`.
+
+**Input matrices.** Call `generate_perf_input_dimensions(dest_acc, dest_sync,
+tile_shape)` for every selected tile. That emits dest-full tall `(max_tiles, 1)`
+and wide `(1, max_tiles)` in **tile counts**, then multiplies by the tile
+shape. Do not match `PERF_INPUT_DIMENSIONS` element sizes such as `[256, 32]`
+against a non-32×32 tile — those assume 32×32 and drop the wide orientation.
+
+Do not copy the 50-way dest-fitting `generate_unary_input_dimensions` grid.
+Dest-full tall/wide is the unary throughput case. Skip dest index and SFPU
+`tile_indices`; those are register offsets, not distinct MOPs.
+
+**Matmul.** Use dest-full tall and wide output grids (`mt,nt` =
+`(1, max_tiles)` and `(max_tiles, 1)`) × `kt={1, 4}` so both `ct>=rt` and
+`ct<rt` addr_mod branches and unpack-heavy vs math-heavy K are covered. MX
+inputs are LoFi-only; Float16 / Float16_b still sweep LoFi–HiFi4.
+
+**Check coverage** with `compare_test_and_perf.py --dir quasar`. Composite
+splits name `list` as the input matrix and `tuple` as `tile_dimensions`.
+Ignore `DestSync.Full`, `implied_math_format`, `run_types`, `loop_factor`,
+and `is_perf` when judging coverage.
 
 ## C++ structure
 
@@ -212,7 +263,10 @@ From the `tt-llk` root:
 4. Inspect every focused `TILE_LOOP` CSV row.
 5. Run the shared non-perf correctness test, including unpack-to-dest and
    destination-accumulation variants when applicable.
-6. Check edited files for lint errors and run `git diff --check`.
+6. If tile sizes or dimensions changed, run
+   `compare_test_and_perf.py --dir quasar` and confirm the composite `tuple`
+   (tile) and `list` (matrix) axes match **Perf sweep coverage**.
+7. Check edited files for lint errors and run `git diff --check`.
 
 Do not:
 

--- a/tt_metal/tt-llk/.cursor/skills/perf-parameter-impact/SKILL.md
+++ b/tt_metal/tt-llk/.cursor/skills/perf-parameter-impact/SKILL.md
@@ -109,10 +109,12 @@ cases:
   Dropping it manufactures pairs across unlike configurations and charges their
   combined difference to `P`.
 
-Quasar matmul is the standing example: `matmul_dimensions()` halves the
-destination tile budget when `dest_acc=Yes`, so geometry is not free to match
-across `dest_acc`. Pairing while ignoring geometry compares different shapes
-and calls the difference a `dest_acc` effect.
+Quasar matmul is the standing example: `matmul_dimensions()` still halves the
+destination tile budget when `dest_acc=Yes`. Perf keeps dest-full tall and
+wide (`(1, max_tiles)` and `(max_tiles, 1)` × `kt={1, 4}`), so dest_acc=No
+is an 8-tile grid and dest_acc=Yes is a 4-tile grid. Geometry is not free to
+match across `dest_acc`. Pairing while ignoring geometry compares different
+shapes and calls the difference a `dest_acc` effect.
 
 For a linked axis, do one of the following, in order of preference:
 
@@ -228,20 +230,25 @@ Order the report:
 For matmul-style reports with format, fidelity, and destination-accumulation
 axes, use this design unless the user requests another:
 
-1. Add four clickable fidelity options: `LoFi`, `HiFi2`, `HiFi3`, and `HiFi4`.
+1. Add clickable fidelity options for values the **current sweep actually
+   emits**. Quasar matmul keeps LoFi–HiFi4 for Float16 / Float16_b and
+   LoFi-only for MX; do not show empty HiFi2/3/4 MX panels as if they were
+   measured.
 2. Under the selected fidelity, show absolute cycles by composite
    input/register mode, output format, and geometry/destination accumulation.
+   Geometry labels should name dest-full **tall vs wide** and `kt=1` vs
+   `kt=4`, not the old 12/9 dest-fill factorization set.
 3. Before placing `dest_acc=No` and `Yes` bars side by side, audit whether both
    arms contain identical geometries and other relevant configurations.
 4. If common geometry exists, restrict the split bars to that common support,
    state the reduced coverage, and use the same color for each metric pair with
    `dest_acc` distinguished by opacity or another restrained treatment.
-5. If no common geometry exists, as in the current Quasar matmul sweep, do not
-   split input/register or output-format categories into adjacent `dest_acc`
-   bars. Either omit that split in favor of the geometry chart or use separate
-   panels labeled **observed bundled population: dest_acc + geometry**. Explicitly
-   state that gaps between panels are descriptive and are not a `dest_acc`
-   effect.
+5. If no common geometry exists, as in the current Quasar matmul sweep (8-tile
+   vs 4-tile dest-full), do not split input/register or output-format
+   categories into adjacent `dest_acc` bars. Either omit that split in favor of
+   the geometry chart or use separate panels labeled **observed bundled
+   population: dest_acc + geometry**. Explicitly state that gaps between
+   panels are descriptive and are not a `dest_acc` effect.
 6. In the geometry chart, encode both geometry and destination accumulation in
    the x-axis label. Keep four metric bars per composite category and do not
    split them again.

--- a/tt_metal/tt-llk/.cursor/skills/perf-report/SKILL.md
+++ b/tt_metal/tt-llk/.cursor/skills/perf-report/SKILL.md
@@ -17,8 +17,8 @@ commit, and the exact command that produced it. Record all four.
 ## Related skills
 
 - `quasar-perf-test` — create or repair the perf test and its `PerfRunType`
-  paths. Use it first when the test does not exist, hangs, or reports
-  implausible metrics.
+  paths, and choose tile/dimension coverage. Use it first when the test does
+  not exist, hangs, reports implausible metrics, or needs sweep-axis changes.
 - `perf-parameter-impact` — analyze a finished `.post.csv`.
 - `run-test` — the repository test-runner workflow.
 
@@ -32,6 +32,10 @@ Read the perf test — `tests/python_tests/perf_[op].py` or
 - how many variants `@parametrize` produces;
 - the architecture: the `quasar/` directory or a `*_[arch].py` suffix implies
   it, otherwise ask.
+
+For Quasar, `compare_test_and_perf.py --dir quasar` is the sweep-audit against
+the functional counterpart (composite `list` = matrix, `tuple` = tile shape).
+Flag stale-report risk when current test axes are absent from the CSV.
 
 Decide scope before running. A narrowed sweep (`-k`, `--op`) is right for
 debugging; a report meant for analysis must cover the full intended sweep.

--- a/tt_metal/tt-llk/.cursor/skills/quasar-perf-test/SKILL.md
+++ b/tt_metal/tt-llk/.cursor/skills/quasar-perf-test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quasar-perf-test
-description: Create, extend, debug, and validate Quasar LLK performance tests and their PerfRunType kernel paths. Use when adding perf_[op]_quasar.py, wiring PerfConfig, implementing UNPACK_ISOLATE / MATH_ISOLATE / PACK_ISOLATE / L1_CONGESTION, or investigating implausible Quasar perf metrics and dvalid handshakes.
+description: Create, extend, debug, and validate Quasar LLK performance tests, their PerfRunType kernel paths, and tile/dimension sweep coverage. Use when adding perf_[op]_quasar.py, wiring PerfConfig, implementing UNPACK_ISOLATE / MATH_ISOLATE / PACK_ISOLATE / L1_CONGESTION, choosing PERF_TILE_SIZES or dest-fill matrices, or investigating implausible Quasar perf metrics and dvalid handshakes.
 ---
 
 # Quasar Perf Test
@@ -12,11 +12,13 @@ Create or repair a Quasar performance test while preserving its functional
 `PerfConfig`, and give every applicable `PerfRunType` a balanced single-stage
 or congestion path.
 
-This skill covers two related workflows:
+This skill covers three related workflows:
 
 - **Create**: add a perf harness for an existing correctness test.
 - **Repair or extend**: implement or debug run-type behavior in an existing
   Quasar kernel.
+- **Sweep coverage**: choose tile shapes and dest-fill matrices with the
+  shared helpers in `helpers/param_config.py`.
 
 ## Choose the workflow
 
@@ -24,7 +26,9 @@ This skill covers two related workflows:
    **Create a perf test**.
 2. If the perf harness exists but run types are missing, hanging, or producing
    implausible metrics, follow **Repair PerfRunType paths**.
-3. In either case, finish with **Validation**.
+3. If adding or changing tile sizes, input dimensions, or fidelity, follow
+   **Perf sweep coverage**.
+4. In all cases, finish with **Validation**.
 
 ## Create a perf test
 
@@ -46,8 +50,9 @@ This skill covers two related workflows:
    - `run_types=PERF_RUN_TYPES_QUASAR` from `helpers.llk_params`
    - a fixed `loop_factor=32`, unless the operation has an established value
    - a fixed `is_perf=True`
-   - stable dimensions and exact destination fill when normalization depends
-     on shape
+   - `DestSync.Half` and `ImpliedMathFormat.Yes` only
+   - tile sizes and dest-fill matrices from **Perf sweep coverage**, not a
+     single hardcoded tile or the full functional dimension grid
 7. Pass `perf_report` and `is_perf=True` to the correctness helper.
 8. Add keyword-only `is_perf=False` and `perf_report=None` to that helper.
    Build shared `test_config_kwargs`, then:
@@ -56,14 +61,60 @@ This skill covers two related workflows:
    if is_perf:
        if perf_report is None:
            raise ValueError("perf_report must be provided when is_perf=True")
-       PerfConfig(run_types=run_types, **test_config_kwargs).run(perf_report)
+   configuration = create_test_or_perf_config(
+       is_perf=is_perf,
+       run_types=run_types,
+       test_config_kwargs=test_config_kwargs,
+   )
+   if is_perf:
+       configuration.run(perf_report)
        return
    ```
 
 9. Keep the correctness path on `TestConfig` with an explicit
    `PERF_RUN_TYPE(PerfRunType.L1_TO_L1)`.
-10. Preserve dynamic shape coverage in correctness tests. Use fixed,
-    comparable workloads only for the perf path.
+10. Preserve dynamic shape coverage in correctness tests. Perf reuses the
+    functional generator with `is_perf=True`; it must not pin one tile shape.
+
+## Perf sweep coverage
+
+Helpers live in `tests/python_tests/helpers/param_config.py`. Drive every
+`is_perf` composite generator through them. Do not hardcode `(16, 16)` or
+`(32, 32)` as the only perf tile.
+
+**Tile shapes.** Intersect the functional tile-size list with `PERF_TILE_SIZES`
+via `select_perf_tile_sizes()`:
+
+| Class | Size | Why |
+|---|---|---|
+| 4-face | `(32, 32)` | Default FPU/pack/unpack path |
+| 1-face | `(16, 16)` | MX-legal single-face path |
+| 2-face narrow | `(32, 16)` | Different face grid / strides |
+| Tiny | `(1, 32)` | Tiny-tile MOP (shared with 2/4/8×32) |
+
+Skip sizes the functional set does not include (for example `pack_untilize`
+keeps `(32, 32)` and `(1, 32)`). Keep existing MX, unpack-to-dest, and 32-bit
+dest filters. Do not add all of `(1, 2, 4, 8, 16)×32`.
+
+**Input matrices.** Call `generate_perf_input_dimensions(dest_acc, dest_sync,
+tile_shape)` for every selected tile. That emits dest-full tall `(max_tiles, 1)`
+and wide `(1, max_tiles)` in **tile counts**, then multiplies by the tile
+shape. Do not match `PERF_INPUT_DIMENSIONS` element sizes such as `[256, 32]`
+against a non-32×32 tile — those assume 32×32 and drop the wide orientation.
+
+Do not copy the 50-way dest-fitting `generate_unary_input_dimensions` grid.
+Dest-full tall/wide is the unary throughput case. Skip dest index and SFPU
+`tile_indices`; those are register offsets, not distinct MOPs.
+
+**Matmul.** Use dest-full tall and wide output grids (`mt,nt` =
+`(1, max_tiles)` and `(max_tiles, 1)`) × `kt={1, 4}` so both `ct>=rt` and
+`ct<rt` addr_mod branches and unpack-heavy vs math-heavy K are covered. MX
+inputs are LoFi-only; Float16 / Float16_b still sweep LoFi–HiFi4.
+
+**Check coverage** with `compare_test_and_perf.py --dir quasar`. Composite
+splits name `list` as the input matrix and `tuple` as `tile_dimensions`.
+Ignore `DestSync.Full`, `implied_math_format`, `run_types`, `loop_factor`,
+and `is_perf` when judging coverage.
 
 ## C++ structure
 
@@ -211,7 +262,10 @@ From the `tt-llk` root:
 4. Inspect every focused `TILE_LOOP` CSV row.
 5. Run the shared non-perf correctness test, including unpack-to-dest and
    destination-accumulation variants when applicable.
-6. Check edited files for lint errors and run `git diff --check`.
+6. If tile sizes or dimensions changed, run
+   `compare_test_and_perf.py --dir quasar` and confirm the composite `tuple`
+   (tile) and `list` (matrix) axes match **Perf sweep coverage**.
+7. Check edited files for lint errors and run `git diff --check`.
 
 Do not:
 

--- a/tt_metal/tt-llk/tests/helpers/include/perf.h
+++ b/tt_metal/tt-llk/tests/helpers/include/perf.h
@@ -121,8 +121,6 @@ inline void _perf_math_loop_clear_valid(std::uint32_t iterations)
 
 inline void _perf_unpack_matmul_mock(std::uint32_t loop_factor, std::uint32_t rt_dim, std::uint32_t kt_dim, std::uint32_t ct_dim)
 {
-    // fixme: add quasar support
-
     for (std::uint32_t loop = 0; loop < loop_factor; loop++)
     {
         for (std::uint32_t j = 0; j < kt_dim; j++)

--- a/tt_metal/tt-llk/tests/helpers/include/quasar_test_common.h
+++ b/tt_metal/tt-llk/tests/helpers/include/quasar_test_common.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 
 #include "ckernel_trisc_common.h"
+#include "perf.h"
 #include "tensor_shape.h"
 
 template <bool implied_math_format, bool fp32_dest, bool int32_dest>

--- a/tt_metal/tt-llk/tests/helpers/include/quasar_test_common.h
+++ b/tt_metal/tt-llk/tests/helpers/include/quasar_test_common.h
@@ -7,11 +7,9 @@
 #include <cstdint>
 
 #include "ckernel_trisc_common.h"
+#include "llk_math_common.h"
 #include "perf.h"
 #include "tensor_shape.h"
-
-template <bool implied_math_format, bool fp32_dest, bool int32_dest>
-inline void _llk_math_srcAB_hw_configure_(DataFormat srca_format, DataFormat srcb_format);
 
 inline void perf_unpack_set_srcb_once_then_srca_per_face(std::uint32_t srcb_once_count, std::uint32_t srca_per_face_count)
 {

--- a/tt_metal/tt-llk/tests/helpers/include/quasar_test_common.h
+++ b/tt_metal/tt-llk/tests/helpers/include/quasar_test_common.h
@@ -9,6 +9,75 @@
 #include "ckernel_trisc_common.h"
 #include "tensor_shape.h"
 
+template <bool implied_math_format, bool fp32_dest, bool int32_dest>
+inline void _llk_math_srcAB_hw_configure_(DataFormat srca_format, DataFormat srcb_format);
+
+inline void perf_unpack_set_srcb_once_then_srca_per_face(std::uint32_t srcb_once_count, std::uint32_t srca_per_face_count)
+{
+    _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(srcb_once_count);
+    _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(srca_per_face_count);
+}
+
+inline void perf_math_clear_srca_per_face_then_srcb_once(std::uint32_t srca_per_face_count, std::uint32_t srcb_once_count)
+{
+    _perf_math_loop_clear_valid<true /*clear_a*/, false /*clear_b*/>(srca_per_face_count);
+    _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(srcb_once_count);
+}
+
+template <bool implied_math_format, bool fp32_dest_acc_en>
+inline void configure_math_hardware_for_float32_int32_or_default(DataFormat math_format, DataFormat dest_format)
+{
+    if constexpr (fp32_dest_acc_en)
+    {
+        if (dest_format == DataFormat::Float32)
+        {
+            _llk_math_srcAB_hw_configure_<implied_math_format, true /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
+        }
+        else if (dest_format == DataFormat::Int32)
+        {
+            _llk_math_srcAB_hw_configure_<implied_math_format, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
+        }
+        else
+        {
+            _llk_math_srcAB_hw_configure_<implied_math_format, false /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
+        }
+    }
+    else
+    {
+        _llk_math_srcAB_hw_configure_<implied_math_format, false /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
+    }
+}
+
+template <ckernel::dest_dvalid_client thread>
+inline void set_up_fpu_to_pack_dest_dvalid_chain()
+{
+    ckernel::set_up_dest_dvalid_per_thread<thread>({ckernel::dest_dvalid_client::FPU, ckernel::dest_dvalid_client::PACK});
+}
+
+template <ckernel::dest_dvalid_client thread>
+inline void set_up_unpack_to_pack_dest_dvalid_chain()
+{
+    ckernel::set_up_dest_dvalid_per_thread<thread>({ckernel::dest_dvalid_client::UNPACK, ckernel::dest_dvalid_client::PACK});
+}
+
+template <ckernel::dest_dvalid_client thread>
+inline void set_up_unpack_to_fpu_to_pack_dest_dvalid_chain()
+{
+    ckernel::set_up_dest_dvalid_per_thread<thread>({ckernel::dest_dvalid_client::UNPACK, ckernel::dest_dvalid_client::FPU, ckernel::dest_dvalid_client::PACK});
+}
+
+template <ckernel::dest_dvalid_client thread>
+inline void set_up_fpu_to_sfpu_to_pack_dest_dvalid_chain()
+{
+    ckernel::set_up_dest_dvalid_per_thread<thread>({ckernel::dest_dvalid_client::FPU, ckernel::dest_dvalid_client::SFPU, ckernel::dest_dvalid_client::PACK});
+}
+
+template <ckernel::dest_dvalid_client thread>
+inline void set_up_unpack_to_sfpu_to_pack_dest_dvalid_chain()
+{
+    ckernel::set_up_dest_dvalid_per_thread<thread>({ckernel::dest_dvalid_client::UNPACK, ckernel::dest_dvalid_client::SFPU, ckernel::dest_dvalid_client::PACK});
+}
+
 inline void clear_dest_dvalid_wait_mask(std::uint32_t wait_mask_addr)
 {
     volatile std::uint32_t* cfg = reinterpret_cast<volatile std::uint32_t*>(TENSIX_CFG_BASE);

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
@@ -270,9 +270,9 @@ void call_unary_sfpu_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_f
     else if constexpr (is_trig_op(OPERATION))
     {
         // One op-templated kernel serves sine/cosine/acosh/asinh/atanh; OPERATION picks the branch
-        // at compile time. APPROXIMATION_MODE=false selects the full-polynomial (accurate) path;
-        // VectorMode::RC (the params default) runs the functor once per face.
-        _llk_math_eltwise_unary_sfpu_params_(calculate_trigonometry<OPERATION, false /* APPROX */, is_fp32_dest_acc_en, ITERATIONS>, dst_index);
+        // at compile time. APPROXIMATION_MODE=false selects the full-polynomial (accurate) path.
+        SFPU_UNARY_CALL(
+            DST_SYNC, is_fp32_dest_acc_en, calculate_trigonometry, (OPERATION, false /* APPROX */, is_fp32_dest_acc_en, ITERATIONS), dst_index, VectorMode::RC);
     }
     else if constexpr (OPERATION == SfpuType::negative)
     {

--- a/tt_metal/tt-llk/tests/python_tests/helpers/chip_architecture.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/chip_architecture.py
@@ -4,8 +4,6 @@
 import os
 from enum import Enum
 
-from ttexalens.tt_exalens_lib import check_context
-
 
 class ChipArchitecture(Enum):
     BLACKHOLE = "blackhole"
@@ -47,6 +45,8 @@ def get_chip_architecture():
 
     chip_architecture = os.getenv("CHIP_ARCH")
     if not chip_architecture:
+        from ttexalens.tt_exalens_lib import check_context
+
         context = check_context()
         chip_architecture = str(context.devices[0]._arch)
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/constraints.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/constraints.py
@@ -110,6 +110,11 @@ def get_valid_math_fidelities(format, operation, PERF_RUN: bool = False):
     ]
 
 
+def get_quasar_perf_math_operations():
+    """Return the elementwise math operations covered by Quasar perf tests."""
+    return [MathOperation.Elwadd, MathOperation.Elwmul]
+
+
 def get_valid_dest_indices(
     dest_sync: DestSync,
     dest_acc: DestAccumulation,

--- a/tt_metal/tt-llk/tests/python_tests/helpers/constraints.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/constraints.py
@@ -110,7 +110,7 @@ def get_valid_math_fidelities(format, operation, PERF_RUN: bool = False):
     ]
 
 
-def get_quasar_perf_math_operations():
+def get_perf_math_operations():
     """Return the elementwise math operations covered by Quasar perf tests."""
     return [MathOperation.Elwadd, MathOperation.Elwmul]
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
@@ -629,6 +629,27 @@ PERF_INPUT_DIMENSIONS = (
     [32, 512],
 )
 
+# One representative per HW tile MOP class. Intersect with each test's functional
+# tile-size set via ``select_perf_tile_sizes`` instead of pinning a single shape.
+PERF_TILE_SIZES = (
+    (32, 32),  # 4-face standard
+    (16, 16),  # 1-face
+    (32, 16),  # 2-face narrow
+    (1, 32),  # tiny-tile MOP (shared with 2/4/8 x 32)
+)
+
+
+def select_perf_tile_sizes(functional_tile_sizes):
+    """Select MOP-class tile sizes that a functional sweep actually supports.
+
+    Keeps ``PERF_TILE_SIZES`` order. MX / unpack-to-dest filters still apply at
+    the call site; this only intersects with the functional tile-size list.
+    """
+    supported_tile_sizes = {tuple(tile_dims) for tile_dims in functional_tile_sizes}
+    return [
+        tile_dims for tile_dims in PERF_TILE_SIZES if tile_dims in supported_tile_sizes
+    ]
+
 
 def select_perf_input_dimensions(functional_dimensions, *, use_largest_fallback=True):
     """Select perf matrices from the dimensions supported by a functional test.
@@ -668,15 +689,38 @@ def generate_perf_input_dimensions(
     *,
     use_largest_fallback=True,
 ):
-    """Select perf matrices from unary functional coverage."""
+    """Dest-full tall and wide matrices, scaled by ``tile_shape``.
+
+    Tile counts are ``(max_tiles, 1)`` and ``(1, max_tiles)`` for the dest
+    capacity of ``dest_sync`` / ``dest_acc``. ``use_largest_fallback`` is kept
+    for call-site compatibility; dest-fill matrices always fit dest.
+    """
     if tile_shape is None:
         tile_shape = construct_tile_shape()
 
-    functional_dimensions = generate_unary_input_dimensions(
-        dest_acc, dest_sync=dest_sync, tile_shape=tile_shape
-    )
+    capacity_divisor = 2 if dest_acc == DestAccumulation.Yes else 1
+    max_tiles_in_dest = DEST_SYNC_TILE_LIMITS[dest_sync] // capacity_divisor
+    tile_rows = tile_shape.total_row_dim()
+    tile_cols = tile_shape.total_col_dim()
+
+    dest_fill_tile_counts = ((max_tiles_in_dest, 1), (1, max_tiles_in_dest))
+    dimensions = []
+    seen = set()
+    for rt_dim, ct_dim in dest_fill_tile_counts:
+        matrix = [rt_dim * tile_rows, ct_dim * tile_cols]
+        key = tuple(matrix)
+        if key not in seen:
+            seen.add(key)
+            dimensions.append(matrix)
+
+    if dimensions or not use_largest_fallback:
+        return dimensions
+
     return select_perf_input_dimensions(
-        functional_dimensions, use_largest_fallback=use_largest_fallback
+        generate_unary_input_dimensions(
+            dest_acc, dest_sync=dest_sync, tile_shape=tile_shape
+        ),
+        use_largest_fallback=True,
     )
 
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
@@ -622,6 +622,64 @@ def generate_unary_input_dimensions(dest_acc, dest_sync=DestSync.Half, tile_shap
     ]
 
 
+PERF_INPUT_DIMENSIONS = (
+    [256, 32],
+    [32, 256],
+    [512, 32],
+    [32, 512],
+)
+
+
+def select_perf_input_dimensions(functional_dimensions, *, use_largest_fallback=True):
+    """Select perf matrices from the dimensions supported by a functional test.
+
+    Keep supported target matrices in ``PERF_INPUT_DIMENSIONS`` order. If the
+    functional test supports none of them, optionally keep only its largest
+    matrix. Prefer the taller matrix when multiple supported matrices have the
+    same area.
+    """
+    normalized_dimensions = [list(dimensions) for dimensions in functional_dimensions]
+    supported_dimensions = {tuple(dimensions) for dimensions in normalized_dimensions}
+    selected_dimensions = [
+        dimensions.copy()
+        for dimensions in PERF_INPUT_DIMENSIONS
+        if tuple(dimensions) in supported_dimensions
+    ]
+    if selected_dimensions:
+        return selected_dimensions
+    if not normalized_dimensions or not use_largest_fallback:
+        return []
+
+    return [
+        max(
+            normalized_dimensions,
+            key=lambda dimensions: (
+                dimensions[0] * dimensions[1],
+                dimensions[0],
+            ),
+        )
+    ]
+
+
+def generate_perf_input_dimensions(
+    dest_acc,
+    dest_sync=DestSync.Half,
+    tile_shape=None,
+    *,
+    use_largest_fallback=True,
+):
+    """Select perf matrices from unary functional coverage."""
+    if tile_shape is None:
+        tile_shape = construct_tile_shape()
+
+    functional_dimensions = generate_unary_input_dimensions(
+        dest_acc, dest_sync=dest_sync, tile_shape=tile_shape
+    )
+    return select_perf_input_dimensions(
+        functional_dimensions, use_largest_fallback=use_largest_fallback
+    )
+
+
 def get_num_blocks_and_num_tiles_in_block(
     dest_sync: DestSync,
     dest_acc: DestAccumulation,

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/__init__.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/__init__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""LLK performance helpers (core, schema, wide_schema, parquet, test_schemas)."""
+"""LLK performance helpers (core, schema, wide_schema, wide_schema_quasar, parquet, test_schemas)."""

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/core.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/core.py
@@ -14,6 +14,7 @@ from typing import Any, ClassVar
 import pandas as pd
 import pytest
 
+from ..chip_architecture import ChipArchitecture
 from ..counters import print_counters, read_counters
 from ..device import BootMode
 from ..format_config import FormatConfig
@@ -476,7 +477,7 @@ def _write_run_parquet(raw_csv_paths, out_dir) -> None:
         if unknown:
             dropped = sum(len(v) for v in unknown.values())
             detail = "; ".join(f"{t}={cols}" for t, cols in sorted(unknown.items()))
-            logger.warning(
+            logger.error(
                 f"perf Parquet: {dropped} column(s) not in the schema were dropped ({detail})"
             )
         logger.info(f"Wrote run Parquet batch: {parquet_path}")
@@ -748,6 +749,40 @@ class PerfConfig(TestConfig):
         other_cols = [c for c in combined.columns if not c.startswith(TEXT_SIZE_PREFIX)]
         return combined[other_cols + text_size_cols]
 
+    @staticmethod
+    def _validate_profiler_stats(stats_df: pd.DataFrame, run_type: PerfRunType) -> None:
+        """Reject missing or invalid wall-clock output for a requested run type."""
+        if stats_df.empty:
+            raise ValueError(
+                f"Profiler produced no timing statistics for requested run type "
+                f"{run_type.name}. Check profiler zone coverage and handshakes."
+            )
+
+        expected_mean_prefix = f"{stat_prefix(MEAN)}{run_type.name}"
+        mean_columns = [
+            column
+            for column in stats_df.columns
+            if column.startswith(expected_mean_prefix)
+        ]
+        if not mean_columns:
+            raise ValueError(
+                f"Profiler statistics for requested run type {run_type.name} "
+                f"contain no mean timing column with prefix "
+                f"{expected_mean_prefix!r}: {list(stats_df.columns)}"
+            )
+
+        negative_values = {
+            column: stats_df.loc[stats_df[column] < 0, column].tolist()
+            for column in mean_columns
+            if (stats_df[column] < 0).any()
+        }
+        if negative_values:
+            raise ValueError(
+                f"Profiler produced negative mean timing values for requested "
+                f"run type {run_type.name}: {negative_values}. Check profiler "
+                f"zone handshakes."
+            )
+
     def run(self, perf_report: PerfReport, run_count=1):
         results = []
         counter_results_list = []
@@ -835,9 +870,16 @@ class PerfConfig(TestConfig):
                 variant_raw_data.append(profiler_data)
 
             get_stats = Profiler.STATS_FUNCTION[run_type]
-            # WC build emits no ZONE_START/ZONE_END events (ZONE_SCOPED muted) — stats df is empty.
             stats_df = get_stats(ProfilerData.concat(variant_raw_data))
-            if not stats_df.empty:
+            # A WC build intentionally suppresses ZONE_SCOPED timing events and
+            # emits counter metrics instead. Quasar excludes the WC TRISC flag,
+            # so it still requires wall-clock stats even when counters are requested.
+            counter_only_build = (
+                TestConfig.ENABLE_PERF_COUNTERS
+                and TestConfig.CHIP_ARCH != ChipArchitecture.QUASAR
+            )
+            if not stats_df.empty or not counter_only_build:
+                PerfConfig._validate_profiler_stats(stats_df, run_type)
                 results.append(stats_df)
 
             if variant_counter_results:

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/core.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/core.py
@@ -472,10 +472,12 @@ def _write_run_parquet(raw_csv_paths, out_dir) -> None:
         diagnostics = convert_csvs_to_parquet(
             sorted(raw_csv_paths), parquet_path, strict=False, **prov
         )
-        dropped = sum(len(v) for v in diagnostics["unknown_columns"].values())
-        if dropped:
+        unknown = diagnostics["unknown_columns"]
+        if unknown:
+            dropped = sum(len(v) for v in unknown.values())
+            detail = "; ".join(f"{t}={cols}" for t, cols in sorted(unknown.items()))
             logger.warning(
-                f"perf Parquet: {dropped} column(s) not in the schema were dropped"
+                f"perf Parquet: {dropped} column(s) not in the schema were dropped ({detail})"
             )
         logger.info(f"Wrote run Parquet batch: {parquet_path}")
     except Exception as exc:  # noqa: BLE001 — Parquet is additive; CSV is primary

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/core.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/core.py
@@ -905,20 +905,27 @@ class PerfConfig(TestConfig):
 
 
 def create_test_or_perf_config(
-    *, is_perf: bool, run_types: list[PerfRunType], test_config_kwargs: dict
+    *,
+    is_perf: bool,
+    run_types: list[PerfRunType],
+    test_config_kwargs: dict,
+    boot_mode: BootMode | None = None,
 ) -> TestConfig:
     """Create the common functional or performance configuration.
 
     The configuration is returned without running it so callers can apply
-    operation-specific format adjustments before execution.
+    operation-specific format adjustments before execution. ``boot_mode`` is
+    functional-only because ``PerfConfig`` owns its fixed performance boot mode.
     """
     if is_perf:
         return PerfConfig(run_types=list(run_types), **test_config_kwargs)
 
-    return TestConfig(
-        **{
-            **test_config_kwargs,
-            "templates": test_config_kwargs["templates"]
-            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
-        }
-    )
+    functional_kwargs = {
+        **test_config_kwargs,
+        "templates": test_config_kwargs["templates"]
+        + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
+    }
+    if boot_mode is not None:
+        functional_kwargs["boot_mode"] = boot_mode
+
+    return TestConfig(**functional_kwargs)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/core.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/core.py
@@ -460,8 +460,12 @@ def _write_run_parquet(raw_csv_paths, out_dir) -> None:
     Raw is the canonical stored form (matching the historical migration): the
     per-tile figures are derivable downstream (TILE_LOOP mean/std divided by
     ``loop_factor * tile_cnt``, both present as columns), so storing raw keeps the
-    table lossless without a redundant per-tile copy. Best-effort: Parquet is
-    additive here, so any failure is logged and never breaks the CSV report.
+    table lossless without a redundant per-tile copy.
+
+    Schema drift (unknown columns, or values that would coerce to NULL) raises
+    ``PerfSchemaError`` so the session fails instead of writing a lossy batch.
+    Other Parquet write failures (missing pyarrow, I/O) are logged and do not
+    break the CSV report, which is already on disk.
     """
     if not raw_csv_paths:
         return
@@ -470,17 +474,12 @@ def _write_run_parquet(raw_csv_paths, out_dir) -> None:
 
         prov = _ci_provenance()
         parquet_path = Path(out_dir) / f"{prov['run_id']}.parquet"
-        diagnostics = convert_csvs_to_parquet(
-            sorted(raw_csv_paths), parquet_path, strict=False, **prov
+        convert_csvs_to_parquet(
+            sorted(raw_csv_paths), parquet_path, strict=True, **prov
         )
-        unknown = diagnostics["unknown_columns"]
-        if unknown:
-            dropped = sum(len(v) for v in unknown.values())
-            detail = "; ".join(f"{t}={cols}" for t, cols in sorted(unknown.items()))
-            logger.error(
-                f"perf Parquet: {dropped} column(s) not in the schema were dropped ({detail})"
-            )
         logger.info(f"Wrote run Parquet batch: {parquet_path}")
+    except ValueError as exc:
+        raise PerfSchemaError(str(exc)) from exc
     except Exception as exc:  # noqa: BLE001 — Parquet is additive; CSV is primary
         logger.warning(f"perf Parquet batch not written: {type(exc).__name__}: {exc}")
 
@@ -493,6 +492,7 @@ def combine_perf_reports():
 
     Also publishes the run's raw combined CSVs as one Parquet batch
     (perf_data/<run_id>.parquet) so a run emits both CSV and Parquet.
+    Unknown Parquet columns raise ``PerfSchemaError`` (CSV is already written).
     """
 
     unique_module_names = get_unique_base_names(TestConfig.PERF_DATA_DIR)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/parquet.py
@@ -5,7 +5,8 @@
 """Parquet output for LLK performance reports
 
 Publishes a run's per-test reports as one immutable, typed Parquet batch whose
-physical schema is the shared wide schema (wide_schema.DB_SCHEMA).
+physical schema is the arch's wide schema: WH/BH use wide_schema.DB_SCHEMA,
+Quasar uses wide_schema_quasar.DB_SCHEMA (selected from provenance ``arch``).
 
 Data flow
 ---------
@@ -61,6 +62,21 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 
 from .wide_schema import DB_SCHEMA, DROPPED_COLUMNS, MANDATORY, PROVENANCE
+
+
+def schema_for_arch(arch) -> list:
+    """Published Parquet table for this architecture family.
+
+    Wormhole and Blackhole share ``wide_schema.DB_SCHEMA``. Quasar has its own
+    table so Quasar-only columns are not mixed into the WH/BH schema, and
+    WH/BH-only columns stay out of Quasar batches.
+    """
+    if arch == "quasar":
+        from .wide_schema_quasar import DB_SCHEMA as QSR_SCHEMA
+
+        return QSR_SCHEMA
+    return DB_SCHEMA
+
 
 _BOOL_MAP = {
     True: True,
@@ -157,9 +173,10 @@ def build_run_batch(
 
     ``test_frames`` maps test_name -> that test's report DataFrame. Each frame is
     stamped with run provenance and concatenated; ``to_table`` then aligns the
-    union to DB_SCHEMA (missing columns -> NULL) and casts types. One row is one
-    test configuration in one execution context.
+    union to that arch's published schema (missing columns -> NULL) and casts
+    types. One row is one test configuration in one execution context.
     """
+    columns = schema_for_arch(arch)
     stamped = [
         stamp_provenance(
             df,
@@ -176,9 +193,9 @@ def build_run_batch(
     combined = (
         pd.concat(stamped, ignore_index=True, sort=False)
         if stamped
-        else pd.DataFrame(columns=[c.name for c in DB_SCHEMA])
+        else pd.DataFrame(columns=[c.name for c in columns])
     )
-    table = to_table(combined)
+    table = to_table(combined, columns)
     validate_batch(table)
     return table
 
@@ -249,7 +266,8 @@ def convert_csvs_to_parquet(
     """Convert a run's per-test CSVs into one typed Parquet batch.
 
     Reads each CSV, coerces its columns to the schema types, and reuses
-    build_run_batch to align + stamp provenance + compact.
+    build_run_batch to align + stamp provenance + compact. ``provenance["arch"]``
+    selects the published table (WH/BH vs Quasar).
 
     With strict=True (default) the conversion must be lossless: if any column
     would be dropped (not in the schema) or any value coerced to NULL, it raises
@@ -257,7 +275,8 @@ def convert_csvs_to_parquet(
     conversion that writes anyway. Either way it returns the diagnostics: per
     test, the dropped columns and the coerced values.
     """
-    schema_by_name = {c.name: c for c in DB_SCHEMA}
+    columns = schema_for_arch(provenance.get("arch"))
+    schema_by_name = {c.name: c for c in columns}
     frames = {}
     diagnostics = {"unknown_columns": {}, "coerced_values": {}}
     for path in csv_paths:

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/parquet.py
@@ -81,6 +81,17 @@ def schema_for_arch(arch: ChipArchitecture) -> list:
     raise ValueError(f"Unsupported architecture: {arch!r}")
 
 
+def dropped_columns_for_arch(arch: ChipArchitecture) -> set:
+    """TEXT_SIZE(...) columns omitted from the published table for this arch."""
+    if arch == ChipArchitecture.QUASAR:
+        from .wide_schema_quasar import DROPPED_COLUMNS as QSR_DROPPED
+
+        return QSR_DROPPED
+    if arch in (ChipArchitecture.WORMHOLE, ChipArchitecture.BLACKHOLE):
+        return DROPPED_COLUMNS
+    raise ValueError(f"Unsupported architecture: {arch!r}")
+
+
 _BOOL_MAP = {
     True: True,
     False: False,
@@ -278,7 +289,9 @@ def convert_csvs_to_parquet(
     conversion that writes anyway. Either way it returns the diagnostics: per
     test, the dropped columns and the coerced values.
     """
-    columns = schema_for_arch(ChipArchitecture.from_string(provenance.get("arch")))
+    arch = ChipArchitecture.from_string(provenance.get("arch"))
+    columns = schema_for_arch(arch)
+    dropped = dropped_columns_for_arch(arch)
     schema_by_name = {c.name: c for c in columns}
     frames = {}
     diagnostics = {"unknown_columns": {}, "coerced_values": {}}
@@ -286,9 +299,9 @@ def convert_csvs_to_parquet(
         name = _test_name_from_csv(path)
         df = pd.read_csv(path)
         # Drop columns the published table intentionally omits (see
-        # wide_schema.DROPPED_COLUMNS), before the unknown-column check so
-        # they are not flagged as accidental drift.
-        df = df.drop(columns=[c for c in DROPPED_COLUMNS if c in df.columns])
+        # DROPPED_COLUMNS on the arch schema), before the unknown-column check
+        # so they are not flagged as accidental drift.
+        df = df.drop(columns=[c for c in dropped if c in df.columns])
         unknown = sorted(set(df.columns) - set(schema_by_name))
         if unknown:
             diagnostics["unknown_columns"][name] = unknown

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/parquet.py
@@ -61,21 +61,24 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 
+from ..chip_architecture import ChipArchitecture
 from .wide_schema import DB_SCHEMA, DROPPED_COLUMNS, MANDATORY, PROVENANCE
 
 
-def schema_for_arch(arch) -> list:
+def schema_for_arch(arch: ChipArchitecture) -> list:
     """Published Parquet table for this architecture family.
 
     Wormhole and Blackhole share ``wide_schema.DB_SCHEMA``. Quasar has its own
     table so Quasar-only columns are not mixed into the WH/BH schema, and
     WH/BH-only columns stay out of Quasar batches.
     """
-    if arch == "quasar":
+    if arch == ChipArchitecture.QUASAR:
         from .wide_schema_quasar import DB_SCHEMA as QSR_SCHEMA
 
         return QSR_SCHEMA
-    return DB_SCHEMA
+    if arch in (ChipArchitecture.WORMHOLE, ChipArchitecture.BLACKHOLE):
+        return DB_SCHEMA
+    raise ValueError(f"Unsupported architecture: {arch!r}")
 
 
 _BOOL_MAP = {
@@ -176,7 +179,7 @@ def build_run_batch(
     union to that arch's published schema (missing columns -> NULL) and casts
     types. One row is one test configuration in one execution context.
     """
-    columns = schema_for_arch(arch)
+    columns = schema_for_arch(ChipArchitecture.from_string(arch))
     stamped = [
         stamp_provenance(
             df,
@@ -275,7 +278,7 @@ def convert_csvs_to_parquet(
     conversion that writes anyway. Either way it returns the diagnostics: per
     test, the dropped columns and the coerced values.
     """
-    columns = schema_for_arch(provenance.get("arch"))
+    columns = schema_for_arch(ChipArchitecture.from_string(provenance.get("arch")))
     schema_by_name = {c.name: c for c in columns}
     frames = {}
     diagnostics = {"unknown_columns": {}, "coerced_values": {}}

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/publish_run.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/publish_run.py
@@ -20,7 +20,7 @@ import os
 
 from .parquet import convert_csvs_to_parquet
 
-_VALID_ARCHES = ("wormhole", "blackhole")
+_VALID_ARCHES = ("wormhole", "blackhole", "quasar")
 _VALID_PIPELINES = ("PR", "nightly")
 
 
@@ -104,7 +104,10 @@ def main(argv=None):
     ap.add_argument("--csv-dir", required=True, help="dir of combined per-test CSVs")
     ap.add_argument("--out", required=True, help="output run parquet path")
     ap.add_argument(
-        "--arch", required=True, choices=_VALID_ARCHES, help="wormhole | blackhole"
+        "--arch",
+        required=True,
+        choices=_VALID_ARCHES,
+        help="wormhole | blackhole | quasar",
     )
     ap.add_argument("--strict", action="store_true", help="fail on schema drift")
     a = ap.parse_args(argv)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/wide_schema.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/wide_schema.py
@@ -58,7 +58,8 @@ _TIMING_COLUMNS = [
 # This IS the table handed to the data team; the Parquet is written with it. Each
 # column's `origin` says who fills it — "test" (default) or "ci".
 # TODO(counters, deferred — see #51249): counter/metric columns join here as
-# nullable once a counter run captures their exact names.
+# nullable once a counter run captures their exact names. Quasar has its own
+# published table in wide_schema_quasar.py — do not mix Quasar columns in here.
 DB_SCHEMA = [
     Column("marker", "string", False, "identity"),
     # formats

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/wide_schema.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/wide_schema.py
@@ -38,14 +38,11 @@ class Column:
 # so the schema is a superset of any run config, not just what one nightly sampled.
 _TIMING_BASES = (
     "L1_TO_L1",
-    "L1_TO_L1[FPU]",
-    "L1_TO_L1[SFPU]",
     "UNPACK_ISOLATE",
     "MATH_ISOLATE",
     "PACK_ISOLATE",
     "L1_CONGESTION[UNPACK]",
     "L1_CONGESTION[PACK]",
-    "SFPU_ISOLATE",
 )
 _TIMING_COLUMNS = [
     Column(stat_column(base, kind), "float64", True, "timing")
@@ -87,12 +84,9 @@ DB_SCHEMA = [
     Column("ct_dim", "int64", True, "configuration"),
     Column("dest_sync", "string", True, "configuration"),
     Column("dst_index", "int64", True, "configuration"),
-    Column("enable_2x_format", "bool", True, "configuration"),
-    Column("enable_direct_indexing", "bool", True, "configuration"),
     Column("fast_mode", "string", True, "configuration"),
     Column("full_ct_dim", "int64", True, "configuration"),
     Column("full_rt_dim", "int64", True, "configuration"),
-    Column("implied_math_format", "string", True, "configuration"),
     Column("in0_c_dim", "int64", True, "configuration"),
     Column("in0_r_dim", "int64", True, "configuration"),
     Column("in1_c_dim", "int64", True, "configuration"),
@@ -158,7 +152,6 @@ DROPPED_COLUMNS = {
     "TEXT_SIZE(MATH_ISOLATE)",
     "TEXT_SIZE(PACK_ISOLATE)",
     "TEXT_SIZE(UNPACK_ISOLATE)",
-    "TEXT_SIZE(SFPU_ISOLATE)",
 }
 
 # Row identity: one test config in one run. The sweep-parameter columns (which

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/wide_schema_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/wide_schema_quasar.py
@@ -20,15 +20,18 @@ Imports no device libraries, so it loads without hardware.
 from .schema import MEAN, STD, stat_column
 from .wide_schema import Column
 
-# Same run-type timing grid as WH/BH: Quasar perf tests use the same PerfRunType
-# names, so the {mean, std} x base columns match.
+# Same PerfRunType timing grid as WH/BH, plus the 4-TRISC parallel FPU/SFPU
+# bases (#53072): L1_TO_L1[FPU], L1_TO_L1[SFPU], SFPU_ISOLATE.
 _TIMING_BASES = (
     "L1_TO_L1",
+    "L1_TO_L1[FPU]",
+    "L1_TO_L1[SFPU]",
     "UNPACK_ISOLATE",
     "MATH_ISOLATE",
     "PACK_ISOLATE",
     "L1_CONGESTION[UNPACK]",
     "L1_CONGESTION[PACK]",
+    "SFPU_ISOLATE",
 )
 _TIMING_COLUMNS = [
     Column(stat_column(base, kind), "float64", True, "timing")
@@ -121,3 +124,14 @@ DB_SCHEMA = [
 OUTPUT_SCHEMA = [c for c in DB_SCHEMA if c.origin == "test"]
 PROVENANCE = [c for c in DB_SCHEMA if c.origin == "ci"]
 MANDATORY = [c.name for c in DB_SCHEMA if not c.nullable]
+
+# Columns a Quasar test emits but the published table intentionally drops.
+# TEXT_SIZE(...) is per-stage ELF code size; not used by the gate. SFPU_ISOLATE
+# is 4-TRISC-only (#53072) and must not live on the WH/BH dropped set.
+DROPPED_COLUMNS = {
+    "TEXT_SIZE(L1_TO_L1)",
+    "TEXT_SIZE(MATH_ISOLATE)",
+    "TEXT_SIZE(PACK_ISOLATE)",
+    "TEXT_SIZE(UNPACK_ISOLATE)",
+    "TEXT_SIZE(SFPU_ISOLATE)",
+}

--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/wide_schema_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/wide_schema_quasar.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared wide nullable schema for Quasar performance reports (v1).
+
+Separate published table from the WH/BH schema in ``wide_schema.py``. A Quasar
+run is aligned to this schema; a WH/BH run is aligned to that one. The two must
+not be mixed: Quasar-only columns (face dims, unpacker engine, implied math
+format, ...) stay out of the WH/BH table, and WH/BH-only columns stay out of
+this one.
+
+Same conventions as ``wide_schema``: one row per test config per run; every
+column except ``marker`` and the mandatory provenance keys is nullable; Column
+dtype/nullability/origin are the contract the Parquet writer enforces.
+
+Imports no device libraries, so it loads without hardware.
+"""
+
+from .schema import MEAN, STD, stat_column
+from .wide_schema import Column
+
+# Same run-type timing grid as WH/BH: Quasar perf tests use the same PerfRunType
+# names, so the {mean, std} x base columns match.
+_TIMING_BASES = (
+    "L1_TO_L1",
+    "UNPACK_ISOLATE",
+    "MATH_ISOLATE",
+    "PACK_ISOLATE",
+    "L1_CONGESTION[UNPACK]",
+    "L1_CONGESTION[PACK]",
+)
+_TIMING_COLUMNS = [
+    Column(stat_column(base, kind), "float64", True, "timing")
+    for base in _TIMING_BASES
+    for kind in (MEAN, STD)
+]
+
+
+# ── The published Quasar table: headers + provenance ─────────────────────────
+DB_SCHEMA = [
+    Column("marker", "string", False, "identity"),
+    # formats
+    Column("formats.input_A", "string", True, "formats"),
+    Column("formats.input_B", "string", True, "formats"),
+    Column("formats.output", "string", True, "formats"),
+    Column("formats.register_A", "string", True, "formats"),
+    Column("formats.register_B", "string", True, "formats"),
+    Column("formats.sfpu_math", "string", True, "formats"),
+    # flags
+    Column("dest_acc", "string", True, "flags"),
+    Column("speed_of_light", "bool", True, "flags"),
+    Column("unpack_to_dest", "string", True, "flags"),
+    # key
+    Column("loop_factor", "int64", True, "key"),
+    Column("tile_cnt", "int64", True, "key"),
+    # configuration — Quasar test parameters + pipeline-injected dims
+    Column("acc_to_dest", "bool", True, "configuration"),
+    Column("approx_mode", "string", True, "configuration"),
+    Column("block_ct_dim", "int64", True, "configuration"),
+    Column("block_rt_dim", "int64", True, "configuration"),
+    Column("broadcast_type", "string", True, "configuration"),
+    Column("c_dimm", "int64", True, "configuration"),
+    Column("data_copy_type", "string", True, "configuration"),
+    Column("dest_sync", "string", True, "configuration"),
+    Column("dst_index", "int64", True, "configuration"),
+    Column("dst_rounding", "string", True, "configuration"),
+    Column("dst_tile_idx", "int64", True, "configuration"),
+    Column("enable_2x_format", "bool", True, "configuration"),
+    Column("enable_direct_indexing", "bool", True, "configuration"),
+    Column("face_c_dim", "int64", True, "configuration"),
+    Column("face_r_dim", "int64", True, "configuration"),
+    Column("full_ct_dim", "int64", True, "configuration"),
+    Column("full_rt_dim", "int64", True, "configuration"),
+    Column("implied_math_format", "string", True, "configuration"),
+    Column("input_format", "string", True, "configuration"),
+    Column("input_num_blocks", "int64", True, "configuration"),
+    Column("input_num_tiles_in_block", "int64", True, "configuration"),
+    Column("input_tile_cnt", "int64", True, "configuration"),
+    Column("k_dimm", "int64", True, "configuration"),
+    Column("math_fidelity", "string", True, "configuration"),
+    Column("math_transpose_faces", "string", True, "configuration"),
+    Column("mathop", "string", True, "configuration"),
+    Column("num_blocks", "int64", True, "configuration"),
+    Column("num_faces", "int64", True, "configuration"),
+    Column("num_faces_A", "int64", True, "configuration"),
+    Column("num_faces_B", "int64", True, "configuration"),
+    Column("num_faces_c_dim_A", "int64", True, "configuration"),
+    Column("num_faces_c_dim_B", "int64", True, "configuration"),
+    Column("num_faces_r_dim_A", "int64", True, "configuration"),
+    Column("num_faces_r_dim_B", "int64", True, "configuration"),
+    Column("num_tiles_in_block", "int64", True, "configuration"),
+    Column("op", "string", True, "configuration"),
+    Column("output_format", "string", True, "configuration"),
+    Column("output_num_blocks", "int64", True, "configuration"),
+    Column("output_num_tiles_in_block", "int64", True, "configuration"),
+    Column("output_tile_cnt", "int64", True, "configuration"),
+    Column("pool_type", "string", True, "configuration"),
+    Column("r_dimm", "int64", True, "configuration"),
+    Column("relu_config", "int64", True, "configuration"),
+    Column("reuse_dest_type", "string", True, "configuration"),
+    Column("sign_magnitude", "bool", True, "configuration"),
+    Column("src0_tile_idx", "int64", True, "configuration"),
+    Column("src1_tile_idx", "int64", True, "configuration"),
+    Column("unpack_transpose_faces", "string", True, "configuration"),
+    Column("unpack_transpose_within_face", "string", True, "configuration"),
+    Column("unpacker_engine_sel", "string", True, "configuration"),
+    Column("zero_point_bits", "int64", True, "configuration"),
+    # timing (complete {mean, std} x base grid — see _TIMING_COLUMNS above)
+    *_TIMING_COLUMNS,
+    # ── provenance: stamped by the publish layer, never emitted by a test ──
+    Column("test_name", "string", False, "identity", origin="ci"),
+    Column("commit_sha", "string", False, "provenance", origin="ci"),
+    Column("arch", "string", False, "provenance", origin="ci"),
+    Column("run_id", "string", False, "provenance", origin="ci"),
+    Column("timestamp", "string", False, "provenance", origin="ci"),
+    Column("pipeline", "string", False, "provenance", origin="ci"),  # PR | nightly
+    Column("pr_number", "string", True, "provenance", origin="ci"),  # NULL for nightly
+]
+
+OUTPUT_SCHEMA = [c for c in DB_SCHEMA if c.origin == "test"]
+PROVENANCE = [c for c in DB_SCHEMA if c.origin == "ci"]
+MANDATORY = [c.name for c in DB_SCHEMA if not c.nullable]

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_broadcast_quasar.py
@@ -6,15 +6,14 @@ from helpers.constraints import get_valid_dest_accumulation_modes
 from helpers.llk_params import (
     PERF_LOOP_FACTOR_QUASAR,
     PERF_RUN_TYPES_QUASAR,
-    BroadcastType,
     MathOperation,
 )
-from helpers.param_config import parametrize
+from helpers.param_config import generate_perf_input_dimensions, parametrize
 from quasar.test_eltwise_binary_broadcast_quasar import (
     BINARY_BROADCAST_FORMATS,
+    BROADCAST_TYPES,
     binary_broadcast_dest_sync_modes,
     binary_broadcast_implied_math_formats,
-    binary_broadcast_input_dimensions,
     binary_broadcast_math_fidelities,
 )
 from quasar.test_eltwise_binary_broadcast_quasar import (
@@ -28,7 +27,7 @@ from quasar.test_eltwise_binary_broadcast_quasar import (
     formats=BINARY_BROADCAST_FORMATS,
     dest_acc=get_valid_dest_accumulation_modes,
     mathop=[MathOperation.Elwadd],
-    broadcast_type=[BroadcastType.Scalar],
+    broadcast_type=BROADCAST_TYPES,
     math_fidelity=lambda formats, mathop: binary_broadcast_math_fidelities(
         formats, mathop, is_perf=True
     ),
@@ -36,8 +35,8 @@ from quasar.test_eltwise_binary_broadcast_quasar import (
         formats, is_perf=True
     ),
     dest_sync_mode=lambda: binary_broadcast_dest_sync_modes(is_perf=True),
-    input_dimensions=lambda dest_acc, dest_sync_mode: binary_broadcast_input_dimensions(
-        dest_acc, dest_sync_mode, is_perf=True
+    input_dimensions=lambda dest_acc, dest_sync_mode: generate_perf_input_dimensions(
+        dest_acc, dest_sync_mode, use_largest_fallback=True
     ),
     run_types=PERF_RUN_TYPES_QUASAR,
     loop_factor=[PERF_LOOP_FACTOR_QUASAR],

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_broadcast_quasar.py
@@ -3,7 +3,12 @@
 
 import pytest
 from helpers.constraints import get_valid_dest_accumulation_modes
-from helpers.llk_params import PERF_RUN_TYPES_QUASAR, BroadcastType, MathOperation
+from helpers.llk_params import (
+    PERF_LOOP_FACTOR_QUASAR,
+    PERF_RUN_TYPES_QUASAR,
+    BroadcastType,
+    MathOperation,
+)
 from helpers.param_config import parametrize
 from quasar.test_eltwise_binary_broadcast_quasar import (
     BINARY_BROADCAST_FORMATS,
@@ -35,7 +40,7 @@ from quasar.test_eltwise_binary_broadcast_quasar import (
         dest_acc, dest_sync_mode, is_perf=True
     ),
     run_types=PERF_RUN_TYPES_QUASAR,
-    loop_factor=[32],
+    loop_factor=[PERF_LOOP_FACTOR_QUASAR],
     is_perf=[True],
 )
 def test_perf_eltwise_binary_broadcast_quasar(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_broadcast_quasar.py
@@ -3,7 +3,7 @@
 
 import pytest
 from helpers.constraints import (
-    get_quasar_perf_math_operations,
+    get_perf_math_operations,
     get_valid_dest_accumulation_modes,
 )
 from helpers.llk_params import (
@@ -28,10 +28,10 @@ from quasar.test_eltwise_binary_broadcast_quasar import (
 @parametrize(
     formats=BINARY_BROADCAST_FORMATS,
     dest_acc=get_valid_dest_accumulation_modes,
-    mathop=get_quasar_perf_math_operations,
+    mathop=get_perf_math_operations,
     broadcast_type=BROADCAST_TYPES,
     math_fidelity=lambda formats, mathop: binary_broadcast_math_fidelities(
-        formats, mathop, is_perf=True
+        formats, mathop
     ),
     implied_math_format=lambda formats: binary_broadcast_implied_math_formats(
         formats, is_perf=True

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_broadcast_quasar.py
@@ -2,11 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from helpers.constraints import get_valid_dest_accumulation_modes
+from helpers.constraints import (
+    get_quasar_perf_math_operations,
+    get_valid_dest_accumulation_modes,
+)
 from helpers.llk_params import (
     PERF_LOOP_FACTOR_QUASAR,
     PERF_RUN_TYPES_QUASAR,
-    MathOperation,
 )
 from helpers.param_config import generate_perf_input_dimensions, parametrize
 from quasar.test_eltwise_binary_broadcast_quasar import (
@@ -26,7 +28,7 @@ from quasar.test_eltwise_binary_broadcast_quasar import (
 @parametrize(
     formats=BINARY_BROADCAST_FORMATS,
     dest_acc=get_valid_dest_accumulation_modes,
-    mathop=[MathOperation.Elwadd],
+    mathop=get_quasar_perf_math_operations,
     broadcast_type=BROADCAST_TYPES,
     math_fidelity=lambda formats, mathop: binary_broadcast_math_fidelities(
         formats, mathop, is_perf=True

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_quasar.py
@@ -2,7 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from helpers.llk_params import PERF_RUN_TYPES_QUASAR, MathOperation
+from helpers.llk_params import (
+    PERF_LOOP_FACTOR_QUASAR,
+    PERF_RUN_TYPES_QUASAR,
+    MathOperation,
+)
 from helpers.param_config import parametrize
 from quasar.test_eltwise_binary_quasar import (
     ELTWISE_FORMATS,
@@ -34,7 +38,7 @@ from quasar.test_eltwise_binary_quasar import test_eltwise_binary as run_eltwise
     acc_to_dest=[False],
     num_faces=[4],
     run_types=PERF_RUN_TYPES_QUASAR,
-    loop_factor=[32],
+    loop_factor=[PERF_LOOP_FACTOR_QUASAR],
     is_perf=[True],
 )
 def test_perf_eltwise_binary_quasar(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_quasar.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from helpers.constraints import get_quasar_perf_math_operations
+from helpers.constraints import get_perf_math_operations
 from helpers.llk_params import (
     PERF_LOOP_FACTOR_QUASAR,
     PERF_RUN_TYPES_QUASAR,
@@ -24,10 +24,8 @@ from quasar.test_eltwise_binary_quasar import (
 @pytest.mark.quasar
 @parametrize(
     formats=ELTWISE_FORMATS,
-    mathop=get_quasar_perf_math_operations,
-    math_fidelity=lambda mathop, formats: eltwise_binary_math_fidelities(
-        mathop, formats, is_perf=True
-    ),
+    mathop=get_perf_math_operations,
+    math_fidelity=eltwise_binary_math_fidelities,
     implied_math_format=lambda formats: eltwise_binary_implied_math_formats(
         formats, is_perf=True
     ),

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_quasar.py
@@ -7,15 +7,17 @@ from helpers.llk_params import (
     PERF_RUN_TYPES_QUASAR,
     MathOperation,
 )
-from helpers.param_config import parametrize
+from helpers.param_config import generate_perf_input_dimensions, parametrize
 from quasar.test_eltwise_binary_quasar import (
     ELTWISE_FORMATS,
     eltwise_binary_dest_sync_dest_acc,
     eltwise_binary_implied_math_formats,
-    eltwise_binary_input_dimensions,
     eltwise_binary_math_fidelities,
 )
 from quasar.test_eltwise_binary_quasar import test_eltwise_binary as run_eltwise_binary
+from quasar.test_eltwise_binary_quasar import (
+    valid_acc_to_dest,
+)
 
 
 @pytest.mark.perf
@@ -32,10 +34,12 @@ from quasar.test_eltwise_binary_quasar import test_eltwise_binary as run_eltwise
     dest_sync_dest_acc=lambda formats: eltwise_binary_dest_sync_dest_acc(
         formats, is_perf=True
     ),
-    input_dimensions=lambda dest_sync_dest_acc: eltwise_binary_input_dimensions(
-        dest_sync_dest_acc, is_perf=True
+    input_dimensions=lambda dest_sync_dest_acc: generate_perf_input_dimensions(
+        dest_sync_dest_acc[1],
+        dest_sync_dest_acc[0],
+        use_largest_fallback=True,
     ),
-    acc_to_dest=[False],
+    acc_to_dest=valid_acc_to_dest,
     num_faces=[4],
     run_types=PERF_RUN_TYPES_QUASAR,
     loop_factor=[PERF_LOOP_FACTOR_QUASAR],

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_quasar.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+from helpers.constraints import get_quasar_perf_math_operations
 from helpers.llk_params import (
     PERF_LOOP_FACTOR_QUASAR,
     PERF_RUN_TYPES_QUASAR,
-    MathOperation,
 )
 from helpers.param_config import generate_perf_input_dimensions, parametrize
 from quasar.test_eltwise_binary_quasar import (
@@ -24,7 +24,7 @@ from quasar.test_eltwise_binary_quasar import (
 @pytest.mark.quasar
 @parametrize(
     formats=ELTWISE_FORMATS,
-    mathop=[MathOperation.Elwadd],
+    mathop=get_quasar_perf_math_operations,
     math_fidelity=lambda mathop, formats: eltwise_binary_math_fidelities(
         mathop, formats, is_perf=True
     ),

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_reuse_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_reuse_dest_quasar.py
@@ -2,7 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from helpers.llk_params import PERF_RUN_TYPES_QUASAR, EltwiseBinaryReuseDestType
+from helpers.llk_params import (
+    PERF_LOOP_FACTOR_QUASAR,
+    PERF_RUN_TYPES_QUASAR,
+    EltwiseBinaryReuseDestType,
+)
 from helpers.param_config import parametrize, runtime
 from quasar.test_eltwise_binary_reuse_dest_quasar import (
     INPUT_DIMENSIONS,
@@ -33,7 +37,7 @@ from quasar.test_eltwise_binary_reuse_dest_quasar import (
     input_dimensions=runtime(INPUT_DIMENSIONS),
     output_dimensions=runtime(valid_output_dimensions),
     run_types=PERF_RUN_TYPES_QUASAR,
-    loop_factor=[32],
+    loop_factor=[PERF_LOOP_FACTOR_QUASAR],
     is_perf=[True],
 )
 def test_perf_eltwise_binary_reuse_dest_quasar(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_reuse_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_reuse_dest_quasar.py
@@ -28,7 +28,7 @@ from quasar.test_eltwise_binary_reuse_dest_quasar import (
 @parametrize(
     formats=REUSE_DEST_FORMATS,
     mathop=lambda formats: reuse_dest_mathops(formats, is_perf=True),
-    math_fidelity=lambda mathop: reuse_dest_math_fidelities(mathop, is_perf=True),
+    math_fidelity=reuse_dest_math_fidelities,
     reuse_dest_type=[
         EltwiseBinaryReuseDestType.DEST_TO_SRCA,
         EltwiseBinaryReuseDestType.DEST_TO_SRCB,

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_sfpu_quasar.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
-from enum import Enum
-
 import pytest
 from helpers.llk_params import (
     PERF_LOOP_FACTOR_QUASAR,
@@ -11,9 +9,12 @@ from helpers.llk_params import (
     DestAccumulation,
     ImpliedMathFormat,
 )
+from helpers.param_config import parametrize, runtime
 from quasar.test_eltwise_binary_sfpu_quasar import (
+    _BF16_ADD_SUB_OPS,
     _FLOAT_OPS,
     _INT_OPS,
+    _QUANT_OPS,
     DEFAULT_SFPU_BINARY_TILE_INDICES,
     SFPU_BINARY_MAX_MIN_FLOAT_FORMATS,
     SFPU_BINARY_MAX_MIN_INT32_FORMATS,
@@ -21,6 +22,9 @@ from quasar.test_eltwise_binary_sfpu_quasar import (
     _get_valid_float_formats_dest_acc,
     max_min_float_dest_acc_for_format,
     max_min_int32_dest_acc_for_format,
+)
+from quasar.test_eltwise_binary_sfpu_quasar import (
+    test_eltwise_binary_sfpu_bf16_rne_quasar as run_eltwise_binary_sfpu_bf16_rne_quasar,
 )
 from quasar.test_eltwise_binary_sfpu_quasar import (
     test_eltwise_binary_sfpu_float_quasar as run_eltwise_binary_sfpu_float_quasar,
@@ -34,129 +38,159 @@ from quasar.test_eltwise_binary_sfpu_quasar import (
 from quasar.test_eltwise_binary_sfpu_quasar import (
     test_eltwise_binary_sfpu_max_min_int32_quasar as run_eltwise_binary_sfpu_max_min_int32_quasar,
 )
+from quasar.test_eltwise_binary_sfpu_quasar import (
+    test_eltwise_binary_sfpu_quant_quasar as run_eltwise_binary_sfpu_quant_quasar,
+)
 
 
-class PerfCaseFamily(Enum):
-    INT = "int"
-    FLOAT = "float"
-    MAX_MIN_FLOAT = "max_min_float"
-    MAX_MIN_INT = "max_min_int"
-
-
-def _generate_perf_cases():
-    cases = []
-
-    for binary_op, mathop, clamp_inputs in _INT_OPS:
-        cases.append(
-            pytest.param(
-                (
-                    PerfCaseFamily.INT,
-                    (
-                        DataFormat.Int32,
-                        DestAccumulation.Yes,
-                        binary_op,
-                        mathop,
-                        clamp_inputs,
-                    ),
-                ),
-                id=f"int-{binary_op.lower()}",
-            )
-        )
-
-    for binary_op, mathop in _FLOAT_OPS:
-        for formats, dest_acc in _get_valid_float_formats_dest_acc():
-            cases.append(
-                pytest.param(
-                    (PerfCaseFamily.FLOAT, ((formats, dest_acc), binary_op, mathop)),
-                    id=(
-                        f"float-{binary_op.lower()}-"
-                        f"{formats.input_format.name}-{formats.output_format.name}-"
-                        f"{dest_acc.name}"
-                    ),
-                )
-            )
-
-    max_min_float_combinations = _generate_max_min_combinations(
-        SFPU_BINARY_MAX_MIN_FLOAT_FORMATS,
-        dest_acc_for_format=max_min_float_dest_acc_for_format,
-        implied_math_formats=(ImpliedMathFormat.Yes,),
-        input_dimensions_list=([32, 32],),
-    )
-    for combination in max_min_float_combinations:
-        formats, dest_acc, _, is_max_op, _ = combination
-        op = "max" if is_max_op else "min"
-        cases.append(
-            pytest.param(
-                (PerfCaseFamily.MAX_MIN_FLOAT, combination),
-                id=(
-                    f"float-{op}-{formats.input_format.name}-"
-                    f"{formats.output_format.name}-{dest_acc.name}"
-                ),
-            )
-        )
-
-    max_min_int_combinations = _generate_max_min_combinations(
-        SFPU_BINARY_MAX_MIN_INT32_FORMATS,
-        dest_acc_for_format=max_min_int32_dest_acc_for_format,
-        implied_math_formats=(ImpliedMathFormat.No,),
-        input_dimensions_list=([32, 32],),
-    )
-    for combination in max_min_int_combinations:
-        _, _, _, is_max_op, _ = combination
-        op = "max" if is_max_op else "min"
-        cases.append(
-            pytest.param((PerfCaseFamily.MAX_MIN_INT, combination), id=f"int-{op}")
-        )
-
-    return cases
-
-
-@pytest.mark.perf
-@pytest.mark.quasar
-# The four families have heterogeneous argument shapes and hand-authored IDs;
-# plain pytest parametrization keeps them in one homogeneous perf-report module.
-@pytest.mark.parametrize("family_and_args", _generate_perf_cases())
-def test_perf_eltwise_binary_sfpu_quasar(perf_report, family_and_args):
-    family, args = family_and_args
-    perf_kwargs = {
+def _perf_kwargs(perf_report):
+    return {
         "run_types": PERF_RUN_TYPES_QUASAR[0],
         "loop_factor": PERF_LOOP_FACTOR_QUASAR,
         "is_perf": True,
         "perf_report": perf_report,
     }
 
-    if family == PerfCaseFamily.INT:
-        data_format, dest_acc, binary_op, mathop, clamp_inputs = args
-        run_eltwise_binary_sfpu_int_quasar(
-            data_format,
-            dest_acc,
-            binary_op,
-            mathop,
-            clamp_inputs,
-            DEFAULT_SFPU_BINARY_TILE_INDICES,
-            **perf_kwargs,
-        )
-    elif family == PerfCaseFamily.FLOAT:
-        formats_dest_acc, binary_op, mathop = args
-        run_eltwise_binary_sfpu_float_quasar(
-            formats_dest_acc,
-            ImpliedMathFormat.Yes,
-            DEFAULT_SFPU_BINARY_TILE_INDICES,
-            binary_op,
-            mathop,
-            **perf_kwargs,
-        )
-    elif family == PerfCaseFamily.MAX_MIN_FLOAT:
-        run_eltwise_binary_sfpu_max_min_float_quasar(
-            args,
-            DEFAULT_SFPU_BINARY_TILE_INDICES,
-            **perf_kwargs,
-        )
-    elif family == PerfCaseFamily.MAX_MIN_INT:
-        run_eltwise_binary_sfpu_max_min_int32_quasar(
-            args,
-            DEFAULT_SFPU_BINARY_TILE_INDICES,
-            **perf_kwargs,
-        )
-    else:
-        raise ValueError(f"Unsupported binary SFPU perf family: {family}")
+
+@pytest.mark.perf
+@pytest.mark.quasar
+@pytest.mark.parametrize(
+    "binary_op, mathop, clamp_inputs", _INT_OPS, ids=[op for op, _, _ in _INT_OPS]
+)
+@pytest.mark.parametrize(
+    "data_format, dest_acc", [(DataFormat.Int32, DestAccumulation.Yes)]
+)
+@pytest.mark.parametrize("tile_indices", [DEFAULT_SFPU_BINARY_TILE_INDICES])
+def test_perf_eltwise_binary_sfpu_int_quasar(
+    perf_report,
+    data_format,
+    dest_acc,
+    binary_op,
+    mathop,
+    clamp_inputs,
+    tile_indices,
+):
+    run_eltwise_binary_sfpu_int_quasar(
+        data_format,
+        dest_acc,
+        binary_op,
+        mathop,
+        clamp_inputs,
+        tile_indices,
+        **_perf_kwargs(perf_report),
+    )
+
+
+@pytest.mark.perf
+@pytest.mark.quasar
+@pytest.mark.parametrize(
+    "binary_op, mathop", _FLOAT_OPS, ids=[op for op, _ in _FLOAT_OPS]
+)
+@parametrize(
+    formats_dest_acc=_get_valid_float_formats_dest_acc(),
+    implied_math_format=[ImpliedMathFormat.Yes],
+    tile_indices=runtime([DEFAULT_SFPU_BINARY_TILE_INDICES]),
+)
+def test_perf_eltwise_binary_sfpu_float_quasar(
+    perf_report,
+    formats_dest_acc,
+    implied_math_format,
+    tile_indices,
+    binary_op,
+    mathop,
+):
+    run_eltwise_binary_sfpu_float_quasar(
+        formats_dest_acc,
+        implied_math_format,
+        tile_indices,
+        binary_op,
+        mathop,
+        **_perf_kwargs(perf_report),
+    )
+
+
+@pytest.mark.perf
+@pytest.mark.quasar
+@pytest.mark.parametrize(
+    "binary_op, mathop", _BF16_ADD_SUB_OPS, ids=[op for op, _ in _BF16_ADD_SUB_OPS]
+)
+@pytest.mark.parametrize("tile_indices", [DEFAULT_SFPU_BINARY_TILE_INDICES])
+def test_perf_eltwise_binary_sfpu_bf16_rne_quasar(
+    perf_report,
+    tile_indices,
+    binary_op,
+    mathop,
+):
+    run_eltwise_binary_sfpu_bf16_rne_quasar(
+        tile_indices,
+        binary_op,
+        mathop,
+        **_perf_kwargs(perf_report),
+    )
+
+
+@pytest.mark.perf
+@pytest.mark.quasar
+@parametrize(
+    formats_dest_acc_implied_math_is_max_input_dims=_generate_max_min_combinations(
+        SFPU_BINARY_MAX_MIN_FLOAT_FORMATS,
+        dest_acc_for_format=max_min_float_dest_acc_for_format,
+        implied_math_formats=(ImpliedMathFormat.Yes,),
+        input_dimensions_list=([32, 32],),
+    ),
+    tile_indices=runtime([DEFAULT_SFPU_BINARY_TILE_INDICES]),
+)
+def test_perf_eltwise_binary_sfpu_max_min_float_quasar(
+    perf_report,
+    formats_dest_acc_implied_math_is_max_input_dims,
+    tile_indices,
+):
+    run_eltwise_binary_sfpu_max_min_float_quasar(
+        formats_dest_acc_implied_math_is_max_input_dims,
+        tile_indices,
+        **_perf_kwargs(perf_report),
+    )
+
+
+@pytest.mark.perf
+@pytest.mark.quasar
+@parametrize(
+    formats_dest_acc_implied_math_is_max_input_dims=_generate_max_min_combinations(
+        SFPU_BINARY_MAX_MIN_INT32_FORMATS,
+        dest_acc_for_format=max_min_int32_dest_acc_for_format,
+        implied_math_formats=(ImpliedMathFormat.No,),
+        input_dimensions_list=([32, 32],),
+    ),
+    tile_indices=runtime([DEFAULT_SFPU_BINARY_TILE_INDICES]),
+)
+def test_perf_eltwise_binary_sfpu_max_min_int32_quasar(
+    perf_report,
+    formats_dest_acc_implied_math_is_max_input_dims,
+    tile_indices,
+):
+    run_eltwise_binary_sfpu_max_min_int32_quasar(
+        formats_dest_acc_implied_math_is_max_input_dims,
+        tile_indices,
+        **_perf_kwargs(perf_report),
+    )
+
+
+@pytest.mark.perf
+@pytest.mark.quasar
+@parametrize(
+    binary_op=_QUANT_OPS,
+    sign_magnitude=[False, True],
+    tile_indices=runtime([DEFAULT_SFPU_BINARY_TILE_INDICES]),
+)
+def test_perf_eltwise_binary_sfpu_quant_quasar(
+    perf_report,
+    binary_op,
+    sign_magnitude,
+    tile_indices,
+):
+    run_eltwise_binary_sfpu_quant_quasar(
+        binary_op,
+        sign_magnitude,
+        tile_indices,
+        **_perf_kwargs(perf_report),
+    )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_binary_sfpu_quasar.py
@@ -54,22 +54,19 @@ def _perf_kwargs(perf_report):
 
 @pytest.mark.perf
 @pytest.mark.quasar
-@pytest.mark.parametrize(
-    "binary_op, mathop, clamp_inputs", _INT_OPS, ids=[op for op, _, _ in _INT_OPS]
+@parametrize(
+    binary_op_mathop_clamp_inputs=_INT_OPS,
+    data_format_dest_acc=[(DataFormat.Int32, DestAccumulation.Yes)],
+    tile_indices=runtime([DEFAULT_SFPU_BINARY_TILE_INDICES]),
 )
-@pytest.mark.parametrize(
-    "data_format, dest_acc", [(DataFormat.Int32, DestAccumulation.Yes)]
-)
-@pytest.mark.parametrize("tile_indices", [DEFAULT_SFPU_BINARY_TILE_INDICES])
 def test_perf_eltwise_binary_sfpu_int_quasar(
     perf_report,
-    data_format,
-    dest_acc,
-    binary_op,
-    mathop,
-    clamp_inputs,
+    binary_op_mathop_clamp_inputs,
+    data_format_dest_acc,
     tile_indices,
 ):
+    binary_op, mathop, clamp_inputs = binary_op_mathop_clamp_inputs
+    data_format, dest_acc = data_format_dest_acc
     run_eltwise_binary_sfpu_int_quasar(
         data_format,
         dest_acc,
@@ -83,10 +80,8 @@ def test_perf_eltwise_binary_sfpu_int_quasar(
 
 @pytest.mark.perf
 @pytest.mark.quasar
-@pytest.mark.parametrize(
-    "binary_op, mathop", _FLOAT_OPS, ids=[op for op, _ in _FLOAT_OPS]
-)
 @parametrize(
+    binary_op_mathop=_FLOAT_OPS,
     formats_dest_acc=_get_valid_float_formats_dest_acc(),
     implied_math_format=[ImpliedMathFormat.Yes],
     tile_indices=runtime([DEFAULT_SFPU_BINARY_TILE_INDICES]),
@@ -96,9 +91,9 @@ def test_perf_eltwise_binary_sfpu_float_quasar(
     formats_dest_acc,
     implied_math_format,
     tile_indices,
-    binary_op,
-    mathop,
+    binary_op_mathop,
 ):
+    binary_op, mathop = binary_op_mathop
     run_eltwise_binary_sfpu_float_quasar(
         formats_dest_acc,
         implied_math_format,
@@ -111,16 +106,16 @@ def test_perf_eltwise_binary_sfpu_float_quasar(
 
 @pytest.mark.perf
 @pytest.mark.quasar
-@pytest.mark.parametrize(
-    "binary_op, mathop", _BF16_ADD_SUB_OPS, ids=[op for op, _ in _BF16_ADD_SUB_OPS]
+@parametrize(
+    binary_op_mathop=_BF16_ADD_SUB_OPS,
+    tile_indices=runtime([DEFAULT_SFPU_BINARY_TILE_INDICES]),
 )
-@pytest.mark.parametrize("tile_indices", [DEFAULT_SFPU_BINARY_TILE_INDICES])
 def test_perf_eltwise_binary_sfpu_bf16_rne_quasar(
     perf_report,
     tile_indices,
-    binary_op,
-    mathop,
+    binary_op_mathop,
 ):
+    binary_op, mathop = binary_op_mathop
     run_eltwise_binary_sfpu_bf16_rne_quasar(
         tile_indices,
         binary_op,

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_unary_datacopy_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_unary_datacopy_quasar.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from helpers.llk_params import PERF_RUN_TYPES_QUASAR
+from helpers.llk_params import PERF_LOOP_FACTOR_QUASAR, PERF_RUN_TYPES_QUASAR
 from helpers.param_config import parametrize
 from quasar.test_eltwise_unary_datacopy_quasar import (
     PERF_DATACOPY_COMBINATIONS,
@@ -23,7 +23,7 @@ from quasar.test_eltwise_unary_datacopy_quasar import (
         is_perf=True,
     ),
     run_types=PERF_RUN_TYPES_QUASAR,
-    loop_factor=[32],
+    loop_factor=[PERF_LOOP_FACTOR_QUASAR],
     is_perf=[True],
 )
 def test_perf_eltwise_unary_datacopy_quasar(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_unary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_unary_sfpu_quasar.py
@@ -19,7 +19,7 @@ from quasar.test_eltwise_unary_sfpu_quasar import (
         is_perf=True
     ),
     run_types=PERF_RUN_TYPES_QUASAR,
-    loop_factor=[PERF_LOOP_FACTOR_QUASAR],
+    loop_factor=[PERF_LOOP_FACTOR_QUASAR / 2],
     is_perf=[True],
 )
 def test_perf_eltwise_unary_sfpu_quasar(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_unary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_eltwise_unary_sfpu_quasar.py
@@ -19,7 +19,7 @@ from quasar.test_eltwise_unary_sfpu_quasar import (
         is_perf=True
     ),
     run_types=PERF_RUN_TYPES_QUASAR,
-    loop_factor=[PERF_LOOP_FACTOR_QUASAR / 2],
+    loop_factor=[PERF_LOOP_FACTOR_QUASAR],
     is_perf=[True],
 )
 def test_perf_eltwise_unary_sfpu_quasar(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_matmul_quasar.py
@@ -21,13 +21,14 @@ from quasar.test_matmul_quasar import test_matmul as run_matmul
 @pytest.mark.quasar
 @parametrize(
     format=MATMUL_FORMAT,
-    math_fidelity=matmul_math_fidelities,
+    math_fidelity=lambda format: matmul_math_fidelities(format, is_perf=True),
     dest_sync_mode=lambda: matmul_dest_sync_modes(is_perf=True),
     dest_acc=matmul_dest_acc_modes,
     dimensions=lambda dest_acc, dest_sync_mode: matmul_dimensions(
         dest_acc,
         dest_sync_mode,
         exact_dest_fill=True,
+        is_perf=True,
     ),
     implied_math_format=lambda format: matmul_implied_math_formats(
         format, is_perf=True

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_matmul_quasar.py
@@ -8,10 +8,10 @@ from quasar.test_matmul_quasar import (
     MATMUL_FORMAT,
     matmul_dest_acc_modes,
     matmul_dest_sync_modes,
+    matmul_dimensions,
     matmul_enable_direct_indexing,
     matmul_implied_math_formats,
     matmul_math_fidelities,
-    matmul_perf_dimensions,
     matmul_register_format_hints,
 )
 from quasar.test_matmul_quasar import test_matmul as run_matmul
@@ -24,7 +24,11 @@ from quasar.test_matmul_quasar import test_matmul as run_matmul
     math_fidelity=matmul_math_fidelities,
     dest_sync_mode=lambda: matmul_dest_sync_modes(is_perf=True),
     dest_acc=matmul_dest_acc_modes,
-    dimensions=matmul_perf_dimensions,
+    dimensions=lambda dest_acc, dest_sync_mode: matmul_dimensions(
+        dest_acc,
+        dest_sync_mode,
+        exact_dest_fill=True,
+    ),
     implied_math_format=lambda format: matmul_implied_math_formats(
         format, is_perf=True
     ),

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_matmul_quasar.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from helpers.llk_params import PERF_RUN_TYPES_QUASAR, Transpose
+from helpers.llk_params import PERF_LOOP_FACTOR_QUASAR, PERF_RUN_TYPES_QUASAR, Transpose
 from helpers.param_config import parametrize
 from quasar.test_matmul_quasar import (
     MATMUL_FORMAT,
@@ -36,7 +36,7 @@ from quasar.test_matmul_quasar import test_matmul as run_matmul
     enable_direct_indexing=matmul_enable_direct_indexing,
     transpose=[Transpose.No],
     run_types=PERF_RUN_TYPES_QUASAR,
-    loop_factor=[32],
+    loop_factor=[PERF_LOOP_FACTOR_QUASAR],
     is_perf=[True],
 )
 def test_perf_matmul_quasar(
@@ -64,8 +64,8 @@ def test_perf_matmul_quasar(
         register_format_hint,
         enable_direct_indexing,
         transpose,
-        run_types,
-        loop_factor,
+        run_types=run_types,
+        loop_factor=loop_factor,
         is_perf=is_perf,
         perf_report=perf_report,
     )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_matmul_quasar.py
@@ -8,10 +8,10 @@ from quasar.test_matmul_quasar import (
     MATMUL_FORMAT,
     matmul_dest_acc_modes,
     matmul_dest_sync_modes,
-    matmul_dimensions,
     matmul_enable_direct_indexing,
     matmul_implied_math_formats,
     matmul_math_fidelities,
+    matmul_perf_dimensions,
     matmul_register_format_hints,
 )
 from quasar.test_matmul_quasar import test_matmul as run_matmul
@@ -24,11 +24,7 @@ from quasar.test_matmul_quasar import test_matmul as run_matmul
     math_fidelity=matmul_math_fidelities,
     dest_sync_mode=lambda: matmul_dest_sync_modes(is_perf=True),
     dest_acc=matmul_dest_acc_modes,
-    dimensions=lambda dest_acc, dest_sync_mode: matmul_dimensions(
-        dest_acc,
-        dest_sync_mode,
-        exact_dest_fill=True,
-    ),
+    dimensions=matmul_perf_dimensions,
     implied_math_format=lambda format: matmul_implied_math_formats(
         format, is_perf=True
     ),

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_pack_l1_acc_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_pack_l1_acc_quasar.py
@@ -3,12 +3,12 @@
 
 import pytest
 from helpers.llk_params import PERF_LOOP_FACTOR_QUASAR, PERF_RUN_TYPES_QUASAR
-from helpers.param_config import parametrize, runtime
+from helpers.param_config import parametrize
 from quasar.test_pack_l1_acc_quasar import (
     ALL_PACK_L1_ACC_COMBINATIONS,
+    INPUT_DIMENSIONS,
     pack_l1_acc_dest_sync_modes,
     pack_l1_acc_implied_math_formats,
-    pack_l1_acc_input_dimensions,
 )
 from quasar.test_pack_l1_acc_quasar import test_pack_l1_acc_quasar as run_pack_l1_acc
 
@@ -21,7 +21,7 @@ from quasar.test_pack_l1_acc_quasar import test_pack_l1_acc_quasar as run_pack_l
         formats_dest_acc, is_perf=True
     ),
     dest_sync_mode=lambda: pack_l1_acc_dest_sync_modes(is_perf=True),
-    input_dimensions=runtime(lambda: pack_l1_acc_input_dimensions(is_perf=True)),
+    input_dimensions=INPUT_DIMENSIONS,
     run_types=PERF_RUN_TYPES_QUASAR,
     loop_factor=[PERF_LOOP_FACTOR_QUASAR],
     is_perf=[True],

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_pack_l1_acc_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_pack_l1_acc_quasar.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from helpers.llk_params import PERF_RUN_TYPES_QUASAR
+from helpers.llk_params import PERF_LOOP_FACTOR_QUASAR, PERF_RUN_TYPES_QUASAR
 from helpers.param_config import parametrize, runtime
 from quasar.test_pack_l1_acc_quasar import (
     ALL_PACK_L1_ACC_COMBINATIONS,
@@ -23,7 +23,7 @@ from quasar.test_pack_l1_acc_quasar import test_pack_l1_acc_quasar as run_pack_l
     dest_sync_mode=lambda: pack_l1_acc_dest_sync_modes(is_perf=True),
     input_dimensions=runtime(lambda: pack_l1_acc_input_dimensions(is_perf=True)),
     run_types=PERF_RUN_TYPES_QUASAR,
-    loop_factor=[32],
+    loop_factor=[PERF_LOOP_FACTOR_QUASAR],
     is_perf=[True],
 )
 def test_perf_pack_l1_acc_quasar(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_pack_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_pack_quasar.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from helpers.llk_params import PERF_RUN_TYPES_QUASAR
+from helpers.llk_params import PERF_LOOP_FACTOR_QUASAR, PERF_RUN_TYPES_QUASAR
 from helpers.param_config import parametrize
 from quasar.test_pack_quasar import PERF_PACK_COMBINATIONS
 from quasar.test_pack_quasar import test_pack_quasar as run_pack
@@ -13,7 +13,7 @@ from quasar.test_pack_quasar import test_pack_quasar as run_pack
 @parametrize(
     formats_dest_acc_sync_dims_relu=PERF_PACK_COMBINATIONS,
     run_types=PERF_RUN_TYPES_QUASAR,
-    loop_factor=[32],
+    loop_factor=[PERF_LOOP_FACTOR_QUASAR],
     is_perf=[True],
 )
 def test_perf_pack_quasar(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_pack_untilize_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_pack_untilize_quasar.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from helpers.llk_params import PERF_RUN_TYPES_QUASAR
+from helpers.llk_params import PERF_LOOP_FACTOR_QUASAR, PERF_RUN_TYPES_QUASAR
 from helpers.param_config import parametrize
 from quasar.test_pack_untilize_quasar import (
     PERF_PACK_UNTILIZE_COMBINATIONS,
@@ -17,7 +17,7 @@ from quasar.test_pack_untilize_quasar import (
 @parametrize(
     formats_dest_acc_sync_dimensions=PERF_PACK_UNTILIZE_COMBINATIONS,
     run_types=PERF_RUN_TYPES_QUASAR,
-    loop_factor=[32],
+    loop_factor=[PERF_LOOP_FACTOR_QUASAR],
     is_perf=[True],
 )
 def test_perf_pack_untilize_quasar(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_reduce_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_reduce_quasar.py
@@ -6,17 +6,18 @@ from helpers.format_config import DataFormat, InputOutputFormat
 from helpers.llk_params import (
     PERF_LOOP_FACTOR_QUASAR,
     PERF_RUN_TYPES_QUASAR,
-    MathFidelity,
     ReduceDimension,
     ReducePool,
 )
 from helpers.param_config import parametrize
 from quasar.test_reduce_quasar import (
+    MATH_FIDELITY_MODES,
     REDUCE_FORMATS,
     reduce_dest_acc_modes,
     reduce_dest_sync_modes,
     reduce_implied_math_formats,
     reduce_pool_type_and_math_fidelity_combinations,
+    reduce_tile_dimensions,
 )
 from quasar.test_reduce_quasar import test_reduce_quasar as run_reduce_quasar
 from quasar.test_reduce_quasar import (
@@ -29,7 +30,7 @@ from quasar.test_reduce_quasar import (
 @pytest.mark.nightly
 @parametrize(
     formats=REDUCE_FORMATS,
-    tile_dimensions=[(32, 32)],
+    tile_dimensions=lambda formats: reduce_tile_dimensions(formats, is_perf=True),
     dest_acc=lambda: reduce_dest_acc_modes(is_perf=True),
     reduce_dim=[ReduceDimension.Row, ReduceDimension.Column, ReduceDimension.Scalar],
     pool_type_and_math_fidelity=lambda: reduce_pool_type_and_math_fidelity_combinations(
@@ -90,7 +91,7 @@ def test_perf_reduce_quasar(
     dest_acc=lambda: reduce_dest_acc_modes(is_perf=True),
     reduce_dim=[ReduceDimension.Column],
     pool_type=[ReducePool.Sum, ReducePool.Average],
-    math_fidelity=[MathFidelity.LoFi],
+    math_fidelity=MATH_FIDELITY_MODES,
     dest_sync_mode=lambda: reduce_dest_sync_modes(is_perf=True),
     run_types=PERF_RUN_TYPES_QUASAR,
     loop_factor=[PERF_LOOP_FACTOR_QUASAR],

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_reduce_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_reduce_quasar.py
@@ -4,6 +4,7 @@
 import pytest
 from helpers.format_config import DataFormat, InputOutputFormat
 from helpers.llk_params import (
+    PERF_LOOP_FACTOR_QUASAR,
     PERF_RUN_TYPES_QUASAR,
     MathFidelity,
     ReduceDimension,
@@ -39,7 +40,7 @@ from quasar.test_reduce_quasar import (
         formats, is_perf=True
     ),
     run_types=PERF_RUN_TYPES_QUASAR,
-    loop_factor=[32],
+    loop_factor=[PERF_LOOP_FACTOR_QUASAR],
     is_perf=[True],
 )
 def test_perf_reduce_quasar(
@@ -92,7 +93,7 @@ def test_perf_reduce_quasar(
     math_fidelity=[MathFidelity.LoFi],
     dest_sync_mode=lambda: reduce_dest_sync_modes(is_perf=True),
     run_types=PERF_RUN_TYPES_QUASAR,
-    loop_factor=[32],
+    loop_factor=[PERF_LOOP_FACTOR_QUASAR],
     is_perf=[True],
 )
 def test_perf_reduce_quasar_mxfp4_2x_gapool(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_transpose_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_transpose_dest_quasar.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from helpers.llk_params import PERF_RUN_TYPES_QUASAR
+from helpers.llk_params import PERF_LOOP_FACTOR_QUASAR, PERF_RUN_TYPES_QUASAR
 from helpers.param_config import parametrize
 from quasar.test_transpose_dest_quasar import (
     PERF_TRANSPOSE_DEST_COMBINATIONS,
@@ -21,7 +21,7 @@ from quasar.test_transpose_dest_quasar import (
     formats_dest_acc_sync_transpose_dims=PERF_TRANSPOSE_DEST_COMBINATIONS,
     implied_math_format=lambda: transpose_dest_implied_math_formats(is_perf=True),
     run_types=PERF_RUN_TYPES_QUASAR,
-    loop_factor=[32],
+    loop_factor=[PERF_LOOP_FACTOR_QUASAR],
     is_perf=[True],
 )
 def test_perf_transpose_dest_quasar(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_unary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_unary_broadcast_quasar.py
@@ -2,7 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from helpers.llk_params import PERF_RUN_TYPES_QUASAR, BroadcastType
+from helpers.llk_params import (
+    PERF_LOOP_FACTOR_QUASAR,
+    PERF_RUN_TYPES_QUASAR,
+    BroadcastType,
+)
 from helpers.param_config import parametrize, runtime
 from quasar.test_unary_broadcast_quasar import (
     INPUT_DIMENSIONS,
@@ -30,7 +34,7 @@ from quasar.test_unary_broadcast_quasar import (
     dest_sync_mode=lambda: unary_broadcast_dest_sync_modes(is_perf=True),
     input_dimensions=runtime(INPUT_DIMENSIONS),
     run_types=PERF_RUN_TYPES_QUASAR,
-    loop_factor=[32],
+    loop_factor=[PERF_LOOP_FACTOR_QUASAR],
     is_perf=[True],
 )
 def test_perf_unary_broadcast_quasar(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_unary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_unary_broadcast_quasar.py
@@ -5,10 +5,10 @@ import pytest
 from helpers.llk_params import (
     PERF_LOOP_FACTOR_QUASAR,
     PERF_RUN_TYPES_QUASAR,
-    BroadcastType,
 )
 from helpers.param_config import parametrize, runtime
 from quasar.test_unary_broadcast_quasar import (
+    BROADCAST_TYPES,
     INPUT_DIMENSIONS,
     UNARY_BROADCAST_FORMATS,
     get_valid_dest_acc_unary_broadcast,
@@ -27,7 +27,7 @@ from quasar.test_unary_broadcast_quasar import (
 @parametrize(
     formats=UNARY_BROADCAST_FORMATS,
     dest_acc=get_valid_dest_acc_unary_broadcast,
-    broadcast_type=[BroadcastType.Scalar],
+    broadcast_type=BROADCAST_TYPES,
     implied_math_format=lambda formats: unary_broadcast_implied_math_formats(
         formats, is_perf=True
     ),

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_unpack_reduce_col_tilizeA_strided_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_unpack_reduce_col_tilizeA_strided_quasar.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from helpers.llk_params import PERF_RUN_TYPES_QUASAR
+from helpers.llk_params import PERF_LOOP_FACTOR_QUASAR, PERF_RUN_TYPES_QUASAR
 from helpers.param_config import parametrize
 from quasar.test_unpack_reduce_col_tilizeA_strided_quasar import (
     PERF_UNPACK_REDUCE_COL_TILIZEA_STRIDED_COMBINATIONS,
@@ -21,7 +21,7 @@ from quasar.test_unpack_reduce_col_tilizeA_strided_quasar import (
     formats_dest_acc_sync_unpack_reduce_col_tilizeA_strided_sel_dims=PERF_UNPACK_REDUCE_COL_TILIZEA_STRIDED_COMBINATIONS,
     implied_math_format=unpack_reduce_col_tilizeA_strided_implied_math_formats,
     run_types=PERF_RUN_TYPES_QUASAR,
-    loop_factor=[32],
+    loop_factor=[PERF_LOOP_FACTOR_QUASAR],
     is_perf=[True],
 )
 def test_perf_unpack_reduce_col_tilizeA_strided_quasar(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_unpack_tilize_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_unpack_tilize_quasar.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from helpers.llk_params import PERF_RUN_TYPES_QUASAR
+from helpers.llk_params import PERF_LOOP_FACTOR_QUASAR, PERF_RUN_TYPES_QUASAR
 from helpers.param_config import parametrize
 from quasar.test_unpack_tilize_quasar import (
     PERF_UNPACK_TILIZE_COMBINATIONS,
@@ -17,7 +17,7 @@ from quasar.test_unpack_tilize_quasar import (
 @parametrize(
     formats_dest_acc_sync_unpack_sel_dimensions=PERF_UNPACK_TILIZE_COMBINATIONS,
     run_types=PERF_RUN_TYPES_QUASAR,
-    loop_factor=[32],
+    loop_factor=[PERF_LOOP_FACTOR_QUASAR],
     is_perf=[True],
 )
 def test_perf_unpack_tilize_quasar(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/perf_unpack_unary_operand_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/perf_unpack_unary_operand_quasar.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-from helpers.llk_params import PERF_RUN_TYPES_QUASAR
+from helpers.llk_params import PERF_LOOP_FACTOR_QUASAR, PERF_RUN_TYPES_QUASAR
 from helpers.param_config import parametrize
 from quasar.test_unpack_unary_operand_quasar import (
     PERF_UNPACK_UNARY_OPERAND_COMBINATIONS,
@@ -17,7 +17,7 @@ from quasar.test_unpack_unary_operand_quasar import (
 @parametrize(
     formats_dest_acc_sync_transpose_unpack_sel_dims=PERF_UNPACK_UNARY_OPERAND_COMBINATIONS,
     run_types=PERF_RUN_TYPES_QUASAR,
-    loop_factor=[32],
+    loop_factor=[PERF_LOOP_FACTOR_QUASAR],
     is_perf=[True],
 )
 def test_perf_unpack_unary_operand_quasar(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_broadcast_quasar.py
@@ -28,10 +28,10 @@ from helpers.param_config import (
     parametrize,
     runtime,
 )
-from helpers.perf.core import PerfConfig
+from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import StimuliSpec, generate_stimuli
-from helpers.test_config import BootMode, TestConfig
+from helpers.test_config import BootMode
 from helpers.test_variant_parameters import (
     BROADCAST_TYPE,
     DEST_SYNC,
@@ -40,9 +40,9 @@ from helpers.test_variant_parameters import (
     MATH_FIDELITY,
     MATH_OP,
     NUM_FACES,
-    PERF_RUN_TYPE,
     TEST_FACE_DIMS,
     TILE_COUNT,
+    generate_input_dim,
 )
 from helpers.tile_constants import DEFAULT_TILE_C_DIM, DEFAULT_TILE_R_DIM
 from helpers.utils import passed_test
@@ -189,6 +189,7 @@ def test_eltwise_binary_broadcast_quasar(
             DEST_SYNC(dest_sync_mode),
         ],
         "runtimes": [
+            generate_input_dim(input_dimensions, input_dimensions),
             TILE_COUNT(tile_cnt_A),
             NUM_FACES(4),
             TEST_FACE_DIMS(),
@@ -210,19 +211,16 @@ def test_eltwise_binary_broadcast_quasar(
         "disable_format_inference": formats.input_format.is_mx_format(),
     }
 
+    configuration = create_test_or_perf_config(
+        is_perf=is_perf,
+        run_types=run_types,
+        test_config_kwargs=test_config_kwargs,
+        boot_mode=boot_mode,
+    )
     if is_perf:
-        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
         configuration.run(perf_report)
         return
 
-    configuration = TestConfig(
-        **{
-            **test_config_kwargs,
-            "templates": test_config_kwargs["templates"]
-            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
-            "boot_mode": boot_mode,
-        },
-    )
     res_from_L1 = configuration.run().result
 
     assert len(res_from_L1) == len(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_broadcast_quasar.py
@@ -83,8 +83,6 @@ def binary_broadcast_implied_math_formats(format, *, is_perf=False):
 def binary_broadcast_math_fidelities(format, mathop, *, is_perf=False):
     if format.input_format == DataFormat.Int8:
         return [MathFidelity.LoFi]
-    if is_perf:
-        return [MathFidelity.LoFi]
     return get_valid_math_fidelities(format, mathop)
 
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_broadcast_quasar.py
@@ -61,6 +61,12 @@ BINARY_BROADCAST_FORMATS = input_output_formats(
     ],
 ) + [InputOutputFormat(DataFormat.Int8, DataFormat.Int32)]
 
+BROADCAST_TYPES = [
+    BroadcastType.Column,
+    BroadcastType.Row,
+    BroadcastType.Scalar,
+]
+
 
 def binary_broadcast_dest_sync_modes(*, is_perf=False):
     return [DestSync.Half] if is_perf else [DestSync.Half, DestSync.Full]
@@ -82,14 +88,6 @@ def binary_broadcast_math_fidelities(format, mathop, *, is_perf=False):
     return get_valid_math_fidelities(format, mathop)
 
 
-def binary_broadcast_input_dimensions(dest_acc, dest_sync_mode, *, is_perf=False):
-    if is_perf:
-        # Nested list: parametrize treats a flat list as multiple values, so
-        # [32, 32] would become input_dimensions=32 (int) and break generate_stimuli.
-        return [[DEFAULT_TILE_R_DIM, DEFAULT_TILE_C_DIM]]
-    return generate_unary_input_dimensions(dest_acc, dest_sync_mode)
-
-
 @pytest.mark.quasar
 @parametrize(
     formats=BINARY_BROADCAST_FORMATS,
@@ -99,19 +97,15 @@ def binary_broadcast_input_dimensions(dest_acc, dest_sync_mode, *, is_perf=False
         MathOperation.Elwsub,
         MathOperation.Elwmul,
     ],
-    broadcast_type=[
-        BroadcastType.Column,
-        BroadcastType.Row,
-        BroadcastType.Scalar,
-    ],
+    broadcast_type=BROADCAST_TYPES,
     math_fidelity=lambda formats, mathop: binary_broadcast_math_fidelities(
         formats, mathop
     ),
     implied_math_format=lambda formats: binary_broadcast_implied_math_formats(formats),
     dest_sync_mode=lambda: binary_broadcast_dest_sync_modes(is_perf=False),
     input_dimensions=runtime(
-        lambda dest_acc, dest_sync_mode: binary_broadcast_input_dimensions(
-            dest_acc, dest_sync_mode, is_perf=False
+        lambda dest_acc, dest_sync_mode: generate_unary_input_dimensions(
+            dest_acc, dest_sync_mode
         )
     ),
     run_types=[[PerfRunType.L1_TO_L1]],

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_broadcast_quasar.py
@@ -80,7 +80,7 @@ def binary_broadcast_implied_math_formats(format, *, is_perf=False):
     return [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
 
 
-def binary_broadcast_math_fidelities(format, mathop, *, is_perf=False):
+def binary_broadcast_math_fidelities(format, mathop):
     if format.input_format == DataFormat.Int8:
         return [MathFidelity.LoFi]
     return get_valid_math_fidelities(format, mathop)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
@@ -71,7 +71,7 @@ def eltwise_binary_implied_math_formats(formats, *, is_perf=False):
     return [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
 
 
-def eltwise_binary_math_fidelities(mathop, formats, *, is_perf=False):
+def eltwise_binary_math_fidelities(mathop, formats):
     if (
         mathop in [MathOperation.Elwadd, MathOperation.Elwsub]
         or formats.input_format == DataFormat.Int8
@@ -131,9 +131,7 @@ ELTWISE_FORMATS = input_output_formats(
         MathOperation.Elwsub,
         MathOperation.Elwmul,
     ],
-    math_fidelity=lambda mathop, formats: eltwise_binary_math_fidelities(
-        mathop, formats, is_perf=False
-    ),
+    math_fidelity=eltwise_binary_math_fidelities,
     implied_math_format=lambda formats: eltwise_binary_implied_math_formats(
         formats, is_perf=False
     ),

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
@@ -23,10 +23,10 @@ from helpers.param_config import (
     parametrize,
     runtime,
 )
-from helpers.perf.core import PerfConfig
+from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import StimuliSpec, generate_stimuli
-from helpers.test_config import BootMode, TestConfig
+from helpers.test_config import BootMode
 from helpers.test_variant_parameters import (
     ACC_TO_DEST,
     DEST_SYNC,
@@ -38,8 +38,8 @@ from helpers.test_variant_parameters import (
     NUM_FACES,
     NUM_TILES_IN_BLOCK,
     OUTPUT_TILE_CNT,
-    PERF_RUN_TYPE,
     TEST_FACE_DIMS,
+    generate_input_dim,
 )
 from helpers.tile_shape import construct_tile_shape
 from helpers.utils import passed_test
@@ -224,6 +224,7 @@ def test_eltwise_binary(
             ACC_TO_DEST(acc_to_dest),
         ],
         "runtimes": [
+            generate_input_dim(input_dimensions, input_dimensions),
             INPUT_TILE_CNT(tile_cnt_A),
             OUTPUT_TILE_CNT(tile_cnt_res),
             NUM_FACES(num_faces),
@@ -249,19 +250,16 @@ def test_eltwise_binary(
         "disable_format_inference": formats.input_format.is_mx_format(),
     }
 
+    configuration = create_test_or_perf_config(
+        is_perf=is_perf,
+        run_types=run_types,
+        test_config_kwargs=test_config_kwargs,
+        boot_mode=boot_mode,
+    )
     if is_perf:
-        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
         configuration.run(perf_report)
         return
 
-    configuration = TestConfig(
-        **{
-            **test_config_kwargs,
-            "boot_mode": boot_mode,
-            "templates": test_config_kwargs["templates"]
-            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
-        },
-    )
     res_from_L1 = configuration.run().result
 
     # Verify results match golden

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
@@ -86,14 +86,6 @@ def eltwise_binary_math_fidelities(mathop, formats, *, is_perf=False):
     ]
 
 
-def eltwise_binary_input_dimensions(dest_sync_dest_acc, *, is_perf=False):
-    if is_perf:
-        # Nested list: parametrize treats a flat list as multiple values, so
-        # [32, 32] would become input_dimensions=32 (int) and break generate_stimuli.
-        return [[32, 32]]
-    return generate_unary_input_dimensions(dest_sync_dest_acc[1], dest_sync_dest_acc[0])
-
-
 # For acc_to_dest setting, accumulate two result tiles into dest. Can be extended.
 def get_num_tiles_per_accumulation(acc_to_dest: bool) -> int:
     return 2 if acc_to_dest else 1
@@ -150,8 +142,8 @@ ELTWISE_FORMATS = input_output_formats(
         formats, is_perf=False
     ),
     input_dimensions=runtime(
-        lambda dest_sync_dest_acc: eltwise_binary_input_dimensions(
-            dest_sync_dest_acc, is_perf=False
+        lambda dest_sync_dest_acc: generate_unary_input_dimensions(
+            dest_sync_dest_acc[1], dest_sync_dest_acc[0]
         )
     ),
     acc_to_dest=valid_acc_to_dest,

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
@@ -73,8 +73,7 @@ def eltwise_binary_implied_math_formats(formats, *, is_perf=False):
 
 def eltwise_binary_math_fidelities(mathop, formats, *, is_perf=False):
     if (
-        is_perf
-        or mathop in [MathOperation.Elwadd, MathOperation.Elwsub]
+        mathop in [MathOperation.Elwadd, MathOperation.Elwsub]
         or formats.input_format == DataFormat.Int8
     ):
         return [MathFidelity.LoFi]

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
@@ -27,10 +27,10 @@ from helpers.param_config import (
     parametrize,
     runtime,
 )
-from helpers.perf.core import PerfConfig
+from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
-from helpers.test_config import BootMode, TestConfig
+from helpers.test_config import BootMode
 from helpers.test_variant_parameters import (
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
@@ -42,7 +42,6 @@ from helpers.test_variant_parameters import (
     NUM_FACES,
     NUM_TILES_IN_BLOCK,
     OUTPUT_TILE_CNT,
-    PERF_RUN_TYPE,
     REUSE_DEST_TYPE,
     TEST_FACE_DIMS,
     generate_input_dim,
@@ -373,19 +372,16 @@ def test_eltwise_binary_reuse_dest_quasar(
         "disable_format_inference": disable_format_inference,
     }
 
+    configuration = create_test_or_perf_config(
+        is_perf=is_perf,
+        run_types=run_types,
+        test_config_kwargs=test_config_kwargs,
+        boot_mode=boot_mode,
+    )
     if is_perf:
-        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
         configuration.run(perf_report)
         return
 
-    configuration = TestConfig(
-        **{
-            **test_config_kwargs,
-            "boot_mode": boot_mode,
-            "templates": test_config_kwargs["templates"]
-            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
-        },
-    )
     res_from_L1 = configuration.run().result
 
     # Verify results match golden

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
@@ -5,7 +5,7 @@
 # Test for eltwise binary operations with reuse_dest on Quasar.
 import pytest
 import torch
-from helpers.constraints import get_quasar_perf_math_operations
+from helpers.constraints import get_perf_math_operations
 from helpers.format_config import DataFormat
 from helpers.golden_generators import (
     EltwiseBinaryGolden,
@@ -93,13 +93,13 @@ def reuse_dest_mathops(formats, *, is_perf=False):
     if is_perf:
         return [
             mathop
-            for mathop in get_quasar_perf_math_operations()
+            for mathop in get_perf_math_operations()
             if mathop in supported_mathops
         ]
     return supported_mathops
 
 
-def reuse_dest_math_fidelities(mathop, *, is_perf=False):
+def reuse_dest_math_fidelities(mathop):
     if mathop in [MathOperation.Elwadd, MathOperation.Elwsub]:
         return [MathFidelity.LoFi]
     return [
@@ -161,7 +161,7 @@ def valid_output_dimensions(formats, dest_sync_mode, input_dimensions) -> list:
 @parametrize(
     formats=REUSE_DEST_FORMATS,
     mathop=lambda formats: reuse_dest_mathops(formats, is_perf=False),
-    math_fidelity=lambda mathop: reuse_dest_math_fidelities(mathop, is_perf=False),
+    math_fidelity=reuse_dest_math_fidelities,
     reuse_dest_type=[
         EltwiseBinaryReuseDestType.DEST_TO_SRCA,
         EltwiseBinaryReuseDestType.DEST_TO_SRCB,

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
@@ -5,6 +5,7 @@
 # Test for eltwise binary operations with reuse_dest on Quasar.
 import pytest
 import torch
+from helpers.constraints import get_quasar_perf_math_operations
 from helpers.format_config import DataFormat
 from helpers.golden_generators import (
     EltwiseBinaryGolden,
@@ -78,18 +79,28 @@ def reuse_dest_dest_sync_modes(*, is_perf=False):
 
 
 def reuse_dest_mathops(formats, *, is_perf=False):
-    if is_perf:
-        return [MathOperation.Elwadd]
     if (
         formats.input_format == DataFormat.MxFp8R
         or formats.input_format == DataFormat.MxFp8P
     ):
-        return [MathOperation.Elwadd, MathOperation.Elwsub]
-    return [MathOperation.Elwadd, MathOperation.Elwsub, MathOperation.Elwmul]
+        supported_mathops = [MathOperation.Elwadd, MathOperation.Elwsub]
+    else:
+        supported_mathops = [
+            MathOperation.Elwadd,
+            MathOperation.Elwsub,
+            MathOperation.Elwmul,
+        ]
+    if is_perf:
+        return [
+            mathop
+            for mathop in get_quasar_perf_math_operations()
+            if mathop in supported_mathops
+        ]
+    return supported_mathops
 
 
 def reuse_dest_math_fidelities(mathop, *, is_perf=False):
-    if is_perf or mathop in [MathOperation.Elwadd, MathOperation.Elwsub]:
+    if mathop in [MathOperation.Elwadd, MathOperation.Elwsub]:
         return [MathFidelity.LoFi]
     return [
         MathFidelity.LoFi,

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_sfpu_quasar.py
@@ -39,7 +39,6 @@ from helpers.stimuli_generator import (
     format_elem_max,
     generate_stimuli,
 )
-from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     DATA_COPY_TYPE,
     DEST_INDEX,
@@ -47,7 +46,6 @@ from helpers.test_variant_parameters import (
     IMPLIED_MATH_FORMAT,
     LOOP_FACTOR,
     NUM_FACES,
-    PERF_RUN_TYPE,
     SFPU_BINARY_OP,
     SFPU_DST_ROUNDING_MODE,
     SFPU_TILE_INDICES,
@@ -439,6 +437,11 @@ def test_eltwise_binary_sfpu_bf16_rne_quasar(
     tile_indices,
     binary_op,
     mathop,
+    *,
+    run_types=(PerfRunType.L1_TO_L1,),
+    loop_factor=1,
+    is_perf=False,
+    perf_report=None,
 ):
     """Binary SFPU ADD/SUB with NearestEven rounding on bfloat16 inputs.
 
@@ -457,6 +460,10 @@ def test_eltwise_binary_sfpu_bf16_rne_quasar(
         binary_op,
         prepare_stimuli=_prepare_float_stimuli,
         dst_rounding_mode=DstRoundingMode.NearestEven,
+        run_types=run_types,
+        loop_factor=loop_factor,
+        is_perf=is_perf,
+        perf_report=perf_report,
     )
 
 
@@ -815,7 +822,16 @@ def _int32_to_smag32(t: torch.Tensor) -> torch.Tensor:
 _QUANT_OPS = ["QUANT", "REQUANT", "DEQUANT"]
 
 
-def _run_quant(binary_op, tile_indices, sign_magnitude=False):
+def _run_quant(
+    binary_op,
+    tile_indices,
+    sign_magnitude=False,
+    *,
+    run_types=(PerfRunType.L1_TO_L1,),
+    loop_factor=1,
+    is_perf=False,
+    perf_report=None,
+):
     src0_idx, src1_idx, dst_idx = tile_indices
     dest_acc = DestAccumulation.Yes  # all quant endpoints are 32-bit
     num_faces = MAX_NUM_FACES
@@ -886,30 +902,29 @@ def _run_quant(binary_op, tile_indices, sign_magnitude=False):
         input_format=DataFormat.Int32, output_format=output_format
     )
 
-    configuration = TestConfig(
-        _CPP_SOURCE,
-        formats,
-        templates=[
+    test_config_kwargs = {
+        "test_name": _CPP_SOURCE,
+        "formats": formats,
+        "templates": [
             SFPU_BINARY_OP(binary_op),
             IMPLIED_MATH_FORMAT(ImpliedMathFormat.No),
             DATA_COPY_TYPE(DataCopyType.A2D),
             UNPACKER_ENGINE_SEL(UnpackerEngine.UnpDest),
             DEST_SYNC(),
-            PERF_RUN_TYPE(PerfRunType.L1_TO_L1),
             SIGN_MAGNITUDE_FORMAT(sign_magnitude),
             SFPU_DST_ROUNDING_MODE(),
             TYPECAST_FORMATS(),
         ],
-        runtimes=[
+        "runtimes": [
             TILE_COUNT(tile_cnt),
             NUM_FACES(num_faces),
             TEST_FACE_DIMS(),
             DEST_INDEX(0),
             SFPU_TILE_INDICES(src0_idx, src1_idx, dst_idx),
-            LOOP_FACTOR(1),
+            LOOP_FACTOR(loop_factor),
             ZERO_POINT(zp_bits),
         ],
-        variant_stimuli=StimuliConfig(
+        "variant_stimuli": StimuliConfig(
             buffer_A,
             DataFormat.Int32,
             buffer_A[:MAX_TILE_ELEMENTS],  # dummy buffer_B (unused by kernel)
@@ -921,9 +936,14 @@ def _run_quant(binary_op, tile_indices, sign_magnitude=False):
             num_faces=num_faces,
             twos_complement=True,  # raw 32-bit identity staging
         ),
-        unpack_to_dest=True,
-        dest_acc=dest_acc,
-        disable_format_inference=True,
+        "unpack_to_dest": True,
+        "dest_acc": dest_acc,
+        "disable_format_inference": True,
+    }
+    configuration = create_test_or_perf_config(
+        is_perf=is_perf,
+        run_types=run_types,
+        test_config_kwargs=test_config_kwargs,
     )
 
     # Packer reads the SFPU result tile from Dest. For dequant the result is fp32;
@@ -934,6 +954,10 @@ def _run_quant(binary_op, tile_indices, sign_magnitude=False):
     fc.pack_dst = output_format
     fc.pack_S_src = output_format
     fc.pack_S_dst = output_format
+
+    if is_perf:
+        configuration.run(perf_report)
+        return
 
     res_from_L1 = configuration.run().result
     assert len(res_from_L1) == len(golden_tensor)
@@ -952,9 +976,26 @@ def _run_quant(binary_op, tile_indices, sign_magnitude=False):
     sign_magnitude=[False, True],
     tile_indices=runtime(_TILE_INDEX_VARIANTS),
 )
-def test_eltwise_binary_sfpu_quant_quasar(binary_op, sign_magnitude, tile_indices):
+def test_eltwise_binary_sfpu_quant_quasar(
+    binary_op,
+    sign_magnitude,
+    tile_indices,
+    *,
+    run_types=(PerfRunType.L1_TO_L1,),
+    loop_factor=1,
+    is_perf=False,
+    perf_report=None,
+):
     """Binary SFPU quant family (quant / requant / dequant), Int32-staged operands
     with a runtime fp32 zero-point; output Int32 (quant/requant) or Float32
     (dequant). Exercised on both the 2's-complement and SIGN_MAGNITUDE_FORMAT
     (SMAG32) datapaths."""
-    _run_quant(binary_op, tile_indices, sign_magnitude)
+    _run_quant(
+        binary_op,
+        tile_indices,
+        sign_magnitude,
+        run_types=run_types,
+        loop_factor=loop_factor,
+        is_perf=is_perf,
+        perf_report=perf_report,
+    )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_datacopy_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_datacopy_quasar.py
@@ -26,10 +26,9 @@ from helpers.param_config import (
     parametrize,
     runtime,
 )
-from helpers.perf.core import PerfConfig
+from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
-from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     DATA_COPY_TYPE,
     DEST_INDEX,
@@ -39,7 +38,6 @@ from helpers.test_variant_parameters import (
     NUM_FACES,
     NUM_FACES_C_DIM,
     NUM_FACES_R_DIM,
-    PERF_RUN_TYPE,
     TEST_FACE_DIMS,
     TILE_COUNT,
     UNPACKER_ENGINE_SEL,
@@ -277,18 +275,15 @@ def test_eltwise_unary_datacopy_quasar(
         ),
     }
 
+    configuration = create_test_or_perf_config(
+        is_perf=is_perf,
+        run_types=run_types,
+        test_config_kwargs=test_config_kwargs,
+    )
     if is_perf:
-        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
         configuration.run(perf_report)
         return
 
-    configuration = TestConfig(
-        **{
-            **test_config_kwargs,
-            "templates": test_config_kwargs["templates"]
-            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
-        },
-    )
     res_from_L1 = configuration.run().result
 
     assert len(res_from_L1) == len(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_datacopy_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_datacopy_quasar.py
@@ -26,6 +26,7 @@ from helpers.param_config import (
     input_output_formats,
     parametrize,
     runtime,
+    select_perf_tile_sizes,
 )
 from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
@@ -78,35 +79,11 @@ def generate_eltwise_unary_datacopy_combinations(
             (DestSync.Half,) if is_perf else (DestSync.Half, DestSync.Full)
         )
         data_copy_types = (DataCopyType.A2D, DataCopyType.B2D)
-
-        if is_perf:
-            tile_dims = (16, 16)
-            tile_shape = construct_tile_shape(tile_dims)
-            for dest_acc in dest_acc_modes:
-                if (
-                    in_fmt != DataFormat.Float32
-                    and fmt.output_format == DataFormat.Float32
-                    and dest_acc == DestAccumulation.No
-                ):
-                    continue
-                for dest_sync in dest_sync_modes:
-                    dimensions_list = generate_perf_input_dimensions(
-                        dest_acc, dest_sync, tile_shape
-                    )
-                    for data_copy_type in data_copy_types:
-                        for dimensions in dimensions_list:
-                            combinations.append(
-                                (
-                                    fmt,
-                                    dest_acc,
-                                    data_copy_type,
-                                    dimensions,
-                                    dest_sync,
-                                    runtime(0),
-                                    runtime(tile_dims),
-                                )
-                            )
-            continue
+        tile_sizes = (
+            select_perf_tile_sizes(SUPPORTED_TILE_SIZES)
+            if is_perf
+            else SUPPORTED_TILE_SIZES
+        )
 
         for dest_acc in dest_acc_modes:
             if (
@@ -118,26 +95,42 @@ def generate_eltwise_unary_datacopy_combinations(
 
             for dest_sync in dest_sync_modes:
                 for data_copy_type in data_copy_types:
-                    for tile_dims in SUPPORTED_TILE_SIZES:
+                    for tile_dims in tile_sizes:
                         if is_mx_unsupported_tile_dims(
                             in_fmt, fmt.output_format, tile_dims
                         ):
                             continue
                         tile_shape = construct_tile_shape(tile_dims)
-                        for dimensions in generate_unary_input_dimensions(
-                            dest_acc, dest_sync=dest_sync, tile_shape=tile_shape
-                        ):
-                            for (
-                                _,
-                                edgecase_dest_index,
-                            ) in calculate_edgecase_dest_indices(
-                                True if dest_acc == DestAccumulation.Yes else False,
-                                dimensions[0]
-                                // tile_dims[0]
-                                * dimensions[1]
-                                // tile_dims[1],
-                                [dest_sync],
-                            ):
+                        dimensions_list = (
+                            generate_perf_input_dimensions(
+                                dest_acc, dest_sync, tile_shape
+                            )
+                            if is_perf
+                            else generate_unary_input_dimensions(
+                                dest_acc, dest_sync=dest_sync, tile_shape=tile_shape
+                            )
+                        )
+                        for dimensions in dimensions_list:
+                            dest_indices = (
+                                [0]
+                                if is_perf
+                                else [
+                                    edgecase_dest_index
+                                    for _, edgecase_dest_index in calculate_edgecase_dest_indices(
+                                        (
+                                            True
+                                            if dest_acc == DestAccumulation.Yes
+                                            else False
+                                        ),
+                                        dimensions[0]
+                                        // tile_dims[0]
+                                        * dimensions[1]
+                                        // tile_dims[1],
+                                        [dest_sync],
+                                    )
+                                ]
+                            )
+                            for dest_index in dest_indices:
                                 combinations.append(
                                     (
                                         fmt,
@@ -145,7 +138,7 @@ def generate_eltwise_unary_datacopy_combinations(
                                         data_copy_type,
                                         dimensions,
                                         dest_sync,
-                                        runtime(edgecase_dest_index),
+                                        runtime(dest_index),
                                         runtime(tile_dims),
                                     )
                                 )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_datacopy_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_datacopy_quasar.py
@@ -21,6 +21,7 @@ from helpers.llk_params import (
 )
 from helpers.param_config import (
     calculate_edgecase_dest_indices,
+    generate_perf_input_dimensions,
     generate_unary_input_dimensions,
     input_output_formats,
     parametrize,
@@ -81,7 +82,6 @@ def generate_eltwise_unary_datacopy_combinations(
         if is_perf:
             tile_dims = (16, 16)
             tile_shape = construct_tile_shape(tile_dims)
-            dimensions = [32, 32]
             for dest_acc in dest_acc_modes:
                 if (
                     in_fmt != DataFormat.Float32
@@ -90,18 +90,22 @@ def generate_eltwise_unary_datacopy_combinations(
                 ):
                     continue
                 for dest_sync in dest_sync_modes:
+                    dimensions_list = generate_perf_input_dimensions(
+                        dest_acc, dest_sync, tile_shape
+                    )
                     for data_copy_type in data_copy_types:
-                        combinations.append(
-                            (
-                                fmt,
-                                dest_acc,
-                                data_copy_type,
-                                runtime(dimensions),
-                                dest_sync,
-                                runtime(0),
-                                runtime(tile_dims),
+                        for dimensions in dimensions_list:
+                            combinations.append(
+                                (
+                                    fmt,
+                                    dest_acc,
+                                    data_copy_type,
+                                    dimensions,
+                                    dest_sync,
+                                    runtime(0),
+                                    runtime(tile_dims),
+                                )
                             )
-                        )
             continue
 
         for dest_acc in dest_acc_modes:
@@ -139,7 +143,7 @@ def generate_eltwise_unary_datacopy_combinations(
                                         fmt,
                                         dest_acc,
                                         data_copy_type,
-                                        runtime(dimensions),
+                                        dimensions,
                                         dest_sync,
                                         runtime(edgecase_dest_index),
                                         runtime(tile_dims),

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
@@ -30,6 +30,7 @@ from helpers.param_config import (
     is_invalid_quasar_sfpu_format_combination,
     parametrize,
     runtime,
+    select_perf_input_dimensions,
 )
 from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
@@ -761,7 +762,8 @@ def generate_sfpu_unary_combinations(*, is_perf=False):
     Functional mode sweeps dest-sync, implied-math, and both [32, 32]/[64, 64]
     dimensions. Performance mode intentionally keeps the complete op, format,
     dest_acc, and approximation coverage while pinning those three axes to
-    DestSync.Half, ImpliedMathFormat.Yes, and [32, 32].
+    DestSync.Half, ImpliedMathFormat.Yes, and the largest functional matrix
+    because none of the preferred perf matrices are supported.
 
     Returns: list of (mathop, fmt, dest_acc, dest_sync, implied_math_format,
     approx_mode, input_dimensions) tuples.
@@ -810,7 +812,11 @@ def generate_sfpu_unary_combinations(*, is_perf=False):
                     if is_perf
                     else (ImpliedMathFormat.No, ImpliedMathFormat.Yes)
                 )
-                input_dims = ([32, 32],) if is_perf else cfg.input_dims
+                input_dims = (
+                    select_perf_input_dimensions(cfg.input_dims)
+                    if is_perf
+                    else cfg.input_dims
+                )
                 for dest_sync in dest_sync_modes:
                     for implied_math_format in implied_math_formats:
                         for approx_mode in approx_modes:

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
@@ -31,10 +31,9 @@ from helpers.param_config import (
     parametrize,
     runtime,
 )
-from helpers.perf.core import PerfConfig
+from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import StimuliSpec, generate_stimuli
-from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     CRK_TILE_DIMM,
     DEST_SYNC,
@@ -44,7 +43,6 @@ from helpers.test_variant_parameters import (
     LOOP_FACTOR,
     MATH_FIDELITY,
     NUM_FACES,
-    PERF_RUN_TYPE,
     TILE_COUNT,
     UNPACK_TRANS_FACES,
 )
@@ -330,20 +328,16 @@ def test_matmul(
         "disable_format_inference": disable_format_inference,
     }
 
+    configuration = create_test_or_perf_config(
+        is_perf=is_perf,
+        run_types=run_types,
+        test_config_kwargs=test_config_kwargs,
+        boot_mode=boot_mode,
+    )
     if is_perf:
-        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
         configuration.run(perf_report)
         return
 
-    # The shared source keys off PERF_RUN_TYPE. PerfConfig injects it per run type;
-    # the functional path runs the plain L1-to-L1 kernel, so supply it explicitly.
-    configuration = TestConfig(
-        boot_mode=boot_mode,
-        **{
-            **test_config_kwargs,
-            "templates": templates + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
-        },
-    )
     res_from_L1 = configuration.run().result
 
     assert len(res_from_L1) == len(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
@@ -30,7 +30,6 @@ from helpers.param_config import (
     input_output_formats,
     parametrize,
     runtime,
-    select_perf_input_dimensions,
 )
 from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
@@ -93,25 +92,6 @@ def matmul_dimensions(dest_acc, dest_sync, *, exact_dest_fill=False):
             else range(1, max_tiles // mt_dim + 1)
         )
         for kt_dim in kt_dims
-    ]
-
-
-def matmul_perf_dimensions(dest_acc, dest_sync):
-    """Select functional matmul variants by their output matrix shape."""
-    functional_dimensions = matmul_dimensions(dest_acc, dest_sync)
-    output_dimensions = [
-        [input_A_dimensions[0], input_B_dimensions[1]]
-        for input_A_dimensions, input_B_dimensions in functional_dimensions
-    ]
-    perf_output_dimensions = select_perf_input_dimensions(
-        output_dimensions, use_largest_fallback=False
-    )
-
-    return [
-        dimensions
-        for output_shape in perf_output_dimensions
-        for dimensions in functional_dimensions
-        if [dimensions[0][0], dimensions[1][1]] == output_shape
     ]
 
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
@@ -50,20 +50,22 @@ from helpers.tilize_untilize import tilize_block, untilize_block
 from helpers.utils import passed_test
 
 kt_dims = [1, 2, 4]
+PERF_KT_DIMS = [1, 4]
 
 
-def matmul_math_fidelities(format):
-    # Integer matmul is LoFi-only on Quasar.
-    return (
-        [MathFidelity.LoFi]
-        if format.input_format == DataFormat.Int8
-        else [
-            MathFidelity.LoFi,
-            MathFidelity.HiFi2,
-            MathFidelity.HiFi3,
-            MathFidelity.HiFi4,
-        ]
-    )
+def matmul_math_fidelities(format, *, is_perf=False):
+    # Integer matmul is LoFi-only on Quasar. MX is already full precision at LoFi,
+    # so perf skips the extra HiFi phases.
+    if format.input_format == DataFormat.Int8 or (
+        is_perf and format.input_format.is_mx_format()
+    ):
+        return [MathFidelity.LoFi]
+    return [
+        MathFidelity.LoFi,
+        MathFidelity.HiFi2,
+        MathFidelity.HiFi3,
+        MathFidelity.HiFi4,
+    ]
 
 
 def matmul_dest_sync_modes(*, is_perf=False):
@@ -78,20 +80,24 @@ def matmul_dest_acc_modes(format):
     )
 
 
-def matmul_dimensions(dest_acc, dest_sync, *, exact_dest_fill=False):
+def matmul_dimensions(dest_acc, dest_sync, *, exact_dest_fill=False, is_perf=False):
     max_tiles = DEST_SYNC_TILE_LIMITS[dest_sync] // (
         2 if dest_acc == DestAccumulation.Yes else 1
     )
+    # Perf keeps dest-full tall (max_tiles, 1) and wide (1, max_tiles) so both
+    # ct>=rt and ct<rt MOP addr_mod branches are covered, and kt=1 vs kt=4.
+    mt_dims = (1, max_tiles) if is_perf else range(1, max_tiles + 1)
+    selected_kt_dims = PERF_KT_DIMS if is_perf else kt_dims
     return [
         ([mt_dim * TILE_DIM, kt_dim * TILE_DIM], [kt_dim * TILE_DIM, nt_dim * TILE_DIM])
-        for mt_dim in range(1, max_tiles + 1)
+        for mt_dim in mt_dims
         if not exact_dest_fill or max_tiles % mt_dim == 0
         for nt_dim in (
             [max_tiles // mt_dim]
             if exact_dest_fill
             else range(1, max_tiles // mt_dim + 1)
         )
-        for kt_dim in kt_dims
+        for kt_dim in selected_kt_dims
     ]
 
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
@@ -30,6 +30,7 @@ from helpers.param_config import (
     input_output_formats,
     parametrize,
     runtime,
+    select_perf_input_dimensions,
 )
 from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
@@ -92,6 +93,25 @@ def matmul_dimensions(dest_acc, dest_sync, *, exact_dest_fill=False):
             else range(1, max_tiles // mt_dim + 1)
         )
         for kt_dim in kt_dims
+    ]
+
+
+def matmul_perf_dimensions(dest_acc, dest_sync):
+    """Select functional matmul variants by their output matrix shape."""
+    functional_dimensions = matmul_dimensions(dest_acc, dest_sync)
+    output_dimensions = [
+        [input_A_dimensions[0], input_B_dimensions[1]]
+        for input_A_dimensions, input_B_dimensions in functional_dimensions
+    ]
+    perf_output_dimensions = select_perf_input_dimensions(
+        output_dimensions, use_largest_fallback=False
+    )
+
+    return [
+        dimensions
+        for output_shape in perf_output_dimensions
+        for dimensions in functional_dimensions
+        if [dimensions[0][0], dimensions[1][1]] == output_shape
     ]
 
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
@@ -300,7 +300,7 @@ def test_matmul(
     ]
     runtimes = [
         CRK_TILE_DIMM(matmul_dims.ct_dim, matmul_dims.rt_dim, matmul_dims.kt_dim),
-        TILE_COUNT(matmul_dims.output_tile_cnt),
+        TILE_COUNT(matmul_dims.output_tile_cnt * matmul_dims.kt_dim),
         NUM_FACES(num_faces, num_faces, num_faces),
         LOOP_FACTOR(loop_factor),
     ]

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_quasar.py
@@ -144,7 +144,7 @@ _ARCH = get_chip_architecture()
 @pytest.mark.quasar
 @parametrize(
     format=MATMUL_FORMAT,
-    math_fidelity=matmul_math_fidelities,
+    math_fidelity=lambda format: matmul_math_fidelities(format, is_perf=False),
     dest_sync_mode=lambda: matmul_dest_sync_modes(is_perf=False),
     dest_acc=matmul_dest_acc_modes,
     dimensions=runtime(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_l1_acc_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_l1_acc_quasar.py
@@ -26,10 +26,10 @@ from helpers.param_config import (
     parametrize,
     runtime,
 )
-from helpers.perf.core import PerfConfig
+from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
-from helpers.test_config import BootMode, TestConfig
+from helpers.test_config import BootMode
 from helpers.test_variant_parameters import (
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
@@ -37,7 +37,6 @@ from helpers.test_variant_parameters import (
     NUM_BLOCKS,
     NUM_FACES,
     NUM_TILES_IN_BLOCK,
-    PERF_RUN_TYPE,
     RELU_CONFIG,
     TEST_FACE_DIMS,
     TILE_COUNT,
@@ -287,19 +286,15 @@ def test_pack_l1_acc_quasar(
         "disable_format_inference": formats.input_format.is_mx_format(),
     }
 
+    configuration = create_test_or_perf_config(
+        is_perf=is_perf,
+        run_types=run_types,
+        test_config_kwargs=test_config_kwargs,
+        boot_mode=boot_mode,
+    )
     if is_perf:
-        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
         configuration.run(perf_report)
         return
-
-    configuration = TestConfig(
-        **{
-            **test_config_kwargs,
-            "templates": test_config_kwargs["templates"]
-            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
-            "boot_mode": boot_mode,
-        },
-    )
 
     res_from_L1 = configuration.run().result
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_l1_acc_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_l1_acc_quasar.py
@@ -24,7 +24,6 @@ from helpers.param_config import (
     get_num_blocks_and_num_tiles_in_block,
     input_output_formats,
     parametrize,
-    runtime,
 )
 from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
@@ -46,9 +45,6 @@ from helpers.tile_constants import FACE_C_DIM, get_tile_params
 from helpers.utils import passed_test
 
 INPUT_DIMENSIONS = [[512, 64], [192, 512]]
-# Nested list of [H, W] pairs: a flat [H, W] is expanded by parametrize into
-# input_dimensions=H (int) and breaks generate_stimuli / rows, cols = dims.
-PERF_ONLY_INPUT_DIMENSIONS = [[512, 64]]
 TILE_DIMENSIONS = [32, 32]
 # Complete list of formats that are supported with L1 accumulation as the
 # OUTPUT format. MX formats (MxInt8) are allowed only as INPUT — accumulation
@@ -144,10 +140,6 @@ def pack_l1_acc_implied_math_formats(formats_dest_acc, *, is_perf=False):
     return [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
 
 
-def pack_l1_acc_input_dimensions(*, is_perf=False):
-    return PERF_ONLY_INPUT_DIMENSIONS if is_perf else INPUT_DIMENSIONS
-
-
 ALL_PACK_L1_ACC_COMBINATIONS = generate_qsr_pack_l1_acc_combinations(
     PACK_L1_ACC_FORMATS
 )
@@ -160,7 +152,7 @@ ALL_PACK_L1_ACC_COMBINATIONS = generate_qsr_pack_l1_acc_combinations(
         formats_dest_acc
     ),
     dest_sync_mode=lambda: pack_l1_acc_dest_sync_modes(is_perf=False),
-    input_dimensions=runtime(lambda: pack_l1_acc_input_dimensions(is_perf=False)),
+    input_dimensions=INPUT_DIMENSIONS,
     run_types=[[PerfRunType.L1_TO_L1]],
     loop_factor=[1],
 )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_quasar.py
@@ -22,6 +22,7 @@ from helpers.llk_params import (
     format_dict,
 )
 from helpers.param_config import (
+    generate_perf_input_dimensions,
     generate_unary_input_dimensions,
     input_output_formats,
     parametrize,
@@ -63,8 +64,8 @@ def generate_qsr_pack_combinations(
 
     Args:
         formats_list: List of input/output format pairs
-        is_perf: Restrict combinations to SyncHalf, NoRelu, a 16x16 tile,
-            and a 32x32 input for performance measurements.
+        is_perf: Restrict combinations to SyncHalf, a 16x16 tile, and perf
+            input dimensions for performance measurements.
 
     Returns:
         List of (format, dest_acc, dest_sync, input_dimensions, relu_type,
@@ -127,13 +128,9 @@ def generate_qsr_pack_combinations(
         # Threshold ReLU modes are not supported for integer pack_src formats
         # (mirroring the pytest.skip guard in the test body).
         relu_types = (
-            [PackerReluType.NoRelu]
-            if is_perf
-            else (
-                [PackerReluType.NoRelu, PackerReluType.ZeroRelu]
-                if in_fmt.is_integer()
-                else all_relu_types
-            )
+            [PackerReluType.NoRelu, PackerReluType.ZeroRelu]
+            if in_fmt.is_integer()
+            else all_relu_types
         )
         for dest_acc in get_dest_acc_modes(in_fmt):
             if is_supported_dest_mode_dependent_conversion(in_fmt, out_fmt, dest_acc):
@@ -141,19 +138,23 @@ def generate_qsr_pack_combinations(
                     tile_dims = MX_SUPPORTED_TILE_SIZES[0]
                     if is_mx_unsupported_tile_dims(in_fmt, out_fmt, tile_dims):
                         continue
-                    input_dimensions = [32, 32]  # [rows, columns]
+                    tile_shape = construct_tile_shape(tile_dims)
                     for dest_sync in dest_sync_modes:
+                        perf_dimensions = generate_perf_input_dimensions(
+                            dest_acc, dest_sync, tile_shape
+                        )
                         for relu_type in relu_types:
-                            combinations.append(
-                                (
-                                    fmt,
-                                    dest_acc,
-                                    dest_sync,
-                                    runtime(input_dimensions),
-                                    runtime(relu_type),
-                                    runtime(tile_dims),
+                            for input_dimensions in perf_dimensions:
+                                combinations.append(
+                                    (
+                                        fmt,
+                                        dest_acc,
+                                        dest_sync,
+                                        runtime(input_dimensions),
+                                        runtime(relu_type),
+                                        runtime(tile_dims),
+                                    )
                                 )
-                            )
                     continue
                 for dest_sync in dest_sync_modes:
                     for tile_dims in SUPPORTED_TILE_SIZES:
@@ -176,7 +177,7 @@ def generate_qsr_pack_combinations(
                                         fmt,
                                         dest_acc,
                                         dest_sync,
-                                        runtime(dimensions),
+                                        dimensions,
                                         runtime(relu_type),
                                         runtime(tile_dims),
                                     )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_quasar.py
@@ -27,12 +27,12 @@ from helpers.param_config import (
     parametrize,
     runtime,
 )
-from helpers.perf.core import PerfConfig
+from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import (  # generate_stimuli_w_tile_dimensions
     generate_stimuli,
 )
-from helpers.test_config import BootMode, TestConfig
+from helpers.test_config import BootMode
 from helpers.test_variant_parameters import (
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
@@ -40,7 +40,6 @@ from helpers.test_variant_parameters import (
     NUM_FACES,
     NUM_FACES_C_DIM,
     NUM_FACES_R_DIM,
-    PERF_RUN_TYPE,
     RELU_CONFIG,
     TEST_FACE_DIMS,
     TILE_COUNT,
@@ -341,26 +340,22 @@ def test_pack_quasar(
         "disable_format_inference": (formats.input_format.is_mx_format()),
     }
 
-    if is_perf:
-        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
-        configuration.run(perf_report)
-        return
-
     # Single output MX quantization, after relu — matches HW's pack-time
     # block-scale derivation from post-relu values.
-    if formats.output_format.is_mx_format():
+    if not is_perf and formats.output_format.is_mx_format():
         golden_tensor = quantize_mx_tensor_chunked(
             golden_tensor.to(torch.bfloat16), formats.output_format
         )
 
-    configuration = TestConfig(
+    configuration = create_test_or_perf_config(
+        is_perf=is_perf,
+        run_types=run_types,
+        test_config_kwargs=test_config_kwargs,
         boot_mode=boot_mode,
-        **{
-            **test_config_kwargs,
-            "templates": test_config_kwargs["templates"]
-            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
-        },
     )
+    if is_perf:
+        configuration.run(perf_report)
+        return
 
     res_from_L1 = configuration.run().result
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_quasar.py
@@ -27,6 +27,7 @@ from helpers.param_config import (
     input_output_formats,
     parametrize,
     runtime,
+    select_perf_tile_sizes,
 )
 from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
@@ -64,8 +65,8 @@ def generate_qsr_pack_combinations(
 
     Args:
         formats_list: List of input/output format pairs
-        is_perf: Restrict combinations to SyncHalf, a 16x16 tile, and perf
-            input dimensions for performance measurements.
+        is_perf: Restrict combinations to SyncHalf, MOP-class tile sizes, and
+            dest-full perf input dimensions for performance measurements.
 
     Returns:
         List of (format, dest_acc, dest_sync, input_dimensions, relu_type,
@@ -134,30 +135,13 @@ def generate_qsr_pack_combinations(
         )
         for dest_acc in get_dest_acc_modes(in_fmt):
             if is_supported_dest_mode_dependent_conversion(in_fmt, out_fmt, dest_acc):
-                if is_perf:
-                    tile_dims = MX_SUPPORTED_TILE_SIZES[0]
-                    if is_mx_unsupported_tile_dims(in_fmt, out_fmt, tile_dims):
-                        continue
-                    tile_shape = construct_tile_shape(tile_dims)
-                    for dest_sync in dest_sync_modes:
-                        perf_dimensions = generate_perf_input_dimensions(
-                            dest_acc, dest_sync, tile_shape
-                        )
-                        for relu_type in relu_types:
-                            for input_dimensions in perf_dimensions:
-                                combinations.append(
-                                    (
-                                        fmt,
-                                        dest_acc,
-                                        dest_sync,
-                                        runtime(input_dimensions),
-                                        runtime(relu_type),
-                                        runtime(tile_dims),
-                                    )
-                                )
-                    continue
+                tile_sizes = (
+                    select_perf_tile_sizes(SUPPORTED_TILE_SIZES)
+                    if is_perf
+                    else SUPPORTED_TILE_SIZES
+                )
                 for dest_sync in dest_sync_modes:
-                    for tile_dims in SUPPORTED_TILE_SIZES:
+                    for tile_dims in tile_sizes:
                         if is_mx_unsupported_tile_dims(in_fmt, out_fmt, tile_dims):
                             continue
                         # Unpack-to-dest (required for 32-bit formats) does not support tiny tiles.
@@ -168,16 +152,23 @@ def generate_qsr_pack_combinations(
                         ):
                             continue
                         tile_shape = construct_tile_shape(tile_dims)
-                        for dimensions in generate_unary_input_dimensions(
-                            dest_acc, dest_sync=dest_sync, tile_shape=tile_shape
-                        ):
+                        dimensions_list = (
+                            generate_perf_input_dimensions(
+                                dest_acc, dest_sync, tile_shape
+                            )
+                            if is_perf
+                            else generate_unary_input_dimensions(
+                                dest_acc, dest_sync=dest_sync, tile_shape=tile_shape
+                            )
+                        )
+                        for dimensions in dimensions_list:
                             for relu_type in relu_types:
                                 combinations.append(
                                     (
                                         fmt,
                                         dest_acc,
                                         dest_sync,
-                                        dimensions,
+                                        runtime(dimensions) if is_perf else dimensions,
                                         runtime(relu_type),
                                         runtime(tile_dims),
                                     )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_untilize_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_untilize_quasar.py
@@ -20,10 +20,9 @@ from helpers.param_config import (
     parametrize,
     runtime,
 )
-from helpers.perf.core import PerfConfig
+from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import StimuliSpec, generate_stimuli
-from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
@@ -31,7 +30,6 @@ from helpers.test_variant_parameters import (
     NUM_FACES,
     NUM_FACES_C_DIM,
     NUM_FACES_R_DIM,
-    PERF_RUN_TYPE,
     TEST_FACE_DIMS,
     TILE_COUNT,
     UNPACKER_ENGINE_SEL,
@@ -250,18 +248,14 @@ def test_pack_untilize_quasar(
         ),
     }
 
+    configuration = create_test_or_perf_config(
+        is_perf=is_perf,
+        run_types=run_types,
+        test_config_kwargs=test_config_kwargs,
+    )
     if is_perf:
-        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
         configuration.run(perf_report)
         return
-
-    configuration = TestConfig(
-        **{
-            **test_config_kwargs,
-            "templates": test_config_kwargs["templates"]
-            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
-        },
-    )
 
     res_from_L1 = configuration.run().result
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_untilize_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_untilize_quasar.py
@@ -15,6 +15,7 @@ from helpers.llk_params import (
     format_dict,
 )
 from helpers.param_config import (
+    generate_perf_input_dimensions,
     generate_unary_input_dimensions,
     input_output_formats,
     parametrize,
@@ -53,8 +54,10 @@ def pack_untilize_dest_sync_modes(*, is_perf=False):
     return [DestSync.Half] if is_perf else [DestSync.Half, DestSync.Full]
 
 
-def pack_untilize_perf_input_dimensions():
-    return [32, 32]
+def pack_untilize_perf_input_dimensions(dest_acc, dest_sync, tile_shape):
+    return generate_perf_input_dimensions(
+        dest_acc, dest_sync, tile_shape, use_largest_fallback=True
+    )
 
 
 def generate_pack_untilize_combinations(
@@ -92,7 +95,6 @@ def generate_pack_untilize_combinations(
         return (DestAccumulation.No, DestAccumulation.Yes)
 
     dest_sync_modes = pack_untilize_dest_sync_modes(is_perf=is_perf)
-    perf_dimensions = pack_untilize_perf_input_dimensions()
     combinations = []
     for fmt in formats_list:
         in_fmt, out_fmt = fmt.input_format, fmt.output_format
@@ -118,7 +120,9 @@ def generate_pack_untilize_combinations(
                         continue
                     tile_shape = construct_tile_shape(tile_dims)
                     dimensions_list = (
-                        [perf_dimensions]
+                        pack_untilize_perf_input_dimensions(
+                            dest_acc, dest_sync, tile_shape
+                        )
                         if is_perf
                         else generate_unary_input_dimensions(
                             dest_acc, dest_sync=dest_sync, tile_shape=tile_shape
@@ -130,7 +134,7 @@ def generate_pack_untilize_combinations(
                                 fmt,
                                 dest_acc,
                                 dest_sync,
-                                runtime(dimensions),
+                                dimensions,
                                 runtime(tile_dims),
                             )
                         )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_untilize_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_untilize_quasar.py
@@ -20,6 +20,7 @@ from helpers.param_config import (
     input_output_formats,
     parametrize,
     runtime,
+    select_perf_tile_sizes,
 )
 from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
@@ -108,7 +109,11 @@ def generate_pack_untilize_combinations(
 
         for dest_acc in get_dest_acc_modes(in_fmt):
             for dest_sync in dest_sync_modes:
-                tile_sizes = [(32, 32)] if is_perf else PACK_UNTILIZE_TILE_SIZES
+                tile_sizes = (
+                    select_perf_tile_sizes(PACK_UNTILIZE_TILE_SIZES)
+                    if is_perf
+                    else PACK_UNTILIZE_TILE_SIZES
+                )
                 for tile_dims in tile_sizes:
                     if is_mx_unsupported_tile_dims(in_fmt, out_fmt, tile_dims):
                         continue

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_reduce_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_reduce_quasar.py
@@ -25,10 +25,9 @@ from helpers.llk_params import (
     format_dict,
 )
 from helpers.param_config import input_output_formats, parametrize
-from helpers.perf.core import PerfConfig
+from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
-from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
@@ -38,10 +37,10 @@ from helpers.test_variant_parameters import (
     NUM_FACES,
     NUM_FACES_C_DIM,
     NUM_FACES_R_DIM,
-    PERF_RUN_TYPE,
     TEST_FACE_DIMS,
     TILE_COUNT,
     UNPACKER_ENGINE_SEL,
+    generate_input_dim,
 )
 from helpers.tile_constants import SUPPORTED_TILE_SIZES, is_mx_unsupported_tile_dims
 from helpers.tile_shape import construct_tile_shape
@@ -257,6 +256,11 @@ def test_reduce_quasar(
             DEST_SYNC(dest_sync_mode),
         ],
         "runtimes": [
+            generate_input_dim(
+                input_dimensions,
+                input_dimensions,
+                tile_dimensions=tile_dimensions,
+            ),
             TILE_COUNT(tile_cnt),
             TEST_FACE_DIMS(tile_shape.face_r_dim, tile_shape.face_c_dim),
             NUM_FACES_R_DIM(tile_shape.num_faces_r_dim),
@@ -288,18 +292,15 @@ def test_reduce_quasar(
         ),
     }
 
+    configuration = create_test_or_perf_config(
+        is_perf=is_perf,
+        run_types=run_types,
+        test_config_kwargs=test_config_kwargs,
+    )
     if is_perf:
-        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
         configuration.run(perf_report)
         return
 
-    configuration = TestConfig(
-        **{
-            **test_config_kwargs,
-            "templates": test_config_kwargs["templates"]
-            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
-        },
-    )
     res_from_L1 = configuration.run().result
 
     assert len(res_from_L1) == len(
@@ -419,6 +420,7 @@ def test_reduce_quasar_mxfp4_2x_gapool(
             DEST_SYNC(dest_sync_mode),
         ],
         "runtimes": [
+            generate_input_dim(input_dimensions, input_dimensions),
             TILE_COUNT(tile_cnt),
             TEST_FACE_DIMS(tile_shape.face_r_dim, tile_shape.face_c_dim),
             NUM_FACES_R_DIM(tile_shape.num_faces_r_dim),
@@ -445,18 +447,15 @@ def test_reduce_quasar_mxfp4_2x_gapool(
         "disable_format_inference": False,
     }
 
+    configuration = create_test_or_perf_config(
+        is_perf=is_perf,
+        run_types=run_types,
+        test_config_kwargs=test_config_kwargs,
+    )
     if is_perf:
-        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
         configuration.run(perf_report)
         return
 
-    configuration = TestConfig(
-        **{
-            **test_config_kwargs,
-            "templates": test_config_kwargs["templates"]
-            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
-        },
-    )
     res_from_L1 = configuration.run().result
 
     assert len(res_from_L1) == len(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_reduce_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_reduce_quasar.py
@@ -24,7 +24,11 @@ from helpers.llk_params import (
     ReducePool,
     format_dict,
 )
-from helpers.param_config import input_output_formats, parametrize
+from helpers.param_config import (
+    input_output_formats,
+    parametrize,
+    select_perf_tile_sizes,
+)
 from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
@@ -86,6 +90,21 @@ def reduce_dest_acc_modes(*, is_perf=False):
     )
 
 
+def reduce_tile_dimensions(formats, *, is_perf=False):
+    functional_tile_sizes = [
+        td
+        for td in SUPPORTED_TILE_SIZES
+        if not is_mx_unsupported_tile_dims(
+            formats.input_format, formats.output_format, td
+        )
+    ]
+    return (
+        select_perf_tile_sizes(functional_tile_sizes)
+        if is_perf
+        else functional_tile_sizes
+    )
+
+
 def reduce_implied_math_formats(formats, *, is_perf=False):
     if is_perf:
         return [ImpliedMathFormat.Yes]
@@ -127,13 +146,7 @@ def reduce_pool_type_and_math_fidelity_combinations(*, is_perf=False):
 @pytest.mark.quasar
 @parametrize(
     formats=REDUCE_FORMATS,
-    tile_dimensions=lambda formats: [
-        td
-        for td in SUPPORTED_TILE_SIZES
-        if not is_mx_unsupported_tile_dims(
-            formats.input_format, formats.output_format, td
-        )
-    ],
+    tile_dimensions=lambda formats: reduce_tile_dimensions(formats, is_perf=False),
     dest_acc=lambda: reduce_dest_acc_modes(is_perf=False),
     reduce_dim=[ReduceDimension.Row, ReduceDimension.Column, ReduceDimension.Scalar],
     pool_type_and_math_fidelity=lambda: reduce_pool_type_and_math_fidelity_combinations(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_reduce_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_reduce_quasar.py
@@ -113,7 +113,7 @@ def reduce_implied_math_formats(formats, *, is_perf=False):
     return [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
 
 
-def reduce_input_dimensions(*, is_perf=False):
+def reduce_input_dimensions():
     return [64, 64]
 
 
@@ -197,7 +197,7 @@ def test_reduce_quasar(
         )
 
     input_dimensions = (
-        reduce_input_dimensions(is_perf=True)
+        reduce_input_dimensions()
         if is_perf
         else [tile_dimensions[0] * 2, tile_dimensions[1] * 2]
     )
@@ -388,7 +388,7 @@ def test_reduce_quasar_mxfp4_2x_gapool(
     is_perf=False,
     perf_report=None,
 ):
-    input_dimensions = reduce_input_dimensions(is_perf=is_perf)
+    input_dimensions = reduce_input_dimensions()
     tile_shape = construct_tile_shape((32, 32))
 
     src_A, tile_cnt, _, _ = generate_stimuli(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_transpose_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_transpose_dest_quasar.py
@@ -44,7 +44,6 @@ from helpers.test_variant_parameters import (
     NUM_FACES_C_DIM,
     NUM_FACES_R_DIM,
     NUM_TILES_IN_BLOCK,
-    PERF_RUN_TYPE,
     TEST_FACE_DIMS,
     TILE_COUNT,
     UNPACKER_ENGINE_SEL,

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_transpose_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_transpose_dest_quasar.py
@@ -149,10 +149,19 @@ def generate_qsr_transpose_dest_combinations(
                 for dest_sync in dest_sync_modes:
                     for math_transpose_faces in transpose_faces_modes:
                         if is_perf:
+                            mode_dimensions = dimensions_by_mode[(dest_acc, dest_sync)]
                             perf_dimensions = select_perf_input_dimensions(
-                                dimensions_by_mode[(dest_acc, dest_sync)],
+                                mode_dimensions,
                                 use_largest_fallback=False,
                             )
+                            # Dest-full vs 2-block is selected via PERF_INPUT_DIMENSIONS.
+                            # Keep the 3-block / 2-switch case when the mode defines it.
+                            three_block = [64, 384]
+                            if (
+                                three_block in mode_dimensions
+                                and three_block not in perf_dimensions
+                            ):
+                                perf_dimensions.append(three_block)
                             for dimensions in perf_dimensions:
                                 combinations.append(
                                     (

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_transpose_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_transpose_dest_quasar.py
@@ -27,7 +27,7 @@ from helpers.param_config import (
     get_num_blocks_and_num_tiles_in_block,
     input_output_formats,
     parametrize,
-    runtime,
+    select_perf_input_dimensions,
 )
 from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
@@ -136,11 +136,7 @@ def generate_qsr_transpose_dest_combinations(
     }
 
     dest_sync_modes = (DestSync.Half,) if is_perf else (DestSync.Half, DestSync.Full)
-    transpose_faces_modes = (
-        (Transpose.No,) if is_perf else (Transpose.No, Transpose.Yes)
-    )
-    perf_dimensions = [32, 32]
-
+    transpose_faces_modes = (Transpose.No, Transpose.Yes)
     combinations = []
     for fmt in formats_list:
         in_fmt, out_fmt = fmt.input_format, fmt.output_format
@@ -153,15 +149,20 @@ def generate_qsr_transpose_dest_combinations(
                 for dest_sync in dest_sync_modes:
                     for math_transpose_faces in transpose_faces_modes:
                         if is_perf:
-                            combinations.append(
-                                (
-                                    fmt,
-                                    dest_acc,
-                                    dest_sync,
-                                    math_transpose_faces,
-                                    runtime(perf_dimensions),
-                                )
+                            perf_dimensions = select_perf_input_dimensions(
+                                dimensions_by_mode[(dest_acc, dest_sync)],
+                                use_largest_fallback=False,
                             )
+                            for dimensions in perf_dimensions:
+                                combinations.append(
+                                    (
+                                        fmt,
+                                        dest_acc,
+                                        dest_sync,
+                                        math_transpose_faces,
+                                        dimensions,
+                                    )
+                                )
                             continue
                         for dimensions in dimensions_by_mode[(dest_acc, dest_sync)]:
                             combinations.append(
@@ -170,7 +171,7 @@ def generate_qsr_transpose_dest_combinations(
                                     dest_acc,
                                     dest_sync,
                                     math_transpose_faces,
-                                    runtime(dimensions),
+                                    dimensions,
                                 )
                             )
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_transpose_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_transpose_dest_quasar.py
@@ -29,10 +29,9 @@ from helpers.param_config import (
     parametrize,
     runtime,
 )
-from helpers.perf.core import PerfConfig
+from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
-from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     DATA_COPY_TYPE,
     DEST_INDEX,
@@ -49,6 +48,7 @@ from helpers.test_variant_parameters import (
     TEST_FACE_DIMS,
     TILE_COUNT,
     UNPACKER_ENGINE_SEL,
+    generate_input_dim,
 )
 from helpers.tile_constants import FACE_C_DIM, get_tile_params
 from helpers.utils import passed_test
@@ -334,6 +334,7 @@ def test_transpose_dest_quasar(
             MATH_TRANSPOSE_FACES(math_transpose_faces),
         ],
         "runtimes": [
+            generate_input_dim(input_dimensions, input_dimensions),
             TILE_COUNT(tile_cnt_A),
             NUM_FACES(num_faces),
             NUM_TILES_IN_BLOCK(
@@ -370,18 +371,15 @@ def test_transpose_dest_quasar(
         "dest_acc": dest_acc,
     }
 
+    configuration = create_test_or_perf_config(
+        is_perf=is_perf,
+        run_types=run_types,
+        test_config_kwargs=test_config_kwargs,
+    )
     if is_perf:
-        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
         configuration.run(perf_report)
         return
 
-    configuration = TestConfig(
-        **{
-            **test_config_kwargs,
-            "templates": test_config_kwargs["templates"]
-            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
-        },
-    )
     res_from_L1 = configuration.run().result
 
     assert len(res_from_L1) == len(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unary_broadcast_quasar.py
@@ -24,10 +24,10 @@ from helpers.param_config import (
     parametrize,
     runtime,
 )
-from helpers.perf.core import PerfConfig
+from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import StimuliSpec, generate_stimuli
-from helpers.test_config import BootMode, TestConfig
+from helpers.test_config import BootMode
 from helpers.test_variant_parameters import (
     BROADCAST_TYPE,
     DEST_SYNC,
@@ -38,7 +38,6 @@ from helpers.test_variant_parameters import (
     NUM_FACES_C_DIM,
     NUM_FACES_R_DIM,
     NUM_TILES_IN_BLOCK,
-    PERF_RUN_TYPE,
     TEST_FACE_DIMS,
     TILE_COUNT,
     UNPACKER_ENGINE_SEL,
@@ -233,19 +232,15 @@ def test_unary_broadcast_quasar(
         "dest_acc": dest_acc,
     }
 
+    configuration = create_test_or_perf_config(
+        is_perf=is_perf,
+        run_types=run_types,
+        test_config_kwargs=test_config_kwargs,
+        boot_mode=boot_mode,
+    )
     if is_perf:
-        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
         configuration.run(perf_report)
         return
-
-    configuration = TestConfig(
-        boot_mode=boot_mode,
-        **{
-            **test_config_kwargs,
-            "templates": test_config_kwargs["templates"]
-            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
-        },
-    )
 
     res_from_L1 = configuration.run().result
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unary_broadcast_quasar.py
@@ -95,6 +95,12 @@ UNARY_BROADCAST_FORMATS = input_output_formats(
     same=True,  # input_fmt != output_fmt not tested, ISSUE: #47560
 )
 
+BROADCAST_TYPES = [
+    BroadcastType.Scalar,
+    BroadcastType.Column,
+    BroadcastType.Row,
+]
+
 
 def get_valid_dest_acc_unary_broadcast(formats):
     """Valid dest accumulation modes for unary broadcast."""
@@ -109,11 +115,7 @@ def get_valid_dest_acc_unary_broadcast(formats):
 @parametrize(
     formats=UNARY_BROADCAST_FORMATS,
     dest_acc=lambda formats: get_valid_dest_acc_unary_broadcast(formats),
-    broadcast_type=[
-        BroadcastType.Scalar,
-        BroadcastType.Column,
-        BroadcastType.Row,
-    ],
+    broadcast_type=BROADCAST_TYPES,
     implied_math_format=lambda formats: unary_broadcast_implied_math_formats(formats),
     dest_sync_mode=lambda: unary_broadcast_dest_sync_modes(is_perf=False),
     input_dimensions=runtime(INPUT_DIMENSIONS),

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_reduce_col_tilizeA_strided_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_reduce_col_tilizeA_strided_quasar.py
@@ -33,6 +33,7 @@ from helpers.param_config import (
     input_output_formats,
     parametrize,
     runtime,
+    select_perf_input_dimensions,
 )
 from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
@@ -140,13 +141,15 @@ def generate_unpack_reduce_col_tilizeA_strided_combinations(
                     if is_mx_unsupported_tile_dims(in_fmt, out_fmt, tile_dimensions):
                         continue
                     tile_shape = construct_tile_shape(tile_dimensions)
+                    functional_dimensions = generate_corner_case_input_dimensions(
+                        dest_sync, acc, tile_shape
+                    )
                     dimensions_list = (
-                        # Perf only measures the single tile case.
-                        [[tile_shape.total_row_dim(), tile_shape.total_col_dim()]]
-                        if is_perf
-                        else generate_corner_case_input_dimensions(
-                            dest_sync, acc, tile_shape
+                        select_perf_input_dimensions(
+                            functional_dimensions, use_largest_fallback=True
                         )
+                        if is_perf
+                        else functional_dimensions
                     )
                     for dimensions in dimensions_list:
                         for pool_type in (
@@ -161,7 +164,7 @@ def generate_unpack_reduce_col_tilizeA_strided_combinations(
                                     fmt,
                                     acc,
                                     dest_sync,
-                                    runtime(dimensions),
+                                    dimensions,
                                     pool_type,
                                     runtime(tile_dimensions),
                                 )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_reduce_col_tilizeA_strided_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_reduce_col_tilizeA_strided_quasar.py
@@ -34,10 +34,10 @@ from helpers.param_config import (
     parametrize,
     runtime,
 )
-from helpers.perf.core import PerfConfig
+from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import generate_stimuli
-from helpers.test_config import BootMode, TestConfig
+from helpers.test_config import BootMode
 from helpers.test_variant_parameters import (
     DEST_SYNC,
     IMPLIED_MATH_FORMAT,
@@ -322,19 +322,16 @@ def test_unpack_reduce_col_tilizeA_strided_quasar(
         "dest_acc": dest_acc,
     }
 
+    configuration = create_test_or_perf_config(
+        is_perf=is_perf,
+        run_types=run_types,
+        test_config_kwargs=test_config_kwargs,
+        boot_mode=boot_mode,
+    )
     if is_perf:
-        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
         configuration.run(perf_report)
         return
 
-    configuration = TestConfig(
-        **{
-            **test_config_kwargs,
-            "templates": test_config_kwargs["templates"]
-            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
-            "boot_mode": boot_mode,
-        },
-    )
     res_from_L1 = configuration.run().result
 
     assert len(res_from_L1) == len(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_reduce_col_tilizeA_strided_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_reduce_col_tilizeA_strided_quasar.py
@@ -30,10 +30,11 @@ from helpers.llk_params import (
 )
 from helpers.param_config import (
     DEST_SYNC_TILE_LIMITS,
+    generate_perf_input_dimensions,
     input_output_formats,
     parametrize,
     runtime,
-    select_perf_input_dimensions,
+    select_perf_tile_sizes,
 )
 from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
@@ -118,7 +119,11 @@ def generate_unpack_reduce_col_tilizeA_strided_combinations(
         """
         return in_fmt in (DataFormat.Int8, DataFormat.UInt8) and in_fmt == out_fmt
 
-    tile_sizes = [(32, 32)] if is_perf else UNPACK_REDUCE_COL_TILIZEA_STRIDED_TILE_SIZES
+    tile_sizes = (
+        select_perf_tile_sizes(UNPACK_REDUCE_COL_TILIZEA_STRIDED_TILE_SIZES)
+        if is_perf
+        else UNPACK_REDUCE_COL_TILIZEA_STRIDED_TILE_SIZES
+    )
 
     combinations = []
 
@@ -141,15 +146,12 @@ def generate_unpack_reduce_col_tilizeA_strided_combinations(
                     if is_mx_unsupported_tile_dims(in_fmt, out_fmt, tile_dimensions):
                         continue
                     tile_shape = construct_tile_shape(tile_dimensions)
-                    functional_dimensions = generate_corner_case_input_dimensions(
-                        dest_sync, acc, tile_shape
-                    )
                     dimensions_list = (
-                        select_perf_input_dimensions(
-                            functional_dimensions, use_largest_fallback=True
-                        )
+                        generate_perf_input_dimensions(acc, dest_sync, tile_shape)
                         if is_perf
-                        else functional_dimensions
+                        else generate_corner_case_input_dimensions(
+                            dest_sync, acc, tile_shape
+                        )
                     )
                     for dimensions in dimensions_list:
                         for pool_type in (

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_reduce_col_tilizeA_strided_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_reduce_col_tilizeA_strided_quasar.py
@@ -49,7 +49,6 @@ from helpers.test_variant_parameters import (
     NUM_FACES,
     NUM_FACES_C_DIM,
     NUM_FACES_R_DIM,
-    PERF_RUN_TYPE,
     TEST_FACE_DIMS,
     TILE_COUNT,
     generate_input_dim,

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_tilize_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_tilize_quasar.py
@@ -26,6 +26,7 @@ from helpers.param_config import (
     input_output_formats,
     parametrize,
     runtime,
+    select_perf_tile_sizes,
 )
 from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
@@ -97,31 +98,11 @@ def generate_unpack_tilize_combinations(
             if in_fmt.is_32_bit()
             else (UnpackerEngine.UnpA, UnpackerEngine.UnpB)
         )
-
-        if is_perf:
-            for dest_acc in dest_acc_modes:
-                for dest_sync in dest_sync_modes:
-                    perf_dimensions = generate_perf_input_dimensions(
-                        dest_acc, dest_sync, use_largest_fallback=True
-                    )
-                    for unpacker_sel in unpacker_engines:
-                        if (
-                            dest_acc == DestAccumulation.Yes
-                            and unpacker_sel == UnpackerEngine.UnpB
-                        ):
-                            continue
-                        for dimensions in perf_dimensions:
-                            combinations.append(
-                                (
-                                    fmt,
-                                    dest_acc,
-                                    dest_sync,
-                                    unpacker_sel,
-                                    dimensions,
-                                    runtime((32, 32)),
-                                )
-                            )
-            continue
+        tile_sizes = (
+            select_perf_tile_sizes(UNPACK_TILIZE_TILE_SIZES)
+            if is_perf
+            else UNPACK_TILIZE_TILE_SIZES
+        )
 
         for dest_acc in dest_acc_modes:
             for dest_sync in dest_sync_modes:
@@ -134,7 +115,7 @@ def generate_unpack_tilize_combinations(
                         and unpacker_sel == UnpackerEngine.UnpB
                     ):
                         continue
-                    for tile_dims in UNPACK_TILIZE_TILE_SIZES:
+                    for tile_dims in tile_sizes:
                         if is_mx_unsupported_tile_dims(in_fmt, out_fmt, tile_dims):
                             continue
                         if (
@@ -144,9 +125,16 @@ def generate_unpack_tilize_combinations(
                         ):
                             continue
                         tile_shape = construct_tile_shape(tile_dims)
-                        for dimensions in generate_unary_input_dimensions(
-                            dest_acc, dest_sync=dest_sync, tile_shape=tile_shape
-                        ):
+                        dimensions_list = (
+                            generate_perf_input_dimensions(
+                                dest_acc, dest_sync, tile_shape
+                            )
+                            if is_perf
+                            else generate_unary_input_dimensions(
+                                dest_acc, dest_sync=dest_sync, tile_shape=tile_shape
+                            )
+                        )
+                        for dimensions in dimensions_list:
                             combinations.append(
                                 (
                                     fmt,

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_tilize_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_tilize_quasar.py
@@ -26,10 +26,10 @@ from helpers.param_config import (
     parametrize,
     runtime,
 )
-from helpers.perf.core import PerfConfig
+from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import StimuliSpec, generate_stimuli
-from helpers.test_config import BootMode, TestConfig
+from helpers.test_config import BootMode
 from helpers.test_variant_parameters import (
     DATA_COPY_TYPE,
     DEST_SYNC,
@@ -38,7 +38,6 @@ from helpers.test_variant_parameters import (
     NUM_FACES,
     NUM_FACES_C_DIM,
     NUM_FACES_R_DIM,
-    PERF_RUN_TYPE,
     TEST_FACE_DIMS,
     TILE_COUNT,
     UNPACKER_ENGINE_SEL,
@@ -279,19 +278,16 @@ def test_unpack_tilize_quasar(
         "disable_format_inference": formats.input_format.is_mx_format(),
     }
 
+    configuration = create_test_or_perf_config(
+        is_perf=is_perf,
+        run_types=run_types,
+        test_config_kwargs=test_config_kwargs,
+        boot_mode=boot_mode,
+    )
     if is_perf:
-        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
         configuration.run(perf_report)
         return
 
-    configuration = TestConfig(
-        boot_mode=boot_mode,
-        **{
-            **test_config_kwargs,
-            "templates": test_config_kwargs["templates"]
-            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
-        },
-    )
     res_from_L1 = configuration.run().result
 
     assert len(res_from_L1) == len(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_tilize_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_tilize_quasar.py
@@ -21,6 +21,7 @@ from helpers.llk_params import (
     format_dict,
 )
 from helpers.param_config import (
+    generate_perf_input_dimensions,
     generate_unary_input_dimensions,
     input_output_formats,
     parametrize,
@@ -75,7 +76,6 @@ def generate_unpack_tilize_combinations(
     """
     combinations = []
 
-    perf_dimensions = [32, 32]
     dest_sync_modes = (DestSync.Half,) if is_perf else (DestSync.Half, DestSync.Full)
 
     for fmt in formats_list:
@@ -99,21 +99,28 @@ def generate_unpack_tilize_combinations(
         )
 
         if is_perf:
-            if in_fmt.is_32_bit():
-                continue
             for dest_acc in dest_acc_modes:
                 for dest_sync in dest_sync_modes:
-                    for unpacker_sel in (UnpackerEngine.UnpA,):
-                        combinations.append(
-                            (
-                                fmt,
-                                dest_acc,
-                                dest_sync,
-                                unpacker_sel,
-                                runtime(perf_dimensions),
-                                runtime((32, 32)),
+                    perf_dimensions = generate_perf_input_dimensions(
+                        dest_acc, dest_sync, use_largest_fallback=True
+                    )
+                    for unpacker_sel in unpacker_engines:
+                        if (
+                            dest_acc == DestAccumulation.Yes
+                            and unpacker_sel == UnpackerEngine.UnpB
+                        ):
+                            continue
+                        for dimensions in perf_dimensions:
+                            combinations.append(
+                                (
+                                    fmt,
+                                    dest_acc,
+                                    dest_sync,
+                                    unpacker_sel,
+                                    dimensions,
+                                    runtime((32, 32)),
+                                )
                             )
-                        )
             continue
 
         for dest_acc in dest_acc_modes:
@@ -146,7 +153,7 @@ def generate_unpack_tilize_combinations(
                                     dest_acc,
                                     dest_sync,
                                     unpacker_sel,
-                                    runtime(dimensions),
+                                    dimensions,
                                     runtime(tile_dims),
                                 )
                             )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_unary_operand_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_unary_operand_quasar.py
@@ -28,6 +28,7 @@ from helpers.param_config import (
     input_output_formats,
     parametrize,
     runtime,
+    select_perf_tile_sizes,
 )
 from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
@@ -75,7 +76,6 @@ def generate_unpack_unary_operand_combinations(
     Returns: List of (format, dest_acc, transpose_en, unpacker_sel, input_dimensions) tuples
     """
     combinations = []
-    perf_tile_dims = (32, 32)
     dest_sync_modes = (DestSync.Half,) if is_perf else (DestSync.Half, DestSync.Full)
 
     for fmt in formats_list:
@@ -100,29 +100,9 @@ def generate_unpack_unary_operand_combinations(
             # pack to Fp32 when dest is in 16-bit mode.
             if in_fmt != DataFormat.Float32 and fmt.output_format == DataFormat.Float32:
                 continue
-            perf_dest_acc_modes = (
+            dest_acc_modes = (
                 dest_acc_modes if in_fmt.is_32_bit() else (DestAccumulation.No,)
             )
-            for dest_acc in perf_dest_acc_modes:
-                for dest_sync in dest_sync_modes:
-                    perf_dimensions = generate_perf_input_dimensions(
-                        dest_acc, dest_sync, use_largest_fallback=True
-                    )
-                    for transpose_en in transpose_modes:
-                        for unpacker_sel in unpacker_engines:
-                            for dimensions in perf_dimensions:
-                                combinations.append(
-                                    (
-                                        fmt,
-                                        dest_acc,
-                                        dest_sync,
-                                        transpose_en,
-                                        unpacker_sel,
-                                        dimensions,
-                                        runtime(perf_tile_dims),
-                                    )
-                                )
-            continue
 
         for dest_acc in dest_acc_modes:
             if (
@@ -135,13 +115,18 @@ def generate_unpack_unary_operand_combinations(
                 continue
             for dest_sync in dest_sync_modes:
                 for transpose_en in transpose_modes:
+                    # transpose is not supported for tiny-tiles
+                    functional_tile_sizes = (
+                        ((32, 32),)
+                        if transpose_en == Transpose.Yes
+                        else SUPPORTED_TILE_SIZES
+                    )
+                    tile_sizes = (
+                        select_perf_tile_sizes(functional_tile_sizes)
+                        if is_perf
+                        else functional_tile_sizes
+                    )
                     for unpacker_sel in unpacker_engines:
-                        # transpose is not supported for tiny-tiles
-                        tile_sizes = (
-                            ((32, 32),)
-                            if transpose_en == Transpose.Yes
-                            else SUPPORTED_TILE_SIZES
-                        )
                         for tile_dims in tile_sizes:
                             if is_mx_unsupported_tile_dims(
                                 in_fmt, fmt.output_format, tile_dims
@@ -153,9 +138,16 @@ def generate_unpack_unary_operand_combinations(
                             ):
                                 continue
                             tile_shape = construct_tile_shape(tile_dims)
-                            for dimensions in generate_unary_input_dimensions(
-                                dest_acc, dest_sync=dest_sync, tile_shape=tile_shape
-                            ):
+                            dimensions_list = (
+                                generate_perf_input_dimensions(
+                                    dest_acc, dest_sync, tile_shape
+                                )
+                                if is_perf
+                                else generate_unary_input_dimensions(
+                                    dest_acc, dest_sync=dest_sync, tile_shape=tile_shape
+                                )
+                            )
+                            for dimensions in dimensions_list:
                                 combinations.append(
                                     (
                                         fmt,

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_unary_operand_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_unary_operand_quasar.py
@@ -23,6 +23,7 @@ from helpers.llk_params import (
     format_dict,
 )
 from helpers.param_config import (
+    generate_perf_input_dimensions,
     generate_unary_input_dimensions,
     input_output_formats,
     parametrize,
@@ -74,7 +75,6 @@ def generate_unpack_unary_operand_combinations(
     Returns: List of (format, dest_acc, transpose_en, unpacker_sel, input_dimensions) tuples
     """
     combinations = []
-    perf_dimensions = [32, 32]
     perf_tile_dims = (32, 32)
     dest_sync_modes = (DestSync.Half,) if is_perf else (DestSync.Half, DestSync.Full)
 
@@ -96,26 +96,32 @@ def generate_unpack_unary_operand_combinations(
         )
 
         if is_perf:
-            if in_fmt.is_32_bit():
-                continue
             # Same packer constraint as the correctness path: non-Fp32 input cannot
             # pack to Fp32 when dest is in 16-bit mode.
             if in_fmt != DataFormat.Float32 and fmt.output_format == DataFormat.Float32:
                 continue
-            for dest_acc in (DestAccumulation.No,):
+            perf_dest_acc_modes = (
+                dest_acc_modes if in_fmt.is_32_bit() else (DestAccumulation.No,)
+            )
+            for dest_acc in perf_dest_acc_modes:
                 for dest_sync in dest_sync_modes:
-                    for unpacker_sel in (UnpackerEngine.UnpA,):
-                        combinations.append(
-                            (
-                                fmt,
-                                dest_acc,
-                                dest_sync,
-                                Transpose.No,
-                                unpacker_sel,
-                                runtime(perf_dimensions),
-                                runtime(perf_tile_dims),
-                            )
-                        )
+                    perf_dimensions = generate_perf_input_dimensions(
+                        dest_acc, dest_sync, use_largest_fallback=True
+                    )
+                    for transpose_en in transpose_modes:
+                        for unpacker_sel in unpacker_engines:
+                            for dimensions in perf_dimensions:
+                                combinations.append(
+                                    (
+                                        fmt,
+                                        dest_acc,
+                                        dest_sync,
+                                        transpose_en,
+                                        unpacker_sel,
+                                        dimensions,
+                                        runtime(perf_tile_dims),
+                                    )
+                                )
             continue
 
         for dest_acc in dest_acc_modes:
@@ -157,7 +163,7 @@ def generate_unpack_unary_operand_combinations(
                                         dest_sync,
                                         transpose_en,
                                         unpacker_sel,
-                                        runtime(dimensions),
+                                        dimensions,
                                         runtime(tile_dims),
                                     )
                                 )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_unary_operand_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_unpack_unary_operand_quasar.py
@@ -28,12 +28,12 @@ from helpers.param_config import (
     parametrize,
     runtime,
 )
-from helpers.perf.core import PerfConfig
+from helpers.perf.core import create_test_or_perf_config
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import (  # generate_stimuli_w_tile_dimensions
     generate_stimuli,
 )
-from helpers.test_config import BootMode, TestConfig
+from helpers.test_config import BootMode
 from helpers.test_variant_parameters import (
     DATA_COPY_TYPE,
     DEST_SYNC,
@@ -42,12 +42,12 @@ from helpers.test_variant_parameters import (
     NUM_FACES,
     NUM_FACES_C_DIM,
     NUM_FACES_R_DIM,
-    PERF_RUN_TYPE,
     TEST_FACE_DIMS,
     TILE_COUNT,
     UNPACK_TRANS_FACES,
     UNPACK_TRANS_WITHIN_FACE,
     UNPACKER_ENGINE_SEL,
+    generate_input_dim,
 )
 from helpers.tile_constants import (
     MX_SUPPORTED_TILE_SIZES,
@@ -284,6 +284,11 @@ def test_unpack_unary_operand_quasar(
             UNPACK_TRANS_WITHIN_FACE(transpose_en),
         ],
         "runtimes": [
+            generate_input_dim(
+                input_dimensions,
+                input_dimensions,
+                tile_dimensions=tile_dimensions,
+            ),
             TEST_FACE_DIMS(tile_shape.face_r_dim),
             NUM_FACES(num_faces),
             TILE_COUNT(tile_cnt_A),
@@ -312,19 +317,16 @@ def test_unpack_unary_operand_quasar(
         "disable_format_inference": formats.input_format.is_mx_format(),
     }
 
+    configuration = create_test_or_perf_config(
+        is_perf=is_perf,
+        run_types=run_types,
+        test_config_kwargs=test_config_kwargs,
+        boot_mode=boot_mode,
+    )
     if is_perf:
-        configuration = PerfConfig(run_types=run_types, **test_config_kwargs)
         configuration.run(perf_report)
         return
 
-    configuration = TestConfig(
-        **{
-            **test_config_kwargs,
-            "templates": test_config_kwargs["templates"]
-            + [PERF_RUN_TYPE(PerfRunType.L1_TO_L1)],
-            "boot_mode": boot_mode,
-        },
-    )
     res_from_L1 = configuration.run().result
 
     assert len(res_from_L1) == len(

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_parquet.py
@@ -23,7 +23,8 @@ from helpers.perf.parquet import (
     write_parquet,
     write_run_batch,
 )
-from helpers.perf.wide_schema import DB_SCHEMA
+from helpers.perf.test_schemas import PERF_TEST_SCHEMAS
+from helpers.perf.wide_schema import DB_SCHEMA, DROPPED_COLUMNS
 
 _RUN_PROV = dict(
     commit_sha="abc123",
@@ -292,6 +293,24 @@ def test_convert_keeps_num_blocks_columns(tmp_path):
     names = pq.read_table(tmp_path / "out.parquet").schema.names
     assert "input_num_blocks" in names
     assert "output_num_blocks" in names
+
+
+def test_catalog_columns_are_in_db_schema():
+    # Every WH/BH per-test CSV column must be in the published WH/BH table (or
+    # intentionally dropped). Quasar has its own table — see
+    # test_perf_parquet_quasar.py.
+    schema_names = {c.name for c in DB_SCHEMA} | DROPPED_COLUMNS
+    missing = {}
+    for test, entry in PERF_TEST_SCHEMAS.items():
+        unknown = sorted(set(entry["columns"]) - schema_names)
+        if unknown:
+            missing[test] = unknown
+    assert not missing, (
+        "WH/BH perf-test catalog column(s) are not in "
+        "helpers.perf.wide_schema.DB_SCHEMA and would be dropped from Parquet: "
+        f"{missing}. Add them as nullable columns (or to DROPPED_COLUMNS if they "
+        "must not be published)."
+    )
 
 
 # ── Parquet -> CSV (reverse conversion) ───────────────────────────────────────

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_parquet_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_parquet_quasar.py
@@ -10,6 +10,8 @@ no chip.
 
 import pandas as pd
 import pyarrow.parquet as pq
+import pytest
+from helpers.chip_architecture import ChipArchitecture
 from helpers.perf.parquet import (
     arrow_schema,
     convert_csvs_to_parquet,
@@ -49,9 +51,16 @@ def _write_csv(tmp_path, name, df):
 
 
 def test_schema_for_arch_selects_quasar_table():
-    assert schema_for_arch("quasar") is QSR_SCHEMA
-    assert schema_for_arch("wormhole") is WH_BH_SCHEMA
-    assert schema_for_arch("blackhole") is WH_BH_SCHEMA
+    assert schema_for_arch(ChipArchitecture.QUASAR) is QSR_SCHEMA
+    assert schema_for_arch(ChipArchitecture.WORMHOLE) is WH_BH_SCHEMA
+    assert schema_for_arch(ChipArchitecture.BLACKHOLE) is WH_BH_SCHEMA
+
+
+def test_schema_for_arch_rejects_unsupported_architecture():
+    with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
+        ValueError, match="Unsupported architecture"
+    ):
+        schema_for_arch("grayskull")
 
 
 def test_quasar_schema_is_not_wh_bh_schema():

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_parquet_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_parquet_quasar.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hardware-free Parquet tests for the Quasar published schema.
+
+Mirrors test_perf_parquet.py against wide_schema_quasar.DB_SCHEMA. Needs pyarrow,
+no chip.
+"""
+
+import pandas as pd
+import pyarrow.parquet as pq
+from helpers.perf.parquet import (
+    arrow_schema,
+    convert_csvs_to_parquet,
+    schema_for_arch,
+)
+from helpers.perf.test_schemas import PERF_TEST_SCHEMAS_QSR
+from helpers.perf.wide_schema import DB_SCHEMA as WH_BH_SCHEMA
+from helpers.perf.wide_schema import DROPPED_COLUMNS
+from helpers.perf.wide_schema_quasar import DB_SCHEMA as QSR_SCHEMA
+
+_QSR_PROV = dict(
+    commit_sha="abc123",
+    arch="quasar",
+    run_id="42",
+    timestamp="2026-01-01T00:00:00",
+    pipeline="PR",
+    pr_number="7",
+)
+
+_UNPACK_TILIZE_QSR_COLS = (
+    "data_copy_type",
+    "face_c_dim",
+    "face_r_dim",
+    "implied_math_format",
+    "num_faces_c_dim_A",
+    "num_faces_c_dim_B",
+    "num_faces_r_dim_A",
+    "num_faces_r_dim_B",
+    "unpacker_engine_sel",
+)
+
+
+def _write_csv(tmp_path, name, df):
+    path = tmp_path / name
+    df.to_csv(path, index=False)
+    return path
+
+
+def test_schema_for_arch_selects_quasar_table():
+    assert schema_for_arch("quasar") is QSR_SCHEMA
+    assert schema_for_arch("wormhole") is WH_BH_SCHEMA
+    assert schema_for_arch("blackhole") is WH_BH_SCHEMA
+
+
+def test_quasar_schema_is_not_wh_bh_schema():
+    # The split: Quasar-only columns must not land in the WH/BH published table.
+    qsr_only = {c.name for c in QSR_SCHEMA} - {c.name for c in WH_BH_SCHEMA}
+    assert "face_c_dim" in qsr_only
+    assert "unpacker_engine_sel" in qsr_only
+    assert "implied_math_format" in qsr_only
+    # WH/BH-only columns must not land in the Quasar published table.
+    wh_only = {c.name for c in WH_BH_SCHEMA} - {c.name for c in QSR_SCHEMA}
+    assert "clamp_negative" in wh_only
+    assert "ternary_mathop" in wh_only
+
+
+def test_arrow_schema_matches_quasar_db_schema():
+    schema = arrow_schema(QSR_SCHEMA)
+    assert schema.names == [c.name for c in QSR_SCHEMA]
+    for field, col in zip(schema, QSR_SCHEMA):
+        assert field.nullable == col.nullable
+
+
+def test_catalog_columns_are_in_quasar_db_schema():
+    schema_names = {c.name for c in QSR_SCHEMA} | DROPPED_COLUMNS
+    missing = {}
+    for test, entry in PERF_TEST_SCHEMAS_QSR.items():
+        unknown = sorted(set(entry["columns"]) - schema_names)
+        if unknown:
+            missing[test] = unknown
+    assert not missing, (
+        "Quasar perf-test catalog column(s) are not in "
+        "helpers.perf.wide_schema_quasar.DB_SCHEMA and would be dropped from "
+        f"Parquet: {missing}. Add them as nullable columns."
+    )
+
+
+def test_convert_keeps_quasar_unpack_tilize_columns(tmp_path):
+    # The 9 unpack-tilize columns that used to trip the live-run drop warning
+    # against the WH/BH schema: they must survive CSV -> Parquet on a Quasar run.
+    df = pd.DataFrame(
+        {
+            "marker": ["INIT"],
+            "data_copy_type": ["DataCopyType.A2D"],
+            "face_c_dim": [16],
+            "face_r_dim": [16],
+            "implied_math_format": ["ImpliedMathFormat.Yes"],
+            "num_faces_c_dim_A": [2],
+            "num_faces_c_dim_B": [2],
+            "num_faces_r_dim_A": [2],
+            "num_faces_r_dim_B": [2],
+            "unpacker_engine_sel": ["UnpackerEngine.UnpA"],
+            "tile_cnt": [8],
+        }
+    )
+    p = _write_csv(tmp_path, "perf_unpack_tilize_quasar.csv", df)
+
+    diag = convert_csvs_to_parquet([p], tmp_path / "out.parquet", **_QSR_PROV)
+
+    assert diag["unknown_columns"] == {}
+    names = pq.read_table(tmp_path / "out.parquet").schema.names
+    assert names == [c.name for c in QSR_SCHEMA]
+    for col in _UNPACK_TILIZE_QSR_COLS:
+        assert col in names
+
+
+def test_convert_drops_quasar_columns_on_wh_bh_schema(tmp_path):
+    # Same CSV against a wormhole run: Quasar-only columns are unknown and dropped.
+    df = pd.DataFrame(
+        {
+            "marker": ["INIT"],
+            "face_c_dim": [16],
+            "unpacker_engine_sel": ["UnpackerEngine.UnpA"],
+            "tile_cnt": [8],
+        }
+    )
+    p = _write_csv(tmp_path, "perf_unpack_tilize_quasar.csv", df)
+
+    diag = convert_csvs_to_parquet(
+        [p],
+        tmp_path / "out.parquet",
+        strict=False,
+        commit_sha="abc123",
+        arch="wormhole",
+        run_id="42",
+        timestamp="2026-01-01T00:00:00",
+        pipeline="PR",
+        pr_number="7",
+    )
+
+    assert diag["unknown_columns"]["perf_unpack_tilize_quasar"] == [
+        "face_c_dim",
+        "unpacker_engine_sel",
+    ]
+    names = pq.read_table(tmp_path / "out.parquet").schema.names
+    assert "face_c_dim" not in names
+    assert names == [c.name for c in WH_BH_SCHEMA]

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_parquet_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_parquet_quasar.py
@@ -17,10 +17,11 @@ from helpers.perf.parquet import (
     convert_csvs_to_parquet,
     schema_for_arch,
 )
+from helpers.perf.schema import MEAN, stat_column
 from helpers.perf.test_schemas import PERF_TEST_SCHEMAS_QSR
 from helpers.perf.wide_schema import DB_SCHEMA as WH_BH_SCHEMA
-from helpers.perf.wide_schema import DROPPED_COLUMNS
 from helpers.perf.wide_schema_quasar import DB_SCHEMA as QSR_SCHEMA
+from helpers.perf.wide_schema_quasar import DROPPED_COLUMNS as QSR_DROPPED_COLUMNS
 
 _QSR_PROV = dict(
     commit_sha="abc123",
@@ -69,6 +70,11 @@ def test_quasar_schema_is_not_wh_bh_schema():
     assert "face_c_dim" in qsr_only
     assert "unpacker_engine_sel" in qsr_only
     assert "implied_math_format" in qsr_only
+    assert "enable_2x_format" in qsr_only
+    assert "enable_direct_indexing" in qsr_only
+    assert stat_column("L1_TO_L1[FPU]", MEAN) in qsr_only
+    assert stat_column("L1_TO_L1[SFPU]", MEAN) in qsr_only
+    assert stat_column("SFPU_ISOLATE", MEAN) in qsr_only
     # WH/BH-only columns must not land in the Quasar published table.
     wh_only = {c.name for c in WH_BH_SCHEMA} - {c.name for c in QSR_SCHEMA}
     assert "clamp_negative" in wh_only
@@ -83,7 +89,7 @@ def test_arrow_schema_matches_quasar_db_schema():
 
 
 def test_catalog_columns_are_in_quasar_db_schema():
-    schema_names = {c.name for c in QSR_SCHEMA} | DROPPED_COLUMNS
+    schema_names = {c.name for c in QSR_SCHEMA} | QSR_DROPPED_COLUMNS
     missing = {}
     for test, entry in PERF_TEST_SCHEMAS_QSR.items():
         unknown = sorted(set(entry["columns"]) - schema_names)
@@ -156,3 +162,26 @@ def test_convert_drops_quasar_columns_on_wh_bh_schema(tmp_path):
     names = pq.read_table(tmp_path / "out.parquet").schema.names
     assert "face_c_dim" not in names
     assert names == [c.name for c in WH_BH_SCHEMA]
+
+
+def test_convert_drops_sfpu_isolate_text_size_on_quasar(tmp_path):
+    # TEXT_SIZE(SFPU_ISOLATE) is Quasar-dropped (#53072), not a published column.
+    df = pd.DataFrame(
+        {
+            "marker": ["INIT"],
+            "enable_2x_format": [True],
+            "implied_math_format": ["ImpliedMathFormat.Yes"],
+            "TEXT_SIZE(SFPU_ISOLATE)": [4096],
+            "tile_cnt": [8],
+        }
+    )
+    p = _write_csv(tmp_path, "perf_sfpu_exp_parallel_matmul_quasar.csv", df)
+
+    diag = convert_csvs_to_parquet([p], tmp_path / "out.parquet", **_QSR_PROV)
+
+    assert diag["unknown_columns"] == {}
+    names = pq.read_table(tmp_path / "out.parquet").schema.names
+    assert "TEXT_SIZE(SFPU_ISOLATE)" not in names
+    assert "enable_2x_format" in names
+    assert "implied_math_format" in names
+    assert names == [c.name for c in QSR_SCHEMA]

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_publish_run.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_publish_run.py
@@ -94,6 +94,33 @@ def test_publish_rejects_unknown_pipeline(tmp_path, monkeypatch):
         publish(str(tmp_path), str(tmp_path / "x.parquet"), "wormhole")
 
 
+def test_publish_quasar_uses_quasar_schema(tmp_path, monkeypatch):
+    sub = tmp_path / "perf_unpack_tilize_quasar"
+    sub.mkdir()
+    _write_csv(
+        sub / "perf_unpack_tilize_quasar.csv",
+        pd.DataFrame(
+            {
+                "marker": ["INIT"],
+                "face_c_dim": [16],
+                "implied_math_format": ["ImpliedMathFormat.Yes"],
+                "unpacker_engine_sel": ["UnpackerEngine.UnpA"],
+                "tile_cnt": [8],
+            }
+        ),
+    )
+    _set_provenance(monkeypatch)
+
+    out = tmp_path / "run.parquet"
+    diag = publish(str(tmp_path), str(out), "quasar")
+
+    assert diag["unknown_columns"] == {}
+    df = pq.read_table(out).to_pandas()
+    assert set(df["arch"]) == {"quasar"}
+    assert list(df["face_c_dim"].dropna()) == [16]
+    assert "face_c_dim" in pq.read_table(out).schema.names
+
+
 def test_main_rejects_bad_arch(tmp_path, monkeypatch):
     _set_provenance(monkeypatch)
     # argparse choices reject wormhole_b0 before publish() runs.

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
@@ -28,7 +28,14 @@ from helpers.perf.core import (
     combine_perf_reports,
     postprocess_tile_loop,
 )
-from helpers.perf.schema import MARKER, MEAN, STD, assert_unique_columns, stat_column
+from helpers.perf.schema import (
+    MARKER,
+    MEAN,
+    STD,
+    PerfSchemaError,
+    assert_unique_columns,
+    stat_column,
+)
 from helpers.perf.wide_schema import DB_SCHEMA, DROPPED_COLUMNS, OUTPUT_SCHEMA
 from helpers.profiler import Profiler, ProfilerData, _stats_l1_to_l1
 from helpers.test_config import BuildMode, TestConfig
@@ -433,3 +440,34 @@ def test_combine_perf_reports_emits_parquet_alongside_csv(tmp_path, monkeypatch)
     assert set(df["arch"]) == {"wormhole"}
     assert set(df["commit_sha"]) == {"testsha"}
     assert set(df["pipeline"]) == {"nightly"}
+
+
+def test_combine_perf_reports_raises_on_unknown_parquet_columns(tmp_path, monkeypatch):
+    # Schema drift must fail the session, not drop columns and continue. CSV is
+    # already written by the time Parquet conversion runs.
+    workers = tmp_path / "workers"
+    workers.mkdir()
+    root = tmp_path / "root"
+    monkeypatch.setattr(TestConfig, "PERF_DATA_DIR", workers)
+    monkeypatch.setattr(TestConfig, "LLK_ROOT", root)
+    monkeypatch.setenv("CHIP_ARCH", "wormhole")
+    monkeypatch.setenv("GITHUB_SHA", "testsha")
+    monkeypatch.setenv("GITHUB_RUN_ID", "testrun")
+
+    pd.DataFrame(
+        {
+            "marker": ["INIT", "TILE_LOOP"],
+            "tile_cnt": [4, 4],
+            "loop_factor": [1, 1],
+            stat_column("MATH_ISOLATE", MEAN): [10.0, 20.0],
+            "made_up_col": [1, 2],
+        }
+    ).to_csv(workers / "perf_x.gw0.csv", index=False)
+
+    with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
+        PerfSchemaError, match="made_up_col"
+    ):
+        combine_perf_reports()
+
+    assert (root / "perf_data" / "perf_x" / "perf_x.csv").exists()
+    assert not (root / "perf_data" / "testrun.parquet").exists()

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_report_hw_free.py
@@ -335,6 +335,40 @@ def test_run_single_run_drops_empty_std(monkeypatch):
     assert stat_column("MATH_ISOLATE", STD) not in frame.columns
 
 
+def test_run_rejects_empty_stats_for_requested_run_type(monkeypatch):
+    monkeypatch.setitem(
+        Profiler.STATS_FUNCTION,
+        PerfRunType.MATH_ISOLATE,
+        lambda data: pd.DataFrame(),
+    )
+
+    with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
+        ValueError,
+        match="no timing statistics for requested run type MATH_ISOLATE",
+    ):
+        _run_hw_free(monkeypatch, [PerfRunType.MATH_ISOLATE], run_count=1)
+
+
+def test_run_rejects_negative_mean_timing(monkeypatch):
+    mean_column = stat_column("MATH_ISOLATE", MEAN)
+    monkeypatch.setitem(
+        Profiler.STATS_FUNCTION,
+        PerfRunType.MATH_ISOLATE,
+        lambda data: pd.DataFrame(
+            {
+                MARKER: ["INIT", "TILE_LOOP"],
+                mean_column: [-1.0, -2.0],
+            }
+        ),
+    )
+
+    with pytest.raises(  # allow-pytest.raises: no expect_error fixture in LLK suite
+        ValueError,
+        match="negative mean timing values.*MATH_ISOLATE",
+    ):
+        _run_hw_free(monkeypatch, [PerfRunType.MATH_ISOLATE], run_count=1)
+
+
 def test_postprocess_tile_loop_derives_per_tile_from_raw():
     # Public per-tile derivation used downstream on the RAW (Parquet/CSV) table.
     raw = pd.DataFrame(

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
@@ -10,6 +10,7 @@
 #include "llk_memory_checks.h"
 #include "perf.h"
 #include "profiler.h"
+#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
 #ifdef LLK_TRISC_UNPACK
@@ -35,7 +36,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     {
         ZONE_SCOPED("INIT")
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
 
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
             ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
@@ -58,8 +59,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             // The SCALAR math MOP clears SrcAB only on the final outer-loop iteration,
             // so mock unpack must produce one SrcA/SrcB handshake per tile.
-            const std::uint32_t dvalids_per_tile = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1u : num_faces;
-            _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(LOOP_FACTOR * TILE_CNT * dvalids_per_tile);
+            const std::uint32_t dvalids_per_tile    = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1u : num_faces;
+            const std::uint32_t src_handshake_iters = LOOP_FACTOR * TILE_CNT * dvalids_per_tile;
+            _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(src_handshake_iters);
         }
         else // UNPACK_ISOLATE, L1_CONGESTION, L1_TO_L1
         {
@@ -101,7 +103,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // End-to-end and math-isolate runs require FPU destination ownership.
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
         }
 
         DataFormat math_format     = static_cast<DataFormat>(formats.math);
@@ -130,16 +132,22 @@ void run_kernel(RUNTIME_PARAMETERS params)
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
         }
-        else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
-        {
-            _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(src_handshake_iters);
-        }
-        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
             // Do exactly the handshakes produced by real unpack. An additional
             // synthetic SET/CLEAR pair races the final unpack and leaves an
             // unmatched clear token, causing the ~2048-cycle stall.
             _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(src_handshake_iters);
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                {
+                    _llk_math_eltwise_binary_broadcast_(i);
+                }
+            }
         }
         else
         {
@@ -149,10 +157,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 {
                     _llk_math_eltwise_binary_broadcast_(i);
                 }
-                if constexpr (PERF_RUN_TYPE != PerfRunType::MATH_ISOLATE)
-                {
-                    _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
-                }
+                _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
             }
         }
         PROFILER_SYNC();
@@ -186,12 +191,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            auto cfg                                    = (std::uint32_t volatile*)TENSIX_CFG_BASE;
-            cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
+            set_up_zero_dest_dvalid_handshake_for_pack();
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
-            set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
         }
 
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
@@ -57,11 +57,18 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            // The SCALAR math MOP clears SrcAB only on the final outer-loop iteration,
-            // so mock unpack must produce one SrcA/SrcB handshake per tile.
-            const std::uint32_t dvalids_per_tile    = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1u : num_faces;
-            const std::uint32_t src_handshake_iters = LOOP_FACTOR * TILE_CNT * dvalids_per_tile;
-            _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(src_handshake_iters);
+            const std::uint32_t srcb_dvalids_per_tile = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1u : num_faces;
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t tile = 0; tile < TILE_CNT; tile++)
+                {
+                    // Real broadcast unpack emits SrcA once, then SrcB once
+                    // per broadcast face. Combining these handshakes blocks
+                    // the second SrcB face while SrcA remains valid.
+                    _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(1);
+                    _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(srcb_dvalids_per_tile);
+                }
+            }
         }
         else // UNPACK_ISOLATE, L1_CONGESTION, L1_TO_L1
         {
@@ -94,10 +101,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t TILE_CNT    = params.TILE_CNT;
     const std::uint32_t num_faces   = params.num_faces;
 #endif
-    // set_last_outer_loop_instr clears SrcAB once on the final face, not once per
-    // face. SCALAR unpack likewise produces one SrcA/SrcB dvalid pair per tile.
-    const std::uint32_t dvalids_per_tile    = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1u : num_faces;
-    const std::uint32_t src_handshake_iters = LOOP_FACTOR * TILE_CNT * dvalids_per_tile;
     {
         ZONE_SCOPED("INIT")
         // End-to-end and math-isolate runs require FPU destination ownership.
@@ -134,10 +137,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            // Do exactly the handshakes produced by real unpack. An additional
-            // synthetic SET/CLEAR pair races the final unpack and leaves an
-            // unmatched clear token, causing the ~2048-cycle stall.
-            _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(src_handshake_iters);
+            const std::uint32_t srcb_only_clears = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 0u : num_faces - 1u;
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                for (std::uint32_t tile = 0; tile < TILE_CNT; tile++)
+                {
+                    // ROW/COL math clears SrcB after each non-final face,
+                    // then clears SrcA and the final SrcB together.
+                    _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(srcb_only_clears);
+                    _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(1);
+                }
+            }
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
@@ -32,7 +32,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A         = params.buffer_A;
     const Operand& buffer_B         = params.buffer_B;
 #endif
-    const std::uint32_t num_tiles_per_unpack = TILE_CNT;
 
     {
         ZONE_SCOPED("INIT")
@@ -47,7 +46,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_unpack_binary_broadcast_operands_init_<BROADCAST_TYPE>(
             ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(),
             ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(),
-            num_tiles_per_unpack);
+            TILE_CNT);
         PROFILER_SYNC();
     }
     {
@@ -65,7 +64,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     // Real broadcast unpack emits SrcA once, then SrcB once
                     // per broadcast face. Combining these handshakes blocks
                     // the second SrcB face while SrcA remains valid.
-                    _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(1);
+                    _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(1 /*iterations*/);
                     _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(srcb_dvalids_per_tile);
                 }
             }
@@ -109,11 +108,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
         }
 
-        DataFormat math_format     = static_cast<DataFormat>(formats.math);
-        DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
+        DataFormat math_format = static_cast<DataFormat>(formats.math);
         if constexpr (is_fp32_dest_acc_en)
         {
-            if (pack_src_format == DataFormat::Int32)
+            if (static_cast<DataFormat>(formats.pack_src) == DataFormat::Int32)
             {
                 _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
             }
@@ -145,7 +143,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     // ROW/COL math clears SrcB after each non-final face,
                     // then clears SrcA and the final SrcB together.
                     _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(srcb_only_clears);
-                    _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(1);
+                    _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(1 /*iterations*/);
                 }
             }
         }
@@ -193,7 +191,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t TILE_CNT    = params.TILE_CNT;
     const Operand& buffer_Res       = params.buffer_Res;
 #endif
-    const std::uint32_t num_tiles_per_pack = TILE_CNT;
 
     {
         ZONE_SCOPED("INIT")
@@ -211,7 +208,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
             ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, TILE_CNT);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
@@ -66,12 +66,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                const std::uint32_t datacopy_handshake_iters = INPUT_TILE_CNT;
-                const std::uint32_t binary_handshake_iters   = INPUT_TILE_CNT * num_faces;
                 // Phase 1 datacopy consumes SrcA once per tile.
-                _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(datacopy_handshake_iters);
+                _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(INPUT_TILE_CNT);
                 // Phase 2 reuse-dest binary consumes both sources per face.
-                _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(binary_handshake_iters);
+                _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(INPUT_TILE_CNT * num_faces);
             }
         }
         else
@@ -156,10 +154,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                const std::uint32_t datacopy_handshake_iters = INPUT_TILE_CNT;
-                const std::uint32_t binary_handshake_iters   = INPUT_TILE_CNT * num_faces;
-                _perf_math_loop_clear_valid<true /*clear_a*/, false /*clear_b*/>(datacopy_handshake_iters);
-                _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(binary_handshake_iters);
+                _perf_math_loop_clear_valid<true /*clear_a*/, false /*clear_b*/>(INPUT_TILE_CNT);
+                _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(INPUT_TILE_CNT * num_faces);
             }
         }
         else

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
@@ -12,6 +12,7 @@
 #include "llk_memory_checks.h"
 #include "perf.h"
 #include "profiler.h"
+#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
 // Globals
@@ -45,7 +46,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
         // Setup data valid scheme
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
 
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
             ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
@@ -65,10 +66,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
+                const std::uint32_t datacopy_handshake_iters = INPUT_TILE_CNT;
+                const std::uint32_t binary_handshake_iters   = INPUT_TILE_CNT * num_faces;
                 // Phase 1 datacopy consumes SrcA once per tile.
-                _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(INPUT_TILE_CNT);
+                _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(datacopy_handshake_iters);
                 // Phase 2 reuse-dest binary consumes both sources per face.
-                _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(INPUT_TILE_CNT * num_faces);
+                _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(binary_handshake_iters);
             }
         }
         else
@@ -131,7 +134,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // L1_TO_L1 / MATH_ISOLATE keep the math↔pack handshake: set up FPU→PACK dest-dvalid.
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
         }
 
         DataFormat src_format = static_cast<DataFormat>(formats.math);
@@ -153,8 +156,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                _perf_math_loop_clear_valid<true /*clear_a*/, false /*clear_b*/>(INPUT_TILE_CNT);
-                _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(INPUT_TILE_CNT * num_faces);
+                const std::uint32_t datacopy_handshake_iters = INPUT_TILE_CNT;
+                const std::uint32_t binary_handshake_iters   = INPUT_TILE_CNT * num_faces;
+                _perf_math_loop_clear_valid<true /*clear_a*/, false /*clear_b*/>(datacopy_handshake_iters);
+                _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(binary_handshake_iters);
             }
         }
         else
@@ -219,12 +224,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            auto cfg                                    = (std::uint32_t volatile*)TENSIX_CFG_BASE;
-            cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
+            set_up_zero_dest_dvalid_handshake_for_pack();
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
-            set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
         }
 
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
@@ -95,8 +95,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 // Quasar's 32-bit A2D datacopy is ELWADD and consumes SrcA
                 // plus the dummy SrcB dvalid emitted by the unpack MOP.
-                const std::uint32_t src_handshake_iters = LOOP_FACTOR * TILE_CNT;
-                _perf_unpack_loop_set_valid<true, is_fp32_dest_acc_en>(src_handshake_iters);
+                _perf_unpack_loop_set_valid<true /*set_a*/, is_fp32_dest_acc_en>(LOOP_FACTOR * TILE_CNT);
             }
         }
         else if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE)
@@ -181,8 +180,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // so integer ordering is preserved. Other ops use the inferred mode.
         if constexpr (test_utils::quasar_binary_op_is_max_min(SFPU_BINARY_OP))
         {
-            const DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-            configure_math_hardware_for_float32_int32_or_default<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, pack_src_format);
+            configure_math_hardware_for_float32_int32_or_default<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(
+                math_format, static_cast<DataFormat>(formats.pack_src));
         }
         else
         {
@@ -191,8 +190,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         if constexpr (!unpack_to_dest)
         {
-            const std::uint32_t num_rows = num_faces * TEST_FACE_R_DIM;
-            _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(num_rows, 1);
+            _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(num_faces * TEST_FACE_R_DIM, 1 /*num_matrices*/);
         }
         // SFPU uses ADDR_MOD_7 and does not overwrite the datacopy MOP's
         // ADDR_MOD_0/1 or bank-0 programming, so both initializers can remain in
@@ -207,8 +205,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             if constexpr (!unpack_to_dest)
             {
-                const std::uint32_t src_handshake_iters = LOOP_FACTOR * TILE_CNT;
-                _perf_math_loop_clear_valid<true, is_fp32_dest_acc_en>(src_handshake_iters);
+                _perf_math_loop_clear_valid<true /*clear_a*/, is_fp32_dest_acc_en>(LOOP_FACTOR * TILE_CNT);
             }
         }
         else if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE)
@@ -267,7 +264,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t DST_TILE_IDX = params.DST_TILE_IDX;
     const Operand& buffer_Res        = params.buffer_Res;
 #endif
-    const std::uint32_t num_tiles_per_pack = 1; // only the SFPU result tile is packed
 
     {
         ZONE_SCOPED("INIT")
@@ -293,7 +289,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
 
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*only the SFPU result tile*/);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
@@ -51,11 +51,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
             // per path: UNPACK for UNP_DEST and FPU for the datacopy path.
             if constexpr (unpack_to_dest)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+                set_up_unpack_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
             }
             else
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+                set_up_fpu_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
             }
         }
         else if constexpr (unpack_to_dest)
@@ -95,7 +95,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 // Quasar's 32-bit A2D datacopy is ELWADD and consumes SrcA
                 // plus the dummy SrcB dvalid emitted by the unpack MOP.
-                _perf_unpack_loop_set_valid<true, is_fp32_dest_acc_en>(LOOP_FACTOR * TILE_CNT);
+                const std::uint32_t src_handshake_iters = LOOP_FACTOR * TILE_CNT;
+                _perf_unpack_loop_set_valid<true, is_fp32_dest_acc_en>(src_handshake_iters);
             }
         }
         else if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE)
@@ -160,12 +161,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
             // producer and the SFPU producer, so both clients are registered.
             if constexpr (unpack_to_dest)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+                set_up_unpack_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::SFPU>();
             }
             else
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+                set_up_fpu_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
+                set_up_fpu_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::SFPU>();
             }
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
@@ -181,18 +182,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         if constexpr (test_utils::quasar_binary_op_is_max_min(SFPU_BINARY_OP))
         {
             const DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-            if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Float32)
-            {
-                _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
-            }
-            else if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
-            {
-                _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
-            }
-            else
-            {
-                _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
-            }
+            configure_math_hardware_for_float32_int32_or_default<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, pack_src_format);
         }
         else
         {
@@ -217,7 +207,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             if constexpr (!unpack_to_dest)
             {
-                _perf_math_loop_clear_valid<true, is_fp32_dest_acc_en>(LOOP_FACTOR * TILE_CNT);
+                const std::uint32_t src_handshake_iters = LOOP_FACTOR * TILE_CNT;
+                _perf_math_loop_clear_valid<true, is_fp32_dest_acc_en>(src_handshake_iters);
             }
         }
         else if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE)
@@ -290,11 +281,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
             // Declare the same dvalid client chain that UNPACK and MATH use.
             if constexpr (unpack_to_dest)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+                set_up_unpack_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
             }
             else
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+                set_up_fpu_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
             }
         }
 

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
@@ -60,8 +60,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            const std::uint32_t src_handshake_iters = LOOP_FACTOR * INPUT_TILE_CNT;
-            _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(src_handshake_iters);
+            _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(LOOP_FACTOR * INPUT_TILE_CNT);
         }
         else
         {
@@ -112,9 +111,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
         }
 
-        DataFormat math_format     = static_cast<DataFormat>(formats.math);
-        DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-        if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+        DataFormat math_format = static_cast<DataFormat>(formats.math);
+        if (is_fp32_dest_acc_en && static_cast<DataFormat>(formats.pack_src) == DataFormat::Int32)
         {
             _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
         }
@@ -132,8 +130,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            const std::uint32_t src_handshake_iters = LOOP_FACTOR * INPUT_TILE_CNT;
-            _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(src_handshake_iters);
+            _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(LOOP_FACTOR * INPUT_TILE_CNT);
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
@@ -10,6 +10,7 @@
 #include "llk_memory_checks.h"
 #include "perf.h"
 #include "profiler.h"
+#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
 // Globals
@@ -38,7 +39,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     {
         ZONE_SCOPED("INIT")
-        set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+        set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
 
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
             ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
@@ -59,7 +60,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(LOOP_FACTOR * INPUT_TILE_CNT);
+            const std::uint32_t src_handshake_iters = LOOP_FACTOR * INPUT_TILE_CNT;
+            _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(src_handshake_iters);
         }
         else
         {
@@ -107,7 +109,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // End-to-end and math-isolate runs require FPU destination ownership.
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
         }
 
         DataFormat math_format     = static_cast<DataFormat>(formats.math);
@@ -130,7 +132,24 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(LOOP_FACTOR * INPUT_TILE_CNT);
+            const std::uint32_t src_handshake_iters = LOOP_FACTOR * INPUT_TILE_CNT;
+            _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(src_handshake_iters);
+        }
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        {
+            for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
+            {
+                std::uint32_t dest_idx = 0;
+                for (std::uint32_t remaining_tiles = INPUT_TILE_CNT; remaining_tiles > 0; remaining_tiles -= std::min(remaining_tiles, NUM_TILES_IN_BLOCK))
+                {
+                    const std::uint32_t num_tiles_in_block = std::min(remaining_tiles, NUM_TILES_IN_BLOCK);
+                    for (std::uint32_t tile = 0; tile < num_tiles_in_block; ++tile)
+                    {
+                        _llk_math_eltwise_binary_<ELTWISE_BINARY_OP>(dest_idx, ckernel::DEFAULT_TENSOR_SHAPE);
+                    }
+                    ++dest_idx;
+                }
+            }
         }
         else
         {
@@ -146,10 +165,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     }
                     ++dest_idx;
                 }
-                if constexpr (PERF_RUN_TYPE != PerfRunType::MATH_ISOLATE)
-                {
-                    _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
-                }
+                _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
             }
         }
         PROFILER_SYNC();
@@ -181,12 +197,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // Clear a stale FPU-to-PACK wait in modes without a math handshake.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            volatile std::uint32_t* cfg                 = (volatile std::uint32_t*)TENSIX_CFG_BASE;
-            cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
+            set_up_zero_dest_dvalid_handshake_for_pack();
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
-            set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
         }
 
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_sub_bcast_col_custom_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_sub_bcast_col_custom_quasar_test.cpp
@@ -87,12 +87,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // The addr-mods are identical for every block, so init once outside the loop.
     _llk_math_eltwise_binary_init_custom_<ELTWISE_BINARY_OP, BROADCAST_TYPE>(tensor_shape);
 
-    const std::uint32_t ct_dim     = params.OUTPUT_NUM_TILES_IN_BLOCK;
     const std::uint32_t num_blocks = static_cast<std::uint32_t>(params.OUTPUT_NUM_BLOCKS);
 
     for (std::uint32_t block = 0; block < num_blocks; block++)
     {
-        _llk_math_sub_bcast_cols_reuse_custom_(ct_dim, tensor_shape, 0 /*dst_index*/);
+        _llk_math_sub_bcast_cols_reuse_custom_(params.OUTPUT_NUM_TILES_IN_BLOCK, tensor_shape, 0 /*dst_index*/);
         _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
     }
 }

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
@@ -80,14 +80,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 const std::uint32_t dvalids_per_tile =
                     (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1u : static_cast<std::uint32_t>(num_faces_r_dim_A * num_faces_c_dim_A);
-                const std::uint32_t src_handshake_iters = LOOP_FACTOR * num_blocks * tiles_in_block * dvalids_per_tile;
-                _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(src_handshake_iters);
+                _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(LOOP_FACTOR * num_blocks * tiles_in_block * dvalids_per_tile);
             }
             else
             {
                 // SrcB dummy dvalid needed for the unpack to dest path
-                const std::uint32_t src_handshake_iters = LOOP_FACTOR * num_blocks * tiles_in_block;
-                _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(src_handshake_iters);
+                _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(LOOP_FACTOR * num_blocks * tiles_in_block);
             }
         }
         else if constexpr (unpack_to_dest)
@@ -96,8 +94,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 for (std::uint32_t block = 0; block < num_blocks; block++)
                 {
-                    const std::uint32_t input_tile_idx = block * tiles_in_block;
-                    _llk_unpack_unary_broadcast_operands_<UNPACKER_ENGINE_SEL, unpack_to_dest>(input_tile_idx);
+                    _llk_unpack_unary_broadcast_operands_<UNPACKER_ENGINE_SEL, unpack_to_dest>(block * tiles_in_block);
                     if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
                     {
                         _llk_unpack_dest_dvalid_section_done_<dest_sync>();
@@ -150,7 +147,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t num_blocks     = params.INPUT_NUM_BLOCKS;
 #endif
     const DataFormat math_format            = static_cast<DataFormat>(formats.math);
-    const DataFormat pack_src_format        = static_cast<DataFormat>(formats.pack_src);
     const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
 
     {
@@ -175,7 +171,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
         }
 
-        if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+        if (is_fp32_dest_acc_en && static_cast<DataFormat>(formats.pack_src) == DataFormat::Int32)
         {
             _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
         }
@@ -205,14 +201,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             if constexpr (!unpack_to_dest)
             {
-                const std::uint32_t dvalids_per_tile    = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1u : num_faces;
-                const std::uint32_t src_handshake_iters = LOOP_FACTOR * num_blocks * tiles_in_block * dvalids_per_tile;
-                _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(src_handshake_iters);
+                const std::uint32_t dvalids_per_tile = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1u : num_faces;
+                _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(LOOP_FACTOR * num_blocks * tiles_in_block * dvalids_per_tile);
             }
             else
             {
-                const std::uint32_t src_handshake_iters = LOOP_FACTOR * num_blocks * tiles_in_block;
-                _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(src_handshake_iters);
+                _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(LOOP_FACTOR * num_blocks * tiles_in_block);
             }
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
@@ -267,7 +261,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_Res                 = params.buffer_Res;
 #endif
 
-    const std::uint32_t num_tiles_per_pack = 1;
 
     {
         ZONE_SCOPED("INIT")
@@ -293,7 +286,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape, 1 /*num_tiles*/);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
@@ -43,7 +43,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+                set_up_unpack_to_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
             }
             else
             {
@@ -54,7 +54,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else
         {
-            set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
         }
 
         const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
@@ -80,12 +80,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 const std::uint32_t dvalids_per_tile =
                     (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1u : static_cast<std::uint32_t>(num_faces_r_dim_A * num_faces_c_dim_A);
-                _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(LOOP_FACTOR * num_blocks * tiles_in_block * dvalids_per_tile);
+                const std::uint32_t src_handshake_iters = LOOP_FACTOR * num_blocks * tiles_in_block * dvalids_per_tile;
+                _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(src_handshake_iters);
             }
             else
             {
                 // SrcB dummy dvalid needed for the unpack to dest path
-                _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(LOOP_FACTOR * num_blocks * tiles_in_block);
+                const std::uint32_t src_handshake_iters = LOOP_FACTOR * num_blocks * tiles_in_block;
+                _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(src_handshake_iters);
             }
         }
         else if constexpr (unpack_to_dest)
@@ -157,11 +159,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             if constexpr (unpack_to_dest)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+                set_up_unpack_to_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
             }
             else
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+                set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
             }
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE && unpack_to_dest)
@@ -170,7 +172,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             // UNPACK→FPU→PACK chain. Math isolate has no unpack destination
             // pulse, so make FPU the producer and restore immediate ownership
             // of the destination register.
-            set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
         }
 
         if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
@@ -203,12 +205,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             if constexpr (!unpack_to_dest)
             {
-                const std::uint32_t dvalids_per_tile = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1u : num_faces;
-                _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(LOOP_FACTOR * num_blocks * tiles_in_block * dvalids_per_tile);
+                const std::uint32_t dvalids_per_tile    = (BROADCAST_TYPE == BroadcastType::SCALAR) ? 1u : num_faces;
+                const std::uint32_t src_handshake_iters = LOOP_FACTOR * num_blocks * tiles_in_block * dvalids_per_tile;
+                _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(src_handshake_iters);
             }
             else
             {
-                _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(LOOP_FACTOR * num_blocks * tiles_in_block);
+                const std::uint32_t src_handshake_iters = LOOP_FACTOR * num_blocks * tiles_in_block;
+                _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(src_handshake_iters);
             }
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
@@ -271,18 +275,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            auto cfg                                    = (volatile std::uint32_t*)TENSIX_CFG_BASE;
-            cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
+            set_up_zero_dest_dvalid_handshake_for_pack();
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
             if constexpr (unpack_to_dest)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+                set_up_unpack_to_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
             }
             else
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+                set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
             }
         }
 

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_datacopy_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_datacopy_quasar_test.cpp
@@ -75,19 +75,20 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
+            const std::uint32_t src_handshake_iters = LOOP_FACTOR * TILE_CNT;
             if constexpr (is_fp32_dest_acc_en)
             {
                 // 32-bit datacopy uses ELWADD and consumes both the selected
                 // source and the dummy source produced by unpack.
-                _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(LOOP_FACTOR * TILE_CNT);
+                _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(src_handshake_iters);
             }
             else if constexpr (DATA_COPY_TYPE == DataCopyType::A2D)
             {
-                _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(LOOP_FACTOR * TILE_CNT);
+                _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(src_handshake_iters);
             }
             else
             {
-                _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(LOOP_FACTOR * TILE_CNT);
+                _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(src_handshake_iters);
             }
         }
         else
@@ -134,7 +135,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // End-to-end and math-isolate runs require FPU destination ownership.
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
         }
 
         DataFormat src_format = static_cast<DataFormat>(formats.math);
@@ -150,17 +151,18 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
+            const std::uint32_t src_handshake_iters = LOOP_FACTOR * TILE_CNT;
             if constexpr (is_fp32_dest_acc_en)
             {
-                _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(LOOP_FACTOR * TILE_CNT);
+                _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(src_handshake_iters);
             }
             else if constexpr (DATA_COPY_TYPE == DataCopyType::A2D)
             {
-                _perf_math_loop_clear_valid<true /*clear_a*/, false /*clear_b*/>(LOOP_FACTOR * TILE_CNT);
+                _perf_math_loop_clear_valid<true /*clear_a*/, false /*clear_b*/>(src_handshake_iters);
             }
             else
             {
-                _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(LOOP_FACTOR * TILE_CNT);
+                _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(src_handshake_iters);
             }
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
@@ -216,12 +218,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            auto cfg                                    = (volatile std::uint32_t*)TENSIX_CFG_BASE;
-            cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
+            set_up_zero_dest_dvalid_handshake_for_pack();
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
-            set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
         }
 
         const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_datacopy_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_datacopy_quasar_test.cpp
@@ -32,7 +32,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A         = params.buffer_A;
     const Operand& buffer_B         = params.buffer_B;
 #endif
-    const std::uint32_t num_tiles_per_unpack = TILE_CNT;
 
     {
         ZONE_SCOPED("INIT")
@@ -63,7 +62,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
 
         _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
-            ckernel::trisc::bfd_current<unp_res>(), tensor_shape_A, num_tiles_per_unpack);
+            ckernel::trisc::bfd_current<unp_res>(), tensor_shape_A, TILE_CNT);
         PROFILER_SYNC();
     }
     {
@@ -210,7 +209,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t DST_INDEX   = params.DST_INDEX;
     const Operand& buffer_Res       = params.buffer_Res;
 #endif
-    const std::uint32_t num_tiles_per_pack = TILE_CNT;
 
     {
         ZONE_SCOPED("INIT")
@@ -229,7 +227,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape_A, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape_A, TILE_CNT);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
@@ -34,27 +34,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     {
         ZONE_SCOPED("INIT")
-        if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
-        {
-            // T0 produces Dest directly on the UNP_DEST path; on the SrcA path,
-            // the FPU datacopy is the producer. Every thread must declare the
-            // same client chain.
-            if constexpr (unpack_to_dest)
-            {
-                set_up_unpack_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
-            }
-            else
-            {
-                set_up_fpu_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
-            }
-        }
-        else
-        {
-            // CFG wait masks persist across run types on the same device.
-            // Isolated/congested UNPACK must not inherit the L1_TO_L1 chain.
-            set_up_zero_dest_dvalid_handshake_for_unpack();
-        }
-
         if constexpr (unpack_to_dest)
         {
             _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>();
@@ -87,6 +66,28 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
             ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, TILE_CNT);
+
+        // Program dest-dvalid CFG after HW configure so wait masks are the last
+        // writes before TILE_LOOP. UNPACK is only a dest client on UNP_DEST.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+        {
+            if constexpr (unpack_to_dest)
+            {
+                set_up_unpack_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
+            }
+            else
+            {
+                // SrcA unpack is not a dest-dvalid client; do not inherit an
+                // UNP_DEST wait mask from a prior kernel on this device.
+                set_up_zero_dest_dvalid_handshake_for_unpack();
+            }
+        }
+        else
+        {
+            // CFG wait masks persist across run types on the same device.
+            // Isolated/congested UNPACK must not inherit the L1_TO_L1 chain.
+            set_up_zero_dest_dvalid_handshake_for_unpack();
+        }
         PROFILER_SYNC();
     }
     {
@@ -149,28 +150,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     {
         ZONE_SCOPED("INIT")
-        if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
-        {
-            // The dvalid chain must match UNPACK exactly. On the FPU path T1 is
-            // both the datacopy producer and the SFPU producer.
-            if constexpr (unpack_to_dest)
-            {
-                set_up_unpack_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::SFPU>();
-            }
-            else
-            {
-                set_up_fpu_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
-                set_up_fpu_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::SFPU>();
-            }
-        }
-        else
-        {
-            // CFG wait masks persist across run types. MATH_ISOLATE runs without
-            // a pack consumer; UNPACK_ISOLATE / L1_CONGESTION only mock Src
-            // handshakes. None of them may inherit the FPU→SFPU→PACK chain.
-            set_up_zero_dest_dvalid_handshake_for_math();
-            set_up_zero_dest_dvalid_handshake_for_sfpu();
-        }
         if constexpr (unpack_to_dest)
         {
             _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>(src_format, src_format);
@@ -199,6 +178,31 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // the INIT zone before the measured TILE_LOOP.
         _llk_math_eltwise_sfpu_init_();
         test_utils::init_unary_sfpu_operation_quasar<SFPU_UNARY_OPERATION, is_fp32_dest_acc_en, APPROX_MODE>();
+
+        // Program dest-dvalid CFG after HW configure so wait masks are the last
+        // writes before TILE_LOOP.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+        {
+            // The dvalid chain must match UNPACK exactly. On the FPU path T1 is
+            // both the datacopy producer and the SFPU producer.
+            if constexpr (unpack_to_dest)
+            {
+                set_up_unpack_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::SFPU>();
+            }
+            else
+            {
+                set_up_fpu_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
+                set_up_fpu_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::SFPU>();
+            }
+        }
+        else
+        {
+            // CFG wait masks persist across run types. MATH_ISOLATE runs without
+            // a pack consumer; UNPACK_ISOLATE / L1_CONGESTION only mock Src
+            // handshakes. None of them may inherit the FPU→SFPU→PACK chain.
+            set_up_zero_dest_dvalid_handshake_for_math();
+            set_up_zero_dest_dvalid_handshake_for_sfpu();
+        }
         PROFILER_SYNC();
     }
     {
@@ -276,6 +280,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     {
         ZONE_SCOPED("INIT")
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
+            ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, TILE_CNT);
+
+        // Program dest-dvalid CFG after HW configure so wait masks are the last
+        // writes before TILE_LOOP.
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
             // Declare the same dvalid client chain that UNPACK and MATH use.
@@ -294,12 +306,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
             // MATH_ISOLATE do not pack. None may inherit the L1_TO_L1 wait mask.
             set_up_zero_dest_dvalid_handshake_for_pack();
         }
-
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
-            ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
-
-        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, TILE_CNT);
         PROFILER_SYNC();
     }
     {
@@ -312,6 +318,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
                 {
                     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+                    // Drain this bank's dest-waited pack before issuing the next.
+                    // Queuing all LOOP_FACTOR packs into one tensix_sync makes the
+                    // TILE_LOOP ZONE_END wall-clock read return 0 on long SFPU ops.
+                    ckernel::wait_pack_idle();
                 }
             }
         }

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
@@ -41,11 +41,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
             // same client chain.
             if constexpr (unpack_to_dest)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+                set_up_unpack_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
             }
             else
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+                set_up_fpu_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
             }
         }
         else if constexpr (unpack_to_dest)
@@ -97,7 +97,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 // Quasar's 32-bit A2D datacopy is ELWADD and consumes SrcA
                 // plus the dummy SrcB dvalid emitted by the unpack MOP.
-                _perf_unpack_loop_set_valid<true, is_fp32_dest_acc_en>(LOOP_FACTOR * TILE_CNT);
+                const std::uint32_t src_handshake_iters = LOOP_FACTOR * TILE_CNT;
+                _perf_unpack_loop_set_valid<true, is_fp32_dest_acc_en>(src_handshake_iters);
             }
         }
         else if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE)
@@ -154,12 +155,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
             // both the datacopy producer and the SFPU producer.
             if constexpr (unpack_to_dest)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+                set_up_unpack_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::SFPU>();
             }
             else
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::SFPU>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+                set_up_fpu_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
+                set_up_fpu_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::SFPU>();
             }
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
@@ -206,7 +207,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             if constexpr (!unpack_to_dest)
             {
-                _perf_math_loop_clear_valid<true, is_fp32_dest_acc_en>(LOOP_FACTOR * TILE_CNT);
+                const std::uint32_t src_handshake_iters = LOOP_FACTOR * TILE_CNT;
+                _perf_math_loop_clear_valid<true, is_fp32_dest_acc_en>(src_handshake_iters);
             }
         }
         else if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE)
@@ -284,11 +286,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
             // Declare the same dvalid client chain that UNPACK and MATH use.
             if constexpr (unpack_to_dest)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+                set_up_unpack_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
             }
             else
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
+                set_up_fpu_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
             }
         }
 

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
@@ -40,8 +40,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else
         {
-            const DataFormat src_format = static_cast<DataFormat>(formats.math);
-            if (src_format == DataFormat::Int32)
+            if (static_cast<DataFormat>(formats.math) == DataFormat::Int32)
             {
                 _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>();
             }
@@ -98,8 +97,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 // Quasar's 32-bit A2D datacopy is ELWADD and consumes SrcA
                 // plus the dummy SrcB dvalid emitted by the unpack MOP.
-                const std::uint32_t src_handshake_iters = LOOP_FACTOR * TILE_CNT;
-                _perf_unpack_loop_set_valid<true, is_fp32_dest_acc_en>(src_handshake_iters);
+                _perf_unpack_loop_set_valid<true /*set_a*/, is_fp32_dest_acc_en>(LOOP_FACTOR * TILE_CNT);
             }
         }
         else if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE)
@@ -170,8 +168,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         if constexpr (!unpack_to_dest)
         {
-            const std::uint32_t num_rows = num_faces * TEST_FACE_R_DIM;
-            _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(num_rows, 1);
+            _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(num_faces * TEST_FACE_R_DIM, 1 /*num_matrices*/);
         }
         // SFPU uses ADDR_MOD_7 and does not overwrite the datacopy MOP's
         // ADDR_MOD_0/1 or bank-0 programming, so both initializers can remain in
@@ -211,13 +208,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             if constexpr (!unpack_to_dest)
             {
-                const std::uint32_t src_handshake_iters = LOOP_FACTOR * TILE_CNT;
-                _perf_math_loop_clear_valid<true, is_fp32_dest_acc_en>(src_handshake_iters);
+                _perf_math_loop_clear_valid<true /*clear_a*/, is_fp32_dest_acc_en>(LOOP_FACTOR * TILE_CNT);
             }
         }
         else if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE)
         {
-            const DataFormat sfpu_format = static_cast<DataFormat>(formats.sfpu_math);
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; ++loop)
             {
                 if constexpr (!unpack_to_dest)
@@ -240,7 +235,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                         APPROX_MODE,
                         SFPU_ITERATIONS,
                         TYPECAST_IN_FORMAT,
-                        TYPECAST_OUT_FORMAT>(DST_INDEX + i, sfpu_format);
+                        TYPECAST_OUT_FORMAT>(DST_INDEX + i, static_cast<DataFormat>(formats.sfpu_math));
                 }
                 if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
                 {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
@@ -48,10 +48,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 set_up_fpu_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
             }
         }
-        else if constexpr (unpack_to_dest)
+        else
         {
-            // L1_TO_L1 may leave UNP_DEST waiting for inactive SFPU/PACK clients.
-            // Isolated/congested UNP_DEST execution must not inherit that chain.
+            // CFG wait masks persist across run types on the same device.
+            // Isolated/congested UNPACK must not inherit the L1_TO_L1 chain.
             set_up_zero_dest_dvalid_handshake_for_unpack();
         }
 
@@ -163,11 +163,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 set_up_fpu_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::SFPU>();
             }
         }
-        else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
+        else
         {
-            // FPU datacopy (when present) and SFPU execute sequentially on this
-            // thread. Keep them on one Dest bank instead of creating a dvalid
-            // chain whose producer would also wait for inactive UNPACK/PACK.
+            // CFG wait masks persist across run types. MATH_ISOLATE runs without
+            // a pack consumer; UNPACK_ISOLATE / L1_CONGESTION only mock Src
+            // handshakes. None of them may inherit the FPU→SFPU→PACK chain.
             set_up_zero_dest_dvalid_handshake_for_math();
             set_up_zero_dest_dvalid_handshake_for_sfpu();
         }
@@ -276,12 +276,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     {
         ZONE_SCOPED("INIT")
-        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
-        {
-            // PACK runs without the L1_TO_L1 producer chain in isolated modes.
-            set_up_zero_dest_dvalid_handshake_for_pack();
-        }
-        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+        if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
             // Declare the same dvalid client chain that UNPACK and MATH use.
             if constexpr (unpack_to_dest)
@@ -292,6 +287,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 set_up_fpu_to_sfpu_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
             }
+        }
+        else
+        {
+            // PACK_ISOLATE / L1_CONGESTION pack independently. UNPACK_ISOLATE /
+            // MATH_ISOLATE do not pack. None may inherit the L1_TO_L1 wait mask.
+            set_up_zero_dest_dvalid_handshake_for_pack();
         }
 
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(

--- a/tt_metal/tt-llk/tests/sources/quasar/isolate_sfpu_add_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/isolate_sfpu_add_quasar_test.cpp
@@ -51,7 +51,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const volatile FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t num_tiles = params.TILE_CNT;
 
     // -------------------------------------------------------------------------
     // Data format inference and dimensions
@@ -101,7 +100,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     bd_pack.f.y_dim       = PARAM_SRCS_YDIM;
     bd_pack.f.z_dim       = PARAM_SRCS_ZDIM;
     _configure_buf_desc_table_(buf_desc_id_pack, bd_pack);
-    _llk_pack_hw_configure_<p_pacr::PACK1, false>(static_cast<DataFormat>(formats.pack_S_src), ckernel::ReluConfig::none());
+    _llk_pack_hw_configure_<p_pacr::PACK1, false /*EN_32BIT_DEST*/>(static_cast<DataFormat>(formats.pack_S_src), ckernel::ReluConfig::none());
 
     // Implied math format disable for SrcS and sfpmem mod selection
     cfg[DISABLE_IMPLIED_SRCS_FORMAT_ADDR32 + TRISC_ID] = !IMPLIED_MATH_FORMAT;
@@ -120,11 +119,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const int num_sfpu_iterations      = PARAM_SRCS_YDIM >> 1; // Divide by 2 since SFSPU operates on 2 rows at a time
     const std::uint32_t replay_buf_len = num_sfpu_iterations * 4;
     load_replay_buf( // TODO: Replace with SFPI call when SFPI is supported for Quasar: https://github.com/tenstorrent/tt-llk/issues/1637
-        0,
+        0 /*start*/,
         replay_buf_len,
-        false,
-        0,
-        0,
+        false /*exec_while_loading*/,
+        0 /*set_mutex*/,
+        0 /*last*/,
         // Lambda function to load replay buffer
         [in0_base, in1_base, out_base, num_sfpu_iterations]
         {
@@ -143,7 +142,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_srcs_config_for_tile_<PARAM_SRCS_INSTRN_COUNT>(PARAM_SRCS_32BIT_MODE);
     _llk_math_eltwise_sfpu_init_();
 
-    for (std::uint32_t i = 0; i < num_tiles; ++i)
+    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
         TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_S, i * PARAM_SRCS_SLICE_COUNT);
 
@@ -164,7 +163,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             TT_UNPACR2_TILE_INC(0b1 /*SrcS tile inc*/, 0b0 /*no L1 inc*/, buf_desc_id_unpack_0, 0b0 /*no dvalid*/);
             TT_UNPACR2_TILE_INC(0b0 /*no SrcS tile inc*/, 0b1 /*L1 inc*/, buf_desc_id_unpack_1, 0b1 /*Set dvalid*/);
             TT_REPLAY(0, replay_buf_len, 0, 0, 0, 0);
-            _llk_math_eltwise_sfpu_srcs_clear_vlds_<true, true>(); // Clears dvalid for SFPU read and write
+            _llk_math_eltwise_sfpu_srcs_clear_vlds_<true /*SRCS_RD_DONE*/, true /*SRCS_WR_DONE*/>(); // Clears dvalid for SFPU read and write
         }
 
         // Remaining SFPU iterations with no unpacker instructions (since they are preloaded)
@@ -172,7 +171,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         for (std::uint32_t j = 0; j < preload_count; j++)
         {
             TT_REPLAY(0, replay_buf_len, 0, 0, 0, 0);
-            _llk_math_eltwise_sfpu_srcs_clear_vlds_<true, true>(); // Clears dvalid for SFPU read and write
+            _llk_math_eltwise_sfpu_srcs_clear_vlds_<true /*SRCS_RD_DONE*/, true /*SRCS_WR_DONE*/>(); // Clears dvalid for SFPU read and write
         }
     }
 

--- a/tt_metal/tt-llk/tests/sources/quasar/isolate_sfpu_square_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/isolate_sfpu_square_quasar_test.cpp
@@ -51,7 +51,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const volatile FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t num_tiles = params.TILE_CNT;
 
     // -------------------------------------------------------------------------
     // Data format inference and dimensions
@@ -90,7 +89,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     bd_pack.f.y_dim       = PARAM_SRCS_YDIM;
     bd_pack.f.z_dim       = PARAM_SRCS_ZDIM;
     _configure_buf_desc_table_(buf_desc_id_pack, bd_pack);
-    _llk_pack_hw_configure_<p_pacr::PACK1, false>(static_cast<DataFormat>(formats.pack_S_src), ckernel::ReluConfig::none());
+    _llk_pack_hw_configure_<p_pacr::PACK1, false /*EN_32BIT_DEST*/>(static_cast<DataFormat>(formats.pack_S_src), ckernel::ReluConfig::none());
 
     // Implied math format disable for SrcS and sfpmem mod selection
     cfg[DISABLE_IMPLIED_SRCS_FORMAT_ADDR32 + TRISC_ID] = !IMPLIED_MATH_FORMAT;
@@ -105,10 +104,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_math_eltwise_sfpu_init_();
 
     const int num_sfpu_iterations = PARAM_SRCS_YDIM >> 1; // SFP_ROWS == 2
-    for (std::uint32_t i = 0; i < num_tiles; ++i)
+    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
         // Unpack/Pack calls can be moved outside the loop by incorporating the loop into the auto-loop registers
-        // Keeping them here for now since num_tiles is not a compile-time constant
+        // Keeping them here for now since params.TILE_CNT is not a compile-time constant
         _llk_unpack_srcs_<PARAM_SRCS_INSTRN_COUNT>(buf_desc_id_unpack, i * PARAM_SRCS_SLICE_COUNT); // Sets dvalid for SFPU to read
 
         // Pack is placed before SFPU because SFPU loop fills up and clogs the instruction buffer leading to hangs
@@ -117,20 +116,19 @@ void run_kernel(RUNTIME_PARAMETERS params)
         for (std::uint32_t slice = 0; slice < PARAM_SRCS_SLICE_COUNT; slice++)
         {
             // Passing addresses into calculate_* will land in a follow-up PR handled in https://github.com/tenstorrent/tt-llk/issues/1353.
-            const int load_base_addr  = ckernel::math::SFPU_SRCS_BASE_ADDR;                       // First slice of SrcS
             const int store_base_addr = ckernel::math::SFPU_SRCS_BASE_ADDR + 2 * PARAM_SRCS_YDIM; // Third slice of SrcS
 
 #pragma GCC unroll 8
             for (int d = 0; d < num_sfpu_iterations; d++)
             {
-                TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, load_base_addr + (d << 1));
+                TT_SFPLOAD(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, ckernel::math::SFPU_SRCS_BASE_ADDR + (d << 1));
                 // Multiply LREG0 * LREG0, store result in LREG0
                 TTI_SFPMUL(p_sfpu::LREG0, p_sfpu::LREG0, p_sfpu::LCONST_0, p_sfpu::LREG0, 0);
                 // Store result back to destination
                 TT_SFPSTORE(p_sfpu::LREG0, p_sfpu::sfpmem::DEFAULT, ADDR_MOD_7, 0, store_base_addr + (d << 1));
             }
 
-            _llk_math_eltwise_sfpu_srcs_clear_vlds_<true, true>(); // Clears dvalid for SFPU read and write
+            _llk_math_eltwise_sfpu_srcs_clear_vlds_<true /*SRCS_RD_DONE*/, true /*SRCS_WR_DONE*/>(); // Clears dvalid for SFPU read and write
         }
     }
 

--- a/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
@@ -11,6 +11,7 @@
 #include "llk_memory_checks.h"
 #include "perf.h"
 #include "profiler.h"
+#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
 // Globals
@@ -107,7 +108,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // handshake.
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
         }
 
         DataFormat math_format     = static_cast<DataFormat>(formats.math);
@@ -195,12 +196,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            auto cfg                                    = (std::uint32_t volatile*)TENSIX_CFG_BASE;
-            cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
+            set_up_zero_dest_dvalid_handshake_for_pack();
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
-            set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
         }
 
         // Full 32x32 tiles: 2x2 faces of 16x16 (tiny tiles not supported for quasar).

--- a/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
@@ -111,11 +111,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
         }
 
-        DataFormat math_format     = static_cast<DataFormat>(formats.math);
-        DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
+        DataFormat math_format = static_cast<DataFormat>(formats.math);
         if constexpr (is_fp32_dest_acc_en)
         {
-            if (pack_src_format == DataFormat::Int32)
+            if (static_cast<DataFormat>(formats.pack_src) == DataFormat::Int32)
             {
                 _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
             }

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_l1_acc_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_l1_acc_quasar_test.cpp
@@ -41,34 +41,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
+                set_up_unpack_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
             }
             else
             {
                 // CFG persists across run types, so non-L1_TO_L1 runs must not
                 // inherit the unpack-to-dest handshake.
                 set_up_zero_dest_dvalid_handshake_for_unpack();
-            }
-
-            DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-            if constexpr (is_fp32_dest_acc_en)
-            {
-                if (pack_src_format == DataFormat::Float32)
-                {
-                    _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>();
-                }
-                else if (pack_src_format == DataFormat::Int32)
-                {
-                    _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>();
-                }
-                else
-                {
-                    _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>();
-                }
-            }
-            else
-            {
-                _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>();
             }
         }
 
@@ -111,13 +90,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             if constexpr (!unpack_to_dest)
             {
+                const std::uint32_t src_handshake_iters = LOOP_FACTOR * TILE_CNT;
                 if constexpr (is_fp32_dest_acc_en)
                 {
-                    _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(LOOP_FACTOR * TILE_CNT);
+                    _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(src_handshake_iters);
                 }
                 else
                 {
-                    _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(LOOP_FACTOR * TILE_CNT);
+                    _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(src_handshake_iters);
                 }
             }
         }
@@ -180,30 +160,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
             // dest-dvalid handshake.
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+                set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
             }
 
             DataFormat math_format     = static_cast<DataFormat>(formats.math);
             DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-            if constexpr (is_fp32_dest_acc_en)
-            {
-                if (pack_src_format == DataFormat::Float32)
-                {
-                    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
-                }
-                else if (pack_src_format == DataFormat::Int32)
-                {
-                    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
-                }
-                else
-                {
-                    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
-                }
-            }
-            else
-            {
-                _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
-            }
+            configure_math_hardware_for_float32_int32_or_default<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, pack_src_format);
 
             _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(
                 num_faces * TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
@@ -219,13 +181,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
             else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
             {
+                const std::uint32_t src_handshake_iters = LOOP_FACTOR * num_blocks * tiles_in_block;
                 if constexpr (is_fp32_dest_acc_en)
                 {
-                    _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(LOOP_FACTOR * num_blocks * tiles_in_block);
+                    _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(src_handshake_iters);
                 }
                 else
                 {
-                    _perf_math_loop_clear_valid<true /*clear_a*/, false /*clear_b*/>(LOOP_FACTOR * num_blocks * tiles_in_block);
+                    _perf_math_loop_clear_valid<true /*clear_a*/, false /*clear_b*/>(src_handshake_iters);
                 }
             }
             else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
@@ -288,18 +251,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            auto cfg                                    = (std::uint32_t volatile*)TENSIX_CFG_BASE;
-            cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
+            set_up_zero_dest_dvalid_handshake_for_pack();
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
             if constexpr (unpack_to_dest)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
+                set_up_unpack_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
             }
             else
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+                set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
             }
         }
 

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_l1_acc_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_l1_acc_quasar_test.cpp
@@ -65,11 +65,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         if constexpr (unpack_to_dest)
         {
-            const std::uint32_t tiles_in_block = OUTPUT_NUM_TILES_IN_BLOCK;
             // ISSUE tt-llk #988: For unpack to dest cannot init the unpacker with 1 tile per unpack, because it will
             // keep writing to dest_idx=0.
             _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(
-                ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, tiles_in_block /*num_tiles_per_unpack*/);
+                ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, OUTPUT_NUM_TILES_IN_BLOCK /*num_tiles_per_unpack*/);
         }
         else
         {
@@ -80,8 +79,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
     {
         ZONE_SCOPED("TILE_LOOP")
-        const std::uint32_t tiles_in_block = OUTPUT_NUM_TILES_IN_BLOCK;
-        const std::uint32_t num_blocks     = static_cast<std::uint32_t>(OUTPUT_NUM_BLOCKS);
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
@@ -105,9 +102,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                for (std::uint32_t block = 0; block < num_blocks; block++)
+                for (std::uint32_t block = 0; block < static_cast<std::uint32_t>(OUTPUT_NUM_BLOCKS); block++)
                 {
-                    _llk_unpack_unary_operand_<SELECTED_UNPACKER>(block * tiles_in_block, ckernel::DEFAULT_TENSOR_SHAPE);
+                    _llk_unpack_unary_operand_<SELECTED_UNPACKER>(block * OUTPUT_NUM_TILES_IN_BLOCK, ckernel::DEFAULT_TENSOR_SHAPE);
                     if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
                     {
                         _llk_unpack_dest_dvalid_section_done_<dest_sync>();
@@ -163,9 +160,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
             }
 
-            DataFormat math_format     = static_cast<DataFormat>(formats.math);
-            DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-            configure_math_hardware_for_float32_int32_or_default<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, pack_src_format);
+            configure_math_hardware_for_float32_int32_or_default<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(
+                static_cast<DataFormat>(formats.math), static_cast<DataFormat>(formats.pack_src));
 
             _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(
                 num_faces * TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_quasar_test.cpp
@@ -33,7 +33,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A         = params.buffer_A;
 #endif
     constexpr std::uint32_t SELECTED_UNPACKER = unpack_to_dest ? p_unpacr::UNP_DEST : p_unpacr::UNP_A;
-    const std::uint32_t num_tiles_per_unpack  = TILE_CNT;
 
     {
         ZONE_SCOPED("INIT")
@@ -65,7 +64,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             _llk_unpack_configure_unary_<SELECTED_UNPACKER>(static_cast<DataFormat>(formats.unpack_A_dst));
         }
         _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(
-            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), tensor_shape_A, num_tiles_per_unpack);
+            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), tensor_shape_A, TILE_CNT);
         PROFILER_SYNC();
     }
     {
@@ -137,9 +136,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
             }
 
-            DataFormat math_format     = static_cast<DataFormat>(formats.math);
-            DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-            configure_math_hardware_for_float32_int32_or_default<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, pack_src_format);
+            configure_math_hardware_for_float32_int32_or_default<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(
+                static_cast<DataFormat>(formats.math), static_cast<DataFormat>(formats.pack_src));
 
             _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(
                 num_faces * TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
@@ -208,7 +206,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const int RELU_CONFIG           = params.RELU_CONFIG;
     const Operand& buffer_Res       = params.buffer_Res;
 #endif
-    const std::uint32_t num_tiles_per_pack = TILE_CNT;
 
     {
         ZONE_SCOPED("INIT")
@@ -235,7 +232,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         const ckernel::ReluConfig relu_config = ckernel::ReluConfig::from_packed(RELU_CONFIG);
-        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape_A, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape_A, TILE_CNT);
         _llk_pack_relu_config_<p_pacr::PACK0, is_fp32_dest_acc_en>(relu_config);
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_quasar_test.cpp
@@ -41,34 +41,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
+                set_up_unpack_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
             }
             else
             {
                 // CFG persists across run types, so isolates must not inherit
                 // the L1_TO_L1 unpack-to-dest handshake.
                 set_up_zero_dest_dvalid_handshake_for_unpack();
-            }
-
-            DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-            if constexpr (is_fp32_dest_acc_en)
-            {
-                if (pack_src_format == DataFormat::Float32)
-                {
-                    _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>();
-                }
-                else if (pack_src_format == DataFormat::Int32)
-                {
-                    _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>();
-                }
-                else
-                {
-                    _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>();
-                }
-            }
-            else
-            {
-                _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>();
             }
         }
 
@@ -100,13 +79,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             if constexpr (!unpack_to_dest)
             {
+                const std::uint32_t src_handshake_iters = LOOP_FACTOR * TILE_CNT;
                 if constexpr (is_fp32_dest_acc_en)
                 {
-                    _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(LOOP_FACTOR * TILE_CNT);
+                    _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(src_handshake_iters);
                 }
                 else
                 {
-                    _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(LOOP_FACTOR * TILE_CNT);
+                    _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(src_handshake_iters);
                 }
             }
         }
@@ -154,30 +134,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
             // handshake; the remaining isolate modes have no FPU consumer.
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+                set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
             }
 
             DataFormat math_format     = static_cast<DataFormat>(formats.math);
             DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-            if constexpr (is_fp32_dest_acc_en)
-            {
-                if (pack_src_format == DataFormat::Float32)
-                {
-                    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
-                }
-                else if (pack_src_format == DataFormat::Int32)
-                {
-                    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
-                }
-                else
-                {
-                    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
-                }
-            }
-            else
-            {
-                _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
-            }
+            configure_math_hardware_for_float32_int32_or_default<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, pack_src_format);
 
             _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(
                 num_faces * TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
@@ -190,13 +152,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
             else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
             {
+                const std::uint32_t src_handshake_iters = LOOP_FACTOR * TILE_CNT;
                 if constexpr (is_fp32_dest_acc_en)
                 {
-                    _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(LOOP_FACTOR * TILE_CNT);
+                    _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(src_handshake_iters);
                 }
                 else
                 {
-                    _perf_math_loop_clear_valid<true /*clear_a*/, false /*clear_b*/>(LOOP_FACTOR * TILE_CNT);
+                    _perf_math_loop_clear_valid<true /*clear_a*/, false /*clear_b*/>(src_handshake_iters);
                 }
             }
             else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
@@ -253,18 +216,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            std::uint32_t volatile* cfg                 = (std::uint32_t volatile*)TENSIX_CFG_BASE;
-            cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
+            set_up_zero_dest_dvalid_handshake_for_pack();
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
             if constexpr (unpack_to_dest)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
+                set_up_unpack_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
             }
             else
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+                set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
             }
         }
 

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_untilize_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_untilize_quasar_test.cpp
@@ -46,37 +46,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
             // persisted wait mask rather than leaving UNP_DEST blocked.
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
+                set_up_unpack_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
             }
             else
             {
                 set_up_zero_dest_dvalid_handshake_for_unpack();
             }
-
-            DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-            if constexpr (is_fp32_dest_acc_en)
-            {
-                if (pack_src_format == DataFormat::Float32)
-                {
-                    _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>();
-                }
-                else if (pack_src_format == DataFormat::Int32)
-                {
-                    _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>();
-                }
-                else
-                {
-                    _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>();
-                }
-            }
-            else
-            {
-                _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>();
-            }
         }
         else
         {
-            set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
         }
 
         unsigned l1_addr_16B;
@@ -126,15 +105,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
             if constexpr (!unpack_to_dest)
             {
                 // Math consumes every tile in every block row.
+                const std::uint32_t src_handshake_iters = LOOP_FACTOR * TILE_CNT;
                 if constexpr (is_fp32_dest_acc_en)
                 {
                     // 32-bit datacopy uses ELWADD and consumes both SrcA
                     // and the dummy SrcB produced by unpack.
-                    _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(LOOP_FACTOR * TILE_CNT);
+                    _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(src_handshake_iters);
                 }
                 else
                 {
-                    _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(LOOP_FACTOR * TILE_CNT);
+                    _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(src_handshake_iters);
                 }
             }
         }
@@ -191,30 +171,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
             // FPU→PACK dest-dvalid handshake (WH/BH style).
             if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE && PERF_RUN_TYPE != PerfRunType::L1_CONGESTION)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+                set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
             }
 
             DataFormat math_format     = static_cast<DataFormat>(formats.math);
             DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-            if constexpr (is_fp32_dest_acc_en)
-            {
-                if (pack_src_format == DataFormat::Float32)
-                {
-                    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
-                }
-                else if (pack_src_format == DataFormat::Int32)
-                {
-                    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
-                }
-                else
-                {
-                    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
-                }
-            }
-            else
-            {
-                _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
-            }
+            configure_math_hardware_for_float32_int32_or_default<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, pack_src_format);
 
             _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(
                 num_faces * TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
@@ -227,13 +189,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
             else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
             {
+                const std::uint32_t src_handshake_iters = LOOP_FACTOR * BLOCK_RT_DIM * BLOCK_CT_DIM;
                 if constexpr (is_fp32_dest_acc_en)
                 {
-                    _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(LOOP_FACTOR * BLOCK_RT_DIM * BLOCK_CT_DIM);
+                    _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(src_handshake_iters);
                 }
                 else
                 {
-                    _perf_math_loop_clear_valid<true /*clear_a*/, false /*clear_b*/>(LOOP_FACTOR * BLOCK_RT_DIM * BLOCK_CT_DIM);
+                    _perf_math_loop_clear_valid<true /*clear_a*/, false /*clear_b*/>(src_handshake_iters);
                 }
             }
             else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
@@ -295,18 +258,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            auto cfg                                    = (std::uint32_t volatile*)TENSIX_CFG_BASE;
-            cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
+            set_up_zero_dest_dvalid_handshake_for_pack();
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
             if constexpr (unpack_to_dest)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
+                set_up_unpack_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
             }
             else
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+                set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
             }
         }
 

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_untilize_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_untilize_quasar_test.cpp
@@ -34,7 +34,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_B         = params.buffer_B;
 #endif
     constexpr std::uint32_t SELECTED_UNPACKER = unpack_to_dest ? p_unpacr::UNP_DEST : p_unpacr::UNP_A;
-    const std::uint32_t num_tiles_per_unpack  = TILE_CNT;
     const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
 
     {
@@ -91,7 +90,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 _llk_unpack_configure_unary_<SELECTED_UNPACKER>(static_cast<DataFormat>(formats.unpack_A_dst));
             }
             _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(
-                ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), tensor_shape_A, num_tiles_per_unpack);
+                ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), tensor_shape_A, TILE_CNT);
         }
         PROFILER_SYNC();
     }
@@ -174,9 +173,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
             }
 
-            DataFormat math_format     = static_cast<DataFormat>(formats.math);
-            DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
-            configure_math_hardware_for_float32_int32_or_default<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, pack_src_format);
+            configure_math_hardware_for_float32_int32_or_default<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(
+                static_cast<DataFormat>(formats.math), static_cast<DataFormat>(formats.pack_src));
 
             _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(
                 num_faces * TEST_FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);

--- a/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
@@ -57,14 +57,15 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
+            const std::uint32_t scale_dvalids_per_tile = 1;
+            const std::uint32_t data_dvalids_per_tile  = num_faces;
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
                 for (std::uint32_t tile = 0; tile < TILE_CNT; tile++)
                 {
                     // Reduce unpack emits one persistent SrcB scale face,
                     // followed by all SrcA faces for each tile.
-                    _perf_unpack_loop_set_valid<false, true>(1);
-                    _perf_unpack_loop_set_valid<true, false>(num_faces);
+                    perf_unpack_set_srcb_once_then_srca_per_face(scale_dvalids_per_tile, data_dvalids_per_tile);
                 }
             }
         }
@@ -113,7 +114,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // PACK_ISOLATE measures pack alone (WH/BH style): skip FPU→PACK dest-dvalid.
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
         }
 
         if (use_int32_dest_alu)
@@ -146,12 +147,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
+            const std::uint32_t scale_dvalids_per_tile = 1;
+            const std::uint32_t data_dvalids_per_tile  = num_faces;
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
                 for (std::uint32_t tile = 0; tile < TILE_CNT; tile++)
                 {
-                    _perf_math_loop_clear_valid<true, false>(num_faces);
-                    _perf_math_loop_clear_valid<false, true>(1);
+                    perf_math_clear_srca_per_face_then_srcb_once(data_dvalids_per_tile, scale_dvalids_per_tile);
                 }
             }
         }
@@ -220,12 +222,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            auto cfg                                    = (std::uint32_t volatile*)TENSIX_CFG_BASE;
-            cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
+            set_up_zero_dest_dvalid_handshake_for_pack();
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
-            set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
         }
 
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);

--- a/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
@@ -108,6 +108,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const bool use_int32_dest_alu             = is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32;
     const bool is_int_fpu_en                  = use_int32_dest_alu && (REDUCE_DIM == ReduceDim::REDUCE_ROW || REDUCE_DIM == ReduceDim::REDUCE_SCALAR);
     const ckernel::TensorShape tensor_shape_A = tensor_shape_from_params(params);
+    constexpr std::uint32_t max_tiles_dest    = is_fp32_dest_acc_en ? 4 : 8;
 
     {
         ZONE_SCOPED("INIT")
@@ -165,13 +166,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 {
                     for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
                     {
-                        for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                        for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += max_tiles_dest)
                         {
-                            _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, true /* is_int_fpu_en */>(i, tensor_shape_A);
-                        }
-                        if constexpr (PERF_RUN_TYPE != PerfRunType::MATH_ISOLATE)
-                        {
-                            _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+                            const std::uint32_t block_tiles = std::min(TILE_CNT - block_start, max_tiles_dest);
+                            for (std::uint32_t block_tile = 0; block_tile < block_tiles; ++block_tile)
+                            {
+                                _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, true /* is_int_fpu_en */>(block_tile, tensor_shape_A);
+                            }
+                            if constexpr (PERF_RUN_TYPE != PerfRunType::MATH_ISOLATE)
+                            {
+                                _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+                            }
                         }
                     }
                 }
@@ -180,13 +185,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
                 {
-                    for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                    for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += max_tiles_dest)
                     {
-                        _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, false /* is_int_fpu_en */>(i, tensor_shape_A);
-                    }
-                    if constexpr (PERF_RUN_TYPE != PerfRunType::MATH_ISOLATE)
-                    {
-                        _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+                        const std::uint32_t block_tiles = std::min(TILE_CNT - block_start, max_tiles_dest);
+                        for (std::uint32_t block_tile = 0; block_tile < block_tiles; ++block_tile)
+                        {
+                            _llk_math_reduce_<POOL_TYPE, REDUCE_DIM, false /* is_int_fpu_en */>(block_tile, tensor_shape_A);
+                        }
+                        if constexpr (PERF_RUN_TYPE != PerfRunType::MATH_ISOLATE)
+                        {
+                            _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+                        }
                     }
                 }
             }
@@ -215,6 +224,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_Res       = params.buffer_Res;
 #endif
     const ckernel::TensorShape tensor_shape_A = tensor_shape_from_params(params);
+    constexpr std::uint32_t max_tiles_dest    = is_fp32_dest_acc_en ? 4 : 8;
 
     {
         ZONE_SCOPED("INIT")
@@ -244,13 +254,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                for (std::uint32_t i = 0; i < TILE_CNT; ++i)
+                for (std::uint32_t block_start = 0; block_start < TILE_CNT; block_start += max_tiles_dest)
                 {
-                    _llk_pack_(i, i, tensor_shape_A);
-                }
-                if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE && PERF_RUN_TYPE != PerfRunType::L1_CONGESTION)
-                {
-                    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+                    const std::uint32_t block_tiles = std::min(TILE_CNT - block_start, max_tiles_dest);
+                    for (std::uint32_t block_tile = 0; block_tile < block_tiles; ++block_tile)
+                    {
+                        _llk_pack_(block_tile, block_start + block_tile, tensor_shape_A);
+                    }
+                    if constexpr (PERF_RUN_TYPE != PerfRunType::PACK_ISOLATE && PERF_RUN_TYPE != PerfRunType::L1_CONGESTION)
+                    {
+                        _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+                    }
                 }
             }
         }

--- a/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
@@ -57,15 +57,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            const std::uint32_t scale_dvalids_per_tile = 1;
-            const std::uint32_t data_dvalids_per_tile  = num_faces;
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
                 for (std::uint32_t tile = 0; tile < TILE_CNT; tile++)
                 {
                     // Reduce unpack emits one persistent SrcB scale face,
                     // followed by all SrcA faces for each tile.
-                    perf_unpack_set_srcb_once_then_srca_per_face(scale_dvalids_per_tile, data_dvalids_per_tile);
+                    perf_unpack_set_srcb_once_then_srca_per_face(1 /*srcb_once_count*/, num_faces);
                 }
             }
         }
@@ -75,7 +73,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 for (std::uint32_t i = 0; i < TILE_CNT; ++i)
                 {
-                    _llk_unpack_reduce_(i, 0, tensor_shape_A);
+                    _llk_unpack_reduce_(i, 0 /*start_l1_tile_idx_1*/, tensor_shape_A);
                 }
             }
         }
@@ -104,8 +102,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t num_faces   = params.num_faces;
 #endif
     DataFormat src_format                     = static_cast<DataFormat>(formats.math);
-    DataFormat pack_src_format                = static_cast<DataFormat>(formats.pack_src);
-    const bool use_int32_dest_alu             = is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32;
+    const bool use_int32_dest_alu             = is_fp32_dest_acc_en && static_cast<DataFormat>(formats.pack_src) == DataFormat::Int32;
     const bool is_int_fpu_en                  = use_int32_dest_alu && (REDUCE_DIM == ReduceDim::REDUCE_ROW || REDUCE_DIM == ReduceDim::REDUCE_SCALAR);
     const ckernel::TensorShape tensor_shape_A = tensor_shape_from_params(params);
     constexpr std::uint32_t max_tiles_dest    = is_fp32_dest_acc_en ? 4 : 8;
@@ -120,7 +117,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         if (use_int32_dest_alu)
         {
-            _llk_math_srcAB_hw_configure_<false, false /* fp32 dest */, true /* int32 dest */>(src_format, src_format);
+            _llk_math_srcAB_hw_configure_<false /*EN_IMPLIED_MATH_FORMAT*/, false /* fp32 dest */, true /* int32 dest */>(src_format, src_format);
         }
         else
         {
@@ -148,13 +145,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            const std::uint32_t scale_dvalids_per_tile = 1;
-            const std::uint32_t data_dvalids_per_tile  = num_faces;
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
                 for (std::uint32_t tile = 0; tile < TILE_CNT; tile++)
                 {
-                    perf_math_clear_srca_per_face_then_srcb_once(data_dvalids_per_tile, scale_dvalids_per_tile);
+                    perf_math_clear_srca_per_face_then_srcb_once(num_faces, 1 /*srcb_once_count*/);
                 }
             }
         }

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_add_parallel_matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_add_parallel_matmul_quasar_test.cpp
@@ -78,7 +78,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
     set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
-    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false>(
+    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*EN_INT32_MATH_FORMAT*/>(
         static_cast<DataFormat>(formats.math), static_cast<DataFormat>(formats.math));
     _llk_math_matmul_init_<(ckernel::MathFidelity)MATH_FIDELITY, ENABLE_DIRECT_INDEXING, ENABLE_2X_FORMAT>(params.CT_DIM, params.RT_DIM);
 
@@ -109,7 +109,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const volatile FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t num_tiles = params.TILE_CNT;
 
     const bool PARAM_SRCS_32BIT_MODE                = _is_srcs_32bit_mode_(static_cast<DataFormat>(formats.unpack_S_dst));
     constexpr std::uint32_t PARAM_SRCS_XDIM         = srcs_dims::XDIM;
@@ -150,7 +149,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     bd_pack.f.y_dim       = PARAM_SRCS_YDIM;
     bd_pack.f.z_dim       = PARAM_SRCS_ZDIM;
     _configure_buf_desc_table_(buf_desc_id_pack, bd_pack);
-    _llk_pack_hw_configure_<p_pacr::PACK1, false>(static_cast<DataFormat>(formats.pack_S_src), ckernel::ReluConfig::none());
+    _llk_pack_hw_configure_<p_pacr::PACK1, false /*EN_32BIT_DEST*/>(static_cast<DataFormat>(formats.pack_S_src), ckernel::ReluConfig::none());
 
     cfg[DISABLE_IMPLIED_SRCS_FORMAT_ADDR32 + TRISC_ID] = !IMPLIED_MATH_FORMAT;
 
@@ -161,11 +160,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const int num_sfpu_iterations      = PARAM_SRCS_YDIM >> 1;
     const std::uint32_t replay_buf_len = num_sfpu_iterations * 4;
     load_replay_buf( // TODO: Replace with SFPI call (#1637)
-        0,
+        0 /*start*/,
         replay_buf_len,
-        false,
-        0,
-        0,
+        false /*exec_while_loading*/,
+        0 /*set_mutex*/,
+        0 /*last*/,
         [in0_base, in1_base, out_base, num_sfpu_iterations]
         {
 #pragma GCC unroll 4
@@ -181,7 +180,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_srcs_config_for_tile_<PARAM_SRCS_INSTRN_COUNT>(PARAM_SRCS_32BIT_MODE);
     _llk_math_eltwise_sfpu_init_();
 
-    for (std::uint32_t i = 0; i < num_tiles; ++i)
+    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
         TT_SET_SRC_TILE_FACE_ROW_IDX(p_set_inc_sel::TILE_SEL, p_unpacr::UNP_S, i * PARAM_SRCS_SLICE_COUNT);
 
@@ -205,14 +204,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
             TT_UNPACR2_TILE_INC(0b1 /*SrcS tile inc*/, 0b0 /*no L1 inc*/, buf_desc_id_unpack_0, 0b0 /*no dvalid*/);
             TT_UNPACR2_TILE_INC(0b0 /*no SrcS tile inc*/, 0b1 /*L1 inc*/, buf_desc_id_unpack_1, 0b1 /*Set dvalid*/);
             TT_REPLAY(0, replay_buf_len, 0, 0, 0, 0);
-            _llk_math_eltwise_sfpu_srcs_clear_vlds_<true, true>();
+            _llk_math_eltwise_sfpu_srcs_clear_vlds_<true /*SRCS_RD_DONE*/, true /*SRCS_WR_DONE*/>();
         }
 
 #pragma GCC unroll preload_count
         for (std::uint32_t j = 0; j < preload_count; j++)
         {
             TT_REPLAY(0, replay_buf_len, 0, 0, 0, 0);
-            _llk_math_eltwise_sfpu_srcs_clear_vlds_<true, true>();
+            _llk_math_eltwise_sfpu_srcs_clear_vlds_<true /*SRCS_RD_DONE*/, true /*SRCS_WR_DONE*/>();
         }
     }
 
@@ -246,9 +245,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _configure_buf_desc_table_(buf_desc_id_dst, bd_dst);
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-    _llk_pack_matmul_init_(buf_desc_id_dst, params.RT_DIM, params.CT_DIM, 1);
+    _llk_pack_matmul_init_(buf_desc_id_dst, params.RT_DIM, params.CT_DIM, 1 /*num_subblocks_c_dim*/);
 
-    _llk_pack_matmul_(0, 0);
+    _llk_pack_matmul_(0 /*start_math_dest_tile_idx*/, 0 /*start_l1_tile_idx*/);
     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }
 

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_exp_parallel_matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_exp_parallel_matmul_quasar_test.cpp
@@ -99,7 +99,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false>(
+        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*EN_INT32_MATH_FORMAT*/>(
             static_cast<DataFormat>(formats.math), static_cast<DataFormat>(formats.math));
         _llk_math_matmul_init_<(ckernel::MathFidelity)MATH_FIDELITY, ENABLE_DIRECT_INDEXING, ENABLE_2X_FORMAT>(CT_DIM, RT_DIM);
         PROFILER_SYNC();
@@ -183,7 +183,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // One MOP run issues one REPLAY per SrcS slice of a tile. The `done` bit on the final
     // LOADMACRO of each replay swaps the SrcS banks and resets the dvalids in hardware, so the
     // SFPU is paced purely by the dvalid handshake with the unpacker and packer.
-    ckernel_template mop(PARAM_SRCS_SLICE_COUNT, 1, _exp_loadmacro_op_(num_sfpu_iterations));
+    ckernel_template mop(PARAM_SRCS_SLICE_COUNT, 1 /*inner_loop_len*/, _exp_loadmacro_op_(num_sfpu_iterations));
 
     {
         ZONE_SCOPED("INIT")
@@ -192,7 +192,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_unpack_configure_unary_<p_unpacr::UNP_S>(static_cast<DataFormat>(formats.unpack_S_dst));
 
         _configure_buf_desc_table_(buf_desc_id_pack, ckernel::trisc::construct_buf_desc(srcs_shape, L1_ADDRESS(params.buffer_Res[0]), formats.pack_S_dst));
-        _llk_pack_hw_configure_<p_pacr::PACK1, false>(static_cast<DataFormat>(formats.pack_S_src), ckernel::ReluConfig::none());
+        _llk_pack_hw_configure_<p_pacr::PACK1, false /*EN_32BIT_DEST*/>(static_cast<DataFormat>(formats.pack_S_src), ckernel::ReluConfig::none());
 
         _llk_unpack_srcs_config_for_tile_<PARAM_SRCS_INSTRN_COUNT>(PARAM_SRCS_32BIT_MODE);
         _llk_pack_srcs_config_for_tile_<PARAM_SRCS_INSTRN_COUNT>(PARAM_SRCS_32BIT_MODE);
@@ -202,11 +202,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // be a compile-time constant, so branch on the runtime 32-bit mode into constexpr variants.
         if (PARAM_SRCS_32BIT_MODE)
         {
-            _exp_init_loadmacro_<2 * srcs_dims::ydim(true)>(load_base_addr, num_sfpu_iterations, load_sfpmem, store_sfpmem);
+            _exp_init_loadmacro_<2 * srcs_dims::ydim(true /*srcs_32bit_mode*/) /*STORE_OFFSET*/>(load_base_addr, num_sfpu_iterations, load_sfpmem, store_sfpmem);
         }
         else
         {
-            _exp_init_loadmacro_<2 * srcs_dims::ydim(false)>(load_base_addr, num_sfpu_iterations, load_sfpmem, store_sfpmem);
+            _exp_init_loadmacro_<2 * srcs_dims::ydim(false /*srcs_32bit_mode*/) /*STORE_OFFSET*/>(load_base_addr, num_sfpu_iterations, load_sfpmem, store_sfpmem);
         }
         mop.program(instrn_buffer);
         PROFILER_SYNC();
@@ -266,7 +266,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         const ckernel::TensorShape tensor_shape = ckernel::tensor_shape_from_num_faces(FACE_R_DIM, params.num_faces);
         _configure_buf_desc_table_(buf_desc_id_dst, ckernel::trisc::construct_buf_desc(tensor_shape, L1_ADDRESS(params.buffer_C[0]), formats.pack_dst));
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_matmul_init_(buf_desc_id_dst, RT_DIM, CT_DIM, 1);
+        _llk_pack_matmul_init_(buf_desc_id_dst, RT_DIM, CT_DIM, 1 /*num_subblocks_c_dim*/);
         PROFILER_SYNC();
     }
     {
@@ -278,14 +278,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                _llk_pack_matmul_(0, 0);
+                _llk_pack_matmul_(0 /*start_math_dest_tile_idx*/, 0 /*start_l1_tile_idx*/);
             }
         }
         else
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
-                _llk_pack_matmul_(0, 0);
+                _llk_pack_matmul_(0 /*start_math_dest_tile_idx*/, 0 /*start_l1_tile_idx*/);
                 _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
             }
         }

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_fill_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_fill_quasar_test.cpp
@@ -24,7 +24,7 @@ using namespace ckernel;
 //   T0 unpack: stage buffer_A from L1 into DEST via the unpack-to-dest path.
 //              The data is a placeholder — the SFPU overwrites every DEST lane.
 //   T1 math:   run _calculate_fill_int_ / _calculate_fill_ to write the constant
-//              (FILL_INT_VALUE or FILL_CONST) into every DEST lane.
+//              5 into every DEST lane.
 //   T2 pack:   pack the filled DEST tile out to buffer_Res in L1.
 
 // Returns true when the unpack source format is one of the integer formats supported
@@ -47,7 +47,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t num_tiles = params.TILE_CNT;
 
     // DEST DVALID handshake: T0 is the producer, T1 (SFPU) and T2 (PACK) are the consumers.
     // fill always uses unpack_to_dest (SFPU test — no FPU datacopy path).
@@ -73,8 +72,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // Configure unpacker → init unary operand path → unpack tile 0 from L1 into DEST.
     _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
     _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
-        ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles);
-    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0, ckernel::DEFAULT_TENSOR_SHAPE);
+        ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, params.TILE_CNT);
+    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0 /*l1_tile_idx*/, ckernel::DEFAULT_TENSOR_SHAPE);
 
     // Release DEST section to the SFPU consumer.
     _llk_unpack_dest_dvalid_section_done_<dest_sync>();
@@ -122,28 +121,24 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     if (is_int_fill)
     {
-        // Int path: _calculate_fill_int_ writes FILL_INT_VALUE to every element of Dest
+        // Int path: _calculate_fill_int_ writes 5 to every element of Dest
         // via SFPLOADI + SFPSTORE; the SFPMEM store mode is selected by FILL_INT_FORMAT
         // at compile time (no runtime dispatch).
-        constexpr std::uint32_t FILL_INT_VALUE = 5;
-
-        // Walk every tile in DEST starting at DST_INDEX, filling all lanes with FILL_INT_VALUE.
+        // Fill every DEST lane in each tile with integer value 5.
         for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
         {
             SFPU_UNARY_CALL(
-                dest_sync, is_fp32_dest_acc_en, _calculate_fill_int_, (FILL_INT_FORMAT, SFPU_ITERATIONS), params.DST_INDEX + i, VectorMode::RC, FILL_INT_VALUE);
+                dest_sync, is_fp32_dest_acc_en, _calculate_fill_int_, (FILL_INT_FORMAT, SFPU_ITERATIONS), params.DST_INDEX + i, VectorMode::RC, 5 /*value*/);
         }
     }
     else
     {
         // Float path: _calculate_fill_ uses SFPU DEFAULT store mode, which supports
         // all float formats (Float16, Float16_b, Float32).
-        constexpr float FILL_CONST = 5.0f;
-
-        // Walk every tile in DEST starting at DST_INDEX, filling all lanes with FILL_CONST.
+        // Walk every tile in DEST starting at DST_INDEX, filling all lanes with 5.0f.
         for (std::uint32_t i = 0; i < params.TILE_CNT; i++)
         {
-            SFPU_UNARY_CALL(dest_sync, is_fp32_dest_acc_en, _calculate_fill_, (SFPU_ITERATIONS), params.DST_INDEX + i, VectorMode::RC, FILL_CONST);
+            SFPU_UNARY_CALL(dest_sync, is_fp32_dest_acc_en, _calculate_fill_, (SFPU_ITERATIONS), params.DST_INDEX + i, VectorMode::RC, 5.0f /*value*/);
         }
     }
 
@@ -171,7 +166,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t num_tiles_per_pack = params.TILE_CNT;
 
     // PACK is the final consumer of the DEST DVALID chain.
     set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
@@ -184,8 +178,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // Configure pack engine 0 → init → pack tile from DST_INDEX into buffer_Res → release section.
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-    _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
-    _llk_pack_(params.DST_INDEX, 0, ckernel::DEFAULT_TENSOR_SHAPE);
+    _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, params.TILE_CNT);
+    _llk_pack_(params.DST_INDEX, 0 /*start_l1_tile_idx*/, ckernel::DEFAULT_TENSOR_SHAPE);
     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }
 #endif

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_trisc3_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_trisc3_quasar_test.cpp
@@ -24,7 +24,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t num_tiles = params.TILE_CNT;
 
     if (unpack_to_dest)
     {
@@ -50,8 +49,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
-        ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles);
-    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0, ckernel::DEFAULT_TENSOR_SHAPE);
+        ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, params.TILE_CNT);
+    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0 /*l1_tile_idx*/, ckernel::DEFAULT_TENSOR_SHAPE);
 
     if (unpack_to_dest)
     {
@@ -86,8 +85,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         DataFormat src_format = static_cast<DataFormat>(formats.math);
         _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, is_int_fpu_en>(src_format, src_format);
 
-        const std::uint32_t num_rows = params.num_faces * params.TEST_FACE_R_DIM;
-        _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(num_rows, 1);
+        _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(params.num_faces * params.TEST_FACE_R_DIM, 1 /*num_matrices*/);
 
         for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
         {
@@ -155,7 +153,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t num_tiles_per_pack = params.TILE_CNT;
 
     if (unpack_to_dest)
     {
@@ -170,8 +167,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
 
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-    _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
-    _llk_pack_(params.DST_INDEX, 0, ckernel::DEFAULT_TENSOR_SHAPE);
+    _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, params.TILE_CNT);
+    _llk_pack_(params.DST_INDEX, 0 /*start_l1_tile_idx*/, ckernel::DEFAULT_TENSOR_SHAPE);
     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }
 #endif

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_swiglu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_swiglu_quasar_test.cpp
@@ -25,13 +25,12 @@
 //   Dest:     tile 0 = gate, tile 1 = up, tile 2 = output
 //   buffer_Res: 1 output tile (the value of dest tile 2 packed out)
 // We unpack 2 tiles to Dest via the unary operand path (unpacker advances
-// through tiles 0,1 automatically with num_tiles=2).
+// through tiles 0,1 automatically from the init argument).
 void run_kernel(RUNTIME_PARAMETERS params)
 {
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t num_input_tiles = 2; // gate + up
 
     if (unpack_to_dest)
     {
@@ -59,8 +58,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
-        ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_input_tiles);
-    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0, ckernel::DEFAULT_TENSOR_SHAPE);
+        ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, 2 /*gate + up*/);
+    _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0 /*l1_tile_idx*/, ckernel::DEFAULT_TENSOR_SHAPE);
 
     if (unpack_to_dest)
     {
@@ -108,17 +107,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
     DataFormat src_format = static_cast<DataFormat>(formats.math);
     _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, is_int_fpu_en>(src_format, src_format);
 
-    constexpr std::uint32_t NUM_INPUT_TILES = 2; // gate + up
-
     if (!unpack_to_dest)
     {
         // FPU path: datacopy BOTH input tiles from SrcA to Dest before the
         // SFPU section reads them. Tile 0 = gate at Dest[0], tile 1 = up at
         // Dest[1].
-        const std::uint32_t num_rows = params.num_faces * params.TEST_FACE_R_DIM;
-        _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(num_rows, 1);
+        _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(params.num_faces * params.TEST_FACE_R_DIM, 1 /*num_matrices*/);
 
-        for (std::uint32_t i = 0; i < NUM_INPUT_TILES; ++i)
+        for (std::uint32_t i = 0; i < 2 /*gate + up*/; ++i)
         {
             _llk_math_eltwise_unary_datacopy_(params.DST_INDEX + i);
         }
@@ -180,8 +176,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    constexpr std::uint32_t num_output_tiles = 1;
-
     // Declare the same dvalid client chain that UNPACK/MATH used, seen from
     // PACK's side. The chain must match on all three threads.
     if (unpack_to_dest)
@@ -197,14 +191,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
 
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-    _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_output_tiles);
+    _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles*/);
 
     // Output lives at Dest tile index 2 — this is the layout *this driver*
     // uses (see "Layout used by this test" at the top of the file): gate=0,
     // up=1, out=2 relative to DST_INDEX. The kernel itself is layout-agnostic
     // and accepts arbitrary (gate, up, out) Dest offsets via
     // `_calculate_swiglu_`'s parameters; +2 is not a property of swiglu.
-    _llk_pack_(params.DST_INDEX + 2, 0, ckernel::DEFAULT_TENSOR_SHAPE);
+    _llk_pack_(params.DST_INDEX + 2 /*start_math_dest_tile_idx*/, 0 /*start_l1_tile_idx*/, ckernel::DEFAULT_TENSOR_SHAPE);
     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }
 #endif

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_topk_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_topk_quasar_test.cpp
@@ -101,8 +101,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     const std::uint32_t unpack_src_format = unpack_src_data_types[stage_index];
                     const std::uint32_t unpack_dst_format = unpack_dst_data_types[stage_index];
 
-                    const int stage_offset = stage_index * NUM_VALUE_TILES_PER_ROW;
-
                     ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
                         ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_A[0]), unpack_src_format);
                     _llk_unpack_configure_unary_<p_unpacr::UNP_A>(static_cast<DataFormat>(unpack_dst_format));
@@ -110,15 +108,15 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     if (first_iteration)
                     {
                         _llk_unpack_unary_operand_init_<p_unpacr::UNP_A, true /*transpose*/, is_fp32_dest_acc_en>(
-                            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1);
+                            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles*/);
                     }
                     else
                     {
                         _llk_unpack_unary_operand_init_<p_unpacr::UNP_A, false /*transpose*/, is_fp32_dest_acc_en>(
-                            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1);
+                            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles*/);
                     }
 
-                    const int first_tile_index  = tile_row_offset + stage_offset + tile_pair_offset;
+                    const int first_tile_index  = tile_row_offset + stage_index * NUM_VALUE_TILES_PER_ROW + tile_pair_offset;
                     const int second_tile_index = first_tile_index + distance;
                     _llk_unpack_unary_operand_<p_unpacr::UNP_A>(first_tile_index, ckernel::DEFAULT_TENSOR_SHAPE);
                     _llk_unpack_unary_operand_<p_unpacr::UNP_A>(second_tile_index, ckernel::DEFAULT_TENSOR_SHAPE);
@@ -162,9 +160,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     constexpr bool APPROX             = false;
     constexpr std::uint32_t dst_index = 0;
     const int end_phase               = TOPK_LOGK - 1;
-    constexpr int start_phase         = 0;
-    constexpr int end_step            = 0;
-    constexpr int start_step          = 0;
 
     // Dest dvalid sync chain: FPU (datacopy) -> SFPU (topk) -> PACK. Math thread owns
     // both the FPU and SFPU clients.
@@ -178,7 +173,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // Datacopy 4 tiles (2 value + 2 index) from SRC to DEST; the FPU dvalid
     // wait gates the writes until pack releases the bank.
-    const std::uint32_t num_rows = 4 * FACE_R_DIM;
 
     // The index datacopy intentionally leaves ALU_FORMAT_SPEC_REG set to Int16.
     // Restore the value format before the SFPU network; the TopK value
@@ -196,10 +190,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
             for (int current_tile_pair_idx = 0; current_tile_pair_idx < num_pairs; ++current_tile_pair_idx)
             {
-                // The datacopy addrmod/MOP depend only on num_rows (constant), not on the
-                // per-stage format, so configure once per pair. The SFPU topk ops below may
+                // The datacopy addrmod/MOP depend only on the constant row count, not on
+                // the per-stage format, so configure once per pair. The SFPU topk ops below may
                 // reprogram bank0, so this stays inside the pipeline loop.
-                _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(num_rows, 1);
+                _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en>(4 * FACE_R_DIM /*num_rows_per_matrix*/, 1 /*num_matrices*/);
 
                 for (Stage stage : {Stage::Values, Stage::Indices})
                 {
@@ -234,9 +228,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
                         VectorMode::RC_custom,
                         TOPK_SORT_DIRECTION,
                         end_phase,
-                        start_phase,
-                        end_step,
-                        start_step);
+                        0 /*start_phase*/,
+                        0 /*end_step*/,
+                        0 /*start_step*/);
                 }
                 else
                 {
@@ -342,30 +336,26 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     const std::uint32_t pack_src_format = pack_src_data_types[stage_index];
                     const std::uint32_t pack_dst_format = pack_dst_data_types[stage_index];
 
-                    const int tile_dest_offset = stage_index * NUM_TILES_PER_STAGE;
-
                     // Configure the per-stage format and L1 address for packing.
                     std::uint32_t l1_addr_16B;
                     if (last_iter)
                     {
-                        const int tile_row_offset = current_tile_row * NUM_TILES_IN_RESULT_BUFFER_PER_ROW;
-                        const int tile_L1_offset  = tile_row_offset + stage_index;
+                        const int tile_L1_offset = current_tile_row * NUM_TILES_IN_RESULT_BUFFER_PER_ROW + stage_index;
                         l1_addr_16B               = params.buffer_Res[tile_L1_offset] / 16;
                     }
                     else
                     {
                         const int tile_row_offset  = current_tile_row * params.FULL_CT_DIM;
                         const int tile_pair_offset = current_tile_pair_idx * (distance * NUM_TILES_PER_STAGE);
-                        const int stage_offset     = stage_index * NUM_VALUE_TILES_PER_ROW;
-                        const int tile_L1_offset   = tile_row_offset + stage_offset + tile_pair_offset;
+                        const int tile_L1_offset   = tile_row_offset + stage_index * NUM_VALUE_TILES_PER_ROW + tile_pair_offset;
                         l1_addr_16B                = params.buffer_A[tile_L1_offset] / 16;
                     }
 
                     ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, l1_addr_16B, pack_dst_format);
-                    _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1);
+                    _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles*/);
 
                     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(pack_src_format), ckernel::ReluConfig::none());
-                    _llk_pack_(tile_dest_offset, 0, ckernel::DEFAULT_TENSOR_SHAPE);
+                    _llk_pack_(stage_index * NUM_TILES_PER_STAGE, 0 /*start_l1_tile_idx*/, ckernel::DEFAULT_TENSOR_SHAPE);
 
                 } // Stage loop.
 

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_where_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_where_quasar_test.cpp
@@ -22,7 +22,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t num_tiles_per_unpack = params.TILE_CNT;
 
     // UNPACK-to-DEST path: UNPACK writes DEST; SFPU reads/writes DEST; PACK reads DEST.
     // FPU path: UNPACK writes SrcA; FPU datacopy writes DEST; SFPU reads/writes DEST; PACK reads DEST.
@@ -49,10 +48,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
-        ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_unpack);
+        ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, params.TILE_CNT);
 
     // Unpacks all three input tiles (cond, true_val, false_val) from buffer_A in one call;
-    // tile count is taken from num_tiles_per_unpack set during init.
+    // tile count is taken from the init argument.
     _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0 /*l1_tile_idx*/, ckernel::DEFAULT_TENSOR_SHAPE);
 
     if constexpr (unpack_to_dest)
@@ -100,8 +99,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     if constexpr (!unpack_to_dest)
     {
-        const std::uint32_t num_rows = params.num_faces * params.TEST_FACE_R_DIM;
-        _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(num_rows, 1);
+        _llk_math_eltwise_unary_datacopy_init_<DATA_COPY_TYPE, is_fp32_dest_acc_en>(params.num_faces * params.TEST_FACE_R_DIM, 1 /*num_matrices*/);
 
         for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
         {
@@ -146,7 +144,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t num_tiles_per_pack = 1;
 
     constexpr auto unpack_dest = unpack_to_dest ? dest_dvalid_client::UNPACK : dest_dvalid_client::FPU;
     set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({unpack_dest, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
@@ -155,11 +152,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
 
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-    _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+    _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles*/);
 
     // Packs only the result tile (DEST[DST_INDEX]); where produces one output tile
     // regardless of how many input tiles were loaded.
-    _llk_pack_(params.DST_INDEX, 0, ckernel::DEFAULT_TENSOR_SHAPE);
+    _llk_pack_(params.DST_INDEX, 0 /*start_l1_tile_idx*/, ckernel::DEFAULT_TENSOR_SHAPE);
     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }
 

--- a/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
@@ -42,7 +42,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+                set_up_unpack_to_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
             }
             else
             {
@@ -53,7 +53,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else
         {
-            set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
         }
 
         unsigned l1_addr_16B;
@@ -89,9 +89,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            // Real unpack produces all SrcA tiles first, then the dummy SrcB
-            // tiles consumed by transpose. Preserve that ordering: the two
-            // MOPs cannot be mocked as one simultaneous SrcAB handshake.
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
                 for (std::uint32_t block = 0; block < num_blocks; block++)
@@ -210,28 +207,21 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             if constexpr (!unpack_to_dest)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+                set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
             }
             else
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::UNPACK, dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+                set_up_unpack_to_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
             }
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
             // Math isolate has no destination producer before FPU, so make FPU
             // the producer and restore immediate ownership of the destination.
-            set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
         }
 
-        if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
-        {
-            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
-        }
-        else
-        {
-            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>(math_format, math_format);
-        }
+        configure_math_hardware_for_float32_int32_or_default<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, pack_src_format);
         PROFILER_SYNC();
     }
     {
@@ -296,18 +286,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            auto cfg                                    = (volatile std::uint32_t*)TENSIX_CFG_BASE;
-            cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
+            set_up_zero_dest_dvalid_handshake_for_pack();
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
             if constexpr (unpack_to_dest)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+                set_up_unpack_to_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
             }
             else
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+                set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
             }
         }
 

--- a/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
@@ -98,7 +98,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 {
                     if constexpr (!unpack_to_dest)
                     {
-                        _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(tiles_in_block);
+                        // FP32 datacopy uses ELWADD, so SrcA and SrcB must become
+                        // valid together before the separate transpose SrcB batch.
+                        _perf_unpack_loop_set_valid<true /*set_a*/, is_fp32_dest_acc_en /*set_b*/>(tiles_in_block);
                     }
                     _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(tiles_in_block);
                 }
@@ -242,7 +244,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 {
                     if constexpr (!unpack_to_dest)
                     {
-                        _perf_math_loop_clear_valid<true /*clear_a*/, false /*clear_b*/>(tiles_in_block);
+                        // Match real 32-bit unpack: datacopy consumes and clears
+                        // paired SrcA/SrcB before transpose consumes dummy SrcB.
+                        _perf_math_loop_clear_valid<true /*clear_a*/, is_fp32_dest_acc_en /*clear_b*/>(tiles_in_block);
                     }
                     _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(tiles_in_block);
                 }

--- a/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
@@ -91,12 +91,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
+                // Match real unpack's per-block ordering. Batching all SrcA
+                // blocks before SrcB deadlocks once the test spans multiple
+                // DEST blocks because math consumes SrcA then SrcB per block.
                 for (std::uint32_t block = 0; block < num_blocks; block++)
                 {
                     if constexpr (!unpack_to_dest)
                     {
-                        // ELWADD is used for Mov2D operation when Dest is in 32bit mode, so we need to set both SrcA and SrcB valid
-                        _perf_unpack_loop_set_valid<true /*set_a*/, is_fp32_dest_acc_en ? true : false /*set_b*/>(tiles_in_block);
+                        _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(tiles_in_block);
                     }
                     _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(tiles_in_block);
                 }
@@ -231,15 +233,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            // Real unpack emits SrcA and dummy SrcB as two ordered batches.
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
+                // Real unpack emits SrcA then dummy SrcB for each block.
+                // Clearing all SrcA blocks first waits on data that unpack
+                // cannot produce until the preceding SrcB block is consumed.
                 for (std::uint32_t block = 0; block < num_blocks; block++)
                 {
                     if constexpr (!unpack_to_dest)
                     {
-                        // ELWADD is used for Mov2D operation when Dest is in 32bit mode, so we need to clear both SrcA and SrcB valid
-                        _perf_math_loop_clear_valid<true /*clear_a*/, is_fp32_dest_acc_en ? true : false /*clear_b*/>(tiles_in_block);
+                        _perf_math_loop_clear_valid<true /*clear_a*/, false /*clear_b*/>(tiles_in_block);
                     }
                     _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(tiles_in_block);
                 }

--- a/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
@@ -34,7 +34,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A            = params.buffer_A;
     const Operand& buffer_B            = params.buffer_B;
 #endif
-    const std::uint32_t num_tiles_per_unpack = tiles_in_block;
 
     {
         ZONE_SCOPED("INIT")
@@ -79,7 +78,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
 
         _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
-            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_unpack);
+            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, tiles_in_block);
         PROFILER_SYNC();
     }
     {
@@ -203,8 +202,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
     const int DST_INDEX                 = params.DST_INDEX;
 #endif
-    const DataFormat math_format     = static_cast<DataFormat>(formats.math);
-    const DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
+    const DataFormat math_format = static_cast<DataFormat>(formats.math);
     {
         ZONE_SCOPED("INIT")
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
@@ -225,7 +223,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
         }
 
-        configure_math_hardware_for_float32_int32_or_default<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, pack_src_format);
+        configure_math_hardware_for_float32_int32_or_default<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en>(math_format, static_cast<DataFormat>(formats.pack_src));
         PROFILER_SYNC();
     }
     {
@@ -285,7 +283,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const int DST_INDEX                       = params.DST_INDEX;
     const Operand& buffer_Res                 = params.buffer_Res;
 #endif
-    const std::uint32_t num_tiles_per_pack = output_tiles_in_block;
 
     {
         ZONE_SCOPED("INIT")
@@ -310,7 +307,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
             TENSOR_SHAPE_FROM_PARAMS(params), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, output_tiles_in_block);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp
@@ -67,14 +67,15 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
+            const std::uint32_t scale_dvalids_per_tile = 1;
+            const std::uint32_t data_dvalids_per_tile  = num_faces;
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
                 for (std::uint32_t tile = 0; tile < TILE_CNT; tile++)
                 {
                     // The strided reduce MOP emits one SrcB scale face and
                     // all SrcA data faces for each tile.
-                    _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(1 /*iterations*/);
-                    _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(num_faces);
+                    perf_unpack_set_srcb_once_then_srca_per_face(scale_dvalids_per_tile, data_dvalids_per_tile);
                 }
             }
         }
@@ -126,7 +127,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // handshake.
         if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
         }
 
         DataFormat math_format     = static_cast<DataFormat>(formats.math);
@@ -157,12 +158,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
+            const std::uint32_t scale_dvalids_per_tile = 1;
+            const std::uint32_t data_dvalids_per_tile  = num_faces;
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
                 for (std::uint32_t tile = 0; tile < TILE_CNT; tile++)
                 {
-                    _perf_math_loop_clear_valid<true /*clear_a*/, false /*clear_b*/>(num_faces);
-                    _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(1 /*iterations*/);
+                    perf_math_clear_srca_per_face_then_srcb_once(data_dvalids_per_tile, scale_dvalids_per_tile);
                 }
             }
         }
@@ -219,12 +221,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            auto cfg                                    = (std::uint32_t volatile*)TENSIX_CFG_BASE;
-            cfg[PACK_DEST_DVALID_CTRL_wait_mask_ADDR32] = 0;
+            set_up_zero_dest_dvalid_handshake_for_pack();
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
         {
-            set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
         }
 
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp
@@ -67,15 +67,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            const std::uint32_t scale_dvalids_per_tile = 1;
-            const std::uint32_t data_dvalids_per_tile  = num_faces;
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
                 for (std::uint32_t tile = 0; tile < TILE_CNT; tile++)
                 {
                     // The strided reduce MOP emits one SrcB scale face and
                     // all SrcA data faces for each tile.
-                    perf_unpack_set_srcb_once_then_srca_per_face(scale_dvalids_per_tile, data_dvalids_per_tile);
+                    perf_unpack_set_srcb_once_then_srca_per_face(1 /*srcb_once_count*/, num_faces);
                 }
             }
         }
@@ -85,10 +83,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 for (std::uint32_t block_rt = 0; block_rt < BLOCK_RT_DIM; block_rt++)
                 {
-                    std::uint32_t offset = block_rt * y_stride_external;
                     for (std::uint32_t block_ct = 0; block_ct < BLOCK_CT_DIM; block_ct++)
                     {
-                        const std::uint32_t l1_unpack_tilize_idx = offset + block_ct;
+                        const std::uint32_t l1_unpack_tilize_idx = block_rt * y_stride_external + block_ct;
                         _llk_unpack_reduce_col_tilizeA_strided_(tensor_shape, l1_unpack_tilize_idx, 0 /*start_l1_tile_idx_1*/);
                     }
                 }
@@ -130,11 +127,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
         }
 
-        DataFormat math_format     = static_cast<DataFormat>(formats.math);
-        DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
+        DataFormat math_format = static_cast<DataFormat>(formats.math);
         if constexpr (is_fp32_dest_acc_en)
         {
-            if (pack_src_format == DataFormat::Int32)
+            if (static_cast<DataFormat>(formats.pack_src) == DataFormat::Int32)
             {
                 _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
             }
@@ -158,13 +154,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
         {
-            const std::uint32_t scale_dvalids_per_tile = 1;
-            const std::uint32_t data_dvalids_per_tile  = num_faces;
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
                 for (std::uint32_t tile = 0; tile < TILE_CNT; tile++)
                 {
-                    perf_math_clear_srca_per_face_then_srcb_once(data_dvalids_per_tile, scale_dvalids_per_tile);
+                    perf_math_clear_srca_per_face_then_srcb_once(num_faces, 1 /*srcb_once_count*/);
                 }
             }
         }
@@ -212,8 +206,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t TILE_CNT    = params.TILE_CNT;
     const Operand& buffer_Res       = params.buffer_Res;
 #endif
-    const std::uint32_t num_tiles_per_pack = TILE_CNT;
-    const auto tensor_shape                = tensor_shape_from_params(params);
+    const auto tensor_shape = tensor_shape_from_params(params);
 
     {
         ZONE_SCOPED("INIT")
@@ -231,7 +224,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
 
-        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape, TILE_CNT);
         _llk_pack_reduce_mask_config_<REDUCE_DIM>(tensor_shape);
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_tilize_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_tilize_quasar_test.cpp
@@ -39,7 +39,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
+                set_up_unpack_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
             }
             else
             {
@@ -65,7 +65,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else
         {
-            set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
         }
 
         const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
@@ -123,7 +123,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // Quasar fused tilize emits one SrcA dvalid per tile: BLOCK_CT_DIM dvalids per
         // `_llk_unpack_tilize_` call and BLOCK_RT_DIM calls per outer loop. With
         // is_fp32_dest_acc_en it also pulses SrcB because FP32 datacopy uses ELWADD.
-        const std::uint32_t total_tilize_dvalids = LOOP_FACTOR * BLOCK_RT_DIM * BLOCK_CT_DIM;
+        const std::uint32_t src_handshake_iters = LOOP_FACTOR * BLOCK_RT_DIM * BLOCK_CT_DIM;
 
         if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE)
         {
@@ -132,15 +132,15 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             if constexpr (is_fp32_dest_acc_en)
             {
-                _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(total_tilize_dvalids);
+                _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(src_handshake_iters);
             }
             else if constexpr (DATA_COPY_TYPE == DataCopyType::A2D)
             {
-                _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(total_tilize_dvalids);
+                _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(src_handshake_iters);
             }
             else
             {
-                _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(total_tilize_dvalids);
+                _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(src_handshake_iters);
             }
         }
         else
@@ -213,7 +213,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             // dest-dvalid handshake.
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+                set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
             }
 
             DataFormat src_format = static_cast<DataFormat>(formats.math);
@@ -231,18 +231,18 @@ void run_kernel(RUNTIME_PARAMETERS params)
             else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
             {
                 // Match tilize producer: SrcA only, or SrcA+SrcB when FP32 dest uses ELWADD.
-                const std::uint32_t total_tilize_dvalids = LOOP_FACTOR * TILE_CNT;
+                const std::uint32_t src_handshake_iters = LOOP_FACTOR * TILE_CNT;
                 if constexpr (is_fp32_dest_acc_en)
                 {
-                    _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(total_tilize_dvalids);
+                    _perf_math_loop_clear_valid<true /*clear_a*/, true /*clear_b*/>(src_handshake_iters);
                 }
                 else if constexpr (DATA_COPY_TYPE == DataCopyType::A2D)
                 {
-                    _perf_math_loop_clear_valid<true /*clear_a*/, false /*clear_b*/>(total_tilize_dvalids);
+                    _perf_math_loop_clear_valid<true /*clear_a*/, false /*clear_b*/>(src_handshake_iters);
                 }
                 else
                 {
-                    _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(total_tilize_dvalids);
+                    _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(src_handshake_iters);
                 }
             }
             else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_tilize_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_tilize_quasar_test.cpp
@@ -296,7 +296,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t TILE_CNT    = params.TILE_CNT;
     const Operand& buffer_Res       = params.buffer_Res;
 #endif
-    const std::uint32_t num_tiles_per_pack = TILE_CNT;
 
     {
         ZONE_SCOPED("INIT")
@@ -316,7 +315,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(tensor_shape, L1_ADDRESS(buffer_Res[0]) /*l1_addr_16B*/, formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none() /*relu_config*/);
-        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape, TILE_CNT);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_tilize_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_tilize_quasar_test.cpp
@@ -37,7 +37,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ZONE_SCOPED("INIT")
         if constexpr (unpack_to_dest)
         {
-            if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+            // UNP_DEST and PACK share DEST. Keep them on the producer/consumer
+            // chain in the congestion run as well; disabling the handshake lets
+            // both threads access the same DEST section and eventually timeout.
+            if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
             {
                 set_up_unpack_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
             }
@@ -130,17 +133,20 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            if constexpr (is_fp32_dest_acc_en)
+            if constexpr (!unpack_to_dest)
             {
-                _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(src_handshake_iters);
-            }
-            else if constexpr (DATA_COPY_TYPE == DataCopyType::A2D)
-            {
-                _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(src_handshake_iters);
-            }
-            else
-            {
-                _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(src_handshake_iters);
+                if constexpr (is_fp32_dest_acc_en)
+                {
+                    _perf_unpack_loop_set_valid<true /*set_a*/, true /*set_b*/>(src_handshake_iters);
+                }
+                else if constexpr (DATA_COPY_TYPE == DataCopyType::A2D)
+                {
+                    _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(src_handshake_iters);
+                }
+                else
+                {
+                    _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(src_handshake_iters);
+                }
             }
         }
         else
@@ -153,7 +159,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     {
                         _llk_unpack_tilize_block_(y * y_stride_external /*l1_face_idx*/, y * BLOCK_CT_DIM /*dest_tile_idx*/);
                     }
-                    if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+                    if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
                     {
                         _llk_unpack_dest_dvalid_section_done_<dest_sync>();
                     }
@@ -294,15 +300,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     {
         ZONE_SCOPED("INIT")
-        // PACK_ISOLATE / L1_CONGESTION: no math↔pack dest-dvalid handshake (WH/BH tilize perf).
-        // Math only clears src dvalids in L1_CONGESTION, so waiting on section_done times out
-        // (~28k/iter) and leaves dest-dvalid CFG wedged for later L1_TO_L1 on the same simulator.
-        // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
-        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        // PACK_ISOLATE and SrcA/SrcB L1_CONGESTION have no active DEST producer,
+        // so they must clear the persisted pack wait mask. UNP_DEST congestion
+        // instead uses the unpack→pack chain because both threads share DEST.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || (PERF_RUN_TYPE == PerfRunType::L1_CONGESTION && !unpack_to_dest))
         {
             set_up_zero_dest_dvalid_handshake_for_pack();
         }
-        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || (PERF_RUN_TYPE == PerfRunType::L1_CONGESTION && unpack_to_dest))
         {
             constexpr auto dest_producer = unpack_to_dest ? dest_dvalid_client::UNPACK : dest_dvalid_client::FPU;
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_producer, dest_dvalid_client::PACK});
@@ -320,11 +325,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
         {
         }
-        else if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || (PERF_RUN_TYPE == PerfRunType::L1_CONGESTION && !unpack_to_dest))
         {
-            // No dest-dvalid section_done: WH/BH L1_CONGESTION packs without math handshake
-            // (math is only a src-clear mock). Per-iter section_done was causing ~28k stalls and
-            // poisoning subsequent L1_TO_L1 on the persistent Quasar simulator.
+            // No section_done without an active DEST producer. In SrcA/SrcB
+            // congestion math only clears source dvalids; it does not produce DEST.
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
                 _llk_pack_(0 /*start_math_dest_tile_idx*/, 0 /*start_l1_tile_idx*/, tensor_shape);

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
@@ -41,7 +41,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
+                set_up_unpack_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
             }
             else
             {
@@ -53,7 +53,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else
         {
-            set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+            set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
         }
 
         const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
@@ -96,13 +96,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
+            const std::uint32_t src_handshake_iters = LOOP_FACTOR;
             if constexpr (DATA_COPY_TYPE == DataCopyType::A2D)
             {
-                _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(LOOP_FACTOR);
+                _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(src_handshake_iters);
             }
             else
             {
-                _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(LOOP_FACTOR);
+                _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(src_handshake_iters);
             }
         }
         else
@@ -155,7 +156,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             // dest-dvalid handshake.
             if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+                set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
             }
 
             DataFormat src_format = static_cast<DataFormat>(formats.math);
@@ -172,13 +173,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
             else if constexpr (PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
             {
+                const std::uint32_t src_handshake_iters = LOOP_FACTOR * TILE_CNT;
                 if constexpr (DATA_COPY_TYPE == DataCopyType::A2D)
                 {
-                    _perf_math_loop_clear_valid<true /*clear_a*/, false /*clear_b*/>(LOOP_FACTOR * TILE_CNT);
+                    _perf_math_loop_clear_valid<true /*clear_a*/, false /*clear_b*/>(src_handshake_iters);
                 }
                 else
                 {
-                    _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(LOOP_FACTOR * TILE_CNT);
+                    _perf_math_loop_clear_valid<false /*clear_a*/, true /*clear_b*/>(src_handshake_iters);
                 }
             }
             else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
@@ -240,11 +242,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             if constexpr (unpack_to_dest)
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::PACK});
+                set_up_unpack_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
             }
             else
             {
-                set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
+                set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
             }
         }
 

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
@@ -39,14 +39,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ZONE_SCOPED("INIT")
         if constexpr (unpack_to_dest)
         {
-            if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+            if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
             {
                 set_up_unpack_to_pack_dest_dvalid_chain<dest_dvalid_client::UNPACK>();
             }
             else
             {
-                // CFG persists across run types, so non-L1_TO_L1 runs must not
-                // inherit the unpack-to-dest handshake.
+                // Isolates have no unpack-to-DEST consumer pulse and must not
+                // inherit a handshake from a preceding run type.
                 set_up_zero_dest_dvalid_handshake_for_unpack();
             }
             _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*is_int_fpu_en*/>();
@@ -96,14 +96,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         else if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE)
         {
-            const std::uint32_t src_handshake_iters = LOOP_FACTOR;
-            if constexpr (DATA_COPY_TYPE == DataCopyType::A2D)
+            if constexpr (!unpack_to_dest)
             {
-                _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(src_handshake_iters);
-            }
-            else
-            {
-                _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(src_handshake_iters);
+                const std::uint32_t src_handshake_iters = LOOP_FACTOR * TILE_CNT;
+                if constexpr (DATA_COPY_TYPE == DataCopyType::A2D)
+                {
+                    _perf_unpack_loop_set_valid<true /*set_a*/, false /*set_b*/>(src_handshake_iters);
+                }
+                else
+                {
+                    _perf_unpack_loop_set_valid<false /*set_a*/, true /*set_b*/>(src_handshake_iters);
+                }
             }
         }
         else
@@ -111,7 +114,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
                 _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0 /*l1_tile_idx*/, tensor_shape_A);
-                if constexpr (unpack_to_dest && PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+                if constexpr (unpack_to_dest && (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION))
                 {
                     _llk_unpack_dest_dvalid_section_done_<dest_sync>();
                 }
@@ -232,13 +235,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     {
         ZONE_SCOPED("INIT")
-        // PACK_ISOLATE and L1_CONGESTION pack without a math↔pack handshake.
-        // Explicitly clear wait_mask — CFG can persist across run-types in the same session.
-        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        // PACK_ISOLATE and SrcA/SrcB L1_CONGESTION have no DEST producer.
+        // Explicitly clear wait_mask because CFG persists across run types.
+        if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || (PERF_RUN_TYPE == PerfRunType::L1_CONGESTION && !unpack_to_dest))
         {
             set_up_zero_dest_dvalid_handshake_for_pack();
         }
-        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1)
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::L1_TO_L1 || (PERF_RUN_TYPE == PerfRunType::L1_CONGESTION && unpack_to_dest))
         {
             if constexpr (unpack_to_dest)
             {
@@ -264,7 +267,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         if constexpr (PERF_RUN_TYPE == PerfRunType::MATH_ISOLATE || PERF_RUN_TYPE == PerfRunType::UNPACK_ISOLATE)
         {
         }
-        else if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || PERF_RUN_TYPE == PerfRunType::L1_CONGESTION)
+        else if constexpr (PERF_RUN_TYPE == PerfRunType::PACK_ISOLATE || (PERF_RUN_TYPE == PerfRunType::L1_CONGESTION && !unpack_to_dest))
         {
             // No dest-dvalid section_done: WH/BH isolate packs without math handshake.
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
@@ -33,7 +33,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A         = params.buffer_A;
     const Operand& buffer_B         = params.buffer_B;
 #endif
-    const std::uint32_t num_tiles_per_unpack = TILE_CNT;
 
     {
         ZONE_SCOPED("INIT")
@@ -84,7 +83,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
 
         _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, TRANSPOSE_EN, is_fp32_dest_acc_en>(
-            ckernel::trisc::bfd_current<unp_res>(), tensor_shape_A, num_tiles_per_unpack);
+            ckernel::trisc::bfd_current<unp_res>(), tensor_shape_A, TILE_CNT);
         PROFILER_SYNC();
     }
     {
@@ -231,7 +230,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t TILE_CNT    = params.TILE_CNT;
     const Operand& buffer_Res       = params.buffer_Res;
 #endif
-    const std::uint32_t num_tiles_per_pack = TILE_CNT;
 
     {
         ZONE_SCOPED("INIT")
@@ -257,7 +255,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape_A, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape_A, TILE_CNT);
         PROFILER_SYNC();
     }
     {


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Relates to #53127
Parent initiative: #50549

Expand and stabilize Quasar LLK performance testing so the perf matrix represents supported functional behavior and detects run-type synchronization defects.

- Reuse functional test configuration from perf wrappers to reduce test/perf drift.
- Add shared selection of representative tall, wide, and supported bank-switching dimensions.
- Broaden format conversions, DEST accumulation modes, broadcast modes, unpacker engines, and operation-specific variants across the Quasar perf suite.
- Centralize Quasar math-format and DEST-DVALID setup helpers.
- Make isolate-mode source-dvalid mocks match real producer/consumer counts and ordering.
- Reset or reconfigure persistent source/DEST state between `PerfRunType` ELFs.
- Fix unpack-to-DEST congestion, transpose multi-block ordering, unary operand handshake counts, and Scalar/Row/Column broadcast synchronization.
- Improve perf configuration/report processing uncovered by the expanded coverage.

These changes prevent false passes with negative profiler values and remove stall-timeout-scale execution delays caused by invalid state carrying into later run types.

### Notes for reviewers
Please focus on:

- whether each C++ isolate/congestion path exactly mirrors the real kernel's source-dvalid sequence;
- DEST-DVALID ownership for `L1_CONGESTION`, especially unpack-to-DEST paths;
- the selected tall/wide dimensions and fallback behavior in `param_config.py`;
- parity between functional test constraints and their `perf_*_quasar.py` wrappers.

Targeted Quasar simulator validation completed for the corrected handshake topologies, including:

- unpack tilize with Float/Int-style 32-bit unpack-to-DEST congestion;
- transpose DEST with multi-block `[32, 512]` coverage;
- unpack unary operand for UnpA, UnpB, and Float32 UnpDest;
- binary broadcast Column tall→wide sequencing plus Row and Scalar paths.

Generated debug logs and comparison outputs remain untracked and are not included in this PR.

All perf tests are ran and results are here:
https://drive.google.com/drive/folders/1WsZb2GfK_bIfF77O2dEvyw--sBrJVZYK

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/improve_quasar_perf_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/improve_quasar_perf_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/improve_quasar_perf_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/improve_quasar_perf_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/improve_quasar_perf_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/improve_quasar_perf_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/improve_quasar_perf_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/improve_quasar_perf_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/improve_quasar_perf_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/improve_quasar_perf_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/improve_quasar_perf_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/improve_quasar_perf_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/improve_quasar_perf_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/improve_quasar_perf_tests)