### PR TITLE
[Feature] ttml: AdamW overload taking the step scalars as tensors

### DIFF
--- a/tt-train/sources/ttml/metal/optimizers/adamw/adamw.cpp
+++ b/tt-train/sources/ttml/metal/optimizers/adamw/adamw.cpp
@@ -44,4 +44,42 @@ ttnn::Tensor adamw(
         stochastic_rounding_seed);
 }
 
+ttnn::Tensor adamw(
+    const ttnn::Tensor& param_in,
+    const ttnn::Tensor& grad,
+    const ttnn::Tensor& exp_avg,
+    const ttnn::Tensor& exp_avg_sq,
+    const std::optional<ttnn::Tensor>& max_exp_avg_sq,
+    float beta1,
+    float beta2,
+    const ttnn::Tensor& step_size,
+    const ttnn::Tensor& inv_sqrt_bias_correction2,
+    const ttnn::Tensor& decay_factor,
+    float epsilon,
+    StochasticRounding stochastic_rounding,
+    std::optional<uint32_t> stochastic_rounding_seed) {
+    TT_FATAL(
+        (stochastic_rounding == StochasticRounding::Enabled) == stochastic_rounding_seed.has_value(),
+        "a stochastic rounding seed must be supplied iff stochastic rounding is enabled");
+    return ttnn::prim::adamw(
+        param_in,
+        grad,
+        exp_avg,
+        exp_avg_sq,
+        max_exp_avg_sq,
+        0.0F,
+        beta1,
+        beta2,
+        0.0F,
+        0.0F,
+        epsilon,
+        0.0F,
+        max_exp_avg_sq.has_value(),
+        stochastic_rounding,
+        stochastic_rounding_seed,
+        step_size,
+        inv_sqrt_bias_correction2,
+        decay_factor);
+}
+
 }  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/optimizers/adamw/adamw.hpp
+++ b/tt-train/sources/ttml/metal/optimizers/adamw/adamw.hpp
@@ -26,4 +26,19 @@ ttnn::Tensor adamw(
     // Required iff stochastic rounding is enabled.
     std::optional<uint32_t> stochastic_rounding_seed = std::nullopt);
 
+ttnn::Tensor adamw(
+    const ttnn::Tensor& param_in,
+    const ttnn::Tensor& grad,
+    const ttnn::Tensor& exp_avg,
+    const ttnn::Tensor& exp_avg_sq,
+    const std::optional<ttnn::Tensor>& max_exp_avg_sq,
+    float beta1,
+    float beta2,
+    const ttnn::Tensor& step_size,
+    const ttnn::Tensor& inv_sqrt_bias_correction2,
+    const ttnn::Tensor& decay_factor,
+    float epsilon,
+    StochasticRounding stochastic_rounding = StochasticRounding::Disabled,
+    std::optional<uint32_t> stochastic_rounding_seed = std::nullopt);
+
 }  // namespace ttml::metal

--- a/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation.cpp
@@ -87,6 +87,29 @@ void AdamWDeviceOperation::validate_on_program_cache_miss(
         check_tensor(
             max_exp_avg_sq.value(), "Max Exponential Average Squared Buffer", tt::tt_metal::Layout::TILE, param_dtype);
     }
