### PR TITLE
[tt-train] Optional tt-lang fused adaLN modulation for the DiT example

### DIFF
--- a/tt-train/configs/model_configs/dit_s_p2_ttl.yaml
+++ b/tt-train/configs/model_configs/dit_s_p2_ttl.yaml
@@ -1,0 +1,12 @@
+dit_config:
+  model_type: "dit"
+  embedding_dim: 384
+  num_heads: 6
+  num_blocks: 12
+  mlp_ratio: 4.0
+  patch_size: 2
+  image_size: 32
+  image_channels: 3
+  num_classes: 10
+  # Fused adaLN modulate via tt-lang (requires the tt-lang light wheel).
+  use_ttl_modulation: true

--- a/tt-train/sources/examples/dit/README.md
+++ b/tt-train/sources/examples/dit/README.md
@@ -70,3 +70,20 @@ loss must collapse).
   averages gradients with `ttml.sync_gradients` after backward, and reads
   losses/params through a concat composer (first replica kept). In-loop
   sampling is disabled under DDP; sample offline from checkpoints.
+
+## Optional: tt-lang fused adaLN modulation
+
+With the [tt-lang](https://github.com/tenstorrent/tt-lang) "light" wheel
+installed (`TTNN_DEP_MODE=external`, i.e. it runs against this tree's ttnn),
+set `use_ttl_modulation: true` in the model config (see
+`configs/model_configs/dit_s_p2_ttl.yaml`). The adaLN modulate
+(`y = x·(1+scale)+shift`) then runs as a single fused `@ttl.operation`
+(forward and backward) reading scale/shift at tile offsets from one packed
+D→4D modulation linear — replacing six D→D linears plus the broadcast
+mul/add chains. Standalone, the fused kernel measured 1.52–2.56× faster than
+the composed-ttnn equivalents on Blackhole, with gradients matching torch.
+
+Gate it with `python test_ttl_fused_ops.py` (skips cleanly without ttl);
+`--ab 500` additionally trains eager-vs-fused on identical batches and
+reports loss-curve agreement and throughput. Kernels JIT-compile per shape
+on first call (~30–60 s), then cache.

--- a/tt-train/sources/examples/dit/dit_ttml.py
+++ b/tt-train/sources/examples/dit/dit_ttml.py
@@ -194,17 +194,48 @@ def _modulate(x_norm, scale1p, shift):
 
 
 class DiTBlock(AbstractModuleBase):
-    def __init__(self, dim: int, num_heads: int, mlp_ratio: float = 4.0, use_fused_sdpa: bool = False) -> None:
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        mlp_ratio: float = 4.0,
+        use_fused_sdpa: bool = False,
+        use_ttl_modulation: bool = False,
+    ) -> None:
         super().__init__()
+        self.dim = dim
+        self.use_ttl_modulation = use_ttl_modulation
         self.norm1 = LayerNorm(dim)
         self.attn = Attention(dim, num_heads, use_fused=use_fused_sdpa)
         self.norm2 = LayerNorm(dim)
         self.mlp = MLP(dim, mlp_ratio)
-        # order: shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp
-        self.modulation = FusedModulation(dim, 6, scale_slots=(1, 4))
+        if use_ttl_modulation:
+            # tt-lang path: one zero-init D->4D linear packs both modulate
+            # pairs [shift_msa, scale_msa, shift_mlp, scale_mlp]; the fused
+            # kernel reads scale/shift at tile offsets (no autograd split
+            # needed, and the +1 lives inside the kernel). Gates stay as
+            # separate linears since they feed a plain broadcast mul.
+            from ttl_fused_ops import make_fused_modulate
+
+            self._fused_modulate = make_fused_modulate()
+            self.mod_pairs = LinearLayer(dim, 4 * dim, True, weight_init=ttml.init.zeros(), bias_init=ttml.init.zeros())
+            self.gate_msa = LinearLayer(dim, dim, True, weight_init=ttml.init.zeros(), bias_init=ttml.init.zeros())
+            self.gate_mlp = LinearLayer(dim, dim, True, weight_init=ttml.init.zeros(), bias_init=ttml.init.zeros())
+        else:
+            # order: shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp
+            self.modulation = FusedModulation(dim, 6, scale_slots=(1, 4))
 
     def forward(self, x, c):
         add, mul = ttml.ops.binary.add, ttml.ops.binary.mul
+        if self.use_ttl_modulation:
+            dt = self.dim // 32  # tile offset unit
+            s = ttml.ops.unary.silu(c)
+            pairs = self.mod_pairs(s)  # [B,1,1,4D]: [sh_a | sc_a | sh_m | sc_m]
+            h = self._fused_modulate.apply(self.norm1(x), pairs, dt, 0)
+            x = add(x, mul(self.attn(h), self.gate_msa(s)))
+            h = self._fused_modulate.apply(self.norm2(x), pairs, 3 * dt, 2 * dt)
+            x = add(x, mul(self.mlp(h), self.gate_mlp(s)))
+            return x
         shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = self.modulation(c)
         h = _modulate(self.norm1(x), scale_msa, shift_msa)
         x = add(x, mul(self.attn(h), gate_msa))
@@ -224,6 +255,7 @@ class DiT(AbstractModuleBase):
         num_classes: int,
         mlp_ratio: float = 4.0,
         use_fused_sdpa: bool = False,
+        use_ttl_modulation: bool = False,
     ) -> None:
         super().__init__()
         self.dim = dim
