### PR TITLE
[skip ci] Skip code-analysis for unrelated changes

### DIFF
--- a/.github/actions/find-changed-files/action.yml
+++ b/.github/actions/find-changed-files/action.yml
@@ -24,6 +24,8 @@ outputs:
     value: ${{ steps.find-changed-files.outputs.submodule-changed }}
   any-code-changed:
     value: ${{ steps.find-changed-files.outputs.any-code-changed }}
+  run-clang-tidy:
+    value: ${{ steps.find-changed-files.outputs.run-clang-tidy }}
   docs-changed:
     value: ${{ steps.find-changed-files.outputs.docs-changed }}
   model-charts-changed:

--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -183,6 +183,23 @@ RAW_LLK_SFPI_CHANGED=$LLK_SFPI_CHANGED
 # tests/scale_out and tests/tt_eager are included because the clang-tidy
 # CMake preset inherits TT_METAL_BUILD_TESTS=TRUE and TTNN_BUILD_TESTS=TRUE,
 # and tests/CMakeLists.txt builds those trees under exactly those flags.
+#
+# .fbs is included alongside the C/C++ extensions: FlatBuffer schemas
+# (tt_metal/impl/flatbuffer/*.fbs, tt_metal/api/.../serialized_descriptors/*.fbs,
+# ttnn/core/tensor/flatbuffer/*.fbs, tt-train/.../serialization/*.fbs) generate
+# *_generated.h headers via GENERATE_FBS_HEADER (cmake/flatbuffers.cmake) that
+# are compiled straight into their target's sources with no SKIP_LINTING or
+# HeaderFilterRegex exclusion — clang-tidy genuinely analyzes them, so an
+# .fbs-only PR must not be skipped.
+#
+# .proto is deliberately NOT included, despite generating C++ the same way:
+# GENERATE_PROTO_FILES (cmake/protobuf.cmake) sets SKIP_LINTING on the
+# generated .pb.cc, drops a no-op .clang-tidy into the generated directory so
+# the .pb.h is never scanned via #include either, and the repo's top-level
+# .clang-tidy HeaderFilterRegex separately excludes '.pb.h$' outright. Same
+# reasoning excludes .capnp: tt_metal/impl/CMakeLists.txt sets SKIP_LINTING
+# on every capnp-generated RPC source/header. Neither can affect clang-tidy
+# output no matter how the schema changes.
 CPP_SOURCE_FOR_CLANG_TIDY_CHANGED=false
 # Explicit, human-auditable list of workflow files whose changes affect the
 # clang-tidy scan itself (its definition, implementation, caller/inputs, or
@@ -193,7 +210,18 @@ CPP_SOURCE_FOR_CLANG_TIDY_CHANGED=false
 CLANG_TIDY_KEY_WORKFLOW_CHANGED=false
 while IFS= read -r FILE; do
     case "$FILE" in
-        @(tt_metal|ttnn|tests/tt_metal|tests/ttnn|tests/scale_out|tests/tt_eager|tt-train|tools|tt_stl)/*(*/)*.@(h|hpp|c|cpp|cc|inl|tpp))
+        @(tt_metal|ttnn|tests/tt_metal|tests/ttnn|tests/scale_out|tests/tt_eager|tt-train|tools|tt_stl)/*(*/)*.@(h|hpp|c|cpp|cc|inl|tpp|fbs))
+            CPP_SOURCE_FOR_CLANG_TIDY_CHANGED=true
+            ;;
+        # tt_metal/llrt/hal's codegen.py/codegen.sh regenerate dev_msgs.hpp,
+        # fabric_telemetry.hpp, and realtime_profiler_msgs.hpp (+ *_impl.hpp),
+        # which ARE linted (no SKIP_LINTING in tt_metal/llrt/hal/CMakeLists.txt).
+        # Their primary inputs (tt_metal/hw/inc/hostdev/*.h) already match the
+        # pattern above, but the generator scripts themselves don't live under
+        # tt_metal/**/*.h|.cpp — a change to the generator logic alone, with no
+        # input header touched, would otherwise regenerate different linted
+        # headers undetected.
+        tt_metal/llrt/hal/codegen/codegen.py|tt_metal/llrt/hal/codegen/codegen.sh)
             CPP_SOURCE_FOR_CLANG_TIDY_CHANGED=true
             ;;
         .github/workflows/code-analysis.yaml|\

