### PR TITLE
blackhole: size erisc kernel config for the 2d-torus fabric router

### DIFF
--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
@@ -229,7 +229,8 @@
 #define MEM_ERISC_FABRIC_ROUTING_PATH_SIZE_2D COMPRESSED_ROUTING_PATH_SIZE_2D
 #define MEM_ERISC_FABRIC_ROUTING_PATH_SIZE MEM_ERISC_FABRIC_ROUTING_PATH_SIZE_2D  // Union size
 #define MEM_ERISC_MAILBOX_SIZE 12768
-#define MEM_ERISC_KERNEL_CONFIG_SIZE (25 * 1024)
+// Must fit the largest erisc kernel config: the 2D-torus fabric_erisc_router needs 25680B.
+#define MEM_ERISC_KERNEL_CONFIG_SIZE (26 * 1024)
 #define MEM_ERISC_BASE 0
 
 // From the top of L1. Common.


### PR DESCRIPTION
## What

Bump `MEM_ERISC_KERNEL_CONFIG_SIZE` from 25 KB to 26 KB on Blackhole.

## Why

Blackhole stores `ACTIVE_ETH` kernel *text* in the erisc kernel-config L1 window.
Wormhole does not (`bh_hal.cpp` returns true for
`DISPATCH_ACTIVE_ETH_KERNEL_CONFIG_BUFFER`, `wh_hal.cpp` returns false). So this
is a BH-only kernel-binary size limit.

The `fabric_erisc_router` config on a multi-mesh 2D-torus finalizes at 25680 B.
The buffer is 25600 B. `configure_fabric` dies at program finalize:

```
Program size (25680) too large for kernel config buffer (25600) on ACTIVE_ETH
```

## This is about margin, not torus

Measured `ACTIVE_ETH` finalize size on BH galaxies:

| meshes | dim_types | size | headroom |
|---|---|---|---|
| 1 | LINE | 20576 | 5024 |
| 1 | RING | 21024 | 4576 |
| 2 | LINE | 24528 | 1072 |
| 2 | RING | **25680** | **-80** |

Multi-mesh costs +3952 B. RING costs +1152 B on top of that.

Neither alone overflows. Every BH multi-mesh MGD in tree is LINE, so they all sit
~1 KB under the ceiling. They are green today by 4%. Any router growth — a new VC,
a bug fix, an `-O` change — breaks them. Torus just got there first.

26 KB restores 944 B of headroom for the torus case.

## Repro

Two BH galaxies. Stock `test_tt_fabric`, no model, no traffic, no C++ changes.
~2 min.

**Step 1.** Patch `bh_hal.cpp`: change `-Werror=stack-usage=1912` to `4096`.
Required — without it the router fails to compile before it can overflow L1. See
the note at the end.

**Step 2.** Build both hosts. Each needs a clone at the same absolute path.

**Step 3.** Save these two files.

<details>
<summary><code>mgd_2glx_torus_xy.textproto</code> — two connected 8x4 RING meshes, one per galaxy</summary>

```
mesh_descriptors {
  name: "M0"
  arch: BLACKHOLE
  device_topology { dims: [ 8, 4 ] dim_types: [ RING, RING ] }
  host_topology   { dims: [ 1, 1 ] }
  channels { count: 2 policy: RELAXED }
}

graph_descriptors {
  name: "G0"
  type: "FABRIC"
  instances { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
  instances { mesh { mesh_descriptor: "M0" mesh_id: 1 } }

  connections {
    nodes { mesh { mesh_descriptor: "M0" mesh_id: 0 } }
    nodes { mesh { mesh_descriptor: "M0" mesh_id: 1 } }
    channels { count: 8 policy: RELAXED }
  }
}

top_level_instance { graph { graph_descriptor: "G0" graph_id: 0 } }
```

Needs one reciprocated inter-galaxy link between the two hosts. Check with
`./build/test/tt_metal/tt_fabric/test_system_health`.
</details>

<details>
<summary><code>tests/tt_metal/tt_fabric/test_infra/test_yamls/test_erisc_config_overflow.yaml</code> — trivial traffic</summary>

```yaml
Tests:
  - name: "TorusXYBringup"
    fabric_setup:
      topology: Torus
      torus_config: XY
      num_links: 1

    defaults:
      ftype: unicast
      ntype: unicast_write
      size: 512
      num_packets: 1

    patterns:
      - type: full_device_random_pairing
        iterations: 1
```
</details>

**Step 4.** Run.

```bash
tt-run -m mgd_2glx_torus_xy.textproto \
  --hosts <galaxy-a>,<galaxy-b> \
  --force-rediscovery \
  ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric \
  --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_erisc_config_overflow.yaml
```

On 25 KB: `TT_FATAL`, rc=134, fabric never opens.
On 26 KB: `Fabric Initialized ... FABRIC_2D_TORUS_XY`, `Tests: 1 executed, 0 failed`, rc=0.

Same commit and hardware on both legs, only this diff differing. Also validated
on a10 BH-galaxy 4-rank Kimi-2.7 prefill.

Notes:
- Do not try this on one galaxy. Single-galaxy torus_xy is 21024 and passes.
- The run that fails SIGABRTs and can leave an eth core wedged. Run
  `tools/scaleout/exabox/recover.sh` before the next launch.
- To see the sizes when they fit, add a `log_info` of `state.offset` / `max_size`
  before the `TT_FATAL` in `finalize_program_offsets` (`program.cpp`). That is how
  the table above was measured.

## Note: erisc0 stack

This config also needs 56 B more erisc0 stack than the `-Werror=stack-usage=1912`
guard in `bh_hal.cpp` allows, which is why Step 1 patches it. That budget is the
base-firmware stack; metal has no knob for it. Separate issue for the fabric team.

Scope-checked on hardware: multi-mesh LINE and single-mesh torus both clear the
1912 guard. Only multi-mesh torus exceeds it — the same config this PR unblocks.
Nothing on main regresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=finalize_program_offsets)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:finalize_program_offsets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=finalize_program_offsets)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:finalize_program_offsets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=finalize_program_offsets)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:finalize_program_offsets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=finalize_program_offsets)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:finalize_program_offsets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=finalize_program_offsets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:finalize_program_offsets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=finalize_program_offsets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:finalize_program_offsets)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=finalize_program_offsets)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:finalize_program_offsets)
