### PR TITLE
[Bug fix] embedding_bw: return a rank-2 gradient

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_backward_embedding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_backward_embedding.py
@@ -53,6 +53,7 @@ def test_embedding_bw(input_dtype, output_dtype, batch_size, seq_len, embedding_
     grad_tensor = ttnn.from_torch(grad_data, dtype=output_dtype, layout=ttnn.TILE_LAYOUT, device=device)
 
     tt_output_tensor_on_device = ttnn.embedding_bw(input_tensor, weights_ttnn, grad_tensor, dtype=output_dtype)
+    assert tt_output_tensor_on_device.shape == weights_shape
     tt_output_tensor = ttnn.to_torch(tt_output_tensor_on_device)
 
     # PyTorch reference

--- a/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/device/embedding_backward_device_operation.cpp
@@ -72,7 +72,7 @@ EmbeddingBackwardDeviceOperation::spec_return_value_t EmbeddingBackwardDeviceOpe
     const auto& grad_tensor = tensor_args.grad_tensor;
     auto embedding_dim = grad_tensor.logical_shape()[-1];
 
-    ttnn::Shape output_shape({1, 1, operation_attributes.num_embeddings, embedding_dim});
+    ttnn::Shape output_shape({operation_attributes.num_embeddings, embedding_dim});
     return tt::tt_metal::TensorSpec(
         output_shape,
         TensorLayout(

--- a/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/embedding_backward/embedding_backward_nanobind.cpp
@@ -33,7 +33,7 @@ void bind_embedding_backward(nb::module_& mod) {
 
 
         Returns:
-            ttnn.Tensor: the output tensor.
+            ttnn.Tensor: the gradient with respect to the weight tensor, of shape (num_embeddings, embedding_dim).
 
         Note:
             The input and the output gradient tensors must have the same datatype.


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Closes #53379.

`spec_return_value` builds the output shape as `{1, 1, num_embeddings, embedding_dim}`  rank 4 for what is a rank-2 gradient. The weight the gradient has to be accumulated into is rank 2, so every caller reshapes. Under PyTorch/XLA the mismatch surfaces at the framework boundary, where the gradient is checked against the parameter it belongs to. It also disagrees with the MLIR-level operation: the repro in #36341 declares `ttir.embedding_backward` as returning `tensor<128256x2048xbf16>`, rank 2.

One line changes the constructed shape to `{num_embeddings, embedding_dim}`.
One line in the existing test asserts the returned shape equals the weight shape, so the contract is pinned from now on. One line puts the shape in the docstring, which did not state one before.

Observed on Blackhole (`ubb_blackhole`, firmware 19.11.0, KMD 2.9.0), same device and session before and after:

```
unpatched:  weight shape: (96, 160)  output shape: Shape([1, 1, 96, 160])
this PR:    weight shape: (96, 160)  output shape: Shape([96, 160])
```

`tests/ttnn/unit_tests/operations/data_movement/test_backward_embedding.py`:
14 collected, 10 passed, 4 skipped, with the new assertion running in all ten.

### Notes for reviewers

**This is a breaking change, and the judgement call is yours, not mine.** Any caller relying on the rank-4 result will see a different shape. The two leading unit dimensions look vestigial, and rank 2 matches both the weight tensor and the framework's expectation, but whether they are vestigial or load-bearing is a question for the maintainers of this op. That is the whole reason this is a separate PR rather than part of #53386: it should be possible to take the accumulation fix and reject this one.

**Not a regression.** The shape has been rank-4 since the operation was added.

**Relationship to #53386.** Both PRs touch `embedding_backward_device_operation.cpp` and `test_backward_embedding.py`, but in disjoint regions, validation and the end of the test file there, the return spec and line 56 here. Verified: they merge cleanly in either order, no conflict. Neither depends on the other.