### PR TITLE
[Test Only] prune the reduce test grid and re-enable test_reduction.py on ttsim

### DIFF
--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -30,10 +30,6 @@ wormhole_b0:
   # Likely OOM killer related failures -- probably need to run these tests serially
   - tests/ttnn/unit_tests/base_functionality/test_reshape.py::test_reshape_oob
 
-  # Numeric mismatches, not root caused
-  # https://github.com/tenstorrent/tt-metal/issues/41530
-  - tests/ttnn/unit_tests/operations/reduce/test_reduction.py
-
 blackhole:
   # Job-level timeouts
   - tests/ttnn/unit_tests/operations/conv/test_conv2d.py
@@ -61,7 +57,3 @@ blackhole:
   # ZEROACC failures
   # https://github.com/tenstorrent/ttsim-private/issues/326
   - tests/ttnn/unit_tests/operations/eltwise/test_broadcast_to.py
-
-  # Numeric mismatches, not root caused
-  # https://github.com/tenstorrent/tt-metal/issues/41530
-  - tests/ttnn/unit_tests/operations/reduce/test_reduction.py

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 
 import ttnn
-from models.common.utility_functions import comp_allclose_and_pcc, is_blackhole, torch_random
+from models.common.utility_functions import comp_allclose_and_pcc, torch_random
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
 
 TEST_PADDING_VALUE = -42
@@ -193,7 +193,10 @@ def test_var_fp32_doscale_wt_gt_1(device, scalar, N):
 
 
 @pytest.mark.parametrize("correction", [False, True])
-@pytest.mark.parametrize("width", [16385, 131072], ids=["partial_tree_leaf", "deep_tree"])
+# 10529 = 32 * 329 + 1: partial tail leaf, 8 carry levels, and 3 cross-level finalize_tree
+# merges, which neither 16385 (512 leaves) nor 131072 (4096 leaves) exercised, since both had a
+# single-bit leaf count. Detects a re-widened centered-moment block by ~43x the 1% tolerance.
+@pytest.mark.parametrize("width", [10529], ids=["partial_leaf_uneven_tree"])
 @pytest.mark.parametrize("torch_dtype,ttnn_dtype", [(torch.bfloat16, ttnn.bfloat16), (torch.float32, ttnn.float32)])
 def test_std_var_wide_low_variance(device, torch_dtype, ttnn_dtype, width, correction):
     # The HW writer combines one equal-count partial per column. For sufficiently
@@ -456,17 +459,24 @@ def test_sum_4d_tensor_dims(device, batch_size, c, h, w, dim, keepdim):
 
 
 @pytest.mark.parametrize("dim1", [1])
-# This test picks the maximum dim2 that will pick the singlecore implementation.
-# TopK multicore uses 8 cores in blackhole, so we need to add support for bitonic sort with 8 cores
-# and non power of 2 dims as compared to wormhole. Issue #23465.
-@pytest.mark.parametrize(
-    "dim2",
-    [8192 - 64, pytest.param(50257, marks=pytest.mark.xfail(condition=is_blackhole(), reason="Issue #23465"))],
-)
 @pytest.mark.parametrize("dim", [1])
-@pytest.mark.parametrize("k", [50, 3200])
 @pytest.mark.parametrize("largest", [True])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+# One case per distinct code path, instead of the (dim2 x k x dtype) product:
+#   (8192,   50) width is a power of 2 and >= multi_core_min_width, and adjusted_k=64 <= 64, so
+#                this is the only case here that reaches the multi-core program factory
+#   (50257,  50) width is not a multiple of 32 -> implicit padding in the last tile (GPT-2 vocab)
+#   (8192, 1024) k > 64 -> single-core, and Kt=32 exercises the multi-tile-k merge ramp
+#   bfloat8_b is paired with the large-k case: bfp8 unpack/pack reconfig plus the bfp8 L1 sizing
+#                path, which only matters when Kt is large
+@pytest.mark.parametrize(
+    "dim2, k, dtype",
+    [
+        (8192, 50, ttnn.bfloat16),
+        (50257, 50, ttnn.bfloat16),
+        (8192, 1024, ttnn.bfloat16),
+        (8192, 1024, ttnn.bfloat8_b),
+    ],
+)
 def test_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
     torch.manual_seed(2005)
     shape = [dim1, dim2]
@@ -530,7 +540,9 @@ def test_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
 
 
 @pytest.mark.parametrize("dim1", [1])
-@pytest.mark.parametrize("dim2", [128256, 151936])
+# 128256 (Llama-3 vocab) carries the UInt32 index / 32-bit-dest branch. 151936 (Qwen) takes the
+# same path and is 18% wider, and it is still covered by tests/.../reduce/test_topk.py.
+@pytest.mark.parametrize("dim2", [128256])
 @pytest.mark.parametrize("dim", [1])
 @pytest.mark.parametrize("k", [50])
 @pytest.mark.parametrize("largest", [True])
@@ -592,10 +604,19 @@ def test_large_2d_topk(device, dim1, dim2, dim, k, largest, dtype):
 @pytest.mark.parametrize("dim3", [8])
 @pytest.mark.parametrize("dim4", [256])
 @pytest.mark.parametrize("dim5", [64])
