### PR TITLE
sampling: salt device seeds of concurrent requests sharing one request seed

### DIFF
--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -36,7 +36,7 @@ def _mark_trace_buffers_corruptible(bucket, value):
         mark_corruptible(value)
 
 
-def _hash_request_seed_to_device_seed(seed: int, counter: int) -> int:
+def _hash_request_seed_to_device_seed(seed: int, counter: int, salt: int = 0) -> int:
     """Derive a stable per-token device seed from a request seed.
 
     The device sampling op accepts bounded positive seeds, while vLLM
@@ -44,8 +44,15 @@ def _hash_request_seed_to_device_seed(seed: int, counter: int) -> int:
     of batch slot. Hashing (request seed, token counter) gives each token
     a deterministic but well-mixed device seed without relying on mutable
     per-slot RNG state. The constants below are the SplitMix64 finalizer.
+
+    ``salt`` separates concurrent requests that carry the same request seed
+    (e.g. n>1 completions of one prompt with a fixed seed): without it every
+    such request derives the identical device seed at the identical token
+    position and the completions come out byte-identical (#53077). A request
+    with a unique seed always has salt 0, so its stream is unchanged.
     """
     value = (int(seed) & _UINT64_MASK) ^ ((int(counter) + 0x9E3779B97F4A7C15) & _UINT64_MASK)
+    value ^= (int(salt) * 0xD1B54A32D192ED03) & _UINT64_MASK
     value = ((value ^ (value >> 30)) * 0xBF58476D1CE4E5B9) & _UINT64_MASK
     value = ((value ^ (value >> 27)) * 0x94D049BB133111EB) & _UINT64_MASK
     value = (value ^ (value >> 31)) & _UINT64_MASK
@@ -680,6 +687,11 @@ class SeedManager:
         self.max_batch_size = max_batch_size
         self.seeds = [None for _ in range(max_batch_size)]
         self.seed_counters = [0 for _ in range(max_batch_size)]
+        # Disambiguates concurrent slots that carry the SAME explicit request
+        # seed (n>1 completions of one prompt with a fixed seed). A slot whose
+        # seed is unique among active slots always has salt 0, preserving the
+        # slot-independent reproducibility of single-sample seeded requests.
+        self.seed_salts = [0 for _ in range(max_batch_size)]
         # Pre-allocate RNG objects; actual request seeds are set via reset_seed().
         self.rngs = [random.Random(secrets.randbits(64)) for _ in range(max_batch_size)]
         self.tt_sampling = tt_sampling
@@ -717,9 +729,29 @@ class SeedManager:
         request_seed = self.seeds[slot]
         if request_seed is None:
             return self._next_device_seed_from_rng(self.rngs[slot])
-        device_seed = _hash_request_seed_to_device_seed(int(request_seed), self.seed_counters[slot])
+        device_seed = _hash_request_seed_to_device_seed(
+            int(request_seed), self.seed_counters[slot], self.seed_salts[slot]
+        )
         self.seed_counters[slot] += 1
         return device_seed
+
+    def _next_free_salt(self, slot: int, seed: int) -> int:
+        """Smallest salt not used by another active slot holding the same request seed.
+
+        The first slot to carry a given seed gets salt 0 (identical stream to
+        today), the second gets 1, and so on. Using the smallest free value --
+        rather than a running count -- avoids re-colliding with a surviving
+        duplicate after an earlier one finished and vacated its slot.
+        """
+        taken = {
+            self.seed_salts[other]
+            for other in range(self.max_batch_size)
+            if other != slot and self.seeds[other] == seed
+        }
+        salt = 0
+        while salt in taken:
+            salt += 1
+        return salt
 
     def _seed_from_slot_params(self, seeds, slot: int):
         if seeds is None:
@@ -754,8 +786,10 @@ class SeedManager:
             self.seeds[slot] = seed
             self.seed_counters[slot] = 0
             if seed is None:
