### PR TITLE
Fix folded all-gather fabric sender alias

### DIFF
--- a/models/demos/deepseek_v3_b1/micro_ops/ccl_all_gather/op.py
+++ b/models/demos/deepseek_v3_b1/micro_ops/ccl_all_gather/op.py
@@ -268,6 +268,7 @@ class AllGatherConfig:
         # Per-device schedule
         mesh_rows, mesh_cols = mesh_shape
         self._per_device = {}
+        self._transport_rt_args_pair = {}
         for row in range(mesh_rows):
             for col in range(mesh_cols):
                 coord = ttnn.MeshCoordinate(row, col)
@@ -565,13 +566,7 @@ class AllGatherConfig:
     # Per-core runtime args (single fabric connection per direction)
     # ======================================================================
 
-    def _build_transport_per_core_rt_args(self, coord, program, core, dst_fabric_node_id):
-        """Build per-core RT args for one transport RISC direction.
-
-        Layout: [dst_mesh_id, dst_chip_id, <single-link fabric args>]
-        The kernel reads dst_mesh_id / dst_chip_id once, then builds the
-        single transport connection from the remaining args.
-        """
+    def _build_transport_per_core_rt_args_base(self, coord, program, core, dst_fabric_node_id):
         info = self._per_device[coord]
         out = [
             int(dst_fabric_node_id.mesh_id),
@@ -588,15 +583,45 @@ class AllGatherConfig:
         )
         return out
 
-    def get_transport_brisc_per_core_rt_args(self, coord, program, core):
+    def _build_transport_rt_args_pair(self, coord, program, core):
+        """Build paired BRISC/NCRISC transport RT args.
+
+        Layout per RISC:
+          [dst_mesh_id, dst_chip_id, <single-link fabric args>,
+           folded, folded_peer_dst_mesh_id, folded_peer_dst_chip_id]
+
+        On mesh-edge folds, both logical directions can resolve to the same
+        Ethernet EDM sender channel. The kernel uses the folded flag to serialize
+        both directions through BRISC's one connection instead of opening two
+        independent senders that alias the same EDM slot.
+        """
         info = self._per_device[coord]
-        dst = info["fabric_node_by_direction"][self._brisc_fabric_direction]
-        return self._build_transport_per_core_rt_args(coord, program, core, dst)
+        brisc_dst = info["fabric_node_by_direction"][self._brisc_fabric_direction]
+        ncrisc_dst = info["fabric_node_by_direction"][self._ncrisc_fabric_direction]
+
+        brisc_args = self._build_transport_per_core_rt_args_base(coord, program, core, brisc_dst)
+        ncrisc_args = self._build_transport_per_core_rt_args_base(coord, program, core, ncrisc_dst)
+        brisc_eth_channel = brisc_args[2]
+        ncrisc_eth_channel = ncrisc_args[2]
+        folded = int(brisc_eth_channel == ncrisc_eth_channel)
+
+        brisc_args.extend([folded, int(ncrisc_dst.mesh_id), int(ncrisc_dst.chip_id)])
+        ncrisc_args.extend([folded, int(ncrisc_dst.mesh_id), int(ncrisc_dst.chip_id)])
+        return brisc_args, ncrisc_args
+
+    def _get_transport_rt_args_pair(self, coord, program, core):
+        key = (int(coord[0]), int(coord[1]))
+        if key not in self._transport_rt_args_pair:
+            self._transport_rt_args_pair[key] = self._build_transport_rt_args_pair(coord, program, core)
+        return self._transport_rt_args_pair[key]
+
+    def get_transport_brisc_per_core_rt_args(self, coord, program, core):
+        brisc_args, _ = self._get_transport_rt_args_pair(coord, program, core)
+        return brisc_args
 
     def get_transport_ncrisc_per_core_rt_args(self, coord, program, core):
