### PR TITLE
[tt-train] Bug fix - Use no_grad to disable gradient mode in Qwen3

### DIFF
--- a/tt-train/sources/examples/qwen3/generate.py
+++ b/tt-train/sources/examples/qwen3/generate.py
@@ -48,6 +48,7 @@ from tqdm.auto import tqdm
 import ttml
 import ttnn
 
+from ttml.common.utils import no_grad
 from ttml.models.qwen3.kv_cache import KVCache
 from utils.device_setup import setup_device, teardown_device
 from utils.memory import MemoryUsageTracker, finalize_memory
@@ -254,6 +255,7 @@ def generate_hf(hf_model, tokenizer, all_prompt_tokens, max_tokens, temperature=
 # =====================================================================
 
 
+@no_grad()
 def generate_ttml(
     model,
     config,
@@ -277,7 +279,6 @@ def generate_ttml(
     them to full vocab before sampling or collection — this is simpler and
     avoids the distributed argmax+Gumbel approximation.
     """
-    ttml.autograd.AutoContext.get_instance().set_gradient_mode(ttml.autograd.GradMode.DISABLED)
     model.eval()
 
     if isinstance(all_prompt_tokens[0], int):


### PR DESCRIPTION
### PR Category
Bug Fix

### Summary
Recent L2 Nightly log with the failure:
https://github.com/tenstorrent/tt-metal/actions/runs/31776244560/job/94731006083

This PR fixes the error when running Qwen3 tests together with certain other tests. This can be reproduced by running:

```
pytest \
  "tt-train/tests/python/test_qwen3_sample_logits_mask.py" \
  "tt-train/tests/python/test_reshape_op.py"
```

```
FAILED tt-train/tests/python/test_reshape_op.py::test_reshape_backward_basic - 
RuntimeError: [Tensor::backward] This tensor has no associated gradient function.
```

Gradient mode was disabled directly using `AutoContext.set_gradient_mode`, but was not re-enabled. AutoContext is process-global, so any subsequent test that need gradients will raise that error. `@no_grad()` wrapper can handle disabling and restoring the gradient mode automatically, so that is used in this PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ctr-kevinwu/fix-missing-gradient)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ctr-kevinwu/fix-missing-gradient)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ctr-kevinwu/fix-missing-gradient)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ctr-kevinwu/fix-missing-gradient)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ctr-kevinwu/fix-missing-gradient)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ctr-kevinwu/fix-missing-gradient)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ctr-kevinwu/fix-missing-gradient)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ctr-kevinwu/fix-missing-gradient)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ctr-kevinwu/fix-missing-gradient)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ctr-kevinwu/fix-missing-gradient)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ctr-kevinwu/fix-missing-gradient)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ctr-kevinwu/fix-missing-gradient)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ctr-kevinwu/fix-missing-gradient)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ctr-kevinwu/fix-missing-gradient)