+                self.seed_salts[slot] = 0
                 self.rngs[slot].seed(self._next_unseeded_rng_seed())
             else:
+                self.seed_salts[slot] = self._next_free_salt(slot, seed)
                 self.rngs[slot].seed(int(seed))
         self._seed_active = any(s is not None for s in self.seeds)
         self._reseted = True
@@ -836,12 +870,15 @@ class SeedManager:
         # Snapshot the state we're about to overwrite.
         old_seeds = list(self.seeds)
         old_counters = list(self.seed_counters)
+        old_salts = list(self.seed_salts)
         old_rngs = list(self.rngs)
         moved_sources = {old_slot for old_slot, _ in moves}
         moved_destinations = {new_slot for _, new_slot in moves}
         for old_slot, new_slot in moves:
             self.seeds[new_slot] = old_seeds[old_slot]
             self.seed_counters[new_slot] = old_counters[old_slot]
+            # The salt travels with the request so its stream survives the move.
+            self.seed_salts[new_slot] = old_salts[old_slot]
             # copy.copy preserves internal RNG state but creates an
             # independent object so the old slot reference does not alias
             # the new one.
@@ -851,6 +888,7 @@ class SeedManager:
         for old_slot in moved_sources - moved_destinations:
             self.seeds[old_slot] = None
             self.seed_counters[old_slot] = 0
+            self.seed_salts[old_slot] = 0
         self._seed_active = any(s is not None for s in self.seeds)
 
     def reset_seed(self, seeds, user_ids):
@@ -868,8 +906,10 @@ class SeedManager:
             self.seeds[slot] = seed
             self.seed_counters[slot] = 0
             if seed is None:
+                self.seed_salts[slot] = 0
                 self.rngs[slot].seed(self._next_unseeded_rng_seed())
             else:
+                self.seed_salts[slot] = self._next_free_salt(slot, seed)
                 self.rngs[slot].seed(int(seed))
         self._seed_active = any(s is not None for s in self.seeds)
         self._reseted = True

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -166,6 +166,62 @@ def test_slot_remap_identity_is_a_noop():
     assert seed_manager._seed_active is True
 
 
+def test_duplicate_request_seeds_get_distinct_device_streams():
+    """Concurrent slots sharing one request seed must not draw identical streams.
+
+    Regression test for #53077: n>1 completions of one prompt with a fixed seed
+    land in different slots with the same request seed, and the device seed was
+    derived from (seed, position) only, so every completion came out identical.
+    """
+    seed_manager = _make_host_only_seed_manager(max_batch_size=4)
+    seed_manager.reset_seed([1234, 1234, 1234, 1234], [0, 1, 2, 3])
+
+    assert sorted(seed_manager.seed_salts) == [0, 1, 2, 3]
+    first_draws = [seed_manager._next_device_seed_for_slot(slot) for slot in range(4)]
+    assert len(set(first_draws)) == 4, f"duplicate-seed slots drew identical device seeds: {first_draws}"
+
+
+def test_unique_seed_stream_is_unchanged_and_slot_independent():
+    """A request whose seed is unique among active slots keeps salt 0, so its
+    stream matches the pre-salt derivation and does not depend on the slot."""
+    manager_a = _make_host_only_seed_manager(max_batch_size=4)
+    manager_a.reset_seed([777], [0])
+    manager_b = _make_host_only_seed_manager(max_batch_size=4)
+    manager_b.reset_seed([777], [3])
+
+    draws_a = [manager_a._next_device_seed_for_slot(0) for _ in range(4)]
+    draws_b = [manager_b._next_device_seed_for_slot(3) for _ in range(4)]
+
+    assert manager_a.seed_salts[0] == 0
+    assert draws_a == draws_b
+
+
+def test_seed_salt_travels_with_slot_remap():
+    seed_manager = _make_host_only_seed_manager(max_batch_size=4)
+    seed_manager.reset_seed([55, 55], [0, 3])  # duplicates: slot0 salt 0, slot3 salt 1
+    assert seed_manager.seed_salts[3] == 1
+
+    # Condense: slot3's request moves into empty slot1.
+    seed_manager.apply_slot_remap(torch.tensor([0, 3, 2, 3], dtype=torch.int32))
+
+    assert seed_manager.seed_salts[1] == 1  # stream identity survives the move
+    assert seed_manager.seed_salts[3] == 0  # vacated slot cleared
+
+
+def test_seed_salt_does_not_recollide_with_surviving_duplicate():
+    seed_manager = _make_host_only_seed_manager(max_batch_size=4)
+    seed_manager.reset_seed([55, 55], [0, 1])  # slot0 salt 0, slot1 salt 1
+    # Slot 0 finishes and is vacated; a new request with the same seed arrives.
+    seed_manager.apply_slot_remap(torch.tensor([1, 1, 2, 3], dtype=torch.int32))
+    assert seed_manager.seeds == [55, None, None, None]
+
+    seed_manager.reset_seed([55], [2])
+
+    # The newcomer must not reuse the surviving request's salt.
+    survivor_slot = 0
+    assert seed_manager.seed_salts[2] != seed_manager.seed_salts[survivor_slot]
+
+
 def test_broadcast_sampling_params_preserves_none_list_fields():
     params = SamplingParams(temperature=[1.0, 1.0], top_k=[1, 1], top_p=[1.0, 1.0], seed=[None, 42])
 


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fixes #53077 (near-identical completions across generations at high temperature).