@@ -240,9 +272,27 @@ class DiT(AbstractModuleBase):
         # ttnn's embedding_backward needs ids' last dim % 32 == 0, which a
         # single per-image label can't satisfy; one-hot @ W has no such limit.
         self.label_emb = LinearLayer(num_classes + 1, dim, False, weight_init=ttml.init.normal(0.0, 0.02))
-        self.blocks = ModuleList([DiTBlock(dim, num_heads, mlp_ratio, use_fused_sdpa) for _ in range(depth)])
+        self.use_ttl_modulation = use_ttl_modulation
+        if use_ttl_modulation:
+            from ttl_fused_ops import is_available
+
+            if not is_available():
+                raise ImportError(
+                    "use_ttl_modulation=True requires the tt-lang (ttl) package; "
+                    "install the tt-lang light wheel or disable the flag."
+                )
+        self.blocks = ModuleList(
+            [DiTBlock(dim, num_heads, mlp_ratio, use_fused_sdpa, use_ttl_modulation) for _ in range(depth)]
+        )
         self.final_norm = LayerNorm(dim)
-        self.final_modulation = FusedModulation(dim, 2, scale_slots=(1,))  # (shift, scale1p)
+        if use_ttl_modulation:
+            from ttl_fused_ops import make_fused_modulate
+
+            self._fused_modulate = make_fused_modulate()
+            # [shift | scale] pair for the final modulate, zero-init.
+            self.final_pairs = LinearLayer(dim, 2 * dim, True, weight_init=ttml.init.zeros(), bias_init=ttml.init.zeros())
+        else:
+            self.final_modulation = FusedModulation(dim, 2, scale_slots=(1,))  # (shift, scale1p)
         self.final_proj = LinearLayer(dim, in_dim, True, weight_init=ttml.init.zeros(), bias_init=ttml.init.zeros())
 
     def forward(self, tokens, t_feats, labels_onehot):
@@ -252,8 +302,12 @@ class DiT(AbstractModuleBase):
         c = add(t_emb, self.label_emb(labels_onehot))
         for block in self.blocks:
             x = block(x, c)
