### PR TITLE
BH LLK topk_xl: unfused SFPLOADMACRO primitives + fused-u16 end-to-end family, with LLK-level tests

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/llk_math_eltwise_unary_sfpu_topk_xl.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/llk_math_eltwise_unary_sfpu_topk_xl.h
@@ -10,48 +10,53 @@
 
 namespace ckernel {
 
-template <uint32_t K, bool APPROXIMATE, bool fused>
+template <uint32_t K, bool fused>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(ckernel::sfpu::_topk_xl_init_<K, fused>);
 }
 
-template <uint32_t K, bool APPROXIMATE>
+template <uint32_t K>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_local_sort(
     uint dst_index, bool ascending, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
-        ckernel::sfpu::_topk_xl_local_sort_<K, APPROXIMATE>, dst_index, vector_mode, dst_index, ascending);
+        ckernel::sfpu::_topk_xl_local_sort_<K>, dst_index, vector_mode, dst_index, ascending);
 }
 
-template <uint32_t K, bool APPROXIMATE, bool fused>
+template <uint32_t K, bool fused>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_merge(uint dst_index, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
-        ckernel::sfpu::_topk_xl_merge_<K, APPROXIMATE, fused>, dst_index, vector_mode, dst_index);
+        ckernel::sfpu::_topk_xl_merge_<K, fused>, dst_index, vector_mode, dst_index);
 }
 
-template <uint32_t K, bool APPROXIMATE, bool fused>
+template <uint32_t K, bool fused>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_rebuild(
     uint dst_index, bool ascending, VectorMode vector_mode = VectorMode::RC_custom) {
     _llk_math_eltwise_unary_sfpu_params_(
-        ckernel::sfpu::_topk_xl_rebuild_<K, APPROXIMATE, fused>, dst_index, vector_mode, dst_index, ascending);
+        ckernel::sfpu::_topk_xl_rebuild_<K, fused>, dst_index, vector_mode, dst_index, ascending);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_add_lsb_indices_init() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(ckernel::sfpu::_topk_xl_add_lsb_indices_init_);
 }
 
-template <uint32_t K, bool APPROXIMATE, uint32_t core_id>
+template <uint32_t K, uint32_t core_id>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_add_lsb_indices(uint dst_index) {
     _llk_math_eltwise_unary_sfpu_params_(
-        ckernel::sfpu::_topk_xl_add_lsb_indices_<K, APPROXIMATE, core_id>, dst_index, VectorMode::RC_custom);
+        ckernel::sfpu::_topk_xl_add_lsb_indices_<K, core_id>, dst_index, VectorMode::RC_custom);
 }
 
-template <bool APPROXIMATE>
+// Runtime-chunk-id stamp (fused end-to-end rows: one instantiation, id per chunk).
+template <uint32_t K>
+inline void llk_math_eltwise_unary_sfpu_topk_xl_add_lsb_indices_rt(uint dst_index, uint32_t chunk_id) {
+    _llk_math_eltwise_unary_sfpu_params_(
+        ckernel::sfpu::_topk_xl_add_lsb_indices_rt_<K>, dst_index, VectorMode::RC_custom, chunk_id);
+}
+
 inline void llk_math_eltwise_unary_sfpu_topk_xl_remove_msb_values_init() {
     ckernel::sfpu::_topk_xl_remove_msb_values_init_();
 }
 
-template <uint32_t K, bool APPROXIMATE, DstSync Dst>
+template <uint32_t K, DstSync Dst>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_remove_msb_values(uint dst_index) {
     TT_SETC16(DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, dst_index + get_dest_buffer_base());
     TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH | p_stall::PACK);
@@ -59,7 +64,6 @@ inline void llk_math_eltwise_unary_sfpu_topk_xl_remove_msb_values(uint dst_index
     ckernel::sfpu::_topk_xl_remove_msb_values_<K, Dst>();
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_init(uint32_t group_id_bit_shift) {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(
         ckernel::sfpu::_topk_xl_separate_indices_init_, group_id_bit_shift);
@@ -69,45 +73,66 @@ inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_init(uint32_t g
 // These wrappers expose the row-major SFPU helpers added to
 // `ckernel_sfpu_topk_xl.h`; the base TopK XL wrappers above and below are
 // otherwise unchanged.
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_init(uint32_t chunk_base) {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(
         ckernel::sfpu::_topk_xl_separate_indices_row_major_init_, chunk_base);
 }
 
-template <bool APPROXIMATE, uint32_t chunk_base_upper16>
+template <uint32_t chunk_base_upper16>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_init_upper(uint32_t chunk_base_low16) {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(
         ckernel::sfpu::_topk_xl_separate_indices_row_major_init_upper_<chunk_base_upper16>, chunk_base_low16);
 }
 
-template <bool APPROXIMATE, uint32_t chunk_base_upper16, uint32_t chunk_base_lower16>
+template <uint32_t chunk_base_upper16, uint32_t chunk_base_lower16>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_init_static() {
     llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(
         ckernel::sfpu::_topk_xl_separate_indices_row_major_init_static_<chunk_base_upper16, chunk_base_lower16>);
 }
 
-template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_reinit() {
     TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
     ckernel::sfpu::_topk_xl_separate_indices_row_major_reinit_();
 }
 // END TOPK_LARGE_INDICES ADDITION: row-major UINT32 index split API.
 
-template <uint32_t K, bool APPROXIMATE, uint32_t group_id>
+template <uint32_t K, uint32_t group_id>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices(uint dst_index) {
     _llk_math_eltwise_unary_sfpu_params_(
-        ckernel::sfpu::_topk_xl_separate_indices_<K, APPROXIMATE, group_id>, dst_index, VectorMode::RC_custom);
+        ckernel::sfpu::_topk_xl_separate_indices_<K, group_id>, dst_index, VectorMode::RC_custom);
 }
 
 // TOPK_LARGE_INDICES ADDITION: row-major UINT32 index split execution API.
-template <uint32_t K, bool APPROXIMATE>
+template <uint32_t K>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major(uint dst_index) {
     _llk_math_eltwise_unary_sfpu_params_(
-        ckernel::sfpu::_topk_xl_separate_indices_row_major_<K, APPROXIMATE>, dst_index, VectorMode::RC_custom);
+        ckernel::sfpu::_topk_xl_separate_indices_row_major_<K>, dst_index, VectorMode::RC_custom);
 }
 
-template <uint32_t K, bool APPROXIMATE>
+// Fused end-to-end: chunk-field-mask init + once-per-row global split.
+inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_global_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(ckernel::sfpu::_topk_xl_separate_indices_row_major_global_init_);
+}
+
+template <uint32_t K>
+inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_global(uint dst_index) {
+    _llk_math_eltwise_unary_sfpu_params_(
+        ckernel::sfpu::_topk_xl_separate_indices_row_major_global_<K>, dst_index, VectorMode::RC_custom);
+}
+
+// Segmented fusion: per-segment split with a runtime segment base OR'd into
+// the decoded index.
+template <uint32_t K>
+inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_global_base(
+    uint dst_index, uint32_t seg_base) {
+    _llk_math_eltwise_unary_sfpu_params_(
+        ckernel::sfpu::_topk_xl_separate_indices_row_major_global_base_<K>,
+        dst_index,
+        VectorMode::RC_custom,
+        seg_base);
+}
+
+template <uint32_t K>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_advance_chunk_base() {
     TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
     ckernel::sfpu::_topk_xl_separate_indices_row_major_advance_chunk_base_<K>();

--- a/tt_metal/hw/inc/api/compute/experimental/topk_xl.h
+++ b/tt_metal/hw/inc/api/compute/experimental/topk_xl.h
@@ -50,7 +50,7 @@ namespace ckernel {
 template <uint32_t K>
 ALWI void topk_xl_local_sort(uint32_t idst, bool ascending) {
     UNPACK((llk_unpack_set_srcb_dummy_valid()));
-    MATH((llk_math_eltwise_unary_sfpu_topk_xl_local_sort<K, APPROX>(idst, ascending)));
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_local_sort<K>(idst, ascending)));
 }
 
 /**
@@ -79,7 +79,7 @@ ALWI void topk_xl_local_sort(uint32_t idst, bool ascending) {
  */
 template <uint32_t K, bool fused = true>
 ALWI void topk_xl_merge(uint32_t idst) {
-    MATH((llk_math_eltwise_unary_sfpu_topk_xl_merge<K, APPROX, fused>(idst)));
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_merge<K, fused>(idst)));
 }
 
 /**
@@ -109,7 +109,7 @@ ALWI void topk_xl_merge(uint32_t idst) {
 template <uint32_t K, bool fused = true>
 ALWI void topk_xl_rebuild(uint32_t idst, bool ascending) {
     UNPACK((llk_unpack_set_srcb_dummy_valid()));
-    MATH((llk_math_eltwise_unary_sfpu_topk_xl_rebuild<K, APPROX, fused>(idst, ascending)));
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_rebuild<K, fused>(idst, ascending)));
 }
 
 /**
@@ -119,8 +119,9 @@ ALWI void topk_xl_rebuild(uint32_t idst, bool ascending) {
  * Programs all of:
  *   * ADDR_MOD_1..7 for the bitonic load/store strides (incl. the +24 / +40 /
  *     +48 stride-folding slots that the inner loops depend on),
- *   * the math-thread MOP Expander with the merge body template (`fused`
- *     selects the body length: 16 for fused, 18 for unfused),
+ *   * the math-thread MOP Expander with the merge body template (16-issue
+ *     body for fused AND for the default macro-scheduled unfused path;
+ *     18 for unfused only when built with -DDISABLE_TOPK_XL_SFPLOADMACRO),
  *   * the SFPU index-tracking config in unfused mode.
  *
  * Because every merge/rebuild/local_sort relies on the ADDR_MOD programming
@@ -130,7 +131,7 @@ ALWI void topk_xl_rebuild(uint32_t idst, bool ascending) {
  */
 template <uint32_t K, bool fused = true>
 ALWI void topk_xl_init() {
-    MATH((llk_math_eltwise_unary_sfpu_topk_xl_init<K, APPROX, fused>()));
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_init<K, fused>()));
 }
 
 /**
@@ -195,7 +196,7 @@ ALWI void topk_xl_copy_tile(
 /**
  * Initializes the state for adding LSB indices to the topk_xl_copy_tile output.
  */
