### PR TITLE
[Quasar] Port SFPI parity kernels and tests

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_activations.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_activations.h
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel_defs.h"
+#include "cmath_common.h"
+#include "sfpi.h"
+#include "ckernel_sfpu_relu.h"
+
+namespace ckernel::sfpu {
+
+// General template structure to implement activations
+template <bool APPROXIMATION_MODE, ActivationType ACTIVATION_TYPE>
+struct ActivationImpl;
+
+// Specialization for HARDSIGMOID activation
+template <bool APPROXIMATION_MODE>
+struct ActivationImpl<APPROXIMATION_MODE, ActivationType::Hardsigmoid> {
+    static inline void apply(sfpi::vFloat& v) {
+        sfpi::vFloat tmp = (v * sfpi::vConstFloatPrgm0) + sfpi::vConstFloatPrgm1;
+        v = _relu_max_body_(tmp, 1.0f);
+    }
+};
+
+// Dispatch wrapper function
+template <bool APPROXIMATION_MODE, ActivationType ACTIVATION_TYPE>
+inline void apply_activation(sfpi::vFloat& v) {
+    ActivationImpl<APPROXIMATION_MODE, ACTIVATION_TYPE>::apply(v);
+}
+
+template <bool APPROXIMATION_MODE, ActivationType ACTIVATION_TYPE, int ITERATIONS>
+inline void calculate_activation() {
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        apply_activation<APPROXIMATION_MODE, ACTIVATION_TYPE>(v);
+        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+void hardsigmoid_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
+    // For hardsigmoid slope is 1/6, FP32 IEEE 754 representation.
+    sfpi::vConstFloatPrgm0 = 0.1666666716337204f;
+    sfpi::vConstFloatPrgm1 = 0.5f;
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_add1.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_add1.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_add1() {
+    for (int d = 0; d < ITERATIONS; d++) {
+        vFloat val = dst_reg[0];
+        dst_reg[0] = 1.0f + val;
+        dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_addcdiv.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_addcdiv.h
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "llk_defs.h"
+#include "sfpi.h"
+#include "ckernel_sfpu_converter.h"
+#include "ckernel_sfpu_binary.h"
+#include "ckernel_sfpu_recip.h"
+
+namespace ckernel::sfpu {
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS>
+inline void calculate_addcdiv(
+    const std::uint32_t dst_index_in0,  // input_a
+    const std::uint32_t dst_index_in1,  // input_b
+    const std::uint32_t dst_index_in2,  // input_c
+    const std::uint32_t dst_index_out,  // output
+    const std::uint32_t value) {        // scalar value to multiply with input_b
+    static_assert(
+        data_format == DataFormat::Float32 || data_format == DataFormat::Float16_b,
+        "Unsupported data format for calculate_addcdiv(). Supported data formats are: Float32, Float16_b");
+
+    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    const sfpi::vFloat value_float = Converter::as_float(value);
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        sfpi::vFloat in2 = sfpi::dst_reg[dst_index_in2 * dst_tile_size_sfpi];
+        sfpi::vFloat result = in0 + (in1 * value_float * sfpu_reciprocal_iter<2>(in2));
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = float32_to_bf16_rne(result);
+        }
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+void init_addcdiv() {
+    sfpu_reciprocal_init<APPROXIMATION_MODE>();
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_addcmul.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_addcmul.h
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "llk_defs.h"
+#include "sfpi.h"
+#include "ckernel_sfpu_converter.h"
+
+namespace ckernel::sfpu {
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS>
+inline void calculate_addcmul(
+    const std::uint32_t dst_index_in0,  // input_a
+    const std::uint32_t dst_index_in1,  // input_b
+    const std::uint32_t dst_index_in2,  // input_c
+    const std::uint32_t dst_index_out,  // output
+    const std::uint32_t value) {        // scalar value to multiply with input_b
+    static_assert(
+        data_format == DataFormat::Float32 || data_format == DataFormat::Float16_b,
+        "Unsupported data format for calculate_addcmul(). Only Float32 and Float16_b (BFloat16) "
+        "are allowed.");
+    static_assert(ITERATIONS % 2 == 0, "calculate_addcmul() processes dest rows in interleaved pairs.");
+
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    const sfpi::vFloat value_float = Converter::as_float(value);
+
+    const std::uint32_t off_in0 = dst_index_in0 * dst_tile_size_sfpi;
+    const std::uint32_t off_in1 = dst_index_in1 * dst_tile_size_sfpi;
+    const std::uint32_t off_in2 = dst_index_in2 * dst_tile_size_sfpi;
+    const std::uint32_t off_out = dst_index_out * dst_tile_size_sfpi;
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d += 2) {
+        // Two independent rows (A at +0, B at +1) so the scheduler can overlap
+        // their dependent MUL->MAD->round chains and hide the 2-cycle latency.
+        sfpi::vFloat a_in0 = sfpi::dst_reg[off_in0];
+        sfpi::vFloat a_in1 = sfpi::dst_reg[off_in1];
+        sfpi::vFloat a_in2 = sfpi::dst_reg[off_in2];
+        sfpi::vFloat b_in0 = sfpi::dst_reg[off_in0 + 1];
+        sfpi::vFloat b_in1 = sfpi::dst_reg[off_in1 + 1];
+        sfpi::vFloat b_in2 = sfpi::dst_reg[off_in2 + 1];
+
+        // Sequence both products before both MADs so the scheduler can issue
+        // MUL_a, MUL_b back-to-back (each hiding the other's latency), then
+        // MAD_a, MAD_b, keeping the pipeline NOP-free.
+        sfpi::vFloat a_prod = value_float * a_in1;
+        sfpi::vFloat b_prod = value_float * b_in1;
+        sfpi::vFloat a_res = a_prod * a_in2 + a_in0;
+        sfpi::vFloat b_res = b_prod * b_in2 + b_in0;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            sfpi::dst_reg[off_out] = sfpi::convert<sfpi::vFloat16b>(a_res, sfpi::RoundMode::Nearest);
+            sfpi::dst_reg[off_out + 1] = sfpi::convert<sfpi::vFloat16b>(b_res, sfpi::RoundMode::Nearest);
+        } else {
+            sfpi::dst_reg[off_out] = a_res;
+            sfpi::dst_reg[off_out + 1] = b_res;
+        }
+        sfpi::dst_reg += 2;
+    }
+}
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_alt_complex_rotate90.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_alt_complex_rotate90.h
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "cmath_common.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+inline void alt_complex_rotate90_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 4>
+inline void calculate_alt_complex_rotate90() {
+    for (int d = 0; d < ITERATIONS; d++) {
+        vFloat val = dst_reg[0];
+        dst_reg[0] = -vFloat(dst_reg[1]);
+        dst_reg[1] = val;
+        dst_reg += 2;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_atan2.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_atan2.h
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: © 2026 Jason Davies <jason@jasondavies.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_recip.h"
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _sfpu_atan2_(sfpi::vFloat y, sfpi::vFloat x) {
+    constexpr bool is_bf16 = !is_fp32_dest_acc_en || APPROXIMATION_MODE;
+
+    sfpi::vFloat r;
+    sfpi::vFloat q;
+    sfpi::vFloat s;
+
+    // Note: if x or y is ±NaN, the use of setsgn, ensures that
+    // max=NaN, which abs does not.  This is important for special
+    // case handling.
+    auto [min, max] = sfpi::min_max(sfpi::setsgn(x, 0), sfpi::setsgn(y, 0));
+
+    // a = min(|x|, |y|) / max(|x|, |y|), i.e. a is on [0, 1].
+    sfpi::vFloat a = min * sfpu_reciprocal<is_bf16>(max);
+
+    // Next we compute the minimax approximation for atan(a).
+
+    if constexpr (is_fp32_dest_acc_en) {
+        q = 0x1.01cp-8f;
+        s = a * a;
+        sfpi::vFloat c6 = -0x1.4bcp-6f;
+        q = __builtin_rvtt_sfpmad(q.get(), s.get(), c6.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
+        sfpi::vFloat c5 = 0x1.93p-5f;
+        q = __builtin_rvtt_sfpmad(q.get(), s.get(), c5.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
+        sfpi::vFloat c4 = -0x1.48cp-4f;
+        q = __builtin_rvtt_sfpmad(q.get(), s.get(), c4.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
+        sfpi::vFloat c3 = 0x1.bd4p-4f;
+        q = __builtin_rvtt_sfpmad(q.get(), s.get(), c3.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
+        sfpi::vFloat c2 = -0x1.24p-3f;
+        q = __builtin_rvtt_sfpmad(q.get(), s.get(), c2.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
+        sfpi::vFloat c1 = 0x1.99938ap-3f;
+        q = __builtin_rvtt_sfpmad(q.get(), s.get(), c1.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
+        sfpi::vFloat c0 = -0x1.555558p-2f;
+        q = __builtin_rvtt_sfpmad(q.get(), s.get(), c0.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
+    } else {
+        q = -0x1.de8p-5f;
+        s = a * a;
+        sfpi::vFloat c1 = 0x1.668p-3f;
+        q = __builtin_rvtt_sfpmad(q.get(), s.get(), c1.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
+        sfpi::vFloat c0 = -0x1.54p-2f;
+        q = __builtin_rvtt_sfpmad(q.get(), s.get(), c0.get(), sfpi::SFPMAD_MOD1_OFFSET_NONE);
+    }
+    sfpi::vFloat half_pi = 0x1.921fb6p+0f;
+    sfpi::vFloat t = q * s;
+    sfpi::vFloat x_abs = sfpi::setsgn(x, 0);
+    r = t * a + a;
+
+    // Special cases:
+
+    v_if(sfpi::as<sfpi::vInt>(min) >= sfpi::as<sfpi::vInt>(x_abs)) {
+        // if |y| ≥ |x| then r = π/2 - r
+        r = half_pi - r;
+        v_if(sfpi::as<sfpi::vInt>(min) >= sfpi::as<sfpi::vInt>(max)) {
+            // if |x| = |y| (including both infinite), then r = π/4
+            r = sfpi::addexp(half_pi, -1);
+            v_if(min == 0.0f) {
+                // if both zero, then r = ±0
+                // SFPI note: the later v_if(x < 0.0f) behaves like a signbit check, so r=-0
+                // is handled by that path.
+                r = 0.0f;
+            }
+            v_endif;
+        }
+        v_endif;
+    }
+    v_endif;
+
+    // if sign of x is negative (including x=-0), then r = π - r
+    v_if(x < 0.0f) {
+        sfpi::vFloat pi = sfpi::addexp(half_pi, 1);
+        r = pi - r;
+    }
+    v_endif;
+
+    if constexpr (!is_fp32_dest_acc_en) {
+        r = sfpi::convert<sfpi::vFloat16b>(r, sfpi::RoundMode::Nearest);
+    }
+
+    r = sfpi::copysgn(r, y);
+
+    // If |x| = NaN or |y| = NaN, vec_min_max will ensure max=NaN as mentioned above.
+    sfpi::vFloat infinity = std::numeric_limits<float>::infinity();
+    v_if(sfpi::as<sfpi::vInt>(infinity) < sfpi::as<sfpi::vInt>(max)) {
+        // if |x| = NaN or |y| = NaN, then r = NaN
+        r = std::numeric_limits<float>::quiet_NaN();
+    }
+    v_endif;
+
+    return r;
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en>
+inline void calculate_sfpu_atan2(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+
+        sfpi::vFloat result = _sfpu_atan2_<APPROXIMATION_MODE, is_fp32_dest_acc_en>(in0, in1);
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void calculate_sfpu_atan2_init() {
+    sfpu_reciprocal_init<APPROXIMATION_MODE || !is_fp32_dest_acc_en>();
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_bitwise.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_bitwise.h
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+#include "ckernel_addrmod.h"
+#include "ckernel_ops.h"
+#include "llk_defs.h"
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+enum class BinaryBitwiseOp : std::uint8_t {
+    AND = 0,
+    OR = 1,
+    XOR = 2,
+};
+
+template <
+    bool APPROXIMATION_MODE,
+    BinaryBitwiseOp BITWISE_OP,
+    InstrModLoadStore INSTRUCTION_MODE = InstrModLoadStore::INT32,
+    int ITERATIONS = 8>
+inline void calculate_sfpu_binary_bitwise(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+    // Bitwise AND/OR/XOR of two integer operands. `a & b` / `a | b` / `a ^ b` lower to the same
+    // single SFPAND/SFPOR/SFPXOR the raw path used (no constant materialization), while the loads,
+    // store and dst walk are left to the compiler.
+    constexpr sfpi::DataLayout layout =
+        (INSTRUCTION_MODE == InstrModLoadStore::LO16) ? sfpi::DataLayout::U16 : sfpi::DataLayout::I32;
+    using vType = std::conditional_t<layout == sfpi::DataLayout::U16, sfpi::vUInt, sfpi::vInt>;
+
+    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        vType a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].mode<layout>();
+        vType b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi].mode<layout>();
+
+        vType result;
+        if constexpr (BITWISE_OP == BinaryBitwiseOp::AND) {
+            result = a & b;
+        } else if constexpr (BITWISE_OP == BinaryBitwiseOp::OR) {
+            result = a | b;
+        } else {
+            result = a ^ b;
+        }
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi].mode<layout>() = result;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_fmod.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_fmod.h
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <limits>
+#include <cstdint>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_binary_remainder.h"
+#include "sfpi.h"
+#include "ckernel_sfpu_recip.h"
+#include "sfpu/ckernel_sfpu_rounding_ops.h"
+
+namespace ckernel::sfpu {
+
+// FMOD = a - trunc(a / b) * b
+// Implemented using 32-bit integer remainder kernel (see ckernel_sfpu_remainder_int32.h)
+sfpi_inline void calculate_fmod_int32_body(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
+    // Read inputs
+    sfpi::vInt a_signed = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+    sfpi::vInt b_signed = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+
+    // Compute unsigned remainder
+    sfpi::vInt r = compute_unsigned_remainder_int32(a_signed, b_signed);
+
+    // FMOD sign handling (result has the same sign as a)
+    v_if(a_signed < 0) { r = -r; }
+    v_endif;
+
+    sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = r;
+}
+
+template <bool is_fp32_dest_acc_en = false>
+sfpi_inline sfpi::vFloat _sfpu_binary_fmod_(sfpi::vFloat in0, sfpi::vFloat in1) {
+    // fmod(a, b) = a - trunc(a/b) * b
+
+    sfpi::vFloat a = in0;
+    sfpi::vFloat b = in1;
+    sfpi::vFloat b_abs = sfpi::abs(b);
+
+    // Compute reciprocal 1/b
+    sfpi::vFloat recip = ckernel::sfpu::sfpu_reciprocal_iter<2>(b);
+
+    // Compute a/b = a * (1/b)
+    sfpi::vFloat div_result = a * recip;
+
+    sfpi::vFloat trunc_div = _trunc_body_(div_result);
+
+    // Compute fmod = a - trunc(a/b) * b
+    sfpi::vFloat result = a - trunc_div * b;
+
+    // Post-correction - fmod result must satisfy |result| < |b|
+    // If |result| >= |b|, the truncation was wrong by 1
+    sfpi::vFloat result_abs = sfpi::abs(result);
+
+    // If result >= b, we truncated too low, add/subtract b to correct
+    v_if(result_abs >= b_abs) {
+        // Determine correction direction based on sign of result
+        v_if(result >= sfpi::vFloat(0.0f)) {
+            result = result - b_abs;  // result was positive and too big
+        }
+        v_else {
+            result = result + b_abs;  // result was negative and too big (magnitude)
+        }
+        v_endif;
+    }
+    v_endif;
+
+    // Sign correction - fmod result must have same sign as 'a' (or be zero)
+    // If a > 0 and result < 0, the truncation was 1 too high, need to add b
+    // If a < 0 and result > 0, the truncation was 1 too low, need to subtract b
+    // This fixes cases where a/b ≈ 0.9999999 but rounds to 1 due to reciprocal error
+    v_if(a >= sfpi::vFloat(0.0f)) {
+        // a is positive, result should be >= 0
+        v_if(result < sfpi::vFloat(0.0f)) {
+            result = result + b_abs;  // over-truncated
+        }
+        v_endif;
+    }
+    v_else {
+        // a is negative, result should be <= 0
+        v_if(result > sfpi::vFloat(0.0f)) {
+            result = result - b_abs;  // under-truncated
+        }
+        v_endif;
+    }
+    v_endif;
+
+    // Handle special cases using conditional assignment (NOT early return!)
+    // When a == b, fmod(a, b) = 0
+    v_if(a == b) { result = sfpi::vFloat(0.0f); }
+    v_endif;
+
+    // Handle division by zero - return NaN
+    v_if(b == sfpi::vFloat(0.0f)) { result = sfpi::vFloat(std::numeric_limits<float>::quiet_NaN()); }
+    v_endif;
+
+    if constexpr (!is_fp32_dest_acc_en) {
+        result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
+    }
+
+    return result;
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_fmod_int32(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        calculate_fmod_int32_body(dst_index_in0, dst_index_in1, dst_index_out);
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>
+inline void calculate_sfpu_binary_fmod(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+    for (int d = 0; d < ITERATIONS; d++) {
+        // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+        constexpr std::uint32_t dst_tile_size_sfpi = 32;
+        sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+
+        sfpi::vFloat result = _sfpu_binary_fmod_<is_fp32_dest_acc_en>(in0, in1);
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+inline void fmod_int32_init() {
+    div_floor_init<APPROXIMATION_MODE>();
+}
+
+template <bool APPROXIMATION_MODE>
+inline void fmod_binary_init() {
+    sfpu_reciprocal_init<false>();
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_pow.h
@@ -1,0 +1,323 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_conversions.h"
+#include "cmath_common.h"
+#include "sfpi.h"
+#include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_polyval.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+/**
+ * @brief Computes base raised to the power of pow (base**pow)
+ *
+ * This function implements binary exponentiation using a polynomial approximation algorithm
+ * based on "Simple Multiple Precision Algorithms for Exponential Functions [Tips & Tricks]"
+ * by Moroz et al. 2022 (https://doi.org/10.1109/MSP.2022.3157460).
+ * More specifically, it is the implementation of the `exp_21f` algorithm described in Section 5
+ *
+ * @param base The base value (sfpi::vFloat vector), can be any floating point number
+ * @param pow The exponent/power value (sfpi::vFloat vector), can be any floating point number
+ *
+ * @return sfpi::vFloat Result of base**pow
+ *
+ * Special Cases:
+ * - base = 0, pow < 0: Returns NaN (undefined)
+ * - base < 0, pow = integer: Returns proper signed result (negative if odd power)
+ * - base < 0, pow = non-integer: Returns NaN (complex result)
+ * - Overflow/underflow: Clamped to appropriate limits
+ *
+ * @note This function assumes that the programmable constants are set to the following values:
+ * - vConstFloatPrgm0 = 1.4426950408889634f;
+ * - vConstFloatPrgm1 = -127.0f;
+ *
+ * @see Moroz et al. 2022 - "Simple Multiple Precision Algorithms for Exponential Functions"
+ *      ( https://doi.org/10.1109/MSP.2022.3157460 )
+ */
+template <bool is_fp32_dest_acc_en = false>
+sfpi_inline sfpi::vFloat _sfpu_binary_power_21f_(sfpi::vFloat base, sfpi::vFloat pow) {
+    // The algorithm works in two steps:
+    // 1) Compute log2(base)
+    // 2) Compute base**pow = 2**(pow * log2(base))
+
+    // Step 1: Compute log2(base)
+    // Normalize base to calculation range
+    sfpi::vFloat absbase = setsgn(base, 0);       // set base as positive
+    sfpi::vFloat x = sfpi::setexp(absbase, 127);  // set exp to exp bias (put base in range of 1-2)
+
+    // 3rd order polynomial approx - determined using rminimax over [1,2]
+    sfpi::vFloat series_result = x * (x * (x * 0x2.44734p-4f - 0xd.e712ap-4f) + 0x2.4f5388p+0f) - 0x1.952992p+0f;
+
+    // Convert exponent to float
+    auto exp = sfpi::convert<sfpi::vSMag>(sfpi::exexp(base));
+    sfpi::vFloat exp_f32 = sfpi::convert<sfpi::vFloat>(exp, sfpi::RoundMode::Nearest);
+
+    // De-normalize to original range
+    const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;           // vConst1Ln2 = 1.4426950408889634f;
+    sfpi::vFloat log2_result = exp_f32 + series_result * vConst1Ln2;  // exp correction: ln(1+x) + exp*ln(2)
+
+    // Step 2: Compute base**pow = 2**(pow * log2(base))
+    // If (base, exponent) => (0, +inf) or (base, exponent) => (N, -inf) then output should be 0
+    // However, intermediary values can overflow, which leads to output increasing again instead of
+    // staying at 0.
+    // This overflow happens when z_f32 < -127. Therefore, we clamp z_f32 to -127.
+    sfpi::vFloat z_f32 = pow * log2_result;
+    const sfpi::vFloat low_threshold = sfpi::vConstFloatPrgm1;
+    v_if(z_f32 < low_threshold) { z_f32 = low_threshold; }
+    v_endif;
+
+    // The paper relies on the following formula (c.f. Sections 1 and 5):
+    // z = (bias + x * log2(a)) * N_m; where:
+    // N_m = 2**23
+    // bias = 0x3f800000
+
+    // In this case, we transform the formula to:
+    // z = (bias) * N_m + (x * log2(a)) * N_m
+    // where (bias + N_m) = 0x3f800000
+    // and (x * log2(a)) * N_m = addexp(z_f32, 23)
+
+    // Notes:
+    // - N_m being a power of 2 ensures equivalent results
+    // - addexp(z_f32, 23) is used because it translates to a single-cycle SFPDIVP2
+    //   instruction with immediate operand (i.e. no extra register used).
+    //   (vs. 1 cycle SFPLOADI + 2 cycles MAD)
+
+    z_f32 = addexp(z_f32, 23);  // equal to multiplying by 2**23
+    const sfpi::vFloat bias = sfpi::vFloat(0x3f800000);
+    sfpi::vInt z = _float_to_int32_positive_(z_f32 + bias);
+
+    sfpi::vInt zii = exexp(sfpi::as<sfpi::vFloat>(z));        // Note: z & 0x7f800000 in paper
+    sfpi::vInt zif = sfpi::exman(sfpi::as<sfpi::vFloat>(z));  // Note: z & 0x007fffff in paper
+
+    // Compute formula in Horner form
+    sfpi::vFloat d1 = sfpi::vFloat(0.40196114e-7);
+    sfpi::vFloat d2 =
+        sfpi::convert<sfpi::vFloat>(sfpi::as<sfpi::vSMag>(sfpi::vInt(0xf94ee7) + zif), sfpi::RoundMode::Nearest);
+    sfpi::vFloat d3 =
+        sfpi::convert<sfpi::vFloat>(sfpi::as<sfpi::vSMag>(sfpi::vInt(0x560e) + zif), sfpi::RoundMode::Nearest);
+
+    d2 = d1 * d2;
+    zif = _float_to_int32_positive_(d2 * d3);
+
+    // Restore exponent
+    zii = sfpi::as<sfpi::vInt>(sfpi::setexp(sfpi::as<sfpi::vFloat>(zif), 127U + zii));
+
+    sfpi::vFloat y = sfpi::as<sfpi::vFloat>(zii);
+
+    // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
+    // Check valid base range
+    auto pow_int = sfpi::convert<sfpi::vSMag16>(
+        pow, sfpi::RoundMode::Nearest);  // int16 should be plenty, since large powers will approach 0/Inf
+    auto pow_rounded = sfpi::convert<sfpi::vFloat>(pow_int, sfpi::RoundMode::Nearest);
+
+    // Division by 0 when base is 0 and pow is negative => set to NaN
+    v_if((absbase == 0.f) && pow < 0.f) {
+        y = std::numeric_limits<float>::quiet_NaN();  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
+    }
+    v_endif;
+
+    v_if(base < 0.0f) {  // negative base
+        // If pow is odd integer then result is negative
+        // If power is even, then result is positive
+        y = sfpi::setsgn2(y, pow_int);
+
+        // Check for integer power, if it is not then overwrite result with NaN
+        v_if(pow_rounded != pow) {  // negative base and non-integer power => set to NaN
+            y = std::numeric_limits<float>::quiet_NaN();
+        }
+        v_endif;
+    }
+    v_endif;
+
+    if constexpr (!is_fp32_dest_acc_en) {
+        // LRegs work on float32 data. If DST is bfloat16 then SFPSTORE will truncate it.
+        // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
+        // rather than 81 (which would have been correct).
+        // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest.
+        y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::Nearest);
+    }
+
+    return y;
+}
+
+sfpi_inline sfpi::vFloat _sfpu_binary_power_f32_(sfpi::vFloat base, sfpi::vFloat pow) {
+    // The algorithm works in two steps:
+    // 1) Compute log2(base)
+    // 2) Compute base**pow = 2**(pow * log2(base))
+
+    // Step 1: Compute log2(base) using improved log
+    // Normalize base to calculation range
+    sfpi::vFloat abs_base = sfpi::abs(base);
+    sfpi::vFloat m = sfpi::setexp(abs_base, 127);
+    sfpi::vInt exp = sfpi::exexp(abs_base);
+
+    // Range reduction: ensure m in [sqrt(2)/2, sqrt(2)] ≈ [0.707, 1.414]
+    constexpr float SQRT2 = 1.4142135381698608f;
+    // If m >= sqrt(2), divide by 2 and increment exponent
+    v_if(m >= SQRT2) {
+        // m = m * 0.5f;  // Divide by 2
+        m = m * 0.5f;
+        exp = exp + 1;
+    }
+    v_endif;
+
+    // Transform to z = (m - 1) / (m + 1)
+    sfpi::vFloat m_plus_1 = m + 1.0f;  // t in [1.707, 2.414] since m in [sqrt(2)/2, sqrt(2)]
+    // 1/t: initial guess 1.0f - 0.2426406871192851f*t (linear interp on [1.7,2.4]), then Newton-Raphson y = y*(2 -
+    // t*y).
+    sfpi::vFloat recip = 1.0f - 0.2426406871192851f * m_plus_1;
+    recip = recip * (2.0f - m_plus_1 * recip);  // 1st NR
+    recip = recip * (2.0f - m_plus_1 * recip);  // 2nd NR
+    // 3rd NR: two NR iterations leave a ~2 ULP reciprocal residual that, after the
+    // atanh(z) log series and pow*log2 multiply, is the floor keeping 2.5 at 4 ULP.
+    // One more quadratically-convergent step drives 1/(m+1) to full fp32 precision.
+    recip = recip * (2.0f - m_plus_1 * recip);  // 3rd NR for float32
+    // z = (m-1)*recip written as a single fused multiply-add (m*recip - recip), one
+    // instruction instead of a separate (m-1) subtract plus a multiply.
+    sfpi::vFloat z = m * recip - recip;
+
+    // Compute z**2 for polynomial evaluation
+    sfpi::vFloat z2 = z * z;
+    // Polynomial approximation using odd powers
+    sfpi::vFloat p = PolynomialEvaluator::eval(
+        z2, 1.0f, 0.3333333333333333f, 0.2f, 0.14285714285714285f, 0.1111111111111111f, 0.09090909090909091f);
+    sfpi::vFloat ln_m = 2.0f * (z * p);
+
+    sfpi::vFloat exp_f32 = sfpi::convert<sfpi::vFloat>(sfpi::convert<sfpi::vSMag>(exp), sfpi::RoundMode::Nearest);
+
+    // log2(base) = ln(base)/ln(2) = exp + ln_m/ln(2). Keep the two contributions
+    // separate: exp_f32 is the large integer part, ln_m*ln2inv the small fractional
+    // part. Collapsing pow*log2(base) into one fp32 before 2**z squeezes out the
+    // fractional mantissa bits for large |base| (the 20-27 ULP error). Instead carry
+    // z = pow*log2(base) as an unevaluated double-float (z_hi, z_lo) and cancel the
+    // large integer part against k=round(z) before the tail is ever rounded away.
+    const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;
+    constexpr float LN2 = 0.693147180559945309f;
+
+    // Step 2: base**pow = 2**(pow*log2(base)).
+    // The residual after the two-sum is the fp32 rounding of pow*exp_f32 itself:
+    // exp_f32 is the large integer exponent and pow can carry a full 24-bit mantissa,
+    // so the product needs ~30 bits and drops its low bits before the two-sum sees
+    // them. exp_f32 is a small integer, so a Veltkamp split of pow makes both partial
+    // products exact (12-bit half * <=7-bit integer fits a 24-bit significand); the low
+    // half pow_lo*exp_f32 rides in z_lo so none of the integer term's bits are lost.
+    constexpr float VELTKAMP_SPLIT = 4097.0f;  // 2**12 + 1
+    sfpi::vFloat pc = pow * VELTKAMP_SPLIT;
+    sfpi::vFloat pow_hi = pc - (pc - pow);
+    sfpi::vFloat pow_lo = pow - pow_hi;
+
+    sfpi::vFloat z_hi = pow_hi * exp_f32;
+    sfpi::vFloat z_lo = pow_lo * exp_f32 + pow * (ln_m * vConst1Ln2);
+
+    // Dekker FastTwoSum so k=round(z) sees the true integer part while the residual e
+    // keeps the dropped tail. Exact under the precondition |z_hi| >= |z_lo| or z_hi == 0:
+    // z_hi = pow*exponent(base) and z_lo carries the fractional log2 term (|z_lo| <
+    // ~0.5*|pow| plus a <=2**-12*|pow| Veltkamp remainder). When exponent(base) == 0 then
+    // z_hi == 0 exactly (the sum is already exact); otherwise |exponent(base)| >= 1 so
+    // |z_hi| >= |pow| > |z_lo|.
+    sfpi::vFloat s = z_hi + z_lo;
+    sfpi::vFloat e = z_lo - (s - z_hi);
+    // vConstFloatPrgm1 holds -127 (matches the original clamp); use it directly to avoid a copy.
+    v_if(s < sfpi::vConstFloatPrgm1) {
+        s = sfpi::vConstFloatPrgm1;
+        e = 0.0f;
+    }
+    v_endif;
+
+    sfpi::vInt k_int;
+    sfpi::vFloat k = _sfpu_round_to_nearest_int32_(s, k_int);
+    // Reduced argument (s - k) is exact by Sterbenz; add back the tail e.
+    sfpi::vFloat frac = (s - k) + e;
+
+    // 2**frac via the accurate exp helper (frac is small), then scale by 2**k.
+    sfpi::vFloat y = _sfpu_exp_fp32_accurate_(frac * LN2);
+    // setexp writes the 8-bit exponent field and wraps instead of saturating, so an
+    // overflowing magnitude silently becomes a finite value. Detect overflow from the
+    // biased exponent about to be written (>= 255 is the inf field) and clamp explicitly.
+    // Checking out_exp (already needed by setexp) instead of keeping the float s live
+    // across the exp helper avoids pushing this kernel past the SFPU register-allocator
+    // budget (reload-insn ICE); out_exp >= 255 is equivalent to s >= 128.
+    sfpi::vInt out_exp = sfpi::exexp(y, sfpi::ExponentMode::Biased) + k_int;
+    y = sfpi::setexp(y, out_exp);
+    v_if(out_exp >= 255) { y = std::numeric_limits<float>::infinity(); }
+    v_endif;
+
+    // Division by 0 when base is 0 and pow is negative => set to NaN (only for negative exponents)
+    v_if(base == 0.f && pow < 0.f) {
+        y = std::numeric_limits<float>::quiet_NaN();  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
+    }
+    v_endif;
+
+    v_if(base < 0.0f) {  // negative base
+        // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
+        // Check valid base range
+        auto pow_int = sfpi::convert<sfpi::vSMag16>(
+            pow, sfpi::RoundMode::Nearest);  // int16 should be plenty, since large powers will approach 0/Inf
+        auto pow_rounded = sfpi::convert<sfpi::vFloat>(pow_int, sfpi::RoundMode::Nearest);
+
+        // If pow is odd integer then result is negative
+        // If power is even, then result is positive
+        // To get the sign bit of result, we can shift last bit of pow_int to the 1st bit
+        y = sfpi::setsgn2(y, pow_int);
+
+        // Check for integer power, if it is not then overwrite result with NaN
+        v_if(pow_rounded != pow) {  // negative base and non-integer power => set to NaN
+            y = std::numeric_limits<float>::quiet_NaN();
+        }
+        v_endif;
+    }
+    v_endif;
+
+    return y;
+}
+
+template <bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _sfpu_binary_power_(sfpi::vFloat base, sfpi::vFloat pow);
+
+// is_fp32_dest_acc_en == false
+template <>
+sfpi_inline sfpi::vFloat _sfpu_binary_power_<false>(sfpi::vFloat base, sfpi::vFloat pow) {
+    return _sfpu_binary_power_21f_<false>(base, pow);
+}
+
+// is_fp32_dest_acc_en == true
+template <>
+sfpi_inline sfpi::vFloat _sfpu_binary_power_<true>(sfpi::vFloat base, sfpi::vFloat pow) {
+    return _sfpu_binary_power_f32_(base, pow);
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>
+inline void calculate_sfpu_binary_pow(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+    for (int d = 0; d < ITERATIONS; d++) {
+        // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+        constexpr std::uint32_t dst_tile_size_sfpi = 32;
+        sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+
+        sfpi::vFloat result = _sfpu_binary_power_<is_fp32_dest_acc_en>(in0, in1);
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+inline void sfpu_binary_pow_init() {
+    math::_reset_counters_<p_setrwc::SET_ABD_F>();
+    sfpi::vConstFloatPrgm0 = 1.442695f;
+    sfpi::vConstFloatPrgm1 = -127.0f;
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
@@ -1,0 +1,265 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <limits>
+#include <cstdint>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_div_int32_floor.h"
+#include "sfpi.h"
+#include "ckernel_sfpu_recip.h"
+#include "sfpu/ckernel_sfpu_rounding_ops.h"
+
+namespace ckernel::sfpu {
+
+// 2^31 as float (used for INT32 sign-magnitude conversion edge cases)
+constexpr float TWO_POW_31 = 2147483648.0f;
+
+// Computes 1/|b| for the unsigned remainder (single Newton–Raphson refinement). Split recip and
+// remainder computation so that the tensor-scalar path can hoist this loop-invariant work above its
+// element loop, since a scalar divisor is identical for every lane and iteration.
+sfpi_inline sfpi::vFloat unsigned_remainder_recip(const sfpi::vMag& b) {
+    // Convert to float; handle 2^31 edge case where sign-magnitude conversion yields negative
+    sfpi::vFloat b_f = sfpi::convert<sfpi::vFloat>(b, sfpi::RoundMode::Nearest);
+    v_if(b_f < 0.0f) { b_f = TWO_POW_31; }
+    v_endif;
+
+    sfpi::vFloat inv_b_f = sfpi::approx_recip(b_f);
+    // One NR step: inv_b = inv_b * (2 - b * inv_b)
+    sfpi::vFloat e = -inv_b_f * b_f + 1.0f;
+    return e * inv_b_f + inv_b_f;
+}
+
+// Computes the unsigned remainder: |a| - floor(|a| / |b|) * |b|, given |b| and 1/|b| precomputed.
+// Use 32-bit integer division from ckernel_sfpu_div_int32_floor.h
+// Returns: unsigned remainder r
+sfpi_inline sfpi::vInt compute_unsigned_remainder_int32(
+    const sfpi::vInt& a_signed, sfpi::vMag b, const sfpi::vFloat& inv_b_f) {
+    // Get absolute value of a for unsigned remainder computation
+    sfpi::vMag a = sfpi::abs(a_signed);
+
+    // Convert to float; handle 2^31 edge case where sign-magnitude conversion yields negative
+    sfpi::vFloat a_f = sfpi::convert<sfpi::vFloat>(a, sfpi::RoundMode::Nearest);
+    v_if(a_f < 0.0f) { a_f = TWO_POW_31; }
+    v_endif;
+
+    // Initial quotient approximation: q = a * (1/b)
+    sfpi::vFloat q_f = a_f * inv_b_f + sfpi::vConstFloatPrgm0;
+    sfpi::vUInt q = sfpi::exman(q_f);
+
+    sfpi::vInt qb = sfpi::fractional_mul(q, b);
+    qb <<= 10;
+
+    // Compute initial remainder
+    sfpi::vInt r = a - qb;
+
+    // Compute correction for approximation error: correction = |r| / b
+    sfpi::vFloat r_f = sfpi::convert<sfpi::vFloat>(sfpi::abs(r), sfpi::RoundMode::Nearest);
+    sfpi::vMag correction = sfpi::convert<sfpi::vUInt16>(r_f * inv_b_f, sfpi::RoundMode::Nearest);
+
+    // Compute correction * b (full 32-bit result from 24-bit multiplies)
+    sfpi::vInt tmp_lo = sfpi::fractional_mul(correction, b);
+    sfpi::vInt tmp_hi = sfpi::fractional_mul(correction, b, sfpi::FractionalHalf::High);
+    sfpi::vInt b_hi = sfpi::fractional_mul(correction, b >> 23);
+    sfpi::vInt tmp = tmp_lo + ((tmp_hi + b_hi) << 23);
+
+    v_if(r < 0) { tmp = -tmp; }
+    v_endif;
+    r -= tmp;
+
+    // Final adjustment to ensure r is in [0, b)
+    v_if(r < 0 && (r - 1) < 0) { r += b; }
+    v_elseif(r >= b) { r -= b; }
+    v_endif;
+
+    return r;
+}
+
+// Computes the unsigned remainder: |a| - floor(|a| / |b|) * |b|
+// Returns: unsigned remainder r
+sfpi_inline sfpi::vInt compute_unsigned_remainder_int32(const sfpi::vInt& a_signed, const sfpi::vInt& b_signed) {
+    sfpi::vMag b = sfpi::abs(b_signed);
+    return compute_unsigned_remainder_int32(a_signed, b, unsigned_remainder_recip(b));
+}
+
+// Remainder = a - floor(a / b) * b
+sfpi_inline void calculate_remainder_int32_body(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
+    // Read inputs
+    sfpi::vInt a_signed = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+    sfpi::vInt b_signed = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+
+    // Compute unsigned remainder
+    sfpi::vInt r = compute_unsigned_remainder_int32(a_signed, b_signed);
+
+    // Remainder sign handling
+    sfpi::vInt sign = a_signed ^ b_signed;
+    v_if(r != 0) {
+        v_if(sign < 0) {
+            // When signs differ, floor(a/b) = trunc(a/b) - 1, so remainder needs adjustment
+            v_if(a_signed < 0) { r = b_signed - r; }
+            v_else { r += b_signed; }
+            v_endif;
+        }
+        v_elseif(a_signed < 0 && b_signed < 0) { r = -r; }
+        v_endif;
+    }
+    v_endif;
+
+    sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = r;
+}
+
+// Unsigned (uint32) remainder. compute_unsigned_remainder_int32() is exact only when both
+// operands are in [0, 2^31) (abs() is a no-op there), so we range-reduce into that regime:
+// * b <  2^31: halve a to clear the problematic top bit. With t = a >> 1 (logical) and
+//              a = 2*t + (a & 1), a % b = (2*(t % b) + (a & 1)) % b. t < 2^31 for every uint32 a,
+//              so the single helper call always sees operands in [0, 2^31).
+// * b >= 2^31: a < 2^32 <= 2*b, so a is already in [0, 2b) and needs no helper (a % b = a or a - b).
+// Both regimes yield a value x in [0, 2b), reduced by one conditional subtract: x % b =
+// (x >=u b) ? x - b : x. The SFPU integer compare only tests sign(x - b), which equals the true
+// unsigned x >=u b except when b >= 2^31 and x < 2^31; a second predicate corrects those lanes
+// (there x < b, so the remainder is x).
+sfpi_inline void calculate_remainder_uint32_body(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
+    // Load raw 32-bit patterns (interpreted as unsigned)
+    sfpi::vInt a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+    sfpi::vInt b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+
+    // Call the helper unconditionally (nesting it inside predication crashes the SFPI rvtt_live
+    // pass). t = (uint32)a >> 1 is always < 2^31, so the helper sees valid [0, 2^31) operands; rt
+    // is only used on the b < 2^31 lanes, but every lane pays the call.
+    sfpi::vInt t = sfpi::vInt(sfpi::vUInt(a) >> 1);
+    sfpi::vInt rt = compute_unsigned_remainder_int32(t, b);
+
+    // Reload a from DEST instead of keeping it live across the helper
+    a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+
+    // b < 2^31 uses x = 2*rt + (a & 1); b >= 2^31 keeps x = a
+    v_if(b >= 0) { a = rt + rt + (a & 1); }
+    v_endif;
+
+    // x % b = (x >=u b) ? x - b : x, valid for both regimes since x in [0, 2b)
+    sfpi::vInt r = a;
+    v_if(sfpi::vUInt(a) >= sfpi::vUInt(b)) { r = a - b; }
+    v_endif;
+    // The above compare only tests sign(x - b), matching x >=u b except when b >= 2^31 and x < 2^31
+    // Then x < b, remainder = x
+    v_if(b < 0 && a >= 0) { r = a; }
+    v_endif;
+
+    sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = r;
+}
+
+template <bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _sfpu_binary_remainder_(sfpi::vFloat in0, sfpi::vFloat in1) {
+    // remainder(a, b) = a - floor(a/b) * b
+
+    sfpi::vFloat a = in0;
+    sfpi::vFloat b = in1;
+
+    // Compute a/b = a * (1/b)
+    sfpi::vFloat div_result = a * sfpu_reciprocal_iter<2>(b);
+
+    // Compute floor(a/b)
+    sfpi::vFloat floor_div = _floor_body_(div_result);
+
+    // Compute remainder = a - floor(a/b) * b
+    sfpi::vFloat result = a - floor_div * b;
+
+    // Sign correction: remainder must match the sign of b (or be zero).
+    // XOR of the float bit-patterns detects sign mismatch via the MSB,
+    // avoiding a compound conditional with four comparisons and an OR.
+    v_if(result != 0.0f) {
+        sfpi::vInt signs = sfpi::as<sfpi::vInt>(result) ^ sfpi::as<sfpi::vInt>(b);
+        v_and(signs < 0);
+        result += b;
+    }
+    v_endif;
+
+    // Magnitude correction: reciprocal imprecision can cause floor() to be greater than the true floor value.
+    v_if(b > sfpi::vFloat(0.0f) && a > sfpi::vFloat(0.0f)) {
+        sfpi::vFloat diff = result - b;
+        v_if(diff >= sfpi::vFloat(0.0f)) { result = diff; }
+        v_endif;
+    }
+    v_endif;
+    v_if(b < sfpi::vFloat(0.0f) && a < sfpi::vFloat(0.0f)) {
+        sfpi::vFloat diff = result - b;
+        v_if(diff <= sfpi::vFloat(0.0f)) { result = diff; }
+        v_endif;
+    }
+    v_endif;
+
+    // Handle division by zero - return NaN
+    v_if(b == sfpi::vFloat(0.0f)) { result = sfpi::vFloat(std::numeric_limits<float>::quiet_NaN()); }
+    v_endif;
+
+    if constexpr (!is_fp32_dest_acc_en) {
+        result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
+    }
+
+    return result;
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_remainder_int32(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+#pragma GCC unroll 2
+    for (int d = 0; d < ITERATIONS; d++) {
+        calculate_remainder_int32_body(dst_index_in0, dst_index_in1, dst_index_out);
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_remainder_uint32(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+#pragma GCC unroll 2
+    for (int d = 0; d < ITERATIONS; d++) {
+        calculate_remainder_uint32_body(dst_index_in0, dst_index_in1, dst_index_out);
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8, bool is_fp32_dest_acc_en = false>
+inline void calculate_sfpu_binary_remainder(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+
+        sfpi::vFloat result = _sfpu_binary_remainder_<is_fp32_dest_acc_en>(in0, in1);
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+inline void remainder_int32_init() {
+    div_floor_init<APPROXIMATION_MODE>();
+}
+
+template <bool APPROXIMATION_MODE>
+inline void remainder_uint32_init() {
+    // Shares the int32 setup: the unsigned path reuses compute_unsigned_remainder_int32().
+    div_floor_init<APPROXIMATION_MODE>();
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void remainder_binary_init() {
+    sfpi::vConstFloatPrgm0 = 2.0f;
+}
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise.h
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "cmath_common.h"
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+enum class UnaryBitwiseOp : std::uint8_t {
+    AND = 0,
+    OR = 1,
+    XOR = 2,
+};
+
+template <UnaryBitwiseOp BITWISE_OP, typename Vec>
+inline Vec compute_unary_bitwise(Vec v, Vec scalar) {
+    if constexpr (BITWISE_OP == UnaryBitwiseOp::AND) {
+        return v & scalar;
+    } else if constexpr (BITWISE_OP == UnaryBitwiseOp::OR) {
+        return v | scalar;
+    } else {
+        static_assert(BITWISE_OP == UnaryBitwiseOp::XOR, "Unsupported bitwise op");
+        return v ^ scalar;
+    }
+}
+
+inline void bitwise_and_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+inline void bitwise_or_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+inline void bitwise_xor_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+template <
+    bool APPROXIMATION_MODE,
+    UnaryBitwiseOp BITWISE_OP,
+    DataFormat DATA_FORMAT = DataFormat::Int32,
+    int ITERATIONS = 8>
+inline void calculate_sfpu_unary_bitwise(const std::uint32_t value) {
+    static_assert(
+        DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt16,
+        "Unsupported data format for bitwise operation. Supported data formats are: Int32, UInt16");
+    if constexpr (DATA_FORMAT == DataFormat::UInt16) {
+        // Bitwise op is per-lane (v & scalar), so `scalar` must be a vector broadcast of `value`
+        // whose type matches the loaded `v` (vUInt for the U16 layout).
+        const sfpi::vUInt scalar = static_cast<unsigned>(value);
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vUInt v = sfpi::dst_reg[0].mode<sfpi::DataLayout::U16>();
+            sfpi::dst_reg[0].mode<sfpi::DataLayout::U16>() = compute_unary_bitwise<BITWISE_OP>(v, scalar);
+            sfpi::dst_reg++;
+        }
+    } else {
+        // I32 layout loads vInt, so `scalar` must be vInt to match `v`.
+        const sfpi::vInt scalar = static_cast<int>(value);
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vInt v = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
+            sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>() = compute_unary_bitwise<BITWISE_OP>(v, scalar);
+            sfpi::dst_reg++;
+        }
+    }
+}
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_not.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "cmath_common.h"
+#include "sfpi.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+inline void bitwise_not_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_bitwise_not() {
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vInt v = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
+        sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>() = ~v;
+        dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void cast_fp32_to_fp16a() {
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        x = sfpi::convert<sfpi::vFloat16a>(x, sfpi::RoundMode::Nearest);
+        sfpi::dst_reg[0] = x;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_cbrt.h
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Jason Davies <jason@jasondavies.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "cmath_common.h"
+
+namespace ckernel::sfpu {
+
+// This is a modified version of "Fast Calculation of Cube and Inverse Cube
+// Roots Using a Magic Constant and Its Implementation on Microcontrollers" by
+// Moroz et al. <https://doi.org/10.3390/en14041058>
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
+inline void calculate_cube_root() {
+    sfpi::vFloat negative_third_256 = -0x1.555556p-10f;
+
+    // Magic constant 0x548c2b4b / 256 + 2^23
+    sfpi::vFloat magic = 1418472267.0f / 256.0f + 8388608.0f;
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat a = sfpi::dst_reg[0];
+        sfpi::vFloat x = sfpi::abs(a);
+
+        // Paper wants i = 0x548c2b4b - i/3.
+        // Due to lack of integer division and lack of fp32 to u32 cast, we
+        // compute this using two instructions: SFPMAD and SFPSHFT.
+        //
+        // First, we compute (0x548c2b4b - i/3) in fp32, but we also need to
+        // add 2^23 to shift the result into the mantissa bits for extraction
+        // as integer.  This only works if (0x548c2b4b - i/3)*k < 2^23, so we
+        // divide everything by 2^8.
+        //
+        // f = (0x548c2b4b - i * 1.0/3.0) / 256.0 + 2^23
+        //   = (0x548c2b4b/256.0 - i * 1.0/3.0/256.0) + 2^23
+
+        sfpi::vFloat f = sfpi::convert<sfpi::vFloat>(sfpi::as<sfpi::vSMag>(x), sfpi::RoundMode::Nearest);
+
+        f = f * negative_third_256 + magic;
+
+        // Now, left-shift by 8 to restore integer result.
+
+        sfpi::vFloat y = sfpi::as<sfpi::vFloat>(sfpi::as<sfpi::vInt>(f) << 8);
+
+        if constexpr (is_fp32_dest_acc_en) {
+            sfpi::vFloat c = (x * y) * (y * y);
+            y = y * (c * (sfpi::vConstFloatPrgm2 * c + sfpi::vConstFloatPrgm1) + sfpi::vConstFloatPrgm0);
+
+            sfpi::vFloat d = x * (y * y);
+            c = d * y + -1.0f;
+            sfpi::vFloat negative_third = sfpi::addexp(negative_third_256, 8);
+            sfpi::vFloat t = c * negative_third + 1.0f;
+            d = sfpi::copysgn(d, a);
+            y = d * (t * t);
+        } else {
+            sfpi::vFloat d = x * (y * y);
+            sfpi::vFloat c = d * y;
+            sfpi::vFloat t = c * (sfpi::vConstFloatPrgm2 * c + sfpi::vConstFloatPrgm1) + sfpi::vConstFloatPrgm0;
+            d = sfpi::copysgn(d, a);
+            y = d * (t * t);
+            y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::Nearest);
+        }
+        sfpi::dst_reg[0] = y;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+inline void cube_root_init() {
+    math::_reset_counters_<p_setrwc::SET_ABD_F>();
+    sfpi::vConstFloatPrgm0 = 0x1.c09806p0f;
+    sfpi::vConstFloatPrgm1 = -0x1.403e6cp0f;
+    sfpi::vConstFloatPrgm2 = 0x1.04cdb2p-1f;
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_celu.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_celu.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "cmath_common.h"
+#include "ckernel_sfpu_converter.h"
+#include "sfpu/ckernel_sfpu_expm1_cw.h"
+
+namespace ckernel::sfpu {
+
+inline void celu_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+// celu(x) = x for x>=0, alpha*(exp(x/alpha)-1) for x<0
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+inline void calculate_celu(std::uint32_t param0, std::uint32_t param1) {
+    sfpi::vFloat alpha = Converter::as_float(param0);
+    sfpi::vFloat alpha_recip = Converter::as_float(param1);
+// unroll 2: with expm1_cw_clamped inlined the loop body is large enough that
+// partial unroll outperforms both full (unroll 8) and no-unroll (~0.8us on WH)
+#pragma GCC unroll 2
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat result = alpha * expm1_cw_clamped(alpha_recip * x);
+
+        v_if(x >= 0.0f) { result = x; }
+        v_endif;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
+        }
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_conversions.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_conversions.h
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Helper function for _sfpu_binary_power_
+// This function is based on _float32_to_int32_, but expects a positive input, which simplifies the code
+// and makes it faster
+#include <cstdint>
+sfpi_inline sfpi::vInt _float_to_int32_positive_(sfpi::vFloat in) {
+    sfpi::vInt result;
+    sfpi::vInt exp = exexp(in);  // extract exponent
+    v_if(exp < 0) { result = 0; }
+    v_elseif(exp > 30)  // overflow occurs above this range
+    {
+        // set to int32 max value in case of overflow
+        result = std::numeric_limits<std::int32_t>::max();
+    }
+    v_else {
+        // extract mantissa
+        sfpi::vInt man = exman(in, sfpi::MantissaMode::ImplicitOne);
+        // shift the mantissa by (23-exponent) to the right
+        sfpi::vInt shift = exp - 23;  // 23 is number of mantissa bits in float32
+        man = shft(man, shift, sfpi::ShiftMode::Logical);
+
+        result = man;
+    }
+    v_endif;
+    return result;
+}
+
+// Convert float32 to bfloat16 using IEEE 754 Round-to-Nearest-Even (RNE)
+// This implements the "add 0x7fff + LSB" algorithm for correct tie-breaking
+sfpi_inline sfpi::vFloat float32_to_bf16_rne(sfpi::vFloat in) {
+    // Get the float32 bits as unsigned integer
+    sfpi::vUInt bits = sfpi::as<sfpi::vUInt>(in);
+
+    // Extract the LSB of what will become the bf16 mantissa (bit 16 of float32)
+    // This is needed for the tie-breaker: round to even
+    sfpi::vUInt lsb = (bits >> 16) & 1;
+
+    // Add 0x7fff + lsb to implement RNE:
+    // - If lower 16 bits > 0x8000: overflow → rounds up
+    // - If lower 16 bits < 0x8000: no overflow → rounds down
+    // - If lower 16 bits = 0x8000 (tie) and lsb=0: 0x7fff+0=0xffff, no overflow → stays even
+    // - If lower 16 bits = 0x8000 (tie) and lsb=1: 0x7fff+1=0x8000, overflow → rounds up to even
+    bits = bits + 0x7fffU + lsb;
+
+    // Clear the lower 16 bits to get bf16 in upper 16 bits (bf16 format in float32)
+    bits = bits & 0xFFFF0000U;
+
+    // Reinterpret back as float
+    return sfpi::as<sfpi::vFloat>(bits);
+}

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_digamma.h
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_converter.h"
+#include "ckernel_sfpu_log.h"
+#include "ckernel_sfpu_recip.h"
+
+#include "ckernel_sfpu_piecewise_rational.h"
+#include "cmath_common.h"
+
+namespace ckernel::sfpu {
+
+// ======================================================================
+// LUT-based digamma via piecewise rational P(x)/Q(x)
+//
+// BF16: n6/d5, 1 segment, range [0.01, 102.0]
+// FP32: n10/d9, 2 segment(s), range [0.01, 102.0]
+// ======================================================================
+
+#ifdef INP_FLOAT32
+constexpr std::uint32_t DIGAMMA_NUM_DEGREE = 10;
+constexpr std::uint32_t DIGAMMA_DEN_DEGREE = 9;
+constexpr std::uint32_t DIGAMMA_NUM_SEGMENTS = 2;
+constexpr std::uint32_t DIGAMMA_LUT_SIZE = 45;
+constexpr std::array<float, 45> DIGAMMA_LUT = {
+    {1.0000000000e-02f,  5.1005000000e+01f, 1.0200000000e+02f, -4.2596286535e-01f, -1.2459139824e+00f,
+     -7.0374596119e-01f, 3.5418295860e-01f, 3.9686101675e-01f, 1.0760356486e-01f,  1.1159370653e-02f,
+     4.5299832709e-04f,  6.4513715188e-06f, 2.3348954770e-08f, 3.3629592167e-12f,  -6.3762914866e-08f,
+     4.2596703768e-01f,  1.0000000000e+00f, 8.2736301422e-01f, 3.0081826448e-01f,  4.9985647202e-02f,
+     3.7117889151e-03f,  1.1463041301e-04f, 1.2610012732e-06f, 3.3732798776e-09f,  1.3856337913e+05f,
+     -2.7915017828e+05f, 5.5189096727e+04f, 2.6230285816e+04f, 2.0102400217e+03f,  5.4774037756e+01f,
+     6.1410588531e-01f,  2.8495312547e-03f, 4.9248967852e-06f, 2.2963254970e-09f,  3.8530168912e-14f,
+     -1.6724299601e+05f, 1.0000000000e+00f, 6.3677231206e+04f, 1.1013851737e+04f,  5.9383811201e+02f,
+     1.2890647910e+01f,  1.2061770104e-01f, 4.7490052009e-04f, 6.9240316615e-07f,  2.5925175628e-10f}};
+
+#else
+
+constexpr std::uint32_t DIGAMMA_NUM_DEGREE = 6;
+constexpr std::uint32_t DIGAMMA_DEN_DEGREE = 5;
+constexpr std::uint32_t DIGAMMA_NUM_SEGMENTS = 1;
+constexpr std::uint32_t DIGAMMA_LUT_SIZE = 15;
+// Layout: [range_lo, range_hi], then num coeffs a0..a6 (ascending degree), then den coeffs b0..b5.
+constexpr std::array<float, 15> DIGAMMA_LUT = {
+    {1.0000000000e-02f,
+     1.0200000000e+02f,
+     -3.3767190625e+05f,
+     -6.0287050000e+05f,
+     2.1532992188e+05f,
+     2.1398454688e+05f,
+     1.9496867188e+04f,
+     2.4847094727e+02f,
+     8.7151519954e-02f,
+     1.0000000000e+00f,
+     3.3760150000e+05f,
+     4.0892268750e+05f,
+     9.9775718750e+04f,
+     5.1246479492e+03f,
+     4.1351390839e+01f}};
+
+#endif
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_digamma() {
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        // Piecewise-rational LUT, fit on [0.01, 102].
+        sfpi::vFloat result =
+            piecewise_rational_eval<DIGAMMA_NUM_DEGREE, DIGAMMA_DEN_DEGREE, DIGAMMA_NUM_SEGMENTS, DIGAMMA_LUT_SIZE>(
+                DIGAMMA_LUT, x);
+
+        // Large-x asymptotic (Bernoulli series). Above the LUT fit range the rational
+        // extrapolates poorly (issue #45520: "behaves bad for x>1000"); the asymptotic
+        // digamma(x) = ln(x) - 1/(2x) - 1/(12x^2) + 1/(120x^4) - ... is ~exact for large x
+        // (truncation error ~8e-11 at x=102), restoring the (1, inf) support the pre-LUT
+        // composite op provided. Crossover at the LUT's upper bound 102 is seamless.
+        // NOTE: uses the register-free (bf16-grade) log body, so large-x fp32 is only
+        // bf16-accurate. #45520 targets bf16 ULP; an fp32-accurate log here would collide
+        // with the reciprocal's vConstFloatPrgm0, so fp32 large-x is intentionally left as-is.
+        v_if(x > 102.0f) {
+            sfpi::vFloat inv_x = sfpu_reciprocal_iter<2>(x);
+            sfpi::vFloat inv_x2 = inv_x * inv_x;
+            // ln(x) - inv_x*0.5 - inv_x2*(1/12 - inv_x2/120). 1/12 and 1/120 are literals:
+            // the reciprocal owns vConstFloatPrgm0/1/2 for its Newton seed, so digamma has no
+            // free program-constant registers to hold them.
+            sfpi::vFloat bern = sfpi::vFloat(0.0833333333f) - inv_x2 * sfpi::vFloat(0.0083333333f);
+            result = _calculate_log_body_no_init_(x) - inv_x * sfpi::vFloat(0.5f) - inv_x2 * bern;
+            // digamma(+inf) = +inf; the log approximation clamps inf to a finite value, so
+            // restore it explicitly (exp field all-ones, zero mantissa => infinity).
+            v_if(sfpi::exexp(x) == 128 && sfpi::exman(x) == 0) { result = std::numeric_limits<float>::infinity(); }
+            v_endif;
+        }
+        v_endif;
+
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+void digamma_init() {
+    math::_reset_counters_<p_setrwc::SET_ABD_F>();
+    // sfpu_reciprocal_init programs vConstFloatPrgm0/1/2 with the reciprocal's Newton seed;
+    // all three stay reserved for it, so digamma must not repurpose Prgm1/Prgm2.
+    sfpu_reciprocal_init();
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: © 2025 Jason Davies <jason@jasondavies.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+
+namespace ckernel::sfpu {
+
+// 32-bit integer division.
+// Template parameter `floor` indicates whether "floor" (true) or "trunc"
+// (false) rounding mode should be used.
+template <bool floor>
+sfpi_inline void calculate_div_int32_body(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
+    sfpi::vInt b_orig = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+
+    // When converting to float, the integers are treated as sign-magnitude.
+    // Convert inputs to positive values to avoid conversion problems, as the
+    // original inputs are two's complement integers.  Note that
+    // sfpi::abs(-2**31) will return -2**31, which will give -0.0 when
+    // converted to float via sfpi::convert
+    sfpi::vMag b = sfpi::abs(b_orig);
+
+    // Convert to floats, but check for the edge case mentioned above.
+    sfpi::vFloat b_f = sfpi::convert<sfpi::vFloat>(b, sfpi::RoundMode::Nearest);
+    v_if(b_f < 0.0f) { b_f = 0x1.0p31f; }
+    v_endif;
+
+    // Compute 1/b accurate to ~22 bits of precision via Halley's Method.
+    // Since the inputs can be as large as 2**31-1, this only gives us an
+    // initial approximation.
+    // We interleave SFPMAD with the loading and conversion of `a`.
+    sfpi::vFloat inv_b_f = sfpi::approx_recip(b_f);
+    sfpi::vFloat e = -inv_b_f * b_f + 1.0f;
+    sfpi::vInt a_orig = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+    e = e * e + e;
+    sfpi::vMag a = sfpi::abs(a_orig);
+    inv_b_f = e * inv_b_f + inv_b_f;
+    sfpi::vFloat a_f = sfpi::convert<sfpi::vFloat>(a, sfpi::RoundMode::Nearest);
+    v_if(a_f < 0.0f) { a_f = 0x1.0p31f; }
+    v_endif;
+
+    // Initial approximation q = a * 1/b.
+    // We add a special mantissa alignment factor 2.0f**(23+10), which shifts
+    // the mantissa so that we extract the top 22 bits of the result.
+    sfpi::vFloat q_f = a_f * inv_b_f + sfpi::vConstFloatPrgm0;
+    sfpi::vInt sign = a_orig ^ b_orig;
+    sfpi::vMag q_m = sfpi::exman(q_f);
+
+    // Compute qb = q * b.  This tells us how close our approximation `q` is to
+    // the target `a`.  We split into 23-bit chunks.
+    // Since inv_b is only accurate to ~22 bits, we only care about the upper
+    // 22 bits, so we can compute qb = (q1<<10 + 0) * (b1<<22 + b0)
+    //                               = (q1<<10) * b0
+
+    sfpi::vInt qb{sfpi::fractional_mul(q_m, b) << 10};
+    sfpi::vInt q{q_m << 10};
+
+    // Compute remainder.
+    sfpi::vInt r = a - qb;
+    sfpi::vFloat r_f = sfpi::convert<sfpi::vFloat>(sfpi::abs(r), sfpi::RoundMode::Nearest);
+
+    // Compute correction value in float32.
+    sfpi::vFloat correction_f = r_f * inv_b_f;
+    sfpi::vMag correction = sfpi::convert<sfpi::vUInt16>(correction_f, sfpi::RoundMode::Nearest);
+
+    // Compute tmp = correction * b.
+    sfpi::vInt b1 = sfpi::fractional_mul(correction, b >> 23);
+    sfpi::vInt tmp_hi = sfpi::fractional_mul(correction, b, sfpi::FractionalHalf::High);
+    sfpi::vInt tmp_lo = sfpi::fractional_mul(correction, b);
+    tmp_hi += b1;
+    tmp_hi <<= 23;
+    sfpi::vInt tmp = tmp_lo + tmp_hi;
+
+    // Apply correction and adjust remainder.
+    v_if(r < 0) {
+        q -= correction;
+        r += tmp;
+    }
+    v_else {
+        q += correction;
+        r -= tmp;
+    }
+    v_endif;
+
+    // Since the correction might have been rounded, we may need to correct one
+    // additional bit.  The (r - 1) < 0 check is required to handle r=INT_MIN.
+    v_if(r < 0 && (r - 1) < 0) {
+        q -= 1;
+        r += b;
+    }
+    v_elseif(r >= b) {
+        q += 1;
+        r -= b;
+    }
+    v_endif;
+
+    sfpi::vInt result = q;
+
+    // If a ^ b >= 0, then the result will be positive, otherwise negative.
+    // Finally, if we expect a negative result, negate the value (two's complement).
+    v_if(sign < 0) {
+        result = -result;
+
+        // Optionally, if we want "floor" rounding, check for a remainder
+        // and subtract one for negative numbers, to round towards negative
+        // infinity.
+
+        if constexpr (floor) {
+            v_if(r != 0) { result -= 1; }
+            v_endif;
+        }
+    }
+    v_endif;
+
+    sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_div_int32_floor(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        calculate_div_int32_body<true>(dst_index_in0, dst_index_in1, dst_index_out);
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_div_int32_trunc(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        calculate_div_int32_body<false>(dst_index_in0, dst_index_in1, dst_index_out);
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+inline void div_trunc_init() {
+    sfpi::vConstFloatPrgm0 = 8589934592.0f;
+}
+
+template <bool APPROXIMATION_MODE>
+inline void div_floor_init() {
+    div_trunc_init<APPROXIMATION_MODE>();
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_elu.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "cmath_common.h"
+#include "ckernel_sfpu_converter.h"
+#include "sfpu/ckernel_sfpu_expm1_cw.h"
+
+namespace ckernel::sfpu {
+
+inline void elu_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+inline void calculate_elu(std::uint32_t slope) {
+    sfpi::vFloat alpha = Converter::as_float(slope);
+// unroll 2: with expm1_cw_clamped inlined the loop body is large enough that
+// partial unroll outperforms both full (unroll 8) and no-unroll (~0.8us on WH)
+#pragma GCC unroll 2
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat result = alpha * expm1_cw_clamped(x);
+
+        v_if(x >= 0.0f) { result = x; }
+        v_endif;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
+        }
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_erfc.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_erfc.h
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "cmath_common.h"
+#include "ckernel_sfpu_converter.h"
+
+#include "ckernel_sfpu_piecewise_rational.h"
+
+namespace ckernel::sfpu {
+
+// ======================================================================
+// LUT-based erfc via piecewise rational P(x)/Q(x)
+//
+// Uses abs(x) symmetry: erfc(-x) = 2 - erfc(x)
+// Fit on [0, 5.0] only, 2 segments with n4/d5 rational per segment.
+// BF16 MaxULP=118 (was 128 with 3-seg n4/d4 on [-5,5])
+// FP32 MaxULP≈9M  (was 1.47B)
+// 18 FMAs          (was 24)
+// ======================================================================
+
+constexpr std::uint32_t ERFC_NUM_DEGREE = 4;
+constexpr std::uint32_t ERFC_DEN_DEGREE = 5;
+constexpr std::uint32_t ERFC_NUM_SEGMENTS = 2;
+constexpr std::uint32_t ERFC_LUT_SIZE = 25;
+constexpr std::array<float, ERFC_LUT_SIZE> ERFC_LUT = {{// Breakpoints
+                                                        0.0000000000e+00f,
+                                                        2.5000000000e+00f,
+                                                        5.0000000000e+00f,
+                                                        // Segment 0 [0, 2.5]: numerator (degree 4)
+                                                        1.0000233650e+00f,
+                                                        -1.3375675678e+00f,
+                                                        6.8185544014e-01f,
+                                                        -1.5691982210e-01f,
+                                                        1.3746744953e-02f,
+                                                        // Segment 0 [0, 2.5]: denominator (degree 5)
+                                                        1.0000000000e+00f,
+                                                        -2.0801517367e-01f,
+                                                        4.3667086959e-01f,
+                                                        -3.4568668343e-03f,
+                                                        2.5104774162e-02f,
+                                                        2.8375532478e-02f,
+                                                        // Segment 1 [2.5, 5.0]: numerator (degree 4)
+                                                        -2.5655237550e-05f,
+                                                        2.1275576728e-05f,
+                                                        -6.6162156145e-06f,
+                                                        9.1439767402e-07f,
+                                                        -4.7387182178e-08f,
+                                                        // Segment 1 [2.5, 5.0]: denominator (degree 5)
+                                                        1.0000000000e+00f,
+                                                        -1.6457208991e-01f,
+                                                        -2.0572184026e-01f,
+                                                        -1.3888636231e-01f,
+                                                        1.2677097321e-01f,
+                                                        -2.1375391632e-02f}};
+
+template <int ITERATIONS = 8>
+inline void calculate_erfc() {
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        // Clamp |x| to 5.0 before evaluation (avoids extrapolation, saves one branch)
+        sfpi::vFloat ax = sfpi::min(sfpi::abs(x), 5.0f);
+        sfpi::vFloat r =
+            piecewise_rational_eval<ERFC_NUM_DEGREE, ERFC_DEN_DEGREE, ERFC_NUM_SEGMENTS, ERFC_LUT_SIZE, false, true>(
+                ERFC_LUT, ax);
+        // erfc(-x) = 2 - erfc(x)
+        v_if(x < 0.0f) { r = 2.0f - r; }
+        v_endif;
+        sfpi::dst_reg[0] = r;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+void erfc_init() {
+    math::_reset_counters_<p_setrwc::SET_ABD_F>();
+    sfpu_reciprocal_init<true>();
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_erfinv.h
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "cmath_common.h"
+#include "ckernel_sfpu_log.h"
+#include "ckernel_sfpu_sqrt_custom.h"
+
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE>
+sfpi_inline sfpi::vFloat calculate_erfinv_body(sfpi::vFloat x) {
+    // Algorithm based on "A handy approximation for the error function and its inverse" by Sergei Winitzki (2008)
+    // This approximation defines erfinv(x) as:
+    // erfinv(x) = sqrt( - 2/(pi*a) - log(1 - x^2)/2 + sqrt( ( 2/(pi*a) + log(1 - x^2)) ^2 - 1/a log(1 - x^2)) )
+    // Where a is a polynomial coefficient used in the approximation of the error function (and reused in inverse error
+    // function)
+
+    // Compute log(1 - x^2)
+    sfpi::vFloat log_value = calculate_log_body<false, false, false>(1.0f - x * x, 0);
+
+    // Paper sets a constant a = 0.147.
+    // This constant is used to compute two constant expressions:
+    constexpr float TwoPiA = -4.330746750799873f;  // -2 / (pi * a)
+    constexpr float OneDivA = 6.802721088435375f;  // 1/a
+
+    // tmp = -2 / (pi * a) - log(1 - x^2)/2
+    sfpi::vFloat tmp = TwoPiA + -0.5f * log_value;
+
+    // calculated_value = temp + sqrt( temp^2 - log_value / a)
+    sfpi::vFloat calculated_value = tmp * tmp - log_value * OneDivA;
+    sfpi::vFloat intermediate_result = sfpu_sqrt_custom<false>(calculated_value);
+    calculated_value = tmp + intermediate_result;
+
+    // result = sqrt(calculated_value)
+    sfpi::vFloat result = sfpu_sqrt_custom<false>(calculated_value);
+
+    return result;
+}
+
+template <bool APPROXIMATION_MODE>
+inline void calculate_erfinv() {
+    constexpr int ITERATIONS = 8;
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat in = sfpi::dst_reg[0];
+        sfpi::vFloat result = calculate_erfinv_body<false>(in);
+        in = sfpi::dst_reg[0];  // reload due to register pressure
+        sfpi::dst_reg[0] = sfpi::copysgn(result, in);
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+void erfinv_init() {
+    math::_reset_counters_<p_setrwc::SET_ABD_F>();
+    log_init<false, false, false>();
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -5,8 +5,10 @@
 
 #pragma once
 
+#include <cstdint>
 #include "ckernel.h"
 #include "ckernel_ops.h"
+#include "ckernel_sfpu_polyval.h"
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
 #include "llk_assert.h"
@@ -42,6 +44,29 @@ sfpi_inline sfpi::vInt _float_to_int32_for_exp_21f_(sfpi::vFloat val) {
         sfpi::exman(val, sfpi::MantissaMode::ImplicitOne);  // get mantissa with implicit bit (man in [1; 2])
     man = sfpi::shft(man, exp, sfpi::ShiftMode::Logical);
     return man;
+}
+
+// Unsafe core used by Blackhole SFPI kernels whose callers have already
+// bounded the input to the representable exp range.
+template <bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat _sfpu_exp_21f_bf16_unsafe_(sfpi::vFloat val) {
+    constexpr float ONE_LN2 = 1.4426950216293334961f;
+    sfpi::vFloat xlog2 = (val * ONE_LN2 + 127.f);
+
+    sfpi::vFloat z = sfpi::as<sfpi::vFloat>(_float_to_int32_for_exp_21f_(xlog2));
+
+    sfpi::vInt exponential_part = sfpi::exexp(z, sfpi::ExponentMode::Biased);
+    sfpi::vMag fractional_part = sfpi::exman(z);
+    sfpi::vFloat frac = sfpi::convert<sfpi::vFloat>(fractional_part, sfpi::RoundMode::Nearest);
+
+    frac = PolynomialEvaluator::eval(frac, 1.0017248f, 7.839635491371155e-08f, 4.791750143340323e-15f);
+    sfpi::vFloat y = sfpi::setexp(frac, exponential_part);
+
+    if constexpr (!is_fp32_dest_acc_en) {
+        y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::Nearest);
+    }
+
+    return y;
 }
 
 /*
@@ -108,6 +133,8 @@ sfpi_inline sfpi::vFloat _sfpu_exp_fp32_accurate_(sfpi::vFloat a) {
     return r * two_i;
 }
 
+sfpi_inline sfpi::vFloat _sfpu_exp_fp32_accurate_unsafe_(sfpi::vFloat x) { return _sfpu_exp_fp32_accurate_(x); }
+
 // Calculates EXP over a full tile. Quasar exposes exactly two implementations:
 //   - approximate exp via the HW nonlinear lookup table (sfpi::approx_exp), and
 //   - full-precision fp32 exp (_sfpu_exp_fp32_accurate_, ported from Blackhole).
@@ -144,7 +171,7 @@ void calculate_exponential([[maybe_unused]] const std::uint32_t exp_base_scale_f
 
 template <
     [[maybe_unused]] bool APPROXIMATION_MODE,
-    [[maybe_unused]] uint32_t scale = 0x3F800000,
+    [[maybe_unused]] std::uint32_t scale = 0x3F800000,
     [[maybe_unused]] bool CLAMP_NEGATIVE = true,
     [[maybe_unused]] bool EN_32BIT_DEST>
 void exp_init() {

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_exp2.h
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Jason Davies <jason@jasondavies.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+#include "ckernel_sfpu_exp.h"
+#include "cmath_common.h"
+#include "sfpi.h"
+
+namespace ckernel::sfpu {
+
+sfpi_inline sfpi::vFloat _sfpu_exp2_fp32_accurate_(sfpi::vFloat x) {
+    sfpi::vFloat f, j, r, y, abs_x;
+    sfpi::vInt i;
+    sfpi::vSMag16 sm;
+
+    // Convert x to sign-magnitude 16-bit integer (round to nearest with ties
+    // away from zero), and convert back to floating point.
+    sm = sfpi::convert<sfpi::vSMag16>(x, sfpi::RoundMode::Nearest);
+    j = sfpi::convert<sfpi::vFloat>(sm, sfpi::RoundMode::Nearest);
+
+    // Range reduced value in [-0.5, 0.5].
+    f = x - j;
+
+    // Minimax polynomial approximation for exp2(f), f in [-0.5, 0.5].
+    // The first three coefficients are rounded to fp16 (one sfploadi per coefficient).
+    // The subsequent three coefficients are fp32 values stored in constant registers.
+    // Interleaved with conversion of sign-magnitude integer in [-32767, 32767] to two's complement.
+    // Interleaved with calculation of the overflow case y = y * inf, giving inf or NaN.
+    // Interleaved with calculation of abs_x = abs(x), which is >= 0.0 unless x is -NaN.
+    r = 0x1.41cp-13f;
+    r = r * f + 0x1.5f4p-10f;
+    r = r * f + 0x1.3b4p-7f;
+    i = sfpi::abs(sfpi::as<sfpi::vInt>(sm));
+    y = r * f + sfpi::vConstFloatPrgm2;
+    i = sfpi::as<sfpi::vInt>(sfpi::copysgn(sfpi::as<sfpi::vFloat>(i), j));
+    r = y * f + sfpi::vConstFloatPrgm1;
+    y *= std::numeric_limits<float>::infinity();
+    r = r * f + sfpi::vConstFloatPrgm0;
+    abs_x = sfpi::abs(x);
+    r = r * f + 1.0f;
+
+    // Exclude -NaN: abs(-NaN) remains negative.
+    v_if(abs_x >= 0.0f) {
+        sfpi::vInt e = sfpi::exexp(r, sfpi::ExponentMode::Biased);
+        e += i;
+        // e < 255
+        v_block {
+            sfpi::vInt e_lt_255 = __builtin_rvtt_sfpiadd_i(e.get(), -255, sfpi::SFPIADD_MOD1_CC_LT0);
+            y = sfpi::setexp(r, e);
+            // e < 1
+            v_if(e_lt_255 < -254) {
+                // Underflow, including subnormals.
+                y = 0.0f;
+            }
+            v_endif;
+        }
+        v_endblock;
+    }
+    v_endif;
+
+    return y;
+}
+
+// BF16 path: branch-free saturation using the mantissa-as-fractional-part trick
+// from the production `_sfpu_exp_21f_bf16_` kernel — but specialised for exp2 by
+// skipping the `* (1/ln2)` multiply (we are already in base-2). vec_min_max clamps
+// xlog2 to [0, 255], so the natural saturation of setexp + the final bf16 round
+// give the correct overflow → +inf and underflow → 0 boundary encodings for free.
+//
+// NaN: ttnn.bfloat16 host-side packing already collapses NaN → +inf before the
+// tensor ever reaches the SFPU (see the "NaN is packed as inf for ttnn.bfloat16"
+// xfails on fmod / remainder / where / rdiv), so a device-side NaN guard here
+// would be dead code.
+sfpi_inline sfpi::vFloat _sfpu_exp2_bf16_(sfpi::vFloat x) {
+    // Map x → xlog2 such that 2^x has biased exponent floor(xlog2) and the
+    // fractional mantissa supplies the (xlog2 - floor) refinement.
+    sfpi::vFloat xlog2 = x + 127.f;
+
+    // Clamp to [0, 255]. Boundary inputs land on the +inf / +0 encodings after
+    // setexp + bf16 round.
+    xlog2 = sfpi::clamp(xlog2, 0.0f, 255.0f);
+
+    // Decompose xlog2 in [0, 255] into:
+    //   exponential_part = floor(xlog2)             (integer in [0, 255])
+    //   fractional_part  = (xlog2 - floor) * 2^23   (integer in [0, 2^23))
+    sfpi::vInt z = _float_to_int32_for_exp_21f_(xlog2);
+
+    sfpi::vInt exponential_part = sfpi::exexp(sfpi::as<sfpi::vFloat>(z), sfpi::ExponentMode::Biased);
+    sfpi::vMag fractional_part = sfpi::exman(sfpi::as<sfpi::vFloat>(z));
+
+    sfpi::vFloat frac = sfpi::convert<sfpi::vFloat>(fractional_part, sfpi::RoundMode::Nearest);
+
+    // Refine 2^x_f on x_f to [0, 2^23). Same minimax coefficients as the
+    // production exp_21f kernel (≤ 3 fp32 ULP, well under 1 bf16 ULP).
+    frac = PolynomialEvaluator::eval(frac, 1.0017248f, 7.839635491371155e-08f, 4.791750143340323e-15f);
+
+    // Recombine: 2^x = (1.frac_mantissa) * 2^(exponential_part - 127).
+    sfpi::vFloat y = sfpi::setexp(frac, exponential_part);
+
+    // SFPSTORE truncates fp32→bf16; round explicitly so the bf16 result matches
+    // a faithful nearest-even rounding of the fp32 mathematical value, and so
+    // that the saturation tricks above (overflow → +inf, underflow → 0) land
+    // on the correct bf16 encoding.
+    return sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::Nearest);
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+inline void calculate_exp2() {
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+
+        if constexpr (is_fp32_dest_acc_en) {
+            sfpi::dst_reg[0] = _sfpu_exp2_fp32_accurate_(v);
+        } else {
+            sfpi::dst_reg[0] = _sfpu_exp2_bf16_(v);
+        }
+
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false>
+inline void exp2_init() {
+    math::_reset_counters_<p_setrwc::SET_ABD_F>();
+    if constexpr (is_fp32_dest_acc_en) {
+        // Coefficients for minimax polynomial.
+        sfpi::vConstFloatPrgm0 = 0x1.62e42ep-1f;
+        sfpi::vConstFloatPrgm1 = 0x1.ebfba0p-3f;
+        sfpi::vConstFloatPrgm2 = 0x1.c6afd8p-5f;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_fmod.h
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_recip.h"
+#include "cmath_common.h"
+#include "ckernel_sfpu_converter.h"
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE>
+inline void init_fmod(const std::uint32_t value, const std::uint32_t recip) {
+    math::_reset_counters_<p_setrwc::SET_ABD_F>();
+    sfpi::vConstFloatPrgm0 = Converter::as_float(value);
+    sfpi::vConstFloatPrgm1 = Converter::as_float(recip);
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_fmod() {
+    // SFPU microcode
+    sfpi::vFloat s = sfpi::abs(sfpi::vConstFloatPrgm0);
+    sfpi::vFloat recip_val = sfpi::abs(sfpi::vConstFloatPrgm1);
+
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat val = sfpi::dst_reg[0];
+        sfpi::vFloat v = sfpi::abs(val);
+
+        sfpi::vFloat quotient;
+        sfpi::vInt exp = sfpi::exexp(v * recip_val);
+        v_if(exp < 0) { quotient = 0.0f; }
+        // Since fp32 has 23 mantissa bits, the LSB represents the fractional part when exp < 23.
+        // We effectively round off the fractional bits to zero by right shifting using (exp - 23) and then left
+        // shifting it back using (0 - (exp - 23)).
+        v_elseif(exp < 23) {
+            quotient = sfpi::as<sfpi::vFloat>(
+                shft((shft(sfpi::as<sfpi::vUInt>(v * recip_val), (exp - 23))), (0 - (exp - 23))));
+        }
+        v_else { quotient = v * recip_val; }
+        v_endif
+
+        v_if(quotient > v * recip_val) {
+            quotient = quotient - 1;
+        }
+        v_endif;
+        v = v - quotient * s;
+
+        v = sfpi::copysgn(v, val);
+
+        v_if(s == 0) { v = std::numeric_limits<float>::quiet_NaN(); }
+        v_endif;
+
+        constexpr auto iter = 10;
+        for (int l = 0; l < iter; l++) {
+            v_if(v >= s) { v = v - s; }
+            v_endif;
+        }
+        v_if(sfpi::abs(v) - s == 0.0f) { v = 0.0f; }
+        v_endif;
+        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_hardmish.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_hardmish.h
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "cmath_common.h"
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+// hardmish(x) = x * clamp(x + 2, 0, 2) / 2
+//             = x * clamp(0.5 * x + 1.0, 0.0, 1.0)
+//
+// For finite x, the piecewise form is:
+//   x <= -2  =>  0         (scale clamped to 0)
+//   x >= 0   =>  x         (scale clamped to 1)
+//   else     =>  x*(x+2)/2 (quadratic)
+//
+// Non-finite inputs follow IEEE 754 operations above.
+// In particular, x = -inf clamps scale to 0, and (-inf) * 0 yields NaN.
+//
+// Constants 0.5 and 1.0 are exactly representable in IEEE 754.
+// Clamping to [0, 1] gives exact boundary values (0 or 1),
+// so the final multiply produces exact 0 or exact x at transitions.
+inline void hardmish_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void hardmish() {
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat scale = x * 0.5f + 1.0f;
+
+        scale = sfpi::clamp(scale, 0.0f, 1.0f);
+
+        sfpi::dst_reg[0] = x * scale;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_hardshrink.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_hardshrink.h
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "cmath_common.h"
+#include "sfpi.h"
+#include "ckernel_sfpu_converter.h"
+
+namespace ckernel::sfpu {
+
+inline void hardshrink_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_hardshrink(std::uint32_t param0) {
+    // Hardshrink(x, λ) = x if |x| > λ, else 0
+    // Single comparison using abs: setsgn(v, 0) clears sign bit
+    // param0 contains lambda as FP32 bits. For BF16 inputs, the host pre-rounds
+    // lambda to BF16 precision (then re-expands to FP32) so that FP32→FP19b
+    // truncation on SFPU preserves the BF16 value exactly. For FP32 inputs,
+    // lambda is passed as full FP32, so both input and lambda undergo the same
+    // FP32→FP19b truncation, keeping comparisons consistent.
+    sfpi::vFloat lambda = Converter::as_float(param0);
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::vFloat abs_v = sfpi::setsgn(v, 0);
+        v_if(abs_v <= lambda) { sfpi::dst_reg[0] = 0.0f; }
+        v_endif;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "cmath_common.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+#define POLYVAL10(coef10, coef9, coef8, coef7, coef6, coef5, coef4, coef3, coef2, coef1, coef0, t4)               \
+    ((coef0 +                                                                                                     \
+      (coef1 +                                                                                                    \
+       (coef2 +                                                                                                   \
+        (coef3 +                                                                                                  \
+         (coef4 + (coef5 + (coef6 + (coef7 + (coef8 + (coef9 + coef10 * t4) * t4) * t4) * t4) * t4) * t4) * t4) * \
+            t4) *                                                                                                 \
+           t4) *                                                                                                  \
+          t4) *                                                                                                   \
+     t4)
+inline void i0_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_i0() {
+#pragma GCC unroll 0
+
+    for (int d = 0; d < ITERATIONS; d++) {
+        vFloat result = 0.0f;
+        vFloat input = dst_reg[0];
+        vFloat x = input * input;
+
+        result = 1.0f + POLYVAL10(
+                            1.50E-22f,
+                            7.24E-20f,
+                            2.90E-17f,
+                            9.39E-15f,
+                            2.40E-12f,
+                            4.71E-10f,
+                            6.78E-08f,
+                            0.000006781684028f,
+                            0.0004340277778f,
+                            0.015625f,
+                            0.25f,
+                            x);
+
+        dst_reg[0] = result;
+        dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_identity.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_identity.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <limits>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_recip.h"
+#include "sfpi.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_identity() {
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        vFloat v = dst_reg[0];
+        dst_reg[0] = v;
+        dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_identity_uint() {
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        vUInt v = dst_reg[0];
+        dst_reg[0] = v;
+        dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_int_sum.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_int_sum.h
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "cmath_common.h"
+
+#include "sfpi.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE>
+inline void calculate_sum_int_col() {
+    for (size_t i = 0; i < 2; ++i) {
+        vInt a = dst_reg[i];
+
+        for (size_t j = 2; j < 8; j += 2) {
+            vInt b = dst_reg[i + j];
+            a += b;
+        }
+
+        for (size_t j = 16; j < 24; j += 2) {
+            vInt b = dst_reg[i + j];
+            a += b;
+        }
+
+        dst_reg[i] = a;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+inline void calculate_sum_int_row() {
+    for (size_t i = 0; i < 8; i += 2) {
+        vInt a = dst_reg[i];
+
+        int arr[] = {1, 8, 9};
+        for (size_t j = 0; j < sizeof(arr) / sizeof(arr[0]); ++j) {
+            vInt b = dst_reg[i + arr[j]];
+            a += b;
+        }
+
+        dst_reg[i] = a;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+inline void sum_int_init() {
+    math::_reset_counters_<p_setrwc::SET_ABD_F>();
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void add_int(const std::uint32_t dst_offset) {
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        vInt a = dst_reg[0];
+        vInt b = dst_reg[32];
+
+        vInt r = a + b;
+
+        dst_reg[0] = r;
+        dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_isclose.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_isclose.h
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "ckernel_sfpu_binary_comp.h"
+#include "ckernel_sfpu_converter.h"
+#include "sfpi.h"
+
+namespace ckernel::sfpu {
+
+// Compute isclose element-wise: result = |a - b| <= atol + rtol * |b|
+//
+// rtol_bits and atol_bits are the IEEE-754 bit-patterns of the tolerance
+// scalars, passed as runtime uint32 arguments from the compute kernel and
+// converted to float via Converter::as_float().
+//
+// EQUAL_NAN controls NaN semantics, matching torch.isclose:
+//   false (default): any NaN input => result = 0
+//   true:            both NaN      => result = 1; one NaN => result = 0
+//
+// Inputs are expected to be float32 or bfloat16. INT32 tensors must be
+// promoted to FLOAT32 before reaching this kernel; invoke_binary_ng_isclose
+// handles this via explicit ttnn::typecast calls before dispatch.
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool EQUAL_NAN>
+inline void calculate_sfpu_isclose(
+    const std::uint32_t dst_index_in0,
+    const std::uint32_t dst_index_in1,
+    const std::uint32_t dst_index_out,
+    std::uint32_t rtol_bits,
+    std::uint32_t atol_bits) {
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    // IEEE-754 abs(+inf). abs_bits == inf_bits -> +-Inf; abs_bits > inf_bits -> NaN
+    // (NaN has exp == 0xFF and a non-zero mantissa, irrespective of sign or
+    // quiet/signaling bit). One comparison classifies both special cases.
+    constexpr std::int32_t inf_bits = 0x7F800000;
+
+    const sfpi::vFloat atol = Converter::as_float(atol_bits);
+    const sfpi::vFloat rtol = Converter::as_float(rtol_bits);
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+
+        // Integer views of a, b and their abs bit patterns. Two constraints: the abs
+        // bits must stay vInt (a vFloat against inf_bits binds to the float overload,
+        // converting it to 2139095040.0f), and the mask cannot be replaced by
+        // bit-casting sfpi::abs() because SFPABS float mode leaves -NaN sign-set.
+        // vConstIntPrgm0 holds 0x7FFFFFFF, programmed in isclose_init.
+        sfpi::vInt a_bits = sfpi::as<sfpi::vInt>(a);
+        sfpi::vInt b_bits = sfpi::as<sfpi::vInt>(b);
+        sfpi::vInt a_abs_bits = a_bits & sfpi::vConstIntPrgm0;
+        sfpi::vInt b_abs_bits = b_bits & sfpi::vConstIntPrgm0;
+        sfpi::vFloat b_abs = sfpi::abs(b);
+
+        // abs(a - b) via sign-bit clear.
+        sfpi::vFloat abs_diff = sfpi::abs(a - b);
+
+        // tolerance = atol + rtol * |b|
+        sfpi::vFloat tol = atol + rtol * b_abs;
+
+        // |a - b| <= atol + rtol * |b|.
+        //
+        // For finite inputs this is the final answer. For +-Inf inputs the
+        // tolerance formula yields inf<=inf=true even for mismatched signs,
+        // and for NaN inputs the hardware comparison can be unreliable; both
+        // are corrected in the single fix-up branch below.
+        sfpi::vFloat result = 0.0f;
+        v_if(abs_diff <= tol) { result = 1.0f; }
+        v_endif;
+
+        // Single fix-up branch covering every "special" lane (Inf or NaN).
+        // Detected by `abs_bits >= inf_bits` which holds iff exp == 0xFF.
+        // Inside, we discard the tolerance result and rebuild from scratch:
+        //   * matching-sign Inf  -> 1     (a_abs_bits == inf AND a_bits == b_bits)
+        //   * both NaN, EQUAL_NAN -> 1    (a_abs_bits >  inf AND b_abs_bits >  inf)
+        //   * everything else (mismatched Inf, one-sided NaN, EQUAL_NAN=false
+        //     NaN) stays at 0.
+        // Folding both old fix-ups into one v_if removes two predicate-stack
+        // push/pop pairs from the hot loop.
+        v_if(a_abs_bits >= inf_bits || b_abs_bits >= inf_bits) {
+            result = 0.0f;
+            v_if(a_abs_bits == inf_bits && a_bits == b_bits) { result = 1.0f; }
+            v_endif;
+            if constexpr (EQUAL_NAN) {
+                v_if(a_abs_bits > inf_bits && b_abs_bits > inf_bits) { result = 1.0f; }
+                v_endif;
+            }
+        }
+        v_endif;
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+// Programs the sign-clear mask into a constant register so the hot loop does not
+// rebuild it with a per-element SFPLOADI inside the replay block.
+inline void isclose_init() { sfpi::vConstIntPrgm0 = 0x7FFFFFFF; }
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_lerp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_lerp.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "llk_defs.h"
+#include "sfpi.h"
+#include "ckernel_sfpu_binary.h"
+
+namespace ckernel::sfpu {
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS>
+inline void calculate_lerp(
+    const std::uint32_t dst_index_in0,  // input (start)
+    const std::uint32_t dst_index_in1,  // end
+    const std::uint32_t dst_index_in2,  // weight
+    const std::uint32_t dst_index_out) {
+    static_assert(
+        data_format == DataFormat::Float32 || data_format == DataFormat::Float16_b,
+        "Unsupported data format for calculate_lerp(). Supported data formats are: Float32, Float16_b.");
+
+    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    // lerp: out = input + weight * (end - input)
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        sfpi::vFloat in2 = sfpi::dst_reg[dst_index_in2 * dst_tile_size_sfpi];
+        sfpi::vFloat result = in0 + in2 * (in1 - in0);
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = float32_to_bf16_rne(result);
+        }
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_lgamma.h
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_log.h"
+#include "cmath_common.h"
+
+#include "sfpi.h"
+#include "ckernel_sfpu_log.h"
+#include "ckernel_sfpu_polyval.h"
+#include "ckernel_sfpu_recip.h"
+
+namespace ckernel::sfpu {
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+inline void calculate_lgamma_stirling() {
+    constexpr float LOG_SQRT_2PI = 0.9189385332046727f;
+
+    // Minimal coefficients for 0-3 ULP
+    constexpr float r0 = 0.0833333333f;   // 1/12
+    constexpr float r1 = -0.0027777777f;  // -1/360
+
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat in = sfpi::dst_reg[0];
+        sfpi::vFloat z = in;
+
+        // 1. Reflection for x < 0.5
+        v_if(in < 0.5f) { z = 1.0f - in; }
+        v_endif;
+
+        // 2. Stirling base: (z - 0.5) * log(z) - z + log(sqrt(2*pi))
+        sfpi::vFloat res = ((z - 0.5f) * _calculate_log_body_no_init_(z) - z + LOG_SQRT_2PI);
+
+        // 3. Bernoulli correction: (1/z)(r0 + r1/z^2).
+        sfpi::vFloat inv_z = sfpu_reciprocal_iter<2>(z);
+        sfpi::vFloat correction = inv_z * (r0 + (inv_z * inv_z) * r1);
+        res = res + correction;
+
+        // TODO: use a polynomial bridge here instead
+        v_if(in == 1.0f || in == 2.0f) { res = 0.0f; }
+        v_endif;
+
+        // reflection adjustment for inputs < 0.5 are done in calculate_lgamma_adjusted.
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            res = sfpi::convert<sfpi::vFloat16b>(res, sfpi::RoundMode::Nearest);
+        }
+
+        sfpi::dst_reg[0] = res;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+inline void calculate_lgamma_adjusted(
+    const std::uint32_t dst_index_in0,  // lgamma_stirling result
+    const std::uint32_t dst_index_in1,  // log|sin(pi * frac(x))| with integer adjustments
+    const std::uint32_t dst_index_in2,  // input x
+    const std::uint32_t dst_index_out) {
+    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    constexpr float ln_pi = 1.1447298858f;
+
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat res_stirling = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat log_sin_pi_x = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        sfpi::vFloat in = sfpi::dst_reg[dst_index_in2 * dst_tile_size_sfpi];
+
+        // ln(pi) - log|sin(pi * frac(x))|
+        sfpi::vFloat reflection_adj = ln_pi - log_sin_pi_x;
+
+        sfpi::vFloat result = res_stirling;
+
+        // For x < 0.5: lgamma(x) = reflection_adj - lgamma(1-x); otherwise use res_stirling.
+        v_if(in < 0.5f) { result = reflection_adj - res_stirling; }
+        v_endif;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
+        } else {
+            sfpi::vInt exp = sfpi::exexp(in);
+            sfpi::vInt man = sfpi::exman(in);
+            v_if(exp == 128 && man == 0) { result = std::numeric_limits<float>::infinity(); }
+            v_endif;
+        }
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+inline void calculate_lgamma_stirling_fp32(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+    constexpr float LOG_SQRT_2PI = 0.9189385332046727f;
+    constexpr float LOG_SQRT_PI = 0.57236494f;  // lgamma(0.5) = ln(sqrt(pi))
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
+    // Minimal coefficients for 0-3 ULP
+    constexpr float r0 = 0.0833333333f;   // 1/12
+    constexpr float r1 = -0.0027777777f;  // -1/360
+    constexpr float r2 = 0.0007936507f;   // 1/1260
+    constexpr float r3 = -0.0005952380f;  // -1/1680
+
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat in = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat log_z = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+        sfpi::vFloat z = in;
+
+        // 1. Reflection for x < 0.5
+        v_if(in < 0.5f) { z = 1.0f - in; }
+        v_endif;
+
+        sfpi::vFloat d1 = z - 1.0f;
+        sfpi::vFloat d2 = z - 2.0f;
+        sfpi::vFloat abs_range1 = sfpi::abs(d1);
+        sfpi::vFloat abs_range2 = sfpi::abs(d2);
+
+        sfpi::vFloat res = z;
+
+        // Polynomial bridge for small range inputs (z near 1 or 2 only)
+
+        v_if(abs_range1 < 0.25f) {
+            // Taylor Expansion around z=1 (d = z - 1.0)
+            constexpr float p0 = -0.57721566f;  // -gamma
+            constexpr float p1 = 0.82246703f;   // zeta(2)/2
+            constexpr float p2 = -0.40068563f;  // -zeta(3)/3
+            constexpr float p3 = 0.27058081f;   // zeta(4)/4
+            constexpr float p4 = -0.20738555f;  // -zeta(5)/5
+            // res = d * (p0 + d * (p1 + d * (p2 + d * (p3 + d * p4))));
+            res = d1 * PolynomialEvaluator::eval(d1, p0, p1, p2, p3, p4);
+        }
+        v_elseif(abs_range2 < 0.25f) {
+            // Taylor Expansion around z=2 (d = z - 2.0)
+            constexpr float q0 = 0.42278434f;   // 1 - gamma
+            constexpr float q1 = 0.32246703f;   // (zeta(2)-1)/2
+            constexpr float q2 = -0.06735230f;  // -(zeta(3)-1)/3
+            constexpr float q3 = 0.02058081f;   // (zeta(4)-1)/4
+            constexpr float q4 = -0.00738555f;  // -(zeta(5)-1)/5
+            res = d2 * PolynomialEvaluator::eval(d2, q0, q1, q2, q3, q4);
+        }
+        v_else {
+            // Stirling base + Bernoulli correction
+            res = ((z - 0.5f) * log_z - z + LOG_SQRT_2PI);
+            sfpi::vFloat inv_z = sfpu_reciprocal_iter<2>(z);
+            sfpi::vFloat inv_z2 = (inv_z * inv_z);
+            // Bernoulli correction: r0 + inv_z2 * (inv_z2 * (r2 + inv_z2 * r3) + r1);
+            sfpi::vFloat correction = PolynomialEvaluator::eval(inv_z2, r0, r1, r2, r3);
+            res = res + inv_z * correction;
+        }
+        v_endif;
+
+        // Handle boundary case
+        v_if(sfpi::abs(z - 0.5f) < 0.01f) { res = LOG_SQRT_PI; }
+        v_endif;
+
+        // reflection adjustment for inputs < 0.5 are done in calculate_lgamma_adjusted.
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = res;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+void lgamma_stirling_init() {
+    math::_reset_counters_<p_setrwc::SET_ABD_F>();
+    // init for sfpu_reciprocal_iter<2> for Blackhole
+    sfpi::vConstFloatPrgm0 = 2.0f;
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_log.h
@@ -6,6 +6,9 @@
 
 #include <cstdint>
 
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "cmath_common.h"
 #include "sfpi.h"
 
 namespace ckernel {
@@ -84,6 +87,34 @@ sfpi_inline sfpi::vFloat _calculate_log_body_no_init_(sfpi::vFloat base) {
     v_endif;
 
     return log_result;
+}
+
+// Blackhole-compatible SFPI helper surface. Kernels shared between the two
+// architectures use this form directly, while Quasar's existing log tile op
+// continues to use the underscored implementation above.
+template <bool FAST_APPROX, bool HAS_BASE_SCALING, bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat calculate_log_body(sfpi::vFloat a, const std::uint32_t log_base_scale_factor) {
+    sfpi::vFloat result = _calculate_log_body_no_init_(a);
+    if constexpr (HAS_BASE_SCALING) {
+        result *= sfpi::as<sfpi::vFloat>(sfpi::vUInt(log_base_scale_factor));
+    }
+    return result;
+}
+
+template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
+inline void log_init() {
+    math::_reset_counters_<p_setrwc::SET_ABD_F>();
+    const float LOG_TWO = 0.693147182f;
+    const float TWO_TO_M23 = 1.19209290e-7f;
+    sfpi::vConstFloatPrgm0 = LOG_TWO * TWO_TO_M23;
+
+    if constexpr (is_fp32_dest_acc_en) {
+        sfpi::vConstFloatPrgm1 = -0x1.00001ap-2f;
+        sfpi::vConstFloatPrgm2 = 0x1.555572p-2f;
+    } else {
+        sfpi::vConstFloatPrgm1 = 0x1.744p-2f;
+        sfpi::vConstFloatPrgm2 = -0x1.008p-1f;
+    }
 }
 
 template <bool APPROXIMATION_MODE, bool HAS_BASE_SCALING, int ITERATIONS>

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_logsigmoid.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_logsigmoid.h
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_converter.h"
+#include "ckernel_sfpu_polyval.h"
+#include "ckernel_sfpu_exp.h"
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_logsigmoid(
+    const std::uint32_t dst_index_in0,  // Index for input (x)
+    const std::uint32_t dst_index_in1,  // Index for exp(-x)
+    const std::uint32_t dst_index_out)  // Index for output
+{
+    // logsigmoid(x) = -softplus(-x)
+    for (int d = 0; d < ITERATIONS; d++) {
+        constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
+        // Read inputs from destination registers
+        sfpi::vFloat x = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+        sfpi::vFloat exp_neg_x = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+
+        // Save original x as result; negate x since we compute softplus(-x)
+        sfpi::vFloat result = x;
+        x = -x;
+
+        v_if(x < -4.0f) {
+            // For very negative: use exp
+            result = -exp_neg_x;
+        }
+        v_elseif(x >= -4.0f && x < 4.0f) {
+            // Polynomial approximation for softplus(-x) in the mid-range
+            result = PolynomialEvaluator::eval(
+                x,
+                0.6924354434013367f,
+                0.49275708198547363f,
+                0.12142381817102432f,
+                0.0031102809589356184f,
+                -0.00330807245336473f,
+                -0.00028794066747650504f,
+                5.3185409342404455e-05f,
+                7.1853546614875086e-06f,
+                7.4961114648886e-08f);
+            result = -result;
+        }
+        v_endif;
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+void logsigmoid_init() {}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_mask.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_mask.h
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "cmath_common.h"
+#include "sfpi.h"
+#include "sfpu/ckernel_sfpu_is_fp16_zero.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+inline void mask_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_mask() {
+    const int mask_val_idx = 32;
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        vFloat mask = dst_reg[mask_val_idx];
+        v_if(_sfpu_is_fp16_zero_(mask)) { dst_reg[0] = 0.0f; }
+        v_endif;
+        dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_int_mask() {
+    const int mask_idx = 32;
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        vInt mask = dst_reg[mask_idx];
+        v_if(mask == 0) { dst_reg[0] = 0.0f; }
+        v_endif;
+        dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_mask_posinf() {
+    const int mask_val_idx = 32;
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        vFloat mask = dst_reg[mask_val_idx];
+        v_if(_sfpu_is_fp16_zero_(mask)) { dst_reg[0] = std::numeric_limits<float>::infinity(); }
+        v_endif;
+        dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_piecewise_rational.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_piecewise_rational.h
@@ -5,22 +5,140 @@
 #pragma once
 
 /**
- * Rational P(x)/Q(x) evaluator for SFPU activations. Carries over the parity evaluator from the
- * Blackhole header of the same name; the other variants there have no Quasar users yet.
+ * Shared piecewise rational P(x)/Q(x) evaluator for LUT-based SFPU activations.
  *
- * For an odd numerator and even denominator (erf, atanh, erfinv) both polynomials are evaluated in
- * the x^2 basis, halving the multiply-add count. The two Horner chains are independent, so their
- * SFPMADs interleave and hide pipeline latency.
+ * Used by ckernel_sfpu_<activation>.h drop-in headers.
+ *
+ * ALL optimization variants included:
+ *   - Interleaved Horner: back-to-back SFPMAD on number/denom hides pipeline latency
+ *   - Parity x²-Horner: halves FMA count for odd-num/even-den (atanh, erfinv, erf)
+ *   - Deferred reciprocal: ONE sfpu_reciprocal for all segments
+ *   - Recursive template unrolling: sfpi_inline prevents spills
+ *   - Range reduction: Cody-Waite for exp/trig, mantissa/exponent for log
+ *
+ * Usage:
+ *   #include "ckernel_sfpu_piecewise_rational.h"
+ *   constexpr std::array<float, N> MY_LUT = {{ ... }};
+ *   sfpi::vFloat result = ckernel::sfpu::piecewise_rational_eval<
+ *       NUM_DEG, DEN_DEG, NUM_SEGS, LUT_SIZE>(MY_LUT, x);
+ *
+ * Parity: #define RATIONAL_NUM_PARITY_ODD + RATIONAL_DEN_PARITY_EVEN before including,
+ *         or use USE_PARITY=true template parameter on piecewise_rational_eval.
+ * Range reduction: #define RANGE_REDUCTION_EXP/TRIG/LOG before including, then use
+ *   piecewise_rational_eval_full<>() which handles reduce/expand.
  */
 
-#include "sfpi.h"
+#include <cstdint>
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_recip.h"
+#include "ckernel_sfpu_converter.h"
 
 namespace ckernel::sfpu {
 
-// Coefficient arrays are indexed by power, so the unused parity's entries are zero and get skipped
-// via NUM_TOP / DEN_TOP below.
+// ============================================================================
+// Range reduction helpers (Cody-Waite for exp/trig, IEEE754 for log)
+// ============================================================================
 
-template <uint32_t NUM_DEGREE, uint32_t DEN_DEGREE>
+#ifdef RANGE_REDUCTION_EXP
+inline void piecewise_exp_reduce(sfpi::vFloat x, sfpi::vFloat& s, sfpi::vInt& k_int) {
+    constexpr float INV_LN2 = 1.4426950408889634f;
+    constexpr float NEG_LN2_HI = -0.6931152343750000f;
+    constexpr float NEG_LN2_LO = -3.19461832987e-05f;
+    const sfpi::vFloat c231 = Converter::as_float(0x4B400000U);
+    sfpi::vFloat tmp = x * INV_LN2 + c231;
+    k_int = sfpi::as<sfpi::vInt>(tmp) - sfpi::as<sfpi::vInt>(c231);
+    s = (tmp - c231) * NEG_LN2_LO + ((tmp - c231) * NEG_LN2_HI + x);
+}
+
+inline sfpi::vFloat piecewise_exp_expand(sfpi::vFloat poly_result, sfpi::vInt k_int) {
+    return sfpi::setexp(poly_result, sfpi::exexp(poly_result, sfpi::ExponentMode::Biased) + k_int);
+}
+#endif
+
+#ifdef RANGE_REDUCTION_TRIG
+inline void piecewise_trig_reduce(sfpi::vFloat x, sfpi::vFloat& s, sfpi::vInt& q_int) {
+    constexpr float FRAC_1_PI = 0.31830988618379067f;
+    const sfpi::vFloat c231 = Converter::as_float(0x4B400000U);
+    // Compute x / pi and round-to-nearest integer value (c.f. Hacker's Delight)
+    sfpi::vFloat tmp = x * FRAC_1_PI + c231;
+    sfpi::vFloat q = tmp - c231;
+    q_int = sfpi::as<sfpi::vInt>(tmp) - sfpi::as<sfpi::vInt>(c231);
+    constexpr float NEG_PI_HI = -3.140625f;
+    constexpr float NEG_PI_LO = -0.00096765358979323846f;
+    s = q * NEG_PI_LO + (q * NEG_PI_HI + x);
+}
+
+inline sfpi::vFloat piecewise_trig_expand(sfpi::vFloat poly_result, sfpi::vInt q_int) {
+    // Sign flip via bitwise XOR: (q_int << 31) ^ result
+    poly_result = sfpi::as<sfpi::vFloat>((sfpi::as<sfpi::vUInt>(q_int) << 31) ^ sfpi::as<sfpi::vUInt>(poly_result));
+    return poly_result;
+}
+#endif
+
+#ifdef RANGE_REDUCTION_LOG
+inline void piecewise_log_reduce(sfpi::vFloat x, sfpi::vFloat& m, sfpi::vInt& e_int) {
+    e_int = sfpi::exexp(x);
+    m = sfpi::setexp(x, 127);
+}
+
+inline sfpi::vFloat piecewise_log_expand(sfpi::vFloat poly_result, sfpi::vInt e_int) {
+#ifdef LOG_EXPAND_CONSTANT
+    constexpr float EXPAND_C = LOG_EXPAND_CONSTANT;
+#else
+    constexpr float EXPAND_C = 0.6931471805599453f;  // ln(2)
+#endif
+    auto e_smag = sfpi::convert<sfpi::vSMag>(e_int);
+    return sfpi::convert<sfpi::vFloat>(e_smag, sfpi::RoundMode::Nearest) * EXPAND_C + poly_result;
+}
+#endif
+
+// ============================================================================
+// Interleaved Horner: evaluate P(x) and Q(x) simultaneously
+// Back-to-back SFPMADs on independent chains hide pipeline latency.
+// ============================================================================
+
+template <std::uint32_t NUM_DEGREE, std::uint32_t DEN_DEGREE>
+sfpi_inline void piecewise_rational_eval_numer_denom(
+    const float* num_coeffs,
+    const float* den_coeffs,
+    sfpi::vFloat x,
+    sfpi::vFloat& out_numer,
+    sfpi::vFloat& out_denom) {
+    constexpr std::uint32_t MIN_DEG = (NUM_DEGREE < DEN_DEGREE) ? NUM_DEGREE : DEN_DEGREE;
+
+    sfpi::vFloat number = num_coeffs[NUM_DEGREE];
+    sfpi::vFloat denom = den_coeffs[DEN_DEGREE];
+
+    if constexpr (NUM_DEGREE > DEN_DEGREE) {
+#pragma GCC unroll 64
+        for (int i = NUM_DEGREE - 1; i >= static_cast<int>(DEN_DEGREE); i--) {
+            number = number * x + num_coeffs[i];
+        }
+    } else if constexpr (DEN_DEGREE > NUM_DEGREE) {
+#pragma GCC unroll 64
+        for (int i = DEN_DEGREE - 1; i >= static_cast<int>(NUM_DEGREE); i--) {
+            denom = denom * x + den_coeffs[i];
+        }
+    }
+
+#pragma GCC unroll 64
+    for (int i = MIN_DEG - 1; i >= 0; i--) {
+        number = number * x + num_coeffs[i];
+        denom = denom * x + den_coeffs[i];
+    }
+
+    out_numer = number;
+    out_denom = denom;
+}
+
+// ============================================================================
+// Parity x²-Horner: odd num / even den → evaluate in x² basis
+// Halves FMA count for atanh, erfinv, erf, etc.
+// Always available — called via USE_PARITY template parameter or macro guard.
+// ============================================================================
+
+template <std::uint32_t NUM_DEGREE, std::uint32_t DEN_DEGREE>
 sfpi_inline void piecewise_rational_eval_parity_numer_denom(
     const float* num_coeffs,
     const float* den_coeffs,
@@ -35,13 +153,13 @@ sfpi_inline void piecewise_rational_eval_parity_numer_denom(
     constexpr int NUM_STEPS = (NUM_TOP - 1) / 2;
     constexpr int DEN_STEPS = DEN_TOP / 2;
 
-    sfpi::vFloat numer = num_coeffs[NUM_TOP];
+    sfpi::vFloat number = num_coeffs[NUM_TOP];
     sfpi::vFloat denom = den_coeffs[DEN_TOP];
 
     if constexpr (NUM_STEPS > DEN_STEPS) {
 #pragma GCC unroll 64
         for (int k = 0; k < NUM_STEPS - DEN_STEPS; k++) {
-            numer = numer * x2 + num_coeffs[NUM_TOP - 2 * (k + 1)];
+            number = number * x2 + num_coeffs[NUM_TOP - 2 * (k + 1)];
         }
     } else if constexpr (DEN_STEPS > NUM_STEPS) {
 #pragma GCC unroll 64
@@ -56,12 +174,153 @@ sfpi_inline void piecewise_rational_eval_parity_numer_denom(
 
 #pragma GCC unroll 64
     for (int k = 1; k <= MIN_STEPS; k++) {
-        numer = numer * x2 + num_coeffs[NUM_POS - 2 * k];
+        number = number * x2 + num_coeffs[NUM_POS - 2 * k];
         denom = denom * x2 + den_coeffs[DEN_POS - 2 * k];
     }
 
-    out_numer = numer * x;  // odd parity: P(x) = x * Horner_result
+    out_numer = number * x;  // odd parity: P(x) = x * Horner_result
     out_denom = denom;
+}
+
+// ============================================================================
+// Unified number/denom dispatcher: selects parity or interleaved automatically
+// ============================================================================
+
+template <std::uint32_t NUM_DEGREE, std::uint32_t DEN_DEGREE, bool USE_PARITY = false>
+sfpi_inline void piecewise_rational_dispatch_numer_denom(
+    const float* num_coeffs,
+    const float* den_coeffs,
+    sfpi::vFloat x,
+    sfpi::vFloat& out_numer,
+    sfpi::vFloat& out_denom,
+    sfpi::vFloat x2 = 0.0f) {
+    if constexpr (USE_PARITY) {
+        piecewise_rational_eval_parity_numer_denom<NUM_DEGREE, DEN_DEGREE>(
+            num_coeffs, den_coeffs, x, x2, out_numer, out_denom);
+    } else {
+        piecewise_rational_eval_numer_denom<NUM_DEGREE, DEN_DEGREE>(num_coeffs, den_coeffs, x, out_numer, out_denom);
+    }
+}
+
+// ============================================================================
+// Recursive segment unroller with deferred reciprocal
+// ============================================================================
+
+template <
+    std::uint32_t SEG,
+    std::uint32_t NUM_DEGREE,
+    std::uint32_t DEN_DEGREE,
+    std::uint32_t NUM_SEGMENTS,
+    std::uint32_t LUT_SIZE,
+    bool USE_PARITY = false>
+sfpi_inline void piecewise_rational_unroll_segment(
+    const std::array<float, LUT_SIZE>& lut,
+    sfpi::vFloat x,
+    sfpi::vFloat& number,
+    sfpi::vFloat& denom,
+    sfpi::vFloat x2 = 0.0f) {
+    if constexpr (SEG < NUM_SEGMENTS) {
+        constexpr std::uint32_t NUM_COEFFS = NUM_DEGREE + 1;
+        constexpr std::uint32_t CPS = NUM_COEFFS + DEN_DEGREE + 1;
+        constexpr std::uint32_t CO = NUM_SEGMENTS + 1;
+        v_if(x >= lut[SEG]) {
+            piecewise_rational_dispatch_numer_denom<NUM_DEGREE, DEN_DEGREE, USE_PARITY>(
+                &lut[CO + SEG * CPS], &lut[CO + SEG * CPS + NUM_COEFFS], x, number, denom, x2);
+        }
+        v_endif;
+        piecewise_rational_unroll_segment<SEG + 1, NUM_DEGREE, DEN_DEGREE, NUM_SEGMENTS, LUT_SIZE, USE_PARITY>(
+            lut, x, number, denom, x2);
+    }
+}
+
+// ============================================================================
+// Public API: evaluate piecewise rational LUT for a single vFloat x
+// Automatically dispatches parity when macros are defined.
+// USE_PARITY template parameter allows per-call parity control without macros.
+// ============================================================================
+
+template <
+    std::uint32_t NUM_DEGREE,
+    std::uint32_t DEN_DEGREE,
+    std::uint32_t NUM_SEGMENTS,
+    std::uint32_t LUT_SIZE,
+    bool USE_PARITY = false,
+    bool APPROX_RECIP = false>
+sfpi_inline sfpi::vFloat piecewise_rational_eval(const std::array<float, LUT_SIZE>& lut, sfpi::vFloat x) {
+    constexpr std::uint32_t NUM_COEFFS = NUM_DEGREE + 1;
+    constexpr std::uint32_t COEFF_OFFSET = NUM_SEGMENTS + 1;
+
+    // Parity controlled exclusively via template parameter — no macro leakage
+    constexpr bool parity_active = USE_PARITY;
+
+    sfpi::vFloat x2;
+    if constexpr (parity_active) {
+        x2 = x * x;
+    }
+
+    sfpi::vFloat number = 0.0f, denom = 0.0f;
+
+    if constexpr (parity_active) {
+        piecewise_rational_eval_parity_numer_denom<NUM_DEGREE, DEN_DEGREE>(
+            &lut[COEFF_OFFSET], &lut[COEFF_OFFSET + NUM_COEFFS], x, x2, number, denom);
+    } else {
+        piecewise_rational_eval_numer_denom<NUM_DEGREE, DEN_DEGREE>(
+            &lut[COEFF_OFFSET], &lut[COEFF_OFFSET + NUM_COEFFS], x, number, denom);
+    }
+
+    // Unroll remaining segments (seg 1..N-1)
+    if constexpr (NUM_SEGMENTS > 1) {
+        piecewise_rational_unroll_segment<1, NUM_DEGREE, DEN_DEGREE, NUM_SEGMENTS, LUT_SIZE, USE_PARITY>(
+            lut, x, number, denom, x2);
+    }
+
+    return number * sfpu_reciprocal<APPROX_RECIP>(denom);
+}
+
+// ============================================================================
+// Full evaluation with range reduction
+// Reads dst_reg, applies reduce → eval → expand, writes back.
+// ============================================================================
+
+template <std::uint32_t NUM_DEGREE, std::uint32_t DEN_DEGREE, std::uint32_t NUM_SEGMENTS, std::uint32_t LUT_SIZE>
+inline void piecewise_rational_eval_full(const std::array<float, LUT_SIZE>& lut, int d) {
+    sfpi::vFloat x_orig = sfpi::dst_reg[d];
+
+#if defined(RANGE_REDUCTION_EXP)
+    sfpi::vFloat x;
+    sfpi::vInt k_int;
+    piecewise_exp_reduce(x_orig, x, k_int);
+#elif defined(RANGE_REDUCTION_TRIG)
+    sfpi::vFloat x;
+    sfpi::vInt q_int;
+    piecewise_trig_reduce(x_orig, x, q_int);
+#elif defined(RANGE_REDUCTION_LOG)
+    sfpi::vFloat x;
+    sfpi::vInt e_int;
+    piecewise_log_reduce(x_orig, x, e_int);
+#else
+    sfpi::vFloat x = x_orig;
+#endif
+
+    sfpi::vFloat result = piecewise_rational_eval<NUM_DEGREE, DEN_DEGREE, NUM_SEGMENTS, LUT_SIZE>(lut, x);
+
+#if defined(RANGE_REDUCTION_EXP)
+    constexpr float EXP_OVERFLOW = 88.5f;
+    constexpr float EXP_UNDERFLOW = -88.5f;
+    v_if(x_orig > EXP_OVERFLOW) { result = std::numeric_limits<float>::infinity(); }
+    v_elseif(x_orig < EXP_UNDERFLOW) { result = 0.0f; }
+    v_else { result = piecewise_exp_expand(result, k_int); }
+    v_endif;
+#elif defined(RANGE_REDUCTION_TRIG)
+    result = piecewise_trig_expand(result, q_int);
+#elif defined(RANGE_REDUCTION_LOG)
+    v_if(x_orig < 0.0f) { result = std::numeric_limits<float>::quiet_NaN(); }
+    v_elseif(x_orig == 0.0f) { result = -std::numeric_limits<float>::infinity(); }
+    v_else { result = piecewise_log_expand(result, e_int); }
+    v_endif;
+#endif
+
+    sfpi::dst_reg[d] = result;
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "ckernel.h"
+#include "ckernel_defs.h"
+
+#include "sfpi.h"
+#include "ckernel_sfpu_converter.h"
+#include "ckernel_sfpu_polyval.h"
+#include "ckernel_sfpu_recip.h"
+#include "cmath_common.h"
+
+namespace ckernel::sfpu {
+
+/**
+ * Fused SFPU kernel for polygamma function: ψ^(n)(x)
+ *
+ * Computes: ψ^(n)(x) = (-1)^(n+1) * n! * Σ_{k=0}^{∞} 1/(x+k)^(n+1)
+ *
+ * Uses exact summation for the first NUM_TERMS terms, then adds an
+ * Euler-Maclaurin asymptotic tail correction for the remaining infinite sum.
+ * This dramatically improves accuracy vs plain truncation (e.g. trigamma
+ * max ULP drops from ~108 to ~1).
+ *
+ * Tail at z = x + NUM_TERMS (Euler-Maclaurin remainder with B₂, B₄, B₆ corrections):
+ *   tail = 1/(n·z^n) + 1/(2·z^(n+1)) + B₂·(n+1)/(z^(n+2))
+ *          + B₄·(n+1)(n+2)(n+3)/(z^(n+4))
+ *          + B₆·(n+1)(n+2)(n+3)(n+4)(n+5)/(z^(n+6))
+ * where B₂=1/6, B₄=-1/30, B₆=1/42 are Bernoulli numbers, giving coefficients
+ *   (n+1)/12, -(n+1)(n+2)(n+3)/720, (n+1)(n+2)(n+3)(n+4)(n+5)/30240
+ *
+ * Parameters are passed as bit-cast uint32_t values:
+ *   n_packed:     order n (as float bits)
+ *   scale_packed: precomputed (-1)^(n+1) * n! (as float bits)
+ */
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS = 8>
+inline void calculate_polygamma(std::uint32_t n_packed, std::uint32_t scale_packed) {
+    // Exact terms (k=0..NUM_TERMS-1). The Euler-Maclaurin tail (with B2,B4,B6 corrections)
+    // is applied at z = x + NUM_TERMS. For the supported domain (x >= 0.5) this puts
+    // z >= 6.5, where the asymptotic remainder is far below bfloat16 precision, so 6 exact
+    // terms are sufficient. Reduced from 11 to save ~5 reciprocals (+power chains) per element.
+    constexpr int NUM_TERMS = 6;
+
+    // Unpack parameters using Converter (union-based type punning supported by SFPU compiler)
+    int n = int(Converter::as_float(n_packed));
+    float scale = Converter::as_float(scale_packed);
+
+    // Precompute Bernoulli-related coefficients for asymptotic tail
+    // B_2 = 1/6 → coeff = (n+1)/12  (from B_2/(2!) * s*(s-1)... but simplified)
+    // B_4 = -1/30 → coeff = -(n+1)(n+2)(n+3)/720
+    // B_6 = 1/42  → coeff = (n+1)(n+2)(n+3)(n+4)(n+5)/30240
+    float n1 = n + 1;
+    float n2 = n + 2;
+    float n3 = n + 3;
+    float n4 = n + 4;
+    float n5 = n + 5;
+    float nf = n;
+    float inv_nf = 1.0f / nf;
+    float c_b2 = n1 / 12.0f;                           // B_2 term coefficient
+    float c_b4 = -(n1 * n2 * n3) / 720.0f;             // B_4 term coefficient
+    float c_b6 = (n1 * n2 * n3 * n4 * n5) / 30240.0f;  // B_6 term coefficient
+
+    constexpr auto RECIP = APPROXIMATION_MODE ? 0 : is_fp32_dest_acc_en ? 2 : 1;
+
+    auto power = [] __attribute__((always_inline)) (sfpi::vFloat x, int pwr, sfpi::vFloat val = 1.0f) {
+        for (;;) {
+            if (pwr & 1) {
+                val *= x;
+            }
+            pwr >>= 1;
+            if (!pwr) {
+                break;
+            }
+            x *= x;
+        }
+        return val;
+    };
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat sum = 0.0f;
+
+        // Part 1: Exact summation of first NUM_TERMS terms
+        // Σ_{k=0}^{NUM_TERMS-1} 1/(x+k)^(n+1)
+        for (int k = 0; k < NUM_TERMS; k++) {
+            sfpi::vFloat xi = x + float(k);
+
+            // Compute reciprocal first, then raise to power (avoids overflow of large intermediates)
+            sfpi::vFloat inv_xi = sfpu_reciprocal_iter<RECIP>(xi);
+            sfpi::vFloat inv_power = power(inv_xi, n, inv_xi);
+
+            sum += inv_power;
+        }
+
+        // Part 2: Euler-Maclaurin asymptotic tail correction
+        // For the remaining sum Σ_{k=NUM_TERMS}^{∞} 1/(x+k)^(n+1)
+        // at z = x + NUM_TERMS:
+        sfpi::vFloat z = x + float(NUM_TERMS);
+        sfpi::vFloat inv_z = sfpu_reciprocal_iter<RECIP>(z);
+        sfpi::vFloat inv_z2 = inv_z * inv_z;
+
+        // Use PolynomialEvaluator for the Bernoulli polynomial in the tail:
+        // E = inv_nf + c_b2*inv_z2 + c_b4*inv_z2^2 + c_b6*inv_z2^3
+        sfpi::vFloat E = PolynomialEvaluator::eval(inv_z2, inv_nf, c_b2, c_b4, c_b6);
+        sfpi::vFloat tail = E + 0.5f * inv_z;
+
+        // Scale by inv_z^n, taking advantage of inv_z^2's
+        // computation above
+        int pwr = n;
+        if (pwr & 1) {
+            tail *= inv_z;
+        }
+        pwr >>= 1;
+        if (pwr) {
+            // x^2n == (x^2)^n
+            tail = power(inv_z2, pwr, tail);
+        }
+
+        sum += tail;
+
+        // Apply scale: (-1)^(n+1) * n!
+        sfpi::vFloat result = sum * scale;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
+        }
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+void polygamma_init() {
+    math::_reset_counters_<p_setrwc::SET_ABD_F>();
+    sfpu_reciprocal_init<APPROXIMATION_MODE>();
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_prelu.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_prelu.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "cmath_common.h"
+#include "ckernel_sfpu_converter.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+inline void prelu_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_prelu(const std::uint32_t value) {
+    // SFPU microcode
+    vFloat init = Converter::as_float(value);
+
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        vFloat a = dst_reg[0];
+        v_if(a < 0.0f) { a = a * init; }
+        v_endif;
+        dst_reg[0] = a;
+        dst_reg++;
+    }
+}
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_rdiv.h
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_recip.h"
+#include "ckernel_sfpu_converter.h"
+#include "cmath_common.h"
+#include "sfpu/ckernel_sfpu_rounding_ops.h"
+
+namespace ckernel {
+namespace sfpu {
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, RoundingMode rounding_mode, int ITERATIONS>
+inline void calculate_rdiv(const std::uint32_t value) {
+    sfpi::vFloat val = Converter::as_float(value);
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat in = sfpi::dst_reg[0];
+        sfpi::vFloat recip;
+        if constexpr (APPROXIMATION_MODE) {
+            recip = sfpu_reciprocal_iter<0>(in);
+        } else {
+            if constexpr (is_fp32_dest_acc_en) {
+                recip = sfpu_reciprocal_iter<2>(in);
+            } else {
+                recip = sfpu_reciprocal_iter<1>(in);
+                recip = sfpi::convert<sfpi::vFloat16b>(recip, sfpi::RoundMode::Nearest);
+            }
+        }
+        sfpi::vFloat result = recip * val;
+
+        if constexpr (rounding_mode == RoundingMode::Trunc) {
+            result = _trunc_body_(result);
+        } else if constexpr (rounding_mode == RoundingMode::Floor) {
+            result = _floor_body_(result);
+        }
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+void rdiv_init() {
+    math::reset_counters(p_setrwc::SET_ABD_F);
+    sfpu_reciprocal_init<APPROXIMATION_MODE>();
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_recip.h
@@ -36,7 +36,7 @@ sfpi_inline sfpi::vFloat _sfpu_reciprocal_(const sfpi::vFloat x) {
         if constexpr (max_iter == 2) {
             sfpi::vFloat y1 = y * -t - 0.0f;
             // If t=NaN, then t>=0.  This check consumes the SFPNOP slot of the preceding SFPMAD.
-            v_if (t < 0) {
+            v_if(t < 0) {
                 t = x * y1 - sfpi::vConstFloatPrgm0;
                 y = y1 * -t - 0.0f;
             }
@@ -44,9 +44,7 @@ sfpi_inline sfpi::vFloat _sfpu_reciprocal_(const sfpi::vFloat x) {
         } else {
             // If t=NaN, then t>=0.  This check cannot be hidden in a SFPNOP slot as it depends on the result of the
             // preceding SFPMAD.
-            v_if (t < 0) {
-                y = y * -t - 0.0f;
-            }
+            v_if(t < 0) { y = y * -t - 0.0f; }
             v_endif;
         }
     }
@@ -60,6 +58,23 @@ inline void _init_reciprocal_() {
     if constexpr (!APPROXIMATION_MODE) {
         sfpi::vConstFloatPrgm0 = 2.0f;
     }
+}
+
+// Compatibility entry points used by portable Blackhole SFPI kernels. Keep the
+// Quasar implementation in one place while preserving the source-kernel API.
+template <int max_iter = 2>
+sfpi_inline sfpi::vFloat sfpu_reciprocal_iter(const sfpi::vFloat x) {
+    return _sfpu_reciprocal_<max_iter>(x);
+}
+
+template <bool APPROXIMATE = false, [[maybe_unused]] bool save_reg = true>
+sfpi_inline sfpi::vFloat sfpu_reciprocal(const sfpi::vFloat x) {
+    return _sfpu_reciprocal_<APPROXIMATE ? 0 : 2>(x);
+}
+
+template <bool APPROXIMATE = false>
+sfpi_inline void sfpu_reciprocal_init() {
+    _init_reciprocal_<APPROXIMATE>();
 }
 
 /**

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_remainder.h
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "ckernel_sfpu_binary_remainder.h"
+#include "ckernel_sfpu_recip.h"
+#include "cmath_common.h"
+#include "ckernel_sfpu_converter.h"
+
+namespace ckernel {
+namespace sfpu {
+
+using sfpi::shft;
+using sfpi::vFloat;
+using sfpi::vInt;
+
+template <bool APPROXIMATION_MODE>
+inline void init_remainder(const std::uint32_t value, const std::uint32_t recip) {
+    math::reset_counters(p_setrwc::SET_ABD_F);
+    sfpi::vConstFloatPrgm0 = Converter::as_float(value);
+    sfpi::vConstFloatPrgm1 = Converter::as_float(recip);
+}
+
+// Unary uint32 remainder mirrors the tensor-tensor kernel in ckernel_sfpu_binary_remainder.h.
+// The divisor is a compile-time literal, so these runtime checks fold at compile time and only take branches:
+//   scalar >= 2^31 -> one conditional subtract
+//   power-of-two -> bitmask
+//   else (< 2^31) -> range-reduce + full helper (1/|b| hoisted). Unlike Wormhole,Blackhole's helper uses the
+//   fractional_mul intrinsic, so divisor width does not change its cost. Small-b branch is not needed.
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_remainder_uint32_scalar(std::uint32_t scalar) {
+    sfpi::vInt b = static_cast<int>(scalar);
+
+    if (scalar >= 0x80000000u) {
+        // b >= 2^31: a < 2^32 <= 2b and a % b = (a >=u b) ? a - b : a.
+        // a is a signed vInt, so a < 0 means the uint32's MSB is set i.e. a >= 2^31.
+        // Only a >= 2^31 can be >=u b, so low-half a keeps r = a. For low-half a and high-half b,
+        // a - b overflows. Gating on `a < 0` ensures the compare only runs when both operands are in [2^31, 2^32).
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vInt a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
+
+            sfpi::vInt r = a;
+            v_if(a < 0 && sfpi::vUInt(a) >= sfpi::vUInt(b)) { r = a - b; }
+            v_endif;
+
+            sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>() = r;
+            sfpi::dst_reg++;
+        }
+    } else if ((scalar & (scalar - 1u)) == 0u) {
+        // Power of two (non-zero: scalar == 0 is rejected by the host TT_FATAL): a % b == a & (b-1)
+        sfpi::vInt mask = static_cast<int>(scalar - 1u);
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vInt a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
+            sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>() = a & mask;
+            sfpi::dst_reg++;
+        }
+    } else {
+        // b < 2^31: range-reduce each a via t = (uint32)a >> 1 (< 2^31). |b| and 1/|b| depend only
+        // on the divisor, so compute them once above the loop.
+        sfpi::vMag b_mag = sfpi::abs(b);
+        sfpi::vFloat inv_b_f = unsigned_remainder_recip(b_mag);
+
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vInt a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
+            sfpi::vInt t = sfpi::vInt(sfpi::vUInt(a) >> 1);
+            sfpi::vInt rt = compute_unsigned_remainder_int32(t, b_mag, inv_b_f);
+
+            // Reload a from DEST instead of keeping it live across the helper
+            a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
+            sfpi::vInt x = rt + rt + (a & 1);  // x = 2 * (t % b) + (a & 1), in [0, 2b)
+
+            sfpi::vInt r = x;
+            v_if(sfpi::vUInt(x) >= sfpi::vUInt(b)) { r = x - b; }
+            v_endif;
+
+            sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>() = r;
+            sfpi::dst_reg++;
+        }
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+inline void calculate_remainder() {
+    // SFPU microcode
+    sfpi::vFloat value_tmp = sfpi::vConstFloatPrgm0;
+    sfpi::vFloat s = sfpi::abs(value_tmp);
+    sfpi::vFloat recip_val = sfpi::abs(sfpi::vConstFloatPrgm1);
+
+#pragma GCC unroll 0
+    for (int d = 0; d < ITERATIONS; d++) {
+        vFloat val = sfpi::dst_reg[0];
+        vFloat v = sfpi::abs(val);
+
+        vFloat quotient;
+        vInt exp = sfpi::exexp(v * recip_val);
+        v_if(exp < 0) { quotient = 0.0f; }
+        // Since fp32 has 23 mantissa bits, the LSB represents the fractional part when exp < 23.
+        // We effectively round off the fractional bits to zero by right shifting using (exp - 23) and then left
+        // shifting it back using (0 - (exp - 23)).
+        v_elseif(exp < 23) {
+            quotient = sfpi::as<sfpi::vFloat>(
+                shft((shft(sfpi::as<sfpi::vUInt>(v * recip_val), (exp - 23))), (0 - (exp - 23))));
+        }
+        v_else { quotient = v * recip_val; }
+        v_endif
+
+        v_if(quotient > v * recip_val) {
+            quotient = quotient - 1;
+        }
+        v_endif;
+        v = v - quotient * s;
+
+        v_if(val < 0 && v != 0) { v = s - v; }
+        v_endif;
+
+        v_if(value_tmp < 0 && v != 0) { v = v + value_tmp; }
+        v_endif;
+        v = sfpi::copysgn(v, value_tmp);
+        v_if(s == 0) { v = std::numeric_limits<float>::quiet_NaN(); }
+        v_endif;
+
+        constexpr auto iter = 10;
+        for (int l = 0; l < iter; l++) {
+            v_if(v >= s) { v = v - s; }
+            v_endif;
+        }
+        v_if(sfpi::abs(v) - s == 0.0f) { v = 0.0f; }
+        v_endif;
+        sfpi::dst_reg[0] = v;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_rpow.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_rpow.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "ckernel.h"
+#include "ckernel_sfpu_binary_pow.h"
+#include "ckernel_sfpu_converter.h"
+#include "sfpi.h"
+
+namespace ckernel::sfpu {
+// ttnn.rpow(exponent, scalar_base) = pow(scalar_base, exponent)
+template <bool APPROXIMATION_MODE, int ITERATIONS, bool is_fp32_dest_acc_en>
+inline void calculate_rpow(const std::uint32_t base_val) {
+    sfpi::vFloat base_val_v = Converter::as_float(base_val);
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::dst_reg[0] = _sfpu_binary_power_<is_fp32_dest_acc_en>(base_val_v, sfpi::dst_reg[0]);
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_rsub_int32.h
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+#include "ckernel_addrmod.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+
+namespace ckernel::sfpu {
+
+template <bool APPROXIMATION_MODE, InstrModLoadStore INSTRUCTION_MODE, int ITERATIONS>
+inline void calculate_rsub_int(
+    const std::uint32_t dst_index_in0, const std::uint32_t dst_index_in1, const std::uint32_t dst_index_out) {
+    static_assert(
+        is_valid_instruction_mode(INSTRUCTION_MODE), "INSTRUCTION_MODE must be one of: INT32_2S_COMP, INT32, LO16.");
+
+    // Reverse subtract in 2's complement: out = in1 - in0 (B - A). `b - a` lowers to the same single
+    // SFPIADD (2's-complement of A) the raw path used, but leaves the loads/store and dst walk to the
+    // compiler. Pick the DataLayout whose load/store format byte matches the original
+    // InstrModLoadStore (LO16->U16, INT32/2S_COMP->I32; on Blackhole INT32_2S_COMP is raw int32).
+    constexpr sfpi::DataLayout layout =
+        (INSTRUCTION_MODE == InstrModLoadStore::LO16) ? sfpi::DataLayout::U16 : sfpi::DataLayout::I32;
+    using vType = std::conditional_t<layout == sfpi::DataLayout::U16, sfpi::vUInt, sfpi::vInt>;
+
+    // size of each tile in Dest is 64/SFP_DESTREG_STRIDE = 32 rows when using sfpi to load/store
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        vType a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].mode<layout>();
+        vType b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi].mode<layout>();
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi].mode<layout>() = b - a;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+void calculate_rsub_scalar_int32(std::uint32_t scalar) {
+    // out = scalar - dst. The scalar is materialized into a vInt once before the loop (as the raw
+    // _sfpu_load_imm32_ path also did), and `s - a` lowers to the same single SFPIADD (2's-complement
+    // of dst) per iteration, leaving the load/store and dst walk to the compiler.
+    const sfpi::vInt s = static_cast<int>(scalar);
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vInt a = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
+        sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>() = s - a;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_selu.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_selu.h
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "cmath_common.h"
+#include "ckernel_sfpu_converter.h"
+#include "sfpu/ckernel_sfpu_expm1_cw.h"
+
+namespace ckernel::sfpu {
+
+// selu(x) = scale * x for x>=0, scale * alpha * (exp(x)-1) for x<0
+// scale ≈ 1.0507, alpha ≈ 1.6733, scale*alpha ≈ 1.7581
+
+inline void selu_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en = false, int ITERATIONS = 8>
+inline void calculate_selu(std::uint32_t scale, std::uint32_t alpha) {
+    const sfpi::vFloat scale_val = Converter::as_float(scale);
+    const sfpi::vFloat scale_alpha = Converter::as_float(scale) * Converter::as_float(alpha);
+// unroll 2: with expm1_cw_clamped inlined the loop body is large enough that
+// partial unroll outperforms both full (unroll 8) and no-unroll (~0.8us on WH)
+#pragma GCC unroll 2
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat result = scale_alpha * expm1_cw_clamped(x);
+
+        v_if(x >= 0.0f) { result = scale_val * x; }
+        v_endif;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
+        }
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_snake_beta.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_snake_beta.h
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "ckernel.h"
+#include "llk_math_eltwise_unary_sfpu.h"
+#include "sfpi.h"
+#include "ckernel_sfpu_polyval.h"
+#include "ckernel_sfpu_recip.h"
+
+namespace ckernel::sfpu {
+
+// SnakeBeta activation: y = x + sin²(α·x) / β.
+// Range-reduces α·x to (-π/2, π/2] then evaluates sin(a) via the calculate_sine() minimax
+// polynomial; sin² is even, so no quadrant sign-fix is needed. Valid for |α·x| < 32767·π
+// (≈1.03e5) before convert<vSMag16> saturates.
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, DataFormat data_format, int ITERATIONS = 8>
+inline void calculate_snake_beta(
+    std::uint32_t dst_index_x,
+    std::uint32_t dst_index_alpha,
+    std::uint32_t dst_index_beta,
+    std::uint32_t dst_index_out) {
+    static_assert(
+        data_format == DataFormat::Float32 || data_format == DataFormat::Float16_b,
+        "snake_beta supports only Float32 and Float16_b");
+
+    constexpr std::uint32_t dst_tile_size_sfpi = 32;
+    constexpr float one_over_pi = 0.318309886183791f;
+    constexpr float pi_f = 3.141592653589793f;
+
+    // sin(a) minimax coefficients on a ∈ (-π/2, π/2]; mirror calculate_sine().
+    constexpr float fp32_C3 = 0x1.5dc908p-19f;
+    constexpr float fp32_C2 = -0x1.9f70fp-13f;
+    constexpr float fp32_C1 = 0x1.110edap-7f;
+    constexpr float fp32_C0 = -0x1.55554cp-3f;
+    constexpr float bf16_C2 = -0x1.8b10a4p-13f;
+    constexpr float bf16_C1 = 0x1.10c2a2p-7f;
+    constexpr float bf16_C0 = -0x1.5554a4p-3f;
+
+    // 2 NR iters for fp32 (≤1 ULP), 1 for bf16 (≤0.5 ULP).
+    constexpr int RECIP_ITER = is_fp32_dest_acc_en ? 2 : 1;
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat x = sfpi::dst_reg[dst_index_x * dst_tile_size_sfpi];
+        sfpi::vFloat alpha = sfpi::dst_reg[dst_index_alpha * dst_tile_size_sfpi];
+        sfpi::vFloat beta = sfpi::dst_reg[dst_index_beta * dst_tile_size_sfpi];
+
+        sfpi::vFloat ax = alpha * x;
+
+        // a = (ax/π - round(ax/π)) * π, single-stage reduction; vConstFloatPrgm0/1/2 are
+        // reserved for the reciprocal estimate so convert<vSMag16> is used instead.
+        sfpi::vFloat ax_over_pi = ax * one_over_pi;
+        sfpi::vSMag16 k = sfpi::convert<sfpi::vSMag16>(ax_over_pi, sfpi::RoundMode::Nearest);
+        sfpi::vFloat k_f = sfpi::convert<sfpi::vFloat>(k, sfpi::RoundMode::Nearest);
+        sfpi::vFloat a = (ax_over_pi - k_f) * pi_f;
+
+        // sin(a) = a + a·s·poly(s), s = a².  PolynomialEvaluator::eval expands to a Horner chain.
+        sfpi::vFloat s = a * a;
+        sfpi::vFloat c = a * s;  // a³
+        sfpi::vFloat r;
+        if constexpr (is_fp32_dest_acc_en) {
+            r = c * PolynomialEvaluator::eval(s, fp32_C0, fp32_C1, fp32_C2, fp32_C3) + a;
+        } else {
+            r = c * PolynomialEvaluator::eval(s, bf16_C0, bf16_C1, bf16_C2) + a;
+        }
+
+        sfpi::vFloat sin2_ax = r * r;
+        sfpi::vFloat inv_beta = sfpu_reciprocal_iter<RECIP_ITER>(beta);
+        sfpi::vFloat result = x + sin2_ax * inv_beta;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
+        }
+
+        sfpi::dst_reg[dst_index_out * dst_tile_size_sfpi] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATE>
+inline void snake_beta_init() {
+    // Common SFPU init inlined (SFPU config register + ADDR_MOD_7 + counter reset), then the op-specific
+    // reciprocal setup below -- one self-contained init, matching exp_init. snake_beta uses only
+    // ADDR_MOD_7 (no op-specific ADDR_MOD_6).
+    sfpu::_init_sfpu_config_reg();
+    addr_mod_t{.srca = {.incr = 0}, .srcb = {.incr = 0}, .dest = {.incr = 0}}.set(ADDR_MOD_7);
+    math::_reset_counters_<p_setrwc::SET_ABD_F>();
+    sfpu_reciprocal_init<APPROXIMATE>();
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_softshrink.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_softshrink.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "cmath_common.h"
+#include "sfpi.h"
+#include "ckernel_sfpu_converter.h"
+
+namespace ckernel::sfpu {
+
+inline void softshrink_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_softshrink(std::uint32_t param0) {
+    // Softshrink(x) = x - λ if x > λ, x + λ if x < -λ, else 0
+    // SFPU microcode
+    sfpi::vFloat lambda = Converter::as_float(param0);
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::dst_reg[0] = 0.0f;
+        v_if(v > lambda) { sfpi::dst_reg[0] = v - lambda; }
+        v_elseif(v < (-lambda)) { sfpi::dst_reg[0] = v + lambda; }
+        v_endif;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_softsign.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_softsign.h
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_sfpu_recip.h"
+#include "cmath_common.h"
+
+namespace ckernel::sfpu {
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_softsign() {
+    // SFPU microcode
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        sfpi::vFloat tmp = sfpi::abs(v) + 1.0f;
+        tmp = sfpu_reciprocal<APPROXIMATION_MODE>(tmp);
+        sfpi::dst_reg[0] = v * tmp;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE>
+void init_softsign() {
+    math::_reset_counters_<p_setrwc::SET_ABD_F>();
+    sfpu_reciprocal_init<APPROXIMATION_MODE>();
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_tanhshrink.h
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ckernel.h"
+#include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_recip.h"
+#include "ckernel_sfpu_tanh.h"
+#include "cmath_common.h"
+
+namespace ckernel::sfpu {
+
+// tanhshrink(x) = x - tanh(x).
+// For small |x|, tanh(x) ~= x, so the subtractive form x - tanh(x) suffers catastrophic
+// cancellation in bf16 (both operands round to the same value -> result 0). Instead, for
+// |x| <= 1 we evaluate tanhshrink directly via the factored odd polynomial x^3 * Q(x^2)
+// (Q is a degree-3 minimax fit of (x - tanh(x))/x^3 on [0,1]); this preserves the x^3
+// leading behaviour and has no cancellation. For |x| > 1 the cancellation is mild, so we
+// return x - tanh(x). bf16 needs only ~2 result ULP there, so it uses a local degree-3
+// tanh polynomial (cheaper than the shared deg-6 _sfpu_tanh_polynomial_); fp32 keeps the
+// sigmoid-based accurate tanh (deg-3 would be ~1700 fp32 ULP).
+template <bool is_fp32_dest_acc_en, int ITERATIONS>
+inline void calculate_tanhshrink() {
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat ax = sfpi::setsgn(x, 0);  // |x|
+
+        // --- small |x| path: tanhshrink(x) = x^3 * Q(x^2) ---
+        // Q is a minimax fit of (x - tanh(x))/x^3 on [0,1]. bf16 needs only degree 3;
+        // fp32 needs degree 6 to reach fp32 precision (degree 3 is ~1700 fp32 ULP).
+        sfpi::vFloat u = x * x;
+        sfpi::vFloat Q;
+        if constexpr (is_fp32_dest_acc_en) {
+            Q = PolynomialEvaluator::eval(
+                u,
+                3.3333331347e-01f,
+                -1.3333128393e-01f,
+                5.3934831172e-02f,
+                -2.1660288796e-02f,
+                8.2192532718e-03f,
+                -2.5107525289e-03f,
+                4.2079269770e-04f);
+        } else {
+            Q = PolynomialEvaluator::eval(
+                u, 3.3329936862e-01f, -1.3223160803e-01f, 4.8076551408e-02f, -1.0762925260e-02f);
+        }
+        sfpi::vFloat result = x * u * Q;  // default = small path
+
+        // --- large |x| path: x - tanh(x) ---
+        v_if(ax > sfpi::vFloat(1.0f)) {
+            if constexpr (is_fp32_dest_acc_en) {
+                // Evaluate on |x| (tanhshrink is odd) so the exp argument -2|x| is always
+                // negative and cannot overflow; the "unsafe" exp is then safe to use.
+                // Clamp |x| to 9 (tanh(9) rounds to 1.0 in fp32) so the saturation tail and
+                // +/-inf stay exact and the exp argument is bounded to [-18, -2].
+                sfpi::vFloat axc = ax;
+                axc = sfpi::min(axc, 9.0f);
+                sfpi::vFloat e = _sfpu_exp_fp32_accurate_unsafe_(-2.f * axc);
+                sfpi::vFloat sig = sfpu_reciprocal_iter<2>(1.0f + e);  // sigmoid(2|x|)
+                sfpi::vFloat tanh_ax = 2.f * sig - 1.0f;               // tanh(|x|)
+                result = sfpi::copysgn(ax - tanh_ax, x);
+            } else {
+                // tanh(|x|) via a degree-3 minimax fit on [1,3.3].
+                // The poly crosses 1.0 monotonically near x~3.12 and stays >1 beyond, so the
+                // clamp to 1.0 holds the saturation tail exactly (including +/-inf).
+                sfpi::vFloat p = PolynomialEvaluator::eval(
+                    ax, 6.1829000893e-02f, 1.0561303143e+00f, -4.0859283753e-01f, 5.3348409333e-02f);
+                p = sfpi::min(p, 1.0f);
+                sfpi::vFloat tanhx = sfpi::copysgn(p, x);  // tanh(-x) = -tanh(x)
+                result = x - tanhx;
+            }
+        }
+        v_endif;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
+        }
+
+        sfpi::dst_reg[0] = result;
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
+inline void tanhshrink_init() {
+    math::_reset_counters_<p_setrwc::SET_ABD_F>();
+    // The bf16 large-|x| path uses only local literal polynomials, so it needs no init.
+    if constexpr (is_fp32_dest_acc_en) {
+        // The fp32 large-|x| path only needs the reciprocal Newton constants; the accurate
+        // exp it uses is pure arithmetic (no LUT / programmable constants).
+        sfpu_reciprocal_init<false>();
+    }
+}
+
+}  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_comp.h
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "cmath_common.h"
+#include "ckernel_sfpu_converter.h"
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+inline void unary_ne_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_unary_ne(std::uint32_t value) {
+    // SFPU microcode
+    sfpi::vFloat s = Converter::as_float(value);
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        v_if(v == s) { v = 0.0f; }
+        v_else { v = 1.0f; }
+        v_endif;
+
+        sfpi::dst_reg[0] = v;
+
+        sfpi::dst_reg++;
+    }
+}
+
+inline void unary_eq_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_unary_eq(std::uint32_t value) {
+    // SFPU microcode
+    sfpi::vFloat s = Converter::as_float(value);
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        v_if(v == s) { v = 1.0f; }
+        v_else { v = 0.0f; }
+        v_endif;
+
+        sfpi::dst_reg[0] = v;
+
+        sfpi::dst_reg++;
+    }
+}
+
+inline void unary_gt_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_unary_gt(std::uint32_t value) {
+    // SFPU microcode
+    sfpi::vFloat s = Converter::as_float(value);
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        v_if(v > s) { v = 1.0f; }
+        v_else { v = 0.0f; }
+        v_endif;
+
+        sfpi::dst_reg[0] = v;
+
+        sfpi::dst_reg++;
+    }
+}
+
+inline void unary_lt_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_unary_lt(std::uint32_t value) {
+    // SFPU microcode
+    sfpi::vFloat s = Converter::as_float(value);
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        v_if(v < s) { v = 1.0f; }
+        v_else { v = 0.0f; }
+        v_endif;
+
+        sfpi::dst_reg[0] = v;
+
+        sfpi::dst_reg++;
+    }
+}
+
+inline void unary_ge_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_unary_ge(std::uint32_t value) {
+    // SFPU microcode
+    sfpi::vFloat s = Converter::as_float(value);
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        v_if(v < s) { v = 0.0f; }
+        v_else { v = 1.0f; }
+        v_endif;
+
+        sfpi::dst_reg[0] = v;
+
+        sfpi::dst_reg++;
+    }
+}
+
+inline void unary_le_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_unary_le(std::uint32_t value) {
+    // SFPU microcode
+    sfpi::vFloat s = Converter::as_float(value);
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat v = sfpi::dst_reg[0];
+        v_if(v > s) { v = 0.0f; }
+        v_else { v = 1.0f; }
+        v_endif;
+
+        sfpi::dst_reg[0] = v;
+
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_power.h
@@ -1,0 +1,423 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "cmath_common.h"
+#include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_conversions.h"
+#include "ckernel_sfpu_converter.h"
+#include "ckernel_sfpu_polyval.h"
+
+using namespace sfpi;
+
+namespace ckernel {
+namespace sfpu {
+
+/**
+ * @brief Computes base raised to the power of pow (base**pow)
+ *
+ * This function implements binary exponentiation using a polynomial approximation algorithm
+ * based on "Simple Multiple Precision Algorithms for Exponential Functions [Tips & Tricks]"
+ * by Moroz et al. 2022 (https://doi.org/10.1109/MSP.2022.3157460).
+ * More specifically, it is the implementation of the `exp_21f` algorithm described in Section 5
+ *
+ * @param base The base value (sfpi::vFloat vector), can be any floating point number
+ * @param pow The exponent/power value (sfpi::vFloat vector), can be any floating point number
+ * @tparam IS_POSITIVE_EXPONENT If true, assumes exponent >= 0 (skips zero-base check for optimization)
+ *
+ * @return sfpi::vFloat Result of base**pow
+ *
+ * Special Cases:
+ * - base = 0, pow < 0: Returns NaN (undefined)
+ * - base < 0, pow = integer: Returns proper signed result (negative if odd power)
+ * - base < 0, pow = non-integer: Returns NaN (complex result)
+ * - Overflow/underflow: Clamped to appropriate limits
+ *
+ * @note This function assumes that the programmable constants are set to the following values:
+ * - vConstFloatPrgm0 = 1.4426950408889634f;
+ * - vConstFloatPrgm1 = -127.0f;
+ * - vConstFloatPrgm2 = std::numeric_limits<float>::quiet_NaN();
+ *
+ * @see Moroz et al. 2022 - "Simple Multiple Precision Algorithms for Exponential Functions"
+ *      ( https://doi.org/10.1109/MSP.2022.3157460 )
+ */
+template <bool IS_POSITIVE_EXPONENT>
+sfpi_inline sfpi::vFloat _sfpu_unary_power_21f_(sfpi::vFloat base, sfpi::vFloat pow) {
+    // The algorithm works in two steps:
+    // 1) Compute log2(base)
+    // 2) Compute base**pow = 2**(pow * log2(base))
+
+    // Step 1: Compute log2(base)
+    // Normalize base to calculation range
+    sfpi::vFloat abs_base = sfpi::abs(base);       // set base as positive
+    sfpi::vFloat x = sfpi::setexp(abs_base, 127);  // set exp to exp bias (put base in range of 1-2)
+
+    // 3rd order polynomial approx - determined using rminimax over [1,2]
+    vFloat series_result = PolynomialEvaluator::eval(x, -0x1.952992p+0f, 0x2.4f5388p+0f, -0xd.e712ap-4f, 0x2.44734p-4f);
+
+    // Convert exponent to float
+    sfpi::vInt exp = sfpi::exexp(base);
+    sfpi::vFloat exp_f32 = sfpi::convert<sfpi::vFloat>(sfpi::convert<sfpi::vSMag>(exp), sfpi::RoundMode::Nearest);
+
+    // De-normalize to original range
+    const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;           // vConst1Ln2 = 1.4426950408889634f;
+    sfpi::vFloat log2_result = exp_f32 + series_result * vConst1Ln2;  // exp correction: ln(1+x) + exp*ln(2)
+
+    // Step 2: Compute base**pow = 2**(pow * log2(base))
+    // If (base, exponent) => (0, +inf) or (base, exponent) => (N, -inf) then output should be 0
+    // However, intermediary values can overflow, which leads to output increasing again instead of
+    // staying at 0.
+    // This overflow happens when z_f32 < -127. Therefore, we clamp z_f32 to -127.
+    sfpi::vFloat z_f32 = pow * log2_result;
+    const sfpi::vFloat low_threshold = sfpi::vConstFloatPrgm1;
+    v_if(z_f32 < low_threshold) { z_f32 = low_threshold; }
+    v_endif;
+
+    // The paper relies on the following formula (c.f. Sections 1 and 5):
+    // z = (bias + x * log2(a)) * N_m; where:
+    // N_m = 2**23
+    // bias = 0x3f800000
+
+    // In this case, we transform the formula to:
+    // z = (bias) * N_m + (x * log2(a)) * N_m
+    // where (bias + N_m) = 0x3f800000
+    // and (x * log2(a)) * N_m = addexp(z_f32, 23)
+
+    // Notes:
+    // - N_m being a power of 2 ensures equivalent results
+    // - addexp(z_f32, 23) is used because it translates to a single-cycle SFPDIVP2
+    //   instruction with immediate operand (i.e. no extra register used).
+    //   (vs. 1 cycle SFPLOADI + 2 cycles MAD)
+
+    z_f32 = sfpi::addexp(z_f32, 23);  // equal to multiplying by 2**23
+    const sfpi::vFloat bias = sfpi::vFloat(0x3f800000);
+    sfpi::vInt z = _float_to_int32_positive_(z_f32 + bias);
+
+    sfpi::vInt zii = sfpi::exexp(sfpi::as<sfpi::vFloat>(z));  // Note: z & 0x7f800000 in paper
+    sfpi::vInt zif = sfpi::exman(sfpi::as<sfpi::vFloat>(z));  // Note: z & 0x007fffff in paper
+
+    // Compute formula in Horner form
+    sfpi::vFloat d1 = sfpi::vFloat(0.40196114e-7);
+    sfpi::vFloat d2 =
+        sfpi::convert<sfpi::vFloat>(sfpi::as<vSMag>(sfpi::vInt(0xf94ee7) + zif), sfpi::RoundMode::Nearest);
+    sfpi::vFloat d3 = sfpi::convert<sfpi::vFloat>(sfpi::as<vSMag>(sfpi::vInt(0x560e) + zif), sfpi::RoundMode::Nearest);
+
+    d2 = d1 * d2;
+    zif = _float_to_int32_positive_(d2 * d3);
+
+    // Restore exponent
+    zii = sfpi::as<sfpi::vInt>(sfpi::setexp(sfpi::as<sfpi::vFloat>(zif), 127U + zii));
+
+    sfpi::vFloat y = sfpi::as<sfpi::vFloat>(zii);
+
+    // Division by 0 when base is 0 and pow is negative => set to NaN (only for negative exponents)
+    if constexpr (!IS_POSITIVE_EXPONENT) {
+        v_if(abs_base == 0.f) {
+            y = sfpi::vConstFloatPrgm2;  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
+        }
+        v_endif;
+    }
+
+    // Negative base handling (for both positive and negative exponents)
+    v_if(base < 0.0f) {
+        // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
+        // Check valid base range
+        auto pow_int = sfpi::convert<sfpi::vSMag16>(
+            pow, sfpi::RoundMode::Nearest);  // int16 should be plenty, since large powers will approach 0/Inf
+        auto pow_rounded = sfpi::convert<sfpi::vFloat>(pow_int, sfpi::RoundMode::Nearest);
+
+        // If pow is odd integer then result is negative
+        // If power is even, then result is positive
+        y = sfpi::setsgn2(y, pow_int);
+
+        // Check for integer power, if it is not then overwrite result with NaN
+        v_if(pow_rounded != pow) {  // negative base and non-integer power => set to NaN
+            y = sfpi::vConstFloatPrgm2;
+        }
+        v_endif;
+    }
+    v_endif;
+
+    // LRegs work on float32 data. If DST is bfloat16 then SFPSTORE will truncate it.
+    // This can reduce accuracy: for instance, 9**2 = 80.8 gets round to 80.5
+    // rather than 81 (which would have been correct).
+    // To avoid this issue, we explicitly convert to bfloat16 using round-to-nearest.
+    y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::Nearest);
+
+    return y;
+}
+
+sfpi_inline sfpi::vFloat _sfpu_pow2_f32_accurate_(sfpi::vFloat z) {
+    // Handle underflow
+    z = sfpi::max(z, -0x7e.ffff8p0f);
+
+    sfpi::vInt k_int;
+    sfpi::vFloat k = _sfpu_round_to_nearest_int32_(z, k_int);
+
+    // Compute val = z * ln(2), then r = val - k*ln(2) in extended precision.
+    constexpr float LN2 = 0.693147180559945309f;
+    constexpr float LN2_HI = -0.6931152343750000f;
+    constexpr float LN2_LO = -3.19461832987e-05f;
+
+    sfpi::vFloat val = z * LN2;
+    sfpi::vFloat r_hi = k * LN2_HI + val;
+    sfpi::vFloat r = k * LN2_LO + r_hi;
+
+    sfpi::vFloat p = PolynomialEvaluator::eval(
+        r, 1.0f, 1.0f, 0.5f, 1.0f / 6.0f, 1.0f / 24.0f, 1.0f / 120.0f, 1.0f / 720.0f, 1.0f / 5040.0f);
+
+    sfpi::vFloat result = sfpi::setexp(p, sfpi::exexp(p, sfpi::ExponentMode::Biased) + k_int);
+
+    // Handle overflow
+    v_if(z >= 128.0f) { result = std::numeric_limits<float>::infinity(); }
+    v_endif;
+
+    return result;
+}
+
+// Computes 2**(z_hi + z_lo) where the argument is supplied as an unevaluated sum
+// (double-float). For pow(x,y): z = y*log2(x) can be O(100) with a tiny but
+// significant fractional tail. Rounding (z_hi + z_lo) into one fp32 before the
+// reduction discards that tail (the 20-27 ULP error). A Dekker FastTwoSum keeps the
+// residual, which is folded back into the reduced remainder r so no fractional bits
+// are lost. FastTwoSum is exact under the precondition |z_hi| >= |z_lo| or z_hi == 0,
+// which both pow callers satisfy: z_hi = pow*exponent(base) and z_lo carries the
+// fractional log2 term (|z_lo| < ~0.5*|pow| plus a <=2**-12*|pow| Veltkamp remainder).
+// When exponent(base) == 0 then z_hi == 0 exactly (the sum is already exact);
+// otherwise |exponent(base)| >= 1 so |z_hi| >= |pow| > |z_lo|.
+sfpi_inline sfpi::vFloat _sfpu_pow2_f32_accurate_hilo_(sfpi::vFloat z_hi, sfpi::vFloat z_lo) {
+    sfpi::vFloat s = z_hi + z_lo;
+    sfpi::vFloat e = z_lo - (s - z_hi);
+
+    s = sfpi::max(s, -0x7e.ffff8p0f);
+
+    sfpi::vInt k_int;
+    sfpi::vFloat k = _sfpu_round_to_nearest_int32_(s, k_int);
+
+    // ln2 split so that f*LN2_HI is exact for the small reduced |f| <= 0.5.
+    constexpr float LN2_HI = 0.693359375f;
+    constexpr float LN2_LO = -2.12194440e-4f;
+
+    // Reduced fractional argument f = (s - k) + e. (s - k) is exact by Sterbenz since
+    // k is the nearest integer to s and |s| < 2**23; adding the residual e restores the
+    // fractional tail that a single-fp32 (z_hi+z_lo) would have discarded.
+    sfpi::vFloat f = (s - k) + e;
+
+    sfpi::vFloat r = f * LN2_HI + f * LN2_LO;
+
+    sfpi::vFloat p = PolynomialEvaluator::eval(
+        r, 1.0f, 1.0f, 0.5f, 1.0f / 6.0f, 1.0f / 24.0f, 1.0f / 120.0f, 1.0f / 720.0f, 1.0f / 5040.0f);
+
+    sfpi::vFloat result = sfpi::setexp(p, sfpi::exexp(p, sfpi::ExponentMode::Biased) + k_int);
+
+    v_if(s >= 128.0f) { result = std::numeric_limits<float>::infinity(); }
+    v_endif;
+
+    return result;
+}
+
+template <bool IS_POSITIVE_EXPONENT>
+sfpi_inline sfpi::vFloat _sfpu_unary_power_61f_updated_(const sfpi::vFloat& base, const sfpi::vFloat& pow) {
+    // The algorithm works in two steps:
+    // 1) Compute log2(base)
+    // 2) Compute base**pow = 2**(pow * log2(base))
+
+    // Step 1: Compute log2(base) using improved log
+    // Normalize base to calculation range
+    sfpi::vFloat abs_base = sfpi::abs(base);
+    sfpi::vFloat m = sfpi::setexp(abs_base, 127);
+    sfpi::vInt exp = sfpi::exexp(abs_base);
+
+    // Range reduction: ensure m in [sqrt(2)/2, sqrt(2)] ≈ [0.707, 1.414]
+    constexpr float SQRT2 = 1.4142135381698608f;
+    v_if(m >= SQRT2) {
+        m = sfpi::addexp(m, -1);
+        exp = exp + 1;
+    }
+    v_endif;
+
+    // Transform to z = (m - 1) / (m + 1)
+    sfpi::vFloat m_plus_1 = m + 1.0f;  // t in [1.707, 2.414] since m in [sqrt(2)/2, sqrt(2)]
+    // 1/t: initial guess 1.003f - 0.244f*t (linear interp on [1.7,2.4]), then Newton-Raphson y = y*(2 - t*y).
+    sfpi::vFloat recip = 1.003f - 0.244f * m_plus_1;
+    recip = recip * (2.0f - m_plus_1 * recip);  // 1st NR
+    recip = recip * (2.0f - m_plus_1 * recip);  // 2nd NR
+    // 3rd NR: two NR iterations leave a ~2 ULP reciprocal residual that, after the
+    // atanh(z) log series and pow*log2 multiply, is the floor keeping 2.5 at 4 ULP.
+    // One more quadratically-convergent step drives 1/(m+1) to full fp32 precision.
+    recip = recip * (2.0f - m_plus_1 * recip);  // 3rd NR for float32
+    // z = (m-1)*recip written as a single fused multiply-add (m*recip - recip), one
+    // instruction instead of a separate (m-1) subtract plus a multiply.
+    sfpi::vFloat z = m * recip - recip;
+
+    // Compute z**2 for polynomial evaluation
+    sfpi::vFloat z2 = z * z;
+    // Polynomial approximation using odd powers
+    sfpi::vFloat p = PolynomialEvaluator::eval(
+        z2, 1.0f, 0.3333333333333333f, 0.2f, 0.14285714285714285f, 0.1111111111111111f, 0.09090909090909091f);
+    sfpi::vFloat ln_m = 2.0f * (z * p);
+
+    sfpi::vFloat exp_f32 = sfpi::convert<sfpi::vFloat>(sfpi::convert<sfpi::vSMag>(exp), sfpi::RoundMode::Nearest);
+
+    // z = pow*log2(base) = pow*exp_f32 (large integer-ish part) + pow*(ln_m*ln2inv)
+    // (fractional part). Summing both into one fp32 before 2**z squeezes out the
+    // fractional mantissa bits for large |base| -- the source of the 20-27 ULP error.
+    // Carry z as an unevaluated double-float (z_hi, z_lo); the helper's Knuth two-sum
+    // preserves the fractional tail across the k=round(z) reduction.
+    const sfpi::vFloat vConst1Ln2 = sfpi::vConstFloatPrgm0;
+
+    // The residual after the two-sum is the fp32 rounding of the product pow*exp_f32
+    // itself. exp_f32 is the (large) integer exponent of base and pow can carry a full
+    // 24-bit mantissa (e.g. 1.7984), so pow*exp_f32 needs ~30 bits and drops its low
+    // bits before the two-sum can see them. Because exp_f32 is a small integer, a
+    // Veltkamp split of pow makes both partial products exact (a 12-bit half times a
+    // <=7-bit integer fits a 24-bit significand):
+    //   pow*exp_f32 = pow_hi*exp_f32 + pow_lo*exp_f32   (both exact)
+    // pow_lo*exp_f32 rides in z_lo, so no bit of the large integer term is lost.
+    // Splitting only pow (not the full Dekker two-product on log2(base)) keeps the
+    // simultaneously-live vector count within the SFPU register budget.
+    constexpr float VELTKAMP_SPLIT = 4097.0f;  // 2**12 + 1
+    sfpi::vFloat pc = pow * VELTKAMP_SPLIT;
+    sfpi::vFloat pow_hi = pc - (pc - pow);
+    sfpi::vFloat pow_lo = pow - pow_hi;
+
+    sfpi::vFloat z_hi = pow_hi * exp_f32;
+    sfpi::vFloat z_lo = pow_lo * exp_f32 + pow * (ln_m * vConst1Ln2);
+    sfpi::vFloat y = _sfpu_pow2_f32_accurate_hilo_(z_hi, z_lo);
+
+    // Division by 0 when base is 0 and pow is negative => set to NaN (only for negative exponents)
+    if constexpr (!IS_POSITIVE_EXPONENT) {
+        v_if(abs_base == 0.f) {
+            y = sfpi::vConstFloatPrgm2;  // negative powers of 0 are NaN, e.g. pow(0, -1.5)
+        }
+        v_endif;
+    }
+
+    v_if(base < 0.0f) {  // negative base
+        // Post-processing: ensure that special values (e.g. 0**0, -1**0.5, ...) are handled correctly
+        // Check valid base range
+        auto pow_int = sfpi::convert<sfpi::vSMag16>(
+            pow, sfpi::RoundMode::Nearest);  // int16 should be plenty, since large powers will approach 0/Inf
+        auto pow_rounded = sfpi::convert<sfpi::vFloat>(pow_int, sfpi::RoundMode::Nearest);
+
+        // If pow is odd integer then result is negative
+        // If power is even, then result is positive
+        // To get the sign bit of result, we can shift last bit of pow_int to the 1st bit
+        y = sfpi::setsgn2(y, pow_int);
+
+        // Check for integer power, if it is not then overwrite result with NaN
+        v_if(pow_rounded != pow) {  // negative base and non-integer power => set to NaN
+            y = sfpi::vConstFloatPrgm2;
+        }
+        v_endif;
+    }
+    v_endif;
+
+    return y;
+}
+
+template <int ITERATIONS>
+inline void _sfpu_unary_power_bf16_(const std::uint32_t exponent) {
+    // Convert exponent to float
+    const float pow_scalar = Converter::as_float(exponent);
+    const sfpi::vFloat pow = pow_scalar;
+
+    if (pow_scalar >= 0.0f) {
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vFloat base = sfpi::dst_reg[0];
+            sfpi::dst_reg[0] = _sfpu_unary_power_21f_<true>(base, pow);
+            sfpi::dst_reg++;
+        }
+    } else {
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vFloat base = sfpi::dst_reg[0];
+            sfpi::dst_reg[0] = _sfpu_unary_power_21f_<false>(base, pow);
+            sfpi::dst_reg++;
+        }
+    }
+}
+
+template <int ITERATIONS>
+inline void _sfpu_unary_power_fp32_(const std::uint32_t exponent) {
+    // Convert exponent to float
+    const float pow_scalar = Converter::as_float(exponent);
+    const sfpi::vFloat pow = pow_scalar;
+
+    if (pow_scalar >= 0.0f) {
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vFloat base = sfpi::dst_reg[0];
+            sfpi::dst_reg[0] = _sfpu_unary_power_61f_updated_<true>(base, pow);
+            sfpi::dst_reg++;
+        }
+    } else {
+#pragma GCC unroll 8
+        for (int d = 0; d < ITERATIONS; d++) {
+            sfpi::vFloat base = sfpi::dst_reg[0];
+            sfpi::dst_reg[0] = _sfpu_unary_power_61f_updated_<false>(base, pow);
+            sfpi::dst_reg++;
+        }
+    }
+}
+
+inline void power_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+/**
+ * @brief Compute power operation
+ *
+ * @param exponent The exponent as IEEE 754 float bits (reinterpreted as uint32_t)
+ */
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
+inline void calculate_unary_power(const std::uint32_t exponent) {
+    if constexpr (is_fp32_dest_acc_en) {
+        _sfpu_unary_power_fp32_<ITERATIONS>(exponent);
+    } else {
+        _sfpu_unary_power_bf16_<ITERATIONS>(exponent);
+    }
+}
+
+/**
+ * @brief Compute power operation using iterative approach
+ *
+ * @param exponent Non-negative integer exponent value
+ */
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_unary_power_iterative(const std::uint32_t exponent) {
+    // iterative approach for positive integer exponents
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        sfpi::vFloat in = sfpi::dst_reg[0];
+        if (exponent == 0) {
+            sfpi::dst_reg[0] = 1.0f;
+        } else {
+            sfpi::vFloat result = in;
+            std::uint32_t exp = exponent - 1;
+
+            while (exp > 0) {
+                if (exp & 1) {
+                    result *= in;
+                }
+                in *= in;
+                exp >>= 1;
+            }
+            sfpi::dst_reg[0] = result;
+        }
+        sfpi::dst_reg++;
+    }
+}
+
+inline void sfpu_unary_pow_init() {
+    sfpi::vConstFloatPrgm0 = 1.4426950408889634f;
+    sfpi::vConstFloatPrgm1 = -127.0f;
+    sfpi::vConstFloatPrgm2 = std::numeric_limits<float>::quiet_NaN();
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_shift.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_unary_shift.h
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "cmath_common.h"
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+
+inline void left_shift_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+// Left shift by an immediate scalar amount. If shift amount is >= 32, the result is 0.
+template <bool APPROXIMATION_MODE, DataFormat DATA_FORMAT = DataFormat::Int32, int ITERATIONS = 8>
+inline void calculate_left_shift(const std::uint32_t shift_amt) {
+    static_assert(
+        DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt16,
+        "Unsupported data format for shift operation. Supported data formats are: Int32, UInt16");
+    const bool out_of_range = shift_amt >= 32;
+    // SFPI overloads both `vInt << unsigned` and `vUInt << unsigned`, so the shift amount's type is
+    // independent of the element type being shifted. Cast to a 32-bit `unsigned` so shift is chosen exactly.
+    const unsigned amt = static_cast<unsigned>(shift_amt);
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        if constexpr (DATA_FORMAT == DataFormat::UInt16) {
+            sfpi::vUInt v = sfpi::dst_reg[0].mode<sfpi::DataLayout::U16>();
+            sfpi::dst_reg[0].mode<sfpi::DataLayout::U16>() = out_of_range ? sfpi::vUInt(0u) : (v << amt);
+        } else {
+            sfpi::vInt v = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
+            sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>() = out_of_range ? sfpi::vInt(0) : (v << amt);
+        }
+        sfpi::dst_reg++;
+    }
+}
+
+inline void right_shift_init() { math::_reset_counters_<p_setrwc::SET_ABD_F>(); }
+
+// Arithmetic right shift by an immediate scalar amount.
+// A shift amount >= 32 saturates to the sign (non-negative -> 0, negative -> -1).
+template <bool APPROXIMATION_MODE, DataFormat DATA_FORMAT = DataFormat::Int32, int ITERATIONS = 8>
+inline void calculate_right_shift(const std::uint32_t shift_amt) {
+    static_assert(
+        DATA_FORMAT == DataFormat::Int32 || DATA_FORMAT == DataFormat::UInt16,
+        "Unsupported data format for shift operation. Supported data formats are: Int32, UInt16");
+    // SFPI overloads both `vInt << unsigned` and `vUInt << unsigned`, so the shift amount's type is
+    // independent of the element type being shifted. Cast to a 32-bit `unsigned` so shift is chosen exactly.
+    const unsigned eff = (shift_amt >= 32) ? 31u : static_cast<unsigned>(shift_amt);
+    const unsigned sign_mask = (eff > 0) ? (~0u << (32 - eff)) : 0u;
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        if constexpr (DATA_FORMAT == DataFormat::UInt16) {
+            sfpi::vUInt v = sfpi::dst_reg[0].mode<sfpi::DataLayout::U16>();
+            sfpi::dst_reg[0].mode<sfpi::DataLayout::U16>() = v >> eff;
+        } else {
+            sfpi::vInt v = sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>();
+            sfpi::vUInt res = sfpi::as<sfpi::vUInt>(v) >> eff;
+            v_if(v < 0) { res = res | sign_mask; }
+            v_endif;
+            sfpi::dst_reg[0].mode<sfpi::DataLayout::I32>() = sfpi::as<sfpi::vInt>(res);
+        }
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
@@ -16,18 +16,60 @@
 //    call_unary_sfpu_operation_quasar() (and to init_unary_sfpu_operation_quasar()
 //    if the op needs an init step).
 #include "experimental/ckernel_sfpu_abs.h"
+#include "llk_sfpu/ckernel_sfpu_activations.h"
+#include "llk_sfpu/ckernel_sfpu_add1.h"
+#include "llk_sfpu/ckernel_sfpu_alt_complex_rotate90.h"
+#include "llk_sfpu/ckernel_sfpu_atan2.h"
+#include "llk_sfpu/ckernel_sfpu_binary_bitwise.h"
+#include "llk_sfpu/ckernel_sfpu_binary_fmod.h"
+#include "llk_sfpu/ckernel_sfpu_binary_pow.h"
+#include "llk_sfpu/ckernel_sfpu_binary_remainder.h"
+#include "llk_sfpu/ckernel_sfpu_bitwise.h"
+#include "llk_sfpu/ckernel_sfpu_bitwise_not.h"
+#include "llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h"
+#include "llk_sfpu/ckernel_sfpu_cbrt.h"
+#include "llk_sfpu/ckernel_sfpu_celu.h"
 #include "llk_sfpu/ckernel_sfpu_clamp.h"
 #include "llk_sfpu/ckernel_sfpu_comp.h"
+#include "llk_sfpu/ckernel_sfpu_digamma.h"
+#include "llk_sfpu/ckernel_sfpu_div_int32_floor.h"
+#include "llk_sfpu/ckernel_sfpu_elu.h"
+#include "llk_sfpu/ckernel_sfpu_erfc.h"
+#include "llk_sfpu/ckernel_sfpu_erfinv.h"
 #include "llk_sfpu/ckernel_sfpu_exp.h"
+#include "llk_sfpu/ckernel_sfpu_exp2.h"
+#include "llk_sfpu/ckernel_sfpu_fmod.h"
 #include "llk_sfpu/ckernel_sfpu_gelu.h"
+#include "llk_sfpu/ckernel_sfpu_hardmish.h"
+#include "llk_sfpu/ckernel_sfpu_hardshrink.h"
+#include "llk_sfpu/ckernel_sfpu_i0.h"
+#include "llk_sfpu/ckernel_sfpu_identity.h"
+#include "llk_sfpu/ckernel_sfpu_int_sum.h"
+#include "llk_sfpu/ckernel_sfpu_isclose.h"
+#include "llk_sfpu/ckernel_sfpu_lgamma.h"
+#include "llk_sfpu/ckernel_sfpu_logsigmoid.h"
+#include "llk_sfpu/ckernel_sfpu_mask.h"
 #include "llk_sfpu/ckernel_sfpu_negative.h"
+#include "llk_sfpu/ckernel_sfpu_polygamma.h"
+#include "llk_sfpu/ckernel_sfpu_prelu.h"
+#include "llk_sfpu/ckernel_sfpu_rdiv.h"
 #include "llk_sfpu/ckernel_sfpu_recip.h"
+#include "llk_sfpu/ckernel_sfpu_remainder.h"
+#include "llk_sfpu/ckernel_sfpu_rpow.h"
 #include "llk_sfpu/ckernel_sfpu_rsqrt.h"
+#include "llk_sfpu/ckernel_sfpu_rsub_int32.h"
+#include "llk_sfpu/ckernel_sfpu_selu.h"
 #include "llk_sfpu/ckernel_sfpu_softplus.h"
+#include "llk_sfpu/ckernel_sfpu_softshrink.h"
+#include "llk_sfpu/ckernel_sfpu_softsign.h"
 #include "llk_sfpu/ckernel_sfpu_square.h"
 #include "llk_sfpu/ckernel_sfpu_tanh.h"
+#include "llk_sfpu/ckernel_sfpu_tanhshrink.h"
 #include "llk_sfpu/ckernel_sfpu_trigonometry.h"
 #include "llk_sfpu/ckernel_sfpu_typecast.h"
+#include "llk_sfpu/ckernel_sfpu_unary_comp.h"
+#include "llk_sfpu/ckernel_sfpu_unary_power.h"
+#include "llk_sfpu/ckernel_sfpu_unary_shift.h"
 #include "sfpu/ckernel_sfpu_relu.h"
 #include "sfpu/ckernel_sfpu_sigmoid.h"
 #include "sfpu/ckernel_sfpu_silu.h"
@@ -49,6 +91,15 @@
 #include "sfpu/ckernel_sfpu_add.h"         // _add_int_ (int add)
 #include "sfpu/ckernel_sfpu_binary_comp.h" // calculate_binary_comp_int32 (int gt/lt/le/ge)
 #include "sfpu/ckernel_sfpu_mul_int32.h"   // _mul_int32_ (int mul)
+
+namespace ckernel::sfpu
+{
+template <bool APPROX_MODE, int ITERATIONS>
+inline void calculate_mask_binary_adapter(const std::uint32_t /*src0_tile*/, const std::uint32_t /*src1_tile*/, const std::uint32_t /*dst_tile*/)
+{
+    calculate_mask<APPROX_MODE, ITERATIONS>();
+}
+} // namespace ckernel::sfpu
 
 namespace test_utils
 {
@@ -123,6 +174,162 @@ void init_unary_sfpu_operation_quasar()
     else if constexpr (is_trig_op(OPERATION))
     {
         init_trigonometry<OPERATION, is_fp32_dest_acc_en>();
+    }
+    else if constexpr (OPERATION == SfpuType::add1 || OPERATION == SfpuType::cast_fp32_to_fp16a || OPERATION == SfpuType::identity)
+    {
+        // No initialization required.
+    }
+    else if constexpr (OPERATION == SfpuType::bitwise_not)
+    {
+        bitwise_not_init();
+    }
+    else if constexpr (OPERATION == SfpuType::cbrt)
+    {
+        cube_root_init<APPROX>();
+    }
+    else if constexpr (OPERATION == SfpuType::celu)
+    {
+        celu_init();
+    }
+    else if constexpr (OPERATION == SfpuType::digamma)
+    {
+        digamma_init<APPROX>();
+    }
+    else if constexpr (OPERATION == SfpuType::elu)
+    {
+        elu_init();
+    }
+    else if constexpr (OPERATION == SfpuType::erfc)
+    {
+        erfc_init<APPROX>();
+    }
+    else if constexpr (OPERATION == SfpuType::erfinv)
+    {
+        erfinv_init<APPROX>();
+    }
+    else if constexpr (OPERATION == SfpuType::exp2)
+    {
+        exp2_init<APPROX, is_fp32_dest_acc_en>();
+    }
+    else if constexpr (OPERATION == SfpuType::fmod)
+    {
+        init_fmod<APPROX>(0x40000000u, 0x3f000000u);
+    }
+    else if constexpr (OPERATION == SfpuType::hardmish)
+    {
+        hardmish_init();
+    }
+    else if constexpr (OPERATION == SfpuType::hardshrink)
+    {
+        hardshrink_init();
+    }
+    else if constexpr (OPERATION == SfpuType::i0)
+    {
+        i0_init();
+    }
+    else if constexpr (OPERATION == SfpuType::lgamma)
+    {
+        lgamma_stirling_init<APPROX, is_fp32_dest_acc_en>();
+    }
+    else if constexpr (OPERATION == SfpuType::polygamma)
+    {
+        polygamma_init<APPROX, is_fp32_dest_acc_en>();
+    }
+    else if constexpr (OPERATION == SfpuType::prelu)
+    {
+        prelu_init();
+    }
+    else if constexpr (OPERATION == SfpuType::rpow)
+    {
+        sfpu_binary_pow_init<APPROX>();
+    }
+    else if constexpr (OPERATION == SfpuType::selu)
+    {
+        selu_init();
+    }
+    else if constexpr (OPERATION == SfpuType::softshrink)
+    {
+        softshrink_init();
+    }
+    else if constexpr (OPERATION == SfpuType::softsign)
+    {
+        init_softsign<APPROX>();
+    }
+    else if constexpr (OPERATION == SfpuType::tanhshrink)
+    {
+        tanhshrink_init<APPROX, is_fp32_dest_acc_en>();
+    }
+    else if constexpr (OPERATION == SfpuType::unary_gt)
+    {
+        unary_gt_init();
+    }
+    else if constexpr (OPERATION == SfpuType::unary_ne)
+    {
+        unary_ne_init();
+    }
+    else if constexpr (OPERATION == SfpuType::unary_eq)
+    {
+        unary_eq_init();
+    }
+    else if constexpr (OPERATION == SfpuType::unary_lt)
+    {
+        unary_lt_init();
+    }
+    else if constexpr (OPERATION == SfpuType::unary_ge)
+    {
+        unary_ge_init();
+    }
+    else if constexpr (OPERATION == SfpuType::unary_le)
+    {
+        unary_le_init();
+    }
+    else if constexpr (OPERATION == SfpuType::power)
+    {
+        sfpu_unary_pow_init();
+    }
+    else if constexpr (OPERATION == SfpuType::left_shift)
+    {
+        left_shift_init();
+    }
+    else if constexpr (OPERATION == SfpuType::right_shift)
+    {
+        right_shift_init();
+    }
+    else if constexpr (OPERATION == SfpuType::hardsigmoid)
+    {
+        hardsigmoid_init<APPROX>();
+    }
+    else if constexpr (OPERATION == SfpuType::unary_bitwise_and)
+    {
+        bitwise_and_init();
+    }
+    else if constexpr (OPERATION == SfpuType::unary_bitwise_or)
+    {
+        bitwise_or_init();
+    }
+    else if constexpr (OPERATION == SfpuType::unary_bitwise_xor)
+    {
+        bitwise_xor_init();
+    }
+    else if constexpr (OPERATION == SfpuType::rdiv)
+    {
+        rdiv_init<APPROX>();
+    }
+    else if constexpr (OPERATION == SfpuType::remainder)
+    {
+        init_remainder<APPROX>(0x40000000u, 0x3f000000u);
+    }
+    else if constexpr (OPERATION == SfpuType::alt_complex_rotate90)
+    {
+        alt_complex_rotate90_init();
+    }
+    else if constexpr (OPERATION == SfpuType::int_sum_col || OPERATION == SfpuType::int_sum_row)
+    {
+        sum_int_init<APPROX>();
+    }
+    else
+    {
+        static_assert(unhandled_op<OPERATION>, "unsupported Quasar SFPU operation");
     }
 }
 
@@ -308,9 +515,180 @@ void call_unary_sfpu_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_f
     {
         SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_typecast, (TYPECAST_IN_FORMAT, TYPECAST_OUT_FORMAT, ITERATIONS), dst_index, VectorMode::RC);
     }
+    else if constexpr (OPERATION == SfpuType::add1)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_add1, (APPROX, ITERATIONS), dst_index, VectorMode::RC);
+    }
+    else if constexpr (OPERATION == SfpuType::bitwise_not)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_bitwise_not, (APPROX, ITERATIONS), dst_index, VectorMode::RC);
+    }
+    else if constexpr (OPERATION == SfpuType::cast_fp32_to_fp16a)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, cast_fp32_to_fp16a, (APPROX, ITERATIONS), dst_index, VectorMode::RC);
+    }
+    else if constexpr (OPERATION == SfpuType::cbrt)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_cube_root, (APPROX, is_fp32_dest_acc_en, ITERATIONS), dst_index, VectorMode::RC);
+    }
+    else if constexpr (OPERATION == SfpuType::celu)
+    {
+        SFPU_UNARY_CALL(
+            DST_SYNC, is_fp32_dest_acc_en, calculate_celu, (APPROX, is_fp32_dest_acc_en, ITERATIONS), dst_index, VectorMode::RC, 0x3f800000u, 0x3f800000u);
+    }
+    else if constexpr (OPERATION == SfpuType::digamma)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_digamma, (APPROX, ITERATIONS), dst_index, VectorMode::RC);
+    }
+    else if constexpr (OPERATION == SfpuType::elu)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_elu, (APPROX, is_fp32_dest_acc_en, ITERATIONS), dst_index, VectorMode::RC, 0x3f800000u);
+    }
+    else if constexpr (OPERATION == SfpuType::erfc)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_erfc, (ITERATIONS), dst_index, VectorMode::RC);
+    }
+    else if constexpr (OPERATION == SfpuType::erfinv)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_erfinv, (APPROX), dst_index, VectorMode::RC);
+    }
+    else if constexpr (OPERATION == SfpuType::exp2)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_exp2, (APPROX, is_fp32_dest_acc_en, ITERATIONS), dst_index, VectorMode::RC);
+    }
+    else if constexpr (OPERATION == SfpuType::fmod)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_fmod, (APPROX, ITERATIONS), dst_index, VectorMode::RC);
+    }
+    else if constexpr (OPERATION == SfpuType::hardmish)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, hardmish, (APPROX, ITERATIONS), dst_index, VectorMode::RC);
+    }
+    else if constexpr (OPERATION == SfpuType::hardshrink)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_hardshrink, (APPROX, ITERATIONS), dst_index, VectorMode::RC, 0x3f000000u);
+    }
+    else if constexpr (OPERATION == SfpuType::i0)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_i0, (APPROX, ITERATIONS), dst_index, VectorMode::RC);
+    }
+    else if constexpr (OPERATION == SfpuType::identity)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_identity, (APPROX, ITERATIONS), dst_index, VectorMode::RC);
+    }
+    else if constexpr (OPERATION == SfpuType::lgamma)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_lgamma_stirling, (APPROX, is_fp32_dest_acc_en, ITERATIONS), dst_index, VectorMode::RC);
+    }
+    else if constexpr (OPERATION == SfpuType::polygamma)
+    {
+        SFPU_UNARY_CALL(
+            DST_SYNC, is_fp32_dest_acc_en, calculate_polygamma, (APPROX, is_fp32_dest_acc_en, ITERATIONS), dst_index, VectorMode::RC, 0x3f800000u, 0x3f800000u);
+    }
+    else if constexpr (OPERATION == SfpuType::prelu)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_prelu, (APPROX, ITERATIONS), dst_index, VectorMode::RC, 0x3e800000u);
+    }
+    else if constexpr (OPERATION == SfpuType::rpow)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_rpow, (APPROX, ITERATIONS, is_fp32_dest_acc_en), dst_index, VectorMode::RC, 0x40000000u);
+    }
+    else if constexpr (OPERATION == SfpuType::selu)
+    {
+        SFPU_UNARY_CALL(
+            DST_SYNC, is_fp32_dest_acc_en, calculate_selu, (APPROX, is_fp32_dest_acc_en, ITERATIONS), dst_index, VectorMode::RC, 0x3f867d5fu, 0x3fd62d7du);
+    }
+    else if constexpr (OPERATION == SfpuType::softshrink)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_softshrink, (APPROX, ITERATIONS), dst_index, VectorMode::RC, 0x3f000000u);
+    }
+    else if constexpr (OPERATION == SfpuType::softsign)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_softsign, (APPROX, ITERATIONS), dst_index, VectorMode::RC);
+    }
+    else if constexpr (OPERATION == SfpuType::tanhshrink)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_tanhshrink, (is_fp32_dest_acc_en, ITERATIONS), dst_index, VectorMode::RC);
+    }
+    else if constexpr (OPERATION == SfpuType::unary_gt)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_unary_gt, (APPROX, ITERATIONS), dst_index, VectorMode::RC, 0x3f000000u);
+    }
+    else if constexpr (OPERATION == SfpuType::unary_ne)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_unary_ne, (APPROX, ITERATIONS), dst_index, VectorMode::RC, 0x3f000000u);
+    }
+    else if constexpr (OPERATION == SfpuType::unary_eq)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_unary_eq, (APPROX, ITERATIONS), dst_index, VectorMode::RC, 0x3f000000u);
+    }
+    else if constexpr (OPERATION == SfpuType::unary_lt)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_unary_lt, (APPROX, ITERATIONS), dst_index, VectorMode::RC, 0x3f000000u);
+    }
+    else if constexpr (OPERATION == SfpuType::unary_ge)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_unary_ge, (APPROX, ITERATIONS), dst_index, VectorMode::RC, 0x3f000000u);
+    }
+    else if constexpr (OPERATION == SfpuType::unary_le)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_unary_le, (APPROX, ITERATIONS), dst_index, VectorMode::RC, 0x3f000000u);
+    }
+    else if constexpr (OPERATION == SfpuType::power)
+    {
+        SFPU_UNARY_CALL(
+            DST_SYNC, is_fp32_dest_acc_en, calculate_unary_power, (APPROX, is_fp32_dest_acc_en, ITERATIONS), dst_index, VectorMode::RC, 0x40000000u);
+    }
+    else if constexpr (OPERATION == SfpuType::left_shift)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_left_shift, (APPROX, DataFormat::Int32, ITERATIONS), dst_index, VectorMode::RC, 3u);
+    }
+    else if constexpr (OPERATION == SfpuType::right_shift)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_right_shift, (APPROX, DataFormat::Int32, ITERATIONS), dst_index, VectorMode::RC, 3u);
+    }
+    else if constexpr (OPERATION == SfpuType::hardsigmoid)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_activation, (APPROX, ActivationType::Hardsigmoid, ITERATIONS), dst_index, VectorMode::RC);
+    }
+    else if constexpr (OPERATION == SfpuType::unary_bitwise_and || OPERATION == SfpuType::unary_bitwise_or || OPERATION == SfpuType::unary_bitwise_xor)
+    {
+        constexpr UnaryBitwiseOp op = OPERATION == SfpuType::unary_bitwise_and  ? UnaryBitwiseOp::AND
+                                      : OPERATION == SfpuType::unary_bitwise_or ? UnaryBitwiseOp::OR
+                                                                                : UnaryBitwiseOp::XOR;
+        SFPU_UNARY_CALL(
+            DST_SYNC, is_fp32_dest_acc_en, calculate_sfpu_unary_bitwise, (APPROX, op, DataFormat::Int32, ITERATIONS), dst_index, VectorMode::RC, 0x55555555u);
+    }
+    else if constexpr (OPERATION == SfpuType::rdiv)
+    {
+        SFPU_UNARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_rdiv,
+            (APPROX, is_fp32_dest_acc_en, RoundingMode::None, ITERATIONS),
+            dst_index,
+            VectorMode::RC,
+            0x40000000u);
+    }
+    else if constexpr (OPERATION == SfpuType::remainder)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_remainder, (APPROX, ITERATIONS), dst_index, VectorMode::RC);
+    }
+    else if constexpr (OPERATION == SfpuType::alt_complex_rotate90)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_alt_complex_rotate90, (APPROX, 4), dst_index, VectorMode::RC);
+    }
+    else if constexpr (OPERATION == SfpuType::int_sum_col)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_sum_int_col, (APPROX), dst_index, VectorMode::R);
+    }
+    else if constexpr (OPERATION == SfpuType::int_sum_row)
+    {
+        SFPU_UNARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_sum_int_row, (APPROX), dst_index, VectorMode::C);
+    }
     else
     {
-        static_assert(unhandled_op<OPERATION>, "call_unary_sfpu_operation_quasar: unhandled Quasar unary SFPU operation");
+        static_assert(unhandled_op<OPERATION>, "unsupported Quasar SFPU operation");
     }
 }
 
