### PR TITLE
[tt-train] DiT example: resume support + low-priority segmented runner

### DIFF
--- a/tt-train/configs/dit_b_p2.yaml
+++ b/tt-train/configs/dit_b_p2.yaml
@@ -1,0 +1,10 @@
+dit_config:
+  model_type: "dit"
+  embedding_dim: 768
+  num_heads: 12
+  num_blocks: 12
+  mlp_ratio: 4.0
+  patch_size: 2
+  image_size: 32
+  image_channels: 3
+  num_classes: 10

--- a/tt-train/configs/model_configs/dit_b_p2.yaml
+++ b/tt-train/configs/model_configs/dit_b_p2.yaml
@@ -1,0 +1,10 @@
+dit_config:
+  model_type: "dit"
+  embedding_dim: 768
+  num_heads: 12
+  num_blocks: 12
+  mlp_ratio: 4.0
+  patch_size: 2
+  image_size: 32
+  image_channels: 3
+  num_classes: 10

--- a/tt-train/configs/training_cifar10_dit_b_p2_edm.yaml
+++ b/tt-train/configs/training_cifar10_dit_b_p2_edm.yaml
@@ -1,0 +1,40 @@
+training_config:
+  project_name: "tt_train_dit_edm_b"
+  seed: 5489
+  batch_size: 2048
+  # EDM official duration: 200 Mimg -> 97,656 steps at batch 2048.
+  max_steps: 98000
+  model_save_interval: 2000
+  data_path: "/data/ayerofieiev/dit/data"
+  output_dir: "/data/ayerofieiev/dit/runs"
+  model_config: "${TT_METAL_RUNTIME_ROOT}/tt-train/configs/model_configs/dit_b_p2.yaml"
+  # EDM: lr ramp over ~10 Mimg then constant (no decay).
+  lr_schedule: warmup_constant
+  warmup_steps: 4800
+  # EDM EMA halflife 0.5 Mimg = 244 steps at b2048 -> per-step decay 0.5^(1/244).
+  ema_decay: 0.99716
+  ema_interval: 25
+  hflip_augment: true
+  optimizer:
+    type: AdamW
+    lr: 0.001
+    beta1: 0.9
+    beta2: 0.999
+    epsilon: 1.0e-8
+    weight_decay: 0.0
+
+diffusion_config:
+  recipe: edm
+  # EDM CIFAR-10 conditional trains without CFG dropout.
+  cfg_drop_prob: 0.0
+
+eval_config:
+  sample_interval: 0
+
+logging_config:
+  log_interval: 100
+  wandb: false
+
+device_config:
+  enable_ddp: true
+  mesh_shape: [32, 1]

--- a/tt-train/configs/training_configs/training_cifar10_dit_b_p2_edm.yaml
+++ b/tt-train/configs/training_configs/training_cifar10_dit_b_p2_edm.yaml
@@ -1,0 +1,40 @@
+training_config:
+  project_name: "tt_train_dit_edm_b"
+  seed: 5489
+  batch_size: 2048
+  # EDM official duration: 200 Mimg -> 97,656 steps at batch 2048.
+  max_steps: 98000
+  model_save_interval: 2000
+  data_path: "/data/ayerofieiev/dit/data"
+  output_dir: "/data/ayerofieiev/dit/runs"
+  model_config: "${TT_METAL_RUNTIME_ROOT}/tt-train/configs/model_configs/dit_b_p2.yaml"
+  # EDM: lr ramp over ~10 Mimg then constant (no decay).
+  lr_schedule: warmup_constant
+  warmup_steps: 4800
+  # EDM EMA halflife 0.5 Mimg = 244 steps at b2048 -> per-step decay 0.5^(1/244).
+  ema_decay: 0.99716
+  ema_interval: 25
+  hflip_augment: true
+  optimizer:
+    type: AdamW
+    lr: 0.001
+    beta1: 0.9
+    beta2: 0.999
+    epsilon: 1.0e-8
+    weight_decay: 0.0
+
+diffusion_config:
+  recipe: edm
+  # EDM CIFAR-10 conditional trains without CFG dropout.
+  cfg_drop_prob: 0.0
+
+eval_config:
+  sample_interval: 0
+
+logging_config:
+  log_interval: 100
+  wandb: false
+
+device_config:
+  enable_ddp: true
+  mesh_shape: [32, 1]

--- a/tt-train/configs/training_configs/training_cifar10_dit_s_p2_edm.yaml
+++ b/tt-train/configs/training_configs/training_cifar10_dit_s_p2_edm.yaml
@@ -1,0 +1,40 @@
+training_config:
+  project_name: "tt_train_dit_edm"
+  seed: 5489
+  batch_size: 2048
+  # EDM official duration: 200 Mimg -> 97,656 steps at batch 2048.
+  max_steps: 98000
+  model_save_interval: 2000
+  data_path: "/data/ayerofieiev/dit/data"
+  output_dir: "/data/ayerofieiev/dit/runs"
+  model_config: "${TT_METAL_RUNTIME_ROOT}/tt-train/configs/model_configs/dit_s_p2.yaml"
+  # EDM: lr ramp over ~10 Mimg then constant (no decay).
+  lr_schedule: warmup_constant
+  warmup_steps: 4800
+  # EDM EMA halflife 0.5 Mimg = 244 steps at b2048 -> per-step decay 0.5^(1/244).
+  ema_decay: 0.99716
+  ema_interval: 25
+  hflip_augment: true
+  optimizer:
+    type: AdamW
+    lr: 0.001
+    beta1: 0.9
+    beta2: 0.999
+    epsilon: 1.0e-8
+    weight_decay: 0.0
+
+diffusion_config:
+  recipe: edm
+  # EDM CIFAR-10 conditional trains without CFG dropout.
+  cfg_drop_prob: 0.0
+
+eval_config:
+  sample_interval: 0
+
+logging_config:
+  log_interval: 100
+  wandb: false
+
+device_config:
+  enable_ddp: true
+  mesh_shape: [32, 1]

--- a/tt-train/sources/examples/dit/README.md
+++ b/tt-train/sources/examples/dit/README.md
@@ -19,6 +19,11 @@ Measured on Blackhole (p150): DiT-S (32.6M params, patch 4) trains at
 | `sample_from_ckpt.py` | Offline DDIM sampling (with CFG) from a saved checkpoint |
 | `test_device_primitives.py` | On-device gate: every primitive the model relies on, cheapest first |
 | `reference_torch.py`, `test_reference.py` | PyTorch golden model (CPU) mirroring the ttml implementation 1:1 |
+| `edm.py` | EDM (Karras 2022) recipe, host side: preconditioning, batch builders (token + image space), Heun sampler, SongUNet block plan |
+| `edm_ops.py` | Convolutional autograd Functions for ttml: `Conv3x3Im2col`, `GroupNormMoreh`, `AvgPool2x2`/`UpsampleNearest2` (adjoint pair), `Permute`, `ConcatChannels`, `Scale` |
+| `edm_unet.py` | DDPM++ SongUNet (EDM CIFAR-10 config, 56.7M params) on ttml, mirroring `reference_unet.py` 1:1 |
+| `reference_unet.py`, `test_reference_unet.py` | PyTorch golden SongUNet + CPU validation (im2col ROW_ORDER, param count, shape walk, EDM overfit) |
+| `test_edm_primitives.py` | On-device gate for the UNet primitives (run before training the UNet) |
 
 ## Run
 
@@ -43,6 +48,25 @@ python sample_from_ckpt.py -c <training_config.yaml> --ckpt runs/dit/<run>/ckpt_
 CIFAR-10 downloads automatically to `training_config.data_path` on first run.
 `--overfit-batch --max-steps 300` trains on one fixed batch (bring-up sanity:
 loss must collapse).
+
+## SongUNet (convolutional EDM backbone, Phase 1)
+
+The EDM DDPM++ "SongUNet" (Karras 2022 CIFAR-10 config) is implemented on
+ttml with **composite im2col convolutions** — native `ttnn.conv2d` re-preps
+weights host-side on every call when weights change, which is unusable for
+training. Trainable 3x3 conv weights are stored flattened as
+`[1,1,9*C_in,C_out]` matrices with `ROW_ORDER = (kh, kw, c_in)` (see
+`reference_unet.py` for the full spec and the documented deviations from
+official EDM). Activations flow as `[B,1,H*W,C]` channels-last tokens so 1x1
+convs, attention, and all conditioning broadcasts reuse the validated DiT
+machinery; GroupNorm wraps the `ttnn.moreh.group_norm` kernel pair in
+NHWC<->NCHW permutes; avgpool/nearest-upsample are implemented as an exact
+adjoint pair. Bring-up order:
+
+```bash
+python test_reference_unet.py     # CPU (torch): golden model, 56.7M params, overfit
+python test_edm_primitives.py    # device gate: conv/GN/pool/attn fwd+bwd parity
+```
 
 ## Design notes (framework workarounds, kept intentionally visible)
 

--- a/tt-train/sources/examples/dit/README.md
+++ b/tt-train/sources/examples/dit/README.md
@@ -83,6 +83,12 @@ forward for backward's dW vs recompute — memory/speed trade),
 `smoke_unet_train.py --probe` phase breakdown). Backward's col2im sums its
 9 shifted tap blocks with one cached stacked-identity matmul, and dX is
 skipped for the pixel-fed `conv_in` when inputs are created without grad.
+With `EDM_NATIVE_CONV=1`, dX also goes native: `dInput = conv2d(dOut,
+flipT(W))` where `flipT` (9 tile-aligned slice+transpose on the ~MB weight)
+reverses the tap blocks and transposes each — the composite col2im remains
+the fallback. `EDM_NHWC_GN=1` (default) computes GroupNorm directly on the
+`[B,1,HW,C]` tokens via a cached group-pooling matmul — no NHWC↔NCHW
+permutes, no moreh kernels; `=0` restores the moreh wrapper.
 
 ## Design notes (framework workarounds, kept intentionally visible)
 

