### PR TITLE
topk_large_indices: multi-rectangle trees, hybrid row split, fused-u16 end-to-end

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
@@ -88,6 +88,30 @@ def test_topk_large_indices_row_major_bfloat16_uint32_indices(device, k, num_row
     _assert_topk_matches_torch(torch_input, tt_indices, k)
 
 
+def test_topk_large_indices_random_k2048_multichunk_multirow(device):
+    # PR2 triage repro (minimal): row-parallel factory, llk_k=2048, num_chunks=4,
+    # multiple rows, RANDOM input — the exact op-level combo behind the routed
+    # k=2048 cells that failed on silicon. If this passes while the routed
+    # composite fails, the composite's post-op chain (gather at index width
+    # 2048 -> gather's untested RM multi-core variant) is the culprit, not
+    # this op. Tie-safe value-multiset assertions (random bf16 has duplicates).
+    torch.manual_seed(0)
+    rows, n, k = 2, 8192, 2048
+    torch_input = torch.randn(rows, n, dtype=torch.bfloat16)
+
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k)
+    indices = ttnn.to_torch(tt_indices, dtype=torch.uint32).to(torch.int64)
+
+    assert indices.min() >= 0
+    assert indices.max() < n
+    for row_indices in indices:
+        assert row_indices.unique().numel() == k
+
+    actual_values = torch.gather(torch_input.float(), dim=-1, index=indices)
+    ref_values, _ = torch.topk(torch_input.float(), k, dim=-1, largest=True, sorted=True)
+    assert_equal(actual_values.sort(dim=-1).values, ref_values.sort(dim=-1).values)
+
+
 def test_topk_large_indices_random_bfloat16_ties_return_distinct_indices(device):
     torch.manual_seed(0)
     rows = 8
@@ -487,3 +511,786 @@ def test_topk_large_indices_valid_length_out_of_range_raises(device, expect_erro
     torch_input = _make_bf16_exact_input(num_rows=1, n=n)
     with expect_error(RuntimeError, "valid_length"):
         ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k, valid_length=valid_length)
+
+
+# ---------------------------------------------------------------------------
+# Column-parallel (intra-row multi-core) path: single row, many chunks per row.
+# The op splits the row's chunks over a rectangle of local cores and merges the
+# per-slice survivors on one final core. Selected automatically when num_rows
+# is 1 and the row is wide enough that the split beats a single core.
+# ---------------------------------------------------------------------------
+
+
+def _make_distinct_block_input(n: int, k: int, block_start: int, background: float = 0.0) -> torch.Tensor:
+    """One row of `background` with k strictly-increasing bf16-exact values at [block_start, block_start+k)."""
+    values = torch.full((1, n), background, dtype=torch.bfloat16)
+    hi16 = (0x3F80 + np.arange(k, dtype=np.uint32)).astype(np.uint32)
+    block = torch.from_numpy((hi16 << 16).view(np.float32).copy()).to(torch.bfloat16)
+    values[:, block_start : block_start + k] = block
+    return values
+
+
+@pytest.mark.parametrize(
+    "k,n",
+    [
+        (512, 32768),  # 64 chunks
+        (512, 65536),  # 128 chunks
+        (1024, 32768),  # 32 chunks
+        (1024, 65536),  # 64 chunks
+        (2048, 65536),  # 32 chunks over ~8 slices -> >=4 chained chunk merges per local core
+        (2048, 102400),  # 50 chunks: uneven chunk split across slices
+        (1536, 65536),  # k below the LLK window (2048): output narrower than the merge sequence
+        (2048, 65537),  # 33 chunks with a 1-element tail chunk on the last slice
+    ],
+)
+def test_topk_large_indices_column_parallel_single_row(device, k, n):
+    torch_input = _make_large_index_input(num_rows=1, n=n, k=k)
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k)
+
+    _assert_topk_matches_torch(torch_input, tt_indices, k)
+
+
+def test_topk_large_indices_column_parallel_top_values_straddle_slice_boundary(device):
+    # W=65536 with k=2048 splits into 8 slices of 8192 columns. Center the
+    # winning block on a slice boundary so both neighbors contribute half of
+    # the final top-k and the cross-slice merge ordering is exercised.
+    n, k = 65536, 2048
+    boundary = 4 * 8192
+    torch_input = _make_distinct_block_input(n, k, block_start=boundary - k // 2)
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k)
+
+    _assert_topk_matches_torch(torch_input, tt_indices, k)
+
+
+def test_topk_large_indices_column_parallel_random_ties_return_distinct_indices(device):
+    # Random bf16 over 64K columns is guaranteed to contain duplicate values,
+    # including ties that straddle slice boundaries. Tie order between slices
+    # is unspecified, so check the selected value multiset and index validity
+    # instead of exact index equality.
+    torch.manual_seed(0)
+    n, k = 65536, 2048
+    torch_input = torch.randn(1, n, dtype=torch.bfloat16)
+
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k)
+    indices = ttnn.to_torch(tt_indices, dtype=torch.uint32).to(torch.int64)[0]
+
+    assert indices.min() >= 0
+    assert indices.max() < n
+    assert indices.unique().numel() == k
+
+    actual_values = torch_input.float()[0][indices]
+    ref_values, _ = torch.topk(torch_input.float()[0], k, largest=True, sorted=True)
+    assert_equal(actual_values.sort().values, ref_values.sort().values)
+
+
+def test_topk_large_indices_column_parallel_all_equal_row(device):
+    # Every element ties. Any k distinct indices are a correct answer; the
+    # merge tree must not lose or duplicate lanes across slices.
+    n, k = 65536, 2048
+    torch_input = torch.ones(1, n, dtype=torch.bfloat16)
+
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k)
+    indices = ttnn.to_torch(tt_indices, dtype=torch.uint32).to(torch.int64)[0]
+
+    assert indices.min() >= 0
+    assert indices.max() < n
+    assert indices.unique().numel() == k
+
+
+@pytest.mark.parametrize("k", [512, 1024, 2048])
+def test_topk_large_indices_column_parallel_all_neginf_is_sentinel(device, k):
+    # All lanes are -inf in every slice, so every gathered sequence is the
+    # degenerate all--inf run and the final core must emit only sentinels.
+    sentinel = 0xFFFFFFFF
+    n = 32 * k
+    torch_input = torch.full((1, n), -float("inf"), dtype=torch.bfloat16)
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k)
+
+    _assert_indices(tt_indices, torch.full((1, k), sentinel, dtype=torch.int64), [1, k])
+
+
+@pytest.mark.parametrize(
+    "valid_length,block_start",
+    [
+        (2048, 0),  # only slice 0 active (single chunk); slices 1..P-1 empty -> writer -inf fill
+        (8192, 8192 - 2048),  # slice 0 fully active, the rest empty
+        (20000, 17952),  # partial tail chunk mid-slice; trailing slices empty
+        (65536, 65536 - 2048),  # full width: no empty slices
+    ],
+)
+def test_topk_large_indices_column_parallel_valid_length(device, valid_length, block_start):
+    # The winning block sits inside the valid prefix; the stale tail holds
+    # LARGER finite decoys that must never be selected. Empty slices (fully
+    # beyond valid_length) contribute writer-fabricated -inf sequences.
+    n, k = 65536, 2048
+    torch_input = _make_distinct_block_input(n, k, block_start=block_start)
+    if valid_length < n:
+        torch_input[:, valid_length:] = 100.0
+
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k, valid_length=valid_length)
+
+    _, ref_indices = torch.topk(torch_input[:, :valid_length].float(), k, dim=-1, largest=True, sorted=True)
+    assert int(ref_indices.max()) < valid_length
+    _assert_indices(tt_indices, ref_indices, [1, k])
+
+
+def test_topk_large_indices_column_parallel_short_valid_length_emits_sentinels(device):
+    # valid_length < k: the real indices come from the short prefix and the
+    # remaining output lanes must be sentinels, with every slice past the
+    # prefix contributing an empty (writer-filled) sequence.
+    n, k = 65536, 2048
+    valid_length = 496
+    torch_input = _make_bf16_exact_input(num_rows=1, n=2048)
+    torch_input = torch.nn.functional.pad(torch_input.float(), (0, n - 2048), value=100.0).to(torch.bfloat16)
+
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k, valid_length=valid_length)
+
+    _, valid_indices = torch.topk(
+        torch_input[:, :valid_length].float(), valid_length, dim=-1, largest=True, sorted=True
+    )
+    expected = torch.cat(
+        [valid_indices, torch.full((1, k - valid_length), 0xFFFFFFFF, dtype=torch.int64)],
+        dim=-1,
+    )
+    _assert_indices(tt_indices, expected, [1, k])
+
+
+def test_topk_large_indices_column_parallel_valid_length_cache_reuse(device):
+    # The column split is derived from the PHYSICAL width only, so a serving
+    # loop growing valid_length must reuse one cached column-parallel program
+    # (empty slices shrink to active ones purely through runtime args).
+    #
+    # Every 8192-wide region carries its own strictly-increasing distinct
+    # k-block at its start, with each block's values above the previous
+    # block's. There are no ties anywhere (tie order vs torch is unspecified,
+    # so an all-zeros prefix cannot be exact-asserted), and each growth step
+    # has a DIFFERENT exact answer — the newest fully-visible block — so a
+    # stale valid_length-derived runtime arg on a cache hit cannot pass.
+    n, k = 65536, 2048
+    num_blocks = 8
+    region_width = n // num_blocks
+    torch_input = torch.zeros(1, n, dtype=torch.bfloat16)
+    for i in range(num_blocks):
+        hi16 = (0x3F80 + i * k + np.arange(k, dtype=np.uint32)).astype(np.uint32)
+        block = torch.from_numpy((hi16 << 16).view(np.float32).copy()).to(torch.bfloat16)
+        torch_input[:, i * region_width : i * region_width + k] = block
+    tt_input = _to_device(torch_input, device)
+
+    device.enable_program_cache()
+    device.clear_program_cache()
+    try:
+        entries = []
+        # valid_length -> index of the largest fully-visible block:
+        # 2048 sees only block 0; 20480 reaches block 2 ([16384, 18432));
+        # 40960 reaches block 4 ([32768, 34816)); full width reaches block 7.
+        for valid_length, top_block in ((2048, 0), (20480, 2), (40960, 4), (n, 7)):
+            tt_indices = ttnn.experimental.topk_large_indices(tt_input, k=k, valid_length=valid_length)
+            entries.append(device.num_program_cache_entries())
+            block_start = top_block * region_width
+            expected = torch.arange(block_start + k - 1, block_start - 1, -1, dtype=torch.int64).unsqueeze(0)
+            _assert_indices(tt_indices, expected, [1, k])
+        assert entries[0] > 0
+        assert max(entries) == min(entries)  # no recompile as valid_length grew
+    finally:
+        device.disable_and_clear_program_cache()
+
+
+def test_topk_large_indices_column_and_row_parallel_programs_coexist_in_cache(device):
+    # A single-row wide input takes the column-parallel factory while a
+    # multi-row input of the same width keeps the row-parallel one; the two
+    # must hash to distinct cache entries and both must stay correct.
+    n, k = 65536, 2048
+    single_row = _make_large_index_input(num_rows=1, n=n, k=k)
+    multi_row = _make_large_index_input(num_rows=2, n=n, k=k)
+
+    device.enable_program_cache()
+    device.clear_program_cache()
+    try:
+        tt_single = ttnn.experimental.topk_large_indices(_to_device(single_row, device), k=k)
+        entries_after_single = device.num_program_cache_entries()
+        tt_multi = ttnn.experimental.topk_large_indices(_to_device(multi_row, device), k=k)
+        entries_after_multi = device.num_program_cache_entries()
+
+        assert entries_after_single > 0
+        assert entries_after_multi == entries_after_single + 1
+
+        _assert_topk_matches_torch(single_row, tt_single, k)
+        _assert_topk_matches_torch(multi_row, tt_multi, k)
+    finally:
+        device.disable_and_clear_program_cache()
+
+
+# ---------------------------------------------------------------------------
+# return_values=True: the op also emits the top-k VALUES (ROW_MAJOR BFLOAT16,
+# sorted descending to match the indices; exact bf16 -inf on sentinel lanes).
+# Default (return_values=False) is unchanged: a single indices tensor from the
+# byte-identical indices-only program.
+# ---------------------------------------------------------------------------
+
+
+def _run_return_values_case(device, torch_input, k, valid_length=None):
+    values, indices = ttnn.experimental.topk_large_indices(
+        _to_device(torch_input, device), k=k, valid_length=valid_length, return_values=True
+    )
+
+    expected_shape = [torch_input.shape[0], k]
+    assert values.dtype == ttnn.bfloat16
+    assert values.layout == ttnn.ROW_MAJOR_LAYOUT
+    assert list(values.shape) == expected_shape
+    _assert_index_metadata(indices, expected_shape)
+
+    torch_values = ttnn.to_torch(values)
+    torch_indices = ttnn.to_torch(indices, dtype=torch.uint32).to(torch.int64)
+
+    search = torch_input if valid_length is None else torch_input[:, :valid_length]
+    # A prefix shorter than k is legal: only min(k, prefix) lanes are finite,
+    # the rest must be exact -inf (asserted below with the sentinel lanes).
+    n_finite = min(k, search.shape[-1])
+    ref_values, _ = torch.topk(search.float(), n_finite, dim=-1, largest=True, sorted=True)
+    # Values: exact, order included — both sides sorted descending, so this
+    # holds even under ties (tie index order is unspecified, value order isn't).
+    assert_equal(torch_values.float()[:, :n_finite], ref_values)
+    if n_finite < k:
+        assert (torch_values.float()[:, n_finite:] == -float("inf")).all()
+
+    # Index/value consistency on non-sentinel lanes: input[index] == value.
+    sentinel_mask = torch_indices == 0xFFFFFFFF
+    safe_indices = torch.where(sentinel_mask, torch.zeros_like(torch_indices), torch_indices)
+    gathered = torch.gather(torch_input, dim=-1, index=safe_indices)
+    assert_equal(
+        torch.where(sentinel_mask, torch_values, gathered),
+        torch.where(sentinel_mask, torch_values, torch_values),
+    )
+    # Sentinel lanes must carry exact bf16 -inf values.
+    assert torch.isneginf(torch_values.float()[sentinel_mask]).all()
+    return torch_values, torch_indices
+
+
+@pytest.mark.parametrize(
+    "k,num_rows,n",
+    [
+        (256, 2, 2048),  # llk 512, k < window (row-parallel, contiguous writer path)
+        (512, 2, 4096),  # llk 512 exact (row-parallel)
+        (1024, 2, 8192),  # llk 1024 (row-parallel, reordered writer path)
+        (2048, 2, 8192),  # llk 2048, 2 value tiles per sequence (row-parallel)
+        (1536, 3, 51200),  # k below the llk window at production-like width (row-parallel)
+    ],
+)
+def test_topk_large_indices_return_values_row_parallel(device, k, num_rows, n):
+    torch.manual_seed(0)
+    torch_input = torch.randn(num_rows, n, dtype=torch.bfloat16)
+    _run_return_values_case(device, torch_input, k)
+
+
+@pytest.mark.parametrize("k", [512, 2048])
+def test_topk_large_indices_return_values_column_parallel(device, k):
+    # Single wide row engages the column-parallel factory (final-core
+    # materialization emits the values).
+    torch.manual_seed(0)
+    torch_input = torch.randn(1, 65536, dtype=torch.bfloat16)
+    _run_return_values_case(device, torch_input, k)
+
+
+@pytest.mark.parametrize("num_rows,n", [(2, 4096), (1, 65536)])  # row-parallel / column-parallel
+def test_topk_large_indices_return_values_neginf_lanes(device, num_rows, n):
+    # 16 finite values, the rest -inf: values must be the finite prefix
+    # descending then exact bf16 -inf; -inf lanes carry the sentinel index.
+    k, finite_count = 512, 16
+    torch_input = torch.full((num_rows, n), -float("inf"), dtype=torch.bfloat16)
+    torch_input[:, :finite_count] = torch.arange(finite_count, dtype=torch.float32).to(torch.bfloat16)
+
+    torch_values, torch_indices = _run_return_values_case(device, torch_input, k)
+
+    assert torch.isneginf(torch_values.float()[:, finite_count:]).all()
+    assert (torch_indices[:, finite_count:] == 0xFFFFFFFF).all()
+    expected_prefix = torch.arange(finite_count - 1, -1, -1, dtype=torch.int64).unsqueeze(0).repeat(num_rows, 1)
+    assert_equal(torch_indices[:, :finite_count], expected_prefix)
+
+
+@pytest.mark.parametrize("valid_length", [600, 300])
+def test_topk_large_indices_return_values_valid_length(device, valid_length):
+    # Bounded search: all winners must come from the prefix even though the
+    # stale tail holds larger finite decoys. valid_length < k is supported by
+    # design: lanes past the prefix's capacity emit -inf values + sentinel
+    # indices (the docstring's "[k, last dimension]" domain is stale — the
+    # short-prefix sentinel behavior is covered by the indices-only suite too).
+    num_rows, n, k = 2, 8192, 512
+    torch_input = torch.zeros(num_rows, n, dtype=torch.bfloat16)
+    torch_input[:, :valid_length] = torch.randn(num_rows, valid_length).to(torch.bfloat16)
+    torch_input[:, valid_length:] = 100.0  # stale tail decoys, must never appear
+
+    torch_values, torch_indices = _run_return_values_case(device, torch_input, k, valid_length=valid_length)
+    finite = torch_indices != 0xFFFFFFFF
+    assert (torch_values.float()[finite] < 100.0).all()
+    assert torch_indices[finite].max() < valid_length
+
+    n_finite = min(k, valid_length)
+    # Finite lanes must be exactly the prefix's top-n_finite values.
+    ref_values, _ = torch.topk(torch_input[:, :valid_length].float(), n_finite, dim=-1, largest=True, sorted=True)
+    got_finite = torch_values.float()[:, :n_finite]
+    assert_equal(ref_values.sort(dim=-1).values, got_finite.sort(dim=-1).values)
+    # Lanes past the prefix capacity are sentinel index + -inf value.
+    if n_finite < k:
+        assert (torch_indices[:, n_finite:] == 0xFFFFFFFF).all()
+        assert (torch_values.float()[:, n_finite:] == -float("inf")).all()
+
+
+def test_topk_large_indices_default_stays_indices_only(device):
+    # Backward compatibility: without return_values the result is a single
+    # indices tensor (not a tuple/list).
+    torch_input = _make_bf16_exact_input(num_rows=2, n=1024)
+    result = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=512)
+    assert isinstance(result, ttnn.Tensor)
+    _assert_topk_matches_torch(torch_input, result, 512)
+
+
+def test_topk_large_indices_return_values_program_cache(device):
+    # return_values is in the program hash: flipping it compiles a second
+    # program; repeating either flavor reuses its cache entry.
+    torch.manual_seed(0)
+    num_rows, n, k = 2, 8192, 1024
+    torch_input = torch.randn(num_rows, n, dtype=torch.bfloat16)
+    tt_input = _to_device(torch_input, device)
+
+    device.enable_program_cache()
+    device.clear_program_cache()
+    try:
+        ttnn.experimental.topk_large_indices(tt_input, k=k)
+        entries_indices_only = device.num_program_cache_entries()
+        values, indices = ttnn.experimental.topk_large_indices(tt_input, k=k, return_values=True)
+        entries_with_values = device.num_program_cache_entries()
+        assert entries_indices_only > 0
+        assert entries_with_values == entries_indices_only + 1
+
+        # Cache hits for both flavors: no growth, results still correct.
+        result2 = ttnn.experimental.topk_large_indices(tt_input, k=k)
+        values2, indices2 = ttnn.experimental.topk_large_indices(tt_input, k=k, return_values=True)
+        assert device.num_program_cache_entries() == entries_with_values
+
+        ref_values, _ = torch.topk(torch_input.float(), k, dim=-1, largest=True, sorted=True)
+        assert_equal(ttnn.to_torch(values).float(), ref_values)
+        assert_equal(ttnn.to_torch(values2).float(), ref_values)
+        assert_equal(
+            ttnn.to_torch(indices, dtype=torch.uint32).to(torch.int64),
+            ttnn.to_torch(indices2, dtype=torch.uint32).to(torch.int64),
+        )
+        _assert_index_metadata(result2, [num_rows, k])
+    finally:
+        device.disable_and_clear_program_cache()
+
+
+# ---------------------------------------------------------------------------
+# num_slices: user override of the column-parallel slice count P. Only valid
+# when the column-parallel path is selected; loud errors otherwise; hashed
+# (distinct P -> distinct cached program).
+# ---------------------------------------------------------------------------
+
+
+def test_topk_large_indices_num_slices_override_correctness(device):
+    # Force P=8 at the canonical column-parallel shape (a 3-level tree; the
+    # tree cost model would pick 32 -- the point here is the OVERRIDE plumbing
+    # produces a correct program; distinct-P correctness is covered by the
+    # cache test below). Random input => tie-safe value-multiset assertions.
+    torch.manual_seed(0)
+    n, k = 65536, 2048
+    torch_input = torch.randn(1, n, dtype=torch.bfloat16)
+
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k, num_slices=8)
+    indices = ttnn.to_torch(tt_indices, dtype=torch.uint32).to(torch.int64)[0]
+
+    assert indices.min() >= 0
+    assert indices.max() < n
+    assert indices.unique().numel() == k
+
+    actual_values = torch_input.float()[0][indices]
+    ref_values, _ = torch.topk(torch_input.float()[0], k, largest=True, sorted=True)
+    assert_equal(actual_values.sort().values, ref_values.sort().values)
+
+
+@pytest.mark.parametrize("num_slices", [4, 16])
+def test_topk_large_indices_num_slices_non_model_values(device, num_slices):
+    # P values the cost model would NOT pick (the tree model picks the chunk
+    # count, 32, here): exercises uneven chunk splits end to end.
+    torch.manual_seed(1)
+    n, k = 65536, 2048
+    torch_input = torch.randn(1, n, dtype=torch.bfloat16)
+
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k, num_slices=num_slices)
+    indices = ttnn.to_torch(tt_indices, dtype=torch.uint32).to(torch.int64)[0]
+
+    assert indices.unique().numel() == k
+    actual_values = torch_input.float()[0][indices]
+    ref_values, _ = torch.topk(torch_input.float()[0], k, largest=True, sorted=True)
+    assert_equal(actual_values.sort().values, ref_values.sort().values)
+
+
+def test_topk_large_indices_num_slices_rejected_on_row_parallel(device, expect_error):
+    # Multi-row shapes take the row-parallel factory where num_slices has no
+    # meaning: explicit beats ignored.
+    torch_input = _make_bf16_exact_input(num_rows=2, n=4096)
+    with expect_error(RuntimeError, "num_slices"):
+        ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=512, num_slices=4)
+
+
+@pytest.mark.parametrize(
+    "num_slices,match",
+    [
+        (1, "num_slices must be in"),  # below [2, 128]
+        (129, "num_slices must be in"),  # above [2, 128]
+        (48, "exceeds the row's chunk count"),  # > num_chunks (65536/2048 = 32 chunks)
+    ],
+)
+def test_topk_large_indices_num_slices_out_of_range_rejected(device, expect_error, num_slices, match):
+    torch_input = torch.randn(1, 65536, dtype=torch.bfloat16)
+    with expect_error(RuntimeError, match):
+        ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=2048, num_slices=num_slices)
+
+
+def test_topk_large_indices_num_slices_program_cache_distinct_entries(device):
+    # num_slices is in the program hash: distinct P values compile distinct
+    # programs; repeating a P reuses its entry.
+    torch.manual_seed(0)
+    n, k = 65536, 2048
+    torch_input = torch.randn(1, n, dtype=torch.bfloat16)
+    tt_input = _to_device(torch_input, device)
+    ref_values, _ = torch.topk(torch_input.float()[0], k, largest=True, sorted=True)
+
+    device.enable_program_cache()
+    device.clear_program_cache()
+    try:
+        entries = []
+        for num_slices in (4, 8, 16, 8):  # trailing 8 must be a cache hit
+            tt_indices = ttnn.experimental.topk_large_indices(tt_input, k=k, num_slices=num_slices)
+            entries.append(device.num_program_cache_entries())
+            indices = ttnn.to_torch(tt_indices, dtype=torch.uint32).to(torch.int64)[0]
+            assert indices.unique().numel() == k
+            assert_equal(torch_input.float()[0][indices].sort().values, ref_values.sort().values)
+        assert entries[0] > 0
+        assert entries[1] == entries[0] + 1
+        assert entries[2] == entries[1] + 1
+        assert entries[3] == entries[2]  # P=8 rerun: cache hit, no growth
+    finally:
+        device.disable_and_clear_program_cache()
+
+
+# ---------------------------------------------------------------------------
+# Column-parallel MERGE TREE (in-place log2(P) reduction on the slice
+# rectangle; slice 0 is the root). These parametrize P via num_slices so the
+# tree shape is explicit; the model default path is exercised by all earlier
+# column_parallel tests.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("num_slices", [4, 8, 16, 32])
+@pytest.mark.parametrize("k", [512, 2048])
+def test_topk_large_indices_tree_random_ties(device, num_slices, k):
+    # Random bf16 has duplicate values, including ties that straddle slice and
+    # tree-level boundaries; tie order is unspecified, so assert the selected
+    # value multiset + index validity. n chosen so every P has >= 1 chunk per
+    # slice for both LLK windows (k=512 -> 64 chunks, k=2048 -> 32 chunks).
+    torch.manual_seed(0)
+    n = 65536
+    torch_input = torch.randn(1, n, dtype=torch.bfloat16)
+
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k, num_slices=num_slices)
+    indices = ttnn.to_torch(tt_indices, dtype=torch.uint32).to(torch.int64)[0]
+
+    assert indices.min() >= 0
+    assert indices.max() < n
+    assert indices.unique().numel() == k
+
+    actual_values = torch_input.float()[0][indices]
+    ref_values, _ = torch.topk(torch_input.float()[0], k, largest=True, sorted=True)
+    assert_equal(actual_values.sort().values, ref_values.sort().values)
+
+
+def test_topk_large_indices_tree_multilevel_adversarial_placement(device):
+    # 3-level tree (P=8, slice width 8192). The winning block is split across
+    # slices that meet only AT THE ROOT and traverse different tree depths:
+    #   slice 5 (upper half of the top-k): 5 -> 4 (level 0), 4 -> 0 (level 2)
+    #   slice 3 (lower half):              3 -> 2 (level 0), 2 -> 0 (level 1)
+    # A mis-ordered intermediate survivor (the num_chunks=4 lesson, applied at
+    # tree levels) only shows when its consumer merges it — the root sees both
+    # halves through 2-deep chains. Values are globally distinct, so the final
+    # rank order is asserted EXACTLY against torch.
+    n, k = 65536, 2048
+    region = 8192
+    half = k // 2
+    torch_input = torch.zeros(1, n, dtype=torch.bfloat16)
+
+    def block(count, base):
+        hi16 = (0x3F80 + base + np.arange(count, dtype=np.uint32)).astype(np.uint32)
+        return torch.from_numpy((hi16 << 16).view(np.float32).copy()).to(torch.bfloat16)
+
+    # Lower half of the winners in slice 3, upper half in slice 5 (all values
+    # distinct and above the zero background).
+    torch_input[0, 3 * region : 3 * region + half] = block(half, 0)
+    torch_input[0, 5 * region : 5 * region + half] = block(half, half)
+
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k, num_slices=8)
+
+    _, ref_indices = torch.topk(torch_input.float(), k, dim=-1, largest=True, sorted=True)
+    _assert_indices(tt_indices, ref_indices, [1, k])
+
+
+def test_topk_large_indices_tree_valid_length_empty_winners(device):
+    # P=16 over 32 chunks (slice width 4096); valid_length=5000 leaves slice 0
+    # full, slice 1 partial, slices 2..15 empty. Empty WINNERS (2, 4, 8, ...)
+    # must adopt their first incoming survivor instead of merging into an
+    # empty DST; empty pure losers ship the writer's -inf scratch. Winning
+    # block sits inside the prefix, decoys beyond it.
+    n, k = 65536, 2048
+    valid_length = 5000
+    torch_input = _make_distinct_block_input(n, k, block_start=valid_length - k)
+    torch_input[:, valid_length:] = 100.0  # stale decoys, must never be selected
+
+    tt_indices = ttnn.experimental.topk_large_indices(
+        _to_device(torch_input, device), k=k, valid_length=valid_length, num_slices=16
+    )
+
+    _, ref_indices = torch.topk(torch_input[:, :valid_length].float(), k, dim=-1, largest=True, sorted=True)
+    assert int(ref_indices.max()) < valid_length
+    _assert_indices(tt_indices, ref_indices, [1, k])
+
+
+@pytest.mark.parametrize("num_slices", [8, 32])
+def test_topk_large_indices_tree_return_values(device, num_slices):
+    # Values ride the tree with the indices (every shipped survivor carries
+    # both regions); the root's with-values materialization must emit the
+    # exact torch value order.
+    torch.manual_seed(2)
+    n, k = 65536, 2048
+    torch_input = torch.randn(1, n, dtype=torch.bfloat16)
+
+    values, indices = ttnn.experimental.topk_large_indices(
+        _to_device(torch_input, device), k=k, return_values=True, num_slices=num_slices
+    )
+
+    torch_values = ttnn.to_torch(values)
+    torch_indices = ttnn.to_torch(indices, dtype=torch.uint32).to(torch.int64)
+    ref_values, _ = torch.topk(torch_input.float(), k, dim=-1, largest=True, sorted=True)
+
+    assert_equal(torch_values.float(), ref_values)  # both sorted descending: exact even under ties
+    gathered = torch.gather(torch_input, dim=-1, index=torch_indices)
+    assert_equal(gathered, torch_values)
+    assert torch_indices[0].unique().numel() == k
+
+
+# ---------------------------------------------------------------------------
+# FLEX formats (opt-ins): tile_output=True, index_dtype=uint16, and TILE-layout
+# input. The compute kernels are byte-shared with the default program — only
+# the reader/writer sources change — so the strongest assertion is BIT-IDENTITY
+# of the logical outputs against the default ROW_MAJOR/UINT32 call on the same
+# input (tie order included: same compute, same input, same result).
+# ---------------------------------------------------------------------------
+
+
+def _run_flex_vs_default(
+    device,
+    torch_input,
+    k,
+    *,
+    tile_input=False,
+    tile_output=False,
+    index_dtype=None,
+    valid_length=None,
+    num_slices=None,
+):
+    tt_in_default = _to_device(torch_input, device)
+    ref_values, ref_indices = ttnn.experimental.topk_large_indices(
+        tt_in_default, k=k, valid_length=valid_length, return_values=True, num_slices=num_slices
+    )
+    ref_values_t = ttnn.to_torch(ref_values).float()
+    ref_indices_t = ttnn.to_torch(ref_indices, dtype=torch.uint32).to(torch.int64)
+
+    in_layout = ttnn.TILE_LAYOUT if tile_input else ttnn.ROW_MAJOR_LAYOUT
+    tt_in_flex = ttnn.from_torch(torch_input, dtype=ttnn.bfloat16, layout=in_layout, device=device)
+    values, indices = ttnn.experimental.topk_large_indices(
+        tt_in_flex,
+        k=k,
+        valid_length=valid_length,
+        return_values=True,
+        num_slices=num_slices,
+        tile_output=tile_output,
+        index_dtype=index_dtype,
+    )
+
+    expected_shape = list(torch_input.shape)
+    expected_shape[-1] = k
+    expected_layout = ttnn.TILE_LAYOUT if tile_output else ttnn.ROW_MAJOR_LAYOUT
+    assert values.layout == expected_layout
+    assert indices.layout == expected_layout
+    assert values.dtype == ttnn.bfloat16
+    assert indices.dtype == (index_dtype or ttnn.uint32)
+    assert list(values.shape) == expected_shape
+    assert list(indices.shape) == expected_shape
+
+    got_values = ttnn.to_torch(values).float()
+    if index_dtype == ttnn.uint16:
+        got_indices = ttnn.to_torch(indices, dtype=torch.int32).to(torch.int64) & 0xFFFF
+        expected_indices = ref_indices_t & 0xFFFF  # sentinel 0xFFFFFFFF truncates to 0xFFFF
+    else:
+        got_indices = ttnn.to_torch(indices, dtype=torch.uint32).to(torch.int64)
+        expected_indices = ref_indices_t
+
+    assert_equal(got_values, ref_values_t)
+    assert_equal(got_indices, expected_indices)
+    return got_values, got_indices
+
+
+@pytest.mark.parametrize(
+    "k,num_rows,n",
+    [
+        (32, 32, 4096),  # llk 512, exact 32-row tile fill (no padding rows)
+        (512, 2, 4096),  # llk 512, row-parallel, 30 padding rows
+        (1024, 3, 8192),  # llk 1024 (reordered CB slices), 29 padding rows
+        (2048, 2, 8192),  # llk 2048, 2 sequence tiles
+        (512, 33, 2048),  # rows straddle a tile-row boundary (2 tile rows, 31 pad rows)
+        (512, 1, 65536),  # column-parallel tree root emission
+        (2048, 1, 65536),  # column-parallel, widest window
+    ],
+)
+def test_topk_large_indices_tile_output_matches_default(device, k, num_rows, n):
+    torch.manual_seed(0)
+    torch_input = torch.randn(num_rows, n, dtype=torch.bfloat16)
+    _run_flex_vs_default(device, torch_input, k, tile_output=True)
+
+
+def test_topk_large_indices_tile_output_rank3_slab_padding(device):
+    # TILE padding is per 2D slab: [2, 3, n] pads each [3, k] slab to [32, k]
+    # independently; the slab-aware writer addressing (slice_idx/in_slice_row)
+    # and per-slab padding fill must not touch neighboring slabs' data rows.
+    torch.manual_seed(1)
+    torch_input = torch.randn(2, 3, 4096, dtype=torch.bfloat16)
+    _run_flex_vs_default(device, torch_input, 512, tile_output=True)
+
+
+@pytest.mark.parametrize(
+    "k,num_rows,n",
+    [
+        (512, 1, 65536),  # column-parallel: the routed single-row shape (face row 0)
+        (2048, 1, 65536),
+        (512, 1, 2048),  # single chunk-count row-parallel single core
+        (512, 3, 5000),  # odd face rows (delta=32 read staging) + non-tile-multiple width
+        (512, 2, 4096),
+        (2048, 33, 8192),  # rows straddle input tile rows, incl. bottom faces
+        (32, 32, 37984),  # sampling-like: k=32, 32 users, non-pow2 width
+    ],
+)
+def test_topk_large_indices_tile_input_matches_default(device, k, num_rows, n):
+    torch.manual_seed(2)
+    torch_input = torch.randn(num_rows, n, dtype=torch.bfloat16)
+    _run_flex_vs_default(device, torch_input, k, tile_input=True)
+
+
+def test_topk_large_indices_tile_input_last_chunk_winners(device):
+    # Every winner sits at the row's END: the tail chunk's final (partial)
+    # slice reads tile-padding garbage columns that the compute must mask by
+    # the logical width. Ascending winners = exact rank-order reference.
+    num_rows, n, k = 2, 4095, 512
+    torch_input = _make_large_index_input(num_rows, n, k)
+    _run_flex_vs_default(device, torch_input, k, tile_input=True)
+
+
+def test_topk_large_indices_tile_input_all_equal_ties(device):
+    # All-equal rows: every lane ties; indices must still be k distinct valid
+    # positions and bit-identical to the default path's tie resolution.
+    torch_input = torch.ones(3, 8192, dtype=torch.bfloat16)
+    _, got_indices = _run_flex_vs_default(device, torch_input, 512, tile_input=True, tile_output=True)
+    for row in got_indices:
+        assert row.unique().numel() == 512
+        assert row.max() < 8192
+
+
+@pytest.mark.parametrize("num_rows,n", [(2, 4096), (1, 65024)])  # row-parallel / column-parallel (n <= 65535)
+def test_topk_large_indices_uint16_matches_default(device, num_rows, n):
+    torch.manual_seed(3)
+    torch_input = torch.randn(num_rows, n, dtype=torch.bfloat16)
+    _run_flex_vs_default(device, torch_input, 512, index_dtype=ttnn.uint16)
+
+
+@pytest.mark.parametrize("tile_output", [False, True])
+def test_topk_large_indices_uint16_neginf_sentinel(device, tile_output):
+    # -inf lanes carry the 0xFFFF sentinel under the UINT16 contract (the
+    # exact value a UINT32 -> UINT16 typecast of 0xFFFFFFFF produces).
+    num_rows, n, k, finite_count = 2, 4096, 512, 16
+    torch_input = torch.full((num_rows, n), -float("inf"), dtype=torch.bfloat16)
+    torch_input[:, :finite_count] = torch.arange(finite_count, dtype=torch.float32).to(torch.bfloat16)
+
+    got_values, got_indices = _run_flex_vs_default(
+        device, torch_input, k, tile_output=tile_output, index_dtype=ttnn.uint16
+    )
+    assert (got_indices[:, finite_count:] == 0xFFFF).all()
+    assert torch.isneginf(got_values.float()[:, finite_count:]).all()
+
+
+def test_topk_large_indices_flex_route_combo(device):
+    # The exact combination the ttnn.topk composite routes through: TILE input
+    # (single row, no untilize), TILE output, UINT16 indices.
+    torch.manual_seed(4)
+    torch_input = torch.randn(1, 65024, dtype=torch.bfloat16)  # <= 65535 => u16-eligible
+    _run_flex_vs_default(device, torch_input, 2048, tile_input=True, tile_output=True, index_dtype=ttnn.uint16)
+
+
+def test_topk_large_indices_flex_multirow_combo(device):
+    # Sampling-shaped combo: 32 users, k=32, u16 + TILE both ways.
+    torch.manual_seed(5)
+    torch_input = torch.randn(32, 37984, dtype=torch.bfloat16)
+    _run_flex_vs_default(device, torch_input, 32, tile_input=True, tile_output=True, index_dtype=ttnn.uint16)
+
+
+def test_topk_large_indices_tile_input_valid_length(device):
+    # Bounded search on a TILE input: the stale tail (larger decoys) must
+    # never be read or ranked.
+    torch.manual_seed(6)
+    num_rows, n, k, valid_length = 2, 8192, 512, 600
+    torch_input = torch.zeros(num_rows, n, dtype=torch.bfloat16)
+    torch_input[:, :valid_length] = torch.randn(num_rows, valid_length).to(torch.bfloat16)
+    torch_input[:, valid_length:] = 100.0
+    got_values, got_indices = _run_flex_vs_default(device, torch_input, k, tile_input=True, valid_length=valid_length)
+    finite = got_indices != 0xFFFFFFFF
+    assert (got_values.float()[finite] < 100.0).all()
+    assert got_indices[finite].max() < valid_length
+
+
+def test_topk_large_indices_uint16_width_too_large_rejected(device, expect_error):
+    torch_input = torch.randn(1, 66560, dtype=torch.bfloat16)
+    with expect_error(RuntimeError, "index_dtype=UINT16 requires"):
+        ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=512, index_dtype=ttnn.uint16)
+
+
+def test_topk_large_indices_tile_output_k_not_multiple_of_32_rejected(device, expect_error):
+    torch_input = torch.randn(2, 4096, dtype=torch.bfloat16)
+    with expect_error(RuntimeError, "tile_output requires k"):
+        ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=48, tile_output=True)
+
+
+def test_topk_large_indices_flex_program_cache(device):
+    # tile_output / index_dtype / input layout are all program-hash inputs:
+    # each flip compiles a new program; repeats are cache hits.
+    torch.manual_seed(7)
+    num_rows, n, k = 2, 8192, 512
+    torch_input = torch.randn(num_rows, n, dtype=torch.bfloat16)
+    ref_values, _ = torch.topk(torch_input.float(), k, dim=-1, largest=True, sorted=True)
+
+    device.enable_program_cache()
+    device.clear_program_cache()
+    try:
+        entries = []
+        configs = [
+            dict(),
+            dict(tile_output=True),
+            dict(tile_output=True, index_dtype=ttnn.uint16),
+            dict(tile_input=True, tile_output=True, index_dtype=ttnn.uint16),
+            dict(tile_output=True),  # repeat: cache hit
+        ]
+        for cfg in configs:
+            got_values, _ = _run_flex_vs_default(device, torch_input, k, **cfg)
+            assert_equal(got_values, ref_values)
+            entries.append(device.num_program_cache_entries())
+        assert entries[1] > entries[0]
+        assert entries[2] > entries[1]
+        assert entries[3] > entries[2]
+        assert entries[4] == entries[3]  # repeated tile_output config: no growth
+    finally:
+        device.disable_and_clear_program_cache()

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
@@ -89,9 +89,9 @@ def test_topk_large_indices_row_major_bfloat16_uint32_indices(device, k, num_row
 
 
 def test_topk_large_indices_random_k2048_multichunk_multirow(device):
-    # PR2 triage repro (minimal): row-parallel factory, llk_k=2048, num_chunks=4,
-    # multiple rows, RANDOM input — the exact op-level combo behind the routed
-    # k=2048 cells that failed on silicon. If this passes while the routed
+    # Minimal repro shape for a class of silicon failures seen during bring-up:
+    # row-parallel factory, llk_k=2048, num_chunks=4, multiple rows, RANDOM
+    # input. If this passes while the routed
     # composite fails, the composite's post-op chain (gather at index width
     # 2048 -> gather's untested RM multi-core variant) is the culprit, not
     # this op. Tie-safe value-multiset assertions (random bf16 has duplicates).
@@ -210,6 +210,10 @@ TOPK_LARGE_INDICES_PRODUCTION_PERF_CONFIGS = [
 ]
 
 
+@pytest.mark.skip(
+    reason="expected_duration_ns pins predate the multi-core landings and must be re-baselined "
+    "on the IOMMU perf-runner class: https://github.com/tenstorrent/tt-metal/issues/53459"
+)
 @pytest.mark.parametrize(
     "case_id,num_rows,n,valid_length,k,expected_duration_ns",
     TOPK_LARGE_INDICES_PRODUCTION_PERF_CONFIGS,

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_topk_large_indices.py
@@ -264,8 +264,11 @@ def test_topk_large_indices_production_perf_check(
 
 
 def test_topk_large_indices_program_cache_ignores_row_count_and_array_size(device):
+    # (2, 131072) crosses the old 32-chunk fused boundary: at k >= 1024 the
+    # compute-body mode is width-independent (one segmented codepath), so a
+    # growing-prefill caller must NOT recompile crossing 65536 positions.
     k = 1536
-    cases = [(2, 3000), (640, 51200), (5, 4097)]
+    cases = [(2, 3000), (640, 51200), (5, 4097), (2, 131072)]
     tt_inputs = []
     for num_rows, n in cases:
         torch_input = _make_large_index_input(num_rows=num_rows, n=n, k=k)
@@ -361,6 +364,156 @@ def test_topk_large_indices_row_major_mixed_negative_infinity_indices_are_sentin
     _assert_indices(tt_indices, expected, [2, k])
 
 
+@pytest.mark.parametrize("k", [512, 2048])
+def test_topk_large_indices_neginf_sentinel_false_returns_real_positions(device, k):
+    # neginf_sentinel=False: -inf value lanes keep their REAL source column
+    # (the fused stamp carries it) instead of the 0xFFFFFFFF sentinel --
+    # stock ttnn.topk / torch parity for the composite routing layer.
+    # n is chunk-aligned (a multiple of k) so every lane is a real column:
+    # unaligned tails are -inf-padded BEFORE the index stamp, so with the
+    # sentinel skipped a padded lane would carry its (out-of-range) padded
+    # position -- the same looseness the stock path has around its own
+    # -inf padding.
+    n = 2 * k
+    finite_count = 16
+    torch_input = torch.full((2, n), -float("inf"), dtype=torch.bfloat16)
+    finite_values = torch.arange(finite_count, dtype=torch.float32).to(torch.bfloat16)
+    torch_input[:, :finite_count] = finite_values
+    tt_indices = ttnn.experimental.topk_large_indices(
+        _to_device(torch_input, device), k=k, neginf_sentinel=False
+    )
+
+    torch_indices = ttnn.to_torch(tt_indices).to(torch.int64)
+    assert list(torch_indices.shape) == [2, k]
+    # Finite lanes are exact (descending finite values live at columns 15..0).
+    expected_prefix = torch.arange(finite_count - 1, -1, -1, dtype=torch.int64)
+    assert_equal(torch_indices[:, :finite_count], expected_prefix.unsqueeze(0).repeat(2, 1))
+    # -inf lanes: real, in-range, unique positions whose source value is -inf.
+    inf_indices = torch_indices[:, finite_count:]
+    assert inf_indices.min() >= finite_count
+    assert inf_indices.max() < n
+    for row in torch_indices:
+        assert row.unique().numel() == k
+    gathered = torch.gather(torch_input, -1, inf_indices)
+    assert torch.isneginf(gathered.float()).all()
+
+
+def test_topk_large_indices_column_parallel_neginf_sentinel_false(device):
+    # Same contract on the column-parallel (merge-tree) factory.
+    k, n, finite_count = 512, 65536, 16
+    torch_input = torch.full((1, n), -float("inf"), dtype=torch.bfloat16)
+    torch_input[:, :finite_count] = torch.arange(finite_count, dtype=torch.float32).to(torch.bfloat16)
+    tt_indices = ttnn.experimental.topk_large_indices(
+        _to_device(torch_input, device), k=k, num_slices=4, neginf_sentinel=False
+    )
+
+    torch_indices = ttnn.to_torch(tt_indices).to(torch.int64)
+    assert list(torch_indices.shape) == [1, k]
+    expected_prefix = torch.arange(finite_count - 1, -1, -1, dtype=torch.int64)
+    assert_equal(torch_indices[:, :finite_count], expected_prefix.unsqueeze(0))
+    inf_indices = torch_indices[:, finite_count:]
+    assert inf_indices.min() >= finite_count
+    assert inf_indices.max() < n
+    assert torch_indices[0].unique().numel() == k
+
+
+def test_topk_large_indices_neginf_sentinel_flag_in_program_cache(device):
+    # The flag is part of the program hash: flipping it on the same shape
+    # must compile a second program, and each variant must keep its own
+    # contract when replayed from cache.
+    k, n, finite_count = 512, 1024, 16
+    torch_input = torch.full((2, n), -float("inf"), dtype=torch.bfloat16)
+    torch_input[:, :finite_count] = torch.arange(finite_count, dtype=torch.float32).to(torch.bfloat16)
+    tt_input = _to_device(torch_input, device)
+
+    device.enable_program_cache()
+    device.clear_program_cache()
+    base_entries = device.num_program_cache_entries()
+    idx_sentinel = ttnn.to_torch(
+        ttnn.experimental.topk_large_indices(tt_input, k=k, neginf_sentinel=True)
+    ).to(torch.int64)
+    after_first = device.num_program_cache_entries()
+    idx_real = ttnn.to_torch(
+        ttnn.experimental.topk_large_indices(tt_input, k=k, neginf_sentinel=False)
+    ).to(torch.int64)
+    after_second = device.num_program_cache_entries()
+    assert after_first > base_entries
+    assert after_second > after_first  # distinct program, not a cache hit
+
+    assert (idx_sentinel[:, finite_count:] == 0xFFFFFFFF).all()
+    assert idx_real[:, finite_count:].max() < n
+    # Replay both from cache and re-check the contracts.
+    idx_sentinel2 = ttnn.to_torch(
+        ttnn.experimental.topk_large_indices(tt_input, k=k, neginf_sentinel=True)
+    ).to(torch.int64)
+    idx_real2 = ttnn.to_torch(
+        ttnn.experimental.topk_large_indices(tt_input, k=k, neginf_sentinel=False)
+    ).to(torch.int64)
+    assert device.num_program_cache_entries() == after_second
+    device.disable_and_clear_program_cache()
+    assert_equal(idx_sentinel2, idx_sentinel)
+    assert_equal(idx_real2, idx_real)
+
+
+# ---------------------------------------------------------------------------
+# Segmented fusion: rows wider than the 32-chunk fused ceiling run <=32-chunk
+# fused segments (segment-local chunk-id stamp, one split per segment) folded
+# by unfused cross-segment merges. Cells pin the risky boundaries: first
+# unfused-era width (33 chunks), a single-chunk tail segment, deep segment
+# counts, and valid_length collapsing a wide program back to one segment.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "k,num_rows,n",
+    [
+        (2048, 2, 67584),  # 33 chunks: segment 1 holds exactly ONE chunk (rebuild-asc after bare sort)
+        (2048, 2, 131072),  # 64 chunks: 2 full segments
+        (1536, 2, 131072),  # k=1536 runs the 2048 window; USER_K slice of a segmented row
+        (2048, 1, 524288),  # 256 chunks: 8 segments (Pavle's scaled shape class)
+        (1536, 2, 524288),
+        (2048, 1, 1048576),  # 512 chunks: 16 segments, index magnitudes to 2^20
+        (1024, 2, 66560),  # K=1024 window: 65 chunks, seg1 = 33... spans capacity at a different K
+        (2048, 2, 100000),  # non-chunk-multiple width: -inf padded tail inside the last segment
+    ],
+)
+def test_topk_large_indices_segmented_widths(device, k, num_rows, n):
+    torch_input = _make_large_index_input(num_rows=num_rows, n=n, k=k)
+    tt_indices = ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=k)
+    _assert_topk_matches_torch(torch_input, tt_indices, k)
+
+
+def test_topk_large_indices_segmented_with_values(device):
+    k, n = 2048, 524288
+    torch_input = _make_large_index_input(num_rows=2, n=n, k=k)
+    tt_values, tt_indices = ttnn.experimental.topk_large_indices(
+        _to_device(torch_input, device), k=k, return_values=True
+    )
+    _assert_topk_matches_torch(torch_input, tt_indices, k)
+    ref_values, _ = torch.topk(torch_input.float(), k, dim=-1, largest=True, sorted=True)
+    assert_equal(ttnn.to_torch(tt_values).float(), ref_values.to(torch.bfloat16).float())
+
+
+def test_topk_large_indices_segmented_valid_length_collapses_to_one_segment(device):
+    # A wide (segmented) program whose runtime valid_length shrinks the row to
+    # <= 32 chunks must run the single-segment path inside the SAME cached
+    # segmented binary -- and again at a segment-boundary-crossing length.
+    k, n = 2048, 524288
+    # Distinct top-k block INSIDE the smallest tested valid_length so every
+    # tested prefix has a tie-free torch reference (zeros elsewhere).
+    torch_input = torch.zeros((2, n), dtype=torch.bfloat16)
+    hi16 = (0x3F80 + np.arange(k, dtype=np.uint32)).astype(np.uint32)
+    torch_input[:, 40960 - k : 40960] = torch.from_numpy((hi16 << 16).view(np.float32).copy()).to(torch.bfloat16)
+    tt_input = _to_device(torch_input, device)
+    device.enable_program_cache()
+    device.clear_program_cache()
+    for valid_length in (n, 40960, 98304):  # 256 chunks, 20 chunks (1 seg), 48 chunks (2 segs)
+        tt_indices = ttnn.experimental.topk_large_indices(tt_input, k=k, valid_length=valid_length)
+        _assert_topk_matches_torch(torch_input[:, :valid_length], tt_indices, k)
+    assert device.num_program_cache_entries() == 1  # one program serves every runtime length
+    device.disable_and_clear_program_cache()
+
+
 # ---------------------------------------------------------------------------
 # valid_length: bound the search to the first N columns of each (wider) row.
 # ---------------------------------------------------------------------------
@@ -403,8 +556,13 @@ def test_topk_large_indices_valid_length_ignores_stale_tail(device, k, n, valid_
     ],
 )
 def test_topk_large_indices_valid_length_matches_sliced_input(device, k, num_rows, n, valid_length):
-    # valid_length=L must be numerically identical to physically slicing the row to [0, L) and running the
-    # full-width op. Both compute top-k over the exact same prefix, so the indices are bit-identical.
+    # valid_length=L must select the exact same top-k VALUE multiset as physically slicing the row to
+    # [0, L) and running the full-width op. Indices may legitimately differ ONLY on exact-bf16 ties: the
+    # two calls have different physical widths, and the engine (and with it the unspecified non-stable
+    # tie order) is chosen per physical width — e.g. the FUSED_E2E gate flips at 32 chunks, and fused
+    # cross-chunk compares break ties by stamped chunk id while unfused merges break them by network
+    # position. Every index mismatch is therefore asserted to be a bitwise value tie, and the sorted
+    # value sequences must match bit-for-bit.
     torch.manual_seed(0)
     torch_input = torch.randn(num_rows, n, dtype=torch.bfloat16)
 
@@ -414,7 +572,18 @@ def test_topk_large_indices_valid_length_matches_sliced_input(device, k, num_row
     bounded_t = ttnn.to_torch(bounded, dtype=torch.uint32).to(torch.int64)
     sliced_t = ttnn.to_torch(sliced, dtype=torch.uint32).to(torch.int64)
     _assert_index_metadata(bounded, [num_rows, k])
-    assert_equal(bounded_t, sliced_t)
+    source = torch_input.to(torch.float32)
+    for r in range(num_rows):
+        gathered_bounded = source[r, bounded_t[r]]
+        gathered_sliced = source[r, sliced_t[r]]
+        diff = (bounded_t[r] != sliced_t[r]).nonzero().flatten()
+        assert torch.equal(
+            gathered_bounded[diff], gathered_sliced[diff]
+        ), f"row {r}: {len(diff)} index diffs include a non-tie (values differ)"
+        assert torch.equal(
+            torch.sort(gathered_bounded, descending=True).values,
+            torch.sort(gathered_sliced, descending=True).values,
+        ), f"row {r}: top-k value multisets differ"
 
 
 def test_topk_large_indices_valid_length_full_width_is_noop(device):
@@ -928,12 +1097,17 @@ def test_topk_large_indices_num_slices_non_model_values(device, num_slices):
     assert_equal(actual_values.sort().values, ref_values.sort().values)
 
 
-def test_topk_large_indices_num_slices_rejected_on_row_parallel(device, expect_error):
-    # Multi-row shapes take the row-parallel factory where num_slices has no
-    # meaning: explicit beats ignored.
+def test_topk_large_indices_num_slices_multirow_matches_row_parallel(device):
+    # Explicit num_slices on a multi-row shape opts into the multi-rectangle
+    # tree factory (one P-core tree per row, all concurrent). The exact top-k
+    # value multiset must match the row-parallel default engine bit-for-bit
+    # (index ORDER may differ only on bf16 ties, which _make_bf16_exact_input
+    # rules out by construction).
     torch_input = _make_bf16_exact_input(num_rows=2, n=4096)
-    with expect_error(RuntimeError, "num_slices"):
-        ttnn.experimental.topk_large_indices(_to_device(torch_input, device), k=512, num_slices=4)
+    tt_input = _to_device(torch_input, device)
+    idx_default = ttnn.to_torch(ttnn.experimental.topk_large_indices(tt_input, k=512))
+    idx_rect = ttnn.to_torch(ttnn.experimental.topk_large_indices(tt_input, k=512, num_slices=4))
+    assert_equal(idx_default, idx_rect)
 
 
 @pytest.mark.parametrize(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/llk_math_eltwise_unary_sfpu_topk_xl.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/llk_math_eltwise_unary_sfpu_topk_xl.h
@@ -46,6 +46,13 @@ inline void llk_math_eltwise_unary_sfpu_topk_xl_add_lsb_indices(uint dst_index) 
         ckernel::sfpu::_topk_xl_add_lsb_indices_<K, APPROXIMATE, core_id>, dst_index, VectorMode::RC_custom);
 }
 
+// Runtime-chunk-id stamp (fused end-to-end rows: one instantiation, id per chunk).
+template <uint32_t K, bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_topk_xl_add_lsb_indices_rt(uint dst_index, uint32_t chunk_id) {
+    _llk_math_eltwise_unary_sfpu_params_(
+        ckernel::sfpu::_topk_xl_add_lsb_indices_rt_<K, APPROXIMATE>, dst_index, VectorMode::RC_custom, chunk_id);
+}
+
 template <bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_remove_msb_values_init() {
     ckernel::sfpu::_topk_xl_remove_msb_values_init_();
@@ -105,6 +112,18 @@ template <uint32_t K, bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major(uint dst_index) {
     _llk_math_eltwise_unary_sfpu_params_(
         ckernel::sfpu::_topk_xl_separate_indices_row_major_<K, APPROXIMATE>, dst_index, VectorMode::RC_custom);
+}
+
+// Fused end-to-end: chunk-field-mask init + once-per-row global split.
+template <bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_global_init() {
+    llk_math_eltwise_unary_sfpu_init<SfpuType::unused>(ckernel::sfpu::_topk_xl_separate_indices_row_major_global_init_);
+}
+
+template <uint32_t K, bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_global(uint dst_index) {
+    _llk_math_eltwise_unary_sfpu_params_(
+        ckernel::sfpu::_topk_xl_separate_indices_row_major_global_<K, APPROXIMATE>, dst_index, VectorMode::RC_custom);
 }
 
 template <uint32_t K, bool APPROXIMATE>

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/llk_math_eltwise_unary_sfpu_topk_xl.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_sfpu/llk_math_eltwise_unary_sfpu_topk_xl.h
@@ -126,6 +126,23 @@ inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_globa
         ckernel::sfpu::_topk_xl_separate_indices_row_major_global_<K, APPROXIMATE>, dst_index, VectorMode::RC_custom);
 }
 
+// Segmented fusion: per-segment split with a runtime segment base OR'd into
+// the decoded index, and the SFPU index-tracking clear for fused re-entry.
+template <uint32_t K, bool APPROXIMATE>
+inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_global_base(
+    uint dst_index, uint32_t seg_base) {
+    _llk_math_eltwise_unary_sfpu_params_(
+        ckernel::sfpu::_topk_xl_separate_indices_row_major_global_base_<K, APPROXIMATE>,
+        dst_index,
+        VectorMode::RC_custom,
+        seg_base);
+}
+
+inline void llk_math_eltwise_unary_sfpu_topk_xl_index_tracking_disable() {
+    TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);
+    ckernel::sfpu::_topk_xl_index_tracking_disable_();
+}
+
 template <uint32_t K, bool APPROXIMATE>
 inline void llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_advance_chunk_base() {
     TTI_STALLWAIT(p_stall::STALL_SFPU, p_stall::MATH);

--- a/tt_metal/hw/inc/api/compute/experimental/topk_xl.h
+++ b/tt_metal/hw/inc/api/compute/experimental/topk_xl.h
@@ -363,6 +363,20 @@ ALWI void topk_xl_separate_indices_row_major_global(uint32_t idst) {
     MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_global<K, false>(idst)));
 }
 
+// Segmented fusion: split one fused segment survivor in place, adding
+// seg_base (= segment_index * 32 * K, power-of-two aligned) to every decoded
+// index. Same init as the plain global split.
+template <uint32_t K>
+ALWI void topk_xl_separate_indices_row_major_global_base(uint32_t idst, uint32_t seg_base) {
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_global_base<K, false>(idst, seg_base)));
+}
+
+// Clears the SFPU index-tracking config bit before a segmented row re-enters
+// fused merges after an unfused cross-segment fold.
+ALWI void topk_xl_index_tracking_disable() {
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_index_tracking_disable()));
+}
+
 template <uint32_t K>
 ALWI void topk_xl_separate_indices_row_major_advance_chunk_base() {
     MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_advance_chunk_base<K, false>()));

--- a/tt_metal/hw/inc/api/compute/experimental/topk_xl.h
+++ b/tt_metal/hw/inc/api/compute/experimental/topk_xl.h
@@ -119,8 +119,9 @@ ALWI void topk_xl_rebuild(uint32_t idst, bool ascending) {
  * Programs all of:
  *   * ADDR_MOD_1..7 for the bitonic load/store strides (incl. the +24 / +40 /
  *     +48 stride-folding slots that the inner loops depend on),
- *   * the math-thread MOP Expander with the merge body template (`fused`
- *     selects the body length: 16 for fused, 18 for unfused),
+ *   * the math-thread MOP Expander with the merge body template (16-issue
+ *     body for fused AND for the default macro-scheduled unfused path;
+ *     18 for unfused only when built with -DDISABLE_TOPK_XL_SFPLOADMACRO),
  *   * the SFPU index-tracking config in unfused mode.
  *
  * Because every merge/rebuild/local_sort relies on the ADDR_MOD programming
@@ -213,6 +214,16 @@ ALWI void topk_xl_add_lsb_indices_init() { MATH((llk_math_eltwise_unary_sfpu_top
 template <uint32_t K, uint32_t core_id>
 ALWI void topk_xl_add_lsb_indices(uint32_t idst) {
     MATH((llk_math_eltwise_unary_sfpu_topk_xl_add_lsb_indices<K, APPROX, core_id>(idst)));
+}
+
+/**
+ * Runtime-chunk-id variant of topk_xl_add_lsb_indices: the 5-bit id in index
+ * bits [15:11] is a runtime argument, so one instantiation stamps every chunk
+ * of a fused end-to-end row (chunk_id in 0..31). Same init.
+ */
+template <uint32_t K>
+ALWI void topk_xl_add_lsb_indices_rt(uint32_t idst, uint32_t chunk_id) {
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_add_lsb_indices_rt<K, APPROX>(idst, chunk_id)));
 }
 
 /**
@@ -333,6 +344,23 @@ ALWI void topk_xl_separate_indices(uint32_t idst) {
 template <uint32_t K>
 ALWI void topk_xl_separate_indices_row_major(uint32_t idst) {
     MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major<K, false>(idst)));
+}
+
+/**
+ * Fused end-to-end split: runs ONCE per row on the final fused survivor.
+ * Each u16 payload carries [chunk_id 15:11 | within-chunk 10:0]; the global
+ * index chunk_id * K + row-major(within-chunk) is recovered from the stamp
+ * itself — no chunk-base bookkeeping. Pair with
+ * topk_xl_separate_indices_row_major_global_init. Sound only for rows of
+ * <= 32 chunks (the FUSED_E2E factory gate).
+ */
+ALWI void topk_xl_separate_indices_row_major_global_init() {
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_global_init<false>()));
+}
+
+template <uint32_t K>
+ALWI void topk_xl_separate_indices_row_major_global(uint32_t idst) {
+    MATH((llk_math_eltwise_unary_sfpu_topk_xl_separate_indices_row_major_global<K, false>(idst)));
 }
 
 template <uint32_t K>

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_topk_xl.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_topk_xl.h
@@ -350,6 +350,12 @@ inline void configure_sequences()
     TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (sequence_word(1) >> 16) & 0xFFFF);
     TTI_SFPCONFIG(0, 4 + 1, 0);
     TTI_SFPCONFIG(MISC_WORD, 8, SFPCFG_IMM16_IS_VALUE);
+    // SFPCONFIG writes to the Sequence/Misc registers take two cycles to
+    // land before an SFPLOADMACRO may consume them; issuing a macro sooner
+    // reads the stale configuration. Two NOPs is the measured minimum on
+    // BH silicon (validated by the mutation-control suite: removing either
+    // NOP flips the macro-vs-optout differential from bit-identical to
+    // divergent).
     TTI_SFPNOP;
     TTI_SFPNOP;
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_topk_xl.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_topk_xl.h
@@ -109,6 +109,16 @@
 #include "sfpi.h"
 #include "sfpu/ckernel_sfpu_load_config.h"
 
+// SFPLOADMACRO acceleration of the UNFUSED merge / rebuild bodies — see the
+// "SFPLOADMACRO acceleration for the UNFUSED merge / rebuild" section below
+// for the full design, silicon validation, and the opt-out contract. Defined
+// here (before `topk_mop_config`) because the merge MOP body length keys on it.
+#if !defined(DISABLE_TOPK_XL_SFPLOADMACRO) && !defined(DISABLE_SFPLOADMACRO)
+#define TOPK_XL_UNFUSED_MACRO 1
+#else
+#define TOPK_XL_UNFUSED_MACRO 0
+#endif
+
 namespace ckernel
 {
 namespace sfpu
@@ -139,7 +149,14 @@ namespace sfpu
 template <bool fused>
 inline void topk_mop_config()
 {
+    // Unfused: the SFPLOADMACRO body is 16 instructions (the two SFPSWAPs and
+    // two of the eight stores ride the macros); the plain body is 18. Must
+    // match what `_topk_xl_merge_` records — both key on the same flag.
+#if TOPK_XL_UNFUSED_MACRO
+    constexpr int body_len = 16;
+#else
     constexpr int body_len              = fused ? 16 : 18;
+#endif
     constexpr std::uint32_t replay_body = lltt::replay_insn(0, body_len);
     ckernel_unpack_template tmpl        = ckernel_unpack_template::lA(replay_body, TT_OP_NOP);
     tmpl.program();
@@ -194,6 +211,269 @@ inline void topk_rebuild_build2048_mop_config()
         /*skipB=*/TT_OP_NOP);
     tmpl.program();
 }
+
+// =============================================================================
+//  SFPLOADMACRO acceleration for the UNFUSED merge / rebuild
+// =============================================================================
+//
+// The unfused merge body and the unfused rebuild's stride-64/32/16 bodies all
+// have the same single-level shape:
+//
+//     load8_rows_x2_unfused + bitonic_sort_len_k<false> + store8_rows_x2_unfused
+//
+// with every store going back to the address it was loaded from. That is the
+// structure the fused macro work proved on silicon: the two SFPSWAPs ride
+// SFPLOADMACRO Simple slots (delay 0) and the store of each macro's own
+// register rides its Store slot (delay 2, address latched at load time —
+// SFPLOADMACRO.md:140). Under SFPU index-tracking mode (LaneConfig bit [2],
+// which the unfused path enables) a macro-scheduled SFPSWAP still performs the
+// argmin/argmax companion swap of LReg[4+VC] <-> LReg[4+VD] — verified
+// bit-identical against the software swap by
+// tests/python_tests/test_topk_unfused_macro_probe.py (arms 1/2/4 green with
+// a sensitivity-proven mutation control, Blackhole silicon, 2026-08-16).
+//
+// The macro body is 16 issues against the shipping 18 issues + 2 two-cycle
+// (plus index-tracking stall) SFPSWAPs (~20-22 cycles):
+//
+//     i0..i3   4x SFPLOAD  (INT32)  index regs LREG4..7 — MUST precede the
+//                                    macros: the companion swap reads/writes
+//                                    LREG4..7 the cycle after each macro.
+//     i4       SFPLOAD  (FP32)      first VC provider
+//     i5       SFPLOADMACRO m0      loads first macroVD; Simple: SFPSWAP,
+//                                    MAD: SFPNOP (footnote ‡), Store: delay 2
+//     i6       SFPLOAD  (FP32)      second VC provider  — the plain load
+//                                    between macros IS the 2-slot separation
+//                                    rule (a macro-scheduled SFPSWAP owns the
+//                                    Simple sub-unit for 2 cycles and is
+//                                    exempt from the automatic stall)
+//     i7       SFPLOADMACRO m1
+//     i8       SFPNOP               m0's store fires here — keep it store-free
+//     i9       SFPSTORE (FP32)      first VC register
+//     i10      SFPNOP               m1's store fires here
+//     i11      SFPSTORE (FP32)      second VC register
+//     i12..i14 3x SFPSTORE (INT32)  LREG4/5/6
+//     i15      SFPSTORE (INT32)     LREG7 — carries the Dst-advance fold
+//                                    (kept in software so every inc_dst_addr
+//                                    variant of the shipping loops survives)
+//
+// Both scheduled stores retire INSIDE the body (delay 2 from i5/i7 fires at
+// i8/i10), so no trailing SFPNOPs and no cross-call pending-store state.
+//
+// Direction maps to which half is macroVD (the macro always overrides Insn.VD
+// with the register its own load writes):
+//   ascending  (sort_k ASC:  SWAP(VC=LREG2, VD=LREG0)) -> macroVD = LREG0/1,
+//              templates' VC = LREG2/3
+//   descending (sort_k DESC: SWAP(VC=LREG0, VD=LREG2)) -> macroVD = LREG2/3,
+//              templates' VC = LREG0/1
+// The merge always takes the descending form (it calls sort_k with false).
+// Merge and rebuild program their own two InstructionTemplates at entry
+// (2 backdoor writes — self-contained, no cross-call template contract, and
+// no collision with the FUSED macro users' templates). The Sequence words and
+// Misc are direction- and caller-invariant and are programmed once per
+// `_topk_xl_init_<K, false>`.
+//
+// Index loads/stores stay in software: only 4 macro slots exist, the 2-bit
+// Store delay field cannot reach past the swap-macros' store cycles in a
+// 16-issue body, and LREG7's store carries the shipping ADDR_MOD fold.
+//
+// Opt-out: define DISABLE_TOPK_XL_SFPLOADMACRO (or the global
+// DISABLE_SFPLOADMACRO) to rebuild the byte-identical pre-macro bodies.
+// TOPK_XL_MACRO_MUTATE is a TEST-ONLY hook: it zeroes the Sequence words so
+// every SFPLOADMACRO degenerates into a plain SFPLOAD ("schedule nothing"),
+// which silently drops the compare-exchanges AND the macro stores — the
+// timing-invisible failure mode the correctness suites must be able to see.
+// (The TOPK_XL_UNFUSED_MACRO gate itself is defined at the top of this file,
+// before `topk_mop_config`, which keys its unfused body length on it.)
+
+#if TOPK_XL_UNFUSED_MACRO
+
+namespace topk_xl_unfused_macro
+{
+
+// Simple byte: selector 4+m -> InstructionTemplate[m], delay 0. 0x80 SET ->
+// Insn.VB = macroVD, leaving Insn.VC at the template's value (with it clear
+// the macro would assign Insn.VC = macroVD and the SFPSWAP degenerates to a
+// same-register compare — which silicon resolves as garbage, not a no-op).
+// 0x40 CLEAR -> Insn.VD = macroVD.
+constexpr std::uint32_t seq_simple(std::uint32_t m)
+{
+    return 0x80u | (0u << 3) | (4u + m);
+}
+
+// MAD byte: SFPNOP at the same delay — required whenever SFPSWAP is scheduled
+// to the Simple sub-unit (SFPLOADMACRO.md:11 footnote ‡). Round: nothing.
+constexpr std::uint32_t SEQ_MAD_NOP = (0u << 3) | 2u;
+
+// Store byte: selector 3 = the built-in SFPSTORE, delay 2 — the SFPSWAP
+// writes macroVD on its second cycle (macro+2), the store fires at macro+3.
+// 0x40/0x80 clear -> Insn.VD = macroVD.
+constexpr std::uint32_t SEQ_STORE = (2u << 3) | 3u;
+
+#if defined(TOPK_XL_MACRO_MUTATE)
+// Mutation control (test-only): schedule nothing.
+constexpr std::uint32_t sequence_word(std::uint32_t)
+{
+    return 0u;
+}
+#else
+constexpr std::uint32_t sequence_word(std::uint32_t m)
+{
+    return (SEQ_STORE << 24) | (SEQ_MAD_NOP << 8) | seq_simple(m);
+}
+#endif
+
+// Misc (SFPLOADMACRO.md:53-57): 0xF0 -> every macro's store inherits its
+// LOAD's Mod0 (FP32 here — the value regs are genuine FP32, same mode the
+// shipping software stores use). 0xB00 -> Simple/MAD/Store on
+// WaitForElapsedInstructions so the delay chain cannot slide if the frontend
+// bubbles.
+constexpr std::uint32_t MISC_WORD = 0xB00u | 0xF0u;
+
+constexpr std::uint32_t SFPCFG_IMM16_IS_VALUE = 1; // SFPCONFIG.md:108
+
+// SFPLOADMACRO field packing (ckernel_ops.h:689, SFPLOADMACRO.md:20-26,45):
+//   lreg_ind = (MacroIndex << 2) | (VD & 3), dest_reg_addr = (Imm9 << 1) | (VD >> 2).
+// VD is u3 and the address low bit is unused (SFPLOAD.md:83), so VD in 0..7
+// never perturbs the address.
+#define TOPK_XL_UNFUSED_LOADMACRO(macro_idx, vd, off) \
+    TTI_SFPLOADMACRO(((macro_idx) << 2) | ((vd) & 3u), InstrModLoadStore::FP32, ADDR_MOD_7, (off) | ((vd) >> 2))
+
+// Program Sequence[0/1] + Misc. Stages each 32-bit word through LReg[0] (the
+// _init_mul_int_ idiom — the Store byte does not fit the imm16 path).
+// Runs from `_topk_xl_init_<K, false>`; LReg[0] is reloaded by every body.
+inline void configure_sequences()
+{
+    TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, sequence_word(0) & 0xFFFF);
+    TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (sequence_word(0) >> 16) & 0xFFFF);
+    TTI_SFPCONFIG(0, 4 + 0, 0);
+    TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_LOWER, sequence_word(1) & 0xFFFF);
+    TTI_SFPLOADI(0, sfpi::SFPLOADI_MOD0_UPPER, (sequence_word(1) >> 16) & 0xFFFF);
+    TTI_SFPCONFIG(0, 4 + 1, 0);
+    TTI_SFPCONFIG(MISC_WORD, 8, SFPCFG_IMM16_IS_VALUE);
+    TTI_SFPNOP;
+    TTI_SFPNOP;
+}
+
+// Install InstructionTemplate[0/1] for one direction via the VD >= 12
+// backdoor (open: the unfused LaneConfig is 0x4, DISABLE_BACKDOOR_LOAD clear).
+// Mod1 stays ALL_ROWS_MAX — both halves are kept and the shipping operand
+// order already puts the macro-reachable half in macroVD.
+template <bool ascending>
+inline void program_templates()
+{
+    if constexpr (ascending)
+    {
+        TTI_SFPSWAP(0, p_sfpu::LREG2, 12, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPSWAP(0, p_sfpu::LREG3, 13, p_sfpswap::ALL_ROWS_MAX);
+    }
+    else
+    {
+        TTI_SFPSWAP(0, p_sfpu::LREG0, 12, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPSWAP(0, p_sfpu::LREG1, 13, p_sfpswap::ALL_ROWS_MAX);
+    }
+}
+
+// The body minus the LREG7 tail — 15 issues (see the section comment's
+// timeline). Kept separate so the split-record loops can emit a per-iter
+// LREG7 ADDR_MOD exactly like the shipping `store_first_7_rows_x2_unfused`
+// pattern.
+template <int indices_offset, int group_2_offset, bool ascending>
+inline void ce_first15()
+{
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_7, indices_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_7, indices_offset + 4);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::INT32, ADDR_MOD_7, indices_offset + group_2_offset + 0);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_7, indices_offset + group_2_offset + 4);
+    if constexpr (ascending)
+    {
+        TTI_SFPLOAD(p_sfpu::LREG2, InstrModLoadStore::FP32, ADDR_MOD_7, group_2_offset + 0);
+        TOPK_XL_UNFUSED_LOADMACRO(0u, p_sfpu::LREG0, 0);
+        TTI_SFPLOAD(p_sfpu::LREG3, InstrModLoadStore::FP32, ADDR_MOD_7, group_2_offset + 4);
+        TOPK_XL_UNFUSED_LOADMACRO(1u, p_sfpu::LREG1, 4);
+        TTI_SFPNOP; // m0's store (LREG0 -> 0) fires here
+        TTI_SFPSTORE(p_sfpu::LREG2, InstrModLoadStore::FP32, ADDR_MOD_7, group_2_offset + 0);
+        TTI_SFPNOP; // m1's store (LREG1 -> 4) fires here
+        TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::FP32, ADDR_MOD_7, group_2_offset + 4);
+    }
+    else
+    {
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_7, 0);
+        TOPK_XL_UNFUSED_LOADMACRO(0u, p_sfpu::LREG2, group_2_offset + 0);
+        TTI_SFPLOAD(p_sfpu::LREG1, InstrModLoadStore::FP32, ADDR_MOD_7, 4);
+        TOPK_XL_UNFUSED_LOADMACRO(1u, p_sfpu::LREG3, group_2_offset + 4);
+        TTI_SFPNOP; // m0's store (LREG2 -> group_2_offset) fires here
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::FP32, ADDR_MOD_7, 0);
+        TTI_SFPNOP; // m1's store (LREG3 -> group_2_offset + 4) fires here
+        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::FP32, ADDR_MOD_7, 4);
+    }
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_7, indices_offset + 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_7, indices_offset + 4);
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::INT32, ADDR_MOD_7, indices_offset + group_2_offset + 0);
+}
+
+// The LREG7 tail — same inc_dst_addr -> ADDR_MOD mapping as
+// `store8_rows_x2_unfused`'s last store, so every shipping fold survives.
+template <int indices_offset, int group_2_offset, int inc_dst_addr>
+inline void ce_tail()
+{
+    constexpr int off = indices_offset + group_2_offset + 4;
+    if constexpr (inc_dst_addr == 40)
+    {
+        TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_3, off);
+    }
+    else if constexpr (inc_dst_addr == 32)
+    {
+        TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_6, off);
+    }
+    else if constexpr (inc_dst_addr == 24)
+    {
+        TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_2, off);
+    }
+    else if constexpr (inc_dst_addr == 16)
+    {
+        TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_5, off);
+    }
+    else if constexpr (inc_dst_addr == 8)
+    {
+        TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_4, off);
+    }
+    else if constexpr (inc_dst_addr == 0)
+    {
+        TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_7, off);
+    }
+    else
+    {
+        static_assert(inc_dst_addr == 0, "Invalid inc_dst_addr");
+    }
+}
+
+// Full 16-issue body.
+template <int indices_offset, int group_2_offset, int inc_dst_addr, bool ascending>
+inline void ce_full()
+{
+    ce_first15<indices_offset, group_2_offset, ascending>();
+    ce_tail<indices_offset, group_2_offset, inc_dst_addr>();
+}
+
+// Record the full body (recording IS the first executed iteration) into
+// replay slots [0, 16) for the runtime direction. Fold iterations replay
+// [0, 15) and emit their own tail.
+template <int indices_offset, int group_2_offset, int inc_dst_addr>
+inline void record_ce_full(const bool dir)
+{
+    if (dir)
+    {
+        load_replay_buf<Exec>(0, 16, [] { ce_full<indices_offset, group_2_offset, inc_dst_addr, true>(); });
+    }
+    else
+    {
+        load_replay_buf<Exec>(0, 16, [] { ce_full<indices_offset, group_2_offset, inc_dst_addr, false>(); });
+    }
+}
+
+} // namespace topk_xl_unfused_macro
+
+#endif // TOPK_XL_UNFUSED_MACRO
 
 // =============================================================================
 //  Init
@@ -282,7 +562,17 @@ inline void _topk_xl_init_()
     {
         // Enable SFPU index-tracking mode (bit [2] of SFPU_CONTROL_REG)
         // so the unfused path can keep indices in a parallel DST region.
+        // Bit [1] (DISABLE_BACKDOOR_LOAD) stays 0, keeping the VD >= 12
+        // InstructionTemplate backdoor open for the macro programming below
+        // and for the per-call template installs in merge / rebuild.
         _sfpu_load_config32_(0xF, 0x0, 0x4);
+
+#if TOPK_XL_UNFUSED_MACRO
+        // Sequence words + Misc for the unfused macro bodies. Direction- and
+        // caller-invariant; the two InstructionTemplates are installed by
+        // `_topk_xl_merge_` / `_topk_xl_rebuild_` at each entry.
+        topk_xl_unfused_macro::configure_sequences();
+#endif
     }
 
     // Program the MOP Expander so the merge's inner loop can fire with a
@@ -1685,15 +1975,19 @@ inline void _topk_xl_merge_(const std::uint32_t dst_index)
 {
     static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
 
-    constexpr bool descending                     = false; // direction the merge writes
+    [[maybe_unused]] constexpr bool descending    = false; // direction the merge writes
     constexpr int num_tiles_per_sequence          = (K == 2048) ? 2 : 1;
     constexpr int row_scale_factor                = (K == 512) ? 1 : (K == 1024) ? 2 : 4;
     constexpr int distance                        = fused ? (64 * num_tiles_per_sequence) : (128 * num_tiles_per_sequence);
     [[maybe_unused]] constexpr int indices_offset = 64 * num_tiles_per_sequence;
     const std::uint32_t tile_offset               = dst_index << DstTileSizeLog2[DstTileShape::Tile32x32];
 
+#if TOPK_XL_UNFUSED_MACRO
+    constexpr int body_len = 16; // must match topk_mop_config's REPLAY length
+#else
     constexpr int body_len = fused ? 16 : 18;
-    constexpr int n_iters  = fused ? (row_scale_factor * 2) : (row_scale_factor * 4);
+#endif
+    constexpr int n_iters = fused ? (row_scale_factor * 2) : (row_scale_factor * 4);
     static_assert(n_iters >= 2, "n_iters < 2 would skip the MOP firing of col=0");
     static_assert(n_iters <= 255, "ckernel_unpack_template::run takes a uint8_t count");
 
@@ -1714,6 +2008,15 @@ inline void _topk_xl_merge_(const std::uint32_t dst_index)
     }
     else
     {
+#if TOPK_XL_UNFUSED_MACRO
+        // SFPLOADMACRO body: the two SFPSWAPs ride the loads' Simple slots
+        // and the macroVD stores ride their Store slots. The merge always
+        // sorts with `descending` (= the ascending=false operand order), so
+        // macroVD = LREG2/3 and the templates' VC = LREG0/1. Every scheduled
+        // store retires inside the body — no trailing SFPNOPs needed.
+        topk_xl_unfused_macro::program_templates<false>();
+        load_replay_buf<Exec>(0, body_len, [] { topk_xl_unfused_macro::ce_full<indices_offset, distance, 8 /* inc_dst_addr */, false>(); });
+#else
         load_replay_buf<Exec>(
             0,
             body_len,
@@ -1723,6 +2026,7 @@ inline void _topk_xl_merge_(const std::uint32_t dst_index)
                 bitonic_sort_len_k<fused>(descending);
                 store8_rows_x2_unfused<indices_offset, distance, 8 /* inc_dst_addr */>();
             });
+#endif
     }
 
     // col=0: fire the remaining (n_iters - 1) iters via one MOP issue.
@@ -1856,8 +2160,78 @@ inline void _topk_xl_rebuild_(const std::uint32_t dst_index, const bool ascendin
         set_dst_write_addr_offset(tile_offset + 0);
         transpose_8_faces<fused, indices_offset, /*manage_outer_cfg=*/false>();
         leave_transpose_cfg_block();
+
+#if TOPK_XL_UNFUSED_MACRO
+        // Install the direction's InstructionTemplates once for all three
+        // stride phases below (2 backdoor writes; Sequence/Misc were
+        // programmed by `_topk_xl_init_<K, false>`).
+        if (dir)
+        {
+            topk_xl_unfused_macro::program_templates<true>();
+        }
+        else
+        {
+            topk_xl_unfused_macro::program_templates<false>();
+        }
+#endif
         for (int col = 0; col < 2; col++)
         {
+#if TOPK_XL_UNFUSED_MACRO
+            // ── Stride-64 — 16-slot macro body, recording IS iter 0 ────────
+            topk_xl_unfused_macro::record_ce_full<indices_offset, 64, 8>(dir);
+            for (int i = 1; i < 8; i++)
+            {
+                lltt::replay(0, 16);
+            }
+            TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+
+            // ── Stride-32 — recorded body carries the ADDR_MOD_4 (+8) tail;
+            // the last inner iter of each outer pair replays [0, 15) and
+            // emits its own ADDR_MOD_3 (+40) tail, exactly the shipping
+            // split-record fold.
+            for (int i = 0; i < 2; i++)
+            {
+                for (int j = 0; j < 4; j++)
+                {
+                    if (i == 0 && j == 0)
+                    {
+                        topk_xl_unfused_macro::record_ce_full<indices_offset, 32, 8>(dir);
+                    }
+                    else if (j < 3)
+                    {
+                        lltt::replay(0, 16);
+                    }
+                    else
+                    {
+                        lltt::replay(0, 15);
+                        topk_xl_unfused_macro::ce_tail<indices_offset, 32, 40>();
+                    }
+                }
+            }
+            TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+
+            // ── Stride-16 — same shape; fold iters take ADDR_MOD_2 (+24) ───
+            for (int i = 0; i < 4; i++)
+            {
+                for (int j = 0; j < 2; j++)
+                {
+                    if (i == 0 && j == 0)
+                    {
+                        topk_xl_unfused_macro::record_ce_full<indices_offset, 16, 8>(dir);
+                    }
+                    else if (j == 0)
+                    {
+                        lltt::replay(0, 16);
+                    }
+                    else
+                    {
+                        lltt::replay(0, 15);
+                        topk_xl_unfused_macro::ce_tail<indices_offset, 16, 24>();
+                    }
+                }
+            }
+            TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+#else
             // ── Stride-64 — clean N = 8 replay, recording IS iter 0 ────────
             load_replay_buf<Exec>(0, 8, [] { load8_rows_x2_unfused<indices_offset, 64>(); });
             bitonic_sort_len_k<fused>(dir);
@@ -1939,6 +2313,7 @@ inline void _topk_xl_rebuild_(const std::uint32_t dst_index, const bool ascendin
                 }
             }
             TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+#endif // TOPK_XL_UNFUSED_MACRO
 
             // ── Stride-8 — clean N = 8 replay, recording IS iter 0 ────────
             load_replay_buf<Exec>(0, 8, [] { load8_rows_x2_unfused<indices_offset, 8>(); });
@@ -2093,6 +2468,19 @@ inline void _topk_xl_rebuild_generic_(const std::uint32_t dst_index, const bool 
         transpose_N_faces</*N*/ row_scale_factor * 2, fused, indices_offset, /*manage_outer_cfg=*/false>();
         leave_transpose_cfg_block();
 
+#if TOPK_XL_UNFUSED_MACRO
+        // Install the direction's InstructionTemplates once for the stride-32
+        // and stride-16 phases below (2 backdoor writes; Sequence/Misc were
+        // programmed by `_topk_xl_init_<K, false>`).
+        if (dir)
+        {
+            topk_xl_unfused_macro::program_templates<true>();
+        }
+        else
+        {
+            topk_xl_unfused_macro::program_templates<false>();
+        }
+#endif
         for (int col = 0; col < 2; col++)
         {
             // The inner loop counts here mirror `row_scale_factor` exactly
@@ -2116,6 +2504,25 @@ inline void _topk_xl_rebuild_generic_(const std::uint32_t dst_index, const bool 
             // first inline iteration.
             if constexpr (K >= 1024)
             {
+#if TOPK_XL_UNFUSED_MACRO
+                // ── stride-32 — 16-slot macro body. The recorded body
+                // carries the ADDR_MOD_4 (+8) tail; the last body of each
+                // outer iter replays [0, 15) and emits the ADDR_MOD_3
+                // (+40) fold tail, preserving the shipping stride walk.
+                topk_xl_unfused_macro::record_ce_full<indices_offset, 32, 8>(dir);
+                for (int i = 0; i < (row_scale_factor >> 1); i++)
+                {
+                    if (!(i == 0))
+                    {
+                        lltt::replay(0, 16);
+                    }
+                    lltt::replay(0, 16);
+                    lltt::replay(0, 16);
+                    lltt::replay(0, 15);
+                    topk_xl_unfused_macro::ce_tail<indices_offset, 32, 40>();
+                }
+                TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+#else
                 // ── stride-32 ─────────────────────────────────────────
                 // Four sort_k pairs per outer iter. The last pair folds
                 // its trailing `INCRWC(+8)` into the LREG7 store via
@@ -2145,8 +2552,23 @@ inline void _topk_xl_rebuild_generic_(const std::uint32_t dst_index, const bool 
                     store8_rows_x2_unfused<indices_offset, 32, 40 /* inc_dst_addr */>();
                 }
                 TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+#endif // TOPK_XL_UNFUSED_MACRO
             }
 
+#if TOPK_XL_UNFUSED_MACRO
+            // ── stride-16 — 16-slot macro body; every second body replays
+            // [0, 15) and emits the ADDR_MOD_2 (+24) fold tail.
+            topk_xl_unfused_macro::record_ce_full<indices_offset, 16, 8>(dir);
+            lltt::replay(0, 15);
+            topk_xl_unfused_macro::ce_tail<indices_offset, 16, 24>();
+            for (int i = 1; i < row_scale_factor; i++)
+            {
+                lltt::replay(0, 16);
+                lltt::replay(0, 15);
+                topk_xl_unfused_macro::ce_tail<indices_offset, 16, 24>();
+            }
+            TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+#else
             // ── stride-16 ─────────────────────────────────────────────
             // Two sort_k iters per outer iter. The first uses ADDR_MOD_4
             // (+8); the second folds its trailing +8 INCRWC into the
@@ -2171,6 +2593,7 @@ inline void _topk_xl_rebuild_generic_(const std::uint32_t dst_index, const bool 
                 store8_rows_x2_unfused<indices_offset, 16, 24 /* inc_dst_addr */>();
             }
             TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+#endif // TOPK_XL_UNFUSED_MACRO
 
             // ── stride-8 + sort_16_alt ────────────────────────────────
             // Clean N-iter replay (no LREG7 fold needed; the store's
@@ -2326,6 +2749,80 @@ inline void _topk_xl_add_lsb_indices_()
     //            extra outer iters needed.
     //   K=1024 → 2 face-pairs total → 1 extra outer iter here.
     //   K=2048 → 4 face-pairs total → 3 extra outer iters here.
+    constexpr int row_scale_factor = K == 512 ? 1 : K == 1024 ? 2 : 4;
+    for (int j = 1; j < row_scale_factor; j++)
+    {
+        TTI_SFPLOAD(p_sfpu::LREG4, 10, ADDR_MOD_4, 0);
+
+        for (int i = 0; i < 4; i++)
+        {
+            lltt::replay(0, 16);
+        }
+    }
+}
+
+// Runtime-chunk-id variant of `_topk_xl_add_lsb_indices_`: identical body,
+// but the 5-bit id in bits [15:11] comes from a RUNTIME argument (composed
+// via TT_SFPLOADI) instead of the template parameter — one stamp
+// instantiation serves every chunk of a fused end-to-end row. KEEP IN SYNC
+// with the template variant above; the ONLY difference is the id load.
+template <std::uint32_t K, bool APPROXIMATION_MODE>
+inline void _topk_xl_add_lsb_indices_rt_(const std::uint32_t chunk_id)
+{
+    static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
+    TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_D);
+
+    TTI_SFPMOV(0, p_sfpu::LTILEID, p_sfpu::LREG0, 0);
+
+    TTI_SFPIADD(1, p_sfpu::LREG0, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(16, p_sfpu::LREG0, p_sfpu::LREG2, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(17, p_sfpu::LREG0, p_sfpu::LREG3, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    TTI_SFPSHFT(6, 0, p_sfpu::LREG0, 1);
+
+    // Load chunk_id (runtime) and place it in bits [15:11] of every lane.
+    // Masked to the 5-bit field at composition: an out-of-contract id can
+    // only wrap within the index field, never spill into the BF16 value
+    // half (the mask is RISC-side arithmetic on the composed immediate —
+    // zero SFPU cost).
+    TT_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_USHORT, chunk_id & 0x1Fu);
+    TTI_SFPSHFT(11, 0, p_sfpu::LREG1, 1);
+
+    TTI_SFPIADD(0, p_sfpu::LREG1, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_ARG_LREG_DST | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(1, p_sfpu::LREG0, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(2, p_sfpu::LREG0, p_sfpu::LREG2, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(3, p_sfpu::LREG0, p_sfpu::LREG3, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+
+    TTI_SFPTRANSP(0, 0, 0, 0);
+
+    lltt::record<lltt::Exec>(0, 16);
+    TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+    TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_7, 2);
+    TTI_SFPLOAD(p_sfpu::LREG6, InstrModLoadStore::INT32, ADDR_MOD_7, 16 + 0);
+    TTI_SFPLOAD(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_7, 16 + 2);
+
+    TTI_SFPOR(0, p_sfpu::LREG0, p_sfpu::LREG4, 0);
+    TTI_SFPOR(0, p_sfpu::LREG1, p_sfpu::LREG5, 0);
+    TTI_SFPOR(0, p_sfpu::LREG2, p_sfpu::LREG6, 0);
+    TTI_SFPOR(0, p_sfpu::LREG3, p_sfpu::LREG7, 0);
+
+    TTI_SFPIADD(4, p_sfpu::LREG0, p_sfpu::LREG0, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(4, p_sfpu::LREG1, p_sfpu::LREG1, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(4, p_sfpu::LREG2, p_sfpu::LREG2, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+    TTI_SFPIADD(4, p_sfpu::LREG3, p_sfpu::LREG3, sfpi::SFPIADD_MOD1_ARG_IMM | sfpi::SFPIADD_MOD1_CC_NONE);
+
+    TTI_SFPSTORE(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+    TTI_SFPSTORE(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_7, 2);
+    TTI_SFPSTORE(p_sfpu::LREG6, InstrModLoadStore::INT32, ADDR_MOD_7, 16 + 0);
+    TTI_SFPSTORE(p_sfpu::LREG7, InstrModLoadStore::INT32, ADDR_MOD_6, 16 + 2);
+
+    for (int i = 1; i < 4; i++)
+    {
+        lltt::replay(0, 16);
+    }
+
     constexpr int row_scale_factor = K == 512 ? 1 : K == 1024 ? 2 : 4;
     for (int j = 1; j < row_scale_factor; j++)
     {
@@ -2568,6 +3065,68 @@ inline void _topk_xl_separate_indices_row_major_()
         TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_UPPER, 0);
         _topk_xl_decode_row_major_index_<K>();
         TTI_SFPOR(0, p_sfpu::LREG12, p_sfpu::LREG0, 0);
+
+        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_0, indices_offset);
+    }
+}
+
+// Fused end-to-end variant: like `_topk_xl_separate_indices_row_major_init_`,
+// but LREG12 carries the chunk-id FIELD MASK (bits [15:11]) instead of a
+// chunk base — the global index is recovered from the stamp itself, so no
+// per-chunk base bookkeeping exists at all.
+inline void _topk_xl_separate_indices_row_major_global_init_()
+{
+    addr_mod_t {
+        .srca = {.incr = 0},
+        .srcb = {.incr = 0},
+        .dest = {.incr = 2},
+    }
+        .set(ADDR_MOD_0);
+
+    _sfpu_load_config32_(p_sfpu::LREG12, /*upper16=*/0, /*lower16=*/0xF800);
+    _sfpu_load_config32_(p_sfpu::LREG13, /*upper16=*/0, /*lower16=*/0x000F);
+    _sfpu_load_config32_(p_sfpu::LREG14, /*upper16=*/0, /*lower16=*/0x0001);
+}
+
+// Fused end-to-end split: runs ONCE per row on the final fused survivor
+// (instead of once per chunk pre-merge). Each u16 payload carries
+// [chunk_id 15:11 | within-chunk coordinate 10:0]; the global index is
+// chunk_id * K + row-major(within-chunk). For K=2048 the stamp field IS
+// chunk_id * 2048; narrower windows shift it down to the right weight.
+// Requires `_topk_xl_separate_indices_row_major_global_init_` (LREG12 =
+// 0xF800). Only sound for rows of <= 32 chunks (5-bit id) — the factory
+// gates FUSED_E2E on the padded chunk count.
+template <std::uint32_t K, bool APPROXIMATION_MODE>
+inline void _topk_xl_separate_indices_row_major_global_()
+{
+    static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
+    constexpr int row_scale_factor       = K == 512 ? 1 : K == 1024 ? 2 : 4;
+    constexpr int num_tiles_per_sequence = K == 512 ? 1 : K == 1024 ? 1 : 2;
+    constexpr int indices_offset         = num_tiles_per_sequence * 64;
+    // chunk_id sits at [15:11] = chunk_id * 2048; rescale to chunk_id * K.
+    constexpr int chunk_field_shift = K == 2048 ? 0 : K == 1024 ? -1 : -2;
+
+    for (int i = 0; i < row_scale_factor * 16; i++)
+    {
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+
+        // Value region: keep BF16 value high half and clear low half.
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
+        TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_LOWER, 0);
+
+        // Index region: clear high half, save the raw u16 (incl. chunk id),
+        // decode the within-chunk coordinate, then OR the rescaled chunk
+        // field back in.
+        TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_UPPER, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG4, 0);
+        _topk_xl_decode_row_major_index_<K>();
+        TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG4, 0);
+        if constexpr (chunk_field_shift != 0)
+        {
+            TTI_SFPSHFT(chunk_field_shift & 0xFFF, p_sfpu::LREG4, p_sfpu::LREG4, 1);
+        }
+        TTI_SFPOR(0, p_sfpu::LREG4, p_sfpu::LREG0, 0);
 
         TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
         TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_0, indices_offset);

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_topk_xl.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/experimental/ckernel_sfpu_topk_xl.h
@@ -3139,6 +3139,56 @@ inline void _topk_xl_separate_indices_row_major_global_()
     }
 }
 
+// Segment-base variant of the global split (segmented fusion for rows wider
+// than 32 chunks): identical decode, then ORs a runtime segment base into the
+// index word. seg_base = seg * 32 * K is a multiple of 2^(5+log2(K)) while the
+// decoded local index occupies exactly those low bits, so OR == ADD with zero
+// bit overlap. LREG5 is free across the loop (body uses LREG0-4, constants
+// LREG12-14) and is loaded once per call.
+template <std::uint32_t K, bool APPROXIMATION_MODE>
+inline void _topk_xl_separate_indices_row_major_global_base_(std::uint32_t seg_base)
+{
+    static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
+    constexpr int row_scale_factor       = K == 512 ? 1 : K == 1024 ? 2 : 4;
+    constexpr int num_tiles_per_sequence = K == 512 ? 1 : K == 1024 ? 1 : 2;
+    constexpr int indices_offset         = num_tiles_per_sequence * 64;
+    constexpr int chunk_field_shift = K == 2048 ? 0 : K == 1024 ? -1 : -2;
+
+    TT_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_UPPER, (seg_base >> 16) & 0xFFFF);
+    TT_SFPLOADI(p_sfpu::LREG5, sfpi::SFPLOADI_MOD0_LOWER, seg_base & 0xFFFF);
+
+    for (int i = 0; i < row_scale_factor * 16; i++)
+    {
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG1, 0);
+        TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_LOWER, 0);
+
+        TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_UPPER, 0);
+        TTI_SFPMOV(0, p_sfpu::LREG0, p_sfpu::LREG4, 0);
+        _topk_xl_decode_row_major_index_<K>();
+        TTI_SFPAND(0, p_sfpu::LREG12, p_sfpu::LREG4, 0);
+        if constexpr (chunk_field_shift != 0)
+        {
+            TTI_SFPSHFT(chunk_field_shift & 0xFFF, p_sfpu::LREG4, p_sfpu::LREG4, 1);
+        }
+        TTI_SFPOR(0, p_sfpu::LREG4, p_sfpu::LREG0, 0);
+        TTI_SFPOR(0, p_sfpu::LREG5, p_sfpu::LREG0, 0);
+
+        TTI_SFPSTORE(p_sfpu::LREG1, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_0, indices_offset);
+    }
+}
+
+// Clears SFPU index-tracking mode (bit [2] of SFPU_CONTROL_REG) set by the
+// unfused _topk_xl_init_. Segmented rows re-enter fused merge/rebuild after
+// an unfused cross-segment fold; no shipping path ran fused merges with the
+// bit set, so clear it defensively at each segment start.
+inline void _topk_xl_index_tracking_disable_()
+{
+    _sfpu_load_config32_(0xF, 0x0, 0x0);
+}
+
 // ============================================================================
 // END TOPK_LARGE_INDICES ADDITION: row-major UINT32 index split support
 // ============================================================================

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute.cpp
@@ -10,6 +10,22 @@
 #include "api/compute/transpose_dest.h"
 #include "api/dataflow/circular_buffer.h"
 
+#include "topk_large_indices_chunk_skip.hpp"
+
+// Data-dependent chunk-skip early-out (row-parallel path only; see
+// topk_large_indices_chunk_skip.hpp for design + soundness proof).
+// One-line A/B toggle: flip to false to reproduce the pre-skip kernel
+// (kernels JIT-compile, no host rebuild needed for the toggle).
+constexpr bool kChunkSkipEnable = true;
+
+// Bring-up diagnostic: dump the post-rebuild DST values region over DPRINT to
+// calibrate rank_to_values_word against torch rank order. Never enable
+// together with performance runs.
+// #define CHUNK_SKIP_DIAG 1
+#ifdef CHUNK_SKIP_DIAG
+#include "api/debug/dprint.h"
+#endif
+
 #ifdef TRISC_MATH
 namespace ckernel::sfpu {
 
@@ -82,15 +98,24 @@ FORCE_INLINE void mark_neginf_indices(uint32_t idst) {
         ckernel::sfpu::_topk_large_indices_mark_neginf_indices_<K>, idst, VectorMode::RC_custom)));
 }
 
+// First half of chunk processing: pull the chunk from the input CB into DST.
+// Always runs -- the chunk must be resident in DST to be inspected at all.
 template <uint32_t K>
-FORCE_INLINE void process_chunk(CircularBuffer& input_cb, uint32_t dst_base, uint32_t active_elements, bool ascending) {
+FORCE_INLINE void copy_chunk(CircularBuffer& input_cb, uint32_t dst_base, uint32_t active_elements) {
     constexpr uint32_t tiles_per_sequence = (K + elements_per_tile - 1) / elements_per_tile;
     const uint32_t input_cb_id = input_cb.get_cb_id();
     input_cb.wait_front(tiles_per_sequence);
     topk_xl_copy_tile_init(input_cb_id);
     topk_xl_copy_tile<K>(input_cb_id, dst_base, 0, active_elements);
     input_cb.pop_front(tiles_per_sequence);
+}
 
+// Second half: stamp fused LSB indices, locally sort, split into unfused
+// values + row-major indices, and advance the chunk base. Skipped (except for
+// the chunk-base advance) when the chunk-skip test proves the chunk cannot
+// contribute to the final top-k.
+template <uint32_t K>
+FORCE_INLINE void finish_chunk(uint32_t dst_base, bool ascending) {
     topk_xl_add_lsb_indices_init();
     topk_xl_add_lsb_indices<K, 0>(dst_base);
 
@@ -100,6 +125,12 @@ FORCE_INLINE void process_chunk(CircularBuffer& input_cb, uint32_t dst_base, uin
     topk_xl_separate_indices_row_major_reinit();
     topk_xl_separate_indices_row_major<K>(dst_base);
     topk_xl_separate_indices_row_major_advance_chunk_base<K>();
+}
+
+template <uint32_t K>
+FORCE_INLINE void process_chunk(CircularBuffer& input_cb, uint32_t dst_base, uint32_t active_elements, bool ascending) {
+    copy_chunk<K>(input_cb, dst_base, active_elements);
+    finish_chunk<K>(dst_base, ascending);
 }
 
 }  // namespace
@@ -112,6 +143,7 @@ void kernel_main() {
     constexpr uint32_t input_cb = get_compile_time_arg_val(0);
     constexpr uint32_t indices_cb = get_compile_time_arg_val(1);
     constexpr uint32_t K = get_compile_time_arg_val(2);
+    constexpr uint32_t USER_K = get_compile_time_arg_val(3);
 
     static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
     constexpr uint32_t tiles_per_sequence = (K + elements_per_tile - 1) / elements_per_tile;
@@ -119,14 +151,22 @@ void kernel_main() {
     constexpr uint32_t slot0 = 0;
     constexpr uint32_t slot1 = sequence_tiles;
 
+    namespace skip = topk_large_indices_chunk_skip;
+
     compute_kernel_hw_startup(input_cb, indices_cb);
     pack_untilize_dest_init<tiles_per_sequence, tiles_per_sequence>(indices_cb);
+    if constexpr (kChunkSkipEnable) {
+        skip::chunk_skip_configure();
+    }
 
     CircularBuffer input_cb_obj(input_cb);
     CircularBuffer indices_cb_obj(indices_cb);
 
     for (uint32_t row = 0; row < num_rows; ++row) {
         tile_regs_acquire();
+#ifdef CHUNK_SKIP_TELEMETRY
+        skip::telemetry_row_begin(num_chunks);
+#endif
 
         topk_xl_separate_indices_row_major_init_static<0, 0>();
 
@@ -140,12 +180,57 @@ void kernel_main() {
 
         for (uint32_t chunk = 1; chunk < num_chunks; ++chunk) {
             const uint32_t active_elements = (chunk + 1 == num_chunks) ? tail_elements : K;
-            process_chunk<K>(input_cb_obj, slot1, active_elements, true);
+            copy_chunk<K>(input_cb_obj, slot1, active_elements);
+
+            if constexpr (kChunkSkipEnable) {
+#ifdef CHUNK_SKIP_TELEMETRY
+                // Telemetry variant: identical gate predicate and identical
+                // per-chunk mailbox traffic on every TRISC; the decision is
+                // recorded (MATH only) before the skip acts.
+                if (chunk >= skip::first_tested_chunk<USER_K>()) {
+                    const bool skipped = skip::chunk_skip_decide<K, USER_K>(slot1);
+                    skip::telemetry_record(chunk, skipped);
+                    if (skipped) {
+                        topk_xl_separate_indices_row_major_advance_chunk_base<K>();
+                        continue;
+                    }
+                }
+#else
+                // Gated start: chunk >= max(2, USER_K/4). The floor of 2 is a
+                // layout requirement (threshold address valid only after the
+                // first merge+rebuild); USER_K/4 amortizes the test to where
+                // skips are actually probable (see the header).
+                if (chunk >= skip::first_tested_chunk<USER_K>() && skip::chunk_skip_decide<K, USER_K>(slot1)) {
+                    // Chunk proven irrelevant (all elements strictly below
+                    // the running USER_K-th survivor). The chunk was popped;
+                    // only the MATH-side chunk-base bookkeeping must advance.
+                    topk_xl_separate_indices_row_major_advance_chunk_base<K>();
+                    continue;
+                }
+#endif
+            }
+
+            finish_chunk<K>(slot1, true);
 
             topk_xl_init<K, false>();
             topk_xl_merge<K, false>(slot0);
             topk_xl_rebuild<K, false>(slot0, false);
         }
+#ifdef CHUNK_SKIP_TELEMETRY
+        skip::telemetry_row_end<USER_K>(row, num_chunks);
+#endif
+
+#if defined(CHUNK_SKIP_DIAG) && defined(TRISC_MATH)
+        // Calibration dump: raw post-rebuild values-region words of slot0.
+        if (row == 0) {
+            skip::chunk_skip_configure();
+            ckernel::tensix_sync();
+            volatile uint32_t* mm = reinterpret_cast<volatile uint32_t*>(RISCV_DEST_START_ADDR);
+            for (uint32_t w = 0; w < tiles_per_sequence * 1024; ++w) {
+                DPRINT("DW {} {}\n", w, mm[w]);
+            }
+        }
+#endif
 
         mark_neginf_indices<K>(slot0);
         materialize_index_rank_order<K>(slot0, indices_cb);

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute.cpp
@@ -110,13 +110,20 @@ FORCE_INLINE void copy_chunk(CircularBuffer& input_cb, uint32_t dst_base, uint32
     input_cb.pop_front(tiles_per_sequence);
 }
 
-// Second half: stamp fused LSB indices, locally sort, split into unfused
-// values + row-major indices, and advance the chunk base. Skipped (except for
-// the chunk-base advance) when the chunk-skip test proves the chunk cannot
-// contribute to the final top-k.
+// Second half: stamp fused LSB indices and locally sort. FUSED_E2E rows stamp
+// the RUNTIME chunk id into index bits [15:11] and stay fused through every
+// merge/rebuild (one global split per row at the end); the classic path splits
+// to unfused values + row-major indices per chunk and advances the chunk base.
 template <uint32_t K>
-FORCE_INLINE void finish_chunk(uint32_t dst_base, bool ascending) {
+FORCE_INLINE void finish_chunk(uint32_t dst_base, bool ascending, uint32_t chunk_id) {
     topk_xl_add_lsb_indices_init();
+#ifdef FUSED_E2E
+    topk_xl_add_lsb_indices_rt<K>(dst_base, chunk_id);
+
+    topk_xl_init<K, true>();
+    topk_xl_local_sort<K>(dst_base, ascending);
+#else
+    (void)chunk_id;
     topk_xl_add_lsb_indices<K, 0>(dst_base);
 
     topk_xl_init<K, true>();
@@ -125,12 +132,30 @@ FORCE_INLINE void finish_chunk(uint32_t dst_base, bool ascending) {
     topk_xl_separate_indices_row_major_reinit();
     topk_xl_separate_indices_row_major<K>(dst_base);
     topk_xl_separate_indices_row_major_advance_chunk_base<K>();
+#endif
 }
 
+#ifdef FUSED_SEGMENTED
+// Segmented fusion (rows wider than 32 chunks): each <=32-chunk segment runs
+// the FUSED_E2E flow with a segment-LOCAL 5-bit chunk id, is split once with
+// the segment base OR'd into the decoded indices, and is folded into the
+// running cross-segment survivor with one unfused merge. See the LLK notes on
+// _topk_xl_separate_indices_row_major_global_base_.
 template <uint32_t K>
-FORCE_INLINE void process_chunk(CircularBuffer& input_cb, uint32_t dst_base, uint32_t active_elements, bool ascending) {
+FORCE_INLINE void finish_chunk_fused_local(uint32_t dst_base, bool ascending, uint32_t local_id) {
+    topk_xl_add_lsb_indices_init();
+    topk_xl_add_lsb_indices_rt<K>(dst_base, local_id);
+
+    topk_xl_init<K, true>();
+    topk_xl_local_sort<K>(dst_base, ascending);
+}
+#endif
+
+template <uint32_t K>
+FORCE_INLINE void process_chunk(
+    CircularBuffer& input_cb, uint32_t dst_base, uint32_t active_elements, bool ascending, uint32_t chunk_id) {
     copy_chunk<K>(input_cb, dst_base, active_elements);
-    finish_chunk<K>(dst_base, ascending);
+    finish_chunk<K>(dst_base, ascending, chunk_id);
 }
 
 }  // namespace
@@ -149,7 +174,19 @@ void kernel_main() {
     constexpr uint32_t tiles_per_sequence = (K + elements_per_tile - 1) / elements_per_tile;
     constexpr uint32_t sequence_tiles = tiles_per_sequence * 2u;
     constexpr uint32_t slot0 = 0;
+#ifdef FUSED_SEGMENTED
+    // Cross-segment survivor (unfused [v,i]) lives at tiles 0..2*tps-1; the
+    // in-flight fused segment at 2*tps..3*tps-1; its incoming chunk after it.
+    constexpr uint32_t slotA = sequence_tiles;
+#endif
+#ifdef FUSED_E2E
+    // Fused survivors are half the width of unfused ones (no separate index
+    // region until the final split), so the incoming chunk sits directly
+    // after the survivor — the fused merge expects its operand there.
+    constexpr uint32_t slot1 = tiles_per_sequence;
+#else
     constexpr uint32_t slot1 = sequence_tiles;
+#endif
 
     namespace skip = topk_large_indices_chunk_skip;
 
@@ -168,20 +205,80 @@ void kernel_main() {
         skip::telemetry_row_begin(num_chunks);
 #endif
 
+#ifdef FUSED_SEGMENTED
+        constexpr uint32_t seg_cap = 32;  // 5-bit local chunk id
+        const uint32_t num_segments = (num_chunks + seg_cap - 1) / seg_cap;
+        for (uint32_t seg = 0; seg < num_segments; ++seg) {
+            const uint32_t seg_first = seg * seg_cap;
+            const uint32_t seg_end = (seg_first + seg_cap < num_chunks) ? (seg_first + seg_cap) : num_chunks;
+            const uint32_t seg_last = seg_end - 1;
+            const uint32_t base = (seg == 0) ? slot0 : slotA;
+            const uint32_t chunkslot = base + tiles_per_sequence;
+            // Segments after the first rebuild their final survivor ASCENDING:
+            // the unfused cross-segment merge consumes a rank-mirrored operand
+            // against the descending survivor (the tree kernels' shipped
+            // rebuild-ascending pattern).
+            const bool mirror_last = (seg != 0);
+
+            if (seg != 0) {
+                // The unfused cross-segment init set the SFPU index-tracking
+                // bit; fused merges have never run under it -- clear it.
+                topk_xl_index_tracking_disable();
+            }
+
+            const uint32_t first_elems = (seg_first + 1 == num_chunks) ? tail_elements : K;
+            copy_chunk<K>(input_cb_obj, base, first_elems);
+            finish_chunk_fused_local<K>(base, false, 0);
+            if (seg_first == seg_last) {
+                topk_xl_rebuild<K, true>(base, mirror_last);
+            }
+            for (uint32_t chunk = seg_first + 1; chunk <= seg_last; ++chunk) {
+                const uint32_t active_elements = (chunk + 1 == num_chunks) ? tail_elements : K;
+                copy_chunk<K>(input_cb_obj, chunkslot, active_elements);
+                finish_chunk_fused_local<K>(chunkslot, true, chunk - seg_first);
+                topk_xl_merge<K, true>(base);
+                topk_xl_rebuild<K, true>(base, mirror_last && (chunk == seg_last));
+            }
+
+            // One split per segment: global index = seg*32*K + local. The
+            // in-place split writes indices at base + tps -- exactly the
+            // unfused merge's dense operand-1 slot when base == slotA, and
+            // exactly the epilogue's expected layout when base == slot0.
+            topk_xl_separate_indices_row_major_global_init();
+            topk_xl_separate_indices_row_major_global_base<K>(base, seg * (seg_cap * K));
+
+            if (seg != 0) {
+                topk_xl_init<K, false>();
+                topk_xl_merge<K, false>(slot0);
+                topk_xl_rebuild<K, false>(slot0, false);
+            }
+        }
+#else
+#ifndef FUSED_E2E
         topk_xl_separate_indices_row_major_init_static<0, 0>();
+#endif
 
         const uint32_t first_chunk_elements = (num_chunks == 1) ? tail_elements : K;
-        process_chunk<K>(input_cb_obj, slot0, first_chunk_elements, false);
+        process_chunk<K>(input_cb_obj, slot0, first_chunk_elements, false, 0);
 
         if (num_chunks == 1) {
+#ifdef FUSED_E2E
+            topk_xl_rebuild<K, true>(slot0, false);
+#else
             topk_xl_init<K, false>();
             topk_xl_rebuild<K, false>(slot0, false);
+#endif
         }
 
         for (uint32_t chunk = 1; chunk < num_chunks; ++chunk) {
             const uint32_t active_elements = (chunk + 1 == num_chunks) ? tail_elements : K;
             copy_chunk<K>(input_cb_obj, slot1, active_elements);
 
+#ifndef FUSED_E2E
+            // Chunk skip is a classic-path feature: its threshold read and
+            // chunk-max scratch assume the unfused DST layout, and every
+            // fused-eligible k=2048 row (<= 32 chunks) sits below the skip
+            // gate's first_tested_chunk anyway.
             if constexpr (kChunkSkipEnable) {
 #ifdef CHUNK_SKIP_TELEMETRY
                 // Telemetry variant: identical gate predicate and identical
@@ -209,12 +306,18 @@ void kernel_main() {
                 }
 #endif
             }
+#endif
 
-            finish_chunk<K>(slot1, true);
+            finish_chunk<K>(slot1, true, chunk);
 
+#ifdef FUSED_E2E
+            topk_xl_merge<K, true>(slot0);
+            topk_xl_rebuild<K, true>(slot0, false);
+#else
             topk_xl_init<K, false>();
             topk_xl_merge<K, false>(slot0);
             topk_xl_rebuild<K, false>(slot0, false);
+#endif
         }
 #ifdef CHUNK_SKIP_TELEMETRY
         skip::telemetry_row_end<USER_K>(row, num_chunks);
@@ -232,7 +335,17 @@ void kernel_main() {
         }
 #endif
 
+#ifdef FUSED_E2E
+        // One global split per row: recover chunk_id * K + within-chunk from
+        // the stamped fused words, leaving the exact unfused layout the
+        // epilogue below has always consumed.
+        topk_xl_separate_indices_row_major_global_init();
+        topk_xl_separate_indices_row_major_global<K>(slot0);
+#endif
+#endif  // FUSED_SEGMENTED
+#ifndef TOPK_SKIP_NEGINF_SENTINEL
         mark_neginf_indices<K>(slot0);
+#endif
         materialize_index_rank_order<K>(slot0, indices_cb);
 
         tile_regs_commit();

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute_tree.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute_tree.cpp
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Column-parallel TREE node compute (every rectangle core except the root).
+//
+// Phase 1 (leaf work): reduce this core's chunk slice to one K survivor in
+// DST, exactly like the old local kernel.
+// Phase 2 (tree work): for each of this core's num_merges winning levels,
+// consume one partner sequence from the recv CB (delivered by this core's
+// writer via the pairwise handshake), copy it to DST operand-1, and
+// merge+rebuild IN PLACE — the survivor never leaves DST between levels.
+// Phase 3 (ship): pack the survivor raw (FP32 values + UINT32 indices) for
+// the writer to send to this core's winner.
+//
+// Directions: the bitonic halver needs operand0 descending and operand1
+// ascending, so every DST-mutating action rebuilds DESCENDING except the
+// LAST one before shipping, which rebuilds ASCENDING (validated upstream by
+// test_topk_xl_rebuild_ascending: rebuild(asc) after a merge is the exact
+// rank-mirror of rebuild(desc)).
+//
+// Empty slice (valid_length cut):
+//   * num_merges == 0 -> nothing to compute; the writer ships the prefilled
+//     all--inf scratch sequence instead.
+//   * num_merges > 0 -> the FIRST partner is ADOPTED (copied to operand-0 and
+//     rebuilt) instead of merged; an ascending monotonic run is bitonic, so
+//     the rebuild is valid in either direction.
+
+#include <cstdint>
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "api/compute/pack.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/experimental/topk_xl.h"
+#include "api/dataflow/circular_buffer.h"
+
+#include "topk_large_indices_compute_common.hpp"
+
+void kernel_main() {
+    using namespace topk_large_indices;
+
+    const uint32_t num_rows = get_arg_val<uint32_t>(0);
+    const uint32_t num_chunks = get_arg_val<uint32_t>(1);
+    const uint32_t tail_elements = get_arg_val<uint32_t>(2);
+    const uint32_t start_chunk = get_arg_val<uint32_t>(3);
+    const uint32_t num_merges = get_arg_val<uint32_t>(4);
+
+    constexpr uint32_t input_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t ship_values_cb = get_compile_time_arg_val(1);
+    constexpr uint32_t ship_indices_cb = get_compile_time_arg_val(2);
+    constexpr uint32_t recv_cb = get_compile_time_arg_val(3);
+    constexpr uint32_t K = get_compile_time_arg_val(4);
+
+    static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
+    constexpr uint32_t tiles_per_sequence = (K + elements_per_tile - 1) / elements_per_tile;
+    constexpr uint32_t sequence_tiles = tiles_per_sequence * 2u;
+    constexpr uint32_t slot0 = 0;
+    constexpr uint32_t slot1 = sequence_tiles;
+
+    const bool own_empty = (num_chunks == 0);
+    // An empty slice with no partners contributes nothing; the writer ships
+    // the -inf scratch sequence.
+    if (own_empty && num_merges == 0) {
+        return;
+    }
+
+    compute_kernel_hw_startup(input_cb, ship_values_cb);
+
+    CircularBuffer input_cb_obj(input_cb);
+    CircularBuffer ship_values_obj(ship_values_cb);
+    CircularBuffer ship_indices_obj(ship_indices_cb);
+    CircularBuffer recv_obj(recv_cb);
+
+    for (uint32_t row = 0; row < num_rows; ++row) {
+        tile_regs_acquire();
+
+        if (!own_empty) {
+            // Leaf reduction of this core's chunk slice. The chunk base is
+            // latched at 0 and stepped with the all-constant advance
+            // primitive: a runtime chunk_base cannot reach the
+            // TTI-immediate config write inside the init.
+            topk_xl_separate_indices_row_major_init_static<0, 0>();
+            for (uint32_t c = 0; c < start_chunk; ++c) {
+                topk_xl_separate_indices_row_major_advance_chunk_base<K>();
+            }
+
+            const uint32_t first_chunk_elements = (num_chunks == 1) ? tail_elements : K;
+            process_chunk<K>(input_cb_obj, slot0, first_chunk_elements, false);
+
+            if (num_chunks == 1) {
+                topk_xl_init<K, false>();
+                topk_xl_rebuild<K, false>(slot0, num_merges == 0 /* ship next -> ascending */);
+            }
+
+            for (uint32_t chunk = 1; chunk < num_chunks; ++chunk) {
+                const uint32_t active_elements = (chunk + 1 == num_chunks) ? tail_elements : K;
+                process_chunk<K>(input_cb_obj, slot1, active_elements, true);
+
+                topk_xl_init<K, false>();
+                topk_xl_merge<K, false>(slot0);
+                const bool last_chunk = (chunk + 1 == num_chunks);
+                topk_xl_rebuild<K, false>(slot0, last_chunk && num_merges == 0);
+            }
+        }
+
+        // Tree merges: one partner sequence per winning level, in level order.
+        for (uint32_t m = 0; m < num_merges; ++m) {
+            const bool ship_next = (m + 1 == num_merges);
+            const bool adopt = own_empty && (m == 0);
+            const uint32_t dst_base = adopt ? slot0 : slot1;
+
+            recv_obj.wait_front(sequence_tiles);
+            // EXPLICIT format reconfig (bf16 -> UInt32): the preceding chunk phase
+            // (topk_xl_copy_tile_init) hw-configures the unpacker for the BF16
+            // input CB, and the plain _short init's state_configure is a no-op
+            // in production JIT builds (the compute-kernel sentinel is compiled
+            // out), so the _with_dt variant's llk reconfig is required here.
+            // The reverse transition is explicit inside topk_xl_copy_tile_init.
+            copy_tile_to_dst_init_short_with_dt(input_cb, recv_cb);
+            for (uint32_t t = 0; t < sequence_tiles; ++t) {
+                copy_tile(recv_cb, t, dst_base + t);
+            }
+            recv_obj.pop_front(sequence_tiles);
+
+            topk_xl_init<K, false>();
+            if (!adopt) {
+                topk_xl_merge<K, false>(slot0);
+            }
+            topk_xl_rebuild<K, false>(slot0, ship_next /* ascending for the winner's halver */);
+        }
+
+        tile_regs_commit();
+        tile_regs_wait();
+
+        // Ship the survivor raw: bit-exact FP32 value tiles then UINT32 index
+        // tiles; the winner's copy_tile round-trips the DST image unchanged.
+        ship_values_obj.reserve_back(tiles_per_sequence);
+        pack_block(slot0, ship_values_cb, tiles_per_sequence);
+        ship_values_obj.push_back(tiles_per_sequence);
+
+        ship_indices_obj.reserve_back(tiles_per_sequence);
+        pack_block(slot0 + tiles_per_sequence, ship_indices_cb, tiles_per_sequence);
+        ship_indices_obj.push_back(tiles_per_sequence);
+
+        tile_regs_release();
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute_tree_root.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute_tree_root.cpp
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Column-parallel TREE root compute (rectangle core (0,0), slice 0).
+//
+// Same leaf reduction and in-DST tree merges as compute_tree.cpp, but the
+// root never ships: every rebuild stays DESCENDING (it is always the next
+// merge's operand 0, and the final materialization emits rank order), and
+// after the last level it materializes the indices exactly like the old
+// final kernel (mark_neginf + rank-order transpose + pack_untilize).
+//
+// Slice 0 always contains at least one element (valid_length >= 1), so the
+// root never needs the empty-slice adopt path.
+
+#include <cstdint>
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "api/compute/pack_untilize.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/experimental/topk_xl.h"
+#include "api/compute/transpose_dest.h"
+#include "api/dataflow/circular_buffer.h"
+
+#include "topk_large_indices_compute_common.hpp"
+
+void kernel_main() {
+    using namespace topk_large_indices;
+
+    const uint32_t num_rows = get_arg_val<uint32_t>(0);
+    const uint32_t num_chunks = get_arg_val<uint32_t>(1);
+    const uint32_t tail_elements = get_arg_val<uint32_t>(2);
+    const uint32_t start_chunk = get_arg_val<uint32_t>(3);  // always 0 for slice 0; kept for arg-layout parity
+    const uint32_t num_merges = get_arg_val<uint32_t>(4);
+
+    constexpr uint32_t input_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t indices_out_cb = get_compile_time_arg_val(1);
+    constexpr uint32_t recv_cb = get_compile_time_arg_val(2);
+    constexpr uint32_t K = get_compile_time_arg_val(3);
+
+    static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
+    constexpr uint32_t tiles_per_sequence = (K + elements_per_tile - 1) / elements_per_tile;
+    constexpr uint32_t sequence_tiles = tiles_per_sequence * 2u;
+    constexpr uint32_t slot0 = 0;
+    constexpr uint32_t slot1 = sequence_tiles;
+
+    compute_kernel_hw_startup(input_cb, indices_out_cb);
+
+    CircularBuffer input_cb_obj(input_cb);
+    CircularBuffer indices_out_obj(indices_out_cb);
+    CircularBuffer recv_obj(recv_cb);
+
+    for (uint32_t row = 0; row < num_rows; ++row) {
+        tile_regs_acquire();
+
+        topk_xl_separate_indices_row_major_init_static<0, 0>();
+        for (uint32_t c = 0; c < start_chunk; ++c) {
+            topk_xl_separate_indices_row_major_advance_chunk_base<K>();
+        }
+
+        const uint32_t first_chunk_elements = (num_chunks == 1) ? tail_elements : K;
+        process_chunk<K>(input_cb_obj, slot0, first_chunk_elements, false);
+
+        if (num_chunks == 1) {
+            topk_xl_init<K, false>();
+            topk_xl_rebuild<K, false>(slot0, false);
+        }
+
+        for (uint32_t chunk = 1; chunk < num_chunks; ++chunk) {
+            const uint32_t active_elements = (chunk + 1 == num_chunks) ? tail_elements : K;
+            process_chunk<K>(input_cb_obj, slot1, active_elements, true);
+
+            topk_xl_init<K, false>();
+            topk_xl_merge<K, false>(slot0);
+            topk_xl_rebuild<K, false>(slot0, false);
+        }
+
+        // Tree merges: one partner sequence per level with a real partner.
+        for (uint32_t m = 0; m < num_merges; ++m) {
+            recv_obj.wait_front(sequence_tiles);
+            // EXPLICIT format reconfig (bf16 -> UInt32): the preceding chunk phase
+            // (topk_xl_copy_tile_init) hw-configures the unpacker for the BF16
+            // input CB, and the plain _short init's state_configure is a no-op
+            // in production JIT builds (the compute-kernel sentinel is compiled
+            // out), so the _with_dt variant's llk reconfig is required here.
+            // The reverse transition is explicit inside topk_xl_copy_tile_init.
+            copy_tile_to_dst_init_short_with_dt(input_cb, recv_cb);
+            for (uint32_t t = 0; t < sequence_tiles; ++t) {
+                copy_tile(recv_cb, t, slot1 + t);
+            }
+            recv_obj.pop_front(sequence_tiles);
+
+            topk_xl_init<K, false>();
+            topk_xl_merge<K, false>(slot0);
+            topk_xl_rebuild<K, false>(slot0, false);
+        }
+
+        mark_neginf_indices<K>(slot0);
+        materialize_index_rank_order<K>(slot0, indices_out_cb);
+
+        tile_regs_commit();
+        tile_regs_wait();
+
+        indices_out_obj.reserve_back(1);
+        pack_untilize_dest_init<tiles_per_sequence, tiles_per_sequence>(indices_out_cb);
+        pack_untilize_dest<tiles_per_sequence, tiles_per_sequence>(indices_out_cb, 1, 0, slot0 + tiles_per_sequence);
+        indices_out_obj.push_back(1);
+
+        tile_regs_release();
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute_tree_root.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute_tree_root.cpp
@@ -95,7 +95,9 @@ void kernel_main() {
             topk_xl_rebuild<K, false>(slot0, false);
         }
 
+#ifndef TOPK_SKIP_NEGINF_SENTINEL
         mark_neginf_indices<K>(slot0);
+#endif
         materialize_index_rank_order<K>(slot0, indices_out_cb);
 
         tile_regs_commit();

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute_tree_root_with_values.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute_tree_root_with_values.cpp
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Column-parallel TREE root compute, return_values variant: identical to
+// compute_tree_root.cpp plus the value materialization/pack (see
+// compute_with_values.cpp for the pack-ordering and fp32->bf16 notes).
+// Separate source so the indices-only tree root binary stays independent.
+
+#include <cstdint>
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "api/compute/pack_untilize.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/experimental/topk_xl.h"
+#include "api/compute/transpose_dest.h"
+#include "api/dataflow/circular_buffer.h"
+
+#include "topk_large_indices_compute_common.hpp"
+
+void kernel_main() {
+    using namespace topk_large_indices;
+
+    const uint32_t num_rows = get_arg_val<uint32_t>(0);
+    const uint32_t num_chunks = get_arg_val<uint32_t>(1);
+    const uint32_t tail_elements = get_arg_val<uint32_t>(2);
+    const uint32_t start_chunk = get_arg_val<uint32_t>(3);  // always 0 for slice 0; kept for arg-layout parity
+    const uint32_t num_merges = get_arg_val<uint32_t>(4);
+
+    constexpr uint32_t input_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t indices_out_cb = get_compile_time_arg_val(1);
+    constexpr uint32_t recv_cb = get_compile_time_arg_val(2);
+    constexpr uint32_t K = get_compile_time_arg_val(3);
+    constexpr uint32_t values_out_cb = get_compile_time_arg_val(4);
+
+    static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
+    constexpr uint32_t tiles_per_sequence = (K + elements_per_tile - 1) / elements_per_tile;
+    constexpr uint32_t sequence_tiles = tiles_per_sequence * 2u;
+    constexpr uint32_t slot0 = 0;
+    constexpr uint32_t slot1 = sequence_tiles;
+
+    compute_kernel_hw_startup(input_cb, indices_out_cb);
+
+    CircularBuffer input_cb_obj(input_cb);
+    CircularBuffer indices_out_obj(indices_out_cb);
+    CircularBuffer values_out_obj(values_out_cb);
+    CircularBuffer recv_obj(recv_cb);
+
+    for (uint32_t row = 0; row < num_rows; ++row) {
+        tile_regs_acquire();
+
+        topk_xl_separate_indices_row_major_init_static<0, 0>();
+        for (uint32_t c = 0; c < start_chunk; ++c) {
+            topk_xl_separate_indices_row_major_advance_chunk_base<K>();
+        }
+
+        const uint32_t first_chunk_elements = (num_chunks == 1) ? tail_elements : K;
+        process_chunk<K>(input_cb_obj, slot0, first_chunk_elements, false);
+
+        if (num_chunks == 1) {
+            topk_xl_init<K, false>();
+            topk_xl_rebuild<K, false>(slot0, false);
+        }
+
+        for (uint32_t chunk = 1; chunk < num_chunks; ++chunk) {
+            const uint32_t active_elements = (chunk + 1 == num_chunks) ? tail_elements : K;
+            process_chunk<K>(input_cb_obj, slot1, active_elements, true);
+
+            topk_xl_init<K, false>();
+            topk_xl_merge<K, false>(slot0);
+            topk_xl_rebuild<K, false>(slot0, false);
+        }
+
+        for (uint32_t m = 0; m < num_merges; ++m) {
+            recv_obj.wait_front(sequence_tiles);
+            // EXPLICIT format reconfig (bf16 -> UInt32): the preceding chunk phase
+            // (topk_xl_copy_tile_init) hw-configures the unpacker for the BF16
+            // input CB, and the plain _short init's state_configure is a no-op
+            // in production JIT builds (the compute-kernel sentinel is compiled
+            // out), so the _with_dt variant's llk reconfig is required here.
+            // The reverse transition is explicit inside topk_xl_copy_tile_init.
+            copy_tile_to_dst_init_short_with_dt(input_cb, recv_cb);
+            for (uint32_t t = 0; t < sequence_tiles; ++t) {
+                copy_tile(recv_cb, t, slot1 + t);
+            }
+            recv_obj.pop_front(sequence_tiles);
+
+            topk_xl_init<K, false>();
+            topk_xl_merge<K, false>(slot0);
+            topk_xl_rebuild<K, false>(slot0, false);
+        }
+
+        mark_neginf_indices<K>(slot0);
+        materialize_index_rank_order<K>(slot0, indices_out_cb);
+        materialize_values_rank_order<K>(slot0);
+
+        tile_regs_commit();
+        tile_regs_wait();
+
+        values_out_obj.reserve_back(1);
+        pack_untilize_dest_init<tiles_per_sequence, tiles_per_sequence>(values_out_cb);
+        pack_untilize_dest<tiles_per_sequence, tiles_per_sequence>(values_out_cb, 1, 0, slot0);
+        values_out_obj.push_back(1);
+
+        indices_out_obj.reserve_back(1);
+        pack_untilize_dest_init<tiles_per_sequence, tiles_per_sequence>(indices_out_cb);
+        pack_untilize_dest<tiles_per_sequence, tiles_per_sequence>(indices_out_cb, 1, 0, slot0 + tiles_per_sequence);
+        indices_out_obj.push_back(1);
+
+        tile_regs_release();
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute_tree_root_with_values.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute_tree_root_with_values.cpp
@@ -90,7 +90,9 @@ void kernel_main() {
             topk_xl_rebuild<K, false>(slot0, false);
         }
 
+#ifndef TOPK_SKIP_NEGINF_SENTINEL
         mark_neginf_indices<K>(slot0);
+#endif
         materialize_index_rank_order<K>(slot0, indices_out_cb);
         materialize_values_rank_order<K>(slot0);
 

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute_with_values.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute_with_values.cpp
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Row-parallel compute, return_values variant: identical to compute.cpp up to
+// the final materialization, then ALSO materializes and packs the FP32 value
+// region as BFLOAT16 (values sit in DST beside the indices already — the
+// unfused merge keeps [values, indices] regions; emitting values costs one
+// extra in-DST transpose pass and one extra pack_untilize per row).
+//
+// Kept as a separate source (not an #ifdef in compute.cpp) so the default
+// indices-only program's kernel binary stays byte-identical.
+//
+// Pack ordering per row: the values pack and the indices pack target CBs with
+// different formats (Float16_b vs Float32) and face geometry, so
+// pack_untilize_dest_init is re-run per pack (init derives format/geometry
+// from the output CB; back-to-back inits are the supported reconfig path).
+// The fp32->bf16 conversion in the packer is exact for the bf16-origin value
+// words, and maps the 0xFF800000 (-inf) sentinel-lane values to bf16 -inf.
+
+#include <cstdint>
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "api/compute/pack_untilize.h"
+#include "api/compute/experimental/topk_xl.h"
+#include "api/compute/transpose_dest.h"
+#include "api/dataflow/circular_buffer.h"
+
+#include "topk_large_indices_compute_common.hpp"
+#include "topk_large_indices_chunk_skip.hpp"
+
+// Data-dependent chunk-skip early-out (row-parallel path only; see
+// topk_large_indices_chunk_skip.hpp for design + soundness proof). One-line
+// A/B toggle; keep in lockstep with compute.cpp's kChunkSkipEnable.
+constexpr bool kChunkSkipEnable = true;
+
+namespace {
+
+// Copy-only half of topk_large_indices::process_chunk (kept local: the shared
+// common header also feeds the column-parallel tree kernels, which must stay
+// untouched by chunk-skip work).
+template <uint32_t K>
+FORCE_INLINE void copy_chunk_only(CircularBuffer& input_cb, uint32_t dst_base, uint32_t active_elements) {
+    constexpr uint32_t tiles = (K + topk_large_indices::elements_per_tile - 1) / topk_large_indices::elements_per_tile;
+    const uint32_t input_cb_id = input_cb.get_cb_id();
+    input_cb.wait_front(tiles);
+    topk_xl_copy_tile_init(input_cb_id);
+    topk_xl_copy_tile<K>(input_cb_id, dst_base, 0, active_elements);
+    input_cb.pop_front(tiles);
+}
+
+// Sort/split half of topk_large_indices::process_chunk.
+template <uint32_t K>
+FORCE_INLINE void finish_chunk_only(uint32_t dst_base, bool ascending) {
+    topk_xl_add_lsb_indices_init();
+    topk_xl_add_lsb_indices<K, 0>(dst_base);
+
+    topk_xl_init<K, true>();
+    topk_xl_local_sort<K>(dst_base, ascending);
+
+    topk_xl_separate_indices_row_major_reinit();
+    topk_xl_separate_indices_row_major<K>(dst_base);
+    topk_xl_separate_indices_row_major_advance_chunk_base<K>();
+}
+
+}  // namespace
+
+void kernel_main() {
+    using namespace topk_large_indices;
+
+    const uint32_t num_rows = get_arg_val<uint32_t>(0);
+    const uint32_t num_chunks = get_arg_val<uint32_t>(1);
+    const uint32_t tail_elements = get_arg_val<uint32_t>(2);
+
+    constexpr uint32_t input_cb = get_compile_time_arg_val(0);
+    constexpr uint32_t indices_cb = get_compile_time_arg_val(1);
+    constexpr uint32_t K = get_compile_time_arg_val(2);
+    constexpr uint32_t values_cb = get_compile_time_arg_val(3);
+    constexpr uint32_t USER_K = get_compile_time_arg_val(4);
+
+    static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
+    constexpr uint32_t tiles_per_sequence = (K + elements_per_tile - 1) / elements_per_tile;
+    constexpr uint32_t sequence_tiles = tiles_per_sequence * 2u;
+    constexpr uint32_t slot0 = 0;
+    constexpr uint32_t slot1 = sequence_tiles;
+
+    namespace skip = topk_large_indices_chunk_skip;
+
+    compute_kernel_hw_startup(input_cb, indices_cb);
+    if constexpr (kChunkSkipEnable) {
+        skip::chunk_skip_configure();
+    }
+
+    CircularBuffer input_cb_obj(input_cb);
+    CircularBuffer indices_cb_obj(indices_cb);
+    CircularBuffer values_cb_obj(values_cb);
+
+    for (uint32_t row = 0; row < num_rows; ++row) {
+        tile_regs_acquire();
+#ifdef CHUNK_SKIP_TELEMETRY
+        skip::telemetry_row_begin(num_chunks);
+#endif
+
+        topk_xl_separate_indices_row_major_init_static<0, 0>();
+
+        const uint32_t first_chunk_elements = (num_chunks == 1) ? tail_elements : K;
+        process_chunk<K>(input_cb_obj, slot0, first_chunk_elements, false);
+
+        if (num_chunks == 1) {
+            topk_xl_init<K, false>();
+            topk_xl_rebuild<K, false>(slot0, false);
+        }
+
+        for (uint32_t chunk = 1; chunk < num_chunks; ++chunk) {
+            const uint32_t active_elements = (chunk + 1 == num_chunks) ? tail_elements : K;
+            copy_chunk_only<K>(input_cb_obj, slot1, active_elements);
+
+            if constexpr (kChunkSkipEnable) {
+#ifdef CHUNK_SKIP_TELEMETRY
+                // Telemetry variant: identical gate predicate and identical
+                // per-chunk mailbox traffic on every TRISC (see compute.cpp).
+                if (chunk >= skip::first_tested_chunk<USER_K>()) {
+                    const bool skipped = skip::chunk_skip_decide<K, USER_K>(slot1);
+                    skip::telemetry_record(chunk, skipped);
+                    if (skipped) {
+                        topk_xl_separate_indices_row_major_advance_chunk_base<K>();
+                        continue;
+                    }
+                }
+#else
+                if (chunk >= skip::first_tested_chunk<USER_K>() && skip::chunk_skip_decide<K, USER_K>(slot1)) {
+                    topk_xl_separate_indices_row_major_advance_chunk_base<K>();
+                    continue;
+                }
+#endif
+            }
+
+            finish_chunk_only<K>(slot1, true);
+
+            topk_xl_init<K, false>();
+            topk_xl_merge<K, false>(slot0);
+            topk_xl_rebuild<K, false>(slot0, false);
+        }
+#ifdef CHUNK_SKIP_TELEMETRY
+        skip::telemetry_row_end<USER_K>(row, num_chunks);
+#endif
+
+        mark_neginf_indices<K>(slot0);
+        materialize_index_rank_order<K>(slot0, indices_cb);
+        materialize_values_rank_order<K>(slot0);
+
+        tile_regs_commit();
+        tile_regs_wait();
+
+        values_cb_obj.reserve_back(1);
+        pack_untilize_dest_init<tiles_per_sequence, tiles_per_sequence>(values_cb);
+        pack_untilize_dest<tiles_per_sequence, tiles_per_sequence>(values_cb, 1, 0, slot0);
+        values_cb_obj.push_back(1);
+
+        indices_cb_obj.reserve_back(1);
+        pack_untilize_dest_init<tiles_per_sequence, tiles_per_sequence>(indices_cb);
+        pack_untilize_dest<tiles_per_sequence, tiles_per_sequence>(indices_cb, 1, 0, slot0 + tiles_per_sequence);
+        indices_cb_obj.push_back(1);
+
+        tile_regs_release();
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute_with_values.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute_with_values.cpp
@@ -49,10 +49,19 @@ FORCE_INLINE void copy_chunk_only(CircularBuffer& input_cb, uint32_t dst_base, u
     input_cb.pop_front(tiles);
 }
 
-// Sort/split half of topk_large_indices::process_chunk.
+// Sort half of topk_large_indices::process_chunk. FUSED_E2E stamps the
+// runtime chunk id and stays fused (one global split per row at the end);
+// the classic path splits to unfused per chunk (see compute.cpp).
 template <uint32_t K>
-FORCE_INLINE void finish_chunk_only(uint32_t dst_base, bool ascending) {
+FORCE_INLINE void finish_chunk_only(uint32_t dst_base, bool ascending, uint32_t chunk_id) {
     topk_xl_add_lsb_indices_init();
+#ifdef FUSED_E2E
+    topk_xl_add_lsb_indices_rt<K>(dst_base, chunk_id);
+
+    topk_xl_init<K, true>();
+    topk_xl_local_sort<K>(dst_base, ascending);
+#else
+    (void)chunk_id;
     topk_xl_add_lsb_indices<K, 0>(dst_base);
 
     topk_xl_init<K, true>();
@@ -61,7 +70,21 @@ FORCE_INLINE void finish_chunk_only(uint32_t dst_base, bool ascending) {
     topk_xl_separate_indices_row_major_reinit();
     topk_xl_separate_indices_row_major<K>(dst_base);
     topk_xl_separate_indices_row_major_advance_chunk_base<K>();
+#endif
 }
+
+#ifdef FUSED_SEGMENTED
+// Segment-local fused finish: runtime stamp of the segment-LOCAL chunk id
+// (see compute.cpp's segmented body).
+template <uint32_t K>
+FORCE_INLINE void finish_chunk_fused_local(uint32_t dst_base, bool ascending, uint32_t local_id) {
+    topk_xl_add_lsb_indices_init();
+    topk_xl_add_lsb_indices_rt<K>(dst_base, local_id);
+
+    topk_xl_init<K, true>();
+    topk_xl_local_sort<K>(dst_base, ascending);
+}
+#endif
 
 }  // namespace
 
@@ -82,7 +105,14 @@ void kernel_main() {
     constexpr uint32_t tiles_per_sequence = (K + elements_per_tile - 1) / elements_per_tile;
     constexpr uint32_t sequence_tiles = tiles_per_sequence * 2u;
     constexpr uint32_t slot0 = 0;
+#ifdef FUSED_SEGMENTED
+    constexpr uint32_t slotA = sequence_tiles;  // in-flight fused segment (see compute.cpp)
+#endif
+#ifdef FUSED_E2E
+    constexpr uint32_t slot1 = tiles_per_sequence;  // fused survivor is half-width (see compute.cpp)
+#else
     constexpr uint32_t slot1 = sequence_tiles;
+#endif
 
     namespace skip = topk_large_indices_chunk_skip;
 
@@ -101,20 +131,70 @@ void kernel_main() {
         skip::telemetry_row_begin(num_chunks);
 #endif
 
+#ifdef FUSED_SEGMENTED
+        // Segmented fusion; identical structure to compute.cpp's segmented
+        // body (see the comments there), using this kernel's chunk helpers.
+        constexpr uint32_t seg_cap = 32;
+        const uint32_t num_segments = (num_chunks + seg_cap - 1) / seg_cap;
+        for (uint32_t seg = 0; seg < num_segments; ++seg) {
+            const uint32_t seg_first = seg * seg_cap;
+            const uint32_t seg_end = (seg_first + seg_cap < num_chunks) ? (seg_first + seg_cap) : num_chunks;
+            const uint32_t seg_last = seg_end - 1;
+            const uint32_t base = (seg == 0) ? slot0 : slotA;
+            const uint32_t chunkslot = base + tiles_per_sequence;
+            const bool mirror_last = (seg != 0);
+
+            if (seg != 0) {
+                topk_xl_index_tracking_disable();
+            }
+
+            const uint32_t first_elems = (seg_first + 1 == num_chunks) ? tail_elements : K;
+            copy_chunk_only<K>(input_cb_obj, base, first_elems);
+            finish_chunk_fused_local<K>(base, false, 0);
+            if (seg_first == seg_last) {
+                topk_xl_rebuild<K, true>(base, mirror_last);
+            }
+            for (uint32_t chunk = seg_first + 1; chunk <= seg_last; ++chunk) {
+                const uint32_t active_elements = (chunk + 1 == num_chunks) ? tail_elements : K;
+                copy_chunk_only<K>(input_cb_obj, chunkslot, active_elements);
+                finish_chunk_fused_local<K>(chunkslot, true, chunk - seg_first);
+                topk_xl_merge<K, true>(base);
+                topk_xl_rebuild<K, true>(base, mirror_last && (chunk == seg_last));
+            }
+
+            topk_xl_separate_indices_row_major_global_init();
+            topk_xl_separate_indices_row_major_global_base<K>(base, seg * (seg_cap * K));
+
+            if (seg != 0) {
+                topk_xl_init<K, false>();
+                topk_xl_merge<K, false>(slot0);
+                topk_xl_rebuild<K, false>(slot0, false);
+            }
+        }
+#else
+#ifndef FUSED_E2E
         topk_xl_separate_indices_row_major_init_static<0, 0>();
+#endif
 
         const uint32_t first_chunk_elements = (num_chunks == 1) ? tail_elements : K;
-        process_chunk<K>(input_cb_obj, slot0, first_chunk_elements, false);
+        copy_chunk_only<K>(input_cb_obj, slot0, first_chunk_elements);
+        finish_chunk_only<K>(slot0, false, 0);
 
         if (num_chunks == 1) {
+#ifdef FUSED_E2E
+            topk_xl_rebuild<K, true>(slot0, false);
+#else
             topk_xl_init<K, false>();
             topk_xl_rebuild<K, false>(slot0, false);
+#endif
         }
 
         for (uint32_t chunk = 1; chunk < num_chunks; ++chunk) {
             const uint32_t active_elements = (chunk + 1 == num_chunks) ? tail_elements : K;
             copy_chunk_only<K>(input_cb_obj, slot1, active_elements);
 
+#ifndef FUSED_E2E
+            // Chunk skip is a classic-path feature (unfused DST layout).
             if constexpr (kChunkSkipEnable) {
 #ifdef CHUNK_SKIP_TELEMETRY
                 // Telemetry variant: identical gate predicate and identical
@@ -134,18 +214,31 @@ void kernel_main() {
                 }
 #endif
             }
+#endif
 
-            finish_chunk_only<K>(slot1, true);
+            finish_chunk_only<K>(slot1, true, chunk);
 
+#ifdef FUSED_E2E
+            topk_xl_merge<K, true>(slot0);
+            topk_xl_rebuild<K, true>(slot0, false);
+#else
             topk_xl_init<K, false>();
             topk_xl_merge<K, false>(slot0);
             topk_xl_rebuild<K, false>(slot0, false);
+#endif
         }
 #ifdef CHUNK_SKIP_TELEMETRY
         skip::telemetry_row_end<USER_K>(row, num_chunks);
 #endif
 
+#ifdef FUSED_E2E
+        topk_xl_separate_indices_row_major_global_init();
+        topk_xl_separate_indices_row_major_global<K>(slot0);
+#endif
+#endif  // FUSED_SEGMENTED
+#ifndef TOPK_SKIP_NEGINF_SENTINEL
         mark_neginf_indices<K>(slot0);
+#endif
         materialize_index_rank_order<K>(slot0, indices_cb);
         materialize_values_rank_order<K>(slot0);
 

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/reader_local.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/reader_local.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Column-parallel local reader: identical to reader.cpp except each core reads
+// only its contiguous slice of every row, offset by slice_offset_bytes.
+// Kept as a separate kernel (instead of an extra runtime arg on reader.cpp) so
+// the row-parallel path's reader source stays byte-identical — its JIT cache
+// entry, binary, and perf baselines are untouched by the column-parallel work.
+
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t start_row = get_arg_val<uint32_t>(1);
+    const uint32_t num_rows = get_arg_val<uint32_t>(2);
+    const uint32_t num_chunks = get_arg_val<uint32_t>(3);
+    const uint32_t tail_chunk_bytes = get_arg_val<uint32_t>(4);
+    const uint32_t input_page_bytes = get_arg_val<uint32_t>(5);
+    // Byte offset of this core's slice within each row. An empty slice
+    // (num_chunks == 0, valid_length cut) reads nothing.
+    const uint32_t slice_offset_bytes = get_arg_val<uint32_t>(6);
+
+    constexpr uint32_t cb_in = get_compile_time_arg_val(0);
+    constexpr uint32_t chunk_bytes = get_compile_time_arg_val(1);
+    constexpr uint32_t tile_bytes = get_compile_time_arg_val(2);
+    constexpr uint32_t tiles_per_chunk = get_compile_time_arg_val(3);
+    constexpr auto input_args = TensorAccessorArgs<4>();
+
+    const auto input = TensorAccessor(input_args, src_addr, input_page_bytes);
+    CircularBuffer input_cb(cb_in);
+    Noc noc;
+
+    for (uint32_t local_row = 0; local_row < num_rows; ++local_row) {
+        const uint32_t row = start_row + local_row;
+        for (uint32_t chunk = 0; chunk < num_chunks; ++chunk) {
+            const uint32_t active_chunk_bytes = (chunk + 1 == num_chunks) ? tail_chunk_bytes : chunk_bytes;
+            input_cb.reserve_back(tiles_per_chunk);
+            for (uint32_t tile = 0; tile < tiles_per_chunk; ++tile) {
+                const uint32_t tile_offset = tile * tile_bytes;
+                const uint32_t read_bytes =
+                    tile_offset < active_chunk_bytes
+                        ? (active_chunk_bytes - tile_offset < tile_bytes ? active_chunk_bytes - tile_offset
+                                                                         : tile_bytes)
+                        : 0;
+                if (read_bytes != 0) {
+                    noc.async_read(
+                        input,
+                        input_cb,
+                        read_bytes,
+                        {.page_id = row, .offset_bytes = slice_offset_bytes + chunk * chunk_bytes + tile_offset},
+                        {.offset_bytes = tile_offset});
+                }
+            }
+            noc.async_read_barrier();
+            input_cb.push_back(tiles_per_chunk);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/reader_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/reader_tile.cpp
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// TILE-layout input reader (shared by the row-parallel and column-parallel
+// factories; the per-core slice offset arrives as start_element, 0 on the
+// row-parallel path). Reads each LLK chunk of a logical row straight out of
+// the tile-padded input tensor into the same contiguous chunk layout the
+// ROW_MAJOR readers (reader.cpp / reader_local.cpp) produce, so the compute
+// kernels are untouched. This lets callers skip the untilize op entirely —
+// for a single logical row it also skips untilize's 32x tile-padding read
+// amplification (only the row's own face rows are pulled from DRAM).
+//
+// A 32x32 bf16 tile stores four 16x16 faces contiguously (f0 rows0-15/
+// cols0-15, f1 rows0-15/cols16-31, f2, f3): one logical row contributes one
+// 32-byte face row per 16 columns. Blackhole NoC DRAM READS require 64-byte
+// congruence between the DRAM and L1 addresses ((l1 & 63) == (dram & 63));
+// the chunk CB's 32-byte-stride slice destinations alternate 0/32 mod 64
+// while a row's DRAM face-row offsets are constant mod 64, so no direct CB
+// placement satisfies every slice. The reader therefore stages every slice:
+//   phase A: one 64-byte read per 16-element slice, from the 64-aligned
+//            offset at/below the face row into a 64-byte-stride staging slot
+//            (both ends 64-aligned -> congruent; the extra 32 bytes are the
+//            neighboring face row, discarded). Never crosses the tile page
+//            end: the last face row starts 64 bytes before it.
+//   phase B: one 32-byte local L1 copy per slice from slot + delta into the
+//            chunk CB, delta = (face_row & 1) * 32 (constant per row; 16-byte
+//            L1 congruence holds since delta is a multiple of 16).
+//
+// Tail chunks read only ceil(active_elements / 16) slices; the CB tail beyond
+// them is stale, exactly like the ROW_MAJOR readers, and the compute masks by
+// active element count. Tile padding COLUMNS inside a read slice are likewise
+// masked by the compute (search width comes from the logical shape).
+
+#include "api/core_local_mem.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);
+    const uint32_t start_row = get_arg_val<uint32_t>(1);
+    const uint32_t num_rows = get_arg_val<uint32_t>(2);
+    const uint32_t num_chunks = get_arg_val<uint32_t>(3);
+    const uint32_t tail_slices = get_arg_val<uint32_t>(4);
+    const uint32_t w_tiles = get_arg_val<uint32_t>(5);         // padded input width / 32
+    const uint32_t rows_2d = get_arg_val<uint32_t>(6);         // logical shape[-2] (1 for rank < 2)
+    const uint32_t start_in_slice = get_arg_val<uint32_t>(7);  // start_row % rows_2d
+    const uint32_t start_slice = get_arg_val<uint32_t>(8);     // start_row / rows_2d
+    const uint32_t start_element = get_arg_val<uint32_t>(9);   // column-parallel slice offset (elements)
+
+    constexpr uint32_t cb_in = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_stage = get_compile_time_arg_val(1);
+    constexpr uint32_t slices_per_chunk = get_compile_time_arg_val(2);  // llk_k / 16
+    constexpr uint32_t tiles_per_chunk = get_compile_time_arg_val(3);   // CB pages per chunk
+    constexpr auto input_args = TensorAccessorArgs<4>();
+
+    constexpr uint32_t input_tile_bytes = 32 * 32 * 2;  // bf16 tile page
+    const auto input = TensorAccessor(input_args, src_addr, input_tile_bytes);
+    CircularBuffer input_cb(cb_in);
+    CircularBuffer stage_cb(cb_stage);
+    Noc noc;
+
+    // The staging slots must be 64-byte aligned for DRAM-read congruence; the
+    // CB base itself is only guaranteed 16-byte aligned, so align up (the CB
+    // is sized with 64 bytes of slack). Held reserved for the whole kernel.
+    stage_cb.reserve_back(1);
+    const uint32_t stage_base = (stage_cb.get_write_ptr() + 63u) & ~63u;
+
+    const uint32_t noc_id = noc.get_noc_id();
+    const auto local_src = [noc_id](uint32_t addr) {
+        return noc_traits_t<UnicastEndpoint>::src_args_type{
+            .noc_x = static_cast<uint32_t>(my_x[noc_id]), .noc_y = static_cast<uint32_t>(my_y[noc_id]), .addr = addr};
+    };
+
+    const uint32_t tiles_per_slice_h = (rows_2d + 31u) >> 5;
+    uint32_t slice_idx = start_slice;
+    uint32_t in_slice_row = start_in_slice;
+    (void)start_row;
+
+    for (uint32_t local_row = 0; local_row < num_rows; ++local_row) {
+        const uint32_t tile_row = slice_idx * tiles_per_slice_h + (in_slice_row >> 5);
+        const uint32_t in_tile_r = in_slice_row & 31u;
+        const uint32_t face_row = in_tile_r & 15u;
+        // Byte offset of this row's face-column-0 run within a tile, split into
+        // the 64-aligned base and the constant sub-64 delta.
+        const uint32_t row_face_bytes = (((in_tile_r >> 4) & 1u) * 512u + face_row * 16u) * 2u;
+        const uint32_t delta = row_face_bytes & 63u;  // (face_row & 1) * 32
+        const uint32_t aligned_base = row_face_bytes & ~63u;
+
+        for (uint32_t chunk = 0; chunk < num_chunks; ++chunk) {
+            const uint32_t active_slices = (chunk + 1 == num_chunks) ? tail_slices : slices_per_chunk;
+            input_cb.reserve_back(tiles_per_chunk);
+            const uint32_t cb_base = input_cb.get_write_ptr();
+            const uint32_t chunk_col = start_element + chunk * (slices_per_chunk * 16u);
+
+            for (uint32_t s = 0; s < active_slices; ++s) {
+                const uint32_t col = chunk_col + s * 16u;
+                const uint32_t page = tile_row * w_tiles + (col >> 5);
+                const uint32_t src_off = aligned_base + ((col >> 4) & 1u) * 512u;  // 64-aligned
+                noc.async_read(
+                    input,
+                    CoreLocalMem<uint32_t>(stage_base + s * 64u),
+                    64,
+                    {.page_id = page, .offset_bytes = src_off},
+                    {.offset_bytes = 0});
+            }
+            noc.async_read_barrier();
+
+            noc.set_async_read_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+                UnicastEndpoint{}, 32, local_src(stage_base));
+            for (uint32_t s = 0; s < active_slices; ++s) {
+                noc.async_read_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+                    UnicastEndpoint{},
+                    CoreLocalMem<uint32_t>(cb_base + s * 32u),
+                    32,
+                    local_src(stage_base + s * 64u + delta),
+                    {.offset_bytes = 0});
+            }
+            noc.async_read_barrier();
+            input_cb.push_back(tiles_per_chunk);
+        }
+
+        if (++in_slice_row == rows_2d) {
+            in_slice_row = 0;
+            ++slice_idx;
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/topk_large_indices_chunk_skip.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/topk_large_indices_chunk_skip.hpp
@@ -170,8 +170,8 @@ constexpr uint32_t first_tested_chunk() {
 //
 // i.e. the post-rebuild descending window is COLUMN-MAJOR over the values
 // region's populated physical rows (32 rows for K=512 -- the top half-tile --
-// 64 for K=1024, 128 for K=2048), 16 words per row. Calibration data:
-// scratchpad storm/tileskip/diag/dprint_k{512,1024,2048}.txt.
+// 64 for K=1024, 128 for K=2048), 16 words per row. Calibrated on silicon
+// by exhaustive DST dumps against torch rank order at all three windows.
 //
 // Soundness note: an address error here would be UNSOUND only if it pointed
 // at a HIGHER-ranked (larger) element; the exhaustive per-rank calibration

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/topk_large_indices_chunk_skip.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/topk_large_indices_chunk_skip.hpp
@@ -1,0 +1,371 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Data-dependent chunk-skip early-out for the ROW-PARALLEL topk_large_indices
+// compute kernels (compute.cpp / compute_with_values.cpp) ONLY. The
+// column-parallel merge-tree kernels must not include this header: their
+// per-slice streams are 1-5 chunks long and the skip probability there is
+// ~0 on any realistic distribution (measured in the tileskip forecast), so
+// the test would be pure regression.
+//
+// MECHANISM
+// ---------
+// The row-parallel leaf loop streams all N/K chunks of a row through one
+// core: per chunk it pays copy + lsb-stamp + fused bitonic sort + index
+// split + merge + rebuild (~2 merge units). For chunk c >= kFirstTestedChunk
+// we test, right after the (unavoidable) copy of the chunk into DST, whether
+// the chunk can possibly contribute to the final top-USER_K:
+//
+//     skip  iff  max(chunk) < T,   T = running USER_K-th largest survivor
+//
+// where T is read from the resident sorted-descending window in DST (the
+// unfused values region of slot0, refreshed by every merge+rebuild) at the
+// DST location holding rank USER_K-1.
+//
+// SOUNDNESS (exact top-k value multiset is preserved)
+// ---------------------------------------------------
+// Invariant: at test time, T equals the USER_K-th largest value of ALL row
+// elements seen so far (processed or skipped). Proof sketch, by induction:
+//   * The resident window holds the top-llk_K of all *merged* elements, and
+//     USER_K <= llk_K, so rank USER_K-1 of the window is the USER_K-th
+//     largest merged element.
+//   * Every skipped element was < T_at_its_skip_time <= current T (T is
+//     monotone non-decreasing: merges only improve the window), so skipped
+//     elements never displace the top-USER_K of the merged set; the USER_K-th
+//     largest of "merged" equals that of "all seen".
+// Now let x be any element of an exact top-USER_K set of the full row, i.e.
+// x >= v_k, the final USER_K-th largest value. Since T <= v_k at all times
+// (at most USER_K-1 elements ever exceed v_k), a chunk containing x has
+// chunk_max >= x >= v_k >= T, so the STRICT test chunk_max < T never fires
+// on it: every top-k candidate enters the window, survives every subsequent
+// top-llk_K merge (it stays within the top-USER_K <= top-llk_K), and reaches
+// the output. Conversely a skipped element is < T <= v_k and belongs to no
+// exact top-k set. Boundary ties (chunk_max == T) are NOT skipped, so tie
+// candidates at v_k always enter the merge; tie *membership* is resolved by
+// the same deterministic merge order as before among the entrants. Skip
+// decisions are pure functions of the input data, so results remain
+// deterministic for a fixed input (stable=false tie semantics, as shipped).
+//
+// DECISION MACHINERY (silicon-validated components)
+// -------------------------------------------------
+// * MATH computes max(chunk) on the SFPU: 32 SFPLOADs per 32-bit DST tile
+//   (auto-advance-2 walk covers all 1024 datums; validated by the cgtceq
+//   bench walk model), lane-wise SFPSWAP/ALL_ROWS_MAX accumulate, then a
+//   full cross-lane max fold (SFPTRANSP + 3 SWAPs + 7x(SFPSHFT2-ROR1 +
+//   SFPNOP + SWAP) -- the ROR1 needs a trailing SFPNOP, and rotations pull
+//   from the RUNNING max because SFPSWAP clobbers both operands).
+// * The folded max is SFPSTOREd (raw bits, InstrModLoadStore::INT32) into
+//   the first INDICES tile of the chunk's own DST sequence -- dead space at
+//   test time: the index split only writes it later, and only when the chunk
+//   is NOT skipped.
+// * MATH RISC does tensix_sync() then reads both the folded max and the
+//   threshold word through the memory-mapped DST window @0xFFBD8000
+//   (RISC_DEST_ACCESS_CTRL SEC1 configured once per kernel for Float32 +
+//   swizzle: on Blackhole this returns raw fp32 words at word index
+//   row*16+col -- the in-tree dprint_tensix_dest_reg float32 path). The
+//   tensix_sync/fold/single-word-read rendezvous is the 81-cycle S0/R0
+//   arrangement validated in tt_metal/tt-llk/tests/sources/cgtceq_perf.cpp;
+//   the same sync also orders the preceding rebuild's stores, so the
+//   threshold read needs no extra sync.
+// * The compare runs on the MATH RISC in sign-magnitude (== IEEE float)
+//   order via a monotone bit transform. Values are bit-exact bf16<<16
+//   payloads end to end (the value words move through sort/merge with
+//   bit-exact 32-bit ops), and the bf16 datapath admits no NaNs (canonical-
+//   ized to inf on ingest), so sign-magnitude order is total and correct.
+// * Cross-TRISC propagation: MATH -> UNPACK through the T1->T0 hardware
+//   mailbox (ckernel::mailbox_write / blocking mailbox_read). NOTE: this op's
+//   copy path ALREADY uses the same T1->T0 FIFO -- topk_xl_copy's
+//   unpack-to-dest handoff mails dst_index per tile (cmath_common.h
+//   set_dst_write_addr<.., UnpackDestination::DestReg>). That stays safe
+//   because the FIFO is order-preserving, single-writer/single-reader, and
+//   both threads issue their reads/writes in identical per-chunk program
+//   order with identical branch predicates: [dst_index x tiles] then
+//   [skip decision, tested chunks only]. Exactly one skip write pairs with
+//   exactly one skip read; worst-case FIFO occupancy is 3 (skip + 2 dst_index
+//   at K=2048), within the depth-4 hardware FIFO, and an overflow would only
+//   stall the writer, not reorder. PACK has no per-chunk work in the leaf
+//   loop and needs no decision.
+// * UNPACK must branch in tandem with MATH: its per-chunk conditional work is
+//   the two llk_unpack_set_srcb_dummy_valid() calls (local_sort + rebuild).
+//   Issuing them for a skipped chunk would leave SrcA/SrcB banks valid with
+//   no consumer (the skipped sort never runs its CLEARDVALID), wedging the
+//   next chunk's real unpack -- hence the mailbox, not an unconditional path.
+//
+// WHY THE CHUNK IS STILL UNPACKED: the copy into DST is the only way to
+// inspect the data; skipping saves the fused sort + index split + merge +
+// rebuild (the ~2 "merge units" that dominate the leaf loop).
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/compute_kernel_api.h"
+
+#ifdef TRISC_MATH
+#include "ckernel_dest.h"  // configure_dest_access, RISCV_DEST_START_ADDR
+#endif
+
+// Bring-up tracing of every decision (MATH). Never enable with perf runs.
+// #define CHUNK_SKIP_DEBUG 1
+#if defined(CHUNK_SKIP_DEBUG) && defined(TRISC_MATH)
+#include "api/debug/dprint.h"
+#endif
+
+// Skip-rate telemetry (paper gap G4): per-row skipped-chunk count plus a
+// per-position skip bitmask, emitted by MATH over DPRINT once per row,
+// OUTSIDE the chunk loop. Observation only -- outputs must stay bit-exact.
+// DPRINT serializes: never enable together with perf runs or the device
+// profiler, and always run with the DPRINT server up (TT_METAL_DPRINT_CORES
+// set), otherwise the kernel-side writer stalls. When left undefined (the
+// default) every telemetry token preprocesses away and the compiled kernels
+// are byte-identical to the pre-telemetry binaries (same guarantee class as
+// CHUNK_SKIP_DEBUG).
+// #define CHUNK_SKIP_TELEMETRY 1
+#if defined(CHUNK_SKIP_TELEMETRY) && defined(TRISC_MATH)
+#include "api/debug/dprint.h"
+#endif
+
+namespace topk_large_indices_chunk_skip {
+
+// First chunk index eligible for the skip test.
+//
+// Floor of 2: chunk 0 seeds the window and chunk 1 tests against a window
+// that has only been LOCALLY sorted (its DST layout is the post-local-sort
+// one, not the post-rebuild rank layout the threshold address below assumes).
+//
+// Amortization gate USER_K/4: for iid data the skip probability at stream
+// position c is P = C(c*K, USER_K)/C((c+1)*K, USER_K) ~= e^(-USER_K/(c+1)),
+// negligible (< e^-4 ~= 1.8%) below c = USER_K/4 -- there the test is pure
+// overhead (~150-350 ns/chunk, measured ungated: +6.8% at user_k=512@128
+// chunks, +1.8% at user_k=1536@25 chunks, while forfeiting < 1 expected skip
+// per row). The gate is a compile-time function of USER_K only, so all
+// TRISCs derive the identical tested-chunk set.
+//
+// Gate-divisor A/B knob: default 4 == the shipping USER_K/4 constant (the
+// default compiles to identical code). Swept in-source by
+// tests/.../_topk_large_indices_gate_ab.sh, which sed-edits the value per
+// arm (JIT rehash, no host rebuild). Do NOT change the default without the
+// full A/B evidence + guard battery (see the harness header + RUN_PLAN).
+#ifndef CHUNK_SKIP_GATE_DIVISOR
+#define CHUNK_SKIP_GATE_DIVISOR 4
+#endif
+template <uint32_t USER_K>
+constexpr uint32_t first_tested_chunk() {
+    constexpr uint32_t layout_floor = 2;
+    constexpr uint32_t amortization_floor = USER_K / CHUNK_SKIP_GATE_DIVISOR;
+    return amortization_floor > layout_floor ? amortization_floor : layout_floor;
+}
+
+// ---------------------------------------------------------------------------
+// rank -> DST MMIO word address of the resident window's values region
+// (slot0, MMIO word = physical_row*16 + col).
+//
+// EMPIRICALLY CALIBRATED ON SILICON (p150a, 2026-08-16): the CHUNK_SKIP_DIAG
+// dump in compute.cpp was run per K with a distinct-monotone bf16 input
+// (bits 0x3800+j) and every dumped word matched against torch rank order.
+// Result, exact for all ranks of all three windows (512/1024/2048 of 512/
+// 1024/2048 words):
+//
+//     word(r) = (r % rows) * 16 + r / rows,   rows = K/16
+//
+// i.e. the post-rebuild descending window is COLUMN-MAJOR over the values
+// region's populated physical rows (32 rows for K=512 -- the top half-tile --
+// 64 for K=1024, 128 for K=2048), 16 words per row. Calibration data:
+// scratchpad storm/tileskip/diag/dprint_k{512,1024,2048}.txt.
+//
+// Soundness note: an address error here would be UNSOUND only if it pointed
+// at a HIGHER-ranked (larger) element; the exhaustive per-rank calibration
+// rules that out.
+// ---------------------------------------------------------------------------
+template <uint32_t K>
+constexpr uint32_t rank_to_values_word(uint32_t r) {
+    constexpr uint32_t rows = K / 16;
+    return (r % rows) * 16 + (r / rows);
+}
+
+#ifdef TRISC_MATH
+
+// Monotone map from IEEE-754 bit pattern (sign-magnitude) to unsigned order.
+inline uint32_t sm_key(uint32_t x) { return (x & 0x80000000u) ? ~x : (x | 0x80000000u); }
+
+namespace sfpu_detail {
+
+// SFPU max-fold over the values tiles of the chunk sequence based at the
+// wrapper's dst_index (slot1). Leaves the 32-lane global max SFPSTOREd (raw
+// bits) at the first row of the sequence's indices region (offset 64*tiles
+// from the base -- where the auto-advance walk counter lands). Clobbers
+// LREG0..LREG7 (all scratch at this point in the leaf loop; the LLK config
+// constants live in LREG12+ and are untouched). ADDR_MOD_0/ADDR_MOD_6 are
+// reprogrammed here and re-initialized by every downstream topk_xl_*_init
+// before their next use (the established per-phase re-init pattern of this
+// kernel).
+template <uint32_t K>
+inline void chunk_maxfold() {
+    using namespace ckernel;
+    constexpr uint32_t tiles = (K + 1023) / 1024;
+    constexpr uint32_t num_loads = tiles * 32;
+
+    // ADDR_MOD_6: the load walk (advance 2 u10 units per SFPLOAD, the
+    // 4-row/32-datum coverage stride). ADDR_MOD_0: no movement (store).
+    addr_mod_t{
+        .srca = {.incr = 0},
+        .srcb = {.incr = 0},
+        .dest = {.incr = 2},
+    }
+        .set(ADDR_MOD_6);
+    addr_mod_t{
+        .srca = {.incr = 0},
+        .srcb = {.incr = 0},
+        .dest = {.incr = 0},
+    }
+        .set(ADDR_MOD_0);
+
+    // Accumulator LREG0 and its transpose partners LREG1..3 = bf16 -inf
+    // (0xFF800000): identity for max, and matches the copy path's padding.
+    TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_LOWER, 0x0000);
+    TTI_SFPLOADI(p_sfpu::LREG0, sfpi::SFPLOADI_MOD0_UPPER, 0xFF80);
+    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_LOWER, 0x0000);
+    TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_UPPER, 0xFF80);
+    TTI_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_LOWER, 0x0000);
+    TTI_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_UPPER, 0xFF80);
+    TTI_SFPLOADI(p_sfpu::LREG3, sfpi::SFPLOADI_MOD0_LOWER, 0x0000);
+    TTI_SFPLOADI(p_sfpu::LREG3, sfpi::SFPLOADI_MOD0_UPPER, 0xFF80);
+
+    // Lane-wise max accumulate. Two alternating load temps so each SFPLOAD
+    // issues under the previous SFPSWAP's bubble. SFPSWAP(0, VC, VD,
+    // ALL_ROWS_MAX) puts max into VC and min into VD (SFPSWAP.md functional
+    // model, silicon-confirmed via the CHUNK_SKIP_DEBUG trace), so the
+    // accumulator rides in the VC slot.
+    for (uint32_t i = 0; i < num_loads / 2; ++i) {
+        TTI_SFPLOAD(p_sfpu::LREG4, InstrModLoadStore::INT32, ADDR_MOD_6, 0);
+        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG4, p_sfpswap::ALL_ROWS_MAX);
+        TTI_SFPLOAD(p_sfpu::LREG5, InstrModLoadStore::INT32, ADDR_MOD_6, 0);
+        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG5, p_sfpswap::ALL_ROWS_MAX);
+    }
+
+    // Cross-lane fold: 4 subvectors -> 1 (TRANSP + 3 SWAPs against the -inf
+    // partners), then 8 lanes -> 1 (7x rotate-running-max). SFPSHFT2-ROR1
+    // requires the trailing SFPNOP; rotations source LREG0 (the running max)
+    // each step because SFPSWAP overwrites both operands.
+    TTI_SFPNOP;
+    TTI_SFPTRANSP(0, 0, 0, 0);
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG2, p_sfpswap::ALL_ROWS_MAX);
+    TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG3, p_sfpswap::ALL_ROWS_MAX);
+    for (uint32_t i = 0; i < 7; ++i) {
+        TTI_SFPSHFT2(0, p_sfpu::LREG0, p_sfpu::LREG1, 3 /*SUBVEC_SHFLROR1*/);
+        TTI_SFPNOP;
+        TTI_SFPSWAP(0, p_sfpu::LREG0, p_sfpu::LREG1, p_sfpswap::ALL_ROWS_MAX);
+    }
+
+    // The walk counter now sits at 64*tiles past the base = row 0 of the
+    // sequence's indices region. Store the folded max there (raw bits); lane
+    // 0 lands at MMIO word 0 of that 4-row window (cgtceq R0_WORD=0).
+    TTI_SFPSTORE(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_0, 0);
+}
+
+}  // namespace sfpu_detail
+
+#endif  // TRISC_MATH
+
+// One-time per-kernel setup (call once before the row loop, MATH only):
+// program MATH's RISC_DEST_ACCESS_CTRL section for raw fp32 MMIO DST reads.
+// Only affects the RISC MMIO window (dprint recipe: no restore needed).
+inline void chunk_skip_configure() {
+#ifdef TRISC_MATH
+    ckernel::configure_dest_access<ckernel::MathThreadId>(DataFormat::Float32, /*enable_swizzle=*/true);
+    ckernel::tensix_sync();
+    ckernel::wait(1000);  // let the config settle before the first MMIO read
+#endif
+}
+
+// Per-tested-chunk decision, callable from all three TRISC builds.
+//  * MATH: computes the decision and mails it to UNPACK.
+//  * UNPACK: blocks on the mailbox for MATH's decision.
+//  * PACK: constant false (no per-chunk work exists on PACK in this loop).
+template <uint32_t K, uint32_t USER_K>
+inline bool chunk_skip_decide(uint32_t slot1) {
+    static_assert(USER_K >= 1 && USER_K <= K, "USER_K must be in [1, K]");
+    (void)slot1;
+#if defined(TRISC_MATH)
+    constexpr uint32_t tiles = (K + 1023) / 1024;
+    constexpr uint32_t threshold_word = rank_to_values_word<K>(USER_K - 1);
+    _llk_math_eltwise_unary_sfpu_params_(sfpu_detail::chunk_maxfold<K>, slot1, VectorMode::RC_custom);
+    ckernel::tensix_sync();
+    volatile uint32_t* mm = reinterpret_cast<volatile uint32_t*>(RISCV_DEST_START_ADDR);
+    const uint32_t max_bits = mm[(slot1 + tiles) * 64 * 16];
+    const uint32_t thr_bits = mm[threshold_word];
+    const bool skip = sm_key(max_bits) < sm_key(thr_bits);
+#ifdef CHUNK_SKIP_DEBUG
+    DPRINT("CSD max {} thr {} skip {}\n", max_bits, thr_bits, skip ? 1u : 0u);
+#endif
+    ckernel::mailbox_write(ckernel::ThreadId::UnpackThreadId, skip ? 1u : 0u);
+    return skip;
+#elif defined(TRISC_UNPACK)
+    return ckernel::mailbox_read(ckernel::ThreadId::MathThreadId) != 0;
+#else
+    return false;
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// Telemetry recorder (CHUNK_SKIP_TELEMETRY builds only). MATH records the
+// decisions it already owns; UNPACK/PACK get no-op stubs so the shared call
+// sites in compute.cpp / compute_with_values.cpp compile on all three TRISC
+// builds. The recorder adds NO mailbox traffic and keeps the tested-chunk
+// predicate identical on all TRISCs, so the T1->T0 FIFO occupancy analysis
+// above (worst case 3 <= depth 4) is unchanged. The tested-chunk count is
+// compile-time deterministic (num_chunks - first_tested_chunk), so only the
+// data-dependent SKIPS are recorded. Emission, once per row (parsed by
+// tests/.../_topk_large_indices_skip_telemetry_parse.py):
+//   CSTL r <row> n <num_chunks> f <first_tested> s <skipped>
+//   CSTLM <word_idx> <mask_word>     (ceil(num_chunks/32) lines per row)
+// ---------------------------------------------------------------------------
+#ifdef CHUNK_SKIP_TELEMETRY
+#ifdef TRISC_MATH
+
+// Route width ceiling 2^19 / min llk window 512 = 1024 chunks max -> 32
+// words. File-scope inline arrays land in TRISC1 local-memory .bss, not the
+// stack.
+inline constexpr uint32_t kTelemetryMaxChunkWords = 32;
+inline uint32_t g_telemetry_skip_mask[kTelemetryMaxChunkWords];
+inline uint32_t g_telemetry_row_skipped;
+
+inline void telemetry_row_begin(uint32_t num_chunks) {
+    const uint32_t words = (num_chunks + 31) / 32;
+    for (uint32_t w = 0; w < words && w < kTelemetryMaxChunkWords; ++w) {
+        g_telemetry_skip_mask[w] = 0;
+    }
+    g_telemetry_row_skipped = 0;
+}
+
+inline void telemetry_record(uint32_t chunk, bool skipped) {
+    if (skipped) {
+        ++g_telemetry_row_skipped;
+        const uint32_t w = chunk / 32;
+        if (w < kTelemetryMaxChunkWords) {
+            g_telemetry_skip_mask[w] |= (1u << (chunk % 32));
+        }
+    }
+}
+
+// Runs between FPU phases on the MATH RISC, after all of the row's skip
+// decisions have completed -- it cannot interleave with the decision mailbox.
+template <uint32_t USER_K>
+inline void telemetry_row_end(uint32_t row, uint32_t num_chunks) {
+    DPRINT("CSTL r {} n {} f {} s {}\n", row, num_chunks, first_tested_chunk<USER_K>(), g_telemetry_row_skipped);
+    const uint32_t words = (num_chunks + 31) / 32;
+    for (uint32_t w = 0; w < words && w < kTelemetryMaxChunkWords; ++w) {
+        DPRINT("CSTLM {} {}\n", w, g_telemetry_skip_mask[w]);
+    }
+}
+
+#else   // CHUNK_SKIP_TELEMETRY on UNPACK/PACK: observe nothing.
+inline void telemetry_row_begin(uint32_t) {}
+inline void telemetry_record(uint32_t, bool) {}
+template <uint32_t USER_K>
+inline void telemetry_row_end(uint32_t, uint32_t) {}
+#endif  // TRISC_MATH
+#endif  // CHUNK_SKIP_TELEMETRY
+
+}  // namespace topk_large_indices_chunk_skip

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/topk_large_indices_compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/topk_large_indices_compute_common.hpp
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared compute helpers for the COLUMN-PARALLEL merge-tree kernels
+// (compute_tree.cpp / compute_tree_root.cpp / compute_tree_root_with_values.cpp)
+// and the row-parallel return_values variant (compute_with_values.cpp).
+//
+// NOTE: compute.cpp (the row-parallel kernel) deliberately keeps its own
+// byte-identical copies of these helpers instead of including this header —
+// its JIT source hash, cached binaries, and tight (+/-1%) perf baselines must
+// stay untouched by column-parallel work. Behavioral changes to a helper must
+// be mirrored there.
+
+#pragma once
+
+#include <cstdint>
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/experimental/topk_xl.h"
+#include "api/compute/transpose_dest.h"
+#include "api/dataflow/circular_buffer.h"
+
+#ifdef TRISC_MATH
+namespace ckernel::sfpu {
+
+// topk_large_indices keeps final values and indices in the TopK XL LLK DST
+// layout until the last rank-order materialization step. The generic compute
+// APIs (`isneginf_tile` + `where_tile`) operate on normal tile layouts and do
+// not line up with this intermediate value/index pairing, so they only replaced
+// a subset of the final -inf lanes during validation.
+//
+// Keep this as op-local SFPU functionality for now instead of exporting a
+// public LLK API: it is tied to the final TopK XL LLK DST contract below,
+// where the value words start at the normal `idst` base and the UINT32 index
+// words start at `indices_offset`. The helper walks that layout directly,
+// compares final values against exact BF16 -inf stored in the FP32 DST
+// container (`0xFF800000`), and conditionally writes the sentinel index
+// `0xFFFFFFFF`.
+inline void _topk_large_indices_mark_neginf_indices_init_() {
+    addr_mod_t{
+        .srca = {.incr = 0},
+        .srcb = {.incr = 0},
+        .dest = {.incr = 2},
+    }
+        .set(ADDR_MOD_0);
+}
+
+template <uint32_t K>
+inline void _topk_large_indices_mark_neginf_indices_() {
+    static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
+    constexpr uint32_t tiles_per_sequence = K == 2048 ? 2 : 1;
+    constexpr uint32_t indices_offset = tiles_per_sequence * 64;
+    constexpr uint32_t iterations = (K == 512 ? 1 : K == 1024 ? 2 : 4) * 16;
+
+    TTI_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_LOWER, 0x0000);
+    TTI_SFPLOADI(p_sfpu::LREG2, sfpi::SFPLOADI_MOD0_UPPER, 0xFF80);
+    TTI_SFPLOADI(p_sfpu::LREG3, sfpi::SFPLOADI_MOD0_LOWER, 0xFFFF);
+    TTI_SFPLOADI(p_sfpu::LREG3, sfpi::SFPLOADI_MOD0_UPPER, 0xFFFF);
+
+    for (uint32_t i = 0; i < iterations; ++i) {
+        TTI_SFPLOAD(p_sfpu::LREG0, InstrModLoadStore::INT32, ADDR_MOD_7, 0);
+        TTI_SFPXOR(0, p_sfpu::LREG2, p_sfpu::LREG0, 0);
+        TTI_SFPSETCC(0, p_sfpu::LREG0, 0, sfpi::SFPSETCC_MOD1_LREG_EQ0);
+        TTI_SFPSTORE(p_sfpu::LREG3, InstrModLoadStore::INT32, ADDR_MOD_0, indices_offset);
+        TTI_SFPENCC(0, 0, 0, 0);
+    }
+}
+
+}  // namespace ckernel::sfpu
+#endif
+
+namespace topk_large_indices {
+
+constexpr uint32_t elements_per_tile = TILE_R_DIM * TILE_C_DIM;
+
+// Transposes the UINT32 index tiles of the final DST sequence into the
+// rank-order layout that pack_untilize + the writer's face reorder turn into
+// row-major output.
+template <uint32_t K>
+FORCE_INLINE void materialize_index_rank_order(uint32_t idst, uint32_t indices_cb) {
+    static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
+    constexpr uint32_t tiles_per_sequence = (K + elements_per_tile - 1) / elements_per_tile;
+
+    transpose_dest_init<true, false>(indices_cb);
+    for (uint32_t t = 0; t < tiles_per_sequence; ++t) {
+        transpose_dest<true, false>(idst + tiles_per_sequence + t);
+    }
+}
+
+// Transposes the FP32 value tiles of the final DST sequence into the same
+// rank-order layout as the indices, for the optional values output.
+// The value words are moved with the 32-bit (INT-mode) transpose so the moves
+// are bit-exact; the fp32->bf16 conversion happens later in the packer.
+// PRECONDITION: materialize_index_rank_order already ran this row (it programs
+// the shared 32-bit transpose_dest init, which this reuses), and
+// mark_neginf_indices ran before EITHER transpose (it reads the value words in
+// the pre-transpose engine layout).
+template <uint32_t K>
+FORCE_INLINE void materialize_values_rank_order(uint32_t idst) {
+    static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
+    constexpr uint32_t tiles_per_sequence = (K + elements_per_tile - 1) / elements_per_tile;
+    for (uint32_t t = 0; t < tiles_per_sequence; ++t) {
+        transpose_dest<true, false>(idst + t);
+    }
+}
+
+// Replaces the index of every exact BF16 -inf value lane with the 0xFFFFFFFF
+// sentinel. Must run after the last merge/rebuild, before materialization.
+template <uint32_t K>
+FORCE_INLINE void mark_neginf_indices(uint32_t idst) {
+    static_assert(K == 512 || K == 1024 || K == 2048, "K must be 512, 1024, or 2048");
+    MATH((ckernel::sfpu::_topk_large_indices_mark_neginf_indices_init_()));
+    MATH((_llk_math_eltwise_unary_sfpu_params_(
+        ckernel::sfpu::_topk_large_indices_mark_neginf_indices_<K>, idst, VectorMode::RC_custom)));
+}
+
+// Copies one K-element chunk from the input CB into DST at dst_base, stamps
+// the fused LSB indices, locally sorts (fused), then splits into unfused FP32
+// values + row-major UINT32 global indices and advances the chunk base.
+// Leaves the sequence at [dst_base .. dst_base + tiles) values and
+// [dst_base + tiles .. dst_base + 2*tiles) indices, sorted in `ascending`
+// direction in the TopK XL engine layout.
+template <uint32_t K>
+FORCE_INLINE void process_chunk(CircularBuffer& input_cb, uint32_t dst_base, uint32_t active_elements, bool ascending) {
+    constexpr uint32_t tiles_per_sequence = (K + elements_per_tile - 1) / elements_per_tile;
+    const uint32_t input_cb_id = input_cb.get_cb_id();
+    input_cb.wait_front(tiles_per_sequence);
+    topk_xl_copy_tile_init(input_cb_id);
+    topk_xl_copy_tile<K>(input_cb_id, dst_base, 0, active_elements);
+    input_cb.pop_front(tiles_per_sequence);
+
+    topk_xl_add_lsb_indices_init();
+    topk_xl_add_lsb_indices<K, 0>(dst_base);
+
+    topk_xl_init<K, true>();
+    topk_xl_local_sort<K>(dst_base, ascending);
+
+    topk_xl_separate_indices_row_major_reinit();
+    topk_xl_separate_indices_row_major<K>(dst_base);
+    topk_xl_separate_indices_row_major_advance_chunk_base<K>();
+}
+
+}  // namespace topk_large_indices

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/topk_large_indices_writer_flex_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/topk_large_indices_writer_flex_common.hpp
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Output-emission helpers shared by the FLEX output writers (writer_flex.cpp,
+// writer_tree_flex.cpp). The flex writers serve the opt-in output formats
+// (tile_output=true and/or index_dtype=UINT16); the default ROW_MAJOR/UINT32
+// program keeps its original writer sources byte-identical and never includes
+// this header.
+//
+// Source data contract (identical to the default writers): per output row the
+// compute kernel pushes one CB page holding the k-element result as 16-element
+// slices — already row-major for the 512 LLK window (source_slices_per_row ==
+// 32), in pack_untilize face-pair order for the 1024/2048 windows. Indices
+// travel as raw 32-bit words (64 B per slice), values as bf16 (32 B per slice).
+//
+// TILE-layout emission: an output row r of a [rows_2d, k] 2D slice lands in
+// tile row (r >> 5) at in-tile row (r & 31). Within a 32x32 tile the four
+// 16x16 faces are stored contiguously (f0 rows0-15/cols0-15, f1 rows0-15/
+// cols16-31, f2, f3), so each 16-element output slice is one contiguous
+// face-row run:
+//   dst_slice d -> tile column d>>1, face (in_tile_r<16 ? 0 : 2) + (d&1),
+//   byte offset ((face * 256) + (in_tile_r & 15) * 16) * elem_bytes.
+// All runs start at 32 B multiples, satisfying Blackhole's 16 B NoC DRAM
+// WRITE alignment (writes, unlike reads, have no 64 B requirement).
+//
+// TILE padding rows are zero-filled from a small zeroed L1 slab so the routed
+// composite matches what tilize_with_val_padding produced (pad value 0).
+
+#pragma once
+
+#include "api/core_local_mem.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc.h"
+#include "api/tensor/noc_traits.h"
+
+namespace topk_large_indices_writer_flex {
+
+// dst (row-major) slice index -> source-CB slice index. Mirrors the
+// pack_untilize face-pair order documented in writer.cpp::copy_row_to_scratch.
+template <uint32_t source_slices_per_row>
+FORCE_INLINE uint32_t source_slice_of(uint32_t dst_slice) {
+    if constexpr (source_slices_per_row == 32) {
+        return dst_slice;  // LLK window 512: the CB page is already row-major
+    } else {
+        static_assert(source_slices_per_row == 64 || source_slices_per_row == 128);
+        const uint32_t tile_col = dst_slice >> 2;
+        const uint32_t face_col = dst_slice & 0x1;
+        const uint32_t face_row_offset = (dst_slice & 0x2) ? source_slices_per_row / 2 : 0;
+        return (2 * tile_col) + face_col + face_row_offset;
+    }
+}
+
+// Narrows the row's uint32 index words into a row-major uint16 row in scratch,
+// applying the face-pair reorder in the same pass. The truncation maps real
+// winners (< 65536, guaranteed by the op's index_dtype=UINT16 validation)
+// losslessly and the 0xFFFFFFFF -inf sentinel to 0xFFFF — the same values a
+// UINT32 -> UINT16 typecast op produces.
+template <uint32_t source_slices_per_row, uint32_t output_slices_per_row>
+FORCE_INLINE void narrow_row_to_u16(uint32_t src_base, uint32_t dst_base) {
+    for (uint32_t d = 0; d < output_slices_per_row; ++d) {
+        const uint32_t s = source_slice_of<source_slices_per_row>(d);
+        volatile tt_l1_ptr uint32_t* src = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(src_base + s * 64);
+        volatile tt_l1_ptr uint32_t* dst = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(dst_base + d * 32);
+        // Pack two narrowed uint16 per 32-bit store (little-endian) — halves
+        // the RISC store count vs per-element uint16 stores.
+        for (uint32_t e = 0; e < 8; ++e) {
+            const uint32_t lo = src[2 * e];
+            const uint32_t hi = src[2 * e + 1];
+            dst[e] = (lo & 0xFFFFu) | (hi << 16);
+        }
+    }
+}
+
+// Scatters one output row's slices into their TILE positions.
+// src_slice_bytes: stride of the 16-element slices in L1 (64 for uint32 CB
+// data, 32 for bf16 CB data or a narrowed uint16 scratch row).
+// src_row_major: the L1 source is already in row-major slice order (a scratch
+// row, or the 512-window CB page); otherwise the face-pair mapping applies.
+template <
+    uint32_t source_slices_per_row,
+    uint32_t output_slices_per_row,
+    uint32_t src_slice_bytes,
+    uint32_t elem_bytes,
+    bool src_row_major,
+    typename TensorAccessorT>
+FORCE_INLINE void issue_tile_row_scatter(
+    const Noc& noc,
+    const TensorAccessorT& tensor,
+    uint32_t src_base,
+    uint32_t tile_row,
+    uint32_t in_tile_r,
+    uint32_t tiles_per_out_row) {
+    constexpr uint32_t slice_bytes = 16 * elem_bytes;
+    // Byte offset of this row's face-col-0 run within a tile.
+    const uint32_t base_off = (((in_tile_r >> 4) & 1) * 512 + (in_tile_r & 15) * 16) * elem_bytes;
+    for (uint32_t d = 0; d < output_slices_per_row; ++d) {
+        const uint32_t s = src_row_major ? d : source_slice_of<source_slices_per_row>(d);
+        const uint32_t page = tile_row * tiles_per_out_row + (d >> 1);
+        const uint32_t dst_off = base_off + (d & 1) * 256 * elem_bytes;
+        noc.async_write(
+            CoreLocalMem<uint32_t>(src_base + s * src_slice_bytes),
+            tensor,
+            slice_bytes,
+            {.offset_bytes = 0},
+            {.page_id = page, .offset_bytes = dst_off});
+    }
+}
+
+// Zero-fills output rows [pad_from, 32) of one output tile row (all its tile
+// columns) from the zeroed slab at zero_base. pad_from must be in [1, 31].
+// The pad region decomposes into at most 3 contiguous face runs per tile; the
+// largest (both bottom faces) is 512 * elem_bytes <= 2048 bytes, which bounds
+// the slab size.
+template <uint32_t elem_bytes, typename TensorAccessorT>
+FORCE_INLINE void issue_tile_row_pad(
+    const Noc& noc,
+    const TensorAccessorT& tensor,
+    uint32_t zero_base,
+    uint32_t tile_row,
+    uint32_t pad_from,
+    uint32_t tiles_per_out_row) {
+    const auto write_zeros = [&](uint32_t page, uint32_t dst_off, uint32_t len) {
+        noc.async_write(
+            CoreLocalMem<uint32_t>(zero_base),
+            tensor,
+            len,
+            {.offset_bytes = 0},
+            {.page_id = page, .offset_bytes = dst_off});
+    };
+    for (uint32_t tile_col = 0; tile_col < tiles_per_out_row; ++tile_col) {
+        const uint32_t page = tile_row * tiles_per_out_row + tile_col;
+        if (pad_from < 16) {
+            const uint32_t top_len = (16 - pad_from) * 16 * elem_bytes;
+            write_zeros(page, pad_from * 16 * elem_bytes, top_len);          // f0 rows [pad_from, 16)
+            write_zeros(page, (256 + pad_from * 16) * elem_bytes, top_len);  // f1 rows [pad_from, 16)
+            write_zeros(page, 512 * elem_bytes, 512 * elem_bytes);           // f2 + f3 entirely
+        } else {
+            const uint32_t q = pad_from - 16;
+            const uint32_t bot_len = (16 - q) * 16 * elem_bytes;
+            write_zeros(page, (512 + q * 16) * elem_bytes, bot_len);  // f2 rows [q, 16)
+            write_zeros(page, (768 + q * 16) * elem_bytes, bot_len);  // f3 rows [q, 16)
+        }
+    }
+}
+
+// Zeroes the pad slab once at kernel start (512 32-bit words = 2048 bytes).
+FORCE_INLINE uint32_t init_pad_slab(uint32_t cb_pad_zero) {
+    CircularBuffer pad_cb(cb_pad_zero);
+    pad_cb.reserve_back(1);
+    const uint32_t base = pad_cb.get_write_ptr();
+    volatile tt_l1_ptr uint32_t* slab = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(base);
+    for (uint32_t i = 0; i < 512; ++i) {
+        slab[i] = 0;
+    }
+    return base;
+}
+
+// --- ROW_MAJOR emission helpers (verbatim structure of writer.cpp's) ---
+
+template <uint32_t source_slices_per_row, uint32_t output_slices_per_row, uint32_t slice_bytes>
+FORCE_INLINE void copy_row_to_scratch(CircularBuffer& src_cb, CircularBuffer& scratch_cb, const Noc& noc) {
+    static_assert(source_slices_per_row == 64 || source_slices_per_row == 128);
+    static_assert(output_slices_per_row >= 1 && output_slices_per_row <= source_slices_per_row);
+    constexpr uint32_t transfer_bytes = slice_bytes;
+    static_assert(transfer_bytes <= NOC_MAX_BURST_SIZE);
+
+    const uint32_t src_base = src_cb.get_read_ptr();
+    const uint32_t dst_base = scratch_cb.get_write_ptr();
+    const uint32_t noc_id = noc.get_noc_id();
+    const auto local_src = [noc_id](uint32_t addr) {
+        return noc_traits_t<UnicastEndpoint>::src_args_type{
+            .noc_x = static_cast<uint32_t>(my_x[noc_id]), .noc_y = static_cast<uint32_t>(my_y[noc_id]), .addr = addr};
+    };
+
+    noc.set_async_read_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+        UnicastEndpoint{}, transfer_bytes, local_src(src_base));
+
+    for (uint32_t dst_slice = 0; dst_slice < output_slices_per_row; ++dst_slice) {
+        const uint32_t src_slice = source_slice_of<source_slices_per_row>(dst_slice);
+        const uint32_t src_addr = src_base + src_slice * slice_bytes;
+        const uint32_t dst_addr = dst_base + dst_slice * slice_bytes;
+        noc.async_read_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+            UnicastEndpoint{},
+            CoreLocalMem<uint32_t>(dst_addr),
+            transfer_bytes,
+            local_src(src_addr),
+            {.offset_bytes = 0});
+    }
+    noc.async_read_barrier();
+}
+
+template <
+    uint32_t source_slices_per_row,
+    uint32_t output_slices_per_row,
+    uint32_t slice_bytes,
+    typename TensorAccessorT>
+FORCE_INLINE void issue_reordered_row_write(
+    CircularBuffer& src_cb,
+    CircularBuffer& scratch_cb,
+    const Noc& noc,
+    const TensorAccessorT& tensor,
+    uint32_t row,
+    uint32_t row_bytes) {
+    src_cb.wait_front(1);
+    scratch_cb.reserve_back(1);
+    copy_row_to_scratch<source_slices_per_row, output_slices_per_row, slice_bytes>(src_cb, scratch_cb, noc);
+    src_cb.pop_front(1);
+
+    scratch_cb.push_back(1);
+    scratch_cb.wait_front(1);
+    noc.async_write(scratch_cb, tensor, row_bytes, {.offset_bytes = 0}, {.page_id = row, .offset_bytes = 0});
+}
+
+template <typename TensorAccessorT>
+FORCE_INLINE void issue_contiguous_row_write(
+    CircularBuffer& src_cb, const Noc& noc, const TensorAccessorT& tensor, uint32_t row, uint32_t row_bytes) {
+    src_cb.wait_front(1);
+    noc.async_write(src_cb, tensor, row_bytes, {.offset_bytes = 0}, {.page_id = row, .offset_bytes = 0});
+}
+
+}  // namespace topk_large_indices_writer_flex

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer_flex.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer_flex.cpp
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Row-parallel FLEX output writer: serves the opt-in output formats of
+// topk_large_indices (tile_output=true and/or index_dtype=UINT16), selected by
+// the program factory via the FLEX_OUT_TILE / FLEX_INDEX_U16 / FLEX_WITH_VALUES
+// defines. The default ROW_MAJOR/UINT32 program keeps using writer.cpp /
+// writer_with_values.cpp so its kernel binaries stay byte-identical.
+//
+// Consumes exactly the same compute-produced CB stream as the default writers
+// (values page then indices page per row when FLEX_WITH_VALUES). See
+// topk_large_indices_writer_flex_common.hpp for the TILE scatter/padding and
+// UINT16 narrowing mechanics.
+//
+// TILE row addressing: TILE padding is per 2D slice — every [rows_2d, k] slab
+// of the (flattened) output pads its rows to a multiple of 32 independently —
+// so the writer tracks (slice_idx, in_slice_row) across its contiguous global
+// row range and the core that owns a slab's LAST logical row zero-fills that
+// slab's padding rows.
+
+#include "topk_large_indices_writer_flex_common.hpp"
+
+void kernel_main() {
+    using namespace topk_large_indices_writer_flex;
+
+    const uint32_t indices_addr = get_arg_val<uint32_t>(0);
+    const uint32_t start_row = get_arg_val<uint32_t>(1);
+    const uint32_t num_rows = get_arg_val<uint32_t>(2);
+#ifdef FLEX_WITH_VALUES
+    const uint32_t values_addr = get_arg_val<uint32_t>(3);
+#endif
+#ifdef FLEX_OUT_TILE
+    const uint32_t rows_2d = get_arg_val<uint32_t>(4);
+    const uint32_t start_in_slice = get_arg_val<uint32_t>(5);
+    const uint32_t start_slice = get_arg_val<uint32_t>(6);
+#endif
+
+    constexpr uint32_t cb_indices = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_indices_scratch = get_compile_time_arg_val(1);
+    constexpr uint32_t indices_page_bytes = get_compile_time_arg_val(2);
+    constexpr uint32_t source_slices_per_row = get_compile_time_arg_val(3);
+    constexpr uint32_t output_slices_per_row = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_values = get_compile_time_arg_val(5);
+    constexpr uint32_t cb_values_scratch = get_compile_time_arg_val(6);
+    constexpr uint32_t values_page_bytes = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_pad_zero = get_compile_time_arg_val(8);
+    constexpr uint32_t tiles_per_out_row = get_compile_time_arg_val(9);
+    constexpr auto indices_args = TensorAccessorArgs<10>();
+#ifdef FLEX_WITH_VALUES
+    constexpr auto values_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
+#endif
+
+#ifdef FLEX_INDEX_U16
+    constexpr uint32_t indices_elem_bytes = 2;
+#else
+    constexpr uint32_t indices_elem_bytes = 4;
+#endif
+    constexpr bool cb_row_major = (source_slices_per_row == 32);
+
+    const auto indices = TensorAccessor(indices_args, indices_addr, indices_page_bytes);
+    CircularBuffer indices_cb(cb_indices);
+#ifdef FLEX_WITH_VALUES
+    const auto values = TensorAccessor(values_args, values_addr, values_page_bytes);
+    CircularBuffer values_cb(cb_values);
+#endif
+    Noc noc;
+
+#ifdef FLEX_OUT_TILE
+    const uint32_t zero_base = init_pad_slab(cb_pad_zero);
+    const uint32_t tiles_per_slice_h = (rows_2d + 31) >> 5;
+    const uint32_t pad_from = rows_2d & 31;  // 0 = slabs fill their tiles exactly, no padding
+    uint32_t slice_idx = start_slice;
+    uint32_t in_slice_row = start_in_slice;
+
+    if (pad_from != 0) {
+        // Zero-fill the padding rows of every 2D slab whose LAST logical row
+        // this core owns. Pad rows are disjoint from every data row, so they
+        // are pre-issued here — before the first compute-produced row is even
+        // awaited — hiding their NoC injection under the compute pipeline
+        // instead of tailing the critical path.
+        const uint32_t end_row = start_row + num_rows;  // exclusive
+        const uint32_t last_tile_row_in_slab = (rows_2d - 1) >> 5;
+        for (uint32_t slab = start_slice;; ++slab) {
+            const uint32_t slab_last_row = slab * rows_2d + (rows_2d - 1);
+            if (slab_last_row >= end_row) {
+                break;
+            }
+            const uint32_t pad_tile_row = slab * tiles_per_slice_h + last_tile_row_in_slab;
+            issue_tile_row_pad<indices_elem_bytes>(noc, indices, zero_base, pad_tile_row, pad_from, tiles_per_out_row);
+#ifdef FLEX_WITH_VALUES
+            issue_tile_row_pad<2>(noc, values, zero_base, pad_tile_row, pad_from, tiles_per_out_row);
+#endif
+        }
+    }
+#endif
+
+    for (uint32_t local_row = 0; local_row < num_rows; ++local_row) {
+        const uint32_t row = start_row + local_row;
+        (void)row;
+#ifdef FLEX_OUT_TILE
+        const uint32_t tile_row = slice_idx * tiles_per_slice_h + (in_slice_row >> 5);
+        const uint32_t in_tile_r = in_slice_row & 31;
+#endif
+
+#ifdef FLEX_WITH_VALUES
+        // Compute pushes values then indices each row; consume in the same order.
+#ifdef FLEX_OUT_TILE
+        values_cb.wait_front(1);
+        issue_tile_row_scatter<source_slices_per_row, output_slices_per_row, 32, 2, cb_row_major>(
+            noc, values, values_cb.get_read_ptr(), tile_row, in_tile_r, tiles_per_out_row);
+        noc.async_writes_flushed();
+        values_cb.pop_front(1);
+#else
+        if constexpr (cb_row_major) {
+            issue_contiguous_row_write(values_cb, noc, values, row, values_page_bytes);
+            noc.async_writes_flushed();
+            values_cb.pop_front(1);
+        } else {
+            CircularBuffer values_scratch_cb(cb_values_scratch);
+            issue_reordered_row_write<source_slices_per_row, output_slices_per_row, 32>(
+                values_cb, values_scratch_cb, noc, values, row, values_page_bytes);
+            noc.async_writes_flushed();
+            values_scratch_cb.pop_front(1);
+        }
+#endif
+#endif  // FLEX_WITH_VALUES
+
+#ifdef FLEX_INDEX_U16
+        {
+            CircularBuffer indices_scratch_cb(cb_indices_scratch);
+            indices_cb.wait_front(1);
+            indices_scratch_cb.reserve_back(1);
+            narrow_row_to_u16<source_slices_per_row, output_slices_per_row>(
+                indices_cb.get_read_ptr(), indices_scratch_cb.get_write_ptr());
+            indices_cb.pop_front(1);  // narrowed synchronously by this RISC
+            indices_scratch_cb.push_back(1);
+            indices_scratch_cb.wait_front(1);
+#ifdef FLEX_OUT_TILE
+            issue_tile_row_scatter<source_slices_per_row, output_slices_per_row, 32, 2, /*src_row_major=*/true>(
+                noc, indices, indices_scratch_cb.get_read_ptr(), tile_row, in_tile_r, tiles_per_out_row);
+#else
+            noc.async_write(
+                indices_scratch_cb,
+                indices,
+                indices_page_bytes,
+                {.offset_bytes = 0},
+                {.page_id = row, .offset_bytes = 0});
+#endif
+            noc.async_writes_flushed();
+            indices_scratch_cb.pop_front(1);
+        }
+#else
+        // UINT32 indices; the flex writer is only selected with at least one
+        // opt-in, so this is necessarily the TILE-output path.
+        indices_cb.wait_front(1);
+        issue_tile_row_scatter<source_slices_per_row, output_slices_per_row, 64, 4, cb_row_major>(
+            noc, indices, indices_cb.get_read_ptr(), tile_row, in_tile_r, tiles_per_out_row);
+        noc.async_writes_flushed();
+        indices_cb.pop_front(1);
+#endif
+
+#ifdef FLEX_OUT_TILE
+        if (++in_slice_row == rows_2d) {
+            in_slice_row = 0;
+            ++slice_idx;
+        }
+#endif
+    }
+
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer_tree.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer_tree.cpp
@@ -1,0 +1,240 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Column-parallel TREE writer — runs on every rectangle core; runtime args
+// select this core's roles per row:
+//
+//  RECEIVER (num_recv > 0): for each winning level with a real partner, in
+//  level order: reserve the recv CB (backpressure: capacity is exactly one
+//  sequence, so this blocks until compute consumed the previous level), zero
+//  the local data semaphore, bump that partner's ready semaphore, wait for
+//  the data semaphore, publish the sequence to compute. Pairwise version of
+//  the old 2-semaphore gather protocol; reset-before-signal ordering is kept
+//  on both sides so a next-row signal can never be clobbered.
+//
+//  SHIPPER (do_ship): wait for compute's packed survivor (or use the
+//  prefilled all--inf scratch when this slice is empty with no partners),
+//  wait for the winner's ready signal, reset it, NoC-write both regions into
+//  the winner's recv CB (same L1 address everywhere: the recv CB spans the
+//  whole rectangle, and its pointers wrap to base every full cycle), barrier,
+//  then bump the winner's data semaphore.
+//
+//  ROOT (!do_ship): after the receive events, stream the materialized index
+//  row to DRAM exactly like the old output writer (contiguous for the 512
+//  LLK window, face-pair -> row-major reorder otherwise).
+
+#include "api/core_local_mem.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/tensor/noc_traits.h"
+
+namespace {
+
+template <uint32_t source_slices_per_row, uint32_t output_slices_per_row, uint32_t slice_bytes>
+FORCE_INLINE void copy_row_to_scratch(CircularBuffer& src_cb, CircularBuffer& scratch_cb, const Noc& noc) {
+    static_assert(source_slices_per_row == 64 || source_slices_per_row == 128);
+    static_assert(output_slices_per_row >= 1 && output_slices_per_row <= source_slices_per_row);
+    constexpr uint32_t transfer_bytes = slice_bytes;
+    static_assert(transfer_bytes <= NOC_MAX_BURST_SIZE);
+
+    const uint32_t src_base = src_cb.get_read_ptr();
+    const uint32_t dst_base = scratch_cb.get_write_ptr();
+    const uint32_t noc_id = noc.get_noc_id();
+    const auto local_src = [noc_id](uint32_t addr) {
+        return noc_traits_t<UnicastEndpoint>::src_args_type{
+            .noc_x = static_cast<uint32_t>(my_x[noc_id]), .noc_y = static_cast<uint32_t>(my_y[noc_id]), .addr = addr};
+    };
+
+    noc.set_async_read_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+        UnicastEndpoint{}, transfer_bytes, local_src(src_base));
+
+    for (uint32_t dst_slice = 0; dst_slice < output_slices_per_row; ++dst_slice) {
+        // pack_untilize emits 16-element slices in face-pair order:
+        // [top-left, bottom-left, top-right, bottom-right] per tile column.
+        const uint32_t tile_col = dst_slice >> 2;
+        const uint32_t face_col = dst_slice & 0x1;
+        const uint32_t face_row_offset = (dst_slice & 0x2) ? source_slices_per_row / 2 : 0;
+        const uint32_t src_slice = (2 * tile_col) + face_col + face_row_offset;
+        const uint32_t src_addr = src_base + src_slice * slice_bytes;
+        const uint32_t dst_addr = dst_base + dst_slice * slice_bytes;
+        noc.async_read_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+            UnicastEndpoint{},
+            CoreLocalMem<uint32_t>(dst_addr),
+            transfer_bytes,
+            local_src(src_addr),
+            {.offset_bytes = 0});
+    }
+    noc.async_read_barrier();
+}
+
+template <
+    uint32_t source_slices_per_row,
+    uint32_t output_slices_per_row,
+    uint32_t slice_bytes,
+    typename TensorAccessorT>
+FORCE_INLINE void issue_reordered_row_write(
+    CircularBuffer& src_cb,
+    CircularBuffer& scratch_cb,
+    const Noc& noc,
+    const TensorAccessorT& tensor,
+    uint32_t row,
+    uint32_t row_bytes) {
+    src_cb.wait_front(1);
+    scratch_cb.reserve_back(1);
+    copy_row_to_scratch<source_slices_per_row, output_slices_per_row, slice_bytes>(src_cb, scratch_cb, noc);
+    src_cb.pop_front(1);
+
+    scratch_cb.push_back(1);
+    scratch_cb.wait_front(1);
+    noc.async_write(scratch_cb, tensor, row_bytes, {.offset_bytes = 0}, {.page_id = row, .offset_bytes = 0});
+}
+
+template <typename TensorAccessorT>
+FORCE_INLINE void issue_contiguous_row_write(
+    CircularBuffer& src_cb, const Noc& noc, const TensorAccessorT& tensor, uint32_t row, uint32_t row_bytes) {
+    src_cb.wait_front(1);
+    noc.async_write(src_cb, tensor, row_bytes, {.offset_bytes = 0}, {.page_id = row, .offset_bytes = 0});
+}
+
+}  // namespace
+
+void kernel_main() {
+    const uint32_t num_rows = get_arg_val<uint32_t>(0);
+    const uint32_t num_recv = get_arg_val<uint32_t>(1);
+    // Up to 7 (x, y) physical-coordinate pairs of the partners this core
+    // receives from, in level order (P <= 128 -> <= 7 levels). Offsets must
+    // match the factory's partner_coords(14) writer-args block.
+    uint32_t partner_x[7];
+    uint32_t partner_y[7];
+    for (uint32_t m = 0; m < 7; ++m) {
+        partner_x[m] = get_arg_val<uint32_t>(2 + 2 * m);
+        partner_y[m] = get_arg_val<uint32_t>(3 + 2 * m);
+    }
+    const uint32_t do_ship = get_arg_val<uint32_t>(16);
+    const uint32_t winner_x = get_arg_val<uint32_t>(17);
+    const uint32_t winner_y = get_arg_val<uint32_t>(18);
+    const uint32_t is_empty_ship = get_arg_val<uint32_t>(19);
+    const uint32_t indices_addr = get_arg_val<uint32_t>(20);
+
+    constexpr uint32_t cb_ship_values = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_ship_indices = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_neginf_scratch = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_recv = get_compile_time_arg_val(3);
+    constexpr uint32_t ready_sem_id = get_compile_time_arg_val(4);
+    constexpr uint32_t data_sem_id = get_compile_time_arg_val(5);
+    constexpr uint32_t tiles_per_sequence = get_compile_time_arg_val(6);
+    constexpr uint32_t tile_bytes = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_indices_out = get_compile_time_arg_val(8);
+    constexpr uint32_t cb_indices_scratch = get_compile_time_arg_val(9);
+    constexpr uint32_t indices_page_bytes = get_compile_time_arg_val(10);
+    constexpr uint32_t source_slices_per_row = get_compile_time_arg_val(11);
+    constexpr uint32_t output_slices_per_row = get_compile_time_arg_val(12);
+    constexpr uint32_t indices_slice_bytes = get_compile_time_arg_val(13);
+    constexpr auto indices_args = TensorAccessorArgs<14>();
+
+    constexpr uint32_t sequence_tiles = 2 * tiles_per_sequence;
+    constexpr uint32_t sequence_bytes = tiles_per_sequence * tile_bytes;
+
+    Noc noc;
+    Semaphore<> ready_sem(ready_sem_id);
+    Semaphore<> data_sem(data_sem_id);
+    UnicastEndpoint remote;
+    CircularBuffer ship_values_cb(cb_ship_values);
+    CircularBuffer ship_indices_cb(cb_ship_indices);
+    CircularBuffer recv_cb(cb_recv);
+
+    // Address symmetry: the recv CB spans the whole rectangle at one address,
+    // and its pointers wrap to base after every full receive cycle, so this
+    // core's own write pointer doubles as the winner's destination base.
+    const uint32_t recv_values_base = recv_cb.get_write_ptr();
+    const uint32_t recv_indices_base = recv_values_base + sequence_bytes;
+
+    if (do_ship != 0 && is_empty_ship != 0) {
+        CircularBuffer scratch_cb(cb_neginf_scratch);
+        scratch_cb.reserve_back(sequence_tiles);
+        const uint32_t scratch_base = scratch_cb.get_write_ptr();
+        constexpr uint32_t sequence_words = sequence_bytes / sizeof(uint32_t);
+        volatile tt_l1_ptr uint32_t* scratch = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(scratch_base);
+        for (uint32_t i = 0; i < sequence_words; ++i) {
+            scratch[i] = 0xFF800000u;  // exact BF16 -inf in the FP32 DST container
+        }
+        for (uint32_t i = 0; i < sequence_words; ++i) {
+            scratch[sequence_words + i] = 0xFFFFFFFFu;  // sentinel index
+        }
+    }
+
+    const auto indices = TensorAccessor(indices_args, indices_addr, indices_page_bytes);
+    CircularBuffer indices_cb(cb_indices_out);
+
+    for (uint32_t row = 0; row < num_rows; ++row) {
+        // Receive events, in level order.
+        for (uint32_t m = 0; m < num_recv; ++m) {
+            recv_cb.reserve_back(sequence_tiles);
+            data_sem.set(0);
+            ready_sem.up(noc, partner_x[m], partner_y[m], 1);
+            data_sem.wait(1);
+            recv_cb.push_back(sequence_tiles);
+        }
+
+        if (do_ship != 0) {
+            uint32_t src_values;
+            uint32_t src_indices;
+            if (is_empty_ship != 0) {
+                CircularBuffer scratch_cb(cb_neginf_scratch);
+                src_values = scratch_cb.get_write_ptr();
+                src_indices = src_values + sequence_bytes;
+            } else {
+                ship_values_cb.wait_front(tiles_per_sequence);
+                ship_indices_cb.wait_front(tiles_per_sequence);
+                src_values = ship_values_cb.get_read_ptr();
+                src_indices = ship_indices_cb.get_read_ptr();
+            }
+
+            ready_sem.wait(1);
+            ready_sem.set(0);
+
+            noc.async_write(
+                CoreLocalMem<uint32_t>(src_values),
+                remote,
+                sequence_bytes,
+                {.offset_bytes = 0},
+                {.noc_x = winner_x, .noc_y = winner_y, .addr = recv_values_base});
+            noc.async_write(
+                CoreLocalMem<uint32_t>(src_indices),
+                remote,
+                sequence_bytes,
+                {.offset_bytes = 0},
+                {.noc_x = winner_x, .noc_y = winner_y, .addr = recv_indices_base});
+            // Drain both source reads (WAR against the compute producer) and
+            // guarantee data-before-signal at the winner.
+            noc.async_write_barrier();
+
+            data_sem.up(noc, winner_x, winner_y, 1);
+            noc.async_atomic_barrier();
+
+            if (is_empty_ship == 0) {
+                ship_values_cb.pop_front(tiles_per_sequence);
+                ship_indices_cb.pop_front(tiles_per_sequence);
+            }
+        } else {
+            // Root: stream the materialized index row to DRAM.
+            if constexpr (source_slices_per_row == 32) {
+                issue_contiguous_row_write(indices_cb, noc, indices, row, indices_page_bytes);
+                noc.async_writes_flushed();
+                indices_cb.pop_front(1);
+            } else {
+                CircularBuffer indices_scratch_cb(cb_indices_scratch);
+                issue_reordered_row_write<source_slices_per_row, output_slices_per_row, indices_slice_bytes>(
+                    indices_cb, indices_scratch_cb, noc, indices, row, indices_page_bytes);
+                noc.async_writes_flushed();
+                indices_scratch_cb.pop_front(1);
+            }
+        }
+    }
+
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer_tree.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer_tree.cpp
@@ -119,6 +119,8 @@ void kernel_main() {
     const uint32_t winner_y = get_arg_val<uint32_t>(18);
     const uint32_t is_empty_ship = get_arg_val<uint32_t>(19);
     const uint32_t indices_addr = get_arg_val<uint32_t>(20);
+    // Multi-rectangle: this rectangle's first output row (0 on a single-rect program).
+    const uint32_t start_row = get_arg_val<uint32_t>(21);
 
     constexpr uint32_t cb_ship_values = get_compile_time_arg_val(0);
     constexpr uint32_t cb_ship_indices = get_compile_time_arg_val(1);
@@ -223,13 +225,13 @@ void kernel_main() {
         } else {
             // Root: stream the materialized index row to DRAM.
             if constexpr (source_slices_per_row == 32) {
-                issue_contiguous_row_write(indices_cb, noc, indices, row, indices_page_bytes);
+                issue_contiguous_row_write(indices_cb, noc, indices, start_row + row, indices_page_bytes);
                 noc.async_writes_flushed();
                 indices_cb.pop_front(1);
             } else {
                 CircularBuffer indices_scratch_cb(cb_indices_scratch);
                 issue_reordered_row_write<source_slices_per_row, output_slices_per_row, indices_slice_bytes>(
-                    indices_cb, indices_scratch_cb, noc, indices, row, indices_page_bytes);
+                    indices_cb, indices_scratch_cb, noc, indices, start_row + row, indices_page_bytes);
                 noc.async_writes_flushed();
                 indices_scratch_cb.pop_front(1);
             }

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer_tree_flex.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer_tree_flex.cpp
@@ -34,6 +34,10 @@ void kernel_main() {
     const uint32_t winner_y = get_arg_val<uint32_t>(18);
     const uint32_t is_empty_ship = get_arg_val<uint32_t>(19);
     const uint32_t indices_addr = get_arg_val<uint32_t>(20);
+    // Multi-rectangle: this rectangle's first output row (0 on a single-rect
+    // program; the factory forbids tile_output with multiple rectangles, so
+    // the TILE scatter paths below keep their rect-local tile_row).
+    const uint32_t start_row_rt = get_arg_val<uint32_t>(22);
 #ifdef FLEX_WITH_VALUES
     const uint32_t values_addr = get_arg_val<uint32_t>(21);
 #endif
@@ -214,7 +218,7 @@ void kernel_main() {
                     indices,
                     indices_page_bytes,
                     {.offset_bytes = 0},
-                    {.page_id = row, .offset_bytes = 0});
+                    {.page_id = start_row_rt + row, .offset_bytes = 0});
 #endif
                 noc.async_writes_flushed();
                 indices_scratch_cb.pop_front(1);

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer_tree_flex.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer_tree_flex.cpp
@@ -1,0 +1,234 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Column-parallel TREE writer, FLEX output variant: writer_tree.cpp /
+// writer_tree_with_values.cpp's inter-core merge-tree traffic (unchanged),
+// with the root's output emission swapped for the flex formats
+// (FLEX_OUT_TILE / FLEX_INDEX_U16 / FLEX_WITH_VALUES defines) — see
+// writer_flex.cpp and topk_large_indices_writer_flex_common.hpp.
+//
+// The column-parallel factory is only selected for single-row inputs
+// (num_rows == 1, so every leading dim is 1): each output row is its own 2D
+// slab — tile row == row, in-tile row 0, padding rows [1, 32).
+
+#include "api/dataflow/noc_semaphore.h"
+
+#include "topk_large_indices_writer_flex_common.hpp"
+
+void kernel_main() {
+    using namespace topk_large_indices_writer_flex;
+
+    const uint32_t num_rows = get_arg_val<uint32_t>(0);
+    const uint32_t num_recv = get_arg_val<uint32_t>(1);
+    // Up to 7 (x, y) partner pairs (P <= 128 -> <= 7 levels). Offsets must
+    // match the factory's partner_coords(14) writer-args block.
+    uint32_t partner_x[7];
+    uint32_t partner_y[7];
+    for (uint32_t m = 0; m < 7; ++m) {
+        partner_x[m] = get_arg_val<uint32_t>(2 + 2 * m);
+        partner_y[m] = get_arg_val<uint32_t>(3 + 2 * m);
+    }
+    const uint32_t do_ship = get_arg_val<uint32_t>(16);
+    const uint32_t winner_x = get_arg_val<uint32_t>(17);
+    const uint32_t winner_y = get_arg_val<uint32_t>(18);
+    const uint32_t is_empty_ship = get_arg_val<uint32_t>(19);
+    const uint32_t indices_addr = get_arg_val<uint32_t>(20);
+#ifdef FLEX_WITH_VALUES
+    const uint32_t values_addr = get_arg_val<uint32_t>(21);
+#endif
+
+    constexpr uint32_t cb_ship_values = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_ship_indices = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_neginf_scratch = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_recv = get_compile_time_arg_val(3);
+    constexpr uint32_t ready_sem_id = get_compile_time_arg_val(4);
+    constexpr uint32_t data_sem_id = get_compile_time_arg_val(5);
+    constexpr uint32_t tiles_per_sequence = get_compile_time_arg_val(6);
+    constexpr uint32_t tile_bytes = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_indices_out = get_compile_time_arg_val(8);
+    constexpr uint32_t cb_indices_scratch = get_compile_time_arg_val(9);
+    constexpr uint32_t indices_page_bytes = get_compile_time_arg_val(10);
+    constexpr uint32_t source_slices_per_row = get_compile_time_arg_val(11);
+    constexpr uint32_t output_slices_per_row = get_compile_time_arg_val(12);
+    constexpr uint32_t cb_values_out = get_compile_time_arg_val(13);
+    constexpr uint32_t cb_values_scratch = get_compile_time_arg_val(14);
+    constexpr uint32_t values_page_bytes = get_compile_time_arg_val(15);
+    constexpr uint32_t cb_pad_zero = get_compile_time_arg_val(16);
+    constexpr uint32_t tiles_per_out_row = get_compile_time_arg_val(17);
+    constexpr auto indices_args = TensorAccessorArgs<18>();
+#ifdef FLEX_WITH_VALUES
+    constexpr auto values_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
+#endif
+
+#ifdef FLEX_INDEX_U16
+    constexpr uint32_t indices_elem_bytes = 2;
+#else
+    constexpr uint32_t indices_elem_bytes = 4;
+#endif
+    constexpr bool cb_row_major = (source_slices_per_row == 32);
+
+    constexpr uint32_t sequence_tiles = 2 * tiles_per_sequence;
+    constexpr uint32_t sequence_bytes = tiles_per_sequence * tile_bytes;
+
+    Noc noc;
+    Semaphore<> ready_sem(ready_sem_id);
+    Semaphore<> data_sem(data_sem_id);
+    UnicastEndpoint remote;
+    CircularBuffer ship_values_cb(cb_ship_values);
+    CircularBuffer ship_indices_cb(cb_ship_indices);
+    CircularBuffer recv_cb(cb_recv);
+
+    const uint32_t recv_values_base = recv_cb.get_write_ptr();
+    const uint32_t recv_indices_base = recv_values_base + sequence_bytes;
+
+    if (do_ship != 0 && is_empty_ship != 0) {
+        CircularBuffer scratch_cb(cb_neginf_scratch);
+        scratch_cb.reserve_back(sequence_tiles);
+        const uint32_t scratch_base = scratch_cb.get_write_ptr();
+        constexpr uint32_t sequence_words = sequence_bytes / sizeof(uint32_t);
+        volatile tt_l1_ptr uint32_t* scratch = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(scratch_base);
+        for (uint32_t i = 0; i < sequence_words; ++i) {
+            scratch[i] = 0xFF800000u;
+        }
+        for (uint32_t i = 0; i < sequence_words; ++i) {
+            scratch[sequence_words + i] = 0xFFFFFFFFu;
+        }
+    }
+
+    const auto indices = TensorAccessor(indices_args, indices_addr, indices_page_bytes);
+    CircularBuffer indices_cb(cb_indices_out);
+#ifdef FLEX_WITH_VALUES
+    const auto values = TensorAccessor(values_args, values_addr, values_page_bytes);
+    CircularBuffer values_cb(cb_values_out);
+#endif
+
+#ifdef FLEX_OUT_TILE
+    if (do_ship == 0) {
+        // Root: pre-issue every slab's padding rows (each output row is its
+        // own [1, k] slab -> pad rows [1, 32) of tile row == row) before the
+        // merge tree even starts — pad rows are disjoint from data rows, so
+        // their NoC injection hides under the compute pipeline.
+        const uint32_t zero_base = init_pad_slab(cb_pad_zero);
+        for (uint32_t row = 0; row < num_rows; ++row) {
+            issue_tile_row_pad<indices_elem_bytes>(noc, indices, zero_base, row, /*pad_from=*/1, tiles_per_out_row);
+#ifdef FLEX_WITH_VALUES
+            issue_tile_row_pad<2>(noc, values, zero_base, row, /*pad_from=*/1, tiles_per_out_row);
+#endif
+        }
+    }
+#endif
+
+    for (uint32_t row = 0; row < num_rows; ++row) {
+        for (uint32_t m = 0; m < num_recv; ++m) {
+            recv_cb.reserve_back(sequence_tiles);
+            data_sem.set(0);
+            ready_sem.up(noc, partner_x[m], partner_y[m], 1);
+            data_sem.wait(1);
+            recv_cb.push_back(sequence_tiles);
+        }
+
+        if (do_ship != 0) {
+            uint32_t src_values;
+            uint32_t src_indices;
+            if (is_empty_ship != 0) {
+                CircularBuffer scratch_cb(cb_neginf_scratch);
+                src_values = scratch_cb.get_write_ptr();
+                src_indices = src_values + sequence_bytes;
+            } else {
+                ship_values_cb.wait_front(tiles_per_sequence);
+                ship_indices_cb.wait_front(tiles_per_sequence);
+                src_values = ship_values_cb.get_read_ptr();
+                src_indices = ship_indices_cb.get_read_ptr();
+            }
+
+            ready_sem.wait(1);
+            ready_sem.set(0);
+
+            noc.async_write(
+                CoreLocalMem<uint32_t>(src_values),
+                remote,
+                sequence_bytes,
+                {.offset_bytes = 0},
+                {.noc_x = winner_x, .noc_y = winner_y, .addr = recv_values_base});
+            noc.async_write(
+                CoreLocalMem<uint32_t>(src_indices),
+                remote,
+                sequence_bytes,
+                {.offset_bytes = 0},
+                {.noc_x = winner_x, .noc_y = winner_y, .addr = recv_indices_base});
+            noc.async_write_barrier();
+
+            data_sem.up(noc, winner_x, winner_y, 1);
+            noc.async_atomic_barrier();
+
+            if (is_empty_ship == 0) {
+                ship_values_cb.pop_front(tiles_per_sequence);
+                ship_indices_cb.pop_front(tiles_per_sequence);
+            }
+        } else {
+            // Root: values row then indices row (compute pushes in that order).
+#ifdef FLEX_OUT_TILE
+            const uint32_t tile_row = row;  // single-row slabs: one tile row per output row
+            constexpr uint32_t in_tile_r = 0;
+#endif
+
+#ifdef FLEX_WITH_VALUES
+#ifdef FLEX_OUT_TILE
+            values_cb.wait_front(1);
+            issue_tile_row_scatter<source_slices_per_row, output_slices_per_row, 32, 2, cb_row_major>(
+                noc, values, values_cb.get_read_ptr(), tile_row, in_tile_r, tiles_per_out_row);
+            noc.async_writes_flushed();
+            values_cb.pop_front(1);
+#else
+            if constexpr (cb_row_major) {
+                issue_contiguous_row_write(values_cb, noc, values, row, values_page_bytes);
+                noc.async_writes_flushed();
+                values_cb.pop_front(1);
+            } else {
+                CircularBuffer values_scratch_cb(cb_values_scratch);
+                issue_reordered_row_write<source_slices_per_row, output_slices_per_row, 32>(
+                    values_cb, values_scratch_cb, noc, values, row, values_page_bytes);
+                noc.async_writes_flushed();
+                values_scratch_cb.pop_front(1);
+            }
+#endif
+#endif  // FLEX_WITH_VALUES
+
+#ifdef FLEX_INDEX_U16
+            {
+                CircularBuffer indices_scratch_cb(cb_indices_scratch);
+                indices_cb.wait_front(1);
+                indices_scratch_cb.reserve_back(1);
+                narrow_row_to_u16<source_slices_per_row, output_slices_per_row>(
+                    indices_cb.get_read_ptr(), indices_scratch_cb.get_write_ptr());
+                indices_cb.pop_front(1);  // narrowed synchronously by this RISC
+                indices_scratch_cb.push_back(1);
+                indices_scratch_cb.wait_front(1);
+#ifdef FLEX_OUT_TILE
+                issue_tile_row_scatter<source_slices_per_row, output_slices_per_row, 32, 2, /*src_row_major=*/true>(
+                    noc, indices, indices_scratch_cb.get_read_ptr(), tile_row, in_tile_r, tiles_per_out_row);
+#else
+                noc.async_write(
+                    indices_scratch_cb,
+                    indices,
+                    indices_page_bytes,
+                    {.offset_bytes = 0},
+                    {.page_id = row, .offset_bytes = 0});
+#endif
+                noc.async_writes_flushed();
+                indices_scratch_cb.pop_front(1);
+            }
+#else
+            // UINT32 indices; flex requires an opt-in, so this is TILE output.
+            indices_cb.wait_front(1);
+            issue_tile_row_scatter<source_slices_per_row, output_slices_per_row, 64, 4, cb_row_major>(
+                noc, indices, indices_cb.get_read_ptr(), tile_row, in_tile_r, tiles_per_out_row);
+            noc.async_writes_flushed();
+            indices_cb.pop_front(1);
+#endif
+        }
+    }
+
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer_tree_with_values.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer_tree_with_values.cpp
@@ -100,6 +100,8 @@ void kernel_main() {
     const uint32_t is_empty_ship = get_arg_val<uint32_t>(19);
     const uint32_t indices_addr = get_arg_val<uint32_t>(20);
     const uint32_t values_addr = get_arg_val<uint32_t>(21);
+    // Multi-rectangle: this rectangle's first output row (0 on a single-rect program).
+    const uint32_t start_row = get_arg_val<uint32_t>(22);
 
     constexpr uint32_t cb_ship_values = get_compile_time_arg_val(0);
     constexpr uint32_t cb_ship_indices = get_compile_time_arg_val(1);
@@ -205,23 +207,23 @@ void kernel_main() {
         } else {
             // Root: values row then indices row (compute pushes in that order).
             if constexpr (source_slices_per_row == 32) {
-                issue_contiguous_row_write(values_cb, noc, values, row, values_page_bytes);
+                issue_contiguous_row_write(values_cb, noc, values, start_row + row, values_page_bytes);
                 noc.async_writes_flushed();
                 values_cb.pop_front(1);
 
-                issue_contiguous_row_write(indices_cb, noc, indices, row, indices_page_bytes);
+                issue_contiguous_row_write(indices_cb, noc, indices, start_row + row, indices_page_bytes);
                 noc.async_writes_flushed();
                 indices_cb.pop_front(1);
             } else {
                 CircularBuffer values_scratch_cb(cb_values_scratch);
                 issue_reordered_row_write<source_slices_per_row, output_slices_per_row, values_slice_bytes>(
-                    values_cb, values_scratch_cb, noc, values, row, values_page_bytes);
+                    values_cb, values_scratch_cb, noc, values, start_row + row, values_page_bytes);
                 noc.async_writes_flushed();
                 values_scratch_cb.pop_front(1);
 
                 CircularBuffer indices_scratch_cb(cb_indices_scratch);
                 issue_reordered_row_write<source_slices_per_row, output_slices_per_row, indices_slice_bytes>(
-                    indices_cb, indices_scratch_cb, noc, indices, row, indices_page_bytes);
+                    indices_cb, indices_scratch_cb, noc, indices, start_row + row, indices_page_bytes);
                 noc.async_writes_flushed();
                 indices_scratch_cb.pop_front(1);
             }

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer_tree_with_values.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer_tree_with_values.cpp
@@ -1,0 +1,232 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Column-parallel TREE writer, return_values variant: writer_tree.cpp plus a
+// second BFLOAT16 output stream at the root (the tree's inter-core traffic is
+// unchanged — survivors always travel with their values). Separate source so
+// the indices-only tree writer binary stays independent.
+
+#include "api/core_local_mem.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/tensor/noc_traits.h"
+
+namespace {
+
+template <uint32_t source_slices_per_row, uint32_t output_slices_per_row, uint32_t slice_bytes>
+FORCE_INLINE void copy_row_to_scratch(CircularBuffer& src_cb, CircularBuffer& scratch_cb, const Noc& noc) {
+    static_assert(source_slices_per_row == 64 || source_slices_per_row == 128);
+    static_assert(output_slices_per_row >= 1 && output_slices_per_row <= source_slices_per_row);
+    constexpr uint32_t transfer_bytes = slice_bytes;
+    static_assert(transfer_bytes <= NOC_MAX_BURST_SIZE);
+
+    const uint32_t src_base = src_cb.get_read_ptr();
+    const uint32_t dst_base = scratch_cb.get_write_ptr();
+    const uint32_t noc_id = noc.get_noc_id();
+    const auto local_src = [noc_id](uint32_t addr) {
+        return noc_traits_t<UnicastEndpoint>::src_args_type{
+            .noc_x = static_cast<uint32_t>(my_x[noc_id]), .noc_y = static_cast<uint32_t>(my_y[noc_id]), .addr = addr};
+    };
+
+    noc.set_async_read_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+        UnicastEndpoint{}, transfer_bytes, local_src(src_base));
+
+    for (uint32_t dst_slice = 0; dst_slice < output_slices_per_row; ++dst_slice) {
+        const uint32_t tile_col = dst_slice >> 2;
+        const uint32_t face_col = dst_slice & 0x1;
+        const uint32_t face_row_offset = (dst_slice & 0x2) ? source_slices_per_row / 2 : 0;
+        const uint32_t src_slice = (2 * tile_col) + face_col + face_row_offset;
+        const uint32_t src_addr = src_base + src_slice * slice_bytes;
+        const uint32_t dst_addr = dst_base + dst_slice * slice_bytes;
+        noc.async_read_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+            UnicastEndpoint{},
+            CoreLocalMem<uint32_t>(dst_addr),
+            transfer_bytes,
+            local_src(src_addr),
+            {.offset_bytes = 0});
+    }
+    noc.async_read_barrier();
+}
+
+template <
+    uint32_t source_slices_per_row,
+    uint32_t output_slices_per_row,
+    uint32_t slice_bytes,
+    typename TensorAccessorT>
+FORCE_INLINE void issue_reordered_row_write(
+    CircularBuffer& src_cb,
+    CircularBuffer& scratch_cb,
+    const Noc& noc,
+    const TensorAccessorT& tensor,
+    uint32_t row,
+    uint32_t row_bytes) {
+    src_cb.wait_front(1);
+    scratch_cb.reserve_back(1);
+    copy_row_to_scratch<source_slices_per_row, output_slices_per_row, slice_bytes>(src_cb, scratch_cb, noc);
+    src_cb.pop_front(1);
+
+    scratch_cb.push_back(1);
+    scratch_cb.wait_front(1);
+    noc.async_write(scratch_cb, tensor, row_bytes, {.offset_bytes = 0}, {.page_id = row, .offset_bytes = 0});
+}
+
+template <typename TensorAccessorT>
+FORCE_INLINE void issue_contiguous_row_write(
+    CircularBuffer& src_cb, const Noc& noc, const TensorAccessorT& tensor, uint32_t row, uint32_t row_bytes) {
+    src_cb.wait_front(1);
+    noc.async_write(src_cb, tensor, row_bytes, {.offset_bytes = 0}, {.page_id = row, .offset_bytes = 0});
+}
+
+}  // namespace
+
+void kernel_main() {
+    const uint32_t num_rows = get_arg_val<uint32_t>(0);
+    const uint32_t num_recv = get_arg_val<uint32_t>(1);
+    // Up to 7 (x, y) partner pairs (P <= 128 -> <= 7 levels). Offsets must
+    // match the factory's partner_coords(14) writer-args block.
+    uint32_t partner_x[7];
+    uint32_t partner_y[7];
+    for (uint32_t m = 0; m < 7; ++m) {
+        partner_x[m] = get_arg_val<uint32_t>(2 + 2 * m);
+        partner_y[m] = get_arg_val<uint32_t>(3 + 2 * m);
+    }
+    const uint32_t do_ship = get_arg_val<uint32_t>(16);
+    const uint32_t winner_x = get_arg_val<uint32_t>(17);
+    const uint32_t winner_y = get_arg_val<uint32_t>(18);
+    const uint32_t is_empty_ship = get_arg_val<uint32_t>(19);
+    const uint32_t indices_addr = get_arg_val<uint32_t>(20);
+    const uint32_t values_addr = get_arg_val<uint32_t>(21);
+
+    constexpr uint32_t cb_ship_values = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_ship_indices = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_neginf_scratch = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_recv = get_compile_time_arg_val(3);
+    constexpr uint32_t ready_sem_id = get_compile_time_arg_val(4);
+    constexpr uint32_t data_sem_id = get_compile_time_arg_val(5);
+    constexpr uint32_t tiles_per_sequence = get_compile_time_arg_val(6);
+    constexpr uint32_t tile_bytes = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_indices_out = get_compile_time_arg_val(8);
+    constexpr uint32_t cb_indices_scratch = get_compile_time_arg_val(9);
+    constexpr uint32_t indices_page_bytes = get_compile_time_arg_val(10);
+    constexpr uint32_t source_slices_per_row = get_compile_time_arg_val(11);
+    constexpr uint32_t output_slices_per_row = get_compile_time_arg_val(12);
+    constexpr uint32_t indices_slice_bytes = get_compile_time_arg_val(13);
+    constexpr uint32_t cb_values_out = get_compile_time_arg_val(14);
+    constexpr uint32_t cb_values_scratch = get_compile_time_arg_val(15);
+    constexpr uint32_t values_page_bytes = get_compile_time_arg_val(16);
+    constexpr uint32_t values_slice_bytes = get_compile_time_arg_val(17);
+    constexpr auto indices_args = TensorAccessorArgs<18>();
+    constexpr auto values_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
+
+    constexpr uint32_t sequence_tiles = 2 * tiles_per_sequence;
+    constexpr uint32_t sequence_bytes = tiles_per_sequence * tile_bytes;
+
+    Noc noc;
+    Semaphore<> ready_sem(ready_sem_id);
+    Semaphore<> data_sem(data_sem_id);
+    UnicastEndpoint remote;
+    CircularBuffer ship_values_cb(cb_ship_values);
+    CircularBuffer ship_indices_cb(cb_ship_indices);
+    CircularBuffer recv_cb(cb_recv);
+
+    const uint32_t recv_values_base = recv_cb.get_write_ptr();
+    const uint32_t recv_indices_base = recv_values_base + sequence_bytes;
+
+    if (do_ship != 0 && is_empty_ship != 0) {
+        CircularBuffer scratch_cb(cb_neginf_scratch);
+        scratch_cb.reserve_back(sequence_tiles);
+        const uint32_t scratch_base = scratch_cb.get_write_ptr();
+        constexpr uint32_t sequence_words = sequence_bytes / sizeof(uint32_t);
+        volatile tt_l1_ptr uint32_t* scratch = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(scratch_base);
+        for (uint32_t i = 0; i < sequence_words; ++i) {
+            scratch[i] = 0xFF800000u;
+        }
+        for (uint32_t i = 0; i < sequence_words; ++i) {
+            scratch[sequence_words + i] = 0xFFFFFFFFu;
+        }
+    }
+
+    const auto indices = TensorAccessor(indices_args, indices_addr, indices_page_bytes);
+    const auto values = TensorAccessor(values_args, values_addr, values_page_bytes);
+    CircularBuffer indices_cb(cb_indices_out);
+    CircularBuffer values_cb(cb_values_out);
+
+    for (uint32_t row = 0; row < num_rows; ++row) {
+        for (uint32_t m = 0; m < num_recv; ++m) {
+            recv_cb.reserve_back(sequence_tiles);
+            data_sem.set(0);
+            ready_sem.up(noc, partner_x[m], partner_y[m], 1);
+            data_sem.wait(1);
+            recv_cb.push_back(sequence_tiles);
+        }
+
+        if (do_ship != 0) {
+            uint32_t src_values;
+            uint32_t src_indices;
+            if (is_empty_ship != 0) {
+                CircularBuffer scratch_cb(cb_neginf_scratch);
+                src_values = scratch_cb.get_write_ptr();
+                src_indices = src_values + sequence_bytes;
+            } else {
+                ship_values_cb.wait_front(tiles_per_sequence);
+                ship_indices_cb.wait_front(tiles_per_sequence);
+                src_values = ship_values_cb.get_read_ptr();
+                src_indices = ship_indices_cb.get_read_ptr();
+            }
+
+            ready_sem.wait(1);
+            ready_sem.set(0);
+
+            noc.async_write(
+                CoreLocalMem<uint32_t>(src_values),
+                remote,
+                sequence_bytes,
+                {.offset_bytes = 0},
+                {.noc_x = winner_x, .noc_y = winner_y, .addr = recv_values_base});
+            noc.async_write(
+                CoreLocalMem<uint32_t>(src_indices),
+                remote,
+                sequence_bytes,
+                {.offset_bytes = 0},
+                {.noc_x = winner_x, .noc_y = winner_y, .addr = recv_indices_base});
+            noc.async_write_barrier();
+
+            data_sem.up(noc, winner_x, winner_y, 1);
+            noc.async_atomic_barrier();
+
+            if (is_empty_ship == 0) {
+                ship_values_cb.pop_front(tiles_per_sequence);
+                ship_indices_cb.pop_front(tiles_per_sequence);
+            }
+        } else {
+            // Root: values row then indices row (compute pushes in that order).
+            if constexpr (source_slices_per_row == 32) {
+                issue_contiguous_row_write(values_cb, noc, values, row, values_page_bytes);
+                noc.async_writes_flushed();
+                values_cb.pop_front(1);
+
+                issue_contiguous_row_write(indices_cb, noc, indices, row, indices_page_bytes);
+                noc.async_writes_flushed();
+                indices_cb.pop_front(1);
+            } else {
+                CircularBuffer values_scratch_cb(cb_values_scratch);
+                issue_reordered_row_write<source_slices_per_row, output_slices_per_row, values_slice_bytes>(
+                    values_cb, values_scratch_cb, noc, values, row, values_page_bytes);
+                noc.async_writes_flushed();
+                values_scratch_cb.pop_front(1);
+
+                CircularBuffer indices_scratch_cb(cb_indices_scratch);
+                issue_reordered_row_write<source_slices_per_row, output_slices_per_row, indices_slice_bytes>(
+                    indices_cb, indices_scratch_cb, noc, indices, row, indices_page_bytes);
+                noc.async_writes_flushed();
+                indices_scratch_cb.pop_front(1);
+            }
+        }
+    }
+
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer_with_values.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer_with_values.cpp
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Output writer, return_values variant: writer.cpp's stream (UINT32 indices,
+// with the face-pair -> row-major slice reorder for LLK windows > 512) plus a
+// second, structurally identical stream for the BFLOAT16 values row. The
+// reorder helpers are shared templates parameterized on slice size, so the
+// values stream reuses them with 2-byte elements. Kept as a separate source
+// so the default indices-only writer binary stays byte-identical.
+
+#include "api/core_local_mem.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/noc.h"
+#include "api/tensor/noc_traits.h"
+
+namespace {
+
+template <uint32_t source_slices_per_row, uint32_t output_slices_per_row, uint32_t slice_bytes>
+FORCE_INLINE void copy_row_to_scratch(CircularBuffer& src_cb, CircularBuffer& scratch_cb, const Noc& noc) {
+    static_assert(source_slices_per_row == 64 || source_slices_per_row == 128);
+    static_assert(output_slices_per_row >= 1 && output_slices_per_row <= source_slices_per_row);
+    constexpr uint32_t transfer_bytes = slice_bytes;
+    static_assert(transfer_bytes <= NOC_MAX_BURST_SIZE);
+
+    const uint32_t src_base = src_cb.get_read_ptr();
+    const uint32_t dst_base = scratch_cb.get_write_ptr();
+    const uint32_t noc_id = noc.get_noc_id();
+    const auto local_src = [noc_id](uint32_t addr) {
+        return noc_traits_t<UnicastEndpoint>::src_args_type{
+            .noc_x = static_cast<uint32_t>(my_x[noc_id]), .noc_y = static_cast<uint32_t>(my_y[noc_id]), .addr = addr};
+    };
+
+    noc.set_async_read_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+        UnicastEndpoint{}, transfer_bytes, local_src(src_base));
+
+    for (uint32_t dst_slice = 0; dst_slice < output_slices_per_row; ++dst_slice) {
+        // pack_untilize emits 16-element slices in face-pair order:
+        // [top-left, bottom-left, top-right, bottom-right] for each tile column.
+        const uint32_t tile_col = dst_slice >> 2;
+        const uint32_t face_col = dst_slice & 0x1;
+        const uint32_t face_row_offset = (dst_slice & 0x2) ? source_slices_per_row / 2 : 0;
+        const uint32_t src_slice = (2 * tile_col) + face_col + face_row_offset;
+        const uint32_t src_addr = src_base + src_slice * slice_bytes;
+        const uint32_t dst_addr = dst_base + dst_slice * slice_bytes;
+        noc.async_read_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+            UnicastEndpoint{},
+            CoreLocalMem<uint32_t>(dst_addr),
+            transfer_bytes,
+            local_src(src_addr),
+            {.offset_bytes = 0});
+    }
+    noc.async_read_barrier();
+}
+
+template <
+    uint32_t source_slices_per_row,
+    uint32_t output_slices_per_row,
+    uint32_t slice_bytes,
+    typename TensorAccessorT>
+FORCE_INLINE void issue_reordered_row_write(
+    CircularBuffer& src_cb,
+    CircularBuffer& scratch_cb,
+    const Noc& noc,
+    const TensorAccessorT& tensor,
+    uint32_t row,
+    uint32_t row_bytes) {
+    src_cb.wait_front(1);
+    scratch_cb.reserve_back(1);
+    copy_row_to_scratch<source_slices_per_row, output_slices_per_row, slice_bytes>(src_cb, scratch_cb, noc);
+    src_cb.pop_front(1);
+
+    scratch_cb.push_back(1);
+    scratch_cb.wait_front(1);
+    noc.async_write(scratch_cb, tensor, row_bytes, {.offset_bytes = 0}, {.page_id = row, .offset_bytes = 0});
+}
+
+template <typename TensorAccessorT>
+FORCE_INLINE void issue_contiguous_row_write(
+    CircularBuffer& src_cb, const Noc& noc, const TensorAccessorT& tensor, uint32_t row, uint32_t row_bytes) {
+    src_cb.wait_front(1);
+    noc.async_write(src_cb, tensor, row_bytes, {.offset_bytes = 0}, {.page_id = row, .offset_bytes = 0});
+}
+
+}  // namespace
+
+void kernel_main() {
+    const uint32_t indices_addr = get_arg_val<uint32_t>(0);
+    const uint32_t start_row = get_arg_val<uint32_t>(1);
+    const uint32_t num_rows = get_arg_val<uint32_t>(2);
+    const uint32_t values_addr = get_arg_val<uint32_t>(3);
+
+    constexpr uint32_t cb_indices = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_indices_scratch = get_compile_time_arg_val(1);
+    constexpr uint32_t indices_page_bytes = get_compile_time_arg_val(2);
+    constexpr uint32_t source_slices_per_row = get_compile_time_arg_val(3);
+    constexpr uint32_t output_slices_per_row = get_compile_time_arg_val(4);
+    constexpr uint32_t indices_slice_bytes = get_compile_time_arg_val(5);
+    constexpr uint32_t cb_values = get_compile_time_arg_val(6);
+    constexpr uint32_t cb_values_scratch = get_compile_time_arg_val(7);
+    constexpr uint32_t values_page_bytes = get_compile_time_arg_val(8);
+    constexpr uint32_t values_slice_bytes = get_compile_time_arg_val(9);
+    constexpr auto indices_args = TensorAccessorArgs<10>();
+    constexpr auto values_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
+
+    const auto indices = TensorAccessor(indices_args, indices_addr, indices_page_bytes);
+    const auto values = TensorAccessor(values_args, values_addr, values_page_bytes);
+    CircularBuffer indices_cb(cb_indices);
+    CircularBuffer values_cb(cb_values);
+    Noc noc;
+
+    if constexpr (source_slices_per_row == 32) {
+        // LLK window 512: pack_untilize already emitted row-major rows.
+        for (uint32_t local_row = 0; local_row < num_rows; ++local_row) {
+            const uint32_t row = start_row + local_row;
+            // Compute pushes values then indices each row; consume in the same order.
+            issue_contiguous_row_write(values_cb, noc, values, row, values_page_bytes);
+            noc.async_writes_flushed();
+            values_cb.pop_front(1);
+
+            issue_contiguous_row_write(indices_cb, noc, indices, row, indices_page_bytes);
+            noc.async_writes_flushed();
+            indices_cb.pop_front(1);
+        }
+    } else {
+        CircularBuffer indices_scratch_cb(cb_indices_scratch);
+        CircularBuffer values_scratch_cb(cb_values_scratch);
+        for (uint32_t local_row = 0; local_row < num_rows; ++local_row) {
+            const uint32_t row = start_row + local_row;
+            issue_reordered_row_write<source_slices_per_row, output_slices_per_row, values_slice_bytes>(
+                values_cb, values_scratch_cb, noc, values, row, values_page_bytes);
+            noc.async_writes_flushed();
+            values_scratch_cb.pop_front(1);
+
+            issue_reordered_row_write<source_slices_per_row, output_slices_per_row, indices_slice_bytes>(
+                indices_cb, indices_scratch_cb, noc, indices, row, indices_page_bytes);
+            noc.async_writes_flushed();
+            indices_scratch_cb.pop_front(1);
+        }
+    }
+
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.cpp
@@ -81,10 +81,10 @@ void validate_runtime_args(const operation_attributes_t& attrs, const tensor_arg
     if (attrs.valid_length.has_value()) {
         const uint32_t valid_length = attrs.valid_length.value();
         TT_FATAL(valid_length > 0, "topk_large_indices valid_length must be > 0");
-        // NOTE: valid_length < k is supported by design — lanes beyond the prefix's
+        // valid_length < k is supported by design — lanes beyond the prefix's
         // capacity emit the 0xFFFFFFFF sentinel index (and -inf values when
-        // return_values is set). The public docstring's "[k, last dimension]" domain
-        // is stale; the tested contract is (0, last dimension].
+        // return_values is set); the documented and tested domain is
+        // (0, last dimension].
         TT_FATAL(
             valid_length <= n,
             "topk_large_indices valid_length {} must be <= the input last dimension {}",

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.cpp
@@ -4,6 +4,10 @@
 
 #include "topk_large_indices_device_operation.hpp"
 
+#include <algorithm>
+
+#include "ttnn/operations/data_movement/concat/concat.hpp"
+
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/math.hpp>
 
@@ -46,6 +50,22 @@ void validate_static_args(const operation_attributes_t& attrs, const tensor_args
             attrs.index_dtype == DataType::UINT32 || attrs.index_dtype == DataType::UINT16,
             "topk_large_indices index_dtype must be UINT32 or UINT16, got {}",
             attrs.index_dtype.value());
+    }
+    // The TILE-output and UINT16-index opt-ins are implemented by the
+    // row-parallel flex writer and the single-row tree-root writer only.
+    // Multi-row rectangle launches (explicit num_slices >= 2 on a multi-row
+    // shape) have neither; without this check the u16 output spec halves the
+    // indices page size under a writer that still emits u32, overflowing into
+    // the values buffer -- silent corruption, so fail loudly instead.
+    if (attrs.num_slices.value_or(1) >= 2 && (attrs.tile_output || attrs.index_dtype == DataType::UINT16)) {
+        const uint32_t rows = operations::experimental::topk_large_indices::flattened_rows_excluding_last_dim(
+            input.logical_shape());
+        TT_FATAL(
+            rows <= 1,
+            "topk_large_indices multi-row rectangle launches (num_slices={} with {} rows) support neither "
+            "tile_output nor index_dtype=UINT16; drop the opt-in or the explicit num_slices",
+            attrs.num_slices.value(),
+            rows);
     }
 }
 
@@ -92,6 +112,24 @@ void validate_runtime_args(const operation_attributes_t& attrs, const tensor_arg
             n);
     }
 
+    // Composite-internal row window: must map onto the canonical rows dimension (all leading dims 1)
+    // and stay in bounds. Both fields travel together.
+    TT_FATAL(
+        attrs.row_start.has_value() == attrs.row_count.has_value(),
+        "topk_large_indices row_start and row_count must be set together");
+    if (attrs.row_count.has_value()) {
+        TT_FATAL(
+            shape.rank() >= 2 && num_rows == shape[shape.rank() - 2],
+            "topk_large_indices row windows require the canonical [1.., R, W] shape (leading dims 1)");
+        const uint64_t row_end = static_cast<uint64_t>(*attrs.row_start) + *attrs.row_count;
+        TT_FATAL(
+            *attrs.row_count > 0 && row_end <= num_rows,
+            "topk_large_indices row window [{}, {}) out of bounds for {} rows",
+            *attrs.row_start,
+            row_end,
+            num_rows);
+    }
+
     // UINT16 index emission: every real winner index must provably fit 16 bits. Winners are
     // positions < the searched width, so search_len <= 65535 guarantees winners <= 65534 and keeps
     // 0xFFFF unambiguous as the truncated -inf sentinel. Checked at runtime because the shape (and
@@ -126,9 +164,16 @@ program::ColumnSplitConfig column_split_config_for(
     const auto& input = tensor_args.input_tensor;
     const auto& shape = input.logical_shape();
     const uint32_t n = shape[shape.rank() - 1];
-    const uint32_t num_rows = flattened_rows_excluding_last_dim(shape);
+    const uint32_t num_rows = attrs.row_count.value_or(flattened_rows_excluding_last_dim(shape));
     const auto grid = input.device()->compute_with_storage_grid_size();
-    return program::compute_column_split_config(attrs.k, n, num_rows, grid, attrs.num_slices);
+    // The device op NEVER auto-selects the multi-row rectangle form: engine
+    // choice must not depend on layout/dtype opt-ins (tile_output forces
+    // ROW_MAJOR-only rects off, and the non-stable op breaks bf16 ties
+    // differently across engines, so "opt-ins change layout, never results"
+    // would silently break). Multi-row rects run only with an explicit
+    // num_slices — set by callers or by the hybrid wrapper's remainder window.
+    return program::compute_column_split_config(
+        attrs.k, n, num_rows, grid, attrs.num_slices, /*allow_multi_row=*/false);
 }
 
 }  // namespace
@@ -173,7 +218,19 @@ ttsl::hash::hash_t TopkLargeIndicesDeviceOperation::compute_program_hash(
         split_config.enabled,
         split_config.num_slices,
         split_config.local_grid_x,
-        split_config.local_grid_y);
+        split_config.local_grid_y,
+        // Rectangle count is program structure (kernel core placement); row
+        // distribution within a fixed rectangle layout stays runtime-only.
+        split_config.num_rects,
+        // Compute-body mode, single-sourced with the factory's kernel-define
+        // selection (see compute_body_mode). For k >= 1024 the mode is
+        // width-independent (one segmented codepath at every width), so the
+        // hash carries NO width term there -- growing-prefill callers never
+        // recompile crossing the old 65536 fused boundary. For smaller k the
+        // mode still folds in the <= 32-chunk fused bit, the only width term.
+        static_cast<uint32_t>(program::compute_body_mode(attrs.k, input.logical_shape()[-1])),
+        // Swaps the sentinel-marking kernel define.
+        attrs.neginf_sentinel);
 }
 
 spec_return_value_t TopkLargeIndicesDeviceOperation::compute_output_specs(
@@ -185,6 +242,10 @@ spec_return_value_t TopkLargeIndicesDeviceOperation::compute_output_specs(
         output_shape_vec.push_back(input_shape[i]);
     }
     output_shape_vec.back() = attrs.k;
+    if (attrs.row_count.has_value()) {
+        // Row-window launch: the output carries only the window's rows.
+        output_shape_vec[output_shape_vec.size() - 2] = *attrs.row_count;
+    }
     const ttnn::Shape output_shape(std::move(output_shape_vec));
 
     const auto memory_config = tensor_args.input_tensor.memory_config();
@@ -221,15 +282,21 @@ TopkLargeIndicesDeviceOperation::invoke(
     bool return_values,
     std::optional<uint32_t> num_slices,
     bool tile_output,
-    std::optional<DataType> index_dtype) {
+    std::optional<DataType> index_dtype,
+    std::optional<uint32_t> row_start,
+    std::optional<uint32_t> row_count,
+    bool neginf_sentinel) {
     return {
         operation_attributes_t{
             .k = k,
             .valid_length = valid_length,
             .return_values = return_values,
             .num_slices = num_slices,
+            .row_start = row_start,
+            .row_count = row_count,
             .tile_output = tile_output,
-            .index_dtype = index_dtype},
+            .index_dtype = index_dtype,
+            .neginf_sentinel = neginf_sentinel},
         tensor_args_t{.input_tensor = input_tensor}};
 }
 
@@ -237,19 +304,129 @@ TopkLargeIndicesDeviceOperation::invoke(
 
 namespace ttnn::experimental {
 
+namespace {
+
+// Hybrid row split: for canonical multi-row calls whose rows exceed the worker
+// grid (>= 2 row-parallel waves), peel the partially-filled last wave off into
+// a concurrent multi-rectangle launch — the row-parallel full waves keep every
+// core busy, and the remainder rows run column-parallel trees on the cores the
+// last wave would have left idle. Two launches over one un-sliced input (the
+// device op's internal row window), then a cheap [rows, k] concat. Returns
+// (full-wave rows, remainder rows, remainder P), or nullopt when the plain
+// single launch is already the right program.
+struct HybridSplit {
+    uint32_t full_wave_rows;
+    uint32_t remainder_rows;
+    uint32_t remainder_slices;
+};
+std::optional<HybridSplit> hybrid_row_split(
+    const Tensor& input,
+    uint32_t k,
+    std::optional<uint32_t> num_slices,
+    bool tile_output,
+    std::optional<DataType> index_dtype,
+    std::optional<uint32_t> valid_length) {
+    if (num_slices.has_value() || tile_output || index_dtype == DataType::UINT16) {
+        // Explicit P and TILE-output calls keep their single launch; UINT16
+        // indices are row-parallel/single-row-tree only, and the hybrid's
+        // remainder window is a multi-row rectangle launch -- fall back to
+        // the plain row-parallel program, which supports u16 at any row count.
+        return std::nullopt;
+    }
+    if (input.storage_type() != StorageType::DEVICE || input.device() == nullptr) {
+        return std::nullopt;
+    }
+    const auto& shape = input.logical_shape();
+    if (shape.rank() < 2) {
+        return std::nullopt;
+    }
+    const uint32_t rows = operations::experimental::topk_large_indices::flattened_rows_excluding_last_dim(shape);
+    if (rows == 0 || rows != shape[shape.rank() - 2]) {
+        return std::nullopt;  // the row window needs the canonical [1.., R, W] shape
+    }
+    const auto grid = input.device()->compute_with_storage_grid_size();
+    const uint32_t cores = static_cast<uint32_t>(grid.x) * static_cast<uint32_t>(grid.y);
+    if (cores == 0 || rows <= cores) {
+        return std::nullopt;  // single row-parallel wave (or the model's own rect pick) already optimal
+    }
+    const uint32_t waves = tt::div_up(rows, cores);
+    const uint32_t r1 = cores * (waves - 1);
+    const uint32_t r2 = rows - r1;
+    // Split only when the remainder genuinely takes (and wins on) the
+    // multi-rectangle path; otherwise the extra launch + concat is pure cost.
+    // Model on the SEARCHED width (valid_length when set), not the buffer's
+    // logical width: preallocated-buffer callers (the DSA indexer grows
+    // valid_length across prefill inside a fixed 1M buffer) otherwise get a
+    // rect window sized for chunks that never run -- measured 2204us for a
+    // 30-row remainder vs 1424us for a FULL 130-row wave at buf=1M/valid=512k,
+    // turning the hybrid into a net loss. The chosen num_slices is an op attr
+    // (hashed), so distinct valid regimes compile distinct remainder programs;
+    // the cost model quantizes P to a handful of values, so cache growth is
+    // bounded.
+    const uint32_t n = shape[shape.rank() - 1];
+    const uint32_t searched = std::min(valid_length.value_or(n), n);
+    // Model on the searched width. Note the rect window's slice boundaries
+    // are position-based over the LOGICAL row, so a short valid prefix
+    // empties trailing slices and the busy ones keep near-full per-slice
+    // work (measured at buf=1M/valid=512k k=2048: remainder 1424us vs 720us
+    // when the trees are sized to the valid width) -- degraded, but still
+    // well ahead of the row-parallel wave (2204us/row-set at that shape), so
+    // the split stays profitable at any valid_length. Runtime slice
+    // rebalancing from valid_length is the follow-up that recovers the gap.
+    const auto cfg = operations::experimental::topk_large_indices::program::compute_column_split_config(
+        k, searched, r2, grid, std::nullopt, /*allow_multi_row=*/true);
+    if (!cfg.enabled || cfg.num_rects < 2) {
+        return std::nullopt;
+    }
+    // The remainder launch passes cfg.num_slices explicitly: the device op's
+    // own auto model never picks multi-row rects (see column_split_config_for).
+    return HybridSplit{r1, r2, cfg.num_slices};
+}
+
+}  // namespace
+
 Tensor topk_large_indices(
     const Tensor& input_tensor,
     uint32_t k,
     std::optional<uint32_t> valid_length,
     std::optional<uint32_t> num_slices,
     bool tile_output,
-    std::optional<DataType> index_dtype) {
-    auto [operation_attributes, tensor_args] =
-        operations::experimental::topk_large_indices::TopkLargeIndicesDeviceOperation::invoke(
-            input_tensor, k, valid_length, /*return_values=*/false, num_slices, tile_output, index_dtype);
-    auto outputs =
-        ttnn::device_operation::launch<operations::experimental::topk_large_indices::TopkLargeIndicesDeviceOperation>(
-            operation_attributes, tensor_args);
+    std::optional<DataType> index_dtype,
+    bool neginf_sentinel) {
+    using Op = operations::experimental::topk_large_indices::TopkLargeIndicesDeviceOperation;
+    if (const auto split = hybrid_row_split(input_tensor, k, num_slices, tile_output, index_dtype, valid_length)) {
+        auto run = [&](uint32_t start, uint32_t count, std::optional<uint32_t> window_slices) {
+            auto [attrs, args] = Op::invoke(
+                input_tensor,
+                k,
+                valid_length,
+                /*return_values=*/false,
+                window_slices,
+                false,
+                index_dtype,
+                start,
+                count,
+                neginf_sentinel);
+            auto outs = ttnn::device_operation::launch<Op>(attrs, args);
+            return std::move(outs[0]);
+        };
+        Tensor full_waves = run(0, split->full_wave_rows, std::nullopt);
+        Tensor remainder = run(split->full_wave_rows, split->remainder_rows, split->remainder_slices);
+        const int rows_dim = static_cast<int>(input_tensor.logical_shape().rank()) - 2;
+        return ttnn::concat(std::vector<Tensor>{full_waves, remainder}, rows_dim);
+    }
+    auto [operation_attributes, tensor_args] = Op::invoke(
+        input_tensor,
+        k,
+        valid_length,
+        /*return_values=*/false,
+        num_slices,
+        tile_output,
+        index_dtype,
+        std::nullopt,
+        std::nullopt,
+        neginf_sentinel);
+    auto outputs = ttnn::device_operation::launch<Op>(operation_attributes, tensor_args);
     return std::move(outputs[0]);
 }
 
@@ -259,13 +436,43 @@ std::tuple<Tensor, Tensor> topk_large_indices_with_values(
     std::optional<uint32_t> valid_length,
     std::optional<uint32_t> num_slices,
     bool tile_output,
-    std::optional<DataType> index_dtype) {
-    auto [operation_attributes, tensor_args] =
-        operations::experimental::topk_large_indices::TopkLargeIndicesDeviceOperation::invoke(
-            input_tensor, k, valid_length, /*return_values=*/true, num_slices, tile_output, index_dtype);
-    auto outputs =
-        ttnn::device_operation::launch<operations::experimental::topk_large_indices::TopkLargeIndicesDeviceOperation>(
-            operation_attributes, tensor_args);
+    std::optional<DataType> index_dtype,
+    bool neginf_sentinel) {
+    using Op = operations::experimental::topk_large_indices::TopkLargeIndicesDeviceOperation;
+    if (const auto split = hybrid_row_split(input_tensor, k, num_slices, tile_output, index_dtype, valid_length)) {
+        auto run = [&](uint32_t start, uint32_t count, std::optional<uint32_t> window_slices) {
+            auto [attrs, args] = Op::invoke(
+                input_tensor,
+                k,
+                valid_length,
+                /*return_values=*/true,
+                window_slices,
+                false,
+                index_dtype,
+                start,
+                count,
+                neginf_sentinel);
+            return ttnn::device_operation::launch<Op>(attrs, args);
+        };
+        auto part1 = run(0, split->full_wave_rows, std::nullopt);
+        auto part2 = run(split->full_wave_rows, split->remainder_rows, split->remainder_slices);
+        const int rows_dim = static_cast<int>(input_tensor.logical_shape().rank()) - 2;
+        Tensor indices = ttnn::concat(std::vector<Tensor>{part1[0], part2[0]}, rows_dim);
+        Tensor values = ttnn::concat(std::vector<Tensor>{part1[1], part2[1]}, rows_dim);
+        return {std::move(values), std::move(indices)};
+    }
+    auto [operation_attributes, tensor_args] = Op::invoke(
+        input_tensor,
+        k,
+        valid_length,
+        /*return_values=*/true,
+        num_slices,
+        tile_output,
+        index_dtype,
+        std::nullopt,
+        std::nullopt,
+        neginf_sentinel);
+    auto outputs = ttnn::device_operation::launch<Op>(operation_attributes, tensor_args);
     // torch convention: (values, indices).
     return {std::move(outputs[1]), std::move(outputs[0])};
 }

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.cpp
@@ -29,9 +29,24 @@ void validate_static_args(const operation_attributes_t& attrs, const tensor_args
     const tt::ARCH arch = tt::tt_metal::hal::get_arch();
     TT_FATAL(
         arch == tt::ARCH::BLACKHOLE, "topk_large_indices is only supported on Blackhole architecture, got {}", arch);
-    TT_FATAL(input.layout() == Layout::ROW_MAJOR, "topk_large_indices input must be ROW_MAJOR");
+    TT_FATAL(
+        input.layout() == Layout::ROW_MAJOR || input.layout() == Layout::TILE,
+        "topk_large_indices input must be ROW_MAJOR or TILE");
     TT_FATAL(input.dtype() == DataType::BFLOAT16, "topk_large_indices input must be BFLOAT16");
     TT_FATAL(!input.is_sharded(), "topk_large_indices input must use interleaved memory");
+    if (attrs.tile_output) {
+        TT_FATAL(
+            attrs.k % 32 == 0,
+            "topk_large_indices tile_output requires k to be a multiple of 32 (no partial output tile "
+            "columns), got {}",
+            attrs.k);
+    }
+    if (attrs.index_dtype.has_value()) {
+        TT_FATAL(
+            attrs.index_dtype == DataType::UINT32 || attrs.index_dtype == DataType::UINT16,
+            "topk_large_indices index_dtype must be UINT32 or UINT16, got {}",
+            attrs.index_dtype.value());
+    }
 }
 
 void validate_runtime_args(const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
@@ -66,11 +81,28 @@ void validate_runtime_args(const operation_attributes_t& attrs, const tensor_arg
     if (attrs.valid_length.has_value()) {
         const uint32_t valid_length = attrs.valid_length.value();
         TT_FATAL(valid_length > 0, "topk_large_indices valid_length must be > 0");
+        // NOTE: valid_length < k is supported by design — lanes beyond the prefix's
+        // capacity emit the 0xFFFFFFFF sentinel index (and -inf values when
+        // return_values is set). The public docstring's "[k, last dimension]" domain
+        // is stale; the tested contract is (0, last dimension].
         TT_FATAL(
             valid_length <= n,
             "topk_large_indices valid_length {} must be <= the input last dimension {}",
             valid_length,
             n);
+    }
+
+    // UINT16 index emission: every real winner index must provably fit 16 bits. Winners are
+    // positions < the searched width, so search_len <= 65535 guarantees winners <= 65534 and keeps
+    // 0xFFFF unambiguous as the truncated -inf sentinel. Checked at runtime because the shape (and
+    // valid_length) is runtime-patched while index_dtype is baked into the program.
+    if (attrs.index_dtype == DataType::UINT16) {
+        const uint32_t search_len = attrs.valid_length.value_or(n);
+        TT_FATAL(
+            search_len <= 65535,
+            "topk_large_indices index_dtype=UINT16 requires the searched width (valid_length if set, else the "
+            "last dimension) to be <= 65535 so winner indices fit 16 bits; got {}",
+            search_len);
     }
 }
 
@@ -87,19 +119,61 @@ void TopkLargeIndicesDeviceOperation::validate_on_program_cache_miss(
     validate_runtime_args(attrs, tensor_args);
 }
 
+namespace {
+
+program::ColumnSplitConfig column_split_config_for(
+    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input_tensor;
+    const auto& shape = input.logical_shape();
+    const uint32_t n = shape[shape.rank() - 1];
+    const uint32_t num_rows = flattened_rows_excluding_last_dim(shape);
+    const auto grid = input.device()->compute_with_storage_grid_size();
+    return program::compute_column_split_config(attrs.k, n, num_rows, grid, attrs.num_slices);
+}
+
+}  // namespace
+
+TopkLargeIndicesDeviceOperation::program_factory_t TopkLargeIndicesDeviceOperation::select_program_factory(
+    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+    if (column_split_config_for(attrs, tensor_args).enabled) {
+        return program::TopkLargeIndicesMultiCoreProgramFactory{};
+    }
+    return program::TopkLargeIndicesProgramFactory{};
+}
+
 ttsl::hash::hash_t TopkLargeIndicesDeviceOperation::compute_program_hash(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
     const auto& input = tensor_args.input_tensor;
     const auto grid = input.device()->compute_with_storage_grid_size();
 
+    // Factory selection (and, on the column-parallel path, the program
+    // structure) depends on the derived split config, so its fields must be
+    // hashed. On the row-parallel path the config is all zeros, preserving the
+    // original shape-free hash: row counts and row widths keep patching
+    // through runtime args without recompiles.
+    const auto split_config = column_split_config_for(attrs, tensor_args);
+
     return tt::tt_metal::operation::hash_operation<TopkLargeIndicesDeviceOperation>(
         attrs.k,
+        // Selects the with-values kernels, extra CBs, and the second output.
+        attrs.return_values,
+        // Selects the tile-scatter writer kernels, output CBs, and output specs.
+        attrs.tile_output,
+        // Selects the narrowing writer path and the indices output spec.
+        attrs.index_dtype,
+        // User P override: also reflected in the derived split_config fields
+        // below, but hashed directly so intent and derivation can never skew.
+        attrs.num_slices,
         input.dtype(),
         input.layout(),
         input.memory_config().memory_layout(),
         input.memory_config().buffer_type(),
         grid.x,
-        grid.y);
+        grid.y,
+        split_config.enabled,
+        split_config.num_slices,
+        split_config.local_grid_x,
+        split_config.local_grid_y);
 }
 
 spec_return_value_t TopkLargeIndicesDeviceOperation::compute_output_specs(
@@ -111,34 +185,89 @@ spec_return_value_t TopkLargeIndicesDeviceOperation::compute_output_specs(
         output_shape_vec.push_back(input_shape[i]);
     }
     output_shape_vec.back() = attrs.k;
+    const ttnn::Shape output_shape(std::move(output_shape_vec));
 
     const auto memory_config = tensor_args.input_tensor.memory_config();
-    return tt::tt_metal::TensorSpec(
-        ttnn::Shape(std::move(output_shape_vec)),
-        tt::tt_metal::TensorLayout(DataType::UINT32, tt::tt_metal::PageConfig(Layout::ROW_MAJOR), memory_config));
+    const Layout output_layout = attrs.tile_output ? Layout::TILE : Layout::ROW_MAJOR;
+    const DataType indices_dtype = attrs.index_dtype.value_or(DataType::UINT32);
+    spec_return_value_t specs;
+    specs.emplace_back(
+        output_shape,
+        tt::tt_metal::TensorLayout(indices_dtype, tt::tt_metal::PageConfig(output_layout), memory_config));
+    if (attrs.return_values) {
+        specs.emplace_back(
+            output_shape,
+            tt::tt_metal::TensorLayout(DataType::BFLOAT16, tt::tt_metal::PageConfig(output_layout), memory_config));
+    }
+    return specs;
 }
 
 tensor_return_value_t TopkLargeIndicesDeviceOperation::create_output_tensors(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-    return create_device_tensor(compute_output_specs(attrs, tensor_args), tensor_args.input_tensor.device());
+    const auto specs = compute_output_specs(attrs, tensor_args);
+    tensor_return_value_t outputs;
+    outputs.reserve(specs.size());
+    for (const auto& spec : specs) {
+        outputs.push_back(create_device_tensor(spec, tensor_args.input_tensor.device()));
+    }
+    return outputs;
 }
 
 std::tuple<TopkLargeIndicesDeviceOperation::operation_attributes_t, TopkLargeIndicesDeviceOperation::tensor_args_t>
-TopkLargeIndicesDeviceOperation::invoke(const Tensor& input_tensor, uint32_t k, std::optional<uint32_t> valid_length) {
-    return {operation_attributes_t{.k = k, .valid_length = valid_length}, tensor_args_t{.input_tensor = input_tensor}};
+TopkLargeIndicesDeviceOperation::invoke(
+    const Tensor& input_tensor,
+    uint32_t k,
+    std::optional<uint32_t> valid_length,
+    bool return_values,
+    std::optional<uint32_t> num_slices,
+    bool tile_output,
+    std::optional<DataType> index_dtype) {
+    return {
+        operation_attributes_t{
+            .k = k,
+            .valid_length = valid_length,
+            .return_values = return_values,
+            .num_slices = num_slices,
+            .tile_output = tile_output,
+            .index_dtype = index_dtype},
+        tensor_args_t{.input_tensor = input_tensor}};
 }
 
 }  // namespace ttnn::operations::experimental::topk_large_indices
 
 namespace ttnn::experimental {
 
-Tensor topk_large_indices(const Tensor& input_tensor, uint32_t k, std::optional<uint32_t> valid_length) {
+Tensor topk_large_indices(
+    const Tensor& input_tensor,
+    uint32_t k,
+    std::optional<uint32_t> valid_length,
+    std::optional<uint32_t> num_slices,
+    bool tile_output,
+    std::optional<DataType> index_dtype) {
     auto [operation_attributes, tensor_args] =
         operations::experimental::topk_large_indices::TopkLargeIndicesDeviceOperation::invoke(
-            input_tensor, k, valid_length);
-    return ttnn::device_operation::launch<
-        operations::experimental::topk_large_indices::TopkLargeIndicesDeviceOperation>(
-        operation_attributes, tensor_args);
+            input_tensor, k, valid_length, /*return_values=*/false, num_slices, tile_output, index_dtype);
+    auto outputs =
+        ttnn::device_operation::launch<operations::experimental::topk_large_indices::TopkLargeIndicesDeviceOperation>(
+            operation_attributes, tensor_args);
+    return std::move(outputs[0]);
+}
+
+std::tuple<Tensor, Tensor> topk_large_indices_with_values(
+    const Tensor& input_tensor,
+    uint32_t k,
+    std::optional<uint32_t> valid_length,
+    std::optional<uint32_t> num_slices,
+    bool tile_output,
+    std::optional<DataType> index_dtype) {
+    auto [operation_attributes, tensor_args] =
+        operations::experimental::topk_large_indices::TopkLargeIndicesDeviceOperation::invoke(
+            input_tensor, k, valid_length, /*return_values=*/true, num_slices, tile_output, index_dtype);
+    auto outputs =
+        ttnn::device_operation::launch<operations::experimental::topk_large_indices::TopkLargeIndicesDeviceOperation>(
+            operation_attributes, tensor_args);
+    // torch convention: (values, indices).
+    return {std::move(outputs[1]), std::move(outputs[0])};
 }
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.hpp
@@ -20,7 +20,11 @@ struct TopkLargeIndicesDeviceOperation {
     using tensor_return_value_t = topk_large_indices::tensor_return_value_t;
     using spec_return_value_t = topk_large_indices::spec_return_value_t;
 
-    using program_factory_t = std::variant<program::TopkLargeIndicesProgramFactory>;
+    using program_factory_t =
+        std::variant<program::TopkLargeIndicesProgramFactory, program::TopkLargeIndicesMultiCoreProgramFactory>;
+
+    static program_factory_t select_program_factory(
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
 
     static void validate_on_program_cache_miss(const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_hit(const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
@@ -34,13 +38,40 @@ struct TopkLargeIndicesDeviceOperation {
         const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
-        const Tensor& input_tensor, uint32_t k, std::optional<uint32_t> valid_length);
+        const Tensor& input_tensor,
+        uint32_t k,
+        std::optional<uint32_t> valid_length,
+        bool return_values,
+        std::optional<uint32_t> num_slices,
+        bool tile_output,
+        std::optional<DataType> index_dtype);
 };
 
 }  // namespace ttnn::operations::experimental::topk_large_indices
 
 namespace ttnn::experimental {
 
-Tensor topk_large_indices(const Tensor& input_tensor, uint32_t k, std::optional<uint32_t> valid_length = std::nullopt);
+// Input may be ROW_MAJOR or TILE layout (BFLOAT16, interleaved). With the defaults the outputs
+// are ROW_MAJOR and the indices are UINT32 — bit-identical behavior to before the opt-ins below
+// existed. tile_output=true emits TILE-layout outputs directly (k must be a multiple of 32;
+// tile padding rows are zero-filled). index_dtype=UINT16 narrows the indices output (searched
+// width must be <= 65535; the -inf sentinel becomes 0xFFFF).
+Tensor topk_large_indices(
+    const Tensor& input_tensor,
+    uint32_t k,
+    std::optional<uint32_t> valid_length = std::nullopt,
+    std::optional<uint32_t> num_slices = std::nullopt,
+    bool tile_output = false,
+    std::optional<DataType> index_dtype = std::nullopt);
+
+// (values, indices): values are BFLOAT16, sorted descending to match the indices;
+// sentinel-index (-inf) lanes carry exact bf16 -inf values. Layout/dtype opt-ins as above.
+std::tuple<Tensor, Tensor> topk_large_indices_with_values(
+    const Tensor& input_tensor,
+    uint32_t k,
+    std::optional<uint32_t> valid_length = std::nullopt,
+    std::optional<uint32_t> num_slices = std::nullopt,
+    bool tile_output = false,
+    std::optional<DataType> index_dtype = std::nullopt);
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation.hpp
@@ -44,7 +44,10 @@ struct TopkLargeIndicesDeviceOperation {
         bool return_values,
         std::optional<uint32_t> num_slices,
         bool tile_output,
-        std::optional<DataType> index_dtype);
+        std::optional<DataType> index_dtype,
+        std::optional<uint32_t> row_start = std::nullopt,
+        std::optional<uint32_t> row_count = std::nullopt,
+        bool neginf_sentinel = true);
 };
 
 }  // namespace ttnn::operations::experimental::topk_large_indices
@@ -62,7 +65,8 @@ Tensor topk_large_indices(
     std::optional<uint32_t> valid_length = std::nullopt,
     std::optional<uint32_t> num_slices = std::nullopt,
     bool tile_output = false,
-    std::optional<DataType> index_dtype = std::nullopt);
+    std::optional<DataType> index_dtype = std::nullopt,
+    bool neginf_sentinel = true);
 
 // (values, indices): values are BFLOAT16, sorted descending to match the indices;
 // sentinel-index (-inf) lanes carry exact bf16 -inf values. Layout/dtype opt-ins as above.
@@ -72,6 +76,7 @@ std::tuple<Tensor, Tensor> topk_large_indices_with_values(
     std::optional<uint32_t> valid_length = std::nullopt,
     std::optional<uint32_t> num_slices = std::nullopt,
     bool tile_output = false,
-    std::optional<DataType> index_dtype = std::nullopt);
+    std::optional<DataType> index_dtype = std::nullopt,
+    bool neginf_sentinel = true);
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation_types.hpp
@@ -6,6 +6,7 @@
 
 #include <limits>
 #include <optional>
+#include <vector>
 
 #include <tt_stl/assert.hpp>
 
@@ -33,13 +34,39 @@ struct operation_attributes_t {
     // without physically slicing the input. nullopt = search the full width. Runtime-only (hash-excluded,
     // validated on cache hit) so a serving loop growing valid_length reuses one program.
     std::optional<uint32_t> valid_length{};
+    // Also emit the top-k VALUES (ROW_MAJOR BFLOAT16, sorted descending to match the indices;
+    // exact bf16 -inf on the sentinel-index lanes). Changes kernel selection, CBs, and output
+    // specs, so it is part of the program hash. Default off: indices-only, byte-identical
+    // program to before this option existed.
+    bool return_values{false};
+    // Override the column-parallel slice count P (number of local cores splitting the row).
+    // Only meaningful when the column-parallel (single-row) factory is selected: setting it on a
+    // row-parallel shape is a loud error, as are values outside [2, 64] or above the row's chunk
+    // count; it is clamped only against the physical core grid (with a warning). Changes the
+    // program structure, so it is part of the program hash. nullopt = the built-in cost model.
+    std::optional<uint32_t> num_slices{};
+    // Emit the outputs (indices, and values when return_values) in TILE layout instead of
+    // ROW_MAJOR. The writer scatters the 16-element result slices straight into their tile
+    // positions and zero-fills the tile padding rows, so callers that need TILE tensors skip
+    // the tilize ops entirely. Requires k % 32 == 0 (no partial output tile columns). Swaps in
+    // dedicated writer kernels and output CBs, so it is part of the program hash. Default off:
+    // ROW_MAJOR outputs, byte-identical program to before this option existed.
+    bool tile_output{false};
+    // Output dtype of the indices tensor. nullopt/UINT32 = today's UINT32 output. UINT16 is an
+    // opt-in narrowing for callers that know every winner index fits 16 bits: it requires the
+    // searched width (valid_length if set, else the last dimension) to be <= 65535 so real
+    // indices are < 0xFFFF and the -inf sentinel truncates to the unambiguous 0xFFFF (the same
+    // value a UINT32 -> UINT16 typecast of the sentinel produces). Changes the writer kernel and
+    // output spec, so it is part of the program hash.
+    std::optional<tt::tt_metal::DataType> index_dtype{};
 };
 
 struct tensor_args_t {
     Tensor input_tensor;
 };
 
-using tensor_return_value_t = Tensor;
-using spec_return_value_t = tt::tt_metal::TensorSpec;
+// [0] = UINT32 indices (always). [1] = BFLOAT16 values (only when return_values).
+using tensor_return_value_t = std::vector<Tensor>;
+using spec_return_value_t = std::vector<tt::tt_metal::TensorSpec>;
 
 }  // namespace ttnn::operations::experimental::topk_large_indices

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation_types.hpp
@@ -34,14 +34,14 @@ struct operation_attributes_t {
     // without physically slicing the input. nullopt = search the full width. Runtime-only (hash-excluded,
     // validated on cache hit) so a serving loop growing valid_length reuses one program.
     std::optional<uint32_t> valid_length{};
-    // Also emit the top-k VALUES (ROW_MAJOR BFLOAT16, sorted descending to match the indices;
+    // Also emit the top-k VALUES (BFLOAT16; ROW_MAJOR, or TILE under tile_output, sorted descending to match the indices;
     // exact bf16 -inf on the sentinel-index lanes). Changes kernel selection, CBs, and output
     // specs, so it is part of the program hash. Default off: indices-only, byte-identical
     // program to before this option existed.
     bool return_values{false};
     // Override the column-parallel slice count P (number of local cores splitting the row).
     // Only meaningful when the column-parallel (single-row) factory is selected: setting it on a
-    // row-parallel shape is a loud error, as are values outside [2, 64] or above the row's chunk
+    // row-parallel shape is a loud error, as are values outside [2, 128] or above the row's chunk
     // count; it is clamped only against the physical core grid (with a warning). Changes the
     // program structure, so it is part of the program hash. nullopt = the built-in cost model.
     std::optional<uint32_t> num_slices{};

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_device_operation_types.hpp
@@ -39,12 +39,23 @@ struct operation_attributes_t {
     // specs, so it is part of the program hash. Default off: indices-only, byte-identical
     // program to before this option existed.
     bool return_values{false};
-    // Override the column-parallel slice count P (number of local cores splitting the row).
-    // Only meaningful when the column-parallel (single-row) factory is selected: setting it on a
-    // row-parallel shape is a loud error, as are values outside [2, 128] or above the row's chunk
-    // count; it is clamped only against the physical core grid (with a warning). Changes the
-    // program structure, so it is part of the program hash. nullopt = the built-in cost model.
+    // Override the column-parallel slice count P (tree cores splitting each row). Single row:
+    // the classic column-parallel tree. Multiple rows: opts into the multi-rectangle variant —
+    // one P-core tree per rectangle, rows split contiguously over as many rectangles as tile the
+    // worker grid, all concurrent (ROW_MAJOR output only; the cost model never auto-selects this
+    // form). Values outside [2, 128] or above the row's chunk count are loud errors; P is clamped
+    // only against the physical core grid (with a warning). Changes the program structure, so it
+    // is part of the program hash. nullopt = the built-in cost model.
     std::optional<uint32_t> num_slices{};
+    // Composite-internal row window [row_start, row_start + row_count): the op reads only these
+    // input rows and emits a row_count-row output. Set by the hybrid wrapper (ttnn::experimental::
+    // topk_large_indices) to run row-parallel full waves and a multi-rectangle remainder wave as
+    // two launches over one un-sliced input; not exposed through the public bindings. Requires the
+    // canonical [1.., R, W] shape (leading dims 1). Runtime-only for the program itself (rows are
+    // runtime args); the effective row count feeds the derived split config, whose hashed fields
+    // already capture any structural difference.
+    std::optional<uint32_t> row_start{};
+    std::optional<uint32_t> row_count{};
     // Emit the outputs (indices, and values when return_values) in TILE layout instead of
     // ROW_MAJOR. The writer scatters the 16-element result slices straight into their tile
     // positions and zero-fills the tile padding rows, so callers that need TILE tensors skip
@@ -59,6 +70,13 @@ struct operation_attributes_t {
     // value a UINT32 -> UINT16 typecast of the sentinel produces). Changes the writer kernel and
     // output spec, so it is part of the program hash.
     std::optional<tt::tt_metal::DataType> index_dtype{};
+    // Emit the 0xFFFFFFFF (0xFFFF under UINT16) sentinel index on lanes whose value is exact
+    // bf16 -inf (default, the op's original contract — sparse-attention consumers drop those
+    // lanes by sentinel). false: keep each -inf lane's REAL source position — the fused index
+    // stamp means every lane, -inf included, carries its true column; the sentinel pass simply
+    // overwrites it. The routed ttnn.topk path uses false for stock/torch index parity.
+    // Swaps a kernel define, so it is part of the program hash.
+    bool neginf_sentinel{true};
 };
 
 struct tensor_args_t {

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.cpp
@@ -596,7 +596,7 @@ ColumnSplitConfig compute_column_split_config(
         log_warning(
             tt::LogOp,
             "topk_large_indices num_slices={} does not fit the {}x{} worker grid's local-core rectangle; "
-            "clamped to {} ({}x{} local cores + 1 merge core)",
+            "clamped to {} ({}x{} tree cores, in-place root)",
             requested,
             grid.x,
             grid.y,

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.cpp
@@ -4,12 +4,17 @@
 
 #include "topk_large_indices_program_factory.hpp"
 
+#include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 
+#include <algorithm>
+#include <cmath>
+#include <map>
 #include <optional>
+#include <string>
 #include <tuple>
 
 namespace ttnn::operations::experimental::topk_large_indices::program {
@@ -81,13 +86,64 @@ uint32_t rows_for_core(
     return 0;
 }
 
+// BFLOAT16 element size of the optional values output.
+constexpr uint32_t values_element_bytes = 2;
+
+// Creates the values-output CB (+ reorder scratch for LLK windows > 512) on `cores`.
+// Mirrors the indices output CBs' structure with bf16-sized rows/slices.
+void create_values_output_cbs(
+    tt::tt_metal::Program& program,
+    const CoreRangeSet& cores,
+    LlkTargetK llk_target_k,
+    uint32_t k,
+    uint32_t cb_values,
+    uint32_t cb_values_scratch) {
+    const uint32_t llk_k = to_uint32(llk_target_k);
+    const uint32_t values_cb_row_bytes = llk_k * values_element_bytes;
+    constexpr uint32_t cb_depth = 2;
+    auto values_cb_config =
+        tt::tt_metal::CircularBufferConfig(cb_depth * values_cb_row_bytes, {{cb_values, tt::DataFormat::Float16_b}})
+            .set_page_size(cb_values, values_cb_row_bytes);
+    if (llk_target_k == LlkTargetK::K512) {
+        values_cb_config.set_unpack_face_geometry(cb_values, tt::constants::FACE_HEIGHT, 2);
+    }
+    tt::tt_metal::CreateCircularBuffer(program, cores, values_cb_config);
+
+    if (llk_target_k != LlkTargetK::K512) {
+        const uint32_t values_row_bytes = k * values_element_bytes;
+        const auto values_scratch_cb_config =
+            tt::tt_metal::CircularBufferConfig(values_row_bytes, {{cb_values_scratch, tt::DataFormat::Float16_b}})
+                .set_page_size(cb_values_scratch, values_row_bytes);
+        tt::tt_metal::CreateCircularBuffer(program, cores, values_scratch_cb_config);
+    }
+}
+
+// True when any output-format opt-in is active: the program then uses the flex
+// writer kernels instead of the default (byte-identical) writer sources.
+bool uses_flex_writer(const operation_attributes_t& attrs) {
+    return attrs.tile_output || attrs.index_dtype == DataType::UINT16;
+}
+
+// Rows of one 2D slice of the (flattened) row space: TILE layouts pad the last
+// two dims per slice, so tile-row addressing needs this alongside the flat row.
+uint32_t rows_2d_of(const ttnn::Shape& shape) { return shape.rank() >= 2 ? shape[shape.rank() - 2] : 1; }
+
+constexpr uint32_t pad_zero_slab_bytes = 2048;  // covers the largest zero run: 512 uint32 elements
+
 void set_runtime_args(
     tt::tt_metal::Program& program,
     const TopkLargeIndicesSharedVariables& shared,
     const Tensor& input,
-    const Tensor& indices,
-    LlkTargetK llk_target_k,
-    std::optional<uint32_t> valid_length) {
+    const tensor_return_value_t& outputs,
+    const operation_attributes_t& attrs) {
+    const LlkTargetK llk_target_k = snap_to_llk_target_k(attrs.k);
+    const std::optional<uint32_t> valid_length = attrs.valid_length;
+    const Tensor& indices = outputs[0];
+    const bool return_values = outputs.size() > 1;
+    const bool tile_input = input.layout() == Layout::TILE;
+    const bool flex_writer = uses_flex_writer(attrs);
+    const uint32_t rows_2d = rows_2d_of(input.logical_shape());
+    const uint32_t w_tiles = input.padded_shape()[-1] / tt::constants::TILE_WIDTH;
     const auto runtime_args = get_runtime_shape_args(input, llk_target_k, valid_length);
     const auto work_split = tt::tt_metal::split_work_to_cores(
         input.device()->compute_with_storage_grid_size(), runtime_args.num_rows, true);
@@ -108,20 +164,57 @@ void set_runtime_args(
             rows,
             num_rows_per_core_group_1);
 
-        tt::tt_metal::SetRuntimeArgs(
-            program,
-            shared.reader_kernel_id,
-            core,
-            {input.buffer()->address(),
-             start_row,
-             rows,
-             runtime_args.num_chunks,
-             runtime_args.input_tail_chunk_bytes,
-             runtime_args.input_row_bytes});
+        if (tile_input) {
+            tt::tt_metal::SetRuntimeArgs(
+                program,
+                shared.reader_kernel_id,
+                core,
+                {input.buffer()->address(),
+                 start_row,
+                 rows,
+                 runtime_args.num_chunks,
+                 tt::div_up(runtime_args.tail_elements, tt::constants::FACE_WIDTH),
+                 w_tiles,
+                 rows_2d,
+                 start_row % rows_2d,
+                 start_row / rows_2d,
+                 0 /* start_element */});
+        } else {
+            tt::tt_metal::SetRuntimeArgs(
+                program,
+                shared.reader_kernel_id,
+                core,
+                {input.buffer()->address(),
+                 start_row,
+                 rows,
+                 runtime_args.num_chunks,
+                 runtime_args.input_tail_chunk_bytes,
+                 runtime_args.input_row_bytes});
+        }
         tt::tt_metal::SetRuntimeArgs(
             program, shared.compute_kernel_id, core, {rows, runtime_args.num_chunks, runtime_args.tail_elements});
-        tt::tt_metal::SetRuntimeArgs(
-            program, shared.writer_kernel_id, core, {indices.buffer()->address(), start_row, rows});
+        if (flex_writer) {
+            tt::tt_metal::SetRuntimeArgs(
+                program,
+                shared.writer_kernel_id,
+                core,
+                {indices.buffer()->address(),
+                 start_row,
+                 rows,
+                 return_values ? outputs[1].buffer()->address() : 0,
+                 rows_2d,
+                 start_row % rows_2d,
+                 start_row / rows_2d});
+        } else if (return_values) {
+            tt::tt_metal::SetRuntimeArgs(
+                program,
+                shared.writer_kernel_id,
+                core,
+                {indices.buffer()->address(), start_row, rows, outputs[1].buffer()->address()});
+        } else {
+            tt::tt_metal::SetRuntimeArgs(
+                program, shared.writer_kernel_id, core, {indices.buffer()->address(), start_row, rows});
+        }
 
         start_row += rows;
     }
@@ -141,7 +234,7 @@ TopkLargeIndicesProgramFactory::cached_program_t TopkLargeIndicesProgramFactory:
     auto program = tt::tt_metal::CreateProgram();
 
     const auto& input = tensor_args.input_tensor;
-    auto& indices = tensor_return_value;
+    auto& indices = tensor_return_value[0];
 
     const uint32_t k = operation_attributes.k;
     const auto llk_target_k = snap_to_llk_target_k(k);
@@ -154,9 +247,18 @@ TopkLargeIndicesProgramFactory::cached_program_t TopkLargeIndicesProgramFactory:
     // Runtime row counts are intentionally patched through runtime args instead of the program hash.
     // Create kernels/CBs across the full worker grid so cache hits can use a different active core subset.
 
+    const bool return_values = operation_attributes.return_values;
+    const bool tile_input = input.layout() == Layout::TILE;
+    const bool tile_output = operation_attributes.tile_output;
+    const bool index_u16 = operation_attributes.index_dtype == DataType::UINT16;
+    const bool flex_writer = uses_flex_writer(operation_attributes);
     constexpr uint32_t cb_in = tt::CBIndex::c_0;
     constexpr uint32_t cb_indices = tt::CBIndex::c_1;
     constexpr uint32_t cb_indices_scratch = tt::CBIndex::c_2;
+    constexpr uint32_t cb_values = tt::CBIndex::c_3;
+    constexpr uint32_t cb_values_scratch = tt::CBIndex::c_4;
+    constexpr uint32_t cb_pad_zero = tt::CBIndex::c_5;
+    constexpr uint32_t cb_stage = tt::CBIndex::c_6;
 
     const uint32_t input_chunk_bytes = llk_k * input.element_size();
     const uint32_t input_tile_bytes = tt::constants::TILE_HW * input.element_size();
@@ -165,7 +267,9 @@ TopkLargeIndicesProgramFactory::cached_program_t TopkLargeIndicesProgramFactory:
     const uint32_t output_slices_per_row = k / row_slice_elements;
     const uint32_t indices_slice_bytes = row_slice_elements * indices.element_size();
     const uint32_t indices_row_bytes = k * indices.element_size();
-    const uint32_t indices_cb_row_bytes = llk_k * indices.element_size();
+    // The indices CB carries the raw 32-bit index words the packer produces,
+    // independent of the (possibly narrowed) output tensor dtype.
+    const uint32_t indices_cb_row_bytes = llk_k * static_cast<uint32_t>(sizeof(uint32_t));
 
     const uint32_t cb_depth = 2;
     const auto input_cb_config =
@@ -182,26 +286,68 @@ TopkLargeIndicesProgramFactory::cached_program_t TopkLargeIndicesProgramFactory:
     }
     tt::tt_metal::CreateCircularBuffer(program, all_cores, indices_cb_config);
 
-    if (llk_target_k != LlkTargetK::K512) {
+    // The scratch also serves as the UINT16 narrowing row (sized with the
+    // output element size either way), so it exists for every LLK window when
+    // narrowing is requested.
+    if (llk_target_k != LlkTargetK::K512 || index_u16) {
         const auto indices_scratch_cb_config =
             tt::tt_metal::CircularBufferConfig(indices_row_bytes, {{cb_indices_scratch, tt::DataFormat::Float32}})
                 .set_page_size(cb_indices_scratch, indices_row_bytes);
         tt::tt_metal::CreateCircularBuffer(program, all_cores, indices_scratch_cb_config);
     }
 
-    std::vector<uint32_t> reader_compile_args = {cb_in, input_chunk_bytes, input_tile_bytes, tiles_per_sequence};
+    if (return_values) {
+        create_values_output_cbs(program, all_cores, llk_target_k, k, cb_values, cb_values_scratch);
+    }
+
+    if (tile_output) {
+        const auto pad_cb_config =
+            tt::tt_metal::CircularBufferConfig(pad_zero_slab_bytes, {{cb_pad_zero, tt::DataFormat::UInt32}})
+                .set_page_size(cb_pad_zero, pad_zero_slab_bytes);
+        tt::tt_metal::CreateCircularBuffer(program, all_cores, pad_cb_config);
+    }
+    // TILE-input staging: one 64-byte slot per 16-element chunk slice, plus
+    // 64 bytes of slack for in-kernel 64-byte alignment of the slot base.
+    const uint32_t stage_bytes = (llk_k / row_slice_elements) * 64 + 64;
+    if (tile_input) {
+        const auto stage_cb_config =
+            tt::tt_metal::CircularBufferConfig(stage_bytes, {{cb_stage, tt::DataFormat::UInt32}})
+                .set_page_size(cb_stage, stage_bytes);
+        tt::tt_metal::CreateCircularBuffer(program, all_cores, stage_cb_config);
+    }
+
+    std::vector<uint32_t> reader_compile_args;
+    if (tile_input) {
+        reader_compile_args = {cb_in, cb_stage, llk_k / row_slice_elements, tiles_per_sequence};
+    } else {
+        reader_compile_args = {cb_in, input_chunk_bytes, input_tile_bytes, tiles_per_sequence};
+    }
     interleaved_accessor_args(input).append_to(reader_compile_args);
 
     auto reader_kernel = tt::tt_metal::CreateKernel(
         program,
-        "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/reader.cpp",
+        tile_input ? "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/reader_tile.cpp"
+                   : "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/reader.cpp",
         all_cores,
         tt::tt_metal::ReaderDataMovementConfig(reader_compile_args));
 
+    // return_values swaps in dedicated with-values kernel sources so the
+    // default (indices-only) program's kernel sources — and therefore its JIT
+    // binaries and perf behavior — stay byte-identical.
     std::vector<uint32_t> compute_compile_args = {cb_in, cb_indices, llk_k};
+    if (return_values) {
+        compute_compile_args.push_back(cb_values);
+    }
+    // User-requested k (<= llk_k): the data-dependent chunk-skip early-out in
+    // the row-parallel compute kernels thresholds against the running k-th
+    // survivor (not the llk_k-th), which is what makes skipping profitable at
+    // small k. attrs.k is already part of the program hash.
+    compute_compile_args.push_back(k);
     auto compute_kernel = tt::tt_metal::CreateKernel(
         program,
-        "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute.cpp",
+        return_values
+            ? "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute_with_values.cpp"
+            : "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute.cpp",
         all_cores,
         tt::tt_metal::ComputeConfig{
             // TopK XL stores fused BF16-value/u16-index words and unfused UINT32 indices in 32-bit DEST lanes.
@@ -210,27 +356,79 @@ TopkLargeIndicesProgramFactory::cached_program_t TopkLargeIndicesProgramFactory:
             .dst_full_sync_en = true,
             .compile_args = compute_compile_args});
 
-    std::vector<uint32_t> writer_compile_args = {
-        cb_indices,
-        cb_indices_scratch,
-        indices_row_bytes,
-        source_slices_per_row,
-        output_slices_per_row,
-        indices_slice_bytes};
-    interleaved_accessor_args(indices).append_to(writer_compile_args);
+    tt::tt_metal::KernelHandle writer_kernel;
+    if (flex_writer) {
+        // Opt-in output formats (TILE layout and/or UINT16 indices): dedicated
+        // flex writer, gated by defines so the default program's writer
+        // binaries stay byte-identical.
+        const uint32_t idx_es = indices.element_size();
+        const uint32_t indices_page_bytes = tile_output ? tt::constants::TILE_HW * idx_es : indices_row_bytes;
+        const uint32_t values_page_bytes =
+            tile_output ? tt::constants::TILE_HW * values_element_bytes : k * values_element_bytes;
+        std::vector<uint32_t> flex_compile_args = {
+            cb_indices,
+            cb_indices_scratch,
+            indices_page_bytes,
+            source_slices_per_row,
+            output_slices_per_row,
+            cb_values,
+            cb_values_scratch,
+            values_page_bytes,
+            cb_pad_zero,
+            tile_output ? k / tt::constants::TILE_WIDTH : 0};
+        interleaved_accessor_args(indices).append_to(flex_compile_args);
+        if (return_values) {
+            interleaved_accessor_args(tensor_return_value[1]).append_to(flex_compile_args);
+        }
+        std::map<std::string, std::string> flex_defines;
+        if (return_values) {
+            flex_defines["FLEX_WITH_VALUES"] = "1";
+        }
+        if (tile_output) {
+            flex_defines["FLEX_OUT_TILE"] = "1";
+        }
+        if (index_u16) {
+            flex_defines["FLEX_INDEX_U16"] = "1";
+        }
+        writer_kernel = tt::tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer_flex.cpp",
+            all_cores,
+            tt::tt_metal::WriterDataMovementConfig(flex_compile_args, flex_defines));
+    } else {
+        std::vector<uint32_t> writer_compile_args = {
+            cb_indices,
+            cb_indices_scratch,
+            indices_row_bytes,
+            source_slices_per_row,
+            output_slices_per_row,
+            indices_slice_bytes};
+        if (return_values) {
+            writer_compile_args.push_back(cb_values);
+            writer_compile_args.push_back(cb_values_scratch);
+            writer_compile_args.push_back(k * values_element_bytes);
+            writer_compile_args.push_back(row_slice_elements * values_element_bytes);
+        }
+        interleaved_accessor_args(indices).append_to(writer_compile_args);
+        if (return_values) {
+            interleaved_accessor_args(tensor_return_value[1]).append_to(writer_compile_args);
+        }
 
-    auto writer_kernel = tt::tt_metal::CreateKernel(
-        program,
-        "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer.cpp",
-        all_cores,
-        tt::tt_metal::WriterDataMovementConfig(writer_compile_args));
+        writer_kernel = tt::tt_metal::CreateKernel(
+            program,
+            return_values
+                ? "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer_with_values.cpp"
+                : "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer.cpp",
+            all_cores,
+            tt::tt_metal::WriterDataMovementConfig(writer_compile_args));
+    }
 
     TopkLargeIndicesSharedVariables shared{
         .reader_kernel_id = reader_kernel,
         .compute_kernel_id = compute_kernel,
         .writer_kernel_id = writer_kernel,
         .cores = cores};
-    set_runtime_args(program, shared, input, indices, llk_target_k, operation_attributes.valid_length);
+    set_runtime_args(program, shared, input, tensor_return_value, operation_attributes);
 
     return cached_program_t{std::move(program), std::move(shared)};
 }
@@ -245,8 +443,646 @@ void TopkLargeIndicesProgramFactory::override_runtime_arguments(
         cached_program.shared_variables,
         tensor_args.input_tensor,
         tensor_return_value,
-        snap_to_llk_target_k(operation_attributes.k),
-        operation_attributes.valid_length);
+        operation_attributes);
+}
+
+// ---------------------------------------------------------------------------
+// Column-parallel (intra-row multi-core) path
+// ---------------------------------------------------------------------------
+
+// Slice-count cap: the in-place merge tree needs only one 2-sequence recv CB
+// per core (16 KB at K=2048), so L1 does not bind P; the envelope is 7 tree
+// levels (128 slices). In practice P is bound first by the worker-grid
+// rectangle capacity (e.g. 13x10 = 130 on P150) and the chunk count.
+constexpr uint32_t max_column_slices = 128;
+
+namespace {
+
+// ceil(log2(p)) for p >= 1: number of pairwise merge-tree levels.
+uint32_t tree_levels(uint32_t p) {
+    uint32_t levels = 0;
+    while ((1u << levels) < p) {
+        ++levels;
+    }
+    return levels;
+}
+
+// The built-in cost-model pick (no user override).
+ColumnSplitConfig compute_model_column_split_config(uint32_t k, uint32_t n, uint32_t num_rows, const CoreCoord& grid) {
+    constexpr uint32_t max_slices = max_column_slices;
+
+    ColumnSplitConfig config{};
+    // Intra-row parallelism only pays off when rows cannot saturate the grid;
+    // restrict to the single-row case this path is built for. Every other
+    // shape keeps the row-parallel factory (and its shape-free program hash)
+    // unchanged.
+    if (num_rows != 1) {
+        return config;
+    }
+    if (static_cast<uint32_t>(grid.x * grid.y) < 2) {
+        return config;
+    }
+
+    const uint32_t llk_k = to_uint32(snap_to_llk_target_k(k));
+    // Physical width only: valid_length must stay runtime-only, so the split
+    // never depends on it (short valid prefixes empty out trailing slices at
+    // runtime instead of changing the program).
+    const uint32_t num_chunks = tt::div_up(n, llk_k);
+    if (num_chunks < 2) {
+        return config;
+    }
+
+    // Cost model in merge units: processing one chunk locally
+    // (copy + lsb + fused sort + index split + merge + rebuild) ~ 2 units,
+    // one tree merge+rebuild ~ 1 unit. With the log-tree the serial term is
+    // ceil(log2 P), so cost(P) = 2*ceil(chunks/P) + ceil(log2 P). Tree cores
+    // must form a rectangle, so search every a x b rectangle that fits the
+    // grid (a <= grid.x, b <= grid.y, a*b <= min(chunks, max_slices)) and
+    // take the cheapest P; ties prefer fewer cores. This beats the previous
+    // full-rows-only fit (e.g. 32 chunks on a 13x10 grid: 8x4 = 32 slices vs
+    // 13x2 = 26; 128+ chunks: 8x8 = 64 vs 13x4 = 52).
+    const uint32_t slice_ceiling = std::min(num_chunks, max_slices);
+    uint32_t num_slices = 0;
+    uint32_t local_grid_x = 0;
+    uint32_t local_grid_y = 0;
+    uint32_t best_cost = std::numeric_limits<uint32_t>::max();
+    for (uint32_t a = 1; a <= static_cast<uint32_t>(grid.x); ++a) {
+        for (uint32_t b = 1; b <= static_cast<uint32_t>(grid.y); ++b) {
+            const uint32_t p = a * b;
+            if (p < 2 || p > slice_ceiling) {
+                continue;
+            }
+            const uint32_t cost = 2 * tt::div_up(num_chunks, p) + tree_levels(p);
+            if (cost < best_cost || (cost == best_cost && p < num_slices)) {
+                best_cost = cost;
+                num_slices = p;
+                local_grid_x = a;
+                local_grid_y = b;
+            }
+        }
+    }
+    if (num_slices < 2) {
+        return config;
+    }
+
+    const uint32_t cost_row = 2 * num_chunks;  // single row -> single core on the row-parallel path
+    if (best_cost >= cost_row) {
+        return config;
+    }
+
+    config.enabled = true;
+    config.num_slices = num_slices;
+    config.local_grid_x = local_grid_x;
+    config.local_grid_y = local_grid_y;
+    return config;
+}
+
+}  // namespace
+
+ColumnSplitConfig compute_column_split_config(
+    uint32_t k, uint32_t n, uint32_t num_rows, const CoreCoord& grid, std::optional<uint32_t> num_slices_override) {
+    ColumnSplitConfig config = compute_model_column_split_config(k, n, num_rows, grid);
+    if (!num_slices_override.has_value()) {
+        return config;
+    }
+
+    // Explicit beats ignored: the override has no meaning on the row-parallel
+    // path, so reject it loudly instead of silently dropping it.
+    TT_FATAL(
+        config.enabled,
+        "topk_large_indices num_slices={} was given, but the column-parallel path is not selected for this call "
+        "(it requires a single row and a row wide enough to split; got {} rows, last dim {}). Remove num_slices "
+        "or reshape to a single-row call.",
+        *num_slices_override,
+        num_rows,
+        n);
+
+    const uint32_t requested = *num_slices_override;
+    TT_FATAL(
+        requested >= 2 && requested <= max_column_slices,
+        "topk_large_indices num_slices must be in [2, {}], got {}",
+        max_column_slices,
+        requested);
+    const uint32_t llk_k = to_uint32(snap_to_llk_target_k(k));
+    const uint32_t num_chunks = tt::div_up(n, llk_k);
+    TT_FATAL(
+        requested <= num_chunks,
+        "topk_large_indices num_slices={} exceeds the row's chunk count {} (last dim {} / LLK window {}); every "
+        "slice must own at least one chunk",
+        requested,
+        num_chunks,
+        n,
+        llk_k);
+
+    // Clamp only against the physical grid (rectangle capacity), with a warning.
+    // Honor the requested count with an exact a x b rectangle when one fits
+    // the grid (e.g. 32 = 8x4 on 13x10); otherwise fall back to the largest
+    // achievable product <= requested, with a warning. The old full-rows-only
+    // fit silently clamped 16->13, 24->13, 32->26, mislabeling P-sweeps.
+    uint32_t num_slices = 0;
+    uint32_t local_grid_x = 0;
+    uint32_t local_grid_y = 0;
+    for (uint32_t a = 1; a <= static_cast<uint32_t>(grid.x); ++a) {
+        for (uint32_t b = 1; b <= static_cast<uint32_t>(grid.y); ++b) {
+            const uint32_t p = a * b;
+            if (p <= requested && p > num_slices) {
+                num_slices = p;
+                local_grid_x = a;
+                local_grid_y = b;
+            }
+        }
+    }
+    if (num_slices != requested) {
+        log_warning(
+            tt::LogOp,
+            "topk_large_indices num_slices={} does not fit the {}x{} worker grid's local-core rectangle; "
+            "clamped to {} ({}x{} local cores + 1 merge core)",
+            requested,
+            grid.x,
+            grid.y,
+            num_slices,
+            local_grid_x,
+            local_grid_y);
+    }
+
+    config.num_slices = num_slices;
+    config.local_grid_x = local_grid_x;
+    config.local_grid_y = local_grid_y;
+    return config;
+}
+
+namespace {
+
+struct SliceRuntime {
+    uint32_t start_chunk = 0;    // index of the slice's first chunk within the row
+    uint32_t start_element = 0;  // start_chunk * llk_k
+    uint32_t num_chunks = 0;     // active chunks after the valid_length cut (0 = empty slice)
+    uint32_t tail_elements = 0;  // active elements in the slice's last chunk
+};
+
+// Splits the physical chunk range evenly over the slices, then bounds each
+// slice by the runtime search width (valid_length). Slices wholly beyond the
+// search width come back empty and are serviced by the writer's -inf fill.
+std::vector<SliceRuntime> compute_slice_runtime(
+    uint32_t n, uint32_t llk_k, uint32_t num_slices, std::optional<uint32_t> valid_length) {
+    const uint32_t search_len = valid_length.value_or(n);
+    const uint32_t num_chunks_phys = tt::div_up(n, llk_k);
+    const uint32_t base_chunks = num_chunks_phys / num_slices;
+    const uint32_t extra_chunks = num_chunks_phys % num_slices;
+
+    std::vector<SliceRuntime> slices(num_slices);
+    uint32_t start_chunk = 0;
+    for (uint32_t s = 0; s < num_slices; ++s) {
+        const uint32_t chunk_count = base_chunks + (s < extra_chunks ? 1 : 0);
+        const uint32_t start_element = start_chunk * llk_k;
+        const uint32_t end_element = std::min((start_chunk + chunk_count) * llk_k, n);
+        const uint32_t active_end = std::min(end_element, search_len);
+
+        SliceRuntime& slice = slices[s];
+        slice.start_chunk = start_chunk;
+        slice.start_element = start_element;
+        if (active_end > start_element) {
+            const uint32_t active_len = active_end - start_element;
+            slice.num_chunks = tt::div_up(active_len, llk_k);
+            slice.tail_elements = active_len - ((slice.num_chunks - 1) * llk_k);
+        }
+        start_chunk += chunk_count;
+    }
+    TT_FATAL(
+        start_chunk == num_chunks_phys,
+        "topk_large_indices column split assigned {} chunks, expected {}",
+        start_chunk,
+        num_chunks_phys);
+    return slices;
+}
+
+void set_runtime_args_multi_core(
+    tt::tt_metal::Program& program,
+    const TopkLargeIndicesMultiCoreSharedVariables& shared,
+    const Tensor& input,
+    const tensor_return_value_t& outputs,
+    const operation_attributes_t& attrs) {
+    const LlkTargetK llk_target_k = snap_to_llk_target_k(attrs.k);
+    const std::optional<uint32_t> valid_length = attrs.valid_length;
+    const Tensor& indices = outputs[0];
+    const bool return_values = outputs.size() > 1;
+    const bool tile_input = input.layout() == Layout::TILE;
+    const bool flex_writer = uses_flex_writer(attrs);
+    const uint32_t llk_k = to_uint32(llk_target_k);
+    const auto& shape = input.logical_shape();
+    const uint32_t n = shape[shape.rank() - 1];
+    const uint32_t num_rows = flattened_rows_excluding_last_dim(shape);
+    const uint32_t input_row_bytes = n * input.element_size();
+    const uint32_t num_slices = static_cast<uint32_t>(shared.cores.size());
+    const uint32_t num_levels = tree_levels(num_slices);
+    TT_FATAL(
+        num_levels <= 7, "topk_large_indices merge tree supports at most 7 levels (128 slices), got {}", num_levels);
+
+    const auto slices = compute_slice_runtime(n, llk_k, num_slices, valid_length);
+    auto* device = input.device();
+
+    const uint32_t rows_2d = rows_2d_of(shape);
+    const uint32_t w_tiles = input.padded_shape()[-1] / tt::constants::TILE_WIDTH;
+
+    for (uint32_t i = 0; i < num_slices; ++i) {
+        const auto& core = shared.cores[i];
+        const auto& slice = slices[i];
+        if (tile_input) {
+            tt::tt_metal::SetRuntimeArgs(
+                program,
+                shared.reader_kernel_id,
+                core,
+                {input.buffer()->address(),
+                 0 /* start_row */,
+                 num_rows,
+                 slice.num_chunks,
+                 tt::div_up(slice.tail_elements, tt::constants::FACE_WIDTH),
+                 w_tiles,
+                 rows_2d,
+                 0 /* start_in_slice */,
+                 0 /* start_slice */,
+                 slice.start_element});
+        } else {
+            tt::tt_metal::SetRuntimeArgs(
+                program,
+                shared.reader_kernel_id,
+                core,
+                {input.buffer()->address(),
+                 0 /* start_row */,
+                 num_rows,
+                 slice.num_chunks,
+                 slice.tail_elements * input.element_size(),
+                 input_row_bytes,
+                 slice.start_element * input.element_size()});
+        }
+
+        // Tree schedule for slice i: it wins levels [0, t) where t is the
+        // index of i's lowest set bit (root i=0 wins every level), merging
+        // partner i + 2^level whenever that slice exists (byes otherwise),
+        // then ships its survivor to i with the lowest set bit cleared.
+        const bool is_root = (i == 0);
+        uint32_t winning_levels = num_levels;
+        if (!is_root) {
+            winning_levels = 0;
+            while (((i >> winning_levels) & 1u) == 0) {
+                ++winning_levels;
+            }
+        }
+        uint32_t num_merges = 0;
+        // 7 (x, y) pairs — must match the writer kernels' partner_x/y[7] and
+        // the positional offsets of the args that follow (do_ship at 16).
+        std::vector<uint32_t> partner_coords(14, 0);
+        for (uint32_t level = 0; level < winning_levels; ++level) {
+            const uint32_t partner = i + (1u << level);
+            if (partner < num_slices) {
+                const CoreCoord partner_physical = device->worker_core_from_logical_core(shared.cores[partner]);
+                partner_coords[2 * num_merges] = static_cast<uint32_t>(partner_physical.x);
+                partner_coords[2 * num_merges + 1] = static_cast<uint32_t>(partner_physical.y);
+                ++num_merges;
+            }
+        }
+
+        tt::tt_metal::SetRuntimeArgs(
+            program,
+            is_root ? shared.compute_root_kernel_id : shared.compute_node_kernel_id,
+            core,
+            {num_rows, slice.num_chunks, slice.tail_elements, slice.start_chunk, num_merges});
+
+        uint32_t winner_x = 0;
+        uint32_t winner_y = 0;
+        if (!is_root) {
+            const uint32_t winner = i & (i - 1);  // clear the lowest set bit
+            const CoreCoord winner_physical = device->worker_core_from_logical_core(shared.cores[winner]);
+            winner_x = static_cast<uint32_t>(winner_physical.x);
+            winner_y = static_cast<uint32_t>(winner_physical.y);
+        }
+        // A shipping core with an empty slice AND no adopted partners has no
+        // survivor in DST; its writer sends the prefilled -inf sequence.
+        const uint32_t is_empty_ship = (!is_root && slice.num_chunks == 0 && num_merges == 0) ? 1u : 0u;
+
+        std::vector<uint32_t> writer_args;
+        writer_args.reserve(20);
+        writer_args.push_back(num_rows);
+        writer_args.push_back(num_merges);
+        for (uint32_t v : partner_coords) {
+            writer_args.push_back(v);
+        }
+        writer_args.push_back(is_root ? 0u : 1u);  // do_ship
+        writer_args.push_back(winner_x);
+        writer_args.push_back(winner_y);
+        writer_args.push_back(is_empty_ship);
+        writer_args.push_back(indices.buffer()->address());
+        if (return_values) {
+            writer_args.push_back(outputs[1].buffer()->address());
+        } else if (flex_writer) {
+            writer_args.push_back(0);  // flex writer arg-layout parity: unused values address
+        }
+        tt::tt_metal::SetRuntimeArgs(program, shared.writer_kernel_id, core, writer_args);
+    }
+}
+
+}  // namespace
+
+TopkLargeIndicesMultiCoreProgramFactory::cached_program_t TopkLargeIndicesMultiCoreProgramFactory::create(
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    auto program = tt::tt_metal::CreateProgram();
+
+    const auto& input = tensor_args.input_tensor;
+    auto& indices = tensor_return_value[0];
+    const bool return_values = operation_attributes.return_values;
+    const bool tile_input = input.layout() == Layout::TILE;
+    const bool tile_output = operation_attributes.tile_output;
+    const bool index_u16 = operation_attributes.index_dtype == DataType::UINT16;
+    const bool flex_writer = uses_flex_writer(operation_attributes);
+
+    const uint32_t k = operation_attributes.k;
+    const auto llk_target_k = snap_to_llk_target_k(k);
+    const uint32_t llk_k = to_uint32(llk_target_k);
+    const uint32_t tiles_per_sequence = (llk_k + tt::constants::TILE_HW - 1) / tt::constants::TILE_HW;
+
+    const auto& shape = input.logical_shape();
+    const uint32_t n = shape[shape.rank() - 1];
+    const uint32_t num_rows = flattened_rows_excluding_last_dim(shape);
+    const auto grid = input.device()->compute_with_storage_grid_size();
+    const auto config = compute_column_split_config(k, n, num_rows, grid, operation_attributes.num_slices);
+    TT_FATAL(config.enabled, "topk_large_indices multi-core factory selected for a shape it does not support");
+    const uint32_t num_slices = config.num_slices;
+
+    // The merge tree lives IN PLACE on the slice rectangle: slice i is
+    // rectangle core (i % sx, i / sx) in row-major order; slice 0 (core
+    // (0,0)) is the root and produces the output. Winners keep their
+    // survivor in DST across levels — only the shipped operand crosses the
+    // NoC, once, per losing core.
+    const CoreRange rect({0, 0}, {config.local_grid_x - 1, config.local_grid_y - 1});
+    const CoreRangeSet all_cores(rect);
+    const auto cores = corerange_to_cores(all_cores, std::nullopt, true);
+    TT_FATAL(
+        cores.size() == num_slices,
+        "topk_large_indices column split expected {} tree cores, got {}",
+        num_slices,
+        cores.size());
+    const CoreCoord root_core = cores.front();
+    const CoreRangeSet root_core_set(CoreRange(root_core, root_core));
+    // All rectangle cores except the root run the node compute kernel.
+    std::vector<CoreRange> node_ranges;
+    if (config.local_grid_x > 1) {
+        node_ranges.emplace_back(CoreCoord(1, 0), CoreCoord(config.local_grid_x - 1, 0));
+    }
+    if (config.local_grid_y > 1) {
+        node_ranges.emplace_back(CoreCoord(0, 1), CoreCoord(config.local_grid_x - 1, config.local_grid_y - 1));
+    }
+    TT_FATAL(!node_ranges.empty(), "topk_large_indices merge tree needs at least 2 slices");
+    const CoreRangeSet node_cores_set(node_ranges);
+
+    constexpr uint32_t cb_in = tt::CBIndex::c_0;
+    constexpr uint32_t cb_indices_out = tt::CBIndex::c_1;
+    constexpr uint32_t cb_indices_scratch = tt::CBIndex::c_2;
+    constexpr uint32_t cb_recv = tt::CBIndex::c_3;
+    constexpr uint32_t cb_ship_values = tt::CBIndex::c_5;
+    constexpr uint32_t cb_ship_indices = tt::CBIndex::c_6;
+    constexpr uint32_t cb_neginf_scratch = tt::CBIndex::c_7;
+    // Root-only values output CBs (return_values only).
+    constexpr uint32_t cb_values_out = tt::CBIndex::c_8;
+    constexpr uint32_t cb_values_scratch = tt::CBIndex::c_9;
+    // Root-only tile-padding zero slab (tile_output only).
+    constexpr uint32_t cb_pad_zero = tt::CBIndex::c_10;
+    // TILE-input read staging (all cores, tile input only).
+    constexpr uint32_t cb_stage = tt::CBIndex::c_11;
+
+    const uint32_t input_chunk_bytes = llk_k * input.element_size();
+    const uint32_t input_tile_bytes = tt::constants::TILE_HW * input.element_size();
+    // The unfused sequences travel as opaque 32-bit words (FP32 values /
+    // UINT32 indices packed raw from DST); one 32x32 tile is 4 KB.
+    const uint32_t tile32_bytes = tt::constants::TILE_HW * sizeof(uint32_t);
+    const uint32_t sequence_bytes = tiles_per_sequence * tile32_bytes;
+    constexpr uint32_t row_slice_elements = tt::constants::FACE_WIDTH;
+    const uint32_t source_slices_per_row = llk_k / row_slice_elements;
+    const uint32_t output_slices_per_row = k / row_slice_elements;
+    const uint32_t indices_slice_bytes = row_slice_elements * indices.element_size();
+    const uint32_t indices_row_bytes = k * indices.element_size();
+    // The indices CB carries the raw 32-bit index words the packer produces,
+    // independent of the (possibly narrowed) output tensor dtype.
+    const uint32_t indices_cb_row_bytes = llk_k * static_cast<uint32_t>(sizeof(uint32_t));
+    constexpr uint32_t cb_depth = 2;
+
+    // The recv CB spans the whole rectangle so every core sees the same L1
+    // address (a shipping core derives its winner's destination from its own
+    // copy). Sized to exactly one sequence: capacity IS the level-to-level
+    // backpressure. Created FIRST so the multi-range address has no gaps.
+    const auto recv_cb_config =
+        tt::tt_metal::CircularBufferConfig(2 * sequence_bytes, {{cb_recv, tt::DataFormat::UInt32}})
+            .set_page_size(cb_recv, tile32_bytes);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, recv_cb_config);
+
+    const auto input_cb_config =
+        tt::tt_metal::CircularBufferConfig(
+            cb_depth * tiles_per_sequence * input_tile_bytes, {{cb_in, tt::DataFormat::Float16_b}})
+            .set_page_size(cb_in, input_tile_bytes);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, input_cb_config);
+
+    const auto ship_values_cb_config =
+        tt::tt_metal::CircularBufferConfig(
+            cb_depth * tiles_per_sequence * tile32_bytes, {{cb_ship_values, tt::DataFormat::UInt32}})
+            .set_page_size(cb_ship_values, tile32_bytes);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, ship_values_cb_config);
+
+    const auto ship_indices_cb_config =
+        tt::tt_metal::CircularBufferConfig(
+            cb_depth * tiles_per_sequence * tile32_bytes, {{cb_ship_indices, tt::DataFormat::UInt32}})
+            .set_page_size(cb_ship_indices, tile32_bytes);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, ship_indices_cb_config);
+
+    // Writer-owned scratch for the empty-slice -inf sequence (values + indices).
+    const auto neginf_scratch_cb_config =
+        tt::tt_metal::CircularBufferConfig(2 * sequence_bytes, {{cb_neginf_scratch, tt::DataFormat::UInt32}})
+            .set_page_size(cb_neginf_scratch, tile32_bytes);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, neginf_scratch_cb_config);
+
+    // Root-only output CBs: identical shape to the row-parallel factory's.
+    auto indices_cb_config =
+        tt::tt_metal::CircularBufferConfig(cb_depth * indices_cb_row_bytes, {{cb_indices_out, tt::DataFormat::Float32}})
+            .set_page_size(cb_indices_out, indices_cb_row_bytes);
+    if (llk_target_k == LlkTargetK::K512) {
+        indices_cb_config.set_unpack_face_geometry(cb_indices_out, tt::constants::FACE_HEIGHT, 2);
+    }
+    tt::tt_metal::CreateCircularBuffer(program, root_core_set, indices_cb_config);
+
+    // Also the UINT16 narrowing row when narrowing is requested (see the
+    // row-parallel factory).
+    if (llk_target_k != LlkTargetK::K512 || index_u16) {
+        const auto indices_scratch_cb_config =
+            tt::tt_metal::CircularBufferConfig(indices_row_bytes, {{cb_indices_scratch, tt::DataFormat::Float32}})
+                .set_page_size(cb_indices_scratch, indices_row_bytes);
+        tt::tt_metal::CreateCircularBuffer(program, root_core_set, indices_scratch_cb_config);
+    }
+
+    if (return_values) {
+        create_values_output_cbs(program, root_core_set, llk_target_k, k, cb_values_out, cb_values_scratch);
+    }
+
+    if (tile_output) {
+        const auto pad_cb_config =
+            tt::tt_metal::CircularBufferConfig(pad_zero_slab_bytes, {{cb_pad_zero, tt::DataFormat::UInt32}})
+                .set_page_size(cb_pad_zero, pad_zero_slab_bytes);
+        tt::tt_metal::CreateCircularBuffer(program, root_core_set, pad_cb_config);
+    }
+    if (tile_input) {
+        const uint32_t stage_bytes = (llk_k / row_slice_elements) * 64 + 64;
+        const auto stage_cb_config =
+            tt::tt_metal::CircularBufferConfig(stage_bytes, {{cb_stage, tt::DataFormat::UInt32}})
+                .set_page_size(cb_stage, stage_bytes);
+        tt::tt_metal::CreateCircularBuffer(program, all_cores, stage_cb_config);
+    }
+
+    // Pairwise tree flow control (see writer_tree.cpp): ready = "my winner's
+    // recv slot is free", data = "my current partner's sequence landed".
+    const uint32_t ready_sem_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+    const uint32_t data_sem_id = tt::tt_metal::CreateSemaphore(program, all_cores, INVALID);
+
+    // Leaf reader: the row-parallel reader plus a per-core slice offset
+    // (reader_local.cpp is reused unchanged from the gather design;
+    // reader_tile.cpp serves TILE-layout inputs on both factories).
+    std::vector<uint32_t> reader_compile_args;
+    if (tile_input) {
+        reader_compile_args = {cb_in, cb_stage, llk_k / row_slice_elements, tiles_per_sequence};
+    } else {
+        reader_compile_args = {cb_in, input_chunk_bytes, input_tile_bytes, tiles_per_sequence};
+    }
+    interleaved_accessor_args(input).append_to(reader_compile_args);
+    auto reader_kernel = tt::tt_metal::CreateKernel(
+        program,
+        tile_input ? "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/reader_tile.cpp"
+                   : "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/reader_local.cpp",
+        all_cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_args));
+
+    const std::vector<uint32_t> compute_node_compile_args = {cb_in, cb_ship_values, cb_ship_indices, cb_recv, llk_k};
+    auto compute_node_kernel = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute_tree.cpp",
+        node_cores_set,
+        tt::tt_metal::ComputeConfig{// Same DST configuration as the row-parallel compute kernel: the
+                                    // unfused K=2048 merge occupies DEST slots 0..7 (FP32, full sync).
+                                    .fp32_dest_acc_en = true,
+                                    .dst_full_sync_en = true,
+                                    .compile_args = compute_node_compile_args});
+
+    std::vector<uint32_t> compute_root_compile_args = {cb_in, cb_indices_out, cb_recv, llk_k};
+    if (return_values) {
+        compute_root_compile_args.push_back(cb_values_out);
+    }
+    auto compute_root_kernel = tt::tt_metal::CreateKernel(
+        program,
+        return_values ? "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/"
+                        "compute_tree_root_with_values.cpp"
+                      : "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute_tree_root.cpp",
+        root_core_set,
+        tt::tt_metal::ComputeConfig{
+            .fp32_dest_acc_en = true, .dst_full_sync_en = true, .compile_args = compute_root_compile_args});
+
+    tt::tt_metal::KernelHandle writer_kernel;
+    if (flex_writer) {
+        const uint32_t idx_es = indices.element_size();
+        const uint32_t indices_page_bytes = tile_output ? tt::constants::TILE_HW * idx_es : indices_row_bytes;
+        const uint32_t values_page_bytes =
+            tile_output ? tt::constants::TILE_HW * values_element_bytes : k * values_element_bytes;
+        std::vector<uint32_t> flex_compile_args = {
+            cb_ship_values,
+            cb_ship_indices,
+            cb_neginf_scratch,
+            cb_recv,
+            ready_sem_id,
+            data_sem_id,
+            tiles_per_sequence,
+            tile32_bytes,
+            cb_indices_out,
+            cb_indices_scratch,
+            indices_page_bytes,
+            source_slices_per_row,
+            output_slices_per_row,
+            cb_values_out,
+            cb_values_scratch,
+            values_page_bytes,
+            cb_pad_zero,
+            tile_output ? k / tt::constants::TILE_WIDTH : 0};
+        interleaved_accessor_args(indices).append_to(flex_compile_args);
+        if (return_values) {
+            interleaved_accessor_args(tensor_return_value[1]).append_to(flex_compile_args);
+        }
+        std::map<std::string, std::string> flex_defines;
+        if (return_values) {
+            flex_defines["FLEX_WITH_VALUES"] = "1";
+        }
+        if (tile_output) {
+            flex_defines["FLEX_OUT_TILE"] = "1";
+        }
+        if (index_u16) {
+            flex_defines["FLEX_INDEX_U16"] = "1";
+        }
+        writer_kernel = tt::tt_metal::CreateKernel(
+            program,
+            "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer_tree_flex.cpp",
+            all_cores,
+            tt::tt_metal::WriterDataMovementConfig(flex_compile_args, flex_defines));
+    } else {
+        std::vector<uint32_t> writer_compile_args = {
+            cb_ship_values,
+            cb_ship_indices,
+            cb_neginf_scratch,
+            cb_recv,
+            ready_sem_id,
+            data_sem_id,
+            tiles_per_sequence,
+            tile32_bytes,
+            cb_indices_out,
+            cb_indices_scratch,
+            indices_row_bytes,
+            source_slices_per_row,
+            output_slices_per_row,
+            indices_slice_bytes};
+        if (return_values) {
+            writer_compile_args.push_back(cb_values_out);
+            writer_compile_args.push_back(cb_values_scratch);
+            writer_compile_args.push_back(k * values_element_bytes);
+            writer_compile_args.push_back(row_slice_elements * values_element_bytes);
+        }
+        interleaved_accessor_args(indices).append_to(writer_compile_args);
+        if (return_values) {
+            interleaved_accessor_args(tensor_return_value[1]).append_to(writer_compile_args);
+        }
+        writer_kernel = tt::tt_metal::CreateKernel(
+            program,
+            return_values
+                ? "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer_tree_with_values.cpp"
+                : "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/writer_tree.cpp",
+            all_cores,
+            tt::tt_metal::WriterDataMovementConfig(writer_compile_args));
+    }
+
+    TopkLargeIndicesMultiCoreSharedVariables shared{
+        .reader_kernel_id = reader_kernel,
+        .compute_node_kernel_id = compute_node_kernel,
+        .compute_root_kernel_id = compute_root_kernel,
+        .writer_kernel_id = writer_kernel,
+        .cores = cores};
+    set_runtime_args_multi_core(program, shared, input, tensor_return_value, operation_attributes);
+
+    return cached_program_t{std::move(program), std::move(shared)};
+}
+
+void TopkLargeIndicesMultiCoreProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& operation_attributes,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    set_runtime_args_multi_core(
+        cached_program.program,
+        cached_program.shared_variables,
+        tensor_args.input_tensor,
+        tensor_return_value,
+        operation_attributes);
 }
 
 }  // namespace ttnn::operations::experimental::topk_large_indices::program

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.cpp
@@ -145,8 +145,12 @@ void set_runtime_args(
     const uint32_t rows_2d = rows_2d_of(input.logical_shape());
     const uint32_t w_tiles = input.padded_shape()[-1] / tt::constants::TILE_WIDTH;
     const auto runtime_args = get_runtime_shape_args(input, llk_target_k, valid_length);
-    const auto work_split = tt::tt_metal::split_work_to_cores(
-        input.device()->compute_with_storage_grid_size(), runtime_args.num_rows, true);
+    // Row window (hybrid wrapper): readers index global input rows from row_base;
+    // writers stay output-relative (the window's output has its own row 0).
+    const uint32_t row_base = attrs.row_start.value_or(0);
+    const uint32_t effective_rows = attrs.row_count.value_or(runtime_args.num_rows);
+    const auto work_split =
+        tt::tt_metal::split_work_to_cores(input.device()->compute_with_storage_grid_size(), effective_rows, true);
     const auto num_active_cores = std::get<0>(work_split);
     const auto& core_group_1 = std::get<2>(work_split);
     const auto& core_group_2 = std::get<3>(work_split);
@@ -164,20 +168,21 @@ void set_runtime_args(
             rows,
             num_rows_per_core_group_1);
 
+        const uint32_t input_row = row_base + start_row;
         if (tile_input) {
             tt::tt_metal::SetRuntimeArgs(
                 program,
                 shared.reader_kernel_id,
                 core,
                 {input.buffer()->address(),
-                 start_row,
+                 input_row,
                  rows,
                  runtime_args.num_chunks,
                  tt::div_up(runtime_args.tail_elements, tt::constants::FACE_WIDTH),
                  w_tiles,
                  rows_2d,
-                 start_row % rows_2d,
-                 start_row / rows_2d,
+                 input_row % rows_2d,
+                 input_row / rows_2d,
                  0 /* start_element */});
         } else {
             tt::tt_metal::SetRuntimeArgs(
@@ -185,7 +190,7 @@ void set_runtime_args(
                 shared.reader_kernel_id,
                 core,
                 {input.buffer()->address(),
-                 start_row,
+                 input_row,
                  rows,
                  runtime_args.num_chunks,
                  runtime_args.input_tail_chunk_bytes,
@@ -219,10 +224,7 @@ void set_runtime_args(
         start_row += rows;
     }
     TT_FATAL(
-        start_row == runtime_args.num_rows,
-        "topk_large_indices assigned {} rows, expected {}",
-        start_row,
-        runtime_args.num_rows);
+        start_row == effective_rows, "topk_large_indices assigned {} rows, expected {}", start_row, effective_rows);
 }
 
 }  // namespace
@@ -343,6 +345,21 @@ TopkLargeIndicesProgramFactory::cached_program_t TopkLargeIndicesProgramFactory:
     // survivor (not the llk_k-th), which is what makes skipping profitable at
     // small k. attrs.k is already part of the program hash.
     compute_compile_args.push_back(k);
+    // Fused end-to-end merge/rebuild: stay in the fused [bf16|u16] word through
+    // every merge/rebuild and split once per row, recovering the global index
+    // from a per-chunk stamp in bits [15:11]. Sound only when every possible
+    // chunk count fits the 5-bit id: <= 32 chunks of the LLK window over the
+    // FULL logical width (valid_length can only shrink the runtime count).
+    // Derived from shape, so it is mirrored into compute_program_hash.
+    std::map<std::string, std::string> compute_defines;
+    switch (compute_body_mode(k, input.logical_shape()[-1])) {
+        case ComputeBodyMode::FusedSegmented: compute_defines["FUSED_SEGMENTED"] = "1"; break;
+        case ComputeBodyMode::FusedE2E: compute_defines["FUSED_E2E"] = "1"; break;
+        case ComputeBodyMode::Classic: break;
+    }
+    if (!operation_attributes.neginf_sentinel) {
+        compute_defines["TOPK_SKIP_NEGINF_SENTINEL"] = "1";
+    }
     auto compute_kernel = tt::tt_metal::CreateKernel(
         program,
         return_values
@@ -354,7 +371,8 @@ TopkLargeIndicesProgramFactory::cached_program_t TopkLargeIndicesProgramFactory:
             .fp32_dest_acc_en = true,
             // K=2048 multi-chunk merge uses DEST slots 0..7; FP32 half-sync mode exposes only 4 tiles.
             .dst_full_sync_en = true,
-            .compile_args = compute_compile_args});
+            .compile_args = compute_compile_args,
+            .defines = compute_defines});
 
     tt::tt_metal::KernelHandle writer_kernel;
     if (flex_writer) {
@@ -468,18 +486,27 @@ uint32_t tree_levels(uint32_t p) {
 }
 
 // The built-in cost-model pick (no user override).
-ColumnSplitConfig compute_model_column_split_config(uint32_t k, uint32_t n, uint32_t num_rows, const CoreCoord& grid) {
+ColumnSplitConfig compute_model_column_split_config(
+    uint32_t k, uint32_t n, uint32_t num_rows, const CoreCoord& grid, bool allow_multi_row) {
     constexpr uint32_t max_slices = max_column_slices;
 
     ColumnSplitConfig config{};
-    // Intra-row parallelism only pays off when rows cannot saturate the grid;
-    // restrict to the single-row case this path is built for. Every other
-    // shape keeps the row-parallel factory (and its shape-free program hash)
-    // unchanged.
-    if (num_rows != 1) {
+    // Intra-row parallelism only pays off when rows cannot saturate the grid.
+    // Single row: the classic tree. Multiple rows (allow_multi_row): the
+    // multi-rectangle form, considered only when EVERY row gets its own
+    // concurrent rectangle (one rect-wave) — then the per-row cost comparison
+    // below is exact and, at any runtime valid_length, the rect's saturating
+    // makespan bounds the loss to one merge term while row-parallel would run
+    // the same single wave. Rows beyond every rectangle capacity keep the
+    // row-parallel factory (and its shape-free program hash) unchanged; the
+    // hybrid wrapper handles those by splitting off a remainder window.
+    if (num_rows != 1 && !allow_multi_row) {
         return config;
     }
     if (static_cast<uint32_t>(grid.x * grid.y) < 2) {
+        return config;
+    }
+    if (num_rows == 0) {
         return config;
     }
 
@@ -512,6 +539,12 @@ ColumnSplitConfig compute_model_column_split_config(uint32_t k, uint32_t n, uint
             if (p < 2 || p > slice_ceiling) {
                 continue;
             }
+            // Multi-row: every row must own a concurrent rectangle, so the
+            // candidate's grid-tiling capacity must cover the row count.
+            const uint32_t capacity = (static_cast<uint32_t>(grid.x) / a) * (static_cast<uint32_t>(grid.y) / b);
+            if (num_rows > capacity) {
+                continue;
+            }
             const uint32_t cost = 2 * tt::div_up(num_chunks, p) + tree_levels(p);
             if (cost < best_cost || (cost == best_cost && p < num_slices)) {
                 best_cost = cost;
@@ -525,8 +558,17 @@ ColumnSplitConfig compute_model_column_split_config(uint32_t k, uint32_t n, uint
         return config;
     }
 
-    const uint32_t cost_row = 2 * num_chunks;  // single row -> single core on the row-parallel path
+    const uint32_t cost_row = 2 * num_chunks;  // one row per core on the row-parallel path (single wave)
     if (best_cost >= cost_row) {
+        return config;
+    }
+    // Multi-row acceptance needs a margin over row-parallel: the only consumer
+    // is the hybrid wrapper's remainder window (the device op itself never
+    // auto-selects multi-row), and its split adds a concat + a second dispatch,
+    // so demand a >= 12.5% modeled win to keep marginal splits from netting
+    // negative. (Was 2x when bare multi-row calls could auto-route; that
+    // routing is gone — see column_split_config_for.)
+    if (num_rows > 1 && best_cost + std::max(2u, cost_row / 8) > cost_row) {
         return config;
     }
 
@@ -534,28 +576,57 @@ ColumnSplitConfig compute_model_column_split_config(uint32_t k, uint32_t n, uint
     config.num_slices = num_slices;
     config.local_grid_x = local_grid_x;
     config.local_grid_y = local_grid_y;
+    // Single row keeps the classic one-rectangle program (byte-identical to
+    // before multi-rect existed). Multi-row tiles at full capacity: rectangles
+    // beyond the runtime row count run zero rows, so the program (and its
+    // hash) is row-count-free within this mode — one cached program serves
+    // any rows in [1, capacity].
+    config.num_rects = (num_rows == 1) ? 1
+                                       : (static_cast<uint32_t>(grid.x) / local_grid_x) *
+                                             (static_cast<uint32_t>(grid.y) / local_grid_y);
     return config;
 }
 
 }  // namespace
 
+bool fused_e2e_gate(uint32_t k, uint32_t input_last_dim) {
+    return tt::div_up(input_last_dim, to_uint32(snap_to_llk_target_k(k))) <= 32;
+}
+
+ComputeBodyMode compute_body_mode(uint32_t k, uint32_t input_last_dim) {
+    // See the header. The k >= 1024 floor keeps the classic body (and its
+    // chunk-skip, arming at chunk >= k/4) for small-k wide rows where skip is
+    // a measured win; at k >= 1024 skip is provably dead at any realistic
+    // width, so the segmented body strictly wins at every width.
+    constexpr uint32_t fused_segmented_min_user_k = 1024;
+    if (k >= fused_segmented_min_user_k) {
+        return ComputeBodyMode::FusedSegmented;
+    }
+    return fused_e2e_gate(k, input_last_dim) ? ComputeBodyMode::FusedE2E : ComputeBodyMode::Classic;
+}
+
 ColumnSplitConfig compute_column_split_config(
-    uint32_t k, uint32_t n, uint32_t num_rows, const CoreCoord& grid, std::optional<uint32_t> num_slices_override) {
-    ColumnSplitConfig config = compute_model_column_split_config(k, n, num_rows, grid);
+    uint32_t k,
+    uint32_t n,
+    uint32_t num_rows,
+    const CoreCoord& grid,
+    std::optional<uint32_t> num_slices_override,
+    bool allow_multi_row) {
+    ColumnSplitConfig config = compute_model_column_split_config(k, n, num_rows, grid, allow_multi_row);
     if (!num_slices_override.has_value()) {
         return config;
     }
 
-    // Explicit beats ignored: the override has no meaning on the row-parallel
-    // path, so reject it loudly instead of silently dropping it.
+    // Explicit num_slices selects the tree path directly. Single row: the
+    // classic column-parallel tree. Multiple rows: the multi-rectangle
+    // variant — one P-core tree per rectangle, rows split contiguously across
+    // as many rectangles as tile the grid, all running concurrently. (The
+    // built-in cost model still never auto-selects the multi-row form; the
+    // override is the opt-in.)
     TT_FATAL(
-        config.enabled,
-        "topk_large_indices num_slices={} was given, but the column-parallel path is not selected for this call "
-        "(it requires a single row and a row wide enough to split; got {} rows, last dim {}). Remove num_slices "
-        "or reshape to a single-row call.",
-        *num_slices_override,
-        num_rows,
-        n);
+        static_cast<uint32_t>(grid.x * grid.y) >= 2,
+        "topk_large_indices num_slices={} needs a worker grid of at least 2 cores",
+        *num_slices_override);
 
     const uint32_t requested = *num_slices_override;
     TT_FATAL(
@@ -582,13 +653,23 @@ ColumnSplitConfig compute_column_split_config(
     uint32_t num_slices = 0;
     uint32_t local_grid_x = 0;
     uint32_t local_grid_y = 0;
+    // Among rectangles of equal core count, prefer the shape that tiles the
+    // grid the most times: with rows > 1 the tiling capacity IS the rectangle
+    // concurrency (a 2x2 fit tiles a 13x10 grid 30 times; a 1x4 fit only 26,
+    // silently doubling some rectangles' row load).
+    uint32_t best_capacity = 0;
     for (uint32_t a = 1; a <= static_cast<uint32_t>(grid.x); ++a) {
         for (uint32_t b = 1; b <= static_cast<uint32_t>(grid.y); ++b) {
             const uint32_t p = a * b;
-            if (p <= requested && p > num_slices) {
+            if (p > requested) {
+                continue;
+            }
+            const uint32_t capacity = (static_cast<uint32_t>(grid.x) / a) * (static_cast<uint32_t>(grid.y) / b);
+            if (p > num_slices || (p == num_slices && capacity > best_capacity)) {
                 num_slices = p;
                 local_grid_x = a;
                 local_grid_y = b;
+                best_capacity = capacity;
             }
         }
     }
@@ -605,9 +686,19 @@ ColumnSplitConfig compute_column_split_config(
             local_grid_y);
     }
 
+    config.enabled = true;
     config.num_slices = num_slices;
     config.local_grid_x = local_grid_x;
     config.local_grid_y = local_grid_y;
+    // Single row keeps the classic one-rectangle program; multi-row tiles at
+    // full capacity (rectangles beyond the runtime row count run zero rows):
+    // row distribution is pure runtime args, so one cached program serves any
+    // row count with this layout.
+    config.num_rects =
+        (num_rows == 1)
+            ? 1
+            : std::max(
+                  1u, (static_cast<uint32_t>(grid.x) / local_grid_x) * (static_cast<uint32_t>(grid.y) / local_grid_y));
     return config;
 }
 
@@ -620,28 +711,34 @@ struct SliceRuntime {
     uint32_t tail_elements = 0;  // active elements in the slice's last chunk
 };
 
-// Splits the physical chunk range evenly over the slices, then bounds each
-// slice by the runtime search width (valid_length). Slices wholly beyond the
-// search width come back empty and are serviced by the writer's -inf fill.
+// Splits the VALID chunk range (bounded by the runtime search width) evenly
+// over the slices. Balancing on valid rather than physical chunks keeps every
+// tree working when a preallocated buffer carries a short valid prefix (the
+// DSA indexer grows valid_length inside a fixed 1M buffer): position-based
+// physical splitting emptied the trailing slices while the busy ones kept
+// near-full per-slice work — measured 1424us vs 720us for a 30-row remainder
+// window at buf=1M/valid=512k k=2048. Slices beyond the valid chunk count
+// come back empty and are serviced by the writer's -inf fill; everything here
+// is runtime-only, so one cached program serves any valid_length with
+// freshly balanced slices.
 std::vector<SliceRuntime> compute_slice_runtime(
     uint32_t n, uint32_t llk_k, uint32_t num_slices, std::optional<uint32_t> valid_length) {
-    const uint32_t search_len = valid_length.value_or(n);
-    const uint32_t num_chunks_phys = tt::div_up(n, llk_k);
-    const uint32_t base_chunks = num_chunks_phys / num_slices;
-    const uint32_t extra_chunks = num_chunks_phys % num_slices;
+    const uint32_t search_len = std::min(valid_length.value_or(n), n);
+    const uint32_t num_chunks_valid = tt::div_up(search_len, llk_k);
+    const uint32_t base_chunks = num_chunks_valid / num_slices;
+    const uint32_t extra_chunks = num_chunks_valid % num_slices;
 
     std::vector<SliceRuntime> slices(num_slices);
     uint32_t start_chunk = 0;
     for (uint32_t s = 0; s < num_slices; ++s) {
         const uint32_t chunk_count = base_chunks + (s < extra_chunks ? 1 : 0);
         const uint32_t start_element = start_chunk * llk_k;
-        const uint32_t end_element = std::min((start_chunk + chunk_count) * llk_k, n);
-        const uint32_t active_end = std::min(end_element, search_len);
+        const uint32_t active_end = std::min((start_chunk + chunk_count) * llk_k, search_len);
 
         SliceRuntime& slice = slices[s];
         slice.start_chunk = start_chunk;
         slice.start_element = start_element;
-        if (active_end > start_element) {
+        if (chunk_count > 0 && active_end > start_element) {
             const uint32_t active_len = active_end - start_element;
             slice.num_chunks = tt::div_up(active_len, llk_k);
             slice.tail_elements = active_len - ((slice.num_chunks - 1) * llk_k);
@@ -649,10 +746,10 @@ std::vector<SliceRuntime> compute_slice_runtime(
         start_chunk += chunk_count;
     }
     TT_FATAL(
-        start_chunk == num_chunks_phys,
+        start_chunk == num_chunks_valid,
         "topk_large_indices column split assigned {} chunks, expected {}",
         start_chunk,
-        num_chunks_phys);
+        num_chunks_valid);
     return slices;
 }
 
@@ -673,7 +770,9 @@ void set_runtime_args_multi_core(
     const uint32_t n = shape[shape.rank() - 1];
     const uint32_t num_rows = flattened_rows_excluding_last_dim(shape);
     const uint32_t input_row_bytes = n * input.element_size();
-    const uint32_t num_slices = static_cast<uint32_t>(shared.cores.size());
+    const uint32_t num_rects = static_cast<uint32_t>(shared.rect_cores.size());
+    TT_FATAL(num_rects >= 1, "topk_large_indices multi-core program has no rectangles");
+    const uint32_t num_slices = static_cast<uint32_t>(shared.rect_cores[0].size());
     const uint32_t num_levels = tree_levels(num_slices);
     TT_FATAL(
         num_levels <= 7, "topk_large_indices merge tree supports at most 7 levels (128 slices), got {}", num_levels);
@@ -684,101 +783,130 @@ void set_runtime_args_multi_core(
     const uint32_t rows_2d = rows_2d_of(shape);
     const uint32_t w_tiles = input.padded_shape()[-1] / tt::constants::TILE_WIDTH;
 
-    for (uint32_t i = 0; i < num_slices; ++i) {
-        const auto& core = shared.cores[i];
-        const auto& slice = slices[i];
-        if (tile_input) {
+    // Rows split contiguously across the leading rectangles (runtime-only,
+    // like valid_length: a different row count reuses this cached program;
+    // rectangles beyond the row count run zero rows and exit immediately).
+    // Row window (hybrid wrapper): readers index global input rows from
+    // row_base; writers stay output-relative.
+    const uint32_t row_base = attrs.row_start.value_or(0);
+    const uint32_t effective_rows = attrs.row_count.value_or(num_rows);
+    const uint32_t rects_used = std::max(1u, std::min(effective_rows, num_rects));
+    const uint32_t base_rows = effective_rows / rects_used;
+    const uint32_t extra_rows = effective_rows % rects_used;
+
+    uint32_t rect_start_row = 0;
+    for (uint32_t r = 0; r < num_rects; ++r) {
+        const auto& rect = shared.rect_cores[r];
+        const uint32_t rect_rows = (r < rects_used) ? base_rows + (r < extra_rows ? 1 : 0) : 0;
+        const uint32_t start_row = rect_start_row;
+        rect_start_row += rect_rows;
+
+        for (uint32_t i = 0; i < num_slices; ++i) {
+            const auto& core = rect[i];
+            const auto& slice = slices[i];
+            const uint32_t input_row = row_base + start_row;
+            if (tile_input) {
+                tt::tt_metal::SetRuntimeArgs(
+                    program,
+                    shared.reader_kernel_id,
+                    core,
+                    {input.buffer()->address(),
+                     input_row,
+                     rect_rows,
+                     slice.num_chunks,
+                     tt::div_up(slice.tail_elements, tt::constants::FACE_WIDTH),
+                     w_tiles,
+                     rows_2d,
+                     input_row % rows_2d,
+                     input_row / rows_2d,
+                     slice.start_element});
+            } else {
+                tt::tt_metal::SetRuntimeArgs(
+                    program,
+                    shared.reader_kernel_id,
+                    core,
+                    {input.buffer()->address(),
+                     input_row,
+                     rect_rows,
+                     slice.num_chunks,
+                     slice.tail_elements * input.element_size(),
+                     input_row_bytes,
+                     slice.start_element * input.element_size()});
+            }
+
+            // Tree schedule for slice i: it wins levels [0, t) where t is the
+            // index of i's lowest set bit (root i=0 wins every level), merging
+            // partner i + 2^level whenever that slice exists (byes otherwise),
+            // then ships its survivor to i with the lowest set bit cleared.
+            const bool is_root = (i == 0);
+            uint32_t winning_levels = num_levels;
+            if (!is_root) {
+                winning_levels = 0;
+                while (((i >> winning_levels) & 1u) == 0) {
+                    ++winning_levels;
+                }
+            }
+            uint32_t num_merges = 0;
+            // 7 (x, y) pairs — must match the writer kernels' partner_x/y[7] and
+            // the positional offsets of the args that follow (do_ship at 16).
+            std::vector<uint32_t> partner_coords(14, 0);
+            for (uint32_t level = 0; level < winning_levels; ++level) {
+                const uint32_t partner = i + (1u << level);
+                if (partner < num_slices) {
+                    const CoreCoord partner_physical = device->worker_core_from_logical_core(rect[partner]);
+                    partner_coords[2 * num_merges] = static_cast<uint32_t>(partner_physical.x);
+                    partner_coords[2 * num_merges + 1] = static_cast<uint32_t>(partner_physical.y);
+                    ++num_merges;
+                }
+            }
+
             tt::tt_metal::SetRuntimeArgs(
                 program,
-                shared.reader_kernel_id,
+                is_root ? shared.compute_root_kernel_id : shared.compute_node_kernel_id,
                 core,
-                {input.buffer()->address(),
-                 0 /* start_row */,
-                 num_rows,
-                 slice.num_chunks,
-                 tt::div_up(slice.tail_elements, tt::constants::FACE_WIDTH),
-                 w_tiles,
-                 rows_2d,
-                 0 /* start_in_slice */,
-                 0 /* start_slice */,
-                 slice.start_element});
-        } else {
-            tt::tt_metal::SetRuntimeArgs(
-                program,
-                shared.reader_kernel_id,
-                core,
-                {input.buffer()->address(),
-                 0 /* start_row */,
-                 num_rows,
-                 slice.num_chunks,
-                 slice.tail_elements * input.element_size(),
-                 input_row_bytes,
-                 slice.start_element * input.element_size()});
-        }
+                {rect_rows, slice.num_chunks, slice.tail_elements, slice.start_chunk, num_merges});
 
-        // Tree schedule for slice i: it wins levels [0, t) where t is the
-        // index of i's lowest set bit (root i=0 wins every level), merging
-        // partner i + 2^level whenever that slice exists (byes otherwise),
-        // then ships its survivor to i with the lowest set bit cleared.
-        const bool is_root = (i == 0);
-        uint32_t winning_levels = num_levels;
-        if (!is_root) {
-            winning_levels = 0;
-            while (((i >> winning_levels) & 1u) == 0) {
-                ++winning_levels;
+            uint32_t winner_x = 0;
+            uint32_t winner_y = 0;
+            if (!is_root) {
+                const uint32_t winner = i & (i - 1);  // clear the lowest set bit
+                const CoreCoord winner_physical = device->worker_core_from_logical_core(rect[winner]);
+                winner_x = static_cast<uint32_t>(winner_physical.x);
+                winner_y = static_cast<uint32_t>(winner_physical.y);
             }
-        }
-        uint32_t num_merges = 0;
-        // 7 (x, y) pairs — must match the writer kernels' partner_x/y[7] and
-        // the positional offsets of the args that follow (do_ship at 16).
-        std::vector<uint32_t> partner_coords(14, 0);
-        for (uint32_t level = 0; level < winning_levels; ++level) {
-            const uint32_t partner = i + (1u << level);
-            if (partner < num_slices) {
-                const CoreCoord partner_physical = device->worker_core_from_logical_core(shared.cores[partner]);
-                partner_coords[2 * num_merges] = static_cast<uint32_t>(partner_physical.x);
-                partner_coords[2 * num_merges + 1] = static_cast<uint32_t>(partner_physical.y);
-                ++num_merges;
+            // A shipping core with an empty slice AND no adopted partners has no
+            // survivor in DST; its writer sends the prefilled -inf sequence.
+            const uint32_t is_empty_ship = (!is_root && slice.num_chunks == 0 && num_merges == 0) ? 1u : 0u;
+
+            std::vector<uint32_t> writer_args;
+            writer_args.reserve(23);
+            writer_args.push_back(rect_rows);
+            writer_args.push_back(num_merges);
+            for (uint32_t v : partner_coords) {
+                writer_args.push_back(v);
             }
+            writer_args.push_back(is_root ? 0u : 1u);  // do_ship
+            writer_args.push_back(winner_x);
+            writer_args.push_back(winner_y);
+            writer_args.push_back(is_empty_ship);
+            writer_args.push_back(indices.buffer()->address());
+            if (return_values) {
+                writer_args.push_back(outputs[1].buffer()->address());
+            } else if (flex_writer) {
+                writer_args.push_back(0);  // flex writer arg-layout parity: unused values address
+            } else {
+                // writer_tree.cpp reads start_row at arg 21 directly after the
+                // indices address; keep the flex/with-values layouts (22) intact.
+            }
+            writer_args.push_back(start_row);
+            tt::tt_metal::SetRuntimeArgs(program, shared.writer_kernel_id, core, writer_args);
         }
-
-        tt::tt_metal::SetRuntimeArgs(
-            program,
-            is_root ? shared.compute_root_kernel_id : shared.compute_node_kernel_id,
-            core,
-            {num_rows, slice.num_chunks, slice.tail_elements, slice.start_chunk, num_merges});
-
-        uint32_t winner_x = 0;
-        uint32_t winner_y = 0;
-        if (!is_root) {
-            const uint32_t winner = i & (i - 1);  // clear the lowest set bit
-            const CoreCoord winner_physical = device->worker_core_from_logical_core(shared.cores[winner]);
-            winner_x = static_cast<uint32_t>(winner_physical.x);
-            winner_y = static_cast<uint32_t>(winner_physical.y);
-        }
-        // A shipping core with an empty slice AND no adopted partners has no
-        // survivor in DST; its writer sends the prefilled -inf sequence.
-        const uint32_t is_empty_ship = (!is_root && slice.num_chunks == 0 && num_merges == 0) ? 1u : 0u;
-
-        std::vector<uint32_t> writer_args;
-        writer_args.reserve(20);
-        writer_args.push_back(num_rows);
-        writer_args.push_back(num_merges);
-        for (uint32_t v : partner_coords) {
-            writer_args.push_back(v);
-        }
-        writer_args.push_back(is_root ? 0u : 1u);  // do_ship
-        writer_args.push_back(winner_x);
-        writer_args.push_back(winner_y);
-        writer_args.push_back(is_empty_ship);
-        writer_args.push_back(indices.buffer()->address());
-        if (return_values) {
-            writer_args.push_back(outputs[1].buffer()->address());
-        } else if (flex_writer) {
-            writer_args.push_back(0);  // flex writer arg-layout parity: unused values address
-        }
-        tt::tt_metal::SetRuntimeArgs(program, shared.writer_kernel_id, core, writer_args);
     }
+    TT_FATAL(
+        rect_start_row == effective_rows,
+        "topk_large_indices multi-rect assigned {} rows, expected {}",
+        rect_start_row,
+        effective_rows);
 }
 
 }  // namespace
@@ -804,36 +932,58 @@ TopkLargeIndicesMultiCoreProgramFactory::cached_program_t TopkLargeIndicesMultiC
 
     const auto& shape = input.logical_shape();
     const uint32_t n = shape[shape.rank() - 1];
-    const uint32_t num_rows = flattened_rows_excluding_last_dim(shape);
+    const uint32_t num_rows = operation_attributes.row_count.value_or(flattened_rows_excluding_last_dim(shape));
     const auto grid = input.device()->compute_with_storage_grid_size();
-    const auto config = compute_column_split_config(k, n, num_rows, grid, operation_attributes.num_slices);
+    const auto config = compute_column_split_config(
+        k, n, num_rows, grid, operation_attributes.num_slices, /*allow_multi_row=*/!tile_output);
     TT_FATAL(config.enabled, "topk_large_indices multi-core factory selected for a shape it does not support");
     const uint32_t num_slices = config.num_slices;
 
-    // The merge tree lives IN PLACE on the slice rectangle: slice i is
-    // rectangle core (i % sx, i / sx) in row-major order; slice 0 (core
-    // (0,0)) is the root and produces the output. Winners keep their
-    // survivor in DST across levels — only the shipped operand crosses the
-    // NoC, once, per losing core.
-    const CoreRange rect({0, 0}, {config.local_grid_x - 1, config.local_grid_y - 1});
-    const CoreRangeSet all_cores(rect);
-    const auto cores = corerange_to_cores(all_cores, std::nullopt, true);
+    // The merge tree lives IN PLACE on each slice rectangle: slice i is
+    // rectangle-local core (i % sx, i / sx) in row-major order; slice 0 (the
+    // rectangle origin) is that tree's root and produces its rows' output.
+    // Winners keep their survivor in DST across levels — only the shipped
+    // operand crosses the NoC, once, per losing core. Multi-rectangle
+    // (num_rects > 1): disjoint rectangles tile the grid and run their trees
+    // concurrently on contiguous row ranges.
+    const uint32_t num_rects = config.num_rects;
+    TT_FATAL(num_rects >= 1, "topk_large_indices multi-core factory needs at least one rectangle");
+    // The TILE-output scatter writes whole 32-row tiles; rectangle row ranges
+    // are not tile-aligned, so the multi-rect form is ROW_MAJOR-output only.
     TT_FATAL(
-        cores.size() == num_slices,
-        "topk_large_indices column split expected {} tree cores, got {}",
-        num_slices,
-        cores.size());
-    const CoreCoord root_core = cores.front();
-    const CoreRangeSet root_core_set(CoreRange(root_core, root_core));
-    // All rectangle cores except the root run the node compute kernel.
+        num_rects == 1 || !tile_output,
+        "topk_large_indices: tile_output is not supported with the multi-rectangle path ({} rectangles); "
+        "drop tile_output or num_slices",
+        num_rects);
+    const uint32_t rects_x = static_cast<uint32_t>(grid.x) / config.local_grid_x;
+    std::vector<CoreRange> all_ranges;
+    std::vector<CoreRange> root_ranges;
     std::vector<CoreRange> node_ranges;
-    if (config.local_grid_x > 1) {
-        node_ranges.emplace_back(CoreCoord(1, 0), CoreCoord(config.local_grid_x - 1, 0));
-    }
-    if (config.local_grid_y > 1) {
-        node_ranges.emplace_back(CoreCoord(0, 1), CoreCoord(config.local_grid_x - 1, config.local_grid_y - 1));
+    std::vector<std::vector<CoreCoord>> rect_cores(num_rects);
+    for (uint32_t r = 0; r < num_rects; ++r) {
+        const uint32_t ox = (r % rects_x) * config.local_grid_x;
+        const uint32_t oy = (r / rects_x) * config.local_grid_y;
+        const CoreRange rect(CoreCoord(ox, oy), CoreCoord(ox + config.local_grid_x - 1, oy + config.local_grid_y - 1));
+        all_ranges.push_back(rect);
+        rect_cores[r] = corerange_to_cores(CoreRangeSet(rect), std::nullopt, true);
+        TT_FATAL(
+            rect_cores[r].size() == num_slices,
+            "topk_large_indices column split expected {} tree cores per rectangle, got {}",
+            num_slices,
+            rect_cores[r].size());
+        root_ranges.emplace_back(rect_cores[r].front(), rect_cores[r].front());
+        // All rectangle cores except the root run the node compute kernel.
+        if (config.local_grid_x > 1) {
+            node_ranges.emplace_back(CoreCoord(ox + 1, oy), CoreCoord(ox + config.local_grid_x - 1, oy));
+        }
+        if (config.local_grid_y > 1) {
+            node_ranges.emplace_back(
+                CoreCoord(ox, oy + 1), CoreCoord(ox + config.local_grid_x - 1, oy + config.local_grid_y - 1));
+        }
     }
     TT_FATAL(!node_ranges.empty(), "topk_large_indices merge tree needs at least 2 slices");
+    const CoreRangeSet all_cores(all_ranges);
+    const CoreRangeSet root_core_set(root_ranges);
     const CoreRangeSet node_cores_set(node_ranges);
 
     constexpr uint32_t cb_in = tt::CBIndex::c_0;
@@ -973,6 +1123,10 @@ TopkLargeIndicesMultiCoreProgramFactory::cached_program_t TopkLargeIndicesMultiC
     if (return_values) {
         compute_root_compile_args.push_back(cb_values_out);
     }
+    std::map<std::string, std::string> root_defines;
+    if (!operation_attributes.neginf_sentinel) {
+        root_defines["TOPK_SKIP_NEGINF_SENTINEL"] = "1";
+    }
     auto compute_root_kernel = tt::tt_metal::CreateKernel(
         program,
         return_values ? "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/"
@@ -980,7 +1134,10 @@ TopkLargeIndicesMultiCoreProgramFactory::cached_program_t TopkLargeIndicesMultiC
                       : "ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/kernels/compute_tree_root.cpp",
         root_core_set,
         tt::tt_metal::ComputeConfig{
-            .fp32_dest_acc_en = true, .dst_full_sync_en = true, .compile_args = compute_root_compile_args});
+            .fp32_dest_acc_en = true,
+            .dst_full_sync_en = true,
+            .compile_args = compute_root_compile_args,
+            .defines = root_defines});
 
     tt::tt_metal::KernelHandle writer_kernel;
     if (flex_writer) {
@@ -1066,7 +1223,7 @@ TopkLargeIndicesMultiCoreProgramFactory::cached_program_t TopkLargeIndicesMultiC
         .compute_node_kernel_id = compute_node_kernel,
         .compute_root_kernel_id = compute_root_kernel,
         .writer_kernel_id = writer_kernel,
-        .cores = cores};
+        .rect_cores = std::move(rect_cores)};
     set_runtime_args_multi_core(program, shared, input, tensor_return_value, operation_attributes);
 
     return cached_program_t{std::move(program), std::move(shared)};

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.hpp
@@ -34,4 +34,58 @@ struct TopkLargeIndicesProgramFactory {
         tensor_return_value_t& tensor_return_value);
 };
 
+// Column-parallel (intra-row multi-core) configuration. Derived purely from
+// (k, physical last dim, num_rows, worker grid) so that:
+//   - select_program_factory / compute_program_hash / create all agree, and
+//   - valid_length stays runtime-only: it shrinks per-core active chunk
+//     counts (down to empty slices) without changing the program structure,
+//     so a serving loop growing valid_length reuses one cached program.
+struct ColumnSplitConfig {
+    bool enabled = false;
+    // Number of row slices == number of tree cores (each reduces >= 1 chunk).
+    uint32_t num_slices = 0;
+    // The tree cores form the rectangle (0, 0)..(local_grid_x-1, local_grid_y-1)
+    // with num_slices == local_grid_x * local_grid_y. Slice i lives at
+    // (i % local_grid_x, i / local_grid_x); slice 0 is the merge-tree root
+    // (there is no separate final core — the reduction is in place: at tree
+    // level L, core i with i % 2^(L+1) == 0 merges core i + 2^L's survivor).
+    uint32_t local_grid_x = 0;
+    uint32_t local_grid_y = 0;
+};
+
+// num_slices_override: user-requested P (operation_attributes_t::num_slices). Validated loudly
+// against [2, 64] and the row's chunk count, clamped only against the physical grid; setting it
+// when the column-parallel path is not selected is an error.
+ColumnSplitConfig compute_column_split_config(
+    uint32_t k,
+    uint32_t n,
+    uint32_t num_rows,
+    const CoreCoord& grid,
+    std::optional<uint32_t> num_slices_override = std::nullopt);
+
+struct TopkLargeIndicesMultiCoreSharedVariables {
+    tt::tt_metal::KernelHandle reader_kernel_id{};
+    tt::tt_metal::KernelHandle compute_node_kernel_id{};
+    tt::tt_metal::KernelHandle compute_root_kernel_id{};
+    tt::tt_metal::KernelHandle writer_kernel_id{};
+    // Slice-major (row-major rectangle) core list; cores[0] is the tree root.
+    std::vector<CoreCoord> cores{};
+};
+
+struct TopkLargeIndicesMultiCoreProgramFactory {
+    using shared_variables_t = TopkLargeIndicesMultiCoreSharedVariables;
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
 }  // namespace ttnn::operations::experimental::topk_large_indices::program

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.hpp
@@ -54,7 +54,7 @@ struct ColumnSplitConfig {
 };
 
 // num_slices_override: user-requested P (operation_attributes_t::num_slices). Validated loudly
-// against [2, 64] and the row's chunk count, clamped only against the physical grid; setting it
+// against [2, 128] and the row's chunk count, clamped only against the physical grid; setting it
 // when the column-parallel path is not selected is an error.
 ColumnSplitConfig compute_column_split_config(
     uint32_t k,

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/device/topk_large_indices_program_factory.hpp
@@ -42,34 +42,59 @@ struct TopkLargeIndicesProgramFactory {
 //     so a serving loop growing valid_length reuses one cached program.
 struct ColumnSplitConfig {
     bool enabled = false;
-    // Number of row slices == number of tree cores (each reduces >= 1 chunk).
+    // Number of row slices == number of tree cores PER RECTANGLE (each reduces >= 1 chunk).
     uint32_t num_slices = 0;
-    // The tree cores form the rectangle (0, 0)..(local_grid_x-1, local_grid_y-1)
-    // with num_slices == local_grid_x * local_grid_y. Slice i lives at
-    // (i % local_grid_x, i / local_grid_x); slice 0 is the merge-tree root
-    // (there is no separate final core — the reduction is in place: at tree
+    // Each tree is a local_grid_x x local_grid_y rectangle with
+    // num_slices == local_grid_x * local_grid_y. Within a rectangle, slice i
+    // lives at rectangle-local (i % local_grid_x, i / local_grid_x); slice 0
+    // is that rectangle's merge-tree root (the reduction is in place: at tree
     // level L, core i with i % 2^(L+1) == 0 merges core i + 2^L's survivor).
     uint32_t local_grid_x = 0;
     uint32_t local_grid_y = 0;
+    // Multi-rectangle (rows > 1 with an explicit num_slices): the grid is
+    // tiled with num_rects disjoint rectangles running concurrently, rows
+    // split contiguously across them (runtime args — one cached program
+    // serves any row count with the same rectangle layout). 1 on the
+    // single-row model-selected path; 0 when disabled.
+    uint32_t num_rects = 0;
 };
 
 // num_slices_override: user-requested P (operation_attributes_t::num_slices). Validated loudly
 // against [2, 128] and the row's chunk count, clamped only against the physical grid; setting it
 // when the column-parallel path is not selected is an error.
+// FUSED_E2E compute-kernel gate: true when every possible chunk count of the
+// row fits the 5-bit chunk-id stamp (<= 32 chunks of the LLK window over the
+// full logical last dim). Shared by the row-parallel factory (kernel define)
+// and compute_program_hash (the derived bit) so they can never skew.
+bool fused_e2e_gate(uint32_t k, uint32_t input_last_dim);
+
+// Row-parallel compute-body selection, single-sourced into the kernel defines
+// AND compute_program_hash so they can never skew:
+//   FusedSegmented -- k >= 1024: ONE codepath at every width (a <= 32-chunk
+//     row runs the single-segment path, which is the FUSED_E2E sequence), so
+//     the width term leaves program selection entirely for this class.
+//   FusedE2E -- smaller k with <= 32 chunks (fused end-to-end).
+//   Classic -- smaller k, wider rows (keeps the chunk-skip, which pays there).
+enum class ComputeBodyMode : uint32_t { Classic = 0, FusedE2E = 1, FusedSegmented = 2 };
+ComputeBodyMode compute_body_mode(uint32_t k, uint32_t input_last_dim);
+
 ColumnSplitConfig compute_column_split_config(
     uint32_t k,
     uint32_t n,
     uint32_t num_rows,
     const CoreCoord& grid,
-    std::optional<uint32_t> num_slices_override = std::nullopt);
+    std::optional<uint32_t> num_slices_override = std::nullopt,
+    bool allow_multi_row = true);
 
 struct TopkLargeIndicesMultiCoreSharedVariables {
     tt::tt_metal::KernelHandle reader_kernel_id{};
     tt::tt_metal::KernelHandle compute_node_kernel_id{};
     tt::tt_metal::KernelHandle compute_root_kernel_id{};
     tt::tt_metal::KernelHandle writer_kernel_id{};
-    // Slice-major (row-major rectangle) core list; cores[0] is the tree root.
-    std::vector<CoreCoord> cores{};
+    // Per-rectangle slice-major (row-major within the rectangle) core lists;
+    // rect_cores[r][0] is rectangle r's tree root. Single-rect programs have
+    // exactly one entry.
+    std::vector<std::vector<CoreCoord>> rect_cores{};
 };
 
 struct TopkLargeIndicesMultiCoreProgramFactory {

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/topk_large_indices_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/topk_large_indices_nanobind.cpp
@@ -4,27 +4,61 @@
 
 #include "topk_large_indices_nanobind.hpp"
 
+#include <optional>
+#include <tuple>
+#include <variant>
+
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/variant.h>
 
 #include "ttnn-nanobind/bind_function.hpp"
 #include "topk_large_indices.hpp"
 
 namespace ttnn::operations::experimental::topk_large_indices::detail {
 
+namespace {
+
+// Dispatches on return_values so the default call keeps returning a single
+// indices tensor (backward compatible) while opting in returns a
+// (values, indices) tuple, torch-style.
+std::variant<ttnn::Tensor, std::tuple<ttnn::Tensor, ttnn::Tensor>> topk_large_indices_py(
+    const ttnn::Tensor& input_tensor,
+    uint32_t k,
+    std::optional<uint32_t> valid_length,
+    bool return_values,
+    std::optional<uint32_t> num_slices,
+    bool tile_output,
+    std::optional<ttnn::DataType> index_dtype) {
+    if (return_values) {
+        return ttnn::experimental::topk_large_indices_with_values(
+            input_tensor, k, valid_length, num_slices, tile_output, index_dtype);
+    }
+    return ttnn::experimental::topk_large_indices(input_tensor, k, valid_length, num_slices, tile_output, index_dtype);
+}
+
+}  // namespace
+
 void bind_topk_large_indices(nb::module_& mod) {
     ttnn::bind_function<"topk_large_indices", "ttnn.experimental.">(
         mod,
         R"doc(
-        Experimental Top-K over the last dimension of a row-major BFLOAT16 tensor.
-        This op is Blackhole-only.
+        Experimental Top-K over the last dimension of a BFLOAT16 tensor (ROW_MAJOR or
+        TILE layout). This op is Blackhole-only.
 
-        Returns a ROW_MAJOR UINT32 tensor containing sorted descending top-k indices.
+        Returns a ROW_MAJOR UINT32 tensor containing sorted descending top-k indices,
+        or, with ``return_values=True``, a ``(values, indices)`` tuple where values is
+        a ROW_MAJOR BFLOAT16 tensor sorted descending to match the indices.
         The output shape matches the input shape except that the last dimension is k.
+        ``tile_output=True`` emits the output tensor(s) in TILE layout instead
+        (requires k to be a multiple of 32; the tile padding rows are zero-filled), and
+        ``index_dtype=ttnn.uint16`` narrows the indices output (requires the searched
+        width to be <= 65535; the -inf sentinel becomes 0xFFFF).
 
         This op is intended for large row-major rows. Internally it snaps k to the
         nearest supported LLK size and streams each input row in LLK-sized windows.
         Input values equal to -inf produce the sentinel index 0xFFFFFFFF when they
-        survive into the final top-k result.
+        survive into the final top-k result; with ``return_values=True`` those lanes
+        carry exact bf16 -inf values.
 
         K constraints:
             * k must be in [16, 2048];
@@ -44,19 +78,38 @@ void bind_topk_large_indices(nb::module_& mod) {
             * restricts the search to the first ``valid_length`` columns of each row;
             * the remaining columns are ignored -- neither read nor ranked -- so an
               over-allocated row whose tail is stale can be searched without slicing it;
-            * must be in [k, last dimension]; defaults to the full last dimension;
+            * must be in (0, last dimension]; defaults to the full last dimension. A
+              prefix shorter than k is allowed: the lanes past its capacity emit the
+              sentinel index 0xFFFFFFFF (and -inf values with return_values=True);
             * applied at runtime (no recompile), so a loop growing valid_length reuses one program.
 
         Args:
             input_tensor: device tensor with ROW_MAJOR layout and BFLOAT16 dtype.
             k: required number of indices to return.
             valid_length: optional number of leading columns to search (default: full width).
+            return_values: also return the top-k values; the result becomes a
+                (values, indices) tuple (default: False, indices tensor only).
+            num_slices: optional column-parallel slice-count (core count) override.
+                Only valid when the column-parallel (single-row) factory is selected;
+                must be in [2, 64] and at most the row's LLK-window chunk count
+                (loud error otherwise); clamped only against the physical core grid,
+                with a warning. Default: the built-in cost model's pick.
+            tile_output: emit the output tensor(s) in TILE layout (default: False,
+                ROW_MAJOR). Requires k to be a multiple of 32. Tile padding rows are
+                zero-filled.
+            index_dtype: dtype of the indices output, ttnn.uint32 or ttnn.uint16
+                (default: None = ttnn.uint32). UINT16 requires the searched width
+                (valid_length if set, else the last dimension) to be <= 65535.
         )doc",
-        &ttnn::experimental::topk_large_indices,
+        &topk_large_indices_py,
         nb::arg("input_tensor"),
         nb::kw_only(),
         nb::arg("k"),
-        nb::arg("valid_length") = std::nullopt);
+        nb::arg("valid_length") = std::nullopt,
+        nb::arg("return_values") = false,
+        nb::arg("num_slices") = std::nullopt,
+        nb::arg("tile_output") = false,
+        nb::arg("index_dtype") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::experimental::topk_large_indices::detail

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/topk_large_indices_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/topk_large_indices_nanobind.cpp
@@ -28,12 +28,14 @@ std::variant<ttnn::Tensor, std::tuple<ttnn::Tensor, ttnn::Tensor>> topk_large_in
     bool return_values,
     std::optional<uint32_t> num_slices,
     bool tile_output,
-    std::optional<ttnn::DataType> index_dtype) {
+    std::optional<ttnn::DataType> index_dtype,
+    bool neginf_sentinel) {
     if (return_values) {
         return ttnn::experimental::topk_large_indices_with_values(
-            input_tensor, k, valid_length, num_slices, tile_output, index_dtype);
+            input_tensor, k, valid_length, num_slices, tile_output, index_dtype, neginf_sentinel);
     }
-    return ttnn::experimental::topk_large_indices(input_tensor, k, valid_length, num_slices, tile_output, index_dtype);
+    return ttnn::experimental::topk_large_indices(
+        input_tensor, k, valid_length, num_slices, tile_output, index_dtype, neginf_sentinel);
 }
 
 }  // namespace
@@ -89,6 +91,14 @@ void bind_topk_large_indices(nb::module_& mod) {
             valid_length: optional number of leading columns to search (default: full width).
             return_values: also return the top-k values; the result becomes a
                 (values, indices) tuple (default: False, indices tensor only).
+            neginf_sentinel: emit the sentinel index (0xFFFFFFFF; 0xFFFF under UINT16)
+                on exact bf16 -inf value lanes (default True, the original contract).
+                False keeps each -inf lane's real source position for stock/torch
+                index parity (the fused stamp already carries it). Caveat: lanes
+                the op itself -inf-pads (width not a multiple of the chunk size,
+                or a short valid_length tail) carry their padded position, which
+                can exceed the logical width -- mirroring the stock op's own
+                looseness around its -inf padding.
             num_slices: optional column-parallel slice-count (core count) override.
                 Only valid when the column-parallel (single-row) factory is selected;
                 must be in [2, 128] and at most the row's LLK-window chunk count
@@ -109,7 +119,8 @@ void bind_topk_large_indices(nb::module_& mod) {
         nb::arg("return_values") = false,
         nb::arg("num_slices") = std::nullopt,
         nb::arg("tile_output") = false,
-        nb::arg("index_dtype") = std::nullopt);
+        nb::arg("index_dtype") = std::nullopt,
+        nb::arg("neginf_sentinel") = true);
 }
 
 }  // namespace ttnn::operations::experimental::topk_large_indices::detail

--- a/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/topk_large_indices_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/topk_large_indices/topk_large_indices_nanobind.cpp
@@ -84,14 +84,14 @@ void bind_topk_large_indices(nb::module_& mod) {
             * applied at runtime (no recompile), so a loop growing valid_length reuses one program.
 
         Args:
-            input_tensor: device tensor with ROW_MAJOR layout and BFLOAT16 dtype.
+            input_tensor: device tensor with ROW_MAJOR or TILE layout and BFLOAT16 dtype.
             k: required number of indices to return.
             valid_length: optional number of leading columns to search (default: full width).
             return_values: also return the top-k values; the result becomes a
                 (values, indices) tuple (default: False, indices tensor only).
             num_slices: optional column-parallel slice-count (core count) override.
                 Only valid when the column-parallel (single-row) factory is selected;
-                must be in [2, 64] and at most the row's LLK-window chunk count
+                must be in [2, 128] and at most the row's LLK-window chunk count
                 (loud error otherwise); clamped only against the physical core grid,
                 with a warning. Default: the built-in cost model's pick.
             tile_output: emit the output tensor(s) in TILE layout (default: False,


### PR DESCRIPTION
### What

**Stacked on #53457** (base branch = its head, so this diff shows only the delta: 11 files, +590/−199). Together with #53457 this takes the production 160-row k=2048 W=65536 call from 712.3 µs (as-shipped) to **388 µs**, with zero call-site changes.

- **Multi-rectangle trees**: the column-parallel factory generalizes from one rectangle to a grid tiling — one P-core in-place merge tree per rectangle, disjoint and concurrent; rows split contiguously as runtime args over capacity-tiled rectangles (empty rectangles run zero rows), so one cached program serves any row count with a given layout. Explicit `num_slices` becomes legal on multi-row shapes (measured: 30 rows @P=4 = **98.8 µs** vs 356.5 row-parallel, 3.6×). The device op never auto-selects the multi-row form: non-stable tie order differs across engines and the TILE/u16 opt-ins are row-parallel-only, so auto-routing would break the opt-ins-change-layout-never-results contract the suite guards.
- **Hybrid row split** (op-internal): canonical calls with rows > worker grid run full row-parallel waves plus a multi-rectangle remainder window over the *same un-sliced input* (new internal `row_start`/`row_count`: readers offset into global rows, writers stay output-relative) and concat the row outputs. 160×65536 k=2048: 712.3 → **467.0 µs**. The remainder-window model requires a ≥12.5% modeled win, so marginal splits never net negative.
- **Fused-u16 end-to-end** (rows of ≤ 32 LLK-window chunks; `FUSED_E2E` factory gate mirrored into the program hash via a single-sourced helper): the runtime chunk-id stamp keeps every merge/rebuild in the fused [bf16|u16] word; one global split per row recovers `chunk_id*K + within-chunk`. Per-row kernel 359.7 → **280.6 µs** (1.28×); the 160-row call lands at **388 µs**. Width > 65536 provably cannot run fused (a u16 must address every global position) and keeps the unfused body, which stays CI-covered via the boundary-width tests.

### Testing

Op suite **181 green on this branch's own build**, including: both fused-gate sides (31-chunk+tail / 32-chunk-exact / >32-chunk fallback widths), poisoned-tail `valid_length` under the fused program, values arm, and program-cache-hit reruns with row redistribution (60→30 rows share one program).

Tie-identity note for reviewers: `valid_length` vs physically-sliced comparisons now span the fused gate (different physical widths choose different engines), so tie order may differ *on exact bf16 ties only*. Audited on silicon: 2,882 index diffs, **0 non-ties**, value multisets bit-exact — and the suite now asserts exactly that contract (per-diff tie proof + bitwise sorted-value equality, not a tolerance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/topk-large-indices-hybrid)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/topk-large-indices-hybrid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/topk-large-indices-hybrid)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/topk-large-indices-hybrid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/topk-large-indices-hybrid)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/topk-large-indices-hybrid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/topk-large-indices-hybrid)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/topk-large-indices-hybrid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/topk-large-indices-hybrid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/topk-large-indices-hybrid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/topk-large-indices-hybrid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/topk-large-indices-hybrid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/topk-large-indices-hybrid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/topk-large-indices-hybrid)

---

## Perf over array length (requested by @pavlejosipovic)

160 rows, k=2048 (k=1536 identical — same 2048 LLK window), p150a, Tracy device-kernel time:

| W (positions) | main µs | this stack µs | speedup | µs per 64k |
|---|---|---|---|---|
| 5,120 | 69 | 66 | 1.06× | — |
| 25,600 | 295 | 181 | 1.63× | 464 |
| 65,536 | 726 | 388 | 1.87× | 388 |
| 131,072 | 1,447 | 752 | 1.92× | 376 |
| 262,144 | 2,890 | 1,480 | 1.95× | 370 |
| 524,288 | 5,775 | 2,932 | 1.97× | 367 |
| 1,048,576 | 11,545 | 5,837 | 1.98× | 365 |

Linear in width: the µs-per-64k column is flat (the small taper is fixed per-row overhead amortizing out); no cliffs at the old 65536 fused boundary. GLM 5.2 DSA-indexer shape (1M preallocated, 512k valid, k=2048): **5.77 → 2.93 ms (1.97×)**.

## How fused-u16 works past 65k positions (segmented fusion)

A fused [bf16|u16] word can only address 2^16 positions, so u16 fusion above 65k is impossible per se. Instead, rows run as ≤32-chunk **segments** (32 × 2048 = exactly the u16 limit): within a segment the chunk id is stamped at runtime into index bits [15:11] (segment-LOCAL, 5 bits always suffice) and every merge/rebuild stays fused; one split per segment decodes to u32 and ORs in the 65536-aligned segment base (OR == ADD, disjoint bits); segments fold into the running survivor with one unfused u32 merge each — 1 unfused merge per 31 fused, preserving ~98% of the fused rate at any width. For k ≥ 1024 this is the single codepath at every width (a ≤32-chunk row is the single-segment case), so program selection carries no width term and a growing valid_length never recompiles.
