### PR TITLE
[ci] Add `vllm-tt-plugin` host tests to vLLM models CI.

### DIFF
--- a/.github/workflows/vllm-model-tests.yaml
+++ b/.github/workflows/vllm-model-tests.yaml
@@ -168,6 +168,9 @@ jobs:
     name: vLLM host tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: read
     container:
       image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       env:
@@ -187,6 +190,7 @@ jobs:
         with:
           submodules: recursive
           path: docker-job
+          persist-credentials: false
       - name: ⬇️ Setup Metal
         uses: ./docker-job/.github/actions/setup-job
         timeout-minutes: 10
@@ -201,6 +205,7 @@ jobs:
           path: docker-job/vllm-tt-plugin
           ref: ${{ inputs.vllm-tt-plugin-ref || 'main' }}
           fetch-depth: 1
+          persist-credentials: false
       - name: 📀 Install vLLM and plugin test dependencies
         run: |
           pushd vllm-tt-plugin

--- a/.github/workflows/vllm-model-tests.yaml
+++ b/.github/workflows/vllm-model-tests.yaml
@@ -163,9 +163,8 @@ jobs:
       build-wheel: true
       platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
       enable-lto: ${{ inputs.enable-lto || false }}
-  vllm-host-tests:
+  vllm-plugin-unit-tests:
     needs: build-artifact
-    name: vLLM host tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -175,7 +174,9 @@ jobs:
       image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       env:
         TT_METAL_HOME: /work
-        PYTHONPATH: /work:/work/vllm-tt-plugin/src
+        VLLM_SOURCE: ${{ inputs.vllm-source || 'plugin' }}
+        PLUGIN_DIR: ${{ inputs.vllm-source == 'fork' && '/work/vllm/plugins/vllm-tt-plugin' || '/work/vllm-tt-plugin' }}
+        PYTHONPATH: ${{ inputs.vllm-source == 'fork' && '/work:/work/vllm' || '/work:/work/vllm-tt-plugin/src' }}
         LD_LIBRARY_PATH: /work/build/lib
       volumes:
         - ${{ github.workspace }}/docker-job:/work
@@ -198,6 +199,7 @@ jobs:
           build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
           wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       - name: ⬇️ Checkout vLLM TT plugin
+        if: ${{ inputs.vllm-source != 'fork' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
@@ -206,15 +208,30 @@ jobs:
           ref: ${{ inputs.vllm-tt-plugin-ref || 'main' }}
           fetch-depth: 1
           persist-credentials: false
+      - name: ⬇️ Checkout vLLM fork
+        if: ${{ inputs.vllm-source == 'fork' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 20
+        with:
+          repository: tenstorrent/vllm
+          path: docker-job/vllm
+          ref: ${{ inputs.vllm-commit || 'dev' }}
+          fetch-depth: 0
+          persist-credentials: false
       - name: 📀 Install vLLM and plugin test dependencies
         run: |
-          pushd vllm-tt-plugin
-          source docs/install-vllm-tt.sh
-          uv pip install -e ".[dev]"
-          popd
+          if [ "$VLLM_SOURCE" = "fork" ]; then
+            VLLM_TARGET_DEVICE=empty uv pip install vllm/ --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match
+            uv pip install --no-deps -e vllm/plugins/vllm-tt-plugin
+          else
+            pushd vllm-tt-plugin
+            source docs/install-vllm-tt.sh
+            uv pip install -e ".[dev]"
+            popd
+          fi
       - name: 🧪 Run host-only plugin tests
         run: |
-          pushd vllm-tt-plugin
+          pushd "$PLUGIN_DIR"
           pytest tests --ignore=tests/tt -v
           popd
   vllm-tests:

--- a/.github/workflows/vllm-model-tests.yaml
+++ b/.github/workflows/vllm-model-tests.yaml
@@ -163,6 +163,55 @@ jobs:
       build-wheel: true
       platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
       enable-lto: ${{ inputs.enable-lto || false }}
+  vllm-host-tests:
+    needs: build-artifact
+    name: vLLM host tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    container:
+      image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      env:
+        TT_METAL_HOME: /work
+        PYTHONPATH: /work:/work/vllm-tt-plugin/src
+        LD_LIBRARY_PATH: /work/build/lib
+      volumes:
+        - ${{ github.workspace }}/docker-job:/work
+    defaults:
+      run:
+        shell: bash
+        working-directory: /work
+    steps:
+      - name: 🧬 Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 20
+        with:
+          submodules: recursive
+          path: docker-job
+      - name: ⬇️ Setup Metal
+        uses: ./docker-job/.github/actions/setup-job
+        timeout-minutes: 10
+        with:
+          build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+          wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      - name: ⬇️ Checkout vLLM TT plugin
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 20
+        with:
+          repository: tenstorrent/vllm-tt-plugin
+          path: docker-job/vllm-tt-plugin
+          ref: ${{ inputs.vllm-tt-plugin-ref || 'main' }}
+          fetch-depth: 1
+      - name: 📀 Install vLLM and plugin test dependencies
+        run: |
+          pushd vllm-tt-plugin
+          source docs/install-vllm-tt.sh
+          uv pip install -e ".[dev]"
+          popd
+      - name: 🧪 Run host-only plugin tests
+        run: |
+          pushd vllm-tt-plugin
+          pytest tests --ignore=tests/tt -v
+          popd
   vllm-tests:
     needs: [check-harbor, build-artifact, resolve-skus]
     secrets: inherit


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Add a vLLM host tests job to the vLLM model-test workflow. It checks out tenstorrent/vllm-tt-plugin, installs its test dependencies, and runs host-only tests (tests, excluding tests/tt) against the built TT-Metal artifacts.

Related: tenstorrent/vllm-tt-plugin#19 - we're currently running plugin tests only locally and so there's no action or job to automatically or manually trigger all the tests.

### Notes for reviewers
Please verify the job setup and artifact reuse.

### CI Status

OoT Plugin check: https://github.com/tenstorrent/tt-metal/actions/runs/31814392371
Fork Plugin check: https://github.com/tenstorrent/tt-metal/actions/runs/31814544773

_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sanjaradylov/ci.add-plugin-host-unit-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sanjaradylov/ci.add-plugin-host-unit-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sanjaradylov/ci.add-plugin-host-unit-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sanjaradylov/ci.add-plugin-host-unit-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sanjaradylov/ci.add-plugin-host-unit-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sanjaradylov/ci.add-plugin-host-unit-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sanjaradylov/ci.add-plugin-host-unit-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sanjaradylov/ci.add-plugin-host-unit-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sanjaradylov/ci.add-plugin-host-unit-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sanjaradylov/ci.add-plugin-host-unit-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sanjaradylov/ci.add-plugin-host-unit-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sanjaradylov/ci.add-plugin-host-unit-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sanjaradylov/ci.add-plugin-host-unit-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sanjaradylov/ci.add-plugin-host-unit-tests)