### PR TITLE
[tt-train] Fix mla_qkv_assemble_bw DST budget guard (4 half-sync fp32 slots, not 8)

### DIFF
--- a/tt-train/sources/ttml/metal/ops/mla_q_rope/device/mla_q_rope_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_q_rope/device/mla_q_rope_device_operation.cpp
@@ -126,8 +126,17 @@ MlaQRopeDeviceOperation::tensor_return_value_t MlaQRopeDeviceOperation::create_o
 
 ttsl::hash::hash_t MlaQRopeDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    // Memory configs are hashed because TensorAccessorArgs bake buffer placement into
+    // compile-time args, so a placement change must not reuse a cached program.
     return tt::tt_metal::operation::hash_operation<MlaQRopeDeviceOperation>(
-        args, tensor_args.q_in.dtype(), tensor_args.q_in.logical_shape(), tensor_args.cos_cache.logical_shape());
+        args,
+        tensor_args.q_in.dtype(),
+        tensor_args.q_in.logical_shape(),
+        tensor_args.cos_cache.logical_shape(),
+        tensor_args.q_in.memory_config(),
+        tensor_args.cos_cache.memory_config(),
+        tensor_args.sin_cache.memory_config(),
+        tensor_args.trans_mat.memory_config());
 }
 
 MlaQRopeDeviceOperation::program_factory_t MlaQRopeDeviceOperation::select_program_factory(

--- a/tt-train/sources/ttml/metal/ops/mla_q_rope/device/mla_q_rope_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_q_rope/device/mla_q_rope_program_factory.cpp
@@ -13,17 +13,17 @@
 #include "metal/common/program_utils.hpp"
 #include "mla_q_rope_device_operation_types.hpp"
 
-// L1 circular buffer sizes (tiles). Tr <= 8, max_dst <= 8, nope_chunk_tiles <= 8.
-//   cb_nope=2*nope_batch_tiles; worst 16
-//   cb_q_pe=dst_batch?max_chunk:2*Tr; worst 16
-//   cb_rope_out=2*Tr; worst 16
-//   cb_cos=2*Tr; worst 16
-//   cb_sin=2*Tr; worst 16
+// L1 circular buffer sizes (tiles). Tr <= 4 (asserted below), max_dst_tiles = 4
+// (fp32_dest_acc_en=true), nope_chunk_tiles = 4.
+//   cb_nope=2*nope_batch_tiles; scales with heads batched per DST pass and round_up(Tn, 4)
+//   cb_q_pe=dst_batch?max_chunk:2*Tr; worst 8
+//   cb_rope_out=2*Tr; worst 8
+//   cb_cos=2*Tr; worst 8
+//   cb_sin=2*Tr; worst 8
 //   cb_trans=1; worst 1
-//   rotated_in=dst_batch?max_chunk:Tr; worst 8
-//   cos_interm=Tr; worst 8
-//   sin_interm=Tr; worst 8
-//   total worst 105 tiles at Tr=8 (~210 KiB at 2 KiB/tile)
+//   rotated_in=dst_batch?max_chunk:Tr; worst 4
+//   cos_interm=Tr; worst 4
+//   sin_interm=Tr; worst 4
 
 namespace {
 

--- a/tt-train/sources/ttml/metal/ops/mla_q_rope/mla_q_rope.hpp
+++ b/tt-train/sources/ttml/metal/ops/mla_q_rope/mla_q_rope.hpp
@@ -17,6 +17,8 @@ namespace ttml::metal {
 // cos_cache / sin_cache: [1, 1, S, qk_rope_dim]
 // trans_mat: [1, 1, 32, 32]
 // Requires qk_rope_dim <= 128 (fp32 dest accumulation, same as rotary_embedding_llama precise).
+// Training additionally requires qk_rope_dim <= 96: mla_qkv_assemble_bw needs qk_rope_dim/32 + 1
+// DST slots and rejects larger dims at program creation.
 ttnn::Tensor mla_q_rope(
     const ttnn::Tensor& q_in,
     const ttnn::Tensor& cos_cache,

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.cpp
@@ -52,9 +52,6 @@ void MLAQKVAssembleBwDeviceOperation::validate_on_program_cache_miss(
         dQ.device() == dK.device() && dK.device() == dV.device(),
         "MLAQKVAssembleBw: dQ, dK, and dV must be on the same device.");
 
-    // compute_output_specs derives each output layout from one input; the outputs are only
-    // interchangeable if every input shares the same placement.
-
     const auto dQ_shape = dQ.padded_shape();
     const auto dK_shape = dK.padded_shape();
     const auto dV_shape = dV.padded_shape();
@@ -135,8 +132,9 @@ MLAQKVAssembleBwDeviceOperation::spec_return_value_t MLAQKVAssembleBwDeviceOpera
     const ttnn::Shape dkv_up_shape({B, 1U, S, args.n_heads * (args.qk_nope_dim + args.v_dim)});
     const ttnn::Shape dk_pe_shape({B, 1U, S, args.qk_rope_dim});
 
-    // Each output inherits from its primary input source. Validation requires all three
-    // inputs share dtype + memory_config, so these layouts are equal in practice.
+    // dq_pre inherits dQ's placement; dkv_up and dk_pe inherit dK's. Inputs may
+    // sit in different memory configs (only interleaved is required); the program
+    // hash keys each input's memory config independently.
     auto dq_layout = tt::tt_metal::TensorLayout(dQ.dtype(), tt::tt_metal::Layout::TILE, dQ.memory_config());
     auto dk_layout = tt::tt_metal::TensorLayout(dK.dtype(), tt::tt_metal::Layout::TILE, dK.memory_config());
     output_specs.emplace_back(dq_pre_shape, dq_layout);

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.cpp
@@ -54,9 +54,6 @@ void MLAQKVAssembleBwDeviceOperation::validate_on_program_cache_miss(
 
     // compute_output_specs derives each output layout from one input; the outputs are only
     // interchangeable if every input shares the same placement.
-    TT_FATAL(
-        dQ.memory_config() == dK.memory_config() && dK.memory_config() == dV.memory_config(),
-        "MLAQKVAssembleBw: dQ, dK, and dV must share the same memory config.");
 
     const auto dQ_shape = dQ.padded_shape();
     const auto dK_shape = dK.padded_shape();

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_device_operation.cpp
@@ -52,6 +52,12 @@ void MLAQKVAssembleBwDeviceOperation::validate_on_program_cache_miss(
         dQ.device() == dK.device() && dK.device() == dV.device(),
         "MLAQKVAssembleBw: dQ, dK, and dV must be on the same device.");
 
+    // compute_output_specs derives each output layout from one input; the outputs are only
+    // interchangeable if every input shares the same placement.
+    TT_FATAL(
+        dQ.memory_config() == dK.memory_config() && dK.memory_config() == dV.memory_config(),
+        "MLAQKVAssembleBw: dQ, dK, and dV must share the same memory config.");
+
     const auto dQ_shape = dQ.padded_shape();
     const auto dK_shape = dK.padded_shape();
     const auto dV_shape = dV.padded_shape();
@@ -155,12 +161,17 @@ MLAQKVAssembleBwDeviceOperation::tensor_return_value_t MLAQKVAssembleBwDeviceOpe
 
 ttsl::hash::hash_t MLAQKVAssembleBwDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    // Memory configs are hashed because TensorAccessorArgs bake buffer placement into
+    // compile-time args, so a placement change must not reuse a cached program.
     return tt::tt_metal::operation::hash_operation<MLAQKVAssembleBwDeviceOperation>(
         args,
         tensor_args.dQ.dtype(),
         tensor_args.dQ.logical_shape(),
         tensor_args.dK.logical_shape(),
-        tensor_args.dV.logical_shape());
+        tensor_args.dV.logical_shape(),
+        tensor_args.dQ.memory_config(),
+        tensor_args.dK.memory_config(),
+        tensor_args.dV.memory_config());
 }
 
 MLAQKVAssembleBwDeviceOperation::program_factory_t MLAQKVAssembleBwDeviceOperation::select_program_factory(

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_bw/device/mla_qkv_assemble_bw_program_factory.cpp
@@ -173,12 +173,14 @@ MLAQKVAssembleBwProgramFactory::cached_program_t MLAQKVAssembleBwProgramFactory:
     const uint32_t num_blocks = B * Ts;
 
     // Compute kernel uses Tr persistent dst-register slots as the head-axis accumulator, plus 1 temp
-    // slot. With fp32 dest accumulation the DST holds 8 fp32 tiles, so the bound is Tr + 1 ≤ 8.
+    // slot. fp32_dest_acc_en=true -> DST holds 4 tiles, so the bound is Tr + 1 <= 4.
+    constexpr uint32_t max_dst_tiles = 4U;
     TT_FATAL(
-        Tr + 1U <= 8U,
-        "MLAQKVAssembleBw: qk_rope_dim ({}) / TILE_W = {} too large for in-register accumulator (max 7).",
+        Tr + 1U <= max_dst_tiles,
+        "MLAQKVAssembleBw: qk_rope_dim ({}) / TILE_W = {} too large for in-register accumulator (max {}).",
         args.qk_rope_dim,
-        Tr);
+        Tr,
+        max_dst_tiles - 1U);
 
     // ── Work split ──
     const auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_device_operation.cpp
@@ -54,9 +54,6 @@ void MLAQKVAssembleFwDeviceOperation::validate_on_program_cache_miss(
 
     // compute_output_specs derives each output layout from one input; the outputs are only
     // interchangeable if every input shares the same placement.
-    TT_FATAL(
-        q_pre.memory_config() == kv_up.memory_config() && kv_up.memory_config() == k_pe.memory_config(),
-        "MLAQKVAssembleFw: q_pre, kv_up, and k_pe must share the same memory config.");
 
     const auto q_pre_shape = q_pre.padded_shape();
     const auto kv_up_shape = kv_up.padded_shape();

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_device_operation.cpp
@@ -52,6 +52,12 @@ void MLAQKVAssembleFwDeviceOperation::validate_on_program_cache_miss(
         q_pre.device() == kv_up.device() && kv_up.device() == k_pe.device(),
         "MLAQKVAssembleFw: q_pre, kv_up, and k_pe must be on the same device.");
 
+    // compute_output_specs derives each output layout from one input; the outputs are only
+    // interchangeable if every input shares the same placement.
+    TT_FATAL(
+        q_pre.memory_config() == kv_up.memory_config() && kv_up.memory_config() == k_pe.memory_config(),
+        "MLAQKVAssembleFw: q_pre, kv_up, and k_pe must share the same memory config.");
+
     const auto q_pre_shape = q_pre.padded_shape();
     const auto kv_up_shape = kv_up.padded_shape();
     const auto k_pe_shape = k_pe.padded_shape();
@@ -158,12 +164,17 @@ MLAQKVAssembleFwDeviceOperation::tensor_return_value_t MLAQKVAssembleFwDeviceOpe
 
 ttsl::hash::hash_t MLAQKVAssembleFwDeviceOperation::compute_program_hash(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
+    // Memory configs are hashed because TensorAccessorArgs bake buffer placement into
+    // compile-time args, so a placement change must not reuse a cached program.
     return tt::tt_metal::operation::hash_operation<MLAQKVAssembleFwDeviceOperation>(
         args,
         tensor_args.kv_up.dtype(),
         tensor_args.q_pre.logical_shape(),
         tensor_args.kv_up.logical_shape(),
-        tensor_args.k_pe.logical_shape());
+        tensor_args.k_pe.logical_shape(),
+        tensor_args.q_pre.memory_config(),
+        tensor_args.kv_up.memory_config(),
+        tensor_args.k_pe.memory_config());
 }
 
 MLAQKVAssembleFwDeviceOperation::program_factory_t MLAQKVAssembleFwDeviceOperation::select_program_factory(

--- a/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/mla_qkv_assemble_fw/device/mla_qkv_assemble_fw_device_operation.cpp
@@ -52,9 +52,6 @@ void MLAQKVAssembleFwDeviceOperation::validate_on_program_cache_miss(
         q_pre.device() == kv_up.device() && kv_up.device() == k_pe.device(),
         "MLAQKVAssembleFw: q_pre, kv_up, and k_pe must be on the same device.");
 
-    // compute_output_specs derives each output layout from one input; the outputs are only
-    // interchangeable if every input shares the same placement.
-
     const auto q_pre_shape = q_pre.padded_shape();
     const auto kv_up_shape = kv_up.padded_shape();
     const auto k_pe_shape = k_pe.padded_shape();
@@ -138,8 +135,9 @@ MLAQKVAssembleFwDeviceOperation::spec_return_value_t MLAQKVAssembleFwDeviceOpera
     const ttnn::Shape k_shape({B, args.n_heads, S, qk_head});
     const ttnn::Shape v_shape({B, args.n_heads, S, args.v_dim});
 
-    // Each output inherits from its primary input source. Validation requires all three
-    // inputs share dtype + memory_config, so these layouts are equal in practice.
+    // q inherits q_pre's placement; k and v inherit kv_up's. Inputs may sit in
+    // different memory configs (only interleaved is required); the program hash
+    // keys each input's memory config independently.
     auto q_layout = tt::tt_metal::TensorLayout(q_pre.dtype(), tt::tt_metal::Layout::TILE, q_pre.memory_config());
     auto kv_layout = tt::tt_metal::TensorLayout(kv_up.dtype(), tt::tt_metal::Layout::TILE, kv_up.memory_config());
     output_specs.emplace_back(q_shape, q_layout);

--- a/tt-train/tests/ops/mla_q_rope_op_test.cpp
+++ b/tt-train/tests/ops/mla_q_rope_op_test.cpp
@@ -14,9 +14,11 @@
 #include "metal/operations.hpp"
 #include "ops/rope_op.hpp"
 #include "test_utils/random_data.hpp"
+#include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/concat/concat.hpp"
 #include "ttnn/operations/data_movement/slice/slice.hpp"
 #include "ttnn/operations/experimental/transformer/rotary_embedding_llama/rotary_embedding_llama.hpp"
+#include "ttnn/types.hpp"
 
 namespace {
 
@@ -164,3 +166,50 @@ INSTANTIATE_TEST_SUITE_P(
         MLA_QRopeShape{
             .name = "batch4_st2", .batch = 4, .seq_len = 64, .n_heads = 2, .qk_nope_dim = 32, .qk_rope_dim = 32}),
     [](const ::testing::TestParamInfo<MLA_QRopeShape>& info) { return info.param.name; });
+
+class MLA_QRopeCacheTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() {
+        ttml::autograd::ctx().open_device();
+    }
+
+    static void TearDownTestSuite() {
+        ttml::autograd::ctx().close_device();
+    }
+};
+
+// Buffer placement is a compile-time property: TensorAccessorArgs bake it into the
+// kernel binary, so the program cache must key on every input's memory config. Runs
+// the op with q_in interleaved in DRAM and again with q_in in L1 at identical shapes,
+// asserting the second run compiles a distinct program and still matches the
+// reference — a cache key blind to placement reuses the DRAM program for the L1
+// buffer and reads through the wrong accessor tables.
+TEST_F(MLA_QRopeCacheTest, DistinctProgramPerInputPlacement) {
+    auto* device = &ttml::autograd::ctx().get_device();
+    device->enable_program_cache();
+
+    const MLA_QRopeShape shape{
+        .name = "cache_small", .batch = 1, .seq_len = 32, .n_heads = 4, .qk_nope_dim = 64, .qk_rope_dim = 32};
+    const uint32_t qk_head = shape.qk_nope_dim + shape.qk_rope_dim;
+    auto q_in = make_bf16_4d(shape.batch, shape.n_heads, shape.seq_len, qk_head, /*seed=*/11U);
+    auto params = build_params(shape.seq_len, shape.qk_rope_dim);
+    const auto ref = reference_q_rope(q_in, params, shape.qk_nope_dim, shape.qk_rope_dim);
+
+    const auto entries_start = device->num_program_cache_entries();
+    const auto fused_dram = ttml::metal::mla_q_rope(
+        q_in, params.cos_cache, params.sin_cache, params.trans_mat, shape.qk_nope_dim, shape.qk_rope_dim);
+    const auto entries_after_dram = device->num_program_cache_entries();
+    // Guard against a vacuous test: the first call must actually populate the cache,
+    // else the delta check below would pass trivially with the cache disabled.
+    ASSERT_GT(entries_after_dram, entries_start) << "program cache not populated by the DRAM-placement run";
+    expect_q_rope_matches_reference(fused_dram, ref, shape, /*label_prefix=*/"dram: ");
+
+    auto q_in_l1 = ttnn::to_memory_config(q_in, ttnn::L1_MEMORY_CONFIG);
+    const auto entries_before_l1 = device->num_program_cache_entries();
+    const auto fused_l1 = ttml::metal::mla_q_rope(
+        q_in_l1, params.cos_cache, params.sin_cache, params.trans_mat, shape.qk_nope_dim, shape.qk_rope_dim);
+    const auto entries_after_l1 = device->num_program_cache_entries();
+    EXPECT_GT(entries_after_l1, entries_before_l1)
+        << "mla_q_rope reused the DRAM-placement program for an L1 input (stale cache key)";
+    expect_q_rope_matches_reference(fused_l1, ref, shape, /*label_prefix=*/"l1: ");
+}

--- a/tt-train/tests/ops/mla_qkv_assemble_op_test.cpp
+++ b/tt-train/tests/ops/mla_qkv_assemble_op_test.cpp
@@ -193,6 +193,9 @@ const std::vector<AssembleShape>& shapes() {
         {"square_st1", 2, 32, 2, 32, 32, 32},
         {"square_st2", 2, 64, 2, 32, 32, 32},
         {"asym_rope2", 2, 64, 4, 128, 64, 128},
+        // Tr = 3 rope tiles: the largest count the bw DST budget admits (Tr + 1 = 4
+        // fp32 accumulator slots) — pins the accepted side of the rejection boundary.
+        {"rope3_dst_max", 1, 32, 2, 32, 96, 32},
         {"heads8_s96", 1, 96, 8, 64, 32, 64},
     };
     return cases;

--- a/tt-train/tests/ops/mla_qkv_assemble_op_test.cpp
+++ b/tt-train/tests/ops/mla_qkv_assemble_op_test.cpp
@@ -215,3 +215,20 @@ TEST_F(MLAQKVAssembleTest, BackwardMatchesReference) {
 TEST_F(MLAQKVAssembleTest, AutogradWrapperBackwardMatchesReference) {
     run_autograd_wrapper_bw({"wrapper_heads4", 2, 64, 4, 64, 32, 64});
 }
+
+TEST_F(MLAQKVAssembleTest, BackwardRejectsRopeDimBeyondDstBudget) {
+    // qk_rope_dim = 128 (Tr = 4) needs Tr + 1 = 5 dst slots; with fp32 dest accumulation the
+    // backward compute kernel's DST accumulator budget is 4, so the op must refuse to launch.
+    constexpr uint32_t n_heads = 2U;
+    constexpr uint32_t qk_nope_dim = 32U;
+    constexpr uint32_t qk_rope_dim = 128U;
+    constexpr uint32_t v_dim = 32U;
+    constexpr uint32_t qk_head = qk_nope_dim + qk_rope_dim;
+
+    const auto dQ = make_input(1U, n_heads, 32U, qk_head, 111U);
+    const auto dK = make_input(1U, n_heads, 32U, qk_head, 222U);
+    const auto dV = make_input(1U, n_heads, 32U, v_dim, 333U);
+
+    EXPECT_ANY_THROW(ttml::metal::mla_qkv_assemble_bw(dQ, dK, dV, n_heads, qk_nope_dim, qk_rope_dim, v_dim))
+        << "mla_qkv_assemble_bw should reject a rope tile count that overflows the DST accumulator";
+}


### PR DESCRIPTION
Fixes #53211

## What

- **DST guard**: `mla_qkv_assemble_bw` asserted `Tr + 1 <= 8` DST tiles, but the kernel runs half-sync + fp32 dest = **4** slots (`dst_full_sync_en` defaults false; confirmed against `kernel_types.hpp` and the repo's own 4-slot comments in mla_q_rope/sdpa_fw). `qk_rope_head_dim >= 128` silently corrupted the `dk_pe` gradient; it is now a loud host error. All shipped MoE configs use rope 32/64 — nothing legitimate newly rejected. The training-side limit (rope ≤ 96, i.e. Tr ≤ 3) is documented beside the forward's ≤ 128 contract.
- **Cache hash**: all three MLA ops now hash input memory configs (placement was baked into compiled programs via per-input `TensorAccessorArgs` but not hashed, so an L1-vs-DRAM placement change at identical shapes reused the wrong compiled program).
- **Memory-config equality: hash-only, not TT_FATAL**. An earlier revision of this PR added equality TT_FATALs to make the stale "validation requires memory_config equality" comments true; device evidence showed mixed placements execute correctly (each input's placement is carried by its own `TensorAccessorArgs`), so f676deaabeb removed the equality checks in favor of hash-only placement keys (two reviewers concurred), and 9c598af627a deleted the stale comments and documented the actual contract (inputs may sit in different memory configs; only interleaved is required; the program hash keys each input's placement independently).
- **Tests** (all device-green):
  - `BackwardRejectsRopeDimBeyondDstBudget` — rope 128 / Tr=4 must throw (negative side of the boundary).
  - `rope3_dst_max` shape (rope 96, Tr=3, exactly the Tr+1=4 budget) in the shared shapes list, running through both fw and bw reference tests — pins the accepted side of the boundary against a future off-by-one in the guard.
  - `MLA_QRopeCacheTest.DistinctProgramPerInputPlacement` — with the program cache enabled, runs DRAM then L1 placement at identical shapes and asserts a distinct program is compiled (fails on the old hash) with correct results on both.

## Validation checklist

- [x] `MLAQKVAssembleTest.*` — existing tests pass; the new negative test FAILS on old kernels (the op silently runs — corruption demonstrated) and PASSES on fixed
- [x] `rope3_dst_max` (Tr=3 exact-budget) fw+bw reference cases — green on device
- [x] `*MlaQRope*` suite incl. the new placement cache test — green on BH
- [x] Memory-config handling: f676deaabeb relaxed the equality TT_FATALs to hash-only after device evidence that mixed placements execute correctly (two reviewers concurred); 9c598af627a cleaned the stale contract comments
- Perf/memory: benchmark JSONs collected on baseline and fixed builds (gram/adamw/mla/rope); comparison pending

## Device verification (BH galaxy, bh_sc5 quad)

All runs on Blackhole galaxies. Baseline ("old kernels") = `origin/main` @ f941b98652e plus only the new tests.

- Negative test (`BackwardRejectsRopeDimBeyondDstBudget`, rope=128 must throw): FAILS on old kernels — the op silently runs, i.e. the corruption path is demonstrated — and PASSES on fixed.
- Boundary pinned from both sides: rope=96 (Tr=3, exact 4-slot budget) executes and matches reference fw+bw; rope=128 (Tr=4) rejects.
- `MLA_QRopeCacheTest.DistinctProgramPerInputPlacement` green: DRAM→L1 placement change compiles a distinct program with correct results on both placements.
- Existing MLA suites pass; single-chip BH suite green (605 tests) on the fixed build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ayerofieiev/kernel-fix/mla-dst-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ayerofieiev/kernel-fix/mla-dst-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ayerofieiev/kernel-fix/mla-dst-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ayerofieiev/kernel-fix/mla-dst-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ayerofieiev/kernel-fix/mla-dst-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ayerofieiev/kernel-fix/mla-dst-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ayerofieiev/kernel-fix/mla-dst-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ayerofieiev/kernel-fix/mla-dst-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ayerofieiev/kernel-fix/mla-dst-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ayerofieiev/kernel-fix/mla-dst-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ayerofieiev/kernel-fix/mla-dst-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ayerofieiev/kernel-fix/mla-dst-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ayerofieiev/kernel-fix/mla-dst-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ayerofieiev/kernel-fix/mla-dst-2026-08-14)