### PR TITLE
Promote custom_mm_reuse_dest_srcb to experimental

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_custom_mm_reuse_dest_srcb_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_custom_mm_reuse_dest_srcb_api.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <cstdint>
+#include "llk_math_common_api.h"
+#include "experimental/llk_math_custom_mm_reuse_dest_srcb.h"
+
+/*************************************************************************
+ * LLK CUSTOM_MM_REUSE_DEST_SRCB
+ *
+ * Second matmul of a fused chain: SrcB is moved out of DEST (where the
+ * preceding custom_mm left its output) instead of being unpacked from L1.
+ * Only SrcA (the weights) is unpacked.
+ *
+ * Uses llk_math_custom_mm_reuse_dest_srcb.h as the low-level implementation.
+ *************************************************************************/
+
+inline void llk_math_custom_mm_reuse_dest_srcb_replay_init() { _llk_math_custom_mm_reuse_dest_srcb_replay_init_(); }
+
+template <bool load_replay = true>
+inline void llk_math_custom_mm_reuse_dest_srcb_init() {
+    _llk_math_custom_mm_reuse_dest_srcb_init_<load_replay>();
+}
+
+template <std::uint32_t in0_tile_r_dim>
+inline void llk_math_custom_mm_reuse_dest_srcb(
+    const std::uint32_t src_index,
+    const std::uint32_t dst_index,
+    const std::uint32_t kt_dim,
+    const std::uint32_t nt_dim,
+    const std::uint32_t src_tile_stride) {
+    _llk_math_custom_mm_reuse_dest_srcb_<in0_tile_r_dim>(src_index, dst_index, kt_dim, nt_dim, src_tile_stride);
+}