-        info = self._per_device[coord]
-        dst = info["fabric_node_by_direction"][self._ncrisc_fabric_direction]
-        return self._build_transport_per_core_rt_args(coord, program, core, dst)
+        _, ncrisc_args = self._get_transport_rt_args_pair(coord, program, core)
+        return ncrisc_args
 
 
 # ---------------------------------------------------------------------------

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/kernels/all_reduce_skip_local_push_smoke_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/kernels/all_reduce_skip_local_push_smoke_kernel.cpp
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "../../../unified_kernels/kernel_op_api.hpp"
+#include "../../../unified_kernels/kernel_utils.hpp"
+#include "../../../unified_kernels/all_reduce.hpp"
+
+void kernel_main() {
+    constexpr bool is_sender = get_named_compile_time_arg_val("is_allreduce_sender_core") == 1;
+    constexpr bool is_receiver = get_named_compile_time_arg_val("is_allreduce_receiver_core") == 1;
+
+#if defined(COMPILE_FOR_TRISC)
+    if constexpr (is_sender) {
+        constexpr uint32_t local_data_cb = get_named_compile_time_arg_val("allreduce_local_data_cb_id");
+        constexpr uint32_t input_num_tiles = get_named_compile_time_arg_val("allreduce_input_num_tiles");
+        cb_reserve_back(local_data_cb, input_num_tiles);
+        cb_push_back(local_data_cb, input_num_tiles);
+    }
+#endif
+
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
+    if constexpr (is_sender) {
+        using WriterCT = deepseek_b1_ops::AllReduce::WriterCTArgs<
+            get_named_compile_time_arg_val("allreduce_local_data_cb_id"),
+            get_named_compile_time_arg_val("allreduce_input_num_tiles"),
+            get_named_compile_time_arg_val("allreduce_page_size_bytes"),
+            get_named_compile_time_arg_val("allreduce_tiles_per_chunk"),
+            get_named_compile_time_arg_val("allreduce_last_chunk_tiles"),
+            get_named_compile_time_arg_val("allreduce_num_chunks"),
+            get_named_compile_time_arg_val("allreduce_num_links"),
+            get_named_compile_time_arg_val("allreduce_writer_link_index"),
+            get_named_compile_time_arg_val("allreduce_writer_signal_local_ready"),
+            get_named_compile_time_arg_val("allreduce_skip_local_push")>;
+
+        deepseek_b1_ops::AllReduce::SenderArgs args{};
+        args.intermediate_buffer_address = get_common_arg_val<uint32_t>(0);
+        args.dest_noc_x = get_common_arg_val<uint32_t>(1);
+        args.dest_noc_y = get_common_arg_val<uint32_t>(2);
+        args.per_core_rta_start_idx = 0;
+
+        deepseek_b1_ops::AllReduce::WriterSingleLink<WriterCT> writer;
+        writer.open_connections(args);
+        writer(args);
+    }
+#endif
+
+#if defined(COMPILE_FOR_NCRISC)
+    if constexpr (is_receiver) {
+        using ReaderCT = deepseek_b1_ops::AllReduce::ReaderCTArgs<
+            get_named_compile_time_arg_val("allreduce_recv_local_data_cb_id"),
+            get_named_compile_time_arg_val("allreduce_remote_data_cb_id"),
+            get_named_compile_time_arg_val("allreduce_residual_cb_id"),
+            get_named_compile_time_arg_val("allreduce_has_residual"),
+            get_named_compile_time_arg_val("allreduce_total_num_tiles"),
+            get_named_compile_time_arg_val("allreduce_page_size_bytes"),
+            get_named_compile_time_arg_val("allreduce_tiles_per_chunk"),
+            get_named_compile_time_arg_val("allreduce_last_chunk_tiles"),
+            get_named_compile_time_arg_val("allreduce_num_chunks"),
+            get_named_compile_time_arg_val("allreduce_num_links")>;
+
+        deepseek_b1_ops::AllReduce::ReceiverArgs args{};
+        args.sem_bank_addr_0 = get_common_arg_val<uint32_t>(0);
+        args.sem_bank_addr_1 = get_common_arg_val<uint32_t>(1);
+        args.sender_noc_x = get_common_arg_val<uint32_t>(2);
+        args.sender_noc_y = get_common_arg_val<uint32_t>(3);
+        args.sender_local_data_l1_addr = get_common_arg_val<uint32_t>(4);
+        args.local_ready_sem_bank_addr = get_common_arg_val<uint32_t>(5);
+
+        deepseek_b1_ops::AllReduce::Reader<ReaderCT> reader;
+        reader(args);
+    }
+#endif
+
+#if defined(COMPILE_FOR_TRISC)
+    if constexpr (is_receiver) {
+        using ComputeCT = deepseek_b1_ops::AllReduce::ComputeCTArgs<
+            get_named_compile_time_arg_val("allreduce_cb_remote"),
+            get_named_compile_time_arg_val("allreduce_cb_local"),
+            get_named_compile_time_arg_val("allreduce_cb_out"),
+            get_named_compile_time_arg_val("allreduce_cb_residual"),
+            get_named_compile_time_arg_val("allreduce_has_residual"),
+            get_named_compile_time_arg_val("allreduce_num_tiles")>;
+
+        deepseek_compute_kernel_init();
+
+        deepseek_b1_ops::AllReduce::ComputeArgs args{};
+        deepseek_b1_ops::AllReduce::Compute<ComputeCT> compute;
+        compute(args);
+    }
+#endif
+}

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/kernels/gather_reduce_all_reduce_smoke_kernel.cpp
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/kernels/gather_reduce_all_reduce_smoke_kernel.cpp
@@ -1,0 +1,283 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "../../../unified_kernels/kernel_op_api.hpp"
+#include "../../../unified_kernels/kernel_utils.hpp"
+#include "../../../unified_kernels/all_reduce.hpp"
+#include "../../../unified_kernels/all_gather.hpp"
+#include "../../../unified_kernels/gather_reduce.hpp"
+
+#if defined(COMPILE_FOR_NCRISC)
+FORCE_INLINE void run_gather_reduce_sender() {
+    constexpr uint32_t src_cb = get_named_compile_time_arg_val("gather_reduce_src_cb");
+    constexpr uint32_t src_num_pages = get_named_compile_time_arg_val("gather_reduce_src_num_pages");
+    unified_kernels::setup_sharded_buffer(src_cb, src_num_pages);
+
+    deepseek_b1_ops::GatherReduce::SenderArgs args{
+        get_named_compile_time_arg_val("gather_reduce_dest_noc_x"),
+        get_named_compile_time_arg_val("gather_reduce_dest_noc_y"),
+        get_named_compile_time_arg_val("gather_reduce_data_size_bytes"),
+        get_named_compile_time_arg_val("gather_reduce_receiver_semaphore_addr"),
+        src_cb,
+        src_num_pages,
+        get_named_compile_time_arg_val("gather_reduce_grid_start_x"),
+        get_named_compile_time_arg_val("gather_reduce_grid_start_y"),
+        get_named_compile_time_arg_val("gather_reduce_grid_end_x"),
+        get_named_compile_time_arg_val("gather_reduce_grid_end_y"),
+        get_named_compile_time_arg_val("gather_reduce_half_num_cores"),
+        get_named_compile_time_arg_val("gather_reduce_dst_cb"),
+        get_named_compile_time_arg_val("gather_reduce_half_size_bytes"),
+        0,
+        noc_index,
+    };
+
+    deepseek_b1_ops::GatherReduce::Op<true, false, false, true, false> gather_reduce;
+    gather_reduce(args);
+}
+#elif defined(COMPILE_FOR_BRISC)
+FORCE_INLINE void run_gather_reduce_receiver() {
+    deepseek_b1_ops::GatherReduce::ReceiverArgs args{
+        get_named_compile_time_arg_val("gather_reduce_noc0_num_senders"),
+        get_named_compile_time_arg_val("gather_reduce_noc1_num_senders"),
+        get_named_compile_time_arg_val("gather_reduce_noc0_receiver_semaphore_addr"),
+        get_named_compile_time_arg_val("gather_reduce_noc1_receiver_semaphore_addr"),
+        get_named_compile_time_arg_val("gather_reduce_dst_cb"),
+        get_named_compile_time_arg_val("gather_reduce_dst_num_tiles"),
+    };
+
+    deepseek_b1_ops::GatherReduce::Op<false, true, false, true, false> gather_reduce;
+    gather_reduce(args);
+}
+#elif defined(COMPILE_FOR_TRISC)
+FORCE_INLINE void run_gather_reduce_compute() {
+    deepseek_compute_kernel_init();
+
+    deepseek_b1_ops::GatherReduce::ComputeArgs args{
+        get_named_compile_time_arg_val("gather_reduce_scratch_cb"),
+        get_named_compile_time_arg_val("gather_reduce_out_cb"),
+        get_named_compile_time_arg_val("gather_reduce_dst_num_tiles"),
+    };
+
+    deepseek_b1_ops::GatherReduce::Op<false, false, true, true, false> gather_reduce;
+    gather_reduce(args);
+}
+#endif
+
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
+template <typename WriterCT>
+FORCE_INLINE deepseek_b1_ops::AllReduce::SenderArgs make_allreduce_sender_args() {
+    deepseek_b1_ops::AllReduce::SenderArgs args{};
+    args.intermediate_buffer_address = get_common_arg_val<uint32_t>(0);
+    args.dest_noc_x = get_common_arg_val<uint32_t>(1);
+    args.dest_noc_y = get_common_arg_val<uint32_t>(2);
+    args.per_core_rta_start_idx = 0;
+    return args;
+}
+
+template <typename TransportCT>
+FORCE_INLINE deepseek_b1_ops::AllGather::TransportArgs make_allgather_transport_args() {
+    deepseek_b1_ops::AllGather::TransportArgs args{};
+    args.scratch_base_addr = get_named_compile_time_arg_val("allgather_scratch_base_addr");
+    args.handoff_sem_bank_addr = get_named_compile_time_arg_val("allgather_handoff_sem_addr");
+    args.dest_output_base_addr = get_named_compile_time_arg_val("allgather_dest_output_base_addr");
+    args.r1_dest_slot_index = get_named_compile_time_arg_val("allgather_r1_dest_slot_index");
+    args.dest_noc_x = get_named_compile_time_arg_val("allgather_dest_noc_x");
+    args.dest_noc_y = get_named_compile_time_arg_val("allgather_dest_noc_y");
+    args.dest_recv_sem_addr = get_named_compile_time_arg_val("allgather_dest_recv_sem_addr");
+    args.r2_dest_slot_index = get_named_compile_time_arg_val("allgather_r2_dest_slot_index");
+    args.per_core_rta_start_idx = get_common_arg_val<uint32_t>(3);
+    return args;
+}
+#endif
+
+void kernel_main() {
+    constexpr bool is_gather_sender = get_named_compile_time_arg_val("is_gather_sender_core") == 1;
+    constexpr bool is_gather_receiver = get_named_compile_time_arg_val("is_gather_receiver_core") == 1;
+    constexpr bool is_allreduce_sender = get_named_compile_time_arg_val("is_allreduce_sender_core") == 1;
+    constexpr bool is_allreduce_receiver = get_named_compile_time_arg_val("is_allreduce_receiver_core") == 1;
+    constexpr bool is_ccl_sync_producer = get_named_compile_time_arg_val("is_ccl_sync_producer_core") == 1;
+    constexpr bool is_ccl_sync2_producer = get_named_compile_time_arg_val("is_ccl_sync2_producer_core") == 1;
+    constexpr bool enable_allgather_transport = get_named_compile_time_arg_val("allgather_transport_enabled") == 1;
+    constexpr bool enable_allgather_gather = get_named_compile_time_arg_val("allgather_gather_enabled") == 1;
+    constexpr bool open_allgather_after_allreduce =
+        get_named_compile_time_arg_val("allgather_open_after_allreduce") == 1;
+
+#if defined(COMPILE_FOR_NCRISC)
+    if constexpr (is_ccl_sync_producer) {
+        constexpr uint32_t ccl_sync_sem_addr = get_named_compile_time_arg_val("ccl_sync_semaphore_addr");
+        constexpr uint32_t ccl_sync_dest_noc_x = get_named_compile_time_arg_val("ccl_sync_dest_noc_x");
+        constexpr uint32_t ccl_sync_dest_noc_y = get_named_compile_time_arg_val("ccl_sync_dest_noc_y");
+        uint64_t ccl_sync_sem_noc_addr = get_noc_addr(ccl_sync_dest_noc_x, ccl_sync_dest_noc_y, ccl_sync_sem_addr);
+        noc_semaphore_inc(ccl_sync_sem_noc_addr, 2);
+        noc_async_atomic_barrier();
+    }
+#endif
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
+    if constexpr (is_ccl_sync2_producer) {
+        constexpr uint32_t ccl_sync_sem_addr = get_named_compile_time_arg_val("ccl_sync_semaphore2_addr");
+        constexpr uint32_t ccl_sync_dest_noc_x = get_named_compile_time_arg_val("ccl_sync2_dest_noc_x");
+        constexpr uint32_t ccl_sync_dest_noc_y = get_named_compile_time_arg_val("ccl_sync2_dest_noc_y");
+        uint64_t ccl_sync_sem_noc_addr = get_noc_addr(ccl_sync_dest_noc_x, ccl_sync_dest_noc_y, ccl_sync_sem_addr);
+        noc_semaphore_inc(ccl_sync_sem_noc_addr, 1);
+        noc_async_atomic_barrier();
+    }
+#endif
+
+#if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
+    if constexpr (is_allreduce_sender) {
+        using WriterCT = deepseek_b1_ops::AllReduce::WriterCTArgs<
+            get_named_compile_time_arg_val("allreduce_local_data_cb_id"),
+            get_named_compile_time_arg_val("allreduce_input_num_tiles"),
+            get_named_compile_time_arg_val("allreduce_page_size_bytes"),
+            get_named_compile_time_arg_val("allreduce_tiles_per_chunk"),
+            get_named_compile_time_arg_val("allreduce_last_chunk_tiles"),
+            get_named_compile_time_arg_val("allreduce_num_chunks"),
+            get_named_compile_time_arg_val("allreduce_num_links"),
+            get_named_compile_time_arg_val("allreduce_writer_link_index"),
+            get_named_compile_time_arg_val("allreduce_writer_signal_local_ready"),
+            get_named_compile_time_arg_val("allreduce_skip_local_push")>;
+
+        deepseek_b1_ops::AllReduce::SenderArgs args = make_allreduce_sender_args<WriterCT>();
+        deepseek_b1_ops::AllReduce::WriterSingleLink<WriterCT> writer;
+        using AllGatherTransportCT = deepseek_b1_ops::AllGather::TransportCTArgs<
+            get_named_compile_time_arg_val("allgather_slice_size_bytes"),
+            get_named_compile_time_arg_val("allgather_num_chunks"),
+            get_named_compile_time_arg_val("allgather_chunk_size_bytes"),
+            get_named_compile_time_arg_val("allgather_last_chunk_bytes"),
+            get_named_compile_time_arg_val("allgather_num_links"),
+            get_named_compile_time_arg_val("allgather_recv_sem_bits_per_slot"),
+            get_named_compile_time_arg_val("allgather_r2_active")>;
+        deepseek_b1_ops::AllGather::TransportArgs allgather_transport_args =
+            make_allgather_transport_args<AllGatherTransportCT>();
+        deepseek_b1_ops::AllGather::TransportSender<AllGatherTransportCT> allgather_sender;
+        PacketHeaderPool::reset();
+        volatile tt_l1_ptr uint32_t* ccl_sync_sem =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_named_compile_time_arg_val("ccl_sync_semaphore_addr"));
+        noc_semaphore_wait_min(ccl_sync_sem, 1);
+        unified_kernels::semaphore_dec(ccl_sync_sem, 1);
+        writer.open_connections(args, false);
+        ccl_sync_sem =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_named_compile_time_arg_val("ccl_sync_semaphore2_addr"));
+        noc_semaphore_wait(ccl_sync_sem, 2 * get_named_compile_time_arg_val("sdpa_fwd_num_cores"));
+        if constexpr (enable_allgather_transport && !open_allgather_after_allreduce) {
+            allgather_sender.open_connections(allgather_transport_args, false);
+            if constexpr (!enable_allgather_gather) {
+                volatile tt_l1_ptr uint32_t* allgather_handoff_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                    get_named_compile_time_arg_val("allgather_handoff_sem_addr"));
+                noc_semaphore_set(allgather_handoff_sem, 1);
+            }
+        }
+
+#if defined(COMPILE_FOR_NCRISC)
+        if constexpr (is_gather_sender) {
+            run_gather_reduce_sender();
+        }
+#elif defined(COMPILE_FOR_BRISC)
+        if constexpr (is_gather_receiver) {
+            run_gather_reduce_receiver();
+        }
+#endif
+
+        writer(args);
+        if constexpr (enable_allgather_transport) {
+            if constexpr (open_allgather_after_allreduce) {
+                allgather_sender.open_connections(allgather_transport_args, false);
+                if constexpr (!enable_allgather_gather) {
+                    volatile tt_l1_ptr uint32_t* allgather_handoff_sem = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+                        get_named_compile_time_arg_val("allgather_handoff_sem_addr"));
+                    noc_semaphore_set(allgather_handoff_sem, 1);
+                }
+            }
+            allgather_sender(allgather_transport_args);
+        }
+    } else {
+#if defined(COMPILE_FOR_NCRISC)
+        if constexpr (is_gather_sender) {
+            run_gather_reduce_sender();
+        }
+#elif defined(COMPILE_FOR_BRISC)
+        if constexpr (is_gather_receiver) {
+            run_gather_reduce_receiver();
+        }
+#endif
+    }
+#elif defined(COMPILE_FOR_TRISC)
+    if constexpr (is_gather_receiver) {
+        run_gather_reduce_compute();
+    }
+#endif
+
+#if defined(COMPILE_FOR_NCRISC)
+    if constexpr (is_allreduce_receiver) {
+        using ReaderCT = deepseek_b1_ops::AllReduce::ReaderCTArgs<
+            get_named_compile_time_arg_val("allreduce_recv_local_data_cb_id"),
+            get_named_compile_time_arg_val("allreduce_remote_data_cb_id"),
+            get_named_compile_time_arg_val("allreduce_residual_cb_id"),
+            get_named_compile_time_arg_val("allreduce_has_residual"),
+            get_named_compile_time_arg_val("allreduce_total_num_tiles"),
+            get_named_compile_time_arg_val("allreduce_page_size_bytes"),
+            get_named_compile_time_arg_val("allreduce_tiles_per_chunk"),
+            get_named_compile_time_arg_val("allreduce_last_chunk_tiles"),
+            get_named_compile_time_arg_val("allreduce_num_chunks"),
+            get_named_compile_time_arg_val("allreduce_num_links")>;
+
+        deepseek_b1_ops::AllReduce::ReceiverArgs args{};
+        args.sem_bank_addr_0 = get_common_arg_val<uint32_t>(0);
+        args.sem_bank_addr_1 = get_common_arg_val<uint32_t>(1);
+        args.sender_noc_x = get_common_arg_val<uint32_t>(2);
+        args.sender_noc_y = get_common_arg_val<uint32_t>(3);
+        args.sender_local_data_l1_addr = get_common_arg_val<uint32_t>(4);
+        args.local_ready_sem_bank_addr = get_common_arg_val<uint32_t>(5);
+
+        deepseek_b1_ops::AllReduce::Reader<ReaderCT> reader;
+        reader(args);
+
+        if constexpr (enable_allgather_gather) {
+            using AllGatherGatherCT = deepseek_b1_ops::AllGather::GatherCTArgs<
+                get_named_compile_time_arg_val("allgather_gather_slice_size_bytes"),
+                get_named_compile_time_arg_val("allgather_gather_num_chunks"),
+                get_named_compile_time_arg_val("allgather_ring_size"),
+                get_named_compile_time_arg_val("allgather_recv_sem_bits_per_slot")>;
+
+            constexpr uint32_t out_cb = get_named_compile_time_arg_val("output_cb_id");
+            constexpr uint32_t out_num_tiles = get_named_compile_time_arg_val("output_num_tiles");
+            cb_wait_front(out_cb, out_num_tiles);
+
+            deepseek_b1_ops::AllGather::GatherArgs allgather_gather_args{};
+            allgather_gather_args.local_input_addr = get_read_ptr(out_cb);
+            allgather_gather_args.output_buffer_addr =
+                get_named_compile_time_arg_val("allgather_dest_output_base_addr");
+            allgather_gather_args.self_slot_index = get_named_compile_time_arg_val("allgather_self_slot_index");
+            allgather_gather_args.transport_scratch_base_addr =
+                get_named_compile_time_arg_val("allgather_scratch_base_addr");
+            allgather_gather_args.transport_noc_x = get_named_compile_time_arg_val("allgather_transport_noc_x");
+            allgather_gather_args.transport_noc_y = get_named_compile_time_arg_val("allgather_transport_noc_y");
+            allgather_gather_args.handoff_sem_bank_addr = get_named_compile_time_arg_val("allgather_handoff_sem_addr");
+            allgather_gather_args.recv_sem_addr = get_named_compile_time_arg_val("allgather_recv_sem_addr");
+            allgather_gather_args.r2_src_slot_index = get_named_compile_time_arg_val("allgather_r2_src_slot_index");
+
+            deepseek_b1_ops::AllGather::GatherController<AllGatherGatherCT> allgather_controller;
+            allgather_controller(allgather_gather_args);
+            cb_pop_front(out_cb, out_num_tiles);
+        }
+    }
+#endif
+
+#if defined(COMPILE_FOR_TRISC)
+    if constexpr (is_allreduce_receiver) {
+        using ComputeCT = deepseek_b1_ops::AllReduce::ComputeCTArgs<
+            get_named_compile_time_arg_val("allreduce_cb_remote"),
+            get_named_compile_time_arg_val("allreduce_cb_local"),
+            get_named_compile_time_arg_val("allreduce_cb_out"),
+            get_named_compile_time_arg_val("allreduce_cb_residual"),
+            get_named_compile_time_arg_val("allreduce_has_residual"),
+            get_named_compile_time_arg_val("allreduce_num_tiles")>;
+
+        deepseek_compute_kernel_init();
+
+        deepseek_b1_ops::AllReduce::ComputeArgs args{};
+        deepseek_b1_ops::AllReduce::Compute<ComputeCT> compute;
+        compute(args);
+    }
+#endif
+}

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_all_reduce.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_all_reduce.py
@@ -13,6 +13,7 @@ This test validates all-reduce on a 1D mesh (2 devices) where:
 4. Optionally, a residual tensor is added to the final result to fuse the next residual add block
 """
 
+import os
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -22,12 +23,18 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import is_slow_dispatch, skip_with_llk_assert
+from models.demos.deepseek_v3_b1.micro_ops.ccl_all_gather.op import AllGatherConfig
 from models.demos.deepseek_v3_b1.micro_ops.ccl_all_reduce.op import DeepseekMinimalAllReduce
 from models.demos.deepseek_v3_b1.tests.unit_tests.ccl_test_utils import (
     create_fabric_router_config,
     get_env_int,
     get_num_links_env_params,
     run_trace_benchmark,
+)
+from models.demos.deepseek_v3_b1.unified_kernel_descriptor import (
+    PerCoreRuntimeArgsDescriptor,
+    UnifiedCompileTimeCoreDescriptor,
+    UnifiedKernelDescriptor,
 )
 
 TEST_SENDER_CORE = ttnn.CoreCoord(0, 0)
@@ -388,3 +395,995 @@ def test_ccl_all_reduce_chunk_and_link_matrix(
             f"Output mismatch for device {device_idx}; "
             f"num_links={num_links}, chunk_num_tiles={chunk_num_tiles}, fuse_residual_add={fuse_residual_add}"
         )
+
+
+def _run_all_reduce_skip_local_push_smoke(
+    *,
+    input_tensor_mesh,
+    intermediate_tensor,
+    output_tensor,
+    semaphores,
+    cluster_axis,
+    num_links,
+    chunk_num_tiles,
+):
+    mesh_device = input_tensor_mesh.device()
+    mesh_shape = mesh_device.shape
+    mesh_rows, mesh_cols = mesh_shape
+
+    allreduce_config = DeepseekMinimalAllReduce.configure(
+        mesh_device=mesh_device,
+        intermediate_tensor=intermediate_tensor,
+        output_tensor=output_tensor,
+        semaphores=semaphores,
+        cluster_axis=cluster_axis,
+        num_links=num_links,
+        chunk_num_tiles=chunk_num_tiles,
+        input_tensor_mesh=input_tensor_mesh,
+        skip_local_push=True,
+    )
+
+    mesh_program_descriptor = ttnn.MeshProgramDescriptor()
+    kernel_path = "models/demos/deepseek_v3_b1/tests/unit_tests/kernels/all_reduce_skip_local_push_smoke_kernel.cpp"
+
+    sender_core = allreduce_config.sender_core
+    receiver_core = allreduce_config.receiver_core
+    sender_grid = ttnn.CoreRangeSet([ttnn.CoreRange(sender_core, sender_core)])
+    receiver_grid = ttnn.CoreRangeSet([ttnn.CoreRange(receiver_core, receiver_core)])
+    combined_grid = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(sender_core, sender_core), ttnn.CoreRange(receiver_core, receiver_core)]
+    )
+
+    for row in range(mesh_rows):
+        for col in range(mesh_cols):
+            coord = ttnn.MeshCoordinate(row, col)
+            unified_kernel = UnifiedKernelDescriptor(
+                kernel_source=kernel_path,
+                core_ranges=combined_grid,
+                ncrisc_named_compile_time_args=allreduce_config.get_ncrisc_named_ct_args(coord),
+                brisc_named_compile_time_args=allreduce_config.get_brisc_named_ct_args(coord),
+                trisc_named_compile_time_args=allreduce_config.get_trisc_named_ct_args(coord)
+                + [
+                    ("allreduce_local_data_cb_id", allreduce_config.local_data_cb_id),
+                    ("allreduce_input_num_tiles", allreduce_config.total_num_tiles),
+                ],
+                trisc_compute_config=ttnn.ComputeConfigDescriptor(
+                    math_fidelity=ttnn.MathFidelity.HiFi4,
+                    fp32_dest_acc_en=True,
+                    dst_full_sync_en=True,
+                    math_approx_mode=False,
+                ),
+                unified_compile_time_core_descriptors=[
+                    UnifiedCompileTimeCoreDescriptor(
+                        named_compile_time_arg="is_allreduce_sender_core",
+                        core_range=sender_grid,
+                        value=1,
+                        other_value=0,
+                    ),
+                    UnifiedCompileTimeCoreDescriptor(
+                        named_compile_time_arg="is_allreduce_receiver_core",
+                        core_range=receiver_grid,
+                        value=1,
+                        other_value=0,
+                    ),
+                ],
+                per_core_runtime_args_descriptor=PerCoreRuntimeArgsDescriptor(
+                    ncrisc_args=[(sender_core, []), (receiver_core, [])],
+                    brisc_args=[(sender_core, []), (receiver_core, [])],
+                    trisc_args=[(sender_core, []), (receiver_core, [])],
+                ),
+                noc_mode=ttnn.NOC_MODE.DM_DYNAMIC_NOC,
+            )
+            kernel_result = unified_kernel.get_kernel_descriptors()
+            sender_group = kernel_result.get_group_by_arg("is_allreduce_sender_core", 1)
+            receiver_group = kernel_result.get_group_by_arg("is_allreduce_receiver_core", 1)
+            if sender_group is None or receiver_group is None:
+                raise ValueError("Expected sender and receiver kernel groups")
+
+            program = ttnn.ProgramDescriptor(
+                kernels=kernel_result.kernels,
+                semaphores=[],
+                cbs=allreduce_config.get_cb_descriptors(coord),
+            )
+            program.kernels[
+                sender_group.ncrisc_kernel_index
+            ].common_runtime_args = allreduce_config.get_sender_ncrisc_common_rt_args(coord)
+            program.kernels[
+                sender_group.brisc_kernel_index
+            ].common_runtime_args = allreduce_config.get_sender_brisc_common_rt_args(coord)
+            program.kernels[sender_group.trisc_kernel_index].common_runtime_args = []
+            program.kernels[
+                receiver_group.ncrisc_kernel_index
+            ].common_runtime_args = allreduce_config.get_receiver_ncrisc_common_rt_args(coord)
+            program.kernels[receiver_group.brisc_kernel_index].common_runtime_args = []
+            program.kernels[receiver_group.trisc_kernel_index].common_runtime_args = []
+
+            ncrisc_per_core_rt = program.kernels[sender_group.ncrisc_kernel_index].runtime_args[sender_core.x][
+                sender_core.y
+            ]
+            ncrisc_per_core_rt.extend(allreduce_config.get_ncrisc_per_core_rt_args(coord, program, sender_core))
+            brisc_per_core_rt = program.kernels[sender_group.brisc_kernel_index].runtime_args[sender_core.x][
+                sender_core.y
+            ]
+            brisc_per_core_rt.extend(allreduce_config.get_brisc_per_core_rt_args(coord, program, sender_core))
+
+            mesh_program_descriptor[ttnn.MeshCoordinateRange(coord, coord)] = program
+
+    ttnn.generic_op([input_tensor_mesh, output_tensor, intermediate_tensor], mesh_program_descriptor)
+    return output_tensor
+
+
+@pytest.mark.parametrize(
+    "num_devices, output_shape, input_shard_shape, tensor_mem_layout",
+    [
+        (
+            2,
+            ALL_REDUCE_OUTPUT_SHAPE,
+            ALL_REDUCE_INPUT_SHARD_SHAPE,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ),
+    ],
+)
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("input_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("cluster_axis", [0])
+@pytest.mark.parametrize("num_links", [1])
+@pytest.mark.parametrize("chunk_num_tiles", [1])
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+            "fabric_router_config": create_fabric_router_config(15232),
+            "trace_region_size": 573440,
+        }
+    ],
+    indirect=True,
+)
+def test_ccl_all_reduce_skip_local_push_smoke(
+    bh_2d_mesh_device,
+    num_devices,
+    output_shape,
+    input_shard_shape,
+    tensor_mem_layout,
+    layout,
+    input_dtype,
+    cluster_axis,
+    num_links,
+    chunk_num_tiles,
+):
+    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices:
+        pytest.skip("Test requires more devices than are available on this platform")
+
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
+    inputs = build_all_reduce_test_inputs(
+        mesh_device=submesh,
+        num_devices=num_devices,
+        output_shape=output_shape,
+        input_shard_shape=input_shard_shape,
+        tensor_mem_layout=tensor_mem_layout,
+        layout=layout,
+        input_dtype=input_dtype,
+        fuse_residual_add=False,
+        semaphore_count=num_links + 1,
+    )
+
+    ttnn_result = _run_all_reduce_skip_local_push_smoke(
+        input_tensor_mesh=inputs.input_tensor_mesh,
+        intermediate_tensor=inputs.intermediate_tensor_mesh,
+        output_tensor=inputs.output_tensor_mesh,
+        semaphores=inputs.semaphores[: num_links + 1],
+        cluster_axis=cluster_axis,
+        num_links=num_links,
+        chunk_num_tiles=chunk_num_tiles,
+    )
+    ttnn.synchronize_device(submesh)
+
+    output_tensor_torch = ttnn.to_torch(
+        ttnn_result,
+        mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0),
+    )
+
+    ref_device_output = output_tensor_torch[0:1, :]
+    for device_idx in range(num_devices):
+        received = output_tensor_torch[device_idx : device_idx + 1, :]
+        if device_idx != 0:
+            assert torch.equal(received, ref_device_output), f"Device {device_idx} output mismatch"
+        assert torch.allclose(received, inputs.torch_expected, rtol=1e-2, atol=1e-2), (
+            f"Output mismatch for device {device_idx}; "
+            f"num_links={num_links}, chunk_num_tiles={chunk_num_tiles}, skip_local_push=True"
+        )
+
+
+def _create_mesh_tensor_from_per_device(
+    *,
+    mesh_device,
+    per_device_tensors,
+    core_range_set,
+    shard_shape,
+    tensor_mem_layout,
+    tile,
+    dtype,
+):
+    mesh_mapper_config = ttnn.MeshMapperConfig([ttnn.PlacementShard(0), ttnn.PlacementReplicate()], mesh_device.shape)
+    shard_spec = ttnn.ShardSpec(
+        core_range_set,
+        shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    mem_config = ttnn.MemoryConfig(tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=shard_spec)
+    return ttnn.from_torch(
+        torch.cat(per_device_tensors, dim=0),
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        tile=tile,
+        dtype=dtype,
+        memory_config=mem_config,
+        mesh_mapper=ttnn.create_mesh_mapper(mesh_device, mesh_mapper_config),
+    )
+
+
+def _create_mesh_tensor_from_per_device_2d(
+    *,
+    mesh_device,
+    per_device_tensors,
+    core_range_set,
+    shard_shape,
+    tensor_mem_layout,
+    tile,
+    dtype,
+):
+    mesh_rows, mesh_cols = mesh_device.shape
+    if len(per_device_tensors) != mesh_rows * mesh_cols:
+        raise ValueError(f"Expected {mesh_rows * mesh_cols} tensors, got {len(per_device_tensors)}")
+
+    rows = []
+    for row in range(mesh_rows):
+        row_tensors = []
+        for col in range(mesh_cols):
+            row_tensors.append(per_device_tensors[row * mesh_cols + col])
+        rows.append(torch.cat(row_tensors, dim=1))
+    host_tensor = torch.cat(rows, dim=0)
+
+    mesh_mapper_config = ttnn.MeshMapperConfig([ttnn.PlacementShard(0), ttnn.PlacementShard(1)], mesh_device.shape)
+    shard_spec = ttnn.ShardSpec(
+        core_range_set,
+        shard_shape,
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    mem_config = ttnn.MemoryConfig(tensor_mem_layout, buffer_type=ttnn.BufferType.L1, shard_spec=shard_spec)
+    return ttnn.from_torch(
+        host_tensor,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        tile=tile,
+        dtype=dtype,
+        memory_config=mem_config,
+        mesh_mapper=ttnn.create_mesh_mapper(mesh_device, mesh_mapper_config),
+    )
+
+
+def _run_gather_reduce_all_reduce_smoke(
+    *,
+    source_tensor_mesh,
+    scratch_tensor_mesh,
+    gather_out_tensor_mesh,
+    intermediate_tensor_mesh,
+    output_tensor_mesh,
+    allgather_output_tensor_mesh,
+    semaphores,
+    gather_semaphore_addrs,
+    ccl_sync_semaphore_addr,
+    ccl_sync2_semaphore_addr,
+    allgather_handoff_semaphore_addr,
+    allgather_recv_semaphore_addr,
+    allgather_transport_risc,
+    allgather_open_after_allreduce,
+    allgather_use_config,
+    allgather_gather_enabled,
+    allreduce_cluster_axis,
+    allgather_cluster_axis,
+    num_links,
+    chunk_num_tiles,
+    gather_dst_num_tiles,
+    gather_sender_grid,
+    gather_receiver_core,
+    allreduce_receiver_core,
+    gather_reduce_data_size_bytes,
+    gather_reduce_src_num_pages,
+):
+    source_cb = 0
+    gather_scratch_cb = 1
+    gather_out_cb = 2
+    ccl_recv_local_data_cb = 3
+    ccl_remote_data_cb = 4
+    ccl_output_cb = 5
+
+    tile_32x32 = ttnn.Tile((32, 32))
+    tile_32x32_size = tile_32x32.get_tile_size(ttnn.bfloat16)
+
+    mesh_device = source_tensor_mesh.device()
+    mesh_shape = mesh_device.shape
+    mesh_rows, mesh_cols = mesh_shape
+
+    allreduce_config = DeepseekMinimalAllReduce.configure(
+        mesh_device=mesh_device,
+        intermediate_tensor=intermediate_tensor_mesh,
+        output_tensor=output_tensor_mesh,
+        semaphores=semaphores,
+        cluster_axis=allreduce_cluster_axis,
+        num_links=num_links,
+        chunk_num_tiles=chunk_num_tiles,
+        local_data_cb_id=gather_out_cb,
+        recv_local_data_cb_id=ccl_recv_local_data_cb,
+        remote_data_cb_id=ccl_remote_data_cb,
+        output_cb_id=ccl_output_cb,
+        input_tensor_mesh=gather_out_tensor_mesh,
+        skip_local_push=True,
+        num_tiles_override=gather_dst_num_tiles,
+        page_size_override=tile_32x32_size,
+    )
+
+    gather_receiver_grid = ttnn.CoreRangeSet([ttnn.CoreRange(gather_receiver_core, gather_receiver_core)])
+    allreduce_receiver_grid = ttnn.CoreRangeSet([ttnn.CoreRange(allreduce_receiver_core, allreduce_receiver_core)])
+    combined_grid = gather_sender_grid.merge(gather_receiver_grid).merge(allreduce_receiver_grid)
+
+    ref_device = ttnn.get_device_tensors(gather_out_tensor_mesh)[0].device()
+    gather_receiver_noc = ref_device.worker_core_from_logical_core(gather_receiver_core)
+    allreduce_receiver_noc = ref_device.worker_core_from_logical_core(allreduce_receiver_core)
+    allgather_scratch_base_addr = ttnn.get_device_tensors(scratch_tensor_mesh)[0].buffer_address()
+    allgather_output_base_addr = ttnn.get_device_tensors(allgather_output_tensor_mesh)[0].buffer_address()
+    allgather_config = None
+    if allgather_use_config:
+        allgather_config = AllGatherConfig(
+            mesh_device=mesh_device,
+            cluster_axis=allgather_cluster_axis,
+            num_links=1,
+            slice_size_bytes=gather_dst_num_tiles * tile_32x32_size,
+            output_addr=allgather_output_base_addr,
+            scratch_base_addr=allgather_scratch_base_addr,
+            handoff_sem_addr=allgather_handoff_semaphore_addr,
+            recv_sem_addr=allgather_recv_semaphore_addr,
+            gather_noc_core=allreduce_receiver_noc,
+            transport_noc_core=gather_receiver_noc,
+            output_cb_id=ccl_output_cb,
+            output_num_tiles=gather_dst_num_tiles,
+        )
+
+    def build_allgather_transport_per_core_rt_args(coord, program, core, row, col):
+        if allgather_cluster_axis == 0:
+            neighbor_coord = ttnn.MeshCoordinate(1 - row, col)
+        else:
+            neighbor_coord = ttnn.MeshCoordinate(row, 1 - col)
+        src_fabric_node_id = mesh_device.get_fabric_node_id(coord)
+        dst_fabric_node_id = mesh_device.get_fabric_node_id(neighbor_coord)
+        out = [
+            int(dst_fabric_node_id.mesh_id),
+            int(dst_fabric_node_id.chip_id),
+        ]
+        out.extend(
+            ttnn.setup_fabric_connection(
+                src_fabric_node_id=src_fabric_node_id,
+                dst_fabric_node_id=dst_fabric_node_id,
+                link_idx=0,
+                program_descriptor=program,
+                worker_core=core,
+            )
+        )
+        return out
+
+    ncrisc_named_compile_time_args = [
+        ("gather_reduce_dest_noc_x", gather_receiver_noc.x),
+        ("gather_reduce_dest_noc_y", gather_receiver_noc.y),
+        ("gather_reduce_data_size_bytes", gather_reduce_data_size_bytes),
+        ("gather_reduce_receiver_semaphore_addr", gather_semaphore_addrs[0]),
+        ("gather_reduce_src_cb", source_cb),
+        ("gather_reduce_src_num_pages", gather_reduce_src_num_pages),
+        ("gather_reduce_grid_start_x", 0),
+        ("gather_reduce_grid_start_y", 0),
+        ("gather_reduce_grid_end_x", 1),
+        ("gather_reduce_grid_end_y", 0),
+        ("gather_reduce_half_num_cores", 1),
+        ("gather_reduce_dst_cb", gather_scratch_cb),
+        ("gather_reduce_half_size_bytes", gather_dst_num_tiles * tile_32x32_size),
+    ]
+
+    brisc_named_compile_time_args = [
+        ("gather_reduce_noc0_num_senders", 2),
+        ("gather_reduce_noc1_num_senders", 0),
+        ("gather_reduce_noc0_receiver_semaphore_addr", gather_semaphore_addrs[0]),
+        ("gather_reduce_noc1_receiver_semaphore_addr", gather_semaphore_addrs[1]),
+        ("gather_reduce_dst_cb", gather_scratch_cb),
+        ("gather_reduce_dst_num_tiles", gather_dst_num_tiles),
+    ]
+
+    trisc_named_compile_time_args = [
+        ("gather_reduce_scratch_cb", gather_scratch_cb),
+        ("gather_reduce_out_cb", gather_out_cb),
+        ("gather_reduce_dst_num_tiles", gather_dst_num_tiles),
+        ("allgather_transport_enabled", 0),
+        ("allgather_gather_enabled", int(allgather_gather_enabled)),
+        ("allgather_open_after_allreduce", int(allgather_open_after_allreduce)),
+    ]
+    ccl_sync_named_compile_time_args = [
+        ("ccl_sync_semaphore_addr", ccl_sync_semaphore_addr),
+        ("ccl_sync_semaphore2_addr", ccl_sync2_semaphore_addr),
+        ("ccl_sync_dest_noc_x", gather_receiver_noc.x),
+        ("ccl_sync_dest_noc_y", gather_receiver_noc.y),
+        ("ccl_sync2_dest_noc_x", gather_receiver_noc.x),
+        ("ccl_sync2_dest_noc_y", gather_receiver_noc.y),
+        ("sdpa_fwd_num_cores", 1),
+    ]
+    if allgather_transport_risc not in {"none", "brisc", "ncrisc", "both"}:
+        raise ValueError(
+            "Expected allgather_transport_risc to be one of none/brisc/ncrisc/both, " f"got {allgather_transport_risc}"
+        )
+    ncrisc_allgather_transport_enabled = 1 if allgather_transport_risc in {"ncrisc", "both"} else 0
+    brisc_allgather_transport_enabled = 1 if allgather_transport_risc in {"brisc", "both"} else 0
+
+    mesh_program_descriptor = ttnn.MeshProgramDescriptor()
+    kernel_path = "models/demos/deepseek_v3_b1/tests/unit_tests/kernels/gather_reduce_all_reduce_smoke_kernel.cpp"
+
+    for row in range(mesh_rows):
+        for col in range(mesh_cols):
+            coord = ttnn.MeshCoordinate(row, col)
+            if allgather_config is None:
+                allgather_ncrisc_named_compile_time_args = [
+                    ("allgather_slice_size_bytes", tile_32x32_size),
+                    ("allgather_num_chunks", 1),
+                    ("allgather_chunk_size_bytes", tile_32x32_size),
+                    ("allgather_last_chunk_bytes", tile_32x32_size),
+                    ("allgather_num_links", 1),
+                    ("allgather_recv_sem_bits_per_slot", 4),
+                    ("allgather_r2_active", 0),
+                    ("allgather_scratch_base_addr", allgather_scratch_base_addr),
+                    ("allgather_handoff_sem_addr", allgather_handoff_semaphore_addr),
+                    ("allgather_dest_output_base_addr", allgather_output_base_addr),
+                    ("allgather_r1_dest_slot_index", 0),
+                    ("allgather_dest_noc_x", allreduce_receiver_noc.x),
+                    ("allgather_dest_noc_y", allreduce_receiver_noc.y),
+                    ("allgather_dest_recv_sem_addr", allgather_recv_semaphore_addr),
+                    ("allgather_r2_dest_slot_index", 0),
+                    ("allgather_gather_slice_size_bytes", tile_32x32_size),
+                    ("allgather_gather_num_chunks", 1),
+                    ("allgather_ring_size", 4),
+                    ("allgather_self_slot_index", 0),
+                    ("allgather_transport_noc_x", gather_receiver_noc.x),
+                    ("allgather_transport_noc_y", gather_receiver_noc.y),
+                    ("allgather_recv_sem_addr", allgather_recv_semaphore_addr),
+                    ("allgather_r2_src_slot_index", 0),
+                    ("output_cb_id", ccl_output_cb),
+                    ("output_num_tiles", gather_dst_num_tiles),
+                ]
+                allgather_brisc_named_compile_time_args = list(allgather_ncrisc_named_compile_time_args)
+            else:
+                allgather_ncrisc_named_compile_time_args = allgather_config.get_fused_ncrisc_named_ct_args(coord)
+                allgather_brisc_named_compile_time_args = allgather_config.get_fused_brisc_named_ct_args(coord)
+            allgather_ncrisc_named_compile_time_args = allgather_ncrisc_named_compile_time_args + [
+                ("allgather_transport_enabled", ncrisc_allgather_transport_enabled),
+                ("allgather_gather_enabled", int(allgather_gather_enabled)),
+                ("allgather_open_after_allreduce", int(allgather_open_after_allreduce)),
+            ]
+            allgather_brisc_named_compile_time_args = allgather_brisc_named_compile_time_args + [
+                ("allgather_transport_enabled", brisc_allgather_transport_enabled),
+                ("allgather_gather_enabled", int(allgather_gather_enabled)),
+                ("allgather_open_after_allreduce", int(allgather_open_after_allreduce)),
+            ]
+            unified_kernel = UnifiedKernelDescriptor(
+                kernel_source=kernel_path,
+                core_ranges=combined_grid,
+                ncrisc_named_compile_time_args=ncrisc_named_compile_time_args
+                + ccl_sync_named_compile_time_args
+                + allgather_ncrisc_named_compile_time_args
+                + allreduce_config.get_ncrisc_named_ct_args(coord),
+                brisc_named_compile_time_args=brisc_named_compile_time_args
+                + ccl_sync_named_compile_time_args
+                + allgather_brisc_named_compile_time_args
+                + allreduce_config.get_brisc_named_ct_args(coord),
+                trisc_named_compile_time_args=trisc_named_compile_time_args
+                + allreduce_config.get_trisc_named_ct_args(coord),
+                trisc_compute_config=ttnn.ComputeConfigDescriptor(
+                    math_fidelity=ttnn.MathFidelity.HiFi4,
+                    fp32_dest_acc_en=True,
+                    dst_full_sync_en=True,
+                    math_approx_mode=False,
+                ),
+                unified_compile_time_core_descriptors=[
+                    UnifiedCompileTimeCoreDescriptor(
+                        named_compile_time_arg="is_gather_sender_core",
+                        core_range=gather_sender_grid,
+                        value=1,
+                        other_value=0,
+                    ),
+                    UnifiedCompileTimeCoreDescriptor(
+                        named_compile_time_arg="is_gather_receiver_core",
+                        core_range=gather_receiver_grid,
+                        value=1,
+                        other_value=0,
+                    ),
+                    UnifiedCompileTimeCoreDescriptor(
+                        named_compile_time_arg="is_allreduce_sender_core",
+                        core_range=gather_receiver_grid,
+                        value=1,
+                        other_value=0,
+                    ),
+                    UnifiedCompileTimeCoreDescriptor(
+                        named_compile_time_arg="is_allreduce_receiver_core",
+                        core_range=allreduce_receiver_grid,
+                        value=1,
+                        other_value=0,
+                    ),
+                    UnifiedCompileTimeCoreDescriptor(
+                        named_compile_time_arg="is_ccl_sync_producer_core",
+                        core_range=allreduce_receiver_grid,
+                        value=1,
+                        other_value=0,
+                    ),
+                    UnifiedCompileTimeCoreDescriptor(
+                        named_compile_time_arg="is_ccl_sync2_producer_core",
+                        core_range=allreduce_receiver_grid,
+                        value=1,
+                        other_value=0,
+                    ),
+                ],
+                per_core_runtime_args_descriptor=PerCoreRuntimeArgsDescriptor(
+                    ncrisc_args=[(gather_receiver_core, []), (allreduce_receiver_core, [])],
+                    brisc_args=[(gather_receiver_core, []), (allreduce_receiver_core, [])],
+                    trisc_args=[(gather_receiver_core, []), (allreduce_receiver_core, [])],
+                ),
+                noc_mode=ttnn.NOC_MODE.DM_DYNAMIC_NOC,
+            )
+            kernel_result = unified_kernel.get_kernel_descriptors()
+            sender_group = kernel_result.get_group_by_arg("is_allreduce_sender_core", 1)
+            receiver_group = kernel_result.get_group_by_arg("is_allreduce_receiver_core", 1)
+            if sender_group is None or receiver_group is None:
+                raise ValueError("Expected all-reduce sender and receiver kernel groups")
+
+            device_idx = row * mesh_cols + col
+            source_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                source_cb, ttnn.get_device_tensors(source_tensor_mesh)[device_idx]
+            )
+            gather_scratch_grid = gather_sender_grid.merge(gather_receiver_grid)
+            scratch_cb_descriptor = ttnn.cb_descriptor_from_sharded_tensor(
+                gather_scratch_cb,
+                ttnn.get_device_tensors(scratch_tensor_mesh)[device_idx],
+                total_size=2 * gather_dst_num_tiles * tile_32x32_size,
+                core_ranges=gather_scratch_grid,
+            )
+            scratch_cb_descriptor.format_descriptors = [
+                ttnn.CBFormatDescriptor(
+                    buffer_index=gather_scratch_cb,
+                    data_format=ttnn.bfloat16,
+                    page_size=tile_32x32_size,
+                    tile=ttnn.TileDescriptor(tile_32x32),
+                )
+            ]
+
+            allreduce_cb_descriptors = allreduce_config.get_cb_descriptors(coord)
+
+            program = ttnn.ProgramDescriptor(
+                kernels=kernel_result.kernels,
+                semaphores=[],
+                cbs=[
+                    source_cb_descriptor,
+                    scratch_cb_descriptor,
+                    *allreduce_cb_descriptors,
+                ],
+            )
+            program.kernels[
+                sender_group.ncrisc_kernel_index
+            ].common_runtime_args = allreduce_config.get_sender_ncrisc_common_rt_args(coord)
+            program.kernels[
+                sender_group.brisc_kernel_index
+            ].common_runtime_args = allreduce_config.get_sender_brisc_common_rt_args(coord)
+            program.kernels[sender_group.trisc_kernel_index].common_runtime_args = []
+            program.kernels[
+                receiver_group.ncrisc_kernel_index
+            ].common_runtime_args = allreduce_config.get_receiver_ncrisc_common_rt_args(coord)
+            program.kernels[receiver_group.brisc_kernel_index].common_runtime_args = []
+            program.kernels[receiver_group.trisc_kernel_index].common_runtime_args = []
+
+            ncrisc_allreduce_per_core_rt = allreduce_config.get_ncrisc_per_core_rt_args(
+                coord, program, gather_receiver_core
+            )
+            ncrisc_allgather_start_idx = len(ncrisc_allreduce_per_core_rt)
+            program.kernels[sender_group.ncrisc_kernel_index].common_runtime_args.append(ncrisc_allgather_start_idx)
+            ncrisc_per_core_rt = program.kernels[sender_group.ncrisc_kernel_index].runtime_args[gather_receiver_core.x][
+                gather_receiver_core.y
+            ]
+            ncrisc_per_core_rt.extend(ncrisc_allreduce_per_core_rt)
+            if allgather_config is None:
+                ncrisc_per_core_rt.extend(
+                    build_allgather_transport_per_core_rt_args(coord, program, gather_receiver_core, row, col)
+                )
+            else:
+                ncrisc_per_core_rt.extend(
+                    allgather_config.get_transport_ncrisc_per_core_rt_args(coord, program, gather_receiver_core)
+                )
+            brisc_per_core_rt = program.kernels[sender_group.brisc_kernel_index].runtime_args[gather_receiver_core.x][
+                gather_receiver_core.y
+            ]
+            brisc_allreduce_per_core_rt = allreduce_config.get_brisc_per_core_rt_args(
+                coord, program, gather_receiver_core
+            )
+            brisc_allgather_start_idx = len(brisc_allreduce_per_core_rt)
+            program.kernels[sender_group.brisc_kernel_index].common_runtime_args.append(brisc_allgather_start_idx)
+            brisc_per_core_rt.extend(brisc_allreduce_per_core_rt)
+            if allgather_config is None:
+                brisc_per_core_rt.extend(
+                    build_allgather_transport_per_core_rt_args(coord, program, gather_receiver_core, row, col)
+                )
+            else:
+                brisc_per_core_rt.extend(
+                    allgather_config.get_transport_brisc_per_core_rt_args(coord, program, gather_receiver_core)
+                )
+
+            mesh_program_descriptor[ttnn.MeshCoordinateRange(coord, coord)] = program
+
+    ttnn.generic_op(
+        [
+            source_tensor_mesh,
+            scratch_tensor_mesh,
+            gather_out_tensor_mesh,
+            intermediate_tensor_mesh,
+            output_tensor_mesh,
+            allgather_output_tensor_mesh,
+        ],
+        mesh_program_descriptor,
+    )
+    if allgather_gather_enabled:
+        return allgather_output_tensor_mesh
+    return output_tensor_mesh
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+            "fabric_router_config": create_fabric_router_config(15232),
+            "trace_region_size": 573440,
+        }
+    ],
+    indirect=True,
+)
+def test_ccl_all_reduce_with_two_sender_gather_reduce_smoke(bh_2d_mesh_device):
+    num_devices = 2
+    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices:
+        pytest.skip("Test requires more devices than are available on this platform")
+
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((num_devices, 1)))
+    gather_sender_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))])
+    gather_receiver_core = ttnn.CoreCoord(2, 0)
+    allreduce_receiver_core = ttnn.CoreCoord(3, 0)
+    gather_receiver_grid = ttnn.CoreRangeSet([ttnn.CoreRange(gather_receiver_core, gather_receiver_core)])
+    gather_scratch_grid = gather_sender_grid.merge(gather_receiver_grid)
+    allreduce_receiver_grid = ttnn.CoreRangeSet([ttnn.CoreRange(allreduce_receiver_core, allreduce_receiver_core)])
+
+    tile_1x32 = ttnn.Tile((1, 32))
+    tile_32x32 = ttnn.Tile((32, 32))
+    tile_1x32_size = tile_1x32.get_tile_size(ttnn.bfloat16)
+    tile_32x32_size = tile_32x32.get_tile_size(ttnn.bfloat16)
+    torch.manual_seed(0)
+    source_per_device = [torch.rand((1, 64), dtype=torch.bfloat16) for _ in range(num_devices)]
+    zeros_32x32 = [torch.zeros((32, 32), dtype=torch.bfloat16) for _ in range(num_devices)]
+    zeros_scratch = [torch.zeros((192, 32), dtype=torch.bfloat16) for _ in range(num_devices)]
+
+    source_tensor_mesh = _create_mesh_tensor_from_per_device(
+        mesh_device=submesh,
+        per_device_tensors=source_per_device,
+        core_range_set=gather_sender_grid,
+        shard_shape=(1, 32),
+        tensor_mem_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        tile=tile_1x32,
+        dtype=ttnn.bfloat16,
+    )
+    scratch_tensor_mesh = _create_mesh_tensor_from_per_device(
+        mesh_device=submesh,
+        per_device_tensors=zeros_scratch,
+        core_range_set=gather_scratch_grid,
+        shard_shape=(64, 32),
+        tensor_mem_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        tile=tile_32x32,
+        dtype=ttnn.bfloat16,
+    )
+    gather_out_tensor_mesh = _create_mesh_tensor_from_per_device(
+        mesh_device=submesh,
+        per_device_tensors=zeros_32x32,
+        core_range_set=gather_receiver_grid,
+        shard_shape=(32, 32),
+        tensor_mem_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        tile=tile_32x32,
+        dtype=ttnn.bfloat16,
+    )
+    intermediate_tensor_mesh = _create_mesh_tensor_from_per_device(
+        mesh_device=submesh,
+        per_device_tensors=zeros_32x32,
+        core_range_set=allreduce_receiver_grid,
+        shard_shape=(32, 32),
+        tensor_mem_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        tile=tile_32x32,
+        dtype=ttnn.bfloat16,
+    )
+    output_tensor_mesh = _create_mesh_tensor_from_per_device(
+        mesh_device=submesh,
+        per_device_tensors=zeros_32x32,
+        core_range_set=allreduce_receiver_grid,
+        shard_shape=(32, 32),
+        tensor_mem_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        tile=tile_32x32,
+        dtype=ttnn.bfloat16,
+    )
+    allgather_output_tensor_mesh = _create_mesh_tensor_from_per_device(
+        mesh_device=submesh,
+        per_device_tensors=zeros_32x32,
+        core_range_set=allreduce_receiver_grid,
+        shard_shape=(32, 32),
+        tensor_mem_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        tile=tile_32x32,
+        dtype=ttnn.bfloat16,
+    )
+
+    compute_grid_size = submesh.compute_with_storage_grid_size()
+    available_cores = ttnn.num_cores_to_corerangeset(
+        compute_grid_size.x * compute_grid_size.y,
+        compute_grid_size,
+        row_wise=True,
+    )
+    allreduce_semaphores = [ttnn.create_global_semaphore(submesh, available_cores, 0) for _ in range(2)]
+    gather_semaphores = [ttnn.create_global_semaphore(submesh, available_cores, 0) for _ in range(2)]
+    ccl_sync_semaphore = ttnn.create_global_semaphore(submesh, available_cores, 0)
+    ccl_sync2_semaphore = ttnn.create_global_semaphore(submesh, available_cores, 0)
+    allgather_semaphores = [ttnn.create_global_semaphore(submesh, available_cores, 0) for _ in range(2)]
+    gather_semaphore_addrs = [ttnn.get_global_semaphore_address(sem) for sem in gather_semaphores]
+    ccl_sync_semaphore_addr = ttnn.get_global_semaphore_address(ccl_sync_semaphore)
+    ccl_sync2_semaphore_addr = ttnn.get_global_semaphore_address(ccl_sync2_semaphore)
+    allgather_semaphore_addrs = [ttnn.get_global_semaphore_address(sem) for sem in allgather_semaphores]
+    allgather_transport_risc = os.environ.get("GATHER_ALLGATHER_RISC", "none").lower()
+    allgather_open = os.environ.get("GATHER_ALLGATHER_OPEN", "early").lower()
+    if allgather_open not in {"early", "late"}:
+        raise ValueError(f"Expected GATHER_ALLGATHER_OPEN to be early or late, got {allgather_open}")
+    allgather_open_after_allreduce = allgather_open == "late"
+
+    ttnn_result = _run_gather_reduce_all_reduce_smoke(
+        source_tensor_mesh=source_tensor_mesh,
+        scratch_tensor_mesh=scratch_tensor_mesh,
+        gather_out_tensor_mesh=gather_out_tensor_mesh,
+        intermediate_tensor_mesh=intermediate_tensor_mesh,
+        output_tensor_mesh=output_tensor_mesh,
+        allgather_output_tensor_mesh=allgather_output_tensor_mesh,
+        semaphores=allreduce_semaphores,
+        gather_semaphore_addrs=gather_semaphore_addrs,
+        ccl_sync_semaphore_addr=ccl_sync_semaphore_addr,
+        ccl_sync2_semaphore_addr=ccl_sync2_semaphore_addr,
+        allgather_handoff_semaphore_addr=allgather_semaphore_addrs[0],
+        allgather_recv_semaphore_addr=allgather_semaphore_addrs[1],
+        allgather_transport_risc=allgather_transport_risc,
+        allgather_open_after_allreduce=allgather_open_after_allreduce,
+        allgather_use_config=False,
+        allgather_gather_enabled=False,
+        allreduce_cluster_axis=0,
+        allgather_cluster_axis=0,
+        num_links=1,
+        chunk_num_tiles=1,
+        gather_dst_num_tiles=1,
+        gather_sender_grid=gather_sender_grid,
+        gather_receiver_core=gather_receiver_core,
+        allreduce_receiver_core=allreduce_receiver_core,
+        gather_reduce_data_size_bytes=tile_1x32_size,
+        gather_reduce_src_num_pages=1,
+    )
+    ttnn.synchronize_device(submesh)
+
+    expected_per_device = []
+    for source in source_per_device:
+        reduced_row = (source[:, :32].float() + source[:, 32:64].float()).bfloat16()
+        reduced = torch.zeros((32, 32), dtype=torch.bfloat16)
+        reduced[0, 0:16] = reduced_row[0, 0:16]
+        reduced[1, 0:16] = reduced_row[0, 16:32]
+        expected_per_device.append(reduced)
+    expected = sum(t.float() for t in expected_per_device).bfloat16()
+
+    output_tensor_torch = ttnn.to_torch(
+        ttnn_result,
+        mesh_composer=ttnn.ConcatMeshToTensor(submesh, dim=0),
+    )
+    for device_idx in range(num_devices):
+        received = output_tensor_torch[device_idx * 32 : (device_idx + 1) * 32, :]
+        assert torch.allclose(
+            received, expected, rtol=1e-2, atol=1e-2
+        ), f"Output mismatch for device {device_idx} in gather-reduce all-reduce smoke"
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+            "fabric_router_config": create_fabric_router_config(15232),
+            "trace_region_size": 573440,
+        }
+    ],
+    indirect=True,
+)
+def test_ccl_all_reduce_gather_allgather_4x2_smoke(bh_2d_mesh_device):
+    mesh_rows = 4
+    mesh_cols = 2
+    num_devices = mesh_rows * mesh_cols
+    if bh_2d_mesh_device.shape[0] * bh_2d_mesh_device.shape[1] < num_devices:
+        pytest.skip("Test requires more devices than are available on this platform")
+
+    submesh = bh_2d_mesh_device.create_submesh(ttnn.MeshShape((mesh_rows, mesh_cols)))
+    gather_sender_grid = ttnn.CoreRangeSet([ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))])
+    gather_receiver_core = ttnn.CoreCoord(2, 0)
+    allreduce_receiver_core = ttnn.CoreCoord(3, 0)
+    gather_receiver_grid = ttnn.CoreRangeSet([ttnn.CoreRange(gather_receiver_core, gather_receiver_core)])
+    gather_scratch_grid = gather_sender_grid.merge(gather_receiver_grid)
+    allreduce_receiver_grid = ttnn.CoreRangeSet([ttnn.CoreRange(allreduce_receiver_core, allreduce_receiver_core)])
+
+    tile_32x32 = ttnn.Tile((32, 32))
+    tile_32x32_size = tile_32x32.get_tile_size(ttnn.bfloat16)
+    gather_dst_num_tiles = int(os.environ.get("GATHER_4X2_DST_TILES", "2"))
+    if gather_dst_num_tiles <= 0:
+        raise ValueError(f"GATHER_4X2_DST_TILES must be positive, got {gather_dst_num_tiles}")
+    reduced_rows = 32 * gather_dst_num_tiles
+    allgather_rows = mesh_rows * reduced_rows
+    scratch_rows = 3 * 2 * reduced_rows
+
+    source_per_device = []
+    for device_idx in range(num_devices):
+        left = torch.zeros((reduced_rows, 32), dtype=torch.bfloat16)
+        right = torch.full((reduced_rows, 32), device_idx + 17, dtype=torch.bfloat16)
+        source_per_device.append(torch.cat([left, right], dim=1))
+    zeros_reduced = [torch.zeros((reduced_rows, 32), dtype=torch.bfloat16) for _ in range(num_devices)]
+    zeros_scratch = [torch.zeros((scratch_rows, 32), dtype=torch.bfloat16) for _ in range(num_devices)]
+    zeros_allgather = [torch.zeros((allgather_rows, 32), dtype=torch.bfloat16) for _ in range(num_devices)]
+
+    source_tensor_mesh = _create_mesh_tensor_from_per_device_2d(
+        mesh_device=submesh,
+        per_device_tensors=source_per_device,
+        core_range_set=gather_sender_grid,
+        shard_shape=(reduced_rows, 32),
+        tensor_mem_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        tile=tile_32x32,
+        dtype=ttnn.bfloat16,
+    )
+    scratch_tensor_mesh = _create_mesh_tensor_from_per_device_2d(
+        mesh_device=submesh,
+        per_device_tensors=zeros_scratch,
+        core_range_set=gather_scratch_grid,
+        shard_shape=(2 * reduced_rows, 32),
+        tensor_mem_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        tile=tile_32x32,
+        dtype=ttnn.bfloat16,
+    )
+    gather_out_tensor_mesh = _create_mesh_tensor_from_per_device_2d(
+        mesh_device=submesh,
+        per_device_tensors=zeros_reduced,
+        core_range_set=gather_receiver_grid,
+        shard_shape=(reduced_rows, 32),
+        tensor_mem_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        tile=tile_32x32,
+        dtype=ttnn.bfloat16,
+    )
+    intermediate_tensor_mesh = _create_mesh_tensor_from_per_device_2d(
+        mesh_device=submesh,
+        per_device_tensors=zeros_reduced,
+        core_range_set=allreduce_receiver_grid,
+        shard_shape=(reduced_rows, 32),
+        tensor_mem_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        tile=tile_32x32,
+        dtype=ttnn.bfloat16,
+    )
+    output_tensor_mesh = _create_mesh_tensor_from_per_device_2d(
+        mesh_device=submesh,
+        per_device_tensors=zeros_reduced,
+        core_range_set=allreduce_receiver_grid,
+        shard_shape=(reduced_rows, 32),
+        tensor_mem_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        tile=tile_32x32,
+        dtype=ttnn.bfloat16,
+    )
+    allgather_output_tensor_mesh = _create_mesh_tensor_from_per_device_2d(
+        mesh_device=submesh,
+        per_device_tensors=zeros_allgather,
+        core_range_set=allreduce_receiver_grid,
+        shard_shape=(allgather_rows, 32),
+        tensor_mem_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        tile=tile_32x32,
+        dtype=ttnn.bfloat16,
+    )
+
+    compute_grid_size = submesh.compute_with_storage_grid_size()
+    available_cores = ttnn.num_cores_to_corerangeset(
+        compute_grid_size.x * compute_grid_size.y,
+        compute_grid_size,
+        row_wise=True,
+    )
+    allreduce_num_links = int(os.environ.get("GATHER_4X2_ALLREDUCE_LINKS", "2"))
+    if allreduce_num_links <= 0:
+        raise ValueError(f"GATHER_4X2_ALLREDUCE_LINKS must be positive, got {allreduce_num_links}")
+    allreduce_semaphores = [
+        ttnn.create_global_semaphore(submesh, available_cores, 0) for _ in range(allreduce_num_links + 1)
+    ]
+    gather_semaphores = [ttnn.create_global_semaphore(submesh, available_cores, 0) for _ in range(2)]
+    ccl_sync_semaphore = ttnn.create_global_semaphore(submesh, available_cores, 0)
+    ccl_sync2_semaphore = ttnn.create_global_semaphore(submesh, available_cores, 0)
+    allgather_semaphores = [ttnn.create_global_semaphore(submesh, available_cores, 0) for _ in range(2)]
+    gather_semaphore_addrs = [ttnn.get_global_semaphore_address(sem) for sem in gather_semaphores]
+    ccl_sync_semaphore_addr = ttnn.get_global_semaphore_address(ccl_sync_semaphore)
+    ccl_sync2_semaphore_addr = ttnn.get_global_semaphore_address(ccl_sync2_semaphore)
+    allgather_semaphore_addrs = [ttnn.get_global_semaphore_address(sem) for sem in allgather_semaphores]
+    allgather_transport_risc = os.environ.get("GATHER_ALLGATHER_RISC", "both").lower()
+    allgather_open = os.environ.get("GATHER_ALLGATHER_OPEN", "early").lower()
+    if allgather_open not in {"early", "late"}:
+        raise ValueError(f"Expected GATHER_ALLGATHER_OPEN to be early or late, got {allgather_open}")
+    allgather_enabled = allgather_transport_risc != "none"
+
+    ttnn_result = _run_gather_reduce_all_reduce_smoke(
+        source_tensor_mesh=source_tensor_mesh,
+        scratch_tensor_mesh=scratch_tensor_mesh,
+        gather_out_tensor_mesh=gather_out_tensor_mesh,
+        intermediate_tensor_mesh=intermediate_tensor_mesh,
+        output_tensor_mesh=output_tensor_mesh,
+        allgather_output_tensor_mesh=allgather_output_tensor_mesh,
+        semaphores=allreduce_semaphores,
+        gather_semaphore_addrs=gather_semaphore_addrs,
+        ccl_sync_semaphore_addr=ccl_sync_semaphore_addr,
+        ccl_sync2_semaphore_addr=ccl_sync2_semaphore_addr,
+        allgather_handoff_semaphore_addr=allgather_semaphore_addrs[0],
+        allgather_recv_semaphore_addr=allgather_semaphore_addrs[1],
+        allgather_transport_risc=allgather_transport_risc,
+        allgather_open_after_allreduce=allgather_open == "late",
+        allgather_use_config=True,
+        allgather_gather_enabled=allgather_enabled,
+        allreduce_cluster_axis=1,
+        allgather_cluster_axis=0,
+        num_links=allreduce_num_links,
+        chunk_num_tiles=1,
+        gather_dst_num_tiles=gather_dst_num_tiles,
+        gather_sender_grid=gather_sender_grid,
+        gather_receiver_core=gather_receiver_core,
+        allreduce_receiver_core=allreduce_receiver_core,
+        gather_reduce_data_size_bytes=gather_dst_num_tiles * tile_32x32_size,
+        gather_reduce_src_num_pages=gather_dst_num_tiles,
+    )
+    ttnn.synchronize_device(submesh)
+
+    row_reduced = []
+    for row in range(mesh_rows):
+        col_reduced = []
+        for col in range(mesh_cols):
+            source = source_per_device[row * mesh_cols + col]
+            col_reduced.append((source[:, :32].float() + source[:, 32:64].float()).bfloat16())
+        row_reduced.append(sum(t.float() for t in col_reduced).bfloat16())
+
+    output_tensor_torch = ttnn.to_torch(
+        ttnn_result,
+        mesh_composer=ttnn.ConcatMesh2dToTensor(submesh, mesh_shape=submesh.shape, dims=(0, 1)),
+    )
+    compare_cols = slice(2, None)
+
+    if allgather_enabled:
+        expected_allgather = torch.cat(row_reduced, dim=0)
+        for row in range(mesh_rows):
+            for col in range(mesh_cols):
+                received = output_tensor_torch[
+                    row * allgather_rows : (row + 1) * allgather_rows,
+                    col * 32 : (col + 1) * 32,
+                ]
+                device_idx = row * mesh_cols + col
+                assert torch.allclose(
+                    received[:, compare_cols], expected_allgather[:, compare_cols], rtol=1e-2, atol=1e-2
+                ), f"All-gather output mismatch for device {device_idx} in 4x2 smoke"
+    else:
+        for row in range(mesh_rows):
+            for col in range(mesh_cols):
+                received = output_tensor_torch[
+                    row * reduced_rows : (row + 1) * reduced_rows,
+                    col * 32 : (col + 1) * 32,
+                ]
+                device_idx = row * mesh_cols + col
+                assert torch.allclose(
+                    received[:, compare_cols], row_reduced[row][:, compare_cols], rtol=1e-2, atol=1e-2
+                ), f"All-reduce output mismatch for device {device_idx} in 4x2 smoke"

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_all_reduce.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_all_reduce.py
@@ -1362,8 +1362,6 @@ def test_ccl_all_reduce_gather_allgather_4x2_smoke(bh_2d_mesh_device):
         ttnn_result,
         mesh_composer=ttnn.ConcatMesh2dToTensor(submesh, mesh_shape=submesh.shape, dims=(0, 1)),
     )
-    compare_cols = slice(2, None)
-
     if allgather_enabled:
         expected_allgather = torch.cat(row_reduced, dim=0)
         for row in range(mesh_rows):
@@ -1374,7 +1372,7 @@ def test_ccl_all_reduce_gather_allgather_4x2_smoke(bh_2d_mesh_device):
                 ]
                 device_idx = row * mesh_cols + col
                 assert torch.allclose(
-                    received[:, compare_cols], expected_allgather[:, compare_cols], rtol=1e-2, atol=1e-2
+                    received, expected_allgather, rtol=1e-2, atol=1e-2
                 ), f"All-gather output mismatch for device {device_idx} in 4x2 smoke"
     else:
         for row in range(mesh_rows):
@@ -1385,5 +1383,5 @@ def test_ccl_all_reduce_gather_allgather_4x2_smoke(bh_2d_mesh_device):
                 ]
                 device_idx = row * mesh_cols + col
                 assert torch.allclose(
-                    received[:, compare_cols], row_reduced[row][:, compare_cols], rtol=1e-2, atol=1e-2
+                    received, row_reduced[row], rtol=1e-2, atol=1e-2
                 ), f"All-reduce output mismatch for device {device_idx} in 4x2 smoke"

--- a/models/demos/deepseek_v3_b1/unified_kernels/all_gather.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/all_gather.hpp
@@ -156,8 +156,10 @@ private:
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
     uint64_t dest_output_noc = 0;
     uint64_t dest_recv_sem_noc = 0;
+    bool folded_connection = false;
     tt::tt_fabric::WorkerToFabricEdmSender connection;
     std::array<volatile tt_l1_ptr PACKET_HEADER_TYPE*, header_ring_size> headers = {};
+    std::array<volatile tt_l1_ptr PACKET_HEADER_TYPE*, header_ring_size> folded_peer_headers = {};
 #endif
     void open_connections_impl([[maybe_unused]] const TransportArgs& args, [[maybe_unused]] bool reset_header_pool) {
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
@@ -169,6 +171,16 @@ private:
         connection =
             tt::tt_fabric::WorkerToFabricEdmSender::build_from_args<ProgrammableCoreType::TENSIX>(arg_idx);
         const auto connection_direction = get_next_hop_router_direction(dst_mesh_id, dst_chip_id);
+        folded_connection = get_arg_val<uint32_t>(arg_idx++) != 0;
+        const uint32_t folded_peer_dst_mesh_id = get_arg_val<uint32_t>(arg_idx++);
+        const uint32_t folded_peer_dst_chip_id = get_arg_val<uint32_t>(arg_idx++);
+
+#if defined(COMPILE_FOR_NCRISC)
+        if (folded_connection) {
+            return;
+        }
+#endif
+
         connection.open_start();
         if (reset_header_pool) {
             PacketHeaderPool::reset();
@@ -184,11 +196,36 @@ private:
             headers[i]->to_noc_fused_unicast_write_atomic_inc(
                 {dest_output_noc, dest_recv_sem_noc, /* placeholder inc_value */ 1, false}, CTArgs::chunk_size_bytes);
         }
+
+#if defined(COMPILE_FOR_BRISC)
+        if (folded_connection) {
+            const auto folded_peer_connection_direction =
+                get_next_hop_router_direction(folded_peer_dst_mesh_id, folded_peer_dst_chip_id);
+            for (uint32_t i = 0; i < header_ring_size; ++i) {
+                folded_peer_headers[i] = PacketHeaderPool::allocate_header();
+                fabric_set_single_hop_unicast_route_from_direction(
+                    folded_peer_headers[i],
+                    folded_peer_connection_direction,
+                    folded_peer_dst_chip_id,
+                    folded_peer_dst_mesh_id);
+                folded_peer_headers[i]->to_noc_fused_unicast_write_atomic_inc(
+                    {dest_output_noc, dest_recv_sem_noc, /* placeholder inc_value */ 1, false},
+                    CTArgs::chunk_size_bytes);
+            }
+        }
+#endif
+
         connection.open_finish();
 #endif
     }
     void impl([[maybe_unused]] const TransportArgs& args) {
 #if defined(COMPILE_FOR_NCRISC) || defined(COMPILE_FOR_BRISC)
+
+#if defined(COMPILE_FOR_NCRISC)
+        if (folded_connection) {
+            return;
+        }
+#endif
 
         connection.setup_stateful_send_cmd_bufs<use_posted_transport_writes>();
 
@@ -224,14 +261,15 @@ private:
         };
 
         // Send a full slice (possibly multi-chunk) over the single connection.
-        auto send_slice = [&](uint32_t src_addr, uint32_t dest_slot_index) __attribute__((always_inline)) {
+        auto send_slice = [&](uint32_t src_addr, uint32_t dest_slot_index, auto& route_headers) __attribute__((
+                              always_inline)) {
             drain_tail_before_reuse_or_teardown();
 
             const uint32_t inc_value = 1u << (dest_slot_index * CTArgs::recv_sem_bits_per_slot);
             const uint64_t dest_base = dest_output_noc + dest_slot_index * CTArgs::slice_size_bytes;
 
             for (uint32_t i = 0; i < header_ring_size; ++i) {
-                headers[i]->set_fused_unicast_write_atomic_inc_value(inc_value);
+                route_headers[i]->set_fused_unicast_write_atomic_inc_value(inc_value);
             }
 
             uint32_t current_chunk_offset_bytes = 0;
@@ -243,7 +281,7 @@ private:
                     refill_free_write_slots();
                 }
 
-                auto* header = headers[current_header_idx++];
+                auto* header = route_headers[current_header_idx++];
                 if constexpr (CTArgs::last_chunk_bytes != CTArgs::chunk_size_bytes) {
                     header->set_payload_size_bytes(payload_bytes);
                 }
@@ -266,12 +304,25 @@ private:
 
         // Round 1: wait for bit 1 (scratch[0] ready), send local slice
         wait_for_bits<1>(handoff_sem_ptr);
-        send_slice(args.scratch_base_addr, args.r1_dest_slot_index);
+        send_slice(args.scratch_base_addr, args.r1_dest_slot_index, headers);
 
-        if constexpr (CTArgs::r2_active) {
+#if defined(COMPILE_FOR_BRISC)
+        if (folded_connection) {
+            send_slice(args.scratch_base_addr, args.r1_dest_slot_index, folded_peer_headers);
+            wait_for_bits<1 << 1>(handoff_sem_ptr);
+            if constexpr (CTArgs::r2_active) {
+                send_slice(args.scratch_base_addr + CTArgs::slice_size_bytes, args.r2_dest_slot_index, headers);
+            } else {
+                send_slice(
+                    args.scratch_base_addr + CTArgs::slice_size_bytes, args.r2_dest_slot_index, folded_peer_headers);
+            }
+            noc_semaphore_set(handoff_sem_ptr, 0);
+        } else
+#endif
+            if constexpr (CTArgs::r2_active) {
             // Round 2: wait for bit 2 (scratch[1] ready), forward received slice
             wait_for_bits<1 << 1>(handoff_sem_ptr);
-            send_slice(args.scratch_base_addr + CTArgs::slice_size_bytes, args.r2_dest_slot_index);
+            send_slice(args.scratch_base_addr + CTArgs::slice_size_bytes, args.r2_dest_slot_index, headers);
 
             // Wait for non-R2 peer's bit 3 ack. Once observed, all NOC incs to
             // this word (bits 1/2 from gather, bit 3 from peer) have landed,


### PR DESCRIPTION
Reopen of #46316 (bot-closed for inactivity), rebased onto current `main`. The original base branch `ncvetkovic/multichip_half_dest_main` is stale/unmerged, so this retargets to `main` — the affected code path in `deepseek_v3_b1/micro_ops/ccl_all_gather` is identical on main and the fix still applies.

---

Summary
- detect when all-gather BRISC/NCRISC transports resolve to the same EDM sender channel
- fold that case through BRISC with separate peer headers while NCRISC exits
- add focused gather-reduce/all-reduce and 4x2 all-gather smokes

Testing
- TT_METAL_SLOW_DISPATCH_MODE=1 TT_MESH_DEVICE_TRACE=1 pytest -s models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_all_reduce.py::test_ccl_all_reduce_with_two_sender_gather_reduce_smoke --tb=short -q (passed; alias_count=0)
- TT_METAL_SLOW_DISPATCH_MODE=1 TT_MESH_DEVICE_TRACE=1 pytest -s models/demos/deepseek_v3_b1/tests/unit_tests/test_ccl_all_reduce.py::test_ccl_all_reduce_gather_allgather_4x2_smoke --tb=short -q (passed; alias_count=0)
- TT_METAL_SLOW_DISPATCH_MODE=1 TT_MESH_DEVICE_TRACE=1 pytest -s models/demos/deepseek_v3_b1/tests/test_decoder_mlp.py::test_decoder_mlp_all_reduce[True-1023-deepseek_v3-mla_decode-4-2-device_params0] --tb=short -q (passed; alias_count=0)
- raw craq-sim fabric_sender_alias_min.py still reproduces the underlying alias without this tt-metal folding fix

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/ccl-folded-allgather-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/ccl-folded-allgather-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/ccl-folded-allgather-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/ccl-folded-allgather-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/ccl-folded-allgather-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/ccl-folded-allgather-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/ccl-folded-allgather-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/ccl-folded-allgather-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/ccl-folded-allgather-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/ccl-folded-allgather-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/ccl-folded-allgather-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/ccl-folded-allgather-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/ccl-folded-allgather-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/ccl-folded-allgather-fix)