### PR TITLE
[Feature] Allow create_program_artifacts directly on the device operation

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -183,6 +183,117 @@ TEST(LaunchOperationTest, ProgramSpecAdapterCompiles) {
     SUCCEED();
 }
 
+// HasDirectSpec: create_program_artifacts on the operation struct itself, the spec analog of
+// HasDirectDescriptor. The adapter wraps it in a factory the concepts must classify correctly.
+namespace direct_spec_test {
+
+struct DirectSpecOp {
+    using operation_attributes_t = OperationAttributes;
+    using tensor_args_t = Tensor;
+    using spec_return_value_t = tt::tt_metal::TensorSpec;
+    using tensor_return_value_t = Tensor;
+
+    static inline int create_calls = 0;
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&) {}
+
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&) {
+        return spec_return_value_t(
+            ttnn::Shape{1, 1, 32, 32}, tt::tt_metal::TensorLayout(DataType::FLOAT32, Layout::TILE, MemoryConfig{}));
+    }
+
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&) {
+        return Tensor();
+    }
+
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
+        const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&) {
+        ++create_calls;
+        return {};
+    }
+};
+
+struct DirectCustomSpecOp : DirectSpecOp {
+    static inline int override_calls = 0;
+
+    static tt::tt_metal::experimental::ProgramRunArgs override_runtime_arguments(
+        const operation_attributes_t&,
+        const tensor_args_t&,
+        tensor_return_value_t&,
+        const std::optional<ttnn::MeshCoordinate>& = std::nullopt) {
+        ++override_calls;
+        return {};
+    }
+};
+
+// An op that keeps its program_factory_t must be unaffected by the shortcut.
+struct WrappedSpecOp : DirectSpecOp {
+    using program_factory_t = std::variant<ProgramSpecFactory>;
+};
+
+template <typename Op>
+using factory_of =
+    std::variant_alternative_t<0, typename device_operation::MeshDeviceOperationAdapter<Op>::program_factory_t>;
+
+static_assert(device_operation::HasDirectSpec<DirectSpecOp>);
+static_assert(!device_operation::HasDirectDescriptor<DirectSpecOp>);
+static_assert(device_operation::DeviceOperationConcept<DirectSpecOp>);
+static_assert(device_operation::ProgramSpecFactoryConcept<factory_of<DirectSpecOp>>);
+static_assert(!device_operation::CustomProgramSpecFactoryConcept<factory_of<DirectSpecOp>>);
+
+// The op's override_runtime_arguments must carry through to the wrapper, or the cache hit would
+// silently degrade to the base concept's tensor-binding-only refresh.
+static_assert(device_operation::HasDirectSpec<DirectCustomSpecOp>);
+static_assert(device_operation::DeviceOperationConcept<DirectCustomSpecOp>);
+static_assert(device_operation::CustomProgramSpecFactoryConcept<factory_of<DirectCustomSpecOp>>);
+static_assert(!device_operation::ProgramSpecFactoryConcept<factory_of<DirectCustomSpecOp>>);
+
+static_assert(!device_operation::HasDirectSpec<WrappedSpecOp>);
+static_assert(std::same_as<factory_of<WrappedSpecOp>, ProgramSpecFactory>);
+
+}  // namespace direct_spec_test
+
+TEST(LaunchOperationTest, DirectSpecFactoryForwardsToOperation) {
+    using direct_spec_test::DirectSpecOp;
+    using Factory = direct_spec_test::factory_of<DirectSpecOp>;
+
+    Tensor input;
+    Tensor output;
+    auto factory = device_operation::MeshDeviceOperationAdapter<DirectSpecOp>::select_program_factory(
+        OperationAttributes{}, input);
+    EXPECT_TRUE(std::holds_alternative<Factory>(factory));
+
+    DirectSpecOp::create_calls = 0;
+    Factory::create_program_artifacts(OperationAttributes{}, input, output);
+    EXPECT_EQ(DirectSpecOp::create_calls, 1);
+}
+
+TEST(LaunchOperationTest, DirectCustomSpecFactoryForwardsOverride) {
+    using direct_spec_test::DirectCustomSpecOp;
+    using Factory = direct_spec_test::factory_of<DirectCustomSpecOp>;
+
+    Tensor input;
+    Tensor output;
+    DirectCustomSpecOp::override_calls = 0;
+    Factory::override_runtime_arguments(OperationAttributes{}, input, output);
+    EXPECT_EQ(DirectCustomSpecOp::override_calls, 1);
+}
+
+TEST(LaunchOperationTest, DirectSpecAdapterCompiles) {
+    using direct_spec_test::DirectSpecOp;
+    using Adapter = device_operation::MeshDeviceOperationAdapter<DirectSpecOp>::ProgramSpecMeshWorkloadFactoryAdapter<
+        direct_spec_test::factory_of<DirectSpecOp>>;
+    [[maybe_unused]] auto create = &Adapter::create_mesh_workload;
+    [[maybe_unused]] auto apply = &Adapter::apply_descriptor;
+
+    using direct_spec_test::DirectCustomSpecOp;
+    using CustomAdapter =
+        device_operation::MeshDeviceOperationAdapter<DirectCustomSpecOp>::CustomProgramSpecMeshWorkloadFactoryAdapter<
+            direct_spec_test::factory_of<DirectCustomSpecOp>>;
+    [[maybe_unused]] auto capply = &CustomAdapter::apply_descriptor;
+    SUCCEED();
+}
+
 // SupportsPerCoreAllocation gates whether launch() will accept a per-core allocated tensor. No op
 // declares supports_per_core_allocation today, so the accept path is otherwise never exercised --
 // a concept that could never match would look identical at runtime. Pin all three directions here:

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -187,9 +187,34 @@ private:
         }
     };
 
