### PR TITLE
Migrate prefill coverage to Fabric2D and TorusXY

### DIFF
--- a/.github/workflows/blackhole-e2e-tests.yaml
+++ b/.github/workflows/blackhole-e2e-tests.yaml
@@ -37,6 +37,7 @@ on:
         type: choice
         options:
           - all
+          - bh-lb-deepseek-prefill-perf
           - bh-qb2-deepseek-d2d-socket-sync
       build-type:
         required: false

--- a/.github/workflows/blaze-models-prefill-tests-impl.yaml
+++ b/.github/workflows/blaze-models-prefill-tests-impl.yaml
@@ -174,6 +174,13 @@ jobs:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
           create-pipeline-dir: "false"
 
+      - name: Configure TorusXY fabric profile
+        if: ${{ matrix.test-group.fabric_profile == 'torus_xy' }}
+        shell: bash
+        run: |
+          echo "TT_MESH_GRAPH_DESC_PATH=/home/user/tt-metal/tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_torus_xy_graph_descriptor.textproto" >> "$GITHUB_ENV"
+          echo "PREFILL_TORUS_XY_CERTIFIED=1" >> "$GITHUB_ENV"
+
       # Same mechanism as .github/actions/setup-job, which this job can't use (not a container
       # job, tests run under mpirun): on dispatch stall the runtime runs
       # TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE inside the hung rank, then throws. Armed here

--- a/models/demos/deepseek_v3_d_p/scripts/common.sh
+++ b/models/demos/deepseek_v3_d_p/scripts/common.sh
@@ -26,7 +26,7 @@ LOG_DIR="/data/$USER/$LOG_NAME"
 
 # Test selection — single source of truth.
 TEST_FILE="$TT_METAL_HOME/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py"
-KFILTER="ds_prefill and pretrained and e256_device_fp32 and fabric2d-mesh-8x4 and 61_layers and balanced and right_pad and smoke and no_determinism and iter25 and 25600 and longbook"
+KFILTER="ds_prefill and pretrained and e256_device_fp32 and torus-xy-8x4 and 61_layers and balanced and right_pad and smoke and no_determinism and iter25 and 25600 and longbook"
 
 # Inner-iteration count, derived from the iterNN token in the filter above.
 INNER_ITERS=$(grep -oE 'iter[0-9]+' <<<"$KFILTER" | grep -oE '[0-9]+' | head -1)

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_embedding_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_embedding_cache.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
 from tests.ttnn.utils_for_testing import comp_pcc
