### PR TITLE
Reconcile topk_xl with tt-blaze: local_sort_generic wrappers and post-copy reinit

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/llk_math_eltwise_unary_sfpu_topk_xl.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/llk_math_eltwise_unary_sfpu_topk_xl.h
@@ -4,33 +4,43 @@
 
 #pragma once
 
+#include <cstdint>
 #include "llk_math_eltwise_unary_sfpu_init.h"
 #include "llk_math_eltwise_unary_sfpu_params.h"
 #include "sfpu/experimental/ckernel_sfpu_topk_xl.h"
 
 namespace ckernel {
 
-template <uint32_t K, bool fused>
+template <std::uint32_t K, bool fused>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(ckernel::sfpu::_topk_xl_init_<K, fused>);
 }
 
-template <uint32_t K>
+template <std::uint32_t K>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_local_sort(
-    uint dst_index, bool ascending, VectorMode vector_mode = VectorMode::RC_custom) {
+    std::uint32_t dst_index, bool ascending, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::_topk_xl_local_sort_<K>, dst_index, vector_mode, dst_index, ascending);
 }
 
-template <uint32_t K, bool fused>
-inline void llk_math_eltwise_unary_sfpu_topk_xl_merge(uint dst_index, VectorMode vector_mode = VectorMode::RC_custom) {
+// Per-column-isolated variant: early_exit_K64 sorts each 64-row column
+// independently and skips the cross-column merge (sparse-K reader).
+template <std::uint32_t K, bool early_exit_K64>
+inline void llk_math_eltwise_unary_sfpu_topk_xl_local_sort_generic(
+    std::uint32_t dst_index, bool ascending, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
-        ckernel::sfpu::_topk_xl_merge_<K, fused>, dst_index, vector_mode, dst_index);
+        ckernel::sfpu::_topk_xl_local_sort_generic_<K, early_exit_K64>, dst_index, vector_mode, dst_index, ascending);
 }
 
-template <uint32_t K, bool fused>
+template <std::uint32_t K, bool fused>
+inline void llk_math_eltwise_unary_sfpu_topk_xl_merge(
+    std::uint32_t dst_index, VectorMode vector_mode = VectorMode::RC_custom) {
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_topk_xl_merge_<K, fused>, dst_index, vector_mode, dst_index);
+}
+
+template <std::uint32_t K, bool fused>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_rebuild(
-    uint dst_index, bool ascending, VectorMode vector_mode = VectorMode::RC_custom) {
+    std::uint32_t dst_index, bool ascending, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::_topk_xl_rebuild_<K, fused>, dst_index, vector_mode, dst_index, ascending);
 }
@@ -39,15 +49,27 @@ inline void llk_math_eltwise_unary_sfpu_topk_xl_add_lsb_indices_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(ckernel::sfpu::_topk_xl_add_lsb_indices_init_);
 }
 
-template <uint32_t K, uint32_t core_id>
-inline void llk_math_eltwise_unary_sfpu_topk_xl_add_lsb_indices(uint dst_index) {
+template <std::uint32_t K, std::uint32_t core_id, bool row_major = false>
+inline void llk_math_eltwise_unary_sfpu_topk_xl_add_lsb_indices(std::uint32_t dst_index) {
     _llk_math_eltwise_unary_sfpu_params_(
-        ckernel::sfpu::_topk_xl_add_lsb_indices_<K, core_id>, dst_index, VectorMode::RC_custom);
+        ckernel::sfpu::_topk_xl_add_lsb_indices_<K, core_id, row_major>, dst_index, VectorMode::RC_custom);
+}
+
+// Reprogram only the MOP Expander after a topk_xl copy, instead of a full
+// topk_xl_init. See ckernel_sfpu_topk_xl.h for what copy init clobbers.
+template <bool fused>
+inline void llk_math_eltwise_unary_sfpu_topk_xl_reinit_mop_after_copy() {
+    ckernel::sfpu::topk_mop_config<fused>();
+}
+
+// Restore the ADDR_MODs and MOP state the unfused rebuild needs after a copy.
+inline void llk_math_eltwise_unary_sfpu_topk_xl_reinit_unfused_rebuild_after_copy() {
+    ckernel::sfpu::topk_reinit_unfused_rebuild_after_copy();
 }
 
 // Runtime-chunk-id stamp (fused end-to-end rows: one instantiation, id per chunk).
-template <uint32_t K>
-inline void llk_math_eltwise_unary_sfpu_topk_xl_add_lsb_indices_rt(uint dst_index, uint32_t chunk_id) {
+template <std::uint32_t K>
+inline void llk_math_eltwise_unary_sfpu_topk_xl_add_lsb_indices_rt(std::uint32_t dst_index, std::uint32_t chunk_id) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::_topk_xl_add_lsb_indices_rt_<K>, dst_index, VectorMode::RC_custom, chunk_id);
 }
@@ -56,15 +78,15 @@ inline void llk_math_eltwise_unary_sfpu_topk_xl_remove_msb_values_init() {
     ckernel::sfpu::_topk_xl_remove_msb_values_init_();
 }
 
