### PR TITLE
sampling: adaptive single-device vocab splits and per-request seed salting

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -338,7 +338,8 @@ models:
     wh_galaxy_perf: 55
     wh_n150: 100
     wh_n300: 60
-    bh_p150: 7
+    # +35 for the Qwen3-0.6B (15) and Qwen3-1.7B (20) P150 entries in models_e2e_tests.yaml.
+    bh_p150: 42
     bh_p300: 8
     bh_quietbox_2: 42
   unit:

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -336,9 +336,9 @@ models:
   e2e_tier3:
     wh_llmbox_perf: 180
     wh_galaxy_perf: 55
-    wh_n150: 81
+    wh_n150: 91
     wh_n300: 60
-    bh_p150: 23
+    bh_p150: 33
     bh_p300: 8
     bh_quietbox_2: 42
   unit:

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -336,9 +336,9 @@ models:
   e2e_tier3:
     wh_llmbox_perf: 180
     wh_galaxy_perf: 55
-    wh_n150: 87
+    wh_n150: 81
     wh_n300: 60
-    bh_p150: 29
+    bh_p150: 23
     bh_p300: 8
     bh_quietbox_2: 42
   unit:

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -338,7 +338,6 @@ models:
     wh_galaxy_perf: 55
     wh_n150: 100
     wh_n300: 60
-    # +35 for the Qwen3-0.6B (15) and Qwen3-1.7B (20) P150 entries in models_e2e_tests.yaml.
     bh_p150: 42
     bh_p300: 8
     bh_quietbox_2: 42

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -336,9 +336,9 @@ models:
   e2e_tier3:
     wh_llmbox_perf: 180
     wh_galaxy_perf: 55
-    wh_n150: 100
+    wh_n150: 87
     wh_n300: 60
-    bh_p150: 42
+    bh_p150: 29
     bh_p300: 8
     bh_quietbox_2: 42
   unit:

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -336,7 +336,7 @@ models:
   e2e_tier3:
     wh_llmbox_perf: 180
     wh_galaxy_perf: 55
-    wh_n150: 65
+    wh_n150: 100
     wh_n300: 60
     bh_p150: 7
     bh_p300: 8

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -366,9 +366,9 @@ models:
     wh_llmbox: 90
     wh_galaxy: 80
     wh_llmbox_perf: 58
-    wh_n150: 41
+    wh_n150: 51
     wh_n300: 33
-    bh_p150: 20
+    bh_p150: 30
     bh_p300: 30
     bh_quietbox_2: 21
   integration:

--- a/.github/workflows/models-t3-e2e-tests.yaml
+++ b/.github/workflows/models-t3-e2e-tests.yaml
@@ -21,6 +21,8 @@ on:
           - qwen2.5-7b
           # qwen2.5-72b: disabled — ci-token-matching hanging on CI
           - qwen2.5-vl-32b
+          - qwen3-0.6b
+          - qwen3-1.7b
           - qwq-32b
           - phi-3-mini
           # phi-4-mini: disabled — assert freqs.shape[-1] == ext_factors.shape[-1]

--- a/.github/workflows/models-t3-unit-tests.yaml
+++ b/.github/workflows/models-t3-unit-tests.yaml
@@ -36,7 +36,7 @@ on:
           - sd35
           - mochi
           - bert-large
-          - tt-sampling
+          - tt-model-sampling
       sku:
         description: "Select SKU to test (not all models are configured for all SKUs. If a combination is non-existent no test will be run)"
         required: false

--- a/.github/workflows/models-t3-unit-tests.yaml
+++ b/.github/workflows/models-t3-unit-tests.yaml
@@ -36,6 +36,7 @@ on:
           - sd35
           - mochi
           - bert-large
+          - tt-sampling
       sku:
         description: "Select SKU to test (not all models are configured for all SKUs. If a combination is non-existent no test will be run)"
         required: false

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -36,7 +36,7 @@ def _mark_trace_buffers_corruptible(bucket, value):
         mark_corruptible(value)
 
 
-def _hash_request_seed_to_device_seed(seed: int, counter: int) -> int:
+def _hash_request_seed_to_device_seed(seed: int, counter: int, salt: int = 0) -> int:
     """Derive a stable per-token device seed from a request seed.
 
     The device sampling op accepts bounded positive seeds, while vLLM
@@ -44,8 +44,15 @@ def _hash_request_seed_to_device_seed(seed: int, counter: int) -> int:
     of batch slot. Hashing (request seed, token counter) gives each token
     a deterministic but well-mixed device seed without relying on mutable
     per-slot RNG state. The constants below are the SplitMix64 finalizer.
+
+    ``salt`` separates concurrent requests that carry the same request seed
+    (e.g. n>1 completions of one prompt with a fixed seed): without it every
+    such request derives the identical device seed at the identical token
+    position and the completions come out byte-identical (#53077). A request
+    with a unique seed always has salt 0, so its stream is unchanged.
     """
     value = (int(seed) & _UINT64_MASK) ^ ((int(counter) + 0x9E3779B97F4A7C15) & _UINT64_MASK)
+    value ^= (int(salt) * 0xD1B54A32D192ED03) & _UINT64_MASK
     value = ((value ^ (value >> 30)) * 0xBF58476D1CE4E5B9) & _UINT64_MASK
     value = ((value ^ (value >> 27)) * 0x94D049BB133111EB) & _UINT64_MASK
     value = (value ^ (value >> 31)) & _UINT64_MASK
@@ -680,6 +687,11 @@ class SeedManager:
         self.max_batch_size = max_batch_size
         self.seeds = [None for _ in range(max_batch_size)]
         self.seed_counters = [0 for _ in range(max_batch_size)]
+        # Disambiguates concurrent slots that carry the SAME explicit request
+        # seed (n>1 completions of one prompt with a fixed seed). A slot whose
+        # seed is unique among active slots always has salt 0, preserving the
+        # slot-independent reproducibility of single-sample seeded requests.
+        self.seed_salts = [0 for _ in range(max_batch_size)]
         # Pre-allocate RNG objects; actual request seeds are set via reset_seed().
         self.rngs = [random.Random(secrets.randbits(64)) for _ in range(max_batch_size)]
         self.tt_sampling = tt_sampling
@@ -717,9 +729,29 @@ class SeedManager:
         request_seed = self.seeds[slot]
         if request_seed is None:
             return self._next_device_seed_from_rng(self.rngs[slot])
-        device_seed = _hash_request_seed_to_device_seed(int(request_seed), self.seed_counters[slot])
+        device_seed = _hash_request_seed_to_device_seed(
+            int(request_seed), self.seed_counters[slot], self.seed_salts[slot]
+        )
         self.seed_counters[slot] += 1
         return device_seed
+
+    def _next_free_salt(self, slot: int, seed: int) -> int:
+        """Smallest salt not used by another active slot holding the same request seed.
+
+        The first slot to carry a given seed gets salt 0 (identical stream to
+        today), the second gets 1, and so on. Using the smallest free value --
+        rather than a running count -- avoids re-colliding with a surviving
+        duplicate after an earlier one finished and vacated its slot.
+        """
+        taken = {
+            self.seed_salts[other]
+            for other in range(self.max_batch_size)
+            if other != slot and self.seeds[other] == seed
+        }
+        salt = 0
+        while salt in taken:
+            salt += 1
+        return salt
 
     def _seed_from_slot_params(self, seeds, slot: int):
         if seeds is None:
@@ -754,8 +786,10 @@ class SeedManager:
             self.seeds[slot] = seed
             self.seed_counters[slot] = 0
             if seed is None:
+                self.seed_salts[slot] = 0
                 self.rngs[slot].seed(self._next_unseeded_rng_seed())
             else:
+                self.seed_salts[slot] = self._next_free_salt(slot, seed)
                 self.rngs[slot].seed(int(seed))
         self._seed_active = any(s is not None for s in self.seeds)
         self._reseted = True
@@ -836,12 +870,15 @@ class SeedManager:
         # Snapshot the state we're about to overwrite.
         old_seeds = list(self.seeds)
         old_counters = list(self.seed_counters)
+        old_salts = list(self.seed_salts)
         old_rngs = list(self.rngs)
         moved_sources = {old_slot for old_slot, _ in moves}
         moved_destinations = {new_slot for _, new_slot in moves}
         for old_slot, new_slot in moves:
             self.seeds[new_slot] = old_seeds[old_slot]
             self.seed_counters[new_slot] = old_counters[old_slot]
+            # The salt travels with the request so its stream survives the move.
+            self.seed_salts[new_slot] = old_salts[old_slot]
             # copy.copy preserves internal RNG state but creates an
             # independent object so the old slot reference does not alias
             # the new one.
@@ -851,6 +888,7 @@ class SeedManager:
         for old_slot in moved_sources - moved_destinations:
             self.seeds[old_slot] = None
             self.seed_counters[old_slot] = 0
+            self.seed_salts[old_slot] = 0
         self._seed_active = any(s is not None for s in self.seeds)
 
     def reset_seed(self, seeds, user_ids):
@@ -868,8 +906,10 @@ class SeedManager:
             self.seeds[slot] = seed
             self.seed_counters[slot] = 0
             if seed is None:
+                self.seed_salts[slot] = 0
                 self.rngs[slot].seed(self._next_unseeded_rng_seed())
             else:
+                self.seed_salts[slot] = self._next_free_salt(slot, seed)
                 self.rngs[slot].seed(int(seed))
         self._seed_active = any(s is not None for s in self.seeds)
         self._reseted = True

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -795,6 +795,12 @@ class SeedManager:
                 self.seed_counters[slot] = 0
                 self.seed_salts[slot] = 0
         self._seed_active = any(s is not None for s in self.seeds)
+        if not self._seed_active:
+            # Re-enter the unseeded three-state machine. The device still holds
+            # the seeded path's non-SKIP reinit values; without a fresh init+SKIP
+            # push, get_new_values early-returns and the device reinitializes
+            # every user's PRNG to the same stale seed on every token.
+            self._reseted = True
 
     def _seed_from_slot_params(self, seeds, slot: int):
         if seeds is None:
@@ -926,6 +932,10 @@ class SeedManager:
             self.seed_counters[old_slot] = 0
             self.seed_salts[old_slot] = 0
         self._seed_active = any(s is not None for s in self.seeds)