--- a/tt_metal/hw/inc/api/compute/experimental/custom_mm_reuse_dest_srcb.h
+++ b/tt_metal/hw/inc/api/compute/experimental/custom_mm_reuse_dest_srcb.h
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/common.h"
+#if defined(TRISC_MATH) && defined(ARCH_BLACKHOLE)
+#include "experimental/llk_math_custom_mm_reuse_dest_srcb_api.h"
+#endif
+#if defined(TRISC_UNPACK) && defined(ARCH_BLACKHOLE)
+#include "experimental/llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_api.h"
+#include "experimental/llk_unpack_A_sdpa_api.h"
+#endif
+
+#if defined(ARCH_BLACKHOLE)
+
+namespace ckernel {
+
+// DEST geometry.  A DEST "row" is 16 datums.
+// custom_mm<dense_packing=true> output tile: 2 faces, 16 rows apart.
+constexpr std::uint32_t CUSTOM_MM_DEST_TILE_ROWS = 32;
+// custom_mm_reuse_dest_srcb accumulator tile: 2 faces, 8 rows apart.
+constexpr std::uint32_t CUSTOM_MM_REUSE_DEST_TILE_ROWS = 16;
+// A standard Tile32x32 DEST slot: 4 faces x 16 rows.
+constexpr std::uint32_t CUSTOM_MM_DEST_ROWS_PER_TILE32 = 64;
+// Rows addressable by math, for the current sync/accum configuration.
+constexpr std::uint32_t CUSTOM_MM_MAX_DEST_ROWS =
+    get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>() * CUSTOM_MM_DEST_ROWS_PER_TILE32;
+
+// clang-format off
+/**
+ * Points the packer at the dense accumulator layout custom_mm_reuse_dest_srcb
+ * writes: faces 8 DEST rows apart, tiles 16.  Only the DEST-side read strides
+ * change; the bytes packed to L1 are unchanged.
+ *
+ * Pair with custom_mm_reuse_dest_srcb_pack_uninit().  While active, the
+ * `tile_index` given to pack_block_contiguous counts 16-row slots, not 32.
+ */
+// clang-format on
+ALWI void custom_mm_reuse_dest_srcb_pack_init() {
+    PACK((cfg_reg_rmw_tensix<PCK0_ADDR_CTRL_ZW_REG_0_Zstride_RMW>(FACE_C_DIM * 8 * 2)));
+    PACK((cfg_reg_rmw_tensix<PCK0_ADDR_CTRL_ZW_REG_0_Wstride_RMW>((TILE_NUM_FACES / 2) * FACE_C_DIM * 8 * 2)));
+}
+
+/**
+ * Restores both packer strides to their defaults (face 16 rows, tile 64).  These
+ * registers are persistent state that no pack init reprograms, so a later op
+ * packing with the default layout would otherwise inherit them.
+ *
+ * A chaining core therefore needs only this call, not also
+ * custom_mm_block_uninit<dense_packing>().
+ */
+ALWI void custom_mm_reuse_dest_srcb_pack_uninit() {
+    PACK((cfg_reg_rmw_tensix<PCK0_ADDR_CTRL_ZW_REG_0_Zstride_RMW>(FACE_C_DIM * FACE_R_DIM * 2)));
+    PACK((cfg_reg_rmw_tensix<PCK0_ADDR_CTRL_ZW_REG_0_Wstride_RMW>(TILE_NUM_FACES * FACE_C_DIM * FACE_R_DIM * 2)));
+}
+
+/**
+ * Loads the math replay program for custom_mm_reuse_dest_srcb_block.  It occupies a
+ * disjoint slice of the FPU replay window from custom_mm's, so issue it alongside
+ * custom_mm_block_init_short rather than between the two matmuls.
+ */
+ALWI void custom_mm_reuse_dest_srcb_replay_init() { MATH((llk_math_custom_mm_reuse_dest_srcb_replay_init())); }
+
+// clang-format off
+/**
+ * Short initialization for custom_mm_reuse_dest_srcb_block.  Safe to call in the
+ * middle of a kernel; it reprograms the math ADDR_MODs, so it must come after the
+ * producing matmul's last math instruction.
+ *
+ * | Argument     | Description                                             | Type     | Valid Range            | Required |
+ * |--------------|---------------------------------------------------------|----------|------------------------|----------|
+ * | load_replay  | Also load the replay program (template)                 | bool     | true, false            | False    |
+ * | in0_cb_id    | CB whose tile descriptor describes the DEST-resident in0 | uint32_t | 0 to 31                | True     |
+ * | in1_cb_id    | CB holding the weights (unpacked into SrcA)             | uint32_t | 0 to 31                | True     |
+ * | nt_dim       | Output width in tiles                                   | uint32_t | 1 to 16                | True     |
+ *
+ * Pass load_replay = false only when custom_mm_reuse_dest_srcb_replay_init() has
+ * already run earlier in the same invocation; that keeps the replay load off the
+ * chain between the two matmuls.
+ */
+// clang-format on
+template <bool load_replay = true>
+ALWI void custom_mm_reuse_dest_srcb_block_init_short(
+    const std::uint32_t in0_cb_id, const std::uint32_t in1_cb_id, const std::uint32_t nt_dim) {
+    UNPACK((llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_init(in0_cb_id, in1_cb_id, /*transpose=*/0, nt_dim)));
+    MATH((llk_math_custom_mm_reuse_dest_srcb_init<load_replay>()));
+}
+
+// clang-format off
+/**
+ * Matmul whose in0 is read out of DEST instead of a CB: computes
+ * out[1, nt_dim*32] += in0_from_dest[1, kt_dim*32] @ in1[kt_dim*32, nt_dim*32].
+ *
+ * in0 is whatever the preceding custom_mm left at DEST row `isrc`, laid out
+ * one tile every `src_tile_stride` rows.  The result accumulates into DEST at
+ * row `idst` in the dense 16-rows-per-tile layout.
+ *
+ * | Argument         | Description                                                    | Type     | Valid Range                    | Required |
+ * |------------------|----------------------------------------------------------------|----------|--------------------------------|----------|
+ * | in0_tile_r_dim   | Height of the in0 tile (template)                              | uint32_t | 1, 2, 4, 8                     | True     |
+ * | in0_cb_id        | CB describing in0 (used only for the unpack init)              | uint32_t | 0 to 31                        | True     |
+ * | in1_cb_id        | Weights CB                                                      | uint32_t | 0 to 31                        | True     |
+ * | in1_tile_index   | First weight tile to read                                       | uint32_t | < CB size                      | True     |
+ * | isrc             | DEST row of the first in0 tile                                  | uint32_t | < half DEST                    | True     |
+ * | idst             | DEST row of the first output tile                               | uint32_t | < half DEST                    | True     |
+ * | kt_dim           | Inner dimension in tiles                                        | uint32_t | even, 2 to 256                 | True     |
+ * | nt_dim           | Output width in tiles                                           | uint32_t | 1 to 16                        | True     |
+ * | in1_k_stride     | Weight tiles between consecutive K rows (nt_dim if contiguous)  | uint32_t | >= nt_dim                      | True     |
+ * | src_tile_stride  | DEST rows between consecutive in0 tiles                         | uint32_t | 32 for custom_mm dense_packing | True     |
+ */
+// clang-format on
+template <std::uint32_t in0_tile_r_dim>
+ALWI void custom_mm_reuse_dest_srcb_block(
+    const std::uint32_t in0_cb_id,
+    const std::uint32_t in1_cb_id,
+    const std::uint32_t in1_tile_index,
+    const std::uint32_t isrc,
+    const std::uint32_t idst,
+    const std::uint32_t kt_dim,
+    const std::uint32_t nt_dim,
+    const std::uint32_t in1_k_stride,
+    const std::uint32_t src_tile_stride = CUSTOM_MM_DEST_TILE_ROWS) {
+    UNPACK((llk_unpack_A_sdpa_set_srcb_dummy_valid()));
+    UNPACK((llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb(
+        in0_cb_id, in1_cb_id, 0, in1_tile_index, kt_dim, nt_dim, in1_k_stride)));
+    MATH((llk_math_custom_mm_reuse_dest_srcb<in0_tile_r_dim>(isrc, idst, kt_dim, nt_dim, src_tile_stride)));
+}
+
+}  // namespace ckernel
+
+#endif  // ARCH_BLACKHOLE

