### PR TITLE
[tt-train] pair zeros-fills with write-zeros barriers in variable_matmul

### DIFF
--- a/tt-train/sources/ttml/metal/ops/variable_matmul/device/kernels/dataflow/matmul_dataflow_common.hpp
+++ b/tt-train/sources/ttml/metal/ops/variable_matmul/device/kernels/dataflow/matmul_dataflow_common.hpp
@@ -64,6 +64,7 @@ void read_in0_block_sync(
     // current write pointer minus the CB base (write_ptr at entry).
     Noc noc;
     const uint32_t cb_base = write_ptr;
+    bool zeros_pending = false;
 
     // i sweeps M (matmul-outer), j sweeps K (matmul-inner).
     const uint32_t m_bound = TransposeA ? shape.logical_d1 : shape.logical_d0;
@@ -96,6 +97,7 @@ void read_in0_block_sync(
                     tensor_accessor, CoreLocalMem<uint32_t>(write_ptr), tile_size_bytes, {.page_id = tile_id}, {});
             } else {
                 fill_zeros_async(noc, dst_cb_id, tile_size_bytes, write_ptr - cb_base);
+                zeros_pending = true;
             }
             write_ptr += tile_size_bytes;
         }
@@ -103,6 +105,13 @@ void read_in0_block_sync(
         write_ptr += (K_block_tiles - (d1_end - d1_start)) * tile_size_bytes;
     }
     noc.async_read_barrier();