--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -34,6 +34,52 @@ LLK_PERF_CHANGED=false
 LLK_CI_CHANGED=false
 WORKFLOWS_CHANGED=false
 
+# Workflow files transitively reachable from the CI gate entrypoints
+# (pr-gate.yaml / merge-gate.yaml) via local `uses: ./.github/workflows/...`
+# references. Only changes to these files can affect what the PR/merge gate
+# actually runs; the ~200 other workflow files are standalone automation
+# (schedule/dispatch-triggered metrics, cleanup, triage, ...) whose changes
+# cannot alter gate results. Computed dynamically so it never rots as
+# workflows are added/removed.
+GATE_REACHABLE_WORKFLOWS=""
+compute_gate_reachable_workflows() {
+    local entrypoints=(".github/workflows/pr-gate.yaml" ".github/workflows/merge-gate.yaml")
+    local queue=() visited=" " current refs ref
+    for current in "${entrypoints[@]}"; do
+        # If an entrypoint is missing, something is off; caller fails open.
+        if [[ ! -f "$current" ]]; then
+            return 1
+        fi
+        queue+=("$current")
+    done
+    while [[ ${#queue[@]} -gt 0 ]]; do
+        current="${queue[0]}"
+        queue=("${queue[@]:1}")
+        if [[ "$visited" == *" $current "* ]]; then
+            continue
+        fi
+        visited+="$current "
+        # Follow local reusable-workflow references (BFS). No match is fine.
+        refs=$(grep -oE 'uses:[[:space:]]*\./\.github/workflows/[^@[:space:]"'\'']+' "$current" | sed 's|.*\./||') || true
+        for ref in $refs; do
+            if [[ -f "$ref" && "$visited" != *" $ref "* ]]; then
+                queue+=("$ref")
+            fi
+        done
+    done
+    GATE_REACHABLE_WORKFLOWS="$visited"
+}
+if ! compute_gate_reachable_workflows; then
+    # Fail open: with an empty set, is_gate_reachable_workflow treats every
+    # workflow as gate-relevant (old behavior). Never silently under-scan.
+    GATE_REACHABLE_WORKFLOWS=""
+fi
+is_gate_reachable_workflow() {
+    if [[ -z "$GATE_REACHABLE_WORKFLOWS" ]]; then
+        return 0
+    fi
+    [[ "$GATE_REACHABLE_WORKFLOWS" == *" $1 "* ]]
+}
 
 while IFS= read -r FILE; do
     case "$FILE" in
@@ -146,12 +192,19 @@ while IFS= read -r FILE; do
             BUILD_WORKFLOWS_CHANGED=true
             ANY_CODE_CHANGED=true
             ;;
-        # Any other workflow change runs the standard PR gate. More specific workflow
-        # patterns above (e.g. llk-*.yaml, build-artifact.yaml) match first and keep
-        # their targeted behavior; this catch-all ensures a workflow-only PR never
-        # silently skips CI. Fanned out to the full gate below (same as submodule).
+        # Any other workflow change that can affect the PR/merge gate runs the
+        # standard PR gate. More specific workflow patterns above (e.g.
+        # llk-*.yaml, build-artifact.yaml) match first and keep their targeted
+        # behavior; this catch-all ensures a gate-relevant workflow-only PR
+        # never silently skips CI. Fanned out to the full gate below (same as
+        # submodule). Workflows NOT reachable from the gate entrypoints are
+        # standalone (own schedule:/workflow_dispatch: triggers, never
+        # uses:-referenced by the gate) — changing them cannot affect gate
+        # results, so they set no flags, like any other unrelated file.
         .github/workflows/*.yaml|.github/workflows/*.yml)
-            WORKFLOWS_CHANGED=true
+            if is_gate_reachable_workflow "$FILE"; then
+                WORKFLOWS_CHANGED=true
+            fi
             ;;
     esac
 done <<< "$CHANGED_FILES"

--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -34,52 +34,6 @@ LLK_PERF_CHANGED=false
 LLK_CI_CHANGED=false
 WORKFLOWS_CHANGED=false
 
-# Workflow files transitively reachable from the CI gate entrypoints
-# (pr-gate.yaml / merge-gate.yaml) via local `uses: ./.github/workflows/...`
-# references. Only changes to these files can affect what the PR/merge gate
-# actually runs; the ~200 other workflow files are standalone automation
-# (schedule/dispatch-triggered metrics, cleanup, triage, ...) whose changes
-# cannot alter gate results. Computed dynamically so it never rots as
-# workflows are added/removed.
-GATE_REACHABLE_WORKFLOWS=""
-compute_gate_reachable_workflows() {
-    local entrypoints=(".github/workflows/pr-gate.yaml" ".github/workflows/merge-gate.yaml")
-    local queue=() visited=" " current refs ref
-    for current in "${entrypoints[@]}"; do
-        # If an entrypoint is missing, something is off; caller fails open.
-        if [[ ! -f "$current" ]]; then
-            return 1
-        fi
-        queue+=("$current")
-    done
-    while [[ ${#queue[@]} -gt 0 ]]; do
-        current="${queue[0]}"
-        queue=("${queue[@]:1}")
-        if [[ "$visited" == *" $current "* ]]; then
-            continue
-        fi
-        visited+="$current "
-        # Follow local reusable-workflow references (BFS). No match is fine.
-        refs=$(grep -oE 'uses:[[:space:]]*\./\.github/workflows/[^@[:space:]"'\'']+' "$current" | sed 's|.*\./||') || true
-        for ref in $refs; do
-            if [[ -f "$ref" && "$visited" != *" $ref "* ]]; then
-                queue+=("$ref")
-            fi
-        done
-    done
-    GATE_REACHABLE_WORKFLOWS="$visited"
-}
-if ! compute_gate_reachable_workflows; then
-    # Fail open: with an empty set, is_gate_reachable_workflow treats every
-    # workflow as gate-relevant (old behavior). Never silently under-scan.
-    GATE_REACHABLE_WORKFLOWS=""
-fi
-is_gate_reachable_workflow() {
-    if [[ -z "$GATE_REACHABLE_WORKFLOWS" ]]; then
-        return 0
-    fi
-    [[ "$GATE_REACHABLE_WORKFLOWS" == *" $1 "* ]]
-}
 
 while IFS= read -r FILE; do
     case "$FILE" in
@@ -192,22 +146,65 @@ while IFS= read -r FILE; do
             BUILD_WORKFLOWS_CHANGED=true
             ANY_CODE_CHANGED=true
             ;;
-        # Any other workflow change that can affect the PR/merge gate runs the
-        # standard PR gate. More specific workflow patterns above (e.g.
-        # llk-*.yaml, build-artifact.yaml) match first and keep their targeted
-        # behavior; this catch-all ensures a gate-relevant workflow-only PR
-        # never silently skips CI. Fanned out to the full gate below (same as
-        # submodule). Workflows NOT reachable from the gate entrypoints are
-        # standalone (own schedule:/workflow_dispatch: triggers, never
-        # uses:-referenced by the gate) — changing them cannot affect gate
-        # results, so they set no flags, like any other unrelated file.
+        # Any other workflow change runs the standard PR gate. More specific workflow
+        # patterns above (e.g. llk-*.yaml, build-artifact.yaml) match first and keep
+        # their targeted behavior; this catch-all ensures a workflow-only PR never
+        # silently skips CI. Fanned out to the full gate below (same as submodule).
         .github/workflows/*.yaml|.github/workflows/*.yml)
-            if is_gate_reachable_workflow "$FILE"; then
-                WORKFLOWS_CHANGED=true
-            fi
+            WORKFLOWS_CHANGED=true
             ;;
     esac
 done <<< "$CHANGED_FILES"
+
+# --- run-clang-tidy inputs: raw snapshot + dedicated re-scans ---------------
+# Snapshot the language-agnostic per-file flags NOW, before the blanket
+# submodule/workflow "treat as everything changed" fallback below mutates
+# them. run-clang-tidy must reflect only changes that can plausibly alter
+# clang-tidy results; deriving it from the post-fallback values would force
+# a full code-analysis rescan for every workflow-only PR, including
+# standalone workflows with zero relevance to what gets built or scanned.
+RAW_CMAKE_CHANGED=$CMAKE_CHANGED
+RAW_CLANG_TIDY_CONFIG_CHANGED=$CLANG_TIDY_CONFIG_CHANGED
+RAW_LLK_WORMHOLE_CHANGED=$LLK_WORMHOLE_CHANGED
+RAW_LLK_BLACKHOLE_CHANGED=$LLK_BLACKHOLE_CHANGED
+RAW_LLK_COMMON_CHANGED=$LLK_COMMON_CHANGED
+RAW_LLK_SFPI_CHANGED=$LLK_SFPI_CHANGED
+
+# clang-tidy is a C/C++-only linter, so the "did relevant source change?"
+# half of run-clang-tidy gets its own dedicated scan for C/C++ extensions
+# only. The shared flags above (tt-metalium-changed, tools-changed, ...) are
+# deliberately NOT reused here: their patterns also match .py files (and
+# e.g. tools/triage/requirements.txt) because other jobs legitimately fire
+# on Python changes — but a Python-only PR cannot affect clang-tidy output.
+CPP_SOURCE_FOR_CLANG_TIDY_CHANGED=false
+# Explicit, human-auditable list of workflow files whose changes affect the
+# clang-tidy scan itself (its definition, implementation, caller/inputs, or
+# the docker image it runs inside). Deliberately a literal list rather than
+# any computed call-graph traversal. NOT listed on purpose:
+# .github/workflows/check-harbor.yaml — it only health-checks the Harbor
+# registry cache and cannot affect what gets built or scanned.
+CLANG_TIDY_KEY_WORKFLOW_CHANGED=false
+while IFS= read -r FILE; do
+    case "$FILE" in
+        tt_metal/**/*.@(h|hpp|c|cpp|cc)|\
+        ttnn/**/*.@(h|hpp|c|cpp|cc)|\
+        tests/tt_metal/**/*.@(h|hpp|c|cpp|cc)|\
+        tests/ttnn/**/*.@(h|hpp|c|cpp|cc)|\
+        tt-train/**/*.@(h|hpp|c|cpp|cc)|\
+        tools/**/*.@(h|hpp|c|cpp|cc)|\
+        tt_stl/**/*.@(h|hpp|c|cpp|cc))
+            CPP_SOURCE_FOR_CLANG_TIDY_CHANGED=true
+            ;;
+        .github/workflows/code-analysis.yaml|\
+        .github/workflows/clang-tidy-reusable.yaml|\
+        .github/workflows/pr-gate.yaml|\
+        .github/workflows/build-docker-artifact.yaml|\
+        .github/workflows/resolve-docker-pull-refs.yaml)
+            CLANG_TIDY_KEY_WORKFLOW_CHANGED=true
+            ;;
+    esac
+done <<< "$CHANGED_FILES"
+# ----------------------------------------------------------------------------
 
 SUBMODULE_PATHS=$(git config --file .gitmodules --get-regexp path | awk '{print $2}')
 SUBMODULE_CHANGED=false
@@ -217,6 +214,24 @@ for submodule_path in $SUBMODULE_PATHS; do
         break
     fi
 done
+
+# run-clang-tidy: should the code-analysis (clang-tidy) job run? Computed
+# from the dedicated C/C++-only scan and the RAW pre-fallback flags above
+# (plus SUBMODULE_CHANGED, which the fallback never mutates, and the explicit
+# key-workflow list) — must be decided before the blanket fallback below
+# forces the shared flags true. Submodules stay included to match the repo's
+# conservative posture: a submodule bump can change header behavior
+# clang-tidy would flag. LLK flags are included because LLK sources are
+# compiled into Metalium device kernels.
+RUN_CLANG_TIDY=false
+if [[ "$CPP_SOURCE_FOR_CLANG_TIDY_CHANGED" = true || \
+      "$RAW_CMAKE_CHANGED" = true || "$RAW_CLANG_TIDY_CONFIG_CHANGED" = true || \
+      "$RAW_LLK_WORMHOLE_CHANGED" = true || "$RAW_LLK_BLACKHOLE_CHANGED" = true || \
+      "$RAW_LLK_COMMON_CHANGED" = true || "$RAW_LLK_SFPI_CHANGED" = true || \
+      "$SUBMODULE_CHANGED" = true || "$CLANG_TIDY_KEY_WORKFLOW_CHANGED" = true ]]; then
+    RUN_CLANG_TIDY=true
+fi
+
 if [[ "$SUBMODULE_CHANGED" = true || "$WORKFLOWS_CHANGED" = true ]]; then
     # Treat any submodule or workflow change as a change to everything; not going to manage dependency trees for this.
     # For workflows this guarantees a workflow-only PR runs the full standard gate (build + smoke + examples + code-analysis)
@@ -259,6 +274,7 @@ declare -A changes=(
     [tools-changed]=$TOOLS_CHANGED
     [submodule-changed]=$SUBMODULE_CHANGED
     [any-code-changed]=$ANY_CODE_CHANGED
+    [run-clang-tidy]=$RUN_CLANG_TIDY
     [docs-changed]=$DOCS_CHANGED
     [model-charts-changed]=$MODEL_CHARTS_CHANGED
     [models-changed]=$MODELS_CHANGED

--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -176,6 +176,13 @@ RAW_LLK_SFPI_CHANGED=$LLK_SFPI_CHANGED
 # deliberately NOT reused here: their patterns also match .py files (and
 # e.g. tools/triage/requirements.txt) because other jobs legitimately fire
 # on Python changes — but a Python-only PR cannot affect clang-tidy output.
+# Each directory needs BOTH a root-level (dir/*.ext) and a nested
+# (dir/**/*.ext) alternative: this script only enables extglob, not
+# globstar, so in case-pattern matching `dir/**/*.ext` requires at least
+# one subdirectory component and would miss files directly in `dir/`.
+# tests/scale_out and tests/tt_eager are included because the clang-tidy
+# CMake preset inherits TT_METAL_BUILD_TESTS=TRUE and TTNN_BUILD_TESTS=TRUE,
+# and tests/CMakeLists.txt builds those trees under exactly those flags.
 CPP_SOURCE_FOR_CLANG_TIDY_CHANGED=false
 # Explicit, human-auditable list of workflow files whose changes affect the
 # clang-tidy scan itself (its definition, implementation, caller/inputs, or
@@ -186,13 +193,15 @@ CPP_SOURCE_FOR_CLANG_TIDY_CHANGED=false
 CLANG_TIDY_KEY_WORKFLOW_CHANGED=false
 while IFS= read -r FILE; do
     case "$FILE" in
-        tt_metal/**/*.@(h|hpp|c|cpp|cc)|\
-        ttnn/**/*.@(h|hpp|c|cpp|cc)|\
-        tests/tt_metal/**/*.@(h|hpp|c|cpp|cc)|\
-        tests/ttnn/**/*.@(h|hpp|c|cpp|cc)|\
-        tt-train/**/*.@(h|hpp|c|cpp|cc)|\
-        tools/**/*.@(h|hpp|c|cpp|cc)|\
-        tt_stl/**/*.@(h|hpp|c|cpp|cc))
+        tt_metal/*.@(h|hpp|c|cpp|cc|inl|tpp)|tt_metal/**/*.@(h|hpp|c|cpp|cc|inl|tpp)|\
+        ttnn/*.@(h|hpp|c|cpp|cc|inl|tpp)|ttnn/**/*.@(h|hpp|c|cpp|cc|inl|tpp)|\
+        tests/tt_metal/*.@(h|hpp|c|cpp|cc|inl|tpp)|tests/tt_metal/**/*.@(h|hpp|c|cpp|cc|inl|tpp)|\
+        tests/ttnn/*.@(h|hpp|c|cpp|cc|inl|tpp)|tests/ttnn/**/*.@(h|hpp|c|cpp|cc|inl|tpp)|\
+        tests/scale_out/*.@(h|hpp|c|cpp|cc|inl|tpp)|tests/scale_out/**/*.@(h|hpp|c|cpp|cc|inl|tpp)|\
+        tests/tt_eager/*.@(h|hpp|c|cpp|cc|inl|tpp)|tests/tt_eager/**/*.@(h|hpp|c|cpp|cc|inl|tpp)|\
+        tt-train/*.@(h|hpp|c|cpp|cc|inl|tpp)|tt-train/**/*.@(h|hpp|c|cpp|cc|inl|tpp)|\
+        tools/*.@(h|hpp|c|cpp|cc|inl|tpp)|tools/**/*.@(h|hpp|c|cpp|cc|inl|tpp)|\
+        tt_stl/*.@(h|hpp|c|cpp|cc|inl|tpp)|tt_stl/**/*.@(h|hpp|c|cpp|cc|inl|tpp))
             CPP_SOURCE_FOR_CLANG_TIDY_CHANGED=true
             ;;
         .github/workflows/code-analysis.yaml|\

