### PR TITLE
Gate Chunked Kimi perf (code_debug 55k, no trace) at +/-5% per chunk

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -136,27 +136,54 @@ LAYER_PCC_THRESHOLD = 0.88
 KV_CACHE_PCC_THRESHOLD = 0.85
 INDEXER_K_PCC_THRESHOLD = 0.95
 
-# Per-chunk baseline medians (seconds) for the perf gate, pulled from a known-good CI run. Keyed by
-# (num_layers, n_chunks, num_iters) so only the exact config we have a CI number for is gated; every
+# Per-chunk baseline medians (seconds) for the perf gate, pulled from known-good CI runs. Keyed by
+# (num_layers, n_chunks, num_iters) so only the exact config we have CI numbers for is gated; every
 # other combo in the sweep stays record-only. Each list has one entry per chunk (index c == chunk c). A
-# single margin (the perf_margin pytest arg) is applied to every chunk. Recalibrate by re-reading the
-# "chunk timing stats" table from a fresh green CI run.
+# single margin is applied to every chunk. Recalibrate by re-reading the "chunk timing stats" table
+# from fresh green CI runs.
 #
-# TRACED ONLY. These are trace-replay numbers, and the gate is hard-wired to use_trace=True at the call
-# site -- the untraced variant is never gated, whatever this table holds. The two are different regimes,
-# not a small delta: this config measures 0.6-0.95 s/chunk traced (a ramp, since chunk c attends to
-# KV[0:c*CHUNK]) but a flat ~1.10 s/chunk untraced, host-dispatch bound so the depth ramp disappears
-# entirely. Untraced per-chunk stddev also reaches 0.22 s within a single run (~20%; run 31670499441
-# job 94387075128), which no meaningful band would survive.
-KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S = {
+# Traced and untraced get SEPARATE tables and SEPARATE margins, selected by mode in
+# `kimi_chunked_perf_gate` -- a traced baseline can never gate an untraced run or vice versa. The two
+# are different regimes, not a small delta: traced measures 0.6-0.95 s/chunk (a ramp, since chunk c
+# attends to KV[0:c*CHUNK]) while untraced is a flat ~1.09 s/chunk, host-dispatch bound so the op2op
+# gap swamps the depth ramp entirely.
+KIMI_TRACED_BASELINE_CHUNK_TIMES_S = {
     # test_kimi_prefill_transformer_chunked_perf[...-L61-preload0-chunks_eleven-ten_iters-traced]
     # (55k / code_debug), from run 31675454129 job 94407856609 -- green, and stable within the run
     # (per-chunk stddev <= 0.002 s over the 9 post-warmup iterations).
     (61, 11, 10): [0.605, 0.606, 0.653, 0.681, 0.711, 0.743, 0.760, 0.793, 0.842, 0.869, 0.905],
 }
-# Default +/- tolerance band around each baseline chunk median (fraction). Overridable per test via the
-# perf_margin pytest argument (see test_prefill_block_perf.py's `margin` column for the design).
-DEFAULT_PERF_MARGIN = 0.03
+KIMI_UNTRACED_BASELINE_CHUNK_TIMES_S = {
+    # test_kimi_prefill_transformer_chunked_perf[...-L61-preload0-chunks_eleven-ten_iters-notrace]
+    # (55k / code_debug). Per chunk, the MEDIAN OVER 10 CI RUNS of that run's own per-chunk median --
+    # a single run is not a usable baseline here the way it is for the traced twin. The 10 (all green,
+    # 2026-08-15, `main`, bh_sc1_high_power): 31868565025 31868547288 31868532277 31868515545
+    # 31868482938 31868467067 31868452031 31868433473 31867986909 31866023124.
+    #
+    # WITHIN a run the untraced spread is huge -- per-chunk stddev reaches 0.33 s (~30%), because every
+    # iteration re-dispatches every op from host and pays a fresh, variable op2op gap. The MEDIAN of the
+    # 9 post-warmup iterations is not: across those 10 runs no chunk median lands further than 2.9% from
+    # the values below, and widening the sample to all 32 runs with a table from 2026-08-11 to 08-15
+    # (many branches) only reaches 3.2%. So the gate is on the median, with UNTRACED_PERF_MARGIN rather
+    # than the traced 3%.
+    #
+    # If this does go flaky, re-center before widening: these are the median over the 10 runs, and
+    # centering each chunk on the midrange of all 32 instead pulls the worst deviation to 2.7% (the
+    # 3.2% is one-sided). Widening to 10% is the fallback after that -- every observed run fits inside
+    # a 6.2% total spread, so a band that needs more than 10% is a regression, not noise.
+    (61, 11, 10): [1.095, 1.094, 1.091, 1.098, 1.093, 1.089, 1.092, 1.089, 1.094, 1.089, 1.090],
+}
+# Per-mode +/- tolerance band around each baseline chunk median (fraction). Traced replays a captured
+# program, so the device is its only noise source; untraced re-dispatches from host every iteration and
+# carries the op2op gap, so it needs the wider band. Overridable per test via the perf_margin pytest
+# argument (None = use the mode default; see test_prefill_block_perf.py's `margin` column).
+#
+# 5% untraced is deliberately tight: the worst per-chunk deviation over all 32 recorded runs is 3.2%,
+# so CI noise already spends ~2/3 of the band. That is the intended bar -- catch a >5% eager-dispatch
+# regression -- but it leaves little slack, so triage a failure as noise-vs-regression (compare the
+# other chunks and the traced twin from the same run) before touching the number.
+TRACED_PERF_MARGIN = 0.03
+UNTRACED_PERF_MARGIN = 0.05
 
 # Deepest config whose per-layer PCC is asserted; deeper runs (L61) stay record-only until their
 # accumulation headroom is pinned.
@@ -1172,6 +1199,11 @@ def run_chunked_transformer_updated(
             raise ValueError(
                 f"baseline_chunk_times_s has {len(baseline_chunk_times_s)} entries but n_chunks={n_chunks}"
             )
+        if gated and perf_margin is None:
+            # perf_margin defaults to None ("use the mode default", resolved by kimi_chunked_perf_gate).
+            # Reaching the gate with it still None means a caller wired up a baseline without a band;
+            # falling through to 0.0 would collapse the band to zero width and fail every chunk.
+            raise ValueError("baseline_chunk_times_s was given without a perf_margin")
         margin = perf_margin if perf_margin is not None else 0.0
 
         headers = ["chunk", "median_time", "stddev"]
@@ -1674,6 +1706,31 @@ def run_chunked_transformer_updated(
     assert not perf_failures, "chunk timing out of baseline tolerance:\n  " + "\n  ".join(perf_failures)
 
 
+def kimi_chunked_perf_gate(use_trace, num_layers, n_chunks, num_iters, preload_isl, perf_margin=None):
+    """Resolve the chunked-Kimi perf gate for one parametrization: returns
+    ``(baseline_chunk_times_s, margin)`` for run_chunked_transformer_updated.
+
+    A baseline of None leaves the run record-only (print_duration_table prints the table and does not
+    assert), which is what every combo outside the two calibrated CI configs gets. Two conditions on
+    top of the table lookup:
+
+      use_trace   -- picks WHICH table and WHICH default margin. The two modes are separate regimes
+                     (see the tables), so this is a hard fork, not a shared table with a mode column:
+                     a traced baseline can never arm an untraced run, or the reverse.
+      preload_isl -- the baselines only mean anything at 0 (the recorded runs started from an empty
+                     cache); any preload depth stays record-only.
+
+    `perf_margin` overrides the mode default when not None, so a caller can still pin a band explicitly.
+    """
+    table, default_margin = (
+        (KIMI_TRACED_BASELINE_CHUNK_TIMES_S, TRACED_PERF_MARGIN)
+        if use_trace
+        else (KIMI_UNTRACED_BASELINE_CHUNK_TIMES_S, UNTRACED_PERF_MARGIN)
+    )
+    baseline = table.get((num_layers, n_chunks, num_iters)) if preload_isl == 0 else None
+    return baseline, (default_margin if perf_margin is None else perf_margin)
+
+
 # No-PCC perf/smoke variant: runs the full n_chunks-chunk prefill `num_iters` times with no golden
 # trace dependency, no intermediate readback, and no PCC. Requires only the Kimi TTNN weight cache (set
 # TT_KIMI_PREFILL_TTNN_CACHE + KIMI_K2_6_HF_MODEL); the golden trace is optional.
@@ -1686,7 +1743,9 @@ def run_chunked_transformer_updated(
 # ids: "traced" not "trace" — "notrace" CONTAINS "trace", so a -k "trace" term would match BOTH
 # modes and silently double a CI job. Matches the padded test's convention.
 @pytest.mark.parametrize("use_trace", [False, True], ids=["notrace", "traced"])
-@pytest.mark.parametrize("perf_margin", [DEFAULT_PERF_MARGIN], ids=["margin3pct"])
+# None = take the band from the mode (TRACED_PERF_MARGIN / UNTRACED_PERF_MARGIN, resolved by
+# kimi_chunked_perf_gate). The two bands differ by more than 3x, so no single literal serves both.
+@pytest.mark.parametrize("perf_margin", [None], ids=["margin_auto"])
 @pytest.mark.parametrize(
     "num_iters", [1, 2, 10, 20, 25], ids=["iters1", "two_iters", "ten_iters", "iters20", "iters25"]
 )
@@ -1753,17 +1812,11 @@ def test_kimi_prefill_transformer_chunked_perf(
 ):
     if preload_isl + n_chunks * CHUNK > SEQ_CACHE_NOPCC:
         pytest.skip(f"preload_isl {preload_isl} + {n_chunks} chunks exceeds the {SEQ_CACHE_NOPCC}-token cache")
-    # Gate against the CI baseline only for the exact config we have a recorded number for; every other
-    # combo in the sweep stays record-only (baseline None -> print_duration_table does not assert). Two
-    # hard conditions on top of the table lookup:
-    #   use_trace   -- the baselines are trace-replay numbers, and the untraced path is a different
-    #                  regime (flat ~1.10 s/chunk, ~20% within-run spread), so it is NEVER gated. This
-    #                  is the guard, not the table's contents: adding an untraced entry cannot arm it.
-    #   preload_isl -- the baseline only means anything at 0 (the recorded runs started from an empty cache).
-    baseline_chunk_times_s = (
-        KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S.get((num_layers, n_chunks, num_iters))
-        if (use_trace and preload_isl == 0)
-        else None
+    # Gate against the CI baseline only for the exact configs we have recorded numbers for; every other
+    # combo in the sweep stays record-only (baseline None -> print_duration_table does not assert). Both
+    # modes are gated, each against its own table and its own band -- see kimi_chunked_perf_gate.
+    baseline_chunk_times_s, perf_margin = kimi_chunked_perf_gate(
+        use_trace, num_layers, n_chunks, num_iters, preload_isl, perf_margin
     )
     run_chunked_transformer_updated(
         variant,
@@ -1788,7 +1841,9 @@ def test_kimi_prefill_transformer_chunked_perf(
 # ids: "traced" not "trace" — "notrace" CONTAINS "trace", so a -k "trace" term would match BOTH
 # modes and silently double a CI job. Matches the padded test's convention.
 @pytest.mark.parametrize("use_trace", [False, True], ids=["notrace", "traced"])
-@pytest.mark.parametrize("perf_margin", [DEFAULT_PERF_MARGIN], ids=["margin3pct"])
+# None = take the band from the mode (TRACED_PERF_MARGIN / UNTRACED_PERF_MARGIN, resolved by
+# kimi_chunked_perf_gate). The two bands differ by more than 3x, so no single literal serves both.
+@pytest.mark.parametrize("perf_margin", [None], ids=["margin_auto"])
 @pytest.mark.parametrize(
     "num_iters", [1, 2, 10, 20, 25], ids=["iters1", "two_iters", "ten_iters", "iters20", "iters25"]
 )
@@ -1853,10 +1908,10 @@ def test_kimi_prefill_transformer_chunked(
         pytest.skip(f"preload_isl {preload_isl} + {n_chunks} chunks exceeds the {SEQ_CACHE_NOPCC}-token cache")
     # ALWAYS record-only -- this accuracy test is never perf-gated. It shares the perf test's
     # parametrization but NOT its is_high_power() skipif, so it can run on a standard-power Blackhole,
-    # where KIMI_NO_PCC_BASELINE_CHUNK_TIMES_S -- measured on a >=130W galaxy -- describes nothing. Gating
-    # here would fail an accuracy run for a timing reason, on hardware the baseline never covered, and the
-    # timing table is incidental to this test anyway (see check_pcc below). The perf gate belongs to, and
-    # stays in, test_kimi_prefill_transformer_chunked_perf.
+    # where the baseline tables -- measured on a >=130W galaxy -- describe nothing. Gating here would fail
+    # an accuracy run for a timing reason, on hardware the baseline never covered, and the timing table is
+    # incidental to this test anyway (see check_pcc below). The perf gate belongs to, and stays in,
+    # test_kimi_prefill_transformer_chunked_perf.
     baseline_chunk_times_s = None
     run_chunked_transformer_updated(
         variant,


### PR DESCRIPTION
### Ticket
Closes #53287. Untraced counterpart of #53101 (traced twin, ±3%).

### Problem
`Blaze - Chunked Kimi perf (code_debug 55k, no trace)` printed its per-chunk timing table but never asserted on it — #53101 hard-wired the gate to `use_trace=True`, so a regression on the eager-dispatch path went green. The stated reason was that untraced within-run spread (~20%) is too wide to band. But that spread is *per-iteration*; the median of the 9 post-warmup iterations is stable, and that is what the gate uses.

### Calibration
Per-chunk `median_time` from every run of this job with a table, 2026-08-11 → 08-15 (32 runs, `bh_sc1_high_power`, many branches). Untraced is flat ~1.09 s/chunk — no depth ramp, the op2op gap swamps it.

Baseline = per chunk, the median over the 10 most recent green runs (2026-08-15, `main`): 31868565025 31868547288 31868532277 31868515545 31868482938 31868467067 31868452031 31868433473 31867986909 31866023124.

| worst single-chunk deviation | those 10 runs | all 32 runs |
|---|---|---|
| | 2.9% | **3.2%** |

Every per-chunk median ever recorded sits in 1.063–1.129 s (6.2% total spread). Replaying all 32 at **±5%: 0 would fail**, worst case using 64% of the band. The issue asked for ±10%; the data does not need it, so this ships the tighter bar and documents the escalation order beside the table — re-center on the midrange first (3.2% → 2.7%, the tail is one-sided), widen to 10% only after.

### Changes
- Split the baseline table by mode: `KIMI_TRACED_BASELINE_CHUNK_TIMES_S` (numbers untouched) + new `KIMI_UNTRACED_BASELINE_CHUNK_TIMES_S`, with `TRACED_PERF_MARGIN = 0.03` / `UNTRACED_PERF_MARGIN = 0.05`.
- `kimi_chunked_perf_gate()` replaces the inline `use_trace` fork and returns `(baseline, margin)`. Mode picks the table *and* the band, so #53101's structural guard survives — generalized from "untraced is never gated" to "each mode only sees its own numbers". `preload_isl > 0` and uncalibrated `(num_layers, n_chunks, num_iters)` stay record-only.
- `perf_margin` parametrizes as `None` = "mode default" (id `margin3pct` → `margin_auto`; no CI `-k` selector uses it); explicit values still override. `print_duration_table` now raises on baseline-without-margin instead of collapsing the band to zero width.

The accuracy test stays record-only — it has no `is_high_power()` skipif, so it can land on hardware the baselines never covered.

### Test plan
- [x] Gate resolution unit-checked over 8 parametrizations (both modes × calibrated/uncalibrated/preloaded + override).
- [x] All 32 historical runs replayed at ±5%: 0 failures.
- [x] CI, 4 runs x {untraced, traced}. All four **untraced** jobs pass; worst chunk uses 28-53% of the 5% band, matching the historical replay.

| run | ran with | untraced (this PR) | traced (unchanged, ±3%) |
|---|---|---|---|
| [31929446467](https://github.com/tenstorrent/tt-metal/actions/runs/31929446467) | ±5% | ✅ worst -2.4% | ✅ worst +0.8% |
| [31929452341](https://github.com/tenstorrent/tt-metal/actions/runs/31929452341) | ±5% | ✅ worst +1.4% | ✅ worst +0.8% |
| [31929212372](https://github.com/tenstorrent/tt-metal/actions/runs/31929212372) | ±10% | ✅ worst -1.7% *(inside ±5% too)* | ✅ worst +1.8% |
| [31929217523](https://github.com/tenstorrent/tt-metal/actions/runs/31929217523) | ±10% | ✅ worst -2.7% *(inside ±5% too)* | ❌ worst +8.3%, 8/11 chunks out |

History was squashed to one commit after these ran. The only delta between what CI executed and `93d7faa` is the reverted `blaze_models_prefill_tests.yaml` comment edits — comments in a pipeline file, not executed by anything — so the results above still describe this code.

**The one red job is the traced gate, and it is pre-existing** — `TRACED_PERF_MARGIN` is 3% before and after this PR, and that job's numbers are unrelated to anything here. Run 31929217523's traced job drew a slow/noisy runner: per-chunk stddev 0.043-0.060 s against the usual ≤0.002 s, medians ramping 0.595 → 0.966 s, worst on the deep chunks (+7.2% chunk 9, +6.7% chunk 10) exactly as predicted when #53101 landed. Its own untraced twin in the same run passed with 2.7% to spare, and the traced job passed on the other three runs.

That is the traced gate's known ~1-in-4 exposure to the pool's slow profile, and the fix is the one this PR demonstrates for untraced: baseline traced off a median-of-N runs rather than the single run 31675454129, and/or give chunks 9-10 their own wider band. Out of scope here — filing separately rather than quietly widening someone else's gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