--- a/tt_metal/hw/inc/api/compute/experimental/custom_mm_reuse_dest_srcb.h
+++ b/tt_metal/hw/inc/api/compute/experimental/custom_mm_reuse_dest_srcb.h
@@ -14,9 +14,9 @@
 #include "experimental/llk_unpack_A_sdpa_api.h"
 #endif
 
-#if defined(ARCH_BLACKHOLE)
-
 namespace ckernel {
+
+#if defined(ARCH_BLACKHOLE)
 
 // DEST geometry.  A DEST "row" is 16 datums.
 // custom_mm<dense_packing=true> output tile: 2 faces, 16 rows apart.
@@ -45,9 +45,11 @@ ALWI void custom_mm_reuse_dest_srcb_pack_init() {
 }
 
 /**
- * Restores both packer strides to their defaults (face 16 rows, tile 64).  These
- * registers are persistent state that no pack init reprograms, so a later op
- * packing with the default layout would otherwise inherit them.
+ * Restores both packer strides to their defaults (face 16 rows, tile 64).
+ * A full llk_pack_init (skip_packer_strides = false) does reprogram these
+ * fields; the restore matters for follow-on ops that pack without one, e.g.
+ * MOP-only pack_block_contiguous paths, which would otherwise inherit the
+ * dense strides.
  *
  * A chaining core therefore needs only this call, not also
  * custom_mm_block_uninit<dense_packing>().
@@ -104,15 +106,15 @@ ALWI void custom_mm_reuse_dest_srcb_block_init_short(
  * | Argument         | Description                                                    | Type     | Valid Range                    | Required |
  * |------------------|----------------------------------------------------------------|----------|--------------------------------|----------|
  * | in0_tile_r_dim   | Height of the in0 tile (template)                              | uint32_t | 1, 2, 4, 8                     | True     |
- * | in0_cb_id        | CB describing in0 (used only for the unpack init)              | uint32_t | 0 to 31                        | True     |
+ * | in0_cb_id        | Currently unused: the unpack init reads geometry from in1 only and the math LLK takes no CB id (in0 geometry comes solely from in0_tile_r_dim). Kept for signature stability with the tt-blaze caller | uint32_t | 0 to 31                        | True     |
  * | in1_cb_id        | Weights CB                                                      | uint32_t | 0 to 31                        | True     |
  * | in1_tile_index   | First weight tile to read                                       | uint32_t | < CB size                      | True     |
  * | isrc             | DEST row of the first in0 tile                                  | uint32_t | < half DEST                    | True     |
- * | idst             | DEST row of the first output tile                               | uint32_t | < half DEST                    | True     |
- * | kt_dim           | Inner dimension in tiles                                        | uint32_t | even, 2 to 256                 | True     |
+ * | idst             | DEST row of the first output tile. The caller must zero DEST at idst first: the MVMULs accumulate (+=) and nothing in this call clears DEST | uint32_t | < half DEST                    | True     |
+ * | kt_dim           | Inner dimension in tiles. All kt_dim in0 tiles must be DEST-resident at once: kt_dim * src_tile_stride + nt_dim * 16 <= CUSTOM_MM_MAX_DEST_ROWS, and the producing custom_mm's ct_dim caps it at 16 | uint32_t | even; see bound                | True     |
  * | nt_dim           | Output width in tiles                                           | uint32_t | 1 to 16                        | True     |
  * | in1_k_stride     | Weight tiles between consecutive K rows (nt_dim if contiguous)  | uint32_t | >= nt_dim                      | True     |
- * | src_tile_stride  | DEST rows between consecutive in0 tiles                         | uint32_t | 32 for custom_mm dense_packing | True     |
+ * | src_tile_stride  | DEST rows between consecutive in0 tiles                         | uint32_t | 32 for custom_mm dense_packing, 64 without | True     |
  */
 // clang-format on
 template <std::uint32_t in0_tile_r_dim>
@@ -128,10 +130,10 @@ ALWI void custom_mm_reuse_dest_srcb_block(
     const std::uint32_t src_tile_stride = CUSTOM_MM_DEST_TILE_ROWS) {
     UNPACK((llk_unpack_A_sdpa_set_srcb_dummy_valid()));
     UNPACK((llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb(
-        in0_cb_id, in1_cb_id, 0, in1_tile_index, kt_dim, nt_dim, in1_k_stride)));
+        in0_cb_id, in1_cb_id, /*tile_index_0=*/0, in1_tile_index, kt_dim, nt_dim, in1_k_stride)));
     MATH((llk_math_custom_mm_reuse_dest_srcb<in0_tile_r_dim>(isrc, idst, kt_dim, nt_dim, src_tile_stride)));
 }
 
