### PR TITLE
Let a line-cabled mesh run the H3 FFN

### DIFF
--- a/models/tt_dit/models/transformers/minimax_h3/transformer_block_minimax_h3.py
+++ b/models/tt_dit/models/transformers/minimax_h3/transformer_block_minimax_h3.py
@@ -312,8 +312,13 @@ class MiniMaxH3TransformerBlock(Module):
         # on 56 of the device's 120 cores at subblock 1x1, making the fused op a measured 45%
         # regression on this stage (1.75 -> 2.55 ms) -- and silently, since an unknown shape does not
         # warn. See mmrs_config for the sweep and the grid/bandwidth tradeoff behind it.
+        #
+        # Ring only: the op asserts `attributes.topology == Ring` ("MinimalMatmulStridedReduceScatter
+        # Async only supports Ring topology"), so a line-cabled mesh has to take the unfused path
+        # below. Gated here rather than left to fail, because the assert fires on the first denoise
+        # step of the first request -- long after warmup reports the model loaded.
         ff2_shape = (normed.shape[2], self.ffn_dim // self.tp_factor, self.hidden_size)
-        if self.tp_factor > 1 and has_mmrs_config(*ff2_shape):
+        if self.tp_factor > 1 and self.ccl_manager.topology == ttnn.Topology.Ring and has_mmrs_config(*ff2_shape):
             # M is only known here (it tracks the packed sequence length), so the blocking is
             # registered at the point of use rather than at construction. Idempotent and cheap.
             register_mmrs_config(*ff2_shape)


### PR DESCRIPTION
MinimalMatmulStridedReduceScatterAsync asserts `topology == Ring`, so on a FABRIC_1D mesh the fused ff2 reduce-scatter kills the first denoise step of the first request with

    TT_FATAL: MinimalMatmulStridedReduceScatterAsync only supports Ring topology.

which lands well after warmup has reported the model loaded. The unfused fall-through immediately below -- ff() then ttnn.addcmul -- already handles it, so gate the fusion on topology the way `use_fused_agmm` upstream of it already is.

Measured on a 4x8 Blackhole Galaxy at 16:9/5s, warm: 74.2 s compute on Ring against 96.3 s on Linear. The whole difference is denoise (60.1 -> 82.6 s); the two VAEs are data-parallel with replicated weights and do not move.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=cglagovich/minimax-h3-linear)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:cglagovich/minimax-h3-linear)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=cglagovich/minimax-h3-linear)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:cglagovich/minimax-h3-linear)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=cglagovich/minimax-h3-linear)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:cglagovich/minimax-h3-linear)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=cglagovich/minimax-h3-linear)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:cglagovich/minimax-h3-linear)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=cglagovich/minimax-h3-linear)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:cglagovich/minimax-h3-linear)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=cglagovich/minimax-h3-linear)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:cglagovich/minimax-h3-linear)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=cglagovich/minimax-h3-linear)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:cglagovich/minimax-h3-linear)