### PR TITLE
Add setup runner failure signature

### DIFF
--- a/.github/scripts/runner_failure_common.py
+++ b/.github/scripts/runner_failure_common.py
@@ -10,7 +10,7 @@ import shutil
 import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -22,7 +22,7 @@ except ModuleNotFoundError:  # pragma: no cover - handled in load_config
     yaml = None
 
 
-SIGNATURE_VERSION = "runner-failure-signatures-2026-08-01-v5"
+SIGNATURE_VERSION = "runner-failure-signatures-2026-08-17-v1"
 UNKNOWN_RUNNER = "(unknown runner)"
 
 OSC_SEQUENCE_RE = re.compile(r"\x1b\].*?\x1b\\")
@@ -82,6 +82,7 @@ class RecentJob:
     html_url: str
     started_at: str
     completed_at: str
+    setup_runner_conclusion: str
 
 
 @dataclass(frozen=True)
@@ -152,6 +153,10 @@ ERROR_SIGNATURES = (
         label="Physical chip not found",
         pattern=r"Physical\s+chip\s+id\s+\d+\s+(?:is\s+)?not\s+found\s+in\s+(?:the\s+)?control\s+plane\s+chip\s+mapping",
         case_sensitive=False,
+    ),
+    ErrorSignature(
+        key="SETUP_RUNNER_FAILURE_FOUND",
+        label="Set up runner failure",
     ),
 )
 
@@ -369,6 +374,19 @@ def workflow_run_jobs_endpoint(owner_repo: str, run_id: str) -> str:
     return f"repos/{owner_repo}/actions/runs/{run_id}/jobs?{query}"
 
 
+def step_conclusion(job: dict[str, Any], step_name: str) -> str:
+    steps = job.get("steps")
+    if not isinstance(steps, list):
+        return ""
+
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        if str(step.get("name") or "").casefold() == step_name.casefold():
+            return str(step.get("conclusion") or "")
+    return ""
+
+
 def recent_job_from_api(
     *,
     owner_repo: str,
@@ -377,6 +395,7 @@ def recent_job_from_api(
     run: dict[str, Any],
     job: dict[str, Any],
 ) -> RecentJob:
+    setup_runner_conclusion = step_conclusion(job, "Set up runner")
     return RecentJob(
         owner_repo=owner_repo,
         workflow=workflow_name,
@@ -392,6 +411,7 @@ def recent_job_from_api(
         html_url=str(job.get("html_url") or ""),
         started_at=str(job.get("started_at") or ""),
         completed_at=str(job.get("completed_at") or ""),
+        setup_runner_conclusion=setup_runner_conclusion,
     )
 
 
@@ -522,6 +542,22 @@ def matching_signature_labels(log_text: str) -> list[str]:
     return [signature.label for signature in ERROR_SIGNATURES if signature_found(log_text, signature)]
 
 
+def setup_runner_step_failed(job: RecentJob) -> bool:
+    return job.setup_runner_conclusion.casefold() == "failure"
+
+
+def matching_job_metadata_signature_labels(job: RecentJob) -> list[str]:
+    if setup_runner_step_failed(job):
+        return ["Set up runner failure"]
+    return []
+
+
+def combine_signature_labels(*label_groups: list[str]) -> list[str]:
+    """Return unique labels in ERROR_SIGNATURES declaration order."""
+    labels_by_name = {label for labels in label_groups for label in labels}
+    return [signature.label for signature in ERROR_SIGNATURES if signature.label in labels_by_name]
+
+
 def fetch_github_job_log(job: RecentJob, timeout: int) -> LogLookupResult:
     endpoint = f"repos/{job.owner_repo}/actions/jobs/{job.job_id}/logs"
     try:
@@ -545,18 +581,47 @@ def fetch_github_job_log(job: RecentJob, timeout: int) -> LogLookupResult:
     return LogLookupResult(log_text=result.stdout, status="fetched")
 
 
+def should_fetch_setup_runner_metadata(job: RecentJob) -> bool:
+    return bool(
+        job.owner_repo and job.job_id and not job.setup_runner_conclusion and job.conclusion.casefold() == "failure"
+    )
+
+
+def enrich_setup_runner_metadata(job: RecentJob, timeout: int) -> RecentJob:
+    if not should_fetch_setup_runner_metadata(job):
+        return job
+
+    try:
+        payload = gh_api_json(f"repos/{job.owner_repo}/actions/jobs/{job.job_id}", timeout=timeout)
+    except (json.JSONDecodeError, OSError, RuntimeError, subprocess.TimeoutExpired) as exc:
+        print(f"warning: could not fetch job metadata for {job.html_url}: {exc}", file=sys.stderr)
+        return job
+
+    if not isinstance(payload, dict):
+        return job
+
+    setup_runner_conclusion = step_conclusion(payload, "Set up runner")
+    if not setup_runner_conclusion:
+        return job
+    return replace(job, setup_runner_conclusion=setup_runner_conclusion)
+
+
 def scan_job(job: RecentJob, timeout: int) -> JobScanResult:
+    job = enrich_setup_runner_metadata(job, timeout=timeout)
+    metadata_signature_labels = matching_job_metadata_signature_labels(job)
     log_result = fetch_github_job_log(job, timeout=timeout)
     if log_result.log_text is None:
         return JobScanResult(
             job=job,
             log_status=log_result.status,
             log_checked=False,
-            signature_labels=(),
+            signature_labels=tuple(metadata_signature_labels),
             fabric_missing_links="",
         )
 
-    signature_labels = matching_signature_labels(log_result.log_text)
+    signature_labels = combine_signature_labels(
+        metadata_signature_labels, matching_signature_labels(log_result.log_text)
+    )
     fabric_missing_links = ""
     if "Fabric link down (MGD topology)" in signature_labels:
         fabric_missing_links = extract_fabric_missing_links(log_result.log_text)
@@ -616,6 +681,7 @@ def job_to_dict(job: RecentJob) -> dict[str, Any]:
         "html_url": job.html_url,
         "started_at": job.started_at,
         "completed_at": job.completed_at,
+        "setup_runner_conclusion": job.setup_runner_conclusion,
     }
 
 
@@ -648,6 +714,7 @@ def job_from_dict(value: dict[str, Any]) -> RecentJob:
         html_url=str(value.get("html_url") or ""),
         started_at=str(value.get("started_at") or ""),
         completed_at=str(value.get("completed_at") or ""),
+        setup_runner_conclusion=str(value.get("setup_runner_conclusion") or ""),
     )
 
 

