### PR TITLE
[Do not merge] cross-arch re-verification scaffold for #53399 (untilize codegen L1 budgeting)

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
@@ -3009,3 +3009,75 @@ def test_pc_untilize_codegen(device, tensor_shape):
             base_count = device.cache_entries_counter.total
         else:
             assert device.cache_entries_counter.total == base_count, "program cache entries differ on same configs"
+
+
+def test_untilize_codegen_with_resident_l1_buffers(device):
+    """Regression: the codegen CB plan must be budgeted against LIVE L1 occupancy.
+
+    Statically allocated CBs grow upward from the allocator's base L1 address while L1 tensors are
+    allocated downward from the top of L1, so the space actually available to a program's CBs is
+    lowest_occupied_compute_l1_address() - base, not the whole of L1. The codegen path originally
+    planned against the whole of L1, which is only correct on an otherwise-idle device; with a
+    model's weights/trace buffers resident in L1 it planned a CB region that overlapped them and
+    ProgramImpl::validate_circular_buffer_region() aborted the run with
+
+        Statically allocated circular buffers in program N clash with L1 buffers on core range ...
+
+    rather than degrading to a shallower CB plan (or falling back to native). Seen end-to-end on
+    Gemma-3-4B in trace mode; reproduced here at the op level by pinning a persistent interleaved
+    L1 tensor before untilizing.
+    """
+    torch.manual_seed(42)
+
+    TILE_BYTES = 2048  # bfloat16 tile
+    info = ttnn._ttnn.reports.get_device_info(device)
+
+    # Wt wide enough that the whole-of-L1 budget selects a double-buffered CB plan, but still
+    # inside the gate's wide-chunk threshold (2 * Wt * 2048 <= 800_000 => Wt <= 195). Two tile
+    # rows keep this on the row-parallel writer, whose CB plan is sized by Wt.
+    wt = 192
+    height_tiles = 2
+    single_buffer_bytes = 2 * wt * TILE_BYTES  # cb_in + cb_out, one slot each
+    double_in_bytes = 3 * wt * TILE_BYTES  # 2x cb_in + 1x cb_out
+
+    # cb_limit is exactly the whole-of-L1 budget the buggy plan used: worker L1 minus the base.
+    if info.cb_limit < double_in_bytes:
+        pytest.skip(f"needs at least {double_in_bytes} B of CB space, device offers {info.cb_limit} B")
+
+    # Leave a headroom window that fits the single-buffer plan but NOT the double-buffered one, so
+    # the only non-clashing plan is unambiguous and an unbudgeted build provably overruns it.
+    headroom_target = single_buffer_bytes + 64 * 1024
+    tiles_per_bank = (info.cb_limit - headroom_target) // TILE_BYTES
+    if tiles_per_bank <= 0:
+        pytest.skip("device L1 is too small to leave a meaningful headroom window")
+
+    # Built before the L1 reservation so that any device-side tilize in from_torch runs with the
+    # usual amount of L1 available; only the untilize under test should see the pressure.
+    # untilize only relayouts values, so the input is its own golden.
+    input_torch_tensor = torch.randn([1, 1, 32 * height_tiles, 32 * wt], dtype=torch.bfloat16)
+    input_ttnn_tensor = ttnn.from_torch(input_torch_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    # Interleaved L1 spreads pages round-robin over every bank, so tiles_per_bank tiles per bank
+    # pushes the lowest occupied L1 address down on all of them. Allocated directly on device: the
+    # contents are irrelevant, only the occupancy matters.
+    resident = ttnn.allocate_tensor_on_device(
+        ttnn.Shape([1, 1, 32 * tiles_per_bank, 32 * info.l1_num_banks]),
+        ttnn.bfloat16,
+        ttnn.TILE_LAYOUT,
+        device,
+        ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1),
+    )
+    try:
+        # Guard against a vacuous pass: if the reservation did not land where intended there is no
+        # L1 pressure left to regress against.
+        actual_headroom = resident.buffer_address() - info.address_at_first_l1_cb_buffer
+        assert single_buffer_bytes <= actual_headroom < double_in_bytes, (
+            f"resident L1 buffer left {actual_headroom} B above the CB base; the test needs it in "
+            f"[{single_buffer_bytes}, {double_in_bytes}) so that only the single-buffer CB plan fits"
+        )
+
+        output = ttnn.untilize(input_ttnn_tensor)
+
+        assert_equal(input_torch_tensor, ttnn.to_torch(output))
+    finally:
+        ttnn.deallocate(resident)

--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize.py
@@ -3011,7 +3011,8 @@ def test_pc_untilize_codegen(device, tensor_shape):
             assert device.cache_entries_counter.total == base_count, "program cache entries differ on same configs"
 
 
-def test_untilize_codegen_with_resident_l1_buffers(device):
+@pytest.mark.parametrize("headroom_regime", ["shallower_cb_plan", "no_cb_plan_fits"])
+def test_untilize_codegen_with_resident_l1_buffers(device, headroom_regime):
     """Regression: the codegen CB plan must be budgeted against LIVE L1 occupancy.
 
     Statically allocated CBs grow upward from the allocator's base L1 address while L1 tensors are
@@ -3026,6 +3027,16 @@ def test_untilize_codegen_with_resident_l1_buffers(device):
     rather than degrading to a shallower CB plan (or falling back to native). Seen end-to-end on
     Gemma-3-4B in trace mode; reproduced here at the op level by pinning a persistent interleaved
     L1 tensor before untilizing.
+
+    Two regimes, both of which must simply produce the right answer:
+      - shallower_cb_plan: enough headroom for the single-buffered codegen plan but not the
+        double-buffered one, so the program factory must degrade the tier it picks.
+      - no_cb_plan_fits: not even the single-buffered codegen plan fits, so the program factory
+        must build the native-equivalent program instead of failing.
+
+    This asserts only on the result, never on which implementation served it: the choice is made
+    inside the program factory (once per program-cache miss, against one L1 snapshot) precisely so
+    that no observer outside it -- including this test -- has to reason about live L1 state.
     """
     torch.manual_seed(42)
 
@@ -3044,9 +3055,20 @@ def test_untilize_codegen_with_resident_l1_buffers(device):
     if info.cb_limit < double_in_bytes:
         pytest.skip(f"needs at least {double_in_bytes} B of CB space, device offers {info.cb_limit} B")
 
-    # Leave a headroom window that fits the single-buffer plan but NOT the double-buffered one, so
-    # the only non-clashing plan is unambiguous and an unbudgeted build provably overruns it.
-    headroom_target = single_buffer_bytes + 64 * 1024
+    if headroom_regime == "shallower_cb_plan":
+        # A headroom window that fits the single-buffer plan but NOT the double-buffered one, so
+        # the only non-clashing codegen plan is unambiguous and an unbudgeted build provably
+        # overruns it.
+        headroom_target = single_buffer_bytes + 64 * 1024
+        expected_headroom = (single_buffer_bytes, double_in_bytes)
+    else:
+        # Below every codegen tier, so the factory has to hand off to native. Still generous
+        # enough for native's own blocked CBs, which it sizes against the same live L1 space.
+        headroom_target = 256 * 1024
+        if headroom_target >= single_buffer_bytes:
+            pytest.skip("device L1 headroom cannot be driven below the smallest codegen CB plan")
+        expected_headroom = (0, single_buffer_bytes)
+
     tiles_per_bank = (info.cb_limit - headroom_target) // TILE_BYTES
     if tiles_per_bank <= 0:
         pytest.skip("device L1 is too small to leave a meaningful headroom window")
@@ -3071,9 +3093,10 @@ def test_untilize_codegen_with_resident_l1_buffers(device):
         # Guard against a vacuous pass: if the reservation did not land where intended there is no
         # L1 pressure left to regress against.
         actual_headroom = resident.buffer_address() - info.address_at_first_l1_cb_buffer