@@ -31,9 +32,9 @@ def cleanup_cache():
     [
         pytest.param(
             (2, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
+            id="fabric2d-2x2",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_ffn_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_ffn_cache.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tt.tt_ffn import TtFfn
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
 from tests.ttnn.utils_for_testing import comp_pcc
@@ -31,9 +32,9 @@ def cleanup_cache():
     [
         pytest.param(
             (2, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
+            id="fabric2d-2x2",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_gate_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_gate_cache.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_gate_weights, get_sp_mesh_composer
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode, TtMoEGateConfig, TtMoEGatePrefill
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
@@ -53,9 +54,9 @@ def create_gate_input(config, mesh_device):
     [
         pytest.param(
             (2, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
+            id="fabric2d-2x2",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_lm_head_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_lm_head_cache.py
@@ -11,6 +11,7 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import profiler
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tt.tt_lm_head import TtLMHead
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import report_and_clear
 from tests.ttnn.utils_for_testing import comp_pcc
@@ -32,9 +33,9 @@ def cleanup_cache():
     [
         pytest.param(
             (2, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
+            id="fabric2d-2x2",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_mla_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_mla_cache.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
@@ -33,18 +34,18 @@ def cleanup_cache():
     [
         pytest.param(
             (2, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
+            id="fabric2d-2x2",
         ),
         # Blackhole forms whole-box meshes only, so the 2x2 case above never runs on an 8-chip
         # loudbox -- it is a 4-device QuietBox / Wormhole shape. 2x4 makes this test actually
         # executable there, which is where the Kimi weight caches are exercised.
         pytest.param(
             (2, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
-            id="linear-2x4",
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+            id="fabric2d-2x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_moe_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_moe_cache.py
@@ -11,6 +11,7 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import profiler
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     compute_constants,
     create_gate_weights,
@@ -42,9 +43,9 @@ def cleanup_cache():
     [
         pytest.param(
             (2, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
+            id="fabric2d-2x2",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -138,7 +139,6 @@ def test_moe_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
         emb_dim=emb_dim,
         hidden_dim=hidden_dim,
         num_links=1,
-        topology=ttnn.Topology.Linear,
         routed_expert_weights=routed_expert_weights,
         shared_expert_weights=shared_expert_weights,
         routed_expert_activations_dtype=ttnn.bfloat8_b,
@@ -206,7 +206,6 @@ def test_moe_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
         emb_dim=emb_dim,
         hidden_dim=hidden_dim,
         num_links=1,
-        topology=ttnn.Topology.Linear,
         routed_expert_weights=None,
         shared_expert_weights=None,
         routed_expert_activations_dtype=ttnn.bfloat8_b,
@@ -247,7 +246,6 @@ def test_moe_weights_cold_warm_cache(mesh_device, device_params, gate_mode):
         emb_dim=emb_dim,
         hidden_dim=hidden_dim,
         num_links=1,
-        topology=ttnn.Topology.Linear,
         routed_expert_weights=None,
         shared_expert_weights=None,
         routed_expert_activations_dtype=ttnn.bfloat8_b,

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_rms_norm_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_rms_norm_cache.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
 from tests.ttnn.utils_for_testing import comp_pcc
@@ -31,9 +32,9 @@ def cleanup_cache():
     [
         pytest.param(
             (2, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
+            id="fabric2d-2x2",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_routed_expert_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_routed_expert_cache.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     ExpertMapping,
     compute_constants,
@@ -40,9 +41,9 @@ def cleanup_cache():
     [
         pytest.param(
             (2, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
+            id="fabric2d-2x2",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/cache/test_shared_expert_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/cache/test_shared_expert_cache.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import TtSharedExpert
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker, report_and_clear
 from tests.ttnn.utils_for_testing import comp_pcc
@@ -31,9 +32,9 @@ def cleanup_cache():
     [
         pytest.param(
             (2, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
+            id="fabric2d-2x2",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/conftest.py
@@ -33,6 +33,14 @@ TestVariant = PrefillModelAdapter
 TEST_VARIANTS = {name: get_adapter(name) for name in ADAPTER_PATHS}
 DSV3 = get_adapter("deepseek_v3_d_p")
 
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
+    assert_torus_xy_descriptor,
+    fabric2d_device_params,
+    torus_x_device_params,
+    torus_xy_device_params,
+    torus_y_device_params,
+)
+
 # glm_5_2 is a TEST-ONLY variant here: its adapter is intentionally kept out of the shared common
 # ADAPTER_PATHS (prefill serving is not wired), so register it locally for the `variant` fixture
 # without modifying the common prefill registry.
@@ -45,148 +53,55 @@ TEST_VARIANTS["glm_5_2"] = GLM52Adapter()
 from models.demos.deepseek_v3_d_p.tt.runners.adapters.kimi_k3 import KimiK3Adapter
 
 TEST_VARIANTS["kimi_k3"] = KimiK3Adapter()
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
 from models.demos.deepseek_v3_d_p.utils.test_utils import convert_state_dict, detect_language_model_prefix
 from models.demos.deepseek_v3_d_p.utils.transformer_helpers import download_infinitebench_subset
 
-# Shared FABRIC_2D parametrize entries for the prefill block + transformer tests.
-# Minimum CI-gated coverage: (4,2) on BH LoudBox, (8,4) on BH Galaxy. (2,4) included
-# for asymmetry coverage. RELAXED_INIT matches the canonical pattern in test_prefill_block.py
-# and is required on BH Galaxy for FABRIC_2D bring-up.
+# Shared production-policy params for prefill block + transformer tests. LoudBox executes canonical
+# 2x4 Fabric2D and one 4x2 axis-order diagnostic; Galaxy production executes only 8x4 TorusXY.
 FABRIC_2D_PREFILL_BLOCK_MESH_PARAMS = [
     pytest.param(
         (4, 2),
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-        },
+        fabric2d_device_params(),
         1,
-        ttnn.Topology.Linear,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
         id="fabric2d-mesh-4x2",
     ),
     pytest.param(
         (2, 4),
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-        },
+        fabric2d_device_params(),
         1,
-        ttnn.Topology.Linear,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
         id="fabric2d-mesh-2x4",
-    ),
-    pytest.param(
-        (8, 4),
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-        },
-        2,
-        ttnn.Topology.Linear,
-        marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-        id="fabric2d-mesh-8x4",
-    ),
-    # FABRIC_2D_TORUS_Y: single-galaxy 8x4 with the SP axis (mesh dim 0, 8-long) closed into a
-    # ring; the TP axis (dim 1, 4-wide) stays a line. Per-axis topology (SP, TP) = (Ring, Linear):
-    # Ring drives the SP-axis MoE dispatch/combine, Linear the TP-axis collectives (RMS-norm, MLA,
-    # shared-expert, gate). A scalar Ring here would deadlock the TP-axis all-gathers on a column
-    # wrap link that has no physical fabric edge. 2-link mirrors the fabric2d-mesh-8x4 sibling.
-    pytest.param(
-        (8, 4),
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-        },
-        2,
-        (ttnn.Topology.Ring, ttnn.Topology.Linear),
-        marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-        # Id omits `fabric2d-`/`mesh-` so it stays out of the count-guarded `-k "8x4 and fabric2d"`
-        # (EXPECT_NUM_TESTS=1) CI selectors that target the fabric2d-mesh siblings; select via `-k torus-y`.
-        id="torus-y-8x4",
-    ),
-    # FABRIC_2D_TORUS_X: single-galaxy 8x4 with the TP axis (mesh dim 1, 4-wide) closed into a ring;
-    # the SP axis (dim 0, 8-long) stays a line. Per-axis topology (SP, TP) = (Linear, Ring): Ring
-    # drives the TP-axis collectives (RMS-norm, MLA, dense-FFN, shared-expert, gate), Linear the
-    # SP-axis MoE dispatch/combine. This is the production full-galaxy X-ring case — it matches the
-    # [LINE,RING] pipeline-prefill descriptors and needs no sub-torus carve (uses all 32 chips).
-    pytest.param(
-        (8, 4),
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-        },
-        2,
-        (ttnn.Topology.Linear, ttnn.Topology.Ring),
-        marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-        id="torus-x-8x4",
     ),
     # FABRIC_2D_TORUS_XY on the full 8x4 galaxy: Ring on BOTH axes (SP dim 0 = Ring-8, TP dim 1 =
     # Ring-4). SP-axis MoE dispatch/combine ride #48225's ring-aware kernels; TP-axis collectives ring.
     pytest.param(
         (8, 4),
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-        },
+        torus_xy_device_params(),
         2,
-        (ttnn.Topology.Ring, ttnn.Topology.Ring),
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
         id="torus-xy-8x4",
     ),
-    # FABRIC_2D_TORUS_Y on a 4x4 sub-torus (16 of the galaxy's 32 chips). Same [RING, LINE]
-    # shape as the 8x4 torus but with a Ring-4 on the SP axis (dim 0). Requires carving the
-    # sub-torus at runtime via TT_VISIBLE_DEVICES (16 chips) + TT_MESH_GRAPH_DESC_PATH pointing at
-    # models/demos/deepseek_v3_d_p/experimental_descriptors/single_bh_galaxy_subtorus_y4_graph_descriptor.textproto
-    # (channels count: 2 -> 2 links).
-    # Per-axis topology (SP, TP) = (Ring, Linear), as for the 8x4 torus.
+    # Existing 16-chip subtorus diagnostics. These run only with an explicit 4x4 carve descriptor;
+    # they are a distinct workload and are not substitutes for production 8x4 TorusXY coverage.
     pytest.param(
         (4, 4),
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-        },
+        torus_y_device_params(),
         2,
-        (ttnn.Topology.Ring, ttnn.Topology.Linear),
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 4), topology="mesh-4x4"),
         id="torus-y-4x4",
     ),
-    # FABRIC_2D_TORUS_X on a 4x4 sub-torus: Ring-4 on the TP/X axis (dim 1), Linear on the SP/Y axis
-    # (dim 0). The mirror of torus-y — wraps the columns instead of the rows, so the TP-axis
-    # collectives (RMS-norm, MLA, dense-FFN, shared-expert, gate) ring while the SP-axis MoE
-    # dispatch/combine stay a line. Carve via TT_VISIBLE_DEVICES (16 chips) + TT_MESH_GRAPH_DESC_PATH
-    # pointing at single_bh_galaxy_subtorus_x4_graph_descriptor.textproto.
     pytest.param(
         (4, 4),
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-        },
+        torus_x_device_params(),
         2,
-        (ttnn.Topology.Linear, ttnn.Topology.Ring),
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 4), topology="mesh-4x4"),
         id="torus-x-4x4",
     ),
-    # FABRIC_2D_TORUS_XY on a 4x4 sub-torus: Ring-4 on BOTH axes (full 2D torus). The SP-axis MoE
-    # dispatch/combine ride the ring-aware kernels and the TP-axis collectives ring too. Carve via
-    # TT_VISIBLE_DEVICES (16 chips) + TT_MESH_GRAPH_DESC_PATH=...subtorus_xy4...
     pytest.param(
         (4, 4),
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-        },
+        torus_xy_device_params(),
         2,
-        (ttnn.Topology.Ring, ttnn.Topology.Ring),
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 4), topology="mesh-4x4"),
         id="torus-xy-4x4",
     ),
@@ -208,114 +123,78 @@ def pytest_collection_modifyitems(config, items):
     Skip tests based on mesh/topology requirements at collection time.
 
     Hardware constraints:
-    - Blackhole: Only supports 4-device configs (linear-4, ring-4)
-    - Wormhole: Ring topology only works with 8 devices (ring-8)
+    - Blackhole: multi-device test shapes must consume the complete local box
+    - Wormhole: wrapped topology only works with 8 devices
 
-    Galaxy ring/subtorus guard (CI): ring and torus fabrics need physical wrap cabling. On a
-    GALAXY board that wrap is subtorus wiring that CI galaxy runners do not have — the native
-    galaxy mesh is 32x4 across 4 hosts, so an 8-ring or 4-ring on a single galaxy is a sub-torus
-    (and the 4-ring exists ONLY on a subtorus-wired galaxy, not on a LoudBox). Opening such a
-    fabric on a CI galaxy just hangs. So on CI + galaxy we skip EVERY torus
-    (FABRIC_2D_TORUS_{X,Y,XY}) and FABRIC_1D_RING config. LoudBox is untouched: its ring is
-    native there, and galaxy-only torus configs can't be collected on it anyway (device count).
-    None of this fires off CI, so a subtorus-wired host (CI unset) still runs everything.
+    Galaxy TorusXY guard (CI): the production ring/ring fabric requires an explicit descriptor and
+    a cabling-certified allocation. Generic Galaxy jobs skip it before device open. Certified jobs
+    set PREFILL_TORUS_XY_CERTIFIED=1 and TT_MESH_GRAPH_DESC_PATH. Native Nx1 ring proxies use
+    Fabric2D TorusY and 1xN ring proxies use TorusX; non-ring local shapes remain unwrapped Fabric2D.
     """
     on_ci = os.getenv("CI") == "true" or "TT_GH_CI_INFRA" in os.environ
+    torus_xy_certified = os.getenv("PREFILL_TORUS_XY_CERTIFIED") == "1"
+    torus_xy_fabric = ttnn.FabricConfig.FABRIC_2D_TORUS_XY
     ring_or_torus_fabrics = {
         ttnn.FabricConfig.FABRIC_2D_TORUS_X,
         ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
         ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
-        ttnn.FabricConfig.FABRIC_1D_RING,
     }
 
     CT = ttnn.cluster.ClusterType
     FC = ttnn.FabricConfig
-    DEFAULT_ALLOWED_FABRICS = frozenset({FC.FABRIC_1D, FC.FABRIC_2D})
+    DEFAULT_ALLOWED_FABRICS = frozenset({FC.DISABLED, FC.FABRIC_2D})
+    # DISABLED is listed only on shapes that already own fabric-irrelevant diagnostics
+    # (currently single-chip and the P300 1x2 masked-bincount row). Do not expand it into
+    # communicating-test matrices merely to make this table visually symmetric.
     CI_ALLOWED_FABRICS = {
-        CT.P150: {(1, 1): [FC.FABRIC_1D, FC.FABRIC_2D]},  # single chip
-        CT.P300: {(2, 1): [FC.FABRIC_1D, FC.FABRIC_2D], (1, 2): [FC.FABRIC_1D, FC.FABRIC_2D]},  # 2 chips
-        CT.P300_X2: {  # 4 chips (bh_quietbox_2), no ring cables in any configuration
-            (4, 1): [FC.FABRIC_1D, FC.FABRIC_2D],
-            (2, 2): [FC.FABRIC_1D, FC.FABRIC_2D],
-            (1, 4): [FC.FABRIC_1D, FC.FABRIC_2D],
+        CT.P150: {(1, 1): [FC.DISABLED, FC.FABRIC_2D]},  # single chip
+        CT.P300: {
+            (2, 1): [FC.FABRIC_2D],
+            (1, 2): [FC.DISABLED, FC.FABRIC_2D],
+        },  # 2 chips
+        CT.P300_X2: {  # 4-chip QuietBox
+            (4, 1): [FC.FABRIC_2D_TORUS_Y],
+            (2, 2): [FC.FABRIC_2D],
+            (1, 4): [FC.FABRIC_2D_TORUS_X],
         },
         CT.P150_X8: {
-            (8, 1): [FC.FABRIC_1D, FC.FABRIC_1D_RING, FC.FABRIC_2D, FC.FABRIC_2D_TORUS_Y],
-            (4, 2): [FC.FABRIC_1D, FC.FABRIC_2D],
-            (2, 4): [FC.FABRIC_1D, FC.FABRIC_2D],
-            (1, 8): [FC.FABRIC_1D, FC.FABRIC_1D_RING, FC.FABRIC_2D, FC.FABRIC_2D_TORUS_X],
+            (8, 1): [FC.FABRIC_2D_TORUS_Y],
+            (4, 2): [FC.FABRIC_2D],
+            (2, 4): [FC.FABRIC_2D],
+            (1, 8): [FC.FABRIC_2D_TORUS_X],
         },
         CT.T3K: {
-            (8, 1): [FC.FABRIC_1D, FC.FABRIC_1D_RING, FC.FABRIC_2D, FC.FABRIC_2D_TORUS_Y],
-            (4, 2): [FC.FABRIC_1D, FC.FABRIC_2D],
-            (2, 4): [FC.FABRIC_1D, FC.FABRIC_2D],
-            (1, 8): [FC.FABRIC_1D, FC.FABRIC_1D_RING, FC.FABRIC_2D, FC.FABRIC_2D_TORUS_X],
+            (8, 1): [FC.FABRIC_2D_TORUS_Y],
+            (4, 2): [FC.FABRIC_2D],
+            (2, 4): [FC.FABRIC_2D],
+            (1, 8): [FC.FABRIC_2D_TORUS_X],
         },
         CT.BLACKHOLE_GALAXY: {
-            (32, 1): [FC.FABRIC_1D, FC.FABRIC_2D],
-            (16, 2): [FC.FABRIC_1D, FC.FABRIC_2D],
-            (8, 4): [
-                FC.FABRIC_1D,
-                FC.FABRIC_1D_RING,
-                FC.FABRIC_2D,
-                FC.FABRIC_2D_TORUS_X,
-                FC.FABRIC_2D_TORUS_Y,
-                FC.FABRIC_2D_TORUS_XY,
-            ],
-            (4, 8): [
-                FC.FABRIC_1D,
-                FC.FABRIC_1D_RING,
-                FC.FABRIC_2D,
-                FC.FABRIC_2D_TORUS_X,
-                FC.FABRIC_2D_TORUS_Y,
-                FC.FABRIC_2D_TORUS_XY,
-            ],
-            (2, 16): [FC.FABRIC_1D, FC.FABRIC_2D],
-            (1, 32): [FC.FABRIC_1D, FC.FABRIC_2D],
+            (32, 1): [FC.FABRIC_2D],
+            (16, 2): [FC.FABRIC_2D],
+            (8, 4): [FC.FABRIC_2D, FC.FABRIC_2D_TORUS_XY],
+            (4, 4): [FC.FABRIC_2D_TORUS_X, FC.FABRIC_2D_TORUS_Y, FC.FABRIC_2D_TORUS_XY],
+            (4, 8): [FC.FABRIC_2D],
+            (2, 16): [FC.FABRIC_2D],
+            (1, 32): [FC.FABRIC_2D],
         },
         CT.GALAXY: {
-            (32, 1): [FC.FABRIC_1D, FC.FABRIC_2D],
-            (16, 2): [FC.FABRIC_1D, FC.FABRIC_2D],
-            (8, 4): [
-                FC.FABRIC_1D,
-                FC.FABRIC_1D_RING,
-                FC.FABRIC_2D,
-                FC.FABRIC_2D_TORUS_X,
-                FC.FABRIC_2D_TORUS_Y,
-                FC.FABRIC_2D_TORUS_XY,
-            ],
-            (4, 8): [
-                FC.FABRIC_1D,
-                FC.FABRIC_1D_RING,
-                FC.FABRIC_2D,
-                FC.FABRIC_2D_TORUS_X,
-                FC.FABRIC_2D_TORUS_Y,
-                FC.FABRIC_2D_TORUS_XY,
-            ],
-            (2, 16): [FC.FABRIC_1D, FC.FABRIC_2D],
-            (1, 32): [FC.FABRIC_1D, FC.FABRIC_2D],
+            (32, 1): [FC.FABRIC_2D],
+            (16, 2): [FC.FABRIC_2D],
+            (8, 4): [FC.FABRIC_2D, FC.FABRIC_2D_TORUS_XY],
+            (4, 4): [FC.FABRIC_2D_TORUS_X, FC.FABRIC_2D_TORUS_Y, FC.FABRIC_2D_TORUS_XY],
+            (4, 8): [FC.FABRIC_2D],
+            (2, 16): [FC.FABRIC_2D],
+            (1, 32): [FC.FABRIC_2D],
         },
         CT.TG: {
-            (32, 1): [FC.FABRIC_1D, FC.FABRIC_2D],
-            (16, 2): [FC.FABRIC_1D, FC.FABRIC_2D],
-            (8, 4): [
-                FC.FABRIC_1D,
-                FC.FABRIC_1D_RING,
-                FC.FABRIC_2D,
-                FC.FABRIC_2D_TORUS_X,
-                FC.FABRIC_2D_TORUS_Y,
-                FC.FABRIC_2D_TORUS_XY,
-            ],
-            (4, 8): [
-                FC.FABRIC_1D,
-                FC.FABRIC_1D_RING,
-                FC.FABRIC_2D,
-                FC.FABRIC_2D_TORUS_X,
-                FC.FABRIC_2D_TORUS_Y,
-                FC.FABRIC_2D_TORUS_XY,
-            ],
-            (2, 16): [FC.FABRIC_1D, FC.FABRIC_2D],
-            (1, 32): [FC.FABRIC_1D, FC.FABRIC_2D],
+            (32, 1): [FC.FABRIC_2D],
+            (16, 2): [FC.FABRIC_2D],
+            (8, 4): [FC.FABRIC_2D, FC.FABRIC_2D_TORUS_XY],
+            (4, 4): [FC.FABRIC_2D_TORUS_X, FC.FABRIC_2D_TORUS_Y, FC.FABRIC_2D_TORUS_XY],
+            (4, 8): [FC.FABRIC_2D],
+            (2, 16): [FC.FABRIC_2D],
+            (1, 32): [FC.FABRIC_2D],
         },
     }
 
@@ -327,32 +206,39 @@ def pytest_collection_modifyitems(config, items):
         else:
             return None
 
-    # Only skip ring/torus on a galaxy; LoudBox rings are native. Galaxy detection via
-    # get_cluster_type() OPENS the chip cluster as a side effect, so only call it when this session
-    # actually collects a ring/torus config to decide on. Otherwise a device-free session — notably the
-    # tracy-based perf tests, which spawn a child pytest — would open the device here in the PARENT and
-    # hold CHIP_IN_USE, deadlocking the child (get_num_devices() below is likewise gated by a marker).
-    # On detection failure default to skipping (a missed skip on a galaxy hangs, worse than over-skip on LB).
+    def _is_torus_xy(item):
+        return _get_requested_fabric_cfg(item) == torus_xy_fabric
+
+    torus_xy_items_collected = any(_is_torus_xy(item) for item in items)
+    if torus_xy_items_collected and torus_xy_certified and not os.getenv("TT_MESH_GRAPH_DESC_PATH"):
+        pytest.exit("PREFILL_TORUS_XY_CERTIFIED=1 requires explicit TT_MESH_GRAPH_DESC_PATH", returncode=2)
+    if torus_xy_items_collected and torus_xy_certified:
+        assert_torus_xy_descriptor(os.environ["TT_MESH_GRAPH_DESC_PATH"])
+
+    # Generic CI galaxies are not wrap-cabling certified. get_cluster_type() opens the chip cluster as a
+    # side effect, so call it only when this session collects a wrapped device configuration. This keeps
+    # device-free tracy perf wrappers from opening devices in the parent; their parametrized child session
+    # performs the detection instead. On detection failure default to skipping (a missed skip can hang).
     skip_rings = False
     cluster_type = None
-    if on_ci and any((_get_requested_fabric_cfg(item) in ring_or_torus_fabrics) for item in items):
+    if any((_get_requested_fabric_cfg(item) in ring_or_torus_fabrics) for item in items):
         try:
             cluster_type = ttnn.cluster.get_cluster_type()
-            skip_rings = cluster_type in [CT.GALAXY, CT.BLACKHOLE_GALAXY, CT.TG]
+            skip_rings = on_ci and cluster_type in [CT.GALAXY, CT.BLACKHOLE_GALAXY, CT.TG]
         except Exception:
             skip_rings = True
 
     for item in items:
-        # Galaxy ring/subtorus guard — runs before the marker check so it catches configs whether or
+        # Galaxy TorusXY guard — runs before the marker check so it catches configs whether or
         # not they carry a requires_mesh_topology mark.
         requested_fabric_cfg = _get_requested_fabric_cfg(item)
         if skip_rings:
-            if requested_fabric_cfg in ring_or_torus_fabrics:
+            certified_production_torus = requested_fabric_cfg == torus_xy_fabric and torus_xy_certified
+            if requested_fabric_cfg in ring_or_torus_fabrics and not certified_production_torus:
                 item.add_marker(
                     pytest.mark.skip(
-                        reason="ring/subtorus config on a CI galaxy runner: an 8-/4-ring on one galaxy "
-                        "needs subtorus wrap cabling that CI galaxies lack -> would hang. Runs only on a "
-                        "subtorus-wired galaxy (CI unset), or — for a native ring — a LoudBox."
+                        reason="Wrapped fabric requires a compatible physical ring; Galaxy TorusXY additionally "
+                        "requires an explicit ring/ring descriptor and a cabling-certified allocation"
                     )
                 )
                 continue
@@ -408,6 +294,24 @@ def pytest_collection_modifyitems(config, items):
 
         if skip_reason:
             item.add_marker(pytest.mark.skip(reason=skip_reason))
+
+
+@pytest.fixture(autouse=True)
+def _assert_certified_torus_profile(request):
+    """Fail closed after mesh open for every certified TorusXY parametrized case."""
+    params = getattr(getattr(request.node, "callspec", None), "params", {})
+    device_params = params.get("device_params")
+    if not isinstance(device_params, dict):
+        return
+    if device_params.get("fabric_config") != ttnn.FabricConfig.FABRIC_2D_TORUS_XY:
+        return
+    if os.getenv("PREFILL_TORUS_XY_CERTIFIED") != "1":
+        return
+    request.getfixturevalue("mesh_device")
+    assert ttnn.get_fabric_config() == ttnn.FabricConfig.FABRIC_2D_TORUS_XY
+    from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
+
+    assert per_axis_topology() == (ttnn.Topology.Ring, ttnn.Topology.Ring)
 
 
 @pytest.fixture

--- a/models/demos/deepseek_v3_d_p/tests/dflash_prefill/test_dflash.py
+++ b/models/demos/deepseek_v3_d_p/tests/dflash_prefill/test_dflash.py
@@ -17,9 +17,10 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.dflash_prefill.tt_dflash_drafter import TtDFlashDrafter
 from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_positions, rotated_chip_positions
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import allocate_dflash_kv_cache
 from tests.ttnn.utils_for_testing import comp_pcc
 
@@ -31,12 +32,6 @@ CHUNK_GLOBAL = 5120
 
 # Per-user cache depth
 MAX_SEQ_LEN = 11 * CHUNK_GLOBAL
-
-_FABRIC_2D = {
-    "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-    "fabric_router_config": create_fabric_router_config(max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
-    "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-}
 
 
 def _unrotate_blockcyclic(rotated: torch.Tensor, sp: int, chunk_global: int) -> torch.Tensor:
@@ -74,15 +69,14 @@ def _read_cache_natural(cache, mesh_device, mesh_shape, sp: int, chunk_global: i
     ],
 )
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            _FABRIC_2D,
+            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -91,7 +85,6 @@ def test_dflash_pcc(
     mesh_device,
     device_params,
     num_links,
-    topology,
     ctx_len,
     n_chunks,
     use_pretrained,
@@ -99,6 +92,7 @@ def test_dflash_pcc(
     drafter_state_dict,
     hf_context_kv,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])[1]
     logger.info(f"weights={'pretrained' if use_pretrained else 'random'}  ctx_len={ctx_len}  n_chunks={n_chunks}")
     cfg = drafter_cfg
     sd = drafter_state_dict
@@ -184,15 +178,14 @@ _MULTITURN_ITERS = [
 @pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"], indirect=True)
 @pytest.mark.parametrize("iters_isl", _MULTITURN_ITERS)
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            _FABRIC_2D,
+            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -201,13 +194,13 @@ def test_dflash_multiturn_pcc(
     mesh_device,
     device_params,
     num_links,
-    topology,
     iters_isl,
     use_pretrained,
     drafter_cfg,
     drafter_state_dict,
     hf_context_kv,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])[1]
     cfg = drafter_cfg
     sd = drafter_state_dict
 

--- a/models/demos/deepseek_v3_d_p/tests/dflash_prefill/test_dflash_prefill_integration.py
+++ b/models/demos/deepseek_v3_d_p/tests/dflash_prefill/test_dflash_prefill_integration.py
@@ -38,9 +38,10 @@ import ttnn
 from conftest import is_galaxy
 from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.dflash_prefill.tt_dflash_drafter import TtDFlashDrafter
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer import TtPrefillTransformer
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import allocate_dflash_kv_cache, init_kvpe_cache
 from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
@@ -68,18 +69,14 @@ MAX_RANDOM_LAYERS = 12
 )
 @pytest.mark.parametrize("n_routed_experts, gate_fallback_mode", [(384, GateComputeMode.DEVICE)], ids=["e384_device"])
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
-            },
+            torus_xy_device_params(fabric_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -97,7 +94,6 @@ def test_dflash_prefill_integration(
     n_routed_experts,
     gate_fallback_mode,
     num_links,
-    topology,
     use_pretrained,
     temperature,
     tokenizer,
@@ -106,6 +102,7 @@ def test_dflash_prefill_integration(
     drafter_state_dict,
     hf_context_kv,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])[1]
     if not use_pretrained and num_layers > MAX_RANDOM_LAYERS:
         pytest.skip(
             f"random verifier at {num_layers} layers materializes the whole Kimi model in host RAM "

--- a/models/demos/deepseek_v3_d_p/tests/fabric_profiles.py
+++ b/models/demos/deepseek_v3_d_p/tests/fabric_profiles.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+"""Shared device-fixture profiles for scoped prefill tests.
+
+Return a fresh dictionary for every ``pytest.param`` so cases cannot share mutable fixture state.
+"""
+
+import re
+from pathlib import Path
+
+import ttnn
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
+
+
+def fabric2d_device_params(*, fabric_payload_size=None, **overrides) -> dict:
+    """Unwrapped local Fabric2D profile for 2x2/2x4/4x2 Blackhole tests."""
+    params = {
+        "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+        "fabric_router_config": create_fabric_router_config(
+            max_payload_size=get_max_payload_size() if fabric_payload_size is None else fabric_payload_size
+        ),
+        "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
+    }
+    params.update(overrides)
+    return params
+
+
+def torus_y_device_params(*, fabric_payload_size=None, **overrides) -> dict:
+    """Fabric2D Ring/Linear profile for an Nx1 mesh."""
+    params = {
+        "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
+        "fabric_router_config": create_fabric_router_config(
+            max_payload_size=get_max_payload_size() if fabric_payload_size is None else fabric_payload_size
+        ),
+        "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
+    }
+    params.update(overrides)
+    return params
+
+
+def torus_x_device_params(*, fabric_payload_size=None, **overrides) -> dict:
+    """Fabric2D Linear/Ring profile for a 1xN mesh."""
+    params = {
+        "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X,
+        "fabric_router_config": create_fabric_router_config(
+            max_payload_size=get_max_payload_size() if fabric_payload_size is None else fabric_payload_size
+        ),
+        "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
+    }
+    params.update(overrides)
+    return params
+
+
+def torus_xy_device_params(*, fabric_payload_size=None, **overrides) -> dict:
+    """Production 8x4 Ring/Ring profile; requires a cabling-certified explicit descriptor."""
+    params = {
+        "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
+        "fabric_router_config": create_fabric_router_config(
+            max_payload_size=get_max_payload_size() if fabric_payload_size is None else fabric_payload_size
+        ),
+        "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
+    }
+    params.update(overrides)
+    return params
+
+
+def assert_torus_xy_descriptor(path: str) -> None:
+    """Fail before device open unless every declared device mesh is 8x4 Ring/Ring."""
+    descriptor_path = Path(path).resolve()
+    text = descriptor_path.read_text()
+    declared = len(re.findall(r"device_topology\s*\{", text))
+    topologies = re.findall(
+        r"device_topology\s*\{[^}]*dims:\s*\[\s*(\d+)\s*,\s*(\d+)\s*\][^}]*"
+        r"dim_types:\s*\[\s*(\w+)\s*,\s*(\w+)\s*\]",
+        text,
+    )
+    assert topologies, f"{descriptor_path}: no two-dimensional device topology found"
+    assert len(topologies) == declared, (
+        f"{descriptor_path}: {declared} device_topology block(s) declared but only "
+        f"{len(topologies)} are two-dimensional; TorusXY requires every mesh to be 8x4 Ring/Ring"
+    )
+    assert all(
+        topology == ("8", "4", "RING", "RING") for topology in topologies
+    ), f"{descriptor_path}: TorusXY requires every device topology to be 8x4 Ring/Ring; found {topologies}"

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_combine_subdevices.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_combine_subdevices.py
@@ -48,11 +48,12 @@ from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
     validate_combine_output,
 )
 from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_validation_results
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 
 # A single representative 2-D mesh config (8 chips). The subdevice placement under test is
 # a property of the per-chip worker grid, independent of the mesh topology, so one config
 # is enough to exercise all four edge lines.
-MESH_CONFIGS = [p for p in ALL_MESH_CONFIGS if p.id == "mesh-4x2"]
+MESH_CONFIGS = [p for p in ALL_MESH_CONFIGS if p.id == "fabric2d-mesh-4x2"]
 
 # Small PCC-checked data case (same shape as test_prefill_combine.py's "pcc" case).
 SEQ_LEN_PER_CHIP = 128
@@ -138,19 +139,20 @@ def _assert_edge_geometry(edge, core_range_set, grid_x, grid_y):
 
 
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     MESH_CONFIGS,
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize("subdevice_edge", SUBDEVICE_EDGES)
 def test_combine_subdevice_placement(
-    mesh_device, device_params, num_links, topology, subdevice_edge, is_ci_env, is_ci_v2_env
+    mesh_device, device_params, num_links, subdevice_edge, is_ci_env, is_ci_v2_env, expect_error
 ):
     """Run combine confined to an edge-row/column worker subdevice and validate vs torch.
 
     The four edge subdevices overlap at the grid corners, so they cannot share one
     sub-device manager; each placement gets its own manager, created and torn down here.
     """
+    topology = per_axis_topology(device_params["fabric_config"])[0]
     # Local-only: this file is collected by every DeepSeek_PREFILL_OP_TESTS job (some
     # unfiltered, e.g. bh_p150/bh_p300), so a -k filter cannot exclude it. Skip in CI the
     # same way test_sub_device_load_clear_timing.py does; runs locally with no env var.
@@ -292,7 +294,7 @@ def test_combine_subdevice_placement(
         sd_manager = mesh_device.create_sub_device_manager([ttnn.SubDevice([edge_cores])], 0)
         mesh_device.load_sub_device_manager(sd_manager)
         try:
-            with pytest.raises(RuntimeError, match="2-D subdevice core grid"):
+            with expect_error(RuntimeError, "2-D subdevice core grid"):
                 ttnn.experimental.deepseek_prefill.combine(
                     tt_dispatched_buffer,
                     tt_dispatched_metadata,

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_rotary_embedding_indexed.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_rotary_embedding_indexed.py
@@ -20,6 +20,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3.reference.modeling_deepseek import rotate_half
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.mla.rope import get_rot_transformation_mat
 from models.demos.deepseek_v3_d_p.tt.mla.utils import block_cyclic_reorder
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -264,9 +265,9 @@ def test_rotary_embedding_indexed_multi_iteration_prefill(
     [
         pytest.param(
             (8, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_2D},
+            torus_xy_device_params(),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_update_padded_kv_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_deepseek_prefill_update_padded_kv_cache.py
@@ -19,6 +19,11 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
+    fabric2d_device_params,
+    torus_x_device_params,
+    torus_xy_device_params,
+)
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 
 # MLA KVPE head dim (kv_lora_rank=512 + qk_rope_head_dim=64). The op is a pure page copy, so a
@@ -252,7 +257,30 @@ def _update_kv(
     ttnn.deallocate(kv_t)
 
 
-@pytest.mark.parametrize("mesh_device", [(1, 4), (2, 4), (8, 4)], ids=["1x4", "2x4", "8x4"], indirect=True)
+@pytest.mark.parametrize(
+    "mesh_device, device_params",
+    [
+        pytest.param(
+            (1, 4),
+            torus_x_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="ring"),
+            id="torus-x-1x4",
+        ),
+        pytest.param(
+            (2, 4),
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+            id="fabric2d-2x4",
+        ),
+        pytest.param(
+            (8, 4),
+            torus_xy_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="torus-xy-8x4",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
 @pytest.mark.parametrize("dtype, layout", DTYPE_LAYOUT_CASES, ids=DTYPE_LAYOUT_IDS)
 @pytest.mark.parametrize(
     "config_name, num_users, num_layers, new_isl_tiles_per_dev, cache_tokens_per_dev",
@@ -265,6 +293,7 @@ def _update_kv(
 @pytest.mark.timeout(0)
 def test_update_padded_kv_cache_single_iteration_prefill(
     mesh_device,
+    device_params,
     config_name,
     num_users,
     num_layers,
@@ -605,9 +634,9 @@ def test_update_padded_kv_cache_multi_iteration_prefill(
     [
         pytest.param(
             (8, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_2D},
+            torus_xy_device_params(),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_dispatch_combine_l1_small_semaphores.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_dispatch_combine_l1_small_semaphores.py
@@ -20,21 +20,21 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_y_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     ExpertMapping,
     compute_constants,
-    create_fabric_router_config,
     extract_mesh_config,
     get_dispatch_input_mesh_mapper,
     get_gate_outputs,
-    get_max_payload_size,
     initialize_test_inputs,
 )
 from models.demos.deepseek_v3_d_p.tt.moe.tt_dispatch import TtDispatchModule
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.utils.test_utils import print_l1_buffers, print_l1_small_buffers
 
 
-def run_dispatch_op(mesh_device, use_l1_small):
+def run_dispatch_op(mesh_device, use_l1_small, topology):
     """Run dispatch op with small tensors in DRAM, creating 2 global semaphores."""
     torch.manual_seed(42)
 
@@ -146,7 +146,7 @@ def run_dispatch_op(mesh_device, use_l1_small):
         max_dispatch_buffer_token_size=max_dispatch_buffer_token_size,
         cluster_axis=sp_axis,
         num_links=1,
-        topology=ttnn.Topology.Linear,
+        topology=topology,
         use_l1_small_for_semaphores=use_l1_small,
     )
     ttnn.synchronize_device(mesh_device)
@@ -178,6 +178,7 @@ def run_combine_op(
     seq_len_per_chip,
     sp_axis,
     use_l1_small,
+    topology,
 ):
     """Run combine op using dispatch outputs, creating 1 global semaphore."""
     output = ttnn.experimental.deepseek_prefill.combine(
@@ -191,7 +192,7 @@ def run_combine_op(
         seq_len_per_chip=seq_len_per_chip,
         cluster_axis=sp_axis,
         num_links=1,
-        topology=ttnn.Topology.Linear,
+        topology=topology,
         init_zeros=False,
         use_l1_small_for_semaphores=use_l1_small,
     )
@@ -204,13 +205,9 @@ def run_combine_op(
     [
         pytest.param(
             (4, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-                "l1_small_size": 512,
-            },
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="linear"),
-            id="linear-4x1",
+            torus_y_device_params(l1_small_size=512),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="ring"),
+            id="torus-y-4x1",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -220,6 +217,8 @@ def run_combine_op(
 def test_deepseek_prefill_l1_small_semaphores(mesh_device, device_params, ccl_op, use_l1_small, expect_error):
     """Test that dispatch/combine semaphores can be placed in L1_SMALL to prevent L1 fragmentation."""
 
+    sp_axis = extract_mesh_config(mesh_device).sp_axis
+    topology = per_axis_topology(device_params["fabric_config"])[sp_axis]
     compute_grid = mesh_device.compute_with_storage_grid_size()
     num_worker_cores = compute_grid.x * compute_grid.y
     logger.info(f"Compute grid: {compute_grid.x}x{compute_grid.y} = {num_worker_cores} cores")
@@ -260,7 +259,7 @@ def test_deepseek_prefill_l1_small_semaphores(mesh_device, device_params, ccl_op
         seq_len_per_chip,
         sp_axis,
         dispatch_intermediates,
-    ) = run_dispatch_op(mesh_device, use_l1_small)
+    ) = run_dispatch_op(mesh_device, use_l1_small, topology)
     tensors_to_free.extend(dispatch_intermediates)
 
     if ccl_op == "combine":
@@ -276,6 +275,7 @@ def test_deepseek_prefill_l1_small_semaphores(mesh_device, device_params, ccl_op
             seq_len_per_chip,
             sp_axis,
             use_l1_small,
+            topology,
         )
         tensors_to_free.append(combine_output)
 

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_fp8_kv_cache_gather.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_fp8_kv_cache_gather.py
@@ -22,6 +22,7 @@ from models.demos.deepseek_v3_d_p.tt.runners.kv_chunk_table import (
     _dram_chunk_size_bytes,
     build_and_serialize_kv_chunk_table,
 )
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import PREFILL_CHUNK_OUTPUT_TOKENS, MlaKvCacheFormat
 
 
@@ -143,7 +144,7 @@ def test_fp8_row_major_kv_cache_all_gather(mesh_device, tmp_path):
         barrier_semaphore=barrier_semaphore,
         num_links=1,
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
-        topology=ttnn.Topology.Linear,
+        topology=per_axis_topology()[sp_axis],
         cluster_axis=sp_axis,
     )
     ttnn.synchronize_device(mesh_device)

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_masked_bincount.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_masked_bincount.py
@@ -14,6 +14,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_x_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import ExpertMapping, extract_mesh_config, get_ep_mesh_composer
 from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import compare_exact, validate_composed
 from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_validation_results
@@ -49,27 +50,27 @@ def torch_masked_bincount(
     [
         pytest.param(
             (1, 1),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            {"fabric_config": ttnn.FabricConfig.DISABLED},
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 1), topology="linear"),
             id="single",
         ),
         pytest.param(
             (1, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            {"fabric_config": ttnn.FabricConfig.DISABLED},
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 2), topology="linear"),
-            id="linear-1x2",
+            id="disabled-1x2",
         ),
         pytest.param(
             (1, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="mesh-1x4"),
-            id="linear-1x4",
+            torus_x_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="ring"),
+            id="torus-x-1x4",
         ),
         pytest.param(
             (2, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
-            id="mesh-4x2",
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+            id="fabric2d-mesh-2x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -193,7 +194,7 @@ def test_masked_bincount(
     [
         pytest.param(
             (1, 1),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            {"fabric_config": ttnn.FabricConfig.DISABLED},
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 1), topology="linear"),
             id="single",
         ),

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_mla_matmuls.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_mla_matmuls.py
@@ -12,6 +12,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_xy_device_params
 
 PCC_REQUIRED = 0.99
 
@@ -188,11 +189,8 @@ SEQ_LEN_25K = 6400
 )
 @pytest.mark.parametrize(
     "device_params",
-    [
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-        }
-    ],
+    [torus_xy_device_params()],
+    ids=["torus-xy"],
     indirect=True,
 )
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_moe_padding_config.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_moe_padding_config.py
@@ -22,15 +22,26 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.mla.utils import rotated_chip_real_token_counts
 
-# Galaxy-shaped SP=8 config (chunk_size_global 5120 -> tokens_per_chip 640) plus a small 2x4 case so
-# the op is exercised on boxes that cannot host 32 chips.
+# Galaxy-shaped SP=8 config (chunk_size_global 5120 -> tokens_per_chip 640) plus the existing small
+# 2x4 case for boxes that cannot host 32 chips. Keep this one-for-one: the production row owns
+# TorusXY, while the local row owns plain Fabric2D.
 _MESHES = [
-    pytest.param((8, 4), marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4")),
-    pytest.param((2, 4), marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4")),
+    pytest.param(
+        (8, 4),
+        torus_xy_device_params(),
+        marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+        id="torus-xy-8x4",
+    ),
+    pytest.param(
+        (2, 4),
+        fabric2d_device_params(),
+        marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+        id="fabric2d-2x4",
+    ),
 ]
-_MESH_IDS = ["8x4", "2x4"]
 
 # (actual_start, actual_isl) pairs. Chosen to cover every branch of the rotation:
 #   * start == 0                -> sequential layout (the degenerate case)
@@ -122,7 +133,7 @@ def _run_case(mesh_device, actual_start: int, actual_isl: int, padding_side: str
     return config, start_t, end_t
 
 
-@pytest.mark.parametrize("mesh_device", _MESHES, ids=_MESH_IDS, indirect=True)
+@pytest.mark.parametrize("mesh_device,device_params", _MESHES, indirect=True)
 @pytest.mark.parametrize("actual_start,actual_isl", _CASES, ids=_IDS)
 def test_moe_padding_config_matches_host(mesh_device, actual_start, actual_isl):
     """The device op reproduces the host builder's per-chip counts exactly."""
@@ -132,13 +143,24 @@ def test_moe_padding_config_matches_host(mesh_device, actual_start, actual_isl):
     _run_case(mesh_device, actual_start, actual_isl)
 
 
-@pytest.mark.parametrize("mesh_device", _MESHES, ids=_MESH_IDS, indirect=True)
+@pytest.mark.parametrize("mesh_device,device_params", _MESHES, indirect=True)
 def test_moe_padding_config_left_padding(mesh_device):
     """pad_side is written through for left padding (start 0 only: rotation implies right padding)."""
     _run_case(mesh_device, 0, 2592, padding_side="left")
 
 
-@pytest.mark.parametrize("mesh_device", [(2, 4)], ids=["2x4"], indirect=True)
+@pytest.mark.parametrize(
+    "mesh_device,device_params",
+    [
+        pytest.param(
+            (2, 4),
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+            id="fabric2d-2x4",
+        )
+    ],
+    indirect=True,
+)
 def test_moe_padding_config_one_program_across_chunks(mesh_device):
     """The per-chunk values must stay OUT of the program hash, and refreshing the metadata tensors in
     place must change the result — together these are exactly what lets one capture replay across

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_offset_cumsum.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_offset_cumsum.py
@@ -14,11 +14,9 @@ import torch
 from loguru import logger
 
 import ttnn
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
-    create_fabric_router_config,
-    extract_mesh_config,
-    get_max_payload_size,
-)
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_y_device_params
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import extract_mesh_config
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 
 
 def torch_offset_cumsum(
@@ -73,64 +71,49 @@ def torch_offset_cumsum(
     [256],
 )
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (2, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
+            fabric2d_device_params(),
             1,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 1), topology="linear"),
-            id="linear-2x1",
+            id="fabric2d-2x1",
         ),
         pytest.param(
             (4, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
+            torus_y_device_params(),
             1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="linear"),
-            id="linear-4x1",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="ring"),
+            id="torus-y-4x1",
         ),
         pytest.param(
             (4, 2),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
+            fabric2d_device_params(),
             1,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
-            id="mesh-4x2",
+            id="fabric2d-mesh-4x2",
         ),
         pytest.param(
             (2, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
+            fabric2d_device_params(),
             1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-4x2"),
-            id="mesh-2x4",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+            id="fabric2d-mesh-2x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
 )
 def test_offset_cumsum(
     mesh_device,
+    device_params,
     n_routed_experts,
     num_links,
-    topology,
 ):
     """Test ttnn.offset_cumsum against PyTorch reference."""
     mesh_config = extract_mesh_config(mesh_device)
     sp_axis = mesh_config.sp_axis
+    topology = per_axis_topology(device_params["fabric_config"])[sp_axis]
     dispatch_group_size = mesh_config.dispatch_group_size
     num_dispatch_groups = mesh_config.num_dispatch_groups
     experts_per_chip = n_routed_experts // num_dispatch_groups // dispatch_group_size

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py
@@ -48,6 +48,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
     validate_combine_output,
 )
 from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert_dispatch_table, log_validation_results
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 
 
 def run_combine(
@@ -350,12 +351,11 @@ class _Test_Mesh:
 SINGLE_GLX_AND_PROXY_MESHES = _Test_Mesh(
     (8, 4),
     {
-        # Ideally all would run torus XY, but some HW configurations like LB/QB cannot support
-        # rings in all configurations. Pick fabric option as representative as possible.
+        # Preserve the existing SP=8 LoudBox proxy with its wrapped Fabric2D equivalent.
         (8, 4): ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
-        (8, 1): ttnn.FabricConfig.FABRIC_1D_RING,  # unexpectedly FABRIC_2D variants hang
+        (8, 1): ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
+        (4, 1): ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
         (4, 2): ttnn.FabricConfig.FABRIC_2D,
-        (4, 1): ttnn.FabricConfig.FABRIC_1D_RING,  # unexpectedly FABRIC_2D variants hang
         (2, 2): ttnn.FabricConfig.FABRIC_2D,
     },
 )
@@ -401,33 +401,18 @@ def _model_scaledown_for_combine(model, ref_mesh, target_mesh, pcc_only):
 
 
 def _topo_marker(mesh, fabric_cfg):
-    if mesh[1] == 1 and fabric_cfg == ttnn.FabricConfig.FABRIC_1D:
-        return "linear"
-    if mesh[1] == 1 and fabric_cfg == ttnn.FabricConfig.FABRIC_1D_RING:
+    if fabric_cfg == ttnn.FabricConfig.FABRIC_2D_TORUS_Y:
         return "ring"
     return f"mesh-{mesh[0]}x{mesh[1]}"
 
 
 def _mesh_id(mesh, fabric_cfg):
-    if mesh[1] == 1 and fabric_cfg == ttnn.FabricConfig.FABRIC_1D:
-        return f"linear-{mesh[0]}"
-    if mesh[1] == 1 and fabric_cfg == ttnn.FabricConfig.FABRIC_1D_RING:
-        return f"ring-{mesh[0]}"
-    return f"mesh-{mesh[0]}x{mesh[1]}"
-
-
-def _fabric_cfg_to_fabric_topo_for_cmb_op(fabric_cfg):
-    # This mapping is specific to an op because fabric topology is the CCL algorithm's data-flow shape (Linear / Ring / Mesh / Torus)
-    # ttnn.FabricConfig is the device-level fabric wiring (FABRIC_1D / FABRIC_1D_RING / FABRIC_2D / FABRIC_2D_TORUS_Y) —
-    # set via the `mesh_device` fixture's device_params.
-    # ttnn.Topology on the other hand is what data-movement pattern the algorithm will use in op kernel runtime.
-    # It depends on the fabric config because config might prevent some topology (e.g. FABRIC_1D does not support Ring topology), but topology
-    # doesn't have to use all of the supported movements. For example it is perfectly valid to ask for Topology.Linear (and not Topology.Mesh)
-    # on FABRIC_2D. Thus it is natural for every CCL op to derive which topology to use from the given fabric config.
-    if fabric_cfg in (ttnn.FabricConfig.FABRIC_1D, ttnn.FabricConfig.FABRIC_2D, ttnn.FabricConfig.FABRIC_2D_TORUS_X):
-        return ttnn.Topology.Linear
-    else:
-        return ttnn.Topology.Ring
+    profile = {
+        ttnn.FabricConfig.FABRIC_2D: "fabric2d",
+        ttnn.FabricConfig.FABRIC_2D_TORUS_Y: "torus-y",
+        ttnn.FabricConfig.FABRIC_2D_TORUS_XY: "torus-xy",
+    }[fabric_cfg]
+    return f"{profile}-{mesh[0]}x{mesh[1]}"
 
 
 def _cross_product_conflated_cmb_test_dimensions():
@@ -435,7 +420,6 @@ def _cross_product_conflated_cmb_test_dimensions():
     for model_name, model_config_class, is_extended_model, test_meshes in COMBINE_MODELS:
         for target_mesh, fabric_cfg in test_meshes.target_meshes.items():
             device_params = fabric_to_device_params(fabric_cfg)
-            fabric_topo = _fabric_cfg_to_fabric_topo_for_cmb_op(fabric_cfg)
             topo_marker = _topo_marker(target_mesh, fabric_cfg)
             mesh_requirements_marker = pytest.mark.requires_mesh_topology(mesh_shape=target_mesh, topology=topo_marker)
             marks = (
@@ -460,7 +444,6 @@ def _cross_product_conflated_cmb_test_dimensions():
                     pytest.param(
                         shape,
                         device_params,
-                        fabric_topo,
                         seq_len_per_chip,
                         model_config.EMB_SIZE,
                         num_experts,
@@ -500,7 +483,7 @@ def _cross_product_conflated_cmb_test_dimensions():
 #    test-code cross product calculation, or are skipped in the body of the test, depending on where it was less cumbersome to implement it.
 #
 @pytest.mark.parametrize(
-    "mesh_device, device_params, topology, seq_len_per_chip, emb_dim, num_routed_experts, num_experts_per_tok, dispatch_buffer_capacity_factor, run_pcc_check",
+    "mesh_device, device_params, seq_len_per_chip, emb_dim, num_routed_experts, num_experts_per_tok, dispatch_buffer_capacity_factor, run_pcc_check",
     _cross_product_conflated_cmb_test_dimensions(),
     indirect=["mesh_device", "device_params"],
 )
@@ -514,13 +497,13 @@ def _cross_product_conflated_cmb_test_dimensions():
 @pytest.mark.parametrize("use_fp8_output", [False, True], ids=["bf16_out", "fp8_out"])
 def test_ttnn_combine(
     mesh_device,
+    device_params,
     seq_len_per_chip,
     emb_dim,
     num_routed_experts,
     num_experts_per_tok,
     dispatch_buffer_capacity_factor,
     num_links,
-    topology,
     use_predictable_data,
     run_pcc_check,
     dispatched_buffer_layout,
@@ -528,6 +511,7 @@ def test_ttnn_combine(
     is_ci_env,
     is_ci_v2_env,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])[0]
     run_combine(
         mesh_device,
         seq_len_per_chip,

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_dispatch.py
@@ -43,6 +43,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
     validate_dispatch_metadata,
 )
 from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert_dispatch_table, log_validation_results
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 
 # =====
 # mesh 4x2
@@ -503,7 +504,7 @@ def dispatch_shape_params():
     dispatch_shape_params(),
 )
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     ALL_MESH_CONFIGS,
     indirect=["mesh_device", "device_params"],
 )
@@ -529,6 +530,7 @@ def dispatch_shape_params():
 @pytest.mark.parametrize("verbose", [False])
 def test_ttnn_dispatch(
     mesh_device,
+    device_params,
     model_name,
     seq_len_per_chip,
     emb_dim,
@@ -536,7 +538,6 @@ def test_ttnn_dispatch(
     num_experts_per_tok,
     dispatch_buffer_capacity_factor,
     num_links,
-    topology,
     use_predictable_data,
     input_layout,
     input_dtype,
@@ -547,6 +548,7 @@ def test_ttnn_dispatch(
     is_ci_env,
     is_ci_v2_env,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])[0]
     run_dispatch(
         mesh_device,
         model_name,

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_reduce.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_reduce.py
@@ -25,6 +25,7 @@ from models.demos.deepseek_v3_d_p.reference.gpt_oss_120b_config import GptOss120
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.reference.minimax_m2_7_config import MiniMaxM27Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.reduce import TorchReduceModule
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_y_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     create_sparse_combine_output,
     extract_mesh_config,
@@ -32,20 +33,21 @@ from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     initialize_test_inputs,
 )
 from models.demos.deepseek_v3_d_p.tt.moe.tt_reduce import TtReduceModule, _weights_have_output_channel_dim
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from tests.ttnn.utils_for_testing import comp_pcc
 
 REDUCE_MESH_PARAMS = [
     pytest.param(
         (4, 1),
-        {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-        marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="linear"),
-        id="linear-4",
+        torus_y_device_params(),
+        marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="ring"),
+        id="torus-y-4x1",
     ),
     pytest.param(
         (4, 2),
-        {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+        fabric2d_device_params(),
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
-        id="mesh-4x2",
+        id="fabric2d-mesh-4x2",
     ),
 ]
 
@@ -74,6 +76,7 @@ def test_weights_output_channel_shape_detection(weights_shape, combine_output_sh
 
 def run_reduce(
     mesh_device,
+    device_params,
     seq_len,
     emb_dim,
     topk,
@@ -85,8 +88,6 @@ def run_reduce(
 
     signpost(f"reduce-{mesh_device.shape}-seq{seq_len}-{'weighted' if use_weights else 'unweighted'}")
 
-    # Set topology and num_links
-    topology = ttnn.Topology.Linear
     num_links = 1
 
     num_devices = mesh_device.get_num_devices()
@@ -204,7 +205,7 @@ def run_reduce(
         topk_dim=2,  # topk is dim 2 in [1, seq, topk, hidden]
         cluster_axis=1,
         num_links=num_links,
-        topology=topology,
+        topology=per_axis_topology(device_params["fabric_config"])[1],
     )
 
     tt_output = tt_reduce(
@@ -234,17 +235,17 @@ def run_reduce(
     ids=["generic"],
 )
 @pytest.mark.parametrize("mesh_device, device_params", REDUCE_MESH_PARAMS, indirect=["mesh_device", "device_params"])
-def test_ttnn_reduce(mesh_device, seq_len, emb_dim, topk, use_weights):
-    run_reduce(mesh_device, seq_len, emb_dim, topk, use_weights)
+def test_ttnn_reduce(mesh_device, device_params, seq_len, emb_dim, topk, use_weights):
+    run_reduce(mesh_device, device_params, seq_len, emb_dim, topk, use_weights)
 
 
 @pytest.mark.parametrize("use_weights", [True, False], ids=["weighted", "unweighted"])
 @pytest.mark.parametrize(
     "mesh_device, device_params", REDUCE_MESH_PARAMS[:1], indirect=["mesh_device", "device_params"]
 )
-def test_ttnn_reduce_single_expert(mesh_device, use_weights):
-    """Top-k=1 cannot be sharded across the second axis of the 4x2 mapper."""
-    run_reduce(mesh_device, seq_len=32, emb_dim=1024, topk=1, use_weights=use_weights)
+def test_ttnn_reduce_single_expert(mesh_device, device_params, use_weights):
+    """Top-k=1 remains on the original single-axis mesh, migrated to TorusY."""
+    run_reduce(mesh_device, device_params, seq_len=32, emb_dim=1024, topk=1, use_weights=use_weights)
 
 
 # Per-model reduce shapes as (id_prefix, config, extended_model). Each model uses seq_len 640 and
@@ -274,5 +275,5 @@ def reduce_shape_params():
 @pytest.mark.parametrize("use_weights", [True, False], ids=["weighted", "unweighted"])
 @pytest.mark.parametrize("seq_len, emb_dim, topk", reduce_shape_params())
 @pytest.mark.parametrize("mesh_device, device_params", REDUCE_MESH_PARAMS, indirect=["mesh_device", "device_params"])
-def test_ttnn_reduce_models(mesh_device, seq_len, emb_dim, topk, use_weights):
-    run_reduce(mesh_device, seq_len, emb_dim, topk, use_weights)
+def test_ttnn_reduce_models(mesh_device, device_params, seq_len, emb_dim, topk, use_weights):
+    run_reduce(mesh_device, device_params, seq_len, emb_dim, topk, use_weights)

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py
@@ -9,16 +9,19 @@ from tracy import signpost
 
 import ttnn
 from models.common.utility_functions import is_blackhole, is_wormhole_b0
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     create_balanced_chunk_order,
     reorder_tensor_chunks,
     reverse_reorder_tensor_chunks,
 )
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.utils.test_utils import WH_WORKER_L1_SIZE
 from models.tt_dit.utils.padding import get_padded_vision_seq_len
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
 from tests.ttnn.unit_tests.operations.sdpa.sdpa_test_utils import fa_rand
+
+_WORKER_L1_SIZE = ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE
 
 
 def get_cache_file_path(cache_path, name, dtype, layout):
@@ -483,32 +486,12 @@ def run_ring_joint_sdpa(
 @pytest.mark.parametrize("skip_check", [True, False], ids=["skip_pcc", "pcc_check"])
 @pytest.mark.parametrize("num_links", [1], ids=["1link"])
 @pytest.mark.parametrize(
-    "device_params, all_gather_topology",
+    "device_params",
     [
-        (
-            {
-                "trace_region_size": 1000000,
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
-            },
-            ttnn.Topology.Linear,
-        ),
-        (
-            {
-                "trace_region_size": 1000000,
-                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-                "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
-            },
-            ttnn.Topology.Linear,
-        ),
+        fabric2d_device_params(trace_region_size=1000000, worker_l1_size=_WORKER_L1_SIZE),
     ],
     indirect=["device_params"],
-    ids=[
-        "line",
-        "fabric2d",
-    ],
+    ids=["fabric2d"],
 )
 @pytest.mark.parametrize(
     "mesh_device",
@@ -529,6 +512,7 @@ def run_ring_joint_sdpa(
 @pytest.mark.timeout(0)
 def test_mla_sdpa(
     mesh_device,
+    device_params,
     b,
     nhq_v,
     nhk,
@@ -544,11 +528,11 @@ def test_mla_sdpa(
     num_links,
     rp_axis,
     up_axis,
-    all_gather_topology,
     skip_check,
     is_balanced,
     reset_seeds,
 ):
+    all_gather_topology = per_axis_topology(device_params["fabric_config"])[rp_axis]
     production_shape = [32, 4]  # hardcoded for now
 
     mesh_device_shape = list(mesh_device.shape)
@@ -868,40 +852,28 @@ def run_ring_joint_sdpa_perf(
 # perf harness allocates trace separately when needed; setting it here would over-allocate
 # device L1 for runs that don't enable tracing.
 @pytest.mark.parametrize(
-    "device_params, all_gather_topology",
+    "mesh_device, device_params",
     [
-        (
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
-            },
-            ttnn.Topology.Linear,
+        pytest.param(
+            (32, 4),
+            fabric2d_device_params(worker_l1_size=_WORKER_L1_SIZE),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(32, 4), topology="mesh-32x4"),
+            id="fabric2d-32x4",
         ),
-        (
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-                "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
-            },
-            ttnn.Topology.Ring,
+        pytest.param(
+            (2, 4),
+            fabric2d_device_params(worker_l1_size=_WORKER_L1_SIZE),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+            id="fabric2d-2x4",
         ),
-        (
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-                "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
-            },
-            ttnn.Topology.Linear,
+        pytest.param(
+            (8, 4),
+            torus_xy_device_params(worker_l1_size=_WORKER_L1_SIZE),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="torus-xy-8x4",
         ),
     ],
-    indirect=["device_params"],
-    ids=["line", "ring", "fabric2d"],
-)
-@pytest.mark.parametrize(
-    "mesh_device",
-    [(32, 4), (8, 4), (2, 4)],
-    ids=["32x4", "8x4", "2x4"],
-    indirect=True,
+    indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize(
     "rp_axis, up_axis",
@@ -912,6 +884,7 @@ def run_ring_joint_sdpa_perf(
 @pytest.mark.timeout(0)
 def test_mla_sdpa_perf(
     mesh_device,
+    device_params,
     b,
     nhq_v,
     nhk,
@@ -926,10 +899,10 @@ def test_mla_sdpa_perf(
     num_links,
     rp_axis,
     up_axis,
-    all_gather_topology,
     is_balanced,
     reset_seeds,
 ):
+    all_gather_topology = per_axis_topology(device_params["fabric_config"])[rp_axis]
     if num_links == 2 and is_wormhole_b0():
         pytest.skip("2 links not supported on Wormhole")
 

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_rope_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_rope_prefill.py
@@ -9,6 +9,7 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import comp_pcc
 from models.demos.deepseek_v3.reference.modeling_deepseek import rotate_half
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup, get_cos_sin_matrix
 from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     create_balanced_chunk_order,
@@ -28,11 +29,7 @@ PCC_REQUIRED = 0.99
 )
 @pytest.mark.parametrize(
     "device_params",
-    [
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-        }
-    ],
+    [fabric2d_device_params()],
     indirect=True,
 )
 @pytest.mark.parametrize("seq_len", [128 * 1024], ids=["seq128k"])

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_sub_device_load_clear_timing.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_sub_device_load_clear_timing.py
@@ -37,6 +37,7 @@ from tracy import signpost
 
 import ttnn
 from models.common.utility_functions import profiler
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 
 # Path the test writes its host-profiler samples to so the wrapper can include
 # them in the final stats summary alongside the tracy-derived numbers.
@@ -92,9 +93,9 @@ def _two_ops_subdevice(mesh_device, x, w, sd_id, core_grid, ckc):
     [
         pytest.param(
             (4, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            fabric2d_device_params(),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
-            id="mesh-4x2",
+            id="fabric2d-mesh-4x2",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_dispatch_combine.py
@@ -26,16 +26,15 @@ from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Confi
 from models.demos.deepseek_v3_d_p.reference.minimax_m2_7_config import MiniMaxM27Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.combine import TorchCombineModule
 from models.demos.deepseek_v3_d_p.reference.tt.moe.dispatch import TorchDispatchModule
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_y_device_params
 from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import ALL_MESH_CONFIGS
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     ExpertMapping,
     compute_constants,
-    create_fabric_router_config,
     extract_mesh_config,
     get_dispatch_input_mesh_mapper,
     get_ep_mesh_composer,
     get_gate_outputs,
-    get_max_payload_size,
     initialize_predictable_test_inputs,
     initialize_test_inputs,
 )
@@ -50,6 +49,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
     validate_roundtrip_output,
 )
 from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert_dispatch_table, log_validation_results
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 
 
 def run_dispatch_combine(
@@ -410,7 +410,7 @@ def dispatch_combine_shape_params():
     dispatch_combine_shape_params(),
 )
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     ALL_MESH_CONFIGS,
     indirect=["mesh_device", "device_params"],
 )
@@ -422,18 +422,20 @@ def dispatch_combine_shape_params():
 )
 def test_ttnn_dispatch_combine(
     mesh_device,
+    device_params,
     seq_len_per_chip,
     emb_dim,
     num_routed_experts,
     num_experts_per_tok,
     dispatch_buffer_capacity_factor,
     num_links,
-    topology,
     use_predictable_data,
     dispatched_buffer_layout,
     is_ci_env,
     is_ci_v2_env,
 ):
+    sp_axis = extract_mesh_config(mesh_device).sp_axis
+    topology = per_axis_topology(device_params["fabric_config"])[sp_axis]
     run_dispatch_combine(
         mesh_device,
         seq_len_per_chip,
@@ -453,16 +455,18 @@ def test_ttnn_dispatch_combine(
 # ------------------------------------------------------------------------------
 # How the `indices` tensor is constructed
 # ------------------------------------------------------------------------------
-# Setup for this test (linear-8-1link):
+# Setup for this test (fabric2d-torus-y-8x1-1link):
 #   dispatch_group_size                = 8  (chips along SP axis)
 #   seq_len_per_chip                   = 256
 #   num_experts_per_tok                = 2
 #   num_routed_experts                 = 16
+#   num_devices                        = 8
 #   experts_per_chip                   = 16 / 8 = 2
 #   expert -> chip mapping             = expert_id // 2
 #     => experts 14 and 15 both land on chip 7
 #   max_dispatched_tokens_per_expert   = 8 * 256 = 2048
-#   max_dispatch_buffer_token_size     = 2048 * 1 = 2048  (factor=1)
+#   raw dispatch-buffer capacity       = 2048 * 1 = 2048  (factor=1)
+#   max_dispatch_buffer_token_size     = 2048 + 32 = 2080  (one tile of alignment reserve)
 #
 # Indices tensor shape: (dispatch_group_size, seq_len_per_chip, num_experts_per_tok) = (8, 256, 2)
 # indices[chip, token, k] is the expert ID chosen as the k-th top-k pick for a
@@ -473,8 +477,8 @@ def test_ttnn_dispatch_combine(
 #   indices[..., 1] = 15
 #   Every (chip, token) picks (14, 15). Counts: expert 14 gets 2048 tokens,
 #   expert 15 gets 2048 tokens, both targeting chip 7's flat buffer.
-#   Chip 7's buffer (2048 slots) fills completely with expert 14 (slots 0..2047),
-#   so expert 15 starts at slot 2048 and is fully omitted (0 slots fit).
+#   Chip 7's buffer (2080 slots) fills slots 0..2047 with expert 14. The alignment
+#   reserve admits 32 tokens from expert 15 and drops its remaining 2016 tokens.
 #
 # Case "cut_short_last":
 #   split = int(0.6 * 256) = 153
@@ -484,33 +488,29 @@ def test_ttnn_dispatch_combine(
 #   indices[:, split:, 1] = 1        # remaining 103 tokens per chip pick 1
 #   Counts: expert 14 gets 8*153 = 1224, expert 15 gets 8*153 = 1224
 #           (both on chip 7); experts 0 and 1 get 8*103 = 824 each (on chip 0).
-#   Chip 7's buffer: expert 14 writes slots 0..1223 (1224 tokens, no overflow),
-#   expert 15 starts at slot 1224 wanting 1224 more, but only 2048-1224 = 824
-#   slots remain, so 400 of expert 15's tokens are dropped mid-expert.
-#   Chip 0's buffer: 824 + 824 = 1648 < 2048, no overflow (as expected).
+#   Chip 7's buffer: expert 14 writes 1224 tokens, then expert 15 starts at the
+#   tile-aligned offset 1248. Only 2080-1248 = 832 slots remain, so 392 of expert
+#   15's tokens are dropped mid-expert.
+#   Chip 0's aligned regions end at 832 + 824 = 1656 < 2080, so it does not overflow.
 #
-# Why 0.6: needs to be in (0.5, 1.0). > 0.5 so A+B exceeds the buffer
-# (guarantees overflow); < 1.0 so A fits fully and the overflow lands inside B.
+# Why 0.6: A fits fully, while the aligned A+B regions exceed the 2080-token buffer,
+# so the overflow lands inside B. Keeping the split below 1.0 also exercises experts 0 and 1.
 # ------------------------------------------------------------------------------
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
+            torus_y_device_params(),
             1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
-            id="linear-8-1link",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
+            id="fabric2d-torus-y-8x1-1link",
         ),
     ],
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize("overflow_mode", ["cut_short_last", "omit_last"])
-def test_ttnn_dispatch_combine_overflow(mesh_device, num_links, topology, overflow_mode):
+def test_ttnn_dispatch_combine_overflow(mesh_device, device_params, num_links, overflow_mode):
     """Verify dispatch/combine does not hang when the flat dispatch buffer overflows.
 
     The dispatch buffer is a flat shared region sized
@@ -519,8 +519,8 @@ def test_ttnn_dispatch_combine_overflow(mesh_device, num_links, topology, overfl
 
     - "cut_short_last": cumulative fill crosses the buffer boundary inside the
       last expert's region on the target chip — its write is cut short mid-expert.
-    - "omit_last": buffer is already full before the last expert begins — its
-      tokens are entirely omitted.
+    - "omit_last": the last expert begins at the raw-capacity boundary, so only
+      the one-tile alignment reserve fits and the rest of its tokens are omitted.
 
     Verifies completion only (no hang); output correctness is not checked.
     """
@@ -534,6 +534,7 @@ def test_ttnn_dispatch_combine_overflow(mesh_device, num_links, topology, overfl
     num_devices = mesh_device.get_num_devices()
     mesh_config = extract_mesh_config(mesh_device)
     sp_axis = mesh_config.sp_axis
+    topology = per_axis_topology(device_params["fabric_config"])[sp_axis]
     dispatch_group_size = mesh_config.dispatch_group_size
     num_dispatch_groups = mesh_config.num_dispatch_groups
 
@@ -659,18 +660,14 @@ def test_ttnn_dispatch_combine_overflow(mesh_device, num_links, topology, overfl
 
 
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            },
+            torus_y_device_params(),
             1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
-            id="linear-8-1link",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
+            id="fabric2d-torus-y-8x1-1link",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -681,12 +678,14 @@ def test_ttnn_dispatch_combine_overflow(mesh_device, num_links, topology, overfl
     ids=["dispatched_buffer_tile", "dispatched_buffer_row_major"],
 )
 def test_ttnn_dispatch_combine_top4(
-    mesh_device, num_links, topology, dispatched_buffer_layout, is_ci_env, is_ci_v2_env
+    mesh_device, device_params, num_links, dispatched_buffer_layout, is_ci_env, is_ci_v2_env
 ):
     """Regression test for num_experts_per_tok > 2 (previously caused hangs due to undersized CB buffering)."""
     # dispatch_buffer_capacity_factor: ceil(N/2) of the most conservative integer
     # N such that dgs*seq*N >= theoretical worst-case dispatch buffer. Real traffic
     # never approaches the worst case, so half-capacity is sufficient.
+    sp_axis = extract_mesh_config(mesh_device).sp_axis
+    topology = per_axis_topology(device_params["fabric_config"])[sp_axis]
     run_dispatch_combine(
         mesh_device=mesh_device,
         seq_len_per_chip=1600,

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_zero_padded_kv_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_zero_padded_kv_cache.py
@@ -16,6 +16,11 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
+    fabric2d_device_params,
+    torus_xy_device_params,
+    torus_y_device_params,
+)
 from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_positions
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import init_kvpe_cache
 
@@ -40,17 +45,22 @@ _FORMATS = [
 ]
 _FORMAT_IDS = ["bfp8_tile", "bf16_rm", "fp8_rm"]
 
-# SP=8 meshes for the block-cyclic cases below (they set sp_axis=0, so sp = mesh_shape[0] = 8, and
-# the _CASES/_MULTI_CASES expected boundary chips 0..7 assume an 8-way SP split). The TP axis (dim 1)
-# only replicates the cache in this op, so it is not what these cases exercise:
-#   * linear-8  (8, 1): the CI-gated Blackhole LoudBox coverage (8xP150, all chips on the SP axis).
-#   * mesh-8x4  (8, 4): the original BH Galaxy coverage; auto-skips on smaller boxes (needs 32 chips).
-# requires_mesh_topology gives a clean collection-time skip on boxes whose chip count doesn't match.
+# The block-cyclic cases require SP=8. Preserve both existing execution environments: the LoudBox
+# proxy uses TorusY and the production Galaxy uses TorusXY.
 _MESHES = [
-    pytest.param((8, 1), marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear")),
-    pytest.param((8, 4), marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4")),
+    pytest.param(
+        (8, 1),
+        torus_y_device_params(),
+        marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
+        id="torus-y-8x1",
+    ),
+    pytest.param(
+        (8, 4),
+        torus_xy_device_params(),
+        marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+        id="torus-xy-8x4",
+    ),
 ]
-_MESH_IDS = ["linear-8", "8x4"]
 
 
 def _init_cache_filled_with_ones(
@@ -153,7 +163,18 @@ def _assert_cache_windows(
     )
 
 
-@pytest.mark.parametrize("mesh_device", [(2, 4)], ids=["2x4"], indirect=True)
+@pytest.mark.parametrize(
+    "mesh_device,device_params",
+    [
+        pytest.param(
+            (2, 4),
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+            id="fabric2d-2x4",
+        )
+    ],
+    indirect=True,
+)
 @pytest.mark.parametrize("dtype,layout", _FORMATS, ids=_FORMAT_IDS)
 @pytest.mark.timeout(0)
 def test_zero_padded_kv_cache_program_cache_cross_chip(mesh_device, dtype, layout):
@@ -213,7 +234,7 @@ def test_zero_padded_kv_cache_program_cache_cross_chip(mesh_device, dtype, layou
     assert mesh_device.num_program_cache_entries() == cache_entries_before + 1
 
 
-@pytest.mark.parametrize("mesh_device", _MESHES, ids=_MESH_IDS, indirect=True)
+@pytest.mark.parametrize("mesh_device,device_params", _MESHES, indirect=True)
 @pytest.mark.parametrize("dtype,layout", _FORMATS, ids=_FORMAT_IDS)
 @pytest.mark.parametrize("chunk_size_global,seq_len_cache,valid_global,expected_chip", _CASES, ids=_IDS)
 @pytest.mark.timeout(0)
@@ -275,7 +296,7 @@ _MULTI_CASES = [
 _MULTI_IDS = [f"L{nl}_U{nu}_slot{s}_layer{ly}_v{v}" for (nl, nu, s, ly, v, _ch) in _MULTI_CASES]
 
 
-@pytest.mark.parametrize("mesh_device", _MESHES, ids=_MESH_IDS, indirect=True)
+@pytest.mark.parametrize("mesh_device,device_params", _MESHES, indirect=True)
 @pytest.mark.parametrize(
     "num_layers,num_users,slot_idx,layer_idx,valid_global,expected_chip", _MULTI_CASES, ids=_MULTI_IDS
 )
@@ -381,7 +402,7 @@ def _make_scalar_tensor(mesh_device, value):
     )
 
 
-@pytest.mark.parametrize("mesh_device", _MESHES, ids=_MESH_IDS, indirect=True)
+@pytest.mark.parametrize("mesh_device,device_params", _MESHES, indirect=True)
 @pytest.mark.parametrize("slot_idx,valid_global", _EQUIV_CASES, ids=_EQUIV_IDS)
 @pytest.mark.timeout(0)
 def test_zero_padded_kv_cache_tensor_matches_scalar(mesh_device, slot_idx, valid_global):
@@ -445,7 +466,7 @@ def test_zero_padded_kv_cache_tensor_matches_scalar(mesh_device, slot_idx, valid
     ttnn.deallocate(tt_valid_global)
 
 
-@pytest.mark.parametrize("mesh_device", _MESHES, ids=_MESH_IDS, indirect=True)
+@pytest.mark.parametrize("mesh_device,device_params", _MESHES, indirect=True)
 @pytest.mark.timeout(0)
 def test_zero_padded_kv_cache_tensor_program_reuse(mesh_device):
     """Cache-HIT coverage of the tensor path: two successive tensor-overload calls with DIFFERENT

--- a/models/demos/deepseek_v3_d_p/tests/pcc/mesh_configs.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/mesh_configs.py
@@ -5,119 +5,83 @@
 """
 Shared mesh configuration parameters for dispatch/combine PCC tests.
 
-The op_unit_tests test_prefill_dispatch.py, test_prefill_combine.py, and
-test_ttnn_dispatch_combine.py import ALL_MESH_CONFIGS to avoid duplicating the same
-pytest.param entries.
+The op_unit_tests test_prefill_dispatch.py, test_ttnn_dispatch_combine.py, and
+test_combine_subdevices.py, plus perf/test_prefill_dispatch_combine.py, import
+ALL_MESH_CONFIGS to avoid duplicating the same pytest.param entries.
+test_combine_subdevices.py pins the `fabric2d-mesh-4x2` ID.
 
-Topology vs FabricConfig
-------------------------
-`Topology` is the CCL algorithm's data-flow shape (Linear / Ring / Mesh / Torus) — a
-pytest parametrize axis. `FabricConfig` is the device-level fabric wiring (FABRIC_1D /
-FABRIC_1D_RING / FABRIC_2D / FABRIC_2D_TORUS_Y) — set via the `mesh_device` fixture's
-device_params. The two are orthogonal: e.g. `Topology::Linear + FABRIC_2D` is valid and
-intended — it asks for linear data-flow over a 2D-routed fabric. FABRIC_2D_TORUS_Y closes
-the row axis (mesh dim 0) into a ring while the column axis (dim 1) stays linear, so it
-pairs with `Topology::Ring` on `cluster_axis=0` (the SP axis); see the 8x4 entries below.
+FabricConfig is the single source of truth. Consumers derive their cluster-axis CCL
+topology with ``per_axis_topology`` instead of carrying a second parameter.
 
 Test-id naming convention
 -------------------------
-- FABRIC_1D entries use shape-only ids: `linear-N-Llink`, `ring-N-Llink`, `mesh-RxC`.
-- FABRIC_2D entries are prefixed with `fabric2d-`: `fabric2d-mesh-RxC[-Llink]`.
-- FABRIC_2D_TORUS_Y entries use `fabric2d-torus-y-RxC[-Llink]` (no `mesh-` infix).
-
-CI -k filters depend on this convention. For example, `-k 'mesh-8x4'` matches BOTH 1D and
-2D variants because `mesh-8x4` is a substring of `fabric2d-mesh-8x4`. To run only 1D
-under an existing `-k 'mesh-*'` filter, append `and not fabric2d-`. To run only 2D, use
-a positive `and fabric2d-` filter. NOTE: `fabric2d-torus-y-RxC` ids deliberately omit the
-`mesh-` infix, so `-k 'mesh-8x4'` does NOT select them — use `-k 'torus-y-8x4'` (or the
-shape-only `-k '8x4'` to catch all three families). They are kept out of the broad
-`mesh-RxC` selectors because the column-ring wrap is a single-galaxy (e.g. 110-c78) config.
+- Local IDs are `fabric2d-mesh-2x2`, `fabric2d-mesh-2x4`, the existing
+  one-link/two-link 4x2 diagnostics, and TorusY Nx1 proxies.
+- Production IDs are `fabric2d-torus-xy-8x4-{1,2}link`.
 """
 
 import pytest
 
 import ttnn
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
+    fabric2d_device_params,
+    torus_x_device_params,
+    torus_xy_device_params,
+    torus_y_device_params,
+)
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import get_max_payload_size
 
 
-def _mesh_param(shape, fabric, payload, nlinks, topo, topo_marker, test_id, reliability_mode=None):
+def _mesh_param(shape, fabric, payload, nlinks, topo_marker, test_id, reliability_mode=None):
     """Build a single pytest.param for the mesh_device parametrize axis.
 
     `topo_marker` is the CI hardware-class string consumed by the `requires_mesh_topology`
     pytest mark, NOT the test's mesh shape. For example, a (2,2) test uses `topo_marker=
     "mesh-4x2"` because (2,2) and (4,2) both run on the LoudBox "mesh-4x2"-class machine.
     """
-    device_params = {
-        "fabric_config": fabric,
-        "fabric_router_config": create_fabric_router_config(max_payload_size=payload),
-    }
+    profile = {
+        ttnn.FabricConfig.FABRIC_2D: fabric2d_device_params,
+        ttnn.FabricConfig.FABRIC_2D_TORUS_Y: torus_y_device_params,
+        ttnn.FabricConfig.FABRIC_2D_TORUS_XY: torus_xy_device_params,
+    }[fabric]
+    device_params = profile(fabric_payload_size=payload)
     if reliability_mode is not None:
         device_params["reliability_mode"] = reliability_mode
     return pytest.param(
         shape,
         device_params,
         nlinks,
-        topo,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=shape, topology=topo_marker),
         id=test_id,
     )
 
 
 ALL_MESH_CONFIGS = [
-    # 2-chip linear
+    # Existing two-chip rows cannot form a useful ring; migrate them one-for-one to Fabric2D.
     _mesh_param(
-        (2, 1), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 1, ttnn.Topology.Linear, "linear", "linear-2-1link"
+        (2, 1),
+        ttnn.FabricConfig.FABRIC_2D,
+        get_max_payload_size(),
+        1,
+        "linear",
+        "fabric2d-2x1-1link",
+        reliability_mode=ttnn.FabricReliabilityMode.RELAXED_INIT,
     ),
     _mesh_param(
-        (2, 1), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 2, ttnn.Topology.Linear, "linear", "linear-2-2link"
+        (2, 1),
+        ttnn.FabricConfig.FABRIC_2D,
+        get_max_payload_size(),
+        2,
+        "linear",
+        "fabric2d-2x1-2link",
+        reliability_mode=ttnn.FabricReliabilityMode.RELAXED_INIT,
     ),
-    # 4-chip linear
-    _mesh_param(
-        (4, 1), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 1, ttnn.Topology.Linear, "linear", "linear-4-1link"
-    ),
-    _mesh_param(
-        (4, 1), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 2, ttnn.Topology.Linear, "linear", "linear-4-2link"
-    ),
-    # 4-chip ring
-    _mesh_param(
-        (4, 1), ttnn.FabricConfig.FABRIC_1D_RING, get_max_payload_size(), 1, ttnn.Topology.Ring, "ring", "ring-4-1link"
-    ),
-    _mesh_param(
-        (4, 1), ttnn.FabricConfig.FABRIC_1D_RING, get_max_payload_size(), 2, ttnn.Topology.Ring, "ring", "ring-4-2link"
-    ),
-    # 2D mesh topologies
-    _mesh_param(
-        (2, 2), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 1, ttnn.Topology.Linear, "mesh-4x2", "mesh-2x2"
-    ),
-    _mesh_param(
-        (4, 2), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 1, ttnn.Topology.Linear, "mesh-4x2", "mesh-4x2"
-    ),
-    _mesh_param(
-        (2, 4), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 1, ttnn.Topology.Linear, "mesh-4x2", "mesh-2x4"
-    ),
-    # 8-chip linear
-    _mesh_param(
-        (8, 1), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 1, ttnn.Topology.Linear, "linear", "linear-8-1link"
-    ),
-    _mesh_param(
-        (8, 1), ttnn.FabricConfig.FABRIC_1D, get_max_payload_size(), 2, ttnn.Topology.Linear, "linear", "linear-8-2link"
-    ),
-    # 8-chip ring
-    _mesh_param(
-        (8, 1), ttnn.FabricConfig.FABRIC_1D_RING, get_max_payload_size(), 1, ttnn.Topology.Ring, "ring", "ring-8-1link"
-    ),
-    _mesh_param(
-        (8, 1), ttnn.FabricConfig.FABRIC_1D_RING, get_max_payload_size(), 2, ttnn.Topology.Ring, "ring", "ring-8-2link"
-    ),
-    # FABRIC_2D variants — every shape with rows>1 AND cols>1 is 2D-eligible.
-    # RELAXED_INIT matches the canonical pattern in test_prefill_block.py and is required
-    # on BH Galaxy for FABRIC_2D bring-up.
+    # Local policy: one 2x2 QuietBox case, canonical 2x4 LoudBox, and one 4x2 axis diagnostic.
     _mesh_param(
         (2, 2),
         ttnn.FabricConfig.FABRIC_2D,
         get_max_payload_size(),
         1,
-        ttnn.Topology.Linear,
         "mesh-4x2",
         "fabric2d-mesh-2x2",
         reliability_mode=ttnn.FabricReliabilityMode.RELAXED_INIT,
@@ -127,7 +91,6 @@ ALL_MESH_CONFIGS = [
         ttnn.FabricConfig.FABRIC_2D,
         get_max_payload_size(),
         1,
-        ttnn.Topology.Linear,
         "mesh-4x2",
         "fabric2d-mesh-4x2",
         reliability_mode=ttnn.FabricReliabilityMode.RELAXED_INIT,
@@ -137,7 +100,6 @@ ALL_MESH_CONFIGS = [
         ttnn.FabricConfig.FABRIC_2D,
         get_max_payload_size(),
         2,
-        ttnn.Topology.Linear,
         "mesh-4x2",
         "fabric2d-mesh-4x2-2link",
         reliability_mode=ttnn.FabricReliabilityMode.RELAXED_INIT,
@@ -147,90 +109,72 @@ ALL_MESH_CONFIGS = [
         ttnn.FabricConfig.FABRIC_2D,
         get_max_payload_size(),
         1,
-        ttnn.Topology.Linear,
         "mesh-4x2",
         "fabric2d-mesh-2x4",
         reliability_mode=ttnn.FabricReliabilityMode.RELAXED_INIT,
     ),
+    # Existing QuietBox SP proxy, with former linear/ring siblings collapsed by FabricConfig.
     _mesh_param(
-        (8, 4),
-        ttnn.FabricConfig.FABRIC_2D,
-        get_max_payload_size(),
-        1,
-        ttnn.Topology.Linear,
-        "mesh-8x4",
-        "fabric2d-mesh-8x4-1link",
-        reliability_mode=ttnn.FabricReliabilityMode.RELAXED_INIT,
-    ),
-    _mesh_param(
-        (8, 4),
-        ttnn.FabricConfig.FABRIC_2D,
-        get_max_payload_size(),
-        2,
-        ttnn.Topology.Linear,
-        "mesh-8x4",
-        "fabric2d-mesh-8x4-2link",
-        reliability_mode=ttnn.FabricReliabilityMode.RELAXED_INIT,
-    ),
-    # 8x4 single-galaxy column ring: FABRIC_2D_TORUS_Y wraps the row axis (mesh dim 0, the
-    # 8-long SP axis) into a ring; the column axis (dim 1, 4-wide) stays a line. The SP-axis
-    # collectives (cluster_axis=0) run Topology.Ring; get_usable_topology keeps Ring because
-    # the coords span the full 8-axis (WRAP). FABRIC_2D_TORUS_Y auto-selects
-    # single_bh_galaxy_torus_y_graph_descriptor.textproto, whose uniform `channels count: 2`
-    # gives the RING-closing row-7<->row-0 edge the same 2-link width as the LINE edges
-    # (matches the 110-c78 wiring, where that wrap is a normal 2-link on every column).
-    _mesh_param(
-        (8, 4),
+        (4, 1),
         ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
         get_max_payload_size(),
         1,
-        ttnn.Topology.Ring,
-        "mesh-8x4",
-        "fabric2d-torus-y-8x4-1link",
+        "ring",
+        "fabric2d-torus-y-4x1-1link",
         reliability_mode=ttnn.FabricReliabilityMode.RELAXED_INIT,
     ),
     _mesh_param(
-        (8, 4),
+        (4, 1),
         ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
         get_max_payload_size(),
         2,
-        ttnn.Topology.Ring,
-        "mesh-8x4",
-        "fabric2d-torus-y-8x4-2link",
+        "ring",
+        "fabric2d-torus-y-4x1-2link",
         reliability_mode=ttnn.FabricReliabilityMode.RELAXED_INIT,
     ),
-    # Experiment: TORUS_XY wraps both axes (different deadlock-dateline placement than
-    # TORUS_Y). The dispatch op still rings on cluster_axis=0 (the 8-dim). Probing whether
-    # the dateline axis affects the multi-hop-over-wrap dispatch hang.
+    # Existing LoudBox SP proxy, migrated from the former linear/ring Fabric1d siblings.
+    _mesh_param(
+        (8, 1),
+        ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
+        get_max_payload_size(),
+        1,
+        "ring",
+        "fabric2d-torus-y-8x1-1link",
+        reliability_mode=ttnn.FabricReliabilityMode.RELAXED_INIT,
+    ),
+    _mesh_param(
+        (8, 1),
+        ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
+        get_max_payload_size(),
+        2,
+        "ring",
+        "fabric2d-torus-y-8x1-2link",
+        reliability_mode=ttnn.FabricReliabilityMode.RELAXED_INIT,
+    ),
+    # Galaxy production policy: existing full 8x4 TorusXY, Ring on the exercised SP axis.
     _mesh_param(
         (8, 4),
         ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
         get_max_payload_size(),
-        1,
-        ttnn.Topology.Ring,
+        2,
         "mesh-8x4",
-        "fabric2d-torus-xy-8x4-1link",
+        "fabric2d-torus-xy-8x4-2link",
         reliability_mode=ttnn.FabricReliabilityMode.RELAXED_INIT,
     ),
 ]
 
 
-def _fabric_cfg_to_init_reliability_mode(fabric_cfg):
-    # For fabric 1d the param is omitted. For fabric 2d ideally it would be strict for reliable perf measurements
-    # Until CI HW supports it, use relaxed
-    if fabric_cfg in (ttnn.FabricConfig.FABRIC_1D, ttnn.FabricConfig.FABRIC_1D_RING):
-        return None
-    else:
-        return ttnn.FabricReliabilityMode.RELAXED_INIT
-
-
 def fabric_to_device_params(fabric_cfg):
-    device_params = {
-        "fabric_config": fabric_cfg,
-        "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-    }
-    reliability_mode = _fabric_cfg_to_init_reliability_mode(fabric_cfg)
-    if reliability_mode is not None:
-        device_params["reliability_mode"] = reliability_mode
-
-    return device_params
+    assert fabric_cfg in (
+        ttnn.FabricConfig.FABRIC_2D,
+        ttnn.FabricConfig.FABRIC_2D_TORUS_X,
+        ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
+        ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
+    )
+    if fabric_cfg == ttnn.FabricConfig.FABRIC_2D:
+        return fabric2d_device_params()
+    if fabric_cfg == ttnn.FabricConfig.FABRIC_2D_TORUS_X:
+        return torus_x_device_params()
+    if fabric_cfg == ttnn.FabricConfig.FABRIC_2D_TORUS_Y:
+        return torus_y_device_params()
+    return torus_xy_device_params()

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ffn.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ffn.py
@@ -16,6 +16,8 @@ from tracy import signpost
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.tt.moe.expert import TorchExpert
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_x_device_params
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_ffn import EMB_DIM, HIDDEN_DIM, TtFfn
 from models.tt_transformers.tt.ccl import get_num_links
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -23,23 +25,14 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 
 @pytest.mark.parametrize("batch_seq_len", [4096, 3200], ids=["4K", "3.2K"])
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (1, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            torus_x_device_params(),
             1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="linear"),
-            id="linear-4",
-        ),
-        pytest.param(
-            (1, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING},
-            1,
-            ttnn.Topology.Ring,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="ring"),
-            id="ring-4",
+            id="torus-x-1x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -49,7 +42,6 @@ def test_ffn_pcc(
     device_params,
     batch_seq_len: int,
     num_links: int,
-    topology: ttnn.Topology,
 ):
     """
     Test TtFfn PCC against TorchExpert reference.
@@ -64,6 +56,7 @@ def test_ffn_pcc(
     activations_dtype = ttnn.bfloat16
     weights_dtype = ttnn.bfloat8_b
 
+    topology = per_axis_topology(device_params["fabric_config"])[1]
     num_devices = mesh_device.get_num_devices()
     mesh_shape = mesh_device.shape
     logger.debug(f"Testing with mesh_shape={mesh_shape}, num_devices={num_devices}")
@@ -127,6 +120,9 @@ def test_ffn_pcc(
     logger.debug(f"TTNN output converted to torch: {tt_output_torch.shape}")
 
     logger.debug("Comparing outputs with PCC")
+    # The 2x4 Fabric2D profile replicates this TP-only FFN across both SP rows. The composer concatenates
+    # those replicas on the sequence dimension, so validate each replica against the same Torch output.
+    torch_output = torch_output.repeat(mesh_shape[0], 1)
     pcc_passed, pcc_message = assert_with_pcc(
         torch_output.to(torch.float32),
         tt_output_torch.to(torch.float32),

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_lm_head.py
@@ -15,7 +15,13 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
+    fabric2d_device_params,
+    torus_x_device_params,
+    torus_xy_device_params,
+)
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import extract_mesh_config
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_lm_head import TtLMHead
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -62,41 +68,35 @@ def random_weights(config, emb_dim: int, vocab_size: int, dtype: torch.dtype):
     ],
 )
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (1, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING},
+            torus_x_device_params(),
             1,
-            ttnn.Topology.Ring,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="ring"),
-            id="1x4-ring",
+            id="torus-x-1x4",
         ),
         pytest.param(
             (2, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING},
+            fabric2d_device_params(),
             1,
-            ttnn.Topology.Ring,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="ring"),
-            id="2x2-ring",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
+            id="fabric2d-2x2",
         ),
         pytest.param(
             (2, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            fabric2d_device_params(),
             1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
-            id="2x4-linear",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+            id="fabric2d-2x4",
         ),
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-            },
+            torus_xy_device_params(),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -110,7 +110,6 @@ def test_lm_head(
     vocab_size: int,
     run_full_pcc_check: bool,
     num_links: int,
-    topology: ttnn.Topology,
     is_balanced: bool,
     is_column_parallel: bool,
 ):
@@ -119,6 +118,7 @@ def test_lm_head(
 
     Torch dtypes are set inline; TTNN dtypes are derived automatically.
     """
+    topology = per_axis_topology(device_params["fabric_config"])[1]
     if batch_seq_len != ttnn.TILE_SIZE and run_full_pcc_check:
         pytest.skip("PCC check is only run for seq_len == TILE_SIZE to avoid slicing complexities")
 

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
@@ -24,6 +24,7 @@ from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Confi
 from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
 from models.demos.deepseek_v3_d_p.reference.minimax_m2_7.modeling_minimax_m2 import MiniMaxM2SparseMoeBlock
 from models.demos.deepseek_v3_d_p.reference.minimax_m2_7_config import MiniMaxM27Config
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     GATE_KEY_PREFIX_DEEPSEEK,
     GATE_KEY_PREFIX_KIMI_K3,
@@ -48,6 +49,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
     validate_composed,
 )
 from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_validation_results
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.utils.test_utils import adjust_shapes_for_testing, get_input_mem_config
 from models.demos.deepseek_v3_d_p.utils.transformer_helpers import GOLDEN_LONGBOOK_TRACE, load_trace_gate_input
 
@@ -184,71 +186,31 @@ def _try_load_real_gate_input(max_seq_len: int, dim: int) -> torch.Tensor | None
 MESH_CONFIGS = [
     pytest.param(
         (2, 2),
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-        },
+        fabric2d_device_params(),
         2,
-        ttnn.Topology.Linear,
-        marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
-        id="mesh-2x2",
-    ),
-    pytest.param(
-        (2, 2),
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-        },
-        2,
-        ttnn.Topology.Linear,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
         id="fabric2d-mesh-2x2",
     ),
     pytest.param(
         (4, 2),
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-        },
+        fabric2d_device_params(),
         2,
-        ttnn.Topology.Linear,
-        marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
-        id="mesh-4x2",
-    ),
-    pytest.param(
-        (4, 2),
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-        },
-        2,
-        ttnn.Topology.Linear,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
         id="fabric2d-mesh-4x2",
     ),
     pytest.param(
         (2, 4),
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-        },
+        fabric2d_device_params(),
         2,
-        ttnn.Topology.Linear,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
-        id="mesh-2x4",
+        id="fabric2d-mesh-2x4",
     ),
     pytest.param(
         (8, 4),
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-        },
+        torus_xy_device_params(),
         2,
-        ttnn.Topology.Linear,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-        id="mesh-8x4",
+        id="torus-xy-8x4",
     ),
 ]
 
@@ -507,15 +469,15 @@ def _reference_topk(config, gate_model, gate_fallback_mode, gate_w, torch_input)
 
 @pytest.mark.parametrize("gate_model, gate_fallback_mode", REGULAR_GATE_CASES)
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     MESH_CONFIGS,
     indirect=["mesh_device", "device_params"],
 )
 def test_forward_pass(
     gate_model,
     mesh_device,
+    device_params,
     num_links,
-    topology,
     gate_fallback_mode,
 ):
     """Gate PCC across model variants and compute modes. The gate picks grouped vs plain top-k from
@@ -526,6 +488,7 @@ def test_forward_pass(
 
     config = _gate_config(gate_model)
     config.ccl_config["NUM_LINKS"] = num_links
+    config.ccl_config["TOPOLOGY"] = per_axis_topology(device_params["fabric_config"])[config.ccl_config["TP_AXIS"]]
     adjust_shapes_for_testing(config, mesh_device)
 
     # DeepSeek-V3's weights can't be reshaped to other expert counts or activations, so that path
@@ -607,7 +570,7 @@ HASH_GATE_MODES = [
 @pytest.mark.parametrize("gate_model", ["dsv4_pro", "dsv4_flash"])
 @pytest.mark.parametrize("gate_compute_mode", HASH_GATE_MODES)
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     MESH_CONFIGS,
     indirect=["mesh_device", "device_params"],
 )
@@ -615,8 +578,8 @@ def test_hash_gate_forward_pass(
     gate_model,
     gate_compute_mode,
     mesh_device,
+    device_params,
     num_links,
-    topology,
 ):
     """DeepSeek-V4 hash-routing gate PCC (host-first HASH_HOST and on-device HASH_DEVICE).
 
@@ -631,6 +594,7 @@ def test_hash_gate_forward_pass(
 
     config = _gate_config(gate_model)
     config.ccl_config["NUM_LINKS"] = num_links
+    config.ccl_config["TOPOLOGY"] = per_axis_topology(device_params["fabric_config"])[config.ccl_config["TP_AXIS"]]
     adjust_shapes_for_testing(config, mesh_device)
 
     gate_w = create_gate_weights(config.n_routed_experts, config.dim)

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_routing_setup.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_routing_setup.py
@@ -16,12 +16,12 @@ from tracy import signpost
 
 import ttnn
 from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_y_device_params
 
 # from models.demos.deepseek_v3_d_p.reference.moe.dispatch import TorchDispatchModule
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     ExpertMapping,
     compute_constants,
-    create_fabric_router_config,
     extract_mesh_config,
     get_ep_mesh_composer,
     get_gate_outputs,
@@ -37,6 +37,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
     validate_replication,
 )
 from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert_dispatch_table, log_validation_results
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 
 
 # dispatch_buffer_capacity_factor below is ceil(N/2) of the most conservative
@@ -49,63 +50,35 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_expert
     ],
 )
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (4, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
-            },
+            torus_y_device_params(fabric_payload_size=7 * 1024),
             2 if is_blackhole() else 1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="linear"),
-            id="linear-4",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 1), topology="ring"),
+            id="torus-y-4x1",
         ),
         pytest.param(
             (8, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
-            },
+            torus_y_device_params(fabric_payload_size=7 * 1024),
             2 if is_blackhole() else 1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
-            id="linear-8",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
+            id="torus-y-8x1",
         ),
         pytest.param(
             (4, 2),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
-            },
+            fabric2d_device_params(fabric_payload_size=7 * 1024),
             2 if is_blackhole() else 1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
