### PR TITLE
Test Only: run sharded DRAM readback on any available bank count

### DIFF
--- a/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_large_mesh_buffer.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_buffer/test_large_mesh_buffer.cpp
@@ -274,6 +274,39 @@ TEST_P(ShardedMeshBufferTestSuite, NIGHTLY_DRAMReadback) {
     // page_size: (bytes)
     auto [tensor_and_grid, page_size] = GetParam();
     auto [device_tensor_shape, core_grid_size] = tensor_and_grid;
+
+    // The parameters above name a bank count (8 on Blackhole, 12 on Wormhole). A harvested part
+    // exposes fewer DRAM banks than the full grid -- 7 of 8 once a GDDR channel is soft-harvested --
+    // which used to skip every case here, leaving the sharded DRAM path with no coverage at all on
+    // such systems. Rather than drop the test, hold the per-bank shard width fixed and narrow the
+    // tensor to the banks this device actually has. The shard each bank sees is byte-for-byte what
+    // the parameter asked for, so every page/tile divisibility invariant below still holds; only the
+    // total tensor shrinks in proportion to the missing banks.
+    if (const uint32_t available_banks = mesh_device_->dram_grid_size().x;
+        available_banks > 0 && core_grid_size.x > available_banks) {
+        const uint32_t per_bank_width = device_tensor_shape.width() / core_grid_size.x;
+        if (per_bank_width * core_grid_size.x != device_tensor_shape.width()) {
+            GTEST_SKIP() << "tensor width " << device_tensor_shape.width() << " is not divisible by requested grid "
+                         << core_grid_size.x;
+        }
+        const uint32_t adjusted_width = per_bank_width * available_banks;
+        if (adjusted_width % constants::TILE_WIDTH != 0) {
+            GTEST_SKIP() << "width " << adjusted_width << " across " << available_banks
+                         << " banks is not tile-aligned";
+        }
+        log_info(
+            tt::LogTest,
+            "Adapting to harvested DRAM: requested {} banks, {} available. Holding per-bank width {} and narrowing "
+            "tensor width {} -> {}",
+            core_grid_size.x,
+            available_banks,
+            per_bank_width,
+            device_tensor_shape.width(),
+            adjusted_width);
+        core_grid_size.x = available_banks;
+        device_tensor_shape = Shape2D(device_tensor_shape.height(), adjusted_width);
+    }
+
     uint64_t device_tensor_size = device_tensor_shape.height() * device_tensor_shape.width() * ElementSize;
 
     if (!validate_sharded_test_inputs(core_grid_size, device_tensor_shape, *mesh_device_, ElementSize)) {


### PR DESCRIPTION
### PR Category
Test Only

### Summary
`LargeShardedReadback` parameters name a fixed DRAM bank count — `CoreCoord(8, 1)` on Blackhole, `CoreCoord(12, 1)` on Wormhole. When a device exposes fewer banks than a parameter asks for, `validate_sharded_test_inputs()` rejects it and the case skips:

```
Skipping test because required grid 8-1 is incompatible with available grid 7-1
Skipping because required shard size/bank (tensor shape: (16384, 16384), grid shape: 8-1,
  derived shard size: 10000000) is greater than available size/bank: FEA6C180, #banks: 7)
```

On a Blackhole with a soft-harvested GDDR channel (7 of 8 banks) **all twelve cases skip**, so the sharded DRAM readback path gets no coverage at all on harvested parts — and it opts out silently, as a skip rather than a failure. The 12-bank parameter additionally skips on *unharvested* Blackhole, since 12 > 8.

This adapts the requested grid to the banks the device actually exposes: hold the per-bank shard width fixed and narrow the tensor to the available bank count. Each bank then sees byte-for-byte the shard the parameter asked for, so the per-bank stress characteristics are preserved and only the total tensor shrinks in proportion to the missing banks (2 GB → 1792 MB on 7 banks).

The adjustment is guarded by a strict greater-than, so any device with at least the requested bank count is unaffected.

### Notes for reviewers
**Why narrow the tensor rather than shrink the shard.** Holding `shard_width` fixed is what keeps this change safe: every page/tile divisibility invariant further down the test is expressed in terms of `shard_width`, which is untouched. The total width becomes `per_bank_width × available_banks`, so if `page_width` divided the shard before, it still divides the total. Exact page division also survives — width becomes `2^11 · 7`, giving a total of `7 · 2^28` bytes, still exactly divisible by all three page sizes (4 KB / 16 KB / 1 MB) because those are powers of two and the odd factor rides along harmlessly.

**Tile alignment** holds for every existing parameter on 7 banks (widths 14336 and 28672, both divisible by 32). There is an explicit `GTEST_SKIP` guard if a future parameter ever produces a non-tile-aligned width, rather than letting it fail deep inside page-shape derivation.

**Coverage recovered on healthy parts too.** The `CoreCoord(12, 1)` parameter was skipping on unharvested Blackhole as well. It now runs there, so this is not purely a harvested-system fix.

**What I could not verify.** Every chip on the system I tested is harvested, so the no-op path (`available_banks >= core_grid_size.x`) is correct by construction — a strict `>` guard — but was not exercised by a run. Worth a second pair of eyes, or a CI run on an unharvested part, to confirm the full-grid case is byte-identical to today.

**Test results.** 32-chip Blackhole Galaxy (`tt-galaxy-bh`, GALAXY-1), fw 19.13.2, KMD 2.9.0, one GDDR channel soft-harvested per chip (non-uniform across chips):

```
[  PASSED  ] 12 tests.   (1154 s)   — previously 12/12 skipped
```

Adaptation applied per parameter shape:

| Requested | Available | Per-bank width (held) | Tensor width |
| --- | --- | --- | --- |
| 8 banks | 7 | 2048 | 16384 → 14336 |
| 8 banks | 7 | 4096 | 32768 → 28672 |
| 12 banks | 7 | 4096 | 49152 → 28672 |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/sharded-dram-readback-bank-adaptive)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/sharded-dram-readback-bank-adaptive)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/sharded-dram-readback-bank-adaptive)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/sharded-dram-readback-bank-adaptive)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/sharded-dram-readback-bank-adaptive)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/sharded-dram-readback-bank-adaptive)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/sharded-dram-readback-bank-adaptive)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/sharded-dram-readback-bank-adaptive)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/sharded-dram-readback-bank-adaptive)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/sharded-dram-readback-bank-adaptive)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/sharded-dram-readback-bank-adaptive)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/sharded-dram-readback-bank-adaptive)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/sharded-dram-readback-bank-adaptive)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/sharded-dram-readback-bank-adaptive)