### PR TITLE
[Bug Fix] Forward decode kwargs through Qwen VL wrappers

### DIFF
--- a/models/demos/qwen25_vl/tt/generator.py
+++ b/models/demos/qwen25_vl/tt/generator.py
@@ -103,6 +103,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         enable_trace=True,
         read_from_device=True,
         sampling_params=None,
+        **kwargs,
     ):
         return self._ttt_generator.decode_forward(
             tokens=tokens,
@@ -112,6 +113,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             enable_trace=enable_trace,
             read_from_device=read_from_device,
             sampling_params=sampling_params,
+            **kwargs,
         )
 
     def __prefill_forward_single_user_text(self, tokens, page_table, user_id, last_token_idx, rot_mats, kv_cache=None):

--- a/models/demos/qwen3_vl/tt/generator.py
+++ b/models/demos/qwen3_vl/tt/generator.py
@@ -113,6 +113,7 @@ class Generator(WarmupForwardMixin):
         enable_trace=True,
         read_from_device=True,
         sampling_params=None,
+        **kwargs,
     ):
         return self._ttt_generator.decode_forward(
             tokens=tokens,
@@ -122,6 +123,7 @@ class Generator(WarmupForwardMixin):
             enable_trace=enable_trace,
             read_from_device=read_from_device,
             sampling_params=sampling_params,
+            **kwargs,
         )
 
     def prefill_forward_single_user_text(


### PR DESCRIPTION
## Summary

- Forward additional decode arguments through the Qwen2.5-VL and Qwen3-VL composition wrappers.
- Allow `slot_remap` from the vLLM TT plugin to reach the shared `tt_transformers` generator instead of failing at the intermediate wrapper.

## Root cause

[vLLM TT plugin PR #45](https://github.com/tenstorrent/vllm-tt-plugin/pull/45) sends `slot_remap` as decode-layout data in both host- and device-sampling modes. The Qwen VL vLLM adapters already accept and forward `**kwargs`, but their intermediate composition wrappers expose a closed `decode_forward` signature. Python therefore rejects `slot_remap` before the call reaches the shared generator:

```text
TypeError: Generator.decode_forward() got an unexpected keyword argument 'slot_remap'
```

This caused:

- [Qwen2.5-VL-72B-Instruct failure](https://github.com/tenstorrent/tt-metal/actions/runs/31787002343/job/94726747951)
- [Qwen3-VL-32B-Instruct failure](https://github.com/tenstorrent/tt-metal/actions/runs/31787002343/job/94726747905)

## Why this is the correct adapter behavior

The Qwen VL classes are composition wrappers around the shared generator, so decode arguments owned by that generator must pass through unchanged. Existing adapters already follow this pattern:

- The [shared `tt_transformers` generator](https://github.com/tenstorrent/tt-metal/blob/main/models/tt_transformers/tt/generator.py#L1324-L1339) explicitly accepts `slot_remap` and additional keyword arguments.
- The [Llama Galaxy vLLM adapter](https://github.com/tenstorrent/tt-metal/blob/main/models/demos/llama3_70b_galaxy/tt/generator_vllm.py#L204-L208) transparently forwards `**kwargs` to the shared implementation.
- The [Gemma4 vLLM adapter](https://github.com/tenstorrent/tt-metal/blob/main/models/demos/gemma4/tt/generator_vllm.py#L693-L708) handles its model-specific input and forwards the remaining `**kwargs`.
- The [Qwen3.6 vLLM adapter](https://github.com/tenstorrent/tt-metal/blob/main/models/demos/blackhole/qwen36/tt/qwen36_vllm.py#L297-L311) consumes `slot_remap` for GDN state and leaves it in `kwargs` so the shared generator can also remap sampling state.

Forwarding `**kwargs` in the two Qwen VL composition wrappers makes them consistent with these adapters and preserves the shared generator as the owner of decode-layout and sampling-state arguments.

## Validation

- `pre-commit run --files models/demos/qwen25_vl/tt/generator.py models/demos/qwen3_vl/tt/generator.py`
- `ruff check models/demos/qwen25_vl/tt/generator.py models/demos/qwen3_vl/tt/generator.py`
- `python3 -m compileall -q models/demos/qwen25_vl/tt/generator.py models/demos/qwen3_vl/tt/generator.py`
- `git diff --check`
- CI: [Qwen2.5-VL](https://github.com/tenstorrent/tt-metal/actions/runs/32002928146), [Qwen3-VL](https://github.com/tenstorrent/tt-metal/actions/runs/32002952426), [All Model Tests](https://github.com/tenstorrent/tt-metal/actions/runs/32002998429)

No new tests are included in this PR.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vpus/fix-qwen-vl-slot-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vpus/fix-qwen-vl-slot-remap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vpus/fix-qwen-vl-slot-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vpus/fix-qwen-vl-slot-remap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vpus/fix-qwen-vl-slot-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vpus/fix-qwen-vl-slot-remap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vpus/fix-qwen-vl-slot-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vpus/fix-qwen-vl-slot-remap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vpus/fix-qwen-vl-slot-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vpus/fix-qwen-vl-slot-remap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vpus/fix-qwen-vl-slot-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vpus/fix-qwen-vl-slot-remap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vpus/fix-qwen-vl-slot-remap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vpus/fix-qwen-vl-slot-remap)