### PR TITLE
[Bug fix] Remove DeepSeek combine JIT warnings

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -135,9 +135,9 @@ void kernel_main() {
         expert_end_idx,
         linearized_mesh_coord);
 
+#if INIT_ZEROS
     const auto output_addr_gen = TensorAccessor(output_args, output_addr);
 
-#if INIT_ZEROS
     // Hybrid row output-zeroing: this core zeroes its assigned page range, then waits for untilizer row cores
     {
         uint32_t page_start = get_arg_val<uint32_t>(rt_args++);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp
@@ -126,11 +126,17 @@ void kernel_main() {
     // num_cores = effective_num_links = min(num_links, 4).
     constexpr uint32_t MAX_WORKER_CORES = 4;
     ASSERT(num_cores <= MAX_WORKER_CORES);
+#if INIT_ZEROS
     uint64_t all_core_barrier_noc_addrs[MAX_WORKER_CORES];
+#endif
     for (uint32_t c = 0; c < num_cores; c++) {
+#if INIT_ZEROS
         uint32_t noc_x = get_arg_val<uint32_t>(rt_args_idx++);
         uint32_t noc_y = get_arg_val<uint32_t>(rt_args_idx++);
         all_core_barrier_noc_addrs[c] = get_noc_addr(noc_x, noc_y, output_init_barrier_l1_offset);
+#else
+        rt_args_idx += 2;
+#endif
     }
 
 #ifdef AXIS


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

The [referenced CI job (workflow run 31783797079, job 94717181316)](https://github.com/tenstorrent/tt-metal/actions/runs/31783797079/job/94717181316) emitted **240 device-JIT C++ compiler warnings**: 120 each from `reader_combine` and `writer_combine` specializations built with `INIT_ZEROS=0`. The declarations were only needed by zero-initialization work, but were compiled regardless.

This change gates those declarations and uses on `INIT_ZEROS`. In the writer's disabled-zero-init variant, it still consumes the two per-core NOC-coordinate runtime arguments so subsequent arguments remain aligned. This removes JIT warning noise without changing either execution path.

The accompanying inventory records the two unique origins and their occurrence counts from that CI job.

### Testing

- `python_env/bin/python -m pytest -q -s models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py::test_ttnn_combine[blackhole-bf16_out-tile-predictable-1link-dsv3-mesh-4x2-pcc]`
- `python_env/bin/pre-commit run --files JIT_KERNEL_WARNINGS_31783797079.md ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_combine.cpp`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-deepseek-combine-jit-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-deepseek-combine-jit-warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-deepseek-combine-jit-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-deepseek-combine-jit-warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-deepseek-combine-jit-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-deepseek-combine-jit-warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-deepseek-combine-jit-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-deepseek-combine-jit-warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-deepseek-combine-jit-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-deepseek-combine-jit-warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-deepseek-combine-jit-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-deepseek-combine-jit-warnings)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-deepseek-combine-jit-warnings)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-deepseek-combine-jit-warnings)