+    struct DirectSpecFactory {
+        static ProgramArtifacts create_program_artifacts(
+            const operation_attributes_t& attrs,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value) {
+            return DeviceOperation::create_program_artifacts(attrs, tensor_args, tensor_return_value);
+        }
+    };
+
+    // Separate type, not a guarded member: CustomProgramSpecFactoryConcept keys on
+    // decltype(&T::override_runtime_arguments), which a guarded member does not satisfy.
+    struct DirectCustomSpecFactory : DirectSpecFactory {
+        static tt::tt_metal::experimental::ProgramRunArgs override_runtime_arguments(
+            const operation_attributes_t& attrs,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value,
+            const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt) {
+            return DeviceOperation::override_runtime_arguments(
+                attrs, tensor_args, tensor_return_value, mesh_dispatch_coordinate);
+        }
+    };
+
     template <typename T, typename = void>
     struct resolve_program_factory {
-        using type = std::variant<DirectDescriptorFactory>;
+        using type = std::variant<std::conditional_t<
+            HasDirectSpec<T>,
+            std::conditional_t<detail::HasSpecRuntimeArgsOverride<T>, DirectCustomSpecFactory, DirectSpecFactory>,
+            DirectDescriptorFactory>>;
     };
     template <typename T>
     struct resolve_program_factory<T, std::void_t<typename T::program_factory_t>> {
@@ -198,6 +223,11 @@ private:
 
 public:
     using program_factory_t = typename resolve_program_factory<DeviceOperation>::type;
+
+    static_assert(
+        !(HasDirectDescriptor<DeviceOperation> && HasDirectSpec<DeviceOperation>),
+        "A DeviceOperation must not define both create_descriptor and create_program_artifacts directly; "
+        "declare a program_factory_t variant instead.");
 
     static_assert(
         HasDirectDescriptor<DeviceOperation> || HasSelectProgramFactory<DeviceOperation> ||

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -138,6 +138,10 @@ concept CustomProgramSpecFactoryConcept =
 template <typename T>
 concept HasDirectDescriptor = requires { &T::create_descriptor; } && !requires { typename T::program_factory_t; };
 
+// Same shortcut for single-spec operations: create_program_artifacts directly on the operation struct.
+template <typename T>
+concept HasDirectSpec = requires { &T::create_program_artifacts; } && !requires { typename T::program_factory_t; };
+
 template <typename device_operation_t>
 concept HasComputeOutputSpecs = requires(
     device_operation_t op,
@@ -204,7 +208,7 @@ concept DeviceOperationConcept =
                           tensor_return_value_t>);
         };
     } && HasComputeOutputSpecs<device_operation_t> &&
