### PR TITLE
Fix perf reorg leftover: _write_run_parquet imports helpers.perf.parquet

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/perf/core.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/perf/core.py
@@ -464,7 +464,7 @@ def _write_run_parquet(raw_csv_paths, out_dir) -> None:
     if not raw_csv_paths:
         return
     try:
-        from .perf_parquet import convert_csvs_to_parquet
+        from .parquet import convert_csvs_to_parquet
 
         prov = _ci_provenance()
         parquet_path = Path(out_dir) / f"{prov['run_id']}.parquet"


### PR DESCRIPTION
combine_perf_reports -> _write_run_parquet lazily imported the pre-reorg module name `.perf_parquet` (helpers.perf.perf_parquet), which no longer exists after perf.py was split into the helpers/perf/ package — it is `.parquet` now. The ModuleNotFoundError was swallowed by the best-effort try/except, so the run Parquet was silently never written and
test_perf_report_hw_free.py::test_combine_perf_reports_emits_parquet_alongside_csv failed deterministically (introduced by the #51951 merge, e60103a8).

Verified: `from helpers.perf.parquet import convert_csvs_to_parquet` resolves (parquet.py pulls in only pandas/pyarrow + sibling schema, no ttexalens).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstojictt/fix-perf-parquet-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstojictt/fix-perf-parquet-import)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstojictt/fix-perf-parquet-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstojictt/fix-perf-parquet-import)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstojictt/fix-perf-parquet-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstojictt/fix-perf-parquet-import)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstojictt/fix-perf-parquet-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstojictt/fix-perf-parquet-import)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstojictt/fix-perf-parquet-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstojictt/fix-perf-parquet-import)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstojictt/fix-perf-parquet-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstojictt/fix-perf-parquet-import)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstojictt/fix-perf-parquet-import)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstojictt/fix-perf-parquet-import)