### PR TITLE
[Bug fix] Set resolved_dispatch_core_type in the offline compile enumerator

### DIFF
--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -16,6 +16,9 @@
   cmd: |
     [ "$ARCH_NAME" = "wormhole_b0" ] && export TT_METAL_GTEST_ETH_DISPATCH=1
     ./build/test/tt_metal/unit_tests_dispatch --gtest_filter='-*NIGHTLY_*:RealtimeProfiler*'
+    # Offline-compile hit tests: AllSupportedProducts artifacts must load under the
+    # live ETH fast-dispatch build key without JIT (#53160).
+    ./build/test/tt_metal/unit_tests_api --gtest_filter='*Precompiled*'
   skus:
     wh_n150_civ2:
       timeout: 10

--- a/tests/tt_metal/tt_metal/api/test_offline_kernel_compile.cpp
+++ b/tests/tt_metal/tt_metal/api/test_offline_kernel_compile.cpp
@@ -14,6 +14,7 @@
 #include <variant>
 #include <vector>
 
+#include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include <tt-metalium/experimental/offline_kernel_compile.hpp>
 #include <tt-metalium/experimental/mock_device/mock_device.hpp>
 #include <tt-metalium/host_api.hpp>
@@ -22,6 +23,7 @@
 #include <tt-metalium/tile.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include "device_fixture.hpp"
+#include "impl/context/metal_context.hpp"
 #include "jit_build/build.hpp"
 #include "llrt/rtoptions.hpp"
 #include "tt_metal/jit_build/build_cache_telemetry.hpp"
@@ -43,6 +45,17 @@ using CBCompileConfig = experimental::OfflineKernelCompileParams::CBCompileConfi
 // which a mock fixture forces to Mock) and skip the offline-compile tests until that path can build
 // (or locate) firmware for the simulator build_key.
 bool offline_compile_unsupported_under_simulator() { return llrt::RunTimeOptions{}.is_simulator_or_emulated(); }
