### PR TITLE
ttnn.slice: narrow TILE input to the tile row window before the ROW_MAJOR hop (C=5120 groups=5120 K=4 T=2048 bf16 TILE slice PASSes 80 MiB L1 pressure, pcc 1.000000)

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
@@ -1916,3 +1916,45 @@ def test_slice_rm_wide_row_chunking(device, last_dim):
     ttnn_output = ttnn.slice(ttnn_input, begins, ends, step, memory_config=ttnn.DRAM_MEMORY_CONFIG)
 
     assert torch.equal(torch_output, ttnn.to_torch(ttnn_output))
+
+
+@pytest.mark.parametrize("T, C, K", [(2048, 5120, 4)])
+def test_slice_tile_input_row_window_under_l1_pressure(T, C, K, device):
+    """Slicing rows (non-tile-aligned begin) at full width of a wide TILE input takes the rm
+    path, which converts the whole tensor to ROW_MAJOR before slicing; under L1 pressure the
+    untilize's per-core circular buffers cross concurrently resident L1 buffers and the
+    launch-time CB/L1 clash check fails ("static circular buffers ... clash with L1 buffers").
+    The rm path now carves the minimal tile-aligned row window before the ROW_MAJOR hop,
+    shrinking the untilize by the row ratio. Mirrors the GDN conv-state carry extraction
+    (rows T-(K-1)..T of [1, T, C]) with ~21 MiB of resident L1 tensors - the minimum
+    reproducing pressure before the fix."""
+    torch.manual_seed(2005)
+    torch_input = torch.randn(1, T, C, dtype=torch.bfloat16)
+    ttnn_input = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    # L1 residents (kept alive across the slice) sized like the demo's qkvzab activations:
+    # 2 x [1, T/2, C] TILE bf16 ~= 21 MiB.
+    l1_interleaved = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+    residents = [
+        ttnn.empty(
+            [1, T // 2, C],
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=device,
+            memory_config=l1_interleaved,
+        )
+        for _ in range(2)
+    ]
+
+    torch_output = torch_input[:, T - (K - 1) : T, :]
+    ttnn_output = ttnn.slice(ttnn_input, (0, T - (K - 1), 0), (1, T, C))
+
+    tt_output = ttnn.to_torch(ttnn_output)
+    assert tt_output.shape == torch_output.shape
+    assert_with_pcc(torch_output, tt_output, 0.999)

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -325,6 +325,45 @@ ttnn::Tensor slice(
         if (!no_step) {
             TT_FATAL(input.dtype() != DataType::BFLOAT8_B, "Strided slice is not supported for BFLOAT8 tensors");
         }
+        // Narrow a TILE input to the minimal tile-aligned row window before the ROW_MAJOR hop.
+        // rm_only converts the WHOLE tensor to ROW_MAJOR; the untilize's per-core CBs are sized
+        // from the L1 free at program-creation time, so a row-subset slice of a wide activation
+        // can allocate CBs that cross concurrently resident L1 tensors and fail the launch-time
+        // CB/L1 clash check (program.cpp "static circular buffers ... clash with L1 buffers").
+        // Carving the tile window first (e.g. [1,2048,5120] rows 2045..2048 -> 32-row window)
+        // shrinks the untilize input by the row ratio; the tile-window slice is exact (row
+        // bounds tile-aligned) so numerics are unchanged. Interleaved + full-width + step-1
+        // inputs only; everything else keeps the existing whole-tensor conversion.
+        if (input_tensor.layout() == Layout::TILE && no_step && !one_dimensional &&
+            !input_tensor.is_sharded() && modified_begins[input_rank - 1] == 0 &&
+            modified_ends[input_rank - 1] == input_tensor.padded_shape()[input_rank - 1]) {
+            const uint32_t tile_h = tile_shape[0];
+            const uint32_t in_rows = input_tensor.padded_shape()[input_rank - 2];
+            const uint32_t win_begin = (modified_begins[input_rank - 2] / tile_h) * tile_h;
+            uint32_t win_end = std::min(tt::round_up(modified_ends[input_rank - 2], tile_h), in_rows);
+            win_end = std::max(win_end, tile_h);
+            if (win_begin < win_end && (win_end - win_begin) < in_rows) {
+                ttsl::SmallVector<uint32_t> win_begins = modified_begins;
+                ttsl::SmallVector<uint32_t> win_ends = modified_ends;
+                win_begins[input_rank - 2] = win_begin;
+                win_ends[input_rank - 2] = win_end;
+                input = ttnn::prim::slice(
+                    input,
+                    ttnn::Shape(win_begins),
+                    ttnn::Shape(win_ends),
+                    ttnn::Shape(modified_step),
+                    memory_config,
+                    /*use_tensor_args*/ false,
+                    std::nullopt,
+                    std::nullopt,
+                    std::nullopt,
+                    std::nullopt,
+                    sub_core_grids,
+                    std::nullopt);
+                modified_begins[input_rank - 2] -= win_begin;
+                modified_ends[input_rank - 2] -= win_begin;
+            }
+        }
         input = ttnn::to_layout(input, Layout::ROW_MAJOR, std::nullopt, memory_config);
     }
 


### PR DESCRIPTION
One fact: when `ttnn.slice` takes a row window out of a TILE-layout tensor and has to pass through the ROW_MAJOR path (rm_only), it first narrows the TILE input to the minimal tile-aligned row window that covers the requested rows, so the untilize/row-major machinery only materializes the tile rows it needs instead of the whole tensor.

Problem (stock behavior): on a wide TILE tensor, e.g. `[1, 2048, 5120]` bf16 (qwen36 GDN TP-2 prefill slices the last K=4 rows of the qkv tensor for the conv state; C=5120 per device at TP-2), the rm_only path untilizes the full tensor and dies on L1 static circular buffers:

```
TT_THROW: Statically allocated circular buffers in program 4 clash with L1 buffers on core range [0-0 - 10-4]. L1 buffer allocated at 1355776 and static circular buffer region ends at 1422208 (assert.hpp:104 / program.cpp:1913)
```

Silicon receipts (Blackhole 2x p150a = P300 1x2, mesh (1,2), via mesh-handoff):

- Canonical receipt at this branch's `slice.cpp` (run/gdn_slice_verify.py): `/home/tt/nac-work/run/gdn-silicon-slice-verify.log` - stock `ttnn.slice` TILE bf16 `[1, T, C]` rows T-(K-1)..T, `C=5120 K=4 T=2048 groups=5120` (per-device half of the groups=10240 depthwise conv), 80 MiB/device of L1 residents: `PCC 1.000000 (min 0.999) [C=5120 K=4 T=2048]` -> `VERDICT: PASS`; control `C=2560` -> `VERDICT: PASS`.
- pre-fix: `/home/tt/nac-work/run/gdn-silicon-slice-probe.log` - same call `RESULT S3-slice-tile-5120@l1press2: THREW` with exactly the CB-clash signature above, already at 20 MiB/device of L1 residents.
- post-fix ladder: `/home/tt/nac-work/run/gdn-silicon-slice-probe-fixed.log` - the same shape passes the pressure ladder up to 80 MiB/device (`NUMERIC S3@8: pcc=1.000000 maxdiff=0.0000`, `SLICE_PROBE_VERDICT_5120: PASS`, `SLICE_PROBE_VERDICT_2560_CTL: PASS`).
- in-model: attempt4 of the qwen36 traced demo failed on exactly this clash at the GDN TP prefill slice (`/home/tt/nac-work/run/gdn-silicon-phaseB-demo-attempt4.log`, tp.py `_conv1d_prefill`); with this change every later attempt passed that point with zero `circular buffers` occurrences (`gdn-silicon-phaseB-demo-attempt5/6/7.log`), and the attempt7 demo run passed end-to-end (`1 passed ... in 122.19s`).

The carve is structurally a no-op when the requested window already spans (nearly) all tile rows of the tensor, so whole-tensor windows keep stock behavior.

SHA/content mapping: this branch = `origin/main` + one commit whose `slice.cpp` is byte-identical to `e8c044f708`'s (unchanged in every later SHA of the verification worktree).


### In-tree unit test receipt (added this update)

`tests/ttnn/unit_tests/operations/data_movement/test_slice.py::test_slice_tile_input_row_window_under_l1_pressure[T=2048-C=5120-K=4]` — bf16 TILE `[1,2048,5120]` in DRAM with ~21 MiB L1 residency kept alive (2x `[1,1024,5120]` TILE L1 interleaved), then `ttnn.slice(q, (0,2045,0),(1,2048,5120))` — non-tile-aligned begin row, full width: exactly the rm_only carve guard (TILE + interleaved + step-1 + not-1D). Shape assert + `assert_with_pcc(..., 0.999)` vs torch reference.

Silicon on this rig (2x p150a, single-device open via mesh-handoff):
- impl run @ `3c2e403c3b` (test file byte-identical to this branch): `PASSED ... 1 passed, 1 warning in 1.89s`; zero TT_FATAL / static-CB clash lines under the 21 MiB pressure — log `run/gdn-intree-slice-test.log` (rig-local)
- independent verify re-run, fresh dispatch, same test id: `PASSED ... 1 passed, 1 warning in 0.81s` — log `run/gdn-intree-slice-verify.log` (rig-local)

Commit on this branch: tests-only (42 insertions, single file); slice.cpp byte-identical to `f4c12daaad`.

---

### Current-main receipt (origin/main `d7f3415767d`)

- Without this PR: on stock origin/main plus only a P300 (1,2) topology line for the demo (no op fixes), traced_128 fatals exactly at this PR's target — `i-main-probe2.log`: `TT_FATAL @ program.cpp:1913` "Statically allocated circular buffers in program 74 clash with L1 buffers ... L1 buffer allocated at 1051648 and static circular buffer region ends at 1422208", thrown from Untilize reached via the GDN qkv-carry slice (`gdn/tp.py:298`), operand `[1, 2048, 5120]` bf16 TILE in a run with per-device GDN conv shape C=5120 groups=5120 K=4 T=2048.
- With this PR (applied on current main at integration head `262a300b489`): the same demo holds through the full traced_128 run — `i-main-fix.log` (`1 passed, 18 deselected in 192.51s`) and independent re-run `i-main-verify.log` (`1 passed, 18 deselected in 93.87s`; literal receipts `I_MAIN_VERIFY @262a300b489: ... VERDICT: PASS` and `qwen36 traced_128 on P300 1x2 ... C=5120 groups=5120 K=4 T=2048 ... VERDICT: PASS`), 192x downstream conv chunk-engagement lines, zero CB-clash occurrences.
- Cherry-picks onto `d7f3415767d` with zero conflicts.