### PR TITLE
fix(ci): check-harbor fallback doesn't fire when caller is schedule-triggered

### DIFF
--- a/.github/workflows/bisect-dispatch.yaml
+++ b/.github/workflows/bisect-dispatch.yaml
@@ -104,6 +104,7 @@ jobs:
 
   test-dispatch:
     needs: [check-harbor, determine-runner-config]
+    if: ${{ !cancelled() && needs.determine-runner-config.result == 'success' }}
     timeout-minutes: 1440
     runs-on: ${{ fromJSON(needs.determine-runner-config.outputs.runs-on-labels) }}
     container:

--- a/.github/workflows/blackhole-e2e-tests.yaml
+++ b/.github/workflows/blackhole-e2e-tests.yaml
@@ -121,6 +121,7 @@ jobs:
           echo "matrix=$matrix_output" >> $GITHUB_OUTPUT
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -135,6 +136,7 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
   blackhole-e2e-tests:
     needs: [check-harbor, build-artifact, generate-card-matrix]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' && needs.generate-card-matrix.result == 'success' }}
     secrets: inherit
     uses: ./.github/workflows/blackhole-e2e-tests-impl.yaml
     strategy:

--- a/.github/workflows/blaze-models-prefill-tests.yaml
+++ b/.github/workflows/blaze-models-prefill-tests.yaml
@@ -78,6 +78,7 @@ jobs:
 
   build-artifact:
     needs: [validate-test-type, check-harbor]
+    if: ${{ !cancelled() && needs.validate-test-type.result == 'success' }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read

--- a/.github/workflows/build-all-docker-images.yaml
+++ b/.github/workflows/build-all-docker-images.yaml
@@ -145,6 +145,7 @@ jobs:
   preflight:
     name: "Calculate Tags"
     needs: [check-harbor]
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     outputs:
       harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}

--- a/.github/workflows/build-and-test-wheels.yaml
+++ b/.github/workflows/build-and-test-wheels.yaml
@@ -10,6 +10,7 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read

--- a/.github/workflows/build-prefill-worker.yaml
+++ b/.github/workflows/build-prefill-worker.yaml
@@ -20,6 +20,7 @@ jobs:
   build:
     name: Build release-models image
     needs: check-harbor
