### PR TITLE
[tt-train] Fix layernorm_bw dx double-subtract and non-L1 nested DST acquire

### DIFF
--- a/tt-train/sources/ttml/metal/ops/layernorm_bw/device/kernels/compute/layernorm_bw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/layernorm_bw/device/kernels/compute/layernorm_bw_kernel.cpp
@@ -328,9 +328,8 @@ inline void compute_dy_gamma_xnorm_sum(const uint32_t row) {
     const uint32_t x_norm_register = 2U;
 
     // compute_x_hat_preprocessing acquires/releases DST itself, so it must run outside this
-    // function's DST window (each release clears a DST half, which would wipe a sum held across
-    // blocks). The running sum is therefore carried through cb_scaled_dy_gamma_xnorm_sum_idx:
-    // each block reloads the partial sum, adds its contribution, and packs it back.
+    // function's DST window (a release clears a DST half, wiping any sum held across blocks).
+    // The running sum is instead carried through cb_scaled_dy_gamma_xnorm_sum_idx.
     for (uint32_t col = 0; col < Wt; col += block_size) {
         // Compute x_hat from input for this block
         cb_wait_front(cb_input_idx, block_size);
@@ -343,52 +342,50 @@ inline void compute_dy_gamma_xnorm_sum(const uint32_t row) {
         tile_regs_acquire();
 
         if (col > 0) {
-            // Reload the partial sum packed by the previous block
             cb_wait_front(cb_scaled_dy_gamma_xnorm_sum_idx, onetile);
             reconfig_data_format(cb_scaled_dy_gamma_xnorm_sum_idx, cb_scaled_dy_gamma_xnorm_sum_idx);
             copy_tile_init(cb_scaled_dy_gamma_xnorm_sum_idx);
             copy_tile(cb_scaled_dy_gamma_xnorm_sum_idx, /* tile_idx */ 0, sum_register);
+        } else {
+            zero_dst_reg(sum_register);
         }
 
         reconfig_data_format(cb_dL_out_idx, cb_dL_out_idx);
 
         const uint32_t current_block_size = std::min(block_size, Wt - col);
         for (uint32_t block_idx = 0; block_idx < current_block_size; ++block_idx) {
-            uint32_t global_col = col + block_idx;
-            const uint32_t target_register = (global_col == 0) ? sum_register : working_register;
+            const uint32_t global_col = col + block_idx;
 
             // Load x_normalized (x_hat)
             copy_tile_init(cb_x_hat_idx);
             copy_tile(cb_x_hat_idx, block_idx, x_norm_register);
 
             // Compute dy * gamma
-            zero_dst_reg(target_register);
+            zero_dst_reg(working_register);
             mul_bcast_rows_init(cb_dL_out_idx, cb_gamma_idx);
-            mul_tiles_bcast_rows(cb_dL_out_idx, cb_gamma_idx, block_idx, block_idx, target_register);
+            mul_tiles_bcast_rows(cb_dL_out_idx, cb_gamma_idx, block_idx, block_idx, working_register);
 
             // Multiply: (dy * gamma) * x_normalized
             mul_binary_tile_init();
-            mul_binary_tile(target_register, x_norm_register, target_register);
+            mul_binary_tile(working_register, x_norm_register, working_register);
 
             // Mask the tile if needed
             if constexpr (do_mask_w) {
                 if (global_col + 1 == Wt) {
                     // Limitation: mask_tile only works when the mask register is immediately next to the data register.
-                    const uint32_t mask_register = target_register + 1U;
+                    const uint32_t mask_register = working_register + 1U;
 
                     copy_tile_init(cb_mask_w_idx);
                     copy_tile(cb_mask_w_idx, /* tile_idx */ 0, /* register idx */ mask_register);
 
                     mask_tile_init();
-                    mask_tile(target_register, mask_register);
+                    mask_tile(working_register, mask_register);
                 }
             }
 
             // Accumulate to sum
-            if (global_col > 0) {
-                add_binary_tile_init();
-                add_binary_tile(sum_register, working_register, sum_register);
-            }
+            add_binary_tile_init();
+            add_binary_tile(sum_register, working_register, sum_register);
         }
 
         tile_regs_commit();

--- a/tt-train/sources/ttml/metal/ops/layernorm_bw/device/kernels/compute/layernorm_bw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/layernorm_bw/device/kernels/compute/layernorm_bw_kernel.cpp
@@ -320,17 +320,17 @@ inline void compute_dy_gamma_sum(const uint32_t row) {
 //                             shape: [1, Wt]
 //                             ...]
 // cb_dL_out_idx, cb_gamma_idx, cb_x_hat_idx blocks are read
-// acquire in the beginning, release in the end
+// acquire and release per block; the running sum is carried through the output CB
 inline void compute_dy_gamma_xnorm_sum(const uint32_t row) {
     // Similar implementation for non-L1 case
     const uint32_t sum_register = 0U;
     const uint32_t working_register = 1U;
     const uint32_t x_norm_register = 2U;
-    tile_regs_acquire();
 
-    reconfig_data_format(cb_dL_out_idx, cb_dL_out_idx);
-
-    // Accumulate dy * gamma * x_normalized into sum_register
+    // compute_x_hat_preprocessing acquires/releases DST itself, so it must run outside this
+    // function's DST window (each release clears a DST half, which would wipe a sum held across
+    // blocks). The running sum is therefore carried through cb_scaled_dy_gamma_xnorm_sum_idx:
+    // each block reloads the partial sum, adds its contribution, and packs it back.
     for (uint32_t col = 0; col < Wt; col += block_size) {
         // Compute x_hat from input for this block
         cb_wait_front(cb_input_idx, block_size);
@@ -339,6 +339,18 @@ inline void compute_dy_gamma_xnorm_sum(const uint32_t row) {
         cb_wait_front(cb_x_hat_idx, block_size);
         cb_wait_front(cb_dL_out_idx, block_size);
         cb_wait_front(cb_gamma_idx, block_size);
+
+        tile_regs_acquire();
+
+        if (col > 0) {
+            // Reload the partial sum packed by the previous block
+            cb_wait_front(cb_scaled_dy_gamma_xnorm_sum_idx, onetile);
+            reconfig_data_format(cb_scaled_dy_gamma_xnorm_sum_idx, cb_scaled_dy_gamma_xnorm_sum_idx);
+            copy_tile_init(cb_scaled_dy_gamma_xnorm_sum_idx);
+            copy_tile(cb_scaled_dy_gamma_xnorm_sum_idx, /* tile_idx */ 0, sum_register);
+        }
+
+        reconfig_data_format(cb_dL_out_idx, cb_dL_out_idx);
 
         const uint32_t current_block_size = std::min(block_size, Wt - col);
         for (uint32_t block_idx = 0; block_idx < current_block_size; ++block_idx) {
@@ -379,14 +391,17 @@ inline void compute_dy_gamma_xnorm_sum(const uint32_t row) {
             }
         }
 
+        tile_regs_commit();
+        if (col > 0) {
+            cb_pop_front(cb_scaled_dy_gamma_xnorm_sum_idx, onetile);
+        }
+        pack_and_push(sum_register, cb_scaled_dy_gamma_xnorm_sum_idx);
+
         cb_pop_front(cb_x_hat_idx, block_size);
         cb_pop_front(cb_dL_out_idx, block_size);
         cb_pop_front(cb_gamma_idx, block_size);
         cb_pop_front(cb_input_idx, block_size);
     }
-
-    tile_regs_commit();
-    pack_and_push(sum_register, cb_scaled_dy_gamma_xnorm_sum_idx);
 
     // Reduce using matmul and scale by 1/N
     const uint32_t reduced_sum_register = 0U;
@@ -432,6 +447,9 @@ inline void compute_dx(const uint32_t input_tile_idx, const uint32_t dx_register
     sub_binary_tile(dx_register, temp_register, dx_register);
 
     // Multiply by x_normalized: x_normalized * (1/N) * sum(dy*gamma * x_normalized)
+    // mul_tiles accumulates into DST and temp_register still holds (1/N) * sum(dy*gamma) from the
+    // copy above, so it must be zeroed or that sum would be subtracted twice.
+    zero_dst_reg(temp_register);
     reconfig_data_format(cb_x_hat_idx, cb_scaled_dy_gamma_xnorm_sum_idx);
     mul_init(cb_x_hat_idx, cb_scaled_dy_gamma_xnorm_sum_idx);
     mul_tiles(cb_x_hat_idx, cb_scaled_dy_gamma_xnorm_sum_idx, input_tile_idx, 0, temp_register);

--- a/tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_program_factory.cpp
@@ -260,7 +260,6 @@ LayerNormForwardProgramFactory::cached_program_t LayerNormForwardProgramFactory:
     const uint32_t num_x_hat_tiles = (everything_fits_in_l1) ? closest_to_Wt_multiple_of_block_size : twice_block_size;
 
     tt::DataFormat default_data_format = tt::DataFormat::Float16_b;
-
     // Input data CBs
     [[maybe_unused]] auto cb_scaler = create_circular_buffer(
         program, all_cores, kScalerCbIndex, default_data_format, bfloat16_single_tile_size_bytes, kNumScalerTiles);

--- a/tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_program_factory.cpp
@@ -260,6 +260,8 @@ LayerNormForwardProgramFactory::cached_program_t LayerNormForwardProgramFactory:
     const uint32_t num_x_hat_tiles = (everything_fits_in_l1) ? closest_to_Wt_multiple_of_block_size : twice_block_size;
 
     tt::DataFormat default_data_format = tt::DataFormat::Float16_b;
+    tt::DataFormat precise_data_format = tt::DataFormat::Float32;
+
     // Input data CBs
     [[maybe_unused]] auto cb_scaler = create_circular_buffer(
         program, all_cores, kScalerCbIndex, default_data_format, bfloat16_single_tile_size_bytes, kNumScalerTiles);
@@ -286,7 +288,7 @@ LayerNormForwardProgramFactory::cached_program_t LayerNormForwardProgramFactory:
 
     // Intermediate computation CBs
     [[maybe_unused]] auto cb_sum = create_circular_buffer(
-        program, all_cores, kSumCbIndex, default_data_format, float32_single_tile_size_bytes, kNumSumTiles);
+        program, all_cores, kSumCbIndex, precise_data_format, float32_single_tile_size_bytes, kNumSumTiles);
     [[maybe_unused]] auto cb_mean_bcast = create_circular_buffer(
         program,
         all_cores,
@@ -295,7 +297,7 @@ LayerNormForwardProgramFactory::cached_program_t LayerNormForwardProgramFactory:
         bfloat16_single_tile_size_bytes,
         kNumMeanBcastTiles);
     [[maybe_unused]] auto cb_variance_sum = create_circular_buffer(
-        program, all_cores, kVarianceSumCbIndex, default_data_format, float32_single_tile_size_bytes, kNumSumTiles);
+        program, all_cores, kVarianceSumCbIndex, precise_data_format, float32_single_tile_size_bytes, kNumSumTiles);
     [[maybe_unused]] auto cb_rstd_bcast = create_circular_buffer(
         program,
         all_cores,

--- a/tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/layernorm_fw/device/layernorm_fw_program_factory.cpp
@@ -260,7 +260,6 @@ LayerNormForwardProgramFactory::cached_program_t LayerNormForwardProgramFactory:
     const uint32_t num_x_hat_tiles = (everything_fits_in_l1) ? closest_to_Wt_multiple_of_block_size : twice_block_size;
 
     tt::DataFormat default_data_format = tt::DataFormat::Float16_b;
-    tt::DataFormat precise_data_format = tt::DataFormat::Float32;
 
     // Input data CBs
     [[maybe_unused]] auto cb_scaler = create_circular_buffer(
@@ -288,7 +287,7 @@ LayerNormForwardProgramFactory::cached_program_t LayerNormForwardProgramFactory:
 
     // Intermediate computation CBs
     [[maybe_unused]] auto cb_sum = create_circular_buffer(
-        program, all_cores, kSumCbIndex, precise_data_format, float32_single_tile_size_bytes, kNumSumTiles);
+        program, all_cores, kSumCbIndex, default_data_format, float32_single_tile_size_bytes, kNumSumTiles);
     [[maybe_unused]] auto cb_mean_bcast = create_circular_buffer(
         program,
         all_cores,
@@ -297,7 +296,7 @@ LayerNormForwardProgramFactory::cached_program_t LayerNormForwardProgramFactory:
         bfloat16_single_tile_size_bytes,
         kNumMeanBcastTiles);
     [[maybe_unused]] auto cb_variance_sum = create_circular_buffer(
-        program, all_cores, kVarianceSumCbIndex, precise_data_format, float32_single_tile_size_bytes, kNumSumTiles);
+        program, all_cores, kVarianceSumCbIndex, default_data_format, float32_single_tile_size_bytes, kNumSumTiles);
     [[maybe_unused]] auto cb_rstd_bcast = create_circular_buffer(
         program,
         all_cores,

--- a/tt-train/tests/ops/layernorm_bw_fused_op_test.cpp
+++ b/tt-train/tests/ops/layernorm_bw_fused_op_test.cpp
@@ -108,10 +108,9 @@ static void CompareKernelVsXArray(
     const uint32_t heads,
     const uint32_t features,
     const int num_iterations = 3,
-    // dx discriminates the kernel bugs: the pre-fix double-subtract sat at 0.15-0.36
-    // max abs error on device, the fixed kernel at <=0.014. dgamma/dbeta are host-side
-    // sums of bf16 per-row components, so their noise grows with rows*features and is
-    // unchanged by the fix (~0.29 at features~8k on device) - graded separately.
+    // dx comes straight from the kernel (<=0.014 max abs error on device), while
+    // dgamma/dbeta are host-side sums of bf16 per-row components whose noise grows
+    // with rows*features (~0.29 at features~8k on device) - graded separately.
     const float dx_atol = 2e-2F,
     const float dgb_atol = 5e-2F) {
     using namespace ttml;

--- a/tt-train/tests/ops/layernorm_bw_fused_op_test.cpp
+++ b/tt-train/tests/ops/layernorm_bw_fused_op_test.cpp
@@ -175,9 +175,9 @@ static void CompareKernelVsXArray(
         ASSERT_EQ(dbeta_ref.shape(), metal_dbeta_flat.shape());
 
         // Compare values
-        EXPECT_TRUE(xt::allclose(metal_dx_flat, dx_ref, 1.0e-3F, 5e-1F));
-        EXPECT_TRUE(xt::allclose(metal_dgamma_flat, dgamma_ref, 1.0e-3F, 5e-1F));
-        EXPECT_TRUE(xt::allclose(metal_dbeta_flat, dbeta_ref, 1.0e-3F, 5e-1F));
+        EXPECT_TRUE(xt::allclose(metal_dx_flat, dx_ref, 1.0e-3F, 1e-2F));
+        EXPECT_TRUE(xt::allclose(metal_dgamma_flat, dgamma_ref, 1.0e-3F, 1e-2F));
+        EXPECT_TRUE(xt::allclose(metal_dbeta_flat, dbeta_ref, 1.0e-3F, 1e-2F));
     }
 }
 

--- a/tt-train/tests/ops/layernorm_bw_fused_op_test.cpp
+++ b/tt-train/tests/ops/layernorm_bw_fused_op_test.cpp
@@ -175,9 +175,12 @@ static void CompareKernelVsXArray(
         ASSERT_EQ(dbeta_ref.shape(), metal_dbeta_flat.shape());
 
         // Compare values
-        EXPECT_TRUE(xt::allclose(metal_dx_flat, dx_ref, 1.0e-3F, 1e-2F));
-        EXPECT_TRUE(xt::allclose(metal_dgamma_flat, dgamma_ref, 1.0e-3F, 1e-2F));
-        EXPECT_TRUE(xt::allclose(metal_dbeta_flat, dbeta_ref, 1.0e-3F, 1e-2F));
+        EXPECT_TRUE(xt::allclose(metal_dx_flat, dx_ref, 1.0e-3F, 1e-2F))
+            << "dx max_abs_diff=" << xt::amax(xt::abs(metal_dx_flat - dx_ref))();
+        EXPECT_TRUE(xt::allclose(metal_dgamma_flat, dgamma_ref, 1.0e-3F, 1e-2F))
+            << "dgamma max_abs_diff=" << xt::amax(xt::abs(metal_dgamma_flat - dgamma_ref))();
+        EXPECT_TRUE(xt::allclose(metal_dbeta_flat, dbeta_ref, 1.0e-3F, 1e-2F))
+            << "dbeta max_abs_diff=" << xt::amax(xt::abs(metal_dbeta_flat - dbeta_ref))();
     }
 }
 

--- a/tt-train/tests/ops/layernorm_bw_fused_op_test.cpp
+++ b/tt-train/tests/ops/layernorm_bw_fused_op_test.cpp
@@ -107,7 +107,13 @@ static void CompareKernelVsXArray(
     const uint32_t seq_len,
     const uint32_t heads,
     const uint32_t features,
-    const int num_iterations = 3) {
+    const int num_iterations = 3,
+    // dx discriminates the kernel bugs: the pre-fix double-subtract sat at 0.15-0.36
+    // max abs error on device, the fixed kernel at <=0.014. dgamma/dbeta are host-side
+    // sums of bf16 per-row components, so their noise grows with rows*features and is
+    // unchanged by the fix (~0.29 at features~8k on device) - graded separately.
+    const float dx_atol = 2e-2F,
+    const float dgb_atol = 5e-2F) {
     using namespace ttml;
 
     for (int iter = 0; iter < num_iterations; iter++) {
@@ -175,11 +181,11 @@ static void CompareKernelVsXArray(
         ASSERT_EQ(dbeta_ref.shape(), metal_dbeta_flat.shape());
 
         // Compare values
-        EXPECT_TRUE(xt::allclose(metal_dx_flat, dx_ref, 1.0e-3F, 1e-2F))
+        EXPECT_TRUE(xt::allclose(metal_dx_flat, dx_ref, 1.0e-3F, dx_atol))
             << "dx max_abs_diff=" << xt::amax(xt::abs(metal_dx_flat - dx_ref))();
-        EXPECT_TRUE(xt::allclose(metal_dgamma_flat, dgamma_ref, 1.0e-3F, 1e-2F))
+        EXPECT_TRUE(xt::allclose(metal_dgamma_flat, dgamma_ref, 1.0e-3F, dgb_atol))
             << "dgamma max_abs_diff=" << xt::amax(xt::abs(metal_dgamma_flat - dgamma_ref))();
-        EXPECT_TRUE(xt::allclose(metal_dbeta_flat, dbeta_ref, 1.0e-3F, 1e-2F))
+        EXPECT_TRUE(xt::allclose(metal_dbeta_flat, dbeta_ref, 1.0e-3F, dgb_atol))
             << "dbeta max_abs_diff=" << xt::amax(xt::abs(metal_dbeta_flat - dbeta_ref))();
     }
 }
@@ -197,11 +203,11 @@ TEST_F(LayerNormBackwardOpTest, MetalLayerNormBw_TwoIncompleteTiles) {
 }
 
 TEST_F(LayerNormBackwardOpTest, NIGHTLY_MetalLayerNormBw_LargeFeatures_NoL1Fit) {
-    CompareKernelVsXArray(3, 273, 1, 8462);
+    CompareKernelVsXArray(3, 273, 1, 8462, 3, /*dx_atol=*/2e-2F, /*dgb_atol=*/4e-1F);
 }
 
 TEST_F(LayerNormBackwardOpTest, MetalLayerNormBw_DoesNotFitInL1_WtNotDivisibleBy4) {
-    CompareKernelVsXArray(3, 100, 1, 8191, 10);
+    CompareKernelVsXArray(3, 100, 1, 8191, 10, /*dx_atol=*/2e-2F, /*dgb_atol=*/4e-1F);
 }
 
 TEST_F(LayerNormBackwardOpTest, MetalLayerNormBw_OneTilePerRow) {


### PR DESCRIPTION
Fixes #53204

## What

- `compute_dx` in `layernorm_bw_kernel.cpp` double-subtracted `mean(dy·γ)`: `mul_tiles` accumulates into DEST on WH/BH and the temp register still held s1. Added the missing `zero_dst_reg` (the kernel already guards this hazard at three other sites).
- The non-L1 path nested `tile_regs_acquire` inside an accumulation window, so only the last block's contribution to `mean(dy·γ·x̂)` survived (the packer zeroes the DST half on every release). Restructured: acquire moved inside the per-block loop after `compute_x_hat_preprocessing`; the running sum is carried through the existing fp32 CB.
- Replaced the vacuous bw tolerance (`atol=5e-1` on O(1) gradients) with device-calibrated grading: **dx `atol=2e-2`** (buggy kernel ≥ 0.15 measured on device, fixed ≤ 0.014 — an order-of-magnitude discrimination band); **dgamma/dbeta graded separately** at `5e-2` default and `4e-1` on the two features≈8k shapes, where the residual is identical on old and fixed kernels — pre-existing bf16 row-sum noise, not part of this bug, so it can't mask the fix. Failures now report `max_abs_diff`.
- ~~`layernorm_fw`: `cb_sum`/`cb_variance_sum` were declared bf16 but sized fp32; now Float32~~ **Retracted** (be7e3e2584e): the fp32 stats-CB format made end-to-end nanogpt training diverge (loss 2.5 → 10) while all unit suites stayed green — the bw tests feed reference stats, so the fused fw→bw stats handoff is unguarded by unit tests. A precision "improvement" with no unit coverage of its consumer is exactly the kind of change e2e has to gate; the fw factory is unchanged in this PR.

## Impact

Every model training with fused layernorm backward got systematically wrong input gradients (dx = rstd·(dy·γ − **2·**mean(dy·γ) − x̂·mean(dy·γ·x̂))); models with hidden dim ≳ 5000 additionally lost most of the second correction term.

## Validation checklist

- [x] Fail-before-fix confirmed on device: all 5 bw tests FAIL on old kernels with dx `max_abs_diff` 0.15–0.36 (incl. `NIGHTLY_MetalLayerNormBw_LargeFeatures_NoL1Fit` and `MetalLayerNormBw_DoesNotFitInL1_WtNotDivisibleBy4` for the non-L1 restructure)
- [x] Pass-after-fix at final tolerances: all 5 bw tests PASS on the fixed kernels (dx residual ≤ 0.014 vs atol 2e-2); old-fails / fixed-passes discrimination preserved
- [x] layernorm fw suite — green (single-chip BH suite, 605 tests); the fw fp32 CB format change was reverted after e2e divergence (be7e3e2584e)
- [x] Loss-curve sanity check: fused-layernorm nanogpt converges to 2.547 vs 2.531 on main (composite) at 76 ms/step — 21% faster than the composite path; the same run gated the fw CB revert above
- [ ] Watcher-enabled run of the non-L1 cases (CB accounting of the new per-block partial-sum pack) — optional hardening; the non-L1 tests are green on device without watcher

## Device verification (BH galaxy, bh_sc5 quad)

All runs on Blackhole galaxies. Baseline ("old kernels") = `origin/main` @ f941b98652e plus only the new tests.

- **Old kernels**: all 5 layernorm bw tests FAIL with dx `max_abs_diff` 0.15–0.36 — the double-subtract bug is directly visible on device.
- **Fixed kernels**: all 5 bw tests PASS at the final calibrated tolerances (dx ≤ 0.014). Latest device round: 7/7 targets green (bw tests + suites).
- dgamma/dbeta residuals on the two features≈8k shapes are identical on old and fixed kernels (graded at 4e-1) — pre-existing bf16 row-sum behavior, orthogonal to this fix.
- **End-to-end**: nanogpt with fused layernorm bw converges (loss 2.547 vs 2.531 on main) at 76 ms/step, 21% faster than composite. The same e2e run caught the fw fp32 stats-CB regression (loss → 10) that every unit suite missed, driving the be7e3e2584e revert.
- Single-chip BH suite: 605 tests passed on the fixed build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ayerofieiev/kernel-fix/layernorm-bw-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ayerofieiev/kernel-fix/layernorm-bw-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ayerofieiev/kernel-fix/layernorm-bw-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ayerofieiev/kernel-fix/layernorm-bw-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ayerofieiev/kernel-fix/layernorm-bw-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ayerofieiev/kernel-fix/layernorm-bw-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ayerofieiev/kernel-fix/layernorm-bw-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ayerofieiev/kernel-fix/layernorm-bw-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ayerofieiev/kernel-fix/layernorm-bw-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ayerofieiev/kernel-fix/layernorm-bw-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ayerofieiev/kernel-fix/layernorm-bw-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ayerofieiev/kernel-fix/layernorm-bw-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ayerofieiev/kernel-fix/layernorm-bw-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ayerofieiev/kernel-fix/layernorm-bw-2026-08-14)