### PR TITLE
conv2d: group-aware L1 weight estimate for grouped/depthwise conv

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
@@ -1065,3 +1065,32 @@ def test_conv1d_depthwise_default_route_long_seq(device):
         packer_l1_acc=True,
         pcc=0.999,
     )
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 1 << 15}], indirect=True)
+def test_conv1d_depthwise_wide_channel_group_aware_l1_estimate(device):
+    """Regression for #53303 / #53304: group-blind L1 weight estimate.
+
+    Depthwise conv1d (groups == C), K=4, T=12, pad=3. The old estimate sized
+    weights as {1, 1, C*K, C} regardless of groups (~838 MB at C=10240 vs
+    ~80 KB actual) and the DRAM auto-slicer TT_FATAL'd.
+
+    After the fix the estimate is {1, 1, (C/groups)*K, C}. Silicon-verified
+    on Blackhole at C=2560 bf16 (PCC 0.999994) and C=5120 bf8 (PCC 0.999824).
+    C=10240 still exceeds per-core L1 even with the corrected estimate
+    (true CB capacity, not estimate error) and is not asserted here.
+    """
+    C = 2560
+    run_conv1d_route(
+        device,
+        batch_size=1,
+        in_channels=C,
+        out_channels=C,
+        input_length=12,
+        kernel_size=4,
+        stride=1,
+        padding=3,
+        groups=C,
+        shard_layout=None,
+        slice_config=None,
+    )

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1047,8 +1047,17 @@ core_count_and_size calculate_L1_usage_for_conv_op(
     const uint32_t output_channels_padded = tt::round_up(out_channels, tt::constants::TILE_WIDTH);
     // Note: These are not exact shapes for weights as prepare_conv_weights will pad the weights depending on the
     // conv2d params, but these are good enough for L1 usage estimation.
+    // For grouped convolutions (groups > 1), each output channel only sees
+    // in_channels/groups input channels, so the weight tensor is
+    // out_channels * (in_channels/groups) * kh * kw — not the dense
+    // in_channels * kh * kw * out_channels. Without this correction the
+    // estimate overstates depthwise weight memory by a factor of `groups`
+    // (e.g. 838 MB vs 80 KB for C=10240, groups=10240), which guarantees
+    // the DRAM auto-slicer can never find a valid config.
+    const uint32_t weight_spatial_product = kernel_size[0] * kernel_size[1];
+    const uint32_t effective_in_channels = (groups > 1) ? (in_channels_aligned / groups) : in_channels_aligned;
     const ttnn::Shape weights_shape(
-        {1, 1, in_channels_aligned * kernel_size[0] * kernel_size[1], output_channels_padded});
+        {1, 1, effective_in_channels * weight_spatial_product, output_channels_padded});
 
     const ParallelConfig input_parallel_config = _halo_input_memory_config.has_value() ? ParallelConfig{
             .grid = _halo_input_memory_config->shard_spec().value().grid,


### PR DESCRIPTION
## Problem

`calculate_L1_usage_for_conv_op()` estimated conv weight memory as `in_channels × kh × kw × out_channels` regardless of `groups`. For grouped/depthwise convolutions the actual weight tensor is `out_channels × (in_channels/groups) × kh × kw`.

At C=10240, groups=10240, K=4 that overstates weights by ~10,000× (~838 MB vs ~80 KB) and the DRAM auto-slicer reports no valid config.

## Change

When `groups > 1`, divide `in_channels_aligned` by `groups` before building the weight-shape estimate. `groups == 1` is unchanged.

## Silicon (2× Blackhole p150a)

| Shape | Result |
|---|---|
| C=2560 bf16 | PASS PCC 0.999994 |
| C=5120 bf8 | PASS PCC 0.999824 |
| C=64 bf16 | PASS PCC 0.999993 |
| C=5120 bf16 | still no valid DRAM slice (real CBs, not estimate) |
| C=10240 bf16 | same — true per-core L1 capacity, T=12 cannot be width-sliced |

Regression test is C=2560, the largest bf16 shape we ran to completion. This PR is an estimate correction, not a C=10240 capacity fix. It does not close #53303.

Refs #53303