--- a/.github/scripts/runner_failure_post_slack.py
+++ b/.github/scripts/runner_failure_post_slack.py
@@ -263,7 +263,7 @@ def slack_runner_table_header() -> list[dict[str, str]]:
 
 
 def failure_summary_for_slack_cell(result: JobScanResult) -> str:
-    if not result.log_checked or not result.signature_labels:
+    if not result.signature_labels:
         # Slack table raw_text cells reject truly empty strings.
         return " "
 

--- a/.github/scripts/runner_failure_report.py
+++ b/.github/scripts/runner_failure_report.py
@@ -34,6 +34,7 @@ from runner_failure_common import (
     result_to_dict,
     scan_jobs,
     signature_counts,
+    step_conclusion,
     write_reports,
 )
 
@@ -605,6 +606,7 @@ def recent_job_from_runner_api_row(
         html_url=html_url,
         started_at=normalize_timestamp(row_value(row, "JOB_START_TS", "STARTED_AT", "started_at", "start_time")),
         completed_at=normalize_timestamp(row_value(row, "JOB_END_TS", "COMPLETED_AT", "completed_at", "end_time")),
+        setup_runner_conclusion="",
     )
 
 
@@ -661,6 +663,7 @@ def recent_job_from_live_github_api(
         ),
         started_at=str(job.get("started_at") or ""),
         completed_at=str(job.get("completed_at") or ""),
+        setup_runner_conclusion=step_conclusion(job, "Set up runner"),
     )
 
 

