### PR TITLE
DEVICE PRINT: helper to print type name

### DIFF
--- a/docs/source/tt-metalium/tools/device_print.rst
+++ b/docs/source/tt-metalium/tools/device_print.rst
@@ -88,6 +88,20 @@ so the host can resolve it:
     DPRINT("Pointer: {}\n", s);               // prints: Pointer: 0x12345678
     DPRINT("String: {}\n", CTSTR("Hello!"));  // prints: String: Hello!
 
+Type names
+^^^^^^^^^^
+
+``dp_type_name_t<T>()`` prints the fully-qualified name of ``T``. The name is resolved at compile time
+and stored in the ELF like ``CTSTR()``, so the argument costs one pointer in the print buffer:
+
+.. code-block:: c++
+
+    namespace ns { struct MyStruct {}; }
+
+    ns::MyStruct x;
+    DPRINT("type: {}\n", dp_type_name_t<int>());          // prints: type: int
+    DPRINT("type: {}\n", dp_type_name_t<decltype(x)>());  // prints: type: ns::MyStruct
+
 Enums
 ^^^^^
 

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_format_updates.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_format_updates.cpp
@@ -226,6 +226,22 @@ TEST_F(DevicePrintFormatUpdatesFixture, PrintStringTypes) {
         "tests/tt_metal/tt_metal/test_kernels/device_print/print_string_types.cpp", ttsl::make_span(messages));
 }
 