-        assert single_buffer_bytes <= actual_headroom < double_in_bytes, (
-            f"resident L1 buffer left {actual_headroom} B above the CB base; the test needs it in "
-            f"[{single_buffer_bytes}, {double_in_bytes}) so that only the single-buffer CB plan fits"
+        low, high = expected_headroom
+        assert low <= actual_headroom < high, (
+            f"resident L1 buffer left {actual_headroom} B above the CB base; the {headroom_regime} "
+            f"regime needs it in [{low}, {high})"
         )
 
         output = ttnn.untilize(input_ttnn_tensor)

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_program_factory.cpp
@@ -5,6 +5,10 @@
 #include "untilize_codegen_program_factory.hpp"
 
 #include <algorithm>
+#include <optional>
+#include <type_traits>
+#include <utility>
+#include <variant>
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
@@ -13,7 +17,11 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt_stl/assert.hpp>
+#include <tt_stl/small_vector.hpp>
 
+#include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/operations/data_movement/untilize/device/untilize_device_operation.hpp"
+#include "ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.hpp"
 #include "untilize_codegen_device_operation.hpp"
 #include "untilize_codegen_supported.hpp"
 
@@ -29,7 +37,6 @@ constexpr const char* kKernelDir = "ttnn/cpp/ttnn/operations/data_movement/until
 constexpr uint32_t kCbIn = tt::CBIndex::c_0;
 constexpr uint32_t kCbOut = tt::CBIndex::c_16;
 constexpr uint32_t kSeqIdentity = 0;  // mirrors common/templates/sequencers.h SEQ_IDENTITY
-using ttnn::operations::data_movement::untilize_codegen::usable_l1_bytes;
 
 std::string kernel_path(const char* name) { return std::string(kKernelDir) + "/" + name; }
 
@@ -60,20 +67,32 @@ struct CbPlan {
 };
 
 // Mirrors codegen_common.factory.cb_policy.plan_cb_depths exactly: 3-tier asymmetric CB
-// depth selection (double-buffer both -> double-buffer input only -> single-buffer both),
-// budgeted against the device's actual usable-L1 (queried, not a hardcoded constant -- see
-// usable_l1_bytes()). The Python source has no 4th "chunked" tier -- it raises when even the
-// single-buffer plan overflows, because the caller (ops/untilize/untilize.py's wide-tensor
-// guard, transcribed into supported_by_codegen's wide-chunk-threshold check) is expected to
-// have already routed such shapes away from this builder entirely. Fail the same way rather
-// than inventing an untraceable fallback depth.
-CbPlan plan_cb_depths(const IDevice* device, uint32_t pages_per_unit, uint32_t page_size, uint32_t block_units) {
+// depth selection (double-buffer both -> double-buffer input only -> single-buffer both).
+//
+// `usable_l1` is the budget measured ONCE per program build by create_descriptor (see
+// kUsableL1Note there): the L1 gap actually free below whatever buffers are already resident,
+// not the whole-core L1 size. Statically allocated CBs grow up from the allocator base while
+// L1 buffers grow down from the top, so planning against total L1 is what let a program whose
+// CBs overlap a resident trace/weight buffer get built at all -- it then died later in
+// ProgramImpl::validate_circular_buffer_region() with "Statically allocated circular buffers
+// ... clash with L1 buffers".
+//
+// Tightening the budget cannot change any plan that previously worked: the three tiers are
+// strictly ordered by size, the live gap is always <= the whole-L1 budget, so the only plans
+// that differ are exactly those the old budget accepted but the allocator would have rejected.
+//
+// The Python source has no 4th "chunked" tier -- it raises when even the single-buffer plan
+// overflows. Returning nullopt instead lets create_descriptor build a native-equivalent
+// program for that case rather than failing the op; the codegen builders themselves still have
+// no depth below single-buffer to fall back to (compute_untilize.cpp reserves a full unit in
+// cb_out per pass), which is exactly why the fallback has to be a different program.
+std::optional<CbPlan> plan_cb_depths(
+    uint64_t usable_l1, uint32_t pages_per_unit, uint32_t page_size, uint32_t block_units) {
     uint64_t p = pages_per_unit;
     uint64_t ts = page_size;
     uint64_t double_both = (2 * p + 2 * p) * ts;
     uint64_t double_in = (2 * p + p) * ts;
     uint64_t single_both = (p + p) * ts;
-    uint64_t usable_l1 = usable_l1_bytes(device);
     if (double_both <= usable_l1) {
         return CbPlan{static_cast<uint32_t>(2 * p), static_cast<uint32_t>(2 * p), pages_per_unit};
     }
@@ -83,15 +102,7 @@ CbPlan plan_cb_depths(const IDevice* device, uint32_t pages_per_unit, uint32_t p
     if (single_both <= usable_l1) {
         return CbPlan{pages_per_unit, pages_per_unit, block_units};
     }
-    TT_THROW(
-        "untilize codegen: single-buffer CB plan exceeds L1 and cannot be reduced without chunking "
-        "(pages_per_unit={}, page_size={}, minimum_bytes={}, budget={}); supported_by_codegen() should "
-        "have routed this shape to native",
-        pages_per_unit,
-        page_size,
-        single_both,
-        usable_l1);
-    return CbPlan{};
+    return std::nullopt;
 }
 
 // Mirrors spec.py's _choose_2d_ncol: largest divisor of wt (>=2) so that every tile-row x
@@ -174,18 +185,24 @@ struct CommonArgs {
     uint32_t out_elem_size;
     bool fp32;
     uint32_t max_bct;
+    // Live L1 headroom, sampled once in create_descriptor -- see kUsableL1Note.
+    uint64_t usable_l1;
 };
 
 // Per-tile-row split (build_untilize_tile's default path / _build_untilize_tile_cliff).
 // Splits total_tile_rows across up to the device's core grid; an uneven split produces a
 // second ("cliff") compute-kernel core group with its own per-core tile-row count.
-ProgramDescriptor build_main_split(const CommonArgs& a, uint32_t wt, uint32_t total_tile_rows) {
+std::optional<ProgramDescriptor> build_main_split(const CommonArgs& a, uint32_t wt, uint32_t total_tile_rows) {
     auto grid = a.device->compute_with_storage_grid_size();
     auto [_num_cores, core_range, cg1, cg2, tpc1, tpc2] =
         tt::tt_metal::split_work_to_cores(grid, total_tile_rows, /*row_wise=*/true);
 
     uint32_t block_ct_dim = compute_block_ct_dim(wt, a.fp32);
-    CbPlan plan = plan_cb_depths(a.device, wt, a.tile_size_for_planning, block_ct_dim);
+    auto maybe_plan = plan_cb_depths(a.usable_l1, wt, a.tile_size_for_planning, block_ct_dim);
+    if (!maybe_plan.has_value()) {
+        return std::nullopt;
+    }
+    const CbPlan& plan = *maybe_plan;
 
     // Row stride used both as the writer's TensorAccessor page pitch and the CB byte stride
     // between physical tile-rows: the FULL padded row (Wt tiles wide), never the logical
@@ -241,14 +258,18 @@ ProgramDescriptor build_main_split(const CommonArgs& a, uint32_t wt, uint32_t to
 
 // Column-parallel split (_build_untilize_column_parallel): single tile-row, Wt>1 -- splits
 // tile-COLUMNS across cores instead of tile-rows.
-ProgramDescriptor build_column_parallel(const CommonArgs& a, uint32_t wt) {
+std::optional<ProgramDescriptor> build_column_parallel(const CommonArgs& a, uint32_t wt) {
     auto grid = a.device->compute_with_storage_grid_size();
     auto [_num_cores, core_range, cg1, cg2, tpc1, tpc2] =
         tt::tt_metal::split_work_to_cores(grid, wt, /*row_wise=*/true);
 
     uint32_t max_tpc = std::max(tpc1, cg2.empty() ? 0u : tpc2);
     uint32_t block_ct_dim = compute_block_ct_dim(max_tpc, a.fp32);
-    CbPlan plan = plan_cb_depths(a.device, max_tpc, a.tile_size_for_planning, block_ct_dim);
+    auto maybe_plan = plan_cb_depths(a.usable_l1, max_tpc, a.tile_size_for_planning, block_ct_dim);
+    if (!maybe_plan.has_value()) {
+        return std::nullopt;
+    }
+    const CbPlan& plan = *maybe_plan;
 
     uint32_t full_stick_size = wt * TILE_WIDTH * a.out_elem_size;
 
@@ -304,7 +325,8 @@ ProgramDescriptor build_column_parallel(const CommonArgs& a, uint32_t wt) {
 // 2D (tile-row x column-block) split (_build_untilize_2d_column): raises core utilization
 // when total_tile_rows alone would leave cores idle. Every one of total_tile_rows*ncol cores
 // owns exactly one (tile-row, column-block) unit of tpc = Wt/ncol tiles.
-ProgramDescriptor build_2d_column(const CommonArgs& a, uint32_t wt, uint32_t total_tile_rows, uint32_t ncol) {
+std::optional<ProgramDescriptor> build_2d_column(
+    const CommonArgs& a, uint32_t wt, uint32_t total_tile_rows, uint32_t ncol) {
     uint32_t tpc = wt / ncol;
     uint32_t num_units = total_tile_rows * ncol;
 
@@ -313,7 +335,11 @@ ProgramDescriptor build_2d_column(const CommonArgs& a, uint32_t wt, uint32_t tot
         tt::tt_metal::split_work_to_cores(grid, num_units, /*row_wise=*/true);
 
     uint32_t block_ct_dim = compute_block_ct_dim(tpc, a.fp32);
-    CbPlan plan = plan_cb_depths(a.device, tpc, a.tile_size_for_planning, block_ct_dim);
+    auto maybe_plan = plan_cb_depths(a.usable_l1, tpc, a.tile_size_for_planning, block_ct_dim);
+    if (!maybe_plan.has_value()) {
+        return std::nullopt;
+    }
+    const CbPlan& plan = *maybe_plan;
 
     uint32_t full_stick_size = wt * TILE_WIDTH * a.out_elem_size;
     uint32_t col_chunk_bytes = tpc * TILE_WIDTH * a.out_elem_size;
@@ -377,7 +403,7 @@ uint32_t count_valid_sticks(uint32_t start, uint32_t count, uint32_t batch_h, ui
 // writer additionally skips physical pad sticks and writes only the unpadded row width, producing
 // the compact output UntilizeCodegenDeviceOperation::compute_output_specs's non-aligned branch
 // declares. Cliff-capable (two compute kernels), same as build_main_split.
-ProgramDescriptor build_with_unpadding(
+std::optional<ProgramDescriptor> build_with_unpadding(
     const CommonArgs& a,
     uint32_t wt,
     uint32_t total_tile_rows,
@@ -389,7 +415,11 @@ ProgramDescriptor build_with_unpadding(
         tt::tt_metal::split_work_to_cores(grid, total_tile_rows, /*row_wise=*/true);
 
     uint32_t block_ct_dim = compute_block_ct_dim(wt, a.fp32);
-    CbPlan plan = plan_cb_depths(a.device, wt, a.tile_size_for_planning, block_ct_dim);
+    auto maybe_plan = plan_cb_depths(a.usable_l1, wt, a.tile_size_for_planning, block_ct_dim);
+    if (!maybe_plan.has_value()) {
+        return std::nullopt;
+    }
+    const CbPlan& plan = *maybe_plan;
 
     uint32_t unpadded_row_bytes = w_unpadded * a.out_elem_size;
     uint32_t padded_row_bytes = wt * TILE_WIDTH * a.out_elem_size;
@@ -446,6 +476,82 @@ ProgramDescriptor build_with_unpadding(
     return desc;
 }
 
+// Last-resort builder for the rare case where NO codegen CB plan fits the L1 that is actually
+// free right now (see kUsableL1Note): build the program the native untilize op would have built
+// for this very same (input -> output) pair, and let prim::untilize_codegen run that instead.
+//
+// This is a program-level fallback, deliberately NOT a routing-level one. supported_by_codegen()
+// is evaluated independently at three sites (ttnn::untilize's routing gate,
+// untilize_force_codegen's TT_FATAL, and validate_on_program_cache_miss) and is only self-
+// consistent because it is a pure function of static properties; teaching it about live L1
+// occupancy is what made routing say "yes" and validate then TT_FATAL on the same tensor. Here
+// the decision is made once, after the op has committed to codegen and after its output tensor
+// is allocated, so there is no second observer to disagree with.
+//
+// Delegating (rather than duplicating native's kernels) keeps the two in lockstep by
+// construction. It is sound because the output tensor the codegen op already allocated is
+// byte-identical in spec to the one native would allocate for the same case:
+//   - tile-aligned  -> UntilizeDeviceOperation::compute_output_specs (same logical shape, same
+//     ROW_MAJOR page config, same dtype demotion bf8_b->bf16, same padded shape carried through)
+//   - non-aligned   -> UntilizeWithUnpaddingDeviceOperation::compute_output_specs with
+//     output_tensor_end = logical_shape - 1, i.e. the compact interleaved spec, which is exactly
+//     what UntilizeCodegenDeviceOperation::compute_output_specs's non-aligned branch declares.
+// The native factories only read `output` (buffer address, spec) to emit their descriptor, so
+// handing them the already-allocated tensor is exactly what their own op would have done.
+ProgramDescriptor build_native_equivalent(
+    const UntilizeCodegenOperationAttributes& operation_attributes, const Tensor& input, const Tensor& output) {
+    namespace dm = ttnn::operations::data_movement;
+
+    // Several native factories take `UntilizeTensorReturnValue&` (non-const). A Tensor is a
+    // shallow, refcounted handle, so this copy aliases the same buffer the op allocated.
+    Tensor out = output;
+
+    const bool fp32_dest_acc_en = input.dtype() == DataType::INT32 || input.dtype() == DataType::UINT32 ||
+                                  input.dtype() == DataType::FLOAT32;
+    auto in_fmt = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    uint32_t single_tile_size = tt::tile_size(in_fmt);
+    uint32_t num_tiles_per_row = input.padded_shape()[-1] / TILE_WIDTH;
+    // Same derivation the native free functions do before calling their prim; note this is itself
+    // a live-L1 query (get_max_l1_space), consistent with the snapshot taken in create_descriptor.
+    const bool enough_space_height =
+        dm::is_enough_space(input, single_tile_size, single_tile_size, num_tiles_per_row);
+
+    const auto& logical_shape = input.logical_shape();
+    const bool tile_aligned = logical_shape[-2] % TILE_HEIGHT == 0 && logical_shape[-1] % TILE_WIDTH == 0;
+
+    if (!tile_aligned) {
+        ttnn::Shape output_tensor_end(ttsl::SmallVector<uint32_t>(logical_shape.rank(), 0));
+        int logical_rank = static_cast<int>(logical_shape.rank());
+        for (int index = -1; index >= -logical_rank; --index) {
+            output_tensor_end[index] = logical_shape[index] - 1;
+        }
+        UntilizeWithUnpaddingParams params{
+            .output_tensor_end = output_tensor_end,
+            .output_mem_config = operation_attributes.output_mem_config,
+            .use_multicore = true,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .enough_space_height = enough_space_height,
+            .sub_core_grids = std::nullopt};
+        auto pf = UntilizeWithUnpaddingDeviceOperation::select_program_factory(params, input);
+        return std::visit(
+            [&](auto&& factory) { return std::decay_t<decltype(factory)>::create_descriptor(params, input, out); }, pf);
+    }
+
+    UntilizeOperationAttributes attrs{
+        .output_mem_config = operation_attributes.output_mem_config,
+        .use_multicore = true,
+        .fp32_dest_acc_en = fp32_dest_acc_en,
+        .sub_core_grids = std::nullopt,
+        .enough_space_height = enough_space_height,
+        // supported_by_codegen() rejects sharded output, so the sharded pf_type branches are
+        // unreachable here; pass false to match what untilize_native would compute.
+        .pf_type = dm::get_pf_type(/*output_is_sharded=*/false, input)};
+    UntilizeTensorArgs args{.input = input};
+    auto pf = UntilizeDeviceOperation::select_program_factory(attrs, args);
+    return std::visit(
+        [&](auto&& factory) { return std::decay_t<decltype(factory)>::create_descriptor(attrs, args, out); }, pf);
+}
+
 }  // namespace
 
 ProgramDescriptor UntilizeCodegenProgramFactory::create_descriptor(
@@ -469,6 +575,30 @@ ProgramDescriptor UntilizeCodegenProgramFactory::create_descriptor(
     a.out_elem_size = output.element_size();
     a.in_buf = input.buffer();
     a.out_buf = output.buffer();
+    // kUsableL1Note: THE single live-L1 decision point for this op.
+    //
+    // Sampled exactly here, once, and threaded through CommonArgs so every builder plans against
+    // one consistent snapshot. get_max_l1_space() is the same helper the native untilize path
+    // uses: (lowest_occupied_compute_l1_address ?: l1_size_per_core) - allocator base, i.e. the
+    // gap between where statically allocated CBs start growing up and where the lowest resident
+    // L1 buffer sits. Taken after create_output_tensors() has already allocated the output, so it
+    // accounts for that too.
+    //
+    // Cost on the hot path: zero. create_descriptor runs only on a program-cache MISS. Every
+    // builder below (and every native factory the fallback can delegate to) emits
+    // emplace_runtime_args with a Buffer* first argument on every core, so buffer bindings are
+    // always populated and resolve; cache HITS therefore take apply_descriptor's
+    // apply_resolved_bindings path, which patches addresses in the cached Program without ever
+    // calling create_descriptor again. (The one exception is the opt-in
+    // ENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK build, OFF by default, which re-invokes
+    // create_descriptor on every hit purely to diff it -- see the note in create_descriptor's
+    // tail.)
+    //
+    // No previously-working program changes shape because of this. plan_cb_depths' three tiers
+    // are strictly ordered by size and the live gap is always <= the whole-L1 budget it used
+    // before, so the only plans that differ are exactly the ones the allocator would have
+    // rejected anyway in ProgramImpl::validate_circular_buffer_region().
+    a.usable_l1 = ttnn::operations::data_movement::get_max_l1_space(input);
 
     // Wt/Ht/NC are derived from the PADDED (physical, tile-aligned) shape, which the reader/
     // compute stages need regardless of dispatch branch below (even the with-unpadding path
@@ -485,7 +615,13 @@ ProgramDescriptor UntilizeCodegenProgramFactory::create_descriptor(
     uint32_t ht = h / TILE_HEIGHT;
     uint32_t total_tile_rows = nc * ht;
 
-    (void)operation_attributes;
+    // Each branch below picks the codegen builder this shape belongs to, exactly as before. The
+    // only new behaviour is that a builder may decline (nullopt) when its CB plan does not fit the
+    // L1 that is free right now, in which case we emit the native-equivalent program instead of
+    // failing the op. Under the opt-in ENABLE_DESCRIPTOR_PATCHING_PARITY_CHECK build this function
+    // is re-invoked on cache hits and diffed against the cached descriptor; if L1 occupancy has
+    // changed enough since the miss to flip a tier, that check can report a spurious mismatch.
+    // That build is a debug aid (OFF by default) and never runs in production dispatch.
 
     // Non-tile-aligned logical shapes (bf16 only -- see supported_by_codegen) route through the
     // with-unpadding builder instead of build_untilize_tile's variants. h == ht * TILE_HEIGHT
@@ -494,11 +630,17 @@ ProgramDescriptor UntilizeCodegenProgramFactory::create_descriptor(
     const auto& logical_shape = input.logical_shape();
     bool tile_aligned = logical_shape[-2] % TILE_HEIGHT == 0 && logical_shape[-1] % TILE_WIDTH == 0;
     if (!tile_aligned) {
-        return build_with_unpadding(a, wt, total_tile_rows, logical_shape[-2], logical_shape[-1], h);
+        if (auto desc = build_with_unpadding(a, wt, total_tile_rows, logical_shape[-2], logical_shape[-1], h)) {
+            return std::move(*desc);
+        }
+        return build_native_equivalent(operation_attributes, input, output);
     }
 
     if (total_tile_rows == 1 && wt > 1) {
-        return build_column_parallel(a, wt);
+        if (auto desc = build_column_parallel(a, wt)) {
+            return std::move(*desc);
+        }
+        return build_native_equivalent(operation_attributes, input, output);
     }
 
     auto grid = a.device->compute_with_storage_grid_size();
@@ -506,10 +648,16 @@ ProgramDescriptor UntilizeCodegenProgramFactory::create_descriptor(
     if (wt > 1) {
         uint32_t ncol = choose_2d_ncol(total_tile_rows, wt, valid_cores);
         if (ncol >= 2) {
-            return build_2d_column(a, wt, total_tile_rows, ncol);
+            if (auto desc = build_2d_column(a, wt, total_tile_rows, ncol)) {
+                return std::move(*desc);
+            }
+            return build_native_equivalent(operation_attributes, input, output);
         }
     }
-    return build_main_split(a, wt, total_tile_rows);
+    if (auto desc = build_main_split(a, wt, total_tile_rows)) {
+        return std::move(*desc);
+    }
+    return build_native_equivalent(operation_attributes, input, output);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_program_factory.hpp
@@ -14,6 +14,11 @@ struct UntilizeCodegenOperationAttributes;
 struct UntilizeCodegenTensorArgs;
 
 struct UntilizeCodegenProgramFactory {
+    // Builds the codegen untilize program for the (already validated, already output-allocated)
+    // case. This is also the op's ONLY live-L1 decision point: it samples the free L1 headroom
+    // once and, if no codegen CB plan fits below the resident L1 buffers, emits the native
+    // untilize program for the same tensors instead of failing. Runs only on a program-cache
+    // miss; cache hits patch the cached program's buffer addresses without re-entering here.
     static tt::tt_metal::ProgramDescriptor create_descriptor(
         const UntilizeCodegenOperationAttributes& operation_attributes,
         const UntilizeCodegenTensorArgs& tensor_args,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_supported.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_supported.cpp
@@ -14,7 +14,20 @@
 namespace ttnn::operations::data_movement::untilize_codegen {
 
 uint32_t usable_l1_bytes(const tt::tt_metal::IDevice* device) {
-    return device->l1_size_per_core() - device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
+    // Same accounting as ProgramImpl::validate_circular_buffer_region(): statically allocated CBs
+    // grow upward from the allocator's base L1 address, L1 buffers are allocated downward from the
+    // top of L1, and that validator TT_THROWs as soon as the CB region end passes
+    // lowest_occupied_compute_l1_address(). Budget against the same frontier so a plan this gate
+    // accepts is one the program validator will accept too. Mirrors get_max_l1_space() in
+    // data_movement/common/common.cpp.
+    //
+    // std::nullopt means nothing is resident in L1 yet, in which case the whole region above the
+    // base is available.
+    const uint32_t base = device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
+    const auto lowest_occupied = device->lowest_occupied_compute_l1_address();
+    const uint32_t ceiling =
+        lowest_occupied.has_value() ? static_cast<uint32_t>(*lowest_occupied) : device->l1_size_per_core();
+    return ceiling > base ? ceiling - base : 0;
 }
 
 // Correctness scope of the ported builders: TILE input, interleaved (non-sharded) input AND
@@ -49,18 +62,42 @@ bool supported_by_codegen(const Tensor& input, const tt::tt_metal::MemoryConfig&
     constexpr uint32_t kTileSize = 2048;  // bf16/bf8_b only in this scope
     constexpr uint64_t kWideChunkThreshold = 800'000;
 
+    auto* device = input.device();
+
+    // plan_cb_depths()'s floor tier: cb_in + cb_out at a single slot each. The factory has no
+    // smaller plan to degrade to below this and TT_THROWs instead, so anything that does not clear
+    // the floor has to be routed to native from here rather than aborting inside program creation.
+    //
+    // usable_l1_bytes() is budgeted against LIVE L1 occupancy, so this check is not a static
+    // shape property: the same shape can clear it on an idle device and fail it alongside a
+    // model's resident weight/trace buffers. That is deliberate -- it is the same budget
+    // ProgramImpl::validate_circular_buffer_region() will hold the resulting program to.
+    auto min_cb_plan_fits = [&](uint32_t pages_per_unit) {
+        return 2ull * pages_per_unit * kTileSize <= usable_l1_bytes(device);
+    };
+
     // Mirrors build_column_parallel + plan_cb_depths: that builder's CB plan is sized by the
-    // busiest core's tile count, not by Wt, and plan_cb_depths() TT_FATALs once even the
-    // single-buffer plan (cb_in + cb_out, one slot per tile each) exceeds the L1 budget. Reject
-    // here so "auto" falls back to native instead of aborting inside program creation.
+    // busiest core's tile count, not by Wt.
     auto column_parallel_plan_fits = [&](uint32_t wt) {
-        auto* device = input.device();
         auto grid = device->compute_with_storage_grid_size();
         auto split = tt::tt_metal::split_work_to_cores(grid, wt, /*row_wise=*/true);
         uint32_t max_tiles_per_core =
             std::max(std::get<4>(split), std::get<3>(split).empty() ? 0u : std::get<5>(split));
-        return 2ull * max_tiles_per_core * kTileSize <= usable_l1_bytes(device);
+        return min_cb_plan_fits(max_tiles_per_core);
     };
+
+    // Wt / total_tile_rows are derived from the PADDED shape (Wt/Ht are physical, tile-grid
+    // quantities), matching how the program factory itself derives them -- including for the
+    // with-unpadding builder, which reads the full physical tile grid and only differs in its
+    // writer.
+    const auto& padded_shape = input.padded_shape();
+    uint32_t rank = padded_shape.rank();
+    uint32_t wt = padded_shape[-1] / tt::constants::TILE_WIDTH;
+    uint32_t nc = 1;
+    for (uint32_t i = 0; i + 2 < rank; ++i) {
+        nc *= padded_shape[i];
+    }
+    uint32_t total_tile_rows = nc * (padded_shape[-2] / tt::constants::TILE_HEIGHT);
 
     const auto& logical = input.logical_shape();
     const bool tile_aligned =
@@ -78,36 +115,32 @@ bool supported_by_codegen(const Tensor& input, const tt::tt_metal::MemoryConfig&
         // slice/untilize/concat cascade outside this port's scope. Uses ceil(W/TILE_W) since W is
         // not tile-aligned here.
         uint32_t wt_ceil = (logical[-1] + tt::constants::TILE_WIDTH - 1) / tt::constants::TILE_WIDTH;
-        return 2ull * wt_ceil * kTileSize <= kWideChunkThreshold;
+        if (2ull * wt_ceil * kTileSize > kWideChunkThreshold) {
+            return false;
+        }
+        // build_with_unpadding plans its CBs on the physical Wt.
+        return min_cb_plan_fits(wt);
     }
 
     // Tile-aligned path: mirrors ops/untilize/untilize.py's wide-tensor guard for
     // build_untilize_tile -- a multi-tile-row input wide enough that a single tile-row would
     // overflow the slice+concat chunking threshold (~800KB for two double-buffered CBs at
     // 2048B/tile) is routed to a slice -> untilize -> concat cascade over unrelated builder
-    // entries, out of scope here. Computed from the PADDED shape (Wt/Ht are physical, tile-grid
-    // quantities), matching how the program factory itself derives Wt/total_tile_rows.
-    const auto& padded_shape = input.padded_shape();
-    uint32_t rank = padded_shape.rank();
-    uint32_t w = padded_shape[-1];
-    uint32_t h = padded_shape[-2];
-    uint32_t wt = w / tt::constants::TILE_WIDTH;
-    uint32_t nc = 1;
-    for (uint32_t i = 0; i + 2 < rank; ++i) {
-        nc *= padded_shape[i];
-    }
-    uint32_t total_tile_rows = nc * (h / tt::constants::TILE_HEIGHT);
+    // entries, out of scope here.
     if (total_tile_rows > 1 && 2ull * wt * kTileSize > kWideChunkThreshold) {
         return false;
     }
     // A single tile-row skips the chunk cascade (build_column_parallel splits Wt across the grid
     // in one dispatch instead), so it is bounded by that builder's own per-core plan, not by the
     // whole-row threshold above.
-    if (total_tile_rows == 1 && wt > 1 && !column_parallel_plan_fits(wt)) {
-        return false;
+    if (total_tile_rows == 1 && wt > 1) {
+        return column_parallel_plan_fits(wt);
     }
 
-    return true;
+    // build_2d_column plans on wt/ncol and build_main_split on wt, so Wt bounds both. (ncol lives
+    // in the factory's anonymous namespace; using the looser bound here can only over-route to
+    // native, never under-route into a plan the factory cannot build.)
+    return min_cb_plan_fits(wt);
 }
 
 bool supported_execution_controls(bool use_multicore, const std::optional<CoreRangeSet>& sub_core_grids) {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_supported.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_supported.cpp
@@ -14,20 +14,7 @@
 namespace ttnn::operations::data_movement::untilize_codegen {
 
 uint32_t usable_l1_bytes(const tt::tt_metal::IDevice* device) {
-    // Same accounting as ProgramImpl::validate_circular_buffer_region(): statically allocated CBs
-    // grow upward from the allocator's base L1 address, L1 buffers are allocated downward from the
-    // top of L1, and that validator TT_THROWs as soon as the CB region end passes
-    // lowest_occupied_compute_l1_address(). Budget against the same frontier so a plan this gate
-    // accepts is one the program validator will accept too. Mirrors get_max_l1_space() in
-    // data_movement/common/common.cpp.
-    //
-    // std::nullopt means nothing is resident in L1 yet, in which case the whole region above the
-    // base is available.
-    const uint32_t base = device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
-    const auto lowest_occupied = device->lowest_occupied_compute_l1_address();
-    const uint32_t ceiling =
-        lowest_occupied.has_value() ? static_cast<uint32_t>(*lowest_occupied) : device->l1_size_per_core();
-    return ceiling > base ? ceiling - base : 0;
+    return device->l1_size_per_core() - device->allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
 }
 
 // Correctness scope of the ported builders: TILE input, interleaved (non-sharded) input AND
@@ -62,42 +49,20 @@ bool supported_by_codegen(const Tensor& input, const tt::tt_metal::MemoryConfig&
     constexpr uint32_t kTileSize = 2048;  // bf16/bf8_b only in this scope
     constexpr uint64_t kWideChunkThreshold = 800'000;
 
-    auto* device = input.device();
-
-    // plan_cb_depths()'s floor tier: cb_in + cb_out at a single slot each. The factory has no
-    // smaller plan to degrade to below this and TT_THROWs instead, so anything that does not clear
-    // the floor has to be routed to native from here rather than aborting inside program creation.
-    //
-    // usable_l1_bytes() is budgeted against LIVE L1 occupancy, so this check is not a static
-    // shape property: the same shape can clear it on an idle device and fail it alongside a
-    // model's resident weight/trace buffers. That is deliberate -- it is the same budget
-    // ProgramImpl::validate_circular_buffer_region() will hold the resulting program to.
-    auto min_cb_plan_fits = [&](uint32_t pages_per_unit) {
-        return 2ull * pages_per_unit * kTileSize <= usable_l1_bytes(device);
-    };
-
     // Mirrors build_column_parallel + plan_cb_depths: that builder's CB plan is sized by the
-    // busiest core's tile count, not by Wt.
+    // busiest core's tile count, not by Wt. A case whose single-buffer plan (cb_in + cb_out, one
+    // slot per tile each) cannot fit even an empty core's L1 is out of scope for every codegen
+    // builder no matter what else is resident, so reject it here and let "auto" pick native.
+    // This is a static bound only -- whether the plan fits the L1 that is actually free right now
+    // is decided once, inside the program factory (see UntilizeCodegenProgramFactory).
     auto column_parallel_plan_fits = [&](uint32_t wt) {
+        auto* device = input.device();
         auto grid = device->compute_with_storage_grid_size();
         auto split = tt::tt_metal::split_work_to_cores(grid, wt, /*row_wise=*/true);
         uint32_t max_tiles_per_core =
             std::max(std::get<4>(split), std::get<3>(split).empty() ? 0u : std::get<5>(split));
-        return min_cb_plan_fits(max_tiles_per_core);
+        return 2ull * max_tiles_per_core * kTileSize <= usable_l1_bytes(device);
     };
-
-    // Wt / total_tile_rows are derived from the PADDED shape (Wt/Ht are physical, tile-grid
-    // quantities), matching how the program factory itself derives them -- including for the
-    // with-unpadding builder, which reads the full physical tile grid and only differs in its
-    // writer.
-    const auto& padded_shape = input.padded_shape();
-    uint32_t rank = padded_shape.rank();
-    uint32_t wt = padded_shape[-1] / tt::constants::TILE_WIDTH;
-    uint32_t nc = 1;
-    for (uint32_t i = 0; i + 2 < rank; ++i) {
-        nc *= padded_shape[i];
-    }
-    uint32_t total_tile_rows = nc * (padded_shape[-2] / tt::constants::TILE_HEIGHT);
 
     const auto& logical = input.logical_shape();
     const bool tile_aligned =
@@ -115,32 +80,36 @@ bool supported_by_codegen(const Tensor& input, const tt::tt_metal::MemoryConfig&
         // slice/untilize/concat cascade outside this port's scope. Uses ceil(W/TILE_W) since W is
         // not tile-aligned here.
         uint32_t wt_ceil = (logical[-1] + tt::constants::TILE_WIDTH - 1) / tt::constants::TILE_WIDTH;
-        if (2ull * wt_ceil * kTileSize > kWideChunkThreshold) {
-            return false;
-        }
-        // build_with_unpadding plans its CBs on the physical Wt.
-        return min_cb_plan_fits(wt);
+        return 2ull * wt_ceil * kTileSize <= kWideChunkThreshold;
     }
 
     // Tile-aligned path: mirrors ops/untilize/untilize.py's wide-tensor guard for
     // build_untilize_tile -- a multi-tile-row input wide enough that a single tile-row would
     // overflow the slice+concat chunking threshold (~800KB for two double-buffered CBs at
     // 2048B/tile) is routed to a slice -> untilize -> concat cascade over unrelated builder
-    // entries, out of scope here.
+    // entries, out of scope here. Computed from the PADDED shape (Wt/Ht are physical, tile-grid
+    // quantities), matching how the program factory itself derives Wt/total_tile_rows.
+    const auto& padded_shape = input.padded_shape();
+    uint32_t rank = padded_shape.rank();
+    uint32_t w = padded_shape[-1];
+    uint32_t h = padded_shape[-2];
+    uint32_t wt = w / tt::constants::TILE_WIDTH;
+    uint32_t nc = 1;
+    for (uint32_t i = 0; i + 2 < rank; ++i) {
+        nc *= padded_shape[i];
+    }
+    uint32_t total_tile_rows = nc * (h / tt::constants::TILE_HEIGHT);
     if (total_tile_rows > 1 && 2ull * wt * kTileSize > kWideChunkThreshold) {
         return false;
     }
     // A single tile-row skips the chunk cascade (build_column_parallel splits Wt across the grid
     // in one dispatch instead), so it is bounded by that builder's own per-core plan, not by the
     // whole-row threshold above.
-    if (total_tile_rows == 1 && wt > 1) {
-        return column_parallel_plan_fits(wt);
+    if (total_tile_rows == 1 && wt > 1 && !column_parallel_plan_fits(wt)) {
+        return false;
     }
 
-    // build_2d_column plans on wt/ncol and build_main_split on wt, so Wt bounds both. (ncol lives
-    // in the factory's anonymous namespace; using the looser bound here can only over-route to
-    // native, never under-route into a plan the factory cannot build.)
-    return min_cb_plan_fits(wt);
+    return true;
 }
 
 bool supported_execution_controls(bool use_multicore, const std::optional<CoreRangeSet>& sub_core_grids) {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_supported.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_supported.hpp
@@ -18,9 +18,16 @@ class IDevice;
 namespace ttnn::operations::data_movement::untilize_codegen {
 
 // Mirrors codegen builder_utils.USABLE_L1: the CB budget every codegen builder plans against.
-// Queried from the device's actual L1 budget (total L1 minus the allocator's reserved base)
-// rather than a hardcoded constant, so the gate and the factory can never disagree with what
-// the allocator will actually hand out. Shared between the two so they stay in lockstep.
+// Queried from the device's *live* L1 occupancy rather than a hardcoded constant, so the gate
+// and the factory can never disagree with what the allocator will actually hand out. Shared
+// between the two so they stay in lockstep.
+//
+// Statically allocated CBs grow upward from the allocator's base L1 address; L1 tensors are
+// allocated downward from the top of L1. The budget is therefore the gap between the two, i.e.
+// lowest_occupied_compute_l1_address() - base -- the exact quantity
+// ProgramImpl::validate_circular_buffer_region() checks the CB region end against. Budgeting
+// against total L1 instead would ignore buffers already resident in L1 (model weights, trace
+// buffers) and plan a CB region that provably clashes with them.
 uint32_t usable_l1_bytes(const tt::tt_metal::IDevice* device);
 
 // Correctness-only: true iff the codegen build_untilize_tile path can produce a bit-exact

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_supported.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize/codegen/untilize_codegen_supported.hpp
@@ -18,21 +18,29 @@ class IDevice;
 namespace ttnn::operations::data_movement::untilize_codegen {
 
 // Mirrors codegen builder_utils.USABLE_L1: the CB budget every codegen builder plans against.
-// Queried from the device's *live* L1 occupancy rather than a hardcoded constant, so the gate
-// and the factory can never disagree with what the allocator will actually hand out. Shared
-// between the two so they stay in lockstep.
+// Queried from the device's static L1 budget (total L1 minus the allocator's reserved base)
+// rather than a hardcoded constant, so the gate and the factory can never disagree with what
+// the allocator will actually hand out. Shared between the two so they stay in lockstep.
 //
-// Statically allocated CBs grow upward from the allocator's base L1 address; L1 tensors are
-// allocated downward from the top of L1. The budget is therefore the gap between the two, i.e.
-// lowest_occupied_compute_l1_address() - base -- the exact quantity
-// ProgramImpl::validate_circular_buffer_region() checks the CB region end against. Budgeting
-// against total L1 instead would ignore buffers already resident in L1 (model weights, trace
-// buffers) and plan a CB region that provably clashes with them.
+// Deliberately a STATIC device property: it must not consult live L1 occupancy (see
+// supported_by_codegen below). How much of this budget is actually free at program-build time
+// is the program factory's business, via get_max_l1_space() -- it is the only place that can
+// observe it once, consistently.
 uint32_t usable_l1_bytes(const tt::tt_metal::IDevice* device);
 
 // Correctness-only: true iff the codegen build_untilize_tile path can produce a bit-exact
 // result for this (input, output_mem_config) case. Consulted by the free function's forced
 // "codegen" branch and by prim::untilize_codegen's validate -- never gated on performance.
+//
+// MUST stay a pure function of static tensor/memory-config properties (layout, dtype, shape,
+// sharding, and static device geometry). It is evaluated independently at three call sites --
+// ttnn::untilize's routing gate, detail::untilize_force_codegen's TT_FATAL, and
+// UntilizeCodegenDeviceOperation::validate_on_program_cache_miss -- at different moments in the
+// same dispatch, and those sites are only consistent with each other because the answer cannot
+// change between them. Making it depend on mutable device state (e.g. live L1 occupancy, which
+// the op's own create_output_tensors() moves by allocating the output) breaks that invariant:
+// routing sees true, dispatches to codegen, and validate then TT_FATALs on the same tensor.
+// Live-L1 accounting belongs in the program factory, which decides once per cache miss.
 bool supported_by_codegen(const Tensor& input, const tt::tt_metal::MemoryConfig& output_mem_config);
 
 // Every codegen builder places work over the full compute-with-storage grid and has no


### PR DESCRIPTION
## Not for merge — cross-arch verification scaffold for #53399

This branch is #53399's head commit (`68f60f8ee`) under a `port/*` name so that
`tt-dm-codegen`'s cross-arch verification can dispatch against it. #53399 itself is refused by
`cross_arch.guard_ref` (`head branch 'fix/untilize-codegen-l1-overlap' is not a port/* branch`) and
carries no `codegen-port-results:v2` block, which is where `dispatch` reads the op and manifest
from. No code differs between this branch and #53399.

**Close this once the runs are collected.** The results belong on #53399.

## What is being re-verified

#53399 changes the untilize codegen CB budget from the whole of L1 above the allocator base to the
gap actually free below resident L1 buffers (`get_max_l1_space`), and lets a builder decline
(`std::nullopt`) into a native-equivalent program instead of aborting when no codegen CB plan fits.
The question this run answers is whether that re-budgeting silently changes any result on the
untilize codegen sweep #50178 shipped against — in particular the L1-`memory_config` half of the
case set, where the input and output tensors themselves lower the ceiling the plan is now budgeted
against.

Each dispatched run covers, on its arch:

- the 112-config perf sweep (wall leg un-profiled, device leg under tracy), native vs ported;
- a bit-exact forced-native vs forced-codegen compare over the same case set;
- the op's in-tree unit tests, which at this commit include the new
  `test_untilize_codegen_with_resident_l1_buffers` regression test;
- `tests/ttnn/nightly/unit_tests/operations/data_movement/test_untilize_codegen_routing.py`.

Baseline is #50178: local wormhole_b0 gate at wall 1.015 / device-vs-native 1.220 /
device-vs-generic-op 0.988, and the last collected CI rows at `3c131242` (blackhole 0.81x,
wormhole_b0 0.83x worst-case device time, ported/native).

## About the block below

Seeded from #50178 so `dispatch` can resolve the op and `collect` has somewhere to write. The
correctness tallies and the one-shot generic-op parity record are inherited from that port and
carry their own commit; `perf` is empty, exactly as it is on #50178, so every performance number
that appears here comes from these runs. `pins` point at this branch and commit.

<!-- codegen-port-results:v2
{
  "arch": "wormhole_b0",
  "cross_arch": {
    "flags": [
      "blackhole: 3 case(s) miss wall-clock parity in CI while still beating native on device \u2014 `[4, 237, 68]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile`, `[70, 41]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile`, `[128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` (4 more cleared on retest)",
      "blackhole: `[1, 1, 128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` retest \u2014 cleared over 5 window(s), wall ratio now 1.019 ported/native",
      "blackhole: `[128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` retest \u2014 inconclusive over 5 window(s), wall ratio now 1.193 ported/native",
      "blackhole: `[247, 52]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest \u2014 cleared over 5 window(s), wall ratio now 0.959 ported/native",
      "blackhole: `[4, 237, 68]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest \u2014 inconclusive over 5 window(s), wall ratio now 0.934 ported/native",
      "blackhole: `[6, 10, 50, 71]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest \u2014 cleared over 5 window(s), wall ratio now 0.917 ported/native",
      "blackhole: `[65, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest \u2014 cleared over 5 window(s), wall ratio now 0.869 ported/native",
      "blackhole: `[70, 41]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest \u2014 inconclusive over 5 window(s), wall ratio now 1.026 ported/native",
      "blackhole: retest of `[1, 1, 128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` over 5 window(s) \u2014 **cleared** (median wall ratio 1.019 ported/native, was flagged at CI's original measurement)",
      "blackhole: retest of `[128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` over 5 window(s) \u2014 **inconclusive** (median wall ratio 1.193 ported/native, was flagged at CI's original measurement)",
      "blackhole: retest of `[247, 52]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) \u2014 **cleared** (median wall ratio 0.959 ported/native, was flagged at CI's original measurement)",
      "blackhole: retest of `[4, 237, 68]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) \u2014 **inconclusive** (median wall ratio 0.934 ported/native, was flagged at CI's original measurement)",
      "blackhole: retest of `[6, 10, 50, 71]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) \u2014 **cleared** (median wall ratio 0.917 ported/native, was flagged at CI's original measurement)",
      "blackhole: retest of `[65, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) \u2014 **cleared** (median wall ratio 0.869 ported/native, was flagged at CI's original measurement)",
      "blackhole: retest of `[70, 41]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) \u2014 **inconclusive** (median wall ratio 1.026 ported/native, was flagged at CI's original measurement)",
      "wormhole_b0: 1 case(s) miss wall-clock parity in CI while still beating native on device \u2014 `[70, 41]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` (4 more cleared on retest)",
      "wormhole_b0: `[1, 4, 104, 60]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest \u2014 cleared over 5 window(s), wall ratio now 0.931 ported/native",
      "wormhole_b0: `[170, 206]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest \u2014 cleared over 5 window(s), wall ratio now 0.971 ported/native",
      "wormhole_b0: `[247, 52]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest \u2014 cleared over 5 window(s), wall ratio now 0.980 ported/native",
      "wormhole_b0: `[70, 41]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest \u2014 cleared over 5 window(s), wall ratio now 0.988 ported/native",
      "wormhole_b0: `[70, 41]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest \u2014 inconclusive over 5 window(s), wall ratio now 0.962 ported/native",
      "wormhole_b0: retest of `[1, 4, 104, 60]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) \u2014 **cleared** (median wall ratio 0.931 ported/native, was flagged at CI's original measurement)",
      "wormhole_b0: retest of `[170, 206]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) \u2014 **cleared** (median wall ratio 0.971 ported/native, was flagged at CI's original measurement)",
      "wormhole_b0: retest of `[247, 52]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) \u2014 **cleared** (median wall ratio 0.980 ported/native, was flagged at CI's original measurement)",
      "wormhole_b0: retest of `[70, 41]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) \u2014 **cleared** (median wall ratio 0.988 ported/native, was flagged at CI's original measurement)",
      "wormhole_b0: retest of `[70, 41]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) \u2014 **inconclusive** (median wall ratio 0.962 ported/native, was flagged at CI's original measurement)"
    ],
    "runs": {
      "blackhole": {
        "run_conclusion": "success",
        "run_id": 32065876271,
        "sha": "68f60f8ee5bfa7d15b32a1c391273addb0164e83",
        "state": "collected",
        "url": "https://github.com/tenstorrent/tt-metal/actions/runs/32065876271"
      },
      "wormhole_b0": {
        "run_conclusion": "success",
        "run_id": 32065863722,
        "sha": "68f60f8ee5bfa7d15b32a1c391273addb0164e83",
        "state": "collected",
        "url": "https://github.com/tenstorrent/tt-metal/actions/runs/32065863722"
      }
    }
  },
  "measurements": {
    "correctness": {
      "failing": 0,
      "implemented_passing": 112,
      "not_started": 0,
      "proven_infeasible": 0,
      "routing": 96
    },
    "parity": {
      "arch": "wormhole_b0",
      "ratio": 0.9876412123113003,
      "sha": "33658abe7786b16a3910c317c29d4f570879f8a8"
    },
    "perf": {
      "blackhole": {
        "board": {
          "arch_env": "blackhole",
          "device_arch": "Arch.BLACKHOLE",
          "labels": [
            "tt-ubuntu-2204-P150b-viommu-stable"
          ],
          "name": "P150",
          "pci": [
            {
              "device": "0xb140",
              "subsystem_device": "0x0041"
            }
          ],
          "runner": "tt-ubuntu-2204-p150b-viommu-stable-rxwdj-runner-gs7lm"
        },
        "config_count": 112,
        "demoted_count": 0,
        "demoted_worst_vs_native": null,
        "device_vs_native": 1.2516161113873694,
        "measured_at": "2026-08-17T21:10:34+00:00",
        "retest_verdicts": {
          "[1, 1, 128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile": {
            "retest_verdict": "cleared",
            "retest_windows": 5,
            "wall_native_us": 105.45000009187788,
            "wall_ported_us": 105.80000002846646,
            "wall_ratio": 0.9816776394843112
          },
          "[128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile": {
            "retest_verdict": "inconclusive",
            "retest_windows": 5,
            "wall_native_us": 93.09000006396673,
            "wall_ported_us": 106.03999999148073,
            "wall_ratio": 0.8383006905137801
          },
          "[247, 52]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile": {
            "retest_verdict": "cleared",
            "retest_windows": 5,
            "wall_native_us": 97.90000012799283,
            "wall_ported_us": 94.57000010115735,
            "wall_ratio": 1.0423572766956533
          },
          "[4, 237, 68]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile": {
            "retest_verdict": "inconclusive",
            "retest_windows": 5,
            "wall_native_us": 109.54999993373349,
            "wall_ported_us": 116.1200000296958,
            "wall_ratio": 1.071002708369235
          },
          "[6, 10, 50, 71]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile": {
            "retest_verdict": "cleared",
            "retest_windows": 5,
            "wall_native_us": 159.69000014592893,
            "wall_ported_us": 139.0800000535819,
            "wall_ratio": 1.0906026143705638
          },
          "[65, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile": {
            "retest_verdict": "cleared",
            "retest_windows": 5,
            "wall_native_us": 112.93000011391996,
            "wall_ported_us": 88.38999997351493,
            "wall_ratio": 1.1504553770815775
          },
          "[70, 41]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile": {
            "retest_verdict": "inconclusive",
            "retest_windows": 5,
            "wall_native_us": 88.53999997882056,
            "wall_ported_us": 94.32000001652341,
            "wall_ratio": 0.974665006836061
          }
        },
        "run_id": 32065876271,
        "sha": "68f60f8ee5bfa7d15b32a1c391273addb0164e83",
        "source": "ci",
        "wall_only_configs": [
          "[128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile",
          "[4, 237, 68]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile",
          "[70, 41]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile"
        ],
        "wall_ratio": 0.7714140904534069
      },
      "wormhole_b0": {
        "board": {
          "arch_env": "wormhole_b0",
          "device_arch": "Arch.WORMHOLE_B0",
          "labels": [
            "tt-ubuntu-2204-N300-viommu-stable"
          ],
          "name": "N300",
          "pci": [
            {
              "device": "0x401e",
              "subsystem_device": "0x0014"
            }
          ],
          "runner": "tt-ubuntu-2204-n300-viommu-stable-wnk2h-runner-5s6ff"
        },
        "config_count": 112,
        "demoted_count": 0,
        "demoted_worst_vs_native": null,
        "device_vs_native": 1.1542792792792793,
        "measured_at": "2026-08-17T21:10:37+00:00",
        "retest_verdicts": {
          "[1, 4, 104, 60]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile": {
            "retest_verdict": "cleared",
            "retest_windows": 5,
            "wall_native_us": 85.89000003667024,
            "wall_ported_us": 80.81999999376421,
            "wall_ratio": 1.0738987526758526
          },
          "[170, 206]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile": {
            "retest_verdict": "cleared",
            "retest_windows": 5,
            "wall_native_us": 94.05000014339748,
            "wall_ported_us": 84.07999985138304,
            "wall_ratio": 1.0303461879286369
          },
          "[247, 52]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile": {
            "retest_verdict": "cleared",
            "retest_windows": 5,
            "wall_native_us": 82.70000000720756,
            "wall_ported_us": 84.47000004707661,
            "wall_ratio": 1.0199005559010454
          },
          "[70, 41]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile": {
            "retest_verdict": "cleared",
            "retest_windows": 5,
            "wall_native_us": 82.13000000978354,
            "wall_ported_us": 81.44000003085239,
            "wall_ratio": 1.0124474284584224
          },
          "[70, 41]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile": {
            "retest_verdict": "inconclusive",
            "retest_windows": 5,
            "wall_native_us": 82.84000000458036,
            "wall_ported_us": 88.27999999994063,
            "wall_ratio": 1.0395144648899268
          }
        },
        "run_id": 32065863722,
        "sha": "68f60f8ee5bfa7d15b32a1c391273addb0164e83",
        "source": "ci",
        "wall_only_configs": [
          "[70, 41]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile"
        ],
        "wall_ratio": 0.8741225568287981
      }
    }
  },
  "op": "untilize",
  "pins": {
    "codegen_commit": "7f2930ff75da8e4731e7d5cf7d730a77aaec3b62",
    "ttmetal_branch": "port/untilize-l1-budget-reverify-20260817T200753Z",
    "ttmetal_commit": "68f60f8ee5bfa7d15b32a1c391273addb0164e83"
  }
}
-->

Related: #53399, #50178

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=port/untilize-l1-budget-reverify-20260817T200753Z)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:port/untilize-l1-budget-reverify-20260817T200753Z)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=port/untilize-l1-budget-reverify-20260817T200753Z)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:port/untilize-l1-budget-reverify-20260817T200753Z)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=port/untilize-l1-budget-reverify-20260817T200753Z)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:port/untilize-l1-budget-reverify-20260817T200753Z)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=port/untilize-l1-budget-reverify-20260817T200753Z)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:port/untilize-l1-budget-reverify-20260817T200753Z)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=port/untilize-l1-budget-reverify-20260817T200753Z)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:port/untilize-l1-budget-reverify-20260817T200753Z)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=port/untilize-l1-budget-reverify-20260817T200753Z)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:port/untilize-l1-budget-reverify-20260817T200753Z)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=port/untilize-l1-budget-reverify-20260817T200753Z)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:port/untilize-l1-budget-reverify-20260817T200753Z)

<!-- codegen-port-cross-arch:begin -->

### Cross-arch verification

| arch | commit | run | state |
|---|---|---|---|
| `blackhole` | `68f60f8e` | [32065876271](https://github.com/tenstorrent/tt-metal/actions/runs/32065876271) | collected |
| `wormhole_b0` | `68f60f8e` | [32065863722](https://github.com/tenstorrent/tt-metal/actions/runs/32065863722) | collected |

**Flagged — a CI result contradicts a local measurement on the same arch.** Reported only: no verdict here changes because of it.

- blackhole: 3 case(s) miss wall-clock parity in CI while still beating native on device — `[4, 237, 68]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile`, `[70, 41]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile`, `[128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` (4 more cleared on retest)
- blackhole: `[1, 1, 128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` retest — cleared over 5 window(s), wall ratio now 1.019 ported/native
- blackhole: `[128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` retest — inconclusive over 5 window(s), wall ratio now 1.193 ported/native
- blackhole: `[247, 52]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest — cleared over 5 window(s), wall ratio now 0.959 ported/native
- blackhole: `[4, 237, 68]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest — inconclusive over 5 window(s), wall ratio now 0.934 ported/native
- blackhole: `[6, 10, 50, 71]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest — cleared over 5 window(s), wall ratio now 0.917 ported/native
- blackhole: `[65, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest — cleared over 5 window(s), wall ratio now 0.869 ported/native
- blackhole: `[70, 41]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest — inconclusive over 5 window(s), wall ratio now 1.026 ported/native
- blackhole: retest of `[1, 1, 128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` over 5 window(s) — **cleared** (median wall ratio 1.019 ported/native, was flagged at CI's original measurement)
- blackhole: retest of `[128, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat8_b|tile` over 5 window(s) — **inconclusive** (median wall ratio 1.193 ported/native, was flagged at CI's original measurement)
- blackhole: retest of `[247, 52]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) — **cleared** (median wall ratio 0.959 ported/native, was flagged at CI's original measurement)
- blackhole: retest of `[4, 237, 68]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) — **inconclusive** (median wall ratio 0.934 ported/native, was flagged at CI's original measurement)
- blackhole: retest of `[6, 10, 50, 71]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) — **cleared** (median wall ratio 0.917 ported/native, was flagged at CI's original measurement)
- blackhole: retest of `[65, 256]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) — **cleared** (median wall ratio 0.869 ported/native, was flagged at CI's original measurement)
- blackhole: retest of `[70, 41]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) — **inconclusive** (median wall ratio 1.026 ported/native, was flagged at CI's original measurement)
- wormhole_b0: 1 case(s) miss wall-clock parity in CI while still beating native on device — `[70, 41]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` (4 more cleared on retest)
- wormhole_b0: `[1, 4, 104, 60]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest — cleared over 5 window(s), wall ratio now 0.931 ported/native
- wormhole_b0: `[170, 206]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest — cleared over 5 window(s), wall ratio now 0.971 ported/native
- wormhole_b0: `[247, 52]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest — cleared over 5 window(s), wall ratio now 0.980 ported/native
- wormhole_b0: `[70, 41]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest — cleared over 5 window(s), wall ratio now 0.988 ported/native
- wormhole_b0: `[70, 41]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` retest — inconclusive over 5 window(s), wall ratio now 0.962 ported/native
- wormhole_b0: retest of `[1, 4, 104, 60]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) — **cleared** (median wall ratio 0.931 ported/native, was flagged at CI's original measurement)
- wormhole_b0: retest of `[170, 206]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) — **cleared** (median wall ratio 0.971 ported/native, was flagged at CI's original measurement)
- wormhole_b0: retest of `[247, 52]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) — **cleared** (median wall ratio 0.980 ported/native, was flagged at CI's original measurement)
- wormhole_b0: retest of `[70, 41]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::DRAM,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) — **cleared** (median wall ratio 0.988 ported/native, was flagged at CI's original measurement)
- wormhole_b0: retest of `[70, 41]|memory_config=MemoryConfig(memory_layout=TensorMemoryLayout::INTERLEAVED,buffer_type=BufferType::L1,shard_spec=std::nullopt,nd_shard_spec=std::nullopt,created_with_nd_shard_spec=0,per_core_allocation=0)|bfloat16|tile` over 5 window(s) — **inconclusive** (median wall ratio 0.962 ported/native, was flagged at CI's original measurement)

**Worst-case device time, ported / native** (lower is faster; `1.0` = no change)

| arch | | ratio | source |
|---|---|---:|---|
| `blackhole/P150` | `███████████████████·····` | 0.80x | ci ([run](https://github.com/tenstorrent/tt-metal/actions/runs/32065876271)) |
| `wormhole_b0/N300` | `█████████████████████···` | 0.87x | ci ([run](https://github.com/tenstorrent/tt-metal/actions/runs/32065863722)) |

<!-- codegen-port-cross-arch:end -->
