### PR TITLE
test(graph_query): assert softmax DFB peak instead of CB peak

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_query_op_constraints.cpp
@@ -467,8 +467,11 @@ TEST_P(SoftmaxOpIfTest, Softmax) {
             true);         // numeric_stable
 
         EXPECT_EQ(query.status, ttnn::graph::ExecutionStatus::Success);
-        // Ensure some real usage is reported
-        EXPECT_GT(query.resource_usage.cb_peak_size_per_core, 1024);
+        // Ensure some real usage is reported. Softmax is a Metal 2.0 op: its program-scope L1
+        // is reported under dataflow_buffer_peak_size_per_core (and peak_memory_usage_per_core),
+        // not cb_peak_size_per_core, which is legitimately 0 for a ported op. See ResourceUsage
+        // in ttnn/api/ttnn/graph/graph_query_op_constraints.hpp.
+        EXPECT_GT(query.resource_usage.dataflow_buffer_peak_size_per_core, 1024);
         EXPECT_GT(query.resource_usage.l1_buffers_peak_per_core, 1024);
         EXPECT_GT(query.resource_usage.l1_output_buffer_per_core, 1024);
         EXPECT_GT(query.resource_usage.peak_memory_usage_per_core, 1024);


### PR DESCRIPTION
## Issue
Closes #52626.

## Summary

- `SoftmaxOpIfTest.Softmax` was asserting `cb_peak_size_per_core > 1024`, which started failing on T3K (`actual: 0 vs 1024`) after #51753 ported softmax to Metal 2.0 `DataflowBuffer`s.
- Softmax's program-scope L1 is now reported under `dataflow_buffer_peak_size_per_core` (and folded into `peak_memory_usage_per_core`); `cb_peak_size_per_core` is legitimately `0` for a Metal 2.0–ported op (see `ResourceUsage` in `ttnn/api/ttnn/graph/graph_query_op_constraints.hpp`).
- Updated the assertion to check `dataflow_buffer_peak_size_per_core` instead, aligning softmax with the sibling `EltwiseUnaryOpIfTest` / `EltwiseBinaryOpIfTest` which already assert on the L1/total buckets rather than the CB bucket.

## Root cause

#51753 (commit `c86f500`) moved `normalization/softmax` from the legacy `ProgramDescriptor` + `CBDescriptor` path to `create_program_artifacts` + `DataflowBufferSpec`. The graph query interface accumulates L1 into separate channels per kind: `cb_peak_size_per_core` is fed only by `circular_buffer_allocate` trace nodes, while DataFlowBuffer allocations go into `dataflow_buffer_peak_size_per_core` (`ttnn/core/graph/graph_trace_utils.cpp`, `extract_resource_usage_per_core`). After the port softmax emits zero `circular_buffer_allocate` nodes, so `cb_peak_size_per_core` is 0 while the op still returns `ExecutionStatus::Success` and its L1 shows up under the DFB/total buckets. The test was not updated alongside the port. Full analysis posted in https://github.com/tenstorrent/tt-metal/issues/52626#issuecomment-5320954840.

## Test plan

- [x] `./build/test/ttnn/unit_tests_ttnn --gtest_filter='QueryOpConstraints/SoftmaxOpIfTest.Softmax/*'` on a T3K box (8× N300, `ARCH_NAME=wormhole_b0`): both previously-failing cases (`0_L1_HS_3x1x1024x1024`, `1_L1_I_4x2x160x224`) now PASS.
- [x] `./build/test/ttnn/unit_tests_ttnn --gtest_filter='QueryOpConstraints/*'`: 39 tests passed across all 4 suites (EltwiseUnary, Softmax, EltwiseBinary, Matmul) — no sibling regressions.
- [x] [![(T3K) T3000 unit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml/badge.svg?branch=gchoudhary/52626/fix-softmax-cb-peak-dfb-accounting)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-unit-tests.yaml?query=branch:gchoudhary/52626/fix-softmax-cb-peak-dfb-accounting)