### PR TITLE
high_bw_all_gather: restore bandwidth for batch-indexed gathers

### DIFF
--- a/tests/ttnn/unit_tests/operations/experimental/test_high_bw_all_gather.py
+++ b/tests/ttnn/unit_tests/operations/experimental/test_high_bw_all_gather.py
@@ -104,6 +104,7 @@ _NUM_LINKS = 2
 # CI performance targets are global sequence lengths. Both divide exactly by
 # the four-rank QuietBox ring and eight-rank Blackhole Galaxy line.
 _CI_PERF_GLOBAL_ROWS = (55_000, 512 * 1024)
+_CI_INDEXED_CACHE_CAPACITY_GLOBAL_ROWS = 1_000_000
 _CI_PERF_TEST_CASES = [
     ("bf16_row_major", ttnn.bfloat16, 576, ttnn.ROW_MAJOR_LAYOUT, 1152),
     ("fp8_row_major", ttnn.fp8_e4m3, 656, ttnn.ROW_MAJOR_LAYOUT, 704),
@@ -494,12 +495,25 @@ def _run_high_bw_all_gather_perf(
     cluster_axis,
     rows_per_device=_PERF_ROWS_PER_DEVICE,
     profile_samples=7,
+    capacity_rows_per_device=None,
+    input_batch_index=None,
+    gathered_dim_size=None,
 ):
     if not ttnn.device.IsProgramRealtimeProfilerActive():
         pytest.skip("high_bw_all_gather bandwidth test requires the realtime device profiler")
 
     axis_size = mesh_device.shape[cluster_axis]
-    global_shape = (1, 1, rows_per_device * axis_size, width)
+    capacity_rows_per_device = capacity_rows_per_device or rows_per_device
+    assert rows_per_device <= capacity_rows_per_device
+    if input_batch_index is not None:
+        assert input_batch_index >= 0
+        cache_slots = input_batch_index + 1
+    else:
+        cache_slots = 1
+    if gathered_dim_size is not None:
+        assert gathered_dim_size == rows_per_device * axis_size
+
+    global_shape = (cache_slots, 1, capacity_rows_per_device * axis_size, width)
     torch.manual_seed(0)
     host_input = torch.rand(global_shape, dtype=torch.bfloat16)
     device_input = _make_tensor(
@@ -516,6 +530,7 @@ def _run_high_bw_all_gather_perf(
     # produces 640 * ring_size output rows).
     local_padded_shape = ttnn.get_device_tensors(device_input)[0].padded_shape
     output_shape = list(local_padded_shape)
+    output_shape[0] = 1
     output_shape[2] *= axis_size
     persistent_output = _make_tensor(
         mesh_device,
@@ -528,16 +543,25 @@ def _run_high_bw_all_gather_perf(
     assert page_size == expected_page_size
     assert ttnn.get_tt_fabric_max_payload_size_bytes() == 14 * 1024
 
-    def run():
+    def run(batch_index=input_batch_index):
+        runtime_controls = {}
+        if batch_index is not None:
+            runtime_controls["input_batch_index"] = batch_index
+        if gathered_dim_size is not None:
+            runtime_controls["gathered_dim_size"] = gathered_dim_size
         return ttnn.experimental.high_bw_all_gather(
             device_input,
             dim=2,
             output_tensor=persistent_output,
             cluster_axis=cluster_axis,
             num_links=_NUM_LINKS,
+            **runtime_controls,
         )
 
-    run()
+    # Prime the indexed program with slot zero, then measure the nonzero slot.
+    # input_batch_index is excluded from the cache key, so this also proves its
+    # source-page base is patched on a cache hit without adding a launch.
+    run(0 if input_batch_index is not None else None)
     ttnn.synchronize_device(mesh_device)
     run()
     ttnn.synchronize_device(mesh_device)
@@ -552,7 +576,8 @@ def _run_high_bw_all_gather_perf(
     bandwidth_gbps = pages_per_device * page_size * (axis_size - 1) / median_ns
     print(
         f"HIGH_BW_ALL_GATHER fabric={ttnn.get_fabric_config()} dtype={dtype} "
-        f"layout={layout} num_links={_NUM_LINKS} rows_per_device={rows_per_device} page_size={page_size}B "
+        f"layout={layout} num_links={_NUM_LINKS} rows_per_device={rows_per_device} "
+        f"capacity_rows_per_device={capacity_rows_per_device} cache_slots={cache_slots} page_size={page_size}B "
         f"median={median_ns / 1e6:.3f}ms effective_receive_bw={bandwidth_gbps:.3f}GB/s "
         f"samples_ms={[round(duration / 1e6, 3) for duration in durations_ns]}"
     )
@@ -630,6 +655,13 @@ def _run_high_bw_all_gather_ci_perf(mesh_device, cluster_axis, min_bandwidth_gbp
         )
         for case_name, dtype, width, layout, expected_page_size in _CI_PERF_TEST_CASES:
             print(f"HIGH_BW_ALL_GATHER_CI_PERF global_rows={global_rows} case={case_name}")
+            # Replace the large BF16 measurement with the serving-shaped indexed-cache path. Its
+            # 512K active payload keeps the existing ring floor meaningful while the 1M allocation
+            # selects the persistent-cache worker topology.
+            indexed_cache_case = global_rows == 512 * 1024 and case_name == "bf16_row_major"
+            capacity_rows_per_device = (
+                _CI_INDEXED_CACHE_CAPACITY_GLOBAL_ROWS // axis_size if indexed_cache_case else None
+            )
             _run_high_bw_all_gather_perf(
                 mesh_device,
                 dtype,
@@ -639,6 +671,9 @@ def _run_high_bw_all_gather_ci_perf(mesh_device, cluster_axis, min_bandwidth_gbp
                 required_bandwidth_gbps,
                 cluster_axis,
                 rows_per_device=rows_per_device,
+                capacity_rows_per_device=capacity_rows_per_device,
+                input_batch_index=1 if indexed_cache_case else None,
+                gathered_dim_size=global_rows if indexed_cache_case else None,
             )
             # Use a compact reference run after the full-size measurement. This
             # validates the same dtype/layout/route without doubling CI memory

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_unicast_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_unicast_factory.cpp
@@ -358,20 +358,29 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
     const bool has_runtime_controls =
         operation_attributes.input_batch_index.has_value() || operation_attributes.gathered_dim_size.has_value();
     const auto page_geometry = derive_page_geometry(input_tensor, output_tensor, operation_attributes);
-    // gathered_dim_size is deliberately cache-key-independent. Runtime controls always use the
-    // direct indexed schedule, and their page ranges are patched below from page_geometry.
+    // gathered_dim_size is deliberately cache-key-independent. Runtime controls reuse the compiled
+    // schedule and patch its selected page base and active ranges below from page_geometry.
     const uint32_t input_page_size = page_geometry.input_page_size;
     const uint32_t num_dram_banks = mesh_device->allocator()->get_num_banks(tt::tt_metal::BufferType::DRAM);
     TT_FATAL(num_dram_banks > 0, "high_bw_all_gather requires at least one allocator-managed DRAM bank");
+    // Size the cached worker topology for the maximum output allocation. Runtime prefix lengths are excluded
+    // from the program hash, so every cache hit must reuse this worst-case tier.
     const uint64_t total_output_bytes =
         (uint64_t)output_tensor.buffer()->num_pages() * output_tensor.buffer()->aligned_page_size();
     const uint64_t per_link_bytes = total_output_bytes / std::max(1u, num_links);
     constexpr uint64_t bank_owned_min_link_bytes = 1500000ULL;
     constexpr uint64_t high_parallelism_min_link_bytes = 32000000ULL;
-    const auto can_use_fixed_shape_bank_owned = [&](uint32_t workers_per_direction) {
-        return !has_runtime_controls &&
-               can_use_output_bank_owned_schedule(
-                   input_tensor, output_tensor, page_geometry, num_links, workers_per_direction, num_dram_banks);
+    // Select the worker tier from the maximum per-slot geometry. Runtime prefixes retain the same fixed
+    // output-rank stride, and both their source and destination page sequences remain bank-stridable; only
+    // the number of active pages changes. This lets one cached program keep the bank-owned fast path while
+    // input_batch_index/gathered_dim_size patch its page base and active slice counts at dispatch time.
+    auto scheduling_geometry = page_geometry;
+    if (has_runtime_controls) {
+        scheduling_geometry.num_input_pages = page_geometry.output_chunks_per_stripe;
+    }
+    const auto can_use_bank_owned = [&](uint32_t workers_per_direction) {
+        return can_use_output_bank_owned_schedule(
+            input_tensor, output_tensor, scheduling_geometry, num_links, workers_per_direction, num_dram_banks);
     };
     uint32_t workers_per_dir = 1;
     if (input_tensor.device()->arch() == tt::ARCH::WORMHOLE_B0) {
@@ -382,22 +391,21 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
         // scatter fallback. Keep two workers for small messages, where additional core/mux setup is not amortized.
         const uint32_t bank_covering_workers =
             scheduler::workers_per_direction_to_cover_banks(num_links, num_dram_banks);
-        if (per_link_bytes >= bank_owned_min_link_bytes && can_use_fixed_shape_bank_owned(bank_covering_workers)) {
+        if (per_link_bytes >= bank_owned_min_link_bytes && can_use_bank_owned(bank_covering_workers)) {
             workers_per_dir = bank_covering_workers;
         }
 
         // Large messages benefit from additional in-flight DRAM reads after every bank is covered.
         const uint32_t high_parallelism_workers = std::max(8u, bank_covering_workers);
-        if (per_link_bytes >= high_parallelism_min_link_bytes &&
-            can_use_fixed_shape_bank_owned(high_parallelism_workers)) {
+        if (per_link_bytes >= high_parallelism_min_link_bytes && can_use_bank_owned(high_parallelism_workers)) {
             workers_per_dir = high_parallelism_workers;
         }
     } else if (input_tensor.device()->arch() == tt::ARCH::BLACKHOLE) {
         // Measured on Blackhole across every qualified page format and line/ring schedules. Four workers amortize
         // their mux/core overhead once a bank-owned message reaches roughly 1.5 MB/link. Eight workers do not
         // consistently pull ahead of four until roughly 32 MB/link.
-        const bool four_workers_bank_owned = can_use_fixed_shape_bank_owned(4);
-        const bool eight_workers_bank_owned = can_use_fixed_shape_bank_owned(8);
+        const bool four_workers_bank_owned = can_use_bank_owned(4);
+        const bool eight_workers_bank_owned = can_use_bank_owned(8);
 
         workers_per_dir = 2;
         if (per_link_bytes >= bank_owned_min_link_bytes && four_workers_bank_owned) {
@@ -422,7 +430,7 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
         available_worker_cores = available_worker_cores.intersection(operation_attributes.sub_core_grid.value());
     }
     const uint32_t preferred_workers_per_dir = workers_per_dir;
-    const bool preferred_schedule_is_bank_owned = can_use_fixed_shape_bank_owned(preferred_workers_per_dir);
+    const bool preferred_schedule_is_bank_owned = can_use_bank_owned(preferred_workers_per_dir);
     const auto worker_count_fits = [&](uint32_t count) {
         return scheduler::worker_count_fits(
             count, num_links, static_cast<uint32_t>(available_worker_cores.num_cores()));
@@ -440,7 +448,7 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
             static_cast<uint32_t>(available_worker_cores.num_cores()),
             reduction_tiers);
     }
-    if (preferred_schedule_is_bank_owned && !can_use_fixed_shape_bank_owned(workers_per_dir)) {
+    if (preferred_schedule_is_bank_owned && !can_use_bank_owned(workers_per_dir)) {
         // Do not spend almost as many cores on the scatter fallback when a restricted grid falls just short of
         // covering every bank.
         workers_per_dir = std::min(2u, workers_per_dir);
@@ -603,13 +611,14 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
     // when the input uses an ND-sharded/block-cyclic DRAM layout. Keeping the
     // destination pages bank-local lets the writer coalesce small pages into a
     // full Fabric packet instead of falling back to four-entry scatter writes.
-    // Runtime-sized cache prefixes use direct indexed scheduling. A bank-owned schedule bakes a
-    // max-shape stride into the binary, so keep it for the fixed-shape fast path only.
-    const bool output_bank_owned_schedule = can_use_fixed_shape_bank_owned(workers_per_dir);
+    // The output stride is already the maximum per-rank slot width. Runtime prefixes patch their active
+    // bank-owned page ranges below without changing that stride or the compiled worker topology.
+    const bool output_bank_owned_schedule = can_use_bank_owned(workers_per_dir);
     const uint32_t slice_step = output_bank_owned_schedule ? num_dram_banks : 1;
-    // Selected-slot/prefix gathers patch this at runtime. Every fixed-shape path, including direct
-    // scheduling, can bake its stripe width so the iterator avoids dynamic div/mod.
-    const uint32_t static_output_chunks_per_stripe = has_runtime_controls ? 0 : output_chunks_per_stripe;
+    // Runtime controls change the selected source base and active page count, but every rank retains its
+    // maximum output slot. Its stripe width is therefore structural and can stay baked into the iterator,
+    // avoiding dynamic divide/modulo on both fixed-shape and selected-prefix paths.
+    const uint32_t static_output_chunks_per_stripe = output_chunks_per_stripe;
 
     ////////////////////////////////////////////////////////////////
     // Circular Buffer and Kernel creation
@@ -878,8 +887,10 @@ HighBwAllGatherUnicastFactory::cached_program_t HighBwAllGatherUnicastFactory::c
         .device_idx = device_idx,
         .forward_iterations = fwd_iters,
         .backward_iterations = bwd_iters,
+        .num_dram_banks = num_dram_banks,
         .is_ring = is_ring,
         .ring_even_split = ring_even_split,
+        .output_bank_owned_schedule = output_bank_owned_schedule,
     };
 
     return {std::move(program), std::move(shared_variables)};
@@ -921,36 +932,51 @@ void HighBwAllGatherUnicastFactory::override_runtime_arguments(
             continue;
         }
 
-        // The selected-slot/prefix path intentionally uses the direct (non-bank-owned) schedule.
         // Patch only scalar runtime arguments: no program rebuild, worker re-selection, allocation, or
-        // tensor view/slice is involved on a cache hit.
+        // tensor view/slice is involved on a cache hit. The compiled schedule may be bank-owned; in that
+        // case each worker keeps one output DRAM bank while the selected input base and active count vary.
         const uint32_t total_slices = shared_vars.num_links * shared_vars.workers_per_direction;
         const uint32_t data_valid_granularity =
             derive_data_valid_granularity(page_geometry, operation_attributes.packet_size, total_slices);
         const uint32_t input_pages_per_slice = page_geometry.num_input_pages / total_slices;
         const uint32_t remainder = page_geometry.num_input_pages % total_slices;
+        const uint32_t slice_step = shared_vars.output_bank_owned_schedule ? shared_vars.num_dram_banks : 1;
         for (uint32_t link = 0; link < shared_vars.num_links; ++link) {
             for (uint32_t dir = 0; dir < 2; ++dir) {
                 const bool is_forward = dir == 0;
-                // Runtime-controlled gathers are always direct scheduled, so their per-worker
-                // output slice is contiguous. Keep this distinct from the ring traversal step.
-                constexpr uint32_t slice_step = 1;
                 const uint32_t num_recv =
                     shared_vars.is_ring
                         ? shared_vars.num_devices / 2
                         : (is_forward ? shared_vars.device_idx : shared_vars.num_devices - 1 - shared_vars.device_idx);
                 for (uint32_t w = 0; w < shared_vars.workers_per_direction; ++w) {
                     const uint32_t slice_idx = link * shared_vars.workers_per_direction + w;
-                    const uint32_t input_page_start =
-                        slice_idx * input_pages_per_slice + std::min(slice_idx, remainder);
+                    uint32_t input_page_start = slice_idx * input_pages_per_slice + std::min(slice_idx, remainder);
+                    uint32_t worker_input_page_count = input_pages_per_slice + (slice_idx < remainder ? 1u : 0u);
+                    if (shared_vars.output_bank_owned_schedule) {
+                        const auto bank_owned_slice = scheduler::derive_bank_owned_slice(
+                            page_geometry.num_input_pages,
+                            shared_vars.num_links,
+                            shared_vars.workers_per_direction,
+                            shared_vars.num_dram_banks,
+                            link,
+                            w);
+                        input_page_start = bank_owned_slice.input_page_start;
+                        worker_input_page_count = bank_owned_slice.page_count;
+                    }
                     const uint32_t input_page_end =
-                        (slice_idx + 1) * input_pages_per_slice + std::min(slice_idx + 1, remainder);
+                        shared_vars.output_bank_owned_schedule
+                            ? input_page_start + worker_input_page_count * shared_vars.num_dram_banks
+                            : (slice_idx + 1) * input_pages_per_slice + std::min(slice_idx + 1, remainder);
                     const uint32_t local_output_start =
-                        (static_cast<uint64_t>(input_page_start) * page_geometry.num_output_chunks) /
-                        page_geometry.num_input_pages;
+                        shared_vars.output_bank_owned_schedule
+                            ? input_page_start
+                            : (static_cast<uint64_t>(input_page_start) * page_geometry.num_output_chunks) /
+                                  page_geometry.num_input_pages;
                     const uint32_t local_output_end =
-                        (static_cast<uint64_t>(input_page_end) * page_geometry.num_output_chunks) /
-                        page_geometry.num_input_pages;
+                        shared_vars.output_bank_owned_schedule
+                            ? local_output_start + worker_input_page_count
+                            : (static_cast<uint64_t>(input_page_end) * page_geometry.num_output_chunks) /
+                                  page_geometry.num_input_pages;
                     const uint32_t slice_count = local_output_end - local_output_start;
                     const uint32_t half = slice_count / 2;
                     const uint32_t final_start =

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_unicast_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/high_bw_all_gather_unicast_factory.hpp
@@ -25,8 +25,10 @@ struct HighBwAllGatherUnicastFactory {
         uint32_t device_idx{};
         uint32_t forward_iterations{};
         uint32_t backward_iterations{};
+        uint32_t num_dram_banks{};
         bool is_ring{};
         bool ring_even_split{};
+        bool output_bank_owned_schedule{};
     };
 
     using cached_mesh_workload_t = ttnn::device_operation::AdaptedCachedMeshWorkload<shared_variables_t>;

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/kernels/unicast_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/kernels/unicast_reader.cpp
@@ -48,8 +48,8 @@ void kernel_main() {
     constexpr uint32_t cb0_id = get_compile_time_arg_val(4);
     constexpr uint32_t cb_page_size = get_compile_time_arg_val(5);
     constexpr uint32_t slice_step = get_compile_time_arg_val(6);
-    // Zero selects the runtime geometry used by selected-slot/prefix gathers. Fixed-shape
-    // bank-owned schedules bake their stripe width and keep the iterator arithmetic constexpr.
+    // The maximum per-rank output slot is structural even for selected-prefix gathers, so its
+    // stripe width stays baked and keeps the iterator arithmetic constexpr.
     constexpr uint32_t static_output_chunks_per_stripe = get_compile_time_arg_val(7);
     constexpr auto input_tensor_args = TensorAccessorArgs<8>();
     constexpr auto output_tensor_args = TensorAccessorArgs<input_tensor_args.next_compile_time_args_offset()>();

--- a/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/kernels/unicast_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/high_bw_all_gather/device/kernels/unicast_writer.cpp
@@ -38,8 +38,8 @@ void kernel_main() {
     constexpr uint32_t cb_page_size = get_compile_time_arg_val(4);
     constexpr uint32_t packet_size = get_compile_time_arg_val(5);
     constexpr uint32_t slice_step = get_compile_time_arg_val(6);
-    // See unicast_reader.cpp: runtime-controlled gathers retain a dynamic stripe width;
-    // fixed bank-owned gathers bake it to avoid divide/modulo in the send loop.
+    // See unicast_reader.cpp: the maximum per-rank output slot remains fixed for
+    // runtime-controlled gathers, so its stripe width can be baked.
     constexpr uint32_t static_output_chunks_per_stripe = get_compile_time_arg_val(7);
     constexpr auto output_tensor_args = TensorAccessorArgs<8>();
 


### PR DESCRIPTION
### PR Category
Performance

### Summary

Batch-indexed and runtime-prefix `high_bw_all_gather` calls unnecessarily disabled bank-owned scheduling and fell back to the direct/scatter schedule. This is a general scheduling regression triggered by batch indexing, not a Galaxy- or hardware-specific issue.

Batch selection and a shorter active prefix change only the selected input base and active page count. The maximum output-slot geometry, rank stride, and DRAM-bank traversal remain fixed, so qualifying gathers can retain the bank-owned fast path.

This change preserves the bank-owned worker topology and patches the selected bank-strided page ranges at dispatch time. It also retains the static output stripe width, avoiding unnecessary dynamic iterator arithmetic.

### Impact

- Restores the bank-owned fast path for qualifying batch-indexed and runtime-prefix gathers.
- Recovers the bandwidth lost to the direct-scheduling fallback, which was roughly half of the expected bandwidth in affected cases.
- Preserves runtime batch selection, variable active prefixes, and program-cache reuse.

### Validation

Existing selected-batch/prefix coverage exercises both cache slots, changing active prefix lengths, correctness, and program-cache reuse.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/high-bw-all-gather-runtime-prefix-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/high-bw-all-gather-runtime-prefix-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/high-bw-all-gather-runtime-prefix-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/high-bw-all-gather-runtime-prefix-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/high-bw-all-gather-runtime-prefix-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/high-bw-all-gather-runtime-prefix-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/high-bw-all-gather-runtime-prefix-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/high-bw-all-gather-runtime-prefix-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/high-bw-all-gather-runtime-prefix-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/high-bw-all-gather-runtime-prefix-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/high-bw-all-gather-runtime-prefix-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/high-bw-all-gather-runtime-prefix-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/high-bw-all-gather-runtime-prefix-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/high-bw-all-gather-runtime-prefix-perf)