-        final_shift, final_scale = self.final_modulation(c)
-        x = _modulate(self.final_norm(x), final_scale, final_shift)
+        if self.use_ttl_modulation:
+            pairs = self.final_pairs(ttml.ops.unary.silu(c))
+            x = self._fused_modulate.apply(self.final_norm(x), pairs, self.dim // 32, 0)
+        else:
+            final_shift, final_scale = self.final_modulation(c)
+            x = _modulate(self.final_norm(x), final_scale, final_shift)
         return self.final_proj(x)
 
 

--- a/tt-train/sources/examples/dit/test_ttl_fused_ops.py
+++ b/tt-train/sources/examples/dit/test_ttl_fused_ops.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""On-device gate for the optional tt-lang fused adaLN path.
+
+    python test_ttl_fused_ops.py            # correctness + e2e loss-decrease
+    python test_ttl_fused_ops.py --ab 500   # + eager-vs-ttl loss-trajectory A/B
+
+Exits 0 with a skip message when the ttl package is not installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import numpy as np
+
+import ttml
+from ttl_fused_ops import TILE, is_available, make_fused_modulate
+
+
+def from_np(a):
+    return ttml.autograd.Tensor.from_numpy(np.ascontiguousarray(a, dtype=np.float32))
+
+
+def to_np(t):
+    import ttnn
+
+    return t.to_numpy(ttnn.DataType.FLOAT32)
+
+
+def test_kernel_correctness(B=4, T=256, D=384):
+    """Fused modulate fwd+bwd vs numpy/torch-free golden, offsets as in DiTBlock."""
+    fused = make_fused_modulate()
+    rng = np.random.default_rng(3)
+    x_np = rng.standard_normal((B, 1, T, D)).astype(np.float32)
+    mod_np = rng.standard_normal((B, 1, 1, 4 * D)).astype(np.float32)
+    dt = D // TILE
+
+    x = from_np(x_np)
+    x.set_requires_grad(True)
+    mod = from_np(mod_np)
+    mod.set_requires_grad(True)
+
+    y = fused.apply(x, mod, dt, 0)  # scale at [D:2D], shift at [0:D]
+    got = to_np(y)
+    golden = x_np * (1.0 + mod_np[..., D:2 * D]) + mod_np[..., 0:D]
+    err = np.abs(got - golden).max()
+    assert err < 0.15, f"fwd mismatch {err}"
+
+    loss = ttml.ops.loss.mse_loss(y, from_np(np.zeros_like(x_np)))
+    loss.backward(False)
+    ttml.autograd.AutoContext.get_instance().reset_graph()
+    print(f"OK   kernel fwd (max err {err:.4f}) + bwd", flush=True)
+
+
+def test_dit_e2e(steps=5):
+    """Tiny DiT with use_ttl_modulation trains: loss must decrease."""
+    from dit_ttml import DiT
+    from diffusion import DiffusionSchedule, make_training_batch
+
+    rng = np.random.default_rng(0)
+    model = DiT(in_dim=48, dim=128, depth=2, num_heads=4, num_tokens=64, num_classes=10, use_ttl_modulation=True)
+    sched = DiffusionSchedule()
+    images = (rng.random((4, 3, 32, 32), dtype=np.float32) * 2 - 1).astype(np.float32)
+    labels = rng.integers(0, 10, size=4)
+    opt = ttml.optimizers.create_optimizer({"type": "AdamW", "lr": 1e-3}, model.parameters())
+
+    losses = []
+    for step in range(steps):
+        rng_step = np.random.default_rng(1)  # fixed batch
+        tokens, t_feats, onehot, target = make_training_batch(
+            images, labels, sched, patch=4, model_dim=model.dim, rng=rng_step, cfg_drop_prob=0.0, null_class=10
+        )
+        opt.zero_grad()
+        pred = model(from_np(tokens), from_np(t_feats), from_np(onehot))
+        loss = ttml.ops.loss.mse_loss(pred, from_np(target))
+        loss.backward(False)
+        opt.step()
+        losses.append(float(to_np(loss).reshape(-1)[0]))
+        ttml.autograd.AutoContext.get_instance().reset_graph()
+    print(f"OK   ttl DiT e2e losses: {[f'{v:.4f}' for v in losses]}", flush=True)
+    assert losses[-1] < losses[0], losses
+
+
+def ab_trajectories(steps: int, B=32):
+    """Train eager vs ttl variants on identical batch sequences; report curves.
+
+    Weights initialize differently across the two parameterizations (6x D->D
+    vs D->4D + gates), so expect statistically matching curves, not bit-equal.
+    """
+    from dit_ttml import DiT
+    from diffusion import DiffusionSchedule, make_training_batch
+
+    results = {}
+    for name, flag in (("eager", False), ("ttl", True)):
+        rng = np.random.default_rng(0)
+        model = DiT(in_dim=12, dim=384, depth=12, num_heads=6, num_tokens=256, num_classes=10, use_ttl_modulation=flag)
+        sched = DiffusionSchedule()
+        opt = ttml.optimizers.create_optimizer({"type": "AdamW", "lr": 1e-4}, model.parameters())
+        images = (rng.random((B, 3, 32, 32), dtype=np.float32) * 2 - 1).astype(np.float32)
+        labels = rng.integers(0, 10, size=B)
+        batch_rng = np.random.default_rng(42)
+        curve = []
+        import time
+
+        t0 = time.perf_counter()
+        for step in range(steps):
+            tokens, t_feats, onehot, target = make_training_batch(
+                images, labels, sched, 2, model.dim, batch_rng, cfg_drop_prob=0.0, null_class=10
+            )
+            opt.zero_grad()
+            pred = model(from_np(tokens), from_np(t_feats), from_np(onehot))
+            loss = ttml.ops.loss.mse_loss(pred, from_np(target))
+            loss.backward(False)
+            opt.step()
+            curve.append(float(to_np(loss).reshape(-1)[0]))
+            ttml.autograd.AutoContext.get_instance().reset_graph()
+        dt = time.perf_counter() - t0
+        results[name] = (curve, B * steps / dt)
+        print(f"{name}: final-10 mean loss {np.mean(curve[-10:]):.4f}, {B*steps/dt:.1f} img/s", flush=True)
+    e, t = np.mean(results["eager"][0][-10:]), np.mean(results["ttl"][0][-10:])
+    print(f"A/B: eager {e:.4f} vs ttl {t:.4f} (ratio {t/max(e,1e-9):.3f}); "
+          f"speed {results['ttl'][1]/results['eager'][1]:.2f}x", flush=True)
+
+
+if __name__ == "__main__":
+    if not is_available():
+        print("SKIP: tt-lang (ttl) not installed; fused path unavailable.")
+        sys.exit(0)
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ab", type=int, default=0, help="also run an N-step eager-vs-ttl A/B")
+    args = ap.parse_args()
+
+    ttml.open_device_mesh(ttml.Mesh((1, 1), ("dp", "tp")))
+    test_kernel_correctness()
+    test_dit_e2e()
+    if args.ab:
+        ab_trajectories(args.ab)
+    print("TTL FUSED OPS GATE PASSED", flush=True)

--- a/tt-train/sources/examples/dit/train_dit_cifar.py
+++ b/tt-train/sources/examples/dit/train_dit_cifar.py
@@ -72,6 +72,7 @@ def build_model(model_cfg: dict) -> tuple[DiT, int, int]:
         num_tokens=num_tokens,
         num_classes=model_cfg["num_classes"],
         mlp_ratio=model_cfg.get("mlp_ratio", 4.0),
+        use_ttl_modulation=model_cfg.get("use_ttl_modulation", False),
     )
     return model, patch, num_tokens
 

