### PR TITLE
Add GPT-OSS golden KV-cache reference and generation scripts

### DIFF
--- a/models/demos/gpt_oss_d_p/reference/model.py
+++ b/models/demos/gpt_oss_d_p/reference/model.py
@@ -107,6 +107,8 @@ class GoldenPrefillModel:
 
         model_path = Path(model_path)
         hf_config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+        if num_layers is not None and not 1 <= num_layers <= hf_config.num_hidden_layers:
+            raise ValueError(f"num_layers must be between 1 and {hf_config.num_hidden_layers}, got {num_layers}")
         self.cfg = GoldenModelConfig(
             num_hidden_layers=num_layers or hf_config.num_hidden_layers,
             num_key_value_heads=hf_config.num_key_value_heads,

--- a/models/demos/gpt_oss_d_p/reference/model.py
+++ b/models/demos/gpt_oss_d_p/reference/model.py
@@ -1,0 +1,231 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU golden reference for GPT-OSS prefill KV-cache generation.
+
+Runs HuggingFace ``AutoModelForCausalLM`` (trust_remote_code) and captures per-layer
+post-RoPE K and raw V before any sliding-window truncation.  GPT-OSS alternates
+sliding_attention (window=128) and full_attention layers; ``DynamicCache`` alone would
+drop early positions on sliding layers during a long prefill, so ``FullKVCapture``
+snapshots K/V in ``update()`` before the parent cache truncates.
+
+Memory approach:
+- Model weights mmap'd via ``low_cpu_mem_usage=True``
+- GPT-OSS disables SDPA (attention sinks need concat-softmax). Default path installs
+  MiniMax-style query-row + MoE token tiling via ``tiled_ops.install_tiled_ops`` so
+  long sequences do not allocate full ``[H, S, S]`` scores (~387 GB at S=55k).
+- Pass ``use_tiled_ops=False`` for stock HF eager (matches older short-seq goldens;
+  OOMs on long sequences).
+- Saves layer-by-layer via streaming callback; releases each layer's full_kv after save
+
+Output layout matches the MiniMax-style golden trace:
+  key_cache_layer_{i}   [1, num_kv_heads, seq_len, head_dim]
+  value_cache_layer_{i} [1, num_kv_heads, seq_len, head_dim]
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Optional
+
+import torch
+from transformers.cache_utils import DynamicCache
+
+
+class FullKVCapture(DynamicCache):
+    """DynamicCache that snapshots full K/V per layer before sliding-window truncation.
+
+    On each ``update()``, HF passes *new* K/V for the current forward (full seq for
+    one-shot prefill). ``full_kv`` holds the complete pre-truncation cache.
+    ``kv_callback`` fires once the accumulated length reaches ``expected_seq_len``.
+    """
+
+    def __init__(
+        self,
+        config,
+        *,
+        kv_callback: Optional[Callable[[int, torch.Tensor, torch.Tensor], None]] = None,
+        num_layers: int | None = None,
+        expected_seq_len: int | None = None,
+        release_after_callback: bool = True,
+    ):
+        super().__init__(config=config)
+        self._kv_callback = kv_callback
+        self._num_layers = num_layers
+        self._expected_seq_len = expected_seq_len
+        self._release_after_callback = release_after_callback
+        self.full_kv: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
+        self._callback_done: set[int] = set()
+
+    def update(self, key_states, value_states, layer_idx, cache_kwargs=None):
+        if self._num_layers is None or layer_idx < self._num_layers:
+            k_new = key_states.detach()
+            v_new = value_states.detach()
+            if layer_idx in self.full_kv:
+                k_prev, v_prev = self.full_kv[layer_idx]
+                k = torch.cat([k_prev, k_new], dim=-2)
+                v = torch.cat([v_prev, v_new], dim=-2)
+            else:
+                k, v = k_new, v_new
+            self.full_kv[layer_idx] = (k, v)
+
+            ready = self._expected_seq_len is None or k.shape[-2] >= self._expected_seq_len
+            if self._kv_callback is not None and ready and layer_idx not in self._callback_done:
+                self._kv_callback(layer_idx, k, v)
+                self._callback_done.add(layer_idx)
+                if self._release_after_callback:
+                    del self.full_kv[layer_idx]
+
+        return super().update(key_states, value_states, layer_idx, cache_kwargs)
+
+
+@dataclass
+class GoldenModelConfig:
+    num_hidden_layers: int
+    num_key_value_heads: int
+    head_dim: int
+    hidden_size: int
+    vocab_size: int
+    sliding_window: int | None
+
+
+class GoldenPrefillModel:
+    """HF-reference prefill model for golden KV generation (one-shot)."""
+
+    def __init__(
+        self,
+        model_path: str | Path,
+        *,
+        num_layers: int | None = None,
+        compute_dtype: torch.dtype = torch.bfloat16,
+        zero_sinks: bool = False,
+        disable_sliding_window: bool = False,
+        use_tiled_ops: bool = True,
+    ):
+        from transformers import AutoConfig, AutoModelForCausalLM
+
+        model_path = Path(model_path)
+        hf_config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+        self.cfg = GoldenModelConfig(
+            num_hidden_layers=num_layers or hf_config.num_hidden_layers,
+            num_key_value_heads=hf_config.num_key_value_heads,
+            head_dim=hf_config.head_dim,
+            hidden_size=hf_config.hidden_size,
+            vocab_size=hf_config.vocab_size,
+            sliding_window=getattr(hf_config, "sliding_window", None),
+        )
+        self.compute_dtype = compute_dtype
+        self._model_path = model_path
+        self.use_tiled_ops = use_tiled_ops
+        self.attn_q_chunk: int | None = None
+        self.ffn_token_chunk: int | None = None
+
+        if use_tiled_ops:
+            from models.demos.gpt_oss_d_p.reference.tiled_ops import install_tiled_ops
+
+            # Install before from_pretrained so any eager dispatch resolves to tiled ops.
+            self.attn_q_chunk, self.ffn_token_chunk = install_tiled_ops()
+            print(
+                f"[load] installed MiniMax-style tiling: "
+                f"ATTN_Q_CHUNK={self.attn_q_chunk} FFN_TOKEN_CHUNK={self.ffn_token_chunk} "
+                f"(env REF_ATTN_Q_CHUNK / REF_FFN_TOKEN_CHUNK)",
+                flush=True,
+            )
+        else:
+            print(
+                "[load] using stock HF eager attention/MoE (no tiling) — "
+                "may OOM on long sequences due to full [H,S,S] scores",
+                flush=True,
+            )
+
+        print(f"[load] loading HF model from {model_path} ({compute_dtype}, cpu, mmap) ...", flush=True)
+        # GPT-OSS: _supports_sdpa=False (sinks). Force eager (stock or tiled replacement).
+        self._model = AutoModelForCausalLM.from_pretrained(
+            model_path,
+            trust_remote_code=True,
+            torch_dtype=compute_dtype,
+            low_cpu_mem_usage=True,
+            attn_implementation="eager",
+        ).eval()
+        print("[load] model loaded", flush=True)
+
+        if zero_sinks:
+            n_zeroed = 0
+            with torch.no_grad():
+                for layer in self._model.model.layers:
+                    attn = layer.self_attn
+                    if hasattr(attn, "sinks") and attn.sinks is not None:
+                        attn.sinks.zero_()
+                        n_zeroed += 1
+            print(f"[load] zeroed attention sinks on {n_zeroed} layer(s)", flush=True)
+
+        if disable_sliding_window:
+            n_disabled = 0
+            if hasattr(self._model.config, "layer_types") and self._model.config.layer_types is not None:
+                self._model.config.layer_types = ["full_attention"] * len(self._model.config.layer_types)
+            for layer in self._model.model.layers:
+                attn = layer.self_attn
+                if hasattr(attn, "sliding_window"):
+                    attn.sliding_window = None
+                if hasattr(attn, "is_sliding"):
+                    attn.is_sliding = False
+                n_disabled += 1
+            print(f"[load] disabled sliding window on {n_disabled} layer(s)", flush=True)
+
+    def prefill(
+        self,
+        input_ids: torch.Tensor,
+        *,
+        kv_callback: Optional[Callable[[int, torch.Tensor, torch.Tensor], None]] = None,
+    ) -> list[tuple[torch.Tensor, torch.Tensor]]:
+        """Run a **one-shot** prefill pass. ``input_ids`` is ``[B, S]`` (B must be 1).
+
+        ``kv_callback(layer_idx, key_cache, value_cache)`` is invoked from ``FullKVCapture.update``
+        once each layer's K/V reaches full sequence length, with tensors shaped
+        ``[1, num_kv_heads, seq_len, head_dim]`` (post-RoPE K, raw V).
+
+        Long sequences stay one-shot; bound peak RAM with tiled attention/MoE
+        (``use_tiled_ops=True``, ``REF_ATTN_Q_CHUNK`` / ``REF_FFN_TOKEN_CHUNK``).
+        """
+        if input_ids.dim() == 1:
+            input_ids = input_ids.unsqueeze(0)
+        if input_ids.shape[0] != 1:
+            raise ValueError(f"golden prefill supports batch size 1, got {input_ids.shape[0]}")
+
+        seq_len = input_ids.shape[1]
+
+        capture = FullKVCapture(
+            config=self._model.config,
+            kv_callback=kv_callback,
+            num_layers=self.cfg.num_hidden_layers,
+            expected_seq_len=seq_len,
+            release_after_callback=True,
+        )
+
+        with torch.no_grad():
+            out = self._model(input_ids=input_ids, use_cache=True, past_key_values=capture)
+        # top-1 sign-off reference: HF's per-position argmax (the forward above already computes logits)
+        self.top1_token_ids = out.logits[0].argmax(-1).to(torch.int32).contiguous().cpu()
+
+        return [capture.full_kv[i] for i in range(self.cfg.num_hidden_layers) if i in capture.full_kv]
+
+
+def load_golden_model(
+    model_path: str | Path,
+    *,
+    num_layers: int | None = None,
+    compute_dtype: torch.dtype = torch.bfloat16,
+    zero_sinks: bool = False,
+    disable_sliding_window: bool = False,
+    use_tiled_ops: bool = True,
+) -> GoldenPrefillModel:
+    """Construct a golden prefill model from an HF checkpoint directory."""
+    return GoldenPrefillModel(
+        model_path,
+        num_layers=num_layers,
+        compute_dtype=compute_dtype,
+        zero_sinks=zero_sinks,
+        disable_sliding_window=disable_sliding_window,
+        use_tiled_ops=use_tiled_ops,
+    )

--- a/models/demos/gpt_oss_d_p/reference/tiled_ops.py
+++ b/models/demos/gpt_oss_d_p/reference/tiled_ops.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""MiniMax-style memory tiling for GPT-OSS HF golden prefill.
+
+GPT-OSS sets ``_supports_sdpa = False`` because attention sinks need the
+concat-then-softmax path (an extra virtual key that absorbs probability mass).
+Stock eager attention therefore materializes full ``[H, S, S]`` scores — at
+S≈55k / Hq=64 / bf16 that alone is ~387 GB and OOMs even on 500GB+ hosts.
+
+These replacements keep **one-shot** prefill math (same causal / sliding-window
+mask + sinks + MoE top-k as a single forward) while never allocating the fat
+score / expert-activation tensors:
+
+* ``tiled_eager_attention_forward`` — loop query rows in ``ATTN_Q_CHUNK``;
+  softmax over full active keys (+ sink column); delete scores each chunk.
+  Exact per-row softmax ⇒ bit-identical to unchunked eager.
+* ``tiled_experts_forward`` — within each hit expert, process tokens in
+  ``FFN_TOKEN_CHUNK`` so ``[N, 2*intermediate]`` never fully materializes.
+
+Install via :func:`install_tiled_ops` before the HF forward. Env knobs match
+MiniMax: ``REF_ATTN_Q_CHUNK`` (default 256), ``REF_FFN_TOKEN_CHUNK`` (default 4096).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Callable
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+ATTN_Q_CHUNK = int(os.environ.get("REF_ATTN_Q_CHUNK", "256"))
+FFN_TOKEN_CHUNK = int(os.environ.get("REF_FFN_TOKEN_CHUNK", "4096"))
+
+
+def tiled_eager_attention_forward(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    scaling: float,
+    dropout: float | int = 0.0,
+    **kwargs,
+):
+    """Drop-in for HF ``eager_attention_forward`` with query-row tiling.
+
+    Matches transformers ``modeling_gpt_oss.eager_attention_forward`` exactly
+    (repeat_kv → scaled QK → optional mask → concat sinks → max-subtract softmax
+    → drop sink column → dropout → @V), but scores peak at
+    ``[B, H, ATTN_Q_CHUNK, S]`` instead of ``[B, H, S, S]``.
+    """
+    # Local import keeps this module usable without transformers at import time
+    # for lightweight unit checks of the tiling helpers.
+    from transformers.models.gpt_oss.modeling_gpt_oss import repeat_kv
+
+    key_states = repeat_kv(key, module.num_key_value_groups)
+    value_states = repeat_kv(value, module.num_key_value_groups)
+
+    batch, num_heads, seq_q, head_dim = query.shape
+    assert dropout == 0.0 or not module.training, "tiled eager golden path expects dropout=0"
+
+    attn_output = torch.empty(batch, num_heads, seq_q, head_dim, dtype=value_states.dtype, device=query.device)
+    sinks = module.sinks.reshape(1, -1, 1, 1)  # [1, Hq, 1, 1]
+
+    for qs in range(0, seq_q, ATTN_Q_CHUNK):
+        qe = min(qs + ATTN_Q_CHUNK, seq_q)
+        q = query[:, :, qs:qe, :]
+        attn_weights = torch.matmul(q, key_states.transpose(2, 3)) * scaling  # [B, H, C, Sk]
+        if attention_mask is not None:
+            # HF masks are [B, 1, Sq, Sk] (or broadcastable); slice query rows only.
+            attn_weights = attn_weights + attention_mask[:, :, qs:qe, :]
+
+        sinks_exp = sinks.expand(batch, -1, qe - qs, -1)
+        combined_logits = torch.cat([attn_weights, sinks_exp], dim=-1)
+        # Matches HF: max-subtract before softmax (bf16 overflow guard).
+        combined_logits = combined_logits - combined_logits.max(dim=-1, keepdim=True).values
+        probs = F.softmax(combined_logits, dim=-1, dtype=combined_logits.dtype)
+        scores = probs[..., :-1]  # drop sink column
+        attn_output[:, :, qs:qe, :] = torch.matmul(scores.to(value_states.dtype), value_states)
+        del attn_weights, sinks_exp, combined_logits, probs, scores
+
+    attn_output = attn_output.transpose(1, 2).contiguous()
+    return attn_output, None
+
+
+def tiled_experts_forward(self, hidden_states: torch.Tensor, router_indices=None, routing_weights=None) -> torch.Tensor:
+    """Drop-in for ``GptOssExperts.forward`` with per-expert token tiling.
+
+    Same sparse dispatch as HF (one_hot → hit experts → index_add_), but when an
+    expert receives more than ``FFN_TOKEN_CHUNK`` tokens the gate_up / down matmuls
+    run in token chunks so the ``[N, 2*intermediate]`` activation never fully
+    materializes. Chunking is along tokens only ⇒ numerically identical.
+    """
+    next_states = torch.zeros_like(hidden_states, dtype=hidden_states.dtype, device=hidden_states.device)
+    with torch.no_grad():
+        expert_mask = torch.nn.functional.one_hot(router_indices, num_classes=self.num_experts)
+        expert_mask = expert_mask.permute(2, 1, 0)
+        expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
+
+    for expert_idx in expert_hit:
+        expert_idx = expert_idx[0]
+        if expert_idx == self.num_experts:
+            continue
+        top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
+        n = token_idx.numel()
+        if n == 0:
+            continue
+
+        if n <= FFN_TOKEN_CHUNK:
+            current_state = hidden_states[token_idx]
+            gate_up = current_state @ self.gate_up_proj[expert_idx] + self.gate_up_proj_bias[expert_idx]
+            gated_output = self._apply_gate(gate_up)
+            out = gated_output @ self.down_proj[expert_idx] + self.down_proj_bias[expert_idx]
+            weighted_output = out * routing_weights[token_idx, top_k_pos, None]
+            next_states.index_add_(0, token_idx, weighted_output.to(hidden_states.dtype))
+        else:
+            for i in range(0, n, FFN_TOKEN_CHUNK):
+                j = min(i + FFN_TOKEN_CHUNK, n)
+                tok = token_idx[i:j]
+                tk = top_k_pos[i:j]
+                current_state = hidden_states[tok]
+                gate_up = current_state @ self.gate_up_proj[expert_idx] + self.gate_up_proj_bias[expert_idx]
+                gated_output = self._apply_gate(gate_up)
+                out = gated_output @ self.down_proj[expert_idx] + self.down_proj_bias[expert_idx]
+                weighted_output = out * routing_weights[tok, tk, None]
+                next_states.index_add_(0, tok, weighted_output.to(hidden_states.dtype))
+                del current_state, gate_up, gated_output, out, weighted_output
+
+    return next_states
+
+
+_STOCK_EAGER: Callable | None = None
+_STOCK_EXPERTS: Callable | None = None
+_INSTALLED = False
+
+
+def install_tiled_ops() -> tuple[int, int]:
+    """Monkey-patch HF GPT-OSS eager attention + experts for long one-shot prefill.
+
+    Returns ``(ATTN_Q_CHUNK, FFN_TOKEN_CHUNK)`` actually installed. Idempotent.
+    """
+    global _STOCK_EAGER, _STOCK_EXPERTS, _INSTALLED
+    import transformers.models.gpt_oss.modeling_gpt_oss as gpt_oss_mod
+
+    if not _INSTALLED:
+        _STOCK_EAGER = gpt_oss_mod.eager_attention_forward
+        _STOCK_EXPERTS = gpt_oss_mod.GptOssExperts.forward
+        gpt_oss_mod.eager_attention_forward = tiled_eager_attention_forward
+        gpt_oss_mod.GptOssExperts.forward = tiled_experts_forward  # type: ignore[method-assign]
+        _INSTALLED = True
+    return ATTN_Q_CHUNK, FFN_TOKEN_CHUNK
+
+
+def assert_tiled_matches_eager(
+    *,
+    seq_len: int = 128,
+    num_heads: int = 8,
+    num_kv_heads: int = 2,
+    head_dim: int = 64,
+    dtype: torch.dtype = torch.float32,
+    seed: int = 0,
+) -> float:
+    """Self-check: tiled vs stock HF eager on a tiny random attention problem.
+
+    Must be called **before** :func:`install_tiled_ops`, or after install (uses the
+    saved stock reference). Returns max abs diff (expect 0 for fp32).
+    """
+    import transformers.models.gpt_oss.modeling_gpt_oss as gpt_oss_mod
+
+    stock = _STOCK_EAGER or gpt_oss_mod.eager_attention_forward
+    # If install already replaced the module attr with tiled, and we somehow lost
+    # the stock ref, comparing tiled-to-tiled is useless — require stock.
+    if stock is tiled_eager_attention_forward:
+        raise RuntimeError("stock eager unavailable; call assert_tiled_matches_eager before install_tiled_ops")
+
+    g = torch.Generator().manual_seed(seed)
+    B, S, Hq, Hkv, D = 1, seq_len, num_heads, num_kv_heads, head_dim
+    groups = Hq // Hkv
+
+    class _Mod(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.num_key_value_groups = groups
+            self.sinks = nn.Parameter(torch.randn(Hq, generator=g, dtype=dtype))
+            self.training = False
+
+    module = _Mod()
+    q = torch.randn(B, Hq, S, D, generator=g, dtype=dtype)
+    k = torch.randn(B, Hkv, S, D, generator=g, dtype=dtype)
+    v = torch.randn(B, Hkv, S, D, generator=g, dtype=dtype)
+    i = torch.arange(S).unsqueeze(1)
+    j = torch.arange(S).unsqueeze(0)
+    mask = torch.zeros(1, 1, S, S, dtype=dtype)
+    mask.masked_fill_(j > i, float("-inf"))
+    scaling = D**-0.5
+
+    out_stock, _ = stock(module, q, k, v, mask, scaling, dropout=0.0)
+    out_tiled, _ = tiled_eager_attention_forward(module, q, k, v, mask, scaling, dropout=0.0)
+    return (out_stock - out_tiled).abs().max().item()
+
+
+if __name__ == "__main__":
+    # Single-chunk (seq <= ATTN_Q_CHUNK) and multi-chunk (partial last tile).
+    cases = [
+        ("single_chunk", 128),
+        ("multi_chunk", ATTN_Q_CHUNK * 2 + 17),
+    ]
+    for name, seq_len in cases:
+        diff = assert_tiled_matches_eager(seq_len=seq_len)
+        print(f"tiled vs stock eager [{name} seq={seq_len}] max_diff={diff:.2e}")
+        assert diff == 0.0, f"tiled attention not bit-identical to stock ({name}): {diff}"
+    install_tiled_ops()
+    print(f"installed tiling: ATTN_Q_CHUNK={ATTN_Q_CHUNK} FFN_TOKEN_CHUNK={FFN_TOKEN_CHUNK}")
+    print("all checks passed")

--- a/models/demos/gpt_oss_d_p/scripts/README_golden_kv.md
+++ b/models/demos/gpt_oss_d_p/scripts/README_golden_kv.md
@@ -84,11 +84,11 @@ The safetensors golden trace is the MiniMax-style format consumed via `PREFILL_T
 | `--prompt-json` / `--prompt` | Input prompt |
 | `--max-tokens N` | Truncate to N tokens |
 | `--chat-template` | Apply chat template (off by default) |
-| `--dtype` | Stored dtype (default: bfloat16) |
+| `--dtype` | Stored dtype only (default: bfloat16); compute is always bfloat16 |
 | `--num-layers N` | Capture first N layers only |
 | `--zero-sinks` | Zero attention sinks (diagnostic) |
 | `--disable-sliding-window` | Force full attention everywhere (diagnostic) |
-| `--model-path` | HF dir, or `$HF_MODEL` / `$DEEPSEEK_V3_HF_MODEL` |
+| `--model-path` | HF dir, or `$HF_MODEL` |
 | `REF_ATTN_Q_CHUNK` | Query-row tile size (default 256); lower if still OOM |
 | `REF_FFN_TOKEN_CHUNK` | MoE token tile size (default 4096) |
 

--- a/models/demos/gpt_oss_d_p/scripts/README_golden_kv.md
+++ b/models/demos/gpt_oss_d_p/scripts/README_golden_kv.md
@@ -1,0 +1,131 @@
+# Generating Golden KV Cache for GPT-OSS
+
+This guide explains how to generate golden reference KV cache traces for validating the GPT-OSS prefill implementation.
+
+## Prerequisites
+
+- **Machine**: ~100GB+ free RAM recommended for weights+activations; 55k one-shot needs tiled attention (below), not 500GB+ for score matrices
+- **Model**: GPT-OSS checkpoint (mxfp4-quantized weights on disk, bf16 compute for attention)
+  - Official: `https://huggingface.co/openai/gpt-oss-120b` or `gpt-oss-20b`
+- **Prompt**: JSON file or text
+- **Time**: Expect several minutes to hours depending on model size and prompt length
+
+### Why 55k used to OOM
+
+GPT-OSS sets `_supports_sdpa=False` (attention sinks need concat-then-softmax). Stock eager
+attention allocates full `[Hq, S, S]` scores — at S=55k / Hq=64 / bf16 that alone is ~387 GB.
+
+**Fix (MiniMax-style true one-shot):** query-row tiling (`REF_ATTN_Q_CHUNK`, default 256) +
+MoE token tiling (`REF_FFN_TOKEN_CHUNK`, default 4096). Same causal/sliding/sinks/MoE math as
+one big forward; scores peak at `[H, chunk, S]` and are deleted each chunk.
+
+## Quick Start
+
+```bash
+cd /path/to/tt-metal
+
+export HF_MODEL=/path/to/gpt-oss-120b
+
+# Option 1: Plain tokenization (default — matches GPT-OSS demos)
+python3 models/demos/gpt_oss_d_p/scripts/generate_golden_kv_cache.py \
+    --prompt-json prompt.json \
+    --out /mnt/models/gpt-oss-cache/golden/longbook_full \
+    --max-tokens 56320
+
+# Option 2: Quick test
+python3 models/demos/gpt_oss_d_p/scripts/generate_golden_kv_cache.py \
+    --prompt "What are the prime factors of 1?" \
+    --out /tmp/gpt_oss_test \
+    --max-tokens 1024
+```
+
+## GPT-OSS Specifics
+
+### Separate K/V format (GQA)
+
+Unlike DeepSeek MLA (`kv_post_transform`), GPT-OSS uses separate K and V caches:
+
+- `key_cache_layer_{N}`: post-RoPE K
+- `value_cache_layer_{N}`: raw V
+- Shape: `[1, num_kv_heads, seq_len, head_dim]` (8 heads × 64 dim for 120B)
+
+### Sliding-window layers
+
+GPT-OSS alternates `sliding_attention` (window=128) and `full_attention` layers. The reference uses `FullKVCapture` to snapshot the **full** sequence K/V before sliding-window truncation — required for long-prefill golden traces.
+
+Use `--disable-sliding-window` only for diagnostics (changes the math vs production).
+
+## Output Format
+
+```
+{out_dir}/
+    metadata.json
+    kv_cache/
+        layer_0.safetensors
+        layer_1.safetensors
+        ...
+```
+
+## Usage with Prefill PCC
+
+```bash
+export PREFILL_TRACE_DIR=/mnt/models/gpt-oss-cache/golden/longbook_full
+export HF_MODEL=/path/to/gpt-oss-120b
+
+python3 models/demos/gpt_oss_d_p/tests/galaxy_prefill_kv_pcc.py
+```
+
+The safetensors golden trace is the MiniMax-style format consumed via `PREFILL_TRACE_DIR`.
+
+## Options
+
+| Flag / env | Description |
+|------------|-------------|
+| `--prompt-json` / `--prompt` | Input prompt |
+| `--max-tokens N` | Truncate to N tokens |
+| `--chat-template` | Apply chat template (off by default) |
+| `--dtype` | Stored dtype (default: bfloat16) |
+| `--num-layers N` | Capture first N layers only |
+| `--zero-sinks` | Zero attention sinks (diagnostic) |
+| `--disable-sliding-window` | Force full attention everywhere (diagnostic) |
+| `--model-path` | HF dir, or `$HF_MODEL` / `$DEEPSEEK_V3_HF_MODEL` |
+| `REF_ATTN_Q_CHUNK` | Query-row tile size (default 256); lower if still OOM |
+| `REF_FFN_TOKEN_CHUNK` | MoE token tile size (default 4096) |
+
+## Tokenization Consistency
+
+| Your Test Uses | Generate Golden With |
+|----------------|----------------------|
+| Plain `tok(prompt)["input_ids"]` | Default (no `--chat-template`) |
+| Chat template | `--chat-template` |
+
+## Storage Estimate
+
+At 56K tokens, 36 layers, 8 KV heads, head_dim=64:
+
+- Per layer: ~2 × (1 × 8 × 56320 × 64 × 2 bytes) ≈ 115 MB
+- Total: ~4 GB
+
+## Example Workflow
+
+```bash
+export HF_MODEL=/data/models/gpt-oss-120b
+export OUT_DIR=/data/golden_traces/gpt_oss
+
+# Short test first
+python3 models/demos/gpt_oss_d_p/scripts/generate_golden_kv_cache.py \
+    --prompt "Hello world" \
+    --out $OUT_DIR/test_1k \
+    --max-tokens 1024
+
+# Verify
+python3 models/demos/gpt_oss_d_p/scripts/verify_golden_kv.py $OUT_DIR/test_1k
+
+# Full 55k one-shot (tiled attn/MoE — no prompt chunking)
+nohup env REF_ATTN_Q_CHUNK=256 REF_FFN_TOKEN_CHUNK=4096 \
+    python3 models/demos/gpt_oss_d_p/scripts/generate_golden_kv_cache.py \
+    --prompt-json prompt.json \
+    --out $OUT_DIR/longbook_full \
+    --max-tokens 56320 \
+    > generate_golden.log 2>&1 &
+```

--- a/models/demos/gpt_oss_d_p/scripts/generate_golden_kv_cache.py
+++ b/models/demos/gpt_oss_d_p/scripts/generate_golden_kv_cache.py
@@ -97,7 +97,7 @@ def parse_args():
         "--model-path",
         type=str,
         default=None,
-        help="HF model directory (default: $HF_MODEL or $DEEPSEEK_V3_HF_MODEL)",
+        help="HF model directory (default: $HF_MODEL)",
     )
     ap.add_argument("--max-tokens", type=int, default=None, help="Truncate prompt to this many tokens")
     ap.add_argument(
@@ -109,7 +109,8 @@ def parse_args():
         "--dtype",
         choices=["bfloat16", "float32", "float16"],
         default="bfloat16",
-        help="Stored KV cache dtype (default: bfloat16)",
+        help="Stored KV cache dtype (default: bfloat16). The reference always computes in "
+        "bfloat16; K/V are cast to this dtype on save (bf16 matches the device cache).",
     )
     ap.add_argument(
         "--num-layers",
@@ -163,9 +164,12 @@ def tokenize_prompt(tokenizer, prompt: str, max_tokens: int | None, use_chat_tem
     else:
         ids = tokenizer(prompt)["input_ids"]
 
-    if max_tokens and len(ids) > max_tokens:
-        print(f"[tokenize] truncating {len(ids)} tokens -> {max_tokens}")
-        ids = ids[:max_tokens]
+    if max_tokens is not None:
+        if max_tokens <= 0:
+            raise ValueError(f"max_tokens must be positive, got {max_tokens}")
+        if len(ids) > max_tokens:
+            print(f"[tokenize] truncating {len(ids)} tokens -> {max_tokens}")
+            ids = ids[:max_tokens]
 
     return ids, len(ids)
 
@@ -176,9 +180,9 @@ def main():
 
     use_tiled_ops = args.attn_mode == "tiled"
 
-    model_path = args.model_path or os.environ.get("HF_MODEL") or os.environ.get("DEEPSEEK_V3_HF_MODEL")
+    model_path = args.model_path or os.environ.get("HF_MODEL")
     if not model_path:
-        print("ERROR: Must provide --model-path or set $HF_MODEL / $DEEPSEEK_V3_HF_MODEL", file=sys.stderr)
+        print("ERROR: Must provide --model-path or set $HF_MODEL", file=sys.stderr)
         return 1
 
     dtype_map = {
@@ -187,6 +191,7 @@ def main():
         "float16": torch.float16,
     }
     dtype = dtype_map[args.dtype]
+    compute_dtype = torch.bfloat16
 
     out_dir = args.out
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -205,7 +210,11 @@ def main():
 
     print(f"\n{'=' * 70}", flush=True)
     print(f"[load] Building golden reference from {model_path}", flush=True)
-    print(f"[load] compute dtype={dtype}; weights mmap'd (low_cpu_mem_usage)", flush=True)
+    print(
+        f"[load] compute dtype=bfloat16 (matches device cache); "
+        f"store dtype={args.dtype}; weights mmap'd (low_cpu_mem_usage)",
+        flush=True,
+    )
     if use_tiled_ops:
         print("[load] one-shot prefill with tiled attn/MoE (--attn-mode tiled)", flush=True)
     else:
@@ -222,7 +231,7 @@ def main():
     model = load_golden_model(
         model_path,
         num_layers=args.num_layers,
-        compute_dtype=dtype,
+        compute_dtype=compute_dtype,
         zero_sinks=args.zero_sinks,
         disable_sliding_window=args.disable_sliding_window,
         use_tiled_ops=use_tiled_ops,
@@ -268,9 +277,9 @@ def main():
         value_cache = value_cache.to(dtype)
         expected_shape = (1, num_kv_heads, seq_len, head_dim)
         if tuple(key_cache.shape) != expected_shape or tuple(value_cache.shape) != expected_shape:
-            tqdm.write(
-                f"[save] WARNING: layer {layer_idx} KV shape mismatch! "
-                f"K: {tuple(key_cache.shape)}, V: {tuple(value_cache.shape)}, expected: {expected_shape}"
+            raise ValueError(
+                f"layer {layer_idx} KV shape mismatch: "
+                f"K={tuple(key_cache.shape)}, V={tuple(value_cache.shape)}, expected={expected_shape}"
             )
         tensors = {
             f"key_cache_layer_{layer_idx}": key_cache.contiguous(),

--- a/models/demos/gpt_oss_d_p/scripts/generate_golden_kv_cache.py
+++ b/models/demos/gpt_oss_d_p/scripts/generate_golden_kv_cache.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate golden KV cache for GPT-OSS prefill validation.
+
+Runs the HF golden reference (models/demos/gpt_oss_d_p/reference/model.py) and extracts
+per-layer post-RoPE K and raw V, saving in the separate K/V format used by the MiniMax-style
+golden trace layout and ``scripts/verify_golden_kv.py``.
+
+GPT-OSS uses alternating sliding/full attention; the reference captures full-length K/V via
+``FullKVCapture`` before sliding-window truncation.
+
+Memory approach (true one-shot — NOT prompt-chunked prefill):
+- Model weights mmap'd via ``low_cpu_mem_usage=True``
+- Computes in bfloat16 (matches device cache dtype)
+- ``--attn-mode tiled`` (default): query-row + MoE token tiling (never allocates [H,S,S]
+  scores). Tune with ``REF_ATTN_Q_CHUNK`` / ``REF_FFN_TOKEN_CHUNK`` (defaults 256 / 4096).
+- ``--attn-mode eager``: stock HF eager (matches older short-seq goldens; OOMs on long seq).
+- Saves layer-by-layer via streaming callback during the forward pass
+
+Output format:
+    {trace_dir}/
+        metadata.json
+        kv_cache/
+            layer_0.safetensors - key_cache_layer_0 / value_cache_layer_0  [1, num_kv_heads, seq_len, head_dim]
+            ...
+
+Usage:
+    export HF_MODEL=/path/to/gpt-oss-120b
+    python3 models/demos/gpt_oss_d_p/scripts/generate_golden_kv_cache.py \\
+        --prompt-json prompt.json \\
+        --out /mnt/models/gpt-oss-cache/golden/longbook_full \\
+        --max-tokens 56320
+
+    # Stock HF eager (old short-seq golden path; no REF_* tiling)
+    python3 models/demos/gpt_oss_d_p/scripts/generate_golden_kv_cache.py \\
+        --prompt-json prompt.json --out /tmp/gpt_oss_2k_eager \\
+        --max-tokens 2000 --attn-mode eager
+
+    # Optional: lower peak RAM further (slower; tiled mode only)
+    REF_ATTN_Q_CHUNK=128 REF_FFN_TOKEN_CHUNK=2048 \\
+      python3 models/demos/gpt_oss_d_p/scripts/generate_golden_kv_cache.py \\
+        --prompt-json prompt.json --out /tmp/gpt_oss_55k --max-tokens 55000
+
+    python3 models/demos/gpt_oss_d_p/scripts/generate_golden_kv_cache.py \\
+        --prompt "What are the prime factors of 1?" \\
+        --out /tmp/gpt_oss_golden
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import resource
+import sys
+import time
+from pathlib import Path
+
+import torch
+from safetensors.torch import save_file
+from tqdm import tqdm
+from transformers import AutoTokenizer
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[4]))
+from models.demos.gpt_oss_d_p.reference.model import load_golden_model  # noqa: E402
+
+
+def _raise_cpu_time_limit():
+    soft, hard = resource.getrlimit(resource.RLIMIT_CPU)
+    if soft != resource.RLIM_INFINITY and (hard == resource.RLIM_INFINITY or soft < hard):
+        try:
+            resource.setrlimit(resource.RLIMIT_CPU, (hard, hard))
+            print(f"[limit] raised RLIMIT_CPU soft {soft}s -> {hard}")
+        except (ValueError, OSError) as e:
+            print(
+                f"[limit] WARNING: could not raise RLIMIT_CPU (soft={soft}s); "
+                f"if the run dies with 'CPU time limit exceeded', run `ulimit -t unlimited` first: {e}",
+                file=sys.stderr,
+            )
+
+
+def parse_args():
+    ap = argparse.ArgumentParser(
+        description="Generate golden KV cache for GPT-OSS",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+
+    prompt_group = ap.add_mutually_exclusive_group(required=True)
+    prompt_group.add_argument("--prompt-json", type=Path, help='JSON file with {"prompt": "..."}')
+    prompt_group.add_argument("--prompt", type=str, help="Direct prompt text")
+
+    ap.add_argument("--out", type=Path, required=True, help="Output trace directory (creates kv_cache/)")
+    ap.add_argument(
+        "--model-path",
+        type=str,
+        default=None,
+        help="HF model directory (default: $HF_MODEL or $DEEPSEEK_V3_HF_MODEL)",
+    )
+    ap.add_argument("--max-tokens", type=int, default=None, help="Truncate prompt to this many tokens")
+    ap.add_argument(
+        "--chat-template",
+        action="store_true",
+        help="Apply chat template (off by default; GPT-OSS demos use plain tokenization)",
+    )
+    ap.add_argument(
+        "--dtype",
+        choices=["bfloat16", "float32", "float16"],
+        default="bfloat16",
+        help="Stored KV cache dtype (default: bfloat16)",
+    )
+    ap.add_argument(
+        "--num-layers",
+        type=int,
+        default=None,
+        help="Number of layers to capture (default: all, 36 for gpt-oss-120b)",
+    )
+    ap.add_argument(
+        "--zero-sinks",
+        action="store_true",
+        help="Zero attention sinks before forward (diagnostic; matches kv_cache_prefill.py --zero-sinks)",
+    )
+    ap.add_argument(
+        "--disable-sliding-window",
+        action="store_true",
+        help="Force full causal attention on all layers (diagnostic)",
+    )
+    ap.add_argument(
+        "--attn-mode",
+        choices=["tiled", "eager"],
+        default="tiled",
+        help=(
+            "Attention/MoE path: 'tiled' (default) installs MiniMax-style tiling controlled by "
+            "REF_ATTN_Q_CHUNK / REF_FFN_TOKEN_CHUNK; 'eager' uses stock HF eager (old short-seq "
+            "golden path, may OOM on long sequences)"
+        ),
+    )
+
+    return ap.parse_args()
+
+
+def load_prompt(args) -> str:
+    if args.prompt_json:
+        with open(args.prompt_json) as f:
+            data = json.load(f)
+        if isinstance(data, dict) and "prompt" in data:
+            return data["prompt"]
+        if isinstance(data, str):
+            return data
+        raise ValueError(f"{args.prompt_json}: expected dict with 'prompt' key or string")
+    return args.prompt
+
+
+def tokenize_prompt(tokenizer, prompt: str, max_tokens: int | None, use_chat_template: bool) -> tuple[list[int], int]:
+    if use_chat_template:
+        ids = tokenizer.apply_chat_template(
+            [{"role": "user", "content": prompt}],
+            add_generation_prompt=True,
+            tokenize=True,
+        )
+    else:
+        ids = tokenizer(prompt)["input_ids"]
+
+    if max_tokens and len(ids) > max_tokens:
+        print(f"[tokenize] truncating {len(ids)} tokens -> {max_tokens}")
+        ids = ids[:max_tokens]
+
+    return ids, len(ids)
+
+
+def main():
+    args = parse_args()
+    _raise_cpu_time_limit()
+
+    use_tiled_ops = args.attn_mode == "tiled"
+
+    model_path = args.model_path or os.environ.get("HF_MODEL") or os.environ.get("DEEPSEEK_V3_HF_MODEL")
+    if not model_path:
+        print("ERROR: Must provide --model-path or set $HF_MODEL / $DEEPSEEK_V3_HF_MODEL", file=sys.stderr)
+        return 1
+
+    dtype_map = {
+        "bfloat16": torch.bfloat16,
+        "float32": torch.float32,
+        "float16": torch.float16,
+    }
+    dtype = dtype_map[args.dtype]
+
+    out_dir = args.out
+    out_dir.mkdir(parents=True, exist_ok=True)
+    kv_cache_dir = out_dir / "kv_cache"
+    kv_cache_dir.mkdir(exist_ok=True)
+
+    print("[load] reading prompt...", flush=True)
+    prompt = load_prompt(args)
+    print(f"[load] prompt length: {len(prompt)} characters", flush=True)
+
+    print(f"[load] loading tokenizer from {model_path}...", flush=True)
+    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+
+    token_ids, seq_len = tokenize_prompt(tokenizer, prompt, args.max_tokens, args.chat_template)
+    print(f"[load] tokenized to {seq_len} tokens (chat_template={args.chat_template})", flush=True)
+
+    print(f"\n{'=' * 70}", flush=True)
+    print(f"[load] Building golden reference from {model_path}", flush=True)
+    print(f"[load] compute dtype={dtype}; weights mmap'd (low_cpu_mem_usage)", flush=True)
+    if use_tiled_ops:
+        print("[load] one-shot prefill with tiled attn/MoE (--attn-mode tiled)", flush=True)
+    else:
+        print(
+            "[load] one-shot prefill with stock HF eager (--attn-mode eager); "
+            "full [H,S,S] scores — use only for short sequences",
+            flush=True,
+        )
+    print(f"{'=' * 70}\n", flush=True)
+
+    torch.set_num_threads(os.cpu_count() or 32)
+
+    t0 = time.time()
+    model = load_golden_model(
+        model_path,
+        num_layers=args.num_layers,
+        compute_dtype=dtype,
+        zero_sinks=args.zero_sinks,
+        disable_sliding_window=args.disable_sliding_window,
+        use_tiled_ops=use_tiled_ops,
+    )
+    num_layers = model.cfg.num_hidden_layers
+    num_kv_heads = model.cfg.num_key_value_heads
+    head_dim = model.cfg.head_dim
+    print(
+        f"[load] reference ready in {time.time() - t0:.1f}s — "
+        f"{num_layers} layers, {num_kv_heads} KV heads, head_dim={head_dim}",
+        flush=True,
+    )
+    if model.cfg.sliding_window and not args.disable_sliding_window:
+        print(
+            f"[forward] sliding_window={model.cfg.sliding_window} on alternating layers; "
+            f"FullKVCapture preserves full-seq K/V",
+            flush=True,
+        )
+
+    print(f"\n{'=' * 70}", flush=True)
+    print(f"[forward] Running one-shot prefill for {seq_len} tokens", flush=True)
+    if use_tiled_ops:
+        print(
+            f"[forward] tiling: ATTN_Q_CHUNK={model.attn_q_chunk} "
+            f"FFN_TOKEN_CHUNK={model.ffn_token_chunk} (not prompt-chunked)",
+            flush=True,
+        )
+    else:
+        print("[forward] stock HF eager (no tiling / not prompt-chunked)", flush=True)
+    print("[forward] WARNING: CPU inference is SLOW — can take many minutes for long prompts!", flush=True)
+    print(f"{'=' * 70}\n", flush=True)
+
+    input_ids = torch.tensor(token_ids, dtype=torch.long).unsqueeze(0)
+    saved_key_shape: list[int] | None = None
+    saved_val_shape: list[int] | None = None
+
+    t0 = time.time()
+    progress = tqdm(total=num_layers, desc="Prefill (save KV per layer)", unit="layer")
+
+    def save_layer(layer_idx: int, key_cache: torch.Tensor, value_cache: torch.Tensor):
+        nonlocal saved_key_shape, saved_val_shape
+        key_cache = key_cache.to(dtype)
+        value_cache = value_cache.to(dtype)
+        expected_shape = (1, num_kv_heads, seq_len, head_dim)
+        if tuple(key_cache.shape) != expected_shape or tuple(value_cache.shape) != expected_shape:
+            tqdm.write(
+                f"[save] WARNING: layer {layer_idx} KV shape mismatch! "
+                f"K: {tuple(key_cache.shape)}, V: {tuple(value_cache.shape)}, expected: {expected_shape}"
+            )
+        tensors = {
+            f"key_cache_layer_{layer_idx}": key_cache.contiguous(),
+            f"value_cache_layer_{layer_idx}": value_cache.contiguous(),
+        }
+        save_file(tensors, str(kv_cache_dir / f"layer_{layer_idx}.safetensors"))
+        saved_key_shape = list(key_cache.shape)
+        saved_val_shape = list(value_cache.shape)
+        progress.update(1)
+
+    with torch.no_grad():
+        model.prefill(input_ids, kv_callback=save_layer)
+    # top-1 sign-off reference consumed by galaxy_prefill_kv_pcc.py (PREFILL_TOP1)
+    save_file({"top1_token_ids": model.top1_token_ids}, str(out_dir / "reference_top1.safetensors"))
+
+    progress.close()
+    forward_time = time.time() - t0
+    mins = int(forward_time // 60)
+    secs = int(forward_time % 60)
+    print(f"\n[forward] completed in {mins}m {secs}s ({seq_len / forward_time:.2f} tok/s)", flush=True)
+    print(f"[save] saved all {num_layers} layers to {kv_cache_dir}/", flush=True)
+
+    if use_tiled_ops:
+        reference = "models.demos.gpt_oss_d_p.reference.model (HF AutoModelForCausalLM golden, tiled ops)"
+        prefill_mode = "one_shot_tiled"
+    else:
+        reference = "models.demos.gpt_oss_d_p.reference.model (HF AutoModelForCausalLM golden)"
+        prefill_mode = "one_shot"
+
+    metadata = {
+        "model_path": str(model_path),
+        "reference": reference,
+        "prompt_source": str(args.prompt_json) if args.prompt_json else "direct",
+        "prompt": prompt[:500] + "..." if len(prompt) > 500 else prompt,
+        "prompt_length_chars": len(prompt),
+        "token_ids": token_ids,
+        "n_tokens": seq_len,
+        "n_layers": num_layers,
+        "num_layers": num_layers,
+        "num_kv_heads": num_kv_heads,
+        "head_dim": head_dim,
+        "sliding_window": model.cfg.sliding_window,
+        "disable_sliding_window": args.disable_sliding_window,
+        "zero_sinks": args.zero_sinks,
+        "dtype": args.dtype,
+        "chat_template": args.chat_template,
+        "prefill_mode": prefill_mode,
+        "attn_mode": args.attn_mode,
+        "attn_q_chunk": model.attn_q_chunk,
+        "ffn_token_chunk": model.ffn_token_chunk,
+        "forward_time_seconds": forward_time,
+        "tokens_per_second": seq_len / forward_time,
+        "kv_cache_format": "separate_k_v",
+        "key_cache_shape": saved_key_shape,
+        "value_cache_shape": saved_val_shape,
+    }
+
+    metadata_path = out_dir / "metadata.json"
+    with open(metadata_path, "w") as f:
+        json.dump(metadata, f, indent=2)
+
+    total_size_gb = sum(f.stat().st_size for f in kv_cache_dir.glob("*.safetensors")) / (1024**3)
+
+    print(f"\n{'=' * 70}", flush=True)
+    print("Golden KV cache generation complete!", flush=True)
+    print(f"{'=' * 70}", flush=True)
+    print(f"Output directory: {out_dir}", flush=True)
+    print(f"Metadata:         {metadata_path}", flush=True)
+    print(f"KV cache:         {kv_cache_dir}/ ({num_layers} layer files)", flush=True)
+    print(f"Total size:       {total_size_gb:.2f} GB", flush=True)
+    print(f"Each layer:       K {saved_key_shape}, V {saved_val_shape}", flush=True)
+    print("Next steps:", flush=True)
+    print(f"  1. Verify: python3 models/demos/gpt_oss_d_p/scripts/verify_golden_kv.py {out_dir}", flush=True)
+    print(f"  2. Use in tests: export PREFILL_TRACE_DIR={out_dir}", flush=True)
+    print(f"{'=' * 70}\n", flush=True)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/models/demos/gpt_oss_d_p/scripts/verify_golden_kv.py
+++ b/models/demos/gpt_oss_d_p/scripts/verify_golden_kv.py
@@ -59,7 +59,18 @@ def verify_trace(trace_dir: Path) -> bool:
     expected_key_shape = tuple(metadata["key_cache_shape"])
     expected_val_shape = tuple(metadata["value_cache_shape"])
 
-    print(f"  metadata OK: {n_tokens} tokens, {num_layers} layers")
+    dtype_name = metadata.get("dtype", "bfloat16")
+    dtype_map = {
+        "bfloat16": (torch.bfloat16, 2),
+        "float16": (torch.float16, 2),
+        "float32": (torch.float32, 4),
+    }
+    if dtype_name not in dtype_map:
+        print(f"  metadata dtype {dtype_name!r} not supported (expected one of {sorted(dtype_map)})")
+        return False
+    expected_dtype, element_size = dtype_map[dtype_name]
+
+    print(f"  metadata OK: {n_tokens} tokens, {num_layers} layers, dtype={dtype_name}")
     print(f"    K shape: {expected_key_shape}, V shape: {expected_val_shape}")
 
     kv_cache_dir = trace_dir / "kv_cache"
@@ -98,8 +109,12 @@ def verify_trace(trace_dir: Path) -> bool:
                     continue
 
                 for name, tensor in (("K", key_tensor), ("V", val_tensor)):
-                    if tensor.dtype != torch.bfloat16:
-                        print(f"  layer {layer_idx}: {name} dtype {tensor.dtype} (expected bfloat16)")
+                    if tensor.dtype != expected_dtype:
+                        print(
+                            f"  layer {layer_idx}: {name} dtype {tensor.dtype} "
+                            f"(expected {expected_dtype}, metadata dtype={dtype_name})"
+                        )
+                        success = False
                     sample = tensor.flatten()[:1000]
                     if not torch.isfinite(sample).all():
                         print(f"  layer {layer_idx}: {name} contains NaN or Inf values")
@@ -118,8 +133,12 @@ def verify_trace(trace_dir: Path) -> bool:
         print("  some layer files had errors")
 
     print("[verify] checking file sizes...")
-    k_size = expected_key_shape[0] * expected_key_shape[1] * expected_key_shape[2] * expected_key_shape[3] * 2
-    v_size = expected_val_shape[0] * expected_val_shape[1] * expected_val_shape[2] * expected_val_shape[3] * 2
+    k_size = (
+        expected_key_shape[0] * expected_key_shape[1] * expected_key_shape[2] * expected_key_shape[3] * element_size
+    )
+    v_size = (
+        expected_val_shape[0] * expected_val_shape[1] * expected_val_shape[2] * expected_val_shape[3] * element_size
+    )
     expected_size_per_layer_mb = (k_size + v_size) / (1024 * 1024)
 
     total_size_mb = 0.0
@@ -142,6 +161,7 @@ def verify_trace(trace_dir: Path) -> bool:
         print(f"   Trace: {trace_dir}")
         print(f"   Tokens: {n_tokens}")
         print(f"   Layers: {num_layers}")
+        print(f"   Dtype: {dtype_name}")
         print(f"   K shape: {expected_key_shape}")
         print(f"   V shape: {expected_val_shape}")
         print(f"   Size: {total_size_mb / 1024:.2f} GB")

--- a/models/demos/gpt_oss_d_p/scripts/verify_golden_kv.py
+++ b/models/demos/gpt_oss_d_p/scripts/verify_golden_kv.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verify a GPT-OSS golden KV cache trace has the expected structure and properties.
+
+GPT-OSS uses GQA with separate post-RoPE K and raw V per layer:
+  key_cache_layer_{N}   [1, num_kv_heads, seq_len, head_dim]
+  value_cache_layer_{N} [1, num_kv_heads, seq_len, head_dim]
+
+Quick sanity check before using a trace for prefill validation:
+- metadata.json complete (token_ids, shapes, layer count)
+- All layer files exist with matching K/V tensors
+- Data is finite (no NaNs/Infs)
+
+Usage:
+    python3 verify_golden_kv.py /path/to/trace_dir
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+
+
+def verify_trace(trace_dir: Path) -> bool:
+    success = True
+
+    print(f"[verify] checking {trace_dir}/metadata.json...")
+    metadata_path = trace_dir / "metadata.json"
+    if not metadata_path.exists():
+        print("  metadata.json not found")
+        return False
+
+    try:
+        with open(metadata_path) as f:
+            metadata = json.load(f)
+    except Exception as e:
+        print(f"  failed to parse metadata.json: {e}")
+        return False
+
+    required_keys = ["token_ids", "n_tokens", "key_cache_shape", "value_cache_shape"]
+    missing = [k for k in required_keys if k not in metadata]
+    if missing:
+        print(f"  metadata missing required keys: {missing}")
+        return False
+
+    n_tokens = metadata["n_tokens"]
+    num_layers = metadata.get("num_layers") or metadata.get("n_layers")
+    if num_layers is None:
+        print("  metadata missing num_layers / n_layers")
+        return False
+
+    expected_key_shape = tuple(metadata["key_cache_shape"])
+    expected_val_shape = tuple(metadata["value_cache_shape"])
+
+    print(f"  metadata OK: {n_tokens} tokens, {num_layers} layers")
+    print(f"    K shape: {expected_key_shape}, V shape: {expected_val_shape}")
+
+    kv_cache_dir = trace_dir / "kv_cache"
+    if not kv_cache_dir.is_dir():
+        print("  kv_cache/ directory not found")
+        return False
+
+    print(f"[verify] checking {num_layers} layer files...")
+    for layer_idx in range(num_layers):
+        layer_file = kv_cache_dir / f"layer_{layer_idx}.safetensors"
+        if not layer_file.exists():
+            print(f"  layer_{layer_idx}.safetensors not found")
+            success = False
+            continue
+
+        key_name = f"key_cache_layer_{layer_idx}"
+        val_name = f"value_cache_layer_{layer_idx}"
+        try:
+            with safe_open(str(layer_file), framework="pt", device="cpu") as f:
+                keys = list(f.keys())
+                if key_name not in keys or val_name not in keys:
+                    print(f"  layer {layer_idx}: expected {key_name!r} and {val_name!r}, found: {keys}")
+                    success = False
+                    continue
+
+                key_tensor = f.get_tensor(key_name)
+                val_tensor = f.get_tensor(val_name)
+
+                if key_tensor.shape != expected_key_shape:
+                    print(f"  layer {layer_idx}: K shape {key_tensor.shape} != expected {expected_key_shape}")
+                    success = False
+                    continue
+                if val_tensor.shape != expected_val_shape:
+                    print(f"  layer {layer_idx}: V shape {val_tensor.shape} != expected {expected_val_shape}")
+                    success = False
+                    continue
+
+                for name, tensor in (("K", key_tensor), ("V", val_tensor)):
+                    if tensor.dtype != torch.bfloat16:
+                        print(f"  layer {layer_idx}: {name} dtype {tensor.dtype} (expected bfloat16)")
+                    sample = tensor.flatten()[:1000]
+                    if not torch.isfinite(sample).all():
+                        print(f"  layer {layer_idx}: {name} contains NaN or Inf values")
+                        success = False
+        except Exception as e:
+            print(f"  layer {layer_idx}: failed to load - {e}")
+            success = False
+            continue
+
+        if (layer_idx + 1) % 10 == 0:
+            print(f"  ... checked {layer_idx + 1}/{num_layers} layers")
+
+    if success:
+        print(f"  all {num_layers} layer files OK")
+    else:
+        print("  some layer files had errors")
+
+    print("[verify] checking file sizes...")
+    k_size = expected_key_shape[0] * expected_key_shape[1] * expected_key_shape[2] * expected_key_shape[3] * 2
+    v_size = expected_val_shape[0] * expected_val_shape[1] * expected_val_shape[2] * expected_val_shape[3] * 2
+    expected_size_per_layer_mb = (k_size + v_size) / (1024 * 1024)
+
+    total_size_mb = 0.0
+    for layer_idx in range(num_layers):
+        layer_file = kv_cache_dir / f"layer_{layer_idx}.safetensors"
+        if layer_file.exists():
+            size_mb = layer_file.stat().st_size / (1024 * 1024)
+            total_size_mb += size_mb
+            if size_mb < expected_size_per_layer_mb * 0.8 or size_mb > expected_size_per_layer_mb * 1.5:
+                print(
+                    f"  layer {layer_idx}: size {size_mb:.1f}MB unexpected "
+                    f"(expected ~{expected_size_per_layer_mb:.1f}MB)"
+                )
+
+    print(f"  total trace size: {total_size_mb:.1f} MB ({total_size_mb / 1024:.2f} GB)")
+
+    print(f"\n{'=' * 70}")
+    if success:
+        print("Trace verification PASSED")
+        print(f"   Trace: {trace_dir}")
+        print(f"   Tokens: {n_tokens}")
+        print(f"   Layers: {num_layers}")
+        print(f"   K shape: {expected_key_shape}")
+        print(f"   V shape: {expected_val_shape}")
+        print(f"   Size: {total_size_mb / 1024:.2f} GB")
+        print(f"\n   Ready to use with PREFILL_TRACE_DIR={trace_dir}")
+    else:
+        print("Trace verification FAILED - see errors above")
+    print(f"{'=' * 70}\n")
+
+    return success
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Verify a GPT-OSS golden KV cache trace directory",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument(
+        "trace_dir",
+        type=Path,
+        help="Path to trace directory (contains metadata.json and kv_cache/)",
+    )
+    args = ap.parse_args()
+
+    if not args.trace_dir.is_dir():
+        print(f"ERROR: {args.trace_dir} is not a directory", file=sys.stderr)
+        return 1
+
+    success = verify_trace(args.trace_dir)
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add a CPU HF golden reference for GPT-OSS prefill (`reference/model.py`) that captures full post-RoPE K / raw V before sliding-window truncation via `FullKVCapture`.
- Add MiniMax-style tiled eager attention + MoE (`reference/tiled_ops.py`) so long one-shot prefill (e.g. ~55k) stays within host RAM without changing golden math.
- Add `generate_golden_kv_cache.py`, `verify_golden_kv.py`, and `README_golden_kv.md` to produce/validate MiniMax-style safetensors traces for `PREFILL_TRACE_DIR` / `galaxy_prefill_kv_pcc.py`.

## Test plan
- [ ] Short golden: generate with `--max-tokens 1024`, run `verify_golden_kv.py` on the output dir
- [ ] Confirm metadata + `kv_cache/layer_*.safetensors` layout matches expected separate K/V format
- [ ] Optional long-seq smoke: tiled path with `REF_ATTN_Q_CHUNK` / `REF_FFN_TOKEN_CHUNK` on a longer prompt
- [ ] Point `PREFILL_TRACE_DIR` at a generated trace and run `tests/galaxy_prefill_kv_pcc.py` if hardware is available

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lgalasTT/new_gpt_oss_d_p_cache_golden)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lgalasTT/new_gpt_oss_d_p_cache_golden)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lgalasTT/new_gpt_oss_d_p_cache_golden)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lgalasTT/new_gpt_oss_d_p_cache_golden)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lgalasTT/new_gpt_oss_d_p_cache_golden)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lgalasTT/new_gpt_oss_d_p_cache_golden)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lgalasTT/new_gpt_oss_d_p_cache_golden)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lgalasTT/new_gpt_oss_d_p_cache_golden)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lgalasTT/new_gpt_oss_d_p_cache_golden)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lgalasTT/new_gpt_oss_d_p_cache_golden)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lgalasTT/new_gpt_oss_d_p_cache_golden)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lgalasTT/new_gpt_oss_d_p_cache_golden)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lgalasTT/new_gpt_oss_d_p_cache_golden)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lgalasTT/new_gpt_oss_d_p_cache_golden)