### PR TITLE
[TTNN] Fix sparse matmul tile mismatch test expectation

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_sparse_matmul.py
@@ -1018,7 +1018,7 @@ def test_sparse_matmul_rejects_optional_output_tile_mismatch(device, expect_erro
         device=device,
     )
 
-    with expect_error(RuntimeError, "must match the output tile"):
+    with expect_error(RuntimeError, "must equal to the in0 tile height"):
         ttnn.sparse_matmul(
             in0,
             in1,


### PR DESCRIPTION
## Summary
- Match the sparse matmul negative test against the error emitted by the shared matmul output-tile validation.
- Restore the sanity matmul group, which failed because the test expected a later sparse-specific validation message.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=zni/fix-sparse-matmul-tile-mismatch-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:zni/fix-sparse-matmul-tile-mismatch-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=zni/fix-sparse-matmul-tile-mismatch-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:zni/fix-sparse-matmul-tile-mismatch-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=zni/fix-sparse-matmul-tile-mismatch-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:zni/fix-sparse-matmul-tile-mismatch-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=zni/fix-sparse-matmul-tile-mismatch-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:zni/fix-sparse-matmul-tile-mismatch-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=zni/fix-sparse-matmul-tile-mismatch-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:zni/fix-sparse-matmul-tile-mismatch-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=zni/fix-sparse-matmul-tile-mismatch-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:zni/fix-sparse-matmul-tile-mismatch-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=zni/fix-sparse-matmul-tile-mismatch-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:zni/fix-sparse-matmul-tile-mismatch-test)