-ALWI void topk_xl_add_lsb_indices_init() { MATH((llk_math_eltwise_unary_sfpu_topk_xl_add_lsb_indices_init<APPROX>())); }
+ALWI void topk_xl_add_lsb_indices_init() { MATH((llk_math_eltwise_unary_sfpu_topk_xl_add_lsb_indices_init())); }
 
 /**
  * Adds LSB indices to the topk_xl_copy_tile output.
@@ -212,7 +213,17 @@ ALWI void topk_xl_add_lsb_indices_init() { MATH((llk_math_eltwise_unary_sfpu_top
  */
 template <uint32_t K, uint32_t core_id>
 ALWI void topk_xl_add_lsb_indices(uint32_t idst) {
-    MATH((llk_math_eltwise_unary_sfpu_topk_xl_add_lsb_indices<K, APPROX, core_id>(idst)));
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_add_lsb_indices<K, core_id>(idst)));
+}
+
+/**
+ * Runtime-chunk-id variant of topk_xl_add_lsb_indices: the 5-bit id in index
+ * bits [15:11] is a runtime argument, so one instantiation stamps every chunk
+ * of a fused end-to-end row (chunk_id in 0..31). Same init.
+ */
+template <uint32_t K>
+ALWI void topk_xl_add_lsb_indices_rt(uint32_t idst, uint32_t chunk_id) {
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_add_lsb_indices_rt<K>(idst, chunk_id)));
 }
 
 /**
@@ -227,7 +238,7 @@ ALWI void topk_xl_add_lsb_indices(uint32_t idst) {
  * on LRegs otherwise.
  */
 ALWI void topk_xl_remove_msb_values_init() {
-    PACK((llk_math_eltwise_unary_sfpu_topk_xl_remove_msb_values_init<false>()));
+    PACK((llk_math_eltwise_unary_sfpu_topk_xl_remove_msb_values_init()));
 }
 
 /**
@@ -248,7 +259,7 @@ ALWI void topk_xl_remove_msb_values_init() {
  */
 template <uint32_t K>
 ALWI void topk_xl_remove_msb_values(uint32_t idst) {
-    PACK((llk_math_eltwise_unary_sfpu_topk_xl_remove_msb_values<K, false, DST_SYNC_MODE>(idst)));
+    PACK((llk_math_eltwise_unary_sfpu_topk_xl_remove_msb_values<K, DST_SYNC_MODE>(idst)));
 }
 
 /**
@@ -267,7 +278,7 @@ ALWI void topk_xl_remove_msb_values(uint32_t idst) {
  * 31                                               | True     |
  */
 ALWI void topk_xl_separate_indices_init(uint32_t group_id_bit_shift) {
-    MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_init<false>(group_id_bit_shift)));
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_init(group_id_bit_shift)));
 }
 
 // TOPK_LARGE_INDICES ADDITION: row-major UINT32 index split compute API.
@@ -280,25 +291,24 @@ ALWI void topk_xl_separate_indices_init(uint32_t group_id_bit_shift) {
  * must be aligned to K.
  */
 ALWI void topk_xl_separate_indices_row_major_init(uint32_t chunk_base) {
-    MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_init<false>(chunk_base)));
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_init(chunk_base)));
 }
 
 template <uint32_t chunk_base_upper16>
 ALWI void topk_xl_separate_indices_row_major_init_upper(uint32_t chunk_base_low16) {
-    MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_init_upper<false, chunk_base_upper16>(
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_init_upper<chunk_base_upper16>(
         chunk_base_low16)));
 }
 
 template <uint32_t chunk_base_upper16, uint32_t chunk_base_lower16>
 ALWI void topk_xl_separate_indices_row_major_init_static() {
     MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_init_static<
-          false,
           chunk_base_upper16,
           chunk_base_lower16>()));
 }
 
 ALWI void topk_xl_separate_indices_row_major_reinit() {
-    MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_reinit<false>()));
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_reinit()));
 }
 
 /**
@@ -321,7 +331,7 @@ ALWI void topk_xl_separate_indices_row_major_reinit() {
  */
 template <uint32_t K, uint32_t group_id>
 ALWI void topk_xl_separate_indices(uint32_t idst) {
-    MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices<K, false, group_id>(idst)));
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices<K, group_id>(idst)));
 }
 
 /**
@@ -332,12 +342,39 @@ ALWI void topk_xl_separate_indices(uint32_t idst) {
  */
 template <uint32_t K>
 ALWI void topk_xl_separate_indices_row_major(uint32_t idst) {
-    MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major<K, false>(idst)));
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major<K>(idst)));
+}
+
+// Loads the chunk-field mask constants for the global splits below; call
+// once before topk_xl_separate_indices_row_major_global / _global_base.
+ALWI void topk_xl_separate_indices_row_major_global_init() {
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_global_init()));
+}
+
+/**
+ * Fused end-to-end split: runs ONCE per row on the final fused survivor.
+ * Each u16 payload carries [chunk_id 15:11 | within-chunk 10:0]; the global
+ * index chunk_id * K + row-major(within-chunk) is recovered from the stamp
+ * itself — no chunk-base bookkeeping. Requires
+ * topk_xl_separate_indices_row_major_global_init. Sound only for rows of
+ * <= 32 chunks (the FUSED_E2E factory gate).
+ */
+template <uint32_t K>
+ALWI void topk_xl_separate_indices_row_major_global(uint32_t idst) {
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_global<K>(idst)));
+}
+
+// Segmented fusion: split one fused segment survivor in place, adding
+// seg_base (= segment_index * 32 * K, power-of-two aligned) to every decoded
+// index. Same init as the plain global split.
+template <uint32_t K>
+ALWI void topk_xl_separate_indices_row_major_global_base(uint32_t idst, uint32_t seg_base) {
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_global_base<K>(idst, seg_base)));
 }
 
 template <uint32_t K>
 ALWI void topk_xl_separate_indices_row_major_advance_chunk_base() {
-    MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_advance_chunk_base<K, false>()));
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_advance_chunk_base<K>()));
 }
 // END TOPK_LARGE_INDICES ADDITION: row-major UINT32 index split compute API.
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_variant_parameters.py
@@ -727,6 +727,8 @@ class TOPK_XL(TemplateParameter):
     fused_reduce: bool = False
     chunk_base_mode: TopKXLChunkBaseMode = TopKXLChunkBaseMode.Static
     chunk_base: int = 0
+    fused_e2e: bool = False
+    seg_base: int = 0
 
     def convert_to_cpp(self) -> str:
         lines: list[str] = [
@@ -742,6 +744,8 @@ class TOPK_XL(TemplateParameter):
             f"constexpr bool TOPK_XL_FUSED_REDUCE = {str(self.fused_reduce).lower()};",
             f"constexpr std::uint32_t TOPK_XL_CHUNK_BASE_MODE = {self.chunk_base_mode.value};",
             f"constexpr std::uint32_t TOPK_XL_CHUNK_BASE = {self.chunk_base};",
+            f"constexpr bool TOPK_XL_FUSED_E2E = {str(self.fused_e2e).lower()};",
+            f"constexpr std::uint32_t TOPK_XL_SEG_BASE = {self.seg_base};",
         ]
         return "\n".join(lines)
 

--- a/tt_metal/tt-llk/tests/python_tests/test_topk_xl.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_topk_xl.py
@@ -108,6 +108,20 @@ def _make_row(search_len: int, seed: int, mode: str) -> torch.Tensor:
         return _distinct_bf16_from_hi16(hi16)
     if mode == "random":
         return torch.randn(search_len, generator=gen).to(torch.bfloat16).float()
+    if mode.startswith("planted:"):
+        # K distinct high values planted at seeded positions over a constant
+        # low filler. The only stimulus that supports search_len > 16384 with
+        # an exact index golden: bf16 has no 2^16 distinct finite positive
+        # values (0x3F80 + 16384 is already +inf), so "positive" cannot scale
+        # -- and the planted positions land in every chunk, exercising the
+        # full runtime chunk-id range.
+        k = int(mode.split(":", 1)[1])
+        row = torch.full((search_len,), 1.0, dtype=torch.float32)  # 0x3F80 filler
+        positions = torch.randperm(search_len, generator=gen)[:k]
+        row[positions] = _distinct_bf16_from_hi16(
+            0x4080 + torch.randperm(k, generator=gen)
+        )
+        return row
     if mode == "all_equal":
         # Degenerate input: all identical.
         return torch.full((search_len,), 3.0, dtype=torch.float32)
@@ -173,6 +187,8 @@ def _variant(
     fused_reduce=False,
     chunk_base_mode=TopKXLChunkBaseMode.Static,
     chunk_base=0,
+    fused_e2e=False,
+    seg_base=0,
     dest_sync=DestSync.Full,
     formats=FORMATS,
 ):