+
+    const auto& step_size = tensor_args.step_size;
+    const auto& inv_sqrt_bias_correction2 = tensor_args.inv_sqrt_bias_correction2;
+    const auto& decay_factor = tensor_args.decay_factor;
+    TT_FATAL(
+        step_size.has_value() == inv_sqrt_bias_correction2.has_value() &&
+            step_size.has_value() == decay_factor.has_value(),
+        "AdamW requires step_size, inv_sqrt_bias_correction2 and decay_factor to be supplied together");
+
+    if (step_size.has_value()) {
+        auto check_scalar = [&](const ttnn::Tensor& tensor, const std::string& name) {
+            check_tensor(tensor, name, tt::tt_metal::Layout::TILE, tt::tt_metal::DataType::FLOAT32);
+            TT_FATAL(
+                tensor.logical_volume() == 1U,
+                "Tensor '{}' must hold exactly one element, got {}",
+                name,
+                tensor.logical_volume());
+            TT_FATAL(tensor.device() == param.device(), "Tensor '{}' must be on the parameter's device", name);
+        };
+        check_scalar(step_size.value(), "Step Size");
+        check_scalar(inv_sqrt_bias_correction2.value(), "Inverse Sqrt Bias Correction 2");
+        check_scalar(decay_factor.value(), "Decay Factor");
+    }
 }
 
 AdamWDeviceOperation::spec_return_value_t AdamWDeviceOperation::compute_output_specs(
@@ -106,8 +129,14 @@ ttsl::hash::hash_t AdamWDeviceOperation::compute_program_hash(
     auto amsgrad = args.amsgrad;
     auto stochastic_rounding = args.stochastic_rounding;
     auto max_exp_avg_sq_initialized = tensor_args.max_exp_avg_sq.has_value();
+    auto scalars_on_device = tensor_args.step_size.has_value();
     auto hash = tt::tt_metal::operation::hash_operation<AdamWDeviceOperation>(
-        amsgrad, stochastic_rounding, max_exp_avg_sq_initialized, param_tensor.dtype(), param_logical_shape);
+        amsgrad,
+        stochastic_rounding,
+        max_exp_avg_sq_initialized,
+        scalars_on_device,
+        param_tensor.dtype(),
+        param_logical_shape);
 
     return hash;
 }
@@ -131,7 +160,10 @@ ttml::metal::optimizers::adamw::device::AdamWDeviceOperation::tensor_return_valu
     float weight_decay,
     bool amsgrad,
     ttml::metal::StochasticRounding stochastic_rounding,
-    std::optional<uint32_t> stochastic_rounding_seed) {
+    std::optional<uint32_t> stochastic_rounding_seed,
+    const std::optional<ttnn::Tensor>& step_size,
+    const std::optional<ttnn::Tensor>& inv_sqrt_bias_correction2,
+    const std::optional<ttnn::Tensor>& decay_factor) {
     using OperationType = ttml::metal::optimizers::adamw::device::AdamWDeviceOperation;
 
     auto operation_attributes = OperationType::operation_attributes_t{
@@ -152,6 +184,9 @@ ttml::metal::optimizers::adamw::device::AdamWDeviceOperation::tensor_return_valu
         .exp_avg = exp_avg,
         .exp_avg_sq = exp_avg_sq,
         .max_exp_avg_sq = max_exp_avg_sq,
+        .step_size = step_size,
+        .inv_sqrt_bias_correction2 = inv_sqrt_bias_correction2,
+        .decay_factor = decay_factor,
     };
 
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);

--- a/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation.hpp
@@ -48,6 +48,9 @@ ttml::metal::optimizers::adamw::device::AdamWDeviceOperation::tensor_return_valu
     float weight_decay,
     bool amsgrad,
     ttml::metal::StochasticRounding stochastic_rounding,
-    std::optional<uint32_t> stochastic_rounding_seed);
+    std::optional<uint32_t> stochastic_rounding_seed,
+    const std::optional<ttnn::Tensor>& step_size = std::nullopt,
+    const std::optional<ttnn::Tensor>& inv_sqrt_bias_correction2 = std::nullopt,
+    const std::optional<ttnn::Tensor>& decay_factor = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation_types.hpp
+++ b/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_device_operation_types.hpp
@@ -33,6 +33,10 @@ struct tensor_args_t {
     const ttnn::Tensor& exp_avg;
     const ttnn::Tensor& exp_avg_sq;
     std::optional<ttnn::Tensor> max_exp_avg_sq = std::nullopt;
+
+    std::optional<ttnn::Tensor> step_size = std::nullopt;
+    std::optional<ttnn::Tensor> inv_sqrt_bias_correction2 = std::nullopt;
+    std::optional<ttnn::Tensor> decay_factor = std::nullopt;
 };
 
 using tensor_return_value_t = ttnn::Tensor;

