### PR TITLE
[Feature] [Codegen] Guard blind regeneration runs against git-history recovery

### DIFF
--- a/tt_metal/tt-llk/.claude/hooks/git-guard.sh
+++ b/tt_metal/tt-llk/.claude/hooks/git-guard.sh
@@ -80,7 +80,10 @@ SUBCMD='(^|[^[:alnum:]_-])git([[:space:]]+(-[^[:space:]]+|-C[[:space:]]+[^[:spac
 # bare-SHA pattern is what stops `git worktree add <dir> <old-sha>` and
 # `git checkout <old-sha> -- <path>`; `worktree` itself stays allowed because the
 # pipeline creates its own worktrees.
-REVREF='HEAD~|HEAD\^|@\{|\.git($|[^[:alnum:]_-])|(^|[^[:alnum:]])[0-9a-f]{7,40}([^[:alnum:]]|$)'
+#
+# Bare SHAs are handled by _has_sha_token below rather than by this pattern — see there for
+# the two false-positive classes the first real run exposed.
+REVREF='HEAD~|HEAD\^|@\{|\.git($|[^[:alnum:]_-])'
 
 # Same, minus the bare-SHA clause, for scanning file content: a 7+ hex-digit token is
 # common in source (constants, masks) and would false-block legitimate writes.
@@ -94,6 +97,21 @@ SUBCMD_LOOSE='(^|[^[:alnum:]_-])git[^[:alnum:]_]+(log|reflog|rev-list|cat-file|b
 
 # Cheap gate: only inspect text that mentions git or a .git path at all.
 GITISH='(^|[^[:alnum:]_-])git([^[:alnum:]_-]|$)|\.git($|[^[:alnum:]_-])'
+
+# A bare commit SHA, as an argument rather than as a fragment of something else. Two
+# false-positive classes from the first real run drove this shape:
+#   * hex inside a path — run ids are 8 hex chars, so every command naming LOG_DIR
+#     (".../2026-08-20_relu_quasar_8c1bcf65/...") matched. Hence: whitespace-delimited only.
+#   * pure-decimal numbers — every digit is a valid hex digit, so Confluence page ids like
+#     1173618806 matched. Hence: the token must contain at least one a-f.
+# A short SHA that happens to be all digits is therefore missed; that is an accepted gap,
+# since this clause is only a backstop behind SUBCMD and the HEAD~/.git patterns.
+_has_sha_token() {
+    printf '%s' "$1" \
+        | grep -oE '(^|[[:space:]])[0-9a-f]{7,40}([[:space:]]|:|$)' \
+        | tr -d '[:space:]:' \
+        | grep -qE '[a-f]'
+}
 
 # Writing a script and then running it defeats a command-text check: the Bash hook only
 # sees `bash x.sh`. Authoring the script *through bash* is already caught (the git text is
@@ -128,6 +146,8 @@ if [ "$BLIND" = "1" ] && [ "$scan_text" = "1" ] && printf '%s' "$cmd" | grep -qE
     if printf '%s' "$cmd" | grep -qE "$SUBCMD" || printf '%s' "$cmd" | grep -qE "$scan_revref"; then
         verdict=BLOCK
     elif [ -n "$scan_loose" ] && printf '%s' "$cmd" | grep -qE "$scan_loose"; then
+        verdict=BLOCK
+    elif [ "$tool" = "Bash" ] && _has_sha_token "$cmd"; then
         verdict=BLOCK
     fi
 fi

--- a/tt_metal/tt-llk/.claude/hooks/git-guard.sh
+++ b/tt_metal/tt-llk/.claude/hooks/git-guard.sh
@@ -17,12 +17,17 @@
 # not contradict the read-only-git-is-allowed policy in ../CLAUDE.md and
 # ../codegen/CLAUDE.md — the codegen router legitimately uses `git log` / `git show`.
 #
-# Log line format (tab separated):
-#     <UTC timestamp>  <session id>  <OK|BLOCK>  <command, newlines flattened>
+# Log line format (tab separated). Every bash command is logged; a Write/Edit is logged only
+# when it is blocked, so the git-relevant lines are not buried:
+#     <UTC timestamp>  <session id>  <Bash|Write|Edit>  <OK|BLOCK>  <text, newlines flattened>
+# Match the verdict as "\tBLOCK\t" rather than by column index — the columns have changed once
+# already, and a hardcoded index fails silently by reporting zero blocks.
 #
-# Log location: $CODEGEN_GUARD_LOG, else $TMPDIR/codegen-git-guard-<session id>.log.
-# The pipeline points CODEGEN_GUARD_LOG at "$LOG_DIR/git-guard.log" so the audit trail
-# is stored exactly like state.json and the agent transcripts.
+# Log location: $CODEGEN_GUARD_LOG when set, else $TMPDIR/codegen-git-guard-<session id>.log.
+# The pipeline does not set that variable — it cannot, since the hook's environment is fixed
+# when Claude starts. It instead copies the session-scoped default to "$LOG_DIR/git-guard.log"
+# in execute_step_extract_transcripts, so the audit trail ends up stored exactly like
+# state.json and the agent transcripts. Set CODEGEN_GUARD_LOG only for a hand-started session.
 
 set -uo pipefail
 
@@ -30,16 +35,26 @@ BLIND="${CODEGEN_BLIND_RUN:-0}"
 
 payload=$(cat)
 
-# Line 1 = session id, line 2.. = the raw command (may span lines).
+# Line 1 = session id, 2 = tool name, 3 = file path (Write/Edit), 4.. = the text to scan:
+# the command for Bash, the written content for Write/Edit.
 meta=$(printf '%s' "$payload" | python3 -c 'import json,sys
 try:
     d = json.load(sys.stdin)
+    ti = d.get("tool_input") or {}
+    tool = str(d.get("tool_name") or "")
     print(str(d.get("session_id") or "nosession"))
-    print(d.get("tool_input", {}).get("command", "") or "")
+    print(tool)
+    print(str(ti.get("file_path") or ""))
+    if tool == "Bash":
+        print(ti.get("command", "") or "")
+    else:
+        print(ti.get("content") or ti.get("new_string") or "")
 except Exception:
-    print("nosession"); print("")' 2>/dev/null)
-sid=$(printf '%s' "$meta" | head -1)
-cmd=$(printf '%s' "$meta" | tail -n +2)
+    print("nosession"); print(""); print(""); print("")' 2>/dev/null)
+sid=$(printf '%s' "$meta" | sed -n 1p)
+tool=$(printf '%s' "$meta" | sed -n 2p)
+path=$(printf '%s' "$meta" | sed -n 3p)
+cmd=$(printf '%s' "$meta" | tail -n +4)
 
 # One log per run — a shared file would make lines unattributable. The default is keyed
 # by session id so a hand-started session still gets its own file. The pipeline collects
@@ -61,27 +76,66 @@ SUBCMD='(^|[^[:alnum:]_-])git([[:space:]]+(-[^[:space:]]+|-C[[:space:]]+[^[:spac
 # bare-SHA pattern is what stops `git worktree add <dir> <old-sha>` and
 # `git checkout <old-sha> -- <path>`; `worktree` itself stays allowed because the
 # pipeline creates its own worktrees.
-REVREF='HEAD~|HEAD\^|@\{|\.git/(logs|objects|refs|packed-refs)|(^|[^[:alnum:]])[0-9a-f]{7,40}([^[:alnum:]]|$)'
+REVREF='HEAD~|HEAD\^|@\{|\.git(/|$)|(^|[^[:alnum:]])[0-9a-f]{7,40}([^[:alnum:]]|$)'
 
-# Cheap gate: only inspect commands that mention git or a .git path at all.
-GITISH='(^|[^[:alnum:]_-])git([^[:alnum:]_-]|$)|\.git/'
+# Same, minus the bare-SHA clause, for scanning file content: a 7+ hex-digit token is
+# common in source (constants, masks) and would false-block legitimate writes.
+REVREF_CONTENT='HEAD~|HEAD\^|@\{|\.git(/|$)'
+
+# In script content the subcommand is often not space-separated —
+# `subprocess.run(["git", "reflog"])` puts quotes and a comma between the two tokens. Any
+# run of non-word characters counts as the separator. This cannot span an intervening word,
+# so `git status; cat build.log` still does not match.
+SUBCMD_LOOSE='(^|[^[:alnum:]_-])git[^[:alnum:]_]+(log|reflog|rev-list|cat-file|blame|stash|fsck|archive|show)([^[:alnum:]_-]|$)'
+
+# Cheap gate: only inspect text that mentions git or a .git path at all.
+GITISH='(^|[^[:alnum:]_-])git([^[:alnum:]_-]|$)|\.git(/|$)'
+
+# Writing a script and then running it defeats a command-text check: the Bash hook only
+# sees `bash x.sh`. Authoring the script *through bash* is already caught (the git text is
+# in the command), so the remaining route is the Write/Edit tool, which never touches a
+# shell. Scan written content too — but only for scripts, so prose that merely mentions
+# `git log` (analysis notes, reports) is not blocked.
+scan_text=0
+scan_revref="$REVREF"
+scan_loose=""
+case "$tool" in
+    Bash)
+        scan_text=1
+        ;;
+    Write|Edit|NotebookEdit)
+        scan_revref="$REVREF_CONTENT"
+        scan_loose="$SUBCMD_LOOSE"
+        case "$path" in
+            *.sh | *.bash | *.zsh | *.py | *.pl) scan_text=1 ;;
+        esac
+        # A shebang makes it a script whatever the extension.
+        printf '%s' "$cmd" | sed -n 1p | grep -q '^#!' && scan_text=1
+        ;;
+esac
 
 verdict=OK
