### PR TITLE
[Cleanup] GlobalSemaphore and GlobalCircularBuffer creation made mesh-based

### DIFF
--- a/tests/tt_metal/distributed/test_mesh_sub_device.cpp
+++ b/tests/tt_metal/distributed/test_mesh_sub_device.cpp
@@ -108,7 +108,7 @@ TEST_F(MeshSubDeviceTestSuite, DataCopyOnSubDevices) {
     auto datacopy_core_phys = mesh_device_->worker_core_from_logical_core(datacopy_coord);
 
     auto all_cores = syncer_core.merge(datacopy_core);
-    auto global_sem = CreateGlobalSemaphore(mesh_device_.get(), all_cores, 0);
+    auto global_sem = GlobalSemaphore(*mesh_device_, all_cores, 0);
 
     Program sync_and_incr_program = CreateProgram();
     auto sync_kernel = CreateKernel(

--- a/tests/tt_metal/distributed/test_mesh_trace.cpp
+++ b/tests/tt_metal/distributed/test_mesh_trace.cpp
@@ -377,7 +377,7 @@ TEST_F(MeshTraceTestSuite, DataCopyOnSubDevicesTrace) {
 
     // Create global semaphore for syncing between programs
     auto all_cores = syncer_core.merge(datacopy_core).merge(add_core);
-    auto global_sem = CreateGlobalSemaphore(mesh_device_.get(), all_cores, 0);
+    auto global_sem = GlobalSemaphore(*mesh_device_, all_cores, 0);
 
     // Program syncs with host and notifies downstream datacopy or addition program
     Program sync_and_incr_program = CreateProgram();

--- a/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
+++ b/tests/tt_metal/tt_fabric/benchmark/collectives/unicast/run_unicast_once.cpp
@@ -185,14 +185,14 @@ Notes:
     // Create the semaphore on the specific receiver logical core of the *mesh*.
     tt::tt_metal::CoreRangeSet rx_core_set(tt::tt_metal::CoreRange(p.receiver_core, p.receiver_core));
     if (!gsemA) {
-        gsemA = tt::tt_metal::CreateGlobalSemaphore(
-            mesh.get(),
+        gsemA = tt::tt_metal::GlobalSemaphore(
+            *mesh,
             rx_core_set,
             /*initial_value=*/0);
     }
     if (!gsemB) {
-        gsemB = tt::tt_metal::CreateGlobalSemaphore(
-            mesh.get(),
+        gsemB = tt::tt_metal::GlobalSemaphore(
+            *mesh,
             rx_core_set,
             /*initial_value=*/0);
     }

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/multicast_runner.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/multicast_runner.cpp
@@ -169,7 +169,7 @@ void run_multicast_write_test(tt::tt_metal::MeshDeviceFixtureBase* fixture, cons
     static std::optional<tt::tt_metal::GlobalSemaphore> gsem_done;
     if (!gsem_done) {
         tt::tt_metal::CoreRangeSet rx_core_one(tt::tt_metal::CoreRange(p.receiver_core, p.receiver_core));
-        gsem_done = tt::tt_metal::CreateGlobalSemaphore(mesh.get(), rx_core_one, /*initial_value=*/0);
+        gsem_done = tt::tt_metal::GlobalSemaphore(*mesh, rx_core_one, /*initial_value=*/0);
     }
 
     constexpr const char* KDIR = "tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/kernels/";

--- a/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/unicast_runner.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_data_movement/addrgen_write/unicast_runner.cpp
@@ -201,8 +201,8 @@ Notes:
     tt::tt_metal::CoreRangeSet rx_core_set(tt::tt_metal::CoreRange(p.receiver_core, p.receiver_core));
     static std::optional<tt::tt_metal::GlobalSemaphore> gsem;
     if (!gsem) {
-        gsem = tt::tt_metal::CreateGlobalSemaphore(
-            mesh.get(),
+        gsem = tt::tt_metal::GlobalSemaphore(
+            *mesh,
             rx_core_set,
             /*initial_value=*/0);
     }

--- a/tests/tt_metal/tt_metal/api/test_global_circular_buffers.cpp
+++ b/tests/tt_metal/tt_metal/api/test_global_circular_buffers.cpp
@@ -36,16 +36,16 @@ TEST_F(MeshDispatchFixture, TensixCreateGlobalCircularBuffers) {
 
     {
         std::vector<std::pair<CoreCoord, CoreRangeSet>> sender_receiver_core_mapping = {{CoreCoord(0, 0), cores}};
-        auto global_cb = tt::tt_metal::experimental::CreateGlobalCircularBuffer(
-            mesh_device.get(), sender_receiver_core_mapping, 3200, tt::tt_metal::BufferType::L1);
+        auto global_cb = tt::tt_metal::experimental::GlobalCircularBuffer(
+            *mesh_device, sender_receiver_core_mapping, 3200, tt::tt_metal::BufferType::L1);
     }
     {
         std::vector<std::pair<CoreCoord, CoreRangeSet>> sender_receiver_core_mapping = {
             {CoreCoord(0, 0), cores}, {CoreCoord(1, 1), cores3}};
         // sender receiver cores overlap
         EXPECT_THROW(
-            tt::tt_metal::experimental::CreateGlobalCircularBuffer(
-                mesh_device.get(), sender_receiver_core_mapping, 3200, tt::tt_metal::BufferType::L1),
+            tt::tt_metal::experimental::GlobalCircularBuffer(
+                *mesh_device, sender_receiver_core_mapping, 3200, tt::tt_metal::BufferType::L1),
             std::exception);
     }
     {
@@ -53,8 +53,8 @@ TEST_F(MeshDispatchFixture, TensixCreateGlobalCircularBuffers) {
             {CoreCoord(0, 0), cores}, {CoreCoord(0, 1), cores2}};
         // receiver cores overlap
         EXPECT_THROW(
-            tt::tt_metal::experimental::CreateGlobalCircularBuffer(
-                mesh_device.get(), sender_receiver_core_mapping, 3200, tt::tt_metal::BufferType::L1),
+            tt::tt_metal::experimental::GlobalCircularBuffer(
+                *mesh_device, sender_receiver_core_mapping, 3200, tt::tt_metal::BufferType::L1),
             std::exception);
     }
 }
@@ -71,12 +71,12 @@ TEST_F(MeshDispatchFixture, TensixProgramGlobalCircularBuffersAPI) {
     auto mesh_device = devices_[0];
 
     std::vector<std::pair<CoreCoord, CoreRangeSet>> sender_receiver_core_mapping = {{sender_core, receiver_cores}};
-    auto global_cb = tt::tt_metal::experimental::CreateGlobalCircularBuffer(
-        mesh_device.get(), sender_receiver_core_mapping, 3200, tt::tt_metal::BufferType::L1);
+    auto global_cb = tt::tt_metal::experimental::GlobalCircularBuffer(
+        *mesh_device, sender_receiver_core_mapping, 3200, tt::tt_metal::BufferType::L1);
     std::vector<std::pair<CoreCoord, CoreRangeSet>> dummy_sender_receiver_core_mapping = {
         {CoreCoord(0, 0), dummy_receiver_cores}};
-    auto dummy_global_cb = tt::tt_metal::experimental::CreateGlobalCircularBuffer(
-        mesh_device.get(), dummy_sender_receiver_core_mapping, 3200, tt::tt_metal::BufferType::L1);
+    auto dummy_global_cb = tt::tt_metal::experimental::GlobalCircularBuffer(
+        *mesh_device, dummy_sender_receiver_core_mapping, 3200, tt::tt_metal::BufferType::L1);
     {
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);

--- a/tests/tt_metal/tt_metal/api/test_global_semaphores.cpp
+++ b/tests/tt_metal/tt_metal/api/test_global_semaphores.cpp
@@ -28,7 +28,7 @@ TEST_F(MeshDispatchFixture, InitializeGlobalSemaphores) {
         auto device_id = mesh_device->get_device_ids()[0];
         {
             uint32_t initial_value = 1;
-            auto global_semaphore = tt::tt_metal::CreateGlobalSemaphore(mesh_device.get(), cores, initial_value);
+            auto global_semaphore = tt::tt_metal::GlobalSemaphore(*mesh_device, cores, initial_value);
             auto address = global_semaphore.address();
             distributed::Synchronize(*mesh_device, std::nullopt);
             for (const auto& core : cores_vec) {
@@ -40,7 +40,7 @@ TEST_F(MeshDispatchFixture, InitializeGlobalSemaphores) {
         }
         {
             uint32_t initial_value = 2;
-            auto global_semaphore = tt::tt_metal::CreateGlobalSemaphore(mesh_device.get(), cores, initial_value);
+            auto global_semaphore = tt::tt_metal::GlobalSemaphore(*mesh_device, cores, initial_value);
             auto address = global_semaphore.address();
             distributed::Synchronize(*mesh_device, std::nullopt);
             for (const auto& core : cores_vec) {
@@ -68,7 +68,7 @@ TEST_F(MeshDispatchFixture, CreateMultipleGlobalSemaphoresOnSameCore) {
             std::vector<DeviceAddr> addresses;
             addresses.reserve(cores.size());
             for (size_t i = 0; i < cores.size(); i++) {
-                global_semaphores.push_back(tt::tt_metal::CreateGlobalSemaphore(mesh_device.get(), cores[i], initial_values[i]));
+                global_semaphores.push_back(tt::tt_metal::GlobalSemaphore(*mesh_device, cores[i], initial_values[i]));
                 addresses.push_back(global_semaphores[i].address());
             }
             distributed::Synchronize(*mesh_device, std::nullopt);
@@ -99,7 +99,7 @@ TEST_F(MeshDispatchFixture, ResetGlobalSemaphores) {
             uint32_t initial_value = 1;
             uint32_t reset_value = 2;
             std::vector<uint32_t> overwrite_value = {2};
-            auto global_semaphore = tt::tt_metal::CreateGlobalSemaphore(mesh_device.get(), cores, initial_value);
+            auto global_semaphore = tt::tt_metal::GlobalSemaphore(*mesh_device, cores, initial_value);
             auto address = global_semaphore.address();
             distributed::Synchronize(*mesh_device, std::nullopt);
             for (const auto& core : cores_vec) {

--- a/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
+++ b/tests/tt_metal/tt_metal/dispatch/dispatch_program/test_global_circular_buffers.cpp
@@ -38,8 +38,8 @@ TEST_F(MeshDispatchFixture, TensixProgramGlobalCircularBuffers) {
     auto all_cores = sender_cores.merge(receiver_cores);
     auto mesh_device = devices_[0];
     std::vector<std::pair<CoreCoord, CoreRangeSet>> sender_receiver_core_mapping = {{sender_core, receiver_cores}};
-    auto global_cb = tt::tt_metal::experimental::CreateGlobalCircularBuffer(
-        mesh_device.get(), sender_receiver_core_mapping, 3200, tt::tt_metal::BufferType::L1);
+    auto global_cb = tt::tt_metal::experimental::GlobalCircularBuffer(
+        *mesh_device, sender_receiver_core_mapping, 3200, tt::tt_metal::BufferType::L1);
 
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -165,8 +165,7 @@ TEST_F(MeshDispatchFixture, TensixProgramClearsStaleRemoteCircularBufferConfig) 
     // Run a rectangular kernel grid with a remote CB on only one receiver. Dispatch must overwrite stale config on
     // idle_core with the zero sentinel that setup_remote_cb_interfaces() skips.
     std::vector<std::pair<CoreCoord, CoreRangeSet>> sparse_mapping = {{sender_core, receiver_cores}};
-    auto sparse_global_cb =
-        experimental::CreateGlobalCircularBuffer(mesh_device.get(), sparse_mapping, 3200, BufferType::L1);
+    auto sparse_global_cb = experimental::GlobalCircularBuffer(*mesh_device, sparse_mapping, 3200, BufferType::L1);
     distributed::MeshWorkload sparse_workload;
     Program sparse_program = CreateProgram();
     experimental::CreateCircularBuffer(sparse_program, receiver_cores, make_cb_config(), sparse_global_cb);

--- a/tests/tt_metal/tt_metal/dispatch/sub_device_test_utils.hpp
+++ b/tests/tt_metal/tt_metal/dispatch/sub_device_test_utils.hpp
@@ -6,6 +6,7 @@
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/global_semaphore.hpp>
+#include <tt-metalium/mesh_device.hpp>
 #include "impl/context/metal_context.hpp"
 #include "impl/kernels/kernel.hpp"
 #include "sub_device.hpp"
@@ -13,10 +14,10 @@
 namespace tt::tt_metal {
 
 inline std::tuple<Program, CoreCoord, GlobalSemaphore> create_single_sync_program(
-    IDevice* device, const SubDevice& sub_device) {
+    distributed::MeshDevice* device, const SubDevice& sub_device) {
     auto syncer_coord = sub_device.cores(HalProgrammableCoreType::TENSIX).ranges().at(0).start_coord;
     auto syncer_core = CoreRangeSet(CoreRange(syncer_coord, syncer_coord));
-    auto global_sem = CreateGlobalSemaphore(device, sub_device.cores(HalProgrammableCoreType::TENSIX), INVALID);
+    auto global_sem = GlobalSemaphore(*device, sub_device.cores(HalProgrammableCoreType::TENSIX), INVALID);
 
     Program syncer_program = CreateProgram();
     auto syncer_kernel = CreateKernel(
@@ -30,7 +31,7 @@ inline std::tuple<Program, CoreCoord, GlobalSemaphore> create_single_sync_progra
 }
 
 inline std::tuple<Program, Program, Program, GlobalSemaphore> create_basic_sync_program(
-    IDevice* device, const SubDevice& sub_device_1, const SubDevice& sub_device_2) {
+    distributed::MeshDevice* device, const SubDevice& sub_device_1, const SubDevice& sub_device_2) {
     auto waiter_coord = sub_device_2.cores(HalProgrammableCoreType::TENSIX).ranges().at(0).start_coord;
     auto waiter_core = CoreRangeSet(CoreRange(waiter_coord, waiter_coord));
     auto waiter_core_physical = device->worker_core_from_logical_core(waiter_coord);
@@ -39,7 +40,7 @@ inline std::tuple<Program, Program, Program, GlobalSemaphore> create_basic_sync_
     auto syncer_core = CoreRangeSet(CoreRange(syncer_coord, syncer_coord));
     auto syncer_core_physical = device->worker_core_from_logical_core(syncer_coord);
     auto all_cores = waiter_core.merge(incrementer_cores).merge(syncer_core);
-    auto global_sem = CreateGlobalSemaphore(device, all_cores, INVALID);
+    auto global_sem = GlobalSemaphore(*device, all_cores, INVALID);
 
     Program waiter_program = CreateProgram();
     auto waiter_kernel = CreateKernel(
@@ -77,7 +78,7 @@ inline std::tuple<Program, Program, Program, GlobalSemaphore> create_basic_sync_
 }
 
 inline std::tuple<Program, Program, Program, GlobalSemaphore> create_basic_eth_sync_program(
-    IDevice* device, const SubDevice& sub_device_1, const SubDevice& sub_device_2, DataMovementProcessor dm_processor) {
+    distributed::MeshDevice* device, const SubDevice& sub_device_1, const SubDevice& sub_device_2, DataMovementProcessor dm_processor) {
     auto waiter_coord = sub_device_2.cores(HalProgrammableCoreType::ACTIVE_ETH).ranges().at(0).start_coord;
     auto waiter_core = CoreRangeSet(CoreRange(waiter_coord, waiter_coord));
     auto tensix_waiter_coord = sub_device_2.cores(HalProgrammableCoreType::TENSIX).ranges().at(0).start_coord;
@@ -88,7 +89,7 @@ inline std::tuple<Program, Program, Program, GlobalSemaphore> create_basic_eth_s
     auto syncer_core = CoreRangeSet(CoreRange(syncer_coord, syncer_coord));
     auto syncer_core_physical = device->worker_core_from_logical_core(syncer_coord);
     auto all_cores = tensix_waiter_core.merge(incrementer_cores).merge(syncer_core);
-    auto global_sem = CreateGlobalSemaphore(device, all_cores, INVALID);
+    auto global_sem = GlobalSemaphore(*device, all_cores, INVALID);
 
     Program waiter_program = CreateProgram();
     auto waiter_kernel = CreateKernel(

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/10_dram_read_remote_cb_sync/test_dram_read_remote_cb.cpp
@@ -167,8 +167,8 @@ create_mesh_workloads(
             .set_page_size(reader_cb_index, single_tile_size);
     tt_metal::CreateCircularBuffer(sender_program, dram_reader_core, reader_cb_config);
 
-    auto global_cb = tt_metal::experimental::CreateGlobalCircularBuffer(
-        device, sender_receiver_core_mapping, padded_global_cb_size, tt_metal::BufferType::L1);
+    auto global_cb = tt_metal::experimental::GlobalCircularBuffer(
+        *device, sender_receiver_core_mapping, padded_global_cb_size, tt_metal::BufferType::L1);
     tt_metal::CircularBufferConfig writer_cb_config = tt_metal::CircularBufferConfig(receiver_cb_size);
     writer_cb_config.remote_index(writer_cb_index).set_page_size(single_tile_size).set_data_format(tile_format);
     tt_metal::experimental::CreateCircularBuffer(sender_program, dram_reader_core, writer_cb_config, global_cb);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/11_remote_cb_sync_matmul_single_core/test_remote_cb_sync_matmul.cpp
@@ -188,8 +188,8 @@ std::tuple<std::vector<tt_metal::Program>, ::tt_metal::experimental::GlobalCircu
     uint32_t in1_receiver_cb_size = in1_block_h * in1_block_w * single_tile_size * cb_num_blocks / num_receivers;
     uint32_t padded_global_cb_size = in1_receiver_cb_size + cb_padding;
 
-    auto global_cb = tt_metal::experimental::CreateGlobalCircularBuffer(
-        device, sender_receiver_core_mapping, padded_global_cb_size, tt_metal::BufferType::L1);
+    auto global_cb = tt_metal::experimental::GlobalCircularBuffer(
+        *device, sender_receiver_core_mapping, padded_global_cb_size, tt_metal::BufferType::L1);
 
     uint32_t in1_writer_cb_index = 31;
     tt_metal::CircularBufferConfig in1_writer_cb_config = tt_metal::CircularBufferConfig(in1_receiver_cb_size);

--- a/tt-train/sources/ttml/core/distributed/ccl_resources.cpp
+++ b/tt-train/sources/ttml/core/distributed/ccl_resources.cpp
@@ -8,9 +8,9 @@
 namespace ttml::core::distributed {
 
 CCLResources::CCLResources() {
-    auto* device = &ttml::autograd::ctx().get_device();
+    auto& device = ttml::autograd::ctx().get_device();
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto compute_with_storage_grid_size = device.compute_with_storage_grid_size();
     uint32_t num_cores_x = compute_with_storage_grid_size.x;
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
 
@@ -21,19 +21,18 @@ CCLResources::CCLResources() {
     all_gather_semaphores.reserve(kNumSemaphoresPairs * kNumSemaphoresPerAllGather);
     reduce_scatter_semaphores.reserve(kNumSemaphoresPairs * kNumSemaphoresPerReduceScatterCall);
     for (uint32_t idx = 0; idx < kNumSemaphoresPairs; ++idx) {
-        barrier_semaphores.push_back(
-            tt::tt_metal::CreateGlobalSemaphore(device, core_range_set, /* initial_value */ 0));
+        barrier_semaphores.push_back(tt::tt_metal::GlobalSemaphore(device, core_range_set, /* initial_value */ 0));
         for (uint32_t adx = 0; adx < kNumSemaphoresPerAllGather; ++adx) {
             all_gather_semaphores.push_back(
-                tt::tt_metal::CreateGlobalSemaphore(device, core_range_set, /* initial_value */ 0));
+                tt::tt_metal::GlobalSemaphore(device, core_range_set, /* initial_value */ 0));
         }
         for (uint32_t rdx = 0; rdx < kNumSemaphoresPerReduceScatterCall; ++rdx) {
             reduce_scatter_semaphores.push_back(
-                tt::tt_metal::CreateGlobalSemaphore(device, core_range_set, /* initial_value */ 0));
+                tt::tt_metal::GlobalSemaphore(device, core_range_set, /* initial_value */ 0));
         }
         for (uint32_t rdx = 0; rdx < kNumSemaphoresPerAllReduceBarrierCall; ++rdx) {
             all_reduce_barrier_semaphores.push_back(
-                tt::tt_metal::CreateGlobalSemaphore(device, core_range_set, /* initial_value */ 0));
+                tt::tt_metal::GlobalSemaphore(device, core_range_set, /* initial_value */ 0));
         }
     }
 }

--- a/tt_metal/api/tt-metalium/experimental/forge_backdoor/global_semaphore.hpp
+++ b/tt_metal/api/tt-metalium/experimental/forge_backdoor/global_semaphore.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <tt-metalium/global_semaphore.hpp>
 
 namespace tt::tt_metal::experimental {
@@ -16,13 +18,23 @@ namespace tt::tt_metal::experimental {
  *
  * | Argument       | Description                                            | Type                                                      | Valid Range  | Required |
  * |----------------|--------------------------------------------------------|-----------------------------------------------------------|--------------|----------|
- * | device         | The device to create the semaphore on                  | IDevice*                                                  |              | Yes      |
+ * | device         | The mesh device to create the semaphore on             | distributed::MeshDevice&                                  |              | Yes      |
  * | cores          | Range of the Tensix coordinates using the semaphore    | const CoreRangeSet &                                      |              | Yes      |
  * | initial_value  | Initial value of the semaphore                         | uint32_t                                                  |              | Yes      |
  * | buffer_type    | Buffer type to store the semaphore                     | BufferType                                                | L1 types     | No       |
  * | address        | Address of the semaphore to create                     | uint64_t                                                  |              | Yes      |
  */
 // clang-format on
+GlobalSemaphore CreateGlobalSemaphore(
+    distributed::MeshDevice& device,
+    const CoreRangeSet& cores,
+    std::optional<uint32_t> initial_value,
+    BufferType buffer_type,
+    uint64_t address);
+
+[[deprecated(
+    "Use CreateGlobalSemaphore(distributed::MeshDevice&, ...) instead. "
+    "CreateGlobalSemaphore(IDevice*, ...) will be removed after 2026-09-17.")]]
 GlobalSemaphore CreateGlobalSemaphore(
     IDevice* device,
     const CoreRangeSet& cores,

--- a/tt_metal/api/tt-metalium/experimental/forge_backdoor/global_semaphore.hpp
+++ b/tt_metal/api/tt-metalium/experimental/forge_backdoor/global_semaphore.hpp
@@ -34,7 +34,7 @@ GlobalSemaphore CreateGlobalSemaphore(
 
 [[deprecated(
     "Use CreateGlobalSemaphore(distributed::MeshDevice&, ...) instead. "
-    "CreateGlobalSemaphore(IDevice*, ...) will be removed after 2026-09-17.")]]
+    "CreateGlobalSemaphore(IDevice*, ...) will be removed after 2026-09-20.")]]
 GlobalSemaphore CreateGlobalSemaphore(
     IDevice* device,
     const CoreRangeSet& cores,

--- a/tt_metal/api/tt-metalium/global_circular_buffer.hpp
+++ b/tt_metal/api/tt-metalium/global_circular_buffer.hpp
@@ -33,6 +33,24 @@ struct GlobalCircularBufferDramSenderInternals;
 
 class GlobalCircularBuffer {
 public:
+    /**
+     * @brief Allocates a global circular buffer in L1 on the device.
+     *
+     * @param device Mesh device to create the global circular buffer on.
+     * @param sender_receiver_core_mapping The mapping of remote sender to remote receiver cores for the circular
+     * buffer.
+     * @param size Size of the global circular buffer per core in bytes.
+     * @param buffer_type Buffer type to store the global circular buffer. Can only be an L1 buffer type.
+     */
+    GlobalCircularBuffer(
+        distributed::MeshDevice& device,
+        const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
+        uint32_t size,
+        BufferType buffer_type = BufferType::L1);
+
+    [[deprecated(
+        "Use GlobalCircularBuffer(distributed::MeshDevice&, ...) instead. "
+        "GlobalCircularBuffer(IDevice*, ...) will be removed after 2026-09-17.")]]
     GlobalCircularBuffer(
         IDevice* device,
         const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
@@ -126,6 +144,9 @@ private:
  * @param buffer_type Buffer type to store the global circular buffer. Can only be an L1 buffer type.\
  * @return The allocated global circular buffer.
  */
+[[deprecated(
+    "Use GlobalCircularBuffer(distributed::MeshDevice&, ...) constructor instead. "
+    "CreateGlobalCircularBuffer(IDevice*, ...) will be removed after 2026-09-17.")]]
 GlobalCircularBuffer CreateGlobalCircularBuffer(
     IDevice* device,
     const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,

--- a/tt_metal/api/tt-metalium/global_circular_buffer.hpp
+++ b/tt_metal/api/tt-metalium/global_circular_buffer.hpp
@@ -138,14 +138,29 @@ private:
 /**
  * @brief Allocates a global circular buffer in L1 on the device.
  *
+ * @param device Mesh device to create the global circular buffer on.
+ * @param sender_receiver_core_mapping The mapping of remote sender to remote receiver cores for the circular buffer.
+ * @param size Size of the global circular buffer per core in bytes.
+ * @param buffer_type Buffer type to store the global circular buffer. Can only be an L1 buffer type.
+ * @return The allocated global circular buffer.
+ */
+GlobalCircularBuffer CreateGlobalCircularBuffer(
+    distributed::MeshDevice& device,
+    const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
+    uint32_t size,
+    BufferType buffer_type = BufferType::L1);
+
+/**
+ * @brief Allocates a global circular buffer in L1 on the device.
+ *
  * @param device The device to create the global circular buffer on.
  * @param sender_receiver_core_mapping The mapping of remote sender to remote receiver cores for the circular buffer.
  * @param size Size of the global circular buffer per core in bytes.
- * @param buffer_type Buffer type to store the global circular buffer. Can only be an L1 buffer type.\
+ * @param buffer_type Buffer type to store the global circular buffer. Can only be an L1 buffer type.
  * @return The allocated global circular buffer.
  */
 [[deprecated(
-    "Use GlobalCircularBuffer(distributed::MeshDevice&, ...) constructor instead. "
+    "Use CreateGlobalCircularBuffer(distributed::MeshDevice&, ...) instead. "
     "CreateGlobalCircularBuffer(IDevice*, ...) will be removed after 2026-09-17.")]]
 GlobalCircularBuffer CreateGlobalCircularBuffer(
     IDevice* device,

--- a/tt_metal/api/tt-metalium/global_circular_buffer.hpp
+++ b/tt_metal/api/tt-metalium/global_circular_buffer.hpp
@@ -50,7 +50,7 @@ public:
 
     [[deprecated(
         "Use GlobalCircularBuffer(distributed::MeshDevice&, ...) instead. "
-        "GlobalCircularBuffer(IDevice*, ...) will be removed after 2026-09-17.")]]
+        "GlobalCircularBuffer(IDevice*, ...) will be removed after 2026-09-20.")]]
     GlobalCircularBuffer(
         IDevice* device,
         const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
@@ -161,7 +161,7 @@ GlobalCircularBuffer CreateGlobalCircularBuffer(
  */
 [[deprecated(
     "Use CreateGlobalCircularBuffer(distributed::MeshDevice&, ...) instead. "
-    "CreateGlobalCircularBuffer(IDevice*, ...) will be removed after 2026-09-17.")]]
+    "CreateGlobalCircularBuffer(IDevice*, ...) will be removed after 2026-09-20.")]]
 GlobalCircularBuffer CreateGlobalCircularBuffer(
     IDevice* device,
     const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,

--- a/tt_metal/api/tt-metalium/global_semaphore.hpp
+++ b/tt_metal/api/tt-metalium/global_semaphore.hpp
@@ -18,15 +18,38 @@ namespace tt::tt_metal {
 class IDevice;
 class GlobalSemaphore;
 class GlobalSemaphoreImpl;
+namespace distributed {
+class MeshDevice;
+}  // namespace distributed
 }  // namespace tt::tt_metal
 
 namespace tt::tt_metal {
 
 class GlobalSemaphore {
 public:
+    /**
+     * @brief Allocates a global semaphore in L1 on the mesh device.
+     *
+     * @param device Mesh device to create the semaphore on.
+     * @param cores Range of Tensix coordinates using the semaphore.
+     * @param initial_value Initial value of the semaphore.
+     * @param buffer_type Buffer type to store the semaphore. Can only be an L1 buffer type.
+     */
+    GlobalSemaphore(
+        distributed::MeshDevice& device,
+        CoreRangeSet cores,
+        uint32_t initial_value,
+        BufferType buffer_type = BufferType::L1);
+
+    [[deprecated(
+        "Use GlobalSemaphore(distributed::MeshDevice&, ...) instead. "
+        "GlobalSemaphore(IDevice*, ...) will be removed after 2026-09-17.")]]
     GlobalSemaphore(
         IDevice* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
 
+    [[deprecated(
+        "Use GlobalSemaphore(distributed::MeshDevice&, ...) instead. "
+        "GlobalSemaphore(IDevice*, ...) will be removed after 2026-09-17.")]]
     GlobalSemaphore(
         IDevice* device, CoreRangeSet&& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
 

--- a/tt_metal/api/tt-metalium/global_semaphore.hpp
+++ b/tt_metal/api/tt-metalium/global_semaphore.hpp
@@ -43,13 +43,13 @@ public:
 
     [[deprecated(
         "Use GlobalSemaphore(distributed::MeshDevice&, ...) instead. "
-        "GlobalSemaphore(IDevice*, ...) will be removed after 2026-09-17.")]]
+        "GlobalSemaphore(IDevice*, ...) will be removed after 2026-09-20.")]]
     GlobalSemaphore(
         IDevice* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
 
     [[deprecated(
         "Use GlobalSemaphore(distributed::MeshDevice&, ...) instead. "
-        "GlobalSemaphore(IDevice*, ...) will be removed after 2026-09-17.")]]
+        "GlobalSemaphore(IDevice*, ...) will be removed after 2026-09-20.")]]
     GlobalSemaphore(
         IDevice* device, CoreRangeSet&& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
 

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -352,7 +352,7 @@ GlobalSemaphore CreateGlobalSemaphore(
 // clang-format on
 [[deprecated(
     "Use CreateGlobalSemaphore(distributed::MeshDevice&, ...) instead. "
-    "CreateGlobalSemaphore(IDevice*, ...) will be removed after 2026-09-17.")]]
+    "CreateGlobalSemaphore(IDevice*, ...) will be removed after 2026-09-20.")]]
 GlobalSemaphore CreateGlobalSemaphore(
     IDevice* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
 
@@ -373,7 +373,7 @@ GlobalSemaphore CreateGlobalSemaphore(
 // clang-format on
 [[deprecated(
     "Use CreateGlobalSemaphore(distributed::MeshDevice&, ...) instead. "
-    "CreateGlobalSemaphore(IDevice*, ...) will be removed after 2026-09-17.")]]
+    "CreateGlobalSemaphore(IDevice*, ...) will be removed after 2026-09-20.")]]
 GlobalSemaphore CreateGlobalSemaphore(
     IDevice* device, CoreRangeSet&& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
 

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -323,6 +323,27 @@ uint32_t CreateSemaphore(
  *
  * | Argument       | Description                                            | Type                                                      | Valid Range  | Required |
  * |----------------|--------------------------------------------------------|-----------------------------------------------------------|--------------|----------|
+ * | device         | The mesh device to create the semaphore on             | distributed::MeshDevice&                                  |              | Yes      |
+ * | cores          | Range of the Tensix coordinates using the semaphore    | CoreRangeSet &&                                           |              | Yes      |
+ * | initial_value  | Initial value of the semaphore                         | uint32_t                                                  |              | Yes      |
+ * | buffer_type    | Buffer type to store the semaphore                     | BufferType                                                | L1 types     | No       |
+ */
+// clang-format on
+GlobalSemaphore CreateGlobalSemaphore(
+    distributed::MeshDevice& device,
+    CoreRangeSet cores,
+    uint32_t initial_value,
+    BufferType buffer_type = BufferType::L1);
+
+// clang-format off
+/**
+ * Initializes a global semaphore on all cores within the specified CoreRangeSet.
+ * This only supports tensix cores, and can only use L1 buffer types like BufferType::L1 and BufferType::L1_SMALL.
+ *
+ * Return value: GlobalSemaphore
+ *
+ * | Argument       | Description                                            | Type                                                      | Valid Range  | Required |
+ * |----------------|--------------------------------------------------------|-----------------------------------------------------------|--------------|----------|
  * | device         | The device to create the semaphore on                  | IDevice*                                                  |              | Yes      |
  * | cores          | Range of the Tensix coordinates using the semaphore    | const CoreRangeSet &                                      |              | Yes      |
  * | initial_value  | Initial value of the semaphore                         | uint32_t                                                  |              | Yes      |
@@ -330,7 +351,7 @@ uint32_t CreateSemaphore(
  */
 // clang-format on
 [[deprecated(
-    "Use GlobalSemaphore(distributed::MeshDevice&, ...) constructor instead. "
+    "Use CreateGlobalSemaphore(distributed::MeshDevice&, ...) instead. "
     "CreateGlobalSemaphore(IDevice*, ...) will be removed after 2026-09-17.")]]
 GlobalSemaphore CreateGlobalSemaphore(
     IDevice* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
@@ -351,7 +372,7 @@ GlobalSemaphore CreateGlobalSemaphore(
  */
 // clang-format on
 [[deprecated(
-    "Use GlobalSemaphore(distributed::MeshDevice&, ...) constructor instead. "
+    "Use CreateGlobalSemaphore(distributed::MeshDevice&, ...) instead. "
     "CreateGlobalSemaphore(IDevice*, ...) will be removed after 2026-09-17.")]]
 GlobalSemaphore CreateGlobalSemaphore(
     IDevice* device, CoreRangeSet&& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);

--- a/tt_metal/api/tt-metalium/host_api.hpp
+++ b/tt_metal/api/tt-metalium/host_api.hpp
@@ -329,6 +329,9 @@ uint32_t CreateSemaphore(
  * | buffer_type    | Buffer type to store the semaphore                     | BufferType                                                | L1 types     | No       |
  */
 // clang-format on
+[[deprecated(
+    "Use GlobalSemaphore(distributed::MeshDevice&, ...) constructor instead. "
+    "CreateGlobalSemaphore(IDevice*, ...) will be removed after 2026-09-17.")]]
 GlobalSemaphore CreateGlobalSemaphore(
     IDevice* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
 
@@ -347,6 +350,9 @@ GlobalSemaphore CreateGlobalSemaphore(
  * | buffer_type    | Buffer type to store the semaphore                     | BufferType                                                | L1 types     | No       |
  */
 // clang-format on
+[[deprecated(
+    "Use GlobalSemaphore(distributed::MeshDevice&, ...) constructor instead. "
+    "CreateGlobalSemaphore(IDevice*, ...) will be removed after 2026-09-17.")]]
 GlobalSemaphore CreateGlobalSemaphore(
     IDevice* device, CoreRangeSet&& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
 

--- a/tt_metal/impl/buffers/global_circular_buffer.cpp
+++ b/tt_metal/impl/buffers/global_circular_buffer.cpp
@@ -101,6 +101,13 @@ void initialize_global_circular_buffer(
 }  // namespace
 
 GlobalCircularBuffer::GlobalCircularBuffer(
+    distributed::MeshDevice& device,
+    const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
+    uint32_t size,
+    BufferType buffer_type) :
+    GlobalCircularBuffer{&device, sender_receiver_core_mapping, size, buffer_type} {}
+
+GlobalCircularBuffer::GlobalCircularBuffer(
     IDevice* device,
     const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
     uint32_t size,

--- a/tt_metal/impl/buffers/global_semaphore.cpp
+++ b/tt_metal/impl/buffers/global_semaphore.cpp
@@ -106,6 +106,15 @@ void GlobalSemaphoreImpl::setup_buffer(
 namespace experimental {
 // Forge backdoor API.
 GlobalSemaphore CreateGlobalSemaphore(
+    distributed::MeshDevice& device,
+    const CoreRangeSet& cores,
+    std::optional<uint32_t> initial_value,
+    BufferType buffer_type,
+    uint64_t address) {
+    return GlobalSemaphore(GlobalSemaphoreImpl(&device, cores, initial_value, buffer_type, address));
+}
+
+GlobalSemaphore CreateGlobalSemaphore(
     IDevice* device,
     const CoreRangeSet& cores,
     std::optional<uint32_t> initial_value,
@@ -116,6 +125,10 @@ GlobalSemaphore CreateGlobalSemaphore(
 }  // namespace experimental
 
 // GlobalSemaphore implementation
+
+GlobalSemaphore::GlobalSemaphore(
+    distributed::MeshDevice& device, CoreRangeSet cores, uint32_t initial_value, BufferType buffer_type) :
+    GlobalSemaphore(GlobalSemaphoreImpl(&device, std::move(cores), initial_value, buffer_type)) {}
 
 GlobalSemaphore::GlobalSemaphore(
     IDevice* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type) :

--- a/tt_metal/impl/experimental/udm/mesh_semaphore.cpp
+++ b/tt_metal/impl/experimental/udm/mesh_semaphore.cpp
@@ -7,6 +7,7 @@
 #include <tt-metalium/experimental/udm/mesh_program.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/distributed.hpp>
+#include <tt-metalium/global_semaphore.hpp>
 #include <tt_stl/assert.hpp>
 
 namespace tt::tt_metal::experimental::udm {
@@ -26,7 +27,7 @@ MeshSemaphoreHandle CreateMeshSemaphore(MeshBuilder& builder, MeshProgram& /* pr
 
     // Create a GlobalSemaphore across all devices in the mesh
     auto* mesh_device = builder.mesh_device();
-    auto global_semaphore = tt::tt_metal::CreateGlobalSemaphore(mesh_device, local_cores, initial_value);
+    auto global_semaphore = tt::tt_metal::GlobalSemaphore(*mesh_device, local_cores, initial_value);
 
     // Synchronize mesh device after creating global semaphore
     tt::tt_metal::distributed::Synchronize(*mesh_device, std::nullopt, {});

--- a/tt_metal/impl/host_api/tt_metal.cpp
+++ b/tt_metal/impl/host_api/tt_metal.cpp
@@ -1781,6 +1781,11 @@ uint32_t CreateSemaphore(
 }
 
 GlobalSemaphore CreateGlobalSemaphore(
+    distributed::MeshDevice& device, CoreRangeSet cores, uint32_t initial_value, BufferType buffer_type) {
+    return GlobalSemaphore(device, std::move(cores), initial_value, buffer_type);
+}
+
+GlobalSemaphore CreateGlobalSemaphore(
     IDevice* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type) {
     return GlobalSemaphore(device, cores, initial_value, buffer_type);
 }
@@ -1967,6 +1972,14 @@ uint8_t GetCurrentCommandQueueIdForThread() {
 }
 
 namespace experimental {
+
+GlobalCircularBuffer CreateGlobalCircularBuffer(
+    distributed::MeshDevice& device,
+    const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
+    uint32_t size,
+    BufferType buffer_type) {
+    return GlobalCircularBuffer(device, sender_receiver_core_mapping, size, buffer_type);
+}
 
 GlobalCircularBuffer CreateGlobalCircularBuffer(
     IDevice* device,

--- a/ttnn/api/ttnn/global_circular_buffer.hpp
+++ b/ttnn/api/ttnn/global_circular_buffer.hpp
@@ -13,13 +13,6 @@
 
 namespace ttnn::global_circular_buffer {
 
-// Single Device APIs
-GlobalCircularBuffer create_global_circular_buffer(
-    IDevice* device,
-    const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
-    uint32_t size,
-    BufferType buffer_type = BufferType::L1);
-
 // Multi Device APIs
 GlobalCircularBuffer create_global_circular_buffer(
     MeshDevice* mesh_device,

--- a/ttnn/api/ttnn/global_semaphore.hpp
+++ b/ttnn/api/ttnn/global_semaphore.hpp
@@ -8,10 +8,6 @@
 
 namespace ttnn::global_semaphore {
 
-// Single Device Creation API
-GlobalSemaphore create_global_semaphore(
-    IDevice* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type = BufferType::L1);
-
 // MeshDevice Creation API
 GlobalSemaphore create_global_semaphore(
     MeshDevice* mesh_device,

--- a/ttnn/core/global_circular_buffer.cpp
+++ b/ttnn/core/global_circular_buffer.cpp
@@ -19,23 +19,12 @@
 namespace ttnn::global_circular_buffer {
 
 GlobalCircularBuffer create_global_circular_buffer(
-    IDevice* device,
-    const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
-    uint32_t size,
-    BufferType buffer_type) {
-    auto guard = tt::tt_metal::make_allocation_context_guard("ttnn.create_global_circular_buffer");
-    return tt::tt_metal::experimental::CreateGlobalCircularBuffer(
-        device, sender_receiver_core_mapping, size, buffer_type);
-}
-
-GlobalCircularBuffer create_global_circular_buffer(
     MeshDevice* device,
     const std::vector<std::pair<CoreCoord, CoreRangeSet>>& sender_receiver_core_mapping,
     uint32_t size,
     BufferType buffer_type) {
     auto guard = tt::tt_metal::make_allocation_context_guard("ttnn.create_global_circular_buffer");
-    return tt::tt_metal::experimental::CreateGlobalCircularBuffer(
-        device, sender_receiver_core_mapping, size, buffer_type);
+    return tt::tt_metal::experimental::GlobalCircularBuffer(*device, sender_receiver_core_mapping, size, buffer_type);
 }
 
 GlobalCircularBuffer create_global_circular_buffer_for_tensor_prefetcher(

--- a/ttnn/core/global_semaphore.cpp
+++ b/ttnn/core/global_semaphore.cpp
@@ -4,22 +4,15 @@
 
 #include "ttnn/global_semaphore.hpp"
 
-#include <tt-metalium/host_api.hpp>
 #include <tt-metalium/experimental/allocation_context.hpp>
 #include <tt-metalium/global_semaphore.hpp>
 
 namespace ttnn::global_semaphore {
 
 GlobalSemaphore create_global_semaphore(
-    IDevice* device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type) {
-    auto guard = tt::tt_metal::make_allocation_context_guard("ttnn.create_global_semaphore");
-    return CreateGlobalSemaphore(device, cores, initial_value, buffer_type);
-}
-
-GlobalSemaphore create_global_semaphore(
     MeshDevice* mesh_device, const CoreRangeSet& cores, uint32_t initial_value, BufferType buffer_type) {
     auto guard = tt::tt_metal::make_allocation_context_guard("ttnn.create_global_semaphore");
-    return CreateGlobalSemaphore(mesh_device, cores, initial_value, buffer_type);
+    return GlobalSemaphore(*mesh_device, cores, initial_value, buffer_type);
 }
 
 tt::tt_metal::DeviceAddr get_global_semaphore_address(const GlobalSemaphore& global_semaphore) {

--- a/ttnn/cpp/ttnn-nanobind/global_circular_buffer.cpp
+++ b/ttnn/cpp/ttnn-nanobind/global_circular_buffer.cpp
@@ -30,38 +30,16 @@ void py_module_types(nb::module_& mod) {
 }
 
 void py_module(nb::module_& mod) {
-    // Single Device APIs
     mod.def(
         "create_global_circular_buffer",
-        nb::overload_cast<IDevice*, const std::vector<std::pair<CoreCoord, CoreRangeSet>>&, uint32_t, BufferType>(
-            &ttnn::global_circular_buffer::create_global_circular_buffer),
-        nb::keep_alive<0, 1>(),  // test
-        nb::arg("device"),
-        nb::arg("sender_receiver_core_mapping"),
-        nb::arg("size"),
-        nb::arg("buffer_type") = tt::tt_metal::BufferType::L1,
-        R"doc(
-            Create a GlobalCircularBuffer Object on a single device.
-
-            Args:
-                device (Device): The device on which to create the global circular buffer.
-                sender_receiver_core_mapping (List[Tuple[CoreCoord, CoreRangeSet]]): The mapping of remote sender to remote receiver cores for the circular buffer.
-                size (int): Size of the global circular buffer per core in bytes.
-                buffer_type (BufferType): The type of buffer to use for the global circular buffer.\
-            )doc");
-
-    // Multi Device APIs
-    mod.def(
-        "create_global_circular_buffer",
-        nb::overload_cast<MeshDevice*, const std::vector<std::pair<CoreCoord, CoreRangeSet>>&, uint32_t, BufferType>(
-            &ttnn::global_circular_buffer::create_global_circular_buffer),
-        nb::keep_alive<0, 1>(),  // test
+        &ttnn::global_circular_buffer::create_global_circular_buffer,
+        nb::keep_alive<0, 1>(),
         nb::arg("mesh_device"),
         nb::arg("sender_receiver_core_mapping"),
         nb::arg("size"),
         nb::arg("buffer_type") = tt::tt_metal::BufferType::L1,
         R"doc(
-            Create a GlobalCircularBuffer Object on a single device.
+            Create a GlobalCircularBuffer Object on a device.
 
             Args:
                 mesh_device (MeshDevice): The mesh device on which to create the global circular buffer.

--- a/ttnn/cpp/ttnn-nanobind/global_semaphore.cpp
+++ b/ttnn/cpp/ttnn-nanobind/global_semaphore.cpp
@@ -17,36 +17,15 @@ namespace ttnn::global_semaphore {
 void py_module_types(nb::module_& mod) { nb::class_<GlobalSemaphore>(mod, "global_semaphore"); }
 
 void py_module(nb::module_& mod) {
-    // Single Device Creation API
     mod.def(
         "create_global_semaphore",
-        nb::overload_cast<IDevice*, const CoreRangeSet&, uint32_t, BufferType>(
-            &ttnn::global_semaphore::create_global_semaphore),
-        nb::arg("device"),
-        nb::arg("cores"),
-        nb::arg("initial_value"),
-        nb::arg("buffer_type") = nb::cast(tt::tt_metal::BufferType::L1),
-        R"doc(
-            Create a GlobalSemaphore Object on a single device.
-
-            Args:
-                device (Device): The device on which to create the global semaphore.
-                cores (CoreRangeSet): The cores on which the global semaphore will be used for synchronization.
-                initial_value (int): The initial value of the global semaphore.
-                buffer_type (BufferType): The type of buffer to use for the global semaphore.
-            )doc");
-
-    // MeshDevice Creation API
-    mod.def(
-        "create_global_semaphore",
-        nb::overload_cast<MeshDevice*, const CoreRangeSet&, uint32_t, BufferType>(
-            &ttnn::global_semaphore::create_global_semaphore),
+        &ttnn::global_semaphore::create_global_semaphore,
         nb::arg("mesh_device"),
         nb::arg("cores"),
         nb::arg("initial_value"),
         nb::arg("buffer_type") = nb::cast(tt::tt_metal::BufferType::L1),
         R"doc(
-            Create a GlobalSemaphore Object on a single device.
+            Create a GlobalSemaphore Object on a device.
 
             Args:
                 mesh_device (MeshDevice): The mesh device on which to create the global semaphore.


### PR DESCRIPTION
### PR Category
Cleanup

### Summary

Advances https://github.com/tenstorrent/tt-metal/issues/51835

`MeshDevice` at this point is the only kind of device that can be created publicly. So, we're gradually updating all the APIs to take it as a parameter instead of ambiguous `IDevice`. In this PR:
- `MeshDevice` overloads are added for `GlobalSemaphore` and `GlobalCircularBuffer` constructor, `CreateGlobalSemaphore` and `CreateGlobalCircularBuffer` free functions, and the alternatives are deprecated.
- Python bindings are changed to only call `MeshDevice` overloads. Other devices don't exist in Python, see:
https://github.com/tenstorrent/tt-metal/blob/ac2e6ad488d969d2097d361d20c855e9df2455d8/ttnn/ttnn/device.py#L13

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov-create-global)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov-create-global)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov-create-global)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov-create-global)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov-create-global)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov-create-global)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov-create-global)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov-create-global)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov-create-global)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov-create-global)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov-create-global)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov-create-global)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov-create-global)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov-create-global)