### PR TITLE
add fused swiglu to strided agmm

### DIFF
--- a/tests/nightly/t3000/ccl/test_strided_all_gather_minimal_matmul_async.py
+++ b/tests/nightly/t3000/ccl/test_strided_all_gather_minimal_matmul_async.py
@@ -10,6 +10,7 @@ import ttnn
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
 from tests.nightly.t3000.ccl.test_all_gather import is_unsupported_case
 from models.common.utility_functions import skip_for_blackhole
+from models.tt_dit.utils.tensor import prepare_for_fused_swiglu
 
 from tracy import signpost
 
@@ -63,6 +64,7 @@ def run_strided_all_gather_minimal_matmul_impl(
     ag_core_grid_offset=(0, 6),
     read_local_slice_from_input=False,
     mm_signal_aggregator_mode=ttnn.MMSignalAggregatorMode.Auto,
+    fuse_swiglu=False,
 ):
     torch.manual_seed(0)
 
@@ -71,7 +73,7 @@ def run_strided_all_gather_minimal_matmul_impl(
     ag_output_shape = [1, 1, M, K]
 
     # Skip unsupported cases
-    (is_known_failure, message) = is_unsupported_case(
+    is_known_failure, message = is_unsupported_case(
         ag_output_shape,
         dim,
         mem_config_ag,
@@ -122,13 +124,36 @@ def run_strided_all_gather_minimal_matmul_impl(
     if chunks > 1:
         assert not use_non_fused, "chunks > 1 is only wired into the fused strided_all_gather_minimal_matmul path"
         assert N % chunks == 0, f"N ({N}) must be divisible by chunks ({chunks})"
+    # N is the op's OUTPUT width. SwiGLU consumes a packed [up|gate] weight of width 2N and
+    # collapses each gate/up tile pair to one output tile, so the device weight is twice as wide.
+    weight_N = 2 * N if fuse_swiglu else N
+    if fuse_swiglu:
+        assert not use_non_fused, "fuse_swiglu is only wired into the fused strided_all_gather_minimal_matmul path"
+        assert not use_ternary, "fuse_swiglu is mutually exclusive with ternary (addcmul)"
+        assert activation is None, "fuse_swiglu is mutually exclusive with fused_activation"
+    # Interleave over the number of devices the weight's N is actually split across (1 when replicated),
+    # so each device's slice holds whole [gate, up] tile pairs.
+    swiglu_ndev = mesh_device.shape[1] if shard_weights else 1
     for i in range(num_iters):
         torch_dtype = torch.float32
         ag_output_tensor = torch.randn(ag_output_shape, dtype=torch_dtype)
         ag_output_tensor_goldens_list.append(ag_output_tensor)
-        weight_input = torch.randn((1, 1, K, N), dtype=torch_dtype)
+        weight_input = torch.randn((1, 1, K, weight_N), dtype=torch_dtype)
         if use_bias:
-            bias_input = torch.randn((1, N), dtype=torch_dtype)
+            bias_input = torch.randn((1, weight_N), dtype=torch_dtype)
+
+        # SwiGLU: tile-pair interleave the weight/bias so each device's N-slice holds whole
+        # [gate, up] pairs. The golden below still uses the original [up|gate] layout.
+        weight_to_load = weight_input
+        bias_to_load = bias_input if use_bias else None
+        if fuse_swiglu:
+            weight_to_load = prepare_for_fused_swiglu(weight_input.reshape(K, weight_N), ndev=swiglu_ndev).reshape(
+                weight_input.shape
+            )
+            if use_bias:
+                bias_to_load = prepare_for_fused_swiglu(bias_input.reshape(1, weight_N), ndev=swiglu_ndev).reshape(
+                    bias_input.shape
+                )
         activation_fn = None
         if activation == "gelu":
             activation_fn = (ttnn.UnaryOpType.GELU, False)
@@ -146,7 +171,7 @@ def run_strided_all_gather_minimal_matmul_impl(
             mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=shard_dims, mesh_shape=tuple(mesh_device.shape)),
         )
         weight_tensor_mesh = ttnn.from_torch(
-            weight_input,
+            weight_to_load,
             device=mesh_device,
             layout=layout,
             dtype=ag_input_dtype,
@@ -157,7 +182,7 @@ def run_strided_all_gather_minimal_matmul_impl(
         )
         if use_bias:
             bias_tensor_mesh = ttnn.from_torch(
-                bias_input,
+                bias_to_load,
                 device=mesh_device,
                 layout=layout,
                 dtype=ag_input_dtype,
@@ -207,6 +232,11 @@ def run_strided_all_gather_minimal_matmul_impl(
         if use_bias:
             # Row-broadcast bias: bias_input is [1, N] and broadcasts over the M rows, matching add_bias_block.
             matmul_output = matmul_output + bias_input
+        if fuse_swiglu:
+            # weight_input is the original [up | gate] packing, so the kernel's silu(gate)*up is
+            # first * silu(second) here. Applied after bias, matching the kernel's swiglu_block.
+            first, second = torch.chunk(matmul_output, 2, dim=-1)
+            matmul_output = first * torch.nn.functional.silu(second)
         if use_ternary:
             matmul_output = ternary_a_input + ternary_scalar * matmul_output * ternary_b_input
         # fused_activation is applied last (mutually exclusive with ternary; see the op's validate).
@@ -307,6 +337,7 @@ def run_strided_all_gather_minimal_matmul_impl(
                 fused_ternary_scalar=ternary_scalar if use_ternary else None,
                 chunks=chunks,
                 mm_signal_aggregator_mode=mm_signal_aggregator_mode,
+                fuse_swiglu=fuse_swiglu,
             )
             # Op returns [all_gather_output, matmul_chunk_0, ..., matmul_chunk_{chunks-1}].
             tt_all_gather_out_tensor = fused_outputs[0]
@@ -556,4 +587,122 @@ def test_strided_all_gather_minimal_matmul_async(
         use_non_fused=use_non_fused,
         shard_weights=shard_weights,
         read_local_slice_from_input=read_local_slice_from_input,
+    )
+
+
+# N here is the OUTPUT width; the device weight is 2N wide (packed [up|gate]). The fabric-bound
+# factory partitions on gate/up PAIRS, so N/32 must divide the core-grid x and mm_block_n/32 must
+# be even for a pair to never straddle a core or an N block.
+@skip_for_blackhole("Requires wormhole_b0 to run")
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
+@pytest.mark.parametrize("num_links", [1], ids=["1link"])
+@pytest.mark.parametrize(
+    "M, K, N, dim, other_dim, num_workers_per_link, layout, ag_input_dtype, mm_block_m, mm_block_k, mm_block_n, subblock_h, subblock_w, mm_core_grid, shard_weights",
+    [
+        # replicated weight: 4096-wide packed weight -> 32 weight tiles/core, mm_block_n = 8 tiles
+        (4096, 4096, 2048, 3, 2, 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, 256, 256, 256, 2, 2, ttnn.CoreCoord(4, 4), False),
+        # sharded weight: 8192-wide packed weight over 8 devices -> 8 weight tiles/core, so mm_block_n
+        # drops to 4 tiles to stay under the per-core work
+        (4096, 4096, 4096, 3, 2, 2, ttnn.TILE_LAYOUT, ttnn.bfloat16, 256, 256, 128, 2, 2, ttnn.CoreCoord(4, 4), True),
+    ],
+    ids=["swiglu_replicated_w", "swiglu_sharded_w"],
+)
+@pytest.mark.parametrize("use_bias", [False, True], ids=["nobias", "bias"])
+@pytest.mark.parametrize("chunks", [1], ids=["1chunk"])
+@pytest.mark.parametrize(
+    "mem_config_input, mem_config_ag, mem_config_mm",
+    [
+        (
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+            ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
+        )
+    ],
+)
+# num_iters > 1 exercises the cached-program override path, not just create().
+@pytest.mark.parametrize("enable_trace,num_iters", [(False, 2)], ids=["check"])
+@pytest.mark.parametrize("read_local_slice_from_input", [True], ids=["read_local"])
+@pytest.mark.parametrize(
+    "device_params, all_gather_topology",
+    [
+        ({"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 90112}, ttnn.Topology.Ring),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring"],
+)
+def test_strided_all_gather_minimal_matmul_async_swiglu(
+    mesh_device,
+    M,
+    K,
+    N,
+    dim,
+    other_dim,
+    num_links,
+    ag_input_dtype,
+    layout,
+    mem_config_input,
+    mem_config_ag,
+    mem_config_mm,
+    enable_trace,
+    all_gather_topology,
+    num_iters,
+    num_workers_per_link,
+    mm_block_m,
+    mm_block_k,
+    mm_block_n,
+    subblock_h,
+    subblock_w,
+    mm_core_grid,
+    shard_weights,
+    use_bias,
+    chunks,
+    read_local_slice_from_input,
+):
+    TILE_SIZE = 32
+    assert not ((M // TILE_SIZE) % num_workers_per_link), f"worker must be divisible by num workers per link"
+
+    N_block_tiles = mm_block_n // TILE_SIZE
+    assert N_block_tiles % 2 == 0, f"fuse_swiglu needs an even mm_block_n in tiles, got {N_block_tiles}"
+
+    # The matmul sees the packed 2N weight; per-core work is measured against that width.
+    weight_Nt = (2 * N) // TILE_SIZE
+    weight_Nt_per_device = weight_Nt // mesh_device.shape[1] if shard_weights else weight_Nt
+    weight_Nt_per_core = weight_Nt_per_device // mm_core_grid.x
+    assert (
+        weight_Nt_per_core % 2 == 0
+    ), f"fuse_swiglu needs an even per-core weight tile count, got {weight_Nt_per_core}"
+    assert (
+        weight_Nt_per_core > N_block_tiles
+    ), f"block_n size is {N_block_tiles} tiles, but only {weight_Nt_per_core} weight tiles of work per core"
+
+    run_strided_all_gather_minimal_matmul_impl(
+        mesh_device,
+        mesh_device.get_num_devices(),
+        M,
+        K,
+        N,
+        dim,
+        other_dim,
+        num_links,
+        ag_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_ag,
+        mem_config_mm,
+        all_gather_topology=all_gather_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+        num_workers_per_link=num_workers_per_link,
+        mm_block_m=mm_block_m,
+        mm_block_k=mm_block_k,
+        mm_block_n=mm_block_n,
+        subblock_h=subblock_h,
+        subblock_w=subblock_w,
+        mm_core_grid=mm_core_grid,
+        use_non_fused=False,
+        shard_weights=shard_weights,
+        use_bias=use_bias,
+        chunks=chunks,
+        read_local_slice_from_input=read_local_slice_from_input,
+        fuse_swiglu=True,
     )

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly/test_strided_all_gather_minimal_matmul_async_bh.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/galaxy/galaxy_nightly/test_strided_all_gather_minimal_matmul_async_bh.py
@@ -188,6 +188,99 @@ def test_strided_all_gather_minimal_matmul_async(
     )
 
 
+# Fused SwiGLU on the strided AGMM. N is the OUTPUT width; the device weight is the 2N-wide packed
+# [up|gate]. On a 12-wide core grid the factory splits gate/up PAIRS, so out_N_tiles = N/32 sets the
+# per-core width: "aligned" divides 12 exactly, "ragged" does not and exercises the pair-aware padding.
+@skip_for_wormhole_b0()
+@skip_for_n_or_less_dev(1)
+@pytest.mark.parametrize("mesh_device", [(8, 4)], indirect=True)
+@pytest.mark.parametrize(
+    "M, K, N, mm_block_m, mm_block_k, mm_block_n, subblock_h, subblock_w",
+    [
+        (9728, 4096, 1536, 512, 256, 128, 2, 2),
+        (9728, 4096, 1024, 512, 256, 128, 2, 2),
+        # Same shape as "aligned" but the N block spans a core's whole weight range (1 block/core).
+        # M block is halved to keep the block CBs inside L1; the N block itself is not a swiglu limit.
+        (9728, 4096, 1536, 256, 256, 256, 2, 2),
+    ],
+    ids=["aligned", "ragged", "full_block"],
+)
+@pytest.mark.parametrize("use_bias", [False, True], ids=["no_bias", "bias"])
+# num_iters > 1 also covers the cached-program override path, not just create().
+@pytest.mark.parametrize("enable_trace,num_iters", [(False, 2)], ids=["check"])
+@pytest.mark.parametrize(
+    "device_params, all_gather_topology",
+    [
+        (
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+                "fabric_router_config": create_fabric_router_config(8192),
+                "trace_region_size": 1171456,
+            },
+            ttnn.Topology.Ring,
+        ),
+    ],
+    indirect=["device_params"],
+    ids=["fabric_ring"],
+)
+def test_strided_all_gather_minimal_matmul_swiglu(
+    mesh_device,
+    M,
+    K,
+    N,
+    mm_block_m,
+    mm_block_k,
+    mm_block_n,
+    subblock_h,
+    subblock_w,
+    use_bias,
+    enable_trace,
+    num_iters,
+    all_gather_topology,
+):
+    mm_core_grid = ttnn.CoreCoord(12, 8)
+    ag_offset = (0, 8)
+    grid = mesh_device.compute_with_storage_grid_size()
+    if grid.x < mm_core_grid.x or grid.y < ag_offset[1] + 1:
+        pytest.skip(f"Requires worker grid >= {mm_core_grid.x}x{ag_offset[1] + 1}, got {grid.x}x{grid.y}")
+
+    assert (mm_block_n // 32) % 2 == 0, "fuse_swiglu requires an even mm_block_n in tiles"
+
+    dram = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+    run_strided_all_gather_minimal_matmul_impl(
+        mesh_device,
+        mesh_device.get_num_devices(),
+        M,
+        K,
+        N,
+        3,  # dim (AG/K shard axis)
+        2,  # other_dim (M/sequence shard axis)
+        2,  # num_links
+        ttnn.bfloat16,
+        ttnn.TILE_LAYOUT,
+        dram,
+        dram,
+        dram,
+        all_gather_topology=all_gather_topology,
+        enable_trace=enable_trace,
+        num_iters=num_iters,
+        num_workers_per_link=3,
+        num_buffers_per_channel=8,
+        mm_block_m=mm_block_m,
+        mm_block_k=mm_block_k,
+        mm_block_n=mm_block_n,
+        subblock_h=subblock_h,
+        subblock_w=subblock_w,
+        mm_core_grid=mm_core_grid,
+        use_non_fused=False,
+        use_bias=use_bias,
+        shard_weights=False,
+        ag_core_grid_offset=ag_offset,
+        read_local_slice_from_input=True,
+        fuse_swiglu=True,
+    )
+
+
 # The AG-matmul configurations the LTX transformer block actually uses
 @skip_for_wormhole_b0()
 @skip_for_n_or_less_dev(1)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_op.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_op.cpp
@@ -23,6 +23,33 @@ void StridedAllGatherMinimalMatmulAsync::validate_on_program_cache_miss(
     TT_FATAL(
         tensor_args.fused_ternary_input_a.has_value() == tensor_args.fused_ternary_input_b.has_value(),
         "StridedAllGatherMinimalMatmulAsync fused addcmul requires both ternary inputs (a and b) or neither.");
+
+    // SwiGLU packs gate/up tile-pairs along the weight's N, so the weight width must be an even
+    // number of tiles; each pair collapses to one output tile. Restated here because this op does
+    // not route through MinimalMatmulDeviceOperation::validate_*.
+    if (attributes.matmul_struct.fuse_swiglu) {
+        TT_FATAL(
+            !attributes.matmul_struct.fused_activation.has_value(),
+            "StridedAllGatherMinimalMatmulAsync cannot combine fuse_swiglu with a unary fused_activation");
+        TT_FATAL(
+            !attributes.matmul_struct.fused_ternary_scalar.has_value() &&
+                !tensor_args.fused_ternary_input_a.has_value(),
+            "StridedAllGatherMinimalMatmulAsync cannot combine fuse_swiglu with fused ternary (addcmul)");
+        const uint32_t N = tensor_args.weight_tensor.logical_shape()[-1];
+        const int32_t chunks = attributes.matmul_struct.chunks;
+        TT_FATAL(
+            N % (2 * tt::constants::TILE_WIDTH) == 0,
+            "StridedAllGatherMinimalMatmulAsync fuse_swiglu requires weight width N={} to be a multiple of "
+            "2*TILE_WIDTH={}",
+            N,
+            2 * tt::constants::TILE_WIDTH);
+        TT_FATAL(
+            (N / chunks) % (2 * tt::constants::TILE_WIDTH) == 0,
+            "StridedAllGatherMinimalMatmulAsync fuse_swiglu requires per-chunk weight width N/chunks={} to be a "
+            "multiple of 2*TILE_WIDTH={}",
+            N / chunks,
+            2 * tt::constants::TILE_WIDTH);
+    }
     if (tensor_args.fused_ternary_input_a.has_value()) {
         TT_FATAL(
             !attributes.matmul_struct.fused_activation.has_value(),
@@ -126,7 +153,8 @@ std::vector<Tensor> strided_all_gather_minimal_matmul_async(
     const std::optional<const Tensor>& fused_ternary_input_b,
     std::optional<float> fused_ternary_scalar,
     int32_t chunks,
-    ttnn::experimental::prim::MMSignalAggregatorMode mm_signal_aggregator_mode) {
+    ttnn::experimental::prim::MMSignalAggregatorMode mm_signal_aggregator_mode,
+    bool fuse_swiglu) {
     using OperationType = ttnn::experimental::prim::StridedAllGatherMinimalMatmulAsync;
 
     // addcmul uses value=1 (torch default) when ternary inputs are given without an explicit scalar
@@ -167,7 +195,8 @@ std::vector<Tensor> strided_all_gather_minimal_matmul_async(
         .output_mem_config = memory_config_mm,
         .fused_ternary_scalar = fused_ternary_scalar,
         .compute_kernel_config = compute_kernel_config.value(),
-        .chunks = chunks};
+        .chunks = chunks,
+        .fuse_swiglu = fuse_swiglu};
     ttnn::experimental::prim::StridedAllGatherAsync ag_op{};
 
     bool read_local_from_input = read_local_slice_from_input.value_or(false);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_op.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_op.hpp
@@ -71,6 +71,9 @@ std::vector<Tensor> strided_all_gather_minimal_matmul_async(
     const std::optional<const Tensor>& fused_ternary_input_b,
     std::optional<float> fused_ternary_scalar,
     int32_t chunks,
-    ttnn::experimental::prim::MMSignalAggregatorMode mm_signal_aggregator_mode);
+    ttnn::experimental::prim::MMSignalAggregatorMode mm_signal_aggregator_mode,
+    // Fused SwiGLU: the weight is a tile-pair-interleaved [gate|up] matrix of width 2N; the matmul
+    // emits silu(gate) * up of width N. See MinimalMatmulParams::fuse_swiglu.
+    bool fuse_swiglu = false);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_program.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/device/strided_all_gather_minimal_matmul_async_program.cpp
@@ -105,7 +105,8 @@ strided_all_gather_minimal_matmul_async_program(
     DeviceComputeKernelConfig compute_kernel_config,
     std::optional<float> fused_ternary_scalar,
     const std::optional<const Tensor>& fused_ternary_input_a,
-    const std::optional<const Tensor>& fused_ternary_input_b) {
+    const std::optional<const Tensor>& fused_ternary_input_b,
+    bool fuse_swiglu) {
     tt::tt_metal::Program program{};
 
     // Create a matmul signal info object that gets populated by the matmul kernel
@@ -138,7 +139,8 @@ strided_all_gather_minimal_matmul_async_program(
         fused_ternary_scalar,
         fused_ternary_input_a,
         fused_ternary_input_b,
-        empty_srs_fused_op_signaler);
+        empty_srs_fused_op_signaler,
+        fuse_swiglu);
 
     // Create the all gather fused op signaler
     std::optional<ttnn::experimental::ccl::StridedAllGatherFusedOpSignaler> all_gather_fused_op_signaler =
@@ -236,7 +238,8 @@ StridedAllGatherMinimalMatmulAsyncProgramFactory::create_at(
         attributes.matmul_struct.compute_kernel_config,
         attributes.matmul_struct.fused_ternary_scalar,
         tensor_args.fused_ternary_input_a,
-        tensor_args.fused_ternary_input_b);
+        tensor_args.fused_ternary_input_b,
+        attributes.matmul_struct.fuse_swiglu);
 }
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/strided_all_gather_minimal_matmul_async.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/strided_all_gather_minimal_matmul_async.cpp
@@ -30,7 +30,8 @@ std::vector<ttnn::Tensor> strided_all_gather_minimal_matmul_async(
     const std::optional<const Tensor>& fused_ternary_input_b,
     std::optional<float> fused_ternary_scalar,
     int32_t chunks,
-    ttnn::experimental::prim::MMSignalAggregatorMode mm_signal_aggregator_mode) {
+    ttnn::experimental::prim::MMSignalAggregatorMode mm_signal_aggregator_mode,
+    bool fuse_swiglu) {
     return ttnn::prim::strided_all_gather_minimal_matmul_async(
         input_tensor,
         weight_tensor,
@@ -55,7 +56,8 @@ std::vector<ttnn::Tensor> strided_all_gather_minimal_matmul_async(
         fused_ternary_input_b,
         fused_ternary_scalar,
         chunks,
-        mm_signal_aggregator_mode);
+        mm_signal_aggregator_mode,
+        fuse_swiglu);
 }
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/strided_all_gather_minimal_matmul_async.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/strided_all_gather_minimal_matmul_async.hpp
@@ -36,6 +36,10 @@ std::vector<ttnn::Tensor> strided_all_gather_minimal_matmul_async(
     std::optional<float> fused_ternary_scalar = std::nullopt,
     int32_t chunks = 1,
     ttnn::experimental::prim::MMSignalAggregatorMode mm_signal_aggregator_mode =
-        ttnn::experimental::prim::MMSignalAggregatorMode::Auto);
+        ttnn::experimental::prim::MMSignalAggregatorMode::Auto,
+    // Fused SwiGLU: the weight is a tile-pair-interleaved [gate|up] matrix of width 2N; the matmul
+    // emits silu(gate) * up, so the output width is N. Mutually exclusive with fused_activation
+    // and the fused ternary (addcmul) inputs.
+    bool fuse_swiglu = false);
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/strided_all_gather_minimal_matmul_async_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/strided_all_gather_minimal_matmul_async/strided_all_gather_minimal_matmul_async_nanobind.cpp
@@ -57,6 +57,12 @@ void bind_strided_all_gather_minimal_matmul_async(nb::module_& mod) {
             * :attr:`fused_ternary_scalar` (Optional[float]): addcmul scale; output = a + scalar * matmul_out * b. Requires both a and b.
             * :attr:`chunks` (int): split the matmul output into this many tensors along N (default 1). Returns [all_gather_output, matmul_chunk_0, ..., matmul_chunk_{chunks-1}]. N must be divisible by chunks.
             * :attr:`mm_signal_aggregator_mode` (ttnn.MMSignalAggregatorMode): whether the all-gather signals the matmul through per-direction aggregator cores. These cost one worker core per direction on top of `num_links * (num_workers_per_link + 1) * 2` mux/worker cores, all placed from `strided_all_gather_core_grid_offset`. `Auto` (default) uses them when they fit and otherwise falls back to reader-signaled matmul with a warning, `On` requires them, `Off` never uses them.
+            * :attr:`fuse_swiglu` (bool): If True, applies SwiGLU fused into the matmul: the weight's N columns
+              are interpreted as a tile-pair-interleaved [gate|up] layout — column tile 2p is the gate and 2p+1
+              the up projection for each pair p (``models.tt_dit.utils.tensor.prepare_for_fused_swiglu`` produces
+              this layout). The op computes silu(gate) * up, so the matmul output width is N/2. The bias (if
+              provided) must use the same column layout. N must be divisible by 2*32, and by 2*32*chunks when
+              chunking. Mutually exclusive with fused_activation and the fused ternary (addcmul) inputs.
 
         Example:
 
@@ -89,7 +95,8 @@ void bind_strided_all_gather_minimal_matmul_async(nb::module_& mod) {
         nb::arg("fused_ternary_input_b") = nb::none(),
         nb::arg("fused_ternary_scalar") = nb::none(),
         nb::arg("chunks") = 1,
-        nb::arg("mm_signal_aggregator_mode") = nb::cast(ttnn::experimental::prim::MMSignalAggregatorMode::Auto));
+        nb::arg("mm_signal_aggregator_mode") = nb::cast(ttnn::experimental::prim::MMSignalAggregatorMode::Auto),
+        nb::arg("fuse_swiglu") = false);
 }
 
 }  // namespace ttnn::operations::experimental::ccl


### PR DESCRIPTION
### PR Category
Feature

### Summary
Enable fused swiglu for the strided all gather matmul.

### Notes for reviewers
This basically enables the option for the strided all gather mamul. The feature exists for other variants.

### CI Failures
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sadesoye/add_fused_swiglu_fabric_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sadesoye/add_fused_swiglu_fabric_mm) : Pre existing failure on main
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sadesoye/add_fused_swiglu_fabric_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sadesoye/add_fused_swiglu_fabric_mm) : Pre existing failure on main
- 
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sadesoye/add_fused_swiglu_fabric_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sadesoye/add_fused_swiglu_fabric_mm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sadesoye/add_fused_swiglu_fabric_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sadesoye/add_fused_swiglu_fabric_mm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sadesoye/add_fused_swiglu_fabric_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sadesoye/add_fused_swiglu_fabric_mm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sadesoye/add_fused_swiglu_fabric_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sadesoye/add_fused_swiglu_fabric_mm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sadesoye/add_fused_swiglu_fabric_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sadesoye/add_fused_swiglu_fabric_mm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sadesoye/add_fused_swiglu_fabric_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sadesoye/add_fused_swiglu_fabric_mm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sadesoye/add_fused_swiglu_fabric_mm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sadesoye/add_fused_swiglu_fabric_mm)