--- a/tt-train/sources/examples/dit/README.md
+++ b/tt-train/sources/examples/dit/README.md
@@ -68,6 +68,15 @@ python test_reference_unet.py     # CPU (torch): golden model, 56.7M params, ove
 python test_edm_primitives.py    # device gate: conv/GN/pool/attn fwd+bwd parity
 ```
 
+**Native conv forward (Phase 2):** `EDM_NATIVE_CONV=1` (or
+`smoke_unet_train.py --native-conv`) routes the 3x3 conv *forward* through
+native `ttnn.conv2d`, which consumes our flat `[1,1,9Cin,Cout]` TILE weight
+in place (passes the device-weight shape sniff, so per-step weight prep is
+skipped entirely; height-sharded is pinned so the expected layout matches
+ROW_ORDER at every shape). Backward stays the im2col composite. Gated by the
+`native conv2d probe`/`parity` checks in `test_edm_primitives.py`; only
+convs with `Cin % 32 == 0` take the native path (`conv_in` keeps im2col).
+
 ## Design notes (framework workarounds, kept intentionally visible)
 
 - **Patchify lives on the host.** There is no autograd permute/transpose, only

--- a/tt-train/sources/examples/dit/README.md
+++ b/tt-train/sources/examples/dit/README.md
@@ -77,6 +77,13 @@ ROW_ORDER at every shape). Backward stays the im2col composite. Gated by the
 `native conv2d probe`/`parity` checks in `test_edm_primitives.py`; only
 convs with `Cin % 32 == 0` take the native path (`conv_in` keeps im2col).
 
+Perf knobs: `EDM_SAVE_PATCHES=auto|1|0` (save the im2col patch tensor from
+forward for backward's dW vs recompute — memory/speed trade),
+`EDM_PROFILE_CONV=1` (per-bucket conv timings in the
+`smoke_unet_train.py --probe` phase breakdown). Backward's col2im sums its
+9 shifted tap blocks with one cached stacked-identity matmul, and dX is
+skipped for the pixel-fed `conv_in` when inputs are created without grad.
+
 ## Design notes (framework workarounds, kept intentionally visible)
 
 - **Patchify lives on the host.** There is no autograd permute/transpose, only

--- a/tt-train/sources/examples/dit/cpu_sample.py
+++ b/tt-train/sources/examples/dit/cpu_sample.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sample a ttml DiT checkpoint on CPU via the PyTorch golden model.
+
+    python cpu_sample.py --ckpt ckpt_ema_002000.npz --out grid.npy \
+        [--dim 384 --depth 12 --heads 6 --patch 2] [--steps 50] [--cfg 2.0]
+
+Loads tt-train .npz weights (names like DiT/blocks/0/attn/qkv/weight,
+shapes [1,1,out,in]) into a torch DiT mirroring dit_ttml.py, then runs DDIM.
+Doubles as a weight-level parity harness between the two implementations.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from reference_torch import DiffusionSchedule, sample_ddim
+
+
+class TorchDiT(nn.Module):
+    """Torch mirror of dit_ttml.DiT (affine LayerNorms, scale1p convention)."""
+
+    def __init__(self, in_dim, dim, depth, num_heads, num_tokens, num_classes, mlp_ratio=4.0):
+        super().__init__()
+        self.dim, self.num_heads, self.num_classes = dim, num_heads, num_classes
+        self.patch_proj = nn.Linear(in_dim, dim)
+        self.pos_emb = nn.Parameter(torch.zeros(1, 1, num_tokens, dim))
+        self.t_fc1, self.t_fc2 = nn.Linear(dim, dim), nn.Linear(dim, dim)
+        self.label_emb = nn.Linear(num_classes + 1, dim, bias=False)
+        self.blocks = nn.ModuleList()
+        for _ in range(depth):
+            b = nn.Module()
+            b.norm1 = nn.LayerNorm(dim, eps=1e-5)
+            b.norm2 = nn.LayerNorm(dim, eps=1e-5)
+            b.qkv, b.proj = nn.Linear(dim, 3 * dim), nn.Linear(dim, dim)
+            b.fc1, b.fc2 = nn.Linear(dim, int(dim * mlp_ratio)), nn.Linear(int(dim * mlp_ratio), dim)
+            b.branches = nn.ModuleList(nn.Linear(dim, dim) for _ in range(6))
+            self.blocks.append(b)
+        self.final_norm = nn.LayerNorm(dim, eps=1e-5)
+        self.final_branches = nn.ModuleList(nn.Linear(dim, dim) for _ in range(2))
+        self.final_proj = nn.Linear(dim, in_dim)
+
+    @staticmethod
+    def _mods(branches, c):
+        s = torch.nn.functional.silu(c)
+        return [br(s) for br in branches]
+
+    def _attn(self, b, x):
+        B, one, T, D = x.shape
+        H, hd = self.num_heads, D // self.num_heads
+        qkv = b.qkv(x).reshape(B, T, 3, H, hd)
+        q, k, v = (qkv[:, :, i].transpose(1, 2) for i in range(3))
+        out = torch.nn.functional.scaled_dot_product_attention(q, k, v)
+        return b.proj(out.transpose(1, 2).reshape(B, 1, T, D))
+
+    def forward(self, tokens, t_feats, labels):
+        onehot = torch.nn.functional.one_hot(labels, self.num_classes + 1).float()
+        onehot = onehot.reshape(labels.shape[0], 1, 1, -1)
+        x = self.patch_proj(tokens) + self.pos_emb
+        c = self.t_fc2(torch.nn.functional.silu(self.t_fc1(t_feats))) + self.label_emb(onehot)
+        for b in self.blocks:
+            sh_a, sc1p_a, g_a, sh_m, sc1p_m, g_m = self._mods(b.branches, c)
+            h = b.norm1(x) * sc1p_a + sh_a
+            x = x + g_a * self._attn(b, h)
+            h = b.norm2(x) * sc1p_m + sh_m
+            x = x + g_m * b.fc2(torch.nn.functional.gelu(b.fc1(h), approximate="tanh"))
+        f_sh, f_sc1p = self._mods(self.final_branches, c)
+        x = self.final_norm(x) * f_sc1p + f_sh
+        return self.final_proj(x)
+
+
+def load_ttml_npz(model: TorchDiT, path: str):
+    z = np.load(path)
+
+    def W(name):  # [1,1,out,in] -> [out,in]
+        return torch.from_numpy(z[name].reshape(z[name].shape[-2], z[name].shape[-1]).copy())
+
+    def B(name):  # [1,1,1,out] -> [out]
+        return torch.from_numpy(z[name].reshape(-1).copy())
+
+    sd = {}
+    sd["patch_proj.weight"], sd["patch_proj.bias"] = W("DiT/patch_proj/weight"), B("DiT/patch_proj/bias")
+    sd["pos_emb"] = torch.from_numpy(z["DiT/pos_emb"].copy())
+    sd["t_fc1.weight"], sd["t_fc1.bias"] = W("DiT/t_fc1/weight"), B("DiT/t_fc1/bias")
+    sd["t_fc2.weight"], sd["t_fc2.bias"] = W("DiT/t_fc2/weight"), B("DiT/t_fc2/bias")
+    sd["label_emb.weight"] = W("DiT/label_emb/weight")
+    for i in range(len(model.blocks)):
+        p = f"DiT/blocks/{i}"
+        sd[f"blocks.{i}.norm1.weight"], sd[f"blocks.{i}.norm1.bias"] = B(f"{p}/norm1/gamma"), B(f"{p}/norm1/beta")
+        sd[f"blocks.{i}.norm2.weight"], sd[f"blocks.{i}.norm2.bias"] = B(f"{p}/norm2/gamma"), B(f"{p}/norm2/beta")
+        sd[f"blocks.{i}.qkv.weight"], sd[f"blocks.{i}.qkv.bias"] = W(f"{p}/attn/qkv/weight"), B(f"{p}/attn/qkv/bias")
+        sd[f"blocks.{i}.proj.weight"], sd[f"blocks.{i}.proj.bias"] = W(f"{p}/attn/proj/weight"), B(f"{p}/attn/proj/bias")
+        sd[f"blocks.{i}.fc1.weight"], sd[f"blocks.{i}.fc1.bias"] = W(f"{p}/mlp/fc1/weight"), B(f"{p}/mlp/fc1/bias")
+        sd[f"blocks.{i}.fc2.weight"], sd[f"blocks.{i}.fc2.bias"] = W(f"{p}/mlp/fc2/weight"), B(f"{p}/mlp/fc2/bias")
+        for j in range(6):
+            sd[f"blocks.{i}.branches.{j}.weight"] = W(f"{p}/modulation/branches/{j}/weight")
+            sd[f"blocks.{i}.branches.{j}.bias"] = B(f"{p}/modulation/branches/{j}/bias")
+    sd["final_norm.weight"], sd["final_norm.bias"] = B("DiT/final_norm/gamma"), B("DiT/final_norm/beta")
+    for j in range(2):
+        sd[f"final_branches.{j}.weight"] = W(f"DiT/final_modulation/branches/{j}/weight")
+        sd[f"final_branches.{j}.bias"] = B(f"DiT/final_modulation/branches/{j}/bias")
+    sd["final_proj.weight"], sd["final_proj.bias"] = W("DiT/final_proj/weight"), B("DiT/final_proj/bias")
+
+    missing, unexpected = model.load_state_dict(sd, strict=True), None
+    return model
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ckpt", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--dim", type=int, default=384)
+    ap.add_argument("--depth", type=int, default=12)
+    ap.add_argument("--heads", type=int, default=6)
+    ap.add_argument("--patch", type=int, default=2)
+    ap.add_argument("--image-size", type=int, default=32)
+    ap.add_argument("--channels", type=int, default=3)
+    ap.add_argument("--classes", type=int, default=10)
+    ap.add_argument("--steps", type=int, default=50)
+    ap.add_argument("--cfg", type=float, default=2.0)
+    ap.add_argument("--seed", type=int, default=0)
+    args = ap.parse_args()
+
+    in_dim = args.patch * args.patch * args.channels
+    num_tokens = (args.image_size // args.patch) ** 2
+    model = TorchDiT(in_dim, args.dim, args.depth, args.heads, num_tokens, args.classes)
+    load_ttml_npz(model, args.ckpt)
+    model.eval()
+
+    # sample_ddim expects the reference_torch DiT API surface; shim the bits it uses.
+    model.pos_emb.data = model.pos_emb.data  # noop; pos_emb.shape[-1] read for t-features
+    schedule = DiffusionSchedule()
+    labels = torch.arange(args.classes)
+    grid = sample_ddim(
+        model, schedule, labels, (args.channels, args.image_size, args.image_size),
+        patch=args.patch, steps=args.steps, cfg_scale=args.cfg, null_class=args.classes,
+        generator=torch.Generator().manual_seed(args.seed),
+    )
+    np.save(args.out, grid.numpy())
+    print(f"saved {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tt-train/sources/examples/dit/diffusion.py
+++ b/tt-train/sources/examples/dit/diffusion.py
@@ -65,12 +65,17 @@ def make_training_batch(
     rng: np.random.Generator,
     cfg_drop_prob: float = 0.1,
     null_class: int | None = None,
+    hflip: bool = False,
 ):
     """Returns (tokens, t_feats, labels_onehot, target) as numpy arrays ready
     for Tensor.from_numpy: [B,1,T,in], [B,1,1,dim], [B,1,1,null_class+1] fp32
     one-hot, [B,1,T,in]. One-hot (not ids): the model embeds labels via
     one-hot @ W because ttnn embedding_backward can't take a single id."""
     b = images.shape[0]
+    if hflip:
+        flip = rng.random(b) < 0.5
+        images = images.copy()
+        images[flip] = images[flip][..., ::-1]
     t = rng.integers(0, schedule.timesteps, size=b)
     noise = rng.standard_normal(images.shape).astype(np.float32)
     noisy = schedule.add_noise(images, noise, t)

--- a/tt-train/sources/examples/dit/edm.py
+++ b/tt-train/sources/examples/dit/edm.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""EDM (Karras et al. 2022, arXiv:2206.00364) training + sampling, host side.
+
+The network F is trained in EDM's F-space, where the loss is EXACTLY
+unweighted MSE — so the device graph is identical to the DDPM path and all
+recipe machinery stays in numpy:
+
+    y      = x + n,  n ~ N(0, sigma^2),  sigma ~ LogNormal(P_mean, P_std)
+    input  = c_in(sigma) * y            (patchified)
+    cond   = c_noise(sigma) = ln(sigma)/4   (fed through the timestep-feature MLP)
+    target = (x - c_skip(sigma) * y) / c_out(sigma)   (patchified)
+    loss   = MSE(F(input, cond, class), target)
+
+Denoiser reconstruction: D(y; sigma) = c_skip * y + c_out * F(c_in * y, c_noise).
+Sampling: EDM deterministic Heun over the rho-spaced sigma schedule.
+
+Official CIFAR-10 class-conditional reference (DDPM++ UNet): FID 1.79.
+This module reproduces the METHODOLOGY on the DiT backbone.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from diffusion import patchify, unpatchify, timestep_features, one_hot
+
+SIGMA_DATA = 0.5
+P_MEAN = -1.2
+P_STD = 1.2
+SIGMA_MIN = 0.002
+SIGMA_MAX = 80.0
+RHO = 7.0
+# c_noise = ln(sigma)/4 spans roughly [-1.6, 1.1]; scale into the sinusoidal
+# embedder's useful range (it was built for integer timesteps 0..1000).
+CNOISE_FEAT_SCALE = 250.0
+
+
+def precond_coeffs(sigma: np.ndarray):
+    """c_skip, c_out, c_in, c_noise for sigma [B] (fp32)."""
+    s2 = sigma**2
+    d2 = SIGMA_DATA**2
+    c_skip = d2 / (s2 + d2)
+    c_out = sigma * SIGMA_DATA / np.sqrt(s2 + d2)
+    c_in = 1.0 / np.sqrt(s2 + d2)
+    c_noise = np.log(sigma) / 4.0
+    return c_skip, c_out, c_in, c_noise
+
+
+def sample_sigma(rng: np.random.Generator, batch: int) -> np.ndarray:
+    return np.exp(rng.normal(P_MEAN, P_STD, size=batch)).astype(np.float32)
+
+
+def make_edm_batch(
+    images: np.ndarray,  # [B, C, H, W] fp32 in [-1, 1]
+    labels: np.ndarray,  # [B] int
+    patch: int,
+    model_dim: int,
+    rng: np.random.Generator,
+    cfg_drop_prob: float = 0.0,
+    null_class: int | None = None,
+    hflip: bool = False,
+):
+    """Returns (input_tokens, cnoise_feats, labels_onehot, target_tokens)."""
+    b = images.shape[0]
+    if hflip:
+        flip = rng.random(b) < 0.5
+        images = images.copy()
+        images[flip] = images[flip][..., ::-1]
+
+    sigma = sample_sigma(rng, b)
+    c_skip, c_out, c_in, c_noise = precond_coeffs(sigma)
+    bc = lambda v: v.reshape(b, 1, 1, 1).astype(np.float32)
+
+    n = rng.standard_normal(images.shape).astype(np.float32) * bc(sigma)
+    y = images + n
+    net_in = bc(c_in) * y
+    target = (images - bc(c_skip) * y) / bc(c_out)
+
+    if null_class is not None and cfg_drop_prob > 0:
+        drop = rng.random(b) < cfg_drop_prob
+        labels = np.where(drop, null_class, labels)
+
+    feats = timestep_features(c_noise * CNOISE_FEAT_SCALE, model_dim)
+    onehot = one_hot(labels, (null_class if null_class is not None else int(labels.max())) + 1)
+    return patchify(net_in, patch), feats.astype(np.float32), onehot, patchify(target, patch)
+
+
+def sigma_schedule(steps: int = 18) -> np.ndarray:
+    i = np.arange(steps, dtype=np.float64)
+    s = (SIGMA_MAX ** (1 / RHO) + i / (steps - 1) * (SIGMA_MIN ** (1 / RHO) - SIGMA_MAX ** (1 / RHO))) ** RHO
+    return np.append(s, 0.0).astype(np.float32)  # sigma_N = 0
+
+
+def heun_sample(
+    denoise,  # callable: (y [B,C,H,W] fp32, sigma scalar) -> D(y; sigma) [B,C,H,W]
+    batch: int,
+    shape: tuple[int, int, int],
+    rng: np.random.Generator,
+    steps: int = 18,
+):
+    """EDM deterministic sampler (Algorithm 1, no stochastic churn)."""
+    sig = sigma_schedule(steps)
+    x = rng.standard_normal((batch, *shape)).astype(np.float32) * sig[0]
+    for i in range(steps):
+        s_cur, s_next = float(sig[i]), float(sig[i + 1])
+        d_cur = (x - denoise(x, s_cur)) / s_cur
+        x_next = x + (s_next - s_cur) * d_cur
+        if s_next > 0:
+            d_next = (x_next - denoise(x_next, s_next)) / s_next
+            x_next = x + (s_next - s_cur) * 0.5 * (d_cur + d_next)
+        x = x_next
+    return x
+
+
+def make_model_denoiser(model_forward, patch: int, model_dim: int, labels_onehot: np.ndarray, channels=3, size=32):
+    """Wrap a token-space F-network forward into an image-space denoiser.
+
+    model_forward: callable(tokens [B,1,T,in], feats [B,1,1,D], onehot) -> tokens.
+    """
+
+    def denoise(y: np.ndarray, sigma: float) -> np.ndarray:
+        b = y.shape[0]
+        s = np.full(b, sigma, dtype=np.float32)
+        c_skip, c_out, c_in, c_noise = precond_coeffs(s)
+        bc = lambda v: v.reshape(b, 1, 1, 1).astype(np.float32)
+        tokens = patchify(bc(c_in) * y, patch)
+        feats = timestep_features(c_noise * CNOISE_FEAT_SCALE, model_dim).astype(np.float32)
+        f = model_forward(tokens, feats, labels_onehot)
+        f_img = unpatchify(f, patch, channels, size, size)
+        return bc(c_skip) * y + bc(c_out) * f_img
+
+    return denoise

--- a/tt-train/sources/examples/dit/edm.py
+++ b/tt-train/sources/examples/dit/edm.py
@@ -53,17 +53,21 @@ def sample_sigma(rng: np.random.Generator, batch: int) -> np.ndarray:
     return np.exp(rng.normal(P_MEAN, P_STD, size=batch)).astype(np.float32)
 
 
-def make_edm_batch(
+def make_edm_batch_image(
     images: np.ndarray,  # [B, C, H, W] fp32 in [-1, 1]
     labels: np.ndarray,  # [B] int
-    patch: int,
     model_dim: int,
     rng: np.random.Generator,
     cfg_drop_prob: float = 0.0,
     null_class: int | None = None,
     hflip: bool = False,
 ):
-    """Returns (input_tokens, cnoise_feats, labels_onehot, target_tokens)."""
+    """Unpatchified EDM batch for image-space (UNet) backbones.
+
+    Returns (net_in [B,C,H,W], cnoise_feats [B,1,1,model_dim],
+    labels_onehot [B,1,1,K], target [B,C,H,W]) — same math as
+    make_edm_batch but leaves images in [B,C,H,W].
+    """
     b = images.shape[0]
     if hflip:
         flip = rng.random(b) < 0.5
@@ -85,7 +89,109 @@ def make_edm_batch(
 
     feats = timestep_features(c_noise * CNOISE_FEAT_SCALE, model_dim)
     onehot = one_hot(labels, (null_class if null_class is not None else int(labels.max())) + 1)
-    return patchify(net_in, patch), feats.astype(np.float32), onehot, patchify(target, patch)
+    return net_in.astype(np.float32), feats.astype(np.float32), onehot, target.astype(np.float32)
+
+
+def make_edm_batch(
+    images: np.ndarray,  # [B, C, H, W] fp32 in [-1, 1]
+    labels: np.ndarray,  # [B] int
+    patch: int,
+    model_dim: int,
+    rng: np.random.Generator,
+    cfg_drop_prob: float = 0.0,
+    null_class: int | None = None,
+    hflip: bool = False,
+):
+    """Returns (input_tokens, cnoise_feats, labels_onehot, target_tokens)."""
+    net_in, feats, onehot, target = make_edm_batch_image(
+        images, labels, model_dim, rng, cfg_drop_prob=cfg_drop_prob, null_class=null_class, hflip=hflip
+    )
+    return patchify(net_in, patch), feats, onehot, patchify(target, patch)
+
+
+def nchw_to_nhwc_tokens(x: np.ndarray) -> np.ndarray:
+    """[B,C,H,W] -> [B,1,H*W,C] channels-last tokens (device UNet activation form)."""
+    b, c, h, w = x.shape
+    return np.ascontiguousarray(x.transpose(0, 2, 3, 1)).reshape(b, 1, h * w, c)
+
+
+def nhwc_tokens_to_nchw(t: np.ndarray, h: int, w: int) -> np.ndarray:
+    """[B,1,H*W,C] -> [B,C,H,W]."""
+    b, _, _, c = t.shape
+    return np.ascontiguousarray(t.reshape(b, h, w, c).transpose(0, 3, 1, 2))
+
+
+# ---------------------------------------------------------------------------
+# SongUNet block plan (shared by reference_unet.py and edm_unet.py)
+# ---------------------------------------------------------------------------
+
+
+class BlockSpec:
+    """One residual block of the DDPM++ SongUNet.
+
+    resample: None | 'down' (avgpool 2x2 BEFORE the block) | 'up'
+              (nearest-2x upsample BEFORE the block).
+    skip_in:  channels concatenated from the encoder skip stack before the
+              block (0 = no skip consumed). Decoder only.
+    res:      spatial resolution the block runs at (after any resample).
+    """
+
+    __slots__ = ("cin", "cout", "res", "attn", "resample", "skip_in")
+
+    def __init__(self, cin, cout, res, attn, resample=None, skip_in=0):
+        self.cin, self.cout, self.res = cin, cout, res
+        self.attn, self.resample, self.skip_in = attn, resample, skip_in
+
+    def __repr__(self):
+        return (
+            f"BlockSpec(cin={self.cin}, cout={self.cout}, res={self.res}, "
+            f"attn={self.attn}, resample={self.resample}, skip_in={self.skip_in})"
+        )
+
+
+def build_unet_plan(
+    img_resolution: int = 32,
+    model_channels: int = 128,
+    channel_mult: tuple = (2, 2, 2),
+    num_blocks: int = 4,
+    attn_resolutions: tuple = (16,),
+):
+    """Encoder/decoder block plans for the DDPM++ SongUNet (EDM CIFAR-10 config).
+
+    Mirrors EDM's SongUNet layout with encoder_type/decoder_type='standard':
+    conv_in, then per level: [down-block (levels>0)] + num_blocks blocks;
+    middle pair (attn + plain) at the lowest resolution; decoder per level:
+    [up-block (levels < deepest)] + (num_blocks+1) skip-concat blocks.
+    The skip stack holds conv_in's output plus every encoder block output.
+
+    Returns (enc_specs, dec_specs). conv_in / out_conv are not in the plan.
+    """
+    enc, skips = [], [model_channels]  # conv_in output is the first skip
+    cout = model_channels
+    for level, mult in enumerate(channel_mult):
+        res = img_resolution >> level
+        if level > 0:
+            enc.append(BlockSpec(cout, cout, res, attn=False, resample="down"))
+            skips.append(cout)
+        for _ in range(num_blocks):
+            cin, cout = cout, model_channels * mult
+            enc.append(BlockSpec(cin, cout, res, attn=res in attn_resolutions))
+            skips.append(cout)
+
+    dec = []
+    for level in reversed(range(len(channel_mult))):
+        res = img_resolution >> level
+        if level == len(channel_mult) - 1:
+            dec.append(BlockSpec(cout, cout, res, attn=True))  # middle 'in0'
+            dec.append(BlockSpec(cout, cout, res, attn=False))  # middle 'in1'
+        else:
+            dec.append(BlockSpec(cout, cout, res, attn=False, resample="up"))
+        for _ in range(num_blocks + 1):
+            s = skips.pop()
+            cin, cout = cout + s, model_channels * channel_mult[level]
+            dec.append(BlockSpec(cin, cout, res, attn=res in attn_resolutions, skip_in=s))
+    assert not skips, f"unconsumed encoder skips: {skips}"
+    return enc, dec
 
 
 def sigma_schedule(steps: int = 18) -> np.ndarray:

--- a/tt-train/sources/examples/dit/edm_ops.py
+++ b/tt-train/sources/examples/dit/edm_ops.py
@@ -71,6 +71,12 @@ NATIVE_CONV = os.environ.get("EDM_NATIVE_CONV", "0") == "1"
 # recomputes (Phase-1 behavior).
 SAVE_PATCHES = os.environ.get("EDM_SAVE_PATCHES", "auto")
 
+# GroupNorm implementation: "1" (default) computes GN directly on the
+# [B,1,HW,C] tokens with row-broadcast ops + a cached group-pooling matmul —
+# no NHWC<->NCHW permutes, no moreh kernels; "0" falls back to the moreh
+# NCHW wrapper (GroupNormMoreh).
+NHWC_GN = os.environ.get("EDM_NHWC_GN", "1") == "1"
+
 # Coarse host-side wall-time buckets around device call groups (enqueue +
 # sync boundaries — good enough to RANK hot spots, not to measure kernels).
 # Enable with EDM_PROFILE_CONV=1 (or set edm_ops.PROFILE_CONV = True).
@@ -149,6 +155,51 @@ def _col2im_sum_matrix(c):
         t = ttml.autograd.Tensor.from_numpy(s).get_value()
         _COL2IM_SUM[c] = t
     return t
+
+
+def _flip_transpose_weight(wv, c, cout):
+    """[1,1,9Cin,Cout] ROW_ORDER -> [1,1,9Cout,Cin]: the weight of the
+    transposed conv computing dInput = conv_s1p1(dOut, flipT(W)).
+
+    Tap flip (kh,kw)->(2-kh,2-kw) is exactly REVERSED block order for a 3x3
+    kernel (k' = 8-k), and each block is channel-transposed [Cin,Cout] ->
+    [Cout,Cin]. Operates on the ~MB-scale weight, all tile-aligned
+    (guarded by Cin%32==0 and Cout%32==0 at the call site).
+    """
+    parts = []
+    for kp in range(9):
+        k = 8 - kp
+        blk = ttnn.slice(wv, [0, 0, k * c, 0], [1, 1, (k + 1) * c, cout])
+        parts.append(ttnn.transpose(blk, -2, -1))
+    return ttnn.concat(parts, dim=2)
+
+
+# Cached [1,1,C,C] group-pooling matrices for NHWC GroupNorm: block-diagonal
+# with 1/(HW*Cg) inside each group's CgxCg block, so
+#   sum_over_rows(x) @ P  ==  per-group mean broadcast to every member
+# channel. For all UNet configs HW, Cg are powers of two, so the scale is
+# exact in bf16. Keyed by (C, groups, HW); P is symmetric (self-transpose),
+# so forward and backward reuse the same tensor.
+_GN_POOL: dict = {}
+
+
+def _gn_pool_matrix(c, groups, hw):
+    key = (c, groups, hw)
+    t = _GN_POOL.get(key)
+    if t is None:
+        cg = c // groups
+        p = np.kron(np.eye(groups, dtype=np.float32), np.full((cg, cg), 1.0 / (hw * cg), dtype=np.float32))
+        t = ttml.autograd.Tensor.from_numpy(p.reshape(1, 1, c, c)).get_value()
+        _GN_POOL[key] = t
+    return t
+
+
+def _sum_over_batch(t, b, c):
+    """[B,1,1,C] -> [1,1,1,C] (param-grad reductions)."""
+    if b == 1:
+        return t
+    r = _tile(ttnn.reshape(_rm(t), (1, 1, b, c)))
+    return ttnn.sum(r, dim=2, keepdim=True)
 
 
 def _im2col(v, b, h, w, c):
@@ -304,10 +355,18 @@ class Conv3x3Im2col(ttml.autograd.Function):
             g = _reshape_rows(grad_output, (1, 1, b * h * w, cout), h * w)
             dw = ttnn.matmul(cols, g, transpose_a=True)  # [1,1,9C,Cout]
             db = ttnn.sum(g, dim=2, keepdim=True)  # [1,1,1,Cout]
-        # dX: col2im of dOut @ W^T. Skipped when the input neither requires
-        # grad nor has upstream graph (e.g. conv_in fed leaf pixels).
+        # dX: skipped when the input neither requires grad nor has upstream
+        # graph (e.g. conv_in fed leaf pixels).
         if not x.get_requires_grad() and x.get_node() is None:
             return None, dw, db
+        # Native dX: dInput = conv_s1p1(dOut, flipT(W)) — one conv2d on the
+        # grad tokens instead of the 170MB col2im canvases. Same guard as the
+        # native forward; composite col2im remains the fallback below.
+        if NATIVE_CONV and c % 32 == 0 and cout % 32 == 0:
+            with _prof("bwd_dx_native"):
+                wflip = _flip_transpose_weight(wv, c, cout)  # [1,1,9Cout,Cin]
+                dx = _conv3x3_native_fwd(grad_output, wflip, b, h, w, cout, c)
+            return dx, dw, db
         with _prof("bwd_col2im"):
             dcols = ttnn.matmul(g, wv, transpose_b=True)  # [1,1,BHW,9C] TILE
             d = ttnn.reshape(_rm(dcols), (b, h, w, 9 * c))
@@ -459,4 +518,62 @@ class GroupNormMoreh(ttml.autograd.Function):
         )
         dx_nhwc = ttnn.permute(_rm(dx_nchw), (0, 2, 3, 1))
         dx = _nhwc_rm_to_tokens(dx_nhwc, b, h, w, c)
+        return dx, dgamma, dbeta
+
+
+class GroupNormNHWC(ttml.autograd.Function):
+    """GroupNorm computed directly on [B,1,HW,C] TILE tokens — no NCHW
+    round-trip, no moreh kernels. Same signature as GroupNormMoreh.
+
+    Group statistics via a cached [1,1,C,C] group-pooling matmul (see
+    _gn_pool_matrix): mean = sum_rows(x) @ P, var = sum_rows((x-mean)^2) @ P
+    (two-pass — numerically safer in bf16 than E[x^2]-mean^2). Everything
+    else is proven row-broadcast binary ops. Backward is the standard GN
+    gradient in the same form:
+        dxhat = dy * gamma
+        dx    = rstd * (dxhat - mean_g(dxhat) - xhat * mean_g(dxhat*xhat))
+        dgamma = sum_{B,HW} dy*xhat,  dbeta = sum_{B,HW} dy
+    with mean_g the same pooling matmul (P is its own transpose).
+    Saves mean/rstd (tiny) and recomputes xhat in backward from the saved
+    input — no extra [B,1,HW,C] tensor kept alive.
+    """
+
+    EPS = 1e-6
+
+    @staticmethod
+    def forward(ctx, x, gamma, beta, num_groups, h, w):
+        v, gv, bv = x.get_value(), gamma.get_value(), beta.get_value()
+        b, c = v.shape[0], v.shape[-1]
+        hw = h * w
+        with _prof("gn_nhwc_fwd"):
+            pool = _gn_pool_matrix(c, num_groups, hw)
+            mean = ttnn.matmul(ttnn.sum(v, dim=2, keepdim=True), pool)  # [B,1,1,C] group means
+            xc = ttnn.subtract(v, mean)
+            var = ttnn.matmul(ttnn.sum(ttnn.multiply(xc, xc), dim=2, keepdim=True), pool)
+            rstd = ttnn.rsqrt(ttnn.add(var, GroupNormNHWC.EPS))
+            xhat = ttnn.multiply(xc, rstd)
+            out = ttnn.add(ttnn.multiply(xhat, gv), bv)
+        ctx.save_for_backward(x, gamma)
+        ctx.mean, ctx.rstd = mean, rstd
+        ctx.dims = (b, hw, c)
+        ctx.num_groups = num_groups
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, gamma = ctx.saved_tensors
+        b, hw, c = ctx.dims
+        with _prof("gn_nhwc_bwd"):
+            v, gv = x.get_value(), gamma.get_value()
+            pool = _gn_pool_matrix(c, ctx.num_groups, hw)
+            xhat = ttnn.multiply(ttnn.subtract(v, ctx.mean), ctx.rstd)  # recompute
+            dy = grad_output
+            dgamma = _sum_over_batch(ttnn.sum(ttnn.multiply(dy, xhat), dim=2, keepdim=True), b, c)
+            dbeta = _sum_over_batch(ttnn.sum(dy, dim=2, keepdim=True), b, c)
+            dxhat = ttnn.multiply(dy, gv)
+            m1 = ttnn.matmul(ttnn.sum(dxhat, dim=2, keepdim=True), pool)
+            m2 = ttnn.matmul(ttnn.sum(ttnn.multiply(dxhat, xhat), dim=2, keepdim=True), pool)
+            dx = ttnn.multiply(
+                ttnn.subtract(ttnn.subtract(dxhat, m1), ttnn.multiply(xhat, m2)), ctx.rstd
+            )
         return dx, dgamma, dbeta

--- a/tt-train/sources/examples/dit/edm_ops.py
+++ b/tt-train/sources/examples/dit/edm_ops.py
@@ -311,7 +311,11 @@ def _conv3x3_native_fwd(v, wv, b, h, w, c, cout):
         device=wv.device(),
         in_channels=c,
         out_channels=cout,
-        batch_size=b,
+        # Data-movement ops (reshape/slice/pad/concat) take GLOBAL logical
+        # shapes on dp-sharded tensors and apply per shard automatically;
+        # conv2d's explicit batch_size is PER-SHARD — the one place the
+        # local/global distinction matters.
+        batch_size=_local_b(b),
         input_height=h,
         input_width=w,
         kernel_size=(3, 3),
@@ -339,7 +343,7 @@ class Conv3x3Im2col(ttml.autograd.Function):
     @staticmethod
     def forward(ctx, x, weight, bias, h, w):
         v, wv, bv = x.get_value(), weight.get_value(), bias.get_value()
-        b = _local_b(v.shape[0])
+        b = v.shape[0]
         c = v.shape[-1]
         cout = wv.shape[-1]
         ctx.save_for_backward(x, weight)
@@ -455,7 +459,7 @@ class AvgPool2x2(ttml.autograd.Function):
     @staticmethod
     def forward(ctx, x, h, w):
         v = x.get_value()
-        b, c = _local_b(v.shape[0]), v.shape[-1]
+        b, c = v.shape[0], v.shape[-1]
         ctx.dims = (b, h, w, c)
         s = _sum_pool2x2_rm(_tokens_to_nhwc_rm(v, b, h, w, c), b, h, w, c)
         return ttnn.multiply(_nhwc_rm_to_tokens(s, b, h // 2, w // 2, c), 0.25)
@@ -479,7 +483,7 @@ class UpsampleNearest2(ttml.autograd.Function):
     @staticmethod
     def forward(ctx, x, h, w):
         v = x.get_value()
-        b, c = _local_b(v.shape[0]), v.shape[-1]
+        b, c = v.shape[0], v.shape[-1]
         ctx.dims = (b, h, w, c)
         up = _nearest_up2_rm(_tokens_to_nhwc_rm(v, b, h, w, c), b, h, w, c)
         return _nhwc_rm_to_tokens(up, b, 2 * h, 2 * w, c)
@@ -505,7 +509,7 @@ class GroupNormMoreh(ttml.autograd.Function):
     @staticmethod
     def forward(ctx, x, gamma, beta, num_groups, h, w):
         v = x.get_value()
-        b, c = _local_b(v.shape[0]), v.shape[-1]
+        b, c = v.shape[0], v.shape[-1]
         nhwc = _tokens_to_nhwc_rm(v, b, h, w, c)
         nchw = _tile(ttnn.permute(nhwc, (0, 3, 1, 2)))  # [B,C,H,W]
         out, mean, rstd = ttnn_moreh.group_norm(
@@ -565,7 +569,7 @@ class GroupNormNHWC(ttml.autograd.Function):
     @staticmethod
     def forward(ctx, x, gamma, beta, num_groups, h, w):
         v, gv, bv = x.get_value(), gamma.get_value(), beta.get_value()
-        b, c = _local_b(v.shape[0]), v.shape[-1]
+        b, c = v.shape[0], v.shape[-1]
         hw = h * w
         with _prof("gn_nhwc_fwd"):
             pool = _gn_pool_matrix(c, num_groups, hw)

--- a/tt-train/sources/examples/dit/edm_ops.py
+++ b/tt-train/sources/examples/dit/edm_ops.py
@@ -1,0 +1,269 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""ttml autograd Functions for convolutional (UNet) training — Phase 1.
+
+Everything here is a "pattern 2" ttml.autograd.Function (see
+ttml/autograd/function.py): forward() takes ttml tensors, computes with raw
+ttnn ops on .get_value(), returns raw ttnn tensors (auto-wrapped); backward()
+receives raw ttnn grads and returns one raw ttnn grad per tensor input.
+
+CANONICAL ACTIVATION SHAPE: [B, 1, H*W, C] channels-last tokens, TILE
+layout, bf16. H and W travel alongside as python ints (static per call
+site). This keeps every broadcast (bias add, per-block embedding add) in the
+already-validated [B,1,T,D] (+) [B,1,1,D] row-broadcast form and lets 1x1
+convs / attention reuse plain LinearLayers.
+
+LAYOUT POLICY: pad/slice/concat/permute/pool/upsample run in ROW_MAJOR
+NHWC (TILE front-padding is restricted and the pool/upsample kernels are RM
+NHWC ops); matmul and moreh.group_norm run in TILE. Conversions are explicit
+via _rm/_tile. Phase 1 optimizes for correctness, not layout-churn count.
+
+CONV WEIGHT ROW_ORDER (must match reference_unet.py exactly):
+    3x3 conv weight is a TILE matrix [1, 1, 9*C_in, C_out] with row index
+        r = (kh*3 + kw)*C_in + c_in,   kh, kw in {0,1,2}
+    i.e. flatten order (kh, kw, c_in), kernel window scanned row-major.
+    _im2col concatenates its 9 shifted views in the same (kh, kw) order, so
+    patches @ W_flat == conv2d(x, W_flat.view(3,3,Ci,Co).permute(3,2,0,1),
+    padding=1). Weight-gradient rows land in the same order.
+
+MEMORY POLICY: conv backward recomputes im2col from the saved input rather
+than saving the 9x-wider patch tensor.
+"""
+
+from __future__ import annotations
+
+import ttnn
+
+import ttml
+
+
+def _rm(v):
+    return ttnn.to_layout(v, ttnn.ROW_MAJOR_LAYOUT)
+
+
+def _tile(v):
+    return ttnn.to_layout(v, ttnn.TILE_LAYOUT)
+
+
+def _tokens_to_nhwc_rm(v, b, h, w, c):
+    """[B,1,HW,C] (any layout) -> ROW_MAJOR [B,H,W,C]."""
+    return ttnn.reshape(_rm(v), (b, h, w, c))
+
+
+def _nhwc_rm_to_tokens(v, b, h, w, c):
+    """ROW_MAJOR [B,H,W,C] -> TILE [B,1,HW,C]."""
+    return _tile(ttnn.reshape(v, (b, 1, h * w, c)))
+
+
+def _im2col(v, b, h, w, c):
+    """[B,1,HW,C] -> TILE [1,1,B*H*W, 9C] patches (ROW_ORDER = (kh, kw, c_in))."""
+    x = _tokens_to_nhwc_rm(v, b, h, w, c)
+    p = ttnn.pad(x, [(0, 0), (1, 1), (1, 1), (0, 0)], 0.0)
+    views = []
+    for kh in range(3):
+        for kw in range(3):
+            views.append(ttnn.slice(p, [0, kh, kw, 0], [b, kh + h, kw + w, c]))
+    cols = ttnn.concat(views, dim=-1)  # RM [B,H,W,9C]
+    return _tile(ttnn.reshape(cols, (1, 1, b * h * w, 9 * c)))
+
+
+class Permute(ttml.autograd.Function):
+    """Autograd permute: ttnn.permute fwd, inverse permute bwd."""
+
+    @staticmethod
+    def forward(ctx, x, dims):
+        dims = tuple(dims)
+        ctx.inverse = tuple(sorted(range(len(dims)), key=dims.__getitem__))
+        return ttnn.permute(x.get_value(), dims)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        return ttnn.permute(grad_output, ctx.inverse)
+
+
+class Scale(ttml.autograd.Function):
+    """Multiply by a python scalar (ttml.ops.binary.mul is tensor-tensor only)."""
+
+    @staticmethod
+    def forward(ctx, x, factor):
+        ctx.factor = factor
+        return ttnn.multiply(x.get_value(), factor)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        return ttnn.multiply(grad_output, ctx.factor)
+
+
+class ConcatChannels(ttml.autograd.Function):
+    """Skip concat along the channel (last) dim of [B,1,HW,C] tokens.
+
+    Backward slices the grad back apart. TILE slice/concat require the
+    boundary channel count to be tile-aligned; all UNet channel counts are
+    multiples of 32 wherever concat is used.
+    """
+
+    @staticmethod
+    def forward(ctx, a, b):
+        va, vb = a.get_value(), b.get_value()
+        ctx.ca, ctx.cb = va.shape[-1], vb.shape[-1]
+        return ttnn.concat([va, vb], dim=-1)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        shape = list(grad_output.shape)
+        begins = [0] * len(shape)
+        ends_a = shape[:-1] + [ctx.ca]
+        begins_b = begins[:-1] + [ctx.ca]
+        ends_b = shape[:-1] + [ctx.ca + ctx.cb]
+        da = ttnn.slice(grad_output, begins, ends_a)
+        db = ttnn.slice(grad_output, begins_b, ends_b)
+        return da, db
+
+
+class Conv3x3Im2col(ttml.autograd.Function):
+    """3x3 same-pad conv as im2col + matmul; weight flat [1,1,9Cin,Cout].
+
+    apply(x [B,1,HW,Cin], weight, bias [1,1,1,Cout], H, W) -> [B,1,HW,Cout].
+    Backward: dW = im2col(x)^T @ dOut (im2col recomputed), db = sum_BHW dOut,
+    dX = col2im(dOut @ W^T) via 9 pad-shift adds.
+    """
+
+    @staticmethod
+    def forward(ctx, x, weight, bias, h, w):
+        v, wv, bv = x.get_value(), weight.get_value(), bias.get_value()
+        b = v.shape[0]
+        c = v.shape[-1]
+        cout = wv.shape[-1]
+        cols = _im2col(v, b, h, w, c)  # [1,1,BHW,9C]
+        out = ttnn.matmul(cols, wv)  # [1,1,BHW,Cout]
+        out = ttnn.add(out, bv)
+        ctx.save_for_backward(x, weight)
+        ctx.dims = (b, h, w, c, cout)
+        return _tile(ttnn.reshape(_rm(out), (b, 1, h * w, cout)))
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, weight = ctx.saved_tensors
+        b, h, w, c, cout = ctx.dims
+        wv = weight.get_value()
+        g = _tile(ttnn.reshape(_rm(grad_output), (1, 1, b * h * w, cout)))
+        # dW / db
+        cols = _im2col(x.get_value(), b, h, w, c)  # recompute (memory policy)
+        dw = ttnn.matmul(cols, g, transpose_a=True)  # [1,1,9C,Cout]
+        db = ttnn.sum(g, dim=2, keepdim=True)  # [1,1,1,Cout]
+        # dX: col2im of dOut @ W^T
+        dcols = ttnn.matmul(g, wv, transpose_b=True)  # [1,1,BHW,9C]
+        d = ttnn.reshape(_rm(dcols), (b, h, w, 9 * c))
+        acc = None
+        for kh in range(3):
+            for kw in range(3):
+                k = kh * 3 + kw
+                part = ttnn.slice(d, [0, 0, 0, k * c], [b, h, w, (k + 1) * c])
+                shifted = ttnn.pad(part, [(0, 0), (kh, 2 - kh), (kw, 2 - kw), (0, 0)], 0.0)
+                shifted = _tile(shifted)  # elementwise add on TILE
+                acc = shifted if acc is None else ttnn.add(acc, shifted)
+        dp = _rm(acc)  # [B,H+2,W+2,C]
+        dx = ttnn.slice(dp, [0, 1, 1, 0], [b, h + 1, w + 1, c])
+        dx = _nhwc_rm_to_tokens(dx, b, h, w, c)
+        return dx, dw, db
+
+
+class AvgPool2x2(ttml.autograd.Function):
+    """2x2/stride-2 average pool on [B,1,HW,C] tokens.
+
+    Backward is the exact adjoint: nearest-2x upsample of dOut times 0.25.
+    """
+
+    @staticmethod
+    def forward(ctx, x, h, w):
+        v = x.get_value()
+        b, c = v.shape[0], v.shape[-1]
+        ctx.dims = (b, h, w, c)
+        r = ttnn.reshape(_rm(v), (1, 1, b * h * w, c))
+        out = ttnn.avg_pool2d(r, b, h, w, c, (2, 2), (2, 2), (0, 0))  # RM [1,1,B*(H/2)*(W/2),C]
+        return _tile(ttnn.reshape(out, (b, 1, (h // 2) * (w // 2), c)))
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        b, h, w, c = ctx.dims
+        g = _tokens_to_nhwc_rm(grad_output, b, h // 2, w // 2, c)
+        up = ttnn.upsample(g, 2)  # RM [B,H,W,C]
+        return ttnn.multiply(_nhwc_rm_to_tokens(up, b, h, w, c), 0.25)
+
+
+class UpsampleNearest2(ttml.autograd.Function):
+    """Nearest-neighbor 2x upsample on [B,1,HW,C] tokens.
+
+    Backward is the exact adjoint: 2x2 SUM pool (avg_pool2d with
+    divisor_override=1) of dOut. AvgPool2x2/UpsampleNearest2 form an
+    adjoint pair; the device gate checks <u, up(x)> == <down(u), x>.
+    """
+
+    @staticmethod
+    def forward(ctx, x, h, w):
+        v = x.get_value()
+        b, c = v.shape[0], v.shape[-1]
+        ctx.dims = (b, h, w, c)
+        r = _tokens_to_nhwc_rm(v, b, h, w, c)
+        up = ttnn.upsample(r, 2)  # RM [B,2H,2W,C]
+        return _nhwc_rm_to_tokens(up, b, 2 * h, 2 * w, c)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        b, h, w, c = ctx.dims
+        g = ttnn.reshape(_rm(grad_output), (1, 1, b * 2 * h * 2 * w, c))
+        down = ttnn.avg_pool2d(g, b, 2 * h, 2 * w, c, (2, 2), (2, 2), (0, 0), divisor_override=1)
+        return _tile(ttnn.reshape(down, (b, 1, h * w, c)))
+
+
+class GroupNormMoreh(ttml.autograd.Function):
+    """GroupNorm on [B,1,HW,C] tokens via ttnn.moreh.group_norm (NCHW TILE).
+
+    apply(x, gamma [1,1,1,C], beta [1,1,1,C], num_groups, H, W).
+    Wraps the moreh op in NHWC<->NCHW permutes (done in ROW_MAJOR — plain
+    data movement); saves the NCHW input plus (mean, rstd) for backward.
+    """
+
+    EPS = 1e-6
+
+    @staticmethod
+    def forward(ctx, x, gamma, beta, num_groups, h, w):
+        v = x.get_value()
+        b, c = v.shape[0], v.shape[-1]
+        nhwc = _tokens_to_nhwc_rm(v, b, h, w, c)
+        nchw = _tile(ttnn.permute(nhwc, (0, 3, 1, 2)))  # [B,C,H,W]
+        out, mean, rstd = ttnn.moreh.group_norm(
+            nchw,
+            num_groups,
+            eps=GroupNormMoreh.EPS,
+            gamma=gamma.get_value(),
+            beta=beta.get_value(),
+            are_required_outputs=[True, True, True],
+        )
+        ctx.save_for_backward(gamma)
+        ctx.nchw, ctx.mean, ctx.rstd = nchw, mean, rstd
+        ctx.dims = (b, h, w, c)
+        ctx.num_groups = num_groups
+        out_nhwc = ttnn.permute(_rm(out), (0, 2, 3, 1))
+        return _nhwc_rm_to_tokens(out_nhwc, b, h, w, c)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (gamma,) = ctx.saved_tensors
+        b, h, w, c = ctx.dims
+        g_nhwc = _tokens_to_nhwc_rm(grad_output, b, h, w, c)
+        g_nchw = _tile(ttnn.permute(g_nhwc, (0, 3, 1, 2)))
+        dx_nchw, dgamma, dbeta = ttnn.moreh.group_norm_backward(
+            g_nchw,
+            ctx.nchw,
+            ctx.mean,
+            ctx.rstd,
+            ctx.num_groups,
+            are_required_outputs=[True, True, True],
+            gamma=gamma.get_value(),
+        )
+        dx_nhwc = ttnn.permute(_rm(dx_nchw), (0, 2, 3, 1))
+        dx = _nhwc_rm_to_tokens(dx_nhwc, b, h, w, c)
+        return dx, dgamma, dbeta

--- a/tt-train/sources/examples/dit/edm_ops.py
+++ b/tt-train/sources/examples/dit/edm_ops.py
@@ -37,10 +37,25 @@ than saving the 9x-wider patch tensor.
 
 from __future__ import annotations
 
+import os
+
 import ttnn
 from ttnn.operations import moreh as ttnn_moreh  # not attached to the ttnn namespace in all builds
 
 import ttml
+
+# Phase 2: route the conv FORWARD through native ttnn.conv2d (backward stays
+# the im2col composite). Our flat [1,1,9Cin,Cout] TILE bf16 param passes
+# conv2d's is_valid_device_conv_weights shape sniff (rank-4 [1,1,*,>=Cout],
+# TILE, dtype match), so ALL host-side weight prep is skipped — the kernel
+# consumes the param in place. Ordering evidence (prepare_conv2d_weights.cpp):
+# every relevant converter emits row = (kh*KW + kw)*Cin + cin == our
+# ROW_ORDER; the height-sharded "special padding" variant is byte-identical
+# iff block_height_padding == 0, which holds when Cin*KW is tile-aligned.
+# Hence the native path is only taken for Cin % 32 == 0 (conv_in with Cin=3
+# keeps the composite), and test_edm_primitives.py carries an empirical
+# probe + parity gate that decides the question on hardware.
+NATIVE_CONV = os.environ.get("EDM_NATIVE_CONV", "0") == "1"
 
 
 def _rm(v):
@@ -126,12 +141,50 @@ class ConcatChannels(ttml.autograd.Function):
         return da, db
 
 
+def _conv3x3_native_fwd(v, wv, b, h, w, c, cout):
+    """Native ttnn.conv2d forward consuming the flat ROW_ORDER weight in place.
+
+    v [B,1,HW,C] tokens -> [B,1,HW,Cout] tokens. No bias here (the caller
+    adds our [1,1,1,Cout] param with the proven row-broadcast add). The
+    weight must never be re-prepped: if the 'Device weights not properly
+    prepared' warning fires on this call, the design failed — the parity
+    gate would also catch that as a throughput/ordering anomaly.
+    """
+    inp = ttnn.reshape(_rm(v), (1, 1, b * h * w, c))
+    # Pin HEIGHT_SHARDED: the expected prepared-weight layout depends on the
+    # shard scheme (block-sharded splits Cin across cores — incompatible with
+    # a shared flat param). Height-sharded with tile-aligned Cin*KW expects
+    # exactly the plain [9Cin,Cout] matrix in our ROW_ORDER, uniformly across
+    # every conv shape in the model — no silent per-shape layout flips.
+    conv_config = ttnn.Conv2dConfig(shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED)
+    out = ttnn.conv2d(
+        input_tensor=inp,
+        weight_tensor=wv,
+        device=wv.device(),
+        in_channels=c,
+        out_channels=cout,
+        batch_size=b,
+        input_height=h,
+        input_width=w,
+        kernel_size=(3, 3),
+        stride=(1, 1),
+        padding=(1, 1),
+        conv_config=conv_config,
+    )
+    if out.memory_config().is_sharded():
+        out = ttnn.to_memory_config(out, ttnn.DRAM_MEMORY_CONFIG)
+    return _tile(ttnn.reshape(_rm(out), (b, 1, h * w, cout)))
+
+
 class Conv3x3Im2col(ttml.autograd.Function):
-    """3x3 same-pad conv as im2col + matmul; weight flat [1,1,9Cin,Cout].
+    """3x3 same-pad conv; weight flat [1,1,9Cin,Cout] (ROW_ORDER).
 
     apply(x [B,1,HW,Cin], weight, bias [1,1,1,Cout], H, W) -> [B,1,HW,Cout].
-    Backward: dW = im2col(x)^T @ dOut (im2col recomputed), db = sum_BHW dOut,
-    dX = col2im(dOut @ W^T) via 9 pad-shift adds.
+    Forward: im2col + matmul composite, or native ttnn.conv2d when
+    EDM_NATIVE_CONV=1 and Cin/Cout are tile-aligned (see NATIVE_CONV note).
+    Backward (always im2col composite): dW = im2col(x)^T @ dOut (im2col
+    recomputed), db = sum_BHW dOut, dX = col2im(dOut @ W^T) via 9 pad-shift
+    adds.
     """
 
     @staticmethod
@@ -140,11 +193,14 @@ class Conv3x3Im2col(ttml.autograd.Function):
         b = v.shape[0]
         c = v.shape[-1]
         cout = wv.shape[-1]
+        ctx.save_for_backward(x, weight)
+        ctx.dims = (b, h, w, c, cout)
+        if NATIVE_CONV and c % 32 == 0 and cout % 32 == 0:
+            out = _conv3x3_native_fwd(v, wv, b, h, w, c, cout)
+            return ttnn.add(out, bv)  # [B,1,HW,Cout] + [1,1,1,Cout]
         cols = _im2col(v, b, h, w, c)  # [1,1,BHW,9C]
         out = ttnn.matmul(cols, wv)  # [1,1,BHW,Cout]
         out = ttnn.add(out, bv)
-        ctx.save_for_backward(x, weight)
-        ctx.dims = (b, h, w, c, cout)
         return _tile(ttnn.reshape(_rm(out), (b, 1, h * w, cout)))
 
     @staticmethod

--- a/tt-train/sources/examples/dit/edm_ops.py
+++ b/tt-train/sources/examples/dit/edm_ops.py
@@ -54,9 +54,13 @@ _DP_SIZE_CACHE = None
 
 
 def _dp_size() -> int:
-    """dp-axis size of the open mesh (cached). Activations sharded over dp
-    report their GLOBAL batch in .shape; ops taking explicit scalar dims need
-    the per-shard batch, so every shape-derived b goes through _local_b."""
+    """dp-axis size of the open mesh (cached; mesh must be open before the
+    first forward). Activations sharded over dp report their GLOBAL batch in
+    .shape; ops taking explicit scalar dims / shape targets need the
+    per-shard batch, so every shape-derived b goes through _local_b.
+    Weights/params are replicated across the mesh — never divide those.
+    Per-chip batch must be >= 1 (tile alignment is carried by HW, so b%32
+    is NOT required)."""
     global _DP_SIZE_CACHE
     if _DP_SIZE_CACHE is None:
         m = ttml.maybe_mesh()
@@ -127,35 +131,6 @@ def prof_report(divisor: float = 1.0, header: str = "") -> None:
     for k, v in sorted(rows, key=lambda kv: -kv[1]):
         n = PROF.get(k + ".n", 0)
         print(f"     conv-prof {k:<22s} {v / divisor * 1000:8.1f} ms/step  ({n} calls)", flush=True)
-
-
-# ---------------------------------------------------------------------------
-# DDP: mesh-sharded (dp) activation tensors report the GLOBAL logical shape,
-# but every explicit scalar dim / shape target we hand to ttnn (conv2d
-# batch_size, [1,1,B*HW,C] reshapes, im2col/col2im canvas shapes, batch-sum
-# reshapes) must describe the PER-SHARD tensor. Everywhere batch is derived
-# from an activation's dim 0 it goes through _local_b. Weights/params are
-# replicated across the mesh — never divide those. Per-chip batch must be
-# >= 1 (and ideally tile-friendly, e.g. a multiple of 32 is NOT required —
-# HW carries the tile alignment).
-# ---------------------------------------------------------------------------
-
-_DP_SIZE = None
-
-
-def _dp_size() -> int:
-    """dp-axis size of the open mesh (1 if no mesh / no 'dp' axis). Cached on
-    first use — the mesh must be open before the first forward pass."""
-    global _DP_SIZE
-    if _DP_SIZE is None:
-        m = ttml.maybe_mesh()
-        _DP_SIZE = m.axis_size("dp") if (m is not None and m.has_axis("dp")) else 1
-    return _DP_SIZE
-
-
-def _local_b(shape0: int) -> int:
-    """Per-shard batch from a (possibly dp-sharded) activation's global dim 0."""
-    return shape0 // _dp_size()
 
 
 def _rm(v):

--- a/tt-train/sources/examples/dit/edm_ops.py
+++ b/tt-train/sources/examples/dit/edm_ops.py
@@ -15,10 +15,13 @@ site). This keeps every broadcast (bias add, per-block embedding add) in the
 already-validated [B,1,T,D] (+) [B,1,1,D] row-broadcast form and lets 1x1
 convs / attention reuse plain LinearLayers.
 
-LAYOUT POLICY: pad/slice/concat/permute/pool/upsample run in ROW_MAJOR
-NHWC (TILE front-padding is restricted and the pool/upsample kernels are RM
-NHWC ops); matmul and moreh.group_norm run in TILE. Conversions are explicit
-via _rm/_tile. Phase 1 optimizes for correctness, not layout-churn count.
+LAYOUT POLICY: pad/slice/concat/permute and the pool/upsample composites
+run in ROW_MAJOR NHWC (TILE front-padding is restricted); matmul, elementwise
+adds, and moreh group_norm run in TILE. Conversions are explicit via
+_rm/_tile. Phase 1 optimizes for correctness, not layout-churn count.
+Pool/upsample avoid the ttnn sliding-window kernels entirely — see the note
+above _sum_pool2x2_rm (ttml opens the mesh with l1_small_size=0, which the
+halo path needs).
 
 CONV WEIGHT ROW_ORDER (must match reference_unet.py exactly):
     3x3 conv weight is a TILE matrix [1, 1, 9*C_in, C_out] with row index
@@ -35,6 +38,7 @@ than saving the 9x-wider patch tensor.
 from __future__ import annotations
 
 import ttnn
+from ttnn.operations import moreh as ttnn_moreh  # not attached to the ttnn namespace in all builds
 
 import ttml
 
@@ -170,8 +174,43 @@ class Conv3x3Im2col(ttml.autograd.Function):
         return dx, dw, db
 
 
+# NOTE: pool/upsample are deliberately NOT ttnn.avg_pool2d / ttnn.upsample.
+# Those go through the sliding-window halo path, which allocates from the
+# L1_SMALL region — and ttml opens its mesh with DEFAULT_L1_SMALL_SIZE = 0
+# (tt-train/sources/ttml/core/mesh_device.cpp), so they die with an
+# out-of-memory TT_FATAL in bank_manager.cpp. For fixed 2x2/stride-2 kernels
+# the same math is a handful of RM reshape/slice/concat + TILE adds — all
+# primitives already exercised by the conv im2col/col2im paths.
+
+
+def _sum_pool2x2_rm(v_rm, b, h, w, c):
+    """RM [B,H,W,C] -> RM [B,H/2,W/2,C], each output = SUM of its 2x2 window.
+
+    Pure data movement + adds, no halo: pair adjacent W pixels via a
+    [B,H,W/2,2C] view (last-dim slices = even/odd columns), then pair
+    adjacent rows via a [B,H/2,W,C] view (dim-2 slices = even/odd rows).
+    """
+    r = ttnn.reshape(v_rm, (b, h, w // 2, 2 * c))
+    even_w = ttnn.slice(r, [0, 0, 0, 0], [b, h, w // 2, c])
+    odd_w = ttnn.slice(r, [0, 0, 0, c], [b, h, w // 2, 2 * c])
+    s = _rm(ttnn.add(_tile(even_w), _tile(odd_w)))  # [B,H,W/2,C]
+    s = ttnn.reshape(s, (b, h // 2, w, c))  # rows (2i, 2i+1) side by side in dim 2
+    even_h = ttnn.slice(s, [0, 0, 0, 0], [b, h // 2, w // 2, c])
+    odd_h = ttnn.slice(s, [0, 0, w // 2, 0], [b, h // 2, w, c])
+    return _rm(ttnn.add(_tile(even_h), _tile(odd_h)))  # [B,H/2,W/2,C]
+
+
+def _nearest_up2_rm(v_rm, b, h, w, c):
+    """RM [B,H,W,C] -> RM [B,2H,2W,C] nearest-neighbor: concat-duplicate each
+    pixel along W (channel-concat + reshape), then each row along H."""
+    r = ttnn.concat([v_rm, v_rm], dim=-1)  # [B,H,W,2C]: pixel duplicated adjacently
+    r = ttnn.reshape(r, (b, h, 1, 2 * w * c))
+    r = ttnn.concat([r, r], dim=-1)  # [B,H,1,4WC]: row duplicated adjacently
+    return ttnn.reshape(r, (b, 2 * h, 2 * w, c))
+
+
 class AvgPool2x2(ttml.autograd.Function):
-    """2x2/stride-2 average pool on [B,1,HW,C] tokens.
+    """2x2/stride-2 average pool on [B,1,HW,C] tokens (halo-free composite).
 
     Backward is the exact adjoint: nearest-2x upsample of dOut times 0.25.
     """
@@ -181,24 +220,23 @@ class AvgPool2x2(ttml.autograd.Function):
         v = x.get_value()
         b, c = v.shape[0], v.shape[-1]
         ctx.dims = (b, h, w, c)
-        r = ttnn.reshape(_rm(v), (1, 1, b * h * w, c))
-        out = ttnn.avg_pool2d(r, b, h, w, c, (2, 2), (2, 2), (0, 0))  # RM [1,1,B*(H/2)*(W/2),C]
-        return _tile(ttnn.reshape(out, (b, 1, (h // 2) * (w // 2), c)))
+        s = _sum_pool2x2_rm(_tokens_to_nhwc_rm(v, b, h, w, c), b, h, w, c)
+        return ttnn.multiply(_nhwc_rm_to_tokens(s, b, h // 2, w // 2, c), 0.25)
 
     @staticmethod
     def backward(ctx, grad_output):
         b, h, w, c = ctx.dims
         g = _tokens_to_nhwc_rm(grad_output, b, h // 2, w // 2, c)
-        up = ttnn.upsample(g, 2)  # RM [B,H,W,C]
+        up = _nearest_up2_rm(g, b, h // 2, w // 2, c)  # RM [B,H,W,C]
         return ttnn.multiply(_nhwc_rm_to_tokens(up, b, h, w, c), 0.25)
 
 
 class UpsampleNearest2(ttml.autograd.Function):
-    """Nearest-neighbor 2x upsample on [B,1,HW,C] tokens.
+    """Nearest-neighbor 2x upsample on [B,1,HW,C] tokens (halo-free composite).
 
-    Backward is the exact adjoint: 2x2 SUM pool (avg_pool2d with
-    divisor_override=1) of dOut. AvgPool2x2/UpsampleNearest2 form an
-    adjoint pair; the device gate checks <u, up(x)> == <down(u), x>.
+    Backward is the exact adjoint: 2x2 SUM pool of dOut. AvgPool2x2 and
+    UpsampleNearest2 form an adjoint pair; the device gate checks both
+    directions numerically.
     """
 
     @staticmethod
@@ -206,20 +244,19 @@ class UpsampleNearest2(ttml.autograd.Function):
         v = x.get_value()
         b, c = v.shape[0], v.shape[-1]
         ctx.dims = (b, h, w, c)
-        r = _tokens_to_nhwc_rm(v, b, h, w, c)
-        up = ttnn.upsample(r, 2)  # RM [B,2H,2W,C]
+        up = _nearest_up2_rm(_tokens_to_nhwc_rm(v, b, h, w, c), b, h, w, c)
         return _nhwc_rm_to_tokens(up, b, 2 * h, 2 * w, c)
 
     @staticmethod
     def backward(ctx, grad_output):
         b, h, w, c = ctx.dims
-        g = ttnn.reshape(_rm(grad_output), (1, 1, b * 2 * h * 2 * w, c))
-        down = ttnn.avg_pool2d(g, b, 2 * h, 2 * w, c, (2, 2), (2, 2), (0, 0), divisor_override=1)
-        return _tile(ttnn.reshape(down, (b, 1, h * w, c)))
+        g = _tokens_to_nhwc_rm(grad_output, b, 2 * h, 2 * w, c)
+        down = _sum_pool2x2_rm(g, b, 2 * h, 2 * w, c)  # RM [B,H,W,C]
+        return _nhwc_rm_to_tokens(down, b, h, w, c)
 
 
 class GroupNormMoreh(ttml.autograd.Function):
-    """GroupNorm on [B,1,HW,C] tokens via ttnn.moreh.group_norm (NCHW TILE).
+    """GroupNorm on [B,1,HW,C] tokens via the moreh group_norm kernels (NCHW TILE).
 
     apply(x, gamma [1,1,1,C], beta [1,1,1,C], num_groups, H, W).
     Wraps the moreh op in NHWC<->NCHW permutes (done in ROW_MAJOR — plain
@@ -234,7 +271,7 @@ class GroupNormMoreh(ttml.autograd.Function):
         b, c = v.shape[0], v.shape[-1]
         nhwc = _tokens_to_nhwc_rm(v, b, h, w, c)
         nchw = _tile(ttnn.permute(nhwc, (0, 3, 1, 2)))  # [B,C,H,W]
-        out, mean, rstd = ttnn.moreh.group_norm(
+        out, mean, rstd = ttnn_moreh.group_norm(
             nchw,
             num_groups,
             eps=GroupNormMoreh.EPS,
@@ -255,7 +292,7 @@ class GroupNormMoreh(ttml.autograd.Function):
         b, h, w, c = ctx.dims
         g_nhwc = _tokens_to_nhwc_rm(grad_output, b, h, w, c)
         g_nchw = _tile(ttnn.permute(g_nhwc, (0, 3, 1, 2)))
-        dx_nchw, dgamma, dbeta = ttnn.moreh.group_norm_backward(
+        dx_nchw, dgamma, dbeta = ttnn_moreh.group_norm_backward(
             g_nchw,
             ctx.nchw,
             ctx.mean,

--- a/tt-train/sources/examples/dit/edm_ops.py
+++ b/tt-train/sources/examples/dit/edm_ops.py
@@ -31,14 +31,20 @@ CONV WEIGHT ROW_ORDER (must match reference_unet.py exactly):
     patches @ W_flat == conv2d(x, W_flat.view(3,3,Ci,Co).permute(3,2,0,1),
     padding=1). Weight-gradient rows land in the same order.
 
-MEMORY POLICY: conv backward recomputes im2col from the saved input rather
-than saving the 9x-wider patch tensor.
+MEMORY POLICY: conv backward needs the im2col patch tensor for dW. By
+default (EDM_SAVE_PATCHES=auto) it is saved from forward when forward
+already computed it (im2col mode) and recomputed in native-conv mode;
+"1" always saves (native fwd computes it just for backward), "0" always
+recomputes (lowest memory, Phase-1 behavior).
 """
 
 from __future__ import annotations
 
 import os
+import time
+from contextlib import contextmanager
 
+import numpy as np
 import ttnn
 from ttnn.operations import moreh as ttnn_moreh  # not attached to the ttnn namespace in all builds
 
@@ -57,6 +63,47 @@ import ttml
 # probe + parity gate that decides the question on hardware.
 NATIVE_CONV = os.environ.get("EDM_NATIVE_CONV", "0") == "1"
 
+# Conv backward memory/speed policy. "auto" saves the im2col patch tensor in
+# ctx when the forward already computed it (im2col fwd mode) and recomputes
+# it in native-fwd mode; "1" always saves (native fwd additionally computes
+# patches just for backward — trades DRAM for the 9-slice+concat recompute,
+# roughly 9x the activation per conv while the graph is alive); "0" always
+# recomputes (Phase-1 behavior).
+SAVE_PATCHES = os.environ.get("EDM_SAVE_PATCHES", "auto")
+
+# Coarse host-side wall-time buckets around device call groups (enqueue +
+# sync boundaries — good enough to RANK hot spots, not to measure kernels).
+# Enable with EDM_PROFILE_CONV=1 (or set edm_ops.PROFILE_CONV = True).
+PROFILE_CONV = os.environ.get("EDM_PROFILE_CONV", "0") == "1"
+PROF: dict = {}
+
+
+@contextmanager
+def _prof(bucket):
+    if not PROFILE_CONV:
+        yield
+        return
+    t0 = time.perf_counter()
+    try:
+        yield
+    finally:
+        PROF[bucket] = PROF.get(bucket, 0.0) + (time.perf_counter() - t0)
+        PROF[bucket + ".n"] = PROF.get(bucket + ".n", 0) + 1
+
+
+def prof_reset():
+    PROF.clear()
+
+
+def prof_report(divisor: float = 1.0, header: str = "") -> None:
+    """Print accumulated buckets (seconds/divisor as ms), largest first."""
+    rows = [(k, v) for k, v in PROF.items() if not k.endswith(".n")]
+    if header:
+        print(header, flush=True)
+    for k, v in sorted(rows, key=lambda kv: -kv[1]):
+        n = PROF.get(k + ".n", 0)
+        print(f"     conv-prof {k:<22s} {v / divisor * 1000:8.1f} ms/step  ({n} calls)", flush=True)
+
 
 def _rm(v):
     return ttnn.to_layout(v, ttnn.ROW_MAJOR_LAYOUT)
@@ -74,6 +121,34 @@ def _tokens_to_nhwc_rm(v, b, h, w, c):
 def _nhwc_rm_to_tokens(v, b, h, w, c):
     """ROW_MAJOR [B,H,W,C] -> TILE [B,1,HW,C]."""
     return _tile(ttnn.reshape(v, (b, 1, h * w, c)))
+
+
+def _reshape_rows(v, shape, hw):
+    """Merge/split the row dims between [B,1,HW,C] and [1,1,BHW,C].
+
+    When HW is tile-aligned (every UNet resolution: 1024/256/64) and the
+    tensor is TILE, tile rows don't straddle the merged boundary, so a direct
+    TILE reshape works (view / on-device repack) — no RM bounce. Otherwise
+    fall back to the ROW_MAJOR roundtrip.
+    """
+    if hw % 32 == 0 and v.layout == ttnn.TILE_LAYOUT:
+        return ttnn.reshape(v, shape)
+    return _tile(ttnn.reshape(_rm(v), shape))
+
+
+# Cached [1,1,9C,C] TILE matrices of 9 vertically-stacked identities: col2im's
+# sum over the 9 taps becomes ONE matmul (fp32 accumulation) instead of a
+# chain of 8 TILE adds with 9 tilize conversions. Keyed by C; ~1-5 MB each.
+_COL2IM_SUM: dict = {}
+
+
+def _col2im_sum_matrix(c):
+    t = _COL2IM_SUM.get(c)
+    if t is None:
+        s = np.tile(np.eye(c, dtype=np.float32), (9, 1)).reshape(1, 1, 9 * c, c)
+        t = ttml.autograd.Tensor.from_numpy(s).get_value()
+        _COL2IM_SUM[c] = t
+    return t
 
 
 def _im2col(v, b, h, w, c):
@@ -173,7 +248,7 @@ def _conv3x3_native_fwd(v, wv, b, h, w, c, cout):
     )
     if out.memory_config().is_sharded():
         out = ttnn.to_memory_config(out, ttnn.DRAM_MEMORY_CONFIG)
-    return _tile(ttnn.reshape(_rm(out), (b, 1, h * w, cout)))
+    return _reshape_rows(out, (b, 1, h * w, cout), h * w)
 
 
 class Conv3x3Im2col(ttml.autograd.Function):
@@ -182,9 +257,10 @@ class Conv3x3Im2col(ttml.autograd.Function):
     apply(x [B,1,HW,Cin], weight, bias [1,1,1,Cout], H, W) -> [B,1,HW,Cout].
     Forward: im2col + matmul composite, or native ttnn.conv2d when
     EDM_NATIVE_CONV=1 and Cin/Cout are tile-aligned (see NATIVE_CONV note).
-    Backward (always im2col composite): dW = im2col(x)^T @ dOut (im2col
-    recomputed), db = sum_BHW dOut, dX = col2im(dOut @ W^T) via 9 pad-shift
-    adds.
+    Backward (always composite): dW = im2col(x)^T @ dOut (patches saved or
+    recomputed per SAVE_PATCHES), db = sum_BHW dOut, dX = col2im(dOut @ W^T)
+    via 9 pad-shifted channel blocks summed by one stacked-identity matmul.
+    dX is skipped entirely for no-grad leaf inputs (conv_in on pixels).
     """
 
     @staticmethod
@@ -195,38 +271,62 @@ class Conv3x3Im2col(ttml.autograd.Function):
         cout = wv.shape[-1]
         ctx.save_for_backward(x, weight)
         ctx.dims = (b, h, w, c, cout)
-        if NATIVE_CONV and c % 32 == 0 and cout % 32 == 0:
-            out = _conv3x3_native_fwd(v, wv, b, h, w, c, cout)
-            return ttnn.add(out, bv)  # [B,1,HW,Cout] + [1,1,1,Cout]
-        cols = _im2col(v, b, h, w, c)  # [1,1,BHW,9C]
-        out = ttnn.matmul(cols, wv)  # [1,1,BHW,Cout]
-        out = ttnn.add(out, bv)
-        return _tile(ttnn.reshape(_rm(out), (b, 1, h * w, cout)))
+        ctx.cols = None
+        use_native = NATIVE_CONV and c % 32 == 0 and cout % 32 == 0
+        if use_native:
+            with _prof("fwd_native"):
+                out = _conv3x3_native_fwd(v, wv, b, h, w, c, cout)
+                out = ttnn.add(out, bv)  # [B,1,HW,Cout] + [1,1,1,Cout]
+            if SAVE_PATCHES == "1":  # precompute for backward (DRAM for speed)
+                with _prof("fwd_im2col"):
+                    ctx.cols = _im2col(v, b, h, w, c)
+            return out
+        with _prof("fwd_im2col"):
+            cols = _im2col(v, b, h, w, c)  # [1,1,BHW,9C]
+            out = ttnn.matmul(cols, wv)  # [1,1,BHW,Cout]
+            out = ttnn.add(out, bv)
+            out = _reshape_rows(out, (b, 1, h * w, cout), h * w)
+        if SAVE_PATCHES != "0":  # "auto"/"1": already computed, keep for bwd
+            ctx.cols = cols
+        return out
 
     @staticmethod
     def backward(ctx, grad_output):
         x, weight = ctx.saved_tensors
         b, h, w, c, cout = ctx.dims
         wv = weight.get_value()
-        g = _tile(ttnn.reshape(_rm(grad_output), (1, 1, b * h * w, cout)))
         # dW / db
-        cols = _im2col(x.get_value(), b, h, w, c)  # recompute (memory policy)
-        dw = ttnn.matmul(cols, g, transpose_a=True)  # [1,1,9C,Cout]
-        db = ttnn.sum(g, dim=2, keepdim=True)  # [1,1,1,Cout]
-        # dX: col2im of dOut @ W^T
-        dcols = ttnn.matmul(g, wv, transpose_b=True)  # [1,1,BHW,9C]
-        d = ttnn.reshape(_rm(dcols), (b, h, w, 9 * c))
-        acc = None
-        for kh in range(3):
-            for kw in range(3):
-                k = kh * 3 + kw
-                part = ttnn.slice(d, [0, 0, 0, k * c], [b, h, w, (k + 1) * c])
-                shifted = ttnn.pad(part, [(0, 0), (kh, 2 - kh), (kw, 2 - kw), (0, 0)], 0.0)
-                shifted = _tile(shifted)  # elementwise add on TILE
-                acc = shifted if acc is None else ttnn.add(acc, shifted)
-        dp = _rm(acc)  # [B,H+2,W+2,C]
-        dx = ttnn.slice(dp, [0, 1, 1, 0], [b, h + 1, w + 1, c])
-        dx = _nhwc_rm_to_tokens(dx, b, h, w, c)
+        cols = ctx.cols
+        if cols is None:
+            with _prof("bwd_im2col_recompute"):
+                cols = _im2col(x.get_value(), b, h, w, c)
+        with _prof("bwd_matmuls"):
+            g = _reshape_rows(grad_output, (1, 1, b * h * w, cout), h * w)
+            dw = ttnn.matmul(cols, g, transpose_a=True)  # [1,1,9C,Cout]
+            db = ttnn.sum(g, dim=2, keepdim=True)  # [1,1,1,Cout]
+        # dX: col2im of dOut @ W^T. Skipped when the input neither requires
+        # grad nor has upstream graph (e.g. conv_in fed leaf pixels).
+        if not x.get_requires_grad() and x.get_node() is None:
+            return None, dw, db
+        with _prof("bwd_col2im"):
+            dcols = ttnn.matmul(g, wv, transpose_b=True)  # [1,1,BHW,9C] TILE
+            d = ttnn.reshape(_rm(dcols), (b, h, w, 9 * c))
+            # Shift each tap's channel block onto the padded canvas, then sum
+            # all 9 blocks with ONE matmul against the cached stacked-identity
+            # matrix (fp32 accumulation) instead of 9 tilize + 8 add ops.
+            parts = []
+            for kh in range(3):
+                for kw in range(3):
+                    k = kh * 3 + kw
+                    part = ttnn.slice(d, [0, 0, 0, k * c], [b, h, w, (k + 1) * c])
+                    parts.append(ttnn.pad(part, [(0, 0), (kh, 2 - kh), (kw, 2 - kw), (0, 0)], 0.0))
+            p = ttnn.concat(parts, dim=-1)  # RM [B,H+2,W+2,9C]
+            rows = b * (h + 2) * (w + 2)
+            p = _tile(ttnn.reshape(p, (1, 1, rows, 9 * c)))
+            dsum = ttnn.matmul(p, _col2im_sum_matrix(c))  # [1,1,rows,C]
+            dp = ttnn.reshape(_rm(dsum), (b, h + 2, w + 2, c))
+            dx = ttnn.slice(dp, [0, 1, 1, 0], [b, h + 1, w + 1, c])
+            dx = _nhwc_rm_to_tokens(dx, b, h, w, c)
         return dx, dw, db
 
 

--- a/tt-train/sources/examples/dit/edm_ops.py
+++ b/tt-train/sources/examples/dit/edm_ops.py
@@ -50,6 +50,24 @@ from ttnn.operations import moreh as ttnn_moreh  # not attached to the ttnn name
 
 import ttml
 
+_DP_SIZE_CACHE = None
+
+
+def _dp_size() -> int:
+    """dp-axis size of the open mesh (cached). Activations sharded over dp
+    report their GLOBAL batch in .shape; ops taking explicit scalar dims need
+    the per-shard batch, so every shape-derived b goes through _local_b."""
+    global _DP_SIZE_CACHE
+    if _DP_SIZE_CACHE is None:
+        m = ttml.maybe_mesh()
+        _DP_SIZE_CACHE = m.axis_size("dp") if (m is not None and m.has_axis("dp")) else 1
+    return _DP_SIZE_CACHE
+
+
+def _local_b(shape0: int) -> int:
+    return int(shape0) // _dp_size()
+
+
 # Phase 2: route the conv FORWARD through native ttnn.conv2d (backward stays
 # the im2col composite). Our flat [1,1,9Cin,Cout] TILE bf16 param passes
 # conv2d's is_valid_device_conv_weights shape sniff (rank-4 [1,1,*,>=Cout],
@@ -109,6 +127,35 @@ def prof_report(divisor: float = 1.0, header: str = "") -> None:
     for k, v in sorted(rows, key=lambda kv: -kv[1]):
         n = PROF.get(k + ".n", 0)
         print(f"     conv-prof {k:<22s} {v / divisor * 1000:8.1f} ms/step  ({n} calls)", flush=True)
+
+
+# ---------------------------------------------------------------------------
+# DDP: mesh-sharded (dp) activation tensors report the GLOBAL logical shape,
+# but every explicit scalar dim / shape target we hand to ttnn (conv2d
+# batch_size, [1,1,B*HW,C] reshapes, im2col/col2im canvas shapes, batch-sum
+# reshapes) must describe the PER-SHARD tensor. Everywhere batch is derived
+# from an activation's dim 0 it goes through _local_b. Weights/params are
+# replicated across the mesh — never divide those. Per-chip batch must be
+# >= 1 (and ideally tile-friendly, e.g. a multiple of 32 is NOT required —
+# HW carries the tile alignment).
+# ---------------------------------------------------------------------------
+
+_DP_SIZE = None
+
+
+def _dp_size() -> int:
+    """dp-axis size of the open mesh (1 if no mesh / no 'dp' axis). Cached on
+    first use — the mesh must be open before the first forward pass."""
+    global _DP_SIZE
+    if _DP_SIZE is None:
+        m = ttml.maybe_mesh()
+        _DP_SIZE = m.axis_size("dp") if (m is not None and m.has_axis("dp")) else 1
+    return _DP_SIZE
+
+
+def _local_b(shape0: int) -> int:
+    """Per-shard batch from a (possibly dp-sharded) activation's global dim 0."""
+    return shape0 // _dp_size()
 
 
 def _rm(v):
@@ -317,7 +364,7 @@ class Conv3x3Im2col(ttml.autograd.Function):
     @staticmethod
     def forward(ctx, x, weight, bias, h, w):
         v, wv, bv = x.get_value(), weight.get_value(), bias.get_value()
-        b = v.shape[0]
+        b = _local_b(v.shape[0])
         c = v.shape[-1]
         cout = wv.shape[-1]
         ctx.save_for_backward(x, weight)
@@ -433,7 +480,7 @@ class AvgPool2x2(ttml.autograd.Function):
     @staticmethod
     def forward(ctx, x, h, w):
         v = x.get_value()
-        b, c = v.shape[0], v.shape[-1]
+        b, c = _local_b(v.shape[0]), v.shape[-1]
         ctx.dims = (b, h, w, c)
         s = _sum_pool2x2_rm(_tokens_to_nhwc_rm(v, b, h, w, c), b, h, w, c)
         return ttnn.multiply(_nhwc_rm_to_tokens(s, b, h // 2, w // 2, c), 0.25)
@@ -457,7 +504,7 @@ class UpsampleNearest2(ttml.autograd.Function):
     @staticmethod
     def forward(ctx, x, h, w):
         v = x.get_value()
-        b, c = v.shape[0], v.shape[-1]
+        b, c = _local_b(v.shape[0]), v.shape[-1]
         ctx.dims = (b, h, w, c)
         up = _nearest_up2_rm(_tokens_to_nhwc_rm(v, b, h, w, c), b, h, w, c)
         return _nhwc_rm_to_tokens(up, b, 2 * h, 2 * w, c)
@@ -483,7 +530,7 @@ class GroupNormMoreh(ttml.autograd.Function):
     @staticmethod
     def forward(ctx, x, gamma, beta, num_groups, h, w):
         v = x.get_value()
-        b, c = v.shape[0], v.shape[-1]
+        b, c = _local_b(v.shape[0]), v.shape[-1]
         nhwc = _tokens_to_nhwc_rm(v, b, h, w, c)
         nchw = _tile(ttnn.permute(nhwc, (0, 3, 1, 2)))  # [B,C,H,W]
         out, mean, rstd = ttnn_moreh.group_norm(
@@ -543,7 +590,7 @@ class GroupNormNHWC(ttml.autograd.Function):
     @staticmethod
     def forward(ctx, x, gamma, beta, num_groups, h, w):
         v, gv, bv = x.get_value(), gamma.get_value(), beta.get_value()
-        b, c = v.shape[0], v.shape[-1]
+        b, c = _local_b(v.shape[0]), v.shape[-1]
         hw = h * w
         with _prof("gn_nhwc_fwd"):
             pool = _gn_pool_matrix(c, num_groups, hw)

--- a/tt-train/sources/examples/dit/edm_unet.py
+++ b/tt-train/sources/examples/dit/edm_unet.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""SongUNet (DDPM++, EDM CIFAR-10 config) on ttml — mirrors reference_unet.py 1:1.
+
+Every trainable tensor has the same name and (up to the [1,1,...] rank-4
+padding) the same shape as its torch counterpart; see
+reference_unet.ttml_name_map. Architecture spec, documented deviations from
+official EDM, and the conv-weight ROW_ORDER all live in reference_unet.py's
+module docstring — this file only mirrors it.
+
+Activations are [B, 1, H*W, C] channels-last tokens in TILE layout, with the
+current H, W tracked as python ints (see edm_ops.py for the layout policy).
+1x1 convs and the embedding/attention projections are plain LinearLayers;
+3x3 convs are Conv3x3Im2col with the flattened [1,1,9*Cin,Cout] weight.
+
+Host-side input prep (see edm.py):
+    net_in, feats, onehot, target = make_edm_batch_image(...)
+    x_tokens      = nchw_to_nhwc_tokens(net_in)   # [B,1,H*W,3]
+    target_tokens = nchw_to_nhwc_tokens(target)
+    pred = model(from_numpy(x_tokens), from_numpy(feats), from_numpy(onehot))
+    loss = ttml.ops.loss.mse_loss(pred, from_numpy(target_tokens))
+"""
+
+from __future__ import annotations
+
+import math
+
+import ttml
+from ttml.modules import AbstractModuleBase, LinearLayer, Parameter, RunMode
+from ttml.modules.module_base import ModuleList
+
+from edm import build_unet_plan
+from edm_ops import AvgPool2x2, ConcatChannels, Conv3x3Im2col, GroupNormMoreh, Scale, UpsampleNearest2
+
+SKIP_SCALE = math.sqrt(0.5)
+
+
+class Conv3x3(AbstractModuleBase):
+    """Trainable 3x3 conv; weight stored flat [1,1,9*Cin,Cout] (ROW_ORDER =
+    (kh, kw, c_in), see reference_unet.py). Init is kaiming-equivalent on the
+    unflattened shape: uniform(+-1/sqrt(9*Cin)) — element-iid, so flatten
+    order does not affect the distribution."""
+
+    def __init__(self, cin: int, cout: int, zero_init: bool = False) -> None:
+        super().__init__()
+        self.cin, self.cout = cin, cout
+        k = 1.0 / math.sqrt(9 * cin)
+        w_init = ttml.init.zeros() if zero_init else ttml.init.uniform(-k, k)
+        b_init = ttml.init.zeros() if zero_init else ttml.init.uniform(-k, k)
+        self.weight = Parameter(w_init((1, 1, 9 * cin, cout)))
+        self.bias = Parameter(b_init((1, 1, 1, cout)))
+
+    def forward(self, x, h: int, w: int):
+        return Conv3x3Im2col.apply(x, self.weight.tensor, self.bias.tensor, h, w)
+
+
+class GroupNorm(AbstractModuleBase):
+    """GroupNorm(min(32, C//4) groups, eps=1e-6) via the moreh kernel pair."""
+
+    def __init__(self, channels: int) -> None:
+        super().__init__()
+        self.num_groups = min(32, channels // 4)
+        self.gamma = Parameter(ttml.init.ones()((1, 1, 1, channels)))
+        self.beta = Parameter(ttml.init.zeros()((1, 1, 1, channels)))
+
+    def forward(self, x, h: int, w: int):
+        return GroupNormMoreh.apply(x, self.gamma.tensor, self.beta.tensor, self.num_groups, h, w)
+
+
+class UNetAttention(AbstractModuleBase):
+    """Single-head self-attention over the [B,1,HW,C] tokens (EDM style):
+    qkv linear -> composite SDPA (mask=None, true non-causal) -> zero-init proj."""
+
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+        self.qkv = LinearLayer(dim, 3 * dim, True, weight_init=ttml.init.normal(0.0, 0.02), bias_init=ttml.init.zeros())
+        self.proj = LinearLayer(dim, dim, True, weight_init=ttml.init.zeros(), bias_init=ttml.init.zeros())
+
+    def forward(self, x):
+        q, k, v = ttml.ops.multi_head_utils.heads_creation(self.qkv(x), 1)
+        out = ttml.ops.attention.scaled_dot_product_attention_composite(q, k, v, None)
+        return self.proj(ttml.ops.multi_head_utils.heads_fusion(out))
+
+
+class UNetBlock(AbstractModuleBase):
+    """DDPM++ residual block, additive embedding (reference_unet.UNetBlock)."""
+
+    def __init__(self, cin: int, cout: int, emb_dim: int, attn: bool, dropout: float) -> None:
+        super().__init__()
+        self.dropout_p = dropout
+        self.norm0 = GroupNorm(cin)
+        self.conv0 = Conv3x3(cin, cout)
+        self.affine = LinearLayer(emb_dim, cout, True)
+        self.norm1 = GroupNorm(cout)
+        self.conv1 = Conv3x3(cout, cout, zero_init=True)
+        self.skip = LinearLayer(cin, cout, True) if cin != cout else None
+        if attn:
+            self.norm2 = GroupNorm(cout)
+            self.attn = UNetAttention(cout)
+        else:
+            self.norm2 = self.attn = None
+
+    def forward(self, x, emb, h: int, w: int):
+        add, silu = ttml.ops.binary.add, ttml.ops.unary.silu
+        y = self.conv0(silu(self.norm0(x, h, w)), h, w)
+        y = add(y, self.affine(silu(emb)))  # [B,1,HW,C] + [B,1,1,C] row broadcast
+        y = silu(self.norm1(y, h, w))
+        if self.dropout_p > 0.0 and self.get_run_mode() == RunMode.TRAIN:
+            y = ttml.ops.dropout.dropout(y, self.dropout_p)
+        y = self.conv1(y, h, w)
+        sk = self.skip(x) if self.skip is not None else x
+        x = Scale.apply(add(sk, y), SKIP_SCALE)
+        if self.attn is not None:
+            x = Scale.apply(add(x, self.attn(self.norm2(x, h, w))), SKIP_SCALE)
+        return x
+
+
+class SongUNet(AbstractModuleBase):
+    """EDM CIFAR-10 DDPM++ SongUNet. forward(x_tokens, t_feats, labels_onehot):
+
+        x_tokens      [B, 1, H*W, in_channels]   channels-last tokens
+        t_feats       [B, 1, 1, emb_dim]         host timestep_features(cnoise*scale)
+        labels_onehot [B, 1, 1, label_dim+1]
+        returns       [B, 1, H*W, out_channels]
+    """
+
+    def __init__(
+        self,
+        img_resolution: int = 32,
+        in_channels: int = 3,
+        out_channels: int = 3,
+        label_dim: int = 10,
+        model_channels: int = 128,
+        channel_mult: tuple = (2, 2, 2),
+        num_blocks: int = 4,
+        attn_resolutions: tuple = (16,),
+        dropout: float = 0.13,
+    ) -> None:
+        super().__init__()
+        self.img_resolution = img_resolution
+        emb_dim = model_channels * 4
+        self.emb_dim = emb_dim
+        self.plan_enc, self.plan_dec = build_unet_plan(
+            img_resolution, model_channels, channel_mult, num_blocks, attn_resolutions
+        )
+        self.conv_in = Conv3x3(in_channels, model_channels)
+        self.t_fc1 = LinearLayer(emb_dim, emb_dim, True)
+        self.t_fc2 = LinearLayer(emb_dim, emb_dim, True)
+        self.label_emb = LinearLayer(label_dim + 1, emb_dim, False)
+        self.enc = ModuleList([UNetBlock(s.cin, s.cout, emb_dim, s.attn, dropout) for s in self.plan_enc])
+        self.dec = ModuleList([UNetBlock(s.cin, s.cout, emb_dim, s.attn, dropout) for s in self.plan_dec])
+        cfinal = self.plan_dec[-1].cout
+        self.out_norm = GroupNorm(cfinal)
+        self.out_conv = Conv3x3(cfinal, out_channels, zero_init=True)
+
+    def forward(self, x, t_feats, labels_onehot):
+        add, silu = ttml.ops.binary.add, ttml.ops.unary.silu
+        emb = add(self.t_fc2(silu(self.t_fc1(t_feats))), self.label_emb(labels_onehot))
+        h = w = self.img_resolution
+        x = self.conv_in(x, h, w)
+        skips = [x]
+        for block, spec in zip(self.enc, self.plan_enc):
+            if spec.resample == "down":
+                x = AvgPool2x2.apply(x, h, w)
+                h, w = h // 2, w // 2
+            x = block(x, emb, h, w)
+            skips.append(x)
+        for block, spec in zip(self.dec, self.plan_dec):
+            if spec.resample == "up":
+                x = UpsampleNearest2.apply(x, h, w)
+                h, w = h * 2, w * 2
+            if spec.skip_in:
+                x = ConcatChannels.apply(x, skips.pop())
+            x = block(x, emb, h, w)
+        assert not skips, f"decoder left {len(skips)} skips unconsumed"
+        return self.out_conv(silu(self.out_norm(x, h, w)), h, w)
+
+
+def song_unet_cifar(label_dim: int = 10) -> SongUNet:
+    """The exact EDM CIFAR-10 DDPM++ config (55-62M params)."""
+    return SongUNet(label_dim=label_dim)
+
+
+def song_unet_tiny(img_resolution: int = 32, label_dim: int = 10) -> SongUNet:
+    """Bring-up config: one block per level, narrow channels, no dropout."""
+    return SongUNet(
+        img_resolution=img_resolution,
+        label_dim=label_dim,
+        model_channels=32,
+        num_blocks=1,
+        dropout=0.0,
+    )

--- a/tt-train/sources/examples/dit/edm_unet.py
+++ b/tt-train/sources/examples/dit/edm_unet.py
@@ -32,7 +32,8 @@ from ttml.modules import AbstractModuleBase, LinearLayer, Parameter, RunMode
 from ttml.modules.module_base import ModuleList
 
 from edm import build_unet_plan
-from edm_ops import AvgPool2x2, ConcatChannels, Conv3x3Im2col, GroupNormMoreh, Scale, UpsampleNearest2
+import edm_ops
+from edm_ops import AvgPool2x2, ConcatChannels, Conv3x3Im2col, GroupNormMoreh, GroupNormNHWC, Scale, UpsampleNearest2
 
 SKIP_SCALE = math.sqrt(0.5)
 
@@ -66,7 +67,8 @@ class GroupNorm(AbstractModuleBase):
         self.beta = Parameter(ttml.init.zeros()((1, 1, 1, channels)))
 
     def forward(self, x, h: int, w: int):
-        return GroupNormMoreh.apply(x, self.gamma.tensor, self.beta.tensor, self.num_groups, h, w)
+        fn = GroupNormNHWC if edm_ops.NHWC_GN else GroupNormMoreh  # EDM_NHWC_GN
+        return fn.apply(x, self.gamma.tensor, self.beta.tensor, self.num_groups, h, w)
 
 
 class UNetAttention(AbstractModuleBase):

--- a/tt-train/sources/examples/dit/reference_unet.py
+++ b/tt-train/sources/examples/dit/reference_unet.py
@@ -1,0 +1,270 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""PyTorch golden model for the ttml SongUNet (edm_unet.py), 1:1 parameter map.
+
+DDPM++ "SongUNet" in the EDM CIFAR-10 configuration (Karras et al. 2022):
+model_channels=128, channel_mult=[2,2,2], num_blocks=4, attention at 16x16
+(plus the middle block at 8x8), dropout=0.13, GroupNorm(eps=1e-6,
+groups=min(32, C//4)), embedding dim = model_channels*4 = 512,
+skip_scale = sqrt(1/2) on residual and attention adds.
+
+Residual block (EDM UNetBlock with adaptive_scale=False, i.e. the additive
+embedding path SongUNet actually uses):
+
+    h = conv0(silu(norm0(x)))
+    h = h + affine(silu(emb))          broadcast over H,W
+    h = conv1(dropout(silu(norm1(h))))
+    x = (skip(x) + h) * sqrt(1/2)      skip = 1x1 conv iff C changes
+    if attn: x = (x + proj(SDPA(qkv(norm2(x))))) * sqrt(1/2)
+
+DOCUMENTED DEVIATIONS from official EDM SongUNet (kept deliberately simple
+for the ttml bring-up; every deviation applies identically to both the torch
+golden and the ttml model, so they stay bit-comparable):
+  1. Down/upsampling is a plain avgpool-2x2 / nearest-2x applied BEFORE the
+     level's first block, instead of being fused into that block's conv0 and
+     skip paths (EDM resamples inside UNetBlock with filter [1,1]).
+  2. Per-block conditioning is affine(silu(emb)); EDM applies affine(emb)
+     directly (its emb is already silu-terminated by the map layers).
+  3. Embedding MLP mirrors edm.py / the DiT: feats(512) come from
+     timestep_features(c_noise * CNOISE_FEAT_SCALE, 512) host-side, then
+     emb = t_fc2(silu(t_fc1(feats))) + label_emb(onehot). EDM instead uses a
+     128-dim Fourier feature -> silu after BOTH map layers, and adds the
+     class embedding before the MLP.
+  4. Attention projections are init'd normal(0, 0.02) for qkv and zeros for
+     proj (EDM uses xavier-based init_attn / init_zero); conv1 and out_conv
+     are zero-init like EDM's init_zero.
+  5. Attention is single-head (matches DDPM++/EDM SongUNet num_heads=1).
+
+CONV WEIGHT ROW_ORDER (the load-bearing convention):
+    Every trainable 3x3 conv weight is stored FLATTENED as a matrix
+        W_flat [9*C_in, C_out]
+    with row index  r = (kh*3 + kw)*C_in + c_in ,  kh, kw in {0,1,2}
+    scanning the kernel window top-left -> bottom-right (row-major), input
+    channel fastest. I.e. flatten order = (kh, kw, c_in).
+    Equivalent OIHW view:  W_flat.view(3,3,Cin,Cout).permute(3,2,0,1).
+    The device im2col concatenates its 9 shifted slices in the same
+    (kh, kw) order, each contributing C_in channels, so
+    patches [BHW, 9*C_in] @ W_flat == conv2d(x, OIHW, padding=1).
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from edm import build_unet_plan
+
+SKIP_SCALE = math.sqrt(0.5)
+
+
+class Conv3x3Flat(nn.Module):
+    """3x3 same-pad conv whose weight is stored flattened [9*Cin, Cout].
+
+    ROW_ORDER = (kh, kw, c_in): see the module docstring. forward() views the
+    flat weight back to OIHW and calls F.conv2d, so semantics are standard.
+    """
+
+    def __init__(self, cin: int, cout: int, zero_init: bool = False):
+        super().__init__()
+        self.cin, self.cout = cin, cout
+        fan_in = 9 * cin
+        k = 1.0 / math.sqrt(fan_in)
+        w = torch.zeros(fan_in, cout) if zero_init else torch.empty(fan_in, cout).uniform_(-k, k)
+        b = torch.zeros(cout) if zero_init else torch.empty(cout).uniform_(-k, k)
+        self.weight = nn.Parameter(w)  # [9*Cin, Cout], ROW_ORDER (kh, kw, cin)
+        self.bias = nn.Parameter(b)
+
+    def oihw(self) -> torch.Tensor:
+        return self.weight.view(3, 3, self.cin, self.cout).permute(3, 2, 0, 1)
+
+    def forward(self, x):  # x [B, Cin, H, W]
+        return F.conv2d(x, self.oihw(), self.bias, padding=1)
+
+
+class Conv1x1(nn.Module):
+    """1x1 conv with nn.Linear-style params [out, in] (mirrors ttml LinearLayer)."""
+
+    def __init__(self, cin: int, cout: int):
+        super().__init__()
+        k = 1.0 / math.sqrt(cin)
+        self.weight = nn.Parameter(torch.empty(cout, cin).uniform_(-k, k))
+        self.bias = nn.Parameter(torch.empty(cout).uniform_(-k, k))
+
+    def forward(self, x):  # [B, Cin, H, W]
+        return torch.einsum("oc,bchw->bohw", self.weight, x) + self.bias.view(1, -1, 1, 1)
+
+
+class AttentionTokens(nn.Module):
+    """Single-head self-attention over flattened spatial tokens (EDM style)."""
+
+    def __init__(self, dim: int):
+        super().__init__()
+        self.qkv = nn.Linear(dim, 3 * dim)
+        self.proj = nn.Linear(dim, dim)
+        nn.init.normal_(self.qkv.weight, 0.0, 0.02)
+        nn.init.zeros_(self.qkv.bias)
+        nn.init.zeros_(self.proj.weight)
+        nn.init.zeros_(self.proj.bias)
+
+    def forward(self, x):  # [B, C, H, W]
+        b, c, h, w = x.shape
+        t = x.reshape(b, c, h * w).transpose(1, 2)  # [B, T, C]
+        q, k, v = self.qkv(t).chunk(3, dim=-1)
+        o = F.scaled_dot_product_attention(q.unsqueeze(1), k.unsqueeze(1), v.unsqueeze(1)).squeeze(1)
+        return self.proj(o).transpose(1, 2).reshape(b, c, h, w)
+
+
+def _gn(c: int) -> nn.GroupNorm:
+    return nn.GroupNorm(min(32, c // 4), c, eps=1e-6)
+
+
+class UNetBlock(nn.Module):
+    def __init__(self, cin: int, cout: int, emb_dim: int, attn: bool, dropout: float):
+        super().__init__()
+        self.dropout_p = dropout
+        self.norm0 = _gn(cin)
+        self.conv0 = Conv3x3Flat(cin, cout)
+        self.affine = nn.Linear(emb_dim, cout)
+        self.norm1 = _gn(cout)
+        self.conv1 = Conv3x3Flat(cout, cout, zero_init=True)
+        self.skip = Conv1x1(cin, cout) if cin != cout else None
+        if attn:
+            self.norm2 = _gn(cout)
+            self.attn = AttentionTokens(cout)
+        else:
+            self.norm2 = self.attn = None
+
+    def forward(self, x, emb):  # x [B,Cin,H,W], emb [B,emb_dim]
+        h = self.conv0(F.silu(self.norm0(x)))
+        h = h + self.affine(F.silu(emb)).unsqueeze(-1).unsqueeze(-1)
+        h = F.silu(self.norm1(h))
+        h = self.conv1(F.dropout(h, self.dropout_p, self.training))
+        x = (h + (self.skip(x) if self.skip is not None else x)) * SKIP_SCALE
+        if self.attn is not None:
+            x = (x + self.attn(self.norm2(x))) * SKIP_SCALE
+        return x
+
+
+class TorchSongUNet(nn.Module):
+    """Golden CPU mirror of edm_unet.SongUNet. See module docstring for spec."""
+
+    def __init__(
+        self,
+        img_resolution: int = 32,
+        in_channels: int = 3,
+        out_channels: int = 3,
+        label_dim: int = 10,  # a +1 null class is appended (CFG convention)
+        model_channels: int = 128,
+        channel_mult: tuple = (2, 2, 2),
+        num_blocks: int = 4,
+        attn_resolutions: tuple = (16,),
+        dropout: float = 0.13,
+    ):
+        super().__init__()
+        self.img_resolution = img_resolution
+        emb_dim = model_channels * 4
+        self.emb_dim = emb_dim
+        self.plan_enc, self.plan_dec = build_unet_plan(
+            img_resolution, model_channels, channel_mult, num_blocks, attn_resolutions
+        )
+        self.conv_in = Conv3x3Flat(in_channels, model_channels)
+        self.t_fc1 = nn.Linear(emb_dim, emb_dim)
+        self.t_fc2 = nn.Linear(emb_dim, emb_dim)
+        self.label_emb = nn.Linear(label_dim + 1, emb_dim, bias=False)
+        self.enc = nn.ModuleList(UNetBlock(s.cin, s.cout, emb_dim, s.attn, dropout) for s in self.plan_enc)
+        self.dec = nn.ModuleList(UNetBlock(s.cin, s.cout, emb_dim, s.attn, dropout) for s in self.plan_dec)
+        cfinal = self.plan_dec[-1].cout
+        self.out_norm = _gn(cfinal)
+        self.out_conv = Conv3x3Flat(cfinal, out_channels, zero_init=True)
+
+    def forward(self, x, t_feats, labels_onehot, verbose: bool = False):
+        """x [B,C,H,W]; t_feats [B,1,1,emb_dim]; labels_onehot [B,1,1,label_dim+1]."""
+
+        def log(tag, t):
+            if verbose:
+                print(f"  {tag:<26s} {tuple(t.shape)}", flush=True)
+
+        emb = self.t_fc2(F.silu(self.t_fc1(t_feats))) + self.label_emb(labels_onehot)
+        emb = emb.reshape(emb.shape[0], self.emb_dim)  # [B, emb_dim]
+        x = self.conv_in(x)
+        log("conv_in", x)
+        skips = [x]
+        for block, spec in zip(self.enc, self.plan_enc):
+            if spec.resample == "down":
+                x = F.avg_pool2d(x, 2)
+            x = block(x, emb)
+            skips.append(x)
+            log(f"enc {spec.res}x{spec.res} -> {spec.cout}" + (" attn" if spec.attn else ""), x)
+        for block, spec in zip(self.dec, self.plan_dec):
+            if spec.resample == "up":
+                x = F.interpolate(x, scale_factor=2, mode="nearest")
+            if spec.skip_in:
+                x = torch.cat([x, skips.pop()], dim=1)
+            x = block(x, emb)
+            log(f"dec {spec.res}x{spec.res} -> {spec.cout}" + (" attn" if spec.attn else ""), x)
+        assert len(skips) == 0, f"decoder left {len(skips)} skips unconsumed"
+        x = self.out_conv(F.silu(self.out_norm(x)))
+        log("out_conv", x)
+        return x
+
+
+# ---------------------------------------------------------------------------
+# ttml .npz checkpoint interop (mirrors cpu_sample.load_ttml_npz conventions)
+# ---------------------------------------------------------------------------
+#
+# ttml names come from the module tree: "SongUNet/enc/3/conv0/weight" etc.
+#   ttml LinearLayer  weight [1,1,out,in], bias [1,1,1,out]
+#   ttml Conv3x3      weight [1,1,9*Cin,Cout] (ROW_ORDER), bias [1,1,1,Cout]
+#   ttml GroupNorm    gamma/beta [1,1,1,C]
+# Torch counterparts use the SAME attribute names, so translation is
+# mechanical: '.'->'/' with root 'SongUNet', GN weight/bias <-> gamma/beta.
+
+
+def ttml_name_map(model: TorchSongUNet) -> dict:
+    """torch state_dict key -> (ttml npz key, torch shape)."""
+    mapping = {}
+    for mod_name, module in model.named_modules():
+        prefix = "SongUNet" + ("/" + mod_name.replace(".", "/") if mod_name else "")
+        if isinstance(module, nn.GroupNorm):
+            mapping[f"{mod_name}.weight"] = f"{prefix}/gamma"
+            mapping[f"{mod_name}.bias"] = f"{prefix}/beta"
+        elif isinstance(module, (nn.Linear, Conv1x1, Conv3x3Flat)):
+            mapping[f"{mod_name}.weight"] = f"{prefix}/weight"
+            if getattr(module, "bias", None) is not None:
+                mapping[f"{mod_name}.bias"] = f"{prefix}/bias"
+    return mapping
+
+
+def load_ttml_npz(model: TorchSongUNet, path: str) -> TorchSongUNet:
+    """Load a tt-train SongUNet .npz checkpoint into the torch golden model."""
+    z = np.load(path)
+    sd = {}
+    for torch_key, ttml_key in ttml_name_map(model).items():
+        ref = model.state_dict()[torch_key]
+        sd[torch_key] = torch.from_numpy(z[ttml_key].reshape(ref.shape).copy())
+    model.load_state_dict(sd, strict=True)
+    return model
+
+
+def export_torch_npz(model: TorchSongUNet, path: str) -> None:
+    """Save torch params under ttml names/shapes (device parity tests load this)."""
+    out = {}
+    sd = model.state_dict()
+    for torch_key, ttml_key in ttml_name_map(model).items():
+        t = sd[torch_key].detach().float().numpy()
+        if t.ndim == 1:  # biases / GN affine -> [1,1,1,C]
+            t = t.reshape(1, 1, 1, -1)
+        elif t.ndim == 2:  # linear [o,i] / conv flat [9ci,co] -> [1,1,a,b]
+            t = t.reshape(1, 1, *t.shape)
+        out[ttml_key] = t
+    np.savez(path, **out)
+
+
+def param_count(model: nn.Module) -> int:
+    return sum(p.numel() for p in model.parameters())

--- a/tt-train/sources/examples/dit/segment_runner.sbatch
+++ b/tt-train/sources/examples/dit/segment_runner.sbatch
@@ -16,6 +16,8 @@
 #   RUN_NAME  stable run dir name (resume identity)
 # Optional:
 #   SEGMENT_SECONDS  training budget per segment (default 900)
+#   TT_MESH_GRAPH_DESC_PATH  REQUIRED for multi-chip meshes: auto-selection may
+#                    pick a descriptor with the wrong eth-channel count
 #   SBATCH_EXTRA     extra args for the resubmission (e.g. --partition=...)
 set -euo pipefail
 

--- a/tt-train/sources/examples/dit/segment_runner.sbatch
+++ b/tt-train/sources/examples/dit/segment_runner.sbatch
@@ -23,6 +23,8 @@ set -euo pipefail
 SEGMENT_SECONDS=${SEGMENT_SECONDS:-900}
 
 export TT_METAL_HOME=$REPO TT_METAL_RUNTIME_ROOT=$REPO PYTHONUNBUFFERED=1
+# Optional: STAGING_DIR with fresher example code to copy over the repo copy.
+if [ -n "${STAGING_DIR:-}" ]; then cp $STAGING_DIR/*.py $REPO/tt-train/sources/examples/dit/; fi
 cd $REPO/tt-train/sources/examples/dit
 
 set +e
@@ -45,7 +47,7 @@ case "$tail" in
     TRAINING_COMPLETE*) echo "chain finished: $tail" ;;
     SEGMENT_END*)
         echo "resubmitting: $tail"
-        sbatch ${SBATCH_EXTRA:-} --export=ALL,REPO=$REPO,CONFIG=$CONFIG,RUN_NAME=$RUN_NAME,SEGMENT_SECONDS=$SEGMENT_SECONDS,SBATCH_EXTRA="${SBATCH_EXTRA:-}" "$0"
+        sbatch ${SBATCH_EXTRA:-} --export=ALL,REPO=$REPO,CONFIG=$CONFIG,RUN_NAME=$RUN_NAME,SEGMENT_SECONDS=$SEGMENT_SECONDS,STAGING_DIR=${STAGING_DIR:-},SBATCH_EXTRA="${SBATCH_EXTRA:-}" "$0"
         ;;
     *) echo "no end marker (rc=0 but unexpected output); chain stopped" ;;
 esac

--- a/tt-train/sources/examples/dit/segment_runner.sbatch
+++ b/tt-train/sources/examples/dit/segment_runner.sbatch
@@ -1,0 +1,51 @@
+#!/bin/bash
+#SBATCH --job-name=dit-segment
+#SBATCH --nodes=1
+#SBATCH --time=00:25:00
+#SBATCH --nice=10000
+#SBATCH --output=logs/segment_%j.log
+
+# Low-priority segmented DiT training: train for SEGMENT_SECONDS, save a
+# resume checkpoint, exit, and resubmit this same script. Between segments
+# the node returns to the pool, and (with --nice) anyone else's queued job
+# runs first — voluntary preemption on clusters without slurm preemption.
+#
+# Required env (pass with sbatch --export=ALL,VAR=...):
+#   REPO      tt-metal root (built, with python_env)
+#   CONFIG    training config yaml (absolute path)
+#   RUN_NAME  stable run dir name (resume identity)
+# Optional:
+#   SEGMENT_SECONDS  training budget per segment (default 900)
+#   SBATCH_EXTRA     extra args for the resubmission (e.g. --partition=...)
+set -euo pipefail
+
+: "${REPO:?}" "${CONFIG:?}" "${RUN_NAME:?}"
+SEGMENT_SECONDS=${SEGMENT_SECONDS:-900}
+
+export TT_METAL_HOME=$REPO TT_METAL_RUNTIME_ROOT=$REPO PYTHONUNBUFFERED=1
+cd $REPO/tt-train/sources/examples/dit
+
+set +e
+$REPO/python_env/bin/python train_dit_cifar.py -c "$CONFIG" \
+    --run-name "$RUN_NAME" --resume --max-seconds "$SEGMENT_SECONDS" \
+    | tee /tmp/segment_out_$$.log
+rc=${PIPESTATUS[0]}
+tail=$(grep -aE "SEGMENT_END|TRAINING_COMPLETE" /tmp/segment_out_$$.log | tail -1)
+rm -f /tmp/segment_out_$$.log
+set -e
+
+# Leave nothing on node-local disk.
+rm -rf /home/$USER/.cache/tt-metal-cache 2>/dev/null || true
+
+if [ $rc -ne 0 ]; then
+    echo "segment crashed (rc=$rc); chain stopped"
+    exit $rc
+fi
+case "$tail" in
+    TRAINING_COMPLETE*) echo "chain finished: $tail" ;;
+    SEGMENT_END*)
+        echo "resubmitting: $tail"
+        sbatch ${SBATCH_EXTRA:-} --export=ALL,REPO=$REPO,CONFIG=$CONFIG,RUN_NAME=$RUN_NAME,SEGMENT_SECONDS=$SEGMENT_SECONDS,SBATCH_EXTRA="${SBATCH_EXTRA:-}" "$0"
+        ;;
+    *) echo "no end marker (rc=0 but unexpected output); chain stopped" ;;
+esac

--- a/tt-train/sources/examples/dit/smoke_unet_train.py
+++ b/tt-train/sources/examples/dit/smoke_unet_train.py
@@ -36,7 +36,13 @@ from edm_unet import song_unet_cifar, song_unet_tiny
 from train_dit_cifar import load_cifar10
 
 
-def from_np(a):
+def from_np(a, mapper=None):
+    import ttnn as _t
+
+    if mapper is not None:
+        return ttml.autograd.Tensor.from_numpy(
+            np.ascontiguousarray(a, dtype=np.float32), _t.Layout.TILE, _t.DataType.BFLOAT16, mapper
+        )
     return ttml.autograd.Tensor.from_numpy(np.ascontiguousarray(a, dtype=np.float32))
 
 
@@ -111,6 +117,7 @@ def main():
     ap.add_argument("--batch", type=int, default=32)
     ap.add_argument("--lr", type=float, default=1e-4)
     ap.add_argument("--probe", action="store_true")
+    ap.add_argument("--mesh", type=int, default=1, help="dp mesh size (DDP; batch is global)")
     ap.add_argument("--native-conv", action="store_true", help="conv fwd via native ttnn.conv2d")
     args = ap.parse_args()
 
@@ -120,7 +127,12 @@ def main():
         edm_ops.NATIVE_CONV = True  # same switch as env EDM_NATIVE_CONV=1
     conv_path = "native" if edm_ops.NATIVE_CONV else "im2col"
 
-    ttml.open_device_mesh(ttml.Mesh((1, 1), ("dp", "tp")))
+    ttml.open_device_mesh(ttml.Mesh((args.mesh, 1), ("dp", "tp")))
+    batch_mapper = ttml.mesh().axis_mapper("dp", tdim=0) if args.mesh > 1 else None
+    loss_composer = None
+    if args.mesh > 1:
+        device = ttml.autograd.AutoContext.get_instance().get_device()
+        loss_composer = ttml.core.distributed.concat_mesh_to_tensor_composer(device, 0)
     images, labels = load_cifar10(args.data_dir)
     print(f"CIFAR loaded {images.shape}", flush=True)
 
@@ -155,7 +167,8 @@ def main():
         loss = ttml.ops.loss.mse_loss(pred, from_np_input(nchw_to_nhwc_tokens(target)))
         loss.backward(False)
         opt.step()
-        loss_val = float(loss.to_numpy(None, None, ttml.autograd.PreferredPrecision.NATIVE).astype(np.float32).reshape(-1)[0])
+        loss_np = loss.to_numpy(None, loss_composer, ttml.autograd.PreferredPrecision.NATIVE)
+        loss_val = float(np.asarray(loss_np, dtype=np.float32).mean())
         ctx.reset_graph()
         if args.probe and step == warmup:
             t0 = time.time()

--- a/tt-train/sources/examples/dit/smoke_unet_train.py
+++ b/tt-train/sources/examples/dit/smoke_unet_train.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""UNet training smoke + throughput probe on real CIFAR-10.
+
+    python smoke_unet_train.py --data-dir <dir> [--model tiny|cifar]
+        [--steps 300] [--batch 32] [--probe]
+
+--probe: 30 timed steps after warmup, prints img/s (use with --model cifar
+to size the full EDM run).
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import numpy as np
+import ttnn
+
+import ttml
+
+from edm import make_edm_batch_image, nchw_to_nhwc_tokens
+from edm_unet import song_unet_cifar, song_unet_tiny
+from train_dit_cifar import load_cifar10
+
+
+def from_np(a):
+    return ttml.autograd.Tensor.from_numpy(np.ascontiguousarray(a, dtype=np.float32))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--data-dir", required=True)
+    ap.add_argument("--model", choices=["tiny", "cifar"], default="tiny")
+    ap.add_argument("--steps", type=int, default=300)
+    ap.add_argument("--batch", type=int, default=32)
+    ap.add_argument("--lr", type=float, default=1e-4)
+    ap.add_argument("--probe", action="store_true")
+    args = ap.parse_args()
+
+    ttml.open_device_mesh(ttml.Mesh((1, 1), ("dp", "tp")))
+    images, labels = load_cifar10(args.data_dir)
+    print(f"CIFAR loaded {images.shape}", flush=True)
+
+    model = song_unet_tiny() if args.model == "tiny" else song_unet_cifar()
+    n_params = sum(int(np.prod(t.shape())) for t in model.parameters().values())
+    print(f"model={args.model} params={n_params/1e6:.2f}M batch={args.batch}", flush=True)
+
+    opt = ttml.optimizers.create_optimizer({"type": "AdamW", "lr": args.lr}, model.parameters())
+    ctx = ttml.autograd.AutoContext.get_instance()
+    rng = np.random.default_rng(0)
+    emb_feat_dim = model.emb_dim  # host timestep_features dim == emb_dim
+
+    model.train()
+    t0 = time.time()
+    warmup = 5 if args.probe else 0
+    n_steps = (warmup + 30) if args.probe else args.steps
+    for step in range(1, n_steps + 1):
+        idx = rng.integers(0, images.shape[0], size=args.batch)
+        net_in, feats, onehot, target = make_edm_batch_image(
+            images[idx], labels[idx], emb_feat_dim, rng, cfg_drop_prob=0.0, null_class=10, hflip=True
+        )
+        opt.zero_grad()
+        pred = model(from_np(nchw_to_nhwc_tokens(net_in)), from_np(feats), from_np(onehot))
+        loss = ttml.ops.loss.mse_loss(pred, from_np(nchw_to_nhwc_tokens(target)))
+        loss.backward(False)
+        opt.step()
+        loss_val = float(loss.to_numpy(None, None, ttml.autograd.PreferredPrecision.NATIVE).astype(np.float32).reshape(-1)[0])
+        ctx.reset_graph()
+        if args.probe and step == warmup:
+            t0 = time.time()
+        if step % 10 == 0 or step <= 3:
+            print(f"step {step:5d} loss {loss_val:.4f}", flush=True)
+    if args.probe:
+        dt = time.time() - t0
+        print(f"PROBE: {30*args.batch/dt:.1f} img/s ({dt/30*1000:.0f} ms/step)", flush=True)
+    print("SMOKE_DONE", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tt-train/sources/examples/dit/smoke_unet_train.py
+++ b/tt-train/sources/examples/dit/smoke_unet_train.py
@@ -8,10 +8,17 @@
         [--steps 300] [--batch 32] [--probe] [--native-conv]
 
 --probe: 30 timed steps after warmup, prints img/s (use with --model cifar
-to size the full EDM run).
+to size the full EDM run), plus a phase breakdown on a fixed batch:
+fwd-only / fwd+bwd / full-step ms (each synced by a device read), with the
+bwd-only and optimizer-only components derived.
 --native-conv (or env EDM_NATIVE_CONV=1): conv FORWARD via native
 ttnn.conv2d consuming the flat weight in place (backward stays im2col).
 Run the probe once with and once without to compare paths.
+
+Env knobs (see edm_ops.py): EDM_PROFILE_CONV=1 prints cumulative per-bucket
+conv timings (fwd_native/fwd_im2col/bwd_im2col_recompute/bwd_col2im/
+bwd_matmuls) per probe phase; EDM_SAVE_PATCHES=auto|1|0 sets the conv
+backward memory/speed policy.
 """
 
 from __future__ import annotations
@@ -31,6 +38,69 @@ from train_dit_cifar import load_cifar10
 
 def from_np(a):
     return ttml.autograd.Tensor.from_numpy(np.ascontiguousarray(a, dtype=np.float32))
+
+
+def from_np_input(a):
+    """Model inputs: no grad needed — lets conv_in skip its dX col2im."""
+    t = from_np(a)
+    t.set_requires_grad(False)
+    return t
+
+
+def read_scalar(t):
+    """Device-sync by pulling one value to host (NATIVE precision: no caching)."""
+    return float(t.to_numpy(None, None, ttml.autograd.PreferredPrecision.NATIVE).astype(np.float32).reshape(-1)[0])
+
+
+def phase_breakdown(model, opt, ctx, batch_np):
+    """Time fwd / fwd+bwd / full-step on one fixed batch; print components."""
+    import edm_ops
+
+    net_in, feats, onehot, target = batch_np
+    x_np, t_np = nchw_to_nhwc_tokens(net_in), nchw_to_nhwc_tokens(target)
+
+    def fwd():
+        pred = model(from_np_input(x_np), from_np_input(feats), from_np_input(onehot))
+        return ttml.ops.loss.mse_loss(pred, from_np_input(t_np))
+
+    def phase_fwd():
+        loss = fwd()
+        read_scalar(loss)  # sync
+        ctx.reset_graph()
+
+    def phase_fwd_bwd():
+        opt.zero_grad()
+        loss = fwd()
+        loss.backward(False)
+        read_scalar(model.out_conv.weight.tensor.get_grad_tensor())  # sync on a grad
+        ctx.reset_graph()
+
+    def phase_full():
+        opt.zero_grad()
+        loss = fwd()
+        loss.backward(False)
+        opt.step()
+        read_scalar(loss)  # sync
+        ctx.reset_graph()
+
+    results = {}
+    for name, fn in [("fwd", phase_fwd), ("fwd+bwd", phase_fwd_bwd), ("full-step", phase_full)]:
+        fn()
+        fn()  # warmup x2 (program caches)
+        edm_ops.prof_reset()
+        n = 10
+        t0 = time.time()
+        for _ in range(n):
+            fn()
+        results[name] = (time.time() - t0) / n * 1000
+        print(f"PHASE {name:<9s} {results[name]:8.1f} ms", flush=True)
+        if edm_ops.PROFILE_CONV:
+            edm_ops.prof_report(divisor=n)
+    print(
+        f"PHASE derived: bwd-only {results['fwd+bwd'] - results['fwd']:.1f} ms, "
+        f"opt-only {results['full-step'] - results['fwd+bwd']:.1f} ms",
+        flush=True,
+    )
 
 
 def main():
@@ -64,6 +134,14 @@ def main():
     emb_feat_dim = model.emb_dim  # host timestep_features dim == emb_dim
 
     model.train()
+
+    if args.probe:  # phase breakdown on one fixed batch, before the img/s loop
+        idx = rng.integers(0, images.shape[0], size=args.batch)
+        batch_np = make_edm_batch_image(
+            images[idx], labels[idx], emb_feat_dim, rng, cfg_drop_prob=0.0, null_class=10
+        )
+        phase_breakdown(model, opt, ctx, batch_np)
+
     t0 = time.time()
     warmup = 5 if args.probe else 0
     n_steps = (warmup + 30) if args.probe else args.steps
@@ -73,8 +151,8 @@ def main():
             images[idx], labels[idx], emb_feat_dim, rng, cfg_drop_prob=0.0, null_class=10, hflip=True
         )
         opt.zero_grad()
-        pred = model(from_np(nchw_to_nhwc_tokens(net_in)), from_np(feats), from_np(onehot))
-        loss = ttml.ops.loss.mse_loss(pred, from_np(nchw_to_nhwc_tokens(target)))
+        pred = model(from_np_input(nchw_to_nhwc_tokens(net_in)), from_np_input(feats), from_np_input(onehot))
+        loss = ttml.ops.loss.mse_loss(pred, from_np_input(nchw_to_nhwc_tokens(target)))
         loss.backward(False)
         opt.step()
         loss_val = float(loss.to_numpy(None, None, ttml.autograd.PreferredPrecision.NATIVE).astype(np.float32).reshape(-1)[0])

--- a/tt-train/sources/examples/dit/smoke_unet_train.py
+++ b/tt-train/sources/examples/dit/smoke_unet_train.py
@@ -5,10 +5,13 @@
 """UNet training smoke + throughput probe on real CIFAR-10.
 
     python smoke_unet_train.py --data-dir <dir> [--model tiny|cifar]
-        [--steps 300] [--batch 32] [--probe]
+        [--steps 300] [--batch 32] [--probe] [--native-conv]
 
 --probe: 30 timed steps after warmup, prints img/s (use with --model cifar
 to size the full EDM run).
+--native-conv (or env EDM_NATIVE_CONV=1): conv FORWARD via native
+ttnn.conv2d consuming the flat weight in place (backward stays im2col).
+Run the probe once with and once without to compare paths.
 """
 
 from __future__ import annotations
@@ -38,7 +41,14 @@ def main():
     ap.add_argument("--batch", type=int, default=32)
     ap.add_argument("--lr", type=float, default=1e-4)
     ap.add_argument("--probe", action="store_true")
+    ap.add_argument("--native-conv", action="store_true", help="conv fwd via native ttnn.conv2d")
     args = ap.parse_args()
+
+    import edm_ops
+
+    if args.native_conv:
+        edm_ops.NATIVE_CONV = True  # same switch as env EDM_NATIVE_CONV=1
+    conv_path = "native" if edm_ops.NATIVE_CONV else "im2col"
 
     ttml.open_device_mesh(ttml.Mesh((1, 1), ("dp", "tp")))
     images, labels = load_cifar10(args.data_dir)
@@ -46,7 +56,7 @@ def main():
 
     model = song_unet_tiny() if args.model == "tiny" else song_unet_cifar()
     n_params = sum(int(np.prod(t.shape())) for t in model.parameters().values())
-    print(f"model={args.model} params={n_params/1e6:.2f}M batch={args.batch}", flush=True)
+    print(f"model={args.model} params={n_params/1e6:.2f}M batch={args.batch} conv={conv_path}", flush=True)
 
     opt = ttml.optimizers.create_optimizer({"type": "AdamW", "lr": args.lr}, model.parameters())
     ctx = ttml.autograd.AutoContext.get_instance()
@@ -75,7 +85,7 @@ def main():
             print(f"step {step:5d} loss {loss_val:.4f}", flush=True)
     if args.probe:
         dt = time.time() - t0
-        print(f"PROBE: {30*args.batch/dt:.1f} img/s ({dt/30*1000:.0f} ms/step)", flush=True)
+        print(f"PROBE[conv={conv_path}]: {30*args.batch/dt:.1f} img/s ({dt/30*1000:.0f} ms/step)", flush=True)
     print("SMOKE_DONE", flush=True)
 
 

--- a/tt-train/sources/examples/dit/test_edm_primitives.py
+++ b/tt-train/sources/examples/dit/test_edm_primitives.py
@@ -24,6 +24,7 @@ import traceback
 
 import numpy as np
 import ttnn
+from ttnn.operations import moreh as ttnn_moreh
 
 import ttml
 

--- a/tt-train/sources/examples/dit/test_edm_primitives.py
+++ b/tt-train/sources/examples/dit/test_edm_primitives.py
@@ -188,7 +188,7 @@ def t_moreh_group_norm_raw():
     xv = from_np(x).get_value()
     gv = from_np(gamma.reshape(1, 1, 1, c)).get_value()
     bv = from_np(beta.reshape(1, 1, 1, c)).get_value()
-    out, mean, rstd = ttnn.moreh.group_norm(
+    out, mean, rstd = ttnn_moreh.group_norm(
         xv, groups, eps=1e-6, gamma=gv, beta=bv, are_required_outputs=[True, True, True]
     )
     ref, _, _ = np_group_norm(x, groups, gamma, beta)
@@ -196,7 +196,7 @@ def t_moreh_group_norm_raw():
     assert_close(got, ref, rtol=0.03, atol=0.05, tag="fwd")
 
     gov = from_np(g_out).get_value()
-    dx, dgamma, dbeta = ttnn.moreh.group_norm_backward(
+    dx, dgamma, dbeta = ttnn_moreh.group_norm_backward(
         gov, xv, mean, rstd, groups, are_required_outputs=[True, True, True], gamma=gv
     )
     rdx, rdgamma, rdbeta = np_group_norm_bwd(x, groups, gamma, g_out)

--- a/tt-train/sources/examples/dit/test_edm_primitives.py
+++ b/tt-train/sources/examples/dit/test_edm_primitives.py
@@ -286,6 +286,95 @@ def t_conv_bwd():
     assert_close(grad_np(bt).reshape(-1), rdb, 0.08, 0.05 * abs(rdb).max(), "dB")
 
 
+def _pcc(a, b):
+    a = a.reshape(-1).astype(np.float64)
+    b = b.reshape(-1).astype(np.float64)
+    return float(np.corrcoef(a, b)[0, 1])
+
+
+@check("native conv2d probe: effective weight row order seen by the kernel")
+def t_native_conv_probe():
+    """Empirically answer the Phase-2 row-ordering question: feed a batch of
+    single-pixel delta images through native ttnn.conv2d using our flat
+    ROW_ORDER weight (consumed in place, no prep), recover the effective
+    OIHW weight the kernel actually applied, and report the row permutation
+    relative to ROW_ORDER. Identity = the kernel's prepared-weight layout
+    equals our flatten; otherwise the printout gives the true ordering so the
+    param (or ROW_ORDER globally) can be permuted to match.
+    """
+    from edm_ops import _conv3x3_native_fwd
+
+    rng = np.random.default_rng(9)
+    cin = cout = 32
+    h = w = 8
+    b = cin  # image k carries a delta at the center pixel, in channel k
+    i0 = j0 = 4
+    # Random +-1 rows: the true match reproduces the row exactly (delta conv
+    # copies weight values), spurious cross-correlations stay well below 1.
+    flat = rng.choice([-1.0, 1.0], size=(9 * cin, cout)).astype(np.float32)
+    x = np.zeros((b, h, w, cin), dtype=np.float32)
+    for k in range(cin):
+        x[k, i0, j0, k] = 1.0
+    xt = from_np(x.reshape(b, 1, h * w, cin))
+    wt = from_np(flat.reshape(1, 1, 9 * cin, cout))
+    out = _conv3x3_native_fwd(xt.get_value(), wt.get_value(), b, h, w, cin, cout)
+    o = ttml.autograd.create_tensor(out, False).to_numpy(ttnn.DataType.FLOAT32).reshape(b, h, w, cout)
+    # out(pi,pj,o) = sum W[o,c,kh,kw] x(pi+kh-1, pj+kw-1, c); the delta at
+    # (i0,j0, ch=k) puts W_eff[o,k,kh,kw] at out[k, i0-kh+1, j0-kw+1, o].
+    eff = np.zeros_like(flat)
+    for kh in range(3):
+        for kw in range(3):
+            for ch in range(cin):
+                eff[(kh * 3 + kw) * cin + ch] = o[ch, i0 - kh + 1, j0 - kw + 1]
+    sims = np.abs(eff @ flat.T) / cout  # 1.0 == exact (up to sign) row match
+    perm = sims.argmax(axis=1)
+    strength = sims.max(axis=1)
+    ident = np.arange(9 * cin)
+    n_id = int((perm == ident).sum())
+    print(f"     row match: {n_id}/{9*cin} identity, min match strength {strength.min():.3f}", flush=True)
+    if n_id != 9 * cin:
+        moved = np.where(perm != ident)[0]
+        print(f"     PERMUTED (ours->kernel), first 20: {list(zip(moved[:20].tolist(), perm[moved[:20]].tolist()))}", flush=True)
+        decode = [((int(r) // cin) // 3, (int(r) // cin) % 3, int(r) % cin) for r in perm[moved[:8]]]
+        print(f"     kernel positions of those rows as (kh,kw,cin): {decode}", flush=True)
+    assert n_id == 9 * cin and strength.min() > 0.9, (
+        f"native conv2d consumes a DIFFERENT row order ({9*cin - n_id} rows moved) — "
+        "apply the printed permutation at init + inverse on wgrad, or change ROW_ORDER globally"
+    )
+
+
+@check("native conv2d fwd parity vs im2col composite (C=32@16x16, C=128@32x32)")
+def t_native_conv_parity():
+    from edm_ops import _conv3x3_native_fwd, _im2col
+
+    rng = np.random.default_rng(10)
+    for cin, cout, h, w in [(32, 32, 16, 16), (128, 128, 32, 32)]:
+        b = 2
+        x_np = rng.standard_normal((b, h, w, cin)).astype(np.float32)
+        w_np = (rng.standard_normal((9 * cin, cout)) / math.sqrt(9 * cin)).astype(np.float32)
+        xt = from_np(x_np.reshape(b, 1, h * w, cin))
+        wt = from_np(w_np.reshape(1, 1, 9 * cin, cout))
+        v, wv = xt.get_value(), wt.get_value()
+
+        native = ttml.autograd.create_tensor(_conv3x3_native_fwd(v, wv, b, h, w, cin, cout), False)
+        native = native.to_numpy(ttnn.DataType.FLOAT32).reshape(b, h, w, cout)
+        comp = ttml.autograd.create_tensor(ttnn.matmul(_im2col(v, b, h, w, cin), wv), False)
+        comp = comp.to_numpy(ttnn.DataType.FLOAT32).reshape(b, h, w, cout)
+        golden = np_conv3x3(x_np, w_np, np.zeros(cout, dtype=np.float32))
+
+        pcc_nc = _pcc(native, comp)
+        pcc_ng = _pcc(native, golden)
+        err_nc = np.abs(native - comp).max()
+        err_ng = np.abs(native - golden).max()
+        print(
+            f"     C={cin}@{h}x{w}: PCC(native,composite)={pcc_nc:.6f} PCC(native,golden)={pcc_ng:.6f} "
+            f"maxerr vs comp {err_nc:.4f}, vs fp32 golden {err_ng:.4f}",
+            flush=True,
+        )
+        assert pcc_nc >= 0.999, f"native/composite diverge at C={cin}: PCC={pcc_nc}"
+        assert pcc_ng >= 0.999, f"native/golden diverge at C={cin}: PCC={pcc_ng}"
+
+
 @check("GroupNormMoreh wrapper fwd+bwd on tokens (C=64,16x16,G=16)")
 def t_groupnorm_wrapper():
     from edm_ops import GroupNormMoreh
@@ -434,6 +523,8 @@ if __name__ == "__main__":
             t_pool_upsample,
             t_conv_fwd,
             t_conv_bwd,
+            t_native_conv_probe,
+            t_native_conv_parity,
             t_groupnorm_wrapper,
             t_concat_channels,
             t_block_parity,

--- a/tt-train/sources/examples/dit/test_edm_primitives.py
+++ b/tt-train/sources/examples/dit/test_edm_primitives.py
@@ -1,0 +1,447 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""On-device gate for every primitive the SongUNet (edm_unet.py) relies on.
+
+Run on a machine with a Tenstorrent device:
+    python test_edm_primitives.py
+
+Style mirrors test_device_primitives.py: [1,1] mesh, cheapest check first,
+prints OK/FAIL per check, exits nonzero on any failure. Goldens are numpy
+(already validated against torch by test_reference_unet.py on CPU); the two
+torch-dependent checks (UNet block parity) skip cleanly if torch is absent.
+
+bf16 tolerances: fwd |err| <= atol + rtol*|golden|; grads looser (they
+accumulate more bf16 roundoff through matmul chains).
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+import traceback
+
+import numpy as np
+import ttnn
+
+import ttml
+
+FAILURES = []
+SKIPPED = []
+
+
+def check(name):
+    def wrap(fn):
+        def run():
+            try:
+                fn()
+                print(f"OK   {name}", flush=True)
+            except _Skip as s:
+                print(f"SKIP {name}: {s}", flush=True)
+                SKIPPED.append(name)
+            except Exception:
+                print(f"FAIL {name}", flush=True)
+                traceback.print_exc()
+                FAILURES.append(name)
+            finally:
+                ttml.autograd.AutoContext.get_instance().reset_graph()
+
+        return run
+
+    return wrap
+
+
+class _Skip(Exception):
+    pass
+
+
+def to_np(t):
+    return t.to_numpy(ttnn.DataType.FLOAT32)
+
+
+def from_np(a, requires_grad=False):
+    t = ttml.autograd.Tensor.from_numpy(np.ascontiguousarray(a, dtype=np.float32))
+    if requires_grad:
+        t.set_requires_grad(True)
+    return t
+
+
+def grad_np(t):
+    return t.get_grad_tensor().to_numpy(ttnn.DataType.FLOAT32)
+
+
+def assert_close(got, ref, rtol, atol, tag=""):
+    err = np.abs(got - ref)
+    tol = atol + rtol * np.abs(ref)
+    bad = err > tol
+    assert not bad.any(), f"{tag}: {bad.sum()}/{bad.size} elems out of tol, max err {err.max():.5f}"
+
+
+# --- numpy goldens (same algorithms validated vs torch in test_reference_unet.py) ---
+
+
+def np_im2col(x_nhwc):
+    b, h, w, c = x_nhwc.shape
+    p = np.pad(x_nhwc, ((0, 0), (1, 1), (1, 1), (0, 0)))
+    views = [p[:, kh : kh + h, kw : kw + w, :] for kh in range(3) for kw in range(3)]
+    return np.concatenate(views, axis=-1).reshape(b * h * w, 9 * c)
+
+
+def np_conv3x3(x_nhwc, w_flat, bias):
+    b, h, w, _ = x_nhwc.shape
+    return (np_im2col(x_nhwc) @ w_flat + bias).reshape(b, h, w, -1)
+
+
+def np_conv3x3_bwd(x_nhwc, w_flat, g_nhwc):
+    b, h, w, c = x_nhwc.shape
+    cout = w_flat.shape[1]
+    g2 = g_nhwc.reshape(-1, cout)
+    cols = np_im2col(x_nhwc)
+    dw, db = cols.T @ g2, g2.sum(axis=0)
+    dcols = (g2 @ w_flat.T).reshape(b, h, w, 9 * c)
+    dp = np.zeros((b, h + 2, w + 2, c), dtype=np.float32)
+    for kh in range(3):
+        for kw in range(3):
+            k = kh * 3 + kw
+            dp[:, kh : kh + h, kw : kw + w, :] += dcols[..., k * c : (k + 1) * c]
+    return dp[:, 1 : h + 1, 1 : w + 1, :], dw, db
+
+
+def np_group_norm(x_nchw, groups, gamma, beta, eps=1e-6):
+    b, c, h, w = x_nchw.shape
+    g = x_nchw.reshape(b, groups, -1)
+    mean = g.mean(-1, keepdims=True)
+    rstd = 1.0 / np.sqrt(g.var(-1, keepdims=True) + eps)
+    xhat = ((g - mean) * rstd).reshape(b, c, h, w)
+    return xhat * gamma.reshape(1, c, 1, 1) + beta.reshape(1, c, 1, 1), xhat, rstd.reshape(b, groups)
+
+
+def np_group_norm_bwd(x_nchw, groups, gamma, g_out, eps=1e-6):
+    b, c, h, w = x_nchw.shape
+    _, xhat, _ = np_group_norm(x_nchw, groups, gamma, np.zeros_like(gamma), eps)
+    dgamma = (g_out * xhat).sum(axis=(0, 2, 3))
+    dbeta = g_out.sum(axis=(0, 2, 3))
+    dxhat = (g_out * gamma.reshape(1, c, 1, 1)).reshape(b, groups, -1)
+    xh = xhat.reshape(b, groups, -1)
+    gg = x_nchw.reshape(b, groups, -1)
+    rstd = 1.0 / np.sqrt(gg.var(-1, keepdims=True) + eps)
+    m1 = dxhat.mean(-1, keepdims=True)
+    m2 = (dxhat * xh).mean(-1, keepdims=True)
+    dx = (rstd * (dxhat - m1 - xh * m2)).reshape(b, c, h, w)
+    return dx.astype(np.float32), dgamma.astype(np.float32), dbeta.astype(np.float32)
+
+
+def tokens(x_nchw):  # [B,C,H,W] -> [B,1,HW,C]
+    b, c, h, w = x_nchw.shape
+    return np.ascontiguousarray(x_nchw.transpose(0, 2, 3, 1)).reshape(b, 1, h * w, c)
+
+
+def untokens(t, h, w):  # [B,1,HW,C] -> [B,H,W,C]
+    return t.reshape(t.shape[0], h, w, t.shape[-1])
+
+
+def mse_grad(pred_np):
+    """d/dpred of mse_loss(pred, 0) = 2*pred/numel."""
+    return (2.0 / pred_np.size) * pred_np
+
+
+# ---------------------------------------------------------------------------
+
+
+@check("RM NHWC pad/slice/concat: raw ttnn im2col vs numpy")
+def t_im2col_raw():
+    from edm_ops import _im2col
+
+    rng = np.random.default_rng(0)
+    b, h, w, c = 2, 8, 8, 32
+    x = rng.standard_normal((b, h, w, c)).astype(np.float32)
+    v = from_np(x.reshape(b, 1, h * w, c)).get_value()
+    cols = _im2col(v, b, h, w, c)
+    got = ttml.autograd.create_tensor(cols, False).to_numpy(ttnn.DataType.FLOAT32).reshape(b * h * w, 9 * c)
+    assert_close(got, np_im2col(x), rtol=0.02, atol=0.02, tag="im2col")
+
+
+@check("Permute fwd+bwd (NHWC <-> NCHW)")
+def t_permute():
+    from edm_ops import Permute
+
+    rng = np.random.default_rng(1)
+    x_np = rng.standard_normal((2, 8, 8, 32)).astype(np.float32)
+    x = from_np(x_np, requires_grad=True)
+    y = Permute.apply(x, (0, 3, 1, 2))
+    assert_close(to_np(y), x_np.transpose(0, 3, 1, 2), rtol=0.02, atol=0.02, tag="fwd")
+    loss = ttml.ops.loss.mse_loss(y, from_np(np.zeros_like(x_np).transpose(0, 3, 1, 2)))
+    loss.backward(False)
+    assert_close(grad_np(x), mse_grad(x_np), rtol=0.05, atol=1e-4, tag="bwd")
+
+
+@check("moreh.group_norm raw fwd+bwd vs numpy (N=4,C=128,32x32,G=32)")
+def t_moreh_group_norm_raw():
+    rng = np.random.default_rng(2)
+    b, c, h, w, groups = 4, 128, 32, 32, 32
+    x = rng.standard_normal((b, c, h, w)).astype(np.float32)
+    gamma = rng.standard_normal(c).astype(np.float32) * 0.5 + 1.0
+    beta = rng.standard_normal(c).astype(np.float32) * 0.1
+    g_out = rng.standard_normal((b, c, h, w)).astype(np.float32)
+
+    xv = from_np(x).get_value()
+    gv = from_np(gamma.reshape(1, 1, 1, c)).get_value()
+    bv = from_np(beta.reshape(1, 1, 1, c)).get_value()
+    out, mean, rstd = ttnn.moreh.group_norm(
+        xv, groups, eps=1e-6, gamma=gv, beta=bv, are_required_outputs=[True, True, True]
+    )
+    ref, _, _ = np_group_norm(x, groups, gamma, beta)
+    got = ttml.autograd.create_tensor(out, False).to_numpy(ttnn.DataType.FLOAT32)
+    assert_close(got, ref, rtol=0.03, atol=0.05, tag="fwd")
+
+    gov = from_np(g_out).get_value()
+    dx, dgamma, dbeta = ttnn.moreh.group_norm_backward(
+        gov, xv, mean, rstd, groups, are_required_outputs=[True, True, True], gamma=gv
+    )
+    rdx, rdgamma, rdbeta = np_group_norm_bwd(x, groups, gamma, g_out)
+    assert_close(ttml.autograd.create_tensor(dx, False).to_numpy(ttnn.DataType.FLOAT32), rdx, 0.05, 0.05, "dx")
+    assert_close(
+        ttml.autograd.create_tensor(dgamma, False).to_numpy(ttnn.DataType.FLOAT32).reshape(-1), rdgamma,
+        0.05, 0.05 * abs(rdgamma).max(), "dgamma",
+    )
+    assert_close(
+        ttml.autograd.create_tensor(dbeta, False).to_numpy(ttnn.DataType.FLOAT32).reshape(-1), rdbeta,
+        0.05, 0.05 * abs(rdbeta).max(), "dbeta",
+    )
+
+
+@check("AvgPool2x2 / UpsampleNearest2 fwd parity + adjoint pair")
+def t_pool_upsample():
+    from edm_ops import AvgPool2x2, UpsampleNearest2
+
+    rng = np.random.default_rng(3)
+    b, c, h, w = 2, 32, 16, 16
+    x_np = rng.standard_normal((b, c, h, w)).astype(np.float32)
+
+    # avgpool fwd
+    x = from_np(tokens(x_np), requires_grad=True)
+    y = AvgPool2x2.apply(x, h, w)
+    ref_pool = x_np.reshape(b, c, h // 2, 2, w // 2, 2).mean(axis=(3, 5))
+    assert_close(to_np(y), tokens(ref_pool), 0.03, 0.03, "pool fwd")
+    # avgpool bwd == 0.25 * nearest-upsample of dOut
+    loss = ttml.ops.loss.mse_loss(y, from_np(np.zeros_like(tokens(ref_pool))))
+    loss.backward(False)
+    g_out = mse_grad(tokens(ref_pool))  # [B,1,HW/4,C]
+    ref_dx = 0.25 * untokens(g_out, h // 2, w // 2).repeat(2, axis=1).repeat(2, axis=2)
+    assert_close(untokens(grad_np(x), h, w), ref_dx, 0.05, 1e-5, "pool bwd")
+    ttml.autograd.AutoContext.get_instance().reset_graph()
+
+    # upsample fwd
+    x2 = from_np(tokens(ref_pool), requires_grad=True)
+    y2 = UpsampleNearest2.apply(x2, h // 2, w // 2)
+    ref_up = untokens(tokens(ref_pool), h // 2, w // 2).repeat(2, axis=1).repeat(2, axis=2)
+    assert_close(untokens(to_np(y2), h, w), ref_up, 0.03, 0.03, "up fwd")
+    # upsample bwd == 2x2 SUM pool of dOut (adjoint of nearest-repeat)
+    loss2 = ttml.ops.loss.mse_loss(y2, from_np(np.zeros((b, 1, h * w, c), dtype=np.float32)))
+    loss2.backward(False)
+    g2 = untokens(mse_grad(tokens(ref_up.transpose(0, 3, 1, 2))), h, w)
+    ref_dx2 = g2.reshape(b, h // 2, 2, w // 2, 2, c).sum(axis=(2, 4))
+    assert_close(untokens(grad_np(x2), h // 2, w // 2), ref_dx2, 0.05, 1e-5, "up bwd")
+
+
+@check("Conv3x3Im2col fwd vs numpy golden (B=2,C=32,16x16)")
+def t_conv_fwd():
+    from edm_ops import Conv3x3Im2col
+
+    rng = np.random.default_rng(4)
+    b, h, w, cin, cout = 2, 16, 16, 32, 32
+    x_np = rng.standard_normal((b, h, w, cin)).astype(np.float32)
+    w_np = (rng.standard_normal((9 * cin, cout)) / math.sqrt(9 * cin)).astype(np.float32)
+    b_np = rng.standard_normal(cout).astype(np.float32) * 0.1
+    x = from_np(x_np.reshape(b, 1, h * w, cin))
+    wt = from_np(w_np.reshape(1, 1, 9 * cin, cout))
+    bt = from_np(b_np.reshape(1, 1, 1, cout))
+    out = Conv3x3Im2col.apply(x, wt, bt, h, w)
+    ref = np_conv3x3(x_np, w_np, b_np)
+    assert_close(untokens(to_np(out), h, w), ref, 0.05, 0.08, "conv fwd")
+
+
+@check("Conv3x3Im2col bwd grads (dX, dW, dB) vs numpy golden")
+def t_conv_bwd():
+    from edm_ops import Conv3x3Im2col
+
+    rng = np.random.default_rng(5)
+    b, h, w, cin, cout = 2, 16, 16, 32, 32
+    x_np = rng.standard_normal((b, h, w, cin)).astype(np.float32)
+    w_np = (rng.standard_normal((9 * cin, cout)) / math.sqrt(9 * cin)).astype(np.float32)
+    b_np = np.zeros(cout, dtype=np.float32)
+    x = from_np(x_np.reshape(b, 1, h * w, cin), requires_grad=True)
+    wt = from_np(w_np.reshape(1, 1, 9 * cin, cout), requires_grad=True)
+    bt = from_np(b_np.reshape(1, 1, 1, cout), requires_grad=True)
+    out = Conv3x3Im2col.apply(x, wt, bt, h, w)
+    loss = ttml.ops.loss.mse_loss(out, from_np(np.zeros((b, 1, h * w, cout), dtype=np.float32)))
+    loss.backward(False)
+    g = mse_grad(np_conv3x3(x_np, w_np, b_np))  # [B,H,W,Cout] fp32 golden upstream grad
+    rdx, rdw, rdb = np_conv3x3_bwd(x_np, w_np, g)
+    scale_w = max(abs(rdw).max(), 1e-8)
+    assert_close(untokens(grad_np(x), h, w), rdx, 0.08, 0.05 * abs(rdx).max(), "dX")
+    assert_close(grad_np(wt).reshape(9 * cin, cout), rdw, 0.08, 0.05 * scale_w, "dW")
+    assert_close(grad_np(bt).reshape(-1), rdb, 0.08, 0.05 * abs(rdb).max(), "dB")
+
+
+@check("GroupNormMoreh wrapper fwd+bwd on tokens (C=64,16x16,G=16)")
+def t_groupnorm_wrapper():
+    from edm_ops import GroupNormMoreh
+
+    rng = np.random.default_rng(6)
+    b, c, h, w, groups = 2, 64, 16, 16, 16
+    x_np = rng.standard_normal((b, c, h, w)).astype(np.float32)
+    gamma = (rng.standard_normal(c) * 0.3 + 1.0).astype(np.float32)
+    beta = (rng.standard_normal(c) * 0.1).astype(np.float32)
+    x = from_np(tokens(x_np), requires_grad=True)
+    gt = from_np(gamma.reshape(1, 1, 1, c), requires_grad=True)
+    bt = from_np(beta.reshape(1, 1, 1, c), requires_grad=True)
+    y = GroupNormMoreh.apply(x, gt, bt, groups, h, w)
+    ref, _, _ = np_group_norm(x_np, groups, gamma, beta)
+    assert_close(untokens(to_np(y), h, w), tokens(ref).reshape(b, h, w, c), 0.03, 0.05, "fwd")
+    loss = ttml.ops.loss.mse_loss(y, from_np(np.zeros((b, 1, h * w, c), dtype=np.float32)))
+    loss.backward(False)
+    g_nchw = untokens(mse_grad(tokens(ref)), h, w).transpose(0, 3, 1, 2)
+    rdx, rdgamma, rdbeta = np_group_norm_bwd(x_np, groups, gamma, g_nchw)
+    assert_close(untokens(grad_np(x), h, w).transpose(0, 3, 1, 2), rdx, 0.08, 0.05 * abs(rdx).max(), "dx")
+    assert_close(grad_np(gt).reshape(-1), rdgamma, 0.08, 0.05 * abs(rdgamma).max(), "dgamma")
+    assert_close(grad_np(bt).reshape(-1), rdbeta, 0.08, 0.05 * abs(rdbeta).max(), "dbeta")
+
+
+@check("ConcatChannels fwd+bwd (skip concat / slice)")
+def t_concat_channels():
+    from edm_ops import ConcatChannels
+
+    rng = np.random.default_rng(7)
+    a_np = rng.standard_normal((2, 1, 64, 32)).astype(np.float32)
+    b_np = rng.standard_normal((2, 1, 64, 64)).astype(np.float32)
+    a = from_np(a_np, requires_grad=True)
+    b = from_np(b_np, requires_grad=True)
+    y = ConcatChannels.apply(a, b)
+    assert_close(to_np(y), np.concatenate([a_np, b_np], axis=-1), 0.02, 0.02, "fwd")
+    loss = ttml.ops.loss.mse_loss(y, from_np(np.zeros_like(to_np(y))))
+    loss.backward(False)
+    g = mse_grad(np.concatenate([a_np, b_np], axis=-1))
+    assert_close(grad_np(a), g[..., :32], 0.05, 1e-5, "dA")
+    assert_close(grad_np(b), g[..., 32:], 0.05, 1e-5, "dB")
+
+
+def _torch_or_skip():
+    try:
+        import torch  # noqa: F401
+
+        return torch
+    except ImportError:
+        raise _Skip("torch not installed on this machine")
+
+
+def _copy_torch_params(tt_module, torch_module):
+    """Copy a torch mirror module's params into the ttml module (same attr names)."""
+    import ml_dtypes
+
+    tsd = {k: v.detach().float().numpy() for k, v in torch_module.named_parameters()}
+    for name, t in tt_module.named_parameters():
+        key = name
+        if key.endswith(".gamma") or key == "gamma":
+            key = key[: -len("gamma")] + "weight"
+        elif key.endswith(".beta") or key == "beta":
+            key = key[: -len("beta")] + "bias"
+        src = tsd[key]
+        cur = t.to_numpy(ttnn.DataType.FLOAT32)
+        t.set_value(
+            ttml.autograd.Tensor.from_numpy(
+                src.reshape(cur.shape).astype(ml_dtypes.bfloat16), layout=ttnn.Layout.TILE
+            ).get_value()
+        )
+
+
+@check("full UNet block fwd+bwd parity vs reference_unet (attn block)")
+def t_block_parity():
+    torch = _torch_or_skip()
+    from edm_unet import UNetBlock as TTBlock
+    from reference_unet import UNetBlock as TorchBlock
+
+    rng = np.random.default_rng(8)
+    b, cin, cout, h, w, emb_dim = 2, 32, 64, 16, 16, 64
+    torch.manual_seed(0)
+    tblock = TorchBlock(cin, cout, emb_dim, attn=True, dropout=0.0)
+    tblock.eval()
+    ttblock = TTBlock(cin, cout, emb_dim, attn=True, dropout=0.0)
+    _copy_torch_params(ttblock, tblock)
+
+    x_np = rng.standard_normal((b, cin, h, w)).astype(np.float32)
+    emb_np = rng.standard_normal((b, 1, 1, emb_dim)).astype(np.float32)
+
+    ref = tblock(torch.from_numpy(x_np), torch.from_numpy(emb_np.reshape(b, emb_dim))).detach().numpy()
+    x = from_np(tokens(x_np), requires_grad=True)
+    emb = from_np(emb_np)
+    out = ttblock(x, emb, h, w)
+    got = untokens(to_np(out), h, w).transpose(0, 3, 1, 2)
+    assert_close(got, ref, 0.05, 0.08, "fwd")
+
+    # bwd parity on dX through an identical mse loss
+    xt = torch.from_numpy(x_np).requires_grad_(True)
+    loss_t = torch.nn.functional.mse_loss(
+        tblock(xt, torch.from_numpy(emb_np.reshape(b, emb_dim))), torch.zeros(b, cout, h, w)
+    )
+    loss_t.backward()
+    loss = ttml.ops.loss.mse_loss(out, from_np(np.zeros((b, 1, h * w, cout), dtype=np.float32)))
+    loss.backward(False)
+    rdx = xt.grad.numpy()
+    assert_close(
+        untokens(grad_np(x), h, w).transpose(0, 3, 1, 2), rdx, 0.10, 0.08 * max(abs(rdx).max(), 1e-8), "dX"
+    )
+
+
+@check("tiny full-UNet e2e: fwd + bwd + 5 optimizer steps decrease loss")
+def t_unet_end2end():
+    from edm import make_edm_batch_image, nchw_to_nhwc_tokens
+    from edm_unet import song_unet_tiny
+
+    rng = np.random.default_rng(0)
+    batch = 2
+    model = song_unet_tiny()
+    images = (rng.random((batch, 3, 32, 32), dtype=np.float32) * 2 - 1).astype(np.float32)
+    labels = rng.integers(0, 10, size=batch)
+    opt = ttml.optimizers.create_optimizer({"type": "AdamW", "lr": 1e-3}, model.parameters())
+
+    losses = []
+    for _ in range(5):
+        rng_step = np.random.default_rng(1)  # fixed batch -> loss must fall
+        net_in, feats, onehot, target = make_edm_batch_image(
+            images, labels, model.emb_dim, rng_step, null_class=10
+        )
+        opt.zero_grad()
+        pred = model(from_np(nchw_to_nhwc_tokens(net_in)), from_np(feats), from_np(onehot))
+        loss = ttml.ops.loss.mse_loss(pred, from_np(nchw_to_nhwc_tokens(target)))
+        loss.backward(False)
+        opt.step()
+        losses.append(float(to_np(loss).reshape(-1)[0]))
+        ttml.autograd.AutoContext.get_instance().reset_graph()
+    print(f"     losses: {[f'{v:.4f}' for v in losses]}", flush=True)
+    assert losses[-1] < losses[0], losses
+
+
+if __name__ == "__main__":
+    ttml.open_device_mesh((1, 1))
+    try:
+        for fn in [
+            t_im2col_raw,
+            t_permute,
+            t_moreh_group_norm_raw,
+            t_pool_upsample,
+            t_conv_fwd,
+            t_conv_bwd,
+            t_groupnorm_wrapper,
+            t_concat_channels,
+            t_block_parity,
+            t_unet_end2end,
+        ]:
+            fn()
+    finally:
+        if FAILURES:
+            print("FAILED:", FAILURES, flush=True)
+        else:
+            print("ALL EDM UNET PRIMITIVES OK" + (f" (skipped: {SKIPPED})" if SKIPPED else ""), flush=True)
+    sys.exit(1 if FAILURES else 0)

--- a/tt-train/sources/examples/dit/test_edm_primitives.py
+++ b/tt-train/sources/examples/dit/test_edm_primitives.py
@@ -375,6 +375,43 @@ def t_native_conv_parity():
         assert pcc_ng >= 0.999, f"native/golden diverge at C={cin}: PCC={pcc_ng}"
 
 
+@check("native dX: conv2d(dOut, flipT(W)) vs composite col2im vs golden")
+def t_conv_bwd_native():
+    import edm_ops
+    from edm_ops import Conv3x3Im2col
+
+    rng = np.random.default_rng(11)
+    saved_flag = edm_ops.NATIVE_CONV
+    try:
+        for cin, cout, h, w in [(32, 32, 16, 16), (128, 128, 32, 32)]:
+            b = 2
+            x_np = rng.standard_normal((b, h, w, cin)).astype(np.float32)
+            w_np = (rng.standard_normal((9 * cin, cout)) / math.sqrt(9 * cin)).astype(np.float32)
+            b_np = np.zeros(cout, dtype=np.float32)
+            g = mse_grad(np_conv3x3(x_np, w_np, b_np))  # fp32 golden upstream grad
+            rdx, rdw, rdb = np_conv3x3_bwd(x_np, w_np, g)
+
+            dxs = {}
+            for mode, flag in [("native", True), ("composite", False)]:
+                edm_ops.NATIVE_CONV = flag
+                x = from_np(x_np.reshape(b, 1, h * w, cin), requires_grad=True)
+                wt = from_np(w_np.reshape(1, 1, 9 * cin, cout), requires_grad=True)
+                bt = from_np(b_np.reshape(1, 1, 1, cout), requires_grad=True)
+                out = Conv3x3Im2col.apply(x, wt, bt, h, w)
+                loss = ttml.ops.loss.mse_loss(out, from_np(np.zeros((b, 1, h * w, cout), dtype=np.float32)))
+                loss.backward(False)
+                dxs[mode] = untokens(grad_np(x), h, w)
+                assert_close(dxs[mode], rdx, 0.08, 0.05 * abs(rdx).max(), f"{mode} dX C={cin}")
+                assert_close(
+                    grad_np(wt).reshape(9 * cin, cout), rdw, 0.08, 0.05 * abs(rdw).max(), f"{mode} dW C={cin}"
+                )
+                ttml.autograd.AutoContext.get_instance().reset_graph()
+            assert_close(dxs["native"], dxs["composite"], 0.05, 0.03 * abs(rdx).max(), f"native-vs-composite C={cin}")
+            print(f"     C={cin}@{h}x{w}: native dX == composite dX == golden", flush=True)
+    finally:
+        edm_ops.NATIVE_CONV = saved_flag
+
+
 @check("GroupNormMoreh wrapper fwd+bwd on tokens (C=64,16x16,G=16)")
 def t_groupnorm_wrapper():
     from edm_ops import GroupNormMoreh
@@ -397,6 +434,39 @@ def t_groupnorm_wrapper():
     assert_close(untokens(grad_np(x), h, w).transpose(0, 3, 1, 2), rdx, 0.08, 0.05 * abs(rdx).max(), "dx")
     assert_close(grad_np(gt).reshape(-1), rdgamma, 0.08, 0.05 * abs(rdgamma).max(), "dgamma")
     assert_close(grad_np(bt).reshape(-1), rdbeta, 0.08, 0.05 * abs(rdbeta).max(), "dbeta")
+
+
+@check("NHWC GroupNorm (pool-matmul) vs moreh vs numpy, fwd+bwd, 2 shapes")
+def t_nhwc_groupnorm():
+    from edm_ops import GroupNormMoreh, GroupNormNHWC
+
+    rng = np.random.default_rng(12)
+    for b, c, h, w, groups in [(4, 128, 32, 32, 32), (2, 64, 16, 16, 16)]:
+        x_np = rng.standard_normal((b, c, h, w)).astype(np.float32)
+        gamma = (rng.standard_normal(c) * 0.3 + 1.0).astype(np.float32)
+        beta = (rng.standard_normal(c) * 0.1).astype(np.float32)
+        ref, _, _ = np_group_norm(x_np, groups, gamma, beta)
+        g_nchw = untokens(mse_grad(tokens(ref)), h, w).transpose(0, 3, 1, 2)
+        rdx, rdgamma, rdbeta = np_group_norm_bwd(x_np, groups, gamma, g_nchw)
+
+        outs = {}
+        for name, fn in [("nhwc", GroupNormNHWC), ("moreh", GroupNormMoreh)]:
+            x = from_np(tokens(x_np), requires_grad=True)
+            gt = from_np(gamma.reshape(1, 1, 1, c), requires_grad=True)
+            bt = from_np(beta.reshape(1, 1, 1, c), requires_grad=True)
+            y = fn.apply(x, gt, bt, groups, h, w)
+            outs[name] = to_np(y)
+            assert_close(untokens(outs[name], h, w), tokens(ref).reshape(b, h, w, c), 0.03, 0.05, f"{name} fwd C={c}")
+            loss = ttml.ops.loss.mse_loss(y, from_np(np.zeros((b, 1, h * w, c), dtype=np.float32)))
+            loss.backward(False)
+            assert_close(
+                untokens(grad_np(x), h, w).transpose(0, 3, 1, 2), rdx, 0.08, 0.05 * abs(rdx).max(), f"{name} dx C={c}"
+            )
+            assert_close(grad_np(gt).reshape(-1), rdgamma, 0.08, 0.05 * abs(rdgamma).max(), f"{name} dgamma C={c}")
+            assert_close(grad_np(bt).reshape(-1), rdbeta, 0.08, 0.05 * abs(rdbeta).max(), f"{name} dbeta C={c}")
+            ttml.autograd.AutoContext.get_instance().reset_graph()
+        assert_close(outs["nhwc"], outs["moreh"], 0.03, 0.05, f"nhwc-vs-moreh fwd C={c}")
+        print(f"     C={c} G={groups} {h}x{w}: NHWC == moreh == golden (fwd+bwd)", flush=True)
 
 
 @check("ConcatChannels fwd+bwd (skip concat / slice)")
@@ -525,7 +595,9 @@ if __name__ == "__main__":
             t_conv_bwd,
             t_native_conv_probe,
             t_native_conv_parity,
+            t_conv_bwd_native,
             t_groupnorm_wrapper,
+            t_nhwc_groupnorm,
             t_concat_channels,
             t_block_parity,
             t_unet_end2end,

--- a/tt-train/sources/examples/dit/test_reference_unet.py
+++ b/tt-train/sources/examples/dit/test_reference_unet.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU validation for reference_unet.py (no device needed).
+
+    python test_reference_unet.py [--full-overfit]
+
+Checks, cheapest first:
+  1. im2col/col2im numpy implementation (the EXACT algorithm edm_ops.py runs
+     on device, same ROW_ORDER) matches torch F.conv2d forward AND autograd
+     gradients — this pins the flattened-weight convention.
+  2. Full EDM CIFAR-10 config parameter count is printed and must land in
+     55M..62M.
+  3. Shape walk: full config forward prints every block's output shape.
+  4. Single-batch EDM overfit on random data: 200 Adam steps, loss must at
+     least halve (reduced config by default for runtime; --full-overfit runs
+     the 56M model).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from edm import make_edm_batch_image
+from reference_unet import Conv3x3Flat, TorchSongUNet, param_count
+
+FAILURES: list[str] = []
+
+
+def check(name, fn):
+    try:
+        fn()
+        print(f"OK   {name}", flush=True)
+    except Exception as e:
+        print(f"FAIL {name}: {e}", flush=True)
+        import traceback
+
+        traceback.print_exc()
+        FAILURES.append(name)
+
+
+# ---------------------------------------------------------------------------
+# 1. numpy im2col / col2im — the device algorithm, validated against torch
+# ---------------------------------------------------------------------------
+
+
+def numpy_im2col(x_nhwc: np.ndarray) -> np.ndarray:
+    """[B,H,W,C] -> [B*H*W, 9C]; slice order (kh, kw) row-major == ROW_ORDER."""
+    b, h, w, c = x_nhwc.shape
+    p = np.pad(x_nhwc, ((0, 0), (1, 1), (1, 1), (0, 0)))
+    views = [p[:, kh : kh + h, kw : kw + w, :] for kh in range(3) for kw in range(3)]
+    return np.concatenate(views, axis=-1).reshape(b * h * w, 9 * c)
+
+
+def numpy_conv3x3_fwd(x_nhwc, w_flat, bias):
+    b, h, w, _ = x_nhwc.shape
+    return (numpy_im2col(x_nhwc) @ w_flat + bias).reshape(b, h, w, -1)
+
+
+def numpy_conv3x3_bwd(x_nhwc, w_flat, g_nhwc):
+    """Returns (dx [B,H,W,C], dW [9C,Cout], db [Cout]) — mirrors edm_ops backward."""
+    b, h, w, c = x_nhwc.shape
+    cout = w_flat.shape[1]
+    g2 = g_nhwc.reshape(b * h * w, cout)
+    cols = numpy_im2col(x_nhwc)
+    dw = cols.T @ g2
+    db = g2.sum(axis=0)
+    dcols = (g2 @ w_flat.T).reshape(b, h, w, 9 * c)
+    dp = np.zeros((b, h + 2, w + 2, c), dtype=x_nhwc.dtype)
+    for kh in range(3):
+        for kw in range(3):
+            k = kh * 3 + kw
+            dp[:, kh : kh + h, kw : kw + w, :] += dcols[..., k * c : (k + 1) * c]
+    return dp[:, 1 : h + 1, 1 : w + 1, :], dw, db
+
+
+def t_im2col_row_order():
+    rng = np.random.default_rng(0)
+    b, h, w, cin, cout = 2, 8, 8, 5, 7  # deliberately non-tile shapes
+    x = rng.standard_normal((b, cin, h, w)).astype(np.float32)
+    conv = Conv3x3Flat(cin, cout)
+    with torch.no_grad():
+        golden = conv(torch.from_numpy(x)).numpy()
+    got = numpy_conv3x3_fwd(
+        np.ascontiguousarray(x.transpose(0, 2, 3, 1)),
+        conv.weight.detach().numpy(),
+        conv.bias.detach().numpy(),
+    ).transpose(0, 3, 1, 2)
+    err = np.abs(got - golden).max()
+    assert err < 1e-4, f"im2col fwd mismatch, max err {err}"
+
+
+def t_col2im_grads():
+    rng = np.random.default_rng(1)
+    b, h, w, cin, cout = 2, 6, 6, 4, 3
+    x = torch.from_numpy(rng.standard_normal((b, cin, h, w)).astype(np.float32)).requires_grad_(True)
+    conv = Conv3x3Flat(cin, cout)
+    g = torch.from_numpy(rng.standard_normal((b, cout, h, w)).astype(np.float32))
+    out = conv(x)
+    out.backward(g)
+    x_nhwc = x.detach().numpy().transpose(0, 2, 3, 1)
+    g_nhwc = g.numpy().transpose(0, 2, 3, 1)
+    dx, dw, db = numpy_conv3x3_bwd(x_nhwc, conv.weight.detach().numpy(), g_nhwc)
+    e_dx = np.abs(dx.transpose(0, 3, 1, 2) - x.grad.numpy()).max()
+    e_dw = np.abs(dw - conv.weight.grad.numpy()).max()
+    e_db = np.abs(db - conv.bias.grad.numpy()).max()
+    assert e_dx < 1e-4 and e_dw < 1e-3 and e_db < 1e-3, (e_dx, e_dw, e_db)
+
+
+# ---------------------------------------------------------------------------
+# 2 + 3. full-config param count and shape walk
+# ---------------------------------------------------------------------------
+
+
+def t_param_count_and_shapes():
+    torch.manual_seed(0)
+    model = TorchSongUNet()  # exact EDM CIFAR-10 config
+    n = param_count(model)
+    print(f"     full CIFAR-10 SongUNet parameters: {n:,} ({n/1e6:.2f}M)", flush=True)
+    assert 55e6 < n < 62e6, f"param count {n} outside 55M..62M"
+    model.eval()
+    x = torch.randn(2, 3, 32, 32)
+    feats = torch.randn(2, 1, 1, model.emb_dim)
+    onehot = F.one_hot(torch.tensor([3, 7]), 11).float().reshape(2, 1, 1, 11)
+    with torch.no_grad():
+        out = model(x, feats, onehot, verbose=True)
+    assert out.shape == (2, 3, 32, 32), out.shape
+
+
+# ---------------------------------------------------------------------------
+# 4. single-batch EDM overfit
+# ---------------------------------------------------------------------------
+
+
+def t_overfit(full: bool):
+    torch.manual_seed(0)
+    if full:
+        model, batch = TorchSongUNet(dropout=0.0), 4
+    else:  # same structure, smaller widths, still every block kind
+        model = TorchSongUNet(model_channels=32, num_blocks=2, dropout=0.0)
+        batch = 4
+    model.train()
+    rng = np.random.default_rng(0)
+    images = (rng.random((batch, 3, 32, 32), dtype=np.float32) * 2 - 1).astype(np.float32)
+    labels = rng.integers(0, 10, size=batch)
+    net_in, feats, onehot, target = make_edm_batch_image(
+        images, labels, model.emb_dim, np.random.default_rng(1), null_class=10
+    )
+    xt = torch.from_numpy(net_in)
+    ft = torch.from_numpy(feats)
+    ot = torch.from_numpy(onehot)
+    tt = torch.from_numpy(target)
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+    losses = []
+    t0 = time.time()
+    for step in range(200):
+        opt.zero_grad()
+        loss = F.mse_loss(model(xt, ft, ot), tt)
+        loss.backward()
+        opt.step()
+        losses.append(loss.item())
+        if step % 25 == 0:
+            print(f"     step {step:4d} loss {loss.item():.5f}", flush=True)
+    print(f"     step  199 loss {losses[-1]:.5f}  ({time.time()-t0:.1f}s)", flush=True)
+    assert losses[-1] < 0.5 * losses[0], f"loss did not halve: {losses[0]:.5f} -> {losses[-1]:.5f}"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--full-overfit", action="store_true", help="overfit the full 56M model (slow)")
+    args = ap.parse_args()
+
+    check("im2col ROW_ORDER fwd vs F.conv2d", t_im2col_row_order)
+    check("col2im backward vs torch autograd", t_col2im_grads)
+    check("param count + shape walk (full config)", t_param_count_and_shapes)
+    check(f"single-batch EDM overfit ({'full' if args.full_overfit else 'reduced'})", lambda: t_overfit(args.full_overfit))
+
+    if FAILURES:
+        print("FAILED:", FAILURES, flush=True)
+    else:
+        print("ALL REFERENCE UNET CHECKS OK", flush=True)
+    sys.exit(1 if FAILURES else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tt-train/sources/examples/dit/train_dit_cifar.py
+++ b/tt-train/sources/examples/dit/train_dit_cifar.py
@@ -176,6 +176,10 @@ def main():
     ap.add_argument("-c", "--config", required=True, help="training config yaml")
     ap.add_argument("--overfit-batch", action="store_true", help="repeat one fixed batch (bringup sanity)")
     ap.add_argument("--max-steps", type=int, default=None, help="override training_config.max_steps")
+    ap.add_argument("--run-name", default=None, help="stable run dir name (required to resume across jobs)")
+    ap.add_argument("--resume", action="store_true", help="resume from <run_dir>/resume.ckpt if present")
+    ap.add_argument("--max-seconds", type=int, default=0,
+                    help="time budget: save resume.ckpt and exit cleanly once exceeded (segmented runs)")
     args = ap.parse_args()
 
     cfg = load_config(args.config)
@@ -200,9 +204,12 @@ def main():
     batch_size = tc["batch_size"]
     max_steps = args.max_steps or tc["max_steps"]
 
-    run_name = f"dit_d{model_cfg['embedding_dim']}x{model_cfg['num_blocks']}_p{model_cfg['patch_size']}_b{batch_size}_{int(time.time())}"
+    run_name = args.run_name or (
+        f"dit_d{model_cfg['embedding_dim']}x{model_cfg['num_blocks']}_p{model_cfg['patch_size']}_b{batch_size}_{int(time.time())}"
+    )
     run_dir = os.path.join(tc["output_dir"], run_name)
     os.makedirs(run_dir, exist_ok=True)
+    resume_path = os.path.join(run_dir, "resume.ckpt")
 
     wandb_run = None
     if lc.get("wandb", False):
@@ -243,10 +250,36 @@ def main():
     sample_every = ec.get("sample_interval", 0)
     ckpt_every = tc.get("model_save_interval", 0)
 
+    # Resume: restore weights + optimizer via ttml.checkpointing (atomic file,
+    # NATIVE-precision gather; immune to the to_numpy stale-cache issue), plus
+    # step / EMA / dataloader-RNG state from the opaque header.
+    start_step = 0
+    if args.resume and os.path.isfile(resume_path):
+        from ttml.checkpointing import load_checkpoint
+
+        header = load_checkpoint(resume_path, model_params=model.parameters(), optimizer=opt)
+        start_step = int(header["step"])
+        rng.bit_generator.state = header["rng_state"]
+        if ema is not None and header.get("ema_state") is not None:
+            ema.state = header["ema_state"]
+        print(f"resumed from {resume_path} at step {start_step}", flush=True)
+
+    def save_resume(step):
+        from ttml.checkpointing import save_checkpoint as ttml_save
+
+        ttml_save(
+            resume_path,
+            header={"step": step, "rng_state": rng.bit_generator.state,
+                    "ema_state": ema.state if ema is not None else None},
+            model_params=model.parameters(),
+            optimizer=opt,
+        )
+
     model.train()
+    t_start = time.time()
     t0 = time.time()
     ema_loss = None
-    for step in range(1, max_steps + 1):
+    for step in range(start_step + 1, max_steps + 1):
         if args.overfit_batch:
             batch_rng = np.random.default_rng(123)
             idx = np.arange(batch_size)
@@ -313,8 +346,16 @@ def main():
                             composer=loss_composer, num_devices=dp_size)
             if ema is not None:
                 save_checkpoint(model, os.path.join(run_dir, f"ckpt_ema_{step:06d}.npz"), state=ema.state)
+            save_resume(step)
+
+        if args.max_seconds and time.time() - t_start > args.max_seconds:
+            save_resume(step)
+            print(f"SEGMENT_END step={step} of {max_steps}", flush=True)
+            return
 
     save_checkpoint(model, os.path.join(run_dir, "ckpt_final.npz"), composer=loss_composer, num_devices=dp_size)
+    save_resume(max_steps)
+    print(f"TRAINING_COMPLETE step={max_steps}", flush=True)
     if ema is not None:
         save_checkpoint(model, os.path.join(run_dir, "ckpt_ema_final.npz"), state=ema.state)
     print(f"done; artifacts in {run_dir}")

--- a/tt-train/sources/examples/dit/train_dit_cifar.py
+++ b/tt-train/sources/examples/dit/train_dit_cifar.py
@@ -81,12 +81,14 @@ def _param_to_numpy(t, composer=None, num_devices: int = 1):
     # precision=FULL runs a device-side typecast whose fp32 view is CACHED and
     # never refreshed (tt-train issue #41657) — with it, every checkpoint/EMA
     # read after the first silently returns stale (init-time) weights.
-    arr = t.to_numpy(None, composer, ttml.autograd.PreferredPrecision.NATIVE).astype(np.float32)
     if composer is not None and num_devices > 1:
-        # Replicated param read via concat composer stacks the per-device
-        # copies along dim 0; keep the first replica.
-        arr = arr[: arr.shape[0] // num_devices]
-    return arr
+        # Replicated params: reading via a concat composer pulls ALL replicas
+        # off the mesh (~5s for a DiT-S param set). Read one shard instead.
+        import ttnn
+
+        shard = ttnn.get_device_tensors(t.get_value(ttml.autograd.PreferredPrecision.NATIVE))[0]
+        return ttnn.to_torch(shard).float().numpy()
+    return t.to_numpy(None, None, ttml.autograd.PreferredPrecision.NATIVE).astype(np.float32)
 
 
 def save_checkpoint(model, path: str, state: dict | None = None, composer=None, num_devices: int = 1):

--- a/tt-train/sources/examples/dit/train_dit_cifar.py
+++ b/tt-train/sources/examples/dit/train_dit_cifar.py
@@ -28,6 +28,7 @@ import ttml
 from ttml.common.config import load_config
 
 from diffusion import DiffusionSchedule, make_training_batch, one_hot, timestep_features, patchify, unpatchify
+from edm import make_edm_batch
 from dit_ttml import DiT
 
 CIFAR_URL = "https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz"
@@ -234,13 +235,16 @@ def main():
     )
     cfg_drop_prob = dc.get("cfg_drop_prob", 0.1)
     hflip = bool(tc.get("hflip_augment", False))
+    recipe = dc.get("recipe", "ddpm")  # "ddpm" | "edm" (Karras et al. 2022, F-space MSE)
 
     opt = ttml.optimizers.create_optimizer(tc["optimizer"], model.parameters())
     ctx = ttml.autograd.AutoContext.get_instance()
     rng = np.random.default_rng(seed)
 
     base_lr = tc["optimizer"]["lr"]
-    use_cosine = tc.get("lr_schedule", "constant") == "cosine"
+    lr_schedule = tc.get("lr_schedule", "constant")
+    use_cosine = lr_schedule == "cosine"
+    use_warmup_const = lr_schedule == "warmup_constant"
     warmup = tc.get("warmup_steps", 500)
     ema = None
     if tc.get("ema_decay", 0):
@@ -290,10 +294,16 @@ def main():
             batch_rng = rng
             idx = rng.integers(0, images.shape[0], size=batch_size)
 
-        tokens, t_feats, onehot, target = make_training_batch(
-            images[idx], labels[idx], schedule, patch, model.dim, batch_rng,
-            cfg_drop_prob=cfg_drop_prob, null_class=num_classes, hflip=hflip,
-        )
+        if recipe == "edm":
+            tokens, t_feats, onehot, target = make_edm_batch(
+                images[idx], labels[idx], patch, model.dim, batch_rng,
+                cfg_drop_prob=cfg_drop_prob, null_class=num_classes, hflip=hflip,
+            )
+        else:
+            tokens, t_feats, onehot, target = make_training_batch(
+                images[idx], labels[idx], schedule, patch, model.dim, batch_rng,
+                cfg_drop_prob=cfg_drop_prob, null_class=num_classes, hflip=hflip,
+            )
 
         import ttnn
 
@@ -304,6 +314,8 @@ def main():
 
         if use_cosine:
             opt.set_lr(cosine_lr(step, max_steps, base_lr, warmup))
+        elif use_warmup_const:
+            opt.set_lr(base_lr * min(1.0, step / max(1, warmup)))
 
         opt.zero_grad()
         pred = model(dev(tokens), dev(t_feats), dev(onehot))

--- a/tt-train/sources/examples/dit/train_dit_cifar.py
+++ b/tt-train/sources/examples/dit/train_dit_cifar.py
@@ -231,6 +231,7 @@ def main():
         beta_end=dc.get("beta_end", 2e-2),
     )
     cfg_drop_prob = dc.get("cfg_drop_prob", 0.1)
+    hflip = bool(tc.get("hflip_augment", False))
 
     opt = ttml.optimizers.create_optimizer(tc["optimizer"], model.parameters())
     ctx = ttml.autograd.AutoContext.get_instance()
@@ -289,7 +290,7 @@ def main():
 
         tokens, t_feats, onehot, target = make_training_batch(
             images[idx], labels[idx], schedule, patch, model.dim, batch_rng,
-            cfg_drop_prob=cfg_drop_prob, null_class=num_classes,
+            cfg_drop_prob=cfg_drop_prob, null_class=num_classes, hflip=hflip,
         )
 
         import ttnn

--- a/tt-train/sources/ttml/core/mesh_device.cpp
+++ b/tt-train/sources/ttml/core/mesh_device.cpp
@@ -4,6 +4,8 @@
 
 #include "mesh_device.hpp"
 
+#include <cstdlib>
+
 #include "hostdevcommon/common_values.hpp"
 #include "ttnn/distributed/api.hpp"
 #include "ttnn/distributed/types.hpp"
@@ -13,7 +15,13 @@ namespace ttml::core {
 MeshDevice::MeshDevice(const tt::tt_metal::distributed::MeshShape& shape, const std::vector<int>& device_ids) :
     m_mesh_device(ttnn::distributed::open_mesh_device(
         shape,
-        DEFAULT_L1_SMALL_SIZE,
+        // TTML_L1_SMALL_SIZE opts into a nonzero L1_SMALL region, required by
+        // ttnn ops using the sliding-window halo path (conv2d, pool, upsample).
+        // Default (0) is unchanged for existing transformer workloads.
+        [] {
+            const char* env = std::getenv("TTML_L1_SMALL_SIZE");
+            return env != nullptr ? static_cast<size_t>(std::stoul(env)) : static_cast<size_t>(DEFAULT_L1_SMALL_SIZE);
+        }(),
         DEFAULT_TRACE_REGION_SIZE,
         /* num_command_queues=*/1,
         tt::tt_metal::DispatchCoreConfig{},


### PR DESCRIPTION
### Description
Stacked on #53124. Adds exact resume to the DiT trainer and a self-chaining segment runner for **voluntary preemption**: train in short `--nice=10000` slices that release the node between segments, so other users' queued jobs always cut in — cooperative low-priority tenancy on clusters where slurm preemption is off.

### Changes Made
- [x] **New Feature:** `--run-name` / `--resume` / `--max-seconds` on `train_dit_cifar.py`. Resume checkpoints use `ttml.checkpointing` (atomic replace, optimizer state via `get_state_dict`, NATIVE-precision gather) with step, EMA state, and dataloader RNG state in the header — a resumed run continues the exact batch sequence.
- [x] **New Feature:** `segment_runner.sbatch` — env-parameterized chain: train `SEGMENT_SECONDS`, save resume, exit, resubmit itself; stops on `TRAINING_COMPLETE` or on a crashed segment; sweeps node-local caches each segment.

### Testing
- [x] Syntax/flow reviewed; single-run behavior unchanged when flags are unset
- [ ] On-device: segment chain end-to-end (resume → loss continuity) — pending one cluster session before undrafting

### Additional Context
Groundwork for elastic multi-node scheduling at secondary priority (grow/shrink data-parallel width between segments based on what's idle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tt-train-dit-resume)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tt-train-dit-resume)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=tt-train-dit-resume)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:tt-train-dit-resume)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tt-train-dit-resume)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tt-train-dit-resume)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=tt-train-dit-resume)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:tt-train-dit-resume)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tt-train-dit-resume)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tt-train-dit-resume)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tt-train-dit-resume)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tt-train-dit-resume)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tt-train-dit-resume)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tt-train-dit-resume)