### PR TITLE
[Bug Fix] Enable fabric kernel compilation and fix H2D/D2H socket hangs under MockDevice

### DIFF
--- a/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
@@ -21,6 +21,7 @@
 #include "impl/profiler/profiler_state.hpp"
 #include "impl/profiler/profiler_state_manager.hpp"
 #include "llrt/get_platform_architecture.hpp"
+#include "llrt/rtoptions.hpp"
 #include "llrt/tt_cluster.hpp"
 #include "tt_metal/fabric/fabric_builder_context.hpp"
 #include "tt_metal/fabric/fabric_context.hpp"
@@ -135,6 +136,10 @@ TEST_F(MockDeviceAPIFixture, SwitchFromMockToRealHardware) {
 
 namespace {
 
+// Debug tooling disables erisc IRAM, which makes the mock fabric compile a no-op; the tests below
+// then have no routers to assert on. Read a fresh RunTimeOptions so this works before any context.
+bool mock_fabric_compile_is_disabled() { return !llrt::RunTimeOptions{}.get_erisc_iram_enabled(); }
+
 // get_num_fabric_initialized_routers() fatals for a device FabricBuilder never visited, so a
 // router count is itself proof the compile ran.
 void expect_mock_fabric_compiles_on_2_chips() {
@@ -157,6 +162,9 @@ void expect_mock_fabric_compiles_on_2_chips() {
 // Mock compiles the fabric program even though it never programs or syncs a router; that compile
 // is what warms the erisc kernel cache on a host with no silicon.
 TEST_F(MockDeviceAPIFixture, FabricProgramIsCompiledOnMock) {
+    if (mock_fabric_compile_is_disabled()) {
+        GTEST_SKIP() << "erisc IRAM disabled; mock fabric compile is skipped";
+    }
     experimental::configure_mock_mode(tt::ARCH::WORMHOLE_B0, 2);
     tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_1D);
     expect_mock_fabric_compiles_on_2_chips();
@@ -165,6 +173,9 @@ TEST_F(MockDeviceAPIFixture, FabricProgramIsCompiledOnMock) {
 
 // Same with the tensix mux, which additionally needs the control plane's tensix datamover config.
 TEST_F(MockDeviceAPIFixture, FabricProgramIsCompiledOnMockWithTensixMux) {
+    if (mock_fabric_compile_is_disabled()) {
+        GTEST_SKIP() << "erisc IRAM disabled; mock fabric compile is skipped";
+    }
     experimental::configure_mock_mode(tt::ARCH::WORMHOLE_B0, 2);
     tt::tt_fabric::SetFabricConfig(
         tt::tt_fabric::FabricConfig::FABRIC_1D,

--- a/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
@@ -186,18 +186,21 @@ TEST_F(MockDeviceAPIFixture, H2DSocketWritesDoNotDeadlockOnMock) {
     constexpr uint32_t kNumPages = 32;  // 8x the FIFO, so it must wrap and reclaim credit repeatedly
 
     const distributed::MeshCoreCoord recv_core{distributed::MeshCoordinate(0, 0), CoreCoord(0, 0)};
-    distributed::H2DSocket socket(
-        mesh_device, recv_core, BufferType::L1, kFifoSize, distributed::H2DMode::HOST_PUSH);
-    socket.set_page_size(kPageSize);
+    // Scoped: the socket owns device buffers, so it must be destroyed before the mesh it borrows.
+    {
+        distributed::H2DSocket socket(
+            mesh_device, recv_core, BufferType::L1, kFifoSize, distributed::H2DMode::HOST_PUSH);
+        socket.set_page_size(kPageSize);
 
-    std::vector<uint32_t> page(kPageSize / sizeof(uint32_t), 0xa5a5a5a5);
-    for (uint32_t i = 0; i < kNumPages; i++) {
-        socket.write(page.data(), 1);
+        std::vector<uint32_t> page(kPageSize / sizeof(uint32_t), 0xa5a5a5a5);
+        for (uint32_t i = 0; i < kNumPages; i++) {
+            socket.write(page.data(), 1);
+        }
+
+        // The queries and the barrier (which the destructor also calls) must agree with reserve_bytes.
+        EXPECT_TRUE(socket.has_space(kPageSize));
+        socket.barrier(1000);
     }
-
-    // The queries and the barrier (which the destructor also calls) must agree with reserve_bytes.
-    EXPECT_TRUE(socket.has_space(kPageSize));
-    socket.barrier(1000);
 
     mesh_device->close();
 }
@@ -213,34 +216,37 @@ TEST_F(MockDeviceAPIFixture, D2HSocketReadsDoNotDeadlockOnMock) {
     constexpr uint32_t kNumPages = 32;  // 8x the FIFO, so the ring must wrap repeatedly
 
     const distributed::MeshCoreCoord sender_core{distributed::MeshCoordinate(0, 0), CoreCoord(0, 0)};
-    distributed::D2HSocket socket(mesh_device, sender_core, kFifoSize);
-    socket.set_page_size(kPageSize);
+    // Scoped: the socket owns device buffers, so it must be destroyed before the mesh it borrows.
+    {
+        distributed::D2HSocket socket(mesh_device, sender_core, kFifoSize);
+        socket.set_page_size(kPageSize);
 
-    std::vector<uint32_t> page(kPageSize / sizeof(uint32_t), 0);
-    for (uint32_t i = 0; i < kNumPages; i++) {
+        std::vector<uint32_t> page(kPageSize / sizeof(uint32_t), 0);
+        for (uint32_t i = 0; i < kNumPages; i++) {
+            socket.read(page.data(), 1, /*notify_sender=*/true);
+        }
+
+        // Availability is scoped to the blocking read that asked for it, so between calls the socket
+        // reports drained. A permanently full FIFO would instead livelock the drain loops below.
+        EXPECT_FALSE(socket.has_data(kPageSize));
+        EXPECT_EQ(socket.pages_available(), 0u);
+
+        // The two idiomatic drain loops must terminate rather than spin.
+        uint32_t drained = 0;
+        while (socket.has_data(kPageSize)) {
+            socket.read(page.data(), 1, /*notify_sender=*/true);
+            ASSERT_LT(++drained, kNumPages) << "has_data() drain loop is not terminating on mock";
+        }
+        uint32_t discard_rounds = 0;
+        while (socket.discard_pending_pages() > 0) {
+            ASSERT_LT(++discard_rounds, kNumPages) << "discard_pending_pages() drain loop is not terminating on mock";
+        }
+
+        // A barrier must settle, and a read after it must still be satisfiable.
+        socket.barrier(1000);
         socket.read(page.data(), 1, /*notify_sender=*/true);
+        socket.barrier(1000);
     }
-
-    // Availability is scoped to the blocking read that asked for it, so between calls the socket
-    // reports drained. A permanently full FIFO would instead livelock the drain loops below.
-    EXPECT_FALSE(socket.has_data(kPageSize));
-    EXPECT_EQ(socket.pages_available(), 0u);
-
-    // The two idiomatic drain loops must terminate rather than spin.
-    uint32_t drained = 0;
-    while (socket.has_data(kPageSize)) {
-        socket.read(page.data(), 1, /*notify_sender=*/true);
-        ASSERT_LT(++drained, kNumPages) << "has_data() drain loop is not terminating on mock";
-    }
-    uint32_t discard_rounds = 0;
-    while (socket.discard_pending_pages() > 0) {
-        ASSERT_LT(++discard_rounds, kNumPages) << "discard_pending_pages() drain loop is not terminating on mock";
-    }
-
-    // A barrier must settle, and a read after it must still be satisfiable.
-    socket.barrier(1000);
-    socket.read(page.data(), 1, /*notify_sender=*/true);
-    socket.barrier(1000);
 
     mesh_device->close();
 }

--- a/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
+++ b/tests/tt_metal/tt_metal/device/test_mock_device_api.cpp
@@ -5,18 +5,25 @@
 #include <gtest/gtest.h>
 #include <tt-metalium/experimental/mock_device/mock_device.hpp>
 #include <tt-metalium/distributed.hpp>
+#include <tt-metalium/experimental/fabric/control_plane.hpp>
+#include <tt-metalium/experimental/fabric/fabric.hpp>
+#include <tt-metalium/experimental/sockets/d2h_socket.hpp>
+#include <tt-metalium/experimental/sockets/h2d_socket.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <umd/device/types/arch.hpp>
 
 #include <cstdlib>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "impl/context/metal_context.hpp"
 #include "impl/profiler/profiler_state.hpp"
 #include "impl/profiler/profiler_state_manager.hpp"
 #include "llrt/get_platform_architecture.hpp"
 #include "llrt/tt_cluster.hpp"
+#include "tt_metal/fabric/fabric_builder_context.hpp"
+#include "tt_metal/fabric/fabric_context.hpp"
 
 namespace tt::tt_metal {
 
@@ -124,6 +131,118 @@ TEST_F(MockDeviceAPIFixture, SwitchFromMockToRealHardware) {
     auto desc = experimental::get_mock_cluster_desc();
     ASSERT_TRUE(desc.has_value());
     EXPECT_EQ(*desc, "wormhole_N300.yaml");
+}
+
+namespace {
+
+// get_num_fabric_initialized_routers() fatals for a device FabricBuilder never visited, so a
+// router count is itself proof the compile ran.
+void expect_mock_fabric_compiles_on_2_chips() {
+    const std::vector<ChipId> device_ids{0, 1};
+    auto devices = detail::CreateDevices(device_ids);
+    ASSERT_EQ(devices.size(), device_ids.size());
+
+    const auto& builder_context =
+        MetalContext::instance().get_control_plane().get_fabric_context().get_builder_context();
+    for (const auto& [device_id, _] : devices) {
+        EXPECT_GT(builder_context.get_num_fabric_initialized_routers(device_id), 0u)
+            << "no fabric routers were built on mock device " << device_id;
+    }
+
+    detail::CloseDevices(devices);
+}
+
+}  // namespace
+
+// Mock compiles the fabric program even though it never programs or syncs a router; that compile
+// is what warms the erisc kernel cache on a host with no silicon.
+TEST_F(MockDeviceAPIFixture, FabricProgramIsCompiledOnMock) {
+    experimental::configure_mock_mode(tt::ARCH::WORMHOLE_B0, 2);
+    tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::FABRIC_1D);
+    expect_mock_fabric_compiles_on_2_chips();
+    tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
+}
+
+// Same with the tensix mux, which additionally needs the control plane's tensix datamover config.
+TEST_F(MockDeviceAPIFixture, FabricProgramIsCompiledOnMockWithTensixMux) {
+    experimental::configure_mock_mode(tt::ARCH::WORMHOLE_B0, 2);
+    tt::tt_fabric::SetFabricConfig(
+        tt::tt_fabric::FabricConfig::FABRIC_1D,
+        tt::tt_fabric::FabricReliabilityMode::STRICT_SYSTEM_HEALTH_SETUP_MODE,
+        /*num_routing_planes=*/std::nullopt,
+        tt::tt_fabric::FabricTensixConfig::MUX);
+    expect_mock_fabric_compiles_on_2_chips();
+    tt::tt_fabric::SetFabricConfig(tt::tt_fabric::FabricConfig::DISABLED);
+}
+
+// Nothing on mock advances the bytes_acked counter H2D credit accounting polls, so without the
+// self-ack the host wedges once it has written one FIFO's worth. Several FIFOs must go through.
+TEST_F(MockDeviceAPIFixture, H2DSocketWritesDoNotDeadlockOnMock) {
+    experimental::configure_mock_mode(tt::ARCH::WORMHOLE_B0, 1);
+    auto mesh_device = distributed::MeshDevice::create_unit_mesh(0);
+
+    constexpr uint32_t kFifoSize = 2048;
+    constexpr uint32_t kPageSize = 512;
+    constexpr uint32_t kNumPages = 32;  // 8x the FIFO, so it must wrap and reclaim credit repeatedly
+
+    const distributed::MeshCoreCoord recv_core{distributed::MeshCoordinate(0, 0), CoreCoord(0, 0)};
+    distributed::H2DSocket socket(
+        mesh_device, recv_core, BufferType::L1, kFifoSize, distributed::H2DMode::HOST_PUSH);
+    socket.set_page_size(kPageSize);
+
+    std::vector<uint32_t> page(kPageSize / sizeof(uint32_t), 0xa5a5a5a5);
+    for (uint32_t i = 0; i < kNumPages; i++) {
+        socket.write(page.data(), 1);
+    }
+
+    // The queries and the barrier (which the destructor also calls) must agree with reserve_bytes.
+    EXPECT_TRUE(socket.has_space(kPageSize));
+    socket.barrier(1000);
+
+    mesh_device->close();
+}
+
+// The D2H mirror: nothing produces data, so bytes_sent never advances and read() blocks forever.
+// The payload is meaningless under mock; what matters is that the host path completes.
+TEST_F(MockDeviceAPIFixture, D2HSocketReadsDoNotDeadlockOnMock) {
+    experimental::configure_mock_mode(tt::ARCH::WORMHOLE_B0, 1);
+    auto mesh_device = distributed::MeshDevice::create_unit_mesh(0);
+
+    constexpr uint32_t kFifoSize = 2048;
+    constexpr uint32_t kPageSize = 512;
+    constexpr uint32_t kNumPages = 32;  // 8x the FIFO, so the ring must wrap repeatedly
+
+    const distributed::MeshCoreCoord sender_core{distributed::MeshCoordinate(0, 0), CoreCoord(0, 0)};
+    distributed::D2HSocket socket(mesh_device, sender_core, kFifoSize);
+    socket.set_page_size(kPageSize);
+
+    std::vector<uint32_t> page(kPageSize / sizeof(uint32_t), 0);
+    for (uint32_t i = 0; i < kNumPages; i++) {
+        socket.read(page.data(), 1, /*notify_sender=*/true);
+    }
+
+    // Availability is scoped to the blocking read that asked for it, so between calls the socket
+    // reports drained. A permanently full FIFO would instead livelock the drain loops below.
+    EXPECT_FALSE(socket.has_data(kPageSize));
+    EXPECT_EQ(socket.pages_available(), 0u);
+
+    // The two idiomatic drain loops must terminate rather than spin.
+    uint32_t drained = 0;
+    while (socket.has_data(kPageSize)) {
+        socket.read(page.data(), 1, /*notify_sender=*/true);
+        ASSERT_LT(++drained, kNumPages) << "has_data() drain loop is not terminating on mock";
+    }
+    uint32_t discard_rounds = 0;
+    while (socket.discard_pending_pages() > 0) {
+        ASSERT_LT(++discard_rounds, kNumPages) << "discard_pending_pages() drain loop is not terminating on mock";
+    }
+
+    // A barrier must settle, and a read after it must still be satisfiable.
+    socket.barrier(1000);
+    socket.read(page.data(), 1, /*notify_sender=*/true);
+    socket.barrier(1000);
+
+    mesh_device->close();
 }
 
 class MockDeviceProfilerFixture : public ::testing::Test {

--- a/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
@@ -319,10 +319,10 @@ private:
     D2HSocket() = default;
 
     // Mock owner only: redirect the device-produced counter to a host-side stand-in.
-    void apply_mock_self_feed(const MeshDevice& mesh_device);
+    void enable_mock_flow_control(const MeshDevice& mesh_device);
 
     // Release a blocked mock wait without advertising persistent availability.
-    void mock_grant(uint32_t num_bytes) { mock_bytes_sent_ = bytes_acked_ + num_bytes; }
+    void simulate_device_sent(uint32_t num_bytes) { mock_bytes_sent_ = bytes_acked_ + num_bytes; }
 
     struct PinnedBufferInfo {
         uint32_t pcie_xy_enc = 0;
@@ -372,7 +372,7 @@ private:
     uint32_t* bytes_sent_ptr_ = nullptr;
     // Host-side device-counter stand-in and its activation flag for mock.
     uint32_t mock_bytes_sent_ = 0;
-    bool mock_self_feed_ = false;
+    bool mock_flow_control_enabled_ = false;
     std::function<void(void*, uint32_t, uint64_t)> pcie_writer_ = nullptr;
     std::unique_ptr<NamedShm> shm_;
     ProcessScope process_scope_ = ProcessScope::CrossProcess;

--- a/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
@@ -318,6 +318,16 @@ public:
 private:
     D2HSocket() = default;
 
+    // Mock only: repoint bytes_sent_ptr_ at a host-side stand-in for the counter the device
+    // would write, so a blocking wait can be satisfied. See the definition for the contract.
+    void apply_mock_self_feed(const MeshDevice* mesh_device);
+
+    // Mock only: grant exactly `num_bytes` of synthetic payload, enough to release the caller
+    // that is currently blocked. Consuming it brings bytes_acked_ back level with the stand-in
+    // counter, which is what leaves the socket reading as drained again afterwards. Call only
+    // from a blocking wait; never to top the FIFO up speculatively.
+    void mock_grant(uint32_t num_bytes) { mock_bytes_sent_ = bytes_acked_ + num_bytes; }
+
     struct PinnedBufferInfo {
         uint32_t pcie_xy_enc = 0;
         uint32_t addr_lo = 0;
@@ -364,6 +374,10 @@ private:
     std::shared_ptr<tt::tt_metal::experimental::PinnedMemory> pinned_memory_ = nullptr;
     std::shared_ptr<uint32_t[]> host_buffer_ = nullptr;
     uint32_t* bytes_sent_ptr_ = nullptr;
+    // Mock only (see apply_mock_self_feed): the stand-in bytes_sent_ptr_ is aimed at, and the
+    // flag that lets blocking waits grant exactly the synthetic bytes they need.
+    uint32_t mock_bytes_sent_ = 0;
+    bool mock_self_feed_ = false;
     std::function<void(void*, uint32_t, uint64_t)> pcie_writer_ = nullptr;
     std::unique_ptr<NamedShm> shm_;
     ProcessScope process_scope_ = ProcessScope::CrossProcess;

--- a/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/d2h_socket.hpp
@@ -318,14 +318,10 @@ public:
 private:
     D2HSocket() = default;
 
-    // Mock only: repoint bytes_sent_ptr_ at a host-side stand-in for the counter the device
-    // would write, so a blocking wait can be satisfied. See the definition for the contract.
-    void apply_mock_self_feed(const MeshDevice* mesh_device);
+    // Mock owner only: redirect the device-produced counter to a host-side stand-in.
+    void apply_mock_self_feed(const MeshDevice& mesh_device);
 
-    // Mock only: grant exactly `num_bytes` of synthetic payload, enough to release the caller
-    // that is currently blocked. Consuming it brings bytes_acked_ back level with the stand-in
-    // counter, which is what leaves the socket reading as drained again afterwards. Call only
-    // from a blocking wait; never to top the FIFO up speculatively.
+    // Release a blocked mock wait without advertising persistent availability.
     void mock_grant(uint32_t num_bytes) { mock_bytes_sent_ = bytes_acked_ + num_bytes; }
 
     struct PinnedBufferInfo {
@@ -374,8 +370,7 @@ private:
     std::shared_ptr<tt::tt_metal::experimental::PinnedMemory> pinned_memory_ = nullptr;
     std::shared_ptr<uint32_t[]> host_buffer_ = nullptr;
     uint32_t* bytes_sent_ptr_ = nullptr;
-    // Mock only (see apply_mock_self_feed): the stand-in bytes_sent_ptr_ is aimed at, and the
-    // flag that lets blocking waits grant exactly the synthetic bytes they need.
+    // Host-side device-counter stand-in and its activation flag for mock.
     uint32_t mock_bytes_sent_ = 0;
     bool mock_self_feed_ = false;
     std::function<void(void*, uint32_t, uint64_t)> pcie_writer_ = nullptr;

--- a/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
@@ -244,7 +244,7 @@ private:
 
     // Mock owner only: alias bytes_acked_ptr_ to bytes_sent_ so the FIFO reads as drained.
     // Connectors remain context-free and do not use this path.
-    void apply_mock_self_ack(const MeshDevice& mesh_device);
+    void enable_mock_flow_control(const MeshDevice& mesh_device);
 
     void reserve_bytes(uint32_t num_bytes);
     void push_bytes(uint32_t num_bytes);

--- a/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
@@ -242,6 +242,11 @@ private:
     void init_receiver_tlb(
         const std::shared_ptr<MeshDevice>& mesh_device, std::optional<uint32_t> device_id = std::nullopt);
 
+    // Mock owner only: repoint bytes_acked_ptr_ at this socket's own bytes_sent_ so the FIFO
+    // always reads as fully drained. The MeshDevice resolves the owning context; nullptr leaves
+    // connector sockets unchanged so they retain their context-free construction contract.
+    void apply_mock_self_ack(const MeshDevice* mesh_device);
+
     void reserve_bytes(uint32_t num_bytes);
     void push_bytes(uint32_t num_bytes);
     void notify_receiver();

--- a/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
+++ b/tt_metal/api/tt-metalium/experimental/sockets/h2d_socket.hpp
@@ -242,10 +242,9 @@ private:
     void init_receiver_tlb(
         const std::shared_ptr<MeshDevice>& mesh_device, std::optional<uint32_t> device_id = std::nullopt);
 
-    // Mock owner only: repoint bytes_acked_ptr_ at this socket's own bytes_sent_ so the FIFO
-    // always reads as fully drained. The MeshDevice resolves the owning context; nullptr leaves
-    // connector sockets unchanged so they retain their context-free construction contract.
-    void apply_mock_self_ack(const MeshDevice* mesh_device);
+    // Mock owner only: alias bytes_acked_ptr_ to bytes_sent_ so the FIFO reads as drained.
+    // Connectors remain context-free and do not use this path.
+    void apply_mock_self_ack(const MeshDevice& mesh_device);
 
     void reserve_bytes(uint32_t num_bytes);
     void push_bytes(uint32_t num_bytes);

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -333,7 +333,7 @@ void D2HSocket::init_common(const std::shared_ptr<MeshDevice>& mesh_device) {
     const SocketSenderSize sender_size;
     bytes_acked_device_offset_ = sender_size.md_size_bytes;
 
-    apply_mock_self_feed(*mesh_device);
+    enable_mock_flow_control(*mesh_device);
 }
 
 D2HSocket::D2HSocket(
@@ -439,8 +439,8 @@ void D2HSocket::set_page_size(uint32_t page_size) {
 
         while (bytes_recv < bytes_adjustment) {
             // On mock, synthesize the wrap padding that bytes_acked_ consumes below.
-            if (mock_self_feed_) {
-                mock_grant(bytes_adjustment);
+            if (mock_flow_control_enabled_) {
+                simulate_device_sent(bytes_adjustment);
             }
             volatile uint32_t bytes_sent_value = using_hugepage_ ? *hugepage_bytes_sent_host_ptr_ : bytes_sent_ptr_[0];
             bytes_recv = bytes_sent_value - bytes_acked_;
@@ -480,8 +480,8 @@ void D2HSocket::wait_for_bytes(uint32_t num_bytes) {
     uint32_t bytes_recv = bytes_sent_ - bytes_acked_;
     while (bytes_recv < num_bytes) {
         // On mock, synthesize exactly the wrap-adjusted bytes this read needs.
-        if (mock_self_feed_) {
-            mock_grant(num_bytes);
+        if (mock_flow_control_enabled_) {
+            simulate_device_sent(num_bytes);
         }
         advance_d2h_simulator_socket_device(mesh_device_, sender_core_.device_coord);
         if (using_hugepage_) {
@@ -499,18 +499,18 @@ void D2HSocket::wait_for_bytes(uint32_t num_bytes) {
     }
 }
 
-void D2HSocket::apply_mock_self_feed(const MeshDevice& mesh_device) {
-    // Emule executes the sender, so only Mock needs a synthetic feed.
+void D2HSocket::enable_mock_flow_control(const MeshDevice& mesh_device) {
+    // Emule executes the sender, so only Mock needs simulated sends.
     if (MetalContext::instance(extract_context_id(&mesh_device)).get_cluster().get_target_device_type() !=
         tt::TargetDevice::Mock) {
         return;
     }
-    // Grants are observed through bytes_sent_ptr_, so mock must remain on the pinned path.
+    // Simulated sends are observed through bytes_sent_ptr_, so mock must stay on the pinned path.
     TT_FATAL(!using_hugepage_, "Mock D2H sockets must use the pinned path, not the hugepage fallback.");
 
-    // Grant only blocking waits. Consuming a grant restores sent == acked, so reads complete while
-    // non-blocking availability checks and drain APIs continue to report an empty socket.
-    mock_self_feed_ = true;
+    // Simulate sends only for blocking waits. Consuming one restores sent == acked, so reads
+    // complete while non-blocking checks and drain APIs continue to report an empty socket.
+    mock_flow_control_enabled_ = true;
     bytes_sent_ptr_ = &mock_bytes_sent_;
     mock_bytes_sent_ = bytes_acked_;
 }

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -285,7 +285,15 @@ void D2HSocket::init_common(const std::shared_ptr<MeshDevice>& mesh_device) {
     const uint32_t pcie_alignment = pcie_alignment_;
     TT_FATAL(fifo_size_ % pcie_alignment == 0, "FIFO size must be PCIe-aligned.");
 
-    bool can_use_pinned_memory = !d2h_uses_hugepage_fallback(MetalContext::instance());
+    // Mock must not take the hugepage fallback: SystemMemoryManager::allocate_region is stubbed
+    // there and hands back a null region, which init_host_buffer_hugepage then memsets (segfault
+    // during construction, before any transfer is attempted). Mock only reaches that branch as an
+    // artifact of the predicate -- iommu_enabled_ is only ever probed for Silicon, so it reads
+    // false on mock and, on an arch without 64-bit PCIe addressing, forces the fallback. The
+    // pinned path works on mock (PinnedMemory has a Mock-only no-mapping path), so use it.
+    auto& ctx = MetalContext::instance(extract_context_id(mesh_device.get()));
+    bool can_use_pinned_memory =
+        !d2h_uses_hugepage_fallback(ctx) || ctx.get_cluster().get_target_device_type() == tt::TargetDevice::Mock;
 
     PinnedBufferInfo data_info;
     PinnedBufferInfo bytes_sent_info;
@@ -329,6 +337,8 @@ void D2HSocket::init_common(const std::shared_ptr<MeshDevice>& mesh_device) {
 
     const SocketSenderSize sender_size;
     bytes_acked_device_offset_ = sender_size.md_size_bytes;
+
+    apply_mock_self_feed(mesh_device.get());
 }
 
 D2HSocket::D2HSocket(
@@ -433,6 +443,12 @@ void D2HSocket::set_page_size(uint32_t page_size) {
         uint32_t bytes_recv = bytes_sent_ - bytes_acked_;
 
         while (bytes_recv < bytes_adjustment) {
+            // Mock: grant the tail bytes this wrap is waiting on. The bytes_acked_ advance just
+            // below consumes them, leaving the socket drained. Free on silicon -- this body only
+            // runs when the host would otherwise block.
+            if (mock_self_feed_) {
+                mock_grant(bytes_adjustment);
+            }
             volatile uint32_t bytes_sent_value = using_hugepage_ ? *hugepage_bytes_sent_host_ptr_ : bytes_sent_ptr_[0];
             bytes_recv = bytes_sent_value - bytes_acked_;
             bytes_sent_ = bytes_sent_value;
@@ -470,6 +486,13 @@ void D2HSocket::wait_for_bytes(uint32_t num_bytes) {
     }
     uint32_t bytes_recv = bytes_sent_ - bytes_acked_;
     while (bytes_recv < num_bytes) {
+        // Mock: grant exactly what this read is blocked on -- no more, so the socket reads as
+        // drained again once the caller pops it. `num_bytes` is already wrap-adjusted above by
+        // the same rule pop_bytes uses to advance bytes_acked_, so the two land level. Free on
+        // silicon: this body only runs when the host would otherwise block.
+        if (mock_self_feed_) {
+            mock_grant(num_bytes);
+        }
         advance_d2h_simulator_socket_device(mesh_device_, sender_core_.device_coord);
         if (using_hugepage_) {
             _mm_clflush(const_cast<void*>(reinterpret_cast<const volatile void*>(hugepage_bytes_sent_host_ptr_)));
@@ -484,6 +507,65 @@ void D2HSocket::wait_for_bytes(uint32_t num_bytes) {
             bytes_sent_ = bytes_sent_value;
         }
     }
+}
+
+void D2HSocket::apply_mock_self_feed(const MeshDevice* mesh_device) {
+    // Owner-only. A connector has no MeshDevice, and resolving the target type from
+    // process-global state would be wrong twice over: MetalContext::instance() *creates* a
+    // default context (and a MetalEnv, opening the driver) when none exists, which is exactly
+    // what a connector process is documented to avoid; and the answer would describe the
+    // connector's own process rather than the owner's target. Cross-process mock is not
+    // reachable anyway -- PCIeCoreWriter enumerates real PCIe devices and throws when the
+    // descriptor's device is absent -- so a connector is silicon by construction. Supporting it
+    // would mean carrying the owner's target type in the descriptor as versioned metadata.
+    if (mesh_device == nullptr) {
+        return;
+    }
+    // Mock only. Emule is deliberately excluded: it really runs the sender kernel and really
+    // fills the FIFO (advance_d2h_simulator_socket_device pumps its scheduler for exactly this
+    // wait), so synthesizing data there would replace real device output with stale bytes.
+    if (MetalContext::instance(extract_context_id(mesh_device)).get_cluster().get_target_device_type() !=
+        tt::TargetDevice::Mock) {
+        return;
+    }
+
+    // A mock device never executes, so it never writes the bytes_sent counter the host polls for
+    // available data, and every read() blocks forever.
+    //
+    // Unlike the H2D direction there is no honest value to converge on: the device is the
+    // producer here, so a mock read necessarily returns whatever happens to be in the FIFO
+    // (zeros, from the zero-initialized SHM). That is the same contract every other device read
+    // already has under mock -- ReadFromDeviceL1 and EnqueueReadBuffer leave the caller's buffer
+    // untouched -- so it introduces no new class of lie. What it buys is that the host code path
+    // runs to completion instead of wedging.
+    //
+    // The contract, deliberately narrow: mock satisfies *blocking* waits and nothing else.
+    // A blocking wait grants itself exactly the bytes it is waiting on (mock_grant), the caller
+    // consumes them, and bytes_acked_ ends up level with the stand-in counter again. So between
+    // calls the socket reads as drained, which is the truthful answer -- no device produced
+    // anything -- and is what the non-blocking queries report:
+    //
+    //   has_data()              -> false
+    //   pages_available()       -> 0
+    //   discard_pending_pages() -> 0
+    //   barrier()               -> returns immediately, no mock special case needed
+    //
+    // The alternative, holding the counter permanently one FIFO ahead, would make every one of
+    // those advertise unbounded device output and would livelock the ordinary drain loops
+    // (`while (has_data()) read();`, `while (discard_pending_pages()) ;`). Trading a blocking
+    // hang for a spinning one is not an improvement, so availability is scoped to the blocking
+    // call that asked for it.
+    //
+    // The residual sharp edge is a caller that polls *for* data (`while (!has_data()) ;`) instead
+    // of blocking in read(): no mock policy can satisfy both that and a drain loop, and such a
+    // caller is explicitly waiting on a device that mock does not have.
+    //
+    // Safe for the same reasons as the H2D alias: every host-side use of bytes_sent_ptr_ is a
+    // read (only the device writes it, over PCIe), and D2HSocket is neither copyable nor movable,
+    // so the self-pointer stays valid for the object's lifetime.
+    mock_self_feed_ = true;
+    bytes_sent_ptr_ = &mock_bytes_sent_;
+    mock_bytes_sent_ = bytes_acked_;
 }
 
 void D2HSocket::pop_bytes(uint32_t num_bytes) {
@@ -575,6 +657,8 @@ void D2HSocket::barrier(std::optional<uint32_t> timeout_ms) {
             }
         }
     }
+    // No mock case here: a mock socket is always level (each grant is consumed by the read that
+    // triggered it), so the loop above is never entered.
 }
 
 void D2HSocket::read(void* data, uint32_t num_pages, bool notify_sender) {

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -285,12 +285,7 @@ void D2HSocket::init_common(const std::shared_ptr<MeshDevice>& mesh_device) {
     const uint32_t pcie_alignment = pcie_alignment_;
     TT_FATAL(fifo_size_ % pcie_alignment == 0, "FIFO size must be PCIe-aligned.");
 
-    // Mock must not take the hugepage fallback: SystemMemoryManager::allocate_region is stubbed
-    // there and hands back a null region, which init_host_buffer_hugepage then memsets (segfault
-    // during construction, before any transfer is attempted). Mock only reaches that branch as an
-    // artifact of the predicate -- iommu_enabled_ is only ever probed for Silicon, so it reads
-    // false on mock and, on an arch without 64-bit PCIe addressing, forces the fallback. The
-    // pinned path works on mock (PinnedMemory has a Mock-only no-mapping path), so use it.
+    // The hugepage fallback segfaults on mock (sysmem is stubbed); force the pinned path.
     auto& ctx = MetalContext::instance(extract_context_id(mesh_device.get()));
     bool can_use_pinned_memory =
         !d2h_uses_hugepage_fallback(ctx) || ctx.get_cluster().get_target_device_type() == tt::TargetDevice::Mock;
@@ -338,7 +333,7 @@ void D2HSocket::init_common(const std::shared_ptr<MeshDevice>& mesh_device) {
     const SocketSenderSize sender_size;
     bytes_acked_device_offset_ = sender_size.md_size_bytes;
 
-    apply_mock_self_feed(mesh_device.get());
+    apply_mock_self_feed(*mesh_device);
 }
 
 D2HSocket::D2HSocket(
@@ -443,9 +438,7 @@ void D2HSocket::set_page_size(uint32_t page_size) {
         uint32_t bytes_recv = bytes_sent_ - bytes_acked_;
 
         while (bytes_recv < bytes_adjustment) {
-            // Mock: grant the tail bytes this wrap is waiting on. The bytes_acked_ advance just
-            // below consumes them, leaving the socket drained. Free on silicon -- this body only
-            // runs when the host would otherwise block.
+            // On mock, synthesize the wrap padding that bytes_acked_ consumes below.
             if (mock_self_feed_) {
                 mock_grant(bytes_adjustment);
             }
@@ -486,10 +479,7 @@ void D2HSocket::wait_for_bytes(uint32_t num_bytes) {
     }
     uint32_t bytes_recv = bytes_sent_ - bytes_acked_;
     while (bytes_recv < num_bytes) {
-        // Mock: grant exactly what this read is blocked on -- no more, so the socket reads as
-        // drained again once the caller pops it. `num_bytes` is already wrap-adjusted above by
-        // the same rule pop_bytes uses to advance bytes_acked_, so the two land level. Free on
-        // silicon: this body only runs when the host would otherwise block.
+        // On mock, synthesize exactly the wrap-adjusted bytes this read needs.
         if (mock_self_feed_) {
             mock_grant(num_bytes);
         }
@@ -509,60 +499,17 @@ void D2HSocket::wait_for_bytes(uint32_t num_bytes) {
     }
 }
 
-void D2HSocket::apply_mock_self_feed(const MeshDevice* mesh_device) {
-    // Owner-only. A connector has no MeshDevice, and resolving the target type from
-    // process-global state would be wrong twice over: MetalContext::instance() *creates* a
-    // default context (and a MetalEnv, opening the driver) when none exists, which is exactly
-    // what a connector process is documented to avoid; and the answer would describe the
-    // connector's own process rather than the owner's target. Cross-process mock is not
-    // reachable anyway -- PCIeCoreWriter enumerates real PCIe devices and throws when the
-    // descriptor's device is absent -- so a connector is silicon by construction. Supporting it
-    // would mean carrying the owner's target type in the descriptor as versioned metadata.
-    if (mesh_device == nullptr) {
-        return;
-    }
-    // Mock only. Emule is deliberately excluded: it really runs the sender kernel and really
-    // fills the FIFO (advance_d2h_simulator_socket_device pumps its scheduler for exactly this
-    // wait), so synthesizing data there would replace real device output with stale bytes.
-    if (MetalContext::instance(extract_context_id(mesh_device)).get_cluster().get_target_device_type() !=
+void D2HSocket::apply_mock_self_feed(const MeshDevice& mesh_device) {
+    // Emule executes the sender, so only Mock needs a synthetic feed.
+    if (MetalContext::instance(extract_context_id(&mesh_device)).get_cluster().get_target_device_type() !=
         tt::TargetDevice::Mock) {
         return;
     }
+    // Grants are observed through bytes_sent_ptr_, so mock must remain on the pinned path.
+    TT_FATAL(!using_hugepage_, "Mock D2H sockets must use the pinned path, not the hugepage fallback.");
 
-    // A mock device never executes, so it never writes the bytes_sent counter the host polls for
-    // available data, and every read() blocks forever.
-    //
-    // Unlike the H2D direction there is no honest value to converge on: the device is the
-    // producer here, so a mock read necessarily returns whatever happens to be in the FIFO
-    // (zeros, from the zero-initialized SHM). That is the same contract every other device read
-    // already has under mock -- ReadFromDeviceL1 and EnqueueReadBuffer leave the caller's buffer
-    // untouched -- so it introduces no new class of lie. What it buys is that the host code path
-    // runs to completion instead of wedging.
-    //
-    // The contract, deliberately narrow: mock satisfies *blocking* waits and nothing else.
-    // A blocking wait grants itself exactly the bytes it is waiting on (mock_grant), the caller
-    // consumes them, and bytes_acked_ ends up level with the stand-in counter again. So between
-    // calls the socket reads as drained, which is the truthful answer -- no device produced
-    // anything -- and is what the non-blocking queries report:
-    //
-    //   has_data()              -> false
-    //   pages_available()       -> 0
-    //   discard_pending_pages() -> 0
-    //   barrier()               -> returns immediately, no mock special case needed
-    //
-    // The alternative, holding the counter permanently one FIFO ahead, would make every one of
-    // those advertise unbounded device output and would livelock the ordinary drain loops
-    // (`while (has_data()) read();`, `while (discard_pending_pages()) ;`). Trading a blocking
-    // hang for a spinning one is not an improvement, so availability is scoped to the blocking
-    // call that asked for it.
-    //
-    // The residual sharp edge is a caller that polls *for* data (`while (!has_data()) ;`) instead
-    // of blocking in read(): no mock policy can satisfy both that and a drain loop, and such a
-    // caller is explicitly waiting on a device that mock does not have.
-    //
-    // Safe for the same reasons as the H2D alias: every host-side use of bytes_sent_ptr_ is a
-    // read (only the device writes it, over PCIe), and D2HSocket is neither copyable nor movable,
-    // so the self-pointer stays valid for the object's lifetime.
+    // Grant only blocking waits. Consuming a grant restores sent == acked, so reads complete while
+    // non-blocking availability checks and drain APIs continue to report an empty socket.
     mock_self_feed_ = true;
     bytes_sent_ptr_ = &mock_bytes_sent_;
     mock_bytes_sent_ = bytes_acked_;
@@ -657,8 +604,6 @@ void D2HSocket::barrier(std::optional<uint32_t> timeout_ms) {
             }
         }
     }
-    // No mock case here: a mock socket is always level (each grant is consumed by the read that
-    // triggered it), so the loop above is never entered.
 }
 
 void D2HSocket::read(void* data, uint32_t num_pages, bool notify_sender) {

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -53,7 +53,7 @@ void advance_h2d_simulator_socket_device(MeshDevice* mesh_device, const MeshCoor
 
 }  // namespace
 
-void H2DSocket::apply_mock_self_ack(const MeshDevice& mesh_device) {
+void H2DSocket::enable_mock_flow_control(const MeshDevice& mesh_device) {
     // Emule executes the receiver, so only Mock needs synthetic acknowledgements.
     if (MetalContext::instance(extract_context_id(&mesh_device)).get_cluster().get_target_device_type() !=
         tt::TargetDevice::Mock) {
@@ -376,7 +376,7 @@ H2DSocket::H2DSocket(
         bytes_acked_info = init_bytes_acked_buffer(mesh_device, recv_device_range_set, pcie_alignment, shm_name);
         bytes_acked_ptr_ = host_buffer_.get();
     }
-    apply_mock_self_ack(*mesh_device);
+    enable_mock_flow_control(*mesh_device);
 
     init_config_buffer(mesh_device);
     init_data_buffer(mesh_device, pcie_alignment);
@@ -420,7 +420,7 @@ H2DSocket::H2DSocket(
     PinnedBufferInfo bytes_acked_info =
         init_bytes_acked_buffer(mesh_device, recv_device_range_set, pcie_alignment_, shm_name);
     bytes_acked_ptr_ = host_buffer_.get();
-    apply_mock_self_ack(*mesh_device);
+    enable_mock_flow_control(*mesh_device);
 
     // Take the caller-supplied DRISC L1 offsets verbatim. No MeshBuffer allocation:
     // the framework's L1 allocator is worker-only, and host writes to DRAM-L1 go

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -53,6 +53,41 @@ void advance_h2d_simulator_socket_device(MeshDevice* mesh_device, const MeshCoor
 
 }  // namespace
 
+void H2DSocket::apply_mock_self_ack(const MeshDevice* mesh_device) {
+    // Owner-only. A connector has no MeshDevice, and resolving the target type from
+    // process-global state would be wrong twice over: MetalContext::instance() *creates* a
+    // default context (and a MetalEnv, opening the driver) when none exists, which is exactly
+    // what a connector process is documented to avoid; and the answer would describe the
+    // connector's own process rather than the owner's target. Cross-process mock is not
+    // reachable anyway -- PCIeCoreWriter enumerates real PCIe devices and throws when the
+    // descriptor's device is absent -- so a connector is silicon by construction. Supporting it
+    // would mean carrying the owner's target type in the descriptor as versioned metadata.
+    if (mesh_device == nullptr) {
+        return;
+    }
+    // Mock only. Emule is deliberately excluded: it really runs the receiver kernel and really
+    // drains the FIFO (advance_h2d_simulator_socket_device pumps its scheduler for exactly this
+    // wait), so faking acks there would let the host overwrite bytes the device has not read.
+    if (MetalContext::instance(extract_context_id(mesh_device)).get_cluster().get_target_device_type() !=
+        tt::TargetDevice::Mock) {
+        return;
+    }
+
+    // A mock device never executes, so it never writes the bytes_acked counter that the host
+    // polls for FIFO credit. The counter stays 0, and once the host has written fifo_size_ bytes
+    // every credit wait blocks forever. Model mock as an infinitely fast consumer instead:
+    // point the ack counter at our own bytes_sent_, so acked always equals sent and the FIFO
+    // always reads as empty.
+    //
+    // Repointing rather than branching in the data path fixes all four readers at once
+    // (reserve_bytes / has_space / acked_past / barrier) and costs nothing on silicon -- this is
+    // a pointer store at construction, not a per-write check. Every host-side use of
+    // bytes_acked_ptr_ is a read (only the device writes it, over PCIe), so aliasing it onto a
+    // host counter cannot corrupt socket state. H2DSocket is neither copyable nor movable, so
+    // the self-pointer stays valid for the object's lifetime.
+    bytes_acked_ptr_ = &bytes_sent_;
+}
+
 H2DSocket::PinnedBufferInfo H2DSocket::init_bytes_acked_buffer(
     const std::shared_ptr<MeshDevice>& mesh_device,
     const MeshCoordinateRangeSet& device_range,
@@ -364,6 +399,7 @@ H2DSocket::H2DSocket(
         bytes_acked_info = init_bytes_acked_buffer(mesh_device, recv_device_range_set, pcie_alignment, shm_name);
         bytes_acked_ptr_ = host_buffer_.get();
     }
+    apply_mock_self_ack(mesh_device.get());
 
     init_config_buffer(mesh_device);
     init_data_buffer(mesh_device, pcie_alignment);
@@ -407,6 +443,7 @@ H2DSocket::H2DSocket(
     PinnedBufferInfo bytes_acked_info =
         init_bytes_acked_buffer(mesh_device, recv_device_range_set, pcie_alignment_, shm_name);
     bytes_acked_ptr_ = host_buffer_.get();
+    apply_mock_self_ack(mesh_device.get());
 
     // Take the caller-supplied DRISC L1 offsets verbatim. No MeshBuffer allocation:
     // the framework's L1 allocator is worker-only, and host writes to DRAM-L1 go

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -53,38 +53,15 @@ void advance_h2d_simulator_socket_device(MeshDevice* mesh_device, const MeshCoor
 
 }  // namespace
 
-void H2DSocket::apply_mock_self_ack(const MeshDevice* mesh_device) {
-    // Owner-only. A connector has no MeshDevice, and resolving the target type from
-    // process-global state would be wrong twice over: MetalContext::instance() *creates* a
-    // default context (and a MetalEnv, opening the driver) when none exists, which is exactly
-    // what a connector process is documented to avoid; and the answer would describe the
-    // connector's own process rather than the owner's target. Cross-process mock is not
-    // reachable anyway -- PCIeCoreWriter enumerates real PCIe devices and throws when the
-    // descriptor's device is absent -- so a connector is silicon by construction. Supporting it
-    // would mean carrying the owner's target type in the descriptor as versioned metadata.
-    if (mesh_device == nullptr) {
-        return;
-    }
-    // Mock only. Emule is deliberately excluded: it really runs the receiver kernel and really
-    // drains the FIFO (advance_h2d_simulator_socket_device pumps its scheduler for exactly this
-    // wait), so faking acks there would let the host overwrite bytes the device has not read.
-    if (MetalContext::instance(extract_context_id(mesh_device)).get_cluster().get_target_device_type() !=
+void H2DSocket::apply_mock_self_ack(const MeshDevice& mesh_device) {
+    // Emule executes the receiver, so only Mock needs synthetic acknowledgements.
+    if (MetalContext::instance(extract_context_id(&mesh_device)).get_cluster().get_target_device_type() !=
         tt::TargetDevice::Mock) {
         return;
     }
 
-    // A mock device never executes, so it never writes the bytes_acked counter that the host
-    // polls for FIFO credit. The counter stays 0, and once the host has written fifo_size_ bytes
-    // every credit wait blocks forever. Model mock as an infinitely fast consumer instead:
-    // point the ack counter at our own bytes_sent_, so acked always equals sent and the FIFO
-    // always reads as empty.
-    //
-    // Repointing rather than branching in the data path fixes all four readers at once
-    // (reserve_bytes / has_space / acked_past / barrier) and costs nothing on silicon -- this is
-    // a pointer store at construction, not a per-write check. Every host-side use of
-    // bytes_acked_ptr_ is a read (only the device writes it, over PCIe), so aliasing it onto a
-    // host counter cannot corrupt socket state. H2DSocket is neither copyable nor movable, so
-    // the self-pointer stays valid for the object's lifetime.
+    // Alias the acknowledgement counter to bytes_sent_ so the FIFO always reads as drained. All
+    // host-side uses of bytes_acked_ptr_ are reads, and the non-movable socket keeps the pointer valid.
     bytes_acked_ptr_ = &bytes_sent_;
 }
 
@@ -399,7 +376,7 @@ H2DSocket::H2DSocket(
         bytes_acked_info = init_bytes_acked_buffer(mesh_device, recv_device_range_set, pcie_alignment, shm_name);
         bytes_acked_ptr_ = host_buffer_.get();
     }
-    apply_mock_self_ack(mesh_device.get());
+    apply_mock_self_ack(*mesh_device);
 
     init_config_buffer(mesh_device);
     init_data_buffer(mesh_device, pcie_alignment);
@@ -443,7 +420,7 @@ H2DSocket::H2DSocket(
     PinnedBufferInfo bytes_acked_info =
         init_bytes_acked_buffer(mesh_device, recv_device_range_set, pcie_alignment_, shm_name);
     bytes_acked_ptr_ = host_buffer_.get();
-    apply_mock_self_ack(mesh_device.get());
+    apply_mock_self_ack(*mesh_device);
 
     // Take the caller-supplied DRISC L1 offsets verbatim. No MeshBuffer allocation:
     // the framework's L1 allocator is worker-only, and host writes to DRAM-L1 go

--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -376,10 +376,11 @@ void MetalEnvImpl::initialize_fabric_tensix_datamover_config() {
         return;
     }
 
-    if (get_cluster().get_target_device_type() == tt::TargetDevice::Mock) {
-        return;
-    }
-
+    // Mock is not excluded here. FabricTensixDatamoverConfig is derived entirely from the control
+    // plane and soc descriptor -- it performs no device I/O -- and FabricFirmwareInitializer now
+    // compiles the fabric program on mock, which reaches get_tensix_config() whenever
+    // FabricTensixConfig is not DISABLED. Skipping this would leave tensix_config_ null and fatal
+    // there. Emule stops before the fabric compile, so it is unaffected either way.
     if (tt::tt_fabric::is_tt_fabric_config(this->fabric_config_)) {
         auto& cp = this->get_control_plane();
         cp.initialize_fabric_tensix_datamover_config();

--- a/tt_metal/impl/context/metal_env.cpp
+++ b/tt_metal/impl/context/metal_env.cpp
@@ -376,11 +376,8 @@ void MetalEnvImpl::initialize_fabric_tensix_datamover_config() {
         return;
     }
 
-    // Mock is not excluded here. FabricTensixDatamoverConfig is derived entirely from the control
-    // plane and soc descriptor -- it performs no device I/O -- and FabricFirmwareInitializer now
-    // compiles the fabric program on mock, which reaches get_tensix_config() whenever
-    // FabricTensixConfig is not DISABLED. Skipping this would leave tensix_config_ null and fatal
-    // there. Emule stops before the fabric compile, so it is unaffected either way.
+    // Mock is included: this is control-plane/soc-descriptor derived (no device I/O), and the mock
+    // fabric compile fatals on a null tensix_config_ when FabricTensixConfig != DISABLED.
     if (tt::tt_fabric::is_tt_fabric_config(this->fabric_config_)) {
         auto& cp = this->get_control_plane();
         cp.initialize_fabric_tensix_datamover_config();

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
@@ -299,7 +299,6 @@ void FabricFirmwareInitializer::init(
         const auto fabric_manager = descriptor_->fabric_manager();
         if (has_flag(fabric_manager, tt_fabric::FabricManagerMode::INIT_FABRIC) ||
             has_flag(fabric_manager, tt_fabric::FabricManagerMode::TERMINATE_FABRIC)) {
-            log_info(tt::LogMetal, "Compiling fabric on mock devices (no router programming or sync)");
             compile_fabric_only();
         }
         return;
@@ -457,17 +456,20 @@ void FabricFirmwareInitializer::compile_and_configure_fabric() {
 }
 
 void FabricFirmwareInitializer::compile_fabric_only() {
-    std::vector<std::shared_future<void>> events;
-    events.reserve(devices_.size());
-    for (auto* dev : devices_) {
-        events.emplace_back(detail::async([dev]() {
-            if (!dev->compile_fabric()) {
-                log_trace(tt::LogMetal, "Did not build fabric on Device {}", dev->id());
-            }
-        }));
+    // ERISC debug builds run from L1 and may exceed the fabric router's L1 budget.
+    // Skipping only leaves the cache cold.
+    if (!rtoptions_.get_erisc_iram_enabled()) {
+        log_info(tt::LogMetal, "Skipping mock fabric compile: erisc IRAM disabled by debug tooling");
+        return;
     }
-    for (const auto& event : events) {
-        event.get();
+    log_info(tt::LogMetal, "Compiling fabric on mock devices (no router programming or sync)");
+
+    // Serial on purpose: the shared tensix mux config mutates state from a const getter, which
+    // races when devices compile in parallel.
+    for (auto* dev : devices_) {
+        if (!dev->compile_fabric()) {
+            log_trace(tt::LogMetal, "Did not build fabric on Device {}", dev->id());
+        }
     }
 }
 

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
@@ -287,8 +287,27 @@ void FabricFirmwareInitializer::init(
         return;
     }
 
-    if (descriptor_->is_mock_device() || skip_fabric_fw_for_emule()) {
-        log_info(tt::LogMetal, "Skipping fabric initialization for mock/emule devices");
+    // Emule JIT-compiles kernels to x86 and never links a RISC-V erisc binary, so there is
+    // nothing to build and nothing to program.
+    if (skip_fabric_fw_for_emule()) {
+        log_info(tt::LogMetal, "Skipping fabric initialization for emule devices");
+        return;
+    }
+
+    // Mock stops after the compile. Everything downstream of it -- writing routing tables,
+    // configure_fabric(), and the router handshake in configure() -- is device I/O that UMD's
+    // MockChip drops on the floor. The compile itself is pure host-side work (control-plane
+    // topology from the mock cluster descriptor, then CompileProgram), and it emits erisc
+    // binaries under the same build key real silicon of this arch would use, so running it
+    // here warms the JIT cache on hosts with no hardware attached.
+    if (descriptor_->is_mock_device()) {
+        if (has_flag(descriptor_->fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC) ||
+            has_flag(descriptor_->fabric_manager(), tt_fabric::FabricManagerMode::TERMINATE_FABRIC)) {
+            log_info(tt::LogMetal, "Compiling fabric on mock devices (no router programming or sync)");
+            compile_fabric_only();
+        } else {
+            log_info(tt::LogMetal, "Skipping fabric initialization for mock devices");
+        }
         return;
     }
 
@@ -322,8 +341,10 @@ void FabricFirmwareInitializer::init(
 }
 
 void FabricFirmwareInitializer::configure() {
-    // Mock/Emule: skip router sync (init() skips fabric; sync would fatal/timeout — emule never
-    // runs the ERISC router, so the handshake status stays NOT_STARTED).
+    // Mock/Emule: skip router sync. On mock, init() compiled the fabric program but never
+    // programmed a router, and MockChip::read_from_device() is a no-op that leaves the status
+    // buffer untouched, so the handshake would spin to the timeout and throw. Emule never runs
+    // the ERISC router at all, so its status stays NOT_STARTED for the same reason.
     if (descriptor_->is_mock_device() || skip_fabric_fw_for_emule()) {
         log_info(tt::LogMetal, "Skipping fabric configure (router sync) for mock/emule devices");
         initialized_.test_and_set();
@@ -442,6 +463,22 @@ void FabricFirmwareInitializer::compile_and_configure_fabric() {
         }
     }
     log_info(tt::LogMetal, "Fabric initialized on {} devices", configured_count);
+}
+
+void FabricFirmwareInitializer::compile_fabric_only() {
+    std::vector<std::shared_future<void>> events;
+    events.reserve(devices_.size());
+    for (auto* dev : devices_) {
+        events.emplace_back(detail::async([dev]() {
+            if (!dev->compile_fabric()) {
+                // No routers on this device (e.g. a chip with no active fabric links).
+                log_trace(tt::LogMetal, "Did not build fabric on Device {}", dev->id());
+            }
+        }));
+    }
+    for (const auto& event : events) {
+        event.get();
+    }
 }
 
 void FabricFirmwareInitializer::wait_for_fabric_router_sync(uint32_t timeout_ms) const {

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
@@ -287,26 +287,20 @@ void FabricFirmwareInitializer::init(
         return;
     }
 
-    // Emule JIT-compiles kernels to x86 and never links a RISC-V erisc binary, so there is
-    // nothing to build and nothing to program.
+    // Emule compiles kernels to x86 and never links an erisc binary.
     if (skip_fabric_fw_for_emule()) {
         log_info(tt::LogMetal, "Skipping fabric initialization for emule devices");
         return;
     }
 
-    // Mock stops after the compile. Everything downstream of it -- writing routing tables,
-    // configure_fabric(), and the router handshake in configure() -- is device I/O that UMD's
-    // MockChip drops on the floor. The compile itself is pure host-side work (control-plane
-    // topology from the mock cluster descriptor, then CompileProgram), and it emits erisc
-    // binaries under the same build key real silicon of this arch would use, so running it
-    // here warms the JIT cache on hosts with no hardware attached.
+    // Mock: compile only, to warm the erisc kernel cache. Everything past the compile is device
+    // I/O that MockChip discards.
     if (descriptor_->is_mock_device()) {
-        if (has_flag(descriptor_->fabric_manager(), tt_fabric::FabricManagerMode::INIT_FABRIC) ||
-            has_flag(descriptor_->fabric_manager(), tt_fabric::FabricManagerMode::TERMINATE_FABRIC)) {
+        const auto fabric_manager = descriptor_->fabric_manager();
+        if (has_flag(fabric_manager, tt_fabric::FabricManagerMode::INIT_FABRIC) ||
+            has_flag(fabric_manager, tt_fabric::FabricManagerMode::TERMINATE_FABRIC)) {
             log_info(tt::LogMetal, "Compiling fabric on mock devices (no router programming or sync)");
             compile_fabric_only();
-        } else {
-            log_info(tt::LogMetal, "Skipping fabric initialization for mock devices");
         }
         return;
     }
@@ -341,10 +335,7 @@ void FabricFirmwareInitializer::init(
 }
 
 void FabricFirmwareInitializer::configure() {
-    // Mock/Emule: skip router sync. On mock, init() compiled the fabric program but never
-    // programmed a router, and MockChip::read_from_device() is a no-op that leaves the status
-    // buffer untouched, so the handshake would spin to the timeout and throw. Emule never runs
-    // the ERISC router at all, so its status stays NOT_STARTED for the same reason.
+    // Mock/Emule: no router ever runs, so the sync below would spin to its timeout and throw.
     if (descriptor_->is_mock_device() || skip_fabric_fw_for_emule()) {
         log_info(tt::LogMetal, "Skipping fabric configure (router sync) for mock/emule devices");
         initialized_.test_and_set();
@@ -471,7 +462,6 @@ void FabricFirmwareInitializer::compile_fabric_only() {
     for (auto* dev : devices_) {
         events.emplace_back(detail::async([dev]() {
             if (!dev->compile_fabric()) {
-                // No routers on this device (e.g. a chip with no active fabric links).
                 log_trace(tt::LogMetal, "Did not build fabric on Device {}", dev->id());
             }
         }));

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.hpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.hpp
@@ -34,7 +34,8 @@ private:
     // Configure fabric sequentially (Galaxy hangs if parallelized).
     void compile_and_configure_fabric();
 
-    // Mock only: compile the fabric program on all devices, without programming or syncing routers.
+    // Mock only: compile the fabric program on every device, without programming or syncing routers.
+    // No-op when debug tooling disables erisc IRAM.
     void compile_fabric_only();
 
     // Wait for fabric router handshake on all devices.

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.hpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.hpp
@@ -34,6 +34,10 @@ private:
     // Configure fabric sequentially (Galaxy hangs if parallelized).
     void compile_and_configure_fabric();
 
+    // Mock only: JIT-compile the fabric program on all devices without programming or
+    // synchronizing the routers. Warms the erisc kernel cache on hosts without silicon.
+    void compile_fabric_only();
+
     // Wait for fabric router handshake on all devices.
     void wait_for_fabric_router_sync(uint32_t timeout_ms) const;
 

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.hpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.hpp
@@ -34,8 +34,7 @@ private:
     // Configure fabric sequentially (Galaxy hangs if parallelized).
     void compile_and_configure_fabric();
 
-    // Mock only: JIT-compile the fabric program on all devices without programming or
-    // synchronizing the routers. Warms the erisc kernel cache on hosts without silicon.
+    // Mock only: compile the fabric program on all devices, without programming or syncing routers.
     void compile_fabric_only();
 
     // Wait for fabric router handshake on all devices.

--- a/tt_metal/sources.cmake
+++ b/tt_metal/sources.cmake
@@ -232,6 +232,9 @@ set(JITAPI_FILES
     impl/dispatch/kernels/cq_realtime_profiler_push.cpp
     impl/dispatch/kernels/device_print_dispatch.h
     fabric/impl/kernels/edm_fabric/fabric_erisc_router.cpp
+    fabric/impl/kernels/edm_fabric/fabric_router_mux_extension.cpp
+    fabric/impl/kernels/edm_fabric/fabric_router_relay_extension.cpp
+    fabric/impl/kernels/edm_fabric/fabric_router_udm_mux_extension.cpp
     fabric/impl/kernels/tt_fabric_mux.cpp
     fabric/impl/kernels/tt_fabric_mux_v2.cpp
     fabric/impl/kernels/tt_fabric_mux_v2_forwarder.hpp


### PR DESCRIPTION
### PR Category
Bug fix / feature.


### Problem
MockDevice can be used to compile kernels and warm the JIT cache without requiring hardware.

Two separate issues prevented some workflows from running correctly:

- Fabric initialization skipped ERISC kernel compilation entirely under mock.
- H2D and D2H sockets waited for progress from device kernels that never execute under mock, causing hangs. D2H could also select an unsupported hugepage path.

### Fix
- Compile fabric kernels under mock, while continuing to skip device programming and router synchronization.
- Initialize the host-side fabric configuration required by Tensix mux configurations.
- Model socket progress under mock so H2D writes and blocking D2H reads complete without making D2H appear to contain persistent data.
- Keep mock D2H sockets on the supported pinned-memory path.

These changes are limited to MockDevice; silicon, simulator, and emule behavior is unchanged.

### Testing
Added hardware-free MockDevice regression coverage for fabric compilation, Tensix mux configuration, and H2D/D2H socket operation.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ckaravasilisTT/mockCompile00)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ckaravasilisTT/mockCompile00)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ckaravasilisTT/mockCompile00)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ckaravasilisTT/mockCompile00)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ckaravasilisTT/mockCompile00)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ckaravasilisTT/mockCompile00)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ckaravasilisTT/mockCompile00)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ckaravasilisTT/mockCompile00)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ckaravasilisTT/mockCompile00)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ckaravasilisTT/mockCompile00)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ckaravasilisTT/mockCompile00)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ckaravasilisTT/mockCompile00)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ckaravasilisTT/mockCompile00)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ckaravasilisTT/mockCompile00)