-if [ "$BLIND" = "1" ] && printf '%s' "$cmd" | grep -qE "$GITISH"; then
-    if printf '%s' "$cmd" | grep -qE "$SUBCMD" || printf '%s' "$cmd" | grep -qE "$REVREF"; then
+if [ "$BLIND" = "1" ] && [ "$scan_text" = "1" ] && printf '%s' "$cmd" | grep -qE "$GITISH"; then
+    if printf '%s' "$cmd" | grep -qE "$SUBCMD" || printf '%s' "$cmd" | grep -qE "$scan_revref"; then
+        verdict=BLOCK
+    elif [ -n "$scan_loose" ] && printf '%s' "$cmd" | grep -qE "$scan_loose"; then
         verdict=BLOCK
     fi
 fi
 
-# Record the command and the verdict. Newlines and tabs are flattened so every command
-# is exactly one greppable line.
-cmd_flat=$(printf '%s' "$cmd" | tr '\n\t' '  ')
-mkdir -p "$(dirname "$LOG")" 2>/dev/null || true
-printf '%s\t%s\t%s\t%s\n' \
-    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$sid" "$verdict" "$cmd_flat" >> "$LOG" 2>/dev/null || true
+# Log every bash command, plus any blocked attempt through another tool. Logging every
+# Write as well would bury the git-relevant lines. Newlines and tabs are flattened so each
+# entry is exactly one greppable line.
+if [ "$tool" = "Bash" ] || [ "$verdict" = "BLOCK" ]; then
+    entry=$(printf '%s' "$cmd" | tr '\n\t' '  ')
+    [ "$tool" != "Bash" ] && entry="$path :: $entry"
+    mkdir -p "$(dirname "$LOG")" 2>/dev/null || true
+    printf '%s\t%s\t%s\t%s\t%s\n' \
+        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$sid" "${tool:-?}" "$verdict" "$entry" >> "$LOG" 2>/dev/null || true
+fi
 
 if [ "$verdict" = "BLOCK" ]; then
-    reason="Blocked by git-guard: this codegen run is a blind regeneration, so reading git history (or an older revision) is not permitted. git status/add/commit and a bare 'git diff' are allowed."
+    reason="Blocked by git-guard: this codegen run is a blind regeneration, so reading git history — directly or from a script — is not permitted. git status/add/commit and a bare 'git diff' are allowed."
     printf '%s\n' "$reason" >&2
     python3 -c 'import json,sys; print(json.dumps({"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":sys.argv[1]}}))' "$reason"
 fi

--- a/tt_metal/tt-llk/.claude/hooks/git-guard.sh
+++ b/tt_metal/tt-llk/.claude/hooks/git-guard.sh
@@ -1,33 +1,28 @@
 #!/usr/bin/env bash
-# git-guard.sh — PreToolUse(Bash) guard for codegen runs.
+# git-guard.sh — PreToolUse hook for codegen runs.
 #
 # Two jobs:
-#   1. Log every bash command the agent runs, with an OK/BLOCK verdict, so a run can
-#      be audited with `grep BLOCK`.
-#   2. During a blind run, deny commands that read git history, so a regeneration
-#      cannot recover the implementation that was hidden for the run.
+#   1. Log every bash command with an OK/BLOCK verdict, so a run can be audited with
+#      `grep BLOCK`.
+#   2. During a blind run, deny reads of git history, so a regeneration cannot recover the
+#      implementation that was hidden for it.
 #
-# Why this exists: a codegen worktree shares the parent repo's object store, so every
-# deleted blob is still reachable. Telling the agent not to look is not enforcement.
-# This is the enforcement for the shell path; the permissions.deny rules in
-# ../settings.json cover the Read/Grep/Glob path, which never touches a shell and so
-# never reaches this script (and therefore is NOT recorded in this log).
+# A codegen worktree shares the parent repo's object store, so every deleted blob is still
+# reachable — telling the agent not to look is not enforcement. This covers the shell path;
+# permissions.deny in ../settings.json covers Read/Grep/Glob, which never reach a hook and so
+# are absent from this log.
 #
-# Blocking is opt-in per run. Without CODEGEN_BLIND_RUN this hook only logs, so it does
-# not contradict the read-only-git-is-allowed policy in ../CLAUDE.md and
-# ../codegen/CLAUDE.md — the codegen router legitimately uses `git log` / `git show`.
+# Blocking is opt-in: without CODEGEN_BLIND_RUN the hook only logs, so it does not contradict
+# the read-only-git policy in ../CLAUDE.md, which the codegen router relies on.
 #
-# Log line format (tab separated). Every bash command is logged; a Write/Edit is logged only
-# when it is blocked, so the git-relevant lines are not buried:
+# Log line, tab separated — every Bash command, plus Write/Edit only when blocked:
 #     <UTC timestamp>  <session id>  <Bash|Write|Edit>  <OK|BLOCK>  <text, newlines flattened>
-# Match the verdict as "\tBLOCK\t" rather than by column index — the columns have changed once
-# already, and a hardcoded index fails silently by reporting zero blocks.
+# Grep the verdict as "\tBLOCK\t", not by column index; the columns have changed once already
+# and a hardcoded index fails silently by reporting zero blocks.
 #
-# Log location: $CODEGEN_GUARD_LOG when set, else $TMPDIR/codegen-git-guard-<session id>.log.
-# The pipeline does not set that variable — it cannot, since the hook's environment is fixed
-# when Claude starts. It instead copies the session-scoped default to "$LOG_DIR/git-guard.log"
-# in execute_step_extract_transcripts, so the audit trail ends up stored exactly like
-# state.json and the agent transcripts. Set CODEGEN_GUARD_LOG only for a hand-started session.
+# Log path: $CODEGEN_GUARD_LOG, else $TMPDIR/codegen-git-guard-<session id>.log, which the
+# pipeline copies into the run's LOG_DIR at the end of the run. Setting the variable only
+# works for a hand-started session — the hook's environment is fixed when Claude starts.
 
 set -uo pipefail
 
@@ -60,56 +55,48 @@ tool=$(printf '%s' "$meta" | sed -n 2p)
 path=$(printf '%s' "$meta" | sed -n 3p)
 cmd=$(printf '%s' "$meta" | tail -n +4)
 
