### PR TITLE
[LLK] Experimental Compute APIs with no CB ID

### DIFF
--- a/tests/tt_metal/tt_metal/llk/single_core_compute_runners.hpp
+++ b/tests/tt_metal/tt_metal/llk/single_core_compute_runners.hpp
@@ -17,6 +17,7 @@
 
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/tile.hpp>
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
@@ -66,6 +67,89 @@ inline vector<std::uint32_t> run_unary(
     CircularBufferConfig cb_dst_config =
         CircularBufferConfig(cb_depth_tiles * output_tile_size, {{tt::CBIndex::c_16, output_fmt}})
             .set_page_size(tt::CBIndex::c_16, output_tile_size);
+    CreateCircularBuffer(program, core, cb_dst_config);
+
+    auto reader = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+
+    auto writer = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    CreateKernel(
+        program,
+        compute_kernel,
+        core,
+        ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = {num_tiles}});
+
+    detail::WriteToBuffer(src_buffer, src_vec);
+    SetRuntimeArgs(program, reader, core, {src_buffer->address(), 0, num_tiles});
+    SetRuntimeArgs(program, writer, core, {dst_buffer->address(), 0, num_tiles});
+
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    workload.add_program(device_range, std::move(program));
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+    distributed::Finish(cq);
+
+    vector<std::uint32_t> result_vec;
+    detail::ReadFromBuffer(dst_buffer, result_vec);
+    return result_vec;
+}
+
+// Like run_unary, but advertises an explicit (possibly partial / tiny) tile geometry on both CBs via
+// set_tile_dims, and sizes every buffer/page by tile.get_tile_size(fmt) instead of the full-tile tt::tile_size.
+// This is what exercises the per-tile L1 stride for sub-32x32 tiles: reader_unary/writer_unary stream at
+// get_tile_size(cb), and the compute kernel derives geometry (incl. block floats' shared-exponent section) from
+// the CB tile dims. Needed to test block-float partial tiles, whose stride the full-tile size would overcount.
+inline vector<std::uint32_t> run_unary_tiled(
+    distributed::MeshDevice& mesh_device,
+    tt::DataFormat input_fmt,
+    tt::DataFormat output_fmt,
+    const tt::tt_metal::Tile& tile,
+    const vector<std::uint32_t>& src_vec,
+    std::uint32_t num_tiles,
+    bool fp32_dest_acc_en,
+    const std::string& compute_kernel,
+    std::uint32_t cb_depth_tiles) {
+    IDevice* dev = mesh_device.get_devices()[0];
+    Program program = CreateProgram();
+    CoreCoord core = {0, 0};
+
+    const std::uint32_t input_tile_size = tile.get_tile_size(input_fmt);
+    const std::uint32_t output_tile_size = tile.get_tile_size(output_fmt);
+
+    InterleavedBufferConfig src_config{
+        .device = dev,
+        .size = num_tiles * input_tile_size,
+        .page_size = num_tiles * input_tile_size,
+        .buffer_type = BufferType::DRAM};
+    auto src_buffer = CreateBuffer(src_config);
+
+    InterleavedBufferConfig dst_config{
+        .device = dev,
+        .size = num_tiles * output_tile_size,
+        .page_size = num_tiles * output_tile_size,
+        .buffer_type = BufferType::DRAM};
+    auto dst_buffer = CreateBuffer(dst_config);
+
+    CircularBufferConfig cb_src_config =
+        CircularBufferConfig(cb_depth_tiles * input_tile_size, {{tt::CBIndex::c_0, input_fmt}})
+            .set_page_size(tt::CBIndex::c_0, input_tile_size);
+    cb_src_config.set_tile_dims(tt::CBIndex::c_0, tile);
+    CreateCircularBuffer(program, core, cb_src_config);
+
+    CircularBufferConfig cb_dst_config =
+        CircularBufferConfig(cb_depth_tiles * output_tile_size, {{tt::CBIndex::c_16, output_fmt}})
+            .set_page_size(tt::CBIndex::c_16, output_tile_size);
+    cb_dst_config.set_tile_dims(tt::CBIndex::c_16, tile);
     CreateCircularBuffer(program, core, cb_dst_config);
 
     auto reader = CreateKernel(

--- a/tests/tt_metal/tt_metal/llk/single_core_compute_runners.hpp
+++ b/tests/tt_metal/tt_metal/llk/single_core_compute_runners.hpp
@@ -1,0 +1,335 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Shared single-core, classic-circular-buffer program runners for the id-free (2.0) compute-API golden tests.
+// Each runner builds a one-core program that streams tiles through a compute kernel (selected by path) and
+// returns the raw device output; the caller validates it against a host-computed golden. These are the proven
+// harnesses the 2.0 kernels were authored against (c_0[/c_1] in via reader_unary/reader_binary, c_16 out via
+// writer_unary), factored out of test_fp8_typecast.cpp so every llk home test file can reuse them.
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/circular_buffer_config.hpp>
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>
+
+namespace tt::tt_metal::unit_tests::llk::single_core {
+
+using std::vector;
+
+// Run a single-input datacopy-style kernel (c_0 -> c_16). The unpacker reads input_fmt, the packer writes
+// output_fmt, so a format mismatch performs an implicit typecast. fp32_dest_acc_en selects Dest 32-bit mode.
+// cb_depth_tiles must be >= any block size the kernel keeps resident (a 1-tile CB deadlocks wait_front(BLOCK)).
+inline vector<std::uint32_t> run_unary(
+    distributed::MeshDevice& mesh_device,
+    tt::DataFormat input_fmt,
+    tt::DataFormat output_fmt,
+    const vector<std::uint32_t>& src_vec,
+    std::uint32_t num_tiles,
+    bool fp32_dest_acc_en,
+    const std::string& compute_kernel,
+    std::uint32_t cb_depth_tiles = 1) {
+    IDevice* dev = mesh_device.get_devices()[0];
+    Program program = CreateProgram();
+    CoreCoord core = {0, 0};
+
+    std::uint32_t input_tile_size = tt::tile_size(input_fmt);
+    std::uint32_t output_tile_size = tt::tile_size(output_fmt);
+
+    InterleavedBufferConfig src_config{
+        .device = dev,
+        .size = num_tiles * input_tile_size,
+        .page_size = num_tiles * input_tile_size,
+        .buffer_type = BufferType::DRAM};
+    auto src_buffer = CreateBuffer(src_config);
+
+    InterleavedBufferConfig dst_config{
+        .device = dev,
+        .size = num_tiles * output_tile_size,
+        .page_size = num_tiles * output_tile_size,
+        .buffer_type = BufferType::DRAM};
+    auto dst_buffer = CreateBuffer(dst_config);
+
+    CircularBufferConfig cb_src_config =
+        CircularBufferConfig(cb_depth_tiles * input_tile_size, {{tt::CBIndex::c_0, input_fmt}})
+            .set_page_size(tt::CBIndex::c_0, input_tile_size);
+    CreateCircularBuffer(program, core, cb_src_config);
+
+    CircularBufferConfig cb_dst_config =
+        CircularBufferConfig(cb_depth_tiles * output_tile_size, {{tt::CBIndex::c_16, output_fmt}})
+            .set_page_size(tt::CBIndex::c_16, output_tile_size);
+    CreateCircularBuffer(program, core, cb_dst_config);
+
+    auto reader = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+
+    auto writer = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    CreateKernel(
+        program,
+        compute_kernel,
+        core,
+        ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = {num_tiles}});
+
+    detail::WriteToBuffer(src_buffer, src_vec);
+    SetRuntimeArgs(program, reader, core, {src_buffer->address(), 0, num_tiles});
+    SetRuntimeArgs(program, writer, core, {dst_buffer->address(), 0, num_tiles});
+
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    workload.add_program(device_range, std::move(program));
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+    distributed::Finish(cq);
+
+    vector<std::uint32_t> result_vec;
+    detail::ReadFromBuffer(dst_buffer, result_vec);
+    return result_vec;
+}
+
+// Run a two-input kernel: c_0, c_1 in (reader_binary) -> c_16 out (writer_unary). All tiles Float16_b.
+// out_tiles defaults to num_tiles (elementwise N->N); reducing ops that collapse the block to fewer outputs
+// must pass out_tiles explicitly or writer_unary over-reads c_16 and deadlocks. cb_depth_tiles must be >= any
+// resident block size. compute_defines lets a shipping kernel (e.g. eltwise_binary.cpp) be steered via defines.
+// extra_compile_args are appended after num_tiles as get_compile_time_arg_val(1..N) -- fused kernels read a mode
+// enum (e.g. BroadcastType, or PoolType/ReduceDim) from them so one kernel covers a whole family.
+inline vector<std::uint32_t> run_binary(
+    distributed::MeshDevice& mesh_device,
+    const vector<std::uint32_t>& src0_vec,
+    const vector<std::uint32_t>& src1_vec,
+    std::uint32_t num_tiles,
+    const std::string& compute_kernel,
+    const std::map<std::string, std::string>& compute_defines = {},
+    std::uint32_t cb_depth_tiles = 1,
+    std::uint32_t out_tiles = 0,
+    const vector<std::uint32_t>& extra_compile_args = {}) {
+    if (out_tiles == 0) {
+        out_tiles = num_tiles;
+    }
+    IDevice* dev = mesh_device.get_devices()[0];
+    Program program = CreateProgram();
+    CoreCoord core = {0, 0};
+
+    const tt::DataFormat fmt = tt::DataFormat::Float16_b;
+    std::uint32_t tile_bytes = tt::tile_size(fmt);
+
+    auto make_dram = [&](std::uint32_t ntiles) {
+        InterleavedBufferConfig cfg{
+            .device = dev,
+            .size = ntiles * tile_bytes,
+            .page_size = ntiles * tile_bytes,
+            .buffer_type = BufferType::DRAM};
+        return CreateBuffer(cfg);
+    };
+    auto src0_buffer = make_dram(num_tiles);
+    auto src1_buffer = make_dram(num_tiles);
+    auto dst_buffer = make_dram(out_tiles);
+
+    auto make_cb = [&](tt::CBIndex idx) {
+        CircularBufferConfig cb_cfg =
+            CircularBufferConfig(cb_depth_tiles * tile_bytes, {{idx, fmt}}).set_page_size(idx, tile_bytes);
+        CreateCircularBuffer(program, core, cb_cfg);
+    };
+    make_cb(tt::CBIndex::c_0);
+    make_cb(tt::CBIndex::c_1);
+    make_cb(tt::CBIndex::c_16);
+
+    auto reader = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+
+    auto writer = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    std::vector<std::uint32_t> compile_args = {num_tiles};
+    compile_args.insert(compile_args.end(), extra_compile_args.begin(), extra_compile_args.end());
+    auto compute = CreateKernel(
+        program,
+        compute_kernel,
+        core,
+        ComputeConfig{.fp32_dest_acc_en = false, .compile_args = compile_args, .defines = compute_defines});
+
+    detail::WriteToBuffer(src0_buffer, src0_vec);
+    detail::WriteToBuffer(src1_buffer, src1_vec);
+    SetRuntimeArgs(program, reader, core, {src0_buffer->address(), 0, src1_buffer->address(), 0, num_tiles});
+    SetRuntimeArgs(program, writer, core, {dst_buffer->address(), 0, out_tiles});
+    // Shipping eltwise_binary.cpp reads runtime args {per_core_block_cnt, per_core_block_size, acc_to_dst};
+    // the id-free kernels read only compile-time num_tiles and ignore these (harmless). One tile per block.
+    SetRuntimeArgs(program, compute, core, {num_tiles, 1, 0});
+
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    workload.add_program(device_range, std::move(program));
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+    distributed::Finish(cq);
+
+    vector<std::uint32_t> result_vec;
+    detail::ReadFromBuffer(dst_buffer, result_vec);
+    return result_vec;
+}
+
+// Run a single-tile matmul: c_0 -> SrcB, c_1 -> SrcA -> c_16. All tiles Float16_b. 7 matmul compile args all 1.
+inline vector<std::uint32_t> run_matmul_single(
+    distributed::MeshDevice& mesh_device,
+    const vector<std::uint32_t>& src0_vec,
+    const vector<std::uint32_t>& src1_vec,
+    const std::string& compute_kernel) {
+    IDevice* dev = mesh_device.get_devices()[0];
+    Program program = CreateProgram();
+    CoreCoord core = {0, 0};
+
+    const tt::DataFormat fmt = tt::DataFormat::Float16_b;
+    std::uint32_t tile_bytes = tt::tile_size(fmt);
+
+    auto make_dram = [&]() {
+        InterleavedBufferConfig cfg{
+            .device = dev, .size = tile_bytes, .page_size = tile_bytes, .buffer_type = BufferType::DRAM};
+        return CreateBuffer(cfg);
+    };
+    auto src0_buffer = make_dram();
+    auto src1_buffer = make_dram();
+    auto dst_buffer = make_dram();
+
+    auto make_cb = [&](tt::CBIndex idx) {
+        CircularBufferConfig cb_cfg = CircularBufferConfig(tile_bytes, {{idx, fmt}}).set_page_size(idx, tile_bytes);
+        CreateCircularBuffer(program, core, cb_cfg);
+    };
+    make_cb(tt::CBIndex::c_0);
+    make_cb(tt::CBIndex::c_1);
+    make_cb(tt::CBIndex::c_16);
+
+    auto reader = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+    auto writer = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    // 7 matmul compile args, all 1: block_tile_dim, dst_tile_rows, dst_tile_cols, block_cnt,
+    // in0_block_tile_cnt, in1_block_tile_cnt, out_block_tile_cnt.
+    CreateKernel(
+        program, compute_kernel, core, ComputeConfig{.fp32_dest_acc_en = false, .compile_args = {1, 1, 1, 1, 1, 1, 1}});
+
+    detail::WriteToBuffer(src0_buffer, src0_vec);
+    detail::WriteToBuffer(src1_buffer, src1_vec);
+    SetRuntimeArgs(program, reader, core, {src0_buffer->address(), 0, src1_buffer->address(), 0, 1});
+    SetRuntimeArgs(program, writer, core, {dst_buffer->address(), 0, 1});
+
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    workload.add_program(device_range, std::move(program));
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+    distributed::Finish(cq);
+
+    vector<std::uint32_t> result_vec;
+    detail::ReadFromBuffer(dst_buffer, result_vec);
+    return result_vec;
+}
+
+// Run a block matmul: A (rt_dim x kt_dim) -> c_0 -> SrcB, B (kt_dim x ct_dim) -> c_1 -> SrcA, C (rt_dim x ct_dim)
+// -> c_16. reader_binary reads the same tile count into c_0 and c_1, so callers must satisfy rt_dim == ct_dim.
+// CBs hold the whole block resident. Compile args = {ct_dim, rt_dim, kt_dim}.
+inline vector<std::uint32_t> run_matmul_block(
+    distributed::MeshDevice& mesh_device,
+    const vector<std::uint32_t>& src0_vec,  // in0 (A) block: rt_dim*kt_dim tiles
+    const vector<std::uint32_t>& src1_vec,  // in1 (B) block: kt_dim*ct_dim tiles
+    std::uint32_t ct_dim,
+    std::uint32_t rt_dim,
+    std::uint32_t kt_dim,
+    const std::string& compute_kernel) {
+    IDevice* dev = mesh_device.get_devices()[0];
+    Program program = CreateProgram();
+    CoreCoord core = {0, 0};
+
+    const tt::DataFormat fmt = tt::DataFormat::Float16_b;
+    std::uint32_t tile_bytes = tt::tile_size(fmt);
+
+    const std::uint32_t in0_tiles = rt_dim * kt_dim;  // A block
+    const std::uint32_t in1_tiles = kt_dim * ct_dim;  // B block
+    const std::uint32_t out_tiles = rt_dim * ct_dim;  // C block
+    // reader_binary reads the same count into c_0 and c_1 -> this runner requires rt_dim == ct_dim.
+    TT_FATAL(in0_tiles == in1_tiles, "run_matmul_block: reader_binary needs in0_tiles == in1_tiles (rt==ct)");
+
+    auto make_dram = [&](std::uint32_t n) {
+        InterleavedBufferConfig cfg{
+            .device = dev, .size = n * tile_bytes, .page_size = n * tile_bytes, .buffer_type = BufferType::DRAM};
+        return CreateBuffer(cfg);
+    };
+    auto src0_buffer = make_dram(in0_tiles);
+    auto src1_buffer = make_dram(in1_tiles);
+    auto dst_buffer = make_dram(out_tiles);
+
+    auto make_cb = [&](tt::CBIndex idx, std::uint32_t depth) {
+        CircularBufferConfig cfg =
+            CircularBufferConfig(depth * tile_bytes, {{idx, fmt}}).set_page_size(idx, tile_bytes);
+        CreateCircularBuffer(program, core, cfg);
+    };
+    make_cb(tt::CBIndex::c_0, in0_tiles);
+    make_cb(tt::CBIndex::c_1, in1_tiles);
+    make_cb(tt::CBIndex::c_16, out_tiles);
+
+    auto reader = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+    auto writer = CreateKernel(
+        program,
+        "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary.cpp",
+        core,
+        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+
+    CreateKernel(
+        program,
+        compute_kernel,
+        core,
+        ComputeConfig{.fp32_dest_acc_en = false, .compile_args = {ct_dim, rt_dim, kt_dim}});
+
+    detail::WriteToBuffer(src0_buffer, src0_vec);
+    detail::WriteToBuffer(src1_buffer, src1_vec);
+    SetRuntimeArgs(program, reader, core, {src0_buffer->address(), 0, src1_buffer->address(), 0, in0_tiles});
+    SetRuntimeArgs(program, writer, core, {dst_buffer->address(), 0, out_tiles});
+
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    workload.add_program(device_range, std::move(program));
+    auto& cq = mesh_device.mesh_command_queue();
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+    distributed::Finish(cq);
+
+    vector<std::uint32_t> result_vec;
+    detail::ReadFromBuffer(dst_buffer, result_vec);
+    return result_vec;
+}
+
+}  // namespace tt::tt_metal::unit_tests::llk::single_core

--- a/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_broadcast.cpp
@@ -37,6 +37,7 @@
 #include "tt_metal/test_utils/df/float32.hpp"
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
+#include "single_core_compute_runners.hpp"
 
 namespace tt::tt_metal {
 class IDevice;
@@ -949,6 +950,74 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, ComputeSubBcastColCustom) {
             break;
         }
     }
+}
+
+// ============================================================================
+// Id-free (2.0) binary broadcast MUL (rows / cols / scalar), validated against the gold_broadcast host golden
+// (not a legacy kernel). c_0 = A (full tile), c_1 = B (masked bcast tile), MUL-broadcast -> c_16. Both inputs
+// are tilized host-side (the device reads tiled operands); the golden broadcast is computed row-major then
+// tilized. Single Float16_b tile, is_close(rtol 0.0155). Runs on Blackhole (BH-only API).
+// ============================================================================
+namespace {
+// Map the test-side BroadcastDim to the kernel-side ckernel BroadcastType numeric value (COL=1, ROW=2,
+// SCALAR=3) passed as get_compile_time_arg_val(1) to the fused bcast_mul_2_0.cpp kernel.
+std::uint32_t bcast_type_arg(BroadcastDim dim) {
+    switch (dim) {
+        case BroadcastDim::ROW: return 2;
+        case BroadcastDim::COL: return 1;
+        case BroadcastDim::SCALAR: return 3;
+    }
+    return 0;
+}
+
+void expect_bcast_mul_matches_golden(distributed::MeshDevice& md, BroadcastDim dim) {
+    const std::string kernel = "tests/tt_metal/tt_metal/test_kernels/compute/bcast_mul_2_0.cpp";
+    ::unit_tests::compute::GoldenConfig config{
+        .num_tiles_r_dim = 1, .num_tiles_c_dim = 1, .face_r_dim = 16, .face_c_dim = 16, .num_faces = 4};
+    auto in0_packed = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b), /*rand_max_float=*/2, /*seed=*/42, /*offset=*/-1.0f);
+    auto in1_packed = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b), /*rand_max_float=*/2, /*seed=*/7, /*offset=*/-1.0f);
+
+    auto in0_bf16 = unpack_vector<bfloat16, std::uint32_t>(in0_packed);
+    auto in1_bf16 = unpack_vector<bfloat16, std::uint32_t>(in1_packed);
+    // Zero the non-broadcast positions of B so device and golden read the same broadcast operand.
+    mask_src_b_for_broadcast(in1_bf16, {32, 32}, dim, /*row_idx=*/0);
+    auto golden_rm = gold_broadcast(in0_bf16, in1_bf16, {32, 32}, EltwiseOp::MUL, dim, /*row_idx=*/0);
+
+    auto c0_input = ::unit_tests::compute::gold_standard_tilize(in0_packed, config);
+    auto c1_input = ::unit_tests::compute::gold_standard_tilize(pack_vector<std::uint32_t, bfloat16>(in1_bf16), config);
+    auto golden_tiled =
+        ::unit_tests::compute::gold_standard_tilize(pack_vector<std::uint32_t, bfloat16>(golden_rm), config);
+
+    auto result = unit_tests::llk::single_core::run_binary(
+        md,
+        c0_input,
+        c1_input,
+        /*num_tiles=*/1,
+        kernel,
+        /*compute_defines=*/{},
+        /*cb_depth_tiles=*/1,
+        /*out_tiles=*/0,
+        /*extra_compile_args=*/{bcast_type_arg(dim)});
+
+    EXPECT_EQ(golden_tiled.size(), result.size());
+    bool close = is_close_packed_vectors<bfloat16, std::uint32_t>(
+        result, golden_tiled, [](const bfloat16& a, const bfloat16& b) { return is_close(a, b, k_broadcast_rtol); });
+    EXPECT_TRUE(close);
+}
+}  // namespace
+
+TEST_F(LLKBlackholeSingleCardFixture, TensixBcastMulRowsIdFreeGolden) {
+    expect_bcast_mul_matches_golden(*this->devices_.at(0), BroadcastDim::ROW);
+}
+
+TEST_F(LLKBlackholeSingleCardFixture, TensixBcastMulColsIdFreeGolden) {
+    expect_bcast_mul_matches_golden(*this->devices_.at(0), BroadcastDim::COL);
+}
+
+TEST_F(LLKBlackholeSingleCardFixture, TensixBcastMulScalarIdFreeGolden) {
+    expect_bcast_mul_matches_golden(*this->devices_.at(0), BroadcastDim::SCALAR);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -30,6 +30,7 @@
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <umd/device/types/arch.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include "single_core_compute_runners.hpp"
 
 namespace tt::tt_metal {
 class IDevice;
@@ -44,14 +45,14 @@ using namespace tt::test_utils;
 namespace unit_tests::compute::matmul_partials {
 
 struct CopyBlockMatmulPartialsConfig {
-    uint32_t single_tile_size = 2 * 32 * 32;
-    uint32_t num_tiles = 1;
+    std::uint32_t single_tile_size = 2 * 32 * 32;
+    std::uint32_t num_tiles = 1;
     // *_ublock defines no. of tiles finished with single LLK API call:
-    uint32_t reader_ublock = 1;
-    uint32_t writer_ublock = 1;
-    uint32_t compute_ublock = 1;
-    uint32_t src0_cb_index = 0;
-    uint32_t ouput_cb_index = 16;
+    std::uint32_t reader_ublock = 1;
+    std::uint32_t writer_ublock = 1;
+    std::uint32_t compute_ublock = 1;
+    std::uint32_t src0_cb_index = 0;
+    std::uint32_t ouput_cb_index = 16;
     // Whether or not we want the result to be stored in DST in FP32:
     bool fp32_dest_acc_en = false;
     // Whether or not to sync full/half DST between MATH and PACK:
@@ -61,9 +62,9 @@ struct CopyBlockMatmulPartialsConfig {
     std::string compute_kernel = "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_block_matmul_partials.cpp";
 };
 
-static std::vector<uint32_t> generate_copy_block_stimulus(
-    uint32_t dram_buffer_size, const CopyBlockMatmulPartialsConfig& test_config) {
-    std::vector<uint32_t> src_vec = create_random_vector_of_bfloat16(dram_buffer_size, 100, 0);
+static std::vector<std::uint32_t> generate_copy_block_stimulus(
+    std::uint32_t dram_buffer_size, const CopyBlockMatmulPartialsConfig& test_config) {
+    std::vector<std::uint32_t> src_vec = create_random_vector_of_bfloat16(dram_buffer_size, 100, 0);
 
     if (test_config.fp32_dest_acc_en) {
         auto src_vec_float = generate_uniform_random_vector<float>(-100, 100, dram_buffer_size / sizeof(float), 0);
@@ -81,9 +82,9 @@ void run_single_core_copy_block_matmul_partials(
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     const experimental::NodeCoord node{0, 0};
 
-    uint32_t single_tile_size = test_config.single_tile_size;
-    uint32_t num_tiles = test_config.num_tiles;
-    uint32_t dram_buffer_size = single_tile_size * num_tiles;
+    std::uint32_t single_tile_size = test_config.single_tile_size;
+    std::uint32_t num_tiles = test_config.num_tiles;
+    std::uint32_t dram_buffer_size = single_tile_size * num_tiles;
 
     tt::DataFormat data_format = test_config.fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
 
@@ -93,8 +94,8 @@ void run_single_core_copy_block_matmul_partials(
     auto src_dram_buffer = distributed::MeshBuffer::create(dram_buffer_config, dram_local_config, mesh_device.get());
     auto dst_dram_buffer = distributed::MeshBuffer::create(dram_buffer_config, dram_local_config, mesh_device.get());
 
-    uint32_t num_input_tiles = test_config.reader_ublock;
-    uint32_t num_output_tiles = test_config.writer_ublock;
+    std::uint32_t num_input_tiles = test_config.reader_ublock;
+    std::uint32_t num_output_tiles = test_config.writer_ublock;
 
     const experimental::DFBSpecName SRC0_DFB{"src0_dfb"};
     const experimental::DFBSpecName DST_DFB{"dst_dfb"};
@@ -223,7 +224,7 @@ void run_single_core_copy_block_matmul_partials(
     workload.add_program(device_range, std::move(program));
     auto& program_run = workload.get_programs().at(device_range);
 
-    std::vector<uint32_t> src_vec = generate_copy_block_stimulus(dram_buffer_size, test_config);
+    std::vector<std::uint32_t> src_vec = generate_copy_block_stimulus(dram_buffer_size, test_config);
     distributed::WriteShard(cq, src_dram_buffer, src_vec, zero_coord);
 
     experimental::ProgramRunArgs params;
@@ -255,7 +256,7 @@ void run_single_core_copy_block_matmul_partials(
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::Finish(cq);
 
-    std::vector<uint32_t> result_vec;
+    std::vector<std::uint32_t> result_vec;
     distributed::ReadShard(cq, result_vec, dst_dram_buffer, zero_coord);
 
     EXPECT_EQ(src_vec.size(), result_vec.size());
@@ -374,6 +375,43 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeCopyPackBlockComputeBottleneck) {
             }
         }
     }
+}
+
+// ============================================================================
+// Id-free (2.0) copy_block / copy_tile_to_dst_init_short / pack_block: each is a pure Float16_b -> Float16_b
+// datacopy, so the host golden is the identity (device output == input, bit-for-bit). Validated against the
+// input, not a legacy kernel. Runs on Blackhole (the id-free API is BH-only).
+// ============================================================================
+TEST_F(LLKBlackholeSingleCardFixture, TensixCopyBlockIdFreeIdentity) {
+    constexpr std::uint32_t num_tiles = 64;  // multiple of the 4-tile block
+    auto src_vec = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result = unit_tests::llk::single_core::run_unary(
+        *this->devices_.at(0),
+        tt::DataFormat::Float16_b,
+        tt::DataFormat::Float16_b,
+        src_vec,
+        num_tiles,
+        /*fp32_dest_acc_en=*/false,
+        "tests/tt_metal/tt_metal/test_kernels/compute/copy_block_2_0.cpp",
+        /*cb_depth_tiles=*/num_tiles);
+    EXPECT_EQ(src_vec, result);
+}
+
+TEST_F(LLKBlackholeSingleCardFixture, TensixPackBlockIdFreeIdentity) {
+    constexpr std::uint32_t num_tiles = 64;  // multiple of the 4-tile block
+    auto src_vec = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result = unit_tests::llk::single_core::run_unary(
+        *this->devices_.at(0),
+        tt::DataFormat::Float16_b,
+        tt::DataFormat::Float16_b,
+        src_vec,
+        num_tiles,
+        /*fp32_dest_acc_en=*/false,
+        "tests/tt_metal/tt_metal/test_kernels/compute/pack_block_2_0.cpp",
+        /*cb_depth_tiles=*/num_tiles);
+    EXPECT_EQ(src_vec, result);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_copy_block_matmul_partials.cpp
@@ -13,10 +13,14 @@
 #include <variant>
 #include <vector>
 
+#include <random>
 #include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/bfloat8.hpp>
+#include <tt-metalium/tile.hpp>
 #include <tt-metalium/buffer.hpp>
 #include <tt-metalium/buffer_types.hpp>
 #include <tt-metalium/circular_buffer_config.hpp>
+#include "tt_metal/test_utils/comparison.hpp"
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include "llk_device_fixture.hpp"
@@ -412,6 +416,49 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixPackBlockIdFreeIdentity) {
         "tests/tt_metal/tt_metal/test_kernels/compute/pack_block_2_0.cpp",
         /*cb_depth_tiles=*/num_tiles);
     EXPECT_EQ(src_vec, result);
+}
+
+// Id-free (2.0) copy_block over a MULTI-TILE window of block-float (Bfp8_b) tiles. This guards the block-float
+// branch of tile_stride_words (internal/llk_descriptor.h): copy_block reads the 4-tile input window at
+// in.l1_address + c * tile_stride_words(Bfp8_b, 32x32) and packs each DST slot back out. A Bfp8_b tile carries a
+// shared-exponent section that a plain datum-count size omits, so if the per-tile stride is wrong, tiles c=1..3
+// are read from the wrong L1 offset and the decoded output diverges from the input. Bfp8_b in AND out => identity
+// copy (golden = the input, is_close within Bfp8 requant). NOTE: only FULL 32x32 block-float tiles are exercised
+// here -- the BH compute datapath does not support partial (sub-32-row) block-float tiles, so the partial-BFP
+// stride (correct in tile_stride_words, matching tt_metal Tile::get_tile_size) cannot be validated on device.
+TEST_F(LLKBlackholeSingleCardFixture, TensixCopyBlockBfp8IdFree) {
+    constexpr std::uint32_t num_tiles = 4;  // exactly one copy_block window
+    const tt::tt_metal::Tile tile({tt::constants::TILE_HEIGHT, tt::constants::TILE_WIDTH});
+    const std::uint32_t datums_per_tile = tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH;
+
+    std::vector<float> src_floats(num_tiles * datums_per_tile);
+    std::mt19937 gen(42);
+    std::uniform_real_distribution<float> dist(-10.0f, 10.0f);
+    for (float& v : src_floats) {
+        v = dist(gen);
+    }
+    auto src_bfp8 =
+        pack_as_bfp8_tiles(ttsl::make_const_span(src_floats), /*row_major_input=*/true, /*is_exp_a=*/false, tile);
+
+    auto result = unit_tests::llk::single_core::run_unary_tiled(
+        *this->devices_.at(0),
+        tt::DataFormat::Bfp8_b,
+        tt::DataFormat::Bfp8_b,
+        tile,
+        src_bfp8,
+        num_tiles,
+        /*fp32_dest_acc_en=*/false,
+        "tests/tt_metal/tt_metal/test_kernels/compute/copy_block_2_0.cpp",
+        /*cb_depth_tiles=*/num_tiles);
+
+    auto result_floats = unpack_bfp8_tiles_into_float_vec(
+        ttsl::make_const_span(result), /*row_major_output=*/true, /*is_exp_a=*/false, tile);
+
+    ASSERT_EQ(result_floats.size(), src_floats.size());
+    EXPECT_TRUE(tt::test_utils::is_close_vectors<float>(src_floats, result_floats, [](float a, float b) {
+        return tt::test_utils::is_close(a, b, /*rtol=*/0.3f, /*atol=*/0.3f);
+    }));
+    EXPECT_TRUE(tt::test_utils::check_pcc(src_floats, result_floats, /*min_pcc=*/0.9999));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_fp8_typecast.cpp
@@ -5,6 +5,8 @@
 #include <gtest/gtest.h>
 #include <cmath>
 #include <cstdint>
+#include <map>
+#include <string>
 #include <vector>
 
 #include <tt-metalium/float8.hpp>
@@ -28,22 +30,39 @@ using std::vector;
 
 namespace unit_tests::llk::fp8_typecast {
 
+// The two datacopy compute kernels validated here (identity/typecast datacopy c_0 -> c_16). Each case()
+// validates the device output against a host golden = the decoded input (an identity typecast is lossless up
+// to the output format's quantization), so these are ordinary golden tests. The SAME golden validates BOTH
+// kernels; every case is run once per kernel so the two APIs get identical coverage:
+//   - kLegacyKernel: the shipping CB-id datacopy (copy_init/copy_tile/pack_tile) -- pre-existing fp8 coverage
+//     from #40287, kept so the CB-id typecast path stays tested.
+//   - kComputeKernel: the id-free (2.0) datacopy using the LLKOperand API (format+geometry as NTTPs, absolute
+//     L1 address at runtime).
+static constexpr const char* kLegacyKernel = "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_fp8.cpp";
+static constexpr const char* kComputeKernel = "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_fp8_2_0.cpp";
+
 // Run a datacopy kernel with different input/output CB formats.
 // The hardware unpacker reads input_fmt and the packer writes output_fmt,
 // performing the format conversion implicitly. fp32_dest_acc_en controls
-// whether the Dest register operates in 32-bit mode.
-static vector<uint32_t> run_fp8_typecast(
+// whether the Dest register operates in 32-bit mode. compute_kernel selects
+// the legacy vs id-free kernel (both take a single {num_tiles} compile-time arg).
+static vector<std::uint32_t> run_fp8_typecast(
     distributed::MeshDevice& mesh_device,
     tt::DataFormat input_fmt,
     tt::DataFormat output_fmt,
-    const vector<uint32_t>& src_vec,
-    uint32_t num_tiles,
-    bool fp32_dest_acc_en) {
+    const vector<std::uint32_t>& src_vec,
+    std::uint32_t num_tiles,
+    bool fp32_dest_acc_en,
+    const std::string& compute_kernel,
+    // CB depth in tiles. Default 1 (streaming double-... single-buffer, as the per-tile kernels use). Block
+    // kernels that keep >1 tile resident (copy_block/pack_block: wait_front(BLOCK)) must pass a depth >= their
+    // block size, else wait_front/reserve_back can never be satisfied in a 1-tile CB and the device deadlocks.
+    std::uint32_t cb_depth_tiles = 1) {
     Program program = CreateProgram();
     CoreCoord core = {0, 0};
 
-    uint32_t input_tile_size = tt::tile_size(input_fmt);
-    uint32_t output_tile_size = tt::tile_size(output_fmt);
+    std::uint32_t input_tile_size = tt::tile_size(input_fmt);
+    std::uint32_t output_tile_size = tt::tile_size(output_fmt);
 
     auto src_buffer = distributed::MeshBuffer::create(
         distributed::ReplicatedBufferConfig{.size = num_tiles * input_tile_size},
@@ -55,12 +74,14 @@ static vector<uint32_t> run_fp8_typecast(
         {.page_size = num_tiles * output_tile_size, .buffer_type = BufferType::DRAM},
         &mesh_device);
 
-    CircularBufferConfig cb_src_config = CircularBufferConfig(input_tile_size, {{tt::CBIndex::c_0, input_fmt}})
-                                             .set_page_size(tt::CBIndex::c_0, input_tile_size);
+    CircularBufferConfig cb_src_config =
+        CircularBufferConfig(cb_depth_tiles * input_tile_size, {{tt::CBIndex::c_0, input_fmt}})
+            .set_page_size(tt::CBIndex::c_0, input_tile_size);
     CreateCircularBuffer(program, core, cb_src_config);
 
-    CircularBufferConfig cb_dst_config = CircularBufferConfig(output_tile_size, {{tt::CBIndex::c_16, output_fmt}})
-                                             .set_page_size(tt::CBIndex::c_16, output_tile_size);
+    CircularBufferConfig cb_dst_config =
+        CircularBufferConfig(cb_depth_tiles * output_tile_size, {{tt::CBIndex::c_16, output_fmt}})
+            .set_page_size(tt::CBIndex::c_16, output_tile_size);
     CreateCircularBuffer(program, core, cb_dst_config);
 
     auto reader = CreateKernel(
@@ -77,7 +98,7 @@ static vector<uint32_t> run_fp8_typecast(
 
     CreateKernel(
         program,
-        "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_fp8.cpp",
+        compute_kernel,
         core,
         ComputeConfig{.fp32_dest_acc_en = fp32_dest_acc_en, .compile_args = {num_tiles}});
 
@@ -95,7 +116,7 @@ static vector<uint32_t> run_fp8_typecast(
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::Finish(cq);
 
-    vector<uint32_t> result_vec;
+    vector<std::uint32_t> result_vec;
     distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_buffer, /*blocking=*/true);
     return result_vec;
 }
@@ -107,7 +128,7 @@ static vector<uint32_t> run_fp8_typecast(
 using tt::test_utils::bf16_to_floats;
 using tt::test_utils::fp8_to_floats;
 
-static vector<float> bfp8_to_floats(const vector<uint32_t>& packed) {
+static vector<float> bfp8_to_floats(const vector<std::uint32_t>& packed) {
     return unpack_bfp8_tiles_into_float_vec(
         ttsl::make_const_span(packed), /*row_major_output=*/false, /*is_exp_a=*/false);
 }
@@ -119,224 +140,171 @@ using tt::test_utils::check_pcc;
 using tt::test_utils::is_close;
 using tt::test_utils::is_close_vectors;
 
+// ============================================================================
+// Per-conversion cases. Each runs the id-free datacopy kernel and validates the
+// device output against a host-computed golden (the decoded input).
+// ============================================================================
+
+// fp8_e4m3 -> Float16_b. Widening: every fp8 value is exactly representable in BF16 -> lossless.
+static void case_fp8_to_bf16(distributed::MeshDevice& md, const std::string& kernel) {
+    constexpr std::uint32_t num_tiles = 64;
+    auto src_vec = create_random_vector_of_float8_e4m3(
+        tt::tile_size(tt::DataFormat::Fp8_e4m3) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result_vec = run_fp8_typecast(
+        md, tt::DataFormat::Fp8_e4m3, tt::DataFormat::Float16_b, src_vec, num_tiles, /*fp32_dest_acc_en=*/true, kernel);
+    auto src_floats = fp8_to_floats(src_vec);
+    auto dst_floats = bf16_to_floats(result_vec);
+    EXPECT_TRUE(is_close_vectors<float>(
+        src_floats, dst_floats, [](float a, float b) { return is_close(a, b, /*rtol=*/0.0f, /*atol=*/0.0f); }));
+    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/1.0));
+}
+
+// Float16_b -> fp8_e4m3. Narrowing: rtol=0.125 covers the max relative fp8 quantization error (~1/8).
+static void case_bf16_to_fp8(distributed::MeshDevice& md, const std::string& kernel) {
+    constexpr std::uint32_t num_tiles = 64;
+    auto src_vec = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result_vec = run_fp8_typecast(
+        md, tt::DataFormat::Float16_b, tt::DataFormat::Fp8_e4m3, src_vec, num_tiles, /*fp32_dest_acc_en=*/true, kernel);
+    auto src_floats = bf16_to_floats(src_vec);
+    auto dst_floats = fp8_to_floats(result_vec);
+    EXPECT_TRUE(is_close_vectors<float>(
+        src_floats, dst_floats, [](float a, float b) { return is_close(a, b, /*rtol=*/0.125f, /*atol=*/0.015625f); }));
+    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/0.999));
+}
+
+// fp8_e4m3 -> Bfp8_b. Widening into a shared-exponent block format.
+static void case_fp8_to_bfp8(distributed::MeshDevice& md, const std::string& kernel) {
+    constexpr std::uint32_t num_tiles = 64;
+    auto src_vec = create_random_vector_of_float8_e4m3(
+        tt::tile_size(tt::DataFormat::Fp8_e4m3) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result_vec = run_fp8_typecast(
+        md, tt::DataFormat::Fp8_e4m3, tt::DataFormat::Bfp8_b, src_vec, num_tiles, /*fp32_dest_acc_en=*/true, kernel);
+    auto src_floats = fp8_to_floats(src_vec);
+    auto dst_floats = bfp8_to_floats(result_vec);
+    EXPECT_TRUE(is_close_vectors<float>(
+        src_floats, dst_floats, [](float a, float b) { return is_close(a, b, /*rtol=*/0.3f, /*atol=*/0.3f); }));
+    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/0.9999));
+}
+
+// Bfp8_b -> fp8_e4m3. Narrowing.
+static void case_bfp8_to_fp8(distributed::MeshDevice& md, const std::string& kernel) {
+    constexpr std::uint32_t num_tiles = 64;
+    auto src_vec = tt::test_utils::create_random_vector_of_bfp8(
+        tt::tile_size(tt::DataFormat::Bfp8_b) * num_tiles,
+        /*is_exp_a=*/false,
+        /*rand_max_float=*/20,
+        /*seed=*/42,
+        /*offset=*/-10.0f);
+    auto result_vec = run_fp8_typecast(
+        md, tt::DataFormat::Bfp8_b, tt::DataFormat::Fp8_e4m3, src_vec, num_tiles, /*fp32_dest_acc_en=*/true, kernel);
+    auto src_floats = bfp8_to_floats(src_vec);
+    auto dst_floats = fp8_to_floats(result_vec);
+    EXPECT_TRUE(is_close_vectors<float>(
+        src_floats, dst_floats, [](float a, float b) { return is_close(a, b, /*rtol=*/0.125f, /*atol=*/0.015625f); }));
+    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/0.999));
+}
+
+// Bfp8_b -> Bfp8_b identity. fp32_dest_acc_en selects Dest 16b vs 32b mode.
+static void case_bfp8_to_bfp8(distributed::MeshDevice& md, const std::string& kernel, bool fp32_dest_acc_en) {
+    constexpr std::uint32_t num_tiles = 64;
+    auto src_vec = tt::test_utils::create_random_vector_of_bfp8(
+        tt::tile_size(tt::DataFormat::Bfp8_b) * num_tiles,
+        /*is_exp_a=*/false,
+        /*rand_max_float=*/20,
+        /*seed=*/42,
+        /*offset=*/-10.0f);
+    auto result_vec = run_fp8_typecast(
+        md, tt::DataFormat::Bfp8_b, tt::DataFormat::Bfp8_b, src_vec, num_tiles, fp32_dest_acc_en, kernel);
+    auto src_floats = bfp8_to_floats(src_vec);
+    auto dst_floats = bfp8_to_floats(result_vec);
+    EXPECT_TRUE(is_close_vectors<float>(
+        src_floats, dst_floats, [](float a, float b) { return is_close(a, b, /*rtol=*/0.3f, /*atol=*/0.3f); }));
+    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/0.9999));
+}
+
+// fp8_e4m3 -> fp8_e4m3 identity. Lossless round-trip.
+static void case_fp8_to_fp8(distributed::MeshDevice& md, const std::string& kernel) {
+    constexpr std::uint32_t num_tiles = 64;
+    auto src_vec = create_random_vector_of_float8_e4m3(
+        tt::tile_size(tt::DataFormat::Fp8_e4m3) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result_vec = run_fp8_typecast(
+        md, tt::DataFormat::Fp8_e4m3, tt::DataFormat::Fp8_e4m3, src_vec, num_tiles, /*fp32_dest_acc_en=*/true, kernel);
+    auto src_floats = fp8_to_floats(src_vec);
+    auto dst_floats = fp8_to_floats(result_vec);
+    EXPECT_TRUE(is_close_vectors<float>(
+        src_floats, dst_floats, [](float a, float b) { return is_close(a, b, /*rtol=*/0.0f, /*atol=*/0.0f); }));
+    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/1.0));
+}
+
+// Float16_b -> Float16_b identity. Lossless round-trip. fp32_dest_acc_en selects Dest 16b vs 32b mode.
+static void case_bf16_to_bf16(distributed::MeshDevice& md, const std::string& kernel, bool fp32_dest_acc_en) {
+    constexpr std::uint32_t num_tiles = 64;
+    auto src_vec = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result_vec = run_fp8_typecast(
+        md, tt::DataFormat::Float16_b, tt::DataFormat::Float16_b, src_vec, num_tiles, fp32_dest_acc_en, kernel);
+    auto src_floats = bf16_to_floats(src_vec);
+    auto dst_floats = bf16_to_floats(result_vec);
+    EXPECT_TRUE(is_close_vectors<float>(
+        src_floats, dst_floats, [](float a, float b) { return is_close(a, b, /*rtol=*/0.0f, /*atol=*/0.0f); }));
+    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/1.0));
+}
+
 }  // namespace unit_tests::llk::fp8_typecast
 
 using namespace unit_tests::llk::fp8_typecast;
 
 // ============================================================================
-// fp8_e4m3 → Float16_b
-// Widening conversion: every fp8 value is exactly representable in BF16.
-// Expected: no precision loss → rtol=0.0, atol=0.0.
+// Legacy CB-id datacopy API — pre-existing fp8 typecast coverage (#40287), validated against a host golden.
 // ============================================================================
-
-TEST_F(LLKBlackholeSingleCardFixture, TensixFp8e4m3ToFloat16b) {
-    auto& mesh_device = *devices_[0];
-    constexpr uint32_t num_tiles = 64;
-    auto src_vec = create_random_vector_of_float8_e4m3(
-        tt::tile_size(tt::DataFormat::Fp8_e4m3) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
-    auto result_vec = run_fp8_typecast(
-        mesh_device,
-        tt::DataFormat::Fp8_e4m3,
-        tt::DataFormat::Float16_b,
-        src_vec,
-        num_tiles,
-        /*fp32_dest_acc_en=*/true);  // BH: Fp8 requires fp32_dest_acc_en=true (JIT-enforced)
-    auto src_floats = fp8_to_floats(src_vec);
-    auto dst_floats = bf16_to_floats(result_vec);
-    EXPECT_TRUE(is_close_vectors<float>(
-        src_floats, dst_floats, [](float a, float b) { return is_close(a, b, /*rtol=*/0.0f, /*atol=*/0.0f); }));
-    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/1.0));
-}
-
-// ============================================================================
-// Float16_b → fp8_e4m3
-// Narrowing: BF16 has 7 mantissa bits vs fp8's 3 → precision loss expected.
-// rtol=0.125 covers the max relative quantization error of fp8 (~1/8).
-// ============================================================================
-
-TEST_F(LLKBlackholeSingleCardFixture, TensixFloat16bToFp8e4m3) {
-    auto& mesh_device = *devices_[0];
-    constexpr uint32_t num_tiles = 64;
-    auto src_vec = create_random_vector_of_bfloat16(
-        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
-    auto result_vec = run_fp8_typecast(
-        mesh_device,
-        tt::DataFormat::Float16_b,
-        tt::DataFormat::Fp8_e4m3,
-        src_vec,
-        num_tiles,
-        /*fp32_dest_acc_en=*/true);  // BH: Fp8 requires fp32_dest_acc_en=true (JIT-enforced)
-    auto src_floats = bf16_to_floats(src_vec);
-    auto dst_floats = fp8_to_floats(result_vec);
-    EXPECT_TRUE(is_close_vectors<float>(
-        src_floats, dst_floats, [](float a, float b) { return is_close(a, b, /*rtol=*/0.125f, /*atol=*/0.015625f); }));
-    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/0.999));
-}
-
-// ============================================================================
-// fp8_e4m3 → Bfp8_b
-// Widening: Bfp8_b has 8 mantissa bits and a shared exponent per 16-element
-// row. For test data within [-10, 10], fp8 values may lose significant
-// precision due to the blocking forming process.
-// ============================================================================
-
-TEST_F(LLKBlackholeSingleCardFixture, TensixFp8e4m3ToBfp8b) {
-    auto& mesh_device = *devices_[0];
-    constexpr uint32_t num_tiles = 64;
-    auto src_vec = create_random_vector_of_float8_e4m3(
-        tt::tile_size(tt::DataFormat::Fp8_e4m3) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
-    auto result_vec = run_fp8_typecast(
-        mesh_device,
-        tt::DataFormat::Fp8_e4m3,
-        tt::DataFormat::Bfp8_b,
-        src_vec,
-        num_tiles,
-        /*fp32_dest_acc_en=*/true);  // BH: Fp8 requires fp32_dest_acc_en=true (JIT-enforced)
-    auto src_floats = fp8_to_floats(src_vec);
-    auto dst_floats = bfp8_to_floats(result_vec);
-    EXPECT_TRUE(is_close_vectors<float>(
-        src_floats, dst_floats, [](float a, float b) { return is_close(a, b, /*rtol=*/0.3f, /*atol=*/0.3f); }));
-    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/0.9999));
-}
-
-// ============================================================================
-// Bfp8_b → fp8_e4m3
-// Narrowing: Bfp8_b has 8 mantissa bits vs fp8's 3 → precision loss expected.
-// ============================================================================
-
-TEST_F(LLKBlackholeSingleCardFixture, TensixBfp8bToFp8e4m3) {
-    auto& mesh_device = *devices_[0];
-    constexpr uint32_t num_tiles = 64;
-    auto src_vec = tt::test_utils::create_random_vector_of_bfp8(
-        tt::tile_size(tt::DataFormat::Bfp8_b) * num_tiles,
-        /*is_exp_a=*/false,
-        /*rand_max_float=*/20,
-        /*seed=*/42,
-        /*offset=*/-10.0f);
-    auto result_vec = run_fp8_typecast(
-        mesh_device,
-        tt::DataFormat::Bfp8_b,
-        tt::DataFormat::Fp8_e4m3,
-        src_vec,
-        num_tiles,
-        /*fp32_dest_acc_en=*/true);  // BH: Fp8 requires fp32_dest_acc_en=true (JIT-enforced)
-    auto src_floats = bfp8_to_floats(src_vec);
-    auto dst_floats = fp8_to_floats(result_vec);
-    EXPECT_TRUE(is_close_vectors<float>(
-        src_floats, dst_floats, [](float a, float b) { return is_close(a, b, /*rtol=*/0.125f, /*atol=*/0.015625f); }));
-    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/0.999));
-}
-
-// ============================================================================
-// Bfp8_b → Bfp8_b (identity)
-// Same format on both sides. The unpack→Dest→repack round-trip through the
-// shared-exponent blocking process may introduce minor rounding, but PCC
-// should remain very high.
-// ============================================================================
-
+TEST_F(LLKBlackholeSingleCardFixture, TensixFp8e4m3ToFloat16b) { case_fp8_to_bf16(*devices_[0], kLegacyKernel); }
+TEST_F(LLKBlackholeSingleCardFixture, TensixFloat16bToFp8e4m3) { case_bf16_to_fp8(*devices_[0], kLegacyKernel); }
+TEST_F(LLKBlackholeSingleCardFixture, TensixFp8e4m3ToBfp8b) { case_fp8_to_bfp8(*devices_[0], kLegacyKernel); }
+TEST_F(LLKBlackholeSingleCardFixture, TensixBfp8bToFp8e4m3) { case_bfp8_to_fp8(*devices_[0], kLegacyKernel); }
 TEST_F(LLKBlackholeSingleCardFixture, TensixBfp8bToBfp8b) {
-    auto& mesh_device = *devices_[0];
-    constexpr uint32_t num_tiles = 64;
-    auto src_vec = tt::test_utils::create_random_vector_of_bfp8(
-        tt::tile_size(tt::DataFormat::Bfp8_b) * num_tiles,
-        /*is_exp_a=*/false,
-        /*rand_max_float=*/20,
-        /*seed=*/42,
-        /*offset=*/-10.0f);
-    auto result_vec = run_fp8_typecast(
-        mesh_device, tt::DataFormat::Bfp8_b, tt::DataFormat::Bfp8_b, src_vec, num_tiles, /*fp32_dest_acc_en=*/false);
-    auto src_floats = bfp8_to_floats(src_vec);
-    auto dst_floats = bfp8_to_floats(result_vec);
-    EXPECT_TRUE(is_close_vectors<float>(
-        src_floats, dst_floats, [](float a, float b) { return is_close(a, b, /*rtol=*/0.3f, /*atol=*/0.3f); }));
-    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/0.9999));
+    case_bfp8_to_bfp8(*devices_[0], kLegacyKernel, /*fp32_dest_acc_en=*/false);
 }
-
 TEST_F(LLKBlackholeSingleCardFixture, TensixBfp8bToBfp8bFp32Dest) {
-    auto& mesh_device = *devices_[0];
-    constexpr uint32_t num_tiles = 64;
-    auto src_vec = tt::test_utils::create_random_vector_of_bfp8(
-        tt::tile_size(tt::DataFormat::Bfp8_b) * num_tiles,
-        /*is_exp_a=*/false,
-        /*rand_max_float=*/20,
-        /*seed=*/42,
-        /*offset=*/-10.0f);
-    auto result_vec = run_fp8_typecast(
-        mesh_device, tt::DataFormat::Bfp8_b, tt::DataFormat::Bfp8_b, src_vec, num_tiles, /*fp32_dest_acc_en=*/true);
-    auto src_floats = bfp8_to_floats(src_vec);
-    auto dst_floats = bfp8_to_floats(result_vec);
-    EXPECT_TRUE(is_close_vectors<float>(
-        src_floats, dst_floats, [](float a, float b) { return is_close(a, b, /*rtol=*/0.3f, /*atol=*/0.3f); }));
-    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/0.9999));
+    case_bfp8_to_bfp8(*devices_[0], kLegacyKernel, /*fp32_dest_acc_en=*/true);
 }
-
-// ============================================================================
-// fp8_e4m3 → fp8_e4m3 (identity)
-// Same format on both sides. The round-trip should be lossless since every
-// fp8 value survives the unpack→Dest→repack cycle exactly.
-// ============================================================================
-
-TEST_F(LLKBlackholeSingleCardFixture, TensixFp8e4m3ToFp8e4m3) {
-    auto& mesh_device = *devices_[0];
-    constexpr uint32_t num_tiles = 64;
-    auto src_vec = create_random_vector_of_float8_e4m3(
-        tt::tile_size(tt::DataFormat::Fp8_e4m3) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
-    auto result_vec = run_fp8_typecast(
-        mesh_device,
-        tt::DataFormat::Fp8_e4m3,
-        tt::DataFormat::Fp8_e4m3,
-        src_vec,
-        num_tiles,
-        /*fp32_dest_acc_en=*/true);  // BH: Fp8 requires fp32_dest_acc_en=true (JIT-enforced)
-    auto src_floats = fp8_to_floats(src_vec);
-    auto dst_floats = fp8_to_floats(result_vec);
-    EXPECT_TRUE(is_close_vectors<float>(
-        src_floats, dst_floats, [](float a, float b) { return is_close(a, b, /*rtol=*/0.0f, /*atol=*/0.0f); }));
-    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/1.0));
-}
-
-// ============================================================================
-// Float16_b → Float16_b (identity)
-// Same format on both sides. The round-trip should be lossless since every
-// BF16 value survives the unpack→Dest→repack cycle exactly.
-// ============================================================================
-
+TEST_F(LLKBlackholeSingleCardFixture, TensixFp8e4m3ToFp8e4m3) { case_fp8_to_fp8(*devices_[0], kLegacyKernel); }
 TEST_F(LLKBlackholeSingleCardFixture, TensixFloat16bToFloat16b) {
-    auto& mesh_device = *devices_[0];
-    constexpr uint32_t num_tiles = 64;
-    auto src_vec = create_random_vector_of_bfloat16(
-        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
-    auto result_vec = run_fp8_typecast(
-        mesh_device,
-        tt::DataFormat::Float16_b,
-        tt::DataFormat::Float16_b,
-        src_vec,
-        num_tiles,
-        /*fp32_dest_acc_en=*/false);
-    auto src_floats = bf16_to_floats(src_vec);
-    auto dst_floats = bf16_to_floats(result_vec);
-    EXPECT_TRUE(is_close_vectors<float>(
-        src_floats, dst_floats, [](float a, float b) { return is_close(a, b, /*rtol=*/0.0f, /*atol=*/0.0f); }));
-    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/1.0));
+    case_bf16_to_bf16(*devices_[0], kLegacyKernel, /*fp32_dest_acc_en=*/false);
+}
+TEST_F(LLKBlackholeSingleCardFixture, TensixFloat16bToFloat16bFp32Dest) {
+    case_bf16_to_bf16(*devices_[0], kLegacyKernel, /*fp32_dest_acc_en=*/true);
 }
 
-TEST_F(LLKBlackholeSingleCardFixture, TensixFloat16bToFloat16bFp32Dest) {
-    auto& mesh_device = *devices_[0];
-    constexpr uint32_t num_tiles = 64;
-    auto src_vec = create_random_vector_of_bfloat16(
-        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
-    auto result_vec = run_fp8_typecast(
-        mesh_device,
-        tt::DataFormat::Float16_b,
-        tt::DataFormat::Float16_b,
-        src_vec,
-        num_tiles,
-        /*fp32_dest_acc_en=*/true);
-    auto src_floats = bf16_to_floats(src_vec);
-    auto dst_floats = bf16_to_floats(result_vec);
-    EXPECT_TRUE(is_close_vectors<float>(
-        src_floats, dst_floats, [](float a, float b) { return is_close(a, b, /*rtol=*/0.0f, /*atol=*/0.0f); }));
-    EXPECT_TRUE(check_pcc(src_floats, dst_floats, /*min_pcc=*/1.0));
+// ============================================================================
+// Id-free (2.0) datacopy API — same cases/golden as above, exercising the LLKOperand kernel.
+// ============================================================================
+TEST_F(LLKBlackholeSingleCardFixture, TensixFp8e4m3ToFloat16bIdFreeGolden) {
+    case_fp8_to_bf16(*devices_[0], kComputeKernel);
+}
+TEST_F(LLKBlackholeSingleCardFixture, TensixFloat16bToFp8e4m3IdFreeGolden) {
+    case_bf16_to_fp8(*devices_[0], kComputeKernel);
+}
+TEST_F(LLKBlackholeSingleCardFixture, TensixFp8e4m3ToBfp8bIdFreeGolden) {
+    case_fp8_to_bfp8(*devices_[0], kComputeKernel);
+}
+TEST_F(LLKBlackholeSingleCardFixture, TensixBfp8bToFp8e4m3IdFreeGolden) {
+    case_bfp8_to_fp8(*devices_[0], kComputeKernel);
+}
+TEST_F(LLKBlackholeSingleCardFixture, TensixBfp8bToBfp8bIdFreeGolden) {
+    case_bfp8_to_bfp8(*devices_[0], kComputeKernel, /*fp32_dest_acc_en=*/false);
+}
+TEST_F(LLKBlackholeSingleCardFixture, TensixBfp8bToBfp8bFp32DestIdFreeGolden) {
+    case_bfp8_to_bfp8(*devices_[0], kComputeKernel, /*fp32_dest_acc_en=*/true);
+}
+TEST_F(LLKBlackholeSingleCardFixture, TensixFp8e4m3ToFp8e4m3IdFreeGolden) {
+    case_fp8_to_fp8(*devices_[0], kComputeKernel);
+}
+TEST_F(LLKBlackholeSingleCardFixture, TensixFloat16bToFloat16bIdFreeGolden) {
+    case_bf16_to_bf16(*devices_[0], kComputeKernel, /*fp32_dest_acc_en=*/false);
+}
+TEST_F(LLKBlackholeSingleCardFixture, TensixFloat16bToFloat16bFp32DestIdFreeGolden) {
+    case_bf16_to_bf16(*devices_[0], kComputeKernel, /*fp32_dest_acc_en=*/true);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_pack_rows.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_pack_rows.cpp
@@ -27,6 +27,7 @@
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/print_helpers.hpp"
 #include <umd/device/types/arch.hpp>
+#include "single_core_compute_runners.hpp"
 
 namespace tt::tt_metal {
 class IDevice;
@@ -44,7 +45,7 @@ struct TestConfig {
     // Whether or not to sync full/half DST between MATH and PACK:
     bool dst_full_sync_en = false;
     // Number of rows to pack from DEST (1-64):
-    uint32_t num_rows;
+    std::uint32_t num_rows;
 };
 
 void run_single_core_pack_rows_program(
@@ -60,29 +61,29 @@ void run_single_core_pack_rows_program(
     CoreCoord core = {0, 0};
 
     // Input: 1 tile (32x32 = 1024 bfloat16 = 2048 bytes)
-    uint32_t input_single_tile_size = 2 * 1024;
+    std::uint32_t input_single_tile_size = 2 * 1024;
     // Output: num_rows * 16 datums * 2 bytes each
-    uint32_t output_size = test_config.num_rows * 16 * 2;
+    std::uint32_t output_size = test_config.num_rows * 16 * 2;
 
     auto src0_dram_buffer = distributed::MeshBuffer::create(
         distributed::ReplicatedBufferConfig{.size = input_single_tile_size},
         {.page_size = input_single_tile_size, .buffer_type = tt_metal::BufferType::DRAM},
         mesh_device.get());
-    uint32_t dram_buffer_src0_addr = src0_dram_buffer->address();
+    std::uint32_t dram_buffer_src0_addr = src0_dram_buffer->address();
 
     auto dst_dram_buffer = distributed::MeshBuffer::create(
         distributed::ReplicatedBufferConfig{.size = output_size},
         {.page_size = output_size, .buffer_type = tt_metal::BufferType::DRAM},
         mesh_device.get());
-    uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
+    std::uint32_t dram_buffer_dst_addr = dst_dram_buffer->address();
 
-    uint32_t src0_cb_index = tt::CBIndex::c_0;
+    std::uint32_t src0_cb_index = tt::CBIndex::c_0;
     tt_metal::CircularBufferConfig cb_src0_config =
         tt_metal::CircularBufferConfig(input_single_tile_size, {{src0_cb_index, tt::DataFormat::Float16_b}})
             .set_page_size(src0_cb_index, input_single_tile_size);
     tt_metal::CreateCircularBuffer(program_, core, cb_src0_config);
 
-    uint32_t output_cb_index = tt::CBIndex::c_16;
+    std::uint32_t output_cb_index = tt::CBIndex::c_16;
     tt_metal::CircularBufferConfig cb_output_config =
         tt_metal::CircularBufferConfig(output_size, {{output_cb_index, tt::DataFormat::Float16_b}})
             .set_page_size(output_cb_index, output_size);
@@ -102,8 +103,8 @@ void run_single_core_pack_rows_program(
         tt_metal::DataMovementConfig{
             .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default});
 
-    vector<uint32_t> compute_kernel_args = {
-        uint(test_config.num_rows),
+    vector<std::uint32_t> compute_kernel_args = {
+        std::uint32_t(test_config.num_rows),
     };
 
     tt_metal::CreateKernel(
@@ -116,8 +117,8 @@ void run_single_core_pack_rows_program(
             .compile_args = compute_kernel_args});
 
     // Generate tilized input data with sequential values
-    std::vector<uint32_t> src0_vec;
-    for (uint32_t i = 0; i < input_single_tile_size / sizeof(uint32_t); i++) {
+    std::vector<std::uint32_t> src0_vec;
+    for (std::uint32_t i = 0; i < input_single_tile_size / sizeof(std::uint32_t); i++) {
         bfloat16 val1(static_cast<float>(i * 2));
         bfloat16 val2(static_cast<float>((i * 2) + 1));
         src0_vec.push_back(pack_two_bfloat16_into_uint32({val1, val2}));
@@ -129,24 +130,25 @@ void run_single_core_pack_rows_program(
         reader_kernel,
         core,
         {dram_buffer_src0_addr,
-         (uint32_t)0,  // dram bank id
-         (uint32_t)1,  // num_tiles
+         (std::uint32_t)0,  // dram bank id
+         (std::uint32_t)1,  // num_tiles
          src0_cb_index,
-         (uint32_t)1,  // block_size
+         (std::uint32_t)1,  // block_size
          false});
 
-    tt_metal::SetRuntimeArgs(program_, unary_writer_kernel, core, {dram_buffer_dst_addr, (uint32_t)0, (uint32_t)1});
+    tt_metal::SetRuntimeArgs(
+        program_, unary_writer_kernel, core, {dram_buffer_dst_addr, (std::uint32_t)0, (std::uint32_t)1});
 
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::Finish(cq);
 
-    std::vector<uint32_t> result_vec;
+    std::vector<std::uint32_t> result_vec;
     distributed::EnqueueReadMeshBuffer(cq, result_vec, dst_dram_buffer, /*blocking=*/true);
 
     ::unit_tests::compute::PackRowsConfig golden_config = {
         .num_rows = static_cast<int>(test_config.num_rows),
     };
-    vector<uint32_t> golden = ::unit_tests::compute::gold_standard_pack_rows(src0_vec, golden_config);
+    vector<std::uint32_t> golden = ::unit_tests::compute::gold_standard_pack_rows(src0_vec, golden_config);
 
     EXPECT_EQ(golden.size(), result_vec.size());
     EXPECT_EQ(golden, result_vec);
@@ -201,5 +203,30 @@ INSTANTIATE_TEST_SUITE_P(
     [](const testing::TestParamInfo<TensixComputePackRowsTest::ParamType>& info) {
         return fmt::format("NumRows_{}_DstSync_{}", info.param.num_rows, info.param.dst_full_sync_en ? "On" : "Off");
     });
+
+// ============================================================================
+// Id-free (2.0) pack_rows: copies one Float16_b tile into DST then row-packs the full tile (num_rows = 64)
+// row-major to c_16. Validated against the gold_standard_pack_rows host golden (exact). Runs on Blackhole
+// (BH-only API). num_rows == 64 writes the whole output tile, so no uninitialized bytes.
+// ============================================================================
+TEST_F(LLKBlackholeSingleCardFixture, TensixPackRowsIdFreeGolden) {
+    constexpr std::uint32_t num_tiles = 1;
+    constexpr int num_rows = 64;  // full tile (matches pack_rows_2_0.cpp)
+    auto src_vec = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result = unit_tests::llk::single_core::run_unary(
+        *this->devices_.at(0),
+        tt::DataFormat::Float16_b,
+        tt::DataFormat::Float16_b,
+        src_vec,
+        num_tiles,
+        /*fp32_dest_acc_en=*/false,
+        "tests/tt_metal/tt_metal/test_kernels/compute/pack_rows_2_0.cpp");
+
+    vector<std::uint32_t> golden = ::unit_tests::compute::gold_standard_pack_rows(
+        src_vec, ::unit_tests::compute::PackRowsConfig{.num_rows = num_rows});
+    EXPECT_EQ(golden.size(), result.size());
+    EXPECT_EQ(golden, result);
+}
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reconfig.cpp
@@ -40,6 +40,7 @@
 #include <umd/device/types/arch.hpp>
 #include "tt_metal/test_utils/bfloat_utils.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include "single_core_compute_runners.hpp"
 
 namespace tt::tt_metal {
 class IDevice;
@@ -88,22 +89,23 @@ bool single_core_reconfig(
     //                      Application Setup
     ////////////////////////////////////////////////////////////////////////////
     bool pass = true;
-    uint32_t in0_id = 0;
-    uint32_t in1_id = 1;
-    uint32_t in2_id = 2;
-    uint32_t out0_id = 16;
-    uint32_t out1_id = 17;
+    std::uint32_t in0_id = 0;
+    std::uint32_t in1_id = 1;
+    std::uint32_t in2_id = 2;
+    std::uint32_t out0_id = 16;
+    std::uint32_t out1_id = 17;
     static float out0_result_old = 0;
     // Since golden is not perfect, some corner cases for these values will
     // make the tests fail. However, this is a representative example since
-    // it utilizes the full BFP16 presicion and range:
+    // it utilizes the full BFP16 precision and range:
     float in0_val = 1.0;
     float in1_val = 127.0;
     float in2_val = 0.0078125;
-    uint32_t single_tile_size_fp32 = 4 * tt::constants::TILE_HW;
-    uint32_t single_tile_size_bfp16b = 2 * tt::constants::TILE_HW;
-    uint32_t single_tile_size_bfp8b = tt::constants::BFLOAT8_B_TILE_HW;
-    uint32_t single_tile_size_out0 = test_config.fp32_dest_acc_en ? single_tile_size_fp32 : single_tile_size_bfp16b;
+    std::uint32_t single_tile_size_fp32 = 4 * tt::constants::TILE_HW;
+    std::uint32_t single_tile_size_bfp16b = 2 * tt::constants::TILE_HW;
+    std::uint32_t single_tile_size_bfp8b = tt::constants::BFLOAT8_B_TILE_HW;
+    std::uint32_t single_tile_size_out0 =
+        test_config.fp32_dest_acc_en ? single_tile_size_fp32 : single_tile_size_bfp16b;
     const size_t dram_buffer_size_bfp16b = test_config.num_tiles * single_tile_size_bfp16b;
     const size_t dram_buffer_size_bfp8b = test_config.num_tiles * single_tile_size_bfp8b;
     const size_t dram_buffer_size_out0 = test_config.num_tiles * single_tile_size_out0;
@@ -126,29 +128,29 @@ bool single_core_reconfig(
     // This will be srcB in Bfp8_b
     auto input0_dram_buffer = distributed::MeshBuffer::create(
         distributed::ReplicatedBufferConfig{.size = dram_buffer_size_bfp8b}, dram_config_bfp8b, mesh_device.get());
-    uint32_t input0_dram_byte_address = input0_dram_buffer->address();
+    std::uint32_t input0_dram_byte_address = input0_dram_buffer->address();
 
     // This will be srcA in Float16_b
     auto input1_dram_buffer = distributed::MeshBuffer::create(
         distributed::ReplicatedBufferConfig{.size = dram_buffer_size_bfp16b}, dram_config_bfp16b, mesh_device.get());
-    uint32_t input1_dram_byte_address = input1_dram_buffer->address();
+    std::uint32_t input1_dram_byte_address = input1_dram_buffer->address();
 
     // This will be DEST in Float16_b
     auto input2_dram_buffer = distributed::MeshBuffer::create(
         distributed::ReplicatedBufferConfig{.size = dram_buffer_size_bfp16b}, dram_config_bfp16b, mesh_device.get());
-    uint32_t input2_dram_byte_address = input2_dram_buffer->address();
+    std::uint32_t input2_dram_byte_address = input2_dram_buffer->address();
 
     // This will be Output0 in Float32 or Float16_b depending on fp32_dest_acc_en
     auto output0_dram_buffer = distributed::MeshBuffer::create(
         distributed::ReplicatedBufferConfig{.size = dram_buffer_size_out0},
         {.page_size = dram_buffer_size_out0, .buffer_type = tt::tt_metal::BufferType::DRAM},
         mesh_device.get());
-    uint32_t output0_dram_byte_address = output0_dram_buffer->address();
+    std::uint32_t output0_dram_byte_address = output0_dram_buffer->address();
 
     // This will be Output1 in Bfp8_b
     auto output1_dram_buffer = distributed::MeshBuffer::create(
         distributed::ReplicatedBufferConfig{.size = dram_buffer_size_bfp8b}, dram_config_bfp8b, mesh_device.get());
-    uint32_t output1_dram_byte_address = output1_dram_buffer->address();
+    std::uint32_t output1_dram_byte_address = output1_dram_buffer->address();
 
     tt_metal::CircularBufferConfig l1_input0_cb_config =
         tt_metal::CircularBufferConfig(dram_buffer_size_bfp8b, {{in0_id, tt::DataFormat::Bfp8_b}})
@@ -177,7 +179,7 @@ bool single_core_reconfig(
             .set_page_size(out1_id, single_tile_size_bfp8b);
     tt_metal::CreateCircularBuffer(program_, core, l1_output1_cb_config);
 
-    vector<uint32_t> compute_kernel_args = {};
+    vector<std::uint32_t> compute_kernel_args = {};
     std::map<std::string, std::string> defines;
 
     defines["LOAD_BUF2_DATA"] = "1";  // Needed always in order for reader kernel to load data from CB2
@@ -217,8 +219,8 @@ bool single_core_reconfig(
         compute_kernel,
         core,
         {
-            uint32_t(test_config.num_tiles),
-            uint32_t(test_config.ublock_size_tiles),
+            std::uint32_t(test_config.num_tiles),
+            std::uint32_t(test_config.ublock_size_tiles),
         });
 
     ////////////////////////////////////////////////////////////////////////////
@@ -229,9 +231,9 @@ bool single_core_reconfig(
     // is in different format than the other. If thread reconfiguration is done
     // incorrectly or underlying API/LLK is broken, this will be shown in either
     // difference in output sizes or values.
-    std::vector<uint32_t> src0_vec = create_constant_vector_of_bfp8(dram_buffer_size_bfp8b, in0_val, false);
-    std::vector<uint32_t> src1_vec = create_constant_vector_of_bfloat16(dram_buffer_size_bfp16b, in1_val);
-    std::vector<uint32_t> src2_vec = create_constant_vector_of_bfloat16(dram_buffer_size_bfp16b, in2_val);
+    std::vector<std::uint32_t> src0_vec = create_constant_vector_of_bfp8(dram_buffer_size_bfp8b, in0_val, false);
+    std::vector<std::uint32_t> src1_vec = create_constant_vector_of_bfloat16(dram_buffer_size_bfp16b, in1_val);
+    std::vector<std::uint32_t> src2_vec = create_constant_vector_of_bfloat16(dram_buffer_size_bfp16b, in2_val);
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Golden Generation
@@ -254,7 +256,7 @@ bool single_core_reconfig(
     // This vector will hold unpacked Bfp8 result:
     std::vector<float> golden1(input1.size());
     // This vector will hold packed fp16_b/fp32 result:
-    std::vector<uint32_t> packed_golden0(input1.size());
+    std::vector<std::uint32_t> packed_golden0(input1.size());
     for (auto i = 0; i < temp_golden.size(); i++) {
         // Do temp = SrcA + SrcB:
         temp_golden[i] = static_cast<float>(input1[i]) + static_cast<float>(bfloat16(input0[i]));
@@ -274,15 +276,15 @@ bool single_core_reconfig(
         }
         // Cast float32 to "packed "uint32 out0 vector if fp32_dest_acc_en:
         if (test_config.fp32_dest_acc_en) {
-            packed_golden0[i] = std::bit_cast<uint32_t>(golden0_fp32[i]);
+            packed_golden0[i] = std::bit_cast<std::uint32_t>(golden0_fp32[i]);
         }
     }
     // Pack out0 vector if not fp32_dest_acc_en:
     if (!test_config.fp32_dest_acc_en) {
-        packed_golden0 = pack_vector<uint32_t, bfloat16>(golden0_bfp16);
+        packed_golden0 = pack_vector<std::uint32_t, bfloat16>(golden0_bfp16);
     }
     // Pack out1 vector:
-    std::vector<uint32_t> packed_golden1 = pack_as_bfp8_tiles(ttsl::make_const_span(golden1), true, false);
+    std::vector<std::uint32_t> packed_golden1 = pack_as_bfp8_tiles(ttsl::make_const_span(golden1), true, false);
 
     // ////////////////////////////////////////////////////////////////////////////
     // //                      Compile and Execute Application
@@ -291,23 +293,23 @@ bool single_core_reconfig(
     distributed::EnqueueWriteMeshBuffer(cq, input1_dram_buffer, src1_vec, /*blocking=*/true);
     distributed::EnqueueWriteMeshBuffer(cq, input2_dram_buffer, src2_vec, /*blocking=*/true);
 
-    static constexpr uint32_t k_input0_dram_bank_id = 0;
-    static constexpr uint32_t k_input1_dram_bank_id = 0;
-    static constexpr uint32_t k_input2_dram_bank_id = 0;
-    static constexpr uint32_t k_output0_dram_bank_id = 0;
-    static constexpr uint32_t k_output1_dram_bank_id = 0;
+    static constexpr std::uint32_t k_input0_dram_bank_id = 0;
+    static constexpr std::uint32_t k_input1_dram_bank_id = 0;
+    static constexpr std::uint32_t k_input2_dram_bank_id = 0;
+    static constexpr std::uint32_t k_output0_dram_bank_id = 0;
+    static constexpr std::uint32_t k_output1_dram_bank_id = 0;
 
     tt_metal::SetRuntimeArgs(
         program_,
         reader_kernel,
         core,
         {
-            (uint32_t)input0_dram_byte_address,
+            (std::uint32_t)input0_dram_byte_address,
             k_input0_dram_bank_id,  // dram bank id
-            (uint32_t)input1_dram_byte_address,
+            (std::uint32_t)input1_dram_byte_address,
             k_input1_dram_bank_id,
-            (uint32_t)test_config.num_tiles,
-            (uint32_t)input2_dram_byte_address,
+            (std::uint32_t)test_config.num_tiles,
+            (std::uint32_t)input2_dram_byte_address,
             k_input2_dram_bank_id,
         });
     tt_metal::SetRuntimeArgs(
@@ -315,14 +317,14 @@ bool single_core_reconfig(
         writer_kernel,
         core,
         {
-            (uint32_t)output0_dram_byte_address,
+            (std::uint32_t)output0_dram_byte_address,
             k_output0_dram_bank_id,
-            (uint32_t)out0_id,
-            (uint32_t)output1_dram_byte_address,
+            (std::uint32_t)out0_id,
+            (std::uint32_t)output1_dram_byte_address,
             k_output1_dram_bank_id,
-            (uint32_t)out1_id,
-            (uint32_t)test_config.num_tiles,
-            (uint32_t)test_config.ublock_size_tiles,
+            (std::uint32_t)out1_id,
+            (std::uint32_t)test_config.num_tiles,
+            (std::uint32_t)test_config.ublock_size_tiles,
         });
 
     distributed::EnqueueMeshWorkload(cq, workload, false);
@@ -331,16 +333,16 @@ bool single_core_reconfig(
     // ////////////////////////////////////////////////////////////////////////////
     // //                      Comparison Checking
     // ////////////////////////////////////////////////////////////////////////////
-    std::vector<uint32_t> dest0_buffer_data(src1_vec.size());
-    std::vector<uint32_t> dest1_buffer_data(src0_vec.size());
+    std::vector<std::uint32_t> dest0_buffer_data(src1_vec.size());
+    std::vector<std::uint32_t> dest1_buffer_data(src0_vec.size());
     distributed::EnqueueReadMeshBuffer(cq, dest0_buffer_data, output0_dram_buffer, /*blocking=*/true);
     distributed::EnqueueReadMeshBuffer(cq, dest1_buffer_data, output1_dram_buffer, /*blocking=*/true);
 
-    pass &= is_close_packed_vectors<bfloat16, uint32_t>(
+    pass &= is_close_packed_vectors<bfloat16, std::uint32_t>(
         dest0_buffer_data, packed_golden0, [&](const bfloat16& a, const bfloat16& b) {
             return is_close(a, b, 0.0155f);
         });
-    pass &= is_close_packed_vectors<bfloat16, uint32_t>(
+    pass &= is_close_packed_vectors<bfloat16, std::uint32_t>(
         dest1_buffer_data, packed_golden1, [&](const bfloat16& a, const bfloat16& b) {
             return is_close(a, b, 0.0155);
         });
@@ -350,15 +352,15 @@ bool single_core_reconfig(
 
 bool single_core_unpack_reconfig_quasar(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
     // Three matmul_tiles ops with unpack reconfig between pairs; see reconfig_unpack_quasar.cpp.
-    constexpr uint32_t kNumOps = 3;
-    const uint32_t f16_tile_size = tt::tile_size(tt::DataFormat::Float16_b);
-    const uint32_t f32_tile_size = tt::tile_size(tt::DataFormat::Float32);
-    const uint32_t out_bytes = kNumOps * f16_tile_size;
+    constexpr std::uint32_t kNumOps = 3;
+    const std::uint32_t f16_tile_size = tt::tile_size(tt::DataFormat::Float16_b);
+    const std::uint32_t f32_tile_size = tt::tile_size(tt::DataFormat::Float32);
+    const std::uint32_t out_bytes = kNumOps * f16_tile_size;
 
     const CoreCoord core = {0, 0};
     auto& cq = mesh_device->mesh_command_queue();
     auto zero_coord = distributed::MeshCoordinate(0, 0);
-    const experimental::NodeCoord node{static_cast<uint32_t>(core.x), static_cast<uint32_t>(core.y)};
+    const experimental::NodeCoord node{static_cast<std::uint32_t>(core.x), static_cast<std::uint32_t>(core.y)};
 
     distributed::DeviceLocalBufferConfig f16_dram_cfg{
         .page_size = f16_tile_size, .buffer_type = tt::tt_metal::BufferType::DRAM, .bottom_up = false};
@@ -512,15 +514,15 @@ bool single_core_unpack_reconfig_quasar(const std::shared_ptr<distributed::MeshD
     // stays in a sensible bfloat16 range; each output element is sum of 32 products).
     // d0/d1, d4/d5 are bfloat16 (Float16_b tile); d2/d3 are float32 (Float32 tile).
     constexpr int kRandMax = 1;
-    constexpr uint32_t elems_per_tile = tt::constants::TILE_HW;
+    constexpr std::uint32_t elems_per_tile = tt::constants::TILE_HW;
     auto src0 = create_random_vector_of_bfloat16(f16_tile_size, kRandMax, /*seed=*/0x1001);
     auto src1 = create_random_vector_of_bfloat16(f16_tile_size, kRandMax, /*seed=*/0x1002);
-    auto gen_random_f32 = [&](uint32_t seed) {
-        std::vector<uint32_t> packed(elems_per_tile);
+    auto gen_random_f32 = [&](std::uint32_t seed) {
+        std::vector<std::uint32_t> packed(elems_per_tile);
         std::mt19937 rng(seed);
         std::uniform_real_distribution<float> dist(0.0f, static_cast<float>(kRandMax));
-        for (uint32_t i = 0; i < elems_per_tile; ++i) {
-            packed[i] = std::bit_cast<uint32_t>(dist(rng));
+        for (std::uint32_t i = 0; i < elems_per_tile; ++i) {
+            packed[i] = std::bit_cast<std::uint32_t>(dist(rng));
         }
         return packed;
     };
@@ -538,7 +540,7 @@ bool single_core_unpack_reconfig_quasar(const std::shared_ptr<distributed::MeshD
 
     auto in0 = unpack_uint32_vec_into_bfloat16_vec(src0);
     auto in1 = unpack_uint32_vec_into_bfloat16_vec(src1);
-    auto unpack_f32 = [](const std::vector<uint32_t>& packed) {
+    auto unpack_f32 = [](const std::vector<std::uint32_t>& packed) {
         std::vector<float> out(packed.size());
         for (size_t i = 0; i < packed.size(); ++i) {
             out[i] = std::bit_cast<float>(packed[i]);
@@ -552,10 +554,10 @@ bool single_core_unpack_reconfig_quasar(const std::shared_ptr<distributed::MeshD
 
     // Face-aware index for a 32x32 tile laid out as 4 faces of 16x16 (face-row-major,
     // then row-major within face). Matches how the device sees a tile in DRAM/L1.
-    auto face_idx = [](uint32_t row, uint32_t col) -> uint32_t {
-        const uint32_t face = (row / tt::constants::FACE_HEIGHT) * 2 + (col / tt::constants::FACE_WIDTH);
-        const uint32_t r = row % tt::constants::FACE_HEIGHT;
-        const uint32_t c = col % tt::constants::FACE_WIDTH;
+    auto face_idx = [](std::uint32_t row, std::uint32_t col) -> std::uint32_t {
+        const std::uint32_t face = (row / tt::constants::FACE_HEIGHT) * 2 + (col / tt::constants::FACE_WIDTH);
+        const std::uint32_t r = row % tt::constants::FACE_HEIGHT;
+        const std::uint32_t c = col % tt::constants::FACE_WIDTH;
         return face * tt::constants::FACE_HW + r * tt::constants::FACE_WIDTH + c;
     };
 
@@ -563,10 +565,10 @@ bool single_core_unpack_reconfig_quasar(const std::shared_ptr<distributed::MeshD
     // sum; output is bfloat16-truncated (pack format is Float16_b).
     auto matmul_face = [&](auto& A, auto& B) -> std::vector<bfloat16> {
         std::vector<bfloat16> C(elems_per_tile);
-        for (uint32_t i = 0; i < tt::constants::TILE_HEIGHT; ++i) {
-            for (uint32_t j = 0; j < tt::constants::TILE_WIDTH; ++j) {
+        for (std::uint32_t i = 0; i < tt::constants::TILE_HEIGHT; ++i) {
+            for (std::uint32_t j = 0; j < tt::constants::TILE_WIDTH; ++j) {
                 float sum = 0.0f;
-                for (uint32_t k = 0; k < tt::constants::TILE_WIDTH; ++k) {
+                for (std::uint32_t k = 0; k < tt::constants::TILE_WIDTH; ++k) {
                     sum += static_cast<float>(A[face_idx(i, k)]) * static_cast<float>(B[face_idx(k, j)]);
                 }
                 C[face_idx(i, j)] = bfloat16(sum);
@@ -579,12 +581,12 @@ bool single_core_unpack_reconfig_quasar(const std::shared_ptr<distributed::MeshD
     auto golden_op1 = matmul_face(in2, in3);
     auto golden_op2 = matmul_face(in4, in5);
     std::vector<bfloat16> golden(kNumOps * elems_per_tile);
-    for (uint32_t e = 0; e < elems_per_tile; ++e) {
+    for (std::uint32_t e = 0; e < elems_per_tile; ++e) {
         golden[0 * elems_per_tile + e] = golden_op0[e];
         golden[1 * elems_per_tile + e] = golden_op1[e];
         golden[2 * elems_per_tile + e] = golden_op2[e];
     }
-    auto packed_golden = pack_vector<uint32_t, bfloat16>(golden);
+    auto packed_golden = pack_vector<std::uint32_t, bfloat16>(golden);
 
     experimental::ProgramRunArgs params;
     params.kernel_run_args = {
@@ -592,17 +594,17 @@ bool single_core_unpack_reconfig_quasar(const std::shared_ptr<distributed::MeshD
             .kernel = READER,
             .runtime_arg_values = experimental::MakeRuntimeArgsForSingleNode(
                 node,
-                {{"src0_addr", static_cast<uint32_t>(inp0_dram->address())},
+                {{"src0_addr", static_cast<std::uint32_t>(inp0_dram->address())},
                  {"src0_bank_id", 0u},
-                 {"src1_addr", static_cast<uint32_t>(inp1_dram->address())},
+                 {"src1_addr", static_cast<std::uint32_t>(inp1_dram->address())},
                  {"src1_bank_id", 0u},
-                 {"src2_addr", static_cast<uint32_t>(inp2_dram->address())},
+                 {"src2_addr", static_cast<std::uint32_t>(inp2_dram->address())},
                  {"src2_bank_id", 0u},
-                 {"src3_addr", static_cast<uint32_t>(inp3_dram->address())},
+                 {"src3_addr", static_cast<std::uint32_t>(inp3_dram->address())},
                  {"src3_bank_id", 0u},
-                 {"src4_addr", static_cast<uint32_t>(inp4_dram->address())},
+                 {"src4_addr", static_cast<std::uint32_t>(inp4_dram->address())},
                  {"src4_bank_id", 0u},
-                 {"src5_addr", static_cast<uint32_t>(inp5_dram->address())},
+                 {"src5_addr", static_cast<std::uint32_t>(inp5_dram->address())},
                  {"src5_bank_id", 0u},
                  {"num_tiles", 1u}}),
         },
@@ -610,7 +612,9 @@ bool single_core_unpack_reconfig_quasar(const std::shared_ptr<distributed::MeshD
             .kernel = WRITER,
             .runtime_arg_values = experimental::MakeRuntimeArgsForSingleNode(
                 node,
-                {{"dst_addr", static_cast<uint32_t>(out_dram->address())}, {"bank_id", 0u}, {"num_tiles", kNumOps}}),
+                {{"dst_addr", static_cast<std::uint32_t>(out_dram->address())},
+                 {"bank_id", 0u},
+                 {"num_tiles", kNumOps}}),
         },
         experimental::ProgramRunArgs::KernelRunArgs{.kernel = COMPUTE},
     };
@@ -618,18 +622,18 @@ bool single_core_unpack_reconfig_quasar(const std::shared_ptr<distributed::MeshD
 
     LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
-    std::vector<uint32_t> dest_buffer_data;
+    std::vector<std::uint32_t> dest_buffer_data;
     distributed::ReadShard(cq, dest_buffer_data, out_dram, zero_coord, false);
 
-    auto device_unpacked = unpack_vector<bfloat16, uint32_t>(dest_buffer_data);
-    auto golden_unpacked = unpack_vector<bfloat16, uint32_t>(packed_golden);
+    auto device_unpacked = unpack_vector<bfloat16, std::uint32_t>(dest_buffer_data);
+    auto golden_unpacked = unpack_vector<bfloat16, std::uint32_t>(packed_golden);
 
     bool pass = true;
-    for (uint32_t t = 0; t < kNumOps; ++t) {
-        uint32_t mismatches = 0;
+    for (std::uint32_t t = 0; t < kNumOps; ++t) {
+        std::uint32_t mismatches = 0;
         int first_mismatch_local = -1;
         float worst_absdiff = 0.0f;
-        for (uint32_t e = 0; e < elems_per_tile; ++e) {
+        for (std::uint32_t e = 0; e < elems_per_tile; ++e) {
             const bfloat16 a = device_unpacked[t * elems_per_tile + e];
             const bfloat16 b = golden_unpacked[t * elems_per_tile + e];
             if (!is_close(a, b, 0.0155f, 0.001f)) {
@@ -663,13 +667,13 @@ bool single_core_unpack_reconfig_quasar(const std::shared_ptr<distributed::MeshD
 bool single_core_pack_reconfig_quasar(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
     // Same 3×2 matmul flow as unpack reconfig; pack reconfig+init per output at pack time; see
     // reconfig_pack_quasar.cpp.
-    const uint32_t f16_tile_size = tt::tile_size(tt::DataFormat::Float16_b);
-    const uint32_t f32_tile_size = tt::tile_size(tt::DataFormat::Float32);
+    const std::uint32_t f16_tile_size = tt::tile_size(tt::DataFormat::Float16_b);
+    const std::uint32_t f32_tile_size = tt::tile_size(tt::DataFormat::Float32);
 
     const CoreCoord core = {0, 0};
     auto& cq = mesh_device->mesh_command_queue();
     auto zero_coord = distributed::MeshCoordinate(0, 0);
-    const experimental::NodeCoord node{static_cast<uint32_t>(core.x), static_cast<uint32_t>(core.y)};
+    const experimental::NodeCoord node{static_cast<std::uint32_t>(core.x), static_cast<std::uint32_t>(core.y)};
 
     distributed::DeviceLocalBufferConfig f16_dram_cfg{
         .page_size = f16_tile_size, .buffer_type = tt::tt_metal::BufferType::DRAM, .bottom_up = false};
@@ -848,15 +852,15 @@ bool single_core_pack_reconfig_quasar(const std::shared_ptr<distributed::MeshDev
     Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
 
     constexpr int kRandMax = 1;
-    constexpr uint32_t elems_per_tile = tt::constants::TILE_HW;
+    constexpr std::uint32_t elems_per_tile = tt::constants::TILE_HW;
     auto src0 = create_random_vector_of_bfloat16(f16_tile_size, kRandMax, /*seed=*/0x2001);
     auto src1 = create_random_vector_of_bfloat16(f16_tile_size, kRandMax, /*seed=*/0x2002);
-    auto gen_random_f32 = [&](uint32_t seed) {
-        std::vector<uint32_t> packed(elems_per_tile);
+    auto gen_random_f32 = [&](std::uint32_t seed) {
+        std::vector<std::uint32_t> packed(elems_per_tile);
         std::mt19937 rng(seed);
         std::uniform_real_distribution<float> dist(0.0f, static_cast<float>(kRandMax));
-        for (uint32_t i = 0; i < elems_per_tile; ++i) {
-            packed[i] = std::bit_cast<uint32_t>(dist(rng));
+        for (std::uint32_t i = 0; i < elems_per_tile; ++i) {
+            packed[i] = std::bit_cast<std::uint32_t>(dist(rng));
         }
         return packed;
     };
@@ -874,7 +878,7 @@ bool single_core_pack_reconfig_quasar(const std::shared_ptr<distributed::MeshDev
 
     auto in0 = unpack_uint32_vec_into_bfloat16_vec(src0);
     auto in1 = unpack_uint32_vec_into_bfloat16_vec(src1);
-    auto unpack_f32 = [](const std::vector<uint32_t>& packed) {
+    auto unpack_f32 = [](const std::vector<std::uint32_t>& packed) {
         std::vector<float> out(packed.size());
         for (size_t i = 0; i < packed.size(); ++i) {
             out[i] = std::bit_cast<float>(packed[i]);
@@ -886,19 +890,19 @@ bool single_core_pack_reconfig_quasar(const std::shared_ptr<distributed::MeshDev
     auto in4 = unpack_uint32_vec_into_bfloat16_vec(src4);
     auto in5 = unpack_uint32_vec_into_bfloat16_vec(src5);
 
-    auto face_idx = [](uint32_t row, uint32_t col) -> uint32_t {
-        const uint32_t face = (row / tt::constants::FACE_HEIGHT) * 2 + (col / tt::constants::FACE_WIDTH);
-        const uint32_t r = row % tt::constants::FACE_HEIGHT;
-        const uint32_t c = col % tt::constants::FACE_WIDTH;
+    auto face_idx = [](std::uint32_t row, std::uint32_t col) -> std::uint32_t {
+        const std::uint32_t face = (row / tt::constants::FACE_HEIGHT) * 2 + (col / tt::constants::FACE_WIDTH);
+        const std::uint32_t r = row % tt::constants::FACE_HEIGHT;
+        const std::uint32_t c = col % tt::constants::FACE_WIDTH;
         return face * tt::constants::FACE_HW + r * tt::constants::FACE_WIDTH + c;
     };
 
     auto matmul_face = [&](auto& A, auto& B) -> std::vector<bfloat16> {
         std::vector<bfloat16> C(elems_per_tile);
-        for (uint32_t i = 0; i < tt::constants::TILE_HEIGHT; ++i) {
-            for (uint32_t j = 0; j < tt::constants::TILE_WIDTH; ++j) {
+        for (std::uint32_t i = 0; i < tt::constants::TILE_HEIGHT; ++i) {
+            for (std::uint32_t j = 0; j < tt::constants::TILE_WIDTH; ++j) {
                 float sum = 0.0f;
-                for (uint32_t k = 0; k < tt::constants::TILE_WIDTH; ++k) {
+                for (std::uint32_t k = 0; k < tt::constants::TILE_WIDTH; ++k) {
                     sum += static_cast<float>(A[face_idx(i, k)]) * static_cast<float>(B[face_idx(k, j)]);
                 }
                 C[face_idx(i, j)] = bfloat16(sum);
@@ -909,10 +913,10 @@ bool single_core_pack_reconfig_quasar(const std::shared_ptr<distributed::MeshDev
 
     auto matmul_face_f32 = [&](const std::vector<float>& A, const std::vector<float>& B) -> std::vector<float> {
         std::vector<float> C(elems_per_tile);
-        for (uint32_t i = 0; i < tt::constants::TILE_HEIGHT; ++i) {
-            for (uint32_t j = 0; j < tt::constants::TILE_WIDTH; ++j) {
+        for (std::uint32_t i = 0; i < tt::constants::TILE_HEIGHT; ++i) {
+            for (std::uint32_t j = 0; j < tt::constants::TILE_WIDTH; ++j) {
                 float sum = 0.0f;
-                for (uint32_t k = 0; k < tt::constants::TILE_WIDTH; ++k) {
+                for (std::uint32_t k = 0; k < tt::constants::TILE_WIDTH; ++k) {
                     sum += A[face_idx(i, k)] * B[face_idx(k, j)];
                 }
                 C[face_idx(i, j)] = sum;
@@ -924,11 +928,11 @@ bool single_core_pack_reconfig_quasar(const std::shared_ptr<distributed::MeshDev
     auto golden_op0 = matmul_face(in0, in1);
     auto golden_op1_f32 = matmul_face_f32(in2, in3);
     auto golden_op2 = matmul_face(in4, in5);
-    auto packed_golden_op0 = pack_vector<uint32_t, bfloat16>(golden_op0);
-    auto packed_golden_op2 = pack_vector<uint32_t, bfloat16>(golden_op2);
-    std::vector<uint32_t> packed_golden_op1(elems_per_tile);
-    for (uint32_t e = 0; e < elems_per_tile; ++e) {
-        packed_golden_op1[e] = std::bit_cast<uint32_t>(golden_op1_f32[e]);
+    auto packed_golden_op0 = pack_vector<std::uint32_t, bfloat16>(golden_op0);
+    auto packed_golden_op2 = pack_vector<std::uint32_t, bfloat16>(golden_op2);
+    std::vector<std::uint32_t> packed_golden_op1(elems_per_tile);
+    for (std::uint32_t e = 0; e < elems_per_tile; ++e) {
+        packed_golden_op1[e] = std::bit_cast<std::uint32_t>(golden_op1_f32[e]);
     }
 
     experimental::ProgramRunArgs params;
@@ -937,34 +941,37 @@ bool single_core_pack_reconfig_quasar(const std::shared_ptr<distributed::MeshDev
             .kernel = READER,
             .runtime_arg_values = experimental::MakeRuntimeArgsForSingleNode(
                 node,
-                {{"src0_addr", static_cast<uint32_t>(inp0_dram->address())},
+                {{"src0_addr", static_cast<std::uint32_t>(inp0_dram->address())},
                  {"src0_bank_id", 0u},
-                 {"src1_addr", static_cast<uint32_t>(inp1_dram->address())},
+                 {"src1_addr", static_cast<std::uint32_t>(inp1_dram->address())},
                  {"src1_bank_id", 0u},
-                 {"src2_addr", static_cast<uint32_t>(inp2_dram->address())},
+                 {"src2_addr", static_cast<std::uint32_t>(inp2_dram->address())},
                  {"src2_bank_id", 0u},
-                 {"src3_addr", static_cast<uint32_t>(inp3_dram->address())},
+                 {"src3_addr", static_cast<std::uint32_t>(inp3_dram->address())},
                  {"src3_bank_id", 0u},
-                 {"src4_addr", static_cast<uint32_t>(inp4_dram->address())},
+                 {"src4_addr", static_cast<std::uint32_t>(inp4_dram->address())},
                  {"src4_bank_id", 0u},
-                 {"src5_addr", static_cast<uint32_t>(inp5_dram->address())},
+                 {"src5_addr", static_cast<std::uint32_t>(inp5_dram->address())},
                  {"src5_bank_id", 0u},
                  {"num_tiles", 1u}}),
         },
         experimental::ProgramRunArgs::KernelRunArgs{
             .kernel = WRITER0,
             .runtime_arg_values = experimental::MakeRuntimeArgsForSingleNode(
-                node, {{"dst_addr", static_cast<uint32_t>(out0_dram->address())}, {"bank_id", 0u}, {"num_tiles", 1u}}),
+                node,
+                {{"dst_addr", static_cast<std::uint32_t>(out0_dram->address())}, {"bank_id", 0u}, {"num_tiles", 1u}}),
         },
         experimental::ProgramRunArgs::KernelRunArgs{
             .kernel = WRITER1,
             .runtime_arg_values = experimental::MakeRuntimeArgsForSingleNode(
-                node, {{"dst_addr", static_cast<uint32_t>(out1_dram->address())}, {"bank_id", 0u}, {"num_tiles", 1u}}),
+                node,
+                {{"dst_addr", static_cast<std::uint32_t>(out1_dram->address())}, {"bank_id", 0u}, {"num_tiles", 1u}}),
         },
         experimental::ProgramRunArgs::KernelRunArgs{
             .kernel = WRITER2,
             .runtime_arg_values = experimental::MakeRuntimeArgsForSingleNode(
-                node, {{"dst_addr", static_cast<uint32_t>(out2_dram->address())}, {"bank_id", 0u}, {"num_tiles", 1u}}),
+                node,
+                {{"dst_addr", static_cast<std::uint32_t>(out2_dram->address())}, {"bank_id", 0u}, {"num_tiles", 1u}}),
         },
         experimental::ProgramRunArgs::KernelRunArgs{.kernel = COMPUTE},
     };
@@ -972,80 +979,82 @@ bool single_core_pack_reconfig_quasar(const std::shared_ptr<distributed::MeshDev
 
     LaunchProgram(*mesh_device, std::move(program), /*wait_until_cores_done=*/true);
 
-    std::vector<uint32_t> out0_data;
-    std::vector<uint32_t> out1_data;
-    std::vector<uint32_t> out2_data;
+    std::vector<std::uint32_t> out0_data;
+    std::vector<std::uint32_t> out1_data;
+    std::vector<std::uint32_t> out2_data;
     distributed::ReadShard(cq, out0_data, out0_dram, zero_coord, false);
     distributed::ReadShard(cq, out1_data, out1_dram, zero_coord, false);
     distributed::ReadShard(cq, out2_data, out2_dram, zero_coord, false);
 
     bool pass = true;
 
-    auto check_bf16_tile =
-        [&](const std::vector<uint32_t>& device_data, const std::vector<uint32_t>& golden_packed, uint32_t op_idx) {
-            auto device_unpacked = unpack_vector<bfloat16, uint32_t>(device_data);
-            auto golden_unpacked = unpack_vector<bfloat16, uint32_t>(golden_packed);
-            uint32_t mismatches = 0;
-            int first_mismatch_local = -1;
-            float worst_absdiff = 0.0f;
-            for (uint32_t e = 0; e < elems_per_tile; ++e) {
-                const bfloat16 a = device_unpacked[e];
-                const bfloat16 b = golden_unpacked[e];
-                if (!is_close(a, b, 0.0155f, 0.001f)) {
-                    if (first_mismatch_local < 0) {
-                        first_mismatch_local = static_cast<int>(e);
-                    }
-                    ++mismatches;
-                    const float absdiff = std::fabs(static_cast<float>(a) - static_cast<float>(b));
-                    worst_absdiff = std::fmax(worst_absdiff, absdiff);
+    auto check_bf16_tile = [&](const std::vector<std::uint32_t>& device_data,
+                               const std::vector<std::uint32_t>& golden_packed,
+                               std::uint32_t op_idx) {
+        auto device_unpacked = unpack_vector<bfloat16, std::uint32_t>(device_data);
+        auto golden_unpacked = unpack_vector<bfloat16, std::uint32_t>(golden_packed);
+        std::uint32_t mismatches = 0;
+        int first_mismatch_local = -1;
+        float worst_absdiff = 0.0f;
+        for (std::uint32_t e = 0; e < elems_per_tile; ++e) {
+            const bfloat16 a = device_unpacked[e];
+            const bfloat16 b = golden_unpacked[e];
+            if (!is_close(a, b, 0.0155f, 0.001f)) {
+                if (first_mismatch_local < 0) {
+                    first_mismatch_local = static_cast<int>(e);
                 }
+                ++mismatches;
+                const float absdiff = std::fabs(static_cast<float>(a) - static_cast<float>(b));
+                worst_absdiff = std::fmax(worst_absdiff, absdiff);
             }
-            if (mismatches == 0) {
-                log_info(tt::LogTest, "OP[{}]: PASS", op_idx);
-            } else {
-                pass = false;
-                log_error(
-                    tt::LogTest,
-                    "OP[{}]: FAIL ({}/{} mismatches; first idx {}; worst absdiff={:.4f})",
-                    op_idx,
-                    mismatches,
-                    elems_per_tile,
-                    first_mismatch_local,
-                    worst_absdiff);
-            }
-        };
+        }
+        if (mismatches == 0) {
+            log_info(tt::LogTest, "OP[{}]: PASS", op_idx);
+        } else {
+            pass = false;
+            log_error(
+                tt::LogTest,
+                "OP[{}]: FAIL ({}/{} mismatches; first idx {}; worst absdiff={:.4f})",
+                op_idx,
+                mismatches,
+                elems_per_tile,
+                first_mismatch_local,
+                worst_absdiff);
+        }
+    };
 
-    auto check_f32_tile =
-        [&](const std::vector<uint32_t>& device_data, const std::vector<uint32_t>& golden_packed, uint32_t op_idx) {
-            uint32_t mismatches = 0;
-            int first_mismatch_local = -1;
-            float worst_absdiff = 0.0f;
-            for (uint32_t e = 0; e < elems_per_tile; ++e) {
-                const float a = std::bit_cast<float>(device_data[e]);
-                const float b = std::bit_cast<float>(golden_packed[e]);
-                if (!is_close(a, b, 0.001f, 0.0001f)) {
-                    if (first_mismatch_local < 0) {
-                        first_mismatch_local = static_cast<int>(e);
-                    }
-                    ++mismatches;
-                    const float absdiff = std::fabs(a - b);
-                    worst_absdiff = std::fmax(worst_absdiff, absdiff);
+    auto check_f32_tile = [&](const std::vector<std::uint32_t>& device_data,
+                              const std::vector<std::uint32_t>& golden_packed,
+                              std::uint32_t op_idx) {
+        std::uint32_t mismatches = 0;
+        int first_mismatch_local = -1;
+        float worst_absdiff = 0.0f;
+        for (std::uint32_t e = 0; e < elems_per_tile; ++e) {
+            const float a = std::bit_cast<float>(device_data[e]);
+            const float b = std::bit_cast<float>(golden_packed[e]);
+            if (!is_close(a, b, 0.001f, 0.0001f)) {
+                if (first_mismatch_local < 0) {
+                    first_mismatch_local = static_cast<int>(e);
                 }
+                ++mismatches;
+                const float absdiff = std::fabs(a - b);
+                worst_absdiff = std::fmax(worst_absdiff, absdiff);
             }
-            if (mismatches == 0) {
-                log_info(tt::LogTest, "OP[{}]: PASS", op_idx);
-            } else {
-                pass = false;
-                log_error(
-                    tt::LogTest,
-                    "OP[{}]: FAIL ({}/{} mismatches; first idx {}; worst absdiff={:.4f})",
-                    op_idx,
-                    mismatches,
-                    elems_per_tile,
-                    first_mismatch_local,
-                    worst_absdiff);
-            }
-        };
+        }
+        if (mismatches == 0) {
+            log_info(tt::LogTest, "OP[{}]: PASS", op_idx);
+        } else {
+            pass = false;
+            log_error(
+                tt::LogTest,
+                "OP[{}]: FAIL ({}/{} mismatches; first idx {}; worst absdiff={:.4f})",
+                op_idx,
+                mismatches,
+                elems_per_tile,
+                first_mismatch_local,
+                worst_absdiff);
+        }
+    };
 
     check_bf16_tile(out0_data, packed_golden_op0, 0);
     check_f32_tile(out1_data, packed_golden_op1, 1);
@@ -1128,6 +1137,26 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, TensixPackReconfigQuasarDfb) {
     for (auto& device : this->devices_) {
         ASSERT_TRUE(unit_tests::compute::reconfig::single_core_pack_reconfig_quasar(device));
     }
+}
+
+// ============================================================================
+// Id-free (2.0) reconfig_data_format_srca (matched-format): the kernel reprograms SrcA to c_0's OWN format
+// then copies c_0 -> DST -> c_16 (Float16_b -> Float16_b), so a correct reconfig leaves the data untouched and
+// the host golden is the identity (device output == input, bit-for-bit). Runs on Blackhole (BH-only API).
+// ============================================================================
+TEST_F(LLKBlackholeSingleCardFixture, TensixReconfigSrcaIdFreeIdentity) {
+    constexpr std::uint32_t num_tiles = 64;
+    auto src_vec = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result = unit_tests::llk::single_core::run_unary(
+        *this->devices_.at(0),
+        tt::DataFormat::Float16_b,
+        tt::DataFormat::Float16_b,
+        src_vec,
+        num_tiles,
+        /*fp32_dest_acc_en=*/false,
+        "tests/tt_metal/tt_metal/test_kernels/compute/reconfig_srca_2_0.cpp");
+    EXPECT_EQ(src_vec, result);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_reduce.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_reduce.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt_stl/reflection.hpp>
+#include <bit>
 #include <chrono>
 #include <fmt/base.h>
 #include <gtest/gtest.h>
@@ -45,6 +46,7 @@
 #include <tt-metalium/tensor/mesh_tensor.hpp>
 #include <tt-metalium/mxfp4.hpp>
 #include <tt-metalium/tile.hpp>
+#include "single_core_compute_runners.hpp"
 
 namespace tt::tt_metal {
 class IDevice;
@@ -59,12 +61,12 @@ using namespace constants;
 
 namespace unit_tests::compute::reduce {
 
-enum ReduceDim : uint8_t { H = 0, W = 1, HW = 2 };
+enum ReduceDim : std::uint8_t { H = 0, W = 1, HW = 2 };
 
-enum ReduceType : uint8_t { SUM = 0, AVG = 1, MAX = 2 };
+enum ReduceType : std::uint8_t { SUM = 0, AVG = 1, MAX = 2 };
 struct ReduceConfig {
     tt_metal::Tile tile_shape = tt_metal::Tile({TILE_HEIGHT, TILE_WIDTH});
-    std::vector<uint32_t> shape;
+    std::vector<std::uint32_t> shape;
     ReduceDim reduce_dim;
     ReduceType reduce_type = ReduceType::SUM;
     float data_gen_rand_max;
@@ -72,10 +74,10 @@ struct ReduceConfig {
     float data_gen_offset;
     float atol;
     float rtol;
-    std::function<std::vector<uint16_t>(
-        const std::vector<uint16_t>&, const std::vector<uint32_t>&, float, uint8_t, bool)>
+    std::function<std::vector<std::uint16_t>(
+        const std::vector<std::uint16_t>&, const std::vector<std::uint32_t>&, float, std::uint8_t, bool)>
         golden_function;
-    std::vector<uint32_t> result_shape;
+    std::vector<std::uint32_t> result_shape;
     bool math_only_reduce = false;
     // Whether or not we want the result to be stored in DST in FP32:
     bool fp32_dest_acc_en = false;
@@ -89,8 +91,8 @@ struct ReduceConfig {
 };
 
 float get_scaler(const ReduceConfig& test_config) {
-    uint32_t H = test_config.shape[2];
-    uint32_t W = test_config.shape[3];
+    std::uint32_t H = test_config.shape[2];
+    std::uint32_t W = test_config.shape[3];
     // If PoolType is MAX or SUM, then the operation is determined by PoolType,
     // but the scaler is 1
     if (test_config.reduce_type != ReduceType::AVG) {
@@ -109,19 +111,19 @@ float get_scaler(const ReduceConfig& test_config) {
 
 // Tiled dimensions and buffer sizes derived from a 4-D NCHW tensor shape, with shared validation.
 struct ReduceDims {
-    uint32_t tile_H;
-    uint32_t tile_W;
-    uint32_t W;
-    uint32_t H;
-    uint32_t NC;
-    uint32_t N;
-    uint32_t Wt;
-    uint32_t Ht;
-    uint32_t num_tensor_tiles;
-    uint32_t single_tile_bytes;
-    uint32_t dram_buffer_size;
-    uint32_t num_golden_elements;
-    uint32_t output_size_bytes;
+    std::uint32_t tile_H;
+    std::uint32_t tile_W;
+    std::uint32_t W;
+    std::uint32_t H;
+    std::uint32_t NC;
+    std::uint32_t N;
+    std::uint32_t Wt;
+    std::uint32_t Ht;
+    std::uint32_t num_tensor_tiles;
+    std::uint32_t single_tile_bytes;
+    std::uint32_t dram_buffer_size;
+    std::uint32_t num_golden_elements;
+    std::uint32_t output_size_bytes;
 };
 
 static ReduceDims compute_and_validate_reduce_dims(const ReduceConfig& test_config) {
@@ -145,7 +147,7 @@ static ReduceDims compute_and_validate_reduce_dims(const ReduceConfig& test_conf
     dims.Ht = dims.H / dims.tile_H;
     dims.num_tensor_tiles = dims.NC * dims.H * dims.W / (dims.tile_W * dims.tile_H);
 
-    const uint32_t divisor = test_config.reduce_dim == ReduceDim::W ? dims.Wt : dims.Ht;
+    const std::uint32_t divisor = test_config.reduce_dim == ReduceDim::W ? dims.Wt : dims.Ht;
     TT_FATAL(dims.num_tensor_tiles % divisor == 0, "Error");
 
     dims.single_tile_bytes = 2 * (dims.tile_W * dims.tile_H);
@@ -171,7 +173,7 @@ static ReduceDims compute_and_validate_reduce_dims(const ReduceConfig& test_conf
 }
 
 void set_math_fid_masks_binary(
-    uint16_t& srca_fid_mask, uint16_t& srcb_fid_mask, MathFidelity math_fidelity = MathFidelity::HiFi4) {
+    std::uint16_t& srca_fid_mask, std::uint16_t& srcb_fid_mask, MathFidelity math_fidelity = MathFidelity::HiFi4) {
     switch (math_fidelity) {
         case MathFidelity::HiFi4:
         case MathFidelity::HiFi3: {
@@ -217,10 +219,10 @@ std::string get_compute_kernel_name(const ReduceDim& reduce_dim) {
 }
 
 void validate_reduce_result(
-    const std::vector<uint32_t>& result_vec,
-    uint32_t num_golden_elements,
+    const std::vector<std::uint32_t>& result_vec,
+    std::uint32_t num_golden_elements,
     const ReduceConfig& test_config,
-    const std::vector<uint32_t>& src_vec,
+    const std::vector<std::uint32_t>& src_vec,
     float scaler) {
     EXPECT_EQ(result_vec.size(), num_golden_elements);
 
@@ -234,28 +236,28 @@ void validate_reduce_result(
 
     auto u16_src0_vec = u16_from_u32_vector(src_vec);
     if (test_config.reduce_type == ReduceType::AVG) {
-        uint16_t srca_fid_mask = 0xFFFF;
-        uint16_t srcb_fid_mask = 0xFFFF;
+        std::uint16_t srca_fid_mask = 0xFFFF;
+        std::uint16_t srcb_fid_mask = 0xFFFF;
         set_math_fid_masks_binary(srca_fid_mask, srcb_fid_mask, test_config.math_fidelity);
-        uint32_t uint32_scaler = *reinterpret_cast<uint32_t*>(&scaler);
+        std::uint32_t uint32_scaler = *reinterpret_cast<std::uint32_t*>(&scaler);
         uint32_scaler &= (0xFFFFFFFF & (srcb_fid_mask << 16));
         scaler = *reinterpret_cast<float*>(&uint32_scaler);
         for (unsigned short& val : u16_src0_vec) {
             val &= srca_fid_mask;
         }
     }
-    uint32_t tile_H = test_config.tile_shape.get_tile_shape()[0];
-    uint32_t tile_W = test_config.tile_shape.get_tile_shape()[1];
-    std::vector<uint16_t> src_linear = convert_layout<uint16_t>(
+    std::uint32_t tile_H = test_config.tile_shape.get_tile_shape()[0];
+    std::uint32_t tile_W = test_config.tile_shape.get_tile_shape()[1];
+    std::vector<std::uint16_t> src_linear = convert_layout<std::uint16_t>(
         u16_src0_vec,
         test_config.shape,
         TensorLayoutType::TILED_NFACES,
         TensorLayoutType::LIN_ROW_MAJOR,
         PhysicalSize{tile_H, tile_W});
-    std::vector<uint16_t> gold_reduced =
-        test_config.golden_function(src_linear, test_config.shape, scaler, uint8_t(test_config.reduce_type), true);
+    std::vector<std::uint16_t> gold_reduced =
+        test_config.golden_function(src_linear, test_config.shape, scaler, std::uint8_t(test_config.reduce_type), true);
 
-    auto gold_4f_u32 = u32_from_u16_vector(convert_layout<uint16_t>(
+    auto gold_4f_u32 = u32_from_u16_vector(convert_layout<std::uint16_t>(
         gold_reduced,
         test_config.result_shape,
         TensorLayoutType::LIN_ROW_MAJOR,
@@ -285,8 +287,9 @@ static experimental::KernelSpec::CompilerOptions::Defines build_reduce_defines(c
 // Build a TensorSpec describing a flat DRAM-interleaved buffer of `total_entries`
 // pages, each `entry_size` bytes. Used to bind src/dst tensors as TensorParameters
 // to the reader/writer kernels via the Metal 2.0 named TensorAccessor ctor.
-static inline tt::tt_metal::TensorSpec make_flat_dram_tensor_spec(uint32_t entry_size, uint32_t total_entries) {
-    const uint32_t entry_size_words = entry_size / sizeof(uint32_t);
+static inline tt::tt_metal::TensorSpec make_flat_dram_tensor_spec(
+    std::uint32_t entry_size, std::uint32_t total_entries) {
+    const std::uint32_t entry_size_words = entry_size / sizeof(std::uint32_t);
     auto page_config = tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR);
     auto memory_config =
         tt::tt_metal::MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
@@ -309,18 +312,18 @@ void run_single_core_reduce_program(
     // srcA L1 page size follows the input format (MxFp4 tiles are smaller than bf16); the dim
     // bookkeeping (tile counts, output sizing, golden) stays in bf16 terms. dims.single_tile_bytes
     // already honors tiny-tile shapes, so only the MxFp4 path needs the format-derived size.
-    const uint32_t input_tile_bytes = (test_config.input_format == tt::DataFormat::MxFp4)
-                                          ? tt::tile_size(tt::DataFormat::MxFp4)
-                                          : dims.single_tile_bytes;
-    const uint32_t num_input_pages = dims.dram_buffer_size / dims.single_tile_bytes;
-    const uint32_t num_output_pages = dims.output_size_bytes / dims.single_tile_bytes;
+    const std::uint32_t input_tile_bytes = (test_config.input_format == tt::DataFormat::MxFp4)
+                                               ? tt::tile_size(tt::DataFormat::MxFp4)
+                                               : dims.single_tile_bytes;
+    const std::uint32_t num_input_pages = dims.dram_buffer_size / dims.single_tile_bytes;
+    const std::uint32_t num_output_pages = dims.output_size_bytes / dims.single_tile_bytes;
     auto in_tensor =
         MeshTensor::allocate_on_device(*mesh_device, make_flat_dram_tensor_spec(input_tile_bytes, num_input_pages));
     auto out_tensor = MeshTensor::allocate_on_device(
         *mesh_device, make_flat_dram_tensor_spec(dims.single_tile_bytes, num_output_pages));
 
-    constexpr uint32_t num_buffer_tiles = 32;
-    constexpr uint32_t num_output_buffer_tiles = 32;
+    constexpr std::uint32_t num_buffer_tiles = 32;
+    constexpr std::uint32_t num_output_buffer_tiles = 32;
     const experimental::DFBSpecName SRC0_DFB{"src0_dfb"};
     const experimental::DFBSpecName SRC1_DFB{"src1_dfb"};
     const experimental::DFBSpecName DST_DFB{"dst_dfb"};
@@ -360,7 +363,7 @@ void run_single_core_reduce_program(
     if (test_config.reduce_dim == ReduceDim::H) {
         reader_kernel_path = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp";
         bfloat16 bfloat_scaler_value = bfloat16(scaler);
-        uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
+        std::uint32_t packed_scaler_value = pack_two_bfloat16_into_uint32({bfloat_scaler_value, bfloat_scaler_value});
         reader_cta_bindings = {{"scaler", packed_scaler_value}};
         reader_defines.emplace("REDUCE_SCALER", "1");
         reader_runtime_arg_names = {"N", "Ht", "Wt", "HtWt"};
@@ -491,7 +494,7 @@ void run_single_core_reduce_program(
 
     // Reader/writer RTAs depend on reduce_dim
     experimental::KernelRunArgs::RuntimeArgValues reader_named_rtas;
-    uint32_t writer_num_tiles;
+    std::uint32_t writer_num_tiles;
     if (test_config.reduce_dim == ReduceDim::H) {
         reader_named_rtas = experimental::MakeRuntimeArgsForSingleNode(
             node,
@@ -507,7 +510,7 @@ void run_single_core_reduce_program(
             node,
             {
                 {"num_tiles", dims.num_tensor_tiles},
-                {"scaler", *reinterpret_cast<uint32_t*>(&scaler)},
+                {"scaler", *reinterpret_cast<std::uint32_t*>(&scaler)},
             });
         writer_num_tiles = test_config.reduce_dim == ReduceDim::W ? (dims.num_tensor_tiles / dims.Wt)
                                                                   : (dims.num_tensor_tiles / (dims.Wt * dims.Ht));
@@ -533,14 +536,14 @@ void run_single_core_reduce_program(
 
     // Shared seeded stimulus (packed bf16, TILED_NFACES). For bf16 input this is written to the
     // device as-is; for MxFp4 input it is quantized to MxFp4 for the device.
-    vector<uint32_t> src_vec = create_random_vector_of_bfloat16(
+    vector<std::uint32_t> src_vec = create_random_vector_of_bfloat16(
         dims.dram_buffer_size, test_config.data_gen_rand_max, test_config.data_gen_seed, test_config.data_gen_offset);
     if (test_config.input_format == tt::DataFormat::MxFp4) {
         std::vector<bfloat16> native = unpack_uint32_vec_into_bfloat16_vec(src_vec);
         std::vector<float> in_floats(native.begin(), native.end());
         // src_vec is already tile-major (TILED_NFACES), so pack as tile-major (no row-major
         // transform) - matching how the matmul stimulus feeds tile-major data.
-        std::vector<uint32_t> mxfp4_packed =
+        std::vector<std::uint32_t> mxfp4_packed =
             tt::tt_metal::pack_as_mxfp4_tiles(ttsl::make_const_span(in_floats), /*row_major_input=*/false);
         tt_metal::detail::WriteToBuffer(*in_tensor.mesh_buffer().get_reference_buffer(), mxfp4_packed);
         // Decode the quantized values back (tile-major) and repack as bf16 for the golden source.
@@ -557,7 +560,7 @@ void run_single_core_reduce_program(
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::Finish(cq);
 
-    std::vector<uint32_t> result_vec;
+    std::vector<std::uint32_t> result_vec;
     tt_metal::detail::ReadFromBuffer(*out_tensor.mesh_buffer().get_reference_buffer(), result_vec);
 
     validate_reduce_result(result_vec, dims.num_golden_elements, test_config, src_vec, get_scaler(test_config));
@@ -582,19 +585,21 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeReduceH) {
         // (issue #10181: disabling due to sporadic failures in slow dispatch mode)
         GTEST_SKIP();
     }
-    std::vector<uint32_t> shape = {1, 3, 19 * TILE_HEIGHT, 17 * TILE_WIDTH};
-    std::vector<uint32_t> result_shape = {shape[0], shape[1], TILE_HEIGHT, shape[3]};
-    for (uint8_t math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
+    std::vector<std::uint32_t> shape = {1, 3, 19 * TILE_HEIGHT, 17 * TILE_WIDTH};
+    std::vector<std::uint32_t> result_shape = {shape[0], shape[1], TILE_HEIGHT, shape[3]};
+    for (std::uint8_t math_fid = std::uint8_t(MathFidelity::LoFi); math_fid <= std::uint8_t(MathFidelity::HiFi4);
+         math_fid++) {
         // MathFidelity : {0, 2, 3, 4}; so skip value 1
         if (math_fid == 1) {
             continue;
         }
-        for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
+        for (std::uint8_t reduce_type = std::uint8_t(ReduceType::SUM); reduce_type <= std::uint8_t(ReduceType::MAX);
+             reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
                 for (bool dst_full_sync_en : {true, false}) {
                     if (this->arch_ == tt::ARCH::QUASAR &&
                         !(!fp32_dest_acc_en && !dst_full_sync_en && reduce_type == ReduceType::AVG &&
-                          math_fid == uint8_t(MathFidelity::HiFi4))) {
+                          math_fid == std::uint8_t(MathFidelity::HiFi4))) {
                         // TODO (#38092): Remove when we can run back to back tests on Quasar
                         continue;
                     }
@@ -620,14 +625,16 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeReduceH) {
 }
 
 TEST_F(LLKMeshDeviceFixture, TensixComputeReduceW) {
-    std::vector<uint32_t> shape = {1, 3, 17 * TILE_HEIGHT, 19 * TILE_WIDTH};
-    std::vector<uint32_t> result_shape = {shape[0], shape[1], shape[2], 32};
-    for (uint8_t math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
+    std::vector<std::uint32_t> shape = {1, 3, 17 * TILE_HEIGHT, 19 * TILE_WIDTH};
+    std::vector<std::uint32_t> result_shape = {shape[0], shape[1], shape[2], 32};
+    for (std::uint8_t math_fid = std::uint8_t(MathFidelity::LoFi); math_fid <= std::uint8_t(MathFidelity::HiFi4);
+         math_fid++) {
         // MathFidelity : {0, 2, 3, 4}; so skip value 1
         if (math_fid == 1) {
             continue;
         }
-        for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
+        for (std::uint8_t reduce_type = std::uint8_t(ReduceType::SUM); reduce_type <= std::uint8_t(ReduceType::MAX);
+             reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
                 for (bool dst_full_sync_en : {true, false}) {
                     ReduceConfig test_config = {
@@ -653,14 +660,16 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeReduceW) {
 }
 
 TEST_F(LLKMeshDeviceFixture, TensixComputeReduceHW) {
-    std::vector<uint32_t> shape = {1, 2, 7 * TILE_HEIGHT, 5 * TILE_WIDTH};
-    std::vector<uint32_t> result_shape = {shape[0], shape[1], 32, 32};
-    for (uint8_t math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
+    std::vector<std::uint32_t> shape = {1, 2, 7 * TILE_HEIGHT, 5 * TILE_WIDTH};
+    std::vector<std::uint32_t> result_shape = {shape[0], shape[1], 32, 32};
+    for (std::uint8_t math_fid = std::uint8_t(MathFidelity::LoFi); math_fid <= std::uint8_t(MathFidelity::HiFi4);
+         math_fid++) {
         // MathFidelity : {0, 2, 3, 4}; so skip value 1
         if (math_fid == 1) {
             continue;
         }
-        for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
+        for (std::uint8_t reduce_type = std::uint8_t(ReduceType::SUM); reduce_type <= std::uint8_t(ReduceType::MAX);
+             reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
                 // Currently fp32 dest unsupported with reduce scalar
                 if (fp32_dest_acc_en && this->arch_ != tt::ARCH::QUASAR) {
@@ -669,7 +678,7 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeReduceHW) {
                 for (bool dst_full_sync_en : {true, false}) {
                     if (this->arch_ == tt::ARCH::QUASAR &&
                         !(!fp32_dest_acc_en && !dst_full_sync_en && reduce_type == ReduceType::AVG &&
-                          math_fid == uint8_t(MathFidelity::HiFi4))) {
+                          math_fid == std::uint8_t(MathFidelity::HiFi4))) {
                         // TODO (#38092): Remove when we can run back to back tests on Quasar
                         continue;
                     }
@@ -699,19 +708,21 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeReduceHMathOnly) {
         // (issue #10181: disabling due to sporadic failures in slow dispatch mode)
         GTEST_SKIP();
     }
-    std::vector<uint32_t> shape = {1, 3, 19 * TILE_HEIGHT, 17 * TILE_WIDTH};
-    std::vector<uint32_t> result_shape = {shape[0], shape[1], TILE_HEIGHT, shape[3]};
-    for (uint8_t math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
+    std::vector<std::uint32_t> shape = {1, 3, 19 * TILE_HEIGHT, 17 * TILE_WIDTH};
+    std::vector<std::uint32_t> result_shape = {shape[0], shape[1], TILE_HEIGHT, shape[3]};
+    for (std::uint8_t math_fid = std::uint8_t(MathFidelity::LoFi); math_fid <= std::uint8_t(MathFidelity::HiFi4);
+         math_fid++) {
         // MathFidelity : {0, 2, 3, 4}; so skip value 1
         if (math_fid == 1) {
             continue;
         }
-        for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
+        for (std::uint8_t reduce_type = std::uint8_t(ReduceType::SUM); reduce_type <= std::uint8_t(ReduceType::MAX);
+             reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
                 for (bool dst_full_sync_en : {true, false}) {
                     if (this->arch_ == tt::ARCH::QUASAR &&
                         !(!fp32_dest_acc_en && !dst_full_sync_en && reduce_type == ReduceType::AVG &&
-                          math_fid == uint8_t(MathFidelity::HiFi4))) {
+                          math_fid == std::uint8_t(MathFidelity::HiFi4))) {
                         // TODO (#38092): Remove when we can run back to back tests on Quasar
                         continue;
                     }
@@ -738,19 +749,21 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeReduceHMathOnly) {
 }
 
 TEST_F(LLKMeshDeviceFixture, TensixComputeReduceWMathOnly) {
-    std::vector<uint32_t> shape = {1, 3, 17 * TILE_HEIGHT, 19 * TILE_WIDTH};
-    std::vector<uint32_t> result_shape = {shape[0], shape[1], shape[2], 32};
-    for (uint8_t math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
+    std::vector<std::uint32_t> shape = {1, 3, 17 * TILE_HEIGHT, 19 * TILE_WIDTH};
+    std::vector<std::uint32_t> result_shape = {shape[0], shape[1], shape[2], 32};
+    for (std::uint8_t math_fid = std::uint8_t(MathFidelity::LoFi); math_fid <= std::uint8_t(MathFidelity::HiFi4);
+         math_fid++) {
         // MathFidelity : {0, 2, 3, 4}; so skip value 1
         if (math_fid == 1) {
             continue;
         }
-        for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
+        for (std::uint8_t reduce_type = std::uint8_t(ReduceType::SUM); reduce_type <= std::uint8_t(ReduceType::MAX);
+             reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
                 for (bool dst_full_sync_en : {true, false}) {
                     if (this->arch_ == tt::ARCH::QUASAR &&
                         !(!fp32_dest_acc_en && !dst_full_sync_en && reduce_type == ReduceType::AVG &&
-                          math_fid == uint8_t(MathFidelity::HiFi4))) {
+                          math_fid == std::uint8_t(MathFidelity::HiFi4))) {
                         // TODO (#38092): Remove when we can run back to back tests on Quasar
                         continue;
                     }
@@ -777,14 +790,16 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeReduceWMathOnly) {
 }
 
 TEST_F(LLKMeshDeviceFixture, TensixComputeReduceHWMathOnly) {
-    std::vector<uint32_t> shape = {1, 2, 7 * TILE_HEIGHT, 5 * TILE_WIDTH};
-    std::vector<uint32_t> result_shape = {shape[0], shape[1], 32, 32};
-    for (uint8_t math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
+    std::vector<std::uint32_t> shape = {1, 2, 7 * TILE_HEIGHT, 5 * TILE_WIDTH};
+    std::vector<std::uint32_t> result_shape = {shape[0], shape[1], 32, 32};
+    for (std::uint8_t math_fid = std::uint8_t(MathFidelity::LoFi); math_fid <= std::uint8_t(MathFidelity::HiFi4);
+         math_fid++) {
         // MathFidelity : {0, 2, 3, 4}; so skip value 1
         if (math_fid == 1) {
             continue;
         }
-        for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
+        for (std::uint8_t reduce_type = std::uint8_t(ReduceType::SUM); reduce_type <= std::uint8_t(ReduceType::MAX);
+             reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
                 // Currently fp32 dest unsupported with reduce scalar
                 if (fp32_dest_acc_en && this->arch_ != tt::ARCH::QUASAR) {
@@ -793,7 +808,7 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeReduceHWMathOnly) {
                 for (bool dst_full_sync_en : {true, false}) {
                     if (this->arch_ == tt::ARCH::QUASAR &&
                         !(!fp32_dest_acc_en && !dst_full_sync_en && reduce_type == ReduceType::AVG &&
-                          math_fid == uint8_t(MathFidelity::HiFi4))) {
+                          math_fid == std::uint8_t(MathFidelity::HiFi4))) {
                         // TODO (#38092): Remove when we can run back to back tests on Quasar
                         continue;
                     }
@@ -821,18 +836,20 @@ TEST_F(LLKMeshDeviceFixture, TensixComputeReduceHWMathOnly) {
 
 TEST_F(LLKMeshDeviceFixture, TensixComputeReduceWTinyTiles) {
     tt_metal::Tile tile_shape = tt_metal::Tile({TILE_HEIGHT / 2, TILE_WIDTH});
-    std::vector<uint32_t> shape = {1, 1, 1 * tile_shape.get_tile_shape()[0], 13 * tile_shape.get_tile_shape()[1]};
-    std::vector<uint32_t> result_shape = {shape[0], shape[1], shape[2], tile_shape.get_tile_shape()[1]};
+    std::vector<std::uint32_t> shape = {1, 1, 1 * tile_shape.get_tile_shape()[0], 13 * tile_shape.get_tile_shape()[1]};
+    std::vector<std::uint32_t> result_shape = {shape[0], shape[1], shape[2], tile_shape.get_tile_shape()[1]};
     if (this->arch_ == tt::ARCH::QUASAR) {
         // Tiny tiles not yet supported on Quasar
         GTEST_SKIP();
     }
-    for (uint8_t math_fid = uint8_t(MathFidelity::LoFi); math_fid <= uint8_t(MathFidelity::HiFi4); math_fid++) {
+    for (std::uint8_t math_fid = std::uint8_t(MathFidelity::LoFi); math_fid <= std::uint8_t(MathFidelity::HiFi4);
+         math_fid++) {
         // MathFidelity : {0, 2, 3, 4}; so skip value 1
         if (math_fid == 1) {
             continue;
         }
-        for (uint8_t reduce_type = uint8_t(ReduceType::SUM); reduce_type <= uint8_t(ReduceType::MAX); reduce_type++) {
+        for (std::uint8_t reduce_type = std::uint8_t(ReduceType::SUM); reduce_type <= std::uint8_t(ReduceType::MAX);
+             reduce_type++) {
             for (bool fp32_dest_acc_en : {true, false}) {
                 for (bool dst_full_sync_en : {true, false}) {
                     ReduceConfig test_config = {
@@ -883,6 +900,136 @@ TEST_F(LLKQuasarMeshDeviceSingleCardFixture, TensixComputeReduceColumnMxFp4X2) {
         .input_format = tt::DataFormat::MxFp4,
     };
     run_single_core_reduce_program(this->devices_.at(0), test_config);
+}
+
+// ============================================================================
+// Id-free (2.0) reduce, validated against the gold_reduce_h/w/hw host goldens (not a legacy kernel). Single
+// Float16_b data tile in c_0, a broadcast-scaler tile (scalar 1.0) in c_1, reduced -> c_16. The 2.0 kernel's
+// ReduceDim maps to the golden as: REDUCE_SCALAR -> gold_reduce_hw, REDUCE_ROW -> gold_reduce_w,
+// REDUCE_COL -> gold_reduce_h. scaler 1.0 (survives the HW double-apply since 1.0^2 == 1.0). Runs on Blackhole.
+// ============================================================================
+namespace {
+// Build the reduce broadcast-scaler tile (matches generate_bcast_scaler in reader_unary_8bank_2_0.cpp):
+// a 32x32 bf16 tile, zero everywhere except the first 16 datums of each of the 4 faces = `scalar`.
+std::vector<std::uint32_t> make_reduce_scaler_tile(float scalar) {
+    std::vector<std::uint16_t> datums(1024, 0);
+    const std::uint16_t packed = static_cast<std::uint16_t>(std::bit_cast<std::uint32_t>(scalar) >> 16);
+    for (int k = 0; k < 4; ++k) {
+        for (int j = 0; j < 16; ++j) {
+            datums[k * 256 + j] = packed;
+        }
+    }
+    return u32_from_u16_vector(datums);
+}
+
+// Compare a reduce device result against the gold_reduce_* golden, scaler 1.0. shape is the NCHW tensor shape
+// (C tiles are reduced independently, matching reduce_block's N-in/N-out per-tile semantics).
+void expect_reduce_matches_golden(
+    const std::vector<std::uint32_t>& result,
+    const std::vector<std::uint32_t>& data_src,
+    const std::function<std::vector<std::uint16_t>(
+        const std::vector<std::uint16_t>&, const std::vector<std::uint32_t>&, float, std::uint8_t, bool)>& golden_fn,
+    std::uint8_t red_type,
+    const std::vector<std::uint32_t>& shape = {1, 1, 32, 32}) {
+    auto src_linear = convert_layout<std::uint16_t>(
+        u16_from_u32_vector(data_src),
+        shape,
+        TensorLayoutType::TILED_NFACES,
+        TensorLayoutType::LIN_ROW_MAJOR,
+        PhysicalSize{32, 32});
+    auto gold_lin = golden_fn(src_linear, shape, /*scaler=*/1.0f, red_type, /*zeropad=*/true);
+    auto gold_tiled = u32_from_u16_vector(convert_layout<std::uint16_t>(
+        gold_lin, shape, TensorLayoutType::LIN_ROW_MAJOR, TensorLayoutType::TILED_NFACES, PhysicalSize{32, 32}));
+
+    EXPECT_EQ(gold_tiled.size(), result.size());
+    int argfail = -1;
+    auto cmp = [](float a, float b) {
+        float maxabs = fmaxf(fabsf(a), fabsf(b));
+        float absdiff = fabsf(a - b);
+        return (absdiff <= 0.1f) || (absdiff <= 0.1f * maxabs);
+    };
+    bool pass = packed_uint32_t_vector_comparison(result, gold_tiled, cmp, &argfail);
+    if (!pass) {
+        log_error(LogTest, "Reduce golden mismatch at position {}", argfail);
+    }
+    EXPECT_TRUE(pass);
+}
+
+// Kernel-side ckernel enum numeric values passed to the fused reduce_2_0.cpp as get_compile_time_arg_val(1)
+// (PoolType) / (2) (ReduceDim). PoolType: SUM=0, MAX=2. ReduceDim: REDUCE_ROW=0, REDUCE_COL=1, REDUCE_SCALAR=2.
+constexpr std::uint32_t kPoolSum = 0;
+constexpr std::uint32_t kPoolMax = 2;
+constexpr std::uint32_t kReduceRow = 0;
+constexpr std::uint32_t kReduceCol = 1;
+constexpr std::uint32_t kReduceScalar = 2;
+
+std::vector<std::uint32_t> run_reduce_idfree(
+    distributed::MeshDevice& md, const std::vector<std::uint32_t>& data, std::uint32_t pool, std::uint32_t dim) {
+    auto scaler = make_reduce_scaler_tile(1.0f);
+    return unit_tests::llk::single_core::run_binary(
+        md,
+        data,
+        scaler,
+        /*num_tiles=*/1,
+        "tests/tt_metal/tt_metal/test_kernels/compute/reduce_2_0.cpp",
+        /*compute_defines=*/{},
+        /*cb_depth_tiles=*/1,
+        /*out_tiles=*/1,
+        /*extra_compile_args=*/{pool, dim});
+}
+}  // namespace
+
+TEST_F(LLKBlackholeSingleCardFixture, TensixReduceScalarSumIdFreeGolden) {
+    auto data = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b), /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result = run_reduce_idfree(*this->devices_.at(0), data, kPoolSum, kReduceScalar);
+    expect_reduce_matches_golden(result, data, ::unit_tests::compute::gold_reduce_hw, /*red_type=*/0);
+}
+
+TEST_F(LLKBlackholeSingleCardFixture, TensixReduceRowSumIdFreeGolden) {
+    auto data = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b), /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result = run_reduce_idfree(*this->devices_.at(0), data, kPoolSum, kReduceRow);
+    expect_reduce_matches_golden(result, data, ::unit_tests::compute::gold_reduce_w, /*red_type=*/0);
+}
+
+TEST_F(LLKBlackholeSingleCardFixture, TensixReduceColSumIdFreeGolden) {
+    auto data = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b), /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result = run_reduce_idfree(*this->devices_.at(0), data, kPoolSum, kReduceCol);
+    expect_reduce_matches_golden(result, data, ::unit_tests::compute::gold_reduce_h, /*red_type=*/0);
+}
+
+TEST_F(LLKBlackholeSingleCardFixture, TensixReduceScalarMaxIdFreeGolden) {
+    auto data = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b), /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result = run_reduce_idfree(*this->devices_.at(0), data, kPoolMax, kReduceScalar);
+    expect_reduce_matches_golden(result, data, ::unit_tests::compute::gold_reduce_hw, /*red_type=*/2);
+}
+
+// reduce_block: N data tiles -> N output tiles, each output = REDUCE_SCALAR SUM of the matching input tile.
+// Modeled as a {1, N, 32, 32} HW reduce (each C tile reduced independently). scaler tile 0 in c_1.
+TEST_F(LLKBlackholeSingleCardFixture, TensixReduceBlockIdFreeGolden) {
+    constexpr std::uint32_t num_tiles = 4;
+    auto data = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    // c_1 holds num_tiles tiles; reduce_block uses scaler tile 0. Fill every slot with the 1.0 scaler tile.
+    auto scaler_tile = make_reduce_scaler_tile(1.0f);
+    std::vector<std::uint32_t> scaler;
+    for (std::uint32_t i = 0; i < num_tiles; ++i) {
+        scaler.insert(scaler.end(), scaler_tile.begin(), scaler_tile.end());
+    }
+    auto result = unit_tests::llk::single_core::run_binary(
+        *this->devices_.at(0),
+        data,
+        scaler,
+        num_tiles,
+        "tests/tt_metal/tt_metal/test_kernels/compute/reduce_block_2_0.cpp",
+        /*compute_defines=*/{},
+        /*cb_depth_tiles=*/num_tiles,
+        /*out_tiles=*/num_tiles);
+    expect_reduce_matches_golden(
+        result, data, ::unit_tests::compute::gold_reduce_hw, /*red_type=*/0, /*shape=*/{1, num_tiles, 32, 32});
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -39,6 +39,7 @@
 #include <umd/device/types/arch.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/distributed.hpp>
+#include "single_core_compute_runners.hpp"
 
 namespace tt::tt_metal {
 
@@ -88,7 +89,7 @@ struct SingleCoreBinaryConfig {
 };
 
 void set_math_fid_masks(
-    uint16_t& srca_fid_mask, uint16_t& srcb_fid_mask, MathFidelity math_fidelity = MathFidelity::HiFi4) {
+    std::uint16_t& srca_fid_mask, std::uint16_t& srcb_fid_mask, MathFidelity math_fidelity = MathFidelity::HiFi4) {
     switch (math_fidelity) {
         case MathFidelity::HiFi4:
         case MathFidelity::HiFi3: {
@@ -112,10 +113,10 @@ void set_math_fid_masks(
 }
 
 struct BinaryStimulus {
-    std::vector<uint32_t> packed_input0;
-    std::vector<uint32_t> packed_input1;
-    std::vector<uint32_t> packed_input2;
-    std::vector<uint32_t> packed_golden;
+    std::vector<std::uint32_t> packed_input0;
+    std::vector<std::uint32_t> packed_input1;
+    std::vector<std::uint32_t> packed_input2;
+    std::vector<std::uint32_t> packed_golden;
     bool is_fp32 = false;
 };
 
@@ -171,22 +172,22 @@ static BinaryStimulus generate_binary_stimulus(const SingleCoreBinaryConfig& tes
     s.is_fp32 = test_config.l1_input_data_format == tt::DataFormat::Float32;
     if (s.is_fp32) {
         const size_t num_elements = byte_size / sizeof(float);
-        s.packed_input0 = generate_packed_uniform_random_vector<uint32_t, float>(-1.0f, 1.0f, num_elements, 0);
-        s.packed_input1 = generate_packed_uniform_random_vector<uint32_t, float>(-1.0f, 1.0f, num_elements, 1);
-        s.packed_input2 = generate_packed_uniform_random_vector<uint32_t, float>(-1.0f, 1.0f, num_elements, 2);
+        s.packed_input0 = generate_packed_uniform_random_vector<std::uint32_t, float>(-1.0f, 1.0f, num_elements, 0);
+        s.packed_input1 = generate_packed_uniform_random_vector<std::uint32_t, float>(-1.0f, 1.0f, num_elements, 1);
+        s.packed_input2 = generate_packed_uniform_random_vector<std::uint32_t, float>(-1.0f, 1.0f, num_elements, 2);
 
         TT_FATAL(
             test_config.l1_output_data_format == tt::DataFormat::Float32, "Float32 stimulus requires Float32 output");
         std::vector<float> input0(s.packed_input0.size());
         std::vector<float> input1(s.packed_input1.size());
         std::vector<float> input2(s.packed_input2.size());
-        std::transform(s.packed_input0.begin(), s.packed_input0.end(), input0.begin(), [](uint32_t value) {
+        std::transform(s.packed_input0.begin(), s.packed_input0.end(), input0.begin(), [](std::uint32_t value) {
             return std::bit_cast<float>(value);
         });
-        std::transform(s.packed_input1.begin(), s.packed_input1.end(), input1.begin(), [](uint32_t value) {
+        std::transform(s.packed_input1.begin(), s.packed_input1.end(), input1.begin(), [](std::uint32_t value) {
             return std::bit_cast<float>(value);
         });
-        std::transform(s.packed_input2.begin(), s.packed_input2.end(), input2.begin(), [](uint32_t value) {
+        std::transform(s.packed_input2.begin(), s.packed_input2.end(), input2.begin(), [](std::uint32_t value) {
             return std::bit_cast<float>(value);
         });
 
@@ -210,22 +211,22 @@ static BinaryStimulus generate_binary_stimulus(const SingleCoreBinaryConfig& tes
                 golden[i] = input2[i] * broadcast_input0[i];
             }
         }
-        s.packed_golden = pack_vector<uint32_t, float>(golden);
+        s.packed_golden = pack_vector<std::uint32_t, float>(golden);
         return s;
     }
 
     s.packed_input0 =
-        generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, byte_size / sizeof(bfloat16), 0);
+        generate_packed_uniform_random_vector<std::uint32_t, bfloat16>(-1.0f, 1.0f, byte_size / sizeof(bfloat16), 0);
     s.packed_input1 =
-        generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, byte_size / sizeof(bfloat16), 1);
+        generate_packed_uniform_random_vector<std::uint32_t, bfloat16>(-1.0f, 1.0f, byte_size / sizeof(bfloat16), 1);
     s.packed_input2 =
-        generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, byte_size / sizeof(bfloat16), 2);
+        generate_packed_uniform_random_vector<std::uint32_t, bfloat16>(-1.0f, 1.0f, byte_size / sizeof(bfloat16), 2);
 
-    auto input0 = unpack_vector<bfloat16, uint32_t>(s.packed_input0);
-    auto input1 = unpack_vector<bfloat16, uint32_t>(s.packed_input1);
-    auto input2 = unpack_vector<bfloat16, uint32_t>(s.packed_input2);
-    uint16_t srca_fid_mask = 0xFFFF;
-    uint16_t srcb_fid_mask = 0xFFFF;
+    auto input0 = unpack_vector<bfloat16, std::uint32_t>(s.packed_input0);
+    auto input1 = unpack_vector<bfloat16, std::uint32_t>(s.packed_input1);
+    auto input2 = unpack_vector<bfloat16, std::uint32_t>(s.packed_input2);
+    std::uint16_t srca_fid_mask = 0xFFFF;
+    std::uint16_t srcb_fid_mask = 0xFFFF;
     if (!is_quasar) {
         set_math_fid_masks(srca_fid_mask, srcb_fid_mask, test_config.math_fidelity);
     }
@@ -239,14 +240,14 @@ static BinaryStimulus generate_binary_stimulus(const SingleCoreBinaryConfig& tes
         for (size_t i = 0; i < golden.size(); ++i) {
             constexpr size_t tile_size = 32 * 32;
             const bfloat16 srca = std::bit_cast<bfloat16>(
-                static_cast<uint16_t>(std::bit_cast<uint16_t>(input2[i % tile_size]) & srca_fid_mask));
-            const bfloat16 srcb = std::bit_cast<bfloat16>(static_cast<uint16_t>(
-                std::bit_cast<uint16_t>(
+                static_cast<std::uint16_t>(std::bit_cast<std::uint16_t>(input2[i % tile_size]) & srca_fid_mask));
+            const bfloat16 srcb = std::bit_cast<bfloat16>(static_cast<std::uint16_t>(
+                std::bit_cast<std::uint16_t>(
                     bfloat16(static_cast<float>(input0[i]) - static_cast<float>(broadcast_input1[i]))) &
                 srcb_fid_mask));
             golden[i] = static_cast<float>(srca) * static_cast<float>(srcb);
         }
-        s.packed_golden = pack_vector<uint32_t, bfloat16>(golden);
+        s.packed_golden = pack_vector<std::uint32_t, bfloat16>(golden);
         return s;
     }
 
@@ -271,10 +272,10 @@ static BinaryStimulus generate_binary_stimulus(const SingleCoreBinaryConfig& tes
             }
             if (test_config.binary_op == "mul") {
                 return (
-                    static_cast<float>(
-                        std::bit_cast<bfloat16>(static_cast<uint16_t>(std::bit_cast<uint16_t>(lhs) & srca_fid_mask))) *
-                    static_cast<float>(
-                        std::bit_cast<bfloat16>(static_cast<uint16_t>(std::bit_cast<uint16_t>(rhs) & srcb_fid_mask))));
+                    static_cast<float>(std::bit_cast<bfloat16>(
+                        static_cast<std::uint16_t>(std::bit_cast<std::uint16_t>(lhs) & srca_fid_mask))) *
+                    static_cast<float>(std::bit_cast<bfloat16>(
+                        static_cast<std::uint16_t>(std::bit_cast<std::uint16_t>(rhs) & srcb_fid_mask))));
             }
             if (test_config.binary_op.find("with_dest_reuse") != std::string::npos) {
                 return static_cast<float>(lhs);
@@ -300,13 +301,13 @@ static BinaryStimulus generate_binary_stimulus(const SingleCoreBinaryConfig& tes
                 const bfloat16 srcb =
                     test_config.dest_reuse_type == BinaryDestReuseType::SrcA ? input_value : dest_value;
                 return static_cast<float>(std::bit_cast<bfloat16>(
-                           static_cast<uint16_t>(std::bit_cast<uint16_t>(srca) & srca_fid_mask))) *
+                           static_cast<std::uint16_t>(std::bit_cast<std::uint16_t>(srca) & srca_fid_mask))) *
                        static_cast<float>(std::bit_cast<bfloat16>(
-                           static_cast<uint16_t>(std::bit_cast<uint16_t>(srcb) & srcb_fid_mask)));
+                           static_cast<std::uint16_t>(std::bit_cast<std::uint16_t>(srcb) & srcb_fid_mask)));
             }
             return rhs;
         });
-    s.packed_golden = pack_vector<uint32_t, bfloat16>(golden);
+    s.packed_golden = pack_vector<std::uint32_t, bfloat16>(golden);
     return s;
 }
 
@@ -346,20 +347,20 @@ static bool read_and_validate_binary_result(
     const std::shared_ptr<distributed::MeshBuffer>& output_dram_buffer,
     const distributed::MeshCoordinate& zero_coord,
     const BinaryStimulus& stimulus,
-    std::vector<uint32_t>* packed_result = nullptr) {
-    std::vector<uint32_t> dest_buffer_data;
+    std::vector<std::uint32_t>* packed_result = nullptr) {
+    std::vector<std::uint32_t> dest_buffer_data;
     distributed::ReadShard(cq, dest_buffer_data, output_dram_buffer, zero_coord, false);
     if (packed_result != nullptr) {
         *packed_result = dest_buffer_data;
     }
 
     if (stimulus.is_fp32) {
-        return is_close_vectors<uint32_t>(
-            dest_buffer_data, stimulus.packed_golden, [](uint32_t actual, uint32_t expected) {
+        return is_close_vectors<std::uint32_t>(
+            dest_buffer_data, stimulus.packed_golden, [](std::uint32_t actual, std::uint32_t expected) {
                 return is_close(std::bit_cast<float>(actual), std::bit_cast<float>(expected), 0.0155f);
             });
     }
-    return is_close_packed_vectors<bfloat16, uint32_t>(
+    return is_close_packed_vectors<bfloat16, std::uint32_t>(
         dest_buffer_data, stimulus.packed_golden, [&](const bfloat16& a, const bfloat16& b) {
             return is_close(a, b, 0.0155f);
         });
@@ -404,7 +405,7 @@ static std::map<std::string, std::string> build_binary_defines(const SingleCoreB
 bool single_core_binary(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const SingleCoreBinaryConfig& test_config,
-    uint32_t num_runs = 1) {
+    std::uint32_t num_runs = 1) {
     TT_FATAL(
         num_runs > 0 && test_config.block_size > 0 && test_config.num_tiles % test_config.block_size == 0,
         "num_runs and block_size must be positive, and num_tiles must be divisible by block_size");
@@ -414,7 +415,7 @@ bool single_core_binary(
     auto& cq = mesh_device->mesh_command_queue();
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     const experimental::NodeCoord node{
-        static_cast<uint32_t>(test_config.core.x), static_cast<uint32_t>(test_config.core.y)};
+        static_cast<std::uint32_t>(test_config.core.x), static_cast<std::uint32_t>(test_config.core.y)};
 
     // Math-fidelity masks model WH/BH LLK behavior; Quasar HW does not apply them.
     auto stimulus = generate_binary_stimulus(test_config, is_quasar);
@@ -438,25 +439,25 @@ bool single_core_binary(
     const experimental::KernelSpecName WRITER{"writer"};
     const experimental::KernelSpecName COMPUTE{"compute"};
 
-    auto make_input_dfb = [&](const experimental::DFBSpecName& name, uint32_t num_entries) {
+    auto make_input_dfb = [&](const experimental::DFBSpecName& name, std::uint32_t num_entries) {
         return experimental::DataflowBufferSpec{
             .unique_id = name,
-            .entry_size = static_cast<uint32_t>(test_config.tile_byte_size),
+            .entry_size = static_cast<std::uint32_t>(test_config.tile_byte_size),
             .num_entries = num_entries,
             .data_format_metadata = test_config.l1_input_data_format,
             .tile_format_metadata = test_config.tile,
         };
     };
 
-    const uint32_t num_tiles_u = static_cast<uint32_t>(test_config.num_tiles);
-    const uint32_t retained_operand_tiles = test_config.precede_dest_reuse_with_col_broadcast ? 1 : num_tiles_u;
+    const std::uint32_t num_tiles_u = static_cast<std::uint32_t>(test_config.num_tiles);
+    const std::uint32_t retained_operand_tiles = test_config.precede_dest_reuse_with_col_broadcast ? 1 : num_tiles_u;
     experimental::DataflowBufferSpec inp0_dfb_spec = make_input_dfb(INP0_DFB, num_tiles_u);
     experimental::DataflowBufferSpec inp1_dfb_spec = make_input_dfb(INP1_DFB, retained_operand_tiles);
     experimental::DataflowBufferSpec inp2_dfb_spec = make_input_dfb(INP2_DFB, retained_operand_tiles);
     experimental::DataflowBufferSpec out_dfb_spec{
         .unique_id = OUT_DFB,
-        .entry_size = static_cast<uint32_t>(test_config.tile_byte_size),
-        .num_entries = static_cast<uint32_t>(test_config.num_tiles),
+        .entry_size = static_cast<std::uint32_t>(test_config.tile_byte_size),
+        .num_entries = static_cast<std::uint32_t>(test_config.num_tiles),
         .data_format_metadata = test_config.l1_output_data_format,
         .tile_format_metadata = test_config.tile,
     };
@@ -617,18 +618,18 @@ bool single_core_binary(
             .kernel = COMPUTE,
             .runtime_arg_values = experimental::MakeRuntimeArgsForSingleNode(
                 node,
-                {{"per_core_block_cnt", static_cast<uint32_t>(test_config.num_tiles / test_config.block_size)},
-                 {"per_core_block_size", static_cast<uint32_t>(test_config.block_size)},
+                {{"per_core_block_cnt", static_cast<std::uint32_t>(test_config.num_tiles / test_config.block_size)},
+                 {"per_core_block_size", static_cast<std::uint32_t>(test_config.block_size)},
                  {"acc_to_dst", 0u}}),
         },
     };
     experimental::SetProgramRunArgs(program, params);
 
-    std::vector<uint32_t> first_result;
-    for (uint32_t run = 0; run < num_runs; ++run) {
+    std::vector<std::uint32_t> first_result;
+    for (std::uint32_t run = 0; run < num_runs; ++run) {
         distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/true);
 
-        std::vector<uint32_t> packed_result;
+        std::vector<std::uint32_t> packed_result;
         if (!read_and_validate_binary_result(cq, output_dram_buffer, zero_coord, stimulus, &packed_result)) {
             return false;
         }
@@ -644,7 +645,7 @@ bool single_core_binary(
 }  // namespace unit_tests::compute::binary
 
 TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingleTileAdd) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -664,7 +665,7 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingle
 }
 
 TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingleTileSub) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -684,7 +685,7 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingle
 }
 
 TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingleTileMul) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -704,7 +705,7 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingle
 }
 
 TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingleTileAddFullInit) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -724,7 +725,7 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingle
 }
 
 TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingleTileSubFullInit) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -744,7 +745,7 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingle
 }
 
 TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingleTileMulFullInit) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -764,7 +765,7 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingle
 }
 
 TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiTileAddWithDestReuse) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -788,7 +789,7 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiT
 }
 
 TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiTileSubWithDestReuse) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -812,7 +813,7 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiT
 }
 
 TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiTileMulWithDestReuse) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -939,7 +940,7 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeColBroadcastThen
 }
 
 TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiTileAdd) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -963,7 +964,7 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiT
 }
 
 TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiTileSub) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -987,7 +988,7 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiT
 }
 
 TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiTileMul) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -1011,7 +1012,7 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiT
 }
 
 TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiTileAddDestAcc) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -1037,7 +1038,7 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiT
 }
 
 TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiTileSubDestAcc) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -1063,7 +1064,7 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiT
 }
 
 TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiTileMulDestAcc) {
-    for (uint8_t i = uint8_t(MathFidelity::LoFi); i <= uint8_t(MathFidelity::HiFi4); i++) {
+    for (std::uint8_t i = std::uint8_t(MathFidelity::LoFi); i <= std::uint8_t(MathFidelity::HiFi4); i++) {
         if (i == 1) {
             continue;
         }
@@ -1086,6 +1087,84 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreMultiT
             }
         }
     }
+}
+
+// ============================================================================
+// Id-free (2.0) eltwise binary ADD family, validated against a C++ host golden (elementwise A + B in
+// bfloat16), not a legacy kernel. Covers plain add, blocked add (blocks of 4), and dest-reuse add (seed
+// DST with A then fold B in). All Float16_b, tolerance is_close(rtol=0.0155). Runs on Blackhole (BH-only API).
+// ============================================================================
+namespace {
+// Host golden: elementwise A + B for two packed Float16_b tile vectors.
+std::vector<std::uint32_t> host_binary_add_golden(
+    const std::vector<std::uint32_t>& src0, const std::vector<std::uint32_t>& src1) {
+    auto a = tt::test_utils::unpack_vector<bfloat16, std::uint32_t>(src0);
+    auto b = tt::test_utils::unpack_vector<bfloat16, std::uint32_t>(src1);
+    TT_FATAL(a.size() == b.size(), "host_binary_add_golden: operand size mismatch");
+    std::vector<bfloat16> out(a.size());
+    for (size_t i = 0; i < a.size(); ++i) {
+        out[i] = bfloat16(static_cast<float>(a[i]) + static_cast<float>(b[i]));
+    }
+    return tt::test_utils::pack_vector<std::uint32_t, bfloat16>(out);
+}
+
+void expect_binary_add_matches_golden(
+    const std::vector<std::uint32_t>& result,
+    const std::vector<std::uint32_t>& src0,
+    const std::vector<std::uint32_t>& src1) {
+    auto golden = host_binary_add_golden(src0, src1);
+    EXPECT_EQ(golden.size(), result.size());
+    bool close = tt::test_utils::is_close_packed_vectors<bfloat16, std::uint32_t>(
+        result, golden, [](const bfloat16& a, const bfloat16& b) { return tt::test_utils::is_close(a, b, 0.0155f); });
+    EXPECT_TRUE(close);
+}
+}  // namespace
+
+TEST_F(LLKBlackholeSingleCardFixture, TensixBinaryAddIdFreeGolden) {
+    constexpr std::uint32_t num_tiles = 64;
+    auto src0 = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto src1 = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/7, /*offset=*/-10.0f);
+    auto result = unit_tests::llk::single_core::run_binary(
+        *this->devices_.at(0),
+        src0,
+        src1,
+        num_tiles,
+        "tests/tt_metal/tt_metal/test_kernels/compute/eltwise_binary_add_idfree.cpp");
+    expect_binary_add_matches_golden(result, src0, src1);
+}
+
+TEST_F(LLKBlackholeSingleCardFixture, TensixBinaryAddBlockIdFreeGolden) {
+    constexpr std::uint32_t num_tiles = 64;  // multiple of the 4-tile block
+    auto src0 = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto src1 = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/7, /*offset=*/-10.0f);
+    auto result = unit_tests::llk::single_core::run_binary(
+        *this->devices_.at(0),
+        src0,
+        src1,
+        num_tiles,
+        "tests/tt_metal/tt_metal/test_kernels/compute/binary_add_block_2_0.cpp",
+        /*compute_defines=*/{},
+        /*cb_depth_tiles=*/num_tiles);
+    expect_binary_add_matches_golden(result, src0, src1);
+}
+
+TEST_F(LLKBlackholeSingleCardFixture, TensixBinaryReuseDestIdFreeGolden) {
+    constexpr std::uint32_t num_tiles = 64;
+    auto src0 = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto src1 = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/7, /*offset=*/-10.0f);
+    auto result = unit_tests::llk::single_core::run_binary(
+        *this->devices_.at(0),
+        src0,
+        src1,
+        num_tiles,
+        "tests/tt_metal/tt_metal/test_kernels/compute/binary_reuse_dest_2_0.cpp");
+    expect_binary_add_matches_golden(result, src0, src1);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
@@ -34,6 +34,7 @@
 #include <tt-metalium/kernel_types.hpp>
 #include "llk_device_fixture.hpp"
 #include <tt-metalium/distributed.hpp>
+#include "single_core_compute_runners.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt_stl/span.hpp>
@@ -62,10 +63,10 @@ namespace unit_tests::compute::matmul {
 // If K > 1 -> dest accumulation within each block
 // If num_blocks > 1 -> partials accumulation (either l1 accumulation or spill and reload)
 struct BlockedMatmulConfig {
-    uint32_t M = 1;           // per-block rows (tiles)
-    uint32_t K = 1;           // per-block inner dim (tiles)
-    uint32_t N = 1;           // per-block cols (tiles)
-    uint32_t num_blocks = 1;  // number of K-blocks
+    std::uint32_t M = 1;           // per-block rows (tiles)
+    std::uint32_t K = 1;           // per-block inner dim (tiles)
+    std::uint32_t N = 1;           // per-block cols (tiles)
+    std::uint32_t num_blocks = 1;  // number of K-blocks
     bool packer_l1_acc = false;
     // Format / DEST-mode parameters. Defaults preserve the original BF16 + fp32_dest=false
     // behaviour exercised by `TensixTestSingleCoreMultiBlock*ComputeMatmul` (and the Quasar
@@ -83,35 +84,35 @@ void create_CBs_for_fused_matmul(
     CoreCoord core,
     bool activations_rm,
     bool output_rm,
-    uint32_t M,
-    uint32_t N,
-    uint32_t in0_block_w,
-    uint32_t /*out_subblock_h*/) {
-    uint32_t num_bytes_for_df = 2;
-    uint32_t in0_cb = 0;
-    uint32_t in1_cb = 1;
-    uint32_t tilize_mode_tilized_in0_cb = 24;
-    uint32_t matmul_partials_cb = 25;
-    uint32_t untilize_mode_final_matmul_partials_cb = 26;
-    uint32_t untilize_mode_reblock_cb = 27;
-    uint32_t out0_cb = 16;
+    std::uint32_t M,
+    std::uint32_t N,
+    std::uint32_t in0_block_w,
+    std::uint32_t /*out_subblock_h*/) {
+    std::uint32_t num_bytes_for_df = 2;
+    std::uint32_t in0_cb = 0;
+    std::uint32_t in1_cb = 1;
+    std::uint32_t tilize_mode_tilized_in0_cb = 24;
+    std::uint32_t matmul_partials_cb = 25;
+    std::uint32_t untilize_mode_final_matmul_partials_cb = 26;
+    std::uint32_t untilize_mode_reblock_cb = 27;
+    std::uint32_t out0_cb = 16;
 
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     auto& program = workload.get_programs().at(device_range);
 
-    uint32_t single_tile_size = num_bytes_for_df * 1024;
+    std::uint32_t single_tile_size = num_bytes_for_df * 1024;
 
-    uint32_t num_output_tiles = M * N;
+    std::uint32_t num_output_tiles = M * N;
 
     // Invariants
-    uint32_t cb0_tiles = M * in0_block_w * 2;
+    std::uint32_t cb0_tiles = M * in0_block_w * 2;
     tt_metal::CircularBufferConfig l1_input0_cb_config =
         tt_metal::CircularBufferConfig(cb0_tiles * single_tile_size, {{in0_cb, tt::DataFormat::Float16_b}})
             .set_page_size(in0_cb, single_tile_size);
     tt_metal::CreateCircularBuffer(program, core, l1_input0_cb_config);
 
-    uint32_t cb1_tiles = N * in0_block_w * 2;
+    std::uint32_t cb1_tiles = N * in0_block_w * 2;
     tt_metal::CircularBufferConfig cb_in1_config =
         tt_metal::CircularBufferConfig(cb1_tiles * single_tile_size, {{in1_cb, tt::DataFormat::Float16_b}})
             .set_page_size(in1_cb, single_tile_size);
@@ -149,7 +150,7 @@ void create_CBs_for_fused_matmul(
 
         // Supposed to be a small CB only responsible for reorganizing
         // the output blocks to fill the whole "per core output block width"
-        uint32_t reblock_cb_tiles = N;  // Only space for one row
+        std::uint32_t reblock_cb_tiles = N;  // Only space for one row
         tt_metal::CircularBufferConfig cb_reblock_config =
             tt_metal::CircularBufferConfig(
                 reblock_cb_tiles * single_tile_size, {{untilize_mode_reblock_cb, tt::DataFormat::Float16_b}})
@@ -205,7 +206,7 @@ void create_CBs_for_fused_matmul(
 
         // Supposed to be a small CB only responsible for reorganizing
         // the output blocks to fill the whole "per core output block width"
-        uint32_t reblock_cb_tiles = N;  // Only space for one row
+        std::uint32_t reblock_cb_tiles = N;  // Only space for one row
         tt_metal::CircularBufferConfig cb_reblock_config =
             tt_metal::CircularBufferConfig(
                 reblock_cb_tiles * single_tile_size, {{untilize_mode_reblock_cb, tt::DataFormat::Float16_b}})
@@ -223,8 +224,8 @@ void create_CBs_for_fused_matmul(
 // Trivial / constant stimulus is avoided so structural K-stride bugs are not
 // masked. M=K=N=1 is the single-tile case; larger (M, K, N) for single_block_matmul.
 struct MatmulStimulus {
-    std::vector<uint32_t> packed_input0;
-    std::vector<uint32_t> packed_input1;
+    std::vector<std::uint32_t> packed_input0;
+    std::vector<std::uint32_t> packed_input1;
     std::vector<float> in0_floats;
     std::vector<float> in1_floats;
 };
@@ -235,20 +236,20 @@ struct MatmulStimulus {
 // reference is the unpack-after-pack roundtrip so the golden reflects the
 // values the hardware actually sees, not the raw RNG samples.
 struct OperandStimulus {
-    std::vector<uint32_t> packed;
+    std::vector<std::uint32_t> packed;
     std::vector<float> floats;
 };
 
-OperandStimulus make_operand_stimulus(tt::DataFormat fmt, uint32_t tile_count, uint32_t seed) {
+OperandStimulus make_operand_stimulus(tt::DataFormat fmt, std::uint32_t tile_count, std::uint32_t seed) {
     constexpr float rng = 1.0f;
     const size_t num_elements = tt::constants::TILE_HW * tile_count;
     OperandStimulus out;
     if (fmt == tt::DataFormat::Fp8_e4m3) {
-        out.packed = generate_packed_uniform_random_vector<uint32_t, float8_e4m3>(
+        out.packed = generate_packed_uniform_random_vector<std::uint32_t, float8_e4m3>(
             float8_e4m3(-rng), float8_e4m3(+rng), num_elements, seed);
         out.floats = fp8_to_floats(out.packed);
     } else if (fmt == tt::DataFormat::Float16_b) {
-        out.packed = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
+        out.packed = generate_packed_uniform_random_vector<std::uint32_t, bfloat16>(
             bfloat16(-rng), bfloat16(+rng), num_elements, seed);
         out.floats = bf16_to_floats(out.packed);
     } else if (fmt == tt::DataFormat::Bfp8_b) {
@@ -286,7 +287,7 @@ OperandStimulus make_operand_stimulus(tt::DataFormat fmt, uint32_t tile_count, u
 }
 
 MatmulStimulus make_matmul_stimulus(
-    tt::DataFormat in0_fmt, tt::DataFormat in1_fmt, uint32_t M, uint32_t K, uint32_t N) {
+    tt::DataFormat in0_fmt, tt::DataFormat in1_fmt, std::uint32_t M, std::uint32_t K, std::uint32_t N) {
     OperandStimulus a = make_operand_stimulus(in0_fmt, M * K, /*seed=*/0);
     OperandStimulus b = make_operand_stimulus(in1_fmt, K * N, /*seed=*/1);
     MatmulStimulus out;
@@ -297,25 +298,29 @@ MatmulStimulus make_matmul_stimulus(
     return out;
 }
 
-MatmulStimulus make_matmul_stimulus(tt::DataFormat in_fmt, uint32_t M, uint32_t K, uint32_t N) {
+MatmulStimulus make_matmul_stimulus(tt::DataFormat in_fmt, std::uint32_t M, std::uint32_t K, std::uint32_t N) {
     return make_matmul_stimulus(in_fmt, in_fmt, M, K, N);
 }
 
 // Host reference matmul over face-major tiles: output layout is M×N tiles × TILE_HW
 // elements per tile.
 std::vector<float> make_matmul_golden(
-    const std::vector<float>& in0_floats, const std::vector<float>& in1_floats, uint32_t M, uint32_t K, uint32_t N) {
+    const std::vector<float>& in0_floats,
+    const std::vector<float>& in1_floats,
+    std::uint32_t M,
+    std::uint32_t K,
+    std::uint32_t N) {
     std::vector<float> golden_floats(M * N * tt::constants::TILE_HW, 0.0f);
-    for (uint32_t mt = 0; mt < M; mt++) {
-        for (uint32_t nt = 0; nt < N; nt++) {
+    for (std::uint32_t mt = 0; mt < M; mt++) {
+        for (std::uint32_t nt = 0; nt < N; nt++) {
             const size_t out_tile_off = (mt * N + nt) * tt::constants::TILE_HW;
-            for (uint32_t y = 0; y < tt::constants::TILE_HEIGHT; y++) {
-                for (uint32_t x = 0; x < tt::constants::TILE_WIDTH; x++) {
+            for (std::uint32_t y = 0; y < tt::constants::TILE_HEIGHT; y++) {
+                for (std::uint32_t x = 0; x < tt::constants::TILE_WIDTH; x++) {
                     float acc = 0.0f;
-                    for (uint32_t kt = 0; kt < K; kt++) {
+                    for (std::uint32_t kt = 0; kt < K; kt++) {
                         const size_t in0_tile_off = (mt * K + kt) * tt::constants::TILE_HW;
                         const size_t in1_tile_off = (kt * N + nt) * tt::constants::TILE_HW;
-                        for (uint32_t z = 0; z < tt::constants::TILE_WIDTH; z++) {
+                        for (std::uint32_t z = 0; z < tt::constants::TILE_WIDTH; z++) {
                             acc += in0_floats[in0_tile_off + byte_tile_face_major_index(z, y)] *
                                    in1_floats[in1_tile_off + byte_tile_face_major_index(x, z)];
                         }
@@ -357,12 +362,12 @@ bool single_tile_matmul(
     bool fp32_dest_acc_en = false) {
     bool pass = true;
     CoreCoord core(0, 0);
-    const uint32_t in0_cb_index = 0;
-    const uint32_t in1_cb_index = 1;
-    const uint32_t out_cb_index = 16;
-    const uint32_t in0_tile_size = tt::tile_size(in0_fmt);
-    const uint32_t in1_tile_size = tt::tile_size(in1_fmt);
-    const uint32_t out_tile_size = tt::tile_size(out_fmt);
+    const std::uint32_t in0_cb_index = 0;
+    const std::uint32_t in1_cb_index = 1;
+    const std::uint32_t out_cb_index = 16;
+    const std::uint32_t in0_tile_size = tt::tile_size(in0_fmt);
+    const std::uint32_t in1_tile_size = tt::tile_size(in1_fmt);
+    const std::uint32_t out_tile_size = tt::tile_size(out_fmt);
 
     auto& cq = mesh_device->mesh_command_queue();
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -446,13 +451,16 @@ bool single_tile_matmul(
         program_,
         reader_kernel,
         core,
-        {(uint32_t)input0_dram_buffer->address(),
-         (uint32_t)0,
-         (uint32_t)input1_dram_buffer->address(),
-         (uint32_t)0,
-         (uint32_t)1});
+        {(std::uint32_t)input0_dram_buffer->address(),
+         (std::uint32_t)0,
+         (std::uint32_t)input1_dram_buffer->address(),
+         (std::uint32_t)0,
+         (std::uint32_t)1});
     tt_metal::SetRuntimeArgs(
-        program_, writer_kernel, core, {(uint32_t)output_dram_buffer->address(), (uint32_t)0, (uint32_t)1});
+        program_,
+        writer_kernel,
+        core,
+        {(std::uint32_t)output_dram_buffer->address(), (std::uint32_t)0, (std::uint32_t)1});
 
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::Finish(cq);
@@ -460,7 +468,7 @@ bool single_tile_matmul(
     ////////////////////////////////////////////////////////////////////////////
     //                      Comparison Checking
     ////////////////////////////////////////////////////////////////////////////
-    std::vector<uint32_t> dest_buffer_data;
+    std::vector<std::uint32_t> dest_buffer_data;
     distributed::EnqueueReadMeshBuffer(cq, dest_buffer_data, output_dram_buffer, /*blocking=*/true);
     std::vector<float> dest_floats;
     if (out_fmt == tt::DataFormat::Fp8_e4m3) {
@@ -493,17 +501,17 @@ bool single_tile_matmul(
 // BF16 test semantics.
 bool single_block_matmul(
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    uint32_t M,
-    uint32_t K,
-    uint32_t N,
+    std::uint32_t M,
+    std::uint32_t K,
+    std::uint32_t N,
     tt::DataFormat in_fmt = tt::DataFormat::Float16_b,
     tt::DataFormat out_fmt = tt::DataFormat::Float16_b,
     bool fp32_dest_acc_en = false) {
     bool pass = true;
     CoreCoord core(0, 0);
-    const uint32_t in0_cb_index = 0;
-    const uint32_t in1_cb_index = 1;
-    const uint32_t out_cb_index = 16;
+    const std::uint32_t in0_cb_index = 0;
+    const std::uint32_t in1_cb_index = 1;
+    const std::uint32_t out_cb_index = 16;
     const size_t in_tile_size = tt::tile_size(in_fmt);
     const size_t out_tile_size = tt::tile_size(out_fmt);
     const size_t in0_byte_size = M * K * in_tile_size;
@@ -592,17 +600,20 @@ bool single_block_matmul(
         program_,
         reader_kernel,
         core,
-        {(uint32_t)input0_dram_buffer->address(),
-         (uint32_t)0,
-         (uint32_t)input1_dram_buffer->address(),
-         (uint32_t)0,
-         (uint32_t)1,              // num_blocks
-         (uint32_t)M * K,          // in0_block_tile_cnt
-         (uint32_t)K * N,          // in1_block_tile_cnt
-         (uint32_t)in0_byte_size,  // in0_block_size_bytes
-         (uint32_t)in1_byte_size});
+        {(std::uint32_t)input0_dram_buffer->address(),
+         (std::uint32_t)0,
+         (std::uint32_t)input1_dram_buffer->address(),
+         (std::uint32_t)0,
+         (std::uint32_t)1,              // num_blocks
+         (std::uint32_t)M * K,          // in0_block_tile_cnt
+         (std::uint32_t)K * N,          // in1_block_tile_cnt
+         (std::uint32_t)in0_byte_size,  // in0_block_size_bytes
+         (std::uint32_t)in1_byte_size});
     tt_metal::SetRuntimeArgs(
-        program_, writer_kernel, core, {(uint32_t)output_dram_buffer->address(), (uint32_t)0, (uint32_t)M * N});
+        program_,
+        writer_kernel,
+        core,
+        {(std::uint32_t)output_dram_buffer->address(), (std::uint32_t)0, (std::uint32_t)M * N});
 
     distributed::EnqueueMeshWorkload(cq, workload, false);
     distributed::Finish(cq);
@@ -610,7 +621,7 @@ bool single_block_matmul(
     ////////////////////////////////////////////////////////////////////////////
     //                      Comparison Checking
     ////////////////////////////////////////////////////////////////////////////
-    std::vector<uint32_t> dest_buffer_data;
+    std::vector<std::uint32_t> dest_buffer_data;
     distributed::EnqueueReadMeshBuffer(cq, dest_buffer_data, output_dram_buffer, /*blocking=*/true);
     std::vector<float> dest_floats;
     // Tolerances under random U(-1, +1) stimulus. FP8 output: ~1/8
@@ -643,10 +654,10 @@ bool single_block_matmul(
 }
 // blocked matmul has blocking on output, spill/reloads or does l1 accumulation using intermediate
 bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const BlockedMatmulConfig& cfg) {
-    const uint32_t M = cfg.M;
-    const uint32_t K = cfg.K;
-    const uint32_t N = cfg.N;
-    const uint32_t num_blocks = cfg.num_blocks;
+    const std::uint32_t M = cfg.M;
+    const std::uint32_t K = cfg.K;
+    const std::uint32_t N = cfg.N;
+    const std::uint32_t num_blocks = cfg.num_blocks;
     const tt::DataFormat in0_fmt = cfg.in0_fmt;
     const tt::DataFormat in1_fmt = cfg.in1_fmt;
     const tt::DataFormat out_fmt = cfg.out_fmt;
@@ -683,28 +694,28 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
         distributed::ReplicatedBufferConfig{.size = in0_total_size_bytes},
         {.page_size = in0_total_size_bytes, .buffer_type = tt::tt_metal::BufferType::DRAM},
         mesh_device.get());
-    const uint32_t in0_dram_addr = input0_dram_buffer->address();
+    const std::uint32_t in0_dram_addr = input0_dram_buffer->address();
     auto input1_dram_buffer = distributed::MeshBuffer::create(
         distributed::ReplicatedBufferConfig{.size = in1_total_size_bytes},
         {.page_size = in1_total_size_bytes, .buffer_type = tt::tt_metal::BufferType::DRAM},
         mesh_device.get());
-    const uint32_t in1_dram_addr = input1_dram_buffer->address();
+    const std::uint32_t in1_dram_addr = input1_dram_buffer->address();
     auto output_dram_buffer = distributed::MeshBuffer::create(
         distributed::ReplicatedBufferConfig{.size = out_byte_size},
         {.page_size = out_byte_size, .buffer_type = tt::tt_metal::BufferType::DRAM},
         mesh_device.get());
-    const uint32_t out_dram_addr = output_dram_buffer->address();
+    const std::uint32_t out_dram_addr = output_dram_buffer->address();
 
-    uint32_t in0_id = 0;
-    uint32_t in1_id = 0;
-    uint32_t out_id = 0;
-    uint32_t partials_id = 0;
+    std::uint32_t in0_id = 0;
+    std::uint32_t in1_id = 0;
+    std::uint32_t out_id = 0;
+    std::uint32_t partials_id = 0;
 
     if (is_quasar) {
-        auto make_dfb = [&](uint32_t entry_size,
-                            uint32_t num_entries,
-                            uint16_t producer_mask,
-                            uint16_t consumer_mask,
+        auto make_dfb = [&](std::uint32_t entry_size,
+                            std::uint32_t num_entries,
+                            std::uint16_t producer_mask,
+                            std::uint16_t consumer_mask,
                             tt::DataFormat fmt) {
             return tt_metal::experimental::dfb::CreateDataflowBuffer(
                 program_,
@@ -753,10 +764,10 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
                 .data_format = out_fmt,
                 .tensix_scope = tt_metal::experimental::dfb::TensixScope::INTRA});
     } else {
-        const uint32_t in0_cb_index = 0;
-        const uint32_t in1_cb_index = 1;
-        const uint32_t out_cb_index = 16;
-        const uint32_t partials_cb_index = 24;
+        const std::uint32_t in0_cb_index = 0;
+        const std::uint32_t in1_cb_index = 1;
+        const std::uint32_t out_cb_index = 16;
+        const std::uint32_t partials_cb_index = 24;
 
         tt_metal::CircularBufferConfig l1_input0_cb_config =
             tt_metal::CircularBufferConfig(in0_block_size_bytes, {{in0_cb_index, in0_fmt}})
@@ -789,7 +800,7 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
         compute_defines["PACKER_L1_ACC"] = "1";
     }
 
-    std::vector<uint32_t> compute_compile_args = {
+    std::vector<std::uint32_t> compute_compile_args = {
         in0_id, in1_id, out_id, partials_id, M * K, K * N, M * N, M, N, K, num_blocks};
 
     KernelHandle reader_kernel;
@@ -872,19 +883,19 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     // accumulate the per-block matmul into the shared golden, using byte_tile_face_major_index
     // for both inputs and output to match the layout the device produces.
     std::vector<float> golden_floats(M * N * tt::constants::TILE_HW, 0.0f);
-    for (uint32_t b = 0; b < num_blocks; b++) {
+    for (std::uint32_t b = 0; b < num_blocks; b++) {
         const size_t in0_block_off = b * M * K * tt::constants::TILE_HW;
         const size_t in1_block_off = b * K * N * tt::constants::TILE_HW;
-        for (uint32_t mt = 0; mt < M; mt++) {
-            for (uint32_t nt = 0; nt < N; nt++) {
+        for (std::uint32_t mt = 0; mt < M; mt++) {
+            for (std::uint32_t nt = 0; nt < N; nt++) {
                 const size_t out_tile_off = (mt * N + nt) * tt::constants::TILE_HW;
-                for (uint32_t y = 0; y < tt::constants::TILE_HEIGHT; y++) {
-                    for (uint32_t x = 0; x < tt::constants::TILE_WIDTH; x++) {
+                for (std::uint32_t y = 0; y < tt::constants::TILE_HEIGHT; y++) {
+                    for (std::uint32_t x = 0; x < tt::constants::TILE_WIDTH; x++) {
                         float acc = 0.0f;
-                        for (uint32_t kt = 0; kt < K; kt++) {
+                        for (std::uint32_t kt = 0; kt < K; kt++) {
                             const size_t in0_tile_off = in0_block_off + (mt * K + kt) * tt::constants::TILE_HW;
                             const size_t in1_tile_off = in1_block_off + (kt * N + nt) * tt::constants::TILE_HW;
-                            for (uint32_t z = 0; z < tt::constants::TILE_WIDTH; z++) {
+                            for (std::uint32_t z = 0; z < tt::constants::TILE_WIDTH; z++) {
                                 acc += in0_stim.floats[in0_tile_off + byte_tile_face_major_index(z, y)] *
                                        in1_stim.floats[in1_tile_off + byte_tile_face_major_index(x, z)];
                             }
@@ -908,24 +919,24 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
         reader_kernel,
         core,
         {
-            (uint32_t)in0_dram_addr,
-            (uint32_t)0,
-            (uint32_t)in1_dram_addr,
-            (uint32_t)0,
-            (uint32_t)num_blocks,
-            (uint32_t)(M * K),  // in0_block_tile_cnt
-            (uint32_t)(K * N),  // in1_block_tile_cnt
-            (uint32_t)in0_block_size_bytes,
-            (uint32_t)in1_block_size_bytes,
+            (std::uint32_t)in0_dram_addr,
+            (std::uint32_t)0,
+            (std::uint32_t)in1_dram_addr,
+            (std::uint32_t)0,
+            (std::uint32_t)num_blocks,
+            (std::uint32_t)(M * K),  // in0_block_tile_cnt
+            (std::uint32_t)(K * N),  // in1_block_tile_cnt
+            (std::uint32_t)in0_block_size_bytes,
+            (std::uint32_t)in1_block_size_bytes,
         });
     tt_metal::SetRuntimeArgs(
         program_,
         writer_kernel,
         core,
         {
-            (uint32_t)out_dram_addr,
-            (uint32_t)0,
-            (uint32_t)(M * N),
+            (std::uint32_t)out_dram_addr,
+            (std::uint32_t)0,
+            (std::uint32_t)(M * N),
         });
 
     auto blocking = is_quasar;
@@ -936,7 +947,7 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     ////////////////////////////////////////////////////////////////////////////
     //                      Comparison Checking
     ////////////////////////////////////////////////////////////////////////////
-    std::vector<uint32_t> dest_buffer_data;
+    std::vector<std::uint32_t> dest_buffer_data;
     distributed::EnqueueReadMeshBuffer(cq, dest_buffer_data, output_dram_buffer, /*blocking=*/true);
     std::vector<float> dest_floats;
     if (out_fmt == tt::DataFormat::Fp8_e4m3) {
@@ -967,9 +978,9 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
 
 // MOP-less matmul (issue #52329): out[rt x ct] = in0[rt x kt] * in1[kt x ct] in one dest acquire.
 struct MatmulConfig {
-    uint32_t rt_dim = 1;
-    uint32_t ct_dim = 1;
-    uint32_t kt_dim = 1;
+    std::uint32_t rt_dim = 1;
+    std::uint32_t ct_dim = 1;
+    std::uint32_t kt_dim = 1;
     MathFidelity math_fidelity = MathFidelity::LoFi;
 };
 
@@ -982,13 +993,13 @@ void run_matmul_no_mop(const std::shared_ptr<distributed::MeshDevice>& mesh_devi
     const experimental::NodeCoord node{0, 0};
     const bool is_quasar = mesh_device->arch() == tt::ARCH::QUASAR;
 
-    const uint32_t rt_dim = test_config.rt_dim;
-    const uint32_t ct_dim = test_config.ct_dim;
-    const uint32_t kt_dim = test_config.kt_dim;
-    const uint32_t in0_num_tiles = rt_dim * kt_dim;
-    const uint32_t in1_num_tiles = kt_dim * ct_dim;
-    const uint32_t out_num_tiles = rt_dim * ct_dim;
-    const uint32_t single_tile_size = tt::constants::TILE_HW * sizeof(bfloat16);
+    const std::uint32_t rt_dim = test_config.rt_dim;
+    const std::uint32_t ct_dim = test_config.ct_dim;
+    const std::uint32_t kt_dim = test_config.kt_dim;
+    const std::uint32_t in0_num_tiles = rt_dim * kt_dim;
+    const std::uint32_t in1_num_tiles = kt_dim * ct_dim;
+    const std::uint32_t out_num_tiles = rt_dim * ct_dim;
+    const std::uint32_t single_tile_size = tt::constants::TILE_HW * sizeof(bfloat16);
 
     log_info(
         tt::LogTest,
@@ -1000,7 +1011,7 @@ void run_matmul_no_mop(const std::shared_ptr<distributed::MeshDevice>& mesh_devi
 
     distributed::DeviceLocalBufferConfig dram_config{
         .page_size = single_tile_size, .buffer_type = tt_metal::BufferType::DRAM, .bottom_up = false};
-    auto make_dram = [&](uint32_t num_tiles) {
+    auto make_dram = [&](std::uint32_t num_tiles) {
         distributed::ReplicatedBufferConfig cfg{.size = single_tile_size * num_tiles};
         return distributed::MeshBuffer::create(cfg, dram_config, mesh_device.get());
     };
@@ -1020,7 +1031,7 @@ void run_matmul_no_mop(const std::shared_ptr<distributed::MeshDevice>& mesh_devi
     const experimental::KernelSpecName WRITER{"writer"};
     const experimental::KernelSpecName COMPUTE{"compute"};
 
-    auto make_dfb = [&](const experimental::DFBSpecName& name, uint32_t num_entries) {
+    auto make_dfb = [&](const experimental::DFBSpecName& name, std::uint32_t num_entries) {
         return experimental::DataflowBufferSpec{
             .unique_id = name,
             .entry_size = single_tile_size,
@@ -1133,9 +1144,9 @@ void run_matmul_no_mop(const std::shared_ptr<distributed::MeshDevice>& mesh_devi
             .kernel = READER,
             .runtime_arg_values = experimental::MakeRuntimeArgsForSingleNode(
                 node,
-                {{"src0_addr", static_cast<uint32_t>(in0_dram->address())},
+                {{"src0_addr", static_cast<std::uint32_t>(in0_dram->address())},
                  {"src0_bank_id", 0u},
-                 {"src1_addr", static_cast<uint32_t>(in1_dram->address())},
+                 {"src1_addr", static_cast<std::uint32_t>(in1_dram->address())},
                  {"src1_bank_id", 0u},
                  {"num_tiles", in0_num_tiles},
                  {"num_bcast_tiles", in1_num_tiles}}),
@@ -1144,7 +1155,7 @@ void run_matmul_no_mop(const std::shared_ptr<distributed::MeshDevice>& mesh_devi
             .kernel = WRITER,
             .runtime_arg_values = experimental::MakeRuntimeArgsForSingleNode(
                 node,
-                {{"dst_addr", static_cast<uint32_t>(out_dram->address())},
+                {{"dst_addr", static_cast<std::uint32_t>(out_dram->address())},
                  {"bank_id", 0u},
                  {"num_tiles", out_num_tiles}}),
         },
@@ -1164,7 +1175,7 @@ void run_matmul_no_mop(const std::shared_ptr<distributed::MeshDevice>& mesh_devi
     distributed::EnqueueMeshWorkload(cq, workload, is_quasar);
     distributed::Finish(cq);
 
-    std::vector<uint32_t> dest_buffer_data;
+    std::vector<std::uint32_t> dest_buffer_data;
     distributed::ReadShard(cq, dest_buffer_data, out_dram, zero_coord);
     std::vector<float> dest_floats = bf16_to_floats(dest_buffer_data);
 
@@ -1335,6 +1346,62 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixTestSingleCoreSingleBlockSingleTileA
         tt::DataFormat::Fp8_e4m3,
         tt::DataFormat::Fp8_e4m3,
         /*fp32_dest_acc_en=*/true));
+}
+
+// ============================================================================
+// Id-free (2.0) matmul, validated against the make_matmul_golden host golden (float reference), not a legacy
+// kernel. Covers single-tile (C = A*B, 32x32x32) and a 2x2x2 block matmul. All Float16_b. Runs on Blackhole
+// (BH-only API). in0 (A) -> c_0 -> SrcB, in1 (B) -> c_1 -> SrcA (the run_matmul_* convention).
+// ============================================================================
+TEST_F(LLKBlackholeSingleCardFixture, TensixMatmulSingleTileIdFreeGolden) {
+    auto src0 = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b), /*rand_max_float=*/2, /*seed=*/42, /*offset=*/-1.0f);
+    auto src1 = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b), /*rand_max_float=*/2, /*seed=*/7, /*offset=*/-1.0f);
+
+    auto golden = unit_tests::compute::matmul::make_matmul_golden(
+        bf16_to_floats(src0), bf16_to_floats(src1), /*M=*/1, /*K=*/1, /*N=*/1);
+    auto result = unit_tests::llk::single_core::run_matmul_single(
+        *this->devices_.at(0), src0, src1, "tests/tt_metal/tt_metal/test_kernels/compute/matmul_idfree.cpp");
+    auto result_floats = bf16_to_floats(result);
+
+    EXPECT_TRUE(is_close_vectors<float>(
+        result_floats, golden, [](float a, float b) { return is_close(a, b, /*rtol=*/0.05f, /*atol=*/0.2f); }));
+    EXPECT_TRUE(check_pcc(result_floats, golden, /*min_pcc=*/0.99));
+}
+
+// Block matmul: one matmul_block call produces the whole rt_dim x ct_dim output block (A[rt x kt] * B[kt x ct]).
+// kt_dim == 1 here so the block is exercised on the output-grid axes (rt x ct) against a real host golden;
+// multi-tile K accumulation is driven by the compute kernel's own K loop (out of this op-level golden's scope).
+TEST_F(LLKBlackholeSingleCardFixture, TensixMatmulBlockIdFreeGolden) {
+    // rt == ct required by run_matmul_block (reader_binary feeds c_0/c_1 the same count). 2x2 block, kt = 1.
+    constexpr std::uint32_t ct_dim = 2, rt_dim = 2, kt_dim = 1;
+    auto src0 = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * (rt_dim * kt_dim),
+        /*rand_max_float=*/2,
+        /*seed=*/42,
+        /*offset=*/-1.0f);
+    auto src1 = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * (kt_dim * ct_dim),
+        /*rand_max_float=*/2,
+        /*seed=*/7,
+        /*offset=*/-1.0f);
+
+    auto golden = unit_tests::compute::matmul::make_matmul_golden(
+        bf16_to_floats(src0), bf16_to_floats(src1), /*M=*/rt_dim, /*K=*/kt_dim, /*N=*/ct_dim);
+    auto result = unit_tests::llk::single_core::run_matmul_block(
+        *this->devices_.at(0),
+        src0,
+        src1,
+        ct_dim,
+        rt_dim,
+        kt_dim,
+        "tests/tt_metal/tt_metal/test_kernels/compute/matmul_block_2_0.cpp");
+    auto result_floats = bf16_to_floats(result);
+
+    EXPECT_TRUE(is_close_vectors<float>(
+        result_floats, golden, [](float a, float b) { return is_close(a, b, /*rtol=*/0.05f, /*atol=*/0.2f); }));
+    EXPECT_TRUE(check_pcc(result_floats, golden, /*min_pcc=*/0.99));
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_transpose.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_transpose.cpp
@@ -41,6 +41,7 @@
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/tensor/mesh_tensor.hpp>
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "single_core_compute_runners.hpp"
 
 namespace tt::tt_metal {
 class IDevice;
@@ -55,13 +56,13 @@ using namespace tt::test_utils::df;
 
 namespace unit_tests::compute::transpose {
 
-enum TransposeType : uint8_t { WH = 0 };
+enum TransposeType : std::uint8_t { WH = 0 };
 
 struct TransposeConfig {
     bool short_init;
     bool transpose_dest;
-    uint32_t single_tile_size;
-    std::vector<uint32_t> shape;
+    std::uint32_t single_tile_size;
+    std::vector<std::uint32_t> shape;
     TransposeType transpose_type;
     tt::DataFormat data_format = tt::DataFormat::Float16_b;
     bool dst_full_sync_en = false;
@@ -70,25 +71,25 @@ struct TransposeConfig {
 
 // Tiled dimensions derived from a 4-D NCHW tensor shape, with shared validation.
 struct TransposeDims {
-    uint32_t W;
-    uint32_t H;
-    uint32_t NC;
-    uint32_t Wt;
-    uint32_t Ht;
-    uint32_t num_tensor_tiles;
+    std::uint32_t W;
+    std::uint32_t H;
+    std::uint32_t NC;
+    std::uint32_t Wt;
+    std::uint32_t Ht;
+    std::uint32_t num_tensor_tiles;
 };
 
-static TransposeDims compute_and_validate_transpose_dims(const std::vector<uint32_t>& shape) {
+static TransposeDims compute_and_validate_transpose_dims(const std::vector<std::uint32_t>& shape) {
     TT_FATAL(shape.size() == 4, "Error");
-    const uint32_t W = shape[3];
-    const uint32_t H = shape[2];
-    const uint32_t NC = shape[1] * shape[0];
+    const std::uint32_t W = shape[3];
+    const std::uint32_t H = shape[2];
+    const std::uint32_t NC = shape[1] * shape[0];
     TT_FATAL(W % 32 == 0 && H % 32 == 0, "Error");
     TT_FATAL(H > 0 && W > 0 && NC > 0, "Error");
-    const uint32_t Wt = W / 32;
+    const std::uint32_t Wt = W / 32;
     // size of DST register, with unary r/w this currently only works if the entire Wt fits into DST for reduce
     TT_FATAL(Wt <= 16, "Error");
-    const uint32_t Ht = H / 32;
+    const std::uint32_t Ht = H / 32;
     return TransposeDims{
         .W = W,
         .H = H,
@@ -104,22 +105,22 @@ static TransposeDims compute_and_validate_transpose_dims(const std::vector<uint3
 // tolerant float compare. 32-bit formats (Float32/Int32) are exact, lossless data movement, so they
 // use an exact word compare.
 void validate_transpose_wh(
-    const std::vector<uint32_t>& src_vec,
-    const std::vector<uint32_t>& shape,
-    const std::vector<uint32_t>& result_vec,
+    const std::vector<std::uint32_t>& src_vec,
+    const std::vector<std::uint32_t>& shape,
+    const std::vector<std::uint32_t>& result_vec,
     tt::DataFormat data_format) {
     TT_FATAL(shape.size() == 4, "Error");
-    const vector<uint32_t> shapeR{shape[0], shape[1], shape[3], shape[2]};
+    const vector<std::uint32_t> shapeR{shape[0], shape[1], shape[3], shape[2]};
 
     bool pass = false;
     int argfail = -1;
-    if (tt::datum_size(data_format) == sizeof(uint32_t)) {
+    if (tt::datum_size(data_format) == sizeof(std::uint32_t)) {
         // 32-bit datum: one uint32 per element, exact compare.
-        auto src_linear =
-            convert_layout<uint32_t>(src_vec, shape, TensorLayoutType::TILED_NFACES, TensorLayoutType::LIN_ROW_MAJOR);
+        auto src_linear = convert_layout<std::uint32_t>(
+            src_vec, shape, TensorLayoutType::TILED_NFACES, TensorLayoutType::LIN_ROW_MAJOR);
         auto gold_lin = ::unit_tests::compute::gold_transpose_wh(src_linear, shape);
-        auto gold_tiled =
-            convert_layout<uint32_t>(gold_lin, shapeR, TensorLayoutType::LIN_ROW_MAJOR, TensorLayoutType::TILED_NFACES);
+        auto gold_tiled = convert_layout<std::uint32_t>(
+            gold_lin, shapeR, TensorLayoutType::LIN_ROW_MAJOR, TensorLayoutType::TILED_NFACES);
 
         ASSERT_EQ(result_vec.size(), gold_tiled.size());
         const auto res_it = std::mismatch(result_vec.begin(), result_vec.end(), gold_tiled.begin()).first;
@@ -135,10 +136,10 @@ void validate_transpose_wh(
             const float absdiff = fabsf(a - b);
             return (absdiff <= atol) || (absdiff < rtol * fmaxf(fabsf(a), fabsf(b)));
         };
-        auto src_linear = convert_layout<uint16_t>(
+        auto src_linear = convert_layout<std::uint16_t>(
             u16_from_u32_vector(src_vec), shape, TensorLayoutType::TILED_NFACES, TensorLayoutType::LIN_ROW_MAJOR);
         auto gold_lin = ::unit_tests::compute::gold_transpose_wh(src_linear, shape);
-        auto gold_tiled = u32_from_u16_vector(convert_layout<uint16_t>(
+        auto gold_tiled = u32_from_u16_vector(convert_layout<std::uint16_t>(
             gold_lin, shapeR, TensorLayoutType::LIN_ROW_MAJOR, TensorLayoutType::TILED_NFACES));
 
         pass = packed_uint32_t_vector_comparison(result_vec, gold_tiled, comparison_function, &argfail);
@@ -153,8 +154,9 @@ void validate_transpose_wh(
 // Build a TensorSpec describing a flat DRAM-interleaved buffer of `total_entries`
 // pages, each `entry_size` bytes. Used to bind src/dst tensors as TensorParameters
 // to the reader/writer kernels via the Metal 2.0 named TensorAccessor ctor.
-static inline tt::tt_metal::TensorSpec make_flat_dram_tensor_spec(uint32_t entry_size, uint32_t total_entries) {
-    const uint32_t entry_size_words = entry_size / sizeof(uint32_t);
+static inline tt::tt_metal::TensorSpec make_flat_dram_tensor_spec(
+    std::uint32_t entry_size, std::uint32_t total_entries) {
+    const std::uint32_t entry_size_words = entry_size / sizeof(std::uint32_t);
     auto page_config = tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR);
     auto memory_config =
         tt::tt_metal::MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
@@ -167,17 +169,17 @@ void run_single_core_transpose(distributed::MeshDevice& mesh_device, const Trans
     const experimental::NodeCoord node{0, 0};
 
     const TransposeDims dims = compute_and_validate_transpose_dims(test_config.shape);
-    const uint32_t NC = dims.NC, Wt = dims.Wt, Ht = dims.Ht, num_tensor_tiles = dims.num_tensor_tiles;
+    const std::uint32_t NC = dims.NC, Wt = dims.Wt, Ht = dims.Ht, num_tensor_tiles = dims.num_tensor_tiles;
 
-    uint32_t dram_buffer_size = test_config.single_tile_size * num_tensor_tiles;
+    std::uint32_t dram_buffer_size = test_config.single_tile_size * num_tensor_tiles;
 
     auto in_tensor = MeshTensor::allocate_on_device(
         mesh_device, make_flat_dram_tensor_spec(test_config.single_tile_size, num_tensor_tiles));
     auto out_tensor = MeshTensor::allocate_on_device(
         mesh_device, make_flat_dram_tensor_spec(test_config.single_tile_size, num_tensor_tiles));
 
-    constexpr uint32_t num_buffer_tiles = 32;
-    constexpr uint32_t num_output_buffer_tiles = 32;
+    constexpr std::uint32_t num_buffer_tiles = 32;
+    constexpr std::uint32_t num_output_buffer_tiles = 32;
 
     const experimental::DFBSpecName INPUT_DFB{"input_dfb"};
     const experimental::DFBSpecName OUTPUT_DFB{"output_dfb"};
@@ -338,8 +340,8 @@ void run_single_core_transpose(distributed::MeshDevice& mesh_device, const Trans
 
     // Fixed seed so each test produces a repeatable input vector across runs.
     constexpr std::uint32_t kRandomSeed = 0x1234;
-    vector<uint32_t> src_vec;
-    const std::uint32_t n_u32 = dram_buffer_size / sizeof(uint32_t);
+    vector<std::uint32_t> src_vec;
+    const std::uint32_t n_u32 = dram_buffer_size / sizeof(std::uint32_t);
     // Fill src_vec with seeded random words: `dist` draws values and `convert` reinterprets
     // each draw into its uint32 word representation for the given data format.
     auto fill_random = [&](auto dist, auto convert) {
@@ -348,11 +350,13 @@ void run_single_core_transpose(distributed::MeshDevice& mesh_device, const Trans
         std::generate(src_vec.begin(), src_vec.end(), [&]() { return convert(dist(rng)); });
     };
     if (test_config.data_format == tt::DataFormat::Float32) {
-        fill_random(
-            std::uniform_real_distribution<float>(-100.0f, 100.0f), [](float v) { return std::bit_cast<uint32_t>(v); });
+        fill_random(std::uniform_real_distribution<float>(-100.0f, 100.0f), [](float v) {
+            return std::bit_cast<std::uint32_t>(v);
+        });
     } else if (test_config.data_format == tt::DataFormat::Int32) {
-        fill_random(
-            std::uniform_int_distribution<int32_t>(-10000, 10000), [](int32_t v) { return static_cast<uint32_t>(v); });
+        fill_random(std::uniform_int_distribution<std::int32_t>(-10000, 10000), [](std::int32_t v) {
+            return static_cast<std::uint32_t>(v);
+        });
     } else {
         src_vec = create_random_vector_of_bfloat16(dram_buffer_size, 100.0f, kRandomSeed);
     }
@@ -365,7 +369,7 @@ void run_single_core_transpose(distributed::MeshDevice& mesh_device, const Trans
     slow_dispatch::ReadFromBuffer(out_tensor.mesh_buffer(), result_vec);
 
     const std::uint32_t bytes_per_elem = tt::datum_size(test_config.data_format);
-    EXPECT_EQ(result_vec.size(), (dims.NC * dims.H * dims.W * bytes_per_elem) / sizeof(uint32_t));
+    EXPECT_EQ(result_vec.size(), (dims.NC * dims.H * dims.W * bytes_per_elem) / sizeof(std::uint32_t));
 
     validate_transpose_wh(src_vec, test_config.shape, result_vec, test_config.data_format);
 }
@@ -412,7 +416,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarTransposeWHDestFloat32) {
         unit_tests::compute::transpose::TransposeConfig test_config = {
             .short_init = false,
             .transpose_dest = true,
-            .single_tile_size = constants::TILE_HW * sizeof(uint32_t),
+            .single_tile_size = constants::TILE_HW * sizeof(std::uint32_t),
             .shape = {1, 1, 64, 64},
             .transpose_type = unit_tests::compute::transpose::TransposeType::WH,
             .data_format = tt::DataFormat::Float32,
@@ -431,7 +435,7 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarTransposeWHDestFloat16b) {
         unit_tests::compute::transpose::TransposeConfig test_config = {
             .short_init = false,
             .transpose_dest = true,
-            .single_tile_size = constants::TILE_HW * sizeof(uint16_t),
+            .single_tile_size = constants::TILE_HW * sizeof(std::uint16_t),
             .shape = {1, 1, 64, 64},
             .transpose_type = unit_tests::compute::transpose::TransposeType::WH,
             .data_format = tt::DataFormat::Float16_b,
@@ -440,6 +444,27 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, QuasarTransposeWHDestFloat16b) {
         };
         unit_tests::compute::transpose::run_single_core_transpose(this->device(), test_config);
     }
+}
+
+// ============================================================================
+// Id-free (2.0) transpose (WH): per-tile within-tile transpose, tiled c_0 -> tiled c_16. Validated against the
+// gold_transpose_wh host golden via the file's validate_transpose_wh helper (packed compare, rtol 0.02).
+// Single Float16_b tile ({1,1,32,32}). Runs on Blackhole (BH-only API).
+// ============================================================================
+TEST_F(LLKBlackholeSingleCardFixture, TensixTransposeIdFreeGolden) {
+    constexpr std::uint32_t num_tiles = 1;
+    const std::vector<std::uint32_t> shape{1, 1, 32, 32};
+    auto src = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/100, /*seed=*/0x1234, /*offset=*/0.0f);
+    auto result = unit_tests::llk::single_core::run_unary(
+        *this->devices_.at(0),
+        tt::DataFormat::Float16_b,
+        tt::DataFormat::Float16_b,
+        src,
+        num_tiles,
+        /*fp32_dest_acc_en=*/false,
+        "tests/tt_metal/tt_metal/test_kernels/compute/transpose_2_0.cpp");
+    unit_tests::compute::transpose::validate_transpose_wh(src, shape, result, tt::DataFormat::Float16_b);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_unary_broadcast.cpp
@@ -44,6 +44,7 @@
 #include "tt_metal/test_utils/packing.hpp"
 #include "tt_metal/test_utils/stimulus.hpp"
 #include <umd/device/types/arch.hpp>
+#include "single_core_compute_runners.hpp"
 #include "tt_metal/test_utils/bfloat_utils.hpp"
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/tensor/mesh_tensor.hpp>
@@ -64,7 +65,7 @@ using namespace tt::test_utils::df;
 
 namespace unit_tests::compute::unary_broadcast {
 
-enum BroadcastDim : uint8_t { ROW, COL, SCALAR, NONE, NUM_DIMS };
+enum BroadcastDim : std::uint8_t { ROW, COL, SCALAR, NONE, NUM_DIMS };
 
 const map<BroadcastDim, std::string> broadcast_dim_to_type = {
     {BroadcastDim::ROW, "BroadcastType::ROW"},
@@ -80,7 +81,7 @@ struct UnaryBroadcastConfig {
 
 // Assume 1Xn tiles.
 template <class T>
-std::vector<T> get_broadcasted_vec(std::vector<T>& src, const std::vector<uint32_t>& shape, BroadcastDim dim) {
+std::vector<T> get_broadcasted_vec(std::vector<T>& src, const std::vector<std::uint32_t>& shape, BroadcastDim dim) {
     int num_tiles = shape.at(0);
     int num_rows = shape.at(1);
     int num_cols = shape.at(2);
@@ -128,16 +129,16 @@ std::vector<T> get_broadcasted_vec(std::vector<T>& src, const std::vector<uint32
 // T_out : type of data the packer will pack out
 // Assume nx1 tiles, row major data layout.
 template <class T_in>
-std::vector<uint32_t> get_tilized_packed_golden_broadcast(
-    std::vector<T_in>& src, const std::vector<uint32_t>& shape, BroadcastDim dim, tt::DataFormat T_out) {
+std::vector<std::uint32_t> get_tilized_packed_golden_broadcast(
+    std::vector<T_in>& src, const std::vector<std::uint32_t>& shape, BroadcastDim dim, tt::DataFormat T_out) {
     static_assert(
         std::is_same_v<bfloat16, T_in> || std::is_same_v<float, T_in>, "Only float & Float_16b type as input allowed");
-    std::vector<uint32_t> tilized_packed_res;
+    std::vector<std::uint32_t> tilized_packed_res;
     ::unit_tests::compute::GoldenConfig config = {.num_tiles_r_dim = shape.at(0), .num_tiles_c_dim = 1};
     std::vector<T_in> vBroadcast = get_broadcasted_vec(src, shape, dim);
     if constexpr (std::is_same_v<bfloat16, T_in>) {
         if (T_out == tt::DataFormat::Float16_b) {
-            auto packed_vec = pack_vector<uint32_t, bfloat16>(vBroadcast);
+            auto packed_vec = pack_vector<std::uint32_t, bfloat16>(vBroadcast);
             tilized_packed_res = ::unit_tests::compute::gold_standard_tilize(packed_vec, config);
         } else if (T_out == tt::DataFormat::Bfp8_b) {
             std::vector<float> tempfp32v;
@@ -156,7 +157,7 @@ std::vector<uint32_t> get_tilized_packed_golden_broadcast(
             for (int i = 0; i < vBroadcast.size(); i++) {
                 tempfp16bv[i] = vBroadcast[i];
             }
-            auto packed_vec = pack_vector<uint32_t, bfloat16>(tempfp16bv);
+            auto packed_vec = pack_vector<std::uint32_t, bfloat16>(tempfp16bv);
             tilized_packed_res = ::unit_tests::compute::gold_standard_tilize(packed_vec, config);
         } else if (T_out == tt::DataFormat::Bfp8_b) {
             tilized_packed_res = pack_as_bfp8_tiles(ttsl::make_const_span(vBroadcast), true, false);
@@ -196,16 +197,16 @@ void log_unpacked_vectors_for_mismatch(
 }  // namespace
 
 bool check_is_close(
-    std::vector<uint32_t>& packed_golden,
-    std::vector<uint32_t>& device_res,
+    std::vector<std::uint32_t>& packed_golden,
+    std::vector<std::uint32_t>& device_res,
     tt::DataFormat T_out,
     std::string_view result_label) {
     if (T_out == tt::DataFormat::Float16_b) {
         if (packed_golden.size() != device_res.size()) {
             TT_THROW("{} mismatch: size golden={} device={}", result_label, packed_golden.size(), device_res.size());
         }
-        auto gold_bf16 = unpack_vector<bfloat16, uint32_t>(packed_golden);
-        auto res_bf16 = unpack_vector<bfloat16, uint32_t>(device_res);
+        auto gold_bf16 = unpack_vector<bfloat16, std::uint32_t>(packed_golden);
+        auto res_bf16 = unpack_vector<bfloat16, std::uint32_t>(device_res);
         auto it = std::mismatch(gold_bf16.begin(), gold_bf16.end(), res_bf16.begin(), [](bfloat16 a, bfloat16 b) {
             return is_close(a, b, 0.0f);
         });
@@ -254,17 +255,22 @@ auto CreateDramBuffer(distributed::MeshDevice& mesh_device, tt::DataFormat dform
 }
 
 CBHandle CreateCircularBufferHelper(
-    distributed::MeshWorkload& workload, CoreCoord& core, uint32_t num_pages, tt::DataFormat dformat, uint32_t id) {
+    distributed::MeshWorkload& workload,
+    CoreCoord& core,
+    std::uint32_t num_pages,
+    tt::DataFormat dformat,
+    std::uint32_t id) {
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    uint32_t page_size = tile_size(dformat);
+    std::uint32_t page_size = tile_size(dformat);
     tt_metal::CircularBufferConfig l1_cb_config =
         tt_metal::CircularBufferConfig(num_pages * page_size, {{id, dformat}}).set_page_size(id, page_size);
     return tt_metal::CreateCircularBuffer(workload.get_programs().at(device_range), core, l1_cb_config);
 }
 
-static inline tt::tt_metal::TensorSpec make_flat_dram_tensor_spec(uint32_t entry_size, uint32_t total_entries) {
-    const uint32_t entry_size_words = entry_size / sizeof(uint32_t);
+static inline tt::tt_metal::TensorSpec make_flat_dram_tensor_spec(
+    std::uint32_t entry_size, std::uint32_t total_entries) {
+    const std::uint32_t entry_size_words = entry_size / sizeof(std::uint32_t);
     auto page_config = tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR);
     auto memory_config =
         tt::tt_metal::MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
@@ -275,23 +281,23 @@ static inline tt::tt_metal::TensorSpec make_flat_dram_tensor_spec(uint32_t entry
 void get_packed_tilized_input_output_pair(
     tt::DataFormat in_t,
     tt::DataFormat out_t,
-    uint32_t num_tiles,
+    std::uint32_t num_tiles,
     BroadcastDim bcast_dim,
-    std::vector<uint32_t>& packed_tilized_input,
-    std::vector<uint32_t>& packed_tilized_output);
+    std::vector<std::uint32_t>& packed_tilized_input,
+    std::vector<std::uint32_t>& packed_tilized_output);
 
 void run_single_core_unary_broadcast_quasar(
     distributed::MeshDevice& mesh_device, const UnaryBroadcastConfig& test_config) {
     const experimental::NodeCoord node{0, 0};
 
-    constexpr uint32_t num_tiles = 32;
-    constexpr uint32_t num_blocks = 4;
-    constexpr uint32_t block_size = num_tiles / num_blocks;
+    constexpr std::uint32_t num_tiles = 32;
+    constexpr std::uint32_t num_blocks = 4;
+    constexpr std::uint32_t block_size = num_tiles / num_blocks;
     const tt::DataFormat in_t = test_config.in_t;
     const tt::DataFormat out_t = test_config.out_t;
-    const uint32_t in_tile_size = tile_size(in_t);
-    const uint32_t out_tile_size = tile_size(out_t);
-    const uint32_t dfb_num_entries = block_size * 2;
+    const std::uint32_t in_tile_size = tile_size(in_t);
+    const std::uint32_t out_tile_size = tile_size(out_t);
+    const std::uint32_t dfb_num_entries = block_size * 2;
 
     auto in_tensor = MeshTensor::allocate_on_device(mesh_device, make_flat_dram_tensor_spec(in_tile_size, num_tiles));
     auto out_tensor = MeshTensor::allocate_on_device(mesh_device, make_flat_dram_tensor_spec(out_tile_size, num_tiles));
@@ -413,8 +419,8 @@ void run_single_core_unary_broadcast_quasar(
     params.tensor_args = {{OUT_TENSOR, experimental::ProgramRunArgs::TensorArgument{out_tensor}}};
     experimental::SetProgramRunArgs(program, params);
 
-    std::vector<uint32_t> packed_tilized_input;
-    std::vector<uint32_t> golden_packed_tilized_output;
+    std::vector<std::uint32_t> packed_tilized_input;
+    std::vector<std::uint32_t> golden_packed_tilized_output;
     get_packed_tilized_input_output_pair(
         in_t, out_t, num_tiles, test_config.broadcast_dim, packed_tilized_input, golden_packed_tilized_output);
     slow_dispatch::WriteToBuffer(in_tensor.mesh_buffer(), packed_tilized_input);
@@ -430,19 +436,19 @@ void run_single_core_unary_broadcast_quasar(
 void get_packed_tilized_input_output_pair(
     tt::DataFormat in_t,
     tt::DataFormat out_t,
-    uint32_t num_tiles,
+    std::uint32_t num_tiles,
     BroadcastDim bcast_dim,
-    std::vector<uint32_t>& packed_tilized_input,
-    std::vector<uint32_t>& packed_tilized_output) {
-    constexpr uint32_t tile_width = 32;
-    constexpr uint32_t tile_height = 32;
-    constexpr uint32_t num_single_tile_elem = tile_width * tile_height;
+    std::vector<std::uint32_t>& packed_tilized_input,
+    std::vector<std::uint32_t>& packed_tilized_output) {
+    constexpr std::uint32_t tile_width = 32;
+    constexpr std::uint32_t tile_height = 32;
+    constexpr std::uint32_t num_single_tile_elem = tile_width * tile_height;
     if (in_t == tt::DataFormat::Float16_b) {
         std::vector<bfloat16> input = generate_uniform_random_vector<bfloat16>(
             1.0f, 2.0f, num_tiles * num_single_tile_elem, std::chrono::system_clock::now().time_since_epoch().count());
 
         ::unit_tests::compute::GoldenConfig config = {.num_tiles_r_dim = num_tiles, .num_tiles_c_dim = 1};
-        auto packed_input = pack_vector<uint32_t, bfloat16>(input);
+        auto packed_input = pack_vector<std::uint32_t, bfloat16>(input);
         packed_tilized_input = ::unit_tests::compute::gold_standard_tilize(packed_input, config);
         packed_tilized_output =
             get_tilized_packed_golden_broadcast(input, {num_tiles, tile_width, tile_height}, bcast_dim, out_t);
@@ -469,28 +475,28 @@ void run_single_core_unary_broadcast(distributed::MeshDevice& mesh_device, const
     auto& program_ = workload.get_programs().at(device_range);
     CoreCoord core = {0, 0};
 
-    constexpr uint32_t num_tiles = 32;
-    constexpr uint32_t num_blocks = 4;
-    constexpr uint32_t block_size = num_tiles / num_blocks;
+    constexpr std::uint32_t num_tiles = 32;
+    constexpr std::uint32_t num_blocks = 4;
+    constexpr std::uint32_t block_size = num_tiles / num_blocks;
     const tt::DataFormat in_t = test_config.in_t;
     const tt::DataFormat out_t = test_config.out_t;
 
     auto src_dram_buffer = CreateDramBuffer(mesh_device, in_t, num_tiles);
     auto dst_dram_buffer = CreateDramBuffer(mesh_device, out_t, num_tiles);
 
-    const uint32_t dfb_num_entries = block_size * 2;
+    const std::uint32_t dfb_num_entries = block_size * 2;
 
     KernelHandle reader_kernel;
     KernelHandle writer_kernel;
 
     // Mesh DRAM: TensorAccessorArgs + reader_unary_8bank / writer_unary_8bank.
-    std::vector<uint32_t> reader_compile_args;
+    std::vector<std::uint32_t> reader_compile_args;
     TensorAccessorArgs(src_dram_buffer).append_to(reader_compile_args);
 
     CreateCircularBufferHelper(workload, core, dfb_num_entries, in_t, 0);
     CreateCircularBufferHelper(workload, core, dfb_num_entries, out_t, 16);
 
-    std::vector<uint32_t> writer_compile_args = {static_cast<uint32_t>(tt::CBIndex::c_16)};
+    std::vector<std::uint32_t> writer_compile_args = {static_cast<std::uint32_t>(tt::CBIndex::c_16)};
     TensorAccessorArgs(dst_dram_buffer).append_to(writer_compile_args);
 
     reader_kernel = tt_metal::CreateKernel(
@@ -525,10 +531,10 @@ void run_single_core_unary_broadcast(distributed::MeshDevice& mesh_device, const
         reader_kernel,
         core,
         {
-            (uint32_t)(src_dram_buffer->address()),
-            (uint32_t)0,  // dram bank id
-            (uint32_t)0,  // unused; keeps num_tiles at index 3
-            (uint32_t)num_tiles,
+            (std::uint32_t)(src_dram_buffer->address()),
+            (std::uint32_t)0,  // dram bank id
+            (std::uint32_t)0,  // unused; keeps num_tiles at index 3
+            (std::uint32_t)num_tiles,
         });
 
     // writer_unary_8bank: arg 0 = base addr, arg 2 = num_tiles
@@ -537,13 +543,13 @@ void run_single_core_unary_broadcast(distributed::MeshDevice& mesh_device, const
         writer_kernel,
         core,
         {
-            (uint32_t)(dst_dram_buffer->address()),
-            (uint32_t)0,  // unused
-            (uint32_t)num_tiles,
+            (std::uint32_t)(dst_dram_buffer->address()),
+            (std::uint32_t)0,  // unused
+            (std::uint32_t)num_tiles,
         });
 
-    std::vector<uint32_t> packed_tilized_input;
-    std::vector<uint32_t> golden_packed_tilized_output;
+    std::vector<std::uint32_t> packed_tilized_input;
+    std::vector<std::uint32_t> golden_packed_tilized_output;
     get_packed_tilized_input_output_pair(
         in_t, out_t, num_tiles, test_config.broadcast_dim, packed_tilized_input, golden_packed_tilized_output);
     distributed::WriteShard(cq, src_dram_buffer, packed_tilized_input, zero_coord);
@@ -551,7 +557,7 @@ void run_single_core_unary_broadcast(distributed::MeshDevice& mesh_device, const
     distributed::EnqueueMeshWorkload(cq, workload, /*blocking=*/false);
     distributed::Finish(cq);
 
-    std::vector<uint32_t> dest_buffer_data;
+    std::vector<std::uint32_t> dest_buffer_data;
     distributed::ReadShard(cq, dest_buffer_data, dst_dram_buffer, zero_coord);
 
     ASSERT_TRUE(check_is_close(golden_packed_tilized_output, dest_buffer_data, out_t, "unary_broadcast_dram_out"));
@@ -611,6 +617,34 @@ TEST_F(QuasarMeshDeviceSingleCardFixture, TensixComputeUnaryBroadcastQuasarDfb) 
             run_single_core_unary_broadcast(this->device(), test_config);
         }
     }
+}
+
+// ============================================================================
+// Id-free (2.0) unary_bcast (BroadcastType::ROW): broadcasts row 0 across all rows of a tile. The device reads
+// a TILED tile, so we feed it gold_standard_tilize(raw) and validate against gold_standard_tilize(broadcast(raw))
+// -- both operate on the same tilized data. Single Float16_b tile, exact compare. Runs on Blackhole (BH-only).
+// ============================================================================
+TEST_F(LLKBlackholeSingleCardFixture, TensixUnaryBcastRowIdFreeGolden) {
+    auto raw = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b), /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto raw_bf16 = unpack_vector<bfloat16, std::uint32_t>(raw);
+    auto bcast_bf16 = get_broadcasted_vec<bfloat16>(raw_bf16, {1, 32, 32}, BroadcastDim::ROW);
+    auto bcast_packed = pack_vector<std::uint32_t, bfloat16>(bcast_bf16);
+
+    ::unit_tests::compute::GoldenConfig config{
+        .num_tiles_r_dim = 1, .num_tiles_c_dim = 1, .face_r_dim = 16, .face_c_dim = 16, .num_faces = 4};
+    auto device_input = ::unit_tests::compute::gold_standard_tilize(raw, config);
+    auto golden = ::unit_tests::compute::gold_standard_tilize(bcast_packed, config);
+
+    auto result = unit_tests::llk::single_core::run_unary(
+        *this->devices_.at(0),
+        tt::DataFormat::Float16_b,
+        tt::DataFormat::Float16_b,
+        device_input,
+        /*num_tiles=*/1,
+        /*fp32_dest_acc_en=*/false,
+        "tests/tt_metal/tt_metal/test_kernels/compute/unary_bcast_2_0.cpp");
+    EXPECT_EQ(golden, result);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -48,6 +48,7 @@
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/tensor/mesh_tensor.hpp>
 #include "tt_metal/impl/dispatch/slow_dispatch.hpp"
+#include "single_core_compute_runners.hpp"
 
 namespace tt::tt_metal {
 class IDevice;
@@ -1646,6 +1647,68 @@ TEST_F(LLKMeshDeviceFixture, TensixComputePackUntilizeDstTinyTile) {
             unit_tests::compute::tilize::run_single_core_tilize_program(*this->devices_.at(0), test_config);
         }
     }
+}
+
+// ============================================================================
+// Id-free (2.0) tilize / pack_untilize / pack_untilize_dest, validated against the gold_standard_tilize /
+// gold_standard_untilize host goldens (exact, bitwise), not a legacy kernel. Single Float16_b tile. Runs on
+// Blackhole (BH-only API). tilize: row-major c_0 -> tiled c_16; (pack_)untilize: tiled c_0 -> row-major c_16.
+// ============================================================================
+TEST_F(LLKBlackholeSingleCardFixture, TensixTilizeIdFreeGolden) {
+    constexpr std::uint32_t num_tiles = 1;
+    auto src = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result = unit_tests::llk::single_core::run_unary(
+        *this->devices_.at(0),
+        tt::DataFormat::Float16_b,
+        tt::DataFormat::Float16_b,
+        src,
+        num_tiles,
+        /*fp32_dest_acc_en=*/false,
+        "tests/tt_metal/tt_metal/test_kernels/compute/tilize_2_0.cpp");
+
+    ::unit_tests::compute::GoldenConfig config{
+        .num_tiles_r_dim = 1, .num_tiles_c_dim = 1, .face_r_dim = 16, .face_c_dim = 16, .num_faces = 4};
+    auto golden = ::unit_tests::compute::gold_standard_tilize(src, config);
+    EXPECT_EQ(golden, result);
+}
+
+TEST_F(LLKBlackholeSingleCardFixture, TensixPackUntilizeIdFreeGolden) {
+    constexpr std::uint32_t num_tiles = 1;
+    auto src = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result = unit_tests::llk::single_core::run_unary(
+        *this->devices_.at(0),
+        tt::DataFormat::Float16_b,
+        tt::DataFormat::Float16_b,
+        src,
+        num_tiles,
+        /*fp32_dest_acc_en=*/false,
+        "tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize_2_0.cpp");
+
+    ::unit_tests::compute::GoldenConfig config{
+        .num_tiles_r_dim = 1, .num_tiles_c_dim = 1, .face_r_dim = 16, .face_c_dim = 16, .num_faces = 4};
+    auto golden = ::unit_tests::compute::gold_standard_untilize(src, config);
+    EXPECT_EQ(golden, result);
+}
+
+TEST_F(LLKBlackholeSingleCardFixture, TensixPackUntilizeDestIdFreeGolden) {
+    constexpr std::uint32_t num_tiles = 1;
+    auto src = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result = unit_tests::llk::single_core::run_unary(
+        *this->devices_.at(0),
+        tt::DataFormat::Float16_b,
+        tt::DataFormat::Float16_b,
+        src,
+        num_tiles,
+        /*fp32_dest_acc_en=*/false,
+        "tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize_dest_2_0.cpp");
+
+    ::unit_tests::compute::GoldenConfig config{
+        .num_tiles_r_dim = 1, .num_tiles_c_dim = 1, .face_r_dim = 16, .face_c_dim = 16, .num_faces = 4};
+    auto golden = ::unit_tests::compute::gold_standard_untilize(src, config);
+    EXPECT_EQ(golden, result);
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -1737,4 +1737,15 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixPackUntilizeBlock4IdFreeGolden) {
     EXPECT_EQ(golden, result);
 }
 
+// NOTE: no distinguishing test for tilize_block's restored input_tile_index / output_tile_index params.
+// The restored parameters default to 0, in which case tile_index folds to `t` and the generated code is
+// byte-identical to before (covered by TensixTilizeIdFreeGolden above). Observing a NONZERO index cleanly
+// would require a block-configured, wide row-major tilize harness: column-tile b of an N-wide row-major
+// input sits at a b*TILE_WIDTH offset with an N*TILE_WIDTH per-row stride, which only tilizes correctly when
+// the unpack MOP is configured for block=N (as legacy's single llk_unpack_tilize_block(base, block, index)
+// call is). The id-free tilize_block uses a per-tile llk_unpack_tilize loop with block=1 init, so an
+// input_tile_index-addressed nonzero column tile reads the input as contiguous standalone tiles instead of a
+// wide block and cannot match gold_standard_tilize. The restored params are correct-for-parity but not
+// cleanly device-observable via this path (same resolution as the D0/D1/Copilot#2 unobservable fixes).
+
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_untilize_tilize.cpp
@@ -1711,4 +1711,30 @@ TEST_F(LLKBlackholeSingleCardFixture, TensixPackUntilizeDestIdFreeGolden) {
     EXPECT_EQ(golden, result);
 }
 
+// Id-free (2.0) pack_untilize with block_ct_dim = 4 (> 1). This executes pack_untilize_block4_2_0.cpp -- the
+// only 2.0 kernel exercising the block>1 window: it reads 4 tiled input tiles in ONE pack_untilize_block<4,4>
+// call at in.l1_address + c * tile_stride_words(...) and writes one row-major row 4 tiles wide at the
+// full_ct_dim * tile_stride_words(...) output stride. Validated against gold_standard_untilize for a 1x4 tile
+// block (exact). (The partial block-float per-tile stride is covered separately by the copy_block Bfp8 partial-
+// tile test in test_copy_block_matmul_partials.cpp.)
+TEST_F(LLKBlackholeSingleCardFixture, TensixPackUntilizeBlock4IdFreeGolden) {
+    constexpr std::uint32_t num_tiles = 4;  // one 1x4 pack_untilize_block<4,4> window
+    auto src = create_random_vector_of_bfloat16(
+        tt::tile_size(tt::DataFormat::Float16_b) * num_tiles, /*rand_max_float=*/20, /*seed=*/42, /*offset=*/-10.0f);
+    auto result = unit_tests::llk::single_core::run_unary(
+        *this->devices_.at(0),
+        tt::DataFormat::Float16_b,
+        tt::DataFormat::Float16_b,
+        src,
+        num_tiles,
+        /*fp32_dest_acc_en=*/false,
+        "tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize_block4_2_0.cpp",
+        /*cb_depth_tiles=*/num_tiles);
+
+    ::unit_tests::compute::GoldenConfig config{
+        .num_tiles_r_dim = 1, .num_tiles_c_dim = 4, .face_r_dim = 16, .face_c_dim = 16, .num_faces = 4};
+    auto golden = ::unit_tests::compute::gold_standard_untilize(src, config);
+    EXPECT_EQ(golden, result);
+}
+
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bcast_mul_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bcast_mul_2_0.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/eltwise_binary.h"  // compute_kernel_hw_startup (CB-id) + tile_regs_* handshake
+#include "api/dataflow/circular_buffer.h"
+#include "api/compute/experimental/2_0/bcast.h"
+#include "api/compute/experimental/2_0/pack.h"
+#include "tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h"
+#include "api/compute/experimental/2_0/hw_startup.h"
+
+// Id-free (2.0) binary broadcast-MUL kernel, classic circular buffers. Per tile: C = A * broadcast(B) -> c_16.
+// The broadcast axis is selected at compile time via get_compile_time_arg_val(1) (BroadcastType COL/ROW/SCALAR),
+// so this ONE kernel covers bcast_mul_{cols,rows,scalar} -- the three differed only in that template arg. The
+// broadcast uses experimental::bcast_init / any_tiles_bcast built from LLKOperands (data format + tile geometry
+// as NTTPs, absolute L1 address the only runtime state) -- NO CB id on the op surface. hw_startup / pack_tile
+// stay the legacy CB-id API so the differential isolates the bcast op. Output must be bit-identical to the
+// legacy kernel for the selected broadcast axis.
+namespace {
+constexpr auto kBcast = static_cast<BroadcastType>(get_compile_time_arg_val(1));
+}
+
+void kernel_main() {
+    std::uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
+
+    CircularBuffer c0(tt::CBIndex::c_0);
+    CircularBuffer c1(tt::CBIndex::c_1);
+    CircularBuffer c16(tt::CBIndex::c_16);
+
+    constexpr auto in0_cb = experimental::Cb<tt::CBIndex::c_0>{};
+    constexpr auto in1_cb = experimental::Cb<tt::CBIndex::c_1>{};
+    constexpr auto out_cb = experimental::Cb<tt::CBIndex::c_16>{};
+    constexpr auto in0_desc = experimental::to_llk_mem_descriptor(in0_cb);
+    constexpr auto in1_desc = experimental::to_llk_mem_descriptor(in1_cb);
+    constexpr auto out_desc = experimental::to_llk_mem_descriptor(out_cb);
+    using AOp = experimental::LLKOperand<static_cast<DataFormat>(in0_desc.format), in0_desc.shape>;
+    using BOp = experimental::LLKOperand<static_cast<DataFormat>(in1_desc.format), in1_desc.shape>;
+    using OutOp = experimental::LLKOperand<static_cast<DataFormat>(out_desc.format), out_desc.shape>;
+
+    compute_kernel_hw_startup(AOp(in0_cb.read_address()), BOp(in1_cb.read_address()), OutOp(out_cb.write_address()));
+    experimental::bcast_init<EltwiseBinaryType::ELWMUL, kBcast>(AOp(in0_cb.read_address()));
+
+    for (std::uint32_t t = 0; t < per_core_tile_cnt; ++t) {
+        c0.wait_front(1);
+        c1.wait_front(1);
+        c16.reserve_back(1);
+
+        tile_regs_acquire();
+        experimental::any_tiles_bcast<EltwiseBinaryType::ELWMUL, kBcast>(
+            AOp(in0_cb.read_address()), BOp(in1_cb.read_address()), 0, 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        experimental::pack_tile(OutOp(out_cb.write_address()), 0);
+        tile_regs_release();
+
+        c0.pop_front(1);
+        c1.pop_front(1);
+        c16.push_back(1);
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/bcast_mul_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/bcast_mul_2_0.cpp
@@ -53,7 +53,7 @@ void kernel_main() {
         tile_regs_commit();
 
         tile_regs_wait();
-        experimental::pack_tile(OutOp(out_cb.write_address()), 0);
+        experimental::pack_tile(OutOp(out_cb.write_address()), 0, 0);
         tile_regs_release();
 
         c0.pop_front(1);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/binary_add_block_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/binary_add_block_2_0.cpp
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/common.h"
+#include "api/compute/eltwise_binary.h"  // compute_kernel_hw_startup + add_init + tile_regs_* handshake
+#include "api/compute/tile_move_copy.h"  // legacy pack_tile
+#include "api/compute/experimental/2_0/eltwise_binary.h"
+#include "api/dataflow/circular_buffer.h"
+#include "tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h"
+
+// Id-free (2.0) eltwise-binary ADD block kernel: process two inputs (c_0, c_1) in blocks of BLOCK_TILES; per
+// block, add_block a run of consecutive tile pairs c_0[i]+c_1[i] -> DST[i], then pack each DST slot -> c_16.
+// IDENTICAL to binary_add_block_legacy.cpp except the block add uses experimental::add_block[/add_init] built
+// from LLKOperands (no CB id). compute_kernel_hw_startup / pack_tile stay the legacy CB-id API so the
+// differential isolates add_block. Output must be bit-for-bit identical to the legacy kernel. num_tiles must be
+// a multiple of BLOCK_TILES and the CBs at least BLOCK_TILES deep (a block keeps BLOCK_TILES tiles resident via
+// wait_front, so a 1-deep CB deadlocks).
+constexpr std::uint32_t BLOCK_TILES = 4;  // fits DST for both fp32 and non-fp32 dest
+
+void kernel_main() {
+    std::uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
+
+    CircularBuffer cb0(tt::CBIndex::c_0);
+    CircularBuffer cb1(tt::CBIndex::c_1);
+    CircularBuffer cb16(tt::CBIndex::c_16);
+
+    constexpr auto in0_cb = experimental::Cb<tt::CBIndex::c_0>{};
+    constexpr auto in1_cb = experimental::Cb<tt::CBIndex::c_1>{};
+    constexpr auto in0_desc = experimental::to_llk_mem_descriptor(in0_cb);
+    constexpr auto in1_desc = experimental::to_llk_mem_descriptor(in1_cb);
+    using AOp = experimental::LLKOperand<static_cast<DataFormat>(in0_desc.format), in0_desc.shape>;
+    using BOp = experimental::LLKOperand<static_cast<DataFormat>(in1_desc.format), in1_desc.shape>;
+
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
+    experimental::add_init(AOp(in0_cb.read_address()));
+
+    for (std::uint32_t b = 0; b < per_core_tile_cnt; b += BLOCK_TILES) {
+        std::uint32_t ntiles = (per_core_tile_cnt - b) < BLOCK_TILES ? (per_core_tile_cnt - b) : BLOCK_TILES;
+
+        tile_regs_acquire();
+        cb0.wait_front(ntiles);
+        cb1.wait_front(ntiles);
+        cb16.reserve_back(ntiles);
+
+        experimental::add_block(AOp(in0_cb.read_address()), BOp(in1_cb.read_address()), 0, 0, 0, ntiles);
+
+        tile_regs_commit();
+        tile_regs_wait();
+        for (std::uint32_t t = 0; t < ntiles; ++t) {
+            pack_tile(t, tt::CBIndex::c_16);
+        }
+
+        cb0.pop_front(ntiles);
+        cb1.pop_front(ntiles);
+        cb16.push_back(ntiles);
+        tile_regs_release();
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/binary_reuse_dest_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/binary_reuse_dest_2_0.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/common.h"
+#include "api/compute/eltwise_binary.h"                   // legacy compute_kernel_hw_startup + tile_regs_*
+#include "api/compute/tile_move_copy.h"                   // legacy copy_tile (seed DST) + pack_tile
+#include "api/compute/experimental/2_0/eltwise_binary.h"  // id-free reuse-dest API (op under test)
+#include "api/dataflow/circular_buffer.h"
+#include "tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h"
+
+// Id-free (2.0) eltwise-binary DEST-REUSE ADD kernel. IDENTICAL to binary_reuse_dest_legacy.cpp except the
+// reuse-dest init + op use the id-free experimental::add_reuse_dest_{init,tiles} built from an LLKOperand for
+// the L1 operand (c_1); the reused operand IS the DST register (runtime index, no LLKOperand). copy_tile /
+// pack_tile / compute_kernel_hw_startup stay the legacy CB-id API so the differential isolates the reuse-dest
+// op. Per tile: seed DST[0] with A (c_0), then DST[0] = DST[0] + c_1 (DST -> SrcA, c_1 -> SrcB) = A + B, pack
+// DST[0] -> c_16. Output must be bit-for-bit identical to the legacy kernel.
+void kernel_main() {
+    std::uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
+
+    CircularBuffer c0(tt::CBIndex::c_0);
+    CircularBuffer c1(tt::CBIndex::c_1);
+    CircularBuffer c16(tt::CBIndex::c_16);
+
+    // L1 operand B (c_1) as an id-free LLKOperand: format + geometry NTTPs, L1 address the only runtime state.
+    constexpr auto in1_cb = experimental::Cb<tt::CBIndex::c_1>{};
+    constexpr auto in1_desc = experimental::to_llk_mem_descriptor(in1_cb);
+    using BOp = experimental::LLKOperand<static_cast<DataFormat>(in1_desc.format), in1_desc.shape>;
+
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
+
+    for (std::uint32_t b = 0; b < per_core_tile_cnt; ++b) {
+        c0.wait_front(1);
+        c1.wait_front(1);
+        c16.reserve_back(1);
+
+        tile_regs_acquire();
+        // Seed DST[0] with operand A from c_0 (legacy datacopy; identical in both kernels).
+        copy_tile_to_dst_init_short(tt::CBIndex::c_0);
+        copy_tile(tt::CBIndex::c_0, 0, 0);
+        // Op under test: DST[0] = DST[0] + c_1  (id-free reuse-dest API; c_1 -> BOp, DST reused).
+        experimental::add_reuse_dest_init<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(BOp(in1_cb.read_address()));
+        experimental::add_reuse_dest_tiles<EltwiseBinaryReuseDestType::DEST_TO_SRCA>(BOp(in1_cb.read_address()), 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, tt::CBIndex::c_16);
+        tile_regs_release();
+
+        c0.pop_front(1);
+        c1.pop_front(1);
+        c16.push_back(1);
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "api/compute/common_globals.h"                            // chlkc format/geometry arrays, MAX_FACE_C_DIM, ALWI
+#include "api/compute/experimental/2_0/internal/llk_descriptor.h"  // LLKMemDescriptor
+#include "internal/circular_buffer_interface.h"                    // get_local_cb_interface (universal, all TRISCs)
+
+// =====================================================================================================
+// TEST-COMMON (device-side) CB helpers. These are the CB-specific "source -> id-free operand" glue used by
+// the 2.0 test kernels; they are deliberately NOT part of the public compute API (llk_operand.h). A shipping
+// kernel resolves an operand from its real source; the unit tests resolve it from a classic CircularBuffer.
+//
+//   * cb_read_address / cb_write_address -- runtime "where": absolute L1 tile base pointer from a CB.
+//   * Cb<CbId>                            -- compile-time CB accessor carrying its id in its TYPE (foldable).
+//   * to_llk_mem_descriptor(Cb<CbId>)     -- compile-time "what": LLKMemDescriptor from the chlkc arrays.
+// =====================================================================================================
+
+namespace ckernel {
+namespace experimental {
+
+// -----------------------------------------------------------------------------------------------------
+// Address seam (runtime "where"). Resolves an absolute L1 tile base pointer from a CB, with NO data format /
+// geometry and NO side effects: get_operand_id / get_output_id are identity on Blackhole (interface index ==
+// cb_id), and these are pure reads of the local CB interface (valid on every TRISC), so a kernel can build the
+// base pointer on any thread and hand it to an id-free op. Absolute (out-of-order) addressing: the op
+// packs/unpacks at exactly this address.
+// -----------------------------------------------------------------------------------------------------
+ALWI std::uint32_t cb_read_address(std::uint32_t cb_id, std::uint32_t tile_index = 0) {
+    const auto& cb = get_local_cb_interface(cb_id);
+    return cb.fifo_rd_ptr - 1 + cb.fifo_page_size * tile_index;
+}
+
+ALWI std::uint32_t cb_write_address(std::uint32_t cb_id, std::uint32_t out_tile_index = 0) {
+    const auto& cb = get_local_cb_interface(cb_id);
+    return cb.fifo_wr_ptr - 1 + cb.fifo_page_size * out_tile_index;
+}
+
+// -----------------------------------------------------------------------------------------------------
+// Source -> descriptor translator (compile-time). The compute op only ever consumes an LLKMemDescriptor NTTP;
+// the SOURCE is known ONLY here. Folding needs COMPILE-TIME source identity, so the accessor carries its
+// identity in its TYPE. `Cb<CbId>` is the compile-time CB accessor used for the id-free path.
+// -----------------------------------------------------------------------------------------------------
+template <std::uint32_t CbId>
+struct Cb {
+    static constexpr std::uint32_t id = CbId;
+    ALWI std::uint32_t read_address(std::uint32_t tile_index = 0) const { return cb_read_address(CbId, tile_index); }
+    ALWI std::uint32_t write_address(std::uint32_t tile_index = 0) const { return cb_write_address(CbId, tile_index); }
+};
+
+// CB source -> LLKMemDescriptor. chlkc format/geometry is indexed by the (compile-time) CB id. The arrays are
+// thread-partitioned (unpack_* on UNPACK/MATH, pack_* on PACK), so this reads whichever exist on the calling
+// thread; the host equalizes both sides to the same L1 format + geometry per CB, so the result is identical on
+// every thread and safe to call anywhere (incl. the kernel body). Folds to a constant.
+template <std::uint32_t CbId>
+constexpr LLKMemDescriptor to_llk_mem_descriptor(Cb<CbId> /*cb*/) {
+#if defined(UCK_CHLKC_PACK)
+    return LLKMemDescriptor{
+        static_cast<DataFormat>(pack_dst_format[CbId]),
+        TensorShape{
+            pack_tile_face_r_dim[CbId], MAX_FACE_C_DIM, pack_num_faces_r_dim[CbId], pack_num_faces_c_dim[CbId]}};
+#else
+    return LLKMemDescriptor{
+        static_cast<DataFormat>(unpack_src_format[CbId]),
+        TensorShape{
+            unpack_tile_face_r_dim[CbId], MAX_FACE_C_DIM, unpack_num_faces_r_dim[CbId], unpack_num_faces_c_dim[CbId]}};
+#endif
+}
+
+}  // namespace experimental
+}  // namespace ckernel

--- a/tests/tt_metal/tt_metal/test_kernels/compute/copy_block_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/copy_block_2_0.cpp
@@ -28,7 +28,7 @@ void kernel_main() {
     using InOp = experimental::LLKOperand<static_cast<DataFormat>(in_desc.format), in_desc.shape>;
 
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
-    experimental::copy_tile_init(InOp(in_cb.read_address()));
+    experimental::copy_init(InOp(in_cb.read_address()));
 
     for (std::uint32_t b = 0; b < per_core_tile_cnt; b += BLOCK_TILES) {
         std::uint32_t ntiles = (per_core_tile_cnt - b) < BLOCK_TILES ? (per_core_tile_cnt - b) : BLOCK_TILES;

--- a/tests/tt_metal/tt_metal/test_kernels/compute/copy_block_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/copy_block_2_0.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/experimental/2_0/tile_move_copy.h"
+#include "api/dataflow/circular_buffer.h"
+#include "tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h"
+
+// Id-free (2.0) copy_block kernel: process the input in blocks of BLOCK_TILES; per block, copy_block a run
+// of consecutive tiles c_0 -> DST, then pack each DST slot -> c_16. IDENTICAL to copy_block_legacy.cpp
+// except the copy uses experimental::copy_block[_init] built from an LLKOperand (no CB id). pack_tile and
+// compute_kernel_hw_startup stay the legacy CB-id API so the differential isolates copy_block. Output must be
+// bit-for-bit identical to the legacy kernel.
+constexpr std::uint32_t BLOCK_TILES = 4;  // fits DST for both fp32 and non-fp32 dest
+
+void kernel_main() {
+    std::uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
+
+    CircularBuffer cb0(tt::CBIndex::c_0);
+    CircularBuffer cb16(tt::CBIndex::c_16);
+
+    constexpr auto in_cb = experimental::Cb<tt::CBIndex::c_0>{};
+    constexpr auto in_desc = experimental::to_llk_mem_descriptor(in_cb);
+    using InOp = experimental::LLKOperand<static_cast<DataFormat>(in_desc.format), in_desc.shape>;
+
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
+    experimental::copy_tile_init(InOp(in_cb.read_address()));
+
+    for (std::uint32_t b = 0; b < per_core_tile_cnt; b += BLOCK_TILES) {
+        std::uint32_t ntiles = (per_core_tile_cnt - b) < BLOCK_TILES ? (per_core_tile_cnt - b) : BLOCK_TILES;
+
+        tile_regs_acquire();
+        cb0.wait_front(ntiles);
+        cb16.reserve_back(ntiles);
+
+        experimental::copy_block(InOp(in_cb.read_address()), 0, 0, ntiles);
+
+        tile_regs_commit();
+        tile_regs_wait();
+        for (std::uint32_t t = 0; t < ntiles; ++t) {
+            pack_tile(t, tt::CBIndex::c_16);
+        }
+
+        cb0.pop_front(ntiles);
+        cb16.push_back(ntiles);
+        tile_regs_release();
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_binary_add_idfree.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_binary_add_idfree.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/eltwise_binary.h"  // compute_kernel_hw_startup + tile_regs_* handshake
+#include "api/dataflow/circular_buffer.h"
+#include "api/compute/experimental/2_0/eltwise_binary.h"
+#include "api/compute/experimental/2_0/pack.h"
+#include "tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h"
+#include "api/compute/experimental/2_0/hw_startup.h"
+
+// Id-free (2.0) eltwise-binary ADD kernel, classic circular buffers. The ops take one LLKOperand per input
+// (format + geometry as NTTPs, L1 address the only runtime state); binary is format-free so only geometry +
+// addresses flow through. Output must be bit-identical to the legacy kernel eltwise_binary_add_legacy.cpp.
+// Named "_idfree" (not "_2_0") to avoid colliding with the pre-existing metal-2.0 eltwise_binary_2_0.cpp.
+void kernel_main() {
+    std::uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
+
+    CircularBuffer c0(tt::CBIndex::c_0);
+    CircularBuffer c1(tt::CBIndex::c_1);
+    CircularBuffer c16(tt::CBIndex::c_16);
+
+    constexpr auto in0_cb = experimental::Cb<tt::CBIndex::c_0>{};
+    constexpr auto in1_cb = experimental::Cb<tt::CBIndex::c_1>{};
+    constexpr auto out_cb = experimental::Cb<tt::CBIndex::c_16>{};
+    constexpr auto in0_desc = experimental::to_llk_mem_descriptor(in0_cb);
+    constexpr auto in1_desc = experimental::to_llk_mem_descriptor(in1_cb);
+    constexpr auto out_desc = experimental::to_llk_mem_descriptor(out_cb);
+    using AOp = experimental::LLKOperand<static_cast<DataFormat>(in0_desc.format), in0_desc.shape>;
+    using BOp = experimental::LLKOperand<static_cast<DataFormat>(in1_desc.format), in1_desc.shape>;
+    using OutOp = experimental::LLKOperand<static_cast<DataFormat>(out_desc.format), out_desc.shape>;
+
+    compute_kernel_hw_startup(AOp(in0_cb.read_address()), BOp(in1_cb.read_address()), OutOp(out_cb.write_address()));
+    experimental::add_init(AOp(in0_cb.read_address()));
+
+    for (std::uint32_t b = 0; b < per_core_tile_cnt; ++b) {
+        c0.wait_front(1);
+        c1.wait_front(1);
+        c16.reserve_back(1);
+
+        tile_regs_acquire();
+        experimental::add_tiles(AOp(in0_cb.read_address()), BOp(in1_cb.read_address()), 0, 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        experimental::pack_tile(OutOp(out_cb.write_address()), 0);
+        tile_regs_release();
+
+        c0.pop_front(1);
+        c1.pop_front(1);
+        c16.push_back(1);
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_binary_add_idfree.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_binary_add_idfree.cpp
@@ -45,7 +45,7 @@ void kernel_main() {
         tile_regs_commit();
 
         tile_regs_wait();
-        experimental::pack_tile(OutOp(out_cb.write_address()), 0);
+        experimental::pack_tile(OutOp(out_cb.write_address()), 0, 0);
         tile_regs_release();
 
         c0.pop_front(1);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_fp8.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_fp8.cpp
@@ -9,7 +9,7 @@
 #include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
-    uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
+    std::uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
 
     CircularBuffer cb0(tt::CBIndex::c_0);
     CircularBuffer cb16(tt::CBIndex::c_16);
@@ -17,7 +17,7 @@ void kernel_main() {
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
     copy_init(tt::CBIndex::c_0);
 
-    for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
+    for (std::uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         tile_regs_acquire();
 
         cb0.wait_front(1);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_fp8_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_fp8_2_0.cpp
@@ -5,7 +5,6 @@
 #include <cstdint>
 
 #include "api/compute/common.h"
-#include "api/compute/tile_move_copy.h"
 #include "api/dataflow/circular_buffer.h"
 
 // Id-free (2.0) datacopy verification: the ops take an LLKOperand (data format + tile geometry as NTTPs,
@@ -32,9 +31,9 @@ void kernel_main() {
     using OutOp = experimental::LLKOperand<static_cast<DataFormat>(out_desc.format), out_desc.shape>;
 
     compute_kernel_hw_startup(InOp(in_cb.read_address()), OutOp(out_cb.write_address()));
-    // fp8 input: the 2.0 experimental::copy_init static_asserts against fp8 (it does not wire the Src
-    // zero-substitution flag), so fp8 datacopy MUST keep the legacy CB-id copy_tile_init here.
-    copy_tile_init(tt::CBIndex::c_0);
+    // fp8 input: fully id-free. The 2.0 copy_init now programs the format-driven Src zero-substitution flag
+    // (flush fp8, preserve otherwise), matching legacy copy_init, so no legacy CB-id init is needed.
+    experimental::copy_init(InOp(in_cb.read_address()));
 
     for (std::uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         tile_regs_acquire();

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_fp8_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_fp8_2_0.cpp
@@ -40,12 +40,12 @@ void kernel_main() {
 
         cb0.wait_front(1);
         cb16.reserve_back(1);
-        experimental::copy_tile(InOp(in_cb.read_address()), 0);
+        experimental::copy_tile(InOp(in_cb.read_address()), 0, 0);
 
         tile_regs_commit();
         tile_regs_wait();
 
-        experimental::pack_tile(OutOp(out_cb.write_address()), 0);
+        experimental::pack_tile(OutOp(out_cb.write_address()), 0, 0);
         cb0.pop_front(1);
         cb16.push_back(1);
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_fp8_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_fp8_2_0.cpp
@@ -32,6 +32,8 @@ void kernel_main() {
     using OutOp = experimental::LLKOperand<static_cast<DataFormat>(out_desc.format), out_desc.shape>;
 
     compute_kernel_hw_startup(InOp(in_cb.read_address()), OutOp(out_cb.write_address()));
+    // fp8 input: the 2.0 experimental::copy_init static_asserts against fp8 (it does not wire the Src
+    // zero-substitution flag), so fp8 datacopy MUST keep the legacy CB-id copy_tile_init here.
     copy_tile_init(tt::CBIndex::c_0);
 
     for (std::uint32_t b = 0; b < per_core_tile_cnt; ++b) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_fp8_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/eltwise_copy_fp8_2_0.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/dataflow/circular_buffer.h"
+
+// Id-free (2.0) datacopy verification: the ops take an LLKOperand (data format + tile geometry as NTTPs,
+// absolute L1 address as the only runtime state) -- NO CB id on the op surface. The register format is
+// derived on-device from the L1 format. Legacy init is kept so this run isolates the id-free OP path +
+// address seam + infer fn. Output must be bit-identical to the legacy path (eltwise_copy_fp8.cpp).
+#include "api/compute/experimental/2_0/tile_move_copy.h"
+#include "api/compute/experimental/2_0/pack.h"
+#include "tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h"
+#include "api/compute/experimental/2_0/hw_startup.h"
+
+void kernel_main() {
+    std::uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
+
+    CircularBuffer cb0(tt::CBIndex::c_0);
+    CircularBuffer cb16(tt::CBIndex::c_16);
+
+    // Compile-time CB accessors -> folded descriptors; the operand bundles descriptor + runtime L1 address.
+    constexpr auto in_cb = experimental::Cb<tt::CBIndex::c_0>{};
+    constexpr auto out_cb = experimental::Cb<tt::CBIndex::c_16>{};
+    constexpr auto in_desc = experimental::to_llk_mem_descriptor(in_cb);
+    constexpr auto out_desc = experimental::to_llk_mem_descriptor(out_cb);
+    using InOp = experimental::LLKOperand<static_cast<DataFormat>(in_desc.format), in_desc.shape>;
+    using OutOp = experimental::LLKOperand<static_cast<DataFormat>(out_desc.format), out_desc.shape>;
+
+    compute_kernel_hw_startup(InOp(in_cb.read_address()), OutOp(out_cb.write_address()));
+    copy_tile_init(tt::CBIndex::c_0);
+
+    for (std::uint32_t b = 0; b < per_core_tile_cnt; ++b) {
+        tile_regs_acquire();
+
+        cb0.wait_front(1);
+        cb16.reserve_back(1);
+        experimental::copy_tile(InOp(in_cb.read_address()), 0);
+
+        tile_regs_commit();
+        tile_regs_wait();
+
+        experimental::pack_tile(OutOp(out_cb.write_address()), 0);
+        cb0.pop_front(1);
+        cb16.push_back(1);
+
+        tile_regs_release();
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_block_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_block_2_0.cpp
@@ -45,7 +45,7 @@ void kernel_main() {
     cb0.wait_front(in0_block_tile_cnt);
     cb1.wait_front(in1_block_tile_cnt);
     experimental::matmul_block(
-        In0Op(in0_cb.read_address()), In1Op(in1_cb.read_address()), 0, 0, 0, false, ct_dim, rt_dim, kt_dim);
+        In0Op(in0_cb.read_address()), In1Op(in1_cb.read_address()), 0, 0, 0, ct_dim, rt_dim, kt_dim);
     cb0.pop_front(in0_block_tile_cnt);
     cb1.pop_front(in1_block_tile_cnt);
     tile_regs_commit();

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_block_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_block_2_0.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/matmul.h"  // legacy compute_kernel_hw_startup + pack_tile (id-free block ops isolated)
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/compute/experimental/2_0/matmul.h"
+#include "tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h"
+
+// Id-free (2.0) block matmul kernel, classic circular buffers. Mirrors matmul_block_legacy.cpp exactly (same
+// compile args {ct_dim, rt_dim, kt_dim}, same single-block structure) but drives the block matmul with the
+// id-free ops: one LLKOperand per input (in0 -> SrcB, in1 -> SrcA), format+geometry as compile-time NTTPs,
+// with the L1 base address + the runtime block dims as the only runtime state. hw_startup + pack are legacy
+// CB-id in BOTH kernels; only the matmul_block_init / matmul_block calls differ, isolating them. Output must be
+// bit-identical to matmul_block_legacy.cpp.
+void kernel_main() {
+    constexpr std::uint32_t ct_dim = get_compile_time_arg_val(0);
+    constexpr std::uint32_t rt_dim = get_compile_time_arg_val(1);
+    constexpr std::uint32_t kt_dim = get_compile_time_arg_val(2);
+    constexpr std::uint32_t in0_block_tile_cnt = rt_dim * kt_dim;  // A block
+    constexpr std::uint32_t in1_block_tile_cnt = kt_dim * ct_dim;  // B block
+    constexpr std::uint32_t out_block_tile_cnt = rt_dim * ct_dim;  // C block
+
+    CircularBuffer cb0(tt::CBIndex::c_0);
+    CircularBuffer cb1(tt::CBIndex::c_1);
+    CircularBuffer cb16(tt::CBIndex::c_16);
+
+    constexpr auto in0_cb = experimental::Cb<tt::CBIndex::c_0>{};
+    constexpr auto in1_cb = experimental::Cb<tt::CBIndex::c_1>{};
+    constexpr auto d0 = experimental::to_llk_mem_descriptor(in0_cb);
+    constexpr auto d1 = experimental::to_llk_mem_descriptor(in1_cb);
+    using In0Op = experimental::LLKOperand<static_cast<DataFormat>(d0.format), d0.shape>;
+    using In1Op = experimental::LLKOperand<static_cast<DataFormat>(d1.format), d1.shape>;
+
+    // hw_startup + pack stay legacy CB-id in both kernels; only matmul_block(_init) is id-free here.
+    compute_kernel_hw_startup<SrcOrder::Reverse>(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
+    experimental::matmul_block_init(
+        In0Op(in0_cb.read_address()), In1Op(in1_cb.read_address()), false, ct_dim, rt_dim, kt_dim);
+
+    tile_regs_acquire();
+    cb0.wait_front(in0_block_tile_cnt);
+    cb1.wait_front(in1_block_tile_cnt);
+    experimental::matmul_block(
+        In0Op(in0_cb.read_address()), In1Op(in1_cb.read_address()), 0, 0, 0, false, ct_dim, rt_dim, kt_dim);
+    cb0.pop_front(in0_block_tile_cnt);
+    cb1.pop_front(in1_block_tile_cnt);
+    tile_regs_commit();
+    tile_regs_wait();
+
+    // Pack out (legacy CB-id in both kernels).
+    cb16.reserve_back(out_block_tile_cnt);
+    for (std::uint32_t i = 0; i < out_block_tile_cnt; ++i) {
+        pack_tile(i, tt::CBIndex::c_16);
+    }
+    cb16.push_back(out_block_tile_cnt);
+
+    tile_regs_release();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_idfree.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_idfree.cpp
@@ -74,7 +74,7 @@ void kernel_main() {
 
     cb16.reserve_back(out_block_tile_cnt);
     for (std::uint32_t i = 0; i < out_block_tile_cnt; ++i) {
-        experimental::pack_tile(OutOp(out_cb.write_address(i)), i);
+        experimental::pack_tile(OutOp(out_cb.write_address()), i, i);
     }
     cb16.push_back(out_block_tile_cnt);
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_idfree.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_idfree.cpp
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/matmul.h"  // compute_kernel_hw_startup, SrcOrder, tile_regs_*
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/compute/experimental/2_0/matmul.h"
+#include "api/compute/experimental/2_0/pack.h"
+#include "tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h"
+#include "api/compute/experimental/2_0/hw_startup.h"
+
+// Id-free (2.0) matmul kernel, classic circular buffers. Mirrors the shipping legacy matmul.cpp structure
+// exactly (same 7 compile-time args + loop nest) but drives it with the id-free ops: one LLKOperand per input
+// (in0 -> SrcB, in1 -> SrcA), format+geometry as NTTPs, L1 addresses the only runtime state. Output must be
+// bit-identical to matmul.cpp. Named "_idfree" (not "_2_0"): matmul_2_0 semantics differ elsewhere.
+void kernel_main() {
+    std::uint32_t block_tile_dim = get_compile_time_arg_val(0);
+    std::uint32_t dst_tile_rows = get_compile_time_arg_val(1);
+    std::uint32_t dst_tile_cols = get_compile_time_arg_val(2);
+    std::uint32_t block_cnt = get_compile_time_arg_val(3);
+    std::uint32_t in0_block_tile_cnt = get_compile_time_arg_val(4);
+    std::uint32_t in1_block_tile_cnt = get_compile_time_arg_val(5);
+    std::uint32_t out_block_tile_cnt = get_compile_time_arg_val(6);
+
+    CircularBuffer cb0(tt::CBIndex::c_0);
+    CircularBuffer cb1(tt::CBIndex::c_1);
+    CircularBuffer cb16(tt::CBIndex::c_16);
+
+    constexpr auto in0_cb = experimental::Cb<tt::CBIndex::c_0>{};
+    constexpr auto in1_cb = experimental::Cb<tt::CBIndex::c_1>{};
+    constexpr auto out_cb = experimental::Cb<tt::CBIndex::c_16>{};
+    constexpr auto d0 = experimental::to_llk_mem_descriptor(in0_cb);
+    constexpr auto d1 = experimental::to_llk_mem_descriptor(in1_cb);
+    constexpr auto out_desc = experimental::to_llk_mem_descriptor(out_cb);
+    using In0Op = experimental::LLKOperand<static_cast<DataFormat>(d0.format), d0.shape>;
+    using In1Op = experimental::LLKOperand<static_cast<DataFormat>(d1.format), d1.shape>;
+    using OutOp = experimental::LLKOperand<static_cast<DataFormat>(out_desc.format), out_desc.shape>;
+
+    compute_kernel_hw_startup<SrcOrder::Reverse>(
+        In0Op(in0_cb.read_address()), In1Op(in1_cb.read_address()), OutOp(out_cb.write_address()));
+    experimental::matmul_init(In0Op(in0_cb.read_address()), In1Op(in1_cb.read_address()));
+
+    tile_regs_acquire();
+    for (std::uint32_t b = 0; b < block_cnt; ++b) {
+        cb0.wait_front(in0_block_tile_cnt);
+        cb1.wait_front(in1_block_tile_cnt);
+        int dst_tile_index = 0;
+        int in0_block_tile_index = 0;
+        for (std::uint32_t r = 0; r < dst_tile_rows; ++r) {
+            for (std::uint32_t c = 0; c < dst_tile_cols; ++c) {
+                int in1_block_tile_index = 0;
+                for (std::uint32_t i = 0; i < block_tile_dim; ++i) {
+                    experimental::matmul_tiles(
+                        In0Op(in0_cb.read_address()),
+                        In1Op(in1_cb.read_address()),
+                        in0_block_tile_index + i,
+                        in1_block_tile_index + c,
+                        dst_tile_index);
+                    in1_block_tile_index += dst_tile_cols;
+                }
+                dst_tile_index++;
+            }
+            in0_block_tile_index += block_tile_dim;
+        }
+        cb0.pop_front(in0_block_tile_cnt);
+        cb1.pop_front(in1_block_tile_cnt);
+    }
+
+    tile_regs_commit();
+    tile_regs_wait();
+
+    cb16.reserve_back(out_block_tile_cnt);
+    for (std::uint32_t i = 0; i < out_block_tile_cnt; ++i) {
+        experimental::pack_tile(OutOp(out_cb.write_address(i)), i);
+    }
+    cb16.push_back(out_block_tile_cnt);
+
+    tile_regs_release();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/pack_block_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/pack_block_2_0.cpp
@@ -5,8 +5,9 @@
 #include <cstdint>
 
 #include "api/compute/common.h"
-#include "api/compute/tile_move_copy.h"
+#include "api/compute/tile_move_copy.h"  // legacy copy_tile OP (the copy-into-DST op stays CB-id)
 #include "api/dataflow/circular_buffer.h"
+#include "api/compute/experimental/2_0/tile_move_copy.h"  // id-free copy_init
 #include "api/compute/experimental/2_0/pack.h"
 #include "tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h"
 
@@ -25,13 +26,17 @@ void kernel_main() {
     CircularBuffer cb0(tt::CBIndex::c_0);
     CircularBuffer cb16(tt::CBIndex::c_16);
 
-    // Compile-time CB accessor -> folded descriptor; the operand bundles descriptor + runtime L1 address.
+    // Compile-time CB accessors -> folded descriptors; the operand bundles descriptor + runtime L1 address.
+    constexpr auto in_cb = experimental::Cb<tt::CBIndex::c_0>{};
+    constexpr auto in_desc = experimental::to_llk_mem_descriptor(in_cb);
+    using InOp = experimental::LLKOperand<static_cast<DataFormat>(in_desc.format), in_desc.shape>;
     constexpr auto out_cb = experimental::Cb<tt::CBIndex::c_16>{};
     constexpr auto out_desc = experimental::to_llk_mem_descriptor(out_cb);
     using OutOp = experimental::LLKOperand<static_cast<DataFormat>(out_desc.format), out_desc.shape>;
 
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
-    copy_tile_init(tt::CBIndex::c_0);
+    // Id-free copy-into-DST init from the input CB (c_0); the copy_tile OP below stays the legacy CB-id call.
+    experimental::copy_init(InOp(in_cb.read_address()));
 
     for (std::uint32_t b = 0; b < per_core_tile_cnt; b += block) {
         tile_regs_acquire();

--- a/tests/tt_metal/tt_metal/test_kernels/compute/pack_block_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/pack_block_2_0.cpp
@@ -14,10 +14,9 @@
 // Id-free (2.0) pack_block kernel: process the input in blocks of 4 tiles. IDENTICAL to pack_block_legacy.cpp
 // except the block pack uses experimental::pack_block, built from an output LLKOperand (data format + tile
 // geometry as NTTPs, absolute L1 address the only runtime state). compute_kernel_hw_startup and the input
-// copy_tile stay the legacy CB-id API so the differential isolates pack_block. pack_block loops over the 2.0
-// pack_tile, deriving each tile's output address from the compile-time output tile stride
-// (out.l1_address + i * tile_stride_words) -- the same consecutive L1 tiles the legacy in-order pack loop
-// writes. Compile-time arg 0 = total tile count (assumed a multiple of 4). Output must be bit-for-bit identical
+// copy_tile stay the legacy CB-id API so the differential isolates pack_block. pack_block loops pack_tile
+// with (out, start_out_tile + i, ifrom_dst + i) -- the same consecutive L1 tiles the legacy in-order pack
+// loop writes. Compile-time arg 0 = total tile count (assumed a multiple of 4). Output must be bit-for-bit identical
 // to the legacy kernel.
 void kernel_main() {
     std::uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/pack_block_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/pack_block_2_0.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/compute/experimental/2_0/pack.h"
+#include "tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h"
+
+// Id-free (2.0) pack_block kernel: process the input in blocks of 4 tiles. IDENTICAL to pack_block_legacy.cpp
+// except the block pack uses experimental::pack_block, built from an output LLKOperand (data format + tile
+// geometry as NTTPs, absolute L1 address the only runtime state). compute_kernel_hw_startup and the input
+// copy_tile stay the legacy CB-id API so the differential isolates pack_block. pack_block loops over the 2.0
+// pack_tile, deriving each tile's output address from the compile-time output tile stride
+// (out.l1_address + i * tile_stride_words) -- the same consecutive L1 tiles the legacy in-order pack loop
+// writes. Compile-time arg 0 = total tile count (assumed a multiple of 4). Output must be bit-for-bit identical
+// to the legacy kernel.
+void kernel_main() {
+    std::uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
+    constexpr std::uint32_t block = 4;
+
+    CircularBuffer cb0(tt::CBIndex::c_0);
+    CircularBuffer cb16(tt::CBIndex::c_16);
+
+    // Compile-time CB accessor -> folded descriptor; the operand bundles descriptor + runtime L1 address.
+    constexpr auto out_cb = experimental::Cb<tt::CBIndex::c_16>{};
+    constexpr auto out_desc = experimental::to_llk_mem_descriptor(out_cb);
+    using OutOp = experimental::LLKOperand<static_cast<DataFormat>(out_desc.format), out_desc.shape>;
+
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
+    copy_tile_init(tt::CBIndex::c_0);
+
+    for (std::uint32_t b = 0; b < per_core_tile_cnt; b += block) {
+        tile_regs_acquire();
+        cb0.wait_front(block);
+        cb16.reserve_back(block);
+
+        for (std::uint32_t i = 0; i < block; ++i) {
+            copy_tile(tt::CBIndex::c_0, i, i);
+        }
+
+        tile_regs_commit();
+        tile_regs_wait();
+
+        // Pack DST[0..block-1] to the block base (reserved-region tile 0); pack_block strides by tile_stride_words.
+        experimental::pack_block(OutOp(out_cb.write_address()), 0 /*ifrom_dst*/, block);
+
+        cb0.pop_front(block);
+        cb16.push_back(block);
+        tile_regs_release();
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/pack_rows_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/pack_rows_2_0.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/pack.h"  // legacy pack_rows_init / pack_rows_uninit (both CB-id-free)
+#include "api/dataflow/circular_buffer.h"
+#include "api/compute/experimental/2_0/pack.h"
+#include "tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h"
+
+// Id-free (2.0) pack_rows kernel. IDENTICAL to pack_rows_legacy.cpp except the row pack uses
+// experimental::pack_rows, built from an output LLKOperand (data format + tile geometry as NTTPs, absolute L1
+// write address the only runtime state). compute_kernel_hw_startup, the input copy_tile, and pack_rows_init /
+// pack_rows_uninit stay the legacy CB-id-free API in BOTH kernels so the differential isolates the row pack.
+// pack_rows_init(num_rows) programs the row count/counters (no format, no CB); experimental::pack_rows then
+// packs num_rows row-major rows from DST[0] to out.l1_address. num_rows is fixed at 64 (full tile) so the whole
+// output tile is written. Compile-time arg 0 = total tile count (per-tile 1->1). Output must be bit-for-bit
+// identical to the legacy kernel.
+void kernel_main() {
+    constexpr std::uint32_t num_tiles = get_compile_time_arg_val(0);
+    constexpr std::uint32_t num_rows = 64;  // full tile (TILE_R*TILE_C / FACE_C = 32*32/16)
+
+    CircularBuffer cb0(tt::CBIndex::c_0);
+    CircularBuffer cb16(tt::CBIndex::c_16);
+
+    // Compile-time CB accessor -> folded descriptor; the operand bundles descriptor + runtime L1 address.
+    constexpr auto out_cb = experimental::Cb<tt::CBIndex::c_16>{};
+    constexpr auto out_desc = experimental::to_llk_mem_descriptor(out_cb);
+    using OutOp = experimental::LLKOperand<static_cast<DataFormat>(out_desc.format), out_desc.shape>;
+
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
+    copy_tile_init(tt::CBIndex::c_0);
+    pack_rows_init(num_rows);
+
+    for (std::uint32_t t = 0; t < num_tiles; ++t) {
+        cb0.wait_front(1);
+        cb16.reserve_back(1);
+
+        tile_regs_acquire();
+        copy_tile(tt::CBIndex::c_0, 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        // Row-pack DST[0] to the reserved output tile base (output_index 0 == write_address()).
+        experimental::pack_rows(OutOp(out_cb.write_address()), 0 /*idst*/);
+        tile_regs_release();
+
+        cb0.pop_front(1);
+        cb16.push_back(1);
+    }
+
+    pack_rows_uninit();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/pack_rows_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/pack_rows_2_0.cpp
@@ -5,20 +5,20 @@
 #include <cstdint>
 
 #include "api/compute/common.h"
-#include "api/compute/tile_move_copy.h"
-#include "api/compute/pack.h"  // legacy pack_rows_init / pack_rows_uninit (both CB-id-free)
+#include "api/compute/tile_move_copy.h"  // legacy copy_tile OP (the copy-into-DST op stays CB-id)
 #include "api/dataflow/circular_buffer.h"
-#include "api/compute/experimental/2_0/pack.h"
+#include "api/compute/experimental/2_0/tile_move_copy.h"  // id-free copy_init
+#include "api/compute/experimental/2_0/pack.h"            // id-free pack_rows[_init/_uninit]
 #include "tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h"
 
-// Id-free (2.0) pack_rows kernel. IDENTICAL to pack_rows_legacy.cpp except the row pack uses
-// experimental::pack_rows, built from an output LLKOperand (data format + tile geometry as NTTPs, absolute L1
-// write address the only runtime state). compute_kernel_hw_startup, the input copy_tile, and pack_rows_init /
-// pack_rows_uninit stay the legacy CB-id-free API in BOTH kernels so the differential isolates the row pack.
-// pack_rows_init(num_rows) programs the row count/counters (no format, no CB); experimental::pack_rows then
-// packs num_rows row-major rows from DST[0] to out.l1_address. num_rows is fixed at 64 (full tile) so the whole
-// output tile is written. Compile-time arg 0 = total tile count (per-tile 1->1). Output must be bit-for-bit
-// identical to the legacy kernel.
+// Id-free (2.0) pack_rows kernel. IDENTICAL to pack_rows_legacy.cpp except the compute-init calls + row pack are
+// id-free: experimental::copy_init (built from an input LLKOperand) replaces the legacy CB-id copy_tile_init, and
+// experimental::pack_rows_init/pack_rows/pack_rows_uninit (built from an output LLKOperand -- data format + tile
+// geometry as NTTPs, absolute L1 write address the only runtime state) replace the legacy CB-id-free pack_rows
+// calls. compute_kernel_hw_startup and the input copy_tile OP stay the legacy CB-id API. pack_rows_init(num_rows)
+// programs the row count/counters (no format, no CB); experimental::pack_rows then packs num_rows row-major rows
+// from DST[0] to out.l1_address. num_rows is fixed at 64 (full tile) so the whole output tile is written.
+// Compile-time arg 0 = total tile count (per-tile 1->1). Output must be bit-for-bit identical to the legacy kernel.
 void kernel_main() {
     constexpr std::uint32_t num_tiles = get_compile_time_arg_val(0);
     constexpr std::uint32_t num_rows = 64;  // full tile (TILE_R*TILE_C / FACE_C = 32*32/16)
@@ -26,14 +26,17 @@ void kernel_main() {
     CircularBuffer cb0(tt::CBIndex::c_0);
     CircularBuffer cb16(tt::CBIndex::c_16);
 
-    // Compile-time CB accessor -> folded descriptor; the operand bundles descriptor + runtime L1 address.
+    // Compile-time CB accessors -> folded descriptors; the operand bundles descriptor + runtime L1 address.
+    constexpr auto in_cb = experimental::Cb<tt::CBIndex::c_0>{};
+    constexpr auto in_desc = experimental::to_llk_mem_descriptor(in_cb);
+    using InOp = experimental::LLKOperand<static_cast<DataFormat>(in_desc.format), in_desc.shape>;
     constexpr auto out_cb = experimental::Cb<tt::CBIndex::c_16>{};
     constexpr auto out_desc = experimental::to_llk_mem_descriptor(out_cb);
     using OutOp = experimental::LLKOperand<static_cast<DataFormat>(out_desc.format), out_desc.shape>;
 
     compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
-    copy_tile_init(tt::CBIndex::c_0);
-    pack_rows_init(num_rows);
+    experimental::copy_init(InOp(in_cb.read_address()));
+    experimental::pack_rows_init(OutOp(out_cb.write_address()), num_rows);
 
     for (std::uint32_t t = 0; t < num_tiles; ++t) {
         cb0.wait_front(1);
@@ -52,5 +55,5 @@ void kernel_main() {
         cb16.push_back(1);
     }
 
-    pack_rows_uninit();
+    experimental::pack_rows_uninit(OutOp(out_cb.write_address()));
 }

--- a/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize_2_0.cpp
@@ -12,8 +12,8 @@
 
 // Id-free (2.0) pack-untilize kernel, classic circular buffers. The ops take LLKOperand (data format + tile
 // geometry as NTTPs, L1 address the only runtime state). pack_untilize_block owns the row/column loops and
-// derives per-tile input/output addresses from the compile-time geometry (SCALE_DATUM_SIZE). Output must be
-// bit-identical to the legacy kernel pack_untilize_legacy.cpp. This run uses block_ct_dim/full_ct_dim/
+// derives per-tile input/output addresses from the compile-time geometry via tile_stride_words. Output must
+// be bit-identical to the legacy kernel pack_untilize_legacy.cpp. This run uses block_ct_dim/full_ct_dim/
 // block_rt_dim == 1 (one tile per CB slot).
 void kernel_main() {
     std::uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize_2_0.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/pack_untilize.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/compute/experimental/2_0/pack_untilize.h"
+#include "tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h"
+#include "api/compute/experimental/2_0/hw_startup.h"
+
+// Id-free (2.0) pack-untilize kernel, classic circular buffers. The ops take LLKOperand (data format + tile
+// geometry as NTTPs, L1 address the only runtime state). pack_untilize_block owns the row/column loops and
+// derives per-tile input/output addresses from the compile-time geometry (SCALE_DATUM_SIZE). Output must be
+// bit-identical to the legacy kernel pack_untilize_legacy.cpp. This run uses block_ct_dim/full_ct_dim/
+// block_rt_dim == 1 (one tile per CB slot).
+void kernel_main() {
+    std::uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
+
+    CircularBuffer cb0(tt::CBIndex::c_0);
+    CircularBuffer cb16(tt::CBIndex::c_16);
+
+    constexpr auto in_cb = experimental::Cb<tt::CBIndex::c_0>{};
+    constexpr auto out_cb = experimental::Cb<tt::CBIndex::c_16>{};
+    constexpr auto in_desc = experimental::to_llk_mem_descriptor(in_cb);
+    constexpr auto out_desc = experimental::to_llk_mem_descriptor(out_cb);
+    using InOp = experimental::LLKOperand<static_cast<DataFormat>(in_desc.format), in_desc.shape>;
+    using OutOp = experimental::LLKOperand<static_cast<DataFormat>(out_desc.format), out_desc.shape>;
+
+    compute_kernel_hw_startup(InOp(in_cb.read_address()), OutOp(out_cb.write_address()));
+    experimental::pack_untilize_init<1 /*block_ct_dim*/, 1 /*full_ct_dim*/>(
+        InOp(in_cb.read_address()), OutOp(out_cb.write_address()));
+
+    for (std::uint32_t b = 0; b < per_core_tile_cnt; ++b) {
+        cb0.wait_front(1);
+        cb16.reserve_back(1);
+
+        experimental::pack_untilize_block<1 /*block_ct_dim*/, 1 /*full_ct_dim*/>(
+            InOp(in_cb.read_address()), 1 /*block_rt_dim*/, OutOp(out_cb.write_address()));
+
+        cb0.pop_front(1);
+        cb16.push_back(1);
+    }
+
+    experimental::pack_untilize_uninit(OutOp(out_cb.write_address()));
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize_2_0.cpp
@@ -11,10 +11,10 @@
 #include "api/compute/experimental/2_0/hw_startup.h"
 
 // Id-free (2.0) pack-untilize kernel, classic circular buffers. The ops take LLKOperand (data format + tile
-// geometry as NTTPs, L1 address the only runtime state). pack_untilize_block owns the row/column loops and
+// geometry as NTTPs, L1 address the only runtime state). pack_untilize_block owns the column loop and
 // derives per-tile input/output addresses from the compile-time geometry via tile_stride_words. Output must
-// be bit-identical to the legacy kernel pack_untilize_legacy.cpp. This run uses block_ct_dim/full_ct_dim/
-// block_rt_dim == 1 (one tile per CB slot).
+// be bit-identical to the legacy kernel pack_untilize_legacy.cpp. This run uses block_ct_dim/full_ct_dim == 1
+// (one tile per CB slot; block_rt_dim is an NTTP defaulting to 1).
 void kernel_main() {
     std::uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
 
@@ -37,7 +37,7 @@ void kernel_main() {
         cb16.reserve_back(1);
 
         experimental::pack_untilize_block<1 /*block_ct_dim*/, 1 /*full_ct_dim*/>(
-            InOp(in_cb.read_address()), 1 /*block_rt_dim*/, OutOp(out_cb.write_address()));
+            InOp(in_cb.read_address()), OutOp(out_cb.write_address()));
 
         cb0.pop_front(1);
         cb16.push_back(1);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize_block4_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize_block4_2_0.cpp
@@ -33,8 +33,7 @@ void kernel_main() {
 
     cb0.wait_front(BLOCK);
     cb16.reserve_back(BLOCK);
-    experimental::pack_untilize_block<BLOCK, BLOCK>(
-        InOp(in_cb.read_address()), 1 /*block_rt_dim*/, OutOp(out_cb.write_address()));
+    experimental::pack_untilize_block<BLOCK, BLOCK>(InOp(in_cb.read_address()), OutOp(out_cb.write_address()));
     cb0.pop_front(BLOCK);
     cb16.push_back(BLOCK);
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize_block4_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize_block4_2_0.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/pack_untilize.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/compute/experimental/2_0/pack_untilize.h"
+#include "tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h"
+#include "api/compute/experimental/2_0/hw_startup.h"
+
+// Id-free (2.0) pack-untilize with block_ct_dim = 4 (> 1). Reads 4 tiled input tiles in ONE window at
+// in.l1_address + c * tile_stride_words(InFormat, InShape) and packs one row-major output row 4 tiles wide.
+// With a block-float (Bfp8_b) INPUT this exercises the per-tile input stride for tile c > 0 -- the case where
+// the old SCALE_DATUM_SIZE stride (68 vs 64 words; exponent bytes omitted) misreads tiles. Output must be
+// bit-identical to pack_untilize_block4_legacy.cpp (differential; pure layout movement, byte-exact).
+void kernel_main() {
+    constexpr std::uint32_t BLOCK = 4;
+
+    CircularBuffer cb0(tt::CBIndex::c_0);
+    CircularBuffer cb16(tt::CBIndex::c_16);
+
+    constexpr auto in_cb = experimental::Cb<tt::CBIndex::c_0>{};
+    constexpr auto out_cb = experimental::Cb<tt::CBIndex::c_16>{};
+    constexpr auto in_desc = experimental::to_llk_mem_descriptor(in_cb);
+    constexpr auto out_desc = experimental::to_llk_mem_descriptor(out_cb);
+    using InOp = experimental::LLKOperand<static_cast<DataFormat>(in_desc.format), in_desc.shape>;
+    using OutOp = experimental::LLKOperand<static_cast<DataFormat>(out_desc.format), out_desc.shape>;
+
+    compute_kernel_hw_startup(InOp(in_cb.read_address()), OutOp(out_cb.write_address()));
+    experimental::pack_untilize_init<BLOCK, BLOCK>(InOp(in_cb.read_address()), OutOp(out_cb.write_address()));
+
+    cb0.wait_front(BLOCK);
+    cb16.reserve_back(BLOCK);
+    experimental::pack_untilize_block<BLOCK, BLOCK>(
+        InOp(in_cb.read_address()), 1 /*block_rt_dim*/, OutOp(out_cb.write_address()));
+    cb0.pop_front(BLOCK);
+    cb16.push_back(BLOCK);
+
+    experimental::pack_untilize_uninit(OutOp(out_cb.write_address()));
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize_dest_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/pack_untilize_dest_2_0.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/experimental/2_0/pack_untilize.h"
+#include "tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h"
+#include "api/dataflow/circular_buffer.h"
+
+// Id-free (2.0) pack-untilize-DEST kernel: per tile, copy c_0 -> DST, then experimental::pack_untilize_dest
+// packs (untilizes) the tile straight out of the DEST register to c_16. The pack ops take only an OUTPUT
+// LLKOperand (data format + tile geometry as NTTPs; L1 address the only runtime state) -- there is NO input
+// operand because the source is the DEST register. copy_tile stays the legacy CB-id API so the differential
+// against pack_untilize_dest_legacy.cpp isolates the pack_untilize_dest[_init] calls. Output must be
+// bit-for-bit identical to the legacy kernel. block_ct_dim = full_ct_dim = block_rt_dim = 1.
+void kernel_main() {
+    std::uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
+
+    CircularBuffer cb0(tt::CBIndex::c_0);
+    CircularBuffer cb16(tt::CBIndex::c_16);
+
+    constexpr auto out_cb = experimental::Cb<tt::CBIndex::c_16>{};
+    constexpr auto out_desc = experimental::to_llk_mem_descriptor(out_cb);
+    using OutOp = experimental::LLKOperand<static_cast<DataFormat>(out_desc.format), out_desc.shape>;
+
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
+    copy_tile_to_dst_init_short(tt::CBIndex::c_0);
+    experimental::pack_untilize_dest_init<1 /*block_ct_dim*/, 1 /*full_ct_dim*/>(OutOp(out_cb.write_address()));
+
+    for (std::uint32_t b = 0; b < per_core_tile_cnt; ++b) {
+        cb0.wait_front(1);
+        cb16.reserve_back(1);
+
+        tile_regs_acquire();
+        copy_tile(tt::CBIndex::c_0, 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        experimental::pack_untilize_dest<1 /*block_ct_dim*/, 1 /*full_ct_dim*/>(
+            OutOp(out_cb.write_address()), 1 /*block_rt_dim*/);
+        tile_regs_release();
+
+        cb0.pop_front(1);
+        cb16.push_back(1);
+    }
+
+    experimental::pack_untilize_uninit(OutOp(out_cb.write_address()));
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reconfig_srca_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reconfig_srca_2_0.cpp
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/experimental/2_0/reconfig_data_format.h"
+#include "api/dataflow/circular_buffer.h"
+#include "tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h"
+
+// Id-free (2.0) reconfig kernel: IDENTICAL to reconfig_srca_legacy.cpp except the per-tile SrcA reconfig
+// uses experimental::reconfig_data_format_srca (no CB id) instead of the legacy CB-id call. copy_tile /
+// pack_tile stay the legacy CB-id API so the differential isolates reconfig_data_format_srca. The operand
+// passed in carries c_0's OWN format/geometry (matched-format reconfig, same as the legacy kernel) -- this
+// must reprogram SrcA without corrupting the copy that follows. Output must be bit-for-bit identical to the
+// legacy kernel.
+void kernel_main() {
+    std::uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
+
+    CircularBuffer cb0(tt::CBIndex::c_0);
+    CircularBuffer cb16(tt::CBIndex::c_16);
+
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
+    copy_tile_init(tt::CBIndex::c_0);
+
+    constexpr auto in_cb = experimental::Cb<tt::CBIndex::c_0>{};
+    constexpr auto in_desc = experimental::to_llk_mem_descriptor(in_cb);
+    using InOp = experimental::LLKOperand<static_cast<DataFormat>(in_desc.format), in_desc.shape>;
+
+    for (std::uint32_t b = 0; b < per_core_tile_cnt; ++b) {
+        tile_regs_acquire();
+        cb0.wait_front(1);
+        cb16.reserve_back(1);
+
+        experimental::reconfig_data_format_srca(InOp(in_cb.read_address()));
+        copy_tile(tt::CBIndex::c_0, 0, 0);
+
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, tt::CBIndex::c_16);
+
+        cb0.pop_front(1);
+        cb16.push_back(1);
+        tile_regs_release();
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reconfig_srca_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reconfig_srca_2_0.cpp
@@ -5,7 +5,8 @@
 #include <cstdint>
 
 #include "api/compute/common.h"
-#include "api/compute/tile_move_copy.h"
+#include "api/compute/tile_move_copy.h"                   // legacy copy_tile OP (the copy-into-DST op stays CB-id)
+#include "api/compute/experimental/2_0/tile_move_copy.h"  // id-free copy_init
 #include "api/compute/experimental/2_0/reconfig_data_format.h"
 #include "api/dataflow/circular_buffer.h"
 #include "tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h"
@@ -22,12 +23,13 @@ void kernel_main() {
     CircularBuffer cb0(tt::CBIndex::c_0);
     CircularBuffer cb16(tt::CBIndex::c_16);
 
-    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
-    copy_tile_init(tt::CBIndex::c_0);
-
     constexpr auto in_cb = experimental::Cb<tt::CBIndex::c_0>{};
     constexpr auto in_desc = experimental::to_llk_mem_descriptor(in_cb);
     using InOp = experimental::LLKOperand<static_cast<DataFormat>(in_desc.format), in_desc.shape>;
+
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
+    // Id-free copy-into-DST init from the input CB (c_0); the copy_tile OP below stays the legacy CB-id call.
+    experimental::copy_init(InOp(in_cb.read_address()));
 
     for (std::uint32_t b = 0; b < per_core_tile_cnt; ++b) {
         tile_regs_acquire();

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_2_0.cpp
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/reduce.h"  // compute_kernel_hw_startup, tile_regs_*, PoolType/ReduceDim
+#include "api/dataflow/circular_buffer.h"
+#include "api/compute/experimental/2_0/reduce.h"
+#include "api/compute/experimental/2_0/pack.h"
+#include "tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h"
+#include "api/compute/experimental/2_0/hw_startup.h"
+
+// Id-free (2.0) minimal single-DST reduce kernel, classic circular buffers. One LLKOperand per input
+// (data, scaler) + output; reduce is format-free so only geometry + addresses flow through. The pool and
+// reduce dim are selected at compile time via get_compile_time_arg_val(1)=PoolType, (2)=ReduceDim, so this
+// ONE kernel covers reduce_{scalar,row,col} SUM and reduce scalar MAX -- those differed only in those two
+// template args. Output must be bit-identical to the matching reduce_*_legacy.cpp. (reduce_block, which has
+// N-in/N-out block semantics + a different pack loop, is a separate kernel.)
+namespace {
+constexpr auto kPool = static_cast<PoolType>(get_compile_time_arg_val(1));
+constexpr auto kDim = static_cast<ReduceDim>(get_compile_time_arg_val(2));
+}  // namespace
+
+void kernel_main() {
+    std::uint32_t num_tiles = get_compile_time_arg_val(0);
+
+    CircularBuffer cb0(tt::CBIndex::c_0);
+    CircularBuffer cb1(tt::CBIndex::c_1);
+    CircularBuffer cb16(tt::CBIndex::c_16);
+
+    constexpr auto data_cb = experimental::Cb<tt::CBIndex::c_0>{};
+    constexpr auto scaler_cb = experimental::Cb<tt::CBIndex::c_1>{};
+    constexpr auto out_cb = experimental::Cb<tt::CBIndex::c_16>{};
+    constexpr auto data_desc = experimental::to_llk_mem_descriptor(data_cb);
+    constexpr auto scaler_desc = experimental::to_llk_mem_descriptor(scaler_cb);
+    constexpr auto out_desc = experimental::to_llk_mem_descriptor(out_cb);
+    using DataOp = experimental::LLKOperand<static_cast<DataFormat>(data_desc.format), data_desc.shape>;
+    using ScalerOp = experimental::LLKOperand<static_cast<DataFormat>(scaler_desc.format), scaler_desc.shape>;
+    using OutOp = experimental::LLKOperand<static_cast<DataFormat>(out_desc.format), out_desc.shape>;
+
+    compute_kernel_hw_startup(
+        DataOp(data_cb.read_address()), ScalerOp(scaler_cb.read_address()), OutOp(out_cb.write_address()));
+    experimental::reduce_init<kPool, kDim>(DataOp(data_cb.read_address()), OutOp(out_cb.write_address()));
+
+    cb0.wait_front(num_tiles);
+    cb1.wait_front(num_tiles);
+    cb16.reserve_back(1);
+
+    tile_regs_acquire();
+    for (std::uint32_t i = 0; i < num_tiles; ++i) {
+        experimental::reduce_tile<kPool, kDim>(
+            DataOp(data_cb.read_address()), ScalerOp(scaler_cb.read_address()), i, 0, 0);
+    }
+    tile_regs_commit();
+
+    tile_regs_wait();
+    experimental::pack_tile(OutOp(out_cb.write_address()), 0);
+    tile_regs_release();
+
+    cb0.pop_front(num_tiles);
+    cb1.pop_front(num_tiles);
+    cb16.push_back(1);
+
+    experimental::reduce_uninit();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_2_0.cpp
@@ -55,7 +55,7 @@ void kernel_main() {
     tile_regs_commit();
 
     tile_regs_wait();
-    experimental::pack_tile(OutOp(out_cb.write_address()), 0);
+    experimental::pack_tile(OutOp(out_cb.write_address()), 0, 0);
     tile_regs_release();
 
     cb0.pop_front(num_tiles);

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_block_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_block_2_0.cpp
@@ -50,7 +50,7 @@ void kernel_main() {
 
     tile_regs_wait();
     for (std::uint32_t i = 0; i < num_tiles; ++i) {
-        experimental::pack_tile(OutOp(out_cb.write_address(i)), i);
+        experimental::pack_tile(OutOp(out_cb.write_address()), i, i);
     }
     tile_regs_release();
 

--- a/tests/tt_metal/tt_metal/test_kernels/compute/reduce_block_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/reduce_block_2_0.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/reduce.h"  // compute_kernel_hw_startup, tile_regs_*, PoolType/ReduceDim
+#include "api/dataflow/circular_buffer.h"
+#include "api/compute/experimental/2_0/reduce.h"
+#include "api/compute/experimental/2_0/pack.h"
+#include "tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h"
+#include "api/compute/experimental/2_0/hw_startup.h"
+
+// Id-free (2.0) REDUCE_SCALAR SUM block kernel, classic circular buffers. One LLKOperand per input
+// (data, scaler) + output; reduce is format-free so only geometry + addresses flow through. Reduces num_tiles
+// data tiles via a SINGLE experimental::reduce_block call with N-in / N-out semantics (data tile i -> DST[i]),
+// then packs the num_tiles reduced tiles to c_16. Output must be bit-identical to reduce_block_legacy.cpp
+// (which calls the legacy reduce_block). Differs from that kernel ONLY in the reduce call, isolating
+// reduce_block. The CBs must be >= num_tiles deep -- the TEST_F passes cb_depth_tiles=num_tiles.
+void kernel_main() {
+    std::uint32_t num_tiles = get_compile_time_arg_val(0);
+
+    CircularBuffer cb0(tt::CBIndex::c_0);
+    CircularBuffer cb1(tt::CBIndex::c_1);
+    CircularBuffer cb16(tt::CBIndex::c_16);
+
+    constexpr auto data_cb = experimental::Cb<tt::CBIndex::c_0>{};
+    constexpr auto scaler_cb = experimental::Cb<tt::CBIndex::c_1>{};
+    constexpr auto out_cb = experimental::Cb<tt::CBIndex::c_16>{};
+    constexpr auto data_desc = experimental::to_llk_mem_descriptor(data_cb);
+    constexpr auto scaler_desc = experimental::to_llk_mem_descriptor(scaler_cb);
+    constexpr auto out_desc = experimental::to_llk_mem_descriptor(out_cb);
+    using DataOp = experimental::LLKOperand<static_cast<DataFormat>(data_desc.format), data_desc.shape>;
+    using ScalerOp = experimental::LLKOperand<static_cast<DataFormat>(scaler_desc.format), scaler_desc.shape>;
+    using OutOp = experimental::LLKOperand<static_cast<DataFormat>(out_desc.format), out_desc.shape>;
+
+    compute_kernel_hw_startup(
+        DataOp(data_cb.read_address()), ScalerOp(scaler_cb.read_address()), OutOp(out_cb.write_address()));
+    experimental::reduce_init<PoolType::SUM, ReduceDim::REDUCE_SCALAR>(
+        DataOp(data_cb.read_address()), OutOp(out_cb.write_address()));
+
+    cb0.wait_front(num_tiles);
+    cb1.wait_front(num_tiles);
+    cb16.reserve_back(num_tiles);
+
+    tile_regs_acquire();
+    experimental::reduce_block<PoolType::SUM, ReduceDim::REDUCE_SCALAR>(
+        DataOp(data_cb.read_address()), ScalerOp(scaler_cb.read_address()), 0, 0, 0, num_tiles);
+    tile_regs_commit();
+
+    tile_regs_wait();
+    for (std::uint32_t i = 0; i < num_tiles; ++i) {
+        experimental::pack_tile(OutOp(out_cb.write_address(i)), i);
+    }
+    tile_regs_release();
+
+    cb0.pop_front(num_tiles);
+    cb1.pop_front(num_tiles);
+    cb16.push_back(num_tiles);
+
+    experimental::reduce_uninit();
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/tilize_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/tilize_2_0.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/tilize.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/compute/experimental/2_0/tilize.h"
+#include "tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h"
+#include "api/compute/experimental/2_0/hw_startup.h"
+
+// Id-free (2.0) tilize kernel, classic circular buffers. The ops take LLKOperand (data format + tile
+// geometry as NTTPs, L1 address the only runtime state). tilize_block owns the block loop and derives each
+// tile's output slot from the compile-time output geometry (SCALE_DATUM_SIZE), so tile t lands in slot t.
+// Output must be bit-identical to the legacy kernel tilize_legacy.cpp. This run uses block == 1 per CB slot.
+void kernel_main() {
+    std::uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
+
+    CircularBuffer cb0(tt::CBIndex::c_0);
+    CircularBuffer cb16(tt::CBIndex::c_16);
+
+    constexpr auto in_cb = experimental::Cb<tt::CBIndex::c_0>{};
+    constexpr auto out_cb = experimental::Cb<tt::CBIndex::c_16>{};
+    constexpr auto in_desc = experimental::to_llk_mem_descriptor(in_cb);
+    constexpr auto out_desc = experimental::to_llk_mem_descriptor(out_cb);
+    using InOp = experimental::LLKOperand<static_cast<DataFormat>(in_desc.format), in_desc.shape>;
+    using OutOp = experimental::LLKOperand<static_cast<DataFormat>(out_desc.format), out_desc.shape>;
+
+    compute_kernel_hw_startup(InOp(in_cb.read_address()), OutOp(out_cb.write_address()));
+    experimental::tilize_init(InOp(in_cb.read_address()), 1 /*block*/, OutOp(out_cb.write_address()));
+
+    for (std::uint32_t b = 0; b < per_core_tile_cnt; ++b) {
+        cb0.wait_front(1);
+        cb16.reserve_back(1);
+
+        experimental::tilize_block(InOp(in_cb.read_address()), 1 /*block*/, OutOp(out_cb.write_address()));
+
+        cb0.pop_front(1);
+        cb16.push_back(1);
+    }
+
+    experimental::tilize_uninit(InOp(in_cb.read_address()), OutOp(out_cb.write_address()));
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/transpose_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/transpose_2_0.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"  // pack_tile (legacy CB-id API, kept identical to the legacy kernel)
+#include "api/compute/experimental/2_0/transpose.h"
+#include "tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h"
+#include "api/dataflow/circular_buffer.h"
+
+// Id-free (2.0) transpose kernel: per tile, unpack+transpose c_0 directly into DST (via
+// experimental::transpose_init / experimental::transpose_tile), pack -> c_16. IDENTICAL to
+// transpose_legacy.cpp except the transpose init/op calls take an LLKOperand instead of a CB id. pack_tile
+// stays the legacy CB-id API so the differential isolates transpose_init/transpose_tile. Output must be
+// bit-for-bit identical to the legacy kernel.
+void kernel_main() {
+    std::uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
+
+    CircularBuffer cb0(tt::CBIndex::c_0);
+    CircularBuffer cb16(tt::CBIndex::c_16);
+
+    constexpr auto in_cb = experimental::Cb<tt::CBIndex::c_0>{};
+    constexpr auto in_desc = experimental::to_llk_mem_descriptor(in_cb);
+    using SrcOp = experimental::LLKOperand<static_cast<DataFormat>(in_desc.format), in_desc.shape>;
+
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
+    experimental::transpose_init(SrcOp(in_cb.read_address()));
+
+    for (std::uint32_t b = 0; b < per_core_tile_cnt; ++b) {
+        tile_regs_acquire();
+        cb0.wait_front(1);
+        cb16.reserve_back(1);
+
+        experimental::transpose_tile(SrcOp(in_cb.read_address()), 0, 0);
+
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, tt::CBIndex::c_16);
+
+        cb0.pop_front(1);
+        cb16.push_back(1);
+        tile_regs_release();
+    }
+}

--- a/tests/tt_metal/tt_metal/test_kernels/compute/unary_bcast_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/unary_bcast_2_0.cpp
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/common.h"
+#include "api/dataflow/circular_buffer.h"
+
+// Id-free (2.0) unary_bcast kernel: per tile, unary_bcast c_0 -> DST (BroadcastType::ROW), pack -> c_16.
+// IDENTICAL to unary_bcast_legacy.cpp except the broadcast uses experimental::unary_bcast[_init] built from an
+// LLKOperand (data format + tile geometry as NTTPs, absolute L1 address as the only runtime state) -- NO CB id
+// on the op surface. The register format is derived on-device from the L1 format. hw_startup / pack_tile stay
+// the legacy CB-id API so the differential isolates unary_bcast. Output must be bit-identical to the legacy kernel.
+#include "api/compute/experimental/2_0/bcast.h"
+#include "tests/tt_metal/tt_metal/test_kernels/compute/cb_operand_helpers.h"
+
+void kernel_main() {
+    std::uint32_t per_core_tile_cnt = get_compile_time_arg_val(0);
+
+    CircularBuffer cb0(tt::CBIndex::c_0);
+    CircularBuffer cb16(tt::CBIndex::c_16);
+
+    // Compile-time CB accessor -> folded descriptor; the operand bundles descriptor + runtime L1 address.
+    constexpr auto in_cb = experimental::Cb<tt::CBIndex::c_0>{};
+    constexpr auto in_desc = experimental::to_llk_mem_descriptor(in_cb);
+    using InOp = experimental::LLKOperand<static_cast<DataFormat>(in_desc.format), in_desc.shape>;
+
+    compute_kernel_hw_startup(tt::CBIndex::c_0, tt::CBIndex::c_16);
+    experimental::unary_bcast_init<BroadcastType::ROW>(InOp(in_cb.read_address()));
+
+    for (std::uint32_t b = 0; b < per_core_tile_cnt; ++b) {
+        tile_regs_acquire();
+        cb0.wait_front(1);
+        cb16.reserve_back(1);
+
+        experimental::unary_bcast<BroadcastType::ROW>(InOp(in_cb.read_address()), 0);
+
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, tt::CBIndex::c_16);
+
+        cb0.pop_front(1);
+        cb16.push_back(1);
+        tile_regs_release();
+    }
+}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/data_format_derive.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/data_format_derive.h
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "tensix_types.h"  // Blackhole DataFormat enum
+#include "ckernel_defs.h"  // IS_BFP_FORMAT (canonical device bfp-format list)
+
+// =====================================================================================================
+// data_format_derive.h (BLACKHOLE) -- compile-time derivation of the *register* data format from a
+// buffer's *L1* data format. This is a HARDWARE/ARCH concern (it encodes Blackhole's register format
+// tables), so it lives at the LLK API level and is consumed only inside the LLK spec wrappers -- the
+// register format is NEVER exposed above the LLK boundary. Compute APIs pass only L1 metadata.
+//
+// This is the BLACKHOLE copy. Wormhole gets its own copy under
+// ckernels/wormhole_b0/metal/llk_api/data_format_derive.h; Quasar is a completely separate arch.
+//
+// Mirrors the SCALAR CORES of jit_build/data_format.cpp:
+//   * infer_unpack_dst_format  <- get_single_unpack_dst_format  (data_format.cpp:141-170)
+//   * infer_pack_src_format    <- get_single_pack_src_format    (data_format.cpp:226-360)
+// scoped to DATACOPY (single operand), with the op-wide knobs fixed to their datacopy defaults:
+// bfp8_pack_precise=false, int_fpu_en=false, enable_2x_src_format=false, arch=BLACKHOLE. The one live
+// input is fp32_dest_acc; unpack_conditional_dst_format is the standard datacopy conditional
+// (Float32 with dest-acc, else Float16_b).
+//
+// KEY SIMPLIFICATION vs the host cores: get_single_pack_src_format computes input_exp_width and
+// output_exp_width BOTH from the single data_format, so they are ALWAYS equal and the host's
+// "different exponent width" else-branch (the only user of CONVERT_EXP_WIDTH) is UNREACHABLE for a
+// single-operand op -- no CONVERT_EXP_WIDTH map on device. MX formats are absent from the Blackhole
+// DataFormat enum, so is_mx handling collapses too. Divergent-format ops (eltwise binary) would grow
+// the two-operand inputs when added.
+// =====================================================================================================
+
+namespace ckernel {
+
+// ---- format-class predicates (device subset of data_format.cpp; MX formats are not in the BH enum) --
+// NOTE: df_is_exp_b_format / df_is_integer_format duplicate host logic (is_exp_b_format @ jit_build/
+// data_format.cpp:54; tt::is_integer_format @ common/tt_backend_api_types.cpp:59) that is NOT includable from
+// a device kernel, so a device-side copy is required. Keep the BH subset here in sync with those host sources.
+
+// Keep in sync with is_exp_b_format (jit_build/data_format.cpp:54) -- BH-enum subset (no MX formats on BH).
+constexpr bool df_is_exp_b_format(DataFormat f) {
+    return f == DataFormat::Tf32 || f == DataFormat::Float16_b || f == DataFormat::Bfp8_b || f == DataFormat::Bfp4_b ||
+           f == DataFormat::Bfp2_b;
+}
+
+// Delegates to the canonical device bfp-format list (ckernel_defs.h) so the set is defined once. masked_data_format
+// (applied inside IS_BFP_FORMAT) is a no-op for plain L1 formats -- same value as an explicit enum compare.
+constexpr bool df_is_bfp_format(DataFormat f) { return ckernel::IS_BFP_FORMAT(static_cast<std::uint32_t>(f)); }
+
+// Keep in sync with tt::is_integer_format (common/tt_backend_api_types.cpp:59) -- BH-enum subset. NOTE the device
+// ckernel_defs.h is_int8_or_int32_format is a NARROWER set (int8/int32 only), so it is not a substitute here.
+constexpr bool df_is_integer_format(DataFormat f) {
+    return f == DataFormat::Int8 || f == DataFormat::UInt8 || f == DataFormat::UInt16 || f == DataFormat::Int32 ||
+           f == DataFormat::UInt32;
+}
+
+// ---- unpack SrcA register format  (mirrors get_single_unpack_dst_format, datacopy scope) -------------
+// Non-fp32 buffer formats unpack into src registers unchanged. Float32 in L1 unpacks to the op's
+// conditional dst format: Float32 when accumulating in fp32 dest, else Float16_b.
+constexpr DataFormat infer_unpack_dst_format(DataFormat l1_format, bool fp32_dest_acc) {
+    if (l1_format == DataFormat::Float32) {
+        return fp32_dest_acc ? DataFormat::Float32 : DataFormat::Float16_b;
+    }
+    return l1_format;
+}
+
+// ---- pack Dest register format  (mirrors get_single_pack_src_format, datacopy scope) -----------------
+constexpr DataFormat infer_pack_src_format(DataFormat l1_format, bool fp32_dest_acc) {
+    const DataFormat cond = fp32_dest_acc ? DataFormat::Float32 : DataFormat::Float16_b;
+
+    if (l1_format == DataFormat::UInt16) {
+        return DataFormat::UInt16;
+    }
+    if (l1_format == DataFormat::Invalid) {
+        return DataFormat::Invalid;
+    }
+    if (l1_format == DataFormat::Fp8_e4m3) {
+        return df_is_exp_b_format(cond) ? DataFormat::Float16_b : DataFormat::Float16;
+    }
+
+    if (fp32_dest_acc) {
+        if (df_is_bfp_format(l1_format)) {
+            // bfp8_pack_precise == false
+            return df_is_exp_b_format(l1_format) ? DataFormat::Bfp8_b : DataFormat::Bfp8;
+        }
+        if (df_is_exp_b_format(l1_format) || l1_format == DataFormat::Float32) {
+            return l1_format;
+        }
+        if (l1_format == DataFormat::Float16) {
+            return DataFormat::Float16_b;
+        }
+        if (l1_format == DataFormat::UInt32) {
+            return DataFormat::UInt32;
+        }
+        if (l1_format == DataFormat::Int32) {
+            return DataFormat::Int32;
+        }
+        if (l1_format == DataFormat::UInt8) {
+            return DataFormat::UInt8;
+        }
+        if (l1_format == DataFormat::Int8) {
+            return DataFormat::Int8;
+        }
+        return l1_format;  // fp32-dest fallthrough (host TT_THROWs; keep format for device)
+    }
+
+    if (df_is_integer_format(l1_format)) {
+        return l1_format;
+    }
+
+    // Single-operand exp-width-match branch (host :297): input_exp_width == output_exp_width always.
+    if (l1_format == DataFormat::Float32) {
+        // fp32 buffer, no dest-acc: pack src is the conditional fp16a/b (here Float16_b).
+        return cond;
+    }
+    if (df_is_bfp_format(l1_format)) {
+        // bfp8_pack_precise == false
+        return df_is_exp_b_format(l1_format) ? DataFormat::Bfp8_b : DataFormat::Bfp8;
+    }
+    return l1_format;
+}
+
+// ---- register-format helpers (uint8 form) ------------------------------------------------------------
+// The LLK cores take the register format as a raw uint8. These wrap infer_unpack_dst_format / infer_pack_src_format
+// with the static_cast so the 2.0 LLK overloads call one helper instead of repeating the cast at every site.
+constexpr std::uint8_t infer_unpack_reg_fmt(DataFormat l1_format, bool fp32_dest_acc) {
+    return static_cast<std::uint8_t>(infer_unpack_dst_format(l1_format, fp32_dest_acc));
+}
+constexpr std::uint8_t infer_pack_reg_fmt(DataFormat l1_format, bool fp32_dest_acc) {
+    return static_cast<std::uint8_t>(infer_pack_src_format(l1_format, fp32_dest_acc));
+}
+
+// =====================================================================================================
+// TWO-OPERAND exponent-width reconciliation (C1). The HW does NOT support mixing exponent widths across the
+// two source registers: both must be the 5-bit "a" family (fp16 / Bfp8 / Bfp4 / ...) or both the 8-bit "b"
+// family (bf16 / Bfp8_b / Tf32 / ...). The ONE exception is Float32, which the HW rebiases to whichever family
+// the OTHER operand uses. Any other cross-family pairing is a hardware error, caught here as a hard compile
+// failure. Formats are passed as template args so both the assert and the derivation fold at compile time.
+// =====================================================================================================
+
+// The common exponent-width family for two operand formats (true = 8-bit "b" family). Float32 is a wildcard
+// that adopts the other operand's family; two concrete formats of different families are rejected.
+template <DataFormat A, DataFormat B>
+constexpr bool common_exp_is_b() {
+    constexpr bool a_fp32 = (A == DataFormat::Float32);
+    constexpr bool b_fp32 = (B == DataFormat::Float32);
+    if constexpr (a_fp32 && b_fp32) {
+        return true;  // both Float32: native 8-bit exponent
+    } else if constexpr (a_fp32) {
+        return df_is_exp_b_format(B);  // Float32 rebiases to B's family
+    } else if constexpr (b_fp32) {
+        return df_is_exp_b_format(A);  // Float32 rebiases to A's family
+    } else {
+        static_assert(
+            df_is_exp_b_format(A) == df_is_exp_b_format(B),
+            "HW does not support mixed exponent-width operands (only Float32 rebiases to the other's width).");
+        return df_is_exp_b_format(A);
+    }
+}
+
+// Unpack-dst (register) format for the SELF operand of a two-operand op, honoring the common exp-width family
+// so both source registers agree. Non-Float32 formats are unchanged (identical to the single-operand infer);
+// a Float32 operand adopts the common family: Float32 under fp32-dest-acc, else Float16_b (b) / Float16 (a).
+// For matching formats this is exactly infer_unpack_dst_format(Self, ...), so it changes nothing on that path
+// -- its job is the Float32-rebias case and the compile-time mixed-width guard.
+template <DataFormat Self, DataFormat Other>
+constexpr DataFormat infer_unpack_dst_format_2op(bool fp32_dest_acc) {
+    static_cast<void>(common_exp_is_b<Self, Other>());  // fires the mixed-width static_assert for any pairing
+    if constexpr (Self == DataFormat::Float32) {
+        if (fp32_dest_acc) {
+            return DataFormat::Float32;
+        }
+        return common_exp_is_b<Self, Other>() ? DataFormat::Float16_b : DataFormat::Float16;
+    } else {
+        return infer_unpack_dst_format(Self, fp32_dest_acc);
+    }
+}
+
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_hw_configure.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_hw_configure.h
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "data_format_derive.h"
+#include "api/compute/experimental/2_0/internal/llk_descriptor.h"
+
+/*************************************************************************
+ * LLK hw_configure -- LLKOperand (id-free, compile-time NTTP) overloads
+ *
+ * Same function names as the CB-id hw_configure APIs, distinguished by taking LLKMemDescriptor NTTPs instead
+ * of CB ids. src/dst formats, face geometry and per-tile size all come from the operand descriptors -- no CB
+ * arrays, no runtime L1-format inference. The two source-register formats are reconciled to a common
+ * exponent-width family via infer_unpack_dst_format_2op (C1): matching formats are unchanged, a Float32
+ * operand rebiases to the other's width, and any other cross-family pairing is a hard compile error.
+ *
+ * This header is deliberately NOT included by the broadly-included *_common_api.h files: it pulls the
+ * ckernel::experimental namespace in, which collides with metal's top-level ::experimental (kernel_args.h)
+ * under `using namespace ckernel`. It is included ONLY by compute_kernel_hw_startup.h, whose id-free overload
+ * is the sole consumer -- and which is never pulled into the legacy kernel_args-based kernels.
+ *************************************************************************/
+
+#ifdef TRISC_UNPACK
+#include "llk_unpack_common_api.h"
+
+template <
+    bool is_fp32_dest_acc_en,
+    ckernel::experimental::LLKMemDescriptor DESC_A,
+    ckernel::experimental::LLKMemDescriptor DESC_B>
+inline void llk_unpack_hw_configure() {
+    constexpr DataFormat A = DESC_A.format;
+    constexpr DataFormat B = DESC_B.format;
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+        static_cast<std::uint32_t>(DESC_A.format),
+        static_cast<std::uint32_t>(DESC_B.format),
+        static_cast<std::uint32_t>(ckernel::infer_unpack_dst_format_2op<A, B>(is_fp32_dest_acc_en)),
+        static_cast<std::uint32_t>(ckernel::infer_unpack_dst_format_2op<B, A>(is_fp32_dest_acc_en)),
+        DESC_A.shape.face_r_dim,
+        DESC_B.shape.face_r_dim,
+        DESC_A.shape.total_num_faces(),
+        DESC_B.shape.total_num_faces(),
+        ckernel::experimental::tile_stride_words(DESC_A.format, DESC_A.shape),
+        ckernel::experimental::tile_stride_words(DESC_B.format, DESC_B.shape));
+}
+#endif
+
+#ifdef TRISC_MATH
+#include "llk_math_common_api.h"
+
+template <
+    bool is_fp32_dest_acc_en,
+    ckernel::experimental::LLKMemDescriptor DESC_A,
+    ckernel::experimental::LLKMemDescriptor DESC_B>
+inline void llk_math_hw_configure() {
+    constexpr DataFormat A = DESC_A.format;
+    constexpr DataFormat B = DESC_B.format;
+    _llk_math_hw_configure_<is_fp32_dest_acc_en>(
+        static_cast<std::uint32_t>(ckernel::infer_unpack_dst_format_2op<A, B>(is_fp32_dest_acc_en)),
+        static_cast<std::uint32_t>(ckernel::infer_unpack_dst_format_2op<B, A>(is_fp32_dest_acc_en)));
+}
+#endif
+
+#ifdef TRISC_PACK
+#include "llk_pack_common_api.h"
+
+template <bool is_fp32_dest_acc_en, ckernel::experimental::LLKMemDescriptor OUT_DESC>
+inline void llk_pack_hw_configure() {
+    constexpr std::uint8_t pack_src = ckernel::infer_pack_reg_fmt(OUT_DESC.format, is_fp32_dest_acc_en);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(
+        pack_src,
+        static_cast<std::uint32_t>(OUT_DESC.format),
+        ckernel::experimental::tile_stride_words(OUT_DESC.format, OUT_DESC.shape),
+        OUT_DESC.shape.face_r_dim,
+        OUT_DESC.shape.total_col_dim(),
+        OUT_DESC.shape.total_num_faces(),
+        false /*partial_face*/,
+        0 /*relu_config*/);
+}
+#endif

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_hw_configure.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_hw_configure.h
@@ -15,7 +15,7 @@
  * Same function names as the CB-id hw_configure APIs, distinguished by taking LLKMemDescriptor NTTPs instead
  * of CB ids. src/dst formats, face geometry and per-tile size all come from the operand descriptors -- no CB
  * arrays, no runtime L1-format inference. The two source-register formats are reconciled to a common
- * exponent-width family via infer_unpack_dst_format_2op (C1): matching formats are unchanged, a Float32
+ * exponent-width family via infer_unpack_dst_format_2op: matching formats are unchanged, a Float32
  * operand rebiases to the other's width, and any other cross-family pairing is a hard compile error.
  *
  * This header is deliberately NOT included by the broadly-included *_common_api.h files: it pulls the

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_hw_configure.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_hw_configure.h
@@ -20,8 +20,8 @@
  *
  * This header is deliberately NOT included by the broadly-included *_common_api.h files: it pulls the
  * ckernel::experimental namespace in, which collides with metal's top-level ::experimental (kernel_args.h)
- * under `using namespace ckernel`. It is included ONLY by compute_kernel_hw_startup.h, whose id-free overload
- * is the sole consumer -- and which is never pulled into the legacy kernel_args-based kernels.
+ * under `using namespace ckernel`. It is included ONLY by experimental/2_0/hw_startup.h, whose id-free
+ * overload is the sole consumer -- and which is never pulled into the legacy kernel_args-based kernels.
  *************************************************************************/
 
 #ifdef TRISC_UNPACK

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_hw_configure.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_hw_configure.h
@@ -77,7 +77,9 @@ inline void llk_pack_hw_configure() {
         OUT_DESC.shape.face_r_dim,
         OUT_DESC.shape.total_col_dim(),
         OUT_DESC.shape.total_num_faces(),
-        false /*partial_face*/,
+        // partial_face: derived from the output geometry, matching legacy get_output_partial_face
+        // (Tile::partial_face == tile height < 32). Folds at compile time; full 32-row tiles give false.
+        ckernel::experimental::is_partial_height(OUT_DESC.shape),
         0 /*relu_config*/);
 }
 #endif

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_math_binary.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_math_binary.h
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "llk_math_binary_api.h"  // legacy CB-id API + unified llk_math_eltwise_binary_{init_,}impl
+#include "api/compute/experimental/2_0/internal/llk_descriptor.h"
+
+/*************************************************************************
+ * LLK ELTWISE BINARY -- LLKOperand (id-free, compile-time NTTP) overloads
+ *
+ * Same function names as the CB-id API (llk_math_eltwise_binary_init / llk_math_eltwise_binary),
+ * distinguished by taking an LLKMemDescriptor (of operand A -- the shape source, mirroring the CB-id API)
+ * as the first NTTP. Eltwise binary math is FORMAT-FREE: it consumes only the tile geometry (DESC_A.shape);
+ * register formats live in the unpacker/dest config from compute_kernel_hw_startup. Both overloads forward
+ * to the same unified cores as the CB-id API.
+ *************************************************************************/
+
+template <
+    ckernel::experimental::LLKMemDescriptor DESC_A,
+    EltwiseBinaryType eltwise_binary_type,
+    BroadcastType src_b_bcast_type = BroadcastType::NONE,
+    MathFidelity math_fidelity = MathFidelity::LoFi,
+    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
+inline void llk_math_eltwise_binary_init(const std::uint32_t acc_to_dest = 0) {
+    llk_math_eltwise_binary_init_impl<eltwise_binary_type, src_b_bcast_type, math_fidelity, binary_reuse_dest>(
+        DESC_A.shape, acc_to_dest);
+}
+
+template <
+    ckernel::experimental::LLKMemDescriptor DESC_A,
+    EltwiseBinaryType eltwise_binary_type,
+    BroadcastType src_b_bcast_type,
+    bool is_fp32_dest_acc_en,
+    MathFidelity math_fidelity,
+    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
+inline void llk_math_eltwise_binary(std::uint32_t dst_index, const bool clear_fp32_dst_acc = true) {
+    llk_math_eltwise_binary_impl<
+        eltwise_binary_type,
+        src_b_bcast_type,
+        is_fp32_dest_acc_en,
+        math_fidelity,
+        binary_reuse_dest>(DESC_A.shape, dst_index, clear_fp32_dst_acc);
+}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_math_matmul.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_math_matmul.h
@@ -16,8 +16,9 @@
  * (llk_math_matmul<fidelity, throttle>(idst, ct, rt)) takes no operand id, so the id-free path reuses the
  * legacy execute directly -- no overload here.
  *
- * partial_face is derived as (in0 total_row_dim() < FACE_R_DIM), exactly as the legacy CB-id
- * llk_math_matmul_init derives it from unpack_tile_r_dim.
+ * partial_face is derived INLINE as (in0 total_row_dim() < FACE_R_DIM), exactly as the legacy CB-id
+ * llk_math_matmul_init derives it from unpack_tile_r_dim. NOTE this is a DIFFERENT threshold than the UNPACK
+ * path (llk_unpack_AB_matmul.h, < TILE_R_DIM); the divergence is inherited from legacy (see llk_descriptor.h).
  *************************************************************************/
 
 template <
@@ -31,8 +32,9 @@ inline void llk_math_matmul_init(
     constexpr std::uint32_t in0_tile_c_dim = IN0_DESC.shape.total_col_dim();
     constexpr std::uint32_t in1_tile_r_dim = IN1_DESC.shape.total_row_dim();
     constexpr std::uint32_t in1_tile_c_dim = IN1_DESC.shape.total_col_dim();
-    // Shared derivation (internal/llk_descriptor.h) so MATH and UNPACK agree; == legacy (in0 tile_r < FACE_R_DIM).
-    constexpr bool partial_face = ckernel::experimental::matmul_partial_face(IN0_DESC);
+    // MATH-side rule == legacy (in0 tile_r < FACE_R_DIM). The UNPACK path uses the looser < TILE_R_DIM (see
+    // llk_unpack_AB_matmul.h / llk_descriptor.h) -- the legacy MATH/UNPACK divergence, preserved.
+    constexpr bool partial_face = in0_tile_r_dim < ckernel::FACE_R_DIM;
 
     llk_math_matmul_init_impl<math_fidelity, THROTTLE_LEVEL>(
         in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, transpose, ct_dim, rt_dim);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_math_matmul.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_math_matmul.h
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "llk_math_matmul_api.h"  // legacy CB-id API + unified llk_math_matmul_init_impl; execute reused as-is
+#include "api/compute/experimental/2_0/internal/llk_descriptor.h"
+
+/*************************************************************************
+ * LLK MATMUL MATH -- LLKOperand (id-free, compile-time NTTP) overload (init only)
+ *
+ * Only the init needs an id-free overload: it derives the per-source tile r/c dims + partial_face from the
+ * two descriptors (IN0 -> SrcB, IN1 -> SrcA). Matmul math is FORMAT-FREE. The matmul math EXECUTE
+ * (llk_math_matmul<fidelity, throttle>(idst, ct, rt)) takes no operand id, so the id-free path reuses the
+ * legacy execute directly -- no overload here.
+ *
+ * partial_face is derived as (in0 total_row_dim() < FACE_R_DIM), exactly as the legacy CB-id
+ * llk_math_matmul_init derives it from unpack_tile_r_dim.
+ *************************************************************************/
+
+template <
+    ckernel::experimental::LLKMemDescriptor IN0_DESC,
+    ckernel::experimental::LLKMemDescriptor IN1_DESC,
+    MathFidelity math_fidelity,
+    int THROTTLE_LEVEL = 0>
+inline void llk_math_matmul_init(
+    const std::uint32_t transpose = 0, const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1) {
+    constexpr std::uint32_t in0_tile_r_dim = IN0_DESC.shape.total_row_dim();
+    constexpr std::uint32_t in0_tile_c_dim = IN0_DESC.shape.total_col_dim();
+    constexpr std::uint32_t in1_tile_r_dim = IN1_DESC.shape.total_row_dim();
+    constexpr std::uint32_t in1_tile_c_dim = IN1_DESC.shape.total_col_dim();
+    // Shared derivation (internal/llk_descriptor.h) so MATH and UNPACK agree; == legacy (in0 tile_r < FACE_R_DIM).
+    constexpr bool partial_face = ckernel::experimental::matmul_partial_face(IN0_DESC);
+
+    llk_math_matmul_init_impl<math_fidelity, THROTTLE_LEVEL>(
+        in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, transpose, ct_dim, rt_dim);
+}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_math_unary_datacopy.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_math_unary_datacopy.h
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "llk_math_unary_datacopy_api.h"  // legacy CB-id API + unified datacopy impls
+#include "data_format_derive.h"
+#include "api/compute/experimental/2_0/internal/llk_descriptor.h"
+
+/*************************************************************************
+ * LLK ELTWISE UNARY DATACOPY -- LLKOperand (id-free, compile-time NTTP) overloads
+ *
+ * Same function names as the CB-id API (llk_math_eltwise_unary_datacopy / _init), distinguished by
+ * taking an LLKMemDescriptor as the first NTTP. MATH never touches L1, so DESC (format + geometry) is all
+ * it consumes; the register format is derived HERE from DESC.format + the fp32-dest-acc flag and never
+ * exposed above the LLK. Both overloads forward to the same unified cores as the CB-id API.
+ *************************************************************************/
+
+template <
+    ckernel::experimental::LLKMemDescriptor DESC,
+    DataCopyType type = DataCopyType::A2D,
+    bool is_fp32_dest_acc_en = false,
+    BroadcastType src_b_bcast_type = BroadcastType::NONE,
+    bool is_int_fpu_en = false,
+    PackMode pack_mode = PackMode::Default>
+inline void llk_math_eltwise_unary_datacopy_init() {
+    constexpr std::uint8_t RegFmt = ckernel::infer_unpack_reg_fmt(DESC.format, is_fp32_dest_acc_en);
+    llk_math_eltwise_unary_datacopy_init_impl<type, is_fp32_dest_acc_en, src_b_bcast_type, is_int_fpu_en, pack_mode>(
+        DESC.shape.total_num_faces(), RegFmt);
+}
+
+template <
+    ckernel::experimental::LLKMemDescriptor DESC,
+    DataCopyType type = DataCopyType::A2D,
+    bool is_fp32_dest_acc_en = false,
+    BroadcastType src_b_bcast_type = BroadcastType::NONE,
+    bool unpack_to_dest = false>
+inline void llk_math_eltwise_unary_datacopy(std::uint32_t dst_index) {
+    constexpr std::uint8_t RegFmt = ckernel::infer_unpack_reg_fmt(DESC.format, is_fp32_dest_acc_en);
+    llk_math_eltwise_unary_datacopy_impl<type, is_fp32_dest_acc_en, src_b_bcast_type, unpack_to_dest>(
+        dst_index, static_cast<std::uint32_t>(DESC.format), RegFmt);
+}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_pack_tile.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_pack_tile.h
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "llk_pack_tile_api.h"  // legacy CB-id API + unified llk_pack_init_impl / llk_pack_impl
+#include "llk_pack_rows_api.h"  // legacy CB-id row pack + raw _llk_pack_rows_ / get_pack_dest_max_tiles
+#include "data_format_derive.h"
+#include "api/compute/experimental/2_0/internal/llk_descriptor.h"
+
+/*************************************************************************
+ * LLK PACK -- LLKOperand (id-free, compile-time NTTP) overloads
+ *
+ * Same function names as the CB-id API (llk_pack_init / llk_pack), distinguished by taking an
+ * LLKMemDescriptor as the first NTTP. DESC carries the output buffer L1 format + geometry; the Dest
+ * register format is derived HERE from DESC.format + the fp32-dest-acc flag and never exposed above the
+ * LLK. Both overloads forward to the same unified cores as the CB-id API. The runtime write address
+ * comes from the caller via cb_operand_helpers.h::cb_write_address (absolute/out-of-order) -- no fifo bookkeeping.
+ *************************************************************************/
+
+template <
+    ckernel::experimental::LLKMemDescriptor DESC,
+    bool is_fp32_dest_acc_en = false,
+    PackMode pack_mode = PackMode::Default,
+    bool zero_output = false,
+    bool skip_addrmod_config = false,
+    bool skip_packer_strides = false>
+inline void llk_pack_init(const std::uint32_t num_tiles = 1) {
+    static_assert(
+        pack_mode != PackMode::Tilize,
+        "single-descriptor llk_pack_init cannot do PackMode::Tilize -- the 8-bit tilize workaround needs the "
+        "input operand's format; use the two-descriptor (OUT_DESC, IN_DESC) overload.");
+    constexpr std::uint8_t RegFmt = ckernel::infer_pack_reg_fmt(DESC.format, is_fp32_dest_acc_en);
+    // is_input_8bit_format only affects the tilize workaround; irrelevant for PackMode::Default datacopy.
+    constexpr bool is_input_8bit_format = false;
+    llk_pack_init_impl<pack_mode, zero_output, skip_addrmod_config, skip_packer_strides>(
+        RegFmt,
+        DESC.shape.face_r_dim,
+        DESC.shape.total_col_dim(),
+        DESC.shape.total_num_faces(),
+        num_tiles,
+        is_input_8bit_format);
+}
+
+// Tilize pack init (id-free): the packer format/geometry come from the OUTPUT descriptor, but the
+// 8-bit tilize workaround depends on the INPUT (untilized) operand's L1 format -- so this overload takes
+// BOTH descriptors. Distinguished from the single-DESC llk_pack_init above by the second LLKMemDescriptor
+// NTTP. Mirrors the CB-id llk_pack_init<PackMode::Tilize>(ocb, num_tiles, icb).
+template <
+    ckernel::experimental::LLKMemDescriptor OUT_DESC,
+    ckernel::experimental::LLKMemDescriptor IN_DESC,
+    bool is_fp32_dest_acc_en = false,
+    PackMode pack_mode = PackMode::Tilize,
+    bool zero_output = false,
+    bool skip_addrmod_config = false,
+    bool skip_packer_strides = false>
+inline void llk_pack_init(const std::uint32_t num_tiles = 1) {
+    constexpr std::uint8_t RegFmt = ckernel::infer_pack_reg_fmt(OUT_DESC.format, is_fp32_dest_acc_en);
+    constexpr bool is_input_8bit_format = IS_8BIT_FORMAT(static_cast<std::uint32_t>(IN_DESC.format));
+    llk_pack_init_impl<pack_mode, zero_output, skip_addrmod_config, skip_packer_strides>(
+        RegFmt,
+        OUT_DESC.shape.face_r_dim,
+        OUT_DESC.shape.total_col_dim(),
+        OUT_DESC.shape.total_num_faces(),
+        num_tiles,
+        is_input_8bit_format);
+}
+
+// DESC is required only to disambiguate this overload from the CB-id llk_pack (same runtime arg count);
+// the pack op itself needs only the runtime write address (format/geometry were set at llk_pack_init).
+template <
+    ckernel::experimental::LLKMemDescriptor DESC,
+    bool is_fp32_dest_acc_en = false,
+    bool out_of_order_output = false,
+    PackMode pack_mode = PackMode::Default>
+inline void llk_pack(std::uint32_t tile_index, std::uint32_t base_ptr) {
+    llk_pack_impl<is_fp32_dest_acc_en, pack_mode>(tile_index, base_ptr);
+}
+
+// Id-free row pack: packs the configured number of rows (set via the CB-id llk_pack_rows_init, which is
+// format-free) from DST[dst_index] to the absolute L1 address base_ptr in row-major order. The DESC NTTP
+// disambiguates this overload from the CB-id llk_pack_rows (same runtime arg count) and carries the output
+// L1 format/geometry -- but the row-pack HW path needs NO format register (formats were programmed at
+// hw_startup/pack_init), so DESC is not read here. Mirrors the CB-id llk_pack_rows minus the CB->address
+// resolution (base_ptr is supplied absolute, e.g. cb_write_address) and the CB-array format debug assert
+// (not reproducible id-free), keeping the retained DST-capacity bound check.
+template <ckernel::experimental::LLKMemDescriptor DESC>
+inline void llk_pack_rows(std::uint32_t dst_index, std::uint32_t base_ptr) {
+    LLK_ASSERT(
+        (dst_index < get_pack_dest_max_tiles<DST_SYNC_MODE>()),
+        "Dst tile exceeds packer destination capacity for the configured W-stride.");
+    _llk_pack_rows_(dst_index, base_ptr);
+}
+
+// Id-free packer data-format reconfigure: reprogram the packer's src/dst format registers + tile geometry
+// from an output LLKMemDescriptor, mirroring the CB-id llk_pack_reconfig_data_format(new_output). Unlike
+// llk_pack_init (which does NOT touch the format registers -- only addrmod/mop/strides), this programs the
+// out/in data formats, dest-read control and exp/section sizes. Used by the id-free pack_untilize init so
+// the packer formats are correct regardless of the prior op (the CB-id path calls reconfig for the same
+// reason). tile_size is the one-tile L1 size derived from the descriptor via tile_stride_words (the id-free
+// stand-in for fifo_page_size): geometry-exact for linear formats, exp section included for block floats.
+template <ckernel::experimental::LLKMemDescriptor DESC, bool is_fp32_dest_acc_en = false>
+inline void llk_pack_reconfig_data_format() {
+    constexpr std::uint8_t RegFmt = ckernel::infer_pack_reg_fmt(DESC.format, is_fp32_dest_acc_en);
+    // tile_size in 16B words (fifo_page_size units) == a single tile's L1 size.
+    constexpr std::uint32_t tile_size = ckernel::experimental::tile_stride_words(DESC.format, DESC.shape);
+    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(
+        RegFmt,
+        static_cast<std::uint32_t>(DESC.format),
+        tile_size,
+        DESC.shape.total_col_dim(),
+        DESC.shape.total_num_faces(),
+        false /* partial_face */);
+}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_pack_untilize.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_pack_untilize.h
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "llk_pack_untilize_api.h"  // legacy CB-id API + unified llk_pack_untilize_*_impl cores
+#include "data_format_derive.h"
+#include "api/compute/experimental/2_0/internal/llk_descriptor.h"
+
+/*************************************************************************
+ * LLK PACK UNTILIZE -- LLKOperand (id-free, compile-time NTTP) overloads
+ *
+ * Same function names as the CB-id API (llk_pack_untilize_init / llk_pack_untilize / _uninit),
+ * distinguished by taking an LLKMemDescriptor (the OUTPUT buffer L1 format + geometry) as the first NTTP.
+ * The dest-register (pack src) format is derived HERE from DESC.format + the fp32-dest-acc flag and never
+ * exposed above the LLK. All three forward to the same unified cores as the CB-id API. The runtime write
+ * base pointer comes from the caller via cb_operand_helpers.h::cb_write_address (absolute/out-of-order).
+ *
+ * ADDRESSING ASSUMPTION (documented at the compute layer, 2_0/pack_untilize.h): the id-free op has no CB
+ * handle, so the per-tile-row output stride (page_stride) is derived from the output descriptor via
+ * tile_stride_words == one tile's L1 size. Correct for linear formats (geometry-exact) and block floats
+ * (exp section included); the remaining edge is padded/multi-tile pages, which no shipping factory uses.
+ *************************************************************************/
+
+template <
+    ckernel::experimental::LLKMemDescriptor OUT_DESC,
+    bool is_fp32_dest_acc_en = false,
+    std::uint32_t block_ct_dim = 8,
+    std::uint32_t full_ct_dim = block_ct_dim,
+    bool narrow_row = false,
+    std::uint32_t row_num_datums = TILE_C_DIM,
+    bool dense = false>
+inline void llk_pack_untilize_init() {
+    constexpr std::uint8_t RegFmt = ckernel::infer_pack_reg_fmt(OUT_DESC.format, is_fp32_dest_acc_en);
+    llk_pack_untilize_init_impl<block_ct_dim, full_ct_dim, narrow_row, row_num_datums, dense>(
+        RegFmt,
+        static_cast<std::uint32_t>(OUT_DESC.format),
+        OUT_DESC.shape.face_r_dim,
+        OUT_DESC.shape.total_num_faces());
+}
+
+template <
+    ckernel::experimental::LLKMemDescriptor OUT_DESC,
+    bool is_fp32_dest_acc_en = false,
+    std::uint32_t block_ct_dim = 8,
+    std::uint32_t full_ct_dim = block_ct_dim,
+    bool narrow_row = false,
+    std::uint32_t row_num_datums = TILE_C_DIM,
+    std::uint32_t tile_dst_ct_offset = 0,
+    bool dense = false>
+inline void llk_pack_untilize(
+    std::uint32_t block_rt_dim,
+    std::uint32_t base_ptr,
+    const std::uint32_t block_c_index = 0,
+    const std::uint32_t tile_dst_rt_offset = 0) {
+    constexpr std::uint8_t RegFmt = ckernel::infer_pack_reg_fmt(OUT_DESC.format, is_fp32_dest_acc_en);
+    // Per tile-row output stride, folded to a compile-time constant. Replaces the legacy
+    // full_ct_dim * fifo_page_size; tile_stride_words is the one-tile L1 size (exp section included for BFP).
+    constexpr std::uint32_t page_stride =
+        full_ct_dim * ckernel::experimental::tile_stride_words(OUT_DESC.format, OUT_DESC.shape);
+    llk_pack_untilize_impl<block_ct_dim, full_ct_dim, narrow_row, row_num_datums, tile_dst_ct_offset, dense>(
+        block_rt_dim,
+        base_ptr,
+        RegFmt,
+        static_cast<std::uint32_t>(OUT_DESC.format),
+        page_stride,
+        OUT_DESC.shape.face_r_dim,
+        OUT_DESC.shape.total_num_faces(),
+        block_c_index,
+        tile_dst_rt_offset);
+}
+
+template <ckernel::experimental::LLKMemDescriptor OUT_DESC, bool is_fp32_dest_acc_en = false>
+inline void llk_pack_untilize_uninit() {
+    constexpr std::uint8_t RegFmt = ckernel::infer_pack_reg_fmt(OUT_DESC.format, is_fp32_dest_acc_en);
+    llk_pack_untilize_uninit_impl(RegFmt);
+}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_unpack_A.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_unpack_A.h
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "llk_unpack_A_api.h"  // legacy CB-id API + the unified llk_unpack_A_init_impl / llk_unpack_A_impl
+#include "data_format_derive.h"
+#include "api/compute/experimental/2_0/internal/llk_descriptor.h"
+
+/*************************************************************************
+ * LLK UNPACK A -- LLKOperand (id-free, compile-time NTTP) overloads
+ *
+ * Same function names as the CB-id API (llk_unpack_A_init / llk_unpack_A), distinguished by taking an
+ * LLKMemDescriptor as the first NTTP instead of a CB id. DESC carries the buffer L1 format + geometry
+ * (folds -> DCE); the SrcA register format is derived HERE from DESC.format + the fp32-dest-acc flag
+ * (data_format_derive.h) and never exposed above the LLK. Both overloads forward to the same unified
+ * cores as the CB-id API. The runtime base pointer comes from the caller via cb_operand_helpers.h::cb_read_address.
+ *************************************************************************/
+
+template <
+    ckernel::experimental::LLKMemDescriptor DESC,
+    bool is_fp32_dest_acc_en = false,
+    BroadcastType BType = BroadcastType::NONE,
+    bool acc_to_dest = false,
+    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
+    bool unpack_to_dest = false>
+inline void llk_unpack_A_init(
+    const std::uint32_t transpose_of_faces = 0, const std::uint32_t within_face_16x16_transpose = 0) {
+    constexpr std::uint8_t RegFmt = ckernel::infer_unpack_reg_fmt(DESC.format, is_fp32_dest_acc_en);
+    llk_unpack_A_init_impl<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
+        transpose_of_faces, within_face_16x16_transpose, DESC.shape, static_cast<std::uint32_t>(DESC.format), RegFmt);
+}
+
+template <
+    ckernel::experimental::LLKMemDescriptor DESC,
+    bool is_fp32_dest_acc_en = false,
+    BroadcastType BType = BroadcastType::NONE,
+    bool acc_to_dest = false,
+    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
+    bool unpack_to_dest = false>
+inline void llk_unpack_A(std::uint32_t base_ptr) {
+    constexpr std::uint8_t RegFmt = ckernel::infer_unpack_reg_fmt(DESC.format, is_fp32_dest_acc_en);
+    llk_unpack_A_impl<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
+        base_ptr, static_cast<std::uint32_t>(DESC.format), RegFmt);
+}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_unpack_AB.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_unpack_AB.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "llk_unpack_AB_api.h"  // legacy CB-id API + unified llk_unpack_AB_init_impl / llk_unpack_AB_impl
+#include "api/compute/experimental/2_0/internal/llk_descriptor.h"
+
+/*************************************************************************
+ * LLK UNPACK AB -- LLKOperand (id-free, compile-time NTTP) overloads
+ *
+ * Same function names as the CB-id API (llk_unpack_AB_init / llk_unpack_AB), distinguished by taking an
+ * LLKMemDescriptor (of operand A -- the shape source, mirroring the CB-id API) as the first NTTP. AB unpack
+ * is FORMAT-FREE at the op level (src/dst formats are programmed once at compute_kernel_hw_startup), so the
+ * op forwards only the two runtime L1 base pointers (from cb_operand_helpers.h::cb_read_address). Both
+ * overloads forward to the same unified cores as the CB-id API. NONE / COL / SCALAR need no operand-B format;
+ * the ROW broadcast path additionally consumes operand B's L1 format, passed as the OperandBFormat NTTP (the
+ * id-free stand-in for the CB-id API's unpack_src_format[operandB_id]); it is [[maybe_unused]] for the others.
+ *************************************************************************/
+
+template <ckernel::experimental::LLKMemDescriptor DESC_A, BroadcastType BType = BroadcastType::NONE>
+inline void llk_unpack_AB_init(const ckernel::Transpose transpose = ckernel::Transpose::None) {
+    llk_unpack_AB_init_impl<BType>(DESC_A.shape, transpose);
+}
+
+template <
+    ckernel::experimental::LLKMemDescriptor DESC_A,
+    BroadcastType BType = BroadcastType::NONE,
+    std::uint8_t OperandBFormat = 0>
+inline void llk_unpack_AB(std::uint32_t base_ptr_a, std::uint32_t base_ptr_b, std::uint32_t bcast_row_idx = 0) {
+    llk_unpack_AB_impl<BType>(base_ptr_a, base_ptr_b, bcast_row_idx, OperandBFormat);
+}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_unpack_AB_matmul.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_unpack_AB_matmul.h
@@ -21,14 +21,17 @@
  *     partial_face_b from IN0 (mirrors the legacy execute's operand wiring exactly, incl. its known quirk).
  *
  * ASSUMPTIONS (documented at the compute layer, 2_0/matmul.h):
- *   - partial_face is derived as (total_row_dim() < FACE_R_DIM) -- the same rule MATH already uses in
- *     llk_math_matmul_init; equals the host unpack_partial_face[] for the tested full tiles.
+ *   - partial_face is derived inline as (total_row_dim() < TILE_R_DIM), matching the legacy CB-id path, which
+ *     feeds the unpacker the host-side Tile::partial_face (tile height < TILE_HEIGHT) via
+ *     get_operand_partial_face(). This is INTENTIONALLY a looser threshold than the MATH engine's rule
+ *     (llk_math_matmul.h uses < FACE_R_DIM): a one-face-high tile (total_row_dim() == 16) is partial-face to the
+ *     unpacker but full-face to the math. The divergence is inherited from legacy; do not unify the two.
  *   - per-tile size derived from the descriptor (fifo_page_size == a single tile's size; exact for linear
  *     formats, single-tile test path never applies the multiplier).
  *************************************************************************/
 
-// matmul_partial_face / matmul_tile_size are shared helpers in internal/llk_descriptor.h (used by both the
-// matmul unpack here and the matmul math), so they are derived identically in one place.
+// matmul_tile_size is a shared helper in internal/llk_descriptor.h. partial_face is derived INLINE below
+// (< TILE_R_DIM) rather than via a helper -- the UNPACK/MATH threshold divergence is documented there.
 
 template <ckernel::experimental::LLKMemDescriptor IN0_DESC, ckernel::experimental::LLKMemDescriptor IN1_DESC>
 inline void llk_unpack_AB_matmul_init(
@@ -46,8 +49,8 @@ inline void llk_unpack_AB_matmul_init(
         IN0_DESC.shape.face_r_dim,
         IN1_DESC.shape.total_num_faces(),
         IN0_DESC.shape.total_num_faces(),
-        ckernel::experimental::matmul_partial_face(IN1_DESC),
-        ckernel::experimental::matmul_partial_face(IN0_DESC));
+        IN1_DESC.shape.total_row_dim() < ckernel::TILE_R_DIM,   // partial_face_a (SrcA <- IN1)
+        IN0_DESC.shape.total_row_dim() < ckernel::TILE_R_DIM);  // partial_face_b (SrcB <- IN0)
 }
 
 template <ckernel::experimental::LLKMemDescriptor IN0_DESC, ckernel::experimental::LLKMemDescriptor IN1_DESC>
@@ -68,8 +71,8 @@ inline void llk_unpack_AB_matmul(
         tile_index_in1,
         ckernel::experimental::matmul_tile_size(IN0_DESC),
         ckernel::experimental::matmul_tile_size(IN1_DESC),
-        ckernel::experimental::matmul_partial_face(IN1_DESC),
-        ckernel::experimental::matmul_partial_face(IN0_DESC),
+        IN1_DESC.shape.total_row_dim() < ckernel::TILE_R_DIM,  // partial_face_a (SrcA <- IN1)
+        IN0_DESC.shape.total_row_dim() < ckernel::TILE_R_DIM,  // partial_face_b (SrcB <- IN0)
         ct_dim,
         rt_dim,
         kt_dim);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_unpack_AB_matmul.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_unpack_AB_matmul.h
@@ -30,8 +30,8 @@
  *     formats, single-tile test path never applies the multiplier).
  *************************************************************************/
 
-// matmul_tile_size is a shared helper in internal/llk_descriptor.h. partial_face is derived INLINE below
-// (< TILE_R_DIM) rather than via a helper -- the UNPACK/MATH threshold divergence is documented there.
+// partial_face is derived INLINE below (< TILE_R_DIM) rather than via a helper -- the UNPACK/MATH
+// threshold divergence is documented in llk_descriptor.h.
 
 template <ckernel::experimental::LLKMemDescriptor IN0_DESC, ckernel::experimental::LLKMemDescriptor IN1_DESC>
 inline void llk_unpack_AB_matmul_init(
@@ -69,8 +69,8 @@ inline void llk_unpack_AB_matmul(
         base_ptr_in1,
         tile_index_in0,
         tile_index_in1,
-        ckernel::experimental::matmul_tile_size(IN0_DESC),
-        ckernel::experimental::matmul_tile_size(IN1_DESC),
+        ckernel::experimental::tile_stride_words(IN0_DESC.format, IN0_DESC.shape),
+        ckernel::experimental::tile_stride_words(IN1_DESC.format, IN1_DESC.shape),
         IN1_DESC.shape.total_row_dim() < ckernel::TILE_R_DIM,  // partial_face_a (SrcA <- IN1)
         IN0_DESC.shape.total_row_dim() < ckernel::TILE_R_DIM,  // partial_face_b (SrcB <- IN0)
         ct_dim,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_unpack_AB_matmul.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_unpack_AB_matmul.h
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "llk_unpack_AB_matmul_api.h"  // legacy CB-id API + unified llk_unpack_AB_matmul_{init_,}impl
+#include "api/compute/experimental/2_0/internal/llk_descriptor.h"
+
+/*************************************************************************
+ * LLK UNPACK AB MATMUL -- LLKOperand (id-free, compile-time NTTP) overloads
+ *
+ * Same function names as the CB-id API, distinguished by two LLKMemDescriptor NTTPs: IN0_DESC (-> SrcB) and
+ * IN1_DESC (-> SrcA). Matmul unpack is FORMAT-FREE at the op level (formats set at
+ * compute_kernel_hw_startup<SrcOrder::Reverse>), so these forward only geometry + addresses + per-tile sizes.
+ *
+ * ROLE SWAP (preserved from legacy): in0 -> SrcB, in1 -> SrcA.
+ *   - init: "unpA"(SrcA) geometry comes from IN1, "unpB"(SrcB) from IN0.
+ *   - execute: base_a/tile_size_a from IN0, base_b/tile_size_b from IN1, but partial_face_a from IN1 and
+ *     partial_face_b from IN0 (mirrors the legacy execute's operand wiring exactly, incl. its known quirk).
+ *
+ * ASSUMPTIONS (documented at the compute layer, 2_0/matmul.h):
+ *   - partial_face is derived as (total_row_dim() < FACE_R_DIM) -- the same rule MATH already uses in
+ *     llk_math_matmul_init; equals the host unpack_partial_face[] for the tested full tiles.
+ *   - per-tile size derived from the descriptor (fifo_page_size == a single tile's size; exact for linear
+ *     formats, single-tile test path never applies the multiplier).
+ *************************************************************************/
+
+// matmul_partial_face / matmul_tile_size are shared helpers in internal/llk_descriptor.h (used by both the
+// matmul unpack here and the matmul math), so they are derived identically in one place.
+
+template <ckernel::experimental::LLKMemDescriptor IN0_DESC, ckernel::experimental::LLKMemDescriptor IN1_DESC>
+inline void llk_unpack_AB_matmul_init(
+    const std::uint32_t transpose = 0,
+    const std::uint32_t ct_dim = 1,
+    const std::uint32_t rt_dim = 1,
+    const std::uint32_t kt_dim = 1) {
+    // unpA(SrcA) <- IN1, unpB(SrcB) <- IN0.
+    llk_unpack_AB_matmul_init_impl(
+        transpose,
+        ct_dim,
+        rt_dim,
+        kt_dim,
+        IN1_DESC.shape.face_r_dim,
+        IN0_DESC.shape.face_r_dim,
+        IN1_DESC.shape.total_num_faces(),
+        IN0_DESC.shape.total_num_faces(),
+        ckernel::experimental::matmul_partial_face(IN1_DESC),
+        ckernel::experimental::matmul_partial_face(IN0_DESC));
+}
+
+template <ckernel::experimental::LLKMemDescriptor IN0_DESC, ckernel::experimental::LLKMemDescriptor IN1_DESC>
+inline void llk_unpack_AB_matmul(
+    std::uint32_t base_ptr_in0,
+    std::uint32_t base_ptr_in1,
+    std::uint32_t tile_index_in0,
+    std::uint32_t tile_index_in1,
+    const std::uint32_t ct_dim = 1,
+    const std::uint32_t rt_dim = 1,
+    const std::uint32_t kt_dim = 1) {
+    // Legacy execute wiring: base_a/tile_size_a <- IN0, base_b/tile_size_b <- IN1; partial_face_a <- IN1,
+    // partial_face_b <- IN0 (preserved verbatim, including the "TODO: Review RT" quirk).
+    llk_unpack_AB_matmul_impl(
+        base_ptr_in0,
+        base_ptr_in1,
+        tile_index_in0,
+        tile_index_in1,
+        ckernel::experimental::matmul_tile_size(IN0_DESC),
+        ckernel::experimental::matmul_tile_size(IN1_DESC),
+        ckernel::experimental::matmul_partial_face(IN1_DESC),
+        ckernel::experimental::matmul_partial_face(IN0_DESC),
+        ct_dim,
+        rt_dim,
+        kt_dim);
+}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_unpack_tilize.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/2_0/llk_unpack_tilize.h
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "llk_unpack_tilize_api.h"  // legacy CB-id API + unified llk_unpack_tilize_init_impl / llk_unpack_tilize_impl
+#include "data_format_derive.h"
+#include "api/compute/experimental/2_0/internal/llk_descriptor.h"
+
+/*************************************************************************
+ * LLK UNPACK TILIZE -- LLKOperand (id-free, compile-time NTTP) overloads
+ *
+ * Same function names as the CB-id API (llk_unpack_tilize_init / llk_unpack_tilize), distinguished by
+ * taking an LLKMemDescriptor as the first NTTP. DESC carries the input buffer L1 format + tile geometry;
+ * the SrcA register (dst) format is derived HERE from DESC.format + the fp32-dest-acc flag and never
+ * exposed above the LLK. narrow_tile is derived from the tile geometry (a single face-column wide tile
+ * is narrow). The runtime base address comes from the caller (cb_operand_helpers.h::cb_read_address).
+ *************************************************************************/
+
+template <ckernel::experimental::LLKMemDescriptor DESC, bool is_fp32_dest_acc_en = false>
+inline void llk_unpack_tilize_init(const std::uint32_t ct_dim) {
+    constexpr std::uint8_t RegFmt = ckernel::infer_unpack_reg_fmt(DESC.format, is_fp32_dest_acc_en);
+    constexpr bool narrow_tile = (DESC.shape.num_faces_c_dim == 1);
+    llk_unpack_tilize_init_impl(
+        static_cast<std::uint32_t>(DESC.format),
+        RegFmt,
+        ct_dim,
+        DESC.shape.face_r_dim,
+        narrow_tile,
+        DESC.shape.total_num_faces());
+}
+
+template <ckernel::experimental::LLKMemDescriptor DESC, bool is_fp32_dest_acc_en = false>
+inline void llk_unpack_tilize(const std::uint32_t base_address, const std::uint32_t tile_index) {
+    constexpr std::uint8_t RegFmt = ckernel::infer_unpack_reg_fmt(DESC.format, is_fp32_dest_acc_en);
+    constexpr bool narrow_tile = (DESC.shape.num_faces_c_dim == 1);
+    llk_unpack_tilize_impl(
+        base_address,
+        tile_index,
+        static_cast<std::uint32_t>(DESC.format),
+        RegFmt,
+        DESC.shape.face_r_dim,
+        DESC.shape.total_num_faces(),
+        narrow_tile);
+}
+
+template <ckernel::experimental::LLKMemDescriptor DESC, bool is_fp32_dest_acc_en = false>
+inline void llk_unpack_tilize_uninit() {
+    constexpr std::uint8_t RegFmt = ckernel::infer_unpack_reg_fmt(DESC.format, is_fp32_dest_acc_en);
+    llk_unpack_tilize_uninit_impl(RegFmt, DESC.shape);
+}

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_binary_api.h
@@ -3,12 +3,47 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_math_common_api.h"
 #include "llk_math_eltwise_binary.h"
 
 /*************************************************************************
  * LLK ELTWISE BINARY
  *************************************************************************/
+
+// Unified cores, shared by the CB-id API below and the LLKOperand API (experimental/2_0/). Eltwise binary
+// math is FORMAT-FREE: it consumes only the tile geometry (from operand A) -- the register formats live in
+// the unpacker/dest config set at compute_kernel_hw_startup. The per-source prologue (resolving the shape
+// from a CB id, or from an LLKMemDescriptor) lives in the callers.
+template <
+    EltwiseBinaryType eltwise_binary_type,
+    BroadcastType src_b_bcast_type,
+    MathFidelity math_fidelity,
+    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
+inline void llk_math_eltwise_binary_init_impl(
+    const ckernel::TensorShape& tensor_shape, const std::uint32_t acc_to_dest) {
+    constexpr auto effective_math_fidelity = get_effective_math_fidelity<eltwise_binary_type, math_fidelity>();
+    _llk_math_eltwise_binary_init_<eltwise_binary_type, src_b_bcast_type, effective_math_fidelity, binary_reuse_dest>(
+        tensor_shape, acc_to_dest);
+}
+
+template <
+    EltwiseBinaryType eltwise_binary_type,
+    BroadcastType src_b_bcast_type,
+    bool is_fp32_dest_acc_en,
+    MathFidelity math_fidelity,
+    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
+inline void llk_math_eltwise_binary_impl(
+    const ckernel::TensorShape& tensor_shape, std::uint32_t dst_index, const bool clear_fp32_dst_acc) {
+    constexpr auto effective_math_fidelity = get_effective_math_fidelity<eltwise_binary_type, math_fidelity>();
+    _llk_math_eltwise_binary_<
+        eltwise_binary_type,
+        src_b_bcast_type,
+        DST_SYNC_MODE,
+        is_fp32_dest_acc_en,
+        effective_math_fidelity,
+        binary_reuse_dest>(tensor_shape, dst_index, clear_fp32_dst_acc);
+}
 
 /**
  * @brief Initialize FPU to perform an elementwise binary operation where Output = SrcA [+, -, *] SrcB.
@@ -35,8 +70,7 @@ inline void llk_math_eltwise_binary_init(
     const std::uint32_t operand_id = get_operand_id(operand_A);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
 
-    constexpr auto effective_math_fidelity = get_effective_math_fidelity<eltwise_binary_type, math_fidelity>();
-    _llk_math_eltwise_binary_init_<eltwise_binary_type, src_b_bcast_type, effective_math_fidelity, binary_reuse_dest>(
+    llk_math_eltwise_binary_init_impl<eltwise_binary_type, src_b_bcast_type, math_fidelity, binary_reuse_dest>(
         tensor_shape, acc_to_dest);
 }
 
@@ -46,7 +80,7 @@ template <
     bool is_fp32_dest_acc_en,
     MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
-inline void llk_math_eltwise_binary(uint dst_index, const bool clear_fp32_dst_acc = true) {
+inline void llk_math_eltwise_binary(std::uint32_t dst_index, const bool clear_fp32_dst_acc = true) {
     // DPRINT("llk_math_eltwise_binary: dst_index = {}, max dest tiles = {}\n",
     //     dst_index,
     //     get_dest_max_tiles_rt<DST_SYNC_MODE, DstTileShape::Tile32x32>());
@@ -56,13 +90,11 @@ inline void llk_math_eltwise_binary(uint dst_index, const bool clear_fp32_dst_ac
         "llk_math_eltwise_binary: dst index exceeds available dest register capacity. Uncomment the DPRINT "
         "block above and enable DPRINT support to inspect the dst index and max dest tile values.");
 
-    constexpr auto effective_math_fidelity = get_effective_math_fidelity<eltwise_binary_type, math_fidelity>();
-    _llk_math_eltwise_binary_<
+    llk_math_eltwise_binary_impl<
         eltwise_binary_type,
         src_b_bcast_type,
-        DST_SYNC_MODE,
         is_fp32_dest_acc_en,
-        effective_math_fidelity,
+        math_fidelity,
         binary_reuse_dest>(ckernel::DEFAULT_TENSOR_SHAPE, dst_index, clear_fp32_dst_acc);
 }
 
@@ -73,7 +105,10 @@ template <
     MathFidelity math_fidelity,
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE>
 inline void llk_math_eltwise_binary(
-    const std::uint32_t operand_A, const std::uint32_t operand_B, uint dst_index, const bool clear_fp32_dst_acc) {
+    const std::uint32_t operand_A,
+    const std::uint32_t operand_B,
+    std::uint32_t dst_index,
+    const bool clear_fp32_dst_acc) {
     // DPRINT("llk_math_eltwise_binary: dst_index = {}, max dest tiles = {}\n",
     //     dst_index,
     //     get_dest_max_tiles_rt<DST_SYNC_MODE, DstTileShape::Tile32x32>());
@@ -86,12 +121,10 @@ inline void llk_math_eltwise_binary(
     const std::uint32_t operand_id = get_operand_id(operand_A);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
 
-    constexpr auto effective_math_fidelity = get_effective_math_fidelity<eltwise_binary_type, math_fidelity>();
-    _llk_math_eltwise_binary_<
+    llk_math_eltwise_binary_impl<
         eltwise_binary_type,
         src_b_bcast_type,
-        DST_SYNC_MODE,
         is_fp32_dest_acc_en,
-        effective_math_fidelity,
+        math_fidelity,
         binary_reuse_dest>(tensor_shape, dst_index, clear_fp32_dst_acc);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_math_common_api.h"
 #include "llk_math_matmul.h"
 #include "sanitizer/api.h"
@@ -10,6 +11,24 @@
 /*************************************************************************
  * LLK MATMUL
  *************************************************************************/
+
+// Unified core, shared by the CB-id API below and the LLKOperand API (experimental/2_0/). Matmul math is
+// FORMAT-FREE: it consumes only tile geometry (tile r/c dims + partial_face). The per-source prologue
+// (resolving these from a CB id, or from an LLKMemDescriptor) lives in the callers. The matmul math EXECUTE
+// (llk_math_matmul below) already takes no operand, so it is reused directly by the id-free API.
+template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0>
+inline void llk_math_matmul_init_impl(
+    const std::uint32_t in0_tile_r_dim,
+    const std::uint32_t in0_tile_c_dim,
+    const std::uint32_t in1_tile_r_dim,
+    const std::uint32_t in1_tile_c_dim,
+    const bool partial_face,
+    const std::uint32_t transpose,
+    const std::uint32_t ct_dim,
+    const std::uint32_t rt_dim) {
+    _llk_math_matmul_init_<math_fidelity, THROTTLE_LEVEL>(
+        in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, transpose, ct_dim, rt_dim);
+}
 
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0>
 inline void llk_math_matmul_init(
@@ -31,12 +50,13 @@ inline void llk_math_matmul_init(
     // In0/operandA -> srcB, In1/operandB -> srcA
     llk::san::math_operand_check(unpack_dst_format[in1_id], unpack_dst_format[in0_id]);
 
-    _llk_math_matmul_init_<math_fidelity, THROTTLE_LEVEL>(
+    llk_math_matmul_init_impl<math_fidelity, THROTTLE_LEVEL>(
         in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, transpose, ct_dim, rt_dim);
 }
 
-template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0, uint32_t num_faces = 4 /*not used*/>
-inline void llk_math_matmul(const uint dst_index, const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1) {
+template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0, std::uint32_t num_faces = 4 /*not used*/>
+inline void llk_math_matmul(
+    const std::uint32_t dst_index, const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1) {
     static_assert(num_faces == 4, "num_faces other than 4 is not supported in llk_math_matmul");
 
     // DPRINT("llk_math_matmul: calculated dest tiles = {}, max dest tiles = {} (dst_index={}, ct_dim={},

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
@@ -37,13 +37,19 @@ inline void llk_math_reduce(const std::uint32_t operandA, const std::uint32_t op
     _llk_math_reduce_<type, dim, is_fp32_dest_acc_en, math_fidelity, is_int_fpu_en>(dst_index, tensor_shape);
 }
 
+// Unified init core (explicit shape), shared by the CB-id API and the LLKOperand API (experimental/2_0/).
+// Reduce math is FORMAT-FREE: it consumes only operand A's tile geometry. The reduce math EXECUTE already has
+// an explicit-shape overload (llk_math_reduce(dst_index, tensor_shape)) reused directly by the id-free path.
+template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, MathFidelity math_fidelity>
+inline void llk_math_reduce_init_impl(const ckernel::TensorShape& tensor_shape) {
+    _llk_math_reduce_init_<type, dim, is_fp32_dest_acc_en, math_fidelity>(tensor_shape);
+}
+
 template <PoolType type, ReduceDim dim, bool is_fp32_dest_acc_en, MathFidelity math_fidelity>
 inline void llk_math_reduce_init(const std::uint32_t operandA, const std::uint32_t operandB) {
     const std::uint32_t operand_id = get_operand_id(operandA);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
-    _llk_math_reduce_init_<type, dim, is_fp32_dest_acc_en, math_fidelity>(tensor_shape);
+    llk_math_reduce_init_impl<type, dim, is_fp32_dest_acc_en, math_fidelity>(tensor_shape);
 }
 
-inline void llk_math_reduce_uninit() {
-    _llk_math_reduce_uninit_();
-}
+inline void llk_math_reduce_uninit() { _llk_math_reduce_uninit_(); }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -12,16 +12,42 @@
  * LLK ELTWISE UNARY DATACOPY
  *************************************************************************/
 
+// Unified cores, shared by the CB-id API below and the LLKOperand API (experimental/). They take
+// already-resolved scalar formats/geometry; the per-source prologue lives in the callers.
+template <
+    DataCopyType type,
+    bool is_fp32_dest_acc_en,
+    BroadcastType src_b_bcast_type = BroadcastType::NONE,
+    bool unpack_to_dest = false>
+inline void llk_math_eltwise_unary_datacopy_impl(
+    std::uint32_t dst_index, std::uint32_t src_format, std::uint32_t dst_format) {
+    LLK_ASSERT((dst_index < get_dest_max_tiles_rt<DST_SYNC_MODE, DstTileShape::Tile32x32>()), "");
+    _llk_math_eltwise_unary_datacopy_<type, DST_SYNC_MODE, is_fp32_dest_acc_en, src_b_bcast_type, unpack_to_dest>(
+        dst_index, src_format, dst_format);
+}
+
+template <
+    DataCopyType type,
+    bool is_fp32_dest_acc_en,
+    BroadcastType src_b_bcast_type = BroadcastType::NONE,
+    bool is_int_fpu_en = false,
+    PackMode pack_mode = PackMode::Default>
+inline void llk_math_eltwise_unary_datacopy_init_impl(std::uint32_t num_faces, std::uint32_t dst_format) {
+    static_assert(
+        pack_mode == PackMode::Default || pack_mode == PackMode::Tilize,
+        "Blackhole math datacopy init supports only PackMode::Default and PackMode::Tilize");
+    _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, is_int_fpu_en, pack_mode>(
+        num_faces, dst_format);
+}
+
 template <
     DataCopyType type,
     bool is_fp32_dest_acc_en,
     BroadcastType src_b_bcast_type = BroadcastType::NONE,
     bool unpack_to_dest = false>
 inline void llk_math_eltwise_unary_datacopy(std::uint32_t dst_index, std::uint32_t operand) {
-    LLK_ASSERT((dst_index < get_dest_max_tiles_rt<DST_SYNC_MODE, DstTileShape::Tile32x32>()), "");
-
     const std::uint32_t operand_id = get_operand_id(operand);
-    _llk_math_eltwise_unary_datacopy_<type, DST_SYNC_MODE, is_fp32_dest_acc_en, src_b_bcast_type, unpack_to_dest>(
+    llk_math_eltwise_unary_datacopy_impl<type, is_fp32_dest_acc_en, src_b_bcast_type, unpack_to_dest>(
         dst_index, unpack_src_format[operand_id], unpack_dst_format[operand_id]);
 }
 
@@ -34,7 +60,7 @@ inline void llk_math_eltwise_unary_datacopy_block(
     std::uint32_t start_dst_index, std::uint32_t ntiles, std::uint32_t operand) {
     const std::uint32_t operand_id = get_operand_id(operand);
 
-    for (uint32_t dst_index = start_dst_index; dst_index < start_dst_index + ntiles; dst_index++) {
+    for (std::uint32_t dst_index = start_dst_index; dst_index < start_dst_index + ntiles; dst_index++) {
         LLK_ASSERT((dst_index < get_dest_max_tiles_rt<DST_SYNC_MODE, DstTileShape::Tile32x32>()), "");
 
         _llk_math_eltwise_unary_datacopy_<type, DST_SYNC_MODE, is_fp32_dest_acc_en, src_b_bcast_type, unpack_to_dest>(
@@ -49,15 +75,9 @@ template <
     bool is_int_fpu_en = false,
     PackMode pack_mode = PackMode::Default>
 inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand) {
-    static_assert(
-        pack_mode == PackMode::Default || pack_mode == PackMode::Tilize,
-        "Blackhole math datacopy init supports only PackMode::Default and PackMode::Tilize");
     const std::uint32_t operand_id = get_operand_id(operand);
-    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
-    const std::uint32_t dst_format = get_operand_dst_format(operand_id);
-
-    _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, is_int_fpu_en, pack_mode>(
-        num_faces, dst_format);
+    llk_math_eltwise_unary_datacopy_init_impl<type, is_fp32_dest_acc_en, src_b_bcast_type, is_int_fpu_en, pack_mode>(
+        get_operand_num_faces(operand_id), get_operand_dst_format(operand_id));
 }
 
 template <BroadcastType src_b_bcast_type = BroadcastType::NONE, bool unpack_to_dest = false>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_reduce_api.h
@@ -3,18 +3,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_pack_common_api.h"
 
 /*************************************************************************
  * LLK PACK REDUCE
  *************************************************************************/
 
+// Unified core (explicit face_r_dim), shared by the CB-id API and the LLKOperand API (experimental/2_0/).
+template <ReduceDim dim, PackMode pack_mode = PackMode::Default>
+inline void llk_pack_reduce_mask_config_impl(const std::uint32_t face_r_dim) {
+    _llk_pack_reduce_mask_config_<dim, pack_mode>(face_r_dim);
+}
+
 // Use the runtime face_r_dim of the output CB. Required for narrow tiles
 // (e.g. tile_dimensions=[1,32]) where face_r_dim differs from FACE_R_DIM.
 template <ReduceDim dim, PackMode pack_mode = PackMode::Default>
-inline void llk_pack_reduce_mask_config(uint32_t ocb) {
+inline void llk_pack_reduce_mask_config(std::uint32_t ocb) {
     const std::uint32_t output_id = get_output_id(ocb);
-    _llk_pack_reduce_mask_config_<dim, pack_mode>(get_output_face_r_dim(output_id));
+    llk_pack_reduce_mask_config_impl<dim, pack_mode>(get_output_face_r_dim(output_id));
 }
 
 inline void llk_pack_reduce_mask_clear() { _llk_pack_reduce_mask_clear_(); }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_tile_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_tile_api.h
@@ -11,6 +11,30 @@
  * LLK PACK
  *************************************************************************/
 
+// Unified cores, shared by the CB-id API below and the LLKOperand API (experimental/). They take
+// already-resolved scalar formats/geometry + the runtime write address; the per-source prologue
+// (resolving these from a CB id, or from an MemDescriptor) lives in the callers.
+template <
+    PackMode pack_mode = PackMode::Default,
+    bool zero_output = false,
+    bool skip_addrmod_config = false,
+    bool skip_packer_strides = false>
+inline void llk_pack_init_impl(
+    const std::uint32_t pack_src_reg_format,
+    const std::uint32_t face_r_dim,
+    const std::uint32_t tile_c_dim,
+    const std::uint32_t num_faces,
+    const std::uint32_t num_tiles,
+    const bool is_input_8bit_format) {
+    _llk_pack_init_<pack_mode, zero_output, skip_addrmod_config, skip_packer_strides>(
+        pack_src_reg_format, face_r_dim, tile_c_dim, num_faces, num_tiles, is_input_8bit_format);
+}
+
+template <bool is_fp32_dest_acc_en, PackMode pack_mode = PackMode::Default>
+inline void llk_pack_impl(std::uint32_t tile_index, std::uint32_t pack_tile_addr) {
+    _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, pack_mode>(tile_index, pack_tile_addr);
+}
+
 template <
     PackMode pack_mode = PackMode::Default,
     bool zero_output = false,
@@ -20,22 +44,24 @@ inline void llk_pack_init(
     const std::uint32_t pack_output, const std::uint32_t num_tiles, const std::uint32_t input_operand) {
     // TODO (https://github.com/tenstorrent/tt-metal/issues/18948): Revisit for narrow_tile
     const std::uint32_t output_id = get_output_id(pack_output);
-    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-    const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
-    const std::uint32_t num_faces = get_output_num_faces(output_id);
 
     if constexpr (!skip_addrmod_config) {
         LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
     }
 
+    // For pack with tilize enabled, check if the original input format is 8-bit.
+    // 8-bit datums (Int8, UInt8, Fp8_e4m3, Lf8) do not require the tilize workaround on Blackhole.
     bool is_input_8bit_format = false;
     if constexpr (pack_mode == PackMode::Tilize) {
-        // 8-bit datums (Int8, UInt8, Fp8_e4m3, Lf8) do not require the tilize workaround on Blackhole.
-        const std::uint32_t src_format = static_cast<std::uint32_t>(unpack_src_format[input_operand]);
-        is_input_8bit_format = IS_8BIT_FORMAT(src_format);
+        is_input_8bit_format = IS_8BIT_FORMAT(static_cast<std::uint32_t>(unpack_src_format[input_operand]));
     }
-    _llk_pack_init_<pack_mode, zero_output, skip_addrmod_config, skip_packer_strides>(
-        pack_src_format[output_id], face_r_dim, tile_c_dim, num_faces, num_tiles, is_input_8bit_format);
+    llk_pack_init_impl<pack_mode, zero_output, skip_addrmod_config, skip_packer_strides>(
+        pack_src_format[output_id],
+        get_output_face_r_dim(output_id),
+        get_output_tile_c_dim(output_id),
+        get_output_num_faces(output_id),
+        num_tiles,
+        is_input_8bit_format);
 }
 
 // input_operand is only consumed by the Blackhole tilize workaround. Keep the common non-tilize API
@@ -77,7 +103,7 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
         llk::san::IGNORE,
         llk::san::IGNORE);
 
-    _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, pack_mode>(tile_index, pack_tile_addr);
+    llk_pack_impl<is_fp32_dest_acc_en, pack_mode>(tile_index, pack_tile_addr);
 }
 
 template <bool is_fp32_dest_acc_en, bool out_of_order_output = false, PackMode pack_mode = PackMode::Default>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_untilize_api.h
@@ -11,6 +11,66 @@
  * LLK PACK UNTILIZE
  *************************************************************************/
 
+// Unified cores, shared by the CB-id API below and the LLKOperand API (experimental/2_0/). They take
+// already-resolved scalar formats/geometry + a runtime write address / per-row stride; the per-source
+// prologue (resolving these from a CB id, or from an LLKMemDescriptor) lives in the callers. The CB-id
+// callers pass base_addr = fifo_wr_ptr - 1 and page_stride = full_ct_dim * fifo_page_size; the id-free
+// callers pass base_addr = cb_write_address(...) and a compile-time page_stride derived from the output
+// descriptor (fifo_page_size == a single tile size assumption -- see experimental/2_0/llk_pack_untilize.h).
+
+template <
+    std::uint32_t block_ct_dim = 8,
+    std::uint32_t full_ct_dim = block_ct_dim,
+    bool narrow_row = false,
+    std::uint32_t row_num_datums = TILE_C_DIM,
+    bool dense = false>
+inline void llk_pack_untilize_init_impl(
+    const std::uint32_t pack_src_format,
+    const std::uint32_t pack_dst_format,
+    const std::uint32_t face_r_dim,
+    const std::uint32_t num_faces) {
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format, pack_dst_format));
+    _llk_pack_untilize_init_<block_ct_dim, full_ct_dim, narrow_row, row_num_datums, dense>(
+        pack_src_format, pack_dst_format, face_r_dim, num_faces);
+}
+
+template <
+    std::uint32_t block_ct_dim = 8,
+    std::uint32_t full_ct_dim = block_ct_dim,
+    bool narrow_row = false,
+    std::uint32_t row_num_datums = TILE_C_DIM,
+    std::uint32_t tile_dst_ct_offset = 0,
+    bool dense = false>
+inline void llk_pack_untilize_impl(
+    const std::uint32_t block_rt_dim,
+    const std::uint32_t base_addr,
+    const std::uint32_t pack_src_format,
+    const std::uint32_t pack_dst_format,
+    const std::uint32_t page_stride,
+    const std::uint32_t face_r_dim,
+    const std::uint32_t num_faces,
+    const std::uint32_t block_c_index,
+    const std::uint32_t tile_dst_rt_offset) {
+    std::uint32_t pack_tile_addr =
+        base_addr + SCALE_DATUM_SIZE(
+                        pack_dst_format,
+                        (block_c_index * ((num_faces > 2) ? num_faces / 2 : num_faces) * block_ct_dim * FACE_C_DIM)) /
+                        16;
+
+    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format, pack_dst_format));
+
+    for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {
+        _llk_pack_untilize_<block_ct_dim, full_ct_dim, narrow_row, tile_dst_ct_offset, dense>(
+            pack_tile_addr, num_faces, block_rt * block_ct_dim + tile_dst_rt_offset);
+
+        pack_tile_addr += page_stride;
+    }
+}
+
+inline void llk_pack_untilize_uninit_impl(const std::uint32_t pack_src_format) {
+    _llk_pack_untilize_uninit_(pack_src_format);
+}
+
 /**
  * Initialize the packer for an untilize operation on the given output operand.
  *
@@ -39,9 +99,7 @@ inline void llk_pack_untilize_init(std::uint32_t output) {
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const std::uint32_t num_faces = get_output_num_faces(output_id);
 
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
-
-    _llk_pack_untilize_init_<block_ct_dim, full_ct_dim, narrow_row, row_num_datums, dense>(
+    llk_pack_untilize_init_impl<block_ct_dim, full_ct_dim, narrow_row, row_num_datums, dense>(
         pack_src_format[output_id], pack_dst_format[output_id], face_r_dim, num_faces);
 }
 
@@ -53,7 +111,7 @@ inline void llk_pack_untilize_init(std::uint32_t output) {
  */
 inline void llk_pack_untilize_uninit(std::uint32_t output) {
     const std::uint32_t output_id = get_output_id(output);
-    _llk_pack_untilize_uninit_(pack_src_format[output_id]);
+    llk_pack_untilize_uninit_impl(pack_src_format[output_id]);
 }
 
 /**
@@ -92,19 +150,15 @@ inline void llk_pack_untilize(
     const std::uint32_t output_id = get_output_id(output);
     const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
     const std::uint32_t num_faces = get_output_num_faces(output_id);
-    std::uint32_t pack_tile_addr =
-        get_local_cb_interface(output_id).fifo_wr_ptr - 1 +
-        SCALE_DATUM_SIZE(
-            pack_dst_format[output_id],
-            (block_c_index * ((num_faces > 2) ? num_faces / 2 : num_faces) * block_ct_dim * FACE_C_DIM)) /
-            16;
 
-    LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
-
-    for (std::uint32_t block_rt = 0; block_rt < block_rt_dim; block_rt++) {
-        _llk_pack_untilize_<block_ct_dim, full_ct_dim, narrow_row, tile_dst_ct_offset, dense>(
-            pack_tile_addr, num_faces, block_rt * block_ct_dim + tile_dst_rt_offset);
-
-        pack_tile_addr += full_ct_dim * get_local_cb_interface(output_id).fifo_page_size;
-    }
+    llk_pack_untilize_impl<block_ct_dim, full_ct_dim, narrow_row, row_num_datums, tile_dst_ct_offset, dense>(
+        block_rt_dim,
+        get_local_cb_interface(output_id).fifo_wr_ptr - 1,
+        pack_src_format[output_id],
+        pack_dst_format[output_id],
+        full_ct_dim * get_local_cb_interface(output_id).fifo_page_size,
+        face_r_dim,
+        num_faces,
+        block_c_index,
+        tile_dst_rt_offset);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
@@ -3,12 +3,39 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_unpack_AB.h"
 #include "llk_unpack_common_api.h"
 
 /*************************************************************************
  * LLK UNPACK AB
  *************************************************************************/
+
+// Unified cores, shared by the CB-id API below and the LLKOperand API (experimental/2_0/). They take the
+// already-resolved tile geometry / runtime addresses; the per-source prologue (resolving these from a CB id,
+// or from an LLKMemDescriptor) lives in the callers. AB unpack is format-free at the op level: the src/dst
+// formats are programmed once at compute_kernel_hw_startup, so the op needs only the two L1 addresses (plus
+// the SrcB source format for the ROW-broadcast path).
+
+template <BroadcastType BType = BroadcastType::NONE>
+inline void llk_unpack_AB_init_impl(const ckernel::TensorShape& tensor_shape, const ckernel::Transpose transpose) {
+    _llk_unpack_AB_init_<BType>(tensor_shape, transpose);
+}
+
+template <BroadcastType BType = BroadcastType::NONE>
+inline void llk_unpack_AB_impl(
+    const std::uint32_t address_a,
+    const std::uint32_t address_b,
+    [[maybe_unused]] const std::uint32_t bcast_row_idx,
+    [[maybe_unused]] const std::uint32_t operandB_src_format) {
+    WAYPOINT("UABW");
+    if constexpr (BType == BroadcastType::ROW) {
+        _llk_unpack_AB_<BType>(address_a, address_b, bcast_row_idx, operandB_src_format);
+    } else {
+        _llk_unpack_AB_<BType>(address_a, address_b);
+    }
+    WAYPOINT("UABD");
+}
 
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_init(
@@ -26,7 +53,7 @@ inline void llk_unpack_AB_init(
         get_operand_num_faces(operandA_id),
         get_operand_num_faces(get_operand_id(operandB))));
 
-    _llk_unpack_AB_init_<BType>(tensor_shape, transpose);
+    llk_unpack_AB_init_impl<BType>(tensor_shape, transpose);
 }
 
 template <BroadcastType BType = BroadcastType::NONE>
@@ -40,7 +67,7 @@ inline void llk_unpack_AB(
     const std::uint32_t operandB,
     const std::uint32_t tile_index_a,
     const std::uint32_t tile_index_b,
-    [[maybe_unused]] const std::uint32_t bcast_row_idx = 0) {
+    const std::uint32_t bcast_row_idx = 0) {
     std::uint32_t operandA_id = get_operand_id(operandA);
     std::uint32_t operandB_id = get_operand_id(operandB);
     std::uint32_t base_address_a = get_local_cb_interface(operandA_id).fifo_rd_ptr - 1;
@@ -63,11 +90,5 @@ inline void llk_unpack_AB(
         get_operand_num_faces(operandA_id),
         get_operand_num_faces(operandB_id)));
 
-    WAYPOINT("UABW");
-    if constexpr (BType == BroadcastType::ROW) {
-        _llk_unpack_AB_<BType>(address_a, address_b, bcast_row_idx, unpack_src_format[operandB_id]);
-    } else {
-        _llk_unpack_AB_<BType>(address_a, address_b);
-    }
-    WAYPOINT("UABD");
+    llk_unpack_AB_impl<BType>(address_a, address_b, bcast_row_idx, unpack_src_format[operandB_id]);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_unpack_AB_matmul.h"
 #include "llk_unpack_common_api.h"
 #include "sanitizer/api.h"
@@ -10,6 +11,62 @@
 /*************************************************************************
  * LLK UNPACK AB MATMUL
  *************************************************************************/
+
+// Unified cores, shared by the CB-id API below and the LLKOperand API (experimental/2_0/). Matmul unpack is
+// FORMAT-FREE at the op level (src/dst formats are programmed at compute_kernel_hw_startup<SrcOrder::Reverse>),
+// so the cores take only the already-resolved geometry (face_r_dim / num_faces / partial_face per src) +
+// runtime addresses + per-tile sizes. The role swap (in0 -> SrcB, in1 -> SrcA) is applied by the callers.
+inline void llk_unpack_AB_matmul_init_impl(
+    const std::uint32_t transpose,
+    const std::uint32_t ct_dim,
+    const std::uint32_t rt_dim,
+    const std::uint32_t kt_dim,
+    const std::uint32_t unpA_face_r_dim,
+    const std::uint32_t unpB_face_r_dim,
+    const std::uint32_t unpA_num_faces,
+    const std::uint32_t unpB_num_faces,
+    const bool partial_face_a,
+    const bool partial_face_b) {
+    _llk_unpack_AB_matmul_init_(
+        transpose,
+        ct_dim,
+        rt_dim,
+        kt_dim,
+        unpA_face_r_dim,
+        unpB_face_r_dim,
+        unpA_num_faces,
+        unpB_num_faces,
+        partial_face_a,
+        partial_face_b);
+}
+
+inline void llk_unpack_AB_matmul_impl(
+    const std::uint32_t base_address_a,
+    const std::uint32_t base_address_b,
+    const std::uint32_t tile_index_a,
+    const std::uint32_t tile_index_b,
+    const std::uint32_t tile_size_a,
+    const std::uint32_t tile_size_b,
+    const bool partial_face_a,
+    const bool partial_face_b,
+    const std::uint32_t ct_dim,
+    const std::uint32_t rt_dim,
+    const std::uint32_t kt_dim) {
+    WAYPOINT("UPMW");
+    _llk_unpack_AB_matmul_(
+        base_address_a,
+        base_address_b,
+        tile_index_a,
+        tile_index_b,
+        tile_size_a,
+        tile_size_b,
+        partial_face_a,
+        partial_face_b,
+        ct_dim,
+        rt_dim,
+        kt_dim);
+    WAYPOINT("UPMD");
+}
 
 __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
     const std::uint32_t operandA,
@@ -20,18 +77,18 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
     const std::uint32_t kt_dim = 1) {
     // In0 -> srcB (supports partial face)
     // In1 -> srcA
-    const uint32_t operandA_id = get_operand_id(operandB);
-    const uint32_t operandB_id = get_operand_id(operandA);
+    const std::uint32_t operandA_id = get_operand_id(operandB);
+    const std::uint32_t operandB_id = get_operand_id(operandA);
 
-    const uint32_t unpA_face_r_dim = get_operand_face_r_dim(operandA_id);
-    const uint32_t unpB_face_r_dim = get_operand_face_r_dim(operandB_id);
+    const std::uint32_t unpA_face_r_dim = get_operand_face_r_dim(operandA_id);
+    const std::uint32_t unpB_face_r_dim = get_operand_face_r_dim(operandB_id);
 
     const bool reuse_a = ct_dim >= rt_dim;
     const bool partial_face_a = get_operand_partial_face(operandA_id);
     const bool partial_face_b = get_operand_partial_face(operandB_id);
 
-    const uint32_t unpA_num_faces = get_operand_num_faces(operandA_id);
-    const uint32_t unpB_num_faces = get_operand_num_faces(operandB_id);  // if partial face -> unpack face by face
+    const std::uint32_t unpA_num_faces = get_operand_num_faces(operandA_id);
+    const std::uint32_t unpB_num_faces = get_operand_num_faces(operandB_id);  // if partial face -> unpack face by face
 
     LLK_ASSERT_BLOCK(are_unpackers_AB_configured_correctly(
         unpack_src_format[operandA_id],
@@ -54,7 +111,7 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
         llk::san::IGNORE,
         llk::san::IGNORE);
 
-    _llk_unpack_AB_matmul_init_(
+    llk_unpack_AB_matmul_init_impl(
         transpose,
         ct_dim,
         rt_dim,
@@ -112,8 +169,7 @@ inline void llk_unpack_AB_matmul(
         get_operand_num_faces(operandB_id),
         get_operand_num_faces(operandA_id));
 
-    WAYPOINT("UPMW");
-    _llk_unpack_AB_matmul_(
+    llk_unpack_AB_matmul_impl(
         base_address_a,
         base_address_b,
         tile_index_a,
@@ -125,5 +181,4 @@ inline void llk_unpack_AB_matmul(
         ct_dim,
         rt_dim,
         kt_dim);
-    WAYPOINT("UPMD");
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_reduce_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_unpack_AB_reduce.h"
 #include "llk_unpack_common_api.h"
 
@@ -10,12 +11,28 @@
  * LLK UNPACK AB REDUCE
  *************************************************************************/
 
+// Unified cores, shared by the CB-id API below and the LLKOperand API (experimental/2_0/). Reduce unpack is
+// FORMAT-FREE at the op level (formats set at compute_kernel_hw_startup), so the cores take only operand A's
+// tile geometry (init) / the two runtime L1 addresses (exec). Callers resolve these from a CB id or a
+// descriptor.
+template <PoolType pool_type, ReduceDim reduce_dim>
+inline void llk_unpack_AB_reduce_init_impl(const ckernel::TensorShape& tensor_shape) {
+    _llk_unpack_AB_reduce_init_<pool_type, reduce_dim>(tensor_shape);
+}
+
+template <PoolType pool_type, ReduceDim reduce_dim>
+inline void llk_unpack_AB_reduce_impl(const std::uint32_t address_a, const std::uint32_t address_b) {
+    WAYPOINT("UABW");
+    _llk_unpack_AB_reduce_<pool_type, reduce_dim>(address_a, address_b);
+    WAYPOINT("UABD");
+}
+
 template <PoolType pool_type, ReduceDim reduce_dim>
 inline void llk_unpack_AB_reduce_init(const std::uint32_t operandA, const std::uint32_t operandB) {
     const std::uint32_t operandA_id = get_operand_id(operandA);
     const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operandA_id);
 
-    _llk_unpack_AB_reduce_init_<pool_type, reduce_dim>(tensor_shape);
+    llk_unpack_AB_reduce_init_impl<pool_type, reduce_dim>(tensor_shape);
 }
 
 template <PoolType pool_type, ReduceDim reduce_dim>
@@ -36,7 +53,5 @@ inline void llk_unpack_AB_reduce(
     LLK_ASSERT(cb_access_within_bounds(operandA_id, tile_index_a, 1), "Indexed tile read exceeds CB boundary");
     LLK_ASSERT(cb_access_within_bounds(operandB_id, tile_index_b, 1), "Indexed tile read exceeds CB boundary");
 
-    WAYPOINT("UABW");
-    _llk_unpack_AB_reduce_<pool_type, reduce_dim>(address_a, address_b);
-    WAYPOINT("UABD");
+    llk_unpack_AB_reduce_impl<pool_type, reduce_dim>(address_a, address_b);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -11,6 +11,42 @@
  * LLK UNPACK A
  *************************************************************************/
 
+// Unified core, shared by the CB-id API below and the LLKOperand API (experimental/). It takes
+// already-resolved scalar format/geometry + the runtime address; the per-source prologue (resolving
+// these from a CB id, or from an MemDescriptor) lives in the callers.
+template <
+    BroadcastType BType = BroadcastType::NONE,
+    bool acc_to_dest = false,
+    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
+    bool unpack_to_dest = false>
+inline void llk_unpack_A_init_impl(
+    const std::uint32_t transpose_of_faces,
+    const std::uint32_t within_face_16x16_transpose,
+    const ckernel::TensorShape tensor_shape,
+    const std::uint32_t src_format,
+    const std::uint32_t dst_format) {
+    LLK_ASSERT_BLOCK((is_unpacker_A_configured_correctly<
+                      UnpackerProgramType::ProgramByTile,
+                      (BType != BroadcastType::NONE && !unpack_to_dest)>(
+        src_format, dst_format, tensor_shape.face_r_dim, tensor_shape.total_num_faces())));
+
+    _llk_unpack_A_init_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
+        transpose_of_faces, within_face_16x16_transpose, tensor_shape, src_format, dst_format);
+}
+
+template <
+    BroadcastType BType = BroadcastType::NONE,
+    bool acc_to_dest = false,
+    EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
+    bool unpack_to_dest = false>
+inline void llk_unpack_A_impl(
+    const std::uint32_t address, const std::uint32_t src_format, const std::uint32_t dst_format) {
+    WAYPOINT("UPAW");
+    _llk_unpack_A_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(address, src_format, dst_format);
+    WAYPOINT("UPAD");
+}
+
+// CB-id API (unchanged behavior): resolve format/geometry from the CB, then call the unified core.
 template <
     BroadcastType BType = BroadcastType::NONE,
     bool acc_to_dest = false,
@@ -21,25 +57,12 @@ inline void llk_unpack_A_init(
     const std::uint32_t within_face_16x16_transpose,
     const std::uint32_t operand) {
     const std::uint32_t operand_id = get_operand_id(operand);
-    const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
-
-    const std::uint32_t operand_unpack_src_format = unpack_src_format[operand_id];
-    const std::uint32_t operand_unpack_dst_format = unpack_dst_format[operand_id];
-
-    LLK_ASSERT_BLOCK((is_unpacker_A_configured_correctly<
-                      UnpackerProgramType::ProgramByTile,
-                      (BType != BroadcastType::NONE && !unpack_to_dest)>(
-        operand_unpack_src_format,
-        operand_unpack_dst_format,
-        tensor_shape.face_r_dim,
-        tensor_shape.total_num_faces())));
-
-    _llk_unpack_A_init_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
+    llk_unpack_A_init_impl<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
         transpose_of_faces,
         within_face_16x16_transpose,
-        tensor_shape,
-        operand_unpack_src_format,
-        operand_unpack_dst_format);
+        get_operand_tensor_shape(operand_id),
+        unpack_src_format[operand_id],
+        unpack_dst_format[operand_id]);
 }
 
 template <
@@ -63,10 +86,8 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
         get_operand_face_r_dim(operand_id),
         get_operand_num_faces(operand_id))));
 
-    WAYPOINT("UPAW");
-    _llk_unpack_A_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
+    llk_unpack_A_impl<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
         address, unpack_src_format[operand_id], unpack_dst_format[operand_id]);
-    WAYPOINT("UPAD");
 }
 
 template <

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -11,6 +11,32 @@
  * LLK UNPACK TILIZE
  *************************************************************************/
 
+// Unified cores, shared by the CB-id API below and the LLKOperand API (experimental/). They take
+// already-resolved scalar format/geometry (+ the runtime base address for the op); the per-source
+// prologue (resolving these from a CB id, or from an MemDescriptor) lives in the callers.
+inline void llk_unpack_tilize_init_impl(
+    const std::uint32_t src_format,
+    const std::uint32_t dst_format,
+    const std::uint32_t ct_dim,
+    const std::uint32_t face_r_dim,
+    const bool narrow_tile,
+    const std::uint32_t num_faces) {
+    _llk_unpack_tilize_init_(src_format, dst_format, ct_dim, face_r_dim, narrow_tile, num_faces);
+}
+
+inline void llk_unpack_tilize_impl(
+    const std::uint32_t base_address,
+    const std::uint32_t tile_index,
+    const std::uint32_t src_format,
+    const std::uint32_t dst_format,
+    const std::uint32_t face_r_dim,
+    const std::uint32_t num_faces,
+    const bool narrow_tile) {
+    WAYPOINT("UPTW");
+    _llk_unpack_tilize_(base_address, tile_index, src_format, dst_format, face_r_dim, num_faces, narrow_tile);
+    WAYPOINT("UPTD");
+}
+
 /**
  * Initialize the unpacker for a single-operand tilize operation.
  *
@@ -21,11 +47,13 @@
  */
 inline void llk_unpack_tilize_init(const std::uint32_t operand, const std::uint32_t ct_dim) {
     const std::uint32_t operand_id = get_operand_id(operand);
-    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
-    const bool narrow_tile = get_operand_narrow_tile(operand_id);
-    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
-    _llk_unpack_tilize_init_(
-        unpack_src_format[operand_id], unpack_dst_format[operand_id], ct_dim, face_r_dim, narrow_tile, num_faces);
+    llk_unpack_tilize_init_impl(
+        unpack_src_format[operand_id],
+        unpack_dst_format[operand_id],
+        ct_dim,
+        get_operand_face_r_dim(operand_id),
+        get_operand_narrow_tile(operand_id),
+        get_operand_num_faces(operand_id));
 }
 
 /**
@@ -39,11 +67,15 @@ inline void llk_unpack_tilize_init(const std::uint32_t operand, const std::uint3
  *
  * @param operand Input circular buffer / operand index.
  */
+inline void llk_unpack_tilize_uninit_impl(const std::uint32_t dst_format, const ckernel::TensorShape tensor_shape) {
+    _llk_unpack_tilize_uninit_(dst_format, tensor_shape);
+}
+
 inline void llk_unpack_tilize_uninit(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
     const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
-    _llk_unpack_tilize_uninit_(
+    llk_unpack_tilize_uninit_impl(
         (std::uint32_t)unpack_dst_format[operand_id], ckernel::tensor_shape_from_num_faces(face_r_dim, num_faces));
 }
 
@@ -58,23 +90,17 @@ inline void llk_unpack_tilize_uninit(const std::uint32_t operand) {
  */
 inline void llk_unpack_tilize(std::uint32_t operand, std::uint32_t tile_index) {
     std::uint32_t operand_id = get_operand_id(operand);
-    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
-    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
-    const bool narrow_tile = get_operand_narrow_tile(operand_id);
-
     std::uint32_t base_address =
         get_local_cb_interface(operand_id).fifo_rd_ptr - 1;  // Remove header size added by descriptor
 
-    WAYPOINT("UPTW");
-    _llk_unpack_tilize_(
+    llk_unpack_tilize_impl(
         base_address,
         tile_index,
         unpack_src_format[operand_id],
         unpack_dst_format[operand_id],
-        face_r_dim,
-        num_faces,
-        narrow_tile);
-    WAYPOINT("UPTD");
+        get_operand_face_r_dim(operand_id),
+        get_operand_num_faces(operand_id),
+        get_operand_narrow_tile(operand_id));
 }
 
 /**

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/bcast.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/bcast.h
@@ -42,17 +42,18 @@ namespace experimental {
 namespace detail {
 // Whether the unary broadcast takes the unpack-to-dest path, decided from the DERIVED REGISTER format
 // (fp32-dest-acc rebias aware), not the raw L1 Format.
-template <DataFormat Format>
+template <DataFormat Format, bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 constexpr bool unary_bcast_unpack_to_dest() {
-    return is_32bit_format(ckernel::infer_unpack_dst_format(Format, DST_ACCUM_MODE));
+    return is_32bit_format(ckernel::infer_unpack_dst_format(Format, is_fp32_dest_acc_en));
 }
 
 // A2D/B2D data-copy direction for the unary broadcast, folded to a constant. Shared by unary_bcast_init /
 // unary_bcast so the policy is spelled once.
-template <BroadcastType bcast_type, DataFormat Format>
+template <BroadcastType bcast_type, DataFormat Format, bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 constexpr DataCopyType unary_bcast_dcopy() {
-    return (unary_bcast_unpack_to_dest<Format>() || bcast_type == BroadcastType::NONE) ? DataCopyType::A2D
-                                                                                       : DataCopyType::B2D;
+    return (unary_bcast_unpack_to_dest<Format, is_fp32_dest_acc_en>() || bcast_type == BroadcastType::NONE)
+               ? DataCopyType::A2D
+               : DataCopyType::B2D;
 }
 }  // namespace detail
 
@@ -64,22 +65,23 @@ constexpr DataCopyType unary_bcast_dcopy() {
  * | Param Type | Name      | Description                                                  | Type          | Valid Range           | Required |
  * |------------|-----------|--------------------------------------------------------------|---------------|-----------------------|----------|
  * | Template   | bcast_type| Broadcast mode (NONE pass-through / ROW / COL / SCALAR)       | BroadcastType | N/A                   | True     |
+ * | Template   | is_fp32_dest_acc_en | fp32 dest-accumulate mode                            | bool          | N/A                   | False    |
  * | Template   | Format    | Buffer L1 data format (deduced from the LLKOperand argument)  | DataFormat    | N/A                   | True     |
  * | Template   | Shape     | Tile geometry (deduced from the LLKOperand argument)         | TensorShape   | N/A                   | True     |
  * | Function   | src       | The source L1 operand (format + shape; address unused here)  | LLKOperand    | N/A                   | True     |
  */
 // clang-format on
-template <BroadcastType bcast_type, DataFormat Format, TensorShape Shape>
+template <BroadcastType bcast_type, bool is_fp32_dest_acc_en = DST_ACCUM_MODE, DataFormat Format, TensorShape Shape>
 ALWI void unary_bcast_init(LLKOperand<Format, Shape> /*src*/) {
     static_assert(
         is_legal_tile_shape(Shape),
         "unary_bcast_init: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
     // 32-bit register formats use the unpack-to-dest A2D path (SrcB is only 19 bits wide); folds to a constant.
-    constexpr bool enable_unpack_to_dest = detail::unary_bcast_unpack_to_dest<Format>();
-    constexpr DataCopyType dcopy = detail::unary_bcast_dcopy<bcast_type, Format>();
+    constexpr bool enable_unpack_to_dest = detail::unary_bcast_unpack_to_dest<Format, is_fp32_dest_acc_en>();
+    constexpr DataCopyType dcopy = detail::unary_bcast_dcopy<bcast_type, Format, is_fp32_dest_acc_en>();
     UNPACK((llk_unpack_A_init<
             LLKOperand<Format, Shape>::descriptor,
-            DST_ACCUM_MODE,
+            is_fp32_dest_acc_en,
             bcast_type,
             false /*acc_to_dest*/,
             EltwiseBinaryReuseDestType::NONE,
@@ -87,7 +89,7 @@ ALWI void unary_bcast_init(LLKOperand<Format, Shape> /*src*/) {
     MATH((llk_math_eltwise_unary_datacopy_init<
           LLKOperand<Format, Shape>::descriptor,
           dcopy,
-          DST_ACCUM_MODE,
+          is_fp32_dest_acc_en,
           bcast_type>()));
 }
 
@@ -100,22 +102,23 @@ ALWI void unary_bcast_init(LLKOperand<Format, Shape> /*src*/) {
  * | Param Type | Name           | Description                                                 | Type          | Valid Range | Required |
  * |------------|----------------|-------------------------------------------------------------|---------------|-------------|----------|
  * | Template   | bcast_type     | Broadcast mode (NONE pass-through / ROW / COL / SCALAR)      | BroadcastType | N/A         | True     |
+ * | Template   | is_fp32_dest_acc_en | fp32 dest-accumulate mode                               | bool          | N/A         | False    |
  * | Template   | Format         | Buffer L1 data format (deduced from the LLKOperand argument) | DataFormat    | N/A         | True     |
  * | Template   | Shape          | Tile geometry (deduced from the LLKOperand argument)        | TensorShape   | N/A         | True     |
  * | Function   | src            | The source L1 operand (format + shape + address)            | LLKOperand    | N/A         | True     |
  * | Function   | dst_tile_index | Tile index in the DST register for the result               | uint32_t      | 0 to 15     | True     |
  */
 // clang-format on
-template <BroadcastType bcast_type, DataFormat Format, TensorShape Shape>
+template <BroadcastType bcast_type, bool is_fp32_dest_acc_en = DST_ACCUM_MODE, DataFormat Format, TensorShape Shape>
 ALWI void unary_bcast(LLKOperand<Format, Shape> src, std::uint32_t dst_tile_index) {
     static_assert(
         is_legal_tile_shape(Shape),
         "unary_bcast: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
-    constexpr bool enable_unpack_to_dest = detail::unary_bcast_unpack_to_dest<Format>();
-    constexpr DataCopyType dcopy = detail::unary_bcast_dcopy<bcast_type, Format>();
+    constexpr bool enable_unpack_to_dest = detail::unary_bcast_unpack_to_dest<Format, is_fp32_dest_acc_en>();
+    constexpr DataCopyType dcopy = detail::unary_bcast_dcopy<bcast_type, Format, is_fp32_dest_acc_en>();
     UNPACK((llk_unpack_A<
             LLKOperand<Format, Shape>::descriptor,
-            DST_ACCUM_MODE,
+            is_fp32_dest_acc_en,
             bcast_type,
             false /*acc_to_dest*/,
             EltwiseBinaryReuseDestType::NONE,
@@ -123,7 +126,7 @@ ALWI void unary_bcast(LLKOperand<Format, Shape> src, std::uint32_t dst_tile_inde
     MATH((llk_math_eltwise_unary_datacopy<
           LLKOperand<Format, Shape>::descriptor,
           dcopy,
-          DST_ACCUM_MODE,
+          is_fp32_dest_acc_en,
           bcast_type,
           enable_unpack_to_dest>(dst_tile_index)));
 }
@@ -143,7 +146,7 @@ ALWI void unary_bcast(LLKOperand<Format, Shape> src, std::uint32_t dst_tile_inde
 // clang-format on
 template <BroadcastType bcast_type, DataFormat Format, TensorShape Shape>
 ALWI void unary_bcast_uninit(LLKOperand<Format, Shape> /*src*/) {
-    constexpr bool enable_unpack_to_dest = detail::unary_bcast_unpack_to_dest<Format>();
+    constexpr bool enable_unpack_to_dest = detail::unary_bcast_unpack_to_dest<Format, DST_ACCUM_MODE>();
     UNPACK((llk_unpack_A_uninit<bcast_type>()));
     MATH((llk_math_eltwise_unary_datacopy_uninit<bcast_type, enable_unpack_to_dest>()));
 }
@@ -199,6 +202,7 @@ ALWI void bcast_init(LLKOperand<AFormat, AShape> /*a*/) {
  * |------------|-----------------|--------------------------------------------------------|-------------------|-------------|----------|
  * | Template   | tBcastOp        | The binary op (ELWADD / ELWSUB / ELWMUL)               | EltwiseBinaryType | N/A         | True     |
  * | Template   | tBcastDim       | The broadcast dim (ROW / COL / SCALAR)                 | BroadcastType     | N/A         | True     |
+ * | Template   | is_fp32_dest_acc_en | fp32 dest-accumulate mode                          | bool              | N/A         | False    |
  * | Template   | AFormat/AShape  | Operand A L1 format + geometry (deduced)               | DataFormat/TensorShape | N/A    | True     |
  * | Template   | BFormat/BShape  | Operand B L1 format + geometry (deduced)               | DataFormat/TensorShape | N/A    | True     |
  * | Function   | a / b           | Input operands (A -> SrcA, broadcast B -> SrcB)        | LLKOperand        | N/A         | True     |
@@ -210,6 +214,7 @@ ALWI void bcast_init(LLKOperand<AFormat, AShape> /*a*/) {
 template <
     EltwiseBinaryType tBcastOp,
     BroadcastType tBcastDim,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
     DataFormat AFormat,
     TensorShape AShape,
     DataFormat BFormat,
@@ -231,7 +236,7 @@ ALWI void any_tiles_bcast(
           LLKOperand<AFormat, AShape>::descriptor,
           tBcastOp,
           tBcastDim,
-          DST_ACCUM_MODE,
+          is_fp32_dest_acc_en,
           (tBcastOp == EltwiseBinaryType::ELWMUL) ? MATH_FIDELITY : MathFidelity::LoFi,
           EltwiseBinaryReuseDestType::NONE>(idst, true /*clear_fp32_dst_acc*/)));
     UNPACK((llk_unpack_AB<LLKOperand<AFormat, AShape>::descriptor, tBcastDim, static_cast<std::uint8_t>(BFormat)>(
@@ -246,12 +251,19 @@ ALWI void any_tiles_bcast(
  * | Param Type | Name           | Description                              | Type          | Valid Range | Required |
  * |------------|----------------|------------------------------------------|---------------|-------------|----------|
  * | Template   | tBcastDim      | The broadcast dim (ROW / COL / SCALAR)   | BroadcastType | N/A         | True     |
+ * | Template   | is_fp32_dest_acc_en | fp32 dest-accumulate mode           | bool          | N/A         | False    |
  * | Function   | a / b          | Input operands                           | LLKOperand    | N/A         | True     |
  * | Function   | itile0 / itile1| Tile indices within A / B                | uint32_t      | N/A         | True     |
  * | Function   | idst           | DST register index for the result        | uint32_t      | 0 to 15     | True     |
  */
 // clang-format on
-template <BroadcastType tBcastDim, DataFormat AFormat, TensorShape AShape, DataFormat BFormat, TensorShape BShape>
+template <
+    BroadcastType tBcastDim,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    DataFormat AFormat,
+    TensorShape AShape,
+    DataFormat BFormat,
+    TensorShape BShape>
 ALWI void add_tiles_bcast(
     LLKOperand<AFormat, AShape> a,
     LLKOperand<BFormat, BShape> b,
@@ -259,7 +271,8 @@ ALWI void add_tiles_bcast(
     std::uint32_t itile1,
     std::uint32_t idst,
     std::uint32_t bcast_row_idx = 0) {
-    any_tiles_bcast<EltwiseBinaryType::ELWADD, tBcastDim>(a, b, itile0, itile1, idst, bcast_row_idx);
+    any_tiles_bcast<EltwiseBinaryType::ELWADD, tBcastDim, is_fp32_dest_acc_en>(
+        a, b, itile0, itile1, idst, bcast_row_idx);
 }
 
 // clang-format off
@@ -270,12 +283,19 @@ ALWI void add_tiles_bcast(
  * | Param Type | Name           | Description                              | Type          | Valid Range | Required |
  * |------------|----------------|------------------------------------------|---------------|-------------|----------|
  * | Template   | tBcastDim      | The broadcast dim (ROW / COL / SCALAR)   | BroadcastType | N/A         | True     |
+ * | Template   | is_fp32_dest_acc_en | fp32 dest-accumulate mode           | bool          | N/A         | False    |
  * | Function   | a / b          | Input operands                           | LLKOperand    | N/A         | True     |
  * | Function   | itile0 / itile1| Tile indices within A / B                | uint32_t      | N/A         | True     |
  * | Function   | idst           | DST register index for the result        | uint32_t      | 0 to 15     | True     |
  */
 // clang-format on
-template <BroadcastType tBcastDim, DataFormat AFormat, TensorShape AShape, DataFormat BFormat, TensorShape BShape>
+template <
+    BroadcastType tBcastDim,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    DataFormat AFormat,
+    TensorShape AShape,
+    DataFormat BFormat,
+    TensorShape BShape>
 ALWI void sub_tiles_bcast(
     LLKOperand<AFormat, AShape> a,
     LLKOperand<BFormat, BShape> b,
@@ -283,7 +303,8 @@ ALWI void sub_tiles_bcast(
     std::uint32_t itile1,
     std::uint32_t idst,
     std::uint32_t bcast_row_idx = 0) {
-    any_tiles_bcast<EltwiseBinaryType::ELWSUB, tBcastDim>(a, b, itile0, itile1, idst, bcast_row_idx);
+    any_tiles_bcast<EltwiseBinaryType::ELWSUB, tBcastDim, is_fp32_dest_acc_en>(
+        a, b, itile0, itile1, idst, bcast_row_idx);
 }
 
 // clang-format off
@@ -294,12 +315,19 @@ ALWI void sub_tiles_bcast(
  * | Param Type | Name           | Description                              | Type          | Valid Range | Required |
  * |------------|----------------|------------------------------------------|---------------|-------------|----------|
  * | Template   | tBcastDim      | The broadcast dim (ROW / COL / SCALAR)   | BroadcastType | N/A         | True     |
+ * | Template   | is_fp32_dest_acc_en | fp32 dest-accumulate mode           | bool          | N/A         | False    |
  * | Function   | a / b          | Input operands                           | LLKOperand    | N/A         | True     |
  * | Function   | itile0 / itile1| Tile indices within A / B                | uint32_t      | N/A         | True     |
  * | Function   | idst           | DST register index for the result        | uint32_t      | 0 to 15     | True     |
  */
 // clang-format on
-template <BroadcastType tBcastDim, DataFormat AFormat, TensorShape AShape, DataFormat BFormat, TensorShape BShape>
+template <
+    BroadcastType tBcastDim,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    DataFormat AFormat,
+    TensorShape AShape,
+    DataFormat BFormat,
+    TensorShape BShape>
 ALWI void mul_tiles_bcast(
     LLKOperand<AFormat, AShape> a,
     LLKOperand<BFormat, BShape> b,
@@ -307,7 +335,8 @@ ALWI void mul_tiles_bcast(
     std::uint32_t itile1,
     std::uint32_t idst,
     std::uint32_t bcast_row_idx = 0) {
-    any_tiles_bcast<EltwiseBinaryType::ELWMUL, tBcastDim>(a, b, itile0, itile1, idst, bcast_row_idx);
+    any_tiles_bcast<EltwiseBinaryType::ELWMUL, tBcastDim, is_fp32_dest_acc_en>(
+        a, b, itile0, itile1, idst, bcast_row_idx);
 }
 
 #endif  // ARCH_BLACKHOLE

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/bcast.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/bcast.h
@@ -1,0 +1,309 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/common_globals.h"
+#include "api/compute/experimental/2_0/llk_operand.h"
+
+#ifdef TRISC_MATH
+#include "experimental/2_0/llk_math_unary_datacopy.h"
+#include "experimental/2_0/llk_math_binary.h"
+#endif
+
+#ifdef TRISC_UNPACK
+#include "experimental/2_0/llk_unpack_A.h"
+#include "experimental/2_0/llk_unpack_AB.h"
+#endif
+
+// =====================================================================================================
+// Id-free (2.0) unary broadcast (unary_bcast). Single-input op: unpacks one L1 tile (with the requested
+// broadcast mode) and datacopies it into DST. Mirrors the legacy ckernel::unary_bcast<bcast_type> family
+// (init/op/uninit) but takes an LLKOperand<Format,Shape> instead of a CB id: Format + Shape are compile-time
+// NTTPs forwarded to the LLK as LLKOperand::descriptor (folds/DCE), and l1_address is the only runtime state.
+// The register format is derived INSIDE the reused LLK overloads; no CB id / register format on the API.
+//
+// Broadcast mode / DataCopyType selection matches the legacy op exactly:
+//   * BroadcastType::NONE is a pass-through and uses DataCopyType::A2D (the tile stays in SrcA; reading it
+//     back with B2D would copy zeros and hang the unpacker).
+//   * ROW / COL / SCALAR broadcasts leave the tile in SrcB and use DataCopyType::B2D.
+//   * 32-bit formats (Float32/UInt32/Int32) take the unpack-to-dest A2D path (SrcB is only 19 bits wide);
+//     this is derived at COMPILE time from the LLKOperand's Format (legacy derives it at runtime from the CB).
+// Blackhole only. The Quasar-specific paths and the deprecated CB-id (icb, ocb) full inits are not carried over.
+// =====================================================================================================
+
+namespace ckernel {
+namespace experimental {
+
+#ifdef ARCH_BLACKHOLE
+
+namespace detail {
+// A2D/B2D data-copy direction for the unary broadcast, folded to a constant: 32-bit formats (which take the
+// unpack-to-dest path) and the NONE pass-through use A2D; a real ROW/COL/SCALAR broadcast of a non-32-bit
+// format uses B2D. Shared by unary_bcast_init / unary_bcast so the policy is spelled once.
+template <BroadcastType bcast_type, DataFormat Format>
+constexpr DataCopyType unary_bcast_dcopy() {
+    return (is_32bit_format(Format) || bcast_type == BroadcastType::NONE) ? DataCopyType::A2D : DataCopyType::B2D;
+}
+}  // namespace detail
+
+// clang-format off
+/**
+ * Paired init for experimental::unary_bcast. Configures the unpack + math pipeline for the id-free unary
+ * broadcast op; call before unary_bcast (including when switching to it from another op). The one-time
+ * hardware configuration must already have been performed via compute_kernel_hw_startup at kernel start.
+ * The broadcast mode and A2D/B2D data-copy direction are fixed here from bcast_type + the operand Format.
+ *
+ * | Param Type | Name      | Description                                                  | Type          | Valid Range           | Required |
+ * |------------|-----------|--------------------------------------------------------------|---------------|-----------------------|----------|
+ * | Template   | bcast_type| Broadcast mode (NONE pass-through / ROW / COL / SCALAR)       | BroadcastType | N/A                   | True     |
+ * | Template   | Format    | Buffer L1 data format (deduced from the LLKOperand argument)  | DataFormat    | N/A                   | True     |
+ * | Template   | Shape     | Tile geometry (deduced from the LLKOperand argument)         | TensorShape   | N/A                   | True     |
+ * | Function   | src       | The source L1 operand (format + shape; address unused here)  | LLKOperand    | N/A                   | True     |
+ */
+// clang-format on
+template <BroadcastType bcast_type, DataFormat Format, TensorShape Shape>
+ALWI void unary_bcast_init(LLKOperand<Format, Shape> /*src*/) {
+    static_assert(
+        is_legal_tile_shape(Shape),
+        "unary_bcast_init: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
+    // 32-bit formats use the unpack-to-dest A2D path (SrcB is only 19 bits wide); folds to a constant.
+    constexpr bool enable_unpack_to_dest = is_32bit_format(Format);
+    constexpr DataCopyType dcopy = detail::unary_bcast_dcopy<bcast_type, Format>();
+    UNPACK((llk_unpack_A_init<
+            LLKOperand<Format, Shape>::descriptor,
+            DST_ACCUM_MODE,
+            bcast_type,
+            false /*acc_to_dest*/,
+            EltwiseBinaryReuseDestType::NONE,
+            enable_unpack_to_dest>()));
+    MATH((llk_math_eltwise_unary_datacopy_init<
+          LLKOperand<Format, Shape>::descriptor,
+          dcopy,
+          DST_ACCUM_MODE,
+          bcast_type>()));
+}
+
+// clang-format off
+/**
+ * Id-free unary broadcast. Unpacks one tile from the L1 region described by the LLKOperand (applying the
+ * broadcast mode) and datacopies it into DST[dst_tile_index]. The DST register must be in the acquired
+ * state. Blocking; compute-engine only. Pair with unary_bcast_init.
+ *
+ * | Param Type | Name           | Description                                                 | Type          | Valid Range | Required |
+ * |------------|----------------|-------------------------------------------------------------|---------------|-------------|----------|
+ * | Template   | bcast_type     | Broadcast mode (NONE pass-through / ROW / COL / SCALAR)      | BroadcastType | N/A         | True     |
+ * | Template   | Format         | Buffer L1 data format (deduced from the LLKOperand argument) | DataFormat    | N/A         | True     |
+ * | Template   | Shape          | Tile geometry (deduced from the LLKOperand argument)        | TensorShape   | N/A         | True     |
+ * | Function   | src            | The source L1 operand (format + shape + address)            | LLKOperand    | N/A         | True     |
+ * | Function   | dst_tile_index | Tile index in the DST register for the result               | uint32_t      | 0 to 15     | True     |
+ */
+// clang-format on
+template <BroadcastType bcast_type, DataFormat Format, TensorShape Shape>
+ALWI void unary_bcast(LLKOperand<Format, Shape> src, std::uint32_t dst_tile_index) {
+    static_assert(
+        is_legal_tile_shape(Shape),
+        "unary_bcast: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
+    constexpr bool enable_unpack_to_dest = is_32bit_format(Format);
+    constexpr DataCopyType dcopy = detail::unary_bcast_dcopy<bcast_type, Format>();
+    UNPACK((llk_unpack_A<
+            LLKOperand<Format, Shape>::descriptor,
+            DST_ACCUM_MODE,
+            bcast_type,
+            false /*acc_to_dest*/,
+            EltwiseBinaryReuseDestType::NONE,
+            enable_unpack_to_dest>(src.l1_address)));
+    MATH((llk_math_eltwise_unary_datacopy<
+          LLKOperand<Format, Shape>::descriptor,
+          dcopy,
+          DST_ACCUM_MODE,
+          bcast_type,
+          enable_unpack_to_dest>(dst_tile_index)));
+}
+
+// clang-format off
+/**
+ * Paired uninit for experimental::unary_bcast. Restores the unpack + math pipeline so a following op can be
+ * initialized cleanly. The underlying LLK uninits are format-free; the operand is taken only so the 32-bit
+ * unpack-to-dest math-uninit variant is selected consistently with unary_bcast_init (folds to a constant).
+ *
+ * | Param Type | Name      | Description                                                  | Type          | Valid Range | Required |
+ * |------------|-----------|--------------------------------------------------------------|---------------|-------------|----------|
+ * | Template   | bcast_type| Broadcast mode (must match the paired unary_bcast_init)      | BroadcastType | N/A         | True     |
+ * | Template   | Format    | Buffer L1 data format (deduced from the LLKOperand argument)  | DataFormat    | N/A         | True     |
+ * | Template   | Shape     | Tile geometry (deduced from the LLKOperand argument)         | TensorShape   | N/A         | True     |
+ * | Function   | src       | The source L1 operand (format + shape; address unused here)  | LLKOperand    | N/A         | True     |
+ */
+// clang-format on
+template <BroadcastType bcast_type, DataFormat Format, TensorShape Shape>
+ALWI void unary_bcast_uninit(LLKOperand<Format, Shape> /*src*/) {
+    constexpr bool enable_unpack_to_dest = is_32bit_format(Format);
+    UNPACK((llk_unpack_A_uninit<bcast_type>()));
+    MATH((llk_math_eltwise_unary_datacopy_uninit<bcast_type, enable_unpack_to_dest>()));
+}
+
+// =====================================================================================================
+// Id-free (2.0) BINARY broadcast (any_tiles_bcast<EltwiseBinaryType, BroadcastType>). Two-input op: C = A [op]
+// broadcast(B), where B is a single tile broadcast across A per the BroadcastType (ROW / COL / SCALAR). Mirrors
+// the legacy ckernel::any_tiles_bcast<tBcastOp, tBcastDim> (bcast_init + any_tiles_bcast) but takes one
+// LLKOperand per input instead of CB ids: Format + Shape are compile-time NTTPs, l1_address the only runtime
+// state. Binary bcast is FORMAT-FREE at the op level (src/dst register formats are programmed once at
+// compute_kernel_hw_startup); geometry (for MATH + the AB-unpack init) is taken from operand A, matching legacy.
+// Per-tile input addresses are derived from each operand's geometry via tile_stride_words (one-tile page).
+//
+// The ROW broadcast path additionally needs operand B's L1 format (forwarded as the OperandBFormat NTTP of the
+// id-free llk_unpack_AB); COL / SCALAR ignore it. BroadcastType::NONE (plain binary) belongs to
+// experimental::add/sub/mul_tiles in eltwise_binary.h, not here.
+// =====================================================================================================
+
+// clang-format off
+/**
+ * Paired init for experimental::any_tiles_bcast (generic op/dim). Configures MATH + the AB unpacker for the
+ * id-free binary broadcast op; call before any_tiles_bcast (including when switching to it from another op).
+ * The one-time hardware configuration must already have been performed via compute_kernel_hw_startup(a, b, out)
+ * at kernel start. Geometry comes from operand A (A.shape == B.shape assumed for the non-broadcast dims).
+ *
+ * | Param Type | Name      | Description                                                  | Type              | Valid Range | Required |
+ * |------------|-----------|--------------------------------------------------------------|-------------------|-------------|----------|
+ * | Template   | tBcastOp  | The binary op (ELWADD / ELWSUB / ELWMUL)                     | EltwiseBinaryType | N/A         | True     |
+ * | Template   | tBcastDim | The broadcast dim (ROW / COL / SCALAR)                       | BroadcastType     | N/A         | True     |
+ * | Template   | AFormat   | Operand A L1 data format (deduced from the LLKOperand)       | DataFormat        | N/A         | True     |
+ * | Template   | AShape    | Operand A tile geometry (deduced from the LLKOperand)        | TensorShape       | N/A         | True     |
+ * | Function   | a         | Operand A (drives geometry; address unused here)            | LLKOperand        | N/A         | True     |
+ */
+// clang-format on
+template <EltwiseBinaryType tBcastOp, BroadcastType tBcastDim, DataFormat AFormat, TensorShape AShape>
+ALWI void bcast_init(LLKOperand<AFormat, AShape> /*a*/) {
+    static_assert(is_legal_tile_shape(AShape), "bcast_init: illegal tile shape for operand A.");
+    static_assert(tBcastDim != BroadcastType::NONE, "bcast_init: use add/sub/mul_init for BroadcastType::NONE.");
+    MATH((llk_math_eltwise_binary_init<LLKOperand<AFormat, AShape>::descriptor, tBcastOp, tBcastDim, MATH_FIDELITY>()));
+    UNPACK((llk_unpack_AB_init<LLKOperand<AFormat, AShape>::descriptor, tBcastDim>(ckernel::Transpose::None)));
+}
+
+// clang-format off
+/**
+ * Id-free binary broadcast: C = A [tBcastOp] broadcast(B) for one tile pair, writing DST[idst]. B is a single
+ * tile broadcast across A per tBcastDim (COL: B's row 0; ROW: B's col 0; SCALAR: B[0,0]). Pair with bcast_init.
+ * The DST register must be acquired. Blocking; compute-engine only. itile0/itile1 index within A/B; geometry
+ * (for MATH) comes from operand A, matching legacy. The ROW path forwards operand B's L1 format to the unpacker.
+ *
+ * | Param Type | Name            | Description                                              | Type              | Valid Range | Required |
+ * |------------|-----------------|--------------------------------------------------------|-------------------|-------------|----------|
+ * | Template   | tBcastOp        | The binary op (ELWADD / ELWSUB / ELWMUL)               | EltwiseBinaryType | N/A         | True     |
+ * | Template   | tBcastDim       | The broadcast dim (ROW / COL / SCALAR)                 | BroadcastType     | N/A         | True     |
+ * | Template   | AFormat/AShape  | Operand A L1 format + geometry (deduced)               | DataFormat/TensorShape | N/A    | True     |
+ * | Template   | BFormat/BShape  | Operand B L1 format + geometry (deduced)               | DataFormat/TensorShape | N/A    | True     |
+ * | Function   | a / b           | Input operands (A -> SrcA, broadcast B -> SrcB)        | LLKOperand        | N/A         | True     |
+ * | Function   | itile0 / itile1 | Tile indices within A / B                              | uint32_t          | N/A         | True     |
+ * | Function   | idst            | DST register index for the result                     | uint32_t          | 0 to 15     | True     |
+ * | Function   | bcast_row_idx   | ROW broadcast: which row of B's tile to broadcast     | uint32_t          | N/A         | False    |
+ */
+// clang-format on
+template <
+    EltwiseBinaryType tBcastOp,
+    BroadcastType tBcastDim,
+    DataFormat AFormat,
+    TensorShape AShape,
+    DataFormat BFormat,
+    TensorShape BShape>
+ALWI void any_tiles_bcast(
+    LLKOperand<AFormat, AShape> a,
+    LLKOperand<BFormat, BShape> b,
+    std::uint32_t itile0,
+    std::uint32_t itile1,
+    std::uint32_t idst,
+    std::uint32_t bcast_row_idx = 0) {
+    static_assert(is_legal_tile_shape(AShape), "any_tiles_bcast: illegal tile shape for operand A.");
+    static_assert(is_legal_tile_shape(BShape), "any_tiles_bcast: illegal tile shape for operand B.");
+    static_assert(tBcastDim != BroadcastType::NONE, "any_tiles_bcast: use add/sub/mul_tiles for BroadcastType::NONE.");
+    // Match legacy any_tiles_bcast order: MATH then UNPACK. bcast_row_idx selects which row of B's tile the ROW
+    // broadcast reads (legacy parity); it is consumed only by the ROW path and ignored by COL / SCALAR.
+    MATH((llk_math_eltwise_binary<
+          LLKOperand<AFormat, AShape>::descriptor,
+          tBcastOp,
+          tBcastDim,
+          DST_ACCUM_MODE,
+          MATH_FIDELITY,
+          EltwiseBinaryReuseDestType::NONE>(idst, true /*clear_fp32_dst_acc*/)));
+    UNPACK((llk_unpack_AB<LLKOperand<AFormat, AShape>::descriptor, tBcastDim, static_cast<std::uint8_t>(BFormat)>(
+        detail::tile_address(a, itile0), detail::tile_address(b, itile1), bcast_row_idx)));
+}
+
+// clang-format off
+/**
+ * Id-free broadcast add: C = A + broadcast(B). Shorthand for any_tiles_bcast<ELWADD, tBcastDim>. See
+ * any_tiles_bcast for the full parameter table and broadcast semantics.
+ *
+ * | Param Type | Name           | Description                              | Type          | Valid Range | Required |
+ * |------------|----------------|------------------------------------------|---------------|-------------|----------|
+ * | Template   | tBcastDim      | The broadcast dim (ROW / COL / SCALAR)   | BroadcastType | N/A         | True     |
+ * | Function   | a / b          | Input operands                           | LLKOperand    | N/A         | True     |
+ * | Function   | itile0 / itile1| Tile indices within A / B                | uint32_t      | N/A         | True     |
+ * | Function   | idst           | DST register index for the result        | uint32_t      | 0 to 15     | True     |
+ */
+// clang-format on
+template <BroadcastType tBcastDim, DataFormat AFormat, TensorShape AShape, DataFormat BFormat, TensorShape BShape>
+ALWI void add_tiles_bcast(
+    LLKOperand<AFormat, AShape> a,
+    LLKOperand<BFormat, BShape> b,
+    std::uint32_t itile0,
+    std::uint32_t itile1,
+    std::uint32_t idst,
+    std::uint32_t bcast_row_idx = 0) {
+    any_tiles_bcast<EltwiseBinaryType::ELWADD, tBcastDim>(a, b, itile0, itile1, idst, bcast_row_idx);
+}
+
+// clang-format off
+/**
+ * Id-free broadcast sub: C = A - broadcast(B). Shorthand for any_tiles_bcast<ELWSUB, tBcastDim>. See
+ * any_tiles_bcast for the full parameter table and broadcast semantics.
+ *
+ * | Param Type | Name           | Description                              | Type          | Valid Range | Required |
+ * |------------|----------------|------------------------------------------|---------------|-------------|----------|
+ * | Template   | tBcastDim      | The broadcast dim (ROW / COL / SCALAR)   | BroadcastType | N/A         | True     |
+ * | Function   | a / b          | Input operands                           | LLKOperand    | N/A         | True     |
+ * | Function   | itile0 / itile1| Tile indices within A / B                | uint32_t      | N/A         | True     |
+ * | Function   | idst           | DST register index for the result        | uint32_t      | 0 to 15     | True     |
+ */
+// clang-format on
+template <BroadcastType tBcastDim, DataFormat AFormat, TensorShape AShape, DataFormat BFormat, TensorShape BShape>
+ALWI void sub_tiles_bcast(
+    LLKOperand<AFormat, AShape> a,
+    LLKOperand<BFormat, BShape> b,
+    std::uint32_t itile0,
+    std::uint32_t itile1,
+    std::uint32_t idst,
+    std::uint32_t bcast_row_idx = 0) {
+    any_tiles_bcast<EltwiseBinaryType::ELWSUB, tBcastDim>(a, b, itile0, itile1, idst, bcast_row_idx);
+}
+
+// clang-format off
+/**
+ * Id-free broadcast mul: C = A * broadcast(B). Shorthand for any_tiles_bcast<ELWMUL, tBcastDim>. See
+ * any_tiles_bcast for the full parameter table and broadcast semantics. The most common broadcast use.
+ *
+ * | Param Type | Name           | Description                              | Type          | Valid Range | Required |
+ * |------------|----------------|------------------------------------------|---------------|-------------|----------|
+ * | Template   | tBcastDim      | The broadcast dim (ROW / COL / SCALAR)   | BroadcastType | N/A         | True     |
+ * | Function   | a / b          | Input operands                           | LLKOperand    | N/A         | True     |
+ * | Function   | itile0 / itile1| Tile indices within A / B                | uint32_t      | N/A         | True     |
+ * | Function   | idst           | DST register index for the result        | uint32_t      | 0 to 15     | True     |
+ */
+// clang-format on
+template <BroadcastType tBcastDim, DataFormat AFormat, TensorShape AShape, DataFormat BFormat, TensorShape BShape>
+ALWI void mul_tiles_bcast(
+    LLKOperand<AFormat, AShape> a,
+    LLKOperand<BFormat, BShape> b,
+    std::uint32_t itile0,
+    std::uint32_t itile1,
+    std::uint32_t idst,
+    std::uint32_t bcast_row_idx = 0) {
+    any_tiles_bcast<EltwiseBinaryType::ELWMUL, tBcastDim>(a, b, itile0, itile1, idst, bcast_row_idx);
+}
+
+#endif  // ARCH_BLACKHOLE
+
+}  // namespace experimental
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/bcast.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/bcast.h
@@ -178,7 +178,15 @@ template <EltwiseBinaryType tBcastOp, BroadcastType tBcastDim, DataFormat AForma
 ALWI void bcast_init(LLKOperand<AFormat, AShape> /*a*/) {
     static_assert(is_legal_tile_shape(AShape), "bcast_init: illegal tile shape for operand A.");
     static_assert(tBcastDim != BroadcastType::NONE, "bcast_init: use add/sub/mul_init for BroadcastType::NONE.");
-    MATH((llk_math_eltwise_binary_init<LLKOperand<AFormat, AShape>::descriptor, tBcastOp, tBcastDim, MATH_FIDELITY>()));
+    // Per-op fidelity, matching legacy's fixed-op bcast inits ({add,sub}_bcast_*_init use LoFi;
+    // mul_bcast_*_init uses MATH_FIDELITY): ADD/SUB do not use the fidelity multiplier, so LoFi is
+    // correct and saves cycles; MUL keeps MATH_FIDELITY. The whole ternary MUST stay inside MATH()
+    // because MATH_FIDELITY is a MATH-thread-only macro (undefined on the UNPACK/PACK images).
+    MATH((llk_math_eltwise_binary_init<
+          LLKOperand<AFormat, AShape>::descriptor,
+          tBcastOp,
+          tBcastDim,
+          (tBcastOp == EltwiseBinaryType::ELWMUL) ? MATH_FIDELITY : MathFidelity::LoFi>()));
     UNPACK((llk_unpack_AB_init<LLKOperand<AFormat, AShape>::descriptor, tBcastDim>(ckernel::Transpose::None)));
 }
 
@@ -220,12 +228,16 @@ ALWI void any_tiles_bcast(
     static_assert(tBcastDim != BroadcastType::NONE, "any_tiles_bcast: use add/sub/mul_tiles for BroadcastType::NONE.");
     // Match legacy any_tiles_bcast order: MATH then UNPACK. bcast_row_idx selects which row of B's tile the ROW
     // broadcast reads (legacy parity); it is consumed only by the ROW path and ignored by COL / SCALAR.
+    // Per-op fidelity, matching legacy's fixed-op bcast execute wrappers ({add,sub}_tiles_bcast_* use LoFi;
+    // mul_tiles_bcast_* uses MATH_FIDELITY): ADD/SUB do not use the fidelity multiplier, so LoFi is correct
+    // and saves cycles; MUL keeps MATH_FIDELITY. The whole ternary MUST stay inside MATH() because
+    // MATH_FIDELITY is a MATH-thread-only macro (undefined on the UNPACK/PACK images).
     MATH((llk_math_eltwise_binary<
           LLKOperand<AFormat, AShape>::descriptor,
           tBcastOp,
           tBcastDim,
           DST_ACCUM_MODE,
-          MATH_FIDELITY,
+          (tBcastOp == EltwiseBinaryType::ELWMUL) ? MATH_FIDELITY : MathFidelity::LoFi,
           EltwiseBinaryReuseDestType::NONE>(idst, true /*clear_fp32_dst_acc*/)));
     UNPACK((llk_unpack_AB<LLKOperand<AFormat, AShape>::descriptor, tBcastDim, static_cast<std::uint8_t>(BFormat)>(
         detail::tile_address(a, itile0), detail::tile_address(b, itile1), bcast_row_idx)));

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/bcast.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/bcast.h
@@ -127,15 +127,16 @@ ALWI void unary_bcast(LLKOperand<Format, Shape> src, std::uint32_t dst_tile_inde
  *
  * | Param Type | Name      | Description                                                  | Type          | Valid Range | Required |
  * |------------|-----------|--------------------------------------------------------------|---------------|-------------|----------|
- * | Template   | bcast_type| Broadcast mode (must match the paired unary_bcast_init)      | BroadcastType | N/A         | True     |
- * | Template   | Format    | Buffer L1 data format (deduced from the LLKOperand argument)  | DataFormat    | N/A         | True     |
+ * | Template   | bcast_type          | Broadcast mode (must match the paired unary_bcast_init)      | BroadcastType | N/A         | True     |
+ * | Template   | is_fp32_dest_acc_en | fp32 dest-accumulate mode                                    | bool          | N/A         | False    |
+ * | Template   | Format              | Buffer L1 data format (deduced from the LLKOperand argument)  | DataFormat    | N/A         | True     |
  * | Template   | Shape     | Tile geometry (deduced from the LLKOperand argument)         | TensorShape   | N/A         | True     |
  * | Function   | src       | The source L1 operand (format + shape; address unused here)  | LLKOperand    | N/A         | True     |
  */
 // clang-format on
-template <BroadcastType bcast_type, DataFormat Format, TensorShape Shape>
+template <BroadcastType bcast_type, bool is_fp32_dest_acc_en = DST_ACCUM_MODE, DataFormat Format, TensorShape Shape>
 ALWI void unary_bcast_uninit(LLKOperand<Format, Shape> /*src*/) {
-    constexpr bool enable_unpack_to_dest = is_unpack_to_dest<Format, DST_ACCUM_MODE>();
+    constexpr bool enable_unpack_to_dest = is_unpack_to_dest<Format, is_fp32_dest_acc_en>();
     UNPACK((llk_unpack_A_uninit<bcast_type>()));
     MATH((llk_math_eltwise_unary_datacopy_uninit<bcast_type, enable_unpack_to_dest>()));
 }

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/bcast.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/bcast.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include "api/compute/common_globals.h"
 #include "api/compute/experimental/2_0/llk_operand.h"
+#include "data_format_derive.h"  // ckernel::infer_unpack_dst_format
 
 #ifdef TRISC_MATH
 #include "experimental/2_0/llk_math_unary_datacopy.h"
@@ -29,8 +30,10 @@
 //   * BroadcastType::NONE is a pass-through and uses DataCopyType::A2D (the tile stays in SrcA; reading it
 //     back with B2D would copy zeros and hang the unpacker).
 //   * ROW / COL / SCALAR broadcasts leave the tile in SrcB and use DataCopyType::B2D.
-//   * 32-bit formats (Float32/UInt32/Int32) take the unpack-to-dest A2D path (SrcB is only 19 bits wide);
-//     this is derived at COMPILE time from the LLKOperand's Format (legacy derives it at runtime from the CB).
+//   * 32-bit register formats (Float32/UInt32/Int32) take the unpack-to-dest A2D path (SrcB is only 19 bits
+//     wide); this is derived at COMPILE time from the DERIVED REGISTER format via infer_unpack_dst_format,
+//     which accounts for the fp32-dest-acc rebias (matching legacy get_operand_dst_format and transpose.h),
+//     so a 16-bit L1 format under fp32 dest-acc correctly takes the 32-bit unpack-to-dest path.
 // Blackhole only. The Quasar-specific paths and the deprecated CB-id (icb, ocb) full inits are not carried over.
 // =====================================================================================================
 
@@ -40,12 +43,21 @@ namespace experimental {
 #ifdef ARCH_BLACKHOLE
 
 namespace detail {
-// A2D/B2D data-copy direction for the unary broadcast, folded to a constant: 32-bit formats (which take the
-// unpack-to-dest path) and the NONE pass-through use A2D; a real ROW/COL/SCALAR broadcast of a non-32-bit
-// format uses B2D. Shared by unary_bcast_init / unary_bcast so the policy is spelled once.
+// Whether the unary broadcast takes the unpack-to-dest path, decided from the DERIVED REGISTER format
+// (not the raw L1 Format): infer_unpack_dst_format applies the fp32-dest-acc rebias, so a 16-bit L1 format
+// under fp32 dest-acc resolves to a 32-bit register format. Mirrors transpose.h's transpose_unpack_to_dest.
+template <DataFormat Format>
+constexpr bool unary_bcast_unpack_to_dest() {
+    return is_32bit_format(ckernel::infer_unpack_dst_format(Format, DST_ACCUM_MODE));
+}
+
+// A2D/B2D data-copy direction for the unary broadcast, folded to a constant: 32-bit register formats (which
+// take the unpack-to-dest path) and the NONE pass-through use A2D; a real ROW/COL/SCALAR broadcast of a
+// non-32-bit register format uses B2D. Shared by unary_bcast_init / unary_bcast so the policy is spelled once.
 template <BroadcastType bcast_type, DataFormat Format>
 constexpr DataCopyType unary_bcast_dcopy() {
-    return (is_32bit_format(Format) || bcast_type == BroadcastType::NONE) ? DataCopyType::A2D : DataCopyType::B2D;
+    return (unary_bcast_unpack_to_dest<Format>() || bcast_type == BroadcastType::NONE) ? DataCopyType::A2D
+                                                                                       : DataCopyType::B2D;
 }
 }  // namespace detail
 
@@ -69,8 +81,9 @@ ALWI void unary_bcast_init(LLKOperand<Format, Shape> /*src*/) {
     static_assert(
         is_legal_tile_shape(Shape),
         "unary_bcast_init: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
-    // 32-bit formats use the unpack-to-dest A2D path (SrcB is only 19 bits wide); folds to a constant.
-    constexpr bool enable_unpack_to_dest = is_32bit_format(Format);
+    // 32-bit register formats use the unpack-to-dest A2D path (SrcB is only 19 bits wide); the decision is
+    // from the derived register format (fp32-dest-acc rebias aware), not the raw L1 Format. Folds to a constant.
+    constexpr bool enable_unpack_to_dest = detail::unary_bcast_unpack_to_dest<Format>();
     constexpr DataCopyType dcopy = detail::unary_bcast_dcopy<bcast_type, Format>();
     UNPACK((llk_unpack_A_init<
             LLKOperand<Format, Shape>::descriptor,
@@ -106,7 +119,7 @@ ALWI void unary_bcast(LLKOperand<Format, Shape> src, std::uint32_t dst_tile_inde
     static_assert(
         is_legal_tile_shape(Shape),
         "unary_bcast: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
-    constexpr bool enable_unpack_to_dest = is_32bit_format(Format);
+    constexpr bool enable_unpack_to_dest = detail::unary_bcast_unpack_to_dest<Format>();
     constexpr DataCopyType dcopy = detail::unary_bcast_dcopy<bcast_type, Format>();
     UNPACK((llk_unpack_A<
             LLKOperand<Format, Shape>::descriptor,
@@ -139,7 +152,7 @@ ALWI void unary_bcast(LLKOperand<Format, Shape> src, std::uint32_t dst_tile_inde
 // clang-format on
 template <BroadcastType bcast_type, DataFormat Format, TensorShape Shape>
 ALWI void unary_bcast_uninit(LLKOperand<Format, Shape> /*src*/) {
-    constexpr bool enable_unpack_to_dest = is_32bit_format(Format);
+    constexpr bool enable_unpack_to_dest = detail::unary_bcast_unpack_to_dest<Format>();
     UNPACK((llk_unpack_A_uninit<bcast_type>()));
     MATH((llk_math_eltwise_unary_datacopy_uninit<bcast_type, enable_unpack_to_dest>()));
 }

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/bcast.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/bcast.h
@@ -7,7 +7,6 @@
 #include <cstdint>
 #include "api/compute/common_globals.h"
 #include "api/compute/experimental/2_0/llk_operand.h"
-#include "data_format_derive.h"  // ckernel::infer_unpack_dst_format
 
 #ifdef TRISC_MATH
 #include "experimental/2_0/llk_math_unary_datacopy.h"
@@ -37,23 +36,13 @@
 namespace ckernel {
 namespace experimental {
 
-#ifdef ARCH_BLACKHOLE
-
 namespace detail {
-// Whether the unary broadcast takes the unpack-to-dest path, decided from the DERIVED REGISTER format
-// (fp32-dest-acc rebias aware), not the raw L1 Format.
-template <DataFormat Format, bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
-constexpr bool unary_bcast_unpack_to_dest() {
-    return is_32bit_format(ckernel::infer_unpack_dst_format(Format, is_fp32_dest_acc_en));
-}
-
 // A2D/B2D data-copy direction for the unary broadcast, folded to a constant. Shared by unary_bcast_init /
 // unary_bcast so the policy is spelled once.
 template <BroadcastType bcast_type, DataFormat Format, bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 constexpr DataCopyType unary_bcast_dcopy() {
-    return (unary_bcast_unpack_to_dest<Format, is_fp32_dest_acc_en>() || bcast_type == BroadcastType::NONE)
-               ? DataCopyType::A2D
-               : DataCopyType::B2D;
+    return (is_unpack_to_dest<Format, is_fp32_dest_acc_en>() || bcast_type == BroadcastType::NONE) ? DataCopyType::A2D
+                                                                                                   : DataCopyType::B2D;
 }
 }  // namespace detail
 
@@ -77,7 +66,7 @@ ALWI void unary_bcast_init(LLKOperand<Format, Shape> /*src*/) {
         is_legal_tile_shape(Shape),
         "unary_bcast_init: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
     // 32-bit register formats use the unpack-to-dest A2D path (SrcB is only 19 bits wide); folds to a constant.
-    constexpr bool enable_unpack_to_dest = detail::unary_bcast_unpack_to_dest<Format, is_fp32_dest_acc_en>();
+    constexpr bool enable_unpack_to_dest = is_unpack_to_dest<Format, is_fp32_dest_acc_en>();
     constexpr DataCopyType dcopy = detail::unary_bcast_dcopy<bcast_type, Format, is_fp32_dest_acc_en>();
     UNPACK((llk_unpack_A_init<
             LLKOperand<Format, Shape>::descriptor,
@@ -114,7 +103,7 @@ ALWI void unary_bcast(LLKOperand<Format, Shape> src, std::uint32_t dst_tile_inde
     static_assert(
         is_legal_tile_shape(Shape),
         "unary_bcast: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
-    constexpr bool enable_unpack_to_dest = detail::unary_bcast_unpack_to_dest<Format, is_fp32_dest_acc_en>();
+    constexpr bool enable_unpack_to_dest = is_unpack_to_dest<Format, is_fp32_dest_acc_en>();
     constexpr DataCopyType dcopy = detail::unary_bcast_dcopy<bcast_type, Format, is_fp32_dest_acc_en>();
     UNPACK((llk_unpack_A<
             LLKOperand<Format, Shape>::descriptor,
@@ -146,7 +135,7 @@ ALWI void unary_bcast(LLKOperand<Format, Shape> src, std::uint32_t dst_tile_inde
 // clang-format on
 template <BroadcastType bcast_type, DataFormat Format, TensorShape Shape>
 ALWI void unary_bcast_uninit(LLKOperand<Format, Shape> /*src*/) {
-    constexpr bool enable_unpack_to_dest = detail::unary_bcast_unpack_to_dest<Format, DST_ACCUM_MODE>();
+    constexpr bool enable_unpack_to_dest = is_unpack_to_dest<Format, DST_ACCUM_MODE>();
     UNPACK((llk_unpack_A_uninit<bcast_type>()));
     MATH((llk_math_eltwise_unary_datacopy_uninit<bcast_type, enable_unpack_to_dest>()));
 }
@@ -338,8 +327,6 @@ ALWI void mul_tiles_bcast(
     any_tiles_bcast<EltwiseBinaryType::ELWMUL, tBcastDim, is_fp32_dest_acc_en>(
         a, b, itile0, itile1, idst, bcast_row_idx);
 }
-
-#endif  // ARCH_BLACKHOLE
 
 }  // namespace experimental
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/bcast.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/bcast.h
@@ -20,21 +20,18 @@
 #endif
 
 // =====================================================================================================
-// Id-free (2.0) unary broadcast (unary_bcast). Single-input op: unpacks one L1 tile (with the requested
-// broadcast mode) and datacopies it into DST. Mirrors the legacy ckernel::unary_bcast<bcast_type> family
-// (init/op/uninit) but takes an LLKOperand<Format,Shape> instead of a CB id: Format + Shape are compile-time
-// NTTPs forwarded to the LLK as LLKOperand::descriptor (folds/DCE), and l1_address is the only runtime state.
-// The register format is derived INSIDE the reused LLK overloads; no CB id / register format on the API.
+// Id-free (2.0) unary broadcast (unary_bcast): unpacks one L1 tile (with the requested broadcast mode) and
+// datacopies it into DST. Takes an LLKOperand<Format,Shape> instead of a CB id: Format + Shape are
+// compile-time NTTPs, l1_address is the only runtime state.
 //
-// Broadcast mode / DataCopyType selection matches the legacy op exactly:
-//   * BroadcastType::NONE is a pass-through and uses DataCopyType::A2D (the tile stays in SrcA; reading it
-//     back with B2D would copy zeros and hang the unpacker).
-//   * ROW / COL / SCALAR broadcasts leave the tile in SrcB and use DataCopyType::B2D.
-//   * 32-bit register formats (Float32/UInt32/Int32) take the unpack-to-dest A2D path (SrcB is only 19 bits
-//     wide); this is derived at COMPILE time from the DERIVED REGISTER format via infer_unpack_dst_format,
-//     which accounts for the fp32-dest-acc rebias (matching legacy get_operand_dst_format and transpose.h),
-//     so a 16-bit L1 format under fp32 dest-acc correctly takes the 32-bit unpack-to-dest path.
-// Blackhole only. The Quasar-specific paths and the deprecated CB-id (icb, ocb) full inits are not carried over.
+// A2D vs B2D selection:
+//   * BroadcastType::NONE is a pass-through and uses A2D (reading a SrcB-resident tile back with B2D would
+//     copy zeros and hang the unpacker).
+//   * ROW / COL / SCALAR broadcasts leave the tile in SrcB and use B2D.
+//   * 32-bit register formats (Float32/UInt32/Int32) always take the unpack-to-dest A2D path (SrcB is only
+//     19 bits wide); decided from the DERIVED register format via infer_unpack_dst_format (fp32-dest-acc
+//     rebias aware), so a 16-bit L1 format under fp32 dest-acc is still routed correctly.
+// Blackhole only.
 // =====================================================================================================
 
 namespace ckernel {
@@ -44,16 +41,14 @@ namespace experimental {
 
 namespace detail {
 // Whether the unary broadcast takes the unpack-to-dest path, decided from the DERIVED REGISTER format
-// (not the raw L1 Format): infer_unpack_dst_format applies the fp32-dest-acc rebias, so a 16-bit L1 format
-// under fp32 dest-acc resolves to a 32-bit register format. Mirrors transpose.h's transpose_unpack_to_dest.
+// (fp32-dest-acc rebias aware), not the raw L1 Format.
 template <DataFormat Format>
 constexpr bool unary_bcast_unpack_to_dest() {
     return is_32bit_format(ckernel::infer_unpack_dst_format(Format, DST_ACCUM_MODE));
 }
 
-// A2D/B2D data-copy direction for the unary broadcast, folded to a constant: 32-bit register formats (which
-// take the unpack-to-dest path) and the NONE pass-through use A2D; a real ROW/COL/SCALAR broadcast of a
-// non-32-bit register format uses B2D. Shared by unary_bcast_init / unary_bcast so the policy is spelled once.
+// A2D/B2D data-copy direction for the unary broadcast, folded to a constant. Shared by unary_bcast_init /
+// unary_bcast so the policy is spelled once.
 template <BroadcastType bcast_type, DataFormat Format>
 constexpr DataCopyType unary_bcast_dcopy() {
     return (unary_bcast_unpack_to_dest<Format>() || bcast_type == BroadcastType::NONE) ? DataCopyType::A2D
@@ -63,10 +58,8 @@ constexpr DataCopyType unary_bcast_dcopy() {
 
 // clang-format off
 /**
- * Paired init for experimental::unary_bcast. Configures the unpack + math pipeline for the id-free unary
- * broadcast op; call before unary_bcast (including when switching to it from another op). The one-time
- * hardware configuration must already have been performed via compute_kernel_hw_startup at kernel start.
- * The broadcast mode and A2D/B2D data-copy direction are fixed here from bcast_type + the operand Format.
+ * Paired init for unary_bcast. Configures the unpack + math pipeline for the given broadcast mode and
+ * operand Format; call before unary_bcast. compute_kernel_hw_startup must already have run.
  *
  * | Param Type | Name      | Description                                                  | Type          | Valid Range           | Required |
  * |------------|-----------|--------------------------------------------------------------|---------------|-----------------------|----------|
@@ -81,8 +74,7 @@ ALWI void unary_bcast_init(LLKOperand<Format, Shape> /*src*/) {
     static_assert(
         is_legal_tile_shape(Shape),
         "unary_bcast_init: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
-    // 32-bit register formats use the unpack-to-dest A2D path (SrcB is only 19 bits wide); the decision is
-    // from the derived register format (fp32-dest-acc rebias aware), not the raw L1 Format. Folds to a constant.
+    // 32-bit register formats use the unpack-to-dest A2D path (SrcB is only 19 bits wide); folds to a constant.
     constexpr bool enable_unpack_to_dest = detail::unary_bcast_unpack_to_dest<Format>();
     constexpr DataCopyType dcopy = detail::unary_bcast_dcopy<bcast_type, Format>();
     UNPACK((llk_unpack_A_init<
@@ -138,9 +130,8 @@ ALWI void unary_bcast(LLKOperand<Format, Shape> src, std::uint32_t dst_tile_inde
 
 // clang-format off
 /**
- * Paired uninit for experimental::unary_bcast. Restores the unpack + math pipeline so a following op can be
- * initialized cleanly. The underlying LLK uninits are format-free; the operand is taken only so the 32-bit
- * unpack-to-dest math-uninit variant is selected consistently with unary_bcast_init (folds to a constant).
+ * Paired uninit for unary_bcast. Restores the unpack + math pipeline; the operand is only used to select
+ * the matching 32-bit unpack-to-dest uninit variant.
  *
  * | Param Type | Name      | Description                                                  | Type          | Valid Range | Required |
  * |------------|-----------|--------------------------------------------------------------|---------------|-------------|----------|
@@ -158,25 +149,21 @@ ALWI void unary_bcast_uninit(LLKOperand<Format, Shape> /*src*/) {
 }
 
 // =====================================================================================================
-// Id-free (2.0) BINARY broadcast (any_tiles_bcast<EltwiseBinaryType, BroadcastType>). Two-input op: C = A [op]
-// broadcast(B), where B is a single tile broadcast across A per the BroadcastType (ROW / COL / SCALAR). Mirrors
-// the legacy ckernel::any_tiles_bcast<tBcastOp, tBcastDim> (bcast_init + any_tiles_bcast) but takes one
-// LLKOperand per input instead of CB ids: Format + Shape are compile-time NTTPs, l1_address the only runtime
-// state. Binary bcast is FORMAT-FREE at the op level (src/dst register formats are programmed once at
-// compute_kernel_hw_startup); geometry (for MATH + the AB-unpack init) is taken from operand A, matching legacy.
-// Per-tile input addresses are derived from each operand's geometry via tile_stride_words (one-tile page).
+// Id-free (2.0) binary broadcast (any_tiles_bcast<EltwiseBinaryType, BroadcastType>): C = A [op]
+// broadcast(B), where B is a single tile broadcast across A per BroadcastType (ROW / COL / SCALAR). Takes
+// one LLKOperand per input instead of CB ids: Format + Shape are compile-time NTTPs, l1_address the only
+// runtime state. Format-free at the op level (src/dst register formats are programmed once at
+// compute_kernel_hw_startup); geometry (for MATH + the AB-unpack init) comes from operand A.
 //
-// The ROW broadcast path additionally needs operand B's L1 format (forwarded as the OperandBFormat NTTP of the
-// id-free llk_unpack_AB); COL / SCALAR ignore it. BroadcastType::NONE (plain binary) belongs to
-// experimental::add/sub/mul_tiles in eltwise_binary.h, not here.
+// The ROW path additionally needs operand B's L1 format (forwarded to the unpacker); COL / SCALAR ignore
+// it. BroadcastType::NONE (plain binary) belongs to experimental::add/sub/mul_tiles in eltwise_binary.h.
 // =====================================================================================================
 
 // clang-format off
 /**
- * Paired init for experimental::any_tiles_bcast (generic op/dim). Configures MATH + the AB unpacker for the
- * id-free binary broadcast op; call before any_tiles_bcast (including when switching to it from another op).
- * The one-time hardware configuration must already have been performed via compute_kernel_hw_startup(a, b, out)
- * at kernel start. Geometry comes from operand A (A.shape == B.shape assumed for the non-broadcast dims).
+ * Paired init for any_tiles_bcast (generic op/dim). Configures MATH + the AB unpacker; call before
+ * any_tiles_bcast. compute_kernel_hw_startup(a, b, out) must already have run. Geometry comes from operand
+ * A (A.shape == B.shape assumed for the non-broadcast dims).
  *
  * | Param Type | Name      | Description                                                  | Type              | Valid Range | Required |
  * |------------|-----------|--------------------------------------------------------------|-------------------|-------------|----------|
@@ -191,10 +178,8 @@ template <EltwiseBinaryType tBcastOp, BroadcastType tBcastDim, DataFormat AForma
 ALWI void bcast_init(LLKOperand<AFormat, AShape> /*a*/) {
     static_assert(is_legal_tile_shape(AShape), "bcast_init: illegal tile shape for operand A.");
     static_assert(tBcastDim != BroadcastType::NONE, "bcast_init: use add/sub/mul_init for BroadcastType::NONE.");
-    // Per-op fidelity, matching legacy's fixed-op bcast inits ({add,sub}_bcast_*_init use LoFi;
-    // mul_bcast_*_init uses MATH_FIDELITY): ADD/SUB do not use the fidelity multiplier, so LoFi is
-    // correct and saves cycles; MUL keeps MATH_FIDELITY. The whole ternary MUST stay inside MATH()
-    // because MATH_FIDELITY is a MATH-thread-only macro (undefined on the UNPACK/PACK images).
+    // ADD/SUB use LoFi (no fidelity multiplier), MUL uses MATH_FIDELITY; the ternary must stay inside MATH()
+    // since MATH_FIDELITY is a MATH-thread-only macro.
     MATH((llk_math_eltwise_binary_init<
           LLKOperand<AFormat, AShape>::descriptor,
           tBcastOp,
@@ -205,10 +190,10 @@ ALWI void bcast_init(LLKOperand<AFormat, AShape> /*a*/) {
 
 // clang-format off
 /**
- * Id-free binary broadcast: C = A [tBcastOp] broadcast(B) for one tile pair, writing DST[idst]. B is a single
- * tile broadcast across A per tBcastDim (COL: B's row 0; ROW: B's col 0; SCALAR: B[0,0]). Pair with bcast_init.
- * The DST register must be acquired. Blocking; compute-engine only. itile0/itile1 index within A/B; geometry
- * (for MATH) comes from operand A, matching legacy. The ROW path forwards operand B's L1 format to the unpacker.
+ * Binary broadcast: C = A [tBcastOp] broadcast(B) for one tile pair, writing DST[idst]. B is broadcast
+ * across A per tBcastDim (COL: B's row 0; ROW: B's col 0; SCALAR: B[0,0]). Pair with bcast_init; DST must
+ * be acquired. itile0/itile1 index within A/B; geometry comes from operand A. The ROW path forwards
+ * operand B's L1 format to the unpacker.
  *
  * | Param Type | Name            | Description                                              | Type              | Valid Range | Required |
  * |------------|-----------------|--------------------------------------------------------|-------------------|-------------|----------|
@@ -239,12 +224,9 @@ ALWI void any_tiles_bcast(
     static_assert(is_legal_tile_shape(AShape), "any_tiles_bcast: illegal tile shape for operand A.");
     static_assert(is_legal_tile_shape(BShape), "any_tiles_bcast: illegal tile shape for operand B.");
     static_assert(tBcastDim != BroadcastType::NONE, "any_tiles_bcast: use add/sub/mul_tiles for BroadcastType::NONE.");
-    // Match legacy any_tiles_bcast order: MATH then UNPACK. bcast_row_idx selects which row of B's tile the ROW
-    // broadcast reads (legacy parity); it is consumed only by the ROW path and ignored by COL / SCALAR.
-    // Per-op fidelity, matching legacy's fixed-op bcast execute wrappers ({add,sub}_tiles_bcast_* use LoFi;
-    // mul_tiles_bcast_* uses MATH_FIDELITY): ADD/SUB do not use the fidelity multiplier, so LoFi is correct
-    // and saves cycles; MUL keeps MATH_FIDELITY. The whole ternary MUST stay inside MATH() because
-    // MATH_FIDELITY is a MATH-thread-only macro (undefined on the UNPACK/PACK images).
+    // bcast_row_idx selects which row of B's tile the ROW broadcast reads; ignored by COL / SCALAR.
+    // ADD/SUB use LoFi (no fidelity multiplier), MUL uses MATH_FIDELITY; the ternary must stay inside MATH()
+    // since MATH_FIDELITY is a MATH-thread-only macro.
     MATH((llk_math_eltwise_binary<
           LLKOperand<AFormat, AShape>::descriptor,
           tBcastOp,

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/eltwise_binary.h
@@ -339,6 +339,7 @@ namespace detail {
 template <
     EltwiseBinaryType eltwise_binary_type,
     EltwiseBinaryReuseDestType reuse_dest,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
     DataFormat Format,
     TensorShape Shape>
 ALWI void binary_reuse_dest_init(LLKOperand<Format, Shape> /*in*/) {
@@ -346,7 +347,7 @@ ALWI void binary_reuse_dest_init(LLKOperand<Format, Shape> /*in*/) {
     // BH: accumulate the unpacked operand into DST at the unpacker (acc_to_dest = true).
     UNPACK((llk_unpack_A_init<
             LLKOperand<Format, Shape>::descriptor,
-            DST_ACCUM_MODE,
+            is_fp32_dest_acc_en,
             BroadcastType::NONE,
             true /*acc_to_dest*/,
             reuse_dest>()));
@@ -363,6 +364,7 @@ ALWI void binary_reuse_dest_init(LLKOperand<Format, Shape> /*in*/) {
 template <
     EltwiseBinaryType eltwise_binary_type,
     EltwiseBinaryReuseDestType reuse_dest,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
     DataFormat Format,
     TensorShape Shape>
 ALWI void binary_reuse_dest_tiles(
@@ -370,7 +372,7 @@ ALWI void binary_reuse_dest_tiles(
     static_assert(is_legal_tile_shape(Shape), "binary_reuse_dest_tiles: illegal tile shape for the L1 operand.");
     UNPACK((llk_unpack_A<
             LLKOperand<Format, Shape>::descriptor,
-            DST_ACCUM_MODE,
+            is_fp32_dest_acc_en,
             BroadcastType::NONE,
             true /*acc_to_dest*/,
             reuse_dest>(tile_address(in, in_tile_index))));
@@ -378,7 +380,7 @@ ALWI void binary_reuse_dest_tiles(
           LLKOperand<Format, Shape>::descriptor,
           eltwise_binary_type,
           BroadcastType::NONE,
-          DST_ACCUM_MODE,
+          is_fp32_dest_acc_en,
           MATH_FIDELITY,
           reuse_dest>(dst_tile_index, true /*clear_fp32_dst_acc*/)));
 }
@@ -395,16 +397,21 @@ ALWI void binary_reuse_dest_tiles(
  *
  * | Param Type | Name       | Description                                                       | Type                       | Valid Range | Required |
  * |------------|------------|-------------------------------------------------------------------|----------------------------|-------------|----------|
- * | Template   | reuse_dest | Which source register the DST operand is loaded into (non-NONE)   | EltwiseBinaryReuseDestType | N/A         | True     |
- * | Function   | in         | L1 operand unpacked into the source register not fed by DST        | LLKOperand                 | N/A         | True     |
+ * | Template   | reuse_dest          | Which source register the DST operand is loaded into (non-NONE)   | EltwiseBinaryReuseDestType | N/A         | True     |
+ * | Template   | is_fp32_dest_acc_en | fp32 dest-accumulate mode                                         | bool                       |             | False    |
+ * | Function   | in                  | L1 operand unpacked into the source register not fed by DST        | LLKOperand                 | N/A         | True     |
  */
 // clang-format on
-template <EltwiseBinaryReuseDestType reuse_dest, DataFormat Format, TensorShape Shape>
+template <
+    EltwiseBinaryReuseDestType reuse_dest,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    DataFormat Format,
+    TensorShape Shape>
 ALWI void add_reuse_dest_init(LLKOperand<Format, Shape> in) {
     static_assert(
         reuse_dest != EltwiseBinaryReuseDestType::NONE,
         "reuse_dest must be DEST_TO_SRCA or DEST_TO_SRCB; for the two-operand op call add_init(a).");
-    detail::binary_reuse_dest_init<EltwiseBinaryType::ELWADD, reuse_dest>(in);
+    detail::binary_reuse_dest_init<EltwiseBinaryType::ELWADD, reuse_dest, is_fp32_dest_acc_en>(in);
 }
 
 // clang-format off
@@ -418,12 +425,16 @@ ALWI void add_reuse_dest_init(LLKOperand<Format, Shape> in) {
  * | Function   | in         | L1 operand unpacked into the source register not fed by DST        | LLKOperand                 | N/A         | True     |
  */
 // clang-format on
-template <EltwiseBinaryReuseDestType reuse_dest, DataFormat Format, TensorShape Shape>
+template <
+    EltwiseBinaryReuseDestType reuse_dest,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    DataFormat Format,
+    TensorShape Shape>
 ALWI void sub_reuse_dest_init(LLKOperand<Format, Shape> in) {
     static_assert(
         reuse_dest != EltwiseBinaryReuseDestType::NONE,
         "reuse_dest must be DEST_TO_SRCA or DEST_TO_SRCB; for the two-operand op call sub_init(a).");
-    detail::binary_reuse_dest_init<EltwiseBinaryType::ELWSUB, reuse_dest>(in);
+    detail::binary_reuse_dest_init<EltwiseBinaryType::ELWSUB, reuse_dest, is_fp32_dest_acc_en>(in);
 }
 
 // clang-format off
@@ -437,12 +448,16 @@ ALWI void sub_reuse_dest_init(LLKOperand<Format, Shape> in) {
  * | Function   | in         | L1 operand unpacked into the source register not fed by DST        | LLKOperand                 | N/A         | True     |
  */
 // clang-format on
-template <EltwiseBinaryReuseDestType reuse_dest, DataFormat Format, TensorShape Shape>
+template <
+    EltwiseBinaryReuseDestType reuse_dest,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    DataFormat Format,
+    TensorShape Shape>
 ALWI void mul_reuse_dest_init(LLKOperand<Format, Shape> in) {
     static_assert(
         reuse_dest != EltwiseBinaryReuseDestType::NONE,
         "reuse_dest must be DEST_TO_SRCA or DEST_TO_SRCB; for the two-operand op call mul_init(a).");
-    detail::binary_reuse_dest_init<EltwiseBinaryType::ELWMUL, reuse_dest>(in);
+    detail::binary_reuse_dest_init<EltwiseBinaryType::ELWMUL, reuse_dest, is_fp32_dest_acc_en>(in);
 }
 
 // clang-format off
@@ -461,10 +476,15 @@ ALWI void mul_reuse_dest_init(LLKOperand<Format, Shape> in) {
  * | Function   | dst_tile_index | DST tile used as the other operand and as the result               | uint32_t                   | < DST size  | True     |
  */
 // clang-format on
-template <EltwiseBinaryReuseDestType reuse_dest, DataFormat Format, TensorShape Shape>
+template <
+    EltwiseBinaryReuseDestType reuse_dest,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    DataFormat Format,
+    TensorShape Shape>
 ALWI void add_reuse_dest_tiles(
     LLKOperand<Format, Shape> in, std::uint32_t in_tile_index, std::uint32_t dst_tile_index) {
-    detail::binary_reuse_dest_tiles<EltwiseBinaryType::ELWADD, reuse_dest>(in, in_tile_index, dst_tile_index);
+    detail::binary_reuse_dest_tiles<EltwiseBinaryType::ELWADD, reuse_dest, is_fp32_dest_acc_en>(
+        in, in_tile_index, dst_tile_index);
 }
 
 // clang-format off
@@ -480,10 +500,15 @@ ALWI void add_reuse_dest_tiles(
  * | Function   | dst_tile_index | DST tile used as the other operand and as the result               | uint32_t                   | < DST size  | True     |
  */
 // clang-format on
-template <EltwiseBinaryReuseDestType reuse_dest, DataFormat Format, TensorShape Shape>
+template <
+    EltwiseBinaryReuseDestType reuse_dest,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    DataFormat Format,
+    TensorShape Shape>
 ALWI void sub_reuse_dest_tiles(
     LLKOperand<Format, Shape> in, std::uint32_t in_tile_index, std::uint32_t dst_tile_index) {
-    detail::binary_reuse_dest_tiles<EltwiseBinaryType::ELWSUB, reuse_dest>(in, in_tile_index, dst_tile_index);
+    detail::binary_reuse_dest_tiles<EltwiseBinaryType::ELWSUB, reuse_dest, is_fp32_dest_acc_en>(
+        in, in_tile_index, dst_tile_index);
 }
 
 // clang-format off
@@ -499,10 +524,15 @@ ALWI void sub_reuse_dest_tiles(
  * | Function   | dst_tile_index | DST tile used as the other operand and as the result               | uint32_t                   | < DST size  | True     |
  */
 // clang-format on
-template <EltwiseBinaryReuseDestType reuse_dest, DataFormat Format, TensorShape Shape>
+template <
+    EltwiseBinaryReuseDestType reuse_dest,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    DataFormat Format,
+    TensorShape Shape>
 ALWI void mul_reuse_dest_tiles(
     LLKOperand<Format, Shape> in, std::uint32_t in_tile_index, std::uint32_t dst_tile_index) {
-    detail::binary_reuse_dest_tiles<EltwiseBinaryType::ELWMUL, reuse_dest>(in, in_tile_index, dst_tile_index);
+    detail::binary_reuse_dest_tiles<EltwiseBinaryType::ELWMUL, reuse_dest, is_fp32_dest_acc_en>(
+        in, in_tile_index, dst_tile_index);
 }
 
 }  // namespace experimental

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/eltwise_binary.h
@@ -20,8 +20,6 @@
 namespace ckernel {
 namespace experimental {
 
-#ifdef ARCH_BLACKHOLE
-
 // Id-free (2.0) two-operand eltwise binary (add/sub/mul). Each op takes one LLKOperand per input
 // (A -> SrcA, B -> SrcB); format+geometry are NTTPs, L1 addresses the only runtime state. Format-free at
 // the op level: src/dst register formats are programmed at compute_kernel_hw_startup; the op forwards only
@@ -506,8 +504,6 @@ ALWI void mul_reuse_dest_tiles(
     LLKOperand<Format, Shape> in, std::uint32_t in_tile_index, std::uint32_t dst_tile_index) {
     detail::binary_reuse_dest_tiles<EltwiseBinaryType::ELWMUL, reuse_dest>(in, in_tile_index, dst_tile_index);
 }
-
-#endif  // ARCH_BLACKHOLE
 
 }  // namespace experimental
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/eltwise_binary.h
@@ -23,26 +23,21 @@ namespace experimental {
 #ifdef ARCH_BLACKHOLE
 
 // Id-free (2.0) two-operand eltwise binary (add/sub/mul). Each op takes one LLKOperand per input
-// (A -> SrcA, B -> SrcB), format+geometry as NTTPs, L1 addresses the only runtime state. Binary is
-// FORMAT-FREE at the op level: the src/dst register formats are programmed at compute_kernel_hw_startup;
-// the op forwards only geometry (from operand A, mirroring legacy) + the two per-tile L1 addresses. Packing
-// is done separately via the id-free experimental::pack_tile. The two-operand ops are BroadcastType::NONE
-// only (broadcast lives in bcast.h); the dest-reuse (accumulation) variants ARE part of this surface -- see
-// the add/sub/mul_reuse_dest_* family further down.
+// (A -> SrcA, B -> SrcB); format+geometry are NTTPs, L1 addresses the only runtime state. Format-free at
+// the op level: src/dst register formats are programmed at compute_kernel_hw_startup; the op forwards only
+// geometry (from operand A) + the two per-tile L1 addresses. Packing is separate (experimental::pack_tile).
+// BroadcastType::NONE only (broadcast lives in bcast.h); dest-reuse (accumulation) variants are further down.
 
 // clang-format off
 /**
- * Paired init for a two-operand eltwise binary op. Always configures BOTH MATH and the AB unpacker (a full
- * init) from operand A's descriptor. Geometry is taken from operand A. compute_kernel_hw_startup(a_cb, b_cb,
- * out_cb) must already have programmed the formats.
+ * Paired init for a two-operand eltwise binary op. Configures MATH and the AB unpacker from operand A's
+ * descriptor; geometry comes from operand A. compute_kernel_hw_startup(a_cb, b_cb, out_cb) must already have
+ * programmed the formats. Operand B contributes nothing at init -- A.shape == B.shape is enforced at
+ * execute (add/sub/mul_tiles).
  *
  * | Template | eltwise_binary_type | ELWADD / ELWSUB / ELWMUL               | EltwiseBinaryType |  | True |
  * | Function | a                   | Operand A (A -> SrcA); drives geometry | LLKOperand       |  | True |
  * | Function | acc_to_dest         | Accumulate the result into DST         | bool             |  | False |
- *
- * NOTE (PART B): the init forwards ONLY operand A's descriptor (geometry + format), mirroring legacy which
- * inits from a single operand. Operand B contributes nothing to init, so it is not taken here; the
- * A.shape == B.shape requirement is enforced at the execute (add/sub/mul_tiles), which does see both.
  */
 // clang-format on
 template <EltwiseBinaryType eltwise_binary_type, DataFormat AFormat, TensorShape AShape>
@@ -114,9 +109,8 @@ ALWI void mul_init(LLKOperand<AFormat, AShape> a, bool acc_to_dest = true) {
 
 // clang-format off
 /**
- * Element-wise C = A [op] B for one tile pair, writing DST[idst]. Pair with the matching *_init. The DST
- * register must be acquired. itile0/itile1 index within operand A/B; idst indexes DST. Geometry (for MATH)
- * comes from operand A, matching the legacy op.
+ * Element-wise C = A [op] B for one tile pair, writing DST[idst]. Pair with the matching *_init. DST must
+ * be acquired. itile0/itile1 index within A/B; idst indexes DST. Geometry (for MATH) comes from operand A.
  *
  * | Function | a / b           | Input operands                      | LLKOperand | | True |
  * | Function | itile0 / itile1 | Tile indices within A / B           | uint32_t   | | True |
@@ -209,12 +203,9 @@ ALWI void mul_tiles(
 
 // clang-format off
 /**
- * Element-wise C = A + B over `ntiles` consecutive tile pairs, writing DST[start_idst + i]. Block/loop form of
- * add_tiles: a pure compute-layer loop over the existing 2.0 add_tiles (mirrors copy_block over copy_tile), so
- * it inherits add_tiles's semantics and requires the same init (add_init). Tile (start_itile0 + i) of A is
- * paired with tile (start_itile1 + i) of B; each per-tile source address is the operand base offset by
- * (start_i + i) * tile_stride_words(Format, Shape) 16-byte words (folds to a compile-time stride). No CB id, no
- * register format on the API. The DST register must be acquired; start_idst + ntiles <= DST size.
+ * Element-wise C = A + B over `ntiles` consecutive tile pairs, writing DST[start_idst + i]. Loop form of
+ * add_tiles (same semantics, same init: add_init). Tile (start_itile0 + i) of A pairs with tile
+ * (start_itile1 + i) of B. DST must be acquired; start_idst + ntiles <= DST size.
  *
  * | Param Type | Name          | Description                                       | Type       | Valid Range | Required |
  * |------------|---------------|--------------------------------------------------|------------|-------------|----------|
@@ -242,12 +233,9 @@ ALWI void add_block(
 
 // clang-format off
 /**
- * Element-wise C = A - B over `ntiles` consecutive tile pairs, writing DST[start_idst + i]. Block/loop form of
- * sub_tiles: a pure compute-layer loop over the existing 2.0 sub_tiles (mirrors copy_block over copy_tile), so
- * it inherits sub_tiles's semantics and requires the same init (sub_init). Tile (start_itile0 + i) of A is
- * paired with tile (start_itile1 + i) of B; each per-tile source address is the operand base offset by
- * (start_i + i) * tile_stride_words(Format, Shape) 16-byte words (folds to a compile-time stride). No CB id, no
- * register format on the API. The DST register must be acquired; start_idst + ntiles <= DST size.
+ * Element-wise C = A - B over `ntiles` consecutive tile pairs, writing DST[start_idst + i]. Loop form of
+ * sub_tiles (same semantics, same init: sub_init). Tile (start_itile0 + i) of A pairs with tile
+ * (start_itile1 + i) of B. DST must be acquired; start_idst + ntiles <= DST size.
  *
  * | Param Type | Name          | Description                                       | Type       | Valid Range | Required |
  * |------------|---------------|--------------------------------------------------|------------|-------------|----------|
@@ -275,12 +263,9 @@ ALWI void sub_block(
 
 // clang-format off
 /**
- * Element-wise C = A * B over `ntiles` consecutive tile pairs, writing DST[start_idst + i]. Block/loop form of
- * mul_tiles: a pure compute-layer loop over the existing 2.0 mul_tiles (mirrors copy_block over copy_tile), so
- * it inherits mul_tiles's semantics and requires the same init (mul_init). Tile (start_itile0 + i) of A is
- * paired with tile (start_itile1 + i) of B; each per-tile source address is the operand base offset by
- * (start_i + i) * tile_stride_words(Format, Shape) 16-byte words (folds to a compile-time stride). No CB id, no
- * register format on the API. The DST register must be acquired; start_idst + ntiles <= DST size.
+ * Element-wise C = A * B over `ntiles` consecutive tile pairs, writing DST[start_idst + i]. Loop form of
+ * mul_tiles (same semantics, same init: mul_init). Tile (start_itile0 + i) of A pairs with tile
+ * (start_itile1 + i) of B. DST must be acquired; start_idst + ntiles <= DST size.
  *
  * | Param Type | Name          | Description                                       | Type       | Valid Range | Required |
  * |------------|---------------|--------------------------------------------------|------------|-------------|----------|
@@ -308,12 +293,9 @@ ALWI void mul_block(
 
 // =====================================================================================================================
 // Dest-reuse (accumulation) binary ops: one operand is taken from the DST register instead of a second L1
-// buffer. This is the id-free successor to the legacy CB-id binary_reuse_dest API (the deprecated
-// binary_dest_reuse_tiles[_init] path is NOT ported). Only the L1 operand becomes an LLKOperand; the reused
-// operand IS the DST register, selected at runtime by dst_tile_index, so it carries no LLKOperand. The
-// EltwiseBinaryType and EltwiseBinaryReuseDestType template params are preserved exactly as legacy. Because
-// only a single operand is unpacked, this path uses llk_unpack_A (not llk_unpack_AB). BH accumulates the
-// unpacked operand into DST at the unpacker (acc_to_dest = true), mirroring the legacy detail path.
+// buffer, selected at runtime by dst_tile_index (so it carries no LLKOperand); only the other operand is an
+// LLKOperand. Because a single operand is unpacked, this path uses llk_unpack_A (not llk_unpack_AB). BH
+// accumulates the unpacked operand into DST at the unpacker (acc_to_dest = true).
 // =====================================================================================================================
 
 namespace detail {
@@ -337,7 +319,7 @@ template <
     TensorShape Shape>
 ALWI void binary_reuse_dest_init(LLKOperand<Format, Shape> /*in*/) {
     static_assert(is_legal_tile_shape(Shape), "binary_reuse_dest_init: illegal tile shape for the L1 operand.");
-    // BH: accumulate the unpacked operand into DST at the unpacker (acc_to_dest = true), matching legacy.
+    // BH: accumulate the unpacked operand into DST at the unpacker (acc_to_dest = true).
     UNPACK((llk_unpack_A_init<
             LLKOperand<Format, Shape>::descriptor,
             DST_ACCUM_MODE,

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/eltwise_binary.h
@@ -31,7 +31,7 @@ namespace experimental {
 // clang-format off
 /**
  * Paired init for a two-operand eltwise binary op. Configures MATH and the AB unpacker from operand A's
- * descriptor; geometry comes from operand A. compute_kernel_hw_startup(a_cb, b_cb, out_cb) must already have
+ * descriptor; geometry comes from operand A. compute_kernel_hw_startup(a, b, out) must already have
  * programmed the formats. Operand B contributes nothing at init -- A.shape == B.shape is enforced at
  * execute (add/sub/mul_tiles).
  *
@@ -335,19 +335,9 @@ ALWI void mul_block(
 // =====================================================================================================================
 
 namespace detail {
-// clang-format off
-/**
- * (detail) Single source of truth for the id-free dest-reuse INIT. One source operand comes from DST, so only
- * the single L1 operand `in` is unpacked (llk_unpack_A). reuse_dest picks which source register the DST tile is
- * loaded into. compute_kernel_hw_startup(a, b, out) must already have programmed the formats.
- *
- * | Param Type | Name                | Description                                        | Type                       | Valid Range | Required |
- * |------------|---------------------|----------------------------------------------------|----------------------------|-------------|----------|
- * | Template   | eltwise_binary_type | ELWADD / ELWSUB / ELWMUL                            | EltwiseBinaryType          | N/A         | True     |
- * | Template   | reuse_dest          | Which source register the DST operand loads into    | EltwiseBinaryReuseDestType | non-NONE    | True     |
- * | Function   | in                  | The single L1 operand (drives geometry + address)   | LLKOperand                 | N/A         | True     |
- */
-// clang-format on
+// Dest-reuse INIT: one source is DST, so only the L1 operand `in` is unpacked (llk_unpack_A). reuse_dest
+// picks which source register the DST tile loads into. compute_kernel_hw_startup(a, b, out) must already
+// have programmed the formats.
 template <
     EltwiseBinaryType eltwise_binary_type,
     EltwiseBinaryReuseDestType reuse_dest,
@@ -370,21 +360,8 @@ ALWI void binary_reuse_dest_init(LLKOperand<Format, Shape> /*in*/) {
           reuse_dest>(0 /*acc_to_dest*/)));
 }
 
-// clang-format off
-/**
- * (detail) Single source of truth for the id-free dest-reuse EXECUTE. The DST[dst_tile_index] tile is loaded
- * into SrcA (DEST_TO_SRCA) or SrcB (DEST_TO_SRCB); the op runs on SrcA & SrcB and writes back to
- * DST[dst_tile_index]. Assumes a prior op populated DST[dst_tile_index], else it reads zeroes.
- *
- * | Param Type | Name                | Description                                          | Type                       | Valid Range | Required |
- * |------------|---------------------|------------------------------------------------------|----------------------------|-------------|----------|
- * | Template   | eltwise_binary_type | ELWADD / ELWSUB / ELWMUL                              | EltwiseBinaryType          | N/A         | True     |
- * | Template   | reuse_dest          | Which source register the DST operand loads into      | EltwiseBinaryReuseDestType | non-NONE    | True     |
- * | Function   | in                  | The single L1 operand (base address + geometry)       | LLKOperand                 | N/A         | True     |
- * | Function   | in_tile_index       | Tile index within the L1 operand                      | uint32_t                   | N/A         | True     |
- * | Function   | dst_tile_index      | DST tile used as the other operand and as the result  | uint32_t                   | < DST size  | True     |
- */
-// clang-format on
+// Dest-reuse EXECUTE: DST[dst_tile_index] loads into SrcA (DEST_TO_SRCA) or SrcB (DEST_TO_SRCB); the op
+// writes back to DST[dst_tile_index]. Assumes a prior op populated that slot, else it reads zeroes.
 template <
     EltwiseBinaryType eltwise_binary_type,
     EltwiseBinaryReuseDestType reuse_dest,

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/eltwise_binary.h
@@ -112,12 +112,18 @@ ALWI void mul_init(LLKOperand<AFormat, AShape> a, bool acc_to_dest = true) {
  * Element-wise C = A [op] B for one tile pair, writing DST[idst]. Pair with the matching *_init. DST must
  * be acquired. itile0/itile1 index within A/B; idst indexes DST. Geometry (for MATH) comes from operand A.
  *
+ * | Template | is_fp32_dest_acc_en | fp32 dest-accumulate mode           | bool       | | False |
  * | Function | a / b           | Input operands                      | LLKOperand | | True |
  * | Function | itile0 / itile1 | Tile indices within A / B           | uint32_t   | | True |
  * | Function | idst            | DST register index for the result   | uint32_t   | | True |
  */
 // clang-format on
-template <DataFormat AFormat, TensorShape AShape, DataFormat BFormat, TensorShape BShape>
+template <
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    DataFormat AFormat,
+    TensorShape AShape,
+    DataFormat BFormat,
+    TensorShape BShape>
 ALWI void add_tiles(
     LLKOperand<AFormat, AShape> a,
     LLKOperand<BFormat, BShape> b,
@@ -132,7 +138,7 @@ ALWI void add_tiles(
           LLKOperand<AFormat, AShape>::descriptor,
           EltwiseBinaryType::ELWADD,
           BroadcastType::NONE,
-          DST_ACCUM_MODE,
+          is_fp32_dest_acc_en,
           MathFidelity::LoFi,
           EltwiseBinaryReuseDestType::NONE>(idst, true /*clear_fp32_dst_acc*/)));
 }
@@ -144,12 +150,18 @@ ALWI void add_tiles(
  *
  * | Param Type | Name            | Description                       | Type       | Valid Range | Required |
  * |------------|-----------------|-----------------------------------|------------|-------------|----------|
+ * | Template   | is_fp32_dest_acc_en | fp32 dest-accumulate mode     | bool       |             | False    |
  * | Function   | a / b           | Input operands                    | LLKOperand | N/A         | True     |
  * | Function   | itile0 / itile1 | Tile indices within A / B         | uint32_t   | N/A         | True     |
  * | Function   | idst            | DST register index for the result | uint32_t   | N/A         | True     |
  */
 // clang-format on
-template <DataFormat AFormat, TensorShape AShape, DataFormat BFormat, TensorShape BShape>
+template <
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    DataFormat AFormat,
+    TensorShape AShape,
+    DataFormat BFormat,
+    TensorShape BShape>
 ALWI void sub_tiles(
     LLKOperand<AFormat, AShape> a,
     LLKOperand<BFormat, BShape> b,
@@ -164,7 +176,7 @@ ALWI void sub_tiles(
           LLKOperand<AFormat, AShape>::descriptor,
           EltwiseBinaryType::ELWSUB,
           BroadcastType::NONE,
-          DST_ACCUM_MODE,
+          is_fp32_dest_acc_en,
           MathFidelity::LoFi,
           EltwiseBinaryReuseDestType::NONE>(idst, true /*clear_fp32_dst_acc*/)));
 }
@@ -176,12 +188,18 @@ ALWI void sub_tiles(
  *
  * | Param Type | Name            | Description                       | Type       | Valid Range | Required |
  * |------------|-----------------|-----------------------------------|------------|-------------|----------|
+ * | Template   | is_fp32_dest_acc_en | fp32 dest-accumulate mode     | bool       |             | False    |
  * | Function   | a / b           | Input operands                    | LLKOperand | N/A         | True     |
  * | Function   | itile0 / itile1 | Tile indices within A / B         | uint32_t   | N/A         | True     |
  * | Function   | idst            | DST register index for the result | uint32_t   | N/A         | True     |
  */
 // clang-format on
-template <DataFormat AFormat, TensorShape AShape, DataFormat BFormat, TensorShape BShape>
+template <
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    DataFormat AFormat,
+    TensorShape AShape,
+    DataFormat BFormat,
+    TensorShape BShape>
 ALWI void mul_tiles(
     LLKOperand<AFormat, AShape> a,
     LLKOperand<BFormat, BShape> b,
@@ -196,7 +214,7 @@ ALWI void mul_tiles(
           LLKOperand<AFormat, AShape>::descriptor,
           EltwiseBinaryType::ELWMUL,
           BroadcastType::NONE,
-          DST_ACCUM_MODE,
+          is_fp32_dest_acc_en,
           MATH_FIDELITY,
           EltwiseBinaryReuseDestType::NONE>(idst, true /*clear_fp32_dst_acc*/)));
 }
@@ -214,9 +232,15 @@ ALWI void mul_tiles(
  * | Function   | start_itile1  | Index of the first source tile within B          | uint32_t   | N/A         | True     |
  * | Function   | start_idst    | Index of the first destination tile in DST       | uint32_t   | 0 to 15     | True     |
  * | Function   | ntiles        | Number of consecutive tile pairs to add          | uint32_t   | start_idst + ntiles <= 16 | True |
+ * | Template   | is_fp32_dest_acc_en | fp32 dest-accumulate mode                  | bool       |             | False |
  */
 // clang-format on
-template <DataFormat AFormat, TensorShape AShape, DataFormat BFormat, TensorShape BShape>
+template <
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    DataFormat AFormat,
+    TensorShape AShape,
+    DataFormat BFormat,
+    TensorShape BShape>
 ALWI void add_block(
     LLKOperand<AFormat, AShape> a,
     LLKOperand<BFormat, BShape> b,
@@ -227,7 +251,7 @@ ALWI void add_block(
     static_assert(is_legal_tile_shape(AShape), "add_block: illegal tile shape for operand A.");
     static_assert(same_tile_shape(AShape, BShape), "add_block: operands A and B must have the same tile shape.");
     for (std::uint32_t i = 0; i < ntiles; ++i) {
-        add_tiles(a, b, start_itile0 + i, start_itile1 + i, start_idst + i);
+        add_tiles<is_fp32_dest_acc_en>(a, b, start_itile0 + i, start_itile1 + i, start_idst + i);
     }
 }
 
@@ -244,9 +268,15 @@ ALWI void add_block(
  * | Function   | start_itile1  | Index of the first source tile within B          | uint32_t   | N/A         | True     |
  * | Function   | start_idst    | Index of the first destination tile in DST       | uint32_t   | 0 to 15     | True     |
  * | Function   | ntiles        | Number of consecutive tile pairs to subtract     | uint32_t   | start_idst + ntiles <= 16 | True |
+ * | Template   | is_fp32_dest_acc_en | fp32 dest-accumulate mode                  | bool       |             | False |
  */
 // clang-format on
-template <DataFormat AFormat, TensorShape AShape, DataFormat BFormat, TensorShape BShape>
+template <
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    DataFormat AFormat,
+    TensorShape AShape,
+    DataFormat BFormat,
+    TensorShape BShape>
 ALWI void sub_block(
     LLKOperand<AFormat, AShape> a,
     LLKOperand<BFormat, BShape> b,
@@ -257,7 +287,7 @@ ALWI void sub_block(
     static_assert(is_legal_tile_shape(AShape), "sub_block: illegal tile shape for operand A.");
     static_assert(same_tile_shape(AShape, BShape), "sub_block: operands A and B must have the same tile shape.");
     for (std::uint32_t i = 0; i < ntiles; ++i) {
-        sub_tiles(a, b, start_itile0 + i, start_itile1 + i, start_idst + i);
+        sub_tiles<is_fp32_dest_acc_en>(a, b, start_itile0 + i, start_itile1 + i, start_idst + i);
     }
 }
 
@@ -274,9 +304,15 @@ ALWI void sub_block(
  * | Function   | start_itile1  | Index of the first source tile within B          | uint32_t   | N/A         | True     |
  * | Function   | start_idst    | Index of the first destination tile in DST       | uint32_t   | 0 to 15     | True     |
  * | Function   | ntiles        | Number of consecutive tile pairs to multiply     | uint32_t   | start_idst + ntiles <= 16 | True |
+ * | Template   | is_fp32_dest_acc_en | fp32 dest-accumulate mode                  | bool       |             | False |
  */
 // clang-format on
-template <DataFormat AFormat, TensorShape AShape, DataFormat BFormat, TensorShape BShape>
+template <
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    DataFormat AFormat,
+    TensorShape AShape,
+    DataFormat BFormat,
+    TensorShape BShape>
 ALWI void mul_block(
     LLKOperand<AFormat, AShape> a,
     LLKOperand<BFormat, BShape> b,
@@ -287,7 +323,7 @@ ALWI void mul_block(
     static_assert(is_legal_tile_shape(AShape), "mul_block: illegal tile shape for operand A.");
     static_assert(same_tile_shape(AShape, BShape), "mul_block: operands A and B must have the same tile shape.");
     for (std::uint32_t i = 0; i < ntiles; ++i) {
-        mul_tiles(a, b, start_itile0 + i, start_itile1 + i, start_idst + i);
+        mul_tiles<is_fp32_dest_acc_en>(a, b, start_itile0 + i, start_itile1 + i, start_idst + i);
     }
 }
 

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/eltwise_binary.h
@@ -1,0 +1,518 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/common_globals.h"
+#include "api/compute/experimental/2_0/llk_operand.h"
+
+#ifdef TRISC_MATH
+#include "experimental/2_0/llk_math_binary.h"
+#endif
+
+#ifdef TRISC_UNPACK
+#include "experimental/2_0/llk_unpack_AB.h"
+#include "experimental/2_0/llk_unpack_A.h"  // dest-reuse path unpacks a single operand (A-only)
+#endif
+
+namespace ckernel {
+namespace experimental {
+
+#ifdef ARCH_BLACKHOLE
+
+// Id-free (2.0) two-operand eltwise binary (add/sub/mul). Each op takes one LLKOperand per input
+// (A -> SrcA, B -> SrcB), format+geometry as NTTPs, L1 addresses the only runtime state. Binary is
+// FORMAT-FREE at the op level: the src/dst register formats are programmed at compute_kernel_hw_startup;
+// the op forwards only geometry (from operand A, mirroring legacy) + the two per-tile L1 addresses. Packing
+// is done separately via the id-free experimental::pack_tile. The two-operand ops are BroadcastType::NONE
+// only (broadcast lives in bcast.h); the dest-reuse (accumulation) variants ARE part of this surface -- see
+// the add/sub/mul_reuse_dest_* family further down.
+
+// clang-format off
+/**
+ * Paired init for a two-operand eltwise binary op. Always configures BOTH MATH and the AB unpacker (a full
+ * init) from operand A's descriptor. Geometry is taken from operand A. compute_kernel_hw_startup(a_cb, b_cb,
+ * out_cb) must already have programmed the formats.
+ *
+ * | Template | eltwise_binary_type | ELWADD / ELWSUB / ELWMUL               | EltwiseBinaryType |  | True |
+ * | Function | a                   | Operand A (A -> SrcA); drives geometry | LLKOperand       |  | True |
+ * | Function | acc_to_dest         | Accumulate the result into DST         | bool             |  | False |
+ *
+ * NOTE (PART B): the init forwards ONLY operand A's descriptor (geometry + format), mirroring legacy which
+ * inits from a single operand. Operand B contributes nothing to init, so it is not taken here; the
+ * A.shape == B.shape requirement is enforced at the execute (add/sub/mul_tiles), which does see both.
+ */
+// clang-format on
+template <EltwiseBinaryType eltwise_binary_type, DataFormat AFormat, TensorShape AShape>
+ALWI void binary_tiles_init(LLKOperand<AFormat, AShape> /*a*/, bool acc_to_dest = false) {
+    MATH((llk_math_eltwise_binary_init<
+          LLKOperand<AFormat, AShape>::descriptor,
+          eltwise_binary_type,
+          BroadcastType::NONE,
+          MATH_FIDELITY>(acc_to_dest)));
+    UNPACK(
+        (llk_unpack_AB_init<LLKOperand<AFormat, AShape>::descriptor, BroadcastType::NONE>(ckernel::Transpose::None)));
+}
+
+// clang-format off
+/**
+ * Paired init for add_tiles (ELWADD). Configures MATH + the AB unpacker from operand A's descriptor;
+ * compute_kernel_hw_startup(a, b, out) must already have programmed the formats. Only operand A is needed at
+ * init (A.shape == B.shape is assumed, enforced at add_tiles) -- see binary_tiles_init.
+ *
+ * | Param Type | Name           | Description                              | Type                   | Valid Range | Required |
+ * |------------|----------------|------------------------------------------|------------------------|-------------|----------|
+ * | Template   | AFormat/AShape | Operand A L1 format + geometry (deduced) | DataFormat/TensorShape | N/A         | True     |
+ * | Function   | a              | Operand A (drives geometry)              | LLKOperand             | N/A         | True     |
+ * | Function   | acc_to_dest    | Accumulate the result into DST           | bool                   | N/A         | False    |
+ */
+// clang-format on
+template <DataFormat AFormat, TensorShape AShape>
+ALWI void add_init(LLKOperand<AFormat, AShape> a, bool acc_to_dest = false) {
+    binary_tiles_init<EltwiseBinaryType::ELWADD>(a, acc_to_dest);
+}
+
+// clang-format off
+/**
+ * Paired init for sub_tiles (ELWSUB). Configures MATH + the AB unpacker from operand A's descriptor;
+ * compute_kernel_hw_startup(a, b, out) must already have programmed the formats. Only operand A is needed at
+ * init (A.shape == B.shape is assumed, enforced at sub_tiles) -- see binary_tiles_init.
+ *
+ * | Param Type | Name           | Description                              | Type                   | Valid Range | Required |
+ * |------------|----------------|------------------------------------------|------------------------|-------------|----------|
+ * | Template   | AFormat/AShape | Operand A L1 format + geometry (deduced) | DataFormat/TensorShape | N/A         | True     |
+ * | Function   | a              | Operand A (drives geometry)              | LLKOperand             | N/A         | True     |
+ * | Function   | acc_to_dest    | Accumulate the result into DST           | bool                   | N/A         | False    |
+ */
+// clang-format on
+template <DataFormat AFormat, TensorShape AShape>
+ALWI void sub_init(LLKOperand<AFormat, AShape> a, bool acc_to_dest = false) {
+    binary_tiles_init<EltwiseBinaryType::ELWSUB>(a, acc_to_dest);
+}
+
+// clang-format off
+/**
+ * Paired init for mul_tiles (ELWMUL). Configures MATH + the AB unpacker from operand A's descriptor;
+ * compute_kernel_hw_startup(a, b, out) must already have programmed the formats. Only operand A is needed at
+ * init (A.shape == B.shape is assumed, enforced at mul_tiles) -- see binary_tiles_init.
+ *
+ * | Param Type | Name           | Description                              | Type                   | Valid Range | Required |
+ * |------------|----------------|------------------------------------------|------------------------|-------------|----------|
+ * | Template   | AFormat/AShape | Operand A L1 format + geometry (deduced) | DataFormat/TensorShape | N/A         | True     |
+ * | Function   | a              | Operand A (drives geometry)              | LLKOperand             | N/A         | True     |
+ * | Function   | acc_to_dest    | Accumulate the result into DST (mul defaults on) | bool           | N/A         | False    |
+ */
+// clang-format on
+template <DataFormat AFormat, TensorShape AShape>
+ALWI void mul_init(LLKOperand<AFormat, AShape> a, bool acc_to_dest = true) {
+    binary_tiles_init<EltwiseBinaryType::ELWMUL>(a, acc_to_dest);
+}
+
+// detail::tile_address (absolute per-tile L1 base) lives in llk_operand.h -- shared by every block op.
+
+// clang-format off
+/**
+ * Element-wise C = A [op] B for one tile pair, writing DST[idst]. Pair with the matching *_init. The DST
+ * register must be acquired. itile0/itile1 index within operand A/B; idst indexes DST. Geometry (for MATH)
+ * comes from operand A, matching the legacy op.
+ *
+ * | Function | a / b           | Input operands                      | LLKOperand | | True |
+ * | Function | itile0 / itile1 | Tile indices within A / B           | uint32_t   | | True |
+ * | Function | idst            | DST register index for the result   | uint32_t   | | True |
+ */
+// clang-format on
+template <DataFormat AFormat, TensorShape AShape, DataFormat BFormat, TensorShape BShape>
+ALWI void add_tiles(
+    LLKOperand<AFormat, AShape> a,
+    LLKOperand<BFormat, BShape> b,
+    std::uint32_t itile0,
+    std::uint32_t itile1,
+    std::uint32_t idst) {
+    static_assert(is_legal_tile_shape(AShape), "add_tiles: illegal tile shape for operand A.");
+    static_assert(same_tile_shape(AShape, BShape), "add_tiles: operands A and B must have the same tile shape.");
+    UNPACK((llk_unpack_AB<LLKOperand<AFormat, AShape>::descriptor, BroadcastType::NONE>(
+        detail::tile_address(a, itile0), detail::tile_address(b, itile1))));
+    MATH((llk_math_eltwise_binary<
+          LLKOperand<AFormat, AShape>::descriptor,
+          EltwiseBinaryType::ELWADD,
+          BroadcastType::NONE,
+          DST_ACCUM_MODE,
+          MathFidelity::LoFi,
+          EltwiseBinaryReuseDestType::NONE>(idst, true /*clear_fp32_dst_acc*/)));
+}
+
+// clang-format off
+/**
+ * Element-wise C = A - B for one tile pair, writing DST[idst]. Pair with sub_init. The DST register must be
+ * acquired. itile0/itile1 index within operand A/B; idst indexes DST. Geometry (for MATH) comes from operand A.
+ *
+ * | Param Type | Name            | Description                       | Type       | Valid Range | Required |
+ * |------------|-----------------|-----------------------------------|------------|-------------|----------|
+ * | Function   | a / b           | Input operands                    | LLKOperand | N/A         | True     |
+ * | Function   | itile0 / itile1 | Tile indices within A / B         | uint32_t   | N/A         | True     |
+ * | Function   | idst            | DST register index for the result | uint32_t   | N/A         | True     |
+ */
+// clang-format on
+template <DataFormat AFormat, TensorShape AShape, DataFormat BFormat, TensorShape BShape>
+ALWI void sub_tiles(
+    LLKOperand<AFormat, AShape> a,
+    LLKOperand<BFormat, BShape> b,
+    std::uint32_t itile0,
+    std::uint32_t itile1,
+    std::uint32_t idst) {
+    static_assert(is_legal_tile_shape(AShape), "sub_tiles: illegal tile shape for operand A.");
+    static_assert(same_tile_shape(AShape, BShape), "sub_tiles: operands A and B must have the same tile shape.");
+    UNPACK((llk_unpack_AB<LLKOperand<AFormat, AShape>::descriptor, BroadcastType::NONE>(
+        detail::tile_address(a, itile0), detail::tile_address(b, itile1))));
+    MATH((llk_math_eltwise_binary<
+          LLKOperand<AFormat, AShape>::descriptor,
+          EltwiseBinaryType::ELWSUB,
+          BroadcastType::NONE,
+          DST_ACCUM_MODE,
+          MathFidelity::LoFi,
+          EltwiseBinaryReuseDestType::NONE>(idst, true /*clear_fp32_dst_acc*/)));
+}
+
+// clang-format off
+/**
+ * Element-wise C = A * B for one tile pair, writing DST[idst]. Pair with mul_init. The DST register must be
+ * acquired. itile0/itile1 index within operand A/B; idst indexes DST. Geometry (for MATH) comes from operand A.
+ *
+ * | Param Type | Name            | Description                       | Type       | Valid Range | Required |
+ * |------------|-----------------|-----------------------------------|------------|-------------|----------|
+ * | Function   | a / b           | Input operands                    | LLKOperand | N/A         | True     |
+ * | Function   | itile0 / itile1 | Tile indices within A / B         | uint32_t   | N/A         | True     |
+ * | Function   | idst            | DST register index for the result | uint32_t   | N/A         | True     |
+ */
+// clang-format on
+template <DataFormat AFormat, TensorShape AShape, DataFormat BFormat, TensorShape BShape>
+ALWI void mul_tiles(
+    LLKOperand<AFormat, AShape> a,
+    LLKOperand<BFormat, BShape> b,
+    std::uint32_t itile0,
+    std::uint32_t itile1,
+    std::uint32_t idst) {
+    static_assert(is_legal_tile_shape(AShape), "mul_tiles: illegal tile shape for operand A.");
+    static_assert(same_tile_shape(AShape, BShape), "mul_tiles: operands A and B must have the same tile shape.");
+    UNPACK((llk_unpack_AB<LLKOperand<AFormat, AShape>::descriptor, BroadcastType::NONE>(
+        detail::tile_address(a, itile0), detail::tile_address(b, itile1))));
+    MATH((llk_math_eltwise_binary<
+          LLKOperand<AFormat, AShape>::descriptor,
+          EltwiseBinaryType::ELWMUL,
+          BroadcastType::NONE,
+          DST_ACCUM_MODE,
+          MATH_FIDELITY,
+          EltwiseBinaryReuseDestType::NONE>(idst, true /*clear_fp32_dst_acc*/)));
+}
+
+// clang-format off
+/**
+ * Element-wise C = A + B over `ntiles` consecutive tile pairs, writing DST[start_idst + i]. Block/loop form of
+ * add_tiles: a pure compute-layer loop over the existing 2.0 add_tiles (mirrors copy_block over copy_tile), so
+ * it inherits add_tiles's semantics and requires the same init (add_init). Tile (start_itile0 + i) of A is
+ * paired with tile (start_itile1 + i) of B; each per-tile source address is the operand base offset by
+ * (start_i + i) * tile_stride_words(Format, Shape) 16-byte words (folds to a compile-time stride). No CB id, no
+ * register format on the API. The DST register must be acquired; start_idst + ntiles <= DST size.
+ *
+ * | Param Type | Name          | Description                                       | Type       | Valid Range | Required |
+ * |------------|---------------|--------------------------------------------------|------------|-------------|----------|
+ * | Function   | a / b         | Input operands (base address + geometry)         | LLKOperand | N/A         | True     |
+ * | Function   | start_itile0  | Index of the first source tile within A          | uint32_t   | N/A         | True     |
+ * | Function   | start_itile1  | Index of the first source tile within B          | uint32_t   | N/A         | True     |
+ * | Function   | start_idst    | Index of the first destination tile in DST       | uint32_t   | 0 to 15     | True     |
+ * | Function   | ntiles        | Number of consecutive tile pairs to add          | uint32_t   | start_idst + ntiles <= 16 | True |
+ */
+// clang-format on
+template <DataFormat AFormat, TensorShape AShape, DataFormat BFormat, TensorShape BShape>
+ALWI void add_block(
+    LLKOperand<AFormat, AShape> a,
+    LLKOperand<BFormat, BShape> b,
+    std::uint32_t start_itile0,
+    std::uint32_t start_itile1,
+    std::uint32_t start_idst,
+    std::uint32_t ntiles) {
+    static_assert(is_legal_tile_shape(AShape), "add_block: illegal tile shape for operand A.");
+    static_assert(same_tile_shape(AShape, BShape), "add_block: operands A and B must have the same tile shape.");
+    for (std::uint32_t i = 0; i < ntiles; ++i) {
+        add_tiles(a, b, start_itile0 + i, start_itile1 + i, start_idst + i);
+    }
+}
+
+// clang-format off
+/**
+ * Element-wise C = A - B over `ntiles` consecutive tile pairs, writing DST[start_idst + i]. Block/loop form of
+ * sub_tiles: a pure compute-layer loop over the existing 2.0 sub_tiles (mirrors copy_block over copy_tile), so
+ * it inherits sub_tiles's semantics and requires the same init (sub_init). Tile (start_itile0 + i) of A is
+ * paired with tile (start_itile1 + i) of B; each per-tile source address is the operand base offset by
+ * (start_i + i) * tile_stride_words(Format, Shape) 16-byte words (folds to a compile-time stride). No CB id, no
+ * register format on the API. The DST register must be acquired; start_idst + ntiles <= DST size.
+ *
+ * | Param Type | Name          | Description                                       | Type       | Valid Range | Required |
+ * |------------|---------------|--------------------------------------------------|------------|-------------|----------|
+ * | Function   | a / b         | Input operands (base address + geometry)         | LLKOperand | N/A         | True     |
+ * | Function   | start_itile0  | Index of the first source tile within A          | uint32_t   | N/A         | True     |
+ * | Function   | start_itile1  | Index of the first source tile within B          | uint32_t   | N/A         | True     |
+ * | Function   | start_idst    | Index of the first destination tile in DST       | uint32_t   | 0 to 15     | True     |
+ * | Function   | ntiles        | Number of consecutive tile pairs to subtract     | uint32_t   | start_idst + ntiles <= 16 | True |
+ */
+// clang-format on
+template <DataFormat AFormat, TensorShape AShape, DataFormat BFormat, TensorShape BShape>
+ALWI void sub_block(
+    LLKOperand<AFormat, AShape> a,
+    LLKOperand<BFormat, BShape> b,
+    std::uint32_t start_itile0,
+    std::uint32_t start_itile1,
+    std::uint32_t start_idst,
+    std::uint32_t ntiles) {
+    static_assert(is_legal_tile_shape(AShape), "sub_block: illegal tile shape for operand A.");
+    static_assert(same_tile_shape(AShape, BShape), "sub_block: operands A and B must have the same tile shape.");
+    for (std::uint32_t i = 0; i < ntiles; ++i) {
+        sub_tiles(a, b, start_itile0 + i, start_itile1 + i, start_idst + i);
+    }
+}
+
+// clang-format off
+/**
+ * Element-wise C = A * B over `ntiles` consecutive tile pairs, writing DST[start_idst + i]. Block/loop form of
+ * mul_tiles: a pure compute-layer loop over the existing 2.0 mul_tiles (mirrors copy_block over copy_tile), so
+ * it inherits mul_tiles's semantics and requires the same init (mul_init). Tile (start_itile0 + i) of A is
+ * paired with tile (start_itile1 + i) of B; each per-tile source address is the operand base offset by
+ * (start_i + i) * tile_stride_words(Format, Shape) 16-byte words (folds to a compile-time stride). No CB id, no
+ * register format on the API. The DST register must be acquired; start_idst + ntiles <= DST size.
+ *
+ * | Param Type | Name          | Description                                       | Type       | Valid Range | Required |
+ * |------------|---------------|--------------------------------------------------|------------|-------------|----------|
+ * | Function   | a / b         | Input operands (base address + geometry)         | LLKOperand | N/A         | True     |
+ * | Function   | start_itile0  | Index of the first source tile within A          | uint32_t   | N/A         | True     |
+ * | Function   | start_itile1  | Index of the first source tile within B          | uint32_t   | N/A         | True     |
+ * | Function   | start_idst    | Index of the first destination tile in DST       | uint32_t   | 0 to 15     | True     |
+ * | Function   | ntiles        | Number of consecutive tile pairs to multiply     | uint32_t   | start_idst + ntiles <= 16 | True |
+ */
+// clang-format on
+template <DataFormat AFormat, TensorShape AShape, DataFormat BFormat, TensorShape BShape>
+ALWI void mul_block(
+    LLKOperand<AFormat, AShape> a,
+    LLKOperand<BFormat, BShape> b,
+    std::uint32_t start_itile0,
+    std::uint32_t start_itile1,
+    std::uint32_t start_idst,
+    std::uint32_t ntiles) {
+    static_assert(is_legal_tile_shape(AShape), "mul_block: illegal tile shape for operand A.");
+    static_assert(same_tile_shape(AShape, BShape), "mul_block: operands A and B must have the same tile shape.");
+    for (std::uint32_t i = 0; i < ntiles; ++i) {
+        mul_tiles(a, b, start_itile0 + i, start_itile1 + i, start_idst + i);
+    }
+}
+
+// =====================================================================================================================
+// Dest-reuse (accumulation) binary ops: one operand is taken from the DST register instead of a second L1
+// buffer. This is the id-free successor to the legacy CB-id binary_reuse_dest API (the deprecated
+// binary_dest_reuse_tiles[_init] path is NOT ported). Only the L1 operand becomes an LLKOperand; the reused
+// operand IS the DST register, selected at runtime by dst_tile_index, so it carries no LLKOperand. The
+// EltwiseBinaryType and EltwiseBinaryReuseDestType template params are preserved exactly as legacy. Because
+// only a single operand is unpacked, this path uses llk_unpack_A (not llk_unpack_AB). BH accumulates the
+// unpacked operand into DST at the unpacker (acc_to_dest = true), mirroring the legacy detail path.
+// =====================================================================================================================
+
+namespace detail {
+// clang-format off
+/**
+ * (detail) Single source of truth for the id-free dest-reuse INIT. One source operand comes from DST, so only
+ * the single L1 operand `in` is unpacked (llk_unpack_A). reuse_dest picks which source register the DST tile is
+ * loaded into. compute_kernel_hw_startup(a, b, out) must already have programmed the formats.
+ *
+ * | Param Type | Name                | Description                                        | Type                       | Valid Range | Required |
+ * |------------|---------------------|----------------------------------------------------|----------------------------|-------------|----------|
+ * | Template   | eltwise_binary_type | ELWADD / ELWSUB / ELWMUL                            | EltwiseBinaryType          | N/A         | True     |
+ * | Template   | reuse_dest          | Which source register the DST operand loads into    | EltwiseBinaryReuseDestType | non-NONE    | True     |
+ * | Function   | in                  | The single L1 operand (drives geometry + address)   | LLKOperand                 | N/A         | True     |
+ */
+// clang-format on
+template <
+    EltwiseBinaryType eltwise_binary_type,
+    EltwiseBinaryReuseDestType reuse_dest,
+    DataFormat Format,
+    TensorShape Shape>
+ALWI void binary_reuse_dest_init(LLKOperand<Format, Shape> /*in*/) {
+    static_assert(is_legal_tile_shape(Shape), "binary_reuse_dest_init: illegal tile shape for the L1 operand.");
+    // BH: accumulate the unpacked operand into DST at the unpacker (acc_to_dest = true), matching legacy.
+    UNPACK((llk_unpack_A_init<
+            LLKOperand<Format, Shape>::descriptor,
+            DST_ACCUM_MODE,
+            BroadcastType::NONE,
+            true /*acc_to_dest*/,
+            reuse_dest>()));
+    MATH((llk_math_eltwise_binary_init<
+          LLKOperand<Format, Shape>::descriptor,
+          eltwise_binary_type,
+          BroadcastType::NONE,
+          MATH_FIDELITY,
+          reuse_dest>(0 /*acc_to_dest*/)));
+}
+
+// clang-format off
+/**
+ * (detail) Single source of truth for the id-free dest-reuse EXECUTE. The DST[dst_tile_index] tile is loaded
+ * into SrcA (DEST_TO_SRCA) or SrcB (DEST_TO_SRCB); the op runs on SrcA & SrcB and writes back to
+ * DST[dst_tile_index]. Assumes a prior op populated DST[dst_tile_index], else it reads zeroes.
+ *
+ * | Param Type | Name                | Description                                          | Type                       | Valid Range | Required |
+ * |------------|---------------------|------------------------------------------------------|----------------------------|-------------|----------|
+ * | Template   | eltwise_binary_type | ELWADD / ELWSUB / ELWMUL                              | EltwiseBinaryType          | N/A         | True     |
+ * | Template   | reuse_dest          | Which source register the DST operand loads into      | EltwiseBinaryReuseDestType | non-NONE    | True     |
+ * | Function   | in                  | The single L1 operand (base address + geometry)       | LLKOperand                 | N/A         | True     |
+ * | Function   | in_tile_index       | Tile index within the L1 operand                      | uint32_t                   | N/A         | True     |
+ * | Function   | dst_tile_index      | DST tile used as the other operand and as the result  | uint32_t                   | < DST size  | True     |
+ */
+// clang-format on
+template <
+    EltwiseBinaryType eltwise_binary_type,
+    EltwiseBinaryReuseDestType reuse_dest,
+    DataFormat Format,
+    TensorShape Shape>
+ALWI void binary_reuse_dest_tiles(
+    LLKOperand<Format, Shape> in, std::uint32_t in_tile_index, std::uint32_t dst_tile_index) {
+    static_assert(is_legal_tile_shape(Shape), "binary_reuse_dest_tiles: illegal tile shape for the L1 operand.");
+    UNPACK((llk_unpack_A<
+            LLKOperand<Format, Shape>::descriptor,
+            DST_ACCUM_MODE,
+            BroadcastType::NONE,
+            true /*acc_to_dest*/,
+            reuse_dest>(tile_address(in, in_tile_index))));
+    MATH((llk_math_eltwise_binary<
+          LLKOperand<Format, Shape>::descriptor,
+          eltwise_binary_type,
+          BroadcastType::NONE,
+          DST_ACCUM_MODE,
+          MATH_FIDELITY,
+          reuse_dest>(dst_tile_index, true /*clear_fp32_dst_acc*/)));
+}
+}  // namespace detail
+
+// clang-format off
+/**
+ * Paired init for dest-reuse element-wise addition (add_reuse_dest_tiles<reuse_dest>). One addend is taken
+ * from the DST register, so only the single L1 operand is unpacked; reuse_dest selects which source register
+ * the DST tile loads into:
+ *   - DEST_TO_SRCA: DST -> SrcA, in -> SrcB   (result = DST + in)
+ *   - DEST_TO_SRCB: DST -> SrcB, in -> SrcA   (result = in + DST)
+ * Pair with add_reuse_dest_tiles. compute_kernel_hw_startup(a, b, out) must already have run.
+ *
+ * | Param Type | Name       | Description                                                       | Type                       | Valid Range | Required |
+ * |------------|------------|-------------------------------------------------------------------|----------------------------|-------------|----------|
+ * | Template   | reuse_dest | Which source register the DST operand is loaded into (non-NONE)   | EltwiseBinaryReuseDestType | N/A         | True     |
+ * | Function   | in         | L1 operand unpacked into the source register not fed by DST        | LLKOperand                 | N/A         | True     |
+ */
+// clang-format on
+template <EltwiseBinaryReuseDestType reuse_dest, DataFormat Format, TensorShape Shape>
+ALWI void add_reuse_dest_init(LLKOperand<Format, Shape> in) {
+    static_assert(
+        reuse_dest != EltwiseBinaryReuseDestType::NONE,
+        "reuse_dest must be DEST_TO_SRCA or DEST_TO_SRCB; for the two-operand op call add_init(a).");
+    detail::binary_reuse_dest_init<EltwiseBinaryType::ELWADD, reuse_dest>(in);
+}
+
+// clang-format off
+/**
+ * Paired init for dest-reuse element-wise subtraction (sub_reuse_dest_tiles<reuse_dest>). See
+ * add_reuse_dest_init; DEST_TO_SRCA gives DST - in, DEST_TO_SRCB gives in - DST.
+ *
+ * | Param Type | Name       | Description                                                       | Type                       | Valid Range | Required |
+ * |------------|------------|-------------------------------------------------------------------|----------------------------|-------------|----------|
+ * | Template   | reuse_dest | Which source register the DST operand is loaded into (non-NONE)   | EltwiseBinaryReuseDestType | N/A         | True     |
+ * | Function   | in         | L1 operand unpacked into the source register not fed by DST        | LLKOperand                 | N/A         | True     |
+ */
+// clang-format on
+template <EltwiseBinaryReuseDestType reuse_dest, DataFormat Format, TensorShape Shape>
+ALWI void sub_reuse_dest_init(LLKOperand<Format, Shape> in) {
+    static_assert(
+        reuse_dest != EltwiseBinaryReuseDestType::NONE,
+        "reuse_dest must be DEST_TO_SRCA or DEST_TO_SRCB; for the two-operand op call sub_init(a).");
+    detail::binary_reuse_dest_init<EltwiseBinaryType::ELWSUB, reuse_dest>(in);
+}
+
+// clang-format off
+/**
+ * Paired init for dest-reuse element-wise multiplication (mul_reuse_dest_tiles<reuse_dest>). See
+ * add_reuse_dest_init; result = DST * in (DEST_TO_SRCA) or in * DST (DEST_TO_SRCB).
+ *
+ * | Param Type | Name       | Description                                                       | Type                       | Valid Range | Required |
+ * |------------|------------|-------------------------------------------------------------------|----------------------------|-------------|----------|
+ * | Template   | reuse_dest | Which source register the DST operand is loaded into (non-NONE)   | EltwiseBinaryReuseDestType | N/A         | True     |
+ * | Function   | in         | L1 operand unpacked into the source register not fed by DST        | LLKOperand                 | N/A         | True     |
+ */
+// clang-format on
+template <EltwiseBinaryReuseDestType reuse_dest, DataFormat Format, TensorShape Shape>
+ALWI void mul_reuse_dest_init(LLKOperand<Format, Shape> in) {
+    static_assert(
+        reuse_dest != EltwiseBinaryReuseDestType::NONE,
+        "reuse_dest must be DEST_TO_SRCA or DEST_TO_SRCB; for the two-operand op call mul_init(a).");
+    detail::binary_reuse_dest_init<EltwiseBinaryType::ELWMUL, reuse_dest>(in);
+}
+
+// clang-format off
+/**
+ * Dest-reuse element-wise add: C = DST[dst_tile_index] + in, where one operand is the tile already in DST and
+ * the other is unpacked from the L1 operand `in`. reuse_dest selects which source register the DST tile loads
+ * into (DEST_TO_SRCA: DST->SrcA, in->SrcB; DEST_TO_SRCB: DST->SrcB, in->SrcA). Assumes a prior op populated
+ * DST[dst_tile_index], else it reads zeroes. Pair with add_reuse_dest_init<reuse_dest>. The DST register must
+ * be acquired.
+ *
+ * | Param Type | Name           | Description                                                        | Type                       | Valid Range | Required |
+ * |------------|----------------|-------------------------------------------------------------------|----------------------------|-------------|----------|
+ * | Template   | reuse_dest     | Which source register the DST operand is loaded into (non-NONE)    | EltwiseBinaryReuseDestType | N/A         | True     |
+ * | Function   | in             | L1 operand unpacked into the source register not fed by DST         | LLKOperand                 | N/A         | True     |
+ * | Function   | in_tile_index  | Index of the tile within the L1 operand                            | uint32_t                   | N/A         | True     |
+ * | Function   | dst_tile_index | DST tile used as the other operand and as the result               | uint32_t                   | < DST size  | True     |
+ */
+// clang-format on
+template <EltwiseBinaryReuseDestType reuse_dest, DataFormat Format, TensorShape Shape>
+ALWI void add_reuse_dest_tiles(
+    LLKOperand<Format, Shape> in, std::uint32_t in_tile_index, std::uint32_t dst_tile_index) {
+    detail::binary_reuse_dest_tiles<EltwiseBinaryType::ELWADD, reuse_dest>(in, in_tile_index, dst_tile_index);
+}
+
+// clang-format off
+/**
+ * Dest-reuse element-wise subtract: C = DST[dst_tile_index] - in (DEST_TO_SRCA) or in - DST (DEST_TO_SRCB).
+ * See add_reuse_dest_tiles; pair with sub_reuse_dest_init<reuse_dest>.
+ *
+ * | Param Type | Name           | Description                                                        | Type                       | Valid Range | Required |
+ * |------------|----------------|-------------------------------------------------------------------|----------------------------|-------------|----------|
+ * | Template   | reuse_dest     | Which source register the DST operand is loaded into (non-NONE)    | EltwiseBinaryReuseDestType | N/A         | True     |
+ * | Function   | in             | L1 operand unpacked into the source register not fed by DST         | LLKOperand                 | N/A         | True     |
+ * | Function   | in_tile_index  | Index of the tile within the L1 operand                            | uint32_t                   | N/A         | True     |
+ * | Function   | dst_tile_index | DST tile used as the other operand and as the result               | uint32_t                   | < DST size  | True     |
+ */
+// clang-format on
+template <EltwiseBinaryReuseDestType reuse_dest, DataFormat Format, TensorShape Shape>
+ALWI void sub_reuse_dest_tiles(
+    LLKOperand<Format, Shape> in, std::uint32_t in_tile_index, std::uint32_t dst_tile_index) {
+    detail::binary_reuse_dest_tiles<EltwiseBinaryType::ELWSUB, reuse_dest>(in, in_tile_index, dst_tile_index);
+}
+
+// clang-format off
+/**
+ * Dest-reuse element-wise multiply: C = DST[dst_tile_index] * in (DEST_TO_SRCA) or in * DST (DEST_TO_SRCB).
+ * See add_reuse_dest_tiles; pair with mul_reuse_dest_init<reuse_dest>.
+ *
+ * | Param Type | Name           | Description                                                        | Type                       | Valid Range | Required |
+ * |------------|----------------|-------------------------------------------------------------------|----------------------------|-------------|----------|
+ * | Template   | reuse_dest     | Which source register the DST operand is loaded into (non-NONE)    | EltwiseBinaryReuseDestType | N/A         | True     |
+ * | Function   | in             | L1 operand unpacked into the source register not fed by DST         | LLKOperand                 | N/A         | True     |
+ * | Function   | in_tile_index  | Index of the tile within the L1 operand                            | uint32_t                   | N/A         | True     |
+ * | Function   | dst_tile_index | DST tile used as the other operand and as the result               | uint32_t                   | < DST size  | True     |
+ */
+// clang-format on
+template <EltwiseBinaryReuseDestType reuse_dest, DataFormat Format, TensorShape Shape>
+ALWI void mul_reuse_dest_tiles(
+    LLKOperand<Format, Shape> in, std::uint32_t in_tile_index, std::uint32_t dst_tile_index) {
+    detail::binary_reuse_dest_tiles<EltwiseBinaryType::ELWMUL, reuse_dest>(in, in_tile_index, dst_tile_index);
+}
+
+#endif  // ARCH_BLACKHOLE
+
+}  // namespace experimental
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/hw_startup.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/hw_startup.h
@@ -14,24 +14,25 @@
 #endif
 
 // =====================================================================================================
-// Id-free (2.0) compute_kernel_hw_startup. This is an OVERLOAD of the shipping compute_kernel_hw_startup
-// (api/compute/compute_kernel_hw_startup.h, CB-id) -- same name, distinguished by taking LLKOperands. It is
-// deliberately kept OUT of the shipping header: that header is pulled in by common.h -> kernel_args.h into
-// every legacy kernel, and this overload references ckernel::experimental, which collides with metal's
-// top-level ::experimental (kernel_args.h) under `using namespace ckernel`. 2.0 kernels (which never include
-// kernel_args.h) include THIS header instead; legacy kernels are untouched. Blackhole only (2.0 scope).
+// Id-free (2.0) compute_kernel_hw_startup: an OVERLOAD of the shipping compute_kernel_hw_startup
+// (api/compute/compute_kernel_hw_startup.h, CB-id) -- same name, distinguished by taking LLKOperands
+// instead of CB ids. Every data format and tile geometry comes from the operand descriptors (NTTPs);
+// there is no runtime L1-format inference and no CB-id dependency on the compute-op surface. The
+// operands' runtime l1_address is unused here (startup only programs formats/geometry).
 //
-// Every data format and tile geometry comes from the operand descriptors (NTTPs); there is NO runtime
-// L1-format inference and NO CB-id dependency left on the compute-op surface. The two source-register formats
-// are reconciled to a common exponent-width family inside the LLK hw_configure (C1). src_order selects how
-// (in0, in1) map onto SrcA/SrcB (Reverse for matmul), exactly as the CB-id overload. The operands' runtime
-// l1_address is unused here (startup only programs formats/geometry). The compute sentinel (a debug spy,
-// disabled by default) is not seeded on this path -- it keys on CB ids, which are gone.
+// NOTE: kept OUT of the shipping header on purpose. That header is pulled into every legacy kernel via
+// common.h -> kernel_args.h, but this overload references ckernel::experimental, which collides with
+// metal's top-level ::experimental (kernel_args.h) under `using namespace ckernel`. 2.0 kernels (which
+// never include kernel_args.h) include THIS header instead; legacy kernels are untouched.
 //
-// NOTE (ordering / config-registers): hw_startup writes the UNPACK/MATH/PACK configuration registers (via the
-// llk_*_hw_configure cores) and must run exactly ONCE, at the top of the kernel, before any op-specific init or
-// any tile traffic on that engine -- these are the shared per-engine config registers, so reprogramming them
-// while an op is in flight is a data race on the engine state. This mirrors the CB-id overload's contract.
+// src_order selects how (in0, in1) map onto SrcA/SrcB (Reverse for matmul), exactly as the CB-id
+// overload. The two source-register formats are reconciled to a common exponent-width family inside
+// the LLK hw_configure. Blackhole only (2.0 scope).
+//
+// CAVEAT: hw_startup writes the shared per-engine UNPACK/MATH/PACK config registers and must run
+// exactly ONCE, at the top of the kernel, before any op-specific init or tile traffic on that engine --
+// reprogramming these registers while an op is in flight is a data race on engine state. Mirrors the
+// CB-id overload's contract.
 // =====================================================================================================
 
 namespace ckernel {
@@ -44,7 +45,7 @@ namespace ckernel {
  * from the operand descriptors (NTTPs) -- no CB ids, no runtime L1-format inference. Call exactly once at the
  * top of the kernel, before any op-specific init. src_order selects how (in0, in1) map onto SrcA/SrcB
  * (SrcOrder::Reverse for matmul: in0 -> SrcB, in1 -> SrcA). The operands' runtime l1_address is unused here.
- * The two source-register formats are reconciled to a common exponent-width family (C1); a mixed-width pairing
+ * The two source-register formats are reconciled to a common exponent-width family; a mixed-width pairing
  * that is not Float32-rebiasable is a hard compile error.
  *
  * | Param Type | Name             | Description                                      | Type                   | Valid Range | Required |
@@ -70,11 +71,9 @@ ALWI void compute_kernel_hw_startup(
     static_assert(experimental::is_legal_tile_shape(SA), "compute_kernel_hw_startup: illegal in0 tile shape.");
     static_assert(experimental::is_legal_tile_shape(SB), "compute_kernel_hw_startup: illegal in1 tile shape.");
     static_assert(experimental::is_legal_tile_shape(SO), "compute_kernel_hw_startup: illegal out tile shape.");
-    // Map the operands onto the physical source registers. For SrcOrder::Reverse (matmul) in0 -> SrcB and
-    // in1 -> SrcA. src_order is a template parameter, so this is resolved at compile time. Each descriptor is
-    // referenced only inside its own thread's macro (UNPACK/MATH/PACK) and so is unused on the other threads;
-    // that is fine under the kernel build's -Wno-unused-variable, exactly as the CB-id overload's src_a_cb /
-    // src_b_cb locals are.
+    // Map the operands onto the physical source registers. For SrcOrder::Reverse (matmul), in0 -> SrcB and
+    // in1 -> SrcA (resolved at compile time). Each descriptor is referenced only inside its own thread's
+    // macro (UNPACK/MATH/PACK), so it is unused on the other threads -- fine under -Wno-unused-variable.
     constexpr bool reverse = (src_order == SrcOrder::Reverse);
     constexpr experimental::LLKMemDescriptor SRCA =
         reverse ? experimental::LLKOperand<FB, SB>::descriptor : experimental::LLKOperand<FA, SA>::descriptor;

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/hw_startup.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/hw_startup.h
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/compute/common.h"                        // ALWI, UNPACK/MATH/PACK, DST_ACCUM_MODE, PackMode
+#include "api/compute/src_order.h"                     // SrcOrder
+#include "api/compute/experimental/2_0/llk_operand.h"  // LLKOperand
+#include "experimental/2_0/llk_hw_configure.h"  // id-free llk_{unpack,math,pack}_hw_configure (+ pack_dest_init / math_pack_sync_init per TRISC)
+
+#ifdef TRISC_PACK
+#include "experimental/2_0/llk_pack_tile.h"  // id-free llk_pack_init<DESC>
+#endif
+
+// =====================================================================================================
+// Id-free (2.0) compute_kernel_hw_startup. This is an OVERLOAD of the shipping compute_kernel_hw_startup
+// (api/compute/compute_kernel_hw_startup.h, CB-id) -- same name, distinguished by taking LLKOperands. It is
+// deliberately kept OUT of the shipping header: that header is pulled in by common.h -> kernel_args.h into
+// every legacy kernel, and this overload references ckernel::experimental, which collides with metal's
+// top-level ::experimental (kernel_args.h) under `using namespace ckernel`. 2.0 kernels (which never include
+// kernel_args.h) include THIS header instead; legacy kernels are untouched. Blackhole only (2.0 scope).
+//
+// Every data format and tile geometry comes from the operand descriptors (NTTPs); there is NO runtime
+// L1-format inference and NO CB-id dependency left on the compute-op surface. The two source-register formats
+// are reconciled to a common exponent-width family inside the LLK hw_configure (C1). src_order selects how
+// (in0, in1) map onto SrcA/SrcB (Reverse for matmul), exactly as the CB-id overload. The operands' runtime
+// l1_address is unused here (startup only programs formats/geometry). The compute sentinel (a debug spy,
+// disabled by default) is not seeded on this path -- it keys on CB ids, which are gone.
+//
+// NOTE (ordering / config-registers): hw_startup writes the UNPACK/MATH/PACK configuration registers (via the
+// llk_*_hw_configure cores) and must run exactly ONCE, at the top of the kernel, before any op-specific init or
+// any tile traffic on that engine -- these are the shared per-engine config registers, so reprogramming them
+// while an op is in flight is a data race on the engine state. This mirrors the CB-id overload's contract.
+// =====================================================================================================
+
+namespace ckernel {
+
+#ifdef ARCH_BLACKHOLE
+
+// clang-format off
+/**
+ * Id-free (2.0) two-input hardware startup. Programs the UNPACK/MATH/PACK register formats + tile geometry
+ * from the operand descriptors (NTTPs) -- no CB ids, no runtime L1-format inference. Call exactly once at the
+ * top of the kernel, before any op-specific init. src_order selects how (in0, in1) map onto SrcA/SrcB
+ * (SrcOrder::Reverse for matmul: in0 -> SrcB, in1 -> SrcA). The operands' runtime l1_address is unused here.
+ * The two source-register formats are reconciled to a common exponent-width family (C1); a mixed-width pairing
+ * that is not Float32-rebiasable is a hard compile error.
+ *
+ * | Param Type | Name             | Description                                      | Type                   | Valid Range | Required |
+ * |------------|------------------|--------------------------------------------------|------------------------|-------------|----------|
+ * | Template   | src_order        | (in0,in1) -> SrcA/SrcB mapping (Reverse=matmul)  | SrcOrder               | N/A         | False    |
+ * | Template   | FA/SA, FB/SB, FO/SO | in0 / in1 / out L1 format + geometry (deduced) | DataFormat/TensorShape | N/A         | True     |
+ * | Function   | in0 / in1        | Input operands (natural order)                   | LLKOperand             | N/A         | True     |
+ * | Function   | out              | Output operand                                   | LLKOperand             | N/A         | True     |
+ */
+// clang-format on
+template <
+    SrcOrder src_order = SrcOrder::Regular,
+    DataFormat FA,
+    TensorShape SA,
+    DataFormat FB,
+    TensorShape SB,
+    DataFormat FO,
+    TensorShape SO>
+ALWI void compute_kernel_hw_startup(
+    experimental::LLKOperand<FA, SA> /*in0*/,
+    experimental::LLKOperand<FB, SB> /*in1*/,
+    experimental::LLKOperand<FO, SO> /*out*/) {
+    static_assert(experimental::is_legal_tile_shape(SA), "compute_kernel_hw_startup: illegal in0 tile shape.");
+    static_assert(experimental::is_legal_tile_shape(SB), "compute_kernel_hw_startup: illegal in1 tile shape.");
+    static_assert(experimental::is_legal_tile_shape(SO), "compute_kernel_hw_startup: illegal out tile shape.");
+    // Map the operands onto the physical source registers. For SrcOrder::Reverse (matmul) in0 -> SrcB and
+    // in1 -> SrcA. src_order is a template parameter, so this is resolved at compile time. Each descriptor is
+    // referenced only inside its own thread's macro (UNPACK/MATH/PACK) and so is unused on the other threads;
+    // that is fine under the kernel build's -Wno-unused-variable, exactly as the CB-id overload's src_a_cb /
+    // src_b_cb locals are.
+    constexpr bool reverse = (src_order == SrcOrder::Reverse);
+    constexpr experimental::LLKMemDescriptor SRCA =
+        reverse ? experimental::LLKOperand<FB, SB>::descriptor : experimental::LLKOperand<FA, SA>::descriptor;
+    constexpr experimental::LLKMemDescriptor SRCB =
+        reverse ? experimental::LLKOperand<FA, SA>::descriptor : experimental::LLKOperand<FB, SB>::descriptor;
+    constexpr experimental::LLKMemDescriptor OUT = experimental::LLKOperand<FO, SO>::descriptor;
+
+    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE, SRCA, SRCB>()));
+
+    MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
+    MATH((llk_math_hw_configure<DST_ACCUM_MODE, SRCA, SRCB>()));
+
+    PACK((llk_pack_hw_configure<DST_ACCUM_MODE, OUT>()));
+    PACK((llk_pack_init<OUT, DST_ACCUM_MODE, PackMode::Default>()));
+    PACK((_llk_pack_dest_init_<DST_SYNC_MODE, DST_ACCUM_MODE>()));
+}
+
+// clang-format off
+/**
+ * Id-free (2.0) single-input hardware startup: convenience overload that configures both source registers from
+ * the same operand. Equivalent to the two-input overload with in0 == in1. Used by single-operand ops
+ * (copy/tilize/pack_untilize).
+ *
+ * | Param Type | Name       | Description                              | Type                   | Valid Range | Required |
+ * |------------|------------|------------------------------------------|------------------------|-------------|----------|
+ * | Template   | src_order  | (in,in) -> SrcA/SrcB mapping             | SrcOrder               | N/A         | False    |
+ * | Template   | F/S, FO/SO | in / out L1 format + geometry (deduced)  | DataFormat/TensorShape | N/A         | True     |
+ * | Function   | in         | The single input operand                 | LLKOperand             | N/A         | True     |
+ * | Function   | out        | Output operand                           | LLKOperand             | N/A         | True     |
+ */
+// clang-format on
+template <SrcOrder src_order = SrcOrder::Regular, DataFormat F, TensorShape S, DataFormat FO, TensorShape SO>
+ALWI void compute_kernel_hw_startup(experimental::LLKOperand<F, S> in, experimental::LLKOperand<FO, SO> out) {
+    compute_kernel_hw_startup<src_order>(in, in, out);
+}
+
+#endif  // ARCH_BLACKHOLE
+
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/hw_startup.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/hw_startup.h
@@ -48,7 +48,8 @@ namespace ckernel {
  *
  * | Param Type | Name             | Description                                      | Type                   | Valid Range | Required |
  * |------------|------------------|--------------------------------------------------|------------------------|-------------|----------|
- * | Template   | src_order        | (in0,in1) -> SrcA/SrcB mapping (Reverse=matmul)  | SrcOrder               | N/A         | False    |
+ * | Template   | src_order           | (in0,in1) -> SrcA/SrcB mapping (Reverse=matmul)  | SrcOrder               | N/A         | False    |
+ * | Template   | is_fp32_dest_acc_en | fp32 dest-accumulate mode                         | bool                   |             | False    |
  * | Template   | FA/SA, FB/SB, FO/SO | in0 / in1 / out L1 format + geometry (deduced) | DataFormat/TensorShape | N/A         | True     |
  * | Function   | in0 / in1        | Input operands (natural order)                   | LLKOperand             | N/A         | True     |
  * | Function   | out              | Output operand                                   | LLKOperand             | N/A         | True     |
@@ -56,6 +57,7 @@ namespace ckernel {
 // clang-format on
 template <
     SrcOrder src_order = SrcOrder::Regular,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
     DataFormat FA,
     TensorShape SA,
     DataFormat FB,
@@ -79,14 +81,14 @@ ALWI void compute_kernel_hw_startup(
         reverse ? experimental::LLKOperand<FA, SA>::descriptor : experimental::LLKOperand<FB, SB>::descriptor;
     constexpr experimental::LLKMemDescriptor OUT = experimental::LLKOperand<FO, SO>::descriptor;
 
-    UNPACK((llk_unpack_hw_configure<DST_ACCUM_MODE, SRCA, SRCB>()));
+    UNPACK((llk_unpack_hw_configure<is_fp32_dest_acc_en, SRCA, SRCB>()));
 
-    MATH((llk_math_pack_sync_init<DST_ACCUM_MODE>()));
-    MATH((llk_math_hw_configure<DST_ACCUM_MODE, SRCA, SRCB>()));
+    MATH((llk_math_pack_sync_init<is_fp32_dest_acc_en>()));
+    MATH((llk_math_hw_configure<is_fp32_dest_acc_en, SRCA, SRCB>()));
 
-    PACK((llk_pack_hw_configure<DST_ACCUM_MODE, OUT>()));
-    PACK((llk_pack_init<OUT, DST_ACCUM_MODE, PackMode::Default>()));
-    PACK((_llk_pack_dest_init_<DST_SYNC_MODE, DST_ACCUM_MODE>()));
+    PACK((llk_pack_hw_configure<is_fp32_dest_acc_en, OUT>()));
+    PACK((llk_pack_init<OUT, is_fp32_dest_acc_en, PackMode::Default>()));
+    PACK((_llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>()));
 }
 
 // clang-format off
@@ -97,15 +99,22 @@ ALWI void compute_kernel_hw_startup(
  *
  * | Param Type | Name       | Description                              | Type                   | Valid Range | Required |
  * |------------|------------|------------------------------------------|------------------------|-------------|----------|
- * | Template   | src_order  | (in,in) -> SrcA/SrcB mapping             | SrcOrder               | N/A         | False    |
- * | Template   | F/S, FO/SO | in / out L1 format + geometry (deduced)  | DataFormat/TensorShape | N/A         | True     |
+ * | Template   | src_order           | (in,in) -> SrcA/SrcB mapping             | SrcOrder               | N/A         | False    |
+ * | Template   | is_fp32_dest_acc_en | fp32 dest-accumulate mode                | bool                   |             | False    |
+ * | Template   | F/S, FO/SO          | in / out L1 format + geometry (deduced)  | DataFormat/TensorShape | N/A         | True     |
  * | Function   | in         | The single input operand                 | LLKOperand             | N/A         | True     |
  * | Function   | out        | Output operand                           | LLKOperand             | N/A         | True     |
  */
 // clang-format on
-template <SrcOrder src_order = SrcOrder::Regular, DataFormat F, TensorShape S, DataFormat FO, TensorShape SO>
+template <
+    SrcOrder src_order = SrcOrder::Regular,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    DataFormat F,
+    TensorShape S,
+    DataFormat FO,
+    TensorShape SO>
 ALWI void compute_kernel_hw_startup(experimental::LLKOperand<F, S> in, experimental::LLKOperand<FO, SO> out) {
-    compute_kernel_hw_startup<src_order>(in, in, out);
+    compute_kernel_hw_startup<src_order, is_fp32_dest_acc_en>(in, in, out);
 }
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/hw_startup.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/hw_startup.h
@@ -37,8 +37,6 @@
 
 namespace ckernel {
 
-#ifdef ARCH_BLACKHOLE
-
 // clang-format off
 /**
  * Id-free (2.0) two-input hardware startup. Programs the UNPACK/MATH/PACK register formats + tile geometry
@@ -109,7 +107,5 @@ template <SrcOrder src_order = SrcOrder::Regular, DataFormat F, TensorShape S, D
 ALWI void compute_kernel_hw_startup(experimental::LLKOperand<F, S> in, experimental::LLKOperand<FO, SO> out) {
     compute_kernel_hw_startup<src_order>(in, in, out);
 }
-
-#endif  // ARCH_BLACKHOLE
 
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/internal/llk_descriptor.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/internal/llk_descriptor.h
@@ -41,13 +41,12 @@ constexpr std::uint32_t round_up_l1_words(std::uint32_t bytes) { return (bytes +
 // clang-format off
 /**
  * (internal) Per-tile L1 stride in 16-byte words, for absolute (out-of-order) tile addressing (base +
- * t*stride). The id-free stand-in for the CB's fifo_page_size, which the shipping factories set to one tile's
- * size. Geometry-exact for BOTH branches, so partial / tiny tiles stride correctly:
- *   * Block floats (Bfp8/Bfp4/Bfp2): a tile is [packed mantissas | shared-exponent section]. This mirrors
- *     tt_metal Tile::get_tile_size (impl/data_format/tile.cpp) scaled by the real geometry: mantissa =
- *     total_tensor_size() at the format's storage width (Bfp8 1 B/datum, Bfp4 1/2, Bfp2 1/4), exp section =
- *     round_up(face_r_dim * total_num_faces, 16). GET_L1_HEADERLESS_TILE_SIZE hard-codes the full-32x32 value
- *     and is WRONG for a partial BFP tile (fewer face rows / faces), so we compute the size here instead.
+ * t*stride). The id-free stand-in for the CB's fifo_page_size, which the shipping factories set to one
+ * tile's size. Geometry-exact for both branches, so partial / tiny tiles stride correctly:
+ *   * Block floats (Bfp8/Bfp4/Bfp2): a tile is [packed mantissas | shared-exponent section], scaled by
+ *     geometry to match tt_metal Tile::get_tile_size -- mantissa bytes scale with storage width (Bfp8
+ *     1 B/datum, Bfp4 1/2, Bfp2 1/4), exponent section is round_up(face_r_dim * total_num_faces, 16).
+ *     (GET_L1_HEADERLESS_TILE_SIZE assumes a full 32x32 tile and is unsafe for a partial BFP tile.)
  *   * Linear formats (Float32/Float16/int): the geometry-exact datum-count size (SCALE_DATUM_SIZE >> 4).
  *
  * | Param Type | Name   | Description                       | Type        | Valid Range | Required |
@@ -79,14 +78,13 @@ constexpr std::uint32_t tile_stride_words(DataFormat format, TensorShape shape) 
     return round_up_l1_words(mantissa_bytes + exp_bytes);
 }
 
-// NOTE (matmul partial_face): the id-free matmul derives partial_face inline at its two call sites, NOT via a
-// shared helper, because the UNPACK and MATH engines use DIFFERENT thresholds (inherited from the legacy CB-id
-// path, do not "unify"):
-//   * MATH  (llk_math_matmul.h):        partial_face = (shape.total_row_dim() < FACE_R_DIM)  -- == legacy math init.
-//   * UNPACK (llk_unpack_AB_matmul.h):  partial_face = (shape.total_row_dim() < TILE_R_DIM)  -- == the legacy
-//     host-side Tile::partial_face (tile height < TILE_HEIGHT) fed via get_operand_partial_face().
-// A one-face-high operand (total_row_dim() == 16) is thus partial-face to the unpacker (16 < 32) but full-face to
-// the math (16 == FACE_R_DIM, not < ).
+// NOTE (matmul partial_face): the id-free matmul computes partial_face inline at its two call sites, NOT via
+// a shared helper, because UNPACK and MATH use DIFFERENT thresholds:
+//   * MATH  (llk_math_matmul.h):       partial_face = (shape.total_row_dim() < FACE_R_DIM).
+//   * UNPACK (llk_unpack_AB_matmul.h): partial_face = (shape.total_row_dim() < TILE_R_DIM), matching the
+//     host-side Tile::partial_face (tile height < TILE_HEIGHT) via get_operand_partial_face().
+// A one-face-high operand (total_row_dim() == 16) is thus partial-face to the unpacker (16 < 32) but
+// full-face to the math (16 == FACE_R_DIM, not <).
 
 /**
  * (internal) Per-tile L1 size in 16B words (fifo_page_size units) for a matmul operand descriptor: geometry-exact
@@ -98,7 +96,7 @@ constexpr std::uint32_t matmul_tile_size(const LLKMemDescriptor& desc) {
 }
 
 // -----------------------------------------------------------------------------------------------------
-// Compile-time contract helpers (PART D). With no CB id, the legality the CB descriptor used to guarantee is
+// Compile-time contract helpers. With no CB id, the legality the CB descriptor used to guarantee is
 // re-established as static_asserts on the operand geometry NTTPs, firing at the user's call site.
 // -----------------------------------------------------------------------------------------------------
 
@@ -109,7 +107,7 @@ constexpr std::uint32_t matmul_tile_size(const LLKMemDescriptor& desc) {
  * runtime validator ckernel::validate_tensor_shape_tile_dependent_ops_ (tensor_shape.h): it adds the per-axis
  * face-grid bound the runtime validator omits, so shapes like {16,16,4,1} / {16,16,1,4} (a 64x16 / 16x64 tile
  * that exceeds the 32x32 limit yet has total_num_faces()==4) are rejected here rather than silently addressed.
- * constexpr so it is usable in the compute-op static_asserts (PART D). `s`: the tile geometry to check.
+ * constexpr so it is usable in the compute-op static_asserts. `s`: the tile geometry to check.
  */
 constexpr bool is_legal_tile_shape(TensorShape s) {
     const bool fr =
@@ -148,7 +146,7 @@ constexpr bool is_partial_height(TensorShape s) { return s.total_row_dim() < TIL
 
 /**
  * (internal) True iff two operands carry the same tile geometry (a two-input op requires matching shapes).
- * Used by the binary-op static_asserts (PART D). `a`, `b`: the two tile geometries to compare.
+ * Used by the binary-op static_asserts. `a`, `b`: the two tile geometries to compare.
  */
 constexpr bool same_tile_shape(TensorShape a, TensorShape b) {
     return a.face_r_dim == b.face_r_dim && a.face_c_dim == b.face_c_dim && a.num_faces_r_dim == b.num_faces_r_dim &&

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/internal/llk_descriptor.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/internal/llk_descriptor.h
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "tensor_shape.h"                // ckernel::TensorShape + geometry helpers
+#include "api/compute/common_globals.h"  // DataFormat enum + ckernel_defs macros (IS_BFP_FORMAT, SCALE_DATUM_SIZE, ...)
+
+// =====================================================================================================
+// INTERNAL (NOT user-facing). The compile-time descriptor + per-tile stride math consumed by the LLK layer
+// AND the compute-op layer. Kernel authors never touch this header -- they use LLKOperand (llk_operand.h).
+//
+//   * LLKMemDescriptor -- the compile-time "sticky note" the LLK ops consume as an NTTP (buffer L1 data
+//     format + tile geometry). Passed as a non-type template parameter (-ftt-nttp) so the per-format
+//     switches / register writes / asserts fold and DCE away.
+//   * tile_stride_words -- the per-tile L1 stride (in 16-byte words) used for absolute tile addressing.
+//
+// The register-side format is NOT carried (derived inside the LLK from `format`); there is NO CB id and NO
+// knowledge of the source (CB / DataflowBuffer / Scratchpad / LocalTensorAccessor).
+// =====================================================================================================
+
+namespace ckernel {
+namespace experimental {
+
+/**
+ * (internal) The compile-time descriptor the LLK APIs accept as an NTTP: buffer L1 format + tile geometry.
+ * `format` is what the unpacker reads / the packer writes; `shape` is the tile geometry (derive num_faces /
+ * tile dims via the TensorShape helpers).
+ */
+struct LLKMemDescriptor {
+    DataFormat format;  // buffer L1 format (what the unpacker reads / the packer writes)
+    TensorShape shape;  // tile geometry; derive num_faces / tile dims via TensorShape helpers
+};
+
+// clang-format off
+/**
+ * (internal) Per-tile L1 stride in 16-byte words, for absolute (out-of-order) tile addressing (base +
+ * t*stride). The id-free stand-in for the CB's fifo_page_size, which the shipping factories set to one tile's
+ * size.
+ *   * Block floats (Bfp8/Bfp4/Bfp2): a tile carries a shared-exponent section that SCALE_DATUM_SIZE omits (and
+ *     it miscounts the sub-byte mantissa), so use GET_L1_HEADERLESS_TILE_SIZE -- exp section included, matching
+ *     tile_size(fmt) / llk_pack_fast_tilize. Assumes a full 32x32 tile (partial BFP tiles are out of scope).
+ *   * Linear formats (Float32/Float16/int): keep the geometry-exact datum-count size so tiny tiles
+ *     (face_r_dim / num_faces below full) stride correctly.
+ *
+ * | Param Type | Name   | Description                       | Type        | Valid Range | Required |
+ * |------------|--------|-----------------------------------|-------------|-------------|----------|
+ * | Function   | format | Buffer L1 data format             | DataFormat  | N/A         | True     |
+ * | Function   | shape  | Tile geometry                     | TensorShape | N/A         | True     |
+ */
+// clang-format on
+constexpr std::uint32_t tile_stride_words(DataFormat format, TensorShape shape) {
+    // The size macros are the legacy numeric-format path; convert the typed format once here.
+    const std::uint32_t fmt = static_cast<std::uint32_t>(format);
+    return IS_BFP_FORMAT(fmt) ? GET_L1_HEADERLESS_TILE_SIZE(fmt)
+                              : (SCALE_DATUM_SIZE(fmt, shape.total_tensor_size()) >> 4);
+}
+
+/**
+ * (internal) partial_face for a matmul operand: the rule (tile_r_dim < FACE_R_DIM) that both the id-free matmul
+ * UNPACK (llk_unpack_AB_matmul) and MATH (llk_math_matmul) derive, shared here so they stay identical (and match
+ * the legacy CB-id llk_math_matmul_init). `desc`: the operand's descriptor.
+ */
+constexpr bool matmul_partial_face(const LLKMemDescriptor& desc) { return desc.shape.total_row_dim() < FACE_R_DIM; }
+
+/**
+ * (internal) Per-tile L1 size in 16B words (fifo_page_size units) for a matmul operand descriptor: geometry-exact
+ * for linear formats, exp section included for block floats. Thin wrapper over tile_stride_words. `desc`: the
+ * operand's descriptor.
+ */
+constexpr std::uint32_t matmul_tile_size(const LLKMemDescriptor& desc) {
+    return tile_stride_words(desc.format, desc.shape);
+}
+
+// -----------------------------------------------------------------------------------------------------
+// Compile-time contract helpers (PART D). With no CB id, the legality the CB descriptor used to guarantee is
+// re-established as static_asserts on the operand geometry NTTPs, firing at the user's call site.
+// -----------------------------------------------------------------------------------------------------
+
+/**
+ * (internal) True iff the tile shape is one the HW can address: face_r_dim in {1,2,4,8,16}, face_c_dim == 16
+ * (always 16 in hardware), the face grid within HW limits (num_faces_r_dim / num_faces_c_dim each in {1,2},
+ * i.e. MAX_NUM_FACES_R_DIM / MAX_NUM_FACES_C_DIM), and total faces in {1,2,4}. Superset of the canonical
+ * runtime validator ckernel::validate_tensor_shape_tile_dependent_ops_ (tensor_shape.h): it adds the per-axis
+ * face-grid bound the runtime validator omits, so shapes like {16,16,4,1} / {16,16,1,4} (a 64x16 / 16x64 tile
+ * that exceeds the 32x32 limit yet has total_num_faces()==4) are rejected here rather than silently addressed.
+ * constexpr so it is usable in the compute-op static_asserts (PART D). `s`: the tile geometry to check.
+ */
+constexpr bool is_legal_tile_shape(TensorShape s) {
+    const bool fr =
+        (s.face_r_dim == 1 || s.face_r_dim == 2 || s.face_r_dim == 4 || s.face_r_dim == 8 || s.face_r_dim == 16);
+    const bool grid =
+        (s.num_faces_r_dim == 1 || s.num_faces_r_dim == 2) && (s.num_faces_c_dim == 1 || s.num_faces_c_dim == 2);
+    const std::uint8_t nf = s.total_num_faces();
+    return fr && (s.face_c_dim == 16) && grid && (nf == 1 || nf == 2 || nf == 4);
+}
+
+/**
+ * (internal) True iff `f` is a 32-bit register format (Float32/UInt32/Int32). These must take the
+ * unpack-to-dest A2D path (SrcB is only 19 bits wide), so bcast / transpose use this to select that path at
+ * compile time (folds to a constant). Shared so the same 3-way format compare is not spelled out per site.
+ */
+constexpr bool is_32bit_format(DataFormat f) {
+    return f == DataFormat::Float32 || f == DataFormat::UInt32 || f == DataFormat::Int32;
+}
+
+/**
+ * (internal) True iff two operands carry the same tile geometry (a two-input op requires matching shapes).
+ * Used by the binary-op static_asserts (PART D). `a`, `b`: the two tile geometries to compare.
+ */
+constexpr bool same_tile_shape(TensorShape a, TensorShape b) {
+    return a.face_r_dim == b.face_r_dim && a.face_c_dim == b.face_c_dim && a.num_faces_r_dim == b.num_faces_r_dim &&
+           a.num_faces_c_dim == b.num_faces_c_dim;
+}
+
+}  // namespace experimental
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/internal/llk_descriptor.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/internal/llk_descriptor.h
@@ -59,12 +59,14 @@ constexpr std::uint32_t tile_stride_words(DataFormat format, TensorShape shape) 
                               : (SCALE_DATUM_SIZE(fmt, shape.total_tensor_size()) >> 4);
 }
 
-/**
- * (internal) partial_face for a matmul operand: the rule (tile_r_dim < FACE_R_DIM) that both the id-free matmul
- * UNPACK (llk_unpack_AB_matmul) and MATH (llk_math_matmul) derive, shared here so they stay identical (and match
- * the legacy CB-id llk_math_matmul_init). `desc`: the operand's descriptor.
- */
-constexpr bool matmul_partial_face(const LLKMemDescriptor& desc) { return desc.shape.total_row_dim() < FACE_R_DIM; }
+// NOTE (matmul partial_face): the id-free matmul derives partial_face inline at its two call sites, NOT via a
+// shared helper, because the UNPACK and MATH engines use DIFFERENT thresholds (inherited from the legacy CB-id
+// path, do not "unify"):
+//   * MATH  (llk_math_matmul.h):        partial_face = (shape.total_row_dim() < FACE_R_DIM)  -- == legacy math init.
+//   * UNPACK (llk_unpack_AB_matmul.h):  partial_face = (shape.total_row_dim() < TILE_R_DIM)  -- == the legacy
+//     host-side Tile::partial_face (tile height < TILE_HEIGHT) fed via get_operand_partial_face().
+// A one-face-high operand (total_row_dim() == 16) is thus partial-face to the unpacker (16 < 32) but full-face to
+// the math (16 == FACE_R_DIM, not < ).
 
 /**
  * (internal) Per-tile L1 size in 16B words (fifo_page_size units) for a matmul operand descriptor: geometry-exact

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/internal/llk_descriptor.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/internal/llk_descriptor.h
@@ -8,6 +8,7 @@
 
 #include "tensor_shape.h"                // ckernel::TensorShape + geometry helpers
 #include "api/compute/common_globals.h"  // DataFormat enum + ckernel_defs macros (IS_BFP_FORMAT, SCALE_DATUM_SIZE, ...)
+#include "data_format_derive.h"          // infer_unpack_dst_format (register-format rebias)
 
 // =====================================================================================================
 // INTERNAL (NOT user-facing). The compile-time descriptor + per-tile stride math consumed by the LLK layer
@@ -84,16 +85,7 @@ constexpr std::uint32_t tile_stride_words(DataFormat format, TensorShape shape) 
 //   * UNPACK (llk_unpack_AB_matmul.h): partial_face = (shape.total_row_dim() < TILE_R_DIM), matching the
 //     host-side Tile::partial_face (tile height < TILE_HEIGHT) via get_operand_partial_face().
 // A one-face-high operand (total_row_dim() == 16) is thus partial-face to the unpacker (16 < 32) but
-// full-face to the math (16 == FACE_R_DIM, not <).
-
-/**
- * (internal) Per-tile L1 size in 16B words (fifo_page_size units) for a matmul operand descriptor: geometry-exact
- * for linear formats, exp section included for block floats. Thin wrapper over tile_stride_words. `desc`: the
- * operand's descriptor.
- */
-constexpr std::uint32_t matmul_tile_size(const LLKMemDescriptor& desc) {
-    return tile_stride_words(desc.format, desc.shape);
-}
+// full-face to the math (16 == FACE_R_DIM, not <). Matmul per-tile L1 size is tile_stride_words.
 
 // -----------------------------------------------------------------------------------------------------
 // Compile-time contract helpers. With no CB id, the legality the CB descriptor used to guarantee is
@@ -128,14 +120,21 @@ constexpr bool is_32bit_format(DataFormat f) {
 }
 
 /**
- * (internal) True iff `f` is a block-float register format (Bfp8/Bfp4/Bfp2, a- and b-exponent families).
- * The BH compute datapath only handles FULL-height (32-row) block-float tiles; partial-height block floats
- * are rejected at the copy/pack surfaces (silent-garbage otherwise). Typed sibling of the IS_BFP_FORMAT macro.
+ * (internal) True iff the operand's REGISTER format (after fp32-dest-acc rebias) is 32-bit and must take
+ * the unpack-to-dest A2D path. Shared by unary bcast and transpose so the same infer+is_32bit check is
+ * not spelled twice.
  */
-constexpr bool is_block_float_format(DataFormat f) {
-    return f == DataFormat::Bfp8 || f == DataFormat::Bfp8_b || f == DataFormat::Bfp4 || f == DataFormat::Bfp4_b ||
-           f == DataFormat::Bfp2 || f == DataFormat::Bfp2_b;
+template <DataFormat Format, bool is_fp32_dest_acc_en>
+constexpr bool is_unpack_to_dest() {
+    return is_32bit_format(ckernel::infer_unpack_dst_format(Format, is_fp32_dest_acc_en));
 }
+
+/**
+ * (internal) True iff `f` is a block-float format (Bfp8/Bfp4/Bfp2, a- and b-exponent families).
+ * The BH compute datapath only handles FULL-height (32-row) block-float tiles; partial-height block floats
+ * are rejected at the copy/pack surfaces (silent-garbage otherwise). Typed wrapper over IS_BFP_FORMAT.
+ */
+constexpr bool is_block_float_format(DataFormat f) { return IS_BFP_FORMAT(static_cast<std::uint32_t>(f)); }
 
 /**
  * (internal) True iff the tile has fewer than 32 rows (partial tile height). For block-float formats a

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/internal/llk_descriptor.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/internal/llk_descriptor.h
@@ -130,6 +130,23 @@ constexpr bool is_32bit_format(DataFormat f) {
 }
 
 /**
+ * (internal) True iff `f` is a block-float register format (Bfp8/Bfp4/Bfp2, a- and b-exponent families).
+ * The BH compute datapath only handles FULL-height (32-row) block-float tiles; partial-height block floats
+ * are rejected at the copy/pack surfaces (silent-garbage otherwise). Typed sibling of the IS_BFP_FORMAT macro.
+ */
+constexpr bool is_block_float_format(DataFormat f) {
+    return f == DataFormat::Bfp8 || f == DataFormat::Bfp8_b || f == DataFormat::Bfp4 || f == DataFormat::Bfp4_b ||
+           f == DataFormat::Bfp2 || f == DataFormat::Bfp2_b;
+}
+
+/**
+ * (internal) True iff the tile has fewer than 32 rows (partial tile height). For block-float formats a
+ * partial-height tile does not flow correctly through the BH compute datapath; use with is_block_float_format
+ * to reject that combination at compile time.
+ */
+constexpr bool is_partial_height(TensorShape s) { return s.total_row_dim() < TILE_R_DIM; }
+
+/**
  * (internal) True iff two operands carry the same tile geometry (a two-input op requires matching shapes).
  * Used by the binary-op static_asserts (PART D). `a`, `b`: the two tile geometries to compare.
  */

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/internal/llk_descriptor.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/internal/llk_descriptor.h
@@ -35,16 +35,20 @@ struct LLKMemDescriptor {
     TensorShape shape;  // tile geometry; derive num_faces / tile dims via TensorShape helpers
 };
 
+// Round up to the 16-byte L1 word granularity (matches tt_metal's L1_ALIGNMENT on Blackhole).
+constexpr std::uint32_t round_up_l1_words(std::uint32_t bytes) { return (bytes + 15u) >> 4; }
+
 // clang-format off
 /**
  * (internal) Per-tile L1 stride in 16-byte words, for absolute (out-of-order) tile addressing (base +
  * t*stride). The id-free stand-in for the CB's fifo_page_size, which the shipping factories set to one tile's
- * size.
- *   * Block floats (Bfp8/Bfp4/Bfp2): a tile carries a shared-exponent section that SCALE_DATUM_SIZE omits (and
- *     it miscounts the sub-byte mantissa), so use GET_L1_HEADERLESS_TILE_SIZE -- exp section included, matching
- *     tile_size(fmt) / llk_pack_fast_tilize. Assumes a full 32x32 tile (partial BFP tiles are out of scope).
- *   * Linear formats (Float32/Float16/int): keep the geometry-exact datum-count size so tiny tiles
- *     (face_r_dim / num_faces below full) stride correctly.
+ * size. Geometry-exact for BOTH branches, so partial / tiny tiles stride correctly:
+ *   * Block floats (Bfp8/Bfp4/Bfp2): a tile is [packed mantissas | shared-exponent section]. This mirrors
+ *     tt_metal Tile::get_tile_size (impl/data_format/tile.cpp) scaled by the real geometry: mantissa =
+ *     total_tensor_size() at the format's storage width (Bfp8 1 B/datum, Bfp4 1/2, Bfp2 1/4), exp section =
+ *     round_up(face_r_dim * total_num_faces, 16). GET_L1_HEADERLESS_TILE_SIZE hard-codes the full-32x32 value
+ *     and is WRONG for a partial BFP tile (fewer face rows / faces), so we compute the size here instead.
+ *   * Linear formats (Float32/Float16/int): the geometry-exact datum-count size (SCALE_DATUM_SIZE >> 4).
  *
  * | Param Type | Name   | Description                       | Type        | Valid Range | Required |
  * |------------|--------|-----------------------------------|-------------|-------------|----------|
@@ -55,8 +59,24 @@ struct LLKMemDescriptor {
 constexpr std::uint32_t tile_stride_words(DataFormat format, TensorShape shape) {
     // The size macros are the legacy numeric-format path; convert the typed format once here.
     const std::uint32_t fmt = static_cast<std::uint32_t>(format);
-    return IS_BFP_FORMAT(fmt) ? GET_L1_HEADERLESS_TILE_SIZE(fmt)
-                              : (SCALE_DATUM_SIZE(fmt, shape.total_tensor_size()) >> 4);
+    if (!IS_BFP_FORMAT(fmt)) {
+        return SCALE_DATUM_SIZE(fmt, shape.total_tensor_size()) >> 4;
+    }
+    // Block-float tile size, generalized from Tile::get_tile_size to the tile geometry (partial BFP support).
+    const std::uint32_t datums = shape.total_tensor_size();
+    // Shared-exponent section: one exponent byte per face row across all faces, padded to the L1 word.
+    // (== tt_metal round_up(face_shape[0] * num_faces, L1_ALIGNMENT).)
+    const std::uint32_t exp_bytes =
+        (static_cast<std::uint32_t>(shape.face_r_dim) * shape.total_num_faces() + 15u) & ~15u;
+    std::uint32_t mantissa_bytes = datums;  // Bfp8/Bfp8_b: 1 byte per datum
+    switch (masked_data_format(fmt)) {
+        case to_underlying(DataFormat::Bfp4):
+        case to_underlying(DataFormat::Bfp4_b): mantissa_bytes = datums >> 1; break;  // 4-bit mantissas
+        case to_underlying(DataFormat::Bfp2):
+        case to_underlying(DataFormat::Bfp2_b): mantissa_bytes = datums >> 2; break;  // 2-bit mantissas
+        default: break;                                                               // Bfp8 / Bfp8_b
+    }
+    return round_up_l1_words(mantissa_bytes + exp_bytes);
 }
 
 // NOTE (matmul partial_face): the id-free matmul derives partial_face inline at its two call sites, NOT via a

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/llk_operand.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/llk_operand.h
@@ -59,20 +59,8 @@ struct LLKOperand {
 };
 
 namespace detail {
-// clang-format off
-/**
- * (detail) Absolute per-tile L1 base for operand `op` at `tile_index` (16B words). The per-tile stride folds to
- * a compile-time constant from the operand geometry via tile_stride_words == one tile's L1 size (geometry-exact
- * for linear formats, exp section included for block floats). Shared by every block/absolute-addressing op
- * (copy/eltwise_binary/reduce/...), so tile stride arithmetic lives in ONE place.
- *
- * | Param Type | Name         | Description                            | Type                   | Valid Range | Required |
- * |------------|--------------|----------------------------------------|------------------------|-------------|----------|
- * | Template   | Format/Shape | Operand L1 format + geometry (deduced) | DataFormat/TensorShape | N/A         | True     |
- * | Function   | op           | The operand (base address + geometry)  | LLKOperand             | N/A         | True     |
- * | Function   | tile_index   | Tile index within the operand          | uint32_t               | N/A         | True     |
- */
-// clang-format on
+// Absolute per-tile L1 base for operand `op` at `tile_index` (16B words). Stride folds to a compile-time
+// constant via tile_stride_words (one tile's L1 size). Shared by every block/absolute-addressing op.
 template <DataFormat Format, TensorShape Shape>
 ALWI std::uint32_t tile_address(LLKOperand<Format, Shape> op, std::uint32_t tile_index) {
     constexpr std::uint32_t stride = tile_stride_words(Format, Shape);

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/llk_operand.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/llk_operand.h
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "api/compute/common_globals.h"                            // DataFormat enum
+#include "api/compute/experimental/2_0/internal/llk_descriptor.h"  // LLKMemDescriptor (the ::descriptor NTTP)
+
+// =====================================================================================================
+// The ONLY public, id-free type kernel authors use: LLKOperand<Format, Shape>. It bundles the two halves of
+// "an L1 tile" split by compile-time vs runtime:
+//   * Format + Shape are NON-TYPE TEMPLATE PARAMETERS (-ftt-nttp) -- the compile-time "what". They build
+//     ::descriptor (an LLKMemDescriptor), forwarded to the LLK as an NTTP so the per-format switches /
+//     register writes / asserts fold and DCE away.
+//   * l1_address is the ONLY runtime member -- the "where". A runtime value cannot be an NTTP, so the split
+//     lives INSIDE the type (NTTP vs member).
+// Bundling keeps an address welded to its own descriptor (a wrong pairing is unrepresentable), and lets an op
+// derive per-tile addresses internally from the compile-time geometry (see tilize_block + tile_stride_words).
+//
+// The source (CB / DataflowBuffer / Scratchpad) is NOT known here. Source -> operand is done at the call site
+// via the test-common CB helpers (cb_operand_helpers.h) or a future accessor's translator.
+// =====================================================================================================
+
+namespace ckernel {
+namespace experimental {
+
+// clang-format off
+/**
+ * The public id-free operand every 2.0 compute op consumes. Bundles the compile-time "what" (Format + Shape as
+ * NTTPs) with the single runtime "where" (l1_address). ::descriptor packs Format+Shape into the LLKMemDescriptor
+ * the LLK layer takes as an NTTP. Construct at the call site from an address (e.g. cb_read_address(cb, tile)).
+ *
+ * | Param Type | Name   | Description                               | Type        | Valid Range | Required |
+ * |------------|--------|-------------------------------------------|-------------|-------------|----------|
+ * | Template   | Format | Buffer L1 data format                     | DataFormat  | N/A         | True     |
+ * | Template   | Shape  | Tile geometry                             | TensorShape | N/A         | True     |
+ * | Function   | addr   | Absolute L1 tile base address (16B words) | uint32_t    | N/A         | True     |
+ */
+// clang-format on
+template <DataFormat Format, TensorShape Shape>
+struct LLKOperand {
+    std::uint32_t l1_address;  // runtime "where"; Format/Shape are the compile-time "what"
+    constexpr explicit LLKOperand(std::uint32_t addr) : l1_address(addr) {}
+
+    // The descriptor the LLK APIs accept (buffer L1 format + geometry).
+    static constexpr LLKMemDescriptor descriptor = LLKMemDescriptor{Format, Shape};
+};
+
+namespace detail {
+// clang-format off
+/**
+ * (detail) Absolute per-tile L1 base for operand `op` at `tile_index` (16B words). The per-tile stride folds to
+ * a compile-time constant from the operand geometry via tile_stride_words == one tile's L1 size (geometry-exact
+ * for linear formats, exp section included for block floats). Shared by every block/absolute-addressing op
+ * (copy/eltwise_binary/reduce/...), so tile stride arithmetic lives in ONE place.
+ *
+ * | Param Type | Name         | Description                            | Type                   | Valid Range | Required |
+ * |------------|--------------|----------------------------------------|------------------------|-------------|----------|
+ * | Template   | Format/Shape | Operand L1 format + geometry (deduced) | DataFormat/TensorShape | N/A         | True     |
+ * | Function   | op           | The operand (base address + geometry)  | LLKOperand             | N/A         | True     |
+ * | Function   | tile_index   | Tile index within the operand          | uint32_t               | N/A         | True     |
+ */
+// clang-format on
+template <DataFormat Format, TensorShape Shape>
+ALWI std::uint32_t tile_address(LLKOperand<Format, Shape> op, std::uint32_t tile_index) {
+    constexpr std::uint32_t stride = tile_stride_words(Format, Shape);
+    return op.l1_address + tile_index * stride;
+}
+}  // namespace detail
+
+}  // namespace experimental
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/llk_operand.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/llk_operand.h
@@ -18,10 +18,12 @@
 //   * l1_address is the ONLY runtime member -- the "where". A runtime value cannot be an NTTP, so the split
 //     lives INSIDE the type (NTTP vs member).
 // Bundling keeps an address welded to its own descriptor (a wrong pairing is unrepresentable), and lets an op
-// derive per-tile addresses internally from the compile-time geometry (see tilize_block + tile_stride_words).
+// derive per-tile addresses internally from the compile-time geometry (see tile_stride_words).
 //
-// The source (CB / DataflowBuffer / Scratchpad) is NOT known here. Source -> operand is done at the call site
-// via the test-common CB helpers (cb_operand_helpers.h) or a future accessor's translator.
+// Namespace split: LLKOperand lives in ckernel::experimental (public); ckernel::experimental::detail holds
+// internal-only helpers built on it (tile_address). The source (CB / DataflowBuffer / Scratchpad) is NOT
+// known here -- source -> operand is done at the call site via the test-common CB helpers
+// (cb_operand_helpers.h) or a future accessor's translator.
 // =====================================================================================================
 
 namespace ckernel {

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/llk_operand.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/llk_operand.h
@@ -5,8 +5,7 @@
 #pragma once
 
 // The experimental 2.0 compute API is Blackhole-only this phase. llk_operand.h is included by every 2.0 op
-// header, so guarding it here hard-fails the compile of any 2.0 kernel built for another arch (rather than
-// silently compiling an empty op body from the per-file `#ifdef ARCH_BLACKHOLE` guards).
+// header, so guarding it here hard-fails the compile of any 2.0 kernel built for another arch.
 #ifndef ARCH_BLACKHOLE
 #error "The experimental 2.0 compute API (LLKOperand) is Blackhole-only; build with ARCH_BLACKHOLE defined."
 #endif

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/llk_operand.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/llk_operand.h
@@ -4,6 +4,13 @@
 
 #pragma once
 
+// The experimental 2.0 compute API is Blackhole-only this phase. llk_operand.h is included by every 2.0 op
+// header, so guarding it here hard-fails the compile of any 2.0 kernel built for another arch (rather than
+// silently compiling an empty op body from the per-file `#ifdef ARCH_BLACKHOLE` guards).
+#ifndef ARCH_BLACKHOLE
+#error "The experimental 2.0 compute API (LLKOperand) is Blackhole-only; build with ARCH_BLACKHOLE defined."
+#endif
+
 #include <cstdint>
 
 #include "api/compute/common_globals.h"                            // DataFormat enum

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/matmul.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/matmul.h
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/common_globals.h"
+#include "api/compute/experimental/2_0/llk_operand.h"
+
+#ifdef TRISC_MATH
+#include "experimental/2_0/llk_math_matmul.h"
+#endif
+
+#ifdef TRISC_UNPACK
+#include "experimental/2_0/llk_unpack_AB_matmul.h"
+#endif
+
+#ifndef MM_THROTTLE
+#define MM_THROTTLE 0
+#endif
+
+namespace ckernel {
+namespace experimental {
+
+#ifdef ARCH_BLACKHOLE
+
+// Id-free (2.0) matmul: single-tile (matmul_init + matmul_tiles) and block (matmul_block_init + matmul_block).
+// Takes one LLKOperand per input; in0 -> SrcB and in1 -> SrcA (the matmul role swap). The role swap for the
+// register formats is applied by compute_kernel_hw_startup<SrcOrder::Reverse>(in0, in1, out) in the kernel;
+// matmul is FORMAT-FREE at the op level, so these ops forward only geometry (via the descriptors) + the two
+// per-tile L1 addresses (+ the runtime block dims for the block form). Packing is separate
+// (experimental::pack_tile). Dynamic (FW-controlled) throttle is NOT part of this surface: the block execute
+// reuses the plain (fixed MM_THROTTLE) legacy execute -- throttle only inserts dead math cycles, so output is
+// bit-identical to the legacy dynamic-throttle path.
+
+// clang-format off
+/**
+ * Short init for matmul_tiles. Configures the unpacker + math engine for matmul. compute_kernel_hw_startup
+ * <SrcOrder::Reverse>(in0, in1, out) must already have run. in0 -> SrcB, in1 -> SrcA.
+ *
+ * | Function | in0 / in1 | Input operands (in0 -> SrcB, in1 -> SrcA) | LLKOperand | | True |
+ * | Function | transpose | Transpose flag for tiles in B             | uint32_t   | | False |
+ */
+// clang-format on
+template <DataFormat F0, TensorShape S0, DataFormat F1, TensorShape S1>
+ALWI void matmul_init(LLKOperand<F0, S0> /*in0*/, LLKOperand<F1, S1> /*in1*/, std::uint32_t transpose = 0) {
+    static_assert(is_legal_tile_shape(S0), "matmul_init: illegal tile shape for in0.");
+    static_assert(is_legal_tile_shape(S1), "matmul_init: illegal tile shape for in1.");
+    MATH((llk_math_matmul_init<
+          LLKOperand<F0, S0>::descriptor,
+          LLKOperand<F1, S1>::descriptor,
+          MATH_FIDELITY,
+          MM_THROTTLE>(transpose)));
+    UNPACK((llk_unpack_AB_matmul_init<LLKOperand<F0, S0>::descriptor, LLKOperand<F1, S1>::descriptor>(transpose)));
+}
+
+// clang-format off
+/**
+ * Tile matmul C = A*B, accumulating into DST[idst]. Pair with matmul_init. DST must be acquired. in0_tile_index
+ * / in1_tile_index index within in0 / in1. Geometry (for MATH partial_face + unpack) comes from the operands.
+ *
+ * | Function | in0 / in1                     | Input operands                   | LLKOperand | | True |
+ * | Function | in0_tile_index / in1_tile_index | Tile indices within in0 / in1  | uint32_t   | | True |
+ * | Function | idst                          | DST register index for result C  | uint32_t   | | True |
+ */
+// clang-format on
+template <DataFormat F0, TensorShape S0, DataFormat F1, TensorShape S1>
+ALWI void matmul_tiles(
+    LLKOperand<F0, S0> in0,
+    LLKOperand<F1, S1> in1,
+    std::uint32_t in0_tile_index,
+    std::uint32_t in1_tile_index,
+    std::uint32_t idst) {
+    static_assert(is_legal_tile_shape(S0), "matmul_tiles: illegal tile shape for in0.");
+    static_assert(is_legal_tile_shape(S1), "matmul_tiles: illegal tile shape for in1.");
+    UNPACK((llk_unpack_AB_matmul<LLKOperand<F0, S0>::descriptor, LLKOperand<F1, S1>::descriptor>(
+        in0.l1_address, in1.l1_address, in0_tile_index, in1_tile_index)));
+    // Matmul math execute takes no operand id -> reuse the legacy (format-free) execute directly.
+    MATH((llk_math_matmul<MATH_FIDELITY, MM_THROTTLE>(idst)));
+}
+
+// clang-format off
+/**
+ * Short init for matmul_block. Configures the unpacker + math engine for block matmul. Pair with matmul_block.
+ * compute_kernel_hw_startup<SrcOrder::Reverse>(in0, in1, out) must already have run. in0 -> SrcB, in1 -> SrcA.
+ * ct_dim / rt_dim / kt_dim are the output-block geometry (see matmul_block) and are RUNTIME args; the register
+ * formats + tile geometry are FORMAT-FREE and come from the two operand descriptors.
+ *
+ * | Function | in0 / in1 | Input operands (in0 -> SrcB, in1 -> SrcA) | LLKOperand | | True |
+ * | Function | transpose | Transpose flag for tiles in B             | uint32_t   | | False |
+ * | Function | ct_dim    | Output block column dim (== B col dim)    | uint32_t   | | False |
+ * | Function | rt_dim    | Output block row dim (== A row dim)       | uint32_t   | | False |
+ * | Function | kt_dim    | Inner dim (== A col dim)                  | uint32_t   | | False |
+ */
+// clang-format on
+template <DataFormat F0, TensorShape S0, DataFormat F1, TensorShape S1>
+ALWI void matmul_block_init(
+    LLKOperand<F0, S0> /*in0*/,
+    LLKOperand<F1, S1> /*in1*/,
+    std::uint32_t transpose = 0,
+    std::uint32_t ct_dim = 1,
+    std::uint32_t rt_dim = 1,
+    std::uint32_t kt_dim = 1) {
+    static_assert(is_legal_tile_shape(S0), "matmul_block_init: illegal tile shape for in0.");
+    static_assert(is_legal_tile_shape(S1), "matmul_block_init: illegal tile shape for in1.");
+    MATH((llk_math_matmul_init<
+          LLKOperand<F0, S0>::descriptor,
+          LLKOperand<F1, S1>::descriptor,
+          MATH_FIDELITY,
+          MM_THROTTLE>(transpose, ct_dim, rt_dim)));
+    UNPACK((llk_unpack_AB_matmul_init<LLKOperand<F0, S0>::descriptor, LLKOperand<F1, S1>::descriptor>(
+        transpose, ct_dim, rt_dim, kt_dim)));
+}
+
+// clang-format off
+/**
+ * Block matmul C = A*B, accumulating into DST starting at idst. Pair with matmul_block_init. DST must be
+ * acquired. A block is a rectangle of tiles: A is rt_dim x kt_dim, B is kt_dim x ct_dim, and the output C is
+ * rt_dim x ct_dim tiles -- i.e. ct_dim*rt_dim output tiles produced in one call (kt_dim tiles along the shared
+ * inner dim). The output must fit in DST. in0_tile_index / in1_tile_index are the base tile within in0 / in1;
+ * the block strides across the operands from there. Geometry (partial_face + per-tile stride) comes from the
+ * operand descriptors. transpose is programmed at matmul_block_init; it is accepted here for signature parity
+ * with the legacy matmul_block but does not re-program the MOP.
+ *
+ * | Function | in0 / in1                       | Input operands (in0 -> SrcB, in1 -> SrcA)    | LLKOperand | | True |
+ * | Function | in0_tile_index / in1_tile_index | Base tile indices within in0 / in1           | uint32_t   | | True |
+ * | Function | idst                            | DST register index for the first result tile | uint32_t   | | True |
+ * | Function | transpose                       | Transpose flag for tiles in B (see above)    | uint32_t   | | True |
+ * | Function | ct_dim                          | Output block column dim (== B col dim)       | uint32_t   | | True |
+ * | Function | rt_dim                          | Output block row dim (== A row dim)          | uint32_t   | | True |
+ * | Function | kt_dim                          | Inner dim (== A col dim)                     | uint32_t   | | True |
+ */
+// clang-format on
+template <DataFormat F0, TensorShape S0, DataFormat F1, TensorShape S1>
+ALWI void matmul_block(
+    LLKOperand<F0, S0> in0,
+    LLKOperand<F1, S1> in1,
+    std::uint32_t in0_tile_index,
+    std::uint32_t in1_tile_index,
+    std::uint32_t idst,
+    const std::uint32_t /*transpose*/,
+    std::uint32_t ct_dim,
+    std::uint32_t rt_dim,
+    std::uint32_t kt_dim) {
+    static_assert(is_legal_tile_shape(S0), "matmul_block: illegal tile shape for in0.");
+    static_assert(is_legal_tile_shape(S1), "matmul_block: illegal tile shape for in1.");
+    UNPACK((llk_unpack_AB_matmul<LLKOperand<F0, S0>::descriptor, LLKOperand<F1, S1>::descriptor>(
+        in0.l1_address, in1.l1_address, in0_tile_index, in1_tile_index, ct_dim, rt_dim, kt_dim)));
+    // Matmul math execute takes no operand id -> reuse the legacy (format-free) block execute directly.
+    // Plain (fixed MM_THROTTLE) execute, no dynamic throttle: throttle only inserts dead math cycles, so the
+    // arithmetic result is bit-identical to the legacy dynamic-throttle path (mirrors matmul_tiles above).
+    MATH((llk_math_matmul<MATH_FIDELITY, MM_THROTTLE>(idst, ct_dim, rt_dim)));
+}
+
+#endif  // ARCH_BLACKHOLE
+
+}  // namespace experimental
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/matmul.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/matmul.h
@@ -26,13 +26,10 @@ namespace experimental {
 #ifdef ARCH_BLACKHOLE
 
 // Id-free (2.0) matmul: single-tile (matmul_init + matmul_tiles) and block (matmul_block_init + matmul_block).
-// Takes one LLKOperand per input; in0 -> SrcB and in1 -> SrcA (the matmul role swap). The role swap for the
-// register formats is applied by compute_kernel_hw_startup<SrcOrder::Reverse>(in0, in1, out) in the kernel;
-// matmul is FORMAT-FREE at the op level, so these ops forward only geometry (via the descriptors) + the two
-// per-tile L1 addresses (+ the runtime block dims for the block form). Packing is separate
-// (experimental::pack_tile). Dynamic (FW-controlled) throttle is NOT part of this surface: the block execute
-// reuses the plain (fixed MM_THROTTLE) legacy execute -- throttle only inserts dead math cycles, so output is
-// bit-identical to the legacy dynamic-throttle path.
+// Two LLKOperands (in0, in1); in0 -> SrcB, in1 -> SrcA (matmul role swap), applied via
+// compute_kernel_hw_startup<SrcOrder::Reverse>(in0, in1, out). Format-free at the op level -- these ops forward
+// only geometry (via the descriptors) and per-tile L1 addresses; packing is separate (experimental::pack_tile).
+// Throttle is fixed (MM_THROTTLE); dynamic throttle is not part of this surface.
 
 // clang-format off
 /**
@@ -76,7 +73,7 @@ ALWI void matmul_tiles(
     static_assert(is_legal_tile_shape(S1), "matmul_tiles: illegal tile shape for in1.");
     UNPACK((llk_unpack_AB_matmul<LLKOperand<F0, S0>::descriptor, LLKOperand<F1, S1>::descriptor>(
         in0.l1_address, in1.l1_address, in0_tile_index, in1_tile_index)));
-    // Matmul math execute takes no operand id -> reuse the legacy (format-free) execute directly.
+    // Math execute takes no operand id; format-free.
     MATH((llk_math_matmul<MATH_FIDELITY, MM_THROTTLE>(idst)));
 }
 
@@ -144,9 +141,7 @@ ALWI void matmul_block(
     static_assert(is_legal_tile_shape(S1), "matmul_block: illegal tile shape for in1.");
     UNPACK((llk_unpack_AB_matmul<LLKOperand<F0, S0>::descriptor, LLKOperand<F1, S1>::descriptor>(
         in0.l1_address, in1.l1_address, in0_tile_index, in1_tile_index, ct_dim, rt_dim, kt_dim)));
-    // Matmul math execute takes no operand id -> reuse the legacy (format-free) block execute directly.
-    // Plain (fixed MM_THROTTLE) execute, no dynamic throttle: throttle only inserts dead math cycles, so the
-    // arithmetic result is bit-identical to the legacy dynamic-throttle path (mirrors matmul_tiles above).
+    // Block execute takes no operand id; format-free, fixed MM_THROTTLE (no dynamic throttle).
     MATH((llk_math_matmul<MATH_FIDELITY, MM_THROTTLE>(idst, ct_dim, rt_dim)));
 }
 

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/matmul.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/matmul.h
@@ -120,13 +120,11 @@ ALWI void matmul_block_init(
  * rt_dim x ct_dim tiles -- i.e. ct_dim*rt_dim output tiles produced in one call (kt_dim tiles along the shared
  * inner dim). The output must fit in DST. in0_tile_index / in1_tile_index are the base tile within in0 / in1;
  * the block strides across the operands from there. Geometry (partial_face + per-tile stride) comes from the
- * operand descriptors. transpose is programmed at matmul_block_init; it is accepted here for signature parity
- * with the legacy matmul_block but does not re-program the MOP.
+ * operand descriptors. transpose is programmed at matmul_block_init; the execute takes no transpose arg.
  *
  * | Function | in0 / in1                       | Input operands (in0 -> SrcB, in1 -> SrcA)    | LLKOperand | | True |
  * | Function | in0_tile_index / in1_tile_index | Base tile indices within in0 / in1           | uint32_t   | | True |
  * | Function | idst                            | DST register index for the first result tile | uint32_t   | | True |
- * | Function | transpose                       | Transpose flag for tiles in B (see above)    | uint32_t   | | True |
  * | Function | ct_dim                          | Output block column dim (== B col dim)       | uint32_t   | | True |
  * | Function | rt_dim                          | Output block row dim (== A row dim)          | uint32_t   | | True |
  * | Function | kt_dim                          | Inner dim (== A col dim)                     | uint32_t   | | True |
@@ -139,7 +137,6 @@ ALWI void matmul_block(
     std::uint32_t in0_tile_index,
     std::uint32_t in1_tile_index,
     std::uint32_t idst,
-    const std::uint32_t /*transpose*/,
     std::uint32_t ct_dim,
     std::uint32_t rt_dim,
     std::uint32_t kt_dim) {

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/matmul.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/matmul.h
@@ -23,8 +23,6 @@
 namespace ckernel {
 namespace experimental {
 
-#ifdef ARCH_BLACKHOLE
-
 // Id-free (2.0) matmul: single-tile (matmul_init + matmul_tiles) and block (matmul_block_init + matmul_block).
 // Two LLKOperands (in0, in1); in0 -> SrcB, in1 -> SrcA (matmul role swap), applied via
 // compute_kernel_hw_startup<SrcOrder::Reverse>(in0, in1, out). Format-free at the op level -- these ops forward
@@ -144,8 +142,6 @@ ALWI void matmul_block(
     // Block execute takes no operand id; format-free, fixed MM_THROTTLE (no dynamic throttle).
     MATH((llk_math_matmul<MATH_FIDELITY, MM_THROTTLE>(idst, ct_dim, rt_dim)));
 }
-
-#endif  // ARCH_BLACKHOLE
 
 }  // namespace experimental
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/pack.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/pack.h
@@ -22,61 +22,57 @@ namespace experimental {
  *
  * Sub-32-row (partial-height) block-float tiles are not supported (compile-time rejected).
  *
- * | Template | Format | Output buffer L1 data format (deduced from LLKOperand) | DataFormat  |  | True |
- * | Template | Shape  | Output tile geometry (deduced from LLKOperand)         | TensorShape |  | True |
+ * | Template | is_fp32_dest_acc_en | fp32 dest-accumulate mode                         | bool        |  | False |
+ * | Template | Format              | Output buffer L1 data format (deduced from LLKOperand) | DataFormat  |  | True |
+ * | Template | Shape               | Output tile geometry (deduced from LLKOperand)         | TensorShape |  | True |
  */
 // clang-format on
-template <DataFormat Format, TensorShape Shape>
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE, DataFormat Format, TensorShape Shape>
 ALWI void pack_init(LLKOperand<Format, Shape> /*out*/) {
     static_assert(is_legal_tile_shape(Shape), "pack_init: illegal output tile shape.");
     static_assert(
         !(is_block_float_format(Format) && is_partial_height(Shape)),
         "pack: sub-32-row (partial-height) block-float tiles are not supported on the BH compute datapath; "
         "use a full 32-row tile.");
-    PACK((llk_pack_init<LLKOperand<Format, Shape>::descriptor, DST_ACCUM_MODE>()));
+    PACK((llk_pack_init<LLKOperand<Format, Shape>::descriptor, is_fp32_dest_acc_en>()));
 }
 
 // clang-format off
 /**
- * Id-free pack. Copies one tile from DST to the absolute L1 address in the output LLKOperand. Formats and
- * geometry were programmed at pack_init; only the runtime write address (out.l1_address) is needed. Blackhole
- * only.
+ * Id-free pack. Copies one tile from DST to L1. `out.l1_address` is the buffer base; the pack address is
+ * `tile_address(out, itile)`. Formats and geometry were programmed at pack_init. Blackhole only.
  *
  * Uses out-of-order (absolute) addressing and does not auto-advance an internal fifo pointer like legacy
- * pack_tile does -- the caller must supply the correct per-tile L1 address on every call. Sub-32-row
- * (partial-height) block-float tiles are not supported (compile-time rejected).
+ * pack_tile does. Sub-32-row (partial-height) block-float tiles are not supported (compile-time rejected).
  *
  * | Template | is_fp32_dest_acc_en | fp32 dest-accumulate mode                          | bool        |         | False |
  * | Template | Format    | Output buffer L1 data format (deduced from LLKOperand) | DataFormat  |         | True |
  * | Template | Shape     | Output tile geometry (deduced from LLKOperand)         | TensorShape |         | True |
- * | Function | out       | The output L1 operand (format+shape+write address)    | LLKOperand  |         | True |
+ * | Function | out       | The output L1 operand (format+shape+buffer base)      | LLKOperand  |         | True |
+ * | Function | itile     | Index of the output tile within `out`, relative to its base | uint32_t | N/A   | True |
  * | Function | ifrom_dst | Tile index in the DST register                         | uint32_t   | 0 to 15 | True |
  */
 // clang-format on
 template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE, DataFormat Format, TensorShape Shape>
-ALWI void pack_tile(LLKOperand<Format, Shape> out, std::uint32_t ifrom_dst) {
+ALWI void pack_tile(LLKOperand<Format, Shape> out, std::uint32_t itile, std::uint32_t ifrom_dst) {
     static_assert(is_legal_tile_shape(Shape), "pack_tile: illegal output tile shape.");
     static_assert(
         !(is_block_float_format(Format) && is_partial_height(Shape)),
         "pack: sub-32-row (partial-height) block-float tiles are not supported on the BH compute datapath; "
         "use a full 32-row tile.");
-    // out_of_order_output=true: pack to the absolute address in the LLKOperand (no fifo_wr_tile_ptr bump).
+    // out_of_order_output=true: pack to the absolute address (no fifo_wr_tile_ptr bump).
     PACK((llk_pack<
           LLKOperand<Format, Shape>::descriptor,
           is_fp32_dest_acc_en,
           /*out_of_order_output=*/true,
-          PackMode::Default>(ifrom_dst, out.l1_address)));
+          PackMode::Default>(ifrom_dst, detail::tile_address(out, itile))));
 }
 
 // clang-format off
 /**
- * Id-free block pack. Packs `ntiles` consecutive tiles from DST to consecutive L1 addresses in the output
+ * Id-free block pack. Packs `ntiles` consecutive tiles from DST to consecutive L1 tiles in the output
  * operand (block/loop form of pack_tile). Tile i is read from DST[ifrom_dst + i] and written to
- * out.l1_address + (start_out_tile + i) * <one-tile stride>, derived at compile time from the output
- * descriptor's format/geometry. Blackhole only.
- *
- * Uses out-of-order addressing per tile (see pack_tile); with start_out_tile = 0 this reproduces the same L1
- * layout a legacy in-order pack_tile loop would write. Sub-32-row (partial-height) block-float tiles are not
+ * output tile (start_out_tile + i). Blackhole only. Sub-32-row (partial-height) block-float tiles are not
  * supported (compile-time rejected).
  *
  * | Param Type | Name          | Description                                                | Type        | Valid Range                          | Required |
@@ -99,11 +95,7 @@ ALWI void pack_block(
         "pack: sub-32-row (partial-height) block-float tiles are not supported on the BH compute datapath; "
         "use a full 32-row tile.");
     for (std::uint32_t i = 0; i < ntiles; ++i) {
-        // pack_tile is itself PACK()-wrapped, so the engine calls stay on the packer thread. Per-tile output
-        // slot via the shared tile_address helper (stride folds to a compile-time constant; matches the CB
-        // one-tile page).
-        experimental::pack_tile<is_fp32_dest_acc_en>(
-            LLKOperand<Format, Shape>(detail::tile_address(out, start_out_tile + i)), ifrom_dst + i);
+        experimental::pack_tile<is_fp32_dest_acc_en>(out, start_out_tile + i, ifrom_dst + i);
     }
 }
 

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/pack.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/pack.h
@@ -30,6 +30,10 @@ namespace experimental {
 template <DataFormat Format, TensorShape Shape>
 ALWI void pack_init(LLKOperand<Format, Shape> /*out*/) {
     static_assert(is_legal_tile_shape(Shape), "pack_init: illegal output tile shape.");
+    static_assert(
+        !(is_block_float_format(Format) && is_partial_height(Shape)),
+        "pack: sub-32-row (partial-height) block-float tiles are not supported on the BH compute datapath; "
+        "use a full 32-row tile.");
     PACK((llk_pack_init<LLKOperand<Format, Shape>::descriptor, DST_ACCUM_MODE>()));
 }
 
@@ -55,6 +59,10 @@ ALWI void pack_init(LLKOperand<Format, Shape> /*out*/) {
 template <DataFormat Format, TensorShape Shape>
 ALWI void pack_tile(LLKOperand<Format, Shape> out, std::uint32_t ifrom_dst) {
     static_assert(is_legal_tile_shape(Shape), "pack_tile: illegal output tile shape.");
+    static_assert(
+        !(is_block_float_format(Format) && is_partial_height(Shape)),
+        "pack: sub-32-row (partial-height) block-float tiles are not supported on the BH compute datapath; "
+        "use a full 32-row tile.");
     // out_of_order_output=true: pack to the absolute address in the LLKOperand (no fifo_wr_tile_ptr bump).
     PACK((llk_pack<
           LLKOperand<Format, Shape>::descriptor,
@@ -88,6 +96,10 @@ template <DataFormat Format, TensorShape Shape>
 ALWI void pack_block(
     LLKOperand<Format, Shape> out, std::uint32_t ifrom_dst, std::uint32_t ntiles, std::uint32_t start_out_tile = 0) {
     static_assert(is_legal_tile_shape(Shape), "pack_block: illegal output tile shape.");
+    static_assert(
+        !(is_block_float_format(Format) && is_partial_height(Shape)),
+        "pack: sub-32-row (partial-height) block-float tiles are not supported on the BH compute datapath; "
+        "use a full 32-row tile.");
     for (std::uint32_t i = 0; i < ntiles; ++i) {
         // pack_tile is itself PACK()-wrapped, so the engine calls stay on the packer thread. Per-tile output
         // slot via the shared tile_address helper (stride folds to a compile-time constant; matches the CB
@@ -122,6 +134,10 @@ ALWI void pack_block(
 template <DataFormat Format, TensorShape Shape>
 ALWI void pack_rows(LLKOperand<Format, Shape> out, std::uint32_t idst) {
     static_assert(is_legal_tile_shape(Shape), "pack_rows: illegal output tile shape.");
+    static_assert(
+        !(is_block_float_format(Format) && is_partial_height(Shape)),
+        "pack: sub-32-row (partial-height) block-float tiles are not supported on the BH compute datapath; "
+        "use a full 32-row tile.");
     PACK((llk_pack_rows<LLKOperand<Format, Shape>::descriptor>(idst, out.l1_address)));
 }
 
@@ -146,6 +162,10 @@ ALWI void pack_rows(LLKOperand<Format, Shape> out, std::uint32_t idst) {
 template <DataFormat Format, TensorShape Shape>
 ALWI void pack_rows_init(LLKOperand<Format, Shape> /*out*/, std::uint32_t num_rows) {
     static_assert(is_legal_tile_shape(Shape), "pack_rows_init: illegal output tile shape.");
+    static_assert(
+        !(is_block_float_format(Format) && is_partial_height(Shape)),
+        "pack: sub-32-row (partial-height) block-float tiles are not supported on the BH compute datapath; "
+        "use a full 32-row tile.");
     PACK((llk_pack_rows_init(num_rows)));
 }
 
@@ -168,6 +188,10 @@ ALWI void pack_rows_init(LLKOperand<Format, Shape> /*out*/, std::uint32_t num_ro
 template <DataFormat Format, TensorShape Shape>
 ALWI void pack_rows_uninit(LLKOperand<Format, Shape> /*out*/) {
     static_assert(is_legal_tile_shape(Shape), "pack_rows_uninit: illegal output tile shape.");
+    static_assert(
+        !(is_block_float_format(Format) && is_partial_height(Shape)),
+        "pack: sub-32-row (partial-height) block-float tiles are not supported on the BH compute datapath; "
+        "use a full 32-row tile.");
     PACK((llk_pack_rows_uninit()));
 }
 

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/pack.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/pack.h
@@ -15,8 +15,6 @@
 namespace ckernel {
 namespace experimental {
 
-#ifdef ARCH_BLACKHOLE
-
 // clang-format off
 /**
  * Id-free pack init. Takes an output LLKOperand (L1 format + geometry as NTTPs); the DST register format is
@@ -190,8 +188,6 @@ ALWI void pack_rows_uninit(LLKOperand<Format, Shape> /*out*/) {
         "use a full 32-row tile.");
     PACK((llk_pack_rows_uninit()));
 }
-
-#endif  // ARCH_BLACKHOLE
 
 }  // namespace experimental
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/pack.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/pack.h
@@ -48,13 +48,14 @@ ALWI void pack_init(LLKOperand<Format, Shape> /*out*/) {
  * pack_tile does -- the caller must supply the correct per-tile L1 address on every call. Sub-32-row
  * (partial-height) block-float tiles are not supported (compile-time rejected).
  *
+ * | Template | is_fp32_dest_acc_en | fp32 dest-accumulate mode                          | bool        |         | False |
  * | Template | Format    | Output buffer L1 data format (deduced from LLKOperand) | DataFormat  |         | True |
  * | Template | Shape     | Output tile geometry (deduced from LLKOperand)         | TensorShape |         | True |
  * | Function | out       | The output L1 operand (format+shape+write address)    | LLKOperand  |         | True |
  * | Function | ifrom_dst | Tile index in the DST register                         | uint32_t   | 0 to 15 | True |
  */
 // clang-format on
-template <DataFormat Format, TensorShape Shape>
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE, DataFormat Format, TensorShape Shape>
 ALWI void pack_tile(LLKOperand<Format, Shape> out, std::uint32_t ifrom_dst) {
     static_assert(is_legal_tile_shape(Shape), "pack_tile: illegal output tile shape.");
     static_assert(
@@ -64,7 +65,7 @@ ALWI void pack_tile(LLKOperand<Format, Shape> out, std::uint32_t ifrom_dst) {
     // out_of_order_output=true: pack to the absolute address in the LLKOperand (no fifo_wr_tile_ptr bump).
     PACK((llk_pack<
           LLKOperand<Format, Shape>::descriptor,
-          DST_ACCUM_MODE,
+          is_fp32_dest_acc_en,
           /*out_of_order_output=*/true,
           PackMode::Default>(ifrom_dst, out.l1_address)));
 }
@@ -82,6 +83,7 @@ ALWI void pack_tile(LLKOperand<Format, Shape> out, std::uint32_t ifrom_dst) {
  *
  * | Param Type | Name          | Description                                                | Type        | Valid Range                          | Required |
  * |------------|---------------|------------------------------------------------------------|-------------|--------------------------------------|----------|
+ * | Template   | is_fp32_dest_acc_en | fp32 dest-accumulate mode                             | bool        |                                      | False    |
  * | Template   | Format        | Output buffer L1 data format (deduced from LLKOperand)     | DataFormat  |                                      | True     |
  * | Template   | Shape         | Output tile geometry (deduced from LLKOperand)            | TensorShape |                                      | True     |
  * | Function   | out           | The output L1 operand (format+shape+block base address)   | LLKOperand  |                                      | True     |
@@ -90,7 +92,7 @@ ALWI void pack_tile(LLKOperand<Format, Shape> out, std::uint32_t ifrom_dst) {
  * | Function   | start_out_tile| Starting output tile index (offset into the block base)   | uint32_t    | N/A                                  | False    |
  */
 // clang-format on
-template <DataFormat Format, TensorShape Shape>
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE, DataFormat Format, TensorShape Shape>
 ALWI void pack_block(
     LLKOperand<Format, Shape> out, std::uint32_t ifrom_dst, std::uint32_t ntiles, std::uint32_t start_out_tile = 0) {
     static_assert(is_legal_tile_shape(Shape), "pack_block: illegal output tile shape.");
@@ -102,7 +104,7 @@ ALWI void pack_block(
         // pack_tile is itself PACK()-wrapped, so the engine calls stay on the packer thread. Per-tile output
         // slot via the shared tile_address helper (stride folds to a compile-time constant; matches the CB
         // one-tile page).
-        experimental::pack_tile(
+        experimental::pack_tile<is_fp32_dest_acc_en>(
             LLKOperand<Format, Shape>(detail::tile_address(out, start_out_tile + i)), ifrom_dst + i);
     }
 }

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/pack.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/pack.h
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/common_globals.h"
+#include "api/compute/experimental/2_0/llk_operand.h"
+
+#ifdef TRISC_PACK
+#include "experimental/2_0/llk_pack_tile.h"
+#endif
+
+namespace ckernel {
+namespace experimental {
+
+#ifdef ARCH_BLACKHOLE
+
+// clang-format off
+/**
+ * Experimental id-free pack init. Takes an output LLKOperand (L1 format + geometry as NTTPs). The Dest
+ * register format is derived INSIDE the LLK from the L1 format; the compute API never sees a register
+ * format. Legacy ckernel::pack_init is untouched.
+ *
+ * | Template | Format | Output buffer L1 data format (deduced from LLKOperand) | DataFormat  |  | True |
+ * | Template | Shape  | Output tile geometry (deduced from LLKOperand)         | TensorShape |  | True |
+ */
+// clang-format on
+template <DataFormat Format, TensorShape Shape>
+ALWI void pack_init(LLKOperand<Format, Shape> /*out*/) {
+    static_assert(is_legal_tile_shape(Shape), "pack_init: illegal output tile shape.");
+    PACK((llk_pack_init<LLKOperand<Format, Shape>::descriptor, DST_ACCUM_MODE>()));
+}
+
+// clang-format off
+/**
+ * Experimental id-free pack. Copies one tile from DST to the absolute L1 address in the output LLKOperand.
+ * Formats/geometry were programmed at pack_init; the pack op needs only the runtime write address
+ * (out.l1_address, from the address seam) -- absolute (out-of-order) addressing. No id, no formats.
+ *
+ * DISCREPANCY vs legacy: legacy pack_tile(ifrom_dst, ocb) uses IN-ORDER packing (out_of_order=false) and
+ * auto-advances the packer's internal fifo tile pointer, so consecutive calls write consecutive tiles. This
+ * 2.0 pack uses OUT-OF-ORDER absolute addressing and does NOT advance any internal pointer: the caller must
+ * supply the correct per-tile L1 address every call (e.g. cb_write_address(cb, t)). Equivalent to legacy for
+ * the normal one-tile-per-reserve pattern; a caller relying on legacy auto-increment must instead index the
+ * address itself.
+ *
+ * | Template | Format    | Output buffer L1 data format (deduced from LLKOperand) | DataFormat  |         | True |
+ * | Template | Shape     | Output tile geometry (deduced from LLKOperand)         | TensorShape |         | True |
+ * | Function | out       | The output L1 operand (format+shape+write address)    | LLKOperand  |         | True |
+ * | Function | ifrom_dst | Tile index in the DST register                         | uint32_t   | 0 to 15 | True |
+ */
+// clang-format on
+template <DataFormat Format, TensorShape Shape>
+ALWI void pack_tile(LLKOperand<Format, Shape> out, std::uint32_t ifrom_dst) {
+    static_assert(is_legal_tile_shape(Shape), "pack_tile: illegal output tile shape.");
+    // out_of_order_output=true: pack to the absolute address in the LLKOperand (no fifo_wr_tile_ptr bump).
+    PACK((llk_pack<
+          LLKOperand<Format, Shape>::descriptor,
+          DST_ACCUM_MODE,
+          /*out_of_order_output=*/true,
+          PackMode::Default>(ifrom_dst, out.l1_address)));
+}
+
+// clang-format off
+/**
+ * Experimental id-free block pack. Packs `ntiles` consecutive tiles from the DST register to consecutive L1
+ * addresses in the output operand -- the block/loop form of pack_tile. It is a thin compute-layer loop over the
+ * 2.0 pack_tile: tile i is read from DST[ifrom_dst + i] and written to
+ * out.l1_address + (start_out_tile + i) * tile_stride_words(Format, Shape), so the per-tile output stride is
+ * derived from the COMPILE-TIME output tile geometry (internal/llk_descriptor.h), not from a CB page size. With
+ * start_out_tile = 0 this reproduces exactly the L1 layout a legacy in-order pack_tile loop would write (each
+ * consecutive call advancing by one tile). Each pack_tile uses absolute (out-of-order) addressing; there is no
+ * internal fifo pointer, so the caller supplies the block base once and the op indexes from it. No id, no formats.
+ *
+ * | Param Type | Name          | Description                                                | Type        | Valid Range                          | Required |
+ * |------------|---------------|------------------------------------------------------------|-------------|--------------------------------------|----------|
+ * | Template   | Format        | Output buffer L1 data format (deduced from LLKOperand)     | DataFormat  |                                      | True     |
+ * | Template   | Shape         | Output tile geometry (deduced from LLKOperand)            | TensorShape |                                      | True     |
+ * | Function   | out           | The output L1 operand (format+shape+block base address)   | LLKOperand  |                                      | True     |
+ * | Function   | ifrom_dst     | Index of the first tile in the DST register               | uint32_t    | 0 to 15                              | True     |
+ * | Function   | ntiles        | Number of tiles to pack from DST to L1                     | uint32_t    | ifrom_dst + ntiles <= DST size (16) | True     |
+ * | Function   | start_out_tile| Starting output tile index (offset into the block base)   | uint32_t    | N/A                                  | False    |
+ */
+// clang-format on
+template <DataFormat Format, TensorShape Shape>
+ALWI void pack_block(
+    LLKOperand<Format, Shape> out, std::uint32_t ifrom_dst, std::uint32_t ntiles, std::uint32_t start_out_tile = 0) {
+    static_assert(is_legal_tile_shape(Shape), "pack_block: illegal output tile shape.");
+    for (std::uint32_t i = 0; i < ntiles; ++i) {
+        // pack_tile is itself PACK()-wrapped, so the engine calls stay on the packer thread. Per-tile output
+        // slot via the shared tile_address helper (stride folds to a compile-time constant; matches the CB
+        // one-tile page).
+        experimental::pack_tile(
+            LLKOperand<Format, Shape>(detail::tile_address(out, start_out_tile + i)), ifrom_dst + i);
+    }
+}
+
+// clang-format off
+/**
+ * Experimental id-free row pack. Packs a run of row-major rows (each 16 datums) from one DST tile to the
+ * absolute L1 address in the output LLKOperand, in row-major (untilized) order -- the id-free successor to the
+ * CB-id pack_rows(idst, ocb, output_index). The number of rows is configured beforehand by the (already
+ * format-free / id-free) pack_rows_init(num_rows); this op needs only the DST tile index and the runtime write
+ * address (out.l1_address, from the address seam -- e.g. cb_write_address(ocb, output_index)). Formats/geometry
+ * were programmed at compute_kernel_hw_startup / pack_init; the row-pack HW path consumes no data format, so the
+ * output LLKOperand supplies only the write address and the compile-time shape (for the legal-shape guard). No id.
+ *
+ * Pair with pack_rows_init / pack_rows_uninit (the CB-id-free legacy calls; both take no CB) exactly as the
+ * legacy pack_rows does. Absolute (out-of-order) addressing: no internal fifo pointer is advanced, so the caller
+ * supplies the correct per-output-region address each call.
+ *
+ * | Param Type | Name  | Description                                              | Type        | Valid Range                          | Required |
+ * |------------|-------|----------------------------------------------------------|-------------|--------------------------------------|----------|
+ * | Template   | Format| Output buffer L1 data format (deduced from LLKOperand)   | DataFormat  |                                      | True     |
+ * | Template   | Shape | Output tile geometry (deduced from LLKOperand)          | TensorShape |                                      | True     |
+ * | Function   | out   | The output L1 operand (format+shape+write address)      | LLKOperand  |                                      | True     |
+ * | Function   | idst  | Index of the tile in the DST register to pack rows from | uint32_t    | 0 to 15                              | True     |
+ */
+// clang-format on
+template <DataFormat Format, TensorShape Shape>
+ALWI void pack_rows(LLKOperand<Format, Shape> out, std::uint32_t idst) {
+    static_assert(is_legal_tile_shape(Shape), "pack_rows: illegal output tile shape.");
+    PACK((llk_pack_rows<LLKOperand<Format, Shape>::descriptor>(idst, out.l1_address)));
+}
+
+#endif  // ARCH_BLACKHOLE
+
+}  // namespace experimental
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/pack.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/pack.h
@@ -19,9 +19,10 @@ namespace experimental {
 
 // clang-format off
 /**
- * Experimental id-free pack init. Takes an output LLKOperand (L1 format + geometry as NTTPs). The Dest
- * register format is derived INSIDE the LLK from the L1 format; the compute API never sees a register
- * format. Legacy ckernel::pack_init is untouched.
+ * Id-free pack init. Takes an output LLKOperand (L1 format + geometry as NTTPs); the DST register format is
+ * derived inside the LLK from the L1 format. Blackhole only.
+ *
+ * Sub-32-row (partial-height) block-float tiles are not supported (compile-time rejected).
  *
  * | Template | Format | Output buffer L1 data format (deduced from LLKOperand) | DataFormat  |  | True |
  * | Template | Shape  | Output tile geometry (deduced from LLKOperand)         | TensorShape |  | True |
@@ -39,16 +40,13 @@ ALWI void pack_init(LLKOperand<Format, Shape> /*out*/) {
 
 // clang-format off
 /**
- * Experimental id-free pack. Copies one tile from DST to the absolute L1 address in the output LLKOperand.
- * Formats/geometry were programmed at pack_init; the pack op needs only the runtime write address
- * (out.l1_address, from the address seam) -- absolute (out-of-order) addressing. No id, no formats.
+ * Id-free pack. Copies one tile from DST to the absolute L1 address in the output LLKOperand. Formats and
+ * geometry were programmed at pack_init; only the runtime write address (out.l1_address) is needed. Blackhole
+ * only.
  *
- * DISCREPANCY vs legacy: legacy pack_tile(ifrom_dst, ocb) uses IN-ORDER packing (out_of_order=false) and
- * auto-advances the packer's internal fifo tile pointer, so consecutive calls write consecutive tiles. This
- * 2.0 pack uses OUT-OF-ORDER absolute addressing and does NOT advance any internal pointer: the caller must
- * supply the correct per-tile L1 address every call (e.g. cb_write_address(cb, t)). Equivalent to legacy for
- * the normal one-tile-per-reserve pattern; a caller relying on legacy auto-increment must instead index the
- * address itself.
+ * Uses out-of-order (absolute) addressing and does not auto-advance an internal fifo pointer like legacy
+ * pack_tile does -- the caller must supply the correct per-tile L1 address on every call. Sub-32-row
+ * (partial-height) block-float tiles are not supported (compile-time rejected).
  *
  * | Template | Format    | Output buffer L1 data format (deduced from LLKOperand) | DataFormat  |         | True |
  * | Template | Shape     | Output tile geometry (deduced from LLKOperand)         | TensorShape |         | True |
@@ -73,14 +71,14 @@ ALWI void pack_tile(LLKOperand<Format, Shape> out, std::uint32_t ifrom_dst) {
 
 // clang-format off
 /**
- * Experimental id-free block pack. Packs `ntiles` consecutive tiles from the DST register to consecutive L1
- * addresses in the output operand -- the block/loop form of pack_tile. It is a thin compute-layer loop over the
- * 2.0 pack_tile: tile i is read from DST[ifrom_dst + i] and written to
- * out.l1_address + (start_out_tile + i) * tile_stride_words(Format, Shape), so the per-tile output stride is
- * derived from the COMPILE-TIME output tile geometry (internal/llk_descriptor.h), not from a CB page size. With
- * start_out_tile = 0 this reproduces exactly the L1 layout a legacy in-order pack_tile loop would write (each
- * consecutive call advancing by one tile). Each pack_tile uses absolute (out-of-order) addressing; there is no
- * internal fifo pointer, so the caller supplies the block base once and the op indexes from it. No id, no formats.
+ * Id-free block pack. Packs `ntiles` consecutive tiles from DST to consecutive L1 addresses in the output
+ * operand (block/loop form of pack_tile). Tile i is read from DST[ifrom_dst + i] and written to
+ * out.l1_address + (start_out_tile + i) * <one-tile stride>, derived at compile time from the output
+ * descriptor's format/geometry. Blackhole only.
+ *
+ * Uses out-of-order addressing per tile (see pack_tile); with start_out_tile = 0 this reproduces the same L1
+ * layout a legacy in-order pack_tile loop would write. Sub-32-row (partial-height) block-float tiles are not
+ * supported (compile-time rejected).
  *
  * | Param Type | Name          | Description                                                | Type        | Valid Range                          | Required |
  * |------------|---------------|------------------------------------------------------------|-------------|--------------------------------------|----------|
@@ -111,17 +109,13 @@ ALWI void pack_block(
 
 // clang-format off
 /**
- * Experimental id-free row pack. Packs a run of row-major rows (each 16 datums) from one DST tile to the
- * absolute L1 address in the output LLKOperand, in row-major (untilized) order -- the id-free successor to the
- * CB-id pack_rows(idst, ocb, output_index). The number of rows is configured beforehand by the (already
- * format-free / id-free) pack_rows_init(num_rows); this op needs only the DST tile index and the runtime write
- * address (out.l1_address, from the address seam -- e.g. cb_write_address(ocb, output_index)). Formats/geometry
- * were programmed at compute_kernel_hw_startup / pack_init; the row-pack HW path consumes no data format, so the
- * output LLKOperand supplies only the write address and the compile-time shape (for the legal-shape guard). No id.
+ * Id-free row pack. Packs a run of row-major rows (each 16 datums) from one DST tile to the absolute L1
+ * address in the output LLKOperand, in row-major (untilized) order. Blackhole only.
  *
- * Pair with pack_rows_init / pack_rows_uninit (the CB-id-free legacy calls; both take no CB) exactly as the
- * legacy pack_rows does. Absolute (out-of-order) addressing: no internal fifo pointer is advanced, so the caller
- * supplies the correct per-output-region address each call.
+ * The number of rows is configured beforehand by pack_rows_init(num_rows). Uses out-of-order (absolute)
+ * addressing -- no internal fifo pointer is advanced, so the caller supplies the correct address each call.
+ * Pair with pack_rows_init / pack_rows_uninit. Sub-32-row (partial-height) block-float tiles are not
+ * supported (compile-time rejected).
  *
  * | Param Type | Name  | Description                                              | Type        | Valid Range                          | Required |
  * |------------|-------|----------------------------------------------------------|-------------|--------------------------------------|----------|
@@ -143,13 +137,13 @@ ALWI void pack_rows(LLKOperand<Format, Shape> out, std::uint32_t idst) {
 
 // clang-format off
 /**
- * Experimental id-free row-pack init. Configures the packer to pack `num_rows` row-major rows (each 16 datums)
- * from a DST tile to L1 -- the id-free successor to the (already CB-id-free) legacy pack_rows_init(num_rows).
- * Takes the OUTPUT LLKOperand for API symmetry with the other 2.0 pack ops, but the row-pack init path programs
- * ONLY the packer counters/addrmods -- NO data format (formats come from compute_kernel_hw_startup / pack_init).
- * The operand therefore supplies only the compile-time shape (for the legal-shape guard); its address/format are
- * not read here. Reuses the existing format-free llk_pack_rows_init core (no new LLK op). Pair with pack_rows and
- * pack_rows_uninit. Legacy ckernel::pack_rows_init is untouched.
+ * Id-free row-pack init. Configures the packer to pack `num_rows` row-major rows (each 16 datums) from a DST
+ * tile to L1. Takes the output LLKOperand for API symmetry with the other 2.0 pack ops, but programs only the
+ * packer counters/addrmods -- no data format (formats come from compute_kernel_hw_startup / pack_init); the
+ * operand supplies only the compile-time shape (legal-shape guard). Pair with pack_rows and pack_rows_uninit.
+ * Blackhole only.
+ *
+ * Sub-32-row (partial-height) block-float tiles are not supported (compile-time rejected).
  *
  * | Param Type | Name     | Description                                                   | Type        | Valid Range | Required |
  * |------------|----------|---------------------------------------------------------------|-------------|-------------|----------|
@@ -171,12 +165,12 @@ ALWI void pack_rows_init(LLKOperand<Format, Shape> /*out*/, std::uint32_t num_ro
 
 // clang-format off
 /**
- * Experimental id-free row-pack uninit. Restores the packer addrmods/counters to their default state after a run
- * of pack_rows, so subsequent standard packing (e.g. pack_tile) works -- the id-free successor to the (already
- * CB-id-free) legacy pack_rows_uninit(). Takes the OUTPUT LLKOperand for API symmetry only; the uninit path
- * programs no data format and reads nothing from the operand (the shape is used solely for the legal-shape guard).
- * Reuses the existing format-free llk_pack_rows_uninit core (no new LLK op). Legacy ckernel::pack_rows_uninit is
- * untouched.
+ * Id-free row-pack uninit. Restores the packer addrmods/counters to their default state after a run of
+ * pack_rows, so subsequent standard packing (e.g. pack_tile) works. Takes the output LLKOperand for API
+ * symmetry only; programs no data format and reads nothing from the operand (the shape is used solely for
+ * the legal-shape guard). Blackhole only.
+ *
+ * Sub-32-row (partial-height) block-float tiles are not supported (compile-time rejected).
  *
  * | Param Type | Name | Description                                                  | Type        | Valid Range | Required |
  * |------------|------|--------------------------------------------------------------|-------------|-------------|----------|

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/pack.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/pack.h
@@ -125,6 +125,52 @@ ALWI void pack_rows(LLKOperand<Format, Shape> out, std::uint32_t idst) {
     PACK((llk_pack_rows<LLKOperand<Format, Shape>::descriptor>(idst, out.l1_address)));
 }
 
+// clang-format off
+/**
+ * Experimental id-free row-pack init. Configures the packer to pack `num_rows` row-major rows (each 16 datums)
+ * from a DST tile to L1 -- the id-free successor to the (already CB-id-free) legacy pack_rows_init(num_rows).
+ * Takes the OUTPUT LLKOperand for API symmetry with the other 2.0 pack ops, but the row-pack init path programs
+ * ONLY the packer counters/addrmods -- NO data format (formats come from compute_kernel_hw_startup / pack_init).
+ * The operand therefore supplies only the compile-time shape (for the legal-shape guard); its address/format are
+ * not read here. Reuses the existing format-free llk_pack_rows_init core (no new LLK op). Pair with pack_rows and
+ * pack_rows_uninit. Legacy ckernel::pack_rows_init is untouched.
+ *
+ * | Param Type | Name     | Description                                                   | Type        | Valid Range | Required |
+ * |------------|----------|---------------------------------------------------------------|-------------|-------------|----------|
+ * | Template   | Format   | Output buffer L1 data format (deduced from LLKOperand)        | DataFormat  |             | True     |
+ * | Template   | Shape    | Output tile geometry (deduced from LLKOperand)               | TensorShape |             | True     |
+ * | Function   | out      | The output L1 operand (used only for the compile-time shape)  | LLKOperand  |             | True     |
+ * | Function   | num_rows | Number of rows to pack from DST to L1 (each row = 16 datums)  | uint32_t    | 1 to 64     | True     |
+ */
+// clang-format on
+template <DataFormat Format, TensorShape Shape>
+ALWI void pack_rows_init(LLKOperand<Format, Shape> /*out*/, std::uint32_t num_rows) {
+    static_assert(is_legal_tile_shape(Shape), "pack_rows_init: illegal output tile shape.");
+    PACK((llk_pack_rows_init(num_rows)));
+}
+
+// clang-format off
+/**
+ * Experimental id-free row-pack uninit. Restores the packer addrmods/counters to their default state after a run
+ * of pack_rows, so subsequent standard packing (e.g. pack_tile) works -- the id-free successor to the (already
+ * CB-id-free) legacy pack_rows_uninit(). Takes the OUTPUT LLKOperand for API symmetry only; the uninit path
+ * programs no data format and reads nothing from the operand (the shape is used solely for the legal-shape guard).
+ * Reuses the existing format-free llk_pack_rows_uninit core (no new LLK op). Legacy ckernel::pack_rows_uninit is
+ * untouched.
+ *
+ * | Param Type | Name | Description                                                  | Type        | Valid Range | Required |
+ * |------------|------|--------------------------------------------------------------|-------------|-------------|----------|
+ * | Template   | Format | Output buffer L1 data format (deduced from LLKOperand)      | DataFormat  |             | True     |
+ * | Template   | Shape  | Output tile geometry (deduced from LLKOperand)             | TensorShape |             | True     |
+ * | Function   | out    | The output L1 operand (used only for the compile-time shape) | LLKOperand  |             | True     |
+ */
+// clang-format on
+template <DataFormat Format, TensorShape Shape>
+ALWI void pack_rows_uninit(LLKOperand<Format, Shape> /*out*/) {
+    static_assert(is_legal_tile_shape(Shape), "pack_rows_uninit: illegal output tile shape.");
+    PACK((llk_pack_rows_uninit()));
+}
+
 #endif  // ARCH_BLACKHOLE
 
 }  // namespace experimental

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/pack_untilize.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/pack_untilize.h
@@ -28,15 +28,10 @@ namespace experimental {
 
 // clang-format off
 /**
- * Experimental id-free pack-untilize init. Takes an input and an output LLKOperand (data format + tile
- * geometry as NTTPs) instead of CB ids. Initializes all three threads (UNPACK/MATH/PACK) to move tilized
- * tiles CB -> DEST (datacopy) and pack them out row-major. Register formats are derived INSIDE the LLK.
- *
- * Mirrors the legacy pack_untilize_init (3-thread) + pack_untilize_dest_init PACK sequence, with one
- * substitution: the legacy PACK path calls llk_pack_reconfig_data_format(ocb) to program the packer format
- * registers from CB metadata; the id-free path calls the LLKOperand overload of that same op (formats from
- * OUT). llk_pack_untilize_init itself only programs addrmod/MOP/z-stride, so this format program is
- * required. BH DEST remap is (re)configured here (llk_math_reconfig_remap), matching the default legacy init.
+ * Id-free pack-untilize init. Takes an input and an output LLKOperand (data format + tile geometry as NTTPs)
+ * instead of CB ids. Initializes all three threads (UNPACK/MATH/PACK) to move tilized tiles from the input
+ * into DEST (datacopy) and pack them out row-major; register formats are derived inside the LLK. DEST remap
+ * is (re)configured here. Blackhole only.
  *
  * | Template | block_ct_dim/full_ct_dim | Block width / full input width in tiles | uint32_t | | False |
  * | Function | in                       | Input operand (tilized; format+geometry) | LLKOperand | | True |
@@ -86,21 +81,12 @@ ALWI void pack_untilize_init(LLKOperand<InFormat, InShape> /*in*/, LLKOperand<Ou
 
 // clang-format off
 /**
- * Experimental id-free pack-untilize of one block. The op owns the row/column loops and self-syncs DEST.
- * Runtime "where": in.l1_address (unpack base; the op offsets by the per-tile input stride derived from
- * InShape) and out.l1_address (the block's first row-major output tile).
+ * Id-free pack-untilize of one block. Owns the row/column loops and self-syncs DEST. Reads from in.l1_address
+ * (unpack base; offset per tile by InShape's stride) and writes the block's first row-major output tile to
+ * out.l1_address. Blackhole only.
  *
- * ADDRESSING vs the legacy BH pack_untilize (fifo_page_size == one tile_size):
- *   Legacy pack_untilize advances the packer write address across tile-rows by the CB's ACTUAL
- *   fifo_page_size (full_ct_dim * fifo_page_size, read from the CB interface). This id-free op has no CB
- *   handle, so llk_pack_untilize derives that per-row stride from the OUTPUT descriptor via
- *   tile_stride_words == one tile's L1 size; the input per-tile unpack base uses the same for InShape.
- *   The shipping untilize factories set both CB pages to one tile (in/out_single_tile_size), so this matches
- *   fifo_page_size for every format they use:
- *     - linear formats (Float32/Float16/int): geometry-exact datum-count size (SCALE_DATUM_SIZE >> 4);
- *     - block floats (Bfp8/Bfp4/Bfp2): mantissa + shared-exponent section, both scaled by the tile geometry
- *       (matches tt_metal Tile::get_tile_size / the shipping CB page; see internal/llk_descriptor.h::tile_stride_words).
- *   Remaining edge (no shipping op hits it): padded / multi-tile CB pages.
+ * Per-row output stride is one tile's L1 size, derived at compile time from the output descriptor -- matches
+ * the shipping untilize factories' one-tile CB page.
  *
  * | Template | block_ct_dim/full_ct_dim | Block width / full input width in tiles | uint32_t | | False |
  * | Function | in            | Input operand (tilized; unpack base)          | LLKOperand | | True |
@@ -157,13 +143,10 @@ ALWI void pack_untilize_block(
 
 // clang-format off
 /**
- * Experimental id-free pack-untilize DEST init (PACK thread only). Use this when the tiles to untilize are
- * ALREADY resident in the DEST register (placed by copy_tile/reduce_tile/etc.), so UNPACK and MATH are NOT
- * configured for a CB -> DEST datacopy here (contrast pack_untilize_init, which configures all three threads).
- * Takes only the OUTPUT LLKOperand (data format + tile geometry as NTTPs) instead of a CB id; the packer
- * register format is derived INSIDE the LLK from OUT. Mirrors the legacy pack_untilize_dest_init PACK path:
- * (re)configure BH DEST remap, program the packer output format, program the untilize MOP/strides, then the
- * untilize dest-offset registers. Pair with pack_untilize_dest / pack_untilize_uninit.
+ * Id-free pack-untilize DEST init (PACK thread only). Use when the tiles to untilize are already resident in
+ * DEST (placed by copy_tile/reduce_tile/etc.) -- UNPACK and MATH are not configured here, unlike
+ * pack_untilize_init. Takes only the output LLKOperand; the packer register format is derived inside the LLK
+ * from OUT. Pair with pack_untilize_dest / pack_untilize_uninit. Blackhole only.
  *
  * | Param Type | Name          | Description                                       | Type       | Valid Range               | Required              |
  * |------------|---------------|---------------------------------------------------|------------|---------------------------|-----------------------|
@@ -206,12 +189,13 @@ ALWI void pack_untilize_dest_init(LLKOperand<OutFormat, OutShape> /*out*/) {
 
 // clang-format off
 /**
- * Experimental id-free pack-untilize of a block whose source is the DEST register (not a CB). Packs
- * (untilizes) block_rt_dim tile-rows that are ALREADY in DEST out to the row-major output at out.l1_address.
- * There is NO input LLKOperand: the source is DEST (selected by tile_dst_ct_offset / tile_dst_rt_offset).
- * The caller owns DEST synchronization (tile_regs_acquire/commit/wait/release) and any CB flow control. The
- * per-tile-row output stride is derived from the OUTPUT descriptor (tile_stride_words == one tile's L1 size;
- * see the addressing note on pack_untilize_block). Pair with pack_untilize_dest_init.
+ * Id-free pack-untilize of a block whose source is DEST (not a CB). Packs (untilizes) block_rt_dim tile-rows
+ * already in DEST (selected by tile_dst_ct_offset / tile_dst_rt_offset) out to the row-major output at
+ * out.l1_address. Blackhole only.
+ *
+ * There is no input LLKOperand. The caller owns DEST synchronization (tile_regs_acquire/commit/wait/release)
+ * and any CB flow control. Per-tile-row output stride is derived from the output descriptor (one tile's L1
+ * size). Pair with pack_untilize_dest_init.
  *
  * | Param Type | Name               | Description                                                    | Type       | Valid Range                             | Required              |
  * |------------|--------------------|----------------------------------------------------------------|------------|-----------------------------------------|-----------------------|
@@ -261,9 +245,8 @@ ALWI void pack_untilize_dest(
 
 // clang-format off
 /**
- * Experimental id-free pack-untilize uninit. Restores the packer Z stride (via the output descriptor's
- * register format) and resets the packer to Default mode so a subsequent op can reprogram it. Mirrors the
- * legacy pack_untilize_uninit (BH path).
+ * Id-free pack-untilize uninit. Restores the packer Z stride (via the output descriptor's register format)
+ * and resets the packer to Default mode so a subsequent op can reprogram it. Blackhole only.
  */
 // clang-format on
 template <DataFormat OutFormat, TensorShape OutShape>

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/pack_untilize.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/pack_untilize.h
@@ -1,0 +1,278 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/common_globals.h"
+#include "api/compute/experimental/2_0/llk_operand.h"
+
+#ifdef TRISC_MATH
+#include "experimental/2_0/llk_math_unary_datacopy.h"
+#endif
+
+#ifdef TRISC_UNPACK
+#include "experimental/2_0/llk_unpack_A.h"
+#endif
+
+#ifdef TRISC_PACK
+#include "experimental/2_0/llk_pack_untilize.h"
+#include "experimental/2_0/llk_pack_tile.h"
+#endif
+
+namespace ckernel {
+namespace experimental {
+
+#ifdef ARCH_BLACKHOLE
+
+// clang-format off
+/**
+ * Experimental id-free pack-untilize init. Takes an input and an output LLKOperand (data format + tile
+ * geometry as NTTPs) instead of CB ids. Initializes all three threads (UNPACK/MATH/PACK) to move tilized
+ * tiles CB -> DEST (datacopy) and pack them out row-major. Register formats are derived INSIDE the LLK.
+ *
+ * Mirrors the legacy pack_untilize_init (3-thread) + pack_untilize_dest_init PACK sequence, with one
+ * substitution: the legacy PACK path calls llk_pack_reconfig_data_format(ocb) to program the packer format
+ * registers from CB metadata; the id-free path calls the LLKOperand overload of that same op (formats from
+ * OUT). llk_pack_untilize_init itself only programs addrmod/MOP/z-stride, so this format program is
+ * required. BH DEST remap is (re)configured here (llk_math_reconfig_remap), matching the default legacy init.
+ *
+ * | Template | block_ct_dim/full_ct_dim | Block width / full input width in tiles | uint32_t | | False |
+ * | Function | in                       | Input operand (tilized; format+geometry) | LLKOperand | | True |
+ * | Function | out                      | Output operand (row-major destination)   | LLKOperand | | True |
+ */
+// clang-format on
+template <
+    std::uint32_t block_ct_dim = 8,
+    std::uint32_t full_ct_dim = block_ct_dim,
+    DataFormat InFormat,
+    TensorShape InShape,
+    DataFormat OutFormat,
+    TensorShape OutShape>
+ALWI void pack_untilize_init(LLKOperand<InFormat, InShape> /*in*/, LLKOperand<OutFormat, OutShape> /*out*/) {
+    static_assert(is_legal_tile_shape(InShape), "pack_untilize_init: illegal input tile shape.");
+    static_assert(is_legal_tile_shape(OutShape), "pack_untilize_init: illegal output tile shape.");
+    static_assert(
+        block_ct_dim > 0 && full_ct_dim % block_ct_dim == 0,
+        "pack_untilize_init: full_ct_dim must be a positive multiple of block_ct_dim.");
+    // UNPACK + MATH: configure the CB -> DEST datacopy (input format drives the SrcA/Dest register format).
+    UNPACK((llk_unpack_A_init<
+            LLKOperand<InFormat, InShape>::descriptor,
+            DST_ACCUM_MODE,
+            BroadcastType::NONE,
+            false /*acc_to_dest*/,
+            EltwiseBinaryReuseDestType::NONE,
+            UnpackToDestEn>(0 /*transpose_of_faces*/, 0 /*within_face_16x16_transpose*/)));
+    MATH((llk_math_eltwise_unary_datacopy_init<
+          LLKOperand<InFormat, InShape>::descriptor,
+          DataCopyType::A2D,
+          DST_ACCUM_MODE,
+          BroadcastType::NONE,
+          false /*is_int_en*/,
+          PackMode::Default>()));
+
+    // PACK: (re)configure BH DEST remap, program the packer output formats, then the untilize MOP/strides
+    // and the untilize dest-offset registers.
+    MATH((llk_math_reconfig_remap(true /*remap_enable*/)));
+    PACK((llk_pack_reconfig_data_format<LLKOperand<OutFormat, OutShape>::descriptor, DST_ACCUM_MODE>()));
+    PACK((llk_pack_untilize_init<
+          LLKOperand<OutFormat, OutShape>::descriptor,
+          DST_ACCUM_MODE,
+          block_ct_dim,
+          full_ct_dim>()));
+    PACK((_llk_init_packer_dest_offset_registers_<DST_SYNC_MODE>()));
+}
+
+// clang-format off
+/**
+ * Experimental id-free pack-untilize of one block. The op owns the row/column loops and self-syncs DEST.
+ * Runtime "where": in.l1_address (unpack base; the op offsets by the per-tile input stride derived from
+ * InShape) and out.l1_address (the block's first row-major output tile).
+ *
+ * ADDRESSING vs the legacy BH pack_untilize (fifo_page_size == one tile_size):
+ *   Legacy pack_untilize advances the packer write address across tile-rows by the CB's ACTUAL
+ *   fifo_page_size (full_ct_dim * fifo_page_size, read from the CB interface). This id-free op has no CB
+ *   handle, so llk_pack_untilize derives that per-row stride from the OUTPUT descriptor via
+ *   tile_stride_words == one tile's L1 size; the input per-tile unpack base uses the same for InShape.
+ *   The shipping untilize factories set both CB pages to one tile (in/out_single_tile_size), so this matches
+ *   fifo_page_size for every format they use: geometry-exact for linear formats, exp section included for
+ *   block floats. Remaining edge (no shipping op hits it): padded/multi-tile pages, and partial/tiny BFP
+ *   tiles (tile_stride_words uses full-tile BFP size).
+ *
+ * | Template | block_ct_dim/full_ct_dim | Block width / full input width in tiles | uint32_t | | False |
+ * | Function | in            | Input operand (tilized; unpack base)          | LLKOperand | | True |
+ * | Function | block_rt_dim  | Height of the block in tiles (rows to pack)   | uint32_t   | >= 1 | True |
+ * | Function | out           | Output operand (first row-major tile address) | LLKOperand | | True |
+ * | Function | block_c_index | Block column index (when full_ct_dim > block_ct_dim) | uint32_t | >= 0 | False |
+ */
+// clang-format on
+template <
+    std::uint32_t block_ct_dim = 8,
+    std::uint32_t full_ct_dim = block_ct_dim,
+    DataFormat InFormat,
+    TensorShape InShape,
+    DataFormat OutFormat,
+    TensorShape OutShape>
+ALWI void pack_untilize_block(
+    LLKOperand<InFormat, InShape> in,
+    std::uint32_t block_rt_dim,
+    LLKOperand<OutFormat, OutShape> out,
+    std::uint32_t block_c_index = 0) {
+    static_assert(is_legal_tile_shape(InShape), "pack_untilize_block: illegal input tile shape.");
+    static_assert(is_legal_tile_shape(OutShape), "pack_untilize_block: illegal output tile shape.");
+    static_assert(
+        block_ct_dim > 0 && full_ct_dim % block_ct_dim == 0,
+        "pack_untilize_block: full_ct_dim must be a positive multiple of block_ct_dim.");
+    // Per-tile input stride (16B words) == one tile's L1 size, folded to a compile-time constant via
+    // tile_stride_words: geometry-exact for linear formats, exp section included for block floats.
+    constexpr std::uint32_t in_tile_stride = tile_stride_words(InFormat, InShape);
+
+    for (std::uint32_t r = 0; r < block_rt_dim; ++r) {
+        MATH((llk_math_wait_for_dest_available()));
+        for (std::uint32_t c = 0; c < block_ct_dim; ++c) {
+            UNPACK((llk_unpack_A<
+                    LLKOperand<InFormat, InShape>::descriptor,
+                    DST_ACCUM_MODE,
+                    BroadcastType::NONE,
+                    false /*acc_to_dest*/,
+                    EltwiseBinaryReuseDestType::NONE,
+                    UnpackToDestEn>(in.l1_address + c * in_tile_stride)));
+            MATH((llk_math_eltwise_unary_datacopy<
+                  LLKOperand<InFormat, InShape>::descriptor,
+                  DataCopyType::A2D,
+                  DST_ACCUM_MODE,
+                  BroadcastType::NONE,
+                  UnpackToDestEn>(c)));
+        }
+        MATH((llk_math_dest_section_done<DST_ACCUM_MODE>()));
+        PACK((llk_packer_wait_for_math_done()));
+        PACK((llk_pack_untilize<LLKOperand<OutFormat, OutShape>::descriptor, DST_ACCUM_MODE, block_ct_dim, full_ct_dim>(
+            1 /*block_rt_dim*/, out.l1_address, block_c_index)));
+        PACK((llk_pack_dest_section_done<DST_ACCUM_MODE>()));
+    }
+}
+
+// clang-format off
+/**
+ * Experimental id-free pack-untilize DEST init (PACK thread only). Use this when the tiles to untilize are
+ * ALREADY resident in the DEST register (placed by copy_tile/reduce_tile/etc.), so UNPACK and MATH are NOT
+ * configured for a CB -> DEST datacopy here (contrast pack_untilize_init, which configures all three threads).
+ * Takes only the OUTPUT LLKOperand (data format + tile geometry as NTTPs) instead of a CB id; the packer
+ * register format is derived INSIDE the LLK from OUT. Mirrors the legacy pack_untilize_dest_init PACK path:
+ * (re)configure BH DEST remap, program the packer output format, program the untilize MOP/strides, then the
+ * untilize dest-offset registers. Pair with pack_untilize_dest / pack_untilize_uninit.
+ *
+ * | Param Type | Name          | Description                                       | Type       | Valid Range               | Required              |
+ * |------------|---------------|---------------------------------------------------|------------|---------------------------|-----------------------|
+ * | Template   | block_ct_dim  | Width of a single block in tiles                  | uint32_t   | 1 to max (DEST size)      | False (default = 8)   |
+ * | Template   | full_ct_dim   | Width of a full input in tiles                    | uint32_t   | Divisible by block_ct_dim | False                 |
+ * | Template   | diagonal      | Diagonal packing (unused on Blackhole; must be false) | bool   | false                     | False                 |
+ * | Template   | narrow_row    | Whether the provided input is narrow              | bool       | true/false                | False                 |
+ * | Template   | row_num_datums| Number of datums per row                          | uint32_t   | >= 1                      | False                 |
+ * | Template   | dense         | Packs two 2-face tiles in a single 4-face region  | bool       | true/false                | False (default false) |
+ * | Function   | out           | Output operand (row-major destination; format+geometry) | LLKOperand |                     | True                  |
+ */
+// clang-format on
+template <
+    std::uint32_t block_ct_dim = 8,
+    std::uint32_t full_ct_dim = block_ct_dim,
+    bool diagonal = false,
+    bool narrow_row = false,
+    std::uint32_t row_num_datums = TILE_C_DIM,
+    bool dense = false,
+    DataFormat OutFormat,
+    TensorShape OutShape>
+ALWI void pack_untilize_dest_init(LLKOperand<OutFormat, OutShape> /*out*/) {
+    static_assert(diagonal == false, "pack_untilize_dest_init: diagonal is only supported on WH.");
+    static_assert(is_legal_tile_shape(OutShape), "pack_untilize_dest_init: illegal output tile shape.");
+    static_assert(
+        block_ct_dim > 0 && full_ct_dim % block_ct_dim == 0,
+        "pack_untilize_dest_init: full_ct_dim must be a positive multiple of block_ct_dim.");
+    MATH((llk_math_reconfig_remap(true /*remap_enable*/)));
+    PACK((llk_pack_reconfig_data_format<LLKOperand<OutFormat, OutShape>::descriptor, DST_ACCUM_MODE>()));
+    PACK((llk_pack_untilize_init<
+          LLKOperand<OutFormat, OutShape>::descriptor,
+          DST_ACCUM_MODE,
+          block_ct_dim,
+          full_ct_dim,
+          narrow_row,
+          row_num_datums,
+          dense>()));
+    PACK((_llk_init_packer_dest_offset_registers_<DST_SYNC_MODE>()));
+}
+
+// clang-format off
+/**
+ * Experimental id-free pack-untilize of a block whose source is the DEST register (not a CB). Packs
+ * (untilizes) block_rt_dim tile-rows that are ALREADY in DEST out to the row-major output at out.l1_address.
+ * There is NO input LLKOperand: the source is DEST (selected by tile_dst_ct_offset / tile_dst_rt_offset).
+ * The caller owns DEST synchronization (tile_regs_acquire/commit/wait/release) and any CB flow control. The
+ * per-tile-row output stride is derived from the OUTPUT descriptor (tile_stride_words == one tile's L1 size;
+ * see the addressing note on pack_untilize_block). Pair with pack_untilize_dest_init.
+ *
+ * | Param Type | Name               | Description                                                    | Type       | Valid Range                             | Required              |
+ * |------------|--------------------|----------------------------------------------------------------|------------|-----------------------------------------|-----------------------|
+ * | Template   | block_ct_dim       | Width of a single block in tiles                               | uint32_t   | 1 to max (DEST size)                    | False (default = 8)   |
+ * | Template   | full_ct_dim        | Width of a full input in tiles                                 | uint32_t   | Divisible by block_ct_dim               | False                 |
+ * | Template   | diagonal           | Diagonal packing (unused on Blackhole; must be false)          | bool       | false                                   | False                 |
+ * | Template   | narrow_row         | Whether the provided input is narrow                           | bool       | true/false                              | False                 |
+ * | Template   | row_num_datums     | Number of datums per row                                        | uint32_t   | >= 1                                    | False                 |
+ * | Template   | tile_dst_ct_offset | Compile-time offset of the tile index in DEST from which to pack | uint32_t | 0 to 7 (0 to 3 if fp32 dest enabled)    | False (default = 0)   |
+ * | Template   | dense              | Packs two 2-face tiles in a single 4-face region               | bool       | true/false                              | False (default false) |
+ * | Function   | out                | Output operand (first row-major output tile address)          | LLKOperand |                                         | True                  |
+ * | Function   | block_rt_dim       | Height of the block in tiles (rows to pack)                    | uint32_t   | >= 1                                    | False (default = 1)   |
+ * | Function   | block_c_index      | Block column index (used when full_ct_dim > block_ct_dim)      | uint32_t   | >= 0                                    | False (default = 0)   |
+ * | Function   | tile_dst_rt_offset | Runtime offset of the tile index in DEST from which to pack    | uint32_t   | 0 to 7 (0 to 3 if fp32 dest enabled)    | False (default = 0)   |
+ */
+// clang-format on
+template <
+    std::uint32_t block_ct_dim = 8,
+    std::uint32_t full_ct_dim = block_ct_dim,
+    bool diagonal = false,
+    bool narrow_row = false,
+    std::uint32_t row_num_datums = TILE_C_DIM,
+    std::uint32_t tile_dst_ct_offset = 0,
+    bool dense = false,
+    DataFormat OutFormat,
+    TensorShape OutShape>
+ALWI void pack_untilize_dest(
+    LLKOperand<OutFormat, OutShape> out,
+    std::uint32_t block_rt_dim = 1,
+    std::uint32_t block_c_index = 0,
+    std::uint32_t tile_dst_rt_offset = 0) {
+    static_assert(diagonal == false, "pack_untilize_dest: diagonal is only supported on WH.");
+    static_assert(is_legal_tile_shape(OutShape), "pack_untilize_dest: illegal output tile shape.");
+    static_assert(
+        block_ct_dim > 0 && full_ct_dim % block_ct_dim == 0,
+        "pack_untilize_dest: full_ct_dim must be a positive multiple of block_ct_dim.");
+    PACK((llk_pack_untilize<
+          LLKOperand<OutFormat, OutShape>::descriptor,
+          DST_ACCUM_MODE,
+          block_ct_dim,
+          full_ct_dim,
+          narrow_row,
+          row_num_datums,
+          tile_dst_ct_offset,
+          dense>(block_rt_dim, out.l1_address, block_c_index, tile_dst_rt_offset)));
+}
+
+// clang-format off
+/**
+ * Experimental id-free pack-untilize uninit. Restores the packer Z stride (via the output descriptor's
+ * register format) and resets the packer to Default mode so a subsequent op can reprogram it. Mirrors the
+ * legacy pack_untilize_uninit (BH path).
+ */
+// clang-format on
+template <DataFormat OutFormat, TensorShape OutShape>
+ALWI void pack_untilize_uninit(LLKOperand<OutFormat, OutShape> /*out*/) {
+    PACK((llk_pack_untilize_uninit<LLKOperand<OutFormat, OutShape>::descriptor, DST_ACCUM_MODE>()));
+    PACK((_llk_init_packer_dest_offset_registers_<DST_SYNC_MODE>()));
+    PACK((llk_pack_reconfig_data_format<LLKOperand<OutFormat, OutShape>::descriptor, DST_ACCUM_MODE>()));
+    PACK((llk_pack_init<LLKOperand<OutFormat, OutShape>::descriptor, DST_ACCUM_MODE, PackMode::Default>()));
+}
+
+#endif  // ARCH_BLACKHOLE
+
+}  // namespace experimental
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/pack_untilize.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/pack_untilize.h
@@ -198,13 +198,13 @@ ALWI void pack_untilize_dest_init(LLKOperand<OutFormat, OutShape> /*out*/) {
 
 // clang-format off
 /**
- * Id-free pack-untilize of a block whose source is DEST (not a CB). Packs (untilizes) block_rt_dim tile-rows
- * already in DEST (selected by tile_dst_ct_offset / tile_dst_rt_offset) out to the row-major output at
- * out.l1_address. Blackhole only.
+ * Id-free pack-untilize of a block whose source is DEST (not an L1 operand). Packs (untilizes)
+ * block_rt_dim tile-rows already in DEST (selected by tile_dst_ct_offset / tile_dst_rt_offset) out to the
+ * row-major output at out.l1_address. Blackhole only.
  *
- * There is no input LLKOperand. The caller owns DEST synchronization (tile_regs_acquire/commit/wait/release)
- * and any CB flow control. Per-tile-row output stride is derived from the output descriptor (one tile's L1
- * size). Pair with pack_untilize_dest_init.
+ * There is no input LLKOperand. The caller owns DEST synchronization (tile_regs_acquire/commit/wait/release).
+ * Per-tile-row output stride is derived from the output descriptor (one tile's L1 size). Pair with
+ * pack_untilize_dest_init.
  *
  * | Param Type | Name               | Description                                                    | Type       | Valid Range                             | Required              |
  * |------------|--------------------|----------------------------------------------------------------|------------|-----------------------------------------|-----------------------|

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/pack_untilize.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/pack_untilize.h
@@ -24,8 +24,6 @@
 namespace ckernel {
 namespace experimental {
 
-#ifdef ARCH_BLACKHOLE
-
 // clang-format off
 /**
  * Id-free pack-untilize init. Takes an input and an output LLKOperand (data format + tile geometry as NTTPs)
@@ -267,8 +265,6 @@ ALWI void pack_untilize_uninit(LLKOperand<OutFormat, OutShape> /*out*/) {
     PACK((llk_pack_reconfig_data_format<LLKOperand<OutFormat, OutShape>::descriptor, is_fp32_dest_acc_en>()));
     PACK((llk_pack_init<LLKOperand<OutFormat, OutShape>::descriptor, is_fp32_dest_acc_en, PackMode::Default>()));
 }
-
-#endif  // ARCH_BLACKHOLE
 
 }  // namespace experimental
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/pack_untilize.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/pack_untilize.h
@@ -34,6 +34,7 @@ namespace experimental {
  * is (re)configured here. Blackhole only.
  *
  * | Template | block_ct_dim/full_ct_dim | Block width / full input width in tiles | uint32_t | | False |
+ * | Template | is_fp32_dest_acc_en      | Whether DEST is in fp32 accumulation mode | bool     | | False |
  * | Function | in                       | Input operand (tilized; format+geometry) | LLKOperand | | True |
  * | Function | out                      | Output operand (row-major destination)   | LLKOperand | | True |
  */
@@ -41,6 +42,7 @@ namespace experimental {
 template <
     std::uint32_t block_ct_dim = 8,
     std::uint32_t full_ct_dim = block_ct_dim,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
     DataFormat InFormat,
     TensorShape InShape,
     DataFormat OutFormat,
@@ -54,7 +56,7 @@ ALWI void pack_untilize_init(LLKOperand<InFormat, InShape> /*in*/, LLKOperand<Ou
     // UNPACK + MATH: configure the CB -> DEST datacopy (input format drives the SrcA/Dest register format).
     UNPACK((llk_unpack_A_init<
             LLKOperand<InFormat, InShape>::descriptor,
-            DST_ACCUM_MODE,
+            is_fp32_dest_acc_en,
             BroadcastType::NONE,
             false /*acc_to_dest*/,
             EltwiseBinaryReuseDestType::NONE,
@@ -62,7 +64,7 @@ ALWI void pack_untilize_init(LLKOperand<InFormat, InShape> /*in*/, LLKOperand<Ou
     MATH((llk_math_eltwise_unary_datacopy_init<
           LLKOperand<InFormat, InShape>::descriptor,
           DataCopyType::A2D,
-          DST_ACCUM_MODE,
+          is_fp32_dest_acc_en,
           BroadcastType::NONE,
           false /*is_int_en*/,
           PackMode::Default>()));
@@ -70,10 +72,10 @@ ALWI void pack_untilize_init(LLKOperand<InFormat, InShape> /*in*/, LLKOperand<Ou
     // PACK: (re)configure BH DEST remap, program the packer output formats, then the untilize MOP/strides
     // and the untilize dest-offset registers.
     MATH((llk_math_reconfig_remap(true /*remap_enable*/)));
-    PACK((llk_pack_reconfig_data_format<LLKOperand<OutFormat, OutShape>::descriptor, DST_ACCUM_MODE>()));
+    PACK((llk_pack_reconfig_data_format<LLKOperand<OutFormat, OutShape>::descriptor, is_fp32_dest_acc_en>()));
     PACK((llk_pack_untilize_init<
           LLKOperand<OutFormat, OutShape>::descriptor,
-          DST_ACCUM_MODE,
+          is_fp32_dest_acc_en,
           block_ct_dim,
           full_ct_dim>()));
     PACK((_llk_init_packer_dest_offset_registers_<DST_SYNC_MODE>()));
@@ -89,6 +91,7 @@ ALWI void pack_untilize_init(LLKOperand<InFormat, InShape> /*in*/, LLKOperand<Ou
  * the shipping untilize factories' one-tile CB page.
  *
  * | Template | block_ct_dim/full_ct_dim | Block width / full input width in tiles | uint32_t | | False |
+ * | Template | is_fp32_dest_acc_en | Whether DEST is in fp32 accumulation mode | bool | | False |
  * | Function | in            | Input operand (tilized; unpack base)          | LLKOperand | | True |
  * | Function | block_rt_dim  | Height of the block in tiles (rows to pack)   | uint32_t   | >= 1 | True |
  * | Function | out           | Output operand (first row-major tile address) | LLKOperand | | True |
@@ -98,6 +101,7 @@ ALWI void pack_untilize_init(LLKOperand<InFormat, InShape> /*in*/, LLKOperand<Ou
 template <
     std::uint32_t block_ct_dim = 8,
     std::uint32_t full_ct_dim = block_ct_dim,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
     DataFormat InFormat,
     TensorShape InShape,
     DataFormat OutFormat,
@@ -121,7 +125,7 @@ ALWI void pack_untilize_block(
         for (std::uint32_t c = 0; c < block_ct_dim; ++c) {
             UNPACK((llk_unpack_A<
                     LLKOperand<InFormat, InShape>::descriptor,
-                    DST_ACCUM_MODE,
+                    is_fp32_dest_acc_en,
                     BroadcastType::NONE,
                     false /*acc_to_dest*/,
                     EltwiseBinaryReuseDestType::NONE,
@@ -129,15 +133,18 @@ ALWI void pack_untilize_block(
             MATH((llk_math_eltwise_unary_datacopy<
                   LLKOperand<InFormat, InShape>::descriptor,
                   DataCopyType::A2D,
-                  DST_ACCUM_MODE,
+                  is_fp32_dest_acc_en,
                   BroadcastType::NONE,
                   UnpackToDestEn>(c)));
         }
-        MATH((llk_math_dest_section_done<DST_ACCUM_MODE>()));
+        MATH((llk_math_dest_section_done<is_fp32_dest_acc_en>()));
         PACK((llk_packer_wait_for_math_done()));
-        PACK((llk_pack_untilize<LLKOperand<OutFormat, OutShape>::descriptor, DST_ACCUM_MODE, block_ct_dim, full_ct_dim>(
-            1 /*block_rt_dim*/, out.l1_address, block_c_index)));
-        PACK((llk_pack_dest_section_done<DST_ACCUM_MODE>()));
+        PACK((llk_pack_untilize<
+              LLKOperand<OutFormat, OutShape>::descriptor,
+              is_fp32_dest_acc_en,
+              block_ct_dim,
+              full_ct_dim>(1 /*block_rt_dim*/, out.l1_address, block_c_index)));
+        PACK((llk_pack_dest_section_done<is_fp32_dest_acc_en>()));
     }
 }
 
@@ -156,6 +163,7 @@ ALWI void pack_untilize_block(
  * | Template   | narrow_row    | Whether the provided input is narrow              | bool       | true/false                | False                 |
  * | Template   | row_num_datums| Number of datums per row                          | uint32_t   | >= 1                      | False                 |
  * | Template   | dense         | Packs two 2-face tiles in a single 4-face region  | bool       | true/false                | False (default false) |
+ * | Template   | is_fp32_dest_acc_en | Whether DEST is in fp32 accumulation mode   | bool       |                           | False                 |
  * | Function   | out           | Output operand (row-major destination; format+geometry) | LLKOperand |                     | True                  |
  */
 // clang-format on
@@ -166,6 +174,7 @@ template <
     bool narrow_row = false,
     std::uint32_t row_num_datums = TILE_C_DIM,
     bool dense = false,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
     DataFormat OutFormat,
     TensorShape OutShape>
 ALWI void pack_untilize_dest_init(LLKOperand<OutFormat, OutShape> /*out*/) {
@@ -175,10 +184,10 @@ ALWI void pack_untilize_dest_init(LLKOperand<OutFormat, OutShape> /*out*/) {
         block_ct_dim > 0 && full_ct_dim % block_ct_dim == 0,
         "pack_untilize_dest_init: full_ct_dim must be a positive multiple of block_ct_dim.");
     MATH((llk_math_reconfig_remap(true /*remap_enable*/)));
-    PACK((llk_pack_reconfig_data_format<LLKOperand<OutFormat, OutShape>::descriptor, DST_ACCUM_MODE>()));
+    PACK((llk_pack_reconfig_data_format<LLKOperand<OutFormat, OutShape>::descriptor, is_fp32_dest_acc_en>()));
     PACK((llk_pack_untilize_init<
           LLKOperand<OutFormat, OutShape>::descriptor,
-          DST_ACCUM_MODE,
+          is_fp32_dest_acc_en,
           block_ct_dim,
           full_ct_dim,
           narrow_row,
@@ -247,14 +256,16 @@ ALWI void pack_untilize_dest(
 /**
  * Id-free pack-untilize uninit. Restores the packer Z stride (via the output descriptor's register format)
  * and resets the packer to Default mode so a subsequent op can reprogram it. Blackhole only.
+ *
+ * | Template | is_fp32_dest_acc_en | Whether DEST is in fp32 accumulation mode | bool | | False |
  */
 // clang-format on
-template <DataFormat OutFormat, TensorShape OutShape>
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE, DataFormat OutFormat, TensorShape OutShape>
 ALWI void pack_untilize_uninit(LLKOperand<OutFormat, OutShape> /*out*/) {
-    PACK((llk_pack_untilize_uninit<LLKOperand<OutFormat, OutShape>::descriptor, DST_ACCUM_MODE>()));
+    PACK((llk_pack_untilize_uninit<LLKOperand<OutFormat, OutShape>::descriptor, is_fp32_dest_acc_en>()));
     PACK((_llk_init_packer_dest_offset_registers_<DST_SYNC_MODE>()));
-    PACK((llk_pack_reconfig_data_format<LLKOperand<OutFormat, OutShape>::descriptor, DST_ACCUM_MODE>()));
-    PACK((llk_pack_init<LLKOperand<OutFormat, OutShape>::descriptor, DST_ACCUM_MODE, PackMode::Default>()));
+    PACK((llk_pack_reconfig_data_format<LLKOperand<OutFormat, OutShape>::descriptor, is_fp32_dest_acc_en>()));
+    PACK((llk_pack_init<LLKOperand<OutFormat, OutShape>::descriptor, is_fp32_dest_acc_en, PackMode::Default>()));
 }
 
 #endif  // ARCH_BLACKHOLE

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/pack_untilize.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/pack_untilize.h
@@ -96,9 +96,11 @@ ALWI void pack_untilize_init(LLKOperand<InFormat, InShape> /*in*/, LLKOperand<Ou
  *   handle, so llk_pack_untilize derives that per-row stride from the OUTPUT descriptor via
  *   tile_stride_words == one tile's L1 size; the input per-tile unpack base uses the same for InShape.
  *   The shipping untilize factories set both CB pages to one tile (in/out_single_tile_size), so this matches
- *   fifo_page_size for every format they use: geometry-exact for linear formats, exp section included for
- *   block floats. Remaining edge (no shipping op hits it): padded/multi-tile pages, and partial/tiny BFP
- *   tiles (tile_stride_words uses full-tile BFP size).
+ *   fifo_page_size for every format they use:
+ *     - linear formats (Float32/Float16/int): geometry-exact datum-count size (SCALE_DATUM_SIZE >> 4);
+ *     - block floats (Bfp8/Bfp4/Bfp2): mantissa + shared-exponent section, both scaled by the tile geometry
+ *       (matches tt_metal Tile::get_tile_size / the shipping CB page; see internal/llk_descriptor.h::tile_stride_words).
+ *   Remaining edge (no shipping op hits it): padded / multi-tile CB pages.
  *
  * | Template | block_ct_dim/full_ct_dim | Block width / full input width in tiles | uint32_t | | False |
  * | Function | in            | Input operand (tilized; unpack base)          | LLKOperand | | True |

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/pack_untilize.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/pack_untilize.h
@@ -81,17 +81,19 @@ ALWI void pack_untilize_init(LLKOperand<InFormat, InShape> /*in*/, LLKOperand<Ou
 
 // clang-format off
 /**
- * Id-free pack-untilize of one block. Owns the row/column loops and self-syncs DEST. Reads from in.l1_address
- * (unpack base; offset per tile by InShape's stride) and writes the block's first row-major output tile to
- * out.l1_address. Blackhole only.
+ * Id-free pack-untilize of one block. Owns the column loop and self-syncs DEST. Reads from in.l1_address
+ * (unpack base; offset per column tile by InShape's stride) and writes the block's first row-major output
+ * tile to out.l1_address. Blackhole only.
  *
- * Per-row output stride is one tile's L1 size, derived at compile time from the output descriptor -- matches
- * the shipping untilize factories' one-tile CB page.
+ * block_rt_dim is an NTTP and must be 1: the loop does not stride in/out across rows (every r unpacks
+ * c = 0..ct-1 from the same base and packs to the same out.l1_address). Legacy hid this behind CB fifo
+ * auto-increment. When row stride is wired (tile_address(in, r * block_ct_dim + c) and a matching output
+ * stride), lift the static_assert.
  *
  * | Template | block_ct_dim/full_ct_dim | Block width / full input width in tiles | uint32_t | | False |
  * | Template | is_fp32_dest_acc_en | Whether DEST is in fp32 accumulation mode | bool | | False |
+ * | Template | block_rt_dim  | Height of the block in tiles (rows to pack)   | uint32_t   | 1 | False |
  * | Function | in            | Input operand (tilized; unpack base)          | LLKOperand | | True |
- * | Function | block_rt_dim  | Height of the block in tiles (rows to pack)   | uint32_t   | >= 1 | True |
  * | Function | out           | Output operand (first row-major tile address) | LLKOperand | | True |
  * | Function | block_c_index | Block column index (when full_ct_dim > block_ct_dim) | uint32_t | >= 0 | False |
  */
@@ -100,20 +102,22 @@ template <
     std::uint32_t block_ct_dim = 8,
     std::uint32_t full_ct_dim = block_ct_dim,
     bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    std::uint32_t block_rt_dim = 1,
     DataFormat InFormat,
     TensorShape InShape,
     DataFormat OutFormat,
     TensorShape OutShape>
 ALWI void pack_untilize_block(
-    LLKOperand<InFormat, InShape> in,
-    std::uint32_t block_rt_dim,
-    LLKOperand<OutFormat, OutShape> out,
-    std::uint32_t block_c_index = 0) {
+    LLKOperand<InFormat, InShape> in, LLKOperand<OutFormat, OutShape> out, std::uint32_t block_c_index = 0) {
     static_assert(is_legal_tile_shape(InShape), "pack_untilize_block: illegal input tile shape.");
     static_assert(is_legal_tile_shape(OutShape), "pack_untilize_block: illegal output tile shape.");
     static_assert(
         block_ct_dim > 0 && full_ct_dim % block_ct_dim == 0,
         "pack_untilize_block: full_ct_dim must be a positive multiple of block_ct_dim.");
+    static_assert(
+        block_rt_dim == 1,
+        "pack_untilize_block: block_rt_dim > 1 is not supported (no in/out row stride; would re-read "
+        "and overwrite the first row).");
     // Per-tile input stride (16B words) == one tile's L1 size, folded to a compile-time constant via
     // tile_stride_words: geometry-exact for linear formats, exp section included for block floats.
     constexpr std::uint32_t in_tile_stride = tile_stride_words(InFormat, InShape);

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/pack_untilize.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/pack_untilize.h
@@ -217,6 +217,7 @@ ALWI void pack_untilize_dest_init(LLKOperand<OutFormat, OutShape> /*out*/) {
  * | Template   | row_num_datums     | Number of datums per row                                        | uint32_t   | >= 1                                    | False                 |
  * | Template   | tile_dst_ct_offset | Compile-time offset of the tile index in DEST from which to pack | uint32_t | 0 to 7 (0 to 3 if fp32 dest enabled)    | False (default = 0)   |
  * | Template   | dense              | Packs two 2-face tiles in a single 4-face region               | bool       | true/false                              | False (default false) |
+ * | Template   | is_fp32_dest_acc_en | Whether DEST is in fp32 accumulation mode                     | bool       |                                         | False                 |
  * | Function   | out                | Output operand (first row-major output tile address)          | LLKOperand |                                         | True                  |
  * | Function   | block_rt_dim       | Height of the block in tiles (rows to pack)                    | uint32_t   | >= 1                                    | False (default = 1)   |
  * | Function   | block_c_index      | Block column index (used when full_ct_dim > block_ct_dim)      | uint32_t   | >= 0                                    | False (default = 0)   |
@@ -231,6 +232,7 @@ template <
     std::uint32_t row_num_datums = TILE_C_DIM,
     std::uint32_t tile_dst_ct_offset = 0,
     bool dense = false,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
     DataFormat OutFormat,
     TensorShape OutShape>
 ALWI void pack_untilize_dest(
@@ -245,7 +247,7 @@ ALWI void pack_untilize_dest(
         "pack_untilize_dest: full_ct_dim must be a positive multiple of block_ct_dim.");
     PACK((llk_pack_untilize<
           LLKOperand<OutFormat, OutShape>::descriptor,
-          DST_ACCUM_MODE,
+          is_fp32_dest_acc_en,
           block_ct_dim,
           full_ct_dim,
           narrow_row,

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/reconfig_data_format.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/reconfig_data_format.h
@@ -44,8 +44,6 @@
 namespace ckernel {
 namespace experimental {
 
-#ifdef ARCH_BLACKHOLE
-
 // ---------------------------------------------------------------------------------------------------------
 // (1) reconfig_data_format_srca
 // ---------------------------------------------------------------------------------------------------------
@@ -124,8 +122,6 @@ ALWI void pack_reconfig_data_format(LLKOperand<Format, Shape> /*new_out*/) {
     static_assert(is_legal_tile_shape(Shape), "pack_reconfig_data_format: illegal output tile shape.");
     PACK((llk_pack_reconfig_data_format<LLKOperand<Format, Shape>::descriptor, DST_ACCUM_MODE>()));
 }
-
-#endif  // ARCH_BLACKHOLE
 
 }  // namespace experimental
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/reconfig_data_format.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/reconfig_data_format.h
@@ -56,21 +56,23 @@ namespace experimental {
  *
  * | Param Type | Name  | Description                                   | Type       | Valid Range | Required |
  * |------------|-------|------------------------------------------------|------------|-------------|----------|
- * | Function   | new_a | New SrcA operand (format+shape are NTTPs)     | LLKOperand | N/A         | True     |
+ * | Template   | is_fp32_dest_acc_en | fp32 dest-accumulate mode               | bool       |             | False    |
+ * | Function   | new_a               | New SrcA operand (format+shape are NTTPs) | LLKOperand | N/A         | True     |
  */
 // clang-format on
-template <DataFormat Format, TensorShape Shape>
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE, DataFormat Format, TensorShape Shape>
 ALWI void reconfig_data_format_srca(LLKOperand<Format, Shape> /*new_a*/) {
     static_assert(is_legal_tile_shape(Shape), "reconfig_data_format_srca: illegal tile shape.");
-    constexpr std::uint8_t RegFmt = static_cast<std::uint8_t>(ckernel::infer_unpack_dst_format(Format, DST_ACCUM_MODE));
+    constexpr std::uint8_t RegFmt =
+        static_cast<std::uint8_t>(ckernel::infer_unpack_dst_format(Format, is_fp32_dest_acc_en));
     constexpr std::uint32_t tile_size = tile_stride_words(Format, Shape);
-    UNPACK((_llk_unpack_reconfig_data_format_srca_impl_<DST_ACCUM_MODE, p_dim_stride_target::IGNORE, false>(
+    UNPACK((_llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, false>(
         static_cast<std::uint32_t>(Format),
         static_cast<std::uint32_t>(RegFmt),
         tile_size,
         Shape.face_r_dim,
         Shape.total_num_faces())));
-    MATH((_llk_math_reconfig_data_format_srca_<DST_ACCUM_MODE, false>(static_cast<std::uint32_t>(RegFmt))));
+    MATH((_llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en, false>(static_cast<std::uint32_t>(RegFmt))));
 }
 
 // ---------------------------------------------------------------------------------------------------------
@@ -84,21 +86,23 @@ ALWI void reconfig_data_format_srca(LLKOperand<Format, Shape> /*new_a*/) {
  *
  * | Param Type | Name  | Description                                   | Type       | Valid Range | Required |
  * |------------|-------|------------------------------------------------|------------|-------------|----------|
- * | Function   | new_b | New SrcB operand (format+shape are NTTPs)     | LLKOperand | N/A         | True     |
+ * | Template   | is_fp32_dest_acc_en | fp32 dest-accumulate mode               | bool       |             | False    |
+ * | Function   | new_b               | New SrcB operand (format+shape are NTTPs) | LLKOperand | N/A         | True     |
  */
 // clang-format on
-template <DataFormat Format, TensorShape Shape>
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE, DataFormat Format, TensorShape Shape>
 ALWI void reconfig_data_format_srcb(LLKOperand<Format, Shape> /*new_b*/) {
     static_assert(is_legal_tile_shape(Shape), "reconfig_data_format_srcb: illegal tile shape.");
-    constexpr std::uint8_t RegFmt = static_cast<std::uint8_t>(ckernel::infer_unpack_dst_format(Format, DST_ACCUM_MODE));
+    constexpr std::uint8_t RegFmt =
+        static_cast<std::uint8_t>(ckernel::infer_unpack_dst_format(Format, is_fp32_dest_acc_en));
     constexpr std::uint32_t tile_size = tile_stride_words(Format, Shape);
-    UNPACK((_llk_unpack_reconfig_data_format_srcb_impl_<DST_ACCUM_MODE, p_dim_stride_target::IGNORE, false>(
+    UNPACK((_llk_unpack_reconfig_data_format_srcb_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, false>(
         static_cast<std::uint32_t>(Format),
         static_cast<std::uint32_t>(RegFmt),
         tile_size,
         Shape.face_r_dim,
         Shape.total_num_faces())));
-    MATH((_llk_math_reconfig_data_format_srcb_<DST_ACCUM_MODE, false>(static_cast<std::uint32_t>(RegFmt))));
+    MATH((_llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en, false>(static_cast<std::uint32_t>(RegFmt))));
 }
 
 // ---------------------------------------------------------------------------------------------------------
@@ -114,13 +118,14 @@ ALWI void reconfig_data_format_srcb(LLKOperand<Format, Shape> /*new_b*/) {
  *
  * | Param Type | Name    | Description                                    | Type       | Valid Range | Required |
  * |------------|---------|-------------------------------------------------|------------|-------------|----------|
- * | Function   | new_out | New output operand (format+shape are NTTPs)   | LLKOperand | N/A         | True     |
+ * | Template   | is_fp32_dest_acc_en | fp32 dest-accumulate mode                    | bool       |             | False    |
+ * | Function   | new_out             | New output operand (format+shape are NTTPs)   | LLKOperand | N/A         | True     |
  */
 // clang-format on
-template <DataFormat Format, TensorShape Shape>
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE, DataFormat Format, TensorShape Shape>
 ALWI void pack_reconfig_data_format(LLKOperand<Format, Shape> /*new_out*/) {
     static_assert(is_legal_tile_shape(Shape), "pack_reconfig_data_format: illegal output tile shape.");
-    PACK((llk_pack_reconfig_data_format<LLKOperand<Format, Shape>::descriptor, DST_ACCUM_MODE>()));
+    PACK((llk_pack_reconfig_data_format<LLKOperand<Format, Shape>::descriptor, is_fp32_dest_acc_en>()));
 }
 
 }  // namespace experimental

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/reconfig_data_format.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/reconfig_data_format.h
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "api/compute/common_globals.h"
+#include "api/compute/experimental/2_0/llk_operand.h"
+#include "data_format_derive.h"  // ckernel::infer_unpack_dst_format -- register-format derivation (BH)
+
+#ifdef TRISC_UNPACK
+// p_dim_stride_target + the raw UNPACK cores _llk_unpack_reconfig_data_format_srca_impl_/_srcb_impl_ (via
+// the transitively-included llk_unpack_common.h). No id-free (LLKMemDescriptor-NTTP) unpack reconfig LLK
+// exists yet, so this file calls straight through to the raw cores with a compile-time-resolved register
+// format, bypassing the CB-id operand-array lookups the legacy llk_unpack_reconfig_data_format_srca(operand)
+// wrapper does.
+#include "llk_unpack_common_api.h"
+#endif
+
+#ifdef TRISC_MATH
+// The raw MATH cores _llk_math_reconfig_data_format_srca_/_srcb_ (via the transitively-included
+// llk_math_common.h). Same rationale as TRISC_UNPACK above -- no id-free MATH reconfig LLK exists yet.
+#include "llk_math_common_api.h"
+#endif
+
+#ifdef TRISC_PACK
+// The id-free packer reconfig ALREADY EXISTS here: llk_pack_reconfig_data_format<LLKMemDescriptor, bool>().
+// This file only wraps it; no new PACK-side LLK code is written.
+#include "experimental/2_0/llk_pack_tile.h"
+#endif
+
+// =====================================================================================================
+// Id-free (2.0) reconfig_data_format -- SINGLE-OPERAND CORE surfaces only. Ports the three 1-operand CORE
+// overloads of the legacy tt_metal/hw/inc/api/compute/reconfig_data_format.h to the id-free LLKOperand
+// pattern:
+//
+//   1. reconfig_data_format_srca(new_a)   -- always re-derives + programs the SrcA format
+//   2. reconfig_data_format_srcb(new_b)   -- always re-derives + programs the SrcB format
+//   3. pack_reconfig_data_format(new_out) -- wraps the EXISTING id-free
+//                                            llk_pack_reconfig_data_format<DESC,...>() from llk_pack_tile.h
+//
+// Each call unconditionally reprograms its operand's format -- the id-free surface deliberately keeps ONLY
+// the single-`LLKOperand` forms. The legacy 2-arg (old,new) "skip if format unchanged" variants and the
+// both-src reconfig_data_format(new_a,new_b)/(old_a,new_a,old_b,new_b) forms are intentionally NOT ported:
+// with compile-time NTTP formats a caller that would benefit from the skip simply omits the call, so the
+// old/new pairs and the two-operand exponent-width reconciliation add no value on the id-free surface.
+//
+// No id-free (LLKMemDescriptor-NTTP) UNPACK/MATH reconfig LLK exists yet (only the PACK side does, reused
+// by pack_untilize). For srcA/srcB this file therefore derives the register format itself (via
+// ckernel::infer_unpack_dst_format, data_format_derive.h) and calls the RAW per-arch cores directly
+// (_llk_unpack_reconfig_data_format_srca_impl_ / _srcb_impl_, and _llk_math_reconfig_data_format_srca_ /
+// _srcb_), bypassing the CB-id operand-array lookups the legacy llk_*_api.h wrappers do. No new llk_*_api.h
+// file is created.
+//
+// DEFERRED (not ported -- see handoff for the full list): the 2-arg (old,new) skip variants; both-src
+// reconfig_data_format; reconfig_full_operand[_srca/_srcb] (tile/face geometry); reconfig_tile_shape
+// [_srca/_srcb] (shape-only, no format); the *_skip_int8 surface; SrcOrder (matmul operand-swap
+// convenience); and all deprecated <bool,bool>/<to_from_int8,...> overloads.
+// =====================================================================================================
+
+namespace ckernel {
+namespace experimental {
+
+#ifdef ARCH_BLACKHOLE
+
+// ---------------------------------------------------------------------------------------------------------
+// (1) reconfig_data_format_srca
+// ---------------------------------------------------------------------------------------------------------
+
+// clang-format off
+/**
+ * Reconfigures the SrcA unpacker/math data format for a new operand, always re-deriving the register format
+ * from the new L1 format (id-free equivalent of legacy reconfig_data_format_srca(new_operand)). Derives the
+ * SrcA register format from `Format` via infer_unpack_dst_format(Format, DST_ACCUM_MODE), then reprograms the
+ * UNPACK tile descriptor/format registers (raw core, dim_stride_target = IGNORE -- geometry untouched,
+ * matching the legacy reconfig_data_format family, not reconfig_full_operand) and the MATH INT8-enable bit.
+ *
+ * | Param Type | Name  | Description                                   | Type       | Valid Range | Required |
+ * |------------|-------|------------------------------------------------|------------|-------------|----------|
+ * | Function   | new_a | New SrcA operand (format+shape are NTTPs)     | LLKOperand | N/A         | True     |
+ */
+// clang-format on
+template <DataFormat Format, TensorShape Shape>
+ALWI void reconfig_data_format_srca(LLKOperand<Format, Shape> /*new_a*/) {
+    static_assert(is_legal_tile_shape(Shape), "reconfig_data_format_srca: illegal tile shape.");
+    constexpr std::uint8_t RegFmt = static_cast<std::uint8_t>(ckernel::infer_unpack_dst_format(Format, DST_ACCUM_MODE));
+    constexpr std::uint32_t tile_size = tile_stride_words(Format, Shape);
+    UNPACK((_llk_unpack_reconfig_data_format_srca_impl_<DST_ACCUM_MODE, p_dim_stride_target::IGNORE, false>(
+        static_cast<std::uint32_t>(Format),
+        static_cast<std::uint32_t>(RegFmt),
+        tile_size,
+        Shape.face_r_dim,
+        Shape.total_num_faces())));
+    MATH((_llk_math_reconfig_data_format_srca_<DST_ACCUM_MODE, false>(static_cast<std::uint32_t>(RegFmt))));
+}
+
+// ---------------------------------------------------------------------------------------------------------
+// (2) reconfig_data_format_srcb
+// ---------------------------------------------------------------------------------------------------------
+
+// clang-format off
+/**
+ * Reconfigures the SrcB unpacker/math data format for a new operand, always re-deriving the register format
+ * from the new L1 format (id-free equivalent of legacy reconfig_data_format_srcb(new_operand)). Mirrors
+ * reconfig_data_format_srca for SrcB. Does not reprogram tile/face geometry.
+ *
+ * | Param Type | Name  | Description                                   | Type       | Valid Range | Required |
+ * |------------|-------|------------------------------------------------|------------|-------------|----------|
+ * | Function   | new_b | New SrcB operand (format+shape are NTTPs)     | LLKOperand | N/A         | True     |
+ */
+// clang-format on
+template <DataFormat Format, TensorShape Shape>
+ALWI void reconfig_data_format_srcb(LLKOperand<Format, Shape> /*new_b*/) {
+    static_assert(is_legal_tile_shape(Shape), "reconfig_data_format_srcb: illegal tile shape.");
+    constexpr std::uint8_t RegFmt = static_cast<std::uint8_t>(ckernel::infer_unpack_dst_format(Format, DST_ACCUM_MODE));
+    constexpr std::uint32_t tile_size = tile_stride_words(Format, Shape);
+    UNPACK((_llk_unpack_reconfig_data_format_srcb_impl_<DST_ACCUM_MODE, p_dim_stride_target::IGNORE, false>(
+        static_cast<std::uint32_t>(Format),
+        static_cast<std::uint32_t>(RegFmt),
+        tile_size,
+        Shape.face_r_dim,
+        Shape.total_num_faces())));
+    MATH((_llk_math_reconfig_data_format_srcb_<DST_ACCUM_MODE, false>(static_cast<std::uint32_t>(RegFmt))));
+}
+
+// ---------------------------------------------------------------------------------------------------------
+// (3) pack_reconfig_data_format -- thin wrapper over the EXISTING id-free LLK
+// (llk_pack_reconfig_data_format<LLKMemDescriptor, bool> in llk_pack_tile.h, already used by pack_untilize).
+// No new PACK-side LLK code; this is purely the compute-API-layer surface.
+// ---------------------------------------------------------------------------------------------------------
+
+// clang-format off
+/**
+ * Reconfigures the packer output data format for a new output operand. Always performs the reconfiguration
+ * (id-free equivalent of legacy pack_reconfig_data_format(new_cb_id)); reprograms only src/dst format
+ * registers + tile geometry, not tile-dimension addrmod state (is_tile_dim_reconfig_en is not ported --
+ * deferred, see handoff).
+ *
+ * | Param Type | Name    | Description                                    | Type       | Valid Range | Required |
+ * |------------|---------|-------------------------------------------------|------------|-------------|----------|
+ * | Function   | new_out | New output operand (format+shape are NTTPs)   | LLKOperand | N/A         | True     |
+ */
+// clang-format on
+template <DataFormat Format, TensorShape Shape>
+ALWI void pack_reconfig_data_format(LLKOperand<Format, Shape> /*new_out*/) {
+    static_assert(is_legal_tile_shape(Shape), "pack_reconfig_data_format: illegal output tile shape.");
+    PACK((llk_pack_reconfig_data_format<LLKOperand<Format, Shape>::descriptor, DST_ACCUM_MODE>()));
+}
+
+#endif  // ARCH_BLACKHOLE
+
+}  // namespace experimental
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/reconfig_data_format.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/reconfig_data_format.h
@@ -11,53 +11,34 @@
 #include "data_format_derive.h"  // ckernel::infer_unpack_dst_format -- register-format derivation (BH)
 
 #ifdef TRISC_UNPACK
-// p_dim_stride_target + the raw UNPACK cores _llk_unpack_reconfig_data_format_srca_impl_/_srcb_impl_ (via
-// the transitively-included llk_unpack_common.h). No id-free (LLKMemDescriptor-NTTP) unpack reconfig LLK
-// exists yet, so this file calls straight through to the raw cores with a compile-time-resolved register
-// format, bypassing the CB-id operand-array lookups the legacy llk_unpack_reconfig_data_format_srca(operand)
-// wrapper does.
+// Raw UNPACK cores (_llk_unpack_reconfig_data_format_srca_impl_/_srcb_impl_); no id-free unpack reconfig LLK
+// exists yet, so this file calls through directly with a compile-time-resolved register format.
 #include "llk_unpack_common_api.h"
 #endif
 
 #ifdef TRISC_MATH
-// The raw MATH cores _llk_math_reconfig_data_format_srca_/_srcb_ (via the transitively-included
-// llk_math_common.h). Same rationale as TRISC_UNPACK above -- no id-free MATH reconfig LLK exists yet.
+// Raw MATH cores (_llk_math_reconfig_data_format_srca_/_srcb_); no id-free MATH reconfig LLK exists yet either.
 #include "llk_math_common_api.h"
 #endif
 
 #ifdef TRISC_PACK
-// The id-free packer reconfig ALREADY EXISTS here: llk_pack_reconfig_data_format<LLKMemDescriptor, bool>().
-// This file only wraps it; no new PACK-side LLK code is written.
+// Id-free packer reconfig already exists (llk_pack_reconfig_data_format<LLKMemDescriptor, bool>()); this
+// file just wraps it.
 #include "experimental/2_0/llk_pack_tile.h"
 #endif
 
 // =====================================================================================================
-// Id-free (2.0) reconfig_data_format -- SINGLE-OPERAND CORE surfaces only. Ports the three 1-operand CORE
-// overloads of the legacy tt_metal/hw/inc/api/compute/reconfig_data_format.h to the id-free LLKOperand
-// pattern:
+// Id-free (2.0) reconfig_data_format -- single-operand surfaces only. Reprograms the srca / srcb / pack
+// register data format from a new operand's descriptor NTTP:
 //
-//   1. reconfig_data_format_srca(new_a)   -- always re-derives + programs the SrcA format
-//   2. reconfig_data_format_srcb(new_b)   -- always re-derives + programs the SrcB format
-//   3. pack_reconfig_data_format(new_out) -- wraps the EXISTING id-free
-//                                            llk_pack_reconfig_data_format<DESC,...>() from llk_pack_tile.h
+//   1. reconfig_data_format_srca(new_a)   -- reprograms the SrcA format
+//   2. reconfig_data_format_srcb(new_b)   -- reprograms the SrcB format
+//   3. pack_reconfig_data_format(new_out) -- wraps the existing id-free llk_pack_reconfig_data_format<...>()
 //
-// Each call unconditionally reprograms its operand's format -- the id-free surface deliberately keeps ONLY
-// the single-`LLKOperand` forms. The legacy 2-arg (old,new) "skip if format unchanged" variants and the
-// both-src reconfig_data_format(new_a,new_b)/(old_a,new_a,old_b,new_b) forms are intentionally NOT ported:
-// with compile-time NTTP formats a caller that would benefit from the skip simply omits the call, so the
-// old/new pairs and the two-operand exponent-width reconciliation add no value on the id-free surface.
-//
-// No id-free (LLKMemDescriptor-NTTP) UNPACK/MATH reconfig LLK exists yet (only the PACK side does, reused
-// by pack_untilize). For srcA/srcB this file therefore derives the register format itself (via
-// ckernel::infer_unpack_dst_format, data_format_derive.h) and calls the RAW per-arch cores directly
-// (_llk_unpack_reconfig_data_format_srca_impl_ / _srcb_impl_, and _llk_math_reconfig_data_format_srca_ /
-// _srcb_), bypassing the CB-id operand-array lookups the legacy llk_*_api.h wrappers do. No new llk_*_api.h
-// file is created.
-//
-// DEFERRED (not ported -- see handoff for the full list): the 2-arg (old,new) skip variants; both-src
-// reconfig_data_format; reconfig_full_operand[_srca/_srcb] (tile/face geometry); reconfig_tile_shape
-// [_srca/_srcb] (shape-only, no format); the *_skip_int8 surface; SrcOrder (matmul operand-swap
-// convenience); and all deprecated <bool,bool>/<to_from_int8,...> overloads.
+// Each call unconditionally reprograms its operand's format (format only; tile/face geometry is untouched).
+// Since formats are compile-time NTTPs, a caller that wants to skip a call simply omits it: the legacy 2-arg
+// (old,new) "skip if unchanged" variants and the both-src forms are not ported, nor are the geometry-aware
+// forms (reconfig_full_operand, reconfig_tile_shape) or the SrcOrder / deprecated overloads. Blackhole only.
 // =====================================================================================================
 
 namespace ckernel {
@@ -71,11 +52,9 @@ namespace experimental {
 
 // clang-format off
 /**
- * Reconfigures the SrcA unpacker/math data format for a new operand, always re-deriving the register format
- * from the new L1 format (id-free equivalent of legacy reconfig_data_format_srca(new_operand)). Derives the
- * SrcA register format from `Format` via infer_unpack_dst_format(Format, DST_ACCUM_MODE), then reprograms the
- * UNPACK tile descriptor/format registers (raw core, dim_stride_target = IGNORE -- geometry untouched,
- * matching the legacy reconfig_data_format family, not reconfig_full_operand) and the MATH INT8-enable bit.
+ * Reprograms the SrcA unpacker/math data format for a new operand. Derives the SrcA register format from
+ * `Format` via infer_unpack_dst_format, then reprograms the UNPACK format registers and the MATH INT8-enable
+ * bit. Tile/face geometry is not touched.
  *
  * | Param Type | Name  | Description                                   | Type       | Valid Range | Required |
  * |------------|-------|------------------------------------------------|------------|-------------|----------|
@@ -102,9 +81,8 @@ ALWI void reconfig_data_format_srca(LLKOperand<Format, Shape> /*new_a*/) {
 
 // clang-format off
 /**
- * Reconfigures the SrcB unpacker/math data format for a new operand, always re-deriving the register format
- * from the new L1 format (id-free equivalent of legacy reconfig_data_format_srcb(new_operand)). Mirrors
- * reconfig_data_format_srca for SrcB. Does not reprogram tile/face geometry.
+ * Reprograms the SrcB unpacker/math data format for a new operand. Mirrors reconfig_data_format_srca for
+ * SrcB; tile/face geometry is not touched.
  *
  * | Param Type | Name  | Description                                   | Type       | Valid Range | Required |
  * |------------|-------|------------------------------------------------|------------|-------------|----------|
@@ -133,10 +111,8 @@ ALWI void reconfig_data_format_srcb(LLKOperand<Format, Shape> /*new_b*/) {
 
 // clang-format off
 /**
- * Reconfigures the packer output data format for a new output operand. Always performs the reconfiguration
- * (id-free equivalent of legacy pack_reconfig_data_format(new_cb_id)); reprograms only src/dst format
- * registers + tile geometry, not tile-dimension addrmod state (is_tile_dim_reconfig_en is not ported --
- * deferred, see handoff).
+ * Reprograms the packer output data format for a new output operand. Updates src/dst format registers and
+ * tile geometry; does not reconfigure tile-dimension addrmod state (is_tile_dim_reconfig_en is not ported).
  *
  * | Param Type | Name    | Description                                    | Type       | Valid Range | Required |
  * |------------|---------|-------------------------------------------------|------------|-------------|----------|

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/reduce.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/reduce.h
@@ -23,8 +23,6 @@
 namespace ckernel {
 namespace experimental {
 
-#ifdef ARCH_BLACKHOLE
-
 // Id-free (2.0) reduce (data + scaler -> reduced). Takes one LLKOperand per input (data, scaler) and one for
 // the output. Format-free at the op level (formats set at compute_kernel_hw_startup); every LLK core here
 // consumes only geometry (data tile shape / output face_r_dim) + the two runtime input addresses. Geometry
@@ -183,8 +181,6 @@ ALWI void reduce_uninit() {
     MATH((llk_math_reduce_uninit()));
     PACK((llk_pack_reduce_mask_clear()));
 }
-
-#endif  // ARCH_BLACKHOLE
 
 }  // namespace experimental
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/reduce.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/reduce.h
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/common_globals.h"
+#include "api/compute/experimental/2_0/llk_operand.h"
+
+#ifdef TRISC_MATH
+#include "llk_math_reduce_api.h"
+#endif
+
+#ifdef TRISC_UNPACK
+#include "llk_unpack_AB_reduce_api.h"
+#endif
+
+#ifdef TRISC_PACK
+#include "llk_pack_reduce_api.h"
+#endif
+
+namespace ckernel {
+namespace experimental {
+
+#ifdef ARCH_BLACKHOLE
+
+// Id-free (2.0) reduce (data + scaler -> reduced). Takes one LLKOperand per input (data, scaler) and one for
+// the output. Reduce is FORMAT-FREE at the op level (formats set at compute_kernel_hw_startup); every LLK
+// core here consumes only geometry (data tile shape / output face_r_dim) + the two runtime input addresses, so
+// there is no id-free LLK header -- the compute op calls the api-level unified cores directly with the
+// descriptor-extracted values. Geometry (for MATH + unpack init) comes from the DATA operand, matching legacy.
+// Packing is separate (experimental::pack_tile); the packer edge mask is programmed here by reduce_init.
+
+// clang-format off
+/**
+ * Reduce init: programs UNPACK (AB reduce), MATH (reduce init), and the PACK edge-mask for the reduction.
+ * compute_kernel_hw_startup(data_cb, scaler_cb, out_cb) must already have programmed the formats.
+ *
+ * | Template | reduce_type | SUM / AVG / MAX                                | PoolType  | | True |
+ * | Template | reduce_dim  | REDUCE_ROW / REDUCE_COL / REDUCE_SCALAR       | ReduceDim | | True |
+ * | Function | data        | Input operand A (reduced); drives geometry    | LLKOperand | | True |
+ * | Function | out         | Output operand (drives the packer edge mask)  | LLKOperand | | True |
+ *
+ * NOTE (PART B): the init uses only the DATA geometry (unpack/math) and the OUT face_r_dim (packer edge
+ * mask). The scaler operand contributes nothing to init, so it is not taken here; it is still passed to
+ * reduce_tile (which needs its address + stride).
+ */
+// clang-format on
+template <PoolType reduce_type, ReduceDim reduce_dim, DataFormat DF, TensorShape DS, DataFormat OF, TensorShape OS>
+ALWI void reduce_init(LLKOperand<DF, DS> /*data*/, LLKOperand<OF, OS> /*out*/) {
+    static_assert(is_legal_tile_shape(DS), "reduce_init: illegal data tile shape.");
+    static_assert(is_legal_tile_shape(OS), "reduce_init: illegal output tile shape.");
+    UNPACK((llk_unpack_AB_reduce_init_impl<reduce_type, reduce_dim>(DS)));
+    MATH((llk_math_reduce_init_impl<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(DS)));
+    PACK((llk_pack_reduce_mask_config_impl<reduce_dim, PackMode::Default>(OS.face_r_dim)));
+}
+
+// clang-format off
+/**
+ * Reduce one tile of data (with the scaler tile) into DST[idst]. Pair with reduce_init. DST must be acquired.
+ * itile / itile_scaler index within data / scaler. Per-tile input addresses are derived from each operand's
+ * geometry via tile_stride_words (one-tile page; exp section included for block floats).
+ *
+ * | Function | data / scaler          | Input operands                    | LLKOperand | | True |
+ * | Function | itile / itile_scaler   | Tile indices within data / scaler | uint32_t   | | True |
+ * | Function | idst                   | DST register index for the result | uint32_t   | | True |
+ */
+// clang-format on
+template <PoolType reduce_type, ReduceDim reduce_dim, DataFormat DF, TensorShape DS, DataFormat SF, TensorShape SS>
+ALWI void reduce_tile(
+    LLKOperand<DF, DS> data,
+    LLKOperand<SF, SS> scaler,
+    std::uint32_t itile,
+    std::uint32_t itile_scaler,
+    std::uint32_t idst) {
+    static_assert(is_legal_tile_shape(DS), "reduce_tile: illegal data tile shape.");
+    static_assert(is_legal_tile_shape(SS), "reduce_tile: illegal scaler tile shape.");
+    // REDUCE_ROW for any pool other than MAX physically swaps the SrcA/SrcB byte streams in the LLK, but the
+    // src-register formats are programmed once at compute_kernel_hw_startup and not re-derived here -- so the
+    // swap only produces correct results when the data and scaler share one L1 format.
+    static_assert(
+        !(reduce_dim == ReduceDim::REDUCE_ROW && reduce_type != PoolType::MAX) || DF == SF,
+        "reduce_tile: REDUCE_ROW (non-MAX) swaps SrcA/SrcB, so data and scaler must have the same data format.");
+    // Match legacy reduce_tile order: MATH then UNPACK.
+    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(idst, DS)));
+    UNPACK((llk_unpack_AB_reduce_impl<reduce_type, reduce_dim>(
+        detail::tile_address(data, itile), detail::tile_address(scaler, itile_scaler))));
+}
+
+// clang-format off
+/**
+ * Reduce `ntiles` consecutive data tiles (each combined with the scaler tile), writing each tile's reduction
+ * to its OWN DST slot: data tile (start_itile + i) -> DST[start_idst + i]. Block/loop form of reduce_tile,
+ * matching the legacy reduce_block N-in / N-out semantics (api/compute/reduce.h) exactly -- it is NOT a
+ * cross-block accumulation into one slot (a caller wanting that loops reduce_tile at a fixed idst). Reuses the
+ * existing 2.0 reduce_tile per tile; per-tile source addressing is inherited from reduce_tile (itile advances
+ * by tile_stride_words internally). Pair with reduce_init. DST must be acquired.
+ *
+ * | Template | reduce_type   | SUM / AVG / MAX                                 | PoolType   | | True |
+ * | Template | reduce_dim    | REDUCE_ROW / REDUCE_COL / REDUCE_SCALAR        | ReduceDim  | | True |
+ * | Function | data / scaler | Input operands                                 | LLKOperand | | True |
+ * | Function | start_itile   | Index of the first data tile within `data`     | uint32_t   | | True |
+ * | Function | itile_scaler  | Tile index within `scaler`                      | uint32_t   | | True |
+ * | Function | start_idst    | DST register index for the first tile's result | uint32_t   | start_idst + ntiles <= DST size | True |
+ * | Function | ntiles        | Number of consecutive data tiles to reduce     | uint32_t   | | True |
+ */
+// clang-format on
+template <PoolType reduce_type, ReduceDim reduce_dim, DataFormat DF, TensorShape DS, DataFormat SF, TensorShape SS>
+ALWI void reduce_block(
+    LLKOperand<DF, DS> data,
+    LLKOperand<SF, SS> scaler,
+    std::uint32_t start_itile,
+    std::uint32_t itile_scaler,
+    std::uint32_t start_idst,
+    std::uint32_t ntiles) {
+    static_assert(is_legal_tile_shape(DS), "reduce_block: illegal data tile shape.");
+    static_assert(is_legal_tile_shape(SS), "reduce_block: illegal scaler tile shape.");
+    for (std::uint32_t i = 0; i < ntiles; ++i) {
+        reduce_tile<reduce_type, reduce_dim>(data, scaler, start_itile + i, itile_scaler, start_idst + i);
+    }
+}
+
+// clang-format off
+/**
+ * Reduce uninit: reset the MATH reduce state and clear the packer edge mask back to default.
+ */
+// clang-format on
+ALWI void reduce_uninit() {
+    MATH((llk_math_reduce_uninit()));
+    PACK((llk_pack_reduce_mask_clear()));
+}
+
+#endif  // ARCH_BLACKHOLE
+
+}  // namespace experimental
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/reduce.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/reduce.h
@@ -144,15 +144,16 @@ ALWI void reduce_block(
  * Geometry comes from num_faces (row-major face layout). Pair with reduce_init. DST must be acquired. For a
  * non-default face layout, use the TensorShape overload below.
  *
- * | Template | reduce_type | SUM / AVG / MAX                          | PoolType  | | True |
- * | Template | reduce_dim  | REDUCE_ROW / REDUCE_COL / REDUCE_SCALAR | ReduceDim | | True |
- * | Function | idst        | DST register index for the result       | uint32_t  | | True |
- * | Function | num_faces   | Number of faces to reduce (default 4)   | uint32_t  | 1 / 2 / 4 | False |
+ * | Template | reduce_type         | SUM / AVG / MAX                          | PoolType  | | True |
+ * | Template | reduce_dim          | REDUCE_ROW / REDUCE_COL / REDUCE_SCALAR | ReduceDim | | True |
+ * | Template | is_fp32_dest_acc_en | fp32 dest-accumulate mode                | bool      | | False |
+ * | Function | idst                | DST register index for the result       | uint32_t  | | True |
+ * | Function | num_faces           | Number of faces to reduce (default 4)   | uint32_t  | 1 / 2 / 4 | False |
  */
 // clang-format on
-template <PoolType reduce_type, ReduceDim reduce_dim>
+template <PoolType reduce_type, ReduceDim reduce_dim, bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 ALWI void reduce_tile_math(std::uint32_t idst, std::uint32_t num_faces = MAX_NUM_FACES) {
-    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(
+    MATH((llk_math_reduce<reduce_type, reduce_dim, is_fp32_dest_acc_en, MATH_FIDELITY>(
         idst, tensor_shape_from_num_faces(MAX_FACE_R_DIM, num_faces))));
 }
 
@@ -161,15 +162,16 @@ ALWI void reduce_tile_math(std::uint32_t idst, std::uint32_t num_faces = MAX_NUM
  * Math-only reduction into DST[idst] with an explicit tile geometry. As above, source tiles must already be
  * in the source registers; takes no LLKOperand. Pair with reduce_init. DST must be acquired.
  *
- * | Template | reduce_type  | SUM / AVG / MAX                          | PoolType             | | True |
- * | Template | reduce_dim   | REDUCE_ROW / REDUCE_COL / REDUCE_SCALAR | ReduceDim            | | True |
- * | Function | idst         | DST register index for the result       | uint32_t             | | True |
- * | Function | tensor_shape | Tile geometry to reduce                  | ckernel::TensorShape | | True |
+ * | Template | reduce_type         | SUM / AVG / MAX                          | PoolType             | | True |
+ * | Template | reduce_dim          | REDUCE_ROW / REDUCE_COL / REDUCE_SCALAR | ReduceDim            | | True |
+ * | Template | is_fp32_dest_acc_en | fp32 dest-accumulate mode                | bool                 | | False |
+ * | Function | idst                | DST register index for the result       | uint32_t             | | True |
+ * | Function | tensor_shape        | Tile geometry to reduce                  | ckernel::TensorShape | | True |
  */
 // clang-format on
-template <PoolType reduce_type, ReduceDim reduce_dim>
+template <PoolType reduce_type, ReduceDim reduce_dim, bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 ALWI void reduce_tile_math(std::uint32_t idst, const ckernel::TensorShape& tensor_shape) {
-    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(idst, tensor_shape)));
+    MATH((llk_math_reduce<reduce_type, reduce_dim, is_fp32_dest_acc_en, MATH_FIDELITY>(idst, tensor_shape)));
 }
 
 // clang-format off

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/reduce.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/reduce.h
@@ -26,25 +26,21 @@ namespace experimental {
 #ifdef ARCH_BLACKHOLE
 
 // Id-free (2.0) reduce (data + scaler -> reduced). Takes one LLKOperand per input (data, scaler) and one for
-// the output. Reduce is FORMAT-FREE at the op level (formats set at compute_kernel_hw_startup); every LLK
-// core here consumes only geometry (data tile shape / output face_r_dim) + the two runtime input addresses, so
-// there is no id-free LLK header -- the compute op calls the api-level unified cores directly with the
-// descriptor-extracted values. Geometry (for MATH + unpack init) comes from the DATA operand, matching legacy.
-// Packing is separate (experimental::pack_tile); the packer edge mask is programmed here by reduce_init.
+// the output. Format-free at the op level (formats set at compute_kernel_hw_startup); every LLK core here
+// consumes only geometry (data tile shape / output face_r_dim) + the two runtime input addresses. Geometry
+// (for MATH + unpack init) comes from the DATA operand. Packing is separate (experimental::pack_tile); the
+// packer edge mask is programmed here by reduce_init.
 
 // clang-format off
 /**
- * Reduce init: programs UNPACK (AB reduce), MATH (reduce init), and the PACK edge-mask for the reduction.
- * compute_kernel_hw_startup(data_cb, scaler_cb, out_cb) must already have programmed the formats.
+ * Reduce init: programs UNPACK (AB reduce), MATH, and the PACK edge-mask. compute_kernel_hw_startup(data_cb,
+ * scaler_cb, out_cb) must already have programmed the formats. Uses only DATA geometry and OUT's face_r_dim;
+ * the scaler operand contributes nothing at init (it's passed to reduce_tile).
  *
  * | Template | reduce_type | SUM / AVG / MAX                                | PoolType  | | True |
  * | Template | reduce_dim  | REDUCE_ROW / REDUCE_COL / REDUCE_SCALAR       | ReduceDim | | True |
  * | Function | data        | Input operand A (reduced); drives geometry    | LLKOperand | | True |
  * | Function | out         | Output operand (drives the packer edge mask)  | LLKOperand | | True |
- *
- * NOTE (PART B): the init uses only the DATA geometry (unpack/math) and the OUT face_r_dim (packer edge
- * mask). The scaler operand contributes nothing to init, so it is not taken here; it is still passed to
- * reduce_tile (which needs its address + stride).
  */
 // clang-format on
 template <PoolType reduce_type, ReduceDim reduce_dim, DataFormat DF, TensorShape DS, DataFormat OF, TensorShape OS>
@@ -82,7 +78,6 @@ ALWI void reduce_tile(
     static_assert(
         !(reduce_dim == ReduceDim::REDUCE_ROW && reduce_type != PoolType::MAX) || DF == SF,
         "reduce_tile: REDUCE_ROW (non-MAX) swaps SrcA/SrcB, so data and scaler must have the same data format.");
-    // Match legacy reduce_tile order: MATH then UNPACK.
     MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(idst, DS)));
     UNPACK((llk_unpack_AB_reduce_impl<reduce_type, reduce_dim>(
         detail::tile_address(data, itile), detail::tile_address(scaler, itile_scaler))));
@@ -91,11 +86,9 @@ ALWI void reduce_tile(
 // clang-format off
 /**
  * Reduce `ntiles` consecutive data tiles (each combined with the scaler tile), writing each tile's reduction
- * to its OWN DST slot: data tile (start_itile + i) -> DST[start_idst + i]. Block/loop form of reduce_tile,
- * matching the legacy reduce_block N-in / N-out semantics (api/compute/reduce.h) exactly -- it is NOT a
- * cross-block accumulation into one slot (a caller wanting that loops reduce_tile at a fixed idst). Reuses the
- * existing 2.0 reduce_tile per tile; per-tile source addressing is inherited from reduce_tile (itile advances
- * by tile_stride_words internally). Pair with reduce_init. DST must be acquired.
+ * to its OWN DST slot: data tile (start_itile + i) -> DST[start_idst + i]. Loop form of reduce_tile (NOT a
+ * cross-block accumulation into one slot -- for that, loop reduce_tile at a fixed idst). Pair with
+ * reduce_init. DST must be acquired.
  *
  * | Template | reduce_type   | SUM / AVG / MAX                                 | PoolType   | | True |
  * | Template | reduce_dim    | REDUCE_ROW / REDUCE_COL / REDUCE_SCALAR        | ReduceDim  | | True |
@@ -123,12 +116,10 @@ ALWI void reduce_block(
 
 // clang-format off
 /**
- * Math-only reduction into DST[idst]. This is the MATH half of reduce_tile with NO unpack/pack: the source
- * tiles must ALREADY be in the source registers (typically staged by a preceding fused op, e.g. tilize). It
- * consumes NO operand -- pure DST math -- so it takes no LLKOperand; geometry is given by num_faces, which maps
- * to the naive row-major face layout (faces laid out row-wise first). Pair with reduce_init. DST must be
- * acquired. For a non-default face layout, use the TensorShape overload below. Reuses the same id-free MATH
- * core as reduce_tile (llk_math_reduce(idst, shape)).
+ * Math-only reduction into DST[idst]: the MATH half of reduce_tile with no unpack/pack. Source tiles must
+ * already be in the source registers (e.g. staged by a preceding fused op like tilize); takes no LLKOperand.
+ * Geometry comes from num_faces (row-major face layout). Pair with reduce_init. DST must be acquired. For a
+ * non-default face layout, use the TensorShape overload below.
  *
  * | Template | reduce_type | SUM / AVG / MAX                          | PoolType  | | True |
  * | Template | reduce_dim  | REDUCE_ROW / REDUCE_COL / REDUCE_SCALAR | ReduceDim | | True |
@@ -144,9 +135,8 @@ ALWI void reduce_tile_math(std::uint32_t idst, std::uint32_t num_faces = MAX_NUM
 
 // clang-format off
 /**
- * Math-only reduction into DST[idst] with an explicit tile geometry. As above, the source tiles must ALREADY
- * be in the source registers and NO operand is consumed (pure DST math, no LLKOperand). Pair with reduce_init.
- * DST must be acquired. Reuses the same id-free MATH core as reduce_tile (llk_math_reduce(idst, shape)).
+ * Math-only reduction into DST[idst] with an explicit tile geometry. As above, source tiles must already be
+ * in the source registers; takes no LLKOperand. Pair with reduce_init. DST must be acquired.
  *
  * | Template | reduce_type  | SUM / AVG / MAX                          | PoolType             | | True |
  * | Template | reduce_dim   | REDUCE_ROW / REDUCE_COL / REDUCE_SCALAR | ReduceDim            | | True |

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/reduce.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/reduce.h
@@ -123,6 +123,44 @@ ALWI void reduce_block(
 
 // clang-format off
 /**
+ * Math-only reduction into DST[idst]. This is the MATH half of reduce_tile with NO unpack/pack: the source
+ * tiles must ALREADY be in the source registers (typically staged by a preceding fused op, e.g. tilize). It
+ * consumes NO operand -- pure DST math -- so it takes no LLKOperand; geometry is given by num_faces, which maps
+ * to the naive row-major face layout (faces laid out row-wise first). Pair with reduce_init. DST must be
+ * acquired. For a non-default face layout, use the TensorShape overload below. Reuses the same id-free MATH
+ * core as reduce_tile (llk_math_reduce(idst, shape)).
+ *
+ * | Template | reduce_type | SUM / AVG / MAX                          | PoolType  | | True |
+ * | Template | reduce_dim  | REDUCE_ROW / REDUCE_COL / REDUCE_SCALAR | ReduceDim | | True |
+ * | Function | idst        | DST register index for the result       | uint32_t  | | True |
+ * | Function | num_faces   | Number of faces to reduce (default 4)   | uint32_t  | 1 / 2 / 4 | False |
+ */
+// clang-format on
+template <PoolType reduce_type, ReduceDim reduce_dim>
+ALWI void reduce_tile_math(std::uint32_t idst, std::uint32_t num_faces = MAX_NUM_FACES) {
+    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(
+        idst, tensor_shape_from_num_faces(MAX_FACE_R_DIM, num_faces))));
+}
+
+// clang-format off
+/**
+ * Math-only reduction into DST[idst] with an explicit tile geometry. As above, the source tiles must ALREADY
+ * be in the source registers and NO operand is consumed (pure DST math, no LLKOperand). Pair with reduce_init.
+ * DST must be acquired. Reuses the same id-free MATH core as reduce_tile (llk_math_reduce(idst, shape)).
+ *
+ * | Template | reduce_type  | SUM / AVG / MAX                          | PoolType             | | True |
+ * | Template | reduce_dim   | REDUCE_ROW / REDUCE_COL / REDUCE_SCALAR | ReduceDim            | | True |
+ * | Function | idst         | DST register index for the result       | uint32_t             | | True |
+ * | Function | tensor_shape | Tile geometry to reduce                  | ckernel::TensorShape | | True |
+ */
+// clang-format on
+template <PoolType reduce_type, ReduceDim reduce_dim>
+ALWI void reduce_tile_math(std::uint32_t idst, const ckernel::TensorShape& tensor_shape) {
+    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(idst, tensor_shape)));
+}
+
+// clang-format off
+/**
  * Reduce uninit: reset the MATH reduce state and clear the packer edge mask back to default.
  */
 // clang-format on

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/reduce.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/reduce.h
@@ -39,16 +39,24 @@ namespace experimental {
  *
  * | Template | reduce_type | SUM / AVG / MAX                                | PoolType  | | True |
  * | Template | reduce_dim  | REDUCE_ROW / REDUCE_COL / REDUCE_SCALAR       | ReduceDim | | True |
+ * | Template | is_fp32_dest_acc_en | fp32 dest-accumulate mode              | bool       | | False |
  * | Function | data        | Input operand A (reduced); drives geometry    | LLKOperand | | True |
  * | Function | out         | Output operand (drives the packer edge mask)  | LLKOperand | | True |
  */
 // clang-format on
-template <PoolType reduce_type, ReduceDim reduce_dim, DataFormat DF, TensorShape DS, DataFormat OF, TensorShape OS>
+template <
+    PoolType reduce_type,
+    ReduceDim reduce_dim,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    DataFormat DF,
+    TensorShape DS,
+    DataFormat OF,
+    TensorShape OS>
 ALWI void reduce_init(LLKOperand<DF, DS> /*data*/, LLKOperand<OF, OS> /*out*/) {
     static_assert(is_legal_tile_shape(DS), "reduce_init: illegal data tile shape.");
     static_assert(is_legal_tile_shape(OS), "reduce_init: illegal output tile shape.");
     UNPACK((llk_unpack_AB_reduce_init_impl<reduce_type, reduce_dim>(DS)));
-    MATH((llk_math_reduce_init_impl<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(DS)));
+    MATH((llk_math_reduce_init_impl<reduce_type, reduce_dim, is_fp32_dest_acc_en, MATH_FIDELITY>(DS)));
     PACK((llk_pack_reduce_mask_config_impl<reduce_dim, PackMode::Default>(OS.face_r_dim)));
 }
 
@@ -58,12 +66,20 @@ ALWI void reduce_init(LLKOperand<DF, DS> /*data*/, LLKOperand<OF, OS> /*out*/) {
  * itile / itile_scaler index within data / scaler. Per-tile input addresses are derived from each operand's
  * geometry via tile_stride_words (one-tile page; exp section included for block floats).
  *
+ * | Template | is_fp32_dest_acc_en    | fp32 dest-accumulate mode          | bool       | | False |
  * | Function | data / scaler          | Input operands                    | LLKOperand | | True |
  * | Function | itile / itile_scaler   | Tile indices within data / scaler | uint32_t   | | True |
  * | Function | idst                   | DST register index for the result | uint32_t   | | True |
  */
 // clang-format on
-template <PoolType reduce_type, ReduceDim reduce_dim, DataFormat DF, TensorShape DS, DataFormat SF, TensorShape SS>
+template <
+    PoolType reduce_type,
+    ReduceDim reduce_dim,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    DataFormat DF,
+    TensorShape DS,
+    DataFormat SF,
+    TensorShape SS>
 ALWI void reduce_tile(
     LLKOperand<DF, DS> data,
     LLKOperand<SF, SS> scaler,
@@ -78,7 +94,7 @@ ALWI void reduce_tile(
     static_assert(
         !(reduce_dim == ReduceDim::REDUCE_ROW && reduce_type != PoolType::MAX) || DF == SF,
         "reduce_tile: REDUCE_ROW (non-MAX) swaps SrcA/SrcB, so data and scaler must have the same data format.");
-    MATH((llk_math_reduce<reduce_type, reduce_dim, DST_ACCUM_MODE, MATH_FIDELITY>(idst, DS)));
+    MATH((llk_math_reduce<reduce_type, reduce_dim, is_fp32_dest_acc_en, MATH_FIDELITY>(idst, DS)));
     UNPACK((llk_unpack_AB_reduce_impl<reduce_type, reduce_dim>(
         detail::tile_address(data, itile), detail::tile_address(scaler, itile_scaler))));
 }
@@ -97,9 +113,17 @@ ALWI void reduce_tile(
  * | Function | itile_scaler  | Tile index within `scaler`                      | uint32_t   | | True |
  * | Function | start_idst    | DST register index for the first tile's result | uint32_t   | start_idst + ntiles <= DST size | True |
  * | Function | ntiles        | Number of consecutive data tiles to reduce     | uint32_t   | | True |
+ * | Template | is_fp32_dest_acc_en | fp32 dest-accumulate mode                 | bool       | | False |
  */
 // clang-format on
-template <PoolType reduce_type, ReduceDim reduce_dim, DataFormat DF, TensorShape DS, DataFormat SF, TensorShape SS>
+template <
+    PoolType reduce_type,
+    ReduceDim reduce_dim,
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    DataFormat DF,
+    TensorShape DS,
+    DataFormat SF,
+    TensorShape SS>
 ALWI void reduce_block(
     LLKOperand<DF, DS> data,
     LLKOperand<SF, SS> scaler,
@@ -110,7 +134,8 @@ ALWI void reduce_block(
     static_assert(is_legal_tile_shape(DS), "reduce_block: illegal data tile shape.");
     static_assert(is_legal_tile_shape(SS), "reduce_block: illegal scaler tile shape.");
     for (std::uint32_t i = 0; i < ntiles; ++i) {
-        reduce_tile<reduce_type, reduce_dim>(data, scaler, start_itile + i, itile_scaler, start_idst + i);
+        reduce_tile<reduce_type, reduce_dim, is_fp32_dest_acc_en>(
+            data, scaler, start_itile + i, itile_scaler, start_idst + i);
     }
 }
 

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/reduce.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/reduce.h
@@ -33,8 +33,8 @@ namespace experimental {
 
 // clang-format off
 /**
- * Reduce init: programs UNPACK (AB reduce), MATH, and the PACK edge-mask. compute_kernel_hw_startup(data_cb,
- * scaler_cb, out_cb) must already have programmed the formats. Uses only DATA geometry and OUT's face_r_dim;
+ * Reduce init: programs UNPACK (AB reduce), MATH, and the PACK edge-mask. compute_kernel_hw_startup(data,
+ * scaler, out) must already have programmed the formats. Uses only DATA geometry and OUT's face_r_dim;
  * the scaler operand contributes nothing at init (it's passed to reduce_tile).
  *
  * | Template | reduce_type | SUM / AVG / MAX                                | PoolType  | | True |

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/tile_move_copy.h
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/common_globals.h"
+#include "api/compute/experimental/2_0/llk_operand.h"
+
+#ifdef TRISC_MATH
+#include "experimental/2_0/llk_math_unary_datacopy.h"
+#endif
+
+#ifdef TRISC_UNPACK
+#include "experimental/2_0/llk_unpack_A.h"
+#endif
+
+namespace ckernel {
+namespace experimental {
+
+#ifdef ARCH_BLACKHOLE
+
+// clang-format off
+/**
+ * Experimental id-free datacopy init. Takes an LLKOperand whose data format + tile geometry are NTTPs
+ * (deduced from the argument). The op forwards LLKOperand<F,S>::descriptor to the LLK as an NTTP (folds);
+ * the register format is derived INSIDE the LLK. It reprograms the unpacker + math datacopy for the operand's
+ * format WITHOUT touching the packer dst-offset registers (those come from compute_kernel_hw_startup) -- on
+ * Blackhole the legacy copy_tile_init IS exactly this short re-init form. No CB id, no register format on the
+ * API surface. Legacy ckernel::copy_tile_init is untouched.
+ *
+ * | Template | Format | Buffer L1 data format (deduced from the LLKOperand argument) | DataFormat  |  | True |
+ * | Template | Shape  | Tile geometry (deduced from the LLKOperand argument)         | TensorShape |  | True |
+ */
+// clang-format on
+template <DataFormat Format, TensorShape Shape>
+ALWI void copy_tile_init(LLKOperand<Format, Shape> /*src*/) {
+    static_assert(
+        is_legal_tile_shape(Shape),
+        "copy_tile_init: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
+    UNPACK((llk_unpack_A_init<
+            LLKOperand<Format, Shape>::descriptor,
+            DST_ACCUM_MODE,
+            BroadcastType::NONE,
+            false,
+            EltwiseBinaryReuseDestType::NONE,
+            UnpackToDestEn>()));
+    MATH((llk_math_eltwise_unary_datacopy_init<
+          LLKOperand<Format, Shape>::descriptor,
+          DataCopyType::A2D,
+          DST_ACCUM_MODE,
+          BroadcastType::NONE>()));
+}
+
+// clang-format off
+/**
+ * Experimental id-free datacopy. Copies one tile from the L1 region described by the LLKOperand into DST.
+ * Compile-time "what" = the LLKOperand NTTPs (Format + Shape, fold/DCE); runtime "where" = src.l1_address
+ * (from the address seam). No CB id, no register format on the API. Precondition: the DST register must be
+ * acquired (tile_regs_acquire) before the call, and copy_tile_init must have run.
+ *
+ * | Template | Format         | Buffer L1 data format (deduced from LLKOperand)   | DataFormat  |         | True |
+ * | Template | Shape          | Tile geometry (deduced from LLKOperand)           | TensorShape |         | True |
+ * | Function | src            | The source L1 operand (format+shape+address)      | LLKOperand  |         | True |
+ * | Function | dst_tile_index | Tile index in the DST register                    | uint32_t    | 0 to 15 | True |
+ */
+// clang-format on
+template <DataFormat Format, TensorShape Shape>
+ALWI void copy_tile(LLKOperand<Format, Shape> src, std::uint32_t dst_tile_index) {
+    static_assert(
+        is_legal_tile_shape(Shape),
+        "copy_tile: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
+    UNPACK((llk_unpack_A<
+            LLKOperand<Format, Shape>::descriptor,
+            DST_ACCUM_MODE,
+            BroadcastType::NONE,
+            false,
+            EltwiseBinaryReuseDestType::NONE,
+            UnpackToDestEn>(src.l1_address)));
+    MATH((llk_math_eltwise_unary_datacopy<
+          LLKOperand<Format, Shape>::descriptor,
+          DataCopyType::A2D,
+          DST_ACCUM_MODE,
+          BroadcastType::NONE,
+          UnpackToDestEn>(dst_tile_index)));
+}
+
+// clang-format off
+/**
+ * Experimental id-free block datacopy. Copies `ntiles` consecutive tiles from the L1 region described by the
+ * LLKOperand into consecutive DST register slots. Block/loop form of copy_tile: matches the legacy
+ * copy_block semantics (tile start_in_tile_index+i lands in DST slot start_dst_tile_index+i). Reuses the
+ * existing 2.0 copy_tile per tile; each tile's source address is the operand base offset by
+ * (start_in_tile_index + i) * tile_stride_words(Format, Shape) 16-byte words (folds to a compile-time
+ * constant). No CB id, no register format on the API. Requires the same init as copy_tile (copy_tile_init).
+ *
+ * | Template | Format               | Buffer L1 data format (deduced from LLKOperand)             | DataFormat  |         | True |
+ * | Template | Shape                | Tile geometry (deduced from LLKOperand)                    | TensorShape |         | True |
+ * | Function | src                  | The source L1 operand (format+shape+base address)          | LLKOperand  |         | True |
+ * | Function | start_in_tile_index  | Index of the first source tile, relative to src base        | uint32_t    | N/A     | True |
+ * | Function | start_dst_tile_index | Index of the first destination tile in the DST register     | uint32_t    | 0 to 15 | True |
+ * | Function | ntiles               | Number of consecutive tiles to copy                         | uint32_t    | start_dst_tile_index + ntiles <= 16 | True |
+ */
+// clang-format on
+template <DataFormat Format, TensorShape Shape>
+ALWI void copy_block(
+    LLKOperand<Format, Shape> src,
+    std::uint32_t start_in_tile_index,
+    std::uint32_t start_dst_tile_index,
+    std::uint32_t ntiles) {
+    static_assert(
+        is_legal_tile_shape(Shape),
+        "copy_block: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
+    for (std::uint32_t i = 0; i < ntiles; ++i) {
+        copy_tile(
+            LLKOperand<Format, Shape>(detail::tile_address(src, start_in_tile_index + i)), start_dst_tile_index + i);
+    }
+}
+
+#endif  // ARCH_BLACKHOLE
+
+}  // namespace experimental
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/tile_move_copy.h
@@ -36,13 +36,14 @@ namespace experimental {
  *
  * Sub-32-row (partial-height) block-float tiles are not supported (compile-time rejected).
  *
+ * | Template | is_fp32_dest_acc_en         | fp32 dest-accumulate mode                                    | bool        |                                                                     | False |
  * | Template | Format                      | Buffer L1 data format (deduced from the LLKOperand argument) | DataFormat  |                                                                     | True  |
  * | Template | Shape                       | Tile geometry (deduced from the LLKOperand argument)         | TensorShape |                                                                     | True  |
  * | Function | transpose                   | Flag to perform transpose on SrcA                           | uint32_t    | Any positive value will indicate transpose is set                   | False |
  * | Function | transpose_within_16x16_face | Flag to perform transpose within 16x16 face                 | uint32_t    | Any positive value will indicate transpose within 16x16 face is set | False |
  */
 // clang-format on
-template <DataFormat Format, TensorShape Shape>
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE, DataFormat Format, TensorShape Shape>
 ALWI void copy_init(
     LLKOperand<Format, Shape> /*src*/, std::uint32_t transpose = 0, std::uint32_t transpose_within_16x16_face = 0) {
     static_assert(
@@ -54,7 +55,7 @@ ALWI void copy_init(
         "(they produce garbage even at tile 0); use a full 32-row tile.");
     UNPACK((llk_unpack_A_init<
             LLKOperand<Format, Shape>::descriptor,
-            DST_ACCUM_MODE,
+            is_fp32_dest_acc_en,
             BroadcastType::NONE,
             false,
             EltwiseBinaryReuseDestType::NONE,
@@ -62,14 +63,14 @@ ALWI void copy_init(
     MATH((llk_math_eltwise_unary_datacopy_init<
           LLKOperand<Format, Shape>::descriptor,
           DataCopyType::A2D,
-          DST_ACCUM_MODE,
+          is_fp32_dest_acc_en,
           BroadcastType::NONE>()));
     // Src zero-substitution flag, chosen by the derived register format (id-free equivalent of legacy
     // copy_init's ckernel::math::_configure_copy_zero_flag_state_(get_operand_dst_format(cbid))): preserve
     // bf16 -0.0 / 16b-int residuals, but flush fp8 (e4m3/e5m2) whose zero widens to a nonzero SrcA residual
     // and must read back as 0. MATH-only config; records no format-reconfig diff. The fn masks to 0x1F.
     MATH((ckernel::math::_configure_copy_zero_flag_state_(
-        static_cast<std::uint32_t>(ckernel::infer_unpack_dst_format(Format, DST_ACCUM_MODE)))));
+        static_cast<std::uint32_t>(ckernel::infer_unpack_dst_format(Format, is_fp32_dest_acc_en)))));
 }
 
 // clang-format off
@@ -79,13 +80,14 @@ ALWI void copy_init(
  * Requires copy_init to have run, and the DST register to be acquired (tile_regs_acquire) before this call.
  * Sub-32-row (partial-height) block-float tiles are not supported (compile-time rejected).
  *
+ * | Template | is_fp32_dest_acc_en | fp32 dest-accumulate mode                          | bool        |         | False |
  * | Template | Format         | Buffer L1 data format (deduced from LLKOperand)   | DataFormat  |         | True |
  * | Template | Shape          | Tile geometry (deduced from LLKOperand)           | TensorShape |         | True |
  * | Function | src            | The source L1 operand (format+shape+address)      | LLKOperand  |         | True |
  * | Function | dst_tile_index | Tile index in the DST register                    | uint32_t    | 0 to 15 | True |
  */
 // clang-format on
-template <DataFormat Format, TensorShape Shape>
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE, DataFormat Format, TensorShape Shape>
 ALWI void copy_tile(LLKOperand<Format, Shape> src, std::uint32_t dst_tile_index) {
     static_assert(
         is_legal_tile_shape(Shape),
@@ -96,7 +98,7 @@ ALWI void copy_tile(LLKOperand<Format, Shape> src, std::uint32_t dst_tile_index)
         "(they produce garbage even at tile 0); use a full 32-row tile.");
     UNPACK((llk_unpack_A<
             LLKOperand<Format, Shape>::descriptor,
-            DST_ACCUM_MODE,
+            is_fp32_dest_acc_en,
             BroadcastType::NONE,
             false,
             EltwiseBinaryReuseDestType::NONE,
@@ -104,7 +106,7 @@ ALWI void copy_tile(LLKOperand<Format, Shape> src, std::uint32_t dst_tile_index)
     MATH((llk_math_eltwise_unary_datacopy<
           LLKOperand<Format, Shape>::descriptor,
           DataCopyType::A2D,
-          DST_ACCUM_MODE,
+          is_fp32_dest_acc_en,
           BroadcastType::NONE,
           UnpackToDestEn>(dst_tile_index)));
 }
@@ -119,6 +121,7 @@ ALWI void copy_tile(LLKOperand<Format, Shape> src, std::uint32_t dst_tile_index)
  * Requires the same init as copy_tile (copy_init). Sub-32-row (partial-height) block-float tiles are not
  * supported (compile-time rejected).
  *
+ * | Template | is_fp32_dest_acc_en  | fp32 dest-accumulate mode                                    | bool        |         | False |
  * | Template | Format               | Buffer L1 data format (deduced from LLKOperand)             | DataFormat  |         | True |
  * | Template | Shape                | Tile geometry (deduced from LLKOperand)                    | TensorShape |         | True |
  * | Function | src                  | The source L1 operand (format+shape+base address)          | LLKOperand  |         | True |
@@ -127,7 +130,7 @@ ALWI void copy_tile(LLKOperand<Format, Shape> src, std::uint32_t dst_tile_index)
  * | Function | ntiles               | Number of consecutive tiles to copy                         | uint32_t    | start_dst_tile_index + ntiles <= 16 | True |
  */
 // clang-format on
-template <DataFormat Format, TensorShape Shape>
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE, DataFormat Format, TensorShape Shape>
 ALWI void copy_block(
     LLKOperand<Format, Shape> src,
     std::uint32_t start_in_tile_index,
@@ -141,7 +144,7 @@ ALWI void copy_block(
         "copy: sub-32-row (partial-height) block-float tiles are not supported on the BH compute datapath "
         "(they produce garbage even at tile 0); use a full 32-row tile.");
     for (std::uint32_t i = 0; i < ntiles; ++i) {
-        copy_tile(
+        copy_tile<is_fp32_dest_acc_en>(
             LLKOperand<Format, Shape>(detail::tile_address(src, start_in_tile_index + i)), start_dst_tile_index + i);
     }
 }

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/tile_move_copy.h
@@ -74,7 +74,8 @@ ALWI void copy_init(
 
 // clang-format off
 /**
- * Id-free datacopy. Copies one tile from the L1 region described by the LLKOperand into DST. Blackhole only.
+ * Id-free datacopy. Copies tile `itile` from the L1 buffer described by the LLKOperand into DST.
+ * `src.l1_address` is the buffer base; the unpack address is `tile_address(src, itile)`. Blackhole only.
  *
  * Requires copy_init to have run, and the DST register to be acquired (tile_regs_acquire) before this call.
  * Sub-32-row (partial-height) block-float tiles are not supported (compile-time rejected).
@@ -82,12 +83,13 @@ ALWI void copy_init(
  * | Template | is_fp32_dest_acc_en | fp32 dest-accumulate mode                          | bool        |         | False |
  * | Template | Format         | Buffer L1 data format (deduced from LLKOperand)   | DataFormat  |         | True |
  * | Template | Shape          | Tile geometry (deduced from LLKOperand)           | TensorShape |         | True |
- * | Function | src            | The source L1 operand (format+shape+address)      | LLKOperand  |         | True |
+ * | Function | src            | The source L1 operand (format+shape+buffer base)  | LLKOperand  |         | True |
+ * | Function | itile          | Index of the tile within `src`, relative to its base | uint32_t | N/A     | True |
  * | Function | dst_tile_index | Tile index in the DST register                    | uint32_t    | 0 to 15 | True |
  */
 // clang-format on
 template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE, DataFormat Format, TensorShape Shape>
-ALWI void copy_tile(LLKOperand<Format, Shape> src, std::uint32_t dst_tile_index) {
+ALWI void copy_tile(LLKOperand<Format, Shape> src, std::uint32_t itile, std::uint32_t dst_tile_index) {
     static_assert(
         is_legal_tile_shape(Shape),
         "copy_tile: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
@@ -101,7 +103,7 @@ ALWI void copy_tile(LLKOperand<Format, Shape> src, std::uint32_t dst_tile_index)
             BroadcastType::NONE,
             false,
             EltwiseBinaryReuseDestType::NONE,
-            UnpackToDestEn>(src.l1_address)));
+            UnpackToDestEn>(detail::tile_address(src, itile))));
     MATH((llk_math_eltwise_unary_datacopy<
           LLKOperand<Format, Shape>::descriptor,
           DataCopyType::A2D,
@@ -112,10 +114,9 @@ ALWI void copy_tile(LLKOperand<Format, Shape> src, std::uint32_t dst_tile_index)
 
 // clang-format off
 /**
- * Id-free block datacopy. Copies `ntiles` consecutive tiles from the L1 region described by the LLKOperand
+ * Id-free block datacopy. Copies `ntiles` consecutive tiles from the L1 buffer described by the LLKOperand
  * into consecutive DST register slots (tile start_in_tile_index+i lands in DST slot start_dst_tile_index+i).
- * Loop form of copy_tile; each tile's source address is offset by (start_in_tile_index + i) tile strides
- * (folds to a compile-time constant). Blackhole only.
+ * Loop form of copy_tile. Blackhole only.
  *
  * Requires the same init as copy_tile (copy_init). Sub-32-row (partial-height) block-float tiles are not
  * supported (compile-time rejected).
@@ -143,8 +144,7 @@ ALWI void copy_block(
         "copy: sub-32-row (partial-height) block-float tiles are not supported on the BH compute datapath "
         "(they produce garbage even at tile 0); use a full 32-row tile.");
     for (std::uint32_t i = 0; i < ntiles; ++i) {
-        copy_tile<is_fp32_dest_acc_en>(
-            LLKOperand<Format, Shape>(detail::tile_address(src, start_in_tile_index + i)), start_dst_tile_index + i);
+        copy_tile<is_fp32_dest_acc_en>(src, start_in_tile_index + i, start_dst_tile_index + i);
     }
 }
 

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/tile_move_copy.h
@@ -23,23 +23,18 @@ namespace experimental {
 
 // clang-format off
 /**
- * Experimental id-free datacopy init. Takes an LLKOperand whose data format + tile geometry are NTTPs
- * (deduced from the argument). The op forwards LLKOperand<F,S>::descriptor to the LLK as an NTTP (folds);
- * the register format is derived INSIDE the LLK. It reprograms the unpacker + math datacopy for the operand's
- * format WITHOUT touching the packer dst-offset registers (those come from compute_kernel_hw_startup) -- on
- * Blackhole this matches the legacy copy_init unpacker + math datacopy re-init. No CB id, no register format on
- * the API surface. Legacy ckernel::copy_tile_init is untouched.
+ * Id-free datacopy init. Takes an LLKOperand whose data format + tile geometry are NTTPs (deduced from the
+ * argument); the register format is derived inside the LLK. Reprograms the unpacker and math datacopy for the
+ * operand's format without touching the packer dst-offset registers (those come from
+ * compute_kernel_hw_startup). Blackhole only.
  *
- * fp8 (Fp8_e4m3 / Lf8 e5m2) IS supported: copy_init programs the format-driven Src zero-substitution flag
- * exactly as legacy copy_init does (ckernel::math::_configure_copy_zero_flag_state_) -- it flushes fp8 zeros
- * (whose SrcA residual would otherwise read back nonzero) and preserves the residual for all other formats
- * (e.g. bf16 -0.0 / 16b-int). The flag is derived id-free from the register format (infer_unpack_dst_format).
+ * fp8 (Fp8_e4m3 / Lf8 e5m2) is supported: the format-driven Src zero-substitution flag is programmed so fp8
+ * zeros read back correctly, while other formats (e.g. bf16 -0.0 / 16b-int) keep their residual value.
  *
- * PARITY: transpose / transpose_within_16x16_face restore the copy-with-transpose capability legacy copy_init
- * exposes; they were dropped when this id-free path was first authored (the authoring agent only exercised the
- * plain, non-transpose copy). Both default OFF (0), so the default copy path is byte-identical; when nonzero they
- * drive the unpacker exactly as legacy copy_init does (transpose -> transpose_of_faces, transpose_within_16x16_face
- * -> within_face_16x16_transpose on the id-free llk_unpack_A_init, the same args transpose_init uses).
+ * transpose / transpose_within_16x16_face support copy-with-transpose; both default off (0), so the default
+ * copy path is unaffected.
+ *
+ * Sub-32-row (partial-height) block-float tiles are not supported (compile-time rejected).
  *
  * | Template | Format                      | Buffer L1 data format (deduced from the LLKOperand argument) | DataFormat  |                                                                     | True  |
  * | Template | Shape                       | Tile geometry (deduced from the LLKOperand argument)         | TensorShape |                                                                     | True  |
@@ -79,10 +74,10 @@ ALWI void copy_init(
 
 // clang-format off
 /**
- * Experimental id-free datacopy. Copies one tile from the L1 region described by the LLKOperand into DST.
- * Compile-time "what" = the LLKOperand NTTPs (Format + Shape, fold/DCE); runtime "where" = src.l1_address
- * (from the address seam). No CB id, no register format on the API. Precondition: the DST register must be
- * acquired (tile_regs_acquire) before the call, and copy_init must have run.
+ * Id-free datacopy. Copies one tile from the L1 region described by the LLKOperand into DST. Blackhole only.
+ *
+ * Requires copy_init to have run, and the DST register to be acquired (tile_regs_acquire) before this call.
+ * Sub-32-row (partial-height) block-float tiles are not supported (compile-time rejected).
  *
  * | Template | Format         | Buffer L1 data format (deduced from LLKOperand)   | DataFormat  |         | True |
  * | Template | Shape          | Tile geometry (deduced from LLKOperand)           | TensorShape |         | True |
@@ -116,12 +111,13 @@ ALWI void copy_tile(LLKOperand<Format, Shape> src, std::uint32_t dst_tile_index)
 
 // clang-format off
 /**
- * Experimental id-free block datacopy. Copies `ntiles` consecutive tiles from the L1 region described by the
- * LLKOperand into consecutive DST register slots. Block/loop form of copy_tile: matches the legacy
- * copy_block semantics (tile start_in_tile_index+i lands in DST slot start_dst_tile_index+i). Reuses the
- * existing 2.0 copy_tile per tile; each tile's source address is the operand base offset by
- * (start_in_tile_index + i) * tile_stride_words(Format, Shape) 16-byte words (folds to a compile-time
- * constant). No CB id, no register format on the API. Requires the same init as copy_tile (copy_init).
+ * Id-free block datacopy. Copies `ntiles` consecutive tiles from the L1 region described by the LLKOperand
+ * into consecutive DST register slots (tile start_in_tile_index+i lands in DST slot start_dst_tile_index+i).
+ * Loop form of copy_tile; each tile's source address is offset by (start_in_tile_index + i) tile strides
+ * (folds to a compile-time constant). Blackhole only.
+ *
+ * Requires the same init as copy_tile (copy_init). Sub-32-row (partial-height) block-float tiles are not
+ * supported (compile-time rejected).
  *
  * | Template | Format               | Buffer L1 data format (deduced from LLKOperand)             | DataFormat  |         | True |
  * | Template | Shape                | Tile geometry (deduced from LLKOperand)                    | TensorShape |         | True |

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/tile_move_copy.h
@@ -19,8 +19,6 @@
 namespace ckernel {
 namespace experimental {
 
-#ifdef ARCH_BLACKHOLE
-
 // clang-format off
 /**
  * Id-free datacopy init. Takes an LLKOperand whose data format + tile geometry are NTTPs (deduced from the
@@ -148,8 +146,6 @@ ALWI void copy_block(
             LLKOperand<Format, Shape>(detail::tile_address(src, start_in_tile_index + i)), start_dst_tile_index + i);
     }
 }
-
-#endif  // ARCH_BLACKHOLE
 
 }  // namespace experimental
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/tile_move_copy.h
@@ -30,12 +30,10 @@ namespace experimental {
  * Blackhole this matches the legacy copy_init unpacker + math datacopy re-init. No CB id, no register format on
  * the API surface. Legacy ckernel::copy_tile_init is untouched.
  *
- * LIMITATION (compile-time enforced): fp8 source formats (Fp8_e4m3 / Lf8 e5m2) are NOT supported yet. Legacy
- * copy_init additionally programs the Src zero-substitution flag by format -- flushing fp8 zeros whose SrcA
- * residual would otherwise read back nonzero. That flag config is not wired into the 2.0 path yet (and cannot
- * be validated through the current golden harness, since it affects the DST value an SFPU op reads, not the
- * packed L1 output). Until it is, fp8 datacopy must use the legacy CB-id copy path; a static_assert here
- * rejects an fp8 LLKOperand rather than silently producing wrong near-zero fp8 results.
+ * fp8 (Fp8_e4m3 / Lf8 e5m2) IS supported: copy_init programs the format-driven Src zero-substitution flag
+ * exactly as legacy copy_init does (ckernel::math::_configure_copy_zero_flag_state_) -- it flushes fp8 zeros
+ * (whose SrcA residual would otherwise read back nonzero) and preserves the residual for all other formats
+ * (e.g. bf16 -0.0 / 16b-int). The flag is derived id-free from the register format (infer_unpack_dst_format).
  *
  * PARITY: transpose / transpose_within_16x16_face restore the copy-with-transpose capability legacy copy_init
  * exposes; they were dropped when this id-free path was first authored (the authoring agent only exercised the
@@ -56,9 +54,9 @@ ALWI void copy_init(
         is_legal_tile_shape(Shape),
         "copy_init: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
     static_assert(
-        Format != DataFormat::Fp8_e4m3 && Format != DataFormat::Lf8,
-        "copy_init: fp8 source (Fp8_e4m3/Lf8) is not supported in the 2.0 datacopy path yet -- it requires "
-        "the legacy copy_init src zero-flag flush, which is not wired in here. Use the legacy CB-id copy path.");
+        !(is_block_float_format(Format) && is_partial_height(Shape)),
+        "copy: sub-32-row (partial-height) block-float tiles are not supported on the BH compute datapath "
+        "(they produce garbage even at tile 0); use a full 32-row tile.");
     UNPACK((llk_unpack_A_init<
             LLKOperand<Format, Shape>::descriptor,
             DST_ACCUM_MODE,
@@ -71,6 +69,12 @@ ALWI void copy_init(
           DataCopyType::A2D,
           DST_ACCUM_MODE,
           BroadcastType::NONE>()));
+    // Src zero-substitution flag, chosen by the derived register format (id-free equivalent of legacy
+    // copy_init's ckernel::math::_configure_copy_zero_flag_state_(get_operand_dst_format(cbid))): preserve
+    // bf16 -0.0 / 16b-int residuals, but flush fp8 (e4m3/e5m2) whose zero widens to a nonzero SrcA residual
+    // and must read back as 0. MATH-only config; records no format-reconfig diff. The fn masks to 0x1F.
+    MATH((ckernel::math::_configure_copy_zero_flag_state_(
+        static_cast<std::uint32_t>(ckernel::infer_unpack_dst_format(Format, DST_ACCUM_MODE)))));
 }
 
 // clang-format off
@@ -91,6 +95,10 @@ ALWI void copy_tile(LLKOperand<Format, Shape> src, std::uint32_t dst_tile_index)
     static_assert(
         is_legal_tile_shape(Shape),
         "copy_tile: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
+    static_assert(
+        !(is_block_float_format(Format) && is_partial_height(Shape)),
+        "copy: sub-32-row (partial-height) block-float tiles are not supported on the BH compute datapath "
+        "(they produce garbage even at tile 0); use a full 32-row tile.");
     UNPACK((llk_unpack_A<
             LLKOperand<Format, Shape>::descriptor,
             DST_ACCUM_MODE,
@@ -132,6 +140,10 @@ ALWI void copy_block(
     static_assert(
         is_legal_tile_shape(Shape),
         "copy_block: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
+    static_assert(
+        !(is_block_float_format(Format) && is_partial_height(Shape)),
+        "copy: sub-32-row (partial-height) block-float tiles are not supported on the BH compute datapath "
+        "(they produce garbage even at tile 0); use a full 32-row tile.");
     for (std::uint32_t i = 0; i < ntiles; ++i) {
         copy_tile(
             LLKOperand<Format, Shape>(detail::tile_address(src, start_in_tile_index + i)), start_dst_tile_index + i);

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/tile_move_copy.h
@@ -27,8 +27,15 @@ namespace experimental {
  * (deduced from the argument). The op forwards LLKOperand<F,S>::descriptor to the LLK as an NTTP (folds);
  * the register format is derived INSIDE the LLK. It reprograms the unpacker + math datacopy for the operand's
  * format WITHOUT touching the packer dst-offset registers (those come from compute_kernel_hw_startup) -- on
- * Blackhole the legacy copy_tile_init IS exactly this short re-init form. No CB id, no register format on the
- * API surface. Legacy ckernel::copy_tile_init is untouched.
+ * Blackhole this matches the legacy copy_init unpacker + math datacopy re-init. No CB id, no register format on
+ * the API surface. Legacy ckernel::copy_tile_init is untouched.
+ *
+ * LIMITATION (compile-time enforced): fp8 source formats (Fp8_e4m3 / Lf8 e5m2) are NOT supported yet. Legacy
+ * copy_init additionally programs the Src zero-substitution flag by format -- flushing fp8 zeros whose SrcA
+ * residual would otherwise read back nonzero. That flag config is not wired into the 2.0 path yet (and cannot
+ * be validated through the current golden harness, since it affects the DST value an SFPU op reads, not the
+ * packed L1 output). Until it is, fp8 datacopy must use the legacy CB-id copy path; a static_assert here
+ * rejects an fp8 LLKOperand rather than silently producing wrong near-zero fp8 results.
  *
  * | Template | Format | Buffer L1 data format (deduced from the LLKOperand argument) | DataFormat  |  | True |
  * | Template | Shape  | Tile geometry (deduced from the LLKOperand argument)         | TensorShape |  | True |
@@ -39,6 +46,10 @@ ALWI void copy_tile_init(LLKOperand<Format, Shape> /*src*/) {
     static_assert(
         is_legal_tile_shape(Shape),
         "copy_tile_init: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
+    static_assert(
+        Format != DataFormat::Fp8_e4m3 && Format != DataFormat::Lf8,
+        "copy_tile_init: fp8 source (Fp8_e4m3/Lf8) is not supported in the 2.0 datacopy path yet -- it requires "
+        "the legacy copy_init src zero-flag flush, which is not wired in here. Use the legacy CB-id copy path.");
     UNPACK((llk_unpack_A_init<
             LLKOperand<Format, Shape>::descriptor,
             DST_ACCUM_MODE,

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/tile_move_copy.h
@@ -37,12 +37,21 @@ namespace experimental {
  * packed L1 output). Until it is, fp8 datacopy must use the legacy CB-id copy path; a static_assert here
  * rejects an fp8 LLKOperand rather than silently producing wrong near-zero fp8 results.
  *
- * | Template | Format | Buffer L1 data format (deduced from the LLKOperand argument) | DataFormat  |  | True |
- * | Template | Shape  | Tile geometry (deduced from the LLKOperand argument)         | TensorShape |  | True |
+ * PARITY: transpose / transpose_within_16x16_face restore the copy-with-transpose capability legacy copy_init
+ * exposes; they were dropped when this id-free path was first authored (the authoring agent only exercised the
+ * plain, non-transpose copy). Both default OFF (0), so the default copy path is byte-identical; when nonzero they
+ * drive the unpacker exactly as legacy copy_init does (transpose -> transpose_of_faces, transpose_within_16x16_face
+ * -> within_face_16x16_transpose on the id-free llk_unpack_A_init, the same args transpose_init uses).
+ *
+ * | Template | Format                      | Buffer L1 data format (deduced from the LLKOperand argument) | DataFormat  |                                                                     | True  |
+ * | Template | Shape                       | Tile geometry (deduced from the LLKOperand argument)         | TensorShape |                                                                     | True  |
+ * | Function | transpose                   | Flag to perform transpose on SrcA                           | uint32_t    | Any positive value will indicate transpose is set                   | False |
+ * | Function | transpose_within_16x16_face | Flag to perform transpose within 16x16 face                 | uint32_t    | Any positive value will indicate transpose within 16x16 face is set | False |
  */
 // clang-format on
 template <DataFormat Format, TensorShape Shape>
-ALWI void copy_tile_init(LLKOperand<Format, Shape> /*src*/) {
+ALWI void copy_tile_init(
+    LLKOperand<Format, Shape> /*src*/, std::uint32_t transpose = 0, std::uint32_t transpose_within_16x16_face = 0) {
     static_assert(
         is_legal_tile_shape(Shape),
         "copy_tile_init: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
@@ -56,7 +65,7 @@ ALWI void copy_tile_init(LLKOperand<Format, Shape> /*src*/) {
             BroadcastType::NONE,
             false,
             EltwiseBinaryReuseDestType::NONE,
-            UnpackToDestEn>()));
+            UnpackToDestEn>(transpose, transpose_within_16x16_face)));
     MATH((llk_math_eltwise_unary_datacopy_init<
           LLKOperand<Format, Shape>::descriptor,
           DataCopyType::A2D,

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/tile_move_copy.h
@@ -50,14 +50,14 @@ namespace experimental {
  */
 // clang-format on
 template <DataFormat Format, TensorShape Shape>
-ALWI void copy_tile_init(
+ALWI void copy_init(
     LLKOperand<Format, Shape> /*src*/, std::uint32_t transpose = 0, std::uint32_t transpose_within_16x16_face = 0) {
     static_assert(
         is_legal_tile_shape(Shape),
-        "copy_tile_init: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
+        "copy_init: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
     static_assert(
         Format != DataFormat::Fp8_e4m3 && Format != DataFormat::Lf8,
-        "copy_tile_init: fp8 source (Fp8_e4m3/Lf8) is not supported in the 2.0 datacopy path yet -- it requires "
+        "copy_init: fp8 source (Fp8_e4m3/Lf8) is not supported in the 2.0 datacopy path yet -- it requires "
         "the legacy copy_init src zero-flag flush, which is not wired in here. Use the legacy CB-id copy path.");
     UNPACK((llk_unpack_A_init<
             LLKOperand<Format, Shape>::descriptor,
@@ -78,7 +78,7 @@ ALWI void copy_tile_init(
  * Experimental id-free datacopy. Copies one tile from the L1 region described by the LLKOperand into DST.
  * Compile-time "what" = the LLKOperand NTTPs (Format + Shape, fold/DCE); runtime "where" = src.l1_address
  * (from the address seam). No CB id, no register format on the API. Precondition: the DST register must be
- * acquired (tile_regs_acquire) before the call, and copy_tile_init must have run.
+ * acquired (tile_regs_acquire) before the call, and copy_init must have run.
  *
  * | Template | Format         | Buffer L1 data format (deduced from LLKOperand)   | DataFormat  |         | True |
  * | Template | Shape          | Tile geometry (deduced from LLKOperand)           | TensorShape |         | True |
@@ -113,7 +113,7 @@ ALWI void copy_tile(LLKOperand<Format, Shape> src, std::uint32_t dst_tile_index)
  * copy_block semantics (tile start_in_tile_index+i lands in DST slot start_dst_tile_index+i). Reuses the
  * existing 2.0 copy_tile per tile; each tile's source address is the operand base offset by
  * (start_in_tile_index + i) * tile_stride_words(Format, Shape) 16-byte words (folds to a compile-time
- * constant). No CB id, no register format on the API. Requires the same init as copy_tile (copy_tile_init).
+ * constant). No CB id, no register format on the API. Requires the same init as copy_tile (copy_init).
  *
  * | Template | Format               | Buffer L1 data format (deduced from LLKOperand)             | DataFormat  |         | True |
  * | Template | Shape                | Tile geometry (deduced from LLKOperand)                    | TensorShape |         | True |

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/tile_move_copy.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/tile_move_copy.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include "api/compute/common_globals.h"
 #include "api/compute/experimental/2_0/llk_operand.h"
+#include "data_format_derive.h"  // ckernel::infer_unpack_dst_format -- register-format derivation (BH)
 
 #ifdef TRISC_MATH
 #include "experimental/2_0/llk_math_unary_datacopy.h"

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/tilize.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/tilize.h
@@ -67,11 +67,11 @@ ALWI void tilize_init(
  *   Tile t is packed to out.l1_address + t * <output tile stride>. The stride folds to a compile-time
  *   constant from the output descriptor via tile_stride_words(OutFormat, OutShape) (16B words):
  *     - linear formats (Float32/Float16/int): geometry-exact datum-count size (SCALE_DATUM_SIZE >> 4);
- *     - block floats (Bfp8/Bfp4/Bfp2): GET_L1_HEADERLESS_TILE_SIZE -- the shared-exponent section included,
- *       matching tile_size(fmt) / the shipping CB page (see internal/llk_descriptor.h::tile_stride_words).
+ *     - block floats (Bfp8/Bfp4/Bfp2): mantissa + shared-exponent section, both scaled by the tile geometry
+ *       (matches tt_metal Tile::get_tile_size / the shipping CB page; see internal/llk_descriptor.h::tile_stride_words).
  *   The shipping tilize factories set the output CB page to exactly one tile (output_single_tile_size), so
  *   this matches fifo_page_size for every format the factories use. Remaining edge (no shipping op hits it):
- *   padded / multi-tile CB pages, and partial/tiny BFP tiles (tile_stride_words uses full-tile BFP size).
+ *   padded / multi-tile CB pages.
  *
  * | Function | in    | Input operand (unpack base; LLK offsets by tile_index) | LLKOperand |     | True |
  * | Function | block | Number of column tiles in the block                    | uint32_t   | > 0 | True |

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/tilize.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/tilize.h
@@ -27,10 +27,10 @@ namespace experimental {
 
 // clang-format off
 /**
- * Experimental id-free tilize init. Takes an input and an output LLKOperand (data format + tile geometry
- * as NTTPs, deduced from the arguments) instead of CB ids; register formats are derived INSIDE the LLK. The
- * tilize pack init needs the input format (8-bit tilize workaround) plus the output format/geometry, hence
- * both operands. `block` is the tilize block width (ct_dim) the unpacker MOP is configured for.
+ * Id-free tilize init. Takes an input and an output LLKOperand (data format + tile geometry as NTTPs,
+ * deduced from the arguments) instead of CB ids; register formats are derived inside the LLK. Both operands
+ * are required: the tilize pack init needs the input format as well as the output format/geometry. `block`
+ * is the tilize block width (ct_dim) the unpacker MOP is configured for. Blackhole only.
  *
  * | Template | InFormat/InShape   | Input buffer L1 format + geometry (deduced)  | DataFormat/TensorShape |  | True |
  * | Template | OutFormat/OutShape | Output buffer L1 format + geometry (deduced)  | DataFormat/TensorShape |  | True |
@@ -59,22 +59,14 @@ ALWI void tilize_init(
 
 // clang-format off
 /**
- * Experimental id-free tilize of one block. The op owns the block loop and self-syncs Dest per tile (no
- * kernel tile_regs). Runtime "where": in.l1_address (unpack base -- the LLK offsets by tile_index inside)
- * and out.l1_address (the block's first output tile).
+ * Id-free tilize of one block. Owns the block loop and self-syncs DEST per tile (no kernel tile_regs). Reads
+ * from in.l1_address (unpack base; the LLK offsets by tile index inside) and writes the block's tiles
+ * starting at out.l1_address. Requires both an input and output operand. Blackhole only.
  *
- * PER-TILE OUTPUT ADDRESSING vs the legacy BH tilize (fifo_page_size == one tile_size):
- *   Tile t is packed to out.l1_address + (output_tile_index + t) * <output tile stride>. The stride folds to a
- *   compile-time constant from the output descriptor via tile_stride_words(OutFormat, OutShape) (16B words):
- *     - linear formats (Float32/Float16/int): geometry-exact datum-count size (SCALE_DATUM_SIZE >> 4);
- *     - block floats (Bfp8/Bfp4/Bfp2): mantissa + shared-exponent section, both scaled by the tile geometry
- *       (matches tt_metal Tile::get_tile_size / the shipping CB page; see internal/llk_descriptor.h::tile_stride_words).
- *   The shipping tilize factories set the output CB page to exactly one tile (output_single_tile_size), so
- *   this matches fifo_page_size for every format the factories use. Remaining edge (no shipping op hits it):
- *   padded / multi-tile CB pages. A caller writing a block into a multi-tile output window may either fold the
- *   destination into out.l1_address (the id-free default) OR pass output_tile_index to shift the first slot;
- *   symmetrically input_tile_index shifts the unpack source (matches legacy tilize_block). Both default to 0,
- *   in which case tile t lands in slot t and the source base is in.l1_address (byte-identical to before).
+ * Per-tile output stride is one tile's L1 size, derived at compile time from the output descriptor's format
+ * and geometry -- this matches the shipping tilize factories' one-tile output CB page. input_tile_index and
+ * output_tile_index (both default 0) shift the unpack source / pack destination tile index; at their
+ * defaults, tile t lands in slot t and the source base is in.l1_address, byte-identical to the legacy op.
  *
  * | Function | in                | Input operand (unpack base; LLK offsets by input_tile_index + t) | LLKOperand |      | True  |
  * | Function | block             | Number of column tiles in the block                             | uint32_t   | > 0  | True  |
@@ -123,8 +115,8 @@ ALWI void tilize_block(
 
 // clang-format off
 /**
- * Experimental id-free tilize uninit. Restore the SrcA/tile config so a subsequent op can reprogram the
- * unpacker, and reset the packer to Default mode.
+ * Id-free tilize uninit. Restores the SrcA/tile config so a subsequent op can reprogram the unpacker, and
+ * resets the packer to Default mode. Blackhole only.
  */
 // clang-format on
 template <DataFormat InFormat, TensorShape InShape, DataFormat OutFormat, TensorShape OutShape>

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/tilize.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/tilize.h
@@ -32,28 +32,34 @@ namespace experimental {
  * are required: the tilize pack init needs the input format as well as the output format/geometry. `block`
  * is the tilize block width (ct_dim) the unpacker MOP is configured for. Blackhole only.
  *
+ * | Template | is_fp32_dest_acc_en | fp32 dest-accumulate mode                     | bool                   |  | False |
  * | Template | InFormat/InShape   | Input buffer L1 format + geometry (deduced)  | DataFormat/TensorShape |  | True |
  * | Template | OutFormat/OutShape | Output buffer L1 format + geometry (deduced)  | DataFormat/TensorShape |  | True |
  * | Function | block              | Tilize block width (ct_dim)                   | uint32_t | > 0 | True |
  */
 // clang-format on
-template <DataFormat InFormat, TensorShape InShape, DataFormat OutFormat, TensorShape OutShape>
+template <
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    DataFormat InFormat,
+    TensorShape InShape,
+    DataFormat OutFormat,
+    TensorShape OutShape>
 ALWI void tilize_init(
     LLKOperand<InFormat, InShape> /*in*/, std::uint32_t block, LLKOperand<OutFormat, OutShape> /*out*/) {
     static_assert(is_legal_tile_shape(InShape), "tilize_init: illegal input tile shape.");
     static_assert(is_legal_tile_shape(OutShape), "tilize_init: illegal output tile shape.");
-    UNPACK((llk_unpack_tilize_init<LLKOperand<InFormat, InShape>::descriptor, DST_ACCUM_MODE>(block)));
+    UNPACK((llk_unpack_tilize_init<LLKOperand<InFormat, InShape>::descriptor, is_fp32_dest_acc_en>(block)));
     MATH((llk_math_eltwise_unary_datacopy_init<
           LLKOperand<InFormat, InShape>::descriptor,
           DataCopyType::A2D,
-          DST_ACCUM_MODE,
+          is_fp32_dest_acc_en,
           BroadcastType::NONE,
           false /*is_int_en*/,
           PackMode::Tilize>()));
     PACK((llk_pack_init<
           LLKOperand<OutFormat, OutShape>::descriptor,
           LLKOperand<InFormat, InShape>::descriptor,
-          DST_ACCUM_MODE,
+          is_fp32_dest_acc_en,
           PackMode::Tilize>(1 /* num_tiles */)));
 }
 
@@ -68,6 +74,7 @@ ALWI void tilize_init(
  * output_tile_index (both default 0) shift the unpack source / pack destination tile index; at their
  * defaults, tile t lands in slot t and the source base is in.l1_address, byte-identical to the legacy op.
  *
+ * | Template | is_fp32_dest_acc_en | fp32 dest-accumulate mode                                       | bool       |      | False |
  * | Function | in                | Input operand (unpack base; LLK offsets by input_tile_index + t) | LLKOperand |      | True  |
  * | Function | block             | Number of column tiles in the block                             | uint32_t   | > 0  | True  |
  * | Function | out               | Output operand (block's first-tile L1 address)                  | LLKOperand |      | True  |
@@ -75,7 +82,12 @@ ALWI void tilize_init(
  * | Function | output_tile_index | Starting tile index added to the pack destination slot          | uint32_t   | >= 0 | False |
  */
 // clang-format on
-template <DataFormat InFormat, TensorShape InShape, DataFormat OutFormat, TensorShape OutShape>
+template <
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    DataFormat InFormat,
+    TensorShape InShape,
+    DataFormat OutFormat,
+    TensorShape OutShape>
 ALWI void tilize_block(
     LLKOperand<InFormat, InShape> in,
     std::uint32_t block,
@@ -86,7 +98,7 @@ ALWI void tilize_block(
     static_assert(is_legal_tile_shape(OutShape), "tilize_block: illegal output tile shape.");
     // Unpack the whole block into srcA first (mirrors llk_unpack_tilize_block), then drain via math+pack.
     for (std::uint32_t t = 0; t < block; t++) {
-        UNPACK((llk_unpack_tilize<LLKOperand<InFormat, InShape>::descriptor, DST_ACCUM_MODE>(
+        UNPACK((llk_unpack_tilize<LLKOperand<InFormat, InShape>::descriptor, is_fp32_dest_acc_en>(
             in.l1_address, input_tile_index + t)));
     }
 
@@ -97,19 +109,19 @@ ALWI void tilize_block(
         MATH((llk_math_eltwise_unary_datacopy<
               LLKOperand<InFormat, InShape>::descriptor,
               DataCopyType::A2D,
-              DST_ACCUM_MODE,
+              is_fp32_dest_acc_en,
               BroadcastType::NONE,
               UnpackToDestEn>(0 /*dst index*/)));
         // Per-tile output slot: out.l1_address + (output_tile_index + t) * one-tile L1 size (via the shared
         // tile_address helper; the stride folds to a compile-time constant).
         PACK((llk_pack<
               LLKOperand<OutFormat, OutShape>::descriptor,
-              DST_ACCUM_MODE,
+              is_fp32_dest_acc_en,
               true /*out_of_order*/,
               PackMode::Default>(0 /*tile index*/, detail::tile_address(out, output_tile_index + t))));
 
-        MATH((llk_math_dest_section_done<DST_ACCUM_MODE>()));
-        PACK((llk_pack_dest_section_done<DST_ACCUM_MODE>()));
+        MATH((llk_math_dest_section_done<is_fp32_dest_acc_en>()));
+        PACK((llk_pack_dest_section_done<is_fp32_dest_acc_en>()));
     }
 }
 

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/tilize.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/tilize.h
@@ -64,27 +64,38 @@ ALWI void tilize_init(
  * and out.l1_address (the block's first output tile).
  *
  * PER-TILE OUTPUT ADDRESSING vs the legacy BH tilize (fifo_page_size == one tile_size):
- *   Tile t is packed to out.l1_address + t * <output tile stride>. The stride folds to a compile-time
- *   constant from the output descriptor via tile_stride_words(OutFormat, OutShape) (16B words):
+ *   Tile t is packed to out.l1_address + (output_tile_index + t) * <output tile stride>. The stride folds to a
+ *   compile-time constant from the output descriptor via tile_stride_words(OutFormat, OutShape) (16B words):
  *     - linear formats (Float32/Float16/int): geometry-exact datum-count size (SCALE_DATUM_SIZE >> 4);
  *     - block floats (Bfp8/Bfp4/Bfp2): mantissa + shared-exponent section, both scaled by the tile geometry
  *       (matches tt_metal Tile::get_tile_size / the shipping CB page; see internal/llk_descriptor.h::tile_stride_words).
  *   The shipping tilize factories set the output CB page to exactly one tile (output_single_tile_size), so
  *   this matches fifo_page_size for every format the factories use. Remaining edge (no shipping op hits it):
- *   padded / multi-tile CB pages.
+ *   padded / multi-tile CB pages. A caller writing a block into a multi-tile output window may either fold the
+ *   destination into out.l1_address (the id-free default) OR pass output_tile_index to shift the first slot;
+ *   symmetrically input_tile_index shifts the unpack source (matches legacy tilize_block). Both default to 0,
+ *   in which case tile t lands in slot t and the source base is in.l1_address (byte-identical to before).
  *
- * | Function | in    | Input operand (unpack base; LLK offsets by tile_index) | LLKOperand |     | True |
- * | Function | block | Number of column tiles in the block                    | uint32_t   | > 0 | True |
- * | Function | out   | Output operand (first tile's L1 address)               | LLKOperand |     | True |
+ * | Function | in                | Input operand (unpack base; LLK offsets by input_tile_index + t) | LLKOperand |      | True  |
+ * | Function | block             | Number of column tiles in the block                             | uint32_t   | > 0  | True  |
+ * | Function | out               | Output operand (block's first-tile L1 address)                  | LLKOperand |      | True  |
+ * | Function | input_tile_index  | Starting tile index added to the unpack source index            | uint32_t   | >= 0 | False |
+ * | Function | output_tile_index | Starting tile index added to the pack destination slot          | uint32_t   | >= 0 | False |
  */
 // clang-format on
 template <DataFormat InFormat, TensorShape InShape, DataFormat OutFormat, TensorShape OutShape>
-ALWI void tilize_block(LLKOperand<InFormat, InShape> in, std::uint32_t block, LLKOperand<OutFormat, OutShape> out) {
+ALWI void tilize_block(
+    LLKOperand<InFormat, InShape> in,
+    std::uint32_t block,
+    LLKOperand<OutFormat, OutShape> out,
+    std::uint32_t input_tile_index = 0,
+    std::uint32_t output_tile_index = 0) {
     static_assert(is_legal_tile_shape(InShape), "tilize_block: illegal input tile shape.");
     static_assert(is_legal_tile_shape(OutShape), "tilize_block: illegal output tile shape.");
     // Unpack the whole block into srcA first (mirrors llk_unpack_tilize_block), then drain via math+pack.
     for (std::uint32_t t = 0; t < block; t++) {
-        UNPACK((llk_unpack_tilize<LLKOperand<InFormat, InShape>::descriptor, DST_ACCUM_MODE>(in.l1_address, t)));
+        UNPACK((llk_unpack_tilize<LLKOperand<InFormat, InShape>::descriptor, DST_ACCUM_MODE>(
+            in.l1_address, input_tile_index + t)));
     }
 
     for (std::uint32_t t = 0; t < block; t++) {
@@ -97,13 +108,13 @@ ALWI void tilize_block(LLKOperand<InFormat, InShape> in, std::uint32_t block, LL
               DST_ACCUM_MODE,
               BroadcastType::NONE,
               UnpackToDestEn>(0 /*dst index*/)));
-        // Per-tile output slot: out.l1_address + t * one-tile L1 size (via the shared tile_address helper;
-        // the stride folds to a compile-time constant).
+        // Per-tile output slot: out.l1_address + (output_tile_index + t) * one-tile L1 size (via the shared
+        // tile_address helper; the stride folds to a compile-time constant).
         PACK((llk_pack<
               LLKOperand<OutFormat, OutShape>::descriptor,
               DST_ACCUM_MODE,
               true /*out_of_order*/,
-              PackMode::Default>(0 /*tile index*/, detail::tile_address(out, t))));
+              PackMode::Default>(0 /*tile index*/, detail::tile_address(out, output_tile_index + t))));
 
         MATH((llk_math_dest_section_done<DST_ACCUM_MODE>()));
         PACK((llk_pack_dest_section_done<DST_ACCUM_MODE>()));

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/tilize.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/tilize.h
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/common_globals.h"
+#include "api/compute/experimental/2_0/llk_operand.h"
+
+#ifdef TRISC_MATH
+#include "experimental/2_0/llk_math_unary_datacopy.h"
+#endif
+
+#ifdef TRISC_UNPACK
+#include "experimental/2_0/llk_unpack_tilize.h"
+#endif
+
+#ifdef TRISC_PACK
+#include "experimental/2_0/llk_pack_tile.h"
+#endif
+
+namespace ckernel {
+namespace experimental {
+
+#ifdef ARCH_BLACKHOLE
+
+// clang-format off
+/**
+ * Experimental id-free tilize init. Takes an input and an output LLKOperand (data format + tile geometry
+ * as NTTPs, deduced from the arguments) instead of CB ids; register formats are derived INSIDE the LLK. The
+ * tilize pack init needs the input format (8-bit tilize workaround) plus the output format/geometry, hence
+ * both operands. `block` is the tilize block width (ct_dim) the unpacker MOP is configured for.
+ *
+ * | Template | InFormat/InShape   | Input buffer L1 format + geometry (deduced)  | DataFormat/TensorShape |  | True |
+ * | Template | OutFormat/OutShape | Output buffer L1 format + geometry (deduced)  | DataFormat/TensorShape |  | True |
+ * | Function | block              | Tilize block width (ct_dim)                   | uint32_t | > 0 | True |
+ */
+// clang-format on
+template <DataFormat InFormat, TensorShape InShape, DataFormat OutFormat, TensorShape OutShape>
+ALWI void tilize_init(
+    LLKOperand<InFormat, InShape> /*in*/, std::uint32_t block, LLKOperand<OutFormat, OutShape> /*out*/) {
+    static_assert(is_legal_tile_shape(InShape), "tilize_init: illegal input tile shape.");
+    static_assert(is_legal_tile_shape(OutShape), "tilize_init: illegal output tile shape.");
+    UNPACK((llk_unpack_tilize_init<LLKOperand<InFormat, InShape>::descriptor, DST_ACCUM_MODE>(block)));
+    MATH((llk_math_eltwise_unary_datacopy_init<
+          LLKOperand<InFormat, InShape>::descriptor,
+          DataCopyType::A2D,
+          DST_ACCUM_MODE,
+          BroadcastType::NONE,
+          false /*is_int_en*/,
+          PackMode::Tilize>()));
+    PACK((llk_pack_init<
+          LLKOperand<OutFormat, OutShape>::descriptor,
+          LLKOperand<InFormat, InShape>::descriptor,
+          DST_ACCUM_MODE,
+          PackMode::Tilize>(1 /* num_tiles */)));
+}
+
+// clang-format off
+/**
+ * Experimental id-free tilize of one block. The op owns the block loop and self-syncs Dest per tile (no
+ * kernel tile_regs). Runtime "where": in.l1_address (unpack base -- the LLK offsets by tile_index inside)
+ * and out.l1_address (the block's first output tile).
+ *
+ * PER-TILE OUTPUT ADDRESSING vs the legacy BH tilize (fifo_page_size == one tile_size):
+ *   Tile t is packed to out.l1_address + t * <output tile stride>. The stride folds to a compile-time
+ *   constant from the output descriptor via tile_stride_words(OutFormat, OutShape) (16B words):
+ *     - linear formats (Float32/Float16/int): geometry-exact datum-count size (SCALE_DATUM_SIZE >> 4);
+ *     - block floats (Bfp8/Bfp4/Bfp2): GET_L1_HEADERLESS_TILE_SIZE -- the shared-exponent section included,
+ *       matching tile_size(fmt) / the shipping CB page (see internal/llk_descriptor.h::tile_stride_words).
+ *   The shipping tilize factories set the output CB page to exactly one tile (output_single_tile_size), so
+ *   this matches fifo_page_size for every format the factories use. Remaining edge (no shipping op hits it):
+ *   padded / multi-tile CB pages, and partial/tiny BFP tiles (tile_stride_words uses full-tile BFP size).
+ *
+ * | Function | in    | Input operand (unpack base; LLK offsets by tile_index) | LLKOperand |     | True |
+ * | Function | block | Number of column tiles in the block                    | uint32_t   | > 0 | True |
+ * | Function | out   | Output operand (first tile's L1 address)               | LLKOperand |     | True |
+ */
+// clang-format on
+template <DataFormat InFormat, TensorShape InShape, DataFormat OutFormat, TensorShape OutShape>
+ALWI void tilize_block(LLKOperand<InFormat, InShape> in, std::uint32_t block, LLKOperand<OutFormat, OutShape> out) {
+    static_assert(is_legal_tile_shape(InShape), "tilize_block: illegal input tile shape.");
+    static_assert(is_legal_tile_shape(OutShape), "tilize_block: illegal output tile shape.");
+    // Unpack the whole block into srcA first (mirrors llk_unpack_tilize_block), then drain via math+pack.
+    for (std::uint32_t t = 0; t < block; t++) {
+        UNPACK((llk_unpack_tilize<LLKOperand<InFormat, InShape>::descriptor, DST_ACCUM_MODE>(in.l1_address, t)));
+    }
+
+    for (std::uint32_t t = 0; t < block; t++) {
+        MATH((llk_math_wait_for_dest_available()));
+        PACK((llk_packer_wait_for_math_done()));
+
+        MATH((llk_math_eltwise_unary_datacopy<
+              LLKOperand<InFormat, InShape>::descriptor,
+              DataCopyType::A2D,
+              DST_ACCUM_MODE,
+              BroadcastType::NONE,
+              UnpackToDestEn>(0 /*dst index*/)));
+        // Per-tile output slot: out.l1_address + t * one-tile L1 size (via the shared tile_address helper;
+        // the stride folds to a compile-time constant).
+        PACK((llk_pack<
+              LLKOperand<OutFormat, OutShape>::descriptor,
+              DST_ACCUM_MODE,
+              true /*out_of_order*/,
+              PackMode::Default>(0 /*tile index*/, detail::tile_address(out, t))));
+
+        MATH((llk_math_dest_section_done<DST_ACCUM_MODE>()));
+        PACK((llk_pack_dest_section_done<DST_ACCUM_MODE>()));
+    }
+}
+
+// clang-format off
+/**
+ * Experimental id-free tilize uninit. Restore the SrcA/tile config so a subsequent op can reprogram the
+ * unpacker, and reset the packer to Default mode.
+ */
+// clang-format on
+template <DataFormat InFormat, TensorShape InShape, DataFormat OutFormat, TensorShape OutShape>
+ALWI void tilize_uninit(LLKOperand<InFormat, InShape> /*in*/, LLKOperand<OutFormat, OutShape> /*out*/) {
+    UNPACK((llk_unpack_tilize_uninit<LLKOperand<InFormat, InShape>::descriptor, DST_ACCUM_MODE>()));
+    PACK((llk_pack_init<LLKOperand<OutFormat, OutShape>::descriptor, DST_ACCUM_MODE, PackMode::Default>()));
+}
+
+#endif  // ARCH_BLACKHOLE
+
+}  // namespace experimental
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/tilize.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/tilize.h
@@ -127,12 +127,19 @@ ALWI void tilize_block(
 /**
  * Id-free tilize uninit. Restores the SrcA/tile config so a subsequent op can reprogram the unpacker, and
  * resets the packer to Default mode. Blackhole only.
+ *
+ * | Template | is_fp32_dest_acc_en | fp32 dest-accumulate mode | bool | | False |
  */
 // clang-format on
-template <DataFormat InFormat, TensorShape InShape, DataFormat OutFormat, TensorShape OutShape>
+template <
+    bool is_fp32_dest_acc_en = DST_ACCUM_MODE,
+    DataFormat InFormat,
+    TensorShape InShape,
+    DataFormat OutFormat,
+    TensorShape OutShape>
 ALWI void tilize_uninit(LLKOperand<InFormat, InShape> /*in*/, LLKOperand<OutFormat, OutShape> /*out*/) {
-    UNPACK((llk_unpack_tilize_uninit<LLKOperand<InFormat, InShape>::descriptor, DST_ACCUM_MODE>()));
-    PACK((llk_pack_init<LLKOperand<OutFormat, OutShape>::descriptor, DST_ACCUM_MODE, PackMode::Default>()));
+    UNPACK((llk_unpack_tilize_uninit<LLKOperand<InFormat, InShape>::descriptor, is_fp32_dest_acc_en>()));
+    PACK((llk_pack_init<LLKOperand<OutFormat, OutShape>::descriptor, is_fp32_dest_acc_en, PackMode::Default>()));
 }
 
 }  // namespace experimental

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/tilize.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/tilize.h
@@ -23,8 +23,6 @@
 namespace ckernel {
 namespace experimental {
 
-#ifdef ARCH_BLACKHOLE
-
 // clang-format off
 /**
  * Id-free tilize init. Takes an input and an output LLKOperand (data format + tile geometry as NTTPs,
@@ -136,8 +134,6 @@ ALWI void tilize_uninit(LLKOperand<InFormat, InShape> /*in*/, LLKOperand<OutForm
     UNPACK((llk_unpack_tilize_uninit<LLKOperand<InFormat, InShape>::descriptor, DST_ACCUM_MODE>()));
     PACK((llk_pack_init<LLKOperand<OutFormat, OutShape>::descriptor, DST_ACCUM_MODE, PackMode::Default>()));
 }
-
-#endif  // ARCH_BLACKHOLE
 
 }  // namespace experimental
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/transpose.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/transpose.h
@@ -7,7 +7,6 @@
 #include <cstdint>
 #include "api/compute/common_globals.h"
 #include "api/compute/experimental/2_0/llk_operand.h"
-#include "data_format_derive.h"  // ckernel::infer_unpack_dst_format -- pure constexpr, used unconditionally below
 
 #ifdef TRISC_MATH
 #include "experimental/2_0/llk_math_unary_datacopy.h"
@@ -29,8 +28,6 @@
 namespace ckernel {
 namespace experimental {
 
-#ifdef ARCH_BLACKHOLE
-
 // clang-format off
 /**
  * Init for transpose_tile / transpose_block. Takes an LLKOperand whose data format + tile geometry are NTTPs
@@ -47,22 +44,13 @@ namespace experimental {
  * | Function   | src    | The source L1 operand (format + shape; address unused here)   | LLKOperand  | N/A         | True     |
  */
 // clang-format on
-namespace detail {
-// True iff transpose takes the unpack-to-dest (A2D) path: the operand's REGISTER format (after
-// infer_unpack_dst_format) is 32-bit. Shared by transpose_init / transpose_tile.
-template <DataFormat Format, bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
-constexpr bool transpose_unpack_to_dest() {
-    return is_32bit_format(ckernel::infer_unpack_dst_format(Format, is_fp32_dest_acc_en));
-}
-}  // namespace detail
-
 template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE, DataFormat Format, TensorShape Shape>
 ALWI void transpose_init(LLKOperand<Format, Shape> /*src*/) {
     static_assert(
         is_legal_tile_shape(Shape),
         "transpose_init: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
 
-    constexpr bool enable_unpack_to_dest = detail::transpose_unpack_to_dest<Format, is_fp32_dest_acc_en>();
+    constexpr bool enable_unpack_to_dest = is_unpack_to_dest<Format, is_fp32_dest_acc_en>();
     // Low-nibble compare intentionally matches both signed Int8 (14) and unsigned UInt8 (30 -> low nibble
     // 0xE): both 8-bit integer formats need the int-FPU (ELWADD) A2D reconstruct path.
     constexpr bool is_8bit_int =
@@ -122,7 +110,7 @@ ALWI void transpose_tile(LLKOperand<Format, Shape> src, std::uint32_t itile, std
         is_legal_tile_shape(Shape),
         "transpose_tile: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
 
-    constexpr bool enable_unpack_to_dest = detail::transpose_unpack_to_dest<Format, is_fp32_dest_acc_en>();
+    constexpr bool enable_unpack_to_dest = is_unpack_to_dest<Format, is_fp32_dest_acc_en>();
     const std::uint32_t addr = detail::tile_address(src, itile);
 
     if constexpr (enable_unpack_to_dest) {
@@ -184,8 +172,6 @@ ALWI void transpose_block(
         transpose_tile<is_fp32_dest_acc_en>(src, start_itile + i, start_idst + i);
     }
 }
-
-#endif  // ARCH_BLACKHOLE
 
 }  // namespace experimental
 }  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/transpose.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/transpose.h
@@ -20,14 +20,10 @@
 #endif
 
 // =====================================================================================================
-// Id-free (2.0) transpose (input transpose / transpose WH). Takes a single input LLKOperand whose data
-// format + tile geometry are NTTPs. Mirrors the legacy Blackhole transpose.h 3-way init split (unpack-to-dest
-// for 32-bit dst formats, the int-FPU A2D reconstruct path for 8-bit integer formats, default otherwise) --
-// but the split is resolved via `if constexpr` on the operand's compile-time Format instead of a runtime CB
-// format lookup, since there is no CB id here. The underlying LLKs (id-free llk_unpack_A / id-free
-// llk_math_eltwise_unary_datacopy, plus the format-free llk_math_transpose_dest reused as-is) are exactly
-// the ones tile_move_copy.h's copy_tile already uses. Blackhole only; the Quasar transpose path is a
-// completely separate LLK generation and is not ported here.
+// Id-free (2.0) transpose: transposes one input tile into DST. Takes a single input LLKOperand (format +
+// tile geometry as NTTPs). The init selects one of three unpack/math paths -- unpack-to-dest for 32-bit dst
+// formats, the int-FPU A2D reconstruct path for 8-bit integer formats, default otherwise -- entirely at
+// compile time via `if constexpr` on the operand's Format (no CB id / runtime lookup). Blackhole only.
 // =====================================================================================================
 
 namespace ckernel {
@@ -37,12 +33,11 @@ namespace experimental {
 
 // clang-format off
 /**
- * Paired init function for transpose_tile / transpose_block. Takes an LLKOperand whose data format + tile
- * geometry are NTTPs (deduced from the argument). Selects, entirely at compile time, among the three
- * unpack/math configurations the legacy Blackhole transpose_init selects at runtime from the CB's formats:
- * unpack-to-dest for 32-bit dst formats (Float32/UInt32/Int32), the int-FPU (ELWADD) A2D reconstruct path
- * for 8-bit integer formats (Int8/UInt8), and the default path for everything else. compute_kernel_hw_startup
- * must already have run once. No CB id, no register format on the API surface.
+ * Init for transpose_tile / transpose_block. Takes an LLKOperand whose data format + tile geometry are NTTPs
+ * (deduced from the argument). Selects, entirely at compile time, one of three unpack/math configurations:
+ * unpack-to-dest for 32-bit dst formats (Float32/UInt32/Int32), the int-FPU (ELWADD) A2D reconstruct path for
+ * 8-bit integer formats (Int8/UInt8), or the default path otherwise. compute_kernel_hw_startup must already
+ * have run once.
  *
  * | Param Type | Name   | Description                                                   | Type        | Valid Range | Required |
  * |------------|--------|----------------------------------------------------------------|-------------|-------------|----------|
@@ -52,9 +47,8 @@ namespace experimental {
  */
 // clang-format on
 namespace detail {
-// True iff transpose takes the unpack-to-dest (A2D) path: the operand's REGISTER format (after the datacopy
-// Float32-rebias via infer_unpack_dst_format) is 32-bit. Shared by transpose_init / transpose_tile. NOTE this
-// runs Format through infer_unpack_dst_format first, unlike the unary-bcast select which tests Format directly.
+// True iff transpose takes the unpack-to-dest (A2D) path: the operand's REGISTER format (after
+// infer_unpack_dst_format) is 32-bit. Shared by transpose_init / transpose_tile.
 template <DataFormat Format>
 constexpr bool transpose_unpack_to_dest() {
     return is_32bit_format(ckernel::infer_unpack_dst_format(Format, DST_ACCUM_MODE));
@@ -88,11 +82,8 @@ ALWI void transpose_init(LLKOperand<Format, Shape> /*src*/) {
               BroadcastType::NONE>()));
         MATH((llk_math_transpose_dest_init<false, true>()));
     } else {
-        // Non-unpack-to-dest path (default + 8-bit integer). The unpack init is identical for both; the only
-        // difference is that 8-bit integer (Int8/UInt8) transpose needs the int-FPU (ELWADD) A2D reconstruct
-        // path, selected via the datacopy init's is_int_fpu_en NTTP (== is_8bit_int; false for the default
-        // path). Ideally the LLK layer would infer this from the data format. TODO: #46832 (same limitation as
-        // the legacy op).
+        // Non-unpack-to-dest path (default + 8-bit integer). Unpack init is identical for both; only the
+        // datacopy init's is_int_fpu_en NTTP differs (true for 8-bit integer, false for default).
         UNPACK((llk_unpack_A_init<
                 LLKOperand<Format, Shape>::descriptor,
                 DST_ACCUM_MODE,
@@ -165,14 +156,10 @@ ALWI void transpose_tile(LLKOperand<Format, Shape> src, std::uint32_t itile, std
 // clang-format off
 /**
  * Performs a 32x32 transpose operation *B[w,h] = A[h,w]* on `ntiles` consecutive tiles from the L1 region
- * described by the LLKOperand, writing each result to a consecutive DST register slot. Block/loop form of
- * transpose_tile: tile `start_itile+i` lands in DST slot `start_idst+i`. Reuses the existing 2.0
- * transpose_tile per tile. Requires the same init as transpose_tile (transpose_init). DST must be in the
- * acquired state. This call is blocking and is only available on the compute engine.
- *
- * NOTE: The loop implementation is transitional, matching the legacy transpose_block. In the future this
- * for-loop must be folded into a hardware MOP / REPLAY buffer so the whole block issues as a single packed
- * op; the blocking then lives in llk-lib without changing this signature.
+ * described by the LLKOperand, writing each result to a consecutive DST register slot: tile `start_itile+i`
+ * lands in DST slot `start_idst+i`. Requires the same init as transpose_tile (transpose_init). DST must be in
+ * the acquired state. This call is blocking and is only available on the compute engine. Currently
+ * implemented as a per-tile loop over transpose_tile.
  *
  * | Param Type | Name        | Description                                                      | Type        | Valid Range                                    | Required |
  * |------------|-------------|-------------------------------------------------------------------|-------------|-------------------------------------------------|----------|

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/transpose.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/transpose.h
@@ -1,0 +1,201 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/common_globals.h"
+#include "api/compute/experimental/2_0/llk_operand.h"
+#include "data_format_derive.h"  // ckernel::infer_unpack_dst_format -- pure constexpr, used unconditionally below
+
+#ifdef TRISC_MATH
+#include "experimental/2_0/llk_math_unary_datacopy.h"
+#include "llk_math_transpose_dest_api.h"
+#endif
+
+#ifdef TRISC_UNPACK
+#include "experimental/2_0/llk_unpack_A.h"
+#include "llk_unpack_common_api.h"  // llk_unpack_set_srcb_dummy_valid
+#endif
+
+// =====================================================================================================
+// Id-free (2.0) transpose (input transpose / transpose WH). Takes a single input LLKOperand whose data
+// format + tile geometry are NTTPs. Mirrors the legacy Blackhole transpose.h 3-way init split (unpack-to-dest
+// for 32-bit dst formats, the int-FPU A2D reconstruct path for 8-bit integer formats, default otherwise) --
+// but the split is resolved via `if constexpr` on the operand's compile-time Format instead of a runtime CB
+// format lookup, since there is no CB id here. The underlying LLKs (id-free llk_unpack_A / id-free
+// llk_math_eltwise_unary_datacopy, plus the format-free llk_math_transpose_dest reused as-is) are exactly
+// the ones tile_move_copy.h's copy_tile already uses. Blackhole only; the Quasar transpose path is a
+// completely separate LLK generation and is not ported here.
+// =====================================================================================================
+
+namespace ckernel {
+namespace experimental {
+
+#ifdef ARCH_BLACKHOLE
+
+// clang-format off
+/**
+ * Paired init function for transpose_tile / transpose_block. Takes an LLKOperand whose data format + tile
+ * geometry are NTTPs (deduced from the argument). Selects, entirely at compile time, among the three
+ * unpack/math configurations the legacy Blackhole transpose_init selects at runtime from the CB's formats:
+ * unpack-to-dest for 32-bit dst formats (Float32/UInt32/Int32), the int-FPU (ELWADD) A2D reconstruct path
+ * for 8-bit integer formats (Int8/UInt8), and the default path for everything else. compute_kernel_hw_startup
+ * must already have run once. No CB id, no register format on the API surface.
+ *
+ * | Param Type | Name   | Description                                                   | Type        | Valid Range | Required |
+ * |------------|--------|----------------------------------------------------------------|-------------|-------------|----------|
+ * | Template   | Format | Buffer L1 data format (deduced from the LLKOperand argument)   | DataFormat  | N/A         | True     |
+ * | Template   | Shape  | Tile geometry (deduced from the LLKOperand argument)           | TensorShape | N/A         | True     |
+ * | Function   | src    | The source L1 operand (format + shape; address unused here)   | LLKOperand  | N/A         | True     |
+ */
+// clang-format on
+namespace detail {
+// True iff transpose takes the unpack-to-dest (A2D) path: the operand's REGISTER format (after the datacopy
+// Float32-rebias via infer_unpack_dst_format) is 32-bit. Shared by transpose_init / transpose_tile. NOTE this
+// runs Format through infer_unpack_dst_format first, unlike the unary-bcast select which tests Format directly.
+template <DataFormat Format>
+constexpr bool transpose_unpack_to_dest() {
+    return is_32bit_format(ckernel::infer_unpack_dst_format(Format, DST_ACCUM_MODE));
+}
+}  // namespace detail
+
+template <DataFormat Format, TensorShape Shape>
+ALWI void transpose_init(LLKOperand<Format, Shape> /*src*/) {
+    static_assert(
+        is_legal_tile_shape(Shape),
+        "transpose_init: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
+
+    constexpr bool enable_unpack_to_dest = detail::transpose_unpack_to_dest<Format>();
+    // Low-nibble compare intentionally matches both signed Int8 (14) and unsigned UInt8 (30 -> low nibble
+    // 0xE): both 8-bit integer formats need the int-FPU (ELWADD) A2D reconstruct path.
+    constexpr bool is_8bit_int =
+        (static_cast<std::uint8_t>(Format) & 0xf) == static_cast<std::uint8_t>(DataFormat::Int8);
+
+    if constexpr (enable_unpack_to_dest) {
+        UNPACK((llk_unpack_A_init<
+                LLKOperand<Format, Shape>::descriptor,
+                DST_ACCUM_MODE,
+                BroadcastType::NONE,
+                false /*acc_to_dest*/,
+                EltwiseBinaryReuseDestType::NONE,
+                UnpackToDestEn>(true /*transpose_of_faces*/, false /*within_face_16x16_transpose*/)));
+        MATH((llk_math_eltwise_unary_datacopy_init<
+              LLKOperand<Format, Shape>::descriptor,
+              DataCopyType::A2D,
+              DST_ACCUM_MODE,
+              BroadcastType::NONE>()));
+        MATH((llk_math_transpose_dest_init<false, true>()));
+    } else {
+        // Non-unpack-to-dest path (default + 8-bit integer). The unpack init is identical for both; the only
+        // difference is that 8-bit integer (Int8/UInt8) transpose needs the int-FPU (ELWADD) A2D reconstruct
+        // path, selected via the datacopy init's is_int_fpu_en NTTP (== is_8bit_int; false for the default
+        // path). Ideally the LLK layer would infer this from the data format. TODO: #46832 (same limitation as
+        // the legacy op).
+        UNPACK((llk_unpack_A_init<
+                LLKOperand<Format, Shape>::descriptor,
+                DST_ACCUM_MODE,
+                BroadcastType::NONE,
+                true /*acc_to_dest*/,
+                EltwiseBinaryReuseDestType::NONE>(true /*transpose_of_faces*/, true /*within_face_16x16_transpose*/)));
+        MATH((llk_math_eltwise_unary_datacopy_init<
+              LLKOperand<Format, Shape>::descriptor,
+              DataCopyType::A2D,
+              DST_ACCUM_MODE,
+              BroadcastType::NONE,
+              is_8bit_int /*is_int_fpu_en*/>()));
+    }
+}
+
+// clang-format off
+/**
+ * Performs a 32x32 transpose operation *B[w,h] = A[h,w]* on one tile from the L1 region described by the
+ * LLKOperand and writes the result to DST[idst]. DST must be in the acquired state (tile_regs_acquire).
+ * This call is blocking and is only available on the compute engine. Pair with transpose_init.
+ *
+ * | Param Type | Name   | Description                                                  | Type        | Valid Range                                    | Required |
+ * |------------|--------|---------------------------------------------------------------|-------------|-------------------------------------------------|----------|
+ * | Template   | Format | Buffer L1 data format (deduced from the LLKOperand argument)  | DataFormat  | N/A                                             | True     |
+ * | Template   | Shape  | Tile geometry (deduced from the LLKOperand argument)          | TensorShape | N/A                                             | True     |
+ * | Function   | src    | The source L1 operand (format + shape + base address)         | LLKOperand  | N/A                                             | True     |
+ * | Function   | itile  | Index of the tile A within `src`, relative to its base address| uint32_t    | N/A                                             | True     |
+ * | Function   | idst   | Index of the tile in DST REG for the result B                 | uint32_t    | Must be less than the acquired size of DST REG | True     |
+ */
+// clang-format on
+template <DataFormat Format, TensorShape Shape>
+ALWI void transpose_tile(LLKOperand<Format, Shape> src, std::uint32_t itile, std::uint32_t idst) {
+    static_assert(
+        is_legal_tile_shape(Shape),
+        "transpose_tile: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
+
+    constexpr bool enable_unpack_to_dest = detail::transpose_unpack_to_dest<Format>();
+    const std::uint32_t addr = detail::tile_address(src, itile);
+
+    if constexpr (enable_unpack_to_dest) {
+        UNPACK((llk_unpack_A<
+                LLKOperand<Format, Shape>::descriptor,
+                DST_ACCUM_MODE,
+                BroadcastType::NONE,
+                false /*acc_to_dest*/,
+                EltwiseBinaryReuseDestType::NONE,
+                UnpackToDestEn>(addr)));
+        UNPACK((llk_unpack_set_srcb_dummy_valid()));
+        MATH((llk_math_eltwise_unary_datacopy<
+              LLKOperand<Format, Shape>::descriptor,
+              DataCopyType::A2D,
+              DST_ACCUM_MODE,
+              BroadcastType::NONE,
+              UnpackToDestEn>(idst)));
+        MATH((llk_math_transpose_dest<false, true>(idst)));
+    } else {
+        UNPACK((llk_unpack_A<
+                LLKOperand<Format, Shape>::descriptor,
+                DST_ACCUM_MODE,
+                BroadcastType::NONE,
+                false /*acc_to_dest*/>(addr)));
+        MATH((llk_math_eltwise_unary_datacopy<
+              LLKOperand<Format, Shape>::descriptor,
+              DataCopyType::A2D,
+              DST_ACCUM_MODE,
+              BroadcastType::NONE>(idst)));
+    }
+}
+
+// clang-format off
+/**
+ * Performs a 32x32 transpose operation *B[w,h] = A[h,w]* on `ntiles` consecutive tiles from the L1 region
+ * described by the LLKOperand, writing each result to a consecutive DST register slot. Block/loop form of
+ * transpose_tile: tile `start_itile+i` lands in DST slot `start_idst+i`. Reuses the existing 2.0
+ * transpose_tile per tile. Requires the same init as transpose_tile (transpose_init). DST must be in the
+ * acquired state. This call is blocking and is only available on the compute engine.
+ *
+ * NOTE: The loop implementation is transitional, matching the legacy transpose_block. In the future this
+ * for-loop must be folded into a hardware MOP / REPLAY buffer so the whole block issues as a single packed
+ * op; the blocking then lives in llk-lib without changing this signature.
+ *
+ * | Param Type | Name        | Description                                                      | Type        | Valid Range                                    | Required |
+ * |------------|-------------|-------------------------------------------------------------------|-------------|-------------------------------------------------|----------|
+ * | Template   | Format      | Buffer L1 data format (deduced from the LLKOperand argument)      | DataFormat  | N/A                                             | True     |
+ * | Template   | Shape       | Tile geometry (deduced from the LLKOperand argument)              | TensorShape | N/A                                             | True     |
+ * | Function   | src         | The source L1 operand (format + shape + base address)             | LLKOperand  | N/A                                             | True     |
+ * | Function   | start_itile | Index of the first tile A within `src`, relative to its base addr | uint32_t    | N/A                                             | True     |
+ * | Function   | start_idst  | Index of the first destination tile in DST REG                    | uint32_t    | Must be less than the acquired size of DST REG | True     |
+ * | Function   | ntiles      | The number of consecutive tiles to transpose                      | uint32_t    | start_idst + ntiles <= acquired DST REG size   | True     |
+ */
+// clang-format on
+template <DataFormat Format, TensorShape Shape>
+ALWI void transpose_block(
+    LLKOperand<Format, Shape> src, std::uint32_t start_itile, std::uint32_t start_idst, std::uint32_t ntiles) {
+    static_assert(
+        is_legal_tile_shape(Shape),
+        "transpose_block: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
+    for (std::uint32_t i = 0; i < ntiles; ++i) {
+        transpose_tile(src, start_itile + i, start_idst + i);
+    }
+}
+
+#endif  // ARCH_BLACKHOLE
+
+}  // namespace experimental
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/2_0/transpose.h
+++ b/tt_metal/hw/inc/api/compute/experimental/2_0/transpose.h
@@ -41,6 +41,7 @@ namespace experimental {
  *
  * | Param Type | Name   | Description                                                   | Type        | Valid Range | Required |
  * |------------|--------|----------------------------------------------------------------|-------------|-------------|----------|
+ * | Template   | is_fp32_dest_acc_en | Whether DEST is in fp32 accumulation mode         | bool        | N/A         | False    |
  * | Template   | Format | Buffer L1 data format (deduced from the LLKOperand argument)   | DataFormat  | N/A         | True     |
  * | Template   | Shape  | Tile geometry (deduced from the LLKOperand argument)           | TensorShape | N/A         | True     |
  * | Function   | src    | The source L1 operand (format + shape; address unused here)   | LLKOperand  | N/A         | True     |
@@ -49,19 +50,19 @@ namespace experimental {
 namespace detail {
 // True iff transpose takes the unpack-to-dest (A2D) path: the operand's REGISTER format (after
 // infer_unpack_dst_format) is 32-bit. Shared by transpose_init / transpose_tile.
-template <DataFormat Format>
+template <DataFormat Format, bool is_fp32_dest_acc_en = DST_ACCUM_MODE>
 constexpr bool transpose_unpack_to_dest() {
-    return is_32bit_format(ckernel::infer_unpack_dst_format(Format, DST_ACCUM_MODE));
+    return is_32bit_format(ckernel::infer_unpack_dst_format(Format, is_fp32_dest_acc_en));
 }
 }  // namespace detail
 
-template <DataFormat Format, TensorShape Shape>
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE, DataFormat Format, TensorShape Shape>
 ALWI void transpose_init(LLKOperand<Format, Shape> /*src*/) {
     static_assert(
         is_legal_tile_shape(Shape),
         "transpose_init: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
 
-    constexpr bool enable_unpack_to_dest = detail::transpose_unpack_to_dest<Format>();
+    constexpr bool enable_unpack_to_dest = detail::transpose_unpack_to_dest<Format, is_fp32_dest_acc_en>();
     // Low-nibble compare intentionally matches both signed Int8 (14) and unsigned UInt8 (30 -> low nibble
     // 0xE): both 8-bit integer formats need the int-FPU (ELWADD) A2D reconstruct path.
     constexpr bool is_8bit_int =
@@ -70,7 +71,7 @@ ALWI void transpose_init(LLKOperand<Format, Shape> /*src*/) {
     if constexpr (enable_unpack_to_dest) {
         UNPACK((llk_unpack_A_init<
                 LLKOperand<Format, Shape>::descriptor,
-                DST_ACCUM_MODE,
+                is_fp32_dest_acc_en,
                 BroadcastType::NONE,
                 false /*acc_to_dest*/,
                 EltwiseBinaryReuseDestType::NONE,
@@ -78,7 +79,7 @@ ALWI void transpose_init(LLKOperand<Format, Shape> /*src*/) {
         MATH((llk_math_eltwise_unary_datacopy_init<
               LLKOperand<Format, Shape>::descriptor,
               DataCopyType::A2D,
-              DST_ACCUM_MODE,
+              is_fp32_dest_acc_en,
               BroadcastType::NONE>()));
         MATH((llk_math_transpose_dest_init<false, true>()));
     } else {
@@ -86,14 +87,14 @@ ALWI void transpose_init(LLKOperand<Format, Shape> /*src*/) {
         // datacopy init's is_int_fpu_en NTTP differs (true for 8-bit integer, false for default).
         UNPACK((llk_unpack_A_init<
                 LLKOperand<Format, Shape>::descriptor,
-                DST_ACCUM_MODE,
+                is_fp32_dest_acc_en,
                 BroadcastType::NONE,
                 true /*acc_to_dest*/,
                 EltwiseBinaryReuseDestType::NONE>(true /*transpose_of_faces*/, true /*within_face_16x16_transpose*/)));
         MATH((llk_math_eltwise_unary_datacopy_init<
               LLKOperand<Format, Shape>::descriptor,
               DataCopyType::A2D,
-              DST_ACCUM_MODE,
+              is_fp32_dest_acc_en,
               BroadcastType::NONE,
               is_8bit_int /*is_int_fpu_en*/>()));
     }
@@ -107,6 +108,7 @@ ALWI void transpose_init(LLKOperand<Format, Shape> /*src*/) {
  *
  * | Param Type | Name   | Description                                                  | Type        | Valid Range                                    | Required |
  * |------------|--------|---------------------------------------------------------------|-------------|-------------------------------------------------|----------|
+ * | Template   | is_fp32_dest_acc_en | Whether DEST is in fp32 accumulation mode        | bool        | N/A                                             | False    |
  * | Template   | Format | Buffer L1 data format (deduced from the LLKOperand argument)  | DataFormat  | N/A                                             | True     |
  * | Template   | Shape  | Tile geometry (deduced from the LLKOperand argument)          | TensorShape | N/A                                             | True     |
  * | Function   | src    | The source L1 operand (format + shape + base address)         | LLKOperand  | N/A                                             | True     |
@@ -114,19 +116,19 @@ ALWI void transpose_init(LLKOperand<Format, Shape> /*src*/) {
  * | Function   | idst   | Index of the tile in DST REG for the result B                 | uint32_t    | Must be less than the acquired size of DST REG | True     |
  */
 // clang-format on
-template <DataFormat Format, TensorShape Shape>
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE, DataFormat Format, TensorShape Shape>
 ALWI void transpose_tile(LLKOperand<Format, Shape> src, std::uint32_t itile, std::uint32_t idst) {
     static_assert(
         is_legal_tile_shape(Shape),
         "transpose_tile: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
 
-    constexpr bool enable_unpack_to_dest = detail::transpose_unpack_to_dest<Format>();
+    constexpr bool enable_unpack_to_dest = detail::transpose_unpack_to_dest<Format, is_fp32_dest_acc_en>();
     const std::uint32_t addr = detail::tile_address(src, itile);
 
     if constexpr (enable_unpack_to_dest) {
         UNPACK((llk_unpack_A<
                 LLKOperand<Format, Shape>::descriptor,
-                DST_ACCUM_MODE,
+                is_fp32_dest_acc_en,
                 BroadcastType::NONE,
                 false /*acc_to_dest*/,
                 EltwiseBinaryReuseDestType::NONE,
@@ -135,20 +137,20 @@ ALWI void transpose_tile(LLKOperand<Format, Shape> src, std::uint32_t itile, std
         MATH((llk_math_eltwise_unary_datacopy<
               LLKOperand<Format, Shape>::descriptor,
               DataCopyType::A2D,
-              DST_ACCUM_MODE,
+              is_fp32_dest_acc_en,
               BroadcastType::NONE,
               UnpackToDestEn>(idst)));
         MATH((llk_math_transpose_dest<false, true>(idst)));
     } else {
         UNPACK((llk_unpack_A<
                 LLKOperand<Format, Shape>::descriptor,
-                DST_ACCUM_MODE,
+                is_fp32_dest_acc_en,
                 BroadcastType::NONE,
                 false /*acc_to_dest*/>(addr)));
         MATH((llk_math_eltwise_unary_datacopy<
               LLKOperand<Format, Shape>::descriptor,
               DataCopyType::A2D,
-              DST_ACCUM_MODE,
+              is_fp32_dest_acc_en,
               BroadcastType::NONE>(idst)));
     }
 }
@@ -163,6 +165,7 @@ ALWI void transpose_tile(LLKOperand<Format, Shape> src, std::uint32_t itile, std
  *
  * | Param Type | Name        | Description                                                      | Type        | Valid Range                                    | Required |
  * |------------|-------------|-------------------------------------------------------------------|-------------|-------------------------------------------------|----------|
+ * | Template   | is_fp32_dest_acc_en | Whether DEST is in fp32 accumulation mode                 | bool        | N/A                                             | False    |
  * | Template   | Format      | Buffer L1 data format (deduced from the LLKOperand argument)      | DataFormat  | N/A                                             | True     |
  * | Template   | Shape       | Tile geometry (deduced from the LLKOperand argument)              | TensorShape | N/A                                             | True     |
  * | Function   | src         | The source L1 operand (format + shape + base address)             | LLKOperand  | N/A                                             | True     |
@@ -171,14 +174,14 @@ ALWI void transpose_tile(LLKOperand<Format, Shape> src, std::uint32_t itile, std
  * | Function   | ntiles      | The number of consecutive tiles to transpose                      | uint32_t    | start_idst + ntiles <= acquired DST REG size   | True     |
  */
 // clang-format on
-template <DataFormat Format, TensorShape Shape>
+template <bool is_fp32_dest_acc_en = DST_ACCUM_MODE, DataFormat Format, TensorShape Shape>
 ALWI void transpose_block(
     LLKOperand<Format, Shape> src, std::uint32_t start_itile, std::uint32_t start_idst, std::uint32_t ntiles) {
     static_assert(
         is_legal_tile_shape(Shape),
         "transpose_block: illegal tile shape (face_r_dim must be 1/2/4/8/16, total faces 1/2/4).");
     for (std::uint32_t i = 0; i < ntiles; ++i) {
-        transpose_tile(src, start_itile + i, start_idst + i);
+        transpose_tile<is_fp32_dest_acc_en>(src, start_itile + i, start_idst + i);
     }
 }
 


### PR DESCRIPTION
### PR Category
Decouple CB synchronization from L1 metadata for compute
https://github.com/tenstorrent/tt-metal/issues/53456

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rtawfik/l1spec-datacopy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rtawfik/l1spec-datacopy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rtawfik/l1spec-datacopy)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rtawfik/l1spec-datacopy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rtawfik/l1spec-datacopy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rtawfik/l1spec-datacopy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rtawfik/l1spec-datacopy)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rtawfik/l1spec-datacopy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rtawfik/l1spec-datacopy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rtawfik/l1spec-datacopy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rtawfik/l1spec-datacopy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rtawfik/l1spec-datacopy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rtawfik/l1spec-datacopy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rtawfik/l1spec-datacopy)