-@pytest.mark.parametrize("dim", [3, 4])
-@pytest.mark.parametrize("k", [17, 32, 64])
 @pytest.mark.parametrize("largest", [True])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+# k=17 -> adjusted_k=32 plus the host-side slice, k=32 -> no slice, k=64 -> Kt=2.
+# dim=4 is the last dim (no transpose), dim=3 takes the transpose/transpose-back path.
+# dtype is orthogonal to both, so it is varied across the cases rather than crossed with them.
+@pytest.mark.parametrize(
+    "dim, k, dtype",
+    [
+        (4, 17, ttnn.bfloat16),
+        (4, 64, ttnn.bfloat8_b),
+        (3, 32, ttnn.bfloat16),
+        (3, 64, ttnn.bfloat8_b),
+    ],
+)
 def test_5d_topk(device, dim1, dim2, dim3, dim4, dim5, dim, k, largest, dtype):
     torch.manual_seed(2005)
     shape = [dim1, dim2, dim3, dim4, dim5]
@@ -665,10 +686,15 @@ def test_5d_topk(device, dim1, dim2, dim3, dim4, dim5, dim, k, largest, dtype):
 @pytest.mark.parametrize("dim5", [128])
 @pytest.mark.parametrize("dim6", [64])
 # @pytest.mark.parametrize("dim", [0, 1, 2, 3, 4, 5]) transpose cannot handle N-D tensor for all dims
-@pytest.mark.parametrize("dim", [4, 5])
-@pytest.mark.parametrize("k", [50, 64])
 @pytest.mark.parametrize("largest", [True])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.bfloat8_b])
+@pytest.mark.parametrize(
+    "dim, k, dtype",
+    [
+        (5, 50, ttnn.bfloat16),
+        (5, 64, ttnn.bfloat8_b),
+        (4, 50, ttnn.bfloat16),
+    ],
+)
 def test_6d_topk(device, dim1, dim2, dim3, dim4, dim5, dim6, dim, k, largest, dtype):
     torch.manual_seed(2005)
     shape = [dim1, dim2, dim3, dim4, dim5, dim6]


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Relates to #41530.

`tests/ttnn/unit_tests/operations/reduce/test_reduction.py` parametrization has a handful of shapes that dominate runtime. On the Blackhole simulator, `test_2d_topk[dim2=50257-k=3200]` costs 66-69 min **per case** (two of them), and the four `width=131072` welford cases cost 14-19 min each. The file is currently deselected on ttsim for that reason.

This replaces the test parameters products with one case per distinct code path:

| Test | Before | After |
|---|---|---|
| `test_2d_topk` | 2 dim2 x 2 k x 2 dtype = 8 | 4 explicit cases |
| `test_large_2d_topk` | 128256, 151936 | 128256 |
| `test_std_var_wide_low_variance` | width 16385, 131072 | width 10529 |
| `test_5d_topk` | 12 | 4 |
| `test_6d_topk` | 8 | 3 |

Measured, **412 passed / 24 skipped / 0 failed** in every configuration:

| | before | after |
|---|---|---|
| Blackhole ttsim, `-n 8` | 1:18:16 | **7:00** |
| Wormhole ttsim, `-n 8` | 48:50 | **4:27** |
| Blackhole silicon (p100a) | 6:53 | **2:01** |
| slowest single test (BH ttsim) | 69 min | **3.2 min** |

Since the runtime is decreased, the file is dropped from `ttsim-skip-list.yaml`, which will also close #41530.

### Notes for reviewers
**Coverage actually goes up for topk.** Multi-core topk requires a power-of-two width and every width in this file today (8128, 50257, 128256, 151936) is non-power-of-two — so all topk cases currently run single-core. The new `(8192, k=50)` case is the only one that reaches the multi-core factory.

**What is dropped:**
- `(50257, k=3200)`: a non-multiple-of-32 width with large k. No code branch is unique to that intersection. The padding branch is still carried by `(50257, k=50)`
- `151936`: same path as 128256, still covered in `reduce/test_topk.py`
- `test_5d_topk`/`test_6d_topk`: dtype crossed with the transpose axis and with k. dtype only selects CB formats and reconfig calls, it's now varied across cases rather than multiplied.

`is_blackhole` is dropped from the imports since the removed xfail was its only use.

**On re-enabling the file on ttsim:** with these grids the slowest test is 3.2 min and the whole `ttnn reduce group` should land around 30 min against its 40 min budget, based on a local estimate.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/reduce-test-grid-prune)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/reduce-test-grid-prune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/reduce-test-grid-prune)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/reduce-test-grid-prune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/reduce-test-grid-prune)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/reduce-test-grid-prune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/reduce-test-grid-prune)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/reduce-test-grid-prune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/reduce-test-grid-prune)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/reduce-test-grid-prune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/reduce-test-grid-prune)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/reduce-test-grid-prune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/reduce-test-grid-prune)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/reduce-test-grid-prune)