### PR TITLE
Bug fix: fall back to auto-shard layout instead of DRAM-slice fatal when conv output width < one tile

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
@@ -1065,3 +1065,91 @@ def test_conv1d_depthwise_default_route_long_seq(device):
         packer_l1_acc=True,
         pcc=0.999,
     )
+
+
+@pytest.mark.parametrize(
+    "shard_layout",
+    [ttnn.TensorMemoryLayout.WIDTH_SHARDED, None],
+    ids=["width_sharded", "auto"],
+)
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+def test_conv1d_unchunked_c10240_width_sharded(device, shard_layout):
+    """Depthwise (groups == C == 10240) GDN prefill shape (K=4, T=12, pad=3) as a SINGLE
+    stock conv1d call on unmodified conv code: this tree has no channel-chunking in the
+    conv2d DRAM path, so a pass here is single-conv by construction.
+
+    The default HEIGHT_SHARDED layout cannot fit this shape on one core (the weight block
+    is width-independent; the auto-slicer fatals with "could not find valid slice
+    configuration"), but WIDTH_SHARDED spreads the 320 output-channel tiles across 80
+    cores, which fits per-core L1. The "auto" case (shard_layout unset) picks a fitting
+    layout automatically.
+
+    Perf caveat (measured on 2x p150a): the single WIDTH_SHARDED conv takes ~1.6 s at T=12
+    vs ~0.07 s for 32 channel chunks of 320 in HEIGHT_SHARDED, so chunked HEIGHT_SHARDED
+    remains the right choice for latency-sensitive callers (see the qwen36 GDN demo path);
+    this test records that the unchunked shape is *feasible*, not that it is faster.
+    """
+    C, K, T, PAD = 10240, 4, 12, 3
+    torch.manual_seed(0)
+    torch_input_ncl = torch.randn(1, C, T, dtype=torch.bfloat16).float()
+    torch_weight = torch.randn(C, 1, K, dtype=torch.bfloat16).float()
+    torch_bias = torch.randn(1, 1, 1, C, dtype=torch.bfloat16).float()
+    golden = torch.nn.functional.conv1d(
+        torch_input_ncl,
+        torch_weight,
+        bias=torch_bias.reshape(-1),
+        stride=1,
+        padding=PAD,
+        dilation=1,
+        groups=C,
+    )
+
+    input_tt = ttnn.from_torch(
+        torch_input_ncl.permute(0, 2, 1),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    weight_tt = ttnn.from_torch(torch_weight, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+    bias_tt = ttnn.from_torch(torch_bias, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    conv_config_kwargs = {"weights_dtype": ttnn.bfloat16, "deallocate_activation": True}
+    if shard_layout is not None:
+        conv_config_kwargs["shard_layout"] = shard_layout
+    conv_config = ttnn.Conv1dConfig(**conv_config_kwargs)
+    compute_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+
+    tt_out, out_length = ttnn.conv1d(
+        input_tensor=input_tt,
+        weight_tensor=weight_tt,
+        device=device,
+        in_channels=C,
+        out_channels=C,
+        bias_tensor=bias_tt,
+        kernel_size=K,
+        stride=1,
+        padding=PAD,
+        dilation=1,
+        batch_size=1,
+        input_length=T,
+        conv_config=conv_config,
+        compute_config=compute_config,
+        groups=C,
+        dtype=ttnn.bfloat16,
+        return_output_dim=True,
+    )
+
+    out = ttnn.to_torch(tt_out).reshape(1, out_length, C).permute(0, 2, 1)
+    passing, pcc_msg = check_with_pcc_without_tensor_printout(out, golden, pcc=0.999)
+    assert passing, pcc_msg
+    config_name = "WIDTH_SHARDED" if shard_layout is not None else "AUTO"
+    logger.info(
+        f"I_UNCHUNK: C=10240 groups=10240 K=4 T=12 pad=3 config={config_name} single-conv VERDICT: PASS"
+    )
+    logger.info(f"I_UNCHUNK_PCC: config={config_name} threshold=0.999 {pcc_msg}")

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -560,6 +560,22 @@ public:
         auto sliced_input_tensor_memory_config = get_input_memory_config(output_slice_start, output_slice_end);
         if (!conv_config.shard_layout.has_value()) {
             conv_config.shard_layout = sliced_input_tensor_memory_config.memory_layout();
+        } else {
+            // A pinned shard layout that cannot fit in L1 cannot be rescued by
+            // width-slicing when the output width is below one tile; resolve it
+            // here so planning and the run agree (see resolve_pinned_shard_layout).
+            auto resolved = resolve_pinned_shard_layout(
+                input_slice_height,
+                input_slice_width,
+                output_slice_height,
+                output_slice_width,
+                slice_padding,
+                sliced_input_tensor_memory_config,
+                conv_config.shard_layout.value());
+            conv_config.shard_layout = resolved.layout;
+            if (resolved.input_memory_config.has_value()) {
+                sliced_input_tensor_memory_config = resolved.input_memory_config.value();
+            }
         }
         auto conv_L1_usage = calculate_L1_usage_for_conv_op(
             batch_size,
@@ -675,6 +691,21 @@ public:
 
         if (!conv_config.shard_layout.has_value() && sliced_input_tensor.is_sharded()) {
             conv_config.shard_layout = sliced_input_tensor.memory_config().memory_layout();
+        } else if (conv_config.shard_layout.has_value()) {
+            // Keep the run consistent with what slice planning accepted: honor a
+            // pinned layout only while it fits (or width-slicing can still reduce
+            // L1 usage); otherwise fall back to the natural auto-shard layout.
+            uint32_t output_slice_height = std::get<0>(output_slice_end) - std::get<0>(output_slice_start);
+            uint32_t output_slice_width = std::get<1>(output_slice_end) - std::get<1>(output_slice_start);
+            conv_config.shard_layout = resolve_pinned_shard_layout(
+                                           input_slice_height,
+                                           input_slice_width,
+                                           output_slice_height,
+                                           output_slice_width,
+                                           this_op_padding,
+                                           get_input_memory_config(output_slice_start, output_slice_end),
+                                           conv_config.shard_layout.value())
+                                           .layout;
         }
         auto conv_config_l1 = conv_config;
 
@@ -708,6 +739,133 @@ public:
             bias_tensor->get() = std::get<4>(conv2d_result).value();
         }
         return {std::get<0>(conv2d_result)};
+    }
+
+private:
+    struct ResolvedShardLayout {
+        TensorMemoryLayout layout;
+        std::optional<tt::tt_metal::MemoryConfig> input_memory_config;
+    };
+
+    // Resolve a user-pinned shard layout for DRAM slicing. Keeps the pinned
+    // layout when it fits in L1, or when the output width spans at least one
+    // tile (width-slicing can still reduce per-slice L1 usage). When the pinned
+    // layout cannot fit and width-slicing structurally cannot apply (output
+    // width below one tile), falls back to the natural auto-shard layout if
+    // that fits — mirroring the width<->height slice-type fallback in
+    // op_slicing.cpp. If nothing fits, the pinned layout is returned unchanged
+    // so genuinely-unsliceable configs still fail in the slicer.
+    ResolvedShardLayout resolve_pinned_shard_layout(
+        uint32_t input_slice_height,
+        uint32_t input_slice_width,
+        uint32_t output_slice_height,
+        uint32_t output_slice_width,
+        const std::array<uint32_t, 4>& slice_padding,
+        const tt::tt_metal::MemoryConfig& pinned_input_memory_config,
+        TensorMemoryLayout pinned_layout) const {
+        if (output_slice_width >= tt::constants::TILE_WIDTH) {
+            return {pinned_layout, pinned_input_memory_config};
+        }
+        auto compute_grid = device->compute_with_storage_grid_size();
+        auto l1_estimate = [&](TensorMemoryLayout layout,
+                               const tt::tt_metal::MemoryConfig& input_memory_config) -> uint64_t {
+            auto conv_config_for_estimate = conv_config;
+            conv_config_for_estimate.shard_layout = layout;
+            auto usage = calculate_L1_usage_for_conv_op(
+                batch_size,
+                input_channels,
+                output_channels,
+                input_slice_height,
+                input_slice_width,
+                output_slice_height,
+                output_slice_width,
+                kernel_size,
+                stride,
+                slice_padding,
+                dilation,
+                groups,
+                bias_tensor.has_value(),
+                input_dtype,
+                output_dtype,
+                input_layout,
+                compute_grid,
+                false,
+                layout,
+                compute_config,
+                conv_config_for_estimate,
+                input_memory_config);
+            return std::max<uint64_t>(
+                static_cast<uint64_t>(usage.halo_input_size) + usage.halo_output_size, usage.total_size);
+        };
+        const uint64_t l1_available =
+            device->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_free_bytes;
+        const uint64_t pinned_usage = l1_estimate(pinned_layout, pinned_input_memory_config);
+        if (pinned_usage <= l1_available) {
+            return {pinned_layout, pinned_input_memory_config};
+        }
+
+        // Pinned layout cannot fit and width-slicing cannot reduce L1 usage:
+        // try the natural (auto-shard) layout.
+        auto conv_config_auto = conv_config;
+        conv_config_auto.shard_layout = std::nullopt;
+        conv_config_auto = determine_conv_config_for_auto_shard(
+            conv_config_auto,
+            false,
+            batch_size,
+            input_channels,
+            output_channels,
+            output_slice_height,
+            output_slice_width,
+            weight_tensor.logical_shape()[3],
+            input_slice_height,
+            input_slice_width,
+            compute_grid,
+            input_layout,
+            input_dtype,
+            output_dtype,
+            std::nullopt,
+            kernel_size,
+            stride,
+            dilation,
+            padding_n4,
+            groups,
+            bias_tensor.has_value(),
+            compute_config);
+        TT_FATAL(
+            conv_config_auto.shard_layout.has_value(),
+            "Auto-shard layout must be resolved by determine_conv_config_for_auto_shard.");
+        const auto natural_layout = conv_config_auto.shard_layout.value();
+        if (natural_layout == pinned_layout) {
+            return {pinned_layout, pinned_input_memory_config};
+        }
+        ShardOrientation shard_orientation =
+            conv_config.transpose_shards ? ShardOrientation::COL_MAJOR : ShardOrientation::ROW_MAJOR;
+        bool single_slice =
+            (input_slice_height == std::get<0>(input_shape)) && (input_slice_width == std::get<1>(input_shape));
+        auto natural_input_memory_config = std::get<1>(determine_input_memory_config(
+            natural_layout,
+            shard_orientation,
+            batch_size,
+            ttnn::Shape({batch_size, input_slice_height, input_slice_width, input_channels}),
+            ttnn::Shape({batch_size, output_slice_height, output_slice_width, output_channels}),
+            false,
+            compute_grid,
+            input_layout,
+            single_slice ? BufferType::L1 : BufferType::DRAM));
+        if (l1_estimate(natural_layout, natural_input_memory_config) <= l1_available) {
+            log_warning(
+                tt::LogOp,
+                "Conv2D DRAM slicing: pinned shard layout {} does not fit in L1 ({} bytes needed, {} available) and "
+                "output width {} is below one tile, so width-slicing cannot reduce L1 usage. Falling back to the "
+                "auto-shard layout {}.",
+                pinned_input_memory_config,
+                pinned_usage,
+                l1_available,
+                output_slice_width,
+                natural_input_memory_config);
+            return {natural_layout, natural_input_memory_config};
+        }
+        return {pinned_layout, pinned_input_memory_config};
     }
 };
 


### PR DESCRIPTION
## Problem

When a conv's output width is narrower than one tile (`out_w < TILE_WIDTH`), `compute_max_num_slices` is 1, so DRAM width-slicing structurally cannot reduce per-core L1 usage. If a pinned `shard_layout`'s L1 estimate exceeds available L1 in that situation, slice planning always hit the hard fatal at `ttnn/cpp/ttnn/operations/sliding_window/op_slicing/op_slicing.cpp:258` ("DRAM Auto slice could not find valid slice configuration ...") — no configuration the slicer could pick would fit. Example: GDN prefill depthwise conv1d `C=10240, groups=10240, K=4, T=12, pad=3` -> `out_w=15` with a pinned `HEIGHT_SHARDED` layout needing 845,783,104 B against 1,428,608 B available.

## Fix (`ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp`, +158)

- One shared private resolver `Conv2dSliceAttr::resolve_pinned_shard_layout()` wired into both slice planning (`get_L1_usage`) and the per-slice run (`run_L1_op`), so planning and run cannot disagree about the layout used for any slice.
- The fallback fires only when ALL of: the pinned layout's estimate exceeds available L1, `output_slice_width < TILE_WIDTH` (width slicing cannot apply, `compute_max_num_slices == 1`), and the natural auto-shard layout (what `shard_layout=None` would pick) differs and fits. In that case the auto-shard layout is used and a `log_warning` explains the fallback.
- Fitting pinned layouts and every `width >= TILE_WIDTH` path return unchanged by construction (early returns before any estimate); genuinely unsliceable configs still fail in the slicer as before.

## Silicon evidence — 2x p150a (P300 1x2), same shape `C=10240 groups=10240 K=4 T=12 pad=3`

- `i10240-verify-a2_probe-device-pcc.log` — pinned `HEIGHT_SHARDED` arm: PASS, pcc=0.999999, fallback warning observed on silicon (pinned 845,783,104 B vs 1,428,608 B available, out_w=15 -> auto `WIDTH_SHARDED`); `shard_layout=None` control arm: PASS, pcc=0.999999, no warning.
- `i10240-verify-b_unchunked-c10240.log` — stock pytest entry `tests/ttnn/unit_tests/operations/conv/test_conv1d.py -k unchunked_c10240`: 2 passed (width_sharded + auto), PCC 0.9999997.
- `i10240-verify-c_guard-dram-slice.log` — `-k dram_slice_auto_shard` guard: 1 passed (`width >= 32` path unchanged).
- `i10240-verify-summary.log` — ends `I10240_VERIFY: VERDICT: PASS`; TT_FATAL count 0 across all runs.

Caveat: for this shape the fallback executes the op width-sharded internally (that is the coverage this change buys); the height-preserving unchunked close is tracked separately (#53314, channel-chunk).
