### PR TITLE
[Fabric2D] Fix prefill dispatch on routed groups

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -6,6 +6,7 @@
 #include "kernels/dataflow/dispatch_plan.hpp"  // PlanHeader / PlanEntry layout (host sizes the plan CB from these)
 #include <algorithm>
 #include <array>
+#include <unordered_set>
 #include <utility>
 #include <limits>
 #include <tt-metalium/core_coord.hpp>
@@ -491,14 +492,18 @@ tt::tt_metal::ProgramDescriptor create_dispatch_program(
     const auto [neighbors, directions] =
         ccl::common::get_neighbors(mesh_view, mesh_coordinate, topology, operation_attributes.axis);
 
-    // FABRIC_2D uses the portable RoutingPlaneConnectionManager (per-destination connection +
-    // multicast handshake) so dispatch-axis traffic forwards multi-hop; FABRIC_1D keeps the legacy
+    // FABRIC_2D uses the portable RoutingPlaneConnectionManager (one connection per required physical
+    // first-hop direction) so dispatch-axis traffic forwards multi-hop; FABRIC_1D keeps the legacy
     // per-direction array connection. INVARIANT: this is_2d_fabric gate (derived from GetFabricConfig())
     // must agree with the kernel's FABRIC_2D #ifdef, which append_routing_plane_connection_manager_rt_args
     // injects based on the control plane's is_2D_routing_enabled(). If the two ever diverge, the host
     // pushes 2D-shaped args while the kernel compiles the 1D #else branch (or vice-versa) and arg
     // parsing corrupts.
     const bool is_2d_fabric = tt::tt_fabric::is_2d_fabric_config(tt::tt_fabric::GetFabricConfig());
+    TT_FATAL(
+        !is_2d_fabric || (operation_attributes.axis.has_value() && operation_attributes.axis.value() < 2),
+        "FABRIC_2D dispatch requires cluster_axis 0 or 1; got {}",
+        operation_attributes.axis.value_or(2));
 
     // c_8: packet header CB for fabric sends (sender-only)
     if (operation_attributes.num_links > 0) {
@@ -961,22 +966,49 @@ tt::tt_metal::ProgramDescriptor create_dispatch_program(
         }
 
         if (operation_attributes.num_links > 0) {
-            // Dispatch-axis neighbors (each a distinct fabric direction) as fabric nodes.
+            // Fabric nodes used to open sender connections. The 1D fabric path follows the two
+            // logical dispatch-axis neighbors. Under Fabric2D, however, routing to every peer in a
+            // logical dispatch group may use additional physical first-hop directions when that group
+            // turns through the physical mesh (for example, logical 8x1 on a 2x4 LoudBox). Open one
+            // connection per physical direction needed by any peer in this dispatch group.
             std::vector<tt::tt_fabric::FabricNodeId> dst_nodes;
-            dst_nodes.reserve(neighbors.size());
-            for (const auto& neighbor_coordinate : neighbors) {
-                if (neighbor_coordinate[0] == mesh_coordinate[0] && neighbor_coordinate[1] == mesh_coordinate[1]) {
-                    continue;
+            if (is_2d_fabric) {
+                std::unordered_set<tt::tt_fabric::eth_chan_directions> used_directions;
+                for (const auto& peer_coordinate : ttnn::MeshCoordinateRange(mesh_view.shape())) {
+                    if (peer_coordinate == mesh_coordinate) {
+                        continue;
+                    }
+                    const bool same_dispatch_group = operation_attributes.axis.value() == 0
+                                                         ? peer_coordinate[1] == mesh_coordinate[1]
+                                                         : peer_coordinate[0] == mesh_coordinate[0];
+                    if (!same_dispatch_group) {
+                        continue;
+                    }
+                    const auto peer_node = mesh_device->get_fabric_node_id(peer_coordinate);
+                    const auto direction = tt::tt_fabric::get_eth_forwarding_direction(src_fabric_node_id, peer_node);
+                    TT_FATAL(
+                        direction.has_value(),
+                        "No Fabric2D forwarding direction from dispatch source {} to peer {}",
+                        src_fabric_node_id,
+                        peer_node);
+                    if (used_directions.insert(direction.value()).second) {
+                        dst_nodes.push_back(peer_node);
+                    }
                 }
-                dst_nodes.push_back(mesh_device->get_fabric_node_id(neighbor_coordinate));
+            } else {
+                dst_nodes.reserve(neighbors.size());
+                for (const auto& neighbor_coordinate : neighbors) {
+                    if (neighbor_coordinate == mesh_coordinate) {
+                        continue;
+                    }
+                    dst_nodes.push_back(mesh_device->get_fabric_node_id(neighbor_coordinate));
+                }
             }
             const uint32_t core_link = core_idx % num_links;
             if (is_2d_fabric) {
-                // Portable RoutingPlaneConnectionManager path: one connection per dispatch-axis neighbor
-                // so traffic forwards across MULTIPLE hops (the legacy fixed-link array connection only
-                // forwards a single hop, deadlocking multi-hop FABRIC_2D — e.g. the 4-device column of a
-                // 4x2 mesh). The writer reads num_connections first, then builds the manager from the
-                // appended args.
+                // Portable RoutingPlaneConnectionManager path: one connection per physical first-hop
+                // direction used by the dispatch group, so traffic forwards across MULTIPLE hops. The
+                // writer reads num_connections first, then builds the manager from the appended args.
                 //
                 // Pick a forwarding link valid for each neighbor's own direction (see
                 // compute_per_neighbor_forwarding_links above for why a single broadcast {core_link} hangs).

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_sender_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_sender_dispatch.cpp
@@ -19,7 +19,6 @@
 #include "tt_metal/fabric/hw/inc/edm_fabric/fabric_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/edm_fabric/routing_plane_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/linear/api.h"
-#include "tt_metal/fabric/hw/inc/packet_header_pool.h"
 #include "ttnn/operations/ccl/common/kernels/moe_utils.hpp"
 #include "ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
 
@@ -191,14 +190,13 @@ void kernel_main() {
     auto* unicast_packet_header = reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_address);
 
 #ifdef FABRIC_2D
-    // Portable FABRIC_2D connections: one RoutingPlaneConnectionManager slot per dispatch-axis
-    // neighbor (each a distinct fabric direction), opened on its correct forwarding routing plane by
-    // the host. Required for multi-hop forwarding along the dispatch axis; the legacy fixed-link
+    // Portable FABRIC_2D connections: one RoutingPlaneConnectionManager slot per physical first-hop
+    // direction needed by the dispatch group, opened on its correct routing plane by the host.
+    // Required for multi-hop forwarding along the dispatch axis; the legacy fixed-link
     // array connection only forwards a single hop (deadlocks on e.g. the 4-device column of a 4x2
     // mesh). FABRIC_1D keeps the legacy array + per-target unicast handshake in the #else branch.
     static_assert(axis != ReplicateGroup::NONE, "FABRIC_2D dispatch requires a concrete cluster_axis");
     uint32_t num_connections = get_arg_val<uint32_t>(rt_args_idx++);
-    uint8_t sem_route_id = PacketHeaderPool::allocate_header_n(static_cast<uint8_t>(num_connections));
     auto fabric_connections = tt::tt_fabric::RoutingPlaneConnectionManager::build_from_args<
         tt::tt_fabric::RoutingPlaneConnectionManager::BUILD_AND_OPEN_CONNECTION>(rt_args_idx, num_connections);
 
@@ -214,71 +212,45 @@ void kernel_main() {
         dir_to_slot[fabric_connections.get_tag(i)] = static_cast<uint8_t>(i);
     }
 
-    // Bidirectional multicast handshake (hs_ = handshake): each device increments the init/exit
-    // semaphore on every other dispatch-axis device exactly once. The forward slot (+axis: SOUTH for
-    // COLS / EAST for ROWS) covers `hs_pos_range` devices, the backward slot the other `hs_neg_range`;
-    // together exactly dispatch_devices-1 peers.
-    //
-    // LINEAR axis: forward covers the (len-1-pos) devices ahead, backward the pos devices behind, and a
-    // connection is forward iff the neighbor's axis position is larger.
-    // RING/TORUS axis: the wrap closes the loop, so the linear split is wrong — the wrap neighbor sits at
-    // the far axis position and would be misclassified as forward, doubling one side and never covering
-    // the other (init_sem never reaches dispatch_devices-1 -> hang). Instead split the ring into two
-    // disjoint arcs that tile all len-1 peers exactly once regardless of pos: forward covers len/2
-    // devices, backward covers the rest. Classify a connection forward iff its eth direction (tag) is the
-    // +axis direction, not by neighbor position.
-    constexpr bool hs_is_cols = (axis == ReplicateGroup::COLS);
-    constexpr uint32_t hs_axis_pos =
-        hs_is_cols ? (linearized_mesh_coord / mesh_cols) : (linearized_mesh_coord % mesh_cols);
-    constexpr uint32_t hs_axis_len = hs_is_cols ? mesh_rows : mesh_cols;
-    constexpr bool hs_is_ring = has_wrap_around<topology>();
-    // Per-direction arc sizes; forward (pos) + backward (neg) = hs_axis_len - 1 in both branches.
-    //   ring:   forward = len/2, backward = the remaining peers — two disjoint arcs that tile every
-    //           peer exactly once, parity-agnostic (NOT "devices ahead/behind", which is linear-only).
-    //   linear: forward = len-1-pos devices ahead, backward = pos devices behind.
-    constexpr uint32_t hs_pos_range = hs_is_ring ? (hs_axis_len / 2) : ((hs_axis_len - 1) - hs_axis_pos);
-    constexpr uint32_t hs_neg_range = hs_is_ring ? ((hs_axis_len - 1) - (hs_axis_len / 2)) : hs_axis_pos;
-    // +axis eth direction that marks a connection "forward" on a ring (a wrap neighbor's axis position
-    // is on the wrong side, so position can't classify it): SOUTH = increasing row index (dim 0,
-    // mesh_rows); EAST = increasing col index (dim 1, mesh_cols) — per the BH galaxy mesh wiring.
-    constexpr uint8_t hs_fwd_tag =
-        hs_is_cols ? static_cast<uint8_t>(eth_chan_directions::SOUTH) : static_cast<uint8_t>(eth_chan_directions::EAST);
-    constexpr uint8_t HS_START_SKIP_SELF = 1;  // start_distance: deliver from the first hop, skipping self
-
-    uint8_t hs_starts[tt::tt_fabric::RoutingPlaneConnectionManager::MaxConnections];
-    uint8_t hs_ranges[tt::tt_fabric::RoutingPlaneConnectionManager::MaxConnections];
-    for (uint32_t i = 0; i < num_connections; ++i) {
-        const uint16_t nbr_chip = fabric_connections.get(i).dst_dev_id;
-        const uint16_t nbr_mesh = fabric_connections.get(i).dst_mesh_id;
-        // Reverse-map this neighbor's (mesh, chip) to its linearized mesh index to read its axis
-        // position. The neighbor must be one of this device's dispatch targets (host guarantees it).
-        uint32_t nbr_lin = 0;
-        bool nbr_found = false;
-        for (uint32_t d = 0; d < num_devices; ++d) {
-            if (dest_chip_ids[d] == nbr_chip && dest_mesh_ids[d] == nbr_mesh) {
-                nbr_lin = d;
-                nbr_found = true;
-                break;
+    // A logical dispatch axis can turn through the physical Fabric2D graph (for example, an 8x1 group
+    // embedded in a 2x4 LoudBox). A multi-hop multicast range cannot describe that path reliably.
+    // Explicitly unicast one semaphore increment to every peer in this dispatch group; each packet uses
+    // the routing plane selected for its actual first hop and carries its final (mesh, chip) destination.
+    constexpr uint32_t dispatch_group_begin = axis == ReplicateGroup::COLS
+                                                  ? linearized_mesh_coord % mesh_cols
+                                                  : (linearized_mesh_coord / mesh_cols) * mesh_cols;
+    constexpr uint32_t dispatch_group_stride = axis == ReplicateGroup::COLS ? mesh_cols : 1;
+    auto dispatch_2d_unicast_handshake = [&](uint64_t sem_addr, bool flush) {
+        for (uint32_t peer = 0; peer < dispatch_devices; ++peer) {
+            const uint32_t dst_chip_index = dispatch_group_begin + peer * dispatch_group_stride;
+            if (dst_chip_index == linearized_mesh_coord) {
+                continue;
             }
-        }
-        ASSERT(nbr_found);  // a connection neighbor missing from dest_chip_ids => mis-sized/garbled rt args
-        // nbr_axis_pos (and the reverse-map above) feed only the linear classifier; unused on a ring.
-        [[maybe_unused]] const uint32_t nbr_axis_pos = hs_is_cols ? (nbr_lin / mesh_cols) : (nbr_lin % mesh_cols);
-        // Ring: classify by the connection's eth direction (the wrap neighbor's axis position is on the
-        // wrong side). Linear: classify by neighbor axis position.
-        const bool is_forward =
-            hs_is_ring ? (fabric_connections.get(i).tag == hs_fwd_tag) : (nbr_axis_pos > hs_axis_pos);
-        hs_starts[i] = HS_START_SKIP_SELF;
-        hs_ranges[i] = is_forward ? static_cast<uint8_t>(hs_pos_range) : static_cast<uint8_t>(hs_neg_range);
-    }
 
-    // flush=true holds the receiver EDM's atomic-inc until this sender's prior fabric writes to that chip
-    // commit (needed at exit to order the inc behind payload/metadata). init passes flush=false: it is the
-    // first fabric traffic, so there are no prior writes to order against — matching the FABRIC_1D path.
-    auto dispatch_2d_mcast_handshake = [&](uint64_t sem_addr, bool flush) {
-        const auto cmd = tt::tt_fabric::NocUnicastAtomicIncCommandHeader{sem_addr, 1, flush};
-        tt::tt_fabric::linear::experimental::fabric_multicast_noc_unicast_atomic_inc(
-            fabric_connections, sem_route_id, cmd, hs_starts, hs_ranges);
+            ccl_routing_utils::line_unicast_route_info_t route_info{};
+            route_info.dst_chip_id = dest_chip_ids[dst_chip_index];
+            route_info.dst_mesh_id = dest_mesh_ids[dst_chip_index];
+            const uint32_t fabric_route =
+                static_cast<uint32_t>(get_next_hop_router_direction(route_info.dst_mesh_id, route_info.dst_chip_id));
+            ASSERT(fabric_route < static_cast<uint32_t>(eth_chan_directions::COUNT));
+            if (fabric_route >= static_cast<uint32_t>(eth_chan_directions::COUNT)) {
+                return;
+            }
+            const uint8_t connection_slot = dir_to_slot[fabric_route];
+            ASSERT(connection_slot != DIR_TO_SLOT_EMPTY);
+            if (connection_slot == DIR_TO_SLOT_EMPTY) {
+                return;
+            }
+
+            ccl_routing_utils::fabric_set_line_unicast_route(
+                pkt_hdr_for_route_helper(unicast_packet_header), route_info);
+            unicast_packet_header->to_noc_unicast_atomic_inc(
+                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{sem_addr, 1, flush});
+            auto& sender = fabric_connections.get(connection_slot).sender;
+            sender.wait_for_empty_write_slot();
+            sender.send_payload_flush_blocking_from_address(
+                reinterpret_cast<uint32_t>(unicast_packet_header), sizeof(PACKET_HEADER_TYPE));
+        }
     };
 #else
     constexpr std::array<bool, 4> directions = DIRECTIONS;
@@ -292,7 +264,7 @@ void kernel_main() {
     // Init semaphore exchange
     const uint64_t init_noc_semaphore_addr = get_noc_addr(init_semaphore_address);
 #ifdef FABRIC_2D
-    dispatch_2d_mcast_handshake(init_noc_semaphore_addr, /*flush=*/false);
+    dispatch_2d_unicast_handshake(init_noc_semaphore_addr, /*flush=*/false);
 #else
     send_init_semaphore_to_configured_targets<
         linearized_mesh_coord,
@@ -435,8 +407,8 @@ void kernel_main() {
     // not be observed before our prior fabric writes (payload + metadata) to that chip have landed,
     // or a peer could see sem-reached-threshold before the data is in DRAM. The two paths enforce
     // this differently:
-    //   - FABRIC_2D: the noc_async_write_barrier() above drains local writes, and the 2D multicast
-    //     handshake is issued with flush=true so the receiver EDM also holds the atomic-inc until our
+    //   - FABRIC_2D: the noc_async_write_barrier() above drains local writes, and each 2D unicast
+    //     handshake packet is issued with flush=true so the receiver EDM holds the atomic-inc until our
     //     prior fabric writes commit (init uses flush=false: no prior writes to order against).
     //   - FABRIC_1D (#else): send_init_semaphore_to_configured_targets is called with /*flush=*/true
     //     so the receiver EDM holds the atomic-inc until our prior writes commit (the init handshake
@@ -444,7 +416,7 @@ void kernel_main() {
     {
         const uint64_t exit_noc_semaphore_addr = get_noc_addr(exit_semaphore_address);
 #ifdef FABRIC_2D
-        dispatch_2d_mcast_handshake(exit_noc_semaphore_addr, /*flush=*/true);
+        dispatch_2d_unicast_handshake(exit_noc_semaphore_addr, /*flush=*/true);
 #else
         send_init_semaphore_to_configured_targets<
             linearized_mesh_coord,
@@ -471,12 +443,9 @@ void kernel_main() {
         noc_semaphore_set(exit_sem_ptr, 0);
     }
 
-    // The atomic-inc handshake helpers (both the FABRIC_2D multicast and the FABRIC_1D per-target
-    // unicast) send via send_payload_flush_non_blocking_from_address — that confirms the write
-    // departed the worker's NIU but not that the bytes landed in the EDM's L1 inbox. If we exit and
-    // close the fabric connections while a send is mid-flight, the EDM might process its slot
-    // bookkeeping before the bytes arrive. A full barrier ensures all writes (and atomics,
-    // defensively) have completed before we close.
+    // FABRIC_2D's FLUSH_BLOCKING handshake sends drain the source before packet-header reuse, but do
+    // not prove arrival in the EDM inbox; FABRIC_1D's per-target helper sends are non-blocking. Keep a
+    // full barrier before either connection path closes so every prior write and atomic has arrived.
     noc_async_full_barrier();
 
 #ifdef FABRIC_2D


### PR DESCRIPTION
## Problem

Prefill dispatch opened only logical-neighbor connections and used an axis multicast semaphore handshake. When a logical dispatch group folds across the physical mesh, peers can require different first-hop directions and miss initialization or exit notifications.

## Op-level fix

Within the dispatch op:

- Derive one sender connection per distinct physical first hop used by the dispatch group.
- Exchange Fabric2D barrier atomics with explicit routed per-peer unicasts.
- Preserve the existing Fabric1D path and final delivery barrier.

The PR changes only the dispatch program factory and writer kernel. It contains no Fabric subsystem/API, model, test, or configuration changes.

## Validation

- `./build_metal.sh --release`
- Existing local overflow proxy cases through `scripts/run_safe_pytest.sh`: 2 passed
- Existing dispatch op-unit suite on LoudBox: [run 32008133200](https://github.com/tenstorrent/tt-metal/actions/runs/32008133200)

Integrated model/topology migration: [#53133](https://github.com/tenstorrent/tt-metal/pull/53133).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-fabric2d-routed-prefill-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-fabric2d-routed-prefill-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-fabric2d-routed-prefill-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-fabric2d-routed-prefill-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-fabric2d-routed-prefill-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-fabric2d-routed-prefill-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-fabric2d-routed-prefill-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-fabric2d-routed-prefill-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-fabric2d-routed-prefill-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-fabric2d-routed-prefill-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-fabric2d-routed-prefill-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-fabric2d-routed-prefill-dispatch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-fabric2d-routed-prefill-dispatch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-fabric2d-routed-prefill-dispatch)