### PR TITLE
[Bug Fix] Apply the decode state slot remap outside device sampling

### DIFF
--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -1321,6 +1321,12 @@ class Generator(WarmupForwardMixin):
             reset_reasons.append("reset_batch")
 
         kv_cache = kv_cache[0]
+        # vLLM sends slot_remap whenever a request's decode row stops matching the
+        # slot its per-slot state sits in, and then records the batch as remapped
+        # either way. Every piece of that state must move on the same step or its map
+        # is wrong from there on, so this cannot wait for a device-sampled step.
+        if slot_remap is not None:
+            self._apply_state_slot_remap(slot_remap)
         active_seed_slots = None
         if start_pos is not None:
             active_seed_slots = [
@@ -1361,7 +1367,6 @@ class Generator(WarmupForwardMixin):
                 reset_batch=reset_batch,
                 prompt_tokens=prompt_tokens,
                 output_tokens=output_tokens,
-                slot_remap=slot_remap,
                 enable_trace=enable_trace,
             )
 
@@ -1547,6 +1552,21 @@ class Generator(WarmupForwardMixin):
 
         return trace_tok_rm
 
+    def _apply_state_slot_remap(self, slot_remap):
+        """Move every piece of per-slot decode state to the layout ``slot_remap``
+        describes: slot ``i`` takes the state at ``slot_remap[i]``.
+
+        The seed RNG is the only such state here, and it is host state read on
+        device-sampled steps. The remap still has to land on the step vLLM sent it,
+        host-sampled steps included: skipping one leaves the RNG a permutation behind
+        for every step after, and no later remap describes the move that was missed.
+        """
+        sampling_module = getattr(self.model, "sampling", None)
+        if sampling_module is None:
+            return
+        seed_manager = sampling_module.seed_manager
+        seed_manager.apply_slot_remap(slot_remap[0 : seed_manager.max_batch_size])
+
     def sample_decode_on_device(
         self,
         tt_logits,
@@ -1556,7 +1576,6 @@ class Generator(WarmupForwardMixin):
         reset_batch=False,
         prompt_tokens: torch.Tensor | None = None,
         output_tokens: torch.Tensor | None = None,
-        slot_remap=None,
         enable_trace=False,
     ):
         tt_out_tok = self.trace_inputs_decode[True][0] if enable_trace and self.trace_inputs_decode[True] else None
@@ -1569,11 +1588,6 @@ class Generator(WarmupForwardMixin):
                 idx for idx, pos in enumerate(torch.as_tensor(start_pos).reshape(-1).tolist()) if int(pos) >= 0
             ]
 
-        # Apply slot remap from condense before advancing seeds.
-        if slot_remap is not None:
-            sm_bs = seed_manager.max_batch_size
-            rank_remap = slot_remap[0:sm_bs]
-            seed_manager.apply_slot_remap(rank_remap)
         if reset_inputs and sampling_params is not None:
             # If we have new inputs, we need to set up the sampling module again
             sampling_params = format_sampling_params(sampling_params, self.model_args.max_batch_size)

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1434,6 +1434,13 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             start_pos = new_start_pos
         self._slots_prefilled_since_decode = set()
 
+        # vLLM sends slot_remap whenever a request's decode row stops matching the
+        # slot its per-slot state sits in, and then records the batch as remapped
+        # either way. Every piece of that state must move on the same step or its map
+        # is wrong from there on, so this cannot wait for a device-sampled step.
+        if slot_remap is not None:
+            self._apply_state_slot_remap(slot_remap)
+
         decode_kwargs = {
             "current_pos": start_pos,
             "tokens": tokens,
@@ -1468,7 +1475,6 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 reset_batch=reset_batch,
                 prompt_tokens=prompt_tokens,
                 output_tokens=output_tokens,
-                slot_remap=slot_remap,
                 enable_trace=enable_trace,
                 skip_precompile=skip_trace_precompile,
             )
@@ -1691,6 +1697,37 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             ttnn.execute_trace(self.model_args[i].mesh_device, trace_id, cq_id=0, blocking=False)
         return self.trace_output_decode[on_device_sampling]
 
+    def _apply_state_slot_remap(self, slot_remap):
+        """Move every piece of per-slot decode state to the layout ``slot_remap``
+        describes: slot ``i`` takes the state at ``slot_remap[i]``.
+
+        The seed RNG is the only such state here, and it is host state read on
+        device-sampled steps. The remap still has to land on the step vLLM sent it,
+        host-sampled steps included: skipping one leaves the RNG a permutation behind
+        for every step after, and no later remap describes the move that was missed.
+        A model built without a sampling module has no such state to move.
+
+        Each rank's seed manager covers only its own ``sm_bs`` slots, so a rank's
+        window of the global remap has to be rebased into that space (the same
+        convention the async-ahead token keep above rebases for).
+        """
+        for i in range(self.data_parallel):
+            sampling_module = getattr(self.model[i], "sampling", None)
+            if sampling_module is None:
+                continue
+            seed_manager = sampling_module.seed_manager
+            sm_bs = seed_manager.max_batch_size
+            window = slot_remap[i * sm_bs : (i + 1) * sm_bs]
+            window = window if isinstance(window, torch.Tensor) else torch.tensor(window)
+            window = window.long() - i * sm_bs
+            # A source outside this rank's own slots is a move the rank cannot make:
+            # the state lives in another rank's seed manager, which this cannot reach.
+            assert bool(((window >= 0) & (window < sm_bs)).all()), (
+                f"rank {i} decode state slot remap leaves its own {sm_bs} slots: "
+                f"{slot_remap[i * sm_bs : (i + 1) * sm_bs]}"
+            )
+            seed_manager.apply_slot_remap(window)
+
     def sample_decode_on_device(
         self,
         tt_logits,
@@ -1699,7 +1736,6 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         reset_batch=False,
         prompt_tokens: torch.Tensor | None = None,
         output_tokens: torch.Tensor | None = None,
-        slot_remap=None,
         enable_trace=False,
         skip_precompile=False,
     ):