-            id="mesh-4x2",
-        ),
-        pytest.param(
-            (4, 2),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
-                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-            },
-            2 if is_blackhole() else 1,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
             id="fabric2d-mesh-4x2",
         ),
         pytest.param(
             (2, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=7 * 1024),
-            },
+            fabric2d_device_params(fabric_payload_size=7 * 1024),
             2 if is_blackhole() else 1,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
-            id="mesh-2x4",
+            id="fabric2d-mesh-2x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -120,7 +93,7 @@ def test_prep_dispatch_combine(
     num_experts_per_tok,
     dispatch_buffer_capacity_factor,
     num_links,
-    topology,
+    device_params,
     use_predictable_data,
     padded_percent,
 ):
@@ -149,6 +122,7 @@ def test_prep_dispatch_combine(
             dispatch_group_size dimension). Equals global_expert_offsets minus the
             per-source-device local offset.
     """
+    topology = per_axis_topology(device_params["fabric_config"])[0]
     torch.manual_seed(42)
     num_devices = mesh_device.get_num_devices()
 

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_parallel_embedding.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_parallel_embedding.py
@@ -17,6 +17,7 @@ from tracy import signpost
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_x_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import get_tp_mesh_composer
 from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
 from tests.ttnn.utils_for_testing import comp_pcc
@@ -34,15 +35,15 @@ from tests.ttnn.utils_for_testing import comp_pcc
     [
         pytest.param(
             (1, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="linear"),
-            id="linear-4",
+            torus_x_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="ring"),
+            id="torus-x-1x4",
         ),
         pytest.param(
             (2, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            fabric2d_device_params(),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
-            id="mesh-2x4",
+            id="fabric2d-2x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_rmsnorm.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_rmsnorm.py
@@ -18,6 +18,8 @@ from loguru import logger
 from tracy import signpost
 
 import ttnn
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_x_device_params
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -30,15 +32,9 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     [
         pytest.param(
             (1, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="linear"),
-            id="linear-4",
-        ),
-        pytest.param(
-            (1, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING},
+            torus_x_device_params(),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="ring"),
-            id="ring-4",
+            id="torus-x-1x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -60,7 +56,7 @@ def test_rmsnorm_distributed(mesh_device, device_params, isl_per_chip, emb_dim, 
 
     num_devices = mesh_device.get_num_devices()
     mesh_shape = mesh_device.shape
-    per_device_width = emb_dim // num_devices
+    per_device_width = emb_dim // mesh_shape[1]
 
     # 4D shapes for distributed RMSNorm
     inp_shape_full = (1, 1, isl_per_chip, emb_dim)
@@ -69,9 +65,7 @@ def test_rmsnorm_distributed(mesh_device, device_params, isl_per_chip, emb_dim, 
     logger.debug(f"Testing with mesh_shape={mesh_shape}, num_devices={num_devices}")
     logger.debug(f"Full input: {inp_shape_full}, per-device: {inp_shape_per_device}")
 
-    # Determine topology from fabric config
-    fabric_config = device_params.get("fabric_config", ttnn.FabricConfig.FABRIC_1D)
-    topology = ttnn.Topology.Ring if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING else ttnn.Topology.Linear
+    topology = per_axis_topology(device_params["fabric_config"])[1]
     logger.debug(f"Using topology: {topology}")
 
     signpost(f"RMSNorm PCC test - {mesh_shape=} {isl_per_chip=} {emb_dim=} {num_links=} {topology=}")
@@ -131,6 +125,9 @@ def test_rmsnorm_distributed(mesh_device, device_params, isl_per_chip, emb_dim, 
     # Compare output against PyTorch reference
     # ============================================
     logger.debug("Comparing distributed RMSNorm vs PyTorch reference")
+    # The 2x4 Fabric2D profile replicates the TP-sharded tensor across the two SP rows. The composer
+    # concatenates those replicas on dim 0, so validate every replica against the same reference.
+    torch_reference = torch_reference.expand(mesh_shape[0], -1, -1, -1)
     pcc_passed, pcc_message = assert_with_pcc(
         torch_reference.to(torch.float32),
         tt_distributed_torch.to(torch.float32),

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
@@ -17,7 +17,9 @@ from tracy import signpost
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.expert import TorchExpert
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_x_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import TtSharedExpert
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.tt_transformers.tt.ccl import get_num_links
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
@@ -37,31 +39,21 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     ids=["4K", "3.2K", "3.2K-k3-6144"],
 )
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (1, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            torus_x_device_params(),
             1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="linear"),
-            id="linear-4",
-        ),
-        pytest.param(
-            (1, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING},
-            1,
-            ttnn.Topology.Ring,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(1, 4), topology="ring"),
-            id="ring-4",
+            id="torus-x-1x4",
         ),
         pytest.param(
             (2, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+            fabric2d_device_params(),
             1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="linear"),
-            id="mesh-2x4",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+            id="fabric2d-2x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -73,7 +65,6 @@ def test_shared_expert_pcc(
     emb_dim: int,
     hidden_dim: int,
     num_links: int,
-    topology: ttnn.Topology,
 ):
     """
     Test TtSharedExpert PCC against TorchExpert reference.
@@ -88,6 +79,7 @@ def test_shared_expert_pcc(
 
     activations_dtype = ttnn.bfloat16
     weights_dtype = ttnn.bfloat8_b
+    topology = per_axis_topology(device_params["fabric_config"])[1]
 
     num_devices = mesh_device.get_num_devices()
     mesh_shape = mesh_device.shape

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_hca.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_hca.py
@@ -31,8 +31,8 @@ from models.demos.deepseek_v3_d_p.reference.deepseek_v4.modeling_deepseek_v4 imp
 )
 from models.demos.deepseek_v3_d_p.reference.deepseek_v4_flash_config import DeepSeekV4FlashConfig
 from models.demos.deepseek_v3_d_p.reference.deepseek_v4_pro_config import DeepSeekV4ProConfig
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.mla.heavily_compressed_attention import TtHCA, TtHCACompressor
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
 from tests.ttnn.utils_for_testing import assert_with_pcc
 
 # Real (pre-pad) prompt lengths. prepare_input pads each up to compress_rate*sp, so the ragged ones
@@ -98,28 +98,24 @@ _MODEL_CONFIGS_FORWARD = [pytest.param(cfg, fwd, id=name) for name, cfg, _, _, f
 _MESH_CONFIGS = [
     pytest.param(
         (2, 2),
-        {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+        fabric2d_device_params(),
         ttnn.Topology.Linear,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
-        id="mesh-2x2",
+        id="fabric2d-mesh-2x2",
     ),
     pytest.param(
         (4, 2),
-        {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+        fabric2d_device_params(),
         ttnn.Topology.Linear,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
-        id="mesh-4x2",
+        id="fabric2d-mesh-4x2",
     ),
     pytest.param(
         (8, 4),
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-        },
-        ttnn.Topology.Linear,
+        torus_xy_device_params(),
+        ttnn.Topology.Ring,
         marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-        id="fabric2d-mesh-8x4",
+        id="torus-xy-8x4",
     ),
 ]
 

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -29,11 +29,15 @@ from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Confi
 from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.expert import ACTIVATION_SILU, ACTIVATION_SITU
 from models.demos.deepseek_v3_d_p.reference.tt.moe.moe import TorchMoe
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
+    fabric2d_device_params,
+    torus_xy_device_params,
+    torus_y_device_params,
+)
 from models.demos.deepseek_v3_d_p.tests.reference_runners import run_reference_moe
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     ExpertMapping,
     compute_constants,
-    create_fabric_router_config,
     create_gate_weights,
     create_latent_weights,
     create_shared_expert_weights,
@@ -60,6 +64,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import (
     log_validation_results,
     visualize_expert_dispatch_table,
 )
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker
 from models.demos.deepseek_v3_d_p.utils.transformer_helpers import GOLDEN_LONGBOOK_TRACE, load_trace_gate_input
 from tests.ttnn.utils_for_testing import comp_pcc
@@ -139,19 +144,6 @@ def run_model(
         raise ValueError(f"no torch reference for {routed_activation}; supported: {list(_TORCH_ROUTED_ACTIVATION)}")
     torch_routed_activation = _TORCH_ROUTED_ACTIVATION[routed_activation]
     upstream_activation = _UPSTREAM_ACT[routed_activation]
-
-    # Scoped: only the linear-8 / 64-expert / HOST_ALL / pcc-check case OOMs without this.
-    # Cached all-gather semaphores get placed at the wrong offset for that specific config.
-    # Test ID matched: test_ttnn_moe[blackhole-linear-8-1600-7168-2048-64-8-2-GateComputeMode.HOST_ALL-True]
-    n_sp_devices_pre, n_tp_devices_pre = mesh_device.shape
-    if (
-        n_sp_devices_pre == 8
-        and n_tp_devices_pre == 1
-        and num_routed_experts == 64
-        and gate_fallback_mode == GateComputeMode.HOST_ALL
-        and run_pcc_check
-    ):
-        mesh_device.disable_and_clear_program_cache()
 
     profiler.clear()
     profiler.start("test_ttnn_moe")
@@ -725,73 +717,35 @@ def run_model(
 )
 @pytest.mark.parametrize("padded_percent", [0, 50], ids=lambda p: f"pad{p}")
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-            },
+            torus_y_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
             2 if is_blackhole() else 1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
-            id="linear-8",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
+            id="torus-y-8x1",
         ),
         pytest.param(
             (4, 2),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-            },
+            fabric2d_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
             2 if is_blackhole() else 1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
-            id="mesh-4x2",
-        ),
-        pytest.param(
-            (4, 2),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-            },
-            2 if is_blackhole() else 1,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
             id="fabric2d-mesh-4x2",
         ),
         pytest.param(
             (2, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-            },
+            fabric2d_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
             2 if is_blackhole() else 1,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
-            id="mesh-2x4",
+            id="fabric2d-mesh-2x4",
         ),
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-            },
+            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
             2 if is_blackhole() else 1,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -811,11 +765,11 @@ def test_ds_moe(
     run_pcc_check,
     is_balanced,
     num_links,
-    topology,
     gate_fallback_mode,
     request,
     padded_percent,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])
     run_model(
         variant,
         config_only,
@@ -852,44 +806,28 @@ def test_ds_moe(
     ],
 )
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 1),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-            },
+            torus_y_device_params(fabric_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
             2 if is_blackhole() else 1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
-            id="linear-8",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="ring"),
+            id="torus-y-8x1",
         ),
         pytest.param(
             (4, 2),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-            },