+    if (zeros_pending) {
+        // Pad fills went through async_write_zeros; one barrier covers the whole
+        // batch, completes the fills (the read barrier does not cover them), and
+        // restores the write path (Quasar zero mode) before the caller's NoC
+        // writes (block forwarding / output writes).
+        noc.write_zeros_l1_barrier();
+    }
 }
 
 /**
@@ -131,6 +140,7 @@ void read_in1_block_sync(
     // Padded/out-of-range tiles are zero-filled into dst_cb_id; offset within the CB is the
     // target write pointer minus the CB base (write_ptr_base).
     Noc noc;
+    bool zeros_pending = false;
     // i sweeps K (matmul-inner), j sweeps N (matmul-outer).
     // shape carries storage-layout sizes: when TransposeB, logical_d0=N, logical_d1=K.
     const uint32_t k_bound = TransposeB ? shape.logical_d1 : shape.logical_d0;
@@ -145,6 +155,7 @@ void read_in1_block_sync(
                     uint32_t wp = write_ptr_base + ((i - d0_start) * N_block_tiles + n_col) * tile_size_bytes;
                     fill_zeros_async(noc, dst_cb_id, tile_size_bytes, wp - write_ptr_base);
                 }
+                zeros_pending = true;
                 continue;
             }
             for (uint32_t i = d0_start; i < d0_end; i++) {
@@ -160,6 +171,7 @@ void read_in1_block_sync(
                         tensor_accessor, CoreLocalMem<uint32_t>(wp), tile_size_bytes, {.page_id = tile_id}, {});
                 } else {
                     fill_zeros_async(noc, dst_cb_id, tile_size_bytes, wp - write_ptr_base);
+                    zeros_pending = true;
                 }
             }
         }
@@ -183,6 +195,7 @@ void read_in1_block_sync(
                         tensor_accessor, CoreLocalMem<uint32_t>(write_ptr), tile_size_bytes, {.page_id = tile_id}, {});
                 } else {
                     fill_zeros_async(noc, dst_cb_id, tile_size_bytes, write_ptr - write_ptr_base);
+                    zeros_pending = true;
                 }
                 write_ptr += tile_size_bytes;
             }
@@ -191,6 +204,13 @@ void read_in1_block_sync(
         }
     }
     noc.async_read_barrier();
+    if (zeros_pending) {
+        // Pad fills went through async_write_zeros; one barrier covers the whole
+        // batch, completes the fills (the read barrier does not cover them), and
+        // restores the write path (Quasar zero mode) before the caller's NoC
+        // writes (block forwarding / output writes).
+        noc.write_zeros_l1_barrier();
+    }
 }
 
 /**


### PR DESCRIPTION
### Problem

Fixes #53225.

`variable_matmul`'s block readers (`read_in0_block_sync`, `read_in1_block_sync` in `matmul_dataflow_common.hpp`) zero-fill padded/out-of-range tiles via `fill_zeros_async` and then end with only `noc.async_read_barrier()`.

On Quasar (tt-2xx), `Noc::async_write_zeros` borrows the overlay write command buffer (cmd buffer 0) into iDMA zero mode; only `write_zeros_l1_barrier()` restores it (see `tt_metal/hw/inc/internal/tt-2xx/noc_zero_l1.inl` and the contract on `Noc::async_write_zeros` in `noc.h`). A read barrier neither completes the fills nor restores the cmd buffer, so the very next NoC write on the same RISC — in0/in1 block forwarding to downstream cores and the deferred output writes in `dm_in0_sender.cpp` / `dm_in1_sender_out.cpp` — runs in zero mode and silently emits zeros. On tt-1xx the fills are implemented as reads from `MEM_ZEROS_BASE`, so the read barrier masked the missing pairing.

### Fix

Pattern taken from the moe kernels on #53220 (`zeros_pending` guard, batch fills, one barrier):

- All pad fills in a block batch behind a single `noc.write_zeros_l1_barrier()`, issued after the existing `noc.async_read_barrier()`.
- The barrier is guarded by a `zeros_pending` flag, so fully in-bounds blocks (the hot path — padding only occurs on edge blocks) pay nothing.
- Four fill sites covered: one in `read_in0_block_sync`, three in `read_in1_block_sync` (TransposeB out-of-N column fill, TransposeB out-of-K fill, non-transpose out-of-K fill).

`dataflow_utils.hpp`'s `fill_zeros_async` docstring documenting this contract is updated on #53220; not duplicated here to avoid conflicts.

### Sweep results

- **tt-train**: all other `fill_zeros_async` / `async_write_zeros` sites are either already paired with `write_zeros_l1_barrier()` on main (`moe_group_combined_kernel.cpp`, `reader_frobenius_normalize.cpp`, `select_target_logit_reader.cpp`) or are fixed on #53220 (`moe_ungroup_reader.cpp`, `moe_ungroup_rmw_writer.cpp`) — left untouched here to avoid cross-branch conflicts.
- **k_split_gram_matmul** (reworked on #53223): its kernels use the read-based `fill_tile_zeros` (loopback reads from `MEM_ZEROS_BASE`), which never borrows cmd buffer 0, and #53223 introduces no `async_write_zeros` sites. Nothing needed there.
- **ttnn** (reported for a follow-up issue, not fixed here — different ownership): `ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_minimal_matmul_async/device/kernels/dm_in1_sender_out.cpp` has the same mismatch — `fill_zeros_async` at line 475, only `async_read_barrier()` at line 495, then `noc_async_write` at line 532 (in1 forwarding). Its sibling `matmul_dataflow_common.hpp` and the `minimal_matmul` / `fabric_bound` variants are correctly paired.

### Validation plan

The hazard is tt-2xx-only (watcher builds assert on it via `NOC_ASSERT_NOT_ZERO_MODE`); on tt-1xx `write_zeros_l1_barrier()` is `noc_async_read_barrier()`, so this change is behaviorally a no-op there beyond a guarded redundant barrier on padded edge blocks. Validation = green BH no-regression run of the variable_matmul tests; Quasar correctness rests on the documented `async_write_zeros` / `write_zeros_l1_barrier` contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ayerofieiev/kernel-fix/zeros-barriers-2026-08-17)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ayerofieiev/kernel-fix/zeros-barriers-2026-08-17)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ayerofieiev/kernel-fix/zeros-barriers-2026-08-17)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ayerofieiev/kernel-fix/zeros-barriers-2026-08-17)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ayerofieiev/kernel-fix/zeros-barriers-2026-08-17)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ayerofieiev/kernel-fix/zeros-barriers-2026-08-17)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ayerofieiev/kernel-fix/zeros-barriers-2026-08-17)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ayerofieiev/kernel-fix/zeros-barriers-2026-08-17)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ayerofieiev/kernel-fix/zeros-barriers-2026-08-17)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ayerofieiev/kernel-fix/zeros-barriers-2026-08-17)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ayerofieiev/kernel-fix/zeros-barriers-2026-08-17)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ayerofieiev/kernel-fix/zeros-barriers-2026-08-17)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ayerofieiev/kernel-fix/zeros-barriers-2026-08-17)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ayerofieiev/kernel-fix/zeros-barriers-2026-08-17)