@@ -213,6 +229,8 @@ def _variant(
                 fused_reduce=fused_reduce,
                 chunk_base_mode=chunk_base_mode,
                 chunk_base=chunk_base,
+                fused_e2e=fused_e2e,
+                seg_base=seg_base,
             ),
         ],
         variant_stimuli=StimuliConfig(
@@ -639,6 +657,88 @@ def test_topk_xl_fused_reduce(K, num_chunks):
     _check_coordinates(
         result, K, rows, num_chunks=num_chunks, group_id=GROUP_ID, core_id=None
     )
+
+
+@parametrize(K=[512, 1024, 2048], num_chunks=[2, 4, 32])
+def test_topk_xl_fused_e2e(K, num_chunks):
+    """
+    Fused END-TO-END (the topk_large_indices wide-row path): the chunk id is
+    stamped at RUNTIME into index bits [15:11] (_topk_xl_add_lsb_indices_rt_),
+    every merge/rebuild stays in the fused word, and ONE row-major global
+    split per row (_topk_xl_separate_indices_row_major_global_) recovers
+    chunk_id * K + within-chunk. num_chunks=32 exercises the full 5-bit stamp
+    range (ids 0..31), the information-theoretic limit of the fused word.
+    """
+    mode = f"planted:{K}" if num_chunks * K > 16384 else "positive"
+    _run_test_topk(K, num_chunks=num_chunks, fused_e2e=True, mode=mode)
+
+
+@parametrize(K=[512, 1024, 2048], seg_base_chunks=[32, 96, 160])
+def test_topk_xl_fused_e2e_segment_base(K, seg_base_chunks):
+    """
+    Segment-base split (_topk_xl_separate_indices_row_major_global_base_,
+    segmented fusion): a runtime seg_base is OR'd into every decoded index.
+    seg_base = seg_chunks * K is 2^(5 + log2 K)-aligned while the decoded
+    local index occupies exactly those low bits, so OR == ADD with zero bit
+    overlap -- the golden simply shifts by seg_base (index_offset).
+
+    The lattice pins each LREG5 load path: K=1024 combines the base with the
+    chunk-field rescale (chunk_field_shift = -1) and its 32-chunk base
+    (0x8000) probes lower-half sign handling; K=512 x 160 (0x14000) and
+    K=1024 x 96 (0x18000) load BOTH halves nonzero; K=2048 bases are pure
+    upper-half (n * 65536).
+    """
+    seg_base = seg_base_chunks * K
+    _run_test_topk(
+        K, num_chunks=4, fused_e2e=True, seg_base=seg_base, index_offset=seg_base
+    )
+
+
+@parametrize(K=[512, 1024, 2048], with_seg_base=[False, True])
+def test_topk_xl_fused_e2e_partial_tail(K, with_seg_base):
+    """-inf padded tail lanes must sort last and never win index lanes --
+    with and without a segment base on the split."""
+    seg_base = (32 * K) if with_seg_base else 0
+    _run_test_topk(
+        K,
+        num_chunks=3,
+        tail_elements=K // 2 + 17,
+        fused_e2e=True,
+        seg_base=seg_base,
+        index_offset=seg_base,
+    )
+
+
+def test_topk_xl_fused_e2e_denormal_word():
+    """
+    +0-valued winners produce denormal-shaped fused words (0x0000xxxx): the
+    runtime stamp and the GLOBAL split must move them with raw integer
+    load/stores -- an FP32 flush would annihilate the index (making it 0,
+    tripping the distinct-index assert). Mirrors
+    test_topk_xl_denormal_fused_word through the fused-e2e pipeline.
+    """
+    _run_test_topk(512, num_chunks=2, mode="zeros_win", fused_e2e=True)
+
+
+def test_topk_xl_fused_e2e_signed():
+    """Negative fused words carrying runtime stamps order correctly."""
+    _run_test_topk(2048, num_chunks=2, mode="signed", fused_e2e=True)
+
+
+def test_topk_xl_fused_e2e_two_rows():
+    """Row-loop re-entry after a global split: ADDR_MOD/LREG12 residue from
+    row r must not leak into row r+1's stamp or split."""
+    _run_test_topk(1024, num_chunks=4, num_rows=2, fused_e2e=True)
+
+
+@parametrize(K=[512, 2048])
+def test_topk_xl_fused_e2e_single_chunk(K):
+    """num_chunks=1: the global split runs on a raw descending local sort
+    with no merge/rebuild in between (the op's single-segment tail case).
+    The harness golden requires >= K valid elements, so the tail is full;
+    -inf pad-lane handling through a split is covered at the op level."""
+    (K,) = K
+    _run_test_topk(K, num_chunks=1, fused_e2e=True)
 
 
 @parametrize(K=[512, 1024, 2048], partial_tail=[False, True])

--- a/tt_metal/tt-llk/tests/python_tests/test_topk_xl_unfused_macro.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_topk_xl_unfused_macro.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Correctness gates for the UNFUSED topk_xl SFPLOADMACRO port (Blackhole).
+
+``ckernel_sfpu_topk_xl.h`` now macro-schedules the unfused merge body and the
+unfused rebuild's single-level stride-64/32/16 bodies BY DEFAULT (opt-out:
+``DISABLE_TOPK_XL_SFPLOADMACRO``). The full ``test_topk_xl.py`` matrix already
+exercises the macro path implicitly (it compiles the shipping header); this
+file adds the three checks that matrix cannot express:
+
+  1. CHAINED golden at num_chunks = 2 and 4 on the exact op path (row-major,
+     unfused). The branch's documented trap: a single merge+rebuild pair
+     cannot see a mis-ordered rebuild (it only PERMUTES its K survivors);
+     >= 3 chained pairs (num_chunks=4) are required for the error to reach
+     the next merge and corrupt the returned SET.
+  2. DIFFERENTIAL: the default (macro) build's packed output must be
+     byte-identical to the ``DISABLE_TOPK_XL_SFPLOADMACRO`` (shipping-body)
+     build on identical stimuli. This is the same macro==software evidence
+     shape the silicon probe (test_topk_unfused_macro_probe.py) validated.
+  3. MUTATION CONTROL: ``TOPK_XL_MACRO_MUTATE`` zeroes the macro Sequence
+     words, degenerating every SFPLOADMACRO into a plain SFPLOAD — the
+     documented "schedule nothing" failure mode that issue-rate timing
+     CANNOT see (the scheduled SFPSWAP and SFPSTORE ride otherwise-idle
+     sub-units either way). It silently drops the compare-exchanges AND the
+     macroVD stores, so the mutated build must diverge from the good build;
+     if it did not, the green runs above would prove nothing.
+     (Do NOT mutate by clearing the Simple byte's 0x80 bit: SFPSWAP(VC==VD)
+     is a same-register 2-cycle read-modify-write that silicon resolves as
+     garbage, not a modelable no-op — measured 2026-08-16.)
+
+Reuses ``sources/topk_xl_test.cpp`` (which compiles the shipping header) and
+the stimulus/golden machinery of ``test_topk_xl.py``.
+"""
+
+from dataclasses import dataclass
+
+import torch
+from conftest import skip_for_quasar, skip_for_wormhole
+from helpers.llk_params import (
+    DestAccumulation,
+    DestSync,
+    TopKSortDirection,
+    TopKXLChunkBaseMode,
+    TopKXLIndexOp,
+    format_dict,
+)
+from helpers.param_config import parametrize
+from helpers.stimuli_config import StimuliConfig
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import DEST_SYNC, TOPK_XL, TemplateParameter
+from test_topk_xl import (
+    ELEMENTS_PER_TILE,
+    FORMATS,
+    GROUP_SHIFT,
+    _build_input,
+    _check,
+    _tiles_per_sequence,
+)
+
+pytestmark = [skip_for_wormhole, skip_for_quasar]
+
+
+@dataclass
+class TOPK_XL_MACRO_KNOBS(TemplateParameter):
+    """Build-header knobs for the unfused SFPLOADMACRO path.
+
+    ``opt_out`` emits ``#define DISABLE_TOPK_XL_SFPLOADMACRO 1`` — the header
+    rebuilds the byte-identical pre-macro bodies. ``mutate`` emits
+    ``#define TOPK_XL_MACRO_MUTATE 1`` — the header zeroes the macro Sequence
+    words (schedule nothing). Defined here rather than in
+    helpers/test_variant_parameters.py because exactly one header consumes
+    them (same rationale as perf_topk_merge_macro.py's parameter classes).
+    """
+
+    opt_out: bool = False
+    mutate: bool = False
+
+    def convert_to_cpp(self) -> str:
+        lines = ["// topk_xl unfused SFPLOADMACRO knobs"]
+        if self.opt_out:
+            lines.append("#define DISABLE_TOPK_XL_SFPLOADMACRO 1")
+        if self.mutate:
+            lines.append("#define TOPK_XL_MACRO_MUTATE 1")
+        return "\n".join(lines)
+
+
+def _variant(K, num_chunks, opt_out=False, mutate=False, num_rows=2):
+    """The op path: row-major index split, UNFUSED merge/rebuild, descending.
+    Mirrors test_topk_xl._variant with the macro knobs added."""
+    tail_elements = K
+    tiles_per_seq = _tiles_per_sequence(K)
+    src_B = torch.zeros(ELEMENTS_PER_TILE, dtype=format_dict[FORMATS.input_format])
+    src_A, rows = _build_input(
+        K, num_chunks, tail_elements, num_rows, "positive", as_float32=False
+    )
+    config = TestConfig(
+        test_name="sources/topk_xl_test.cpp",
+        formats=FORMATS,
+        templates=[
+            DEST_SYNC(DestSync.Full),
+            TOPK_XL(
+                k=K,
+                num_chunks=num_chunks,
+                tail_elements=tail_elements,
+                num_rows=num_rows,
+                index_op=TopKXLIndexOp.RowMajor,
+                group_id=0,
+                group_shift=GROUP_SHIFT,
+                core_id=0,
+                sort_direction=TopKSortDirection.Descending,
+                fused_reduce=False,
+                chunk_base_mode=TopKXLChunkBaseMode.Static,
+                chunk_base=0,
+            ),
+            TOPK_XL_MACRO_KNOBS(opt_out=opt_out, mutate=mutate),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            FORMATS.input_format,
+            src_B,
+            FORMATS.input_format,
+            FORMATS.output_format,
+            tile_count_A=num_rows * num_chunks * tiles_per_seq,
+            tile_count_B=1,
+            tile_count_res=num_rows * 2 * tiles_per_seq,
+        ),
+        dest_acc=DestAccumulation.Yes,
+        unpack_to_dest=False,
+    )
+    return config, rows
+
+
+@parametrize(K=[512, 1024, 2048], num_chunks=[2, 4])
+def test_topk_xl_unfused_macro_chained(K, num_chunks):
+    """Golden gate on the default (macro-on) build. num_chunks=4 chains three
+    merge+rebuild pairs — the only configuration that catches a mis-ordered
+    rebuild (interleave/drain bugs present as EXACTLY that failure)."""
+    config, rows = _variant(K, num_chunks=num_chunks)
+    result = config.run().result
+    _check(result, K, rows, compare_index_set=True)
+
+
+@parametrize(K=[512, 1024, 2048])
+def test_topk_xl_unfused_macro_equals_opt_out(K):
+    """DIFFERENTIAL: default (macro) build == DISABLE_TOPK_XL_SFPLOADMACRO
+    (shipping-body) build, byte-for-byte on the packed result, at
+    num_chunks=4. Both must also pass the golden — equality of two wrong
+    outputs would otherwise slip through."""
+    (K,) = K
+    good_cfg, rows = _variant(K, num_chunks=4)
+    base_cfg, _ = _variant(K, num_chunks=4, opt_out=True)
+    # Build both before running either: under --compile-producer, run() skips
+    # as soon as the first variant is built (same reason as
+    # test_topk_rebuild_full_macro's mutation test).
+    good_cfg.prepare()
+    base_cfg.prepare()
+    good, base = good_cfg.run().result, base_cfg.run().result
+
+    _check(good, K, rows, compare_index_set=True)
+    assert torch.equal(good, base), (
+        f"K={K}: macro build's packed output differs from the opt-out "
+        f"(shipping-body) build — the unfused SFPLOADMACRO bodies are not "
+        f"bit-identical to the software bodies"
+    )
+
+
+@parametrize(K=[512, 1024, 2048])
+def test_topk_xl_unfused_macro_mutation(K):
+    """MUTATION CONTROL. TOPK_XL_MACRO_MUTATE zeroes the Sequence words:
+    every SFPLOADMACRO in the unfused merge/rebuild degenerates into a plain
+    SFPLOAD, dropping the compare-exchanges and the macroVD stores. The
+    mutated build must diverge from the good build at num_chunks=4; a green
+    mutated arm would mean every other test in this file is blind to whether
+    the macros do any work."""
+    (K,) = K
+    good_cfg, rows = _variant(K, num_chunks=4)
+    bad_cfg, _ = _variant(K, num_chunks=4, mutate=True)
+    good_cfg.prepare()
+    bad_cfg.prepare()
+    good, bad = good_cfg.run().result, bad_cfg.run().result
+
+    # Sanity: the unmutated build of this exact variant agrees with the
+    # golden, otherwise a red mutation arm is evidence of nothing.
+    _check(good, K, rows, compare_index_set=True)
+
+    assert not torch.equal(good, bad), (
+        f"K={K}: MUTATION NOT DETECTED — schedule-nothing macros produced "
+        f"the same packed output as the real ones. Every PASS in this file "
+        f"is void; the macro path is either not being compiled in or not "
+        f"being exercised."
+    )

--- a/tt_metal/tt-llk/tests/sources/topk_xl_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/topk_xl_test.cpp
@@ -60,24 +60,27 @@ std::uint32_t math_sync_tile_dst_index = 0;
 constexpr std::uint32_t ELEMENTS_PER_TILE = ckernel::TILE_R_DIM * ckernel::TILE_C_DIM;
 constexpr std::uint32_t TILES_PER_SEQ     = (TOPK_XL_K + ELEMENTS_PER_TILE - 1) / ELEMENTS_PER_TILE;
 constexpr std::uint32_t SLOT0             = 0;
-constexpr bool APPROX                     = false; // The wrappers take this param but never use it.
 
 constexpr bool INDEX_OP_ROW_MAJOR  = (TOPK_XL_INDEX_OP == 0);
 constexpr bool INDEX_OP_SEPARATE   = (TOPK_XL_INDEX_OP == 1);
 constexpr bool INDEX_OP_REMOVE_MSB = (TOPK_XL_INDEX_OP == 2);
 
 constexpr bool FUSED_REDUCE = TOPK_XL_FUSED_REDUCE;
+// Fused END-TO-END (the topk_large_indices wide-row family): runtime chunk-id
+// stamp in index bits [15:11], fused merge/rebuild, one row-major GLOBAL split
+// at the end (plain, or with a segment base for segmented fusion).
+constexpr bool FUSED_E2E = TOPK_XL_FUSED_E2E;
 
 // Second merge operand. `_topk_xl_merge_` reads it at a fixed distance from the
 // first: 64 dest units (one tile) per sequence-tile when fused, 128 (value +
 // index region) when unfused, so the slot stride follows the mode.
-constexpr std::uint32_t SLOT1 = FUSED_REDUCE ? TILES_PER_SEQ : (2 * TILES_PER_SEQ);
+constexpr std::uint32_t SLOT1 = (FUSED_REDUCE || FUSED_E2E) ? TILES_PER_SEQ : (2 * TILES_PER_SEQ);
 
 // A lone chunk has nothing to merge with, but the row-major path still rebuilds it;
 // the fused path merges/rebuilds only when there is a second operand.
 // Both TRISCs use this: MATH issues the rebuild, UNPACK the SrcB dummy valid feeding it.
 // Fused variants leave TOPK_XL_INDEX_OP at its 0 default and ignore it, hence the !FUSED_REDUCE.
-constexpr bool REBUILD_LONE_CHUNK = !FUSED_REDUCE && INDEX_OP_ROW_MAJOR && TOPK_XL_NUM_CHUNKS == 1;
+constexpr bool REBUILD_LONE_CHUNK = !FUSED_REDUCE && !FUSED_E2E && INDEX_OP_ROW_MAJOR && TOPK_XL_NUM_CHUNKS == 1;
 
 constexpr std::uint32_t CHUNK_BASE_HI16 = (TOPK_XL_CHUNK_BASE >> 16) & 0xFFFF;
 constexpr std::uint32_t CHUNK_BASE_LO16 = TOPK_XL_CHUNK_BASE & 0xFFFF;
@@ -183,19 +186,19 @@ inline void topk_xl_init()
 template <std::uint32_t K>
 inline void topk_xl_local_sort(std::uint32_t dst_index, bool ascending)
 {
-    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_topk_xl_local_sort_<K, APPROX>, dst_index, VectorMode::RC_custom, dst_index, ascending);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_topk_xl_local_sort_<K>, dst_index, VectorMode::RC_custom, dst_index, ascending);
 }
 
 template <std::uint32_t K, bool fused>
 inline void topk_xl_merge(std::uint32_t dst_index)
 {
-    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_topk_xl_merge_<K, APPROX, fused>, dst_index, VectorMode::RC_custom, dst_index);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_topk_xl_merge_<K, fused>, dst_index, VectorMode::RC_custom, dst_index);
 }
 
 template <std::uint32_t K, bool fused>
 inline void topk_xl_rebuild(std::uint32_t dst_index, bool ascending)
 {
-    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_topk_xl_rebuild_<K, APPROX, fused>, dst_index, VectorMode::RC_custom, dst_index, ascending);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_topk_xl_rebuild_<K, fused>, dst_index, VectorMode::RC_custom, dst_index, ascending);
 }
 
 inline void topk_xl_add_lsb_indices_init()
@@ -208,7 +211,7 @@ template <std::uint32_t K, std::uint32_t core_id>
 inline void topk_xl_add_lsb_indices(std::uint32_t dst_index)
 {
     static_assert(core_id < 32, "core_id occupies index bits [15:11]");
-    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_topk_xl_add_lsb_indices_<K, APPROX, core_id>, dst_index, VectorMode::RC_custom);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_topk_xl_add_lsb_indices_<K, core_id>, dst_index, VectorMode::RC_custom);
 }
 
 // --- Row-major index split (topk_large_indices op path) ---
@@ -244,7 +247,7 @@ inline void topk_xl_separate_indices_row_major_reinit()
 template <std::uint32_t K>
 inline void topk_xl_separate_indices_row_major(std::uint32_t dst_index)
 {
-    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_topk_xl_separate_indices_row_major_<K, APPROX>, dst_index, VectorMode::RC_custom);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_topk_xl_separate_indices_row_major_<K>, dst_index, VectorMode::RC_custom);
 }
 
 template <std::uint32_t K>
@@ -264,7 +267,7 @@ inline void topk_xl_separate_indices_init(std::uint32_t group_id_bit_shift)
 template <std::uint32_t K, std::uint32_t group_id>
 inline void topk_xl_separate_indices(std::uint32_t dst_index)
 {
-    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_topk_xl_separate_indices_<K, APPROX, group_id>, dst_index, VectorMode::RC_custom);
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_topk_xl_separate_indices_<K, group_id>, dst_index, VectorMode::RC_custom);
 }
 
 // Shared core: copy the chunk into `slot`, stamp indices, fused local-sort.
@@ -283,6 +286,41 @@ __attribute__((noinline)) void copy_sort(std::uint32_t slot, std::uint32_t activ
 
     topk_xl_init<K, true>();
     topk_xl_local_sort<K>(slot, ascending);
+}
+
+// Fused-e2e variant of copy_sort: the chunk id is stamped at RUNTIME into
+// index bits [15:11] (the topk_large_indices compute kernels' path).
+template <std::uint32_t K>
+__attribute__((noinline)) void copy_sort_rt(std::uint32_t slot, std::uint32_t active_elements, bool ascending, std::uint32_t chunk_id, std::uint32_t dst_format)
+{
+    ckernel::_llk_math_topk_xl_copy_init_(dst_format);
+    for (std::uint32_t t = 0; t < TILES_PER_SEQ; t++)
+    {
+        ckernel::_llk_math_topk_xl_copy_(slot + t, dst_format, tile_active_elements(active_elements, t));
+    }
+
+    topk_xl_add_lsb_indices_init();
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_topk_xl_add_lsb_indices_rt_<K>, slot, VectorMode::RC_custom, chunk_id);
+
+    topk_xl_init<K, true>();
+    topk_xl_local_sort<K>(slot, ascending);
+}
+
+inline void topk_xl_separate_indices_row_major_global_init()
+{
+    ckernel::sfpu::_topk_xl_separate_indices_row_major_global_init_();
+}
+
+template <std::uint32_t K>
+inline void topk_xl_separate_indices_row_major_global(std::uint32_t dst_index)
+{
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_topk_xl_separate_indices_row_major_global_<K>, dst_index, VectorMode::RC_custom);
+}
+
+template <std::uint32_t K>
+inline void topk_xl_separate_indices_row_major_global_base(std::uint32_t dst_index, std::uint32_t seg_base)
+{
+    _llk_math_eltwise_unary_sfpu_params_(ckernel::sfpu::_topk_xl_separate_indices_row_major_global_base_<K>, dst_index, VectorMode::RC_custom, seg_base);
 }
 
 // Row-major process_chunk: copy_sort then split into unfused values + row-major
@@ -344,7 +382,27 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         _llk_math_wait_for_dest_available_<dest_sync>();
 
-        if constexpr (FUSED_REDUCE)
+        if constexpr (FUSED_E2E)
+        {
+            // Fused end-to-end: runtime chunk-id stamps, fused merge/rebuild,
+            // then ONE global split -- plain or with a segment base.
+            copy_sort_rt<TOPK_XL_K>(SLOT0, chunk_active_elements(0), false /* ascending */, 0, math_format);
+            for (std::uint32_t c = 1; c < TOPK_XL_NUM_CHUNKS; c++)
+            {
+                copy_sort_rt<TOPK_XL_K>(SLOT1, chunk_active_elements(c), true /* ascending */, c, math_format);
+                merge_and_rebuild<TOPK_XL_K, true /* fused */>(true /* do_merge */);
+            }
+            topk_xl_separate_indices_row_major_global_init();
+            if constexpr (TOPK_XL_SEG_BASE != 0)
+            {
+                topk_xl_separate_indices_row_major_global_base<TOPK_XL_K>(SLOT0, TOPK_XL_SEG_BASE);
+            }
+            else
+            {
+                topk_xl_separate_indices_row_major_global<TOPK_XL_K>(SLOT0);
+            }
+        }
+        else if constexpr (FUSED_REDUCE)
         {
             // Fused reduction: chunks stay in the fused [value|index] form all the
             // way through merge/rebuild, and the index split happens once at the end.

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_topk_xl.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_topk_xl.h
@@ -109,6 +109,16 @@
 #include "sfpi.h"
 #include "sfpu/ckernel_sfpu_load_config.h"
 
+// SFPLOADMACRO acceleration of the UNFUSED merge / rebuild bodies — see the
+// "SFPLOADMACRO acceleration for the UNFUSED merge / rebuild" section below
+// for the full design, silicon validation, and the opt-out contract. Defined
+// here (before `topk_mop_config`) because the merge MOP body length keys on it.
+#if !defined(DISABLE_TOPK_XL_SFPLOADMACRO) && !defined(DISABLE_SFPLOADMACRO)
+#define TOPK_XL_UNFUSED_MACRO 1
+#else
+#define TOPK_XL_UNFUSED_MACRO 0
+#endif
+
 namespace ckernel
 {
 namespace sfpu
@@ -139,7 +149,14 @@ namespace sfpu
 template <bool fused>
 inline void topk_mop_config()
 {
+    // Unfused: the SFPLOADMACRO body is 16 instructions (the two SFPSWAPs and
+    // two of the eight stores ride the macros); the plain body is 18. Must
+    // match what `_topk_xl_merge_` records — both key on the same flag.
+#if TOPK_XL_UNFUSED_MACRO
+    constexpr int body_len = 16;
+#else
     constexpr int body_len              = fused ? 16 : 18;
+#endif
     constexpr std::uint32_t replay_body = lltt::replay_insn(0, body_len);
     ckernel_unpack_template tmpl        = ckernel_unpack_template::lA(replay_body, TT_OP_NOP);
     tmpl.program();
@@ -194,6 +211,283 @@ inline void topk_rebuild_build2048_mop_config()
         /*skipB=*/TT_OP_NOP);
     tmpl.program();
 }
+
+// =============================================================================
+//  SFPLOADMACRO acceleration for the UNFUSED merge / rebuild
+// =============================================================================
+//
+// The unfused merge body and the unfused rebuild's stride-64/32/16 bodies all
+// have the same single-level shape:
+//
+//     load8_rows_x2_unfused + bitonic_sort_len_k<false> + store8_rows_x2_unfused
+//
+// with every store going back to the address it was loaded from. That is the
+// structure the fused macro work proved on silicon: the two SFPSWAPs ride
+// SFPLOADMACRO Simple slots (delay 0) and the store of each macro's own
+// register rides its Store slot (delay 2, address latched at load time —
+// SFPLOADMACRO.md:140). Under SFPU index-tracking mode (LaneConfig bit [2],
+// which the unfused path enables) a macro-scheduled SFPSWAP still performs the
+// argmin/argmax companion swap of LReg[4+VC] <-> LReg[4+VD] — verified
+// bit-identical against the software swap by
+// tests/python_tests/test_topk_unfused_macro_probe.py (arms 1/2/4 green with
+// a sensitivity-proven mutation control, Blackhole silicon, 2026-08-16).
+//
+// The macro body is 16 issues against the shipping 18 issues + 2 two-cycle
+// (plus index-tracking stall) SFPSWAPs (~20-22 cycles):
+//
+//     i0..i3   4x SFPLOAD  (INT32)  index regs LREG4..7 — MUST precede the
+//                                    macros: the companion swap reads/writes
+//                                    LREG4..7 the cycle after each macro.
+//     i4       SFPLOAD  (FP32)      first VC provider
+//     i5       SFPLOADMACRO m0      loads first macroVD; Simple: SFPSWAP,
+//                                    MAD: SFPNOP (footnote ‡), Store: delay 2
+//     i6       SFPLOAD  (FP32)      second VC provider  — the plain load
+//                                    between macros IS the 2-slot separation
+//                                    rule (a macro-scheduled SFPSWAP owns the
+//                                    Simple sub-unit for 2 cycles and is
+//                                    exempt from the automatic stall)
+//     i7       SFPLOADMACRO m1
+//     i8       SFPNOP               m0's store fires here — keep it store-free
+//     i9       SFPSTORE (FP32)      first VC register
+//     i10      SFPNOP               m1's store fires here
+//     i11      SFPSTORE (FP32)      second VC register
+//     i12..i14 3x SFPSTORE (INT32)  LREG4/5/6
+//     i15      SFPSTORE (INT32)     LREG7 — carries the Dst-advance fold
+//                                    (kept in software so every inc_dst_addr
+//                                    variant of the shipping loops survives)
+//
+// Both scheduled stores retire INSIDE the body (delay 2 from i5/i7 fires at
+// i8/i10), so no trailing SFPNOPs and no cross-call pending-store state.
+//
+// Direction maps to which half is macroVD (the macro always overrides Insn.VD
+// with the register its own load writes):
+//   ascending  (sort_k ASC:  SWAP(VC=LREG2, VD=LREG0)) -> macroVD = LREG0/1,
+//              templates' VC = LREG2/3
+//   descending (sort_k DESC: SWAP(VC=LREG0, VD=LREG2)) -> macroVD = LREG2/3,
+//              templates' VC = LREG0/1
+// The merge always takes the descending form (it calls sort_k with false).
+// Merge and rebuild program their own two InstructionTemplates at entry
+// (2 backdoor writes — self-contained, no cross-call template contract, and
+// no collision with the FUSED macro users' templates). The Sequence words and
+// Misc are direction- and caller-invariant and are programmed once per
+// `_topk_xl_init_<K, false>`.
+//
+// Index loads/stores stay in software: only 4 macro slots exist, the 2-bit
+// Store delay field cannot reach past the swap-macros' store cycles in a
+// 16-issue body, and LREG7's store carries the shipping ADDR_MOD fold.
+//
+// Opt-out: define DISABLE_TOPK_XL_SFPLOADMACRO (or the global
+// DISABLE_SFPLOADMACRO) to rebuild the byte-identical pre-macro bodies.
+// TOPK_XL_MACRO_MUTATE is a TEST-ONLY hook: it zeroes the Sequence words so
+// every SFPLOADMACRO degenerates into a plain SFPLOAD ("schedule nothing"),
+// which silently drops the compare-exchanges AND the macro stores — the
+// timing-invisible failure mode the correctness suites must be able to see.
+// (The TOPK_XL_UNFUSED_MACRO gate itself is defined at the top of this file,
+// before `topk_mop_config`, which keys its unfused body length on it.)
+
+#if TOPK_XL_UNFUSED_MACRO
+
+namespace topk_xl_unfused_macro
+{
+
+// Simple byte: selector 4+m -> InstructionTemplate[m], delay 0. 0x80 SET ->
+// Insn.VB = macroVD, leaving Insn.VC at the template's value (with it clear
+// the macro would assign Insn.VC = macroVD and the SFPSWAP degenerates to a
+// same-register compare — which silicon resolves as garbage, not a no-op).
+// 0x40 CLEAR -> Insn.VD = macroVD.
+constexpr std::uint32_t seq_simple(std::uint32_t m)
+{
+    return 0x80u | (0u << 3) | (4u + m);
+}
+
+// MAD byte: SFPNOP at the same delay — required whenever SFPSWAP is scheduled
+// to the Simple sub-unit (SFPLOADMACRO.md:11 footnote ‡). Round: nothing.
+constexpr std::uint32_t SEQ_MAD_NOP = (0u << 3) | 2u;
+
+// Store byte: selector 3 = the built-in SFPSTORE, delay 2 — the SFPSWAP
+// writes macroVD on its second cycle (macro+2), the store fires at macro+3.
+// 0x40/0x80 clear -> Insn.VD = macroVD.
+constexpr std::uint32_t SEQ_STORE = (2u << 3) | 3u;
+
+#if defined(TOPK_XL_MACRO_MUTATE)
+// Mutation control (test-only): schedule nothing.
+constexpr std::uint32_t sequence_word(std::uint32_t)
+{
+    return 0u;
+}
+#else
+constexpr std::uint32_t sequence_word(std::uint32_t m)
+{
+    return (SEQ_STORE << 24) | (SEQ_MAD_NOP << 8) | seq_simple(m);
+}
+#endif
+
+// Misc (SFPLOADMACRO.md:53-57): 0xF0 -> every macro's store inherits its
+// LOAD's Mod0 (FP32 here — the value regs are genuine FP32, same mode the
+// shipping software stores use). 0xB00 -> Simple/MAD/Store on
+// WaitForElapsedInstructions so the delay chain cannot slide if the frontend
+// bubbles.
+constexpr std::uint32_t MISC_WORD = 0xB00u | 0xF0u;
+
+// TTI_SFPCONFIG(imm16, dest, mod1) fields (SFPCONFIG.md):
+//   dest  — target config register: SequenceReg[i] sits at 4+i (:52-55),
+//           the Misc register at 8 (:56).
+//   mod1  — 0: load the 32-bit word staged in LReg[0] into `dest` (:100);
+//           SFPCFG_IMM16_IS_VALUE (1): write imm16 directly (:108).
+constexpr std::uint32_t SFPCFG_DEST_SEQUENCE_BASE = 4; // dest of SequenceReg[0]; [1] at +1
+constexpr std::uint32_t SFPCFG_DEST_MISC          = 8;
+constexpr std::uint32_t SFPCFG_LOAD_FROM_LREG0    = 0;
+constexpr std::uint32_t SFPCFG_IMM16_IS_VALUE     = 1; // SFPCONFIG.md:108
+
+// SFPLOADMACRO field packing (ckernel_ops.h:689, SFPLOADMACRO.md:20-26,45):
+//   lreg_ind = (MacroIndex << 2) | (VD & 3), dest_reg_addr = (Imm9 << 1) | (VD >> 2).
+// VD is u3 and the address low bit is unused (SFPLOAD.md:83), so VD in 0..7
+// never perturbs the address.
+#define TOPK_XL_UNFUSED_LOADMACRO(macro_idx, vd, off) \
+    TTI_SFPLOADMACRO(((macro_idx) << 2) | ((vd) & 3u), InstrModLoadStore::FP32, ADDR_MOD_7, (off) | ((vd) >> 2))
+
+// Program Sequence[0/1] + Misc. Stages each 32-bit word through LReg[0] (the
+// _init_mul_int_ idiom — the Store byte does not fit the imm16 path).
+// Runs from `_topk_xl_init_<K, false>`; LReg[0] is reloaded by every body.
+inline void configure_sequences()
+{
+    TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, sequence_word(0) & 0xFFFF);
+    TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (sequence_word(0) >> 16) & 0xFFFF);
+    TTI_SFPCONFIG(0, SFPCFG_DEST_SEQUENCE_BASE + 0, SFPCFG_LOAD_FROM_LREG0);
+    TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, sequence_word(1) & 0xFFFF);
+    TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (sequence_word(1) >> 16) & 0xFFFF);
+    TTI_SFPCONFIG(0, SFPCFG_DEST_SEQUENCE_BASE + 1, SFPCFG_LOAD_FROM_LREG0);
+    TTI_SFPCONFIG(MISC_WORD, SFPCFG_DEST_MISC, SFPCFG_IMM16_IS_VALUE);
+    // SFPCONFIG writes to the Sequence/Misc registers take two cycles to
+    // land before an SFPLOADMACRO may consume them; issuing a macro sooner
+    // reads the stale configuration. Two NOPs is the measured minimum on
+    // BH silicon (validated by the mutation-control suite: removing either
+    // NOP flips the macro-vs-optout differential from bit-identical to
+    // divergent).
+    TTI_SFPNOP;
+    TTI_SFPNOP;
+}
+
+// Install InstructionTemplate[0/1] for one direction via the VD >= 12
+// backdoor (open: the unfused LaneConfig is 0x4, DISABLE_BACKDOOR_LOAD clear).
+// Mod1 stays ALL_ROWS_MAX — both halves are kept and the shipping operand
+// order already puts the macro-reachable half in macroVD.
+template <bool ascending>
+inline void program_templates()
+{
+    if constexpr (ascending)
+    {
+        TTI_SFPSWAP(0, p_sfpu::LREG2, 12, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPSWAP(0, p_sfpu::LREG3, 13, p_sfpswap::ALL_ROWS_MAX);
+    }
+    else
+    {
+        TTI_SFPSWAP(0, p_sfpu::LREG0, 12, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPSWAP(0, p_sfpu::LREG1, 13, p_sfpswap::ALL_ROWS_MAX);
+    }
+}
+
+// The body minus the LREG7 tail — 15 issues (see the section comment's
+// timeline). Kept separate so the split-record loops can emit a per-iter
+// LREG7 ADDR_MOD exactly like the shipping `store_first_7_rows_x2_unfused`
+// pattern.
+template <int indices_offset, int group_2_offset, bool ascending>
+inline void ce_first15()
+{
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_7, indices_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_7, indices_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::INT32, ADDR_MOD_7, indices_offset + group_2_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_7, indices_offset + group_2_offset + 4);
+    if constexpr (ascending)
+    {
+        TTI_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::FP32, ADDR_MOD_7, group_2_offset + 0);
+        TOPK_XL_UNFUSED_LOADMACRO(0u, p_sfpu::LREG0, 0);
+        TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::FP32, ADDR_MOD_7, group_2_offset + 4);
+        TOPK_XL_UNFUSED_LOADMACRO(1u, p_sfpu::LREG1, 4);
+        TTI_SFPNOP; // m0's store (LREG0 -> 0) fires here
+        TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::FP32, ADDR_MOD_7, group_2_offset + 0);
+        TTI_SFPNOP; // m1's store (LREG1 -> 4) fires here
+        TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::FP32, ADDR_MOD_7, group_2_offset + 4);
+    }
+    else
+    {
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_7, 0);
+        TOPK_XL_UNFUSED_LOADMACRO(0u, p_sfpu::LREG2, group_2_offset + 0);
+        TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::FP32, ADDR_MOD_7, 4);
+        TOPK_XL_UNFUSED_LOADMACRO(1u, p_sfpu::LREG3, group_2_offset + 4);
+        TTI_SFPNOP; // m0's store (LREG2 -> group_2_offset) fires here
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_7, 0);
+        TTI_SFPNOP; // m1's store (LREG3 -> group_2_offset + 4) fires here
+        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP32, ADDR_MOD_7, 4);
+    }
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_7, indices_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_7, indices_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::INT32, ADDR_MOD_7, indices_offset + group_2_offset + 0);
+}
+
+// The LREG7 tail — same inc_dst_addr -> ADDR_MOD mapping as
+// `store8_rows_x2_unfused`'s last store, so every shipping fold survives.
+template <int indices_offset, int group_2_offset, int inc_dst_addr>
+inline void ce_tail()
+{
+    constexpr int off = indices_offset + group_2_offset + 4;
+    if constexpr (inc_dst_addr == 40)
+    {
+        TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_3, off);
+    }
+    else if constexpr (inc_dst_addr == 32)
+    {
+        TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_6, off);
+    }
+    else if constexpr (inc_dst_addr == 24)
+    {
+        TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_2, off);
+    }
+    else if constexpr (inc_dst_addr == 16)
+    {
+        TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_5, off);
+    }
+    else if constexpr (inc_dst_addr == 8)
+    {
+        TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_4, off);
+    }
+    else if constexpr (inc_dst_addr == 0)
+    {
+        TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_7, off);
+    }
+    else
+    {
+        static_assert(inc_dst_addr == 0, "Invalid inc_dst_addr");
+    }
+}
+
+// Full 16-issue body.
+template <int indices_offset, int group_2_offset, int inc_dst_addr, bool ascending>
+inline void ce_full()
+{
+    ce_first15<indices_offset, group_2_offset, ascending>();
+    ce_tail<indices_offset, group_2_offset, inc_dst_addr>();
+}
+
+// Record the full body (recording IS the first executed iteration) into
+// replay slots [0, 16) for the runtime direction. Fold iterations replay
+// [0, 15) and emit their own tail.
+template <int indices_offset, int group_2_offset, int inc_dst_addr>
+inline void record_ce_full(const bool dir)
+{
+    if (dir)
+    {
+        load_replay_buf<Exec>(0, 16, [] { ce_full<indices_offset, group_2_offset, inc_dst_addr, true>(); });
+    }
+    else
+    {
+        load_replay_buf<Exec>(0, 16, [] { ce_full<indices_offset, group_2_offset, inc_dst_addr, false>(); });
+    }
+}
+
+} // namespace topk_xl_unfused_macro
+
+#endif // TOPK_XL_UNFUSED_MACRO
 
 // =============================================================================
 //  Init
@@ -282,7 +576,17 @@ inline void _topk_xl_init_()
     {
         // Enable SFPU index-tracking mode (bit [2] of SFPU_CONTROL_REG)
         // so the unfused path can keep indices in a parallel DST region.
+        // Bit [1] (DISABLE_BACKDOOR_LOAD) stays 0, keeping the VD >= 12
+        // InstructionTemplate backdoor open for the macro programming below
+        // and for the per-call template installs in merge / rebuild.
         _sfpu_load_config32_(0xF, 0x0, 0x4);
+
+#if TOPK_XL_UNFUSED_MACRO
+        // Sequence words + Misc for the unfused macro bodies. Direction- and
+        // caller-invariant; the two InstructionTemplates are installed by
+        // `_topk_xl_merge_` / `_topk_xl_rebuild_` at each entry.
+        topk_xl_unfused_macro::configure_sequences();
+#endif
     }
 
     // Program the MOP Expander so the merge's inner loop can fire with a
@@ -1170,16 +1474,16 @@ inline void canonical_big_block_with_replay(bool dir)
 // `set_dst_write_addr_offset(tile_offset + (col ? 0 : 2))` flips the Dst
 // pointer between the even and odd columns of the current pair of DST tiles.
 // Forward declaration — defined below the K=2048 optimized body.
-template <std::uint32_t K, bool APPROXIMATION_MODE>
+template <std::uint32_t K>
 inline void _topk_xl_local_sort_generic_(std::uint32_t dst_index, bool ascending);
 
-template <std::uint32_t K, bool APPROXIMATION_MODE>
+template <std::uint32_t K>
 inline void _topk_xl_local_sort_(const std::uint32_t dst_index, const bool ascending)
 {
     static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
     if constexpr (K != 2048)
     {
-        _topk_xl_local_sort_generic_<K, APPROXIMATION_MODE>(dst_index, ascending);
+        _topk_xl_local_sort_generic_<K>(dst_index, ascending);
         return;
     }
 
@@ -1425,7 +1729,7 @@ inline void _topk_xl_local_sort_(const std::uint32_t dst_index, const bool ascen
 // The K=2048 case continues to be routed to the K=2048 fast path by
 // `_topk_xl_local_sort_`'s `if constexpr (K != 2048)` guard, so the
 // codegen here is exercised only by K=512 and K=1024.
-template <std::uint32_t K, bool APPROXIMATION_MODE>
+template <std::uint32_t K>
 inline void _topk_xl_local_sort_generic_(const std::uint32_t dst_index, const bool ascending)
 {
     static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
@@ -1680,20 +1984,24 @@ inline void _topk_xl_local_sort_generic_(const std::uint32_t dst_index, const bo
 // We record the body once (recording IS iter 0 of col=0), then fire it
 // through the MOP Expander programmed at init: each column collapses to
 // a single TTI_MOP issue that re-runs the recorded body N_ITERS times.
-template <std::uint32_t K, bool APPROXIMATION_MODE, bool fused>
+template <std::uint32_t K, bool fused>
 inline void _topk_xl_merge_(const std::uint32_t dst_index)
 {
     static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
 
-    constexpr bool descending                     = false; // direction the merge writes
+    [[maybe_unused]] constexpr bool descending    = false; // direction the merge writes
     constexpr int num_tiles_per_sequence          = (K == 2048) ? 2 : 1;
     constexpr int row_scale_factor                = (K == 512) ? 1 : (K == 1024) ? 2 : 4;
     constexpr int distance                        = fused ? (64 * num_tiles_per_sequence) : (128 * num_tiles_per_sequence);
     [[maybe_unused]] constexpr int indices_offset = 64 * num_tiles_per_sequence;
     const std::uint32_t tile_offset               = dst_index << DstTileSizeLog2[DstTileShape::Tile32x32];
 
+#if TOPK_XL_UNFUSED_MACRO
+    constexpr int body_len = 16; // must match topk_mop_config's REPLAY length
+#else
     constexpr int body_len = fused ? 16 : 18;
-    constexpr int n_iters  = fused ? (row_scale_factor * 2) : (row_scale_factor * 4);
+#endif
+    constexpr int n_iters = fused ? (row_scale_factor * 2) : (row_scale_factor * 4);
     static_assert(n_iters >= 2, "n_iters < 2 would skip the MOP firing of col=0");
     static_assert(n_iters <= 255, "ckernel_unpack_template::run takes a uint8_t count");
 
@@ -1714,6 +2022,15 @@ inline void _topk_xl_merge_(const std::uint32_t dst_index)
     }
     else
     {
+#if TOPK_XL_UNFUSED_MACRO
+        // SFPLOADMACRO body: the two SFPSWAPs ride the loads' Simple slots
+        // and the macroVD stores ride their Store slots. The merge always
+        // sorts with `descending` (= the ascending=false operand order), so
+        // macroVD = LREG2/3 and the templates' VC = LREG0/1. Every scheduled
+        // store retires inside the body — no trailing SFPNOPs needed.
+        topk_xl_unfused_macro::program_templates<false>();
+        load_replay_buf<Exec>(0, body_len, [] { topk_xl_unfused_macro::ce_full<indices_offset, distance, 8 /* inc_dst_addr */, false>(); });
+#else
         load_replay_buf<Exec>(
             0,
             body_len,
@@ -1723,6 +2040,7 @@ inline void _topk_xl_merge_(const std::uint32_t dst_index)
                 bitonic_sort_len_k<fused>(descending);
                 store8_rows_x2_unfused<indices_offset, distance, 8 /* inc_dst_addr */>();
             });
+#endif
     }
 
     // col=0: fire the remaining (n_iters - 1) iters via one MOP issue.
@@ -1752,16 +2070,16 @@ inline void _topk_xl_merge_(const std::uint32_t dst_index)
 // template (the body is 34 instructions and doesn't fit in one 32-slot
 // replay window), unfused mode uses straightforward split-record loops.
 // Forward declaration — defined below the K=2048 optimized body.
-template <std::uint32_t K, bool APPROXIMATION_MODE, bool fused>
+template <std::uint32_t K, bool fused>
 inline void _topk_xl_rebuild_generic_(std::uint32_t dst_index, bool ascending);
 
-template <std::uint32_t K, bool APPROXIMATION_MODE, bool fused>
+template <std::uint32_t K, bool fused>
 inline void _topk_xl_rebuild_(const std::uint32_t dst_index, const bool ascending)
 {
     static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
     if constexpr (K != 2048)
     {
-        _topk_xl_rebuild_generic_<K, APPROXIMATION_MODE, fused>(dst_index, ascending);
+        _topk_xl_rebuild_generic_<K, fused>(dst_index, ascending);
         return;
     }
 
@@ -1856,8 +2174,78 @@ inline void _topk_xl_rebuild_(const std::uint32_t dst_index, const bool ascendin
         set_dst_write_addr_offset(tile_offset + 0);
         transpose_8_faces<fused, indices_offset, /*manage_outer_cfg=*/false>();
         leave_transpose_cfg_block();
+
+#if TOPK_XL_UNFUSED_MACRO
+        // Install the direction's InstructionTemplates once for all three
+        // stride phases below (2 backdoor writes; Sequence/Misc were
+        // programmed by `_topk_xl_init_<K, false>`).
+        if (dir)
+        {
+            topk_xl_unfused_macro::program_templates<true>();
+        }
+        else
+        {
+            topk_xl_unfused_macro::program_templates<false>();
+        }
+#endif
         for (int col = 0; col < 2; col++)
         {
+#if TOPK_XL_UNFUSED_MACRO
+            // ── Stride-64 — 16-slot macro body, recording IS iter 0 ────────
+            topk_xl_unfused_macro::record_ce_full<indices_offset, 64, 8>(dir);
+            for (int i = 1; i < 8; i++)
+            {
+                lltt::replay(0, 16);
+            }
+            TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+
+            // ── Stride-32 — recorded body carries the ADDR_MOD_4 (+8) tail;
+            // the last inner iter of each outer pair replays [0, 15) and
+            // emits its own ADDR_MOD_3 (+40) tail, exactly the shipping
+            // split-record fold.
+            for (int i = 0; i < 2; i++)
+            {
+                for (int j = 0; j < 4; j++)
+                {
+                    if (i == 0 && j == 0)
+                    {
+                        topk_xl_unfused_macro::record_ce_full<indices_offset, 32, 8>(dir);
+                    }
+                    else if (j < 3)
+                    {
+                        lltt::replay(0, 16);
+                    }
+                    else
+                    {
+                        lltt::replay(0, 15);
+                        topk_xl_unfused_macro::ce_tail<indices_offset, 32, 40>();
+                    }
+                }
+            }
+            TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+
+            // ── Stride-16 — same shape; fold iters take ADDR_MOD_2 (+24) ───
+            for (int i = 0; i < 4; i++)
+            {
+                for (int j = 0; j < 2; j++)
+                {
+                    if (i == 0 && j == 0)
+                    {
+                        topk_xl_unfused_macro::record_ce_full<indices_offset, 16, 8>(dir);
+                    }
+                    else if (j == 0)
+                    {
+                        lltt::replay(0, 16);
+                    }
+                    else
+                    {
+                        lltt::replay(0, 15);
+                        topk_xl_unfused_macro::ce_tail<indices_offset, 16, 24>();
+                    }
+                }
+            }
+            TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+#else
             // ── Stride-64 — clean N = 8 replay, recording IS iter 0 ────────
             load_replay_buf<Exec>(0, 8, [] { load8_rows_x2_unfused<indices_offset, 64>(); });
             bitonic_sort_len_k<fused>(dir);
@@ -1939,6 +2327,7 @@ inline void _topk_xl_rebuild_(const std::uint32_t dst_index, const bool ascendin
                 }
             }
             TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+#endif // TOPK_XL_UNFUSED_MACRO
 
             // ── Stride-8 — clean N = 8 replay, recording IS iter 0 ────────
             load_replay_buf<Exec>(0, 8, [] { load8_rows_x2_unfused<indices_offset, 8>(); });
@@ -1994,7 +2383,7 @@ inline void _topk_xl_rebuild_(const std::uint32_t dst_index, const bool ascendin
 //
 // The K=2048 case continues to be routed to the K=2048 fast path by
 // `_topk_xl_rebuild_`'s `if constexpr (K != 2048)` guard.
-template <std::uint32_t K, bool APPROXIMATION_MODE, bool fused>
+template <std::uint32_t K, bool fused>
 inline void _topk_xl_rebuild_generic_(const std::uint32_t dst_index, const bool ascending)
 {
     static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
@@ -2093,6 +2482,19 @@ inline void _topk_xl_rebuild_generic_(const std::uint32_t dst_index, const bool 
         transpose_N_faces</*N*/ row_scale_factor * 2, fused, indices_offset, /*manage_outer_cfg=*/false>();
         leave_transpose_cfg_block();
 
+#if TOPK_XL_UNFUSED_MACRO
+        // Install the direction's InstructionTemplates once for the stride-32
+        // and stride-16 phases below (2 backdoor writes; Sequence/Misc were
+        // programmed by `_topk_xl_init_<K, false>`).
+        if (dir)
+        {
+            topk_xl_unfused_macro::program_templates<true>();
+        }
+        else
+        {
+            topk_xl_unfused_macro::program_templates<false>();
+        }
+#endif
         for (int col = 0; col < 2; col++)
         {
             // The inner loop counts here mirror `row_scale_factor` exactly
@@ -2116,6 +2518,25 @@ inline void _topk_xl_rebuild_generic_(const std::uint32_t dst_index, const bool 
             // first inline iteration.
             if constexpr (K >= 1024)
             {
+#if TOPK_XL_UNFUSED_MACRO
+                // ── stride-32 — 16-slot macro body. The recorded body
+                // carries the ADDR_MOD_4 (+8) tail; the last body of each
+                // outer iter replays [0, 15) and emits the ADDR_MOD_3
+                // (+40) fold tail, preserving the shipping stride walk.
+                topk_xl_unfused_macro::record_ce_full<indices_offset, 32, 8>(dir);
+                for (int i = 0; i < (row_scale_factor >> 1); i++)
+                {
+                    if (!(i == 0))
+                    {
+                        lltt::replay(0, 16);
+                    }
+                    lltt::replay(0, 16);
+                    lltt::replay(0, 16);
+                    lltt::replay(0, 15);
+                    topk_xl_unfused_macro::ce_tail<indices_offset, 32, 40>();
+                }
+                TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+#else
                 // ── stride-32 ─────────────────────────────────────────
                 // Four sort_k pairs per outer iter. The last pair folds
                 // its trailing `INCRWC(+8)` into the LREG7 store via
@@ -2145,8 +2566,23 @@ inline void _topk_xl_rebuild_generic_(const std::uint32_t dst_index, const bool 
                     store8_rows_x2_unfused<indices_offset, 32, 40 /* inc_dst_addr */>();
                 }
                 TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+#endif // TOPK_XL_UNFUSED_MACRO
             }
 
+#if TOPK_XL_UNFUSED_MACRO
+            // ── stride-16 — 16-slot macro body; every second body replays
+            // [0, 15) and emits the ADDR_MOD_2 (+24) fold tail.
+            topk_xl_unfused_macro::record_ce_full<indices_offset, 16, 8>(dir);
+            lltt::replay(0, 15);
+            topk_xl_unfused_macro::ce_tail<indices_offset, 16, 24>();
+            for (int i = 1; i < row_scale_factor; i++)
+            {
+                lltt::replay(0, 16);
+                lltt::replay(0, 15);
+                topk_xl_unfused_macro::ce_tail<indices_offset, 16, 24>();
+            }
+            TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+#else
             // ── stride-16 ─────────────────────────────────────────────
             // Two sort_k iters per outer iter. The first uses ADDR_MOD_4
             // (+8); the second folds its trailing +8 INCRWC into the
@@ -2171,6 +2607,7 @@ inline void _topk_xl_rebuild_generic_(const std::uint32_t dst_index, const bool 
                 store8_rows_x2_unfused<indices_offset, 16, 24 /* inc_dst_addr */>();
             }
             TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+#endif // TOPK_XL_UNFUSED_MACRO
 
             // ── stride-8 + sort_16_alt ────────────────────────────────
             // Clean N-iter replay (no LREG7 fold needed; the store's
@@ -2245,7 +2682,7 @@ inline void _topk_xl_add_lsb_indices_init_()
 //   bits [ 4: 0] — within-row column (5 bits, lane id)
 //
 // After this routine each DST word reads as `[ bf16 value | u16 index ]`.
-template <std::uint32_t K, bool APPROXIMATION_MODE, std::uint32_t core_id>
+template <std::uint32_t K, std::uint32_t core_id>
 inline void _topk_xl_add_lsb_indices_()
 {
     static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
@@ -2326,6 +2763,80 @@ inline void _topk_xl_add_lsb_indices_()
     //            extra outer iters needed.
     //   K=1024 → 2 face-pairs total → 1 extra outer iter here.
     //   K=2048 → 4 face-pairs total → 3 extra outer iters here.
+    constexpr int row_scale_factor = K == 512 ? 1 : K == 1024 ? 2 : 4;
+    for (int j = 1; j < row_scale_factor; j++)
+    {
+        TTI_SFPLOAD(p_sfpu::LREG4, 10, ADDR_MOD_4, 0);
+
+        for (int i = 0; i < 4; i++)
+        {
+            lltt::replay(0, 16);
+        }
+    }
+}
+
+// Runtime-chunk-id variant of `_topk_xl_add_lsb_indices_`: identical body,
+// but the 5-bit id in bits [15:11] comes from a RUNTIME argument (composed
+// via TT_SFPLOADI) instead of the template parameter — one stamp
+// instantiation serves every chunk of a fused end-to-end row. KEEP IN SYNC
+// with the template variant above; the ONLY difference is the id load.
+template <std::uint32_t K>
+inline void _topk_xl_add_lsb_indices_rt_(const std::uint32_t chunk_id)
+{
+    static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+
+    TTI_SFPMOV(0, p_sfpu::LTILEID, p_sfpu::LREG0, 0);
+
+    TTI_SFPIADD(1, p_sfpu::LREG0, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(16, p_sfpu::LREG0, p_sfpu::LREG2, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(17, p_sfpu::LREG0, p_sfpu::LREG3, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    TTI_SFPSHFT(6, 0, p_sfpu::LREG0, 1);
+
+    // Load chunk_id (runtime) and place it in bits [15:11] of every lane.
+    // Masked to the 5-bit field at composition: an out-of-contract id can
+    // only wrap within the index field, never spill into the BF16 value
+    // half (the mask is RISC-side arithmetic on the composed immediate —
+    // zero SFPU cost).
+    TT_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, chunk_id & 0x1Fu);
+    TTI_SFPSHFT(11, 0, p_sfpu::LREG1, 1);
+
+    TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_ARG_LREG_DST | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(1, p_sfpu::LREG0, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(2, p_sfpu::LREG0, p_sfpu::LREG2, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(3, p_sfpu::LREG0, p_sfpu::LREG3, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    lltt::record<lltt::Exec>(0, 16);
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_7, 2);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::INT32, ADDR_MOD_7, 16 + 0);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_7, 16 + 2);
+
+    TTI_SFPOR(0, p_sfpu::LREG0, p_sfpu::LREG4, 0);
+    TTI_SFPOR(0, p_sfpu::LREG1, p_sfpu::LREG5, 0);
+    TTI_SFPOR(0, p_sfpu::LREG2, p_sfpu::LREG6, 0);
+    TTI_SFPOR(0, p_sfpu::LREG3, p_sfpu::LREG7, 0);
+
+    TTI_SFPIADD(4, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(4, p_sfpu::LREG1, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(4, p_sfpu::LREG2, p_sfpu::LREG2, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(4, p_sfpu::LREG3, p_sfpu::LREG3, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_7, 2);
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::INT32, ADDR_MOD_7, 16 + 0);
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_6, 16 + 2);
+
+    for (int i = 1; i < 4; i++)
+    {
+        lltt::replay(0, 16);
+    }
+
     constexpr int row_scale_factor = K == 512 ? 1 : K == 1024 ? 2 : 4;
     for (int j = 1; j < row_scale_factor; j++)
     {
@@ -2548,7 +3059,7 @@ inline void _topk_xl_decode_row_major_index_()
     TTI_SFPMOV(0, p_sfpu::LREG2, p_sfpu::LREG0, 0);
 }
 
-template <std::uint32_t K, bool APPROXIMATION_MODE>
+template <std::uint32_t K>
 inline void _topk_xl_separate_indices_row_major_()
 {
     static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
@@ -2568,6 +3079,109 @@ inline void _topk_xl_separate_indices_row_major_()
         TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_UPPER, 0);
         _topk_xl_decode_row_major_index_<K>();
         TTI_SFPOR(0, p_sfpu::LREG12, p_sfpu::LREG0, 0);
+
+        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_0, indices_offset);
+    }
+}
+
+// Fused end-to-end variant: like `_topk_xl_separate_indices_row_major_init_`,
+// but LREG12 carries the chunk-id FIELD MASK (bits [15:11]) instead of a
+// chunk base — the global index is recovered from the stamp itself, so no
+// per-chunk base bookkeeping exists at all.
+inline void _topk_xl_separate_indices_row_major_global_init_()
+{
+    addr_mod_t {
+        .srca = {.incr = 0},
+        .srcb = {.incr = 0},
+        .dest = {.incr = 2},
+    }
+        .set(ADDR_MOD_0);
+
+    _sfpu_load_config32_(p_sfpu::LREG12, /*upper16=*/0, /*lower16=*/0xF800);
+    _sfpu_load_config32_(p_sfpu::LREG13, /*upper16=*/0, /*lower16=*/0x000F);
+    _sfpu_load_config32_(p_sfpu::LREG14, /*upper16=*/0, /*lower16=*/0x0001);
+}
+
+// Fused end-to-end split: runs ONCE per row on the final fused survivor
+// (instead of once per chunk pre-merge). Each u16 payload carries
+// [chunk_id 15:11 | within-chunk coordinate 10:0]; the global index is
+// chunk_id * K + row-major(within-chunk). For K=2048 the stamp field IS
+// chunk_id * 2048; narrower windows shift it down to the right weight.
+// Requires `_topk_xl_separate_indices_row_major_global_init_` (LREG12 =
+// 0xF800). Only sound for rows of <= 32 chunks (5-bit id) — the factory
+// gates FUSED_E2E on the padded chunk count.
+template <std::uint32_t K>
+inline void _topk_xl_separate_indices_row_major_global_()
+{
+    static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
+    constexpr int row_scale_factor       = K == 512 ? 1 : K == 1024 ? 2 : 4;
+    constexpr int num_tiles_per_sequence = K == 512 ? 1 : K == 1024 ? 1 : 2;
+    constexpr int indices_offset         = num_tiles_per_sequence * 64;
+    // chunk_id sits at [15:11] = chunk_id * 2048; rescale to chunk_id * K.
+    constexpr int chunk_field_shift = K == 2048 ? 0 : K == 1024 ? -1 : -2;
+
+    for (int i = 0; i < row_scale_factor * 16; i++)
+    {
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+
+        // Value region: keep BF16 value high half and clear low half.
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
+        TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_LOWER, 0);
+
+        // Index region: clear high half, save the raw u16 (incl. chunk id),
+        // decode the within-chunk coordinate, then OR the rescaled chunk
+        // field back in.
+        TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_UPPER, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG4, 0);
+        _topk_xl_decode_row_major_index_<K>();
+        TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG4, 0);
+        if constexpr (chunk_field_shift != 0)
+        {
+            TTI_SFPSHFT(chunk_field_shift & 0xFFF, p_sfpu::LREG4, p_sfpu::LREG4, 1);
+        }
+        TTI_SFPOR(0, p_sfpu::LREG4, p_sfpu::LREG0, 0);
+
+        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_0, indices_offset);
+    }
+}
+
+// Segment-base variant of the global split (segmented fusion for rows wider
+// than 32 chunks): identical decode, then ORs a runtime segment base into the
+// index word. seg_base = seg * 32 * K is a multiple of 2^(5+log2(K)) while the
+// decoded local index occupies exactly those low bits, so OR == ADD with zero
+// bit overlap. LREG5 is free across the loop (body uses LREG0-4, constants
+// LREG12-14) and is loaded once per call.
+template <std::uint32_t K>
+inline void _topk_xl_separate_indices_row_major_global_base_(std::uint32_t seg_base)
+{
+    static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
+    constexpr int row_scale_factor       = K == 512 ? 1 : K == 1024 ? 2 : 4;
+    constexpr int num_tiles_per_sequence = K == 512 ? 1 : K == 1024 ? 1 : 2;
+    constexpr int indices_offset         = num_tiles_per_sequence * 64;
+    constexpr int chunk_field_shift = K == 2048 ? 0 : K == 1024 ? -1 : -2;
+
+    TT_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_UPPER, (seg_base >> 16) & 0xFFFF);
+    TT_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_LOWER, seg_base & 0xFFFF);
+
+    for (int i = 0; i < row_scale_factor * 16; i++)
+    {
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
+        TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_LOWER, 0);
+
+        TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_UPPER, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG4, 0);
+        _topk_xl_decode_row_major_index_<K>();
+        TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG4, 0);
+        if constexpr (chunk_field_shift != 0)
+        {
+            TTI_SFPSHFT(chunk_field_shift & 0xFFF, p_sfpu::LREG4, p_sfpu::LREG4, 1);
+        }
+        TTI_SFPOR(0, p_sfpu::LREG4, p_sfpu::LREG0, 0);
+        TTI_SFPOR(0, p_sfpu::LREG5, p_sfpu::LREG0, 0);
 
         TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
         TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_0, indices_offset);
@@ -2605,7 +3219,7 @@ inline void _topk_xl_separate_indices_row_major_()
 // issues vs an inline n-iter loop, at zero correctness risk because the
 // body is fully template-static (`group_id` is a template parameter) and
 // the per-call shift amount has already been latched into LREG12.
-template <std::uint32_t K, bool APPROXIMATION_MODE, std::uint32_t group_id>
+template <std::uint32_t K, std::uint32_t group_id>
 inline void _topk_xl_separate_indices_()
 {
     static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");


### PR DESCRIPTION
**Consolidated LLK PR** (restructured per @pavlejosipovic's review direction: LLK changes as their own PR with LLK-level tests, reviewed by the LLK team first; the op-level change (#53457) stacks on this branch).

All Blackhole `topk_xl` LLK deltas of the `topk_large_indices` line, three primitive families in `ckernel_sfpu_topk_xl.h` + the `llk_api` shim + the compute-API header:

1. **Unfused merge/rebuild on SFPLOADMACRO-scheduled compare-exchange** — the InstructionTemplate bodies installed per entry; scheduling notes inline (silicon-validated).
2. **Fused-u16 end-to-end**: `_topk_xl_add_lsb_indices_rt_` (runtime chunk-id stamp into index bits [15:11] via `TT_SFPLOADI`) and the once-per-row global split `_topk_xl_separate_indices_row_major_global_(_init_)` recovering `chunk_id * K + within-chunk` from the fused [bf16|u16] word.
3. **Segmented-fusion support**: `_topk_xl_separate_indices_row_major_global_base_` (runtime 2^(5+log2 K)-aligned segment base OR'd into every decoded index — OR == ADD, disjoint bits). (An earlier draft carried a defensive index-tracking-disable primitive; an adversarial audit proved it unreachable — every fused init resets the whole SFPU LaneConfig via `_init_sfpu_config_reg` — so it was deleted rather than shipped untestable.)

**LLK-level tests** (`tt-llk/tests`, primitives exercised bare through the `topk_xl_test.cpp` harness):
- New `FUSED_E2E` kernel mode: runtime stamp + fused merge/rebuild + global split, `num_chunks` ∈ {2, 4, **32**} — 32 covers the full 5-bit stamp range (ids 0..31), the information-theoretic limit of the fused word.
- Segment-base split at two bases per K; partial `-inf` tail; the index-tracking-disable re-entry pattern; the unfused SFPLOADMACRO macro path (`test_topk_xl_unfused_macro.py`).
- New `planted` stimulus mode: K distinct bf16 highs at seeded positions over constant filler — the only exact-index golden possible past `search_len` 16384 (bf16 has no 2^16 distinct finite positive values; `0x3F80 + 16384` is already `+inf`).

**Test quality was adversarially audited and mutation-tested on silicon**: stamping a wrong chunk id fails 9 cells; dropping the segment base fails all 9 base cells; the checker enforces exact index sets, K-distinctness, range-after-offset, and per-lane index→value pairing. Added from the audit: a denormal-word cell (an FP32-flush regression in the stamp or split annihilates an index and trips the distinct-index assert), a 3×3 segment-base lattice pinning every LREG5 load path and the per-K chunk-field rescale, signed values, two-row re-entry, single-chunk no-merge split, and tails × base.

**Silicon (p150a)**: full `topk_xl` + `topk` LLK family — **118 passed, 10 skipped**.

Consumer context: these primitives carry a measured **1.87–1.98× over main** for `topk_large_indices` from 64k→1M positions (linear in width; table in #53457), including the GLM 5.2 DSA-indexer shape at 5.77→2.93 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/topk-xl-llk-primitives)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/topk-xl-llk-primitives)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/topk-xl-llk-primitives)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/topk-xl-llk-primitives)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/topk-xl-llk-primitives)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/topk-xl-llk-primitives)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/topk-xl-llk-primitives)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/topk-xl-llk-primitives)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/topk-xl-llk-primitives)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/topk-xl-llk-primitives)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/topk-xl-llk-primitives)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/topk-xl-llk-primitives)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/topk-xl-llk-primitives)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/topk-xl-llk-primitives)