+            fabric2d_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
             2 if is_blackhole() else 1,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
-            id="mesh-4x2",
+            id="fabric2d-mesh-4x2",
         ),
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
-            },
+            torus_xy_device_params(fabric_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
             2 if is_blackhole() else 1,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -908,10 +846,10 @@ def test_kimi_moe(
     dispatch_buffer_capacity_factor,
     run_pcc_check,
     num_links,
-    topology,
     gate_fallback_mode,
     request,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])
     run_model(
         variant,
         config_only,
@@ -950,33 +888,23 @@ def test_kimi_moe(
     ],
 )
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         # Loudbox proxy for local bring-up; no pipeline selects it. TP stays 4 as on the 8x4 anchor:
         # at TP=1 the shared expert is unsharded and its gate matmul's CBs exceed L1.
         pytest.param(
             (2, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK3Config.FABRIC_PAYLOAD_SIZE),
-                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-            },
+            fabric2d_device_params(fabric_payload_size=KimiK3Config.FABRIC_PAYLOAD_SIZE),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="fabric2d-mesh-2x4",
         ),
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK3Config.FABRIC_PAYLOAD_SIZE),
-                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-            },
+            torus_xy_device_params(fabric_payload_size=KimiK3Config.FABRIC_PAYLOAD_SIZE),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="fabric2d-mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -995,7 +923,6 @@ def test_kimi_k3_moe(
     dispatch_buffer_capacity_factor,
     run_pcc_check,
     num_links,
-    topology,
     gate_fallback_mode,
     request,
 ):
