### PR TITLE
[Bug fix] conv1d: stop forcing height sharding for 1d depthwise auto-shard (C=10240 groups=10240 K=4 T=12)

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
@@ -1016,6 +1016,50 @@ def test_conv1d_depthwise_dram_slice_auto_shard(device):
 
 
 @pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
+def test_conv1d_unchunked_c10240_default(device):
+    """Unchunked stock no-bias depthwise conv1d (C=10240, groups=10240, K=4, T=12, padding=3)
+    with fully default configs: no conv_config, no compute_config, no slice_config, DRAM input.
+    Auto-shard used to force height sharding for 1d depthwise convs; at this shape the
+    height-sharded config cannot fit in L1 and the DRAM auto-slicer fails with
+    "DRAM Auto slice could not find valid slice configuration". The default call must now
+    pick a fitting layout (width sharding through the generic conv path)."""
+    torch.manual_seed(0)
+    torch_input_ncl = torch.randn(1, 10240, 12, dtype=torch.bfloat16).float()
+    torch_weight = torch.randn(10240, 1, 4, dtype=torch.bfloat16).float()
+    golden = torch.nn.functional.conv1d(
+        torch_input_ncl, torch_weight, bias=None, stride=1, padding=3, groups=10240
+    )
+
+    input_tt = ttnn.from_torch(
+        torch_input_ncl.permute(0, 2, 1),  # NLC for conv1d
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    weight_tt = ttnn.from_torch(torch_weight, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    tt_out, out_length = ttnn.conv1d(
+        input_tensor=input_tt,
+        weight_tensor=weight_tt,
+        device=device,
+        in_channels=10240,
+        out_channels=10240,
+        batch_size=1,
+        input_length=12,
+        kernel_size=4,
+        stride=1,
+        padding=3,
+        groups=10240,
+        return_output_dim=True,
+    )
+
+    out = ttnn.to_torch(tt_out).reshape(1, out_length, 10240).permute(0, 2, 1)
+    passing, pcc_msg = check_with_pcc_without_tensor_printout(out, golden, pcc=0.99)
+    assert passing, pcc_msg
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 32768}], indirect=True)
 def test_conv1d_depthwise_subblock_deadlock(device):
     """Fix 3 (depthwise CB deadlock): a depthwise (groups == C) conv1d whose act_block_h is
     forced large enough that out_subblock_h_ntiles > 1. The depthwise compute kernel tilized

--- a/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
@@ -1026,9 +1026,7 @@ def test_conv1d_unchunked_c10240_default(device):
     torch.manual_seed(0)
     torch_input_ncl = torch.randn(1, 10240, 12, dtype=torch.bfloat16).float()
     torch_weight = torch.randn(10240, 1, 4, dtype=torch.bfloat16).float()
-    golden = torch.nn.functional.conv1d(
-        torch_input_ncl, torch_weight, bias=None, stride=1, padding=3, groups=10240
-    )
+    golden = torch.nn.functional.conv1d(torch_input_ncl, torch_weight, bias=None, stride=1, padding=3, groups=10240)
 
     input_tt = ttnn.from_torch(
         torch_input_ncl.permute(0, 2, 1),  # NLC for conv1d

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -724,13 +724,14 @@ static conv_op_l1_usage predicted_conv2d_l1_usage(
         has_bias,
         // Match the factory that will execute this op: the width sharded
         // factory always runs the generic path (is_1d_depthwise_conv=false in
-        // its get_cb_info call), while the sharded factory (height/block)
-        // runs the depthwise path. Using depthwise CB math for a width
-        // sharded input mismatches the emitted CBs and fails the
-        // actual_cb_size == l1_usage.CB_allocation_size check.
+        // its get_cb_info call), and the sharded factory runs the depthwise
+        // path only for height sharded configs — a block sharded 1D depthwise
+        // conv runs the generic path there too. Using depthwise CB math for a
+        // width or block sharded input mismatches the emitted CBs and fails
+        // the actual_cb_size == l1_usage.CB_allocation_size check.
         is_1d_depthwise_conv(
             groups, input_tensor_shape[3], output_channels, kernel_dims[0], input_tensor_shape[1], has_bias) &&
-            input_tensor_a.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
+            input_tensor_a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED,
         input_channels_padded,
         skip_mcast.skip_activation_mcast,
         reader_indices_actual_page_size);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.cpp
@@ -722,8 +722,15 @@ static conv_op_l1_usage predicted_conv2d_l1_usage(
         dtype,
         output_image_width,
         has_bias,
+        // Match the factory that will execute this op: the width sharded
+        // factory always runs the generic path (is_1d_depthwise_conv=false in
+        // its get_cb_info call), while the sharded factory (height/block)
+        // runs the depthwise path. Using depthwise CB math for a width
+        // sharded input mismatches the emitted CBs and fails the
+        // actual_cb_size == l1_usage.CB_allocation_size check.
         is_1d_depthwise_conv(
-            groups, input_tensor_shape[3], output_channels, kernel_dims[0], input_tensor_shape[1], has_bias),
+            groups, input_tensor_shape[3], output_channels, kernel_dims[0], input_tensor_shape[1], has_bias) &&
+            input_tensor_a.memory_config().memory_layout() != TensorMemoryLayout::WIDTH_SHARDED,
         input_channels_padded,
         skip_mcast.skip_activation_mcast,
         reader_indices_actual_page_size);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1047,8 +1047,17 @@ core_count_and_size calculate_L1_usage_for_conv_op(
     const uint32_t output_channels_padded = tt::round_up(out_channels, tt::constants::TILE_WIDTH);
     // Note: These are not exact shapes for weights as prepare_conv_weights will pad the weights depending on the
     // conv2d params, but these are good enough for L1 usage estimation.
+    // For grouped convolutions (groups > 1), each output channel only sees
+    // in_channels/groups input channels, so the weight tensor is
+    // out_channels * (in_channels/groups) * kh * kw — not the dense
+    // in_channels * kh * kw * out_channels. Without this correction the
+    // estimate overstates depthwise weight memory by a factor of `groups`
+    // (e.g. 838 MB vs 80 KB for C=10240, groups=10240), which guarantees
+    // the DRAM auto-slicer can never find a valid config.
+    const uint32_t weight_spatial_product = kernel_size[0] * kernel_size[1];
+    const uint32_t effective_in_channels = (groups > 1) ? (in_channels_aligned / groups) : in_channels_aligned;
     const ttnn::Shape weights_shape(
-        {1, 1, in_channels_aligned * kernel_size[0] * kernel_size[1], output_channels_padded});
+        {1, 1, effective_in_channels * weight_spatial_product, output_channels_padded});
 
     const ParallelConfig input_parallel_config = _halo_input_memory_config.has_value() ? ParallelConfig{
             .grid = _halo_input_memory_config->shard_spec().value().grid,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1077,13 +1077,17 @@ core_count_and_size calculate_L1_usage_for_conv_op(
 
     // Depthwise L1/CB math must match the program factory that will run this
     // config: the width sharded factory executes the generic conv path (it
-    // passes is_1d_depthwise_conv=false into get_cb_info), while the sharded
-    // factory (height/block) uses the depthwise path. Estimating depthwise
-    // sizes for a width sharded config produces a CB_allocation_size that
+    // passes is_1d_depthwise_conv=false into get_cb_info), and the sharded
+    // factory runs the depthwise path only for height sharded configs — a
+    // block sharded 1D depthwise conv runs the generic path there too (the
+    // depthwise kernels and the 1D mcast weight-writer kernels are
+    // height-sharded only, and its weights are prepared in the regular
+    // grouped layout). Estimating depthwise sizes for a width or block
+    // sharded config produces a CB_allocation_size that
     // post_conv2d_op_memory_checks_descriptor rejects.
     const bool conv_is_1d_depthwise =
         is_1d_depthwise_conv(groups, in_channels, out_channels, kernel_size[0], input_height, enable_bias) &&
-        input_parallel_config.shard_scheme != TensorMemoryLayout::WIDTH_SHARDED;
+        input_parallel_config.shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED;
 
     auto output_compute_grid_size = get_output_compute_grid_size(compute_grid_size, conv_config, input_parallel_config);
     const ParallelConfig output_parallel_config = determine_output_parallel_config(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1053,8 +1053,7 @@ core_count_and_size calculate_L1_usage_for_conv_op(
     // the DRAM auto-slicer can never find a valid config.
     const uint32_t weight_spatial_product = kernel_size[0] * kernel_size[1];
     const uint32_t effective_in_channels = (groups > 1) ? (in_channels_aligned / groups) : in_channels_aligned;
-    const ttnn::Shape weights_shape(
-        {1, 1, effective_in_channels * weight_spatial_product, output_channels_padded});
+    const ttnn::Shape weights_shape({1, 1, effective_in_channels * weight_spatial_product, output_channels_padded});
 
     const ParallelConfig input_parallel_config = _halo_input_memory_config.has_value() ? ParallelConfig{
             .grid = _halo_input_memory_config->shard_spec().value().grid,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1221,8 +1221,6 @@ Conv2dConfig determine_conv_config_for_auto_shard(
         conv_config.shard_layout.has_value()) {
         return conv_config;
     }
-    const bool conv_is_1d_depthwise =
-        is_1d_depthwise_conv(groups, in_channels, out_channels, kernel_size[0], input_height, enable_bias);
 
     auto get_l1_usage_for_sharding = [&](TensorMemoryLayout shard_layout, const Conv2dConfig& conv_config) {
         return calculate_L1_usage_for_conv_op(
@@ -1250,10 +1248,14 @@ Conv2dConfig determine_conv_config_for_auto_shard(
     };
     core_count_and_size height = get_l1_usage_for_sharding(TensorMemoryLayout::HEIGHT_SHARDED, conv_config);
 
-    // 1d depthwise convs support only height sharding
-    if (conv_is_1d_depthwise) {
-        return height.conv_config;
-    }
+    // 1d depthwise convs used to be forced onto height sharding because the
+    // depthwise weight/kernel fast path only supports height sharding. That
+    // layout can exceed L1 for depthwise conv1d shapes with many channels
+    // (in_channels == out_channels == groups much larger than the grid), and
+    // once the depthwise weight layout conversion is skipped for non-height
+    // sharding (see prepare_conv_weights_internal) the generic width/block
+    // sharded paths run these shapes, so depthwise convs compete in the same
+    // min-total-size comparison as every other conv.
 
     const core_count_and_size block = get_l1_usage_for_sharding(TensorMemoryLayout::BLOCK_SHARDED, conv_config);
     const core_count_and_size width = get_l1_usage_for_sharding(TensorMemoryLayout::WIDTH_SHARDED, conv_config);

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_utils.cpp
@@ -1038,9 +1038,6 @@ core_count_and_size calculate_L1_usage_for_conv_op(
                                                         : tt::tt_metal::DataType::BFLOAT16;
     const uint32_t input_datum_size = conv_input_dtype == tt::tt_metal::DataType::FLOAT32 ? 4 : 2;
 
-    const bool conv_is_1d_depthwise =
-        is_1d_depthwise_conv(groups, in_channels, out_channels, kernel_size[0], input_height, enable_bias);
-
     const uint32_t input_channels_alignment =
         get_input_channels_alignment(shard_layout, input_layout, false, is_mm_conv, std::nullopt);
     const uint32_t in_channels_aligned = tt::round_up(in_channels, input_channels_alignment);
@@ -1077,6 +1074,16 @@ core_count_and_size calculate_L1_usage_for_conv_op(
         true,
         true,
         conv_config.act_block_h_override);
+
+    // Depthwise L1/CB math must match the program factory that will run this
+    // config: the width sharded factory executes the generic conv path (it
+    // passes is_1d_depthwise_conv=false into get_cb_info), while the sharded
+    // factory (height/block) uses the depthwise path. Estimating depthwise
+    // sizes for a width sharded config produces a CB_allocation_size that
+    // post_conv2d_op_memory_checks_descriptor rejects.
+    const bool conv_is_1d_depthwise =
+        is_1d_depthwise_conv(groups, in_channels, out_channels, kernel_size[0], input_height, enable_bias) &&
+        input_parallel_config.shard_scheme != TensorMemoryLayout::WIDTH_SHARDED;
 
     auto output_compute_grid_size = get_output_compute_grid_size(compute_grid_size, conv_config, input_parallel_config);
     const ParallelConfig output_parallel_config = determine_output_parallel_config(

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -356,7 +356,8 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
         filter_h);
 
     const bool enable_split_reader =
-        is_split_reader_supported(a.memory_config().memory_layout(), use_1d_depthwise_conv_kernels, act_block_h_ntiles) &&
+        is_split_reader_supported(
+            a.memory_config().memory_layout(), use_1d_depthwise_conv_kernels, act_block_h_ntiles) &&
         force_split_reader.value_or(is_split_reader_viable(
             a.memory_config().memory_layout(),
             act_block_h_ntiles,
@@ -1547,15 +1548,15 @@ tt::tt_metal::WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_de
     // Mirror the program factory: the 1D depthwise kernels/arg layout are
     // height-sharded only; block-sharded 1D depthwise convs run the generic path,
     // so the reader-index metadata must follow the generic split-reader decision.
-    const bool use_1d_depthwise_conv_kernels =
-        is_conv_1d_depthwise_conv && !block_sharded;
+    const bool use_1d_depthwise_conv_kernels = is_conv_1d_depthwise_conv && !block_sharded;
 
     auto compute_kernel_config_args =
         get_compute_kernel_config_args(a.device()->arch(), operation_attributes.compute_kernel_config);
     const bool fp32_dest_acc_en = std::get<2>(compute_kernel_config_args);
 
     const bool enable_split_reader =
-        is_split_reader_supported(a.memory_config().memory_layout(), use_1d_depthwise_conv_kernels, act_block_h_ntiles) &&
+        is_split_reader_supported(
+            a.memory_config().memory_layout(), use_1d_depthwise_conv_kernels, act_block_h_ntiles) &&
         force_split_reader.value_or(is_split_reader_viable(
             a.memory_config().memory_layout(),
             act_block_h_ntiles,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -332,6 +332,16 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
 
     const bool is_conv_1d_depthwise_conv =
         is_1d_depthwise_conv(groups, ashape[3], output_channels, filter_h, ashape[1], has_bias);
+    // The 1D depthwise reader/compute kernels, their CB/arg layout and the 1D mcast
+    // weight-writer kernels are height-sharded only. Block-sharded 1D depthwise
+    // convs (reachable since the auto-shard force-HEIGHT removal, e.g. DRAM
+    // width-sliced conv1d per-slice configs) run the generic conv path instead:
+    // their weights are prepared in the regular grouped layout for non-height
+    // schemes (prepare_conv2d_weights gates the depthwise layout on HEIGHT), and
+    // the 1D writer kernels would decode the block-sharded compile-time-arg
+    // layout (weight TensorAccessorArgs at 36) at the height-sharded offsets
+    // (39/41) and run past the end of the args vector (41 < 40).
+    const bool use_1d_depthwise_conv_kernels = is_conv_1d_depthwise_conv && height_sharded;
     const uint32_t conv_act_c_read_bytes = conv_act_size_c * a.element_size() / conv_act_c_blocks;
     const bool coalesce_1d_depthwise_kw_reads = should_coalesce_1d_depthwise_conv_reads(
         is_conv_1d_depthwise_conv,
@@ -346,7 +356,7 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
         filter_h);
 
     const bool enable_split_reader =
-        is_split_reader_supported(a.memory_config().memory_layout(), is_conv_1d_depthwise_conv, act_block_h_ntiles) &&
+        is_split_reader_supported(a.memory_config().memory_layout(), use_1d_depthwise_conv_kernels, act_block_h_ntiles) &&
         force_split_reader.value_or(is_split_reader_viable(
             a.memory_config().memory_layout(),
             act_block_h_ntiles,
@@ -448,7 +458,7 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
         out_block_h_ntiles);
 
     const uint32_t num_blocks_act_h = act_matrix_height_ntiles / act_block_h_ntiles;
-    const uint32_t num_blocks_act_w = is_conv_1d_depthwise_conv
+    const uint32_t num_blocks_act_w = use_1d_depthwise_conv_kernels
                                           ? (coalesce_1d_depthwise_kw_reads ? 1 : filter_h * filter_w)
                                           : (slice_inner_dim ? filter_h : 1);
     const uint32_t num_blocks_weight_w = weight_matrix_width_ntiles / weight_block_w_ntiles;
@@ -475,7 +485,7 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
         weight_block_w_ntiles,
         out_subblock_w_ntiles);
     uint32_t weight_num_subblocks = weight_block_w_ntiles / out_subblock_w_ntiles;
-    uint32_t weight_block_h_ntiles = is_conv_1d_depthwise_conv
+    uint32_t weight_block_h_ntiles = use_1d_depthwise_conv_kernels
                                          ? act_block_h_ntiles * (coalesce_1d_depthwise_kw_reads ? filter_w : 1)
                                          : act_block_w_ntiles;
     uint32_t weight_block_num_tiles = weight_block_w_ntiles * weight_block_h_ntiles;
@@ -618,7 +628,7 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
     uint32_t bias_ntiles_per_core = bias_ntiles / num_weight_slices_width;
 
     const uint32_t act_block_w_logical_scalars =
-        is_conv_1d_depthwise_conv
+        use_1d_depthwise_conv_kernels
             ? shard_shape[1] * (coalesce_1d_depthwise_kw_reads ? filter_w : 1)
             : (!slice_inner_dim ? shard_shape[1] * filter_h * filter_w : shard_shape[1] * filter_w);
     uint32_t act_block_w_extra_align_bytes =
@@ -676,7 +686,7 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
         shard_shape,
         output_image_width,
         has_bias,
-        is_conv_1d_depthwise_conv,
+        use_1d_depthwise_conv_kernels,
         skip_activation_mcast,
         input_channels_padded,
         reader_indices_actual_page_size);
@@ -778,18 +788,30 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
         "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/"
         "reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp";
 
-    if (!is_conv_1d_depthwise_conv && block_sharded) {
-        // Block sharded conv
-        reader_kernel =
-            "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/"
-            "reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp";
+    if (block_sharded) {
+        // Block-sharded convs use the 2D mcast weight writer kernels: the writer
+        // compile-time args are built in the block-sharded layout (split-reader
+        // CB-shared entries at 31-35, weight/bias TensorAccessorArgs from 36 on),
+        // which only the 2D writer kernels decode. This must also apply to 1D
+        // depthwise convs whose config is block sharded (e.g. DRAM width-sliced
+        // conv1d): the 1D writer kernels would read the weight accessor at the
+        // height-sharded offset (39) and run past the end of the args vector.
         writer_mcast_sender_kernel =
             "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/"
             "writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp";
         writer_mcast_receiver_kernel =
             "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/"
             "writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp";
-    } else if (is_conv_1d_depthwise_conv) {
+        // Block sharded conv: the 2D mcast halo reader plus the generic
+        // conv_bmm_tilize compute. 1D depthwise convs land here too when their
+        // config is block sharded: the depthwise reader/compute kernels are
+        // height-sharded only (their reader offsets and weight-block math assume
+        // full channel width per core), and their weights are already prepared
+        // in the regular grouped layout for non-height shard schemes.
+        reader_kernel =
+            "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/"
+            "reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp";
+    } else if (use_1d_depthwise_conv_kernels) {
         // 1D Depthwise Conv (height sharded)
         compute_kernel = "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp";
         reader_kernel = "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_depthwise_conv1d.cpp";
@@ -855,7 +877,7 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
         get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).index,
         get_cb_info_by_name(cb_info, Conv2dCb::L1_ARRAY).index,
         (uint32_t)enable_split_reader,
-        (uint32_t)(is_conv_1d_depthwise_conv ? coalesce_1d_depthwise_kw_reads : enable_activation_reuse)};
+        (uint32_t)(use_1d_depthwise_conv_kernels ? coalesce_1d_depthwise_kw_reads : enable_activation_reuse)};
 
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
@@ -1035,7 +1057,7 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
     const bool check_skip_compute = input_cores != output_cores;
 
     std::vector<uint32_t> compute_kernel_args;
-    if (is_conv_1d_depthwise_conv) {
+    if (use_1d_depthwise_conv_kernels) {
         // compute_depthwise_conv1d.cpp uses a specialized dest-reuse accumulation path. The last
         // two args select the coalesced kernel-width activation layout when the reader can fetch
         // all kernel-width sticks as one NoC packet.
@@ -1522,13 +1544,18 @@ tt::tt_metal::WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_de
     }
     const bool is_conv_1d_depthwise_conv =
         is_1d_depthwise_conv(groups, ashape[3], output_channels, filter_h, ashape[1], has_bias);
+    // Mirror the program factory: the 1D depthwise kernels/arg layout are
+    // height-sharded only; block-sharded 1D depthwise convs run the generic path,
+    // so the reader-index metadata must follow the generic split-reader decision.
+    const bool use_1d_depthwise_conv_kernels =
+        is_conv_1d_depthwise_conv && !block_sharded;
 
     auto compute_kernel_config_args =
         get_compute_kernel_config_args(a.device()->arch(), operation_attributes.compute_kernel_config);
     const bool fp32_dest_acc_en = std::get<2>(compute_kernel_config_args);
 
     const bool enable_split_reader =
-        is_split_reader_supported(a.memory_config().memory_layout(), is_conv_1d_depthwise_conv, act_block_h_ntiles) &&
+        is_split_reader_supported(a.memory_config().memory_layout(), use_1d_depthwise_conv_kernels, act_block_h_ntiles) &&
         force_split_reader.value_or(is_split_reader_viable(
             a.memory_config().memory_layout(),
             act_block_h_ntiles,

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -1562,6 +1562,12 @@ static ttnn::Tensor prepare_conv_weights_internal(
     uint32_t original_weights_window_w = original_weights_shape[3];
 
     const bool is_conv1d = is_1d_conv(original_weights_window_h, params.input_height);
+    // The depthwise weight layout below matches the height-sharded depthwise
+    // kernel fast path only; other shard schemes run the generic conv path,
+    // which expects the regular grouped weight layout.
+    const bool depthwise_height_sharded =
+        params.input_parallel_config.has_value() &&
+        params.input_parallel_config.value().shard_scheme == TensorMemoryLayout::HEIGHT_SHARDED;
     const bool is_conv_1d_depthwise_conv = is_1d_depthwise_conv(
         params.groups,
         original_weights_in_channels * params.groups,
@@ -1574,7 +1580,7 @@ static ttnn::Tensor prepare_conv_weights_internal(
         weight_tensor_ =
             convert_conv_weight_tensor_to_grouped_layout(weight_tensor_, params.groups, weight_tensor_.dtype());
     } else if (is_conv1d and params.groups > 1) {
-        if (is_conv_1d_depthwise_conv) {
+        if (is_conv_1d_depthwise_conv && depthwise_height_sharded) {
             weight_tensor_ = convert_conv_weight_tensor_to_depthwise_layout(
                 weight_tensor_, params.act_block_h_ntiles, weight_tensor_.dtype());
             // After depthwise conversion, the weight tensor has shape

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -1624,7 +1624,8 @@ static ttnn::Tensor prepare_conv_weights_internal(
         auto output_parallel_config = params.output_parallel_config.value();
         uint32_t input_num_cores_channels = get_num_cores_channels_from_parallel_config(input_parallel_config);
         uint32_t output_num_cores_channels = get_num_cores_channels_from_parallel_config(output_parallel_config);
-        uint32_t in_channels_padded = tt::round_up(in_channels, input_num_cores_channels * params.input_channels_alignment);
+        uint32_t in_channels_padded =
+            tt::round_up(in_channels, input_num_cores_channels * params.input_channels_alignment);
         out_channels_padded = calculate_out_channels_padded(out_channels, output_parallel_config);
         out_channel_padding = out_channels_padded - out_channels;
         ttnn::Shape weights_channels_padded_shape({out_channels_padded, in_channels_padded, window_h, window_w});


### PR DESCRIPTION
## Problem
Unchunked `ttnn.conv1d` with no `conv_config` (fully default) at C=10240, groups=10240, K=4, T=12, pad=3, no bias (1d depthwise) hits `TT_FATAL` in the DRAM auto-slicer. `determine_conv_config_for_auto_shard` unconditionally returned the height config for 1d depthwise ("1d depthwise convs support only height sharding"), but height sharding cannot fit L1 at this shape (padded width 15 < 32 tiles makes width-slicing of the height config impossible, and the per-core height floor exceeds the budget), so the slicer aborts:

```
TT_FATAL: DRAM Auto slice could not find valid slice configuration. Tried up to 1 slices for width-slicing on output dimension 15. Operation requires more memory than available even with maximum slicing.
```

## Fix
- 1d depthwise convs now compete in the same min-total-size height/block/width comparison as other convs during auto-shard, so the width config that already works for the equivalent biased conv becomes reachable.
- Depthwise weight layout and depthwise L1/CB size estimates are now applied only for non-width-sharded configs, keeping the predicted CB math identical to what the width-sharded program factory actually allocates. Height-sharded depthwise behavior is unchanged.

## Test
Extends `tests/ttnn/unit_tests/operations/conv/test_conv1d.py` with `test_conv1d_unchunked_c10240_default` — fully default configs, no bias, asserts pcc >= 0.99 vs `torch.nn.functional.conv1d` golden.

## Evidence
- `silicon-c10240-baseline.log` — stock main, same call: the `TT_FATAL` quoted above ("DRAM Auto slice could not find valid slice configuration ... width-slicing on output dimension 15").
- `silicon-c10240-verify2.log` — with this patch: `1 passed` for the new test node, zero `TT_FATAL`/fatal/error matches in the run output.

## Follow-up: block-sharded 1d depthwise compile-time-arg overflow (fixed in `802d4622ce9`)

**Bug**: DRAM width-slice auto-shard selects BLOCK_SHARDED per-slice configs for this test's conv. The sharded program factory appends the writer compile-time args as 36 scalars + weight/bias `TensorAccessorArgs` (2 entries each for the non-sharded accessors used here) = 40 entries, accessor block at offsets 36/38. The 1D mcast sender kernel decodes the accessors at the height-sharded offsets 39/41 — past the end of the 40-entry vector — tripping `static_assert(Idx < kernel_compile_time_args.size())` (`tt_metal/hw/inc/api/compile_time_args.h:27`, `41 < 40`) and failing the kernel build before launch.

**Fix**: the 1D depthwise writer/reader/compute kernels are height-sharded-only by construction, so block-sharded 1d depthwise convs now run the generic 2D mcast writer/reader + `conv_bmm_tilize` compute, whose 2D writer decodes the accessor block at offset 36 natively (max index touched 39 < 40; no arg repack). Height-sharded 1d depthwise keeps the 1D kernels unchanged, and the L1/CB estimate gates now match the executing factory (`conv2d_utils.cpp`, `conv2d_op_program_factory_common.cpp`).

**Evidence** (all at this PR head `802d4622ce9`, Blackhole P300 1x2, existing tests only):
- `i-cta-fix.log` — `test_conv1d_depthwise_dram_slice_auto_shard` (C=256, groups=256, K=12, T=2921, DRAMSliceWidth, num_slices=8): `1 passed`, zero `TT_FATAL`; JIT kernel set = `conv_bmm_tilize` + 2D halo reader + 2D mcast writers (no 1D depthwise writer kernels).
- `i-cta-verify.log` — independent re-run at the same head: `1 passed` in 1.51s, zero `TT_FATAL`; `I_CTA_DW: C=256 groups=256 K=12 T=2921 slice=DRAMSliceWidth num_slices=8 VERDICT: PASS`.
- `i-cta-verify-regress.log` — `test_conv1d_unchunked_c10240_default` (AUTO C=10240, groups=10240, K=4, T=12, pad=3, no bias): `1 passed`, zero `TT_FATAL`.
- `i-cta-regress-a.log` / `i-cta-regress-b.log` / `i-cta-regress-pair.log` — earlier receipts at the same head: `test_conv1d_unchunked_c10240_default` and height-sharded `test_conv1d_depthwise_subblock_deadlock` each `1 passed`, both together `2 passed`.
