### PR TITLE
Force Metal 2.0 legality checks on (ignore the skip_validation bypass)

### DIFF
--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -498,6 +498,10 @@ void AttachBorrowedDFBBuffers(
 // ============================================================================
 
 void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip_validation) {
+    // TEMPORARY (op-porting window): the skip_validation bypass is unhooked — see the note in
+    // BuildProgramFromSpec. To restore, delete this line.
+    skip_validation = false;
+
     log_debug(tt::LogMetal, "Setting ProgramRunArgs");
 
     // Metal 2.0 run-args API: only valid on a Program created from a ProgramSpec (the run-args
@@ -1088,6 +1092,12 @@ void ValidateUpdateProgramRunArgs(const Program& program, const ProgramRunArgs& 
 }
 
 void UpdateProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip_validation) {
+    // TEMPORARY (op-porting window): the skip_validation bypass is unhooked — see the note in
+    // BuildProgramFromSpec. This is the one that matters most for the custom-concept ports: the
+    // TensorSpec check reached from here is their only detection of a too-loose program hash.
+    // To restore, delete this line.
+    skip_validation = false;
+
     log_debug(tt::LogMetal, "Updating ProgramRunArgs (partial fast-path)");
 
     detail::ProgramImpl& program_impl = program.impl();
@@ -1259,6 +1269,10 @@ void UpdateProgramRunArgs(Program& program, const ProgramRunArgs& params, bool s
 }
 
 ProgramRunArgs MergeProgramRunArgs(ProgramRunArgs base, std::span<const ProgramRunArgs> rest, bool skip_validation) {
+    // TEMPORARY (op-porting window): the skip_validation bypass is unhooked — see the note in
+    // BuildProgramFromSpec. To restore, delete this line.
+    skip_validation = false;
+
     for (const ProgramRunArgs& other : rest) {
         // Tensor args: union by TensorParameter name (disjoint).
         for (const auto& [name, arg] : other.tensor_args) {

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2843,6 +2843,13 @@ std::set<experimental::quasar::QuasarComputeProcessor> GetComputeProcessorSet(Co
 namespace {
 
 Program BuildProgramFromSpec(distributed::MeshDevice& mesh_device, const ProgramSpec& spec, bool skip_validation) {
+    // TEMPORARY (op-porting window): the skip_validation bypass is unhooked. Metal 2.0 legality
+    // checks are a ported op's primary safety net, and they must not be optional while ops are
+    // being ported. Every caller gets them, whatever it asks for. This covers all three public
+    // spec entry points (MakeProgramFromSpec, MakeMeshWorkloadFromSpec[s]), which funnel here.
+    // To restore the bypass, delete this line; the parameter is plumbed through untouched.
+    skip_validation = false;
+
     log_debug(tt::LogMetal, "Creating Program from ProgramSpec ({})", spec.name);
 
     // Step 1a: Collect derived data (builds lookup tables, checks structural invariants)


### PR DESCRIPTION
Metal 2.0's public entry points take a skip_validation flag, and the only production caller — the TTNN adapter — passes it from a config knob that defaults to off. The intent had been checks on the slow path and off on the fast one (safe, since the fast path is the TTNN infra's); it went in the other way around, so ops were being ported and verified with no legality checking on the path that builds the Program.

Unhook the bypass in the runtime for the duration of ops porting: each public entry point ignores its argument and always validates. The parameters stay plumbed through untouched, so restoring the bypass is deleting four lines.

This also restores the custom-concept ports' only detection of a too-loose program hash: the TensorSpec check reached from UpdateProgramRunArgs.

Nothing changes in TTNN — validate_program_args and the adapter's reads of it simply go inert, leaving the existing CI overrides harmless.

unit_tests_api: 1985 run, 0 failed.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/disable-legality-bypass)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/disable-legality-bypass)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/disable-legality-bypass)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/disable-legality-bypass)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/disable-legality-bypass)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/disable-legality-bypass)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/disable-legality-bypass)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/disable-legality-bypass)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/disable-legality-bypass)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/disable-legality-bypass)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/disable-legality-bypass)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/disable-legality-bypass)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/disable-legality-bypass)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/disable-legality-bypass)