+        if not self._seed_active:
+            # Same re-arm as deactivate_slots_except: a remap that overwrites the
+            # last seeded slot must push init+SKIP or the device PRNG freezes.
+            self._reseted = True
 
     def reset_seed(self, seeds, user_ids):
         """Update RNG state for the given user slots after a prefill.

--- a/models/common/sampling/generator.py
+++ b/models/common/sampling/generator.py
@@ -753,6 +753,49 @@ class SeedManager:
             salt += 1
         return salt
 
+    def _set_slot_seed(self, slot: int, seed, *, keep_existing_salt: bool):
+        """Single writer for a slot's (seed, counter, salt, rng) state.
+
+        With ``keep_existing_salt`` (decode-path re-registration of a running
+        request), a slot that already holds the same request seed is left
+        untouched: salts are collision-free among live same-seed slots by
+        construction, and recomputing one mid-generation (the unconditional
+        re-registration on the first decode after any admission) would splice
+        the request onto a finished sibling's RNG stream. Without it (prefill
+        admission of a new request) the slot is fully reset, including a fresh
+        smallest-free salt, so a unique-seed request always lands on salt 0.
+        """
+        if keep_existing_salt and seed is not None and self.seeds[slot] == seed:
+            return
+        self.seeds[slot] = seed
+        self.seed_counters[slot] = 0
+        if seed is None:
+            self.seed_salts[slot] = 0
+            self.rngs[slot].seed(self._next_unseeded_rng_seed())
+        else:
+            self.seed_salts[slot] = self._next_free_salt(slot, seed)
+            self.rngs[slot].seed(int(seed))
+
+    def deactivate_slots_except(self, live_slots) -> None:
+        """Drop seed state of slots that are no longer live.
+
+        Nothing else clears a finished request's slot when condense has no
+        move to make (a request finishing at the tail of the batch leaves its
+        seed behind), so the ghost would keep counting toward _next_free_salt
+        and hand a later unique-seed request a salt > 0, breaking seeded
+        reproducibility. Callers pass the current live-slot set (decode
+        positions >= 0).
+        """
+        if not self._seed_active:
+            return
+        live = {int(slot) for slot in live_slots}
+        for slot in range(self.max_batch_size):
+            if slot not in live and self.seeds[slot] is not None:
+                self.seeds[slot] = None
+                self.seed_counters[slot] = 0
+                self.seed_salts[slot] = 0
+        self._seed_active = any(s is not None for s in self.seeds)
+
     def _seed_from_slot_params(self, seeds, slot: int):
         if seeds is None:
             return None
@@ -783,14 +826,7 @@ class SeedManager:
         for user in user_ids:
             slot = int(user)
             seed = self._seed_from_slot_params(seeds, slot)
-            self.seeds[slot] = seed
-            self.seed_counters[slot] = 0
-            if seed is None:
-                self.seed_salts[slot] = 0
-                self.rngs[slot].seed(self._next_unseeded_rng_seed())
-            else:
-                self.seed_salts[slot] = self._next_free_salt(slot, seed)
-                self.rngs[slot].seed(int(seed))
+            self._set_slot_seed(slot, seed, keep_existing_salt=True)
         self._seed_active = any(s is not None for s in self.seeds)
         self._reseted = True
 
@@ -903,14 +939,7 @@ class SeedManager:
         for i, user in enumerate(user_ids):
             slot = int(user)
             seed = self._seed_from_slot_params(seeds, i)
-            self.seeds[slot] = seed
-            self.seed_counters[slot] = 0
-            if seed is None:
-                self.seed_salts[slot] = 0
-                self.rngs[slot].seed(self._next_unseeded_rng_seed())
-            else:
-                self.seed_salts[slot] = self._next_free_salt(slot, seed)
-                self.rngs[slot].seed(int(seed))
+            self._set_slot_seed(slot, seed, keep_existing_salt=False)
         self._seed_active = any(s is not None for s in self.seeds)
         self._reseted = True
 

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -133,6 +133,20 @@ class TTSampling(LightweightModule):
         padded_vocab_size = getattr(args, "padded_vocab_size", None)
         self.padded_vocab_size = padded_vocab_size if padded_vocab_size is not None else args.vocab_size
         self.vocab_size = args.vocab_size
+
+        # Single-device top-k runs the vocab in same-device chunks (multi-step reduction).
+        # ttnn.topk handles at most 64K elements per call, so use the fewest power-of-two
+        # chunks whose width fits: two chunks preserve the historical behavior for every
+        # vocab up to 128K, and larger vocabs (e.g. Qwen3's 151936) get four (#53064).
+        self._num_vocab_splits = 2
+        if self.multi_step_reduction:
+            while self.padded_vocab_size // self._num_vocab_splits > 64 * 1024:
+                self._num_vocab_splits *= 2
+            chunk_width = self.padded_vocab_size // self._num_vocab_splits
+            assert self.padded_vocab_size % self._num_vocab_splits == 0 and chunk_width % 32 == 0, (
+                f"padded_vocab_size={self.padded_vocab_size} cannot be cut into "
+                f"{self._num_vocab_splits} tile-aligned single-device top-k chunks"
+            )
         # Round up to the next tile boundary (32) — device tensors must be tile-aligned.
         raw_batch = getattr(args, "max_batch_size", 32)
         self.max_batch_size = max(32, ((raw_batch + 31) // 32) * 32)
@@ -291,7 +305,7 @@ class TTSampling(LightweightModule):
 
     def _get_num_sampling_shards(self):
         if self.multi_step_reduction:
-            return 2
+            return self._num_vocab_splits
         if 1 in self.cluster_shape:
             return max(self.cluster_shape[0], self.cluster_shape[1])
 
@@ -755,11 +769,23 @@ class TTSampling(LightweightModule):
         x_bf16 = self._mask_invalid_vocab_logits(x_bf16)
 
         if self.multi_step_reduction:
-            x_bf16_list = ttnn.split(x_bf16, x_bf16.shape[-1] // 2, dim=3)
+            x_bf16_list = ttnn.split(x_bf16, x_bf16.shape[-1] // self._num_vocab_splits, dim=3)
             topk_values_list = []
             topk_indices_list = []
 
             for i in range(len(x_bf16_list)):
+                # Pad a non-power-of-2 chunk so ttnn.topk hits the multi-core factory.
+                # Padded slots hold -inf and can never be selected; the post-concat
+                # per-chunk offsets use the unpadded chunk width, so real indices are
+                # unaffected.
+                if self.pad_to_power_of_2 and not is_power_of_2(x_bf16_list[i].shape[-1]):
+                    padded_value = upper_power_of_2(x_bf16_list[i].shape[-1])
+                    x_bf16_list[i] = ttnn.pad(
+                        x_bf16_list[i],
+                        [(0, 0), (0, 0), (0, 0), (0, padded_value - x_bf16_list[i].shape[-1])],
+                        value=-sys.float_info.max,
+                        sub_core_grids=self.sub_core_grids,
+                    )
                 topk_values, topk_indices = ttnn.topk(
                     x_bf16_list[i],
                     k=self.max_top_k,

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -35,6 +35,9 @@ TIEBREAK_DELTA_FLOOR = 1e-30
 # that sentinel + index cannot overflow the int32 the min reduce runs in.
 TIEBREAK_INDEX_SENTINEL = 2**24
 
+# Widest input ttnn.topk accepts in one call; vocabs beyond it must be cut into chunks.
+TOPK_MAX_WIDTH = 64 * 1024
+
 
 class TTSampling(LightweightModule):
     """
@@ -68,6 +71,21 @@ class TTSampling(LightweightModule):
         Uses persistent buffers when CCL supports line_all_gather (llama3_70b_galaxy),
         otherwise uses standard all_gather where the CCL API handles memory allocation (tt-transformers).
     """
+
+    @classmethod
+    def num_single_device_vocab_splits(cls, padded_vocab_size):
+        """Fewest power-of-two same-device chunks whose width fits ttnn.topk.
+
+        Returns None when no tile-aligned cut exists, in which case the caller
+        must fall back to host sampling instead of constructing TTSampling.
+        """
+        num_splits = 2
+        while padded_vocab_size // num_splits > TOPK_MAX_WIDTH:
+            num_splits *= 2
+        chunk_width = padded_vocab_size // num_splits
+        if padded_vocab_size % num_splits != 0 or chunk_width % ttnn.TILE_SIZE != 0:
+            return None
+        return num_splits
 
     def _is_force_argmax_sampling(self, k, p, temp):
         """Detect whether all users request deterministic greedy decoding.
@@ -135,18 +153,21 @@ class TTSampling(LightweightModule):
         self.vocab_size = args.vocab_size
 
         # Single-device top-k runs the vocab in same-device chunks (multi-step reduction).
-        # ttnn.topk handles at most 64K elements per call, so use the fewest power-of-two
-        # chunks whose width fits: two chunks preserve the historical behavior for every
-        # vocab up to 128K, and larger vocabs (e.g. Qwen3's 151936) get four (#53064).
+        # ttnn.topk handles at most TOPK_MAX_WIDTH elements per call, so use the fewest
+        # power-of-two chunks whose width fits: two chunks preserve the historical behavior
+        # for every vocab up to 128K, and larger vocabs get four -- e.g. Qwen3's 151936
+        # (#53064) and Gemma-2's 256000. Callers gate on num_single_device_vocab_splits()
+        # returning non-None (host-sampling fallback), so reaching None here is a caller
+        # bug. Raise rather than assert: this guards a correctness invariant (misaligned
+        # chunks silently corrupt global token indices) and must survive python -O.
         self._num_vocab_splits = 2
         if self.multi_step_reduction:
