### PR TITLE
[Test Only] Add fp32 sort index test

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
@@ -218,8 +218,11 @@ def test_sort_fp32_wide_index_correctness(descending, device):
     indices = ttnn.to_torch(ttnn_sort_indices).reshape(-1).to(torch.int64)
 
     assert_equal(torch_sort_values, values)
-    assert indices.min() >= 0 and indices.max() < n
-    assert indices.unique().numel() == n
+    assert (
+        indices.min() >= 0 and indices.max() < n
+    ), f"indices out of range [0, {n}): min={int(indices.min())}, max={int(indices.max())}"
+    unique_count = indices.unique().numel()
+    assert unique_count == n, f"{n - unique_count} duplicated indices"
     assert_equal(input.reshape(-1)[indices], values.reshape(-1))
 
 

--- a/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
@@ -188,6 +188,42 @@ def test_sort_long_tensor(shape, dim, descending, device):
 
 
 @pytest.mark.parametrize(
+    "descending",
+    [
+        False,
+        # Descending order pads the row with -inf, which ties with real -inf
+        # entries and can emit padding indices (>= n) into the output.
+        pytest.param(True, marks=pytest.mark.xfail(strict=True, reason="#53326: padding indices leak")),
+    ],
+)
+def test_sort_fp32_wide_index_correctness(descending, device):
+    # Sort a wide fp32 row dominated by -inf duplicates. Ties make exact torch
+    # index parity undefined, so check invariants instead: exact sorted values,
+    # uint32 indices forming a valid permutation, and gather-consistency.
+    torch.manual_seed(0)
+    shape = [1, 151936]
+    n = shape[-1]
+    # A few finite logits in a sea of -inf, as in masked vocab-size logits.
+    input = torch.full(shape, float("-inf"), dtype=torch.float32)
+    input[..., torch.randperm(n)[:328]] = torch.randn(328) * 8.0
+
+    torch_sort_values, _ = torch.sort(input, dim=-1, descending=descending)
+
+    ttnn_input = ttnn.from_torch(input, ttnn.float32, layout=ttnn.Layout.TILE, device=device)
+    ttnn_sort_values, ttnn_sort_indices = ttnn.sort(ttnn_input, dim=-1, descending=descending)
+
+    assert ttnn_sort_indices.dtype == ttnn.uint32
+
+    values = ttnn.to_torch(ttnn_sort_values)
+    indices = ttnn.to_torch(ttnn_sort_indices).reshape(-1).to(torch.int64)
+
+    assert_equal(torch_sort_values, values)
+    assert indices.min() >= 0 and indices.max() < n
+    assert indices.unique().numel() == n
+    assert_equal(input.reshape(-1)[indices], values.reshape(-1))
+
+
+@pytest.mark.parametrize(
     "shape, dim, descending",
     [
         ([64, 64], -1, True),

--- a/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_sort.py
@@ -187,37 +187,52 @@ def test_sort_long_tensor(shape, dim, descending, device):
         assert_equal(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
 
 
+def _sort_fp32_wide(descending, device):
+    # A few finite logits in a sea of -inf, as in masked vocab-size logits.
+    torch.manual_seed(0)
+    n = 151936
+    input = torch.full((1, n), float("-inf"), dtype=torch.float32)
+    input[..., torch.randperm(n)[:328]] = torch.randn(328) * 8.0
+
+    ttnn_input = ttnn.from_torch(input, ttnn.float32, layout=ttnn.Layout.TILE, device=device)
+    ttnn_sort_values, ttnn_sort_indices = ttnn.sort(ttnn_input, dim=-1, descending=descending)
+    return input, ttnn_sort_values, ttnn_sort_indices
+
+
+@pytest.mark.parametrize("descending", [False, True])
+def test_sort_fp32_wide_values(descending, device):
+    input, ttnn_sort_values, ttnn_sort_indices = _sort_fp32_wide(descending, device)
+
+    torch_sort_values, _ = torch.sort(input, dim=-1, descending=descending)
+
+    assert ttnn_sort_indices.dtype == ttnn.uint32
+    assert_equal(torch_sort_values, ttnn.to_torch(ttnn_sort_values))
+
+
 @pytest.mark.parametrize(
     "descending",
     [
         False,
         # Descending order pads the row with -inf, which ties with real -inf
         # entries and can emit padding indices (>= n) into the output.
-        pytest.param(True, marks=pytest.mark.xfail(strict=True, reason="#53326: padding indices leak")),
+        pytest.param(
+            True,
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason="https://github.com/tenstorrent/tt-metal/issues/53326: padding indices leak",
+            ),
+        ),
     ],
 )
 def test_sort_fp32_wide_index_correctness(descending, device):
-    # Sort a wide fp32 row dominated by -inf duplicates. Ties make exact torch
-    # index parity undefined, so check invariants instead: exact sorted values,
-    # uint32 indices forming a valid permutation, and gather-consistency.
-    torch.manual_seed(0)
-    shape = [1, 151936]
-    n = shape[-1]
-    # A few finite logits in a sea of -inf, as in masked vocab-size logits.
-    input = torch.full(shape, float("-inf"), dtype=torch.float32)
-    input[..., torch.randperm(n)[:328]] = torch.randn(328) * 8.0
+    # Ties make exact torch index parity undefined, so check invariants instead:
+    # indices form a valid permutation and gather back the sorted values.
+    input, ttnn_sort_values, ttnn_sort_indices = _sort_fp32_wide(descending, device)
 
-    torch_sort_values, _ = torch.sort(input, dim=-1, descending=descending)
-
-    ttnn_input = ttnn.from_torch(input, ttnn.float32, layout=ttnn.Layout.TILE, device=device)
-    ttnn_sort_values, ttnn_sort_indices = ttnn.sort(ttnn_input, dim=-1, descending=descending)
-
-    assert ttnn_sort_indices.dtype == ttnn.uint32
-
+    n = input.shape[-1]
     values = ttnn.to_torch(ttnn_sort_values)
     indices = ttnn.to_torch(ttnn_sort_indices).reshape(-1).to(torch.int64)
 
-    assert_equal(torch_sort_values, values)
     assert (
         indices.min() >= 0 and indices.max() < n
     ), f"indices out of range [0, {n}): min={int(indices.min())}, max={int(indices.max())}"


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Relates to #26057. Adds regression coverage for its repro (fp32 `[1, 151936]` logits, mostly `-inf`), whose reported defects — fp32 value saturation and int16 index overflow — are fixed on main (#41007, #33983) but had no test pinning them: the closest existing case (`test_sort_long_tensor`) covers the shape in bfloat16 and asserts values only.

The new test asserts, per direction:
- sorted values match `torch.sort` exactly (pins the fp32 saturation defect),
- indices are uint32 (pins the int16 overflow defect),
- indices are in range and form a valid permutation,
- gathering the input by the returned indices reproduces the sorted values.

Exact torch index parity is deliberately not asserted: the input is tie-heavy and ties sort unstably until #25797/#33492 issues are resolved.

`descending=True` is an xfail for #53326 (found while writing this test): the `-inf` tile padding ties with real `-inf` entries and out-of-range indices go into the output.

### Notes for reviewers
- Runtime is ~2s for both parametrizations on Blackhole p100a (warm JIT cache): one shape, two directions.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwroszTT/26057-sort-fp32-wide-index-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwroszTT/26057-sort-fp32-wide-index-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwroszTT/26057-sort-fp32-wide-index-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwroszTT/26057-sort-fp32-wide-index-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwroszTT/26057-sort-fp32-wide-index-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwroszTT/26057-sort-fp32-wide-index-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwroszTT/26057-sort-fp32-wide-index-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwroszTT/26057-sort-fp32-wide-index-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwroszTT/26057-sort-fp32-wide-index-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwroszTT/26057-sort-fp32-wide-index-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwroszTT/26057-sort-fp32-wide-index-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwroszTT/26057-sort-fp32-wide-index-regression)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwroszTT/26057-sort-fp32-wide-index-regression)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwroszTT/26057-sort-fp32-wide-index-regression)