@@ -357,7 +735,7 @@ constexpr ckernel::sfpu::QuantVariant quant_variant_of()
  *        other ops, which have no runtime init argument.
  * @note Pair with @ref call_binary_sfpu_operation_quasar for the calculate step.
  */
-template <ckernel::BinaryOp OP, bool SIGN_MAGNITUDE_FORMAT = false>
+template <ckernel::BinaryOp OP, bool SIGN_MAGNITUDE_FORMAT = false, bool is_fp32_dest_acc_en = false>
 void init_binary_sfpu_operation_quasar([[maybe_unused]] std::uint32_t zero_point = 0)
 {
     if constexpr (OP == BinaryOp::MUL)
@@ -377,7 +755,54 @@ void init_binary_sfpu_operation_quasar([[maybe_unused]] std::uint32_t zero_point
         // One op-templated quant kernel; DEQUANT's caller passes bits of -zero_point.
         quant_family_init<quant_variant_of<OP>(), SIGN_MAGNITUDE_FORMAT>(zero_point);
     }
-    // ADD / SUB / GT / LT / LE / GE are stateless — no init.
+    else if constexpr (OP == BinaryOp::ADD || OP == BinaryOp::SUB || OP == BinaryOp::GT || OP == BinaryOp::LT || OP == BinaryOp::LE || OP == BinaryOp::GE)
+    {
+        // No initialization required.
+    }
+    else if constexpr (OP == BinaryOp::BITWISE_AND || OP == BinaryOp::BITWISE_OR || OP == BinaryOp::BITWISE_XOR || OP == BinaryOp::RSUB_INT32)
+    {
+        // No initialization required.
+    }
+    else if constexpr (OP == BinaryOp::ATAN2)
+    {
+        calculate_sfpu_atan2_init<false, is_fp32_dest_acc_en>();
+    }
+    else if constexpr (OP == BinaryOp::FMOD)
+    {
+        fmod_binary_init<false>();
+    }
+    else if constexpr (OP == BinaryOp::POW)
+    {
+        sfpu_binary_pow_init<false>();
+    }
+    else if constexpr (OP == BinaryOp::REMAINDER)
+    {
+        remainder_binary_init<false, is_fp32_dest_acc_en>();
+    }
+    else if constexpr (OP == BinaryOp::DIV_INT32)
+    {
+        div_trunc_init<false>();
+    }
+    else if constexpr (OP == BinaryOp::DIV_INT32_FLOOR)
+    {
+        div_floor_init<false>();
+    }
+    else if constexpr (OP == BinaryOp::ISCLOSE)
+    {
+        isclose_init();
+    }
+    else if constexpr (OP == BinaryOp::LOGSIGMOID)
+    {
+        logsigmoid_init<false>();
+    }
+    else if constexpr (OP == BinaryOp::MASK)
+    {
+        mask_init();
+    }
+    else
+    {
+        static_assert(unhandled_op<OP>, "unsupported Quasar SFPU operation");
+    }
 }
 
 /**
@@ -530,9 +955,93 @@ void call_binary_sfpu_operation_quasar(std::uint32_t src0_tile, std::uint32_t sr
                 VectorMode::RC);
         }
     }
+    else if constexpr (OP == BinaryOp::ATAN2)
+    {
+        SFPU_BINARY_CALL(
+            DST_SYNC, is_fp32_dest_acc_en, calculate_sfpu_atan2, (false, ITERATIONS, is_fp32_dest_acc_en), src0_tile, src1_tile, dst_tile, VectorMode::RC);
+    }
+    else if constexpr (OP == BinaryOp::BITWISE_AND || OP == BinaryOp::BITWISE_OR || OP == BinaryOp::BITWISE_XOR)
+    {
+        constexpr BinaryBitwiseOp op = OP == BinaryOp::BITWISE_AND  ? BinaryBitwiseOp::AND
+                                       : OP == BinaryOp::BITWISE_OR ? BinaryBitwiseOp::OR
+                                                                    : BinaryBitwiseOp::XOR;
+        SFPU_BINARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_sfpu_binary_bitwise,
+            (false, op, InstrModLoadStore::INT32, ITERATIONS),
+            src0_tile,
+            src1_tile,
+            dst_tile,
+            VectorMode::RC);
+    }
+    else if constexpr (OP == BinaryOp::FMOD)
+    {
+        SFPU_BINARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_sfpu_binary_fmod,
+            (false, ITERATIONS, is_fp32_dest_acc_en),
+            src0_tile,
+            src1_tile,
+            dst_tile,
+            VectorMode::RC);
+    }
+    else if constexpr (OP == BinaryOp::POW)
+    {
+        SFPU_BINARY_CALL(
+            DST_SYNC, is_fp32_dest_acc_en, calculate_sfpu_binary_pow, (false, ITERATIONS, is_fp32_dest_acc_en), src0_tile, src1_tile, dst_tile, VectorMode::RC);
+    }
+    else if constexpr (OP == BinaryOp::REMAINDER)
+    {
+        SFPU_BINARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_sfpu_binary_remainder,
+            (false, ITERATIONS, is_fp32_dest_acc_en),
+            src0_tile,
+            src1_tile,
+            dst_tile,
+            VectorMode::RC);
+    }
+    else if constexpr (OP == BinaryOp::DIV_INT32)
+    {
+        SFPU_BINARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_div_int32_trunc, (false, ITERATIONS), src0_tile, src1_tile, dst_tile, VectorMode::RC);
+    }
+    else if constexpr (OP == BinaryOp::DIV_INT32_FLOOR)
+    {
+        SFPU_BINARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_div_int32_floor, (false, ITERATIONS), src0_tile, src1_tile, dst_tile, VectorMode::RC);
+    }
+    else if constexpr (OP == BinaryOp::ISCLOSE)
+    {
+        SFPU_BINARY_CALL(
+            DST_SYNC,
+            is_fp32_dest_acc_en,
+            calculate_sfpu_isclose,
+            (false, ITERATIONS, false),
+            src0_tile,
+            src1_tile,
+            dst_tile,
+            VectorMode::RC,
+            0x3727c5acu,
+            0x322bcc77u);
+    }
+    else if constexpr (OP == BinaryOp::LOGSIGMOID)
+    {
+        SFPU_BINARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_logsigmoid, (false, ITERATIONS), src0_tile, src1_tile, dst_tile, VectorMode::RC);
+    }
+    else if constexpr (OP == BinaryOp::MASK)
+    {
+        SFPU_BINARY_CALL(DST_SYNC, is_fp32_dest_acc_en, calculate_mask_binary_adapter, (false, ITERATIONS), src0_tile, src1_tile, dst_tile, VectorMode::RC);
+    }
+    else if constexpr (OP == BinaryOp::RSUB_INT32)
+    {
+        SFPU_BINARY_CALL(
+            DST_SYNC, is_fp32_dest_acc_en, calculate_rsub_int, (false, InstrModLoadStore::INT32, ITERATIONS), src0_tile, src1_tile, dst_tile, VectorMode::RC);
+    }
     else
     {
-        static_assert(unhandled_op<OP>, "call_binary_sfpu_operation_quasar: unhandled Quasar binary SFPU operation");
+        static_assert(unhandled_op<OP>, "unsupported Quasar SFPU operation");
     }
 }
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
@@ -216,6 +216,12 @@ class MathOperation(Enum):
     UnaryMaxUint32 = OpSpec("unary_max_uint32", MathOpType.SFPU_UNARY)
     UnaryMinUint32 = OpSpec("unary_min_uint32", MathOpType.SFPU_UNARY)
     BitwiseNot = OpSpec("bitwise_not", MathOpType.SFPU_UNARY)
+    UnaryBitwiseAnd = OpSpec("unary_bitwise_and", MathOpType.SFPU_UNARY)
+    UnaryBitwiseOr = OpSpec("unary_bitwise_or", MathOpType.SFPU_UNARY)
+    UnaryBitwiseXor = OpSpec("unary_bitwise_xor", MathOpType.SFPU_UNARY)
+    AltComplexRotate90 = OpSpec("alt_complex_rotate90", MathOpType.SFPU_UNARY)
+    IntSumCol = OpSpec("int_sum_col", MathOpType.SFPU_UNARY)
+    IntSumRow = OpSpec("int_sum_row", MathOpType.SFPU_UNARY)
     # logical_not(x) = (x == 0) ? 1 : 0, exercised on the float (DEFAULT-layout)
     # path. cpp_enum_value must match the SfpuType enumerator name.
     # NOTE: main added `LogicalNot` with the same cpp value; keep both so

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -497,6 +497,12 @@ _OP_DOMAIN_REGISTRY: Dict[
     MathOperation.UnaryLe: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-2.0, high=2.0)
     ),
+    MathOperation.UnaryNe: OperandSpecs(
+        spec_A=StimuliSpec.custom(values=[-2.0, -1.0, 0.0, 0.5, 1.0, 2.0], seed=0)
+    ),
+    MathOperation.UnaryEq: OperandSpecs(
+        spec_A=StimuliSpec.custom(values=[-2.0, -1.0, 0.0, 0.5, 1.0, 2.0], seed=0)
+    ),
     # unary max/min against value 0.0; span both signs
     MathOperation.UnaryMax: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-5.0, high=5.0)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -13,6 +13,7 @@ from .llk_params import (
     FPU_BINARY_OPERATIONS,
     REDUCE_OPERATIONS,
     SFPU_BINARY_OPERATIONS,
+    SFPU_TERNARY_OPERATIONS,
     SFPU_UNARY_OPERATIONS,
     ApproximationMode,
     BroadcastType,
@@ -172,6 +173,10 @@ def _generate_operation_constants(mathop: MathOperation) -> list[str]:
     elif mathop in SFPU_BINARY_OPERATIONS:
         constants.append(
             f"constexpr auto SFPU_BINARY_OPERATION = ckernel::BinaryOp::{mathop.cpp_enum_value};"
+        )
+    elif mathop in SFPU_TERNARY_OPERATIONS:
+        constants.append(
+            f"constexpr auto SFPU_TERNARY_OPERATION = SfpuType::{mathop.cpp_enum_value};"
         )
     elif mathop in FPU_BINARY_OPERATIONS:
         constants.append(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_sfpu_quasar.py
@@ -958,3 +958,111 @@ def test_eltwise_binary_sfpu_quant_quasar(binary_op, sign_magnitude, tile_indice
     (dequant). Exercised on both the 2's-complement and SIGN_MAGNITUDE_FORMAT
     (SMAG32) datapaths."""
     _run_quant(binary_op, tile_indices, sign_magnitude)
+
+
+EXTENDED_SFPU_BINARY_CASES = (
+    (MathOperation.SfpuAtan2, DataFormat.Float16_b),
+    (MathOperation.SfpuBitwiseAnd, DataFormat.Int32),
+    (MathOperation.SfpuBitwiseOr, DataFormat.Int32),
+    (MathOperation.SfpuBitwiseXor, DataFormat.Int32),
+    (MathOperation.SfpuBinaryFmod, DataFormat.Float16_b),
+    (MathOperation.SfpuElwpow, DataFormat.Float16_b),
+    (MathOperation.SfpuBinaryRemainder, DataFormat.Float16_b),
+    # SfpuDivInt32 deliberately covers calculate_div_int32_trunc from the
+    # div_int32_floor header, matching the Blackhole test named SfpuDivInt32.
+    # The separate div_int32 header has a float-output contract and is skipped.
+    (MathOperation.SfpuDivInt32, DataFormat.Int32),
+    (MathOperation.SfpuDivInt32Floor, DataFormat.Int32),
+    (MathOperation.SfpuIsclose, DataFormat.Float16_b),
+    (MathOperation.SfpuLogsigmoid, DataFormat.Float16_b),
+    (MathOperation.SfpuMask, DataFormat.Float16_b),
+    (MathOperation.SfpuRsubInt32, DataFormat.Int32),
+)
+
+
+def _extended_binary_specs_for(mathop):
+    if mathop in {
+        MathOperation.SfpuBitwiseAnd,
+        MathOperation.SfpuBitwiseOr,
+        MathOperation.SfpuBitwiseXor,
+        MathOperation.SfpuRsubInt32,
+    }:
+        spec = StimuliSpec.uniform(low=-1_000_000, high=1_000_000)
+        return spec, spec
+    if mathop in {MathOperation.SfpuDivInt32, MathOperation.SfpuDivInt32Floor}:
+        return StimuliSpec.uniform(low=1, high=1_000_000), StimuliSpec.uniform(
+            low=1, high=10_000
+        )
+    if mathop == MathOperation.SfpuAtan2:
+        spec = StimuliSpec.uniform(low=-5.0, high=5.0)
+        return spec, spec
+    if mathop in {
+        MathOperation.SfpuBinaryFmod,
+        MathOperation.SfpuBinaryRemainder,
+    }:
+        return StimuliSpec.uniform(low=-5.0, high=5.0), StimuliSpec.uniform(
+            low=0.5, high=4.0
+        )
+    if mathop == MathOperation.SfpuElwpow:
+        return StimuliSpec.uniform(low=0.25, high=4.0), StimuliSpec.uniform(
+            low=-2.0, high=2.0
+        )
+    spec = StimuliSpec.uniform(low=-4.0, high=4.0)
+    return spec, spec
+
+
+def _prepare_extended_binary_stimuli(
+    formats, _input_dimensions, src0_idx, src1_idx, mathop
+):
+    spec_A, spec_B = _extended_binary_specs_for(mathop)
+    operand_A, _, operand_B, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=[32, 32],
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=[32, 32],
+        spec_A=spec_A,
+        spec_B=spec_B,
+    )
+
+    flat_A = operand_A.flatten()
+    flat_B = operand_B.flatten()
+    if mathop == MathOperation.SfpuIsclose:
+        # Equal, within-tolerance, and clearly-different lanes keep both result
+        # branches live. The remaining random pairs are intentionally far apart.
+        flat_A[:6] = torch.tensor([0.0, 1.0, -1.0, 100.0, 2.0, -3.0])
+        flat_B[:6] = torch.tensor([0.0, 1.0, -1.0, 100.0, 2.5, -4.0])
+    elif mathop == MathOperation.SfpuLogsigmoid:
+        flat_A[:] = torch.linspace(-8.0, 3.9, MAX_TILE_ELEMENTS)
+        flat_B[:] = torch.exp(-flat_A.to(torch.float32)).to(flat_B.dtype)
+    elif mathop == MathOperation.SfpuMask:
+        flat_B[::2] = 0.0
+        flat_B[1::2] = 1.0
+
+    staged, tile_count = _stage_binary_operands(
+        flat_A, flat_B, (src0_idx, src1_idx, 0), flat_A.dtype
+    )
+    # buffer_B is unused by this UNPACK-to-DEST kernel, but the shared driver
+    # allocates it with the same tile count as staged buffer_A.
+    return staged, tile_count, torch.zeros_like(staged)
+
+
+@pytest.mark.quasar
+@pytest.mark.parametrize(
+    "mathop,data_format",
+    EXTENDED_SFPU_BINARY_CASES,
+    ids=[mathop.name for mathop, _ in EXTENDED_SFPU_BINARY_CASES],
+)
+def test_eltwise_binary_sfpu_extended_quasar(mathop, data_format):
+    torch.manual_seed(0)
+    formats = InputOutputFormat(data_format, data_format)
+    dest_acc = DestAccumulation.Yes if data_format.is_32_bit() else DestAccumulation.No
+
+    _run_sfpu_binary_llk_golden(
+        formats,
+        dest_acc,
+        ImpliedMathFormat.No,
+        DEFAULT_SFPU_BINARY_TILE_INDICES,
+        mathop,
+        binary_op=mathop.cpp_enum_value,
+        prepare_stimuli=_prepare_extended_binary_stimuli,
+    )

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
@@ -27,6 +27,7 @@ from helpers.param_config import (
     runtime,
 )
 from helpers.perf.core import create_test_or_perf_config
+from helpers.sfpu_domains import exclude_undefined, for_op_pipeline
 from helpers.stimuli_config import StimuliConfig
 from helpers.stimuli_generator import (
     StimuliSpec,
@@ -50,6 +51,7 @@ from helpers.test_variant_parameters import (
     UNPACKER_ENGINE_SEL,
 )
 from helpers.tile_constants import MAX_NUM_FACES
+from helpers.tilize_untilize import untilize
 from helpers.utils import passed_test
 
 
@@ -953,3 +955,261 @@ def test_eltwise_unary_sfpu_quasar(
         res_tensor,
         formats.output_format,
     ), "Assert against golden failed"
+
+
+# Omitted operations are intentional and reported with architecture-specific
+# reasons in the coverage report; keeping them out prevents known-invalid QSR
+# behavior from masquerading as passing coverage.
+EXTENDED_SFPU_UNARY_CASES = (
+    MathOperation.Add1,
+    MathOperation.BitwiseNot,
+    MathOperation.CastFp32ToFp16a,
+    MathOperation.Cbrt,
+    MathOperation.Celu,
+    MathOperation.Digamma,
+    MathOperation.Elu,
+    MathOperation.Erfc,
+    MathOperation.Erfinv,
+    MathOperation.Exp2,
+    MathOperation.Fmod,
+    MathOperation.Hardmish,
+    MathOperation.Hardshrink,
+    MathOperation.I0,
+    MathOperation.Identity,
+    MathOperation.Lgamma,
+    MathOperation.Polygamma,
+    MathOperation.Prelu,
+    MathOperation.Rpow,
+    MathOperation.Selu,
+    MathOperation.Softshrink,
+    MathOperation.Softsign,
+    MathOperation.Tanhshrink,
+    MathOperation.UnaryGt,
+    MathOperation.UnaryNe,
+    MathOperation.UnaryEq,
+    MathOperation.UnaryLt,
+    MathOperation.UnaryGe,
+    MathOperation.UnaryLe,
+    MathOperation.UnaryPower,
+    MathOperation.LeftShift,
+    MathOperation.RightShift,
+    MathOperation.Hardsigmoid,
+    MathOperation.UnaryBitwiseAnd,
+    MathOperation.UnaryBitwiseOr,
+    MathOperation.UnaryBitwiseXor,
+    MathOperation.Rdiv,
+    MathOperation.Remainder,
+    MathOperation.AltComplexRotate90,
+    MathOperation.IntSumCol,
+    MathOperation.IntSumRow,
+)
+
+EXTENDED_INTEGER_OPS = {
+    MathOperation.BitwiseNot,
+    MathOperation.UnaryBitwiseAnd,
+    MathOperation.UnaryBitwiseOr,
+    MathOperation.UnaryBitwiseXor,
+    MathOperation.LeftShift,
+    MathOperation.RightShift,
+    MathOperation.IntSumCol,
+    MathOperation.IntSumRow,
+}
+
+
+def _extended_formats_for(mathop):
+    if mathop in EXTENDED_INTEGER_OPS:
+        return InputOutputFormat(DataFormat.Int32, DataFormat.Int32)
+    if mathop == MathOperation.CastFp32ToFp16a:
+        # The SFPI conversion narrows mantissa precision in an FP32 LReg; keeping
+        # FP32 output makes that conversion directly observable.
+        return InputOutputFormat(DataFormat.Float32, DataFormat.Float32)
+    return InputOutputFormat(DataFormat.Float16_b, DataFormat.Float16_b)
+
+
+def _extended_stimuli_for(mathop, formats):
+    if mathop in {
+        MathOperation.BitwiseNot,
+        MathOperation.UnaryBitwiseAnd,
+        MathOperation.UnaryBitwiseOr,
+        MathOperation.UnaryBitwiseXor,
+    }:
+        return StimuliSpec.uniform(low=-(2**30), high=2**30 - 1)
+    if mathop in (MathOperation.LeftShift, MathOperation.RightShift):
+        # Keep left-shift-by-three in signed int32 range.
+        return StimuliSpec.uniform(low=-(2**27), high=2**27 - 1)
+    if mathop in {MathOperation.IntSumCol, MathOperation.IntSumRow}:
+        # Keep the 32-element reduction far from int32 overflow while spanning
+        # both signs and every face of the tile.
+        return StimuliSpec.uniform(low=-1_000_000, high=1_000_000)
+    if mathop == MathOperation.AltComplexRotate90:
+        return StimuliSpec.uniform(low=-4.0, high=4.0)
+    return exclude_undefined(
+        mathop,
+        for_op_pipeline(mathop, formats.input_format, formats.output_format).spec_A,
+    )
+
+
+@pytest.mark.quasar
+@pytest.mark.parametrize(
+    "mathop",
+    EXTENDED_SFPU_UNARY_CASES,
+    ids=[mathop.name for mathop in EXTENDED_SFPU_UNARY_CASES],
+)
+def test_eltwise_unary_sfpu_extended_quasar(mathop):
+    torch.manual_seed(0)
+
+    formats = _extended_formats_for(mathop)
+    input_dimensions = [32, 32]
+    dest_acc = (
+        DestAccumulation.Yes
+        if formats.input_format.is_32_bit()
+        else DestAccumulation.No
+    )
+    unpack_to_dest = formats.input_format.is_32_bit()
+
+    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+        spec_A=_extended_stimuli_for(mathop, formats),
+    )
+
+    # Pin discontinuities and previously uncovered branches into every run.
+    flat = src_A.flatten()
+    if mathop in {
+        MathOperation.Sign,
+        MathOperation.Heaviside,
+        MathOperation.UnaryGt,
+        MathOperation.UnaryNe,
+        MathOperation.UnaryEq,
+        MathOperation.UnaryLt,
+        MathOperation.UnaryGe,
+        MathOperation.UnaryLe,
+    }:
+        flat[:6] = torch.tensor([-1.0, -0.0, 0.0, 0.5, 1.0, 2.0], dtype=flat.dtype)
+    elif mathop == MathOperation.I1:
+        # Blackhole's existing sweep only reaches the central polynomial. These
+        # lanes also exercise both signs of the asymptotic helper path.
+        flat[:6] = torch.tensor([-20.0, -10.0, -4.0, 4.0, 10.0, 20.0], dtype=flat.dtype)
+
+    if mathop == MathOperation.BitwiseNot:
+        golden_tensor = torch.bitwise_not(src_A.to(torch.int32)).flatten()
+    elif mathop == MathOperation.UnaryBitwiseAnd:
+        golden_tensor = torch.bitwise_and(
+            src_A.to(torch.int32), torch.tensor(0x55555555, dtype=torch.int32)
+        ).flatten()
+    elif mathop == MathOperation.UnaryBitwiseOr:
+        golden_tensor = torch.bitwise_or(
+            src_A.to(torch.int32), torch.tensor(0x55555555, dtype=torch.int32)
+        ).flatten()
+    elif mathop == MathOperation.UnaryBitwiseXor:
+        golden_tensor = torch.bitwise_xor(
+            src_A.to(torch.int32), torch.tensor(0x55555555, dtype=torch.int32)
+        ).flatten()
+    elif mathop == MathOperation.AltComplexRotate90:
+        golden_tensor = src_A.clone()
+        golden_tensor[0::2] = -src_A[1::2]
+        golden_tensor[1::2] = src_A[0::2]
+        golden_tensor = golden_tensor.flatten()
+    elif mathop in {MathOperation.IntSumCol, MathOperation.IntSumRow}:
+        # int_sum reduces the SFPU's row/column lane groups, producing partial
+        # reductions in a subset of DEST. Convert the face-tilized input back
+        # to row-major before calculating those groups.
+        input_matrix = (
+            untilize(src_A, stimuli_format=DataFormat.Int32)
+            .reshape(32, 32)
+            .to(torch.int64)
+        )
+        if mathop == MathOperation.IntSumCol:
+            golden_tensor = torch.stack(
+                [input_matrix[row::4, :].sum(dim=0) for row in range(4)]
+            ).to(torch.int32)
+        else:
+            golden_tensor = (
+                input_matrix[:, 0:16:2]
+                + input_matrix[:, 1:16:2]
+                + input_matrix[:, 16:32:2]
+                + input_matrix[:, 17:32:2]
+            ).to(torch.int32)
+    else:
+        generate_golden = get_golden_generator(UnarySFPUGolden)
+        golden_tensor = generate_golden(
+            mathop,
+            src_A,
+            formats.output_format,
+            dest_acc,
+            formats.input_format,
+            input_dimensions,
+        )
+
+    test_config_kwargs = {
+        "test_name": "sources/quasar/eltwise_unary_sfpu_quasar_test.cpp",
+        "formats": formats,
+        "templates": [
+            MATH_OP(mathop=mathop),
+            APPROX_MODE(
+                ApproximationMode.Yes
+                if mathop == MathOperation.I1
+                else ApproximationMode.No
+            ),
+            IMPLIED_MATH_FORMAT(ImpliedMathFormat.Yes),
+            DATA_COPY_TYPE(DataCopyType.A2D),
+            UNPACKER_ENGINE_SEL(
+                UnpackerEngine.UnpDest if unpack_to_dest else UnpackerEngine.UnpA
+            ),
+            DEST_SYNC(DestSync.Half),
+            TYPECAST_FORMATS(),
+        ],
+        "runtimes": [
+            TILE_COUNT(tile_cnt_A),
+            NUM_FACES(MAX_NUM_FACES),
+            TEST_FACE_DIMS(),
+            DEST_INDEX(0),
+            LOOP_FACTOR(1),
+        ],
+        "variant_stimuli": StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_B,
+            tile_count_res=tile_cnt_A,
+            num_faces=MAX_NUM_FACES,
+            twos_complement=formats.input_format.is_integer(),
+        ),
+        "unpack_to_dest": unpack_to_dest,
+        "dest_acc": dest_acc,
+    }
+
+    configuration = create_test_or_perf_config(
+        is_perf=False,
+        run_types=(PerfRunType.L1_TO_L1,),
+        test_config_kwargs=test_config_kwargs,
+    )
+    result = configuration.run().result
+
+    result_tensor = torch.tensor(result, dtype=format_dict[formats.output_format])
+    if mathop == MathOperation.IntSumCol:
+        result_matrix = untilize(
+            result_tensor, stimuli_format=DataFormat.Int32
+        ).reshape(32, 32)
+        reduced_result = result_matrix[:4, :]
+        assert torch.equal(golden_tensor, reduced_result), (
+            f"int_sum_col mismatch: expected={golden_tensor.tolist()}, "
+            f"actual={reduced_result.tolist()}"
+        )
+    elif mathop == MathOperation.IntSumRow:
+        result_matrix = untilize(
+            result_tensor, stimuli_format=DataFormat.Int32
+        ).reshape(32, 32)
+        reduced_result = result_matrix[:, 0:16:2]
+        assert torch.equal(golden_tensor, reduced_result), (
+            f"int_sum_row mismatch: expected={golden_tensor.tolist()}, "
+            f"actual={reduced_result.tolist()}"
+        )
+    else:
+        assert len(result_tensor) == len(golden_tensor)
+        assert passed_test(golden_tensor, result_tensor, formats.output_format)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_where_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_where_quasar.py
@@ -1,10 +1,16 @@
 # SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 # SPDX-License-Identifier: Apache-2.0
 
+import struct
+
 import pytest
 import torch
 from helpers.format_config import DataFormat, FormatConfig
-from helpers.golden_generators import WhereGolden, get_golden_generator
+from helpers.golden_generators import (
+    TernarySFPUGolden,
+    WhereGolden,
+    get_golden_generator,
+)
 from helpers.llk_params import (
     DataCopyType,
     DestAccumulation,
@@ -15,13 +21,14 @@ from helpers.llk_params import (
     format_dict,
 )
 from helpers.param_config import (
+    InputOutputFormat,
     generate_sfpu_format_dest_acc_combinations,
     input_output_formats,
     parametrize,
     runtime,
 )
 from helpers.stimuli_config import StimuliConfig
-from helpers.stimuli_generator import generate_stimuli
+from helpers.stimuli_generator import StimuliSpec, generate_stimuli
 from helpers.test_config import TestConfig
 from helpers.test_variant_parameters import (
     DATA_COPY_TYPE,
@@ -305,3 +312,92 @@ def test_sfpu_where_mcw_quasar(
     assert passed_test(
         golden_tensor[mask], res_tensor[mask], formats.output_format
     ), "Assert against golden failed"
+
+
+EXTENDED_SFPU_TERNARY_CASES = (
+    MathOperation.SfpuAddcmul,
+    MathOperation.SfpuAddcdiv,
+    MathOperation.SfpuLerp,
+    MathOperation.SfpuSnakeBeta,
+)
+_SCALAR_BITS = struct.unpack("<I", struct.pack("<f", 2.0))[0]
+
+
+@pytest.mark.quasar
+@pytest.mark.parametrize(
+    "mathop",
+    EXTENDED_SFPU_TERNARY_CASES,
+    ids=[mathop.name for mathop in EXTENDED_SFPU_TERNARY_CASES],
+)
+def test_sfpu_ternary_extended_quasar(mathop):
+    torch.manual_seed(0)
+    formats = InputOutputFormat(DataFormat.Float16_b, DataFormat.Float16_b)
+    spec_ab = StimuliSpec.uniform(low=-1.0, high=1.0)
+    spec_c = (
+        StimuliSpec.uniform(low=1.0, high=2.0)
+        if mathop in {MathOperation.SfpuAddcdiv, MathOperation.SfpuSnakeBeta}
+        else spec_ab
+    )
+
+    src_A, tile_count, src_B, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=[32, 32],
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=[32, 32],
+        spec_A=spec_ab,
+        spec_B=spec_ab,
+    )
+    src_C, _, _, _ = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=[32, 32],
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=[32, 32],
+        spec_A=spec_c,
+        spec_B=spec_c,
+    )
+
+    golden = get_golden_generator(TernarySFPUGolden)(
+        mathop, src_A, src_B, src_C, _SCALAR_BITS, formats.output_format
+    )
+    staged = torch.cat([src_A.flatten(), src_B.flatten(), src_C.flatten()])
+
+    configuration = TestConfig(
+        "sources/quasar/sfpu_where_quasar_test.cpp",
+        formats,
+        templates=[
+            MATH_OP(mathop=mathop),
+            IMPLIED_MATH_FORMAT(ImpliedMathFormat.No),
+            DATA_COPY_TYPE(DataCopyType.A2D),
+            UNPACKER_ENGINE_SEL(UnpackerEngine.UnpA),
+            DEST_SYNC(),
+            VECTOR_MODE(VectorMode.RC),
+        ],
+        runtimes=[
+            TILE_COUNT(3),
+            NUM_FACES(4),
+            TEST_FACE_DIMS(),
+            DEST_INDEX(0),
+        ],
+        variant_stimuli=StimuliConfig(
+            staged,
+            formats.input_format,
+            torch.zeros_like(src_A),
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=3,
+            tile_count_B=tile_count,
+            tile_count_res=tile_count,
+            num_faces=4,
+        ),
+        unpack_to_dest=False,
+        dest_acc=DestAccumulation.No,
+    )
+
+    result = torch.tensor(
+        configuration.run().result, dtype=format_dict[formats.output_format]
+    )
+    golden_tensor = torch.tensor(
+        golden, dtype=format_dict[formats.output_format]
+    ).flatten()
+    assert len(result) == len(golden_tensor)
+    assert passed_test(golden_tensor, result, formats.output_format)

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
@@ -219,7 +219,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // ADDR_MOD_0/1 or bank-0 programming, so both initializers can remain in
         // the INIT zone before the measured TILE_LOOP.
         _llk_math_eltwise_sfpu_init_();
-        test_utils::init_binary_sfpu_operation_quasar<SFPU_BINARY_OP, SFPU_SIGN_MAGNITUDE>(params.ZERO_POINT);
+        test_utils::init_binary_sfpu_operation_quasar<SFPU_BINARY_OP, SFPU_SIGN_MAGNITUDE, is_fp32_dest_acc_en>(params.ZERO_POINT);
         PROFILER_SYNC();
     }
     {
@@ -289,7 +289,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t DST_TILE_IDX    = params.DST_TILE_IDX;
     const Operand& buffer_Res           = params.buffer_Res;
 #endif
-    std::uint32_t const buf_desc_id        = 8;
+    const std::uint32_t buf_desc_id        = 8;
     const std::uint32_t num_tiles_per_pack = 1; // only the SFPU result tile is packed
 
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_where_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_where_quasar_test.cpp
@@ -81,6 +81,10 @@ const bool is_int_fpu_en = false;
 #include "cmath_common.h"
 #include "llk_math_common.h"
 #include "llk_math_eltwise_unary_datacopy.h"
+#include "llk_sfpu/ckernel_sfpu_addcdiv.h"
+#include "llk_sfpu/ckernel_sfpu_addcmul.h"
+#include "llk_sfpu/ckernel_sfpu_lerp.h"
+#include "llk_sfpu/ckernel_sfpu_snake_beta.h"
 #include "llk_sfpu/ckernel_sfpu_where.h"
 #include "llk_sfpu/llk_math_eltwise_ternary_sfpu_macros.h"
 #include "params.h"
@@ -120,22 +124,86 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
     }
 
-    _llk_math_eltwise_ternary_sfpu_init_<SfpuType::where>();
+    _llk_math_eltwise_ternary_sfpu_init_<SFPU_TERNARY_OPERATION>();
 
-    // Runs calculate_where over the faces selected by VECTOR_MODE: cond=base+0,
-    // true_val=base+1, false_val=base+2, result written to base+0. Faces
-    // outside the selected set keep whatever the producer wrote into Dest before
-    // SFPU ran (the cond tile, here), so Python asserts only processed faces.
-    SFPU_TERNARY_CALL(
-        dest_sync,
-        is_fp32_dest_acc_en,
-        calculate_where,
-        (false /*APPROXIMATION_MODE*/),
-        params.DST_INDEX + 0u /*DST_IN0*/,
-        params.DST_INDEX + 1u /*DST_IN1*/,
-        params.DST_INDEX + 2u /*DST_IN2*/,
-        params.DST_INDEX + 0u /*DST_OUT*/,
-        VECTOR_MODE);
+    if constexpr (SFPU_TERNARY_OPERATION == SfpuType::addcdiv)
+    {
+        init_addcdiv<false /*APPROXIMATION_MODE*/>();
+    }
+    else if constexpr (SFPU_TERNARY_OPERATION == SfpuType::snake_beta)
+    {
+        snake_beta_init<false /*APPROXIMATION_MODE*/>();
+    }
+
+    if constexpr (SFPU_TERNARY_OPERATION == SfpuType::addcmul)
+    {
+        SFPU_TERNARY_CALL(
+            dest_sync,
+            is_fp32_dest_acc_en,
+            calculate_addcmul,
+            (false, is_fp32_dest_acc_en, DataFormat::Float16_b, SFPU_ITERATIONS),
+            params.DST_INDEX + 0u,
+            params.DST_INDEX + 1u,
+            params.DST_INDEX + 2u,
+            params.DST_INDEX + 0u,
+            VectorMode::RC,
+            0x40000000u);
+    }
+    else if constexpr (SFPU_TERNARY_OPERATION == SfpuType::addcdiv)
+    {
+        SFPU_TERNARY_CALL(
+            dest_sync,
+            is_fp32_dest_acc_en,
+            calculate_addcdiv,
+            (false, is_fp32_dest_acc_en, DataFormat::Float16_b, SFPU_ITERATIONS),
+            params.DST_INDEX + 0u,
+            params.DST_INDEX + 1u,
+            params.DST_INDEX + 2u,
+            params.DST_INDEX + 0u,
+            VectorMode::RC,
+            0x40000000u);
+    }
+    else if constexpr (SFPU_TERNARY_OPERATION == SfpuType::lerp)
+    {
+        SFPU_TERNARY_CALL(
+            dest_sync,
+            is_fp32_dest_acc_en,
+            calculate_lerp,
+            (false, is_fp32_dest_acc_en, DataFormat::Float16_b, SFPU_ITERATIONS),
+            params.DST_INDEX + 0u,
+            params.DST_INDEX + 1u,
+            params.DST_INDEX + 2u,
+            params.DST_INDEX + 0u,
+            VectorMode::RC);
+    }
+    else if constexpr (SFPU_TERNARY_OPERATION == SfpuType::snake_beta)
+    {
+        SFPU_TERNARY_CALL(
+            dest_sync,
+            is_fp32_dest_acc_en,
+            calculate_snake_beta,
+            (false, is_fp32_dest_acc_en, DataFormat::Float16_b, SFPU_ITERATIONS),
+            params.DST_INDEX + 0u,
+            params.DST_INDEX + 1u,
+            params.DST_INDEX + 2u,
+            params.DST_INDEX + 0u,
+            VectorMode::RC);
+    }
+    else
+    {
+        // Runs calculate_where over the faces selected by VECTOR_MODE: cond=base+0,
+        // true_val=base+1, false_val=base+2, result written to base+0.
+        SFPU_TERNARY_CALL(
+            dest_sync,
+            is_fp32_dest_acc_en,
+            calculate_where,
+            (false /*APPROXIMATION_MODE*/),
+            params.DST_INDEX + 0u /*DST_IN0*/,
+            params.DST_INDEX + 1u /*DST_IN1*/,
+            params.DST_INDEX + 2u /*DST_IN2*/,
+            params.DST_INDEX + 0u /*DST_OUT*/,
+            VECTOR_MODE);
+    }
 
     _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();
 }

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_defs.h
@@ -17,6 +17,22 @@
 namespace ckernel
 {
 
+enum class ActivationType
+{
+    Celu        = 0,
+    Elu         = 1,
+    Gelu        = 2,
+    Hardtanh    = 3,
+    Hardsigmoid = 4,
+};
+
+enum class RoundingMode : std::uint8_t
+{
+    None  = 0,
+    Trunc = 1,
+    Floor = 2,
+};
+
 // Helper function to convert to underlying type
 // e.g. to_underlying(MathFidelity::HiFi4) -> 4 (underlying type of MathFidelity is std::uint8_t)
 template <typename T>
@@ -76,6 +92,19 @@ enum class BinaryOp : std::uint8_t
     QUANT,
     REQUANT,
     DEQUANT,
+    POW,
+    FMOD,
+    REMAINDER,
+    BITWISE_AND,
+    BITWISE_OR,
+    BITWISE_XOR,
+    DIV_INT32,
+    DIV_INT32_FLOOR,
+    RSUB_INT32,
+    MASK,
+    ATAN2,
+    ISCLOSE,
+    LOGSIGMOID,
 };
 
 // For instructions that address lower/upper 16 bits of a register

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/cmath_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/cmath_common.h
@@ -123,6 +123,14 @@ inline void _reset_counters_()
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, SETRWC);
 }
 