-            while self.padded_vocab_size // self._num_vocab_splits > 64 * 1024:
-                self._num_vocab_splits *= 2
-            chunk_width = self.padded_vocab_size // self._num_vocab_splits
-            assert self.padded_vocab_size % self._num_vocab_splits == 0 and chunk_width % 32 == 0, (
-                f"padded_vocab_size={self.padded_vocab_size} cannot be cut into "
-                f"{self._num_vocab_splits} tile-aligned single-device top-k chunks"
-            )
+            self._num_vocab_splits = self.num_single_device_vocab_splits(self.padded_vocab_size)
+            if self._num_vocab_splits is None:
+                raise ValueError(
+                    f"padded_vocab_size={self.padded_vocab_size} cannot be cut into "
+                    f"tile-aligned single-device top-k chunks of at most {TOPK_MAX_WIDTH}"
+                )
         # Round up to the next tile boundary (32) — device tensors must be tile-aligned.
         raw_batch = getattr(args, "max_batch_size", 32)
         self.max_batch_size = max(32, ((raw_batch + 31) // 32) * 32)

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -87,6 +87,20 @@ class TTSampling(LightweightModule):
             return None
         return num_splits
 
+    @staticmethod
+    def _untilize_chunk_count(width):
+        """Fewest tile-aligned even chunks of at most TOPK_MAX_WIDTH each, or 1
+        when the row is narrow enough (<= 2 * TOPK_MAX_WIDTH, the widest row
+        known to untilize in one program) or no such cut exists."""
+        if width <= 2 * TOPK_MAX_WIDTH:
+            return 1
+        num_chunks = -(-width // TOPK_MAX_WIDTH)
+        while num_chunks <= width // ttnn.TILE_SIZE:
+            if width % num_chunks == 0 and (width // num_chunks) % ttnn.TILE_SIZE == 0:
+                return num_chunks
+            num_chunks += 1
+        return 1
+
     def _is_force_argmax_sampling(self, k, p, temp):
         """Detect whether all users request deterministic greedy decoding.
 
@@ -772,13 +786,16 @@ class TTSampling(LightweightModule):
                 )
             if slice_valid_vocab:
                 x = self._slice_valid_vocab_for_argmax(x)
-            if self.multi_step_reduction and self._num_vocab_splits > 2 and x.shape[-1] % self._num_vocab_splits == 0:
+            num_untilize_chunks = self._untilize_chunk_count(x.shape[-1])
+            if num_untilize_chunks > 1:
                 # Untilizing the full row in one program needs a static circular-buffer
                 # region proportional to the row width; past ~150K elements it clashes
                 # with the model's resident L1 buffers at compile (Gemma-2's 256000-wide
-                # logits throw "circular buffers ... clash with L1 buffers"). Untilize
-                # the same chunks the top-k path uses and concat row-major instead.
-                x_chunks = ttnn.split(x, x.shape[-1] // self._num_vocab_splits, dim=3)
+                # logits throw "circular buffers ... clash with L1 buffers"). The gate
+                # is width-based, not mesh-based: multi-device force-argmax gathers the
+                # full padded vocab onto every device and hits the same wall. Untilize
+                # in tile-aligned chunks and concat row-major instead.
+                x_chunks = ttnn.split(x, x.shape[-1] // num_untilize_chunks, dim=3)
                 untilized_chunks = [ttnn.untilize(chunk, use_multicore=True) for chunk in x_chunks]
                 for chunk in x_chunks:
                     chunk.deallocate()

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -772,7 +772,21 @@ class TTSampling(LightweightModule):
                 )
             if slice_valid_vocab:
                 x = self._slice_valid_vocab_for_argmax(x)
-            x_untilized = ttnn.untilize(x, use_multicore=True)
+            if self.multi_step_reduction and self._num_vocab_splits > 2 and x.shape[-1] % self._num_vocab_splits == 0:
+                # Untilizing the full row in one program needs a static circular-buffer
+                # region proportional to the row width; past ~150K elements it clashes
+                # with the model's resident L1 buffers at compile (Gemma-2's 256000-wide
+                # logits throw "circular buffers ... clash with L1 buffers"). Untilize
+                # the same chunks the top-k path uses and concat row-major instead.
+                x_chunks = ttnn.split(x, x.shape[-1] // self._num_vocab_splits, dim=3)
+                untilized_chunks = [ttnn.untilize(chunk, use_multicore=True) for chunk in x_chunks]
+                for chunk in x_chunks:
+                    chunk.deallocate()
+                x_untilized = ttnn.concat(untilized_chunks, dim=3)
+                for chunk in untilized_chunks:
+                    ttnn.deallocate(chunk)
+            else:
+                x_untilized = ttnn.untilize(x, use_multicore=True)
             tt_out_tok = ttnn.argmax(
                 x_untilized,
                 dim=-1,

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -826,18 +826,9 @@ class TTSampling(LightweightModule):
             topk_indices_list = []
 
             for i in range(len(x_bf16_list)):
-                # Pad a non-power-of-2 chunk so ttnn.topk hits the multi-core factory.
-                # Padded slots hold -inf and can never be selected; the post-concat
-                # per-chunk offsets use the unpadded chunk width, so real indices are
-                # unaffected.
-                if self.pad_to_power_of_2 and not is_power_of_2(x_bf16_list[i].shape[-1]):
-                    padded_value = upper_power_of_2(x_bf16_list[i].shape[-1])
-                    x_bf16_list[i] = ttnn.pad(
-                        x_bf16_list[i],
-                        [(0, 0), (0, 0), (0, 0), (0, padded_value - x_bf16_list[i].shape[-1])],
-                        value=-sys.float_info.max,
-                        sub_core_grids=self.sub_core_grids,
-                    )
+                # Chunks are not padded to a power of two here: an A/B on this path
+                # (PR #53167) measured no end-to-end decode benefit from steering
+                # ttnn.topk to the multi-core factory, so single-core chunks stay.
                 topk_values, topk_indices = ttnn.topk(
                     x_bf16_list[i],
                     k=self.max_top_k,

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -91,15 +91,25 @@ class TTSampling(LightweightModule):
     def _untilize_chunk_count(width):
         """Fewest tile-aligned even chunks of at most TOPK_MAX_WIDTH each, or 1
         when the row is narrow enough (<= 2 * TOPK_MAX_WIDTH, the widest row
-        known to untilize in one program) or no such cut exists."""
+        known to untilize in one program).
+
+        Raise rather than fall back: a wide row that cannot be cut would either
+        recreate the full-row circular-buffer/L1 compile clash (silent return 1)
+        or explode into thousands of tiny chunks (unbounded search), and both
+        are better caught at the source. The search is bounded so chunks stay at
+        least half of TOPK_MAX_WIDTH wide.
+        """
         if width <= 2 * TOPK_MAX_WIDTH:
             return 1
         num_chunks = -(-width // TOPK_MAX_WIDTH)
-        while num_chunks <= width // ttnn.TILE_SIZE:
+        max_chunks = 2 * num_chunks
+        while num_chunks <= max_chunks:
             if width % num_chunks == 0 and (width // num_chunks) % ttnn.TILE_SIZE == 0:
                 return num_chunks
             num_chunks += 1
-        return 1
+        raise ValueError(
+            f"cannot cut an untilize row of width {width} into tile-aligned chunks of at most {TOPK_MAX_WIDTH}"
+        )
 
     def _is_force_argmax_sampling(self, k, p, temp):
         """Detect whether all users request deterministic greedy decoding.
@@ -796,8 +806,13 @@ class TTSampling(LightweightModule):
                 # full padded vocab onto every device and hits the same wall. Untilize
                 # in tile-aligned chunks and concat row-major instead.
                 x_chunks = ttnn.split(x, x.shape[-1] // num_untilize_chunks, dim=3)
-                untilized_chunks = [ttnn.untilize(chunk, use_multicore=True) for chunk in x_chunks]
+                untilized_chunks = []
                 for chunk in x_chunks:
+                    # Free each tiled chunk as soon as its row-major copy exists,
+                    # so peak memory holds ~1 full-vocab buffer less than freeing
+                    # after the loop (this runs inside the captured decode trace,
+                    # so the peak is baked into the trace region size).
+                    untilized_chunks.append(ttnn.untilize(chunk, use_multicore=True))
                     chunk.deallocate()
                 x_untilized = ttnn.concat(untilized_chunks, dim=3)
                 for chunk in untilized_chunks:

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -923,3 +923,50 @@ def test_ttsampling_topk_matches_argmax_on_single_device(vocab_size, mesh_device
 
     header = f"{len(failures)}/{batch_size} users did not sample the row maximum (vocab_size={vocab_size})"
     assert not failures, header + ":\n" + "\n".join(failures)
+
+
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+def test_ttsampling_duplicate_request_seeds_sample_diverse_tokens(mesh_device):
+    """A batch of users sharing one request seed must not all sample the same token.
+
+    Device-level regression test for #53077: every user gets identical logits (a flat-ish
+    top-32 so the multinomial draw is what differentiates them) and the identical request
+    seed. Before per-slot seed salting, every slot derived the same device seed at the same
+    position and the whole batch sampled the same token. The draw must also be reproducible:
+    a fresh manager with the same seed produces the same tokens.
+    """
+    torch.manual_seed(7)
+    batch_size = 32
+    vocab_size = 32768
+
+    def _sample_once():
+        sampler = TTSampling(
+            args=_single_device_sampling_args(mesh_device, vocab_size),
+            mesh_device=mesh_device,
+            tt_ccl=None,
+            k=torch.full((batch_size,), 32),
+            p=torch.ones(batch_size),
+            temp=torch.ones(batch_size),
+        )
+        assert not sampler.force_argmax_sampling
+        seed_manager = SeedManager(sampler, max_batch_size=batch_size)
+        seed_manager.reset_seed([1234] * batch_size, list(range(batch_size)))
+        seed_manager.get_new_values(list(range(batch_size)))
+
+        # One logits row replicated across the batch: only the RNG stream can differ.
+        row = torch.zeros(1, 1, 1, vocab_size)
+        row[..., :32] = 5.0  # 32 equally-likely candidates, everything else improbable
+        logits_host = row.expand(1, 1, batch_size, vocab_size).contiguous()
+        logits_tt = ttnn.from_torch(logits_host, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh_device)
+        tokens_tt, _ = sampler(logits_tt)
+        return ttnn.to_torch(tokens_tt).flatten()[:batch_size].long().tolist()
+
+    tokens_first = _sample_once()
+    tokens_second = _sample_once()
+
+    assert all(0 <= t < vocab_size for t in tokens_first)
+    assert len(set(tokens_first)) > 1, (
+        f"all {batch_size} users with the same request seed sampled token {tokens_first[0]} -- "
+        "duplicate-seed slots are drawing from identical RNG streams (#53077)"
+    )
+    assert tokens_first == tokens_second, "same request seed must reproduce the same tokens across runs"

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -813,6 +813,9 @@ def _single_device_sampling_args(mesh_device, vocab_size, max_top_k=32, max_batc
         pytest.param(32768, id="v32768_multicore_halves"),
         # Half the vocab is not a power of two, so each half falls back to the single-core factory.
         pytest.param(32000, id="v32000_single_core_halves"),
+        # Half the vocab exceeds ttnn.topk's 64K width limit, so TTSampling must cut the vocab
+        # into four same-device chunks. Qwen3 has exactly this vocab size (#53064).
+        pytest.param(151936, id="v151936_four_way_split"),
     ],
 )
 @pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -167,6 +167,62 @@ def test_slot_remap_identity_is_a_noop():
     assert seed_manager._seed_active is True
 
 
+def test_duplicate_request_seeds_get_distinct_device_streams():
+    """Concurrent slots sharing one request seed must not draw identical streams.
+
+    Regression test for #53077: n>1 completions of one prompt with a fixed seed
+    land in different slots with the same request seed, and the device seed was
+    derived from (seed, position) only, so every completion came out identical.
+    """
+    seed_manager = _make_host_only_seed_manager(max_batch_size=4)
+    seed_manager.reset_seed([1234, 1234, 1234, 1234], [0, 1, 2, 3])
+
+    assert sorted(seed_manager.seed_salts) == [0, 1, 2, 3]
+    first_draws = [seed_manager._next_device_seed_for_slot(slot) for slot in range(4)]
+    assert len(set(first_draws)) == 4, f"duplicate-seed slots drew identical device seeds: {first_draws}"
+
+
+def test_unique_seed_stream_is_unchanged_and_slot_independent():
+    """A request whose seed is unique among active slots keeps salt 0, so its
+    stream matches the pre-salt derivation and does not depend on the slot."""
+    manager_a = _make_host_only_seed_manager(max_batch_size=4)
+    manager_a.reset_seed([777], [0])
+    manager_b = _make_host_only_seed_manager(max_batch_size=4)
+    manager_b.reset_seed([777], [3])
+
+    draws_a = [manager_a._next_device_seed_for_slot(0) for _ in range(4)]
+    draws_b = [manager_b._next_device_seed_for_slot(3) for _ in range(4)]
+
+    assert manager_a.seed_salts[0] == 0
+    assert draws_a == draws_b
+
+
+def test_seed_salt_travels_with_slot_remap():
+    seed_manager = _make_host_only_seed_manager(max_batch_size=4)
+    seed_manager.reset_seed([55, 55], [0, 3])  # duplicates: slot0 salt 0, slot3 salt 1
+    assert seed_manager.seed_salts[3] == 1
+
+    # Condense: slot3's request moves into empty slot1.
+    seed_manager.apply_slot_remap(torch.tensor([0, 3, 2, 3], dtype=torch.int32))
+
+    assert seed_manager.seed_salts[1] == 1  # stream identity survives the move
+    assert seed_manager.seed_salts[3] == 0  # vacated slot cleared
+
+
+def test_seed_salt_does_not_recollide_with_surviving_duplicate():
+    seed_manager = _make_host_only_seed_manager(max_batch_size=4)
+    seed_manager.reset_seed([55, 55], [0, 1])  # slot0 salt 0, slot1 salt 1
+    # Slot 0 finishes and is vacated; a new request with the same seed arrives.
+    seed_manager.apply_slot_remap(torch.tensor([1, 1, 2, 3], dtype=torch.int32))
+    assert seed_manager.seeds == [55, None, None, None]
+
+    seed_manager.reset_seed([55], [2])
+
+    # The newcomer must not reuse the surviving request's salt.
+    survivor_slot = 0
+    assert seed_manager.seed_salts[2] != seed_manager.seed_salts[survivor_slot]
+
+
 def test_broadcast_sampling_params_preserves_none_list_fields():
     params = SamplingParams(temperature=[1.0, 1.0], top_k=[1, 1], top_p=[1.0, 1.0], seed=[None, 42])
 

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -223,6 +223,61 @@ def test_seed_salt_does_not_recollide_with_surviving_duplicate():
     assert seed_manager.seed_salts[2] != seed_manager.seed_salts[survivor_slot]
 
 
+def test_seed_salt_survives_decode_re_registration_after_sibling_finishes():
+    """The unconditional decode-path re-registration (first decode after any
+    admission) must not recompute a running request's salt: after its same-seed
+    sibling finishes, the recomputed salt would drop to the sibling's and the
+    survivor's remaining tokens would replay the finished stream."""
+    seed_manager = _make_host_only_seed_manager(max_batch_size=4)
+    seed_manager.reset_seed([42, 42], [0, 1])  # A salt 0, B salt 1
+    assert seed_manager.seed_salts[1] == 1
+
+    # A finishes; condense moves B down into slot 0 (salt travels).
+    seed_manager.apply_slot_remap(torch.tensor([1, 1, 2, 3], dtype=torch.int32))
+    assert seed_manager.seed_salts[0] == 1
+
+    # An unrelated admission triggers reset_batch: every active slot re-registers.
+    seed_manager.reset_seed([7], [2])
+    seed_manager.reset_seed_from_slots([42, None, 7, None], [0, 2])
+
+    assert seed_manager.seed_salts[0] == 1  # B keeps its stream mid-generation
+
+
+def test_finished_tail_request_ghost_seed_is_cleared():
+    """A request finishing at the batch tail is never vacated by condense; the
+    decode-path deactivate must drop it so a later unique-seed request still
+    gets salt 0 (seeded reproducibility)."""
+    seed_manager = _make_host_only_seed_manager(max_batch_size=4)
+    seed_manager.reset_seed([42], [3])
+    # Tail completion: identity remap makes no moves, the ghost stays.
+    seed_manager.apply_slot_remap(torch.tensor([0, 1, 2, 3], dtype=torch.int32))
+    assert seed_manager.seeds[3] == 42
+
+    seed_manager.deactivate_slots_except([0])
+    assert seed_manager.seeds[3] is None
+
+    # A fresh unique seed-42 request must land on salt 0.
+    seed_manager.reset_seed([42], [1])
+    assert seed_manager.seed_salts[1] == 0
+
+
+def test_prefill_admission_into_same_slot_fully_resets_seed_state():
+    """reset_seed registers a NEW request: even when the slot already holds the
+    same seed value, the counter must restart and the salt must be recomputed
+    (its old salt may reflect siblings that no longer exist)."""
+    seed_manager = _make_host_only_seed_manager(max_batch_size=4)
+    seed_manager.reset_seed([42, 42], [0, 1])
+    assert seed_manager.seed_salts[1] == 1
+    seed_manager._next_device_seed_for_slot(1)
+    assert seed_manager.seed_counters[1] == 1
+
+    seed_manager.deactivate_slots_except([1])  # slot 0's request finished
+    seed_manager.reset_seed([42], [1])  # new same-seed request admitted into slot 1
+
+    assert seed_manager.seed_salts[1] == 0
+    assert seed_manager.seed_counters[1] == 0
+
+
 def test_broadcast_sampling_params_preserves_none_list_fields():
     params = SamplingParams(temperature=[1.0, 1.0], top_k=[1, 1], top_p=[1.0, 1.0], seed=[None, 42])
 
@@ -857,6 +912,20 @@ def test_top_k_logprobs_pcc_torch_vs_tt(shape, mesh_device):
 )
 def test_num_single_device_vocab_splits(padded_vocab_size, expected_splits):
     assert TTSampling.num_single_device_vocab_splits(padded_vocab_size) == expected_splits
+
+
+@pytest.mark.parametrize(
+    "width, expected",
+    [
+        (32768, 1),
+        (131072, 1),  # exactly 2*TOPK_MAX_WIDTH: full-row untilize known good (Galaxy padded vocab)
+        (151936, 4),  # Qwen3
+        (256000, 4),  # Gemma-2
+        (262144, 4),  # 4*TOPK_MAX_WIDTH exactly
+    ],
+)
+def test_untilize_chunk_count(width, expected):
+    assert TTSampling._untilize_chunk_count(width) == expected
 
 
 @pytest.mark.parametrize(

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -859,6 +859,51 @@ def test_num_single_device_vocab_splits(padded_vocab_size, expected_splits):
     assert TTSampling.num_single_device_vocab_splits(padded_vocab_size) == expected_splits
 
 
+@pytest.mark.parametrize(
+    "vocab_size",
+    [
+        # Qwen3: 4-way split, chunked untilize in the argmax fast path.
+        pytest.param(151936, id="v151936_chunked_untilize"),
+        # Gemma-2-2B: a single full-row untilize threw a circular-buffer/L1 clash at
+        # program compile; the chunked untilize must keep the fast path working.
+        pytest.param(256000, id="v256000_chunked_untilize_gemma"),
+    ],
+)
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+def test_ttsampling_force_argmax_matches_row_max_on_wide_vocab(vocab_size, mesh_device):
+    """Greedy params through the force-argmax fast path must pick the row maximum."""
+    torch.manual_seed(42)
+    batch_size = 32
+
+    args = _single_device_sampling_args(mesh_device, vocab_size)
+    args.model_config = {"SAMPLING_AG_CONFIG": {"allow_force_argmax": True, "num_links": 1, "topology": None}}
+    sampler = TTSampling(
+        args=args,
+        mesh_device=mesh_device,
+        tt_ccl=None,
+        k=torch.ones(batch_size),
+        p=torch.zeros(batch_size),
+        temp=torch.ones(batch_size),
+    )
+    assert sampler.force_argmax_sampling, "greedy params must take the argmax fast path"
+
+    logits_host = torch.randn(1, 1, batch_size, vocab_size)
+    logits_tt = ttnn.from_torch(logits_host, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=mesh_device)
+    logits_bf16 = ttnn.to_torch(logits_tt).float().reshape(batch_size, vocab_size)
+
+    tokens_tt, _log_probs = sampler(logits_tt)
+    tokens = ttnn.to_torch(tokens_tt).flatten()[:batch_size].long()
+
+    row_max = logits_bf16.max(dim=-1).values
+    for user in range(batch_size):
+        token = int(tokens[user])
+        assert 0 <= token < vocab_size, f"user {user}: token {token} outside [0, {vocab_size})"
+        assert logits_bf16[user, token].item() == row_max[user].item(), (
+            f"user {user}: token {token} has logit {logits_bf16[user, token].item():.6f}, "
+            f"but the row maximum is {row_max[user].item():.6f}"
+        )
+
+
 def _single_device_sampling_args(mesh_device, vocab_size, max_top_k=32, max_batch_size=32):
     """Minimal args for TTSampling on a 1x1 mesh: no vocab padding, no force-argmax."""
     grid = mesh_device.compute_with_storage_grid_size()

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -261,6 +261,33 @@ def test_finished_tail_request_ghost_seed_is_cleared():
     assert seed_manager.seed_salts[1] == 0
 
 
+def test_deactivating_last_seeded_slot_rearms_the_unseeded_push():
+    """When the last seeded request finishes, the device still holds non-SKIP
+    reinit values; unless _reseted is set, get_new_values early-returns forever
+    and every surviving user's PRNG reinitializes to the same stale seed each
+    token (frozen sampling)."""
+    seed_manager = _make_host_only_seed_manager(max_batch_size=4)
+    seed_manager.reset_seed([42], [3])
+    seed_manager._reseted = False  # simulate the post-push steady state
+
+    seed_manager.deactivate_slots_except([0])
+
+    assert seed_manager._seed_active is False
+    assert seed_manager._reseted is True
+
+
+def test_remap_overwriting_last_seeded_slot_rearms_the_unseeded_push():
+    seed_manager = _make_host_only_seed_manager(max_batch_size=4)
+    seed_manager.reset_seed([42], [0])
+    seed_manager._reseted = False
+
+    # Condense moves the (unseeded) request from slot 1 over the seeded slot 0.
+    seed_manager.apply_slot_remap(torch.tensor([1, 1, 2, 3], dtype=torch.int32))
+
+    assert seed_manager._seed_active is False
+    assert seed_manager._reseted is True
+
+
 def test_prefill_admission_into_same_slot_fully_resets_seed_state():
     """reset_seed registers a NEW request: even when the slot already holds the
     same seed value, the counter must restart and the salt must be recomputed

--- a/models/common/tests/test_sampling.py
+++ b/models/common/tests/test_sampling.py
@@ -845,6 +845,20 @@ def test_top_k_logprobs_pcc_torch_vs_tt(shape, mesh_device):
 # ===========================================================================
 
 
+@pytest.mark.parametrize(
+    "padded_vocab_size, expected_splits",
+    [
+        (32768, 2),  # Mistral: two 16384-wide halves
+        (151936, 4),  # Qwen3: four 37984-wide chunks
+        (256000, 4),  # Gemma-2: four 64000-wide chunks
+        (131072, 2),  # exactly 2x TOPK_MAX_WIDTH still splits in two
+        (131104, None),  # four 32776-wide chunks are not tile-aligned -> host-sampling fallback
+    ],
+)
+def test_num_single_device_vocab_splits(padded_vocab_size, expected_splits):
+    assert TTSampling.num_single_device_vocab_splits(padded_vocab_size) == expected_splits
+
+
 def _single_device_sampling_args(mesh_device, vocab_size, max_top_k=32, max_batch_size=32):
     """Minimal args for TTSampling on a 1x1 mesh: no vocab padding, no force-argmax."""
     grid = mesh_device.compute_with_storage_grid_size()
@@ -872,6 +886,9 @@ def _single_device_sampling_args(mesh_device, vocab_size, max_top_k=32, max_batc
         # Half the vocab exceeds ttnn.topk's 64K width limit, so TTSampling must cut the vocab
         # into four same-device chunks. Qwen3 has exactly this vocab size (#53064).
         pytest.param(151936, id="v151936_four_way_split"),
+        # Four 64000-wide tile-aligned chunks, none a power of two. Gemma-2-2B has exactly
+        # this vocab size and is the largest vocab any tiered model runs on one device.
+        pytest.param(256000, id="v256000_four_way_split_gemma"),
     ],
 )
 @pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)

--- a/models/demos/llama3_70b_galaxy/demo/conftest.py
+++ b/models/demos/llama3_70b_galaxy/demo/conftest.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import json
+
 
 # These inputs override the default inputs used by simple_text_demo.py. Check the main demo to see the default values.
 def pytest_addoption(parser):
@@ -17,7 +19,9 @@ def pytest_addoption(parser):
         "--paged_attention", action="store", type=bool, help="Whether to use paged attention or default attention"
     )
     parser.addoption("--page_params", action="store", type=dict, help="Page parameters for paged attention")
-    parser.addoption("--sampling_params", action="store", type=dict, help="Sampling parameters for decoding")
+    # type=dict cannot parse a command-line string, so the option was write-only until now;
+    # accept a JSON object, e.g. --sampling_params '{"temperature": 1.0, "top_k": 1, "top_p": 0.5}'
+    parser.addoption("--sampling_params", action="store", type=json.loads, help="Sampling parameters for decoding")
     parser.addoption(
         "--stop_at_eos", action="store", type=int, help="Whether to stop decoding when the model generates an EoS token"
     )

--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -921,7 +921,11 @@ def test_demo_text(
     max_generated_tokens = request.config.getoption("--max_generated_tokens") or max_generated_tokens
     paged_attention = request.config.getoption("--paged_attention") or paged_attention
     page_params = request.config.getoption("--page_params") or page_params
-    sampling_params = request.config.getoption("--sampling_params") or sampling_params
+    cli_sampling_params = request.config.getoption("--sampling_params")
+    if cli_sampling_params:
+        # Merge onto the parametrized defaults so a partial override (e.g. only
+        # temperature) keeps the remaining keys the demo indexes unconditionally.
+        sampling_params = {**sampling_params, **cli_sampling_params}
     if request.config.getoption("--stop_at_eos") in [
         0,
         1,

--- a/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
@@ -556,7 +556,11 @@ def test_qwen_demo_text(
     max_generated_tokens = request.config.getoption("--max_generated_tokens") or max_generated_tokens
     paged_attention = request.config.getoption("--paged_attention") or paged_attention
     page_params = request.config.getoption("--page_params") or page_params
-    sampling_params = request.config.getoption("--sampling_params") or sampling_params
+    cli_sampling_params = request.config.getoption("--sampling_params")
+    if cli_sampling_params:
+        # Merge onto the parametrized defaults so a partial override (e.g. only
+        # temperature) keeps the remaining keys the demo indexes unconditionally.
+        sampling_params = {**sampling_params, **cli_sampling_params}
 
     stop_at_eos = False  # Default to False
     if request.config.getoption("--stop_at_eos") in [

--- a/models/demos/llama3_70b_galaxy/tt/generator.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator.py
@@ -1574,6 +1574,11 @@ class Generator(WarmupForwardMixin):
             sm_bs = seed_manager.max_batch_size
             rank_remap = slot_remap[0:sm_bs]
             seed_manager.apply_slot_remap(rank_remap)
+        # Drop seed state of slots no longer live (a request finishing at
+        # the batch tail is never vacated by condense), so its ghost seed
+        # cannot inflate a later request's salt.
+        if active_seed_slots is not None:
+            seed_manager.deactivate_slots_except(active_seed_slots)
         if reset_inputs and sampling_params is not None:
             # If we have new inputs, we need to set up the sampling module again
             sampling_params = format_sampling_params(sampling_params, self.model_args.max_batch_size)

--- a/models/demos/multimodal/gemma3/demo/conftest.py
+++ b/models/demos/multimodal/gemma3/demo/conftest.py
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
 # SPDX-License-Identifier: Apache-2.0
-import json
 import argparse
+import json
 
 from models.tt_transformers.tt.model_config import parse_optimizations
 

--- a/models/demos/multimodal/gemma3/demo/conftest.py
+++ b/models/demos/multimodal/gemma3/demo/conftest.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 
 # SPDX-License-Identifier: Apache-2.0
+import json
 import argparse
 
 from models.tt_transformers.tt.model_config import parse_optimizations
@@ -37,7 +38,9 @@ def pytest_addoption(parser):
         help="Whether to use paged attention (1/true) or default KV (0/false). Omit to use the parametrized default.",
     )
     parser.addoption("--page_params", action="store", type=dict, help="Page parameters for paged attention")
-    parser.addoption("--sampling_params", action="store", type=dict, help="Sampling parameters for decoding")
+    # type=dict cannot parse a command-line string, so the option was write-only until now;
+    # accept a JSON object, e.g. --sampling_params '{"temperature": 1.0, "top_k": 1, "top_p": 0.5}'
+    parser.addoption("--sampling_params", action="store", type=json.loads, help="Sampling parameters for decoding")
     parser.addoption(
         "--stop_at_eos", action="store", type=int, help="Whether to stop decoding when the model generates an EoS token"
     )

--- a/models/demos/multimodal/gemma3/demo/text_demo.py
+++ b/models/demos/multimodal/gemma3/demo/text_demo.py
@@ -833,7 +833,11 @@ def test_demo_text(
     page_params = request.config.getoption("--page_params") or page_params
     if isinstance(page_params, str):  # Required for proper load of a dictionary from the override command
         page_params = json.loads(page_params)
-    sampling_params = request.config.getoption("--sampling_params") or sampling_params
+    cli_sampling_params = request.config.getoption("--sampling_params")
+    if cli_sampling_params:
+        # Merge onto the parametrized defaults so a partial override (e.g. only
+        # temperature) keeps the remaining keys the demo indexes unconditionally.
+        sampling_params = {**sampling_params, **cli_sampling_params}
     json_config_file = request.config.getoption("--decoder_config_file")
     token_accuracy = request.config.getoption("--token_accuracy") or token_accuracy
     stress_test = request.config.getoption("--stress_test") or stress_test

--- a/models/demos/qwen25_vl/demo/conftest.py
+++ b/models/demos/qwen25_vl/demo/conftest.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+
 import nltk
 import pytest
 

--- a/models/demos/qwen25_vl/demo/conftest.py
+++ b/models/demos/qwen25_vl/demo/conftest.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import nltk
 import pytest
 
@@ -30,7 +31,9 @@ def pytest_addoption(parser):
         "--paged_attention", action="store", type=bool, help="Whether to use paged attention or default attention"
     )
     parser.addoption("--page_params", action="store", type=dict, help="Page parameters for paged attention")
-    parser.addoption("--sampling_params", action="store", type=dict, help="Sampling parameters for decoding")
+    # type=dict cannot parse a command-line string, so the option was write-only until now;
+    # accept a JSON object, e.g. --sampling_params '{"temperature": 1.0, "top_k": 1, "top_p": 0.5}'
+    parser.addoption("--sampling_params", action="store", type=json.loads, help="Sampling parameters for decoding")
     parser.addoption(
         "--stop_at_eos", action="store", type=int, help="Whether to stop decoding when the model generates an EoS token"
     )

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -314,7 +314,11 @@ def test_demo(
     max_generated_tokens = request.config.getoption("--max_generated_tokens") or max_generated_tokens
     paged_attention = request.config.getoption("--paged_attention") or paged_attention
     page_params = request.config.getoption("--page_params") or page_params
-    sampling_params = request.config.getoption("--sampling_params") or sampling_params
+    cli_sampling_params = request.config.getoption("--sampling_params")
+    if cli_sampling_params:
+        # Merge onto the parametrized defaults so a partial override (e.g. only
+        # temperature) keeps the remaining keys the demo indexes unconditionally.
+        sampling_params = {**sampling_params, **cli_sampling_params}
     if request.config.getoption("--stop_at_eos") in [
         0,
         1,

--- a/models/demos/qwen3_vl/demo/conftest.py
+++ b/models/demos/qwen3_vl/demo/conftest.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+
 import nltk
 import pytest
 

--- a/models/demos/qwen3_vl/demo/conftest.py
+++ b/models/demos/qwen3_vl/demo/conftest.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import nltk
 import pytest
 
@@ -30,7 +31,9 @@ def pytest_addoption(parser):
         "--paged_attention", action="store", type=bool, help="Whether to use paged attention or default attention"
     )
     parser.addoption("--page_params", action="store", type=dict, help="Page parameters for paged attention")
-    parser.addoption("--sampling_params", action="store", type=dict, help="Sampling parameters for decoding")
+    # type=dict cannot parse a command-line string, so the option was write-only until now;
+    # accept a JSON object, e.g. --sampling_params '{"temperature": 1.0, "top_k": 1, "top_p": 0.5}'
+    parser.addoption("--sampling_params", action="store", type=json.loads, help="Sampling parameters for decoding")
     parser.addoption(
         "--stop_at_eos", action="store", type=int, help="Whether to stop decoding when the model generates an EoS token"
     )

--- a/models/demos/qwen3_vl/demo/demo.py
+++ b/models/demos/qwen3_vl/demo/demo.py
@@ -294,7 +294,11 @@ def test_demo(
     max_generated_tokens = request.config.getoption("--max_generated_tokens") or max_generated_tokens
     paged_attention = request.config.getoption("--paged_attention") or paged_attention
     page_params = request.config.getoption("--page_params") or page_params
-    sampling_params = request.config.getoption("--sampling_params") or sampling_params
+    cli_sampling_params = request.config.getoption("--sampling_params")
+    if cli_sampling_params:
+        # Merge onto the parametrized defaults so a partial override (e.g. only
+        # temperature) keeps the remaining keys the demo indexes unconditionally.
+        sampling_params = {**sampling_params, **cli_sampling_params}
     if request.config.getoption("--stop_at_eos") in [
         0,
         1,

--- a/models/model_ci_tiers.md
+++ b/models/model_ci_tiers.md
@@ -104,6 +104,8 @@ it is classified differently on different systems.
 | Qwen2.5-7B | WH N300 |
 | Qwen2.5-72B | WH LLMBox |
 | Qwen2.5-VL-32B | WH LLMBox, BH QuietBox 2 |
+| Qwen3-0.6B | WH N150, BH P150 |
+| Qwen3-1.7B | WH N150, BH P150 |
 | Gemma-4-E2B | WH N150, BH P150 |
 | Gemma-4-E4B | BH P300, BH QuietBox 2 |
 | Mamba-2.8B | WH N150 |

--- a/models/tt_transformers/demo/conftest.py
+++ b/models/tt_transformers/demo/conftest.py
@@ -2,6 +2,8 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import json
+
 from models.tt_transformers.tt.model_config import parse_optimizations
 
 
@@ -20,7 +22,9 @@ def pytest_addoption(parser):
         "--paged_attention", action="store", type=bool, help="Whether to use paged attention or default attention"
     )
     parser.addoption("--page_params", action="store", type=dict, help="Page parameters for paged attention")
-    parser.addoption("--sampling_params", action="store", type=dict, help="Sampling parameters for decoding")
+    # type=dict cannot parse a command-line string, so the option was write-only until now;
+    # accept a JSON object, e.g. --sampling_params '{"temperature": 1.0, "top_k": 1, "top_p": 0.5}'
+    parser.addoption("--sampling_params", action="store", type=json.loads, help="Sampling parameters for decoding")
     parser.addoption(
         "--stop_at_eos", action="store", type=int, help="Whether to stop decoding when the model generates an EoS token"
     )

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -919,7 +919,11 @@ def test_demo_text(
     page_params = request.config.getoption("--page_params") or page_params
     if isinstance(page_params, str):  # Required for proper load of a dictionary from the override command
         page_params = json.loads(page_params)
-    sampling_params = request.config.getoption("--sampling_params") or sampling_params
+    cli_sampling_params = request.config.getoption("--sampling_params")
+    if cli_sampling_params:
+        # Merge onto the parametrized defaults so a partial override (e.g. only
+        # temperature) keeps the remaining keys the demo indexes unconditionally.
+        sampling_params = {**sampling_params, **cli_sampling_params}
     json_config_file = request.config.getoption("--decoder_config_file")
     token_accuracy = request.config.getoption("--token_accuracy") or token_accuracy
     stress_test = request.config.getoption("--stress_test") or stress_test

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1759,6 +1759,11 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 sm_bs = sampling_module.seed_manager.max_batch_size
                 rank_remap = slot_remap[i * sm_bs : (i + 1) * sm_bs]
                 sampling_module.seed_manager.apply_slot_remap(rank_remap)
+            # Drop seed state of slots no longer live (a request finishing at
+            # the batch tail is never vacated by condense), so its ghost seed
+            # cannot inflate a later request's salt.
+            if active_seed_slots is not None:
+                sampling_module.seed_manager.deactivate_slots_except(active_seed_slots)
             # Register each request's explicit seed into the seed manager and
             # tie its RNG counter to the absolute decode position before
             # advancing. Without registration the per-request seed never reaches

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -152,8 +152,15 @@ class Transformer(LightweightModule):
         )
 
         # Initialize on-device sampling if supported
-        # Sampling on device is supported only if each device has maximum logits size of 64*1024
-        sampling_splits = self.args.num_devices if list(self.mesh_device.shape) != [1, 1] else 2
+        # Sampling on device is supported only if each device has maximum logits size of 64*1024.
+        # On a single device TTSampling cuts the vocab into as many same-device chunks as needed
+        # (power-of-two, each <= 64*1024), so any vocab it can cut tile-aligned is supported (#53064).
+        if list(self.mesh_device.shape) != [1, 1]:
+            sampling_splits = self.args.num_devices
+        else:
+            sampling_splits = 2
+            while self.args.vocab_size // sampling_splits > 64 * 1024:
+                sampling_splits *= 2
         self._supports_on_device_sampling = prefetcher is None and self.args.vocab_size // sampling_splits <= 64 * 1024
         if self._supports_on_device_sampling:
             self.sampling = SamplingGenerator(

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -10,6 +10,7 @@ import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.common.rmsnorm import RMSNorm
 from models.common.sampling.generator import SamplingGenerator
+from models.common.sampling.tt_sampling import TOPK_MAX_WIDTH, TTSampling
 from models.tt_transformers.tt.ccl import TT_CCL
 from models.tt_transformers.tt.common import Mode, copy_host_to_device
 from models.tt_transformers.tt.decoder import TransformerBlock
@@ -152,16 +153,16 @@ class Transformer(LightweightModule):
         )
 
         # Initialize on-device sampling if supported
-        # Sampling on device is supported only if each device has maximum logits size of 64*1024.
-        # On a single device TTSampling cuts the vocab into as many same-device chunks as needed
-        # (power-of-two, each <= 64*1024), so any vocab it can cut tile-aligned is supported (#53064).
+        # Sampling on device is supported only if each device holds at most TOPK_MAX_WIDTH logits.
+        # On a single device TTSampling cuts the padded vocab into as many same-device chunks as
+        # needed (power-of-two, each <= TOPK_MAX_WIDTH), so any vocab it can cut tile-aligned is
+        # supported (#53064); anything it cannot falls back to host sampling.
+        padded_vocab_size = getattr(self.args, "padded_vocab_size", None) or self.args.vocab_size
         if list(self.mesh_device.shape) != [1, 1]:
-            sampling_splits = self.args.num_devices
+            vocab_fits_on_device = padded_vocab_size // self.args.num_devices <= TOPK_MAX_WIDTH
         else:
-            sampling_splits = 2
-            while self.args.vocab_size // sampling_splits > 64 * 1024:
-                sampling_splits *= 2
-        self._supports_on_device_sampling = prefetcher is None and self.args.vocab_size // sampling_splits <= 64 * 1024
+            vocab_fits_on_device = TTSampling.num_single_device_vocab_splits(padded_vocab_size) is not None
+        self._supports_on_device_sampling = prefetcher is None and vocab_fits_on_device
         if self._supports_on_device_sampling:
             self.sampling = SamplingGenerator(
                 args=args,

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -2794,15 +2794,14 @@ class ModelArgs:
                 "Qwen2.5-7B and Qwen2.5-VL-7B is only supported on 2 or 4 devices, run on an N300 or use MESH_DEVICE=N150x4"
             )
 
-        if self.num_devices > 0:
-            sampling_splits = self.num_devices if self.cluster_shape != [1, 1] else 2
-            # Only enable this optimization on the non-multi-step sampling path.
-            # The [1, 1] mesh path splits logits before TopK today and would need
-            # matching input padding in `TTSampling.sample()` to safely use it.
-            self.pad_logits_to_power_of_2 = self.cluster_shape != [1, 1] and (
-                should_pad_sampling_logits_to_power_of_2(self.base_model_name, self.padded_vocab_size, sampling_splits)
+        if self.num_devices > 0 and self.cluster_shape != [1, 1]:
+            self.pad_logits_to_power_of_2 = should_pad_sampling_logits_to_power_of_2(
+                self.base_model_name, self.padded_vocab_size, self.num_devices
             )
         else:
+            # Off on [1, 1]: an A/B on the multi-step split path (PR #53167)
+            # measured no end-to-end decode benefit from padding the topk chunks
+            # to a power of two, so the flag stays multi-device only.
             self.pad_logits_to_power_of_2 = False
 
         self.unpadded_hidden_dim = self.hidden_dim

--- a/tests/emule/models/conftest.py
+++ b/tests/emule/models/conftest.py
@@ -8,6 +8,7 @@
 # fixtures come from the root tt-metal conftest.py (in the ancestry). Re-sync
 # alongside the vendored demo on a tt-metal pin bump.
 
+import json
 from models.tt_transformers.tt.model_config import parse_optimizations
 
 
@@ -26,7 +27,9 @@ def pytest_addoption(parser):
         "--paged_attention", action="store", type=bool, help="Whether to use paged attention or default attention"
     )
     parser.addoption("--page_params", action="store", type=dict, help="Page parameters for paged attention")
-    parser.addoption("--sampling_params", action="store", type=dict, help="Sampling parameters for decoding")
+    # type=dict cannot parse a command-line string, so the option was write-only until now;
+    # accept a JSON object, e.g. --sampling_params '{"temperature": 1.0, "top_k": 1, "top_p": 0.5}'
+    parser.addoption("--sampling_params", action="store", type=json.loads, help="Sampling parameters for decoding")
     parser.addoption(
         "--stop_at_eos", action="store", type=int, help="Whether to stop decoding when the model generates an EoS token"
     )

--- a/tests/emule/models/test_tt_transformers_text_demo.py
+++ b/tests/emule/models/test_tt_transformers_text_demo.py
@@ -912,7 +912,11 @@ def test_demo_text(
     page_params = request.config.getoption("--page_params") or page_params
     if isinstance(page_params, str):  # Required for proper load of a dictionary from the override command
         page_params = json.loads(page_params)
-    sampling_params = request.config.getoption("--sampling_params") or sampling_params
+    cli_sampling_params = request.config.getoption("--sampling_params")
+    if cli_sampling_params:
+        # Merge onto the parametrized defaults so a partial override (e.g. only
+        # temperature) keeps the remaining keys the demo indexes unconditionally.
+        sampling_params = {**sampling_params, **cli_sampling_params}
     json_config_file = request.config.getoption("--decoder_config_file")
     token_accuracy = request.config.getoption("--token_accuracy") or token_accuracy
     stress_test = request.config.getoption("--stress_test") or stress_test

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -288,6 +288,10 @@
     # HF_HOME and generate the weight cache at TT_CACHE_PATH; warm re-runs are faster.
     pytest --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-1"
     pytest --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-32"
+    # The greedy CI config takes the argmax fast path and never reaches top-k (see #52928), so
+    # run once with k=1/p=0.5/temp=1: still deterministic, but p not in {0, 1} declines the
+    # fast path and exercises the 4-way vocab split every decode step.
+    pytest --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-1" --sampling_params '{"temperature": 1.0, "top_k": 1, "top_p": 0.5}'
   model: qwen3-0.6b
   model_family: Qwen
   skus:
@@ -305,6 +309,10 @@
     # HF_HOME and generate the weight cache at TT_CACHE_PATH; warm re-runs are faster.
     pytest --timeout 720 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-1"
     pytest --timeout 720 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-32"
+    # The greedy CI config takes the argmax fast path and never reaches top-k (see #52928), so
+    # run once with k=1/p=0.5/temp=1: still deterministic, but p not in {0, 1} declines the
+    # fast path and exercises the 4-way vocab split every decode step.
+    pytest --timeout 720 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-1" --sampling_params '{"temperature": 1.0, "top_k": 1, "top_p": 0.5}'
   model: qwen3-1.7b
   model_family: Qwen
   skus:

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -277,6 +277,44 @@
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models
 
+# The two small Qwen3 models carry the full 151936 vocab on a single card, which exercises
+# TTSampling's N-way (here 4-way) single-device vocab split for on-device sampling (#53064) --
+# no other tiered model runs a >128K vocab on one device. No reference tokens exist yet, so
+# these run the functional CI demos; add ci-token-matching once a refpt is generated.
+- name: Qwen3-0.6B e2e tests
+  cmd: |
+    export HF_MODEL=Qwen/Qwen3-0.6B HF_HOME=/mnt/MLPerf/huggingface TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-0.6B MESH_DEVICE=N150
+    # Extra time budget vs a warm run: the first CI run must download the checkpoint into
+    # HF_HOME and generate the weight cache at TT_CACHE_PATH; warm re-runs are faster.
+    pytest --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-1"
+    pytest --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-32"
+  model: qwen3-0.6b
+  model_family: Qwen
+  skus:
+    wh_n150:
+      timeout: 15
+      tier: 3
+      release_ready: false
+  owner_id: U03PUAKE719 # Miguel Tairum Cruz
+  team: models
+
+- name: Qwen3-1.7B e2e tests
+  cmd: |
+    export HF_MODEL=Qwen/Qwen3-1.7B HF_HOME=/mnt/MLPerf/huggingface TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-1.7B MESH_DEVICE=N150
+    # Extra time budget vs a warm run: the first CI run must download the checkpoint into
+    # HF_HOME and generate the weight cache at TT_CACHE_PATH; warm re-runs are faster.
+    pytest --timeout 720 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-1"
+    pytest --timeout 720 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-32"
+  model: qwen3-1.7b
+  model_family: Qwen
+  skus:
+    wh_n150:
+      timeout: 20
+      tier: 3
+      release_ready: false
+  owner_id: U03PUAKE719 # Miguel Tairum Cruz
+  team: models
+
 - name: Qwen2.5-32B e2e tests
   cmd: |
     export HF_MODEL=Qwen/Qwen2.5-32B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen2.5-32B-Instruct

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -277,21 +277,11 @@
   owner_id: U053W15B6JF # Djordje Ivanovic
   team: models
 
-# The two small Qwen3 models carry the full 151936 vocab on a single card, which exercises
-# TTSampling's N-way (here 4-way) single-device vocab split for on-device sampling (#53064);
-# Gemma-2-2B on wh_n150 covers the same path with a 256000 vocab. No reference tokens exist
-# yet, so these run the functional CI demos; add ci-token-matching once a refpt is generated.
 - name: Qwen3-0.6B e2e tests
   cmd: |
-    # MESH_DEVICE is set by the runner (this entry runs on both wh_n150 and bh_p150).
     export HF_MODEL=Qwen/Qwen3-0.6B HF_HOME=/mnt/MLPerf/huggingface TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-0.6B
-    # Extra time budget vs a warm run: the first CI run must download the checkpoint into
-    # HF_HOME and generate the weight cache at TT_CACHE_PATH; warm re-runs are faster.
     pytest --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-1"
     pytest --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-32"
-    # The greedy CI config takes the argmax fast path and never reaches top-k (see #52928), so
-    # run once with k=1/p=0.5/temp=1: still deterministic, but p not in {0, 1} declines the
-    # fast path and exercises the 4-way vocab split every decode step.
     pytest --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-1" --sampling_params '{"temperature": 1.0, "top_k": 1, "top_p": 0.5}'
   model: qwen3-0.6b
   model_family: Qwen
@@ -309,15 +299,9 @@
 
 - name: Qwen3-1.7B e2e tests
   cmd: |
-    # MESH_DEVICE is set by the runner (this entry runs on both wh_n150 and bh_p150).
     export HF_MODEL=Qwen/Qwen3-1.7B HF_HOME=/mnt/MLPerf/huggingface TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-1.7B
-    # Extra time budget vs a warm run: the first CI run must download the checkpoint into
-    # HF_HOME and generate the weight cache at TT_CACHE_PATH; warm re-runs are faster.
     pytest --timeout 720 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-1"
     pytest --timeout 720 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-32"
-    # The greedy CI config takes the argmax fast path and never reaches top-k (see #52928), so
-    # run once with k=1/p=0.5/temp=1: still deterministic, but p not in {0, 1} declines the
-    # fast path and exercises the 4-way vocab split every decode step.
     pytest --timeout 720 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-1" --sampling_params '{"temperature": 1.0, "top_k": 1, "top_p": 0.5}'
   model: qwen3-1.7b
   model_family: Qwen

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -280,16 +280,16 @@
 - name: Qwen3-0.6B e2e tests
   cmd: |
     export HF_MODEL=Qwen/Qwen3-0.6B HF_HOME=/mnt/MLPerf/huggingface TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-0.6B
-    pytest --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-1" --sampling_params '{"temperature": 1.0, "top_k": 1, "top_p": 0.5}'
+    pytest --timeout 720 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-1" --sampling_params '{"temperature": 1.0, "top_k": 1, "top_p": 0.5}'
   model: qwen3-0.6b
   model_family: Qwen
   skus:
     wh_n150:
-      timeout: 8
+      timeout: 12
       tier: 3
       release_ready: false
     bh_p150:
-      timeout: 8
+      timeout: 12
       tier: 3
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
@@ -298,16 +298,16 @@
 - name: Qwen3-1.7B e2e tests
   cmd: |
     export HF_MODEL=Qwen/Qwen3-1.7B HF_HOME=/mnt/MLPerf/huggingface TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-1.7B
-    pytest --timeout 720 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-1" --sampling_params '{"temperature": 1.0, "top_k": 1, "top_p": 0.5}'
+    pytest --timeout 840 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-1" --sampling_params '{"temperature": 1.0, "top_k": 1, "top_p": 0.5}'
   model: qwen3-1.7b
   model_family: Qwen
   skus:
     wh_n150:
-      timeout: 8
+      timeout: 14
       tier: 3
       release_ready: false
     bh_p150:
-      timeout: 8
+      timeout: 14
       tier: 3
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -280,18 +280,17 @@
 - name: Qwen3-0.6B e2e tests
   cmd: |
     export HF_MODEL=Qwen/Qwen3-0.6B HF_HOME=/mnt/MLPerf/huggingface TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-0.6B
-    pytest --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-1"
     pytest --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-32"
     pytest --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-1" --sampling_params '{"temperature": 1.0, "top_k": 1, "top_p": 0.5}'
   model: qwen3-0.6b
   model_family: Qwen
   skus:
     wh_n150:
-      timeout: 15
+      timeout: 10
       tier: 3
       release_ready: false
     bh_p150:
-      timeout: 15
+      timeout: 10
       tier: 3
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
@@ -300,18 +299,17 @@
 - name: Qwen3-1.7B e2e tests
   cmd: |
     export HF_MODEL=Qwen/Qwen3-1.7B HF_HOME=/mnt/MLPerf/huggingface TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-1.7B
-    pytest --timeout 720 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-1"
     pytest --timeout 720 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-32"
     pytest --timeout 720 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-1" --sampling_params '{"temperature": 1.0, "top_k": 1, "top_p": 0.5}'
   model: qwen3-1.7b
   model_family: Qwen
   skus:
     wh_n150:
-      timeout: 20
+      timeout: 12
       tier: 3
       release_ready: false
     bh_p150:
-      timeout: 20
+      timeout: 12
       tier: 3
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -283,7 +283,8 @@
 # these run the functional CI demos; add ci-token-matching once a refpt is generated.
 - name: Qwen3-0.6B e2e tests
   cmd: |
-    export HF_MODEL=Qwen/Qwen3-0.6B HF_HOME=/mnt/MLPerf/huggingface TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-0.6B MESH_DEVICE=N150
+    # MESH_DEVICE is set by the runner (this entry runs on both wh_n150 and bh_p150).
+    export HF_MODEL=Qwen/Qwen3-0.6B HF_HOME=/mnt/MLPerf/huggingface TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-0.6B
     # Extra time budget vs a warm run: the first CI run must download the checkpoint into
     # HF_HOME and generate the weight cache at TT_CACHE_PATH; warm re-runs are faster.
     pytest --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-1"
@@ -299,12 +300,17 @@
       timeout: 15
       tier: 3
       release_ready: false
+    bh_p150:
+      timeout: 15
+      tier: 3
+      release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
   team: models
 
 - name: Qwen3-1.7B e2e tests
   cmd: |
-    export HF_MODEL=Qwen/Qwen3-1.7B HF_HOME=/mnt/MLPerf/huggingface TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-1.7B MESH_DEVICE=N150
+    # MESH_DEVICE is set by the runner (this entry runs on both wh_n150 and bh_p150).
+    export HF_MODEL=Qwen/Qwen3-1.7B HF_HOME=/mnt/MLPerf/huggingface TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-1.7B
     # Extra time budget vs a warm run: the first CI run must download the checkpoint into
     # HF_HOME and generate the weight cache at TT_CACHE_PATH; warm re-runs are faster.
     pytest --timeout 720 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-1"
@@ -317,6 +323,10 @@
   model_family: Qwen
   skus:
     wh_n150:
+      timeout: 20
+      tier: 3
+      release_ready: false
+    bh_p150:
       timeout: 20
       tier: 3
       release_ready: false

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -278,9 +278,9 @@
   team: models
 
 # The two small Qwen3 models carry the full 151936 vocab on a single card, which exercises
-# TTSampling's N-way (here 4-way) single-device vocab split for on-device sampling (#53064) --
-# no other tiered model runs a >128K vocab on one device. No reference tokens exist yet, so
-# these run the functional CI demos; add ci-token-matching once a refpt is generated.
+# TTSampling's N-way (here 4-way) single-device vocab split for on-device sampling (#53064);
+# Gemma-2-2B on wh_n150 covers the same path with a 256000 vocab. No reference tokens exist
+# yet, so these run the functional CI demos; add ci-token-matching once a refpt is generated.
 - name: Qwen3-0.6B e2e tests
   cmd: |
     # MESH_DEVICE is set by the runner (this entry runs on both wh_n150 and bh_p150).

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -280,17 +280,16 @@
 - name: Qwen3-0.6B e2e tests
   cmd: |
     export HF_MODEL=Qwen/Qwen3-0.6B HF_HOME=/mnt/MLPerf/huggingface TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-0.6B
-    pytest --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-32"
     pytest --timeout 600 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-1" --sampling_params '{"temperature": 1.0, "top_k": 1, "top_p": 0.5}'
   model: qwen3-0.6b
   model_family: Qwen
   skus:
     wh_n150:
-      timeout: 10
+      timeout: 8
       tier: 3
       release_ready: false
     bh_p150:
-      timeout: 10
+      timeout: 8
       tier: 3
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz
@@ -299,17 +298,16 @@
 - name: Qwen3-1.7B e2e tests
   cmd: |
     export HF_MODEL=Qwen/Qwen3-1.7B HF_HOME=/mnt/MLPerf/huggingface TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen3-1.7B
-    pytest --timeout 720 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-32"
     pytest --timeout 720 models/tt_transformers/demo/simple_text_demo.py -k "performance-ci-1" --sampling_params '{"temperature": 1.0, "top_k": 1, "top_p": 0.5}'
   model: qwen3-1.7b
   model_family: Qwen
   skus:
     wh_n150:
-      timeout: 12
+      timeout: 8
       tier: 3
       release_ready: false
     bh_p150:
-      timeout: 12
+      timeout: 8
       tier: 3
       release_ready: false
   owner_id: U03PUAKE719 # Miguel Tairum Cruz

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -1388,3 +1388,17 @@
       tier: 2
   owner_id: U082LLYBLSW # Gabriel Tobar (CODEOWNERS @gtobarTT)
   team: models
+
+- name: On-device sampling unit tests
+  cmd: |
+    pytest --timeout 300 models/common/tests/test_sampling.py -k "ttsampling or num_single_device_vocab_splits"
+  model: tt-sampling
+  skus:
+    wh_n150:
+      timeout: 10
+      tier: 3
+    bh_p150:
+      timeout: 10
+      tier: 3
+  owner_id: U03PUAKE719 # Miguel Tairum Cruz
+  team: models

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -1391,7 +1391,7 @@
 
 - name: On-device sampling unit tests
   cmd: |
-    pytest --timeout 300 models/common/tests/test_sampling.py -k "ttsampling or num_single_device_vocab_splits"
+    pytest --timeout 300 models/common/tests/test_sampling.py -k "ttsampling or num_single_device_vocab_splits or untilize_chunk_count or seed or slot_remap"
   model: tt-sampling
   skus:
     wh_n150:

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -1392,7 +1392,7 @@
 - name: On-device sampling unit tests
   cmd: |
     pytest --timeout 300 models/common/tests/test_sampling.py -k "ttsampling or num_single_device_vocab_splits or untilize_chunk_count or seed or slot_remap"
-  model: tt-sampling
+  model: tt-model-sampling
   skus:
     wh_n150:
       timeout: 10


### PR DESCRIPTION
### PR Category

Feature / Bug fix

### Summary

Fixes #53064 and #53077 in one PR (both live in `models/common/sampling/`).

Rebased on main after #53001 merged.

#### Adaptive vocab splits (#53064)

TTSampling's single-device path hardcoded a two-way vocab split, and tt-transformers refused on-device sampling whenever `vocab_size / 2 > 64*1024` — shutting it off for every Qwen3 model (vocab 151936).

- Single-device multi-step reduction now cuts the vocab into the fewest power-of-two chunks whose width fits ttnn.topk's 64K limit (`TTSampling.num_single_device_vocab_splits`): two chunks preserve exact historical behavior for vocabs ≤128K; Qwen3 (151936) and Gemma-2 (256000) get four. Per-chunk index offsets already scale with the shard count; with the iota indices buffers gone (#52928) no per-chunk indices plumbing is needed.
- The tt-transformers gate calls the same helper on `padded_vocab_size`, so any tile-aligned-cuttable vocab is supported on a single device, and anything uncuttable falls back to host sampling instead of asserting.
- Chunks are **not** padded to a power of two — measured to be pure overhead, see the A/B section below.
- The force-argmax fast path untilizes rows wider than 2×64K in tile-aligned chunks: a single full-row untilize of Gemma-2's 256000-wide logits statically allocates circular buffers that clash with the model's resident L1 buffers at program compile.
- On the issue's question 5: on meshes the split is the physical vocab sharding; on 1×1 it exists only to fit the topk width limit — 2 was simply the minimum that fit all vocabs shipped so far.

#### Per-request seed salting (#53077)

On-device sampling derives each token's device seed as `hash(request_seed, token_position)` — deliberately slot-independent. n>1 completions of one prompt with a fixed seed occupy several slots with the same request seed, derive identical device seeds at identical positions, and come out byte-identical at any temperature. (The `replicate_seeds` broadcast flagged in the issue is repaired by the next decode-step seed push and is not the mechanism.)

Fix: each slot gets a seed salt — the smallest value not used by another active slot holding the same request seed — folded into the SplitMix64 derivation. Unique-seed requests keep salt 0, making their streams **bit-identical to today**; duplicates get well-separated streams. The salt travels with the request through batch condense, and smallest-free assignment prevents re-collision with a surviving duplicate.

Salt lifecycle across continuous batching (from review): all slot seed writes go through one `_set_slot_seed` helper. The decode-path re-registration (first decode after any admission) keeps an existing salt when the slot already holds the same seed, so a running request's stream never switches after a same-seed sibling finishes; prefill admission fully resets. Finished requests that condense never vacates (tail of the batch) are dropped via `deactivate_slots_except(live_slots)` so ghost seeds cannot inflate a later unique-seed request's salt past 0. Known residual: a request evicted and re-admitted keeps its stream via position-aligned counters, but its salt is recomputed at re-admission — restoring it exactly needs per-request identity the seed manager does not have.

### Pad-to-power-of-2 A/B on the single-device path (tested, then dropped)

The multi-step chunk loop originally carried an optional per-chunk pad to the next power of two, intended to steer ttnn.topk from the single-core to the multi-core program factory (Qwen3's 37984-wide chunks are not powers of two). The gate was never enabled for [1,1] meshes, so we force-enabled it for the small Qwen3 models on a scratch branch (`mtairum/qwen3-pad-pow2-ab`) and A/B'd against this branch on wh_n150, same base commit and runner pool:

| Qwen3-0.6B, 128th-token decode | single-core chunks (base) | padded multi-core chunks |
|---|---|---|
| greedy batch-1 (argmax fast path) | 12.55 ms/tok — 79.7 t/s/u | 12.27 ms/tok — 81.5 t/s/u |
| greedy batch-32 (argmax fast path) | 15.64 ms/tok — 63.9 t/s/u | 15.33 ms/tok — 65.2 t/s/u |
| top-k run (k=1, p=0.5 — declines the fast path) | 96.42 ms/tok — 10.37 t/s/u | 96.89 ms/tok — 10.32 t/s/u |

The padded path is functionally correct (the single-device top-k unit tests pass with it force-enabled) but changes end-to-end decode by <0.5% — noise. The top-k path's ~84 ms/step overhead over argmax lives in the rest of the sampling chain (tiebreak / gather / multinomial pipeline of many small ops), not in the wide topk scans, so the factory switch cannot matter. The dead branch is removed and `pad_logits_to_power_of_2` stays multi-device only (its original, measured use). Speeding up single-card top-k decode is a separate profiling exercise on the sampling chain.

Runs: base 0.6B [32175056716](https://github.com/tenstorrent/tt-metal/actions/runs/32175056716), padded 0.6B [32175064191](https://github.com/tenstorrent/tt-metal/actions/runs/32175064191), padded unit [32175071449](https://github.com/tenstorrent/tt-metal/actions/runs/32175071449).

### Testing

- `test_ttsampling_topk_matches_argmax_on_single_device`: vocabs 32768 / 32000 / 151936 (4-way split) / 256000 (Gemma-2).
- `test_ttsampling_force_argmax_matches_row_max_on_wide_vocab`: chunked-untilize argmax path at 151936 and 256000.
- Pure-python tests for the split math (`num_single_device_vocab_splits`, incl. host-fallback case) and untilize chunk count.
- Seven host-only SeedManager tests: duplicate-seed stream distinctness, unique-seed stream unchanged and slot-independent, salt survives remap, no re-collision after vacate, salt survives decode re-registration after a sibling finishes, tail-ghost clearing, prefill full-reset in a reused slot.
- New tier-3 `tt-sampling` CI entry runs the above on wh_n150 and bh_p150 (previously `models/common/tests/test_sampling.py` had no tiered-CI coverage).
- `--sampling_params` is now usable everywhere: the type=dict→json.loads fix is swept across all six conftests registering the option (emule vendored copy, qwen25_vl, qwen3_vl, llama3_70b_galaxy, multimodal/gemma3), and a partial JSON override (e.g. only temperature) merges onto the parametrized defaults instead of KeyError'ing.
- Hardware-validated on CI (wh_n150): Gemma-2-2B ci-token-matching e2e (on-device sampling now live for its 256000 vocab), Qwen3-0.6B e2e incl. the top-k vocab-split run, Qwen3-1.7B e2e ([32234528254](https://github.com/tenstorrent/tt-metal/actions/runs/32234528254)), tt-sampling unit on both SKUs.

CI runner note: the runners have no internet, so HF checkpoints for new entries must be seeded on the MLPerf mount out of band (done for Qwen3-0.6B/1.7B on the N150 pool). The bh_p150 skus will need the same seeding on the BH cache before their first scheduled run.

### Design note for reviewers

Deterministic replay for duplicate-seed requests now depends on admission order (k-th duplicate gets salt k). The previous behavior — all duplicates byte-identical — provided determinism nobody could use. If a stronger contract is wanted (e.g. vLLM passing a per-sequence sample index), the salt is the natural place to plumb it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/qwen3-nway-vocab-split)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/qwen3-nway-vocab-split)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/qwen3-nway-vocab-split)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/qwen3-nway-vocab-split)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/qwen3-nway-vocab-split)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/qwen3-nway-vocab-split)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/qwen3-nway-vocab-split)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/qwen3-nway-vocab-split)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/qwen3-nway-vocab-split)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/qwen3-nway-vocab-split)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/qwen3-nway-vocab-split)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/qwen3-nway-vocab-split)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/qwen3-nway-vocab-split)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/qwen3-nway-vocab-split)