--- a/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/optimizers/adamw/device/adamw_program_factory.cpp
@@ -33,6 +33,9 @@ constexpr uint32_t kGradAddrIdx = 1U;
 constexpr uint32_t kExpAvgAddrIdx = 2U;
 constexpr uint32_t kExpAvgSqAddrIdx = 3U;
 constexpr uint32_t kMaxExpAvgSqAddrIdx = 4U;
+constexpr uint32_t kStepSizeAddrIdx = 5U;
+constexpr uint32_t kInvSqrtBc2AddrIdx = 6U;
+constexpr uint32_t kDecayFactorAddrIdx = 7U;
 // compute runtime args
 constexpr uint32_t kComputeBeta1Idx = 0U;
 constexpr uint32_t kComputeBeta2Idx = 1U;
@@ -54,6 +57,7 @@ constexpr auto kGradCbIndex = tt::CBIndex::c_1;
 constexpr auto kExpAvgCbIndex = tt::CBIndex::c_2;
 constexpr auto kExpAvgSqCbIndex = tt::CBIndex::c_3;
 constexpr auto kMaxExpAvgSqInCbIndex = tt::CBIndex::c_4;
+constexpr auto kScalarsCbIndex = tt::CBIndex::c_5;
 
 constexpr auto kOutputCbIndex = tt::CBIndex::c_16;
 constexpr auto kExpAvgOutCbIndex = tt::CBIndex::c_17;
