### PR TITLE
[skip ci] fix(docs): keep Python API list tables visible

### DIFF
--- a/docs/source/common/_static/tt_theme.css
+++ b/docs/source/common/_static/tt_theme.css
@@ -1323,11 +1323,9 @@ h2.tt-api-section-heading {
   margin: 0 !important;
 }
 
-/* Hide raw docutils table (replaced by api_style.js list) — gated on the custom
-   shell that loads api_style.js so plain builds keep native API tables. */
-body:has(.tt-top-nav) .rst-content dl.cpp.function table.docutils,
-body:has(.tt-top-nav) .rst-content dl.py.function table.docutils,
-body:has(.tt-top-nav) .rst-content dl.py.class table.docutils {
+/* Hide only the C++ tables replaced by api_style.js. Python API tables are
+   rendered natively and must remain visible. */
+body:has(.tt-top-nav) .rst-content dl.cpp.function table.docutils {
   display: none !important;
 }
 


### PR DESCRIPTION
Fixes #53333

## Summary

- Keep Python API list-tables visible in the custom documentation shell.
- Continue hiding only C++ docutils tables that are replaced by `api_style.js`.

## Root cause

The shared CSS selector hid `dl.py.function` and `dl.py.class` tables whenever `.tt-top-nav` was present. The custom JavaScript does not replace Python docstring list-tables, so those tables disappeared from rendered pages.

## Validation

Before:
<img width="468" height="142" alt="image" src="https://github.com/user-attachments/assets/170607b7-5391-4d4c-903c-2ba087b8bb33" />

After:
<img width="454" height="207" alt="image" src="https://github.com/user-attachments/assets/b6046e16-165a-46f4-8ff3-1cbb442e5044" />