--- a/.github/scripts/test_runner_failure_common.py
+++ b/.github/scripts/test_runner_failure_common.py
@@ -1,0 +1,44 @@
+from runner_failure_common import matching_job_metadata_signature_labels, recent_job_from_api
+
+
+def test_setup_runner_failure_signature_matches_step_conclusion() -> None:
+    job = recent_job_from_api(
+        owner_repo="tenstorrent/tt-metal",
+        workflow_name="all-model-tests",
+        workflow_id="all-model-tests.yaml",
+        run={"id": 31525883863, "run_attempt": 1, "html_url": "https://example.test/run"},
+        job={
+            "id": 93905365734,
+            "name": "t3-e2e-tests / MNIST MLP e2e tests [wh_n150]",
+            "conclusion": "failure",
+            "steps": [
+                {"name": "Set up job", "conclusion": "success"},
+                {"name": "Set up runner", "conclusion": "failure"},
+            ],
+        },
+    )
+
+    labels = matching_job_metadata_signature_labels(job)
+    assert job.setup_runner_conclusion == "failure", job
+    assert "Set up runner failure" in labels, labels
+
+
+def test_setup_runner_failure_signature_ignores_successful_step() -> None:
+    job = recent_job_from_api(
+        owner_repo="tenstorrent/tt-metal",
+        workflow_name="all-model-tests",
+        workflow_id="all-model-tests.yaml",
+        run={"id": 31525883863, "run_attempt": 1, "html_url": "https://example.test/run"},
+        job={
+            "id": 93905365734,
+            "name": "t3-e2e-tests / MNIST MLP e2e tests [wh_n150]",
+            "conclusion": "failure",
+            "steps": [
+                {"name": "Set up job", "conclusion": "success"},
+                {"name": "Set up runner", "conclusion": "success"},
+            ],
+        },
+    )
+
+    labels = matching_job_metadata_signature_labels(job)
+    assert labels == [], labels

--- a/.github/scripts/test_runner_failure_post_slack.py
+++ b/.github/scripts/test_runner_failure_post_slack.py
@@ -1,0 +1,30 @@
+from runner_failure_common import JobScanResult, RecentJob
+from runner_failure_post_slack import failure_summary_for_slack_cell
+
+
+def test_failure_summary_shows_metadata_signature_when_log_not_checked() -> None:
+    result = JobScanResult(
+        job=RecentJob(
+            owner_repo="tenstorrent/tt-metal",
+            workflow="all-model-tests",
+            workflow_id="all-model-tests.yaml",
+            run_id="1",
+            run_attempt="1",
+            run_url="https://example.test/run",
+            job_id="2",
+            name="job",
+            runner_name="runner",
+            status="completed",
+            conclusion="failure",
+            html_url="https://example.test/job",
+            started_at="",
+            completed_at="",
+            setup_runner_conclusion="failure",
+        ),
+        log_status="gh api timed out",
+        log_checked=False,
+        signature_labels=("Set up runner failure",),
+        fabric_missing_links="",
+    )
+
+    assert failure_summary_for_slack_cell(result) == "Set up runner failure"


### PR DESCRIPTION
## Summary
- add a `Set up runner failure` runner-failure signature for failures inside the self-hosted runner job-start hook
- bump the runner-failure signature version so scans re-check with the new signature set
- add focused tests for matching setup-hook failures without matching later workflow-step exits

Example caught: https://github.com/tenstorrent/tt-metal/actions/runs/31525883863/job/93905365734#step:2:135

## Testing
- `PYTHONPATH=.github/scripts /tmp/tt-metal-runner-failure-validation/bin/python -m pytest --confcutdir=.github/scripts .github/scripts/test_runner_failure_common.py`
- `scan_job(...)` returned `('Set up runner failure',)` for the linked job
- `/tmp/tt-metal-runner-failure-validation/bin/pre-commit run --files .github/scripts/runner_failure_common.py .github/scripts/test_runner_failure_common.py`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=tcheda/setup-runner-failure-signature)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:tcheda/setup-runner-failure-signature)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=tcheda/setup-runner-failure-signature)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:tcheda/setup-runner-failure-signature)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=tcheda/setup-runner-failure-signature)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:tcheda/setup-runner-failure-signature)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=tcheda/setup-runner-failure-signature)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:tcheda/setup-runner-failure-signature)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=tcheda/setup-runner-failure-signature)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:tcheda/setup-runner-failure-signature)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=tcheda/setup-runner-failure-signature)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:tcheda/setup-runner-failure-signature)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=tcheda/setup-runner-failure-signature)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:tcheda/setup-runner-failure-signature)