-# One log per run — a shared file would make lines unattributable. The default is keyed
-# by session id so a hand-started session still gets its own file. The pipeline collects
-# this file into the run's LOG_DIR at the end of the run (execute_step_extract_transcripts).
+# One log per run — a shared file would make lines unattributable. Keyed by session id so a
+# hand-started session still gets its own file.
 LOG="${CODEGEN_GUARD_LOG:-${TMPDIR:-/tmp}/codegen-git-guard-${sid}.log}"
 
-# Blind mode can also be armed by a marker file, which is how the pipeline does it:
-# HIDE_EXISTING_KERNEL is chosen *after* Claude has started, and a running process's
-# environment cannot be changed from the outside. The marker can be created mid-session.
+# Blind mode can also be armed mid-session by a marker file, which is how the pipeline does
+# it: HIDE_EXISTING_KERNEL is chosen after Claude has started, and a running process's
+# environment cannot be changed from outside.
 if [ "$BLIND" != "1" ] && [ -f "${TMPDIR:-/tmp}/codegen-blind-run-${sid}" ]; then
     BLIND=1
 fi
 
-# A history-reading git subcommand. Allows for a path prefix (/usr/bin/git), a
-# `command` prefix, and leading options such as `-C <dir>` or `--no-pager`.
+# A history-reading git subcommand. Tolerates a path prefix (/usr/bin/git), a `command`
+# prefix, and leading options such as `-C <dir>` or `--no-pager`.
 SUBCMD='(^|[^[:alnum:]_-])git([[:space:]]+(-[^[:space:]]+|-C[[:space:]]+[^[:space:]]+))*[[:space:]]+(log|reflog|rev-list|cat-file|blame|stash|fsck|archive|show|shortlog|whatchanged|for-each-ref)([^[:alnum:]_-]|$)'
 
-# Any explicit reference to an older revision, or a raw read of the object store. The
-# bare-SHA pattern is what stops `git worktree add <dir> <old-sha>` and
-# `git checkout <old-sha> -- <path>`; `worktree` itself stays allowed because the
-# pipeline creates its own worktrees.
-#
-# Bare SHAs are handled by _has_sha_token below rather than by this pattern — see there for
-# the two false-positive classes the first real run exposed.
+# An explicit reference to an older revision, or a raw read of the object store. `worktree`
+# itself stays allowed, since the pipeline creates its own. Bare SHAs — which is what stops
+# `git worktree add <dir> <old-sha>` — are handled by _has_sha_token below, not here.
 REVREF='HEAD~|HEAD\^|@\{|\.git($|[^[:alnum:]_-])'
 
 # Same, minus the bare-SHA clause, for scanning file content: a 7+ hex-digit token is
 # common in source (constants, masks) and would false-block legitimate writes.
 REVREF_CONTENT='HEAD~|HEAD\^|@\{|\.git($|[^[:alnum:]_-])'
 
-# In script content the subcommand is often not space-separated —
-# `subprocess.run(["git", "reflog"])` puts quotes and a comma between the two tokens. Any
-# run of non-word characters counts as the separator. This cannot span an intervening word,
-# so `git status; cat build.log` still does not match.
+# In script content the subcommand is often not space-separated — `["git", "reflog"]` puts
+# quotes and a comma between the tokens. Any run of non-word characters counts as the
+# separator, but it cannot span a word, so `git status; cat build.log` still does not match.
 SUBCMD_LOOSE='(^|[^[:alnum:]_-])git[^[:alnum:]_]+(log|reflog|rev-list|cat-file|blame|stash|fsck|archive|show|shortlog|whatchanged|for-each-ref)([^[:alnum:]_-]|$)'
 
-# `git branch -v` prints the tip commit's subject for every branch — the same disclosure as
-# `git log -1`, which is how the topk run's analyzer would have learned the op was hidden.
-# Only the verbose forms are blocked: setup_worktree.sh needs `git branch <name> <base>` and
-# `git branch -D <name>` — and a branch name can itself contain "-v" (…-quasar-v7), so the
-# flag must be a standalone token.
+# `git branch -v` prints each branch's tip subject — the same disclosure as `git log -1`, and
+# how the topk run's analyzer would have learned the op was hidden. Only the verbose forms are
+# blocked: setup_worktree.sh needs plain `git branch <name> <base>` and `git branch -D`. A
+# branch name can itself contain "-v" (…-quasar-v7), so the flag must be a standalone token.
 BRANCHV='(^|[^[:alnum:]_-])git[[:space:]]+branch[^;|&]*[[:space:]](-vv?|--verbose)([[:space:]]|$)'
 
 # Cheap gate: only inspect text that mentions git or a .git path at all.
 GITISH='(^|[^[:alnum:]_-])git([^[:alnum:]_-]|$)|\.git($|[^[:alnum:]_-])'
 
