### PR TITLE
[Cleanup] Fabric tests update to Mesh APIs

### DIFF
--- a/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_fixture.hpp
@@ -19,6 +19,7 @@
 #include "common/tt_backend_api_types.hpp"
 #include <llrt/tt_cluster.hpp>
 #include <tt-metalium/allocator.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 #include "test_host_kernel_common.hpp"
 
 namespace tt::tt_fabric::fabric_router_tests {
@@ -135,7 +136,7 @@ public:
     void RunProgramNonblocking(
         const std::shared_ptr<tt::tt_metal::distributed::MeshDevice>& device, tt::tt_metal::Program& program) {
         if (this->slow_dispatch_) {
-            tt::tt_metal::detail::LaunchProgram(device->get_devices()[0], program, false);
+            tt::tt_metal::slow_dispatch::LaunchProgram(*device, program, false);
         } else {
             tt::tt_metal::distributed::MeshCommandQueue& cq = device->mesh_command_queue();
             // Create a mesh workload from the program

--- a/tests/tt_metal/tt_fabric/common/fabric_worker_kernel_helpers.cpp
+++ b/tests/tt_metal/tt_fabric/common/fabric_worker_kernel_helpers.cpp
@@ -54,11 +54,10 @@ std::shared_ptr<tt_metal::Program> create_traffic_generator_program(
 
     auto program = std::make_shared<tt_metal::Program>();
 
-    // Use first device
-    auto* src_physical_device = device->get_devices()[0];
     // Get source fabric node ID from logical first device
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    FabricNodeId src_fabric_node = control_plane.get_fabric_node_id_from_physical_chip_id(src_physical_device->id());
+    const auto device_id = device->get_device_ids()[0];
+    FabricNodeId src_fabric_node = control_plane.get_fabric_node_id_from_physical_chip_id(device_id);
     // Target core on remote chip for traffic destination
     tt::tt_metal::CoreCoord remote_logical_core(0, 0);
 
@@ -129,16 +128,13 @@ void signal_worker_teardown(
 
     std::vector<uint32_t> data = {WORKER_TEARDOWN};
 
-    // Get the actual device where the kernel is running (first device in mesh)
-    auto* device = mesh_device->get_devices()[0];
-
     auto virtual_core = mesh_device->virtual_core_from_logical_core(logical_core, CoreType::WORKER);
 
     // Use Cluster::write_core() to write to L1 on the device
     tt::tt_metal::MetalContext::instance().get_cluster().write_core(
         data.data(),
         sizeof(uint32_t),
-        tt_cxy_pair(device->id(), virtual_core),
+        tt_cxy_pair(mesh_device->get_device_ids()[0], virtual_core),
         teardown_signal_address);
 }
 

--- a/tests/tt_metal/tt_fabric/common/test_fabric_edm_common.hpp
+++ b/tests/tt_metal/tt_fabric/common/test_fabric_edm_common.hpp
@@ -29,6 +29,7 @@
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/mesh_workload.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 #include <umd/device/types/arch.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
@@ -139,7 +140,7 @@ static void build_and_enqueue(
         futures.emplace_back(tt::tt_metal::detail::async([&devices, &programs, i, enqueue_only]() {
             if constexpr (std::is_same_v<ProgramContainer, std::vector<Program*>>) {
                 if (!enqueue_only) {
-                    tt::tt_metal::detail::CompileProgram(devices[i]->get_devices()[0], *programs[i]);
+                    slow_dispatch::CompileProgram(*devices[i], *programs[i]);
                 }
                 MeshWorkload mesh_workload;
                 MeshCoordinateRange device_range = MeshCoordinateRange({0, 0}, {0, 0});  // Single device range
@@ -147,7 +148,7 @@ static void build_and_enqueue(
                 tt::tt_metal::distributed::EnqueueMeshWorkload(devices[i]->mesh_command_queue(), mesh_workload, false);
             } else {
                 if (!enqueue_only) {
-                    tt::tt_metal::detail::CompileProgram(devices[i]->get_devices()[0], programs[i]);
+                    slow_dispatch::CompileProgram(*devices[i], programs[i]);
                 }
                 MeshWorkload mesh_workload;
                 MeshCoordinateRange device_range = MeshCoordinateRange({0, 0}, {0, 0});  // Single device range

--- a/tests/tt_metal/tt_fabric/common/utils.cpp
+++ b/tests/tt_metal/tt_fabric/common/utils.cpp
@@ -49,7 +49,7 @@ bool find_device_with_neighbor_in_multi_direction(
     // Find a device with enough neighbours in the specified direction
     bool connection_found = false;
     for (const auto& device : devices) {
-        src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(device->get_devices()[0]->id());
+        src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(device->get_device_ids()[0]);
         if (incoming_direction.has_value()) {
             if (control_plane.get_intra_chip_neighbors(src_fabric_node_id, incoming_direction.value()).empty()) {
                 // This potential source will not have the requested incoming direction, skip
@@ -82,7 +82,7 @@ bool find_device_with_neighbor_in_multi_direction(
             }
         }
         if (connection_found) {
-            src_physical_device_id = device->get_devices()[0]->id();
+            src_physical_device_id = device->get_device_ids()[0];
             dst_fabric_node_ids_by_dir = std::move(temp_end_fabric_node_ids_by_dir);
             dst_physical_device_ids_by_dir = std::move(temp_physical_end_device_ids_by_dir);
             break;
@@ -101,12 +101,12 @@ bool find_device_with_neighbor_in_direction(
     auto& control_plane= tt::tt_metal::MetalContext::instance().get_control_plane();
     auto devices = fixture->get_devices();
     for (const auto& device : devices) {
-        src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(device->get_devices()[0]->id());
+        src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(device->get_device_ids()[0]);
 
         // Get neighbours within a mesh in the given direction
         auto neighbors = control_plane.get_intra_chip_neighbors(src_fabric_node_id, direction);
         if (!neighbors.empty()) {
-            src_physical_device_id = device->get_devices()[0]->id();
+            src_physical_device_id = device->get_device_ids()[0];
             dst_fabric_node_id = FabricNodeId(src_fabric_node_id.mesh_id, neighbors[0]);
             dst_physical_device_id = control_plane.get_physical_chip_id_from_fabric_node_id(dst_fabric_node_id);
             return true;

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_1d_fabric.cpp
@@ -302,10 +302,10 @@ void RunTestLineMcast(BaseFabricFixture* fixture, const std::vector<McastRouting
     // Launch sender and receiver programs and wait for them to finish
     // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
     for (auto& [dev, recv_program] : recv_programs) {
-        log_info(tt::LogTest, "Run receiver on: {}", dev->get_devices()[0]->id());
+        log_info(tt::LogTest, "Run receiver on: {}", dev->get_device_ids()[0]);
         fixture->RunProgramNonblocking(dev, *recv_program);
     }
-    log_info(tt::LogTest, "Run Sender on: {}", sender_device->get_devices()[0]->id());
+    log_info(tt::LogTest, "Run Sender on: {}", sender_device->get_device_ids()[0]);
     fixture->RunProgramNonblocking(sender_device, sender_program);
 
     // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
@@ -315,8 +315,8 @@ void RunTestLineMcast(BaseFabricFixture* fixture, const std::vector<McastRouting
     fixture->WaitForSingleProgramDone(sender_device, sender_program);
 
     std::vector<uint32_t> sender_status;
-    tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+    tt_metal::slow_dispatch::ReadFromL1(
+        *sender_device,
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -330,8 +330,8 @@ void RunTestLineMcast(BaseFabricFixture* fixture, const std::vector<McastRouting
     // NOLINTNEXTLINE(bugprone-nondeterministic-pointer-iteration-order)
     for (auto& [dev, _] : recv_programs) {
         std::vector<uint32_t> receiver_status;
-        tt_metal::detail::ReadFromDeviceL1(
-            dev->get_devices()[0],
+        tt_metal::slow_dispatch::ReadFromL1(
+            *dev,
             receiver_logical_core,
             worker_mem_map.test_results_address,
             worker_mem_map.test_results_size_bytes,
@@ -397,8 +397,8 @@ void RunTestUnicastRaw(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDir
         auto random_dev_list = get_random_numbers_from_range(0, devices.size() - 1, devices.size());
 
         // pick the first two in the list to be src and dst devices for the test.
-        src_physical_device_id = devices[random_dev_list[0]]->get_devices()[0]->id();
-        dst_physical_device_id = devices[random_dev_list[1]]->get_devices()[0]->id();
+        src_physical_device_id = devices[random_dev_list[0]]->get_device_ids()[0];
+        dst_physical_device_id = devices[random_dev_list[1]]->get_device_ids()[0];
         src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(src_physical_device_id);
         dst_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(dst_physical_device_id);
         mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
@@ -513,16 +513,16 @@ void RunTestUnicastRaw(BaseFabricFixture* fixture, uint32_t num_hops, RoutingDir
     std::vector<uint32_t> sender_status;
     std::vector<uint32_t> receiver_status;
 
-    tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+    tt_metal::slow_dispatch::ReadFromL1(
+        *sender_device,
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
         sender_status,
         CoreType::WORKER);
 
-    tt_metal::detail::ReadFromDeviceL1(
-        receiver_device->get_devices()[0],
+    tt_metal::slow_dispatch::ReadFromL1(
+        *receiver_device,
         receiver_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -635,13 +635,13 @@ void run_unicast_test_bw_chips(
     // Simple notification mailbox with flushing atomic increment is used instead of 2-way handshake for simple testing
     if (use_dram_dst) {
         std::vector<uint32_t> zeros(tt::tt_metal::hal::get_l1_alignment() / sizeof(uint32_t), 0);  // zero out mailbox
-        tt_metal::detail::WriteToDeviceL1(
-            receiver_device->get_devices()[0],
+        tt_metal::slow_dispatch::WriteToL1(
+            *receiver_device,
             receiver_logical_core,
             worker_mem_map.notification_mailbox_address,
             zeros,
             CoreType::WORKER);
-        tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(receiver_device->get_devices()[0]->id());
+        tt::tt_metal::MetalContext::instance().get_cluster().l1_barrier(receiver_device->get_device_ids()[0]);
     }
 
     std::vector<uint32_t> receiver_runtime_args = {worker_mem_map.packet_payload_size_bytes, num_packets, time_seed};
@@ -676,16 +676,16 @@ void run_unicast_test_bw_chips(
     std::vector<uint32_t> sender_status;
     std::vector<uint32_t> receiver_status;
 
-    tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+    tt_metal::slow_dispatch::ReadFromL1(
+        *sender_device,
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
         sender_status,
         CoreType::WORKER);
 
-    tt_metal::detail::ReadFromDeviceL1(
-        receiver_device->get_devices()[0],
+    tt_metal::slow_dispatch::ReadFromL1(
+        *receiver_device,
         receiver_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -741,8 +741,8 @@ void RunTestUnicastConnAPIRandom(BaseFabricFixture* fixture) {
     // In 2D routing the source and desitnation devices can be anywhere on the mesh.
     auto random_dev_list = get_random_numbers_from_range(0, devices.size() - 1, 2);
 
-    const auto src_physical_device_id = devices[random_dev_list[0]]->get_devices()[0]->id();
-    const auto dst_physical_device_id = devices[random_dev_list[1]]->get_devices()[0]->id();
+    const auto src_physical_device_id = devices[random_dev_list[0]]->get_device_ids()[0];
+    const auto dst_physical_device_id = devices[random_dev_list[1]]->get_device_ids()[0];
 
     log_info(tt::LogTest, "Src Phys ChipId {}", src_physical_device_id);
     log_info(tt::LogTest, "Dst Phys ChipId {}", dst_physical_device_id);
@@ -1077,8 +1077,8 @@ void RunTestMCastConnAPI(
     std::vector<uint32_t> left_recv_status;
     std::vector<uint32_t> right_recv_status;
 
-    tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+    tt_metal::slow_dispatch::ReadFromL1(
+        *sender_device,
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -1097,8 +1097,8 @@ void RunTestMCastConnAPI(
             const auto& receiver_device = fixture->get_device(device_id);
             std::vector<uint32_t> recv_status;
 
-            tt_metal::detail::ReadFromDeviceL1(
-                receiver_device->get_devices()[0],
+            tt_metal::slow_dispatch::ReadFromL1(
+                *receiver_device,
                 receiver_logical_core,
                 worker_mem_map.test_results_address,
                 worker_mem_map.test_results_size_bytes,
@@ -1618,8 +1618,8 @@ void RunTest2DMCastConnAPI(
     std::vector<uint32_t> left_recv_status;
     std::vector<uint32_t> right_recv_status;
 
-    tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+    tt_metal::slow_dispatch::ReadFromL1(
+        *sender_device,
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -1637,8 +1637,8 @@ void RunTest2DMCastConnAPI(
         const auto& receiver_device = fixture->get_device(rx_physical_device_id);
         std::vector<uint32_t> recv_status;
 
-        tt_metal::detail::ReadFromDeviceL1(
-            receiver_device->get_devices()[0],
+        tt_metal::slow_dispatch::ReadFromL1(
+            *receiver_device,
             receiver_logical_core,
             worker_mem_map.test_results_address,
             worker_mem_map.test_results_size_bytes,
@@ -1839,8 +1839,8 @@ void RunTestChipMCast1D(BaseFabricFixture* fixture, RoutingDirection dir, uint32
     std::vector<uint32_t> left_recv_status;
     std::vector<uint32_t> right_recv_status;
 
-    tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+    tt_metal::slow_dispatch::ReadFromL1(
+        *sender_device,
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -1866,8 +1866,8 @@ void RunTestChipMCast1D(BaseFabricFixture* fixture, RoutingDirection dir, uint32
 
             std::vector<uint32_t> recv_status;
 
-            tt_metal::detail::ReadFromDeviceL1(
-                receiver_device->get_devices()[0],
+            tt_metal::slow_dispatch::ReadFromL1(
+                *receiver_device,
                 receiver_logical_core,
                 worker_mem_map.test_results_address,
                 worker_mem_map.test_results_size_bytes,
@@ -2046,9 +2046,9 @@ void RunEDMConnectionStressTest(
                 worker_args.push_back(i % message_counts.size());
 
                 const auto sender_fabric_node_id =
-                    tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->get_devices()[0]->id());
+                    tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(sender_device->get_device_ids()[0]);
                 const auto receiver_fabric_node_id =
-                    tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(receiver_device->get_devices()[0]->id());
+                    tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(receiver_device->get_device_ids()[0]);
                 append_fabric_connection_rt_args(
                     sender_fabric_node_id,
                     receiver_fabric_node_id,
@@ -2262,8 +2262,8 @@ void FabricUnicastCommon(
     }
 
     std::vector<uint32_t> sender_status;
-    tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+    tt_metal::slow_dispatch::ReadFromL1(
+        *sender_device,
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -2273,8 +2273,8 @@ void FabricUnicastCommon(
 
     std::vector<uint32_t> receiver_status;
     for (const auto& recv_dev : receiver_devices) {
-        tt_metal::detail::ReadFromDeviceL1(
-            recv_dev->get_devices()[0],
+        tt_metal::slow_dispatch::ReadFromL1(
+            *recv_dev,
             receiver_logical_core,
             worker_mem_map.test_results_address,
             worker_mem_map.test_results_size_bytes,
@@ -2572,16 +2572,12 @@ void UDMFabricUnicastCommon(
         if (noc_packet_type == NocPacketType::NOC_UNICAST_ATOMIC_INC) {
             uint32_t total_size_to_clear = num_packets * worker_mem_map.packet_payload_size_bytes;
             std::vector<uint32_t> zeros(total_size_to_clear / sizeof(uint32_t), 0);
-            tt_metal::detail::WriteToDeviceL1(
-                receiver_device->get_devices()[0],
-                receiver_logical_core,
-                worker_mem_map.target_address,
-                zeros,
-                CoreType::WORKER);
+            tt_metal::slow_dispatch::WriteToL1(
+                *receiver_device, receiver_logical_core, worker_mem_map.target_address, zeros, CoreType::WORKER);
             // Clear RISC1 target memory as well
             if (dual_risc) {
-                tt_metal::detail::WriteToDeviceL1(
-                    receiver_device->get_devices()[0],
+                tt_metal::slow_dispatch::WriteToL1(
+                    *receiver_device,
                     receiver_logical_core,
                     worker_mem_map_risc1.target_address,
                     zeros,
@@ -2602,8 +2598,8 @@ void UDMFabricUnicastCommon(
                                   const WorkerMemMap& mem_map,
                                   const std::string& risc_name) {
         std::vector<uint32_t> sender_status;
-        tt_metal::detail::ReadFromDeviceL1(
-            sender_device->get_devices()[0],
+        tt_metal::slow_dispatch::ReadFromL1(
+            *sender_device,
             sender_core,
             mem_map.test_results_address,
             mem_map.test_results_size_bytes,
@@ -2613,8 +2609,8 @@ void UDMFabricUnicastCommon(
             << "Sender " << risc_name << " failed at core (" << sender_core.x << ", " << sender_core.y << ")";
 
         std::vector<uint32_t> receiver_status;
-        tt_metal::detail::ReadFromDeviceL1(
-            receiver_device->get_devices()[0],
+        tt_metal::slow_dispatch::ReadFromL1(
+            *receiver_device,
             receiver_core,
             mem_map.test_results_address,
             mem_map.test_results_size_bytes,
@@ -2687,7 +2683,7 @@ void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocPacketType no
 
     // Calculate number of sender/receiver cores per device (all cores in top/bottom half)
     // Split grid into top half (senders) and bottom half (receivers)
-    auto grid_size = devices[0]->get_devices()[0]->compute_with_storage_grid_size();
+    auto grid_size = devices[0]->compute_with_storage_grid_size();
     uint32_t receiver_y_start = grid_size.y / 2;
     uint32_t receiver_y_end = grid_size.y;
     uint32_t sender_rows = receiver_y_start;                  // Number of rows in top half
@@ -2986,15 +2982,11 @@ void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocPacketType no
             for (uint32_t core_idx = 0; core_idx < num_core_pairs; core_idx++) {
                 tt::tt_metal::CoreCoord receiver_logical_core = receiver_logical_cores[core_idx];
                 std::vector<uint32_t> zeros(total_l1_to_clear / sizeof(uint32_t), 0);
-                tt_metal::detail::WriteToDeviceL1(
-                    device_ptr->get_devices()[0],
-                    receiver_logical_core,
-                    worker_mem_map.target_address,
-                    zeros,
-                    CoreType::WORKER);
+                tt_metal::slow_dispatch::WriteToL1(
+                    *device_ptr, receiver_logical_core, worker_mem_map.target_address, zeros, CoreType::WORKER);
                 if (dual_risc) {
-                    tt_metal::detail::WriteToDeviceL1(
-                        device_ptr->get_devices()[0],
+                    tt_metal::slow_dispatch::WriteToL1(
+                        *device_ptr,
                         receiver_logical_core,
                         worker_mem_map_risc1.target_address,
                         zeros,
@@ -3033,8 +3025,8 @@ void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocPacketType no
 
                 // Check sender status
                 std::vector<uint32_t> sender_status;
-                tt_metal::detail::ReadFromDeviceL1(
-                    device_ptr->get_devices()[0],
+                tt_metal::slow_dispatch::ReadFromL1(
+                    *device_ptr,
                     sender_logical_core,
                     mem_map.test_results_address,
                     mem_map.test_results_size_bytes,
@@ -3050,8 +3042,8 @@ void UDMFabricUnicastAllToAllCommon(BaseFabricFixture* fixture, NocPacketType no
 
                 // Check receiver status
                 std::vector<uint32_t> receiver_status;
-                tt_metal::detail::ReadFromDeviceL1(
-                    device_ptr->get_devices()[0],
+                tt_metal::slow_dispatch::ReadFromL1(
+                    *device_ptr,
                     receiver_logical_core,
                     mem_map.test_results_address,
                     mem_map.test_results_size_bytes,
@@ -3363,8 +3355,8 @@ void Fabric2DMulticastCommon(
     }
 
     std::vector<uint32_t> sender_status;
-    tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+    tt_metal::slow_dispatch::ReadFromL1(
+        *sender_device,
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -3376,8 +3368,8 @@ void Fabric2DMulticastCommon(
 
     for (auto& [dev, _] : receiver_programs) {
         std::vector<uint32_t> recv_status;
-        tt_metal::detail::ReadFromDeviceL1(
-            dev->get_devices()[0],
+        tt_metal::slow_dispatch::ReadFromL1(
+            *dev,
             receiver_logical_core,
             worker_mem_map.test_results_address,
             worker_mem_map.test_results_size_bytes,
@@ -3545,8 +3537,8 @@ void FabricMulticastCommon(
     }
 
     std::vector<uint32_t> sender_status;
-    tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+    tt_metal::slow_dispatch::ReadFromL1(
+        *sender_device,
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -3558,8 +3550,8 @@ void FabricMulticastCommon(
 
     for (auto& [dev, _] : receiver_programs) {
         std::vector<uint32_t> recv_status;
-        tt_metal::detail::ReadFromDeviceL1(
-            dev->get_devices()[0],
+        tt_metal::slow_dispatch::ReadFromL1(
+            *dev,
             receiver_logical_core,
             worker_mem_map.test_results_address,
             worker_mem_map.test_results_size_bytes,
@@ -3832,8 +3824,8 @@ void FabricSparseMulticastCommon(
     }
 
     std::vector<uint32_t> sender_status;
-    tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+    tt_metal::slow_dispatch::ReadFromL1(
+        *sender_device,
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -3843,8 +3835,8 @@ void FabricSparseMulticastCommon(
 
     for (auto& [dev, _] : receiver_programs) {
         std::vector<uint32_t> recv_status;
-        tt_metal::detail::ReadFromDeviceL1(
-            dev->get_devices()[0],
+        tt_metal::slow_dispatch::ReadFromL1(
+            *dev,
             receiver_logical_core,
             worker_mem_map.test_results_address,
             worker_mem_map.test_results_size_bytes,

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_apis.cpp
@@ -94,7 +94,7 @@ void RunGetNextHopRouterDirectionTest(BaseFabricFixture* fixture, bool is_multi_
     for (size_t src_idx = 0; src_idx < NUM_DEVICES; src_idx++) {
         const auto& src_device = devices[src_idx];
         auto src_fabric_node_id =
-            control_plane.get_fabric_node_id_from_physical_chip_id(src_device->get_devices()[0]->id());
+            control_plane.get_fabric_node_id_from_physical_chip_id(src_device->get_device_ids()[0]);
         uint32_t src_fabric_chip_id = src_fabric_node_id.chip_id;
 
         uint32_t result_size = NUM_DEVICES * sizeof(uint32_t);
@@ -114,7 +114,7 @@ void RunGetNextHopRouterDirectionTest(BaseFabricFixture* fixture, bool is_multi_
         // Add mesh_id and chip_id pairs for all destinations
         for (size_t dst_idx = 0; dst_idx < NUM_DEVICES; dst_idx++) {
             auto dst_fabric_node_id =
-                control_plane.get_fabric_node_id_from_physical_chip_id(devices[dst_idx]->get_devices()[0]->id());
+                control_plane.get_fabric_node_id_from_physical_chip_id(devices[dst_idx]->get_device_ids()[0]);
             runtime_args.push_back(*dst_fabric_node_id.mesh_id);  // dst_mesh_id
             runtime_args.push_back(dst_fabric_node_id.chip_id);   // dst_chip_id
         }
@@ -138,7 +138,7 @@ void RunGetNextHopRouterDirectionTest(BaseFabricFixture* fixture, bool is_multi_
     for (size_t src_idx = 0; src_idx < NUM_DEVICES; src_idx++) {
         const auto& src_device = devices[src_idx];
         auto src_fabric_node_id =
-            control_plane.get_fabric_node_id_from_physical_chip_id(src_device->get_devices()[0]->id());
+            control_plane.get_fabric_node_id_from_physical_chip_id(src_device->get_device_ids()[0]);
 
         std::vector<uint32_t> result_data;
         tt::tt_metal::distributed::ReadShard(
@@ -148,7 +148,7 @@ void RunGetNextHopRouterDirectionTest(BaseFabricFixture* fixture, bool is_multi_
             tt::tt_metal::distributed::MeshCoordinate({0, 0}));
         for (size_t dst_idx = 0; dst_idx < NUM_DEVICES; dst_idx++) {
             auto dst_fabric_node_id =
-                control_plane.get_fabric_node_id_from_physical_chip_id(devices[dst_idx]->get_devices()[0]->id());
+                control_plane.get_fabric_node_id_from_physical_chip_id(devices[dst_idx]->get_device_ids()[0]);
             uint32_t actual_direction = result_data[dst_idx];
             if (src_fabric_node_id == dst_fabric_node_id) {
                 // Self-routing should return INVALID_DIRECTION
@@ -203,8 +203,7 @@ void RunSetUnicastRouteTest(
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
 
     // Get mesh shape to determine if it's 2D fabric
-    auto src_fabric_node_id =
-        control_plane.get_fabric_node_id_from_physical_chip_id(devices[0]->get_devices()[0]->id());
+    auto src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(devices[0]->get_device_ids()[0]);
     auto mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
     const auto& fabric_context = control_plane.get_fabric_context();
     const auto topology = fabric_context.get_fabric_topology();
@@ -225,7 +224,7 @@ void RunSetUnicastRouteTest(
     for (size_t src_idx = 0; src_idx < NUM_DEVICES; src_idx++) {
         const auto& src_device = devices[src_idx];
         auto src_fabric_node_id =
-            control_plane.get_fabric_node_id_from_physical_chip_id(src_device->get_devices()[0]->id());
+            control_plane.get_fabric_node_id_from_physical_chip_id(src_device->get_device_ids()[0]);
         uint32_t src_fabric_chip_id = src_fabric_node_id.chip_id;
 
         uint32_t result_size = NUM_DEVICES * RESULT_SIZE_PER_DEVICE * sizeof(uint32_t);
@@ -247,7 +246,7 @@ void RunSetUnicastRouteTest(
         // Add mesh_id and chip_id pairs for all destinations
         for (size_t dst_idx = 0; dst_idx < NUM_DEVICES; dst_idx++) {
             auto dst_fabric_node_id =
-                control_plane.get_fabric_node_id_from_physical_chip_id(devices[dst_idx]->get_devices()[0]->id());
+                control_plane.get_fabric_node_id_from_physical_chip_id(devices[dst_idx]->get_device_ids()[0]);
             runtime_args.push_back(*dst_fabric_node_id.mesh_id);  // dst_mesh_id
             runtime_args.push_back(dst_fabric_node_id.chip_id);   // dst_chip_id
         }
@@ -289,25 +288,18 @@ void RunSetUnicastRouteTest(
     for (size_t src_idx = 0; src_idx < NUM_DEVICES; src_idx++) {
         const auto& src_device = devices[src_idx];
         auto src_fabric_node_id =
-            control_plane.get_fabric_node_id_from_physical_chip_id(src_device->get_devices()[0]->id());
+            control_plane.get_fabric_node_id_from_physical_chip_id(src_device->get_device_ids()[0]);
 
         uint32_t result_size = NUM_DEVICES * RESULT_SIZE_PER_DEVICE * sizeof(uint32_t);
         std::vector<uint32_t> result_data;
 
-        // Use tt_metal detail API to read from device L1 memory directly
-        // Note: This is experimental and bypasses safety checks
         CoreType read_core_type = (core_type == HalProgrammableCoreType::IDLE_ETH) ? CoreType::ETH : CoreType::WORKER;
-        tt::tt_metal::detail::ReadFromDeviceL1(
-            src_device->get_devices()[0],
-            logical_cores[src_idx],
-            result_addrs[src_idx],
-            result_size,
-            result_data,
-            read_core_type);
+        tt::tt_metal::slow_dispatch::ReadFromL1(
+            *src_device, logical_cores[src_idx], result_addrs[src_idx], result_size, result_data, read_core_type);
 
         for (size_t dst_idx = 0; dst_idx < NUM_DEVICES; dst_idx++) {
             auto dst_fabric_node_id =
-                control_plane.get_fabric_node_id_from_physical_chip_id(devices[dst_idx]->get_devices()[0]->id());
+                control_plane.get_fabric_node_id_from_physical_chip_id(devices[dst_idx]->get_device_ids()[0]);
             if (!is_2d_fabric && std::abs(
                                      static_cast<long>(src_fabric_node_id.chip_id) -
                                      static_cast<long>(dst_fabric_node_id.chip_id)) >= MAX_CHIPS_LOWLAT_1D) {
@@ -344,8 +336,7 @@ std::vector<std::tuple<uint32_t, uint32_t, uint32_t, uint32_t>> GenerateAllValid
     }
 
     auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-    auto src_fabric_node_id =
-        control_plane.get_fabric_node_id_from_physical_chip_id(devices[0]->get_devices()[0]->id());
+    auto src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(devices[0]->get_device_ids()[0]);
     auto mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
 
     uint32_t ns_dim = mesh_shape[0];
@@ -939,7 +930,7 @@ std::vector<std::pair<tt::tt_metal::CoreCoord, tt::tt_metal::CoreCoord>> GetAllW
 
 // UDM Mode Worker Coordinate Tests - test fabric communication with all workers simultaneously
 TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastWriteAllWorkerCoords) {
-    auto grid_size = get_devices()[0]->get_devices()[0]->compute_with_storage_grid_size();
+    auto grid_size = get_devices()[0]->compute_with_storage_grid_size();
     auto all_worker_pairs = GetAllWorkerCoordPairs(grid_size);
     log_info(tt::LogTest, "Testing {} worker pairs for write operations", all_worker_pairs.size());
     for (uint32_t dst : {5u, 6u, 7u}) {
@@ -950,7 +941,7 @@ TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastWriteAllWorkerCoords) 
 }
 
 TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastReadAllWorkerCoords) {
-    auto grid_size = get_devices()[0]->get_devices()[0]->compute_with_storage_grid_size();
+    auto grid_size = get_devices()[0]->compute_with_storage_grid_size();
     auto all_worker_pairs = GetAllWorkerCoordPairs(grid_size);
     log_info(tt::LogTest, "Testing {} worker pairs for read operations", all_worker_pairs.size());
     for (uint32_t dst : {5u, 6u, 7u}) {
@@ -964,7 +955,7 @@ TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastWriteAllWorkerCoordsDu
     if (arch_ == tt::ARCH::WORMHOLE_B0) {
         GTEST_SKIP() << "Dual RISC test does not support wormhole";
     }
-    auto grid_size = get_devices()[0]->get_devices()[0]->compute_with_storage_grid_size();
+    auto grid_size = get_devices()[0]->compute_with_storage_grid_size();
     auto all_worker_pairs = GetAllWorkerCoordPairs(grid_size);
     log_info(tt::LogTest, "Testing {} worker pairs for write operations", all_worker_pairs.size());
     for (uint32_t dst : {5u, 6u, 7u}) {
@@ -978,7 +969,7 @@ TEST_F(NightlyFabric2DUDMModeFixture, TestUDMFabricUnicastReadAllWorkerCoordsDua
     if (arch_ == tt::ARCH::WORMHOLE_B0) {
         GTEST_SKIP() << "Dual RISC test does not support wormhole";
     }
-    auto grid_size = get_devices()[0]->get_devices()[0]->compute_with_storage_grid_size();
+    auto grid_size = get_devices()[0]->compute_with_storage_grid_size();
     auto all_worker_pairs = GetAllWorkerCoordPairs(grid_size);
     log_info(tt::LogTest, "Testing {} worker pairs for read operations", all_worker_pairs.size());
     for (uint32_t dst : {5u, 6u, 7u}) {

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux.cpp
@@ -237,7 +237,7 @@ std::vector<ChipId> get_physical_chip_sequence(uint32_t num_seq_chips) {
 uint32_t get_sender_id(tt::tt_metal::CoreCoord logical_core) { return logical_core.x << 16 || logical_core.y; }
 
 void create_kernel(
-    tt::tt_metal::IDevice* device,
+    tt::tt_metal::distributed::MeshDevice& device,
     tt::tt_metal::Program& program_handle,
     const std::string& kernel_src,
     const tt::tt_metal::CoreCoord& logical_core,
@@ -257,7 +257,7 @@ void create_kernel(
 
     for (const auto& [start_address, num_bytes] : addresses_to_clear) {
         std::vector<uint32_t> zero_vec((num_bytes / sizeof(uint32_t)), 0);
-        tt::tt_metal::detail::WriteToDeviceL1(device, logical_core, start_address, zero_vec);
+        tt::tt_metal::slow_dispatch::WriteToL1(device, logical_core, start_address, zero_vec);
     }
 }
 
@@ -267,15 +267,16 @@ void create_mux_kernel(
     const std::shared_ptr<tt_metal::distributed::MeshDevice>& device,
     const std::shared_ptr<tt_metal::distributed::MeshDevice>& dest_device,
     tt::tt_metal::Program& program_handle) {
-    const auto src_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(device->get_devices()[0]->id());
-    const auto dst_node_id =
-        tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(dest_device->get_devices()[0]->id());
+    const auto src_device_id = device->get_device_ids()[0];
+    const auto dst_device_id = dest_device->get_device_ids()[0];
+    const auto src_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(src_device_id);
+    const auto dst_node_id = tt::tt_fabric::get_fabric_node_id_from_physical_chip_id(dst_device_id);
     const auto& available_links = get_forwarding_link_indices(src_node_id, dst_node_id);
     TT_FATAL(
         !available_links.empty(),
         "Couldnt find any forwarding routing planes from: {} to: {}",
-        device->id(),
-        dest_device->id());
+        src_device_id,
+        dst_device_id);
 
     std::vector<uint32_t> mux_ct_args = mux_kernel_config.get_fabric_mux_compile_time_args();
     std::vector<uint32_t> mux_rt_args = mux_kernel_config.get_fabric_mux_run_time_args(
@@ -283,13 +284,7 @@ void create_mux_kernel(
 
     std::vector<std::pair<size_t, size_t>> addresses_to_clear = {};
     create_kernel(
-        device->get_devices()[0],
-        program_handle,
-        mux_kernel_src,
-        mux_logical_core,
-        mux_ct_args,
-        mux_rt_args,
-        addresses_to_clear);
+        *device, program_handle, mux_kernel_src, mux_logical_core, mux_ct_args, mux_rt_args, addresses_to_clear);
 }
 
 void create_worker_kernel(
@@ -359,10 +354,10 @@ void create_worker_kernel(
 
     if (test_config.is_2d_fabric) {
         const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
-        const auto src_fabric_node_id =
-            control_plane.get_fabric_node_id_from_physical_chip_id(device->get_devices()[0]->id());
-        const auto dst_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(
-            worker_test_config.dest_device->get_devices()[0]->id());
+        const auto src_device_id = device->get_device_ids()[0];
+        const auto dst_device_id = worker_test_config.dest_device->get_device_ids()[0];
+        const auto src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(src_device_id);
+        const auto dst_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(dst_device_id);
         const auto mesh_shape = control_plane.get_physical_mesh_shape(src_fabric_node_id.mesh_id);
         const auto forwarding_direction =
             control_plane.get_forwarding_direction(src_fabric_node_id, dst_fabric_node_id);
@@ -398,7 +393,7 @@ void create_worker_kernel(
     }
 
     create_kernel(
-        device->get_devices()[0],
+        *device,
         program_handle,
         std::string(worker_test_config.kernel_src),
         worker_logical_core,
@@ -602,10 +597,11 @@ void run_mux_test_variant(FabricMuxBaseFixture* fixture, TestConfig test_config)
     }
 
     if (!test_config.terminate_from_kernel) {
-        auto wait_for_worker_completion = [&](tt::tt_metal::IDevice* device, const tt::tt_metal::CoreCoord& core) {
+        auto wait_for_worker_completion = [&](tt::tt_metal::distributed::MeshDevice& device,
+                                              const tt::tt_metal::CoreCoord& core) {
             std::vector<uint32_t> worker_status(1, 0);
             while ((worker_status[0] & 0xFFFF) == 0) {
-                tt_metal::detail::ReadFromDeviceL1(
+                tt_metal::slow_dispatch::ReadFromL1(
                     device, core, worker_memory_map.test_results_address, 4, worker_status);
             }
         };
@@ -613,25 +609,22 @@ void run_mux_test_variant(FabricMuxBaseFixture* fixture, TestConfig test_config)
         log_info(LogTest, "Waiting for senders to complete");
         for (const auto& device : devices) {
             for (const auto& [core, _] : device_senders_map[device]) {
-                wait_for_worker_completion(device->get_devices()[0], core);
+                wait_for_worker_completion(*device, core);
             }
         }
 
         log_info(LogTest, "Senders done, waiting for receivers to complete");
         for (const auto& device : devices) {
             for (const auto& [core, _] : device_receivers_map[device]) {
-                wait_for_worker_completion(device->get_devices()[0], core);
+                wait_for_worker_completion(*device, core);
             }
         }
 
         log_info(LogTest, "Receivers done, terminating mux kernel");
         std::vector<uint32_t> mux_termination_signal(1, tt::tt_fabric::TerminationSignal::IMMEDIATELY_TERMINATE);
         for (auto i = 0; i < devices.size(); i++) {
-            tt::tt_metal::detail::WriteToDeviceL1(
-                devices[i]->get_devices()[0],
-                worker_logical_cores[0],
-                mux_termination_signal_addresses[i],
-                mux_termination_signal);
+            tt::tt_metal::slow_dispatch::WriteToL1(
+                *devices[i], worker_logical_cores[0], mux_termination_signal_addresses[i], mux_termination_signal);
         }
     }
 
@@ -640,9 +633,10 @@ void run_mux_test_variant(FabricMuxBaseFixture* fixture, TestConfig test_config)
         fixture->WaitForSingleProgramDone(devices[i], program_handles[i]);
     }
 
-    auto validate_worker_results = [&](tt::tt_metal::IDevice* device, const tt::tt_metal::CoreCoord& core) {
+    auto validate_worker_results = [&](tt::tt_metal::distributed::MeshDevice& device,
+                                       const tt::tt_metal::CoreCoord& core) {
         std::vector<uint32_t> worker_status;
-        tt_metal::detail::ReadFromDeviceL1(
+        tt_metal::slow_dispatch::ReadFromL1(
             device, core, worker_memory_map.test_results_address, test_results_size_bytes, worker_status);
         EXPECT_EQ(worker_status[TT_FABRIC_STATUS_INDEX], TT_FABRIC_STATUS_PASS);
     };
@@ -650,11 +644,11 @@ void run_mux_test_variant(FabricMuxBaseFixture* fixture, TestConfig test_config)
     log_info(LogTest, "Programs done, validating results");
     for (const auto& device : devices) {
         for (const auto& [core, _] : device_senders_map[device]) {
-            validate_worker_results(device->get_devices()[0], core);
+            validate_worker_results(*device, core);
         }
 
         for (const auto& [core, _] : device_receivers_map[device]) {
-            validate_worker_results(device->get_devices()[0], core);
+            validate_worker_results(*device, core);
         }
     }
 }

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux_v2.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_mux_v2.cpp
@@ -156,7 +156,7 @@ struct ReceiverDeviceContext {
     MuxDeployment receiver_mux_deployment;
 };
 
-ChipId get_physical_device_id(const MeshDevicePtr& device) { return device->get_devices()[0]->id(); }
+ChipId get_physical_device_id(const MeshDevicePtr& device) { return device->get_device_ids()[0]; }
 
 uint32_t align_up(uint32_t value, uint32_t alignment) { return ((value + alignment - 1) / alignment) * alignment; }
 
@@ -670,13 +670,8 @@ uint64_t read_word_count(const std::vector<uint32_t>& worker_status) {
 std::vector<uint32_t> read_worker_status(
     const MeshDevicePtr& device, const tt::tt_metal::CoreCoord& logical_core, uint32_t test_results_address) {
     std::vector<uint32_t> worker_status;
-    tt::tt_metal::detail::ReadFromDeviceL1(
-        device->get_devices()[0],
-        logical_core,
-        test_results_address,
-        kTestResultsSizeBytes,
-        worker_status,
-        CoreType::WORKER);
+    tt::tt_metal::slow_dispatch::ReadFromL1(
+        *device, logical_core, test_results_address, kTestResultsSizeBytes, worker_status, CoreType::WORKER);
     return worker_status;
 }
 

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_smoke.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_basic_fabric_smoke.cpp
@@ -48,8 +48,8 @@ void RunTestUnicastSmoke(BaseFabricFixture* fixture) {
     auto sender_device = devices[0];
     auto receiver_device = devices[1];
 
-    auto src_physical_device_id = sender_device->get_devices()[0]->id();
-    auto dst_physical_device_id = receiver_device->get_devices()[0]->id();
+    auto src_physical_device_id = sender_device->get_device_ids()[0];
+    auto dst_physical_device_id = receiver_device->get_device_ids()[0];
 
     auto src_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(src_physical_device_id);
     auto dst_fabric_node_id = control_plane.get_fabric_node_id_from_physical_chip_id(dst_physical_device_id);
@@ -145,16 +145,16 @@ void RunTestUnicastSmoke(BaseFabricFixture* fixture) {
     std::vector<uint32_t> sender_status;
     std::vector<uint32_t> receiver_status;
 
-    tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+    tt_metal::slow_dispatch::ReadFromL1(
+        *sender_device,
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
         sender_status,
         CoreType::WORKER);
 
-    tt_metal::detail::ReadFromDeviceL1(
-        receiver_device->get_devices()[0],
+    tt_metal::slow_dispatch::ReadFromL1(
+        *receiver_device,
         receiver_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/test_sparse_mcast_perpage.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/test_sparse_mcast_perpage.cpp
@@ -149,8 +149,8 @@ void RunSparseMcastPerPage(BaseFabricFixture* fixture, RoutingDirection dir, uin
     }
 
     std::vector<uint32_t> sender_status;
-    tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+    tt_metal::slow_dispatch::ReadFromL1(
+        *sender_device,
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
@@ -160,8 +160,8 @@ void RunSparseMcastPerPage(BaseFabricFixture* fixture, RoutingDirection dir, uin
 
     for (auto& [dev, _] : receiver_programs) {
         std::vector<uint32_t> recv_status;
-        tt_metal::detail::ReadFromDeviceL1(
-            dev->get_devices()[0],
+        tt_metal::slow_dispatch::ReadFromL1(
+            *dev,
             receiver_logical_core,
             worker_mem_map.test_results_address,
             worker_mem_map.test_results_size_bytes,

--- a/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_channel_trimming_capture.cpp
@@ -117,8 +117,7 @@ std::vector<EthCoreCaptureResult> read_capture_from_all_eth_cores(
 
     for (const auto& [logical_core, channel_id] : capture_cores) {
         std::vector<uint32_t> raw_data;
-        tt_metal::detail::ReadFromDeviceL1(
-            device->get_devices()[0], logical_core, capture_addr, capture_size, raw_data, CoreType::ETH);
+        tt_metal::slow_dispatch::ReadFromL1(*device, logical_core, capture_addr, capture_size, raw_data, CoreType::ETH);
 
         CaptureResults capture{};
         std::memcpy(static_cast<void*>(&capture), raw_data.data(), std::min(capture_size, raw_data.size() * sizeof(uint32_t)));
@@ -155,8 +154,7 @@ void clear_capture_on_device(BaseFabricFixture* fixture, ChipId physical_chip_id
     const auto capture_cores = get_active_fabric_capture_cores(physical_chip_id);
     const auto& device = fixture->get_device(physical_chip_id);
     for (const auto& [logical_core, _] : capture_cores) {
-        tt_metal::detail::WriteToDeviceL1(
-            device->get_devices()[0], logical_core, capture_addr, raw, CoreType::ETH);
+        tt_metal::slow_dispatch::WriteToL1(*device, logical_core, capture_addr, raw, CoreType::ETH);
     }
 }
 
@@ -355,16 +353,16 @@ UnicastTrafficResult run_unicast_traffic_bw_nodes(
     std::vector<uint32_t> sender_status;
     std::vector<uint32_t> receiver_status;
 
-    tt_metal::detail::ReadFromDeviceL1(
-        sender_device->get_devices()[0],
+    tt_metal::slow_dispatch::ReadFromL1(
+        *sender_device,
         sender_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,
         sender_status,
         CoreType::WORKER);
 
-    tt_metal::detail::ReadFromDeviceL1(
-        receiver_device->get_devices()[0],
+    tt_metal::slow_dispatch::ReadFromL1(
+        *receiver_device,
         receiver_logical_core,
         worker_mem_map.test_results_address,
         worker_mem_map.test_results_size_bytes,


### PR DESCRIPTION
### PR Category
Cleanup, Test Only

### Summary

Advances https://github.com/tenstorrent/tt-metal/issues/51835

Legacy API usage related to `IDevice` and `Buffer` is replaced with mesh alternatives in the fabric tests.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov-fabric-tests-idevice)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov-fabric-tests-idevice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov-fabric-tests-idevice)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov-fabric-tests-idevice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov-fabric-tests-idevice)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov-fabric-tests-idevice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov-fabric-tests-idevice)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov-fabric-tests-idevice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov-fabric-tests-idevice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov-fabric-tests-idevice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov-fabric-tests-idevice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov-fabric-tests-idevice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov-fabric-tests-idevice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov-fabric-tests-idevice)