### PR TITLE
[Feature]: Add Watcher Ringbuffer on Quasar and Blackhole

### DIFF
--- a/docs/source/tt-metalium/tools/watcher.rst
+++ b/docs/source/tt-metalium/tools/watcher.rst
@@ -190,19 +190,22 @@ The resulting message will be printed on the command line (and watcher log):
 Ring Buffer
 -----------
 A small ring buffer is available on each core, accessible via the `WATCHER_RING_BUFFER_PUSH()` macro.
-This ring buffer has 32 `uint32_t` elements, and when more than the max amounts of elements
-are pushed into the buffer, the oldest are overwritten. When the watcher is disabled, the ring
-buffer is still present, but any writes to it are compiled out. An example of pushing data to the
-ring buffer, and the resulting log is shown below.
+Each entry holds one `uint32_t`, and once the buffer is full the oldest entries are overwritten. When
+the watcher is disabled, the ring buffer is still present, but any writes to it are compiled out. An
+example of pushing data to the ring buffer, and the resulting log is shown below.
 
-The ring buffer has two implementations depending on architecture:
+The implementation and capacity depend on the architecture:
 
-- **Wormhole (SPSC)**: a single-producer ring buffer with no synchronization between RISCs. Calling
-  `WATCHER_RING_BUFFER_PUSH()` from different RISCs on the same core at the same time is undefined
-  behaviour.
-- **Blackhole and Quasar (MPSC)**: a lock-free ring buffer built on RISC-V atomics, safe to call
-  concurrently from every RISC on the same core. Each entry is tagged with the pushing processor's name
-  as a prefix in the log; the naming itself differs by architecture (see below).
+- **Wormhole (SPSC), 32 entries**: a single-producer ring buffer with no synchronization between
+  RISCs. Calling `WATCHER_RING_BUFFER_PUSH()` from different RISCs on the same core at the same time
+  is undefined behaviour.
+- **Blackhole (MPSC), 32 entries**: lock-free, using a RISC-V atomic on the head counter.
+- **Quasar (MPSC), 128 entries**: lock-free, using NEO cluster semaphore 31, which is reserved for
+  the watcher and must not be used by kernels.
+
+Both MPSC variants are safe to call concurrently from every RISC on the same core, and tag each
+entry with the pushing processor's name as a prefix in the log; the naming itself differs by
+architecture (see below).
 
 .. code-block::
 
@@ -219,7 +222,7 @@ watcher log. On Wormhole (SPSC), writing 40 entries drops the oldest 8, printed 
 
 .. code-block::
 