-# Mentioning .git in order to SKIP it is not an attempt to read it. `find . -not -path
-# "./.git/*"` and `grep --exclude-dir=.git` are the normal ways to keep a search out of the
-# object store, and blocking them produced 2 false positives on the first real topk run.
-# Strip exclusion clauses before scanning. A real history read cannot hide inside one: a git
-# subcommand survives the scrub (`git log --exclude=x` still reads as `git log`).
+# Naming .git in order to SKIP it is not an attempt to read it. `find . -not -path "./.git/*"`
+# and `grep --exclude-dir=.git` are the normal ways to keep a search out of the object store,
+# and blocking them produced 2 false positives on the first real topk run. A real history read
+# cannot hide inside an exclusion: `git log --exclude=x` still reads as `git log`.
 _scrub_exclusions() {
     printf '%s' "$1" \
         | sed -E 's/(-not[[:space:]]+-path|![[:space:]]+-path)[[:space:]]+[^[:space:]]+//g' \
@@ -118,14 +105,14 @@ _scrub_exclusions() {
         | sed -E 's/:\(exclude\)[^[:space:]]*//g'
 }
 
-# A bare commit SHA, as an argument rather than as a fragment of something else. Two
-# false-positive classes from the first real run drove this shape:
-#   * hex inside a path — run ids are 8 hex chars, so every command naming LOG_DIR
-#     (".../2026-08-20_relu_quasar_8c1bcf65/...") matched. Hence: whitespace-delimited only.
-#   * pure-decimal numbers — every digit is a valid hex digit, so Confluence page ids like
-#     1173618806 matched. Hence: the token must contain at least one a-f.
-# A short SHA that happens to be all digits is therefore missed; that is an accepted gap,
-# since this clause is only a backstop behind SUBCMD and the HEAD~/.git patterns.
+# A bare commit SHA as an argument, not as a fragment of something else. Two false-positive
+# classes from the first real run drove this shape:
+#   * hex inside a path — run ids are 8 hex chars, so every command naming LOG_DIR matched.
+#     Hence: whitespace-delimited only.
+#   * pure-decimal numbers — every digit is a valid hex digit, so Confluence page ids matched.
+#     Hence: the token must contain at least one a-f.
+# An all-digit short SHA is therefore missed — accepted, since this is only a backstop behind
+# SUBCMD and the HEAD~/.git patterns.
 _has_sha_token() {
     printf '%s' "$1" \
         | grep -oE '(^|[[:space:]])[0-9a-f]{7,40}([[:space:]]|:|$)' \
@@ -133,11 +120,10 @@ _has_sha_token() {
         | grep -qE '[a-f]'
 }
 
-# Writing a script and then running it defeats a command-text check: the Bash hook only
-# sees `bash x.sh`. Authoring the script *through bash* is already caught (the git text is
-# in the command), so the remaining route is the Write/Edit tool, which never touches a
-# shell. Scan written content too — but only for scripts, so prose that merely mentions
-# `git log` (analysis notes, reports) is not blocked.
+# Writing a script and then running it would defeat a command-text check: the Bash hook only
+# sees `bash x.sh`. Authoring it through bash is already caught (the git text is in the
+# command), so the remaining route is Write/Edit, which never touches a shell. Scan written
+# content too — but only for scripts, so prose that merely mentions `git log` is not blocked.
 scan_text=0
 scan_revref="$REVREF"
 scan_loose=""
@@ -154,11 +140,10 @@ case "$tool" in
         # A shebang makes it a script whatever the extension.
         printf '%s' "$cmd" | sed -n 1p | grep -q '^#!' && scan_text=1
         ;;
-    # Read/Grep/Glob are deliberately NOT matched. `permissions.deny` short-circuits before
-    # PreToolUse — measured: a denied Read never reaches this hook — so matching them would add
-    # no log entry and no protection, while spending ~38 ms on every file read (~76 s over a
-    # 2000-read run). Reads of .git are refused by the deny rules in ../settings.json instead;
-    # the cost is that those refusals do not appear in this log.
+    # Read/Grep/Glob are deliberately NOT matched: `permissions.deny` short-circuits before
+    # PreToolUse (measured — a denied Read never reaches this hook), so matching them would add
+    # no protection while costing ~38 ms per file read (~76 s over a 2000-read run). The deny
+    # rules in ../settings.json refuse those reads; the cost is they are not logged here.
 esac
 
 verdict=OK
@@ -174,9 +159,8 @@ if [ "$BLIND" = "1" ] && [ "$scan_text" = "1" ] && printf '%s' "$scan_src" | gre
     fi
 fi
 
-# Log every bash command, plus any blocked attempt through another tool. Logging every
-# Write as well would bury the git-relevant lines. Newlines and tabs are flattened so each
-# entry is exactly one greppable line.
+# Log every bash command, plus any blocked attempt through another tool; logging every Write
+# would bury the git-relevant lines. Newlines and tabs are flattened to one greppable line.
 if [ "$tool" = "Bash" ] || [ "$verdict" = "BLOCK" ]; then
     entry=$(printf '%s' "$cmd" | tr '\n\t' '  ')
     [ "$tool" != "Bash" ] && entry="$path :: $entry"

--- a/tt_metal/tt-llk/.claude/hooks/git-guard.sh
+++ b/tt_metal/tt-llk/.claude/hooks/git-guard.sh
@@ -47,8 +47,12 @@ try:
     print(str(ti.get("file_path") or ""))
     if tool == "Bash":
         print(ti.get("command", "") or "")
-    else:
+    elif tool in ("Write", "Edit", "NotebookEdit"):
         print(ti.get("content") or ti.get("new_string") or "")
+    else:
+        # Read/Grep/Glob: the target path is what matters, not any content.
+        keys = ("file_path", "notebook_path", "path", "pattern")
+        print(" ".join(str(ti.get(k)) for k in keys if ti.get(k)))
 except Exception:
     print("nosession"); print(""); print(""); print("")' 2>/dev/null)
 sid=$(printf '%s' "$meta" | sed -n 1p)
@@ -76,11 +80,11 @@ SUBCMD='(^|[^[:alnum:]_-])git([[:space:]]+(-[^[:space:]]+|-C[[:space:]]+[^[:spac
 # bare-SHA pattern is what stops `git worktree add <dir> <old-sha>` and
 # `git checkout <old-sha> -- <path>`; `worktree` itself stays allowed because the
 # pipeline creates its own worktrees.
-REVREF='HEAD~|HEAD\^|@\{|\.git(/|$)|(^|[^[:alnum:]])[0-9a-f]{7,40}([^[:alnum:]]|$)'
+REVREF='HEAD~|HEAD\^|@\{|\.git($|[^[:alnum:]_-])|(^|[^[:alnum:]])[0-9a-f]{7,40}([^[:alnum:]]|$)'
 
 # Same, minus the bare-SHA clause, for scanning file content: a 7+ hex-digit token is
 # common in source (constants, masks) and would false-block legitimate writes.
-REVREF_CONTENT='HEAD~|HEAD\^|@\{|\.git(/|$)'
+REVREF_CONTENT='HEAD~|HEAD\^|@\{|\.git($|[^[:alnum:]_-])'
 
 # In script content the subcommand is often not space-separated —
 # `subprocess.run(["git", "reflog"])` puts quotes and a comma between the two tokens. Any
@@ -89,7 +93,7 @@ REVREF_CONTENT='HEAD~|HEAD\^|@\{|\.git(/|$)'
 SUBCMD_LOOSE='(^|[^[:alnum:]_-])git[^[:alnum:]_]+(log|reflog|rev-list|cat-file|blame|stash|fsck|archive|show)([^[:alnum:]_-]|$)'
 
 # Cheap gate: only inspect text that mentions git or a .git path at all.
-GITISH='(^|[^[:alnum:]_-])git([^[:alnum:]_-]|$)|\.git(/|$)'
+GITISH='(^|[^[:alnum:]_-])git([^[:alnum:]_-]|$)|\.git($|[^[:alnum:]_-])'
 
 # Writing a script and then running it defeats a command-text check: the Bash hook only
 # sees `bash x.sh`. Authoring the script *through bash* is already caught (the git text is
@@ -112,6 +116,11 @@ case "$tool" in
         # A shebang makes it a script whatever the extension.
         printf '%s' "$cmd" | sed -n 1p | grep -q '^#!' && scan_text=1
         ;;
+    # Read/Grep/Glob are deliberately NOT matched. `permissions.deny` short-circuits before
+    # PreToolUse — measured: a denied Read never reaches this hook — so matching them would add
+    # no log entry and no protection, while spending ~38 ms on every file read (~76 s over a
+    # 2000-read run). Reads of .git are refused by the deny rules in ../settings.json instead;
+    # the cost is that those refusals do not appear in this log.
 esac
 
 verdict=OK

--- a/tt_metal/tt-llk/.claude/hooks/git-guard.sh
+++ b/tt_metal/tt-llk/.claude/hooks/git-guard.sh
@@ -74,7 +74,7 @@ fi
 
 # A history-reading git subcommand. Allows for a path prefix (/usr/bin/git), a
 # `command` prefix, and leading options such as `-C <dir>` or `--no-pager`.
-SUBCMD='(^|[^[:alnum:]_-])git([[:space:]]+(-[^[:space:]]+|-C[[:space:]]+[^[:space:]]+))*[[:space:]]+(log|reflog|rev-list|cat-file|blame|stash|fsck|archive|show)([^[:alnum:]_-]|$)'
+SUBCMD='(^|[^[:alnum:]_-])git([[:space:]]+(-[^[:space:]]+|-C[[:space:]]+[^[:space:]]+))*[[:space:]]+(log|reflog|rev-list|cat-file|blame|stash|fsck|archive|show|shortlog|whatchanged|for-each-ref)([^[:alnum:]_-]|$)'
 
 # Any explicit reference to an older revision, or a raw read of the object store. The
 # bare-SHA pattern is what stops `git worktree add <dir> <old-sha>` and
@@ -93,10 +93,30 @@ REVREF_CONTENT='HEAD~|HEAD\^|@\{|\.git($|[^[:alnum:]_-])'
 # `subprocess.run(["git", "reflog"])` puts quotes and a comma between the two tokens. Any
 # run of non-word characters counts as the separator. This cannot span an intervening word,
 # so `git status; cat build.log` still does not match.
-SUBCMD_LOOSE='(^|[^[:alnum:]_-])git[^[:alnum:]_]+(log|reflog|rev-list|cat-file|blame|stash|fsck|archive|show)([^[:alnum:]_-]|$)'
+SUBCMD_LOOSE='(^|[^[:alnum:]_-])git[^[:alnum:]_]+(log|reflog|rev-list|cat-file|blame|stash|fsck|archive|show|shortlog|whatchanged|for-each-ref)([^[:alnum:]_-]|$)'
+
+# `git branch -v` prints the tip commit's subject for every branch — the same disclosure as
+# `git log -1`, which is how the topk run's analyzer would have learned the op was hidden.
+# Only the verbose forms are blocked: setup_worktree.sh needs `git branch <name> <base>` and
+# `git branch -D <name>` — and a branch name can itself contain "-v" (…-quasar-v7), so the
+# flag must be a standalone token.
+BRANCHV='(^|[^[:alnum:]_-])git[[:space:]]+branch[^;|&]*[[:space:]](-vv?|--verbose)([[:space:]]|$)'
 
 # Cheap gate: only inspect text that mentions git or a .git path at all.
 GITISH='(^|[^[:alnum:]_-])git([^[:alnum:]_-]|$)|\.git($|[^[:alnum:]_-])'
+
+# Mentioning .git in order to SKIP it is not an attempt to read it. `find . -not -path
+# "./.git/*"` and `grep --exclude-dir=.git` are the normal ways to keep a search out of the
+# object store, and blocking them produced 2 false positives on the first real topk run.
+# Strip exclusion clauses before scanning. A real history read cannot hide inside one: a git
+# subcommand survives the scrub (`git log --exclude=x` still reads as `git log`).
+_scrub_exclusions() {
+    printf '%s' "$1" \
+        | sed -E 's/(-not[[:space:]]+-path|![[:space:]]+-path)[[:space:]]+[^[:space:]]+//g' \
+        | sed -E 's/--exclude(-dir)?=[^[:space:]]+//g' \
+        | sed -E 's/--exclude(-dir)?[[:space:]]+[^[:space:]]+//g' \
+        | sed -E 's/:\(exclude\)[^[:space:]]*//g'
+}
 
 # A bare commit SHA, as an argument rather than as a fragment of something else. Two
 # false-positive classes from the first real run drove this shape:
@@ -142,12 +162,14 @@ case "$tool" in
 esac
 
 verdict=OK
-if [ "$BLIND" = "1" ] && [ "$scan_text" = "1" ] && printf '%s' "$cmd" | grep -qE "$GITISH"; then
-    if printf '%s' "$cmd" | grep -qE "$SUBCMD" || printf '%s' "$cmd" | grep -qE "$scan_revref"; then
+scan_src="$(_scrub_exclusions "$cmd")"
+if [ "$BLIND" = "1" ] && [ "$scan_text" = "1" ] && printf '%s' "$scan_src" | grep -qE "$GITISH"; then
+    if printf '%s' "$scan_src" | grep -qE "$SUBCMD" || printf '%s' "$scan_src" | grep -qE "$scan_revref" \
+        || { [ "$tool" = "Bash" ] && printf '%s' "$scan_src" | grep -qE "$BRANCHV"; }; then
         verdict=BLOCK
-    elif [ -n "$scan_loose" ] && printf '%s' "$cmd" | grep -qE "$scan_loose"; then
+    elif [ -n "$scan_loose" ] && printf '%s' "$scan_src" | grep -qE "$scan_loose"; then
         verdict=BLOCK
-    elif [ "$tool" = "Bash" ] && _has_sha_token "$cmd"; then
+    elif [ "$tool" = "Bash" ] && _has_sha_token "$scan_src"; then
         verdict=BLOCK
     fi
 fi

--- a/tt_metal/tt-llk/.claude/hooks/git-guard.sh
+++ b/tt_metal/tt-llk/.claude/hooks/git-guard.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# git-guard.sh — PreToolUse(Bash) guard for codegen runs.
+#
+# Two jobs:
+#   1. Log every bash command the agent runs, with an OK/BLOCK verdict, so a run can
+#      be audited with `grep BLOCK`.
+#   2. During a blind run, deny commands that read git history, so a regeneration
+#      cannot recover the implementation that was hidden for the run.
+#
+# Why this exists: a codegen worktree shares the parent repo's object store, so every
+# deleted blob is still reachable. Telling the agent not to look is not enforcement.
+# This is the enforcement for the shell path; the permissions.deny rules in
+# ../settings.json cover the Read/Grep/Glob path, which never touches a shell and so
+# never reaches this script (and therefore is NOT recorded in this log).
+#
+# Blocking is opt-in per run. Without CODEGEN_BLIND_RUN this hook only logs, so it does
+# not contradict the read-only-git-is-allowed policy in ../CLAUDE.md and
+# ../codegen/CLAUDE.md — the codegen router legitimately uses `git log` / `git show`.
+#
+# Log line format (tab separated):
+#     <UTC timestamp>  <session id>  <OK|BLOCK>  <command, newlines flattened>
+#
+# Log location: $CODEGEN_GUARD_LOG, else $TMPDIR/codegen-git-guard-<session id>.log.
+# The pipeline points CODEGEN_GUARD_LOG at "$LOG_DIR/git-guard.log" so the audit trail
+# is stored exactly like state.json and the agent transcripts.
+
+set -uo pipefail
+
+BLIND="${CODEGEN_BLIND_RUN:-0}"
+
+payload=$(cat)
+
+# Line 1 = session id, line 2.. = the raw command (may span lines).
+meta=$(printf '%s' "$payload" | python3 -c 'import json,sys
+try:
+    d = json.load(sys.stdin)
+    print(str(d.get("session_id") or "nosession"))
+    print(d.get("tool_input", {}).get("command", "") or "")
+except Exception:
+    print("nosession"); print("")' 2>/dev/null)
+sid=$(printf '%s' "$meta" | head -1)
+cmd=$(printf '%s' "$meta" | tail -n +2)
+
+# One log per run — a shared file would make lines unattributable. The default is keyed
+# by session id so a hand-started session still gets its own file. The pipeline collects
+# this file into the run's LOG_DIR at the end of the run (execute_step_extract_transcripts).
+LOG="${CODEGEN_GUARD_LOG:-${TMPDIR:-/tmp}/codegen-git-guard-${sid}.log}"
+
+# Blind mode can also be armed by a marker file, which is how the pipeline does it:
+# HIDE_EXISTING_KERNEL is chosen *after* Claude has started, and a running process's
+# environment cannot be changed from the outside. The marker can be created mid-session.
+if [ "$BLIND" != "1" ] && [ -f "${TMPDIR:-/tmp}/codegen-blind-run-${sid}" ]; then
+    BLIND=1
+fi
+
+# A history-reading git subcommand. Allows for a path prefix (/usr/bin/git), a
+# `command` prefix, and leading options such as `-C <dir>` or `--no-pager`.
+SUBCMD='(^|[^[:alnum:]_-])git([[:space:]]+(-[^[:space:]]+|-C[[:space:]]+[^[:space:]]+))*[[:space:]]+(log|reflog|rev-list|cat-file|blame|stash|fsck|archive|show)([^[:alnum:]_-]|$)'
+
+# Any explicit reference to an older revision, or a raw read of the object store. The
+# bare-SHA pattern is what stops `git worktree add <dir> <old-sha>` and
+# `git checkout <old-sha> -- <path>`; `worktree` itself stays allowed because the
+# pipeline creates its own worktrees.
+REVREF='HEAD~|HEAD\^|@\{|\.git/(logs|objects|refs|packed-refs)|(^|[^[:alnum:]])[0-9a-f]{7,40}([^[:alnum:]]|$)'
+
+# Cheap gate: only inspect commands that mention git or a .git path at all.
+GITISH='(^|[^[:alnum:]_-])git([^[:alnum:]_-]|$)|\.git/'
+
+verdict=OK
+if [ "$BLIND" = "1" ] && printf '%s' "$cmd" | grep -qE "$GITISH"; then
+    if printf '%s' "$cmd" | grep -qE "$SUBCMD" || printf '%s' "$cmd" | grep -qE "$REVREF"; then
+        verdict=BLOCK
+    fi
+fi
+
+# Record the command and the verdict. Newlines and tabs are flattened so every command
+# is exactly one greppable line.
+cmd_flat=$(printf '%s' "$cmd" | tr '\n\t' '  ')
+mkdir -p "$(dirname "$LOG")" 2>/dev/null || true
+printf '%s\t%s\t%s\t%s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$sid" "$verdict" "$cmd_flat" >> "$LOG" 2>/dev/null || true
+
+if [ "$verdict" = "BLOCK" ]; then
+    reason="Blocked by git-guard: this codegen run is a blind regeneration, so reading git history (or an older revision) is not permitted. git status/add/commit and a bare 'git diff' are allowed."
+    printf '%s\n' "$reason" >&2
+    python3 -c 'import json,sys; print(json.dumps({"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":sys.argv[1]}}))' "$reason"
+fi
+
+exit 0

--- a/tt_metal/tt-llk/.claude/settings.json
+++ b/tt_metal/tt-llk/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://json.schemastore.org/claude-code-settings.json",
+    "permissions": {
+        "deny": [
+            "Read(//**/.git/**)",
+            "Read(//localdev/jmacanovic/tt-metal/.git/**)"
+        ]
+    },
+    "hooks": {
+        "PreToolUse": [
+            {
+                "matcher": "Bash",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/git-guard.sh\"",
+                        "timeout": 10,
+                        "statusMessage": "git-guard"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tt_metal/tt-llk/.claude/settings.json
+++ b/tt_metal/tt-llk/.claude/settings.json
@@ -2,14 +2,13 @@
     "$schema": "https://json.schemastore.org/claude-code-settings.json",
     "permissions": {
         "deny": [
-            "Read(//**/.git/**)",
-            "Read(//localdev/jmacanovic/tt-metal/.git/**)"
+            "Read(//**/.git/**)"
         ]
     },
     "hooks": {
         "PreToolUse": [
             {
-                "matcher": "Bash",
+                "matcher": "Bash|Write|Edit",
                 "hooks": [
                     {
                         "type": "command",

--- a/tt_metal/tt-llk/CLAUDE.md
+++ b/tt_metal/tt-llk/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Read-only git commands are allowed (`git rev-parse`, `git log`, `git status`, `git diff`, `git show`). **NEVER push, commit, checkout, restore, reset, or otherwise modify** the repo via git.
 
-**Blind codegen runs are stricter.** A run that exports `CODEGEN_BLIND_RUN=1` regenerates an implementation that was deliberately hidden, so recovering it from history would invalidate the result. In that mode the `PreToolUse` hook `.claude/hooks/git-guard.sh` denies history reads (`log`, `show`, `reflog`, `rev-list`, `cat-file`, `blame`, `stash`, `fsck`, `archive`), any reference to an older revision (`HEAD~`, `HEAD^`, `@{`, a bare SHA), and direct reads under `.git/`. `git status`, `git add`, `git commit`, a bare `git diff`, and `git worktree add` on a branch stay available. Outside a blind run the hook only logs commands and the policy above applies unchanged. Every bash command is logged either way — set `CODEGEN_GUARD_LOG` to keep that log with the run's artifacts.
+**In a blind codegen run, treat git history as unavailable.** Do not read `log`, `show`, `reflog`, `rev-list`, `cat-file`, `blame`, `stash`, `fsck`, or `archive`; do not name an older revision (`HEAD~`, `HEAD^`, `@{`, a bare SHA); do not read under `.git/`. `status`, `add`, `commit`, a bare `diff`, and `worktree add` on a branch stay allowed. If a git command is denied, do not look for another route to the same information.
 
 ## LLK CodeGen System
 

--- a/tt_metal/tt-llk/CLAUDE.md
+++ b/tt_metal/tt-llk/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Read-only git commands are allowed (`git rev-parse`, `git log`, `git status`, `git diff`, `git show`). **NEVER push, commit, checkout, restore, reset, or otherwise modify** the repo via git.
 
+**Blind codegen runs are stricter.** A run that exports `CODEGEN_BLIND_RUN=1` regenerates an implementation that was deliberately hidden, so recovering it from history would invalidate the result. In that mode the `PreToolUse` hook `.claude/hooks/git-guard.sh` denies history reads (`log`, `show`, `reflog`, `rev-list`, `cat-file`, `blame`, `stash`, `fsck`, `archive`), any reference to an older revision (`HEAD~`, `HEAD^`, `@{`, a bare SHA), and direct reads under `.git/`. `git status`, `git add`, `git commit`, a bare `git diff`, and `git worktree add` on a branch stay available. Outside a blind run the hook only logs commands and the policy above applies unchanged. Every bash command is logged either way — set `CODEGEN_GUARD_LOG` to keep that log with the run's artifacts.
+
 ## LLK CodeGen System
 
 To generate kernels for a target architecture, start Claude from the `codegen/` folder:

--- a/tt_metal/tt-llk/codegen/.claude/settings.json
+++ b/tt_metal/tt-llk/codegen/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://json.schemastore.org/claude-code-settings.json",
+    "permissions": {
+        "deny": [
+            "Read(//**/.git/**)",
+            "Read(//localdev/jmacanovic/tt-metal/.git/**)"
+        ]
+    },
+    "hooks": {
+        "PreToolUse": [
+            {
+                "matcher": "Bash",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "\"${CLAUDE_PROJECT_DIR:-.}/../.claude/hooks/git-guard.sh\"",
+                        "timeout": 10,
+                        "statusMessage": "git-guard"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tt_metal/tt-llk/codegen/.claude/settings.json
+++ b/tt_metal/tt-llk/codegen/.claude/settings.json
@@ -2,14 +2,13 @@
     "$schema": "https://json.schemastore.org/claude-code-settings.json",
     "permissions": {
         "deny": [
-            "Read(//**/.git/**)",
-            "Read(//localdev/jmacanovic/tt-metal/.git/**)"
+            "Read(//**/.git/**)"
         ]
     },
     "hooks": {
         "PreToolUse": [
             {
-                "matcher": "Bash",
+                "matcher": "Bash|Write|Edit",
                 "hooks": [
                     {
                         "type": "command",

--- a/tt_metal/tt-llk/codegen/scripts/quasar/orchestrator_steps.sh
+++ b/tt_metal/tt-llk/codegen/scripts/quasar/orchestrator_steps.sh
@@ -403,6 +403,23 @@ execute_step_hide_existing_kernel() {
     # file this run deliberately ignored. Space-separated: every path is repo-relative and
     # space-free.
     ss HIDDEN_FILES "${hidden[*]}"
+
+    # Arm .claude/hooks/git-guard.sh for the rest of this session: from here on it denies
+    # every git-history read, so the implementation just hidden cannot be recovered from the
+    # object store the worktree shares with the parent repo. A marker file is used rather
+    # than an env var because HIDE_EXISTING_KERNEL is decided after Claude has started and a
+    # running process's environment cannot be changed from outside.
+    local _sid
+    _sid="$(sg SESSION_ID 2>/dev/null || echo "")"
+    [ -z "$_sid" ] && _sid="$(python "$_ORCH_SCRIPTS/session_cost.py" --print-session 2>/dev/null | awk '{print $1}')"
+    if [ -n "$_sid" ]; then
+        _disk_guard touch "${TMPDIR:-/tmp}/codegen-blind-run-${_sid}" || return $?
+        ss GUARD_ARMED true --json
+        echo "  git-guard armed (blind mode) for session $_sid"
+    else
+        ss GUARD_ARMED false --json
+        echo "  WARNING: SESSION_ID unresolved — git-guard NOT armed; this run is not blind-safe"
+    fi
     # Guard: a test source left on the branch that #includes a header we just hid makes the
     # run's compile fail in a way no agent can repair — worst under LOCK_TESTS, where the
     # tester may not touch tests. Scan the run's own compile scope (tt-llk tests) and
@@ -1140,6 +1157,20 @@ execute_step_extract_transcripts() {
     python "$S/extract_run_transcripts.py" --log-dir "$_L" \
         ${sid:+--session-id "$sid" --project-cwd "$pcwd"} \
         || echo "extract_run_transcripts: skipped (non-fatal)"
+
+    # Collect the git-guard command log alongside the transcripts, and record how many
+    # commands it denied. GUARD_BLOCKS is the whole audit: 0 means this run never reached
+    # for git history; anything higher names the commands in git-guard.log.
+    local guard_src="${TMPDIR:-/tmp}/codegen-git-guard-${sid}.log" blocks=0
+    if [ -n "$sid" ] && [ -f "$guard_src" ]; then
+        _disk_guard cp "$guard_src" "$_L/git-guard.log" || return $?
+        blocks="$(grep -c $'\tBLOCK\t' "$_L/git-guard.log" 2>/dev/null || echo 0)"
+        rm -f "${TMPDIR:-/tmp}/codegen-blind-run-${sid}"
+        echo "git-guard: $(wc -l < "$_L/git-guard.log") command(s) logged, $blocks blocked"
+    else
+        echo "git-guard: no log for session ${sid:-<unknown>} (hook not active this run)"
+    fi
+    ss GUARD_BLOCKS "$blocks" --json
 }
 
 # ===========================================================================

--- a/tt_metal/tt-llk/codegen/scripts/quasar/orchestrator_steps.sh
+++ b/tt_metal/tt-llk/codegen/scripts/quasar/orchestrator_steps.sh
@@ -370,10 +370,9 @@ execute_step_hide_existing_kernel() {
     local hide; hide="$(sg HIDE_EXISTING_KERNEL 2>/dev/null || echo false)"
     if [ "$hide" != "true" ]; then echo "hide_existing_kernel: not requested — skipping"; return 0; fi
 
-    # Resolve the session id BEFORE touching the repo. .claude/hooks/git-guard.sh is armed by a
-    # marker file keyed on it, so without an id the op can be hidden but its recovery cannot be
-    # blocked — a run that is not blind-safe. Fail here, while the worktree is still pristine,
-    # rather than after the removals have been committed.
+    # Resolve the session id before touching the repo: git-guard is armed by a marker file keyed
+    # on it, so without an id the op can be hidden but its recovery cannot be blocked. Fail while
+    # the worktree is still pristine, rather than after the removals are committed.
     local _sid
     _sid="$(sg SESSION_ID 2>/dev/null || echo "")"
     [ -z "$_sid" ] && _sid="${CLAUDE_CODE_SESSION_ID:-}"
@@ -421,12 +420,10 @@ execute_step_hide_existing_kernel() {
     # space-free.
     ss HIDDEN_FILES "${hidden[*]}"
 
-    # Arm .claude/hooks/git-guard.sh for the rest of this session: from here on it denies
-    # every git-history read, so the implementation just hidden cannot be recovered from the
-    # object store the worktree shares with the parent repo. A marker file is used rather
-    # than an env var because HIDE_EXISTING_KERNEL is decided after Claude has started and a
-    # running process's environment cannot be changed from outside. `_sid` was resolved and
-    # validated at the top of this function, before anything was removed.
+    # Arm git-guard for the rest of this session: from here on it denies every git-history read,
+    # so the implementation just hidden cannot be recovered from the object store the worktree
+    # shares with the parent repo. A marker file rather than an env var, because
+    # HIDE_EXISTING_KERNEL is decided after Claude has started.
     _disk_guard touch "${TMPDIR:-/tmp}/codegen-blind-run-${_sid}" || return $?
     ss GUARD_ARMED true --json
     ss SESSION_ID "$_sid"
@@ -1169,25 +1166,24 @@ execute_step_extract_transcripts() {
         ${sid:+--session-id "$sid" --project-cwd "$pcwd"} \
         || echo "extract_run_transcripts: skipped (non-fatal)"
 
-    # Collect the git-guard command log alongside the transcripts, and record how many
-    # commands it denied. GUARD_BLOCKS carries the audit: 0 means the guard ran and this run
-    # never reached for git history, and anything higher names the commands in git-guard.log.
-    # With no log there is nothing to count, so GUARD_BLOCKS is null — "not measured", which
-    # must stay distinguishable from a measured zero. Reporting 0 there would make an
-    # unenforced run look like a clean one.
+    # Collect the git-guard log alongside the transcripts and record how many commands it
+    # denied. GUARD_BLOCKS=0 means the guard ran and this run never reached for git history;
+    # higher means git-guard.log names the commands. No log means nothing to count, so
+    # GUARD_BLOCKS is null — "not measured" must stay distinguishable from a measured zero, or
+    # an unenforced run looks like a clean one.
     local guard_src="${TMPDIR:-/tmp}/codegen-git-guard-${sid}.log" blocks=null
     if [ -n "$sid" ] && [ -f "$guard_src" ]; then
         _disk_guard cp "$guard_src" "$_L/git-guard.log" || return $?
-        # `grep -c` prints 0 AND exits 1 when nothing matches, so the fallback has to be on
-        # the assignment — `|| echo 0` inside the substitution would append a second zero and
-        # make GUARD_BLOCKS "0\n0", which `ss --json` rejects. Match the tab-delimited verdict
-        # rather than a column index, so the count survives a change to the log's columns.
+        # `grep -c` prints 0 AND exits 1 on no match, so the fallback goes on the assignment —
+        # `|| echo 0` inside the substitution would append a second zero, making GUARD_BLOCKS
+        # "0\n0", which `ss --json` rejects. Match the tab-delimited verdict, not a column
+        # index, so the count survives a change to the log's columns.
         blocks="$(grep -c $'\tBLOCK\t' "$_L/git-guard.log" 2>/dev/null)" || blocks=0
         rm -f "${TMPDIR:-/tmp}/codegen-blind-run-${sid}"
         echo "git-guard: $(wc -l < "$_L/git-guard.log") command(s) logged, $blocks blocked"
     elif [ "$(sg GUARD_ARMED 2>/dev/null || echo false)" = "true" ]; then
         # Armed at hide time but no log at the end: the hook never ran, so the removals went
-        # ahead unenforced. Say so loudly — this run's blindness is unverified.
+        # ahead unenforced.
         echo "  WARNING: git-guard was armed but produced no log for session ${sid:-<unknown>}." >&2
         echo "  The hook did not run, so this run's blindness is UNVERIFIED (GUARD_BLOCKS=null)." >&2
     else

--- a/tt_metal/tt-llk/codegen/scripts/quasar/orchestrator_steps.sh
+++ b/tt_metal/tt-llk/codegen/scripts/quasar/orchestrator_steps.sh
@@ -369,6 +369,23 @@ execute_step_hide_existing_kernel() {
     local _L; _L="$(_LOG)"
     local hide; hide="$(sg HIDE_EXISTING_KERNEL 2>/dev/null || echo false)"
     if [ "$hide" != "true" ]; then echo "hide_existing_kernel: not requested — skipping"; return 0; fi
+
+    # Resolve the session id BEFORE touching the repo. .claude/hooks/git-guard.sh is armed by a
+    # marker file keyed on it, so without an id the op can be hidden but its recovery cannot be
+    # blocked — a run that is not blind-safe. Fail here, while the worktree is still pristine,
+    # rather than after the removals have been committed.
+    local _sid
+    _sid="$(sg SESSION_ID 2>/dev/null || echo "")"
+    [ -z "$_sid" ] && _sid="${CLAUDE_CODE_SESSION_ID:-}"
+    [ -z "$_sid" ] && _sid="$(python "$_ORCH_SCRIPTS/session_cost.py" --print-session 2>/dev/null | awk '{print $1}')"
+    if [ -z "$_sid" ]; then
+        ss GUARD_ARMED false --json
+        echo "  ERROR: SESSION_ID unresolved — git-guard cannot be armed, so a blind run cannot" >&2
+        echo "  be enforced. Nothing was hidden. Set CLAUDE_CODE_SESSION_ID or clear" >&2
+        echo "  HIDE_EXISTING_KERNEL and rerun." >&2
+        return 1
+    fi
+
     local wt kn kt gen; wt="$(_wt)"; kn="$(sg KERNEL_NAME)"; kt="$(sg KERNEL_TYPE)"; gen="$(sg GENERATED_KERNEL)"
     local -a patterns=(); [ -n "$gen" ] && patterns+=("$gen")
     if [ "$kt" = "sfpu" ]; then
@@ -408,18 +425,12 @@ execute_step_hide_existing_kernel() {
     # every git-history read, so the implementation just hidden cannot be recovered from the
     # object store the worktree shares with the parent repo. A marker file is used rather
     # than an env var because HIDE_EXISTING_KERNEL is decided after Claude has started and a
-    # running process's environment cannot be changed from outside.
-    local _sid
-    _sid="$(sg SESSION_ID 2>/dev/null || echo "")"
-    [ -z "$_sid" ] && _sid="$(python "$_ORCH_SCRIPTS/session_cost.py" --print-session 2>/dev/null | awk '{print $1}')"
-    if [ -n "$_sid" ]; then
-        _disk_guard touch "${TMPDIR:-/tmp}/codegen-blind-run-${_sid}" || return $?
-        ss GUARD_ARMED true --json
-        echo "  git-guard armed (blind mode) for session $_sid"
-    else
-        ss GUARD_ARMED false --json
-        echo "  WARNING: SESSION_ID unresolved — git-guard NOT armed; this run is not blind-safe"
-    fi
+    # running process's environment cannot be changed from outside. `_sid` was resolved and
+    # validated at the top of this function, before anything was removed.
+    _disk_guard touch "${TMPDIR:-/tmp}/codegen-blind-run-${_sid}" || return $?
+    ss GUARD_ARMED true --json
+    ss SESSION_ID "$_sid"
+    echo "  git-guard armed (blind mode) for session $_sid"
     # Guard: a test source left on the branch that #includes a header we just hid makes the
     # run's compile fail in a way no agent can repair — worst under LOCK_TESTS, where the
     # tester may not touch tests. Scan the run's own compile scope (tt-llk tests) and
@@ -1159,14 +1170,26 @@ execute_step_extract_transcripts() {
         || echo "extract_run_transcripts: skipped (non-fatal)"
 
     # Collect the git-guard command log alongside the transcripts, and record how many
-    # commands it denied. GUARD_BLOCKS is the whole audit: 0 means this run never reached
-    # for git history; anything higher names the commands in git-guard.log.
-    local guard_src="${TMPDIR:-/tmp}/codegen-git-guard-${sid}.log" blocks=0
+    # commands it denied. GUARD_BLOCKS carries the audit: 0 means the guard ran and this run
+    # never reached for git history, and anything higher names the commands in git-guard.log.
+    # With no log there is nothing to count, so GUARD_BLOCKS is null — "not measured", which
+    # must stay distinguishable from a measured zero. Reporting 0 there would make an
+    # unenforced run look like a clean one.
+    local guard_src="${TMPDIR:-/tmp}/codegen-git-guard-${sid}.log" blocks=null
     if [ -n "$sid" ] && [ -f "$guard_src" ]; then
         _disk_guard cp "$guard_src" "$_L/git-guard.log" || return $?
-        blocks="$(grep -c $'\tBLOCK\t' "$_L/git-guard.log" 2>/dev/null || echo 0)"
+        # `grep -c` prints 0 AND exits 1 when nothing matches, so the fallback has to be on
+        # the assignment — `|| echo 0` inside the substitution would append a second zero and
+        # make GUARD_BLOCKS "0\n0", which `ss --json` rejects. Match the tab-delimited verdict
+        # rather than a column index, so the count survives a change to the log's columns.
+        blocks="$(grep -c $'\tBLOCK\t' "$_L/git-guard.log" 2>/dev/null)" || blocks=0
         rm -f "${TMPDIR:-/tmp}/codegen-blind-run-${sid}"
         echo "git-guard: $(wc -l < "$_L/git-guard.log") command(s) logged, $blocks blocked"
+    elif [ "$(sg GUARD_ARMED 2>/dev/null || echo false)" = "true" ]; then
+        # Armed at hide time but no log at the end: the hook never ran, so the removals went
+        # ahead unenforced. Say so loudly — this run's blindness is unverified.
+        echo "  WARNING: git-guard was armed but produced no log for session ${sid:-<unknown>}." >&2
+        echo "  The hook did not run, so this run's blindness is UNVERIFIED (GUARD_BLOCKS=null)." >&2
     else
         echo "git-guard: no log for session ${sid:-<unknown>} (hook not active this run)"
     fi


### PR DESCRIPTION
### Summary

A blind run (`HIDE_EXISTING_KERNEL`, `REMOVE_TESTS`) deletes the target op's files and
commits that on the worktree branch, so the agent finds nothing at `HEAD`. But a worktree
shares the parent repo's object store, so the deleted code is still reachable —
`git show HEAD~1:<path>`, `git rev-list --all --objects`, or reading `.git/logs/HEAD`
recovers it. The only protection was an instruction in the prompt, and afterwards there
was no way to tell whether a run had looked.

Adds enforcement plus a per-run audit trail:

- **`.claude/hooks/git-guard.sh`** — `PreToolUse` hook on `Bash|Write|Edit`. Logs every
  command with an `OK`/`BLOCK` verdict; in blind mode denies history reads (`log`, `show`,
  `reflog`, `rev-list`, `cat-file`, `blame`, `stash`, `fsck`, `archive`), older-revision
  references (`HEAD~`, `@{`, bare SHA), and any `.git` path. It also scans **written
  scripts**, so a git command cannot be smuggled into a file and then executed.
- **Two `settings.json`** (`codegen/`, `tt-llk/`) — wire the hook and deny
  `Read(//**/.git/**)`, covering the `Read`/`Grep`/`Glob` path the hook cannot see.
- **`orchestrator_steps.sh`** — the hide step arms the guard, and **fails before hiding
  anything** if it cannot; the transcripts step copies the log to `$LOG_DIR/git-guard.log`
  and records `GUARD_BLOCKS` in `state.json`.
- **`tt-llk/CLAUDE.md`** — documents the policy.

Auditing a run is one field:

| `GUARD_BLOCKS` | meaning |
|---|---|
| `0` | the guard ran and the run never reached for history |
| `n` | `n` attempts — named in `git-guard.log` |
| `null` | not measured — **not** evidence of a clean run |

**Default is off.** Outside a blind run the hook only logs, so the router keeps the
read-only git it documents. `git status`/`add`/`commit`, bare `git diff`, and
`git worktree add -b <branch>` stay allowed even in blind mode — the pipeline needs them.

### Notes for reviewers

**Marker file, not an env var.** `HIDE_EXISTING_KERNEL` is chosen after Claude starts, and
you can't change a running process's environment. An `export` in the pipeline wouldn't
survive either — each Bash call is a fresh shell. So the hide step touches
`$TMPDIR/codegen-blind-run-<session-id>` and the hook keys off that.

**Two settings files.** Settings load from the launch directory. Runs launch from
`codegen/`, and `tt-llk/.claude/settings.json` is verifiably not picked up there — the test
command returned `RAN` before `codegen/.claude/settings.json` existed, `BLOCKED` after.

**Threat model.** This stops accidental and casual history access — the failure mode we
actually see. It does not defeat deliberate evasion: a command assembled letter-by-letter,
base64-decoded, or built from concatenated strings passes any text check, wherever that
check lives. Verified, and deliberately not chased — heuristics there buy false confidence
rather than coverage. `GUARD_BLOCKS` and the command log are the durable part, and the
structural fix (a checkout whose history never contained the hidden files) is the only
version that is immune.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jmacanovic/codegen-git-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jmacanovic/codegen-git-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jmacanovic/codegen-git-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jmacanovic/codegen-git-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=jmacanovic/codegen-git-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:jmacanovic/codegen-git-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jmacanovic/codegen-git-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jmacanovic/codegen-git-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jmacanovic/codegen-git-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jmacanovic/codegen-git-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jmacanovic/codegen-git-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jmacanovic/codegen-git-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jmacanovic/codegen-git-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jmacanovic/codegen-git-guard)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jmacanovic/codegen-git-guard)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jmacanovic/codegen-git-guard)