### PR TITLE
[Cleanup] emule tests modernization

### DIFF
--- a/tests/tt_metal/tt_metal/api/emule/test_alignment_writes.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_alignment_writes.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // To run (from the tt-metal repo root, after an emule build):
-//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="MeshDeviceFixture.Noc*"
+//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="UnitMeshFixture.Noc*"
 //
 // The DRAM-read tests are arch-specific (`_WH` = 32 B rule, `_BH` = 64 B rule).
 // Each one queries the device arch at runtime and GTEST_SKIPs when it doesn't
@@ -27,6 +27,7 @@
 #include <tt-metalium/mesh_buffer.hpp>
 #include <umd/device/types/core_coordinates.hpp>
 #include "device_fixture.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -35,10 +36,9 @@ namespace tt::tt_metal {
 
 // L1->L1 read: the L1 destination 0x30001 is not 16-byte aligned -> abort.
 // (The source 0x30000 IS 16-aligned, so only the destination branch fires.)
-TEST_F(MeshDeviceFixture, NocRead_L1_Misaligned_SanityCheck) {
+TEST_F(UnitMeshFixture, NocRead_L1_Misaligned_SanityCheck) {
     setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -60,7 +60,8 @@ TEST_F(MeshDeviceFixture, NocRead_L1_Misaligned_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        detail::LaunchProgram(device, program), ".*NOC Transfer Alignment.*L1 destination.*must be 16-byte aligned.*");
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        ".*NOC Transfer Alignment.*L1 destination.*must be 16-byte aligned.*");
 
     unsetenv("TT_METAL_EMULE_ASAN");
 }
