### PR TITLE
[Feature] Quasar: Cache hw_thread_idx in a thread_local variable

### DIFF
--- a/tt_metal/hw/firmware/src/tt-2xx/dispatch_dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dispatch_dm.cc
@@ -43,6 +43,7 @@ uint32_t noc_posted_writes_num_issued[NUM_NOCS] __attribute__((used));
 
 thread_local CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
 
+thread_local uint32_t hw_thread_idx __attribute__((used));
 thread_local uint32_t tt_l1_ptr* rta_l1_base __attribute__((used));
 thread_local uint32_t tt_l1_ptr* crta_l1_base __attribute__((used));
 thread_local uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
@@ -98,7 +99,9 @@ volatile KernelBarrier g_kernel_barrier[NUM_KERNEL_BARRIERS] __attribute__((used
 
 extern "C" uint32_t _start1() {
     configure_csr();
-    uint32_t hartid = internal_::get_hw_thread_idx();
+    // Raw read: hw_thread_idx has not been filled yet, and do_thread_crt1() below zeroes the .tbss
+    // it lives in, so caching it any earlier would just be discarded.
+    uint32_t hartid = internal_::read_hw_thread_idx();
     if (hartid == 0) {
         extern uint32_t __ldm_data_start[];
         do_crt1(__ldm_data_start);
@@ -106,6 +109,8 @@ extern "C" uint32_t _start1() {
     }
     extern uint32_t __ldm_tdata_init[];
     do_thread_crt1(__ldm_tdata_init);
+    // .tbss has been zeroed: cache this thread's hw index.
+    internal_::init_hw_thread_idx();
     while ((*GET_MAILBOX_ADDRESS_DEV(fw_shared_globals_ready))[0] != SHARED_GLOBALS_READY_GO) {
     }
     WAYPOINT("I");

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -52,6 +52,7 @@ uint32_t noc_posted_writes_num_issued[NUM_NOCS] __attribute__((used));
 // temporary for things to build
 thread_local CBInterface cb_interface[NUM_CIRCULAR_BUFFERS] __attribute__((used));
 
+thread_local uint32_t hw_thread_idx __attribute__((used));
 thread_local uint32_t tt_l1_ptr* rta_l1_base __attribute__((used));
 thread_local uint32_t tt_l1_ptr* crta_l1_base __attribute__((used));
 thread_local uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
@@ -229,7 +230,9 @@ inline void trigger_sync_register_init() { subordinate_sync->neo0_trisc0 = RUN_S
 
 extern "C" uint32_t _start1() {
     configure_csr();
-    uint32_t hartid = internal_::get_hw_thread_idx();
+    // Raw read: hw_thread_idx has not been filled yet, and do_thread_crt1() below zeroes the .tbss
+    // it lives in, so caching it any earlier would just be discarded.
+    uint32_t hartid = internal_::read_hw_thread_idx();
     if (hartid == 0) {
         extern uint32_t __ldm_data_start[];
         do_crt1(__ldm_data_start);
@@ -239,6 +242,8 @@ extern "C" uint32_t _start1() {
     }
     extern uint32_t __ldm_tdata_init[];
     do_thread_crt1(__ldm_tdata_init);
+    // .tbss has been zeroed: cache this thread's hw index.
+    internal_::init_hw_thread_idx();
 
     // Remapper can always stay enabled even if no remapper pairs are configured.
     // The default mirroring scheme is used if a particular remapper entry's clientR[0] valid bit is not set.

--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -34,6 +34,7 @@ thread_local uint32_t sumIDs[SUM_COUNT] __attribute__((used));
 }  // namespace kernel_profiler
 #endif
 
+thread_local uint32_t hw_thread_idx __attribute__((used));
 thread_local uint32_t tt_l1_ptr* rta_l1_base __attribute__((used));
 thread_local uint32_t tt_l1_ptr* crta_l1_base __attribute__((used));
 thread_local uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
@@ -110,13 +111,13 @@ inline void enable_cc_stack() {
 
 extern "C" uint32_t _start1() {
     configure_csr();
-    uint32_t hartid = internal_::get_hw_thread_idx();
+    // Raw read: hw_thread_idx has not been filled yet, and do_thread_crt1() below zeroes the .tbss
+    // it lives in, so caching it any earlier would just be discarded.
+    uint32_t hartid = internal_::read_hw_thread_idx();
     uint32_t neo_id = internal_::get_neo_id();
     uint32_t trisc_id = internal_::get_trisc_id();
-    DEVICE_PRINT("hartid: {}\n", hartid);
     volatile tt_l1_ptr uint8_t* const trisc_run = &((tt_l1_ptr mailboxes_t*)(MEM_MAILBOX_BASE + MEM_L1_UNCACHED_BASE))
                                                        ->subordinate_sync.map[hartid];  // first entry is for NCRISC
-    WAYPOINT("I");
 
     if (neo_id == 0) {
         extern uint32_t __ldm_data_start[];
@@ -126,6 +127,12 @@ extern "C" uint32_t _start1() {
     }
     extern uint32_t __ldm_tdata_init[];
     do_thread_crt1(__ldm_tdata_init);
+    // .tbss has been zeroed: cache this thread's hw index.
+    internal_::init_hw_thread_idx();
+    // DEVICE_PRINT and WAYPOINT index their per-thread slots via get_hw_thread_idx(), so they have to
+    // come after the cache is filled.
+    DEVICE_PRINT("hartid: {}\n", hartid);
+    WAYPOINT("I");
 
     while ((*GET_MAILBOX_ADDRESS_DEV(fw_shared_globals_ready))[MaxDMProcessorsPerCoreType + trisc_id] !=
            SHARED_GLOBALS_READY_GO) {

--- a/tt_metal/hw/inc/internal/hw_thread.h
+++ b/tt_metal/hw/inc/internal/hw_thread.h
@@ -11,24 +11,22 @@
 #include "ckernel.h"
 #endif
 
-#if defined(ARCH_QUASAR)
+#if defined(ARCH_QUASAR) && (defined(COMPILE_FOR_TRISC) || defined(COMPILE_FOR_DM))
 extern thread_local uint32_t hw_thread_idx;
 #endif
 
 namespace internal_ {
 
-#if defined(ARCH_QUASAR)
+#if defined(ARCH_QUASAR) && (defined(COMPILE_FOR_TRISC) || defined(COMPILE_FOR_DM))
 inline __attribute__((always_inline)) uint32_t read_hw_thread_idx() {
 #if defined(COMPILE_FOR_TRISC)
     uint32_t neo_id = ckernel::csr_read<ckernel::CSR::NEO_ID>();
     uint32_t trisc_id = ckernel::csr_read<ckernel::CSR::TRISC_ID>();
     return NUM_DM_CORES + NUM_TRISC_CORES * neo_id + trisc_id;
-#elif defined(COMPILE_FOR_DM)
+#else
     uint64_t hartid;
     asm volatile("csrr %0, mhartid" : "=r"(hartid));
     return static_cast<uint32_t>(hartid);
-#else
-#error "Invalid Quasar compile target."
 #endif
 }
 
@@ -65,7 +63,7 @@ inline __attribute__((always_inline)) void init_hw_thread_idx() { hw_thread_idx 
 // ETH Wormhole: Index 0
 // ETH Blackhole/Quasar: Index 0 to 1
 inline __attribute__((always_inline)) uint32_t get_hw_thread_idx() {
-#if defined(ARCH_QUASAR)
+#if defined(ARCH_QUASAR) && (defined(COMPILE_FOR_TRISC) || defined(COMPILE_FOR_DM))
     return hw_thread_idx;
 #else
     return PROCESSOR_INDEX;

--- a/tt_metal/hw/inc/internal/hw_thread.h
+++ b/tt_metal/hw/inc/internal/hw_thread.h
@@ -32,8 +32,7 @@ inline __attribute__((always_inline)) uint32_t read_hw_thread_idx() {
 #endif
 }
 
-// Fills ::hw_thread_idx for the calling hardware thread. Must run once per thread after
-// do_thread_crt1() has initialized thread-local storage, and before anything calls
+// Fills ::hw_thread_idx for the calling hardware thread. Must run once per thread before anything calls
 // get_hw_thread_idx().
 inline __attribute__((always_inline)) void init_hw_thread_idx() { hw_thread_idx = read_hw_thread_idx(); }
 #endif

--- a/tt_metal/hw/inc/internal/hw_thread.h
+++ b/tt_metal/hw/inc/internal/hw_thread.h
@@ -11,7 +11,32 @@
 #include "ckernel.h"
 #endif
 
+#if defined(ARCH_QUASAR)
+extern thread_local uint32_t hw_thread_idx;
+#endif
+
 namespace internal_ {
+
+#if defined(ARCH_QUASAR)
+inline __attribute__((always_inline)) uint32_t read_hw_thread_idx() {
+#if defined(COMPILE_FOR_TRISC)
+    uint32_t neo_id = ckernel::csr_read<ckernel::CSR::NEO_ID>();
+    uint32_t trisc_id = ckernel::csr_read<ckernel::CSR::TRISC_ID>();
+    return NUM_DM_CORES + NUM_TRISC_CORES * neo_id + trisc_id;
+#elif defined(COMPILE_FOR_DM)
+    uint64_t hartid;
+    asm volatile("csrr %0, mhartid" : "=r"(hartid));
+    return static_cast<uint32_t>(hartid);
+#else
+#error "Invalid Quasar compile target."
+#endif
+}
+
+// Fills ::hw_thread_idx for the calling hardware thread. Must run once per thread after
+// do_thread_crt1() has initialized thread-local storage, and before anything calls
+// get_hw_thread_idx().
+inline __attribute__((always_inline)) void init_hw_thread_idx() { hw_thread_idx = read_hw_thread_idx(); }
+#endif
 
 // Internal API - not for direct use in kernels
 // Returns the hardware thread index for the current processor
@@ -27,6 +52,9 @@ namespace internal_ {
 //   Index 16-19: NEO2 Cluster (TRISC0-TRISC3)
 //   Index 20-23: NEO3 Cluster (TRISC0-TRISC3)
 //
+// On Quasar this serves the cached index, so it is valid only once init_hw_thread_idx() has run on this
+// thread.
+//
 // Blackhole/Wormhole (tt-1xx) Tensix:
 //   Index 0: BRISC  (DM0)
 //   Index 1: NCRISC (DM1)
@@ -38,14 +66,8 @@ namespace internal_ {
 // ETH Wormhole: Index 0
 // ETH Blackhole/Quasar: Index 0 to 1
 inline __attribute__((always_inline)) uint32_t get_hw_thread_idx() {
-#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_TRISC)
-    uint32_t neo_id = ckernel::csr_read<ckernel::CSR::NEO_ID>();
-    uint32_t trisc_id = ckernel::csr_read<ckernel::CSR::TRISC_ID>();
-    return NUM_DM_CORES + NUM_TRISC_CORES * neo_id + trisc_id;
-#elif defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
-    uint64_t hartid;
-    asm volatile("csrr %0, mhartid" : "=r"(hartid));
-    return static_cast<uint32_t>(hartid);
+#if defined(ARCH_QUASAR)
+    return hw_thread_idx;
 #else
     return PROCESSOR_INDEX;
 #endif


### PR DESCRIPTION
### PR Category
Feature

### Summary
Currently `get_hw_thread_idx()` re-reads the CSR every time it is called. The ckernel implementation of the CSR read contains a fence, therefore introduces a larger overhead than a plain CSR read. Since the hw_thread_idx doesn't change for a given processor, cache the hw_thread_idx in a thread_local variable at the beginning of firmware so subsequent accesses are faster. On TRISCs, this allows the profiler zone measurement to drop from ~270 cycles to ~220 cycles for a 200-cycle zone. 

### Notes for reviewers
`get_hw_thread_idx()` shouldn't be called until it is initialized.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=shengxiangji/get_thread_id_overhead)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:shengxiangji/get_thread_id_overhead)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=shengxiangji/get_thread_id_overhead)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:shengxiangji/get_thread_id_overhead)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=shengxiangji/get_thread_id_overhead)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:shengxiangji/get_thread_id_overhead)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=shengxiangji/get_thread_id_overhead)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:shengxiangji/get_thread_id_overhead)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=shengxiangji/get_thread_id_overhead)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:shengxiangji/get_thread_id_overhead)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=shengxiangji/get_thread_id_overhead)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:shengxiangji/get_thread_id_overhead)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=shengxiangji/get_thread_id_overhead)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:shengxiangji/get_thread_id_overhead)