### PR TITLE
[Bug fix] Fix teardown after ttnn.setup_fast_dispatch

### DIFF
--- a/tt_metal/distributed/dispatch_context.cpp
+++ b/tt_metal/distributed/dispatch_context.cpp
@@ -176,6 +176,10 @@ void DispatchContext::terminate_fast_dispatch(distributed::MeshDevice* mesh_devi
         device->command_queues_.clear();
     }
 
+    // Teardown dispatch firmware so is_dispatch_firmware_active() returns false.
+    // This must happen before set_fast_dispatch_mode(false) so profiler sync can run correctly.
+    device_manager->teardown_dispatch_firmware();
+
     fast_dispatch_enabled_ = false;
 
     // Disable Fast Dispatch and reinitialize dispatch managers to pick up SD core descriptor

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -526,6 +526,17 @@ void DeviceManager::initialize_dispatch_firmware(bool force_recreate_topology) {
     init_done_.insert(DispatchKernelInitializer::key);
 }
 
+void DeviceManager::teardown_dispatch_firmware() {
+    // This function is used by DispatchContext when terminating manual FD setup.
+    // DispatchContext already terminates command queues manually, so we just need to
+    // mark the dispatch firmware as torn down without re-running teardown logic.
+    if (init_done_.contains(DispatchKernelInitializer::key)) {
+        auto* dispatch_initializer =
+            dynamic_cast<DispatchKernelInitializer*>(initializers_[DispatchKernelInitializer::key].get());
+        dispatch_initializer->mark_as_torn_down(init_done_);
+    }
+}
+
 const std::unordered_set<CoreCoord>& DeviceManager::get_virtual_dispatch_cores(ChipId dev_id) const {
     if (!initializers_.contains(DispatchKernelInitializer::key)) {
         // Dispatch firmware is not initialized in minimal mode

--- a/tt_metal/impl/device/device_manager.hpp
+++ b/tt_metal/impl/device/device_manager.hpp
@@ -56,6 +56,7 @@ public:
     // Initialize dispatch firmware (compile + configure device CQs). This may be used by dispatchcontext to
     // re-enable fast dispatch after it was disabled at runtime.
     void initialize_dispatch_firmware(bool force_recreate_topology);
+    void teardown_dispatch_firmware();
     void reset_dispatch_topology();
     // API needed due to Issue #19729
     std::size_t get_max_num_eth_cores_across_all_devices() const;

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
@@ -114,6 +114,14 @@ void DispatchKernelInitializer::teardown(std::unordered_set<InitializerKey>& ini
     init_done.erase(key);
 }
 
+void DispatchKernelInitializer::mark_as_torn_down(std::unordered_set<InitializerKey>& init_done) {
+    // Used by DispatchContext when it has already terminated command queues manually.
+    // Just clear state without re-running teardown logic.
+    devices_.clear();
+    initialized_ = false;
+    init_done.erase(key);
+}
+
 bool DispatchKernelInitializer::is_initialized() const { return initialized_; }
 
 void DispatchKernelInitializer::compile_dispatch_kernels() {

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.hpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.hpp
@@ -26,6 +26,9 @@ public:
     void init(const std::vector<Device*>& devices, const std::unordered_set<InitializerKey>& init_done) override;
     void configure() override;
     void teardown(std::unordered_set<InitializerKey>& init_done) override;
+    // Mark as torn down without running teardown logic. Used by DispatchContext when
+    // it has already terminated command queues and just needs to clear the initialized flag.
+    void mark_as_torn_down(std::unordered_set<InitializerKey>& init_done);
     // Returns true if fast dispatch is enabled and has been configured
     bool is_initialized() const override;
     const std::unordered_set<CoreCoord>& get_virtual_dispatch_cores(ChipId dev_id) const;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

`DispatchContext::terminate_fast_dispatch()` cleared the command queues and flipped
`fast_dispatch_enabled_`, but never told `DeviceManager` that the dispatch firmware was gone —
`DispatchKernelInitializer` kept `initialized_ = true` and its key in `init_done_`, so
`is_dispatch_firmware_active()` still returned `true` after teardown.

That state is read by the profiler, which asserts the opposite on the sync path:

TT_ASSERT(!device_manager()->is_dispatch_firmware_active(),
          "Profiler sync is not supported with fast dispatch enabled!");

So tearing down a manual `ttnn.setup_fast_dispatch()` session left the dispatch-firmware state
stale and tripped profiler sync on close.

### Notes for reviewers

`terminate_fast_dispatch()` already terminates the command queues itself, so re-running
`DispatchKernelInitializer::teardown()` would duplicate that work. Instead this adds
`mark_as_torn_down()`, which only clears the tracking state (`devices_`, `initialized_`, and the
`init_done` key), reached via a new `DeviceManager::teardown_dispatch_firmware()`.

Placement matters: the call sits *before* `fast_dispatch_enabled_ = false` and the
`set_fast_dispatch_mode(false)` / dispatch-manager reinit below it, so profiler sync sees the
correct state. No behaviour change for anything that doesn't use manual FD setup/teardown —
the normal `teardown()` path is untouched.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadeem/fix_setup_fast_dispatch_teardown_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadeem/fix_setup_fast_dispatch_teardown_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadeem/fix_setup_fast_dispatch_teardown_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadeem/fix_setup_fast_dispatch_teardown_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadeem/fix_setup_fast_dispatch_teardown_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadeem/fix_setup_fast_dispatch_teardown_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadeem/fix_setup_fast_dispatch_teardown_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadeem/fix_setup_fast_dispatch_teardown_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadeem/fix_setup_fast_dispatch_teardown_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadeem/fix_setup_fast_dispatch_teardown_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadeem/fix_setup_fast_dispatch_teardown_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadeem/fix_setup_fast_dispatch_teardown_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadeem/fix_setup_fast_dispatch_teardown_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadeem/fix_setup_fast_dispatch_teardown_2)