-template <uint32_t K, DstSync Dst>
-inline void llk_math_eltwise_unary_sfpu_topk_xl_remove_msb_values(uint dst_index) {
+template <std::uint32_t K, DstSync Dst>
+inline void llk_math_eltwise_unary_sfpu_topk_xl_remove_msb_values(std::uint32_t dst_index) {
     TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, dst_index + get_dest_buffer_base());
     TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH | p_stall::PACK);
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
     ckernel::sfpu::_topk_xl_remove_msb_values_<K, Dst>();
 }
 
-inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_init(uint32_t group_id_bit_shift) {
+inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_init(std::uint32_t group_id_bit_shift) {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(
         ckernel::sfpu::_topk_xl_separate_indices_init_, group_id_bit_shift);
 }
@@ -73,18 +95,18 @@ inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_init(uint32_t g
 // These wrappers expose the row-major SFPU helpers added to
 // `ckernel_sfpu_topk_xl.h`; the base TopK XL wrappers above and below are
 // otherwise unchanged.
-inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_init(uint32_t chunk_base) {
+inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_init(std::uint32_t chunk_base) {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(
         ckernel::sfpu::_topk_xl_separate_indices_row_major_init_, chunk_base);
 }
 
-template <uint32_t chunk_base_upper16>
-inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_init_upper(uint32_t chunk_base_low16) {
+template <std::uint32_t chunk_base_upper16>
+inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_init_upper(std::uint32_t chunk_base_low16) {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(
         ckernel::sfpu::_topk_xl_separate_indices_row_major_init_upper_<chunk_base_upper16>, chunk_base_low16);
 }
 
-template <uint32_t chunk_base_upper16, uint32_t chunk_base_lower16>
+template <std::uint32_t chunk_base_upper16, std::uint32_t chunk_base_lower16>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_init_static() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(
         ckernel::sfpu::_topk_xl_separate_indices_row_major_init_static_<chunk_base_upper16, chunk_base_lower16>);
@@ -96,15 +118,15 @@ inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_reini
 }
 // END TOPK_LARGE_INDICES ADDITION: row-major UINT32 index split API.
 
-template <uint32_t K, uint32_t group_id>
-inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices(uint dst_index) {
+template <std::uint32_t K, std::uint32_t group_id>
+inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices(std::uint32_t dst_index) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::_topk_xl_separate_indices_<K, group_id>, dst_index, VectorMode::RC_custom);
 }
 
 // TOPK_LARGE_INDICES ADDITION: row-major UINT32 index split execution API.
-template <uint32_t K>
-inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major(uint dst_index) {
+template <std::uint32_t K>
+inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major(std::uint32_t dst_index) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::_topk_xl_separate_indices_row_major_<K>, dst_index, VectorMode::RC_custom);
 }
@@ -114,25 +136,22 @@ inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_globa
     llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(ckernel::sfpu::_topk_xl_separate_indices_row_major_global_init_);
 }
 
-template <uint32_t K>
-inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_global(uint dst_index) {
+template <std::uint32_t K>
+inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_global(std::uint32_t dst_index) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::_topk_xl_separate_indices_row_major_global_<K>, dst_index, VectorMode::RC_custom);
 }
 
 // Segmented fusion: per-segment split with a runtime segment base OR'd into
 // the decoded index.
-template <uint32_t K>
+template <std::uint32_t K>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_global_base(
-    uint dst_index, uint32_t seg_base) {
+    std::uint32_t dst_index, std::uint32_t seg_base) {
     _llk_math_eltwise_unary_sfpu_params_(
-        ckernel::sfpu::_topk_xl_separate_indices_row_major_global_base_<K>,
-        dst_index,
-        VectorMode::RC_custom,
-        seg_base);
+        ckernel::sfpu::_topk_xl_separate_indices_row_major_global_base_<K>, dst_index, VectorMode::RC_custom, seg_base);
 }
 