--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -193,15 +193,7 @@ CPP_SOURCE_FOR_CLANG_TIDY_CHANGED=false
 CLANG_TIDY_KEY_WORKFLOW_CHANGED=false
 while IFS= read -r FILE; do
     case "$FILE" in
-        tt_metal/*.@(h|hpp|c|cpp|cc|inl|tpp)|tt_metal/**/*.@(h|hpp|c|cpp|cc|inl|tpp)|\
-        ttnn/*.@(h|hpp|c|cpp|cc|inl|tpp)|ttnn/**/*.@(h|hpp|c|cpp|cc|inl|tpp)|\
-        tests/tt_metal/*.@(h|hpp|c|cpp|cc|inl|tpp)|tests/tt_metal/**/*.@(h|hpp|c|cpp|cc|inl|tpp)|\
-        tests/ttnn/*.@(h|hpp|c|cpp|cc|inl|tpp)|tests/ttnn/**/*.@(h|hpp|c|cpp|cc|inl|tpp)|\
-        tests/scale_out/*.@(h|hpp|c|cpp|cc|inl|tpp)|tests/scale_out/**/*.@(h|hpp|c|cpp|cc|inl|tpp)|\
-        tests/tt_eager/*.@(h|hpp|c|cpp|cc|inl|tpp)|tests/tt_eager/**/*.@(h|hpp|c|cpp|cc|inl|tpp)|\
-        tt-train/*.@(h|hpp|c|cpp|cc|inl|tpp)|tt-train/**/*.@(h|hpp|c|cpp|cc|inl|tpp)|\
-        tools/*.@(h|hpp|c|cpp|cc|inl|tpp)|tools/**/*.@(h|hpp|c|cpp|cc|inl|tpp)|\
-        tt_stl/*.@(h|hpp|c|cpp|cc|inl|tpp)|tt_stl/**/*.@(h|hpp|c|cpp|cc|inl|tpp))
+        @(tt_metal|ttnn|tests/tt_metal|tests/ttnn|tests/scale_out|tests/tt_eager|tt-train|tools|tt_stl)/*(*/)*.@(h|hpp|c|cpp|cc|inl|tpp))
             CPP_SOURCE_FOR_CLANG_TIDY_CHANGED=true
             ;;
         .github/workflows/code-analysis.yaml|\

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -164,6 +164,7 @@ jobs:
     runs-on: ubuntu-slim
     outputs:
       any-code-changed: ${{ steps.find-changes.outputs.any-code-changed }}