@@ -1021,6 +948,7 @@ def test_kimi_k3_moe(
     after the sum. The failure mode to avoid is hunting a kernel defect that is really accumulation
     error.
     """
+    topology = per_axis_topology(device_params["fabric_config"])
     run_model(
         variant,
         config_only,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py
@@ -6,22 +6,19 @@
 Device performance tests for DeepSeekv3/KimiK2.6/GLM5.2 MoE dispatch and combine operations.
 
 Runs test_prefill_dispatch_combine.py::test_ttnn_dispatch_combine[perf_captured_<model>_chunk]
-(<model> in {dsv3, kimi26, glm52}) on an LB 8x1 mesh. It replays the hottest (layer, col) pairs from a real prefill
-capture. The operation sequence is the same as the production workflow.
+(<model> in {dsv3, kimi26, glm52}) on the existing LB 8x1 proxy migrated to Fabric2D TorusY. It replays the hottest
+(layer, col) pairs from a real prefill capture. The operation sequence is the same as the
+production workflow.
 Tests that were ran in order to capture the routing data:
 
 The captures hold Galaxy-global expert IDs; the loader (`load_captured_routing`)
 shifts a column's own experts down to [0, experts_per_col) and sends the rest to
-sentinel (num_routed_experts-1), so the LB single-col combine kernel (first_expert_id=0) interprets
-them correctly, then slices the gate outputs to [0:1] for LB's single dispatch
-group. The per-model kernel config lives in the worker's parametrize entries.
+sentinel (num_routed_experts-1), then runs one Galaxy column on the LoudBox.
 """
 
 import pytest
 
 from models.demos.deepseek_v3_d_p.utils.perf_utils import run_model_device_perf_test_per_op
-
-_REAL_INDICES_TOPOS = [("linear", 2), ("ring", 2)]
 
 # Picks come from the production 11x5120 chunked-prefill run (code_debug), for DSv3 and KimiK2.6.
 # One chunk per case: 5120 tokens over the 8-chip dispatch group => seq_len_per_chip 640.
@@ -46,68 +43,44 @@ _GLM52_CHUNK_PICKS = [
     (14, 2),  # 25.0%
     (10, 0),  # 25.0%
 ]
-# Key is (topo, nlinks, layer, col). Baselines are single tracy runs on LB 8x1
-# (run-to-run spread measured at ~0.5%, well inside the margins below).
-_DISPATCH_DS_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
-    ("linear", 2, 19, 2): 1_436_892,
-    ("linear", 2, 29, 0): 1_611_611,
-    ("linear", 2, 4, 2): 828_157,
-    ("linear", 2, 56, 3): 1_121_669,
-    ("ring", 2, 19, 2): 872_934,
-    ("ring", 2, 29, 0): 837_074,
-    ("ring", 2, 4, 2): 552_136,
-    ("ring", 2, 56, 3): 634_804,
+# Key is (layer, col). The retained values are the old ring-profile measurements and are
+# migration starting points for Fabric2D TorusY on the same LoudBox proxy.
+_DISPATCH_DS_CHUNK_EXPECTED_NS: dict[tuple[int, int], int] = {
+    (19, 2): 872_934,
+    (29, 0): 837_074,
+    (4, 2): 552_136,
+    (56, 3): 634_804,
 }
-_COMBINE_DS_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
-    ("linear", 2, 19, 2): 1_716_614,
-    ("linear", 2, 29, 0): 1_690_610,
-    ("linear", 2, 4, 2): 1_012_207,
-    ("linear", 2, 56, 3): 1_179_193,
-    ("ring", 2, 19, 2): 1_433_990,
-    ("ring", 2, 29, 0): 1_372_652,
-    ("ring", 2, 4, 2): 749_534,
-    ("ring", 2, 56, 3): 905_037,
+_COMBINE_DS_CHUNK_EXPECTED_NS: dict[tuple[int, int], int] = {
+    (19, 2): 1_433_990,
+    (29, 0): 1_372_652,
+    (4, 2): 749_534,
+    (56, 3): 905_037,
 }
-_DISPATCH_KIMI_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
-    ("linear", 2, 45, 2): 1_236_188,
-    ("linear", 2, 48, 0): 1_459_057,
-    ("linear", 2, 30, 3): 788_904,
-    ("linear", 2, 32, 1): 797_993,
-    ("ring", 2, 45, 2): 878_836,
-    ("ring", 2, 48, 0): 806_776,
-    ("ring", 2, 30, 3): 553_826,
-    ("ring", 2, 32, 1): 555_157,
+_DISPATCH_KIMI_CHUNK_EXPECTED_NS: dict[tuple[int, int], int] = {
+    (45, 2): 878_836,
+    (48, 0): 806_776,
+    (30, 3): 553_826,
+    (32, 1): 555_157,
 }
-_COMBINE_KIMI_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
-    ("linear", 2, 45, 2): 1_558_296,
-    ("linear", 2, 48, 0): 1_642_857,
-    ("linear", 2, 30, 3): 1_068_094,
-    ("linear", 2, 32, 1): 1_123_141,
-    ("ring", 2, 45, 2): 1_267_431,
-    ("ring", 2, 48, 0): 1_291_803,
-    ("ring", 2, 30, 3): 870_001,
-    ("ring", 2, 32, 1): 848_981,
+_COMBINE_KIMI_CHUNK_EXPECTED_NS: dict[tuple[int, int], int] = {
+    (45, 2): 1_267_431,
+    (48, 0): 1_291_803,
+    (30, 3): 870_001,
+    (32, 1): 848_981,
 }
 
-_DISPATCH_GLM52_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
-    ("linear", 2, 3, 0): 1_859_463,
-    ("linear", 2, 8, 0): 1_331_674,
-    ("linear", 2, 14, 2): 766_664,
-    ("linear", 2, 10, 0): 819_157,
-    ("ring", 2, 3, 0): 1_247_679,
-    ("ring", 2, 8, 0): 815_378,
-    ("ring", 2, 14, 2): 493_043,
-    ("ring", 2, 10, 0): 473_592,
+_DISPATCH_GLM52_CHUNK_EXPECTED_NS: dict[tuple[int, int], int] = {
+    (3, 0): 1_247_679,
+    (8, 0): 815_378,
+    (14, 2): 493_043,
+    (10, 0): 473_592,
 }
-_COMBINE_GLM52_CHUNK_EXPECTED_NS: dict[tuple[str, int, int, int], int] = {
-    ("linear", 2, 3, 0): 2_071_561,
-    ("linear", 2, 8, 0): 1_543_287,
-    ("linear", 2, 14, 2): 898_859,
-    ("linear", 2, 10, 0): 977_011,
-    ("ring", 2, 3, 0): 1_576_451,
-    ("ring", 2, 8, 0): 1_218_739,
-    ("ring", 2, 14, 2): 692_124,
-    ("ring", 2, 10, 0): 806_988,
+_COMBINE_GLM52_CHUNK_EXPECTED_NS: dict[tuple[int, int], int] = {
+    (3, 0): 1_576_451,
+    (8, 0): 1_218_739,
+    (14, 2): 692_124,
+    (10, 0): 806_988,
 }
 
 # model -> (picks, dispatch baselines, combine baselines).
@@ -122,8 +95,6 @@ def _perf_param_per_op(
     op,
     worker_file,
     worker_test,
-    topo,
-    nlinks,
     expected_per_op: dict,
     margin: float = 0.03,
     captured_layer: int | None = None,
@@ -143,8 +114,8 @@ def _perf_param_per_op(
     to the pcc test dir. Override to `tests/perf` for workers that only run the
     perf path and shouldn't be collected by the PCC pipeline.
     """
-    worker_id = f"{topo}-8-{nlinks}link"
-    model_name = f"deepseek_v3_{op}_{topo}_8_{nlinks}link"
+    worker_id = "fabric2d-torus-y-8x1-2link"
+    model_name = f"deepseek_v3_{op}_torus_y_8x1_2link"
     use_captured = captured_layer is not None and captured_col is not None
     parametrize_id = f"perf_captured_{model}_chunk" if use_captured else "perf_no_pcc"
     k_filter = f"{parametrize_id} and {worker_id}"
@@ -163,7 +134,7 @@ def _perf_param_per_op(
         f"deepseek_v3_{op}",
         model_name,
         margin,
-        f"{topo}-8-{nlinks}link",
+        "torus-y-8x1-2link",
         extra_env,
     )
 
@@ -173,22 +144,19 @@ _DISPATCH_COMBINE_PERF_PARAMS = [
         "dispatch_combine",
         "test_prefill_dispatch_combine.py",
         "test_ttnn_dispatch_combine",
-        topo,
-        nlinks,
         expected_per_op={
-            "DispatchDeviceOperation": dispatch_ns[(topo, nlinks, layer, col)],
-            "CombineDeviceOperation": combine_ns[(topo, nlinks, layer, col)],
+            "DispatchDeviceOperation": dispatch_ns[(layer, col)],
+            "CombineDeviceOperation": combine_ns[(layer, col)],
         },
-        margin=0.045 if topo == "ring" else 0.03,
+        margin=0.045,
         captured_layer=layer,
         captured_col=col,
         model=model,
         worker_dir="models/demos/deepseek_v3_d_p/tests/perf",
     )
     for model, (picks, dispatch_ns, combine_ns) in _MODELS.items()
-    for topo, nlinks in _REAL_INDICES_TOPOS
     for layer, col in picks
-    if (topo, nlinks, layer, col) in dispatch_ns and (topo, nlinks, layer, col) in combine_ns
+    if (layer, col) in dispatch_ns and (layer, col) in combine_ns
 ]
 
 

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_k3_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_k3_moe_perf.py
@@ -43,9 +43,10 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tests.pcc.test_ttnn_moe import run_model
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.utils.perf_utils import adjust_margin_for_ddr_speed
 from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import is_high_power
 from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program_merged, require_realtime_profiler
@@ -83,27 +84,23 @@ _IGNORE_POWER = os.environ.get("K3_MOE_PERF_IGNORE_POWER") == "1"
 )
 @pytest.mark.timeout(0)
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK3Config.FABRIC_PAYLOAD_SIZE),
-                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-            },
+            torus_xy_device_params(fabric_payload_size=KimiK3Config.FABRIC_PAYLOAD_SIZE),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="fabric2d-mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize("variant", ["kimi_k3"], indirect=True, ids=["kimi_k3"])
-def test_kimi_k3_moe_perf_galaxy(variant, config_only, mesh_device, device_params, num_links, topology, request):
+def test_kimi_k3_moe_perf_galaxy(variant, config_only, mesh_device, device_params, num_links, request):
     """896 experts / top-16, 3584 latent: device time of one MoE forward at 5k ISL."""
     require_realtime_profiler("the Kimi-K3 MoE perf gate")
+    topology = per_axis_topology(device_params["fabric_config"])
 
     per_program = {}
 

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py
@@ -2,26 +2,34 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import pytest
 
 from models.demos.deepseek_v3_d_p.utils.perf_utils import (
     _is_galaxy_env,
     adjust_margin_for_ddr_speed,
-    run_mla_perf_with_approximation,
+    run_mla_perf_loudbox,
     run_model_device_perf_test_with_merge,
 )
 
 _TEST_PATH = "models/demos/deepseek_v3_d_p/tests/test_mla.py::test_ds_mla"
 
-_CMD_2X4 = f"pytest {_TEST_PATH} -k 'balanced-skip_check-seq100k-scaled_sl-random-line-2x4'"
-_CMD_8X4 = f"pytest {_TEST_PATH} -k 'balanced-skip_check-seq100k-scaled_sl-random-line-8x4'"
+_CMD_2X4 = f"pytest {_TEST_PATH} -k 'balanced and skip_check and seq100k and scaled_sl and random and fabric2d-2x4'"
+_CMD_8X4 = f"pytest {_TEST_PATH} -k 'balanced and skip_check and seq100k and scaled_sl and random and torus-xy-8x4'"
 
 # Kimi K2.6 chunked prefill: 50k KV-cache prefix + one fresh 5k chunk (chunk_size_global=5120). On
 # the 8x4 Galaxy (sp=8) this lands chunk_local=640 per chip, exercising the num_heads=64 chunked-only
 # 640 matmul/SDPA configs. Functional reference (no PCC) keeps the measured region to the single
 # forward (the 50k prefix is preloaded host->device before the MLA_START signpost, so it is not timed).
 _CHUNKED_TEST_PATH = "models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill"
-_CMD_CHUNKED_8X4 = f"pytest {_CHUNKED_TEST_PATH} -k 'deep-50k+5k and kimi and func and 8x4 and fabric2d'"
+_CMD_CHUNKED_8X4 = f"pytest {_CHUNKED_TEST_PATH} -k 'deep-50k+5k and kimi and func and torus-xy-8x4'"
+
+
+def _require_certified_torus_xy():
+    if os.getenv("PREFILL_TORUS_XY_CERTIFIED") != "1" or not os.getenv("TT_MESH_GRAPH_DESC_PATH"):
+        pytest.fail("TorusXY perf requires a certified Galaxy and explicit mesh graph descriptor")
+
 
 # Kimi K3 (NoPE + output gate, 96 heads): same scenario/mesh as the K2.6 command above. 'k3' not
 # 'kimi' in the -k -- the ids are disjoint so the two selectors cannot cross-match.
@@ -35,22 +43,20 @@ _CMD_CHUNKED_8X4 = f"pytest {_CHUNKED_TEST_PATH} -k 'deep-50k+5k and kimi and fu
 # this reason (13_947_233 vs a 7_118_649 baseline that matches one forward within 2%). The metadata
 # axis came in with 3d3c65f985b (#51624), predating both K3 commits. Fix is to pin 'and scalar'
 # there too and keep 7_118_649; left alone here so this change doesn't touch another CI baseline.
-_CMD_K3_CHUNKED_8X4 = f"pytest {_CHUNKED_TEST_PATH} -k 'deep-50k+5k and k3 and func and 8x4 and fabric2d and scalar'"
+_CMD_K3_CHUNKED_8X4 = f"pytest {_CHUNKED_TEST_PATH} " "-k 'deep-50k+5k and k3 and func and torus-xy-8x4 and scalar'"
 
 
 @pytest.mark.timeout(0)
 def test_deepseek_v3_mla_perf_loudbox():
-    """
-    Measures perf on LB in 2x4 mesh shape, validates against its own perf baseline, and computes the approximate Galaxy perf.
-    SDPA time is scaled by 4 (SP 2→8 = 4x, TP 4→4 = 1x) while other ops are added as-is.
-    """
-    run_mla_perf_with_approximation(
+    """Retain the existing 2x4 LoudBox proxy on unwrapped Fabric2D."""
+    run_mla_perf_loudbox(
         command_2x4=_CMD_2X4,
-        expected_ns_2x4=8_244_047,  # Recalibrated 2026-06-10 on BH LoudBox 2x4.
-        model_name_2x4="deepseek_v3_mla_lb_2x4",
+        # Measured 2026-08-15 on the BH LoudBox Fabric2D CI runner (run 31895358174).
+        expected_ns_2x4=8_857_393,
+        model_name_2x4="deepseek_v3_mla_lb_2x4_fabric2d",
         subdir="deepseek_v3_mla",
         margin=0.03,
-        comments_2x4="seq100k_scaled_lb_2x4_proxy",
+        comments_2x4="seq100k_scaled_lb_2x4_fabric2d_proxy",
     )
 
 
@@ -58,12 +64,15 @@ def test_deepseek_v3_mla_perf_loudbox():
 def test_deepseek_v3_mla_perf_galaxy():
     if not _is_galaxy_env():
         pytest.skip("This test requires 8x4 mesh - galaxy. (set MESH_DEVICE=TG)")
+    _require_certified_torus_xy()
 
     margin = adjust_margin_for_ddr_speed(0.03)
 
     run_model_device_perf_test_with_merge(
         command=_CMD_8X4,
-        expected_device_perf_ns_per_iteration=14_252_829,  # Recalibrated 2026-06-10 on bh-glx-110-c08u02; FABRIC_1D.
+        # Migration starting threshold: measured 2026-06-10 on bh-glx-110-c08u02 with FABRIC_1D.
+        # The first certified TorusXY result must be used to recalibrate it.
+        expected_device_perf_ns_per_iteration=14_252_829,
         subdir="deepseek_v3_mla",
         model_name="deepseek_v3_mla_glx_8x4",
         num_iterations=1,
@@ -80,11 +89,13 @@ def test_kimi_mla_chunked_perf_galaxy():
     640 matmul/SDPA configs end to end. Ground-truth 8x4 measurement (no 2x4 approximation)."""
     if not _is_galaxy_env():
         pytest.skip("This test requires 8x4 mesh - galaxy. (set MESH_DEVICE=TG)")
+    _require_certified_torus_xy()
 
     margin = adjust_margin_for_ddr_speed(0.03)
 
     run_model_device_perf_test_with_merge(
         command=_CMD_CHUNKED_8X4,
+        # Historical baseline: measured with unwrapped FABRIC_2D, not TorusXY.
         expected_device_perf_ns_per_iteration=7_118_649,
         subdir="deepseek_v3_mla",
         model_name="kimi_mla_chunked_glx_8x4",
@@ -110,21 +121,19 @@ def test_kimi_k3_mla_chunked_perf_galaxy():
     16 -> 24 (ideal work scales exactly 1.5x, measured 1.689x) -- 12.6% efficiency lost at identical
     shapes/grid/fidelity. Worth a targeted look before treating this baseline as the floor.
 
-    Not run through run_mla_perf_with_approximation: that helper predicts Galaxy by scaling only
-    RingJointSDPADeviceOperation, and its op sets do not know about g_proj or its all-gather, so the
-    extrapolation would read optimistic. This is a ground-truth 8x4 measurement instead.
+    This stays a ground-truth 8x4 measurement; a local 2x4 extrapolation would ignore g_proj and its
+    all-gather and read optimistic.
     """
     if not _is_galaxy_env():
         pytest.skip("This test requires 8x4 mesh - galaxy. (set MESH_DEVICE=TG)")
+    _require_certified_torus_xy()
 
     margin = adjust_margin_for_ddr_speed(0.03)
 
     run_model_device_perf_test_with_merge(
         command=_CMD_K3_CHUNKED_8X4,
-        # Measured 2026-08-04 on bh-glx-b06u08 (8x4, FABRIC_2D, DDR 14000); replaces a 9_966_109
-        # estimate that read 16% low. Two runs agreed to 0.02%. Not inflated by the sub-nominal DDR:
-        # K2.6 scalar-only on this box reads 6_984_119 vs its committed 7_118_649, i.e. 1.9% faster
-        # than the box those baselines came from.
+        # Migration starting threshold: measured 2026-08-04 on bh-glx-b06u08 with unwrapped FABRIC_2D.
+        # The first certified TorusXY result must be used to recalibrate it.
         expected_device_perf_ns_per_iteration=11_562_468,
         subdir="kimi_k3_mla",
         model_name="kimi_k3_mla_chunked_glx_8x4",

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
@@ -2,18 +2,9 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-MoE device-perf tests approximating glx 8x4 from LB (8-chip) proxies.
+"""MoE device-perf proxies on LoudBox plus production 8x4 TorusXY ground truth."""
 
-- `test_deepseek_v3_moe_perf_loudbox`: runs 8x1 and 2x4 proxies once each, validates
-  each against its own perf baseline, and in the same pass computes the approximate
-  8x4 galaxy total (SP ops from 8x1 + TP ops from 2x4). One test, two device runs,
-  three signals: per-proxy perf regression catches + approximation artifact.
-- `test_deepseek_v3_moe_perf_galaxy`: 8x4 ground truth (skipped off-glx).
-
-Sum of per-op approximation approximates one glx column's MoE block kernel time;
-the 8x4 ground-truth test is the reference the approximation is compared against.
-"""
+import os
 
 import pytest
 
@@ -26,50 +17,53 @@ from models.demos.deepseek_v3_d_p.utils.perf_utils import (
 
 _TEST_PATH = "models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe"
 
-# `and pad0` pins the padding parametrize (test_ttnn_moe.py adds pad0/pad50 ids) so each
-# command still selects exactly one case; pad0 keeps the no-padding baselines below valid.
-_CMD_8X1 = f"pytest {_TEST_PATH} -k 'perf-host-64 and linear-8 and pad0'"
-# `not fabric2d-` excludes the new FABRIC_2D parametrize ids in test_ttnn_moe.py (substring `mesh-2x4`/`mesh-8x4` would otherwise match).
-_CMD_2X4 = f"pytest {_TEST_PATH} -k 'perf-device-256 and mesh-2x4 and not linear-8 and not mesh-4x2 and not mesh-8x4 and not fabric2d- and pad0'"
-_CMD_8X4_pad0 = f"pytest {_TEST_PATH} -k 'perf-device-256 and mesh-8x4 and not linear-8 and not mesh-4x2 and not mesh-2x4 and not fabric2d- and pad0'"
-_CMD_8X4_pad50 = f"pytest {_TEST_PATH} -k 'perf-device-256 and mesh-8x4 and not linear-8 and not mesh-4x2 and not mesh-2x4 and not fabric2d- and pad50'"
+# `and pad0`/`and pad50` pins the padding parametrize so each command selects
+# exactly one production TorusXY case.
+_CMD_8X4_pad0 = f"pytest {_TEST_PATH} -k 'perf-device-256 and torus-xy-8x4 and pad0'"
+_CMD_8X4_pad50 = f"pytest {_TEST_PATH} -k 'perf-device-256 and torus-xy-8x4 and pad50'"
+_CMD_8X1 = f"pytest {_TEST_PATH} -k 'perf-host-64 and torus-y-8x1 and pad0'"
+_CMD_2X4 = f"pytest {_TEST_PATH} -k 'perf-device-256 and fabric2d-mesh-2x4 and pad0'"
+
+
+def _require_certified_torus_xy():
+    if os.getenv("PREFILL_TORUS_XY_CERTIFIED") != "1" or not os.getenv("TT_MESH_GRAPH_DESC_PATH"):
+        pytest.fail("TorusXY perf requires a certified Galaxy and explicit mesh graph descriptor")
 
 
 @pytest.mark.timeout(0)
 def test_deepseek_v3_moe_perf_loudbox():
-    """
-    Run 8x1 + 2x4 proxies once each on loudbox (BH-LoudBox, 8xP150).
-    Validates each proxy against its own baseline AND computes the approximate
-    8x4 total from the same two CSVs (no extra device work).
+    """Run the existing 8x1 + 2x4 proxies and retain their 8x4 approximation signal.
+
+    The 8x1 SP proxy is migrated from Fabric1d Linear to Fabric2d TorusY; the 2x4 TP proxy is
+    migrated to unwrapped Fabric2d because its two-wide SP dimension cannot form a useful ring.
     """
     run_moe_perf_with_approximation(
         command_8x1=_CMD_8X1,
-        # Recalibrated 2026-07-27 on BH LoudBox 8x1 after routed expert optimization with removing prezeroing
-        # Was 15_506_174.
-        expected_ns_8x1=14_549_108,
-        model_name_8x1="deepseek_v3_moe_lb_8x1_dispatch_combine",
+        expected_ns_8x1=15_393_888,  # Mean of two post-migration Fabric2D TorusY runs on 2026-08-15.
+        model_name_8x1="deepseek_v3_moe_lb_8x1_torus_y_dispatch_combine",
         command_2x4=_CMD_2X4,
-        # Recalibrated 2026-07-27 on BH LoudBox 2x4 for. Was 23_956_009.
-        expected_ns_2x4=15_954_784,
-        model_name_2x4="deepseek_v3_moe_lb_2x4_gate",
+        expected_ns_2x4=17_217_341,  # Recalibrated 2026-08-14 on this LoudBox with Fabric2D.
+        model_name_2x4="deepseek_v3_moe_lb_2x4_fabric2d_gate",
         subdir="deepseek_v3_moe",
         margin=0.03,
-        comments_8x1="seq3200_lb_8x1_dispatch_combine_proxy",
-        comments_2x4="seq3200_lb_2x4_gate_proxy",
+        comments_8x1="seq3200_lb_8x1_torus_y_dispatch_combine_proxy",
+        comments_2x4="seq3200_lb_2x4_fabric2d_gate_proxy",
     )
 
 
 @pytest.mark.timeout(0)
 def test_deepseek_v3_moe_perf_galaxy():
-    """8x4 galaxy ground truth — the reference the loudbox approximation targets."""
+    """Measure the production 8x4 TorusXY Galaxy path without padding."""
     if not _is_galaxy_env():
         pytest.skip("This test requires 8x4 mesh - galaxy. (set MESH_DEVICE=TG)")
+    _require_certified_torus_xy()
 
     margin = adjust_margin_for_ddr_speed(0.03)
 
     run_model_device_perf_test_with_merge(
         command=_CMD_8X4_pad0,
-        expected_device_perf_ns_per_iteration=21_028_751,  # Recalibrated 2026-07-26
+        # Historical baseline: measured with FABRIC_1D, not TorusXY.
+        expected_device_perf_ns_per_iteration=21_028_751,
         subdir="deepseek_v3_moe",
         model_name="deepseek_v3_moe_glx_8x4",
         num_iterations=1,
@@ -84,12 +78,14 @@ def test_deepseek_v3_moe_perf_galaxy_pad50():
     """8x4 galaxy ground truth with 50% right-padding + padding-aware routing (zigzag placement)."""
     if not _is_galaxy_env():
         pytest.skip("This test requires 8x4 mesh - galaxy. (set MESH_DEVICE=TG)")
+    _require_certified_torus_xy()
 
     margin = adjust_margin_for_ddr_speed(0.03)
 
     run_model_device_perf_test_with_merge(
         command=_CMD_8X4_pad50,
-        expected_device_perf_ns_per_iteration=14_107_228,  # Recalibrated 2026-07-27 (perf improvement, was 15_719_590).
+        # Historical baseline: measured with FABRIC_1D, not TorusXY.
+        expected_device_perf_ns_per_iteration=14_107_228,
         subdir="deepseek_v3_moe",
         model_name="deepseek_v3_moe_glx_8x4_pad50",
         num_iterations=1,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
@@ -2,148 +2,56 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Prefill block-level device-perf tests with real pretrained weights.
-
-- `block_8x4_layer0_dense`: full MLA + dense FFN block on an 8x4 galaxy mesh. Measures
-  MLA, dense FFN, norms, and residual adds. Gives a baseline without the MoE path.
-- `block_8x4_layer3_moe`: full MLA + MoE block on an 8x4 galaxy mesh (gate + dispatch +
-  routed experts + combine + shared expert + reduce). Subtract the dense-layer number to
-  isolate MoE overhead.
-- `block_2x4_layer3_moe`: full MLA + MoE block on a 2x4 2-link mesh, using the smaller
-  `isl_6k4` configuration for real-weights perf coverage on that topology.
-
-All three run 1 iteration with `skip_reference=True` (no torch reference, bfp8/bfp4
-production dtypes). The 8x4 cases run at `isl_total=25*1024` (`isl_25k`), while the 2x4
-case runs at `isl_total=6*1024+512` (`isl_6k4`). Requires the appropriate hardware for the
-selected mesh topology and `DEEPSEEK_V3_HF_MODEL` pointing to the pretrained checkpoint.
-"""
+"""Device-perf wrappers for local Fabric2D, 4x4 subtorus, and production TorusXY workloads."""
 
 import os
 import re
 
 import pytest
 
-from models.demos.deepseek_v3_d_p.utils.perf_utils import run_model_device_perf_test_with_merge
+from models.demos.deepseek_v3_d_p.utils.perf_utils import _is_galaxy_env, run_model_device_perf_test_with_merge
 
 _TEST_PATH = "models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py"
 
-# 4x4 sub-torus carving: 16 of the galaxy's 32 chips + the Ring-4-on-Y graph descriptor.
-# Applied via run_model_device_perf_test_with_merge(extra_env=...) (which sets os.environ
-# around the subprocess) rather than prefixed into the pytest command — tracy's `-m` flag
-# mis-parses leading KEY=VAL tokens as module names (see perf_utils docstring).
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), *([".."] * 5)))
 _SUBTORUS_Y4_ENV = {
-    # The 16 PCIe device indices forming the inner 4x4 sub-torus carved from the 8x4 galaxy.
-    # These MUST match the chip->(tray, asic) pinnings in
-    # single_bh_galaxy_subtorus_y4_pinned_graph_descriptor.textproto: if the descriptor's pinned
-    # set changes, regenerate this list from it (do not edit independently).
     "TT_VISIBLE_DEVICES": "2,3,6,7,10,11,14,15,18,19,22,23,26,27,30,31",
     "TT_MESH_GRAPH_DESC_PATH": os.path.join(
         _REPO_ROOT,
-        "models/demos/deepseek_v3_d_p/experimental_descriptors/single_bh_galaxy_subtorus_y4_graph_descriptor.textproto",
+        "models/demos/deepseek_v3_d_p/experimental_descriptors/"
+        "single_bh_galaxy_subtorus_y4_graph_descriptor.textproto",
     ),
 }
-# Same 16-chip carve, X-ring ([LINE,RING]) and XY-ring ([RING,RING]) descriptors.
 _SUBTORUS_X4_ENV = {
     "TT_VISIBLE_DEVICES": _SUBTORUS_Y4_ENV["TT_VISIBLE_DEVICES"],
     "TT_MESH_GRAPH_DESC_PATH": os.path.join(
         _REPO_ROOT,
-        "models/demos/deepseek_v3_d_p/experimental_descriptors/single_bh_galaxy_subtorus_x4_graph_descriptor.textproto",
+        "models/demos/deepseek_v3_d_p/experimental_descriptors/"
+        "single_bh_galaxy_subtorus_x4_graph_descriptor.textproto",
     ),
 }
 _SUBTORUS_XY4_ENV = {
     "TT_VISIBLE_DEVICES": _SUBTORUS_Y4_ENV["TT_VISIBLE_DEVICES"],
     "TT_MESH_GRAPH_DESC_PATH": os.path.join(
         _REPO_ROOT,
-        "models/demos/deepseek_v3_d_p/experimental_descriptors/single_bh_galaxy_subtorus_xy4_graph_descriptor.textproto",
+        "models/demos/deepseek_v3_d_p/experimental_descriptors/"
+        "single_bh_galaxy_subtorus_xy4_graph_descriptor.textproto",
     ),
 }
 
-# The 4x4 sub-torus (16 chips) can only measure the 128-expert HOST-gate MoE path: the loop test
-# halves the routed experts 256 -> 128 on the (4,4) mesh (8/chip), and the device grouped-gate
-# kernel (deepseek_grouped_gate / moe_grouped_topk) hard-requires exactly 256 experts — so the
-# device gate is unavailable at 128, and the 256-expert device gate stalls on the ring on the
-# sub-torus (the reason the host gate exists for 4x4). The HOST gate's device-perf number is
-# dominated by host round-trip stalls and no longer tracks the 2026-07-01 device-kernel baseline
-# (measured ~9x over on current main), so the margin check is not meaningful. Skip until the device
-# gate is viable on the 4x4 sub-torus, or the baseline is recalibrated for the host-gate path.
 _SUBTORUS_4X4_HOSTGATE_SKIP = pytest.mark.skip(
-    reason="4x4 sub-torus MoE runs only the 128-expert HOST gate (device gate needs 256 experts and "
-    "stalls on the ring on the sub-torus); host-gate device-perf is host-stall-dominated and does not "
-    "track the device-kernel baseline (~9x over on current main). Recalibrate/re-enable when the "
-    "device gate is viable on the 4x4 sub-torus."
+    reason="4x4 subtorus MoE uses the 128-expert host gate; its device-perf is host-stall-dominated "
+    "and needs a new baseline before the gate can be re-enabled"
 )
 
 
 @pytest.mark.parametrize(
     "command, expected_device_perf_ns_per_iteration, subdir, model_name, num_iterations, batch_size, margin, comments",
     [
-        # FABRIC_1D baselines — tightened with `and not fabric2d-` to exclude the new
-        # 2D parametrize ids in test_prefill_block_loop.py (substring `mesh-8x4`/`mesh-2x4`
-        # would otherwise match both 1D and 2D variants).
         (
-            f"pytest {_TEST_PATH} -k 'mesh-8x4 and layer0 and gate_device and no_ref and isl_25k and not fabric2d-'",
-            19_378_393,  # Recalibrated 2026-06-10 on bh-glx-110-c08u02 (deepseek_v3_d_p perf run); FABRIC_1D.
-            "deepseek_v3_prefill_block",
-            "deepseek_v3_prefill_block_8x4_layer0_dense",
-            1,
-            1,
-            0.03,
-            "glx_8x4_layer0_dense_real_weights",
-        ),
-        (
-            f"pytest {_TEST_PATH} -k 'mesh-8x4 and layer3 and gate_device and no_ref and isl_25k and not fabric2d-'",
-            71_888_628,  # Recalibrated 2026-06-10 on bh-glx-110-c08u02 (deepseek_v3_d_p perf run); FABRIC_1D.
-            "deepseek_v3_prefill_block",
-            "deepseek_v3_prefill_block_8x4_layer3_moe",
-            1,
-            1,
-            0.03,
-            "glx_8x4_layer3_moe_real_weights",
-        ),
-        (
-            f"pytest {_TEST_PATH} -k 'mesh-2x4-2link and layer3 and gate_device and no_ref and isl_6k4'",
-            35_655_993,  # Re-centered 2026-07-27 for two stacked speedups now in the tree -- BOTH
-            # the in-place direct-write change (drop the separate output buffer + per-layer fill;
-            # measured 50.61 ms alone) AND #47536 (update_padded_kv_cache RM/fp8; measured 51.29 ms
-            # alone). The combined 2x4-2link number can't be measured on the galaxy, so the target is
-            # the midpoint of the plausible combined band [48.91, 50.61] ms; margin 0.03 ->
-            # [48.27, 51.25] ms brackets both speedups stacking and either alone. Was 53_000_000.
-            "deepseek_v3_prefill_block",
-            "deepseek_v3_prefill_block_2x4_layer3_moe",
-            1,
-            1,
-            0.03,
-            "2x4_layer3_moe_real_weights_2link",
-        ),
-        # FABRIC_2D variants. The layer3 MoE entry has been calibrated against a real run on
-        # BH Galaxy (~149.6 ms measured); the other two are still uncalibrated placeholders
-        # with a wide margin so the first run will pass and surface the measured number.
-        (
-            f"pytest {_TEST_PATH} -k 'fabric2d-mesh-8x4 and layer0 and gate_device and no_ref and isl_25k'",
-            23_148_850,  # Recalibrated 2026-07-30 on bh-glx-110-c08u02 (with FABRIC_2D init flush=false change).
-            "deepseek_v3_prefill_block",
-            "deepseek_v3_prefill_block_8x4_layer0_dense_fabric2d",
-            1,
-            1,
-            0.03,
-            "glx_8x4_layer0_dense_real_weights_fabric2d",
-        ),
-        (
-            f"pytest {_TEST_PATH} -k 'fabric2d-mesh-8x4 and layer3 and gate_device and no_ref and isl_25k'",
-            73_816_910,  # Recalibrated 2026-07-27 (perf improvement, was 76_706_230).
-            "deepseek_v3_prefill_block",
-            "deepseek_v3_prefill_block_8x4_layer3_moe_fabric2d",
-            1,
-            1,
-            0.03,
-            "glx_8x4_layer3_moe_real_weights_fabric2d",
-        ),
-        (
-            f"pytest {_TEST_PATH} -k 'fabric2d-mesh-2x4 and layer3 and gate_device and no_ref and isl_6k4'",
-            48_977_160,  # Recalibrated 2026-07-29 from 3 measured 2x4-2link runs (48.99, 48.94,
-            # 49.00 ms; mean 48.977 ms, spread ~0.13%), matching the CI-observed 48.967 ms.
+            f"pytest {_TEST_PATH} -k 'fabric2d-mesh-2x4-2link and layer3 and gate_device and no_ref and isl_6k4'",
+            38_638_478,  # Recalibrated 2026-08-14 after #51019 balanced dispatch across both links.
+            # Two local LoudBox runs (38.364, 38.397 ms) and BH E2E CI (39.154 ms); mean 38.638 ms.
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_2x4_layer3_moe_fabric2d",
             1,
@@ -151,109 +59,9 @@ _SUBTORUS_4X4_HOSTGATE_SKIP = pytest.mark.skip(
             0.03,
             "2x4_layer3_moe_real_weights_fabric2d",
         ),
-        # FABRIC_2D_TORUS_Y variants — single-galaxy 8x4 with the SP axis (dim 0) closed into a ring
-        # (Ring on SP-axis dispatch/combine, Linear on TP-axis collectives). Only the 8x4 cases are
-        # meaningful: TORUS_Y wraps the SP axis, and on a 2x4 mesh that axis is 2-wide so the ring
-        # degenerates to Linear. All entries calibrated 2026-06-26 on the 110-c78 BH galaxy at the
-        # standard 0.03 margin (real weights).
-        (
-            f"pytest {_TEST_PATH} -k 'torus-y-8x4 and layer0 and gate_device and no_ref and isl_25k'",
-            25_236_993,  # Recalibrated 2026-06-26 on 110-c78 BH galaxy; FABRIC_2D_TORUS_Y Ring-8 (layer0 dense, isl_25k).
-            "deepseek_v3_prefill_block",
-            "deepseek_v3_prefill_block_8x4_layer0_dense_torus_y",
-            1,
-            1,
-            0.03,
-            "glx_8x4_layer0_dense_real_weights_torus_y",
-        ),
-        (
-            f"pytest {_TEST_PATH} -k 'torus-y-8x4 and layer3 and gate_device and no_ref and isl_25k'",
-            67_193_413,  # Recalibrated 2026-06-26 on 110-c78 BH galaxy; FABRIC_2D_TORUS_Y Ring-8 (layer3 MoE, device gate).
-            "deepseek_v3_prefill_block",
-            "deepseek_v3_prefill_block_8x4_layer3_moe_torus_y",
-            1,
-            1,
-            0.03,
-            "glx_8x4_layer3_moe_real_weights_torus_y",
-        ),
-        # FABRIC_2D_TORUS_Y on a 4x4 sub-torus (16 chips, Ring-4 on the SP axis). Must be run with
-        # TT_VISIBLE_DEVICES (16 chips) + TT_MESH_GRAPH_DESC_PATH=...subtorus_y4... (applied via
-        # extra_env below). Uses isl_12k8 (12800 = half of 25k) so the 4-wide SP axis shards to
-        # 3200 tokens/chip — the same per-chip load as the 8x4 at isl_25k, which fits L1. isl_25k
-        # here would be 6400/chip and overflow L1 (MoE circular buffers exceed the 1.5 MB budget).
-        # The layer0 dense entry below is live (calibrated 2026-06-26 on 110-c78, Ring-4 SP axis, 0.03
-        # margin). The two layer3 MoE entries are SKIPPED (_SUBTORUS_4X4_HOSTGATE_SKIP): they run the
-        # 128-expert HOST gate whose device-perf no longer tracks the baseline — same reason as the
-        # torus-x/xy 4x4 block below.
-        #
-        # Gate: on the (4,4) mesh the loop test auto-halves the routed experts to 128 (128/16 = 8
-        # per chip, matching the 8x4 at 256/32) and runs the HOST gate, because the device
-        # grouped-gate kernels hard-require exactly 256 experts. So these layer3 entries measure the
-        # 128-expert / HOST-gate path (the working 4x4 scenario). The 256-expert device gate can be
-        # forced with DS_4X4_FULL_EXPERTS=1, but that path currently stalls on the ring (the reason
-        # moe-gate_host_all was added) and is deliberately NOT exercised here.
-        (
-            f"pytest {_TEST_PATH} -k 'torus-y-4x4 and layer0 and gate_device and no_ref and isl_12k8'",
-            17_978_418,  # Recalibrated 2026-06-26 on 110-c78 BH galaxy; FABRIC_2D_TORUS_Y Ring-4 (layer0 dense, 3200 tok/chip).
-            "deepseek_v3_prefill_block",
-            "deepseek_v3_prefill_block_4x4_layer0_dense_torus_y",
-            1,
-            1,
-            0.03,
-            "subtorus_4x4_layer0_dense_real_weights_torus_y_isl12k8",
-        ),
-        pytest.param(
-            f"pytest {_TEST_PATH} -k 'torus-y-4x4 and layer3 and gate_device and no_ref and isl_12k8'",
-            56_528_886,  # Recalibrated 2026-06-26 on 110-c78 BH galaxy; FABRIC_2D_TORUS_Y Ring-4 (layer3 MoE, 128 experts / HOST gate).
-            "deepseek_v3_prefill_block",
-            "deepseek_v3_prefill_block_4x4_layer3_moe_torus_y",  # 128 experts / HOST gate (see note above)
-            1,
-            1,
-            0.03,
-            "subtorus_4x4_layer3_moe_128experts_8perchip_hostgate_isl12k8",
-            marks=_SUBTORUS_4X4_HOSTGATE_SKIP,  # host-gate perf no longer tracks the baseline; see marker note
-        ),
-        # 4x4 sub-torus at isl_2k56 (2560 = half of 5k -> 640 tokens/chip on the 4-wide SP axis).
-        # Same 128-expert / HOST-gate behavior as the isl_12k8 layer3 entry above (see note).
-        pytest.param(
-            f"pytest {_TEST_PATH} -k 'torus-y-4x4 and layer3 and gate_device and no_ref and isl_2k56'",
-            15_570_232,  # Recalibrated 2026-06-26 on 110-c78 BH galaxy; FABRIC_2D_TORUS_Y Ring-4 (layer3 MoE, 640 tok/chip, HOST gate).
-            "deepseek_v3_prefill_block",
-            "deepseek_v3_prefill_block_4x4_layer3_moe_torus_y_isl2k56",  # 128 experts / HOST gate
-            1,
-            1,
-            0.03,
-            "subtorus_4x4_layer3_moe_128experts_8perchip_hostgate_isl2k56",
-            marks=_SUBTORUS_4X4_HOSTGATE_SKIP,  # host-gate perf no longer tracks the baseline; see marker note
-        ),
-        # FABRIC_2D_TORUS_X (X/TP-axis ring) — production full-galaxy case ([LINE,RING] pipeline
-        # descriptors): Ring on the TP-axis collectives (RMS-norm, MLA, dense-FFN, shared-expert,
-        # gate), Linear on the SP-axis MoE dispatch/combine. Baselines calibrated 2026-07-01 on the
-        # 110-c910 BH galaxy at the standard 0.03 margin (real weights).
-        (
-            f"pytest {_TEST_PATH} -k 'torus-x-8x4 and layer0 and gate_device and no_ref and isl_25k'",
-            22_656_265,  # Calibrated 2026-07-01 on 110-c910 BH galaxy; TORUS_X Ring (layer0 dense, isl_25k). Faster than torus_y (TP collectives ring).
-            "deepseek_v3_prefill_block",
-            "deepseek_v3_prefill_block_8x4_layer0_dense_torus_x",
-            1,
-            1,
-            0.03,
-            "glx_8x4_layer0_dense_real_weights_torus_x",
-        ),
-        (
-            f"pytest {_TEST_PATH} -k 'torus-x-8x4 and layer3 and gate_device and no_ref and isl_25k'",
-            75_154_221,  # Calibrated 2026-07-01 on 110-c910 BH galaxy; TORUS_X (layer3 MoE, isl_25k). Slower than torus_y: SP dispatch/combine run Linear (X-ring doesn't wrap the SP axis).
-            "deepseek_v3_prefill_block",
-            "deepseek_v3_prefill_block_8x4_layer3_moe_torus_x",
-            1,
-            1,
-            0.03,
-            "glx_8x4_layer3_moe_real_weights_torus_x",
-        ),
-        # FABRIC_2D_TORUS_XY (both axes ring) on the full 8x4 galaxy.
         (
             f"pytest {_TEST_PATH} -k 'torus-xy-8x4 and layer0 and gate_device and no_ref and isl_25k'",
-            18_157_603,  # Calibrated 2026-07-01 on 110-c910 BH galaxy; TORUS_XY (layer0 dense, isl_25k). Fastest dense: both axes ring, incl. the SP-axis ring-attention SDPA.
+            18_157_603,  # Calibrated 2026-07-01 on BH Galaxy 110-c910, TorusXY, real weights.
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_8x4_layer0_dense_torus_xy",
             1,
@@ -263,7 +71,7 @@ _SUBTORUS_4X4_HOSTGATE_SKIP = pytest.mark.skip(
         ),
         (
             f"pytest {_TEST_PATH} -k 'torus-xy-8x4 and layer3 and gate_device and no_ref and isl_25k'",
-            60_634_662,  # Calibrated 2026-07-01 on 110-c910 BH galaxy; TORUS_XY (layer3 MoE, isl_25k). Fastest MoE: SP dispatch/combine AND TP collectives all ring.
+            60_634_662,  # Calibrated 2026-07-01 on BH Galaxy 110-c910, TorusXY, real weights.
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_8x4_layer3_moe_torus_xy",
             1,
@@ -271,13 +79,41 @@ _SUBTORUS_4X4_HOSTGATE_SKIP = pytest.mark.skip(
             0.03,
             "glx_8x4_layer3_moe_real_weights_torus_xy",
         ),
-        # 4x4 sub-torus (16-chip carve) at isl_12k8 — 128-expert / HOST-gate path (loop test halves
-        # experts on 4x4), same methodology as the torus_y 4x4 entries. Needs the carve env.
-        # SKIPPED: host-gate device-perf doesn't track the device-kernel baseline; see
-        # _SUBTORUS_4X4_HOSTGATE_SKIP above. (The torus_y 4x4 entries share this host-gate path.)
+        (
+            f"pytest {_TEST_PATH} -k 'torus-y-4x4 and layer0 and gate_device and no_ref and isl_12k8'",
+            17_978_418,
+            "deepseek_v3_prefill_block",
+            "deepseek_v3_prefill_block_4x4_layer0_dense_torus_y",
+            1,
+            1,
+            0.03,
+            "subtorus_4x4_layer0_dense_real_weights_torus_y_isl12k8",
+        ),
+        pytest.param(
+            f"pytest {_TEST_PATH} -k 'torus-y-4x4 and layer3 and gate_device and no_ref and isl_12k8'",
+            56_528_886,
+            "deepseek_v3_prefill_block",
+            "deepseek_v3_prefill_block_4x4_layer3_moe_torus_y",
+            1,
+            1,
+            0.03,
+            "subtorus_4x4_layer3_moe_128experts_8perchip_hostgate_isl12k8",
+            marks=_SUBTORUS_4X4_HOSTGATE_SKIP,
+        ),
+        pytest.param(
+            f"pytest {_TEST_PATH} -k 'torus-y-4x4 and layer3 and gate_device and no_ref and isl_2k56'",
+            15_570_232,
+            "deepseek_v3_prefill_block",
+            "deepseek_v3_prefill_block_4x4_layer3_moe_torus_y_isl2k56",
+            1,
+            1,
+            0.03,
+            "subtorus_4x4_layer3_moe_128experts_8perchip_hostgate_isl2k56",
+            marks=_SUBTORUS_4X4_HOSTGATE_SKIP,
+        ),
         pytest.param(
             f"pytest {_TEST_PATH} -k 'torus-x-4x4 and layer3 and gate_device and no_ref and isl_12k8'",
-            54_804_819,  # Calibrated 2026-07-01 on 110-c910 BH galaxy; TORUS_X Ring-4 (layer3 MoE, 128 experts / HOST gate, isl_12k8).
+            54_804_819,
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_4x4_layer3_moe_torus_x",
             1,
@@ -288,7 +124,7 @@ _SUBTORUS_4X4_HOSTGATE_SKIP = pytest.mark.skip(
         ),
         pytest.param(
             f"pytest {_TEST_PATH} -k 'torus-xy-4x4 and layer3 and gate_device and no_ref and isl_12k8'",
-            52_978_544,  # Calibrated 2026-07-01 on 110-c910 BH galaxy; TORUS_XY Ring-4 (layer3 MoE, 128 experts / HOST gate, isl_12k8).
+            52_978_544,
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_4x4_layer3_moe_torus_xy",
             1,
@@ -299,21 +135,12 @@ _SUBTORUS_4X4_HOSTGATE_SKIP = pytest.mark.skip(
         ),
     ],
     ids=[
-        "block_8x4_layer0_dense",
-        "block_8x4_layer3_moe",
-        "block_2x4_layer3_moe",
-        "block_8x4_layer0_dense_fabric2d",
-        "block_8x4_layer3_moe_fabric2d",
         "block_2x4_layer3_moe_fabric2d",
-        "block_8x4_layer0_dense_torus_y",
-        "block_8x4_layer3_moe_torus_y",
+        "block_8x4_layer0_dense_torus_xy",
+        "block_8x4_layer3_moe_torus_xy",
         "block_4x4_layer0_dense_torus_y",
         "block_4x4_layer3_moe_torus_y",
         "block_4x4_layer3_moe_torus_y_isl2k56",
-        "block_8x4_layer0_dense_torus_x",
-        "block_8x4_layer3_moe_torus_x",
-        "block_8x4_layer0_dense_torus_xy",
-        "block_8x4_layer3_moe_torus_xy",
         "block_4x4_layer3_moe_torus_x",
         "block_4x4_layer3_moe_torus_xy",
     ],
@@ -329,27 +156,18 @@ def test_deepseek_v3_prefill_block_perf(
     margin,
     comments,
 ):
-    # Subtorus/torus perf entries spawn a child pytest on a FABRIC_2D_TORUS_Y fabric, which needs
-    # wrap cabling absent on CI runners -> would hang on bh-glx. Skip on CI; these run only on a
-    # subtorus-wired host (CI unset). Mirrors the collection-time guard in the deepseek conftest.
-    if "torus" in model_name and (os.getenv("CI") == "true" or "TT_GH_CI_INFRA" in os.environ):
-        pytest.skip("subtorus/torus perf entry: no wrap-cabled CI runner (would hang on bh-glx)")
+    if "_8x4_" in model_name and "torus_xy" in model_name:
+        if not _is_galaxy_env():
+            pytest.skip("This test requires 8x4 mesh - galaxy. (set MESH_DEVICE=TG)")
+        if os.getenv("PREFILL_TORUS_XY_CERTIFIED") != "1" or not os.getenv("TT_MESH_GRAPH_DESC_PATH"):
+            pytest.fail("TorusXY perf requires a certified Galaxy and explicit mesh graph descriptor")
 
-    # 4x4 sub-torus variants need 16 specific chips carved out + the Ring-4-on-Y descriptor.
-    # These must reach the worker via os.environ (extra_env), not the command string.
     extra_env = None
     if "_4x4_" in model_name:
-        # Pick the carve descriptor by the exact `_torus_<axis>` token. A regex on the delimited
-        # token (not a raw substring) avoids the "torus_x" ⊂ "torus_xy" trap and tolerates a trailing
-        # suffix like `_isl2k56` (present on some torus_y ids). Alternation tries `xy` before `x`.
-        _carve_env_by_axis = {"x": _SUBTORUS_X4_ENV, "xy": _SUBTORUS_XY4_ENV, "y": _SUBTORUS_Y4_ENV}
-        m = re.search(r"_torus_(xy|x|y)(?:_|$)", model_name)
-        assert m is not None, f"4x4 perf entry {model_name!r} has no _torus_<axis> token"
-        extra_env = dict(_carve_env_by_axis[m.group(1)])
-        # 4x4 layer3 entries measure the 128-expert / HOST-gate path. Clear DS_4X4_FULL_EXPERTS for
-        # the worker so the result is deterministic regardless of any value left in the launching
-        # shell — the loop test then halves to 128 experts and forces HOST_ALL. (Forcing 256 experts
-        # on the device gate currently stalls on the ring; see the parametrize note above.)
+        carve_env_by_axis = {"x": _SUBTORUS_X4_ENV, "xy": _SUBTORUS_XY4_ENV, "y": _SUBTORUS_Y4_ENV}
+        match = re.search(r"_torus_(xy|x|y)(?:_|$)", model_name)
+        assert match is not None, f"4x4 perf entry {model_name!r} has no _torus_<axis> token"
+        extra_env = dict(carve_env_by_axis[match.group(1)])
         extra_env["DS_4X4_FULL_EXPERTS"] = ""
 
     run_model_device_perf_test_with_merge(

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_dispatch_combine.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_dispatch_combine.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-End-to-end dispatch+combine perf worker for one Galaxy column replayed on LB 8x1.
+End-to-end dispatch+combine perf worker for one Galaxy column replayed on LB 8x1 TorusY.
 
 Runs TtDispatchModule → production layout transform (squeeze → TILE+bfp8 →
 unsqueeze) → TtCombineModule(init_zeros=True) in a single forward pass on
@@ -40,9 +40,9 @@ from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
 )
 from models.demos.deepseek_v3_d_p.tt.moe.tt_combine import TtCombineModule
 from models.demos.deepseek_v3_d_p.tt.moe.tt_dispatch import TtDispatchModule
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 
-# Geometry of the replay, not of any model: LB 8x1 stands in for ONE column of the Galaxy the
-# capture was taken on, which has 4 columns of 8 chips.
+# Geometry of the replay: LB 8x1 stands in for one 8-chip Galaxy column.
 GALAXY_NUM_DISPATCH_GROUPS = 4
 DISPATCH_GROUP_SIZE = 8
 CHUNK = 5 * 1024  # tokens per chunk in the chunked-prefill run the captures come from
@@ -51,6 +51,8 @@ DISPATCH_BUFFER_CAPACITY_FACTOR = 8
 
 # One entry per model whose chunked-prefill capture we replay; add a model by extending this list.
 _CHUNK_MODELS = [("dsv3", DeepSeekV3Config), ("kimi26", KimiK26Config), ("glm52", GLM52Config)]
+_TORUS_Y_MESH_CONFIGS = [param for param in ALL_MESH_CONFIGS if param.id == "fabric2d-torus-y-8x1-2link"]
+assert len(_TORUS_Y_MESH_CONFIGS) == 1, "LoudBox TorusY proxy config missing from ALL_MESH_CONFIGS"
 
 
 # One chunk (5120 tokens) spread over the 8-chip dispatch group => seq_len_per_chip 640. Expert
@@ -77,20 +79,20 @@ _CHUNK_MODELS = [("dsv3", DeepSeekV3Config), ("kimi26", KimiK26Config), ("glm52"
     ],
 )
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
-    ALL_MESH_CONFIGS,
+    "mesh_device, device_params, num_links",
+    _TORUS_Y_MESH_CONFIGS,
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.timeout(0)
 def test_ttnn_dispatch_combine(
     mesh_device,
+    device_params,
     seq_len_per_chip,
     emb_dim,
     num_routed_experts,
     num_experts_per_tok,
     dispatch_buffer_capacity_factor,
     num_links,
-    topology,
     experts_per_chip_override,
     model,
 ):
@@ -104,6 +106,7 @@ def test_ttnn_dispatch_combine(
 
     mesh_config = extract_mesh_config(mesh_device)
     sp_axis = mesh_config.sp_axis
+    topology = per_axis_topology(device_params["fabric_config"])[sp_axis]
     dispatch_group_size = mesh_config.dispatch_group_size
     num_dispatch_groups = mesh_config.num_dispatch_groups
 
@@ -145,8 +148,7 @@ def test_ttnn_dispatch_combine(
         model=model,
         captured_indices_path=os.getenv("TT_DS_USE_CAPTURED_INDICES"),
     )
-
-    # get_gate_outputs produces 4-row outputs (Galaxy-global); slice to [0:1] for LB's single dispatch group.
+    # get_gate_outputs produces Galaxy-global rows; keep the selected proxy column only.
     expert_offsets, expert_token_counts, expert_region_offsets, _ = get_gate_outputs(
         indices,
         dispatch_group_size,
@@ -216,7 +218,7 @@ def test_ttnn_dispatch_combine(
     combine_module = TtCombineModule(
         mesh_device=mesh_device,
         dispatch_group_size=dispatch_group_size,
-        num_dispatch_groups=1,  # LB has 1 physical dispatch group; we simulate one Galaxy col on it.
+        num_dispatch_groups=1,
         experts_per_chip=experts_per_chip,
         num_experts_per_tok=num_experts_per_tok,
         seq_len_per_chip=seq_len_per_chip,

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/sparse_mla_mesh.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/sparse_mla_mesh.py
@@ -2,15 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Hardware-adaptive mesh parametrization for the device tests.
+Hardware-adaptive Fabric2D mesh parametrization for the sparse-MLA vs-trace diagnostics.
 
 The tests are written for a `mesh_device` whose shape is ``(sp_size, tp_size)``
 (``sp_axis, tp_axis = 0, 1``). Which shapes are valid depends on the box the
-suite runs on, so instead of hard-coding ``[(1, 4), (2, 2)]`` every test pulls
+suite runs on, so instead of hard-coding one box every test pulls
 its parametrization from here:
 
-    QuietBox  (4 chips):  single chip, TP=4,        SP=2 × TP=2
-    LoudBox   (8 chips):  SP=8,        SP=4 × TP=2,  SP=2 × TP=4
+    QuietBox  (4 chips):  SP=1 × TP=4, SP=2 × TP=2
+    LoudBox   (8 chips):  SP=8 × TP=1, SP=4 × TP=2, SP=2 × TP=4
     Galaxy   (32 chips):  SP=8 × TP=4   (production layout)
 
 Detection mirrors ``tests/nightly/sdpa_perf_utils.MeshConfig.detect()``: it
@@ -29,6 +29,14 @@ import os
 
 import pytest
 
+import ttnn
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
+    fabric2d_device_params,
+    torus_x_device_params,
+    torus_xy_device_params,
+    torus_y_device_params,
+)
+
 
 def detect_num_devices() -> int:
     """Number of TT devices, counted from /dev/tenstorrent/* without opening them.
@@ -42,9 +50,8 @@ def detect_num_devices() -> int:
 # (sp_size, tp_size) shapes per box, keyed by exact physical device count.
 # In production (Galaxy) the layout is TP=4, SP=8.
 MESH_SHAPES_BY_DEVICE_COUNT = {
-    1: [(1, 1)],  # single chip
-    4: [(1, 1), (1, 4), (2, 2)],  # QuietBox: single, TP=4, SP2×TP2
-    8: [(8, 1), (4, 2), (2, 4)],  # LoudBox: SP=8, SP4×TP2, SP2×TP4
+    4: [(1, 1), (1, 4), (2, 2)],  # QuietBox: existing single-chip diagnostic, TP ring, and SP2×TP2
+    8: [(8, 1), (4, 2), (2, 4)],  # LoudBox: SP proxy plus axis-sensitive 2D profiles
     32: [(8, 4)],  # Galaxy (prod): SP=8, TP=4
 }
 
@@ -75,12 +82,16 @@ def _shape_id(shape) -> str:
 def supported_mesh_shapes(num_devices: int = None):
     """(shapes, ids) — SP×TP shape set for the detected box.
 
-    Unknown box: a single pure-TP plane spanning every chip, so the suite still runs (and is
-    clearly labelled) on non-standard machines.
+    Unknown boxes return one collection-time skipped 2x2 sentinel; they never open a degenerate
+    Fabric2D mesh merely to keep the parametrization nonempty.
     """
     if num_devices is None:
         num_devices = detect_num_devices()
-    shapes = MESH_SHAPES_BY_DEVICE_COUNT.get(num_devices) or [(1, max(num_devices, 1))]
+    shapes = MESH_SHAPES_BY_DEVICE_COUNT.get(num_devices)
+    if shapes is None:
+        return [pytest.param((2, 2), marks=pytest.mark.skip(reason=f"unsupported device count {num_devices}"))], [
+            "unsupported"
+        ]
     return shapes, [_shape_id(s) for s in shapes]
 
 
@@ -92,3 +103,48 @@ def parametrize_mesh_device():
     """
     shapes, ids = supported_mesh_shapes()
     return pytest.mark.parametrize("mesh_device", shapes, ids=ids, indirect=True)
+
+
+def parametrize_mesh_and_device_params(*, worker_l1_size, torus_xy_certified=False):
+    """Pair each existing sparse-MLA mesh with its valid Fabric2D profile."""
+    params = []
+    for shape in MESH_SHAPES_BY_DEVICE_COUNT.get(detect_num_devices(), []):
+        if shape == (1, 1):
+            device_params = {"fabric_config": ttnn.FabricConfig.DISABLED}
+            marker = None
+            profile = "disabled"
+        elif shape[1] == 1 and shape[0] > 2:
+            device_params = torus_y_device_params(worker_l1_size=worker_l1_size)
+            marker = "ring"
+            profile = "torus-y"
+        elif shape[0] == 1 and shape[1] > 2:
+            device_params = torus_x_device_params(worker_l1_size=worker_l1_size)
+            marker = "ring"
+            profile = "torus-x"
+        elif shape == (8, 4) and torus_xy_certified:
+            device_params = torus_xy_device_params(worker_l1_size=worker_l1_size)
+            marker = "mesh-8x4"
+            profile = "torus-xy"
+        else:
+            device_params = fabric2d_device_params(worker_l1_size=worker_l1_size)
+            marker = f"mesh-{shape[0]}x{shape[1]}"
+            profile = "fabric2d"
+        marks = [] if marker is None else pytest.mark.requires_mesh_topology(mesh_shape=shape, topology=marker)
+        params.append(
+            pytest.param(
+                shape,
+                device_params,
+                marks=marks,
+                id=f"{profile}-sp{shape[0]}xtp{shape[1]}",
+            )
+        )
+    if not params:
+        params.append(
+            pytest.param(
+                (2, 2),
+                fabric2d_device_params(worker_l1_size=worker_l1_size),
+                marks=pytest.mark.skip(reason=f"unsupported device count {detect_num_devices()}"),
+                id="unsupported",
+            )
+        )
+    return pytest.mark.parametrize("mesh_device,device_params", params, indirect=["mesh_device", "device_params"])

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py
@@ -8,8 +8,6 @@ path separate while reusing the same TT execution helper and the production mesh
 / fabric axes from the dense MLA tests.
 """
 
-import os
-
 import pytest
 import torch
 from loguru import logger
@@ -17,6 +15,11 @@ from ttnn.device import is_blackhole
 
 import ttnn
 from models.common.utility_functions import comp_pcc
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
+    fabric2d_device_params,
+    torus_x_device_params,
+    torus_xy_device_params,
+)
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_mesh import KVPE_MIN_TOKENS_PER_CHIP, detect_num_devices
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_reference import (
     build_weights,
@@ -30,7 +33,7 @@ from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup, interleaved_to_halfsplit_perm
 from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_positions, rotated_chip_positions
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.test_utils import WH_WORKER_L1_SIZE
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -58,14 +61,15 @@ def _collect_kvpe_cache(cache, mesh_device):
 # thin per-chip head shard at tp=4 (64/4=16 < 32) is handled by the head→sequence reshard in
 # ttMLA._sparse_mla (#48727) + the head-replicated seq-sharded indexer, so GLM is no longer TP-capped.
 # Coverage rationale:
-#   QuietBox (4):  (2,2) TP=2 and (1,4) TP=4 — both variants at both TP.
+#   QuietBox (4):  (1,4) TorusX and (2,2) Fabric2D.
 #   LoudBox  (8):  (2,4) TP=4 and (4,2) TP=2 — both variants at both TP.
-#   Galaxy   (32): (8,4) production TP=4 + (8,2) TP=2 plane.
+#   Galaxy   (32): (8,4) production TP=4 + the existing (8,2) TP=2 diagnostic plane.
 # Mesh shape is NOT correctness-invariant, so accuracy sweeps the whole box set; determinism and
 # chunked pin to each variant's anchor (highest supported TP) — see _sparse_cases(anchor_only=True).
 SPARSE_MESH_BY_DEVICES = {
     4: [(2, 2), (1, 4)],
     8: [(2, 4), (4, 2)],
+    # Only the complete 8x4 view uses TorusXY. The existing 8x2 plane remains plain Fabric2D.
     32: [(8, 4), (8, 2)],
 }
 
@@ -77,9 +81,21 @@ SPARSE_SEQS_ANCHOR = [5120]
 
 
 def _sparse_meshes():
-    """Current box's candidate (sp, tp) meshes; best-effort single TP plane on non-standard boxes."""
-    n = detect_num_devices()
-    return SPARSE_MESH_BY_DEVICES.get(n, [(1, max(n, 1))])
+    """Current box's supported (sp, tp) meshes, or None for an unsupported device count."""
+    return SPARSE_MESH_BY_DEVICES.get(detect_num_devices())
+
+
+def _worker_l1_size():
+    return ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE
+
+
+def _device_params_for_mesh(mesh):
+    """Assign one fabric to each existing mesh; topology is not a separate test axis."""
+    if mesh == (1, 4):
+        return torus_x_device_params(worker_l1_size=_worker_l1_size())
+    if mesh == (8, 4):
+        return torus_xy_device_params(worker_l1_size=_worker_l1_size())
+    return fabric2d_device_params(worker_l1_size=_worker_l1_size())
 
 
 def _seq_ok_for_mesh(seq_len, mesh):
@@ -93,9 +109,21 @@ def _anchor_mesh(meshes):
 
 
 def _sparse_cases(seqs, anchor_only):
-    """Generate (variant, mesh, seq_len) params for the CURRENT box — only valid combos, so the
+    """Generate (variant, mesh, seq_len, device_params) for the current box — only valid combos, so the
     collected matrix equals the run matrix (validity is enforced here, not via runtime skips)."""
     meshes = _sparse_meshes()
+    if meshes is None:
+        num_devices = detect_num_devices()
+        return [
+            pytest.param(
+                SPARSE_VARIANTS[0],
+                (2, 2),
+                seqs[-1],
+                fabric2d_device_params(worker_l1_size=_worker_l1_size()),
+                marks=pytest.mark.skip(reason=f"unsupported device count {num_devices}"),
+                id="unsupported-fabric2d",
+            )
+        ]
     chosen = [_anchor_mesh(meshes)] if (anchor_only and meshes) else meshes
     cases = []
     for mesh in chosen:
@@ -103,8 +131,22 @@ def _sparse_cases(seqs, anchor_only):
             if not _seq_ok_for_mesh(seq_len, mesh):
                 continue
             for variant_name in SPARSE_VARIANTS:
+                topology_mark = (
+                    []
+                    if mesh == (8, 2)
+                    else pytest.mark.requires_mesh_topology(
+                        mesh_shape=mesh, topology="ring" if mesh == (1, 4) else f"mesh-{mesh[0]}x{mesh[1]}"
+                    )
+                )
                 cases.append(
-                    pytest.param(variant_name, mesh, seq_len, id=f"{variant_name}-{mesh[0]}x{mesh[1]}-seq{seq_len}")
+                    pytest.param(
+                        variant_name,
+                        mesh,
+                        seq_len,
+                        _device_params_for_mesh(mesh),
+                        marks=topology_mark,
+                        id=f"{variant_name}-shape-{mesh[0]}x{mesh[1]}-seq{seq_len}",
+                    )
                 )
     return cases
 
@@ -113,7 +155,7 @@ def _sparse_accuracy_cases():
     """BF16 covers both sparsity regimes; scaled FP8 covers only the real-pruning regime."""
     cases = []
     for case in _sparse_cases(SPARSE_SEQS_ACCURACY, anchor_only=False):
-        variant, mesh, seq_len = case.values
+        variant, mesh, seq_len, device_params = case.values
         formats = [MlaKvCacheFormat.BF16_RM]
         if seq_len == SPARSE_SEQS_ANCHOR[0]:
             formats.append(MlaKvCacheFormat.SCALED_FP8)
@@ -123,7 +165,9 @@ def _sparse_accuracy_cases():
                     variant,
                     mesh,
                     seq_len,
+                    _device_params_for_mesh(mesh),
                     cache_format,
+                    marks=case.marks,
                     id=f"{case.id}-kv_{cache_format.value}",
                 )
             )
@@ -132,51 +176,6 @@ def _sparse_accuracy_cases():
 
 SPARSE_ACCURACY_CASES = _sparse_accuracy_cases()
 SPARSE_ANCHOR_CASES = _sparse_cases(SPARSE_SEQS_ANCHOR, anchor_only=True)
-
-# All three fabric transports, keyed by name. Fabric is NOT swept: correctness is ~invariant to the
-# transport, so the suite pins one fabric (PREFERRED below) and lets a dedicated fabric test cover
-# multi-transport bring-up. The ids/dicts are kept so DS_SPARSE_FABRIC can select any of them.
-_SPARSE_FABRICS = {
-    "line": {
-        "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-        "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
-    },
-    "ring": {
-        "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-        "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
-    },
-    "fabric2d": {
-        "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-        "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-        "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-        "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
-    },
-}
-# Auto-pin the fabric: priority fabric2d > ring > line (fabric2d is the Galaxy/production bring-up).
-# Override with DS_SPARSE_FABRIC=line|ring|fabric2d. TODO: replace the priority default with a real
-# per-box capability probe; for now it defaults to the top-priority (production) transport.
-_SPARSE_FABRIC_PRIORITY = ["fabric2d", "ring", "line"]
-
-
-def _preferred_fabric_name() -> str:
-    env = os.environ.get("DS_SPARSE_FABRIC")
-    if env:
-        assert env in _SPARSE_FABRICS, f"DS_SPARSE_FABRIC={env!r} must be one of {sorted(_SPARSE_FABRICS)}"
-        return env
-    return _SPARSE_FABRIC_PRIORITY[0]
-
-
-PREFERRED_FABRIC = _preferred_fabric_name()
-SPARSE_DEVICE_PARAMS = [_SPARSE_FABRICS[PREFERRED_FABRIC]]
-SPARSE_DEVICE_IDS = [PREFERRED_FABRIC]
-
-
-def _topology_from_device_params(device_params):
-    return (
-        ttnn.Topology.Ring
-        if device_params.get("fabric_config") == ttnn.FabricConfig.FABRIC_1D_RING
-        else ttnn.Topology.Linear
-    )
 
 
 def _init_index_kv_cache(config, mesh_device, seq_len, mesh_shape, sp_axis, slot_num=1):
@@ -708,8 +707,11 @@ def run_sparse_mla_rotated_case(
     ttnn.synchronize_device(mesh_device)
 
 
-@pytest.mark.parametrize("variant, mesh_device, seq_len", SPARSE_ANCHOR_CASES, indirect=["variant", "mesh_device"])
-@pytest.mark.parametrize("device_params", SPARSE_DEVICE_PARAMS, ids=SPARSE_DEVICE_IDS, indirect=True)
+@pytest.mark.parametrize(
+    "variant, mesh_device, seq_len, device_params",
+    SPARSE_ANCHOR_CASES,
+    indirect=["variant", "mesh_device", "device_params"],
+)
 @pytest.mark.parametrize("iters_isl", [[2560, 2592, 5120]], ids=["maxedge"])
 @pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
 @pytest.mark.timeout(0)
@@ -722,11 +724,10 @@ def test_sparse_mla_rotated(
 # One combined parametrization instead of independent variant/mesh/sequence/format axes. BF16 retains
 # both sparsity regimes; scaled FP8 is restricted to the real-pruning sequence to avoid redundant CI work.
 @pytest.mark.parametrize(
-    "variant, mesh_device, seq_len, cache_format",
+    "variant, mesh_device, seq_len, device_params, cache_format",
     SPARSE_ACCURACY_CASES,
-    indirect=["variant", "mesh_device"],
+    indirect=["variant", "mesh_device", "device_params"],
 )
-@pytest.mark.parametrize("device_params", SPARSE_DEVICE_PARAMS, ids=SPARSE_DEVICE_IDS, indirect=True)
 @pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
 @pytest.mark.timeout(0)
 def test_sparse_mla_accuracy(
@@ -748,7 +749,7 @@ def test_sparse_mla_accuracy(
         return original(q, *args, **kwargs)
 
     monkeypatch.setattr(ttnn.experimental, "ring_indexer_score_dsa", check_indexer_q_format)
-    topology = _topology_from_device_params(device_params)
+    topology = per_axis_topology(device_params["fabric_config"])
     run_sparse_mla_accuracy_case(
         variant,
         config_only,
@@ -766,8 +767,11 @@ def test_sparse_mla_accuracy(
 SPARSE_REUSE_CASES = [c for c in SPARSE_ANCHOR_CASES if "glm_5_2" in c.id]
 
 
-@pytest.mark.parametrize("variant, mesh_device, seq_len", SPARSE_REUSE_CASES, indirect=["variant", "mesh_device"])
-@pytest.mark.parametrize("device_params", SPARSE_DEVICE_PARAMS, ids=SPARSE_DEVICE_IDS, indirect=True)
+@pytest.mark.parametrize(
+    "variant, mesh_device, seq_len, device_params",
+    SPARSE_REUSE_CASES,
+    indirect=["variant", "mesh_device", "device_params"],
+)
 @pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
 @pytest.mark.timeout(0)
 def test_sparse_mla_indexer_reuse(
@@ -781,7 +785,7 @@ def test_sparse_mla_indexer_reuse(
     weights, _ = build_weights(variant, config, layer=ds_layer, checkpoint_path=ds_checkpoint, repo=ds_repo)
     mesh_shape = list(mesh_device.shape)
     sp_axis, tp_axis = 0, 1
-    topology = _topology_from_device_params(device_params)
+    topology = per_axis_topology(device_params["fabric_config"])
 
     def _kvpe():
         return init_mla_kv_cache(
@@ -821,23 +825,29 @@ def test_sparse_mla_indexer_reuse(
 
 
 # Anchor cases (per-variant prod-closest mesh, seq=4096); collected == run.
-@pytest.mark.parametrize("variant, mesh_device, seq_len", SPARSE_ANCHOR_CASES, indirect=["variant", "mesh_device"])
-@pytest.mark.parametrize("device_params", SPARSE_DEVICE_PARAMS, ids=SPARSE_DEVICE_IDS, indirect=True)
+@pytest.mark.parametrize(
+    "variant, mesh_device, seq_len, device_params",
+    SPARSE_ANCHOR_CASES,
+    indirect=["variant", "mesh_device", "device_params"],
+)
 @pytest.mark.parametrize("n_runs", [3], ids=["x3"])
 @pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
 @pytest.mark.timeout(0)
 def test_sparse_mla_determinism(
     mesh_device, seq_len, n_runs, device_params, variant, config_only, ds_layer, ds_checkpoint, ds_repo
 ):
-    topology = _topology_from_device_params(device_params)
+    topology = per_axis_topology(device_params["fabric_config"])
     run_sparse_mla_determinism_case(
         variant, config_only, mesh_device, seq_len, n_runs, topology, ds_layer, ds_checkpoint, ds_repo
     )
 
 
 # Anchor cases (seq=5120) crossed with the single prefill chunk size; collected == run.
-@pytest.mark.parametrize("variant, mesh_device, seq_len", SPARSE_ANCHOR_CASES, indirect=["variant", "mesh_device"])
-@pytest.mark.parametrize("device_params", SPARSE_DEVICE_PARAMS, ids=SPARSE_DEVICE_IDS, indirect=True)
+@pytest.mark.parametrize(
+    "variant, mesh_device, seq_len, device_params",
+    SPARSE_ANCHOR_CASES,
+    indirect=["variant", "mesh_device", "device_params"],
+)
 @pytest.mark.parametrize("chunk", [1024], ids=["c1k"])
 @pytest.mark.parametrize(
     "cache_format",
@@ -867,8 +877,11 @@ def test_sparse_mla_chunked(
 SPARSE_KV_ONLY_CASES = [c for c in SPARSE_ANCHOR_CASES if "glm_5_1" in c.id]
 
 
-@pytest.mark.parametrize("variant, mesh_device, seq_len", SPARSE_KV_ONLY_CASES, indirect=["variant", "mesh_device"])
-@pytest.mark.parametrize("device_params", SPARSE_DEVICE_PARAMS, ids=SPARSE_DEVICE_IDS, indirect=True)
+@pytest.mark.parametrize(
+    "variant, mesh_device, seq_len, device_params",
+    SPARSE_KV_ONLY_CASES,
+    indirect=["variant", "mesh_device", "device_params"],
+)
 @pytest.mark.parametrize("chunk", [1024], ids=["c1k"])
 @pytest.mark.skipif(not is_blackhole(), reason="DSA ops (indexer / sparse SDPA) are Blackhole-only")
 @pytest.mark.timeout(0)

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_cache.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_cache.py
@@ -25,6 +25,7 @@ from ttnn.device import is_blackhole
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32 import random_mla_weights
 from models.demos.deepseek_v3_d_p.reference.glm_5_2_config import GLM52Config, glm_5_2_hf_config
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.mla.indexer import (
     ReuseIndexer,
@@ -219,12 +220,11 @@ def _build_mla(config, state_dict, mesh_device, weight_cache_path):
     [
         pytest.param(
             (4, 2),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
-            },
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="linear"),
-            id="linear-4x2",
+            fabric2d_device_params(
+                worker_l1_size=ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE
+            ),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
+            id="fabric2d-4x2",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -300,12 +300,11 @@ def test_sparse_mla_cache_only_stays_sparse(mesh_device, device_params, variant,
     [
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
-            },
+            torus_xy_device_params(
+                worker_l1_size=ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE
+            ),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_ccl_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_ccl_perf.py
@@ -24,9 +24,14 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import glm_hf_config
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
+    fabric2d_device_params,
+    torus_xy_device_params,
+    torus_y_device_params,
+)
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_mesh import detect_num_devices
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.test_sparse_mla_perf import CHUNK_TOKENS, GALAXY_SP, SCENARIOS
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal
 from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program
 
@@ -251,28 +256,21 @@ GLM_SEQUENCE_TO_HEAD = CollectivePath(
 def ccl_mesh_param(collective_axis: int):
     """`pytest.param(mesh_shape, device_params, marks, id)` for the box + collective axis (collection time).
 
-    Galaxy (32): the production 8x4. LoudBox (8): an SP=8 line proxy (one line of 8 mirrors a Galaxy SP
-    row) for SP collectives, or a 2x4 mesh preserving TP=4 for TP collectives.
+    Galaxy (32): the production 8x4 TorusXY profile. LoudBox (8): the existing SP=8 proxy migrated
+    to TorusY for SP-axis collectives, or the existing 2x4 Fabric2D proxy for TP collectives.
     """
     num_devices = detect_num_devices()
-    canonical_fabric = {  # matches the deepseek conftest FABRIC_2D params (fabric router + reliability mode)
-        "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-        "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-    }
-    fabric_2d = {"trace_region_size": 100000, "fabric_config": ttnn.FabricConfig.FABRIC_2D, **canonical_fabric}
+    fabric_2d = fabric2d_device_params(trace_region_size=100000)
+    torus_xy = torus_xy_device_params(trace_region_size=100000)
     if num_devices == 32:
-        system, mesh_shape, mesh_topology, device_params = "galaxy", (8, 4), "mesh-8x4", fabric_2d
+        system, mesh_shape, mesh_topology, device_params = "galaxy_torus_xy", (8, 4), "mesh-8x4", torus_xy
     elif num_devices == 8:
-        system = "loudbox_proxy"
         if collective_axis == SP_AXIS:
-            # SP=8 line proxy for a Galaxy SP row. Production runs the SP all-gather on Topology.Linear
-            # (mla.py:259), so the proxy mirrors that with a FABRIC_1D line — not a ring, which would model a
-            # transport Galaxy does not use today. FABRIC_1D isolates the single axis, so it omits the 2D
-            # fabric-router config.
-            mesh_shape, mesh_topology = (8, 1), "line"
-            device_params = {"trace_region_size": 100000, "fabric_config": ttnn.FabricConfig.FABRIC_1D}
+            system, mesh_shape, mesh_topology = "loudbox_torus_y", (8, 1), "ring"
+            device_params = torus_y_device_params(trace_region_size=100000)
         else:
-            mesh_shape, mesh_topology, device_params = (2, 4), "mesh-2x4", fabric_2d
+            system, device_params = "loudbox_fabric2d", fabric_2d
+            mesh_shape, mesh_topology = (2, 4), "mesh-2x4"
     else:
         reason = f"CCL perf supports Galaxy (32 chips) or LoudBox (8), found {num_devices}"
         return pytest.param((1, 1), fabric_2d, marks=pytest.mark.skip(reason=reason), id="unsupported")
@@ -285,10 +283,10 @@ def ccl_mesh_param(collective_axis: int):
     )
 
 
-def resolve_runtime_system(mesh_device, path: CollectivePath, topology=ttnn.Topology.Linear) -> RuntimeSystem:
+def resolve_runtime_system(mesh_device, path: CollectivePath, fabric_config) -> RuntimeSystem:
     """Fabric roofline inputs for the live mesh: topology, link count, per-direction bandwidth."""
     mesh_shape = tuple(mesh_device.shape)
-    # Production uses Linear; perf tests may override this to compare the same workload on Ring.
+    topology = per_axis_topology(fabric_config)[path.collective_axis]
     default_gbps = _GALAXY_LINK_GBPS_PER_DIRECTION if math.prod(mesh_shape) == 32 else _LOUDBOX_LINK_GBPS_PER_DIRECTION
     link_gbps = float(os.environ.get("MLA_CCL_LINK_GBPS_PER_DIRECTION", default_gbps))
     return RuntimeSystem(mesh_shape, topology, NUM_LINKS, link_gbps)
@@ -609,10 +607,10 @@ def _workload(scenario):
     )
 
 
-def _run(mesh_device, path, scenario, topology=ttnn.Topology.Linear):
+def _run(mesh_device, device_params, path, scenario):
     assert mesh_device.arch() == ttnn.Arch.BLACKHOLE, "bandwidth assumptions apply to Blackhole only"
     workload = _workload(scenario)
-    system = resolve_runtime_system(mesh_device, path, topology)
+    system = resolve_runtime_system(mesh_device, path, device_params["fabric_config"])
     measurement = run_collective(mesh_device, path, workload, system)
     traffic = collective_roofline(path, workload, mesh_device, system)
     report(path, scenario, mesh_device, measurement, traffic)
@@ -624,33 +622,28 @@ def _run(mesh_device, path, scenario, topology=ttnn.Topology.Linear):
     [ccl_mesh_param(SP_AXIS)],
     indirect=["mesh_device", "device_params"],
 )
-def test_kvpe_all_gather_perf(mesh_device, scenario):
+def test_kvpe_all_gather_perf(mesh_device, device_params, scenario):
     """Profile the SP all-gather used for the GLM KVPE prefix."""
-    _run(mesh_device, KVPE_ALL_GATHER, scenario)
-
-
-RESHARD_TOPOLOGIES = (ttnn.Topology.Linear, ttnn.Topology.Ring)
+    _run(mesh_device, device_params, KVPE_ALL_GATHER, scenario)
 
 
 @pytest.mark.parametrize("scenario", _NON_LOOP_SCENARIOS, ids=_scenario_id)
-@pytest.mark.parametrize("topology", RESHARD_TOPOLOGIES, ids=["linear", "ring"])
 @pytest.mark.parametrize(
     "mesh_device,device_params",
     [ccl_mesh_param(TP_AXIS)],
     indirect=["mesh_device", "device_params"],
 )
-def test_glm_head_to_sequence_reshard_perf(mesh_device, scenario, topology):
+def test_glm_head_to_sequence_reshard_perf(mesh_device, device_params, scenario):
     """Profile GLM's head-sharded to sequence-sharded TP redistribution."""
-    _run(mesh_device, GLM_HEAD_TO_SEQUENCE, scenario, topology)
+    _run(mesh_device, device_params, GLM_HEAD_TO_SEQUENCE, scenario)
 
 
 @pytest.mark.parametrize("scenario", _NON_LOOP_SCENARIOS, ids=_scenario_id)
-@pytest.mark.parametrize("topology", RESHARD_TOPOLOGIES, ids=["linear", "ring"])
 @pytest.mark.parametrize(
     "mesh_device,device_params",
     [ccl_mesh_param(TP_AXIS)],
     indirect=["mesh_device", "device_params"],
 )
-def test_glm_sequence_to_head_reshard_perf(mesh_device, scenario, topology):
+def test_glm_sequence_to_head_reshard_perf(mesh_device, device_params, scenario):
     """Profile GLM's sequence-sharded to head-sharded TP redistribution."""
-    _run(mesh_device, GLM_SEQUENCE_TO_HEAD, scenario, topology)
+    _run(mesh_device, device_params, GLM_SEQUENCE_TO_HEAD, scenario)

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_perf.py
@@ -12,11 +12,12 @@ and the cache scale by SP/8, so smaller boxes run a proportionally shorter seque
 workload mirrors Galaxy rather than a heavier one:
   * Galaxy   (32 chips): SP=8 × TP=4, chunk=5120, cache=50k,   heads=128 (full workload)
   * LoudBox  (8 chips):  SP=2 × TP=4, chunk=1280, cache=12.5k, heads=128 (1/4 sequence length)
-  * QuietBox (4 chips):  SP=1 × TP=4, chunk=640,  cache=6.25k, heads=128 (1/8 sequence length)
+  * QuietBox (4 chips):  SP=1 × TP=4, chunk=640,  cache=6.25k, heads=128 (1/8 sequence length, TorusX)
 
 That keeps the per-chip COMPUTE shapes equal to Galaxy: local query rows/chip (640), MLA heads/chip
 (32), indexer heads/chip (16), the per-chip KVPE depth (cache/SP = 6.25k on every box), AND the number
-of chunks-to-fill in `cold` (11 on every box, not 41 on LoudBox). CAVEAT: the indexer K-cache is
+of chunks-to-fill in `cold` (11 on every box, not 41 on LoudBox). QuietBox's single-axis mesh runs
+Fabric2D TorusX. CAVEAT: the indexer K-cache is
 replicated full-depth (= the box-local cache), so on smaller boxes it holds a proportionally SHORTER
 prefix than Galaxy — only Galaxy exercises the true 50k (or 0.5M) indexer/top-k depth; smaller boxes
 under-represent any op that scales with the replicated key-cache length.
@@ -158,12 +159,6 @@ _CONFIG_BUILDERS = {
     "glm_5_1": glm_hf_config,
     "glm_5_2": glm_5_2_hf_config,
 }
-
-# Fabric transport being profiled — single source for BOTH the device_params and the run manifest, so the
-# recorded provenance can never drift from what actually ran (FABRIC_2D is the production transport;
-# FABRIC_1D exhibited the multi-hop line-broadcast hang). FABRIC_2D + fabric_router_config leaves the
-# fabric-tensix datamover off, so the realtime profiler stays eligible (see PR #49840 CCL benchmarks).
-PERF_FABRIC = ttnn.FabricConfig.FABRIC_2D
 
 # Realtime-profiler record drain ceiling. The receiver thread delivers records asynchronously; the
 # wrapper stops once no new record has landed for its settle window, bounded by this ceiling. A generous
@@ -404,7 +399,7 @@ def _detect_perf_workload(variant_name: str) -> tuple[PerfWorkload, str | None]:
     num_devices = detect_num_devices()
     system = _SYSTEM_BY_DEVICE_COUNT.get(num_devices)
     if system is None:
-        placeholder = PerfWorkload("unsupported", num_devices, (1, 1), CHUNK_TOKENS, 32, 16)
+        placeholder = PerfWorkload("unsupported", num_devices, (2, 2), CHUNK_TOKENS, 32, 16)
         return placeholder, (
             "sparse MLA perf supports Blackhole QuietBox/LoudBox/Galaxy only " f"(detected {num_devices} chips)"
         )
@@ -429,6 +424,37 @@ def _detect_perf_workload(variant_name: str) -> tuple[PerfWorkload, str | None]:
 
 
 PERF_WORKLOAD, PERF_SKIP_REASON = _detect_perf_workload(VARIANT)
+_TORUS_XY_CERTIFIED = os.environ.get("PREFILL_TORUS_XY_CERTIFIED") == "1" and bool(
+    os.environ.get("TT_MESH_GRAPH_DESC_PATH")
+)
+if PERF_WORKLOAD.system_name == "Galaxy" and not _TORUS_XY_CERTIFIED:
+    PERF_SKIP_REASON = "Galaxy sparse MLA perf requires a certified TorusXY graph descriptor"
+PERF_FABRIC_BY_SYSTEM = {
+    "QuietBox": ttnn.FabricConfig.FABRIC_2D_TORUS_X,
+    "LoudBox": ttnn.FabricConfig.FABRIC_2D,
+    "Galaxy": ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
+}
+PERF_FABRIC = PERF_FABRIC_BY_SYSTEM.get(PERF_WORKLOAD.system_name, ttnn.FabricConfig.FABRIC_2D)
+PERF_FABRIC_ID = {
+    ttnn.FabricConfig.FABRIC_2D: "fabric2d",
+    ttnn.FabricConfig.FABRIC_2D_TORUS_X: "torus-x",
+    ttnn.FabricConfig.FABRIC_2D_TORUS_XY: "torus-xy",
+}[PERF_FABRIC]
+PERF_TOPOLOGY_MARK = pytest.mark.requires_mesh_topology(
+    mesh_shape=PERF_WORKLOAD.mesh_shape,
+    topology="ring"
+    if PERF_FABRIC == ttnn.FabricConfig.FABRIC_2D_TORUS_X
+    else f"mesh-{PERF_WORKLOAD.sp}x{PERF_WORKLOAD.tp}",
+)
+PERF_MESH_PARAM = (
+    pytest.param(
+        PERF_WORKLOAD.mesh_shape,
+        marks=(pytest.mark.skip(reason=PERF_SKIP_REASON), PERF_TOPOLOGY_MARK),
+        id="unsupported",
+    )
+    if PERF_SKIP_REASON
+    else pytest.param(PERF_WORKLOAD.mesh_shape, marks=PERF_TOPOLOGY_MARK, id=PERF_WORKLOAD.id)
+)
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -602,7 +628,7 @@ PERF_CASES = [
 ]
 
 
-@pytest.mark.parametrize("mesh_device", [PERF_WORKLOAD.mesh_shape], ids=[PERF_WORKLOAD.id], indirect=True)
+@pytest.mark.parametrize("mesh_device", [PERF_MESH_PARAM], indirect=True)
 @pytest.mark.parametrize(
     "device_params",
     [
@@ -613,7 +639,7 @@ PERF_CASES = [
             "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
         }
     ],
-    ids=["fabric2d"],
+    ids=[PERF_FABRIC_ID],
     indirect=True,
 )
 @pytest.mark.parametrize("attn_mode,kv_cache_format", PERF_CASES)
@@ -795,7 +821,11 @@ def test_mla_chunked_perf(mesh_device, variant, scenario, attn_mode, kv_cache_fo
             f"{workload.system_name} proxy "
             f"{workload.chunk_tokens}-tok chunk, {span}, SP={workload.sp}×TP={workload.tp}",
             f"Galaxy target: {CHUNK_TOKENS}-tok chunk @ {galaxy_cache}-tok cache, SP={GALAXY_SP}×TP={GALAXY_TP}; "
-            f"local chunk={CHUNK_TOKENS // GALAXY_SP}, local MLA heads={workload.num_attention_heads // GALAXY_TP}",
+            f"local chunk={CHUNK_TOKENS // GALAXY_SP}, "
+            f"Galaxy local MLA/index heads={workload.num_attention_heads // GALAXY_TP}/"
+            f"{workload.index_n_heads // GALAXY_TP}; "
+            f"proxy local MLA/index heads={workload.num_attention_heads // workload.tp}/"
+            f"{workload.index_n_heads // workload.tp}",
             f"critical-path device-kernel time over the {'prefill' if is_cold else 'chunk'} "
             f"(realtime profiler; per-program max across chips): "
             f"{total_ns/1e6:.3f} ms across {int(by_op['count'].sum())} device programs",

--- a/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_vs_trace.py
+++ b/models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla_vs_trace.py
@@ -36,14 +36,9 @@ the layout DOES matter: pass --ds-kpe-layout vllm to reindex our k_pe to vLLM's
 half-split layout (interleaved_to_halfsplit_perm in tt/mla/rope.py) and assert a hard
 element-wise k_pe PCC (~0.99997) instead of the frame-invariant L2.
 
-Runtime (Blackhole 1x4, layer shard already downloaded — measured layer 0):
-  host_*  (CPU only)            ~25 s for all 3 (shared module fixture: weight load +
-                                one 5120 forward; the 3 asserts are ~0 s each)
-  device indexer                ~45 s  (10 s mesh setup + 30 s device stems/score/topk)
-  device kv                     ~65 s  (forward + sparse_mla host fallback, ~24 GB RAM)
-  device mla                    ~50 s  (forward + sparse_mla host fallback, ~24 GB RAM)
-First run adds one-time JIT kernel compile (~1-2 min) and, if uncached, a multi-GB
-HF shard download. All are correctness gates → marked `gate`; @timeout(0).
+Device rows use only the supported Fabric2D 2x2, 2x4, 4x2, or 8x4 profiles. Runtime depends on
+mesh and cache warmth; first run adds one-time JIT compilation and, if uncached, a multi-GB HF
+shard download. All are correctness gates → marked `gate`; @timeout(0).
 
 ────────────────────────────────────────────────────────────────────────────────
 GLM-5.1 (model id `glm_5_1`)
@@ -72,7 +67,8 @@ from models.common.utility_functions import comp_pcc
 from models.demos.deepseek_v3_d_p.reference.cpu_deepseek_v32 import SparseMLAReference, pretrained_mla_weights
 from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config, glm_hf_config  # GLM dims + HF config
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_mesh import (
-    parametrize_mesh_device,
+    detect_num_devices,
+    parametrize_mesh_and_device_params,
     skip_if_seq_too_small_for_sp,
 )
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_plugin import is_marker_explicitly_selected
@@ -257,14 +253,14 @@ def _assert_kv(ref_kv: torch.Tensor, kvpe: torch.Tensor, tag: str, kpe_layout: s
 
 
 # ----------------------------------------------------------------------------
-# Device: the TT implementation vs the official reference (Blackhole 1x4).
+# Device: the TT implementation vs the official reference on supported Fabric2D profiles.
 # ----------------------------------------------------------------------------
-_DEVICE_PARAMS = [
-    {
-        "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-        "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
-    }
-]
+_WORKER_L1_SIZE = ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE
+_TORUS_XY_CERTIFIED = (
+    detect_num_devices() == 32
+    and os.environ.get("PREFILL_TORUS_XY_CERTIFIED") == "1"
+    and bool(os.environ.get("TT_MESH_GRAPH_DESC_PATH"))
+)
 
 
 def _config_for(model: str):
@@ -315,8 +311,7 @@ def _shard_idx_input(t, mesh_device):
     )
 
 
-@parametrize_mesh_device()
-@pytest.mark.parametrize("device_params", _DEVICE_PARAMS, ids=["line"], indirect=True)
+@parametrize_mesh_and_device_params(worker_l1_size=_WORKER_L1_SIZE, torus_xy_certified=_TORUS_XY_CERTIFIED)
 @pytest.mark.parametrize("model, layer", _CASES, ids=_CASE_IDS)
 @pytest.mark.timeout(0)
 def test_indexer_device_vs_reference(mesh_device, model, layer, device_params, monkeypatch):
@@ -437,8 +432,7 @@ def _run_device_forward(model, config, layer, mesh_device):
     return ref, out_t, kvpe_t
 
 
-@parametrize_mesh_device()
-@pytest.mark.parametrize("device_params", _DEVICE_PARAMS, ids=["line"], indirect=True)
+@parametrize_mesh_and_device_params(worker_l1_size=_WORKER_L1_SIZE, torus_xy_certified=_TORUS_XY_CERTIFIED)
 @pytest.mark.parametrize("model, layer", _CASES, ids=_CASE_IDS)
 @pytest.mark.timeout(0)
 def test_kv_cache_device_vs_reference(mesh_device, model, layer, device_params, ds_kpe_layout):
@@ -449,8 +443,7 @@ def test_kv_cache_device_vs_reference(mesh_device, model, layer, device_params, 
     ttnn.synchronize_device(mesh_device)
 
 
-@parametrize_mesh_device()
-@pytest.mark.parametrize("device_params", _DEVICE_PARAMS, ids=["line"], indirect=True)
+@parametrize_mesh_and_device_params(worker_l1_size=_WORKER_L1_SIZE, torus_xy_certified=_TORUS_XY_CERTIFIED)
 @pytest.mark.parametrize("model, layer", _CASES, ids=_CASE_IDS)
 @pytest.mark.timeout(0)
 def test_mla_output_device_vs_reference(mesh_device, model, layer, device_params):

--- a/models/demos/deepseek_v3_d_p/tests/test_d2d_socket_sync.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_d2d_socket_sync.py
@@ -20,6 +20,7 @@ import torch
 
 import ttnn
 from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
 
 _TOKENS_PER_ROW = 640  # tokens of the chunk carried per mesh row (the realistic knob)
 _HIDDEN = 7168  # DeepSeek-V3 / Kimi-K2 hidden size, sharded across the mesh columns
@@ -61,18 +62,18 @@ def _to_device(torch_u32, mesh, mapper):
     [
         pytest.param(
             (8, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_2D},
+            torus_xy_device_params(),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
         # 4-chip QuietBox variant: 2 rows -> 1 sender row + 1 receiver row, 2 cols. Per-shard
         # page = (7168/2)*4 = 14336 B (< the 16384 B FIFO), so the same op path runs on a
         # small multi-card box (no 32-chip Galaxy needed).
         pytest.param(
             (2, 2),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_2D},
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="linear"),
-            id="linear-2x2",
+            fabric2d_device_params(),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 2), topology="mesh-2x2"),
+            id="fabric2d-2x2",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/test_disaggregation.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_disaggregation.py
@@ -30,7 +30,7 @@ from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
     "device_params",
     [
         {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "fabric_config": ttnn.FabricConfig.DISABLED,
         }
     ],
     indirect=True,
@@ -102,7 +102,7 @@ def test_kv_cache_address_table(mesh_device, seq_len):
     "device_params",
     [
         {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "fabric_config": ttnn.FabricConfig.DISABLED,
         }
     ],
     indirect=True,

--- a/models/demos/deepseek_v3_d_p/tests/test_embedding_socket.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_embedding_socket.py
@@ -16,6 +16,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import get_tp_mesh_composer
 from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
 from tests.ttnn.utils_for_testing import comp_pcc
@@ -26,9 +27,9 @@ from tests.ttnn.utils_for_testing import comp_pcc
     [
         pytest.param(
             (8, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_2D},
+            torus_xy_device_params(),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/test_h2d_socket_sync.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_h2d_socket_sync.py
@@ -11,6 +11,7 @@ from loguru import logger
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import get_tp_mesh_composer
 from models.demos.deepseek_v3_d_p.tt.tt_parallel_embedding import TtParallelEmbedding
 from tests.ttnn.utils_for_testing import comp_pcc
@@ -24,9 +25,9 @@ _METADATA_SIZE_BYTES = 12
     [
         pytest.param(
             (8, 4),
-            {"fabric_config": ttnn.FabricConfig.FABRIC_2D},
+            torus_xy_device_params(),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],

--- a/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py
@@ -13,11 +13,13 @@ from ttnn.device import is_blackhole
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.mla_reference import create_mla_reference
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_reference import build_weights
 from models.demos.deepseek_v3_d_p.tests.test_mla import run_mla_inference
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
 from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_positions, reverse_reorder_tensor_chunks
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
     BH_NUM_DRAM_BANKS,
     NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK,
@@ -42,15 +44,8 @@ from tests.ttnn.utils_for_testing import assert_equal
 )
 @pytest.mark.parametrize(
     "device_params",
-    [
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-        },
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-        },
-    ],
-    ids=["line", "ring"],
+    [torus_xy_device_params()],
+    ids=["torus-xy"],
     indirect=True,
 )
 @pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"])
@@ -86,8 +81,7 @@ def test_kv_cache_table(
     else:
         config, weights = request.getfixturevalue("random_weights")
 
-    fabric_config = device_params.get("fabric_config", ttnn.FabricConfig.FABRIC_1D)
-    topology = ttnn.Topology.Ring if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING else ttnn.Topology.Linear
+    topology = per_axis_topology(device_params["fabric_config"])
 
     sp_axis = 0
     tp_axis = 1
@@ -203,15 +197,8 @@ def test_kv_cache_table(
 )
 @pytest.mark.parametrize(
     "device_params",
-    [
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-        },
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-        },
-    ],
-    ids=["line", "ring"],
+    [torus_xy_device_params()],
+    ids=["torus-xy"],
     indirect=True,
 )
 @pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"])
@@ -247,8 +234,7 @@ def test_kimi_kv_cache_table(
 
     logger.info(f"model={variant.name} num_heads={config.num_attention_heads} hidden={config.hidden_size}")
 
-    fabric_config = device_params.get("fabric_config", ttnn.FabricConfig.FABRIC_1D)
-    topology = ttnn.Topology.Ring if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING else ttnn.Topology.Linear
+    topology = per_axis_topology(device_params["fabric_config"])
 
     sp_axis = 0
     tp_axis = 1
@@ -337,15 +323,8 @@ def test_kimi_kv_cache_table(
 )
 @pytest.mark.parametrize(
     "device_params",
-    [
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-        },
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-        },
-    ],
-    ids=["line", "ring"],
+    [torus_xy_device_params()],
+    ids=["torus-xy"],
     indirect=True,
 )
 @pytest.mark.parametrize("seq_len", [5 * 1024, 10 * 1024, 25 * 1024], ids=["seq5k", "seq10k", "seq25k"])
@@ -451,12 +430,8 @@ def test_kimi_kv_cache_mock(
 )
 @pytest.mark.parametrize(
     "device_params",
-    [
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-        },
-    ],
-    ids=["line"],
+    [torus_xy_device_params()],
+    ids=["torus-xy"],
     indirect=True,
 )
 @pytest.mark.parametrize("seq_len", [5 * 1024, 10 * 1024], ids=["seq5k", "seq10k"])
@@ -645,8 +620,7 @@ def test_glm_kv_cache_table(
     block-cyclic layout coincides with the sequential (Kimi) layout, so no chunk reorder is needed.
     """
     config = config_only
-    fabric_config = device_params.get("fabric_config", ttnn.FabricConfig.FABRIC_1D)
-    topology = ttnn.Topology.Ring if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING else ttnn.Topology.Linear
+    topology = per_axis_topology(device_params["fabric_config"])
 
     sp_axis = 0
     tp_axis = 1
@@ -836,16 +810,12 @@ def test_glm_kv_cache_table(
 # the indexer runs and fills the index-key cache), fills both the KVPE and indexer caches, builds the
 # merged 2-config kimi table (config 0 = KVPE, config 1 = index), and reads every 32-token chunk back.
 @pytest.mark.parametrize(
-    "mesh_device",
-    [(2, 4), (8, 4)],
-    ids=["2x4", "8x4"],
-    indirect=True,
-)
-@pytest.mark.parametrize(
-    "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}],
-    ids=["line"],
-    indirect=True,
+    "mesh_device,device_params",
+    [
+        pytest.param((2, 4), fabric2d_device_params(), id="fabric2d-2x4"),
+        pytest.param((8, 4), torus_xy_device_params(), id="torus-xy-8x4"),
+    ],
+    indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize("seq_len", [5 * 1024], ids=["seq5k"])
 @pytest.mark.parametrize("variant", ["glm_5_2"], indirect=True, ids=["glm52"])
@@ -865,8 +835,7 @@ def test_glm52_kv_cache_table(
     both, read back chunk-by-chunk. This is the SP-only baseline that main lacks for GLM-5.2.
     """
     config = config_only
-    fabric_config = device_params.get("fabric_config", ttnn.FabricConfig.FABRIC_1D)
-    topology = ttnn.Topology.Ring if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING else ttnn.Topology.Linear
+    topology = per_axis_topology(device_params["fabric_config"])
 
     sp_axis = 0
     tp_axis = 1

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -18,6 +18,7 @@ from ttnn.device import is_blackhole
 import ttnn
 from models.common.utility_functions import comp_pcc, hf_cache_layer_kv
 from models.demos.deepseek_v3_d_p.reference.mla_reference import create_mla_reference
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params, torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tests.reference_runners import run_reference_mla
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers, resolve_has_indexer
@@ -30,7 +31,7 @@ from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     reverse_reorder_tensor_chunks,
     rotated_chip_positions,
 )
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.utils.chunked_prefill_utils import (
     cpu_mla_reference,
     load_trace,
@@ -42,6 +43,12 @@ from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import is_high_power
 from models.demos.deepseek_v3_d_p.utils.test_utils import WH_WORKER_L1_SIZE
 from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program
 from tests.ttnn.utils_for_testing import assert_with_pcc
+
+_WORKER_L1_SIZE = ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE
+
+
+def _local_fabric2d_params():
+    return fabric2d_device_params(worker_l1_size=_WORKER_L1_SIZE)
 
 
 def run_mla_inference(
@@ -201,8 +208,7 @@ def run_model(
     else:
         config, weights = request.getfixturevalue("random_weights")
 
-    fabric_config = device_params.get("fabric_config", ttnn.FabricConfig.FABRIC_1D)
-    topology = ttnn.Topology.Ring if fabric_config == ttnn.FabricConfig.FABRIC_1D_RING else ttnn.Topology.Linear
+    topology = per_axis_topology(device_params["fabric_config"])
 
     production_mesh = [32, 4]
     sp_axis = 0
@@ -397,31 +403,15 @@ def run_model(
 
 # sp x tp
 @pytest.mark.parametrize(
-    "mesh_device",
-    [(32, 4), (8, 4), (2, 4)],
-    ids=["32x4", "8x4", "2x4"],
-    indirect=True,
-)
-@pytest.mark.parametrize(
-    "device_params",
+    "mesh_device,device_params",
     [
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-            "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
-        },
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-            "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
-        },
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-            "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
-        },
+        # Multi-host 32x4 is a four-Galaxy scale-out diagnostic. There is no certified descriptor
+        # that closes this entire logical mesh into one XY torus, so it remains unwrapped Fabric2D.
+        pytest.param((32, 4), _local_fabric2d_params(), id="fabric2d-32x4"),
+        pytest.param((8, 4), torus_xy_device_params(worker_l1_size=_WORKER_L1_SIZE), id="torus-xy-8x4"),
+        pytest.param((2, 4), _local_fabric2d_params(), id="fabric2d-2x4"),
     ],
-    ids=["line", "ring", "fabric2d"],
-    indirect=True,
+    indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"])
 @pytest.mark.parametrize("scale_down_sl", [False, True], ids=["max_sl", "scaled_sl"])
@@ -458,27 +448,13 @@ def test_ds_mla(
     )
 
 
-@pytest.mark.parametrize("mesh_device", [(8, 4), (2, 4)], ids=["8x4", "2x4"], indirect=True)
 @pytest.mark.parametrize(
-    "device_params",
+    "mesh_device,device_params",
     [
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-            "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
-        },
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-            "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
-        },
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-            "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
-        },
+        pytest.param((8, 4), torus_xy_device_params(worker_l1_size=_WORKER_L1_SIZE), id="torus-xy-8x4"),
+        pytest.param((2, 4), _local_fabric2d_params(), id="fabric2d-2x4"),
     ],
-    ids=["line", "ring", "fabric2d"],
-    indirect=True,
+    indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize("use_pretrained", [False], ids=["random"])
 @pytest.mark.parametrize("scale_down_sl", [False, True], ids=["max_sl", "scaled_sl"])
@@ -580,7 +556,7 @@ def _run_chunked_prefill(
     prefill_len=0,
     num_users=1,
     use_pretrained=False,
-    topology=ttnn.Topology.Linear,
+    topology=None,
     use_metadata_tensor=False,
     determinism_check=False,
     profile=False,
@@ -608,6 +584,8 @@ def _run_chunked_prefill(
     if profile and not ttnn.device.IsProgramRealtimeProfilerActive():
         pytest.fail("realtime profiler inactive (needs Blackhole, WORKER dispatch, fabric-tensix DM off)")
     sp_axis, tp_axis = 0, 1
+    if topology is None:
+        topology = per_axis_topology()
     mesh_shape = list(mesh_device.shape)
     sp = mesh_shape[sp_axis]
     tile = ttnn.TILE_SIZE
@@ -962,30 +940,16 @@ _CHUNKED_SCENARIOS = (
 
 
 @pytest.mark.parametrize(
-    "device_params",
+    "mesh_device,device_params",
     [
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-        },
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-        },
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-            # high_bw_all_gather parks its readiness/completion semaphores in L1_SMALL when the device
-            # reserves one, and falls back to general L1 otherwise. On the 8x4 grid the fallback
-            # fragments L1 enough that a later op's static circular buffers collide with it.
-            "l1_small_size": 1152,
-        },
+        pytest.param((2, 2), fabric2d_device_params(l1_small_size=1152), id="fabric2d-2x2"),
+        pytest.param((2, 4), fabric2d_device_params(l1_small_size=1152), id="fabric2d-2x4"),
+        # high_bw_all_gather parks readiness/completion semaphores in L1_SMALL. On 8x4 the
+        # fallback fragments general L1 enough that a later op's static circular buffers collide.
+        pytest.param((8, 4), torus_xy_device_params(l1_small_size=1152), id="torus-xy-8x4"),
     ],
-    ids=["line", "ring", "fabric2d"],
-    indirect=True,
+    indirect=["mesh_device", "device_params"],
 )
-@pytest.mark.parametrize("mesh_device", [(2, 2), (2, 4), (8, 4)], ids=["2x2", "2x4", "8x4"], indirect=True)
 @pytest.mark.parametrize("reference", ["cpu", "trace", None], ids=["cpu", "trace", "func"])
 @pytest.mark.parametrize("kwargs", [kw for _, kw in _CHUNKED_SCENARIOS], ids=[sid for sid, _ in _CHUNKED_SCENARIOS])
 @pytest.mark.parametrize(
@@ -1037,11 +1001,7 @@ def test_mla_chunked_prefill(
     # fixture skips the test if the env var is set but the checkpoint is incomplete.
     if reference == "cpu" and os.environ.get(variant.env_var) and not kwargs.get("use_pretrained"):
         kwargs = {**kwargs, "use_pretrained": True}
-    topology = (
-        ttnn.Topology.Ring
-        if device_params.get("fabric_config") == ttnn.FabricConfig.FABRIC_1D_RING
-        else ttnn.Topology.Linear
-    )
+    topology = per_axis_topology(device_params["fabric_config"])
     _run_chunked_prefill(
         request,
         mesh_device,
@@ -1054,19 +1014,17 @@ def test_mla_chunked_prefill(
 
 
 @pytest.mark.parametrize(
-    "device_params",
+    "mesh_device,device_params",
     [
-        {
-            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
-            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-            "l1_small_size": 1152,
-        }
+        pytest.param(
+            (8, 4),
+            torus_xy_device_params(l1_small_size=1152),
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="torus-xy-8x4",
+        )
     ],
-    ids=["fabric2d"],
-    indirect=True,
+    indirect=["mesh_device", "device_params"],
 )
-@pytest.mark.parametrize("mesh_device", [(8, 4)], ids=["8x4"], indirect=True)
 @pytest.mark.parametrize("variant", ["kimi_k3"], indirect=True, ids=["k3"])
 @pytest.mark.skipif(not is_blackhole(), reason="kimi_k3 and the realtime profiler are Blackhole-only")
 @pytest.mark.skipif(
@@ -1081,11 +1039,12 @@ def test_mla_chunked_perf_check(request, mesh_device, device_params, variant):
     NOT comparable to test_kimi_k3_mla_chunked_perf_galaxy's 11_562_468: that number comes from the
     Tracy merge path, which averages collectives across chips, while this takes the max for every
     program. K3's forward is ~7% CCL, so the two disagree by construction."""
+    topology = per_axis_topology(device_params["fabric_config"])
     total_ns = _run_chunked_prefill(
         request,
         mesh_device,
         reference=None,
-        topology=ttnn.Topology.Linear,
+        topology=topology,
         profile=True,
         iters_isl=[5120],
         prefill_len=50 * 1024,

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -31,6 +31,12 @@ from models.demos.deepseek_v3_d_p.reference.glm_5_1 import glm_decoder_layer_ref
 from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.moe import load_moe_weights_from_hf
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import (
+    fabric2d_device_params,
+    torus_x_device_params,
+    torus_xy_device_params,
+    torus_y_device_params,
+)
 from models.demos.deepseek_v3_d_p.tests.sparse_mla.sparse_mla_reference import build_weights
 from models.demos.deepseek_v3_d_p.tt.mla.indexer import indexer_layer_is_reused, num_full_indexer_layers
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
@@ -39,8 +45,8 @@ from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     reorder_tensor_chunks,
     reverse_reorder_tensor_chunks,
 )
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import TtPrefillBlock
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
@@ -502,175 +508,48 @@ def run_model(
     "layer_type, gate_fallback_mode",
     [("dense", None), ("moe", GateComputeMode.DEVICE), ("moe", GateComputeMode.HOST_ALL)],
     # The host-gate id omits the `moe` token on purpose: CI selects the device gate via count-guarded
-    # `-k "... and moe and ..."` (EXPECT_NUM_TESTS=1), so a host id carrying `moe` would be collected too
+    # `-k "... and moe and ..."`, so a host id carrying `moe` would be collected too
     # and break the count. It is a local sub-256-expert aid (CI-skipped by enum); select via `-k host_gate`.
     ids=["dense", "moe-gate_device", "host_gate_all"],
 )
 @pytest.mark.parametrize("is_balanced", [True, False], ids=["balanced", "non_balanced"])
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (2, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-            },
+            fabric2d_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
             1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
-            id="mesh-2x4",
-        ),
-        pytest.param(
-            (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-            },
-            2,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
-        ),
-        pytest.param(
-            (2, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-            },
-            1,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
             id="fabric2d-mesh-2x4",
         ),
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-            },
+            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
             2,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="fabric2d-mesh-8x4",
-        ),
-        pytest.param(
-            (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-            },
-            1,
-            # Per-axis topology (SP-axis-0, TP-axis-1). FABRIC_2D_TORUS_Y wraps ONLY the SP axis
-            # into a ring → Ring for SP-axis MoE dispatch/combine; the 4-wide TP axis stays a line
-            # → Linear for TP-axis collectives (RMS-norm, MLA, shared-expert, gate). A scalar Ring
-            # here deadlocks the TP-axis all-gathers on a non-existent column wrap link.
-            (ttnn.Topology.Ring, ttnn.Topology.Linear),
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            # Id omits the `fabric2d-`/`mesh-` tokens on purpose: CI runs the fabric2d-mesh siblings
-            # via count-guarded `-k "8x4 and fabric2d"` (EXPECT_NUM_TESTS=1) selectors, so a torus id
-            # carrying `fabric2d` would be collected too and break the count. Select it with `-k torus-y`.
-            id="torus-y-8x4",
-        ),
-        pytest.param(
-            (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-            },
-            1,
-            # FABRIC_2D_TORUS_X wraps ONLY the TP axis (dim 1) into a ring → Ring for the TP-axis
-            # collectives (RMS-norm, MLA, dense-FFN, shared-expert, gate); the SP axis (dim 0) stays
-            # a line → Linear for the SP-axis MoE dispatch/combine. Production full-galaxy X-ring
-            # case (matches the [LINE,RING] pipeline descriptors); no sub-torus carve needed.
-            (ttnn.Topology.Linear, ttnn.Topology.Ring),
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="torus-x-8x4",
-        ),
-        pytest.param(
-            (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-            },
-            1,
-            # FABRIC_2D_TORUS_XY wraps BOTH axes: SP (dim 0) and TP (dim 1) are each a ring. The
-            # SP-axis MoE dispatch/combine + ring-attention SDPA ride the SP ring (the path #48225's
-            # ring-aware dispatch/combine kernels support), and the TP-axis collectives ring on dim 1.
-            (ttnn.Topology.Ring, ttnn.Topology.Ring),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
             id="torus-xy-8x4",
         ),
         pytest.param(
             (4, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_Y,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-            },
+            torus_y_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
             2,
-            # 4x4 sub-torus: Ring-4 on the SP axis (dim 0), Linear on the 4-wide TP axis (dim 1).
-            # Run with TT_VISIBLE_DEVICES (16 chips) + TT_MESH_GRAPH_DESC_PATH=...subtorus_y4...
-            (ttnn.Topology.Ring, ttnn.Topology.Linear),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 4), topology="mesh-4x4"),
             id="torus-y-4x4",
         ),
         pytest.param(
             (4, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-            },
+            torus_x_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
             2,
-            # 4x4 full 2D sub-torus: Ring-4 on BOTH axes (dim 0 = SP/Y, dim 1 = TP/X). Both axes have
-            # a physical wrap, so TP-axis collectives (RMS-norm, MLA, shared-expert) can ring too.
-            # Run with TT_VISIBLE_DEVICES (16 chips) + TT_MESH_GRAPH_DESC_PATH=...subtorus_xy4...
-            (ttnn.Topology.Ring, ttnn.Topology.Ring),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 4), topology="mesh-4x4"),
-            id="torus-xy-4x4",
+            id="torus-x-4x4",
         ),
         pytest.param(
             (4, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_X,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-            },
+            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
             2,
-            # 4x4 sub-torus: Ring-4 on the TP/X axis (dim 1), Linear on the SP/Y axis (dim 0). Only
-            # the TP axis is physically wrapped, so TP-axis collectives (RMS-norm, MLA, dense-FFN,
-            # shared-expert, gate) ring while the SP-axis MoE dispatch/combine stay a line — a scalar
-            # Ring here would deadlock dispatch/combine on a non-existent row wrap link.
-            # Run with TT_VISIBLE_DEVICES (16 chips) + TT_MESH_GRAPH_DESC_PATH=...subtorus_x4...
-            (ttnn.Topology.Linear, ttnn.Topology.Ring),
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 4), topology="mesh-4x4"),
-            id="torus-x-4x4",
+            id="torus-xy-4x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -691,7 +570,6 @@ def test_ds_prefill_block(
     layer_type,
     gate_fallback_mode,
     num_links,
-    topology,
     pcc_validation,
     input_source,
     tokenizer,
@@ -702,6 +580,7 @@ def test_ds_prefill_block(
     use_pretrained,
     request,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])
     # FABRIC_2D on the 2x4 mesh regresses the MoE/device-gate PCC ~3 points below the 0.992 gate.
     # xfail this exact combo (keeping the real threshold for every other config) until it is fixed;
     # strict=True turns an XPASS into a failure so the marker is removed once the fix lands.
@@ -762,18 +641,14 @@ def test_ds_prefill_block(
 )
 @pytest.mark.parametrize("is_balanced", [False], ids=["non_balanced"])
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
-            },
+            torus_xy_device_params(fabric_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -795,7 +670,6 @@ def test_kimi_prefill_block(
     layer_type,
     gate_fallback_mode,
     num_links,
-    topology,
     pcc_validation,
     input_source,
     tokenizer,
@@ -806,6 +680,7 @@ def test_kimi_prefill_block(
     use_pretrained,
     request,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])
     run_model(
         variant,
         config_only,
@@ -940,20 +815,17 @@ def _glm_pretrained_weights(config, model_dir, layer_idx, is_moe):
 
 
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE),
-                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-                "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE,
-            },
+            torus_xy_device_params(
+                fabric_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE,
+                worker_l1_size=ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE,
+            ),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="fabric2d-mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -969,13 +841,13 @@ def test_glm_prefill_block(
     mesh_device,
     device_params,
     num_links,
-    topology,
     seq_len,
     layer_type,
     model_path,
     weight_cache_path,
 ):
     """One fused GLM decoder block (sparse-SDPA MLA + norm/residual + dense|MoE FFN) vs composed CPU ref."""
+    topology = per_axis_topology(device_params["fabric_config"])
     is_moe = layer_type == "moe"
     config = config_only
     config.max_seq_len = seq_len

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block_chunked.py
@@ -34,11 +34,12 @@ from models.common.utility_functions import is_blackhole, profiler
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.reference.glm_5_2_config import GLM52Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.mla.indexer import full_indexer_rank, num_full_indexer_layers, resolve_has_indexer
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
 from models.demos.deepseek_v3_d_p.tt.mla.utils import blockcyclic_positions, rotated_chip_positions
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import TtPrefillBlock
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
@@ -359,20 +360,14 @@ def run_chunked_block(
     ids=["dense", "moe-gate_device"],
 )
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-            },
+            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -390,8 +385,8 @@ def test_ds_prefill_block_chunked(
     layer_idx,
     gate_fallback_mode,
     num_links,
-    topology,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])
     run_chunked_block(
         variant,
         config_only,
@@ -540,20 +535,14 @@ def run_chunked_block_multiuser(
 @pytest.mark.parametrize("num_users", [2], ids=["U2"])
 @pytest.mark.parametrize("layer_idx, gate_fallback_mode", [(2, None)], ids=["dense"])
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-            },
+            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -571,8 +560,8 @@ def test_ds_prefill_block_chunked_multiuser(
     layer_idx,
     gate_fallback_mode,
     num_links,
-    topology,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])
     run_chunked_block_multiuser(
         variant,
         config_only,
@@ -828,20 +817,14 @@ def run_chunked_block_padded(
     ids=["dense", "moe-gate_device"],
 )
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-            },
+            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -859,8 +842,8 @@ def test_ds_prefill_block_chunked_padded(
     layer_idx,
     gate_fallback_mode,
     num_links,
-    topology,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])
     run_chunked_block_padded(
         variant, config_only, mesh_device, weight_cache_path, splits, layer_idx, gate_fallback_mode, num_links, topology
     )
@@ -884,18 +867,14 @@ def test_ds_prefill_block_chunked_padded(
     ids=["moe-gate_host"],
 )
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
-            },
+            torus_xy_device_params(fabric_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -913,8 +892,8 @@ def test_kimi_prefill_block_chunked(
     layer_idx,
     gate_fallback_mode,
     num_links,
-    topology,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])
     run_chunked_block(
         variant,
         config_only,
@@ -935,18 +914,14 @@ def test_kimi_prefill_block_chunked(
     ids=["moe-gate_host"],
 )
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
-            },
+            torus_xy_device_params(fabric_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -964,8 +939,8 @@ def test_kimi_prefill_block_chunked_padded(
     layer_idx,
     gate_fallback_mode,
     num_links,
-    topology,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])
     run_chunked_block_padded(
         variant, config_only, mesh_device, weight_cache_path, splits, layer_idx, gate_fallback_mode, num_links, topology
     )
