### PR TITLE
Remove prefill-team tests from demo SP release pipeline

### DIFF
--- a/.github/workflows/demo-sp-release.yaml
+++ b/.github/workflows/demo-sp-release.yaml
@@ -39,7 +39,6 @@ on:
         type: choice
         options:
           - all
-          - deepseek_prefill
           - deepseek_decode
           - deepseek_unit_tests
           - wan22
@@ -73,22 +72,7 @@ jobs:
       platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
       enable-lto: ${{ inputs.enable-lto || false }}
       build-wheel: true
-      tracy: true # required for device-perf tests (e.g. galaxy DeepSeek Prefill PERF)
-
-  deepseek-prefill-tests:
-    name: "DeepSeek Prefill Tests"
-    needs: [build-artifact]
-    if: ${{ inputs.test-group == 'all' || inputs.test-group == 'deepseek_prefill' || github.event_name == 'schedule' }}
-    secrets: inherit
-    uses: ./.github/workflows/demo-sp-release-impl.yaml
-    with:
-      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      enabled-skus: bh_galaxy,bh_loudbox
-      model: deepseek_prefill
-      mlperf-read-only: ${{ inputs.mlperf-read-only != false }}
-      job-prefix: "[DeepSeek Prefill] "
+      tracy: true # required for device-perf tests (e.g. Galaxy DiT Wan2.2 model perf)
 
   deepseek-decode-tests:
     name: "DeepSeek Decode Tests (B1 Decoder Block)"

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -1,6 +1,6 @@
 # This file defines the test matrix for the SP Demo Release pipeline.
 # This pipeline includes tests for:
-#   - Galaxy DeepSeek Prefill
+#   - DeepSeek V3 B1 (decode, host IO, unit tests)
 #   - Wan 2.2 (across Galaxy and T3K)
 
 # Each entry represents a parallel job with the following keys:
@@ -12,82 +12,6 @@
 #   model: Model identifier for filtering tests.
 
 # For max allowed timeout refer to .github/time_budget.yaml