+      run-clang-tidy: ${{ steps.find-changes.outputs.run-clang-tidy }}
       docs-changed: ${{ steps.find-changes.outputs.docs-changed }}
       cmake-changed: ${{ steps.find-changes.outputs.cmake-changed }}
       tt-metalium-changed: ${{ steps.find-changes.outputs.tt-metalium-changed }}

--- a/.github/workflows/pr-gate.yaml
+++ b/.github/workflows/pr-gate.yaml
@@ -297,12 +297,13 @@ jobs:
 
   # Full clang-tidy scan (same checks enforced at merge gate).
   # force-scan=true → single full-scan job (avoids 4-way per-target split with high setup overhead).
-  # Gated on any-code-changed so docs/workflow-only PRs are skipped entirely.
+  # Gated on run-clang-tidy so docs-only PRs and workflow-only PRs that cannot
+  # affect the scan (see find-changed-files.sh's explicit key-workflow list) are skipped entirely.
   code-analysis:
     needs: [build-docker-images, find-changed-files]
     if: >-
       ${{
-        needs.find-changed-files.outputs.any-code-changed == 'true' &&
+        needs.find-changed-files.outputs.run-clang-tidy == 'true' &&
         ((github.event_name == 'pull_request' && !github.event.pull_request.draft) || github.event_name == 'merge_group')
       }}
     uses: ./.github/workflows/code-analysis.yaml


