### PR TITLE
Set KERNEL_COMPILE_TIME_ARG_MAP via a generated header instead of -D define

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_compile_time_args.cpp
+++ b/tests/tt_metal/tt_metal/api/test_compile_time_args.cpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <gtest/gtest.h>
+#include <unistd.h>
+#include <cstddef>
 #include <cstdint>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tt_metal.hpp>
@@ -93,6 +95,74 @@ TEST_F(CompileTimeArgsTest, TensixTestNamedCompileTimeArgs) {
         {"", 3},
         {"!@#$%^&*()", 12},
         {"very_long_parameter_name_that_someone_could_potentially_use_to_try_to_break_the_kernel", 456}};
+
+    CreateKernel(
+        program_,
+        "tests/tt_metal/tt_metal/test_kernels/misc/named_compile_time_args_kernel.cpp",
+        core,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = compile_time_args,
+            .defines = defines,
+            .named_compile_args = named_compile_time_args});
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+
+    std::vector<uint32_t> results;
+    detail::ReadFromDeviceL1(device, core, write_addr, 4 * sizeof(uint32_t), results);
+
+    ASSERT_EQ(results[0], compile_time_args[0]) << "'!@#$%^&*()' should be 12";
+    ASSERT_EQ(results[1], compile_time_args[1])
+        << "'very_long_parameter_name_that_someone_could_potentially_use_to_try_to_break_the_kernel' should be 456";
+    ASSERT_EQ(results[2], compile_time_args[2]) << "'buffer_size' should be 1024";
+    ASSERT_EQ(results[3], compile_time_args[3]) << "\"\" should be 3";
+}
+
+// A named CT arg map too large to fit in one argv element must still build and resolve correctly.
+//
+// The map used to be passed as -DKERNEL_COMPILE_TIME_ARG_MAP={...}, and a single argv element is
+// capped at MAX_ARG_STRLEN (32 pages = 128 KB) no matter how the compiler is spawned. Whole-model
+// fused ops emit thousands of long named args and cross that on the strength of this one define,
+// which surfaced only as "posix_spawnp failed for .../riscv-tt-elf-g++: Argument list too long".
+// The map is now delivered as a force-included generated header, which has no size limit.
+//
+// The filler args exist purely to make the map oversized; the kernel reads the same four sentinel
+// names as the test above, so a wrong or truncated map fails on the values rather than on the build.
+//
+// Regression test for tenstorrent/tt-blaze#2017 and tenstorrent/tt-blaze#3209.
+TEST_F(CompileTimeArgsTest, TensixTestNamedCompileTimeArgsExceedingArgvLimit) {
+    auto mesh_device = get_mesh_device();
+    CoreCoord core = {0, 0};
+    auto& cq = mesh_device->mesh_command_queue();
+    auto device_range = distributed::MeshCoordinateRange(mesh_device->shape());
+    distributed::MeshWorkload workload;
+    Program program;
+    workload.add_program(device_range, std::move(program));
+    auto& program_ = workload.get_programs().at(device_range);
+    auto* device = mesh_device->get_devices()[0];
+
+    const uint32_t write_addr = mesh_device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
+
+    const std::map<std::string, std::string> defines = {{"WRITE_ADDRESS", std::to_string(write_addr)}};
+
+    const std::vector<uint32_t> compile_time_args = {12, 456, 1024, 3};
+    std::unordered_map<std::string, uint32_t> named_compile_time_args = {
+        {"buffer_size", 1024},
+        {"", 3},
+        {"!@#$%^&*()", 12},
+        {"very_long_parameter_name_that_someone_could_potentially_use_to_try_to_break_the_kernel", 456}};
+
+    // Keys shaped like a real fused op's, where every key repeats the op's naming scope. Sized to
+    // clear 128 KB of map text with margin so the test keeps its teeth as the formatter evolves.
+    const size_t max_arg_strlen = 32 * static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    size_t map_text_bytes = 0;
+    for (size_t i = 0; map_text_bytes < 2 * max_arg_strlen; ++i) {
+        std::string name = "oversized_named_ct_arg_map_filler_scope__attn__qkv_proj__mcast_" + std::to_string(i) +
+                           ".execute_receiver_on_ncrisc_arg";
+        map_text_bytes += name.size() + sizeof("{\"\",4294967295},");
+        named_compile_time_args.emplace(std::move(name), static_cast<uint32_t>(i));
+    }
+    ASSERT_GT(map_text_bytes, max_arg_strlen);
 
     CreateKernel(
         program_,

--- a/tests/tt_metal/tt_metal/jit_build/sources.cmake
+++ b/tests/tt_metal/tt_metal/jit_build/sources.cmake
@@ -8,5 +8,6 @@ set(UNIT_TESTS_JIT_BUILD_SRC
     test_jit_build_telemetry.cpp
     test_jit_compile_deduper.cpp
     test_kernel_signature_parser.cpp
+    test_named_ct_arg_map.cpp
     test_sync_build_steps.cpp
 )

--- a/tests/tt_metal/tt_metal/jit_build/test_named_ct_arg_map.cpp
+++ b/tests/tt_metal/tt_metal/jit_build/test_named_ct_arg_map.cpp
@@ -1,0 +1,264 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <spawn.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include "jit_build/jit_build_utils.hpp"
+
+// The named compile-time-arg map (KERNEL_COMPILE_TIME_ARG_MAP) is delivered to kernels as a
+// force-included generated header rather than a -D define. These tests cover the formatter that
+// produces that header, and pin the OS constraint that forces the design: a -D define lands in a
+// single argv element, and one element is capped at MAX_ARG_STRLEN (128 KB) regardless of how the
+// compiler is spawned. Whole-model fused ops emit maps larger than that on their own.
+//
+// See tenstorrent/tt-blaze#2017 and tenstorrent/tt-blaze#3209.
+
+namespace tt::jit_build::utils {
+namespace {
+
+// Linux caps a single argv element at 32 pages, independent of the total ARG_MAX budget.
+std::size_t max_arg_strlen() { return 32 * static_cast<std::size_t>(sysconf(_SC_PAGESIZE)); }
+
+// Parse a formatted map body ({"a",1},{"b",2}) back into a map, so a round-trip can assert that
+// formatting is lossless. Deliberately strict: anything unexpected fails the test rather than
+// being skipped.
+std::unordered_map<std::string, std::uint32_t> parse_map_body(std::string_view body) {
+    std::unordered_map<std::string, std::uint32_t> parsed;
+    std::size_t pos = 0;
+    while (pos < body.size()) {
+        if (body[pos] == ',') {
+            ++pos;
+            continue;
+        }
+        EXPECT_EQ(body[pos], '{') << "at offset " << pos;
+        const std::size_t key_open = body.find('"', pos);
+        const std::size_t key_close = body.find('"', key_open + 1);
+        const std::size_t entry_end = body.find('}', key_close);
+        if (key_open == std::string_view::npos || key_close == std::string_view::npos ||
+            entry_end == std::string_view::npos) {
+            ADD_FAILURE() << "malformed entry at offset " << pos;
+            break;
+        }
+        const std::string key(body.substr(key_open + 1, key_close - key_open - 1));
+        // Skip the comma between the closing key quote and the value.
+        const std::string value(body.substr(key_close + 2, entry_end - key_close - 2));
+        parsed[key] = static_cast<std::uint32_t>(std::stoul(value));
+        pos = entry_end + 1;
+    }
+    return parsed;
+}
+
+// A map shaped like what a whole-model decoder layer emits: ~1750 entries whose keys average ~75
+// characters, because every key repeats the op's naming scope. This is the size class that broke
+// the -D delivery.
+std::unordered_map<std::string, std::uint32_t> make_whole_model_sized_map(std::size_t num_entries = 1750) {
+    std::unordered_map<std::string, std::uint32_t> named_args;
+    named_args.reserve(num_entries);
+    for (std::size_t i = 0; i < num_entries; ++i) {
+        named_args.emplace(
+            "gemma4_sliding_window_decoder_layer__attn__qkv_proj__mcast_" + std::to_string(i) +
+                ".execute_receiver_on_ncrisc_arg",
+            static_cast<std::uint32_t>(i));
+    }
+    return named_args;
+}
+
+// Try to exec /bin/true with one argv element of |len| bytes. Returns the posix_spawn errno
+// (0 on success), which is E2BIG once the element crosses MAX_ARG_STRLEN.
+int spawn_with_argv_element_of_length(std::size_t len) {
+    std::string big(len, 'x');
+    std::vector<char*> argv = {const_cast<char*>("/bin/true"), big.data(), nullptr};
+
+    pid_t pid = 0;
+    const int rc = posix_spawn(&pid, argv[0], nullptr, nullptr, argv.data(), environ);
+    if (rc == 0) {
+        int status = 0;
+        waitpid(pid, &status, 0);
+    }
+    return rc;
+}
+
+TEST(NamedCtArgMap, EmptyMapFormatsToEmptyBody) { EXPECT_EQ(format_named_ct_arg_map({}), ""); }
+
+TEST(NamedCtArgMap, FormatsEntriesAsCommaSeparatedBracedPairs) {
+    EXPECT_EQ(format_named_ct_arg_map({{"cb_in0", 1}}), R"({"cb_in0",1})");
+    EXPECT_EQ(format_named_ct_arg_map({{"b", 2}, {"a", 1}}), R"({"a",1},{"b",2})");
+}
+
+// The formatter reads an unordered_map, whose iteration order is not reproducible across runs or
+// processes. Sorting matters because this text is written to disk and hashed by the per-object
+// dephash cache: unsorted output would churn the cache and force spurious recompiles.
+TEST(NamedCtArgMap, OrdersByKeySoOutputIsReproducible) {
+    std::unordered_map<std::string, std::uint32_t> forward;
+    std::unordered_map<std::string, std::uint32_t> reverse;
+    for (int i = 0; i < 64; ++i) {
+        forward.emplace("arg_" + std::to_string(i), i);
+    }
+    for (int i = 63; i >= 0; --i) {
+        reverse.emplace("arg_" + std::to_string(i), i);
+    }
+
+    const std::string forward_body = format_named_ct_arg_map(forward);
+    EXPECT_EQ(forward_body, format_named_ct_arg_map(reverse));
+
+    // Spot-check that it really is ascending key order, not just consistent.
+    EXPECT_LT(forward_body.find(R"({"arg_0",0})"), forward_body.find(R"({"arg_1",1})"));
+}
+
+// Covers the key shapes the existing named-CT-arg kernel test relies on, including the empty name
+// and punctuation-only names.
+TEST(NamedCtArgMap, RoundTripsEveryEntryLosslessly) {
+    const std::unordered_map<std::string, std::uint32_t> named_args = {
+        {"buffer_size", 1024},
+        {"", 3},
+        {"!@#$%^&*()", 12},
+        {"very_long_parameter_name_that_someone_could_potentially_use_to_try_to_break_the_kernel", 456},
+        {"zero", 0},
+        {"max", 0xFFFFFFFFu},
+    };
+
+    EXPECT_EQ(parse_map_body(format_named_ct_arg_map(named_args)), named_args);
+}
+
+TEST(NamedCtArgMap, RoundTripsAWholeModelSizedMap) {
+    const auto named_args = make_whole_model_sized_map();
+    const auto parsed = parse_map_body(format_named_ct_arg_map(named_args));
+
+    EXPECT_EQ(parsed.size(), named_args.size());
+    EXPECT_EQ(parsed, named_args);
+}
+
+TEST(NamedCtArgMap, HeaderDefinesTheMacroAndIsIncludeGuarded) {
+    const std::string header = format_named_ct_arg_map_header({{"cb_in0", 1}});
+
+    EXPECT_NE(header.find("#pragma once"), std::string::npos);
+    EXPECT_NE(header.find(R"(#define KERNEL_COMPILE_TIME_ARG_MAP {"cb_in0",1})"), std::string::npos);
+    // The macro must be the whole body on one logical line: a stray newline inside the map would
+    // terminate the #define and silently truncate the arg list.
+    const std::size_t define_pos = header.find("#define KERNEL_COMPILE_TIME_ARG_MAP");
+    EXPECT_EQ(header.find('\n', define_pos), header.size() - 1);
+}
+
+TEST(NamedCtArgMap, HeaderIsByteIdenticalForEqualMaps) {
+    const auto named_args = make_whole_model_sized_map(256);
+    std::unordered_map<std::string, std::uint32_t> rebuilt(named_args.begin(), named_args.end());
+
+    EXPECT_EQ(format_named_ct_arg_map_header(named_args), format_named_ct_arg_map_header(rebuilt));
+}
+
+// The regression this delivery mechanism exists to prevent: a whole-model map does not fit in one
+// argv element, but the recipe footprint that replaces it is a fixed couple of dozen bytes.
+TEST(NamedCtArgMap, WholeModelMapExceedsArgvLimitWhileRecipeFootprintStaysTiny) {
+    const std::string body = format_named_ct_arg_map(make_whole_model_sized_map());
+    const std::string as_define = "-DKERNEL_COMPILE_TIME_ARG_MAP=" + body;
+
+    EXPECT_GT(as_define.size(), max_arg_strlen())
+        << "test map is no longer representative of a whole-model kernel; it must exceed " << max_arg_strlen()
+        << " bytes to exercise the limit";
+
+    // What actually goes on the command line now, regardless of how big the map is.
+    const std::size_t recipe_footprint = std::strlen("-include") + NAMED_CT_ARG_MAP_HEADER.size();
+    EXPECT_LT(recipe_footprint, 128u);
+
+    // And the map itself still travels intact, in the header.
+    EXPECT_NE(format_named_ct_arg_map_header(make_whole_model_sized_map()).find(body), std::string::npos);
+}
+
+// Pins the constraint the design is built around. posix_spawn removed tt-metal's whole-command
+// ceiling, but not this per-element one -- which is why a large map still could not ride on a -D.
+TEST(NamedCtArgMap, KernelRejectsAnArgvElementAtOrAboveMaxArgStrlen) {
+    const std::size_t limit = max_arg_strlen();
+
+    EXPECT_EQ(spawn_with_argv_element_of_length(limit - 1), 0) << "just under the limit should exec";
+    EXPECT_EQ(spawn_with_argv_element_of_length(limit), E2BIG);
+    EXPECT_EQ(spawn_with_argv_element_of_length(limit + 4096), E2BIG);
+}
+
+// A bare filename (rather than a path) is what lets one recipe compile on both the local host and
+// the remote JIT compile server, whose per-kernel directory layout differs.
+TEST(NamedCtArgMap, HeaderNameIsRelativeSoItResolvesOnBothCompileHosts) {
+    EXPECT_FALSE(NAMED_CT_ARG_MAP_HEADER.empty());
+    EXPECT_EQ(NAMED_CT_ARG_MAP_HEADER.find('/'), std::string_view::npos);
+    EXPECT_TRUE(NAMED_CT_ARG_MAP_HEADER.ends_with(".h"));
+}
+
+// End-to-end check of the delivery mechanism, in the directory layout the real compiles use: the
+// generated header sits in the per-kernel dir and the compiler runs with cwd = a per-target subdir,
+// reaching it through the "-I.." on every compile. Both the local build and the JIT compile server
+// arrange things this way, which is what lets a bare -include work identically on both -- an
+// absolute client-side path would compile locally and then fail on the server.
+//
+// Uses the host compiler and only the preprocessor, so it needs neither a device nor the RISC-V
+// toolchain: what is under test is name resolution and macro visibility, not code generation.
+TEST(NamedCtArgMap, ForceIncludedHeaderResolvesFromTargetSubdirAndDefinesTheMap) {
+    namespace fs = std::filesystem;
+
+    const fs::path kernel_dir = fs::temp_directory_path() / "tt_named_ct_arg_map_test" / "kernel";
+    const fs::path target_dir = kernel_dir / "ncrisc";
+    fs::remove_all(kernel_dir.parent_path());
+    fs::create_directories(target_dir);
+
+    const std::unordered_map<std::string, std::uint32_t> named_args = {{"cb_in0", 7}, {"num_tiles", 64}};
+    {
+        std::ofstream header(kernel_dir / NAMED_CT_ARG_MAP_HEADER);
+        header << format_named_ct_arg_map_header(named_args);
+        ASSERT_TRUE(header.good());
+    }
+
+    // Mirrors hw/inc/api/compile_time_args.h: build the lookup table from the macro and resolve a
+    // name at compile time, so a missing or malformed map fails the compile.
+    const fs::path src = kernel_dir / "consumer.cpp";
+    {
+        std::ofstream f(src);
+        f << "#include <string_view>\n#include <utility>\n#include <cstdint>\n"
+             "constexpr std::pair<std::string_view, uint32_t> named_args_map[] = {KERNEL_COMPILE_TIME_ARG_MAP};\n"
+             "constexpr uint32_t get_named_ct_arg(std::string_view name) {\n"
+             "    for (const auto& [n, v] : named_args_map) { if (n == name) { return v; } }\n"
+             "    return 0xFFFFFFFFu;\n"
+             "}\n"
+             "static_assert(get_named_ct_arg(\"cb_in0\") == 7);\n"
+             "static_assert(get_named_ct_arg(\"num_tiles\") == 64);\n";
+        ASSERT_TRUE(f.good());
+    }
+
+    // -I. / -I.. and cwd = target dir replicate JitBuildEnv's include list and exec_command's
+    // working directory. The bare -include must resolve through -I.. alone.
+    const std::vector<std::string> args = {
+        "c++",
+        "-std=c++17",
+        "-fsyntax-only",
+        "-I.",
+        "-I..",
+        "-include",
+        std::string(NAMED_CT_ARG_MAP_HEADER),
+        "../consumer.cpp"};
+    if (!exec_command(args, target_dir.string(), (target_dir / "compile.log").string())) {
+        std::ifstream log(target_dir / "compile.log");
+        const std::string output((std::istreambuf_iterator<char>(log)), std::istreambuf_iterator<char>());
+        // A host compiler is not guaranteed at test runtime; a missing one is not a product failure.
+        if (output.find("c++") != std::string::npos && output.find("not found") != std::string::npos) {
+            GTEST_SKIP() << "no host c++ compiler available";
+        }
+        FAIL() << "force-included map header failed to compile:\n" << output;
+    }
+
+    fs::remove_all(kernel_dir.parent_path());
+}
+
+}  // namespace
+}  // namespace tt::jit_build::utils

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -55,6 +55,7 @@
 
 #include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
+#include "jit_build/jit_build_utils.hpp"  // format_named_ct_arg_map (shared with the silicon JIT path)
 #include "impl/buffers/circular_buffer.hpp"
 #include "impl/buffers/semaphore.hpp"
 #include <tt-metalium/device.hpp>
@@ -1030,6 +1031,14 @@ static std::function<void()> jit_compile_kernel(
                 f << "#define " << key << " " << value << "\n";
             }
         }
+        // KERNEL_COMPILE_TIME_ARG_MAP (read by api/compile_time_args.h) goes in the wrapper for the
+        // same reason the kernel defines above do -- emule shells out via std::system(), so it has
+        // the whole command as one argv string against MAX_ARG_STRLEN (128 KB), and this map alone
+        // can exceed that. Must precede every include so the consuming header sees it.
+        if (!named_compile_args.empty()) {
+            f << "#define KERNEL_COMPILE_TIME_ARG_MAP "
+              << tt::jit_build::utils::format_named_ct_arg_map(named_compile_args) << "\n";
+        }
         f << "#include \"jit_kernel_stubs.hpp\"\n";
         // Metal-2.0 `namespace args` (base).
         emit_metal2_namespaces(f, bindings, named_compile_args);
@@ -1064,21 +1073,8 @@ static std::function<void()> jit_compile_kernel(
     // rather than here, so they can be dynamically computed per-program.
     std::string define_flags = " -DTT_EMULE_USE_L1_POOL";
 
-    // 5b. Build -DKERNEL_COMPILE_TIME_ARG_MAP for named compile-time args
-    if (!named_compile_args.empty()) {
-        std::ostringstream ss;
-        ss << " \"-DKERNEL_COMPILE_TIME_ARG_MAP=";
-        bool first = true;
-        for (const auto& [name, value] : named_compile_args) {
-            if (!first) {
-                ss << ',';
-            }
-            ss << "{\\\"" << name << "\\\"," << value << "}";
-            first = false;
-        }
-        ss << "\"";
-        define_flags += ss.str();
-    }
+    // 5b. KERNEL_COMPILE_TIME_ARG_MAP is emitted as a #define at the top of wrapper.cpp (step 3),
+    // not as a -D flag here: it is far too large for one shell command. See that site.
 
     // 6. Compute the kernel's source directory for relative includes
     std::string kernel_dir = std::filesystem::path(abs_kernel).parent_path().string();

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -265,10 +265,11 @@ KernelCompileDescriptor build_kernel_descriptor(
                     target.target_name + "__" + std::filesystem::path(target.objs[i]).filename().string() + ".ii";
                 const std::string ii_path = client_out_dir + "/" + ii_name;
                 // Preprocess with the EXACT compile flags via the shared argv builder + exec_command
-                // (posix_spawn, NO shell). A shell command string would mangle map-valued defines
-                // like -DKERNEL_COMPILE_TIME_ARG_MAP={"cb_in0",1},... (braces/quotes/commas/spaces)
-                // and drop named compile-time args. cwd = client_out_dir so -I. / -I.. resolve to
-                // the target + generated-files dirs, identical to the real compile env. -MMD (in
+                // (posix_spawn, NO shell). A shell command string would mangle defines carrying
+                // shell metacharacters, like -DFULL_KERNEL_NAME="<name>" (quotes/parens/commas).
+                // cwd = client_out_dir so -I. / -I.. resolve to the target + generated-files dirs,
+                // identical to the real compile env — which is also what lets the named-CT-arg-map
+                // header's bare -include resolve here. -MMD (in
                 // cflags) leaves a .d next to each .ii; the reuse-cache sidecar is built from those
                 // only after a successful compile (see JitBuildState::write_reuse_cache).
                 const auto args = tt::jit_build::utils::build_gpp_argv(

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -628,13 +628,12 @@ void JitBuildState::write_reuse_cache(std::string_view kernel_name) const {
 void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* settings, size_t src_index) const {
     TTZoneScopedD(JIT);
 
-    // Build the compile recipe (opt/cflags/includes/defines, including kernel-specific
-    // include paths and the named-compile-arg map) ONCE via export_target_recipe, then turn it
-    // into an argv with the shared builder and run it SHELL-FREE via exec_command — the same argv
-    // builder the JIT compile server and preprocess-and-ship use. Shell-free also means map-valued
-    // defines like
-    // -DKERNEL_COMPILE_TIME_ARG_MAP={"name",idx},... need no escaping — each define is one argv
-    // element, passed verbatim (the macro expansion lives in tt_metal/hw/inc/compile_time_args.h).
+    // Build the compile recipe (opt/cflags/includes/defines, including kernel-specific include
+    // paths and the -include for the named-compile-arg map header) ONCE via export_target_recipe,
+    // then turn it into an argv with the shared builder and run it SHELL-FREE via exec_command —
+    // the same argv builder the JIT compile server and preprocess-and-ship use. Shell-free also
+    // means defines carrying shell metacharacters, like -DFULL_KERNEL_NAME="<name>", need no
+    // escaping — each define is one argv element, passed verbatim.
     const tt::jit_build::TargetRecipe recipe = export_target_recipe(settings);
 
     std::string cflags = recipe.cflags;
@@ -967,22 +966,24 @@ tt::jit_build::TargetRecipe JitBuildState::export_target_recipe(const JitBuildSe
     if (settings) {
         // FULL_KERNEL_NAME: consumed by the LLK sanitizer (CTSTR(FULL_KERNEL_NAME)). Emitted
         // shell-free as one verbatim argv element with literal quotes (the unified/remote-JIT
-        // path does no shell expansion), matching the KERNEL_COMPILE_TIME_ARG_MAP convention below.
+        // path does no shell expansion).
         defines.push_back(fmt::format(R"(-DFULL_KERNEL_NAME="{}")", settings->get_full_kernel_name()));
         settings->process_compile_time_args([&defines](const std::vector<uint32_t>& values) {
             if (!values.empty()) {
                 defines.push_back(fmt::format("-DKERNEL_COMPILE_TIME_ARGS={}", fmt::join(values, ",")));
             }
         });
+        // KERNEL_COMPILE_TIME_ARG_MAP arrives as a force-included header (written by genfiles,
+        // see write_named_ct_arg_map_header) rather than a -D define, because one define is one
+        // argv element and the map alone can exceed the per-element MAX_ARG_STRLEN. Two argv
+        // elements, and the bare filename resolves via the "-I.." every compile carries -- so this
+        // recipe stays valid verbatim on the remote compile server, where a client-side absolute
+        // path would not resolve. See NAMED_CT_ARG_MAP_HEADER.
         settings->process_named_compile_time_args(
             [&defines](const std::unordered_map<std::string, uint32_t>& named_args) {
                 if (!named_args.empty()) {
-                    std::string compile_time_arg_map = "-DKERNEL_COMPILE_TIME_ARG_MAP=";
-                    auto it = std::back_inserter(compile_time_arg_map);
-                    for (const auto& [name, value] : named_args) {
-                        fmt::format_to(it, "{{\"{}\",{}}},", name, value);
-                    }
-                    defines.push_back(std::move(compile_time_arg_map));
+                    defines.emplace_back("-include");
+                    defines.emplace_back(tt::jit_build::utils::NAMED_CT_ARG_MAP_HEADER);
                 }
             });
     }

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -26,6 +26,7 @@
 #include <string>
 #include <string_view>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -97,6 +98,29 @@ void write_file(const string& path, const string& content) {
     if (!f) {
         throw std::runtime_error("Failed to write file: " + path);
     }
+}
+
+// Writes the named compile-time-arg map header, which build.cpp force-includes (-include) in place
+// of a -DKERNEL_COMPILE_TIME_ARG_MAP define; see NAMED_CT_ARG_MAP_HEADER for why the map cannot ride
+// on the command line. Emitted for any kernel with named CT args, Metal 2.0 or legacy, blaze or not.
+// Returns true if a header was written.
+//
+// Written here rather than in the build step so it lands in the kernel's generated-files directory
+// alongside the other generated headers, which is what the remote JIT path uploads to the compile
+// server (Program's read_directory_files) and what preprocess-and-ship inlines into the .ii. Every
+// caller of jit_build_genfiles_* runs it immediately before jit_build(), so the file is in place for
+// the local compile too.
+bool write_named_ct_arg_map_header(const string& out_dir, const JitBuildSettings& settings) {
+    std::unordered_map<std::string, uint32_t> named_args;
+    settings.process_named_compile_time_args(
+        [&named_args](const std::unordered_map<std::string, uint32_t>& args) { named_args = args; });
+    if (named_args.empty()) {
+        return false;
+    }
+    write_file(
+        out_dir + string(jit_build::utils::NAMED_CT_ARG_MAP_HEADER),
+        jit_build::utils::format_named_ct_arg_map_header(named_args));
+    return true;
 }
 
 // METAL 2.0 only:
@@ -504,6 +528,9 @@ void jit_build_genfiles_kernel_include(
         kernel_header_content =
             string("#include \"kernel_bindings_generated.h\"\n#include \"kernel_args_generated.h\"\n");
     }
+    // No #include line: this one is force-included by the compile recipe so the map is defined
+    // before any header that reads it (api/compile_time_args.h) can be pulled in.
+    write_named_ct_arg_map_header(out_dir, settings);
     ////////////////////////////////////////////////////////////
     // Blaze-only experimental named args
     // Removal is tracked by issue #50953
@@ -536,6 +563,9 @@ void jit_build_genfiles_triscs_src(
         write_kernel_bindings_generated_header(out_dir, settings);
         write_kernel_args_generated_header(out_dir, settings);
     }
+    // No prolog #include: force-included by the compile recipe instead, so the map is defined ahead
+    // of any header that reads it (api/compile_time_args.h).
+    write_named_ct_arg_map_header(out_dir, settings);
     ////////////////////////////////////////////////////////////
     // Blaze-only experimental named args
     // Removal is tracked by issue #50953

--- a/tt_metal/jit_build/jit_build_utils.cpp
+++ b/tt_metal/jit_build/jit_build_utils.cpp
@@ -88,8 +88,8 @@ std::vector<std::string> build_gpp_argv(
     };
     append(cflags);
     append(includes);
-    // Each define is one argv element, passed verbatim (no shell) — this is what makes
-    // map-valued defines like -DKERNEL_COMPILE_TIME_ARG_MAP={"cb_in0",1},... survive.
+    // Each define is one argv element, passed verbatim (no shell) — this is what makes defines
+    // carrying shell metacharacters, like -DFULL_KERNEL_NAME="<name>", survive unescaped.
     args.insert(args.end(), defines.begin(), defines.end());
     switch (action) {
         case GppAction::Compile:
@@ -217,6 +217,40 @@ std::vector<tt::jit_build::GeneratedFile> read_directory_files(
         }
     }
     return files;
+}
+
+std::string format_named_ct_arg_map(const std::unordered_map<std::string, std::uint32_t>& named_args) {
+    std::vector<const std::pair<const std::string, std::uint32_t>*> sorted;
+    sorted.reserve(named_args.size());
+    for (const auto& entry : named_args) {
+        sorted.push_back(&entry);
+    }
+    std::sort(sorted.begin(), sorted.end(), [](const auto* a, const auto* b) { return a->first < b->first; });
+
+    // Whole-model kernels reach 100 KB+ here; size it up front rather than growing ~1750 times.
+    std::size_t reserved = 0;
+    for (const auto* entry : sorted) {
+        reserved += entry->first.size() + 16;
+    }
+    std::string out;
+    out.reserve(reserved);
+
+    for (const auto* entry : sorted) {
+        if (!out.empty()) {
+            out += ',';
+        }
+        out += "{\"";
+        out += entry->first;
+        out += "\",";
+        out += std::to_string(entry->second);
+        out += '}';
+    }
+    return out;
+}
+
+std::string format_named_ct_arg_map_header(const std::unordered_map<std::string, std::uint32_t>& named_args) {
+    return "// AUTO-GENERATED -- do not edit.\n#pragma once\n\n#define KERNEL_COMPILE_TIME_ARG_MAP " +
+           format_named_ct_arg_map(named_args) + "\n";
 }
 
 void create_file(const std::string& file_path_str) {

--- a/tt_metal/jit_build/jit_build_utils.hpp
+++ b/tt_metal/jit_build/jit_build_utils.hpp
@@ -8,6 +8,8 @@
 #include <filesystem>
 #include <span>
 #include <string>
+#include <string_view>
+#include <unordered_map>
 #include <vector>
 
 #include "jit_build/types.hpp"
@@ -31,7 +33,7 @@ enum class GppAction {
 };
 // Build the argv for a single gpp invocation from recipe fields. The argv is for
 // exec_command() (posix_spawn, NO shell), so defines/flags containing shell metacharacters
-// (e.g. -DKERNEL_COMPILE_TIME_ARG_MAP={"cb_in0",1},...) are passed verbatim — each define is
+// (e.g. -DFULL_KERNEL_NAME="<name>") are passed verbatim — each define is
 // its own argv element and is never re-quoted or shell-split. `opt_level` is the bare level
 // without the leading dash (e.g. "O3"). `dep_path` is used only for Compile.
 // One argv builder shared by the local compile, the remote compile server, and preprocess-and-ship.
@@ -45,6 +47,34 @@ std::vector<std::string> build_gpp_argv(
     GppAction action,
     const std::string& out_path,
     const std::string& dep_path = "");
+
+// Filename, within a kernel's generated-files directory, of the header carrying the named
+// compile-time-arg map (KERNEL_COMPILE_TIME_ARG_MAP, consumed by hw/inc/api/compile_time_args.h).
+//
+// The map travels as a force-included (-include) header instead of a
+// -DKERNEL_COMPILE_TIME_ARG_MAP=... define because one define is one argv element, and the kernel
+// caps a single element at MAX_ARG_STRLEN (32 * PAGE_SIZE = 128 KB) no matter how the compiler is
+// spawned -- posix_spawn removes the whole-command ceiling, not the per-element one. Kernels
+// emitting thousands of long named args cross it on the strength of this one define alone, and the
+// only symptom is "posix_spawnp failed for .../riscv-tt-elf-g++: Argument list too long", which
+// names neither the define nor a size limit. File contents are not subject to that limit.
+//
+// A bare filename (not a path) is deliberate: it resolves through the "-I.." carried by every
+// compile, since a kernel's generated-files directory is the parent of its per-target out_dir on
+// both the local and the JIT-compile-server layouts. That keeps one recipe valid on both sides of
+// the RPC, where an absolute client-side path would not exist on the server.
+inline constexpr std::string_view NAMED_CT_ARG_MAP_HEADER = "named_ct_arg_map_generated.h";
+
+// Render |named_args| as the initializer body of KERNEL_COMPILE_TIME_ARG_MAP:
+//   {"a",1},{"b",2}
+// Empty when |named_args| is empty. Entries are emitted in ascending key order so the text is
+// byte-identical for a given arg set: std::unordered_map iteration order is not reproducible, and
+// this text feeds both the on-disk generated header (per-object dephash cache) and, for emule, the
+// wrapper source.
+std::string format_named_ct_arg_map(const std::unordered_map<std::string, std::uint32_t>& named_args);
+
+// Full contents of NAMED_CT_ARG_MAP_HEADER for |named_args|.
+std::string format_named_ct_arg_map_header(const std::unordered_map<std::string, std::uint32_t>& named_args);
 
 void create_file(const std::string& file_path_str);
 


### PR DESCRIPTION
## Problem

Every named compile-time arg a kernel registers is packed into one long
`-DKERNEL_COMPILE_TIME_ARG_MAP={...}` flag. Linux limits any single command-line argument
to 128 KB, so once a kernel's arg list is big enough, it simply cannot be compiled. The
only symptom points at the compiler:

```
posix_spawnp failed for .../riscv-tt-elf-g++: Argument list too long (jit_build_utils.cpp:156)
→ ncrisc build failed
→ Failed to generate binaries for gemma4_sliding_window_decoder_layer
```

Nothing there mentions compile-time args or a size limit. That one flag is essentially the
whole command line — the next longest argument on a failing compile is under 200 bytes.

This is not specific to one model. Large fused ops emit hundreds to thousands of named
args, and each arg name repeats the op's full naming scope, so names average ~75 bytes and
the ceiling lands around 1,750 args. Several tt-blaze models are already close:

| kernel | named args | % of limit |
|---|---|---|
| `gemma4_global_decoder_layer` | 1,293 | ~74% |
| `gemma4_sliding_window_decoder_layer` | 1,256 | ~72% |
| `dflash_decoder` | 1,098 | ~63% |
| `minimax_m2_global_layer` | 1,089 | ~62% |

The reported failure measured 131,755 bytes against the 131,072 limit — over by 0.5%.

Note that the 128 KB limit applies to each argument individually, so switching the JIT
build to `posix_spawn` did not help here: it removed the cap on total command length, but
this single flag exceeds the per-argument cap on its own.

## Fix

Write the arg list into a small generated header per kernel and have the compiler include
it automatically, instead of passing it as a flag. File contents have no size limit, so the
command line stays short no matter how many args a kernel has.

Kernels see no difference: `KERNEL_COMPILE_TIME_ARG_MAP` is defined exactly as before, and
`get_named_compile_time_arg_val()` keeps working everywhere it is used.

Three details worth calling out:

- The header is written alongside the other generated per-kernel headers rather than at
  build time. That directory is already uploaded to the remote compile server and already
  folded into preprocessed output, so local builds, remote builds, and preprocessed builds
  all pick it up with no new plumbing.
- The include uses a plain filename, not a full path. The remote compile server lays its
  directories out differently from the local build, and both already search the right
  parent directory, so one setting works on both. A local absolute path would build fine
  here and then fail on the server.
- Args are sorted by name. They come from an unordered map, so their order otherwise varies
  between runs; sorting keeps the generated file identical run to run, which the build
  cache depends on.

Caching is unaffected: the named args are already part of the hash that picks a kernel's
output directory, so a changed arg list lands in a different directory, and the new header
is tracked as a dependency of every object built from it.

The emulator path had the same problem, and worse — it runs its compile through a shell, so
it is limited by *total* command length. It now writes the arg list into the generated
wrapper source, which is already where that path puts kernel defines to keep long or
awkward values off the command line. Both paths share one formatter, so they produce
identical text.

Fixes tenstorrent/tt-blaze#2017
Fixes tenstorrent/tt-blaze#3209
