### PR TITLE
sweeps: replay stale traced topk vectors without their indices tensor

### DIFF
--- a/tests/sweep_framework/sweeps/model_traced/topk_model_traced.py
+++ b/tests/sweep_framework/sweeps/model_traced/topk_model_traced.py
@@ -185,6 +185,16 @@ def run(
             if isinstance(indices_tensor_info["shape"], (list, tuple))
             else indices_tensor_info["shape"]
         )
+        # ttnn.topk now rejects an indices tensor whose shape differs from the input's, and one
+        # supplied for a reduction that is not on the last dimension (#52928). Traces recorded
+        # before that fix can carry a half-width or pow2-padded indices shape from the old
+        # sampling code; production no longer passes indices_tensor at all, so replay such
+        # vectors without one instead of aborting at the TT_FATAL. The values are unaffected
+        # either way -- the kernel generates identical indices itself.
+        dim_is_last = dim_val in (-1, len(shape) - 1)
+        if idx_shape != shape or not dim_is_last:
+            indices_tensor_info = None
+    if indices_tensor_info and indices_tensor_info["shape"] is not None:
         idx_dtype = indices_tensor_info.get("dtype") or ttnn.uint16
         idx_layout = indices_tensor_info.get("layout") or ttnn.TILE_LAYOUT
         idx_mem = indices_tensor_info.get("memory_config") or ttnn.DRAM_MEMORY_CONFIG


### PR DESCRIPTION
### PR Category

Test / CI

### Summary

Follow-up to #53001 (fix for #52928).

That PR makes `ttnn.topk` reject a caller-supplied `indices_tensor` whose shape differs from the input's, and one supplied when the reduction is not on the last dimension. Traced vectors in the model-traced topk sweep that were recorded from the pre-fix sampling code can carry a half-width or pow2-padded indices shape, so the sweep would abort at the new TT_FATAL mid-run instead of producing a PCC result.

This guards the replay: vectors whose recorded `indices_tensor_shape` no longer matches the input (or whose reduction dim is not last) run without the indices tensor — matching production, which no longer passes one at all — while vectors with a still-valid shape keep exercising the overload. Values are unaffected either way; the kernel generates identical indices itself.

Should merge after #53001 (harmless before it — the guard simply never fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/topk-traced-sweep-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/topk-traced-sweep-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/topk-traced-sweep-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/topk-traced-sweep-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/topk-traced-sweep-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/topk-traced-sweep-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/topk-traced-sweep-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/topk-traced-sweep-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/topk-traced-sweep-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/topk-traced-sweep-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/topk-traced-sweep-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/topk-traced-sweep-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/topk-traced-sweep-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/topk-traced-sweep-guard)