**Root cause**: on-device sampling derives each token's device seed as `hash(request_seed, token_position)` — deliberately slot-independent so a seeded request reproduces regardless of batch layout. But n>1 completions of one prompt with a fixed seed (the GRPO rollout pattern) occupy several slots with the *same* request seed, derive identical device seeds at identical token positions, and therefore sample byte-identical continuations. Temperature is irrelevant — the streams are equal by construction. (The `replicate_seeds` broadcast flagged in the issue thread is repaired by the next decode-step seed push and is not the mechanism.)

**Fix**: give each slot a seed salt — the smallest value not used by any other active slot holding the same request seed — folded into the SplitMix64 derivation:

- A request whose seed is **unique** among active slots always gets salt 0, making the derivation **bit-identical to today** — single-sample seeded reproducibility and slot independence are fully preserved.
- Duplicate-seed slots get salts 1, 2, … and draw well-separated streams, so n completions with one seed now differ (deterministically, given admission order).
- The salt travels with the request through batch condense (`apply_slot_remap`) so its stream survives slot moves, and smallest-free assignment prevents a newcomer re-colliding with a surviving duplicate after an earlier one vacated its slot.

### Testing

Four new host-only `SeedManager` unit tests in `models/common/tests/test_sampling.py` (duplicate seeds draw distinct device seeds; unique-seed stream unchanged and slot-independent; salt survives remap; no re-collision after vacate). Host-only — no device needed; runs in the T3K tttv2 pipeline that covers this file.

**Draft**: needs a hardware run of the #53077 repro (llama-3.2-1b, 16 completions, temperature=1.5, fixed seed) to confirm end-to-end.

### Design note for reviewers

Deterministic replay for duplicate-seed requests now depends on admission order (k-th duplicate gets salt k). The previous behavior — all duplicates byte-identical — provided determinism nobody could use. If a stronger contract is wanted (e.g. vLLM passing a per-sequence sample index), the salt is the natural place to plumb it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/sampling-duplicate-seed-salt)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/sampling-duplicate-seed-salt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/sampling-duplicate-seed-salt)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/sampling-duplicate-seed-salt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/sampling-duplicate-seed-salt)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/sampling-duplicate-seed-salt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/sampling-duplicate-seed-salt)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/sampling-duplicate-seed-salt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/sampling-duplicate-seed-salt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/sampling-duplicate-seed-salt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/sampling-duplicate-seed-salt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/sampling-duplicate-seed-salt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/sampling-duplicate-seed-salt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/sampling-duplicate-seed-salt)