@@ -113,6 +117,9 @@ void assign_per_core_runtime_args(
     const tt::tt_metal::Buffer* exp_avg_buffer,
     const tt::tt_metal::Buffer* exp_avg_sq_buffer,
     const tt::tt_metal::Buffer* max_exp_avg_sq_buffer,
+    const tt::tt_metal::Buffer* step_size_buffer,
+    const tt::tt_metal::Buffer* inv_sqrt_bc2_buffer,
+    const tt::tt_metal::Buffer* decay_factor_buffer,
     const tt::tt_metal::Buffer* output_buffer,
     const operation_attributes_t& attrs,
     uint32_t num_cores,
@@ -124,11 +131,14 @@ void assign_per_core_runtime_args(
     float one_minus_beta1 = 1.0f - attrs.beta1;
     float one_minus_beta2 = 1.0f - attrs.beta2;
 
-    float bias_correction1 = 1.0f - attrs.beta1_pow;
-    float bias_correction2 = 1.0f - attrs.beta2_pow;
-    float step_size = attrs.lr / bias_correction1;
-    float inv_sqrt_bc2 = 1.0f / std::sqrt(bias_correction2);
-    float decay_factor = 1.0f - attrs.lr * attrs.weight_decay;
+    float step_size = 0.0f;
+    float inv_sqrt_bc2 = 0.0f;
+    float decay_factor = 0.0f;
+    if (step_size_buffer == nullptr) {
+        step_size = attrs.lr / (1.0f - attrs.beta1_pow);
+        inv_sqrt_bc2 = 1.0f / std::sqrt(1.0f - attrs.beta2_pow);
+        decay_factor = 1.0f - attrs.lr * attrs.weight_decay;
+    }
 
     std::vector<uint32_t> seeds = make_stochastic_rounding_seeds(attrs.stochastic_rounding_seed, num_cores);
 
@@ -171,6 +181,9 @@ void assign_per_core_runtime_args(
              exp_avg_buffer->address(),
              exp_avg_sq_buffer->address(),
              max_exp_avg_sq_buffer != nullptr ? max_exp_avg_sq_buffer->address() : 0U,
+             step_size_buffer != nullptr ? step_size_buffer->address() : 0U,
+             inv_sqrt_bc2_buffer != nullptr ? inv_sqrt_bc2_buffer->address() : 0U,
+             decay_factor_buffer != nullptr ? decay_factor_buffer->address() : 0U,
              num_tiles_per_core,
              num_tiles_written});
 
@@ -213,6 +226,7 @@ AdamWProgramFactory::cached_program_t AdamWProgramFactory::create(
     const auto& exp_avg = tensor_args.exp_avg;
     const auto& exp_avg_sq = tensor_args.exp_avg_sq;
     const auto& max_exp_avg_sq_opt = tensor_args.max_exp_avg_sq;
+    const bool scalars_on_device = tensor_args.step_size.has_value();
 
     auto* device = param.device();
 
@@ -311,6 +325,11 @@ AdamWProgramFactory::cached_program_t AdamWProgramFactory::create(
             intermediate_num_tiles);
     }
 
+    if (scalars_on_device) {
+        [[maybe_unused]] auto cb_scalars = create_circular_buffer(
+            program, all_cores, kScalarsCbIndex, intermediate_data_format, float32_single_tile_size_bytes, 3U);
+    }
+
     // Intermediate CBs are always fp32
     [[maybe_unused]] auto cb_momentum = create_circular_buffer(
         program,
@@ -337,10 +356,14 @@ AdamWProgramFactory::cached_program_t AdamWProgramFactory::create(
     auto* exp_avg_buffer = exp_avg.buffer();
     auto* exp_avg_sq_buffer = exp_avg_sq.buffer();
     auto* max_exp_avg_sq_buffer = max_exp_avg_sq_opt.has_value() ? max_exp_avg_sq_opt.value().buffer() : nullptr;
+    auto* step_size_buffer = scalars_on_device ? tensor_args.step_size.value().buffer() : nullptr;
+    auto* inv_sqrt_bc2_buffer = scalars_on_device ? tensor_args.inv_sqrt_bias_correction2.value().buffer() : nullptr;
+    auto* decay_factor_buffer = scalars_on_device ? tensor_args.decay_factor.value().buffer() : nullptr;
     auto* output_buffer = output.buffer();
 
     std::map<std::string, std::string> defines;
     defines["AMSGRAD"] = operation_attributes.amsgrad ? "1" : "0";
+    defines["SCALARS_ON_DEVICE"] = scalars_on_device ? "1" : "0";
     defines["STOCH_ROUND"] = operation_attributes.stochastic_rounding == StochasticRounding::Enabled ? "1" : "0";
 
     AdamWKernels kernels{};
@@ -351,6 +374,9 @@ AdamWProgramFactory::cached_program_t AdamWProgramFactory::create(
     tt::tt_metal::TensorAccessorArgs(exp_avg_buffer).append_to(reader_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(exp_avg_sq_buffer).append_to(reader_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(max_exp_avg_sq_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(step_size_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(inv_sqrt_bc2_buffer).append_to(reader_compile_time_args);
+    tt::tt_metal::TensorAccessorArgs(decay_factor_buffer).append_to(reader_compile_time_args);
     kernels.reader = create_reader_kernel(program, all_cores, reader_compile_time_args, defines, kReaderKernelPath);
 
     std::vector<uint32_t> writer_compile_time_args{block_size};
@@ -401,6 +427,9 @@ AdamWProgramFactory::cached_program_t AdamWProgramFactory::create(
         exp_avg_buffer,
         exp_avg_sq_buffer,
         max_exp_avg_sq_buffer,
+        step_size_buffer,
+        inv_sqrt_bc2_buffer,
+        decay_factor_buffer,
         output_buffer,
         operation_attributes,
         num_cores,
@@ -451,6 +480,12 @@ void AdamWProgramFactory::override_runtime_arguments(
     auto* exp_avg_sq_buffer = tensor_args.exp_avg_sq.buffer();
     auto* max_exp_avg_sq_buffer =
         tensor_args.max_exp_avg_sq.has_value() ? tensor_args.max_exp_avg_sq.value().buffer() : nullptr;
+    auto* step_size_buffer = tensor_args.step_size.has_value() ? tensor_args.step_size.value().buffer() : nullptr;
+    auto* inv_sqrt_bc2_buffer = tensor_args.inv_sqrt_bias_correction2.has_value()
+                                    ? tensor_args.inv_sqrt_bias_correction2.value().buffer()
+                                    : nullptr;
+    auto* decay_factor_buffer =
+        tensor_args.decay_factor.has_value() ? tensor_args.decay_factor.value().buffer() : nullptr;
     auto* output_buffer = tensor_return_value.buffer();
 
     // Only address arguments need updating here; tile counts remain the same as in create().
@@ -464,11 +499,14 @@ void AdamWProgramFactory::override_runtime_arguments(
     float one_minus_beta1 = 1.0f - attrs.beta1;
     float one_minus_beta2 = 1.0f - attrs.beta2;
 
-    float bias_correction1 = 1.0f - attrs.beta1_pow;
-    float bias_correction2 = 1.0f - attrs.beta2_pow;
-    float step_size = attrs.lr / bias_correction1;
-    float inv_sqrt_bc2 = 1.0f / std::sqrt(bias_correction2);
-    float decay_factor = 1.0f - attrs.lr * attrs.weight_decay;
+    float step_size = 0.0f;
+    float inv_sqrt_bc2 = 0.0f;
+    float decay_factor = 0.0f;
+    if (step_size_buffer == nullptr) {
+        step_size = attrs.lr / (1.0f - attrs.beta1_pow);
+        inv_sqrt_bc2 = 1.0f / std::sqrt(1.0f - attrs.beta2_pow);
+        decay_factor = 1.0f - attrs.lr * attrs.weight_decay;
+    }
 
     std::vector<uint32_t> seeds = make_stochastic_rounding_seeds(attrs.stochastic_rounding_seed, num_cores);
 
@@ -497,6 +535,9 @@ void AdamWProgramFactory::override_runtime_arguments(
             runtime_args[kExpAvgSqAddrIdx] = exp_avg_sq_buffer->address();
             runtime_args[kMaxExpAvgSqAddrIdx] =
                 max_exp_avg_sq_buffer != nullptr ? max_exp_avg_sq_buffer->address() : 0U;
+            runtime_args[kStepSizeAddrIdx] = step_size_buffer != nullptr ? step_size_buffer->address() : 0U;
+            runtime_args[kInvSqrtBc2AddrIdx] = inv_sqrt_bc2_buffer != nullptr ? inv_sqrt_bc2_buffer->address() : 0U;
+            runtime_args[kDecayFactorAddrIdx] = decay_factor_buffer != nullptr ? decay_factor_buffer->address() : 0U;
         }
         // Update compute kernel args
         {
@@ -504,11 +545,13 @@ void AdamWProgramFactory::override_runtime_arguments(
             runtime_args[kComputeBeta1Idx] = std::bit_cast<uint32_t>(attrs.beta1);
             runtime_args[kComputeBeta2Idx] = std::bit_cast<uint32_t>(attrs.beta2);
             runtime_args[kComputeEpsilonIdx] = std::bit_cast<uint32_t>(attrs.epsilon);
-            runtime_args[kComputeStepSizeIdx] = std::bit_cast<uint32_t>(step_size);
-            runtime_args[kComputeInvSqrtBiasCorrection2Idx] = std::bit_cast<uint32_t>(inv_sqrt_bc2);
+            if (step_size_buffer == nullptr) {
+                runtime_args[kComputeStepSizeIdx] = std::bit_cast<uint32_t>(step_size);
+                runtime_args[kComputeInvSqrtBiasCorrection2Idx] = std::bit_cast<uint32_t>(inv_sqrt_bc2);
+                runtime_args[kComputeDecayFactorIdx] = std::bit_cast<uint32_t>(decay_factor);
+            }
             runtime_args[kComputeOneMinusBeta1Idx] = std::bit_cast<uint32_t>(one_minus_beta1);
             runtime_args[kComputeOneMinusBeta2Idx] = std::bit_cast<uint32_t>(one_minus_beta2);
-            runtime_args[kComputeDecayFactorIdx] = std::bit_cast<uint32_t>(decay_factor);
             runtime_args[kComputeSeedIdx] = seeds[i];
         }
         // Update writer kernel args

--- a/tt-train/sources/ttml/metal/optimizers/adamw/device/kernels/compute/adamw_kernel.cpp
+++ b/tt-train/sources/ttml/metal/optimizers/adamw/device/kernels/compute/adamw_kernel.cpp
@@ -6,6 +6,7 @@
 
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/bcast.h"
+#include "api/compute/cb_api.h"
 #include "api/compute/binary_max_min.h"
 #include "api/compute/common.h"
 #include "api/compute/eltwise_binary_sfpu.h"
@@ -22,6 +23,7 @@ constexpr auto cb_grad_idx = tt::CBIndex::c_1;
 constexpr auto cb_exp_avg_idx = tt::CBIndex::c_2;
 constexpr auto cb_exp_avg_sq_idx = tt::CBIndex::c_3;
 constexpr auto cb_max_exp_avg_sq_in_idx = tt::CBIndex::c_4;
+constexpr auto cb_scalars_idx = tt::CBIndex::c_5;
 
 constexpr auto cb_output_idx = tt::CBIndex::c_16;
 constexpr auto cb_exp_avg_out_idx = tt::CBIndex::c_17;
@@ -54,6 +56,17 @@ void kernel_main() {
     uint32_t one_minus_beta2 = get_arg_val<uint32_t>(args_idx++);
     uint32_t decay_factor = get_arg_val<uint32_t>(args_idx++);
     [[maybe_unused]] uint32_t seed = get_arg_val<uint32_t>(args_idx++);
+
+#if SCALARS_ON_DEVICE
+    cb_wait_front(cb_scalars_idx, 3);
+#if defined(ARCH_BLACKHOLE)
+    asm volatile("fence");
+#endif
+    step_size = read_tile_value(cb_scalars_idx, 0, 0);
+    inv_sqrt_bc2 = read_tile_value(cb_scalars_idx, 1, 0);
+    decay_factor = read_tile_value(cb_scalars_idx, 2, 0);
+    cb_pop_front(cb_scalars_idx, 3);
+#endif
 
     init_sfpu(cb_param_idx, cb_output_idx);
 #if STOCH_ROUND

--- a/tt-train/sources/ttml/metal/optimizers/adamw/device/kernels/dataflow/reader_adamw.cpp
+++ b/tt-train/sources/ttml/metal/optimizers/adamw/device/kernels/dataflow/reader_adamw.cpp
@@ -12,6 +12,7 @@ constexpr auto cb_grad_idx = tt::CBIndex::c_1;
 constexpr auto cb_exp_avg_idx = tt::CBIndex::c_2;
 constexpr auto cb_exp_avg_sq_idx = tt::CBIndex::c_3;
 constexpr auto cb_max_exp_avg_sq_in_idx = tt::CBIndex::c_4;
+constexpr auto cb_scalars_idx = tt::CBIndex::c_5;
 
 constexpr uint32_t block_size = get_compile_time_arg_val(0);
 
@@ -22,6 +23,9 @@ void kernel_main() {
     const uint32_t exp_avg_addr = get_arg_val<uint32_t>(runtime_args_counter++);
     const uint32_t exp_avg_sq_addr = get_arg_val<uint32_t>(runtime_args_counter++);
     const uint32_t max_exp_avg_sq_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    const uint32_t step_size_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    const uint32_t inv_sqrt_bc2_addr = get_arg_val<uint32_t>(runtime_args_counter++);
+    const uint32_t decay_factor_addr = get_arg_val<uint32_t>(runtime_args_counter++);
 
     const uint32_t num_tiles_to_process = get_arg_val<uint32_t>(runtime_args_counter++);
     const uint32_t start_tile = get_arg_val<uint32_t>(runtime_args_counter++);
@@ -36,12 +40,32 @@ void kernel_main() {
     constexpr auto exp_avg_args = TensorAccessorArgs<grad_args.next_compile_time_args_offset()>();
     constexpr auto exp_avg_sq_args = TensorAccessorArgs<exp_avg_args.next_compile_time_args_offset()>();
     constexpr auto max_exp_avg_sq_args = TensorAccessorArgs<exp_avg_sq_args.next_compile_time_args_offset()>();
+    constexpr auto step_size_args = TensorAccessorArgs<max_exp_avg_sq_args.next_compile_time_args_offset()>();
+    constexpr auto inv_sqrt_bc2_args = TensorAccessorArgs<step_size_args.next_compile_time_args_offset()>();
+    constexpr auto decay_factor_args = TensorAccessorArgs<inv_sqrt_bc2_args.next_compile_time_args_offset()>();
 
     const auto param_addr_gen = TensorAccessor(param_args, param_addr);
     const auto grad_addr_gen = TensorAccessor(grad_args, grad_addr);
     const auto exp_avg_addr_gen = TensorAccessor(exp_avg_args, exp_avg_addr);
     const auto exp_avg_sq_addr_gen = TensorAccessor(exp_avg_sq_args, exp_avg_sq_addr);
     const auto max_exp_avg_sq_addr_gen = TensorAccessor(max_exp_avg_sq_args, max_exp_avg_sq_addr);
+
+#if SCALARS_ON_DEVICE
+    {
+        const uint32_t scalar_tile_size_bytes = get_tile_size(cb_scalars_idx);
+        const auto step_size_addr_gen = TensorAccessor(step_size_args, step_size_addr);
+        const auto inv_sqrt_bc2_addr_gen = TensorAccessor(inv_sqrt_bc2_args, inv_sqrt_bc2_addr);
+        const auto decay_factor_addr_gen = TensorAccessor(decay_factor_args, decay_factor_addr);
+
+        cb_reserve_back(cb_scalars_idx, 3);
+        const uint32_t l1_write_addr = get_write_ptr(cb_scalars_idx);
+        noc_async_read_tile(0, step_size_addr_gen, l1_write_addr);
+        noc_async_read_tile(0, inv_sqrt_bc2_addr_gen, l1_write_addr + scalar_tile_size_bytes);
+        noc_async_read_tile(0, decay_factor_addr_gen, l1_write_addr + 2 * scalar_tile_size_bytes);
+        noc_async_read_barrier();
+        cb_push_back(cb_scalars_idx, 3);
+    }
+#endif
 
     uint32_t end_tile = start_tile + num_tiles_to_process;
     for (uint32_t tile_idx = start_tile; tile_idx < end_tile; tile_idx += block_size) {

--- a/tt-train/tests/CMakeLists.txt
+++ b/tt-train/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SOURCES
     ops/frobenius_normalize_test.cpp
     ops/k_split_gram_matmul_op_test.cpp
     optimizers/adamw_full_precision_test.cpp
+    optimizers/adamw_no_host_test.cpp
     optimizers/no_op_test.cpp
     modules/distributed/linear_test.cpp
     serialization/model_serializer_test.cpp

--- a/tt-train/tests/optimizers/adamw_no_host_test.cpp
+++ b/tt-train/tests/optimizers/adamw_no_host_test.cpp
@@ -1,0 +1,60 @@
+#include <gtest/gtest.h>
+#include <cmath>
+#include <random>
+#include <vector>
+#include "autograd/auto_context.hpp"
+#include "core/tt_tensor_utils.hpp"
+#include "metal/optimizers/adamw/adamw.hpp"
+
+namespace {
+constexpr float kLr = 1e-3F, kB1 = 0.9F, kB2 = 0.999F, kEps = 1e-8F, kWd = 0.01F;
+
+class AdamWNoHostTest : public ::testing::Test {
+public:
+    static void SetUpTestSuite() { ttml::autograd::ctx().open_device(); }
+    static void TearDownTestSuite() { ttml::autograd::ctx().close_device(); }
+protected:
+    static ttnn::Tensor rand_t(const ttnn::Shape& s, float lo, float hi, uint32_t seed) {
+        std::mt19937 g(seed);
+        std::uniform_real_distribution<float> d(lo, hi);
+        std::vector<float> v(s.volume());
+        for (float& x : v) x = d(g);
+        return ttml::core::from_vector<float, ttnn::DataType::FLOAT32>(v, s, &ttml::autograd::ctx().get_device());
+    }
+    static ttnn::Tensor rand_bf16(const ttnn::Shape& s, float lo, float hi, uint32_t seed) {
+        std::mt19937 g(seed);
+        std::uniform_real_distribution<float> d(lo, hi);
+        std::vector<float> v(s.volume());
+        for (float& x : v) x = d(g);
+        return ttml::core::from_vector<float, ttnn::DataType::BFLOAT16>(v, s, &ttml::autograd::ctx().get_device());
+    }
+    static ttnn::Tensor scalar(float v) {
+        return ttml::core::from_vector<float, ttnn::DataType::FLOAT32>(
+            std::vector<float>{v}, ttnn::Shape({1U, 1U, 1U, 1U}), &ttml::autograd::ctx().get_device());
+    }
+};
+
+TEST_F(AdamWNoHostTest, MatchesFloatOverload) {
+    const ttnn::Shape shape({1U, 1U, 64U, 64U});
+    const uint32_t step = 7U;
+    const float b1p = std::pow(kB1, static_cast<float>(step));
+    const float b2p = std::pow(kB2, static_cast<float>(step));
+
+    auto p0 = rand_t(shape, -1.F, 1.F, 2);
+    auto g0 = rand_bf16(shape, -1.F, 1.F, 1);
+    auto m0 = rand_t(shape, -1.F, 1.F, 3), v0 = rand_t(shape, 0.F, 1.F, 4);
+    auto p1 = rand_t(shape, -1.F, 1.F, 2);
+    auto g1 = rand_bf16(shape, -1.F, 1.F, 1);
+    auto m1 = rand_t(shape, -1.F, 1.F, 3), v1 = rand_t(shape, 0.F, 1.F, 4);
+
+    auto expected = ttml::metal::adamw(p0, g0, m0, v0, std::nullopt, kLr, kB1, kB2, b1p, b2p, kEps, kWd);
+    auto actual = ttml::metal::adamw(
+        p1, g1, m1, v1, std::nullopt, kB1, kB2,
+        scalar(kLr / (1.0F - b1p)), scalar(1.0F / std::sqrt(1.0F - b2p)), scalar(1.0F - kLr * kWd), kEps);
+
+    auto e = ttml::core::to_vector(expected);
+    auto a = ttml::core::to_vector(actual);
+    ASSERT_EQ(a.size(), e.size());
+    for (size_t i = 0; i < e.size(); ++i) ASSERT_FLOAT_EQ(a[i], e[i]) << "at " << i;
+}
+}  // namespace


### PR DESCRIPTION
### PR Category
Feature

### Summary

`ttml::metal::adamw` takes `step_size`, `1 / sqrt(bias_correction2)` and `decay_factor` as `float`, so a caller holding them on device has to read them back to host. This adds an overload taking the three as single-element float32 tensors, which the kernel reads from L1.

The float overload is unchanged, so upstream and downstream users keep it.

### Notes for reviewers

- The three tensors carry the derived scalars, not `beta^t` / `lr`: the kernel drops them straight into the slots the runtime args filled, so the update is unchanged and no arithmetic moves onto the RISC-V core.
- `scalars_on_device` is in the program hash, since `SCALARS_ON_DEVICE` changes the kernel binary.
- `adamw_no_host_test.cpp` drives both overloads over identical inputs and requires bit-equality.

> [!NOTE]
> The scalar fetch is deliberately naive. Every core reads all three itself, and `noc_async_read_tile` pulls a whole 4 KB tile per scalar: 12 KB of L1 per core and ~768 KB of DRAM traffic per dispatch on a 64-core grid, to deliver 12 bytes.
>
> Left as is: the same dispatch streams parameters, gradients and both moments through those cores, on the order of 10 GB for a 1B model, so this is ~0.01% of the traffic. A multicast would remove the per-core repetition if it ever shows up in a profile.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=agobeljicTT/adamw_no_host)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:agobeljicTT/adamw_no_host)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=agobeljicTT/adamw_no_host)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:agobeljicTT/adamw_no_host)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=agobeljicTT/adamw_no_host)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:agobeljicTT/adamw_no_host)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=agobeljicTT/adamw_no_host)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:agobeljicTT/adamw_no_host)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=agobeljicTT/adamw_no_host)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:agobeljicTT/adamw_no_host)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=agobeljicTT/adamw_no_host)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:agobeljicTT/adamw_no_host)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=agobeljicTT/adamw_no_host)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:agobeljicTT/adamw_no_host)