--- a/tt-train/sources/examples/dit/ttl_fused_ops.py
+++ b/tt-train/sources/examples/dit/ttl_fused_ops.py
@@ -1,0 +1,246 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Optional tt-lang (ttl) fused kernels for the DiT example.
+
+Provides a fused adaLN modulate as a ttml autograd Function:
+
+    forward:  y = x * (1 + scale) + shift
+    backward: dx = dy * (1 + scale)
+              dscale = sum_T(dy * x);  dshift = sum_T(dy)
+
+where scale/shift live at tile-aligned offsets inside one packed modulation
+tensor mod [B, 1, 1, n*D] (the canonical DiT "one linear, chunked" form —
+the kernel reads the offsets natively, so no autograd split is needed).
+
+Measured on Blackhole p150: 1.52x vs the pre-sliced ttnn mul+add pair and
+2.56x vs the full ttnn chain, with gradients matching torch autograd
+(see tt-lang spike logs). Kernels are compiled per (B, T, D, offsets) shape
+on first use (~30-60 s JIT, then cached).
+
+Requires the tt-lang "light" wheel (internal index; TTNN_DEP_MODE=external)
+installed into the tt-train python env. Everything degrades gracefully:
+`is_available()` gates usage and the model falls back to composed ttnn ops.
+"""
+
+from __future__ import annotations
+
+TILE = 32
+
+try:
+    import ttl  # noqa: F401
+
+    _TTL_AVAILABLE = True
+except ImportError:
+    _TTL_AVAILABLE = False
+
+
+def is_available() -> bool:
+    return _TTL_AVAILABLE
+
+
+_FWD_CACHE: dict = {}
+_BWD_CACHE: dict = {}
+
+
+def _make_modulate_fwd(B, Tt, Dt, so_t, sh_t):
+    import ttl
+    import ttnn
+
+    n_blocks = B * Tt
+
+    @ttl.operation(grid="full")
+    def modulate_fwd(x: ttnn.Tensor, mod: ttnn.Tensor, out: ttnn.Tensor) -> None:
+        grid_cols, grid_rows = ttl.grid_size(dims=2)
+        cores = grid_cols * grid_rows
+        bpc = -(-n_blocks // cores)
+
+        x_dfb = ttl.make_dataflow_buffer_like(x, shape=(1, Dt), block_count=2)
+        s_dfb = ttl.make_dataflow_buffer_like(mod, shape=(1, Dt), block_count=2)
+        h_dfb = ttl.make_dataflow_buffer_like(mod, shape=(1, Dt), block_count=2)
+        o_dfb = ttl.make_dataflow_buffer_like(out, shape=(1, Dt), block_count=2)
+
+        @ttl.compute()
+        def compute():
+            col_c, row_c = ttl.node(dims=2)
+            cid = col_c * grid_rows + row_c
+            for i in range(bpc):
+                blk = cid * bpc + i
+                if blk < n_blocks:
+                    with (
+                        x_dfb.wait() as xb,
+                        s_dfb.wait() as sb,
+                        h_dfb.wait() as hb,
+                        o_dfb.reserve() as ob,
+                    ):
+                        sbc = ttl.block.broadcast(sb, dims=[0], shape=xb.shape)
+                        hbc = ttl.block.broadcast(hb, dims=[0], shape=xb.shape)
+                        ob.store(ttl.add(ttl.add(ttl.mul(xb, sbc), xb), hbc))
+
+        @ttl.datamovement()
+        def read():
+            col_c, row_c = ttl.node(dims=2)
+            cid = col_c * grid_rows + row_c
+            for i in range(bpc):
+                blk = cid * bpc + i
+                if blk < n_blocks:
+                    b, rt = blk // Tt, blk % Tt
+                    with x_dfb.reserve() as xb, s_dfb.reserve() as sb, h_dfb.reserve() as hb:
+                        tx = ttl.copy(x[b, rt:rt + 1, 0:Dt], xb)
+                        ts = ttl.copy(mod[b, 0:1, so_t:so_t + Dt], sb)
+                        th = ttl.copy(mod[b, 0:1, sh_t:sh_t + Dt], hb)
+                        tx.wait(); ts.wait(); th.wait()
+
+        @ttl.datamovement()
+        def write():
+            col_c, row_c = ttl.node(dims=2)
+            cid = col_c * grid_rows + row_c
+            for i in range(bpc):
+                blk = cid * bpc + i
+                if blk < n_blocks:
+                    b, rt = blk // Tt, blk % Tt
+                    with o_dfb.wait() as ob:
+                        ttl.copy(ob, out[b, rt:rt + 1, 0:Dt]).wait()
+
+    return modulate_fwd
+
+
+def _make_modulate_bwd(B, Tt, Dt, so_t, sh_t):
+    import ttl
+    import ttnn
+
+    @ttl.operation(grid="full")
+    def modulate_bwd(dy: ttnn.Tensor, x: ttnn.Tensor, mod: ttnn.Tensor,
+                     dx: ttnn.Tensor, dmod: ttnn.Tensor) -> None:
+        grid_cols, grid_rows = ttl.grid_size(dims=2)
+        cores = grid_cols * grid_rows
+        bpc = -(-B // cores)
+
+        dy_dfb = ttl.make_dataflow_buffer_like(dy, shape=(1, Dt), block_count=2)
+        x_dfb = ttl.make_dataflow_buffer_like(x, shape=(1, Dt), block_count=2)
+        s_dfb = ttl.make_dataflow_buffer_like(mod, shape=(1, Dt), block_count=2)
+        dx_dfb = ttl.make_dataflow_buffer_like(dx, shape=(1, Dt), block_count=2)
+        accs_dfb = ttl.make_dataflow_buffer_like(dy, shape=(1, Dt), block_count=2)
+        acch_dfb = ttl.make_dataflow_buffer_like(dy, shape=(1, Dt), block_count=2)
+        ds_dfb = ttl.make_dataflow_buffer_like(dmod, shape=(1, Dt), block_count=2)
+        dh_dfb = ttl.make_dataflow_buffer_like(dmod, shape=(1, Dt), block_count=2)
+
+        @ttl.compute()
+        def compute():
+            col_c, row_c = ttl.node(dims=2)
+            cid = col_c * grid_rows + row_c
+            for i in range(bpc):
+                b = cid * bpc + i
+                if b < B:
+                    with s_dfb.wait() as scale:
+                        for rt in range(Tt):
+                            with dy_dfb.wait() as dyb, x_dfb.wait() as xb:
+                                with dx_dfb.reserve() as dxw:
+                                    sbc = ttl.block.broadcast(scale, dims=[0], shape=dyb.shape)
+                                    dxw.store(ttl.add(ttl.mul(dyb, sbc), dyb))
+                                if Tt == 1:
+                                    with ds_dfb.reserve() as dsw:
+                                        dsw.store(ttl.math.reduce_sum(ttl.mul(dyb, xb), dims=[0]))
+                                    with dh_dfb.reserve() as dhw:
+                                        dhw.store(ttl.math.reduce_sum(dyb, dims=[0]))
+                                elif rt == 0:
+                                    with accs_dfb.reserve() as aw:
+                                        aw.store(ttl.math.reduce_sum(ttl.mul(dyb, xb), dims=[0]))
+                                    with acch_dfb.reserve() as bw:
+                                        bw.store(ttl.math.reduce_sum(dyb, dims=[0]))
+                                elif rt < Tt - 1:
+                                    with accs_dfb.wait() as aold, accs_dfb.reserve() as anew:
+                                        anew.store(ttl.add(aold, ttl.math.reduce_sum(ttl.mul(dyb, xb), dims=[0])))
+                                    with acch_dfb.wait() as bold, acch_dfb.reserve() as bnew:
+                                        bnew.store(ttl.add(bold, ttl.math.reduce_sum(dyb, dims=[0])))
+                                else:
+                                    with accs_dfb.wait() as aold, ds_dfb.reserve() as dsw:
+                                        dsw.store(ttl.add(aold, ttl.math.reduce_sum(ttl.mul(dyb, xb), dims=[0])))
+                                    with acch_dfb.wait() as bold, dh_dfb.reserve() as dhw:
+                                        dhw.store(ttl.add(bold, ttl.math.reduce_sum(dyb, dims=[0])))
+
+        @ttl.datamovement()
+        def read():
+            col_c, row_c = ttl.node(dims=2)
+            cid = col_c * grid_rows + row_c
+            for i in range(bpc):
+                b = cid * bpc + i
+                if b < B:
+                    with s_dfb.reserve() as sb:
+                        ttl.copy(mod[b, 0:1, so_t:so_t + Dt], sb).wait()
+                    for rt in range(Tt):
+                        with dy_dfb.reserve() as dyb, x_dfb.reserve() as xb:
+                            t1 = ttl.copy(dy[b, rt:rt + 1, 0:Dt], dyb)
+                            t2 = ttl.copy(x[b, rt:rt + 1, 0:Dt], xb)
+                            t1.wait(); t2.wait()
+
+        @ttl.datamovement()
+        def write():
+            col_c, row_c = ttl.node(dims=2)
+            cid = col_c * grid_rows + row_c
+            for i in range(bpc):
+                b = cid * bpc + i
+                if b < B:
+                    for rt in range(Tt):
+                        with dx_dfb.wait() as dxb:
+                            ttl.copy(dxb, dx[b, rt:rt + 1, 0:Dt]).wait()
+                    with ds_dfb.wait() as dsb:
+                        ttl.copy(dsb, dmod[b, 0:1, so_t:so_t + Dt]).wait()
+                    with dh_dfb.wait() as dhb:
+                        ttl.copy(dhb, dmod[b, 0:1, sh_t:sh_t + Dt]).wait()
+
+    return modulate_bwd
+
+
+def _get_fwd(key):
+    if key not in _FWD_CACHE:
+        _FWD_CACHE[key] = _make_modulate_fwd(*key)
+    return _FWD_CACHE[key]
+
+
+def _get_bwd(key):
+    if key not in _BWD_CACHE:
+        _BWD_CACHE[key] = _make_modulate_bwd(*key)
+    return _BWD_CACHE[key]
+
+
+def make_fused_modulate():
+    """Returns the FusedAdaLNModulate autograd Function class (requires ttl)."""
+    import ttml
+    import ttnn
+
+    class FusedAdaLNModulate(ttml.autograd.Function):
+        """y = x * (1 + mod[so:so+D]) + mod[sh:sh+D]; offsets in tiles.
+
+        x: [B,1,T,D]; mod: [B,1,1,n*D]. Both bf16 TILE. dmod is written only
+        at this call's offsets; multiple calls sharing one mod tensor
+        accumulate their grads through autograd's add_grad.
+        """
+
+        @staticmethod
+        def forward(ctx, x, mod, so_t, sh_t):
+            vx, vm = x.get_value(), mod.get_value()
+            Bc, _, Tc, Dc = (int(s) for s in vx.shape)
+            ctx.key = (Bc, Tc // TILE, Dc // TILE, so_t, sh_t)
+            ctx.mod_shape = [int(s) for s in vm.shape]
+            x3 = ttnn.reshape(vx, [Bc, Tc, Dc])
+            m3 = ttnn.reshape(vm, [Bc, 1, ctx.mod_shape[-1]])
+            out3 = ttnn.zeros([Bc, Tc, Dc], dtype=vx.dtype, layout=vx.layout, device=vx.device())
+            _get_fwd(ctx.key)(x3, m3, out3)
+            ctx.save_for_backward(x3, m3)
+            return ttnn.reshape(out3, [Bc, 1, Tc, Dc])
+
+        @staticmethod
+        def backward(ctx, grad_output):
+            Bc, Tt, Dt, so_t, sh_t = ctx.key
+            x3, m3 = ctx.saved_tensors
+            dy3 = ttnn.reshape(grad_output, [Bc, Tt * TILE, Dt * TILE])
+            dx3 = ttnn.zeros([Bc, Tt * TILE, Dt * TILE], dtype=dy3.dtype, layout=dy3.layout, device=dy3.device())
+            dmod3 = ttnn.zeros([Bc, 1, ctx.mod_shape[-1]], dtype=dy3.dtype, layout=dy3.layout, device=dy3.device())
+            _get_bwd(ctx.key)(dy3, x3, m3, dx3, dmod3)
+            dx = ttnn.reshape(dx3, [Bc, 1, Tt * TILE, Dt * TILE])
+            dmod = ttnn.reshape(dmod3, ctx.mod_shape)
+            return dx, dmod
+
+    return FusedAdaLNModulate


### PR DESCRIPTION
### Description
Stacked on #53124. Adds an **optional tt-lang (`ttl`) fused kernel path** for the DiT example's adaLN modulation — the first tt-lang training kernel (forward *and* backward) integrated into ttml autograd.

`y = x·(1+scale)+shift` runs as one fused `@ttl.operation` pair reading scale/shift at tile offsets from a packed modulation tensor, letting the model use the canonical DiT form (one zero-init D→4D "pairs" linear + separate gate linears per block): **3 linears + 2 fused kernels per block instead of 6 linears + 4 broadcast ops**. Off by default; without the tt-lang wheel the example is unchanged (clear ImportError if the flag is set without `ttl`).

### Changes Made
- [x] **New Feature:** `ttl_fused_ops.py` (kernels + `FusedAdaLNModulate` autograd Function + availability gate), `use_ttl_modulation` flag through `DiT`/`DiTBlock`/trainer, `dit_s_p2_ttl.yaml` config, `test_ttl_fused_ops.py` gate, README section.

### Testing
- [x] Standalone kernel validated on Blackhole p150: forward numerics vs golden (bf16 tolerance), backward gradients matching torch autograd (dx err 4.5e-6, dscale 4.0e-5); **1.52×** vs the pre-sliced ttnn mul+add pair, **2.56×** vs the full composed chain at B=64/T=256/D=384.
- [ ] **Integrated end-to-end validation pending** (why this is a draft): `python test_ttl_fused_ops.py --ab 500` trains eager-vs-fused DiT-S on identical batches and reports loss-curve agreement + throughput — needs one device run before marking ready.

### Review Checklist
- [x] No breaking changes (flag default off; graceful skip without ttl)

### Additional Context
- tt-lang light wheels (cp310/cp312, `TTNN_DEP_MODE=external`) come from the internal index; hence optional-only.
- Upstream compiler bug found during development, worked around here (scalar-batch-index/2D-block formulation): tenstorrent/tt-lang#898.
- Follow-up candidates on the same pattern: fused gate application (`x + gate·y`) and fused bias+GELU in the MLP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tt-train-dit-ttl-fused)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tt-train-dit-ttl-fused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=tt-train-dit-ttl-fused)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:tt-train-dit-ttl-fused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tt-train-dit-ttl-fused)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tt-train-dit-ttl-fused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=tt-train-dit-ttl-fused)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:tt-train-dit-ttl-fused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tt-train-dit-ttl-fused)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tt-train-dit-ttl-fused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tt-train-dit-ttl-fused)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tt-train-dit-ttl-fused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tt-train-dit-ttl-fused)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tt-train-dit-ttl-fused)