-
-# ============================================================================
-# Galaxy DeepSeek Prefill Tests
-# ============================================================================
-
-- name: "(Galaxy) DeepSeek Prefill e2e tests"
-  cmd: |
-    uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528
-    export HF_HOME=/mnt/MLPerf/huggingface/hub
-    EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-golden pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and non_balanced and fabric2d and no_determinism and iter5 and dense and pcc and not pretrained" -vvv --tb=short
-    EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-golden pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and non_balanced and fabric2d and no_determinism and iter5 and moe and pcc and not pretrained" -vvv --tb=short
-    EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-golden pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and non_balanced and fabric2d and with_determinism and iter5 and dense and smoke and random and not pretrained" -vvv --tb=short
-    EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-golden pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and non_balanced and fabric2d and with_determinism and iter5 and moe and smoke and random and not pretrained" -vvv --tb=short
-    EXPECT_NUM_TESTS=1 \
-    TT_DS_PREFILL_TTNN_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache-prefill-fresh \
-    TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-golden-32a3e8b6/ \
-    pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py -k "ds_prefill and pretrained and e256_device_fp32 and fabric2d-mesh-8x4 and 61_layers and balanced and right_pad and smoke and no_determinism and iter25 and 25600 and longbook" -vvv --tb=short --timeout=1800
-    # to replace test_prefill_transformer.py with add kimi and deepseek runners tests
-  model: deepseek_prefill
-  skus:
-    bh_galaxy:
-      timeout: 20
-  owner_id: U0ACLAM77PS # Kosta Grujcic
-  team: models
-
-- name: "(Galaxy) DeepSeek Prefill Perf tests"
-  cmd: |
-    uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528
-    export HF_HOME=/mnt/MLPerf/huggingface/hub
-    export MESH_DEVICE=TG
-    EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-golden pytest models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py -k "block_8x4 and fabric2d and layer0" -vvv --tb=short
-    EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-golden pytest models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py -k "block_8x4 and fabric2d and layer3" -vvv --tb=short
-    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py::test_deepseek_v3_moe_perf_galaxy -vvv --tb=short
-    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py::test_deepseek_v3_moe_perf_galaxy_pad50 -vvv --tb=short
-    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py::test_deepseek_v3_mla_perf_galaxy -vvv --tb=short
-    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py::test_kimi_mla_chunked_perf_galaxy -vvv --tb=short
-  model: deepseek_prefill
-  skus:
-    bh_galaxy:
-      timeout: 30
-  owner_id: U0ACLAM77PS # Kosta Grujcic
-  team: models
-
-- name: "(bh loudbox) DeepSeek Prefill modules"
-  cmd: |
-    # deepseek and kimi prefill on 2x4 mesh
-    EXPECT_NUM_TESTS=2 pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_ds_mla -k "2x4 and not 32x4 and random and scaled_sl and check_pcc and 100k and fabric2d" -vvv --tb=short
-    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_kimi_mla -k "2x4 and random and scaled_sl and check_pcc and seq5k and fabric2d" -vvv --tb=short
-    EXPECT_NUM_TESTS=1 python -m pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k 'maxedge-1u and kimi and cpu and 2x4 and fabric2d and no_determinism'
-    EXPECT_NUM_TESTS=1 python -m pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k 'maxedge-1u and ds and cpu and 2x4 and fabric2d and no_determinism'
-    # deepseek and kimi moe blocks. NOTE: pcc-device-256 (DSv3) is pinned exact + `not pad50` so it stays
-    # 1 test — bare `pcc-device` would substring-match `pcc-device-glm-256` and inflate the count.
-    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe -k "linear-8 and pcc-device-256 and not pad50" -vvv --tb=short --timeout=1800
-    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_kimi_moe -k "linear-8 and 5k and not 25k and not perf" -vvv --tb=short --timeout=1800
-  model: deepseek_prefill
-  skus:
-    bh_loudbox:
-      timeout: 30
-  owner_id: U0ACLAM77PS # Kosta Grujcic
-  team: models
-
-- name: "(bh loudbox) GLM-5.2 Prefill modules"
-  cmd: |
-    # GLM-5.2 counterparts to the Kimi lines above. GLM's MLA is DSA/sparse (no absorbed-MLA analog), so
-    # it's its own stage with its own MLA ref cache; no EXPECT_NUM_TESTS since _sparse_cases emits a
-    # box-dependent seq count.
-    DS_SPARSE_FABRIC=fabric2d GLM52_MLA_REF_CACHE=/tmp/glm_5_2_mla_ref_cache pytest models/demos/deepseek_v3_d_p/tests/sparse_mla/test_sparse_mla.py -k "glm_5_2 and 2x4 and fabric2d" -vvv --tb=short
-    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe -k "linear-8 and pcc-device-glm-256 and not pad50" -vvv --tb=short --timeout=1800
-  model: deepseek_prefill
-  skus:
-    bh_loudbox:
-      timeout: 30
-  owner_id: U09LK84G4TF  # Nikola Milicevic
-  team: models
 
 # ============================================================================
 # DeepSeek V3 B1 Host IO and Decoder Sweep Tests (Blitz) - Blackhole P300 and Galaxy


### PR DESCRIPTION
Removes the prefill-team-owned jobs from `tests/pipeline_reorg/demo_sp_release_tests.yaml`:

- `(bh loudbox) GLM-5.2 Prefill modules`
- `(bh loudbox) DeepSeek Prefill modules`
- `(Galaxy) DeepSeek Prefill Perf tests`
- `(Galaxy) DeepSeek Prefill e2e tests`

That empties the `deepseek_prefill` model group, so the `deepseek-prefill-tests`
caller job in `.github/workflows/demo-sp-release.yaml` (and its `test-group`
choice) is removed too — otherwise `prepare_test_matrix.py` would hard-fail with
"No tests found for model 'deepseek_prefill'" on every scheduled run. No
`bh_loudbox` jobs remain in this pipeline.

Verified locally: `verify_time_budget.py` passes and `prepare_test_matrix.py`
for `bh_galaxy,bh_loudbox` yields 8 jobs, none of them prefill.

Closes #52883

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kgrujcic/52857-demo-sp)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kgrujcic/52857-demo-sp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kgrujcic/52857-demo-sp)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kgrujcic/52857-demo-sp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kgrujcic/52857-demo-sp)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kgrujcic/52857-demo-sp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kgrujcic/52857-demo-sp)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kgrujcic/52857-demo-sp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kgrujcic/52857-demo-sp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kgrujcic/52857-demo-sp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kgrujcic/52857-demo-sp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kgrujcic/52857-demo-sp)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kgrujcic/52857-demo-sp)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kgrujcic/52857-demo-sp)