### PR TITLE
[Bug fix] emule: converge the runner with the emule-blaze fork

### DIFF
--- a/tt_metal/distributed/pinned_memory.cpp
+++ b/tt_metal/distributed/pinned_memory.cpp
@@ -96,10 +96,14 @@ void PinnedMemoryImpl::initialize_from_devices(
         unique_mmio_devices.insert(mmio_device_id);
     }
 
-    // Mock/emulated devices have no SysmemManager, so there is no host-memory
-    // mapping to perform. Record the device map and keep the host pointer only;
-    // device/NOC address queries return dummies (see get_device_addr / get_noc_addr).
-    if (cluster.is_mock_or_emulated()) {
+    // MockChip has no SysmemManager, so there is no host-memory mapping to perform. Record the
+    // device map and keep the host pointer only; device/NOC address queries return dummies (see
+    // get_device_addr / get_noc_addr).
+    //
+    // Mock only, not is_mock_or_emulated(): SWEmuleChip has a real SimulationSysmemManager, so a
+    // dummy address would strand the host-facing socket counters an emulated kernel writes back.
+    // See tt-emule docs/socket-emulation.md §7.
+    if (cluster.get_target_device_type() == tt::TargetDevice::Mock) {
         is_mock_ = true;
         mock_host_ptr_ = host_buffer;
         host_offset_ = 0;

--- a/tt_metal/distributed/pinned_memory.cpp
+++ b/tt_metal/distributed/pinned_memory.cpp
@@ -96,13 +96,10 @@ void PinnedMemoryImpl::initialize_from_devices(
         unique_mmio_devices.insert(mmio_device_id);
     }
 
-    // MockChip has no SysmemManager, so there is no host-memory mapping to perform. Record the
-    // device map and keep the host pointer only; device/NOC address queries return dummies (see
-    // get_device_addr / get_noc_addr).
-    //
-    // Mock only, not is_mock_or_emulated(): SWEmuleChip has a real SimulationSysmemManager, so a
-    // dummy address would strand the host-facing socket counters an emulated kernel writes back.
-    // See tt-emule docs/socket-emulation.md §7.
+    // MockChip has no SysmemManager, so there is nothing to map: keep the host pointer and let
+    // device/NOC queries return dummies (see get_device_addr / get_noc_addr). Mock only, not
+    // is_mock_or_emulated() — SWEmuleChip has a real SimulationSysmemManager, and a dummy address
+    // would strand an emulated kernel's socket counters. See tt-emule docs/socket-emulation.md §7.
     if (cluster.get_target_device_type() == tt::TargetDevice::Mock) {
         is_mock_ = true;
         mock_host_ptr_ = host_buffer;

--- a/tt_metal/distributed/pinned_memory.cpp
+++ b/tt_metal/distributed/pinned_memory.cpp
@@ -99,7 +99,7 @@ void PinnedMemoryImpl::initialize_from_devices(
     // MockChip has no SysmemManager, so there is nothing to map: keep the host pointer and let
     // device/NOC queries return dummies (see get_device_addr / get_noc_addr). Mock only, not
     // is_mock_or_emulated() — SWEmuleChip has a real SimulationSysmemManager, and a dummy address
-    // would strand an emulated kernel's socket counters. See tt-emule docs/socket-emulation.md §7.
+    // would strand the host-facing socket counters an emulated kernel writes back.
     if (cluster.get_target_device_type() == tt::TargetDevice::Mock) {
         is_mock_ = true;
         mock_host_ptr_ = host_buffer;

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -1529,6 +1529,23 @@ static std::map<std::string, std::string> build_kernel_defines(
                 }
             }
         }
+        // A dataflow buffer carries the same LLK-facing entry metadata as a circular buffer, keyed
+        // by the same device slot, so it feeds the same tables — without this a program declaring
+        // DFBs instead of CBs (ttnn::typecast) reports page size 0 to its kernels.
+        // See tt-emule docs/cb-dataformat.md.
+        for (const auto& dfb_impl : impl.dataflow_buffers_on_core(first_core)) {
+            const uint32_t slot = dfb_impl->device_slot;
+            if (slot >= EMULE_NUM_CBS) {  // no CB view above the ceiling, so no metadata either
+                continue;
+            }
+            const auto& dfb_cfg = dfb_impl->config;
+            tile_sizes[slot] = dfb_cfg.entry_size;
+            cb_formats[slot] = static_cast<uint8_t>(dfb_cfg.data_format);
+            if (dfb_cfg.tile.has_value()) {
+                tile_r_dim[slot] = dfb_cfg.tile->get_height();
+                tile_c_dim[slot] = dfb_cfg.tile->get_width();
+            }
+        }
         std::ostringstream ts, df, tr, tc;
         for (uint32_t i = 0; i < EMULE_NUM_CBS; i++) {
             if (i) {
@@ -1735,17 +1752,31 @@ static void collect_kernels(
             // chain and to define `is_brisc` / `is_ncrisc` / `is_trisc` constexpr bools; without
             // them, `SelectByRISCV<>` aliases fail to resolve. Emule runs all RISCs in one unified
             // thread, so we set the corresponding macro based on the kernel's processor class.
+            //
+            // PROCESSOR_INDEX — silicon's HAL emits it alongside the COMPILE_FOR_* defines, and
+            // get_hw_thread_idx() returns it, so the debug headers reaching it (waypoint, pause,
+            // assert, device_print) fail to compile without it. Taken from the HAL, not hard-coded,
+            // so it tracks tt-metal.
+            uint32_t processor_type_idx = 0;  // emule fuses TRISC0-2 into one compute fiber
             if (is_tensix) {
                 defines["COMPILE_FOR_TRISC"] = "1";
             } else if (auto* dm_kernel = dynamic_cast<DataMovementKernel*>(kernel.get()); dm_kernel != nullptr) {
                 auto cfg_variant = dm_kernel->config();
                 const auto& cfg = std::get<DataMovementConfig>(cfg_variant);
                 switch (cfg.processor) {
-                    case DataMovementProcessor::RISCV_0: defines["COMPILE_FOR_BRISC"] = "1"; break;
-                    case DataMovementProcessor::RISCV_1: defines["COMPILE_FOR_NCRISC"] = "1"; break;
+                    case DataMovementProcessor::RISCV_0:
+                        defines["COMPILE_FOR_BRISC"] = "1";
+                        processor_type_idx = 0;
+                        break;
+                    case DataMovementProcessor::RISCV_1:
+                        defines["COMPILE_FOR_NCRISC"] = "1";
+                        processor_type_idx = 1;
+                        break;
                     default: break;
                 }
             }
+            defines["PROCESSOR_INDEX"] = std::to_string(hal.get_processor_index(
+                hal.get_programmable_core_type(pct), kernel->get_kernel_processor_class(), processor_type_idx));
 
             // Helper: compute cache key from a defines map (preserves upstream's sorted
             // iteration of named_compile_args and defines for key stability).
@@ -2883,7 +2914,16 @@ static void init_core_cb_sync(
     bool configured[EMULE_NUM_CBS] = {};
     auto configure = [&](const std::shared_ptr<CircularBufferImpl>& cb_impl, const CoreCoord& lc) {
         for (uint8_t idx : cb_impl->local_buffer_indices()) {
-            if (idx >= EMULE_NUM_CBS || configured[idx]) {
+            // Loud, not clamped: an index past the ceiling means the host CircularBufferConfig
+            // did not cap at the arch's NUM_CIRCULAR_BUFFERS. Skipping it silently leaves the
+            // CB's sync state uninitialised, which surfaces far away as wrong tile data.
+            TT_FATAL(
+                idx < EMULE_NUM_CBS,
+                "CB index {} exceeds the emulated CB ceiling ({}); the host CircularBufferConfig must cap at the "
+                "arch's NUM_CIRCULAR_BUFFERS.",
+                idx,
+                EMULE_NUM_CBS);
+            if (configured[idx]) {
                 continue;
             }
             uint32_t cb_addr = cb_impl->address();

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -1545,7 +1545,14 @@ static std::map<std::string, std::string> build_kernel_defines(
                 EMULE_NUM_CBS,
                 MetalContext::instance().hal().get_arch_num_circular_buffers());
             const auto& dfb_cfg = dfb_impl->config;
-            tile_sizes[slot] = dfb_cfg.entry_size;
+            // Derived like the CB pass above, not from entry_size: that is the NOC-facing entry
+            // stride, which typecast deliberately aligns, and it belongs to the sync state only.
+            // Invalid format is skipped for the same reason set_dfb_data_fmt_and_tile skips it.
+            if (dfb_cfg.data_format == tt::DataFormat::Invalid) {
+                continue;
+            }
+            tile_sizes[slot] = dfb_cfg.tile.has_value() ? dfb_cfg.tile->get_tile_size(dfb_cfg.data_format)
+                                                        : Tile().get_tile_size(dfb_cfg.data_format);
             cb_formats[slot] = static_cast<uint8_t>(dfb_cfg.data_format);
             if (dfb_cfg.tile.has_value()) {
                 tile_r_dim[slot] = dfb_cfg.tile->get_height();

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -339,22 +339,26 @@ static uint64_t get_pcie_base_cached(uint32_t device_id) {
 extern "C" uint8_t* __emule_resolve_noc_addr(uint64_t noc_addr) {
     emule_require_self(__func__);
 
-    // Host-facing (PCIe) address: SimulationSysmemManager's device_io_addr space starts at
-    // pcie_base_ and shares the same 64-bit range as a real on-chip NOC address, so this branch
-    // must run FIRST, before any noc_x/noc_y/local_addr decomposition below.
+    // Host-facing (PCIe) address: SimulationSysmemManager's device_io_addr space shares the 64-bit
+    // range with on-chip NOC addresses, and pcie_base_ alone cannot separate them — on Wormhole it
+    // is 0x8'0000'0000, below the bit-36 coordinate field, so every on-chip address clears it.
+    // Membership in the mapped-buffer registry is the discriminator; the threshold is a pre-filter.
     uint32_t device_id = __emule_self->chip_id;
     if (noc_addr >= get_pcie_base_cached(device_id)) {
         auto* sw_emu = get_sw_emulated_chip(static_cast<tt::ChipId>(device_id));
         auto* sysmem = sw_emu ? static_cast<tt::umd::SimulationSysmemManager*>(sw_emu->get_sysmem_manager()) : nullptr;
         // A host-facing address (>= pcie_base) is by construction on an emule chip that has a
         // SimulationSysmemManager, so a null manager is a contract violation, not a resolvable miss.
-        // (A buffer miss still returns nullptr below — callers like noc_semaphore_set_remote rely on it.)
         TT_FATAL(
             sysmem != nullptr,
             "emule: host-facing NOC address 0x{:x} on chip {} has no SimulationSysmemManager.",
             noc_addr,
             device_id);
-        return static_cast<uint8_t*>(sysmem->get_mapped_host_ptr(noc_addr));
+        if (auto* host_ptr = static_cast<uint8_t*>(sysmem->get_mapped_host_ptr(noc_addr))) {
+            return host_ptr;
+        }
+        // Registry miss — fall through and decode as on-chip. A genuine host-facing miss finds no
+        // core either and still returns nullptr, which callers like noc_semaphore_set_remote need.
     }
 
     uint32_t noc_x = (noc_addr >> NOC_LOCAL_BITS) & NOC_NODE_MASK;
@@ -651,7 +655,7 @@ struct CoreSetup {
     uint8_t phys_x;
     uint8_t phys_y;
     std::vector<DFBAllocInfo> dfb_allocs;
-    bool has_dfbs = false;
+    bool has_tc_dfbs = false;  // Quasar: DFBs here are tile-counter-backed, not CB-backed
     uint32_t sem_base;
     uint32_t sem_size;
     // Globally-allocated (persistent) CB extents on this core, packed (start<<32|end);
@@ -1535,9 +1539,13 @@ static std::map<std::string, std::string> build_kernel_defines(
         // See tt-emule docs/cb-dataformat.md.
         for (const auto& dfb_impl : impl.dataflow_buffers_on_core(first_core)) {
             const uint32_t slot = dfb_impl->device_slot;
-            if (slot >= EMULE_NUM_CBS) {  // no CB view above the ceiling, so no metadata either
-                continue;
-            }
+            TT_FATAL(
+                slot < EMULE_NUM_CBS,
+                "DFB device slot {} exceeds the emulated CB ceiling ({}); the host assigns slots below the arch's "
+                "NUM_CIRCULAR_BUFFERS ({}).",
+                slot,
+                EMULE_NUM_CBS,
+                MetalContext::instance().hal().get_arch_num_circular_buffers());
             const auto& dfb_cfg = dfb_impl->config;
             tile_sizes[slot] = dfb_cfg.entry_size;
             cb_formats[slot] = static_cast<uint8_t>(dfb_cfg.data_format);
@@ -2936,10 +2944,10 @@ static void init_core_cb_sync(
             const auto& cb_fg = cb_impl->unpack_face_geometry(idx);
             if (cb_fg.has_value()) {
                 cb_face_r_dim = cb_fg->face_r_dim;
-                cb_num_faces  = cb_fg->num_faces;
+                cb_num_faces = cb_fg->num_faces;
             }
-            core->init_cb_sync(idx, base, page_size, num_pages, cb_impl->globally_allocated(),
-                               cb_face_r_dim, cb_num_faces);
+            core->init_cb_sync(
+                idx, base, page_size, num_pages, cb_impl->globally_allocated(), cb_face_r_dim, cb_num_faces);
             configured[idx] = true;
             log_debug(
                 tt::LogMetal,
@@ -2981,25 +2989,29 @@ static void init_core_semaphores(
     }
 }
 
-// Allocate L1 for each DFB on a core, register CB-sync bridges, and initialize
-// tile counters. Returns per-DFB allocation info consumed by launch_cores.
+// Allocate L1 for each DFB on a core, register CB-sync bridges, and — on Quasar —
+// initialize tile counters. Returns per-DFB allocation info consumed by launch_cores.
 static std::vector<DFBAllocInfo> allocate_dfbs_on_core(
     tt_emule::Core* core,
     const CoreCoord& logical_core,
     const std::vector<std::shared_ptr<tt::tt_metal::experimental::dfb::detail::DataflowBufferImpl>>& dfb_impls) {
     core->reset_dfb_sync();
     if (dfb_impls.empty()) {
-        // No DFBs to allocate (always the case on WH/BH; DFBs are Quasar-only),
-        // so the L1 bump allocator never grows and there's nothing to reset.
-        // Skipping reset also leaves the mmap-init zeros at MEM_ZEROS_BASE
-        // undisturbed for kernels that NOC-read the region.
+        // Nothing to allocate, so the L1 bump allocator never grows and there's
+        // nothing to reset. Skipping reset also leaves the mmap-init zeros at
+        // MEM_ZEROS_BASE undisturbed for kernels that NOC-read the region.
         return {};
     }
-    // DFB fallback path (Quasar): start the bump allocator at 0.  When Quasar
-    // bring-up needs to protect MEM_ZEROS from bump-allocator overlap, dispatch
-    // its per-arch MEM_ZEROS_BASE here.
+    // Tile counters are Quasar hardware; on WH/BH a DFB is the circular buffer the
+    // kernel-side DataflowBuffer wraps, so init_cb_sync below is its whole sync state.
+    // Same predicate metal's own finalize_dataflow_buffer_configs() splits on.
+    // See docs/DFB_EMULATION.md §1.
+    const bool tc_backed = MetalContext::instance().hal().has_tile_counter_registers();
+    // DFB fallback path: start the bump allocator at 0.  When Quasar bring-up needs
+    // to protect MEM_ZEROS from bump-allocator overlap, dispatch its per-arch
+    // MEM_ZEROS_BASE here.
     core->reset_l1_bump();
-    if (!core->tile_counters()) {
+    if (tc_backed && !core->tile_counters()) {
         core->init_tile_counters(4);
     }
 
@@ -3044,34 +3056,53 @@ static std::vector<DFBAllocInfo> allocate_dfbs_on_core(
         bool is_all = (cfg.cap == ::dfb::AccessPattern::ALL);
         uint32_t M = is_all ? cfg.num_producers : std::max<uint32_t>(cfg.num_producers, cfg.num_consumers);
         uint32_t capacity = cfg.num_entries / M;
-        core->init_dfb_sync(device_slot, base, cfg.entry_size, cfg.num_entries, capacity);
 
         // Also populate CB sync state for this DFB so compute ops (pack_tile,
         // matmul_tiles) can reuse the same L1 buffer via cb_read_ptr/cb_write_ptr.
+        // On WH/BH this IS the DFB's sync state, and the slot is a CB index — host
+        // assign_dfb_device_slot() picks it below get_arch_num_circular_buffers().
+        TT_FATAL(
+            device_slot < EMULE_NUM_CBS,
+            "DFB device slot {} exceeds the emulated CB ceiling ({}); the host assigns slots below the arch's "
+            "NUM_CIRCULAR_BUFFERS ({}).",
+            device_slot,
+            EMULE_NUM_CBS,
+            MetalContext::instance().hal().get_arch_num_circular_buffers());
         // Same faced-tile geometry carry as the CB pass above, else full-tile 16/4.
-        if (device_slot < EMULE_NUM_CBS) {
-            uint32_t dfb_face_r_dim = 16, dfb_num_faces = 4;
-            if (cfg.unpack_face_geometry.has_value()) {
-                dfb_face_r_dim = cfg.unpack_face_geometry->face_r_dim;
-                dfb_num_faces  = cfg.unpack_face_geometry->num_faces;
-            }
-            core->init_cb_sync(static_cast<uint8_t>(device_slot), base, cfg.entry_size, cfg.num_entries,
-                               /*globally_allocated=*/false, dfb_face_r_dim, dfb_num_faces);
+        uint32_t dfb_face_r_dim = 16, dfb_num_faces = 4;
+        if (cfg.unpack_face_geometry.has_value()) {
+            dfb_face_r_dim = cfg.unpack_face_geometry->face_r_dim;
+            dfb_num_faces = cfg.unpack_face_geometry->num_faces;
         }
+        core->init_cb_sync(
+            static_cast<uint8_t>(device_slot),
+            base,
+            cfg.entry_size,
+            cfg.num_entries,
+            /*globally_allocated=*/false,
+            dfb_face_r_dim,
+            dfb_num_faces);
 
-        // Initialize tile counters for this DFB.
-        // STRIDED: M TCs. ALL DM-DM: P*C TCs. Counter IDs are spaced by
-        // MAX_TC_SLOTS_PER_DFB to prevent cross-DFB collisions.
-        if (device_slot >= (tt_emule::TILE_COUNTERS_PER_NEO / tt_emule::MAX_TC_SLOTS_PER_DFB)) {
-            throw std::out_of_range("DFB device slot exceeds safe TC range (max 8 DFBs per NEO with neo_id=0)");
-        }
-        uint8_t counter_base = static_cast<uint8_t>(device_slot * tt_emule::MAX_TC_SLOTS_PER_DFB);
-        uint32_t num_tcs_to_init = is_all ? static_cast<uint32_t>(cfg.num_producers) * cfg.num_consumers : M;
-        for (uint32_t tc_idx = 0; tc_idx < num_tcs_to_init; ++tc_idx) {
-            auto& tc = core->tile_counters()->get(0, counter_base + static_cast<uint8_t>(tc_idx));
-            tc.capacity = capacity;
-            tc.posted.store(0, std::memory_order_relaxed);
-            tc.acked.store(0, std::memory_order_relaxed);
+        // Quasar tile counters: STRIDED gets M TCs, ALL DM-DM gets P*C. Counter IDs are
+        // spaced by MAX_TC_SLOTS_PER_DFB to prevent cross-DFB collisions. DFBSyncState is
+        // part of the same tile-counter model, so it is populated here too.
+        if (tc_backed) {
+            core->init_dfb_sync(device_slot, base, cfg.entry_size, cfg.num_entries, capacity);
+            if (device_slot >= (tt_emule::TILE_COUNTERS_PER_NEO / tt_emule::MAX_TC_SLOTS_PER_DFB)) {
+                // counter_base below assigns out of NEO 0 only. Lifting this means spreading
+                // DFBs across NEOs and threading neo_id through populate_dfb_interface_slots
+                // and the cb_api CB->DFB bridge.
+                throw std::out_of_range(
+                    "Quasar DFB device slot exceeds safe TC range (max 8 DFBs per NEO with neo_id=0)");
+            }
+            uint8_t counter_base = static_cast<uint8_t>(device_slot * tt_emule::MAX_TC_SLOTS_PER_DFB);
+            uint32_t num_tcs_to_init = is_all ? static_cast<uint32_t>(cfg.num_producers) * cfg.num_consumers : M;
+            for (uint32_t tc_idx = 0; tc_idx < num_tcs_to_init; ++tc_idx) {
+                auto& tc = core->tile_counters()->get(0, counter_base + static_cast<uint8_t>(tc_idx));
+                tc.capacity = capacity;
+                tc.posted.store(0, std::memory_order_relaxed);
+                tc.acked.store(0, std::memory_order_relaxed);
+            }
         }
 
         dfb_allocs.push_back({device_slot, base_addr, &cfg});
@@ -3113,7 +3144,11 @@ static void setup_core_state(
         init_core_semaphores(core, impl, logical_core, emule_sem_base);
 
         auto dfb_impls = impl.dataflow_buffers_on_core(logical_core);
-        bool has_dfbs = !dfb_impls.empty();
+        // Tile-counter and per-thread DFB-interface state is Quasar-only. Leaving both null
+        // on WH/BH keeps the cb_api CB->DFB bridge short-circuited, where a DFB is already
+        // CB-backed (allocate_dfbs_on_core) — and keeps a WH/BH slot, which may run to
+        // get_arch_num_circular_buffers(), from indexing the MAX_DFBS-sized interface array.
+        bool has_tc_dfbs = !dfb_impls.empty() && MetalContext::instance().hal().has_tile_counter_registers();
         std::vector<DFBAllocInfo> dfb_allocs = allocate_dfbs_on_core(core, logical_core, dfb_impls);
 
         uint32_t sem_region_size = tt::tt_metal::NUM_SEMAPHORES * EMULE_SEM_ALIGN;
@@ -3124,7 +3159,7 @@ static void setup_core_state(
              phys_x,
              phys_y,
              std::move(dfb_allocs),
-             has_dfbs,
+             has_tc_dfbs,
              emule_sem_base,
              sem_region_size,
              std::move(persistent_cb_ranges)});
@@ -3531,7 +3566,7 @@ static void launch_cores(
         auto* core = cs.core;
         uint8_t* l1_data = core->l1_data();
         tt_emule::CBSyncState* cb_array = core->cb_sync_array();
-        tt_emule::TileCounterArray* tc_array = cs.has_dfbs ? core->tile_counters() : nullptr;
+        tt_emule::TileCounterArray* tc_array = cs.has_tc_dfbs ? core->tile_counters() : nullptr;
         const uint8_t px = cs.phys_x;
         const uint8_t py = cs.phys_y;
         const uint32_t lx = cs.logical_core.x;
@@ -3543,7 +3578,7 @@ static void launch_cores(
         cstate.logical_y = ly;
 
         std::vector<std::unique_ptr<tt_emule::EmuleDFBInterface[]>> per_thread_dfbs;
-        if (cs.has_dfbs) {
+        if (cs.has_tc_dfbs) {
             per_thread_dfbs = build_per_thread_dfb_interfaces(*cs.ki_list, cs.dfb_allocs);
         }
 
@@ -3569,7 +3604,7 @@ static void launch_cores(
         for (size_t kidx = 0; kidx < cs.ki_list->size(); ++kidx) {
             KernelInfo* ki_ptr = &(*cs.ki_list)[kidx];
             auto& ki = *ki_ptr;
-            tt_emule::EmuleDFBInterface* dfb_array = cs.has_dfbs ? per_thread_dfbs[kidx].get() : nullptr;
+            tt_emule::EmuleDFBInterface* dfb_array = cs.has_tc_dfbs ? per_thread_dfbs[kidx].get() : nullptr;
 
             // Build + populate the fiber-owned ctx (set-once identity). The scheduler
             // repoints __emule_self to this ctx on swap-in; my_x/my_y are restored from

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -339,10 +339,9 @@ static uint64_t get_pcie_base_cached(uint32_t device_id) {
 extern "C" uint8_t* __emule_resolve_noc_addr(uint64_t noc_addr) {
     emule_require_self(__func__);
 
-    // Host-facing (PCIe) address: SimulationSysmemManager's device_io_addr space shares the 64-bit
-    // range with on-chip NOC addresses, and pcie_base_ alone cannot separate them — on Wormhole it
-    // is 0x8'0000'0000, below the bit-36 coordinate field, so every on-chip address clears it.
-    // Membership in the mapped-buffer registry is the discriminator; the threshold is a pre-filter.
+    // pcie_base alone cannot tell host-facing from on-chip: on Wormhole it is 0x8'0000'0000,
+    // below the bit-36 coordinate field, so every on-chip address clears it. Registry
+    // membership is the discriminator; the threshold is only a pre-filter.
     uint32_t device_id = __emule_self->chip_id;
     if (noc_addr >= get_pcie_base_cached(device_id)) {
         auto* sw_emu = get_sw_emulated_chip(static_cast<tt::ChipId>(device_id));
@@ -357,8 +356,8 @@ extern "C" uint8_t* __emule_resolve_noc_addr(uint64_t noc_addr) {
         if (auto* host_ptr = static_cast<uint8_t*>(sysmem->get_mapped_host_ptr(noc_addr))) {
             return host_ptr;
         }
-        // Registry miss — fall through and decode as on-chip. A genuine host-facing miss finds no
-        // core either and still returns nullptr, which callers like noc_semaphore_set_remote need.
+        // Miss: decode as on-chip. A real host-facing miss finds no core either and still
+        // returns nullptr, which noc_semaphore_set_remote relies on.
     }
 
     uint32_t noc_x = (noc_addr >> NOC_LOCAL_BITS) & NOC_NODE_MASK;
@@ -1533,9 +1532,8 @@ static std::map<std::string, std::string> build_kernel_defines(
                 }
             }
         }
-        // A dataflow buffer carries the same LLK-facing entry metadata as a circular buffer, keyed
-        // by the same device slot, so it feeds the same tables — without this a program declaring
-        // DFBs instead of CBs (ttnn::typecast) reports page size 0 to its kernels.
+        // A DFB carries the same entry metadata at the same device slot, so it feeds the same
+        // tables; without this ttnn::typecast reports page size 0 to its kernels.
         // See tt-emule docs/cb-dataformat.md.
         for (const auto& dfb_impl : impl.dataflow_buffers_on_core(first_core)) {
             const uint32_t slot = dfb_impl->device_slot;
@@ -1761,10 +1759,8 @@ static void collect_kernels(
             // them, `SelectByRISCV<>` aliases fail to resolve. Emule runs all RISCs in one unified
             // thread, so we set the corresponding macro based on the kernel's processor class.
             //
-            // PROCESSOR_INDEX — silicon's HAL emits it alongside the COMPILE_FOR_* defines, and
-            // get_hw_thread_idx() returns it, so the debug headers reaching it (waypoint, pause,
-            // assert, device_print) fail to compile without it. Taken from the HAL, not hard-coded,
-            // so it tracks tt-metal.
+            // PROCESSOR_INDEX backs get_hw_thread_idx(), so the debug headers that reach it
+            // (waypoint, pause, assert, device_print) will not compile without it.
             uint32_t processor_type_idx = 0;  // emule fuses TRISC0-2 into one compute fiber
             if (is_tensix) {
                 defines["COMPILE_FOR_TRISC"] = "1";
@@ -2922,9 +2918,8 @@ static void init_core_cb_sync(
     bool configured[EMULE_NUM_CBS] = {};
     auto configure = [&](const std::shared_ptr<CircularBufferImpl>& cb_impl, const CoreCoord& lc) {
         for (uint8_t idx : cb_impl->local_buffer_indices()) {
-            // Loud, not clamped: an index past the ceiling means the host CircularBufferConfig
-            // did not cap at the arch's NUM_CIRCULAR_BUFFERS. Skipping it silently leaves the
-            // CB's sync state uninitialised, which surfaces far away as wrong tile data.
+            // Loud, not clamped: a silent skip leaves the CB's sync state uninitialised, which
+            // resurfaces far away as wrong tile data.
             TT_FATAL(
                 idx < EMULE_NUM_CBS,
                 "CB index {} exceeds the emulated CB ceiling ({}); the host CircularBufferConfig must cap at the "
@@ -3002,10 +2997,9 @@ static std::vector<DFBAllocInfo> allocate_dfbs_on_core(
         // MEM_ZEROS_BASE undisturbed for kernels that NOC-read the region.
         return {};
     }
-    // Tile counters are Quasar hardware; on WH/BH a DFB is the circular buffer the
-    // kernel-side DataflowBuffer wraps, so init_cb_sync below is its whole sync state.
-    // Same predicate metal's own finalize_dataflow_buffer_configs() splits on.
-    // See docs/DFB_EMULATION.md §1.
+    // Tile counters are Quasar hardware. On WH/BH a DFB is the CB the kernel-side
+    // DataflowBuffer wraps, so init_cb_sync below is its whole sync state.
+    // See tt-emule docs/DFB_EMULATION.md §1.
     const bool tc_backed = MetalContext::instance().hal().has_tile_counter_registers();
     // DFB fallback path: start the bump allocator at 0.  When Quasar bring-up needs
     // to protect MEM_ZEROS from bump-allocator overlap, dispatch its per-arch
@@ -3059,8 +3053,7 @@ static std::vector<DFBAllocInfo> allocate_dfbs_on_core(
 
         // Also populate CB sync state for this DFB so compute ops (pack_tile,
         // matmul_tiles) can reuse the same L1 buffer via cb_read_ptr/cb_write_ptr.
-        // On WH/BH this IS the DFB's sync state, and the slot is a CB index — host
-        // assign_dfb_device_slot() picks it below get_arch_num_circular_buffers().
+        // On WH/BH the slot is a CB index, so this IS the DFB's whole sync state.
         TT_FATAL(
             device_slot < EMULE_NUM_CBS,
             "DFB device slot {} exceeds the emulated CB ceiling ({}); the host assigns slots below the arch's "
@@ -3083,15 +3076,13 @@ static std::vector<DFBAllocInfo> allocate_dfbs_on_core(
             dfb_face_r_dim,
             dfb_num_faces);
 
-        // Quasar tile counters: STRIDED gets M TCs, ALL DM-DM gets P*C. Counter IDs are
-        // spaced by MAX_TC_SLOTS_PER_DFB to prevent cross-DFB collisions. DFBSyncState is
-        // part of the same tile-counter model, so it is populated here too.
+        // STRIDED gets M TCs, ALL DM-DM gets P*C, spaced by MAX_TC_SLOTS_PER_DFB so DFBs cannot
+        // collide. DFBSyncState belongs to the same model, so it is populated here too.
         if (tc_backed) {
             core->init_dfb_sync(device_slot, base, cfg.entry_size, cfg.num_entries, capacity);
             if (device_slot >= (tt_emule::TILE_COUNTERS_PER_NEO / tt_emule::MAX_TC_SLOTS_PER_DFB)) {
-                // counter_base below assigns out of NEO 0 only. Lifting this means spreading
-                // DFBs across NEOs and threading neo_id through populate_dfb_interface_slots
-                // and the cb_api CB->DFB bridge.
+                // counter_base assigns out of NEO 0 only. Lifting this means spreading DFBs
+                // across NEOs and threading neo_id through the CB->DFB bridge.
                 throw std::out_of_range(
                     "Quasar DFB device slot exceeds safe TC range (max 8 DFBs per NEO with neo_id=0)");
             }
@@ -3144,10 +3135,8 @@ static void setup_core_state(
         init_core_semaphores(core, impl, logical_core, emule_sem_base);
 
         auto dfb_impls = impl.dataflow_buffers_on_core(logical_core);
-        // Tile-counter and per-thread DFB-interface state is Quasar-only. Leaving both null
-        // on WH/BH keeps the cb_api CB->DFB bridge short-circuited, where a DFB is already
-        // CB-backed (allocate_dfbs_on_core) — and keeps a WH/BH slot, which may run to
-        // get_arch_num_circular_buffers(), from indexing the MAX_DFBS-sized interface array.
+        // Quasar-only. Null on WH/BH keeps the cb_api CB->DFB bridge short-circuited, and stops
+        // a slot legal up to get_arch_num_circular_buffers() indexing the MAX_DFBS-sized array.
         bool has_tc_dfbs = !dfb_impls.empty() && MetalContext::instance().hal().has_tile_counter_registers();
         std::vector<DFBAllocInfo> dfb_allocs = allocate_dfbs_on_core(core, logical_core, dfb_impls);
 

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -286,23 +286,13 @@ extern "C" void __emule_fiber_note_publish(unsigned pages) {
     efib::FiberScheduler::instance().note_publish(pages);
 }
 
-// Worker L1 slot size + mask: a worker's L1 field is a 0-based in-slot offset (< 2 MB), so masking the low
-// bits is an idempotent guard. Applied ONLY for WORKER cores (DRAM banks are GB-scale — see the
-// per-resolver comments). Used by every NOC-address resolver.
-static constexpr uint32_t L1_SLOT_SIZE = 2u * 1024 * 1024;  // 2 MB per worker L1 slot
-static constexpr uint32_t L1_SLOT_MASK = L1_SLOT_SIZE - 1;  // 0x1FFFFF
-
 // Resolve a NOC address (encoded 64-bit) to a host pointer.
 // Real firmware encoding: y in bits [47:42], x in bits [41:36], addr in bits [35:0]
 //
-// The L1_SLOT_MASK is applied ONLY for WORKER cores. Two reasons:
-//  1. Worker L1 fields are 0-based in-slot offsets (from `get_write_ptr()` etc.),
-//     always < 2 MB, so the mask is an idempotent guard on the local field.
-//  2. DRAM banks are GB-scale (2 GB on Wormhole views, 4 GB on Blackhole)
-//     and the kernel-side per-bank addrgen helper produces an `addr` field
-//     that is the true in-bank offset (already includes
-//     `bank_to_dram_offset[bank_index]`). Masking to 2 MB silently aliases
-//     any DRAM access >= 2 MB to an offset within the first 2 MB of the bank.
+// The decoded offset is bounded by the target core's own size, not masked into range: a
+// worker L1 field is a 0-based in-slot offset while a DRAM bank is GB-scale (2 GB on
+// Wormhole views, 4 GB on Blackhole), so no single mask fits both, and an offset that fits
+// neither belongs to no core.
 // Helper: get SWEmuleChip* from MetalContext cluster for a given device_id. (Relocated up from
 // later in this file — needed here for the PCIe branch below, and by the fabric teleport hooks
 // further down.)
@@ -356,8 +346,9 @@ extern "C" uint8_t* __emule_resolve_noc_addr(uint64_t noc_addr) {
         if (auto* host_ptr = static_cast<uint8_t*>(sysmem->get_mapped_host_ptr(noc_addr))) {
             return host_ptr;
         }
-        // Miss: decode as on-chip. A real host-facing miss finds no core either and still
-        // returns nullptr, which noc_semaphore_set_remote relies on.
+        // Miss: decode as on-chip. The bounds check below is what keeps an unmapped
+        // host-window address from landing on a core — it decodes to a real coord (the
+        // window carries no coordinates) but with an offset no core is that big.
     }
 
     uint32_t noc_x = (noc_addr >> NOC_LOCAL_BITS) & NOC_NODE_MASK;
@@ -368,10 +359,13 @@ extern "C" uint8_t* __emule_resolve_noc_addr(uint64_t noc_addr) {
         uint64_t key = (uint64_t(noc_x) << 32) | noc_y;
         auto it = __emule_self->core_map->find(key);
         if (it != __emule_self->core_map->end()) {
-            uint32_t offset = (it->second->role() == tt_emule::CoreRole::WORKER)
-                                  ? (static_cast<uint32_t>(local_addr) & L1_SLOT_MASK)
-                                  : static_cast<uint32_t>(local_addr);
-            return it->second->l1_ptr(offset);
+            // An offset the target cannot hold is not an address on that core, so it is a
+            // resolve miss like any other. Bounding it by the core's own size, rather than
+            // masking it into range, is what keeps a bad address from silently landing on
+            // real memory.
+            if (local_addr < it->second->l1_size()) {
+                return it->second->l1_ptr(local_addr);
+            }
         }
     }
     return nullptr;
@@ -427,11 +421,10 @@ extern "C" void __emule_multicast_write(uint64_t mcast_addr, const uint8_t* src,
     uint32_t y_start = (mcast_addr >> (NOC_LOCAL_BITS + 3 * NOC_NODE_ID_BITS)) & NOC_NODE_MASK;
     uint64_t l1_offset = mcast_addr & NOC_LOCAL_MASK;
 
-    // The L1 offset is a 0-based in-slot offset (< 2 MB, from get_write_ptr() etc.), so masking
-    // with SLOT_MASK is an idempotent guard on the local field.
-    // Multicast targets only WORKER cores (DRAM cores are skipped by the role
-    // check in the delivery loop below), so the mask is L1-correct here.
-    l1_offset &= L1_SLOT_MASK;
+    // Left raw: the offset is a 0-based in-slot L1 offset (get_write_ptr() etc.), and an
+    // out-of-range one is a kernel bug, so Core::l1_ptr's bounds check should surface it
+    // rather than a mask hiding it. Multicast targets only WORKER cores; the delivery loop
+    // below skips the rest.
 
     emule_require_self(__func__);
     if (!__emule_self->core_map) {
@@ -480,7 +473,7 @@ extern "C" void __emule_multicast_write(uint64_t mcast_addr, const uint8_t* src,
             uint64_t key = (uint64_t(x) << 32) | y;
             auto it = __emule_self->core_map->find(key);
             if (it != __emule_self->core_map->end() && it->second->role() == tt_emule::CoreRole::WORKER) {
-                uint8_t* dst = it->second->l1_ptr(static_cast<uint32_t>(l1_offset));
+                uint8_t* dst = it->second->l1_ptr(l1_offset);
                 if (size == sizeof(uint32_t)) {
                     TT_FATAL(
                         reinterpret_cast<uintptr_t>(dst) % alignof(std::atomic<uint32_t>) == 0,
@@ -2328,10 +2321,12 @@ extern "C" uint8_t* __emule_fabric_resolve_remote(uint32_t dst_chip, uint64_t no
         }
         return nullptr;
     }
-    uint32_t offset = (cit->second->role() == tt_emule::CoreRole::WORKER)
-                          ? (static_cast<uint32_t>(local_addr) & L1_SLOT_MASK)
-                          : static_cast<uint32_t>(local_addr);
-    return cit->second->l1_ptr(offset);
+    // Bounded by the target's own size, as in __emule_resolve_noc_addr: an offset it cannot
+    // hold is a miss, not something to mask into range.
+    if (local_addr >= cit->second->l1_size()) {
+        return nullptr;
+    }
+    return cit->second->l1_ptr(local_addr);
 }
 
 // Destination chip for a fabric send from src_chip: the single ethernet-connected neighbor of a

--- a/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
+++ b/tt_metal/impl/emulation/emule_fiber_scheduler.cpp
@@ -138,9 +138,9 @@ struct FiberSchedulerImpl {
     bool persistent_ = false;  // run_persistent/pump in flight: a host-fed socket wait quiescing is
                                // a resumable HostWait, not a tier-1 deadlock. See run_persistent().
     bool host_wait_ = false;   // set by inner_loop when it broke out for host I/O (vs Done/deadlock)
-    unsigned socket_poll_waiters_ = 0;  // fibers TAGGED spin-polling (under mu_). Sticky gate; freshness decides
+    unsigned socket_poll_waiters_ = 0;   // fibers TAGGED spin-polling (under mu_). Sticky gate; freshness decides
     uint64_t poll_wait_staleness_ = 64;  // resumes a tag stays credible unrefreshed; per-fiber, so peers can't age it
-    unsigned cb_poll_waiters_ = 0;  // as socket_poll_waiters_, but for CB probes (peer-fed)
+    unsigned cb_poll_waiters_ = 0;       // as socket_poll_waiters_, but for CB probes (peer-fed)
     std::exception_ptr first_eptr_;
 
     std::atomic<uint64_t> progress_{0};      // fiber completions + published pages (tier 2)


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Brings `main`'s copy of the emule runner up to what the emule fork runs. Nothing builds this
code here — `TT_METAL_USE_EMULE` defaults to `OFF` and there is no emule job — so it drifts
from the fork, where it is the only place it gets compiled and tested, and every fork rebase
has to reconcile the difference by hand. After this, the two hold identical emule sources.

All of it sits in `TT_METAL_USE_EMULE`-gated code or an emule-only branch of a mock predicate,
so a default build is unaffected.

**A dataflow buffer on Wormhole/Blackhole is a circular buffer.** Tile-counter setup is gated
on `hal().has_tile_counter_registers()`, the predicate `finalize_dataflow_buffer_configs()`
already splits on. Those arches have no tile counters, so the previous code applied a Quasar
limit — 8 DFBs per core — to hardware without the feature, and `ttnn::batch_norm` (9 DFBs since
its Metal 2.0 port) could not be allocated. Also closes a latent OOB: Blackhole allows 64 DFB
slots against a `MAX_DFBS` of 32.

**A resolved NOC offset is bounded by the target core's size.** `Core::l1_ptr` already
bounds-checks and takes `uint64_t` so a GB-scale DRAM bank needs no truncation; the resolvers
now pass the offset through unmodified and treat one the target cannot hold as a resolve miss.
Previously a worker offset was masked into a 2 MB slot and a DRAM offset truncated to 32 bits.
That mattered because UMD hands kernels `device_io_addr = pcie_base + arena_offset`, which
carries no NOC coordinates, so an unmapped host-window address decodes to `(0, 0)` — where
Wormhole's soc descriptor has a DRAM core — and the truncation pulled a >32 GB offset into
range and returned a valid pointer instead of `nullptr`. Applies to
`__emule_resolve_noc_addr` and `__emule_fabric_resolve_remote`;
`__emule_multicast_write` likewise passes its offset through, so `l1_ptr` surfaces a bad one.

**Wormhole on-chip NOC addresses resolve.** Mapped-buffer registry membership is the
host-facing discriminator, with `noc_addr >= pcie_base` kept only as a pre-filter. The bare
threshold only works when `pcie_base` sits above the NOC-encoded range; on Wormhole it is
`0x8'0000'0000`, *below* the bit-36 coordinate field, so every on-chip address took the host
path, missed the registry and returned `nullptr`. Callers guard with `if (ptr)`, so transfers
were silently skipped and kernels read stale L1 — wrong data, no crash, on every Wormhole test
moving data over the NOC.

**DFB entry metadata and `PROCESSOR_INDEX`.** `build_kernel_defines` walks
`dataflow_buffers_on_core` and derives tile metadata from `data_format` + `tile`, skipping
`DataFormat::Invalid` slots, matching `ProgramImpl::set_dfb_data_fmt_and_tile`; `entry_size` is
the NOC-facing stride and stays in the sync state. Without the walk a program declaring DFBs
instead of CBs (`ttnn::typecast`) reported page size 0 to its kernels. `PROCESSOR_INDEX` backs
`get_hw_thread_idx()`, which the debug headers need to compile. Two silent `EMULE_NUM_CBS`
skips are `TT_FATAL`s.

**`PinnedMemory`'s no-mapping path is `Mock`-only.** `SWEmuleChip` has a real
`SimulationSysmemManager`, so dummy addresses stranded the host-facing socket counters an
emulated kernel writes back. Same narrowing already at `distributed.cpp:121-125`.

Four commits are comment or whitespace only.

### Notes for reviewers

**tt-metal CI cannot exercise any of this** — it builds with `TT_METAL_USE_EMULE=OFF`, so these
files are not compiled here and a break would merge silently. The evidence is emule-side, on a
build of this branch's exact file content:

| Check | Result |
|---|---|
| Blackhole ttnn PR gate set (48 entries incl. typecast, batch_norm, topk) | 48 pass, 0 fail |
| C++ regression: wormhole / quasar / blackhole | 39/0, 73/0, 20/0 |
| `Core::l1_ptr` OOB aborts across every log | none |
| Compile + link, `TT_METAL_USE_EMULE=ON` | clean |
| tt-emule-blaze CI at this content (17 checks: both builds, p150 + loudbox blaze gates, TTNN smoke, bh_galaxy) | green |

The fork carries byte-identical files and its divergence from `main` is patch-id-identical to
this diff, so those results apply directly here. Companion PR:
tenstorrent/tt-emule-blaze#315

Worth a look:

- The zero OOB-abort count is the load-bearing evidence for the bounds change. Removing the
  mask and the truncation means a previously-silent wrap now trips `Core::l1_ptr`'s existing
  loud check, and nothing in ttnn or three arches of C++ tripped it.
- Per-CB face geometry (#52742) now reaches emule's `CBSyncState`, which `pack_untilize` reads
  — the fork had never populated it, so it ran the full-tile 16/4 default throughout.
- `main`'s removal of the pass-2 global CB fill (#52726) is adopted; all three `topk` entries,
  the path it existed for, pass.
- Checking whether an address maps to a PCIe core is not possible against what UMD supplies,
  since `device_io_addr` carries no coordinates. Encoding the PCIe tile's coordinates, or
  giving `SimulationSysmemManager` a simulation-only `pcie_base` above the NOC range (which
  would also fix Quasar's `default: return 0`), are tt-umd changes and are not here.