+
+// CreateKernel injects ControlPlane::get_fabric_kernel_defines() (ROUTING_MODE,
+// FABRIC_1D_PKT_HDR_EXTENSION_WORDS, ...) into every data-movement and ethernet kernel whenever a
+// fabric config is active.
+// CompileKernelOffline cannot reproduce them: the values derive from live cluster topology (hop
+// counts feed the packet-header sizing) and it has no ControlPlane by construction.
+// TODO(#53160): emit fabric-define variants offline, or stop keying non-fabric kernels on fabric
+// defines, then drop this skip.
+bool offline_compile_unsupported_with_fabric_defines() {
+    return !MetalContext::instance().get_control_plane().get_fabric_kernel_defines().empty();
+}
 
 struct ScopedTempDir {
     explicit ScopedTempDir(const std::string& tag) {
@@ -249,6 +262,10 @@ TEST_F(AnyDispatchMeshDeviceFixture, RuntimePrecompiledHitLoadsWithoutJit) {
         GTEST_SKIP() << "CompileKernelOffline has no precompiled firmware for the simulator build_key "
                         "(multi-erisc disabled); skipping under TT_METAL_SIMULATOR.";
     }
+    if (offline_compile_unsupported_with_fabric_defines()) {
+        GTEST_SKIP() << "Fabric is active, so CreateKernel injects fabric defines that CompileKernelOffline "
+                        "cannot reproduce; the offline bucket is keyed on a different compile hash.";
+    }
     auto* device = this->devices_.at(0)->get_devices().at(0);
 
     ScopedTempDir precompiled_root("tt_metal_precompiled_seed_hit");
@@ -267,6 +284,10 @@ TEST_F(AnyDispatchMeshDeviceFixture, RuntimePrecompiledHitWithCbMetadataLoadsWit
     if (offline_compile_unsupported_under_simulator()) {
         GTEST_SKIP() << "CompileKernelOffline has no precompiled firmware for the simulator build_key "
                         "(multi-erisc disabled); skipping under TT_METAL_SIMULATOR.";
+    }
+    if (offline_compile_unsupported_with_fabric_defines()) {
+        GTEST_SKIP() << "Fabric is active, so CreateKernel injects fabric defines that CompileKernelOffline "
+                        "cannot reproduce; the offline bucket is keyed on a different compile hash.";
     }
     // Verifies the CBCompileConfigsFromProgram + CompileKernelOffline path produces a
     // bucket whose hash inputs (build_key + hlk_desc CB metadata + kernel compute hash)

--- a/tests/tt_metal/tt_metal/api/test_offline_kernel_compile.cpp
+++ b/tests/tt_metal/tt_metal/api/test_offline_kernel_compile.cpp
@@ -240,7 +240,11 @@ TEST_F(OfflineKernelCompileMockFixture, CompileKernelOfflineEmitsExpectedSubtree
 
 }  // namespace
 
-TEST_F(MeshDeviceFixture, RuntimePrecompiledHitLoadsWithoutJit) {
+// AnyDispatchMeshDeviceFixture (not MeshDeviceFixture) so these tests run under
+// fast dispatch, including TT_METAL_GTEST_ETH_DISPATCH=1. MeshDeviceFixture
+// requires slow dispatch, which always resolves to WORKER and cannot catch an
+// offline/runtime ETH build-key mismatch (#53160).
+TEST_F(AnyDispatchMeshDeviceFixture, RuntimePrecompiledHitLoadsWithoutJit) {
     if (offline_compile_unsupported_under_simulator()) {
         GTEST_SKIP() << "CompileKernelOffline has no precompiled firmware for the simulator build_key "
                         "(multi-erisc disabled); skipping under TT_METAL_SIMULATOR.";
@@ -259,7 +263,7 @@ TEST_F(MeshDeviceFixture, RuntimePrecompiledHitLoadsWithoutJit) {
     EXPECT_EQ(jit_srcs.delta(), 0u);
 }
 
-TEST_F(MeshDeviceFixture, RuntimePrecompiledHitWithCbMetadataLoadsWithoutJit) {
+TEST_F(AnyDispatchMeshDeviceFixture, RuntimePrecompiledHitWithCbMetadataLoadsWithoutJit) {
     if (offline_compile_unsupported_under_simulator()) {
         GTEST_SKIP() << "CompileKernelOffline has no precompiled firmware for the simulator build_key "
                         "(multi-erisc disabled); skipping under TT_METAL_SIMULATOR.";
@@ -307,7 +311,7 @@ TEST_F(MeshDeviceFixture, RuntimePrecompiledHitWithCbMetadataLoadsWithoutJit) {
     EXPECT_EQ(jit_srcs.delta(), 0u);
 }
 
-TEST_F(MeshDeviceFixture, RuntimeMissingPrecompiledFallsBackToJit) {
+TEST_F(AnyDispatchMeshDeviceFixture, RuntimeMissingPrecompiledFallsBackToJit) {
     const auto precompiled_config = make_precompiled_config(kMissingPrecompiledRoot, BinaryPolicy::JitCompile);
     Program program = create_precompiled_program(precompiled_config);
     auto* device = this->devices_.at(0)->get_devices().at(0);
@@ -318,7 +322,7 @@ TEST_F(MeshDeviceFixture, RuntimeMissingPrecompiledFallsBackToJit) {
     EXPECT_GT(jit_srcs.delta(), 0u);
 }
 
-TEST_F(MeshDeviceFixture, RuntimeMissingPrecompiledErrorsOnPolicyError) {
+TEST_F(AnyDispatchMeshDeviceFixture, RuntimeMissingPrecompiledErrorsOnPolicyError) {
     const auto precompiled_config = make_precompiled_config(kMissingPrecompiledRoot, BinaryPolicy::Error);
     Program program = create_precompiled_program(precompiled_config);
     auto* device = this->devices_.at(0)->get_devices().at(0);

--- a/tt_metal/impl/dispatch/dispatch_core_common.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "impl/dispatch/dispatch_core_common.hpp"
+#include <tt_stl/assert.hpp>
 #include <tt_stl/reflection.hpp>
 #include "dispatch_core_common.hpp"
 #include "impl/context/metal_context.hpp"
@@ -57,6 +58,14 @@ CoreType get_core_type_from_config(const DispatchCoreConfig& config) {
 CoreType resolve_dispatch_core_type(
     tt::tt_metal::MetalEnvImpl& env, ChipId device_id, const DispatchCoreConfig& dispatch_core_config) {
     return ::tt::tt_metal::detail::resolve_dispatch_core_type(env, device_id, dispatch_core_config);
+}
+
+CoreType resolve_dispatch_core_type(tt::ARCH arch, DispatchCoreType dispatch_core_type) {
+    TT_FATAL(
+        arch != tt::ARCH::QUASAR,
+        "Offline dispatch-core resolution is not implemented for Quasar; DISPATCH vs WORKER "
+        "depends on the SoC descriptor and TT_METAL_TENSIX_DISPATCH_CORES");
+    return get_core_type_from_config(DispatchCoreConfig{dispatch_core_type});
 }
 
 DispatchCoreConfig get_dispatch_core_config() {

--- a/tt_metal/impl/dispatch/dispatch_core_common.hpp
+++ b/tt_metal/impl/dispatch/dispatch_core_common.hpp
@@ -44,6 +44,11 @@ CoreType get_core_type_from_config(const DispatchCoreConfig& config);
 CoreType resolve_dispatch_core_type(
     MetalEnvImpl& env, tt::ChipId device_id, const DispatchCoreConfig& dispatch_core_config);
 
+// Offline-safe resolution: WH/BH map DispatchCoreType to CoreType. Quasar DISPATCH vs WORKER
+// depends on the SoC descriptor and TT_METAL_TENSIX_DISPATCH_CORES, so this overload throws
+// rather than silently emitting WORKER.
+CoreType resolve_dispatch_core_type(tt::ARCH arch, DispatchCoreType dispatch_core_type);
+
 // Resolve the dispatch core axis from a DispatchCoreConfig without depending on MetalContext.
 // Uses the config's explicit axis if set; otherwise falls back to arch-based resolution.
 // TODO: https://github.com/tenstorrent/tt-metal/issues/39974

--- a/tt_metal/jit_build/jit_device_config.cpp
+++ b/tt_metal/jit_build/jit_device_config.cpp
@@ -209,6 +209,7 @@ void enumerate_jit_device_configs(
                             // has no effect on compilation
                             .harvesting_mask = 0,
                             .dispatch_core_type = dispatch_core_type,
+                            .resolved_dispatch_core_type = resolve_dispatch_core_type(arch, dispatch_core_type),
                             .dispatch_core_axis = dispatch_core_axis,
                             .coordinate_virtualization_enabled = true,
                             .dispatch_message_addr = dispatch_message_addr(hal, dispatch_core_type),


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Related to #53160.

#48929 added `JitDeviceConfig::resolved_dispatch_core_type` and switched
`compute_build_key()` to hash it, but only the live path (`create_jit_device_config`)
populated the field. The offline enumerator left it at the `WORKER` default, so
`CompileKernelOffline(AllSupportedProducts)` and `precompile_fw` emitted ETH-dispatch
artifacts under a WORKER key.
On T3K / `TT_METAL_GTEST_ETH_DISPATCH=1`, runtime then misses the precompiled kernel
bucket (`PrecompiledKernelNotFoundError`) and the matching firmware bundle
(`find_precompiled_dir` falls back to JIT).

This PR:
- Resolves the field in `enumerate_jit_device_configs` via a new offline-safe
  `resolve_dispatch_core_type(arch, DispatchCoreType)` (WH/BH map WORKER/ETH; Quasar
  not supported at this point).
- Runs the existing precompiled-hit tests under `AnyDispatchMeshDeviceFixture` and
  from `runtime_fast_dispatch_on_eth`, so ETH fast dispatch is actually covered.
  `MeshDeviceFixture` required slow dispatch, which always resolves to WORKER.
Verified on WH N150 with `TT_METAL_GTEST_ETH_DISPATCH=1`:
```
./build/test/tt_metal/unit_tests_api --gtest_filter='*Precompiled*'
```
Failed before the enumerator fix . Passes after.
Firmware keys use the same enumerator; the on-disk `tt_metal/pre-compiled/` bundle will be fixed as well.

### Notes for reviewers
Quasar not supported for the new variant of `resolve_dispatch_core_type` is probably ok -- current offline compile path does not cover Quasar, and offline compile path will migrate to MetalEnv so hopefully it can provide enough context to decide dispatch core type for Quasar.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ruizhang/offline_buildkey_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/offline_buildkey_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ruizhang/offline_buildkey_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ruizhang/offline_buildkey_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ruizhang/offline_buildkey_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/offline_buildkey_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ruizhang/offline_buildkey_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ruizhang/offline_buildkey_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ruizhang/offline_buildkey_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/offline_buildkey_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ruizhang/offline_buildkey_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/offline_buildkey_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ruizhang/offline_buildkey_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/offline_buildkey_fix)