@@ -1754,11 +1790,6 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 max_seed_slots = sampling_module.seed_manager.max_batch_size
                 start_values = torch.as_tensor(start_pos[i]).reshape(-1).tolist()
                 active_seed_slots = [idx for idx, pos in enumerate(start_values[:max_seed_slots]) if int(pos) >= 0]
-            # Apply slot remap from condense before advancing seeds.
-            if slot_remap is not None:
-                sm_bs = sampling_module.seed_manager.max_batch_size
-                rank_remap = slot_remap[i * sm_bs : (i + 1) * sm_bs]
-                sampling_module.seed_manager.apply_slot_remap(rank_remap)
             # Register each request's explicit seed into the seed manager and
             # tie its RNG counter to the absolute decode position before
             # advancing. Without registration the per-request seed never reaches


### PR DESCRIPTION
## The bug

`slot_remap` is decode-layout data: the vLLM TT plugin sends it on the step a request's decode row stops matching the slot its per-slot state sits in, and then records the batch as remapped in its own ownership map. That record is unconditional, so the move has to be unconditional too.

Both generators applied the seed-RNG move inside `sample_decode_on_device`, which runs only when `sampling_params is not None`. On a host-sampled step the plugin advanced its map and the seed manager did not move. Nothing repairs that afterwards: the next remap describes the next move, never the one that was skipped, so the mapping stays a permutation behind for the rest of those requests' lives.

Host-sampled decode steps are not an edge case. `check_perform_device_sampling` falls back to host sampling for `logprobs >= 1` on every model except gpt-oss, and for `min_p`, `bad_words`, `logit_bias`, `allowed_token_ids`, `min_tokens`, and structured output. One client asking for logprobs flips the whole step, co-batched requests included.

## The change

`_apply_state_slot_remap` on both generators, called from `decode_forward` whenever `slot_remap` is supplied. Same placement Qwen3.6's adapter already uses for its GDN recurrent/conv state (`qwen36_vllm.py`), so the two stateful paths now agree: per-slot state moves when the plugin says it moved.

The seed RNG is the only per-slot state either generator owns, hence one call in the helper. The `tt_transformers` async-ahead token keep still consumes `slot_remap` directly and is left alone: it permutes device token/position buffers that only exist under device sampling, so its gate is correct.

Two things ride along:

- `tt_transformers` now rebases each rank's window of the remap into that rank's own seed manager space. `slot_remap` holds global slot indices (the same convention the async-ahead keep rebases for, a few lines up), and each rank's seed manager only covers its own `sm_bs` slots, so the old in-loop call read past the end of the per-rank state for `data_parallel > 1`. A source outside the rank's own slots now asserts rather than silently applying an in-range but wrong move.
- The dead `slot_remap` parameter is dropped from both `sample_decode_on_device` methods; no caller passed it other than `decode_forward`. Deepseek's same-named method keeps its own (explicitly ignored) parameter and is untouched.

## Scope, precisely

`SeedManager.apply_slot_remap` is pure host state (`seeds`, `seed_counters`, `rngs`) and returns immediately unless a request seed is active. That bounds this fix tightly, so to be explicit about what it does *not* do:

- **Unseeded traffic: no-op.** `_seed_active` is False, so the remap was already doing nothing on those steps.
- **Seeded traffic on all-device-sampled steps: no-op.** The old placement already applied it.
- **What it fixes:** a seeded request whose batch layout changes on a step that fell back to host sampling. Mixed batches are the reachable case, `test_mixed_params_batch` among them.

## Validation

https://github.com/tenstorrent/tt-metal/actions/runs/32048327499

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=viktorpus/apply-slot-remap-outside-device-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:viktorpus/apply-slot-remap-outside-device-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=viktorpus/apply-slot-remap-outside-device-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:viktorpus/apply-slot-remap-outside-device-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/apply-slot-remap-outside-device-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/apply-slot-remap-outside-device-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=viktorpus/apply-slot-remap-outside-device-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:viktorpus/apply-slot-remap-outside-device-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/apply-slot-remap-outside-device-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/apply-slot-remap-outside-device-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/apply-slot-remap-outside-device-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/apply-slot-remap-outside-device-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/apply-slot-remap-outside-device-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/apply-slot-remap-outside-device-sampling)