### PR TITLE
[Cleanup] Replace LLK workaround with (now working) mul_reuse_dest_tiles

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_large_tensor.cpp
@@ -48,27 +48,16 @@ void kernel_main() {
     constexpr auto dfb_out_id = get_named_compile_time_arg_val("cb_out");  // output
     constexpr auto dfb_gamma_id = get_named_compile_time_arg_val("cb_gamma");
     constexpr auto dfb_beta_id = get_named_compile_time_arg_val("cb_beta");
-    constexpr uint32_t dfb_xmm_id = get_named_compile_time_arg_val("cb_xmm");   // x minus mean
-    constexpr auto dfb_ex_id = get_named_compile_time_arg_val("cb_ex");         // E[x]
-    constexpr auto dfb_ex2_id = get_named_compile_time_arg_val("cb_ex2");       // E[(x-E[x])^2]
-    constexpr auto dfb_xmm2_id = get_named_compile_time_arg_val("cb_xmm2");     // xmm^2
-    constexpr auto dfb_ex2pe_id = get_named_compile_time_arg_val("cb_ex2pe");   // E[(x-E[x])^2]+eps
-    uint32_t dfb_fusion = get_named_compile_time_arg_val("cb_fusion");          // stream gamma/beta
+    constexpr auto dfb_ex_id = get_named_compile_time_arg_val("cb_ex");        // E[x]
+    constexpr auto dfb_ex2_id = get_named_compile_time_arg_val("cb_ex2");      // E[(x-E[x])^2]
+    constexpr auto dfb_xmm2_id = get_named_compile_time_arg_val("cb_xmm2");    // xmm^2
+    constexpr auto dfb_ex2pe_id = get_named_compile_time_arg_val("cb_ex2pe");  // E[(x-E[x])^2]+eps
+    uint32_t dfb_fusion = get_named_compile_time_arg_val("cb_fusion");         // stream gamma/beta
     constexpr auto scaler0 = 0;
     constexpr auto dfb_accumulate_id = get_named_compile_time_arg_val("cb_accumulate");  // For accumulating (x-E[x])^2
 
     constexpr auto dfb_in_rm_id =
         get_named_compile_time_arg_val("cb_in_rm");  // input row-major (if row-major input, otherwise unused)
-
-#ifdef FUSE_PRE_ADD
-#ifdef RMSNORM
-    constexpr uint32_t dfb_x_id = dfb_xmm_id;
-#else
-    constexpr uint32_t dfb_x_id = get_named_compile_time_arg_val("cb_x");
-#endif
-#else
-    constexpr uint32_t dfb_x_id = dfb_in_id;
-#endif
 
     DataflowBuffer dfb_eps(dfb_eps_id);
     DataflowBuffer dfb_in(dfb_in_id);
@@ -76,7 +65,6 @@ void kernel_main() {
     DataflowBuffer dfb_out(dfb_out_id);
     DataflowBuffer dfb_gamma(dfb_gamma_id);
     DataflowBuffer dfb_beta(dfb_beta_id);
-    DataflowBuffer dfb_xmm(dfb_xmm_id);
     DataflowBuffer dfb_ex(dfb_ex_id);
     DataflowBuffer dfb_ex2(dfb_ex2_id);
     DataflowBuffer dfb_xmm2(dfb_xmm2_id);
@@ -84,15 +72,22 @@ void kernel_main() {
     DataflowBuffer dfb_accumulate(dfb_accumulate_id);
     DataflowBuffer dfb_scaler(dfb_scaler_id);
     DataflowBuffer dfb_in_rm(dfb_in_rm_id);
-    DataflowBuffer dfb_x(dfb_x_id);
 
-#ifdef FUSE_PRE_ADD
-    compute_kernel_hw_startup(dfb_in_id, dfb_inb_id, dfb_x_id);
-#else
     // Always call compute_kernel_hw_startup regardless of TILIZE_IN.
     // This initializes llk_pack_dest_init, which sets up the MATH-PACK DST semaphore
-    // in the "available for MATH" state.  Without it, the first tilize_block call's
+    // in the "available for MATH" state. Without it, the first tilize_block call's
     // internal llk_math_wait_for_dest_available() spins forever (deadlock).
+    //
+    // The output CB argument programs the pack hardware from that CB's descriptor, so it must name
+    // a CB the host allocates on this path: the first tile packed below goes to cb_xmm2 for RMS
+    // norm and to cb_ex otherwise.
+#ifdef FUSE_PRE_ADD
+#ifdef RMSNORM
+    compute_kernel_hw_startup(dfb_in_id, dfb_inb_id, dfb_xmm2_id);
+#else
+    compute_kernel_hw_startup(dfb_in_id, dfb_inb_id, dfb_ex_id);
+#endif
+#else
 #ifdef RMSNORM
     compute_kernel_hw_startup(dfb_in_id, dfb_scaler_id, dfb_xmm2_id);
 #else
@@ -321,28 +316,16 @@ void kernel_main() {
             }
             dfb_inb.pop_front(block.full_block_size());
 #endif
-            tile_regs_commit();
-            tile_regs_wait();
-            // Note: We shouldn't have to pack to
-            // intermediate CB. We should be able to
-            // do a binary dest with reuse (as we used
-            // to). However, tt-llk #868 is preventing
-            // that from working at the moment.
-            dfb_xmm.reserve_back(block.full_block_size());
-            pack_reconfig_data_format(dfb_xmm_id);
+            // Multiply by 1/(√(Var(X) + ε)) in place in DST. SrcA currently holds cb_inb (fused) or
+            // cb_in (non-fused), the last operand read above; switch it to cb_ex2pe's format.
+#ifdef FUSE_PRE_ADD
+            reconfig_data_format_srca(dfb_inb_id, dfb_ex2pe_id);
+#else
+            reconfig_data_format_srca(dfb_in_id, dfb_ex2pe_id);
+#endif
+            mul_reuse_dest_init<EltwiseBinaryReuseDestType::DEST_TO_SRCB>(dfb_ex2pe_id);
             for (auto i : block.local()) {
-                pack_tile(i, dfb_xmm_id);
-            }
-            dfb_xmm.push_back(block.full_block_size());
-            tile_regs_release();
-
-            dfb_xmm.wait_front(block.full_block_size());
-            reconfig_data_format(dfb_xmm_id, dfb_ex2pe_id);
-            tile_regs_acquire();
-
-            mul_init(dfb_xmm_id, dfb_ex2pe_id);
-            for (auto i : block.local()) {
-                mul_tiles(dfb_xmm_id, dfb_ex2pe_id, i, 0, i);
+                mul_reuse_dest_tiles<EltwiseBinaryReuseDestType::DEST_TO_SRCB>(dfb_ex2pe_id, 0 /*in_tile_index*/, i);
 #ifdef SFPU_OP_INIT_ACTIVATION
                 // Activation must be applied last. If do_gamma != 0 or do_beta != 0 then
                 // activation will be applied after the gamma/beta multiplication/addition.
@@ -366,7 +349,6 @@ void kernel_main() {
             }
             tile_regs_release();
             DataflowBuffer(dfb_fusion).push_back(block.full_block_size());
-            dfb_xmm.pop_front(block.full_block_size());
 
             if constexpr (do_gamma == 1) {
                 tile_regs_acquire();

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/layernorm_op_multi_core.cpp
@@ -739,8 +739,13 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
         program_descriptor.cbs.push_back(std::move(cb19_desc));
     }
 
-    // CB 24: Intermediate 0
-    if (!rms_norm || fuse_pre_add || large_tensor_needed) {
+    // CB 24: Intermediate 0. Holds x - E[x] in layernorm.cpp / layernorm_welford.cpp, which need it
+    // for every case except RMS norm without fused pre-add (there x - E[x] aliases cb_in), and
+    // serves as the gamma/beta fusion buffer in layernorm_large_tensor_welford.cpp.
+    // layernorm_large_tensor.cpp keeps x - E[x] in DST instead, so on the large-tensor path the CB
+    // is only needed by the welford kernel.
+    const bool cb_xmm_needed = (!rms_norm || fuse_pre_add) && (!large_tensor_needed || use_welford_and_not_rms_norm);
+    if (cb_xmm_needed) {
         program_descriptor.cbs.push_back(
             make_cb_descriptor(im0_t * single_tile_size, tt::CBIndex::c_24, cb_data_format, single_tile_size));
     }
@@ -803,7 +808,10 @@ tt::tt_metal::ProgramDescriptor LayerNormMultiCoreProgramFactory::create_descrip
         // When welford_fp32_alias is active, register c_29 as a second buffer index on the
         // same SRAM with UnpackToDestFp32 mode so transpose_tile preserves full FP32 into
         // DEST.
-        if (!rms_norm) {
+        // layernorm_large_tensor.cpp keeps the post-add result in DST instead, so on the
+        // large-tensor path the CB is only needed by the welford kernel.
+        const bool cb_x_needed = !rms_norm && (!large_tensor_needed || use_welford_and_not_rms_norm);
+        if (cb_x_needed) {
             auto cb23_desc =
                 make_cb_descriptor(im6_t * single_tile_size, tt::CBIndex::c_23, cb_data_format, single_tile_size);
             if (welford_fp32_alias) {


### PR DESCRIPTION
### Summary

LLK issue https://github.com/tenstorrent/tt-llk/issues/868 has been fixed, so this PR removes the workaround that is no longer needed.
With the workaround removed, the code once again uses `binary_dest_reuse_tiles`, which is more efficient than using intermediate CBs. Unused intermediate CB (`c_24`) has been removed, which made it apparent that `c_23` was also unused in this kernel, so it was also removed, freeing up SRAM space.

Closes #45600

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fplavec/45600_remaining_workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fplavec/45600_remaining_workaround)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fplavec/45600_remaining_workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fplavec/45600_remaining_workaround)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fplavec/45600_remaining_workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fplavec/45600_remaining_workaround)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fplavec/45600_remaining_workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fplavec/45600_remaining_workaround)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fplavec/45600_remaining_workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fplavec/45600_remaining_workaround)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fplavec/45600_remaining_workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fplavec/45600_remaining_workaround)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fplavec/45600_remaining_workaround)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fplavec/45600_remaining_workaround)