-    (HasDirectDescriptor<device_operation_t> ||
+    (HasDirectDescriptor<device_operation_t> || HasDirectSpec<device_operation_t> ||
      (HasProgramFactoryType<device_operation_t> && AllFactoriesValid<typename device_operation_t::program_factory_t>));
 
 template <typename device_operation_t>


### PR DESCRIPTION
### Problem

`HasDirectDescriptor` lets a single-descriptor op declare `create_descriptor` directly on the
device-operation struct, with no `program_factory_t`. The adapter wraps it in
`DirectDescriptorFactory` and builds the one-alternative variant itself.

There is no analog for `create_program_artifacts`. `resolve_program_factory`'s primary template
hard-codes `std::variant<DirectDescriptorFactory>`, so an op that declares only
`create_program_artifacts` on the struct does not merely miss the shortcut — it fails to compile.
Every single-factory spec op therefore has to add a nested factory struct plus a one-alternative
`std::variant` to its device-op header. 17 ops on main currently carry a one-alternative
`program_factory_t` over a spec factory.

### What changes

- `HasDirectSpec` in `operation_concepts.hpp`, mirroring `HasDirectDescriptor`
  (`&T::create_program_artifacts` + no `program_factory_t`), and added to `DeviceOperationConcept`'s
  disjunction.
- `DirectSpecFactory` / `DirectCustomSpecFactory` in the adapter, forwarding to the op.
  `resolve_program_factory` picks between them and `DirectDescriptorFactory`.
- A `static_assert` rejecting an op that declares both `create_descriptor` and
  `create_program_artifacts` directly, which the selection would otherwise resolve silently.

### Why two wrapper types instead of one with a guarded member

`CustomProgramSpecFactoryConcept` keys on `decltype(&T::override_runtime_arguments)`. A member
guarded by a defaulted template parameter or a `requires` clause does not satisfy that, so a single
wrapper would classify as the base `ProgramSpecFactoryConcept` — whose cache hit refreshes tensor
bindings only, dropping the op's run-args re-apply with no compile error. The classification is
resolved at wrapper-selection time instead, and pinned by tests in both directions.

### What does not change

`select_program_factory` and the existing `variant_size == 1` assert needed no edit: a direct-spec op
has no `select_program_factory`, so it already falls through to `variant_alternative_t<0>`, and the
generated variant has one alternative. The `program_factory_t` partial specialization still wins for
every op that declares one — no existing op is affected, and none is migrated here.

### Testing

`tests/ttnn/unit_tests/gtests/test_launch_operation.cpp`, alongside the existing spec-concept block:

- Static asserts on three ops — direct spec, direct spec + `override_runtime_arguments`, and one that
  keeps its `program_factory_t`. These pin `HasDirectSpec`, `DeviceOperationConcept`, that the
  override-carrying op resolves to `CustomProgramSpecFactoryConcept` and **not** the base concept
  (and the converse for the plain one), and that an explicit `program_factory_t` still wins.
- `DirectSpecFactoryForwardsToOperation` — `select_program_factory` returns the wrapper, and
  `create_program_artifacts` reaches the op.
- `DirectCustomSpecFactoryForwardsOverride` — `override_runtime_arguments` reaches the op.
- `DirectSpecAdapterCompiles` — force-instantiates both mesh-workload adapters against the wrappers.

Negative control: compiling the same test file against the unpatched headers fails on the
classification asserts and selects `DirectDescriptorFactory` for a spec op, so the tests do bind to
the new behavior rather than passing vacuously.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/direct-spec-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/direct-spec-factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/direct-spec-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/direct-spec-factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/direct-spec-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/direct-spec-factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/direct-spec-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/direct-spec-factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/direct-spec-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/direct-spec-factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/direct-spec-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/direct-spec-factory)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/direct-spec-factory)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/direct-spec-factory)