-    Core (x=1,y=1):    R,R,R,R,R rmsg:D0G|BNT smsg:GGGG k_ids:1|0|0
+    Core (x=1,y=1):
         debug_ring_buffer=
         [0x00000028,0x00000027,0x00000026,0x00000025,0x00000024,0x00000023,0x00000022,0x00000021,
          0x00000020,0x0000001f,0x0000001e,0x0000001d,0x0000001c,0x0000001b,0x0000001a,0x00000019,
@@ -229,19 +232,20 @@ watcher log. On Wormhole (SPSC), writing 40 entries drops the oldest 8, printed 
 On Blackhole and Quasar (MPSC), each entry carries the pushing processor's name. The naming differs by
 architecture: Blackhole uses `BRISC`/`NCRISC`/`TRISC0-2`, while Quasar's 8 data-movement processors are
 named `DM0`-`DM7` and its 16 compute processors are named `Neo0TRISC0`-`Neo3TRISC3` (cluster-qualified).
+On Quasar, `DM0` and `DM1` are reserved for the runtime, so user kernels only ever appear as `DM2`-`DM7`.
 
 .. code-block::
 
     # Blackhole
-    Core (x=1,y=1):    R,R,R,R,R rmsg:D0G|BNT smsg:GGGG k_ids:1|0|0
+    Core (x=1,y=1):
         debug_ring_buffer=
         [[BRISC]0x00000028,[TRISC0]0x00000027,[BRISC]0x00000026,[NCRISC]0x00000025,[TRISC1]0x00000024,
          ...]
 
     # Quasar
-    Core (x=1,y=1):    R,R,R,R,R,R,R,R rmsg:D0G|BNT smsg:GGGG k_ids:1|0|0
+    Core (x=1,y=1):
         debug_ring_buffer=
-        [[DM0]0x00000028,[Neo0TRISC0]0x00000027,[DM3]0x00000026,[DM1]0x00000025,[Neo2TRISC1]0x00000024,
+        [[DM2]0x00000028,[Neo0TRISC0]0x00000027,[DM5]0x00000026,[DM3]0x00000025,[Neo2TRISC1]0x00000024,
          ...]
 
 Stack Usage Measurement

--- a/docs/source/tt-metalium/tools/watcher.rst
+++ b/docs/source/tt-metalium/tools/watcher.rst
@@ -190,14 +190,19 @@ The resulting message will be printed on the command line (and watcher log):
 Ring Buffer
 -----------
 A small ring buffer is available on each core, accessible via the `WATCHER_RING_BUFFER_PUSH()` macro.
-This ring buffer has 31 `uint32_t` elements, and when more than the max amounts of elements
+This ring buffer has 32 `uint32_t` elements, and when more than the max amounts of elements
 are pushed into the buffer, the oldest are overwritten. When the watcher is disabled, the ring
 buffer is still present, but any writes to it are compiled out. An example of pushing data to the
 ring buffer, and the resulting log is shown below.
 
-Important: the ring buffer does not have any synchronization for writes between difference RISCs on
-the same core. Calling `WATCHER_RING_BUFFER_PUSH()` from different RISCs in the same core at the same time
-is undefined behaviour.
+The ring buffer has two implementations depending on architecture:
+
+- **Wormhole (SPSC)**: a single-producer ring buffer with no synchronization between RISCs. Calling
+  `WATCHER_RING_BUFFER_PUSH()` from different RISCs on the same core at the same time is undefined
+  behaviour.
+- **Blackhole and Quasar (MPSC)**: a lock-free ring buffer built on RISC-V atomics, safe to call
+  concurrently from every RISC on the same core. Each entry is tagged with the pushing processor's name
+  as a prefix in the log; the naming itself differs by architecture (see below).
 
 .. code-block::
 
@@ -210,18 +215,34 @@ is undefined behaviour.
     }
 
 The contents of the ring buffer for each core (if values have been written) will be shown in the
-watcher log:
+watcher log. On Wormhole (SPSC), writing 40 entries drops the oldest 8, printed newest-first:
 
 .. code-block::
 
-    # The ring buffer has a size of 32 elements, therefore writing 40 entries into the buffer will
-    # result in the oldest 8 entries being dropped. Entries are printed starting with the most recent.
     Core (x=1,y=1):    R,R,R,R,R rmsg:D0G|BNT smsg:GGGG k_ids:1|0|0
-        debug_ring_buffer(latest_written_idx=8)=
+        debug_ring_buffer=
         [0x00000028,0x00000027,0x00000026,0x00000025,0x00000024,0x00000023,0x00000022,0x00000021,
          0x00000020,0x0000001f,0x0000001e,0x0000001d,0x0000001c,0x0000001b,0x0000001a,0x00000019,
          0x00000018,0x00000017,0x00000016,0x00000015,0x00000014,0x00000013,0x00000012,0x00000011,
          0x00000010,0x0000000f,0x0000000e,0x0000000d,0x0000000c,0x0000000b,0x0000000a,0x00000009]
+
+On Blackhole and Quasar (MPSC), each entry carries the pushing processor's name. The naming differs by
+architecture: Blackhole uses `BRISC`/`NCRISC`/`TRISC0-2`, while Quasar's 8 data-movement processors are
+named `DM0`-`DM7` and its 16 compute processors are named `Neo0TRISC0`-`Neo3TRISC3` (cluster-qualified).
+
+.. code-block::
+
+    # Blackhole
+    Core (x=1,y=1):    R,R,R,R,R rmsg:D0G|BNT smsg:GGGG k_ids:1|0|0
+        debug_ring_buffer=
+        [[BRISC]0x00000028,[TRISC0]0x00000027,[BRISC]0x00000026,[NCRISC]0x00000025,[TRISC1]0x00000024,
+         ...]
+
+    # Quasar
+    Core (x=1,y=1):    R,R,R,R,R,R,R,R rmsg:D0G|BNT smsg:GGGG k_ids:1|0|0
+        debug_ring_buffer=
+        [[DM0]0x00000028,[Neo0TRISC0]0x00000027,[DM3]0x00000026,[DM1]0x00000025,[Neo2TRISC1]0x00000024,
+         ...]
 
 Stack Usage Measurement
 -----------------------

--- a/tests/pipeline_reorg/runtime_sanity_tests.yaml
+++ b/tests/pipeline_reorg/runtime_sanity_tests.yaml
@@ -73,7 +73,7 @@
     ./build/test/tt_metal/unit_tests_api --gtest_filter='-ProgramRunArgsTestQuasar.*:ProgramSpecTestQuasar.*:ProgramSpecHWTest.*' &&
     ./build/test/tt_metal/unit_tests_data_movement &&
     ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter='DevicePrintFixture.IdleEthTestPrint' &&
-    ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter='MeshWatcherFixture.TestWatcherRingBufferIErisc' &&
+    ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter='*WatcherRingBufferTest.TestWatcherRingBuffer/IErisc' &&
     ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter='MeshWatcherFixture.TestWatcherStackUsage0' &&
     ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter='MeshWatcherFixture.TestWatcherStackUsage16' &&
     ./build/test/tt_metal/unit_tests_dispatch --gtest_filter='MeshDispatchFixture.TensixIdleEthTestSemaphores' &&

--- a/tests/scripts/run_tools_tests.sh
+++ b/tests/scripts/run_tools_tests.sh
@@ -20,7 +20,7 @@ if [[ -z "$TT_METAL_SLOW_DISPATCH_MODE" ]] ; then
     echo "Watcher dump all data test - Pass"
 
     # Check that stack dumping is working
-    ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter=*TestWatcherRingBufferBrisc
+    ./build/test/tt_metal/unit_tests_debug_tools --gtest_filter=*WatcherRingBufferTest.TestWatcherRingBuffer/Brisc
     ./build/tools/watcher_dump -d=0 -w
     grep "BRISC highest stack usage:" generated/watcher/watcher.log > /dev/null || { echo "Error: couldn't find stack usage in watcher log after dump." ; exit 1; }
     echo "Watcher stack usage test - Pass"

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
@@ -20,6 +20,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/program.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include "impl/context/metal_context.hpp"
 #include "impl/kernels/kernel.hpp"
 #include <umd/device/types/core_coordinates.hpp>
@@ -31,54 +32,44 @@
 using namespace tt;
 using namespace tt::tt_metal;
 
-constexpr uint32_t NUM_PUSHES_SINGLE = 40;  // Single-thread tests push 40 values
-constexpr uint32_t NUM_PUSHES_MULTI = 4;    // Multi-DM test: 4 pushes per DM (8 DMs x 4 = 32 total)
+constexpr uint32_t NUM_PUSHES_MULTI = 4;  // Multi-writer test: 4 pushes per thread (6 DMs, or 16 TRISCs)
 
-// Generate expected ring buffer data for TRISC/ERISC/BH/WH tests
-// Pattern: (idx << 16) | (idx + 1), buffer holds 32, newest first (40 down to 9)
-std::vector<uint32_t> get_expected_data() {
+// Expected strings for a single-processor ring buffer test.
+// SPSC: pattern (idx << 16) | (idx + 1). MPSC: pattern (thread_idx << 16) | seq.
+// Newest first, limited to buffer capacity (num_pushes is chosen by the caller to exceed
+// capacity, so this always exercises wraparound).
+std::vector<std::string> get_expected_single_processor(
+    HalProgrammableCoreType core_type, uint32_t thread_idx, uint32_t num_pushes) {
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    bool is_mpsc = hal.has_mpsc_ring_buffer();
+    uint32_t capacity = hal.get_ring_buffer_capacity();
+    uint32_t first_visible = (num_pushes > capacity) ? num_pushes - capacity : 0;
+
     std::vector<uint32_t> data;
-    for (uint32_t idx = NUM_PUSHES_SINGLE - 1; idx >= NUM_PUSHES_SINGLE - 32; idx--) {
-        data.push_back((idx << 16) | (idx + 1));
+    for (uint32_t seq = num_pushes - 1; seq >= first_visible && seq < num_pushes; seq--) {
+        data.push_back(is_mpsc ? ((thread_idx << 16) | seq) : ((seq << 16) | (seq + 1)));
     }
-    return data;
-}
 
-// Generate expected ring buffer data for Quasar single-DM tests
-// Pattern: (thread_idx << 16) | seq, buffer holds 32, newest first
-std::vector<uint32_t> get_expected_data_dm(uint32_t thread_idx) {
-    std::vector<uint32_t> data;
-    for (uint32_t seq = NUM_PUSHES_SINGLE - 1; seq >= NUM_PUSHES_SINGLE - 32; seq--) {
-        data.push_back((thread_idx << 16) | seq);
+    std::vector<uint32_t> thread_indices;
+    if (is_mpsc) {
+        thread_indices.assign(data.size(), thread_idx);
     }
-    return data;
-}
-
-// Expected strings for BH/WH (SPSC format)
-std::vector<std::string> get_expected_spsc() {
-    auto data = get_expected_data();
-    std::vector<std::string> result = {"debug_ring_buffer="};
-    auto lines = FormatRingBuffer(data);
-    result.insert(result.end(), lines.begin(), lines.end());
-    return result;
-}
-
-// Expected strings for Quasar single-DM (MPSC format with processor prefix)
-std::vector<std::string> get_expected_mpsc(HalProgrammableCoreType core_type, uint32_t thread_idx) {
-    auto data = get_expected_data_dm(thread_idx);
-    std::vector<uint32_t> thread_indices(data.size(), thread_idx);  // All from same thread in test
     std::vector<std::string> result = {"debug_ring_buffer="};
     auto lines = FormatRingBuffer(data, thread_indices, core_type);
     result.insert(result.end(), lines.begin(), lines.end());
     return result;
 }
 
-// Each thread's first push must be (thread_idx << 16) | 0.
+// Each thread's first push must be (hw_thread_id << 16) | 0, where hw_thread_id is the physical
+// hw thread id (get_hw_thread_idx()) actually encoded by the kernel -- not the loop-local index.
+// hw_id_offset maps the local index [0, num_threads) to the physical id range actually launched
+// (e.g. Quasar user DMs launch on DM2..DM7, so hw_id_offset=2).
 std::vector<std::string> get_expected_multi_writer(
-    const std::function<std::string(uint32_t)>& prefix_for_thread, uint32_t num_threads) {
+    const std::function<std::string(uint32_t)>& prefix_for_thread, uint32_t num_threads, uint32_t hw_id_offset = 0) {
     std::vector<std::string> expected = {"debug_ring_buffer="};
-    for (uint32_t thread_idx = 0; thread_idx < num_threads; thread_idx++) {
-        expected.push_back(fmt::format("[{}]0x{:08x}", prefix_for_thread(thread_idx), (thread_idx << 16) | 0));
+    for (uint32_t local_idx = 0; local_idx < num_threads; local_idx++) {
+        uint32_t hw_id = local_idx + hw_id_offset;
+        expected.push_back(fmt::format("[{}]0x{:08x}", prefix_for_thread(hw_id), (hw_id << 16) | 0));
     }
     return expected;
 }
@@ -94,79 +85,74 @@ void RunTest(
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    workload.add_program(device_range, {});
-    auto& program = workload.get_programs().at(device_range);
+    Program program = Program();
     auto* device = mesh_device->get_devices()[0];
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     bool is_quasar = device->arch() == tt::ARCH::QUASAR;
-    bool is_mpsc = is_quasar || device->arch() == tt::ARCH::BLACKHOLE;
+    // Exceed capacity so every test exercises wraparound, regardless of buffer size.
+    uint32_t num_pushes = multi_dm_test ? NUM_PUSHES_MULTI : (hal.get_ring_buffer_capacity() + 12);
+    constexpr const char* kernel_legacy = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp";
+    constexpr const char* kernel_metal2 = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf_2_0.cpp";
+    const experimental::KernelSpecName kRingbufKernelName{"ringbuf_kernel"};
 
     // Depending on riscv type, choose one core to run the test on
     // and set up the kernel on the correct risc
     CoreCoord logical_core, virtual_core;
     switch (processor.core_type) {
-        case HalProgrammableCoreType::TENSIX:
+        case HalProgrammableCoreType::TENSIX: {
             logical_core = CoreCoord{0, 0};
             virtual_core = device->worker_core_from_logical_core(logical_core);
+            // TENSIX cores use the Metal 2.0 host API; ETH/DRAM/DISPATCH cores below remain on the
+            // legacy host API (no Metal 2.0 equivalent exists for those programmable core types).
+            experimental::KernelSpec kernel_spec{.unique_id = kRingbufKernelName, .source = kernel_metal2};
             switch (processor.processor_class) {
                 case HalProcessorClassType::DM: {
+                    kernel_spec.compile_time_args["num_pushes"] = num_pushes;
                     if (is_quasar) {
-                        uint32_t num_pushes = multi_dm_test ? NUM_PUSHES_MULTI : NUM_PUSHES_SINGLE;
-                        std::vector<uint32_t> compile_args =
-                            multi_dm_test ? std::vector<uint32_t>{num_pushes}
-                                          : std::vector<uint32_t>{num_pushes, processor.processor_type};
-                        std::map<std::string, std::string> defines =
-                            multi_dm_test ? std::map<std::string, std::string>{{"MULTI_DM_TEST", "1"}}
-                                          : std::map<std::string, std::string>{};
-                        tt::tt_metal::experimental::quasar::CreateKernel(
-                            program,
-                            "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
-                            logical_core,
-                            tt::tt_metal::experimental::quasar::QuasarDataMovementConfig{
-                                .num_threads_per_cluster = 8, .compile_args = compile_args, .defines = defines});
+                        // No way to pin a Gen2 DM kernel to a specific hw thread: launch on all 6
+                        // user DM threads (DM0/DM1 are reserved for the runtime) and filter in-kernel.
+                        kernel_spec.num_threads = 6;
+                        if (multi_dm_test) {
+                            kernel_spec.compiler_options.defines = {{"MULTI_DM_TEST", "1"}};
+                        } else {
+                            kernel_spec.compile_time_args["dm_id"] = processor.processor_type;
+                        }
+                        kernel_spec.hw_config = experimental::DataMovementGen2Config{};
                     } else {
-                        DataMovementConfig dm_config{};
-                        dm_config.processor = static_cast<tt_metal::DataMovementProcessor>(processor.processor_type);
-                        dm_config.noc = (processor.processor_type == 0) ? tt_metal::NOC::RISCV_0_default
-                                                                        : tt_metal::NOC::RISCV_1_default;
-                        dm_config.compile_args = {NUM_PUSHES_SINGLE};
-                        CreateKernel(
-                            program,
-                            "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
-                            logical_core,
-                            dm_config);
+                        kernel_spec.hw_config = experimental::DataMovementGen1Config{
+                            .processor = static_cast<tt_metal::DataMovementProcessor>(processor.processor_type),
+                            .noc = (processor.processor_type == 0) ? tt_metal::NOC::RISCV_0_default
+                                                                   : tt_metal::NOC::RISCV_1_default,
+                        };
                     }
                     break;
                 }
-                case HalProcessorClassType::COMPUTE:
-                    if (is_quasar) {
-                        uint32_t num_threads = multi_dm_test ? 4 : 1;
-                        uint32_t num_pushes = multi_dm_test ? NUM_PUSHES_MULTI : NUM_PUSHES_SINGLE;
-                        std::map<std::string, std::string> defines =
-                            multi_dm_test
-                                ? std::map<std::string, std::string>{{"MULTI_DM_TEST", "1"}}
-                                : std::map<std::string, std::string>{
-                                      {fmt::format("WATCHER_RINGBUF_TRISC{}", processor.processor_type), "1"}};
-                        tt::tt_metal::experimental::quasar::CreateKernel(
-                            program,
-                            "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
-                            logical_core,
-                            experimental::quasar::QuasarComputeConfig{
-                                .num_threads_per_cluster = num_threads,
-                                .compile_args = {num_pushes},
-                                .defines = defines});
+                case HalProcessorClassType::COMPUTE: {
+                    kernel_spec.compile_time_args["num_pushes"] = num_pushes;
+                    if (multi_dm_test) {
+                        kernel_spec.compiler_options.defines = {{"MULTI_DM_TEST", "1"}};
                     } else {
-                        CreateKernel(
-                            program,
-                            "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
-                            logical_core,
-                            ComputeConfig{
-                                .compile_args = {NUM_PUSHES_SINGLE},
-                                .defines = {
-                                    {fmt::format("WATCHER_RINGBUF_TRISC{}", processor.processor_type), "1"}}});
+                        kernel_spec.compiler_options.defines = {
+                            {fmt::format("WATCHER_RINGBUF_TRISC{}", processor.processor_type), "1"}};
+                    }
+                    if (is_quasar) {
+                        kernel_spec.num_threads = multi_dm_test ? 4 : 1;
+                        kernel_spec.hw_config = experimental::ComputeGen2Config{};
+                    } else {
+                        kernel_spec.hw_config = experimental::ComputeGen1Config{};
                     }
                     break;
+                }
             }
+            experimental::WorkUnitSpec wu{
+                .name = "main",
+                .kernels = {kRingbufKernelName},
+                .target_nodes = experimental::NodeCoord{logical_core},
+            };
+            experimental::ProgramSpec spec{.name = "watcher_ringbuf", .kernels = {kernel_spec}, .work_units = {wu}};
+            program = experimental::MakeProgramFromSpec(*mesh_device, spec);
             break;
+        }
         case HalProgrammableCoreType::ACTIVE_ETH:
             if (device->get_active_ethernet_cores(true).empty()) {
                 log_info(LogTest, "Skipping this test since device has no active ethernet cores.");
@@ -176,9 +162,9 @@ void RunTest(
             virtual_core = device->ethernet_core_from_logical_core(logical_core);
             CreateKernel(
                 program,
-                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                kernel_legacy,
                 logical_core,
-                EthernetConfig{.noc = tt_metal::NOC::NOC_0, .compile_args = {NUM_PUSHES_SINGLE}});
+                EthernetConfig{.noc = tt_metal::NOC::NOC_0, .compile_args = {num_pushes}});
             break;
         case HalProgrammableCoreType::IDLE_ETH:
             if (device->get_inactive_ethernet_cores().empty()) {
@@ -189,13 +175,11 @@ void RunTest(
             virtual_core = device->ethernet_core_from_logical_core(logical_core);
             CreateKernel(
                 program,
-                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                kernel_legacy,
                 logical_core,
-                EthernetConfig{
-                    .eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0, .compile_args = {NUM_PUSHES_SINGLE}});
+                EthernetConfig{.eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0, .compile_args = {num_pushes}});
             break;
         case HalProgrammableCoreType::DRAM: {
-            const auto& hal = tt::tt_metal::MetalContext::instance().hal();
             if (!hal.has_programmable_core_type(HalProgrammableCoreType::DRAM)) {
                 log_info(LogTest, "Skipping: DRAM programmable cores not available on this architecture.");
                 GTEST_SKIP();
@@ -205,13 +189,12 @@ void RunTest(
             virtual_core = device->virtual_core_from_logical_core(logical_core, CoreType::DRAM);
             CreateKernel(
                 program,
-                "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                kernel_legacy,
                 logical_core,
-                DramConfig{.noc = tt_metal::NOC::NOC_0, .compile_args = {NUM_PUSHES_SINGLE}});
+                DramConfig{.noc = tt_metal::NOC::NOC_0, .compile_args = {num_pushes}});
             break;
         }
         case HalProgrammableCoreType::DISPATCH: {
-            const auto& hal = tt::tt_metal::MetalContext::instance().hal();
             if (!hal.has_programmable_core_type(HalProgrammableCoreType::DISPATCH)) {
                 log_info(LogTest, "Skipping: dispatch-engine programmable cores not available on this architecture.");
                 GTEST_SKIP();
@@ -222,6 +205,7 @@ void RunTest(
         case HalProgrammableCoreType::COUNT: TT_THROW("Unsupported core type");
     }
     log_info(LogTest, "Running test on device {} core {}[{}]...", device->id(), logical_core, virtual_core);
+    workload.add_program(device_range, std::move(program));
 
     // Run the program
     fixture->RunProgram(mesh_device, workload, true);
@@ -229,25 +213,37 @@ void RunTest(
     log_info(tt::LogTest, "Checking file: {}", fixture->log_file_name);
 
     // Check log
-    if (is_mpsc) {
-        if (multi_dm_test) {
+    if (multi_dm_test) {
+        if (processor.processor_class == HalProcessorClassType::DM) {
+            // DM0/DM1 are reserved for the runtime and never assigned to a kernel (see
+            // ReserveProcessors in program_spec.cpp, which fills bits in ascending order and
+            // treats DM0/DM1 as pre-used), so the 6 launched threads land on DM2..DM7 in order.
             EXPECT_TRUE(FileContainsAllStrings(
                 fixture->log_file_name,
-                get_expected_multi_writer([](uint32_t dm) { return fmt::format("DM{}", dm); }, /*num_threads=*/8)));
+                get_expected_multi_writer(
+                    [](uint32_t dm) { return fmt::format("DM{}", dm); }, /*num_threads=*/6, /*hw_id_offset=*/2)));
         } else {
-            // Thread index for DM is processor_type (0-7), for TRISC it's 8+ based on HAL mapping
-            uint32_t thread_idx = processor.processor_type;
-            if (processor.processor_class == HalProcessorClassType::COMPUTE) {
-                // Compute processors start after DM processors in the HAL index
-                const auto& hal = tt::tt_metal::MetalContext::instance().hal();
-                thread_idx =
-                    hal.get_processor_index(processor.core_type, processor.processor_class, processor.processor_type);
-            }
-            EXPECT_TRUE(FileContainsAllStringsInOrder(
-                fixture->log_file_name, get_expected_mpsc(processor.core_type, thread_idx)));
+            // All 16 TRISCs (4 engines x 4 roles) push; HAL processor index for COMPUTE starts
+            // right after the 8 DM entries.
+            EXPECT_TRUE(FileContainsAllStrings(
+                fixture->log_file_name,
+                get_expected_multi_writer(
+                    [&hal](uint32_t hw_id) {
+                        return hal.get_processor_class_name(HalProgrammableCoreType::TENSIX, hw_id, false);
+                    },
+                    /*num_threads=*/16,
+                    /*hw_id_offset=*/8)));
         }
     } else {
-        EXPECT_TRUE(FileContainsAllStringsInOrder(fixture->log_file_name, get_expected_spsc()));
+        // Thread index for DM is processor_type (0-7), for TRISC it's 8+ based on HAL mapping
+        uint32_t thread_idx = processor.processor_type;
+        if (processor.processor_class == HalProcessorClassType::COMPUTE) {
+            // Compute processors start after DM processors in the HAL index
+            thread_idx =
+                hal.get_processor_index(processor.core_type, processor.processor_class, processor.processor_type);
+        }
+        EXPECT_TRUE(FileContainsAllStringsInOrder(
+            fixture->log_file_name, get_expected_single_processor(processor.core_type, thread_idx, num_pushes)));
     }
 }
 
@@ -255,32 +251,53 @@ void RunMultiRiscTestBH(MeshWatcherFixture* fixture, const std::shared_ptr<distr
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
-    workload.add_program(device_range, {});
-    auto& program = workload.get_programs().at(device_range);
     CoreCoord logical_core{0, 0};
-    const std::string kernel_path = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp";
+    const std::string kernel_path = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf_2_0.cpp";
 
-    DataMovementConfig brisc_config{};
-    brisc_config.processor = tt_metal::DataMovementProcessor::RISCV_0;
-    brisc_config.noc = tt_metal::NOC::RISCV_0_default;
-    brisc_config.compile_args = {NUM_PUSHES_MULTI};
-    CreateKernel(program, kernel_path, logical_core, brisc_config);
+    const experimental::KernelSpecName brisc_name{"brisc"};
+    const experimental::KernelSpecName ncrisc_name{"ncrisc"};
+    const experimental::KernelSpecName trisc_name{"trisc"};
 
-    DataMovementConfig ncrisc_config{};
-    ncrisc_config.processor = tt_metal::DataMovementProcessor::RISCV_1;
-    ncrisc_config.noc = tt_metal::NOC::RISCV_1_default;
-    ncrisc_config.compile_args = {NUM_PUSHES_MULTI};
-    CreateKernel(program, kernel_path, logical_core, ncrisc_config);
+    experimental::KernelSpec brisc_spec{
+        .unique_id = brisc_name,
+        .source = kernel_path,
+        .compile_time_args = {{"num_pushes", NUM_PUSHES_MULTI}},
+        .hw_config =
+            experimental::DataMovementGen1Config{
+                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
+    };
+    experimental::KernelSpec ncrisc_spec{
+        .unique_id = ncrisc_name,
+        .source = kernel_path,
+        .compile_time_args = {{"num_pushes", NUM_PUSHES_MULTI}},
+        .hw_config =
+            experimental::DataMovementGen1Config{
+                .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
+    };
+    // One ComputeGen1Config kernel builds all 3 TRISC binaries; each needs its own
+    // WATCHER_RINGBUF_TRISC{n} define.
+    experimental::KernelSpec trisc_spec{
+        .unique_id = trisc_name,
+        .source = kernel_path,
+        .compiler_options =
+            {.defines =
+                 {{"WATCHER_RINGBUF_TRISC0", "1"}, {"WATCHER_RINGBUF_TRISC1", "1"}, {"WATCHER_RINGBUF_TRISC2", "1"}}},
+        .compile_time_args = {{"num_pushes", NUM_PUSHES_MULTI}},
+        .hw_config = experimental::ComputeGen1Config{},
+    };
 
-    // One ComputeConfig call builds all 3 TRISC binaries; each needs its own WATCHER_RINGBUF_TRISC{n} define.
-    CreateKernel(
-        program,
-        kernel_path,
-        logical_core,
-        ComputeConfig{
-            .compile_args = {NUM_PUSHES_MULTI},
-            .defines = {
-                {"WATCHER_RINGBUF_TRISC0", "1"}, {"WATCHER_RINGBUF_TRISC1", "1"}, {"WATCHER_RINGBUF_TRISC2", "1"}}});
+    experimental::WorkUnitSpec wu{
+        .name = "main",
+        .kernels = {brisc_name, ncrisc_name, trisc_name},
+        .target_nodes = experimental::NodeCoord{logical_core},
+    };
+    experimental::ProgramSpec spec{
+        .name = "watcher_ringbuf_multi_risc",
+        .kernels = {brisc_spec, ncrisc_spec, trisc_spec},
+        .work_units = {wu},
+    };
+    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    workload.add_program(device_range, std::move(program));
 
     fixture->RunProgram(mesh_device, workload, true);
 
@@ -295,115 +312,96 @@ void RunMultiRiscTestBH(MeshWatcherFixture* fixture, const std::shared_ptr<distr
             /*num_threads=*/5)));
 }
 
+// Test parameters for the single-processor (and multi-writer) ring buffer suite.
+struct RingBufferTestParams {
+    std::string test_name;
+    HalProcessorIdentifier processor;
+    bool multi_dm_test = false;
+};
+
+class WatcherRingBufferTest : public MeshWatcherFixture, public ::testing::WithParamInterface<RingBufferTestParams> {};
+
+TEST_P(WatcherRingBufferTest, TestWatcherRingBuffer) {
+    const auto& params = GetParam();
+    const auto& hal = MetalContext::instance().hal();
+    bool is_quasar = (hal.get_arch() == tt::ARCH::QUASAR);
+
+    if (!hal.has_programmable_core_type(params.processor.core_type)) {
+        GTEST_SKIP() << "Test " << params.test_name << ": core type not available on this architecture";
+    }
+
+    uint32_t available_processors = hal.get_processor_types_count(
+        params.processor.core_type, static_cast<uint32_t>(params.processor.processor_class));
+    if (params.processor.processor_type >= available_processors) {
+        GTEST_SKIP() << "Test " << params.test_name << " requires processor type " << params.processor.processor_type
+                     << " but only " << available_processors << " available on this architecture";
+    }
+
+    // Multi-writer test is Quasar-only (uses the Quasar-specific 6-DM/16-TRISC reservation scheme).
+    if (params.multi_dm_test && !is_quasar) {
+        GTEST_SKIP() << "Multi-writer MPSC test is Quasar-only";
+    }
+
+    // On Quasar, DM0/DM1 are reserved for the runtime (ISR/remapper) and never assigned to a
+    // user kernel, so the single-DM Brisc/NCrisc params (processor_type 0/1, meaningful only as
+    // BRISC/NCRISC on Gen1 WH/BH) can't be exercised there.
+    bool is_reserved_quasar_dm =
+        is_quasar && !params.multi_dm_test && params.processor.processor_class == HalProcessorClassType::DM &&
+        params.processor.core_type == HalProgrammableCoreType::TENSIX && params.processor.processor_type < 2;
+    if (is_reserved_quasar_dm) {
+        GTEST_SKIP() << "Test " << params.test_name << ": DM0/DM1 are reserved for the runtime on Quasar";
+    }
+
+    bool is_idle_eth = (params.processor.core_type == HalProgrammableCoreType::IDLE_ETH);
+    bool is_dram = (params.processor.core_type == HalProgrammableCoreType::DRAM);
+    if ((is_idle_eth || is_dram) && !this->IsSlowDispatch()) {
+        GTEST_SKIP() << "Test " << params.test_name << " requires Slow Dispatch";
+    }
+
+    for (auto& mesh_device : this->devices_) {
+        this->RunTestOnDevice(
+            [&params](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+                RunTest(fixture, mesh_device, params.processor, params.multi_dm_test);
+                if (params.multi_dm_test) {
+                    RunTest(
+                        fixture,
+                        mesh_device,
+                        {HalProgrammableCoreType::TENSIX, HalProcessorClassType::COMPUTE, 0},
+                        /*multi_dm_test=*/true);
+                }
+            },
+            mesh_device);
+    }
+}
+
 using enum HalProgrammableCoreType;
 using enum HalProcessorClassType;
 
-TEST_F(MeshWatcherFixture, TestWatcherRingBufferBrisc) {
-    for (auto& mesh_device : this->devices_) {
-        this->RunTestOnDevice(
-            [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-                RunTest(fixture, mesh_device, {TENSIX, DM, 0});
-            },
-            mesh_device);
-    }
-}
-
-TEST_F(MeshWatcherFixture, TestWatcherRingBufferNCrisc) {
-    for (auto& mesh_device : this->devices_) {
-        this->RunTestOnDevice(
-            [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-                RunTest(fixture, mesh_device, {TENSIX, DM, 1});
-            },
-            mesh_device);
-    }
-}
-
-TEST_F(MeshWatcherFixture, TestWatcherRingBufferTrisc0) {
-    for (auto& mesh_device : this->devices_) {
-        this->RunTestOnDevice(
-            [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-                RunTest(fixture, mesh_device, {TENSIX, COMPUTE, 0});
-            },
-            mesh_device);
-    }
-}
-
-TEST_F(MeshWatcherFixture, TestWatcherRingBufferTrisc1) {
-    for (auto& mesh_device : this->devices_) {
-        this->RunTestOnDevice(
-            [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-                RunTest(fixture, mesh_device, {TENSIX, COMPUTE, 1});
-            },
-            mesh_device);
-    }
-}
-
-TEST_F(MeshWatcherFixture, TestWatcherRingBufferTrisc2) {
-    for (auto& mesh_device : this->devices_) {
-        this->RunTestOnDevice(
-            [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-                RunTest(fixture, mesh_device, {TENSIX, COMPUTE, 2});
-            },
-            mesh_device);
-    }
-}
-
-TEST_F(MeshWatcherFixture, TestWatcherRingBufferErisc) {
-    for (auto& mesh_device : this->devices_) {
-        this->RunTestOnDevice(
-            [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-                RunTest(fixture, mesh_device, {ACTIVE_ETH, DM, 0});
-            },
-            mesh_device);
-    }
-}
-
-TEST_F(MeshWatcherFixture, TestWatcherRingBufferIErisc) {
-    if (!this->IsSlowDispatch()) {
-        log_info(tt::LogTest, "FD-on-idle-eth not supported.");
-        GTEST_SKIP();
-    }
-    for (auto& mesh_device : this->devices_) {
-        this->RunTestOnDevice(
-            [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-                RunTest(fixture, mesh_device, {IDLE_ETH, DM, 0});
-            },
-            mesh_device);
-    }
-}
-
-TEST_F(MeshWatcherFixture, TensixDramTestWatcherRingBufferDrisc) {
-    if (!this->IsSlowDispatch()) {
-        log_info(tt::LogTest, "DRAM cores only support Slow Dispatch (Fast Dispatch not yet supported).");
-        GTEST_SKIP();
-    }
-    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
-    if (!hal.has_programmable_core_type(HalProgrammableCoreType::DRAM)) {
-        log_info(tt::LogTest, "Skipping: DRAM programmable cores not available on this architecture.");
-        GTEST_SKIP();
-    }
-    for (auto& mesh_device : this->devices_) {
-        this->RunTestOnDevice(
-            [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-                RunTest(fixture, mesh_device, {DRAM, DM, 0});
-            },
-            mesh_device);
-    }
-}
-
-TEST_F(MeshWatcherFixture, TestWatcherRingBufferMpscMultiDM) {
-    for (auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        if (device->arch() != tt::ARCH::QUASAR) {
-            GTEST_SKIP() << "Multi-DM MPSC test is Quasar-only";
-        }
-        this->RunTestOnDevice(
-            [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-                RunTest(fixture, mesh_device, {TENSIX, DM, 0}, /*multi_dm_test=*/true);
-            },
-            mesh_device);
-    }
-}
+INSTANTIATE_TEST_SUITE_P(
+    WatcherRingBufferTests,
+    WatcherRingBufferTest,
+    ::testing::Values(
+        // DM processors
+        RingBufferTestParams{"Brisc", {TENSIX, DM, 0}},
+        RingBufferTestParams{"NCrisc", {TENSIX, DM, 1}},
+        RingBufferTestParams{"DM2", {TENSIX, DM, 2}},
+        RingBufferTestParams{"DM3", {TENSIX, DM, 3}},
+        RingBufferTestParams{"DM4", {TENSIX, DM, 4}},
+        RingBufferTestParams{"DM5", {TENSIX, DM, 5}},
+        RingBufferTestParams{"DM6", {TENSIX, DM, 6}},
+        RingBufferTestParams{"DM7", {TENSIX, DM, 7}},
+        // TRISC processors
+        RingBufferTestParams{"Trisc0", {TENSIX, COMPUTE, 0}},
+        RingBufferTestParams{"Trisc1", {TENSIX, COMPUTE, 1}},
+        RingBufferTestParams{"Trisc2", {TENSIX, COMPUTE, 2}},
+        // Ethernet processors
+        RingBufferTestParams{"Erisc", {ACTIVE_ETH, DM, 0}},
+        RingBufferTestParams{"IErisc", {IDLE_ETH, DM, 0}},
+        // DRAM (DRISC)
+        RingBufferTestParams{"Drisc", {DRAM, DM, 0}},
+        // Multi-writer MPSC test (Quasar only): 6 user DMs, then 16 TRISCs
+        RingBufferTestParams{"MpscMultiDM", {TENSIX, DM, 0}, /*multi_dm_test=*/true}),
+    [](const ::testing::TestParamInfo<RingBufferTestParams>& info) { return info.param.test_name; });
 
 TEST_F(MeshWatcherFixture, TestWatcherRingBufferMpscMultiRiscBH) {
     for (auto& mesh_device : this->devices_) {

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
@@ -73,13 +73,12 @@ std::vector<std::string> get_expected_mpsc(HalProgrammableCoreType core_type, ui
     return result;
 }
 
-// Expected strings for Quasar multi-DM test (MPSC format)
-// Verifies all 8 DMs wrote entries with matching [DMx] prefix and data
-std::vector<std::string> get_expected_multi_dm() {
+// Each thread's first push must be (thread_idx << 16) | 0.
+std::vector<std::string> get_expected_multi_writer(
+    const std::function<std::string(uint32_t)>& prefix_for_thread, uint32_t num_threads) {
     std::vector<std::string> expected = {"debug_ring_buffer="};
-    for (uint32_t dm = 0; dm < 8; dm++) {
-        // First push from each DM: (dm << 16) | 0
-        expected.push_back(fmt::format("[DM{}]0x{:08x}", dm, (dm << 16) | 0));
+    for (uint32_t thread_idx = 0; thread_idx < num_threads; thread_idx++) {
+        expected.push_back(fmt::format("[{}]0x{:08x}", prefix_for_thread(thread_idx), (thread_idx << 16) | 0));
     }
     return expected;
 }
@@ -99,6 +98,7 @@ void RunTest(
     auto& program = workload.get_programs().at(device_range);
     auto* device = mesh_device->get_devices()[0];
     bool is_quasar = device->arch() == tt::ARCH::QUASAR;
+    bool is_mpsc = is_quasar || device->arch() == tt::ARCH::BLACKHOLE;
 
     // Depending on riscv type, choose one core to run the test on
     // and set up the kernel on the correct risc
@@ -229,9 +229,11 @@ void RunTest(
     log_info(tt::LogTest, "Checking file: {}", fixture->log_file_name);
 
     // Check log
-    if (is_quasar) {
+    if (is_mpsc) {
         if (multi_dm_test) {
-            EXPECT_TRUE(FileContainsAllStrings(fixture->log_file_name, get_expected_multi_dm()));
+            EXPECT_TRUE(FileContainsAllStrings(
+                fixture->log_file_name,
+                get_expected_multi_writer([](uint32_t dm) { return fmt::format("DM{}", dm); }, /*num_threads=*/8)));
         } else {
             // Thread index for DM is processor_type (0-7), for TRISC it's 8+ based on HAL mapping
             uint32_t thread_idx = processor.processor_type;
@@ -247,6 +249,50 @@ void RunTest(
     } else {
         EXPECT_TRUE(FileContainsAllStringsInOrder(fixture->log_file_name, get_expected_spsc()));
     }
+}
+
+void RunMultiRiscTestBH(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+    distributed::MeshWorkload workload;
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    workload.add_program(device_range, {});
+    auto& program = workload.get_programs().at(device_range);
+    CoreCoord logical_core{0, 0};
+    const std::string kernel_path = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp";
+
+    DataMovementConfig brisc_config{};
+    brisc_config.processor = tt_metal::DataMovementProcessor::RISCV_0;
+    brisc_config.noc = tt_metal::NOC::RISCV_0_default;
+    brisc_config.compile_args = {NUM_PUSHES_MULTI};
+    CreateKernel(program, kernel_path, logical_core, brisc_config);
+
+    DataMovementConfig ncrisc_config{};
+    ncrisc_config.processor = tt_metal::DataMovementProcessor::RISCV_1;
+    ncrisc_config.noc = tt_metal::NOC::RISCV_1_default;
+    ncrisc_config.compile_args = {NUM_PUSHES_MULTI};
+    CreateKernel(program, kernel_path, logical_core, ncrisc_config);
+
+    // One ComputeConfig call builds all 3 TRISC binaries; each needs its own WATCHER_RINGBUF_TRISC{n} define.
+    CreateKernel(
+        program,
+        kernel_path,
+        logical_core,
+        ComputeConfig{
+            .compile_args = {NUM_PUSHES_MULTI},
+            .defines = {
+                {"WATCHER_RINGBUF_TRISC0", "1"}, {"WATCHER_RINGBUF_TRISC1", "1"}, {"WATCHER_RINGBUF_TRISC2", "1"}}});
+
+    fixture->RunProgram(mesh_device, workload, true);
+
+    log_info(tt::LogTest, "Checking file: {}", fixture->log_file_name);
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    EXPECT_TRUE(FileContainsAllStrings(
+        fixture->log_file_name,
+        get_expected_multi_writer(
+            [&hal](uint32_t thread_idx) {
+                return hal.get_processor_class_name(HalProgrammableCoreType::TENSIX, thread_idx, false);
+            },
+            /*num_threads=*/5)));
 }
 
 using enum HalProgrammableCoreType;
@@ -354,6 +400,20 @@ TEST_F(MeshWatcherFixture, TestWatcherRingBufferMpscMultiDM) {
         this->RunTestOnDevice(
             [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
                 RunTest(fixture, mesh_device, {TENSIX, DM, 0}, /*multi_dm_test=*/true);
+            },
+            mesh_device);
+    }
+}
+
+TEST_F(MeshWatcherFixture, TestWatcherRingBufferMpscMultiRiscBH) {
+    for (auto& mesh_device : this->devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        if (device->arch() != tt::ARCH::BLACKHOLE) {
+            GTEST_SKIP() << "Multi-RISC MPSC test is Blackhole-only";
+        }
+        this->RunTestOnDevice(
+            [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+                RunMultiRiscTestBH(fixture, mesh_device);
             },
             mesh_device);
     }

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
@@ -32,12 +32,10 @@
 using namespace tt;
 using namespace tt::tt_metal;
 
-constexpr uint32_t NUM_PUSHES_MULTI = 4;  // Multi-writer test: 4 pushes per thread (6 DMs, or 16 TRISCs)
+// 22 Quasar writers x 5 = 110 entries, within the 128-entry buffer so nothing is evicted
+constexpr uint32_t NUM_PUSHES_MULTI = 5;
 
-// Expected strings for a single-processor ring buffer test.
-// SPSC: pattern (idx << 16) | (idx + 1). MPSC: pattern (thread_idx << 16) | seq.
-// Newest first, limited to buffer capacity (num_pushes is chosen by the caller to exceed
-// capacity, so this always exercises wraparound).
+// Newest-first, limited to buffer capacity.
 std::vector<std::string> get_expected_single_processor(
     HalProgrammableCoreType core_type, uint32_t thread_idx, uint32_t num_pushes) {
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
@@ -60,18 +58,17 @@ std::vector<std::string> get_expected_single_processor(
     return result;
 }
 
-// Each thread's first push must be (hw_thread_id << 16) | 0, where hw_thread_id is the physical
-// hw thread id (get_hw_thread_idx()) actually encoded by the kernel -- not the loop-local index.
-// hw_id_offset maps the local index [0, num_threads) to the physical id range actually launched
-// (e.g. Quasar user DMs launch on DM2..DM7, so hw_id_offset=2).
-std::vector<std::string> get_expected_multi_writer(
-    const std::function<std::string(uint32_t)>& prefix_for_thread, uint32_t num_threads, uint32_t hw_id_offset = 0) {
-    std::vector<std::string> expected = {"debug_ring_buffer="};
+// The kernel encodes get_hw_thread_idx(), so hw_id_offset shifts the loop index onto the physical
+// ids actually launched (Quasar user DMs run on DM2...DM7, so hw_id_offset=2)
+void append_expected_writers(
+    std::vector<std::string>& expected,
+    const std::function<std::string(uint32_t)>& prefix_for_thread,
+    uint32_t num_threads,
+    uint32_t hw_id_offset = 0) {
     for (uint32_t local_idx = 0; local_idx < num_threads; local_idx++) {
         uint32_t hw_id = local_idx + hw_id_offset;
         expected.push_back(fmt::format("[{}]0x{:08x}", prefix_for_thread(hw_id), (hw_id << 16) | 0));
     }
-    return expected;
 }
 
 namespace {
@@ -79,44 +76,38 @@ namespace {
 void RunTest(
     MeshWatcherFixture* fixture,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    HalProcessorIdentifier processor,
-    bool multi_dm_test = false) {
+    HalProcessorIdentifier processor) {
     // Set up program
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
     Program program = Program();
     auto* device = mesh_device->get_devices()[0];
+
+    // Depending on riscv type, choose one core to run the test on
+    // and set up the kernel on the correct risc
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     bool is_quasar = device->arch() == tt::ARCH::QUASAR;
-    // Exceed capacity so every test exercises wraparound, regardless of buffer size.
-    uint32_t num_pushes = multi_dm_test ? NUM_PUSHES_MULTI : (hal.get_ring_buffer_capacity() + 12);
+    // Push past capacity so the oldest entries are overwritten, whatever the buffer size.
+    uint32_t num_pushes = hal.get_ring_buffer_capacity() + 12;
     constexpr const char* kernel_legacy = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp";
     constexpr const char* kernel_metal2 = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf_2_0.cpp";
     const experimental::KernelSpecName kRingbufKernelName{"ringbuf_kernel"};
 
-    // Depending on riscv type, choose one core to run the test on
-    // and set up the kernel on the correct risc
     CoreCoord logical_core, virtual_core;
     switch (processor.core_type) {
         case HalProgrammableCoreType::TENSIX: {
             logical_core = CoreCoord{0, 0};
             virtual_core = device->worker_core_from_logical_core(logical_core);
-            // TENSIX cores use the Metal 2.0 host API; ETH/DRAM/DISPATCH cores below remain on the
-            // legacy host API (no Metal 2.0 equivalent exists for those programmable core types).
+            // ETH/DRAM below stay on the legacy host API; it has no Metal 2.0 equivalent.
             experimental::KernelSpec kernel_spec{.unique_id = kRingbufKernelName, .source = kernel_metal2};
             switch (processor.processor_class) {
                 case HalProcessorClassType::DM: {
                     kernel_spec.compile_time_args["num_pushes"] = num_pushes;
                     if (is_quasar) {
-                        // No way to pin a Gen2 DM kernel to a specific hw thread: launch on all 6
-                        // user DM threads (DM0/DM1 are reserved for the runtime) and filter in-kernel.
+                        // Launch on all 6 user DM threads (DM0/DM1 are reserved for the runtime) and filter in-kernel.
                         kernel_spec.num_threads = 6;
-                        if (multi_dm_test) {
-                            kernel_spec.compiler_options.defines = {{"MULTI_DM_TEST", "1"}};
-                        } else {
-                            kernel_spec.compile_time_args["dm_id"] = processor.processor_type;
-                        }
+                        kernel_spec.compile_time_args["dm_id"] = processor.processor_type;
                         kernel_spec.hw_config = experimental::DataMovementGen2Config{};
                     } else {
                         kernel_spec.hw_config = experimental::DataMovementGen1Config{
@@ -129,14 +120,10 @@ void RunTest(
                 }
                 case HalProcessorClassType::COMPUTE: {
                     kernel_spec.compile_time_args["num_pushes"] = num_pushes;
-                    if (multi_dm_test) {
-                        kernel_spec.compiler_options.defines = {{"MULTI_DM_TEST", "1"}};
-                    } else {
-                        kernel_spec.compiler_options.defines = {
-                            {fmt::format("WATCHER_RINGBUF_TRISC{}", processor.processor_type), "1"}};
-                    }
+                    kernel_spec.compiler_options.defines = {
+                        {fmt::format("WATCHER_RINGBUF_TRISC{}", processor.processor_type), "1"}};
                     if (is_quasar) {
-                        kernel_spec.num_threads = multi_dm_test ? 4 : 1;
+                        kernel_spec.num_threads = 1;
                         kernel_spec.hw_config = experimental::ComputeGen2Config{};
                     } else {
                         kernel_spec.hw_config = experimental::ComputeGen1Config{};
@@ -213,110 +200,86 @@ void RunTest(
     log_info(tt::LogTest, "Checking file: {}", fixture->log_file_name);
 
     // Check log
-    if (multi_dm_test) {
-        if (processor.processor_class == HalProcessorClassType::DM) {
-            // DM0/DM1 are reserved for the runtime and never assigned to a kernel (see
-            // ReserveProcessors in program_spec.cpp, which fills bits in ascending order and
-            // treats DM0/DM1 as pre-used), so the 6 launched threads land on DM2..DM7 in order.
-            EXPECT_TRUE(FileContainsAllStrings(
-                fixture->log_file_name,
-                get_expected_multi_writer(
-                    [](uint32_t dm) { return fmt::format("DM{}", dm); }, /*num_threads=*/6, /*hw_id_offset=*/2)));
-        } else {
-            // All 16 TRISCs (4 engines x 4 roles) push; HAL processor index for COMPUTE starts
-            // right after the 8 DM entries.
-            EXPECT_TRUE(FileContainsAllStrings(
-                fixture->log_file_name,
-                get_expected_multi_writer(
-                    [&hal](uint32_t hw_id) {
-                        return hal.get_processor_class_name(HalProgrammableCoreType::TENSIX, hw_id, false);
-                    },
-                    /*num_threads=*/16,
-                    /*hw_id_offset=*/8)));
-        }
-    } else {
-        // Thread index for DM is processor_type (0-7), for TRISC it's 8+ based on HAL mapping
-        uint32_t thread_idx = processor.processor_type;
-        if (processor.processor_class == HalProcessorClassType::COMPUTE) {
-            // Compute processors start after DM processors in the HAL index
-            thread_idx =
-                hal.get_processor_index(processor.core_type, processor.processor_class, processor.processor_type);
-        }
-        EXPECT_TRUE(FileContainsAllStringsInOrder(
-            fixture->log_file_name, get_expected_single_processor(processor.core_type, thread_idx, num_pushes)));
-    }
+    uint32_t thread_idx =
+        hal.get_processor_index(processor.core_type, processor.processor_class, processor.processor_type);
+    EXPECT_TRUE(FileContainsAllStringsInOrder(
+        fixture->log_file_name, get_expected_single_processor(processor.core_type, thread_idx, num_pushes)));
 }
 
-void RunMultiRiscTestBH(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+void RunMultiWriterTest(MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
     auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    auto* device = mesh_device->get_devices()[0];
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    const bool is_quasar = device->arch() == tt::ARCH::QUASAR;
     CoreCoord logical_core{0, 0};
-    const std::string kernel_path = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf_2_0.cpp";
+    constexpr const char* kernel = "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf_2_0.cpp";
 
-    const experimental::KernelSpecName brisc_name{"brisc"};
-    const experimental::KernelSpecName ncrisc_name{"ncrisc"};
-    const experimental::KernelSpecName trisc_name{"trisc"};
+    std::vector<experimental::KernelSpec> specs;
+    std::vector<experimental::KernelSpecName> names;
+    auto add_spec = [&](const char* name, experimental::KernelSpec spec) {
+        spec.unique_id = experimental::KernelSpecName{name};
+        spec.source = kernel;
+        spec.compile_time_args["num_pushes"] = NUM_PUSHES_MULTI;
+        names.push_back(spec.unique_id);
+        specs.push_back(std::move(spec));
+    };
+    auto tensix_name = [&hal](uint32_t hw_id) {
+        return hal.get_processor_class_name(HalProgrammableCoreType::TENSIX, hw_id, false);
+    };
 
-    experimental::KernelSpec brisc_spec{
-        .unique_id = brisc_name,
-        .source = kernel_path,
-        .compile_time_args = {{"num_pushes", NUM_PUSHES_MULTI}},
-        .hw_config =
-            experimental::DataMovementGen1Config{
-                .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default},
-    };
-    experimental::KernelSpec ncrisc_spec{
-        .unique_id = ncrisc_name,
-        .source = kernel_path,
-        .compile_time_args = {{"num_pushes", NUM_PUSHES_MULTI}},
-        .hw_config =
-            experimental::DataMovementGen1Config{
-                .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default},
-    };
-    // One ComputeGen1Config kernel builds all 3 TRISC binaries; each needs its own
-    // WATCHER_RINGBUF_TRISC{n} define.
-    experimental::KernelSpec trisc_spec{
-        .unique_id = trisc_name,
-        .source = kernel_path,
-        .compiler_options =
-            {.defines =
-                 {{"WATCHER_RINGBUF_TRISC0", "1"}, {"WATCHER_RINGBUF_TRISC1", "1"}, {"WATCHER_RINGBUF_TRISC2", "1"}}},
-        .compile_time_args = {{"num_pushes", NUM_PUSHES_MULTI}},
-        .hw_config = experimental::ComputeGen1Config{},
-    };
+    std::vector<std::string> expected = {"debug_ring_buffer="};
+    if (is_quasar) {
+        add_spec(
+            "dm",
+            {.num_threads = 6,
+             .compiler_options = {.defines = {{"MULTI_DM_TEST", "1"}}},
+             .hw_config = experimental::DataMovementGen2Config{}});
+        add_spec(
+            "compute",
+            {.num_threads = 4,
+             .compiler_options = {.defines = {{"MULTI_DM_TEST", "1"}}},
+             .hw_config = experimental::ComputeGen2Config{}});
+        // DM0/DM1 are reserved, so the 6 launched threads land on DM2...DM7. COMPUTE follows the 8
+        // DM entries in the HAL index.
+        append_expected_writers(expected, [](uint32_t dm) { return fmt::format("DM{}", dm); }, 6, 2);
+        append_expected_writers(expected, tensix_name, 16, 8);
+    } else {
+        add_spec(
+            "brisc",
+            {.hw_config = experimental::DataMovementGen1Config{
+                 .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default}});
+        add_spec(
+            "ncrisc",
+            {.hw_config = experimental::DataMovementGen1Config{
+                 .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default}});
+        // One ComputeGen1Config kernel builds all 3 TRISC binaries; each needs its own define.
+        add_spec(
+            "trisc",
+            {.compiler_options =
+                 {.defines =
+                      {{"WATCHER_RINGBUF_TRISC0", "1"},
+                       {"WATCHER_RINGBUF_TRISC1", "1"},
+                       {"WATCHER_RINGBUF_TRISC2", "1"}}},
+             .hw_config = experimental::ComputeGen1Config{}});
+        append_expected_writers(expected, tensix_name, 5);
+    }
 
     experimental::WorkUnitSpec wu{
-        .name = "main",
-        .kernels = {brisc_name, ncrisc_name, trisc_name},
-        .target_nodes = experimental::NodeCoord{logical_core},
-    };
-    experimental::ProgramSpec spec{
-        .name = "watcher_ringbuf_multi_risc",
-        .kernels = {brisc_spec, ncrisc_spec, trisc_spec},
-        .work_units = {wu},
-    };
-    Program program = experimental::MakeProgramFromSpec(*mesh_device, spec);
-    workload.add_program(device_range, std::move(program));
+        .name = "main", .kernels = names, .target_nodes = experimental::NodeCoord{logical_core}};
+    experimental::ProgramSpec spec{.name = "watcher_ringbuf_multi", .kernels = specs, .work_units = {wu}};
+    workload.add_program(device_range, experimental::MakeProgramFromSpec(*mesh_device, spec));
 
     fixture->RunProgram(mesh_device, workload, true);
 
     log_info(tt::LogTest, "Checking file: {}", fixture->log_file_name);
-    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
-    EXPECT_TRUE(FileContainsAllStrings(
-        fixture->log_file_name,
-        get_expected_multi_writer(
-            [&hal](uint32_t thread_idx) {
-                return hal.get_processor_class_name(HalProgrammableCoreType::TENSIX, thread_idx, false);
-            },
-            /*num_threads=*/5)));
+    EXPECT_TRUE(FileContainsAllStrings(fixture->log_file_name, expected));
 }
 
-// Test parameters for the single-processor (and multi-writer) ring buffer suite.
 struct RingBufferTestParams {
     std::string test_name;
     HalProcessorIdentifier processor;
-    bool multi_dm_test = false;
 };
 
 class WatcherRingBufferTest : public MeshWatcherFixture, public ::testing::WithParamInterface<RingBufferTestParams> {};
@@ -324,7 +287,7 @@ class WatcherRingBufferTest : public MeshWatcherFixture, public ::testing::WithP
 TEST_P(WatcherRingBufferTest, TestWatcherRingBuffer) {
     const auto& params = GetParam();
     const auto& hal = MetalContext::instance().hal();
-    bool is_quasar = (hal.get_arch() == tt::ARCH::QUASAR);
+    const bool is_quasar = (hal.get_arch() == tt::ARCH::QUASAR);
 
     if (!hal.has_programmable_core_type(params.processor.core_type)) {
         GTEST_SKIP() << "Test " << params.test_name << ": core type not available on this architecture";
@@ -337,23 +300,15 @@ TEST_P(WatcherRingBufferTest, TestWatcherRingBuffer) {
                      << " but only " << available_processors << " available on this architecture";
     }
 
-    // Multi-writer test is Quasar-only (uses the Quasar-specific 6-DM/16-TRISC reservation scheme).
-    if (params.multi_dm_test && !is_quasar) {
-        GTEST_SKIP() << "Multi-writer MPSC test is Quasar-only";
-    }
-
-    // On Quasar, DM0/DM1 are reserved for the runtime (ISR/remapper) and never assigned to a
-    // user kernel, so the single-DM Brisc/NCrisc params (processor_type 0/1, meaningful only as
-    // BRISC/NCRISC on Gen1 WH/BH) can't be exercised there.
-    bool is_reserved_quasar_dm =
-        is_quasar && !params.multi_dm_test && params.processor.processor_class == HalProcessorClassType::DM &&
-        params.processor.core_type == HalProgrammableCoreType::TENSIX && params.processor.processor_type < 2;
+    const bool is_reserved_quasar_dm = is_quasar && params.processor.core_type == HalProgrammableCoreType::TENSIX &&
+                                       params.processor.processor_class == HalProcessorClassType::DM &&
+                                       params.processor.processor_type < 2;
     if (is_reserved_quasar_dm) {
         GTEST_SKIP() << "Test " << params.test_name << ": DM0/DM1 are reserved for the runtime on Quasar";
     }
 
-    bool is_idle_eth = (params.processor.core_type == HalProgrammableCoreType::IDLE_ETH);
-    bool is_dram = (params.processor.core_type == HalProgrammableCoreType::DRAM);
+    const bool is_idle_eth = (params.processor.core_type == HalProgrammableCoreType::IDLE_ETH);
+    const bool is_dram = (params.processor.core_type == HalProgrammableCoreType::DRAM);
     if ((is_idle_eth || is_dram) && !this->IsSlowDispatch()) {
         GTEST_SKIP() << "Test " << params.test_name << " requires Slow Dispatch";
     }
@@ -361,14 +316,7 @@ TEST_P(WatcherRingBufferTest, TestWatcherRingBuffer) {
     for (auto& mesh_device : this->devices_) {
         this->RunTestOnDevice(
             [&params](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-                RunTest(fixture, mesh_device, params.processor, params.multi_dm_test);
-                if (params.multi_dm_test) {
-                    RunTest(
-                        fixture,
-                        mesh_device,
-                        {HalProgrammableCoreType::TENSIX, HalProcessorClassType::COMPUTE, 0},
-                        /*multi_dm_test=*/true);
-                }
+                RunTest(fixture, mesh_device, params.processor);
             },
             mesh_device);
     }
@@ -381,7 +329,6 @@ INSTANTIATE_TEST_SUITE_P(
     WatcherRingBufferTests,
     WatcherRingBufferTest,
     ::testing::Values(
-        // DM processors
         RingBufferTestParams{"Brisc", {TENSIX, DM, 0}},
         RingBufferTestParams{"NCrisc", {TENSIX, DM, 1}},
         RingBufferTestParams{"DM2", {TENSIX, DM, 2}},
@@ -390,30 +337,24 @@ INSTANTIATE_TEST_SUITE_P(
         RingBufferTestParams{"DM5", {TENSIX, DM, 5}},
         RingBufferTestParams{"DM6", {TENSIX, DM, 6}},
         RingBufferTestParams{"DM7", {TENSIX, DM, 7}},
-        // TRISC processors
         RingBufferTestParams{"Trisc0", {TENSIX, COMPUTE, 0}},
         RingBufferTestParams{"Trisc1", {TENSIX, COMPUTE, 1}},
         RingBufferTestParams{"Trisc2", {TENSIX, COMPUTE, 2}},
-        // Ethernet processors
+        RingBufferTestParams{"Trisc3", {TENSIX, COMPUTE, 3}},  // Quasar only
         RingBufferTestParams{"Erisc", {ACTIVE_ETH, DM, 0}},
         RingBufferTestParams{"IErisc", {IDLE_ETH, DM, 0}},
-        // DRAM (DRISC)
-        RingBufferTestParams{"Drisc", {DRAM, DM, 0}},
-        // Multi-writer MPSC test (Quasar only): 6 user DMs, then 16 TRISCs
-        RingBufferTestParams{"MpscMultiDM", {TENSIX, DM, 0}, /*multi_dm_test=*/true}),
+        RingBufferTestParams{"Drisc", {DRAM, DM, 0}}),
     [](const ::testing::TestParamInfo<RingBufferTestParams>& info) { return info.param.test_name; });
 
-TEST_F(MeshWatcherFixture, TestWatcherRingBufferMpscMultiRiscBH) {
+// Every writer on the core pushes from one program: 22 on Quasar (6 DMs + 16 TRISCs), 5 on
+// Blackhole. The DM-vs-TRISC overlap is what the Quasar semaphore exists to serialize.
+TEST_F(MeshWatcherFixture, TestWatcherRingBufferMpscMultiWriter) {
+    const auto& hal = MetalContext::instance().hal();
+    if (!hal.has_mpsc_ring_buffer()) {
+        GTEST_SKIP() << "Multi-writer test requires the MPSC ring buffer";
+    }
     for (auto& mesh_device : this->devices_) {
-        auto* device = mesh_device->get_devices()[0];
-        if (device->arch() != tt::ARCH::BLACKHOLE) {
-            GTEST_SKIP() << "Multi-RISC MPSC test is Blackhole-only";
-        }
-        this->RunTestOnDevice(
-            [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
-                RunMultiRiscTestBH(fixture, mesh_device);
-            },
-            mesh_device);
+        this->RunTestOnDevice(RunMultiWriterTest, mesh_device);
     }
 }
 

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
@@ -23,6 +23,7 @@
 #include "impl/context/metal_context.hpp"
 #include "impl/kernels/kernel.hpp"
 #include <umd/device/types/core_coordinates.hpp>
+#include "impl/debug/debug_helpers.hpp"
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // A test for checking debug ring buffer feature.
@@ -30,21 +31,66 @@
 using namespace tt;
 using namespace tt::tt_metal;
 
-std::vector<std::string> expected = {
-    "debug_ring_buffer=",
-    "[0x00270028,0x00260027,0x00250026,0x00240025,0x00230024,0x00220023,0x00210022,0x00200021,",
-    " 0x001f0020,0x001e001f,0x001d001e,0x001c001d,0x001b001c,0x001a001b,0x0019001a,0x00180019,",
-    " 0x00170018,0x00160017,0x00150016,0x00140015,0x00130014,0x00120013,0x00110012,0x00100011,",
-    " 0x000f0010,0x000e000f,0x000d000e,0x000c000d,0x000b000c,0x000a000b,0x0009000a,0x00080009,",
-    "]"
-};
+constexpr uint32_t NUM_PUSHES_SINGLE = 40;  // Single-thread tests push 40 values
+constexpr uint32_t NUM_PUSHES_MULTI = 4;    // Multi-DM test: 4 pushes per DM (8 DMs x 4 = 32 total)
+
+// Generate expected ring buffer data for TRISC/ERISC/BH/WH tests
+// Pattern: (idx << 16) | (idx + 1), buffer holds 32, newest first (40 down to 9)
+std::vector<uint32_t> get_expected_data() {
+    std::vector<uint32_t> data;
+    for (uint32_t idx = NUM_PUSHES_SINGLE - 1; idx >= NUM_PUSHES_SINGLE - 32; idx--) {
+        data.push_back((idx << 16) | (idx + 1));
+    }
+    return data;
+}
+
+// Generate expected ring buffer data for Quasar single-DM tests
+// Pattern: (thread_idx << 16) | seq, buffer holds 32, newest first
+std::vector<uint32_t> get_expected_data_dm(uint32_t thread_idx) {
+    std::vector<uint32_t> data;
+    for (uint32_t seq = NUM_PUSHES_SINGLE - 1; seq >= NUM_PUSHES_SINGLE - 32; seq--) {
+        data.push_back((thread_idx << 16) | seq);
+    }
+    return data;
+}
+
+// Expected strings for BH/WH (SPSC format)
+std::vector<std::string> get_expected_spsc() {
+    auto data = get_expected_data();
+    std::vector<std::string> result = {"debug_ring_buffer="};
+    auto lines = FormatRingBuffer(data);
+    result.insert(result.end(), lines.begin(), lines.end());
+    return result;
+}
+
+// Expected strings for Quasar single-DM (MPSC format with processor prefix)
+std::vector<std::string> get_expected_mpsc(HalProgrammableCoreType core_type, uint32_t thread_idx) {
+    auto data = get_expected_data_dm(thread_idx);
+    std::vector<uint32_t> thread_indices(data.size(), thread_idx);  // All from same thread in test
+    std::vector<std::string> result = {"debug_ring_buffer="};
+    auto lines = FormatRingBuffer(data, thread_indices, core_type);
+    result.insert(result.end(), lines.begin(), lines.end());
+    return result;
+}
+
+// Expected strings for Quasar multi-DM test (MPSC format)
+// Verifies all 8 DMs wrote entries with matching [DMx] prefix and data
+std::vector<std::string> get_expected_multi_dm() {
+    std::vector<std::string> expected = {"debug_ring_buffer="};
+    for (uint32_t dm = 0; dm < 8; dm++) {
+        // First push from each DM: (dm << 16) | 0
+        expected.push_back(fmt::format("[DM{}]0x{:08x}", dm, (dm << 16) | 0));
+    }
+    return expected;
+}
 
 namespace {
 
 void RunTest(
     MeshWatcherFixture* fixture,
     const std::shared_ptr<distributed::MeshDevice>& mesh_device,
-    HalProcessorIdentifier processor) {
+    HalProcessorIdentifier processor,
+    bool multi_dm_test = false) {
     // Set up program
     distributed::MeshWorkload workload;
     auto zero_coord = distributed::MeshCoordinate(0, 0);
@@ -52,6 +98,7 @@ void RunTest(
     workload.add_program(device_range, {});
     auto& program = workload.get_programs().at(device_range);
     auto* device = mesh_device->get_devices()[0];
+    bool is_quasar = device->arch() == tt::ARCH::QUASAR;
 
     // Depending on riscv type, choose one core to run the test on
     // and set up the kernel on the correct risc
@@ -62,32 +109,61 @@ void RunTest(
             virtual_core = device->worker_core_from_logical_core(logical_core);
             switch (processor.processor_class) {
                 case HalProcessorClassType::DM: {
-                    DataMovementConfig dm_config{};
-                    switch (processor.processor_type) {
-                        case 0:
-                            dm_config.processor = tt_metal::DataMovementProcessor::RISCV_0;
-                            dm_config.noc = tt_metal::NOC::RISCV_0_default;
-                            break;
-                        case 1:
-                            dm_config.processor = tt_metal::DataMovementProcessor::RISCV_1;
-                            dm_config.noc = tt_metal::NOC::RISCV_1_default;
-                            break;
-                        default: TT_THROW("Unsupported DM processor type {}", processor.processor_type);
+                    if (is_quasar) {
+                        uint32_t num_pushes = multi_dm_test ? NUM_PUSHES_MULTI : NUM_PUSHES_SINGLE;
+                        std::vector<uint32_t> compile_args =
+                            multi_dm_test ? std::vector<uint32_t>{num_pushes}
+                                          : std::vector<uint32_t>{num_pushes, processor.processor_type};
+                        std::map<std::string, std::string> defines =
+                            multi_dm_test ? std::map<std::string, std::string>{{"MULTI_DM_TEST", "1"}}
+                                          : std::map<std::string, std::string>{};
+                        tt::tt_metal::experimental::quasar::CreateKernel(
+                            program,
+                            "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                            logical_core,
+                            tt::tt_metal::experimental::quasar::QuasarDataMovementConfig{
+                                .num_threads_per_cluster = 8, .compile_args = compile_args, .defines = defines});
+                    } else {
+                        DataMovementConfig dm_config{};
+                        dm_config.processor = static_cast<tt_metal::DataMovementProcessor>(processor.processor_type);
+                        dm_config.noc = (processor.processor_type == 0) ? tt_metal::NOC::RISCV_0_default
+                                                                        : tt_metal::NOC::RISCV_1_default;
+                        dm_config.compile_args = {NUM_PUSHES_SINGLE};
+                        CreateKernel(
+                            program,
+                            "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                            logical_core,
+                            dm_config);
                     }
-                    CreateKernel(
-                        program,
-                        "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
-                        logical_core,
-                        dm_config);
                     break;
                 }
                 case HalProcessorClassType::COMPUTE:
-                    CreateKernel(
-                        program,
-                        "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
-                        logical_core,
-                        ComputeConfig{
-                            .defines = {{fmt::format("WATCHER_RINGBUF_TRISC{}", processor.processor_type), "1"}}});
+                    if (is_quasar) {
+                        uint32_t num_threads = multi_dm_test ? 4 : 1;
+                        uint32_t num_pushes = multi_dm_test ? NUM_PUSHES_MULTI : NUM_PUSHES_SINGLE;
+                        std::map<std::string, std::string> defines =
+                            multi_dm_test
+                                ? std::map<std::string, std::string>{{"MULTI_DM_TEST", "1"}}
+                                : std::map<std::string, std::string>{
+                                      {fmt::format("WATCHER_RINGBUF_TRISC{}", processor.processor_type), "1"}};
+                        tt::tt_metal::experimental::quasar::CreateKernel(
+                            program,
+                            "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                            logical_core,
+                            experimental::quasar::QuasarComputeConfig{
+                                .num_threads_per_cluster = num_threads,
+                                .compile_args = {num_pushes},
+                                .defines = defines});
+                    } else {
+                        CreateKernel(
+                            program,
+                            "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
+                            logical_core,
+                            ComputeConfig{
+                                .compile_args = {NUM_PUSHES_SINGLE},
+                                .defines = {
+                                    {fmt::format("WATCHER_RINGBUF_TRISC{}", processor.processor_type), "1"}}});
+                    }
                     break;
             }
             break;
@@ -102,7 +178,7 @@ void RunTest(
                 program,
                 "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
                 logical_core,
-                EthernetConfig{.noc = tt_metal::NOC::NOC_0});
+                EthernetConfig{.noc = tt_metal::NOC::NOC_0, .compile_args = {NUM_PUSHES_SINGLE}});
             break;
         case HalProgrammableCoreType::IDLE_ETH:
             if (device->get_inactive_ethernet_cores().empty()) {
@@ -115,7 +191,8 @@ void RunTest(
                 program,
                 "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
                 logical_core,
-                EthernetConfig{.eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0});
+                EthernetConfig{
+                    .eth_mode = Eth::IDLE, .noc = tt_metal::NOC::NOC_0, .compile_args = {NUM_PUSHES_SINGLE}});
             break;
         case HalProgrammableCoreType::DRAM: {
             const auto& hal = tt::tt_metal::MetalContext::instance().hal();
@@ -130,7 +207,7 @@ void RunTest(
                 program,
                 "tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp",
                 logical_core,
-                DramConfig{.noc = tt_metal::NOC::NOC_0});
+                DramConfig{.noc = tt_metal::NOC::NOC_0, .compile_args = {NUM_PUSHES_SINGLE}});
             break;
         }
         case HalProgrammableCoreType::DISPATCH: {
@@ -152,12 +229,24 @@ void RunTest(
     log_info(tt::LogTest, "Checking file: {}", fixture->log_file_name);
 
     // Check log
-    EXPECT_TRUE(
-        FileContainsAllStringsInOrder(
-            fixture->log_file_name,
-            expected
-        )
-    );
+    if (is_quasar) {
+        if (multi_dm_test) {
+            EXPECT_TRUE(FileContainsAllStrings(fixture->log_file_name, get_expected_multi_dm()));
+        } else {
+            // Thread index for DM is processor_type (0-7), for TRISC it's 8+ based on HAL mapping
+            uint32_t thread_idx = processor.processor_type;
+            if (processor.processor_class == HalProcessorClassType::COMPUTE) {
+                // Compute processors start after DM processors in the HAL index
+                const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+                thread_idx =
+                    hal.get_processor_index(processor.core_type, processor.processor_class, processor.processor_type);
+            }
+            EXPECT_TRUE(FileContainsAllStringsInOrder(
+                fixture->log_file_name, get_expected_mpsc(processor.core_type, thread_idx)));
+        }
+    } else {
+        EXPECT_TRUE(FileContainsAllStringsInOrder(fixture->log_file_name, get_expected_spsc()));
+    }
 }
 
 using enum HalProgrammableCoreType;
@@ -251,6 +340,20 @@ TEST_F(MeshWatcherFixture, TensixDramTestWatcherRingBufferDrisc) {
         this->RunTestOnDevice(
             [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
                 RunTest(fixture, mesh_device, {DRAM, DM, 0});
+            },
+            mesh_device);
+    }
+}
+
+TEST_F(MeshWatcherFixture, TestWatcherRingBufferMpscMultiDM) {
+    for (auto& mesh_device : this->devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        if (device->arch() != tt::ARCH::QUASAR) {
+            GTEST_SKIP() << "Multi-DM MPSC test is Quasar-only";
+        }
+        this->RunTestOnDevice(
+            [](MeshWatcherFixture* fixture, const std::shared_ptr<distributed::MeshDevice>& mesh_device) {
+                RunTest(fixture, mesh_device, {TENSIX, DM, 0}, /*multi_dm_test=*/true);
             },
             mesh_device);
     }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp
@@ -5,11 +5,8 @@
 #include <cstdint>
 #include "api/debug/ring_buffer.h"
 #include "api/compile_time_args.h"
-#if defined(ARCH_QUASAR)
-// Use internal_::get_hw_thread_idx() to get HAL processor index (0-7 for DM, 8+ for TRISC).
-// This matches the thread_idx embedded in MPSC write_id by ring_buffer.h, ensuring the
-// data payload's thread_idx matches the prefix shown in watcher output (e.g., [Neo0TRISC0]).
-// Note: get_my_thread_id() returns a different value (processor-local index) and would mismatch.
+#if defined(ARCH_QUASAR) || defined(ARCH_BLACKHOLE)
+// get_hw_thread_idx(), not get_my_thread_id(), must match ring_buffer.h's MPSC write_id encoding.
 #include "internal/hw_thread.h"
 #endif
 
@@ -41,14 +38,14 @@ void kernel_main() {
 #if (defined(UCK_CHLKC_UNPACK) && defined(WATCHER_RINGBUF_TRISC0)) || \
       (defined(UCK_CHLKC_MATH) && defined(WATCHER_RINGBUF_TRISC1)) || \
       (defined(UCK_CHLKC_PACK) && defined(WATCHER_RINGBUF_TRISC2))
-#if defined(ARCH_QUASAR)
-    // Quasar: use HAL thread_idx for MPSC verification
+#if defined(ARCH_QUASAR) || defined(ARCH_BLACKHOLE)
+    // Quasar/Blackhole: use HAL thread_idx for MPSC verification
     uint32_t thread_idx = internal_::get_hw_thread_idx();
     for (uint32_t seq = 0; seq < num_pushes; seq++) {
         WATCHER_RING_BUFFER_PUSH((thread_idx << 16) | seq);
     }
 #else
-    // WH/BH SPSC: use idx pattern, compile-time filter ensures only matching TRISC runs
+    // WH SPSC: use idx pattern, compile-time filter ensures only matching TRISC runs
     for (uint32_t idx = 0; idx < num_pushes; idx++) {
         WATCHER_RING_BUFFER_PUSH((idx + 1) + (idx << 16));
     }
@@ -57,8 +54,17 @@ void kernel_main() {
 
 #if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || \
     defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_DRISC)
+#if defined(ARCH_BLACKHOLE)
+    // Blackhole MPSC: use HAL thread_idx
+    uint32_t thread_idx = internal_::get_hw_thread_idx();
+    for (uint32_t seq = 0; seq < num_pushes; seq++) {
+        WATCHER_RING_BUFFER_PUSH((thread_idx << 16) | seq);
+    }
+#else
+    // WH SPSC: use idx pattern
     for (uint32_t idx = 0; idx < num_pushes; idx++) {
         WATCHER_RING_BUFFER_PUSH((idx + 1) + (idx << 16));
     }
+#endif
 #endif
 }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp
@@ -4,23 +4,60 @@
 
 #include <cstdint>
 #include "api/debug/ring_buffer.h"
+#include "api/compile_time_args.h"
+#if defined(ARCH_QUASAR)
+// Use internal_::get_hw_thread_idx() to get HAL processor index (0-7 for DM, 8+ for TRISC).
+// This matches the thread_idx embedded in MPSC write_id by ring_buffer.h, ensuring the
+// data payload's thread_idx matches the prefix shown in watcher output (e.g., [Neo0TRISC0]).
+// Note: get_my_thread_id() returns a different value (processor-local index) and would mismatch.
+#include "internal/hw_thread.h"
+#endif
 
 /*
- * A test for the watcher waypointing feature.
+ * A test for the watcher ring buffer feature.
 */
-#if !defined(COMPILE_FOR_BRISC) && !defined(COMPILE_FOR_NCRISC) && !defined(COMPILE_FOR_ERISC) && \
-    !defined(COMPILE_FOR_IDLE_ERISC) && !defined(COMPILE_FOR_DRISC)
+#if defined(COMPILE_FOR_TRISC)
 #include "api/compute/common.h"
 #endif
 
 void kernel_main() {
-    // Conditionally enable using defines for each trisc
-#if (defined(UCK_CHLKC_UNPACK) and defined(WATCHER_RINGBUF_TRISC0)) or \
-    (defined(UCK_CHLKC_MATH) and defined(WATCHER_RINGBUF_TRISC1)) or \
-    (defined(UCK_CHLKC_PACK) and defined(WATCHER_RINGBUF_TRISC2)) or \
-    (defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || \
-     defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_DRISC))
-    for (uint32_t idx = 0; idx < 40; idx++) {
+    constexpr uint32_t num_pushes = get_compile_time_arg_val(0);
+
+#if defined(COMPILE_FOR_DM)
+    uint32_t thread_idx = internal_::get_hw_thread_idx();
+#if !defined(MULTI_DM_TEST)
+    // Single-DM test: only specified DM runs
+    constexpr uint32_t dm_id = get_compile_time_arg_val(1);
+    if (dm_id != thread_idx) {
+        return;
+    }
+#endif
+    for (uint32_t seq = 0; seq < num_pushes; seq++) {
+        WATCHER_RING_BUFFER_PUSH((thread_idx << 16) | seq);
+    }
+    return;
+#endif
+
+#if (defined(UCK_CHLKC_UNPACK) && defined(WATCHER_RINGBUF_TRISC0)) || \
+      (defined(UCK_CHLKC_MATH) && defined(WATCHER_RINGBUF_TRISC1)) || \
+      (defined(UCK_CHLKC_PACK) && defined(WATCHER_RINGBUF_TRISC2))
+#if defined(ARCH_QUASAR)
+    // Quasar: use HAL thread_idx for MPSC verification
+    uint32_t thread_idx = internal_::get_hw_thread_idx();
+    for (uint32_t seq = 0; seq < num_pushes; seq++) {
+        WATCHER_RING_BUFFER_PUSH((thread_idx << 16) | seq);
+    }
+#else
+    // WH/BH SPSC: use idx pattern, compile-time filter ensures only matching TRISC runs
+    for (uint32_t idx = 0; idx < num_pushes; idx++) {
+        WATCHER_RING_BUFFER_PUSH((idx + 1) + (idx << 16));
+    }
+#endif
+#endif
+
+#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || \
+    defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_DRISC)
+    for (uint32_t idx = 0; idx < num_pushes; idx++) {
         WATCHER_RING_BUFFER_PUSH((idx + 1) + (idx << 16));
     }
 #endif

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf.cpp
@@ -2,69 +2,27 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Ethernet and DRAM cores only; TENSIX uses watcher_ringbuf_2_0.cpp.
+
 #include <cstdint>
 #include "api/debug/ring_buffer.h"
 #include "api/compile_time_args.h"
-#if defined(ARCH_QUASAR) || defined(ARCH_BLACKHOLE)
+#if defined(DEBUG_RING_BUFFER_MPSC)
 // get_hw_thread_idx(), not get_my_thread_id(), must match ring_buffer.h's MPSC write_id encoding.
 #include "internal/hw_thread.h"
-#endif
-
-/*
- * A test for the watcher ring buffer feature.
-*/
-#if defined(COMPILE_FOR_TRISC)
-#include "api/compute/common.h"
 #endif
 
 void kernel_main() {
     constexpr uint32_t num_pushes = get_compile_time_arg_val(0);
 
-#if defined(COMPILE_FOR_DM)
-    uint32_t thread_idx = internal_::get_hw_thread_idx();
-#if !defined(MULTI_DM_TEST)
-    // Single-DM test: only specified DM runs
-    constexpr uint32_t dm_id = get_compile_time_arg_val(1);
-    if (dm_id != thread_idx) {
-        return;
-    }
-#endif
-    for (uint32_t seq = 0; seq < num_pushes; seq++) {
-        WATCHER_RING_BUFFER_PUSH((thread_idx << 16) | seq);
-    }
-    return;
-#endif
-
-#if (defined(UCK_CHLKC_UNPACK) && defined(WATCHER_RINGBUF_TRISC0)) || \
-      (defined(UCK_CHLKC_MATH) && defined(WATCHER_RINGBUF_TRISC1)) || \
-      (defined(UCK_CHLKC_PACK) && defined(WATCHER_RINGBUF_TRISC2))
-#if defined(ARCH_QUASAR) || defined(ARCH_BLACKHOLE)
-    // Quasar/Blackhole: use HAL thread_idx for MPSC verification
+#if defined(DEBUG_RING_BUFFER_MPSC)
     uint32_t thread_idx = internal_::get_hw_thread_idx();
     for (uint32_t seq = 0; seq < num_pushes; seq++) {
         WATCHER_RING_BUFFER_PUSH((thread_idx << 16) | seq);
     }
 #else
-    // WH SPSC: use idx pattern, compile-time filter ensures only matching TRISC runs
     for (uint32_t idx = 0; idx < num_pushes; idx++) {
         WATCHER_RING_BUFFER_PUSH((idx + 1) + (idx << 16));
     }
-#endif
-#endif
-
-#if defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || \
-    defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC) || defined(COMPILE_FOR_DRISC)
-#if defined(ARCH_BLACKHOLE)
-    // Blackhole MPSC: use HAL thread_idx
-    uint32_t thread_idx = internal_::get_hw_thread_idx();
-    for (uint32_t seq = 0; seq < num_pushes; seq++) {
-        WATCHER_RING_BUFFER_PUSH((thread_idx << 16) | seq);
-    }
-#else
-    // WH SPSC: use idx pattern
-    for (uint32_t idx = 0; idx < num_pushes; idx++) {
-        WATCHER_RING_BUFFER_PUSH((idx + 1) + (idx << 16));
-    }
-#endif
 #endif
 }

--- a/tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/watcher_ringbuf_2_0.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// TENSIX cores only; ethernet and DRAM use watcher_ringbuf.cpp.
+
+#include <cstdint>
+#include "api/debug/ring_buffer.h"
+#include "experimental/kernel_args.h"
+#if defined(DEBUG_RING_BUFFER_MPSC)
+// get_hw_thread_idx(), not get_my_thread_id(), must match ring_buffer.h's MPSC write_id encoding.
+#include "internal/hw_thread.h"
+#endif
+
+#if defined(COMPILE_FOR_TRISC)
+#include "api/compute/common.h"
+#endif
+
+// Which processors push: all data movement (COMPILE_FOR_DM is Quasar, BRISC/NCRISC are WH/BH), plus
+// TRISCs selected either individually by WATCHER_RINGBUF_TRISCn or collectively by MULTI_DM_TEST.
+#if defined(COMPILE_FOR_DM) || defined(COMPILE_FOR_BRISC) || defined(COMPILE_FOR_NCRISC) || \
+    (defined(COMPILE_FOR_TRISC) && defined(MULTI_DM_TEST)) ||                               \
+    (defined(UCK_CHLKC_UNPACK) && defined(WATCHER_RINGBUF_TRISC0)) ||                       \
+    (defined(UCK_CHLKC_MATH) && defined(WATCHER_RINGBUF_TRISC1)) ||                         \
+    (defined(UCK_CHLKC_PACK) && defined(WATCHER_RINGBUF_TRISC2)) ||                         \
+    (defined(UCK_CHLKC_ISOLATE_SFPU) && defined(WATCHER_RINGBUF_TRISC3))
+#define WATCHER_RINGBUF_PUSHER
+#endif
+
+void kernel_main() {
+#if defined(WATCHER_RINGBUF_PUSHER)
+    constexpr uint32_t num_pushes = get_arg(args::num_pushes);
+
+#if defined(DEBUG_RING_BUFFER_MPSC)
+    const uint32_t thread_idx = internal_::get_hw_thread_idx();
+#if defined(COMPILE_FOR_DM) && !defined(MULTI_DM_TEST)
+    // Single-DM test: all 6 user DMs are launched, only the requested one pushes.
+    if (get_arg(args::dm_id) != thread_idx) {
+        return;
+    }
+#endif
+#endif
+
+    for (uint32_t i = 0; i < num_pushes; i++) {
+#if defined(DEBUG_RING_BUFFER_MPSC)
+        WATCHER_RING_BUFFER_PUSH((thread_idx << 16) | i);
+#else
+        // WH slots carry no write_id, so the payload itself encodes the sequence.
+        WATCHER_RING_BUFFER_PUSH((i + 1) + (i << 16));
+#endif
+    }
+#endif
+}

--- a/tt_metal/hw/firmware/src/tt-2xx/dispatch_dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dispatch_dm.cc
@@ -8,6 +8,7 @@
 #include "internal/hw_thread.h"
 #include "api/debug/waypoint.h"
 #include "api/debug/dprint.h"
+#include "api/debug/ring_buffer.h"
 #include "internal/debug/stack_usage.h"
 #include "internal/debug/sanitize.h"
 #include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h"
@@ -105,6 +106,8 @@ extern "C" uint32_t _start1() {
     if (hartid == 0) {
         extern uint32_t __ldm_data_start[];
         do_crt1(__ldm_data_start);
+        // Must precede the ready flag below, which releases the other pushers.
+        WATCHER_RING_BUFFER_INIT();
         (*GET_MAILBOX_ADDRESS_DEV(fw_shared_globals_ready))[hartid] = SHARED_GLOBALS_READY_GO;
     }
     extern uint32_t __ldm_tdata_init[];

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -9,6 +9,7 @@
 #include "internal/hw_thread.h"
 #include "api/debug/waypoint.h"
 #include "api/debug/dprint.h"
+#include "api/debug/ring_buffer.h"
 #include "internal/debug/stack_usage.h"
 #include "internal/debug/sanitize.h"
 #include "internal/tt-2xx/dataflow_buffer/dataflow_buffer_init.h"
@@ -236,6 +237,8 @@ extern "C" uint32_t _start1() {
     if (hartid == 0) {
         extern uint32_t __ldm_data_start[];
         do_crt1(__ldm_data_start);
+        // Must precede the ready flag below, which releases the other pushers.
+        WATCHER_RING_BUFFER_INIT();
         // Originally initalized to WAIT by host firmware initializer.
         // Will be set back to WAIT immediately before running kernels.
         (*GET_MAILBOX_ADDRESS_DEV(fw_shared_globals_ready))[hartid] = SHARED_GLOBALS_READY_GO;

--- a/tt_metal/hw/inc/api/debug/ring_buffer.h
+++ b/tt_metal/hw/inc/api/debug/ring_buffer.h
@@ -4,30 +4,75 @@
 
 #pragma once
 
-// We use a magic value to initialize the ring buffer to, so that we can avoid printing it to the
-// watcher log if no ring buffer data has been written. Choose -1 so that we can increment it to
-// 0 and immediately use it as an index for the first write.
-constexpr static int16_t DEBUG_RING_BUFFER_STARTING_INDEX = -1;
-
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
 
 #include "hostdev/dev_msgs.h"
 
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_RING_BUFFER) && !defined(FORCE_WATCHER_OFF)
 
-void push_to_ring_buffer(uint32_t val) {
-    auto buf = GET_MAILBOX_ADDRESS_DEV(watcher.debug_ring_buf);
+// Ring buffer modes:
+// - Quasar: MPSC (32-bit atomics, lock-free) - works on both DM (tt-qsr64) and TRISC (tt-qsr32)
+// - WH/BH: SPSC
+
+#if defined(ARCH_QUASAR)
+#include "internal/tt-2xx/quasar/overlay/overlay_addresses.h"
+#include "internal/hw_thread.h"
+
+inline __attribute__((always_inline)) void flush_l2_cache_line(uintptr_t addr) {
+    asm volatile("fence" ::: "memory");
+    volatile uint64_t* flush_reg = reinterpret_cast<volatile uint64_t*>(L2_FLUSH_ADDR);
+    *flush_reg = static_cast<uint64_t>(addr);
+    asm volatile("fence" ::: "memory");
+}
+
+// Must be inline - DM stack is only 1KB, can't afford function call overhead
+inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
+    auto* wrapper = GET_MAILBOX_ADDRESS_DEV(watcher.debug_ring_buf);
+    auto* buf = reinterpret_cast<debug_mpsc_ring_buf_msg_t*>(wrapper->data);
+
+    // Remap to cached for atomics
+    uintptr_t addr = reinterpret_cast<uintptr_t>(buf);
+    if (addr >= MEM_L1_UNCACHED_BASE) {
+        buf = reinterpret_cast<debug_mpsc_ring_buf_msg_t*>(addr - MEM_L1_UNCACHED_BASE);
+    }
+
+    // Atomically claim a slot
+    uint32_t pos = __atomic_fetch_add(&buf->head, 1, __ATOMIC_RELAXED);
+    uint32_t idx = pos & DEBUG_RING_BUFFER_MASK;
+
+    // Write data
+    buf->slots[idx].data = val;
+
+    // Publish with thread ID + position (for host validation & hole detection)
+    uint32_t thread_idx = internal_::get_hw_thread_idx();
+    uint32_t write_id = (thread_idx << DEBUG_RING_BUFFER_THREAD_ID_SHIFT) | ((pos + 1) & DEBUG_RING_BUFFER_POS_MASK);
+    __atomic_store_n(&buf->slots[idx].write_id, write_id, __ATOMIC_RELEASE);
+
+    // Flush cache line for host visibility
+    // TODO: can this be optimized by flushing only after N amount of heads
+    flush_l2_cache_line(reinterpret_cast<uintptr_t>(&buf->slots[idx]));
+    // Head needs to be flushed separately since it lies on a different cache line
+    flush_l2_cache_line(reinterpret_cast<uintptr_t>(&buf->head));
+}
+
+#else  // WH/BH: SPSC ring buffer
+
+inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
+    auto* wrapper = GET_MAILBOX_ADDRESS_DEV(watcher.debug_ring_buf);
+    auto* buf = reinterpret_cast<debug_spsc_ring_buf_msg_t tt_l1_ptr*>(wrapper->data);
     volatile tt_l1_ptr int16_t* curr_ptr = &buf->current_ptr;
     volatile tt_l1_ptr uint16_t* wrapped = &buf->wrapped;
     uint32_t* data = buf->data;
 
-    // Bounds check, set to -1 to wrap since we increment before using.
+    // Bounds check, set to -1 to wrap since we increment before using
     if (*curr_ptr >= DEBUG_RING_BUFFER_ELEMENTS - 1) {
         *curr_ptr = DEBUG_RING_BUFFER_STARTING_INDEX;
         *wrapped = 1;
     }
     data[++(*curr_ptr)] = val;
 }
+
+#endif  // ARCH_QUASAR
 
 #define WATCHER_RING_BUFFER_PUSH(x) push_to_ring_buffer(x)
 #else  // !defined(WATCHER_ENABLED)

--- a/tt_metal/hw/inc/api/debug/ring_buffer.h
+++ b/tt_metal/hw/inc/api/debug/ring_buffer.h
@@ -11,12 +11,14 @@
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_RING_BUFFER) && !defined(FORCE_WATCHER_OFF)
 
 // Ring buffer modes:
-// - Quasar: MPSC (32-bit atomics, lock-free) - works on both DM (tt-qsr64) and TRISC (tt-qsr32)
-// - WH/BH: SPSC
+// - Quasar, Blackhole: MPSC (32-bit atomics, lock-free)
+// - WH: SPSC
+
+#if defined(ARCH_QUASAR) || defined(ARCH_BLACKHOLE)
+#include "internal/hw_thread.h"
 
 #if defined(ARCH_QUASAR)
 #include "internal/tt-2xx/quasar/overlay/overlay_addresses.h"
-#include "internal/hw_thread.h"
 
 inline __attribute__((always_inline)) void flush_l2_cache_line(uintptr_t addr) {
     asm volatile("fence" ::: "memory");
@@ -24,17 +26,20 @@ inline __attribute__((always_inline)) void flush_l2_cache_line(uintptr_t addr) {
     *flush_reg = static_cast<uint64_t>(addr);
     asm volatile("fence" ::: "memory");
 }
+#endif  // ARCH_QUASAR
 
 // Must be inline - DM stack is only 1KB, can't afford function call overhead
 inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
     auto* wrapper = GET_MAILBOX_ADDRESS_DEV(watcher.debug_ring_buf);
     auto* buf = reinterpret_cast<debug_mpsc_ring_buf_msg_t*>(wrapper->data);
 
+#if defined(ARCH_QUASAR)
     // Remap to cached for atomics
     uintptr_t addr = reinterpret_cast<uintptr_t>(buf);
     if (addr >= MEM_L1_UNCACHED_BASE) {
         buf = reinterpret_cast<debug_mpsc_ring_buf_msg_t*>(addr - MEM_L1_UNCACHED_BASE);
     }
+#endif  // ARCH_QUASAR
 
     // Atomically claim a slot
     uint32_t pos = __atomic_fetch_add(&buf->head, 1, __ATOMIC_RELAXED);
@@ -43,19 +48,19 @@ inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
     // Write data
     buf->slots[idx].data = val;
 
-    // Publish with thread ID + position (for host validation & hole detection)
     uint32_t thread_idx = internal_::get_hw_thread_idx();
-    uint32_t write_id = (thread_idx << DEBUG_RING_BUFFER_THREAD_ID_SHIFT) | ((pos + 1) & DEBUG_RING_BUFFER_POS_MASK);
-    __atomic_store_n(&buf->slots[idx].write_id, write_id, __ATOMIC_RELEASE);
+    __atomic_store_n(&buf->slots[idx].write_id, thread_idx + 1, __ATOMIC_RELEASE);
 
+#if defined(ARCH_QUASAR)
     // Flush cache line for host visibility
     // TODO: can this be optimized by flushing only after N amount of heads
     flush_l2_cache_line(reinterpret_cast<uintptr_t>(&buf->slots[idx]));
     // Head needs to be flushed separately since it lies on a different cache line
     flush_l2_cache_line(reinterpret_cast<uintptr_t>(&buf->head));
+#endif  // ARCH_QUASAR
 }
 
-#else  // WH/BH: SPSC ring buffer
+#else  // WH: SPSC ring buffer
 
 inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
     auto* wrapper = GET_MAILBOX_ADDRESS_DEV(watcher.debug_ring_buf);
@@ -72,7 +77,7 @@ inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
     data[++(*curr_ptr)] = val;
 }
 
-#endif  // ARCH_QUASAR
+#endif  // ARCH_QUASAR || ARCH_BLACKHOLE
 
 #define WATCHER_RING_BUFFER_PUSH(x) push_to_ring_buffer(x)
 #else  // !defined(WATCHER_ENABLED)

--- a/tt_metal/hw/inc/api/debug/ring_buffer.h
+++ b/tt_metal/hw/inc/api/debug/ring_buffer.h
@@ -21,12 +21,14 @@
 #include "risc_common.h"
 #if defined(ARCH_QUASAR)
 #include "tensix_neo_reg.h"
+// NEO cluster semaphore 31 is reserved for the MPSC head; kernels must not use it. The watcher's
+// host reader hardcodes the same register (watcher_device_reader.cpp).
 constexpr uintptr_t watcher_ring_buf_sem = TENSIX_GLOBAL_REGS_SEMAPHORE_REGS_SEMAPHORE_31__REG_ADDR;
 #endif
 
 inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
     auto* wrapper = GET_MAILBOX_ADDRESS_DEV(watcher.debug_ring_buf);
-    auto* buf = reinterpret_cast<debug_mpsc_ring_buf_msg_t*>(wrapper->data);
+    auto* buf = reinterpret_cast<debug_mpsc_ring_buf_msg_t tt_l1_ptr*>(wrapper->data);
 
 #if defined(ARCH_QUASAR)
     // A read at +4*(inc+8) posts `inc` and returns the pre-increment value.

--- a/tt_metal/hw/inc/api/debug/ring_buffer.h
+++ b/tt_metal/hw/inc/api/debug/ring_buffer.h
@@ -16,24 +16,14 @@
 
 #if defined(ARCH_QUASAR) || defined(ARCH_BLACKHOLE)
 #include "internal/hw_thread.h"
-
-#if defined(ARCH_QUASAR)
-#include "internal/tt-2xx/quasar/overlay/overlay_addresses.h"
-
-inline __attribute__((always_inline)) void flush_l2_cache_line(uintptr_t addr) {
-    asm volatile("fence" ::: "memory");
-    volatile uint64_t* flush_reg = reinterpret_cast<volatile uint64_t*>(L2_FLUSH_ADDR);
-    *flush_reg = static_cast<uint64_t>(addr);
-    asm volatile("fence" ::: "memory");
-}
-#endif  // ARCH_QUASAR
+#include "risc_common.h"
 
 // Must be inline - DM stack is only 1KB, can't afford function call overhead
 inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
     auto* wrapper = GET_MAILBOX_ADDRESS_DEV(watcher.debug_ring_buf);
     auto* buf = reinterpret_cast<debug_mpsc_ring_buf_msg_t*>(wrapper->data);
 
-#if defined(ARCH_QUASAR)
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
     // Remap to cached for atomics
     uintptr_t addr = reinterpret_cast<uintptr_t>(buf);
     if (addr >= MEM_L1_UNCACHED_BASE) {
@@ -51,7 +41,7 @@ inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
     uint32_t thread_idx = internal_::get_hw_thread_idx();
     __atomic_store_n(&buf->slots[idx].write_id, thread_idx + 1, __ATOMIC_RELEASE);
 
-#if defined(ARCH_QUASAR)
+#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
     // Flush cache line for host visibility
     // TODO: can this be optimized by flushing only after N amount of heads
     flush_l2_cache_line(reinterpret_cast<uintptr_t>(&buf->slots[idx]));

--- a/tt_metal/hw/inc/api/debug/ring_buffer.h
+++ b/tt_metal/hw/inc/api/debug/ring_buffer.h
@@ -10,47 +10,39 @@
 
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_RING_BUFFER) && !defined(FORCE_WATCHER_OFF)
 
-// Ring buffer modes:
-// - Quasar, Blackhole: MPSC (32-bit atomics, lock-free)
-// - WH: SPSC
+// Ring buffer modes (see DEBUG_RING_BUFFER_MPSC for which cores get which):
+// - Quasar:    MPSC, slot claimed via a NEO cluster semaphore (DM and TRISC caches are not
+//              coherent, so a RISC-V atomic on an L1 word would not serialize between them)
+// - Blackhole: MPSC, slot claimed via a 32-bit RISC-V atomic on the in-mailbox head
+// - Wormhole:  SPSC, no synchronization between RISCs
 
-#if defined(ARCH_QUASAR) || defined(ARCH_BLACKHOLE)
+#if defined(DEBUG_RING_BUFFER_MPSC)
 #include "internal/hw_thread.h"
 #include "risc_common.h"
+#if defined(ARCH_QUASAR)
+#include "tensix_neo_reg.h"
+constexpr uintptr_t watcher_ring_buf_sem = TENSIX_GLOBAL_REGS_SEMAPHORE_REGS_SEMAPHORE_31__REG_ADDR;
+#endif
 
-// Must be inline - DM stack is only 1KB, can't afford function call overhead
 inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
     auto* wrapper = GET_MAILBOX_ADDRESS_DEV(watcher.debug_ring_buf);
     auto* buf = reinterpret_cast<debug_mpsc_ring_buf_msg_t*>(wrapper->data);
 
-#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
-    // Remap to cached for atomics
-    uintptr_t addr = reinterpret_cast<uintptr_t>(buf);
-    if (addr >= MEM_L1_UNCACHED_BASE) {
-        buf = reinterpret_cast<debug_mpsc_ring_buf_msg_t*>(addr - MEM_L1_UNCACHED_BASE);
-    }
-#endif  // ARCH_QUASAR
-
-    // Atomically claim a slot
+#if defined(ARCH_QUASAR)
+    // A read at +4*(inc+8) posts `inc` and returns the pre-increment value.
+    uint32_t pos = *reinterpret_cast<volatile uint32_t*>(watcher_ring_buf_sem + 4 * (1 + 8));
+#else
     uint32_t pos = __atomic_fetch_add(&buf->head, 1, __ATOMIC_RELAXED);
+#endif
     uint32_t idx = pos & DEBUG_RING_BUFFER_MASK;
 
-    // Write data
     buf->slots[idx].data = val;
 
     uint32_t thread_idx = internal_::get_hw_thread_idx();
     __atomic_store_n(&buf->slots[idx].write_id, thread_idx + 1, __ATOMIC_RELEASE);
-
-#if defined(ARCH_QUASAR) && defined(COMPILE_FOR_DM)
-    // Flush cache line for host visibility
-    // TODO: can this be optimized by flushing only after N amount of heads
-    flush_l2_cache_line(reinterpret_cast<uintptr_t>(&buf->slots[idx]));
-    // Head needs to be flushed separately since it lies on a different cache line
-    flush_l2_cache_line(reinterpret_cast<uintptr_t>(&buf->head));
-#endif  // ARCH_QUASAR
 }
 
-#else  // WH: SPSC ring buffer
+#else  // SPSC ring buffer
 
 inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
     auto* wrapper = GET_MAILBOX_ADDRESS_DEV(watcher.debug_ring_buf);
@@ -59,7 +51,7 @@ inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
     volatile tt_l1_ptr uint16_t* wrapped = &buf->wrapped;
     uint32_t* data = buf->data;
 
-    // Bounds check, set to -1 to wrap since we increment before using
+    // Bounds check, set to -1 to wrap since we increment before using.
     if (*curr_ptr >= DEBUG_RING_BUFFER_ELEMENTS - 1) {
         *curr_ptr = DEBUG_RING_BUFFER_STARTING_INDEX;
         *wrapped = 1;
@@ -67,11 +59,22 @@ inline __attribute__((always_inline)) void push_to_ring_buffer(uint32_t val) {
     data[++(*curr_ptr)] = val;
 }
 
-#endif  // ARCH_QUASAR || ARCH_BLACKHOLE
+#endif  // DEBUG_RING_BUFFER_MPSC
+
+// Quasar: hardware raises GLOBAL_SEMAPHORES/POST_ON_UNINITIALIZED if a semaphore is posted before it
+// is initialized. DM0 firmware does it. The watcher reads it over NoC later, once the core
+// is out of reset.
+inline __attribute__((always_inline)) void init_ring_buffer() {
+#if defined(ARCH_QUASAR)
+    *reinterpret_cast<volatile uint32_t*>(watcher_ring_buf_sem) = 0;
+#endif
+}
 
 #define WATCHER_RING_BUFFER_PUSH(x) push_to_ring_buffer(x)
+#define WATCHER_RING_BUFFER_INIT() init_ring_buffer()
 #else  // !defined(WATCHER_ENABLED)
 #define WATCHER_RING_BUFFER_PUSH(x)
+#define WATCHER_RING_BUFFER_INIT()
 #endif  // defined(WATCHER_ENABLED)
 
 #endif  // KERNEL_BUILD || FW_BUILD

--- a/tt_metal/hw/inc/hostdev/debug_ring_buffer_common.h
+++ b/tt_metal/hw/inc/hostdev/debug_ring_buffer_common.h
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+// SPSC (WH/BH)
+constexpr int16_t DEBUG_RING_BUFFER_STARTING_INDEX = -1;
+constexpr int DEBUG_RING_BUFFER_SPSC_ELEMENTS = 32;
+
+struct debug_spsc_ring_buf_msg_t {
+    int16_t current_ptr;
+    uint16_t wrapped;
+    uint32_t data[DEBUG_RING_BUFFER_SPSC_ELEMENTS];
+};
+
+// MPSC (Quasar) - lock-free ring buffer for concurrent writes using 32-bit atomics
+// Works on both tt-qsr64 (DM) and tt-qsr32 (TRISC)
+constexpr int DEBUG_RING_BUFFER_MPSC_ELEMENTS = 32;
+constexpr uint32_t DEBUG_RING_BUFFER_MPSC_MASK = DEBUG_RING_BUFFER_MPSC_ELEMENTS - 1;
+constexpr uint32_t DEBUG_RING_BUFFER_MPSC_THREAD_ID_SHIFT = 27;   // Upper 5 bits for thread_idx (0-31)
+constexpr uint32_t DEBUG_RING_BUFFER_MPSC_POS_MASK = 0x07FFFFFF;  // Lower 27 bits for position
+
+struct debug_mpsc_ring_buf_slot_t {
+    uint32_t data;
+    uint32_t write_id;  // [31:27] thread_idx | [26:0] (pos+1)
+};
+
+struct debug_mpsc_ring_buf_msg_t {
+    uint32_t head;
+    uint8_t _pad[60];  // Pad to 64-byte cache line
+    debug_mpsc_ring_buf_slot_t slots[DEBUG_RING_BUFFER_MPSC_ELEMENTS];
+};
+
+// Host-side MPSC helpers
+inline uint32_t debug_ring_buffer_get_thread_idx(uint32_t write_id) {
+    return write_id >> DEBUG_RING_BUFFER_MPSC_THREAD_ID_SHIFT;
+}
+
+inline uint32_t debug_ring_buffer_get_position(uint32_t write_id) { return write_id & DEBUG_RING_BUFFER_MPSC_POS_MASK; }
+
+inline bool debug_ring_buffer_is_slot_valid(uint32_t write_id, uint32_t expected_pos) {
+    return debug_ring_buffer_get_position(write_id) == ((expected_pos + 1) & DEBUG_RING_BUFFER_MPSC_POS_MASK);
+}
+
+// Device-side constants (debug_ring_buf_size is in core_config.h for codegen)
+#if defined(KERNEL_BUILD) || defined(FW_BUILD)
+
+#if defined(ARCH_QUASAR)
+constexpr int DEBUG_RING_BUFFER_ELEMENTS = DEBUG_RING_BUFFER_MPSC_ELEMENTS;
+constexpr uint32_t DEBUG_RING_BUFFER_MASK = DEBUG_RING_BUFFER_MPSC_MASK;
+constexpr uint32_t DEBUG_RING_BUFFER_THREAD_ID_SHIFT = DEBUG_RING_BUFFER_MPSC_THREAD_ID_SHIFT;
+constexpr uint32_t DEBUG_RING_BUFFER_POS_MASK = DEBUG_RING_BUFFER_MPSC_POS_MASK;
+#else
+constexpr int DEBUG_RING_BUFFER_ELEMENTS = DEBUG_RING_BUFFER_SPSC_ELEMENTS;
+#endif
+
+#endif  // KERNEL_BUILD || FW_BUILD

--- a/tt_metal/hw/inc/hostdev/debug_ring_buffer_common.h
+++ b/tt_metal/hw/inc/hostdev/debug_ring_buffer_common.h
@@ -1,13 +1,14 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
 
-// SPSC (WH)
+// We use a magic value to initialize the ring buffer to, so that we can avoid printing it to the
+// watcher log if no ring buffer data has been written. Choose -1 so that we can increment it to
+// 0 and immediately use it as an index for the first write.
 constexpr int16_t DEBUG_RING_BUFFER_STARTING_INDEX = -1;
 constexpr int DEBUG_RING_BUFFER_SPSC_ELEMENTS = 32;
 
@@ -17,13 +18,8 @@ struct debug_spsc_ring_buf_msg_t {
     uint32_t data[DEBUG_RING_BUFFER_SPSC_ELEMENTS];
 };
 
-// MPSC (Quasar, Blackhole) - lock-free ring buffer for concurrent writes using 32-bit atomics
-// Works on tt-qsr64 (DM), tt-qsr32 (TRISC), and BH BRISC/NCRISC/TRISC0-2 (Zaamo)
-// Capacity differs per arch: Quasar launches up to 22 concurrent user writers (6 DMs + 16
-// TRISCs) pushing a handful of entries each, so needs enough headroom that one writer's
-// oldest entries don't get evicted before the host can read them (head is a single counter
-// shared by every writer, so entries are evicted in push order, not per-writer). Blackhole
-// only ever launches 5 writers (2 DM + 3 TRISC), so the original, smaller capacity still holds.
+// Writers share one head, so a chatty writer evicts the others: capacity scales with the number of
+// concurrent writers per arch, not just with how much history is wanted.
 constexpr int DEBUG_RING_BUFFER_MPSC_ELEMENTS_QUASAR = 128;
 constexpr int DEBUG_RING_BUFFER_MPSC_ELEMENTS_BLACKHOLE = 32;
 
@@ -32,46 +28,42 @@ struct debug_mpsc_ring_buf_slot_t {
     uint32_t write_id;  // thread_idx + 1; 0 means never written
 };
 
-// Device-side struct, one capacity per arch. `head` and `slots` stay top-level fields (not
-// nested) so device code (ring_buffer.h) accesses them exactly as before.
+// NEO cluster semaphore reserved for the MPSC head; kernels must not use it. Quasar keeps head here
+// rather than L1 because DM and TRISC atomics run in different coherence domains.
+constexpr uint32_t WATCHER_RING_BUF_SEMAPHORE = 31;
+
 template <int Capacity>
 struct debug_mpsc_ring_buf_msg_tmpl_t {
     uint32_t head;
-    uint8_t _pad[60];  // Pad to 64-byte cache line
     debug_mpsc_ring_buf_slot_t slots[Capacity];
 };
 
 using debug_mpsc_ring_buf_msg_quasar_t = debug_mpsc_ring_buf_msg_tmpl_t<DEBUG_RING_BUFFER_MPSC_ELEMENTS_QUASAR>;
 using debug_mpsc_ring_buf_msg_blackhole_t = debug_mpsc_ring_buf_msg_tmpl_t<DEBUG_RING_BUFFER_MPSC_ELEMENTS_BLACKHOLE>;
 
-inline uint32_t debug_ring_buffer_get_thread_idx(uint32_t write_id) { return write_id - 1; }
-
-inline bool debug_ring_buffer_is_slot_valid(uint32_t write_id) { return write_id != 0; }
-
-// Host-side only: the host doesn't know at compile time which arch's (differently-capacitied)
-// debug_mpsc_ring_buf_msg_t it's reading, so it can't index through a single fixed struct type.
-// `head` and the offset to `slots` are identical in both arch variants regardless of capacity
-// (only the trailing array length differs), so raw pointer arithmetic works for either.
-inline uint32_t debug_mpsc_ring_buffer_head(const uint8_t* base) { return *reinterpret_cast<const uint32_t*>(base); }
-
-inline const debug_mpsc_ring_buf_slot_t* debug_mpsc_ring_buffer_slot(const uint8_t* base, uint32_t idx) {
-    constexpr size_t kSlotsOffset = offsetof(debug_mpsc_ring_buf_msg_tmpl_t<1>, slots);
-    return reinterpret_cast<const debug_mpsc_ring_buf_slot_t*>(
-        base + kSlotsOffset + static_cast<size_t>(idx) * sizeof(debug_mpsc_ring_buf_slot_t));
-}
+// Host doesn't know the target arch at compile time; it reads through the largest variant.
+static_assert(
+    DEBUG_RING_BUFFER_MPSC_ELEMENTS_BLACKHOLE <= DEBUG_RING_BUFFER_MPSC_ELEMENTS_QUASAR,
+    "host view must alias the largest MPSC variant");
+using debug_mpsc_ring_buf_view_t = debug_mpsc_ring_buf_msg_quasar_t;
 
 // Device-side constants (debug_ring_buf_size is in core_config.h for codegen)
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
 
+// TODO: re-verify on Quasar ERISC/DRISC once runtime support for those cores lands -
+// they may need to fall back to SPSC.
+#if defined(ARCH_QUASAR) || defined(ARCH_BLACKHOLE)
+#define DEBUG_RING_BUFFER_MPSC 1
+#endif
+
+#if defined(DEBUG_RING_BUFFER_MPSC)
 #if defined(ARCH_QUASAR)
 constexpr int DEBUG_RING_BUFFER_MPSC_ELEMENTS = DEBUG_RING_BUFFER_MPSC_ELEMENTS_QUASAR;
 using debug_mpsc_ring_buf_msg_t = debug_mpsc_ring_buf_msg_quasar_t;
-#elif defined(ARCH_BLACKHOLE)
+#else
 constexpr int DEBUG_RING_BUFFER_MPSC_ELEMENTS = DEBUG_RING_BUFFER_MPSC_ELEMENTS_BLACKHOLE;
 using debug_mpsc_ring_buf_msg_t = debug_mpsc_ring_buf_msg_blackhole_t;
 #endif
-
-#if defined(ARCH_QUASAR) || defined(ARCH_BLACKHOLE)
 constexpr int DEBUG_RING_BUFFER_ELEMENTS = DEBUG_RING_BUFFER_MPSC_ELEMENTS;
 constexpr uint32_t DEBUG_RING_BUFFER_MASK = DEBUG_RING_BUFFER_MPSC_ELEMENTS - 1;
 #else

--- a/tt_metal/hw/inc/hostdev/debug_ring_buffer_common.h
+++ b/tt_metal/hw/inc/hostdev/debug_ring_buffer_common.h
@@ -6,7 +6,7 @@
 
 #include <cstdint>
 
-// SPSC (WH/BH)
+// SPSC (WH)
 constexpr int16_t DEBUG_RING_BUFFER_STARTING_INDEX = -1;
 constexpr int DEBUG_RING_BUFFER_SPSC_ELEMENTS = 32;
 
@@ -16,16 +16,14 @@ struct debug_spsc_ring_buf_msg_t {
     uint32_t data[DEBUG_RING_BUFFER_SPSC_ELEMENTS];
 };
 
-// MPSC (Quasar) - lock-free ring buffer for concurrent writes using 32-bit atomics
-// Works on both tt-qsr64 (DM) and tt-qsr32 (TRISC)
+// MPSC (Quasar, Blackhole) - lock-free ring buffer for concurrent writes using 32-bit atomics
+// Works on tt-qsr64 (DM), tt-qsr32 (TRISC), and BH BRISC/NCRISC/TRISC0-2 (Zaamo)
 constexpr int DEBUG_RING_BUFFER_MPSC_ELEMENTS = 32;
 constexpr uint32_t DEBUG_RING_BUFFER_MPSC_MASK = DEBUG_RING_BUFFER_MPSC_ELEMENTS - 1;
-constexpr uint32_t DEBUG_RING_BUFFER_MPSC_THREAD_ID_SHIFT = 27;   // Upper 5 bits for thread_idx (0-31)
-constexpr uint32_t DEBUG_RING_BUFFER_MPSC_POS_MASK = 0x07FFFFFF;  // Lower 27 bits for position
 
 struct debug_mpsc_ring_buf_slot_t {
     uint32_t data;
-    uint32_t write_id;  // [31:27] thread_idx | [26:0] (pos+1)
+    uint32_t write_id;  // thread_idx + 1; 0 means never written
 };
 
 struct debug_mpsc_ring_buf_msg_t {
@@ -34,25 +32,16 @@ struct debug_mpsc_ring_buf_msg_t {
     debug_mpsc_ring_buf_slot_t slots[DEBUG_RING_BUFFER_MPSC_ELEMENTS];
 };
 
-// Host-side MPSC helpers
-inline uint32_t debug_ring_buffer_get_thread_idx(uint32_t write_id) {
-    return write_id >> DEBUG_RING_BUFFER_MPSC_THREAD_ID_SHIFT;
-}
+inline uint32_t debug_ring_buffer_get_thread_idx(uint32_t write_id) { return write_id - 1; }
 
-inline uint32_t debug_ring_buffer_get_position(uint32_t write_id) { return write_id & DEBUG_RING_BUFFER_MPSC_POS_MASK; }
-
-inline bool debug_ring_buffer_is_slot_valid(uint32_t write_id, uint32_t expected_pos) {
-    return debug_ring_buffer_get_position(write_id) == ((expected_pos + 1) & DEBUG_RING_BUFFER_MPSC_POS_MASK);
-}
+inline bool debug_ring_buffer_is_slot_valid(uint32_t write_id) { return write_id != 0; }
 
 // Device-side constants (debug_ring_buf_size is in core_config.h for codegen)
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
 
-#if defined(ARCH_QUASAR)
+#if defined(ARCH_QUASAR) || defined(ARCH_BLACKHOLE)
 constexpr int DEBUG_RING_BUFFER_ELEMENTS = DEBUG_RING_BUFFER_MPSC_ELEMENTS;
 constexpr uint32_t DEBUG_RING_BUFFER_MASK = DEBUG_RING_BUFFER_MPSC_MASK;
-constexpr uint32_t DEBUG_RING_BUFFER_THREAD_ID_SHIFT = DEBUG_RING_BUFFER_MPSC_THREAD_ID_SHIFT;
-constexpr uint32_t DEBUG_RING_BUFFER_POS_MASK = DEBUG_RING_BUFFER_MPSC_POS_MASK;
 #else
 constexpr int DEBUG_RING_BUFFER_ELEMENTS = DEBUG_RING_BUFFER_SPSC_ELEMENTS;
 #endif

--- a/tt_metal/hw/inc/hostdev/debug_ring_buffer_common.h
+++ b/tt_metal/hw/inc/hostdev/debug_ring_buffer_common.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 // SPSC (WH)
@@ -18,30 +19,61 @@ struct debug_spsc_ring_buf_msg_t {
 
 // MPSC (Quasar, Blackhole) - lock-free ring buffer for concurrent writes using 32-bit atomics
 // Works on tt-qsr64 (DM), tt-qsr32 (TRISC), and BH BRISC/NCRISC/TRISC0-2 (Zaamo)
-constexpr int DEBUG_RING_BUFFER_MPSC_ELEMENTS = 32;
-constexpr uint32_t DEBUG_RING_BUFFER_MPSC_MASK = DEBUG_RING_BUFFER_MPSC_ELEMENTS - 1;
+// Capacity differs per arch: Quasar launches up to 22 concurrent user writers (6 DMs + 16
+// TRISCs) pushing a handful of entries each, so needs enough headroom that one writer's
+// oldest entries don't get evicted before the host can read them (head is a single counter
+// shared by every writer, so entries are evicted in push order, not per-writer). Blackhole
+// only ever launches 5 writers (2 DM + 3 TRISC), so the original, smaller capacity still holds.
+constexpr int DEBUG_RING_BUFFER_MPSC_ELEMENTS_QUASAR = 128;
+constexpr int DEBUG_RING_BUFFER_MPSC_ELEMENTS_BLACKHOLE = 32;
 
 struct debug_mpsc_ring_buf_slot_t {
     uint32_t data;
     uint32_t write_id;  // thread_idx + 1; 0 means never written
 };
 
-struct debug_mpsc_ring_buf_msg_t {
+// Device-side struct, one capacity per arch. `head` and `slots` stay top-level fields (not
+// nested) so device code (ring_buffer.h) accesses them exactly as before.
+template <int Capacity>
+struct debug_mpsc_ring_buf_msg_tmpl_t {
     uint32_t head;
     uint8_t _pad[60];  // Pad to 64-byte cache line
-    debug_mpsc_ring_buf_slot_t slots[DEBUG_RING_BUFFER_MPSC_ELEMENTS];
+    debug_mpsc_ring_buf_slot_t slots[Capacity];
 };
+
+using debug_mpsc_ring_buf_msg_quasar_t = debug_mpsc_ring_buf_msg_tmpl_t<DEBUG_RING_BUFFER_MPSC_ELEMENTS_QUASAR>;
+using debug_mpsc_ring_buf_msg_blackhole_t = debug_mpsc_ring_buf_msg_tmpl_t<DEBUG_RING_BUFFER_MPSC_ELEMENTS_BLACKHOLE>;
 
 inline uint32_t debug_ring_buffer_get_thread_idx(uint32_t write_id) { return write_id - 1; }
 
 inline bool debug_ring_buffer_is_slot_valid(uint32_t write_id) { return write_id != 0; }
 
+// Host-side only: the host doesn't know at compile time which arch's (differently-capacitied)
+// debug_mpsc_ring_buf_msg_t it's reading, so it can't index through a single fixed struct type.
+// `head` and the offset to `slots` are identical in both arch variants regardless of capacity
+// (only the trailing array length differs), so raw pointer arithmetic works for either.
+inline uint32_t debug_mpsc_ring_buffer_head(const uint8_t* base) { return *reinterpret_cast<const uint32_t*>(base); }
+
+inline const debug_mpsc_ring_buf_slot_t* debug_mpsc_ring_buffer_slot(const uint8_t* base, uint32_t idx) {
+    constexpr size_t kSlotsOffset = offsetof(debug_mpsc_ring_buf_msg_tmpl_t<1>, slots);
+    return reinterpret_cast<const debug_mpsc_ring_buf_slot_t*>(
+        base + kSlotsOffset + static_cast<size_t>(idx) * sizeof(debug_mpsc_ring_buf_slot_t));
+}
+
 // Device-side constants (debug_ring_buf_size is in core_config.h for codegen)
 #if defined(KERNEL_BUILD) || defined(FW_BUILD)
 
+#if defined(ARCH_QUASAR)
+constexpr int DEBUG_RING_BUFFER_MPSC_ELEMENTS = DEBUG_RING_BUFFER_MPSC_ELEMENTS_QUASAR;
+using debug_mpsc_ring_buf_msg_t = debug_mpsc_ring_buf_msg_quasar_t;
+#elif defined(ARCH_BLACKHOLE)
+constexpr int DEBUG_RING_BUFFER_MPSC_ELEMENTS = DEBUG_RING_BUFFER_MPSC_ELEMENTS_BLACKHOLE;
+using debug_mpsc_ring_buf_msg_t = debug_mpsc_ring_buf_msg_blackhole_t;
+#endif
+
 #if defined(ARCH_QUASAR) || defined(ARCH_BLACKHOLE)
 constexpr int DEBUG_RING_BUFFER_ELEMENTS = DEBUG_RING_BUFFER_MPSC_ELEMENTS;
-constexpr uint32_t DEBUG_RING_BUFFER_MASK = DEBUG_RING_BUFFER_MPSC_MASK;
+constexpr uint32_t DEBUG_RING_BUFFER_MASK = DEBUG_RING_BUFFER_MPSC_ELEMENTS - 1;
 #else
 constexpr int DEBUG_RING_BUFFER_ELEMENTS = DEBUG_RING_BUFFER_SPSC_ELEMENTS;
 #endif

--- a/tt_metal/hw/inc/hostdev/debug_ring_buffer_common.h
+++ b/tt_metal/hw/inc/hostdev/debug_ring_buffer_common.h
@@ -28,10 +28,6 @@ struct debug_mpsc_ring_buf_slot_t {
     uint32_t write_id;  // thread_idx + 1; 0 means never written
 };
 
-// NEO cluster semaphore reserved for the MPSC head; kernels must not use it. Quasar keeps head here
-// rather than L1 because DM and TRISC atomics run in different coherence domains.
-constexpr uint32_t WATCHER_RING_BUF_SEMAPHORE = 31;
-
 template <int Capacity>
 struct debug_mpsc_ring_buf_msg_tmpl_t {
     uint32_t head;

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -29,6 +29,7 @@
 
 #include "hostdevcommon/profiler_common.h"
 #include "hostdevcommon/dprint_common.h"
+#include "hostdev/debug_ring_buffer_common.h"
 
 #ifdef HAL_BUILD
 // HAL will include this file for different arch/cores, resulting in conflicting definitions that
@@ -309,12 +310,8 @@ struct debug_pause_msg_t {
 // Needs to be 32b-divisible, since the host clears pause flags from host using read_core()/write_core().
 static_assert(sizeof(debug_pause_msg_t) % sizeof(uint32_t) == 0);
 
-constexpr static int DEBUG_RING_BUFFER_ELEMENTS = 32;
-constexpr static int DEBUG_RING_BUFFER_SIZE = DEBUG_RING_BUFFER_ELEMENTS * sizeof(uint32_t);
 struct debug_ring_buf_msg_t {
-    int16_t current_ptr;
-    uint16_t wrapped;
-    uint32_t data[DEBUG_RING_BUFFER_ELEMENTS];
+    uint8_t data[debug_ring_buf_size];
 };
 
 struct debug_stack_usage_per_cpu_t {

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -445,6 +445,9 @@ static_assert(decltype(DevicePrintMemoryLayout::buffer)::processor_count == PROC
 
 // Watcher struct needs to be 32b-divisible, since we need to write it from host using write_core().
 static_assert(sizeof(watcher_msg_t) % sizeof(uint32_t) == 0);
+// debug_ring_buf is a byte array reinterpreted as 4-byte fields, and on Blackhole its head is the
+// target of an atomic, which traps if misaligned.
+static_assert(offsetof(watcher_msg_t, debug_ring_buf) % sizeof(uint32_t) == 0);
 static_assert(sizeof(kernel_config_msg_t) % sizeof(uint32_t) == 0);
 static_assert(sizeof(core_info_msg_t) % sizeof(uint32_t) == 0);
 

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/core_config.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/core_config.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <stdint.h>
+#include "hostdev/debug_ring_buffer_common.h"
 
 enum ProgrammableCoreType {
     TENSIX = 0,
@@ -40,3 +41,6 @@ constexpr uint8_t tensix_harvest_axis = 0x2;
 constexpr uint8_t subordinate_map_size = sizeof(subordinate_map_t);
 #define LOG_BASE_2_OF_DRAM_ALIGNMENT 6
 #define LOG_BASE_2_OF_L1_ALIGNMENT 4
+
+// Debug ring buffer structs/constants are in debug_ring_buffer_common.h
+constexpr uint32_t debug_ring_buf_size = sizeof(debug_spsc_ring_buf_msg_t);

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/core_config.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/core_config.h
@@ -42,7 +42,4 @@ constexpr uint8_t subordinate_map_size = sizeof(subordinate_map_t);
 #define LOG_BASE_2_OF_DRAM_ALIGNMENT 6
 #define LOG_BASE_2_OF_L1_ALIGNMENT 4
 
-// Debug ring buffer structs/constants are in debug_ring_buffer_common.h. Reference the concrete
-// per-arch type directly (not the ARCH_BLACKHOLE-gated debug_mpsc_ring_buf_msg_t alias): this
-// header is also pulled in by host-side code (e.g. bh_hal.cpp) that never defines ARCH_BLACKHOLE.
 constexpr uint32_t debug_ring_buf_size = sizeof(debug_mpsc_ring_buf_msg_blackhole_t);

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/core_config.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/core_config.h
@@ -42,5 +42,7 @@ constexpr uint8_t subordinate_map_size = sizeof(subordinate_map_t);
 #define LOG_BASE_2_OF_DRAM_ALIGNMENT 6
 #define LOG_BASE_2_OF_L1_ALIGNMENT 4
 
-// Debug ring buffer structs/constants are in debug_ring_buffer_common.h
-constexpr uint32_t debug_ring_buf_size = sizeof(debug_mpsc_ring_buf_msg_t);
+// Debug ring buffer structs/constants are in debug_ring_buffer_common.h. Reference the concrete
+// per-arch type directly (not the ARCH_BLACKHOLE-gated debug_mpsc_ring_buf_msg_t alias): this
+// header is also pulled in by host-side code (e.g. bh_hal.cpp) that never defines ARCH_BLACKHOLE.
+constexpr uint32_t debug_ring_buf_size = sizeof(debug_mpsc_ring_buf_msg_blackhole_t);

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/core_config.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/core_config.h
@@ -43,4 +43,4 @@ constexpr uint8_t subordinate_map_size = sizeof(subordinate_map_t);
 #define LOG_BASE_2_OF_L1_ALIGNMENT 4
 
 // Debug ring buffer structs/constants are in debug_ring_buffer_common.h
-constexpr uint32_t debug_ring_buf_size = sizeof(debug_spsc_ring_buf_msg_t);
+constexpr uint32_t debug_ring_buf_size = sizeof(debug_mpsc_ring_buf_msg_t);

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
@@ -110,7 +110,7 @@
 // Hardcode below due to compiler bug that cannot statically resolve the expression see GH issue #19265
 #define MEM_MAILBOX_BASE 96  // (MEM_NCRISC_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2) * 2)  // 2 nocs * 2 (B,NC)
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 13488
+#define MEM_MAILBOX_SIZE 13424
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)
 #define MEM_ZEROS_BASE ((MEM_MAILBOX_END + 31) & ~31)
 
@@ -332,14 +332,9 @@
 // sized for its 2 processors) to free L1 for the programmable-DRAM-core kernel working region.
 //
 // mailboxes_t is unconditional: every debug/profiling feature that lives in the mailbox reserves its space
-// whether or not the feature is turned on, so this one number covers, simultaneously and regardless of which
-// are enabled at runtime, the watcher (472B: waypoints, NOC sanitize, assert, pause, stack usage,
-// insert-delays, MPSC ring buffer), DPRINT (204B = 1 processor * 204) and the kernel profiler (2304B = 256B
-// control vector + 1 processor * 2KB marker buffer). Nothing else in the DRISC map is conditional either:
-// the fabric routing tables/packet-header pool are Tensix/ERISC-only, and the realtime profiler message
-// lives in the CQ region rather than the mailbox. The remaining 1500B is the launch ring (8 * 144B) + go
-// messages + core info + sync/ready flags.
-#define MEM_DRISC_MAILBOX_SIZE 4480
+// whether or not it is enabled at runtime, so this number must cover the watcher, DPRINT and the kernel
+// profiler simultaneously.
+#define MEM_DRISC_MAILBOX_SIZE 4416
 #define MEM_DRISC_MAILBOX_END (MEM_DRISC_MAILBOX_BASE + MEM_DRISC_MAILBOX_SIZE)
 #define MEM_DRISC_L1_INLINE_BASE MEM_DRISC_MAILBOX_END
 #define MEM_DRISC_L1_INLINE_END (MEM_DRISC_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2) * 2)

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
@@ -110,7 +110,7 @@
 // Hardcode below due to compiler bug that cannot statically resolve the expression see GH issue #19265
 #define MEM_MAILBOX_BASE 96  // (MEM_NCRISC_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2) * 2)  // 2 nocs * 2 (B,NC)
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 13296
+#define MEM_MAILBOX_SIZE 13488
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)
 #define MEM_ZEROS_BASE ((MEM_MAILBOX_END + 31) & ~31)
 

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
@@ -333,13 +333,13 @@
 //
 // mailboxes_t is unconditional: every debug/profiling feature that lives in the mailbox reserves its space
 // whether or not the feature is turned on, so this one number covers, simultaneously and regardless of which
-// are enabled at runtime, the watcher (288B: waypoints, NOC sanitize, assert, pause, stack usage,
-// insert-delays, ring buffer), DPRINT (204B = 1 processor * 204) and the kernel profiler (2304B = 256B
+// are enabled at runtime, the watcher (472B: waypoints, NOC sanitize, assert, pause, stack usage,
+// insert-delays, MPSC ring buffer), DPRINT (204B = 1 processor * 204) and the kernel profiler (2304B = 256B
 // control vector + 1 processor * 2KB marker buffer). Nothing else in the DRISC map is conditional either:
 // the fabric routing tables/packet-header pool are Tensix/ERISC-only, and the realtime profiler message
-// lives in the CQ region rather than the mailbox. The remaining 1492B is the launch ring (8 * 144B) + go
+// lives in the CQ region rather than the mailbox. The remaining 1500B is the launch ring (8 * 144B) + go
 // messages + core info + sync/ready flags.
-#define MEM_DRISC_MAILBOX_SIZE 4288
+#define MEM_DRISC_MAILBOX_SIZE 4480
 #define MEM_DRISC_MAILBOX_END (MEM_DRISC_MAILBOX_BASE + MEM_DRISC_MAILBOX_SIZE)
 #define MEM_DRISC_L1_INLINE_BASE MEM_DRISC_MAILBOX_END
 #define MEM_DRISC_L1_INLINE_END (MEM_DRISC_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2) * 2)

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/core_config.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/core_config.h
@@ -40,5 +40,4 @@ constexpr uint8_t subordinate_map_size = sizeof(subordinate_map_t);
 #define LOG_BASE_2_OF_DRAM_ALIGNMENT 5
 #define LOG_BASE_2_OF_L1_ALIGNMENT 4
 
-// Debug ring buffer structs/constants are in debug_ring_buffer_common.h
 constexpr uint32_t debug_ring_buf_size = sizeof(debug_spsc_ring_buf_msg_t);

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/core_config.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/core_config.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <stdint.h>
+#include "hostdev/debug_ring_buffer_common.h"
 
 enum ProgrammableCoreType {
     TENSIX = 0,
@@ -38,3 +39,6 @@ constexpr uint8_t tensix_harvest_axis = 0x1;
 constexpr uint8_t subordinate_map_size = sizeof(subordinate_map_t);
 #define LOG_BASE_2_OF_DRAM_ALIGNMENT 5
 #define LOG_BASE_2_OF_L1_ALIGNMENT 4
+
+// Debug ring buffer structs/constants are in debug_ring_buffer_common.h
+constexpr uint32_t debug_ring_buf_size = sizeof(debug_spsc_ring_buf_msg_t);

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/core_config.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/core_config.h
@@ -114,7 +114,4 @@ constexpr uint8_t subordinate_map_size = sizeof(subordinate_map_t);
 #define LOG_BASE_2_OF_DRAM_ALIGNMENT 6  // TODO: verify
 #define LOG_BASE_2_OF_L1_ALIGNMENT 4
 
-// Debug ring buffer structs/constants are in debug_ring_buffer_common.h. Reference the concrete
-// per-arch type directly (not the ARCH_QUASAR-gated debug_mpsc_ring_buf_msg_t alias): this
-// header is also pulled in by host-side code that never defines ARCH_QUASAR.
 constexpr uint32_t debug_ring_buf_size = sizeof(debug_mpsc_ring_buf_msg_quasar_t);

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/core_config.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/core_config.h
@@ -114,5 +114,7 @@ constexpr uint8_t subordinate_map_size = sizeof(subordinate_map_t);
 #define LOG_BASE_2_OF_DRAM_ALIGNMENT 6  // TODO: verify
 #define LOG_BASE_2_OF_L1_ALIGNMENT 4
 
-// Debug ring buffer structs/constants are in debug_ring_buffer_common.h
-constexpr uint32_t debug_ring_buf_size = sizeof(debug_mpsc_ring_buf_msg_t);
+// Debug ring buffer structs/constants are in debug_ring_buffer_common.h. Reference the concrete
+// per-arch type directly (not the ARCH_QUASAR-gated debug_mpsc_ring_buf_msg_t alias): this
+// header is also pulled in by host-side code that never defines ARCH_QUASAR.
+constexpr uint32_t debug_ring_buf_size = sizeof(debug_mpsc_ring_buf_msg_quasar_t);

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/core_config.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/core_config.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <stdint.h>
+#include "hostdev/debug_ring_buffer_common.h"
 
 enum ProgrammableCoreType {
     TENSIX = 0,
@@ -112,3 +113,6 @@ constexpr uint8_t tensix_harvest_axis = 0x2;
 constexpr uint8_t subordinate_map_size = sizeof(subordinate_map_t);
 #define LOG_BASE_2_OF_DRAM_ALIGNMENT 6  // TODO: verify
 #define LOG_BASE_2_OF_L1_ALIGNMENT 4
+
+// Debug ring buffer structs/constants are in debug_ring_buffer_common.h
+constexpr uint32_t debug_ring_buf_size = sizeof(debug_mpsc_ring_buf_msg_t);

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
@@ -93,7 +93,7 @@
 #define UNCACHED_MEM_MAILBOX_BASE (0x400010)  // workaround for https://github.com/tenstorrent/tt-metal/issues/19265
 // Magic sizes must be big enough to hold mailboxes_t.  static_asserts will fire if either is too small.
 // The dispatch engine mailbox is DM-only (8 processors).
-#define MEM_MAILBOX_SIZE 59264
+#define MEM_MAILBOX_SIZE 58944
 #define MEM_DISPATCH_MAILBOX_SIZE 22720
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)
 #define MEM_DISPATCH_MAILBOX_END (MEM_MAILBOX_BASE + MEM_DISPATCH_MAILBOX_SIZE)

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
@@ -93,7 +93,7 @@
 #define UNCACHED_MEM_MAILBOX_BASE (0x400010)  // workaround for https://github.com/tenstorrent/tt-metal/issues/19265
 // Magic sizes must be big enough to hold mailboxes_t.  static_asserts will fire if either is too small.
 // The dispatch engine mailbox is DM-only (8 processors).
-#define MEM_MAILBOX_SIZE 58944
+#define MEM_MAILBOX_SIZE 58928
 #define MEM_DISPATCH_MAILBOX_SIZE 22720
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)
 #define MEM_DISPATCH_MAILBOX_END (MEM_MAILBOX_BASE + MEM_DISPATCH_MAILBOX_SIZE)

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
@@ -93,7 +93,7 @@
 #define UNCACHED_MEM_MAILBOX_BASE (0x400010)  // workaround for https://github.com/tenstorrent/tt-metal/issues/19265
 // Magic sizes must be big enough to hold mailboxes_t.  static_asserts will fire if either is too small.
 // The dispatch engine mailbox is DM-only (8 processors).
-#define MEM_MAILBOX_SIZE 58928
+#define MEM_MAILBOX_SIZE 59696
 #define MEM_DISPATCH_MAILBOX_SIZE 22720
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)
 #define MEM_DISPATCH_MAILBOX_END (MEM_MAILBOX_BASE + MEM_DISPATCH_MAILBOX_SIZE)

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
@@ -94,7 +94,7 @@
 // Magic sizes must be big enough to hold mailboxes_t.  static_asserts will fire if either is too small.
 // The dispatch engine mailbox is DM-only (8 processors).
 #define MEM_MAILBOX_SIZE 59632
-#define MEM_DISPATCH_MAILBOX_SIZE 22720
+#define MEM_DISPATCH_MAILBOX_SIZE 23616
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)
 #define MEM_DISPATCH_MAILBOX_END (MEM_MAILBOX_BASE + MEM_DISPATCH_MAILBOX_SIZE)
 

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
@@ -93,7 +93,7 @@
 #define UNCACHED_MEM_MAILBOX_BASE (0x400010)  // workaround for https://github.com/tenstorrent/tt-metal/issues/19265
 // Magic sizes must be big enough to hold mailboxes_t.  static_asserts will fire if either is too small.
 // The dispatch engine mailbox is DM-only (8 processors).
-#define MEM_MAILBOX_SIZE 59696
+#define MEM_MAILBOX_SIZE 59632
 #define MEM_DISPATCH_MAILBOX_SIZE 22720
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)
 #define MEM_DISPATCH_MAILBOX_END (MEM_MAILBOX_BASE + MEM_DISPATCH_MAILBOX_SIZE)

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
@@ -93,7 +93,7 @@
 #define UNCACHED_MEM_MAILBOX_BASE (0x400010)  // workaround for https://github.com/tenstorrent/tt-metal/issues/19265
 // Magic sizes must be big enough to hold mailboxes_t.  static_asserts will fire if either is too small.
 // The dispatch engine mailbox is DM-only (8 processors).
-#define MEM_MAILBOX_SIZE 58752
+#define MEM_MAILBOX_SIZE 59264
 #define MEM_DISPATCH_MAILBOX_SIZE 22720
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)
 #define MEM_DISPATCH_MAILBOX_END (MEM_MAILBOX_BASE + MEM_DISPATCH_MAILBOX_SIZE)

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -163,6 +163,7 @@ set(HW_JIT_API_HEADERS
     inc/api/core_local_mem.h
     inc/api/tensor/noc_traits.h
     inc/hostdev/cross_node_dfb_constants.h
+    inc/hostdev/debug_ring_buffer_common.h
     inc/hostdev/dev_msgs.h
     inc/hostdev/device_print_common.h
     inc/hostdev/device_print_structures.h

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -29,6 +29,7 @@
 #include "llrt/hal.hpp"
 #include "internal/tt-2xx/quasar/error_handling.h"
 #include "internal/tt-2xx/quasar/overlay/remapper_common.hpp"
+#include "hostdev/debug_ring_buffer_common.h"
 
 namespace tt::tt_metal {
 
@@ -461,6 +462,25 @@ inline std::vector<std::string> FormatRingBuffer(
     line += "]";
     lines.push_back(line);
     return lines;
+}
+
+// SPSC overload - extracts data in newest-first order and formats
+inline std::vector<std::string> FormatRingBuffer(
+    const debug_spsc_ring_buf_msg_t& buf, HalProgrammableCoreType core_type = HalProgrammableCoreType::TENSIX) {
+    if (buf.current_ptr == DEBUG_RING_BUFFER_STARTING_INDEX) {
+        return {};
+    }
+    // Extract newest-first: walk backwards from current_ptr, wrap at 0
+    std::vector<uint32_t> data;
+    int16_t ptr = buf.current_ptr;
+    int16_t count = buf.wrapped ? DEBUG_RING_BUFFER_SPSC_ELEMENTS : (ptr + 1);
+    for (int16_t i = 0; i < count; i++) {
+        data.push_back(buf.data[ptr]);
+        if (--ptr < 0) {
+            ptr = DEBUG_RING_BUFFER_SPSC_ELEMENTS - 1;
+        }
+    }
+    return FormatRingBuffer(data, {}, core_type);
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -442,7 +442,7 @@ inline std::vector<std::string> FormatRingBuffer(
         return {};
     }
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
-    const bool is_mpsc = (hal.get_arch() == tt::ARCH::QUASAR);
+    const bool is_mpsc = (hal.get_arch() == tt::ARCH::QUASAR) || (hal.get_arch() == tt::ARCH::BLACKHOLE);
 
     std::vector<std::string> lines;
     std::string line = "[";

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -442,13 +442,11 @@ inline std::vector<std::string> FormatRingBuffer(
     if (data.empty()) {
         return {};
     }
-    TT_ASSERT(
-        thread_indices.empty() || thread_indices.size() == data.size(),
-        "FormatRingBuffer: thread_indices ({}) must be empty or the same length as data ({})",
-        thread_indices.size(),
-        data.size());
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     const bool is_mpsc = hal.has_mpsc_ring_buffer();
+    TT_ASSERT(
+        !is_mpsc || thread_indices.size() == data.size(),
+        "FormatRingBuffer: MPSC data requires one thread index per entry");
 
     constexpr size_t entries_per_line = 8;
 

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -442,7 +442,7 @@ inline std::vector<std::string> FormatRingBuffer(
         return {};
     }
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
-    const bool is_mpsc = (hal.get_arch() == tt::ARCH::QUASAR) || (hal.get_arch() == tt::ARCH::BLACKHOLE);
+    const bool is_mpsc = hal.has_mpsc_ring_buffer();
 
     std::vector<std::string> lines;
     std::string line = "[";

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -16,6 +16,7 @@
 #include <fmt/ranges.h>
 
 #include <fmt/format.h>
+#include <tt_stl/assert.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
 #include "context/metal_env_accessor.hpp"
 #include "llrt/core_descriptor.hpp"
@@ -430,7 +431,7 @@ inline int debug_server_finish_timeout_sec(const llrt::RunTimeOptions& rtoptions
     return rtoptions.get_simulator_enabled() ? 30 : 2;
 }
 
-// Format ring buffer output - auto-detects SPSC (WH/BH) vs MPSC (Quasar) based on arch
+// Format ring buffer output - auto-detects SPSC (WH) vs MPSC (Quasar/BH) based on arch
 // For MPSC, thread_indices and core_type are used to prefix entries with processor name
 // Returns vector of lines like ["[0x00270028,...,", " 0x001f0020,...,", "]"]
 // or for MPSC: ["[[DM0]0x00270028,...,", " [DM0]0x001f0020,...,", "]"]
@@ -441,19 +442,26 @@ inline std::vector<std::string> FormatRingBuffer(
     if (data.empty()) {
         return {};
     }
+    TT_ASSERT(
+        thread_indices.empty() || thread_indices.size() == data.size(),
+        "FormatRingBuffer: thread_indices ({}) must be empty or the same length as data ({})",
+        thread_indices.size(),
+        data.size());
     const auto& hal = tt::tt_metal::MetalContext::instance().hal();
     const bool is_mpsc = hal.has_mpsc_ring_buffer();
+
+    constexpr size_t entries_per_line = 8;
 
     std::vector<std::string> lines;
     std::string line = "[";
     for (size_t i = 0; i < data.size(); i++) {
-        if (is_mpsc && !thread_indices.empty()) {
+        if (is_mpsc) {
             auto name = hal.get_processor_class_name(core_type, thread_indices[i], false);
             line += fmt::format("[{}]0x{:08x},", name, data[i]);
         } else {
             line += fmt::format("0x{:08x},", data[i]);
         }
-        if ((i + 1) % 8 == 0 && i + 1 < data.size()) {
+        if ((i + 1) % entries_per_line == 0 && i + 1 < data.size()) {
             lines.push_back(line);
             line = " ";  // Continuation lines start with space
         }
@@ -470,14 +478,15 @@ inline std::vector<std::string> FormatRingBuffer(
     if (buf.current_ptr == DEBUG_RING_BUFFER_STARTING_INDEX) {
         return {};
     }
-    // Extract newest-first: walk backwards from current_ptr, wrap at 0
+    // Extract newest-first: walk backwards from the last written entry, wrapping at 0
     std::vector<uint32_t> data;
-    int16_t ptr = buf.current_ptr;
-    int16_t count = buf.wrapped ? DEBUG_RING_BUFFER_SPSC_ELEMENTS : (ptr + 1);
+    const int16_t last_written_idx = buf.current_ptr;
+    const int16_t count = buf.wrapped ? DEBUG_RING_BUFFER_SPSC_ELEMENTS : (last_written_idx + 1);
+    int16_t idx = last_written_idx;
     for (int16_t i = 0; i < count; i++) {
-        data.push_back(buf.data[ptr]);
-        if (--ptr < 0) {
-            ptr = DEBUG_RING_BUFFER_SPSC_ELEMENTS - 1;
+        data.push_back(buf.data[idx]);
+        if (--idx < 0) {
+            idx = DEBUG_RING_BUFFER_SPSC_ELEMENTS - 1;
         }
     }
     return FormatRingBuffer(data, {}, core_type);

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <optional>
 #include <set>
+#include <span>
 #include <vector>
 #include <cctype>
 #include <cstdio>
@@ -426,6 +427,40 @@ inline int debug_server_wait_timeout_sec(const llrt::RunTimeOptions& rtoptions) 
 
 inline int debug_server_finish_timeout_sec(const llrt::RunTimeOptions& rtoptions) {
     return rtoptions.get_simulator_enabled() ? 30 : 2;
+}
+
+// Format ring buffer output - auto-detects SPSC (WH/BH) vs MPSC (Quasar) based on arch
+// For MPSC, thread_indices and core_type are used to prefix entries with processor name
+// Returns vector of lines like ["[0x00270028,...,", " 0x001f0020,...,", "]"]
+// or for MPSC: ["[[DM0]0x00270028,...,", " [DM0]0x001f0020,...,", "]"]
+inline std::vector<std::string> FormatRingBuffer(
+    std::span<const uint32_t> data,
+    std::span<const uint32_t> thread_indices = {},
+    HalProgrammableCoreType core_type = HalProgrammableCoreType::TENSIX) {
+    if (data.empty()) {
+        return {};
+    }
+    const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+    const bool is_mpsc = (hal.get_arch() == tt::ARCH::QUASAR);
+
+    std::vector<std::string> lines;
+    std::string line = "[";
+    for (size_t i = 0; i < data.size(); i++) {
+        if (is_mpsc && !thread_indices.empty()) {
+            auto name = hal.get_processor_class_name(core_type, thread_indices[i], false);
+            line += fmt::format("[{}]0x{:08x},", name, data[i]);
+        } else {
+            line += fmt::format("0x{:08x},", data[i]);
+        }
+        if ((i + 1) % 8 == 0 && i + 1 < data.size()) {
+            lines.push_back(line);
+            line = " ";  // Continuation lines start with space
+        }
+    }
+    line.pop_back();  // Remove trailing comma
+    line += "]";
+    lines.push_back(line);
+    return lines;
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -905,7 +905,7 @@ void WatcherDeviceReader::Core::DumpRingBuffer(bool to_stdout) const {
     const auto& hal = reader_.env.get_hal();
 
     // On Quasar and Blackhole (Zaamo-capable), use MPSC ring buffer format
-    if (hal.get_arch() == tt::ARCH::QUASAR || hal.get_arch() == tt::ARCH::BLACKHOLE) {
+    if (hal.has_mpsc_ring_buffer()) {
         DumpMpscRingBuffer(to_stdout);
         return;
     }
@@ -936,20 +936,24 @@ void WatcherDeviceReader::Core::DumpMpscRingBuffer(bool to_stdout) const {
         dev_msgs_factory.offset_of<dev_msgs::watcher_msg_t>(dev_msgs::watcher_msg_t::Field::debug_ring_buf);
     auto ring_buf_offset = watcher_offset + ring_buf_field_offset;
     const auto* raw_ptr = reinterpret_cast<const uint8_t*>(l1_read_buf_.data());
-    const auto* rb = reinterpret_cast<const debug_mpsc_ring_buf_msg_t*>(raw_ptr + ring_buf_offset);
+    // The host doesn't know at compile time which arch's (differently-capacitied)
+    // debug_mpsc_ring_buf_msg_t is laid out here, so read via arch-agnostic pointer helpers
+    // (head and the offset to slots are identical across arch variants) rather than a fixed
+    // struct type.
+    const uint8_t* rb_base = raw_ptr + ring_buf_offset;
 
-    constexpr uint32_t capacity = DEBUG_RING_BUFFER_MPSC_ELEMENTS;
-    constexpr uint32_t mask = DEBUG_RING_BUFFER_MPSC_MASK;
-    uint32_t head = rb->head;
+    uint32_t capacity = hal.get_ring_buffer_capacity();
+    uint32_t mask = hal.get_ring_buffer_mask();
+    uint32_t head = debug_mpsc_ring_buffer_head(rb_base);
     uint32_t count = head < capacity ? head : capacity;
 
     std::vector<MpscRingBufEntry> entries;  // newest first
     for (uint32_t i = 0; i < count; i++) {
-        const auto& slot = rb->slots[(head - 1 - i) & mask];
-        if (!debug_ring_buffer_is_slot_valid(slot.write_id)) {
+        const auto* slot = debug_mpsc_ring_buffer_slot(rb_base, (head - 1 - i) & mask);
+        if (!debug_ring_buffer_is_slot_valid(slot->write_id)) {
             continue;
         }
-        entries.push_back({slot.data, debug_ring_buffer_get_thread_idx(slot.write_id)});
+        entries.push_back({slot->data, debug_ring_buffer_get_thread_idx(slot->write_id)});
     }
 
     if (!entries.empty()) {

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -904,13 +904,13 @@ void WatcherDeviceReader::Core::DumpEthLinkStatus() const {
 void WatcherDeviceReader::Core::DumpRingBuffer(bool to_stdout) const {
     const auto& hal = reader_.env.get_hal();
 
-    // On Quasar, use MPSC ring buffer format
-    if (hal.get_arch() == tt::ARCH::QUASAR) {
+    // On Quasar and Blackhole (Zaamo-capable), use MPSC ring buffer format
+    if (hal.get_arch() == tt::ARCH::QUASAR || hal.get_arch() == tt::ARCH::BLACKHOLE) {
         DumpMpscRingBuffer(to_stdout);
         return;
     }
 
-    // WH/BH: SPSC ring buffer - cast byte array wrapper to impl struct
+    // WH: SPSC ring buffer - cast byte array wrapper to impl struct
     const auto* ring_buf_data =
         reinterpret_cast<const debug_spsc_ring_buf_msg_t*>(mbox_data_.watcher().debug_ring_buf().data().data());
 
@@ -929,7 +929,6 @@ void WatcherDeviceReader::Core::DumpRingBuffer(bool to_stdout) const {
 }
 
 void WatcherDeviceReader::Core::DumpMpscRingBuffer(bool to_stdout) const {
-    // Quasar MPSC ring buffer
     const auto& hal = reader_.env.get_hal();
     auto dev_msgs_factory = hal.get_dev_msgs_factory(programmable_core_type_);
     auto watcher_offset = dev_msgs_factory.offset_of<dev_msgs::mailboxes_t>(dev_msgs::mailboxes_t::Field::watcher);
@@ -939,43 +938,21 @@ void WatcherDeviceReader::Core::DumpMpscRingBuffer(bool to_stdout) const {
     const auto* raw_ptr = reinterpret_cast<const uint8_t*>(l1_read_buf_.data());
     const auto* rb = reinterpret_cast<const debug_mpsc_ring_buf_msg_t*>(raw_ptr + ring_buf_offset);
 
-    const uint32_t head = rb->head;
     constexpr uint32_t capacity = DEBUG_RING_BUFFER_MPSC_ELEMENTS;
     constexpr uint32_t mask = DEBUG_RING_BUFFER_MPSC_MASK;
+    uint32_t head = rb->head;
+    uint32_t count = head < capacity ? head : capacity;
 
-    // Track position and buffer per core
-    uint32_t& last_pos = reader_.mpsc_last_consumed_pos_[virtual_coord_];
-    auto& entries = reader_.mpsc_ring_buf_entries_[virtual_coord_];
-
-    // If buffer overflowed, advance to oldest valid position
-    if (head > last_pos + capacity) {
-        last_pos = head - capacity;
-    }
-
-    // Collect new valid entries (oldest to newest)
-    std::vector<MpscRingBufEntry> new_entries;
-    for (uint32_t pos = last_pos; pos < head; pos++) {
-        const auto& slot = rb->slots[pos & mask];
-        if (!debug_ring_buffer_is_slot_valid(slot.write_id, pos)) {
-            break;  // Hole - in-flight write, resume next poll
+    std::vector<MpscRingBufEntry> entries;  // newest first
+    for (uint32_t i = 0; i < count; i++) {
+        const auto& slot = rb->slots[(head - 1 - i) & mask];
+        if (!debug_ring_buffer_is_slot_valid(slot.write_id)) {
+            continue;
         }
-        new_entries.push_back({slot.data, debug_ring_buffer_get_thread_idx(slot.write_id)});
-        last_pos = pos + 1;
+        entries.push_back({slot.data, debug_ring_buffer_get_thread_idx(slot.write_id)});
     }
 
-    // Insert new entries at the front (newest first)
-    if (!new_entries.empty()) {
-        // Reverse new_entries so newest is first, then prepend to existing
-        entries.insert(entries.begin(), new_entries.rbegin(), new_entries.rend());
-        // Trim to capacity
-        if (entries.size() > capacity) {
-            entries.resize(capacity);
-        }
-    }
-
-    // Output full buffer if non-empty
     if (!entries.empty()) {
-        // Extract data and thread indices for formatter
         std::vector<uint32_t> data, thread_indices;
         data.reserve(entries.size());
         thread_indices.reserve(entries.size());

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -34,6 +34,7 @@
 #include "impl/dispatch/dispatch_engine_cores.hpp"
 #include "hal_types.hpp"
 #include "api/debug/ring_buffer.h"
+#include "hostdev/debug_ring_buffer_common.h"
 #include "impl/context/metal_context.hpp"
 #include "watcher_device_reader.hpp"
 #include <impl/debug/watcher_server.hpp>
@@ -298,6 +299,7 @@ private:
     void DumpPauseStatus() const;
     void DumpEthLinkStatus() const;
     void DumpRingBuffer(bool to_stdout = false) const;
+    void DumpMpscRingBuffer(bool to_stdout = false) const;
     void DumpRunState(uint32_t state) const;
     void DumpLaunchMessage() const;
     void DumpWaypoints(bool to_stdout = false) const;
@@ -900,24 +902,33 @@ void WatcherDeviceReader::Core::DumpEthLinkStatus() const {
 }
 
 void WatcherDeviceReader::Core::DumpRingBuffer(bool to_stdout) const {
-    auto ring_buf_data = mbox_data_.watcher().debug_ring_buf();
+    const auto& hal = reader_.env.get_hal();
+
+    // On Quasar, use MPSC ring buffer format
+    if (hal.get_arch() == tt::ARCH::QUASAR) {
+        DumpMpscRingBuffer(to_stdout);
+        return;
+    }
+
+    // WH/BH: SPSC ring buffer - cast byte array wrapper to impl struct
+    const auto* ring_buf_data =
+        reinterpret_cast<const debug_spsc_ring_buf_msg_t*>(mbox_data_.watcher().debug_ring_buf().data().data());
+
     string out;
-    if (ring_buf_data.current_ptr() != DEBUG_RING_BUFFER_STARTING_INDEX) {
-        // Latest written idx is one less than the index read out of L1.
+    if (ring_buf_data->current_ptr != DEBUG_RING_BUFFER_STARTING_INDEX) {
         out += "\n\tdebug_ring_buffer=\n\t[";
-        int curr_idx = ring_buf_data.current_ptr();
-        size_t ring_buffer_elements = ring_buf_data.data().size();
+        int curr_idx = ring_buf_data->current_ptr;
+        size_t ring_buffer_elements = DEBUG_RING_BUFFER_SPSC_ELEMENTS;
         for (int count = 1; count <= ring_buffer_elements; count++) {
-            out += fmt::format("0x{:08x},", ring_buf_data.data()[curr_idx]);
+            out += fmt::format("0x{:08x},", ring_buf_data->data[curr_idx]);
             if (count % 8 == 0) {
                 out += "\n\t ";
             }
             if (curr_idx == 0) {
-                if (ring_buf_data.wrapped() == 0) {
+                if (ring_buf_data->wrapped == 0) {
                     break;  // No wrapping, so no extra data available
                 }
                 curr_idx = ring_buffer_elements - 1;  // Loop
-
             } else {
                 curr_idx--;
             }
@@ -935,6 +946,73 @@ void WatcherDeviceReader::Core::DumpRingBuffer(bool to_stdout) const {
         }
     } else {
         fprintf(reader_.f, "%s", out.c_str());
+    }
+}
+
+void WatcherDeviceReader::Core::DumpMpscRingBuffer(bool to_stdout) const {
+    // Quasar MPSC ring buffer
+    const auto& hal = reader_.env.get_hal();
+    auto dev_msgs_factory = hal.get_dev_msgs_factory(programmable_core_type_);
+    auto watcher_offset = dev_msgs_factory.offset_of<dev_msgs::mailboxes_t>(dev_msgs::mailboxes_t::Field::watcher);
+    auto ring_buf_field_offset =
+        dev_msgs_factory.offset_of<dev_msgs::watcher_msg_t>(dev_msgs::watcher_msg_t::Field::debug_ring_buf);
+    auto ring_buf_offset = watcher_offset + ring_buf_field_offset;
+    const auto* raw_ptr = reinterpret_cast<const uint8_t*>(l1_read_buf_.data());
+    const auto* rb = reinterpret_cast<const debug_mpsc_ring_buf_msg_t*>(raw_ptr + ring_buf_offset);
+
+    const uint32_t head = rb->head;
+    constexpr uint32_t capacity = DEBUG_RING_BUFFER_MPSC_ELEMENTS;
+    constexpr uint32_t mask = DEBUG_RING_BUFFER_MPSC_MASK;
+
+    // Track position and buffer per core
+    uint32_t& last_pos = reader_.mpsc_last_consumed_pos_[virtual_coord_];
+    auto& entries = reader_.mpsc_ring_buf_entries_[virtual_coord_];
+
+    // If buffer overflowed, advance to oldest valid position
+    if (head > last_pos + capacity) {
+        last_pos = head - capacity;
+    }
+
+    // Collect new valid entries (oldest to newest)
+    std::vector<MpscRingBufEntry> new_entries;
+    for (uint32_t pos = last_pos; pos < head; pos++) {
+        const auto& slot = rb->slots[pos & mask];
+        if (!debug_ring_buffer_is_slot_valid(slot.write_id, pos)) {
+            break;  // Hole - in-flight write, resume next poll
+        }
+        new_entries.push_back({slot.data, debug_ring_buffer_get_thread_idx(slot.write_id)});
+        last_pos = pos + 1;
+    }
+
+    // Insert new entries at the front (newest first)
+    if (!new_entries.empty()) {
+        // Reverse new_entries so newest is first, then prepend to existing
+        entries.insert(entries.begin(), new_entries.rbegin(), new_entries.rend());
+        // Trim to capacity
+        if (entries.size() > capacity) {
+            entries.resize(capacity);
+        }
+    }
+
+    // Output full buffer if non-empty
+    if (!entries.empty()) {
+        // Extract data and thread indices for formatter
+        std::vector<uint32_t> data, thread_indices;
+        data.reserve(entries.size());
+        thread_indices.reserve(entries.size());
+        for (const auto& e : entries) {
+            data.push_back(e.data);
+            thread_indices.push_back(e.thread_idx);
+        }
+
+        auto lines = FormatRingBuffer(data, thread_indices, programmable_core_type_);
+        string out = "\n\tdebug_ring_buffer=\n\t" + fmt::format("{}", fmt::join(lines, "\n\t"));
+
+        if (to_stdout) {
+            log_info(tt::LogMetal, "Last ring buffer status: {}", out);
+        } else {
+            fprintf(reader_.f, "%s", out.c_str());
+        }
     }
 }
 

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -19,6 +19,7 @@
 #include <core_coord.hpp>
 #include <fmt/base.h>
 #include <fmt/ranges.h>
+#include "internal/tt-2xx/quasar/tensix_neo_reg.h"
 #include "llrt/metal_soc_descriptor.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include <umd/device/types/core_coordinates.hpp>
@@ -33,7 +34,6 @@
 #include "dispatch_core_common.hpp"
 #include "impl/dispatch/dispatch_engine_cores.hpp"
 #include "hal_types.hpp"
-#include "api/debug/ring_buffer.h"
 #include "hostdev/debug_ring_buffer_common.h"
 #include "impl/context/metal_context.hpp"
 #include "watcher_device_reader.hpp"
@@ -288,6 +288,8 @@ private:
     HalProgrammableCoreType programmable_core_type_;
     std::string core_str_;
     std::vector<std::byte> l1_read_buf_;
+    // Quasar MPSC head, read at snapshot time
+    uint32_t sem_head_ = 0;
     dev_msgs::mailboxes_t::ConstView mbox_data_;
     dev_msgs::launch_msg_t::ConstView launch_msg_;
     const WatcherDeviceReader& reader_;
@@ -300,6 +302,7 @@ private:
     void DumpEthLinkStatus() const;
     void DumpRingBuffer(bool to_stdout = false) const;
     void DumpMpscRingBuffer(bool to_stdout = false) const;
+    void EmitRingBuffer(const std::vector<std::string>& lines, bool to_stdout) const;
     void DumpRunState(uint32_t state) const;
     void DumpLaunchMessage() const;
     void DumpWaypoints(bool to_stdout = false) const;
@@ -319,6 +322,7 @@ private:
         HalProgrammableCoreType programmable_core_type,
         std::string core_str,
         std::vector<std::byte> l1_read_buf,
+        uint32_t sem_head,
         dev_msgs::Factory dev_msgs_factory,
         const WatcherDeviceReader& reader,
         DumpData& dump_data) :
@@ -326,6 +330,7 @@ private:
         programmable_core_type_(programmable_core_type),
         core_str_(std::move(core_str)),
         l1_read_buf_(std::move(l1_read_buf)),
+        sem_head_(sem_head),
         mbox_data_(dev_msgs_factory.create_view<dev_msgs::mailboxes_t>(l1_read_buf_.data())),
         launch_msg_(get_valid_launch_message(mbox_data_)),
         reader_(reader),
@@ -600,11 +605,24 @@ WatcherDeviceReader::Core WatcherDeviceReader::Core::Create(
     std::vector<std::byte> l1_read_buf(mailbox_read_size);
     reader.env.get_cluster().read_core(
         l1_read_buf.data(), l1_read_buf.size(), {static_cast<size_t>(reader.device_id), virtual_coord}, mailbox_addr);
+
+    // Quasar's MPSC head lives in a semaphore register rather than the mailbox. Read it here with the
+    // rest of the snapshot.
+    uint32_t sem_head = 0;
+    if (hal.get_arch() == tt::ARCH::QUASAR) {
+        reader.env.get_cluster().read_core(
+            &sem_head,
+            sizeof(sem_head),
+            {static_cast<size_t>(reader.device_id), virtual_coord},
+            TENSIX_GLOBAL_REGS_SEMAPHORE_REGS_SEMAPHORE_31__REG_ADDR);
+    }
+
     return Core(
         virtual_coord,
         programmable_core_type,
         std::move(core_str),
         std::move(l1_read_buf),
+        sem_head,
         dev_msgs_factory,
         reader,
         dump_data);
@@ -904,7 +922,7 @@ void WatcherDeviceReader::Core::DumpEthLinkStatus() const {
 void WatcherDeviceReader::Core::DumpRingBuffer(bool to_stdout) const {
     const auto& hal = reader_.env.get_hal();
 
-    // On Quasar and Blackhole (Zaamo-capable), use MPSC ring buffer format
+    // On Quasar and Blackhole, use MPSC ring buffer format
     if (hal.has_mpsc_ring_buffer()) {
         DumpMpscRingBuffer(to_stdout);
         return;
@@ -914,13 +932,15 @@ void WatcherDeviceReader::Core::DumpRingBuffer(bool to_stdout) const {
     const auto* ring_buf_data =
         reinterpret_cast<const debug_spsc_ring_buf_msg_t*>(mbox_data_.watcher().debug_ring_buf().data().data());
 
-    string out;
-    auto lines = FormatRingBuffer(*ring_buf_data, programmable_core_type_);
-    if (!lines.empty()) {
-        out = "\n\tdebug_ring_buffer=\n\t" + fmt::format("{}", fmt::join(lines, "\n\t"));
-    }
+    EmitRingBuffer(FormatRingBuffer(*ring_buf_data, programmable_core_type_), to_stdout);
+}
 
-    // This function can either dump to stdout or the log file.
+// Either dumps to stdout or to the log file.
+void WatcherDeviceReader::Core::EmitRingBuffer(const std::vector<std::string>& lines, bool to_stdout) const {
+    if (lines.empty()) {
+        return;
+    }
+    string out = "\n\tdebug_ring_buffer=\n\t" + fmt::format("{}", fmt::join(lines, "\n\t"));
     if (to_stdout) {
         log_info(tt::LogMetal, "Last ring buffer status: {}", out);
     } else {
@@ -930,50 +950,30 @@ void WatcherDeviceReader::Core::DumpRingBuffer(bool to_stdout) const {
 
 void WatcherDeviceReader::Core::DumpMpscRingBuffer(bool to_stdout) const {
     const auto& hal = reader_.env.get_hal();
-    auto dev_msgs_factory = hal.get_dev_msgs_factory(programmable_core_type_);
-    auto watcher_offset = dev_msgs_factory.offset_of<dev_msgs::mailboxes_t>(dev_msgs::mailboxes_t::Field::watcher);
-    auto ring_buf_field_offset =
-        dev_msgs_factory.offset_of<dev_msgs::watcher_msg_t>(dev_msgs::watcher_msg_t::Field::debug_ring_buf);
-    auto ring_buf_offset = watcher_offset + ring_buf_field_offset;
-    const auto* raw_ptr = reinterpret_cast<const uint8_t*>(l1_read_buf_.data());
-    // The host doesn't know at compile time which arch's (differently-capacitied)
-    // debug_mpsc_ring_buf_msg_t is laid out here, so read via arch-agnostic pointer helpers
-    // (head and the offset to slots are identical across arch variants) rather than a fixed
-    // struct type.
-    const uint8_t* rb_base = raw_ptr + ring_buf_offset;
+    const auto* rb =
+        reinterpret_cast<const debug_mpsc_ring_buf_view_t*>(mbox_data_.watcher().debug_ring_buf().data().data());
 
     uint32_t capacity = hal.get_ring_buffer_capacity();
-    uint32_t mask = hal.get_ring_buffer_mask();
-    uint32_t head = debug_mpsc_ring_buffer_head(rb_base);
-    uint32_t count = head < capacity ? head : capacity;
+    uint32_t mask = capacity - 1;  // capacity is a power of two
+    // Quasar keeps head in a semaphore register, snapshotted alongside the mailbox.
+    uint32_t head = (hal.get_arch() == tt::ARCH::QUASAR) ? sem_head_ : rb->head;
 
-    std::vector<MpscRingBufEntry> entries;  // newest first
-    for (uint32_t i = 0; i < count; i++) {
-        const auto* slot = debug_mpsc_ring_buffer_slot(rb_base, (head - 1 - i) & mask);
-        if (!debug_ring_buffer_is_slot_valid(slot->write_id)) {
+    // Scan every slot rather than min(head, capacity): the semaphore is 16-bit, so head wraps and
+    // cannot bound the live entries.
+    std::vector<uint32_t> data, thread_indices;  // newest first
+    data.reserve(capacity);
+    thread_indices.reserve(capacity);
+    for (uint32_t i = 0; i < capacity; i++) {
+        const auto& slot = rb->slots[(head - 1 - i) & mask];
+        // write_id is thread_idx + 1, so 0 means the slot was never written.
+        if (slot.write_id == 0) {
             continue;
         }
-        entries.push_back({slot->data, debug_ring_buffer_get_thread_idx(slot->write_id)});
+        data.push_back(slot.data);
+        thread_indices.push_back(slot.write_id - 1);
     }
 
-    if (!entries.empty()) {
-        std::vector<uint32_t> data, thread_indices;
-        data.reserve(entries.size());
-        thread_indices.reserve(entries.size());
-        for (const auto& e : entries) {
-            data.push_back(e.data);
-            thread_indices.push_back(e.thread_idx);
-        }
-
-        auto lines = FormatRingBuffer(data, thread_indices, programmable_core_type_);
-        string out = "\n\tdebug_ring_buffer=\n\t" + fmt::format("{}", fmt::join(lines, "\n\t"));
-
-        if (to_stdout) {
-            log_info(tt::LogMetal, "Last ring buffer status: {}", out);
-        } else {
-            fprintf(reader_.f, "%s", out.c_str());
-        }
-    }
+    EmitRingBuffer(FormatRingBuffer(data, thread_indices, programmable_core_type_), to_stdout);
 }
 
 void WatcherDeviceReader::Core::DumpRunState(uint32_t state) const {

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -915,35 +915,14 @@ void WatcherDeviceReader::Core::DumpRingBuffer(bool to_stdout) const {
         reinterpret_cast<const debug_spsc_ring_buf_msg_t*>(mbox_data_.watcher().debug_ring_buf().data().data());
 
     string out;
-    if (ring_buf_data->current_ptr != DEBUG_RING_BUFFER_STARTING_INDEX) {
-        out += "\n\tdebug_ring_buffer=\n\t[";
-        int curr_idx = ring_buf_data->current_ptr;
-        size_t ring_buffer_elements = DEBUG_RING_BUFFER_SPSC_ELEMENTS;
-        for (int count = 1; count <= ring_buffer_elements; count++) {
-            out += fmt::format("0x{:08x},", ring_buf_data->data[curr_idx]);
-            if (count % 8 == 0) {
-                out += "\n\t ";
-            }
-            if (curr_idx == 0) {
-                if (ring_buf_data->wrapped == 0) {
-                    break;  // No wrapping, so no extra data available
-                }
-                curr_idx = ring_buffer_elements - 1;  // Loop
-            } else {
-                curr_idx--;
-            }
-        }
-        // Remove the last comma
-        out.pop_back();
-        out += "]";
+    auto lines = FormatRingBuffer(*ring_buf_data, programmable_core_type_);
+    if (!lines.empty()) {
+        out = "\n\tdebug_ring_buffer=\n\t" + fmt::format("{}", fmt::join(lines, "\n\t"));
     }
 
     // This function can either dump to stdout or the log file.
     if (to_stdout) {
-        if (!out.empty()) {
-            out = string("Last ring buffer status: ") + out;
-            log_info(tt::LogMetal, "{}", out);
-        }
+        log_info(tt::LogMetal, "Last ring buffer status: {}", out);
     } else {
         fprintf(reader_.f, "%s", out.c_str());
     }

--- a/tt_metal/impl/debug/watcher_device_reader.hpp
+++ b/tt_metal/impl/debug/watcher_device_reader.hpp
@@ -23,6 +23,12 @@ constexpr uint32_t DEBUG_SANITIZE_SENTINEL_OK_32 = 0xbadabada;
 constexpr uint16_t DEBUG_SANITIZE_SENTINEL_OK_16 = 0xbada;
 constexpr uint8_t DEBUG_SANITIZE_SENTINEL_OK_8 = 0xda;
 
+// MPSC ring buffer entry for host-side tracking (data + thread for display)
+struct MpscRingBufEntry {
+    uint32_t data;
+    uint32_t thread_idx;  // Needed for [DM0] prefix in output
+};
+
 class WatcherDeviceReader {
 public:
     WatcherDeviceReader(
@@ -51,6 +57,13 @@ private:
     const std::vector<std::string>& kernel_names;
     std::map<CoreCoord, uint32_t> logical_core_to_eth_link_retraining_count;
     std::map<HalProgrammableCoreType, EnableSymbolsInfo> symbols_info_cache_;
+
+    // MPSC ring buffer reader state (Quasar only) - tracks last consumed position per core
+    // Mutable because this is reader state updated during const Dump operations
+    mutable std::map<CoreCoord, uint32_t> mpsc_last_consumed_pos_;
+    // MPSC ring buffer entries (Quasar only) - maintains full buffer contents per core for display
+    // Stores entries newest-first, limited to buffer capacity (32 entries)
+    mutable std::map<CoreCoord, std::vector<MpscRingBufEntry>> mpsc_ring_buf_entries_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/watcher_device_reader.hpp
+++ b/tt_metal/impl/debug/watcher_device_reader.hpp
@@ -23,10 +23,9 @@ constexpr uint32_t DEBUG_SANITIZE_SENTINEL_OK_32 = 0xbadabada;
 constexpr uint16_t DEBUG_SANITIZE_SENTINEL_OK_16 = 0xbada;
 constexpr uint8_t DEBUG_SANITIZE_SENTINEL_OK_8 = 0xda;
 
-// MPSC ring buffer entry for host-side tracking (data + thread for display)
 struct MpscRingBufEntry {
     uint32_t data;
-    uint32_t thread_idx;  // Needed for [DM0] prefix in output
+    uint32_t thread_idx;
 };
 
 class WatcherDeviceReader {
@@ -57,13 +56,6 @@ private:
     const std::vector<std::string>& kernel_names;
     std::map<CoreCoord, uint32_t> logical_core_to_eth_link_retraining_count;
     std::map<HalProgrammableCoreType, EnableSymbolsInfo> symbols_info_cache_;
-
-    // MPSC ring buffer reader state (Quasar only) - tracks last consumed position per core
-    // Mutable because this is reader state updated during const Dump operations
-    mutable std::map<CoreCoord, uint32_t> mpsc_last_consumed_pos_;
-    // MPSC ring buffer entries (Quasar only) - maintains full buffer contents per core for display
-    // Stores entries newest-first, limited to buffer capacity (32 entries)
-    mutable std::map<CoreCoord, std::vector<MpscRingBufEntry>> mpsc_ring_buf_entries_;
 };
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/watcher_device_reader.hpp
+++ b/tt_metal/impl/debug/watcher_device_reader.hpp
@@ -23,11 +23,6 @@ constexpr uint32_t DEBUG_SANITIZE_SENTINEL_OK_32 = 0xbadabada;
 constexpr uint16_t DEBUG_SANITIZE_SENTINEL_OK_16 = 0xbada;
 constexpr uint8_t DEBUG_SANITIZE_SENTINEL_OK_8 = 0xda;
 
-struct MpscRingBufEntry {
-    uint32_t data;
-    uint32_t thread_idx;
-};
-
 class WatcherDeviceReader {
 public:
     WatcherDeviceReader(

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -400,9 +400,9 @@ void WatcherServer::Impl::init_device(ChipId device_id) {
         data.assert_status().tripped() = dev_msgs::DebugAssertOK;
         data.assert_status().which() = DEBUG_SANITIZE_SENTINEL_OK_8;
 
-        // Initialize debug ring buffer. Quasar MPSC buffer is already zeroed on create.
-        // WH/BH SPSC buffer needs current_ptr set to -1 as sentinel.
-        if (hal.get_arch() != tt::ARCH::QUASAR) {
+        // Initialize debug ring buffer. Quasar/Blackhole MPSC buffer is already zeroed on create.
+        // WH SPSC buffer needs current_ptr set to -1 as sentinel.
+        if (hal.get_arch() == tt::ARCH::WORMHOLE_B0) {
             auto* ring_buf = reinterpret_cast<debug_spsc_ring_buf_msg_t*>(data.debug_ring_buf().data().data());
             ring_buf->current_ptr = DEBUG_RING_BUFFER_STARTING_INDEX;
             ring_buf->wrapped = 0;

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -25,7 +25,6 @@
 #include <tt_stl/fmt.hpp>
 #include "context/metal_env_impl.hpp"
 #include "core_coord.hpp"
-#include "api/debug/ring_buffer.h"
 #include "debug_helpers.hpp"
 #include "hal_types.hpp"
 #include "llrt/hal.hpp"
@@ -40,6 +39,7 @@
 #include "rtoptions.hpp"
 #include "watcher_device_reader.hpp"
 #include "impl/dispatch/dispatch_engine_cores.hpp"
+#include "hostdev/debug_ring_buffer_common.h"
 
 using namespace tt::tt_metal;
 
@@ -400,10 +400,13 @@ void WatcherServer::Impl::init_device(ChipId device_id) {
         data.assert_status().tripped() = dev_msgs::DebugAssertOK;
         data.assert_status().which() = DEBUG_SANITIZE_SENTINEL_OK_8;
 
-        // Initialize debug ring buffer to a known init val, we'll check against this to see if any
-        // data has been written.
-        data.debug_ring_buf().current_ptr() = DEBUG_RING_BUFFER_STARTING_INDEX;
-        data.debug_ring_buf().wrapped() = 0;
+        // Initialize debug ring buffer. Quasar MPSC buffer is already zeroed on create.
+        // WH/BH SPSC buffer needs current_ptr set to -1 as sentinel.
+        if (hal.get_arch() != tt::ARCH::QUASAR) {
+            auto* ring_buf = reinterpret_cast<debug_spsc_ring_buf_msg_t*>(data.debug_ring_buf().data().data());
+            ring_buf->current_ptr = DEBUG_RING_BUFFER_STARTING_INDEX;
+            ring_buf->wrapped = 0;
+        }
     }
 
     // Initialize Debug Delay feature

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -443,8 +443,6 @@ public:
 
     tt::ARCH get_arch() const { return arch_; }
 
-    // Debug ring buffer: MPSC on Quasar/Blackhole (lock-free, many-writer), SPSC on Wormhole.
-    // MPSC capacity differs per arch -- see debug_ring_buffer_common.h.
     bool has_mpsc_ring_buffer() const { return arch_ == tt::ARCH::QUASAR || arch_ == tt::ARCH::BLACKHOLE; }
     uint32_t get_ring_buffer_capacity() const {
         switch (arch_) {
@@ -453,7 +451,6 @@ public:
             default: return DEBUG_RING_BUFFER_SPSC_ELEMENTS;
         }
     }
-    uint32_t get_ring_buffer_mask() const { return get_ring_buffer_capacity() - 1; }
 
     // Returns the NoC topology type (MESH or TORUS)
     NoCTopologyType get_noc_topology() const { return noc_topology_; }

--- a/tt_metal/llrt/hal.hpp
+++ b/tt_metal/llrt/hal.hpp
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "tt_memory.h"
+#include "hostdev/debug_ring_buffer_common.h"
 #include "hal/generated/dev_msgs.hpp"                // IWYU pragma: export
 #include "hal/generated/fabric_telemetry.hpp"        // IWYU pragma: export
 #include "hal/generated/realtime_profiler_msgs.hpp"  // IWYU pragma: export
@@ -441,6 +442,18 @@ public:
         bool enable_blackhole_dram_programmable_cores = false);
 
     tt::ARCH get_arch() const { return arch_; }
+
+    // Debug ring buffer: MPSC on Quasar/Blackhole (lock-free, many-writer), SPSC on Wormhole.
+    // MPSC capacity differs per arch -- see debug_ring_buffer_common.h.
+    bool has_mpsc_ring_buffer() const { return arch_ == tt::ARCH::QUASAR || arch_ == tt::ARCH::BLACKHOLE; }
+    uint32_t get_ring_buffer_capacity() const {
+        switch (arch_) {
+            case tt::ARCH::QUASAR: return DEBUG_RING_BUFFER_MPSC_ELEMENTS_QUASAR;
+            case tt::ARCH::BLACKHOLE: return DEBUG_RING_BUFFER_MPSC_ELEMENTS_BLACKHOLE;
+            default: return DEBUG_RING_BUFFER_SPSC_ELEMENTS;
+        }
+    }
+    uint32_t get_ring_buffer_mask() const { return get_ring_buffer_capacity() - 1; }
 
     // Returns the NoC topology type (MESH or TORUS)
     NoCTopologyType get_noc_topology() const { return noc_topology_; }


### PR DESCRIPTION
### PR Category
Feature

### Summary
Addresses https://github.com/tenstorrent/tt-metal/issues/38105, https://github.com/tenstorrent/tt-metal/issues/51369, https://github.com/tenstorrent/tt-metal/issues/16874

The watcher debug ring buffer was SPSC: shared across RISCs with no synchronization. On Quasar (6 DMs + 16 TRISCs), and Blackhole (2 DMs + 3 TRISCs), concurrent `WATCHER_RING_BUFFER_PUSH` calls race on the head index, so entries are lost or overwritten and there's no way to tell which processor wrote what.

This adds an MPSC ring buffer for both BH and Quasar, keeping Wormhole on SPSC (doesn't support RISC-V atomics):
- Slot claim is atomic per push - RISC-V atomics on Blackhole; on Quasar a NEO cluster semaphore, because DM and TRISC caches are not coherent with each other, so a RISC-V atomic on an L1 word would not serialize across them.
- Each entry is tagged with the pushing processor, printed as [DM5] / [Neo0TRISC0] / [BRISC] in the watcher log.
- Per-arch capacity - Quasar 128, Blackhole 32 (unchanged)
- `test_ringbuf.cpp` migrates to the Metal 2.0 host API, with a new multi-writer test that launches all 22 Quasar writers (6 DM + 16 TRISC) in a single program to stress test MPSC ringbuf.
  - `watcher_ringbuf.cpp` is now ethernet/DRAM only; TENSIX uses the new `watcher_ringbuf_2_0.cpp`

### Notes for reviewers
- `ring_buffer.h` — the Quasar/Blackhole split is the core of the change. Quasar's head lives in NEO cluster semaphore 31, which is now reserved and must not be used by kernels (documented in `debug_ring_buffer_common.h`). An issue is created to track and enforce this [here](https://github.com/tenstorrent/tt-metal/issues/53447)
- Init placement (`dm.cc`, `dispatch_dm.cc`) - the semaphore must be seeded before any pusher. It sits immediately before the `fw_shared_globals_ready` store, the one barrier where every other hart is still parked. It could not be done from host at init -- was resulting in a hang.

TODO: needs to be verified on DRISC/ERISCs on Quasar once runtime support for those will be developed.

Runtime unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/32005618128

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/quasar_watcher_rb)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/quasar_watcher_rb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadkarni/quasar_watcher_rb)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadkarni/quasar_watcher_rb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/quasar_watcher_rb)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/quasar_watcher_rb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/quasar_watcher_rb)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/quasar_watcher_rb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/quasar_watcher_rb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/quasar_watcher_rb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/quasar_watcher_rb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/quasar_watcher_rb)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/quasar_watcher_rb)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/quasar_watcher_rb)