+// dp_type_name_t<T> carries no data: the type name is stored in .device_print_strings and the
+// argument is the pointer to it, so it uses the same type specifier as CTSTR.
+TEST_F(DevicePrintFormatUpdatesFixture, PrintTypeName) {
+    std::vector<std::string_view> messages = {
+        "builtin type: {0,s}\n"sv,
+        "struct type: {0,s}\n"sv,
+        "enum type: {0,s}\n"sv,
+        "template type: {0,s}\n"sv,
+        "decltype: {0,s}\n"sv,
+        "with value: {0,s} = {1,f}\n"sv,
+    };
+
+    TestFormatUpdate(
+        "tests/tt_metal/tt_metal/test_kernels/device_print/print_type_name.cpp", ttsl::make_span(messages));
+}
+
 TEST_F(DevicePrintFormatUpdatesFixture, PrintReorder) {
     std::vector<std::string_view> messages = {
         "u16_1: {4,H} u16_2: {5,H} u32_1: {0,I} u32_2: {1,I} u32_3: {2,I} u32_4: {3,I}\n"sv,

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
@@ -588,6 +588,21 @@ TEST_F(DevicePrintOutputFixture, PrintStringTypes) {
     TestOutput("tests/tt_metal/tt_metal/test_kernels/device_print/print_string_types.cpp", messages);
 }
 
+// Type names are extracted from __PRETTY_FUNCTION__ at compile time and resolved from the ELF on the
+// host, same as CTSTR. int/float are used over uint32_t/int8_t, whose spelling is typedef-dependent.
+TEST_F(DevicePrintOutputFixture, PrintTypeName) {
+    std::vector<std::string> messages = {
+        "builtin type: int",
+        "struct type: test::deep::Foo",
+        "enum type: test::deep::Bar",
+        "template type: test::deep::Wrapper<int>",
+        "decltype: float",
+        "with value: float = 1",
+    };
+
+    TestOutput("tests/tt_metal/tt_metal/test_kernels/device_print/print_type_name.cpp", messages);
+}
+
 TEST_F(DevicePrintOutputFixture, PrintReorder) {
     std::vector<std::string> messages = {
         "u16_1: 16 u16_2: 32 u32_1: 1 u32_2: 2 u32_3: 4 u32_4: 8",

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/print_type_name.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/print_type_name.cpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/debug/device_print.h"
+
+namespace test::deep {
+struct Foo {};
+
+template <typename T>
+struct Wrapper {};
+
+enum class Bar : uint8_t {
+    A = 0,
+};
+}  // namespace test::deep
+
+/*
+ * Test printing type names from a kernel running on BRISC.
+ */
+
+void kernel_main() {
+    float f = 1.0f;
+    DEVICE_PRINT("builtin type: {}\n", dp_type_name_t<int>());
+    DEVICE_PRINT("struct type: {}\n", dp_type_name_t<test::deep::Foo>());
+    DEVICE_PRINT("enum type: {}\n", dp_type_name_t<test::deep::Bar>());
+    DEVICE_PRINT("template type: {}\n", dp_type_name_t<test::deep::Wrapper<int>>());
+    DEVICE_PRINT("decltype: {}\n", dp_type_name_t<decltype(f)>());
+    DEVICE_PRINT("with value: {} = {}\n", dp_type_name_t<decltype(f)>(), f);
+}

--- a/tt_metal/hw/inc/api/debug/device_print.h
+++ b/tt_metal/hw/inc/api/debug/device_print.h
@@ -97,6 +97,11 @@ struct dp_typed_array_t {
     dp_typed_array_t(uint16_t type, uint32_t* ptr) : ptr(ptr), type(type) {}
 };
 
+// Prints T's fully-qualified name, resolved at compile time. Tag type: the name string is allocated
+// in .device_print_strings by the serializer, so nothing is carried here.
+template <typename T>
+struct dp_type_name_t {};
+
 struct dp_top_callstack_t {
     std::uintptr_t pc;
     std::uintptr_t ra;
@@ -257,10 +262,12 @@ void device_print_dispatcher_execute_hook();
 
 namespace device_print_detail {
 
-// Forward declarations needed by register_string_info.
+// Forward declarations needed by register_string_info and register_type_name_string.
 namespace formatting {
 template <std::size_t N, typename... Args>
 constexpr auto update_format_string(const char (&format)[N]);
+template <typename T>
+constexpr auto get_type_name_string();
 }
 
 // Helper to invoke a callable with arguments copied by value.
@@ -302,6 +309,15 @@ static std::uintptr_t register_string_info() {
         __attribute__((section(DEVICE_PRINT_STRINGS_INFO_SECTION_NAME), used)) = {
             allocated_string.data(), allocated_file_string.data(), Tag::line()};
     return reinterpret_cast<std::uintptr_t>(&allocated_string_info);
+}
+
+// Allocates T's name in .device_print_strings and returns the pointer. `static` for the same
+// internal-linkage reason as register_string_info.
+template <typename T>
+static const char* register_type_name_string() {
+    static constexpr auto kTypeName = formatting::get_type_name_string<T>().to_array();
+    static const auto allocated_type_name __attribute__((section(DEVICE_PRINT_STRINGS_SECTION_NAME), used)) = kTypeName;
+    return allocated_type_name.data();
 }
 
 template <typename BufferType>
@@ -363,15 +379,6 @@ struct static_string {
         arr[size] = '\0';
         return arr;
     }
-
-    // Helper to create a compact array of the actual used size
-    template <std::size_t... Is>
-    constexpr std::array<char, sizeof...(Is)> to_compact_array_impl(std::index_sequence<Is...>) const {
-        return {{data[Is]...}};
-    }
-
-    // Returns an array sized exactly to fit the string content (size + 1 for null terminator)
-    constexpr auto to_compact_array() const { return to_compact_array_impl(std::make_index_sequence<size + 1>{}); }
 
     template <std::size_t M>
     constexpr bool check(const char (&expected)[M]) const {
@@ -1004,6 +1011,14 @@ struct device_print_type<dp_typed_array_t<len>> {
     }
 };
 
+template <typename T>
+struct device_print_type<dp_type_name_t<T>> {
+    static constexpr device_print_type_info value = device_print_type<ct_string>::value;
+    static void serialize(device_print_buffer_ptr<uint8_t> device_print_buffer, uint32_t offset, dp_type_name_t<T>) {
+        device_print_type<ct_string>::serialize(device_print_buffer, offset, ct_string{register_type_name_string<T>()});
+    }
+};
+
 template <>
 struct device_print_type<dp_top_callstack_t> {
     static_assert(
@@ -1094,34 +1109,46 @@ constexpr std::array<uint32_t, sizeof...(Args)> get_arg_offsets() {
     return arg_offset;
 }
 
-// Extracts the fully-qualified type name from __PRETTY_FUNCTION__ at compile time.
-// GCC format: "... [with T = test::deep::Enum1]"
+// Extracts the fully-qualified type name from __PRETTY_FUNCTION__ at compile time. The result is
+// sized exactly to the name, so to_array() yields a compact copy.
 template <typename T>
 constexpr auto get_type_name_string() {
-#if defined(__GNUC__)
-    constexpr const char* fn = __PRETTY_FUNCTION__;
-#else
+#if !defined(__GNUC__)
     static_assert(false, "get_type_name_string requires __PRETTY_FUNCTION__ (GCC/Clang)");
 #endif
-    std::size_t fn_len = 0;
-    while (fn[fn_len] != '\0') {
-        fn_len++;
-    }
-
-    // Search for "T = " in "[with T = TypeName]"
-    std::size_t name_start = 0;
-    for (std::size_t i = 0; i + 3 < fn_len; i++) {
-        if (fn[i] == 'T' && fn[i + 1] == ' ' && fn[i + 2] == '=' && fn[i + 3] == ' ') {
-            name_start = i + 4;
-            break;
+    // Locates the type name in a __PRETTY_FUNCTION__ of the form "... [with T = test::deep::Enum1]",
+    // returning it as {start, length}.
+    constexpr auto find_type_name = [](const char* fn) {
+        std::size_t fn_len = 0;
+        while (fn[fn_len] != '\0') {
+            fn_len++;
         }
-    }
-    // End is at ']' (last char before null, or ';' for multiple template params)
-    std::size_t name_end = fn_len - 1;
 
-    helpers::static_string<1024> result;
-    for (std::size_t i = name_start; i < name_end; i++) {
-        result.push_back(fn[i]);
+        // Search for "T = " in "[with T = TypeName]"
+        std::size_t start = 0;
+        for (std::size_t i = 0; i + 3 < fn_len; i++) {
+            if (fn[i] == 'T' && fn[i + 1] == ' ' && fn[i + 2] == '=' && fn[i + 3] == ' ') {
+                start = i + 4;
+                break;
+            }
+        }
+
+        // The name ends at the first ';' — GCC appends "; other = ..." when the signature names further
+        // template params or typedefs — or, when there is none, at the trailing ']'.
+        std::size_t end = start;
+        while (end < fn_len && fn[end] != ';') {
+            end++;
+        }
+        return std::tuple<std::size_t, std::size_t>{start, (end == fn_len ? fn_len - 1 : end) - start};
+    };
+
+    constexpr auto type_name = find_type_name(__PRETTY_FUNCTION__);
+    constexpr std::size_t start = std::get<0>(type_name);
+    constexpr std::size_t length = std::get<1>(type_name);
+
+    helpers::static_string<length> result;
+    for (std::size_t i = 0; i < length; i++) {
+        result.push_back(__PRETTY_FUNCTION__[start + i]);
     }
     return result;
 }


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Feature

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Adds a helper that allows printing of any type easily. I did it using a helper class because I felt it's intuitive, even though the type isn't really necessary. I am open to other suggestions for the API.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sstanisic/reflect-types-dprint)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sstanisic/reflect-types-dprint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sstanisic/reflect-types-dprint)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sstanisic/reflect-types-dprint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sstanisic/reflect-types-dprint)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sstanisic/reflect-types-dprint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sstanisic/reflect-types-dprint)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sstanisic/reflect-types-dprint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sstanisic/reflect-types-dprint)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sstanisic/reflect-types-dprint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sstanisic/reflect-types-dprint)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sstanisic/reflect-types-dprint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sstanisic/reflect-types-dprint)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sstanisic/reflect-types-dprint)