### PR TITLE
[Cleanup] Make MeshBuffer a pure RAII type

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_buffer.cpp
+++ b/tests/tt_metal/distributed/test_mesh_buffer.cpp
@@ -280,25 +280,33 @@ TEST_F(MeshBufferTest2x4, Deallocation) {
         return buffer->address();
     }();
 
-    // Test that creating and deallocating a MeshBuffer frees the address.
+    // Test that destroying a MeshBuffer frees the address.
     auto buffer1 = MeshBuffer::create(buffer_config, device_local_config, mesh_device_.get());
     EXPECT_TRUE(buffer1->is_allocated());
     EXPECT_EQ(buffer1->address(), expected_address);
 
-    buffer1->deallocate();
-    EXPECT_FALSE(buffer1->is_allocated());
+    buffer1.reset();
 
     auto buffer2 = MeshBuffer::create(buffer_config, device_local_config, mesh_device_.get());
     EXPECT_TRUE(buffer2->is_allocated());
     EXPECT_EQ(buffer2->address(), expected_address);
 
-    // Test deallocation of the view also works.
-    auto buffer_view = MeshBuffer::create(buffer_config, device_local_config, mesh_device_.get(), buffer2->address());
-    EXPECT_TRUE(buffer_view->is_allocated());
-    EXPECT_EQ(buffer_view->address(), expected_address);
+    // Test that destroying a view leaves the allocation it views intact.
+    {
+        auto buffer_view =
+            MeshBuffer::create(buffer_config, device_local_config, mesh_device_.get(), buffer2->address());
+        EXPECT_TRUE(buffer_view->is_allocated());
+        EXPECT_EQ(buffer_view->address(), expected_address);
+    }
+    EXPECT_TRUE(buffer2->is_allocated());
+    EXPECT_EQ(buffer2->address(), expected_address);
 