-template <uint32_t K>
+template <std::uint32_t K>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_advance_chunk_base() {
     TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
     ckernel::sfpu::_topk_xl_separate_indices_row_major_advance_chunk_base_<K>();

--- a/tt_metal/hw/inc/api/compute/experimental/topk_xl.h
+++ b/tt_metal/hw/inc/api/compute/experimental/topk_xl.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/common.h"
 #include "api/compute/tile_move_copy.h"
@@ -47,10 +48,33 @@ namespace ckernel {
  * ascending  | Sort direction: true for ascending, false for descending                   | bool     | true, false |
  * True     |
  */
-template <uint32_t K>
-ALWI void topk_xl_local_sort(uint32_t idst, bool ascending) {
+template <std::uint32_t K>
+ALWI void topk_xl_local_sort(std::uint32_t idst, bool ascending) {
     UNPACK((llk_unpack_set_srcb_dummy_valid()));
     MATH((llk_math_eltwise_unary_sfpu_topk_xl_local_sort<K>(idst, ascending)));
+}
+
+/**
+ * Per-column-isolated local sort. Runs the same bitonic network as
+ * topk_xl_local_sort up to the length-64 build, then (with early_exit_K64)
+ * returns before the cross-column merge phases, leaving each 64-row column
+ * sorted in isolation — used by the sparse-K reader to sink all-zero packed
+ * mask words to the bottom of each column.
+ *
+ * With early_exit_K64 = true this does NOT issue llk_unpack_set_srcb_dummy_valid:
+ * the early-exit column sort never consumes a real SrcB operand, so the dummy
+ * valid is dead config, and dropping it saves one UNPACK-thread issue per call.
+ * The default (full-sort) instantiation runs the same network as
+ * topk_xl_local_sort and does issue it.
+ *
+ * early_exit_K64 requires K >= 1024; K = 512 is rejected by static_assert.
+ */
+template <std::uint32_t K, bool early_exit_K64 = false>
+ALWI void topk_xl_local_sort_generic(std::uint32_t idst, bool ascending) {
+    if constexpr (!early_exit_K64) {
+        UNPACK((llk_unpack_set_srcb_dummy_valid()));
+    }
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_local_sort_generic<K, early_exit_K64>(idst, ascending)));
 }
 
 /**
@@ -77,8 +101,8 @@ ALWI void topk_xl_local_sort(uint32_t idst, bool ascending) {
  * perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     | | fused |
  * Whether values + indices are fused as single FP32 datum in DST             | bool     | true, false | False    |
  */
-template <uint32_t K, bool fused = true>
-ALWI void topk_xl_merge(uint32_t idst) {
+template <std::uint32_t K, bool fused = true>
+ALWI void topk_xl_merge(std::uint32_t idst) {
     MATH((llk_math_eltwise_unary_sfpu_topk_xl_merge<K, fused>(idst)));
 }
 
@@ -106,8 +130,8 @@ ALWI void topk_xl_merge(uint32_t idst) {
  * True     | | fused      | Whether values + indices are fused as single FP32 datum in DST             | bool     |
  * true, false                                           | False    |
  */
-template <uint32_t K, bool fused = true>
-ALWI void topk_xl_rebuild(uint32_t idst, bool ascending) {
+template <std::uint32_t K, bool fused = true>
+ALWI void topk_xl_rebuild(std::uint32_t idst, bool ascending) {
     UNPACK((llk_unpack_set_srcb_dummy_valid()));
     MATH((llk_math_eltwise_unary_sfpu_topk_xl_rebuild<K, fused>(idst, ascending)));
 }
@@ -129,7 +153,7 @@ ALWI void topk_xl_rebuild(uint32_t idst, bool ascending) {
  * once again at the fused → unfused mode switch in the extended 256K path.
  * The hot loop must not re-call this per stage.
  */
-template <uint32_t K, bool fused = true>
+template <std::uint32_t K, bool fused = true>
 ALWI void topk_xl_init() {
     MATH((llk_math_eltwise_unary_sfpu_topk_xl_init<K, fused>()));
 }
@@ -137,7 +161,7 @@ ALWI void topk_xl_init() {
 /**
  * Initialize unpack/math state for topk_xl_copy_tile.
  */
-ALWI void topk_xl_copy_tile_init(uint32_t cbid, uint32_t call_line = __builtin_LINE()) {
+ALWI void topk_xl_copy_tile_init(std::uint32_t cbid, std::uint32_t call_line = __builtin_LINE()) {
     // TOPK_LARGE_INDICES ADDITION: the low-level copy wrapper only initializes
     // the TopK XL copy LLKs. This TTNN op enters through the standard compute
     // API, so it must also configure SRCA unpack/math state for the input CB.
@@ -174,16 +198,19 @@ ALWI void topk_xl_copy_tile_init(uint32_t cbid, uint32_t call_line = __builtin_L
  * | | num_elements           | Number of elements to copy (partial-tile unpack)                   | uint32_t | 1 .. K
  * | True     |
  */
-template <uint32_t K>
+template <std::uint32_t K>
 ALWI void topk_xl_copy_tile(
-    uint32_t in_cb_id, uint32_t dst_start_tile_index, uint32_t in_tile_index_base, uint32_t num_elements) {
-    constexpr uint32_t elements_per_tile = TILE_R_DIM * TILE_C_DIM;
+    std::uint32_t in_cb_id,
+    std::uint32_t dst_start_tile_index,
+    std::uint32_t in_tile_index_base,
+    std::uint32_t num_elements) {
+    constexpr std::uint32_t elements_per_tile = TILE_R_DIM * TILE_C_DIM;
     if constexpr (K <= elements_per_tile) {
         UNPACK((llk_unpack_topk_xl_copy_one_tile_unpack(in_cb_id, in_tile_index_base, num_elements)));
         MATH((llk_math_topk_xl_copy_one_tile_math(in_cb_id, dst_start_tile_index, num_elements)));
     } else {
-        const uint32_t n1 = num_elements < elements_per_tile ? num_elements : elements_per_tile;
-        const uint32_t n2 = num_elements > elements_per_tile ? (num_elements - elements_per_tile) : 0;
+        const std::uint32_t n1 = num_elements < elements_per_tile ? num_elements : elements_per_tile;
+        const std::uint32_t n2 = num_elements > elements_per_tile ? (num_elements - elements_per_tile) : 0;
 
         UNPACK((llk_unpack_topk_xl_copy_one_tile_unpack(in_cb_id, in_tile_index_base, n1)));
         MATH((llk_math_topk_xl_copy_one_tile_math(in_cb_id, dst_start_tile_index, n1)));
@@ -211,9 +238,33 @@ ALWI void topk_xl_add_lsb_indices_init() { MATH((llk_math_eltwise_unary_sfpu_top
  * | idst       | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less
  than the size of the DST register buffer | True     |
  */
-template <uint32_t K, uint32_t core_id>
-ALWI void topk_xl_add_lsb_indices(uint32_t idst) {
-    MATH((llk_math_eltwise_unary_sfpu_topk_xl_add_lsb_indices<K, core_id>(idst)));
+template <std::uint32_t K, std::uint32_t core_id, bool row_major = false>
+ALWI void topk_xl_add_lsb_indices(std::uint32_t idst) {
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_add_lsb_indices<K, core_id, row_major>(idst)));
+}
+
+/**
+ * Reprogram only the MOP Expander after topk_xl_copy_tile_init, instead of a
+ * full topk_xl_init. copy init clobbers ADDR_MOD_0/3 and the MOP; the fused
+ * merge/rebuild kernels use ADDR_MOD_1/5/6/7, so for fused = true only the MOP
+ * needs reinstalling — saving the CFG/ADDR_MOD writes a full init would issue
+ * per merge stage on the recv path.
+ */
+template <bool fused = true>
+ALWI void topk_xl_reinit_mop_after_copy() {
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_reinit_mop_after_copy<fused>()));
+}
+
+/**
+ * Restore the subset of unfused TopK state clobbered by copy_tile_init.
+ *
+ * In addition to the shared MOP Expander, unfused rebuild consumes ADDR_MOD_3,
+ * which copy init rewrites, and ADDR_MOD_2, which is (re)established for the
+ * unfused stride in case the preceding phase was fused. The remaining TopK
+ * ADDR_MODs and SFPU index-tracking state stay live.
+ */
+ALWI void topk_xl_reinit_unfused_rebuild_after_copy() {
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_reinit_unfused_rebuild_after_copy()));
 }
 
 /**
@@ -221,8 +272,8 @@ ALWI void topk_xl_add_lsb_indices(uint32_t idst) {
  * bits [15:11] is a runtime argument, so one instantiation stamps every chunk
  * of a fused end-to-end row (chunk_id in 0..31). Same init.
  */
-template <uint32_t K>
-ALWI void topk_xl_add_lsb_indices_rt(uint32_t idst, uint32_t chunk_id) {
+template <std::uint32_t K>
+ALWI void topk_xl_add_lsb_indices_rt(std::uint32_t idst, std::uint32_t chunk_id) {
     MATH((llk_math_eltwise_unary_sfpu_topk_xl_add_lsb_indices_rt<K>(idst, chunk_id)));
 }
 
@@ -237,9 +288,7 @@ ALWI void topk_xl_add_lsb_indices_rt(uint32_t idst, uint32_t chunk_id) {
  * The kernel static_asserts DstSync::SyncFull as MATH and PACK would contend
  * on LRegs otherwise.
  */
-ALWI void topk_xl_remove_msb_values_init() {
-    PACK((llk_math_eltwise_unary_sfpu_topk_xl_remove_msb_values_init()));
-}
+ALWI void topk_xl_remove_msb_values_init() { PACK((llk_math_eltwise_unary_sfpu_topk_xl_remove_msb_values_init())); }
 
 /**
  * Removes MSB values from the topk_xl data, leaving only the indices.
@@ -257,8 +306,8 @@ ALWI void topk_xl_remove_msb_values_init() {
  * 2048                                    | True     | | idst       | The index of the tile in DST register buffer to
  * perform the computation on | uint32_t | Must be less than the size of the DST register buffer | True     |
  */
-template <uint32_t K>
-ALWI void topk_xl_remove_msb_values(uint32_t idst) {
+template <std::uint32_t K>
+ALWI void topk_xl_remove_msb_values(std::uint32_t idst) {
     PACK((llk_math_eltwise_unary_sfpu_topk_xl_remove_msb_values<K, DST_SYNC_MODE>(idst)));
 }
 
@@ -277,7 +326,7 @@ ALWI void topk_xl_remove_msb_values(uint32_t idst) {
  * | group_id_bit_shift   | Bit position at which group_id is placed in the indices                    | uint32_t | 0 ..
  * 31                                               | True     |
  */
-ALWI void topk_xl_separate_indices_init(uint32_t group_id_bit_shift) {
+ALWI void topk_xl_separate_indices_init(std::uint32_t group_id_bit_shift) {
     MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_init(group_id_bit_shift)));
 }
 
@@ -290,17 +339,17 @@ ALWI void topk_xl_separate_indices_init(uint32_t group_id_bit_shift) {
  * indices. The chunk_base is ORed into each decoded within-chunk position and
  * must be aligned to K.
  */
-ALWI void topk_xl_separate_indices_row_major_init(uint32_t chunk_base) {
+ALWI void topk_xl_separate_indices_row_major_init(std::uint32_t chunk_base) {
     MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_init(chunk_base)));
 }
 
-template <uint32_t chunk_base_upper16>
-ALWI void topk_xl_separate_indices_row_major_init_upper(uint32_t chunk_base_low16) {
+template <std::uint32_t chunk_base_upper16>
+ALWI void topk_xl_separate_indices_row_major_init_upper(std::uint32_t chunk_base_low16) {
     MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_init_upper<chunk_base_upper16>(
         chunk_base_low16)));
 }
 
-template <uint32_t chunk_base_upper16, uint32_t chunk_base_lower16>
+template <std::uint32_t chunk_base_upper16, std::uint32_t chunk_base_lower16>
 ALWI void topk_xl_separate_indices_row_major_init_static() {
     MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_init_static<
           chunk_base_upper16,
@@ -329,8 +378,8 @@ ALWI void topk_xl_separate_indices_row_major_reinit() {
  * | The index of the tile in DST register buffer to perform the computation on | uint32_t | Must be less than the size
  * of the DST register buffer | True     |
  */
-template <uint32_t K, uint32_t group_id>
-ALWI void topk_xl_separate_indices(uint32_t idst) {
+template <std::uint32_t K, std::uint32_t group_id>
+ALWI void topk_xl_separate_indices(std::uint32_t idst) {
     MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices<K, group_id>(idst)));
 }
 
@@ -340,8 +389,8 @@ ALWI void topk_xl_separate_indices(uint32_t idst) {
  * within-chunk position, then ORed with the chunk base configured by
  * topk_xl_separate_indices_row_major_init.
  */
-template <uint32_t K>
-ALWI void topk_xl_separate_indices_row_major(uint32_t idst) {
+template <std::uint32_t K>
+ALWI void topk_xl_separate_indices_row_major(std::uint32_t idst) {
     MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major<K>(idst)));
 }
 
@@ -359,20 +408,20 @@ ALWI void topk_xl_separate_indices_row_major_global_init() {
  * topk_xl_separate_indices_row_major_global_init. Sound only for rows of
  * <= 32 chunks (the FUSED_E2E factory gate).
  */
-template <uint32_t K>
-ALWI void topk_xl_separate_indices_row_major_global(uint32_t idst) {
+template <std::uint32_t K>
+ALWI void topk_xl_separate_indices_row_major_global(std::uint32_t idst) {
     MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_global<K>(idst)));
 }
 
 // Segmented fusion: split one fused segment survivor in place, adding
 // seg_base (= segment_index * 32 * K, power-of-two aligned) to every decoded
 // index. Same init as the plain global split.
-template <uint32_t K>
-ALWI void topk_xl_separate_indices_row_major_global_base(uint32_t idst, uint32_t seg_base) {
+template <std::uint32_t K>
+ALWI void topk_xl_separate_indices_row_major_global_base(std::uint32_t idst, std::uint32_t seg_base) {
     MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_global_base<K>(idst, seg_base)));
 }
 
-template <uint32_t K>
+template <std::uint32_t K>
 ALWI void topk_xl_separate_indices_row_major_advance_chunk_base() {
     MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_advance_chunk_base<K>()));
 }

--- a/tt_metal/hw/inc/api/compute/experimental/topk_xl.h
+++ b/tt_metal/hw/inc/api/compute/experimental/topk_xl.h
@@ -262,6 +262,13 @@ ALWI void topk_xl_reinit_mop_after_copy() {
  * which copy init rewrites, and ADDR_MOD_2, which is (re)established for the
  * unfused stride in case the preceding phase was fused. The remaining TopK
  * ADDR_MODs and SFPU index-tracking state stay live.
+ *
+ * NOT restored: ADDR_MOD_4. copy init does not touch it, but
+ * topk_xl_add_lsb_indices_init reprograms it to +16 while unfused rebuild
+ * needs +8 — so if add_lsb_indices_init has run since the last full
+ * topk_xl_init<fused=false>, run that full init instead of this helper.
+ * (tt-blaze's callers always follow add_lsb with a full init, so this
+ * sequence does not arise there.)
  */
 ALWI void topk_xl_reinit_unfused_rebuild_after_copy() {
     MATH((llk_math_eltwise_unary_sfpu_topk_xl_reinit_unfused_rebuild_after_copy()));

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_topk_xl.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_topk_xl.h
@@ -167,6 +167,9 @@ inline void topk_mop_config()
 // it is (re)established because the unfused rebuild needs the unfused stride and
 // the preceding phase may have been fused. All other TopK state (ADDR_MOD_1/4/5/6,
 // index tracking, and formats) remains live, so a full topk_xl_init is unnecessary.
+// Caveat: ADDR_MOD_4 stays live only if _topk_xl_add_lsb_indices_init_ (which
+// reprograms it to +16; unfused rebuild needs +8) has not run since the last full
+// unfused init — callers in that situation need topk_xl_init<false>, not this.
 inline void topk_reinit_unfused_rebuild_after_copy()
 {
     addr_mod_t {

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_topk_xl.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_topk_xl.h
@@ -155,11 +155,35 @@ inline void topk_mop_config()
 #if TOPK_XL_UNFUSED_MACRO
     constexpr int body_len = 16;
 #else
-    constexpr int body_len              = fused ? 16 : 18;
+    constexpr int body_len = fused ? 16 : 18;
 #endif
     constexpr std::uint32_t replay_body = lltt::replay_insn(0, body_len);
     ckernel_unpack_template tmpl        = ckernel_unpack_template::lA(replay_body, TT_OP_NOP);
     tmpl.program();
+}
+
+// _llk_math_topk_xl_copy_init_ rewrites ADDR_MOD_0 and ADDR_MOD_3 for datacopy,
+// so ADDR_MOD_3 must be restored here. ADDR_MOD_2 is not clobbered by copy init;
+// it is (re)established because the unfused rebuild needs the unfused stride and
+// the preceding phase may have been fused. All other TopK state (ADDR_MOD_1/4/5/6,
+// index tracking, and formats) remains live, so a full topk_xl_init is unnecessary.
+inline void topk_reinit_unfused_rebuild_after_copy()
+{
+    addr_mod_t {
+        .srca = {.incr = 0},
+        .srcb = {.incr = 0},
+        .dest = {.incr = 40},
+    }
+        .set(ADDR_MOD_3);
+
+    addr_mod_t {
+        .srca = {.incr = 0},
+        .srcb = {.incr = 0},
+        .dest = {.incr = 24},
+    }
+        .set(ADDR_MOD_2);
+
+    topk_mop_config<false>();
 }
 
 // Program the MOP Expander for the stride-2 length-2048 build phase of
@@ -1474,7 +1498,7 @@ inline void canonical_big_block_with_replay(bool dir)
 // `set_dst_write_addr_offset(tile_offset + (col ? 0 : 2))` flips the Dst
 // pointer between the even and odd columns of the current pair of DST tiles.
 // Forward declaration — defined below the K=2048 optimized body.
-template <std::uint32_t K>
+template <std::uint32_t K, bool early_exit_K64 = false>
 inline void _topk_xl_local_sort_generic_(std::uint32_t dst_index, bool ascending);
 
 template <std::uint32_t K>
@@ -1729,10 +1753,15 @@ inline void _topk_xl_local_sort_(const std::uint32_t dst_index, const bool ascen
 // The K=2048 case continues to be routed to the K=2048 fast path by
 // `_topk_xl_local_sort_`'s `if constexpr (K != 2048)` guard, so the
 // codegen here is exercised only by K=512 and K=1024.
-template <std::uint32_t K>
+template <std::uint32_t K, bool early_exit_K64>
 inline void _topk_xl_local_sort_generic_(const std::uint32_t dst_index, const bool ascending)
 {
     static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
+    // early_exit_K64 sorts each 64-row column in isolation and returns before the
+    // cross-column merge phases (sparse-K reader: sink all-zero packed mask words
+    // to the bottom of each column). The length-64 build lives in the K >= 1024
+    // block, so a K=512 instantiation would return before it runs.
+    static_assert(!early_exit_K64 || K >= 1024, "early_exit_K64 requires K >= 1024: the length-64 build phase lives in the K >= 1024 block");
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
     bool dir                            = ascending;
     const std::uint32_t tile_offset     = dst_index << DstTileSizeLog2[DstTileShape::Tile32x32];
@@ -1799,7 +1828,13 @@ inline void _topk_xl_local_sort_generic_(const std::uint32_t dst_index, const bo
                 load16_rows_x2<32>();
                 bitonic_sort_len_k(dir);
                 store16_rows_x2<32, 48>();
-                dir = !dir;
+                // Early-exit sorts each column in isolation, so it suppresses the
+                // inter-pair flip when there is only one pair; the full sort keeps
+                // its historical unconditional flip.
+                if constexpr (!early_exit_K64 || (row_scale_factor >> 1) > 1)
+                {
+                    dir = !dir;
+                }
             }
             TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
 
@@ -1817,16 +1852,28 @@ inline void _topk_xl_local_sort_generic_(const std::uint32_t dst_index, const bo
                 lltt::replay(0, 8);
                 bitonic_sort_len_32(dir);
                 lltt::replay(8, 8);
-                if ((i & 1) == 1)
+                if constexpr (!early_exit_K64 || row_scale_factor > 2)
                 {
-                    dir = !dir;
+                    if ((i & 1) == 1)
+                    {
+                        dir = !dir;
+                    }
                 }
             }
             TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
         }
 
         set_dst_write_addr_offset(tile_offset + (col ? 0 : 2));
-        dir = !dir;
+        if constexpr (!early_exit_K64)
+        {
+            dir = !dir;
+        }
+    }
+
+    if constexpr (early_exit_K64)
+    {
+        // Each column is fully sorted in isolation; skip the cross-column merge.
+        return;
     }
 
     // ── build bitonic sequences of len=(K/8) ──────────────────────────────
@@ -2682,10 +2729,81 @@ inline void _topk_xl_add_lsb_indices_init_()
 //   bits [ 4: 0] — within-row column (5 bits, lane id)
 //
 // After this routine each DST word reads as `[ bf16 value | u16 index ]`.
-template <std::uint32_t K, std::uint32_t core_id>
+// `row_major` (default false) selects the within-chunk index ordering. The
+// default numbers the two [32, 32] tiles as a 64-row x 32-col grid in
+// COLUMN-MAJOR order: index(tile, row, col) = col*64 + tile*32 + row. Set
+// `row_major = true` for a plain ROW-MAJOR order: index = tile*1024 + row*32 + col.
+template <std::uint32_t K, std::uint32_t core_id, bool row_major = false>
 inline void _topk_xl_add_lsb_indices_()
 {
     static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
+
+    if constexpr (row_major)
+    {
+        TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+
+        // Tile ID into LREG0 (across the 32 lanes: 0, 2, 4, ..., 60, 62).
+        TTI_SFPMOV(0, p_sfpu::LTILEID, p_sfpu::LREG0, 0);
+
+        // Load core_id and place it in bits [15:11] of every lane.
+        TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, core_id);
+        TTI_SFPSHFT(11, 0, p_sfpu::LREG1, 1);
+        TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_ARG_LREG_DST | sfpi::SFPIADD_MOD1_CC_NONE);
+
+        // LREG1 = LREG0 + 1, LREG2 = LREG0 + 256, LREG3 = LREG0 + 257 — give the
+        // four index variants we need across the four-row LREG block.
+        TTI_SFPIADD(1, p_sfpu::LREG0, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+        TTI_SFPIADD(256, p_sfpu::LREG0, p_sfpu::LREG2, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+        TTI_SFPIADD(257, p_sfpu::LREG0, p_sfpu::LREG3, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+
+        // ── OR the precomputed indices into the low 16 bits of every DST word.
+        // Same 16-slot record/replay shape as the column-major body below.
+        lltt::record<lltt::Exec>(0, 16);
+        TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_7, 2);
+        TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::INT32, ADDR_MOD_7, 16 + 0);
+        TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_7, 16 + 2);
+
+        TTI_SFPOR(0, p_sfpu::LREG0, p_sfpu::LREG4, 0);
+        TTI_SFPOR(0, p_sfpu::LREG1, p_sfpu::LREG5, 0);
+        TTI_SFPOR(0, p_sfpu::LREG2, p_sfpu::LREG6, 0);
+        TTI_SFPOR(0, p_sfpu::LREG3, p_sfpu::LREG7, 0);
+
+        TTI_SFPIADD(64, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+        TTI_SFPIADD(64, p_sfpu::LREG1, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+        TTI_SFPIADD(64, p_sfpu::LREG2, p_sfpu::LREG2, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+        TTI_SFPIADD(64, p_sfpu::LREG3, p_sfpu::LREG3, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+
+        TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_7, 2);
+        TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::INT32, ADDR_MOD_7, 16 + 0);
+        TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_6, 16 + 2);
+
+        for (int i = 1; i < 4; i++)
+        {
+            lltt::replay(0, 16);
+        }
+
+        // Outer loop over the remaining face-pairs, same shape as the
+        // column-major body below; the row-major index advance between
+        // face-pairs is +256 (tile*1024 spans two 512-element face-pairs).
+        constexpr int row_scale_factor = K == 512 ? 1 : K == 1024 ? 2 : 4;
+        for (int j = 1; j < row_scale_factor; j++)
+        {
+            TTI_SFPIADD(256, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+            TTI_SFPIADD(256, p_sfpu::LREG1, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+            TTI_SFPIADD(256, p_sfpu::LREG2, p_sfpu::LREG2, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+            TTI_SFPIADD(256, p_sfpu::LREG3, p_sfpu::LREG3, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+            TTI_SFPLOAD(p_sfpu::LREG4, 10, ADDR_MOD_4, 0);
+
+            for (int i = 0; i < 4; i++)
+            {
+                lltt::replay(0, 16);
+            }
+        }
+        return;
+    }
+
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
 
     // Tile ID into LREG0 (across the 32 lanes: 0, 2, 4, ..., 60, 62).
@@ -3160,7 +3278,7 @@ inline void _topk_xl_separate_indices_row_major_global_base_(std::uint32_t seg_b
     constexpr int row_scale_factor       = K == 512 ? 1 : K == 1024 ? 2 : 4;
     constexpr int num_tiles_per_sequence = K == 512 ? 1 : K == 1024 ? 1 : 2;
     constexpr int indices_offset         = num_tiles_per_sequence * 64;
-    constexpr int chunk_field_shift = K == 2048 ? 0 : K == 1024 ? -1 : -2;
+    constexpr int chunk_field_shift      = K == 2048 ? 0 : K == 1024 ? -1 : -2;
 
     TT_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_UPPER, (seg_base >> 16) & 0xFFFF);
     TT_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_LOWER, seg_base & 0xFFFF);


### PR DESCRIPTION
Rewritten from scratch against main after #53455 (SFPLOADMACRO primitives + fused-u16 family) reshaped the topk_xl stack and dropped APPROXIMATE from the template signatures. The previous branch head conflicted in 23 hunks; this version applies the same four tt-blaze gaps as pure additions to the post-#53455 code, following its conventions (no APPROXIMATE anywhere).

The four gaps, unchanged from the original PR:

- topk_xl_local_sort_generic (compute API) and llk_math_eltwise_unary_sfpu_topk_xl_local_sort_generic (llk_api): the SFPU primitive already exists canonically; only the wrapper layers were missing, so the entry point was unreachable from a kernel.
- _topk_xl_local_sort_generic_ gains a trailing early_exit_K64 = false template parameter: sort each 64-row column in isolation and return before the cross-column merge (sparse-K reader). Guarded by static_assert(!early_exit_K64 || K >= 1024) — the length-64 build lives in the K >= 1024 block. All three direction-flip suppressions are gated on early_exit_K64, so the default instantiation is instruction-for-instruction identical to main (verified: a line-level diff of the body against main is +14/-0 — pure additions).
- topk_xl_reinit_mop_after_copy<fused>() and topk_xl_reinit_unfused_rebuild_after_copy(), each routed through a new llk_api wrapper. The MOP reinit inherits #53455's TOPK_XL_UNFUSED_MACRO handling via topk_mop_config<fused>. The unfused reinit restores ADDR_MOD_3 (+40) and re-establishes ADDR_MOD_2 (+24), matching the file's documented address-mod recipe (unchanged by #53455).
- _topk_xl_add_lsb_indices_ gains a trailing row_major = false parameter (threaded through llk_api and compute API): the default keeps #53455's column-major order (index = col*64 + tile*32 + row); row_major = true gives plain row-major (index = tile*1024 + row*32 + col). Implemented as an early-return branch so the existing column-major body is untouched (verified +46/-0). Live in tt-blaze: indexer_local_topk calls it with row_major=true in two places. The _rt_ runtime-chunk-id variant from #53455 is left column-major-only, matching its single caller.

Carried over from the previous review round (Copilot):

- int32_mode stays dropped: LS_MOD is unconditionally InstrModLoadStore::INT32 in load16_rows_x2/store16_rows_x2 on main today, so the flag was inert. tt-blaze's single early-exit call site drops its third template argument at rewire (one line, agreed).
- llk_unpack_set_srcb_dummy_valid is issued for the full-sort instantiation and skipped only under early_exit_K64.
- The ADDR_MOD_2 comment states re-establishment, not restoration.

blaze parity after this change: zero blaze-only symbols across all three files; the only signature difference is the removed int32_mode parameter.

### Note for reviewers

This PR was rewritten from scratch after #53455 landed — the previous head conflicted in 23 hunks against the reshaped family. All Copilot findings from the earlier review round remain addressed in this version (direction-flip gating, K >= 1024 static_assert, dummy-valid gating, llk_api routing, int32_mode removal, ADDR_MOD_2 attribution). Roughly a quarter of the changed lines are `uint32_t` -> `std::uint32_t` rewrites of pre-existing code applied automatically by the `fix-cstdint` pre-commit hook; the substantive change is the additions described above.

### Tests

No test in this PR. #53455's LLK-level tests cover the fused-u16 family and the default column-major/full-sort paths, which are unchanged here by construction (verified: the `_topk_xl_local_sort_generic_` body diff vs main is +14/-0 and `_topk_xl_add_lsb_indices_` is +46/-0 — pure additions). The new `early_exit_K64`, `row_major`, and post-copy reinit paths have no coverage yet; they are exercised today by tt-blaze's `glm_sparse_read_sdpa`, `indexer_local_topk`, `distributed_topk`, and `cross_device_allgather_tree_merge`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilenkovic/reconcile-topk-xl)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilenkovic/reconcile-topk-xl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilenkovic/reconcile-topk-xl)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilenkovic/reconcile-topk-xl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilenkovic/reconcile-topk-xl)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilenkovic/reconcile-topk-xl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilenkovic/reconcile-topk-xl)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilenkovic/reconcile-topk-xl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilenkovic/reconcile-topk-xl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilenkovic/reconcile-topk-xl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilenkovic/reconcile-topk-xl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilenkovic/reconcile-topk-xl)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilenkovic/reconcile-topk-xl)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilenkovic/reconcile-topk-xl)