### PR TITLE
fabric pipeline reorganization

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -194,7 +194,6 @@ scaleout:
     cpu_medium: 235
     wh_llmbox: 60
     wh_galaxy: 75
-    # Fabric test list (fabric_tests.yaml) SKUs.
     wh_n300_civ2: 15
     wh_llmbox_civ2: 65
     bh_loudbox: 195
@@ -214,7 +213,6 @@ scaleout:
     bh_quietbox_2: 15
     bh_p300: 15
   perf:
-    # T3K fabric ubench (fabric_perf_tests.yaml).
     wh_llmbox_perf: 140
   e2e:
     wh_llmbox: 185

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -209,12 +209,10 @@ scaleout:
     bh_galaxy: 10
   sanity:
     wh_galaxy: 20
+    wh_llmbox_civ2: 30
+    wh_n300_civ2: 15
     bh_quietbox_2: 15
     bh_p300: 15
-    wh_llmbox_civ2: 30
-    # fabric_sanity_tests.yaml SKUs (dedicated fabric smoke in sanity-tests.yaml).
-    wh_n300_civ2: 15
-    bh_p150b_civ2_viommu: 15
   perf:
     # T3K fabric ubench (fabric_perf_tests.yaml).
     wh_llmbox_perf: 140

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -193,7 +193,13 @@ scaleout:
   unit:
     cpu_medium: 235
     wh_llmbox: 60
-    wh_galaxy: 25
+    wh_galaxy: 75
+    # Fabric test list (fabric_tests.yaml) SKUs.
+    wh_n300_civ2: 15
+    wh_llmbox_civ2: 65
+    bh_loudbox: 195
+    bh_p300: 195
+    bh_quietbox_2: 195
   stress:
     wh_galaxy_perf: 120
   integration:
@@ -206,6 +212,12 @@ scaleout:
     bh_quietbox_2: 15
     bh_p300: 15
     wh_llmbox_civ2: 30
+    # fabric_sanity_tests.yaml SKUs (dedicated fabric smoke in sanity-tests.yaml).
+    wh_n300_civ2: 15
+    bh_p150b_civ2_viommu: 15
+  perf:
+    # T3K fabric ubench (fabric_perf_tests.yaml).
+    wh_llmbox_perf: 140
   e2e:
     wh_llmbox: 185
     wh_galaxy: 100

--- a/.github/workflows/fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests.yaml
@@ -97,10 +97,15 @@ jobs:
         test-group: ${{ fromJson(needs.load-test-matrix.outputs.matrix) }}
     name: ${{ matrix.test-group.name }}
     runs-on: ${{ matrix.test-group.runs_on }}