+// Compatibility entry point used by architecture-shared SFPI kernel bodies.
+// Call sites pass a p_setrwc compile-time constant, which the always-inline
+// wrapper preserves as the Quasar instruction immediate.
+__attribute__((always_inline)) inline void reset_counters(const std::uint32_t setrwc)
+{
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, setrwc);
+}
+
 /**
  * @brief Inc dest counter using carriage return (why use the CR?)
  * @tparam NUM_ROWS: number of 16 datum rows to increment dest by, value must be <=255
@@ -223,3 +231,14 @@ inline void eltwise_binary_reuse_dest_as_src()
 }
 
 } // namespace ckernel::math
+
+namespace ckernel::sfpu
+{
+
+// Compatibility name used by architecture-shared SFPI init bodies.
+inline void _init_sfpu_config_reg()
+{
+    math::_init_sfpu_config_reg_();
+}
+
+} // namespace ckernel::sfpu

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_expm1_cw.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_expm1_cw.h
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "llk_sfpu/ckernel_sfpu_converter.h"
+#include "llk_sfpu/ckernel_sfpu_polyval.h"
+#include "sfpi.h"
+
+namespace ckernel::sfpu
+{
+
+// ======================================================================
+// Shared helper: exp(x) - 1 via Cody-Waite range reduction + factored
+// expm1 polynomial. Used by ELU, CELU and SELU.
+//
+// Algorithm: x = k*ln(2) + r, |r| <= ln(2)/2
+//   expm1(r) = r * h(r), h(r) = minimax polynomial on [-ln2/2, ln2/2]
+//   exp(x)-1 = (2^k - 1) + 2^k * expm1(r)
+//
+// BF16 h degree 4: max abs error = 1.60e-7 (Sollya remez)
+// FP32 h degree 5: max abs error = 8.67e-9 (Sollya remez)
+// ======================================================================
+
+constexpr float CW_INV_LN2    = 1.4426950408889634f;
+constexpr float CW_NEG_LN2_HI = -0.6931152343750000f;
+constexpr float CW_NEG_LN2_LO = -3.19461832987e-05f;
+
+sfpi_inline sfpi::vFloat expm1_cw_clamped(sfpi::vFloat x)
+{
+    // Clamp to prevent exponent underflow (k < -127 wraps setexp)
+    v_if (x < -87.0f)
+    {
+        x = -87.0f;
+    }
+    v_endif;
+
+    // Cody-Waite range reduction: x = k*ln(2) + r
+    const sfpi::vFloat c231 = Converter::as_float(0x4B400000U);
+    sfpi::vFloat tmp        = x * CW_INV_LN2 + c231;
+    sfpi::vFloat k_f        = tmp - c231;
+    sfpi::vFloat r          = k_f * CW_NEG_LN2_HI + x;
+    r                       = r + k_f * CW_NEG_LN2_LO;
+
+    // expm1(r) = r * h(r), Horner evaluation of h
+#ifdef INP_FLOAT32
+    sfpi::vFloat h = PolynomialEvaluator::eval(r, 1.0f, 5.0000000000e-01f, 1.6666504741e-01f, 4.1666239500e-02f, 8.3691505715e-03f, 1.3948583510e-03f);
+#else
+    sfpi::vFloat h = PolynomialEvaluator::eval(r, 1.0f, 4.9999371171e-01f, 1.6666433215e-01f, 4.1875664145e-02f, 8.3751315251e-03f);
+#endif
+    h = r * h;
+
+    // Reconstruct: exp(x)-1 = (2^k - 1) + 2^k * expm1(r).
+    // Keep the exponent construction in integer exponent space; Quasar does
+    // not preserve Blackhole's large raw-bit immediate shortcut.
+    sfpi::vInt k_int   = sfpi::as<sfpi::vInt>(tmp) - sfpi::as<sfpi::vInt>(c231);
+    sfpi::vFloat two_k = sfpi::as<sfpi::vFloat>((k_int + 127) << 23);
+    return (two_k - 1.0f) + two_k * h;
+}
+
+} // namespace ckernel::sfpu

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_is_fp16_zero.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_is_fp16_zero.h
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "sfpi.h"
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+sfpi_inline sfpi::vBool _sfpu_is_fp16_zero_(const sfpi::vFloat& v)
+{
+    return v == 0.0F;
+}
+
+} // namespace sfpu
+} // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -13,6 +13,23 @@ namespace ckernel
 {
 namespace sfpu
 {
+
+sfpi_inline sfpi::vFloat _relu_max_body_(sfpi::vFloat val, sfpi::vFloat threshold)
+{
+    sfpi::vFloat result = val;
+    v_if (result > threshold)
+    {
+        result = threshold;
+    }
+    v_endif;
+    v_if (result < 0.0f)
+    {
+        result = 0.0f;
+    }
+    v_endif;
+    return result;
+}
+
 // Calculates RELU for number of rows of output SFPU ops (Quasar = 2 rows)
 inline void _calculate_relu_sfp_rows_()
 {
@@ -57,7 +74,7 @@ template <int ITERATIONS = SFPU_ITERATIONS>
 inline void _calculate_lrelu_(const std::uint32_t slope)
 {
     TT_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_FLOATB, (slope >> 16)); // store slope in LREG2 (runtime imm)
-    TTI_SFPENCC(1, 2);                                           // enable cc
+    TTI_SFPENCC(1, 2);                                                     // enable cc
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
@@ -89,7 +106,7 @@ template <int ITERATIONS = SFPU_ITERATIONS>
 inline void _relu_min_(const std::uint32_t threshold)
 {
     TT_SFPLOADI(p_sfpu::LREG2, 0 /*Float16_b*/, (threshold >> 16)); // store threshold in LREG2 (runtime imm)
