### PR TITLE
[tt-train] Fix AdamW state-restore beta ordering; validate optimizer state shapes; per-buffer SGD dampening

### DIFF
--- a/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation.cpp
@@ -87,6 +87,24 @@ void AdamWDeviceOperation::validate_on_program_cache_miss(
         check_tensor(
             max_exp_avg_sq.value(), "Max Exponential Average Squared Buffer", tt::tt_metal::Layout::TILE, param_dtype);
     }
+
+    // Tile counts and reader/writer extents are derived solely from the parameter tensor, so any
+    // smaller companion tensor would be read or written past its allocation.
+    auto check_shape = [&param](const ttnn::Tensor& tensor, const std::string& name) {
+        TT_FATAL(
+            tensor.padded_shape() == param.padded_shape(),
+            "Tensor '{}' must match the parameter's padded shape. Parameter: {}, '{}': {}",
+            name,
+            param.padded_shape(),
+            name,
+            tensor.padded_shape());
+    };
+    check_shape(grad, "Gradient");
+    check_shape(exp_avg, "Exponential Average Buffer");
+    check_shape(exp_avg_sq, "Exponential Average Squared Buffer");
+    if (max_exp_avg_sq.has_value()) {
+        check_shape(max_exp_avg_sq.value(), "Max Exponential Average Squared Buffer");
+    }
 }
 
 AdamWDeviceOperation::spec_return_value_t AdamWDeviceOperation::compute_output_specs(

--- a/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation.cpp
@@ -13,10 +13,12 @@ namespace ttml::metal::optimizers::adamw::device {
 
 void AdamWDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    auto check_tensor = [](const ttnn::Tensor& tensor,
-                           const std::string& name,
-                           const tt::tt_metal::Layout required_layout,
-                           const tt::tt_metal::DataType required_dtype) {
+    const auto& param = tensor_args.param;
+    auto check_tensor = [&param](
+                            const ttnn::Tensor& tensor,
+                            const std::string& name,
+                            const tt::tt_metal::Layout required_layout,
+                            const tt::tt_metal::DataType required_dtype) {
         TT_FATAL(
             tensor.storage_type() == ttnn::StorageType::DEVICE,
             "AdamW optimizer requires '{}' to be on DEVICE. Got storage type: '{}'",
@@ -50,9 +52,17 @@ void AdamWDeviceOperation::validate_on_program_cache_miss(
             "Tensor '{}' must use INTERLEAVED memory layout, but got '{}'",
             name,
             enchantum::to_string(tensor.memory_config().memory_layout()));
+
+        // Tile counts and reader/writer extents are derived solely from the parameter tensor, so any
+        // smaller companion tensor would be read or written past its allocation.
+        TT_FATAL(
+            tensor.padded_shape() == param.padded_shape(),
+            "Tensor '{}' must match the parameter's padded shape. Expected {}, got {}",
+            name,
+            param.padded_shape(),
+            tensor.padded_shape());
     };
 
-    const auto& param = tensor_args.param;
     const auto& grad = tensor_args.grad;
     const auto& exp_avg = tensor_args.exp_avg;
     const auto& exp_avg_sq = tensor_args.exp_avg_sq;
@@ -86,24 +96,6 @@ void AdamWDeviceOperation::validate_on_program_cache_miss(
     if (max_exp_avg_sq.has_value()) {
         check_tensor(
             max_exp_avg_sq.value(), "Max Exponential Average Squared Buffer", tt::tt_metal::Layout::TILE, param_dtype);
-    }
-
-    // Tile counts and reader/writer extents are derived solely from the parameter tensor, so any
-    // smaller companion tensor would be read or written past its allocation.
-    auto check_shape = [&param](const ttnn::Tensor& tensor, const std::string& name) {
-        TT_FATAL(
-            tensor.padded_shape() == param.padded_shape(),
-            "Tensor '{}' must match the parameter's padded shape. Parameter: {}, '{}': {}",
-            name,
-            param.padded_shape(),
-            name,
-            tensor.padded_shape());
-    };
-    check_shape(grad, "Gradient");
-    check_shape(exp_avg, "Exponential Average Buffer");
-    check_shape(exp_avg_sq, "Exponential Average Squared Buffer");
-    if (max_exp_avg_sq.has_value()) {
-        check_shape(max_exp_avg_sq.value(), "Max Exponential Average Squared Buffer");
     }
 }
 

--- a/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation.cpp
@@ -53,6 +53,15 @@ void AdamWDeviceOperation::validate_on_program_cache_miss(
             name,
             enchantum::to_string(tensor.memory_config().memory_layout()));
 
+        // Logical shapes must match for element-for-element correspondence with the parameter;
+        // padding alone cannot tell apart tensors that round up to the same tile extent.
+        TT_FATAL(
+            tensor.logical_shape() == param.logical_shape(),
+            "Tensor '{}' must match the parameter's logical shape. Expected {}, got {}",
+            name,
+            param.logical_shape(),
+            tensor.logical_shape());
+
         // Tile counts and reader/writer extents are derived solely from the parameter tensor, so any
         // smaller companion tensor would be read or written past its allocation.
         TT_FATAL(

--- a/tt-train/sources/ttml/metal/optimizers/sgd/device/sgd_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/optimizers/sgd/device/sgd_device_operation.cpp
@@ -53,6 +53,15 @@ void SGDDeviceOperation::validate_on_program_cache_miss(
             name,
             enchantum::to_string(tensor.memory_config().memory_layout()));
 
+        // Logical shapes must match for element-for-element correspondence with the parameter;
+        // padding alone cannot tell apart tensors that round up to the same tile extent.
+        TT_FATAL(
+            tensor.logical_shape() == param.logical_shape(),
+            "Tensor '{}' must match the parameter's logical shape. Expected {}, got {}",
+            name,
+            param.logical_shape(),
+            tensor.logical_shape());
+
         // Tile counts and reader/writer extents are derived solely from the parameter tensor, so any
         // smaller companion tensor would be read or written past its allocation.
         TT_FATAL(

--- a/tt-train/sources/ttml/metal/optimizers/sgd/device/sgd_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/optimizers/sgd/device/sgd_device_operation.cpp
@@ -62,6 +62,22 @@ void SGDDeviceOperation::validate_on_program_cache_miss(
             momentum_buffer.value(), "Momentum Buffer", tt::tt_metal::Layout::TILE, tt::tt_metal::DataType::BFLOAT16);
     }
 
+    // Tile counts and reader/writer extents are derived solely from the parameter tensor, so any
+    // smaller companion tensor would be read or written past its allocation.
+    auto check_shape = [&param](const ttnn::Tensor& tensor, const std::string& name) {
+        TT_FATAL(
+            tensor.padded_shape() == param.padded_shape(),
+            "Tensor '{}' must match the parameter's padded shape. Parameter: {}, '{}': {}",
+            name,
+            param.padded_shape(),
+            name,
+            tensor.padded_shape());
+    };
+    check_shape(grad, "Gradient");
+    if (momentum_buffer.has_value()) {
+        check_shape(momentum_buffer.value(), "Momentum Buffer");
+    }
+
     const auto momentum = args.momentum;
     const auto use_momentum = (momentum > 0.0F);
     if (use_momentum) {

--- a/tt-train/sources/ttml/metal/optimizers/sgd/device/sgd_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/optimizers/sgd/device/sgd_device_operation.cpp
@@ -13,10 +13,12 @@ namespace ttml::metal::optimizers::sgd::device {
 
 void SGDDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    auto check_tensor = [](const ttnn::Tensor& tensor,
-                           const std::string& name,
-                           const tt::tt_metal::Layout required_layout,
-                           const tt::tt_metal::DataType required_dtype) {
+    const auto& param = tensor_args.param;
+    auto check_tensor = [&param](
+                            const ttnn::Tensor& tensor,
+                            const std::string& name,
+                            const tt::tt_metal::Layout required_layout,
+                            const tt::tt_metal::DataType required_dtype) {
         TT_FATAL(
             tensor.storage_type() == ttnn::StorageType::DEVICE,
             "SGD optimizer requires '{}' to be on DEVICE. Got storage type: '{}'",
@@ -50,9 +52,17 @@ void SGDDeviceOperation::validate_on_program_cache_miss(
             "Tensor '{}' must use INTERLEAVED memory layout, but got '{}'",
             name,
             enchantum::to_string(tensor.memory_config().memory_layout()));
+
+        // Tile counts and reader/writer extents are derived solely from the parameter tensor, so any
+        // smaller companion tensor would be read or written past its allocation.
+        TT_FATAL(
+            tensor.padded_shape() == param.padded_shape(),
+            "Tensor '{}' must match the parameter's padded shape. Expected {}, got {}",
+            name,
+            param.padded_shape(),
+            tensor.padded_shape());
     };
 
-    const auto& param = tensor_args.param;
     const auto& grad = tensor_args.grad;
     const auto& momentum_buffer = tensor_args.momentum_buffer;
     check_tensor(param, "Parameter", tt::tt_metal::Layout::TILE, tt::tt_metal::DataType::BFLOAT16);
@@ -60,22 +70,6 @@ void SGDDeviceOperation::validate_on_program_cache_miss(
     if (momentum_buffer.has_value()) {
         check_tensor(
             momentum_buffer.value(), "Momentum Buffer", tt::tt_metal::Layout::TILE, tt::tt_metal::DataType::BFLOAT16);
-    }
-
-    // Tile counts and reader/writer extents are derived solely from the parameter tensor, so any
-    // smaller companion tensor would be read or written past its allocation.
-    auto check_shape = [&param](const ttnn::Tensor& tensor, const std::string& name) {
-        TT_FATAL(
-            tensor.padded_shape() == param.padded_shape(),
-            "Tensor '{}' must match the parameter's padded shape. Parameter: {}, '{}': {}",
-            name,
-            param.padded_shape(),
-            name,
-            tensor.padded_shape());
-    };
-    check_shape(grad, "Gradient");
-    if (momentum_buffer.has_value()) {
-        check_shape(momentum_buffer.value(), "Momentum Buffer");
     }
 
     const auto momentum = args.momentum;

--- a/tt-train/sources/ttml/optimizers/adamw.cpp
+++ b/tt-train/sources/ttml/optimizers/adamw.cpp
@@ -134,13 +134,14 @@ serialization::StateDict AdamW::get_state_dict() const {
 }
 
 void AdamW::set_state_dict(const serialization::StateDict& dict) {
-    set_steps(serialization::get_value_type<size_t>(dict, "steps"));
     set_lr(serialization::get_value_type<float>(dict, "lr"));
     m_config.beta1 = serialization::get_value_type<float>(dict, "beta1");
     m_config.beta2 = serialization::get_value_type<float>(dict, "beta2");
     m_config.epsilon = serialization::get_value_type<float>(dict, "epsilon");
     m_config.weight_decay = serialization::get_value_type<float>(dict, "weight_decay");
     m_config.stochastic_rounding = serialization::get_value_type<bool>(dict, "stochastic_rounding");
+    // set_steps derives the beta powers from m_config, so the betas must be restored first.
+    set_steps(serialization::get_value_type<size_t>(dict, "steps"));
     m_exp_avg = std::get<serialization::NamedParameters>(dict.at("exp_avg"));
     m_exp_avg_sq = std::get<serialization::NamedParameters>(dict.at("exp_avg_sq"));
 
@@ -177,6 +178,9 @@ float AdamW::get_beta1() const {
 
 void AdamW::set_beta1(float beta1) {
     m_config.beta1 = beta1;
+    // Bias correction uses beta^t with the current beta (PyTorch semantics), so the
+    // accumulated power must be rebuilt from the new value.
+    m_beta1_pow = static_cast<float>(std::pow(beta1, m_steps));
 }
 
 float AdamW::get_beta2() const {
@@ -185,6 +189,7 @@ float AdamW::get_beta2() const {
 
 void AdamW::set_beta2(float beta2) {
     m_config.beta2 = beta2;
+    m_beta2_pow = static_cast<float>(std::pow(beta2, m_steps));
 }
 
 float AdamW::get_epsilon() const {

--- a/tt-train/sources/ttml/optimizers/adamw.cpp
+++ b/tt-train/sources/ttml/optimizers/adamw.cpp
@@ -135,12 +135,11 @@ serialization::StateDict AdamW::get_state_dict() const {
 
 void AdamW::set_state_dict(const serialization::StateDict& dict) {
     set_lr(serialization::get_value_type<float>(dict, "lr"));
-    m_config.beta1 = serialization::get_value_type<float>(dict, "beta1");
-    m_config.beta2 = serialization::get_value_type<float>(dict, "beta2");
+    set_beta1(serialization::get_value_type<float>(dict, "beta1"));
+    set_beta2(serialization::get_value_type<float>(dict, "beta2"));
     m_config.epsilon = serialization::get_value_type<float>(dict, "epsilon");
     m_config.weight_decay = serialization::get_value_type<float>(dict, "weight_decay");
     m_config.stochastic_rounding = serialization::get_value_type<bool>(dict, "stochastic_rounding");
-    // set_steps derives the beta powers from m_config, so the betas must be restored first.
     set_steps(serialization::get_value_type<size_t>(dict, "steps"));
     m_exp_avg = std::get<serialization::NamedParameters>(dict.at("exp_avg"));
     m_exp_avg_sq = std::get<serialization::NamedParameters>(dict.at("exp_avg_sq"));
@@ -179,8 +178,8 @@ float AdamW::get_beta1() const {
 void AdamW::set_beta1(float beta1) {
     m_config.beta1 = beta1;
     // Bias correction uses beta^t with the current beta (PyTorch semantics), so the
-    // accumulated power must be rebuilt from the new value.
-    m_beta1_pow = static_cast<float>(std::pow(beta1, m_steps));
+    // beta powers must be rebuilt from the new value; set_steps owns that derivation.
+    set_steps(m_steps);
 }
 
 float AdamW::get_beta2() const {
@@ -189,7 +188,7 @@ float AdamW::get_beta2() const {
 
 void AdamW::set_beta2(float beta2) {
     m_config.beta2 = beta2;
-    m_beta2_pow = static_cast<float>(std::pow(beta2, m_steps));
+    set_steps(m_steps);
 }
 
 float AdamW::get_epsilon() const {

--- a/tt-train/sources/ttml/optimizers/adamw_full_precision.cpp
+++ b/tt-train/sources/ttml/optimizers/adamw_full_precision.cpp
@@ -121,11 +121,10 @@ serialization::StateDict AdamWFullPrecision::get_state_dict() const {
 
 void AdamWFullPrecision::set_state_dict(const serialization::StateDict& dict) {
     set_lr(serialization::get_value_type<float>(dict, "lr"));
-    m_config.beta1 = serialization::get_value_type<float>(dict, "beta1");
-    m_config.beta2 = serialization::get_value_type<float>(dict, "beta2");
+    set_beta1(serialization::get_value_type<float>(dict, "beta1"));
+    set_beta2(serialization::get_value_type<float>(dict, "beta2"));
     m_config.epsilon = serialization::get_value_type<float>(dict, "epsilon");
     m_config.weight_decay = serialization::get_value_type<float>(dict, "weight_decay");
-    // set_steps derives the beta powers from m_config, so the betas must be restored first.
     set_steps(serialization::get_value_type<size_t>(dict, "steps"));
     m_master_weights = std::get<serialization::NamedParameters>(dict.at("master_weights"));
     m_exp_avg = std::get<serialization::NamedParameters>(dict.at("exp_avg"));
@@ -165,8 +164,8 @@ float AdamWFullPrecision::get_beta1() const {
 void AdamWFullPrecision::set_beta1(float beta1) {
     m_config.beta1 = beta1;
     // Bias correction uses beta^t with the current beta (PyTorch semantics), so the
-    // accumulated power must be rebuilt from the new value.
-    m_beta1_pow = static_cast<float>(std::pow(beta1, m_steps));
+    // beta powers must be rebuilt from the new value; set_steps owns that derivation.
+    set_steps(m_steps);
 }
 
 float AdamWFullPrecision::get_beta2() const {
@@ -175,7 +174,7 @@ float AdamWFullPrecision::get_beta2() const {
 
 void AdamWFullPrecision::set_beta2(float beta2) {
     m_config.beta2 = beta2;
-    m_beta2_pow = static_cast<float>(std::pow(beta2, m_steps));
+    set_steps(m_steps);
 }
 
 float AdamWFullPrecision::get_epsilon() const {

--- a/tt-train/sources/ttml/optimizers/adamw_full_precision.cpp
+++ b/tt-train/sources/ttml/optimizers/adamw_full_precision.cpp
@@ -120,12 +120,13 @@ serialization::StateDict AdamWFullPrecision::get_state_dict() const {
 }
 
 void AdamWFullPrecision::set_state_dict(const serialization::StateDict& dict) {
-    set_steps(serialization::get_value_type<size_t>(dict, "steps"));
     set_lr(serialization::get_value_type<float>(dict, "lr"));
     m_config.beta1 = serialization::get_value_type<float>(dict, "beta1");
     m_config.beta2 = serialization::get_value_type<float>(dict, "beta2");
     m_config.epsilon = serialization::get_value_type<float>(dict, "epsilon");
     m_config.weight_decay = serialization::get_value_type<float>(dict, "weight_decay");
+    // set_steps derives the beta powers from m_config, so the betas must be restored first.
+    set_steps(serialization::get_value_type<size_t>(dict, "steps"));
     m_master_weights = std::get<serialization::NamedParameters>(dict.at("master_weights"));
     m_exp_avg = std::get<serialization::NamedParameters>(dict.at("exp_avg"));
     m_exp_avg_sq = std::get<serialization::NamedParameters>(dict.at("exp_avg_sq"));
@@ -163,6 +164,9 @@ float AdamWFullPrecision::get_beta1() const {
 
 void AdamWFullPrecision::set_beta1(float beta1) {
     m_config.beta1 = beta1;
+    // Bias correction uses beta^t with the current beta (PyTorch semantics), so the
+    // accumulated power must be rebuilt from the new value.
+    m_beta1_pow = static_cast<float>(std::pow(beta1, m_steps));
 }
 
 float AdamWFullPrecision::get_beta2() const {
@@ -171,6 +175,7 @@ float AdamWFullPrecision::get_beta2() const {
 
 void AdamWFullPrecision::set_beta2(float beta2) {
     m_config.beta2 = beta2;
+    m_beta2_pow = static_cast<float>(std::pow(beta2, m_steps));
 }
 
 float AdamWFullPrecision::get_epsilon() const {

--- a/tt-train/sources/ttml/optimizers/sgd.cpp
+++ b/tt-train/sources/ttml/optimizers/sgd.cpp
@@ -103,10 +103,11 @@ void SGD::set_state_dict(const serialization::StateDict& dict) {
     m_config.weight_decay = serialization::get_value_type<float>(dict, "weight_decay");
     m_config.nesterov = serialization::get_value_type<bool>(dict, "nesterov");
     m_momentum = std::get<serialization::NamedParameters>(dict.at("momentum"));
-    // Restored buffers carry accumulated momentum, so they are past their first update.
-    // (A checkpoint saved before any step also marks its zero buffers, so the resumed
-    // first update applies dampening to a zero buffer — an accepted corner case, since
-    // distinguishing it would require serializing this set.)
+    // Restored buffers are treated as past their first update. Buffers are preallocated
+    // for every trainable parameter, so a buffer that never received a gradient before the
+    // checkpoint (frozen parameter, or a checkpoint saved before any step) is also marked,
+    // and its first resumed update applies dampening to a zero buffer — an accepted corner
+    // case, since distinguishing it would require serializing this set.
     m_momentum_initialized.clear();
     for (const auto& [name, tensor_ptr] : m_momentum) {
         m_momentum_initialized.insert(name);

--- a/tt-train/sources/ttml/optimizers/sgd.cpp
+++ b/tt-train/sources/ttml/optimizers/sgd.cpp
@@ -104,6 +104,9 @@ void SGD::set_state_dict(const serialization::StateDict& dict) {
     m_config.nesterov = serialization::get_value_type<bool>(dict, "nesterov");
     m_momentum = std::get<serialization::NamedParameters>(dict.at("momentum"));
     // Restored buffers carry accumulated momentum, so they are past their first update.
+    // (A checkpoint saved before any step also marks its zero buffers, so the resumed
+    // first update applies dampening to a zero buffer — an accepted corner case, since
+    // distinguishing it would require serializing this set.)
     m_momentum_initialized.clear();
     for (const auto& [name, tensor_ptr] : m_momentum) {
         m_momentum_initialized.insert(name);

--- a/tt-train/sources/ttml/optimizers/sgd.cpp
+++ b/tt-train/sources/ttml/optimizers/sgd.cpp
@@ -54,6 +54,7 @@ void SGD::step() {
         auto param = theta_ptr->get_value(autograd::PreferredPrecision::HALF);
 
         std::optional<ttnn::Tensor> momentum_buffer;
+        bool first_momentum_update = false;
         if (m_config.momentum > 0.0) {
             auto it = m_momentum.find(name);
             if (it == m_momentum.end()) {
@@ -62,11 +63,13 @@ void SGD::step() {
                     /* requires_grad */ false);
                 it = m_momentum.emplace(name, std::move(buf)).first;
             }
+            first_momentum_update = m_momentum_initialized.insert(name).second;
             momentum_buffer = it->second->get_value(autograd::PreferredPrecision::HALF);
         }
 
-        // The first step should not apply dampening
-        float dampening = m_steps == 0 ? 0.0f : m_config.dampening;
+        // A buffer's first update must produce buf = g (PyTorch seeds fresh buffers with the raw
+        // gradient); the buffer is zero at that point, so skipping dampening is sufficient.
+        float dampening = first_momentum_update ? 0.0f : m_config.dampening;
         ttml::metal::sgd(
             param,
             gradients,
@@ -100,6 +103,11 @@ void SGD::set_state_dict(const serialization::StateDict& dict) {
     m_config.weight_decay = serialization::get_value_type<float>(dict, "weight_decay");
     m_config.nesterov = serialization::get_value_type<bool>(dict, "nesterov");
     m_momentum = std::get<serialization::NamedParameters>(dict.at("momentum"));
+    // Restored buffers carry accumulated momentum, so they are past their first update.
+    m_momentum_initialized.clear();
+    for (const auto& [name, tensor_ptr] : m_momentum) {
+        m_momentum_initialized.insert(name);
+    }
 }
 
 size_t SGD::get_steps() const {

--- a/tt-train/sources/ttml/optimizers/sgd.hpp
+++ b/tt-train/sources/ttml/optimizers/sgd.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <unordered_set>
+
 #include "optimizers/optimizer_base.hpp"
 #include "serialization/serializable.hpp"
 
@@ -56,6 +58,11 @@ private:
     size_t m_steps{0};
     SGDConfig m_config;
     ttml::serialization::NamedParameters m_momentum;
+    // Buffers that have received at least one update. PyTorch seeds a fresh momentum
+    // buffer with the raw gradient (buf = g), so each buffer's first update must skip
+    // dampening — tracked per buffer because a lazily-unfrozen parameter can take its
+    // first step at any global step count.
+    std::unordered_set<std::string> m_momentum_initialized;
 };
 
 }  // namespace ttml::optimizers

--- a/tt-train/sources/ttml/optimizers/sgd_composite.cpp
+++ b/tt-train/sources/ttml/optimizers/sgd_composite.cpp
@@ -59,7 +59,10 @@ void SGDComposite::step() {
         }
 
         if (m_config.momentum != 0.0F) {
-            if (m_steps != 0) {
+            // A buffer's first update must produce theta = g (PyTorch seeds fresh buffers with
+            // the raw gradient), so momentum and dampening are skipped for it.
+            const bool first_momentum_update = m_theta_initialized.insert(name).second;
+            if (!first_momentum_update) {
                 // apply momentum
                 theta = ttnn::multiply(
                     theta,
@@ -114,6 +117,11 @@ void SGDComposite::set_state_dict(const serialization::StateDict& dict) {
     m_theta = std::get<serialization::NamedParameters>(dict.at("theta"));
     m_steps = serialization::get_value_type<size_t>(dict, "steps");
     set_lr(serialization::get_value_type<float>(dict, "lr"));
+    // Restored buffers carry accumulated momentum, so they are past their first update.
+    m_theta_initialized.clear();
+    for (const auto& [name, tensor_ptr] : m_theta) {
+        m_theta_initialized.insert(name);
+    }
 }
 
 size_t SGDComposite::get_steps() const {

--- a/tt-train/sources/ttml/optimizers/sgd_composite.cpp
+++ b/tt-train/sources/ttml/optimizers/sgd_composite.cpp
@@ -115,10 +115,11 @@ void SGDComposite::set_state_dict(const serialization::StateDict& dict) {
     m_theta = std::get<serialization::NamedParameters>(dict.at("theta"));
     m_steps = serialization::get_value_type<size_t>(dict, "steps");
     set_lr(serialization::get_value_type<float>(dict, "lr"));
-    // Restored buffers carry accumulated momentum, so they are past their first update.
-    // (A checkpoint saved before any step also marks its zero buffers, so the resumed
-    // first update applies dampening to a zero buffer — an accepted corner case, since
-    // distinguishing it would require serializing this set.)
+    // Restored buffers are treated as past their first update. Buffers are preallocated
+    // for every trainable parameter, so a buffer that never received a gradient before the
+    // checkpoint (frozen parameter, or a checkpoint saved before any step) is also marked,
+    // and its first resumed update applies dampening to a zero buffer — an accepted corner
+    // case, since distinguishing it would require serializing this set.
     m_theta_initialized.clear();
     for (const auto& [name, tensor_ptr] : m_theta) {
         m_theta_initialized.insert(name);

--- a/tt-train/sources/ttml/optimizers/sgd_composite.cpp
+++ b/tt-train/sources/ttml/optimizers/sgd_composite.cpp
@@ -60,25 +60,23 @@ void SGDComposite::step() {
 
         if (m_config.momentum != 0.0F) {
             // A buffer's first update must produce theta = g (PyTorch seeds fresh buffers with
-            // the raw gradient), so momentum and dampening are skipped for it.
+            // the raw gradient); the buffer is zero at that point, so momentum and dampening
+            // are skipped for it.
             const bool first_momentum_update = m_theta_initialized.insert(name).second;
             if (!first_momentum_update) {
-                // apply momentum
                 theta = ttnn::multiply(
                     theta,
                     m_config.momentum,
                     /* fast_and_approximate_mode*/ true);
-                // dampening
-                if (m_config.dampening != 0.0F) {
-                    theta = ttnn::add(
-                        theta,
-                        ttnn::multiply(
-                            gradients,
-                            1 - m_config.dampening,
-                            /* fast_and_approximate_mode*/ true));
-                } else {
-                    theta = ttnn::add(theta, gradients);
-                }
+            }
+            const float dampening = first_momentum_update ? 0.0F : m_config.dampening;
+            if (dampening != 0.0F) {
+                theta = ttnn::add(
+                    theta,
+                    ttnn::multiply(
+                        gradients,
+                        1 - dampening,
+                        /* fast_and_approximate_mode*/ true));
             } else {
                 theta = ttnn::add(theta, gradients);
             }
@@ -118,6 +116,9 @@ void SGDComposite::set_state_dict(const serialization::StateDict& dict) {
     m_steps = serialization::get_value_type<size_t>(dict, "steps");
     set_lr(serialization::get_value_type<float>(dict, "lr"));
     // Restored buffers carry accumulated momentum, so they are past their first update.
+    // (A checkpoint saved before any step also marks its zero buffers, so the resumed
+    // first update applies dampening to a zero buffer — an accepted corner case, since
+    // distinguishing it would require serializing this set.)
     m_theta_initialized.clear();
     for (const auto& [name, tensor_ptr] : m_theta) {
         m_theta_initialized.insert(name);

--- a/tt-train/sources/ttml/optimizers/sgd_composite.hpp
+++ b/tt-train/sources/ttml/optimizers/sgd_composite.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <unordered_set>
+
 #include "optimizers/optimizer_base.hpp"
 #include "serialization/serializable.hpp"
 
@@ -47,6 +49,12 @@ private:
     size_t m_steps{0};
     SGDCompositeConfig m_config;
     ttml::serialization::NamedParameters m_theta;
+    // Buffers that have received at least one update. PyTorch seeds a fresh momentum
+    // buffer with the raw gradient (buf = g), so each buffer's first update must skip
+    // momentum and dampening — tracked per buffer because a lazily-unfrozen parameter
+    // can take its first step at any global step count. Mirrors the fused SGD so the
+    // two implementations stay bitwise-comparable.
+    std::unordered_set<std::string> m_theta_initialized;
 };
 
 }  // namespace ttml::optimizers

--- a/tt-train/tests/optimizers/adamw_full_precision_test.cpp
+++ b/tt-train/tests/optimizers/adamw_full_precision_test.cpp
@@ -333,3 +333,148 @@ static const AdamWFullPrecisionCase kAMSGradCases[] = {
 
 INSTANTIATE_TEST_SUITE_P(
     AdamWFullPrecisionAMSGrad, AdamWFullPrecisionComparisonTest, ::testing::ValuesIn(kAMSGradCases), CaseName);
+
+// ====================================================================
+// State-dict restore tests
+// A checkpoint's betas may differ from the constructor config; both the
+// moment updates and the bias correction (beta powers) must follow the
+// restored betas.
+// ====================================================================
+
+class AdamWFullPrecisionStateDictTest : public ::testing::Test {
+public:
+    static void SetUpTestSuite() {
+        ttml::autograd::ctx().open_device();
+    }
+    static void TearDownTestSuite() {
+        ttml::autograd::ctx().close_device();
+    }
+
+protected:
+    void TearDown() override {
+        ttml::autograd::ctx().reset_graph();
+    }
+};
+
+// Builds an optimizer whose constructor betas differ from the effective ones, applies the
+// effective betas either through the state dict or through the setters, then verifies one
+// step against a CPU reference driven purely by the effective betas.
+static void run_effective_betas_step_and_compare(bool use_beta_setters) {
+    using namespace ttml;
+
+    const float lr = 1e-2f;
+    const float epsilon = 1e-8f;
+    const size_t initial_steps = 10;
+    const float constructor_beta1 = 0.9f;
+    const float constructor_beta2 = 0.999f;
+    const float effective_beta1 = 0.5f;
+    const float effective_beta2 = 0.9f;
+    const std::array<std::size_t, 4> shape = {1, 1, 128, 256};
+
+    autograd::ctx().set_seed(123U);
+    auto& gen = autograd::ctx().get_generator();
+    const uint32_t seed_param = gen();
+    const uint32_t seed_grad = gen();
+    const uint32_t seed_first_moment = gen();
+    const uint32_t seed_second_moment = gen();
+
+    xt::xarray<float> w0 = test_utils::make_uniform_xarray<float>(shape, -1.0F, 1.0F, seed_param);
+    xt::xarray<bfloat16> g0_bf16 =
+        test_utils::make_uniform_xarray<bfloat16>(shape, bfloat16{-1.0F}, bfloat16{1.0F}, seed_grad);
+    xt::xarray<float> g0 = xt::cast<float>(g0_bf16);
+    xt::xarray<float> m0 = test_utils::make_uniform_xarray<float>(shape, -1.0F, 1.0F, seed_first_moment);
+    xt::xarray<float> v0 = test_utils::make_uniform_xarray<float>(shape, 0.0F, 1.0F, seed_second_moment);
+
+    // CPU reference driven purely by the effective betas: the behavior a resumed run must match.
+    CPUAdamWFullPrecision cpu_opt(lr, effective_beta1, effective_beta2, epsilon, /*weight_decay=*/0.0f);
+    cpu_opt.set_state(w0, m0, v0, initial_steps);
+    xt::xarray<float> w_cpu = cpu_opt.step(g0);
+
+    auto theta = autograd::create_tensor(core::from_xtensor(w0, &autograd::ctx().get_device()), true);
+    serialization::NamedParameters params{{"theta", theta}};
+
+    optimizers::AdamWFullPrecisionConfig cfg;
+    cfg.lr = lr;
+    cfg.beta1 = constructor_beta1;
+    cfg.beta2 = constructor_beta2;
+    cfg.epsilon = epsilon;
+    cfg.weight_decay = 0.0f;
+    optimizers::AdamWFullPrecision opt(params, cfg);
+
+    // When exercising the setters, the state dict carries the constructor betas so that only
+    // the setters introduce the effective ones.
+    const float state_beta1 = use_beta_setters ? constructor_beta1 : effective_beta1;
+    const float state_beta2 = use_beta_setters ? constructor_beta2 : effective_beta2;
+    {
+        serialization::StateDict state;
+        state["steps"] = initial_steps;
+        state["lr"] = lr;
+        state["beta1"] = state_beta1;
+        state["beta2"] = state_beta2;
+        state["epsilon"] = epsilon;
+        state["weight_decay"] = 0.0f;
+        state["master_weights"] =
+            serialization::NamedParameters{{"theta", autograd::create_tensor(to_tt_fp32(w0), false)}};
+        state["exp_avg"] = serialization::NamedParameters{{"theta", autograd::create_tensor(to_tt_fp32(m0), false)}};
+        state["exp_avg_sq"] =
+            serialization::NamedParameters{{"theta", autograd::create_tensor(to_tt_fp32(v0), false)}};
+        state["amsgrad"] = false;
+        opt.set_state_dict(state);
+    }
+
+    if (use_beta_setters) {
+        opt.set_beta1(effective_beta1);
+        opt.set_beta2(effective_beta2);
+    }
+
+    EXPECT_EQ(opt.get_steps(), initial_steps);
+    EXPECT_FLOAT_EQ(opt.get_beta1(), effective_beta1);
+    EXPECT_FLOAT_EQ(opt.get_beta2(), effective_beta2);
+
+    theta->set_grad(to_tt_bf16(g0_bf16));
+    opt.step();
+
+    const auto& device_master_weights = opt.get_master_weights();
+    auto master_weights_tensor = device_master_weights.at("theta")->get_value(autograd::PreferredPrecision::FULL);
+    auto actual = core::to_xtensor(master_weights_tensor);
+
+    auto error_metrics = [](const xt::xarray<float>& reference, const xt::xarray<float>& candidate) {
+        float sum_error = 0.0f;
+        float max_error = 0.0f;
+        for (size_t i = 0; i < reference.size(); ++i) {
+            float error = std::abs(reference.flat(i) - candidate.flat(i));
+            sum_error += error;
+            max_error = std::max(max_error, error);
+        }
+        return std::pair<float, float>(sum_error / static_cast<float>(reference.size()), max_error);
+    };
+
+    const float mean_error_tolerance = 1e-7f;
+    const float max_error_tolerance = 1e-6f;
+    auto [mean_error, max_error] = error_metrics(w_cpu, actual);
+    EXPECT_LE(mean_error, mean_error_tolerance) << "bias correction must follow the effective betas";
+    EXPECT_LE(max_error, max_error_tolerance) << "bias correction must follow the effective betas";
+
+    // Guard against a vacuous pass: a step whose moments follow the effective betas but whose
+    // bias correction still carries the constructor betas' powers must be clearly distinguishable
+    // from the reference.
+    xt::xarray<float> m1 = effective_beta1 * m0 + (1.0f - effective_beta1) * g0;
+    xt::xarray<float> v1 = effective_beta2 * v0 + (1.0f - effective_beta2) * (g0 * g0);
+    const float stale_bias_correction1 =
+        1.0f - std::pow(constructor_beta1, static_cast<float>(initial_steps)) * effective_beta1;
+    const float stale_bias_correction2 =
+        1.0f - std::pow(constructor_beta2, static_cast<float>(initial_steps)) * effective_beta2;
+    xt::xarray<float> w_stale =
+        w0 - lr * (m1 / stale_bias_correction1) / (xt::sqrt(v1 / stale_bias_correction2) + epsilon);
+    auto [stale_mean_error, stale_max_error] = error_metrics(w_cpu, w_stale);
+    EXPECT_GT(stale_mean_error, mean_error_tolerance)
+        << "constructor and effective betas too close to distinguish; test is not meaningful";
+}
+
+TEST_F(AdamWFullPrecisionStateDictTest, RestoredBetasDriveBiasCorrection) {
+    run_effective_betas_step_and_compare(/*use_beta_setters=*/false);
+}
+
+TEST_F(AdamWFullPrecisionStateDictTest, BetaSettersRecomputeBiasCorrection) {
+    run_effective_betas_step_and_compare(/*use_beta_setters=*/true);
+}

--- a/tt-train/tests/optimizers/adamw_test.cpp
+++ b/tt-train/tests/optimizers/adamw_test.cpp
@@ -9,6 +9,7 @@
 
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "metal/operations.hpp"
 #include "test_utils/random_data.hpp"
 #include "xtensor/core/xtensor_forward.hpp"
 
@@ -567,6 +568,39 @@ TEST_F(AdamWStateDictTest, RestoredBetasDriveBiasCorrection) {
 
 TEST_F(AdamWStateDictTest, BetaSettersRecomputeBiasCorrection) {
     run_effective_betas_step_and_compare(/*use_beta_setters=*/true);
+}
+
+// ====================================================================
+// Validation tests
+// ====================================================================
+
+using AdamWValidationTest = AdamWStateDictTest;
+
+TEST_F(AdamWValidationTest, RejectsLogicalShapeMismatchWithEqualPadding) {
+    using namespace ttml;
+
+    // Logical 31x32 and 32x32 both round up to one 32x32 tile, so only logical-shape
+    // validation can tell them apart.
+    const std::array<std::size_t, 4> param_shape = {1, 1, 32, 32};
+    const std::array<std::size_t, 4> grad_shape = {1, 1, 31, 32};
+    auto param = to_tt_bf16(test_utils::make_uniform_xarray<float>(param_shape, -1.0F, 1.0F, 123U));
+    auto grad = to_tt_bf16(test_utils::make_uniform_xarray<float>(grad_shape, -1.0F, 1.0F, 124U));
+    auto exp_avg = to_tt_bf16(test_utils::make_uniform_xarray<float>(param_shape, -1.0F, 1.0F, 125U));
+    auto exp_avg_sq = to_tt_bf16(test_utils::make_uniform_xarray<float>(param_shape, 0.0F, 1.0F, 126U));
+
+    EXPECT_ANY_THROW(ttml::metal::adamw(
+        param,
+        grad,
+        exp_avg,
+        exp_avg_sq,
+        /* max_exp_avg_sq */ std::nullopt,
+        /* lr */ 1e-3f,
+        /* beta1 */ 0.9f,
+        /* beta2 */ 0.999f,
+        /* beta1_pow */ 0.9f,
+        /* beta2_pow */ 0.999f,
+        /* epsilon */ 1e-8f,
+        /* weight_decay */ 0.0f));
 }
 
 // ====================================================================

--- a/tt-train/tests/optimizers/adamw_test.cpp
+++ b/tt-train/tests/optimizers/adamw_test.cpp
@@ -441,6 +441,136 @@ TEST_F(AdamWWeightDecaySkip1DTest, SkipsDecayOn1DParamsOnly) {
 }
 
 // ====================================================================
+// State-dict restore tests
+// A checkpoint's betas may differ from the constructor config; both the
+// moment updates and the bias correction (beta powers) must follow the
+// restored betas.
+// ====================================================================
+
+class AdamWStateDictTest : public ::testing::Test {
+public:
+    static void SetUpTestSuite() {
+        ttml::autograd::ctx().open_device();
+    }
+    static void TearDownTestSuite() {
+        ttml::autograd::ctx().close_device();
+    }
+
+protected:
+    void TearDown() override {
+        ttml::autograd::ctx().reset_graph();
+    }
+};
+
+// Builds an optimizer whose constructor betas differ from the effective ones, applies the
+// effective betas either through the state dict or through the setters, then verifies one
+// step against a CPU reference driven purely by the effective betas.
+static void run_effective_betas_step_and_compare(bool use_beta_setters) {
+    using namespace ttml;
+
+    const float lr = 1e-2f;
+    const float epsilon = 1e-8f;
+    const size_t initial_steps = 10;
+    const float constructor_beta1 = 0.9f;
+    const float constructor_beta2 = 0.999f;
+    const float effective_beta1 = 0.5f;
+    const float effective_beta2 = 0.9f;
+    const std::array<std::size_t, 4> shape = {1, 1, 128, 256};
+
+    autograd::ctx().set_seed(123U);
+    auto& gen = autograd::ctx().get_generator();
+    const uint32_t seed_param = gen();
+    const uint32_t seed_grad = gen();
+    const uint32_t seed_first_moment = gen();
+    const uint32_t seed_second_moment = gen();
+
+    xt::xarray<float> w0 = test_utils::make_uniform_xarray<float>(shape, -1.0F, 1.0F, seed_param);
+    xt::xarray<float> g0 = test_utils::make_uniform_xarray<float>(shape, -1.0F, 1.0F, seed_grad);
+    xt::xarray<float> m0 = test_utils::make_uniform_xarray<float>(shape, -1.0F, 1.0F, seed_first_moment);
+    xt::xarray<float> v0 = test_utils::make_uniform_xarray<float>(shape, 0.0F, 1.0F, seed_second_moment);
+
+    // CPU reference driven purely by the effective betas: the behavior a resumed run must match.
+    xt::xarray<float> w_cpu = w0;
+    CPUAdamW cpu_opt(lr, effective_beta1, effective_beta2, epsilon, /*weight_decay=*/0.0f, /*amsgrad=*/false);
+    cpu_opt.set_state(m0, v0, initial_steps);
+    cpu_opt.step(w_cpu, g0);
+
+    auto theta = autograd::create_tensor(to_tt_bf16(w0), true);
+    theta->set_grad(to_tt_bf16(g0));
+    serialization::NamedParameters params{{"theta", theta}};
+
+    optimizers::AdamWConfig cfg;
+    cfg.lr = lr;
+    cfg.beta1 = constructor_beta1;
+    cfg.beta2 = constructor_beta2;
+    cfg.epsilon = epsilon;
+    cfg.weight_decay = 0.0f;
+    optimizers::AdamW opt(params, cfg);
+
+    // When exercising the setters, the state dict carries the constructor betas so that only
+    // the setters introduce the effective ones.
+    const float state_beta1 = use_beta_setters ? constructor_beta1 : effective_beta1;
+    const float state_beta2 = use_beta_setters ? constructor_beta2 : effective_beta2;
+    {
+        serialization::StateDict state;
+        state["exp_avg"] = serialization::NamedParameters{{"theta", autograd::create_tensor(to_tt_bf16(m0), false)}};
+        state["exp_avg_sq"] =
+            serialization::NamedParameters{{"theta", autograd::create_tensor(to_tt_bf16(v0), false)}};
+        state["steps"] = initial_steps;
+        state["lr"] = lr;
+        state["beta1"] = state_beta1;
+        state["beta2"] = state_beta2;
+        state["epsilon"] = epsilon;
+        state["weight_decay"] = 0.0f;
+        state["amsgrad"] = false;
+        state["stochastic_rounding"] = false;
+        opt.set_state_dict(state);
+    }
+
+    if (use_beta_setters) {
+        opt.set_beta1(effective_beta1);
+        opt.set_beta2(effective_beta2);
+    }
+
+    EXPECT_EQ(opt.get_steps(), initial_steps);
+    EXPECT_FLOAT_EQ(opt.get_beta1(), effective_beta1);
+    EXPECT_FLOAT_EQ(opt.get_beta2(), effective_beta2);
+
+    opt.step();
+
+    auto result = core::to_xtensor(theta->get_value());
+    auto metrics = compute_error_metrics(w_cpu, result, "effective_betas");
+
+    const float mean_error_tolerance = 1e-3f;
+    const float max_error_tolerance = 1e-2f;
+    EXPECT_LE(metrics.mean_error, mean_error_tolerance) << "bias correction must follow the effective betas";
+    EXPECT_LE(metrics.max_error, max_error_tolerance) << "bias correction must follow the effective betas";
+
+    // Guard against a vacuous pass: a step whose moments follow the effective betas but whose
+    // bias correction still carries the constructor betas' powers must be clearly distinguishable
+    // from the reference.
+    xt::xarray<float> m1 = effective_beta1 * m0 + (1.0f - effective_beta1) * g0;
+    xt::xarray<float> v1 = effective_beta2 * v0 + (1.0f - effective_beta2) * (g0 * g0);
+    const float stale_bias_correction1 =
+        1.0f - std::pow(constructor_beta1, static_cast<float>(initial_steps)) * effective_beta1;
+    const float stale_bias_correction2 =
+        1.0f - std::pow(constructor_beta2, static_cast<float>(initial_steps)) * effective_beta2;
+    xt::xarray<float> w_stale =
+        w0 - lr * (m1 / stale_bias_correction1) / (xt::sqrt(v1 / stale_bias_correction2) + epsilon);
+    auto stale_metrics = compute_error_metrics(w_cpu, w_stale, "stale_bias_correction");
+    EXPECT_GT(stale_metrics.mean_error, mean_error_tolerance)
+        << "constructor and effective betas too close to distinguish; test is not meaningful";
+}
+
+TEST_F(AdamWStateDictTest, RestoredBetasDriveBiasCorrection) {
+    run_effective_betas_step_and_compare(/*use_beta_setters=*/false);
+}
+
+TEST_F(AdamWStateDictTest, BetaSettersRecomputeBiasCorrection) {
+    run_effective_betas_step_and_compare(/*use_beta_setters=*/true);
+}
+
+// ====================================================================
 // AMSGrad Tests
 // Test AdamW with AMSGrad variant enabled
 // ====================================================================

--- a/tt-train/tests/optimizers/adamw_test.cpp
+++ b/tt-train/tests/optimizers/adamw_test.cpp
@@ -514,8 +514,7 @@ static void run_effective_betas_step_and_compare(bool use_beta_setters) {
     {
         serialization::StateDict state;
         state["exp_avg"] = serialization::NamedParameters{{"theta", autograd::create_tensor(to_tt_bf16(m0), false)}};
-        state["exp_avg_sq"] =
-            serialization::NamedParameters{{"theta", autograd::create_tensor(to_tt_bf16(v0), false)}};
+        state["exp_avg_sq"] = serialization::NamedParameters{{"theta", autograd::create_tensor(to_tt_bf16(v0), false)}};
         state["steps"] = initial_steps;
         state["lr"] = lr;
         state["beta1"] = state_beta1;

--- a/tt-train/tests/optimizers/sgd_test.cpp
+++ b/tt-train/tests/optimizers/sgd_test.cpp
@@ -11,6 +11,7 @@
 
 #include "autograd/auto_context.hpp"
 #include "core/tt_tensor_utils.hpp"
+#include "metal/operations.hpp"
 #include "optimizers/sgd.hpp"
 #include "optimizers/sgd_composite.hpp"
 #include "test_utils/random_data.hpp"
@@ -335,3 +336,112 @@ static const ParityCase kNesterovWDNightlyCases[] = {
 
 INSTANTIATE_TEST_SUITE_P(
     NIGHTLY_SGDNesterovWeightDecayParity, SGDParityTest, ::testing::ValuesIn(kNesterovWDNightlyCases), CaseName);
+
+// ====================================================================
+// Late momentum-buffer initialization
+// A buffer's first update must seed it with the raw gradient (buf = g,
+// PyTorch semantics) even when other parameters have already advanced
+// the global step count.
+// ====================================================================
+
+class SGDLateMomentumTest : public ::testing::Test {
+public:
+    static void SetUpTestSuite() {
+        ttml::autograd::ctx().open_device();
+    }
+    static void TearDownTestSuite() {
+        ttml::autograd::ctx().close_device();
+    }
+
+protected:
+    void TearDown() override {
+        ttml::autograd::ctx().reset_graph();
+    }
+};
+
+// Runs two parameters where only "early" receives gradients for the first two steps and
+// "late" receives its first gradient on the third, then verifies the late buffer holds the
+// raw gradient despite nonzero dampening.
+template <typename Optimizer, typename Config>
+static void run_late_momentum_case(const char* buffers_key) {
+    using namespace ttml;
+
+    const std::array<std::size_t, 4> shape = {1, 1, 32, 32};
+    const float dampening = 0.5f;
+
+    autograd::ctx().set_seed(123U);
+    auto& gen = autograd::ctx().get_generator();
+    xt::xarray<float> w_early = test_utils::make_uniform_xarray<float>(shape, -1.0F, 1.0F, gen());
+    xt::xarray<float> g_early = test_utils::make_uniform_xarray<float>(shape, -1.0F, 1.0F, gen());
+    xt::xarray<float> w_late = test_utils::make_uniform_xarray<float>(shape, -1.0F, 1.0F, gen());
+    // Bounded away from zero so the raw gradient and its dampened value differ everywhere.
+    xt::xarray<float> g_late = test_utils::make_uniform_xarray<float>(shape, 0.25F, 1.0F, gen());
+
+    auto theta_early = autograd::create_tensor(to_tt(w_early), true);
+    auto theta_late = autograd::create_tensor(to_tt(w_late), true);
+    ttml::serialization::NamedParameters params{{"early", theta_early}, {"late", theta_late}};
+
+    Config cfg;
+    cfg.lr = 1e-2f;
+    cfg.momentum = 0.9f;
+    cfg.dampening = dampening;
+    Optimizer opt(params, cfg);
+
+    // Advance the global step with only the early parameter receiving gradients.
+    theta_early->set_grad(to_tt(g_early));
+    opt.step();
+    opt.step();
+
+    // The late parameter's first gradient arrives at a nonzero global step.
+    theta_late->set_grad(to_tt(g_late));
+    opt.step();
+
+    auto state = opt.get_state_dict();
+    const auto& buffers = std::get<ttml::serialization::NamedParameters>(state.at(buffers_key));
+    auto buf_late = ttml::core::to_xtensor(buffers.at("late")->get_value());
+
+    auto g_late_bf16 = ttml::core::to_xtensor(theta_late->get_grad());
+    size_t num_mismatches = compare_tensors(g_late_bf16, buf_late, w_late, g_late);
+    EXPECT_EQ(num_mismatches, 0) << "a buffer's first update must seed it with the raw gradient";
+
+    // Guard against a vacuous pass: the dampened seed must be distinguishable from the raw
+    // gradient for every element.
+    for (size_t i = 0; i < g_late_bf16.size(); ++i) {
+        ASSERT_NE(g_late_bf16.flat(i), (1.0f - dampening) * g_late_bf16.flat(i));
+    }
+}
+
+TEST_F(SGDLateMomentumTest, FusedFirstLateUpdateSeedsRawGradient) {
+    run_late_momentum_case<ttml::optimizers::SGD, ttml::optimizers::SGDConfig>("momentum");
+}
+
+TEST_F(SGDLateMomentumTest, CompositeFirstLateUpdateSeedsRawGradient) {
+    run_late_momentum_case<ttml::optimizers::SGDComposite, ttml::optimizers::SGDCompositeConfig>("theta");
+}
+
+// ====================================================================
+// Validation tests
+// ====================================================================
+
+using SGDValidationTest = SGDLateMomentumTest;
+
+TEST_F(SGDValidationTest, RejectsLogicalShapeMismatchWithEqualPadding) {
+    using namespace ttml;
+
+    // Logical 31x32 and 32x32 both round up to one 32x32 tile, so only logical-shape
+    // validation can tell them apart.
+    const std::array<std::size_t, 4> param_shape = {1, 1, 32, 32};
+    const std::array<std::size_t, 4> grad_shape = {1, 1, 31, 32};
+    auto param = to_tt(test_utils::make_uniform_xarray<float>(param_shape, -1.0F, 1.0F, 123U));
+    auto grad = to_tt(test_utils::make_uniform_xarray<float>(grad_shape, -1.0F, 1.0F, 124U));
+
+    EXPECT_ANY_THROW(ttml::metal::sgd(
+        param,
+        grad,
+        /* lr */ 1e-2f,
+        /* momentum */ 0.0f,
+        /* dampening */ 0.0f,
+        /* weight_decay */ 0.0f,
+        /* nesterov */ false,
+        /* momentum_buffer */ std::nullopt));
+}


### PR DESCRIPTION
Fixes #53212

## What

- **State-restore ordering**: `AdamW::set_state_dict` computed beta powers (`set_steps`) before restoring the checkpointed betas — resuming with different betas left bias correction permanently wrong. Fixed in `adamw.cpp` **and** `adamw_full_precision.cpp` (exact copy of the bug); `set_beta1/set_beta2` now recompute the powers, and the power derivation lives in one place (899b0322652). MorehAdamW/AdamWComposite compute powers inline and were never affected. Known sibling gap, out of scope here: `adamw_composite` doesn't restore betas from the state dict at all — tracked in #53212.
- **State-tensor validation**: `ttnn::prim::adamw`/`sgd` now TT_FATAL when grad/exp_avg/exp_avg_sq/max_exp_avg_sq/momentum don't match the param's **logical** shape as well as its padded shape (d05b82a339, after review). Padded-shape equality alone let e.g. a logical 31x32 grad pass against a 32x32 param (both pad to one tile); readers previously walked past a smaller tensor's extent — silent garbage moments. The padded check stays, since tile counts and reader/writer extents come from the parameter's padded allocation.
- **SGD first-step dampening**: PyTorch skips dampening on each buffer's *first* update; both implementations gated on global `m_steps == 0`, so lazily-unfrozen params got `(1−dampening)·g` instead of `buf = g`. Now per-buffer, changed identically in fused and composite so bitwise parity is structurally preserved; common path (all buffers start at step 0) is bit-identical to before. Deliberate documented edge: a never-updated preallocated buffer round-trips a checkpoint as initialized (matching the pre-existing `m_steps != 0` resume behavior); persisting the initialized set would be a state-dict format change.
- **Tests** (all device-green):
  - `AdamWStateDictTest` cases where constructor betas ≠ effective betas, compared against a CPU reference driven purely by effective betas — with an analytic vacuous-pass guard asserting the old buggy result is distinguishable from the reference.
  - `AdamWFullPrecisionStateDictTest` — mirrors the fused cases for `adamw_full_precision.cpp`, which previously had no test that could catch its copy of the bug.
  - `AdamWValidationTest.RejectsLogicalShapeMismatchWithEqualPadding` / `SGDValidationTest.RejectsLogicalShapeMismatchWithEqualPadding` — negative cases for the logical-shape check (equal single-tile padding, must throw).
  - `SGDLateMomentumTest` — a parameter receiving its first gradient at a nonzero global step must get `buf = g` exactly (per-buffer first-step dampening skip), on both fused and composite.

## Validation checklist

- [x] Full `adamw_test.cpp` — both `AdamWStateDictTest` cases FAIL on old kernels and PASS on fixed (before/after complete); `sgd_test.cpp` parity green
- [x] `tests/python/test_optimizer_state_dict.py` — full optimizer suites green on BH
- [x] Negative check: mismatched grad/state shapes TT_FATAL — logical-shape negative tests (equal padding) green on device, alongside the padded-shape validation
- [x] `adamw_full_precision` coverage: dedicated `AdamWFullPrecisionStateDictTest` fail-old/pass-fixed on device (replaces the planned manual resume check for this file)
- [ ] Short real resume (checkpoint → restore → sane loss trajectory) — end-to-end sanity, not yet run; unit coverage above now spans every touched file
- Perf/memory: benchmark JSONs collected on baseline and fixed builds (gram/adamw/mla/rope); comparison pending

## Device verification (BH galaxy, bh_sc5 quad)

All runs on Blackhole galaxies. Baseline ("old kernels") = `origin/main` @ f941b98652e plus only the new tests.

- Both `AdamWStateDictTest` cases FAIL on old kernels and PASS on fixed — before/after complete for the state-restore ordering fix; `AdamWFullPrecisionStateDictTest` covers the duplicated bug in the full-precision path.
- Logical-shape negative tests (AdamW and SGD), `SGDLateMomentumTest`, and fused/composite SGD parity all green on the fixed build.
- Full optimizer suites green; single-chip BH suite 605 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ayerofieiev/kernel-fix/adamw-state-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ayerofieiev/kernel-fix/adamw-state-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ayerofieiev/kernel-fix/adamw-state-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ayerofieiev/kernel-fix/adamw-state-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ayerofieiev/kernel-fix/adamw-state-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ayerofieiev/kernel-fix/adamw-state-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ayerofieiev/kernel-fix/adamw-state-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ayerofieiev/kernel-fix/adamw-state-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ayerofieiev/kernel-fix/adamw-state-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ayerofieiev/kernel-fix/adamw-state-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ayerofieiev/kernel-fix/adamw-state-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ayerofieiev/kernel-fix/adamw-state-2026-08-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ayerofieiev/kernel-fix/adamw-state-2026-08-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ayerofieiev/kernel-fix/adamw-state-2026-08-14)