### PR TITLE
docs(llk-contract): one meaning per symbol — × / ∏ product, + / Σ tagged union

### DIFF
--- a/tt_metal/tt-llk/docs/llk-formal-contract.md
+++ b/tt_metal/tt-llk/docs/llk-formal-contract.md
@@ -8,7 +8,7 @@ Neither side is frozen. Where the math and the code disagree today, §7 lists it
 convergence item. The target is that every symbol here maps to one place in the code, and the
 checker tool reads its rules from §5–§6.
 
-Notation: `≜` is "defined as", `∈` is "is an element of", `⨁` joins named fields into a record, `⊥` is unset (as in not
+Notation: `≜` is "defined as", `∈` is "is an element of", `⟨…⟩` is a record literal, `×` / `∏` join fields into a record (product — all fields present at once, a struct), `+` / `Σ` form a tagged union (coproduct — exactly one alternative live, a `std::variant`; "sum" here means one term is selected, not arithmetic addition), `⊥` is unset (as in not
 touched by the Sanitizer, not a HW reset value).
 
 ---
@@ -41,7 +41,7 @@ S ≜ ⟨ s_U, s_F, s_S, s_P ; Γ ⟩           // struct State [operation.h]
 ```
 
 `Γ` is the global `UnwindContext unwind`. It holds source locations, not contract state.
-We can restate this as `S = Σᵢ sᵢ + Γ`, where `i ∈ I`.
+We can restate this as `S = ∏ᵢ sᵢ × Γ`, where `i ∈ I` (a product — all four per-EXU states and `Γ` are present at once).
 
 ### 2.2 Per-EXU state `sᵢ`  (`ExuState<i>`, types.h)
 
@@ -63,13 +63,13 @@ Live operation record:
 Therefore:
 
 ```
-sᵢ  =  ρᵢ  +  yᵢ  +  Σ_{j∈Ωᵢ} x̂ⱼ
+sᵢ  =  ρᵢ  ×  yᵢ  ×  Σ_{j∈Ωᵢ} x̂ⱼ
 ```
 
 
-An important distinction here is that `ρᵢ` is needed for FSM check, while the other terms are required for the operand check. If we're only interested in operand check, we can simplify the previous expression to `sᵢ = Σⱼ x̂ⱼ + yᵢ`, where `Σ` is a tagged union, not a sum, and `yᵢ`.
+An important distinction here is that `ρᵢ` is needed for FSM check, while the other terms are required for the operand check. If we're only interested in operand check, we can simplify the previous expression to `sᵢ = Σⱼ x̂ⱼ × yᵢ`: `Σⱼ x̂ⱼ` is the tagged union over operations (one term live) and `× yᵢ` joins in the shared operand record.
 
-`⨁` (your `Σ`) is a tagged union: at runtime one term is live. That live term is `ωᵢ`, or
+`Σⱼ x̂ⱼ` is the tagged union: at runtime one term is live. That live term is `ωᵢ`, or
 `∅` before the first `init`. `yᵢ` is shared by all operations of the EXU, so it sits once in
 `sᵢ` and once as the snapshot `y'ⱼ` inside each `x̂ⱼ`. This is the `std::variant` (one live
 alternative) plus the single `Operand<i>::Struct` in `ExuState`.
@@ -118,7 +118,7 @@ x̂ⱼ ≜ ⟨ σⱼ , xⱼ , y'ⱼ ⟩
 | `xⱼ` | `G::Struct state` | the operation's own fields (§2.6) |
 | `y'ⱼ` | `Operand<i>::Struct snap` | operand snapshot = `maskⱼ(yᵢ)` |
 
-Your `x̂ⱼ = xⱼ + y'ⱼ` leaves out `σⱼ`. Use `x̂ⱼ = σⱼ ⊕ xⱼ ⊕ y'ⱼ`.
+Your `x̂ⱼ = xⱼ × y'ⱼ` leaves out `σⱼ`. Use `x̂ⱼ = σⱼ × xⱼ × y'ⱼ` (a record — all three present).
 
 **Mask.** `maskⱼ` is the `known` bits of `snap`. `init` snapshots only the operand fields the
 hook restated; the rest stay `⊥`. So `y'ⱼ` is a partial view of `yᵢ`: the fields operation `j`


### PR DESCRIPTION
## Why

`⨁` was defined **two contradictory ways** in the contract:

- Notation line: *"`⨁` joins named fields into a record"* → a **product** (all fields present).
- §2.2: *"`⨁` (your `Σ`) is a tagged union"* → a **sum / coproduct** (one alternative live).

Both can't hold. On top of that, `Σ` and `+` were each used for *both* product and sum in different spots (e.g. `S = Σᵢ sᵢ + Γ` is a product; `Σⱼ x̂ⱼ` is a union), and §2.5 used `⊕` for a product.

## Decision

One symbol family per concept:

```
PRODUCT (record / struct — all fields present at once):   ×  (binary)   ∏  (n-ary)   ⟨…⟩ (literal)
SUM     (tagged union / coproduct — one alternative live): +  (binary)   Σ  (n-ary)
```

`⨁` and `⊕` are retired. `Σ`/`+` now *always* mean the tagged union (std::variant); `×`/`∏` always mean the record join (struct).

## Changes (6 spots)

| # | where | before | after |
|---|-------|--------|-------|
| 1 | Notation | `⨁` joins named fields into a record | full ×/∏ vs +/Σ legend + `⟨…⟩` |
| 2 | §2.1 | `S = Σᵢ sᵢ + Γ` | `S = ∏ᵢ sᵢ × Γ` |
| 3 | §2.2 | `sᵢ = ρᵢ + yᵢ + Σ_{j} x̂ⱼ` | `sᵢ = ρᵢ × yᵢ × Σ_{j} x̂ⱼ` |
| 4 | §2.2 | `sᵢ = Σⱼ x̂ⱼ + yᵢ` (+ "tagged union, not a sum" caveat) | `sᵢ = Σⱼ x̂ⱼ × yᵢ`, caveat folded into notation |
| 5 | §2.2 | ``⨁` (your `Σ`) is a tagged union` | ``Σⱼ x̂ⱼ` is the tagged union` |
| 6 | §2.5 | `x̂ⱼ = σⱼ ⊕ xⱼ ⊕ y'ⱼ` | `x̂ⱼ = σⱼ × xⱼ × y'ⱼ` |

Semantics unchanged — this is purely notation reconciliation. Targets the WIP branch `ncvetkovic/contract_and_more`, **not** main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/contract-notation-sum-product)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/contract-notation-sum-product)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/contract-notation-sum-product)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/contract-notation-sum-product)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ncvetkovic/contract-notation-sum-product)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ncvetkovic/contract-notation-sum-product)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/contract-notation-sum-product)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/contract-notation-sum-product)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/contract-notation-sum-product)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/contract-notation-sum-product)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/contract-notation-sum-product)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/contract-notation-sum-product)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/contract-notation-sum-product)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/contract-notation-sum-product)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/contract-notation-sum-product)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/contract-notation-sum-product)