-    TTI_SFPENCC(1, 2);                                               // enable cc
+    TTI_SFPENCC(1, 2);                                              // enable cc
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {
@@ -125,7 +142,7 @@ template <int ITERATIONS = SFPU_ITERATIONS>
 inline void _relu_max_(const std::uint32_t threshold)
 {
     TT_SFPLOADI(p_sfpu::LREG2, 0 /*Float16_b*/, (threshold >> 16)); // store threshold in LREG2 (runtime imm)
-    TTI_SFPENCC(1, 2);                                               // enable cc
+    TTI_SFPENCC(1, 2);                                              // enable cc
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++)
     {

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Jason Davies <jason@jasondavies.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <array>
+#include <climits>
+
+#include "ckernel.h"
+#include "ckernel_defs.h"
+#include "sfpi.h"
+
+namespace ckernel
+{
+namespace sfpu
+{
+
+// #41922: CONSTRUCTION ZONE
+// Implemented:Standard calling API, old bodies
+// ToDo: use sfpi API
+
+// compute truncate to zero
+sfpi_inline sfpi::vFloat _trunc_body_(sfpi::vFloat val)
+{
+    sfpi::vFloat result = val;
+    sfpi::vInt exp      = sfpi::exexp(val);
+    v_if (exp < 0)
+    {
+        const sfpi::vFloat zero = 0.0f;
+        result                  = sfpi::copysgn(zero, val);
+    }
+    v_elseif (exp < 23)
+    {
+        const sfpi::vInt shift = exp - 23;
+        result                 = sfpi::as<sfpi::vFloat>(sfpi::shft(sfpi::shft(sfpi::as<sfpi::vUInt>(val), shift), -shift));
+    }
+    v_else
+    {
+        result = val;
+    }
+    v_endif;
+    return result;
+}
+
+// compute floor
+sfpi_inline sfpi::vFloat _floor_body_(sfpi::vFloat val)
+{
+    sfpi::vFloat result = _trunc_body_(val);
+    v_if (val < result)
+    {
+        result -= 1.0f;
+    }
+    v_endif;
+    return result;
+}
+
+// computes ceil
+sfpi_inline sfpi::vFloat _ceil_body_(sfpi::vFloat val)
+{
+    sfpi::vFloat result = _trunc_body_(val);
+    v_if (val > result)
+    {
+        result += 1.0f;
+    }
+    v_endif;
+    return result;
+}
+
+inline constexpr std::array<float, 84> PRECOMPUTED_POW10_TABLE = {
+    1e-45F, 1e-44F, 1e-43F, 1e-42F, 1e-41F, 1e-40F, 1e-39F, 1e-38F, 1e-37F, 1e-36F, 1e-35F, 1e-34F, 1e-33F, 1e-32F, 1e-31F, 1e-30F, 1e-29F,
+    1e-28F, 1e-27F, 1e-26F, 1e-25F, 1e-24F, 1e-23F, 1e-22F, 1e-21F, 1e-20F, 1e-19F, 1e-18F, 1e-17F, 1e-16F, 1e-15F, 1e-14F, 1e-13F, 1e-12F,
+    1e-11F, 1e-10F, 1e-9F,  1e-8F,  1e-7F,  1e-6F,  1e-5F,  1e-4F,  1e-3F,  1e-2F,  1e-1F,  1e0F,   1e1F,   1e2F,   1e3F,   1e4F,   1e5F,
+    1e6F,   1e7F,   1e8F,   1e9F,   1e10F,  1e11F,  1e12F,  1e13F,  1e14F,  1e15F,  1e16F,  1e17F,  1e18F,  1e19F,  1e20F,  1e21F,  1e22F,
+    1e23F,  1e24F,  1e25F,  1e26F,  1e27F,  1e28F,  1e29F,  1e30F,  1e31F,  1e32F,  1e33F,  1e34F,  1e35F,  1e36F,  1e37F,  1e38F,
+};
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+sfpi_inline void _calculate_floor_()
+{
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        sfpi::dst_reg[0] = _floor_body_(sfpi::dst_reg[0]);
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+sfpi_inline void _calculate_ceil_()
+{
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        sfpi::dst_reg[0] = _ceil_body_(sfpi::dst_reg[0]);
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+sfpi_inline void _calculate_trunc_()
+{
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        sfpi::dst_reg[0] = _trunc_body_(sfpi::dst_reg[0]);
+        sfpi::dst_reg++;
+    }
+}
+
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+sfpi_inline void _calculate_frac_()
+{
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        sfpi::vFloat x   = sfpi::dst_reg[0];
+        sfpi::dst_reg[0] = x - _trunc_body_(x);
+        sfpi::dst_reg++;
+    }
+}
+
+sfpi_inline sfpi::vFloat _round_even_(sfpi::vFloat v)
+{
+    // Create a temporary copy tmp = abs(v).
+    sfpi::vFloat tmp = sfpi::setsgn(v, 0);
+    // For all 0 ≤ x < 2**23, x + 2**23 will shift out the fractional part with round-to-nearest-even.
+    tmp += 0x1.p23f;
+    // Hide SFPNOP; extract exponent.
+    sfpi::vInt exp = sfpi::exexp(v);
+    // Subtract 2**23 to restore exponent.
+    tmp += -0x1.p23f;
+    // Hide SFPNOP; check exponent.  If x ≥ 2**23, then there is no fractional part.
+    v_if (exp < 23)
+    {
+        // v.{Exp,Man}=tmp.{Exp,Man}; retaining original sign.
+        v = sfpi::copysgn(tmp, v);
+    }
+    v_endif;
+    return v;
+}
+
+template <bool APPROXIMATE, int ITERATIONS = 8>
+void _calculate_round_(const int decimals)
+{
+    const auto exp10i = [](int n)
+    {
+        if (n > 38) // 38 is max decimal places float32 can store for positive values
+        {
+            return 1.0F / 0.0F;
+        }
+
+        if (n < -45) // 45 is max decimal places float32 can store for negative values
+        {
+            return 0.0F;
+        }
+
+        return PRECOMPUTED_POW10_TABLE[n + 45];
+    };
+
+    const sfpi::vFloat coeff   = exp10i(decimals);
+    const sfpi::vFloat inverse = exp10i(-decimals);
+
+    for (int d = 0; d < ITERATIONS; ++d)
+    {
+        sfpi::vFloat v      = sfpi::dst_reg[0];
+        sfpi::vFloat result = inverse * _round_even_(v * coeff);
+        sfpi::dst_reg[0]    = result;
+        sfpi::dst_reg++;
+    }
+}
+
+// Performs stochastic rounding of values in DST from fp32 to fp16b format.
+template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
+sfpi_inline void _calculate_stochastic_round_()
+{
+#pragma GCC unroll ITERATIONS
+    for (int d = 0; d < ITERATIONS; d++)
+    {
+        sfpi::vFloat x   = sfpi::dst_reg[0];
+        x                = sfpi::convert<sfpi::vFloat16b>(x, sfpi::RoundMode::NearestStochastic);
+        sfpi::dst_reg[0] = x;
+        sfpi::dst_reg++;
+    }
+}
+
+} // namespace sfpu
+} // namespace ckernel

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
@@ -120,6 +120,51 @@ enum class SfpuType : std::uint32_t
     greater_than_zero,
     less_than_equal_zero,
     greater_than_equal_zero,
+    add1,
+    bitwise_not,
+    cast_fp32_to_fp16a,
+    cbrt,
+    celu,
+    digamma,
+    elu,
+    erfc,
+    erfinv,
+    exp2,
+    fmod,
+    hardmish,
+    hardshrink,
+    i0,
+    identity,
+    lgamma,
+    polygamma,
+    prelu,
+    rpow,
+    selu,
+    softshrink,
+    softsign,
+    tanhshrink,
+    unary_gt,
+    unary_ne,
+    unary_eq,
+    unary_lt,
+    unary_ge,
+    unary_le,
+    power,
+    left_shift,
+    right_shift,
+    hardsigmoid,
+    unary_bitwise_and,
+    unary_bitwise_or,
+    unary_bitwise_xor,
+    rdiv,
+    remainder,
+    alt_complex_rotate90,
+    addcmul,
+    addcdiv,
+    lerp,
+    snake_beta,
+    int_sum_col,
+    int_sum_row,
 };
 
 enum class DstSync : std::uint8_t
@@ -150,6 +195,30 @@ enum class PackMode : std::uint8_t
     Untilize = 1,
     Tilize   = 2,
 };