-}  // namespace ckernel
-
 #endif  // ARCH_BLACKHOLE
+
+}  // namespace ckernel

--- a/tt_metal/hw/inc/api/compute/experimental/custom_mm_reuse_dest_srcb.h
+++ b/tt_metal/hw/inc/api/compute/experimental/custom_mm_reuse_dest_srcb.h
@@ -92,11 +92,14 @@ ALWI void custom_mm_reuse_dest_srcb_block_init_short(
 // clang-format off
 /**
  * Matmul whose in0 is read out of DEST instead of a CB: computes
- * out[1, nt_dim*32] += in0_from_dest[1, kt_dim*32] @ in1[kt_dim*32, nt_dim*32].
+ * out[in0_tile_r_dim, nt_dim*32] += in0_from_dest[in0_tile_r_dim, kt_dim*32]
+ *     @ in1[kt_dim*32, nt_dim*32].
  *
  * in0 is whatever the preceding custom_mm left at DEST row `isrc`, laid out
- * one tile every `src_tile_stride` rows.  The result accumulates into DEST at
- * row `idst` in the dense 16-rows-per-tile layout.
+ * one tile every `src_tile_stride` rows; the math LLK copies `in0_tile_r_dim`
+ * source rows per tile (1, 2, 4 or 8).  The result accumulates the same
+ * `in0_tile_r_dim` output rows into DEST at row `idst` in the dense
+ * 16-rows-per-tile layout.
  *
  * | Argument         | Description                                                    | Type     | Valid Range                    | Required |
  * |------------------|----------------------------------------------------------------|----------|--------------------------------|----------|

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -105,6 +105,7 @@ set(HW_JIT_API_HEADERS
     inc/api/compute/experimental/compressed_custom_mm.h
     inc/api/compute/experimental/compute_kernel_hw_cleanup.h
     inc/api/compute/experimental/custom_mm.h
+    inc/api/compute/experimental/custom_mm_reuse_dest_srcb.h
     inc/api/compute/experimental/eltwise_mul_scalar.h
     inc/api/compute/experimental/fast_untilize.h
     inc/api/compute/experimental/mul_reduce_scalar.h

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_custom_mm_reuse_dest_srcb.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_custom_mm_reuse_dest_srcb.h
@@ -78,6 +78,12 @@ constexpr std::uint32_t CUSTOM_MM_REUSE_REPLAY_OFFSET = ckernel::math::replay_bu
 static_assert(
     CUSTOM_MM_REUSE_REPLAY_OFFSET >= ckernel::math::replay_buf_offset + 11,
     "replay program overlaps custom_mm's, which uses up to 11 entries at the window base");
+// The 11 above mirrors custom_mm's function-local replay_buf_len (operandB_face_r_dim == 8
+// ? 11 : 9), which is not exported; deriving both from one named constant is a follow-up
+// that touches the already-merged custom_mm.h.
+static_assert(
+    CUSTOM_MM_REUSE_REPLAY_OFFSET + CUSTOM_MM_REUSE_REPLAY_LEN <= ckernel::math::replay_buf_offset + CUSTOM_MM_REUSE_FPU_REPLAY_LEN,
+    "replay program runs past the FPU half of the math replay window");
 
 inline void custom_mm_reuse_dest_srcb_configure_mop()
 {
@@ -119,6 +125,11 @@ inline void _llk_math_custom_mm_reuse_dest_srcb_init_()
 // Preconditions:
 // - the unpacker has issued a zero-and-set-dvalid on SrcB
 // - DEST at dst_index is zero
+// - for in0_tile_r_dim < 4, rows of the producing custom_mm's output above the tile
+//   height should be zero (its clear_src=false power optimization can leave stale
+//   products there; MOV_4_ROWS drags two such rows into SrcB for in0_tile_r_dim == 2 —
+//   benign today because the packer reads only in0_tile_r_dim rows per face, but the
+//   cross-op coupling is real)
 template <std::uint32_t in0_tile_r_dim>
 inline void _llk_math_custom_mm_reuse_dest_srcb_(
     const std::uint32_t src_index, const std::uint32_t dst_index, const std::uint32_t kt_dim, const std::uint32_t nt_dim, const std::uint32_t src_tile_stride)

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_custom_mm_reuse_dest_srcb.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_custom_mm_reuse_dest_srcb.h
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_include.h"
+#include "ckernel_ops.h"
+#include "ckernel_template.h"
+#include "cmath_common.h"
+#include "llk_assert.h"
+#include "llk_math_common.h"
+
+using namespace ckernel;
+
+// Second matmul of a fused chain.  in0 is *not* unpacked from L1 — it is moved
+// straight out of DEST into SrcB with MOVD2B.  Only SrcA (the weights) is unpacked.
+//
+// Source (in0) tile layout in DEST — what `custom_mm<split_acc, dense_packing>`
+// produces after its finalization step, for an in0 tile of shape [r, 32]:
+//     cols  0..15  ->  rows  base + 0  .. base + (r-1)
+//     cols 16..31  ->  rows  base + 16 .. base + 16 + (r-1)
+//     next tile at base + src_tile_stride   (32 with dense_packing, else 64)
+//
+// Output (accumulator) tile layout in DEST — the dense 2x8-row layout shared
+// with the SDPA custom matmuls:
+//     cols  0..15  ->  rows base + 0 .. base + 7
+//     cols 16..31  ->  rows base + 8 .. base + 15
+//     next tile at base + 16
+// Half the DEST footprint of a `custom_mm` output tile, which is what lets the
+// two matmuls' live ranges coexist in half DEST.  Pack it with Zstride = 8 rows
+// and Wstride = 16 rows (see `custom_mm_reuse_dest_srcb_pack_init`).
+//
+// Constraints:
+// - in0 (SrcB) tile shape: [{1, 2, 4, 8}, 32]; in1 (SrcA) tile shape: [32, 32]
+// - rt_dim: 1
+// - nt_dim: 1 to 16
+// - kt_dim: even number from 2 to 256 (inclusive)
+// - fidelity: LoFi only
+
+inline void custom_mm_reuse_dest_srcb_configure_addrmod()
+{
+    addr_mod_t {
+        .srca = {.incr = 16, .clr = 0, .cr = 0},
+        .srcb = {.incr = 0, .clr = 0, .cr = 0},
+        .dest = {.incr = 8, .clr = 0, .cr = 0},
+    }
+        .set(ADDR_MOD_0); // Next face in the output width dim (cols 16..31)
+
+    addr_mod_t {
+        .srca = {.incr = 16, .clr = 0, .cr = 0}, .srcb = {.incr = 8, .clr = 0, .cr = 0}, .dest = {.incr = 0, .clr = 0, .cr = 1}, // Return to the tile base
+    }
+        .set(ADDR_MOD_1); // Next face in the inner (K) dim: SrcB rows 8..15
+
+    addr_mod_t {
+        .srca = {.incr = 0, .clr = 0, .cr = 0},
+        .srcb = {.incr = 0, .clr = 0, .cr = 0},
+        .dest = {.incr = 0, .clr = 0, .cr = 0},
+    }
+        .set(ADDR_MOD_2); // NOP — used by the DEST -> SrcB moves
+
+    addr_mod_t {
+        .srca = {.incr = 0, .clr = 1, .cr = 0},
+        .srcb = {.incr = 0, .clr = 1, .cr = 0},
+        .dest = {.incr = 8, .clr = 0, .cr = 0, .c_to_cr = 1}, // Next output tile
+    }
+        .set(ADDR_MOD_3);
+}
+
+// FPU half of the math replay buffer: [replay_buf_offset, replay_buf_offset + 16).
+constexpr std::uint32_t CUSTOM_MM_REUSE_FPU_REPLAY_LEN = 16;
+constexpr std::uint32_t CUSTOM_MM_REUSE_REPLAY_LEN     = 4;
+// Top-anchored so custom_mm's program, which sits at the window base, cannot overwrite
+// it.  That is what lets this one load before the first matmul instead of between them.
+constexpr std::uint32_t CUSTOM_MM_REUSE_REPLAY_OFFSET = ckernel::math::replay_buf_offset + CUSTOM_MM_REUSE_FPU_REPLAY_LEN - CUSTOM_MM_REUSE_REPLAY_LEN;
+static_assert(
+    CUSTOM_MM_REUSE_REPLAY_OFFSET >= ckernel::math::replay_buf_offset + 11,
+    "replay program overlaps custom_mm's, which uses up to 11 entries at the window base");
+
+inline void custom_mm_reuse_dest_srcb_configure_mop()
+{
+    // One output tile = 4 MVMULs (2 SrcA faces along K x 2 along N), all
+    // accumulating into the 16 DEST rows of that tile.
+    load_replay_buf(
+        CUSTOM_MM_REUSE_REPLAY_OFFSET,
+        CUSTOM_MM_REUSE_REPLAY_LEN,
+        []
+        {
+            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // K 0..15  x N 0..15
+            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_1, 0); // K 0..15  x N 16..31
+            TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // K 16..31 x N 0..15
+            TTI_MVMUL(p_setrwc::CLR_A, 0, ADDR_MOD_3, 0);    // K 16..31 x N 16..31
+        });
+}
+
+// Loads the replay program.  May run before the first matmul: custom_mm reloads only
+// the base of the window, which this program sits clear of.
+inline void _llk_math_custom_mm_reuse_dest_srcb_replay_init_()
+{
+    custom_mm_reuse_dest_srcb_configure_mop();
+}
+
+// custom_mm rewrites all eight ADDR_MODs each invocation, so this must follow its last
+// math instruction.  Set load_replay = false when _replay_init_ has already run.
+template <bool load_replay = true>
+inline void _llk_math_custom_mm_reuse_dest_srcb_init_()
+{
+    custom_mm_reuse_dest_srcb_configure_addrmod();
+    if constexpr (load_replay)
+    {
+        custom_mm_reuse_dest_srcb_configure_mop();
+    }
+}
+
+// src_index / dst_index are bank-relative DEST *row* offsets (not tile slots).
+//
+// Preconditions:
+// - the unpacker has issued a zero-and-set-dvalid on SrcB
+// - DEST at dst_index is zero
+template <std::uint32_t in0_tile_r_dim>
+inline void _llk_math_custom_mm_reuse_dest_srcb_(
+    const std::uint32_t src_index, const std::uint32_t dst_index, const std::uint32_t kt_dim, const std::uint32_t nt_dim, const std::uint32_t src_tile_stride)
+{
+    static_assert(
+        in0_tile_r_dim == 1 || in0_tile_r_dim == 2 || in0_tile_r_dim == 4 || in0_tile_r_dim == 8,
+        "custom_mm_reuse_dest_srcb: in0 tile height must be 1, 2, 4 or 8");
+
+    const std::uint32_t dest_buffer_base = get_dest_buffer_base();
+    TTI_STALLWAIT(p_stall::STALL_MATH, p_stall::SRCB_VLD | p_stall::WAIT_SFPU);
+
+    for (std::uint32_t i = 0; i < kt_dim; i++)
+    {
+        TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, src_index + i * src_tile_stride + dest_buffer_base);
+        math::reset_counters(p_setrwc::SET_ABD_F);
+
+        // DEST -> SrcB.  MVMULs 1/2 read SrcB rows 0..7 (K cols 0..15) and
+        // MVMULs 3/4 read rows 8..15 (K cols 16..31), so source face0 lands at
+        // SrcB row 0 and source face1 (DEST row +16) at SrcB row 8.
+        if constexpr (in0_tile_r_dim == 8)
+        {
+            TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_2, p_movd2b::MOV_4_ROWS, 0);
+            TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 4, ADDR_MOD_2, p_movd2b::MOV_4_ROWS, 4);
+            TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 8, ADDR_MOD_2, p_movd2b::MOV_4_ROWS, 16);
+            TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 12, ADDR_MOD_2, p_movd2b::MOV_4_ROWS, 20);
+        }
+        else if constexpr (in0_tile_r_dim == 1)
+        {
+            TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_2, p_movd2b::MOV_1_ROW, 0);
+            TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 8, ADDR_MOD_2, p_movd2b::MOV_1_ROW, 16);
+        }
+        else
+        {
+            // r_dim 2 or 4: one 4-row move per face.  Rows r..3 of a custom_mm
+            // output face are zero (its in0 unpack clears the SrcB rows above
+            // the tile height), so over-copying them is harmless.
+            TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 0, ADDR_MOD_2, p_movd2b::MOV_4_ROWS, 0);
+            TTI_MOVD2B(0, p_movd2b::SRC_ZERO_OFFSET + 8, ADDR_MOD_2, p_movd2b::MOV_4_ROWS, 16);
+        }
+
+        TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, dst_index + dest_buffer_base);
+        for (std::uint32_t j = 0; j < nt_dim; j++)
+        {
+            lltt::replay(CUSTOM_MM_REUSE_REPLAY_OFFSET, CUSTOM_MM_REUSE_REPLAY_LEN);
+        }
+    }
+
+    TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
+}


### PR DESCRIPTION
### PR Category

LLK promotion (additive)

### Summary

Completes the custom_mm family. #52727 promoted `custom_mm` and `compressed_custom_mm`; this adds the third sibling, which blaze uses for K-dimension reduction matmuls that reuse SrcB straight out of DEST:

- `tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_custom_mm_reuse_dest_srcb.h` — the math LLK.
- `tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_custom_mm_reuse_dest_srcb_api.h` — the operand-lookup wrapper.
- `tt_metal/hw/inc/api/compute/experimental/custom_mm_reuse_dest_srcb.h` — the compute-API entry point, registered in `tt_metal/hw/sources.cmake`.

Copied from blaze with the vendored include paths rewritten to the canonical `experimental/` form.

### Why this is stacked on the SDPA PR, not on #52727

The name suggests it belongs with #52727, but the compute-API header's unpack path pulls `llk_unpack_AB_sdpa_custom_mm_reuse_dest_srcb_api.h` and `llk_unpack_A_sdpa_api.h` — both promoted in #53295, neither present on
#52727. It has no unpack half of its own; it reuses the SDPA unpackers.
So the chain is main <- #52727 <- #53295 <- this PR, and GitHub will retarget as each merges. The math LLK itself is standalone (only ckernel/cmath/llk_math_common deps).

### Changes on top of the blaze source

**Blackhole guard.** Both the thread includes and the API body are behind `ARCH_BLACKHOLE`, matching `experimental/custom_mm.h` from #52727 — the family this file belongs to.

Worth noting for #53295 review: the SDPA compute-API headers it promotes (`sdpa.h`, `sdpa_custom_mm.h`, `sdpa_custom_mm_reuse_dest_srcb.h`) use bare `#ifdef TRISC_*` without the arch guard, so the two families are currently inconsistent. Not a build break — these headers are shipped in `HW_JIT_API_HEADERS` but only fail if a non-Blackhole kernel actually includes them, and today's only consumers are Blackhole-only. Still worth settling on one convention across the experimental surface.

### Tests

Additive only — no metal callers yet, so nothing existing changes behaviour or codegen. No LLK test in this PR; the family's test coverage arrives with #52727's `matmul_custom_compressed_test.cpp`, and this variant needs a DEST-preloaded fixture that the current harness does not provide.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilenkovic/promote-custom-mm-reuse-dest-srcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilenkovic/promote-custom-mm-reuse-dest-srcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilenkovic/promote-custom-mm-reuse-dest-srcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilenkovic/promote-custom-mm-reuse-dest-srcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilenkovic/promote-custom-mm-reuse-dest-srcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilenkovic/promote-custom-mm-reuse-dest-srcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilenkovic/promote-custom-mm-reuse-dest-srcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilenkovic/promote-custom-mm-reuse-dest-srcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilenkovic/promote-custom-mm-reuse-dest-srcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilenkovic/promote-custom-mm-reuse-dest-srcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilenkovic/promote-custom-mm-reuse-dest-srcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilenkovic/promote-custom-mm-reuse-dest-srcb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilenkovic/promote-custom-mm-reuse-dest-srcb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilenkovic/promote-custom-mm-reuse-dest-srcb)