@@ -1144,21 +1119,15 @@ def run_chunked_block_glm_indexer(
 @pytest.mark.parametrize("n_chunks", [11], ids=["chunks11"])
 @pytest.mark.parametrize("layer_idx", [2, 6, 30, 62, 74], ids=lambda l: f"L{l}")
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=GLM52Config.FABRIC_PAYLOAD_SIZE),
-                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-                # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores.
-                "l1_small_size": 768,
-            },
+            # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores.
+            torus_xy_device_params(fabric_payload_size=GLM52Config.FABRIC_PAYLOAD_SIZE, l1_small_size=768),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -1167,8 +1136,9 @@ def run_chunked_block_glm_indexer(
 @pytest.mark.skipif(not is_blackhole(), reason="GLM DSA (indexer) is Blackhole-only")
 @pytest.mark.timeout(0)
 def test_glm_prefill_block_indexer_teacher_forced(
-    variant, config_only, mesh_device, device_params, weight_cache_path, n_chunks, layer_idx, num_links, topology
+    variant, config_only, mesh_device, device_params, weight_cache_path, n_chunks, layer_idx, num_links
 ):
+    topology = per_axis_topology(device_params["fabric_config"])
     run_chunked_block_glm_indexer(
         variant, config_only, mesh_device, weight_cache_path, n_chunks, layer_idx, num_links, topology
     )

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py
@@ -34,10 +34,11 @@ from models.demos.deepseek_v3.utils.config_helpers import sub_state_dict
 from models.demos.deepseek_v3.utils.test_utils import dequantize_state_dict
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.tests.conftest import FABRIC_2D_PREFILL_BLOCK_MESH_PARAMS
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import fabric2d_device_params
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.mla.rope import RotarySetup
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import TtPrefillBlock
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.transformer_helpers import (
@@ -84,47 +85,20 @@ PLOT_DIR = "models/demos/deepseek_v3_d_p/tests"
 )
 @pytest.mark.parametrize("skip_reference", [False, True], ids=["with_ref", "no_ref"])
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (1, 1),
             {},
             1,
-            ttnn.Topology.Linear,
             id="mesh-1x1",
         ),
         pytest.param(
             (2, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=DeepSeekV3Config.EMB_SIZE),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
-            id="mesh-2x4",
-        ),
-        pytest.param(
-            (2, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=DeepSeekV3Config.EMB_SIZE),
-            },
-            2,  # num_links = 2
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
-            id="mesh-2x4-2link",
-        ),
-        pytest.param(
-            (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=DeepSeekV3Config.EMB_SIZE),
-            },
+            fabric2d_device_params(fabric_payload_size=DeepSeekV3Config.EMB_SIZE),
             2,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
