### PR TITLE
[LLK][test] Skip SfpuLcm dest_acc=Yes on Blackhole (codegen-sensitive hang, #52997)

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/test_sfpu_binary.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_sfpu_binary.py
@@ -77,6 +77,21 @@ def _skip_bh_float16_no_dest_acc(formats, dest_acc):
         )
 
 
+def _skip_sfpu_lcm_dest_acc_bh(mathop, dest_acc):
+    """SfpuLcm dest_acc=Yes is codegen-sensitive on Blackhole and hangs (extra dest SFPLOAD after
+    SFPU): it passes on an unperturbed build but any codegen shift -- extra nops, an inlining change
+    -- tips it into a TENSIX timeout. Disabled until the missing stall is added. See tt-metal#52997.
+    """
+    if (
+        TestConfig.CHIP_ARCH == ChipArchitecture.BLACKHOLE
+        and mathop == MathOperation.SfpuLcm
+        and dest_acc == DestAccumulation.Yes
+    ):
+        pytest.skip(
+            "SfpuLcm dest_acc=Yes is codegen-sensitive and hangs on Blackhole; see tt-metal#52997"
+        )
+
+
 # =============================================================================
 # Shared crafted-stimuli helpers
 #
@@ -911,6 +926,7 @@ _INT_BINARY_STIMULI = {
     dest_acc=[DestAccumulation.Yes],
 )
 def test_sfpu_binary_int_uniform(mathop, dest_acc):
+    _skip_sfpu_lcm_dest_acc_bh(mathop, dest_acc)
     int_format = DataFormat.UInt32 if mathop in _UINT32_BINARY_OPS else DataFormat.Int32
     formats = InputOutputFormat(int_format, int_format)
     low, high = _INT_BINARY_STIMULI[mathop]


### PR DESCRIPTION
## What
Skip `test_sfpu_binary_int_uniform[mathop:SfpuLcm-dest_acc:Yes]` on Blackhole.

## Why
Per **#52997**, this case hangs on Blackhole (`TENSIX TIMED OUT`, *extra dest SFPLOAD after SFPU*). It passes on an unperturbed build, but it is **codegen-sensitive** — the issue notes that *inserting extra RISC nops in the SFPU-binary caller is enough to hang it*. So it fails spuriously on **any** PR that shifts LLK codegen, independent of that PR's logic.

It is currently blocking the copy / eltwise-unary init-cleanup PR **#49924** (whose `noinline` size fix perturbs codegen) via the required **PR Gate Status**. Rather than each codegen PR working around it, skip it centrally until the underlying missing stall is fixed.

## Scope
- One targeted skip (BH + `SfpuLcm` + `dest_acc=Yes`), guarded and referencing #52997.
- The real fix (adding the stall in the SFPU-binary path) remains tracked in **#52997** — this only disables the fragile test in the meantime.

cc @amahmudTT @halghTT (owner/author of #52997)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=llk/disable-sfpulcm-dest-acc-52997)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:llk/disable-sfpulcm-dest-acc-52997)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=llk/disable-sfpulcm-dest-acc-52997)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:llk/disable-sfpulcm-dest-acc-52997)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=llk/disable-sfpulcm-dest-acc-52997)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:llk/disable-sfpulcm-dest-acc-52997)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=llk/disable-sfpulcm-dest-acc-52997)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:llk/disable-sfpulcm-dest-acc-52997)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=llk/disable-sfpulcm-dest-acc-52997)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:llk/disable-sfpulcm-dest-acc-52997)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=llk/disable-sfpulcm-dest-acc-52997)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:llk/disable-sfpulcm-dest-acc-52997)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=llk/disable-sfpulcm-dest-acc-52997)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:llk/disable-sfpulcm-dest-acc-52997)