@@ -68,10 +69,9 @@ TEST_F(MeshDeviceFixture, NocRead_L1_Misaligned_SanityCheck) {
 // L1->L1 write: the L1 source 0x30001 is not 16-byte aligned -> abort. Misaligns
 // the SOURCE (not the destination) so this exercises the write check's L1-source
 // branch, which no other death test covers.
-TEST_F(MeshDeviceFixture, NocWrite_L1_Misaligned_SanityCheck) {
+TEST_F(UnitMeshFixture, NocWrite_L1_Misaligned_SanityCheck) {
     setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -93,7 +93,8 @@ TEST_F(MeshDeviceFixture, NocWrite_L1_Misaligned_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        detail::LaunchProgram(device, program), ".*NOC Transfer Alignment.*L1 source.*must be 16-byte aligned.*");
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        ".*NOC Transfer Alignment.*L1 source.*must be 16-byte aligned.*");
 
     unsetenv("TT_METAL_EMULE_ASAN");
 }
@@ -103,10 +104,9 @@ TEST_F(MeshDeviceFixture, NocWrite_L1_Misaligned_SanityCheck) {
 // the branch reached only when the destination passes AND the source resolves to
 // L1 (not DRAM). No other read test exercises it (the DRAM tests take the
 // DRAM-source arm; NocRead_L1_Misaligned aborts on the destination first).
-TEST_F(MeshDeviceFixture, NocRead_L1_Misaligned_Source_SanityCheck) {
+TEST_F(UnitMeshFixture, NocRead_L1_Misaligned_Source_SanityCheck) {
     setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -128,7 +128,8 @@ TEST_F(MeshDeviceFixture, NocRead_L1_Misaligned_Source_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        detail::LaunchProgram(device, program), ".*NOC Transfer Alignment.*L1 source.*must be 16-byte aligned.*");
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        ".*NOC Transfer Alignment.*L1 source.*must be 16-byte aligned.*");
 
     unsetenv("TT_METAL_EMULE_ASAN");
 }
@@ -138,10 +139,9 @@ TEST_F(MeshDeviceFixture, NocRead_L1_Misaligned_Source_SanityCheck) {
 // branch fires with its L1 label ("%s destination" -> "L1 destination"). No
 // other write test exercises the L1-destination path (NocWrite_L1_Misaligned
 // aborts on the source first; NocWrite_DRAM_Misaligned takes the DRAM label).
-TEST_F(MeshDeviceFixture, NocWrite_L1_Misaligned_Dest_SanityCheck) {
+TEST_F(UnitMeshFixture, NocWrite_L1_Misaligned_Dest_SanityCheck) {
     setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -163,7 +163,8 @@ TEST_F(MeshDeviceFixture, NocWrite_L1_Misaligned_Dest_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        detail::LaunchProgram(device, program), ".*NOC Transfer Alignment.*L1 destination.*must be 16-byte aligned.*");
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        ".*NOC Transfer Alignment.*L1 destination.*must be 16-byte aligned.*");
 
     unsetenv("TT_METAL_EMULE_ASAN");
 }
@@ -173,16 +174,14 @@ TEST_F(MeshDeviceFixture, NocWrite_L1_Misaligned_Dest_SanityCheck) {
 // alignment (WH = 32 B) and must abort. The L1 destination 0x30020 IS 16-byte
 // aligned, so its branch passes and only the DRAM-source branch fires.
 // Constructs the DRAM NOC address from the host-side NOC XY of DRAM bank 0.
-TEST_F(MeshDeviceFixture, NocRead_DRAM_Misaligned_SanityCheck_WH) {
+TEST_F(UnitMeshFixture, NocRead_DRAM_Misaligned_SanityCheck_WH) {
     setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto& mesh = this->devices_.at(0);
-    auto* device = mesh->get_devices()[0];
     // WH-only: the 32 B DRAM-read rule is compiled into the JIT kernel only under
     // a wormhole cluster. Under blackhole the same offset aborts with the 64 B
     // message (regex mismatch), so gate to WH and SKIP elsewhere rather than fail
     // — this keeps the bare `Noc*` glob green on any arch.
-    if (device->arch() != tt::ARCH::WORMHOLE_B0) {
+    if (this->device().arch() != tt::ARCH::WORMHOLE_B0) {
         GTEST_SKIP() << "WH-only (32 B DRAM-read alignment); device arch is not wormhole.";
     }
     CoreCoord logical_core = {0, 0};
@@ -191,7 +190,7 @@ TEST_F(MeshDeviceFixture, NocRead_DRAM_Misaligned_SanityCheck_WH) {
     // Get DRAM bank 0 NOC coordinates and build a NOC address with offset 0x10
     // (16-byte aligned, NOT 32-byte aligned).
     // NOC encoding: (y << 6) | x, shifted by 36 for the local-address field.
-    auto dram_noc_coord = mesh->virtual_core_from_logical_core({0, 0}, CoreType::DRAM);
+    auto dram_noc_coord = this->device().virtual_core_from_logical_core({0, 0}, CoreType::DRAM);
     uint32_t noc_xy = (static_cast<uint32_t>(dram_noc_coord.y) << 6) | static_cast<uint32_t>(dram_noc_coord.x);
     uint64_t dram_src = (static_cast<uint64_t>(noc_xy) << 36) | 0x0010ULL;
     uint32_t dram_lo = static_cast<uint32_t>(dram_src & 0xFFFFFFFFU);
@@ -220,7 +219,8 @@ TEST_F(MeshDeviceFixture, NocRead_DRAM_Misaligned_SanityCheck_WH) {
     SetRuntimeArgs(program, kernel, logical_core, {dram_lo, dram_hi, l1_dst});
 
     EXPECT_DEATH(
-        detail::LaunchProgram(device, program), ".*NOC Transfer Alignment.*DRAM source.*must be 32-byte aligned.*");
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        ".*NOC Transfer Alignment.*DRAM source.*must be 32-byte aligned.*");
 
     unsetenv("TT_METAL_EMULE_ASAN");
 }
@@ -232,16 +232,14 @@ TEST_F(MeshDeviceFixture, NocRead_DRAM_Misaligned_SanityCheck_WH) {
 // JIT-compiles with ARCH_BLACKHOLE, so the src mask is 0x3F and the message
 // reads "64-byte aligned". The 0x20 offset would PASS the WH 32 B rule, so this
 // test only fires under blackhole (the runners gate _WH/_BH by arch).
-TEST_F(MeshDeviceFixture, NocRead_DRAM_Misaligned_SanityCheck_BH) {
+TEST_F(UnitMeshFixture, NocRead_DRAM_Misaligned_SanityCheck_BH) {
     setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto& mesh = this->devices_.at(0);
-    auto* device = mesh->get_devices()[0];
     // BH-only: the 64 B DRAM-read rule is compiled into the JIT kernel only under
     // a blackhole cluster. Under wormhole the 32 B rule accepts this 32-aligned
     // offset, so the read proceeds and aborts as an OOB write instead — gate to
     // BH and SKIP elsewhere so the bare `Noc*` glob stays green on any arch.
-    if (device->arch() != tt::ARCH::BLACKHOLE) {
+    if (this->device().arch() != tt::ARCH::BLACKHOLE) {
         GTEST_SKIP() << "BH-only (64 B DRAM-read alignment); device arch is not blackhole.";
     }
     CoreCoord logical_core = {0, 0};
@@ -249,7 +247,7 @@ TEST_F(MeshDeviceFixture, NocRead_DRAM_Misaligned_SanityCheck_BH) {
 
     // Get DRAM bank 0 NOC coordinates and build a NOC address with offset 0x20
     // (32-byte aligned, NOT 64-byte aligned).
-    auto dram_noc_coord = mesh->virtual_core_from_logical_core({0, 0}, CoreType::DRAM);
+    auto dram_noc_coord = this->device().virtual_core_from_logical_core({0, 0}, CoreType::DRAM);
     uint32_t noc_xy = (static_cast<uint32_t>(dram_noc_coord.y) << 6) | static_cast<uint32_t>(dram_noc_coord.x);
     uint64_t dram_src = (static_cast<uint64_t>(noc_xy) << 36) | 0x0020ULL;
     uint32_t dram_lo = static_cast<uint32_t>(dram_src & 0xFFFFFFFFU);
@@ -278,7 +276,8 @@ TEST_F(MeshDeviceFixture, NocRead_DRAM_Misaligned_SanityCheck_BH) {
     SetRuntimeArgs(program, kernel, logical_core, {dram_lo, dram_hi, l1_dst});
 
     EXPECT_DEATH(
-        detail::LaunchProgram(device, program), ".*NOC Transfer Alignment.*DRAM source.*must be 64-byte aligned.*");
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        ".*NOC Transfer Alignment.*DRAM source.*must be 64-byte aligned.*");
 
     unsetenv("TT_METAL_EMULE_ASAN");
 }
@@ -286,16 +285,14 @@ TEST_F(MeshDeviceFixture, NocRead_DRAM_Misaligned_SanityCheck_BH) {
 // L1->DRAM write (WH/BH): the DRAM destination offset 0x01 is not 16-byte aligned
 // (DRAM write alignment is 16 B on both arches) -> abort. The L1 source 0x30000
 // IS 16-aligned, so only the destination branch fires.
-TEST_F(MeshDeviceFixture, NocWrite_DRAM_Misaligned_SanityCheck) {
+TEST_F(UnitMeshFixture, NocWrite_DRAM_Misaligned_SanityCheck) {
     setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto& mesh = this->devices_.at(0);
-    auto* device = mesh->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     // Build DRAM NOC address with offset 0x01 so lower 4 bits = 1.
-    auto dram_noc_coord = mesh->virtual_core_from_logical_core({0, 0}, CoreType::DRAM);
+    auto dram_noc_coord = this->device().virtual_core_from_logical_core({0, 0}, CoreType::DRAM);
     uint32_t noc_xy = (static_cast<uint32_t>(dram_noc_coord.y) << 6) | static_cast<uint32_t>(dram_noc_coord.x);
     uint64_t dram_dst = (static_cast<uint64_t>(noc_xy) << 36) | 0x0001ULL;
     uint32_t dram_lo = static_cast<uint32_t>(dram_dst & 0xFFFFFFFFU);
@@ -323,7 +320,7 @@ TEST_F(MeshDeviceFixture, NocWrite_DRAM_Misaligned_SanityCheck) {
     SetRuntimeArgs(program, kernel, logical_core, {dram_lo, dram_hi, l1_src});
 
     EXPECT_DEATH(
-        detail::LaunchProgram(device, program),
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
         ".*NOC Transfer Alignment.*DRAM destination.*must be 16-byte aligned.*");
 
     unsetenv("TT_METAL_EMULE_ASAN");
@@ -341,13 +338,11 @@ TEST_F(MeshDeviceFixture, NocWrite_DRAM_Misaligned_SanityCheck) {
 // failing this test. The DRAM source is a real DRAM-bank NOC-XY (so the NOC
 // resolver maps it instead of raising a Fabric violation) and the L1 dest sits
 // inside an allocated L1 buffer (so the dst-side OOB-tensor check passes).
-TEST_F(MeshDeviceFixture, NocRead_DRAM_Aligned_NoViolation_WH) {
+TEST_F(UnitMeshFixture, NocRead_DRAM_Aligned_NoViolation_WH) {
     setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto& mesh = this->devices_.at(0);
-    auto* device = mesh->get_devices()[0];
     // WH-only positive control (guards the 32 B / 0x1F mask). Skip on other arches.
-    if (device->arch() != tt::ARCH::WORMHOLE_B0) {
+    if (this->device().arch() != tt::ARCH::WORMHOLE_B0) {
         GTEST_SKIP() << "WH-only positive control; device arch is not wormhole.";
     }
     CoreCoord logical_core = {0, 0};
@@ -358,14 +353,17 @@ TEST_F(MeshDeviceFixture, NocRead_DRAM_Aligned_NoViolation_WH) {
     // bits (0x20) differ from the DRAM source's (0x40) — that divergence is
     // exactly what the broken 0xFF mask used to reject.
     constexpr uint32_t buf_size = 8192;
-    auto l1_buf = Buffer::create(device, buf_size, buf_size, BufferType::L1);
+    auto l1_buf = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = buf_size},
+        {.page_size = buf_size, .buffer_type = BufferType::L1},
+        &this->device());
     uint32_t base = static_cast<uint32_t>(l1_buf->address());
     uint32_t l1_dst = ((base + 0xFFu) & ~0xFFu) + 0x20u;  // 256-align, +0x20 -> low5=0, low8=0x20
     ASSERT_GE(l1_dst, base);
     ASSERT_LT(l1_dst + 32u, base + buf_size);
 
     // DRAM source on bank 0, offset 0x40 (32-byte aligned, low5=0).
-    auto dram_noc_coord = mesh->virtual_core_from_logical_core({0, 0}, CoreType::DRAM);
+    auto dram_noc_coord = this->device().virtual_core_from_logical_core({0, 0}, CoreType::DRAM);
     uint32_t noc_xy = (static_cast<uint32_t>(dram_noc_coord.y) << 6) | static_cast<uint32_t>(dram_noc_coord.x);
     constexpr uint32_t dram_off = 0x40u;
     uint64_t dram_src = (static_cast<uint64_t>(noc_xy) << 36) | dram_off;
@@ -397,7 +395,7 @@ TEST_F(MeshDeviceFixture, NocRead_DRAM_Aligned_NoViolation_WH) {
 
     // Must NOT abort. If the alignment mask regresses to something stricter than
     // 0x1F, this LaunchProgram SIGABRTs and the harness marks the test failed.
-    detail::LaunchProgram(device, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
     SUCCEED();
 
     unsetenv("TT_METAL_EMULE_ASAN");
@@ -412,13 +410,11 @@ TEST_F(MeshDeviceFixture, NocRead_DRAM_Aligned_NoViolation_WH) {
 // SIGABRTs, failing this test. As with the WH control, the DRAM source is a real
 // DRAM-bank NOC-XY (mapped by the NOC resolver, not a Fabric violation) and the
 // L1 dest sits inside an allocated L1 buffer (so the dst-side OOB check passes).
-TEST_F(MeshDeviceFixture, NocRead_DRAM_Aligned_NoViolation_BH) {
+TEST_F(UnitMeshFixture, NocRead_DRAM_Aligned_NoViolation_BH) {
     setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto& mesh = this->devices_.at(0);
-    auto* device = mesh->get_devices()[0];
     // BH-only positive control (guards the 64 B / 0x3F mask). Skip on other arches.
-    if (device->arch() != tt::ARCH::BLACKHOLE) {
+    if (this->device().arch() != tt::ARCH::BLACKHOLE) {
         GTEST_SKIP() << "BH-only positive control; device arch is not blackhole.";
     }
     CoreCoord logical_core = {0, 0};
@@ -429,14 +425,17 @@ TEST_F(MeshDeviceFixture, NocRead_DRAM_Aligned_NoViolation_BH) {
     // (0x80) differ from the DRAM source's (0x40) — that divergence is exactly
     // what an over-strict relative mask would wrongly reject.
     constexpr uint32_t buf_size = 8192;
-    auto l1_buf = Buffer::create(device, buf_size, buf_size, BufferType::L1);
+    auto l1_buf = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = buf_size},
+        {.page_size = buf_size, .buffer_type = BufferType::L1},
+        &this->device());
     uint32_t base = static_cast<uint32_t>(l1_buf->address());
     uint32_t l1_dst = ((base + 0xFFu) & ~0xFFu) + 0x80u;  // 256-align, +0x80 -> low6=0, low8=0x80
     ASSERT_GE(l1_dst, base);
     ASSERT_LT(l1_dst + 64u, base + buf_size);
 
     // DRAM source on bank 0, offset 0x40 (64-byte aligned, low6=0).
-    auto dram_noc_coord = mesh->virtual_core_from_logical_core({0, 0}, CoreType::DRAM);
+    auto dram_noc_coord = this->device().virtual_core_from_logical_core({0, 0}, CoreType::DRAM);
     uint32_t noc_xy = (static_cast<uint32_t>(dram_noc_coord.y) << 6) | static_cast<uint32_t>(dram_noc_coord.x);
     constexpr uint32_t dram_off = 0x40u;
     uint64_t dram_src = (static_cast<uint64_t>(noc_xy) << 36) | dram_off;
@@ -468,7 +467,7 @@ TEST_F(MeshDeviceFixture, NocRead_DRAM_Aligned_NoViolation_BH) {
 
     // Must NOT abort. If the alignment mask regresses to something stricter than
     // 0x3F, this LaunchProgram SIGABRTs and the harness marks the test failed.
-    detail::LaunchProgram(device, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
     SUCCEED();
 
     unsetenv("TT_METAL_EMULE_ASAN");
@@ -480,10 +479,9 @@ TEST_F(MeshDeviceFixture, NocRead_DRAM_Aligned_NoViolation_BH) {
 // passes, since the other positive controls are DRAM-source reads. Placed here,
 // with the other non-death controls (after every death test), so the death
 // tests' EXPECT_DEATH forks all precede any non-death LaunchProgram.
-TEST_F(MeshDeviceFixture, NocRead_L1_Aligned_NoViolation) {
+TEST_F(UnitMeshFixture, NocRead_L1_Aligned_NoViolation) {
     setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -493,7 +491,10 @@ TEST_F(MeshDeviceFixture, NocRead_L1_Aligned_NoViolation) {
     // fire for the wrong reason. The allocator aligns buffer starts to >=16 B, so
     // base and base+16 are both 16-byte aligned.
     constexpr uint32_t buffer_size = 1024;
-    auto buf = Buffer::create(device, buffer_size, buffer_size, BufferType::L1);
+    auto buf = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = buffer_size},
+        {.page_size = buffer_size, .buffer_type = BufferType::L1},
+        &this->device());
     uint32_t base = static_cast<uint32_t>(buf->address());
     ASSERT_EQ(base & 0xF, 0u);
 
@@ -516,7 +517,7 @@ TEST_F(MeshDeviceFixture, NocRead_L1_Aligned_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {base});
 
     // Must NOT abort on the alignment check.
-    detail::LaunchProgram(device, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
     SUCCEED();
 
     unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/emule/test_cb_leak.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_cb_leak.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // To run (from the tt-metal repo root, after an emule build):
-//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="MeshDeviceFixture.Dirty_CB_*"
+//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="UnitMeshFixture.Dirty_CB_*"
 
 #include <gtest/gtest.h>
 #include <cstdint>
@@ -13,6 +13,7 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -30,14 +31,13 @@ namespace tt::tt_metal {
 // more than they push but always push after their last reserve (see
 // Dirty_CB_LookaheadReserve_NoViolation). The sanitizer must catch a truly
 // un-followed reserve/wait while leaving the lookahead idiom alone.
-TEST_F(MeshDeviceFixture, Dirty_CB_ReserveWithoutPush) {
+TEST_F(UnitMeshFixture, Dirty_CB_ReserveWithoutPush) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
     // This test validates the Dirty CB check itself, so force it on regardless
     // of any environment-level opt-out (TT_METAL_EMULE_ASAN_SKIP_DIRTY_CB) that a
     // regression run may have exported to skip the check elsewhere.
     ::unsetenv("TT_METAL_EMULE_ASAN_SKIP_DIRTY_CB");
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -62,20 +62,20 @@ TEST_F(MeshDeviceFixture, Dirty_CB_ReserveWithoutPush) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        detail::LaunchProgram(device, program), ".*Dirty CB Detected: Core \\(0, 0\\) CB 0 was not flushed!.*");
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        ".*Dirty CB Detected: Core \\(0, 0\\) CB 0 was not flushed!.*");
 }
 
 // The consumer-side mirror: a kernel that waits on a page but never pops it
 // leaves the CB un-flushed — the consumer claimed read access it never released,
 // so the read pointer desyncs. The sanitizer must catch this too.
-TEST_F(MeshDeviceFixture, Dirty_CB_WaitWithoutPop) {
+TEST_F(UnitMeshFixture, Dirty_CB_WaitWithoutPop) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
     // This test validates the Dirty CB check itself, so force it on regardless
     // of any environment-level opt-out (TT_METAL_EMULE_ASAN_SKIP_DIRTY_CB) that a
     // regression run may have exported to skip the check elsewhere.
     ::unsetenv("TT_METAL_EMULE_ASAN_SKIP_DIRTY_CB");
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -103,7 +103,8 @@ TEST_F(MeshDeviceFixture, Dirty_CB_WaitWithoutPop) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        detail::LaunchProgram(device, program), ".*Dirty CB Detected: Core \\(0, 0\\) CB 0 was not flushed!.*");
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        ".*Dirty CB Detected: Core \\(0, 0\\) CB 0 was not flushed!.*");
 }
 
 // Lookahead / double-buffer producer: reserves more pages than it pushes on
@@ -115,11 +116,10 @@ TEST_F(MeshDeviceFixture, Dirty_CB_WaitWithoutPop) {
 // NOT abort. It is the regression guard for the false positive that a net-count
 // Dirty-CB check produced (it flagged ~num_blocks*block_tiles "unpushed" pages on
 // a correct matmul reader); the trailing-dangling-flag detection fixes it.
-TEST_F(MeshDeviceFixture, Dirty_CB_LookaheadReserve_NoViolation) {
+TEST_F(UnitMeshFixture, Dirty_CB_LookaheadReserve_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
     ::unsetenv("TT_METAL_EMULE_ASAN_SKIP_DIRTY_CB");
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -150,7 +150,7 @@ TEST_F(MeshDeviceFixture, Dirty_CB_LookaheadReserve_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Must NOT abort — lookahead over-reservation is correct on silicon.
-    detail::LaunchProgram(device, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -161,14 +161,13 @@ TEST_F(MeshDeviceFixture, Dirty_CB_LookaheadReserve_NoViolation) {
 // nothing was popped). Leftover occupancy is NOT what this check is about — only
 // unmatched reserve/wait. This must NOT abort. It also guards against regressing
 // to the old (mistaken) "any occupied CB aborts" rule.
-TEST_F(MeshDeviceFixture, Dirty_CB_Balanced_NoViolation) {
+TEST_F(UnitMeshFixture, Dirty_CB_Balanced_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
     // This test validates the Dirty CB check itself, so force it on regardless
     // of any environment-level opt-out (TT_METAL_EMULE_ASAN_SKIP_DIRTY_CB) that a
     // regression run may have exported to skip the check elsewhere.
     ::unsetenv("TT_METAL_EMULE_ASAN_SKIP_DIRTY_CB");
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -194,7 +193,7 @@ TEST_F(MeshDeviceFixture, Dirty_CB_Balanced_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Must NOT abort.
-    detail::LaunchProgram(device, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -206,11 +205,10 @@ TEST_F(MeshDeviceFixture, Dirty_CB_Balanced_NoViolation) {
 // the runner's sweep_per_kernel_dirty_cbs returns early. This lets a regression
 // run proceed past a known un-flushed-CB bug while every other sanitizer stays
 // active.
-TEST_F(MeshDeviceFixture, Dirty_CB_SkipEnv_Suppresses) {
+TEST_F(UnitMeshFixture, Dirty_CB_SkipEnv_Suppresses) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
     ::setenv("TT_METAL_EMULE_ASAN_SKIP_DIRTY_CB", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -235,7 +233,7 @@ TEST_F(MeshDeviceFixture, Dirty_CB_SkipEnv_Suppresses) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Must NOT abort — the Dirty CB check is suppressed by the opt-out env var.
-    detail::LaunchProgram(device, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN_SKIP_DIRTY_CB");

--- a/tests/tt_metal/tt_metal/api/emule/test_cb_pages.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_cb_pages.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // To run (from the tt-metal repo root, after an emule build):
-//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="MeshDeviceFixture.CB_Reservation_*"
+//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="UnitMeshFixture.CB_Reservation_*"
 
 #include <gtest/gtest.h>
 #include <cstdint>
@@ -13,14 +13,14 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
 
 namespace tt::tt_metal {
 
-TEST_F(MeshDeviceFixture, CB_Reservation_Overflow_SanityCheck) {
-    auto* device = this->devices_.at(0)->get_devices()[0];
+TEST_F(UnitMeshFixture, CB_Reservation_Overflow_SanityCheck) {
     CoreCoord logical_core = {0, 0};
 
     Program program = CreateProgram();
@@ -45,17 +45,18 @@ TEST_F(MeshDeviceFixture, CB_Reservation_Overflow_SanityCheck) {
         logical_core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
-    EXPECT_DEATH(detail::LaunchProgram(device, program), ".*\\[ASAN ERROR\\] CB Reservation Overflow:.*");
+    EXPECT_DEATH(
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        ".*\\[ASAN ERROR\\] CB Reservation Overflow:.*");
 }
 
 // CB Reservation Overflow is the one check that is ALWAYS ON (not gated by
 // TT_METAL_EMULE_ASAN) — gating it would let an over-reserve deadlock on the
 // free-space wait instead of reporting a clear error. This test explicitly
 // clears the master switch and confirms the over-reserve still aborts.
-TEST_F(MeshDeviceFixture, CB_Reservation_Overflow_AlwaysOn) {
+TEST_F(UnitMeshFixture, CB_Reservation_Overflow_AlwaysOn) {
     ::unsetenv("TT_METAL_EMULE_ASAN");  // master switch OFF — check must still fire
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
 
     Program program = CreateProgram();
@@ -79,7 +80,9 @@ TEST_F(MeshDeviceFixture, CB_Reservation_Overflow_AlwaysOn) {
         logical_core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
-    EXPECT_DEATH(detail::LaunchProgram(device, program), ".*\\[ASAN ERROR\\] CB Reservation Overflow:.*");
+    EXPECT_DEATH(
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        ".*\\[ASAN ERROR\\] CB Reservation Overflow:.*");
 }
 
 // Boundary positive control: reserving EXACTLY the CB's capacity (n ==
@@ -95,10 +98,9 @@ TEST_F(MeshDeviceFixture, CB_Reservation_Overflow_AlwaysOn) {
 // single-threaded parent. (The regression runner also splits them into separate
 // invocations; this ordering additionally keeps the bare `CB_Reservation_*` glob
 // runnable.)
-TEST_F(MeshDeviceFixture, CB_Reservation_ExactCapacity_NoViolation) {
+TEST_F(UnitMeshFixture, CB_Reservation_ExactCapacity_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
 
     Program program = CreateProgram();
@@ -125,7 +127,7 @@ TEST_F(MeshDeviceFixture, CB_Reservation_ExactCapacity_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Must NOT abort.
-    detail::LaunchProgram(device, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/emule/test_host_alignment.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_host_alignment.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // To run (from the tt-metal repo root, after an emule build):
-//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="MeshDeviceFixture.Host_Alignment_*"
+//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="UnitMeshFixture.Host_Alignment_*"
 
 // Coverage for the host-side L1/DRAM alignment sanitizer (host_sanitizers.hpp
 // check_host_l1_alignment / check_host_dram_alignment). These checks fire only
@@ -26,9 +26,11 @@
 #include <vector>
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -37,15 +39,17 @@ namespace tt::tt_metal {
 
 // Unaligned host->L1 write/read at an odd (1-byte-aligned) address inside an
 // allocated L1 buffer must NOT abort on emule, and must round-trip correctly.
-TEST_F(MeshDeviceFixture, Host_Alignment_L1_Unaligned_NoViolation) {
+TEST_F(UnitMeshFixture, Host_Alignment_L1_Unaligned_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
 
     // Allocate an L1 buffer so the poke targets a valid, non-reserved address.
     constexpr uint32_t buf_size = 256;
-    auto buf = Buffer::create(device, buf_size, buf_size, BufferType::L1);
+    auto buf = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = buf_size},
+        {.page_size = buf_size, .buffer_type = BufferType::L1},
+        &this->device());
 
     // Deliberately unaligned: buffer base + 1 byte. On a DMA-backed build with a
     // real alignment > 1 this would be rejected; on emule it must be accepted.
@@ -53,12 +57,12 @@ TEST_F(MeshDeviceFixture, Host_Alignment_L1_Unaligned_NoViolation) {
     std::vector<uint8_t> payload = {0xDE, 0xAD, 0xBE, 0xEF};
 
     // Must NOT abort.
-    detail::WriteToDeviceL1(
-        device, logical_core, unaligned_addr, ttsl::Span<const uint8_t>(payload.data(), payload.size()));
+    slow_dispatch::WriteToL1(
+        this->device(), logical_core, unaligned_addr, ttsl::Span<const uint8_t>(payload.data(), payload.size()));
 
     std::vector<uint8_t> readback(payload.size(), 0);
-    detail::ReadFromDeviceL1(
-        device, logical_core, unaligned_addr, ttsl::Span<uint8_t>(readback.data(), readback.size()));
+    slow_dispatch::ReadFromL1(
+        this->device(), logical_core, unaligned_addr, ttsl::Span<uint8_t>(readback.data(), readback.size()));
 
     EXPECT_EQ(readback, payload);
 
@@ -67,25 +71,26 @@ TEST_F(MeshDeviceFixture, Host_Alignment_L1_Unaligned_NoViolation) {
 
 // DRAM counterpart: an unaligned host->DRAM channel write/read must likewise be
 // a no-op for the alignment check on emule and round-trip correctly.
-TEST_F(MeshDeviceFixture, Host_Alignment_DRAM_Unaligned_NoViolation) {
+TEST_F(UnitMeshFixture, Host_Alignment_DRAM_Unaligned_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
-
-    auto* device = this->devices_.at(0)->get_devices()[0];
 
     // Allocate a DRAM buffer to obtain a valid, non-reserved DRAM address.
     constexpr uint32_t buf_size = 256;
-    auto buf = Buffer::create(device, buf_size, buf_size, BufferType::DRAM);
+    auto buf = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = buf_size},
+        {.page_size = buf_size, .buffer_type = BufferType::DRAM},
+        &this->device());
 
     uint32_t unaligned_addr = static_cast<uint32_t>(buf->address()) + 1;
     std::vector<uint8_t> payload = {0x01, 0x23, 0x45, 0x67};
 
     // Channel 0 backs this DRAM allocation on the wormhole_N150 mock. Must NOT abort.
-    detail::WriteToDeviceDRAMChannel(
-        device, /*dram_channel=*/0, unaligned_addr, ttsl::Span<const uint8_t>(payload.data(), payload.size()));
+    slow_dispatch::WriteToDRAMChannel(
+        this->device(), /*dram_channel=*/0, unaligned_addr, ttsl::Span<const uint8_t>(payload.data(), payload.size()));
 
     std::vector<uint8_t> readback(payload.size(), 0);
-    detail::ReadFromDeviceDRAMChannel(
-        device, /*dram_channel=*/0, unaligned_addr, ttsl::Span<uint8_t>(readback.data(), readback.size()));
+    slow_dispatch::ReadFromDRAMChannel(
+        this->device(), /*dram_channel=*/0, unaligned_addr, ttsl::Span<uint8_t>(readback.data(), readback.size()));
 
     EXPECT_EQ(readback, payload);
 

--- a/tests/tt_metal/tt_metal/api/emule/test_metadata_size.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_metadata_size.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // To run (from the tt-metal repo root, after an emule build):
-//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="MeshDeviceFixture.Metadata_*"
+//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="UnitMeshFixture.Metadata_*"
 
 #include <gtest/gtest.h>
 #include <cstdint>
@@ -20,6 +20,7 @@
 #include <tt-metalium/allocator.hpp>
 #include "impl/context/metal_context.hpp"
 #include "device_fixture.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -31,11 +32,9 @@ namespace tt::tt_metal {
 // underlying detection is validate_circular_buffer_region in ProgramImpl; our
 // wrapper in ConfigureDeviceWithProgram translates its TT_THROW into an
 // ASAN-style abort for emule.
-TEST_F(MeshDeviceFixture, Metadata_CB_Tensor_Clash_SanityCheck) {
+TEST_F(UnitMeshFixture, Metadata_CB_Tensor_Clash_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto& mesh_device = this->devices_.at(0);
-    auto* device = mesh_device->get_devices()[0];
     CoreCoord logical_core = {0, 0};
 
     // Pin a low lowest_occupied_compute_l1_address by allocating a 1 MB L1
@@ -46,7 +45,7 @@ TEST_F(MeshDeviceFixture, Metadata_CB_Tensor_Clash_SanityCheck) {
     distributed::DeviceLocalBufferConfig l1_local_config{
         .page_size = l1_buffer_size, .buffer_type = BufferType::L1, .bottom_up = false};
     distributed::ReplicatedBufferConfig l1_buf_config{.size = l1_buffer_size};
-    auto l1_buffer = distributed::MeshBuffer::create(l1_buf_config, l1_local_config, mesh_device.get());
+    auto l1_buffer = distributed::MeshBuffer::create(l1_buf_config, l1_local_config, &this->device());
 
     // CB sized to overrun the buffer's lower edge.
     Program program = CreateProgram();
@@ -68,7 +67,9 @@ TEST_F(MeshDeviceFixture, Metadata_CB_Tensor_Clash_SanityCheck) {
         logical_core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
-    EXPECT_DEATH(detail::LaunchProgram(device, program), ".*\\[ASAN ERROR\\] Metadata Overflow.*");
+    EXPECT_DEATH(
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        ".*\\[ASAN ERROR\\] Metadata Overflow.*");
 }
 
 // Directly exercises the emule-only static KERNEL_CONFIG-window check
@@ -86,10 +87,9 @@ TEST_F(MeshDeviceFixture, Metadata_CB_Tensor_Clash_SanityCheck) {
 // reachable when the ring buffer is larger than that window (config can land in
 // the band between them); otherwise the finalize FATAL fires first and this check
 // is defensive. The test self-calibrates and SKIPs when the band is unusable.
-TEST_F(MeshDeviceFixture, Metadata_KernelConfigWindow_Overflow_SanityCheck) {
+TEST_F(UnitMeshFixture, Metadata_KernelConfigWindow_Overflow_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
 
     const auto& hal = MetalContext::instance().hal();
@@ -98,7 +98,8 @@ TEST_F(MeshDeviceFixture, Metadata_KernelConfigWindow_Overflow_SanityCheck) {
         static_cast<uint32_t>(hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::KERNEL_CONFIG));
     uint32_t default_unreserved =
         static_cast<uint32_t>(hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::DEFAULT_UNRESERVED));
-    uint32_t alloc_unreserved = static_cast<uint32_t>(device->allocator()->get_base_allocator_addr(HalMemType::L1));
+    uint32_t alloc_unreserved =
+        static_cast<uint32_t>(this->device().allocator()->get_base_allocator_addr(HalMemType::L1));
     uint32_t window_size = default_unreserved - kc_base;    // check_program_metadata_size bound
     uint32_t ringbuffer_size = alloc_unreserved - kc_base;  // finalize_offsets TT_FATAL bound
 
@@ -152,7 +153,9 @@ TEST_F(MeshDeviceFixture, Metadata_KernelConfigWindow_Overflow_SanityCheck) {
     std::vector<uint32_t> args(n_args, 0u);
     SetRuntimeArgs(program, kernel, logical_core, args);
 
-    EXPECT_DEATH(detail::LaunchProgram(device, program), ".*\\[ASAN ERROR\\] Metadata Overflow.*");
+    EXPECT_DEATH(
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        ".*\\[ASAN ERROR\\] Metadata Overflow.*");
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
 }
@@ -167,10 +170,9 @@ TEST_F(MeshDeviceFixture, Metadata_KernelConfigWindow_Overflow_SanityCheck) {
 // until the watchdog aborts. Keeping death tests first lets each fork cleanly.
 // (Today the window-overflow death test SKIPs on WH/BH, but this ordering keeps
 // the bare `Metadata_*` glob safe on any arch where it does fire.)
-TEST_F(MeshDeviceFixture, Metadata_CB_Tensor_NoViolation) {
+TEST_F(UnitMeshFixture, Metadata_CB_Tensor_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
 
     // A tiny 2-page CB leaves the vast majority of L1 free; no clash possible.
@@ -191,7 +193,7 @@ TEST_F(MeshDeviceFixture, Metadata_CB_Tensor_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Must NOT abort.
-    detail::LaunchProgram(device, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/emule/test_noc_without_barrier.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_noc_without_barrier.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // To run (from the tt-metal repo root, after an emule build):
-//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="MeshDeviceFixture.NoC_Barrier_*"
+//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="UnitMeshFixture.NoC_Barrier_*"
 
 #include <gtest/gtest.h>
 
@@ -14,16 +14,16 @@
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "device_fixture.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
 
 namespace tt::tt_metal {
 
-TEST_F(MeshDeviceFixture, NoC_Barrier_Missing_SanityCheck) {
+TEST_F(UnitMeshFixture, NoC_Barrier_Missing_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -36,7 +36,10 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_Missing_SanityCheck) {
     // Allocate a real L1 buffer as the noc_async_read destination so the
     // tensor-area sanitizer doesn't fire before cb_pop_front triggers the
     // barrier check.
-    auto dst_buf = Buffer::create(device, 1024, 1024, BufferType::L1);
+    auto dst_buf = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = 1024},
+        {.page_size = 1024, .buffer_type = BufferType::L1},
+        &this->device());
 
     // 2. Kernel that reads then pops WITHOUT a barrier. Popping frees the page
     //    for the producer to refill while the read is still in flight — a race.
@@ -60,7 +63,7 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_Missing_SanityCheck) {
     SetRuntimeArgs(program, kernel, logical_core, {dst_buf->address()});
 
     EXPECT_DEATH(
-        detail::LaunchProgram(device, program),
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
         ".*Race Condition: cb_pop_front.*called while a NoC read is still pending.*");
 }
 
@@ -72,10 +75,9 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_Missing_SanityCheck) {
 // leave a genuine missing-barrier bug on the page-accessor path uncaught otherwise.
 // (Kept before the non-death controls below so its EXPECT_DEATH forks from a
 // still-single-threaded parent — see the ordering note in the regression runner.)
-TEST_F(MeshDeviceFixture, NoC_Barrier_Missing_AddrGen_SanityCheck) {
+TEST_F(UnitMeshFixture, NoC_Barrier_Missing_AddrGen_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -86,8 +88,11 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_Missing_AddrGen_SanityCheck) {
 
     // DRAM source for the page-accessor read + a real L1 destination (so the
     // tensor/OOB check doesn't pre-empt the pop-time race check).
-    auto src_buf = Buffer::create(device, 1024, 1024, BufferType::DRAM);
-    auto dst_buf = Buffer::create(device, 1024, 1024, BufferType::L1);
+    distributed::ReplicatedBufferConfig buf_config{.size = 1024};
+    distributed::DeviceLocalBufferConfig dram_config{.page_size = 1024, .buffer_type = BufferType::DRAM};
+    distributed::DeviceLocalBufferConfig l1_config{.page_size = 1024, .buffer_type = BufferType::L1};
+    auto src_buf = distributed::MeshBuffer::create(buf_config, dram_config, &this->device());
+    auto dst_buf = distributed::MeshBuffer::create(buf_config, l1_config, &this->device());
 
     // The TensorAccessor reads its bank layout from compile-time args.
     std::vector<uint32_t> reader_ct_args;
@@ -116,7 +121,7 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_Missing_AddrGen_SanityCheck) {
     SetRuntimeArgs(program, kernel, logical_core, {src_buf->address(), dst_buf->address()});
 
     EXPECT_DEATH(
-        detail::LaunchProgram(device, program),
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
         ".*Race Condition: cb_pop_front.*called while a NoC read is still pending.*");
 }
 
@@ -125,10 +130,9 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_Missing_AddrGen_SanityCheck) {
 // the subsequent cb_pop_front sees zero in-flight reads. Guards the check from
 // firing when the kernel correctly barriers (and confirms the barrier actually
 // resets the counter). The CB is cycled in balance so nothing else fires.
-TEST_F(MeshDeviceFixture, NoC_Barrier_Present_NoViolation) {
+TEST_F(UnitMeshFixture, NoC_Barrier_Present_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -137,7 +141,10 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_Present_NoViolation) {
         CircularBufferConfig(2048, {{cb_id, tt::DataFormat::Float16_b}}).set_page_size(cb_id, 1024);
     CreateCircularBuffer(program, logical_core, cb_config);
 
-    auto dst_buf = Buffer::create(device, 1024, 1024, BufferType::L1);
+    auto dst_buf = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = 1024},
+        {.page_size = 1024, .buffer_type = BufferType::L1},
+        &this->device());
 
     std::string kernel_src = R"(
         #include "api/dataflow/dataflow_api.h"
@@ -164,7 +171,7 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_Present_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {dst_buf->address()});
 
     // Must NOT abort.
-    detail::LaunchProgram(device, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -176,10 +183,9 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_Present_NoViolation) {
 // clear-to-zero semantic: if noc_async_read_barrier ever regressed to a decrement,
 // the counter would still be 1 at the pop and this legitimate ≥2-read kernel would
 // false-positive — which no single-read test can catch.
-TEST_F(MeshDeviceFixture, NoC_Barrier_MultiRead_SingleBarrier_NoViolation) {
+TEST_F(UnitMeshFixture, NoC_Barrier_MultiRead_SingleBarrier_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -188,7 +194,10 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_MultiRead_SingleBarrier_NoViolation) {
         CircularBufferConfig(2048, {{cb_id, tt::DataFormat::Float16_b}}).set_page_size(cb_id, 1024);
     CreateCircularBuffer(program, logical_core, cb_config);
 
-    auto dst_buf = Buffer::create(device, 1024, 1024, BufferType::L1);
+    auto dst_buf = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = 1024},
+        {.page_size = 1024, .buffer_type = BufferType::L1},
+        &this->device());
 
     std::string kernel_src = R"(
         #include "api/dataflow/dataflow_api.h"
@@ -215,7 +224,7 @@ TEST_F(MeshDeviceFixture, NoC_Barrier_MultiRead_SingleBarrier_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {dst_buf->address()});
 
     // Must NOT abort — the single barrier cleared both in-flight reads.
-    detail::LaunchProgram(device, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/emule/test_padded_write.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_padded_write.cpp
@@ -3,41 +3,45 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // To run (from the tt-metal repo root, after an emule build):
-//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="MeshDeviceFixture.Tensor_Padding_*"
+//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="UnitMeshFixture.Tensor_Padding_*"
 
 #include <gtest/gtest.h>
 #include <cstdint>
 #include <vector>
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
 #include "impl/emulation/host_sanitizers.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
 
 namespace tt::tt_metal {
 
-TEST_F(MeshDeviceFixture, Tensor_Padding_Violation_SanityCheck) {
+TEST_F(UnitMeshFixture, Tensor_Padding_Violation_SanityCheck) {
     GTEST_SKIP() << "Temporarily disabled. See SANITIZER_CHECKS.md for details.";
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     // 1. Create a buffer mimicking a padded tensor layout:
     // 1024 bytes of logical data, but padded to a 2048-byte physical block size.
-    // Buffer::create only takes a single size — emule::register_logical_size()
+    // MeshBuffer::create only takes a single size — emule::register_logical_size()
     // declares that bytes [logical_size, physical_size) are hardware padding and
     // registers them with LiveL1PaddingRanges so the kernel-side sanitizer
     // in __emule_local_l1_to_ptr will fire on accesses into that region.
     uint32_t logical_size = 1024;
     uint32_t physical_size = 2048;
-    auto buffer = Buffer::create(device, physical_size, physical_size, BufferType::L1);
-    tt::tt_metal::emule::register_logical_size(*buffer, logical_size);
+    auto buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = physical_size},
+        {.page_size = physical_size, .buffer_type = BufferType::L1},
+        &this->device());
+    tt::tt_metal::emule::register_logical_size(*buffer->get_reference_buffer(), logical_size);
 
     // 2. Add an inline kernel that attempts to modify a padded datum at byte
     // 1028 — inside the 2048-byte allocation (so it passes the OOB-tensor
@@ -70,7 +74,7 @@ TEST_F(MeshDeviceFixture, Tensor_Padding_Violation_SanityCheck) {
 
     // 3. The emulator should intercept the illegal write inside l1_ptr
     EXPECT_DEATH(
-        detail::LaunchProgram(device, program),
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
         ".*Tensor Padding Violation: Attempted to write to a padded memory region at address 0x.*");
 }
 

--- a/tests/tt_metal/tt_metal/api/emule/test_pointer_size.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_pointer_size.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // To run (from the tt-metal repo root, after an emule build):
-//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="MeshDeviceFixture.Local_L1_Alignment_*"
+//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="UnitMeshFixture.Local_L1_Alignment_*"
 
 #include <gtest/gtest.h>
 #include <cstdint>
@@ -13,16 +13,16 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
 
 namespace tt::tt_metal {
 
-TEST_F(MeshDeviceFixture, Local_L1_Alignment_SanityCheck) {
+TEST_F(UnitMeshFixture, Local_L1_Alignment_SanityCheck) {
     GTEST_SKIP() << "Temporarily disabled.";
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -43,7 +43,9 @@ TEST_F(MeshDeviceFixture, Local_L1_Alignment_SanityCheck) {
         logical_core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
-    EXPECT_DEATH(detail::LaunchProgram(device, program), ".*Local L1 Alignment: Offset 0x5 must be 4-byte aligned.*");
+    EXPECT_DEATH(
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        ".*Local L1 Alignment: Offset 0x5 must be 4-byte aligned.*");
 }
 
 }  // namespace tt::tt_metal

--- a/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_semaphore_write.cpp
@@ -3,24 +3,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // To run (from the tt-metal repo root, after an emule build):
-//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="MeshDeviceFixture.Semaphore_*"
+//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="UnitMeshFixture.Semaphore_*"
 
 #include <gtest/gtest.h>
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
 
 namespace tt::tt_metal {
 
-TEST_F(MeshDeviceFixture, Semaphore_Direct_Write_SanityCheck) {
+TEST_F(UnitMeshFixture, Semaphore_Direct_Write_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -44,7 +45,7 @@ TEST_F(MeshDeviceFixture, Semaphore_Direct_Write_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        detail::LaunchProgram(device, program),
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
         ".*Illegal Semaphore Access: Offset 0x.*is inside the reserved Semaphore region.*");
 }
 
@@ -52,16 +53,18 @@ TEST_F(MeshDeviceFixture, Semaphore_Direct_Write_SanityCheck) {
 // OUTSIDE the reserved semaphore region — must NOT abort. Guards the semaphore
 // check from flagging normal L1 addressing (the region test must be a precise
 // [start, end) containment, not an over-broad lower-bound).
-TEST_F(MeshDeviceFixture, Semaphore_OutsideRegion_NoViolation) {
+TEST_F(UnitMeshFixture, Semaphore_OutsideRegion_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     // A normal L1 buffer is allocated well away from the reserved semaphore
     // region (which lives in the low system area near EMULE_SEM_BASE).
-    auto buf = Buffer::create(device, 1024, 1024, BufferType::L1);
+    auto buf = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = 1024},
+        {.page_size = 1024, .buffer_type = BufferType::L1},
+        &this->device());
     uint32_t addr = static_cast<uint32_t>(buf->address());
 
     std::string kernel_src = R"(
@@ -80,7 +83,7 @@ TEST_F(MeshDeviceFixture, Semaphore_OutsideRegion_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {addr});
 
     // Must NOT abort.
-    detail::LaunchProgram(device, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/emule/test_tensor_bad_access.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_tensor_bad_access.cpp
@@ -3,17 +3,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // To run (from the tt-metal repo root, after an emule build):
-//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="MeshDeviceFixture.Host_UAF_*"
+//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="UnitMeshFixture.Host_UAF_*"
 
 #include <gtest/gtest.h>
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/experimental/core_subset_write/buffer_write.hpp>
 #include "device_fixture.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -22,60 +25,65 @@ namespace tt::tt_metal {
 
 // These tests verify the host-side Use-After-Free sanitizer in tt_metal.cpp
 // fires for every public Buffer-access entry point. Each test allocates a
-// Buffer, deallocates it (keeping the Buffer object alive — Buffer's address_
-// member still points at memory the allocator has now reclaimed), and then
-// invokes the entry point, expecting an abort with the [ASAN ERROR]
-// Use-After-Free message naming that specific entry point.
+// MeshBuffer, deallocates its device-local Buffer (keeping the Buffer object
+// alive — Buffer's address_ member still points at memory the allocator has
+// now reclaimed), and then invokes the entry point, expecting an abort with
+// the [ASAN ERROR] Use-After-Free message naming that specific entry point.
 
-TEST_F(MeshDeviceFixture, Host_UAF_WriteToBuffer_SanityCheck) {
+TEST_F(UnitMeshFixture, Host_UAF_WriteToBuffer_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
-
-    auto buffer = Buffer::create(device, 1024, 1024, BufferType::L1);
-    DeallocateBuffer(*buffer);
+    auto buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = 1024},
+        {.page_size = 1024, .buffer_type = BufferType::L1},
+        &this->device());
+    buffer->deallocate();
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
-    EXPECT_DEATH(detail::WriteToBuffer(*buffer, data), ".*Use-After-Free.*WriteToBuffer.*");
+    EXPECT_DEATH(slow_dispatch::WriteToBuffer(*buffer, data), ".*Use-After-Free.*WriteToBuffer.*");
 }
 
-TEST_F(MeshDeviceFixture, Host_UAF_ReadFromBuffer_SanityCheck) {
+TEST_F(UnitMeshFixture, Host_UAF_ReadFromBuffer_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
-
-    auto buffer = Buffer::create(device, 1024, 1024, BufferType::L1);
-    DeallocateBuffer(*buffer);
+    auto buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = 1024},
+        {.page_size = 1024, .buffer_type = BufferType::L1},
+        &this->device());
+    buffer->deallocate();
 
     std::vector<uint32_t> out;
-    EXPECT_DEATH(detail::ReadFromBuffer(*buffer, out), ".*Use-After-Free.*ReadFromBuffer.*");
+    EXPECT_DEATH(slow_dispatch::ReadFromBuffer(*buffer, out), ".*Use-After-Free.*ReadFromBuffer.*");
 }
 
-TEST_F(MeshDeviceFixture, Host_UAF_ReadShard_SanityCheck) {
-    auto* device = this->devices_.at(0)->get_devices()[0];
-
+TEST_F(UnitMeshFixture, Host_UAF_ReadShard_SanityCheck) {
     // ReadShard's sanitizer check runs before its is_sharded() assertion, so a
     // plain interleaved buffer still drives the UAF path under test here.
-    auto buffer = Buffer::create(device, 1024, 1024, BufferType::L1);
-    DeallocateBuffer(*buffer);
+    auto buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = 1024},
+        {.page_size = 1024, .buffer_type = BufferType::L1},
+        &this->device());
+    DeallocateBuffer(*buffer->get_reference_buffer());
 
     std::vector<uint8_t> out(1024);
-    EXPECT_DEATH(detail::ReadShard(*buffer, out.data(), /*core_id=*/0), ".*Use-After-Free.*ReadShard.*");
+    EXPECT_DEATH(
+        detail::ReadShard(*buffer->get_reference_buffer(), out.data(), /*core_id=*/0), ".*Use-After-Free.*ReadShard.*");
 }
 
-TEST_F(MeshDeviceFixture, Host_UAF_CoreSubsetWriteToBuffer_SanityCheck) {
+TEST_F(UnitMeshFixture, Host_UAF_CoreSubsetWriteToBuffer_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
-
-    auto buffer = Buffer::create(device, 1024, 1024, BufferType::L1);
-    DeallocateBuffer(*buffer);
+    auto buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = 1024},
+        {.page_size = 1024, .buffer_type = BufferType::L1},
+        &this->device());
+    buffer->deallocate();
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
     CoreRangeSet logical_core_filter{CoreRange{CoreCoord{0, 0}, CoreCoord{0, 0}}};
     EXPECT_DEATH(
         experimental::core_subset_write::WriteToBuffer(
-            *buffer,
+            *buffer->get_reference_buffer(),
             ttsl::Span<const uint8_t>(reinterpret_cast<const uint8_t*>(data.data()), data.size() * sizeof(uint32_t)),
             logical_core_filter),
         ".*Use-After-Free.*core_subset_write.*");
@@ -85,33 +93,35 @@ TEST_F(MeshDeviceFixture, Host_UAF_CoreSubsetWriteToBuffer_SanityCheck) {
 // overloads in tt_metal.hpp dereference and forward to the Buffer& entry
 // points, so this confirms the sanitizer fires through the smart-pointer path
 // too (the path most user code actually takes).
-TEST_F(MeshDeviceFixture, Host_UAF_WriteToBuffer_SharedPtrOverload_SanityCheck) {
+TEST_F(UnitMeshFixture, Host_UAF_WriteToBuffer_SharedPtrOverload_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
-
-    auto buffer = Buffer::create(device, 1024, 1024, BufferType::L1);
-    DeallocateBuffer(*buffer);
+    auto buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = 1024},
+        {.page_size = 1024, .buffer_type = BufferType::L1},
+        &this->device());
+    buffer->deallocate();
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
-    EXPECT_DEATH(detail::WriteToBuffer(buffer, data), ".*Use-After-Free.*WriteToBuffer.*");
+    EXPECT_DEATH(slow_dispatch::WriteToBuffer(*buffer, data), ".*Use-After-Free.*WriteToBuffer.*");
 }
 
 // Positive control: a write/read round-trip on a LIVE (still-allocated) buffer
 // must NOT abort and must round-trip the data. Guards the check from regressing
 // to flag healthy buffers (e.g. an inverted is_allocated() test).
-TEST_F(MeshDeviceFixture, Host_UAF_Allocated_NoViolation) {
+TEST_F(UnitMeshFixture, Host_UAF_Allocated_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
-
-    auto buffer = Buffer::create(device, 1024, 1024, BufferType::L1);  // left allocated
+    auto buffer = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = 1024},
+        {.page_size = 1024, .buffer_type = BufferType::L1},
+        &this->device());  // left allocated
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
-    detail::WriteToBuffer(*buffer, data);  // must NOT abort
+    slow_dispatch::WriteToBuffer(*buffer, data);  // must NOT abort
 
     std::vector<uint32_t> out;
-    detail::ReadFromBuffer(*buffer, out);  // must NOT abort
+    slow_dispatch::ReadFromBuffer(*buffer, out);  // must NOT abort
     EXPECT_EQ(out, data);
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/emule/test_tensor_bad_access.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_tensor_bad_access.cpp
@@ -37,7 +37,7 @@ TEST_F(UnitMeshFixture, Host_UAF_WriteToBuffer_SanityCheck) {
         distributed::ReplicatedBufferConfig{.size = 1024},
         {.page_size = 1024, .buffer_type = BufferType::L1},
         &this->device());
-    buffer->deallocate();
+    DeallocateBuffer(*buffer->get_reference_buffer());
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
     EXPECT_DEATH(slow_dispatch::WriteToBuffer(*buffer, data), ".*Use-After-Free.*WriteToBuffer.*");
@@ -50,7 +50,7 @@ TEST_F(UnitMeshFixture, Host_UAF_ReadFromBuffer_SanityCheck) {
         distributed::ReplicatedBufferConfig{.size = 1024},
         {.page_size = 1024, .buffer_type = BufferType::L1},
         &this->device());
-    buffer->deallocate();
+    DeallocateBuffer(*buffer->get_reference_buffer());
 
     std::vector<uint32_t> out;
     EXPECT_DEATH(slow_dispatch::ReadFromBuffer(*buffer, out), ".*Use-After-Free.*ReadFromBuffer.*");
@@ -77,7 +77,7 @@ TEST_F(UnitMeshFixture, Host_UAF_CoreSubsetWriteToBuffer_SanityCheck) {
         distributed::ReplicatedBufferConfig{.size = 1024},
         {.page_size = 1024, .buffer_type = BufferType::L1},
         &this->device());
-    buffer->deallocate();
+    DeallocateBuffer(*buffer->get_reference_buffer());
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
     CoreRangeSet logical_core_filter{CoreRange{CoreCoord{0, 0}, CoreCoord{0, 0}}};
@@ -100,7 +100,7 @@ TEST_F(UnitMeshFixture, Host_UAF_WriteToBuffer_SharedPtrOverload_SanityCheck) {
         distributed::ReplicatedBufferConfig{.size = 1024},
         {.page_size = 1024, .buffer_type = BufferType::L1},
         &this->device());
-    buffer->deallocate();
+    Dea;
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
     EXPECT_DEATH(slow_dispatch::WriteToBuffer(*buffer, data), ".*Use-After-Free.*WriteToBuffer.*");

--- a/tests/tt_metal/tt_metal/api/emule/test_tensor_bad_access.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_tensor_bad_access.cpp
@@ -100,7 +100,7 @@ TEST_F(UnitMeshFixture, Host_UAF_WriteToBuffer_SharedPtrOverload_SanityCheck) {
         distributed::ReplicatedBufferConfig{.size = 1024},
         {.page_size = 1024, .buffer_type = BufferType::L1},
         &this->device());
-    Dea;
+    DeallocateBuffer(*buffer->get_reference_buffer());
 
     std::vector<uint32_t> data(256, 0xABCDEFu);
     EXPECT_DEATH(slow_dispatch::WriteToBuffer(*buffer, data), ".*Use-After-Free.*WriteToBuffer.*");

--- a/tests/tt_metal/tt_metal/api/emule/test_valid_mem_wrong_alloc.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_valid_mem_wrong_alloc.cpp
@@ -3,16 +3,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // To run (from the tt-metal repo root, after an emule build):
-//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="MeshDeviceFixture.Object_Intent_*"
+//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="UnitMeshFixture.Object_Intent_*"
 
 #include <gtest/gtest.h>
 #include <cstdint>
 #include <vector>
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -26,24 +28,25 @@ namespace tt::tt_metal {
 // pass the victim buffer's absolute address as a runtime arg, or it authorizes
 // the very write it is trying to flag. These tests pass only the victim's BYTE
 // OFFSET from the resolved buffer; the victim's address never enters the args.
-TEST_F(MeshDeviceFixture, Object_Intent_Provenance_Violation_SanityCheck) {
+TEST_F(UnitMeshFixture, Object_Intent_Provenance_Violation_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     // 1. Allocate two distinct buffers sequentially in L1 memory.
     //
     // L1 allocates top-down by default (see Buffer::bottom_up_ in buffer.cpp),
-    // so the first Buffer::create lands at the highest address and the second
+    // so the first MeshBuffer::create lands at the highest address and the second
     // lands immediately below it. Allocate Buffer B first so it occupies the
     // upper slot — Buffer A then sits directly under it with addr_a < addr_b.
     // That arrangement matches the narrative the kernel computes below
     // (overshoot Buffer A upward to stomp Buffer B).
     uint32_t buf_size = 1024;  // 1 KB each
-    auto buffer_b = Buffer::create(device, buf_size, buf_size, BufferType::L1);
-    auto buffer_a = Buffer::create(device, buf_size, buf_size, BufferType::L1);
+    distributed::ReplicatedBufferConfig buffer_config{.size = buf_size};
+    distributed::DeviceLocalBufferConfig l1_config{.page_size = buf_size, .buffer_type = BufferType::L1};
+    auto buffer_b = distributed::MeshBuffer::create(buffer_config, l1_config, &this->device());
+    auto buffer_a = distributed::MeshBuffer::create(buffer_config, l1_config, &this->device());
 
     uint32_t addr_a = buffer_a->address();
     uint32_t addr_b = buffer_b->address();
@@ -92,7 +95,7 @@ TEST_F(MeshDeviceFixture, Object_Intent_Provenance_Violation_SanityCheck) {
 
     // 3. The sanitizer should catch that the execution sequence breached pointer provenance bounds
     EXPECT_DEATH(
-        detail::LaunchProgram(device, program),
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
         ".*Object Intent Violation: Attempted to modify memory belonging to an adjacent object context.*");
 }
 
@@ -109,18 +112,19 @@ TEST_F(MeshDeviceFixture, Object_Intent_Provenance_Violation_SanityCheck) {
 // fiber worker pool alive in the parent; a later EXPECT_DEATH fork()s and the
 // child inherits that pool's locked state without its threads, hanging until the
 // watchdog aborts (~124 s). Death-first keeps each fork clean.
-TEST_F(MeshDeviceFixture, Object_Intent_Provenance_NonAdjacent_Violation) {
+TEST_F(UnitMeshFixture, Object_Intent_Provenance_NonAdjacent_Violation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     // Top-down: first allocated lands highest. Order so addr_a < addr_b < addr_c.
     uint32_t buf_size = 1024;
-    auto buffer_c = Buffer::create(device, buf_size, buf_size, BufferType::L1);
-    auto buffer_b = Buffer::create(device, buf_size, buf_size, BufferType::L1);
-    auto buffer_a = Buffer::create(device, buf_size, buf_size, BufferType::L1);
+    distributed::ReplicatedBufferConfig buffer_config{.size = buf_size};
+    distributed::DeviceLocalBufferConfig l1_config{.page_size = buf_size, .buffer_type = BufferType::L1};
+    auto buffer_c = distributed::MeshBuffer::create(buffer_config, l1_config, &this->device());
+    auto buffer_b = distributed::MeshBuffer::create(buffer_config, l1_config, &this->device());
+    auto buffer_a = distributed::MeshBuffer::create(buffer_config, l1_config, &this->device());
     uint32_t addr_a = buffer_a->address();
     uint32_t addr_b = buffer_b->address();
     uint32_t addr_c = buffer_c->address();
@@ -158,7 +162,7 @@ TEST_F(MeshDeviceFixture, Object_Intent_Provenance_NonAdjacent_Violation) {
     SetRuntimeArgs(program, kernel, logical_core, {addr_a, addr_c - addr_a});
 
     EXPECT_DEATH(
-        detail::LaunchProgram(device, program),
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
         ".*Object Intent Violation: Attempted to modify memory belonging to an adjacent object context.*");
 }
 
@@ -170,16 +174,17 @@ TEST_F(MeshDeviceFixture, Object_Intent_Provenance_NonAdjacent_Violation) {
 // crash and fail. It guards the well-behaved path from being broken by future
 // changes to the resolved-set tracking or snapshot logic. (Placed after the death
 // tests above: see the fork/worker-pool ordering note on the NonAdjacent test.)
-TEST_F(MeshDeviceFixture, Object_Intent_Provenance_NoViolation_Control) {
+TEST_F(UnitMeshFixture, Object_Intent_Provenance_NoViolation_Control) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     uint32_t buf_size = 1024;
-    auto buffer_b = Buffer::create(device, buf_size, buf_size, BufferType::L1);
-    auto buffer_a = Buffer::create(device, buf_size, buf_size, BufferType::L1);
+    distributed::ReplicatedBufferConfig buffer_config{.size = buf_size};
+    distributed::DeviceLocalBufferConfig l1_config{.page_size = buf_size, .buffer_type = BufferType::L1};
+    auto buffer_b = distributed::MeshBuffer::create(buffer_config, l1_config, &this->device());
+    auto buffer_a = distributed::MeshBuffer::create(buffer_config, l1_config, &this->device());
 
     // Resolve both buffers, write only within bounds of each — the
     // "intended write set" covers every buffer whose bytes change.
@@ -204,7 +209,7 @@ TEST_F(MeshDeviceFixture, Object_Intent_Provenance_NoViolation_Control) {
 
     // Must NOT abort. If the sanitizer is over-eager, LaunchProgram will SIGABRT
     // and the test harness will mark this as failed.
-    detail::LaunchProgram(device, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
     SUCCEED();
 }
 
@@ -217,16 +222,17 @@ TEST_F(MeshDeviceFixture, Object_Intent_Provenance_NoViolation_Control) {
 // even though the kernel never resolved a pointer into it. Guards the exemption
 // from regressing (which would re-introduce false positives on real in-place
 // TT-NN ops).
-TEST_F(MeshDeviceFixture, Object_Intent_IOArg_Exempt_NoViolation) {
+TEST_F(UnitMeshFixture, Object_Intent_IOArg_Exempt_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     uint32_t buf_size = 1024;
-    auto buffer_b = Buffer::create(device, buf_size, buf_size, BufferType::L1);
-    auto buffer_a = Buffer::create(device, buf_size, buf_size, BufferType::L1);
+    distributed::ReplicatedBufferConfig buffer_config{.size = buf_size};
+    distributed::DeviceLocalBufferConfig l1_config{.page_size = buf_size, .buffer_type = BufferType::L1};
+    auto buffer_b = distributed::MeshBuffer::create(buffer_config, l1_config, &this->device());
+    auto buffer_a = distributed::MeshBuffer::create(buffer_config, l1_config, &this->device());
     uint32_t addr_a = buffer_a->address();
     uint32_t addr_b = buffer_b->address();
     ASSERT_LT(addr_a, addr_b);
@@ -253,7 +259,7 @@ TEST_F(MeshDeviceFixture, Object_Intent_IOArg_Exempt_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {addr_a, addr_b});
 
     // Must NOT abort — B was handed to the kernel as a runtime arg.
-    detail::LaunchProgram(device, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -267,17 +273,19 @@ TEST_F(MeshDeviceFixture, Object_Intent_IOArg_Exempt_NoViolation) {
 // non-empty); it is not modified, so it never flags. If the globally-allocated
 // exemption regresses, the CB backing would be snapshotted, seen modified, and
 // (never resolved) flagged as a violation — this pins that exemption.
-TEST_F(MeshDeviceFixture, Object_Intent_GloballyAllocatedCB_Exempt_NoViolation) {
+TEST_F(UnitMeshFixture, Object_Intent_GloballyAllocatedCB_Exempt_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     // Non-exempt L1 buffer, left untouched — makes Object Intent active (snapshots_
     // non-empty) without itself changing (so it never flags).
     uint32_t buf_size = 1024;
-    auto buffer_a = Buffer::create(device, buf_size, buf_size, BufferType::L1);
+    auto buffer_a = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = buf_size},
+        {.page_size = buf_size, .buffer_type = BufferType::L1},
+        &this->device());
     (void)buffer_a;
 
     // Globally-allocated CB backing — exempt from the Object Intent snapshot.
@@ -286,10 +294,13 @@ TEST_F(MeshDeviceFixture, Object_Intent_GloballyAllocatedCB_Exempt_NoViolation) 
     constexpr uint32_t num_pages = 2;
     // Single-bank backing (bank size == CB total_size), required for a
     // globally-allocated CB.
-    auto backing = Buffer::create(device, num_pages * page_size, num_pages * page_size, BufferType::L1);
+    auto backing = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = num_pages * page_size},
+        {.page_size = num_pages * page_size, .buffer_type = BufferType::L1},
+        &this->device());
     CircularBufferConfig cb_config = CircularBufferConfig(num_pages * page_size, {{cb_id, tt::DataFormat::Float16_b}})
                                          .set_page_size(cb_id, page_size)
-                                         .set_globally_allocated_address(*backing);
+                                         .set_globally_allocated_address(*backing->get_reference_buffer());
     CreateCircularBuffer(program, logical_core, cb_config);
 
     // Kernel writes into the globally-allocated CB backing WITHOUT resolving it as
@@ -313,7 +324,7 @@ TEST_F(MeshDeviceFixture, Object_Intent_GloballyAllocatedCB_Exempt_NoViolation) 
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Must NOT abort — writing a globally-allocated CB the kernel owns is legitimate.
-    detail::LaunchProgram(device, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -328,16 +339,17 @@ TEST_F(MeshDeviceFixture, Object_Intent_GloballyAllocatedCB_Exempt_NoViolation) 
 // gate regressed, per-kernel attribution would run on a multi-kernel core: each
 // kernel would see the OTHER kernel's (unresolved) buffer as modified and abort —
 // or corrupt the shared resolved-log vector via concurrent appends.
-TEST_F(MeshDeviceFixture, Object_Intent_MultiKernel_Core_NoViolation) {
+TEST_F(UnitMeshFixture, Object_Intent_MultiKernel_Core_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     uint32_t buf_size = 1024;
-    auto buffer_1 = Buffer::create(device, buf_size, buf_size, BufferType::L1);
-    auto buffer_2 = Buffer::create(device, buf_size, buf_size, BufferType::L1);
+    distributed::ReplicatedBufferConfig buffer_config{.size = buf_size};
+    distributed::DeviceLocalBufferConfig l1_config{.page_size = buf_size, .buffer_type = BufferType::L1};
+    auto buffer_1 = distributed::MeshBuffer::create(buffer_config, l1_config, &this->device());
+    auto buffer_2 = distributed::MeshBuffer::create(buffer_config, l1_config, &this->device());
 
     // Two kernels on the same core (RISCV_0 + RISCV_1), each resolving and writing
     // only its own buffer within bounds.
@@ -372,7 +384,7 @@ TEST_F(MeshDeviceFixture, Object_Intent_MultiKernel_Core_NoViolation) {
     SetRuntimeArgs(program, kernel_1, logical_core, {buffer_2->address()});
 
     // Must NOT abort — Object Intent no-ops on multi-kernel cores.
-    detail::LaunchProgram(device, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/emule/test_write_beyond_res_pages.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_write_beyond_res_pages.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // To run (from the tt-metal repo root, after an emule build):
-//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="MeshDeviceFixture.CB_Boundary_*"
+//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="UnitMeshFixture.CB_Boundary_*"
 
 #include <gtest/gtest.h>
 #include <cstdint>
@@ -11,9 +11,11 @@
 #include <vector>
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -26,10 +28,9 @@ namespace tt::tt_metal {
 // flows through __emule_local_l1_to_ptr, where the sanitizer recognizes the
 // address as belonging to a CB region but landing outside the currently-
 // reserved sub-range, and aborts before the memcpy.
-TEST_F(MeshDeviceFixture, CB_Boundary_Violation_SanityCheck) {
+TEST_F(UnitMeshFixture, CB_Boundary_Violation_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -63,7 +64,8 @@ TEST_F(MeshDeviceFixture, CB_Boundary_Violation_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        detail::LaunchProgram(device, program), ".*CB Boundary Violation: Attempted to access CB 0.*reserved.*");
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        ".*CB Boundary Violation: Attempted to access CB 0.*reserved.*");
 }
 
 // Read-side counterpart. The kernel pushes one page (so the consumer side has
@@ -73,10 +75,9 @@ TEST_F(MeshDeviceFixture, CB_Boundary_Violation_SanityCheck) {
 // on, which on silicon the producer may still be filling. The source address
 // flows through __emule_local_l1_to_ptr; the sanitizer sees the access is
 // outside both windows (write reservation is empty after the push) and aborts.
-TEST_F(MeshDeviceFixture, CB_Boundary_Violation_Read_SanityCheck) {
+TEST_F(UnitMeshFixture, CB_Boundary_Violation_Read_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -109,7 +110,8 @@ TEST_F(MeshDeviceFixture, CB_Boundary_Violation_Read_SanityCheck) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     EXPECT_DEATH(
-        detail::LaunchProgram(device, program), ".*CB Boundary Violation: Attempted to access CB 0.*Read window.*");
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        ".*CB Boundary Violation: Attempted to access CB 0.*Read window.*");
 }
 
 // Wraparound negative control. Identical setup (3-page CB, write_idx=2, reserve
@@ -126,10 +128,9 @@ TEST_F(MeshDeviceFixture, CB_Boundary_Violation_Read_SanityCheck) {
 // in the parent; a later EXPECT_DEATH fork()s and the child inherits that pool's
 // locked state without its threads, hanging until the watchdog aborts (~124 s).
 // Death-first keeps each fork clean. (See the note in the CB_Reservation test.)
-TEST_F(MeshDeviceFixture, CB_Boundary_Wraparound_Violation_SanityCheck) {
+TEST_F(UnitMeshFixture, CB_Boundary_Wraparound_Violation_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -164,7 +165,9 @@ TEST_F(MeshDeviceFixture, CB_Boundary_Wraparound_Violation_SanityCheck) {
         logical_core,
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
-    EXPECT_DEATH(detail::LaunchProgram(device, program), ".*CB Boundary Violation: Attempted to access CB 0.*");
+    EXPECT_DEATH(
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
+        ".*CB Boundary Violation: Attempted to access CB 0.*");
 }
 
 // Wraparound positive control. On a 3-page CB we cycle the write/read pointers
@@ -182,10 +185,9 @@ TEST_F(MeshDeviceFixture, CB_Boundary_Wraparound_Violation_SanityCheck) {
 // tell "accepted because wrapped correctly" apart from "the check went dormant"
 // — the additive-counter false-negative mode. With 3 pages the window is a
 // strict subset, which the paired Violation test below relies on.)
-TEST_F(MeshDeviceFixture, CB_Boundary_Wraparound_NoViolation) {
+TEST_F(UnitMeshFixture, CB_Boundary_Wraparound_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -223,7 +225,7 @@ TEST_F(MeshDeviceFixture, CB_Boundary_Wraparound_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Wrapped access is legal and the kernel exits flushed → no sanitizer fires.
-    detail::LaunchProgram(device, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -235,10 +237,9 @@ TEST_F(MeshDeviceFixture, CB_Boundary_Wraparound_NoViolation) {
 // The boundary check is only meaningful relative to an active window, so this
 // must NOT abort. This is the exact shape (reserved==0, waited==0) that the old
 // check false-positived across the TT-NN sweeps (expand/reshape/roll/to_memory_config/…).
-TEST_F(MeshDeviceFixture, CB_Boundary_NoActiveWindow_NoViolation) {
+TEST_F(UnitMeshFixture, CB_Boundary_NoActiveWindow_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -269,7 +270,7 @@ TEST_F(MeshDeviceFixture, CB_Boundary_NoActiveWindow_NoViolation) {
 
     // Must NOT abort. If the window check regresses to firing without an active
     // reservation/wait, LaunchProgram SIGABRTs and this test fails.
-    detail::LaunchProgram(device, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -278,10 +279,9 @@ TEST_F(MeshDeviceFixture, CB_Boundary_NoActiveWindow_NoViolation) {
 // Produced-region reuse control: a write back into an already-produced page
 // [read_idx, write_idx), outside the active reserve window, must NOT abort (the
 // conv activation-reuse pattern). See SANITIZER_CHECKS.md §7.
-TEST_F(MeshDeviceFixture, CB_Boundary_ProducedRegionReuse_NoViolation) {
+TEST_F(UnitMeshFixture, CB_Boundary_ProducedRegionReuse_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -318,7 +318,7 @@ TEST_F(MeshDeviceFixture, CB_Boundary_ProducedRegionReuse_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Reuse of produced data is legal and the kernel exits flushed → no abort.
-    detail::LaunchProgram(device, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -332,10 +332,9 @@ TEST_F(MeshDeviceFixture, CB_Boundary_ProducedRegionReuse_NoViolation) {
 // with the exemption in force this must NOT abort. If the `!cb.globally_allocated`
 // guard regresses, every real sharded/matmul CB (cb_in0_sharded, DRAM-sharded
 // readers) would false-positive — this pins that guard.
-TEST_F(MeshDeviceFixture, CB_Boundary_GloballyAllocated_Exempt_NoViolation) {
+TEST_F(UnitMeshFixture, CB_Boundary_GloballyAllocated_Exempt_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -346,10 +345,13 @@ TEST_F(MeshDeviceFixture, CB_Boundary_GloballyAllocated_Exempt_NoViolation) {
     // Backing L1 buffer makes the CB globally allocated (sharded-style addressing).
     // Single-bank (one buffer page spanning the whole CB) so its bank size equals
     // the CB total_size — a globally-allocated CB must fit inside its backing bank.
-    auto backing = Buffer::create(device, num_pages * page_size, num_pages * page_size, BufferType::L1);
+    auto backing = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = num_pages * page_size},
+        {.page_size = num_pages * page_size, .buffer_type = BufferType::L1},
+        &this->device());
     CircularBufferConfig cb_config = CircularBufferConfig(num_pages * page_size, {{cb_id, tt::DataFormat::Float16_b}})
                                          .set_page_size(cb_id, page_size)
-                                         .set_globally_allocated_address(*backing);
+                                         .set_globally_allocated_address(*backing->get_reference_buffer());
     CreateCircularBuffer(program, logical_core, cb_config);
 
     std::string kernel_src = R"(
@@ -373,7 +375,7 @@ TEST_F(MeshDeviceFixture, CB_Boundary_GloballyAllocated_Exempt_NoViolation) {
         DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
     // Must NOT abort — globally-allocated CBs are exempt from the boundary window check.
-    detail::LaunchProgram(device, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
@@ -3,16 +3,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // To run (from the tt-metal repo root, after an emule build):
-//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="MeshDeviceFixture.OOB_Tensor_*"
+//   build_emule/test/tt_metal/unit_tests_api --gtest_filter="UnitMeshFixture.OOB_Tensor_*"
 
 #include <gtest/gtest.h>
 #include <cstdint>
 #include <vector>
 
 #include <tt-metalium/host_api.hpp>
+#include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include "device_fixture.hpp"
+#include "tt_metal/impl/dispatch/slow_dispatch.hpp"
 
 using namespace tt;
 using namespace tt::tt_metal;
@@ -25,16 +27,18 @@ namespace tt::tt_metal {
 // within the L1 mmap and well above l1_unreserved_base, so it is not inside
 // any system region and not inside any allocated tensor). The sanitizer is
 // expected to abort with an Out-of-Bounds Write ASAN message.
-TEST_F(MeshDeviceFixture, OOB_Tensor_Gap_L1_SanityCheck) {
+TEST_F(UnitMeshFixture, OOB_Tensor_Gap_L1_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     // One small L1 buffer near the top of L1 (allocator is top-down for L1).
     constexpr uint32_t buffer_size = 1024;
-    auto buf = Buffer::create(device, buffer_size, buffer_size, BufferType::L1);
+    auto buf = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = buffer_size},
+        {.page_size = buffer_size, .buffer_type = BufferType::L1},
+        &this->device());
 
     // Pick a target that sits 64 KB below the buffer's start. That lands in
     // user-allocatable L1 (above l1_unreserved_base on a fresh device with a
@@ -59,7 +63,7 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_Gap_L1_SanityCheck) {
     SetRuntimeArgs(program, kernel, logical_core, {oob_addr});
 
     EXPECT_DEATH(
-        detail::LaunchProgram(device, program),
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
         ".*Out-of-Bounds Write: Attempted to access address.*not part of any allocated tensor.*");
 }
 
@@ -69,17 +73,19 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_Gap_L1_SanityCheck) {
 // dram_unreserved_base but does not fall inside the allocated buffer. The
 // sanitizer is expected to abort with an Out-of-Bounds Write ASAN message
 // naming DRAM.
-TEST_F(MeshDeviceFixture, OOB_Tensor_Gap_DRAM_SanityCheck) {
+TEST_F(UnitMeshFixture, OOB_Tensor_Gap_DRAM_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     // One small DRAM buffer. DRAM allocates bottom-up from dram_unreserved_base
     // by default, so the buffer's address is close to that base.
     constexpr uint32_t buffer_size = 1024;
-    auto buf = Buffer::create(device, buffer_size, buffer_size, BufferType::DRAM);
+    auto buf = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = buffer_size},
+        {.page_size = buffer_size, .buffer_type = BufferType::DRAM},
+        &this->device());
 
     // Target a DRAM offset 1 MB above the buffer — well above the buffer's
     // end and above dram_unreserved_base, but not inside any allocated DRAM
@@ -105,7 +111,7 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_Gap_DRAM_SanityCheck) {
     SetRuntimeArgs(program, kernel, logical_core, {oob_addr});
 
     EXPECT_DEATH(
-        detail::LaunchProgram(device, program),
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
         ".*Out-of-Bounds Write: Attempted to access DRAM address.*not part of any allocated tensor.*");
 }
 
@@ -114,20 +120,22 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_Gap_DRAM_SanityCheck) {
 // tensor) must still abort — a kernel overrunning a raw-L1 region is a real bug
 // the check must keep catching. Kept among the death tests (before the non-death
 // controls below) so its EXPECT_DEATH forks from a single-threaded parent.
-TEST_F(MeshDeviceFixture, OOB_Tensor_HostPoke_JustPast_SanityCheck) {
+TEST_F(UnitMeshFixture, OOB_Tensor_HostPoke_JustPast_SanityCheck) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     constexpr uint32_t buffer_size = 1024;
-    auto anchor = Buffer::create(device, buffer_size, buffer_size, BufferType::L1);
+    auto anchor = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = buffer_size},
+        {.page_size = buffer_size, .buffer_type = BufferType::L1},
+        &this->device());
     constexpr uint32_t gap_distance = 64 * 1024;
     uint32_t poke_addr = static_cast<uint32_t>(anchor->address()) - gap_distance;
 
     std::vector<uint32_t> host_data(32, 0xABCDABCDu);  // poked region = [poke_addr, poke_addr+128)
-    detail::WriteToDeviceL1(device, logical_core, poke_addr, host_data);
+    slow_dispatch::WriteToL1(this->device(), logical_core, poke_addr, host_data);
 
     // One word past the poked region: not in the poke range, not in any tensor.
     uint32_t past_addr = poke_addr + static_cast<uint32_t>(host_data.size() * sizeof(uint32_t));
@@ -148,7 +156,7 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_HostPoke_JustPast_SanityCheck) {
     SetRuntimeArgs(program, kernel, logical_core, {past_addr});
 
     EXPECT_DEATH(
-        detail::LaunchProgram(device, program),
+        slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true),
         ".*Out-of-Bounds Write: Attempted to access address.*not part of any allocated tensor.*");
 }
 
@@ -156,15 +164,17 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_HostPoke_JustPast_SanityCheck) {
 // buffer must NOT abort. Guards the OOB check from flagging legitimate in-bounds
 // accesses (e.g. an off-by-one in the range comparison or the offset
 // normalization).
-TEST_F(MeshDeviceFixture, OOB_Tensor_InBounds_L1_NoViolation) {
+TEST_F(UnitMeshFixture, OOB_Tensor_InBounds_L1_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     constexpr uint32_t buffer_size = 1024;
-    auto buf = Buffer::create(device, buffer_size, buffer_size, BufferType::L1);
+    auto buf = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = buffer_size},
+        {.page_size = buffer_size, .buffer_type = BufferType::L1},
+        &this->device());
     // A word comfortably inside the buffer.
     uint32_t in_addr = static_cast<uint32_t>(buf->address()) + 64;
 
@@ -184,7 +194,7 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_InBounds_L1_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {in_addr});
 
     // Must NOT abort — the address is inside an allocated tensor.
-    detail::LaunchProgram(device, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -192,15 +202,17 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_InBounds_L1_NoViolation) {
 
 // Positive control (DRAM): resolving a DRAM offset INSIDE an allocated DRAM
 // buffer via __emule_dram_ptr must NOT abort.
-TEST_F(MeshDeviceFixture, OOB_Tensor_InBounds_DRAM_NoViolation) {
+TEST_F(UnitMeshFixture, OOB_Tensor_InBounds_DRAM_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
     constexpr uint32_t buffer_size = 1024;
-    auto buf = Buffer::create(device, buffer_size, buffer_size, BufferType::DRAM);
+    auto buf = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = buffer_size},
+        {.page_size = buffer_size, .buffer_type = BufferType::DRAM},
+        &this->device());
     uint32_t in_addr = static_cast<uint32_t>(buf->address()) + 64;
 
     std::string kernel_src = R"(
@@ -220,7 +232,7 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_InBounds_DRAM_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {in_addr});
 
     // Must NOT abort — the offset is inside an allocated DRAM tensor.
-    detail::LaunchProgram(device, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");
@@ -233,10 +245,9 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_InBounds_DRAM_NoViolation) {
 // __emule_asan_check_oob_tensor (the DM-microbenchmark raw-L1 false-positive fix)
 // — if that scan regresses, legitimate raw-L1 reads/writes start aborting and
 // only the separate unit_tests_data_movement binary would notice.
-TEST_F(MeshDeviceFixture, OOB_Tensor_HostPoke_Accept_NoViolation) {
+TEST_F(UnitMeshFixture, OOB_Tensor_HostPoke_Accept_NoViolation) {
     ::setenv("TT_METAL_EMULE_ASAN", "1", 1);
 
-    auto* device = this->devices_.at(0)->get_devices()[0];
     CoreCoord logical_core = {0, 0};
     Program program = CreateProgram();
 
@@ -244,12 +255,15 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_HostPoke_Accept_NoViolation) {
     // gap: above l1_unreserved_base, inside no allocated tensor) via
     // WriteToDeviceL1 — which registers the host-poke extent when ASAN is on.
     constexpr uint32_t buffer_size = 1024;
-    auto anchor = Buffer::create(device, buffer_size, buffer_size, BufferType::L1);
+    auto anchor = distributed::MeshBuffer::create(
+        distributed::ReplicatedBufferConfig{.size = buffer_size},
+        {.page_size = buffer_size, .buffer_type = BufferType::L1},
+        &this->device());
     constexpr uint32_t gap_distance = 64 * 1024;
     uint32_t poke_addr = static_cast<uint32_t>(anchor->address()) - gap_distance;
 
     std::vector<uint32_t> host_data(32, 0xABCDABCDu);  // 128-byte poked region
-    detail::WriteToDeviceL1(device, logical_core, poke_addr, host_data);
+    show_dispatch::WriteToL1(this->device(), logical_core, poke_addr, host_data);
 
     std::string kernel_src = R"(
         #include "api/dataflow/dataflow_api.h"
@@ -267,7 +281,7 @@ TEST_F(MeshDeviceFixture, OOB_Tensor_HostPoke_Accept_NoViolation) {
     SetRuntimeArgs(program, kernel, logical_core, {poke_addr});
 
     // Must NOT abort — the address is inside a host-designated raw-L1 region.
-    detail::LaunchProgram(device, program);
+    slow_dispatch::LaunchProgram(this->device(), program, /*wait_until_cores_done=*/true);
     SUCCEED();
 
     ::unsetenv("TT_METAL_EMULE_ASAN");

--- a/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/emule/test_write_outside_tensor.cpp
@@ -263,7 +263,7 @@ TEST_F(UnitMeshFixture, OOB_Tensor_HostPoke_Accept_NoViolation) {
     uint32_t poke_addr = static_cast<uint32_t>(anchor->address()) - gap_distance;
 
     std::vector<uint32_t> host_data(32, 0xABCDABCDu);  // 128-byte poked region
-    show_dispatch::WriteToL1(this->device(), logical_core, poke_addr, host_data);
+    slow_dispatch::WriteToL1(this->device(), logical_core, poke_addr, host_data);
 
     std::string kernel_src = R"(
         #include "api/dataflow/dataflow_api.h"


### PR DESCRIPTION
### PR Category
Cleanup, Test Only

### Summary

Advances https://github.com/tenstorrent/tt-metal/issues/51835

Legacy API usage related to `IDevice` and `Buffer` is replaced with modern mesh alternatives in emule tests.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=obacherikov-emule-launch-program)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:obacherikov-emule-launch-program)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=obacherikov-emule-launch-program)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:obacherikov-emule-launch-program)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=obacherikov-emule-launch-program)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:obacherikov-emule-launch-program)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=obacherikov-emule-launch-program)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:obacherikov-emule-launch-program)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=obacherikov-emule-launch-program)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:obacherikov-emule-launch-program)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=obacherikov-emule-launch-program)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:obacherikov-emule-launch-program)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=obacherikov-emule-launch-program)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:obacherikov-emule-launch-program)