### PR TITLE
[tt-train] Fix sdpa_fw mask=None hang, WH scale truncation, and sdpa_bw validation gaps

### DIFF
--- a/tt-train/sources/ttml/metal/common/sdpa_compute_utils_common.hpp
+++ b/tt-train/sources/ttml/metal/common/sdpa_compute_utils_common.hpp
@@ -9,19 +9,6 @@
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/eltwise_unary/exp.h"
 
-// FP32 bits → BF16 bits with round-to-nearest-even. A plain `>> 16` truncation
-// can be off by a full BF16 ulp (~2^-8 relative), which matters here because the
-// WH exp path applies the BF16 scale to P while the LSE and the backward pass use
-// the full FP32 scale — the rounding error would become a systematic fw/bw
-// mismatch instead of noise. RTN halves the worst-case error; carrying full FP32
-// through the WH SFPU scale multiply would remove it entirely but needs LLK work.
-// Unlike the host-side bfloat16 conversion this has no NaN guard: the bias carry
-// would turn a NaN into Inf, but the only input is 1/sqrt(head_dim), always finite.
-inline constexpr uint16_t sdpa_fp32_bits_to_bf16_rne(uint32_t fp32_bits) {
-    const uint32_t rounding_bias = 0x7FFFU + ((fp32_bits >> 16) & 1U);
-    return static_cast<uint16_t>((fp32_bits + rounding_bias) >> 16);
-}
-
 #ifdef TRISC_MATH
 #ifdef ARCH_BLACKHOLE
 
@@ -179,15 +166,17 @@ inline void sdpa_exp_tile_init() {
 }
 
 // Arch-dispatched scaled exp: exp(scale * x) over 8 face groups.
-//   WH: pre-multiplies by scale via sfpi then calls accurate exp directly.
-//   BH: folds scale into LREG12 at init time — one SFPU op fewer per element.
-template <uint32_t scaler_fp32>
+//   WH: pre-multiplies by the BF16 scale via sfpi then calls accurate exp directly.
+//       `scaler_bf16` carries the host-side RNE conversion of `scaler_fp32` (low 16 bits).
+//   BH: folds the full FP32 scale into LREG12 at init time — one SFPU op fewer per element.
+template <uint32_t scaler_fp32, uint32_t scaler_bf16>
 inline void sdpa_exp_tile_scaled(uint32_t idst) {
 #ifdef ARCH_WORMHOLE
-    constexpr uint16_t scaler_bf16 = sdpa_fp32_bits_to_bf16_rne(scaler_fp32);
 #ifdef TRISC_MATH
     _llk_math_eltwise_unary_sfpu_params_(
-        _sdpa_detail::mul_then_sfpi_exp</*ITERATIONS*/ 8, DST_ACCUM_MODE, scaler_bf16>, idst, VectorMode::RC);
+        _sdpa_detail::mul_then_sfpi_exp</*ITERATIONS*/ 8, DST_ACCUM_MODE, static_cast<uint16_t>(scaler_bf16)>,
+        idst,
+        VectorMode::RC);
 #endif
 #elif defined(ARCH_BLACKHOLE)
     sdpa_exp_tile_init</*approx*/ false, /*SCALE_EN*/ true, scaler_fp32>();
@@ -196,15 +185,15 @@ inline void sdpa_exp_tile_scaled(uint32_t idst) {
 }
 
 // Arch-dispatched scaled first-column exp: exp(scale * x) over column 0 only (4 iterations).