+
+// Compatibility selector used by SFPI kernels whose load/store layout is
+// chosen at compile time. Quasar kernels map these values to sfpi::DataLayout;
+// the Blackhole instruction encodings are never emitted on Quasar.
+enum class InstrModLoadStore
+{
+    DEFAULT       = 0,
+    FP16A         = 1,
+    FP16B         = 2,
+    FP32          = 3,
+    INT32         = 4,
+    INT8          = 5,
+    LO16          = 6,
+    HI16          = 7,
+    INT32_2S_COMP = 12,
+    INT8_2S_COMP  = 13,
+    LO16_ONLY     = 14,
+    HI16_ONLY     = 15,
+};
+
+inline constexpr bool is_valid_instruction_mode(const InstrModLoadStore mode)
+{
+    return mode == InstrModLoadStore::INT32_2S_COMP || mode == InstrModLoadStore::INT32 || mode == InstrModLoadStore::LO16;
+}
 
 // Packer ReLU modes; encoding matches RELU_MODE (2 bits) in HW.
 enum class ReluType : std::uint8_t


### PR DESCRIPTION
## Summary

- port 46 Blackhole SFPI functionalities to Quasar, keeping the arithmetic kernel bodies as carbon copies and adding only the Quasar compatibility surfaces they require
- add the helper-only `conversions` header used transitively by `binary_pow` and `unary_power`
- wire the operations through the normal Quasar `SfpuType`/`BinaryOp` dispatch paths (no direct numeric operation IDs)
- expand the existing Quasar unary, binary, and ternary tests, including native Int32 staging and structural `int_sum` row/column goldens