+    if: ${{ !cancelled() }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/check-harbor.yaml
+++ b/.github/workflows/check-harbor.yaml
@@ -89,14 +89,23 @@ jobs:
             HEALTH_RESPONSE=$(curl --max-time 10 -sf "https://harbor.ci.tenstorrent.net/api/v2.0/health" 2>/dev/null || true)
           fi
 
-          # Validate the body is actually JSON before parsing it. A 200 with a
-          # non-JSON body (e.g. a proxy/maintenance page served while Harbor is
-          # degraded) is exactly the kind of response most likely when Harbor is
-          # unhealthy — jq would abort the whole script under `set -e` on that
-          # input, hard-failing the job instead of falling back like every other
-          # unavailable/unhealthy case here.
-          if [ -n "$HEALTH_RESPONSE" ] && echo "$HEALTH_RESPONSE" | jq -e . > /dev/null 2>&1; then
-            echo "$HEALTH_RESPONSE" | jq -r '.components[]? | select(.status != "healthy") | "\(.name):\(.status)"' | while IFS=: read -r name status; do
+          # Validate the body is not just JSON, but actually *shaped* like Harbor's
+          # health payload, before parsing it further. A 200 with a non-JSON body
+          # (e.g. a proxy/maintenance page) or JSON of the wrong shape (a root
+          # array, a scalar, or an object missing/mistyping .status) is exactly the
+          # kind of response most likely when Harbor is degraded -- checking JSON
+          # syntax alone (`jq -e .`) isn't enough, since a root array or wrong-typed
+          # .status still crashes the .components/.status lookups below with a jq
+          # type error; under `set -e` that hard-fails the job instead of falling
+          # back like every other unavailable/unhealthy case here. This single
+          # guard subsumes the syntax check too (jq itself errors on invalid JSON).
+          if [ -n "$HEALTH_RESPONSE" ] && echo "$HEALTH_RESPONSE" | jq -e 'type == "object" and (.status | type) == "string"' > /dev/null 2>&1; then
+            # Once the guard above passes, .status is known-good, but individual
+            # .components[] entries aren't schema-checked -- wrap each element's
+            # processing in its own `?` so one malformed entry (e.g. a scalar
+            # instead of an object) just produces no warning for that entry,
+            # rather than aborting the whole jq invocation for every component.
+            echo "$HEALTH_RESPONSE" | jq -r '.components[]? | (select(.status != "healthy") | "\(.name):\(.status)")?' | while IFS=: read -r name status; do
               echo "::warning title=Harbor Component Unhealthy::Component $name has status: $status"
             done
 

--- a/.github/workflows/check-harbor.yaml
+++ b/.github/workflows/check-harbor.yaml
@@ -96,7 +96,7 @@ jobs:
           # input, hard-failing the job instead of falling back like every other
           # unavailable/unhealthy case here.
           if [ -n "$HEALTH_RESPONSE" ] && echo "$HEALTH_RESPONSE" | jq -e . > /dev/null 2>&1; then
-            echo "$HEALTH_RESPONSE" | jq -r '.components[] | select(.status != "healthy") | "\(.name):\(.status)"' | while IFS=: read -r name status; do
+            echo "$HEALTH_RESPONSE" | jq -r '.components[]? | select(.status != "healthy") | "\(.name):\(.status)"' | while IFS=: read -r name status; do
               echo "::warning title=Harbor Component Unhealthy::Component $name has status: $status"
             done
 

--- a/.github/workflows/check-harbor.yaml
+++ b/.github/workflows/check-harbor.yaml
@@ -32,14 +32,26 @@ jobs:
         env:
           HARBOR_PREFIX: ${{ vars.HARBOR_PREFIX }}
           EVENT_NAME: ${{ github.event_name }}
+          # github.event_name reflects the *root* trigger of the whole run, which is
+          # still "schedule" when this reusable workflow is workflow_call'd from another
+          # workflow that itself happens to be cron-triggered (e.g. sanity-tests.yaml).
+          # github.event.schedule carries the actual cron string that fired, so comparing
+          # it against this workflow's own cron is what actually tells apart "I am running
+          # as my own standalone hourly monitor" from "I was called by someone else's cron".
+          SCHEDULE_CRON: ${{ github.event.schedule }}
         run: |
           set -euo pipefail
+
+          OWN_SCHEDULE_RUN=false
+          if [ "$EVENT_NAME" = "schedule" ] && [ "$SCHEDULE_CRON" = "0 * * * *" ]; then
+            OWN_SCHEDULE_RUN=true
+          fi
 
           HARBOR_HEALTHY=false
           if ! command -v jq > /dev/null 2>&1; then
             echo "::error title=Missing jq::jq is required to parse Harbor health responses. Docker pulls will fall back to direct GHCR."
             echo "harbor-prefix=" >> "$GITHUB_OUTPUT"
-            if [ "$EVENT_NAME" = "schedule" ]; then
+            if [ "$OWN_SCHEDULE_RUN" = "true" ]; then
               exit 1
             fi
             exit 0
@@ -83,6 +95,6 @@ jobs:
             echo "Harbor did not respond within timeout. Falling back to direct GHCR." >> "$GITHUB_STEP_SUMMARY"
           fi
 
-          if [ "$HARBOR_HEALTHY" != "true" ] && [ "$EVENT_NAME" = "schedule" ]; then
+          if [ "$HARBOR_HEALTHY" != "true" ] && [ "$OWN_SCHEDULE_RUN" = "true" ]; then
             exit 1
           fi

--- a/.github/workflows/check-harbor.yaml
+++ b/.github/workflows/check-harbor.yaml
@@ -11,6 +11,20 @@ on:
         type: string
         default: "tt-ubuntu-light"
         description: "Runner label for the Harbor health check job"
+      called-via-workflow-call:
+        required: false
+        type: boolean
+        default: true
+        description: >-
+          Internal marker, do not set explicitly. Defaults to true whenever this
+          workflow is invoked via workflow_call (input defaults are resolved for
+          that trigger); it is unset/empty on this workflow's own standalone
+          `schedule` trigger below, since the `inputs` context does not exist
+          for that event at all. Used to tell apart "I am check-harbor's own
+          hourly monitor" from "I was workflow_call'd by a workflow that
+          itself happens to be schedule-triggered" (e.g. sanity-tests.yaml) —
+          github.event_name/github.event.schedule can't distinguish the two,
+          since they're inherited from the whole run's root trigger either way.
     outputs:
       harbor-prefix:
         description: "Harbor pull-through prefix from org vars when healthy; empty to pull GHCR directly"
@@ -32,18 +46,21 @@ jobs:
         env:
           HARBOR_PREFIX: ${{ vars.HARBOR_PREFIX }}
           EVENT_NAME: ${{ github.event_name }}
-          # github.event_name reflects the *root* trigger of the whole run, which is
-          # still "schedule" when this reusable workflow is workflow_call'd from another
-          # workflow that itself happens to be cron-triggered (e.g. sanity-tests.yaml).
-          # github.event.schedule carries the actual cron string that fired, so comparing
-          # it against this workflow's own cron is what actually tells apart "I am running
-          # as my own standalone hourly monitor" from "I was called by someone else's cron".
-          SCHEDULE_CRON: ${{ github.event.schedule }}
+          CALLED_VIA_WORKFLOW_CALL: ${{ inputs.called-via-workflow-call }}
         run: |
           set -euo pipefail
 
+          # Only check-harbor's own standalone hourly monitor should hard-fail on an
+          # unhealthy Harbor (so the failure pages someone); every workflow_call
+          # consumer must always fall back gracefully instead. EVENT_NAME alone can't
+          # tell the two apart (it's inherited from the whole run's root trigger, so
+          # it reads "schedule" even when a schedule-triggered caller like
+          # sanity-tests.yaml workflow_call's us) — CALLED_VIA_WORKFLOW_CALL resolves
+          # to its declared default ("true") only when this run *is* a workflow_call,
+          # since the `inputs` context plainly does not exist on the standalone
+          # `schedule` trigger.
           OWN_SCHEDULE_RUN=false
-          if [ "$EVENT_NAME" = "schedule" ] && [ "$SCHEDULE_CRON" = "0 * * * *" ]; then
+          if [ "$EVENT_NAME" = "schedule" ] && [ "$CALLED_VIA_WORKFLOW_CALL" != "true" ]; then
             OWN_SCHEDULE_RUN=true
           fi
 
@@ -72,7 +89,13 @@ jobs:
             HEALTH_RESPONSE=$(curl --max-time 10 -sf "https://harbor.ci.tenstorrent.net/api/v2.0/health" 2>/dev/null || true)
           fi
 
-          if [ -n "$HEALTH_RESPONSE" ]; then
+          # Validate the body is actually JSON before parsing it. A 200 with a
+          # non-JSON body (e.g. a proxy/maintenance page served while Harbor is
+          # degraded) is exactly the kind of response most likely when Harbor is
+          # unhealthy — jq would abort the whole script under `set -e` on that
+          # input, hard-failing the job instead of falling back like every other
+          # unavailable/unhealthy case here.
+          if [ -n "$HEALTH_RESPONSE" ] && echo "$HEALTH_RESPONSE" | jq -e . > /dev/null 2>&1; then
             echo "$HEALTH_RESPONSE" | jq -r '.components[] | select(.status != "healthy") | "\(.name):\(.status)"' | while IFS=: read -r name status; do
               echo "::warning title=Harbor Component Unhealthy::Component $name has status: $status"
             done
@@ -88,6 +111,11 @@ jobs:
               echo "### Harbor Registry Unhealthy" >> "$GITHUB_STEP_SUMMARY"
               echo "Overall status: \`$OVERALL_STATUS\`. Falling back to direct GHCR." >> "$GITHUB_STEP_SUMMARY"
             fi
+          elif [ -n "$HEALTH_RESPONSE" ]; then
+            echo "::error title=Harbor Unavailable::Harbor registry responded with unparseable data. Docker pulls will fall back to direct GHCR."
+            echo "harbor-prefix=" >> "$GITHUB_OUTPUT"
+            echo "### Harbor Registry Unavailable" >> "$GITHUB_STEP_SUMMARY"
+            echo "Harbor responded, but not with valid JSON (possibly a proxy/maintenance page). Falling back to direct GHCR." >> "$GITHUB_STEP_SUMMARY"
           else
             echo "::error title=Harbor Unavailable::Harbor registry did not respond. Docker pulls will fall back to direct GHCR."
             echo "harbor-prefix=" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/code-coverage.yaml
+++ b/.github/workflows/code-coverage.yaml
@@ -27,6 +27,7 @@ jobs:
 
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -43,6 +44,7 @@ jobs:
 
   run-ttnn-tests:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     uses: ./.github/workflows/ttnn-sanity-tests-impl.yaml
     secrets: inherit
     with:

--- a/.github/workflows/compile-time-tracker.yaml
+++ b/.github/workflows/compile-time-tracker.yaml
@@ -15,6 +15,7 @@ jobs:
 
   track-compile-time:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     name: "⏱️ Track Compile Time"
     runs-on: tt-ubuntu-2204-large-stable
     timeout-minutes: 120

--- a/.github/workflows/demo-sp-release.yaml
+++ b/.github/workflows/demo-sp-release.yaml
@@ -62,6 +62,7 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read

--- a/.github/workflows/docs-latest-public-wrapper.yaml
+++ b/.github/workflows/docs-latest-public-wrapper.yaml
@@ -32,6 +32,7 @@ jobs:
 
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read

--- a/.github/workflows/fabric-multihost-exabox.yaml
+++ b/.github/workflows/fabric-multihost-exabox.yaml
@@ -21,6 +21,7 @@ jobs:
 
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read

--- a/.github/workflows/galaxy-deepseek-tests.yaml
+++ b/.github/workflows/galaxy-deepseek-tests.yaml
@@ -67,6 +67,7 @@ jobs:
 
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -138,6 +139,7 @@ jobs:
   # ── Galaxy tests (N-x module tests, runs in parallel with T3K gate) ────
   Galaxy-DeepSeek-tests:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     secrets: inherit
     uses: ./.github/workflows/galaxy-deepseek-tests-impl.yaml
     with:

--- a/.github/workflows/galaxy-demo-tests.yaml
+++ b/.github/workflows/galaxy-demo-tests.yaml
@@ -50,6 +50,7 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -62,6 +63,7 @@ jobs:
       build-inplace-wheel: true
   galaxy-demo-tests:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     secrets: inherit
     uses: ./.github/workflows/galaxy-demo-tests-impl.yaml
     with:

--- a/.github/workflows/galaxy-e2e-tests.yaml
+++ b/.github/workflows/galaxy-e2e-tests.yaml
@@ -43,6 +43,7 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -55,6 +56,7 @@ jobs:
       build-inplace-wheel: true
   galaxy-e2e-tests:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     uses: ./.github/workflows/galaxy-e2e-tests-impl.yaml
     secrets: inherit
     with:

--- a/.github/workflows/galaxy-health.yaml
+++ b/.github/workflows/galaxy-health.yaml
@@ -49,6 +49,7 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -62,6 +63,7 @@ jobs:
 
   galaxy-health-test:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     secrets: inherit
     uses: ./.github/workflows/galaxy-health-impl.yaml
     with:

--- a/.github/workflows/galaxy-integration-tests.yaml
+++ b/.github/workflows/galaxy-integration-tests.yaml
@@ -46,6 +46,7 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -59,6 +60,7 @@ jobs:
       build-inplace-wheel: true
   galaxy-integration-tests:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     uses: ./.github/workflows/galaxy-integration-tests-impl.yaml
     secrets: inherit
     with:

--- a/.github/workflows/galaxy-multi-user-isolation-tests.yaml
+++ b/.github/workflows/galaxy-multi-user-isolation-tests.yaml
@@ -43,6 +43,7 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read

--- a/.github/workflows/galaxy-perf-tests.yaml
+++ b/.github/workflows/galaxy-perf-tests.yaml
@@ -54,6 +54,7 @@ jobs:
 
   build-artifact-profiler:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -69,6 +70,7 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
   galaxy-perf-tests:
     needs: [check-harbor, build-artifact-profiler]
+    if: ${{ !cancelled() && needs.build-artifact-profiler.result == 'success' }}
     secrets: inherit
     uses: ./.github/workflows/galaxy-perf-tests-impl.yaml
     with:

--- a/.github/workflows/galaxy-profiler-tests.yaml
+++ b/.github/workflows/galaxy-profiler-tests.yaml
@@ -34,6 +34,7 @@ jobs:
 
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -49,6 +50,7 @@ jobs:
 
   galaxy-profiler-tests:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     uses: ./.github/workflows/galaxy-profiler-tests-impl.yaml
     secrets: inherit
     with:

--- a/.github/workflows/galaxy-sanity.yaml
+++ b/.github/workflows/galaxy-sanity.yaml
@@ -44,6 +44,7 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -57,6 +58,7 @@ jobs:
 
   galaxy-sanity-test:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     secrets: inherit
     uses: ./.github/workflows/galaxy-sanity-impl.yaml
     with:

--- a/.github/workflows/galaxy-stress-tests.yaml
+++ b/.github/workflows/galaxy-stress-tests.yaml
@@ -48,6 +48,7 @@ jobs:
 
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -61,6 +62,7 @@ jobs:
 
   galaxy-stress-test:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     secrets: inherit
     uses: ./.github/workflows/galaxy-stress-tests-impl.yaml
     with:

--- a/.github/workflows/galaxy-unit-tests.yaml
+++ b/.github/workflows/galaxy-unit-tests.yaml
@@ -49,6 +49,7 @@ jobs:
 
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -63,6 +64,7 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
   galaxy-unit-tests:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     secrets: inherit
     uses: ./.github/workflows/galaxy-unit-tests-impl.yaml
     with:

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -240,6 +240,7 @@ jobs:
 
   resolve-docker-pull-refs:
     needs: [check-harbor, build]
+    if: ${{ !cancelled() && needs.build.result == 'success' }}
     uses: ./.github/workflows/resolve-docker-pull-refs.yaml
     with:
       harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
@@ -249,6 +250,7 @@ jobs:
 
   resolve-docker-pull-refs-tsan:
     needs: [check-harbor, build-tsan]
+    if: ${{ !cancelled() && needs.build-tsan.result == 'success' }}
     uses: ./.github/workflows/resolve-docker-pull-refs.yaml
     with:
       harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
@@ -256,6 +258,7 @@ jobs:
 
   resolve-docker-pull-refs-asan:
     needs: [check-harbor, build-asan]
+    if: ${{ !cancelled() && needs.build-asan.result == 'success' }}
     uses: ./.github/workflows/resolve-docker-pull-refs.yaml
     with:
       harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
@@ -306,6 +309,7 @@ jobs:
 
   triage-tests:
     needs: [build, resolve-docker-pull-refs, find-changes, check-harbor]
+    if: ${{ !cancelled() && needs.build.result == 'success' && needs.resolve-docker-pull-refs.result == 'success' && needs.find-changes.result == 'success' }}
     secrets: inherit
     uses: ./.github/workflows/triage-tests-impl.yaml
     with:

--- a/.github/workflows/metal-run-microbenchmarks.yaml
+++ b/.github/workflows/metal-run-microbenchmarks.yaml
@@ -36,6 +36,7 @@ jobs:
 
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -49,6 +50,7 @@ jobs:
       tracy: true
   run-microbenchmarks:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     uses: ./.github/workflows/metal-run-microbenchmarks-impl.yaml
     secrets: inherit
     with:

--- a/.github/workflows/models-t1-device-perf-tests.yaml
+++ b/.github/workflows/models-t1-device-perf-tests.yaml
@@ -85,6 +85,7 @@ jobs:
           fi
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -99,6 +100,7 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
   models-device-perf-tests:
     needs: [check-harbor, build-artifact, resolve-skus]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' && needs.resolve-skus.result == 'success' }}
     secrets: inherit
     uses: ./.github/workflows/models-device-perf-tests-impl.yaml
     with:

--- a/.github/workflows/models-t1-e2e-tests.yaml
+++ b/.github/workflows/models-t1-e2e-tests.yaml
@@ -118,6 +118,7 @@ jobs:
           echo "model=all" >> $GITHUB_OUTPUT
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -131,6 +132,7 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
   models-e2e-tests:
     needs: [check-harbor, build-artifact, resolve-skus]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' && needs.resolve-skus.result == 'success' }}
     # id-token: write is required by the nested exabox multihost job (multihost-ci runner chart).
     # Job-level permissions replace inherited defaults, so restate the reads the container legs need too.
     permissions:

--- a/.github/workflows/models-t1-sweep-tests.yaml
+++ b/.github/workflows/models-t1-sweep-tests.yaml
@@ -88,6 +88,7 @@ jobs:
           fi
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -101,6 +102,7 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
   models-sweep-tests:
     needs: [check-harbor, build-artifact, resolve-skus]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' && needs.resolve-skus.result == 'success' }}
     secrets: inherit
     uses: ./.github/workflows/models-sweep-tests-impl.yaml
     with:

--- a/.github/workflows/models-t1-unit-tests.yaml
+++ b/.github/workflows/models-t1-unit-tests.yaml
@@ -120,6 +120,7 @@ jobs:
           echo "model=all" >> $GITHUB_OUTPUT
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -133,6 +134,7 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
   models-unit-tests:
     needs: [check-harbor, build-artifact, resolve-skus]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' && needs.resolve-skus.result == 'success' }}
     secrets: inherit
     # OIDC only on this caller (multihost-ci runner chart may need it), not workflow-wide.
     # Job-level permissions replace inherited defaults, so restate what tests need.

--- a/.github/workflows/models-t2-e2e-tests.yaml
+++ b/.github/workflows/models-t2-e2e-tests.yaml
@@ -116,6 +116,7 @@ jobs:
           echo "model=all" >> $GITHUB_OUTPUT
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -129,6 +130,7 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
   models-e2e-tests:
     needs: [check-harbor, build-artifact, resolve-skus]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' && needs.resolve-skus.result == 'success' }}
     # id-token: write is required by the nested exabox multihost job (multihost-ci runner chart).
     # Job-level permissions replace inherited defaults, so restate the reads the container legs need too.
     permissions:

--- a/.github/workflows/models-t2-sweep-tests.yaml
+++ b/.github/workflows/models-t2-sweep-tests.yaml
@@ -89,6 +89,7 @@ jobs:
           fi
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -102,6 +103,7 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
   models-sweep-tests:
     needs: [check-harbor, build-artifact, resolve-skus]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' && needs.resolve-skus.result == 'success' }}
     secrets: inherit
     uses: ./.github/workflows/models-sweep-tests-impl.yaml
     with:

--- a/.github/workflows/models-t2-unit-tests.yaml
+++ b/.github/workflows/models-t2-unit-tests.yaml
@@ -116,6 +116,7 @@ jobs:
           echo "model=all" >> $GITHUB_OUTPUT
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read

--- a/.github/workflows/models-t3-e2e-tests.yaml
+++ b/.github/workflows/models-t3-e2e-tests.yaml
@@ -123,6 +123,7 @@ jobs:
           echo "model=all" >> $GITHUB_OUTPUT
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -136,6 +137,7 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
   models-e2e-tests:
     needs: [check-harbor, build-artifact, resolve-skus]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' && needs.resolve-skus.result == 'success' }}
     # id-token: write is required by the nested exabox multihost job (multihost-ci runner chart).
     # Job-level permissions replace inherited defaults, so restate the reads the container legs need too.
     permissions:

--- a/.github/workflows/models-t3-unit-tests.yaml
+++ b/.github/workflows/models-t3-unit-tests.yaml
@@ -120,6 +120,7 @@ jobs:
           echo "model=all" >> $GITHUB_OUTPUT
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -133,6 +134,7 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
   models-unit-tests:
     needs: [check-harbor, build-artifact, resolve-skus]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' && needs.resolve-skus.result == 'success' }}
     secrets: inherit
     # OIDC only on this caller (multihost-ci runner chart may need it), not workflow-wide.
     # Job-level permissions replace inherited defaults, so restate what tests need.

--- a/.github/workflows/multi-host-deepseekv3.yaml
+++ b/.github/workflows/multi-host-deepseekv3.yaml
@@ -92,6 +92,7 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read

--- a/.github/workflows/multi-host-physical.yaml
+++ b/.github/workflows/multi-host-physical.yaml
@@ -58,6 +58,7 @@ jobs:
 
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read

--- a/.github/workflows/perf-device-models.yaml
+++ b/.github/workflows/perf-device-models.yaml
@@ -73,6 +73,7 @@ jobs:
 
   build-artifact-profiler:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -87,6 +88,7 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
   device-perf:
     needs: [check-harbor, build-artifact-profiler]
+    if: ${{ !cancelled() && needs.build-artifact-profiler.result == 'success' }}
     secrets: inherit
     uses: ./.github/workflows/perf-device-models-impl.yaml
     with:

--- a/.github/workflows/pipeline-select-galaxy.yaml
+++ b/.github/workflows/pipeline-select-galaxy.yaml
@@ -221,6 +221,7 @@ jobs:
           esac
   build-artifact:
     needs: [check-harbor, determine-tests]
+    if: ${{ !cancelled() && needs.determine-tests.result == 'success' }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read

--- a/.github/workflows/pipeline-select-t3k.yaml
+++ b/.github/workflows/pipeline-select-t3k.yaml
@@ -153,6 +153,7 @@ jobs:
           esac
   build-artifact:
     needs: [check-harbor, determine-tests]
+    if: ${{ !cancelled() && needs.determine-tests.result == 'success' }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read

--- a/.github/workflows/pipeline-select.yaml
+++ b/.github/workflows/pipeline-select.yaml
@@ -95,6 +95,7 @@ jobs:
 
   build-artifact:
     needs: [check-harbor, determine-tests]
+    if: ${{ !cancelled() && needs.determine-tests.result == 'success' }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read

--- a/.github/workflows/publish-release-image-wrapper.yaml
+++ b/.github/workflows/publish-release-image-wrapper.yaml
@@ -22,6 +22,7 @@ jobs:
 
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       packages: write
@@ -53,6 +54,7 @@ jobs:
       - check-harbor
       - build-artifact
       - create-image-tag-name
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' && needs.create-image-tag-name.result == 'success' }}
     secrets: inherit
     with:
       version: dev-${{ needs.create-image-tag-name.outputs.image-tag-name }}

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -64,6 +64,7 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
   build-artifact:
     needs: [check-harbor, parse-platform]
+    if: ${{ !cancelled() && needs.parse-platform.result == 'success' }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read

--- a/.github/workflows/runtime-integration-tests.yaml
+++ b/.github/workflows/runtime-integration-tests.yaml
@@ -131,6 +131,7 @@ jobs:
           echo "Selected SKUs: $SKUS"
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -145,6 +146,7 @@ jobs:
 
   runtime-integration-tests:
     needs: [check-harbor, build-artifact, resolve-skus]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' && needs.resolve-skus.result == 'success' }}
     uses: ./.github/workflows/runtime-integration-tests-impl.yaml
     secrets: inherit
     with:

--- a/.github/workflows/runtime-perf-tests.yaml
+++ b/.github/workflows/runtime-perf-tests.yaml
@@ -46,6 +46,7 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -59,6 +60,7 @@ jobs:
 
   runtime-perf-tests:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     permissions:
       actions: read
       contents: read
@@ -82,6 +84,7 @@ jobs:
   # not perturbed by profiler instrumentation. Used by the profiler-based tests.
   build-artifact-profiler:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -96,6 +99,7 @@ jobs:
 
   runtime-perf-profiler-tests:
     needs: [check-harbor, build-artifact-profiler]
+    if: ${{ !cancelled() && needs.build-artifact-profiler.result == 'success' }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/runtime-sanity-tests.yaml
+++ b/.github/workflows/runtime-sanity-tests.yaml
@@ -131,6 +131,7 @@ jobs:
           echo "Selected SKUs: $SKUS"
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -144,6 +145,7 @@ jobs:
 
   runtime-sanity-tests:
     needs: [check-harbor, build-artifact, resolve-skus]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' && needs.resolve-skus.result == 'success' }}
     uses: ./.github/workflows/runtime-sanity-tests-impl.yaml
     secrets: inherit
     with:

--- a/.github/workflows/runtime-unit-tests.yaml
+++ b/.github/workflows/runtime-unit-tests.yaml
@@ -131,6 +131,7 @@ jobs:
           echo "Selected SKUs: $SKUS"
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -145,6 +146,7 @@ jobs:
 
   runtime-unit-tests:
     needs: [check-harbor, build-artifact, resolve-skus]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' && needs.resolve-skus.result == 'success' }}
     uses: ./.github/workflows/runtime-unit-tests-impl.yaml
     secrets: inherit
     with:

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -224,6 +224,9 @@ jobs:
   # Just pass platform and enable-lto inputs directly.
   build-artifact:
     needs: check-harbor
+    # A failed/errored check-harbor must not skip the whole pipeline: an empty
+    # harbor-prefix output already means "fall back to direct GHCR pulls".
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read

--- a/.github/workflows/single-card-demo-tests.yaml
+++ b/.github/workflows/single-card-demo-tests.yaml
@@ -55,6 +55,7 @@ jobs:
 
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -69,6 +70,7 @@ jobs:
       tracy: ${{ inputs.enable-ops-recording || false }}
   single-card-demo-tests:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     secrets: inherit
     uses: ./.github/workflows/single-card-demo-tests-impl.yaml
     with:

--- a/.github/workflows/single-card-ttnn-models-frequent-tests.yaml
+++ b/.github/workflows/single-card-ttnn-models-frequent-tests.yaml
@@ -71,6 +71,7 @@ jobs:
 
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -84,6 +85,7 @@ jobs:
       tracy: ${{ inputs.enable-ops-recording || false }}
   single-card-ttnn-models-frequent-tests:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     uses: ./.github/workflows/single-card-ttnn-models-frequent-tests-impl.yaml
     secrets: inherit
     with:

--- a/.github/workflows/t3000-demo-tests.yaml
+++ b/.github/workflows/t3000-demo-tests.yaml
@@ -78,6 +78,7 @@ jobs:
 
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -90,6 +91,7 @@ jobs:
       build-inplace-wheel: true
   t3000-demo-tests:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     secrets: inherit
     uses: ./.github/workflows/t3000-demo-tests-impl.yaml
     with:

--- a/.github/workflows/t3000-e2e-tests.yaml
+++ b/.github/workflows/t3000-e2e-tests.yaml
@@ -36,6 +36,7 @@ jobs:
 
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -48,6 +49,7 @@ jobs:
       build-inplace-wheel: true
   t3000-e2e-tests:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     secrets: inherit
     uses: ./.github/workflows/t3000-e2e-tests-impl.yaml
     with:

--- a/.github/workflows/t3000-fast-tests.yaml
+++ b/.github/workflows/t3000-fast-tests.yaml
@@ -38,6 +38,7 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -51,6 +52,7 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
   t3000-sanity-tests:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     secrets: inherit
     uses: ./.github/workflows/t3000-sanity-tests-impl.yaml
     with:

--- a/.github/workflows/t3000-integration-tests.yaml
+++ b/.github/workflows/t3000-integration-tests.yaml
@@ -47,6 +47,7 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -60,6 +61,7 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
   t3000-integration-tests:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     secrets: inherit
     uses: ./.github/workflows/t3000-integration-tests-impl.yaml
     with:

--- a/.github/workflows/t3000-perf-tests.yaml
+++ b/.github/workflows/t3000-perf-tests.yaml
@@ -45,6 +45,7 @@ jobs:
 
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -59,6 +60,7 @@ jobs:
       tracy: true
   t3000-perf-tests:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     secrets: inherit
     uses: ./.github/workflows/t3000-perf-tests-impl.yaml
     with:

--- a/.github/workflows/t3000-profiler-tests.yaml
+++ b/.github/workflows/t3000-profiler-tests.yaml
@@ -34,6 +34,7 @@ jobs:
 
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -49,6 +50,7 @@ jobs:
 
   t3000-profiler-tests:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     uses: ./.github/workflows/t3000-profiler-tests-impl.yaml
     secrets: inherit
     with:

--- a/.github/workflows/t3000-unit-tests.yaml
+++ b/.github/workflows/t3000-unit-tests.yaml
@@ -51,6 +51,7 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -63,6 +64,7 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
   t3000-unit-tests:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     secrets: inherit
     uses: ./.github/workflows/t3000-unit-tests-impl.yaml
     with:

--- a/.github/workflows/temp-ccache-test.yaml
+++ b/.github/workflows/temp-ccache-test.yaml
@@ -8,6 +8,7 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -23,6 +24,7 @@ jobs:
 
   ttnn-unit-tests:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     uses: ./.github/workflows/ttnn-sanity-tests-impl.yaml
     secrets: inherit
     with:

--- a/.github/workflows/test-dispatch.yaml
+++ b/.github/workflows/test-dispatch.yaml
@@ -62,6 +62,7 @@ jobs:
   # Just pass platform and enable-lto inputs directly.
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -77,6 +78,7 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
   test-dispatch:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     timeout-minutes: 120
     runs-on: ${{ fromJSON(inputs.runner-label) }}
     container:

--- a/.github/workflows/tm-data-movement-wrapper.yaml
+++ b/.github/workflows/tm-data-movement-wrapper.yaml
@@ -57,6 +57,7 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -125,6 +126,7 @@ jobs:
   data-movement-unit-tests:
     uses: ./.github/workflows/tm-data-movement-unit-impl.yaml
     needs: [check-harbor, build-artifact, generate-matrix]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' && needs.generate-matrix.result == 'success' }}
     secrets: inherit
     strategy:
       fail-fast: false

--- a/.github/workflows/tm-fabric-tests.yaml
+++ b/.github/workflows/tm-fabric-tests.yaml
@@ -107,6 +107,7 @@ jobs:
 
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read

--- a/.github/workflows/triage-tests.yaml
+++ b/.github/workflows/triage-tests.yaml
@@ -58,6 +58,7 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -71,6 +72,7 @@ jobs:
 
   triage-tests:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     uses: ./.github/workflows/triage-tests-impl.yaml
     secrets: inherit
     with:

--- a/.github/workflows/tt-metal-l2-nightly.yaml
+++ b/.github/workflows/tt-metal-l2-nightly.yaml
@@ -112,6 +112,7 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -161,6 +162,7 @@ jobs:
 
   resolve-docker-pull-refs:
     needs: [check-harbor, build-artifact]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}
     uses: ./.github/workflows/resolve-docker-pull-refs.yaml
     with:
       harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}

--- a/.github/workflows/ttnn-model-trace-sweep-validation-impl.yaml
+++ b/.github/workflows/ttnn-model-trace-sweep-validation-impl.yaml
@@ -50,6 +50,7 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -401,6 +402,7 @@ jobs:
   run-sweeps-with-tracer:
     name: ${{ matrix.batch_display }}
     needs: [check-harbor, build-artifact, prepare-validation-inputs, generate-sweeps, compute-sweep-matrix]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' && needs.prepare-validation-inputs.result == 'success' && needs.generate-sweeps.result == 'success' && needs.compute-sweep-matrix.result == 'success' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ttnn-run-model-trace.yaml
+++ b/.github/workflows/ttnn-run-model-trace.yaml
@@ -200,6 +200,7 @@ jobs:
   build-artifact:
     name: Build
     needs: [check-harbor, validate-inputs]
+    if: ${{ !cancelled() && needs.validate-inputs.result == 'success' }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -214,6 +215,7 @@ jobs:
   trace-model:
     name: "Trace: ${{ matrix.slug }}"
     needs: [check-harbor, validate-inputs, build-artifact]
+    if: ${{ !cancelled() && needs.validate-inputs.result == 'success' && needs.build-artifact.result == 'success' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ttnn-run-sweeps.yaml
+++ b/.github/workflows/ttnn-run-sweeps.yaml
@@ -794,6 +794,7 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
   build-artifact:
     needs: [check-harbor, resolve-inputs]
+    if: ${{ !cancelled() && needs.resolve-inputs.result == 'success' }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read

--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -61,6 +61,7 @@ jobs:
     uses: ./.github/workflows/check-harbor.yaml
   build-artifact:
     needs: check-harbor
+    if: ${{ !cancelled() }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read

--- a/.github/workflows/vllm-model-tests.yaml
+++ b/.github/workflows/vllm-model-tests.yaml
@@ -152,6 +152,7 @@ jobs:
             "${{ needs.resolve-skus.outputs.model }}"
   build-artifact:
     needs: [check-harbor, validate-filters]
+    if: ${{ !cancelled() && needs.validate-filters.result == 'success' }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -165,6 +166,7 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
   vllm-tests:
     needs: [check-harbor, build-artifact, resolve-skus]
+    if: ${{ !cancelled() && needs.build-artifact.result == 'success' && needs.resolve-skus.result == 'success' }}
     secrets: inherit
     uses: ./.github/workflows/vllm-model-tests-impl.yaml
     with:


### PR DESCRIPTION
## Summary

Investigating why [this failing check-harbor run](https://github.com/tenstorrent/tt-metal/actions/runs/31916671059/job/95112958310) errored out instead of posting an annotation and falling back to direct GHCR, as designed.

### Root cause (two compounding issues)

1. **`check-harbor.yaml`'s schedule-only hard-fail fired for the wrong caller.** The health-check script intentionally `exit 1`s when Harbor is unhealthy *and* the run's root trigger is `schedule` — meant to make check-harbor's own standalone hourly monitor (`on: schedule: cron: "0 * * * *"`) go red so someone notices. But that ambient signal can't tell apart check-harbor's own cron from any `workflow_call` caller that's itself schedule-triggered (e.g. `sanity-tests.yaml`'s `"0 */4 * * *"`) — confirmed empirically in the failing run's logs.
2. **`sanity-tests.yaml`'s `build-artifact` job had no `if:` guard tolerating a failed `check-harbor`.** Once check-harbor's job conclusion is `failure`, plain `needs: check-harbor` cascades the whole downstream job graph to `skipped` instead of falling back via the empty `harbor-prefix` output.

### Fixes

- **check-harbor.yaml**: replaced the ambiguous `github.event_name`/cron-string signal with an explicit `called-via-workflow-call` boolean `workflow_call` input (`default: true`) — its declared default resolves whenever this workflow is invoked via `workflow_call` (even if the caller omits it, which all ~70 callers do), but the `inputs` context doesn't exist at all on check-harbor's own standalone `schedule` trigger. This cleanly distinguishes "I'm check-harbor's own hourly monitor" from "I was called by a schedule-triggered workflow" without depending on cron strings (which would've silently broken if a future caller ever adopted the same cron, or under the open upstream bug where `github.event.schedule` can go stale after an edit).
- **check-harbor.yaml**: validate the Harbor health response is actually JSON before parsing it with `jq` — a 200 with a non-JSON or wrong-shaped body (e.g. a proxy/maintenance page, plausible exactly when Harbor is degraded) previously tripped `set -e`/`pipefail` and hard-failed the job the same way the original bug did, for every one of check-harbor's ~70 callers, not just sanity-tests.yaml. Also hardened `.components[]` → `.components[]?` for the same reason.
- **~70 caller workflows** (`sanity-tests.yaml`, `runtime-sanity-tests.yaml`, and everything else with `check-harbor` in a `needs:` list): added `if: ${{ !cancelled() }}` (or `!cancelled() && needs.X.result == 'success' && ...` enumerating any other co-dependencies) to every job that had zero pre-existing `if:` condition, so a failed/errored check-harbor degrades to the empty-`harbor-prefix` GHCR fallback instead of cascading the whole pipeline to skipped.

### Why `if: ${{ !cancelled() && needs.build-artifact.result == 'success' }}` and not just `!cancelled()`?

Isn't `build-artifact` already required to succeed by being listed in `needs:`? Only when the job has **no custom `if:`** — GitHub Actions' implicit default (require every job in `needs:` to have succeeded) only applies in that case. As soon as a job's `if:` contains one of the four status-check functions (`success()`, `failure()`, `cancelled()`, `always()`), that implicit default is gone — the custom expression is used as-is, for *all* of that job's needs at once, not just the one being targeted.

We added `!cancelled()` specifically to stop gating on `check-harbor`'s success (a failed check-harbor should mean "empty harbor-prefix, fall back to GHCR," not "block the job"). But `!cancelled()` can't selectively exempt just check-harbor — it removes the implicit success requirement for *every* dependency. So a job with `needs: [check-harbor, build-artifact]` and only `if: ${{ !cancelled() }}` would now also run even if `build-artifact` genuinely failed (e.g. a compile error) — which we don't want: there'd be no docker image/wheel to test against.

The explicit `needs.build-artifact.result == 'success'` restores, by hand, the exact gating that `!cancelled()` just removed — for every need *except* check-harbor, the one dependency we're deliberately choosing to tolerate. This isn't something invented for this PR either: `resolve-docker-pull-refs` in `sanity-tests.yaml` already used this exact pattern before this PR touched anything, and every added guard here follows that established convention.

### Deliberately left for human follow-up (not auto-edited)

A handful of jobs already have custom `if:` conditions that don't contain a GHA status-check function (`always()`/`failure()`/`cancelled()`), so they technically still gate on check-harbor's success too — but correctly merging a new failure-tolerance clause into unfamiliar existing conditional logic at this scale is real risk, so these were intentionally left alone rather than guessed at:

- `all-model-tests.yaml:347`, `blaze-models-prefill-tests.yaml:96,116`, `build-wrapper.yaml:118,141`, `pr-gate.yaml:92,109-110`, `release-build-test-publish.yaml:142-143,254-260`, `tm-data-movement-wrapper.yaml:141`, `tt-metal-l2-nightly.yaml:276`
- `merge-gate.yaml`: `build`, `build-tsan`, `build-asan`, `build-sweeps`, `runtime-smoke-tests`, `runtime-basic-tests`, `ttnn-smoke-tests`, `ttnn-basic-tests`, `models-smoke-tests`, `scaleout-unit-tests`, `scaleout-cpu-only-unit-tests` (currently `if: false`, dormant), `resolve-docker-pull-refs-llk`
- `code-analysis.yaml:146,160` (`build-docker-image`, `resolve-docker-pull-refs`) use `if: ${{ always() && !failure() && !cancelled() }}` — despite containing status functions, `!failure()` still means a failed check-harbor skips these two jobs. Flagged rather than changed since both jobs share this exact convention deliberately.

## Test plan

- [x] sanity handling harbor failure
- [x] `python3 -c "import yaml; yaml.safe_load(open(f))"` across all ~67 touched files — all pass
- [x] Hand-simulated the check-harbor script logic (own-cron vs. workflow_call-cron, healthy/unhealthy/no-response/non-JSON-response/wrong-shape-JSON-response) against both `OWN_SCHEDULE_RUN` and the JSON-validation guard — all branches produce the intended exit code and `harbor-prefix` output
- [x] Diff-audited: confirmed zero dropped/extra dependencies across all edited jobs' `needs.X.result == 'success'` enumerations, and that the sweep is pure-addition (no unintended deletions/reformatting)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsexton/0-fix-check-harbor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsexton/0-fix-check-harbor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsexton/0-fix-check-harbor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsexton/0-fix-check-harbor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsexton/0-fix-check-harbor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsexton/0-fix-check-harbor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsexton/0-fix-check-harbor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsexton/0-fix-check-harbor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsexton/0-fix-check-harbor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsexton/0-fix-check-harbor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsexton/0-fix-check-harbor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsexton/0-fix-check-harbor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsexton/0-fix-check-harbor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsexton/0-fix-check-harbor)