-template <uint32_t scaler_fp32>
+template <uint32_t scaler_fp32, uint32_t scaler_bf16>
 inline void sdpa_exp_tile_first_column_scaled(uint32_t idst) {
 #ifdef ARCH_WORMHOLE
-    constexpr uint16_t scaler_bf16 = sdpa_fp32_bits_to_bf16_rne(scaler_fp32);
 #ifdef TRISC_MATH
     constexpr int ITERATIONS_HALF_FACE = 4;
     constexpr int DST_STRIDE = 2;
     _llk_math_eltwise_unary_sfpu_params_(
-        _sdpa_detail::mul_then_sfpi_exp<ITERATIONS_HALF_FACE, DST_ACCUM_MODE, scaler_bf16, DST_STRIDE>,
+        _sdpa_detail::
+            mul_then_sfpi_exp<ITERATIONS_HALF_FACE, DST_ACCUM_MODE, static_cast<uint16_t>(scaler_bf16), DST_STRIDE>,
         idst,
         VectorMode::C);
 #endif

--- a/tt-train/sources/ttml/metal/common/sdpa_compute_utils_common.hpp
+++ b/tt-train/sources/ttml/metal/common/sdpa_compute_utils_common.hpp
@@ -9,6 +9,17 @@
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/eltwise_unary/exp.h"
 
+// FP32 bits → BF16 bits with round-to-nearest-even. A plain `>> 16` truncation
+// can be off by a full BF16 ulp (~2^-8 relative), which matters here because the
+// WH exp path applies the BF16 scale to P while the LSE and the backward pass use
+// the full FP32 scale — the rounding error would become a systematic fw/bw
+// mismatch instead of noise. RTN halves the worst-case error; carrying full FP32
+// through the WH SFPU scale multiply would remove it entirely but needs LLK work.
+inline constexpr uint16_t sdpa_fp32_bits_to_bf16_rne(uint32_t fp32_bits) {
+    const uint32_t rounding_bias = 0x7FFFU + ((fp32_bits >> 16) & 1U);
+    return static_cast<uint16_t>((fp32_bits + rounding_bias) >> 16);
+}
+
 #ifdef TRISC_MATH
 #ifdef ARCH_BLACKHOLE
 
@@ -171,7 +182,7 @@ inline void sdpa_exp_tile_init() {
 template <uint32_t scaler_fp32>
 inline void sdpa_exp_tile_scaled(uint32_t idst) {
 #ifdef ARCH_WORMHOLE
-    constexpr uint16_t scaler_bf16 = static_cast<uint16_t>(scaler_fp32 >> 16);
+    constexpr uint16_t scaler_bf16 = sdpa_fp32_bits_to_bf16_rne(scaler_fp32);
 #ifdef TRISC_MATH
     _llk_math_eltwise_unary_sfpu_params_(
         _sdpa_detail::mul_then_sfpi_exp</*ITERATIONS*/ 8, DST_ACCUM_MODE, scaler_bf16>, idst, VectorMode::RC);
@@ -186,7 +197,7 @@ inline void sdpa_exp_tile_scaled(uint32_t idst) {
 template <uint32_t scaler_fp32>
 inline void sdpa_exp_tile_first_column_scaled(uint32_t idst) {
 #ifdef ARCH_WORMHOLE
-    constexpr uint16_t scaler_bf16 = static_cast<uint16_t>(scaler_fp32 >> 16);
+    constexpr uint16_t scaler_bf16 = sdpa_fp32_bits_to_bf16_rne(scaler_fp32);
 #ifdef TRISC_MATH
     constexpr int ITERATIONS_HALF_FACE = 4;
     constexpr int DST_STRIDE = 2;

--- a/tt-train/sources/ttml/metal/common/sdpa_compute_utils_common.hpp
+++ b/tt-train/sources/ttml/metal/common/sdpa_compute_utils_common.hpp
@@ -15,6 +15,8 @@
 // the full FP32 scale — the rounding error would become a systematic fw/bw
 // mismatch instead of noise. RTN halves the worst-case error; carrying full FP32
 // through the WH SFPU scale multiply would remove it entirely but needs LLK work.
+// Unlike the host-side bfloat16 conversion this has no NaN guard: the bias carry
+// would turn a NaN into Inf, but the only input is 1/sqrt(head_dim), always finite.
 inline constexpr uint16_t sdpa_fp32_bits_to_bf16_rne(uint32_t fp32_bits) {
     const uint32_t rounding_bias = 0x7FFFU + ((fp32_bits >> 16) & 1U);
     return static_cast<uint16_t>((fp32_bits + rounding_bias) >> 16);

--- a/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_kv_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_kv_device_operation.cpp
@@ -106,8 +106,11 @@ void SDPABackwardKVDeviceOperation::validate_on_program_cache_miss(
     check_tile_aligned(key, "Key");
     check_tile_aligned(value, "Value");
 
-    // The reader streams `intermediates` (forward-pass logsumexp) as FP32 tiles straight
-    // from DRAM; a wrong tensor here would produce garbage gradients with no error.
+    // The reader streams `intermediates` (forward-pass logsumexp) as FP32 tiles via a
+    // TensorAccessor, which handles DRAM and L1 interleaved buffers alike; a wrong tensor
+    // here would produce garbage gradients with no error. sdpa_fw allocates it with query's
+    // memory config, so an L1-interleaved query legitimately yields L1-interleaved
+    // intermediates — only sharded layouts are unsupported.
     const auto& intermediates = tensor_args.intermediates;
     TT_FATAL(intermediates.device() == query.device(), "intermediates must be on the same device as query");
     TT_FATAL(
@@ -119,12 +122,12 @@ void SDPABackwardKVDeviceOperation::validate_on_program_cache_miss(
         "intermediates must be FLOAT32, got {}",
         intermediates.dtype());
     TT_FATAL(
-        intermediates.buffer() != nullptr && intermediates.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM &&
+        intermediates.buffer() != nullptr &&
             intermediates.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
-        "intermediates must be DRAM interleaved");
+        "intermediates must be interleaved");
     {
         constexpr uint32_t kIntermediateWidth = 32U;  // one logsumexp tile per query row
-        const auto interm_shape = intermediates.padded_shape();
+        const auto interm_shape = intermediates.logical_shape();
         TT_FATAL(
             interm_shape[0] == qB && interm_shape[1] == qH && interm_shape[2] == qS &&
                 interm_shape[3] == kIntermediateWidth,
@@ -173,6 +176,11 @@ void SDPABackwardKVDeviceOperation::validate_on_program_cache_miss(
             mask.dtype() == tt::tt_metal::DataType::BFLOAT16,
             "Attention mask must be BFLOAT16 (mask CB pages are sized for BFLOAT16 tiles), got {}",
             mask.dtype());
+        TT_FATAL(
+            mask.layout() == tt::tt_metal::Layout::TILE,
+            "Attention mask must have TILE layout, got {}",
+            mask.layout());
+        TT_FATAL(mask.device() == query.device(), "Attention mask must be on the same device as query");
         auto mask_shape = mask.logical_shape();
         auto [mB, mH, mS1, mS2] = mask_shape.to_array_4D();
 

--- a/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_kv_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_kv_device_operation.cpp
@@ -47,10 +47,17 @@ void SDPABackwardKVDeviceOperation::validate_on_program_cache_miss(
         query_shape,
         key_shape);
 
-    // Validate data formats
+    // Validate data formats. The program factory sizes every input CB for BFLOAT16 tiles,
+    // so any other dtype would overrun CB pages and silently corrupt gradients.
     TT_FATAL(
-        grad_output.dtype() == query.dtype() && query.dtype() == key.dtype() && key.dtype() == value.dtype(),
-        "All input tensors must have the same data type");
+        grad_output.dtype() == tt::tt_metal::DataType::BFLOAT16 &&
+            query.dtype() == tt::tt_metal::DataType::BFLOAT16 &&
+            key.dtype() == tt::tt_metal::DataType::BFLOAT16 && value.dtype() == tt::tt_metal::DataType::BFLOAT16,
+        "All input tensors must be BFLOAT16. Got grad_output={}, query={}, key={}, value={}",
+        grad_output.dtype(),
+        query.dtype(),
+        key.dtype(),
+        value.dtype());
 
     // Validate device placement
     TT_FATAL(
@@ -81,6 +88,61 @@ void SDPABackwardKVDeviceOperation::validate_on_program_cache_miss(
     const auto [kB, kH, kS, kE] = key_shape.to_array_4D();
     const auto [vB, vH, vS, vE] = value_shape.to_array_4D();
 
+    // The softmax scaler is 1/sqrt(head_dim) computed from the padded shape and kernels
+    // iterate the padded sequence, so tile padding on S or head_dim would silently
+    // mis-scale attention instead of erroring out.
+    const auto check_tile_aligned = [](const ttnn::Tensor& tensor, const char* name) {
+        const auto& logical = tensor.logical_shape();
+        const auto& padded = tensor.padded_shape();
+        TT_FATAL(
+            logical[-1] == padded[-1] && logical[-2] == padded[-2],
+            "Tensor '{}' must be tile-aligned in sequence and head_dim (padded shape == logical shape). "
+            "Got logical={}, padded={}",
+            name,
+            logical,
+            padded);
+    };
+    check_tile_aligned(query, "Query");
+    check_tile_aligned(key, "Key");
+    check_tile_aligned(value, "Value");
+
+    // The reader streams `intermediates` (forward-pass logsumexp) as FP32 tiles straight
+    // from DRAM; a wrong tensor here would produce garbage gradients with no error.
+    const auto& intermediates = tensor_args.intermediates;
+    TT_FATAL(intermediates.device() == query.device(), "intermediates must be on the same device as query");
+    TT_FATAL(
+        intermediates.layout() == tt::tt_metal::Layout::TILE,
+        "intermediates must have TILE layout, got {}",
+        intermediates.layout());
+    TT_FATAL(
+        intermediates.dtype() == tt::tt_metal::DataType::FLOAT32,
+        "intermediates must be FLOAT32, got {}",
+        intermediates.dtype());
+    TT_FATAL(
+        intermediates.buffer() != nullptr && intermediates.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM &&
+            intermediates.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
+        "intermediates must be DRAM interleaved");
+    {
+        constexpr uint32_t kIntermediateWidth = 32U;  // one logsumexp tile per query row
+        const auto interm_shape = intermediates.padded_shape();
+        TT_FATAL(
+            interm_shape[0] == qB && interm_shape[1] == qH && interm_shape[2] == qS &&
+                interm_shape[3] == kIntermediateWidth,
+            "intermediates shape must be (B, q_heads, S, 32) = ({}, {}, {}, {}). Got {}",
+            qB,
+            qH,
+            qS,
+            kIntermediateWidth,
+            interm_shape);
+    }
+
+    // Dropout backward is not implemented; accepting a nonzero probability would silently
+    // return gradients of the dropout-free forward.
+    TT_FATAL(
+        operation_attributes.dropout_probability == 0.0F,
+        "Dropout is not supported in SDPA backward. Got dropout_probability={}, expected 0.0.",
+        operation_attributes.dropout_probability);
+
     TT_FATAL(
         qH > 0 && kH > 0 && vH > 0,
         "Number of heads must be greater than zero. Got q_heads={}, kv_heads={}, v_heads={}",
@@ -107,6 +169,10 @@ void SDPABackwardKVDeviceOperation::validate_on_program_cache_miss(
     // Validate mask shape if provided - must be (1, 1, S, S)
     if (tensor_args.attn_mask.has_value()) {
         const auto& mask = tensor_args.attn_mask.value();
+        TT_FATAL(
+            mask.dtype() == tt::tt_metal::DataType::BFLOAT16,
+            "Attention mask must be BFLOAT16 (mask CB pages are sized for BFLOAT16 tiles), got {}",
+            mask.dtype());
         auto mask_shape = mask.logical_shape();
         auto [mB, mH, mS1, mS2] = mask_shape.to_array_4D();
 

--- a/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_kv_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_kv_device_operation.cpp
@@ -91,20 +91,23 @@ void SDPABackwardKVDeviceOperation::validate_on_program_cache_miss(
     // The softmax scaler is 1/sqrt(head_dim) computed from the padded shape and kernels
     // iterate the padded sequence, so tile padding on S or head_dim would silently
     // mis-scale attention instead of erroring out.
-    const auto check_tile_aligned = [](const ttnn::Tensor& tensor, const char* name) {
+    // V's head_dim never feeds the softmax scaler and non-tile-aligned vdim is a
+    // supported configuration (DiffVDim), so V is only checked on the sequence dim.
+    const auto check_tile_aligned = [](const ttnn::Tensor& tensor, const char* name, bool check_last_dim) {
         const auto& logical = tensor.logical_shape();
         const auto& padded = tensor.padded_shape();
         TT_FATAL(
-            logical[-1] == padded[-1] && logical[-2] == padded[-2],
-            "Tensor '{}' must be tile-aligned in sequence and head_dim (padded shape == logical shape). "
+            (!check_last_dim || logical[-1] == padded[-1]) && logical[-2] == padded[-2],
+            "Tensor '{}' must be tile-aligned in sequence{} (padded shape == logical shape). "
             "Got logical={}, padded={}",
             name,
+            check_last_dim ? " and head_dim" : "",
             logical,
             padded);
     };
-    check_tile_aligned(query, "Query");
-    check_tile_aligned(key, "Key");
-    check_tile_aligned(value, "Value");
+    check_tile_aligned(query, "Query", /*check_last_dim=*/true);
+    check_tile_aligned(key, "Key", /*check_last_dim=*/true);
+    check_tile_aligned(value, "Value", /*check_last_dim=*/false);
 
     // The reader streams `intermediates` (forward-pass logsumexp) as FP32 tiles via a
     // TensorAccessor, which handles DRAM and L1 interleaved buffers alike; a wrong tensor

--- a/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_q_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_q_device_operation.cpp
@@ -47,10 +47,19 @@ void SDPABackwardQDeviceOperation::validate_on_program_cache_miss(
         query_shape,
         key_shape);
 
-    // Validate data formats
+    // Validate data formats. The program factory sizes every input CB for BFLOAT16 tiles,
+    // so any other dtype would overrun CB pages and silently corrupt gradients.
     TT_FATAL(
-        grad_output.dtype() == query.dtype() && query.dtype() == key.dtype() && key.dtype() == value.dtype(),
-        "All input tensors must have the same data type");
+        grad_output.dtype() == tt::tt_metal::DataType::BFLOAT16 &&
+            tensor_args.attn_output.dtype() == tt::tt_metal::DataType::BFLOAT16 &&
+            query.dtype() == tt::tt_metal::DataType::BFLOAT16 &&
+            key.dtype() == tt::tt_metal::DataType::BFLOAT16 && value.dtype() == tt::tt_metal::DataType::BFLOAT16,
+        "All input tensors must be BFLOAT16. Got grad_output={}, attn_output={}, query={}, key={}, value={}",
+        grad_output.dtype(),
+        tensor_args.attn_output.dtype(),
+        query.dtype(),
+        key.dtype(),
+        value.dtype());
 
     // Validate device placement
     TT_FATAL(
@@ -61,6 +70,61 @@ void SDPABackwardQDeviceOperation::validate_on_program_cache_miss(
     const auto [qB, qH, qS, qE] = query_shape.to_array_4D();
     const auto [kB, kH, kS, kE] = key_shape.to_array_4D();
     const auto [vB, vH, vS, vE] = value_shape.to_array_4D();
+
+    // The softmax scaler is 1/sqrt(head_dim) computed from the padded shape and kernels
+    // iterate the padded sequence, so tile padding on S or head_dim would silently
+    // mis-scale attention instead of erroring out.
+    const auto check_tile_aligned = [](const ttnn::Tensor& tensor, const char* name) {
+        const auto& logical = tensor.logical_shape();
+        const auto& padded = tensor.padded_shape();
+        TT_FATAL(
+            logical[-1] == padded[-1] && logical[-2] == padded[-2],
+            "Tensor '{}' must be tile-aligned in sequence and head_dim (padded shape == logical shape). "
+            "Got logical={}, padded={}",
+            name,
+            logical,
+            padded);
+    };
+    check_tile_aligned(query, "Query");
+    check_tile_aligned(key, "Key");
+    check_tile_aligned(value, "Value");
+
+    // The reader streams `intermediates` (forward-pass logsumexp) as FP32 tiles straight
+    // from DRAM; a wrong tensor here would produce garbage gradients with no error.
+    const auto& intermediates = tensor_args.intermediates;
+    TT_FATAL(intermediates.device() == query.device(), "intermediates must be on the same device as query");
+    TT_FATAL(
+        intermediates.layout() == tt::tt_metal::Layout::TILE,
+        "intermediates must have TILE layout, got {}",
+        intermediates.layout());
+    TT_FATAL(
+        intermediates.dtype() == tt::tt_metal::DataType::FLOAT32,
+        "intermediates must be FLOAT32, got {}",
+        intermediates.dtype());
+    TT_FATAL(
+        intermediates.buffer() != nullptr && intermediates.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM &&
+            intermediates.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
+        "intermediates must be DRAM interleaved");
+    {
+        constexpr uint32_t kIntermediateWidth = 32U;  // one logsumexp tile per query row
+        const auto interm_shape = intermediates.padded_shape();
+        TT_FATAL(
+            interm_shape[0] == qB && interm_shape[1] == qH && interm_shape[2] == qS &&
+                interm_shape[3] == kIntermediateWidth,
+            "intermediates shape must be (B, q_heads, S, 32) = ({}, {}, {}, {}). Got {}",
+            qB,
+            qH,
+            qS,
+            kIntermediateWidth,
+            interm_shape);
+    }
+
+    // Dropout backward is not implemented; accepting a nonzero probability would silently
+    // return gradients of the dropout-free forward.
+    TT_FATAL(
+        operation_attributes.dropout_probability == 0.0F,
+        "Dropout is not supported in SDPA backward. Got dropout_probability={}, expected 0.0.",
+        operation_attributes.dropout_probability);
 
     TT_FATAL(
         qH > 0 && kH > 0 && vH > 0,
@@ -99,6 +163,10 @@ void SDPABackwardQDeviceOperation::validate_on_program_cache_miss(
     // Validate mask shape if provided - must be (1, 1, S, S)
     if (tensor_args.attn_mask.has_value()) {
         const auto& mask = tensor_args.attn_mask.value();
+        TT_FATAL(
+            mask.dtype() == tt::tt_metal::DataType::BFLOAT16,
+            "Attention mask must be BFLOAT16 (mask CB pages are sized for BFLOAT16 tiles), got {}",
+            mask.dtype());
         auto mask_shape = mask.logical_shape();
         auto [mB, mH, mS1, mS2] = mask_shape.to_array_4D();
 

--- a/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_q_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_q_device_operation.cpp
@@ -63,7 +63,8 @@ void SDPABackwardQDeviceOperation::validate_on_program_cache_miss(
 
     // Validate device placement
     TT_FATAL(
-        grad_output.device() == query.device() && query.device() == key.device() && key.device() == value.device(),
+        grad_output.device() == query.device() && tensor_args.attn_output.device() == query.device() &&
+            query.device() == key.device() && key.device() == value.device(),
         "All input tensors must be on the same device");
 
     // Extract and validate heads from tensor shapes
@@ -89,8 +90,11 @@ void SDPABackwardQDeviceOperation::validate_on_program_cache_miss(
     check_tile_aligned(key, "Key");
     check_tile_aligned(value, "Value");
 
-    // The reader streams `intermediates` (forward-pass logsumexp) as FP32 tiles straight
-    // from DRAM; a wrong tensor here would produce garbage gradients with no error.
+    // The reader streams `intermediates` (forward-pass logsumexp) as FP32 tiles via a
+    // TensorAccessor, which handles DRAM and L1 interleaved buffers alike; a wrong tensor
+    // here would produce garbage gradients with no error. sdpa_fw allocates it with query's
+    // memory config, so an L1-interleaved query legitimately yields L1-interleaved
+    // intermediates — only sharded layouts are unsupported.
     const auto& intermediates = tensor_args.intermediates;
     TT_FATAL(intermediates.device() == query.device(), "intermediates must be on the same device as query");
     TT_FATAL(
@@ -102,12 +106,12 @@ void SDPABackwardQDeviceOperation::validate_on_program_cache_miss(
         "intermediates must be FLOAT32, got {}",
         intermediates.dtype());
     TT_FATAL(
-        intermediates.buffer() != nullptr && intermediates.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM &&
+        intermediates.buffer() != nullptr &&
             intermediates.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED,
-        "intermediates must be DRAM interleaved");
+        "intermediates must be interleaved");
     {
         constexpr uint32_t kIntermediateWidth = 32U;  // one logsumexp tile per query row
-        const auto interm_shape = intermediates.padded_shape();
+        const auto interm_shape = intermediates.logical_shape();
         TT_FATAL(
             interm_shape[0] == qB && interm_shape[1] == qH && interm_shape[2] == qS &&
                 interm_shape[3] == kIntermediateWidth,
@@ -156,8 +160,10 @@ void SDPABackwardQDeviceOperation::validate_on_program_cache_miss(
 
     // Validate tensors have tile layout
     TT_FATAL(
-        grad_output.layout() == tt::tt_metal::Layout::TILE && query.layout() == tt::tt_metal::Layout::TILE &&
-            key.layout() == tt::tt_metal::Layout::TILE && value.layout() == tt::tt_metal::Layout::TILE,
+        grad_output.layout() == tt::tt_metal::Layout::TILE &&
+            tensor_args.attn_output.layout() == tt::tt_metal::Layout::TILE &&
+            query.layout() == tt::tt_metal::Layout::TILE && key.layout() == tt::tt_metal::Layout::TILE &&
+            value.layout() == tt::tt_metal::Layout::TILE,
         "All input tensors must have TILE layout");
 
     // Validate mask shape if provided - must be (1, 1, S, S)
@@ -167,6 +173,11 @@ void SDPABackwardQDeviceOperation::validate_on_program_cache_miss(
             mask.dtype() == tt::tt_metal::DataType::BFLOAT16,
             "Attention mask must be BFLOAT16 (mask CB pages are sized for BFLOAT16 tiles), got {}",
             mask.dtype());
+        TT_FATAL(
+            mask.layout() == tt::tt_metal::Layout::TILE,
+            "Attention mask must have TILE layout, got {}",
+            mask.layout());
+        TT_FATAL(mask.device() == query.device(), "Attention mask must be on the same device as query");
         auto mask_shape = mask.logical_shape();
         auto [mB, mH, mS1, mS2] = mask_shape.to_array_4D();
 

--- a/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_q_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_q_device_operation.cpp
@@ -75,20 +75,23 @@ void SDPABackwardQDeviceOperation::validate_on_program_cache_miss(
     // The softmax scaler is 1/sqrt(head_dim) computed from the padded shape and kernels
     // iterate the padded sequence, so tile padding on S or head_dim would silently
     // mis-scale attention instead of erroring out.
-    const auto check_tile_aligned = [](const ttnn::Tensor& tensor, const char* name) {
+    // V's head_dim never feeds the softmax scaler and non-tile-aligned vdim is a
+    // supported configuration (DiffVDim), so V is only checked on the sequence dim.
+    const auto check_tile_aligned = [](const ttnn::Tensor& tensor, const char* name, bool check_last_dim) {
         const auto& logical = tensor.logical_shape();
         const auto& padded = tensor.padded_shape();
         TT_FATAL(
-            logical[-1] == padded[-1] && logical[-2] == padded[-2],
-            "Tensor '{}' must be tile-aligned in sequence and head_dim (padded shape == logical shape). "
+            (!check_last_dim || logical[-1] == padded[-1]) && logical[-2] == padded[-2],
+            "Tensor '{}' must be tile-aligned in sequence{} (padded shape == logical shape). "
             "Got logical={}, padded={}",
             name,
+            check_last_dim ? " and head_dim" : "",
             logical,
             padded);
     };
-    check_tile_aligned(query, "Query");
-    check_tile_aligned(key, "Key");
-    check_tile_aligned(value, "Value");
+    check_tile_aligned(query, "Query", /*check_last_dim=*/true);
+    check_tile_aligned(key, "Key", /*check_last_dim=*/true);
+    check_tile_aligned(value, "Value", /*check_last_dim=*/false);
 
     // The reader streams `intermediates` (forward-pass logsumexp) as FP32 tiles via a
     // TensorAccessor, which handles DRAM and L1 interleaved buffers alike; a wrong tensor

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/compute/sdpa_compute_utils.hpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/compute/sdpa_compute_utils.hpp
@@ -156,7 +156,7 @@ void update_cur_row_max_value(
 //
 // DST budget: Sk_chunk_t registers are held live across sub_tiles_bcast_cols + exp_tile +
 // (two) pack passes. With fp32_dest_acc_en=true the DST has 4 tiles, so Sk_chunk_t <= 4.
-template <uint32_t scaler_fp32, uint32_t Sk_chunk_t = 1U>
+template <uint32_t scaler_fp32, uint32_t scaler_bf16, uint32_t Sk_chunk_t = 1U>
 void apply_exp_inplace_and_find_exp_sum(uint32_t cb_attention_weights, uint32_t cb_cur_max, uint32_t cb_cur_exp_sum) {
     cb_wait_front(cb_attention_weights, Sk_chunk_t);
     cb_wait_front(cb_cur_max, onetile);
@@ -170,7 +170,7 @@ void apply_exp_inplace_and_find_exp_sum(uint32_t cb_attention_weights, uint32_t 
     for (uint32_t n = 0; n < Sk_chunk_t; ++n) {
         sub_tiles_bcast_cols(
             cb_attention_weights, cb_cur_max, /* in0 tile_idx */ n, /* in1 tile_idx */ 0, /* dst_reg_idx */ n);
-        sdpa_exp_tile_scaled<scaler_fp32>(n);
+        sdpa_exp_tile_scaled<scaler_fp32, scaler_bf16>(n);
     }
     tile_regs_commit();
 
@@ -265,7 +265,7 @@ void matmul_qk_by_v(
     cb_push_back(cb_cur_mm_out, Wt);
 }
 
-template <uint32_t scaler_fp32>
+template <uint32_t scaler_fp32, uint32_t scaler_bf16>
 void update_exp_max_diff(uint32_t cb_prev_max_value, uint32_t cb_cur_max_value, uint32_t cb_exp_max_diff) {
     cb_wait_front(cb_prev_max_value, onetile);
     cb_wait_front(cb_cur_max_value, onetile);
@@ -286,7 +286,7 @@ void update_exp_max_diff(uint32_t cb_prev_max_value, uint32_t cb_cur_max_value, 
     // First-column scaled exp: exp(scale * (prev_max - cur_max)).
     // Both max values are column vectors, so the result is a column vector —
     // only column 0 has data. Process 4× fewer SFPU iterations than full-tile exp.
-    sdpa_exp_tile_first_column_scaled<scaler_fp32>(exp_max_diff_dst_idx);
+    sdpa_exp_tile_first_column_scaled<scaler_fp32, scaler_bf16>(exp_max_diff_dst_idx);
     tile_regs_commit();
 
     tile_regs_wait();

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/compute/sdpa_fw_compute_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/compute/sdpa_fw_compute_kernel.cpp
@@ -42,6 +42,8 @@ constexpr uint32_t custom_inf_bits = get_compile_time_arg_val(7);  // used to tr
 [[maybe_unused]] constexpr uint32_t Sk_chunk_t =
     get_compile_time_arg_val(8);  // multi-tile K/V chunking factor (1 = single-tile inner loop)
 constexpr uint32_t pv_block_size = get_compile_time_arg_val(9);  // PV matmul_block ct_dim (cap = dst_size)
+constexpr uint32_t scaler_bf16_bits =
+    get_compile_time_arg_val(10);  // host-side RNE BF16 of scaler_bits, for the WH fused scale+exp
 constexpr uint32_t pairs_per_seq = Ht / 2;
 
 constexpr uint32_t cb_query = tt::CBIndex::c_0;
@@ -196,10 +198,6 @@ FORCE_INLINE void process_single_row(uint32_t global_row_idx) {
         // The per-n mask is unique (no reusable transformed tiles) and apply_mask_on_reg operates
         // on a single DST tile + scratch, which fits comfortably here. K is laid out col-major
         // in cb_key (uniform reader layout), so the K tile index is `feat*Sk_chunk_t + n`.
-        //
-        // Without USE_ATTN_MASK (AttentionMaskType::None) the host never creates cb_attn_mask
-        // and the reader never fills it, so every mask touch must be compiled out; scaling
-        // still happens later inside the scaled exp of the softmax.
         constexpr uint32_t matmul_accum_reg = 0U;
         for (uint32_t n = 0; n < Sk_chunk_t; ++n) {
             matmul_init(cb_query, cb_key, /* transpose */ 1);
@@ -243,7 +241,7 @@ FORCE_INLINE void process_single_row(uint32_t global_row_idx) {
             alias_cb_prev_max,
             /* do_eltwise_max */ k_chunk > 0);
 
-        apply_exp_inplace_and_find_exp_sum<scaler_bits, Sk_chunk_t>(
+        apply_exp_inplace_and_find_exp_sum<scaler_bits, scaler_bf16_bits, Sk_chunk_t>(
             cb_attention_weights, alias_cb_cur_max, alias_cb_cur_sum_exp);
 
         matmul_qk_by_v<Sk_chunk_t>(vWt, pv_block_size, cb_attention_weights, cb_value, alias_cb_cur_mm_out);
@@ -253,7 +251,7 @@ FORCE_INLINE void process_single_row(uint32_t global_row_idx) {
 
         // Online correction against the previous chunk's running stats.
         if (k_chunk > 0) {
-            update_exp_max_diff<scaler_bits>(alias_cb_prev_max, alias_cb_cur_max, cb_exp_max_diff);
+            update_exp_max_diff<scaler_bits, scaler_bf16_bits>(alias_cb_prev_max, alias_cb_cur_max, cb_exp_max_diff);
             cb_pop_front(alias_cb_prev_max, onetile);
 
             update_cur_exp_sum_inplace(alias_cb_prev_sum_exp, alias_cb_cur_sum_exp, cb_exp_max_diff);

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/compute/sdpa_fw_compute_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/device/kernels/compute/sdpa_fw_compute_kernel.cpp
@@ -192,10 +192,14 @@ FORCE_INLINE void process_single_row(uint32_t global_row_idx) {
             cb_push_back(cb_attention_weights, Sk_chunk_t);
         }
 #else
-        // USE_ATTN_MASK (provided mask) — uses a per-`n` matmul_tiles + apply_mask_on_reg path.
+        // USE_ATTN_MASK (provided mask) and no-mask — a per-`n` matmul_tiles path.
         // The per-n mask is unique (no reusable transformed tiles) and apply_mask_on_reg operates
         // on a single DST tile + scratch, which fits comfortably here. K is laid out col-major
         // in cb_key (uniform reader layout), so the K tile index is `feat*Sk_chunk_t + n`.
+        //
+        // Without USE_ATTN_MASK (AttentionMaskType::None) the host never creates cb_attn_mask
+        // and the reader never fills it, so every mask touch must be compiled out; scaling
+        // still happens later inside the scaled exp of the softmax.
         constexpr uint32_t matmul_accum_reg = 0U;
         for (uint32_t n = 0; n < Sk_chunk_t; ++n) {
             matmul_init(cb_query, cb_key, /* transpose */ 1);
@@ -209,7 +213,9 @@ FORCE_INLINE void process_single_row(uint32_t global_row_idx) {
                     tile_idx * Sk_chunk_t + n,
                     /* dst */ matmul_accum_reg);
             }
+#ifdef USE_ATTN_MASK
             apply_mask_on_reg(matmul_accum_reg, cb_attn_mask, minus_one_bits, custom_inf_bits, /* mask_tile_idx */ n);
+#endif
             tile_regs_commit();
             tile_regs_wait();
             cb_reserve_back(cb_attention_weights, onetile);
@@ -218,9 +224,11 @@ FORCE_INLINE void process_single_row(uint32_t global_row_idx) {
             cb_push_back(cb_attention_weights, onetile);
         }
 
+#ifdef USE_ATTN_MASK
         // Every mask tile is unique per (row, k tile). Pop the whole chunk's worth so the
         // reader can stage the next chunk.
         cb_pop_front(cb_attn_mask, Sk_chunk_t);
+#endif
 #endif
         // CAUSAL_MASK/BALANCED_PARALLELISM: the two mask tiles stay permanently fronted; no pop.
 

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_device_operation.cpp
@@ -61,6 +61,24 @@ void SDPAForwardDeviceOperation::validate_on_program_cache_miss(
     check_tensor(key, "Key", tt::tt_metal::Layout::TILE, tt::tt_metal::DataType::BFLOAT16);
     check_tensor(value, "Value", tt::tt_metal::Layout::TILE, tt::tt_metal::DataType::BFLOAT16);
 
+    // The softmax scaler is 1/sqrt(head_dim) computed from the padded shape and kernels
+    // iterate the padded sequence, so tile padding on S or head_dim would silently
+    // mis-scale attention instead of erroring out.
+    const auto check_tile_aligned = [](const ttnn::Tensor& tensor, const char* name) {
+        const auto& logical = tensor.logical_shape();
+        const auto& padded = tensor.padded_shape();
+        TT_FATAL(
+            logical[-1] == padded[-1] && logical[-2] == padded[-2],
+            "Tensor '{}' must be tile-aligned in sequence and head_dim (padded shape == logical shape). "
+            "Got logical={}, padded={}",
+            name,
+            logical,
+            padded);
+    };
+    check_tile_aligned(query, "Query");
+    check_tile_aligned(key, "Key");
+    check_tile_aligned(value, "Value");
+
     auto query_shape = query.logical_shape();
     auto key_shape = key.logical_shape();
     auto value_shape = value.logical_shape();

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_device_operation.cpp
@@ -62,22 +62,25 @@ void SDPAForwardDeviceOperation::validate_on_program_cache_miss(
     check_tensor(value, "Value", tt::tt_metal::Layout::TILE, tt::tt_metal::DataType::BFLOAT16);
 
     // The softmax scaler is 1/sqrt(head_dim) computed from the padded shape and kernels
-    // iterate the padded sequence, so tile padding on S or head_dim would silently
-    // mis-scale attention instead of erroring out.
-    const auto check_tile_aligned = [](const ttnn::Tensor& tensor, const char* name) {
+    // iterate the padded sequence, so tile padding on S or Q/K head_dim would silently
+    // mis-scale attention instead of erroring out. V's head_dim never feeds the scaler
+    // and non-tile-aligned vdim is a supported configuration (DiffVDim), so V is only
+    // checked on the sequence dim.
+    const auto check_tile_aligned = [](const ttnn::Tensor& tensor, const char* name, bool check_last_dim) {
         const auto& logical = tensor.logical_shape();
         const auto& padded = tensor.padded_shape();
         TT_FATAL(
-            logical[-1] == padded[-1] && logical[-2] == padded[-2],
-            "Tensor '{}' must be tile-aligned in sequence and head_dim (padded shape == logical shape). "
+            (!check_last_dim || logical[-1] == padded[-1]) && logical[-2] == padded[-2],
+            "Tensor '{}' must be tile-aligned in sequence{} (padded shape == logical shape). "
             "Got logical={}, padded={}",
             name,
+            check_last_dim ? " and head_dim" : "",
             logical,
             padded);
     };
-    check_tile_aligned(query, "Query");
-    check_tile_aligned(key, "Key");
-    check_tile_aligned(value, "Value");
+    check_tile_aligned(query, "Query", /*check_last_dim=*/true);
+    check_tile_aligned(key, "Key", /*check_last_dim=*/true);
+    check_tile_aligned(value, "Value", /*check_last_dim=*/false);
 
     auto query_shape = query.logical_shape();
     auto key_shape = key.logical_shape();

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_program_factory.cpp
@@ -6,6 +6,7 @@
 
 #include <bit>
 #include <cmath>
+#include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
 #include "metal/common/program_utils.hpp"
@@ -290,8 +291,14 @@ SDPAForwardProgramFactory::cached_program_t SDPAForwardProgramFactory::create(
     const uint32_t kWt = kEmbd / tt::constants::TILE_WIDTH;
     const uint32_t vWt = vEmbd / tt::constants::TILE_WIDTH;
 
-    const uint32_t scaler =
-        std::bit_cast<uint32_t>(1.0F / std::sqrt(static_cast<float>(qEmbd)));  // calculate scale factor
+    const float scale = 1.0F / std::sqrt(static_cast<float>(qEmbd));
+    const uint32_t scaler = std::bit_cast<uint32_t>(scale);
+    // BF16 copy of the scale for the WH fused scale+exp path (SFPU multiplies P by a BF16
+    // immediate there, while the LSE and the backward pass use the full FP32 scale). RNE
+    // instead of `>> 16` truncation halves the worst-case rounding gap so it stays noise
+    // rather than a systematic fw/bw mismatch. The conversion runs on host because the
+    // kernel TU cannot see the host bfloat16 implementation.
+    const uint32_t scaler_bf16 = fp32_to_bf16_bits_round_to_nearest_even(scale);
     const uint32_t minus_one = std::bit_cast<uint32_t>(-1.0F);  // used to transform mask from 1/0 to 0/-1
     const uint32_t custom_inf = std::bit_cast<uint32_t>(1e9F);  // used to transform mask from 0/-1 to 0/-1e9F
 
@@ -595,6 +602,7 @@ SDPAForwardProgramFactory::cached_program_t SDPAForwardProgramFactory::create(
             custom_inf,          // used to transform mask from 0/-1 to 0/-1e9F
             Sk_chunk_t,          // multi-tile K/V chunking factor
             pv_block_size,       // PV matmul_block ct_dim (cap = dst_size, no scratch)
+            scaler_bf16,         // BF16 (RNE) scale for the WH fused scale+exp path
         };
 
         kernels.compute_group_1 = tt::tt_metal::CreateKernel(
@@ -623,6 +631,7 @@ SDPAForwardProgramFactory::cached_program_t SDPAForwardProgramFactory::create(
             custom_inf,                 // used to transform mask from 0/-1 to 0/-1e9F
             Sk_chunk_t,                 // multi-tile K/V chunking factor
             pv_block_size,              // PV matmul_block ct_dim (cap = dst_size, no scratch)
+            scaler_bf16,                // BF16 (RNE) scale for the WH fused scale+exp path
         };
 
         kernels.compute_group_1 = tt::tt_metal::CreateKernel(
@@ -650,6 +659,7 @@ SDPAForwardProgramFactory::cached_program_t SDPAForwardProgramFactory::create(
                 custom_inf,                 // used to transform mask from 0/-1 to 0/-1e9F
                 Sk_chunk_t,                 // multi-tile K/V chunking factor
                 pv_block_size,              // PV matmul_block ct_dim (cap = dst_size, no scratch)
+                scaler_bf16,                // BF16 (RNE) scale for the WH fused scale+exp path
             };
 
             kernels.compute_group_2 = tt::tt_metal::CreateKernel(

--- a/tt-train/tests/ops/sdpa_bw_op_test.cpp
+++ b/tt-train/tests/ops/sdpa_bw_op_test.cpp
@@ -994,6 +994,136 @@ TEST_F(SDPABackwardTest, ShapeMismatch_GradOutputLastDim) {
         << "sdpa_bw should reject grad_output whose last dim doesn't match value's last dim";
 }
 
+// ========== Validation-Contract Negative Tests ==========
+// Each test below takes a minimal valid input set and corrupts exactly one property,
+// checking that sdpa_bw rejects it instead of silently producing garbage gradients.
+
+namespace {
+
+struct SdpaBwInputs {
+    ttnn::Tensor grad_output;
+    ttnn::Tensor attn_output;
+    ttnn::Tensor query;
+    ttnn::Tensor key;
+    ttnn::Tensor value;
+    ttnn::Tensor intermediates;
+};
+
+SdpaBwInputs make_minimal_sdpa_bw_inputs() {
+    using namespace ttml;
+    constexpr std::size_t B = 1U, H = 1U, S = 32U, D = 32U;
+    constexpr std::size_t kIntermediateWidth = 32U;  // one logsumexp tile per query row
+    auto* device = &autograd::ctx().get_device();
+    auto& rng = autograd::ctx().get_generator();
+    const uint32_t seed = rng();
+
+    const std::array<std::size_t, 4> shape{B, H, S, D};
+    const std::array<std::size_t, 4> interm_shape{B, H, S, kIntermediateWidth};
+
+    const auto make_bf16 = [&](const std::array<std::size_t, 4>& s) {
+        return core::from_xtensor(ttml::test_utils::make_uniform_xarray<float>(s, -1.0F, 1.0F, seed), device);
+    };
+    return SdpaBwInputs{
+        .grad_output = make_bf16(shape),
+        .attn_output = make_bf16(shape),
+        .query = make_bf16(shape),
+        .key = make_bf16(shape),
+        .value = make_bf16(shape),
+        .intermediates = core::from_xtensor<float, ttnn::DataType::FLOAT32>(
+            ttml::test_utils::make_uniform_xarray<float>(interm_shape, -1.0F, 1.0F, seed), device)};
+}
+
+}  // namespace
+
+TEST_F(SDPABackwardTest, Validation_RejectsFP32Inputs) {
+    using namespace ttml;
+    const auto in = make_minimal_sdpa_bw_inputs();
+    auto* device = &autograd::ctx().get_device();
+
+    const std::array<std::size_t, 4> shape{1U, 1U, 32U, 32U};
+    const auto fp32_tensor = core::from_xtensor<float, ttnn::DataType::FLOAT32>(
+        ttml::test_utils::make_uniform_xarray<float>(shape, -1.0F, 1.0F, 42U), device);
+
+    EXPECT_ANY_THROW(metal::sdpa_bw(
+        fp32_tensor, in.attn_output, in.query, in.key, in.value, in.intermediates, metal::AttentionMaskType::None))
+        << "sdpa_bw should reject FP32 grad_output (input CBs are sized for BFLOAT16 tiles)";
+
+    EXPECT_ANY_THROW(metal::sdpa_bw(
+        in.grad_output, fp32_tensor, in.query, in.key, in.value, in.intermediates, metal::AttentionMaskType::None))
+        << "sdpa_bw should reject FP32 attn_output (input CBs are sized for BFLOAT16 tiles)";
+}
+
+TEST_F(SDPABackwardTest, Validation_RejectsMalformedIntermediates) {
+    using namespace ttml;
+    const auto in = make_minimal_sdpa_bw_inputs();
+    auto* device = &autograd::ctx().get_device();
+
+    // Wrong shape: last dim must be the 32-wide logsumexp tile
+    const std::array<std::size_t, 4> wide_shape{1U, 1U, 32U, 64U};
+    const auto wrong_shape_intermediates = core::from_xtensor<float, ttnn::DataType::FLOAT32>(
+        ttml::test_utils::make_uniform_xarray<float>(wide_shape, -1.0F, 1.0F, 42U), device);
+    EXPECT_ANY_THROW(metal::sdpa_bw(
+        in.grad_output,
+        in.attn_output,
+        in.query,
+        in.key,
+        in.value,
+        wrong_shape_intermediates,
+        metal::AttentionMaskType::None))
+        << "sdpa_bw should reject intermediates whose shape isn't (B, q_heads, S, 32)";
+
+    // Wrong dtype: the reader streams intermediates as FP32 tiles
+    const std::array<std::size_t, 4> interm_shape{1U, 1U, 32U, 32U};
+    const auto bf16_intermediates =
+        core::from_xtensor(ttml::test_utils::make_uniform_xarray<float>(interm_shape, -1.0F, 1.0F, 42U), device);
+    EXPECT_ANY_THROW(metal::sdpa_bw(
+        in.grad_output,
+        in.attn_output,
+        in.query,
+        in.key,
+        in.value,
+        bf16_intermediates,
+        metal::AttentionMaskType::None))
+        << "sdpa_bw should reject non-FP32 intermediates";
+}
+
+TEST_F(SDPABackwardTest, Validation_RejectsNonzeroDropout) {
+    using namespace ttml;
+    const auto in = make_minimal_sdpa_bw_inputs();
+
+    EXPECT_ANY_THROW(metal::sdpa_bw(
+        in.grad_output,
+        in.attn_output,
+        in.query,
+        in.key,
+        in.value,
+        in.intermediates,
+        metal::AttentionMaskType::None,
+        std::nullopt,
+        /*dropout_probability=*/0.5F))
+        << "sdpa_bw should reject nonzero dropout: backward has no dropout support and would "
+           "silently return gradients of the dropout-free forward";
+}
+
+TEST_F(SDPABackwardTest, Validation_RejectsPaddedQK) {
+    using namespace ttml;
+    const auto in = make_minimal_sdpa_bw_inputs();
+    auto* device = &autograd::ctx().get_device();
+
+    // head_dim=48 is not tile-aligned; TILE layout pads it to 64, and the softmax scaler
+    // would be computed from the padded dim, silently mis-scaling attention.
+    const std::array<std::size_t, 4> unaligned_shape{1U, 1U, 32U, 48U};
+    const auto padded_query =
+        core::from_xtensor(ttml::test_utils::make_uniform_xarray<float>(unaligned_shape, -1.0F, 1.0F, 42U), device);
+    const auto padded_key =
+        core::from_xtensor(ttml::test_utils::make_uniform_xarray<float>(unaligned_shape, -1.0F, 1.0F, 43U), device);
+
+    EXPECT_ANY_THROW(metal::sdpa_bw(
+        in.grad_output, in.attn_output, padded_query, padded_key, in.value, in.intermediates,
+        metal::AttentionMaskType::None))
+        << "sdpa_bw should reject Q/K with non-tile-aligned head_dim";
+}
+
 // ========== Ring Attention Simulation on Single Device ==========
 // Simulates ring attention forward + backward on a single device by splitting
 // K/V into chunks along the sequence dimension and combining outputs with the

--- a/tt-train/tests/ops/sdpa_fw_op_test.cpp
+++ b/tt-train/tests/ops/sdpa_fw_op_test.cpp
@@ -506,8 +506,16 @@ void run_sdpa_test(const SDPATestConfig& config) {
         config.batch_size, config.num_key_heads, config.sequence_length, head_dim_v};
     xt::xarray<float> value_tensor = ttml::test_utils::make_uniform_xarray<float>(value_shape, -1.0F, 1.0F, seed);
 
-    // Create attention mask in kernel-expected format (1, 1, S, S) - broadcasted across batches/heads
-    xt::xarray<float> attn_mask_tensor = generate_mask(query_tensor);
+    // Create attention mask in kernel-expected format (1, 1, S, S) - broadcasted across batches/heads.
+    // For None the kernel computes unmasked attention, so the reference mask must keep
+    // every position (all-ones) instead of the causal pattern.
+    xt::xarray<float> attn_mask_tensor;
+    if (config.mask_type == ttml::metal::AttentionMaskType::None) {
+        const auto seq = static_cast<std::size_t>(config.sequence_length);
+        attn_mask_tensor = xt::ones<float>({1UL, 1UL, seq, seq});
+    } else {
+        attn_mask_tensor = generate_mask(query_tensor);
+    }
 
     // Convert to device tensors
     auto query = core::from_xtensor(query_tensor, &autograd::ctx().get_device());
@@ -986,6 +994,36 @@ TEST_F(SDPAForwardTest, SDPAForwardTest_CausalMask_TwoTileRows) {
         .num_key_heads = 1U,
         .mask_type = ttml::metal::AttentionMaskType::Causal,
         .test_name = "CausalMask_TwoTileRows"};
+    run_sdpa_test(config);
+}
+
+TEST_F(SDPAForwardTest, SDPAForwardTest_NoMask_Small) {
+    // mask_type=None: compute skips mask application entirely, so the reader must not
+    // push mask tiles into a CB nothing consumes. Always-on guard for the no-mask path.
+    SDPATestConfig config{
+        .batch_size = 1U,
+        .sequence_length = 128U,
+        .query_dim = 128U,
+        .key_value_dim = 128U,
+        .num_query_heads = 2U,
+        .num_key_heads = 2U,
+        .mask_type = ttml::metal::AttentionMaskType::None,
+        .test_name = "NoMask_Small_2H"};
+    run_sdpa_test(config);
+}
+
+TEST_F(SDPAForwardTest, SDPAForwardTest_NoMask_TwoTileRows) {
+    // 64 seq len -> Ht=2 -> Sk_chunk_t=2 on the no-mask compute path: chunked inner loop
+    // with no mask CB traffic.
+    SDPATestConfig config{
+        .batch_size = 1U,
+        .sequence_length = 64U,
+        .query_dim = 64U,
+        .key_value_dim = 64U,
+        .num_query_heads = 1U,
+        .num_key_heads = 1U,
+        .mask_type = ttml::metal::AttentionMaskType::None,
+        .test_name = "NoMask_TwoTileRows"};
     run_sdpa_test(config);
 }
 

--- a/tt_metal/api/tt-metalium/bfloat16.hpp
+++ b/tt_metal/api/tt-metalium/bfloat16.hpp
@@ -59,6 +59,9 @@ private:
     uint16_t from_float(float val);
 };
 
+// FP32 → BF16 bits with round-to-nearest-even; NaN maps to the canonical quiet NaN (0x7FC0).
+uint16_t fp32_to_bf16_bits_round_to_nearest_even(float val);
+
 std::ostream& operator<<(std::ostream& os, const bfloat16& bfp16);
 
 bool operator==(const std::vector<bfloat16>& lhs, const std::vector<bfloat16>& rhs);

--- a/tt_metal/impl/data_format/bfloat16.cpp
+++ b/tt_metal/impl/data_format/bfloat16.cpp
@@ -15,7 +15,6 @@
 
 #include "impl/data_format/bfloat16_utils.hpp"
 
-namespace {
 uint16_t fp32_to_bf16_bits_round_to_nearest_even(float val) {
     if (std::isnan(val)) {
         // NaN is represented when all exponent bits are 1 and mantissa is non-zero.
@@ -29,8 +28,6 @@ uint16_t fp32_to_bf16_bits_round_to_nearest_even(float val) {
     uint32_t rounding_bias = ((U32 >> 16) & 1) + UINT32_C(0x7FFF);
     return static_cast<uint16_t>((U32 + rounding_bias) >> 16);
 }
-
-}  // namespace
 
 bfloat16 bfloat16::truncate(float float_num) {
     uint32_t U32 = std::bit_cast<uint32_t>(float_num);


### PR DESCRIPTION
Fixes #53207

## What

- **mask=None hang**: `sdpa_fw_compute_kernel.cpp` unconditionally waited on / popped the mask CB (c_3), which the host never creates for `AttentionMaskType::None` — guaranteed hang. Mask application now compiled out on the None path (scaling was never in `apply_mask_on_reg`, so no substitute needed). Guarded by always-on regression tests (`SDPAForwardTest_NoMask_Small`, `SDPAForwardTest_NoMask_TwoTileRows`) — previously the only None-path caller was a permanently skipped NIGHTLY test.
- **WH scale truncation**: the WH exp path built its bf16 scale by truncation (`>>16`); now round-to-nearest-even. Reduces the systematic fw/bw P mismatch for head dims where 1/√d isn't bf16-exact (d=128). BH path untouched.
- **bw validation** (both sdpa_bw ops): inputs pinned to BFLOAT16 (CB pages are bf16-sized; FP32 inputs previously produced silent garbage — including `attn_output`, which was never dtype-checked at all); `intermediates` validated (FP32/TILE/INTERLEAVED/(B,H,S,32)) — INTERLEAVED means DRAM **or** L1: an earlier revision said DRAM-only, but `sdpa_fw` allocates intermediates with the query's memory config, so an L1-interleaved query legitimately yields L1-interleaved intermediates and the reader's TensorAccessor handles both; only sharded layouts are rejected; `TT_FATAL(dropout == 0)` (fw already had it; bw silently ignored dropout). Covered by four negative validation tests (`Validation_RejectsFP32Inputs`, `Validation_RejectsMalformedIntermediates`, `Validation_RejectsNonzeroDropout`, `Validation_RejectsPaddedQK`).
- **Padded-dim scale**: fw and bw now reject padded ≠ logical on S and head_dim — the softmax scaler was computed from the padded dim (head_dim 40 silently used 1/8 instead of 1/√40). The alignment check is restricted to **Q/K head_dim only**: V with a non-tile-aligned vdim is a supported DiffVDim config (V's vdim never feeds the scaler) and the first revision wrongly rejected it — caught on device, fixed in 504173ce67e.

Remaining work under #53207 (design decision, not taken here): fully-masked rows produce uniform attention in fw and inf/NaN in bw.

## Validation checklist

- [x] sdpa fw/bw suites on BH — full single-chip round green (605 tests passed) after 504173ce67e, DiffVDim configs included
- [ ] sdpa fw/bw suites on WH — pending
- [x] `metal::sdpa_fw(..., None, ...)` on device — previously a guaranteed hang; no hang on BH (single-chip suite green), plus the two always-on no-mask regression tests pass. WH run pending for full coverage
- [ ] Check whether RTN scaling tightens the D=128 bw tolerances (needs the WH run)
- [x] Negative tests: FP32 bw inputs, wrong intermediates, dropout≠0, non-tile-aligned Q/K dims TT_FATAL as expected — all four device-green in the 605-test round
- [ ] Do NOT re-enable the 10 DISABLED_ bw suites until #46121 is root-caused

## Device verification (BH galaxy, bh_sc5 quad)

All runs on Blackhole galaxies; BH was the test vehicle for this PR.

- The new tile-alignment validation initially rejected V with non-tile-aligned vdim — a supported DiffVDim config. Caught on device; fixed by restricting the check to Q/K (504173ce67e). Rerun confirmed: `SDPAForwardTest`/`SDPABackwardTest` green in the full 605-test single-chip round, including the no-mask regression tests and the four negative validation tests.
- mask=None path: single-chip BH suite green — no hang.
- Coverage caveat: the None-path hang fix and the WH RTN scale change still need a WH run for full coverage (both code paths were exercised on BH only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ayerofieiev/kernel-fix/sdpa-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ayerofieiev/kernel-fix/sdpa-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ayerofieiev/kernel-fix/sdpa-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ayerofieiev/kernel-fix/sdpa-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ayerofieiev/kernel-fix/sdpa-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ayerofieiev/kernel-fix/sdpa-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ayerofieiev/kernel-fix/sdpa-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ayerofieiev/kernel-fix/sdpa-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ayerofieiev/kernel-fix/sdpa-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ayerofieiev/kernel-fix/sdpa-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ayerofieiev/kernel-fix/sdpa-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ayerofieiev/kernel-fix/sdpa-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ayerofieiev/kernel-fix/sdpa-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ayerofieiev/kernel-fix/sdpa-2026-08-14)
