### PR TITLE
[skip ci] ci: fix compile-time-tracker push auth broken by actions/checkout v6

### DIFF
--- a/.github/workflows/compile-time-tracker.yaml
+++ b/.github/workflows/compile-time-tracker.yaml
@@ -129,8 +129,12 @@ jobs:
           # the conditional include never fires, and push/pull fall back to
           # anonymous HTTPS ("could not read Username for 'https://github.com'").
           # An authenticated remote URL also covers the `git pull --rebase` in the
-          # retry loop below. Same approach as code-coverage.yaml.
-          git clone --branch gh-pages --single-branch \
+          # retry loop below. Same approach as code-coverage.yaml. --depth 1 is
+          # safe here: a shallow clone fetches new remote commits incrementally
+          # just like a full clone when `git pull --rebase` needs them, so it
+          # doesn't affect the retry path, and keeps this daily job from
+          # re-downloading an ever-growing branch history on every run.
+          git clone --branch gh-pages --single-branch --depth 1 \
             "https://x-access-token:${METRICS_PAT}@github.com/tenstorrent/tt-metal-compile-time-tracker.git" \
             /tmp/metrics-repo
 

--- a/.github/workflows/compile-time-tracker.yaml
+++ b/.github/workflows/compile-time-tracker.yaml
@@ -115,18 +115,26 @@ jobs:
             exit 1
           fi
 
-      - name: ⬇️ Checkout metrics repo (gh-pages)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        timeout-minutes: 20
-        with:
-          repository: tenstorrent/tt-metal-compile-time-tracker
-          token: ${{ secrets.CLANGSA_RESULTS_PAT }}
-          ref: gh-pages
-          path: metrics-repo
-
       - name: 📊 Append compile time to CSV and push
+        env:
+          METRICS_PAT: ${{ secrets.CLANGSA_RESULTS_PAT }}
         run: |
-          cd metrics-repo
+          # Clone the metrics repo with the PAT embedded in the remote URL, into
+          # /tmp (a tmpfs, see `options: --tmpfs /tmp`) rather than into the
+          # bind-mounted workspace. Do not rely on actions/checkout's persisted
+          # credentials here: since v6 it authenticates later steps via
+          # `includeIf.gitdir:` entries written only for $GITHUB_WORKSPACE and
+          # /github/workspace. This job mounts the workspace at /work, so the
+          # gitdir git resolves (/work/metrics-repo/.git) matches neither entry,
+          # the conditional include never fires, and push/pull fall back to
+          # anonymous HTTPS ("could not read Username for 'https://github.com'").
+          # An authenticated remote URL also covers the `git pull --rebase` in the
+          # retry loop below. Same approach as code-coverage.yaml.
+          git clone --branch gh-pages --single-branch \
+            "https://x-access-token:${METRICS_PAT}@github.com/tenstorrent/tt-metal-compile-time-tracker.git" \
+            /tmp/metrics-repo
+
+          cd /tmp/metrics-repo
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 


### PR DESCRIPTION
## Summary

The `Compile Time Tracker` workflow has failed on every single scheduled run since **2026-05-16** (last success: 2026-05-15). Compilation always succeeds — only the final push of results to `tenstorrent/tt-metal-compile-time-tracker` fails, with:

```
fatal: could not read Username for 'https://github.com': No such device or address
```

### Root cause

This broke immediately after #44056 bumped `actions/checkout` from v4 → v6.0.2 in this file. `actions/checkout` v6 changed how it persists git credentials for later steps in the same job: instead of writing `http.extraheader` directly and unconditionally into the checked-out repo's `.git/config`, it now writes the token to a temp file and links it via `includeIf.gitdir:<path>` conditional includes — configured only for `$GITHUB_WORKSPACE` and `/github/workspace` paths.

This job's container bind-mounts the workspace at a custom `/work` path (the same `runner/issues/878` workaround used elsewhere in this repo, e.g. `clang-static-analyzer.yaml`), and steps run from there. So when the push step does `cd metrics-repo && git push`, the actual gitdir git resolves is `/work/metrics-repo/.git` — which matches neither `includeIf.gitdir:` path checkout configured. The conditional include never fires, no `Authorization` header applies, and the push runs anonymously.

Confirmed against the live job logs (`git config --local includeIf.gitdir:/__w/tt-metal/tt-metal/metrics-repo/.git...` and `.../github/workspace/metrics-repo/.git...`, neither matching `/work/metrics-repo/.git`) and against `actions/checkout`'s `GitAuthHelper` source, which hardcodes exactly those two path variants.

No data was lost — the target repo/branch (`tenstorrent/tt-metal-compile-time-tracker`, `gh-pages`) is intact through 2026-05-15, it just stopped receiving new commits.

### Fix

Stop depending on `actions/checkout`'s auto-persisted credentials for this step, since they're inherently path-fragile here. Instead, clone the metrics repo directly with the PAT embedded in the remote URL, into `/tmp` (already tmpfs per this job's `options: --tmpfs /tmp`) rather than the bind-mounted workspace — the same approach already used successfully by `code-coverage.yaml`'s push to `tt-metal-code-coverage` in this same repo/container/mount setup. This also covers the `git pull --rebase` retry path for free, which needs the same auth and was previously broken too.

## Test plan

- [ ] YAML validated locally (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Manually trigger via `workflow_dispatch` and confirm the push step succeeds and a new row lands in `tenstorrent/tt-metal-compile-time-tracker`'s `gh-pages` branch
- [ ] Confirm next scheduled run (midnight PST) also succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/compile-time-tracker-push-auth)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/compile-time-tracker-push-auth)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/compile-time-tracker-push-auth)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/compile-time-tracker-push-auth)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/compile-time-tracker-push-auth)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/compile-time-tracker-push-auth)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/compile-time-tracker-push-auth)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/compile-time-tracker-push-auth)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/compile-time-tracker-push-auth)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/compile-time-tracker-push-auth)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/compile-time-tracker-push-auth)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/compile-time-tracker-push-auth)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/compile-time-tracker-push-auth)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/compile-time-tracker-push-auth)