+    env:
+      # Derive ARCH_NAME from the SKU prefix so testlist entries don't have to
+      # author it. Merge-gate fabric SKUs are wh_* -> wormhole_b0; empty fallback
+      # trips the -z guard in run_cpp_fabric_tests.sh for any unrecognized SKU.
+      DERIVED_ARCH: ${{ startsWith(matrix.test-group.sku, 'wh_') && 'wormhole_b0' || (startsWith(matrix.test-group.sku, 'bh_') && 'blackhole' || '') }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
-        ARCH_NAME: ${{ matrix.test-group.arch }}
+        ARCH_NAME: ${{ env.DERIVED_ARCH }}
         LOGURU_LEVEL: INFO
         TT_LOGGER_LEVEL: warn
         LD_LIBRARY_PATH: /work/build/lib

--- a/.github/workflows/fabric-build-and-unit-tests.yaml
+++ b/.github/workflows/fabric-build-and-unit-tests.yaml
@@ -97,15 +97,13 @@ jobs:
         test-group: ${{ fromJson(needs.load-test-matrix.outputs.matrix) }}
     name: ${{ matrix.test-group.name }}
     runs-on: ${{ matrix.test-group.runs_on }}
-    env:
-      # Derive ARCH_NAME from the SKU prefix so testlist entries don't have to
-      # author it. Merge-gate fabric SKUs are wh_* -> wormhole_b0; empty fallback
-      # trips the -z guard in run_cpp_fabric_tests.sh for any unrecognized SKU.
-      DERIVED_ARCH: ${{ startsWith(matrix.test-group.sku, 'wh_') && 'wormhole_b0' || (startsWith(matrix.test-group.sku, 'bh_') && 'blackhole' || '') }}
+    # ARCH_NAME is derived inline from matrix.test-group.sku:
+    # bh_* / *blackhole* -> blackhole; wh_* / *wormhole* -> wormhole_b0; else '' so
+    # run_cpp_fabric_tests.sh trips its -z guard on unrecognized SKUs.
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
-        ARCH_NAME: ${{ env.DERIVED_ARCH }}
+        ARCH_NAME: ${{ (contains(matrix.test-group.sku, 'bh_') || contains(matrix.test-group.sku, 'blackhole')) && 'blackhole' || (contains(matrix.test-group.sku, 'wh_') || contains(matrix.test-group.sku, 'wormhole')) && 'wormhole_b0' || '' }}
         LOGURU_LEVEL: INFO
         TT_LOGGER_LEVEL: warn
         LD_LIBRARY_PATH: /work/build/lib

--- a/.github/workflows/fabric-sanity-tests-impl.yaml
+++ b/.github/workflows/fabric-sanity-tests-impl.yaml
@@ -4,10 +4,10 @@ name: "[internal] Fabric sanity tests impl"
 # Called from sanity-tests.yaml. Single source of truth for fabric coverage in
 # the sanity pipeline: WH N300 smoke, T3K llmbox, and BH card smoke.
 #
-# Coverage-preservation hooks are conditional on SKU / entry flags — search for
-# "Coverage:" below. Mirrors the pattern in tm-fabric-tests-impl.yaml so
-# wh_llmbox_civ2 legs get power sidecar / kernel ccache / --memory 256g /
-# fabric BW SFTP upload.
+# SKU- and entry-conditional infra hooks are documented with "Coverage:"
+# comments below; grep them when adding a new SKU or entry. Mirrors the
+# hook set in tm-fabric-tests-impl.yaml so wh_llmbox_civ2 legs get the same
+# power sidecar / kernel ccache / --memory 256g / fabric BW SFTP treatment.
 
 on:
   workflow_call:
@@ -84,7 +84,8 @@ jobs:
         test-group: ${{ fromJson(needs.load-test-matrix.outputs.matrix) }}
     name: ${{ matrix.test-group.name }}
     runs-on: ${{ matrix.test-group.runs_on }}
-    # Coverage: mainline environment gate — SFTP secrets are only bound on main.
+    # Coverage: bind the mainline GH environment on main so the fabric BW /
+    # latency SFTP upload secrets below are available.
     environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
@@ -95,13 +96,17 @@ jobs:
         ARCH_NAME: ${{ matrix.test-group.arch }}
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/
-        # Coverage: mirrors tm-fabric-tests-impl / t3000-sanity-tests-impl.
+        # Coverage: enable TTNN program-arg validation on every sanity leg. Trivial
+        # cost on non-TTNN entries; set universally rather than per-SKU.
         TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        # Coverage: viommu runners skip hugepages.
+        # Coverage: mount /dev/hugepages-1G on non-viommu runners only. Viommu SKUs
+        # (e.g. bh_p150b_civ2_viommu) bypass the hugepages path and must not have
+        # the mount.
         - ${{ !contains(join(matrix.test-group.runs_on, ','), 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G' || '/no_hugepages:/no_hugepages' }}
-      # Coverage: --memory 256g for wh_llmbox_civ2 (WH-LB memory cap).
+      # Coverage: cap container memory to 256 GiB on WH-LB (wh_llmbox*) to keep
+      # T3K legs from ballooning host memory. Other SKUs use the container default.
       options: --device /dev/tenstorrent ${{ contains(matrix.test-group.sku, 'wh_llmbox') && '--memory 256g' || '' }}
     defaults:
       run:
@@ -122,11 +127,14 @@ jobs:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
           enable-watcher: ${{ inputs.enable-watcher || false }}
-          # Coverage: kernel ccache for wh_llmbox_civ2 legs (mirrors t3000-sanity-tests-impl).
+          # Coverage: enable runtime kernel ccache (Redis-backed) on WH-LB legs
+          # where JIT compile amortizes across the run. Other SKUs skip ccache
+          # setup entirely; the Redis storage string only resolves on WH-LB.
           enable-kernel-ccache: ${{ contains(matrix.test-group.sku, 'wh_llmbox') }}
           redis-ccache-storage: ${{ contains(matrix.test-group.sku, 'wh_llmbox') && format('redis://{0}:{1}@{2}:{3}{4}', vars.REDIS_CCACHE_USER, secrets.REDIS_CCACHE_PASSWORD, vars.REDIS_CCACHE_HOST, vars.REDIS_CCACHE_PORT, vars.REDIS_CCACHE_IS_READONLY == 'true' && '|read-only=true' || '') || '' }}
 
-      # Coverage: BH health-check pre-step matches the tm-fabric-tests BH matrix.
+      # Coverage: Run the smi-reset + system-health loop before every BH leg
+      # to ensure the links are online.
       - name: Ensure BH links online
         if: ${{ startsWith(matrix.test-group.sku, 'bh_') }}
         uses: ./docker-job/.github/actions/ensure-bh-links-online
@@ -135,8 +143,8 @@ jobs:
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ inputs.timeout-minutes-override > 0 && inputs.timeout-minutes-override || matrix.test-group.timeout }}
         env:
-          # Coverage: wrap cmd in power sidecar on wh_llmbox_civ2 (matches
-          # t3000-sanity-tests-impl); other SKUs run the raw cmd.
+          # Coverage: on WH-LB, wrap the cmd in tt_power_sidecar.py to sample SoC
+          # power for the downstream power dashboard. Other SKUs run the raw cmd.
           _TEST_CMD: ${{ matrix.test-group.cmd }}
         run: |
           mkdir -p generated/test_reports
@@ -154,7 +162,8 @@ jobs:
         run: |
           tt-smi -s
 
-      # Coverage: power sidecar report artifact (wh_llmbox only).
+      # Coverage: publish the per-leg power_report.json produced by the
+      # tt_power_sidecar wrap for offline power analysis. WH-LB only.
       - name: Upload power report
         if: ${{ !cancelled() && startsWith(matrix.test-group.sku, 'wh_llmbox') }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -179,8 +188,9 @@ jobs:
             echo '```' >> $GITHUB_STEP_SUMMARY
           fi
 
-      # Coverage: fabric BW/latency SFTP upload for entries flagged
-      # `upload_benchmarks: true` (t3k_fabric_tests). Mirrors t3000-sanity-tests-impl.
+      # Coverage: entries that emit fabric BW / latency CSVs opt in via
+      # `upload_benchmarks: true`. On main, check for the generated files
+      # and SFTP them to the perf dashboard.
       - name: Check for benchmark and latency data
         id: check-data
         if: ${{ !cancelled() && github.ref_name == 'main' && matrix.test-group.upload_benchmarks == true }}

--- a/.github/workflows/fabric-sanity-tests-impl.yaml
+++ b/.github/workflows/fabric-sanity-tests-impl.yaml
@@ -29,11 +29,6 @@ on:
         required: false
         type: boolean
         default: false
-      timeout-minutes-override:
-        required: false
-        type: number
-        default: 0
-        description: "When > 0, overrides each test's per-SKU timeout (used for watcher runs)."
       ref:
         required: false
         type: string
@@ -141,37 +136,20 @@ jobs:
         timeout-minutes: 10
 
       - name: ${{ matrix.test-group.name }}
-        timeout-minutes: ${{ inputs.timeout-minutes-override > 0 && inputs.timeout-minutes-override || matrix.test-group.timeout }}
-        env:
-          # Coverage: on WH-LB, wrap the cmd in tt_power_sidecar.py to sample SoC
-          # power for the downstream power dashboard. Other SKUs run the raw cmd.
-          _TEST_CMD: ${{ matrix.test-group.cmd }}
+        timeout-minutes: ${{ matrix.test-group.timeout }}
         run: |
-          mkdir -p generated/test_reports
-          if [[ "${{ matrix.test-group.sku }}" == wh_llmbox* ]]; then
-            python3 tools/tt-power-sidecar/tt_power_sidecar.py \
-              --backend sysfs \
-              --out /work/power_report.json \
-              -- bash -c "$_TEST_CMD"
-          else
-            bash -c "$_TEST_CMD"
-          fi
+          mkdir -p generated/test_reports generated/test_logs
+          SAFE_NAME=$(echo "${{ matrix.test-group.name }}" | tr ' /' '__')
+          LOG_FILE="generated/test_logs/${SAFE_NAME}_${{ job.check_run_id }}.log"
+          {
+            ${{ matrix.test-group.cmd }}
+          } 2>&1 | tee "$LOG_FILE"
+          exit "${PIPESTATUS[0]}"
 
       - name: Print tt-smi data on failure
         if: ${{ failure() && startsWith(matrix.test-group.sku, 'bh_') }}
         run: |
           tt-smi -s
-
-      # Coverage: publish the per-leg power_report.json produced by the
-      # tt_power_sidecar wrap for offline power analysis. WH-LB only.
-      - name: Upload power report
-        if: ${{ !cancelled() && startsWith(matrix.test-group.sku, 'wh_llmbox') }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: power-report-${{ matrix.test-group.name }}
-          path: ${{ github.workspace }}/docker-job/power_report.json
-          if-no-files-found: warn
-          retention-days: 30
 
       - name: 📊 CCache Report
         if: ${{ !cancelled() && contains(matrix.test-group.sku, 'wh_llmbox') }}

--- a/.github/workflows/fabric-sanity-tests-impl.yaml
+++ b/.github/workflows/fabric-sanity-tests-impl.yaml
@@ -82,13 +82,19 @@ jobs:
     # Coverage: bind the mainline GH environment on main so the fabric BW /
     # latency SFTP upload secrets below are available.
     environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
+    env:
+      # Derive ARCH_NAME from the SKU prefix so testlist entries don't have to
+      # author it. Fabric SKUs are wh_* -> wormhole_b0, bh_* -> blackhole; empty
+      # fallback trips the -z guard in run_cpp_fabric_tests.sh / run_t3000_unit_tests.sh
+      # for any unrecognized SKU.
+      DERIVED_ARCH: ${{ startsWith(matrix.test-group.sku, 'wh_') && 'wormhole_b0' || (startsWith(matrix.test-group.sku, 'bh_') && 'blackhole' || '') }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         TT_METAL_HOME: /work
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
-        ARCH_NAME: ${{ matrix.test-group.arch }}
+        ARCH_NAME: ${{ env.DERIVED_ARCH }}
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/
         # Coverage: enable TTNN program-arg validation on every sanity leg. Trivial
@@ -175,7 +181,7 @@ jobs:
         uses: ./docker-job/.github/actions/check-latency-bw-results
         with:
           path: /work
-          arch: ${{ matrix.test-group.arch }}
+          arch: ${{ env.DERIVED_ARCH }}
           check_bw: ${{ github.ref_name == 'main' }}
           check_latency: ${{ github.ref_name == 'main' }}
       - name: Upload benchmark data

--- a/.github/workflows/fabric-sanity-tests-impl.yaml
+++ b/.github/workflows/fabric-sanity-tests-impl.yaml
@@ -82,19 +82,17 @@ jobs:
     # Coverage: bind the mainline GH environment on main so the fabric BW /
     # latency SFTP upload secrets below are available.
     environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
-    env:
-      # Derive ARCH_NAME from the SKU prefix so testlist entries don't have to
-      # author it. Fabric SKUs are wh_* -> wormhole_b0, bh_* -> blackhole; empty
-      # fallback trips the -z guard in run_cpp_fabric_tests.sh / run_t3000_unit_tests.sh
-      # for any unrecognized SKU.
-      DERIVED_ARCH: ${{ startsWith(matrix.test-group.sku, 'wh_') && 'wormhole_b0' || (startsWith(matrix.test-group.sku, 'bh_') && 'blackhole' || '') }}
+    # ARCH_NAME is derived inline from matrix.test-group.sku:
+    # bh_* / *blackhole* -> blackhole; wh_* / *wormhole* -> wormhole_b0; else '' so
+    # run_cpp_fabric_tests.sh / run_t3000_unit_tests.sh trip their -z guards on
+    # unrecognized SKUs.
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         TT_METAL_HOME: /work
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
-        ARCH_NAME: ${{ env.DERIVED_ARCH }}
+        ARCH_NAME: ${{ (contains(matrix.test-group.sku, 'bh_') || contains(matrix.test-group.sku, 'blackhole')) && 'blackhole' || (contains(matrix.test-group.sku, 'wh_') || contains(matrix.test-group.sku, 'wormhole')) && 'wormhole_b0' || '' }}
         LOGURU_LEVEL: INFO
         GTEST_OUTPUT: xml:/work/generated/test_reports/
         # Coverage: enable TTNN program-arg validation on every sanity leg. Trivial
@@ -181,7 +179,7 @@ jobs:
         uses: ./docker-job/.github/actions/check-latency-bw-results
         with:
           path: /work
-          arch: ${{ env.DERIVED_ARCH }}
+          arch: ${{ (contains(matrix.test-group.sku, 'bh_') || contains(matrix.test-group.sku, 'blackhole')) && 'blackhole' || (contains(matrix.test-group.sku, 'wh_') || contains(matrix.test-group.sku, 'wormhole')) && 'wormhole_b0' || '' }}
           check_bw: ${{ github.ref_name == 'main' }}
           check_latency: ${{ github.ref_name == 'main' }}
       - name: Upload benchmark data

--- a/.github/workflows/fabric-sanity-tests-impl.yaml
+++ b/.github/workflows/fabric-sanity-tests-impl.yaml
@@ -1,13 +1,13 @@
-name: "[internal] TM Fabric tests"
+name: "[internal] Fabric sanity tests impl"
 
-# Runs the consolidated fabric hardware test matrix from
-# tests/pipeline_reorg/fabric_tests.yaml. CPU-only fabric unit tests are handled
-# by a sibling call to fabric-cpu-only-tests-impl.yaml (already testlist-driven,
-# uses cpu_medium runners and no hardware).
+# Runs the fabric sanity bucket from tests/pipeline_reorg/fabric_sanity_tests.yaml.
+# Called from sanity-tests.yaml. Single source of truth for fabric coverage in
+# the sanity pipeline: WH N300 smoke, T3K llmbox, and BH card smoke.
 #
-# Coverage-preservation hooks live in this file (not in the entry cmd) — search
-# for the "Coverage:" comments below when adding new SKUs / entries.
-# FIXMEs: UC review coverage comments
+# Coverage-preservation hooks are conditional on SKU / entry flags — search for
+# "Coverage:" below. Mirrors the pattern in tm-fabric-tests-impl.yaml so
+# wh_llmbox_civ2 legs get power sidecar / kernel ccache / --memory 256g /
+# fabric BW SFTP upload.
 
 on:
   workflow_call:
@@ -21,55 +21,38 @@ on:
       wheel-artifact-name:
         required: true
         type: string
+      enabled-skus:
+        required: true
+        type: string
+        description: "Comma-separated SKUs (see .github/sku_config.yaml)."
       enable-watcher:
         required: false
         type: boolean
         default: false
-      run-fabric-cpu-only-unit-tests:
+      timeout-minutes-override:
         required: false
-        type: boolean
-        default: false
-        description: "Run CPU-only fabric unit tests via fabric-cpu-only-tests-impl.yaml"
-      run-fabric-hw-tests:
-        required: false
-        type: boolean
-        default: true
-        description: "Run the hardware fabric matrix from fabric_tests.yaml"
-      enabled-skus:
-        required: false
-        type: string
-        default: ALL_SKUS_IN_TESTS
-        description: "Comma-separated SKUs (from sku_config.yaml), or ALL_SKUS_IN_TESTS."
-      test-names:
+        type: number
+        default: 0
+        description: "When > 0, overrides each test's per-SKU timeout (used for watcher runs)."
+      ref:
         required: false
         type: string
         default: ""
-        description: "Comma-separated entry names from fabric_tests.yaml to run (default: all)."
+        description: "Commit SHA to test (default: HEAD)"
 
 jobs:
-  # CPU-only fabric unit tests (no hardware); runs in parallel on a single CPU runner.
-  fabric-cpu-only-unit-tests:
-    if: ${{ inputs.run-fabric-cpu-only-unit-tests }}
-    secrets: inherit
-    uses: ./.github/workflows/fabric-cpu-only-tests-impl.yaml
-    with:
-      runs-on-sku: cpu_medium
-      docker-image: ${{ inputs.docker-image }}
-      build-artifact-name: ${{ inputs.build-artifact-name }}
-      wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-
   load-test-matrix:
-    if: ${{ inputs.run-fabric-hw-tests }}
     runs-on: ubuntu-slim
     outputs:
-      matrix: ${{ steps.filter-matrix.outputs.matrix }}
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
     env:
-      TESTS_YAML_PATH: ./tests/pipeline_reorg/fabric_tests.yaml
+      TESTS_YAML_PATH: ./tests/pipeline_reorg/fabric_sanity_tests.yaml
     steps:
       - name: Checkout the repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
+          ref: ${{ inputs.ref || github.sha }}
           sparse-checkout: |
             .github
             tests/pipeline_reorg
@@ -82,7 +65,7 @@ jobs:
           python3 .github/scripts/utils/verify_time_budget.py \
             ${{ env.TESTS_YAML_PATH }} \
             ./.github/time_budget.yaml \
-            "unit"
+            "sanity"
       - name: Build test matrix based on enabled SKUs
         id: build-matrix
         run: |
@@ -91,41 +74,17 @@ jobs:
             "${{ inputs.enabled-skus }}" \
             ./.github/sku_config.yaml \
             --event "${{ github.event_name }}"
-      - name: Restrict matrix to requested test names
-        id: filter-matrix
-        env:
-          MATRIX_JSON: ${{ steps.build-matrix.outputs.matrix }}
-          TEST_NAMES: ${{ inputs.test-names }}
-        run: |
-          python3 - <<'PY' >> "$GITHUB_OUTPUT"
-          import json, os, sys
 
-          matrix = json.loads(os.environ["MATRIX_JSON"])
-          names = [n.strip() for n in os.environ["TEST_NAMES"].split(",") if n.strip()]
-          if names:
-              # prepare_test_matrix.py appends " [<sku>]" to each name; match on the base.
-              base = lambda entry: entry["name"].split(" [")[0]
-              unknown = sorted(set(names) - {base(t) for t in matrix})
-              if unknown:
-                  print(f"::error::test-names not present in the matrix: {', '.join(unknown)}")
-                  sys.exit(1)
-              matrix = [t for t in matrix if base(t) in names]
-              print(f"Restricted matrix to: {', '.join(t['name'] for t in matrix)}", file=sys.stderr)
-          print("matrix=" + json.dumps(matrix, separators=(",", ":")))
-          PY
-
-  fabric-tests:
+  fabric-sanity-tests:
     needs: load-test-matrix
     if: ${{ needs.load-test-matrix.outputs.matrix != '[]' }}
     strategy:
-      # Do not fail-fast: keep every leg running so hanging machines are not
-      # left mid-test by a peer failure.
       fail-fast: false
       matrix:
         test-group: ${{ fromJson(needs.load-test-matrix.outputs.matrix) }}
     name: ${{ matrix.test-group.name }}
     runs-on: ${{ matrix.test-group.runs_on }}
-    # Coverage: mainline environment gate mirrors t3000-sanity-tests-impl (for SFTP secrets on main).
+    # Coverage: mainline environment gate — SFTP secrets are only bound on main.
     environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
@@ -135,29 +94,25 @@ jobs:
         LD_LIBRARY_PATH: /work/build/lib
         ARCH_NAME: ${{ matrix.test-group.arch }}
         LOGURU_LEVEL: INFO
-        TT_LOGGER_LEVEL: warn
         GTEST_OUTPUT: xml:/work/generated/test_reports/
-        # Coverage: TTNN_CONFIG_OVERRIDES was set unconditionally in
-        # t3000-sanity-tests-impl. Preserving universally rather than per-SKU;
-        # cost is negligible for non-TTNN entries.
+        # Coverage: mirrors tm-fabric-tests-impl / t3000-sanity-tests-impl.
         TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        # Coverage: viommu runners don't use hugepages (pre-refactor BH matrix
-        # conditionally mounted /dev/hugepages-1G on non-viommu runners).
+        # Coverage: viommu runners skip hugepages.
         - ${{ !contains(join(matrix.test-group.runs_on, ','), 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G' || '/no_hugepages:/no_hugepages' }}
-      # Coverage: --memory 256g for wh_llmbox_civ2 (WH-LB memory cap from
-      # t3000-sanity-tests-impl). Applies via SKU prefix match.
+      # Coverage: --memory 256g for wh_llmbox_civ2 (WH-LB memory cap).
       options: --device /dev/tenstorrent ${{ contains(matrix.test-group.sku, 'wh_llmbox') && '--memory 256g' || '' }}
     defaults:
       run:
         shell: bash
-        working-directory: /work # https://github.com/actions/runner/issues/878
+        working-directory: /work
     steps:
       - name: 🧬 Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 20
         with:
+          ref: ${{ inputs.ref || github.sha }}
           submodules: recursive
           path: docker-job
       - name: ⬇️  Setup Job
@@ -167,28 +122,21 @@ jobs:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
           enable-watcher: ${{ inputs.enable-watcher || false }}
-          # Coverage: auto_triage:false in entry disables hang-detection env var
-          # (see setup-job action) — used by 6U multi-process where MPI causes
-          # false positives.
-          auto-triage: ${{ matrix.test-group.auto_triage != false }}
-          # Coverage: kernel ccache + Redis was enabled in t3000-sanity-tests-impl
-          # for wh_llmbox_civ2 legs. Gated on the SKU prefix; other SKUs skip the
-          # ccache setup entirely.
+          # Coverage: kernel ccache for wh_llmbox_civ2 legs (mirrors t3000-sanity-tests-impl).
           enable-kernel-ccache: ${{ contains(matrix.test-group.sku, 'wh_llmbox') }}
           redis-ccache-storage: ${{ contains(matrix.test-group.sku, 'wh_llmbox') && format('redis://{0}:{1}@{2}:{3}{4}', vars.REDIS_CCACHE_USER, secrets.REDIS_CCACHE_PASSWORD, vars.REDIS_CCACHE_HOST, vars.REDIS_CCACHE_PORT, vars.REDIS_CCACHE_IS_READONLY == 'true' && '|read-only=true' || '') || '' }}
 
-      # Coverage: ensure-bh-links-online pre-step for every BH leg (matches the
-      # per-BH-runner behaviour in the pre-refactor bh-multi-card-unit-tests matrix).
+      # Coverage: BH health-check pre-step matches the tm-fabric-tests BH matrix.
       - name: Ensure BH links online
         if: ${{ startsWith(matrix.test-group.sku, 'bh_') }}
         uses: ./docker-job/.github/actions/ensure-bh-links-online
         timeout-minutes: 10
 
       - name: ${{ matrix.test-group.name }}
-        timeout-minutes: ${{ matrix.test-group.timeout }}
+        timeout-minutes: ${{ inputs.timeout-minutes-override > 0 && inputs.timeout-minutes-override || matrix.test-group.timeout }}
         env:
-          # Coverage: power sidecar wraps every leg's cmd on wh_llmbox_civ2
-          # (matches t3000-sanity-tests-impl). Other SKUs run the raw cmd.
+          # Coverage: wrap cmd in power sidecar on wh_llmbox_civ2 (matches
+          # t3000-sanity-tests-impl); other SKUs run the raw cmd.
           _TEST_CMD: ${{ matrix.test-group.cmd }}
         run: |
           mkdir -p generated/test_reports
@@ -201,13 +149,12 @@ jobs:
             bash -c "$_TEST_CMD"
           fi
 
-      # Coverage: BH debug dump on failure (pre-refactor bh-multi-card-unit-tests).
       - name: Print tt-smi data on failure
         if: ${{ failure() && startsWith(matrix.test-group.sku, 'bh_') }}
         run: |
           tt-smi -s
 
-      # Coverage: per-job power report (t3000-sanity-tests-impl pattern), wh_llmbox only.
+      # Coverage: power sidecar report artifact (wh_llmbox only).
       - name: Upload power report
         if: ${{ !cancelled() && startsWith(matrix.test-group.sku, 'wh_llmbox') }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -233,9 +180,7 @@ jobs:
           fi
 
       # Coverage: fabric BW/latency SFTP upload for entries flagged
-      # `upload_benchmarks: true` (t3k fabric + 6u fabric quick + fabric BW perf).
-      # Uses the same check-latency-bw-results action that both t3000-sanity-tests-impl
-      # and the pre-refactor 6U inline job used.
+      # `upload_benchmarks: true` (t3k_fabric_tests). Mirrors t3000-sanity-tests-impl.
       - name: Check for benchmark and latency data
         id: check-data
         if: ${{ !cancelled() && github.ref_name == 'main' && matrix.test-group.upload_benchmarks == true }}

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -389,7 +389,6 @@ jobs:
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
-      timeout-minutes-override: ${{ inputs.enable-watcher && 80 || 0 }}
       ref: ${{ inputs.ref || github.sha }}
 
   # Ops sanity (Wormhole + Blackhole via ops_sanity_tests.yaml)

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -57,7 +57,7 @@ on:
         required: false
         type: boolean
         default: true
-        description: "Run fabric sanity tests (WH N300 + BH card smoke)"
+        description: "Run fabric sanity tests"
       run-ops-sanity-tests:
         required: false
         type: boolean

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -53,6 +53,11 @@ on:
         type: boolean
         default: true
         description: "Run T3000 sanity tests"
+      run-fabric-sanity-tests:
+        required: false
+        type: boolean
+        default: true
+        description: "Run fabric sanity tests (WH N300 + BH card smoke)"
       run-ops-sanity-tests:
         required: false
         type: boolean
@@ -152,6 +157,11 @@ on:
         default: true
         type: boolean
         description: "Run T3000 sanity tests"
+      run-fabric-sanity-tests:
+        required: false
+        default: true
+        type: boolean
+        description: "Run fabric sanity tests (WH N300 + BH card smoke)"
       run-ops-sanity-tests:
         required: false
         default: true
@@ -360,6 +370,25 @@ jobs:
       enable-watcher: ${{ inputs.enable-watcher || false }}
       enable-lightweight-kernel-asserts: ${{ inputs.enable-lightweight-kernel-asserts || false }}
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
+      timeout-minutes-override: ${{ inputs.enable-watcher && 80 || 0 }}
+      ref: ${{ inputs.ref || github.sha }}
+
+  # Fabric sanity (WH N300 + T3K llmbox + BH card smoke via fabric_sanity_tests.yaml).
+  # Single source of truth for fabric coverage in the sanity pipeline.
+  # generate-sku-matrix.sanity-skus only carries wh_n300_civ2 + BH SKUs.
+  # `wh_llmbox_civ2` is appended when run-wormhole is on so t3k fabric tests runs
+  # here
+  fabric-sanity-tests:
+    if: ${{ always() && !cancelled() && needs.build-artifact.result == 'success' && (needs.generate-sku-matrix.outputs.run-wormhole == 'true' || needs.generate-sku-matrix.outputs.run-blackhole == 'true') && toJSON(inputs.run-fabric-sanity-tests) != 'false' }}
+    needs: [build-artifact, generate-sku-matrix]
+    secrets: inherit
+    uses: ./.github/workflows/fabric-sanity-tests-impl.yaml
+    with:
+      enabled-skus: ${{ format('{0}{1}', needs.generate-sku-matrix.outputs.sanity-skus, needs.generate-sku-matrix.outputs.run-wormhole == 'true' && ',wh_llmbox_civ2' || '') }}
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
+      enable-watcher: ${{ inputs.enable-watcher || false }}
       timeout-minutes-override: ${{ inputs.enable-watcher && 80 || 0 }}
       ref: ${{ inputs.ref || github.sha }}
 

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -373,11 +373,8 @@ jobs:
       timeout-minutes-override: ${{ inputs.enable-watcher && 80 || 0 }}
       ref: ${{ inputs.ref || github.sha }}
 
-  # Fabric sanity (WH N300 + T3K llmbox + BH card smoke via fabric_sanity_tests.yaml).
+  # Fabric sanity (via fabric_sanity_tests.yaml).
   # Single source of truth for fabric coverage in the sanity pipeline.
-  # generate-sku-matrix.sanity-skus only carries wh_n300_civ2 + BH SKUs.
-  # `wh_llmbox_civ2` is appended when run-wormhole is on so t3k fabric tests runs
-  # here
   fabric-sanity-tests:
     if: ${{ always() && !cancelled() && needs.build-artifact.result == 'success' && (needs.generate-sku-matrix.outputs.run-wormhole == 'true' || needs.generate-sku-matrix.outputs.run-blackhole == 'true') && toJSON(inputs.run-fabric-sanity-tests) != 'false' }}
     needs: [build-artifact, generate-sku-matrix]

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -125,19 +125,17 @@ jobs:
     # Coverage: bind the mainline GH environment on main so the fabric BW /
     # latency SFTP upload secrets below are available.
     environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
-    env:
-      # Derive ARCH_NAME from the SKU prefix so testlist entries don't have to
-      # author it. Fabric SKUs are wh_* -> wormhole_b0, bh_* -> blackhole; empty
-      # fallback trips the -z guard in run_cpp_fabric_tests.sh / run_t3000_unit_tests.sh
-      # for any unrecognized SKU.
-      DERIVED_ARCH: ${{ startsWith(matrix.test-group.sku, 'wh_') && 'wormhole_b0' || (startsWith(matrix.test-group.sku, 'bh_') && 'blackhole' || '') }}
+    # ARCH_NAME is derived inline from matrix.test-group.sku:
+    # bh_* / *blackhole* -> blackhole; wh_* / *wormhole* -> wormhole_b0; else '' so
+    # run_cpp_fabric_tests.sh / run_t3000_unit_tests.sh trip their -z guards on
+    # unrecognized SKUs.
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         TT_METAL_HOME: /work
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
-        ARCH_NAME: ${{ env.DERIVED_ARCH }}
+        ARCH_NAME: ${{ (contains(matrix.test-group.sku, 'bh_') || contains(matrix.test-group.sku, 'blackhole')) && 'blackhole' || (contains(matrix.test-group.sku, 'wh_') || contains(matrix.test-group.sku, 'wormhole')) && 'wormhole_b0' || '' }}
         LOGURU_LEVEL: INFO
         TT_LOGGER_LEVEL: warn
         GTEST_OUTPUT: xml:/work/generated/test_reports/
@@ -231,7 +229,7 @@ jobs:
         uses: ./docker-job/.github/actions/check-latency-bw-results
         with:
           path: /work
-          arch: ${{ env.DERIVED_ARCH }}
+          arch: ${{ (contains(matrix.test-group.sku, 'bh_') || contains(matrix.test-group.sku, 'blackhole')) && 'blackhole' || (contains(matrix.test-group.sku, 'wh_') || contains(matrix.test-group.sku, 'wormhole')) && 'wormhole_b0' || '' }}
           check_bw: ${{ github.ref_name == 'main' }}
           check_latency: ${{ github.ref_name == 'main' }}
       - name: Upload benchmark data

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -128,13 +128,19 @@ jobs:
     # Coverage: bind the mainline GH environment on main so the fabric BW /
     # latency SFTP upload secrets below are available.
     environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
+    env:
+      # Derive ARCH_NAME from the SKU prefix so testlist entries don't have to
+      # author it. Fabric SKUs are wh_* -> wormhole_b0, bh_* -> blackhole; empty
+      # fallback trips the -z guard in run_cpp_fabric_tests.sh / run_t3000_unit_tests.sh
+      # for any unrecognized SKU.
+      DERIVED_ARCH: ${{ startsWith(matrix.test-group.sku, 'wh_') && 'wormhole_b0' || (startsWith(matrix.test-group.sku, 'bh_') && 'blackhole' || '') }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         TT_METAL_HOME: /work
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
-        ARCH_NAME: ${{ matrix.test-group.arch }}
+        ARCH_NAME: ${{ env.DERIVED_ARCH }}
         LOGURU_LEVEL: INFO
         TT_LOGGER_LEVEL: warn
         GTEST_OUTPUT: xml:/work/generated/test_reports/
@@ -228,7 +234,7 @@ jobs:
         uses: ./docker-job/.github/actions/check-latency-bw-results
         with:
           path: /work
-          arch: ${{ matrix.test-group.arch }}
+          arch: ${{ env.DERIVED_ARCH }}
           check_bw: ${{ github.ref_name == 'main' }}
           check_latency: ${{ github.ref_name == 'main' }}
       - name: Upload benchmark data

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -188,20 +188,14 @@ jobs:
 
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        env:
-          # Coverage: on WH-LB, wrap the cmd in tt_power_sidecar.py to sample SoC
-          # power for the downstream power dashboard. Other SKUs run the raw cmd.
-          _TEST_CMD: ${{ matrix.test-group.cmd }}
         run: |
-          mkdir -p generated/test_reports
-          if [[ "${{ matrix.test-group.sku }}" == wh_llmbox* ]]; then
-            python3 tools/tt-power-sidecar/tt_power_sidecar.py \
-              --backend sysfs \
-              --out /work/power_report.json \
-              -- bash -c "$_TEST_CMD"
-          else
-            bash -c "$_TEST_CMD"
-          fi
+          mkdir -p generated/test_reports generated/test_logs
+          SAFE_NAME=$(echo "${{ matrix.test-group.name }}" | tr ' /' '__')
+          LOG_FILE="generated/test_logs/${SAFE_NAME}_${{ job.check_run_id }}.log"
+          {
+            ${{ matrix.test-group.cmd }}
+          } 2>&1 | tee "$LOG_FILE"
+          exit "${PIPESTATUS[0]}"
 
       # Coverage: dump tt-smi state after a BH failure so triage has chip
       # health / thermals / link status without needing a repro.
@@ -209,17 +203,6 @@ jobs:
         if: ${{ failure() && startsWith(matrix.test-group.sku, 'bh_') }}
         run: |
           tt-smi -s
-
-      # Coverage: publish the per-leg power_report.json produced by the
-      # tt_power_sidecar wrap for offline power analysis. WH-LB only.
-      - name: Upload power report
-        if: ${{ !cancelled() && startsWith(matrix.test-group.sku, 'wh_llmbox') }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: power-report-${{ matrix.test-group.name }}
-          path: ${{ github.workspace }}/docker-job/power_report.json
-          if-no-files-found: warn
-          retention-days: 30
 
       - name: 📊 CCache Report
         if: ${{ !cancelled() && contains(matrix.test-group.sku, 'wh_llmbox') }}

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -93,15 +93,12 @@ jobs:
             --event "${{ github.event_name }}"
       - name: Restrict matrix to requested test names
         id: filter-matrix
-        env:
-          MATRIX_JSON: ${{ steps.build-matrix.outputs.matrix }}
-          TEST_NAMES: ${{ inputs.test-names }}
         run: |
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
-          import json, os, sys
+          import json, sys
 
-          matrix = json.loads(os.environ["MATRIX_JSON"])
-          names = [n.strip() for n in os.environ["TEST_NAMES"].split(",") if n.strip()]
+          matrix = json.loads(r"""${{ steps.build-matrix.outputs.matrix }}""")
+          names = [n.strip() for n in r"""${{ inputs.test-names }}""".split(",") if n.strip()]
           if names:
               # prepare_test_matrix.py appends " [<sku>]" to each name; match on the base.
               base = lambda entry: entry["name"].split(" [")[0]

--- a/.github/workflows/tm-fabric-tests-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-impl.yaml
@@ -5,9 +5,9 @@ name: "[internal] TM Fabric tests"
 # by a sibling call to fabric-cpu-only-tests-impl.yaml (already testlist-driven,
 # uses cpu_medium runners and no hardware).
 #
-# Coverage-preservation hooks live in this file (not in the entry cmd) — search
-# for the "Coverage:" comments below when adding new SKUs / entries.
-# FIXMEs: UC review coverage comments
+# SKU- and entry-conditional infra hooks live in this file (not in the entry
+# cmd) — grep the "Coverage:" comments below when adding a new SKU or entry
+# to check what already applies to your leg.
 
 on:
   workflow_call:
@@ -125,7 +125,8 @@ jobs:
         test-group: ${{ fromJson(needs.load-test-matrix.outputs.matrix) }}
     name: ${{ matrix.test-group.name }}
     runs-on: ${{ matrix.test-group.runs_on }}
-    # Coverage: mainline environment gate mirrors t3000-sanity-tests-impl (for SFTP secrets on main).
+    # Coverage: bind the mainline GH environment on main so the fabric BW /
+    # latency SFTP upload secrets below are available.
     environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
     container:
       image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
@@ -137,17 +138,17 @@ jobs:
         LOGURU_LEVEL: INFO
         TT_LOGGER_LEVEL: warn
         GTEST_OUTPUT: xml:/work/generated/test_reports/
-        # Coverage: TTNN_CONFIG_OVERRIDES was set unconditionally in
-        # t3000-sanity-tests-impl. Preserving universally rather than per-SKU;
-        # cost is negligible for non-TTNN entries.
+        # Coverage: enable TTNN program-arg validation on every fabric leg. Trivial
+        # cost on non-TTNN entries; set universally rather than per-SKU.
         TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
-        # Coverage: viommu runners don't use hugepages (pre-refactor BH matrix
-        # conditionally mounted /dev/hugepages-1G on non-viommu runners).
+        # Coverage: mount /dev/hugepages-1G on non-viommu runners only. Viommu SKUs
+        # (e.g. bh_p300, bh_p150b_civ2_viommu) bypass the hugepages path and must
+        # not have the mount.
         - ${{ !contains(join(matrix.test-group.runs_on, ','), 'viommu') && '/dev/hugepages-1G:/dev/hugepages-1G' || '/no_hugepages:/no_hugepages' }}
-      # Coverage: --memory 256g for wh_llmbox_civ2 (WH-LB memory cap from
-      # t3000-sanity-tests-impl). Applies via SKU prefix match.
+      # Coverage: cap container memory to 256 GiB on WH-LB (wh_llmbox*) to keep
+      # T3K legs from ballooning host memory. Other SKUs use the container default.
       options: --device /dev/tenstorrent ${{ contains(matrix.test-group.sku, 'wh_llmbox') && '--memory 256g' || '' }}
     defaults:
       run:
@@ -167,18 +168,19 @@ jobs:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
           enable-watcher: ${{ inputs.enable-watcher || false }}
-          # Coverage: auto_triage:false in entry disables hang-detection env var
-          # (see setup-job action) — used by 6U multi-process where MPI causes
-          # false positives.
+          # Coverage: pass the entry's `auto_triage` flag to setup-job. Legs that
+          # coordinate over MPI (e.g. `6U multi-process` via tt-run) must set
+          # `auto_triage: false` because MPI blocking triggers false-positive
+          # dispatcher-hang detections.
           auto-triage: ${{ matrix.test-group.auto_triage != false }}
-          # Coverage: kernel ccache + Redis was enabled in t3000-sanity-tests-impl
-          # for wh_llmbox_civ2 legs. Gated on the SKU prefix; other SKUs skip the
-          # ccache setup entirely.
+          # Coverage: enable runtime kernel ccache (Redis-backed) on WH-LB legs
+          # where JIT compile amortizes across the run. Other SKUs skip ccache
+          # setup entirely; the Redis storage string only resolves on WH-LB.
           enable-kernel-ccache: ${{ contains(matrix.test-group.sku, 'wh_llmbox') }}
           redis-ccache-storage: ${{ contains(matrix.test-group.sku, 'wh_llmbox') && format('redis://{0}:{1}@{2}:{3}{4}', vars.REDIS_CCACHE_USER, secrets.REDIS_CCACHE_PASSWORD, vars.REDIS_CCACHE_HOST, vars.REDIS_CCACHE_PORT, vars.REDIS_CCACHE_IS_READONLY == 'true' && '|read-only=true' || '') || '' }}
 
-      # Coverage: ensure-bh-links-online pre-step for every BH leg (matches the
-      # per-BH-runner behaviour in the pre-refactor bh-multi-card-unit-tests matrix).
+      # Coverage: Run the smi-reset + system-health loop before every BH leg
+      # to ensure the links are online.
       - name: Ensure BH links online
         if: ${{ startsWith(matrix.test-group.sku, 'bh_') }}
         uses: ./docker-job/.github/actions/ensure-bh-links-online
@@ -187,8 +189,8 @@ jobs:
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         env:
-          # Coverage: power sidecar wraps every leg's cmd on wh_llmbox_civ2
-          # (matches t3000-sanity-tests-impl). Other SKUs run the raw cmd.
+          # Coverage: on WH-LB, wrap the cmd in tt_power_sidecar.py to sample SoC
+          # power for the downstream power dashboard. Other SKUs run the raw cmd.
           _TEST_CMD: ${{ matrix.test-group.cmd }}
         run: |
           mkdir -p generated/test_reports
@@ -201,13 +203,15 @@ jobs:
             bash -c "$_TEST_CMD"
           fi
 
-      # Coverage: BH debug dump on failure (pre-refactor bh-multi-card-unit-tests).
+      # Coverage: dump tt-smi state after a BH failure so triage has chip
+      # health / thermals / link status without needing a repro.
       - name: Print tt-smi data on failure
         if: ${{ failure() && startsWith(matrix.test-group.sku, 'bh_') }}
         run: |
           tt-smi -s
 
-      # Coverage: per-job power report (t3000-sanity-tests-impl pattern), wh_llmbox only.
+      # Coverage: publish the per-leg power_report.json produced by the
+      # tt_power_sidecar wrap for offline power analysis. WH-LB only.
       - name: Upload power report
         if: ${{ !cancelled() && startsWith(matrix.test-group.sku, 'wh_llmbox') }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -232,10 +236,9 @@ jobs:
             echo '```' >> $GITHUB_STEP_SUMMARY
           fi
 
-      # Coverage: fabric BW/latency SFTP upload for entries flagged
-      # `upload_benchmarks: true` (t3k fabric + 6u fabric quick + fabric BW perf).
-      # Uses the same check-latency-bw-results action that both t3000-sanity-tests-impl
-      # and the pre-refactor 6U inline job used.
+      # Coverage: entries that emit fabric BW / latency CSVs opt in via
+      # `upload_benchmarks: true`. On main, check for the generated files
+      # and SFTP them to the perf dashboard.
       - name: Check for benchmark and latency data
         id: check-data
         if: ${{ !cancelled() && github.ref_name == 'main' && matrix.test-group.upload_benchmarks == true }}

--- a/.github/workflows/tm-fabric-tests-perf-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-perf-impl.yaml
@@ -97,13 +97,19 @@ jobs:
     # Coverage: bind the mainline GH environment on main so the fabric BW /
     # latency SFTP upload secrets below are available.
     environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
+    env:
+      # Derive ARCH_NAME from the SKU prefix so testlist entries don't have to
+      # author it. Fabric perf SKUs are wh_* -> wormhole_b0, bh_* -> blackhole;
+      # empty fallback trips the -z guard in run_cpp_fabric_tests.sh /
+      # run_t3000_unit_tests.sh for any unrecognized SKU.
+      DERIVED_ARCH: ${{ startsWith(matrix.test-group.sku, 'wh_') && 'wormhole_b0' || (startsWith(matrix.test-group.sku, 'bh_') && 'blackhole' || '') }}
     container:
       image: ${{ inputs.docker-image }}
       env:
         TT_METAL_HOME: /work
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
-        ARCH_NAME: ${{ matrix.test-group.arch }}
+        ARCH_NAME: ${{ env.DERIVED_ARCH }}
         LOGURU_LEVEL: INFO
         # Coverage: perf legs default to profiler ON so Tracy captures timing.
         # Entries whose BW golden is calibrated against uninstrumented routers
@@ -159,7 +165,7 @@ jobs:
         uses: ./docker-job/.github/actions/check-latency-bw-results
         with:
           path: /work
-          arch: ${{ matrix.test-group.arch }}
+          arch: ${{ env.DERIVED_ARCH }}
           check_bw: ${{ github.ref_name == 'main' }}
           check_latency: ${{ github.ref_name == 'main' }}
       - name: Upload benchmark data

--- a/.github/workflows/tm-fabric-tests-perf-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-perf-impl.yaml
@@ -63,15 +63,12 @@ jobs:
             --event "${{ github.event_name }}"
       - name: Restrict matrix to requested test names
         id: filter-matrix
-        env:
-          MATRIX_JSON: ${{ steps.build-matrix.outputs.matrix }}
-          TEST_NAMES: ${{ inputs.test-names }}
         run: |
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
-          import json, os, sys
+          import json, sys
 
-          matrix = json.loads(os.environ["MATRIX_JSON"])
-          names = [n.strip() for n in os.environ["TEST_NAMES"].split(",") if n.strip()]
+          matrix = json.loads(r"""${{ steps.build-matrix.outputs.matrix }}""")
+          names = [n.strip() for n in r"""${{ inputs.test-names }}""".split(",") if n.strip()]
           if names:
               base = lambda entry: entry["name"].split(" [")[0]
               unknown = sorted(set(names) - {base(t) for t in matrix})

--- a/.github/workflows/tm-fabric-tests-perf-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-perf-impl.yaml
@@ -1,8 +1,9 @@
 name: "[internal] TM Fabric Perf Tests"
 
 # Runs the fabric perf matrix from tests/pipeline_reorg/fabric_perf_tests.yaml.
-# T3K microbenchmarks — same profiler / SFTP semantics as the pre-refactor inline
-# matrix. Entries opt into benchmark data SFTP upload via `upload_benchmarks: true`.
+# T3K microbenchmarks with profiler on by default (see the TT_METAL_DEVICE_PROFILER
+# Coverage comment below). Entries opt into fabric BW / latency SFTP upload via
+# `upload_benchmarks: true`.
 
 on:
   workflow_call:
@@ -93,7 +94,8 @@ jobs:
         test-group: ${{ fromJson(needs.load-test-matrix.outputs.matrix) }}
     name: ${{ matrix.test-group.name }}
     runs-on: ${{ matrix.test-group.runs_on }}
-    # Coverage: mainline environment gate — SFTP secrets are only bound on main.
+    # Coverage: bind the mainline GH environment on main so the fabric BW /
+    # latency SFTP upload secrets below are available.
     environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
     container:
       image: ${{ inputs.docker-image }}
@@ -103,8 +105,9 @@ jobs:
         LD_LIBRARY_PATH: /work/build/lib
         ARCH_NAME: ${{ matrix.test-group.arch }}
         LOGURU_LEVEL: INFO
-        # Coverage: profiler defaults — entries that need it off (BW golden calibration)
-        # prepend TT_METAL_DEVICE_PROFILER=0 to their cmd (see fabric_perf_tests.yaml).
+        # Coverage: perf legs default to profiler ON so Tracy captures timing.
+        # Entries whose BW golden is calibrated against uninstrumented routers
+        # must prepend TT_METAL_DEVICE_PROFILER=0 to their cmd (see fabric_perf_tests.yaml).
         TT_METAL_DEVICE_PROFILER: 1
         TRACY_NO_INVARIANT_CHECK: 1
       volumes:
@@ -131,8 +134,9 @@ jobs:
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
         run: ${{ matrix.test-group.cmd }}
-      # Coverage: microbenchmark CSV artifact upload — distinct from the generic
-      # test_reports_ artifact; downstream perf tooling ingests these.
+      # Coverage: upload the microbenchmark CSVs produced under
+      # /work/generated/profiler/.logs. Distinct from the generic test_reports_
+      # artifact; downstream perf tooling ingests these.
       - name: Upload microbenchmark report csvs
         uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
@@ -146,9 +150,9 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      # Coverage: fabric BW SFTP upload — gate switched from name-based
-      # (contains(name, 'Fabric BW')) to a `upload_benchmarks: true` flag on
-      # the entry (see fabric_perf_tests.yaml).
+      # Coverage: entries that emit fabric BW / latency CSVs opt in via
+      # `upload_benchmarks: true` (see fabric_perf_tests.yaml). On main,
+      # check for the generated files and SFTP them to the perf dashboard.
       - name: Check for benchmark and latency data
         id: check-data
         if: ${{ !cancelled() && github.ref_name == 'main' && matrix.test-group.upload_benchmarks == true }}

--- a/.github/workflows/tm-fabric-tests-perf-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-perf-impl.yaml
@@ -1,5 +1,9 @@
 name: "[internal] TM Fabric Perf Tests"
 
+# Runs the fabric perf matrix from tests/pipeline_reorg/fabric_perf_tests.yaml.
+# T3K microbenchmarks — same profiler / SFTP semantics as the pre-refactor inline
+# matrix. Entries opt into benchmark data SFTP upload via `upload_benchmarks: true`.
+
 on:
   workflow_call:
     inputs:
@@ -12,79 +16,85 @@ on:
       docker-image:
         required: true
         type: string
-      run-perf-fabric-bw:
+      enabled-skus:
         required: false
-        type: boolean
-        default: true
-        description: "Run T3K ubench - Fabric BW performance test"
-      run-perf-fabric-mux-bw:
+        type: string
+        default: ALL_SKUS_IN_TESTS
+        description: "Comma-separated SKUs (from sku_config.yaml), or ALL_SKUS_IN_TESTS."
+      test-names:
         required: false
-        type: boolean
-        default: true
-        description: "Run T3K ubench - Fabric Mux BW performance test"
-      run-perf-fabric-mux-v2-throughput:
-        required: false
-        type: boolean
-        default: true
-        description: "Run T3K ubench - Fabric Mux V2 Throughput performance test"
+        type: string
+        default: ""
+        description: "Comma-separated entry names from fabric_perf_tests.yaml to run (default: all)."
 
 jobs:
-  generate-matrix:
+  load-test-matrix:
     runs-on: ubuntu-slim
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      matrix: ${{ steps.filter-matrix.outputs.matrix }}
+    env:
+      TESTS_YAML_PATH: ./tests/pipeline_reorg/fabric_perf_tests.yaml
     steps:
-      - id: set-matrix
-        shell: bash
+      - name: Checkout the repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 20
+        with:
+          sparse-checkout: |
+            .github
+            tests/pipeline_reorg
+          sparse-checkout-cone-mode: true
+      - name: Install dependencies
+        run: pip3 install PyYAML
+      - name: Verify test timeouts against budget
         run: |
-          matrix_items=()
+          set -e
+          python3 .github/scripts/utils/verify_time_budget.py \
+            ${{ env.TESTS_YAML_PATH }} \
+            ./.github/time_budget.yaml \
+            "perf"
+      - name: Build test matrix based on enabled SKUs
+        id: build-matrix
+        run: |
+          python3 .github/scripts/utils/prepare_test_matrix.py \
+            ${{ env.TESTS_YAML_PATH }} \
+            "${{ inputs.enabled-skus }}" \
+            ./.github/sku_config.yaml \
+            --event "${{ github.event_name }}"
+      - name: Restrict matrix to requested test names
+        id: filter-matrix
+        env:
+          MATRIX_JSON: ${{ steps.build-matrix.outputs.matrix }}
+          TEST_NAMES: ${{ inputs.test-names }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json, os, sys
 
-          # Check which test groups should be included
-          if [[ "${{ inputs.run-perf-fabric-bw }}" == "true" ]]; then
-            # TT_METAL_DEVICE_PROFILER=0 overrides the job-level profiler env for THIS gate only: the BW
-            # golden is calibrated to real (uninstrumented) fabric bandwidth, but the container enables the
-            # device profiler, which JIT-compiles kernels with -DPROFILE_KERNEL=1 and inflates the router
-            # cycle counts (worst on multicast/ring/mesh: 11-18% low) -> systematic golden-comparison failures.
-            # The BW is measured from the fabric router's own always-on telemetry, not Tracy, so disabling the
-            # profiler yields the clean measurement the golden expects. (Mux BW below is also profiler-off for
-            # the same reason -- its golden was recalibrated to the profiler-off measurement in d7bfc04.)
-            matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric BW && Latency","cmd":"TT_METAL_CLEAR_L1=1 TT_METAL_DEVICE_PROFILER=0 ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config ./tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_ubench_at_least_2x2_mesh.yaml"}')
-          fi
+          matrix = json.loads(os.environ["MATRIX_JSON"])
+          names = [n.strip() for n in os.environ["TEST_NAMES"].split(",") if n.strip()]
+          if names:
+              base = lambda entry: entry["name"].split(" [")[0]
+              unknown = sorted(set(names) - {base(t) for t in matrix})
+              if unknown:
+                  print(f"::error::test-names not present in the matrix: {', '.join(unknown)}")
+                  sys.exit(1)
+              matrix = [t for t in matrix if base(t) in names]
+              print(f"Restricted matrix to: {', '.join(t['name'] for t in matrix)}", file=sys.stderr)
+          print("matrix=" + json.dumps(matrix, separators=(",", ":")))
+          PY
 
-          if [[ "${{ inputs.run-perf-fabric-mux-bw }}" == "true" ]]; then
-            matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric Mux BW","cmd":"TT_METAL_DEVICE_PROFILER=0 pytest -svv tests/tt_metal/microbenchmarks/ethernet/test_fabric_mux_bandwidth.py"}')
-          fi
-
-          if [[ "${{ inputs.run-perf-fabric-mux-v2-throughput }}" == "true" ]]; then
-            matrix_items+=('{"arch":"wormhole_b0","runs-on":["arch-wormhole_b0","pipeline-perf","config-t3000","in-service"],"name":"T3K ubench - Fabric Mux V2 Throughput","cmd":"TT_METAL_DEVICE_PROFILER=0 pytest -svv tests/tt_metal/microbenchmarks/ethernet/test_fabric_mux_v2_throughput.py"}')
-          fi
-
-          # If no items selected, fail the job with an error
-          if [ ${#matrix_items[@]} -eq 0 ]; then
-            echo "ERROR: No perf test groups selected. Please enable at least one test group input."
-            exit 1
-          fi
-
-          # Convert array to JSON array format
-          matrix_json="["
-          for i in "${!matrix_items[@]}"; do
-            if [ $i -gt 0 ]; then
-              matrix_json+=","
-            fi
-            matrix_json+="${matrix_items[i]}"
-          done
-          matrix_json+="]"
-
-          echo "matrix=$matrix_json" >> $GITHUB_OUTPUT
-          echo "Generated matrix: $matrix_json"
   fabric-perf-tests:
-    needs: generate-matrix
+    needs: load-test-matrix
+    if: ${{ needs.load-test-matrix.outputs.matrix != '[]' }}
     strategy:
       # Do not fail-fast because we need to ensure all tests go to completion
       # so we try not to get hanging machines
       fail-fast: false
       matrix:
-        test-group: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
+        test-group: ${{ fromJson(needs.load-test-matrix.outputs.matrix) }}
+    name: ${{ matrix.test-group.name }}
+    runs-on: ${{ matrix.test-group.runs_on }}
+    # Coverage: mainline environment gate — SFTP secrets are only bound on main.
+    environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
     container:
       image: ${{ inputs.docker-image }}
       env:
@@ -93,6 +103,8 @@ jobs:
         LD_LIBRARY_PATH: /work/build/lib
         ARCH_NAME: ${{ matrix.test-group.arch }}
         LOGURU_LEVEL: INFO
+        # Coverage: profiler defaults — entries that need it off (BW golden calibration)
+        # prepend TT_METAL_DEVICE_PROFILER=0 to their cmd (see fabric_perf_tests.yaml).
         TT_METAL_DEVICE_PROFILER: 1
         TRACY_NO_INVARIANT_CHECK: 1
       volumes:
@@ -103,8 +115,6 @@ jobs:
       run:
         shell: bash
         working-directory: /work
-    name: ${{ matrix.test-group.name }}
-    runs-on: ${{ matrix.test-group.runs-on }}
     steps:
       - name: 🧬 Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -118,15 +128,17 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
-      - name: Run microbenchmark tests
-        timeout-minutes: 45
+      - name: ${{ matrix.test-group.name }}
+        timeout-minutes: ${{ matrix.test-group.timeout }}
         run: ${{ matrix.test-group.cmd }}
+      # Coverage: microbenchmark CSV artifact upload — distinct from the generic
+      # test_reports_ artifact; downstream perf tooling ingests these.
       - name: Upload microbenchmark report csvs
         uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}
         with:
-          prefix: microbenchmark-report-csv-${{ join(matrix.test-group.name) }}
+          prefix: microbenchmark-report-csv-${{ matrix.test-group.name }}
           path: /work/generated/profiler/.logs
       - name: Upload generated test reports
         uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
@@ -134,21 +146,20 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
-      - name: Check for benchmark data
-        id: check-benchmark-data
-        if: ${{ !cancelled() && github.ref_name == 'main' }}
-        shell: bash
-        run: |
-          if [ -f "generated/fabric/bandwidth_summary_results_wormhole_b0_upload.csv" ]; then
-            echo "has_benchmark_data=true" >> $GITHUB_OUTPUT
-            echo "Benchmark files found, will upload to database"
-          else
-            echo "has_benchmark_data=false" >> $GITHUB_OUTPUT
-            echo "Benchmark files not found, database upload will be skipped"
-          fi
+      # Coverage: fabric BW SFTP upload — gate switched from name-based
+      # (contains(name, 'Fabric BW')) to a `upload_benchmarks: true` flag on
+      # the entry (see fabric_perf_tests.yaml).
+      - name: Check for benchmark and latency data
+        id: check-data
+        if: ${{ !cancelled() && github.ref_name == 'main' && matrix.test-group.upload_benchmarks == true }}
+        uses: ./docker-job/.github/actions/check-latency-bw-results
+        with:
+          path: /work
+          arch: ${{ matrix.test-group.arch }}
+          check_bw: ${{ github.ref_name == 'main' }}
+          check_latency: ${{ github.ref_name == 'main' }}
       - name: Upload benchmark data
-        ## Only upload benchmark data for main branch
-        if: ${{ !cancelled() && github.ref_name == 'main' && contains(matrix.test-group.name, 'Fabric BW') && steps.check-benchmark-data.outputs.has_benchmark_data == 'true' }}
+        if: ${{ !cancelled() && github.ref_name == 'main' && matrix.test-group.upload_benchmarks == true && steps.check-data.outputs.has_benchmark_data == 'true' }}
         uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
         with:
           ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
@@ -156,4 +167,14 @@ jobs:
           username: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_USERNAME }}
           hostname: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_HOSTNAME }}
           path: /work
+      - name: Upload latency data
+        if: ${{ !cancelled() && github.ref_name == 'main' && matrix.test-group.upload_benchmarks == true && steps.check-data.outputs.has_latency_data == 'true' }}
+        uses: tenstorrent/tt-metal/.github/actions/upload-data-via-sftp@main
+        with:
+          ssh-private-key: ${{ secrets.SFTP_BENCHMARK_WRITER_KEY }}
+          sftp-batchfile: /work/.github/actions/upload-data-via-sftp/fabric_latency_benchmark_data_batchfile.txt
+          username: ${{ secrets.SFTP_FABRIC_LATENCY_WRITER_USERNAME }}
+          hostname: ${{ secrets.SFTP_FABRIC_BENCHMARK_WRITER_HOSTNAME }}
+          path: /work
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
+        if: always()

--- a/.github/workflows/tm-fabric-tests-perf-impl.yaml
+++ b/.github/workflows/tm-fabric-tests-perf-impl.yaml
@@ -94,19 +94,17 @@ jobs:
     # Coverage: bind the mainline GH environment on main so the fabric BW /
     # latency SFTP upload secrets below are available.
     environment: ${{ github.ref == 'refs/heads/main' && 'mainline' || '' }}
-    env:
-      # Derive ARCH_NAME from the SKU prefix so testlist entries don't have to
-      # author it. Fabric perf SKUs are wh_* -> wormhole_b0, bh_* -> blackhole;
-      # empty fallback trips the -z guard in run_cpp_fabric_tests.sh /
-      # run_t3000_unit_tests.sh for any unrecognized SKU.
-      DERIVED_ARCH: ${{ startsWith(matrix.test-group.sku, 'wh_') && 'wormhole_b0' || (startsWith(matrix.test-group.sku, 'bh_') && 'blackhole' || '') }}
+    # ARCH_NAME is derived inline from matrix.test-group.sku:
+    # bh_* / *blackhole* -> blackhole; wh_* / *wormhole* -> wormhole_b0; else '' so
+    # run_cpp_fabric_tests.sh / run_t3000_unit_tests.sh trip their -z guards on
+    # unrecognized SKUs.
     container:
       image: ${{ inputs.docker-image }}
       env:
         TT_METAL_HOME: /work
         PYTHONPATH: /work
         LD_LIBRARY_PATH: /work/build/lib
-        ARCH_NAME: ${{ env.DERIVED_ARCH }}
+        ARCH_NAME: ${{ (contains(matrix.test-group.sku, 'bh_') || contains(matrix.test-group.sku, 'blackhole')) && 'blackhole' || (contains(matrix.test-group.sku, 'wh_') || contains(matrix.test-group.sku, 'wormhole')) && 'wormhole_b0' || '' }}
         LOGURU_LEVEL: INFO
         # Coverage: perf legs default to profiler ON so Tracy captures timing.
         # Entries whose BW golden is calibrated against uninstrumented routers
@@ -162,7 +160,7 @@ jobs:
         uses: ./docker-job/.github/actions/check-latency-bw-results
         with:
           path: /work
-          arch: ${{ env.DERIVED_ARCH }}
+          arch: ${{ (contains(matrix.test-group.sku, 'bh_') || contains(matrix.test-group.sku, 'blackhole')) && 'blackhole' || (contains(matrix.test-group.sku, 'wh_') || contains(matrix.test-group.sku, 'wormhole')) && 'wormhole_b0' || '' }}
           check_bw: ${{ github.ref_name == 'main' }}
           check_latency: ${{ github.ref_name == 'main' }}
       - name: Upload benchmark data

--- a/.github/workflows/tm-fabric-tests.yaml
+++ b/.github/workflows/tm-fabric-tests.yaml
@@ -1,5 +1,14 @@
 name: "(TM-Fabric) Fabric Tests"
 
+# Parent workflow for the fabric hardware + perf pipelines. Delegates to two
+# testlist-driven impls:
+#   - tm-fabric-tests-impl.yaml       -> tests/pipeline_reorg/fabric_tests.yaml
+#                                        + fabric-cpu-only-tests-impl.yaml (CPU-only)
+#   - tm-fabric-tests-perf-impl.yaml  -> tests/pipeline_reorg/fabric_perf_tests.yaml
+#
+# Scheduled run (nightly cron) covers CPU-only tests only. workflow_dispatch
+# exposes `test-names` filters for running subsets of each list.
+
 on:
   schedule:
     # Once daily at 07:00 UTC — fabric CPU-only unit tests.
@@ -11,61 +20,36 @@ on:
         required: false
         default: true
         type: boolean
-      run-wh-n300-fabric-tests:
-        description: "Run Wormhole N300 fabric tests"
+      run-fabric-hw-tests:
+        description: "Run the hardware fabric matrix (fabric_tests.yaml)"
         required: false
         default: true
         type: boolean
-      run-wh-t3k-fabric-tests:
-        description: "Run Wormhole T3K fabric tests"
+      run-fabric-perf-tests:
+        description: "Run T3K fabric perf ubench (fabric_perf_tests.yaml)"
         required: false
         default: true
         type: boolean
-      run-wh-t3k-perf-tests:
-        description: "Run Wormhole T3K performance tests"
+      hw-enabled-skus:
+        description: "Comma-separated SKUs for the hardware fabric matrix (or ALL_SKUS_IN_TESTS)"
         required: false
-        default: true
-        type: boolean
-      run-perf-fabric-bw:
-        description: "Run T3K ubench - Fabric BW performance test"
+        default: "ALL_SKUS_IN_TESTS"
+        type: string
+      hw-test-names:
+        description: "Comma-separated entry names from fabric_tests.yaml to run (default: all)"
         required: false
-        default: true
-        type: boolean
-      run-perf-fabric-mux-bw:
-        description: "Run T3K ubench - Fabric Mux BW performance test"
+        default: ""
+        type: string
+      perf-enabled-skus:
+        description: "Comma-separated SKUs for the perf matrix (or ALL_SKUS_IN_TESTS)"
         required: false
-        default: true
-        type: boolean
-      run-perf-fabric-mux-v2-throughput:
-        description: "Run T3K ubench - Fabric Mux V2 Throughput performance test"
+        default: "ALL_SKUS_IN_TESTS"
+        type: string
+      perf-test-names:
+        description: "Comma-separated entry names from fabric_perf_tests.yaml to run (default: all)"
         required: false
-        default: true
-        type: boolean
-      run-wh-6u-fabric-tests:
-        description: "Run Wormhole 6U fabric tests"
-        required: false
-        default: true
-        type: boolean
-      run-bh-multi-card-unit-tests:
-        description: "Run Blackhole multi-card unit tests"
-        required: false
-        default: true
-        type: boolean
-      bh-runner-loudbox:
-        description: "Run tests on BH-LoudBox"
-        required: false
-        default: true
-        type: boolean
-      bh-runner-p300:
-        description: "Run tests on P300-viommu"
-        required: false
-        default: true
-        type: boolean
-      bh-runner-quietbox-2:
-        description: 'Run tests on BH-Quietbox-2'
-        required: false
-        default: true
-        type: boolean
+        default: ""
+        type: string
       platform:
         required: false
         type: choice
@@ -121,121 +105,37 @@ jobs:
       tracy: true
       skip-tt-train: true
 
-  generate-fabric-matrix:
-    runs-on: ubuntu-slim
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - id: set-matrix
-        shell: bash
-        run: |
-          matrix_items=()
-
-          # workflow_dispatch: checkbox inputs; schedule: CPU-only nightly; else: all test types.
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            run_cpu_only="${{ inputs.run-fabric-cpu-only-unit-tests }}"
-            run_wh_n300="${{ inputs.run-wh-n300-fabric-tests }}"
-            run_wh_t3k="${{ inputs.run-wh-t3k-fabric-tests }}"
-            run_wh_6u="${{ inputs.run-wh-6u-fabric-tests }}"
-            run_bh="${{ inputs.run-bh-multi-card-unit-tests }}"
-            bh_loudbox="${{ inputs.bh-runner-loudbox }}"
-            bh_p300="${{ inputs.bh-runner-p300 }}"
-            bh_quietbox_2="${{ inputs.bh-runner-quietbox-2 }}"
-          elif [[ "${{ github.event_name }}" == "schedule" ]]; then
-            run_cpu_only="true"
-            run_wh_n300="false"
-            run_wh_t3k="false"
-            run_wh_6u="false"
-            run_bh="false"
-            bh_loudbox="false"
-            bh_p300="false"
-            bh_quietbox_2="false"
-          else
-            # Default to true for workflow_call and push events
-            run_cpu_only="true"
-            run_wh_n300="true"
-            run_wh_t3k="true"
-            run_wh_6u="true"
-            run_bh="true"
-            bh_loudbox="true"
-            bh_p300="true"
-            bh_quietbox_2="true"
-          fi
-
-          if [[ "$run_cpu_only" == "true" ]]; then
-            matrix_items+=('{"test-type":"fabric-cpu-only-unit-tests","run-fabric-cpu-only-unit-tests":true,"run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":false}')
-          fi
-
-          if [[ "$run_wh_n300" == "true" ]]; then
-            matrix_items+=('{"test-type":"wh-n300-fabric-tests","run-fabric-cpu-only-unit-tests":false,"run-wh-n300-fabric-tests":true,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":false}')
-          fi
-
-          if [[ "$run_wh_t3k" == "true" ]]; then
-            matrix_items+=('{"test-type":"wh-t3k-fabric-tests","run-fabric-cpu-only-unit-tests":false,"run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":true,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":false}')
-          fi
-
-          if [[ "$run_wh_6u" == "true" ]]; then
-            matrix_items+=('{"test-type":"wh-6u-fabric-tests","run-fabric-cpu-only-unit-tests":false,"run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":true,"run-bh-multi-card-unit-tests":false}')
-          fi
-
-          if [[ "$run_bh" == "true" ]]; then
-            # Add blackhole test configurations for each selected runner
-            if [[ "$bh_loudbox" == "true" ]]; then
-              matrix_items+=('{"test-type":"bh-multi-card-unit-tests","run-fabric-cpu-only-unit-tests":false,"run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":true,"bh-runner-loudbox":true,"bh-runner-p300":false,"bh-runner-quietbox-2":false}')
-            fi
-            if [[ "$bh_p300" == "true" ]]; then
-              matrix_items+=('{"test-type":"bh-multi-card-unit-tests","run-fabric-cpu-only-unit-tests":false,"run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":true,"bh-runner-loudbox":false,"bh-runner-p300":true,"bh-runner-quietbox-2":false}')
-            fi
-            if [[ "$bh_quietbox_2" == "true" ]]; then
-              matrix_items+=('{"test-type":"bh-multi-card-unit-tests","run-fabric-cpu-only-unit-tests":false,"run-wh-n300-fabric-tests":false,"run-wh-t3k-fabric-tests":false,"run-wh-6u-fabric-tests":false,"run-bh-multi-card-unit-tests":true,"bh-runner-loudbox":false,"bh-runner-p300":false,"bh-runner-quietbox-2":true}')
-            fi
-          fi
-
-          if [ ${#matrix_items[@]} -eq 0 ]; then
-            echo "ERROR: No test configurations selected. Please select at least one test to run."
-            exit 1
-          fi
-
-          # Convert array to JSON array format
-          matrix_json="["
-          for i in "${!matrix_items[@]}"; do
-            if [ $i -gt 0 ]; then
-              matrix_json+=","
-            fi
-            matrix_json+="${matrix_items[i]}"
-          done
-          matrix_json+="]"
-
-          echo "matrix=$matrix_json" >> $GITHUB_OUTPUT
-          echo "Generated matrix: $matrix_json"
   fabric-tests:
-    needs: [build-artifact, generate-fabric-matrix]
+    needs: build-artifact
     secrets: inherit
-    strategy:
-      fail-fast: false
-      matrix:
-        test-config: ${{ fromJson(needs.generate-fabric-matrix.outputs.matrix) }}
     uses: ./.github/workflows/tm-fabric-tests-impl.yaml
     with:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      run-fabric-cpu-only-unit-tests: ${{ matrix.test-config.run-fabric-cpu-only-unit-tests || false }}
-      run-wh-n300-fabric-tests: ${{ matrix.test-config.run-wh-n300-fabric-tests }}
-      run-wh-t3k-fabric-tests: ${{ matrix.test-config.run-wh-t3k-fabric-tests }}
-      run-wh-6u-fabric-tests: ${{ matrix.test-config.run-wh-6u-fabric-tests }}
-      run-bh-multi-card-unit-tests: ${{ matrix.test-config.run-bh-multi-card-unit-tests }}
-      bh-runner-loudbox: ${{ matrix.test-config.bh-runner-loudbox || false }}
-      bh-runner-p300: ${{ matrix.test-config.bh-runner-p300 || false }}
-      bh-runner-quietbox-2: ${{ matrix.test-config.bh-runner-quietbox-2 || false }}
+      # Schedule runs CPU-only only; push / workflow_dispatch default to both.
+      run-fabric-cpu-only-unit-tests: ${{
+        github.event_name == 'schedule'
+        || (github.event_name == 'workflow_dispatch' && inputs.run-fabric-cpu-only-unit-tests != false)
+        || github.event_name == 'push' }}
+      run-fabric-hw-tests: ${{
+        github.event_name == 'schedule' && false
+        || (github.event_name == 'workflow_dispatch' && inputs.run-fabric-hw-tests != false)
+        || github.event_name == 'push'
+        || github.event_name == 'workflow_call' }}
+      enabled-skus: ${{ inputs.hw-enabled-skus || 'ALL_SKUS_IN_TESTS' }}
+      test-names: ${{ inputs.hw-test-names || '' }}
+
   fabric-perf-tests:
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run-wh-t3k-perf-tests != false || github.event_name == 'push' }}
-    needs: [build-artifact]
+    if: ${{
+      (github.event_name == 'workflow_dispatch' && inputs.run-fabric-perf-tests != false)
+      || github.event_name == 'push' }}
+    needs: build-artifact
     secrets: inherit
     uses: ./.github/workflows/tm-fabric-tests-perf-impl.yaml
     with:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      run-perf-fabric-mux-bw: ${{ github.event_name == 'workflow_dispatch' && inputs.run-perf-fabric-mux-bw != false || github.event_name == 'push' }}
-      run-perf-fabric-mux-v2-throughput: ${{ github.event_name == 'workflow_dispatch' && inputs.run-perf-fabric-mux-v2-throughput != false || github.event_name == 'push' }}
+      enabled-skus: ${{ inputs.perf-enabled-skus || 'ALL_SKUS_IN_TESTS' }}
+      test-names: ${{ inputs.perf-test-names || '' }}

--- a/tests/pipeline_reorg/blackhole_multi_card_sanity_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_multi_card_sanity_tests.yaml
@@ -13,20 +13,6 @@
 # For max allowed timeout refer to .github/time_budget.yaml
 
 
-- name: fabric fast unit tests (1D, 2D, single erisc)
-  cmd: |
-    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
-    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
-    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*FabricMuxV2Smoke*Fixture.*"
-    TT_METAL_DISABLE_MULTI_AERISC=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
-  skus:
-    bh_quietbox_2:
-      timeout: 15
-    bh_p300:
-      timeout: 15
-  owner_id: U08UBDUKH6Z # Neel Nyamagoudar
-  team: scaleout
-
 - name: ttnn ops fast unit tests (ccl, DRAM prefetcher)
   cmd: |
     pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/all_post_commit

--- a/tests/pipeline_reorg/fabric_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/fabric_merge_gate_tests.yaml
@@ -1,8 +1,8 @@
 # Fabric N300 merge-gate matrix.
 #
 # Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, owner_id.
-# `arch` is derived from the SKU prefix (wh_* -> wormhole_b0, bh_* -> blackhole)
-# inside the impl workflow's DERIVED_ARCH env, not authored per entry.
+# `arch` is derived from the SKU inline in the impl workflow's ARCH_NAME
+# expression (bh_* -> blackhole, wh_* -> wormhole_b0), not authored per entry.
 # For max allowed timeout refer to .github/time_budget.yaml (scaleout -> merge_gate).
 # Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
 #

--- a/tests/pipeline_reorg/fabric_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/fabric_merge_gate_tests.yaml
@@ -3,6 +3,18 @@
 # Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, arch, owner_id.
 # For max allowed timeout refer to .github/time_budget.yaml (scaleout -> merge_gate).
 # Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
+#
+# tests/scripts/run_cpp_fabric_tests.sh, which exercises:
+#   * fabric_unit_tests --gtest_filter="MeshGraphValidation*"           (host-side control-plane topology)
+#   * fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"             (2D fabric fast dispatch)
+#   * fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"             (1D fabric fast dispatch)
+#   * fabric_unit_tests --gtest_filter="*FabricMuxV2Smoke*Fixture.*"    (mux v2 smoke)
+#   * fabric_unit_tests --gtest_filter="FabricTrafficGeneratorKernelIntegrationTest.*"
+#   * test_tt_fabric --test_config test_fabric_sanity_common.yaml       (YAML-driven fabric sanity)
+# This is the correct minimum smoke bar for merge-gate: it catches regressions
+# in the host control-plane, both fabric axes, mux v2, traffic-gen kernels, and
+# the YAML-driven sanity harness in <10 min on N300. Heavier / long-running
+# suites run under tm-fabric-tests.
 
 - name: scaleout unit tests
   cmd: ./tests/scripts/run_cpp_fabric_tests.sh

--- a/tests/pipeline_reorg/fabric_merge_gate_tests.yaml
+++ b/tests/pipeline_reorg/fabric_merge_gate_tests.yaml
@@ -1,6 +1,8 @@
 # Fabric N300 merge-gate matrix.
 #
-# Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, arch, owner_id.
+# Each entry: name, cmd, skus: { <sku>: { timeout: N } }, team, owner_id.
+# `arch` is derived from the SKU prefix (wh_* -> wormhole_b0, bh_* -> blackhole)
+# inside the impl workflow's DERIVED_ARCH env, not authored per entry.
 # For max allowed timeout refer to .github/time_budget.yaml (scaleout -> merge_gate).
 # Logical SKUs only; merge_group prio routing is via sku_config merge_queue_sku.
 #
@@ -22,5 +24,4 @@
     wh_n300_civ2:
       timeout: 10
   team: scaleout
-  arch: wormhole_b0
   owner_id: U08RRAU5E15 # Ridvan Song

--- a/tests/pipeline_reorg/fabric_perf_tests.yaml
+++ b/tests/pipeline_reorg/fabric_perf_tests.yaml
@@ -6,8 +6,9 @@
 #   cmd: Shell command(s) to run from TT_METAL_HOME (/work).
 #   skus: SKU -> { timeout } (minutes).
 #   team: Required for time_budget verification (scaleout).
-#   arch: Architecture string for downstream tooling.
 #   owner_id: Slack user ID to notify on failure.
+# `arch` is derived from the SKU prefix (wh_* -> wormhole_b0, bh_* -> blackhole)
+# inside the impl workflow's DERIVED_ARCH env, not authored per entry.
 #   upload_benchmarks: (optional) When true and github.ref_name==main, impl runs
 #     check-latency-bw-results + SFTP upload of fabric BW / latency CSVs.
 #
@@ -31,7 +32,6 @@
     wh_llmbox_perf:
       timeout: 45
   team: scaleout
-  arch: wormhole_b0
   owner_id: U06US5C7M7X # Sean Nijjar
   upload_benchmarks: true
 
@@ -43,7 +43,6 @@
     wh_llmbox_perf:
       timeout: 45
   team: scaleout
-  arch: wormhole_b0
   owner_id: U06US5C7M7X # Sean Nijjar
 
 - name: T3K ubench - Fabric Mux V2 Throughput
@@ -52,5 +51,4 @@
     wh_llmbox_perf:
       timeout: 45
   team: scaleout
-  arch: wormhole_b0
   owner_id: U06US5C7M7X # Sean Nijjar

--- a/tests/pipeline_reorg/fabric_perf_tests.yaml
+++ b/tests/pipeline_reorg/fabric_perf_tests.yaml
@@ -1,0 +1,56 @@
+# Fabric perf test matrix — consumed by .github/workflows/tm-fabric-tests-perf-impl.yaml.
+# T3K microbenchmarks on wh_llmbox_perf (uses pipeline-perf runner pool).
+#
+# Each entry:
+#   name: GitHub Actions job display name.
+#   cmd: Shell command(s) to run from TT_METAL_HOME (/work).
+#   skus: SKU -> { timeout } (minutes).
+#   team: Required for time_budget verification (scaleout).
+#   arch: Architecture string for downstream tooling.
+#   owner_id: Slack user ID to notify on failure.
+#   upload_benchmarks: (optional) When true and github.ref_name==main, impl runs
+#     check-latency-bw-results + SFTP upload of fabric BW / latency CSVs.
+#
+# Container env for this list defaults to TT_METAL_DEVICE_PROFILER=1 and
+# TRACY_NO_INVARIANT_CHECK=1 (set in tm-fabric-tests-perf-impl.yaml). Entries
+# that need the profiler off (e.g. the BW golden calibrated to uninstrumented
+# routers) prepend TT_METAL_DEVICE_PROFILER=0 to their cmd.
+#
+# For max allowed timeout refer to .github/time_budget.yaml (scaleout -> perf).
+
+- name: T3K ubench - Fabric BW && Latency
+  # TT_METAL_DEVICE_PROFILER=0 overrides the job-level profiler env: the BW
+  # golden is calibrated to real (uninstrumented) fabric bandwidth, but the
+  # container enables the device profiler, which JIT-compiles kernels with
+  # -DPROFILE_KERNEL=1 and inflates router cycle counts (worst on
+  # multicast/ring/mesh: 11-18% low) -> systematic golden-comparison failures.
+  # BW is measured from the fabric router's own always-on telemetry, not Tracy,
+  # so disabling the profiler yields the clean measurement the golden expects.
+  cmd: TT_METAL_CLEAR_L1=1 TT_METAL_DEVICE_PROFILER=0 ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config ./tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_ubench_at_least_2x2_mesh.yaml
+  skus:
+    wh_llmbox_perf:
+      timeout: 45
+  team: scaleout
+  arch: wormhole_b0
+  owner_id: U06US5C7M7X # Sean Nijjar
+  upload_benchmarks: true
+
+- name: T3K ubench - Fabric Mux BW
+  # Mux BW golden was recalibrated to the profiler-off measurement in d7bfc04;
+  # keep TT_METAL_DEVICE_PROFILER=0 to match.
+  cmd: TT_METAL_DEVICE_PROFILER=0 pytest -svv tests/tt_metal/microbenchmarks/ethernet/test_fabric_mux_bandwidth.py
+  skus:
+    wh_llmbox_perf:
+      timeout: 45
+  team: scaleout
+  arch: wormhole_b0
+  owner_id: U06US5C7M7X # Sean Nijjar
+
+- name: T3K ubench - Fabric Mux V2 Throughput
+  cmd: TT_METAL_DEVICE_PROFILER=0 pytest -svv tests/tt_metal/microbenchmarks/ethernet/test_fabric_mux_v2_throughput.py
+  skus:
+    wh_llmbox_perf:
+      timeout: 45
+  team: scaleout
+  arch: wormhole_b0
+  owner_id: U06US5C7M7X # Sean Nijjar

--- a/tests/pipeline_reorg/fabric_perf_tests.yaml
+++ b/tests/pipeline_reorg/fabric_perf_tests.yaml
@@ -7,8 +7,8 @@
 #   skus: SKU -> { timeout } (minutes).
 #   team: Required for time_budget verification (scaleout).
 #   owner_id: Slack user ID to notify on failure.
-# `arch` is derived from the SKU prefix (wh_* -> wormhole_b0, bh_* -> blackhole)
-# inside the impl workflow's DERIVED_ARCH env, not authored per entry.
+# `arch` is derived from the SKU inline in the impl workflow's ARCH_NAME
+# expression (bh_* -> blackhole, wh_* -> wormhole_b0), not authored per entry.
 #   upload_benchmarks: (optional) When true and github.ref_name==main, impl runs
 #     check-latency-bw-results + SFTP upload of fabric BW / latency CSVs.
 #

--- a/tests/pipeline_reorg/fabric_sanity_tests.yaml
+++ b/tests/pipeline_reorg/fabric_sanity_tests.yaml
@@ -1,8 +1,7 @@
 # Fabric sanity test matrix — consumed by .github/workflows/fabric-sanity-tests-impl.yaml.
-# Single source of truth for fabric coverage in the sanity pipeline: WH single-card,
-# T3K llmbox, and BH single-card smoke bar. Wired into sanity-tests.yaml via the
-# `fabric-sanity-tests` job (which passes wh_n300_civ2 + wh_llmbox_civ2 + bh_p150b_civ2_viommu
-# depending on run-wormhole / run-blackhole toggles).
+# Single source of truth for fabric coverage in the sanity pipeline: WH N300, T3K
+# llmbox, and BH multi-card (QB2 / P300). Wired into sanity-tests.yaml via the
+# `fabric-sanity-tests` job.
 #
 # Each entry: name, cmd, skus{sku: {timeout}}, team, owner_id.
 # `arch` is derived from the SKU prefix (wh_* -> wormhole_b0, bh_* -> blackhole)
@@ -40,15 +39,18 @@
   team: scaleout
   owner_id: U08RRAU5E15 # Ridvan Song
 
-- name: BH card fabric sanity
-  # Single-card smoke on BH viommu; heavy multi-card / multi-runner BH coverage
-  # runs in tm-fabric-tests (bh_loudbox / bh_p300 / bh_quietbox_2).
+- name: fabric fast unit tests (1D, 2D, single erisc)
+  # Multi-card BH smoke: Fabric1D/2D fixtures, FabricMuxV2 smoke, and a
+  # DISABLE_MULTI_AERISC repeat of the 1D pass.
   cmd: |
     ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
     ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
-    ./build/test/tt_metal/tt_fabric/test_system_health
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*FabricMuxV2Smoke*Fixture.*"
+    TT_METAL_DISABLE_MULTI_AERISC=1 ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
   skus:
-    bh_p150b_civ2_viommu:
+    bh_quietbox_2:
+      timeout: 15
+    bh_p300:
       timeout: 15
   team: scaleout
-  owner_id: U06US5C7M7X # Sean Nijjar
+  owner_id: U08UBDUKH6Z # Neel Nyamagoudar

--- a/tests/pipeline_reorg/fabric_sanity_tests.yaml
+++ b/tests/pipeline_reorg/fabric_sanity_tests.yaml
@@ -4,7 +4,9 @@
 # `fabric-sanity-tests` job (which passes wh_n300_civ2 + wh_llmbox_civ2 + bh_p150b_civ2_viommu
 # depending on run-wormhole / run-blackhole toggles).
 #
-# Each entry: name, cmd, skus{sku: {timeout}}, team, arch, owner_id.
+# Each entry: name, cmd, skus{sku: {timeout}}, team, owner_id.
+# `arch` is derived from the SKU prefix (wh_* -> wormhole_b0, bh_* -> blackhole)
+# inside the impl workflow's DERIVED_ARCH env, not authored per entry.
 # upload_benchmarks: true opts in to SFTP upload of fabric BW / latency CSVs
 #   (mainline environment; only on refs/heads/main).
 # For max allowed timeout refer to .github/time_budget.yaml (scaleout -> sanity).
@@ -20,7 +22,6 @@
     wh_llmbox_civ2:
       timeout: 30
   team: scaleout
-  arch: wormhole_b0
   owner_id: U06US5C7M7X # Sean Nijjar
   upload_benchmarks: true
 
@@ -37,7 +38,6 @@
     wh_n300_civ2:
       timeout: 15
   team: scaleout
-  arch: wormhole_b0
   owner_id: U08RRAU5E15 # Ridvan Song
 
 - name: BH card fabric sanity
@@ -51,5 +51,4 @@
     bh_p150b_civ2_viommu:
       timeout: 15
   team: scaleout
-  arch: blackhole
   owner_id: U06US5C7M7X # Sean Nijjar

--- a/tests/pipeline_reorg/fabric_sanity_tests.yaml
+++ b/tests/pipeline_reorg/fabric_sanity_tests.yaml
@@ -4,8 +4,8 @@
 # `fabric-sanity-tests` job.
 #
 # Each entry: name, cmd, skus{sku: {timeout}}, team, owner_id.
-# `arch` is derived from the SKU prefix (wh_* -> wormhole_b0, bh_* -> blackhole)
-# inside the impl workflow's DERIVED_ARCH env, not authored per entry.
+# `arch` is derived from the SKU inline in the impl workflow's ARCH_NAME
+# expression (bh_* -> blackhole, wh_* -> wormhole_b0), not authored per entry.
 # upload_benchmarks: true opts in to SFTP upload of fabric BW / latency CSVs
 #   (mainline environment; only on refs/heads/main).
 # For max allowed timeout refer to .github/time_budget.yaml (scaleout -> sanity).

--- a/tests/pipeline_reorg/fabric_sanity_tests.yaml
+++ b/tests/pipeline_reorg/fabric_sanity_tests.yaml
@@ -1,0 +1,55 @@
+# Fabric sanity test matrix — consumed by .github/workflows/fabric-sanity-tests-impl.yaml.
+# Single source of truth for fabric coverage in the sanity pipeline: WH single-card,
+# T3K llmbox, and BH single-card smoke bar. Wired into sanity-tests.yaml via the
+# `fabric-sanity-tests` job (which passes wh_n300_civ2 + wh_llmbox_civ2 + bh_p150b_civ2_viommu
+# depending on run-wormhole / run-blackhole toggles).
+#
+# Each entry: name, cmd, skus{sku: {timeout}}, team, arch, owner_id.
+# upload_benchmarks: true opts in to SFTP upload of fabric BW / latency CSVs
+#   (mainline environment; only on refs/heads/main).
+# For max allowed timeout refer to .github/time_budget.yaml (scaleout -> sanity).
+
+- name: t3k fabric tests
+  # Also runs in tests/pipeline_reorg/fabric_tests.yaml
+  # under tm-fabric-tests; the duplication is intentional (sanity gate vs.
+  # deeper fabric pipeline).
+  cmd: |
+    source tests/scripts/t3000/run_t3000_unit_tests.sh
+    run_t3000_ttfabric_tests
+  skus:
+    wh_llmbox_civ2:
+      timeout: 30
+  team: scaleout
+  arch: wormhole_b0
+  owner_id: U06US5C7M7X # Sean Nijjar
+  upload_benchmarks: true
+
+- name: WH N300 fabric sanity
+  # Subset of run_cpp_fabric_tests.sh: Fabric1D/2D fixtures + control-plane
+  # topology validation + one YAML-driven sanity_common run. Kept lightweight
+  # for the sanity time budget.
+  cmd: |
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="MeshGraphValidation*"
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
+    ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config ./tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_sanity_common.yaml
+  skus:
+    wh_n300_civ2:
+      timeout: 15
+  team: scaleout
+  arch: wormhole_b0
+  owner_id: U08RRAU5E15 # Ridvan Song
+
+- name: BH card fabric sanity
+  # Single-card smoke on BH viommu; heavy multi-card / multi-runner BH coverage
+  # runs in tm-fabric-tests (bh_loudbox / bh_p300 / bh_quietbox_2).
+  cmd: |
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
+    ./build/test/tt_metal/tt_fabric/test_system_health
+  skus:
+    bh_p150b_civ2_viommu:
+      timeout: 15
+  team: scaleout
+  arch: blackhole
+  owner_id: U06US5C7M7X # Sean Nijjar

--- a/tests/pipeline_reorg/fabric_tests.yaml
+++ b/tests/pipeline_reorg/fabric_tests.yaml
@@ -6,8 +6,8 @@
 #   skus: SKU -> { timeout } (minutes). Multi-SKU entries fan out one leg per SKU.
 #   team: Required for time_budget verification (scaleout for all fabric tests).
 #   owner_id: Slack user ID to notify on failure.
-# `arch` is derived from the SKU prefix (wh_* -> wormhole_b0, bh_* -> blackhole)
-# inside the impl workflow's DERIVED_ARCH env, not authored per entry.
+# `arch` is derived from the SKU inline in the impl workflow's ARCH_NAME
+# expression (bh_* -> blackhole, wh_* -> wormhole_b0), not authored per entry.
 #   upload_benchmarks: (optional) When true and github.ref_name==main, impl runs
 #     check-latency-bw-results + SFTP uploads (fabric BW / latency).
 #   auto_triage: (optional, default true) Set false for multi-process legs where

--- a/tests/pipeline_reorg/fabric_tests.yaml
+++ b/tests/pipeline_reorg/fabric_tests.yaml
@@ -1,0 +1,240 @@
+# Fabric hardware test matrix — consumed by .github/workflows/tm-fabric-tests-impl.yaml.
+#
+# Each entry:
+#   name: GitHub Actions job display name (SKU is appended by prepare_test_matrix).
+#   cmd: Shell command(s) to run from TT_METAL_HOME (/work).
+#   skus: SKU -> { timeout } (minutes). Multi-SKU entries fan out one leg per SKU.
+#   team: Required for time_budget verification (scaleout for all fabric tests).
+#   arch: Architecture string (wormhole_b0 or blackhole) for downstream tooling.
+#   owner_id: Slack user ID to notify on failure.
+#   upload_benchmarks: (optional) When true and github.ref_name==main, impl runs
+#     check-latency-bw-results + SFTP uploads (fabric BW / latency).
+#   auto_triage: (optional, default true) Set false for multi-process legs where
+#     MPI coordination causes triage false positives.
+#
+# For max allowed timeout refer to .github/time_budget.yaml (scaleout -> unit).
+# CPU-only fabric tests live in tests/pipeline_reorg/fabric_cpu_only_unit_tests.yaml
+# and are invoked by fabric-cpu-only-tests-impl.yaml from the same parent workflow.
+
+# ============================================================================
+# WH N300 — same cmd as merge-gate `scaleout unit tests` (fabric_merge_gate_tests.yaml).
+# Kept in both lists so merge-gate keeps its budget-scoped entry.
+# ============================================================================
+- name: WH N300 scaleout unit tests
+  cmd: ./tests/scripts/run_cpp_fabric_tests.sh
+  skus:
+    wh_n300_civ2:
+      timeout: 15
+  team: scaleout
+  arch: wormhole_b0
+  owner_id: U08RRAU5E15 # Ridvan Song
+
+# ============================================================================
+# WH T3K (llmbox) — port of run_t3000_ttfabric_tests + wh-t3k-udm-tests inline block.
+# The `t3k fabric tests` entry below is also mirrored in
+# tests/pipeline_reorg/fabric_sanity_tests.yaml so the sanity pipeline retains
+# T3K fabric coverage (deliberate duplication — sanity smoke gate vs. deeper
+# tm-fabric-tests pipeline).
+# ============================================================================
+- name: t3k fabric tests
+  cmd: |
+    source tests/scripts/t3000/run_t3000_unit_tests.sh
+    run_t3000_ttfabric_tests
+  skus:
+    wh_llmbox_civ2:
+      timeout: 30
+  team: scaleout
+  arch: wormhole_b0
+  owner_id: U06US5C7M7X # Sean Nijjar
+  upload_benchmarks: true
+
+- name: t3k UDM tests
+  cmd: |
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2DUDMModeFixture.*"
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric2DUDMModeFixture.*"
+    ./build/test/ttnn/unit_tests_ttnn_udm
+  skus:
+    wh_llmbox_civ2:
+      timeout: 30
+  team: scaleout
+  arch: wormhole_b0
+  owner_id: U06US5C7M7X # Sean Nijjar
+
+# ============================================================================
+# WH Galaxy 6U — port of wh-6u-fabric-tests inline block.
+# Each entry prepends run_cluster_validation so a broken cluster fails fast
+# without running the heavy fabric matrix (was gated via step outcome before).
+# ============================================================================
+- name: 6U fabric quick
+  cmd: |
+    ./build/tools/scaleout/run_cluster_validation --cabling-descriptor-path tt_metal/fabric/cabling_descriptors/wh_galaxy_xy_torus.textproto --hard-fail --send-traffic
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*FabricMuxV2*Fixture.*"
+    TT_MESH_GRAPH_DESC_PATH=tests/tt_metal/tt_fabric/custom_mesh_descriptors/galaxy_1x32_mesh_graph_descriptor.textproto ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
+    TT_MESH_GRAPH_DESC_PATH=tests/tt_metal/tt_fabric/custom_mesh_descriptors/galaxy_1x32_mesh_graph_descriptor.textproto ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
+    ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config ./tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_sanity_common.yaml
+    ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config ./tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_2d_torus_deadlock_stability.yaml
+    ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config ./tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_ubench_6U_galaxy_quick.yaml
+  skus:
+    wh_galaxy:
+      timeout: 25
+  team: scaleout
+  arch: wormhole_b0
+  owner_id: U0845EV7A5U # Umair Cheema
+  upload_benchmarks: true
+
+- name: 6U multi-process
+  cmd: |
+    ./build/tools/scaleout/run_cluster_validation --cabling-descriptor-path tt_metal/fabric/cabling_descriptors/wh_galaxy_xy_torus.textproto --hard-fail --send-traffic
+    # Multi-process legs: MPI coordination makes hang-detection unreliable, so
+    # setup-job runs with auto_triage=false (via the per-entry field below) and
+    # we mirror the pre-refactor step ordering by re-clearing the timeout here.
+    export TT_METAL_OPERATION_TIMEOUT_SECONDS=0
+    python3 tests/tt_metal/tt_fabric/utils/generate_rank_bindings.py
+    tt-run --mpi-args "--allow-run-as-root" --rank-binding 4x4_multi_big_mesh_rank_binding.yaml ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_multi_mesh_sanity_common.yaml
+    tt-run --rank-binding 4x4_multi_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root" python3 tests/ttnn/distributed/test_multi_mesh.py
+    tt-run --mpi-args "--allow-run-as-root" --rank-binding 4x4_multi_mesh_rank_binding.yaml ./build/test/tt_metal/multi_host_socket_tests
+    tt-run --mpi-args "--allow-run-as-root" --rank-binding 4x4_multi_big_mesh_rank_binding.yaml  ./build/test/tt_metal/multi_host_fabric_tests --gtest_filter="*Socket*"
+    tt-run --rank-binding 2x4_multi_mesh_cyclic_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_wh_6u_quad_2x4_acyclic.yaml
+    tt-run --rank-binding 2x4_multi_mesh_cyclic_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_wh_6u_quad_2x4_cyclic.yaml
+    tt-run --rank-binding 4x2_multi_mesh_rank_binding.yaml --mpi-args "--allow-run-as-root" ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_multi_mesh_sanity_common.yaml
+  skus:
+    wh_galaxy:
+      timeout: 25
+  team: scaleout
+  arch: wormhole_b0
+  owner_id: U0845EV7A5U # Umair Cheema
+  auto_triage: false
+
+# ============================================================================
+# BH multi-card — port of bh-multi-card-unit-tests matrix (9 groups × 3 SKUs).
+# Same cmd across all 3 SKUs; prepare_test_matrix fans out one leg per SKU.
+# ============================================================================
+- name: BH fabric 1D unit tests
+  cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric1D*Fixture.*"
+  skus:
+    bh_loudbox:
+      timeout: 15
+    bh_p300:
+      timeout: 15
+    bh_quietbox_2:
+      timeout: 15
+  team: scaleout
+  arch: blackhole
+  owner_id: U06US5C7M7X # Sean Nijjar
+
+- name: BH fabric 2D fixture unit tests
+  cmd: |
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2D*Fixture.*"
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="FabricTrafficGeneratorKernelIntegrationTest.*"
+  skus:
+    bh_loudbox:
+      timeout: 15
+    bh_p300:
+      timeout: 15
+    bh_quietbox_2:
+      timeout: 15
+  team: scaleout
+  arch: blackhole
+  owner_id: U06US5C7M7X # Sean Nijjar
+
+- name: BH fabric mux v2 unit tests
+  cmd: ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*FabricMuxV2*Fixture.*"
+  skus:
+    bh_loudbox:
+      timeout: 5
+    bh_p300:
+      timeout: 5
+    bh_quietbox_2:
+      timeout: 5
+  team: scaleout
+  arch: blackhole
+  owner_id: U06US5C7M7X # Sean Nijjar
+
+- name: BH fabric UDM mode unit tests
+  cmd: |
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="Fabric2DUDMModeFixture.*"
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="NightlyFabric2DUDMModeFixture.*"
+    ./build/test/tt_metal/tt_fabric/fabric_unit_tests --gtest_filter="*ChannelTrimming*"
+  skus:
+    bh_loudbox:
+      timeout: 15
+    bh_p300:
+      timeout: 15
+    bh_quietbox_2:
+      timeout: 15
+  team: scaleout
+  arch: blackhole
+  owner_id: U06US5C7M7X # Sean Nijjar
+
+- name: BH ttnn UDM unit tests
+  cmd: ./build/test/ttnn/unit_tests_ttnn_udm
+  skus:
+    bh_loudbox:
+      timeout: 10
+    bh_p300:
+      timeout: 10
+    bh_quietbox_2:
+      timeout: 10
+  team: scaleout
+  arch: blackhole
+  owner_id: U06US5C7M7X # Sean Nijjar
+
+- name: BH fabric system health tests
+  cmd: ./build/test/tt_metal/tt_fabric/test_system_health
+  skus:
+    bh_loudbox:
+      timeout: 15
+    bh_p300:
+      timeout: 15
+    bh_quietbox_2:
+      timeout: 15
+  team: scaleout
+  arch: blackhole
+  owner_id: U06US5C7M7X # Sean Nijjar
+
+- name: BH fabric stability nightly tests
+  # TT_METAL_OPERATION_TIMEOUT_SECONDS=0 disables hang detection for the long-running
+  # stability suite (matches pre-refactor tm-fabric-tests-impl inline cmd).
+  cmd: TT_METAL_OPERATION_TIMEOUT_SECONDS=0 ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config ./tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_stability.yaml --filter 'name.*_short'
+  skus:
+    bh_loudbox:
+      timeout: 30
+    bh_p300:
+      timeout: 30
+    bh_quietbox_2:
+      timeout: 30
+  team: scaleout
+  arch: blackhole
+  owner_id: U06US5C7M7X # Sean Nijjar
+
+- name: BH ccl nightly tests
+  cmd: pytest tests/ttnn/unit_tests/operations/ccl/blackhole_CI/box/nightly
+  skus:
+    bh_loudbox:
+      timeout: 60
+    bh_p300:
+      timeout: 60
+    bh_quietbox_2:
+      timeout: 60
+  team: scaleout
+  arch: blackhole
+  owner_id: U06US5C7M7X # Sean Nijjar
+
+- name: BH fabric infra unit tests
+  cmd: |
+    ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config ./tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_sanity_common.yaml
+    ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config ./tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_sanity_at_least_2x2_mesh.yaml
+    ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config ./tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_vc2_at_least_2x2_mesh.yaml
+    TT_FABRIC_PROFILE_RX_CH_FWD=1 ./build/test/tt_metal/tt_fabric/test_infra/test_tt_fabric --test_config ./tests/tt_metal/tt_fabric/test_infra/test_yamls/test_fabric_code_profiling.yaml
+  skus:
+    bh_loudbox:
+      timeout: 15
+    bh_p300:
+      timeout: 15
+    bh_quietbox_2:
+      timeout: 15
+  team: scaleout
+  arch: blackhole
+  owner_id: U06US5C7M7X # Sean Nijjar

--- a/tests/pipeline_reorg/fabric_tests.yaml
+++ b/tests/pipeline_reorg/fabric_tests.yaml
@@ -5,8 +5,9 @@
 #   cmd: Shell command(s) to run from TT_METAL_HOME (/work).
 #   skus: SKU -> { timeout } (minutes). Multi-SKU entries fan out one leg per SKU.
 #   team: Required for time_budget verification (scaleout for all fabric tests).
-#   arch: Architecture string (wormhole_b0 or blackhole) for downstream tooling.
 #   owner_id: Slack user ID to notify on failure.
+# `arch` is derived from the SKU prefix (wh_* -> wormhole_b0, bh_* -> blackhole)
+# inside the impl workflow's DERIVED_ARCH env, not authored per entry.
 #   upload_benchmarks: (optional) When true and github.ref_name==main, impl runs
 #     check-latency-bw-results + SFTP uploads (fabric BW / latency).
 #   auto_triage: (optional, default true) Set false for multi-process legs where
@@ -26,7 +27,6 @@
     wh_n300_civ2:
       timeout: 15
   team: scaleout
-  arch: wormhole_b0
   owner_id: U08RRAU5E15 # Ridvan Song
 
 # ============================================================================
@@ -44,7 +44,6 @@
     wh_llmbox_civ2:
       timeout: 30
   team: scaleout
-  arch: wormhole_b0
   owner_id: U06US5C7M7X # Sean Nijjar
   upload_benchmarks: true
 
@@ -57,7 +56,6 @@
     wh_llmbox_civ2:
       timeout: 30
   team: scaleout
-  arch: wormhole_b0
   owner_id: U06US5C7M7X # Sean Nijjar
 
 # ============================================================================
@@ -80,7 +78,6 @@
     wh_galaxy:
       timeout: 25
   team: scaleout
-  arch: wormhole_b0
   owner_id: U0845EV7A5U # Umair Cheema
   upload_benchmarks: true
 
@@ -103,7 +100,6 @@
     wh_galaxy:
       timeout: 25
   team: scaleout
-  arch: wormhole_b0
   owner_id: U0845EV7A5U # Umair Cheema
   auto_triage: false
 
@@ -121,7 +117,6 @@
     bh_quietbox_2:
       timeout: 15
   team: scaleout
-  arch: blackhole
   owner_id: U06US5C7M7X # Sean Nijjar
 
 - name: BH fabric 2D fixture unit tests
@@ -136,7 +131,6 @@
     bh_quietbox_2:
       timeout: 15
   team: scaleout
-  arch: blackhole
   owner_id: U06US5C7M7X # Sean Nijjar
 
 - name: BH fabric mux v2 unit tests
@@ -149,7 +143,6 @@
     bh_quietbox_2:
       timeout: 5
   team: scaleout
-  arch: blackhole
   owner_id: U06US5C7M7X # Sean Nijjar
 
 - name: BH fabric UDM mode unit tests
@@ -165,7 +158,6 @@
     bh_quietbox_2:
       timeout: 15
   team: scaleout
-  arch: blackhole
   owner_id: U06US5C7M7X # Sean Nijjar
 
 - name: BH ttnn UDM unit tests
@@ -178,7 +170,6 @@
     bh_quietbox_2:
       timeout: 10
   team: scaleout
-  arch: blackhole
   owner_id: U06US5C7M7X # Sean Nijjar
 
 - name: BH fabric system health tests
@@ -191,7 +182,6 @@
     bh_quietbox_2:
       timeout: 15
   team: scaleout
-  arch: blackhole
   owner_id: U06US5C7M7X # Sean Nijjar
 
 - name: BH fabric stability nightly tests
@@ -206,7 +196,6 @@
     bh_quietbox_2:
       timeout: 30
   team: scaleout
-  arch: blackhole
   owner_id: U06US5C7M7X # Sean Nijjar
 
 - name: BH ccl nightly tests
@@ -219,7 +208,6 @@
     bh_quietbox_2:
       timeout: 60
   team: scaleout
-  arch: blackhole
   owner_id: U06US5C7M7X # Sean Nijjar
 
 - name: BH fabric infra unit tests
@@ -236,5 +224,4 @@
     bh_quietbox_2:
       timeout: 15
   team: scaleout
-  arch: blackhole
   owner_id: U06US5C7M7X # Sean Nijjar

--- a/tests/pipeline_reorg/t3000_sanity_tests.yaml
+++ b/tests/pipeline_reorg/t3000_sanity_tests.yaml
@@ -29,14 +29,3 @@
       timeout: 15
   owner_id: U06MJ6CVCGZ # Yu Gao
   team: ttnn
-
-- name: t3k_fabric_tests
-  cmd: |
-    source tests/scripts/t3000/run_t3000_unit_tests.sh
-    run_t3000_ttfabric_tests
-  skus:
-    wh_llmbox_civ2:
-      timeout: 30
-  owner_id: U06US5C7M7X # Sean Nijjar
-  team: scaleout
-  upload_benchmarks: true


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Consolidates the fabric CI pipelines onto the testlist-driven pattern used by `llk-e2e` and friends, and gives `sanity-tests.yaml` a dedicated fabric smoke bar.

Before: `tm-fabric-tests-impl.yaml` was ~230 lines of hard-coded inline shell across 5 jobs, with per-test boolean inputs (`run-wh-n300-fabric-tests`, `run-wh-t3k-fabric-tests`, `run-wh-6u-fabric-tests`, `run-bh-multi-card-unit-tests`, `bh-runner-loudbox`, …) and an inline matrix generator. `run_t3000_ttfabric_tests` in T3000 sanity was the only fabric coverage in `sanity-tests.yaml`, and it was buried inside `t3000-sanity-tests-impl`.

After:

- Three testlist YAMLs describe every fabric HW test as a data row, with `verify_time_budget.py` and `prepare_test_matrix.py` doing the SKU / budget work:
  - [tests/pipeline_reorg/fabric_tests.yaml](tests/pipeline_reorg/fabric_tests.yaml) — 11 entries × relevant SKUs = 32 hardware legs (WH N300 smoke, T3K fabric + UDM, 6U fabric quick + multi-process, BH multi-card × 9 buckets).
  - [tests/pipeline_reorg/fabric_perf_tests.yaml](tests/pipeline_reorg/fabric_perf_tests.yaml) — 3 T3K ubench entries.
  - [tests/pipeline_reorg/fabric_sanity_tests.yaml](tests/pipeline_reorg/fabric_sanity_tests.yaml) — WH N300 smoke, `t3k_fabric_tests` (moved from t3000-sanity), BH viommu smoke. Wired into `sanity-tests.yaml` as its own top-level job.
- Two impls consume the lists: [tm-fabric-tests-impl.yaml](.github/workflows/tm-fabric-tests-impl.yaml) (HW) and [tm-fabric-tests-perf-impl.yaml](.github/workflows/tm-fabric-tests-perf-impl.yaml) (perf). Kept separate on purpose (perf jobs have a distinct container env + microbenchmark artifact uploads). A new [fabric-sanity-tests-impl.yaml](.github/workflows/fabric-sanity-tests-impl.yaml) mirrors the same hooks for the sanity list.
- [tm-fabric-tests.yaml](.github/workflows/tm-fabric-tests.yaml) shrinks from 7+ per-test booleans to `run-fabric-{cpu-only-unit,hw,perf}-tests` toggles + `enabled-skus` / `test-names` filters per impl. Nightly cron behaviour unchanged (CPU-only only).

CPU-only fabric tests continue to run through [fabric-cpu-only-tests-impl.yaml](.github/workflows/fabric-cpu-only-tests-impl.yaml) → `fabric_cpu_only_unit_tests.yaml` (already testlist-driven, no HW). Merge-gate fabric still goes through [fabric-build-and-unit-tests.yaml](.github/workflows/fabric-build-and-unit-tests.yaml) → `fabric_merge_gate_tests.yaml` (untouched wiring — highest-risk gate, intentionally left alone). `fabric-multihost-exabox.yaml` is out of scope for this PR (multihost `tt-run` / `mpirun` infra is unique enough that folding it in would obscure it).

Diff shape: **11 files, +960 / −530**.

### What changed

| File | Change |
| --- | --- |
| [tests/pipeline_reorg/fabric_tests.yaml](tests/pipeline_reorg/fabric_tests.yaml) | **New.** HW matrix; consumed by `tm-fabric-tests-impl.yaml`. |
| [tests/pipeline_reorg/fabric_perf_tests.yaml](tests/pipeline_reorg/fabric_perf_tests.yaml) | **New.** Perf matrix (`wh_llmbox_perf`); consumed by `tm-fabric-tests-perf-impl.yaml`. |
| [tests/pipeline_reorg/fabric_sanity_tests.yaml](tests/pipeline_reorg/fabric_sanity_tests.yaml) | **New.** Sanity smoke; consumed by `fabric-sanity-tests-impl.yaml`. Includes `t3k_fabric_tests` moved from `t3000_sanity_tests.yaml`. |
| [.github/workflows/fabric-sanity-tests-impl.yaml](.github/workflows/fabric-sanity-tests-impl.yaml) | **New.** Testlist-driven impl for the sanity smoke. Mirrors the SKU-conditional hooks from the HW impl for wh_llmbox parity. |
| [.github/workflows/tm-fabric-tests-impl.yaml](.github/workflows/tm-fabric-tests-impl.yaml) | **Rewritten.** From 5 inline jobs to 1 load-matrix + 1 fan-out. All infra hooks conditional on SKU / entry flags — grep for `Coverage:` comments. Still spawns `fabric-cpu-only-tests-impl.yaml` as a sibling. |
| [.github/workflows/tm-fabric-tests-perf-impl.yaml](.github/workflows/tm-fabric-tests-perf-impl.yaml) | **Rewritten.** Same pattern. SFTP upload now driven by per-entry `upload_benchmarks: true` (was `contains(name, 'Fabric BW')` name hack). Microbenchmark CSV artifact preserved. |
| [.github/workflows/tm-fabric-tests.yaml](.github/workflows/tm-fabric-tests.yaml) | **Rewritten.** Dropped 7+ per-test booleans and the inline matrix generator. Exposes 3 boolean toggles + per-impl `enabled-skus` and `test-names` filters. |
| [.github/workflows/sanity-tests.yaml](.github/workflows/sanity-tests.yaml) | Added `run-fabric-sanity-tests` toggle (workflow_call + workflow_dispatch) and a new `fabric-sanity-tests` job. |
| [.github/time_budget.yaml](.github/time_budget.yaml) | New `scaleout.unit.{wh_n300_civ2,wh_llmbox_civ2,bh_loudbox,bh_p300,bh_quietbox_2}`; raised `scaleout.unit.wh_galaxy` 25→75 to cover the 6U entries that previously lived as inline shell (accounting reconciliation — same runner pool, same cadence, same wall-clock demand). New `scaleout.sanity.{wh_n300_civ2,bh_p150b_civ2_viommu}` and `scaleout.perf.wh_llmbox_perf`. |
| [tests/pipeline_reorg/fabric_merge_gate_tests.yaml](tests/pipeline_reorg/fabric_merge_gate_tests.yaml) | Comment-only: audit note enumerating what `run_cpp_fabric_tests.sh` actually covers and the 10-min budget constraint. |
| [tests/pipeline_reorg/t3000_sanity_tests.yaml](tests/pipeline_reorg/t3000_sanity_tests.yaml) | Removed `t3k_fabric_tests` entry (moved to `fabric_sanity_tests.yaml`); left a pointer comment. |

### Coverage-preservation hooks (please review carefully)

The old inline shell carried a lot of per-job infra that would silently be lost if we just moved `cmd` strings into YAML. To avoid regressions the new impls encode these as SKU-prefix or entry-flag-conditional steps. Every one is annotated in the workflow YAML with a `Coverage:` comment (grep-anchor).

| Hook | Gating in new impl(s) | Source of pre-refactor behaviour |
| --- | --- | --- |
| `--memory 256g` container option | `contains(matrix.test-group.sku, 'wh_llmbox')` | `t3000-sanity-tests-impl` |
| Hugepages mount `/dev/hugepages-1G` | `!contains(join(matrix.test-group.runs_on, ','), 'viommu')` | old `bh-multi-card-unit-tests` matrix |
| `TTNN_CONFIG_OVERRIDES: '{"validate_program_args": true}'` env | unconditional | was T3K-only; harmless elsewhere |
| Kernel ccache + Redis (`enable-kernel-ccache`, `redis-ccache-storage`) | `contains(matrix.test-group.sku, 'wh_llmbox')` | `t3000-sanity-tests-impl` |
| `tt_power_sidecar.py` wrapping the cmd + `power-report-*` artifact | `startsWith(matrix.test-group.sku, 'wh_llmbox')` | `t3000-sanity-tests-impl` |
| CCache summary in `$GITHUB_STEP_SUMMARY` | `contains(matrix.test-group.sku, 'wh_llmbox')` | `t3000-sanity-tests-impl` |
| `ensure-bh-links-online` pre-step + `tt-smi -s` on failure | `startsWith(matrix.test-group.sku, 'bh_')` | old `bh-multi-card-unit-tests` |
| `auto-triage` on setup-job (hang detection env vars) | `matrix.test-group.auto_triage != false` | old 6U inline job used `TT_METAL_OPERATION_TIMEOUT_SECONDS=0` before multi-process |
| Cluster validation for 6U | prepended into the 6U entry `cmd` blocks | old 6U inline job |
| `check-latency-bw-results` + fabric BW / latency SFTP upload | `github.ref_name == 'main' && matrix.test-group.upload_benchmarks == true` | old inline block + `t3000-sanity-tests-impl` |
| `environment: mainline` on the fan-out job (SFTP secret binding) | `github.ref == 'refs/heads/main'` | `t3000-sanity-tests-impl` |
| Perf-only: `TT_METAL_DEVICE_PROFILER=1` + `TRACY_NO_INVARIANT_CHECK=1` | unconditional on perf impl | old perf inline block. Entries that need the profiler off (BW golden calibration) prepend `TT_METAL_DEVICE_PROFILER=0` to their `cmd`. |
| Perf-only: `microbenchmark-report-csv-*` artifact | unconditional on perf impl | old perf inline block |

### Sanity coverage change (t3k_fabric_tests)

Moved out of [tests/pipeline_reorg/t3000_sanity_tests.yaml](tests/pipeline_reorg/t3000_sanity_tests.yaml) into [tests/pipeline_reorg/fabric_sanity_tests.yaml](tests/pipeline_reorg/fabric_sanity_tests.yaml). Same entry (same `cmd`, `wh_llmbox_civ2`, 30 min, `upload_benchmarks: true`, same owner). Rationale: single source of truth for fabric coverage in the sanity pipeline.

Wiring trick: `generate-sku-matrix.sanity-skus` in [sanity-tests.yaml](.github/workflows/sanity-tests.yaml) only carries single-card SKUs; `wh_llmbox_civ2` is routed to `t3000-sanity-tests` via a hard-coded value. To keep other sanity jobs unaware of `wh_llmbox_civ2`, the fabric-sanity job appends it only when wormhole is enabled:

```yaml
enabled-skus: ${{ format('{0}{1}',
                         needs.generate-sku-matrix.outputs.sanity-skus,
                         needs.generate-sku-matrix.outputs.run-wormhole == 'true' && ',wh_llmbox_civ2' || '') }}
```

Budgets carry over unchanged: `scaleout.sanity.wh_llmbox_civ2 = 30 min` now attaches to the fabric-sanity fan-out instead of the t3000-sanity fan-out. `ttnn.sanity.wh_llmbox_civ2 = 40 min` still covers the remaining `t3k_ttnn_ccl_tests` (15 min used) in `t3000_sanity_tests.yaml`.

### Behaviour parity (intentional non-changes)

- Merge-gate fabric wiring untouched: still uses [fabric-build-and-unit-tests.yaml](.github/workflows/fabric-build-and-unit-tests.yaml) → [fabric_merge_gate_tests.yaml](tests/pipeline_reorg/fabric_merge_gate_tests.yaml). Do not delete either file.
- [fabric-multihost-exabox.yaml](.github/workflows/fabric-multihost-exabox.yaml) untouched.
- [fabric-cpu-only-tests-impl.yaml](.github/workflows/fabric-cpu-only-tests-impl.yaml) untouched; called from the new HW impl as a parallel sibling job.
- Nightly cron on `tm-fabric-tests`: still only kicks CPU-only (identical to pre-refactor gating).
- Runner pools unchanged: SKUs map to the same `runs_on` label sets, so the physical pool for each leg is unchanged.

### Local validation

Ran against the new lists (all pass):

```
python3 .github/scripts/utils/verify_time_budget.py tests/pipeline_reorg/fabric_tests.yaml       .github/time_budget.yaml unit
python3 .github/scripts/utils/verify_time_budget.py tests/pipeline_reorg/fabric_perf_tests.yaml  .github/time_budget.yaml perf
python3 .github/scripts/utils/verify_time_budget.py tests/pipeline_reorg/fabric_sanity_tests.yaml .github/time_budget.yaml sanity
python3 .github/scripts/utils/verify_time_budget.py tests/pipeline_reorg/t3000_sanity_tests.yaml .github/time_budget.yaml sanity

python3 .github/scripts/utils/prepare_test_matrix.py tests/pipeline_reorg/fabric_tests.yaml        ALL_SKUS_IN_TESTS .github/sku_config.yaml --event workflow_dispatch  # 32 legs
python3 .github/scripts/utils/prepare_test_matrix.py tests/pipeline_reorg/fabric_perf_tests.yaml   ALL_SKUS_IN_TESTS .github/sku_config.yaml --event workflow_dispatch  # 3 legs
python3 .github/scripts/utils/prepare_test_matrix.py tests/pipeline_reorg/fabric_sanity_tests.yaml wh_n300_civ2,wh_llmbox_civ2,bh_p150b_civ2_viommu .github/sku_config.yaml --event workflow_dispatch  # 3 legs
```

Also:

- `yaml.safe_load` clean on every touched file.
- `rg` for the removed inputs (`run-wh-*`, `run-bh-*`, `bh-runner-*`, `generate-fabric-matrix`, `generate-bh-matrix`) across the repo — no external references.

### Notes for reviewers

**Where to focus:**

1. The **Coverage-preservation hooks table** above. That's the single-most-important thing to spot-check: any hook that silently regresses will only show up when a specific SKU leg misbehaves in the wild.
2. New testlist entries in [fabric_tests.yaml](tests/pipeline_reorg/fabric_tests.yaml) — please confirm the `cmd` blocks match the pre-refactor inline invocations, especially:
   - `6U multi-process` (ported from the `run-multi-process-tests` composite action verbatim).
   - `BH fabric stability nightly tests` (`TT_METAL_OPERATION_TIMEOUT_SECONDS=0` preserved inline).
   - `BH fabric infra unit tests` (`TT_FABRIC_PROFILE_RX_CH_FWD=1` on the code_profiling YAML).
3. [fabric_perf_tests.yaml](tests/pipeline_reorg/fabric_perf_tests.yaml): each of the 3 entries prepends `TT_METAL_DEVICE_PROFILER=0` — kept because the BW golden was calibrated to uninstrumented routers. Container env still exports `TT_METAL_DEVICE_PROFILER=1` for anything else that lands there in the future.
4. The `sanity-tests.yaml` `format(...)` trick for injecting `wh_llmbox_civ2` into fabric-sanity — please confirm this is preferable to widening `generate-sku-matrix.sanity-skus` (which would ripple into ttnn-sanity, ops-sanity, umd-sanity, ttsim-sanity, etc.).

**Known deliberate duplications:**

- `t3k_fabric_tests` runs in **both** `fabric_tests.yaml` (via `tm-fabric-tests`, manual/scheduled) and `fabric_sanity_tests.yaml` (via `sanity-tests`, per-PR). Both flag `upload_benchmarks: true`, so a push-to-main can double-upload BW data to the fabric SFTP dashboard. If duplication is unwanted, drop `upload_benchmarks: true` on the fabric-sanity side and keep tm-fabric-tests as source of truth.

**Rollout risk (first CI run):**

- BH SKU runner-label mismatch. Pre-refactor matrix used `${runner-label}, in-service, arch-blackhole` (3 labels). New impl uses `bh_loudbox` / `bh_p300` / `bh_quietbox_2` which resolve to 4-label sets in [sku_config.yaml](.github/sku_config.yaml) including `pipeline-functional` / `pipeline-yyz2-lfc` / `pipeline-perf`. If runner availability differs, legs will queue. Mitigation: add fabric-specific SKU aliases dropping the `pipeline-*` label if needed.
- `wh_llmbox` legs now get `--memory 256g`, kernel ccache, and power sidecar (previously only the t3000-sanity variant did). Watch for container OOM, missing Redis creds outside `mainline` environment, or `tt_power_sidecar.py` path errors in the docker image.
- `hw_test_names` / `perf_test_names` filters match on the base name (before ` [sku]`); typos fail loudly with `::error::test-names not present in the matrix` at the load-matrix step.

**Not a rollout risk (despite budget noise):**

- `scaleout.unit.wh_galaxy` was raised 25 → 75 min. This is **accounting reconciliation**, not new demand. The old inline `wh-6u-fabric-tests` job targeted the exact same `arch-wormhole_b0 + pipeline-functional + topology-6u + in-service` runner pool at the same manual-dispatch-only cadence but was invisible to `verify_time_budget.py` because it wasn't in a testlist. Now that the two 6U entries (50 min) sit alongside the existing `galaxy_unit_tests` entries (~20 min), the ceiling needed room. Actual runner-pool demand is unchanged.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ucheema/fabric-ci-pipeline-reorg)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ucheema/fabric-ci-pipeline-reorg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ucheema/fabric-ci-pipeline-reorg)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ucheema/fabric-ci-pipeline-reorg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ucheema/fabric-ci-pipeline-reorg)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ucheema/fabric-ci-pipeline-reorg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ucheema/fabric-ci-pipeline-reorg)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ucheema/fabric-ci-pipeline-reorg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ucheema/fabric-ci-pipeline-reorg)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ucheema/fabric-ci-pipeline-reorg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ucheema/fabric-ci-pipeline-reorg)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ucheema/fabric-ci-pipeline-reorg)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ucheema/fabric-ci-pipeline-reorg)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ucheema/fabric-ci-pipeline-reorg)