### PR TITLE
[Bug fix] embedding_bw: accumulate repeated indices in FP32

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_backward_embedding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_backward_embedding.py
@@ -120,4 +120,55 @@ def test_embedding_bw_with_program_cache(
         logger.debug(comp_out)
         assert comp_pass
 
-    assert device.cache_entries_counter.total == 1
+    # embedding_bw dispatches two programs: the device primitive, which
+    # accumulates into a private FLOAT32 result, and the typecast that converts
+    # it once to the public output dtype. Both are cached on the first call and
+    # neither is recreated on the second, so two entries is the cache-hit result.
+    assert device.cache_entries_counter.total == 2
+
+
+@pytest.mark.parametrize("collision_count", [32, 64, 128, 256, 512, 1024, 2048])
+def test_embedding_bw_repeated_indices_accumulate_exactly(collision_count, device):
+    batch_size = 32
+    seq_len = 64
+    embedding_dim = 128
+    num_embeddings = 64
+    target_index = 7
+    total_positions = batch_size * seq_len
+
+    non_target_indices = torch.tensor(
+        [index for index in range(num_embeddings) if index != target_index], dtype=torch.int64
+    )
+    input_index = non_target_indices[torch.arange(total_positions).remainder(num_embeddings - 1)]
+    target_positions = torch.div(
+        torch.arange(collision_count) * total_positions, collision_count, rounding_mode="floor"
+    )
+    input_index[target_positions] = target_index
+    input_index = input_index.reshape(batch_size, seq_len)
+
+    hidden_values = 1 + torch.arange(embedding_dim, dtype=torch.float32).remainder(8)
+    grad_data = (
+        hidden_values.view(1, 1, 1, embedding_dim)
+        .expand(1, 1, total_positions, embedding_dim)
+        .div(2048)
+        .to(torch.bfloat16)
+        .contiguous()
+    )
+    golden = torch.zeros(num_embeddings, embedding_dim, dtype=torch.float32)
+    golden.index_add_(0, input_index.reshape(-1), grad_data.float().reshape(-1, embedding_dim))
+
+    input_tensor = ttnn.from_torch(input_index, dtype=ttnn.uint32, device=device)
+    weights_tensor = ttnn.from_torch(
+        torch.zeros(num_embeddings, embedding_dim),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+    )
+    grad_tensor = ttnn.from_torch(grad_data, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    output = ttnn.embedding_bw(input_tensor, weights_tensor, grad_tensor, dtype=ttnn.bfloat16)
+    output_torch = ttnn.to_torch(output).float()
+
+    # Shape-agnostic on purpose: this test is about accumulation, not the
+    # returned rank.
+    assert torch.equal(golden, output_torch.reshape(num_embeddings, embedding_dim))

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reshuffle_rows.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_reshuffle_rows.h
@@ -10,6 +10,7 @@
 #include "ckernel_addrmod.h"
 #include "ckernel_instr_params.h"
 #include "cmath_common.h"
+#include "llk_defs.h"
 #include "sfpi.h"
 
 namespace ckernel {
@@ -39,8 +40,13 @@ namespace sfpu {
  */
 inline void reshuffle_rows_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false>
 inline void calculate_reshuffle_rows(uint idx_addr) {
+    // With FP32 destination accumulation each DEST entry is 32 bits wide, so the
+    // SFPU load/store instructions must select the FP32 instruction mode. The
+    // per-tile DEST stride below is unchanged: 64 is the stride in both modes.
+    constexpr InstrModLoadStore mod0 =
+        is_fp32_dest_acc_en ? InstrModLoadStore::FP32 : InstrModLoadStore::DEFAULT;
     constexpr std::uint32_t output_tile_offset = 64;
 
     // clr DEST tile 1
@@ -84,14 +90,17 @@ inline void calculate_reshuffle_rows(uint idx_addr) {
         std::uint32_t output_row_lreg = output_lreg[dst_row % 4];
 
         // load in the input row and output row
-        TT_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_7, input_row_addr);                             // Face 0/2, even columns
-        TT_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_7, input_row_addr + 2);                         // Face 0/2, odd columns
-        TT_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_7, input_row_addr + 16);                        // Face 1/3, even columns
-        TT_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_7, input_row_addr + 18);                        // Face 1/3, odd columns
-        TT_SFPLOAD(p_sfpu::LREG4, 0, ADDR_MOD_7, output_tile_offset + output_row_addr);       // Face 0/2, even columns
-        TT_SFPLOAD(p_sfpu::LREG5, 0, ADDR_MOD_7, output_tile_offset + output_row_addr + 2);   // Face 0/2, odd columns
-        TT_SFPLOAD(p_sfpu::LREG6, 0, ADDR_MOD_7, output_tile_offset + output_row_addr + 16);  // Face 1/3, even columns
-        TT_SFPLOAD(p_sfpu::LREG7, 0, ADDR_MOD_7, output_tile_offset + output_row_addr + 18);  // Face 1/3, odd columns
+        TT_SFPLOAD(p_sfpu::LREG0, mod0, ADDR_MOD_7, input_row_addr);                       // Face 0/2, even columns
+        TT_SFPLOAD(p_sfpu::LREG1, mod0, ADDR_MOD_7, input_row_addr + 2);                   // Face 0/2, odd columns
+        TT_SFPLOAD(p_sfpu::LREG2, mod0, ADDR_MOD_7, input_row_addr + 16);                  // Face 1/3, even columns
+        TT_SFPLOAD(p_sfpu::LREG3, mod0, ADDR_MOD_7, input_row_addr + 18);                  // Face 1/3, odd columns
+        TT_SFPLOAD(p_sfpu::LREG4, mod0, ADDR_MOD_7, output_tile_offset + output_row_addr);  // Face 0/2, even columns
+        TT_SFPLOAD(
+            p_sfpu::LREG5, mod0, ADDR_MOD_7, output_tile_offset + output_row_addr + 2);  // Face 0/2, odd columns
+        TT_SFPLOAD(
+            p_sfpu::LREG6, mod0, ADDR_MOD_7, output_tile_offset + output_row_addr + 16);  // Face 1/3, even columns
+        TT_SFPLOAD(
+            p_sfpu::LREG7, mod0, ADDR_MOD_7, output_tile_offset + output_row_addr + 18);  // Face 1/3, odd columns
         // TRANSPOSE #1: Rearrange loaded 4-row blocks to isolate target rows
         // SFPLOAD loads 4 consecutive rows (e.g., rows 4-7) into LREG0-3, but we only want one specific row (e.g., row
         // 5) This transpose shuffles the register contents so row 5 data becomes accessible via input_row_lreg[1]
@@ -107,10 +116,13 @@ inline void calculate_reshuffle_rows(uint idx_addr) {
         // Prepares the computed result for SFPSTORE, which expects data in LREG4-7 positions
         // This undoes the first transpose to match the expected storage layout
         TTI_SFPTRANSP(0, 0, 0, 0);  // Puts desired output row back into LREG4-7 for storage
-        TT_SFPSTORE(p_sfpu::LREG4, 0, ADDR_MOD_7, output_tile_offset + output_row_addr);       // Face 0/2, even columns
-        TT_SFPSTORE(p_sfpu::LREG5, 0, ADDR_MOD_7, output_tile_offset + output_row_addr + 2);   // Face 0/2, odd columns
-        TT_SFPSTORE(p_sfpu::LREG6, 0, ADDR_MOD_7, output_tile_offset + output_row_addr + 16);  // Face 1/3, even columns
-        TT_SFPSTORE(p_sfpu::LREG7, 0, ADDR_MOD_7, output_tile_offset + output_row_addr + 18);  // Face 1/3, odd columns
+        TT_SFPSTORE(p_sfpu::LREG4, mod0, ADDR_MOD_7, output_tile_offset + output_row_addr);  // Face 0/2, even columns
+        TT_SFPSTORE(
+            p_sfpu::LREG5, mod0, ADDR_MOD_7, output_tile_offset + output_row_addr + 2);  // Face 0/2, odd columns
+        TT_SFPSTORE(
+            p_sfpu::LREG6, mod0, ADDR_MOD_7, output_tile_offset + output_row_addr + 16);  // Face 1/3, even columns
+        TT_SFPSTORE(
+            p_sfpu::LREG7, mod0, ADDR_MOD_7, output_tile_offset + output_row_addr + 18);  // Face 1/3, odd columns
     }
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reshuffle_rows.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_reshuffle_rows.h
@@ -10,6 +10,7 @@
 #include "ckernel_addrmod.h"
 #include "ckernel_instr_params.h"
 #include "cmath_common.h"
+#include "llk_defs.h"
 #include "sfpi.h"
 
 namespace ckernel {
@@ -39,8 +40,13 @@ namespace sfpu {
  */
 inline void reshuffle_rows_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false>
 inline void calculate_reshuffle_rows(uint idx_addr) {
+    // With FP32 destination accumulation each DEST entry is 32 bits wide, so the
+    // SFPU load/store instructions must select the FP32 instruction mode. The
+    // per-tile DEST stride below is unchanged: 64 is the stride in both modes.
+    constexpr InstrModLoadStore mod0 =
+        is_fp32_dest_acc_en ? InstrModLoadStore::FP32 : InstrModLoadStore::DEFAULT;
     constexpr std::uint32_t output_tile_offset = 64;
 
     // clr DEST tile 1
@@ -84,14 +90,17 @@ inline void calculate_reshuffle_rows(uint idx_addr) {
         std::uint32_t output_row_lreg = output_lreg[dst_row % 4];
 
         // load in the input row and output row
-        TT_SFPLOAD(p_sfpu::LREG0, 0, ADDR_MOD_3, input_row_addr);                             // Face 0/2, even columns
-        TT_SFPLOAD(p_sfpu::LREG1, 0, ADDR_MOD_3, input_row_addr + 2);                         // Face 0/2, odd columns
-        TT_SFPLOAD(p_sfpu::LREG2, 0, ADDR_MOD_3, input_row_addr + 16);                        // Face 1/3, even columns
-        TT_SFPLOAD(p_sfpu::LREG3, 0, ADDR_MOD_3, input_row_addr + 18);                        // Face 1/3, odd columns
-        TT_SFPLOAD(p_sfpu::LREG4, 0, ADDR_MOD_3, output_tile_offset + output_row_addr);       // Face 0/2, even columns
-        TT_SFPLOAD(p_sfpu::LREG5, 0, ADDR_MOD_3, output_tile_offset + output_row_addr + 2);   // Face 0/2, odd columns
-        TT_SFPLOAD(p_sfpu::LREG6, 0, ADDR_MOD_3, output_tile_offset + output_row_addr + 16);  // Face 1/3, even columns
-        TT_SFPLOAD(p_sfpu::LREG7, 0, ADDR_MOD_3, output_tile_offset + output_row_addr + 18);  // Face 1/3, odd columns
+        TT_SFPLOAD(p_sfpu::LREG0, mod0, ADDR_MOD_3, input_row_addr);                       // Face 0/2, even columns
+        TT_SFPLOAD(p_sfpu::LREG1, mod0, ADDR_MOD_3, input_row_addr + 2);                   // Face 0/2, odd columns
+        TT_SFPLOAD(p_sfpu::LREG2, mod0, ADDR_MOD_3, input_row_addr + 16);                  // Face 1/3, even columns
+        TT_SFPLOAD(p_sfpu::LREG3, mod0, ADDR_MOD_3, input_row_addr + 18);                  // Face 1/3, odd columns
+        TT_SFPLOAD(p_sfpu::LREG4, mod0, ADDR_MOD_3, output_tile_offset + output_row_addr);  // Face 0/2, even columns
+        TT_SFPLOAD(
+            p_sfpu::LREG5, mod0, ADDR_MOD_3, output_tile_offset + output_row_addr + 2);  // Face 0/2, odd columns
+        TT_SFPLOAD(
+            p_sfpu::LREG6, mod0, ADDR_MOD_3, output_tile_offset + output_row_addr + 16);  // Face 1/3, even columns
+        TT_SFPLOAD(
+            p_sfpu::LREG7, mod0, ADDR_MOD_3, output_tile_offset + output_row_addr + 18);  // Face 1/3, odd columns
         // TRANSPOSE #1: Rearrange loaded 4-row blocks to isolate target rows
         // SFPLOAD loads 4 consecutive rows (e.g., rows 4-7) into LREG0-3, but we only want one specific row (e.g., row
         // 5) This transpose shuffles the register contents so row 5 data becomes accessible via input_row_lreg[1]
@@ -108,10 +117,13 @@ inline void calculate_reshuffle_rows(uint idx_addr) {
         // Prepares the computed result for SFPSTORE, which expects data in LREG4-7 positions
         // This undoes the first transpose to match the expected storage layout
         TTI_SFPTRANSP(0, 0, 0, 0);  // Puts desired output row back into LREG4-7 for storage
-        TT_SFPSTORE(p_sfpu::LREG4, 0, ADDR_MOD_3, output_tile_offset + output_row_addr);       // Face 0/2, even columns
-        TT_SFPSTORE(p_sfpu::LREG5, 0, ADDR_MOD_3, output_tile_offset + output_row_addr + 2);   // Face 0/2, odd columns
-        TT_SFPSTORE(p_sfpu::LREG6, 0, ADDR_MOD_3, output_tile_offset + output_row_addr + 16);  // Face 1/3, even columns
-        TT_SFPSTORE(p_sfpu::LREG7, 0, ADDR_MOD_3, output_tile_offset + output_row_addr + 18);  // Face 1/3, odd columns
+        TT_SFPSTORE(p_sfpu::LREG4, mod0, ADDR_MOD_3, output_tile_offset + output_row_addr);  // Face 0/2, even columns
+        TT_SFPSTORE(
+            p_sfpu::LREG5, mod0, ADDR_MOD_3, output_tile_offset + output_row_addr + 2);  // Face 0/2, odd columns
+        TT_SFPSTORE(
+            p_sfpu::LREG6, mod0, ADDR_MOD_3, output_tile_offset + output_row_addr + 16);  // Face 1/3, even columns
+        TT_SFPSTORE(
+            p_sfpu::LREG7, mod0, ADDR_MOD_3, output_tile_offset + output_row_addr + 18);  // Face 1/3, odd columns
     }
 }
 

--- a/tt_metal/hw/inc/api/compute/reshuffle.h
+++ b/tt_metal/hw/inc/api/compute/reshuffle.h
@@ -29,8 +29,16 @@ namespace ckernel {
  */
 // clang-format on
 ALWI void reshuffle_rows_tile(uint32_t idst, uint32_t idx_addr) {
+    // DST_ACCUM_MODE must reach the SFPU implementation: it selects the FP32
+    // load/store instruction mode required when DEST holds 32-bit entries.
     MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_reshuffle_rows, (APPROX), idst, VectorMode::RC_custom, idx_addr));
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        calculate_reshuffle_rows,
+        (APPROX, DST_ACCUM_MODE),
+        idst,
+        VectorMode::RC_custom,
+        idx_addr));
 }
 
 /**

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
@@ -43,8 +43,12 @@ void EmbeddingBackwardDeviceOperation::validate_on_program_cache_miss(
         grad_tensor.dtype() == DataType::BFLOAT16 or grad_tensor.dtype() == DataType::BFLOAT8_B,
         "Output gradient tensor must be BFLOAT16 or BFLOAT8_B");
     TT_FATAL(
-        grad_tensor.dtype() == operation_attributes.output_dtype,
-        "Output and input gradient tensors must have the same dtype");
+        grad_tensor.dtype() == operation_attributes.output_dtype or
+            operation_attributes.output_dtype == DataType::FLOAT32,
+        "Invalid output dtype {}: must match the input gradient dtype {}, or be FLOAT32 for internal "
+        "accumulation.",
+        operation_attributes.output_dtype,
+        grad_tensor.dtype());
 
     TT_FATAL(
         grad_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED or

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_descriptor.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_program_descriptor.cpp
@@ -155,7 +155,8 @@ ProgramDescriptor EmbeddingBackwardDeviceOperation::create_descriptor(
         (uint32_t)num_embeddings_tiles,
         (uint32_t)index_page_size,
         (uint32_t)(tensor_args.index_tensor.dtype() == DataType::BFLOAT16),
-        (uint32_t)(tensor_return_value.dtype() == DataType::BFLOAT16)};
+        (uint32_t)(tensor_return_value.dtype() == DataType::BFLOAT16),
+        (uint32_t)(tensor_return_value.dtype() == DataType::FLOAT32)};
     TensorAccessorArgs(*grad_tensor_buffer).append_to(reader_compile_time_args);
     TensorAccessorArgs(*index_tensor_buffer).append_to(reader_compile_time_args);
     TensorAccessorArgs(*out_buffer).append_to(reader_compile_time_args);
@@ -174,7 +175,8 @@ ProgramDescriptor EmbeddingBackwardDeviceOperation::create_descriptor(
     compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_desc.core_ranges = all_cores;
     compute_desc.compile_time_args = {max_tiles_per_core, input_height_tiles};
-    compute_desc.config = ComputeConfigDescriptor{};
+    compute_desc.config =
+        ComputeConfigDescriptor{.fp32_dest_acc_en = tensor_return_value.dtype() == DataType::FLOAT32};
 
     ////////////////////////////////////////////////////////////////////////////
     //                 Run-time arguments

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/compute/embedding_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/compute/embedding_backward.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/reconfig_data_format.h"
 #include "api/compute/reshuffle.h"
 #include "api/compute/tile_move_copy.h"
 #include "api/dataflow/circular_buffer.h"
@@ -26,6 +27,13 @@ void kernel_main() {
     CircularBuffer cb_out(cb_out_idx);
 
     unary_op_init_common(cb_grad_idx, cb_out_idx);
+
+    // cb_grad carries the incoming gradient in its public dtype (BF16/BFP8) while
+    // cb_out_intermed and cb_out hold the accumulator. When the accumulator is
+    // FLOAT32 the two differ, so the packer must be told which format it writes;
+    // the unpacker is reconfigured per copy_tile below. Without these calls the
+    // data is treated as 16-bit even with fp32_dest_acc_en enabled.
+    pack_reconfig_data_format(cb_out_idx);
 
     for (uint32_t i = 0; i < input_height; ++i) {
         cb_grad.wait_front(max_tiles_per_core);
@@ -52,8 +60,14 @@ void kernel_main() {
                 tile_regs_acquire();
                 tile_regs_wait();
 
+                // A single unpacker configuration cannot serve both source CBs
+                // once their formats diverge, so reconfigure around each copy.
+                reconfig_data_format_srca(cb_grad_idx);
+                copy_tile_to_dst_init_short(cb_grad_idx);
                 copy_tile(cb_grad_idx, hidden_dim, 0);
 
+                reconfig_data_format_srca(cb_out_intermed_idx);
+                copy_tile_to_dst_init_short(cb_out_intermed_idx);
                 copy_tile(cb_out_intermed_idx, hidden_dim, 1);
 
                 reshuffle_rows_tile_init();

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/dataflow/reader_embedding_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/kernels/dataflow/reader_embedding_backward.cpp
@@ -73,9 +73,15 @@ FORCE_INLINE void generate_mask(uint32_t index_l1_addr, uint32_t chunk_id, uint3
 
 FORCE_INLINE void generate_zeros_cb(uint32_t input_l1_addr) {
     constexpr bool is_output_bfloat16 = get_compile_time_arg_val(6) == 1;
+    constexpr bool is_output_float32 = get_compile_time_arg_val(7) == 1;
     auto input_l1_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(input_l1_addr);
 
-    if constexpr (is_output_bfloat16) {
+    if constexpr (is_output_float32) {
+        // 1024 * 4 = 4096 bytes = single tile of float32
+        for (uint32_t i = 0; i < 1024; ++i) {
+            input_l1_ptr[i] = 0;
+        }
+    } else if constexpr (is_output_bfloat16) {
         // 512 * 4 = 2048 bytes = single tile of bfloat16
         for (uint32_t i = 0; i < 512; ++i) {
             input_l1_ptr[i] = 0;
@@ -111,7 +117,7 @@ void kernel_main() {
     constexpr uint32_t grad_page_size = get_tile_size(cb_grad_idx);
     constexpr uint32_t out_page_size = get_tile_size(cb_id_out0_idx);
 
-    constexpr auto grad_args = TensorAccessorArgs<7>();
+    constexpr auto grad_args = TensorAccessorArgs<8>();
     constexpr auto index_args = TensorAccessorArgs<grad_args.next_compile_time_args_offset()>();
     constexpr auto out_args = TensorAccessorArgs<index_args.next_compile_time_args_offset()>();
 

--- a/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward.cpp
@@ -8,6 +8,7 @@
 
 #include "ttnn/common/constants.hpp"
 #include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/copy/typecast/typecast.hpp"
 #include "ttnn/operations/embedding_backward/device/embedding_backward_device_operation.hpp"
 #include "ttnn/operation.hpp"
 
@@ -30,8 +31,26 @@ Tensor embedding_bw(
     const auto output_mem_config = memory_config.value_or(output_gradient_tensor_arg.memory_config());
     const auto out_dtype = dtype.value_or(output_gradient_tensor_arg.dtype());
 
-    return ttnn::prim::embedding_backward(
-        input_tensor, output_gradient_tensor_arg, output_mem_config, out_dtype, num_embeddings, optional_output_tensor);
+    TT_FATAL(
+        out_dtype == DataType::BFLOAT16 || out_dtype == DataType::BFLOAT8_B,
+        "Embedding backward output must be BFLOAT16 or BFLOAT8_B");
+    TT_FATAL(
+        output_gradient_tensor_arg.dtype() == out_dtype,
+        "Output and input gradient tensors must have the same dtype");
+
+    // embedding_backward repeatedly reads and writes partial output tiles. Doing
+    // that in the public low-precision dtype loses contributions when an index
+    // occurs many times. Keep the public BF16/BFP8 input and output contract,
+    // but use a private FP32 accumulation buffer and convert exactly once when
+    // the complete gradient is available.
+    auto fp32_accumulation = ttnn::prim::embedding_backward(
+        input_tensor,
+        output_gradient_tensor_arg,
+        output_mem_config,
+        DataType::FLOAT32,
+        num_embeddings,
+        std::nullopt);
+    return ttnn::typecast(fp32_accumulation, out_dtype, output_mem_config, optional_output_tensor);
 }
 
 }  // namespace ttnn


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Closes #36341.

`ttnn.embedding_bw` silently loses contributions when the same index appears many times in one batch.

The device operation accumulates into partial output tiles: it reads a tile back, adds to it, and writes it out again. In BFLOAT16 or BFLOAT8_B that read-modify-write drops the increment once the running sum grows. BFLOAT16 carries 8 mantissa bits, so a sum near 256 stops absorbing increments of 1. An index that appears once is accumulated correctly. An index that appears often is not.

This is not a corner case for language models. An embedding gradient with a batch of 32 x 64 tokens over a 35-token vocabulary puts roughly 1000 contributions into a single row on every step. The reporter of #36341 hit it in Qwen 2.5 and Llama 3.2 training, with error per element reaching 30% atol.

The fix keeps the public BFLOAT16/BFLOAT8_B contract and accumulates privately in FLOAT32. Two commits:

1. **`[LLK] reshuffle_rows: honor FP32 destination accumulation`.**
   `calculate_reshuffle_rows` hard-codes instruction mode 0 (DEFAULT) in every `TT_SFPLOAD` and `TT_SFPSTORE`, so with 32-bit DEST entries it loads and stores as if they were 16-bit. Separately, `reshuffle_rows_tile` accepts `DST_ACCUM_MODE` through `SFPU_UNARY_CALL` but never forwards it. Adds an `is_fp32_dest_acc_en` template parameter selecting `InstrModLoadStore::FP32`, following `calculate_addcmul`, and forwards `DST_ACCUM_MODE`. When the parameter is false the emitted code is byte-identical, so no existing caller changes.

2. **`Fix loss of repeated-index contributions in embedding backward`.**
   `embedding_bw` now requests FLOAT32 from the primitive and typecasts exactly once, when the complete gradient is available. Supporting changes: relax the device-op dtype assertion to permit the internal FLOAT32 output, pass `fp32_dest_acc_en` in the compute config when the output is FLOAT32, teach `generate_zeros_cb` the FLOAT32 tile size, and reconfigure the unpacker around each `copy_tile` now that two circular buffers can carry different formats.

Adds `test_embedding_bw_repeated_indices_accumulate_exactly`, seven cases driving 32 to 2048 contributions into one embedding row and comparing against a CPU `index_add_` reference under `torch.equal` — exact equality, not a
tolerance.

**Measured on Blackhole** (`ubb_blackhole`, firmware 19.11.0, KMD 2.9.0), kernel cache cleared before each run so the JIT inputs were recompiled rather than served from cache:

| Tree | Collected | Result |
|---|---|---|
| unpatched `e16f6cbfb09` | 14 | 10 passed, 4 skipped |
| this PR | 21 | 17 passed, 4 skipped |

Running the new test against unpatched binaries confirms it detects the defect rather than passing either way. Six of the seven cases fail; only `collision_count=32` passes, and everything above it fails:

| `collision_count` | 32 | 64 | 128 | 256 | 512 | 1024 | 2048 |
|---|---|---|---|---|---|---|---|
| unpatched | pass | fail | fail | fail | fail | fail | fail |
| this PR | pass | pass | pass | pass | pass | pass | pass |

The threshold is where the rounding argument puts it. Each contribution is `k/2048` for `k` in 1..8, so at 32 contributions every partial sum still fits in BFLOAT16's 8 significant bits, and from 64 it does not.

The eight pre-existing numerical cases and both program-cache cases pass on both trees.

The change also reduces rounding on the shapes already covered upstream. Worst PCC across the eight `test_embedding_bw` cases moves from **0.99993880** to **0.99995352**. Maximum absolute deltas of 0.024 to 0.096 remain, consistent with ordinary BFLOAT16 rounding of the public output.

### Notes for reviewers

**The public API is unchanged, and the two dtype assertions moved in opposite directions on purpose.** The primitive's assertion is relaxed to accept a FLOAT32 output, because that is what the wrapper now asks it for. The wrapper gains an explicit check that the caller's `dtype` is BFLOAT16 or BFLOAT8_B and matches the gradient. Net effect for callers: identical to before.

**A preallocated `output_tensor` now flows into the typecast rather than into the primitive.** The primitive allocates its own FLOAT32 buffer. This is the one place where behavior a caller can observe has shifted, and it is worth a look.

Commit 1 cannot ship on its own. `reshuffle_rows_tile` has exactly one consumer in the tree.  the embedding backward compute kernel,  so alone it would add an FP32 path that nothing requests and no test exercises. Commit 2 is what enables that caller and what the tests cover.

**On the alternative diagnosis in #36341.** A comment on that issue proposes that `reshuffle_rows` overwrites rather than accumulates, and suggests serializing unique indices so reshuffle never sees a duplicate. The measurements above distinguish the two explanations, and they do not support overwriting.

On unpatched code, `collision_count=32` passes `torch.equal` **exactly** while 64 and above fail. If contributions were being overwritten, 32 would fail too, and badly, the row would hold a single contribution instead of the sum of 32.
Overwriting cannot produce a result that is bit-exact at 32 and wrong at 64. Rounding can, and the boundary falls where BFLOAT16's 8 significant bits run out. Widening the accumulator to FLOAT32 then recovers every case exactly, which it could not do if the contributions were being lost rather than rounded.

The two explanations predict different fixes, so it seemed better to lay the evidence out than to leave it implicit in the diff.

**Costs, stated plainly.** The FLOAT32 accumulation buffer is twice the size of the BFLOAT16 one. The typecast adds a second cached program, so the existing program-cache assertion moves from one entry to two, that changed line is deliberate, not a test being loosened to pass. `embedding_bw` performance is **not measured**; we can produce numbers if that blocks review. An alternative worth discussing is packing the final result directly in the requested dtype and dropping the separate typecast, which we did not attempt.

**All four files commit 2 touches are JIT inputs, not host-build inputs.** Clear the kernel cache before re-testing or the old kernels will be served.

This work came out of running a masked diffusion language model on Blackhole through PyTorch/XLA, where the gradient was wrong before the loss ever moved.