The ported functionality set is:

`activations`, `add1`, `addcdiv`, `addcmul`, `alt_complex_rotate90`, `atan2`, `binary_bitwise`, `binary_fmod`, `binary_pow`, `binary_remainder`, `bitwise`, `bitwise_not`, `cast_fp32_to_fp16a`, `cbrt`, `celu`, `digamma`, `div_int32_floor`, `elu`, `erfc`, `erfinv`, `exp2`, `fmod`, `hardmish`, `hardshrink`, `i0`, `identity`, `int_sum`, `isclose`, `lerp`, `lgamma`, `logsigmoid`, `mask`, `polygamma`, `prelu`, `rdiv`, `remainder`, `rpow`, `rsub_int32`, `selu`, `snake_beta`, `softshrink`, `softsign`, `tanhshrink`, `unary_comp`, `unary_power`, and `unary_shift`.

## Validation

Quasar emulation, using `.claude/scripts/run_test.sh run`:

- expanded unary: 41/41 compile, 41/41 simulation
- expanded binary: 13/13 compile, 13/13 simulation
- expanded ternary: 4/4 compile, 4/4 simulation
- combined: 58/58 compile and 58/58 simulation

All repository pre-commit and commit hooks pass, including clang-format, Black/isort, pylint, codespell, fixed-width integer normalization, include validation, and whitespace checks.

