### PR TITLE
[Bug fix] ttnn.pow(0, p) returns 2^(-127p) instead of 0 (#51468)

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_pow.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_pow.py
@@ -249,6 +249,74 @@ def test_special_input_fp32(device):
 
 
 @pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
+def test_pow_zero_base_special_cases(device, dtype):
+    # Needs its own inputs: the shared generators strip ±0 before any caller sees them.
+    # Asserts exact equality, not allclose — a regressed 2**(-127p) is ~7.7e-20 at p=0.5,
+    # well inside any absolute tolerance this file uses elsewhere.
+    torch_dtype = getattr(torch, dtype)
+    ttnn_dtype = getattr(ttnn, dtype)
+    shape = [1, 1, 32, 32]
+    positive_exponents = (1e-4, 0.01, 0.25, 0.5, 1.0 / 3.0, 0.75, 0.99, 1.5, 3.0, 4.0)
+
+    def assert_zero_power_undefined(out):
+        if dtype == "float32":
+            assert torch.isnan(out).all()
+        else:
+            # bf16 dest reads back as inf rather than the NaN the kernel writes
+            # (tenstorrent/tt-llk#675), so only non-finiteness is assertable here.
+            assert (~torch.isfinite(out)).all()
+
+    for exponent in positive_exponents:
+        exp_t = torch.full(shape, exponent, dtype=torch_dtype)
+        tt_exp = ttnn.from_torch(exp_t, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+        # rpow scalar base is always +0; one run per exponent covers that kernel.
+        rpow_out = ttnn.to_torch(ttnn.rpow(tt_exp, 0.0))
+        assert torch.equal(
+            rpow_out, torch.zeros_like(rpow_out)
+        ), f"rpow({exponent}, 0.0) = {rpow_out.flatten()[0].item()}"
+
+        for base_val in (0.0, -0.0):
+            zeros = torch.full(shape, base_val, dtype=torch_dtype)
+            tt_zeros = ttnn.from_torch(zeros, dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+            unary_out = ttnn.to_torch(ttnn.pow(tt_zeros, exponent))
+            assert torch.equal(
+                unary_out, torch.zeros_like(unary_out)
+            ), f"unary pow({base_val}, {exponent}) = {unary_out.flatten()[0].item()}"
+
+            binary_out = ttnn.to_torch(ttnn.pow(tt_zeros, tt_exp))
+            assert torch.equal(
+                binary_out, torch.zeros_like(binary_out)
+            ), f"binary pow({base_val}, {exponent}) = {binary_out.flatten()[0].item()}"
+
+    tt_zeros = ttnn.from_torch(
+        torch.zeros(shape, dtype=torch_dtype), dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device
+    )
+    # Scalar 0.0 is an integer exponent → power_iterative, not the SFPU kernel.
+    unary_zero_exp = ttnn.to_torch(ttnn.pow(tt_zeros, 0.0))
+    assert torch.equal(unary_zero_exp, torch.ones_like(unary_zero_exp))
+
+    tt_zero_exp = ttnn.from_torch(
+        torch.zeros(shape, dtype=torch_dtype), dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device
+    )
+    binary_zero_exp = ttnn.to_torch(ttnn.pow(tt_zeros, tt_zero_exp))
+    assert torch.equal(binary_zero_exp, torch.ones_like(binary_zero_exp))
+
+    unary_neg = ttnn.to_torch(ttnn.pow(tt_zeros, -1.5))
+    assert_zero_power_undefined(unary_neg)
+
+    tt_neg_zero = ttnn.from_torch(
+        torch.full(shape, -0.0, dtype=torch_dtype), dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device
+    )
+    tt_neg_exp = ttnn.from_torch(
+        torch.full(shape, -1.5, dtype=torch_dtype), dtype=ttnn_dtype, layout=ttnn.TILE_LAYOUT, device=device
+    )
+    binary_neg = ttnn.to_torch(ttnn.pow(tt_zeros, tt_neg_exp))
+    binary_neg_zero = ttnn.to_torch(ttnn.pow(tt_neg_zero, tt_neg_exp))
+    assert_zero_power_undefined(binary_neg)
+    assert_zero_power_undefined(binary_neg_zero)
+
+
+@pytest.mark.parametrize("dtype", ["float32", "bfloat16"])
 def test_pow_determinism(device, dtype):
     torch.manual_seed(0)
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -31,6 +31,7 @@ namespace sfpu {
  * @return sfpi::vFloat Result of base**pow
  *
  * Special Cases:
+ * - base = 0, pow > 0: Returns 0
  * - base = 0, pow < 0: Returns NaN (undefined)
  * - base < 0, pow = integer: Returns proper signed result (negative if odd power)
  * - base < 0, pow = non-integer: Returns NaN (complex result)
@@ -119,12 +120,6 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat
         pow, sfpi::RoundMode::Nearest);  // int16 should be plenty, since large powers will approach 0/Inf
     auto pow_rounded = sfpi::convert<sfpi::vFloat>(pow_int, sfpi::RoundMode::Nearest);
 
-    // Division by 0 when base is 0 and pow is negative => set to NaN
-    v_if((absbase == 0.f) && pow < 0.f) {
-        y = std::numeric_limits<float>::quiet_NaN();  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
-    }
-    v_endif;
-
     v_if(base < 0.0f) {  // negative base
         // If pow is odd integer then result is negative
         // If power is even, then result is positive
@@ -132,6 +127,24 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat
 
         // Check for integer power, if it is not then overwrite result with NaN
         v_if(pow_rounded != pow) {  // negative base and non-integer power => set to NaN
+            y = std::numeric_limits<float>::quiet_NaN();
+        }
+        v_endif;
+    }
+    v_endif;
+
+    // setexp/exexp map 0 to log2 = -127, so 0**p evaluates as 2**(-127p).
+    // Must follow the negative-base branch: SFPU `<` is sign-bit based, so
+    // v_if(base < 0) classes -0 as negative and would overwrite the 0 with the
+    // complex-result NaN; -0 is a zero, not a negative base.
+    // Fill 0 for every non-zero exponent, then narrow to the negative ones.
+    // v_and tightens the enclosing predicate in place, so it costs one compare
+    // where a second flat v_if would also save and restore the lane mask.
+    // pow == 0 fails the != 0 gate and keeps 1.
+    v_if(absbase == 0.f) {
+        v_if(pow != 0.f) {
+            y = 0.0f;
+            v_and(pow < 0.f);
             y = std::numeric_limits<float>::quiet_NaN();
         }
         v_endif;
@@ -251,12 +264,6 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_f32_(sfpi::vFloat base, sfpi::vFloat
     v_if(out_exp >= 255) { y = std::numeric_limits<float>::infinity(); }
     v_endif;
 
-    // Division by 0 when base is 0 and pow is negative => set to NaN (only for negative exponents)
-    v_if(base == 0.f && pow < 0.f) {
-        y = std::numeric_limits<float>::quiet_NaN();  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
-    }
-    v_endif;
-
     v_if(base < 0.0f) {  // negative base
         // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
         // Check valid base range
@@ -271,6 +278,28 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_f32_(sfpi::vFloat base, sfpi::vFloat
 
         // Check for integer power, if it is not then overwrite result with NaN
         v_if(pow_rounded != pow) {  // negative base and non-integer power => set to NaN
+            y = std::numeric_limits<float>::quiet_NaN();
+        }
+        v_endif;
+    }
+    v_endif;
+
+    // setexp/exexp map 0 to log2 = -127, so 0**p evaluates as 2**(-127p).
+    // Must follow the negative-base branch: SFPU `<` is sign-bit based, so
+    // v_if(base < 0) classes -0 as negative and would overwrite the 0 with the
+    // complex-result NaN; -0 is a zero, not a negative base.
+    // SFPU `== 0` is bit-exact, so matching -0 needs an abs. Recompute it here
+    // rather than reusing abs_base: that live range would span the log2/exp2 body
+    // and spills this kernel.
+    // Fill 0 for every non-zero exponent, then narrow to the negative ones.
+    // v_and tightens the enclosing predicate in place, so it costs one compare
+    // where a second flat v_if would also save and restore the lane mask.
+    // pow == 0 fails the != 0 gate and keeps 1.
+    sfpi::vFloat abs_end = sfpi::abs(base);
+    v_if(abs_end == 0.f) {
+        v_if(pow != 0.f) {
+            y = 0.0f;
+            v_and(pow < 0.f);
             y = std::numeric_limits<float>::quiet_NaN();
         }
         v_endif;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -25,11 +25,12 @@ namespace sfpu {
  *
  * @param base The base value (sfpi::vFloat vector), can be any floating point number
  * @param pow The exponent/power value (sfpi::vFloat vector), can be any floating point number
- * @tparam IS_POSITIVE_EXPONENT If true, assumes exponent >= 0 (skips zero-base check for optimization)
+ * @tparam IS_POSITIVE_EXPONENT If true, assumes exponent >= 0 (zero base maps to 0 rather than NaN)
  *
  * @return sfpi::vFloat Result of base**pow
  *
  * Special Cases:
+ * - base = 0, pow > 0: Returns 0
  * - base = 0, pow < 0: Returns NaN (undefined)
  * - base < 0, pow = integer: Returns proper signed result (negative if odd power)
  * - base < 0, pow = non-integer: Returns NaN (complex result)
@@ -112,14 +113,6 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
 
     sfpi::vFloat y = sfpi::as<sfpi::vFloat>(zii);
 
-    // Division by 0 when base is 0 and pow is negative => set to NaN (only for negative exponents)
-    if constexpr (!IS_POSITIVE_EXPONENT) {
-        v_if(abs_base == 0.f) {
-            y = sfpi::vConstFloatPrgm2;  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
-        }
-        v_endif;
-    }
-
     // Negative base handling (for both positive and negative exponents)
     v_if(base < 0.0f) {
         // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
@@ -139,6 +132,20 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
         v_endif;
     }
     v_endif;
+
+    // setexp/exexp map 0 to log2 = -127, so 0**p evaluates as 2**(-127p).
+    // Must follow the sign branch: SFPU `<` is sign-bit based, so v_if(base < 0)
+    // fires on -0 and would replace the 0 result with NaN for non-integer p.
+    // pow == 0 falls through the guard and keeps 1.
+    if constexpr (IS_POSITIVE_EXPONENT) {
+        v_if(abs_base == 0.f && pow > 0.f) { y = 0.0f; }
+        v_endif;
+    } else {
+        v_if(abs_base == 0.f) {
+            y = sfpi::vConstFloatPrgm2;  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
+        }
+        v_endif;
+    }
 
     // LRegs work on float32 data. If DST is bfloat16 then SFPSTORE will truncate it.
     // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
@@ -287,14 +294,6 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
     sfpi::vFloat z_lo = pow_lo * exp_f32 + pow * (ln_m * vConst1Ln2);
     sfpi::vFloat y = _sfpu_pow2_f32_accurate_hilo_(z_hi, z_lo);
 
-    // Division by 0 when base is 0 and pow is negative => set to NaN (only for negative exponents)
-    if constexpr (!IS_POSITIVE_EXPONENT) {
-        v_if(abs_base == 0.f) {
-            y = sfpi::vConstFloatPrgm2;  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
-        }
-        v_endif;
-    }
-
     v_if(base < 0.0f) {  // negative base
         // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
         // Check valid base range
@@ -314,6 +313,20 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
         v_endif;
     }
     v_endif;
+
+    // setexp/exexp map 0 to log2 = -127, so 0**p evaluates as 2**(-127p).
+    // Must follow the sign branch: SFPU `<` is sign-bit based, so v_if(base < 0)
+    // fires on -0 and would replace the 0 result with NaN for non-integer p.
+    // pow == 0 falls through the guard and keeps 1.
+    if constexpr (IS_POSITIVE_EXPONENT) {
+        v_if(abs_base == 0.f && pow > 0.f) { y = 0.0f; }
+        v_endif;
+    } else {
+        v_if(abs_base == 0.f) {
+            y = sfpi::vConstFloatPrgm2;  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
+        }
+        v_endif;
+    }
 
     return y;
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -31,6 +31,7 @@ namespace sfpu {
  * @return sfpi::vFloat Result of base**pow
  *
  * Special Cases:
+ * - base = 0, pow > 0: Returns 0
  * - base = 0, pow < 0: Returns NaN (undefined)
  * - base < 0, pow = integer: Returns proper signed result (negative if odd power)
  * - base < 0, pow = non-integer: Returns NaN (complex result)
@@ -119,12 +120,6 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat
         pow, sfpi::RoundMode::Nearest);  // int16 should be plenty, since large powers will approach 0/Inf
     auto pow_rounded = sfpi::convert<sfpi::vFloat>(pow_int, sfpi::RoundMode::Nearest);
 
-    // Division by 0 when base is 0 and pow is negative => set to NaN
-    v_if((absbase == 0.f) && pow < 0.f) {
-        y = std::numeric_limits<float>::quiet_NaN();  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
-    }
-    v_endif;
-
     v_if(base < 0.0f) {  // negative base
         // If pow is odd integer then result is negative
         // If power is even, then result is positive
@@ -133,6 +128,24 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat
 
         // Check for integer power, if it is not then overwrite result with NaN
         v_if(pow_rounded != pow) {  // negative base and non-integer power => set to NaN
+            y = std::numeric_limits<float>::quiet_NaN();
+        }
+        v_endif;
+    }
+    v_endif;
+
+    // setexp/exexp map 0 to log2 = -127, so 0**p evaluates as 2**(-127p).
+    // Must follow the negative-base branch: SFPU `<` is sign-bit based, so
+    // v_if(base < 0) classes -0 as negative and would overwrite the 0 with the
+    // complex-result NaN; -0 is a zero, not a negative base.
+    // Fill 0 for every non-zero exponent, then narrow to the negative ones.
+    // v_and tightens the enclosing predicate in place, so it costs one compare
+    // where a second flat v_if would also save and restore the lane mask.
+    // pow == 0 fails the != 0 gate and keeps 1.
+    v_if(absbase == 0.f) {
+        v_if(pow != 0.f) {
+            y = 0.0f;
+            v_and(pow < 0.f);
             y = std::numeric_limits<float>::quiet_NaN();
         }
         v_endif;
@@ -252,12 +265,6 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_f32_(sfpi::vFloat base, sfpi::vFloat
     v_if(out_exp >= 255) { y = std::numeric_limits<float>::infinity(); }
     v_endif;
 
-    // Division by 0 when base is 0 and pow is negative => set to NaN (only for negative exponents)
-    v_if(base == 0.f && pow < 0.f) {
-        y = std::numeric_limits<float>::quiet_NaN();  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
-    }
-    v_endif;
-
     v_if(base < 0.0f) {  // negative base
         // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
         // Check valid base range
@@ -271,6 +278,28 @@ sfpi_inline sfpi::vFloat _sfpu_binary_power_f32_(sfpi::vFloat base, sfpi::vFloat
 
         // Check for integer power, if it is not then overwrite result with NaN
         v_if(pow_rounded != pow) {  // negative base and non-integer power => set to NaN
+            y = std::numeric_limits<float>::quiet_NaN();
+        }
+        v_endif;
+    }
+    v_endif;
+
+    // setexp/exexp map 0 to log2 = -127, so 0**p evaluates as 2**(-127p).
+    // Must follow the negative-base branch: SFPU `<` is sign-bit based, so
+    // v_if(base < 0) classes -0 as negative and would overwrite the 0 with the
+    // complex-result NaN; -0 is a zero, not a negative base.
+    // SFPU `== 0` is bit-exact, so matching -0 needs an abs. Recompute it here
+    // rather than reusing abs_base: that live range would span the log2/exp2 body
+    // and spills this kernel.
+    // Fill 0 for every non-zero exponent, then narrow to the negative ones.
+    // v_and tightens the enclosing predicate in place, so it costs one compare
+    // where a second flat v_if would also save and restore the lane mask.
+    // pow == 0 fails the != 0 gate and keeps 1.
+    sfpi::vFloat abs_end = sfpi::abs(base);
+    v_if(abs_end == 0.f) {
+        v_if(pow != 0.f) {
+            y = 0.0f;
+            v_and(pow < 0.f);
             y = std::numeric_limits<float>::quiet_NaN();
         }
         v_endif;

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -27,11 +27,12 @@ namespace sfpu {
  *
  * @param base The base value (sfpi::vFloat vector), can be any floating point number
  * @param pow The exponent/power value (sfpi::vFloat vector), can be any floating point number
- * @tparam IS_POSITIVE_EXPONENT If true, assumes exponent >= 0 (skips zero-base check for optimization)
+ * @tparam IS_POSITIVE_EXPONENT If true, assumes exponent >= 0 (zero base maps to 0 rather than NaN)
  *
  * @return sfpi::vFloat Result of base**pow
  *
  * Special Cases:
+ * - base = 0, pow > 0: Returns 0
  * - base = 0, pow < 0: Returns NaN (undefined)
  * - base < 0, pow = integer: Returns proper signed result (negative if odd power)
  * - base < 0, pow = non-integer: Returns NaN (complex result)
@@ -114,14 +115,6 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
 
     sfpi::vFloat y = sfpi::as<sfpi::vFloat>(zii);
 
-    // Division by 0 when base is 0 and pow is negative => set to NaN (only for negative exponents)
-    if constexpr (!IS_POSITIVE_EXPONENT) {
-        v_if(abs_base == 0.f) {
-            y = sfpi::vConstFloatPrgm2;  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
-        }
-        v_endif;
-    }
-
     // Negative base handling (for both positive and negative exponents)
     v_if(base < 0.0f) {
         // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
@@ -142,6 +135,20 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat 
         v_endif;
     }
     v_endif;
+
+    // setexp/exexp map 0 to log2 = -127, so 0**p evaluates as 2**(-127p).
+    // Must follow the sign branch: SFPU `<` is sign-bit based, so v_if(base < 0)
+    // fires on -0 and would replace the 0 result with NaN for non-integer p.
+    // pow == 0 falls through the guard and keeps 1.
+    if constexpr (IS_POSITIVE_EXPONENT) {
+        v_if(abs_base == 0.f && pow > 0.f) { y = 0.0f; }
+        v_endif;
+    } else {
+        v_if(abs_base == 0.f) {
+            y = sfpi::vConstFloatPrgm2;  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
+        }
+        v_endif;
+    }
 
     // LRegs work on float32 data. If DST is bfloat16 then SFPSTORE will truncate it.
     // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
@@ -295,14 +302,6 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
     sfpi::vFloat z_lo = pow_lo * exp_f32 + pow * (ln_m * vConst1Ln2);
     sfpi::vFloat y = _sfpu_pow2_f32_accurate_hilo_(z_hi, z_lo);
 
-    // Division by 0 when base is 0 and pow is negative => set to NaN (only for negative exponents)
-    if constexpr (!IS_POSITIVE_EXPONENT) {
-        v_if(abs_base == 0.f) {
-            y = sfpi::vConstFloatPrgm2;  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
-        }
-        v_endif;
-    }
-
     v_if(base < 0.0f) {  // negative base
         // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
         // Check valid base range
@@ -322,6 +321,20 @@ sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base
         v_endif;
     }
     v_endif;
+
+    // setexp/exexp map 0 to log2 = -127, so 0**p evaluates as 2**(-127p).
+    // Must follow the sign branch: SFPU `<` is sign-bit based, so v_if(base < 0)
+    // fires on -0 and would replace the 0 result with NaN for non-integer p.
+    // pow == 0 falls through the guard and keeps 1.
+    if constexpr (IS_POSITIVE_EXPONENT) {
+        v_if(abs_base == 0.f && pow > 0.f) { y = 0.0f; }
+        v_endif;
+    } else {
+        v_if(abs_base == 0.f) {
+            y = sfpi::vConstFloatPrgm2;  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
+        }
+        v_endif;
+    }
 
     return y;
 }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fixes #51468. `setexp`/`exexp` map `log2(0)` to `-127`, so `ttnn.pow(0, p)` returned `2**(-127p)` for every `p`. `2**(-127p)` is a normal float only for `p < 126/127 ≈ 0.992`, so small exponents return visibly wrong values (`pow(0, 0.5)` = `7.67e-20`) while larger ones underflow and flush to `0` — which is why `pow(t, 4)` always looked correct and `pow(t, 0.5)` did not. The zero-base guard only covered `pow < 0 → NaN`.

Unary and binary SFPU kernels (WH + BH) now fill `±0 ** p>0 → +0`, after the sign branch. `rpow` inherits the binary kernel. `0**0 → 1` unchanged. `0**negative` stays NaN on fp32 (documented behaviour); bf16 dest packs that NaN as inf.

Also fixes a pre-existing case on binary fp32: `pow(-0, negative even integer)` returned inf (e.g. `pow(-0, -2)`), because the guard's `base == 0.f` is bit-exact and misses `-0`. The zero-base guard now uses a single `abs`, so it returns NaN like every other path. Non-integer negative `p` was already correct — the sign branch caught it.

Issue #51468 is wrong that `-0` behaves like `+0`. SFPU `<` is sign-bit based, so `v_if(base < 0)` fires on `-0`: pre-fix `pow(-0, 0.5)` was NaN, not `7.67e-20`.

### Notes for reviewers
- The zero fill runs after the negative-base branch. SFPU `<` is sign-bit based, so `v_if(base < 0)` classes `-0` as a negative base and would give `-0 ** 0.5` the complex-result NaN. `-0` is a zero, not a negative base — `torch.pow(-0.0, 0.5)` is `+0` — so the zero fill has to run last and win.
- Do not drop `abs_end` and reuse the top-of-function `abs_base` in these guards: that keeps `abs_base` live across the whole log2/exp2 body and spills `_sfpu_binary_power_f32_` on Blackhole (`sfpi_classes.h:131: internal compiler error: cannot store sfpu register`). Recomputing `sfpi::abs(base)` at the point of use costs one instruction and frees the register.
- `v_and` narrowing rather than two flat `v_if`s: `v_and` tightens the active lane mask in
  place, so it needs no `sfppushc`/`sfppopc`/`sfpcompc` for a second predicate scope.
  144 vs 147 SFPU instructions on Blackhole, 173 vs 176 on Wormhole — the same
  `sfpsetcc −2 / sfpencc −1` exchange with nothing added. A nested `v_if`/`v_elseif`
  measures 148, worse than either.
- `pow(0, NaN)` on the binary path returns `+0` where it previously returned `inf`; both
  are wrong (IEEE says NaN) and the guard shape does not affect it — flat, nested and
  `v_and` all measure `0x00000000`. Tracked in #53922 with the cost of fixing it.
- No third unary template instantiation, to stay clear of the reload-insn ICE from #49625. (Not measured; that ICE is a different failure mode from the spill above.)
- Binary fp32 `pow(-0, odd integer)` was IEEE `-0` pre-fix and is `+0` post-fix (zero fill runs after `setsgn2`). Issue success criteria allow `+0`. Unary was already `+0`.
- On bf16 dest, the NaN the kernel writes for `0**negative` reads back as inf
  (tenstorrent/tt-llk#675 — packers flush NaN to infinity on the BF16→BF16 path), so the
  test asserts `isnan` on fp32 and only `~isfinite` on bf16.
- Scalar `pow(t, 0.0)` floors to the integer overload and routes to `power_iterative`, not the SFPU kernel; SFPU `0**0` is covered by the tensor-exponent path.

### Test plan
- [x] `test_pow_zero_base_special_cases` (new) — exact `0` for `±0` × `{1e-4, 0.01, 0.25, 0.5, 1/3, 0.75, 0.99, 1.5, 3, 4}` on unary, binary and `rpow`; `0**0 == 1`; fp32 `isnan` / bf16 `~isfinite` for `±0 ** -1.5`. Asserts exact equality, not tolerance — a regressed `2**(-127p)` is ~`7.7e-20` at `p=0.5` and passes any `allclose` this file uses.
- [x] `test_pow.py` + `test_unary_pow.py` full — 594 passed, 3 xfailed (pre-existing), Blackhole. Includes `test_special_input_fp32`, `test_unary_pow_fp32_ulp_noninteger` (≤3 ULP) and `test_unary_pow_fp32_ulp_integer_exact` (0 ULP), so #49625's accuracy gates are unmoved.
- [x] Wormhole 
- [ ] CI post-commit

### Performance

Blackhole `p100a`, binary `pow`, device kernel time via tracy
(`ttnn-eltwise-op-tester/bench.py --type binary -k pow`).Run-to-run spread
is 0.002% on bf16 and bit-identical on fp32, so these deltas are well outside noise.

| state | bf16 cycles/tile | fp32 cycles/tile |
|---|---:|---:|
| pre-fix (`d7f3415767d`) | 3263.71 | 5606.21 |
| flat `v_if` pair | 3391.79 | 5735.90 |
| `v_and` narrowing | 3295.69 | 5639.71 |

| comparison | bf16 | fp32 |
|---|---:|---:|
| cost of the fix (pre-fix → flat pair) | +128.08 (+3.92%) | +129.69 (+2.31%) |
| `v_and` vs flat pair | **−96.10 (−2.83%)** | **−96.19 (−1.68%)** |
| net cost vs pre-fix (`v_and`) | +31.98 (+0.98%) | +33.50 (+0.60%) |

`v_and` recovers ~75% of the fix's cost. Cycles agree exactly with the
disassembly: `cycles_per_datum × 32 lanes` gives 3.00 (bf16) and 3.01 (fp32) for
the `v_and` saving, matching the 147 → 144 SFPU instruction count in
`trisc1.elf`, and 4.00 / 4.05 for the fix itself. One SFPU instruction = one
cycle across 32 lanes on this kernel.

`v_and` is behaviourally identical, not just correct: base ∈ {`+0`, `−0`} × all
65536 bf16 exponent patterns × both dtypes = 262,144 lanes, **0 bitwise
differences** against the flat pair. All 32,640 positive exponent patterns
return exact `+0`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iklemenskiTT/51468/fix-pow-zero-base)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iklemenskiTT/51468/fix-pow-zero-base)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iklemenskiTT/51468/fix-pow-zero-base)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iklemenskiTT/51468/fix-pow-zero-base)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iklemenskiTT/51468/fix-pow-zero-base)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iklemenskiTT/51468/fix-pow-zero-base)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iklemenskiTT/51468/fix-pow-zero-base)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iklemenskiTT/51468/fix-pow-zero-base)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iklemenskiTT/51468/fix-pow-zero-base)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iklemenskiTT/51468/fix-pow-zero-base)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iklemenskiTT/51468/fix-pow-zero-base)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iklemenskiTT/51468/fix-pow-zero-base)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iklemenskiTT/51468/fix-pow-zero-base)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iklemenskiTT/51468/fix-pow-zero-base)