### PR DESCRIPTION
### Problem

Workflow-only PRs trigger a full `code-analysis` (clang-tidy) run in `pr-gate.yaml`, even when the changed workflow has zero relevance to C++ compilation or linting (e.g. #53385 touched only a scheduled metrics-push workflow). This wastes significant CI compute.

### Fix

Add a new `run-clang-tidy` output to `find-changed-files.sh`, computed independently of the existing `any-code-changed` flag (which intentionally treats any workflow or submodule change as "everything changed," and stays that way for the other jobs that rely on it). `code-analysis` in `pr-gate.yaml` now gates on `run-clang-tidy` instead.

`run-clang-tidy` is `true` when any of the following changed:
- **C/C++ source relevant to clang-tidy**: `.h`/`.hpp`/`.c`/`.cpp`/`.cc`/`.inl`/`.tpp`/`.fbs` files under `tt_metal/`, `ttnn/`, `tests/tt_metal/`, `tests/ttnn/`, `tests/scale_out/`, `tests/tt_eager/`, `tt-train/`, `tools/`, `tt_stl/` (root-level or nested). `.py` is deliberately excluded — clang-tidy can't be affected by Python-only changes, unlike the shared flags that other jobs reuse.
- Two HAL codegen scripts (`tt_metal/llrt/hal/codegen/codegen.{py,sh}`) that regenerate linted headers from inputs not otherwise covered.
- CMake files, `.clang-tidy` config, LLK hardware-backend sources, or a submodule bump.
- An explicit list of workflows that affect the scan itself: `code-analysis.yaml`, `clang-tidy-reusable.yaml`, `pr-gate.yaml`, `build-docker-artifact.yaml`, `resolve-docker-pull-refs.yaml`.

Deliberately **not** included: `.proto`/`.capnp` schema files — their generated C++ is explicitly excluded from clang-tidy via `SKIP_LINTING` and `HeaderFilterRegex`, so they can't affect scan results; and `check-harbor.yaml` — it's just a registry health check.

### Test plan

Verified with isolated single-file changesets on `origin/main` (avoids false positives from testing on top of this branch's own workflow changes):

| Change | `run-clang-tidy` |
|---|---|
| `tt_metal/**/*.{cpp,h,inl,tpp,fbs}` (root or nested) | `true` |
| `tests/scale_out/`, `tests/tt_eager/` C++ sources | `true` |
| HAL `codegen.py` / `codegen.sh` | `true` |
| `CMakeLists.txt`, `.clang-tidy` | `true` |
| Key workflows (`pr-gate.yaml`, `code-analysis.yaml`, etc.) | `true` |
| `**/*.py`, `.proto`, `.capnp`, `README.md`, `check-harbor.yaml`, unrelated workflows | `false` |

Output plumbing verified structurally: composite action → job output → `code-analysis`'s `if:` all reference the same `run-clang-tidy` name.