## Remaining parity rows

The following rows are not counted among the 46 directly validated functionalities. Except for the helper-only `conversions` header, their kernel sources are intentionally excluded from this PR:

- `conversions` has no standalone init/calculate entry point or output. Its carbon-copy helper is included and exercised transitively through the power kernels.
- `div_int32`: the separate header consumes Int32 operands but produces Float32. The existing test named `SfpuDivInt32` actually covers `calculate_div_int32_trunc` from `div_int32_floor`; the separate kernel needs a mixed Int32-input/Float32-output runner.
- `tiled_prod`: the carbon-copy body needs a new structural golden for its cumulative product across SFPU DEST registers. There is no existing Blackhole correctness caller to copy.
- `i1`: non-approximate compilation hits an SFPI register-spill ICE at the reciprocal expression because the live polynomial/input/reciprocal values exceed Quasar's eight LRegs.
- `heaviside`, `sign`, and `logical_not`: the observed signed-zero failures directly match #50208, where Quasar float comparisons are lowered without the SFPSETCC FP32-format bit.
- `erf`, `hardtanh`, and `xielu`: their negative-bound clamp/max failures are strongly consistent with #50208 and should be rerun after the SFPI comparison fix rather than receiving Quasar-specific kernel-body rewrites.
- `expm1`: it uses comparison operators affected by #50208, but also contains architecture-sensitive exponent reconstruction. It must be rerun after #50208 before determining whether a second port is required.

#51346 does not block this set: none of the included or excluded parity kernels calls `sfpi::lut2`/`lut2_sign`.

Related issues:

- #50208
- #51346