-    buffer_view->deallocate();
-    EXPECT_FALSE(buffer_view->is_allocated());
+    // A moved-from MeshBuffer no longer owns an allocation; the move target takes it over.
+    auto move_target = MeshBuffer::create(buffer_config, device_local_config, mesh_device_.get());
+    *move_target = std::move(*buffer2);
+    EXPECT_FALSE(buffer2->is_allocated());
+    EXPECT_TRUE(move_target->is_allocated());
+    EXPECT_EQ(move_target->address(), expected_address);
 }
 
 TEST(MeshBufferTest, DeallocationWithoutMeshDevice) {

--- a/tt_metal/api/tt-metalium/mesh_buffer.hpp
+++ b/tt_metal/api/tt-metalium/mesh_buffer.hpp
@@ -105,14 +105,10 @@ public:
     MeshBuffer(MeshBuffer&& other) noexcept;
     MeshBuffer& operator=(MeshBuffer&& other) noexcept;
 
-    // Returns true if the MeshBuffer is allocated. Note that MeshBuffer is created in the allocated state; either the
-    // destructor or the `deallocate` method deallocate the MeshBuffer.
+    // Returns true if the MeshBuffer holds a live allocation. A MeshBuffer is created in the allocated state and
+    // stays allocated for its entire lifetime; this returns false only for a moved-from MeshBuffer, or once the
+    // owning MeshDevice has been destroyed. To release the memory, destroy the MeshBuffer.
     bool is_allocated() const;
-
-    // Deallocates the MeshBuffer.
-    // TODO: Re-consider a need for explicit deallocation methods, as opposed to relying on RAII to clean up the
-    // resources.
-    void deallocate();
 
     // Throws an exception if the corresponding MeshDevice is already deallocated
     MeshDevice* device() const;
@@ -176,6 +172,12 @@ private:
         state_(ExternallyOwnedState{}) {}
 
     void initialize_device_buffers();
+
+    // Releases the device memory and moves the MeshBuffer into `DeallocatedState`. Called only by the destructor and
+    // by move-assignment (to release whatever this object held before taking over `other`'s allocation). MeshBuffer is
+    // an RAII type: memory release is not part of its public API.
+    void deallocate();
+
     MeshBufferConfig config_;
     DeviceLocalBufferConfig device_local_config_;
     std::weak_ptr<MeshDevice> mesh_device_;


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

`MeshBuffer` owns device memory, is copy-deleted and move-enabled, and frees its allocation in its destructor — it is an RAII type in every respect except that it also exposes a public `deallocate()`. That method lets a caller unmake the invariant the type otherwise guarantees: after calling it, a live `MeshBuffer` refers to memory that has been handed back to the allocator, and every other holder of that `shared_ptr` is left holding a husk. It has carried a TODO since it was introduced:

> `// TODO: Re-consider a need for explicit deallocation methods, as opposed to relying on RAII to clean up the resources.`

This removes it from the public API. The implementation moves to the private section, where it stays as the shared body for `~MeshBuffer()` and move-assignment. Memory release is now reachable only by destroying the object.

`is_allocated()` is kept — it is still meaningful, and still reachable as `false`, for a moved-from `MeshBuffer` and for one whose `MeshDevice` has already been destroyed. `DeallocatedState` likewise stays in `MeshBufferState`, since it is the moved-from state.

Relates to the same direction as the `Allocation` work: move-only RAII ownership, so `Buffer`'s `shared_ptr` + `enable_shared_from_this` contagion does not have to be reproduced in every type that holds device memory.

### Notes for reviewers

**In-tree callers: two, both in one test.** `tests/tt_metal/distributed/test_mesh_buffer.cpp` `TEST_F(MeshBufferTest2x4, Deallocation)` was the only external user. Its stated purpose was already scope-based ("Verify that a buffer is deallocated on the MeshDevice when it goes out of scope on host"), so it is rewritten to match:

- the explicit `buffer1->deallocate()` becomes `buffer1.reset()`, and the address-reuse assertion that follows is unchanged — it is what actually proves the memory was freed;
- the view case moves into a nested scope, and now additionally asserts that destroying a view leaves the allocation it views intact — a property the old `deallocate()`-based version could not check;
- a moved-from case is added, so the `EXPECT_FALSE(is_allocated())` coverage that the removed calls provided is not lost.

`TEST(MeshBufferTest, DeallocationWithoutMeshDevice)` is untouched; it already exercised the destructor path with an expired `MeshDevice`.

**ttnn needs no change.** `DeviceStorage::deallocate()` already releases memory by replacing the `Allocated` state with a tombstone and letting the `MeshTensor` destructor run — it never called `MeshBuffer::deallocate()`.

**No bindings.** `MeshBuffer` has no nanobind/pybind surface in this repo, so there is no Python-visible change.

**Out-of-tree: one repo, tt-mlir, two lines, both semantics-preserving.** tt-mlir pins tt-metal by SHA, so nothing breaks at merge — only at their next pin bump. Both sites are landable independently and ahead of that bump:

- `runtime/lib/ttmetal/executor.cpp` — the `DeallocateBufferCommand` handler calls `deallocate()` and then erases the map entry. The call is redundant: every `DeallocateBufferCommand` the compiler can emit refers to a buffer the executor solely owns, so the `erase()` alone already drops the last reference and runs the destructor. This holds because `ttmetal::DeallocateBufferOp` is a 1:1 lowering of `memref::DeallocOp`, and the only passes that insert one (`D2M/Transforms/Allocate.cpp`, `D2M/Transforms/HoistCBAllocs.cpp`) require a defining `memref::AllocOp` and skip anything whose last use is `func::ReturnOp` — so program inputs (block arguments, co-owned by the caller's `Tensor`) and program outputs are never deallocated. Circular buffer configs hold a non-owning `const Buffer&`, so they do not extend lifetime either.
- `runtime/python/runtime/utils.cpp` — `MeshBufferWrapper::deallocate()` becomes `buffer.reset()`. As a side effect this fixes the adjacent `is_allocated()`, which tests `buffer != nullptr` and so currently reports `true` after a deallocate. Its one caller is the allocator probe in `tools/ttnn-jit/_src/memory_analyzer.py`.

**Verification.** Confirmed by compiling against the modified header that `deallocate()` is now inaccessible externally (`error: 'deallocate' is a private member of 'tt::tt_metal::distributed::MeshBuffer'`), that the header itself still compiles clean, and that the operations the rewritten test performs (`shared_ptr::reset`, move-assignment through `*a = std::move(*b)`, `is_allocated()`/`address()` after the move) type-check against the real class. The functional address-reuse assertions need hardware and will run in CI.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brain/mesh-buffer-raii)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brain/mesh-buffer-raii)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=brain/mesh-buffer-raii)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:brain/mesh-buffer-raii)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brain/mesh-buffer-raii)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brain/mesh-buffer-raii)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=brain/mesh-buffer-raii)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:brain/mesh-buffer-raii)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=brain/mesh-buffer-raii)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brain/mesh-buffer-raii)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=brain/mesh-buffer-raii)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brain/mesh-buffer-raii)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=brain/mesh-buffer-raii)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brain/mesh-buffer-raii)