### PR TITLE
[Fabric2D] Fix all-to-all routing and synchronization

### DIFF
--- a/tests/nightly/t3000/ccl/test_all_to_all_async_generic.py
+++ b/tests/nightly/t3000/ccl/test_all_to_all_async_generic.py
@@ -626,6 +626,34 @@ def test_all_to_all_fabric_2d(
     )
 
 
+# A 1x8 view of the 2x4 board follows its perimeter, so axis 1 turns corners. Initialization multicast cannot route it.
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [{"trace_region_size": 100000, "fabric_config": ttnn.FabricConfig.FABRIC_2D}],
+    indirect=True,
+)
+def test_all_to_all_fabric_2d_bent_axis(mesh_device):
+    run_all_to_all_impl(
+        mesh_device,
+        mesh_device.get_num_devices(),
+        logical_shape=[1, 128, 128, 512],
+        in_dim=1,
+        out_dim=2,
+        num_links=2,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        topology=ttnn.Topology.Ring,
+        num_iters=2,
+        input_mem_config=ttnn.DRAM_MEMORY_CONFIG,
+        output_mem_config=ttnn.DRAM_MEMORY_CONFIG,
+        do_check=True,
+        trace_mode=False,
+        reuse_inputs=False,
+        cluster_axis=1,
+    )
+
+
 @pytest.mark.parametrize(
     "mesh_device,device_params,cluster_axis",
     [

--- a/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_all_to_all_async_generic_perf.py
+++ b/tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly/test_all_to_all_async_generic_perf.py
@@ -1,0 +1,213 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Traced correctness and performance coverage for GLM's production all-to-all reshards.
+
+The complete four-chip QuietBox or eight-chip LoudBox is used as one TP ring.  Per-chip tensor
+volume matches production, while the output shard scales with the physical ring size.  Both
+reshard directions run in one test so a passing performance result also proves bit-exact data
+movement through the same traced command stream.
+"""
+
+import math
+import statistics
+from dataclasses import dataclass
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole, skip_with_llk_assert, skip_with_watcher
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_equal
+from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program_merged, require_realtime_profiler
+
+_NUM_LINKS = 2
+_MAX_PACKET_PAYLOAD_SIZE = 14 * 1024
+_PROFILE_SAMPLES = 3
+# Same-shape BF16 TILE qualification references with a 2% relative margin.
+_REFERENCE_USEFUL_BANDWIDTH_GBPS = {
+    (4, "head_to_sequence"): 31.3,
+    (4, "sequence_to_head"): 31.3,
+    (8, "head_to_sequence"): 31.8,
+    (8, "sequence_to_head"): 36.7,
+}
+_PERF_MARGIN = 0.02
+
+
+@dataclass(frozen=True)
+class ReshardCase:
+    name: str
+    local_input_shape: tuple[int, ...]
+    in_dim: int
+    out_dim: int
+
+
+def _reshard_cases(ring_size):
+    return (
+        ReshardCase("head_to_sequence", (1, 16, 640, 576), in_dim=1, out_dim=2),
+        ReshardCase("sequence_to_head", (1, 16 * ring_size, 640 // ring_size, 512), in_dim=2, out_dim=1),
+    )
+
+
+def _fabric_router_config():
+    config = ttnn.FabricRouterConfig()
+    config.max_packet_payload_size_bytes = _MAX_PACKET_PAYLOAD_SIZE
+    return config
+
+
+_DEVICE_PARAMS = {
+    "fabric_config": ttnn.FabricConfig.FABRIC_2D_TORUS_XY,
+    "fabric_router_config": _fabric_router_config(),
+    "reliability_mode": ttnn.FabricReliabilityMode.STRICT_INIT,
+    "fabric_tensix_config": ttnn.FabricTensixConfig.DISABLED,
+    "trace_region_size": 100_000,
+    "require_exact_physical_num_devices": True,
+}
+
+
+def _make_input(mesh_device, case):
+    ring_size = mesh_device.shape[0]
+    global_shape = list(case.local_input_shape)
+    global_shape[case.in_dim] *= ring_size
+    torch.manual_seed(0)
+    host_input = torch.rand(global_shape, dtype=torch.bfloat16)
+    mapper = ttnn.create_mesh_mapper(
+        mesh_device,
+        ttnn.MeshMapperConfig([ttnn.PlacementShard(case.in_dim), ttnn.PlacementShard(case.out_dim)], mesh_device.shape),
+    )
+    device_input = ttnn.from_torch(
+        host_input,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=mapper,
+    )
+    assert tuple(ttnn.get_device_tensors(device_input)[0].shape) == case.local_input_shape
+    return host_input, device_input
+
+
+def _make_output(mesh_device, case):
+    output_shape = list(case.local_input_shape)
+    output_shape[case.in_dim] *= mesh_device.shape[0]
+    output_shape[case.out_dim] //= mesh_device.shape[0]
+    return ttnn.from_torch(
+        torch.zeros(output_shape, dtype=torch.bfloat16),
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+
+def _all_to_all_duration_ns(programs):
+    durations = [
+        info["duration_ns"]
+        for info in programs.values()
+        if any("all_to_all_sender_writer.cpp" in source for source in info["kernel_sources"])
+    ]
+    assert len(durations) == 1, f"expected one generic all-to-all program, found {len(durations)} in {programs}"
+    return durations[0]
+
+
+def _run_reshard(mesh_device, case):
+    host_input, device_input = _make_input(mesh_device, case)
+    output_buffer = _make_output(mesh_device, case)
+    trace_id = None
+    trace_capture_ended = False
+    trace_output = None
+    try:
+
+        def run_once():
+            return ttnn.experimental.all_to_all_async_generic(
+                device_input,
+                in_dim=case.in_dim,
+                out_dim=case.out_dim,
+                persistent_output_buffer=output_buffer,
+                num_links=_NUM_LINKS,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                topology=ttnn.Topology.Ring,
+                cluster_axis=0,
+            )
+
+        # Compile outside capture, then capture exactly one production collective.
+        run_once()
+        ttnn.synchronize_device(mesh_device)
+
+        trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+        trace_output = run_once()
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        trace_capture_ended = True
+        ttnn.synchronize_device(mesh_device)
+
+        def replay_once():
+            ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=False)
+
+        # Exclude first-replay jitter, then take a real-time device-profiler median.
+        replay_once()
+        ttnn.synchronize_device(mesh_device)
+        durations_ns = []
+        for _ in range(_PROFILE_SAMPLES):
+            _, programs = profile_realtime_program_merged(mesh_device, replay_once)
+            durations_ns.append(_all_to_all_duration_ns(programs))
+
+        actual = ttnn.to_torch(trace_output, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=case.out_dim))
+        equal, message = comp_equal(host_input, actual)
+        assert equal, f"{case.name} traced all-to-all output mismatch: {message}"
+
+        median_ns = statistics.median(durations_ns)
+        local_input_bytes = math.prod(case.local_input_shape) * torch.bfloat16.itemsize
+        useful_remote_bytes = local_input_bytes * (mesh_device.shape[0] - 1) / mesh_device.shape[0]
+        useful_bandwidth_gbps = useful_remote_bytes / median_ns
+        reference_bandwidth_gbps = _REFERENCE_USEFUL_BANDWIDTH_GBPS[(mesh_device.shape[0], case.name)]
+        minimum_bandwidth_gbps = reference_bandwidth_gbps * (1 - _PERF_MARGIN)
+        logger.info(
+            "all_to_all_async_generic production proxy: case={} ring_size={} fabric={} topology=ring "
+            "payload={}B links={} local_input={} median={:.3f}us useful_bw={:.3f}GB/s "
+            "reference={:.3f}GB/s minimum={:.3f}GB/s samples_us={}".format(
+                case.name,
+                mesh_device.shape[0],
+                ttnn.get_fabric_config(),
+                ttnn.get_tt_fabric_max_payload_size_bytes(),
+                _NUM_LINKS,
+                case.local_input_shape,
+                median_ns / 1e3,
+                useful_bandwidth_gbps,
+                reference_bandwidth_gbps,
+                minimum_bandwidth_gbps,
+                [round(duration / 1e3, 3) for duration in durations_ns],
+            )
+        )
+        assert useful_bandwidth_gbps >= minimum_bandwidth_gbps, (
+            f"{case.name} useful bandwidth {useful_bandwidth_gbps:.3f} GB/s is below "
+            f"{minimum_bandwidth_gbps:.3f} GB/s (reference {reference_bandwidth_gbps:.3f} GB/s)"
+        )
+    finally:
+        if trace_id is not None:
+            try:
+                if not trace_capture_ended:
+                    ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+            finally:
+                ttnn.release_trace(mesh_device, trace_id)
+        ttnn.deallocate(output_buffer)
+        ttnn.deallocate(device_input)
+
+
+@run_for_blackhole("generic all-to-all production perf coverage requires Blackhole fabric")
+@pytest.mark.requires_host_iommu
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
+@skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
+@pytest.mark.parametrize("mesh_device", [(4, 1), (8, 1)], ids=["quietbox_4x1", "loudbox_8x1"], indirect=True)
+@pytest.mark.parametrize("device_params", [_DEVICE_PARAMS], indirect=True)
+@pytest.mark.timeout(0)
+def test_all_to_all_async_generic_production_perf_and_accuracy(mesh_device):
+    """Verify both GLM reshards on the complete physical Ring and gate their traced device bandwidth."""
+    require_realtime_profiler("generic all-to-all production perf checks")
+    assert ttnn.get_num_devices() == math.prod(mesh_device.shape)
+    assert ttnn.get_fabric_config() == ttnn.FabricConfig.FABRIC_2D_TORUS_XY
+    assert ttnn.get_tt_fabric_max_payload_size_bytes() == _MAX_PACKET_PAYLOAD_SIZE
+
+    for case in _reshard_cases(mesh_device.shape[0]):
+        _run_reshard(mesh_device, case)

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_device_operation.cpp
@@ -5,18 +5,106 @@
 #include "all_to_all_async_generic_device_operation.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+#include <tt-metalium/distributed_context.hpp>
+#include <tt-metalium/distributed_host_buffer.hpp>
+
+namespace {
+
+struct DrainCoreMapping {
+    std::vector<ttnn::CoreCoord> logical_core_candidates;
+    std::vector<ttnn::CoreCoord> virtual_cores;
+};
+
+DrainCoreMapping gather_drain_virtual_cores(
+    const ttnn::Tensor& input_tensor, const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    struct DrainCoreRecord {
+        uint32_t valid = 0;
+        uint32_t x = 0;
+        uint32_t y = 0;
+    };
+
+    auto* mesh_device = input_tensor.device();
+    const auto subdevice = sub_device_id.value_or(mesh_device->get_sub_device_ids().at(0));
+    const auto available_core_count =
+        mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, subdevice).num_cores();
+    TT_FATAL(available_core_count > 0, "All-to-all cannot select its drain synchronization core");
+    // Direct schedules drain on selected core 0. Mux schedules place the mux on core 0 and drain on sender core 1.
+    // Use the same allocation helper as the program factory so non-rectangular subdevices produce the same prefix.
+    auto [candidate_core_range, logical_core_candidates] =
+        ttnn::ccl::choose_worker_cores(1, std::min<size_t>(2, available_core_count), mesh_device, sub_device_id);
+    (void)candidate_core_range;
+    const auto mesh_shape = mesh_device->shape();
+    const size_t candidates_per_node = logical_core_candidates.size();
+
+    std::vector<DrainCoreRecord> local_records(mesh_shape.mesh_size() * candidates_per_node);
+    auto maybe_device_it = mesh_device->get_view().begin();
+    for (const auto& coord : ttnn::MeshCoordinateRange(mesh_shape)) {
+        const auto& maybe_coordinate_device = *maybe_device_it++;
+        if (maybe_coordinate_device.is_remote()) {
+            continue;
+        }
+        const size_t node_index = coord.to_linear_index(mesh_shape);
+        for (size_t candidate = 0; candidate < candidates_per_node; ++candidate) {
+            const auto drain_virtual_core =
+                maybe_coordinate_device.value()->worker_core_from_logical_core(logical_core_candidates[candidate]);
+            local_records[node_index * candidates_per_node + candidate] = {
+                .valid = 1,
+                .x = static_cast<uint32_t>(drain_virtual_core.x),
+                .y = static_cast<uint32_t>(drain_virtual_core.y)};
+        }
+    }
+
+    // Like the device collective itself, this host exchange requires SPMD invocation by every mesh rank. Every rank
+    // enters it on every Fabric2D invocation, independently of its local program-cache state. Do not process-cache
+    // this exchange: asymmetric caches across ranks would let some ranks skip the collective and deadlock the others.
+    // Exchanging only the two possible drain coordinates per mesh node keeps heterogeneous harvesting correct without
+    // putting a collective in the program factory or exposing remote device translation through MeshDevice.
+    const auto distributed_context = tt::tt_metal::DistributedHostBuffer::create(mesh_device->get_view()).context();
+    const size_t world_size = *distributed_context->size();
+    std::vector<DrainCoreRecord> gathered_records(local_records.size() * world_size);
+    if (world_size == 1) {
+        gathered_records = local_records;
+    } else {
+        distributed_context->all_gather(
+            ttsl::as_writable_bytes(ttsl::Span<DrainCoreRecord>{local_records}),
+            ttsl::as_writable_bytes(ttsl::Span<DrainCoreRecord>{gathered_records}));
+    }
+
+    std::vector<ttnn::CoreCoord> drain_virtual_cores(local_records.size());
+    std::vector<uint32_t> owner_counts(local_records.size(), 0);
+    for (size_t rank = 0; rank < world_size; ++rank) {
+        for (size_t node = 0; node < local_records.size(); ++node) {
+            const auto& record = gathered_records[rank * local_records.size() + node];
+            if (record.valid == 0) {
+                continue;
+            }
+            TT_FATAL(
+                owner_counts[node] == 0,
+                "All-to-all mesh node {} drain candidate {} is owned by more than one distributed rank",
+                node / candidates_per_node,
+                node % candidates_per_node);
+            drain_virtual_cores[node] = {record.x, record.y};
+            owner_counts[node] = 1;
+        }
+    }
+    for (size_t node = 0; node < owner_counts.size(); ++node) {
+        TT_FATAL(
+            owner_counts[node] == 1,
+            "No distributed rank owns all-to-all mesh node {} drain candidate {}",
+            node / candidates_per_node,
+            node % candidates_per_node);
+    }
+    return {
+        .logical_core_candidates = std::move(logical_core_candidates), .virtual_cores = std::move(drain_virtual_cores)};
+}
+
+}  // namespace
 
 namespace ttnn::experimental::prim {
 
 void AllToAllAsyncGenericDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     validate_on_program_cache_hit(operation_attributes, tensor_args);
-
-    if (tt::tt_fabric::is_2d_fabric_config(tt::tt_fabric::GetFabricConfig())) {
-        TT_FATAL(
-            operation_attributes.cluster_axis.has_value(),
-            "all_to_all_async_generic on FABRIC_2D requires a cluster_axis");
-    }
 
     const auto& input_tensor = tensor_args.input_tensor;
     TT_FATAL(input_tensor.storage_type() == StorageType::DEVICE, "Operands to all_to_all_async must be on device");
@@ -92,6 +180,12 @@ void AllToAllAsyncGenericDeviceOperation::validate_on_program_cache_miss(
 
 void AllToAllAsyncGenericDeviceOperation::validate_on_program_cache_hit(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    if (tt::tt_fabric::is_2d_fabric_config(tt::tt_fabric::GetFabricConfig())) {
+        TT_FATAL(
+            operation_attributes.cluster_axis.has_value(),
+            "all_to_all_async_generic on FABRIC_2D requires a cluster_axis");
+    }
+
     const auto& input_tensor = tensor_args.input_tensor;
     const auto& persistent_output_buffer = tensor_args.persistent_output_buffer;
 
@@ -158,8 +252,6 @@ ttsl::hash::hash_t AllToAllAsyncGenericDeviceOperation::compute_program_hash(
     auto sd_id = subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
     auto subdevice_core_range_set = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
     const auto fabric_config = tt::tt_fabric::GetFabricConfig();
-    const auto axis_topology = ttnn::ccl::get_axis_topology(
-        tensor_args.input_tensor, fabric_config, operation_attributes.cluster_axis.value_or(0));
     const auto max_payload_size = tt::tt_fabric::get_tt_fabric_max_payload_size_bytes();
     // The cached program contains the fabric mux kernel and client ABI. Bump this whenever either changes.
     constexpr uint32_t fabric_mux_implementation_version = 2;
@@ -171,11 +263,14 @@ ttsl::hash::hash_t AllToAllAsyncGenericDeviceOperation::compute_program_hash(
         operation_attributes.output_mem_config,
         operation_attributes.topology,
         operation_attributes.cluster_axis,
+        operation_attributes.axis_is_straight,
         subdevice_core_range_set,
         fabric_config,
-        axis_topology,
+        operation_attributes.axis_topology,
         max_payload_size,
         fabric_mux_implementation_version,
+        operation_attributes.drain_logical_core_candidates,
+        operation_attributes.drain_virtual_cores,
         tensor_args);
 }
 
@@ -197,6 +292,17 @@ Tensor all_to_all_async_generic(
         "all_to_all_async is a collective operation and requires more than 1 device, but has {}",
         num_devices);
 
+    DrainCoreMapping drain_core_mapping;
+    const auto fabric_config = tt::tt_fabric::GetFabricConfig();
+    const bool is_fabric_2d = tt::tt_fabric::is_2d_fabric_config(fabric_config);
+    const uint32_t resolved_cluster_axis = cluster_axis.value_or(0);
+    const auto axis_topology = ttnn::ccl::get_axis_topology(input_tensor, fabric_config, resolved_cluster_axis);
+    const bool axis_is_straight =
+        !is_fabric_2d || ttnn::ccl::is_axis_straight(*input_tensor.device(), resolved_cluster_axis);
+    if (is_fabric_2d) {
+        drain_core_mapping = gather_drain_virtual_cores(input_tensor, sub_device_id);
+    }
+
     auto operation_attributes = OperationType::operation_attributes_t{
         .in_dim = static_cast<uint32_t>(in_dim),
         .out_dim = static_cast<uint32_t>(out_dim),
@@ -205,7 +311,11 @@ Tensor all_to_all_async_generic(
         .output_mem_config = memory_config.value_or(input_tensor.memory_config()),
         .topology = topology,
         .sub_device_id = sub_device_id,
-        .cluster_axis = cluster_axis};
+        .cluster_axis = cluster_axis,
+        .axis_topology = axis_topology,
+        .axis_is_straight = axis_is_straight,
+        .drain_logical_core_candidates = std::move(drain_core_mapping.logical_core_candidates),
+        .drain_virtual_cores = std::move(drain_core_mapping.virtual_cores)};
     auto tensor_args = OperationType::tensor_args_t{
         .input_tensor = input_tensor, .persistent_output_buffer = persistent_output_buffer};
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_device_operation_types.hpp
@@ -6,8 +6,10 @@
 
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/operations/ccl/ccl_host_datastructures.hpp"
+#include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/sub_device.hpp>
 #include <optional>
+#include <vector>
 
 namespace ttnn::experimental::prim {
 
@@ -20,6 +22,10 @@ struct AllToAllAsyncGenericParams {
     const ttnn::ccl::Topology topology;
     const std::optional<tt::tt_metal::SubDeviceId> sub_device_id;
     const std::optional<uint32_t> cluster_axis;
+    const tt::tt_fabric::Topology axis_topology;
+    const bool axis_is_straight;
+    const std::vector<tt::tt_metal::CoreCoord> drain_logical_core_candidates;
+    const std::vector<tt::tt_metal::CoreCoord> drain_virtual_cores;
 };
 
 struct AllToAllAsyncGenericInputs {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/all_to_all_async_generic_program_factory.cpp
@@ -12,6 +12,7 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <algorithm>
+#include <cstddef>
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
@@ -19,6 +20,53 @@
 namespace ttnn::experimental::prim {
 
 namespace {
+// The active route-buffer size is specialized into the device kernel. Bound host-generated custom routes by the
+// smallest supported Fabric2D tier; the kernel additionally checks its exact compile-time capacity before injection.
+// TODO: Replace this conservative bound when an existing Fabric API exposes the active route-buffer capacity.
+constexpr uint32_t minimum_fabric2d_route_capacity = 19;
+
+struct CustomFabric2DRoute {
+    uint32_t num_commands = 0;
+    tt::tt_fabric::eth_chan_directions initial_direction = tt::tt_fabric::eth_chan_directions::COUNT;
+    std::vector<uint32_t> packed_commands;
+};
+
+uint8_t fabric_direction_command(tt::tt_fabric::eth_chan_directions direction) {
+    using MeshRoutingFields = tt::tt_fabric::RoutingFieldsConstants::Mesh;
+    switch (direction) {
+        case tt::tt_fabric::eth_chan_directions::EAST: return MeshRoutingFields::FORWARD_EAST;
+        case tt::tt_fabric::eth_chan_directions::WEST: return MeshRoutingFields::FORWARD_WEST;
+        case tt::tt_fabric::eth_chan_directions::NORTH: return MeshRoutingFields::FORWARD_NORTH;
+        case tt::tt_fabric::eth_chan_directions::SOUTH: return MeshRoutingFields::FORWARD_SOUTH;
+        default:
+            TT_THROW("All-to-all custom route does not support fabric direction {}", static_cast<uint32_t>(direction));
+    }
+}
+
+uint8_t fabric_terminal_command(tt::tt_fabric::eth_chan_directions incoming_direction) {
+    switch (incoming_direction) {
+        case tt::tt_fabric::eth_chan_directions::EAST:
+            return fabric_direction_command(tt::tt_fabric::eth_chan_directions::WEST);
+        case tt::tt_fabric::eth_chan_directions::WEST:
+            return fabric_direction_command(tt::tt_fabric::eth_chan_directions::EAST);
+        case tt::tt_fabric::eth_chan_directions::NORTH:
+            return fabric_direction_command(tt::tt_fabric::eth_chan_directions::SOUTH);
+        case tt::tt_fabric::eth_chan_directions::SOUTH:
+            return fabric_direction_command(tt::tt_fabric::eth_chan_directions::NORTH);
+        default:
+            TT_THROW(
+                "All-to-all custom route does not support fabric direction {}",
+                static_cast<uint32_t>(incoming_direction));
+    }
+}
+
+void set_packed_route_command(CustomFabric2DRoute& route, uint32_t command_index, uint8_t command) {
+    constexpr uint32_t commands_per_word = 8;
+    TT_FATAL(command_index / commands_per_word < route.packed_commands.size(), "Custom route command is out of range");
+    route.packed_commands[command_index / commands_per_word] |= static_cast<uint32_t>(command)
+                                                                << ((command_index % commands_per_word) * 4);
+}
+
 ttnn::Shape get_tiled_shape(const ttnn::Tensor& input_tensor) {
     const auto& tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
     const auto& shape = input_tensor.padded_shape();
@@ -49,9 +97,256 @@ static_assert(
     banks_owned_by_link(8, 3, 0) == 3 && banks_owned_by_link(8, 3, 1) == 3 && banks_owned_by_link(8, 3, 2) == 2,
     "Uneven 8-bank/3-link ownership must distribute as 3, 3, 2");
 
-constexpr uint32_t direction_schedule_cores_per_link(uint32_t workers_per_direction) {
-    const uint32_t mux_cores = workers_per_direction > 1 ? 2 : 0;
-    return 2 * workers_per_direction + mux_cores + 1;  // two directions, optional muxes, and local copy
+constexpr uint32_t direction_schedule_cores_per_link(uint32_t workers_per_direction, uint32_t num_direction_groups) {
+    const uint32_t mux_cores = workers_per_direction > 1 ? num_direction_groups : 0;
+    return num_direction_groups * workers_per_direction + mux_cores + 1;  // remote groups, muxes, and local copy
+}
+
+constexpr uint32_t num_cardinal_fabric_directions = ttnn::operations::ccl::common::num_fabric_directions;
+
+struct AllToAllStreamSchedule {
+    std::vector<std::vector<int32_t>> device_offsets;
+    std::vector<std::vector<std::vector<uint32_t>>> block_starts;
+    std::vector<std::vector<std::vector<uint32_t>>> block_ends;
+    std::vector<std::vector<std::vector<uint32_t>>> block_strides;
+    std::vector<std::vector<std::vector<uint32_t>>> completion_flags;
+    uint32_t semaphore_sent = 0;
+};
+
+AllToAllStreamSchedule build_stream_schedule(
+    const AllToAllAsyncGenericParams& operation_attributes,
+    const Tensor& input_tensor,
+    const MeshCoordinate& mesh_coordinate,
+    const tt::tt_fabric::FabricNodeId& sender_device_fabric_node_id,
+    ttnn::ccl::Topology effective_topology,
+    uint32_t device_index,
+    bool is_ring,
+    bool is_fabric_2d,
+    bool split_antipode_across_arcs,
+    bool use_direction_owned_schedule,
+    bool use_bank_owned_schedule,
+    uint32_t workers_per_direction,
+    size_t num_senders_per_link,
+    size_t local_sender_stream,
+    uint32_t num_direction_groups,
+    const std::vector<uint32_t>& direction_group_to_physical_direction,
+    const std::array<int32_t, num_cardinal_fabric_directions>& physical_direction_to_group,
+    uint32_t num_dram_banks,
+    uint32_t blocks_per_core,
+    uint32_t num_blocks,
+    uint32_t block_stride) {
+    AllToAllStreamSchedule schedule{
+        .device_offsets = std::vector<std::vector<int32_t>>(num_senders_per_link),
+        .block_starts = std::vector<std::vector<std::vector<uint32_t>>>(num_senders_per_link),
+        .block_ends = std::vector<std::vector<std::vector<uint32_t>>>(num_senders_per_link),
+        .block_strides = std::vector<std::vector<std::vector<uint32_t>>>(num_senders_per_link),
+        .completion_flags = std::vector<std::vector<std::vector<uint32_t>>>(num_senders_per_link),
+    };
+    for (size_t stream = 0; stream < num_senders_per_link; ++stream) {
+        schedule.block_starts[stream].resize(operation_attributes.num_links);
+        schedule.block_ends[stream].resize(operation_attributes.num_links);
+        schedule.block_strides[stream].resize(operation_attributes.num_links);
+        schedule.completion_flags[stream].resize(operation_attributes.num_links);
+    }
+
+    auto* device = input_tensor.device();
+    std::vector<std::vector<uint32_t>> destination_groups(num_senders_per_link);
+    std::vector<int32_t> ring_ordered_offsets;
+    std::vector<uint32_t> direction_target_indices(num_direction_groups, 0);
+    auto direction_group_for_offset = [&](int32_t device_offset) -> uint32_t {
+        if (!is_fabric_2d) {
+            return device_offset < 0 ? 1 : 0;
+        }
+        const bool antipodal =
+            split_antipode_across_arcs && std::abs(device_offset) * 2 == operation_attributes.num_devices;
+        const int32_t route_offset = antipodal ? (device_offset > 0 ? 1 : -1) : device_offset;
+        const auto connection_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
+            input_tensor, mesh_coordinate, route_offset, effective_topology, operation_attributes.cluster_axis);
+        TT_FATAL(connection_coord.has_value(), "No all-to-all target at device offset {}", device_offset);
+        const auto connection_node = device->get_fabric_node_id(*connection_coord);
+        const auto direction =
+            tt::tt_fabric::get_eth_forwarding_direction(sender_device_fabric_node_id, connection_node);
+        TT_FATAL(
+            direction.has_value(),
+            "No Fabric2D forwarding direction from all-to-all source {} to target {}",
+            sender_device_fabric_node_id,
+            connection_node);
+        const uint32_t direction_index = static_cast<uint32_t>(*direction);
+        TT_FATAL(
+            direction_index < physical_direction_to_group.size() && physical_direction_to_group[direction_index] >= 0,
+            "Fabric2D direction {} is absent from the collective all-to-all schedule",
+            direction_index);
+        return static_cast<uint32_t>(physical_direction_to_group[direction_index]);
+    };
+    auto sender_stream_for_offset = [&](int32_t device_offset) {
+        if (device_offset == 0 && num_senders_per_link > 1) {
+            return local_sender_stream;
+        }
+        if (use_direction_owned_schedule) {
+            const uint32_t direction_group = direction_group_for_offset(device_offset);
+            return static_cast<size_t>(direction_group) * workers_per_direction +
+                   (direction_target_indices[direction_group]++ % workers_per_direction);
+        }
+        return size_t{0};
+    };
+    if (is_ring) {
+        // Visit global destinations in the same order on every source to avoid a cyclic fabric schedule.
+        // Use the shortest signed Ring offset; preserve the raw sign for an even-size antipode.
+        for (uint32_t target_device = 0; target_device < operation_attributes.num_devices; ++target_device) {
+            int32_t device_offset = static_cast<int32_t>(target_device) - static_cast<int32_t>(device_index);
+            const int32_t half_ring = static_cast<int32_t>(operation_attributes.num_devices / 2);
+            if (device_offset < -half_ring) {
+                device_offset += operation_attributes.num_devices;
+            } else if (device_offset > half_ring) {
+                device_offset -= operation_attributes.num_devices;
+            }
+            if (use_direction_owned_schedule && use_bank_owned_schedule) {
+                ring_ordered_offsets.push_back(device_offset);
+            } else {
+                const size_t sender_stream = sender_stream_for_offset(device_offset);
+                schedule.device_offsets[sender_stream].push_back(device_offset);
+                destination_groups[sender_stream].push_back(target_device);
+            }
+        }
+    } else {
+        // Keep a common global order on every source, but alternate destinations from opposite ends of the line.
+        // This gives the independent positive/negative fabric connections a chance to drain concurrently instead
+        // of issuing every destination on one side before turning to the other side.
+        for (uint32_t step = 0; step < operation_attributes.num_devices; ++step) {
+            const uint32_t target_device = step % 2 == 0 ? step / 2 : operation_attributes.num_devices - 1 - step / 2;
+            const int32_t device_offset = static_cast<int32_t>(target_device) - static_cast<int32_t>(device_index);
+            const size_t sender_stream = sender_stream_for_offset(device_offset);
+            schedule.device_offsets[sender_stream].push_back(device_offset);
+            destination_groups[sender_stream].push_back(step / 2);
+        }
+    }
+
+    std::vector<std::vector<uint32_t>> bank_indices(num_senders_per_link);
+    if (use_bank_owned_schedule) {
+        const uint32_t max_banks_per_link = banks_owned_by_link(num_dram_banks, operation_attributes.num_links, 0);
+        if (is_ring && use_direction_owned_schedule) {
+            // A TP4 Ring has only one or two remote destinations per direction. Assigning a whole destination to one
+            // worker would leave most mux clients idle, so stripe each destination's DRAM banks across all workers in
+            // that direction. Each bank still owns a full contiguous packet stream; opposite directions retain
+            // opposite bank order to reduce receiver-side bank contention.
+            for (uint32_t target_index = 0; target_index < ring_ordered_offsets.size(); ++target_index) {
+                const int32_t device_offset = ring_ordered_offsets[target_index];
+                const bool local = device_offset == 0;
+                const bool antipodal = !local && split_antipode_across_arcs &&
+                                       std::abs(device_offset) * 2 == operation_attributes.num_devices;
+                const int32_t half_ring = static_cast<int32_t>(operation_attributes.num_devices / 2);
+                for (uint32_t bank_phase = 0; bank_phase < max_banks_per_link; ++bank_phase) {
+                    // Split an even Ring's antipodal destination evenly across both arcs. Source parity swaps which
+                    // arc owns bank 0 so adjacent sources do not start on the same direction. Other negative routes
+                    // retain reverse bank order to avoid matching the positive direction's receiver-bank phase.
+                    const int32_t routed_offset =
+                        antipodal ? (((bank_phase + device_index) % 2 == 0) ? half_ring : -half_ring) : device_offset;
+                    const uint32_t direction_base =
+                        local ? 0 : direction_group_for_offset(routed_offset) * workers_per_direction;
+                    const uint32_t bank_in_link =
+                        !antipodal && routed_offset < 0 ? max_banks_per_link - 1 - bank_phase : bank_phase;
+                    const size_t sender_stream =
+                        local ? local_sender_stream
+                              : direction_base + ((bank_phase + target_index) % workers_per_direction);
+                    schedule.device_offsets[sender_stream].push_back(routed_offset);
+                    bank_indices[sender_stream].push_back(bank_in_link);
+                }
+            }
+        } else {
+            for (uint32_t stream = 0; stream < num_senders_per_link; ++stream) {
+                auto& stream_offsets = schedule.device_offsets[stream];
+                const auto ordered_targets = stream_offsets;
+                const auto& ordered_groups = destination_groups[stream];
+                stream_offsets.clear();
+                stream_offsets.reserve(ordered_targets.size() * max_banks_per_link);
+                bank_indices[stream].reserve(ordered_targets.size() * max_banks_per_link);
+                // Alternate the two globally paired destinations after each bank slice. This preserves the common
+                // destination order while reducing the interval during which only one fabric direction is issued.
+                const uint32_t num_destination_groups =
+                    is_ring ? operation_attributes.num_devices : (operation_attributes.num_devices + 1) / 2;
+                for (uint32_t group = 0; group < num_destination_groups; ++group) {
+                    for (uint32_t bank_phase = 0; bank_phase < max_banks_per_link; ++bank_phase) {
+                        bool negative_direction_stream = false;
+                        if (use_direction_owned_schedule && stream < local_sender_stream) {
+                            const uint32_t direction_group = stream / workers_per_direction;
+                            const uint32_t direction = direction_group_to_physical_direction[direction_group];
+                            negative_direction_stream = is_fabric_2d
+                                                            ? direction == tt::tt_fabric::eth_chan_directions::WEST ||
+                                                                  direction == tt::tt_fabric::eth_chan_directions::NORTH
+                                                            : direction_group == 1;
+                        }
+                        // Walk opposite directions in opposite bank orders. This preserves each same-bank contiguous
+                        // packet and avoids making both directions contend for the same bank at the same time.
+                        const uint32_t bank_in_link =
+                            negative_direction_stream ? max_banks_per_link - 1 - bank_phase : bank_phase;
+                        for (uint32_t target_index = 0; target_index < ordered_targets.size(); ++target_index) {
+                            if (ordered_groups[target_index] == group) {
+                                stream_offsets.push_back(ordered_targets[target_index]);
+                                bank_indices[stream].push_back(bank_in_link);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    for (uint32_t link = 0; link < operation_attributes.num_links; ++link) {
+        uint32_t current_start_block = link * blocks_per_core;
+        uint32_t current_end_block = (link + 1) * blocks_per_core;
+        if (link == operation_attributes.num_links - 1) {
+            current_end_block = num_blocks;
+        }
+        for (size_t stream = 0; stream < num_senders_per_link; ++stream) {
+            for (size_t schedule_index = 0; schedule_index < schedule.device_offsets[stream].size(); ++schedule_index) {
+                if (use_bank_owned_schedule) {
+                    const uint32_t bank_in_link = bank_indices[stream][schedule_index];
+                    const uint32_t bank_start = bank_in_link * operation_attributes.num_links + link;
+                    // The final bank phase can be absent on some links when bank count is not divisible by link
+                    // count. Keep the common stream schedule and represent that link's missing bank as empty work.
+                    const bool link_owns_bank =
+                        bank_in_link < banks_owned_by_link(num_dram_banks, operation_attributes.num_links, link);
+                    schedule.block_starts[stream][link].push_back(link_owns_bank ? bank_start : num_blocks);
+                    schedule.block_ends[stream][link].push_back(num_blocks);
+                } else {
+                    schedule.block_starts[stream][link].push_back(current_start_block);
+                    schedule.block_ends[stream][link].push_back(current_end_block);
+                }
+                schedule.completion_flags[stream][link].push_back(false);
+                schedule.block_strides[stream][link].push_back(block_stride);
+            }
+        }
+    }
+
+    // Direction-owned schedules signal at the end of each contiguous non-empty destination run. Bank-phased
+    // schedules can alternate two destinations within a phase and signal once per destination and link. Both rules
+    // skip absent bank phases and generic empty work ranges.
+    // Each device must send the same number of completion signals that its transpose peer schedule sends back;
+    // the final barrier relies on this symmetric per-pair completion-count invariant.
+    for (size_t stream = 0; stream < num_senders_per_link; ++stream) {
+        for (uint32_t link = 0; link < operation_attributes.num_links; ++link) {
+            std::unordered_set<int32_t> completed_offsets;
+            bool has_next_nonempty_offset = false;
+            int32_t next_nonempty_offset = 0;
+            for (size_t schedule_index = schedule.device_offsets[stream].size(); schedule_index-- > 0;) {
+                if (schedule.block_starts[stream][link][schedule_index] >=
+                    schedule.block_ends[stream][link][schedule_index]) {
+                    continue;
+                }
+                const int32_t device_offset = schedule.device_offsets[stream][schedule_index];
+                const bool target_complete = use_bank_owned_schedule && !use_direction_owned_schedule
+                                                 ? completed_offsets.insert(device_offset).second
+                                                 : (!has_next_nonempty_offset || device_offset != next_nonempty_offset);
+                if (target_complete) {
+                    schedule.completion_flags[stream][link][schedule_index] = true;
+                    ++schedule.semaphore_sent;
+                }
+                has_next_nonempty_offset = true;
+                next_nonempty_offset = device_offset;
+            }
+        }
+    }
+    return schedule;
 }
 
 }  // namespace
@@ -106,11 +401,10 @@ AllToAllAsyncGenericProgram::create_at(
 
     const auto fabric_config = tt::tt_fabric::GetFabricConfig();
     const bool is_fabric_2d = tt::tt_fabric::is_2d_fabric_config(fabric_config);
+    const uint32_t fabric2d_route_capacity = is_fabric_2d ? minimum_fabric2d_route_capacity : 0;
     // FABRIC_2D_TORUS_X/Y wraps only one mesh axis even though get_fabric_topology() reports Torus for both.
     // Resolve wrapping for the collective's axis so a Ring on the other axis cannot open a nonexistent hop.
-    const auto axis_fabric_topology =
-        ttnn::ccl::get_axis_topology(tensor_args.input_tensor, fabric_config, cluster_axis);
-    const bool fabric_has_wrap_links = axis_fabric_topology == tt::tt_fabric::Topology::Ring;
+    const bool fabric_has_wrap_links = operation_attributes.axis_topology == tt::tt_fabric::Topology::Ring;
     const bool operation_uses_wrap_links =
         operation_attributes.topology == ttnn::ccl::Topology::Ring && fabric_has_wrap_links;
     const auto effective_topology =
@@ -123,16 +417,26 @@ AllToAllAsyncGenericProgram::create_at(
         tensor_args.input_tensor, mesh_coordinate, 1, effective_topology, operation_attributes.cluster_axis);
     const std::optional<MeshCoordinate> backward_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
         tensor_args.input_tensor, mesh_coordinate, -1, effective_topology, operation_attributes.cluster_axis);
-    const auto [fabric_neighbors, fabric_directions] = ttnn::operations::ccl::common::get_neighbors(
-        tensor_args.input_tensor.device()->get_view(),
-        mesh_coordinate,
-        connection_topology,
-        operation_attributes.cluster_axis);
+    const auto fabric_directions = ttnn::operations::ccl::common::get_neighbors(
+                                       tensor_args.input_tensor.device()->get_view(),
+                                       mesh_coordinate,
+                                       connection_topology,
+                                       operation_attributes.cluster_axis)
+                                       .second;
 
     TT_FATAL(device_index < operation_attributes.num_devices, "DEBUG: device_index: {}", device_index);
 
     tt::tt_metal::Program program{};
     MeshDevice* device = tensor_args.input_tensor.device();
+    // Mesh workloads build programs for global coordinates and discard remote programs at dispatch. Inspect the view's
+    // MaybeRemote entry rather than calling the deprecated physical-device APIs, which throw for remote coordinates.
+    // A remote coordinate only needs a representative device to complete construction; its translated NOC coordinates
+    // are never submitted by this rank. Local coordinates use their own chip for harvesting-aware NOC translation.
+    const auto coordinate_index = mesh_coordinate.to_linear_index(device->shape());
+    const auto& maybe_coordinate_device = *(device->get_view().begin() + static_cast<std::ptrdiff_t>(coordinate_index));
+    tt::tt_metal::IDevice* coordinate_device = maybe_coordinate_device.when(
+        [](tt::tt_metal::IDevice* local_device) { return local_device; },
+        [device]() { return static_cast<tt::tt_metal::IDevice*>(device); });
 
     std::vector<Tensor> input_tensors = {tensor_args.input_tensor};
     std::vector<Tensor> output_tensors = {tensor_return_value};
@@ -187,57 +491,229 @@ AllToAllAsyncGenericProgram::create_at(
     const uint32_t block_stride = use_bank_owned_schedule ? num_dram_banks : 1;
 
     // Direction ownership, worker parallelism, and bank ownership are independent choices. Large messages use up to
-    // three workers per physical direction; two or one are selected when a restricted subdevice cannot fit the
-    // preferred schedule. Multiple workers share one fabric connection through a mux, while a one-worker direction
-    // connects directly. Logical Ring over a non-wrapping mesh retains the legacy schedule because the sign of its
-    // logical shortest path does not identify the first physical hop.
+    // three workers per physical egress; two or one are selected when a restricted subdevice cannot fit the preferred
+    // schedule. Multiple workers sharing an egress use one mux, while a one-worker egress connects directly.
     constexpr uint32_t preferred_workers_per_direction = 3;
-    constexpr uint32_t mux_num_directions = 2;
-    const bool direction_routing_is_physical = !is_ring || fabric_has_wrap_links;
+    constexpr uint32_t logical_num_directions = 2;
+
+    // Build one collective-wide, compact ordering of the physical first-hop directions used by Fabric2D. Every chip
+    // uses the same stream-group indices, even when a direction is inactive on that chip, so transpose peers retain
+    // symmetric completion counts. A folded logical axis can use three or four physical egresses across the collective;
+    // grouping by the actual first hop lets those paths retain the parallel mux schedule instead of falling back to the
+    // serial routed schedule. Fabric1D uses fixed positive/negative logical groups.
+    std::array<bool, num_cardinal_fabric_directions> collective_physical_directions{};
+    if (is_fabric_2d) {
+        auto record_physical_direction = [&](const MeshCoordinate& source_coord, int32_t offset) {
+            const auto source_node = device->get_fabric_node_id(source_coord);
+            const auto connection_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
+                tensor_args.input_tensor, source_coord, offset, effective_topology, operation_attributes.cluster_axis);
+            TT_FATAL(connection_coord.has_value(), "No all-to-all target at device offset {}", offset);
+            const auto connection_node = device->get_fabric_node_id(*connection_coord);
+            const auto direction = tt::tt_fabric::get_eth_forwarding_direction(source_node, connection_node);
+            TT_FATAL(
+                direction.has_value(),
+                "No Fabric2D forwarding direction from all-to-all source {} to target {}",
+                source_node,
+                connection_node);
+            const uint32_t direction_index = static_cast<uint32_t>(*direction);
+            TT_FATAL(
+                direction_index < num_cardinal_fabric_directions,
+                "All-to-all does not support Fabric2D egress direction {}",
+                direction_index);
+            collective_physical_directions[direction_index] = true;
+        };
+
+        for (uint32_t source_device = 0; source_device < operation_attributes.num_devices; ++source_device) {
+            MeshCoordinate source_coord = mesh_coordinate;
+            source_coord[cluster_axis] = source_device;
+            for (uint32_t target_device = 0; target_device < operation_attributes.num_devices; ++target_device) {
+                int32_t device_offset = static_cast<int32_t>(target_device) - static_cast<int32_t>(source_device);
+                if (is_ring) {
+                    const int32_t half_ring = static_cast<int32_t>(operation_attributes.num_devices / 2);
+                    if (device_offset < -half_ring) {
+                        device_offset += operation_attributes.num_devices;
+                    } else if (device_offset > half_ring) {
+                        device_offset -= operation_attributes.num_devices;
+                    }
+                }
+                if (device_offset == 0) {
+                    continue;
+                }
+                record_physical_direction(source_coord, device_offset);
+            }
+        }
+    }
+
+    std::vector<uint32_t> direction_group_to_physical_direction;
+    std::array<int32_t, num_cardinal_fabric_directions> physical_direction_to_group{};
+    physical_direction_to_group.fill(-1);
+    if (is_fabric_2d) {
+        for (uint32_t direction = 0; direction < num_cardinal_fabric_directions; ++direction) {
+            if (collective_physical_directions[direction]) {
+                physical_direction_to_group[direction] =
+                    static_cast<int32_t>(direction_group_to_physical_direction.size());
+                direction_group_to_physical_direction.push_back(direction);
+            }
+        }
+    } else {
+        direction_group_to_physical_direction = {0, 1};
+    }
+    const uint32_t num_direction_groups = static_cast<uint32_t>(direction_group_to_physical_direction.size());
+    TT_FATAL(num_direction_groups > 0, "All-to-all collective has no remote direction groups");
+    auto get_direct_ring_hop_directions =
+        [&](const MeshCoordinate& source_coord,
+            int32_t device_offset) -> std::optional<std::vector<tt::tt_fabric::eth_chan_directions>> {
+        const uint32_t num_hops = std::abs(device_offset);
+        std::vector<tt::tt_fabric::eth_chan_directions> hop_directions;
+        hop_directions.reserve(num_hops);
+        auto previous_coord = source_coord;
+        for (uint32_t hop = 1; hop <= num_hops; ++hop) {
+            const int32_t hop_offset = device_offset > 0 ? static_cast<int32_t>(hop) : -static_cast<int32_t>(hop);
+            const auto next_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
+                tensor_args.input_tensor,
+                source_coord,
+                hop_offset,
+                effective_topology,
+                operation_attributes.cluster_axis);
+            TT_FATAL(next_coord.has_value(), "No ring coordinate at offset {}", hop_offset);
+            const auto previous_node = device->get_fabric_node_id(previous_coord);
+            const auto next_node = device->get_fabric_node_id(*next_coord);
+            // Host boundaries do not affect this proof because every rank has the global physical direction map.
+            // Inter-mesh routers can replace a custom route at the boundary, so retain canonical routing for those
+            // arcs.
+            if (previous_node.mesh_id != next_node.mesh_id) {
+                return std::nullopt;
+            }
+            const auto directions = tt::tt_fabric::get_neighbor_eth_directions(previous_node, next_node);
+            if (directions.empty()) {
+                return std::nullopt;
+            }
+            hop_directions.push_back(directions.front());
+            previous_coord = *next_coord;
+        }
+        return hop_directions;
+    };
+
+    auto custom_ring_route_is_representable = [&](const std::optional<std::vector<tt::tt_fabric::eth_chan_directions>>&
+                                                      maybe_hop_directions) {
+        if (!maybe_hop_directions.has_value() || maybe_hop_directions->empty() ||
+            maybe_hop_directions->size() > fabric2d_route_capacity) {
+            return false;
+        }
+        const auto& hop_directions = *maybe_hop_directions;
+        auto is_spine_direction = [](tt::tt_fabric::eth_chan_directions direction) {
+            return direction == tt::tt_fabric::eth_chan_directions::NORTH ||
+                   direction == tt::tt_fabric::eth_chan_directions::SOUTH;
+        };
+        auto is_branch_direction = [](tt::tt_fabric::eth_chan_directions direction) {
+            return direction == tt::tt_fabric::eth_chan_directions::EAST ||
+                   direction == tt::tt_fabric::eth_chan_directions::WEST;
+        };
+        // The mesh header has only one branch offset per E/W direction. A custom route with zeroed branch offsets is
+        // therefore safe only when a spine router never hands the packet to an E/W branch router. Canonical routing
+        // remains the correctness fallback for folded arcs that need that transition (including multi-turn snakes).
+        for (uint32_t hop = 1; hop < hop_directions.size(); ++hop) {
+            if (is_spine_direction(hop_directions[hop - 1]) && is_branch_direction(hop_directions[hop])) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    bool split_antipode_across_arcs = is_ring && !is_fabric_2d;
+    if (is_ring && is_fabric_2d && operation_attributes.num_devices > 2 && operation_attributes.num_devices % 2 == 0) {
+        const int32_t half_ring = static_cast<int32_t>(operation_attributes.num_devices / 2);
+        split_antipode_across_arcs = true;
+        for (uint32_t source_device = 0; source_device < operation_attributes.num_devices; ++source_device) {
+            MeshCoordinate source_coord = mesh_coordinate;
+            source_coord[cluster_axis] = source_device;
+            const auto positive_hops = get_direct_ring_hop_directions(source_coord, half_ring);
+            const auto negative_hops = get_direct_ring_hop_directions(source_coord, -half_ring);
+            const bool source_can_split = custom_ring_route_is_representable(positive_hops) &&
+                                          custom_ring_route_is_representable(negative_hops) &&
+                                          positive_hops->front() != negative_hops->front();
+            if (!source_can_split) {
+                split_antipode_across_arcs = false;
+                break;
+            }
+        }
+    }
+
+    auto build_custom_ring_route = [&](int32_t device_offset) {
+        CustomFabric2DRoute route;
+        const auto maybe_hop_directions = get_direct_ring_hop_directions(mesh_coordinate, device_offset);
+        TT_FATAL(maybe_hop_directions.has_value(), "All-to-all custom Fabric2D route requires direct ring edges");
+        const auto& hop_directions = *maybe_hop_directions;
+        const uint32_t num_hops = hop_directions.size();
+        TT_FATAL(
+            custom_ring_route_is_representable(maybe_hop_directions),
+            "All-to-all custom Fabric2D route with {} hops is not representable by the active {}-command header",
+            num_hops,
+            fabric2d_route_capacity);
+        route.num_commands = num_hops;
+        route.packed_commands.resize((num_hops + 7) / 8, 0);
+        route.initial_direction = hop_directions.front();
+
+        // Injection selects hop 0's egress. Each intermediate router consumes the next hop's direction, and the
+        // destination consumes the direction opposite its ingress to drain locally.
+        for (uint32_t command = 0; command + 1 < num_hops; ++command) {
+            set_packed_route_command(route, command, fabric_direction_command(hop_directions[command + 1]));
+        }
+        set_packed_route_command(route, num_hops - 1, fabric_terminal_command(hop_directions.back()));
+        return route;
+    };
+
     const uint32_t max_useful_workers_per_direction =
         is_ring ? preferred_workers_per_direction
                 : std::min(preferred_workers_per_direction, operation_attributes.num_devices - 1);
     TT_FATAL(max_useful_workers_per_direction > 0, "Direction-owned all-to-all requires at least two devices");
     // Normalize the message into full-payload packet equivalents per direction-worker lane. A lane is the pair of
     // same-index positive/negative workers: destination placement decides which member receives the work, while the
-    // total message determines whether adding that lane can amortize its worker and mux startup. Five-run size sweeps
-    // put the Linear crossover at 16 packet equivalents per lane. Ring needs only four because the legacy schedule
-    // serializes both physical directions through one remote stream. Unlike a byte cutoff, this scales with fabric
-    // payload capacity, tensor page size, link count, and the number of useful worker lanes.
+    // total message determines whether adding that lane can amortize its worker and mux startup. Linear requires 16
+    // packet equivalents per lane. Ring requires four because the compact schedule serializes both physical directions
+    // through one remote stream. Unlike a byte cutoff, this scales with fabric payload capacity, tensor page size,
+    // link count, and the number of useful worker lanes.
     constexpr uint32_t linear_min_packets_per_lane = 16;
     constexpr uint32_t ring_min_packets_per_lane = 4;
     const uint32_t min_packets_per_lane = is_ring ? ring_min_packets_per_lane : linear_min_packets_per_lane;
     const uint64_t packets_per_lane =
         tensor_return_value.buffer()->num_pages() / (static_cast<uint64_t>(operation_attributes.num_links) *
                                                      max_useful_workers_per_direction * number_pages_per_packet);
-    const bool parallel_workers_are_worthwhile = packets_per_lane >= min_packets_per_lane;
+    // The thresholds apply to two direction groups. Folded axes can require three or four physical egresses, each with
+    // its own workers and mux, so scale the startup cost proportionally.
+    const bool parallel_workers_are_worthwhile =
+        packets_per_lane * logical_num_directions >= static_cast<uint64_t>(min_packets_per_lane) * num_direction_groups;
     uint32_t workers_per_direction = 0;
-    if (direction_routing_is_physical && parallel_workers_are_worthwhile) {
-        // Deliberately qualify the preferred three-worker schedule before adapting to core capacity. Two workers are
-        // a restricted-subdevice fallback for large messages, not a lower size tier; sweeps on full-core systems did
-        // not find a message-size region where choosing two workers was better than both legacy and three workers.
+    if (parallel_workers_are_worthwhile) {
+        // Qualify the preferred three-worker schedule before adapting to core capacity. Two workers are a
+        // restricted-subdevice fallback for large messages, not a lower size tier.
         for (uint32_t candidate = max_useful_workers_per_direction; candidate > 0; --candidate) {
-            if (direction_schedule_cores_per_link(candidate) * operation_attributes.num_links <=
+            if (direction_schedule_cores_per_link(candidate, num_direction_groups) * operation_attributes.num_links <=
                 available_worker_cores) {
                 workers_per_direction = candidate;
                 break;
             }
         }
     }
-    // A single direct worker per direction is safe for the generic scatter order on a line. Bank-owned batches can
-    // cyclically block independent direct directions. On a 2D Ring/Torus, routing can choose either equal-cost path
-    // for an antipodal destination, while a direct direction-owned worker opens only one of them. Retain the proven
-    // legacy remote/local schedule for either case when a restricted subdevice cannot fit a mux tier. A muxed stream
-    // is safe on a 2D Ring/Torus because it injects through a concrete physical neighbor; that first hop breaks an
-    // antipodal tie, after which routing from the neighbor continues along the selected arc.
-    if (workers_per_direction == 1 && (use_bank_owned_schedule || (is_fabric_2d && fabric_has_wrap_links))) {
+    // A single direct worker per direction is safe for generic scatter order. Bank-owned batches can cyclically block
+    // independent direct directions, so use the compact schedule when a restricted subdevice cannot fit a mux tier.
+    // Fabric2D antipodes are safe once streams are grouped by their concrete first hop.
+    if (workers_per_direction == 1 && use_bank_owned_schedule) {
         workers_per_direction = 0;
     }
     const bool use_direction_owned_schedule = workers_per_direction > 0;
+    // Explicit antipode routes belong to the direction-owned schedule. The compact schedule uses canonical Fabric2D
+    // routing, which also keeps its per-target runtime record below the Tensix RTA limit.
+    if (is_fabric_2d && !use_direction_owned_schedule) {
+        split_antipode_across_arcs = false;
+    }
+    const uint32_t custom_fabric2d_route_words =
+        is_fabric_2d && split_antipode_across_arcs ? (operation_attributes.num_devices / 2 + 7) / 8 : 0;
     const bool use_worker_mux = workers_per_direction > 1;
     const uint32_t mux_cores_per_direction = workers_per_direction + 1;
-    const uint32_t direction_senders_per_link = mux_num_directions * workers_per_direction + 1;
-    const uint32_t direction_total_cores_per_link = direction_schedule_cores_per_link(workers_per_direction);
+    const uint32_t direction_senders_per_link = num_direction_groups * workers_per_direction + 1;
+    const uint32_t direction_total_cores_per_link =
+        direction_schedule_cores_per_link(workers_per_direction, num_direction_groups);
     const size_t num_senders_per_link = use_direction_owned_schedule
                                             ? direction_senders_per_link
                                             : (available_worker_cores >= 2 * operation_attributes.num_links ? 2 : 1);
@@ -256,23 +732,23 @@ AllToAllAsyncGenericProgram::create_at(
 
     std::vector<CoreCoord> sender_worker_cores;
     sender_worker_cores.reserve(operation_attributes.num_links * num_senders_per_link);
-    std::vector<std::array<CoreCoord, mux_num_directions>> mux_cores(
-        use_worker_mux ? operation_attributes.num_links : 0);
+    std::vector<std::vector<CoreCoord>> mux_cores(
+        use_worker_mux ? operation_attributes.num_links : 0,
+        std::vector<CoreCoord>(use_worker_mux ? num_direction_groups : 0));
     std::set<CoreRange> sender_worker_core_set;
     for (uint32_t link = 0; link < operation_attributes.num_links; ++link) {
         const uint32_t link_base = link * total_cores_per_link;
         if (use_worker_mux) {
-            mux_cores[link][0] = all_worker_cores[link_base];
-            mux_cores[link][1] = all_worker_cores[link_base + mux_cores_per_direction];
-            for (uint32_t worker = 0; worker < workers_per_direction; ++worker) {
-                sender_worker_cores.push_back(all_worker_cores[link_base + 1 + worker]);
-            }
-            for (uint32_t worker = 0; worker < workers_per_direction; ++worker) {
-                sender_worker_cores.push_back(all_worker_cores[link_base + mux_cores_per_direction + 1 + worker]);
+            for (uint32_t direction_group = 0; direction_group < num_direction_groups; ++direction_group) {
+                const uint32_t direction_base = link_base + direction_group * mux_cores_per_direction;
+                mux_cores[link][direction_group] = all_worker_cores[direction_base];
+                for (uint32_t worker = 0; worker < workers_per_direction; ++worker) {
+                    sender_worker_cores.push_back(all_worker_cores[direction_base + 1 + worker]);
+                }
             }
             sender_worker_cores.push_back(all_worker_cores[link_base + direction_total_cores_per_link - 1]);
         } else if (use_direction_owned_schedule) {
-            for (uint32_t worker = 0; worker < mux_num_directions * workers_per_direction; ++worker) {
+            for (uint32_t worker = 0; worker < num_direction_groups * workers_per_direction; ++worker) {
                 sender_worker_cores.push_back(all_worker_cores[link_base + worker]);
             }
             sender_worker_cores.push_back(all_worker_cores[link_base + direction_total_cores_per_link - 1]);
@@ -312,6 +788,7 @@ AllToAllAsyncGenericProgram::create_at(
 
     const uint32_t num_cores_per_blocks = operation_attributes.num_links;
     const uint32_t blocks_per_core = num_blocks / num_cores_per_blocks;
+    const size_t local_sender_stream = num_senders_per_link - 1;
 
     auto sender_reader_kernel_config = tt::tt_metal::ReaderDataMovementConfig{};
     sender_reader_kernel_config.compile_args = {
@@ -339,182 +816,34 @@ AllToAllAsyncGenericProgram::create_at(
         sender_worker_core_range,
         sender_reader_kernel_config);
 
-    std::vector<std::vector<int32_t>> device_offsets(num_senders_per_link);
-    std::vector<std::vector<uint32_t>> destination_groups(num_senders_per_link);
-    std::vector<int32_t> ring_ordered_offsets;
-    std::vector<std::vector<std::vector<uint32_t>>> block_starts(num_senders_per_link),
-        block_ends(num_senders_per_link), block_strides(num_senders_per_link), completion_flags(num_senders_per_link);
-    for (size_t i = 0; i < num_senders_per_link; ++i) {
-        block_starts[i].resize(operation_attributes.num_links);
-        block_ends[i].resize(operation_attributes.num_links);
-        block_strides[i].resize(operation_attributes.num_links);
-        completion_flags[i].resize(operation_attributes.num_links);
-    }
-    const size_t local_sender_stream = num_senders_per_link - 1;
-    uint32_t positive_target_index = 0;
-    uint32_t negative_target_index = 0;
-    auto sender_stream_for_offset = [&](int32_t device_offset) {
-        if (device_offset == 0 && num_senders_per_link > 1) {
-            return local_sender_stream;
-        }
-        if (use_direction_owned_schedule) {
-            if (device_offset < 0) {
-                return size_t{workers_per_direction + (negative_target_index++ % workers_per_direction)};
-            }
-            return size_t{positive_target_index++ % workers_per_direction};
-        }
-        return size_t{0};
-    };
-    if (is_ring) {
-        // Visit global destinations in the same order on every source to avoid a cyclic fabric schedule.
-        // Use the shortest signed Ring offset; preserve the raw sign for an even-size antipode.
-        for (uint32_t target_device = 0; target_device < operation_attributes.num_devices; ++target_device) {
-            int32_t device_offset = static_cast<int32_t>(target_device) - static_cast<int32_t>(device_index);
-            const int32_t half_ring = static_cast<int32_t>(operation_attributes.num_devices / 2);
-            if (device_offset < -half_ring) {
-                device_offset += operation_attributes.num_devices;
-            } else if (device_offset > half_ring) {
-                device_offset -= operation_attributes.num_devices;
-            }
-            if (use_direction_owned_schedule && use_bank_owned_schedule) {
-                ring_ordered_offsets.push_back(device_offset);
-            } else {
-                const size_t sender_stream = sender_stream_for_offset(device_offset);
-                device_offsets[sender_stream].push_back(device_offset);
-                destination_groups[sender_stream].push_back(target_device);
-            }
-        }
-    } else {
-        // Keep a common global order on every source, but alternate destinations from opposite ends of the line.
-        // This gives the independent positive/negative fabric connections a chance to drain concurrently instead
-        // of issuing every destination on one side before turning to the other side.
-        for (uint32_t step = 0; step < operation_attributes.num_devices; ++step) {
-            const uint32_t target_device = step % 2 == 0 ? step / 2 : operation_attributes.num_devices - 1 - step / 2;
-            const int32_t device_offset = static_cast<int32_t>(target_device) - static_cast<int32_t>(device_index);
-            const size_t sender_stream = sender_stream_for_offset(device_offset);
-            device_offsets[sender_stream].push_back(device_offset);
-            destination_groups[sender_stream].push_back(step / 2);
-        }
-    }
-    std::vector<std::vector<uint32_t>> bank_indices(num_senders_per_link);
-    if (use_bank_owned_schedule) {
-        const uint32_t max_banks_per_link = banks_owned_by_link(num_dram_banks, operation_attributes.num_links, 0);
-        if (is_ring && use_direction_owned_schedule) {
-            // A TP4 Ring has only one or two remote destinations per direction. Assigning a whole destination to one
-            // worker would leave most mux clients idle, so stripe each destination's DRAM banks across all workers in
-            // that direction. Each bank still owns a full contiguous packet stream; opposite directions retain
-            // opposite bank order to reduce receiver-side bank contention.
-            for (uint32_t target_index = 0; target_index < ring_ordered_offsets.size(); ++target_index) {
-                const int32_t device_offset = ring_ordered_offsets[target_index];
-                const bool local = device_offset == 0;
-                const bool antipodal = !local && std::abs(device_offset) * 2 == operation_attributes.num_devices;
-                const int32_t half_ring = static_cast<int32_t>(operation_attributes.num_devices / 2);
-                for (uint32_t bank_phase = 0; bank_phase < max_banks_per_link; ++bank_phase) {
-                    // Split an even Ring's antipodal destination evenly across both arcs. Source parity swaps which
-                    // arc owns bank 0 so adjacent sources do not start on the same direction. Other negative routes
-                    // retain reverse bank order to avoid matching the positive direction's receiver-bank phase.
-                    const int32_t routed_offset =
-                        antipodal ? (((bank_phase + device_index) % 2 == 0) ? half_ring : -half_ring) : device_offset;
-                    const uint32_t direction_base = routed_offset < 0 ? workers_per_direction : 0;
-                    const uint32_t bank_in_link =
-                        !antipodal && routed_offset < 0 ? max_banks_per_link - 1 - bank_phase : bank_phase;
-                    const size_t sender_stream =
-                        local ? local_sender_stream
-                              : direction_base + ((bank_phase + target_index) % workers_per_direction);
-                    device_offsets[sender_stream].push_back(routed_offset);
-                    bank_indices[sender_stream].push_back(bank_in_link);
-                }
-            }
-        } else {
-            for (uint32_t stream = 0; stream < num_senders_per_link; ++stream) {
-                auto& stream_offsets = device_offsets[stream];
-                const auto ordered_targets = stream_offsets;
-                const auto ordered_groups = destination_groups[stream];
-                stream_offsets.clear();
-                stream_offsets.reserve(ordered_targets.size() * max_banks_per_link);
-                bank_indices[stream].reserve(ordered_targets.size() * max_banks_per_link);
-                // Alternate the two globally paired destinations after each bank slice. This preserves the common
-                // destination order while reducing the interval during which only one fabric direction is issued.
-                const uint32_t num_destination_groups =
-                    is_ring ? operation_attributes.num_devices : (operation_attributes.num_devices + 1) / 2;
-                for (uint32_t group = 0; group < num_destination_groups; ++group) {
-                    for (uint32_t bank_phase = 0; bank_phase < max_banks_per_link; ++bank_phase) {
-                        const bool negative_direction_stream = use_direction_owned_schedule &&
-                                                               stream >= workers_per_direction &&
-                                                               stream < mux_num_directions * workers_per_direction;
-                        // Walk opposite directions in opposite bank orders. This preserves each same-bank contiguous
-                        // packet and avoids making both directions contend for the same bank at the same time.
-                        const uint32_t bank_in_link =
-                            negative_direction_stream ? max_banks_per_link - 1 - bank_phase : bank_phase;
-                        for (uint32_t target_index = 0; target_index < ordered_targets.size(); ++target_index) {
-                            if (ordered_groups[target_index] == group) {
-                                stream_offsets.push_back(ordered_targets[target_index]);
-                                bank_indices[stream].push_back(bank_in_link);
-                            }
-                        }
-                    }
-                }
-                destination_groups[stream].clear();
-            }
-        }
-    }
-
-    for (uint32_t link = 0; link < operation_attributes.num_links; ++link) {
-        uint32_t current_start_block = link * blocks_per_core;
-        uint32_t current_end_block = (link + 1) * blocks_per_core;
-        if (link == operation_attributes.num_links - 1) {
-            current_end_block = num_blocks;
-        }
-        for (size_t stream = 0; stream < num_senders_per_link; ++stream) {
-            for (size_t schedule_index = 0; schedule_index < device_offsets[stream].size(); ++schedule_index) {
-                if (use_bank_owned_schedule) {
-                    const uint32_t bank_in_link = bank_indices[stream][schedule_index];
-                    const uint32_t bank_start = bank_in_link * operation_attributes.num_links + link;
-                    // The final bank phase can be absent on some links when bank count is not divisible by link
-                    // count. Keep the common stream schedule and represent that link's missing bank as empty work.
-                    const bool link_owns_bank =
-                        bank_in_link < banks_owned_by_link(num_dram_banks, operation_attributes.num_links, link);
-                    block_starts[stream][link].push_back(link_owns_bank ? bank_start : num_blocks);
-                    block_ends[stream][link].push_back(num_blocks);
-                } else {
-                    block_starts[stream][link].push_back(current_start_block);
-                    block_ends[stream][link].push_back(current_end_block);
-                }
-                completion_flags[stream][link].push_back(false);
-                block_strides[stream][link].push_back(block_stride);
-            }
-        }
-    }
-
-    // Direction-owned schedules signal at the end of each contiguous non-empty destination run. The legacy
-    // bank-owned schedule can alternate two destinations within a bank phase, so retain its original one signal
-    // per destination and link. Both rules skip absent bank phases and generic empty work ranges.
-    // Each device must send the same number of completion signals that its transpose peer schedule sends back;
-    // the final barrier relies on this symmetric per-pair completion-count invariant.
-    uint32_t semaphore_sent = 0;
-    for (size_t stream = 0; stream < num_senders_per_link; ++stream) {
-        for (uint32_t link = 0; link < operation_attributes.num_links; ++link) {
-            std::unordered_set<int32_t> completed_offsets;
-            bool has_next_nonempty_offset = false;
-            int32_t next_nonempty_offset = 0;
-            for (size_t schedule_index = device_offsets[stream].size(); schedule_index-- > 0;) {
-                if (block_starts[stream][link][schedule_index] >= block_ends[stream][link][schedule_index]) {
-                    continue;
-                }
-                const int32_t device_offset = device_offsets[stream][schedule_index];
-                const bool target_complete = use_bank_owned_schedule && !use_direction_owned_schedule
-                                                 ? completed_offsets.insert(device_offset).second
-                                                 : (!has_next_nonempty_offset || device_offset != next_nonempty_offset);
-                if (target_complete) {
-                    completion_flags[stream][link][schedule_index] = true;
-                    ++semaphore_sent;
-                }
-                has_next_nonempty_offset = true;
-                next_nonempty_offset = device_offset;
-            }
-        }
-    }
-
+    const auto stream_schedule = build_stream_schedule(
+        operation_attributes,
+        tensor_args.input_tensor,
+        mesh_coordinate,
+        sender_device_fabric_node_id,
+        effective_topology,
+        device_index,
+        is_ring,
+        is_fabric_2d,
+        split_antipode_across_arcs,
+        use_direction_owned_schedule,
+        use_bank_owned_schedule,
+        workers_per_direction,
+        num_senders_per_link,
+        local_sender_stream,
+        num_direction_groups,
+        direction_group_to_physical_direction,
+        physical_direction_to_group,
+        num_dram_banks,
+        blocks_per_core,
+        num_blocks,
+        block_stride);
+    const auto& device_offsets = stream_schedule.device_offsets;
+    const auto& block_starts = stream_schedule.block_starts;
+    const auto& block_ends = stream_schedule.block_ends;
+    const auto& block_strides = stream_schedule.block_strides;
+    const auto& completion_flags = stream_schedule.completion_flags;
+    const uint32_t semaphore_sent = stream_schedule.semaphore_sent;
     std::vector<CoreRangeSet> sender_stream_core_ranges(num_senders_per_link);
     for (uint32_t core_id = 0; core_id < sender_worker_cores.size(); ++core_id) {
         const auto& core = sender_worker_cores[core_id];
@@ -529,20 +858,22 @@ AllToAllAsyncGenericProgram::create_at(
     if (use_direction_owned_schedule) {
         // Direction indices follow {East, West, North, South}. Axis 1 is horizontal and axis 0 is vertical.
         // A 1D connection only needs distinct non-zero masks; its low-latency header routes by signed hop count.
-        const uint32_t positive_direction = !is_fabric_2d || cluster_axis == 1 ? 0 : 3;
-        const uint32_t negative_direction = !is_fabric_2d || cluster_axis == 1 ? 1 : 2;
-        const bool has_positive_connection =
-            is_fabric_2d ? fabric_directions[positive_direction] : forward_coord.has_value();
-        const bool has_negative_connection =
-            is_fabric_2d ? fabric_directions[negative_direction] : backward_coord.has_value();
-        if (has_positive_connection) {
-            for (uint32_t worker = 0; worker < workers_per_direction; ++worker) {
-                sender_stream_direction_masks[worker] = 1U << positive_direction;
+        for (uint32_t direction_group = 0; direction_group < num_direction_groups; ++direction_group) {
+            const uint32_t direction = direction_group_to_physical_direction[direction_group];
+            bool has_connection = direction_group == 0 ? forward_coord.has_value() : backward_coord.has_value();
+            if (is_fabric_2d) {
+                has_connection = false;
+                for (uint32_t worker = 0; worker < workers_per_direction && !has_connection; ++worker) {
+                    const auto& offsets = device_offsets[direction_group * workers_per_direction + worker];
+                    has_connection = std::any_of(
+                        offsets.begin(), offsets.end(), [](int32_t device_offset) { return device_offset != 0; });
+                }
             }
-        }
-        if (has_negative_connection) {
+            if (!has_connection) {
+                continue;
+            }
             for (uint32_t worker = 0; worker < workers_per_direction; ++worker) {
-                sender_stream_direction_masks[workers_per_direction + worker] = 1U << negative_direction;
+                sender_stream_direction_masks[direction_group * workers_per_direction + worker] = 1U << direction;
             }
         }
     } else {
@@ -564,24 +895,148 @@ AllToAllAsyncGenericProgram::create_at(
             device->l1_size_per_core());
     }
 
+    struct Fabric2DConnectionInfo {
+        std::optional<tt::tt_fabric::FabricNodeId> representative_node;
+        std::vector<uint32_t> common_links;
+    };
+    auto add_fabric2d_connection_target = [&](std::array<Fabric2DConnectionInfo, num_cardinal_fabric_directions>& infos,
+                                              int32_t device_offset) {
+        if (device_offset == 0) {
+            return;
+        }
+        const bool antipodal =
+            split_antipode_across_arcs && std::abs(device_offset) * 2 == operation_attributes.num_devices;
+        const int32_t route_offset = antipodal ? (device_offset > 0 ? 1 : -1) : device_offset;
+        const auto connection_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
+            tensor_args.input_tensor,
+            mesh_coordinate,
+            route_offset,
+            effective_topology,
+            operation_attributes.cluster_axis);
+        TT_FATAL(connection_coord.has_value(), "No all-to-all target at device offset {}", device_offset);
+
+        const auto connection_node = device->get_fabric_node_id(*connection_coord);
+        const auto direction =
+            tt::tt_fabric::get_eth_forwarding_direction(sender_device_fabric_node_id, connection_node);
+        TT_FATAL(
+            direction.has_value(),
+            "No Fabric2D forwarding direction from all-to-all source {} to target {}",
+            sender_device_fabric_node_id,
+            connection_node);
+        auto& info = infos[static_cast<uint32_t>(*direction)];
+        const auto valid_links =
+            tt::tt_fabric::get_forwarding_link_indices(sender_device_fabric_node_id, connection_node);
+        TT_FATAL(
+            !valid_links.empty(),
+            "No Fabric2D forwarding links from all-to-all source {} to target {}",
+            sender_device_fabric_node_id,
+            connection_node);
+        if (!info.representative_node.has_value()) {
+            info.representative_node = connection_node;
+            info.common_links = valid_links;
+            return;
+        }
+        std::erase_if(info.common_links, [&](uint32_t link) {
+            return std::find(valid_links.begin(), valid_links.end(), link) == valid_links.end();
+        });
+        TT_FATAL(
+            !info.common_links.empty(),
+            "Fabric2D all-to-all targets in direction {} have no common forwarding link",
+            static_cast<uint32_t>(*direction));
+    };
+
     if (use_worker_mux) {
         for (uint32_t link = 0; link < operation_attributes.num_links; ++link) {
-            const std::array<std::optional<MeshCoordinate>, mux_num_directions> direction_neighbors = {
-                forward_coord, backward_coord};
-            for (uint32_t direction = 0; direction < mux_num_directions; ++direction) {
-                const uint32_t representative_stream = direction * workers_per_direction;
+            for (uint32_t direction_group = 0; direction_group < num_direction_groups; ++direction_group) {
+                const uint32_t representative_stream = direction_group * workers_per_direction;
                 if (sender_stream_direction_masks[representative_stream] == 0) {
                     continue;
                 }
-                TT_FATAL(direction_neighbors[direction].has_value(), "Active all-to-all mux direction has no neighbor");
+                const uint32_t physical_direction = direction_group_to_physical_direction[direction_group];
+                std::optional<tt::tt_fabric::FabricNodeId> connection_node;
+                std::vector<uint32_t> common_links;
+                if (is_fabric_2d) {
+                    std::array<Fabric2DConnectionInfo, num_cardinal_fabric_directions> connection_infos;
+                    for (uint32_t worker = 0; worker < workers_per_direction; ++worker) {
+                        const auto& offsets = device_offsets[direction_group * workers_per_direction + worker];
+                        for (const int32_t device_offset : offsets) {
+                            add_fabric2d_connection_target(connection_infos, device_offset);
+                        }
+                    }
+                    connection_node = connection_infos[physical_direction].representative_node;
+                    common_links = std::move(connection_infos[physical_direction].common_links);
+                } else {
+                    const auto& neighbor_coord = direction_group == 0 ? forward_coord : backward_coord;
+                    if (neighbor_coord.has_value()) {
+                        connection_node = device->get_fabric_node_id(*neighbor_coord);
+                    }
+                }
+                TT_FATAL(connection_node.has_value(), "Active all-to-all mux direction has no connection node");
+                uint32_t connection_link = link;
+                // Fabric1D wrap links are not represented in the routing table, so use the configured link index.
+                if (is_fabric_2d) {
+                    TT_FATAL(
+                        link < common_links.size(),
+                        "All-to-all link {} is unavailable for Fabric2D mux direction {} ({} link(s) available)",
+                        link,
+                        physical_direction,
+                        common_links.size());
+                    connection_link = common_links[link];
+                }
                 tt::tt_fabric::add_fabric_mux_v2_to_program(
                     program,
                     mux_config,
-                    mux_cores[link][direction],
+                    mux_cores[link][direction_group],
                     sender_device_fabric_node_id,
-                    device->get_fabric_node_id(*direction_neighbors[direction]),
-                    link);
+                    *connection_node,
+                    connection_link);
             }
+        }
+    }
+
+    const CoreCoord drain_sync_logical_core = sender_worker_cores[0];
+    const auto drain_sync_core = is_fabric_2d
+                                     ? coordinate_device->worker_core_from_logical_core(drain_sync_logical_core)
+                                     : device->worker_core_from_logical_core(drain_sync_logical_core);
+    size_t drain_candidate_index = 0;
+    if (is_fabric_2d) {
+        const auto candidate_it = std::find(
+            operation_attributes.drain_logical_core_candidates.begin(),
+            operation_attributes.drain_logical_core_candidates.end(),
+            drain_sync_logical_core);
+        TT_FATAL(
+            candidate_it != operation_attributes.drain_logical_core_candidates.end(),
+            "All-to-all drain logical core {} is not one of the exchanged candidates",
+            drain_sync_logical_core);
+        drain_candidate_index = std::distance(operation_attributes.drain_logical_core_candidates.begin(), candidate_it);
+        TT_FATAL(
+            operation_attributes.drain_virtual_cores.size() ==
+                device->shape().mesh_size() * operation_attributes.drain_logical_core_candidates.size(),
+            "All-to-all drain-core map has {} entries for {} nodes and {} candidates",
+            operation_attributes.drain_virtual_cores.size(),
+            device->shape().mesh_size(),
+            operation_attributes.drain_logical_core_candidates.size());
+    }
+    auto get_target_drain_core = [&](const MeshCoordinate& target_coord) {
+        const size_t target_index =
+            target_coord.to_linear_index(device->shape()) * operation_attributes.drain_logical_core_candidates.size() +
+            drain_candidate_index;
+        TT_FATAL(
+            target_index < operation_attributes.drain_virtual_cores.size(),
+            "Missing all-to-all drain core for mesh coordinate {}",
+            target_coord);
+        return operation_attributes.drain_virtual_cores[target_index];
+    };
+    bool use_multicast_initialization = is_fabric_2d && operation_attributes.axis_is_straight;
+    if (use_multicast_initialization) {
+        // Multicast is valid only on a physically straight axis and when every destination maps the drain semaphore
+        // to the same harvested worker. Bent axes and heterogeneous harvesting use destination-specific unicasts.
+        for (uint32_t target_device = 0;
+             target_device < operation_attributes.num_devices && use_multicast_initialization;
+             ++target_device) {
+            MeshCoordinate target_coord = mesh_coordinate;
+            target_coord[cluster_axis] = target_device;
+            use_multicast_initialization = get_target_drain_core(target_coord) == drain_sync_core;
         }
     }
 
@@ -607,12 +1062,14 @@ AllToAllAsyncGenericProgram::create_at(
             *sender_device_fabric_node_id.mesh_id,       // source_mesh_id
             is_fabric_2d,                                // is_fabric_2d
             sender_stream_direction_masks[stream],       // fabric_direction_mask
-            number_pages_per_packet                      // max_pages_per_packet
+            number_pages_per_packet,                     // max_pages_per_packet
+            custom_fabric2d_route_words,                 // custom_fabric2d_route_words
+            use_multicast_initialization                 // use_multicast_initialization
         };
 
         tt::tt_metal::TensorAccessorArgs(tensor_return_value.buffer())
             .append_to(sender_writer_kernel_config.compile_args);
-        const bool stream_uses_mux = use_worker_mux && stream < mux_num_directions * workers_per_direction &&
+        const bool stream_uses_mux = use_worker_mux && stream < num_direction_groups * workers_per_direction &&
                                      sender_stream_direction_masks[stream] != 0;
         sender_writer_kernel_config.compile_args.push_back(stream_uses_mux);
         sender_writer_kernel_config.compile_args.push_back(workers_per_direction);
@@ -627,28 +1084,38 @@ AllToAllAsyncGenericProgram::create_at(
 
     CoreRange sender_box = sender_worker_core_range.bounding_box();
     // Swap start and end coord
-    const uint32_t mcast_dest_noc_start_x = device->worker_core_from_logical_core(sender_box.end_coord).x;
-    const uint32_t mcast_dest_noc_end_x = device->worker_core_from_logical_core(sender_box.start_coord).x;
-    const uint32_t mcast_dest_noc_start_y = device->worker_core_from_logical_core(sender_box.end_coord).y;
-    const uint32_t mcast_dest_noc_end_y = device->worker_core_from_logical_core(sender_box.start_coord).y;
+    // MeshDevice translates through a representative chip, which is insufficient when Galaxy chips have different
+    // Tensix harvesting maps. These addresses are consumed by the program at mesh_coordinate, so translate them on
+    // that chip specifically.
+    const uint32_t mcast_dest_noc_start_x = coordinate_device->worker_core_from_logical_core(sender_box.end_coord).x;
+    const uint32_t mcast_dest_noc_end_x = coordinate_device->worker_core_from_logical_core(sender_box.start_coord).x;
+    const uint32_t mcast_dest_noc_start_y = coordinate_device->worker_core_from_logical_core(sender_box.end_coord).y;
+    const uint32_t mcast_dest_noc_end_y = coordinate_device->worker_core_from_logical_core(sender_box.start_coord).y;
     const uint32_t mcast_size = sender_box.size();
 
-    auto drain_sync_core = device->worker_core_from_logical_core(sender_worker_cores[0]);
+    CustomFabric2DRoute positive_antipode_route;
+    CustomFabric2DRoute negative_antipode_route;
+    if (is_fabric_2d && split_antipode_across_arcs) {
+        const int32_t half_ring = static_cast<int32_t>(operation_attributes.num_devices / 2);
+        positive_antipode_route = build_custom_ring_route(half_ring);
+        negative_antipode_route = build_custom_ring_route(-half_ring);
+    }
+    const CustomFabric2DRoute no_custom_route;
 
     for (uint32_t core_id = 0; core_id < sender_worker_cores.size(); ++core_id) {
         const auto& core = sender_worker_cores[core_id];
+        const size_t sender_stream = core_id % num_senders_per_link;
+        const uint32_t link = core_id / num_senders_per_link;
+        const auto& stream_device_offsets = device_offsets[sender_stream];
         std::vector<uint32_t> sender_reader_rt_args = {
             tensor_args.input_tensor.buffer()->address(),
-            device_offsets[core_id % num_senders_per_link].size(),
+            stream_device_offsets.size(),
         };
-        for (uint32_t i = 0; i < device_offsets[core_id % num_senders_per_link].size(); ++i) {
-            sender_reader_rt_args.push_back(device_offsets[core_id % num_senders_per_link][i]);
-            sender_reader_rt_args.push_back(
-                block_starts[core_id % num_senders_per_link][core_id / num_senders_per_link][i]);
-            sender_reader_rt_args.push_back(
-                block_ends[core_id % num_senders_per_link][core_id / num_senders_per_link][i]);
-            sender_reader_rt_args.push_back(
-                block_strides[core_id % num_senders_per_link][core_id / num_senders_per_link][i]);
+        for (uint32_t i = 0; i < stream_device_offsets.size(); ++i) {
+            sender_reader_rt_args.push_back(stream_device_offsets[i]);
+            sender_reader_rt_args.push_back(block_starts[sender_stream][link][i]);
+            sender_reader_rt_args.push_back(block_ends[sender_stream][link][i]);
+            sender_reader_rt_args.push_back(block_strides[sender_stream][link][i]);
         }
         tt::tt_metal::SetRuntimeArgs(program, sender_reader_kernel_id, {core}, sender_reader_rt_args);
 
@@ -656,8 +1123,8 @@ AllToAllAsyncGenericProgram::create_at(
             tensor_return_value.buffer()->address(),
             init_barrier_semaphore.address(),
             final_barrier_semaphore.address(),
-            core_id % num_senders_per_link,
-            core_id / num_senders_per_link,
+            sender_stream,
+            link,
             mcast_dest_noc_start_x,
             mcast_dest_noc_start_y,
             mcast_dest_noc_end_x,
@@ -665,21 +1132,17 @@ AllToAllAsyncGenericProgram::create_at(
             mcast_size,
             drain_sync_core.x,
             drain_sync_core.y,
-            device_offsets[core_id % num_senders_per_link].size(),
+            stream_device_offsets.size(),
         };
 
-        for (uint32_t i = 0; i < device_offsets[core_id % num_senders_per_link].size(); ++i) {
-            sender_writer_rt_args.push_back(device_offsets[core_id % num_senders_per_link][i]);
-            sender_writer_rt_args.push_back(
-                block_starts[core_id % num_senders_per_link][core_id / num_senders_per_link][i]);
-            sender_writer_rt_args.push_back(
-                block_ends[core_id % num_senders_per_link][core_id / num_senders_per_link][i]);
-            sender_writer_rt_args.push_back(
-                block_strides[core_id % num_senders_per_link][core_id / num_senders_per_link][i]);
-            sender_writer_rt_args.push_back(
-                completion_flags[core_id % num_senders_per_link][core_id / num_senders_per_link][i]);
+        for (uint32_t i = 0; i < stream_device_offsets.size(); ++i) {
+            sender_writer_rt_args.push_back(stream_device_offsets[i]);
+            sender_writer_rt_args.push_back(block_starts[sender_stream][link][i]);
+            sender_writer_rt_args.push_back(block_ends[sender_stream][link][i]);
+            sender_writer_rt_args.push_back(block_strides[sender_stream][link][i]);
+            sender_writer_rt_args.push_back(completion_flags[sender_stream][link][i]);
 
-            const int32_t device_offset = device_offsets[core_id % num_senders_per_link][i];
+            const int32_t device_offset = stream_device_offsets[i];
             const auto target_coord = ttnn::ccl::get_physical_neighbor_from_physical_coord(
                 tensor_args.input_tensor,
                 mesh_coordinate,
@@ -688,25 +1151,50 @@ AllToAllAsyncGenericProgram::create_at(
                 operation_attributes.cluster_axis);
             TT_FATAL(target_coord.has_value(), "No all-to-all target at device offset {}", device_offset);
 
-            if (tt::tt_fabric::is_2d_fabric_config(tt::tt_fabric::GetFabricConfig())) {
+            if (is_fabric_2d) {
                 const auto target_node_id = device->get_fabric_node_id(target_coord.value());
                 sender_writer_rt_args.push_back(*target_node_id.mesh_id);
                 sender_writer_rt_args.push_back(target_node_id.chip_id);
+                const auto target_drain_sync_core = get_target_drain_core(*target_coord);
+                sender_writer_rt_args.push_back(target_drain_sync_core.x);
+                sender_writer_rt_args.push_back(target_drain_sync_core.y);
             } else {
                 // The low-latency 1D header uses the second route field as a hop count.
                 sender_writer_rt_args.push_back(0);
                 sender_writer_rt_args.push_back(std::abs(device_offset));
             }
+
+            const CustomFabric2DRoute* custom_route = &no_custom_route;
+            if (is_fabric_2d && split_antipode_across_arcs &&
+                std::abs(device_offset) * 2 == operation_attributes.num_devices) {
+                custom_route = device_offset > 0 ? &positive_antipode_route : &negative_antipode_route;
+            }
+            if (custom_fabric2d_route_words > 0) {
+                TT_FATAL(
+                    custom_route->packed_commands.empty() ||
+                        custom_route->packed_commands.size() == custom_fabric2d_route_words,
+                    "All-to-all custom route ABI expected {} packed words, got {}",
+                    custom_fabric2d_route_words,
+                    custom_route->packed_commands.size());
+                sender_writer_rt_args.push_back(custom_route->num_commands);
+                sender_writer_rt_args.push_back(static_cast<uint32_t>(custom_route->initial_direction));
+                if (custom_route->packed_commands.empty()) {
+                    sender_writer_rt_args.insert(sender_writer_rt_args.end(), custom_fabric2d_route_words, 0);
+                } else {
+                    sender_writer_rt_args.insert(
+                        sender_writer_rt_args.end(),
+                        custom_route->packed_commands.begin(),
+                        custom_route->packed_commands.end());
+                }
+            }
         }
-        const size_t sender_stream = core_id % num_senders_per_link;
         const bool is_remote_sender = sender_stream != local_sender_stream || num_senders_per_link == 1;
-        const bool stream_uses_mux = use_worker_mux && sender_stream < mux_num_directions * workers_per_direction &&
+        const bool stream_uses_mux = use_worker_mux && sender_stream < num_direction_groups * workers_per_direction &&
                                      sender_stream_direction_masks[sender_stream] != 0;
         if (stream_uses_mux) {
-            const uint32_t link = core_id / num_senders_per_link;
             const uint32_t direction = sender_stream / workers_per_direction;
             const uint32_t worker = sender_stream % workers_per_direction;
-            const auto mux_virtual_core = device->worker_core_from_logical_core(mux_cores[link][direction]);
+            const auto mux_virtual_core = coordinate_device->worker_core_from_logical_core(mux_cores[link][direction]);
             const auto flow_control_sem_id = tt::tt_metal::CreateSemaphore(program, core, 0);
             const auto teardown_sem_id = tt::tt_metal::CreateSemaphore(program, core, 0);
             mux_config.append_client_connection_rt_args(
@@ -715,31 +1203,45 @@ AllToAllAsyncGenericProgram::create_at(
                 {.flow_control_sem_id = flow_control_sem_id, .teardown_sem_id = teardown_sem_id},
                 sender_writer_rt_args);
         } else if (is_fabric_2d) {
+            // Open one routed connection for every physical first-hop direction used by this stream. Logical axes can
+            // fold through the physical mesh, so neither the logical sign nor a single link index identifies all valid
+            // sender planes. The manager tags each connection by physical direction for the kernel's route lookup.
+            std::array<Fabric2DConnectionInfo, num_cardinal_fabric_directions> connection_infos;
             if (is_remote_sender) {
-                // Append connections in the same {E, W, N, S} order as the compile-time direction mask.
-                size_t neighbor_index = 0;
-                for (uint32_t direction = 0; direction < fabric_directions.size(); ++direction) {
-                    if (!fabric_directions[direction]) {
-                        continue;
-                    }
-                    const auto& neighbor_coord = fabric_neighbors[neighbor_index++];
-                    if ((sender_stream_direction_masks[sender_stream] & (1U << direction)) == 0) {
-                        continue;
-                    }
-                    tt::tt_fabric::append_fabric_connection_rt_args(
-                        sender_device_fabric_node_id,
-                        device->get_fabric_node_id(neighbor_coord),
-                        core_id / num_senders_per_link,
-                        program,
-                        {core},
-                        sender_writer_rt_args);
+                for (const int32_t device_offset : device_offsets[sender_stream]) {
+                    add_fabric2d_connection_target(connection_infos, device_offset);
                 }
             }
+            std::vector<tt::tt_fabric::FabricNodeId> connection_nodes;
+            std::vector<uint32_t> connection_links;
+            const uint32_t requested_link = link;
+            for (const auto& info : connection_infos) {
+                if (!info.representative_node.has_value()) {
+                    continue;
+                }
+                TT_FATAL(
+                    requested_link < info.common_links.size(),
+                    "All-to-all link {} is unavailable for Fabric2D direction with {} common link(s)",
+                    requested_link,
+                    info.common_links.size());
+                connection_nodes.push_back(*info.representative_node);
+                connection_links.push_back(info.common_links[requested_link]);
+            }
+            sender_writer_rt_args.push_back(static_cast<uint32_t>(connection_nodes.size()));
+            tt::tt_fabric::append_routing_plane_connection_manager_rt_args(
+                sender_device_fabric_node_id,
+                connection_nodes,
+                connection_links,
+                program,
+                sender_writer_kernel_ids[sender_stream],
+                core,
+                sender_writer_rt_args,
+                tt::tt_fabric::FabricApiType::Linear);
         } else {
             const bool owns_positive_direction = !use_direction_owned_schedule || sender_stream < workers_per_direction;
             const bool owns_negative_direction =
-                !use_direction_owned_schedule ||
-                (sender_stream >= workers_per_direction && sender_stream < mux_num_directions * workers_per_direction);
+                !use_direction_owned_schedule || (sender_stream >= workers_per_direction &&
+                                                  sender_stream < logical_num_directions * workers_per_direction);
             const bool with_forward = is_remote_sender && owns_positive_direction && forward_coord.has_value();
             const bool with_backward = is_remote_sender && owns_negative_direction && backward_coord.has_value();
             sender_writer_rt_args.push_back(with_forward);
@@ -748,7 +1250,7 @@ AllToAllAsyncGenericProgram::create_at(
                 tt::tt_fabric::append_fabric_connection_rt_args(
                     sender_device_fabric_node_id,
                     device->get_fabric_node_id(forward_coord.value()),
-                    core_id / num_senders_per_link,
+                    link,
                     program,
                     {core},
                     sender_writer_rt_args);
@@ -759,7 +1261,7 @@ AllToAllAsyncGenericProgram::create_at(
                 tt::tt_fabric::append_fabric_connection_rt_args(
                     sender_device_fabric_node_id,
                     device->get_fabric_node_id(backward_coord.value()),
-                    core_id / num_senders_per_link,
+                    link,
                     program,
                     {core},
                     sender_writer_rt_args);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_async_generic/device/kernels/all_to_all_sender_writer.cpp
@@ -11,6 +11,7 @@
 #include "cpp/ttnn/operations/ccl/common/types/fabric_directions.hpp"
 #include "cpp/ttnn/operations/ccl/kernel_common/worker_routing_utils.hpp"
 #include "cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "tt_metal/fabric/hw/inc/edm_fabric/routing_plane_connection_manager.hpp"
 #include "tt_metal/fabric/hw/inc/tt_fabric_mux_v2_sender.hpp"
 #include "ckernel.h"
 #include <cstdint>
@@ -39,63 +40,159 @@ constexpr uint16_t source_mesh_id = get_compile_time_arg_val(14);
 constexpr bool is_fabric_2d = get_compile_time_arg_val(15);
 constexpr uint32_t fabric_direction_mask = get_compile_time_arg_val(16);
 constexpr uint32_t max_pages_per_packet = get_compile_time_arg_val(17);
-constexpr auto output_tensor_args = TensorAccessorArgs<18>();
+constexpr uint32_t custom_fabric2d_route_words = get_compile_time_arg_val(18);
+constexpr bool use_multicast_initialization = get_compile_time_arg_val(19);
+constexpr auto output_tensor_args = TensorAccessorArgs<20>();
 constexpr uint32_t mux_ct_base = output_tensor_args.next_compile_time_args_offset();
-constexpr bool use_worker_mux = get_compile_time_arg_val(mux_ct_base) != 0;
+// This flag is specialized per stream by the host. Endpoint streams without a physical egress compile against the
+// routing-plane-manager ABI even when other streams in the same program use a worker mux.
+constexpr bool stream_uses_mux = get_compile_time_arg_val(mux_ct_base) != 0;
 constexpr uint32_t mux_num_clients = get_compile_time_arg_val(mux_ct_base + 1);
 constexpr uint32_t compile_safe_mux_num_clients = mux_num_clients == 0 ? 1 : mux_num_clients;
 constexpr bool has_fabric_connections = fabric_direction_mask != 0;
+constexpr bool has_custom_fabric2d_routes = custom_fabric2d_route_words != 0;
+static_assert(!has_custom_fabric2d_routes || is_fabric_2d, "Custom routes require Fabric2D");
+// Base record: offset, block range/stride, completion, mesh and chip. Fabric2D adds the destination's harvested drain
+// coordinate. Only programs that actually split an antipode add route metadata and the words used by that route.
+constexpr uint32_t target_drain_args = is_fabric_2d ? 2 : 0;
+constexpr uint32_t target_custom_route_args = has_custom_fabric2d_routes ? 2 + custom_fabric2d_route_words : 0;
+constexpr uint32_t target_runtime_args = 7 + target_drain_args + target_custom_route_args;
+constexpr uint32_t target_drain_args_idx = 7;
+constexpr uint32_t target_custom_route_args_idx = target_drain_args_idx + target_drain_args;
+constexpr uint32_t default_initial_direction = static_cast<uint32_t>(tt::tt_fabric::eth_chan_directions::COUNT);
 constexpr auto fabric_directions =
     ttnn::operations::ccl::common::fabric_direction_mask_to_directions(fabric_direction_mask);
-constexpr auto num_fabric_directions = ttnn::operations::ccl::common::num_fabric_directions;
-using Fabric2DConnections = std::array<tt::tt_fabric::WorkerToFabricEdmSender, num_fabric_directions>;
-using FabricMuxSender = tt::tt_fabric::FabricMuxV2Sender<>;
+using Fabric2DConnections = tt::tt_fabric::RoutingPlaneConnectionManager;
+using FabricMuxSender = tt::tt_fabric::FabricMuxV2Sender</*EAGER_STAGING=*/true>;
 struct FabricMuxConnection {
     FabricMuxSender sender;
 };
 using DirectFabricConnections = std::conditional_t<is_fabric_2d, Fabric2DConnections, FabricConnectionManager>;
-using FabricConnections = std::conditional_t<use_worker_mux, FabricMuxConnection, DirectFabricConnections>;
+using FabricConnections = std::conditional_t<stream_uses_mux, FabricMuxConnection, DirectFabricConnections>;
+constexpr bool fabric2d_multicast_initialization_is_safe = is_fabric_2d && use_multicast_initialization;
+
+FORCE_INLINE uint32_t get_custom_route_num_commands(size_t target_arg_idx) {
+    if constexpr (has_custom_fabric2d_routes) {
+        return get_arg_val<uint32_t>(target_arg_idx + target_custom_route_args_idx);
+    }
+    return 0;
+}
+
+FORCE_INLINE uint32_t get_custom_route_initial_direction(size_t target_arg_idx) {
+    if constexpr (has_custom_fabric2d_routes) {
+        return get_arg_val<uint32_t>(target_arg_idx + target_custom_route_args_idx + 1);
+    }
+    return default_initial_direction;
+}
+
+FORCE_INLINE size_t get_custom_route_packed_args_idx(size_t target_arg_idx) {
+    return target_arg_idx + target_custom_route_args_idx + 2;
+}
+
+[[noreturn]] FORCE_INLINE void fail_stop_invalid_fabric_route() {
+    // ASSERT gives watcher builds a precise failure signal. The explicit trap and spin remain the production fallback:
+    // an invalid route must not inject on an arbitrary egress and corrupt the collective's completion count.
+    ASSERT(false);
+    asm volatile("ebreak");
+    while (true) {
+    }
+}
+
+template <typename PacketHeader>
+FORCE_INLINE void set_target_unicast_route(
+    volatile PacketHeader* packet_header,
+    const ccl_routing_utils::line_unicast_route_info_t& route_info,
+    uint32_t custom_route_num_commands,
+    size_t custom_route_args_idx) {
+    if constexpr (std::is_base_of_v<tt::tt_fabric::HybridMeshPacketHeader, PacketHeader>) {
+        if (custom_route_num_commands == 0) {
+            tt::tt_fabric::fabric_set_unicast_route(packet_header, route_info.dst_chip_id, route_info.dst_mesh_id);
+        }
+        if (custom_route_num_commands != 0) {
+            if (custom_route_num_commands > tt::tt_fabric::FabricHeaderConfig::MESH_ROUTE_BUFFER_SIZE) {
+                fail_stop_invalid_fabric_route();
+            }
+            packet_header->dst_start_node_id =
+                (static_cast<uint32_t>(route_info.dst_mesh_id) << 16) | route_info.dst_chip_id;
+            packet_header->mcast_params_64 = 0;
+            packet_header->is_mcast_active = 0;
+            packet_header->routing_fields.value = 0;
+            for (uint32_t command = 0; command < tt::tt_fabric::FabricHeaderConfig::MESH_ROUTE_BUFFER_SIZE; ++command) {
+                constexpr uint32_t commands_per_word = 8;
+                uint8_t route_command = 0;
+                if (command < custom_route_num_commands) {
+                    const uint32_t packed_word =
+                        get_arg_val<uint32_t>(custom_route_args_idx + command / commands_per_word);
+                    route_command = static_cast<uint8_t>((packed_word >> ((command % commands_per_word) * 4)) & 0xf);
+                }
+                packet_header->route_buffer[command] = route_command;
+            }
+            return;
+        }
+    } else {
+        if (custom_route_num_commands != 0) {
+            fail_stop_invalid_fabric_route();
+        }
+        ccl_routing_utils::fabric_set_line_unicast_route(packet_header, route_info);
+    }
+}
 
 inline FabricMuxSender& select_connection(
     FabricMuxConnection& fabric_connection,
     [[maybe_unused]] int device_offset,
     [[maybe_unused]] uint16_t dest_mesh_id,
-    [[maybe_unused]] uint16_t dest_chip_id) {
+    [[maybe_unused]] uint16_t dest_chip_id,
+    [[maybe_unused]] uint32_t initial_direction) {
     return fabric_connection.sender;
+}
+
+inline tt::tt_fabric::WorkerToFabricEdmSender& select_connection_by_direction(
+    Fabric2DConnections& fabric_connections, uint32_t direction) {
+    for (uint32_t slot = 0; slot < fabric_connections.active_count(); ++slot) {
+        if (fabric_connections.get_tag(slot) == direction) {
+            return fabric_connections.get(slot).sender;
+        }
+    }
+    fail_stop_invalid_fabric_route();
 }
 
 inline tt::tt_fabric::WorkerToFabricEdmSender& select_connection(
     Fabric2DConnections& fabric_connections,
     [[maybe_unused]] int device_offset,
     uint16_t dest_mesh_id,
-    uint16_t dest_chip_id) {
-    return fabric_connections[get_next_hop_router_direction(dest_mesh_id, dest_chip_id)];
+    uint16_t dest_chip_id,
+    uint32_t initial_direction) {
+    const uint32_t direction = initial_direction == default_initial_direction
+                                   ? static_cast<uint32_t>(get_next_hop_router_direction(dest_mesh_id, dest_chip_id))
+                                   : initial_direction;
+    return select_connection_by_direction(fabric_connections, direction);
 }
 
 inline tt::tt_fabric::WorkerToFabricEdmSender& select_connection(
     FabricConnectionManager& fabric_connections,
     int device_offset,
     [[maybe_unused]] uint16_t dest_mesh_id,
-    [[maybe_unused]] uint16_t dest_chip_id) {
+    [[maybe_unused]] uint16_t dest_chip_id,
+    [[maybe_unused]] uint32_t initial_direction) {
     return (device_offset > 0) ? fabric_connections.get_forward_connection()
                                : fabric_connections.get_backward_connection();
 }
 
-inline void finish_open_connections(Fabric2DConnections& fabric_connections) {
-    ttnn::operations::ccl::common::open_direction_connections_barrier(fabric_directions, fabric_connections);
+inline void finish_all_to_all_connections(Fabric2DConnections& fabric_connections) { fabric_connections.open_finish(); }
+
+inline void finish_all_to_all_connections(FabricConnectionManager& fabric_connections) {
+    fabric_connections.open_finish();
 }
 
-inline void finish_open_connections(FabricConnectionManager& fabric_connections) { fabric_connections.open_finish(); }
-
-inline void finish_open_connections(FabricMuxConnection& fabric_connection) { fabric_connection.sender.open(); }
-
-inline void close_connections(Fabric2DConnections& fabric_connections) {
-    ttnn::operations::ccl::common::close_direction_connections(fabric_directions, fabric_connections);
+inline void finish_all_to_all_connections(FabricMuxConnection& fabric_connection) {
+    fabric_connection.sender.flush</*Blocking=*/true>();
 }
 
-inline void close_connections(FabricConnectionManager& fabric_connections) { fabric_connections.close(); }
+inline void close_all_to_all_connections(Fabric2DConnections& fabric_connections) { fabric_connections.close(); }
 
-inline void close_connections(FabricMuxConnection& fabric_connection) { fabric_connection.sender.close(); }
+inline void close_all_to_all_connections(FabricConnectionManager& fabric_connections) { fabric_connections.close(); }
+
+inline void close_all_to_all_connections(FabricMuxConnection& fabric_connection) { fabric_connection.sender.close(); }
 
 inline void send_mux_packet_blocking(
     FabricMuxConnection& fabric_connection, uint32_t packet_header_address, size_t packet_header_size) {
@@ -112,6 +209,7 @@ void send_initialization(
     uint32_t local_num_devices,
     size_t device_offsets_idx,
     uint64_t init_semaphore_noc_addr_in_pkt,
+    uint32_t global_init_semaphore_addr,
     volatile PacketHeader* pkt_hdr_sema_forward,
     volatile PacketHeader* pkt_hdr_sema_backward,
     uint32_t packet_header_buffer_addr_sema_forward,
@@ -127,14 +225,14 @@ void send_initialization(
     if (link_id != 0) {
         return;
     }
-    if constexpr (Topology == tt::tt_fabric::Topology::Ring) {
-        // Ring destinations are split across direction-specific mux workers. Have link 0 send one unicast
-        // initialization increment for each unique destination owned by this worker. Ring bank schedules are striped
-        // across mux clients; the client owning destination bank 0 is the single initialization owner. This is
-        // independent of 1D hop-count versus Fabric2D mesh/chip routing and guarantees exactly one increment per
-        // source at every remote destination.
+    if constexpr (
+        (Topology == tt::tt_fabric::Topology::Ring || is_fabric_2d) && !fabric2d_multicast_initialization_is_safe) {
+        // Ring destinations and folded Fabric2D Linear axes are split across direction-specific mux workers. Have link
+        // 0 send one unicast initialization increment for each unique destination owned by this worker. Bank schedules
+        // are striped across mux clients; the client owning destination bank 0 is the single initialization owner.
+        // Per-target unicast avoids assuming that a logical Linear axis follows one physical mesh row or column.
         for (uint32_t did = 0; did < local_num_devices; ++did) {
-            const size_t target_arg_idx = device_offsets_idx + did * 7;
+            const size_t target_arg_idx = device_offsets_idx + did * target_runtime_args;
             const int32_t device_offset = get_arg_val<int32_t>(target_arg_idx);
             const uint32_t block_start = get_arg_val<uint32_t>(target_arg_idx + 1);
             if (device_offset == 0 || block_start != 0) {
@@ -144,16 +242,27 @@ void send_initialization(
             const ccl_routing_utils::line_unicast_route_info_t route_info = {
                 .dst_mesh_id = static_cast<uint16_t>(get_arg_val<uint32_t>(target_arg_idx + 5)),
                 .dst_chip_id = static_cast<uint16_t>(get_arg_val<uint32_t>(target_arg_idx + 6))};
+            const uint64_t target_init_semaphore_noc_addr =
+                is_fabric_2d ? safe_get_noc_addr(
+                                   get_arg_val<uint32_t>(target_arg_idx + target_drain_args_idx),
+                                   get_arg_val<uint32_t>(target_arg_idx + target_drain_args_idx + 1),
+                                   global_init_semaphore_addr)
+                             : init_semaphore_noc_addr_in_pkt;
             auto* packet_header = device_offset > 0 ? pkt_hdr_sema_forward : pkt_hdr_sema_backward;
             const uint32_t packet_header_address =
                 device_offset > 0 ? packet_header_buffer_addr_sema_forward : packet_header_buffer_addr_sema_backward;
-            ccl_routing_utils::fabric_set_line_unicast_route(packet_header, route_info);
+            set_target_unicast_route(
+                packet_header,
+                route_info,
+                get_custom_route_num_commands(target_arg_idx),
+                get_custom_route_packed_args_idx(target_arg_idx));
             packet_header->to_noc_unicast_atomic_inc(
-                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{init_semaphore_noc_addr_in_pkt, 1});
+                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{target_init_semaphore_noc_addr, 1});
             send_mux_packet_blocking(fabric_connection, packet_header_address, sizeof(PacketHeader));
         }
     } else {
-        // Linear uses one multicast per direction, so only one Mux V2 client owns initialization.
+        // A straight, uniformly harvested Fabric2D axis and Fabric1D Linear use one multicast per direction, so only
+        // one Mux V2 client owns initialization.
         if (core_id % compile_safe_mux_num_clients != 0) {
             return;
         }
@@ -210,9 +319,10 @@ void send_initialization(
     Fabric2DConnections& fabric_connections,
     [[maybe_unused]] uint32_t core_id,
     uint32_t link_id,
-    [[maybe_unused]] uint32_t local_num_devices,
-    [[maybe_unused]] size_t device_offsets_idx,
+    uint32_t local_num_devices,
+    size_t device_offsets_idx,
     uint64_t init_semaphore_noc_addr_in_pkt,
+    uint32_t global_init_semaphore_addr,
     volatile PacketHeader* pkt_hdr_sema_forward,
     volatile PacketHeader* pkt_hdr_sema_backward,
     uint32_t packet_header_buffer_addr_sema_forward,
@@ -228,36 +338,78 @@ void send_initialization(
     if (link_id != 0) {
         return;
     }
-    constexpr uint32_t positive_range = num_devices - current_device_id - 1;
-    constexpr uint32_t negative_range = current_device_id;
-    constexpr uint32_t positive_direction =
-        replicate_axis == ReplicateGroup::COLS ? eth_chan_directions::SOUTH : eth_chan_directions::EAST;
-    constexpr uint32_t negative_direction =
-        replicate_axis == ReplicateGroup::COLS ? eth_chan_directions::NORTH : eth_chan_directions::WEST;
 
-    if constexpr (positive_range > 0 && fabric_directions[positive_direction]) {
-        constexpr uint16_t east_range = replicate_axis == ReplicateGroup::ROWS ? positive_range : 0;
-        constexpr uint16_t south_range = replicate_axis == ReplicateGroup::COLS ? positive_range : 0;
-        tt::tt_fabric::fabric_set_mcast_route(
-            pkt_hdr_sema_forward, source_chip_id, source_mesh_id, east_range, 0, 0, south_range);
-        pkt_hdr_sema_forward->to_noc_unicast_atomic_inc(
-            tt::tt_fabric::NocUnicastAtomicIncCommandHeader{init_semaphore_noc_addr_in_pkt, 1});
-        auto& connection = fabric_connections[positive_direction];
-        connection.wait_for_empty_write_slot();
-        connection.send_payload_flush_blocking_from_address(
-            packet_header_buffer_addr_sema_forward, sizeof(PacketHeader));
+    if constexpr (fabric2d_multicast_initialization_is_safe) {
+        constexpr uint32_t positive_range = num_devices - current_device_id - 1;
+        constexpr uint32_t negative_range = current_device_id;
+        constexpr uint32_t positive_direction =
+            replicate_axis == ReplicateGroup::COLS ? eth_chan_directions::SOUTH : eth_chan_directions::EAST;
+        constexpr uint32_t negative_direction =
+            replicate_axis == ReplicateGroup::COLS ? eth_chan_directions::NORTH : eth_chan_directions::WEST;
+
+        if constexpr (positive_range > 0 && fabric_directions[positive_direction]) {
+            constexpr uint16_t east_range = replicate_axis == ReplicateGroup::ROWS ? positive_range : 0;
+            constexpr uint16_t south_range = replicate_axis == ReplicateGroup::COLS ? positive_range : 0;
+            tt::tt_fabric::fabric_set_mcast_route(
+                pkt_hdr_sema_forward, source_chip_id, source_mesh_id, east_range, 0, 0, south_range);
+            pkt_hdr_sema_forward->to_noc_unicast_atomic_inc(
+                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{init_semaphore_noc_addr_in_pkt, 1});
+            auto& connection = select_connection_by_direction(fabric_connections, positive_direction);
+            connection.wait_for_empty_write_slot();
+            connection.send_payload_flush_blocking_from_address(
+                packet_header_buffer_addr_sema_forward, sizeof(PacketHeader));
+        }
+        if constexpr (negative_range > 0 && fabric_directions[negative_direction]) {
+            constexpr uint16_t west_range = replicate_axis == ReplicateGroup::ROWS ? negative_range : 0;
+            constexpr uint16_t north_range = replicate_axis == ReplicateGroup::COLS ? negative_range : 0;
+            tt::tt_fabric::fabric_set_mcast_route(
+                pkt_hdr_sema_backward, source_chip_id, source_mesh_id, 0, west_range, north_range, 0);
+            pkt_hdr_sema_backward->to_noc_unicast_atomic_inc(
+                tt::tt_fabric::NocUnicastAtomicIncCommandHeader{init_semaphore_noc_addr_in_pkt, 1});
+            auto& connection = select_connection_by_direction(fabric_connections, negative_direction);
+            connection.wait_for_empty_write_slot();
+            connection.send_payload_flush_blocking_from_address(
+                packet_header_buffer_addr_sema_backward, sizeof(PacketHeader));
+        }
+        return;
     }
-    if constexpr (negative_range > 0 && fabric_directions[negative_direction]) {
-        constexpr uint16_t west_range = replicate_axis == ReplicateGroup::ROWS ? negative_range : 0;
-        constexpr uint16_t north_range = replicate_axis == ReplicateGroup::COLS ? negative_range : 0;
-        tt::tt_fabric::fabric_set_mcast_route(
-            pkt_hdr_sema_backward, source_chip_id, source_mesh_id, 0, west_range, north_range, 0);
-        pkt_hdr_sema_backward->to_noc_unicast_atomic_inc(
-            tt::tt_fabric::NocUnicastAtomicIncCommandHeader{init_semaphore_noc_addr_in_pkt, 1});
-        auto& connection = fabric_connections[negative_direction];
+
+    // A logical ring can turn through several physical directions. Send one initialization increment to every unique
+    // destination owned by this stream, using the connection selected from the destination's actual first hop. Bank
+    // schedules are striped across streams, so the stream owning destination bank 0 is the single initialization owner.
+    for (uint32_t did = 0; did < local_num_devices; ++did) {
+        const size_t target_arg_idx = device_offsets_idx + did * target_runtime_args;
+        const int32_t device_offset = get_arg_val<int32_t>(target_arg_idx);
+        const uint32_t block_start = get_arg_val<uint32_t>(target_arg_idx + 1);
+        if (device_offset == 0 || block_start != 0) {
+            continue;
+        }
+
+        const ccl_routing_utils::line_unicast_route_info_t route_info = {
+            .dst_mesh_id = static_cast<uint16_t>(get_arg_val<uint32_t>(target_arg_idx + 5)),
+            .dst_chip_id = static_cast<uint16_t>(get_arg_val<uint32_t>(target_arg_idx + 6))};
+        const uint64_t target_init_semaphore_noc_addr = safe_get_noc_addr(
+            get_arg_val<uint32_t>(target_arg_idx + target_drain_args_idx),
+            get_arg_val<uint32_t>(target_arg_idx + target_drain_args_idx + 1),
+            global_init_semaphore_addr);
+        auto* packet_header = device_offset > 0 ? pkt_hdr_sema_forward : pkt_hdr_sema_backward;
+        const uint32_t packet_header_address =
+            device_offset > 0 ? packet_header_buffer_addr_sema_forward : packet_header_buffer_addr_sema_backward;
+        set_target_unicast_route(
+            packet_header,
+            route_info,
+            get_custom_route_num_commands(target_arg_idx),
+            get_custom_route_packed_args_idx(target_arg_idx));
+        packet_header->to_noc_unicast_atomic_inc(
+            tt::tt_fabric::NocUnicastAtomicIncCommandHeader{target_init_semaphore_noc_addr, 1});
+        auto& connection = select_connection(
+            fabric_connections,
+            device_offset,
+            route_info.dst_mesh_id,
+            route_info.dst_chip_id,
+            get_custom_route_initial_direction(target_arg_idx));
         connection.wait_for_empty_write_slot();
-        connection.send_payload_flush_blocking_from_address(
-            packet_header_buffer_addr_sema_backward, sizeof(PacketHeader));
+        connection.send_payload_flush_blocking_from_address(packet_header_address, sizeof(PacketHeader));
     }
 }
 
@@ -269,6 +421,7 @@ void send_initialization(
     [[maybe_unused]] uint32_t local_num_devices,
     [[maybe_unused]] size_t device_offsets_idx,
     uint64_t init_semaphore_noc_addr_in_pkt,
+    [[maybe_unused]] uint32_t global_init_semaphore_addr,
     volatile PacketHeader* pkt_hdr_sema_forward,
     volatile PacketHeader* pkt_hdr_sema_backward,
     uint32_t packet_header_buffer_addr_sema_forward,
@@ -321,18 +474,17 @@ void send_initialization(
     }
 }
 
+template <typename FabricSender>
 void write_data(
     const Noc& noc_obj,
     uint64_t dest_addrs[4],
     uint16_t payload_sizes[4],
     uint32_t parts_count,
     volatile PACKET_HEADER_TYPE* pkt_hdr,
-    FabricConnections& fabric_connections,
+    FabricSender* target_connection,
     size_t l1_read_addr,
     uint64_t output_semaphore_noc_addr_in_pkt,
     int device_offset,
-    uint16_t dest_mesh_id,
-    uint16_t dest_chip_id,
     bool last) {
     bool local = device_offset == 0;
     if (local) {
@@ -344,6 +496,7 @@ void write_data(
             l1_read_addr += payload_sizes[part];
         }
     } else {
+        ASSERT(target_connection != nullptr);
         if (last) {
             // TODO: reduce number of packages when atomic fused with scatter will be introduced
             if (parts_count > 1) {
@@ -354,19 +507,11 @@ void write_data(
                     }
                     pkt_hdr->to_noc_unicast_scatter_write(
                         NocUnicastScatterCommandHeader(dest_addrs, payload_sizes, parts_count - 1), scatter_payload);
-                    perform_payload_send(
-                        select_connection(fabric_connections, device_offset, dest_mesh_id, dest_chip_id),
-                        l1_read_addr,
-                        scatter_payload,
-                        pkt_hdr);
+                    perform_payload_send(*target_connection, l1_read_addr, scatter_payload, pkt_hdr);
                     l1_read_addr += scatter_payload;
                 } else {
                     pkt_hdr->to_noc_unicast_write(NocUnicastCommandHeader({dest_addrs[0]}), payload_sizes[0]);
-                    perform_payload_send(
-                        select_connection(fabric_connections, device_offset, dest_mesh_id, dest_chip_id),
-                        l1_read_addr,
-                        payload_sizes[0],
-                        pkt_hdr);
+                    perform_payload_send(*target_connection, l1_read_addr, payload_sizes[0], pkt_hdr);
                     l1_read_addr += payload_sizes[0];
                 }
                 noc_obj.async_writes_flushed();
@@ -376,11 +521,7 @@ void write_data(
                 NocUnicastAtomicIncFusedCommandHeader(
                     {dest_addrs[parts_count - 1], output_semaphore_noc_addr_in_pkt, 1, false}),
                 payload_sizes[parts_count - 1]);
-            perform_payload_send(
-                select_connection(fabric_connections, device_offset, dest_mesh_id, dest_chip_id),
-                l1_read_addr,
-                payload_sizes[parts_count - 1],
-                pkt_hdr);
+            perform_payload_send(*target_connection, l1_read_addr, payload_sizes[parts_count - 1], pkt_hdr);
         } else {
             uint32_t scatter_payload = 0;
             for (uint32_t part = 0; part < parts_count; ++part) {
@@ -392,11 +533,7 @@ void write_data(
                 pkt_hdr->to_noc_unicast_scatter_write(
                     NocUnicastScatterCommandHeader(dest_addrs, payload_sizes, parts_count), scatter_payload);
             }
-            perform_payload_send(
-                select_connection(fabric_connections, device_offset, dest_mesh_id, dest_chip_id),
-                l1_read_addr,
-                scatter_payload,
-                pkt_hdr);
+            perform_payload_send(*target_connection, l1_read_addr, scatter_payload, pkt_hdr);
         }
     }
     noc_obj.async_writes_flushed();
@@ -425,19 +562,19 @@ void kernel_main() {
     uint32_t local_num_devices = get_arg_val<uint32_t>(arg_idx++);
     auto output_addrgen = TensorAccessor(output_tensor_args, output_address);
     size_t device_offsets_idx = arg_idx;
-    arg_idx += local_num_devices * 7;
+    arg_idx += local_num_devices * target_runtime_args;
 
     auto fabric_connections = [&]() {
-        if constexpr (use_worker_mux) {
+        if constexpr (stream_uses_mux) {
             auto sender = FabricMuxSender::build_from_args(arg_idx);
+            // Match the direct-fabric connection lifecycle: begin the mux handshake before local setup, then wait for
+            // readiness at finish_all_to_all_connections() immediately before issuing initialization traffic.
+            sender.open();
             return FabricMuxConnection{.sender = sender};
         } else if constexpr (is_fabric_2d) {
-            Fabric2DConnections connections;
-            if constexpr (has_fabric_connections) {
-                ttnn::operations::ccl::common::open_direction_connections_async(
-                    fabric_directions, connections, arg_idx);
-            }
-            return connections;
+            const uint32_t num_connections = get_arg_val<uint32_t>(arg_idx++);
+            return Fabric2DConnections::build_from_args<Fabric2DConnections::BUILD_AND_OPEN_CONNECTION_START_ONLY>(
+                arg_idx, num_connections);
         } else {
             return FabricConnectionManager::build_from_args<
                 FabricConnectionManager::BUILD_AND_OPEN_CONNECTION_START_ONLY>(arg_idx);
@@ -481,8 +618,8 @@ void kernel_main() {
         reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_addr_sema_backward);
 
     {
-        if constexpr (has_fabric_connections) {
-            finish_open_connections(fabric_connections);
+        if constexpr ((is_fabric_2d && !stream_uses_mux) || has_fabric_connections) {
+            finish_all_to_all_connections(fabric_connections);
         }
     }
 
@@ -497,6 +634,7 @@ void kernel_main() {
             local_num_devices,
             device_offsets_idx,
             init_semaphore_noc_addr_in_pkt,
+            global_init_semaphore_addr,
             pkt_hdr_sema_forward,
             pkt_hdr_sema_backward,
             packet_header_buffer_addr_sema_forward,
@@ -533,6 +671,24 @@ void kernel_main() {
             const ccl_routing_utils::line_unicast_route_info_t route_info = {
                 .dst_mesh_id = static_cast<uint16_t>(get_arg_val<uint32_t>(device_offsets_idx++)),
                 .dst_chip_id = static_cast<uint16_t>(get_arg_val<uint32_t>(device_offsets_idx++))};
+            uint32_t target_drain_sync_core_x = 0;
+            uint32_t target_drain_sync_core_y = 0;
+            if constexpr (is_fabric_2d) {
+                target_drain_sync_core_x = get_arg_val<uint32_t>(device_offsets_idx++);
+                target_drain_sync_core_y = get_arg_val<uint32_t>(device_offsets_idx++);
+            }
+            uint32_t custom_route_num_commands = 0;
+            uint32_t custom_route_initial_direction = default_initial_direction;
+            if constexpr (has_custom_fabric2d_routes) {
+                custom_route_num_commands = get_arg_val<uint32_t>(device_offsets_idx++);
+                custom_route_initial_direction = get_arg_val<uint32_t>(device_offsets_idx++);
+            }
+            const size_t custom_route_args_idx = device_offsets_idx;
+            device_offsets_idx += custom_fabric2d_route_words;
+            const uint64_t target_output_semaphore_noc_addr =
+                is_fabric_2d
+                    ? safe_get_noc_addr(target_drain_sync_core_x, target_drain_sync_core_y, global_semaphore_addr)
+                    : output_semaphore_noc_addr_in_pkt;
             const uint32_t device_id = (current_device_id + device_offset + num_devices) % num_devices;
 
             volatile PACKET_HEADER_TYPE* pkt_hdr = nullptr;
@@ -542,8 +698,15 @@ void kernel_main() {
                 pkt_hdr = pkt_hdr_backward;
             }
             if (device_offset != 0) {
-                ccl_routing_utils::fabric_set_line_unicast_route(pkt_hdr, route_info);
+                set_target_unicast_route(pkt_hdr, route_info, custom_route_num_commands, custom_route_args_idx);
             }
+            auto* target_connection = device_offset == 0 ? nullptr
+                                                         : &select_connection(
+                                                               fabric_connections,
+                                                               device_offset,
+                                                               route_info.dst_mesh_id,
+                                                               route_info.dst_chip_id,
+                                                               custom_route_initial_direction);
 
             auto calculate_params = [&](int b) {
                 const uint32_t o = b / (concat_num_tiles * inner_dims_size);
@@ -583,12 +746,10 @@ void kernel_main() {
                     payload_sizes,
                     current_part,
                     pkt_hdr,
-                    fabric_connections,
+                    target_connection,
                     l1_read_addr,
-                    output_semaphore_noc_addr_in_pkt,
+                    target_output_semaphore_noc_addr,
                     device_offset,
-                    route_info.dst_mesh_id,
-                    route_info.dst_chip_id,
                     last);
                 l1_read_addr += current_package_payload;
                 current_package_payload = 0;
@@ -631,8 +792,8 @@ void kernel_main() {
 
     noc_obj.async_write_barrier();
     {
-        if constexpr (has_fabric_connections) {
-            close_connections(fabric_connections);
+        if constexpr ((is_fabric_2d && !stream_uses_mux) || has_fabric_connections) {
+            close_all_to_all_connections(fabric_connections);
         }
     }
     if (core_id == 0 && link_id == 0) {


### PR DESCRIPTION
## Problem

Generic all-to-all assumed that a logical offset sign identified one physical egress, that one drain-core NOC coordinate was valid on every chip, and that canonical routing matched both arcs chosen for an even-ring antipode. Folded Fabric2D axes and heterogeneous harvesting violate those assumptions and can hang initialization or data movement.

## Fix

- Group streams and muxes by the actual physical first hop, and intersect routing-plane links across every target using that egress.
- Build control-plane-derived routes for representable antipodal arcs so initialization and data use the same first hop.
- Exchange both drain-core coordinates on every Fabric2D invocation, translate local logical cores per chip, and patch destination coordinates through runtime arguments.
- Preserve multicast startup for straight uniformly harvested axes; use per-target initialization for folded or heterogeneous layouts.
- Share authoritative route and connection capacities between host and device code.

No tests or configurations are added or removed.

## Validation

- `./build_metal.sh --release`
- Existing nine-case Fabric2D all-to-all matrix on a 2x4 Blackhole LoudBox through `scripts/run_safe_pytest.sh`: 9 passed
- Existing GLM 5.2 TP4 TorusXY craq-sim proxy completed both all-to-all directions and its bit-exact reshard comparison
- Existing generic all-to-all CCL suite: [run 32008133159](https://github.com/tenstorrent/tt-metal/actions/runs/32008133159)

Integrated model/topology migration: [#53133](https://github.com/tenstorrent/tt-metal/pull/53133).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-fabric2d-folded-ring-all-to-all)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-fabric2d-folded-ring-all-to-all)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-fabric2d-folded-ring-all-to-all)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-fabric2d-folded-ring-all-to-all)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-fabric2d-folded-ring-all-to-all)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-fabric2d-folded-ring-all-to-all)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-fabric2d-folded-ring-all-to-all)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-fabric2d-folded-ring-all-to-all)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-fabric2d-folded-ring-all-to-all)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-fabric2d-folded-ring-all-to-all)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-fabric2d-folded-ring-all-to-all)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-fabric2d-folded-ring-all-to-all)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-fabric2d-folded-ring-all-to-all)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-fabric2d-folded-ring-all-to-all)
