### PR TITLE
Refactor DEVICE_PRINT tests to utilize Metal 2.0 API

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
+++ b/tests/tt_metal/tt_metal/debug_tools/CMakeLists.txt
@@ -12,7 +12,12 @@ function(create_unit_test_executable)
     target_precompile_headers(${exec_name} REUSE_FROM metal_common_pch)
 
     # Link libraries
-    target_link_libraries(${exec_name} PRIVATE test_metal_common_libs)
+    target_link_libraries(
+        ${exec_name}
+        PRIVATE
+            test_metal_common_libs
+            ttexalens::elf
+    )
 
     # Set include directories
     target_include_directories(

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -23,6 +23,11 @@
 #include "impl/program/program_impl.hpp"
 #include "impl/kernels/kernel.hpp"
 
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <filesystem>
+
 namespace tt::tt_metal {
 
 class DebugToolsMeshFixture : public MeshDispatchFixture {
@@ -321,41 +326,38 @@ protected:
 public:
     std::string dprint_file_name;
 
+    // Hardware config for a single-threaded data-movement kernel, portable across generations.
+    static experimental::DataMovementHardwareConfig SingleThreadDmConfig(tt::ARCH arch) {
+        if (arch == tt::ARCH::QUASAR) {
+            return experimental::DataMovementGen2Config{};
+        }
+        return experimental::DataMovementGen1Config{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0};
+    }
+
+    // Compiles the kernel and returns the path to its ELF, so the caller can inspect the binary.
     std::string CompileKernel(const std::string& kernel_path, stl::Span<const uint32_t> runtime_args = {}) {
         // Get the first available mesh device
         auto mesh_device = this->devices_.at(0);
 
-        // Set up program
-        distributed::MeshWorkload workload;
-        auto zero_coord = distributed::MeshCoordinate(0, 0);
-        auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-        Program program = Program();
-        workload.add_program(device_range, std::move(program));
-        auto& program_ = workload.get_programs().at(device_range);
+        // MakeProgramFromSpec compiles eagerly, so the ELF exists on disk once it returns and a
+        // build failure surfaces here as a throw (which the compilation-failure tests rely on).
+        auto spec = MakeSingleDmPrintSpec(mesh_device->arch(), kernel_path, runtime_args.size());
+        Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+        SetSingleDmPrintArgs(program, runtime_args);
 
-        // This tests prints only on a single core
-        constexpr CoreCoord core = {0, 0};  // Print on first core only
-        DataMovementConfig config{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default};
-        KernelHandle kernel_handle = CreateKernel(program_, kernel_path, core, config);
-
-        SetRuntimeArgs(program_, kernel_handle, core, runtime_args);
         auto* device = mesh_device->get_devices()[0];
-        detail::CompileProgram(device, program_);
-
-        // Find compiled kernel and extract format string from it to compare with expected_format_message
         const auto& hal = tt::tt_metal::MetalContext::instance().hal();
         uint32_t tensix_core_type = hal.get_programmable_core_type_index(tt::tt_metal::HalProgrammableCoreType::TENSIX);
         uint32_t dm_class_idx = enchantum::to_underlying(tt::tt_metal::HalProcessorClassType::DM);
 
-        int riscv_id = static_cast<std::underlying_type_t<tt::tt_metal::DataMovementProcessor>>(config.processor);
+        const auto& kernel = program.impl().get_kernel_by_spec_name(kPrintKernelName.get());
+        const int riscv_id = static_cast<int>(kernel->get_kernel_processor_type(0));
 
         const auto& build_state =
             tt::tt_metal::BuildEnvManager::get_instance(extract_context_id(device))
                 .get_kernel_build_state(device->build_id(), tensix_core_type, dm_class_idx, riscv_id);
 
-        const auto& kernel = program_.impl().get_kernel(kernel_handle);
-        const std::string full_kernel_name = kernel->get_full_kernel_name();
-        return build_state.get_target_out_path(full_kernel_name);
+        return build_state.get_target_out_path(kernel->get_full_kernel_name());
     }
 
     // A function to run a program, according to which dispatch mode is set.
@@ -363,20 +365,14 @@ public:
         const std::shared_ptr<distributed::MeshDevice>& mesh_device,
         const std::string& kernel_path,
         stl::Span<const uint32_t> runtime_args = {}) {
-        // Set up program
+        auto spec = MakeSingleDmPrintSpec(mesh_device->arch(), kernel_path, runtime_args.size());
+        Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+        SetSingleDmPrintArgs(program, runtime_args);
+
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-        Program program = Program();
         workload.add_program(device_range, std::move(program));
-        auto& program_ = workload.get_programs().at(device_range);
-
-        // This tests prints only on a single core
-        constexpr CoreCoord core = {0, 0};  // Print on first core only
-        DataMovementConfig config{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default};
-        KernelHandle kernel_handle = CreateKernel(program_, kernel_path, core, config);
-
-        SetRuntimeArgs(program_, kernel_handle, core, runtime_args);
 
         // Only difference is that we need to wait for the print server to catch
         // up after running a test.
@@ -397,6 +393,43 @@ public:
         const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
         DebugToolsMeshFixture::RunTestOnDevice(run_function, mesh_device);
         MetalContext::instance().dprint_server()->clear_log_file();
+    }
+
+private:
+    static constexpr experimental::NodeCoord kPrintNode{0, 0};
+    static inline const experimental::KernelSpecName kPrintKernelName{"dprint"};
+
+    // A one-kernel data-movement ProgramSpec for the DPRINT tests.
+    static experimental::ProgramSpec MakeSingleDmPrintSpec(
+        tt::ARCH arch, const std::string& kernel_path, size_t num_args) {
+        return experimental::ProgramSpec{
+            .name = "dprint",
+            .kernels = {experimental::KernelSpec{
+                .unique_id = kPrintKernelName,
+                .source = std::filesystem::path{kernel_path},
+                .num_threads = 1,
+                .hw_config = SingleThreadDmConfig(arch),
+                .advanced_options =
+                    experimental::KernelAdvancedOptions{.num_runtime_varargs = static_cast<uint32_t>(num_args)},
+            }},
+            .work_units = {experimental::WorkUnitSpec{
+                .name = "main", .kernels = {kPrintKernelName}, .target_nodes = kPrintNode}},
+        };
+    }
+
+    // SetProgramRunArgs requires an entry for every kernel that declares runtime args and rejects
+    // entries for kernels that declare none, so this is a no-op when the kernel takes no arguments.
+    static void SetSingleDmPrintArgs(Program& program, stl::Span<const uint32_t> runtime_args) {
+        if (runtime_args.empty()) {
+            return;
+        }
+        experimental::ProgramRunArgs::KernelRunArgs kernel_run_args{.kernel = kPrintKernelName};
+        kernel_run_args.advanced_options.runtime_varargs[kPrintNode] =
+            std::vector<uint32_t>(runtime_args.begin(), runtime_args.end());
+
+        experimental::ProgramRunArgs run_args;
+        run_args.kernel_run_args.push_back(std::move(kernel_run_args));
+        experimental::SetProgramRunArgs(program, run_args);
     }
 };
 

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_format_updates.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_format_updates.cpp
@@ -2,16 +2,40 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
+#include <vector>
+
 #include "debug_tools_fixture.hpp"
-#include "tt_metal/llrt/tt_elffile.hpp"
 #include "hostdev/device_print_structures.h"
+#include "elf_file.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
-using namespace ll_api;
 using namespace std::string_view_literals;
 
-using DevicePrintStringInfo = device_print_detail::structures::DevicePrintStringInfo32;
+namespace {
+
+using StringInfo32 = device_print_detail::structures::DevicePrintStringInfo32;
+using StringInfo64 = device_print_detail::structures::DevicePrintStringInfo64;
+
+template <typename InfoT>
+std::vector<StringInfo64> ReadStringInfos(std::span<const std::byte> info_bytes) {
+    const auto* entries = reinterpret_cast<const InfoT*>(info_bytes.data());
+    const size_t count = info_bytes.size() / sizeof(InfoT);
+
+    std::vector<StringInfo64> infos;
+    infos.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        infos.push_back(StringInfo64{
+            .format_string_ptr = entries[i].format_string_ptr,
+            .file = entries[i].file,
+            .line = entries[i].line,
+            .padding = entries[i].padding});
+    }
+    return infos;
+}
+
+}  // namespace
 
 class DevicePrintFormatUpdatesFixture : public DevicePrintFixture {
 public:
@@ -21,43 +45,38 @@ public:
         stl::Span<const uint32_t> runtime_args = {}) {
         const std::string elf_file_path = CompileKernel(kernel_path, runtime_args);
 
-        // Read device_print sections from ELF
-        ElfFile elf;
-        elf.ReadImage(elf_file_path);
+        // Same reader the DEVICE_PRINT server uses (DevicePrintParser::get_parser_for_elf). It also
+        // reports the ELF's pointer size, which is what selects the matching string-info layout:
+        // the entries are pointer-sized, so they are 4 bytes wide on Wormhole/Blackhole and 8 on
+        // Quasar.
+        ttexalens::native_elf::ElfFile elf(elf_file_path);
 
-        std::cout << "ELF file read successfully: " << elf_file_path << std::endl;
+        const auto* info_section = elf.get_section_by_name(".device_print_strings_info");
+        const auto* strings_section = elf.get_section_by_name(".device_print_strings");
+        ASSERT_NE(info_section, nullptr);
+        ASSERT_NE(strings_section, nullptr);
 
-        const auto& segments = elf.GetSegments();
-        ASSERT_FALSE(segments.empty());
-        uint64_t format_strings_info_address = 0;
-        std::span<std::byte> format_strings_info_bytes =
-            elf.GetSectionContents(".device_print_strings_info", format_strings_info_address);
+        const std::span<const std::byte> format_strings_info_bytes = info_section->data();
+        const std::span<const std::byte> format_strings_bytes = strings_section->data();
+        const uint64_t format_strings_address = strings_section->address();
         ASSERT_FALSE(format_strings_info_bytes.empty());
-        uint64_t format_strings_address = 0;
-        std::span<std::byte> format_strings_bytes =
-            elf.GetSectionContents(".device_print_strings", format_strings_address);
         ASSERT_FALSE(format_strings_bytes.empty());
 
-        // Extract strings from sections
-        DevicePrintStringInfo* info_ptr = reinterpret_cast<DevicePrintStringInfo*>(format_strings_info_bytes.data());
-        size_t num_messages = format_strings_info_bytes.size() / sizeof(DevicePrintStringInfo);
+        const std::vector<StringInfo64> string_infos = elf.get_pointer_size() == 8
+                                                           ? ReadStringInfos<StringInfo64>(format_strings_info_bytes)
+                                                           : ReadStringInfos<StringInfo32>(format_strings_info_bytes);
+
+        // An entry's format_string_ptr and file are both addresses into the strings section.
+        const auto string_at = [&](uint64_t address) {
+            return std::string_view(
+                reinterpret_cast<const char*>(format_strings_bytes.data() + (address - format_strings_address)));
+        };
 
         for (const auto& expected_format_message : expected_format_messages) {
-            bool found = false;
-            for (size_t i = 0; i < num_messages; ++i) {
-                const DevicePrintStringInfo& info = info_ptr[i];
-                const char* format_string = reinterpret_cast<const char*>(
-                    format_strings_bytes.data() + (info.format_string_ptr - format_strings_address));
-                std::string_view format_str(format_string);
-                const char* file_string =
-                    reinterpret_cast<const char*>(format_strings_bytes.data() + (info.file - format_strings_address));
-                std::string_view file_str(file_string);
-                if (format_str == expected_format_message && file_str.ends_with(kernel_path)) {
-                    // Found expected format string
-                    found = true;
-                    break;
-                }
-            }
+            const bool found = std::ranges::any_of(string_infos, [&](const StringInfo64& info) {
+                return string_at(info.format_string_ptr) == expected_format_message &&
+                       string_at(info.file).ends_with(kernel_path);
+            });
             if (!found) {
                 FAIL() << "Expected format string not found: " << expected_format_message;
             }

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_mesh_coords.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_mesh_coords.cpp
@@ -82,17 +82,27 @@ void ConfigureDevicePrintForCoord(
 // so the DEVICE_PRINT output directly matches what was configured in the DEVICE_PRINT filter.
 distributed::MeshWorkload BuildMeshCoordWorkload(const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
     distributed::MeshWorkload workload;
-    constexpr CoreCoord kCore = {0, 0};
+    constexpr experimental::NodeCoord kNode = {0, 0};
+    const experimental::KernelSpecName kKernel{"mesh_coord_print"};
+
     for (const auto& coord : distributed::MeshCoordinateRange(mesh_device->shape())) {
         auto [row, col] = GetGlobalCoord(mesh_device->get_device(coord)->id());
-        Program program;
-        CreateKernel(
-            program,
-            "tests/tt_metal/tt_metal/test_kernels/device_print/print_mesh_coord.cpp",
-            kCore,
-            DataMovementConfig{
-                .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default, .compile_args = {row, col}});
-        workload.add_program(distributed::MeshCoordinateRange(coord, coord), std::move(program));
+
+        experimental::ProgramSpec spec{
+            .name = "dprint_mesh_coord",
+            .kernels = {experimental::KernelSpec{
+                .unique_id = kKernel,
+                .source =
+                    std::filesystem::path{"tests/tt_metal/tt_metal/test_kernels/device_print/print_mesh_coord.cpp"},
+                .num_threads = 1,
+                .compile_time_args = {{"row", row}, {"col", col}},
+                .hw_config = DevicePrintFixture::SingleThreadDmConfig(mesh_device->arch()),
+            }},
+            .work_units = {experimental::WorkUnitSpec{.name = "main", .kernels = {kKernel}, .target_nodes = kNode}},
+        };
+
+        workload.add_program(
+            distributed::MeshCoordinateRange(coord, coord), experimental::MakeProgramFromSpec(*mesh_device, spec));
     }
     return workload;
 }

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_multi_kernel_print.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_multi_kernel_print.cpp
@@ -48,6 +48,26 @@ Program& add_empty_program(distributed::MeshWorkload& workload) {
     return workload.get_programs().at(range);
 }
 
+// One print kernel per node, each its own KernelSpec in its own WorkUnit. These tests are about a
+// program carrying several distinct kernels, so this deliberately does not collapse them into a
+// single kernel fanned out over a node range.
+Program make_worker_print_program(
+    distributed::MeshDevice& mesh_device, const std::vector<experimental::NodeCoord>& nodes) {
+    experimental::ProgramSpec spec{.name = "dprint_multi_kernel"};
+    for (size_t i = 0; i < nodes.size(); i++) {
+        const experimental::KernelSpecName name{"worker_print_" + std::to_string(i)};
+        spec.kernels.push_back(experimental::KernelSpec{
+            .unique_id = name,
+            .source = std::filesystem::path{kWorkerKernel},
+            .num_threads = 1,
+            .hw_config = DevicePrintFixture::SingleThreadDmConfig(mesh_device.arch()),
+        });
+        spec.work_units.push_back(
+            experimental::WorkUnitSpec{.name = "wu_" + std::to_string(i), .kernels = {name}, .target_nodes = nodes[i]});
+    }
+    return experimental::MakeProgramFromSpec(mesh_device, spec);
+}
+
 EthernetConfig make_active_eth_config() {
     constexpr DataMovementProcessor processor = DataMovementProcessor::RISCV_0;
     EthernetConfig config{.noc = static_cast<NOC>(processor), .processor = processor};
@@ -61,17 +81,16 @@ EthernetConfig make_active_eth_config() {
 // Single program, two BRISC kernels on two different worker cores.
 TEST_F(DevicePrintFixture, TwoWorkerKernelsSameProgram) {
     for (auto& mesh_device : this->devices_) {
-        distributed::MeshWorkload workload;
-        Program& program = add_empty_program(workload);
-
-        const std::vector<CoreCoord> cores = {{0, 0}, {1, 0}};
-        for (const auto& core : cores) {
-            CreateKernel(
-                program,
-                kWorkerKernel,
-                core,
-                DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+        // Kernel placement is bounds-checked against the compute grid, which is a single node on
+        // some Quasar configurations.
+        const CoreCoord grid = mesh_device->compute_with_storage_grid_size();
+        if (grid.x < 2) {
+            log_info(tt::LogTest, "Skipping device (need a compute grid at least 2 wide, have {}x{})", grid.x, grid.y);
+            continue;
         }
+
+        distributed::MeshWorkload workload;
+        workload.add_program(single_device_range(), make_worker_print_program(*mesh_device, {{0, 0}, {1, 0}}));
 
         this->RunProgram(mesh_device, workload);
         EXPECT_TRUE(FileContainsAllStrings(this->dprint_file_name, kWorkerExpected));
@@ -105,15 +124,9 @@ TEST_F(DevicePrintFixture, TwoActiveEthKernelsSameProgram) {
 // Two programs run back-to-back on the same worker core / RISC.
 TEST_F(DevicePrintFixture, TwoWorkerProgramsBackToBack) {
     for (auto& mesh_device : this->devices_) {
-        constexpr CoreCoord core = {0, 0};
         for (int i = 0; i < 2; i++) {
             distributed::MeshWorkload workload;
-            Program& program = add_empty_program(workload);
-            CreateKernel(
-                program,
-                kWorkerKernel,
-                core,
-                DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+            workload.add_program(single_device_range(), make_worker_print_program(*mesh_device, {{0, 0}}));
             this->RunProgram(mesh_device, workload);
         }
 

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_mute_device.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_mute_device.cpp
@@ -51,33 +51,12 @@ protected:
 namespace {
 namespace CMAKE_UNIQUE_NAMESPACE {
 void RunTest(DevicePrintFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-    // Set up program and command queue
-    constexpr CoreCoord core = {0, 0};  // Print on first core only
-    distributed::MeshWorkload workload;
-    auto device_range =
-        distributed::MeshCoordinateRange(distributed::MeshCoordinate(0, 0), distributed::MeshCoordinate(0, 0));
-    Program program = Program();
-    workload.add_program(device_range, std::move(program));
-    auto& program_ = workload.get_programs().at(device_range);
-
-    // Create a CB for testing TSLICE, dimensions are 32x32 bfloat16s
-    constexpr uint32_t src0_cb_index = CBIndex::c_0;
-    constexpr uint32_t buffer_size = 32 * 32 * sizeof(bfloat16);
-    CircularBufferConfig cb_src0_config =
-        CircularBufferConfig(buffer_size, {{src0_cb_index, tt::DataFormat::Float16_b}})
-            .set_page_size(src0_cb_index, buffer_size);
-    tt_metal::CreateCircularBuffer(program_, core, cb_src0_config);
-
     // This kernel is enough to fill up the print buffer, even though the device is not being
     // printed from, we still need to drain the print buffer to prevent hanging the core.
-    CreateKernel(
-        program_,
-        "tests/tt_metal/tt_metal/test_kernels/device_print/print_all_argument_sizes.cpp",
-        core,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
-
-    // Run the program
-    fixture->RunProgram(mesh_device, workload);
+    //
+    // (There used to be a circular buffer here "for testing TSLICE", but print_all_argument_sizes.cpp
+    // contains nothing but DEVICE_PRINT calls and never touched it, so it was dead weight.)
+    fixture->RunProgram(mesh_device, "tests/tt_metal/tt_metal/test_kernels/device_print/print_all_argument_sizes.cpp");
 
     // Check that the log file is empty.
     std::fstream log_file;

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_before_finish.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_before_finish.cpp
@@ -32,35 +32,17 @@ namespace CMAKE_UNIQUE_NAMESPACE {
 namespace {
 
 void RunTest(DevicePrintFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-    // Set up program
-    distributed::MeshWorkload workload;
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    Program program = Program();
-    workload.add_program(device_range, std::move(program));
-    auto& program_ = workload.get_programs().at(device_range);
     auto* device = mesh_device->get_devices()[0];
 
     // This tests prints only on a single core
     CoreCoord xy_start = {0, 0};
     CoreCoord xy_end = {0, 0};
 
-    KernelHandle brisc_print_kernel_id = CreateKernel(
-        program_,
-        "tests/tt_metal/tt_metal/test_kernels/device_print/print_with_wait.cpp",
-        CoreRange(xy_start, xy_end),
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
-
     // Run the program, use a large delay for the last print to emulate a long-running kernel.
     uint32_t clk_mhz = tt::tt_metal::MetalContext::instance().get_cluster().get_device_aiclk(device->id());
     uint32_t delay_cycles = clk_mhz * 4000000;  // 4 seconds
-    for (uint32_t x = xy_start.x; x <= xy_end.x; x++) {
-        for (uint32_t y = xy_start.y; y <= xy_end.y; y++) {
-            const std::vector<uint32_t> args = {delay_cycles, x, y};
-            SetRuntimeArgs(program_, brisc_print_kernel_id, CoreCoord{x, y}, args);
-        }
-    }
-    fixture->RunProgram(mesh_device, workload);
+    const std::vector<uint32_t> args = {delay_cycles, xy_start.x, xy_start.y};
+    fixture->RunProgram(mesh_device, "tests/tt_metal/tt_metal/test_kernels/device_print/print_with_wait.cpp", args);
     // Close system instantly after running to attempt to cut off prints.
     fixture->TearDownTestSuite();
 

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_config_register.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_config_register.cpp
@@ -373,7 +373,7 @@ TEST_F(DevicePrintFixture, ConfigRegAluTestPrint) {
     // Setup test configuration
     ConfigRegPrintTestConfig test_config = {
         .core = CoreCoord(0, 0),
-        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp",
+        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/device_print/writer_config_reg.cpp",
         .num_of_registers = 1,
         .field_names = field_names_alu_config,
         .field_values = field_values_alu_config,
@@ -398,7 +398,7 @@ TEST_F(DevicePrintFixture, ConfigRegTileDescriptorTestPrint) {
 
     ConfigRegPrintTestConfig test_config = {
         .core = CoreCoord(0, 0),
-        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp",
+        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/device_print/writer_config_reg.cpp",
         .num_of_registers = 2,
         .field_names = field_names_unpack_tile_descriptor,
         .field_values = field_values_unpack_tile_descriptor,
@@ -422,7 +422,7 @@ TEST_F(DevicePrintFixture, ConfigRegUnpackTestPrint) {
     // Setup test configuration
     ConfigRegPrintTestConfig test_config = {
         .core = CoreCoord(0, 0),
-        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp",
+        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/device_print/writer_config_reg.cpp",
         .num_of_registers = 2,
         .field_names = field_names_unpack_config,
         .field_values = field_values_unpack_config,
@@ -458,7 +458,7 @@ TEST_F(DevicePrintFixture, ConfigRegPackTestPrint) {
     // Setup test configuration
     ConfigRegPrintTestConfig test_config = {
         .core = CoreCoord(0, 0),
-        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp",
+        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/device_print/writer_config_reg.cpp",
         .num_of_registers = num_of_registers,
         .field_names = field_names_pack_config,
         .field_values = field_values_pack_config,
@@ -479,7 +479,7 @@ TEST_F(DevicePrintFixture, ConfigRegReluTestPrint) {
     // Setup test configuration
     ConfigRegPrintTestConfig test_config = {
         .core = CoreCoord(0, 0),
-        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp",
+        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/device_print/writer_config_reg.cpp",
         .num_of_registers = 1,
         .field_names = field_names_relu_config,
         .field_values = field_values_relu_config,
@@ -500,7 +500,7 @@ TEST_F(DevicePrintFixture, ConfigRegDestRdCtrlTestPrint) {
     // Setup test configuration
     ConfigRegPrintTestConfig test_config = {
         .core = CoreCoord(0, 0),
-        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp",
+        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/device_print/writer_config_reg.cpp",
         .num_of_registers = 1,
         .field_names = field_names_dest_rd_ctrl,
         .field_values = field_values_dest_rd_ctrl,
@@ -523,7 +523,7 @@ TEST_F(DevicePrintFixture, ConfigRegPackEdgeOffsetTestPrint) {
     // Setup test configuration
     ConfigRegPrintTestConfig test_config = {
         .core = CoreCoord(0, 0),
-        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp",
+        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/device_print/writer_config_reg.cpp",
         .num_of_registers = num_of_registers,
         .field_names = field_names_pack_edge_offset,
         .field_values = field_values_pack_edge_offset,
@@ -546,7 +546,7 @@ TEST_F(DevicePrintFixture, ConfigRegPackCountersTestPrint) {
     // Setup test configuration
     ConfigRegPrintTestConfig test_config = {
         .core = CoreCoord(0, 0),
-        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp",
+        .write_kernel = "tests/tt_metal/tt_metal/test_kernels/device_print/writer_config_reg.cpp",
         .num_of_registers = num_of_registers,
         .field_names = field_names_pack_counters,
         .field_values = field_values_pack_counters,

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_config_register.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_config_register.cpp
@@ -277,13 +277,29 @@ static std::string int_to_hex(int value) {
     return ss.str();
 }
 
-// Prepares the compute kernel with the specified program and test configuration
-static KernelHandle prepare_writer(distributed::MeshWorkload& workload, const ConfigRegPrintTestConfig& config) {
-    auto zero_coord = distributed::MeshCoordinate(0, 0);
-    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    auto& program_ = workload.get_programs().at(device_range);
-    return tt_metal::CreateKernel(
-        program_, config.write_kernel, config.core, tt_metal::ComputeConfig{.compile_args = {config.register_name}});
+// Builds the compute-kernel program for the specified test configuration.
+static Program make_writer_program(distributed::MeshDevice& mesh_device, const ConfigRegPrintTestConfig& config) {
+    experimental::ComputeHardwareConfig hw_config;
+    if (mesh_device.arch() == tt::ARCH::QUASAR) {
+        hw_config = experimental::ComputeGen2Config{};
+    } else {
+        hw_config = experimental::ComputeGen1Config{};
+    }
+
+    const experimental::KernelSpecName kKernel{"config_reg_writer"};
+    experimental::ProgramSpec spec{
+        .name = "dprint_config_reg",
+        .kernels = {experimental::KernelSpec{
+            .unique_id = kKernel,
+            .source = std::filesystem::path{config.write_kernel},
+            .num_threads = 1,
+            .compile_time_args = {{"register_name", config.register_name}},
+            .hw_config = hw_config,
+        }},
+        .work_units = {experimental::WorkUnitSpec{
+            .name = "main", .kernels = {kKernel}, .target_nodes = experimental::NodeCoord{config.core}}},
+    };
+    return experimental::MakeProgramFromSpec(mesh_device, spec);
 }
 
 static std::string generate_golden_output(
@@ -329,15 +345,15 @@ static void print_config_reg(
     DevicePrintFixture* fixture,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     const ConfigRegPrintTestConfig& config) {
+    if (mesh_device->arch() == tt::ARCH::QUASAR) {
+        GTEST_SKIP() << "Tensix config registers are Gen1-only (no ckernel_debug.h for Quasar)";
+    }
+
     // Create program
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    tt_metal::Program program = tt_metal::CreateProgram();
-    workload.add_program(device_range, std::move(program));
-
-    // Prepare write kernel
-    [[maybe_unused]] auto write_kernel = prepare_writer(workload, config);
+    workload.add_program(device_range, make_writer_program(*mesh_device, config));
 
     // Generate golden output
     std::string golden_output =

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
@@ -95,6 +95,30 @@ experimental::ProgramSpec MakeQuasarPrintSpec(
     return spec;
 }
 
+// A single compute kernel on `node`, portable across generations. Gen1 runs it on TRISC0/1/2; Gen2
+// runs it on one Tensix engine's TRISCs. Both satisfy the tests that only assert on printed strings.
+experimental::ProgramSpec MakeComputePrintSpec(
+    tt::ARCH arch, std::string_view kernel_path, const experimental::NodeCoord& node = kDefaultPrintNode) {
+    experimental::ComputeHardwareConfig hw_config;
+    if (arch == tt::ARCH::QUASAR) {
+        hw_config = experimental::ComputeGen2Config{};
+    } else {
+        hw_config = experimental::ComputeGen1Config{};
+    }
+
+    const experimental::KernelSpecName name{"compute_print"};
+    return experimental::ProgramSpec{
+        .name = "dprint_compute",
+        .kernels = {experimental::KernelSpec{
+            .unique_id = name,
+            .source = std::filesystem::path{kernel_path},
+            .num_threads = 1,
+            .hw_config = hw_config,
+        }},
+        .work_units = {experimental::WorkUnitSpec{.name = "main", .kernels = {name}, .target_nodes = node}},
+    };
+}
+
 // Gives every kernel in the spec its iteration count as vararg 0. The node is read back out of the
 // spec so it cannot drift from the one the kernels were placed on.
 experimental::ProgramRunArgs MakeIterationArgs(const experimental::ProgramSpec& spec, uint32_t iterations) {
@@ -619,16 +643,10 @@ TEST_F(DevicePrintOutputFixture, PrintInlineFunction) {
         distributed::MeshWorkload workload;
         auto zero_coord = distributed::MeshCoordinate(0, 0);
         auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-        Program program = Program();
-        workload.add_program(device_range, std::move(program));
-        auto& program_ = workload.get_programs().at(device_range);
 
-        constexpr CoreCoord core = {0, 0};
-        CreateKernel(
-            program_,
-            "tests/tt_metal/tt_metal/test_kernels/device_print/print_inline_function.cpp",
-            core,
-            ComputeConfig{});
+        auto spec = MakeComputePrintSpec(
+            mesh_device->arch(), "tests/tt_metal/tt_metal/test_kernels/device_print/print_inline_function.cpp");
+        workload.add_program(device_range, experimental::MakeProgramFromSpec(*mesh_device, spec));
 
         RunProgram(mesh_device, workload);
         MetalContext::instance().dprint_server()->await();

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_prepend_device_core_risc.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_prepend_device_core_risc.cpp
@@ -49,6 +49,50 @@ void UpdateGoldenOutput(
     }
 }
 
+constexpr const char* kPrintSimpleKernel = "tests/tt_metal/tt_metal/test_kernels/device_print/print_simple.cpp";
+
+// The Tensix half of the test, on the Metal 2.0 host API: BRISC + NCRISC + compute on every core in
+// `cores`. This is Gen1-only by construction -- the golden output below spells out the Gen1 RISC
+// names (BR/NC/TR0/TR1/TR2), which have no Gen2 equivalent.
+Program MakeTensixPrependProgram(distributed::MeshDevice& mesh_device, const CoreRange& cores) {
+    const experimental::KernelSpecName kBrisc{"prepend_brisc"};
+    const experimental::KernelSpecName kNcrisc{"prepend_ncrisc"};
+    const experimental::KernelSpecName kCompute{"prepend_compute"};
+    const auto source = std::filesystem::path{kPrintSimpleKernel};
+
+    // Two dedicated-NOC DM kernels on one node must take distinct NOCs, or spec validation rejects
+    // them (and the hardware would deadlock).
+    experimental::ProgramSpec spec{
+        .name = "dprint_prepend",
+        .kernels =
+            {experimental::KernelSpec{
+                 .unique_id = kBrisc,
+                 .source = source,
+                 .num_threads = 1,
+                 .hw_config =
+                     experimental::DataMovementGen1Config{
+                         .processor = DataMovementProcessor::RISCV_0, .noc = NOC::NOC_0},
+             },
+             experimental::KernelSpec{
+                 .unique_id = kNcrisc,
+                 .source = source,
+                 .num_threads = 1,
+                 .hw_config =
+                     experimental::DataMovementGen1Config{
+                         .processor = DataMovementProcessor::RISCV_1, .noc = NOC::NOC_1},
+             },
+             experimental::KernelSpec{
+                 .unique_id = kCompute,
+                 .source = source,
+                 .num_threads = 1,
+                 .hw_config = experimental::ComputeGen1Config{},
+             }},
+        .work_units = {experimental::WorkUnitSpec{
+            .name = "main", .kernels = {kBrisc, kNcrisc, kCompute}, .target_nodes = experimental::NodeRange{cores}}},
+    };
+    return experimental::MakeProgramFromSpec(mesh_device, spec);
+}
+
 void RunTest(
     DevicePrintFixture* fixture,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
@@ -59,25 +103,27 @@ void RunTest(
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    Program program = Program();
-    workload.add_program(device_range, std::move(program));
-    auto& program_ = workload.get_programs().at(device_range);
     auto* device = mesh_device->get_devices()[0];
 
-    CreateKernel(
-        program_,
-        "tests/tt_metal/tt_metal/test_kernels/device_print/print_simple.cpp",
-        cores,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+    // The ethernet variant still needs the legacy API (Metal 2.0 places kernels on Tensix only), and
+    // a Program cannot mix the two APIs -- so that variant keeps the whole program on the old path.
+    Program program = add_active_eth_kernel ? Program() : MakeTensixPrependProgram(*mesh_device, cores);
+    workload.add_program(device_range, std::move(program));
+    auto& program_ = workload.get_programs().at(device_range);
 
-    CreateKernel(
-        program_,
-        "tests/tt_metal/tt_metal/test_kernels/device_print/print_simple.cpp",
-        cores,
-        DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
-
-    CreateKernel(
-        program_, "tests/tt_metal/tt_metal/test_kernels/device_print/print_simple.cpp", cores, ComputeConfig{});
+    if (add_active_eth_kernel) {
+        CreateKernel(
+            program_,
+            kPrintSimpleKernel,
+            cores,
+            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+        CreateKernel(
+            program_,
+            kPrintSimpleKernel,
+            cores,
+            DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+        CreateKernel(program_, kPrintSimpleKernel, cores, ComputeConfig{});
+    }
 
     for ([[maybe_unused]] const CoreCoord& core : cores) {
         UpdateGoldenOutput(golden_output, mesh_device, "BR");
@@ -92,7 +138,7 @@ void RunTest(
         CoreRangeSet crs(std::set<CoreRange>(active_eth_cores.begin(), active_eth_cores.end()));
         tt_metal::EthernetConfig config = {.noc = tt_metal::NOC::NOC_0, .processor = DataMovementProcessor::RISCV_0};
         eth_test_common::set_arch_specific_eth_config(config);
-        CreateKernel(program_, "tests/tt_metal/tt_metal/test_kernels/device_print/print_simple.cpp", crs, config);
+        CreateKernel(program_, kPrintSimpleKernel, crs, config);
 
         for ([[maybe_unused]] const CoreCoord& core : active_eth_cores) {
             if (tt::tt_metal::MetalContext::instance().hal().get_num_risc_processors(
@@ -113,6 +159,10 @@ void RunTest(
 }  // namespace
 
 TEST_F(DevicePrintFixture, TensixTestPrintPrependDeviceCoreRisc) {
+    if (MetalContext::instance().hal().get_arch() == tt::ARCH::QUASAR) {
+        GTEST_SKIP() << "Golden output is specific to the Gen1 RISC naming";
+    }
+
     tt::tt_metal::MetalContext::instance().rtoptions().set_feature_prepend_device_core_risc(
         tt::llrt::RunTimeDebugFeatureDprint, true);
     for (auto& mesh_device : this->devices_) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp
@@ -230,7 +230,7 @@ void write_pack_counters(
 }
 
 void kernel_main() {
-    uint32_t register_name = get_compile_time_arg_val(0);
+    uint32_t register_name = get_arg(args::register_name);
 
     // Get pointer to registers for current state ID
     volatile uint tt_reg_ptr* cfg = get_cfg_pointer();

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/print_mesh_coord.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/print_mesh_coord.cpp
@@ -6,12 +6,12 @@
 
 /**
  * Minimal kernel used by test_mesh_coords.cpp.
- * Compile-time args 0 and 1 must be the global system-mesh row and column of the device
+ * The "row" and "col" compile-time args must be the global system-mesh row and column of the device
  * this kernel is running on.  The DEVICE_PRINT line lets the test verify that DEVICE_PRINT output is
  * restricted to the expected mesh coordinate when TT_METAL_DPRINT_MESH_COORDS is configured.
  */
 void kernel_main() {
-    constexpr uint32_t row = get_compile_time_arg_val(0);
-    constexpr uint32_t col = get_compile_time_arg_val(1);
+    constexpr uint32_t row = get_arg(args::row);
+    constexpr uint32_t col = get_arg(args::col);
     DEVICE_PRINT("mesh_coord=({},{})\n", row, col);
 }

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/writer_config_reg.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/writer_config_reg.cpp
@@ -265,7 +265,8 @@ void kernel_main() {
             tile_descriptor.f = tile_descriptor_vec[1];
             write_unpack_tile_descriptor(cfg, THCON_SEC1_REG0_TileDescriptor_ADDR32, 2, tile_descriptor);
             break;
-        case UNPACK_CONFIG: uint num_of_words_unpack_config;
+        case UNPACK_CONFIG:
+            uint num_of_words_unpack_config;
             num_of_words_unpack_config = 2;
             ckernel::unpacker::unpack_config_u unpack_config;
             generate_unpack_config(unpack_config.f);


### PR DESCRIPTION
Updated most of the DEVICE_PRINT tests to utilize Metal 2.0 API.
Not all tests are supported in Metal 2.0 API (ETH, DRAM).

Verified manually that tests pass on WH/BH/Quasar.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vjovanovic/device_print_tests_metal20)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vjovanovic/device_print_tests_metal20)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vjovanovic/device_print_tests_metal20)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vjovanovic/device_print_tests_metal20)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vjovanovic/device_print_tests_metal20)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vjovanovic/device_print_tests_metal20)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vjovanovic/device_print_tests_metal20)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vjovanovic/device_print_tests_metal20)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vjovanovic/device_print_tests_metal20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vjovanovic/device_print_tests_metal20)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vjovanovic/device_print_tests_metal20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vjovanovic/device_print_tests_metal20)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vjovanovic/device_print_tests_metal20)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vjovanovic/device_print_tests_metal20)