+            id="fabric2d-mesh-2x4-2link",
         ),
         # FABRIC_2D variants — shared list defined in conftest.py (also used by
         # test_prefill_transformer.py). Covers (4,2) BH LoudBox, (2,4) asymmetric, (8,4) BH Galaxy.
@@ -141,12 +115,12 @@ def test_prefill_block_loop(
     skip_reference,
     gate_fallback_mode,
     num_links,
-    topology,
     model_path,
     hf_config,
     state_dict,
     tokenizer,
 ):
+    topology = per_axis_topology(device_params.get("fabric_config", ttnn.FabricConfig.DISABLED))
     # Perf runs (skip_reference=True) measure once; PCC/divergence runs loop for 30 iters
     num_iters = 1 if skip_reference else 30
     # --- Validate fixtures ---
@@ -155,8 +129,8 @@ def test_prefill_block_loop(
     if state_dict is None:
         pytest.skip("State dict not available (no pretrained weights)")
 
-    # isl_2k56 / isl_12k8 exist only for the 4x4 sub-torus sweep and are not part of CI coverage on
-    # any mesh; skip them under CI.
+    # These sequence lengths belong to the existing 4x4 subtorus sweep, which is intentionally
+    # local/experimental until a dedicated CI owner exists.
     if (os.getenv("CI") == "true" or "TT_GH_CI_INFRA" in os.environ) and isl_total in (2560, 12800):
         pytest.skip("isl_2k56 / isl_12k8 are subtorus-4x4-only; not run in CI")
 
@@ -173,16 +147,11 @@ def test_prefill_block_loop(
     emb_dim = config.hidden_size
     first_k_dense = config.first_k_dense_replace  # 3
     n_routed = config.n_routed_experts  # 256
-    # The 4x4 sub-torus has 16 chips vs the 8x4 galaxy's 32, so the full 256 experts pack
-    # 256/16=16 experts/chip. Halve to 128 so each chip holds 128/16=8 experts, matching the 8x4
-    # (256/32=8). The device grouped-gate kernels (deepseek_grouped_gate / moe_grouped_topk) hard-
-    # require exactly 256 experts, so the 128-expert path MUST use the host gate — forced below.
-    # The first n_routed experts (gate rows + expert weights) are kept; applies to the (4,4) mesh.
-    # Opt out with DS_4X4_FULL_EXPERTS=1 to keep all 256 experts (16/chip) and honor the requested
-    # gate (e.g. real device gate) — viable at small ISL where 256 experts still fit L1.
+    # Preserve the existing 4x4 diagnostic's per-chip expert load: 128/16 == 256/32. The device
+    # grouped-gate kernels require 256 experts, so this path uses the host gate below.
     halve_experts_4x4 = mesh_shape == [4, 4] and not os.environ.get("DS_4X4_FULL_EXPERTS")
     if halve_experts_4x4:
-        n_routed = config.n_routed_experts // 2  # 128
+        n_routed = config.n_routed_experts // 2
         config.n_routed_experts = n_routed
         logger.info(f"[4x4 sub-torus] Using half the routed experts: {n_routed} (8 experts/chip)")
     # Synthetic expert modes:
@@ -212,10 +181,6 @@ def test_prefill_block_loop(
     else:
         layer_type = "dense" if is_dense else "MoE"
 
-    # 4x4 sub-torus runs 128 routed experts, but the device grouped-gate kernels require exactly
-    # 256 — so 128 experts can only route through the HOST gate. Drive the MoE run from the
-    # gate_device param (forced to HOST_ALL) and skip the redundant gate_host param so the matrix
-    # doesn't double-run the identical host-gate config.
     if halve_experts_4x4 and not is_dense:
         if gate_fallback_mode == GateComputeMode.HOST_ALL:
             pytest.skip(
@@ -289,8 +254,8 @@ def test_prefill_block_loop(
             }
             logger.info(f"Zeroed gate weights: weight={gate_shape}, bias={bias_shape}")
         else:
-            # [:n_routed] is a no-op at the full 256 and keeps the first 128 gate rows/biases on
-            # the 4x4 sub-torus, matching the first 128 routed_expert_weights loaded below.
+            # At 128 routed experts, keep the first 128 gate rows/biases in lockstep with the
+            # routed-expert weights loaded below.
             layer_sd["gate_weights"] = {
                 "weight": layer_dequant["mlp.gate.weight"][:n_routed],
                 "e_score_correction_bias": layer_dequant["mlp.gate.e_score_correction_bias"][:n_routed],
@@ -467,8 +432,6 @@ def test_prefill_block_loop(
     # ------------------------------------------------------------------
     # 3. Create TT block & infrastructure
     # ------------------------------------------------------------------
-    # The block reads the routed-expert count from model_cfg.NUM_ROUTED_EXPERTS. Mirror the 4x4
-    # halving via a subclass so the shared DeepSeekV3Config class is left untouched.
     if halve_experts_4x4:
 
         class _SubtorusHalfExperts(DeepSeekV3Config):

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -32,18 +32,18 @@ from loguru import logger
 import ttnn
 from conftest import is_galaxy
 from models.common.utility_functions import is_blackhole, profiler
-from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.tests.conftest import FABRIC_2D_PREFILL_BLOCK_MESH_PARAMS
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.mla.indexer import num_full_indexer_layers, resolve_has_indexer
 from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     create_balanced_chunk_order,
     reorder_tensor_chunks,
     reverse_reorder_tensor_chunks,
 )
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer import TtPrefillTransformer
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.pcc_plot_utils import generate_pcc_plots, write_pcc_summary
@@ -880,34 +880,8 @@ def run_model(
 @pytest.mark.parametrize("determinism_check", [False, True], ids=["no_determinism", "with_determinism"])
 @pytest.mark.parametrize("num_iterations", [1, 2, 5, 25, 2000], ids=["iter1", "iter2", "iter5", "iter25", "iter2000"])
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
-        pytest.param(
-            (2, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-            },
-            1,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(2, 4), topology="mesh-2x4"),
-            id="mesh-2x4",
-        ),
-        pytest.param(
-            (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-            },
-            2,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
-        ),
         # FABRIC_2D variants — shared list defined in conftest.py (also used by
         # test_prefill_block_loop.py). Covers (4,2) BH LoudBox, (2,4) asymmetric, (8,4) BH Galaxy.
         *FABRIC_2D_PREFILL_BLOCK_MESH_PARAMS,
@@ -928,7 +902,6 @@ def test_ds_prefill_transformer(
     n_routed_experts,
     gate_fallback_mode,
     num_links,
-    topology,
     pcc_validation,
     determinism_check,
     num_iterations,
@@ -942,6 +915,7 @@ def test_ds_prefill_transformer(
     tokenizer,
     request,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])
     run_model(
         variant,
         config_only,
@@ -1014,18 +988,14 @@ def test_ds_prefill_transformer(
 @pytest.mark.parametrize("determinism_check", [False, True], ids=["no_determinism", "with_determinism"])
 @pytest.mark.parametrize("num_iterations", [1, 2, 5, 25, 2000], ids=["iter1", "iter2", "iter5", "iter25", "iter2000"])
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
-            },
+            torus_xy_device_params(fabric_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -1044,7 +1014,6 @@ def test_kimi_prefill_transformer(
     n_routed_experts,
     gate_fallback_mode,
     num_links,
-    topology,
     pcc_validation,
     determinism_check,
     num_iterations,
@@ -1058,6 +1027,7 @@ def test_kimi_prefill_transformer(
     tokenizer,
     request,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])
     run_model(
         variant,
         config_only,
@@ -1122,18 +1092,14 @@ def test_kimi_prefill_transformer(
 @pytest.mark.parametrize("determinism_check", [False], ids=["no_determinism"])
 @pytest.mark.parametrize("num_iterations", [1], ids=["iter1"])
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE),
-            },
+            torus_xy_device_params(fabric_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -1152,7 +1118,6 @@ def test_glm_prefill_transformer(
     n_routed_experts,
     gate_fallback_mode,
     num_links,
-    topology,
     pcc_validation,
     determinism_check,
     num_iterations,
@@ -1166,6 +1131,7 @@ def test_glm_prefill_transformer(
     tokenizer,
     request,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])
     # Full-transformer end-to-end validates against the GPU trace (variant.test_prefill_trace_default;
     # approach B) — MLA/DSA + MoE correctness live in their op-level tests.
     run_model(

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -40,6 +40,7 @@ from models.common.utility_functions import is_blackhole, profiler
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
+from models.demos.deepseek_v3_d_p.tests.fabric_profiles import torus_xy_device_params
 from models.demos.deepseek_v3_d_p.tt.mla.indexer import (
     full_indexer_rank,
     get_fused_ring_host_timing,
@@ -52,8 +53,8 @@ from models.demos.deepseek_v3_d_p.tt.mla.utils import (
     blockcyclic_positions,
     rotated_chip_positions,
 )
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import per_axis_topology
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_block import get_block_timings, reset_block_timings
 from models.demos.deepseek_v3_d_p.tt.tt_prefill_transformer import TtPrefillTransformer
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
@@ -136,11 +137,11 @@ LAYER_PCC_THRESHOLD = 0.88
 KV_CACHE_PCC_THRESHOLD = 0.85
 INDEXER_K_PCC_THRESHOLD = 0.95
 
-# Per-chunk baseline medians (seconds) for the perf gate, pulled from known-good CI runs. Keyed by
-# (num_layers, n_chunks, num_iters) so only the exact config we have CI numbers for is gated; every
-# other combo in the sweep stays record-only. Each list has one entry per chunk (index c == chunk c). A
-# single margin is applied to every chunk. Recalibrate by re-reading the "chunk timing stats" table
-# from fresh green CI runs.
+# Per-chunk baseline medians (seconds) for the perf gate, derived from completed CI runs. Keyed by
+# (num_layers, n_chunks, num_iters) so only exact configs with CI numbers are gated; every other combo
+# in the sweep stays record-only. Each list has one entry per chunk (index c == chunk c). Recalibrate
+# from the per-chunk median across multiple independent Galaxy runs rather than copying one run's
+# measurements directly.
 #
 # Traced and untraced get SEPARATE tables and SEPARATE margins, selected by mode in
 # `kimi_chunked_perf_gate` -- a traced baseline can never gate an untraced run or vice versa. The two
@@ -149,9 +150,23 @@ INDEXER_K_PCC_THRESHOLD = 0.95
 # gap swamps the depth ramp entirely.
 KIMI_TRACED_BASELINE_CHUNK_TIMES_S = {
     # test_kimi_prefill_transformer_chunked_perf[...-L61-preload0-chunks_eleven-ten_iters-traced]
-    # (55k / code_debug), from run 31675454129 job 94407856609 -- green, and stable within the run
-    # (per-chunk stddev <= 0.002 s over the 9 post-warmup iterations).
-    (61, 11, 10): [0.605, 0.606, 0.653, 0.681, 0.711, 0.743, 0.760, 0.793, 0.842, 0.869, 0.905],
+    # (55k / code_debug), measured after the Fabric2D TorusXY routing fixes. Each entry is the median
+    # across the per-run medians from run 31944546064/job 95160035844 and run 31951045807/job
+    # 95176102903. With two runs, that is the midpoint of the two observations rather than either
+    # run's one-sided value.
+    (61, 11, 10): [
+        0.5660,
+        0.5695,
+        0.6120,
+        0.6615,
+        0.6925,
+        0.7205,
+        0.7455,
+        0.7785,
+        0.8200,
+        0.8585,
+        0.8935,
+    ],
 }
 KIMI_UNTRACED_BASELINE_CHUNK_TIMES_S = {
     # test_kimi_prefill_transformer_chunked_perf[...-L61-preload0-chunks_eleven-ten_iters-notrace]
@@ -881,20 +896,14 @@ def run_chunked_transformer(
 @pytest.mark.parametrize("n_chunks", [11], ids=["chunks11"])
 @pytest.mark.parametrize("num_layers", [1, 10, 61], ids=["L1", "L10", "L61"])
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-            },
+            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -911,8 +920,8 @@ def test_ds_prefill_transformer_chunked(
     num_layers,
     n_chunks,
     num_links,
-    topology,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])
     run_chunked_transformer(
         variant,
         config_only,
@@ -929,20 +938,14 @@ def test_ds_prefill_transformer_chunked(
 @pytest.mark.parametrize("splits", [_PADDED_FULL_55K], ids=["full55k"])
 @pytest.mark.parametrize("num_layers", [1, 10, 61], ids=["L1", "L10", "L61"])
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-            },
+            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -959,8 +962,8 @@ def test_ds_prefill_transformer_chunked_padded(
     num_layers,
     splits,
     num_links,
-    topology,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])
     run_chunked_transformer_padded(
         variant,
         config_only,
@@ -991,45 +994,19 @@ _PADDED_MODES = ["notrace", "traced"]
 @pytest.mark.parametrize("splits", [_PADDED_MID_15K, _PADDED_FULL_55K], ids=["mid15k", "full55k"])
 @pytest.mark.parametrize("num_layers", [1, 10, 61], ids=["L1", "L10", "L61"])
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
-                # Carve a small L1_SMALL region so the MoE routing all-gather can place its global
-                # semaphores there (use_l1_small_for_semaphores) instead of pinning the main-L1 floor.
-                # Kept minimal: L1_SMALL is carved from the top of L1, so a large value would shift the
-                # main-L1 buffer floor down and could re-introduce the clash.
-                "l1_small_size": 768,
-                # Needed only by mode="traced"; device_params is a separate parametrize axis so it
-                # cannot be conditioned on `mode`. Reserving it for every mode costs DRAM headroom the
-                # non-traced modes do not use — harmless here (the traced L61/full55k case, which has
-                # the largest KV cache of the matrix, already runs with this reservation).
-                "trace_region_size": 256 * 1024 * 1024,
-            },
+            # L1_SMALL holds the routing semaphores plus sparse-MLA high-bandwidth-gather semaphores.
+            torus_xy_device_params(
+                fabric_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE,
+                l1_small_size=768,
+                trace_region_size=256 * 1024 * 1024,
+            ),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
-        ),
-        pytest.param(
-            (8, 4),
-            {
-                # FABRIC_2D + Topology.Linear: the transport this config ships on, and what the Blaze
-                # "Chunked Kimi Padded Accuracy" job runs. RELAXED_INIT is required for FABRIC_2D
-                # bring-up on BH Galaxy. L1_SMALL as in the 1D param above.
-                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
-                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-                "l1_small_size": 768,
-                "trace_region_size": 256 * 1024 * 1024,
-            },
-            2,
-            ttnn.Topology.Linear,
-            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="fabric2d-mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -1046,12 +1023,12 @@ def test_kimi_prefill_transformer_chunked_padded(
     num_layers,
     splits,
     num_links,
-    topology,
     mode,
 ):
     """Padded/rotated chunked prefill, traced vs untraced (see _PADDED_MODES). Both modes exercise
     padding-aware MoE over the same `splits` and assert per-layer KV-cache PCC against the golden, so
     a traced-vs-notrace diff isolates the trace/metadata path itself rather than harness differences."""
+    topology = per_axis_topology(device_params["fabric_config"])
     common = (
         variant,
         config_only,
@@ -1088,20 +1065,16 @@ def test_kimi_prefill_transformer_chunked_padded(
 )
 @pytest.mark.parametrize("num_layers", [1, 10, 78], ids=["L1", "L10", "L78"])
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE),
-                # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores and rest for other needs.
-                "l1_small_size": 1152,
-            },
+            # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores
+            # and retain the existing reserve for other needs.
+            torus_xy_device_params(fabric_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE, l1_small_size=1152),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -1119,8 +1092,8 @@ def test_glm_prefill_transformer_chunked(
     n_chunks,
     preload_isl,
     num_links,
-    topology,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])
     run_chunked_transformer(
         variant,
         config_only,
@@ -1766,24 +1739,18 @@ def kimi_chunked_perf_gate(use_trace, num_layers, n_chunks, num_iters, preload_i
 )
 @pytest.mark.parametrize("num_layers", [1, 10, 61], ids=["L1", "L10", "L61"])
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
-                # L1_SMALL region for the MoE routing all-gather's semaphores (see TtMoERoutingSetup).
-                "l1_small_size": 768,
-                # Required by mode="traced": without it conftest logs "No trace region size" and the
-                # captured trace buffers come out of general DRAM instead of a reserved region —
-                # unbounded, and trace_bytes() then reports 0.00 MB because the TRACE pool is empty.
-                "trace_region_size": 256 * 1024 * 1024,
-            },
+            torus_xy_device_params(
+                fabric_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE,
+                l1_small_size=768,
+                trace_region_size=256 * 1024 * 1024,
+            ),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -1805,11 +1772,11 @@ def test_kimi_prefill_transformer_chunked_perf(
     n_chunks,
     num_iters,
     num_links,
-    topology,
     perf_margin,
     use_trace,
     preload_isl,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])
     if preload_isl + n_chunks * CHUNK > SEQ_CACHE_NOPCC:
         pytest.skip(f"preload_isl {preload_isl} + {n_chunks} chunks exceeds the {SEQ_CACHE_NOPCC}-token cache")
     # Gate against the CI baseline only for the exact configs we have recorded numbers for; every other
@@ -1864,24 +1831,18 @@ def test_kimi_prefill_transformer_chunked_perf(
 )
 @pytest.mark.parametrize("num_layers", [1, 10, 61], ids=["L1", "L10", "L61"])
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
-                # L1_SMALL region for the MoE routing all-gather's semaphores (see TtMoERoutingSetup).
-                "l1_small_size": 768,
-                # Required by mode="traced": without it conftest logs "No trace region size" and the
-                # captured trace buffers come out of general DRAM instead of a reserved region —
-                # unbounded, and trace_bytes() then reports 0.00 MB because the TRACE pool is empty.
-                "trace_region_size": 256 * 1024 * 1024,
-            },
+            torus_xy_device_params(
+                fabric_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE,
+                l1_small_size=768,
+                trace_region_size=256 * 1024 * 1024,
+            ),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -1899,11 +1860,11 @@ def test_kimi_prefill_transformer_chunked(
     n_chunks,
     num_iters,
     num_links,
-    topology,
     perf_margin,
     use_trace,
     preload_isl,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])
     if preload_isl + n_chunks * CHUNK > SEQ_CACHE_NOPCC:
         pytest.skip(f"preload_isl {preload_isl} + {n_chunks} chunks exceeds the {SEQ_CACHE_NOPCC}-token cache")
     # ALWAYS record-only -- this accuracy test is never perf-gated. It shares the perf test's
@@ -1948,20 +1909,14 @@ def test_kimi_prefill_transformer_chunked(
 )
 @pytest.mark.parametrize("num_layers", [1, 10, 61], ids=["L1", "L10", "L61"])
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            {
-                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
-                "fabric_router_config": create_fabric_router_config(
-                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
-                ),
-            },
+            torus_xy_device_params(fabric_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -1979,8 +1934,8 @@ def test_ds_prefill_transformer_chunked_no_pcc(
     n_chunks,
     num_iters,
     num_links,
-    topology,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])
     run_chunked_transformer_updated(
         variant,
         config_only,
@@ -2023,23 +1978,16 @@ def test_ds_prefill_transformer_chunked_no_pcc(
 )
 @pytest.mark.parametrize("num_layers", [1, 10, 78], ids=["L1", "L10", "L78"])
 @pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
+    "mesh_device, device_params, num_links",
     [
         pytest.param(
             (8, 4),
-            {
-                # FABRIC_2D + Topology.Linear: the production transport for the GLM chunked-prefill
-                # perf measurement. RELAXED_INIT is required for FABRIC_2D bring-up on BH Galaxy.
-                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
-                "fabric_router_config": create_fabric_router_config(max_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE),
-                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
-                # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores and rest for other needs.
-                "l1_small_size": 1152,
-            },
+            # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores
+            # and retain the existing reserve for other needs.
+            torus_xy_device_params(fabric_payload_size=GLM51Config.FABRIC_PAYLOAD_SIZE, l1_small_size=1152),
             2,
-            ttnn.Topology.Linear,
             marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
-            id="mesh-8x4",
+            id="torus-xy-8x4",
         ),
     ],
     indirect=["mesh_device", "device_params"],
@@ -2061,9 +2009,9 @@ def test_glm_prefill_transformer_chunked_no_pcc(
     n_chunks,
     num_iters,
     num_links,
-    topology,
     preload_isl,
 ):
+    topology = per_axis_topology(device_params["fabric_config"])
     if preload_isl + n_chunks * CHUNK > SEQ_CACHE_NOPCC:
         pytest.skip(f"preload_isl {preload_isl} + {n_chunks} chunks exceeds the {SEQ_CACHE_NOPCC}-token cache")
     run_chunked_transformer_updated(

--- a/models/demos/deepseek_v3_d_p/tt/tt_distributed_rms_norm.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_distributed_rms_norm.py
@@ -7,7 +7,7 @@ TTNN implementation of Distributed RMSNorm module for DeepSeek V3.
 
 This module performs distributed RMSNorm across chips using:
 1. rms_norm_pre_all_gather - compute local sum(x^2) statistics
-2. all_gather - gather statistics across chips
+2. high_bw_all_gather - gather statistics across chips
 3. rms_norm_post_all_gather - normalize using global statistics
 
 Supports both DRAM interleaved and L1 sharded memory configurations.
@@ -176,6 +176,7 @@ class TtDistributedRmsNorm(LightweightModule):
         self.stats_memcfg = stats_memcfg
         self.weight_cache_path = weight_cache_path
         self.cache_name_prefix = cache_name_prefix
+        self._gathered_stats = None
 
         logger.debug(f"Initializing TtDistributedRmsNorm with emb_dim={emb_dim}, epsilon={epsilon}")
         logger.debug(f"Mesh shape: {mesh_device.shape}, num_devices={self.num_devices}")
@@ -260,18 +261,25 @@ class TtDistributedRmsNorm(LightweightModule):
         )
         logger.debug(f"Pre-all-gather stats shape: {tt_stats.shape}")
 
-        # Step 2: All-gather stats across cluster_axis
-        all_gather_kwargs = {
-            "input_tensor": tt_stats,
-            "dim": 3,
-            "cluster_axis": self.cluster_axis,
-            "num_links": self.num_links,
-            "topology": self.topology,
-        }
-        if self.stats_memcfg is not None:
-            all_gather_kwargs["memory_config"] = self.stats_memcfg
-
-        tt_gathered_stats = ttnn.all_gather(**all_gather_kwargs)
+        # Step 2: Gather stats across cluster_axis. high_bw_all_gather writes into a caller-provided
+        # DRAM tensor, so allocate its fixed-shape output once and reuse it across forwards.
+        if self._gathered_stats is None:
+            gathered_shape = list(tt_stats.shape)
+            gathered_shape[3] *= self.mesh_device.shape[self.cluster_axis]
+            self._gathered_stats = ttnn.empty(
+                gathered_shape,
+                dtype=tt_stats.dtype,
+                layout=tt_stats.layout,
+                device=self.mesh_device,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+        tt_gathered_stats = ttnn.experimental.high_bw_all_gather(
+            tt_stats,
+            dim=3,
+            output_tensor=self._gathered_stats,
+            cluster_axis=self.cluster_axis,
+            num_links=self.num_links,
+        )
         ttnn.deallocate(tt_stats)
         logger.debug(f"Gathered stats shape: {tt_gathered_stats.shape}")
 
@@ -284,7 +292,6 @@ class TtDistributedRmsNorm(LightweightModule):
             dtype=ttnn.bfloat16,
             program_config=self.sharded_progcfg,
         )
-        ttnn.deallocate(tt_gathered_stats)
         logger.debug(f"Output shape: {tt_output.shape}")
 
         return tt_output

--- a/models/demos/deepseek_v3_d_p/tt/tt_distributed_rms_norm.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_distributed_rms_norm.py
@@ -7,7 +7,7 @@ TTNN implementation of Distributed RMSNorm module for DeepSeek V3.
 
 This module performs distributed RMSNorm across chips using:
 1. rms_norm_pre_all_gather - compute local sum(x^2) statistics
-2. high_bw_all_gather - gather statistics across chips
+2. high_bw_all_gather (or all_gather fallback) - gather statistics across chips
 3. rms_norm_post_all_gather - normalize using global statistics
 
 Supports both DRAM interleaved and L1 sharded memory configurations.
@@ -25,6 +25,14 @@ from models.common.lightweightmodule import LightweightModule
 # DeepSeek 671B RMSNorm dimensions
 EMB_DIM = 7168
 EPSILON = 1e-6
+
+
+def _supports_high_bw_all_gather(tensor: ttnn.Tensor, cluster_axis: int) -> bool:
+    """Return whether the tensor topology can represent a gather on ``cluster_axis``."""
+    tensor_topology = tensor.tensor_topology()
+    distribution_rank = len(tuple(tensor_topology.distribution_shape()))
+    placement_count = len(tuple(tensor_topology.placements()))
+    return cluster_axis < distribution_rank and cluster_axis < placement_count
 
 
 class TtDistributedRmsNorm(LightweightModule):
@@ -261,25 +269,44 @@ class TtDistributedRmsNorm(LightweightModule):
         )
         logger.debug(f"Pre-all-gather stats shape: {tt_stats.shape}")
 
-        # Step 2: Gather stats across cluster_axis. high_bw_all_gather writes into a caller-provided
-        # DRAM tensor, so allocate its fixed-shape output once and reuse it across forwards.
-        if self._gathered_stats is None:
-            gathered_shape = list(tt_stats.shape)
-            gathered_shape[3] *= self.mesh_device.shape[self.cluster_axis]
-            self._gathered_stats = ttnn.empty(
-                gathered_shape,
-                dtype=tt_stats.dtype,
-                layout=tt_stats.layout,
-                device=self.mesh_device,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        # Step 2: Gather stats across cluster_axis. high_bw_all_gather requires topology metadata
+        # for every mesh axis through cluster_axis. Pipeline-parallel runners may expose a 1D tensor
+        # distribution on a 2D mesh, so preserve the general all_gather path for those tensors.
+        use_high_bw_all_gather = _supports_high_bw_all_gather(tt_stats, self.cluster_axis)
+        if use_high_bw_all_gather:
+            # high_bw_all_gather writes into a caller-provided DRAM tensor, so allocate its
+            # fixed-shape output once and reuse it across forwards.
+            if self._gathered_stats is None:
+                gathered_shape = list(tt_stats.shape)
+                gathered_shape[3] *= self.mesh_device.shape[self.cluster_axis]
+                self._gathered_stats = ttnn.empty(
+                    gathered_shape,
+                    dtype=tt_stats.dtype,
+                    layout=tt_stats.layout,
+                    device=self.mesh_device,
+                    memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                )
+            tt_gathered_stats = ttnn.experimental.high_bw_all_gather(
+                tt_stats,
+                dim=3,
+                output_tensor=self._gathered_stats,
+                cluster_axis=self.cluster_axis,
+                num_links=self.num_links,
             )
-        tt_gathered_stats = ttnn.experimental.high_bw_all_gather(
-            tt_stats,
-            dim=3,
-            output_tensor=self._gathered_stats,
-            cluster_axis=self.cluster_axis,
-            num_links=self.num_links,
-        )
+        else:
+            logger.debug(
+                f"Falling back to all_gather: tensor topology does not represent cluster_axis={self.cluster_axis}"
+            )
+            all_gather_kwargs = {
+                "input_tensor": tt_stats,
+                "dim": 3,
+                "cluster_axis": self.cluster_axis,
+                "num_links": self.num_links,
+                "topology": self.topology,
+            }
+            if self.stats_memcfg is not None:
+                all_gather_kwargs["memory_config"] = self.stats_memcfg
+            tt_gathered_stats = ttnn.all_gather(**all_gather_kwargs)
         ttnn.deallocate(tt_stats)
         logger.debug(f"Gathered stats shape: {tt_gathered_stats.shape}")
 
@@ -292,6 +319,8 @@ class TtDistributedRmsNorm(LightweightModule):
             dtype=ttnn.bfloat16,
             program_config=self.sharded_progcfg,
         )
+        if not use_high_bw_all_gather:
+            ttnn.deallocate(tt_gathered_stats)
         logger.debug(f"Output shape: {tt_output.shape}")
 
         return tt_output

--- a/models/demos/deepseek_v3_d_p/utils/perf_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/perf_utils.py
@@ -540,7 +540,7 @@ def run_moe_perf_with_approximation(
         raise AssertionError(f"Perf check(s) outside expected range — {summary}")
 
 
-def run_mla_perf_with_approximation(
+def run_mla_perf_loudbox(
     command_2x4: str,
     expected_ns_2x4: float,
     model_name_2x4: str,
@@ -550,6 +550,11 @@ def run_mla_perf_with_approximation(
     margin: float = 0.03,
     comments_2x4: str = "",
 ):
+    """Run and validate the local 2x4 unwrapped-Fabric2D MLA proxy.
+
+    This result is not extrapolated to the production 8x4 TorusXY topology: scaling SDPA alone
+    cannot account for the different CCL topology.
+    """
     logger.info("=== 2x4 MLA perf test on LB ===")
     run_model_device_perf_test_with_merge(
         command=command_2x4,
@@ -561,9 +566,3 @@ def run_mla_perf_with_approximation(
         margin=margin,
         comments=comments_2x4,
     )
-    csv_2x4 = get_latest_ops_log_filename(subdir)
-    logger.info(f"2x4 CSV: {csv_2x4}")
-
-    logger.info("=== Approximating 8x4 Galaxy total from 2x4 ===")
-    df_approx = approximate_mla_galaxy_perf(csv_2x4=csv_2x4)
-    logger.info(f"\n{df_approx.to_string(index=False)}")

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -149,10 +149,10 @@
   cmd: |
     exit_code=0
     export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/huggingface/hub/models--deepseek-ai--DeepSeek-R1-0528
-    pytest models/demos/deepseek_v3_d_p/tests/pcc/ -vvv --tb=short -k "not matmul_pcc and not perf-host-64 and ((mesh-4x2 or mesh-2x4 or linear-8) or not (moe_gate_prefill2d or moe_routing_setup or ttnn_moe)) and not (linear-8 and (pcc-device or (5k and not 25k))) and not (ttnn_moe and kimi and perf) and not (ttnn_moe and deepseek_v3 and mesh-4x2 and not fabric2d-) and not pad50 and (not hca or (flash and chunk5120-varying))" --timeout 1800 || exit_code=$?
-    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_ds_mla -k "2x4 and random and scaled_sl and check_pcc and line" -vvv --tb=short || exit_code=$?
-    pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "balanced and not non_balanced and fabric2d and not pretrained" -vvv --tb=short --timeout=900 || exit_code=$?
-    pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py -k "2x4 and layer0 and device and not fabric2d- and 2link" -vvv --tb=short || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/pcc/ -vvv --tb=short -k "not matmul_pcc and not perf-host-64 and ((fabric2d-mesh-4x2 or fabric2d-mesh-2x4 or fabric2d-2x4 or torus-y-8x1) or not (moe_gate_prefill2d or moe_routing_setup or ttnn_moe)) and not (torus-y-8x1 and (pcc-device or (5k and not 25k))) and not (ttnn_moe and kimi and perf) and not pad50 and (not hca or (flash and chunk5120-varying))" --timeout 1800 || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_ds_mla -k "fabric2d-2x4 and random and scaled_sl and check_pcc" -vvv --tb=short || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "balanced and not non_balanced and fabric2d-mesh-2x4 and not pretrained" -vvv --tb=short --timeout=900 || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py -k "fabric2d-mesh-2x4-2link and layer0 and device" -vvv --tb=short || exit_code=$?
     exit $exit_code
   skus:
     bh_loudbox:
@@ -166,12 +166,11 @@
   cmd: |
     exit_code=0
     export GLM52_MLA_REF_CACHE=/tmp/glm_5_2_mla_ref_cache
-    export DS_SPARSE_FABRIC=fabric2d
     # Sparse MLA (GLM-5.2) vs MLACPU. Random weights + on-the-fly CPU truth -> no staged weights.
     # GLM-5.2 reshards heads->sequence in _sparse_mla so it now runs at tp=4; 2x4 is its coverage (accuracy
     # + the determinism/chunked anchor cases, which pin to the highest-TP mesh). The sparse suite carries
     # no tier markers, so there is no -m gate.
-    pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "glm_5_2 and 2x4 and fabric2d" -vvv --tb=short || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "glm_5_2 and 2x4" -vvv --tb=short || exit_code=$?
     exit $exit_code
   skus:
     bh_loudbox:
@@ -186,7 +185,7 @@
     exit_code=0
     # Cheap host-side coverage for the mixed-format cache contract and producer decoding.
     pytest models/demos/common/prefill/tests/test_prefill_producer_kv_decode.py models/demos/deepseek_v3_d_p/tests/test_sparse_kv_cache_contract.py -vvv --tb=short || exit_code=$?
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or (4x2 and pcc_check and not fabric2d)) and (not test_rope_prefill or 4x2) and (not update_padded_kv_cache or 2x4) and (not rotary_embedding_indexed or 2x4) and (not moe_padding_config or 2x4) and (not zero_padded or linear-8 or 2x4) and not single-1 and (not test_prefill_dispatch or ((bf16_in and tile and bf16_out) or (fp8_scaled_in and row_major and fp8_out)))" -m "not extended_model" || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or (4x2 and pcc_check and fabric2d)) and (not test_rope_prefill or 4x2) and (not update_padded_kv_cache or 2x4) and (not rotary_embedding_indexed or 2x4) and (not moe_padding_config or fabric2d-2x4) and (not zero_padded or torus-y-8x1 or fabric2d-2x4) and not single-1 and (not test_prefill_dispatch or ((bf16_in and tile and bf16_out) or (fp8_scaled_in and row_major and fp8_out)))" -m "not extended_model" || exit_code=$?
     exit $exit_code
   skus:
     bh_loudbox:
@@ -200,9 +199,9 @@
   cmd: |
     exit_code=0
     export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/huggingface/hub/models--deepseek-ai--DeepSeek-R1-0528
-    # pytest models/demos/deepseek_v3_d_p/tests/perf/test_dispatch_combine_perf.py -m models_device_performance_bare_metal -vvv --tb=short --timeout=900 || exit_code=$? Commented out until problems with various results on different runners is resolved Issue https://github.com/tenstorrent/tt-metal/issues/47287
-    pytest models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py -vvv --tb=short || exit_code=$?
-    pytest models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py -vvv --tb=short || exit_code=$?
+    # Dispatch/combine perf remains disabled pending issue #47287.
+    pytest models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py::test_deepseek_v3_moe_perf_loudbox -vvv --tb=short || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py::test_deepseek_v3_mla_perf_loudbox -vvv --tb=short || exit_code=$?
     pytest models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py -k "block_2x4" -vvv --tb=short || exit_code=$?
     exit $exit_code
   skus:
@@ -216,7 +215,7 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
-    pytest models/demos/deepseek_v3_d_p/tests/pcc/ -vvv --tb=short -k "not matmul_pcc and not perf-host-64 and (mesh-2x2 or not (moe_gate_prefill2d or moe_routing_setup or ttnn_moe)) and (not hca or (flash and chunk5120-varying))" --timeout 1800 || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/pcc/ -vvv --tb=short -k "not matmul_pcc and not perf-host-64 and ((fabric2d-mesh-2x2 or fabric2d-2x2 or torus-x-1x4 or torus-y-4x1) or not (moe_gate_prefill2d or moe_routing_setup or ttnn_moe)) and (not hca or (flash and chunk5120-varying))" --timeout 1800 || exit_code=$?
     pytest models/demos/deepseek_v3_d_p/tests/cache/ -vvv --tb=short || exit_code=$?
     exit $exit_code
   skus:
@@ -230,7 +229,7 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or not fabric2d) and not single-1 and (not test_prefill_dispatch or ((bf16_in and tile and bf16_out) or (fp8_scaled_in and row_major and fp8_out)))" -m "not extended_model" || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or fabric2d) and not single-1 and (not test_prefill_dispatch or ((bf16_in and tile and bf16_out) or (fp8_scaled_in and row_major and fp8_out)))" -m "not extended_model" || exit_code=$?
     exit $exit_code
   skus:
     bh_p150b_civ2:
@@ -243,7 +242,7 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or not fabric2d) and not single-1 and (not test_prefill_dispatch or ((bf16_in and tile and bf16_out) or (fp8_scaled_in and row_major and fp8_out)))" -m "not extended_model" || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or fabric2d) and not single-1 and (not test_prefill_dispatch or ((bf16_in and tile and bf16_out) or (fp8_scaled_in and row_major and fp8_out)))" -m "not extended_model" || exit_code=$?
     exit $exit_code
   skus:
     bh_p300:
@@ -256,7 +255,7 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or (2x2 and pcc_check and not fabric2d)) and (not test_prefill_dispatch or ((bf16_in and tile and bf16_out) or (fp8_scaled_in and row_major and fp8_out and fp8_disp_compression)))" || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or (2x2 and pcc_check and fabric2d)) and (not test_prefill_dispatch or ((bf16_in and tile and bf16_out) or (fp8_scaled_in and row_major and fp8_out and fp8_disp_compression)))" || exit_code=$?
     exit $exit_code
   skus:
     bh_quietbox_2:
@@ -268,11 +267,11 @@
   name: bh_qb2_DeepSeek_D2D_SOCKET_SYNC
   model-name: deepseek_prefill
   # Program-cache validation for outbound_socket_service_sync (D2D sender op) on a 4-chip
-  # QuietBox (linear-2x2 variant): 2 sender + 2 receiver chips over tt-fabric. Confirms the
+  # QuietBox Fabric2D 2x2 variant: 2 sender + 2 receiver chips over tt-fabric. Confirms the
   # op is built once and cache-hits on the 2nd dispatch (input addr is a BufferBinding).
   cmd: |
     exit_code=0
-    pytest models/demos/deepseek_v3_d_p/tests/test_d2d_socket_sync.py -k "linear-2x2" -vvv --tb=short || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/test_d2d_socket_sync.py -k "fabric2d-2x2" -vvv --tb=short || exit_code=$?
     exit $exit_code
   skus:
     bh_quietbox_2:

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -35,8 +35,12 @@
 
 # For max allowed timeout refer to .github/time_budget.yaml
 
+# Galaxy-Blaze setup validates each allocation, then the reusable workflow maps
+# `fabric_profile: torus_xy` to the production TorusXY descriptor and certification environment.
+
 # Blackhole Galaxy DeepSeek Prefill tests
 - name: "DeepSeek-V3-671B MoE gate accuracy"
+  fabric_profile: torus_xy
   cmd: |
     export DEEPSEEK_V3_HF_MODEL=/mnt/models/DeepSeek-R1-0528-fp8-4236a6af/
     export DEEPSEEK_V3_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/CI
@@ -45,9 +49,10 @@
     export DEEPSEEK_V3_TRACE_DIR=/mnt/models/deepseek-prefill-cache
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
+      set -e
       export OMP_NUM_THREADS=$(nproc)
       uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py -k "mesh-8x4"
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py -k "torus-xy-8x4"
     '
   test_type: moe_gate
   test_group: module
@@ -59,6 +64,7 @@
   sp_config: sc1
 
 - name: "DeepSeek-V3-671B MLA accuracy 100k, 128k"
+  fabric_profile: torus_xy
   cmd: |
     export DEEPSEEK_V3_HF_MODEL=/mnt/models/DeepSeek-R1-0528-fp8-4236a6af/
     export DEEPSEEK_V3_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/CI
@@ -68,9 +74,10 @@
     export DEEPSEEK_V3_MLA_REF_CACHE=/mnt/models/deepseek-prefill-cache/test_mla_output
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
+      set -e
       export OMP_NUM_THREADS=$(nproc)
       uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_ds_mla -k "8x4 and random and max_sl and check_pcc and balanced and fabric2d" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_ds_mla -k "torus-xy-8x4 and random and max_sl and check_pcc and balanced" -vvv --tb=short
     '
   test_type: mla
   test_group: module
@@ -82,12 +89,14 @@
   sp_config: sc1
 
 - name: "DeepSeek-V3-671B & Kimi-K2.6-1T MLA chunked accuracy 10k@5k"
+  fabric_profile: torus_xy
   cmd: |
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
+      set -e
       export OMP_NUM_THREADS=$(nproc)
       uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "maxedge-1u and cpu and 8x4 and fabric2d and (dsv3 or kimi) and no_determinism" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "maxedge-1u and cpu and torus-xy-8x4 and (dsv3 or kimi) and no_determinism" -vvv --tb=short
     '
   test_type: mla_chunked
   test_group: module
@@ -99,12 +108,14 @@
   sp_config: sc1
 
 - name: "Kimi-K3-2.8T MLA chunked accuracy 10k@5k + determinism 5k@5k"
+  fabric_profile: torus_xy
   cmd: |
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
+      set -e
       export OMP_NUM_THREADS=$(nproc)
       uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "k3 and 8x4 and fabric2d and scalar and ((maxedge-1u and cpu and no_determinism) or (plain-5k and func and with_determinism))" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "k3 and torus-xy-8x4 and scalar and ((maxedge-1u and cpu and no_determinism) or (plain-5k and func and with_determinism))" -vvv --tb=short
     '
   test_type: k3_mla
   test_group: module
@@ -122,7 +133,7 @@
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
       uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "k3 and production-50k+5k and trace and 8x4 and fabric2d and scalar and no_determinism" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "k3 and production-50k+5k and trace and torus-xy-8x4 and scalar and no_determinism" -vvv --tb=short
     '
   test_type: k3_mla_trace
   test_group: module
@@ -134,12 +145,13 @@
   sp_config: sc1
 
 - name: "Kimi-K3-2.8T MLA chunked perf 55k@5k"
+  fabric_profile: torus_xy
   cmd: |
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
       uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_perf_check -k "k3 and 8x4 and fabric2d" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_perf_check -k "k3 and torus-xy-8x4" -vvv --tb=short
     '
   test_type: k3_mla_perf
   test_group: module
@@ -151,11 +163,12 @@
   sp_config: sc1
 
 - name: "DeepSeek-V4-Flash HCA chunked accuracy 6k@5k"
+  fabric_profile: torus_xy
   cmd: |
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_hca.py::test_hca_chunked_prefill_mesh -k "flash and chunk5120-varying and 8x4" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_hca.py::test_hca_chunked_prefill_mesh -k "flash and chunk5120-varying and torus-xy-8x4" -vvv --tb=short
     '
   test_type: hca_chunked
   test_group: module
@@ -167,11 +180,12 @@
   sp_config: sc1
 
 - name: "DeepSeek-V4-Flash HCA chunked perf 10k@5k"
+  fabric_profile: torus_xy
   cmd: |
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/perf/test_ttnn_hca_perf.py -k "flash and 8x4" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/perf/test_ttnn_hca_perf.py -k "flash and torus-xy-8x4" -vvv --tb=short
     '
   test_type: hca_perf
   test_group: module
@@ -183,6 +197,7 @@
   sp_config: sc1
 
 - name: "KV cache table accuracy (DeepSeek-V3-671B, Kimi-K2.6-1T, GLM-5.2-744B)"
+  fabric_profile: torus_xy
   cmd: |
     export DEEPSEEK_V3_HF_MODEL=/mnt/models/DeepSeek-R1-0528-fp8-4236a6af/
     export DEEPSEEK_V3_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/CI
@@ -191,11 +206,12 @@
     export DEEPSEEK_V3_TRACE_DIR=/mnt/models/deepseek-prefill-cache
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
+      set -e
       export OMP_NUM_THREADS=$(nproc)
       uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_kv_cache_table -k "line and pretrained and seq5k" -vvv --tb=short
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_kimi_kv_cache_mock -k "line" -vvv --tb=short
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_glm52_kv_cache_table -k "8x4" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_kv_cache_table -k "torus-xy and pretrained and seq5k" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_kimi_kv_cache_mock -k "torus-xy" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_glm52_kv_cache_table -k "torus-xy-8x4" -vvv --tb=short
       python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_kv_cache_table.py::test_dflash_kv_cache_mock -k "seq5k and 1user and 2layers" -vvv --tb=short
     '
   test_type: kv_cache_table
@@ -208,6 +224,7 @@
   sp_config: sc1
 
 - name: "DeepSeek-V3-671B prefill block accuracy"
+  fabric_profile: torus_xy
   cmd: |
     export DEEPSEEK_V3_HF_MODEL=/mnt/models/DeepSeek-R1-0528-fp8-4236a6af/
     export DEEPSEEK_V3_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/CI
@@ -216,9 +233,10 @@
     export DEEPSEEK_V3_TRACE_DIR=/mnt/models/deepseek-prefill-cache
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
+      set -e
       export OMP_NUM_THREADS=$(nproc)
       uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and pcc and iter1 and no_determinism and fabric2d and pretrained" -vvv --tb=short --timeout=900
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "torus-xy-8x4 and pcc and iter1 and no_determinism and pretrained and balanced and not non_balanced and not host_gate_all" -vvv --tb=short --timeout=900
     '
   test_type: prefill_block
   test_group: module
@@ -231,6 +249,7 @@
   sp_config: sc1
 
 - name: "Kimi-K2.6-1T chunked prefill padded accuracy 15k@5k (no trace)"
+  fabric_profile: torus_xy
   cmd: |
     export MESH_DEVICE=TG
     export LOGURU_LEVEL=INFO
@@ -238,8 +257,9 @@
     export TT_KIMI_PREFILL_TTNN_CACHE=/mnt/models/Kimi-K2_6-Cache/Kimi-K2_6-Cache-prefill
     export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/golden/structured_traces/kimi_debug_55k_vllm
     mpirun --bind-to none --pernode --tag-output bash -lc '
+      set -e
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_kimi_prefill_transformer_chunked_padded -k "kimi and fabric2d-mesh-8x4 and L61 and mid15k and notrace" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_kimi_prefill_transformer_chunked_padded -k "kimi and torus-xy-8x4 and L61 and mid15k and notrace" -vvv --tb=short
     '
   test_type: kimi_chunked_padded
   test_group: module
@@ -258,6 +278,7 @@
 # entry (not a second -k term) so a trace-only regression is attributed on the CI dashboard instead
 # of being hidden inside a two-case job.
 - name: "Kimi-K2.6-1T chunked prefill padded accuracy 15k@5k (trace)"
+  fabric_profile: torus_xy
   cmd: |
     export MESH_DEVICE=TG
     export LOGURU_LEVEL=INFO
@@ -266,7 +287,7 @@
     export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/golden/structured_traces/kimi_debug_55k_vllm
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_kimi_prefill_transformer_chunked_padded -k "kimi and fabric2d-mesh-8x4 and L61 and mid15k and traced" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_kimi_prefill_transformer_chunked_padded -k "kimi and torus-xy-8x4 and L61 and mid15k and traced" -vvv --tb=short
     '
   test_type: kimi_chunked_padded
   test_group: module
@@ -280,12 +301,13 @@
   sp_config: sc1
 
 - name: "Kimi-K2.6-1T MLA accuracy 5k, 25k"
+  fabric_profile: torus_xy
   cmd: |
     export KIMI_MLA_REF_CACHE=/mnt/models/kimi-prefill-cache/test_mla_output
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_kimi_mla -k "8x4 and random and max_sl and check_pcc and sequential and line and (seq5k or seq25k)" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_kimi_mla -k "torus-xy-8x4 and random and max_sl and check_pcc and sequential and (seq5k or seq25k)" -vvv --tb=short
     '
   test_type: kimi_mla
   test_group: module
@@ -297,6 +319,7 @@
   sp_config: sc1
 
 - name: "GLM-5.2-744B sparse MLA accuracy + determinism (incl. chunked 5k@1k)"
+  fabric_profile: torus_xy
   cmd: |
     export MESH_DEVICE=TG
     export GLM52_MLA_REF_CACHE=/mnt/models/deepseek-prefill-cache/glm_5_2_mla_ref_cache
@@ -307,7 +330,7 @@
     # (The glm_5_1-only kv_only case is intentionally not run here; GLM-5.1 is fully retired from CI.)
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "glm_5_2 and 8x4 and fabric2d" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "glm_5_2 and shape-8x4" -vvv --tb=short
     '
   test_type: dsa_mla_glm
   test_group: module
@@ -319,12 +342,13 @@
   sp_config: sc1
 
 - name: "GLM-5.2-744B MoE accuracy 12.5k + perf 25k"
+  fabric_profile: torus_xy
   cmd: |
     export MESH_DEVICE=TG
     # GLM-5.2 256-expert MoE (device gate, DEVICE_FP32) vs the CPU MoE reference; random weights.
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe -k "mesh-8x4 and (pcc-device-glm-256 or perf-device-glm-256)" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe -k "torus-xy-8x4 and (pcc-device-glm-256 or perf-device-glm-256)" -vvv --tb=short
     '
   test_type: glm_moe
   test_group: module
@@ -336,6 +360,7 @@
   sp_config: sc1
 
 - name: "GLM-5.2-744B prefill block accuracy 5k"
+  fabric_profile: torus_xy
   cmd: |
     export MESH_DEVICE=TG
     export GLM52_HF_MODEL=/mnt/models/deepseek-prefill-cache/GLM-5.2-FP8/
@@ -348,7 +373,7 @@
     # dense and MoE parametrizations.
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_glm_prefill_block -k "seq5120 and fabric2d-mesh-8x4 and glm52" -vvv --tb=short --timeout=300
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_glm_prefill_block -k "seq5120 and torus-xy-8x4 and glm52" -vvv --tb=short --timeout=300
     '
   test_type: glm_prefill_block
   test_group: module
@@ -360,11 +385,12 @@
   sp_config: sc1
 
 - name: "Kimi-K2.6-1T MoE accuracy 5k + perf 25k"
+  fabric_profile: torus_xy
   cmd: |
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_kimi_moe -k "mesh-8x4 and (kimi-5k-pcc or kimi-25k-perf)" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_kimi_moe -k "torus-xy-8x4 and (kimi-5k-pcc or kimi-25k-perf)" -vvv --tb=short
     '
   test_type: kimi_moe
   test_group: module
@@ -380,7 +406,7 @@
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_kimi_k3_moe -k "fabric2d-mesh-8x4 and kimi_k3-5k-pcc" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_kimi_k3_moe -k "torus-xy-8x4 and kimi_k3-5k-pcc" -vvv --tb=short
     '
   test_type: kimi_k3_moe
   test_group: module
@@ -408,15 +434,17 @@
   sp_config: sc1
 
 - name: "Kimi-K2.6-1T prefill block accuracy 5k, 25k"
+  fabric_profile: torus_xy
   cmd: |
     export MESH_DEVICE=TG
     export KIMI_K2_6_HF_MODEL=/mnt/models/Kimi-K2_6-dequantized
     export TT_KIMI_PREFILL_TTNN_CACHE=/mnt/models/Kimi-K2.6-Cache/CI
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
+      set -e
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_kimi_prefill_block -k "mesh-8x4 and pcc-prompt_5k and iter1 and no_determinism and pretrained" -vvv --tb=short --timeout=1320
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_kimi_prefill_block -k "mesh-8x4 and pcc-prompt_25k and iter1 and no_determinism and pretrained" -vvv --tb=short --timeout=1320
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_kimi_prefill_block -k "torus-xy-8x4 and pcc-prompt_5k and iter1 and no_determinism and pretrained" -vvv --tb=short --timeout=1320
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_kimi_prefill_block -k "torus-xy-8x4 and pcc-prompt_25k and iter1 and no_determinism and pretrained" -vvv --tb=short --timeout=1320
     '
 
   test_type: kimi_prefill_block
@@ -429,6 +457,7 @@
   sp_config: sc1
 
 - name: "DeepSeek-V3-671B prefill block determinism 25k"
+  fabric_profile: torus_xy
   cmd: |
     export DEEPSEEK_V3_HF_MODEL=/mnt/models/DeepSeek-R1-0528-fp8-4236a6af/
     export DEEPSEEK_V3_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/CI
@@ -438,9 +467,10 @@
     export MESH_DEVICE=TG
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
+      set -e
       export OMP_NUM_THREADS=$(nproc)
       uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and perf-prompt_25k and with_determinism and iter2 and not iter25 and not iter2000 and moe-gate_device and balanced and not non_balanced and pretrained" -vvv --tb=short --timeout=900
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "torus-xy-8x4 and perf-prompt_25k and with_determinism and iter2 and not iter25 and not iter2000 and moe-gate_device and balanced and not non_balanced and pretrained" -vvv --tb=short --timeout=900
     '
 
   test_type: prefill_block_determinism
@@ -453,6 +483,7 @@
   sp_config: sc1
 
 - name: "DeepSeek-V3-671B prefill transformer determinism 25k"
+  fabric_profile: torus_xy
   cmd: |
     export DEEPSEEK_V3_HF_MODEL=/mnt/models/DeepSeek-R1-0528-fp8-4236a6af/
     export DEEPSEEK_V3_CACHE=/mnt/models/DeepSeek-R1-0528-Cache/CI
@@ -461,9 +492,10 @@
     export DEEPSEEK_V3_TRACE_DIR=/mnt/models/deepseek-prefill-cache
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
+      set -e
       export OMP_NUM_THREADS=$(nproc)
       uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py::test_ds_prefill_transformer -k "mesh-8x4 and 5_layers and e256_device_fp32 and longbook_qa_eng and 25600 and iter2 and not iter25 and not iter2000 and smoke and with_determinism and random and balanced and right_pad" -vvv --tb=short --timeout=2940
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py::test_ds_prefill_transformer -k "torus-xy-8x4 and 5_layers and e256_device_fp32 and longbook_qa_eng and 25600 and iter2 and not iter25 and not iter2000 and smoke and with_determinism and random and balanced and right_pad" -vvv --tb=short --timeout=2940
     '
   test_type: prefill_transformer_determinism
   test_group: module
@@ -524,6 +556,7 @@
   sp_config: sc1
 
 - name: "Kimi-K2.6-1T chunked prefill perf code_debug 55k@5k (no trace)"
+  fabric_profile: torus_xy
   # 55k-ISL chunked-prefill perf/smoke for Kimi: full 61 layers, 11 chunks x 5120 = 56320 tokens
   # (the full code_debug trace), 10 iterations. No-PCC: it drives the real chunked-prefill path end to
   # end (build once, forward 10x) and passes on completion -- no golden readback, no accuracy compare.
@@ -540,8 +573,9 @@
     export TT_KIMI_PREFILL_TTNN_CACHE=/mnt/models/Kimi-K2_6-Cache/Kimi-K2_6-Cache-prefill
     export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/golden/structured_traces/kimi_debug_55k_vllm
     mpirun --bind-to none --pernode --tag-output bash -lc '
+      set -e
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_kimi_prefill_transformer_chunked_perf -k "L61 and preload0 and chunks_eleven and ten_iters and notrace" -xvs
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_kimi_prefill_transformer_chunked_perf -k "kimi and torus-xy-8x4 and L61 and preload0 and chunks_eleven and ten_iters and notrace" -xvs
     '
   test_type: kimi_chunked
   test_group: module
@@ -558,6 +592,7 @@
 # is captured once and replayed. Separate entry so the two per-chunk timing tables are attributed
 # independently -- a traced-vs-untraced perf delta is the number this pair exists to surface.
 - name: "Kimi-K2.6-1T chunked prefill perf code_debug 55k@5k (trace)"
+  fabric_profile: torus_xy
   # 55k-ISL chunked-prefill perf/smoke for Kimi: full 61 layers, 11 chunks x 5120 = 56320 tokens
   # (the full code_debug trace), 10 iterations. No-PCC: it drives the real chunked-prefill path end to
   # end (build once, forward 10x) and passes on completion -- no golden readback, no accuracy compare.
@@ -574,8 +609,9 @@
     export TT_KIMI_PREFILL_TTNN_CACHE=/mnt/models/Kimi-K2_6-Cache/Kimi-K2_6-Cache-prefill
     export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/golden/structured_traces/kimi_debug_55k_vllm
     mpirun --bind-to none --pernode --tag-output bash -lc '
+      set -e
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_kimi_prefill_transformer_chunked_perf -k "L61 and preload0 and chunks_eleven and ten_iters and traced" -xvs
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_kimi_prefill_transformer_chunked_perf -k "kimi and torus-xy-8x4 and L61 and preload0 and chunks_eleven and ten_iters and traced" -xvs
     '
   test_type: kimi_chunked
   test_group: module
@@ -589,6 +625,7 @@
   sp_config: sc1
 
 - name: "GLM-5.2-744B chunked prefill perf code_debug 55k@5k"
+  fabric_profile: torus_xy
   cmd: |
     export MESH_DEVICE=TG
     export LOGURU_LEVEL=INFO
@@ -597,7 +634,7 @@
     export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/glm-traces/vllm-glm52-indexer-kcache-55k
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_glm_prefill_transformer_chunked_no_pcc[blackhole-glm52-mesh-8x4-L78-preload0-chunks_eleven-ten_iters] -xvs
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_glm_prefill_transformer_chunked_no_pcc -k "glm52 and torus-xy-8x4 and L78 and preload0 and chunks_eleven and ten_iters" -xvs
     '
   test_type: glm_chunked
   test_group: module
@@ -609,6 +646,7 @@
   sp_config: sc1
 
 - name: "GLM-5.2-744B chunked prefill accuracy code_debug 55k@5k"
+  fabric_profile: torus_xy
   cmd: |
     export MESH_DEVICE=TG
     export LOGURU_LEVEL=INFO
@@ -617,7 +655,7 @@
     export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/glm-traces/vllm-glm52-indexer-kcache-55k
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_glm_prefill_transformer_chunked -k "glm52 and 8x4 and L78 and warm_cache" -xvs
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py::test_glm_prefill_transformer_chunked -k "glm52 and torus-xy-8x4 and L78 and warm_cache" -xvs
     '
   test_type: glm_chunked_accuracy
   test_group: module
@@ -629,14 +667,15 @@
   sp_config: sc1
 
 - name: "Kimi-K2.6-1T DFlash drafter accuracy"
+  fabric_profile: torus_xy
   cmd: |
     export MESH_DEVICE=TG
     export DFLASH_HF_MODEL=/mnt/models/Kimi-K2.6-DFlash
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/dflash_prefill/test_dflash.py::test_dflash_pcc -k "mesh-8x4 and pretrained and ctx5k-1chunk" -vvv --tb=short --timeout=600
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/dflash_prefill/test_dflash.py::test_dflash_multiturn_pcc -k "mesh-8x4 and pretrained and (aligned_min or midchip_straddle or lastchip or rot_partial)" -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/dflash_prefill/test_dflash.py::test_dflash_pcc -k "torus-xy-8x4 and pretrained and ctx5k-1chunk" -vvv --tb=short --timeout=600
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/dflash_prefill/test_dflash.py::test_dflash_multiturn_pcc -k "torus-xy-8x4 and pretrained and (aligned_min or midchip_straddle or lastchip or rot_partial)" -vvv --tb=short
     '
   test_type: kimi_dflash
   test_group: module
@@ -648,9 +687,11 @@
   sp_config: sc1
 
 - name: "Kimi-K2.6-1T prefill runner accuracy code_debug 55k@5k"
+  fabric_profile: torus_xy
   cmd: |
     export MESH_DEVICE=TG
     export PREFILL_MODEL=kimi_k2_6
+    export PREFILL_FABRIC_MODE=2d_torus_xy
     export PREFILL_HF_MODEL=/mnt/models/Kimi-K2_6-dequantized
     export PREFILL_TTNN_CACHE=/mnt/models/Kimi-K2_6-Cache/Kimi-K2_6-Cache-prefill
     export PREFILL_TRACE_DIR=/mnt/models/deepseek-prefill-cache/golden/structured_traces/kimi_debug_55k_vllm


### PR DESCRIPTION
## Summary

Migrate the existing DeepSeek V3/V3.2, Kimi 2.x, K3, and GLM 5.2 prefill coverage off Fabric1D. Production 8x4 Galaxy configurations use Fabric2D with TorusXY; supported single-axis proxy rings use the matching torus direction; allocations that cannot form a useful ring remain plain Fabric2D.

Existing semantic coverage and all 28 Blaze matrix rows are preserved. This is a topology migration only: no model development, new tests, or new configurations.

## Standalone op fixes

This staging PR carries each reusable hang fix as a separate commit so the complete model stack can be validated together. Each fix is also independently reviewable:

- [#53170 — all-gather on folded logical rings](https://github.com/tenstorrent/tt-metal/pull/53170)
- [#53171 — prefill dispatch on routed groups](https://github.com/tenstorrent/tt-metal/pull/53171)
- [#53172 — prefill combine on routed groups](https://github.com/tenstorrent/tt-metal/pull/53172)
- [#53293 — all-to-all routing and synchronization](https://github.com/tenstorrent/tt-metal/pull/53293)

## Performance

For traced Kimi 55k chunked prefill, the sum of per-chunk medians moved from 8.168 s to 7.918 s across two TorusXY Galaxy runs: **3.1% lower latency overall**, with every chunk improving by 1.2–6.4%. The existing mode-specific gates remain 3% for traced and 5% for untraced runs.

Measurements: [run 31944546064](https://github.com/tenstorrent/tt-metal/actions/runs/31944546064), [run 31951045807](https://github.com/tenstorrent/tt-metal/actions/runs/31951045807).

## Validation

- Release build: `./build_metal.sh --release`.
- Existing local 8x1 TorusY all-gather, dispatch, and combine coverage, plus the 2x4 Ring generic all-to-all case, through `scripts/run_safe_pytest.sh`.
- Cross-model Galaxy coverage for DeepSeek, Kimi, K3, and GLM: [run 31977343418](https://github.com/tenstorrent/tt-metal/actions/runs/31977343418).
- Traced and untraced Kimi chunked prefill: [run 31977527889](https://github.com/tenstorrent/tt-metal/actions/runs/31977527889).
- Targeted GLM 5.2 chunked performance on this code tree: [run 32000951979](https://github.com/tenstorrent/tt-metal/actions/runs/32000951979) (in progress).

[![Blackhole E2E](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pjosipovic/fabric2d-torus-xy-existing-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch%3Apjosipovic%2Ffabric2d-torus-xy-existing-tests)
[![Blaze Models Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=pjosipovic/fabric2d-torus-xy-existing-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch%3Apjosipovic%2Ffabric2d-torus-xy-existing-tests)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fabric2d-torus-xy-existing-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fabric2d-torus-xy-existing-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fabric2d-torus-xy-existing-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fabric2d-torus-xy-existing-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fabric2d-torus-xy-existing-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fabric2d-torus-xy-existing-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fabric2d-torus-xy-existing-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fabric2d-torus-xy-existing-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fabric2d-torus-xy-existing-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fabric2d-torus-xy-existing-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fabric2d-torus-xy-existing-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fabric2d-torus-xy-existing-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fabric2d-torus-xy-existing-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fabric2d-torus-xy-existing-tests)