### PR TITLE
ttnn.topk: route large-k, wide/non-pow2 small-k, and MoE-gate shapes onto topk_large_indices (BH)

### DIFF
--- a/tests/sweep_framework/sweeps/reduction/topk/topk.py
+++ b/tests/sweep_framework/sweeps/reduction/topk/topk.py
@@ -56,11 +56,33 @@ parameters = {
             [0, 1, 2, 3],
         ],
         "largest": [True, False],
-        "k": [32],  # only k = 32 is supported for now
+        "k": [32],  # small-k suite; large k is swept by the "large_k" suite below
         "input_a_dtype": [ttnn.float32, ttnn.bfloat16, ttnn.bfloat8_b],
         "input_layout": [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT],
         "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
         "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG, ttnn.L1_MEMORY_CONFIG],
+    },
+    "large_k": {
+        # Large-k coverage (64 < k <= 2048). On Blackhole + bfloat16 + last-dim +
+        # largest these route through the ttnn.experimental.topk_large_indices
+        # composite (indices from the op, values gathered back from the
+        # original tensor — exact); everywhere else stock single-core would
+        # take seconds-to-minutes per vector, so those combinations are
+        # invalidated below rather than swept.
+        "input_shape": gen_shapes([1, 1, 1, 8192], [1, 1, 4, 131072], [1, 1, 1, 8192], 20)
+        + gen_shapes([1, 1, 1, 100000], [1, 1, 2, 100000], [1, 1, 1, 1], 2)
+        + gen_shapes([1, 1, 32, 8192], [1, 1, 64, 65536], [1, 1, 32, 8192], 6)
+        # Routed-envelope ceiling is 2^19: the value-recovery gather parks a
+        # full W * 2 B input row-stick in L1, so wider rows fall back to the
+        # stock single-core factory (seconds-to-minutes per vector here).
+        + gen_shapes([1, 1, 4, 262144], [1, 1, 8, 524288], [1, 1, 4, 262144], 4),
+        "dim": [-1],
+        "largest": [True],
+        "k": [96, 128, 256, 512, 1024, 2048],
+        "input_a_dtype": [ttnn.bfloat16],
+        "input_layout": [ttnn.TILE_LAYOUT],
+        "input_a_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
+        "output_memory_config": [ttnn.DRAM_MEMORY_CONFIG],
     },
     "xfail": {
         "input_shape": gen_shapes([1, 1, 32, 64], [6, 12, 256, 1024], [1, 1, 32, 64], 64)
@@ -101,6 +123,18 @@ parameters = {
 def invalidate_vector(test_vector) -> Tuple[bool, Optional[str]]:
     if len(test_vector["input_shape"]) != 4:
         return True, "Input shape must be 4D"
+    if test_vector["k"] > 64:
+        # The large_k suite covers the Blackhole routed path
+        # (ttnn.experimental.topk_large_indices). The standard sweep matrix
+        # schedules every regular module on the wormhole-n150 lane
+        # (compute_sweep_matrix.py: compute_standard_matrix) and has no
+        # Blackhole lane, so these vectors are pre-staged as INVALID: on WH
+        # the stock single-core factory takes seconds-to-minutes per vector
+        # (recorded as hangs, triggering device resets). Routed-path CI
+        # coverage lives in tests/ttnn/unit_tests/operations/reduce/
+        # test_topk.py (Blackhole-gated). Flip this to arch-conditional
+        # sub-checks when a Blackhole sweeps lane exists.
+        return True, "large_k suite is Blackhole-only (routed path); no Blackhole sweep lane yet"
     if test_vector["dim"] != -1:
         return True, "Only the last dim is supported right now"
     if test_vector["dim"] * (-1) > (len(test_vector["input_shape"])):
@@ -134,7 +168,20 @@ def run(
     data_seed = random.randint(0, 20000000)
     torch.manual_seed(data_seed)
 
-    input_shape = sanitize_shape(input_shape, "topk")
+    if k > 64:
+        # The large_k suite exists to cover the Blackhole routed path
+        # (ttnn.experimental.topk_large_indices). Elsewhere these vectors land
+        # on the stock linear single-core factory (seconds-to-minutes per
+        # vector against the 30s timeout, recorded as hangs). Generation-time
+        # invalidation cannot see the target arch (the generator is offline),
+        # so fail fast here instead.
+        assert "blackhole" in ttnn.get_arch_name().lower(), "large_k suite is Blackhole-only (routed path)"
+        # sanitize_shape rounds the last dim up to the next power of two,
+        # which would silently retarget the non-pow2 vectors (e.g. W=100000)
+        # onto already-covered pow2 widths. Non-pow2 width is one of the two
+        # structural reasons the routed path exists — run the declared shape.
+    else:
+        input_shape = sanitize_shape(input_shape, "topk")
 
     torch_input_tensor_a = gen_func_with_cast_tt(
         partial(torch_random, low=-100, high=100, dtype=torch.float32), input_a_dtype

--- a/tests/ttnn/unit_tests/operations/reduce/_topk_route_cells_bench.py
+++ b/tests/ttnn/unit_tests/operations/reduce/_topk_route_cells_bench.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""Per-cell composite bench for the ttnn.topk -> topk_large_indices routing
+boundary questions (review #53464): pow2-4096 arm and tiny-width large-k
+floor. One cell per invocation; run under `python -m tracy -r -v` and sum
+DEVICE KERNEL DURATION over the report CSV.
+
+Usage: _topk_route_cells_bench.py <H> <W> <k> <routed|stock>
+`stock` forces the stock engine by passing sub_core_grids (the routing
+predicate declines whenever sub_core_grids is provided).
+"""
+import sys
+import torch
+import ttnn
+from loguru import logger
+
+H, W, K = int(sys.argv[1]), int(sys.argv[2]), int(sys.argv[3])
+ARM = sys.argv[4]
+WARMUP, ITERS = 3, 30
+
+device = ttnn.open_device(device_id=0)
+device.enable_program_cache()
+
+torch.manual_seed(2005)
+torch_input = torch.randn(1, 1, H, W, dtype=torch.bfloat16) * 0.9
+tt_input = ttnn.from_torch(torch_input, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
+
+kwargs = dict(dim=-1, largest=True, sorted=True)
+if ARM == "stock":
+    grid = device.compute_with_storage_grid_size()
+    kwargs["sub_core_grids"] = ttnn.CoreRangeSet(
+        [ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))]
+    )
+
+for _ in range(WARMUP + ITERS):
+    values, indices = ttnn.topk(tt_input, K, **kwargs)
+    ttnn.synchronize_device(device)
+
+logger.info(f"BENCH_DONE H={H} W={W} k={K} arm={ARM} iters={WARMUP + ITERS}")
+ttnn.close_device(device)

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -546,3 +546,206 @@ def test_topk_multicore_values_beyond_first_tile_row(num_rows, largest, device):
     assert torch.allclose(
         got_s, ref_s, atol=1e-2
     ), f"values fabricated past first tile row: max_diff={(got_s - ref_s).abs().max():.4f}"
+
+
+# ---------------------------------------------------------------------------
+# Large-k Blackhole routing: ttnn.topk with bf16, dim=-1, largest=True,
+# stable=False and 64 < k <= 2048 is routed at the composite level through
+# ttnn.experimental.topk_large_indices (untilize -> clamp to lowest-finite
+# bf16 -> op -> gather of the ORIGINAL values by index -> tilize -> index
+# dtype match; a slice pair only when k is not a multiple of 16), bypassing
+# the single-core cliff (the device op's own multi-core path is gated at
+# k <= 64 + pow2 width + width < 65536).
+#
+# Tie semantics on the routed path: the returned index SET is a correct top-k
+# set with deterministic-but-unspecified tie order, so these tests assert
+# value-exactness (both sides sorted descending) and index validity
+# (input[index] == value, in-range, unique), never index-order equality.
+# ---------------------------------------------------------------------------
+
+from models.common.utility_functions import is_blackhole
+
+
+def run_topk_large_k_routed_test(N, C, H, W, k, device):
+    torch.manual_seed(2005)
+    shape = [N, C, H, W]
+    torch_input = torch.randn(shape, dtype=torch.bfloat16) * 0.9
+    ttnn_input = ttnn.from_torch(torch_input, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
+
+    pyt_values, _ = torch.topk(torch_input, k, dim=-1, largest=True, sorted=True)
+
+    ttnn_values, ttnn_indices = ttnn.topk(ttnn_input, k, dim=-1, largest=True, sorted=True)
+
+    # Index dtype contract must match the stock device op: UINT16 iff the
+    # tile-padded width fits 16 bits, else UINT32.
+    padded_w = 32 * ((W + 31) // 32)
+    uint16_expected = padded_w <= UINT16_MAX
+    assert ttnn_indices.dtype == (ttnn.uint16 if uint16_expected else ttnn.uint32)
+
+    desired_shape = [N, C, H, k]
+    assert list(ttnn_values.shape) == desired_shape
+    assert list(ttnn_indices.shape) == desired_shape
+
+    torch_values = ttnn.to_torch(ttnn_values)
+    torch_indices = ttnn.to_torch(ttnn_indices, dtype=torch.uint16 if uint16_expected else torch.uint32).to(torch.int64)
+
+    # Values: exact, order included -- both sides are sorted descending, so
+    # this holds even under ties.
+    assert_equal(torch_values, pyt_values)
+
+    # Indices: value-based validation (tie order is unspecified).
+    assert torch_indices.min() >= 0
+    assert torch_indices.max() < W
+    gathered = torch.gather(torch_input, -1, torch_indices)
+    assert_equal(gathered, torch_values)
+    for row_indices in torch_indices.reshape(-1, k):
+        assert row_indices.unique().numel() == k
+
+
+@pytest.mark.skipif(
+    not is_blackhole(), reason="large-k routing is Blackhole-only; stock single-core takes minutes at these shapes"
+)
+@pytest.mark.parametrize("k", [96, 128, 256, 512, 1024, 2048])
+@pytest.mark.parametrize("W", [8192, 32768, 65536, 131072])
+def test_topk_large_k_routed(k, W, device):
+    # All combos take the routed (topk_large_indices) path: bf16, dim=-1,
+    # largest=True, stable=False, 64 < k <= 2048, W <= 2^19.
+    run_topk_large_k_routed_test(1, 1, 32, W, k, device)
+
+
+@pytest.mark.skipif(
+    not is_blackhole(), reason="large-k routing is Blackhole-only; stock single-core takes minutes at these shapes"
+)
+@pytest.mark.parametrize("k", [512, 2048])
+def test_topk_large_k_routed_non_pow2_width(k, device):
+    # W=100000: neither a power of two nor 16-bit -- the old multi-core gates
+    # excluded it entirely; the routed path supports it natively.
+    run_topk_large_k_routed_test(1, 1, 32, 100000, k, device)
+
+
+@pytest.mark.skipif(
+    not is_blackhole(), reason="large-k routing is Blackhole-only; stock single-core takes minutes at these shapes"
+)
+@pytest.mark.parametrize("W", [262144, 524288])
+@pytest.mark.parametrize("k", [1536, 2048])
+def test_topk_large_k_routed_wide(k, W, device):
+    # The routed envelope extends to 2^19 — the RM gather parks one full
+    # W * 2 B input row-stick in an L1 CB, so 2^20 would not fit Blackhole's
+    # 1.5 MB budget (see large_k_route_max_width in topk.cpp). Fewer rows
+    # keep host-side reference cost and transfer size sane at these widths.
+    run_topk_large_k_routed_test(1, 1, 8, W, k, device)
+
+
+@pytest.mark.skipif(
+    not is_blackhole(), reason="large-k routing is Blackhole-only; stock single-core takes minutes at these shapes"
+)
+def test_topk_large_k_routed_single_row(device):
+    # A single logical row engages topk_large_indices' column-parallel
+    # (intra-row multi-core) factory underneath the routed composite.
+    run_topk_large_k_routed_test(1, 1, 1, 65536, 2048, device)
+
+
+@pytest.mark.skipif(
+    not is_blackhole(), reason="large-k routing is Blackhole-only; stock single-core takes minutes at these shapes"
+)
+def test_topk_large_k_routed_neginf_lanes(device):
+    # Rows whose top-k contains exact -inf: the routed path clamps the op's
+    # input to the lowest finite bf16 (the op then sees no -inf and stamps a
+    # REAL source position for every lane — its 0xFFFFFFFF sentinel never
+    # fires) and gathers values from the ORIGINAL tensor, so -inf values are
+    # bit-exact and -inf lanes carry real positions (stock/torch parity).
+    # W=65536 is tile-aligned, so every returned index must be a real
+    # in-range column.
+    torch.manual_seed(2005)
+    W, k, finite_count = 65536, 512, 100  # W=65536 -> tile-padded > 65535 -> uint32 indices
+    torch_input = torch.full((1, 1, 32, W), -float("inf"), dtype=torch.bfloat16)
+    finite = (torch.randn(1, 1, 32, finite_count) * 0.9).to(torch.bfloat16)
+    torch_input[..., :finite_count] = finite
+
+    ttnn_input = ttnn.from_torch(torch_input, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
+    ttnn_values, ttnn_indices = ttnn.topk(ttnn_input, k, dim=-1, largest=True, sorted=True)
+    assert ttnn_indices.dtype == ttnn.uint32
+
+    torch_values = ttnn.to_torch(ttnn_values)
+    torch_indices = ttnn.to_torch(ttnn_indices, dtype=torch.uint32).to(torch.int64)
+    pyt_values, _ = torch.topk(torch_input, k, dim=-1, largest=True, sorted=True)
+
+    # Values match torch exactly, including the -inf tail.
+    assert_equal(torch_values, pyt_values)
+
+    # ALL lanes (finite and -inf alike) carry real, in-range, unique,
+    # self-consistent indices -- no sentinel anywhere.
+    assert torch_indices.min() >= 0
+    assert torch_indices.max() < W
+    gathered = torch.gather(torch_input, -1, torch_indices)
+    assert_equal(gathered, torch_values)
+    for row_indices in torch_indices.reshape(-1, k):
+        assert row_indices.unique().numel() == k
+    # The finite lanes specifically must point into the finite prefix.
+    assert torch_indices[..., :finite_count].max() < finite_count
+
+
+@pytest.mark.skipif(not is_blackhole(), reason="fallback-path guards mirror the Blackhole routing predicate")
+def test_topk_large_k_routing_fallbacks(device):
+    # Shapes/args just OUTSIDE the routing predicate must keep the stock
+    # (device-op) path and stay correct. Kept at W=8192 so the stock
+    # single-core runs are fast.
+    W = 8192
+
+    # k=2049 exceeds the topk_large_indices ceiling (2048) -> stock path.
+    run_topk_test(1, 1, 32, W, 2049, ttnn.bfloat16, 3, True, True, device)
+
+    # largest=False is not supported by topk_large_indices -> stock path.
+    run_topk_test(1, 1, 32, W, 512, ttnn.bfloat16, 3, True, False, device)
+
+    # stable=True promises lowest-index tie-breaking -> stock path. A
+    # constant row makes this a real guard: stable top-96 of an all-equal
+    # row MUST return indices 0..95 in order, which the routed (non-stable)
+    # engine does not promise -- so this asserts INDICES, not just values.
+    # (Value-only asserts pass on either engine and would not catch the
+    # stable guard being deleted from the routing predicate.)
+    torch_input = torch.ones(1, 1, 32, W, dtype=torch.bfloat16)
+    ttnn_input = ttnn.from_torch(torch_input, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
+    ttnn_values, ttnn_indices = ttnn.topk(ttnn_input, 96, dim=-1, largest=True, sorted=True, stable=True)
+    assert_equal(ttnn.to_torch(ttnn_values), torch.ones(1, 1, 32, 96, dtype=torch.bfloat16))
+    expected_indices = torch.arange(96, dtype=torch.int64).expand(1, 1, 32, 96)
+    assert_equal(ttnn.to_torch(ttnn_indices).to(torch.int64), expected_indices)
+
+
+@pytest.mark.skipif(
+    not is_blackhole(), reason="large-k routing is Blackhole-only; stock single-core takes minutes at these shapes"
+)
+def test_topk_routed_k_not_multiple_of_16(device):
+    # k=100 exercises the routed k % 16 != 0 tail: topk_large_indices
+    # requires a multiple of 16, so the op runs at k_rounded=112 and
+    # post_topk_transform slices back down to 100.
+    run_topk_large_k_routed_test(1, 1, 32, 8192, 100, device)
+
+
+
+@pytest.mark.skipif(not is_blackhole(), reason="routing predicate is Blackhole-only")
+def test_topk_large_k_routing_engages(device):
+    # Guards the routing predicate itself: outputs alone are also satisfied
+    # by the stock path, so a silently narrowed predicate would demote the
+    # whole routed suite to stock with everything still green. Graph capture
+    # shows which ops actually ran.
+    torch.manual_seed(2005)
+    torch_input = torch.randn(1, 1, 32, 8192, dtype=torch.bfloat16) * 0.9
+    ttnn_input = ttnn.from_torch(torch_input, ttnn.bfloat16, layout=ttnn.Layout.TILE, device=device)
+
+    def ran_large_indices(captured) -> bool:
+        # The device op surfaces as TopkLargeIndices*/topk_large_indices
+        # depending on node type; normalize before matching.
+        return "largeindices" in str(captured).lower().replace("_", "")
+
+    # Routed shape (k=96 > 64): topk_large_indices must appear in the trace.
+    ttnn.graph.begin_graph_capture()
+    ttnn.topk(ttnn_input, 96, dim=-1, largest=True, sorted=True)
+    assert ran_large_indices(ttnn.graph.end_graph_capture())
+
+    # Stock shape (k=32, pow2 width >= 8192 -> multi-core bitonic eligible):
+    # the routed op must NOT appear.
+    ttnn.graph.begin_graph_capture()
+    ttnn.topk(ttnn_input, 32, dim=-1, largest=True, sorted=True)
+    assert not ran_large_indices(ttnn.graph.end_graph_capture())
+

--- a/tests/ttnn/unit_tests/operations/reduce/test_topk.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_topk.py
@@ -551,10 +551,13 @@ def test_topk_multicore_values_beyond_first_tile_row(num_rows, largest, device):
 # ---------------------------------------------------------------------------
 # Large-k Blackhole routing: ttnn.topk with bf16, dim=-1, largest=True,
 # stable=False and 64 < k <= 2048 is routed at the composite level through
-# ttnn.experimental.topk_large_indices (untilize -> clamp to lowest-finite
-# bf16 -> op -> gather of the ORIGINAL values by index -> tilize -> index
-# dtype match; a slice pair only when k is not a multiple of 16), bypassing
-# the single-core cliff (the device op's own multi-core path is gated at
+# ttnn.experimental.topk_large_indices (fused untilize+clamp to lowest-finite
+# bf16 — the private topk_route_prep device op, exercised by EVERY routed
+# call below -> op -> fused gather of the ORIGINAL values straight from the
+# TILE source + TILE assembly of both outputs + index dtype emit — the
+# private topk_route_finish device op, also exercised by EVERY routed call;
+# a slice pair only when k is not a multiple of 16), bypassing the
+# single-core cliff (the device op's own multi-core path is gated at
 # k <= 64 + pow2 width + width < 65536).
 #
 # Tie semantics on the routed path: the returned index SET is a correct top-k
@@ -629,11 +632,36 @@ def test_topk_large_k_routed_non_pow2_width(k, device):
 @pytest.mark.parametrize("W", [262144, 524288])
 @pytest.mark.parametrize("k", [1536, 2048])
 def test_topk_large_k_routed_wide(k, W, device):
-    # The routed envelope extends to 2^19 — the RM gather parks one full
-    # W * 2 B input row-stick in an L1 CB, so 2^20 would not fit Blackhole's
-    # 1.5 MB budget (see large_k_route_max_width in topk.cpp). Fewer rows
-    # keep host-side reference cost and transfer size sane at these widths.
+    # The routed envelope extends to 2^19 — kept from the gather-era L1
+    # constraint as the silicon-validated ceiling even though the fused
+    # topk_route_finish tail no longer stages full rows (see
+    # large_k_route_max_width in topk.cpp). Fewer rows keep host-side
+    # reference cost and transfer size sane at these widths.
     run_topk_large_k_routed_test(1, 1, 8, W, k, device)
+
+
+@pytest.mark.skipif(
+    not is_blackhole(), reason="large-k routing is Blackhole-only; stock single-core takes minutes at these shapes"
+)
+def test_topk_large_k_routed_ragged_shape(device):
+    # H=30 and W=4999, neither a multiple of 32: the fused topk_route_prep
+    # writer must emit ONLY the logical sticks/columns (tile padding dropped
+    # on both axes), and W=4999 -> 157 width-tiles (prime) forces its
+    # bw_last=5 remainder blocks on every tile-row. Every other routed cell
+    # is 32-aligned, so this is the lone cover for both clamps.
+    run_topk_large_k_routed_test(1, 1, 30, 4999, 96, device)
+
+
+@pytest.mark.skipif(
+    not is_blackhole(), reason="large-k routing is Blackhole-only; stock single-core takes minutes at these shapes"
+)
+def test_topk_large_k_routed_ragged_tall(device):
+    # TALL ragged: enough tile-rows that cores own MULTIPLE prep blocks
+    # crossing tile-row boundaries (nblocks = 7 * ceil(157/8) = 140 > grid),
+    # which desynchronizes the prep input-CB read pointer on the bw_last
+    # remainder blocks -- the wrap hazard the flat 30-row ragged cell is
+    # structurally blind to (1 block/core there).
+    run_topk_large_k_routed_test(1, 1, 224, 4999, 96, device)
 
 
 @pytest.mark.skipif(
@@ -718,9 +746,22 @@ def test_topk_large_k_routing_fallbacks(device):
 def test_topk_routed_k_not_multiple_of_16(device):
     # k=100 exercises the routed k % 16 != 0 tail: topk_large_indices
     # requires a multiple of 16, so the op runs at k_rounded=112 and
-    # post_topk_transform slices back down to 100.
+    # post_topk_transform slices back down to 100. k_rounded=112 is also the
+    # suite's only k_rounded % 32 == 16 cell: topk_route_finish's last output
+    # tile is half k-padding (its right face pair must stay zero-filled).
     run_topk_large_k_routed_test(1, 1, 32, 8192, 100, device)
 
+
+@pytest.mark.skipif(
+    not is_blackhole(), reason="large-k routing is Blackhole-only; stock single-core takes minutes at these shapes"
+)
+def test_topk_large_k_routed_multi_tile_rows(device):
+    # H=96 (3 row-tiles) x C=2 batches: topk_route_finish decomposes its work
+    # units over GLOBAL tile rows (batch * R_p/32 + rt) and pages the source
+    # gather at row_tile * width_tiles + idx/32 — every other routed cell has
+    # H <= 32 and a single batch (row_tile == 0, batch == 0 throughout), which
+    # would leave that decomposition entirely uncovered.
+    run_topk_large_k_routed_test(1, 2, 96, 8192, 96, device)
 
 
 @pytest.mark.skipif(not is_blackhole(), reason="routing predicate is Blackhole-only")
@@ -748,4 +789,3 @@ def test_topk_large_k_routing_engages(device):
     ttnn.graph.begin_graph_capture()
     ttnn.topk(ttnn_input, 32, dim=-1, largest=True, sorted=True)
     assert not ran_large_indices(ttnn.graph.end_graph_capture())
-

--- a/ttnn/cpp/ttnn/operations/reduction/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/reduction/sources.cmake
@@ -43,6 +43,10 @@ set(TTNN_OP_REDUCTION_SRCS
     topk/topk.cpp
     topk/device/topk_single_core_program_factory.cpp
     topk/device/topk_multi_core_program_factory.cpp
+    topk/device/topk_route_prep_device_operation.cpp
+    topk/device/topk_route_prep_program_factory.cpp
+    topk/device/topk_route_finish_device_operation.cpp
+    topk/device/topk_route_finish_program_factory.cpp
     reduction_common/reduction_common.cpp
     reduce_op_validation.cpp
     manual_seed/manual_seed.cpp

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_route_prep_untilize_clamp.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_route_prep_untilize_clamp.cpp
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// topk_route_prep compute: fused untilize + clamp for ttnn.topk's large-k routing
+// composite. Skeleton mirrors the standard copy_tile -> DEST -> pack_untilize_dest
+// pattern (see e.g. data_movement/permute/device/kernels/compute/
+// transpose_xw_rm_single_tile_size.cpp), with a unary_max pass injected while the
+// tiles sit in DEST.
+//
+// Per block of bw tiles (bw = min(DEST capacity, tiles left in the tile-row); the
+// factory passes the two possible widths as compile args): copy each tile into
+// DEST, floor it at CLAMP_BITS — the fp32 bit pattern of the lowest finite bf16
+// (0xFF7F0000, i.e. -3.3895313892515355e38; see the factory for the derivation and
+// topk.cpp's clamp-trick contract for why — then pack_untilize the block into one
+// output-CB page (32 sticks of bw*32 elements).
+
+#include <cstdint>
+
+#include "api/compute/compute_kernel_api.h"  // unary_max_tile(_init)
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/pack_untilize.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "ttnn/cpp/ttnn/kernel_lib/dest_helpers.hpp"  // compute_kernel_lib::DEST_AUTO_LIMIT
+
+namespace {
+
+template <uint32_t bw, uint32_t cb_in, uint32_t cb_out>
+ALWI void clamp_untilize_block(DataflowBuffer& dfb_in, DataflowBuffer& dfb_out) {
+    dfb_out.reserve_back(1);  // one output page holds the whole untilized block
+
+    tile_regs_acquire();
+    // Consume per tile at CB index 0: indexed reads past index 0 do NO wrap
+    // arithmetic (llk_unpack_A computes rd_ptr + index*page and the front can
+    // straddle fifo_limit once mixed bw_full/bw_last pops desynchronize the
+    // read pointer on width_tiles % bw_full != 0 tensors) -- index 0 after a
+    // per-tile pop is the one always-wrap-safe access pattern.
+    for (uint32_t j = 0; j < bw; ++j) {
+        dfb_in.wait_front(1);
+        copy_tile(cb_in, 0, j);
+        dfb_in.pop_front(1);
+    }
+    for (uint32_t j = 0; j < bw; ++j) {
+        unary_max_tile(j, CLAMP_BITS);
+    }
+    tile_regs_commit();
+
+    tile_regs_wait();
+    pack_untilize_dest<bw>(cb_out);
+    tile_regs_release();
+
+    dfb_out.push_back(1);
+}
+
+}  // namespace
+
+void kernel_main() {
+    constexpr uint32_t bw_full = get_compile_time_arg_val(0);
+    constexpr uint32_t bw_last = get_compile_time_arg_val(1);  // remainder block width, in [1, bw_full]
+    constexpr uint32_t cb_in = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_out = get_compile_time_arg_val(3);
+
+    // The factory sizes bw_full for bf16 half-sync DEST; keep it honest at compile time.
+    static_assert(bw_full >= 1 && bw_full <= compute_kernel_lib::DEST_AUTO_LIMIT, "block width exceeds DEST capacity");
+    static_assert(bw_last >= 1 && bw_last <= bw_full, "remainder block width out of range");
+
+    const uint32_t nblocks = get_arg_val<uint32_t>(0);
+    const uint32_t start_block = get_arg_val<uint32_t>(1);
+    const uint32_t nblocks_per_row = get_arg_val<uint32_t>(2);
+
+    DataflowBuffer dfb_in(cb_in);
+    DataflowBuffer dfb_out(cb_out);
+
+    compute_kernel_hw_startup(cb_in, cb_out);
+    unary_op_init_common(cb_in, cb_out);
+    unary_max_tile_init();
+    pack_untilize_dest_init<bw_full>(cb_out);
+
+    // Blocks are tile-row-major; only the last block of each tile-row is bw_last wide.
+    uint32_t pos = start_block % nblocks_per_row;
+    for (uint32_t b = 0; b < nblocks; ++b) {
+        const bool last_in_row = (pos == nblocks_per_row - 1);
+        if constexpr (bw_last == bw_full) {
+            clamp_untilize_block<bw_full, cb_in, cb_out>(dfb_in, dfb_out);
+        } else {
+            if (last_in_row) {
+                // The packer is configured per block width; swap it around the remainder block.
+                pack_untilize_uninit(cb_out);
+                pack_untilize_dest_init<bw_last>(cb_out);
+                clamp_untilize_block<bw_last, cb_in, cb_out>(dfb_in, dfb_out);
+                pack_untilize_uninit(cb_out);
+                pack_untilize_dest_init<bw_full>(cb_out);
+            } else {
+                clamp_untilize_block<bw_full, cb_in, cb_out>(dfb_in, dfb_out);
+            }
+        }
+        pos = last_in_row ? 0 : pos + 1;
+    }
+
+    pack_untilize_uninit(cb_out);
+}

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_topk_route_finish_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_topk_route_finish_gather.cpp
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// topk_route_finish reader: per work unit (one 16-row face-pair half of one output tile),
+// gather THIS RISC'S SHARE of the selected bf16 logits straight out of the TILE-layout
+// source and assemble it into the unit's value and index staging halves. The gather is
+// split across both data-movement RISCs: this reader (BRISC) owns unit rows [0, 8), the
+// writer (NCRISC) owns rows [8, 16) — see topk_route_finish_gather_common.hpp for the
+// row-disjointness argument and the trid double-wave pipeline both sides share.
+//
+// Per unit(row_tile, kt, half):
+//   1. Issue the reads for this RISC's <=8 index-stick segments: for each valid owned row,
+//      a valid_cols*4 B slice of that row's RM u32 index stick at byte offset kt*128
+//      (both 64 B aligned -- Blackhole DRAM reads require 64 B alignment on both ends).
+//   2. Zero THIS RISC's row ranges of both staging halves while the stick reads fly
+//      (always: cheaper than tracking which of the four padding cases applies, and it
+//      guarantees the zero-filled-tile-padding contract). The writer zeroes rows [8, 16).
+//   3. Barrier the stick reads, then gather each selected element with a 64 B NoC read
+//      from the source tile's face-row region into a rotating bounce slot — 32-deep waves
+//      on alternating trids, retiring the previous wave while the current one flies.
+//   4. Push both halves to the writer. The push carries only "rows [0, 8) and their zero
+//      fill are done"; the writer completes rows [8, 16) itself before writing out.
+//
+// TILE face math (32x32 tile = four 16x16 faces stored contiguously, [f0|f1 / f2|f3],
+// bf16 face = 512 B, face row = 32 B):
+//
+//   SOURCE side -- element (wr, wc) of a tile, wr = row & 31, wc = idx & 31:
+//     byte = (wr>>4)<<10 | (wc>>4)<<9 | (wr&15)<<5 | (wc&15)<<1
+//   (face index (wr>>4)*2 + (wc>>4) selects a 512 B face, (wr&15) the 32 B face row,
+//   (wc&15) the 2 B element). The unit spans one source row-tile, so the source page is
+//   row_tile*width_tiles + (idx>>5) and wr = half*16 + lr for local row lr in [0,16).
+//
+//   OUTPUT side -- the unit IS one face-pair of the output tile: rows
+//   [half*16, half*16+16) are faces {2*half, 2*half+1}, i.e. bytes
+//   [half*1024, half*1024+1024) of the 2048 B bf16 tile page. For output element
+//   (lr, c) (c = column within the output tile, c < 32): wr_out = half*16 + lr, so
+//   wr_out>>4 == half and wr_out&15 == lr, and the full-tile formula splits into the
+//   page base half*1024 (applied by the WRITER as the page offset) plus the staging
+//   offset
+//     off16 = (c>>4)<<9 | lr<<5 | (c&15)<<1
+//   -- the staging half is byte-for-byte the tile's face-pair range, so the writer can
+//   blast it with one contiguous write. The u32 index staging doubles every term
+//   (4 B elements, 1024 B faces, 64 B face rows), i.e. off32 = off16 << 1; u16 index
+//   staging uses off16 unchanged.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+#include "topk_route_finish_gather_common.hpp"
+
+void kernel_main() {
+    using namespace topk_route_finish;
+
+    const uint32_t src_addr = get_arg_val<uint32_t>(0);  // TILE bf16 logits
+    const uint32_t idx_addr = get_arg_val<uint32_t>(1);  // RM u32 index sticks
+    const uint32_t start_unit = get_arg_val<uint32_t>(2);
+    const uint32_t num_units = get_arg_val<uint32_t>(3);
+    const uint32_t logical_rows = get_arg_val<uint32_t>(4);         // R
+    const uint32_t row_tiles_per_batch = get_arg_val<uint32_t>(5);  // R_p / 32
+    const uint32_t k_rounded = get_arg_val<uint32_t>(6);
+
+    constexpr uint32_t k_tiles = get_compile_time_arg_val(0);      // div_up(k_rounded, 32)
+    constexpr uint32_t width_tiles = get_compile_time_arg_val(1);  // W_p / 32
+    constexpr uint32_t cb_stick = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_bounce = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_values = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_indices = get_compile_time_arg_val(5);
+    constexpr bool index_is_u32 = get_compile_time_arg_val(6) == 1;
+    constexpr auto src_args = TensorAccessorArgs<7>();
+    constexpr auto idx_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+
+    // Page sizes are baked compile-time by the host's TensorAccessorArgs (2048 B tiles /
+    // k_rounded*4 B sticks).
+    const auto src = TensorAccessor(src_args, src_addr);
+    const auto idx = TensorAccessor(idx_args, idx_addr);
+
+    Noc noc;
+    DataflowBuffer dfb_stick(cb_stick);    // reader-private scratch: never pushed
+    DataflowBuffer dfb_bounce(cb_bounce);  // reader-private scratch: never pushed
+    DataflowBuffer dfb_values(cb_values);
+    DataflowBuffer dfb_indices(cb_indices);
+
+    // Scratch bases are fixed for the whole kernel (1-page CBs, nothing pushed). The CB
+    // allocator aligns CB bases to the 64 B DRAM alignment, which the 64 B bounce slots
+    // and 128 B stick rows rely on.
+    const uint32_t stick_base = dfb_stick.get_write_ptr();
+    const uint32_t bounce_base = dfb_bounce.get_write_ptr();
+    const CoreLocalMem<uint32_t> stick_dst(stick_base);
+    const CoreLocalMem<uint32_t> bounce_dst(bounce_base);
+    volatile tt_l1_ptr uint32_t* const stick_l1 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(stick_base);
+
+    for (uint32_t u = start_unit; u < start_unit + num_units; ++u) {
+        const uint32_t row_tile = u / (k_tiles * 2);  // global (all batches)
+        const uint32_t rem = u % (k_tiles * 2);
+        const uint32_t kt = rem >> 1;
+        const uint32_t half = rem & 1;
+
+        const uint32_t batch = row_tile / row_tiles_per_batch;
+        const uint32_t row_in_batch0 = (row_tile % row_tiles_per_batch) * 32 + half * half_rows;
+
+        // Row clamp: rows at or past logical R are tile-height padding (stay zero). Units
+        // that are ALL padding still run: they exist to zero their face-pair. This RISC
+        // owns rows [0, 8) of the unit.
+        const uint32_t rows_left = row_in_batch0 < logical_rows ? logical_rows - row_in_batch0 : 0;
+        const uint32_t valid_rows = rows_left < half_rows ? rows_left : half_rows;
+        const uint32_t my_rows = valid_rows < rows_per_risc ? valid_rows : rows_per_risc;
+        // Column clamp: when k_rounded % 32 == 16, the last output tile's right face pair
+        // is k-padding (stays zero).
+        const uint32_t cols_left = k_rounded - kt * tile_width;
+        const uint32_t valid_cols = cols_left < tile_width ? cols_left : tile_width;
+
+        dfb_values.reserve_back(1);
+        dfb_indices.reserve_back(1);
+        const uint32_t val_base = dfb_values.get_write_ptr();
+        const uint32_t idx_out_base = dfb_indices.get_write_ptr();
+
+        // Issue this RISC's stick-segment reads first so their flight overlaps the
+        // zero-fill below: row lr's stick is page batch*R + row_in_batch0 + lr; the unit's
+        // columns start at u32 offset kt*32.
+        for (uint32_t lr = 0; lr < my_rows; ++lr) {
+            noc.async_read(
+                idx,
+                stick_dst,
+                valid_cols * 4,
+                {.page_id = batch * logical_rows + row_in_batch0 + lr, .offset_bytes = kt * stick_seg_bytes},
+                {.offset_bytes = lr * stick_seg_bytes});
+        }
+
+        // Zero this RISC's row ranges of both staging halves. Covers all padding cases at
+        // once (row padding, k-padding, R==0 units, garbage-guarding fresh CB pages); the
+        // writer zeroes rows [8, 16) — every staging byte is zeroed by exactly one RISC.
+        zero_half_rows<2>(val_base, 0, rows_per_risc);
+        if constexpr (index_is_u32) {
+            zero_half_rows<4>(idx_out_base, 0, rows_per_risc);
+        } else {
+            zero_half_rows<2>(idx_out_base, 0, rows_per_risc);
+        }
+
+        if (my_rows > 0) {
+            // Plain barrier: only the stick reads are outstanding here (both gather trids
+            // were drained before the previous unit's push).
+            noc.async_read_barrier();
+            gather_unit_rows<index_is_u32>(
+                noc,
+                src,
+                bounce_dst,
+                bounce_base,
+                stick_l1,
+                val_base,
+                idx_out_base,
+                row_tile,
+                width_tiles,
+                half,
+                0,  // lr_begin: reader owns rows [0, 8)
+                my_rows,
+                valid_cols);
+        }
+
+        dfb_values.push_back(1);
+        dfb_indices.push_back(1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/topk_route_finish_gather_common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/topk_route_finish_gather_common.hpp
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared per-unit gather machinery for topk_route_finish, used by BOTH data-movement RISCs:
+// the reader (BRISC) gathers unit rows [0, 8) and the writer (NCRISC) gathers rows [8, 16).
+//
+// Row-split safety (why two RISCs may fill the same staging page concurrently): a staged
+// half is the output tile's face-pair range — two contiguous faces of 16 rows each, one
+// row = 16 elements. The staging offset of element (lr, c) is
+//   off16 = (c>>4)<<9 | lr<<5 | (c&15)<<1        (bf16 values / u16 indices; u32 doubles it)
+// so row lr occupies byte range [lr*32, lr*32+32) WITHIN each 512 B face: lr in [0,8)
+// touches only bytes [0,256) of each face, lr in [8,16) only [256,512). The two RISCs
+// therefore write disjoint 32 B face rows (disjoint words), both for the gather stores and
+// for the split zero-fill — no synchronization is needed on the staging bytes themselves.
+//
+// Wave pipeline (trid double-buffering): gather reads are issued in 32-deep waves whose
+// packets are tagged with alternating NoC transaction ids (wave_trid0 + parity). The tag is
+// applied through the sticky NOC_PACKET_TAG register — noc_async_read_set_trid() once per
+// wave; every read issued from the read cmd buffer inherits it until it is re-set (the same
+// stickiness Noc::set_async_read_state documents). While wave B's reads are in flight, wave
+// A is retired with a per-trid barrier (noc_async_read_barrier_with_trid via
+// Noc::async_read_barrier<NocOptions::TXN_ID>) followed by extraction — so extraction and
+// the next wave's issue overlap the previous wave's flight instead of every wave paying a
+// full-drain stall. The 64-slot bounce buffer holds exactly the two in-flight waves.
+// The tag register is sticky, so between waves the OTHER reads issued from the read cmd
+// buffer (index-stick reads) also carry the current wave trid; that is safe because every
+// read -- tagged or not -- bumps noc_reads_num_issued, making the plain read barrier a
+// global superset of any per-trid barrier. gather_unit_rows resets the tag to 0 before
+// returning so traffic after it is genuinely untagged. Waves use trids 1 and 2, at most
+// 32 reads outstanding per trid, far under the 255-per-trid hardware counter.
+
+#pragma once
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+namespace topk_route_finish {
+
+constexpr uint32_t tile_width = 32;
+constexpr uint32_t half_rows = 16;                    // rows per work unit (one face-pair)
+constexpr uint32_t rows_per_risc = 8;                 // reader rows [0,8), writer rows [8,16)
+constexpr uint32_t stick_seg_bytes = tile_width * 4;  // 128 B: 32 u32 indices
+constexpr uint32_t bounce_slot_bytes = 64;            // Blackhole DRAM-read alignment
+constexpr uint32_t gather_wave = 32;                  // reads in flight per trid wave
+constexpr uint32_t wave_trid0 = 1;                    // waves use trids {1, 2}; 0 stays untagged
+
+// Zero rows [lr0, lr1) of one staged half. elem_bytes = 2 (bf16 values / u16 indices) or
+// 4 (u32 indices); face/row strides scale with it (see off16 above: u32 doubles every term).
+template <uint32_t elem_bytes>
+inline void zero_half_rows(uint32_t base, uint32_t lr0, uint32_t lr1) {
+    constexpr uint32_t row_bytes = 16 * elem_bytes;  // 16 elements per face row
+    constexpr uint32_t face_bytes = 16 * row_bytes;  // 16 rows per face
+    for (uint32_t face = 0; face < 2; ++face) {
+        volatile tt_l1_ptr uint32_t* p =
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(base + face * face_bytes + lr0 * row_bytes);
+        for (uint32_t w = 0; w < (lr1 - lr0) * row_bytes / 4; ++w) {
+            p[w] = 0;
+        }
+    }
+}
+
+// Gather unit rows [lr_begin, lr_begin + nrows) into the staged halves.
+//
+// stick_l1 holds the calling RISC's staged index-stick segments, locally indexed: local row
+// j corresponds to global unit row lr = lr_begin + j. The caller must have barriered the
+// stick reads before calling. On return every gathered element has been extracted into the
+// staging halves and NO tagged reads remain outstanding (both wave trids are drained).
+template <bool index_is_u32, typename SrcAccessor>
+inline void gather_unit_rows(
+    const Noc& noc,
+    const SrcAccessor& src,
+    const CoreLocalMem<uint32_t>& bounce_dst,
+    uint32_t bounce_base,
+    volatile tt_l1_ptr uint32_t* stick_l1,
+    uint32_t val_base,
+    uint32_t idx_out_base,
+    uint32_t row_tile,
+    uint32_t width_tiles,
+    uint32_t half,
+    uint32_t lr_begin,
+    uint32_t nrows,
+    uint32_t valid_cols) {
+    // In-flight bookkeeping, one set per wave parity (RISC-private; never a NoC target).
+    uint16_t pend_off16[2][gather_wave];  // output staging offset (bf16/u16 flavor)
+    uint8_t pend_sub[2][gather_wave];     // element offset within the 64 B bounce slot
+    uint32_t pend_idxv[2][gather_wave];   // the gathered source index itself
+
+    auto extract = [&](uint32_t p, uint32_t count) {
+        const uint32_t slots = bounce_base + p * gather_wave * bounce_slot_bytes;
+        for (uint32_t s = 0; s < count; ++s) {
+            const uint16_t v =
+                *reinterpret_cast<volatile tt_l1_ptr uint16_t*>(slots + s * bounce_slot_bytes + pend_sub[p][s]);
+            *reinterpret_cast<volatile tt_l1_ptr uint16_t*>(val_base + pend_off16[p][s]) = v;
+            if constexpr (index_is_u32) {
+                *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(idx_out_base + (pend_off16[p][s] << 1)) =
+                    pend_idxv[p][s];
+            } else {
+                *reinterpret_cast<volatile tt_l1_ptr uint16_t*>(idx_out_base + pend_off16[p][s]) =
+                    static_cast<uint16_t>(pend_idxv[p][s]);
+            }
+        }
+    };
+
+    uint32_t parity = 0;
+    uint32_t cnt = 0;
+    bool other_in_flight = false;
+    noc_async_read_set_trid(wave_trid0, noc.get_noc_id());
+    for (uint32_t j = 0; j < nrows; ++j) {
+        const uint32_t lr = lr_begin + j;
+        for (uint32_t c = 0; c < valid_cols; ++c) {
+            const uint32_t index_value = stick_l1[j * tile_width + c];
+            // Source: wr = half*16 + lr, wc = index_value & 31 (see the reader's face math).
+            const uint32_t src_page = row_tile * width_tiles + (index_value >> 5);
+            const uint32_t byte =
+                (half << 10) | (((index_value >> 4) & 1) << 9) | (lr << 5) | ((index_value & 15) << 1);
+            noc.async_read(
+                src,
+                bounce_dst,
+                bounce_slot_bytes,
+                {.page_id = src_page, .offset_bytes = byte & ~(bounce_slot_bytes - 1)},
+                {.offset_bytes = (parity * gather_wave + cnt) * bounce_slot_bytes});
+            pend_sub[parity][cnt] = byte & (bounce_slot_bytes - 1);
+            pend_off16[parity][cnt] = (c >> 4) << 9 | lr << 5 | (c & 15) << 1;
+            pend_idxv[parity][cnt] = index_value;
+
+            if (++cnt == gather_wave) {
+                // This wave is full and in flight; before reusing the OTHER wave's slots,
+                // retire it.
+                if (other_in_flight) {
+                    noc.async_read_barrier<NocOptions::TXN_ID>({.trid = wave_trid0 + (parity ^ 1)});
+                    extract(parity ^ 1, gather_wave);
+                }
+                other_in_flight = true;
+                parity ^= 1;
+                cnt = 0;
+                noc_async_read_set_trid(wave_trid0 + parity, noc.get_noc_id());
+            }
+        }
+    }
+    // Drain. The full other-parity wave (if any) was issued before the current partial one.
+    if (other_in_flight) {
+        noc.async_read_barrier<NocOptions::TXN_ID>({.trid = wave_trid0 + (parity ^ 1)});
+        extract(parity ^ 1, gather_wave);
+    }
+    if (cnt > 0) {
+        noc.async_read_barrier<NocOptions::TXN_ID>({.trid = wave_trid0 + parity});
+        extract(parity, cnt);
+    }
+    // The tag register is sticky across kernel exit (firmware resets it at boot, not per
+    // launch): restore 0 so later reads -- this kernel's and the next kernel's on this
+    // RISC -- are untagged.
+    noc_async_read_set_trid(0, noc.get_noc_id());
+}
+
+}  // namespace topk_route_finish

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_topk_route_finish_tiles.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_topk_route_finish_tiles.cpp
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// topk_route_finish writer: gather THIS RISC'S SHARE of the per-unit load (unit rows
+// [8, 16); the reader owns rows [0, 8) — see topk_route_finish_gather_common.hpp for the
+// row-disjointness argument and the shared trid double-wave pipeline), then drain the
+// completed staged face-pair halves into the two TILE outputs. Each staged page is
+// byte-for-byte the output tile's face-pair range (see the reader's face-math comment), so
+// a unit is exactly two contiguous page writes:
+//
+//   unit(row_tile, kt, half) -> output page row_tile * k_tiles + kt,
+//     values:  1024 B at byte offset half * 1024 (bf16 tile page = 2048 B)
+//     indices: index_half_bytes at offset half * index_half_bytes (u16 page = 2048 B,
+//              u32 page = 4096 B)
+//
+// Both offsets are multiples of 16 B, satisfying the (write-side) DRAM/L1 NoC alignment.
+//
+// Split protocol (why this cannot deadlock or race): per unit u this kernel
+//   1. computes the unit's staging page addresses BEFORE wait_front — get_read_ptr() is
+//      plain local pointer state (fifo_rd_ptr), it never blocks, and it already points at
+//      the page unit u will occupy: both kernels walk the same unit order, this kernel is
+//      the CBs' only consumer, and its own pop of unit u-2 is what freed that page (units
+//      0 and 1 use never-touched pages). Writing into it before the reader's push is safe
+//      because everything this kernel writes (its zero-fill ranges and its gather stores)
+//      lives in rows [8, 16) — 32 B face rows the reader never touches (the reader's
+//      reserve_back only moves credits, it writes no bytes);
+//   2. zeroes its row ranges, reads its own <=8 index-stick segments into private scratch,
+//      and gathers rows [8, 16) into the staging page (per-trid barriers inside
+//      gather_unit_rows drain all of its reads before returning);
+//   3. THEN calls wait_front — the reader's push guarantees rows [0, 8) and their zero
+//      fill are complete — and only then issues the output writes, write-barriers, pops.
+// The only cross-RISC blocking edges are the single producer/consumer pair: the reader
+// blocks only in reserve_back (waiting on this kernel's pops) and its own NoC barriers
+// (hardware-bounded); this kernel blocks only in wait_front (waiting on the reader's
+// pushes) and its own NoC barriers. The gather happens strictly BEFORE wait_front and
+// blocks only on hardware-bounded barriers, so by induction on the unit index every unit
+// terminates — no wait cycle exists.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+#include "topk_route_finish_gather_common.hpp"
+
+void kernel_main() {
+    using namespace topk_route_finish;
+
+    const uint32_t values_addr = get_arg_val<uint32_t>(0);
+    const uint32_t indices_addr = get_arg_val<uint32_t>(1);
+    const uint32_t start_unit = get_arg_val<uint32_t>(2);
+    const uint32_t num_units = get_arg_val<uint32_t>(3);
+    const uint32_t src_addr = get_arg_val<uint32_t>(4);             // TILE bf16 logits
+    const uint32_t idx_addr = get_arg_val<uint32_t>(5);             // RM u32 index sticks
+    const uint32_t logical_rows = get_arg_val<uint32_t>(6);         // R
+    const uint32_t row_tiles_per_batch = get_arg_val<uint32_t>(7);  // R_p / 32
+    const uint32_t k_rounded = get_arg_val<uint32_t>(8);
+
+    constexpr uint32_t k_tiles = get_compile_time_arg_val(0);
+    constexpr uint32_t width_tiles = get_compile_time_arg_val(1);  // W_p / 32
+    constexpr uint32_t cb_values = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_indices = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_stick = get_compile_time_arg_val(4);          // writer-private scratch
+    constexpr uint32_t cb_bounce = get_compile_time_arg_val(5);         // writer-private scratch
+    constexpr uint32_t value_half_bytes = get_compile_time_arg_val(6);  // 1024
+    constexpr uint32_t index_half_bytes = get_compile_time_arg_val(7);  // 1024 (u16) / 2048 (u32)
+    constexpr bool index_is_u32 = get_compile_time_arg_val(8) == 1;
+    constexpr auto values_args = TensorAccessorArgs<9>();
+    constexpr auto indices_args = TensorAccessorArgs<values_args.next_compile_time_args_offset()>();
+    constexpr auto src_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
+    constexpr auto idx_args = TensorAccessorArgs<src_args.next_compile_time_args_offset()>();
+
+    // Page sizes (2048 B bf16 / 2048 or 4096 B index tiles, 2048 B source tiles /
+    // k_rounded*4 B sticks) are baked compile-time by the host's TensorAccessorArgs.
+    const auto values_out = TensorAccessor(values_args, values_addr);
+    const auto indices_out = TensorAccessor(indices_args, indices_addr);
+    const auto src = TensorAccessor(src_args, src_addr);
+    const auto idx = TensorAccessor(idx_args, idx_addr);
+
+    Noc noc;
+    DataflowBuffer dfb_values(cb_values);
+    DataflowBuffer dfb_indices(cb_indices);
+    DataflowBuffer dfb_stick(cb_stick);    // writer-private scratch: never pushed
+    DataflowBuffer dfb_bounce(cb_bounce);  // writer-private scratch: never pushed
+
+    // Scratch bases are fixed for the whole kernel (1-page CBs, nothing pushed); CB bases
+    // are 64 B aligned, which the bounce slots and 128 B stick rows rely on.
+    const uint32_t stick_base = dfb_stick.get_write_ptr();
+    const uint32_t bounce_base = dfb_bounce.get_write_ptr();
+    const CoreLocalMem<uint32_t> stick_dst(stick_base);
+    const CoreLocalMem<uint32_t> bounce_dst(bounce_base);
+    volatile tt_l1_ptr uint32_t* const stick_l1 = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(stick_base);
+
+    for (uint32_t u = start_unit; u < start_unit + num_units; ++u) {
+        const uint32_t row_tile = u / (k_tiles * 2);
+        const uint32_t rem = u % (k_tiles * 2);
+        const uint32_t kt = rem >> 1;
+        const uint32_t half = rem & 1;
+        const uint32_t page = row_tile * k_tiles + kt;
+
+        // Same clamps as the reader; this RISC owns rows [8, 16) of the unit.
+        const uint32_t batch = row_tile / row_tiles_per_batch;
+        const uint32_t row_in_batch0 = (row_tile % row_tiles_per_batch) * 32 + half * half_rows;
+        const uint32_t rows_left = row_in_batch0 < logical_rows ? logical_rows - row_in_batch0 : 0;
+        const uint32_t valid_rows = rows_left < half_rows ? rows_left : half_rows;
+        const uint32_t my_rows = valid_rows > rows_per_risc ? valid_rows - rows_per_risc : 0;
+        const uint32_t cols_left = k_rounded - kt * tile_width;
+        const uint32_t valid_cols = cols_left < tile_width ? cols_left : tile_width;
+
+        // Unit u's staging page addresses, read BEFORE wait_front (see the split-protocol
+        // comment at the top for why this is safe).
+        const uint32_t val_base = dfb_values.get_read_ptr();
+        const uint32_t idx_out_base = dfb_indices.get_read_ptr();
+
+        // Issue this RISC's stick-segment reads (rows [8, 8+my_rows), locally indexed from
+        // 0 in the private scratch) so their flight overlaps the zero-fill below.
+        for (uint32_t j = 0; j < my_rows; ++j) {
+            noc.async_read(
+                idx,
+                stick_dst,
+                valid_cols * 4,
+                {.page_id = batch * logical_rows + row_in_batch0 + rows_per_risc + j,
+                 .offset_bytes = kt * stick_seg_bytes},
+                {.offset_bytes = j * stick_seg_bytes});
+        }
+
+        // Zero this RISC's row ranges [8, 16) of both staging halves (the reader zeroes
+        // [0, 8) — every staging byte is zeroed by exactly one RISC).
+        zero_half_rows<2>(val_base, rows_per_risc, half_rows);
+        if constexpr (index_is_u32) {
+            zero_half_rows<4>(idx_out_base, rows_per_risc, half_rows);
+        } else {
+            zero_half_rows<2>(idx_out_base, rows_per_risc, half_rows);
+        }
+
+        if (my_rows > 0) {
+            // Plain barrier: only the stick reads are outstanding here (both gather trids
+            // were drained before the previous unit's output writes, and the previous
+            // unit's writes were write-barriered before its pop).
+            noc.async_read_barrier();
+            gather_unit_rows<index_is_u32>(
+                noc,
+                src,
+                bounce_dst,
+                bounce_base,
+                stick_l1,
+                val_base,
+                idx_out_base,
+                row_tile,
+                width_tiles,
+                half,
+                rows_per_risc,  // lr_begin: writer owns rows [8, 16)
+                my_rows,
+                valid_cols);
+        }
+
+        // The reader's push guarantees rows [0, 8) and their zero fill are complete; this
+        // kernel's own rows [8, 16) were completed above. The staged halves are now whole.
+        dfb_values.wait_front(1);
+        dfb_indices.wait_front(1);
+
+        noc.async_write(
+            CoreLocalMem<uint32_t>(val_base),
+            values_out,
+            value_half_bytes,
+            {.offset_bytes = 0},
+            {.page_id = page, .offset_bytes = half * value_half_bytes});
+        noc.async_write(
+            CoreLocalMem<uint32_t>(idx_out_base),
+            indices_out,
+            index_half_bytes,
+            {.offset_bytes = 0},
+            {.page_id = page, .offset_bytes = half * index_half_bytes});
+
+        // Both staged pages are about to be recycled by the reader; the writes must have
+        // fully landed before the credits go back.
+        noc.async_write_barrier();
+        dfb_values.pop_front(1);
+        dfb_indices.pop_front(1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_topk_route_prep_stick_layout.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_topk_route_prep_stick_layout.cpp
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// topk_route_prep writer. Copied-with-attribution from
+// ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/dataflow/
+// writer_unary_stick_layout_split_rows_interleaved_parallel_columns.cpp
+// (same structure: wait one untilized CB page, NoC-write its rows onto output
+// sticks, barrier, pop). Changes vs the source:
+//   1. Row clamp (the design's stated change): the last tile-row of each batch
+//      emits only min(32, R - rt*32) logical sticks, so tile-height padding
+//      never reaches the ROW_MAJOR output.
+//   2. Per-block (rt, wt) derivation + width clamp: the source writer's fixed
+//      per-core column offset is only valid for single-tile-row tensors (its
+//      parallelize-column factory), while this op splits a general tile grid
+//      into per-tile-row blocks — so each block derives its own stick ids and
+//      stick offset, and the last block of a row emits only the logical
+//      min(bw*32, W - wt0*32) columns (W_p > W tile-width padding dropped).
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
+    const uint32_t nblocks = get_arg_val<uint32_t>(1);
+    const uint32_t start_block = get_arg_val<uint32_t>(2);
+    const uint32_t nblocks_per_row = get_arg_val<uint32_t>(3);
+    const uint32_t tile_rows_per_batch = get_arg_val<uint32_t>(4);  // R_p / 32
+    const uint32_t logical_rows = get_arg_val<uint32_t>(5);         // R
+    const uint32_t logical_width = get_arg_val<uint32_t>(6);        // W
+
+    constexpr uint32_t bw_full = get_compile_time_arg_val(0);
+    constexpr uint32_t bw_last = get_compile_time_arg_val(1);
+    constexpr uint32_t cb_out = get_compile_time_arg_val(2);
+    constexpr auto dst_args = TensorAccessorArgs<3>();
+
+    constexpr uint32_t tile_height = 32;
+    constexpr uint32_t tile_width = 32;
+    constexpr uint32_t elem_bytes = 2;  // bf16 only (validated host-side)
+
+    // Output pages are W-element logical sticks; the accessor's page size is the
+    // compile-time AlignedPageSize baked in by TensorAccessorArgs on the host.
+    const auto s = TensorAccessor(dst_args, dst_addr);
+
+    Noc noc;
+    DataflowBuffer dfb_out(cb_out);
+
+    // Blocks are tile-row-major over all batches: block -> (tile_row = b / nblocks_per_row,
+    // pos = b % nblocks_per_row); tile_row -> (batch, row_in_batch). Maintained incrementally.
+    uint32_t pos = start_block % nblocks_per_row;
+    const uint32_t start_tile_row = start_block / nblocks_per_row;
+    uint32_t batch = start_tile_row / tile_rows_per_batch;
+    uint32_t row_in_batch = start_tile_row % tile_rows_per_batch;
+
+    for (uint32_t b = 0; b < nblocks; ++b) {
+        const bool last_in_row = (pos == nblocks_per_row - 1);
+        const uint32_t bw = last_in_row ? bw_last : bw_full;
+
+        // Row clamp: emit only the logical sticks of a height-padded last tile-row.
+        const uint32_t first_row = row_in_batch * tile_height;
+        const uint32_t rows_left = logical_rows - first_row;
+        const uint32_t nrows = rows_left < tile_height ? rows_left : tile_height;
+
+        // Width clamp: emit only the logical columns of a width-padded last block.
+        const uint32_t col0 = pos * bw_full * tile_width;
+        const uint32_t cols_left = logical_width - col0;
+        const uint32_t block_cols = bw * tile_width;
+        const uint32_t ncols = cols_left < block_cols ? cols_left : block_cols;
+
+        const uint32_t stick_offset_bytes = col0 * elem_bytes;
+        const uint32_t write_bytes = ncols * elem_bytes;
+        const uint32_t cb_stick_stride = bw * tile_width * elem_bytes;  // untilized block row pitch
+        const uint32_t base_stick = batch * logical_rows + first_row;
+
+        dfb_out.wait_front(1);
+        uint32_t l1_read_addr = dfb_out.get_read_ptr();
+        for (uint32_t k = 0; k < nrows; ++k) {
+            CoreLocalMem<uint32_t> src(l1_read_addr);
+            noc.async_write(
+                src,
+                s,
+                write_bytes,
+                {.offset_bytes = 0},
+                {.page_id = base_stick + k, .offset_bytes = stick_offset_bytes});
+            l1_read_addr += cb_stick_stride;
+        }
+        noc.async_write_barrier();
+        dfb_out.pop_front(1);
+
+        if (last_in_row) {
+            pos = 0;
+            if (++row_in_batch == tile_rows_per_batch) {
+                row_in_batch = 0;
+                ++batch;
+            }
+        } else {
+            ++pos;
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_route_finish_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_route_finish_device_operation.cpp
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "topk_route_finish_device_operation.hpp"
+
+#include <tt-metalium/constants.hpp>
+
+#include <limits>
+
+namespace ttnn::operations::reduction::topk_route_finish {
+
+namespace {
+
+void validate_static_args(const operation_attributes_t& /*attrs*/, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input_tensor;
+    const auto& indices = tensor_args.indices_tensor;
+
+    // These fields are part of the program hash; they are validated on cache miss before compiling
+    // the program and do not need to be rechecked on every cache hit.
+    TT_FATAL(input.layout() == Layout::TILE, "topk_route_finish logits input must be TILE layout");
+    TT_FATAL(input.dtype() == DataType::BFLOAT16, "topk_route_finish logits input must be BFLOAT16");
+    TT_FATAL(!input.memory_config().is_sharded(), "topk_route_finish logits input must use interleaved memory");
+    TT_FATAL(indices.layout() == Layout::ROW_MAJOR, "topk_route_finish indices input must be ROW_MAJOR");
+    TT_FATAL(indices.dtype() == DataType::UINT32, "topk_route_finish indices input must be UINT32");
+    TT_FATAL(!indices.memory_config().is_sharded(), "topk_route_finish indices input must use interleaved memory");
+}
+
+void validate_runtime_args(const operation_attributes_t& /*attrs*/, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input_tensor;
+    const auto& indices = tensor_args.indices_tensor;
+
+    TT_FATAL(input.storage_type() == StorageType::DEVICE, "topk_route_finish logits input must be on device");
+    TT_FATAL(input.buffer() != nullptr, "topk_route_finish logits input must have an allocated buffer");
+    TT_FATAL(indices.storage_type() == StorageType::DEVICE, "topk_route_finish indices input must be on device");
+    TT_FATAL(indices.buffer() != nullptr, "topk_route_finish indices input must have an allocated buffer");
+
+    const auto& input_shape = input.logical_shape();
+    const auto& indices_shape = indices.logical_shape();
+    TT_FATAL(input_shape.rank() >= 2, "topk_route_finish logits input must have rank >= 2");
+    TT_FATAL(
+        indices_shape.rank() == input_shape.rank(),
+        "topk_route_finish inputs must have equal rank, got {} and {}",
+        input_shape.rank(),
+        indices_shape.rank());
+    // The indices tensor is the logits' shape with the last dim swapped for k_rounded: the reader
+    // pages index sticks with (batch * R + row), so every leading dim (R included) must match.
+    for (int i = 0; i < static_cast<int>(input_shape.rank()) - 1; ++i) {
+        TT_FATAL(
+            indices_shape[i] == input_shape[i],
+            "topk_route_finish shape mismatch at dim {}: logits {}, indices {}",
+            i,
+            input_shape[i],
+            indices_shape[i]);
+    }
+    const uint32_t k_rounded = indices_shape[-1];
+    TT_FATAL(
+        k_rounded >= 16 && k_rounded % 16 == 0,
+        "topk_route_finish k_rounded must be a positive multiple of 16, got {}",
+        k_rounded);
+    TT_FATAL(
+        k_rounded <= input_shape[-1],
+        "topk_route_finish k_rounded {} must be <= the logits width {}",
+        k_rounded,
+        input_shape[-1]);
+}
+
+}  // namespace
+
+void TopkRouteFinishDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+    validate_runtime_args(attrs, tensor_args);
+}
+
+void TopkRouteFinishDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+    validate_static_args(attrs, tensor_args);
+    validate_runtime_args(attrs, tensor_args);
+}
+
+TopkRouteFinishDeviceOperation::program_factory_t TopkRouteFinishDeviceOperation::select_program_factory(
+    const operation_attributes_t& /*attrs*/, const tensor_args_t& /*tensor_args*/) {
+    return program::TopkRouteFinishProgramFactory{};
+}
+
+ttsl::hash::hash_t TopkRouteFinishDeviceOperation::compute_program_hash(
+    const operation_attributes_t& /*attrs*/, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input_tensor;
+    const auto& indices = tensor_args.indices_tensor;
+    const auto grid = input.device()->compute_with_storage_grid_size();
+
+    // Program-structure terms (see the program factory's work split):
+    //   - width_tiles (W_p / 32) feeds the reader's source-page math (compile arg);
+    //   - k_rounded fixes K_t = div_up(k_rounded, 32) (compile arg) AND the indices input
+    //     TensorAccessor's compile-time stick (page) size (k_rounded * 4 B);
+    //   - total_tile_rows (padded volume / W_p / 32) fixes the unit count and hence the
+    //     split_blocks_for_tilize core partition (which cores carry kernels is create-time state);
+    //   - index_is_u32 selects the output index dtype, its CB/staging sizes, and the output
+    //     TensorAccessor's page size (2048 vs 4096 B tiles).
+    // Logical R stays hash-free: it only feeds reader/writer runtime args (the per-unit valid-row
+    // clamp), re-derived from the tensors in override_runtime_arguments on every cache hit.
+    const auto& padded = input.padded_shape();
+    const uint32_t width_tiles = padded[-1] / tt::constants::TILE_WIDTH;
+    const uint32_t total_tile_rows = (input.physical_volume() / padded[-1]) / tt::constants::TILE_HEIGHT;
+    const uint32_t k_rounded = indices.logical_shape()[-1];
+    const bool index_is_u32 = padded[-1] > std::numeric_limits<uint16_t>::max();
+
+    return tt::tt_metal::operation::hash_operation<TopkRouteFinishDeviceOperation>(
+        input.dtype(),
+        input.layout(),
+        input.memory_config().memory_layout(),
+        input.memory_config().buffer_type(),
+        indices.dtype(),
+        indices.layout(),
+        indices.memory_config().memory_layout(),
+        indices.memory_config().buffer_type(),
+        grid.x,
+        grid.y,
+        width_tiles,
+        total_tile_rows,
+        k_rounded,
+        index_is_u32);
+}
+
+spec_return_value_t TopkRouteFinishDeviceOperation::compute_output_specs(
+    const operation_attributes_t& /*attrs*/, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input_tensor;
+    const auto& indices = tensor_args.indices_tensor;
+
+    // Both outputs: the logits' logical shape with the last dim swapped for k_rounded, TILE,
+    // same interleaved memory config as the logits — exactly what the unfused route's
+    // to_layout(TILE) pair produced.
+    ttnn::Shape output_shape = input.logical_shape();
+    output_shape[-1] = indices.logical_shape()[-1];
+
+    // Stock device-op index dtype contract (topk_device_operation.cpp compute_output_specs):
+    // UINT16 iff the TILE-PADDED source width fits 16 bits, else UINT32.
+    const DataType index_dtype =
+        input.padded_shape()[-1] <= std::numeric_limits<uint16_t>::max() ? DataType::UINT16 : DataType::UINT32;
+
+    return {
+        tt::tt_metal::TensorSpec(
+            output_shape,
+            tt::tt_metal::TensorLayout(
+                DataType::BFLOAT16, tt::tt_metal::PageConfig(Layout::TILE), input.memory_config())),
+        tt::tt_metal::TensorSpec(
+            output_shape,
+            tt::tt_metal::TensorLayout(index_dtype, tt::tt_metal::PageConfig(Layout::TILE), input.memory_config()))};
+}
+
+tensor_return_value_t TopkRouteFinishDeviceOperation::create_output_tensors(
+    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+    const auto specs = compute_output_specs(attrs, tensor_args);
+    auto* device = tensor_args.input_tensor.device();
+    return {create_device_tensor(std::get<0>(specs), device), create_device_tensor(std::get<1>(specs), device)};
+}
+
+std::tuple<TopkRouteFinishDeviceOperation::operation_attributes_t, TopkRouteFinishDeviceOperation::tensor_args_t>
+TopkRouteFinishDeviceOperation::invoke(const Tensor& input_tensor, const Tensor& indices_tensor) {
+    return {operation_attributes_t{}, tensor_args_t{.input_tensor = input_tensor, .indices_tensor = indices_tensor}};
+}
+
+}  // namespace ttnn::operations::reduction::topk_route_finish
+
+namespace ttnn::operations::reduction::topk {
+
+std::vector<Tensor> topk_route_finish(const Tensor& input_tensor, const Tensor& indices_tensor) {
+    using Op = ttnn::operations::reduction::topk_route_finish::TopkRouteFinishDeviceOperation;
+    auto [operation_attributes, tensor_args] = Op::invoke(input_tensor, indices_tensor);
+    auto [values, indices] = ttnn::device_operation::launch<Op>(operation_attributes, tensor_args);
+    std::vector<Tensor> result;
+    result.reserve(2);
+    result.push_back(std::move(values));
+    result.push_back(std::move(indices));
+    return result;
+}
+
+}  // namespace ttnn::operations::reduction::topk

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_route_finish_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_route_finish_device_operation.hpp
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tuple>
+#include <variant>
+#include <vector>
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+// topk_route_finish: PRIVATE finish op for ttnn.topk's large-k Blackhole routing
+// composite (topk.cpp: run_topk_large_indices_route). Fuses the route's whole tail —
+// gather of the ORIGINAL values by index + TILE assembly of both outputs + index
+// dtype emit — into one kernel launch:
+//
+//   inputs:  (a) the ORIGINAL TILE bf16 logits [..., R, W], interleaved (DRAM or L1)
+//            (b) ROW_MAJOR UINT32 indices [..., R, k_rounded], interleaved — the
+//                topk_large_indices output (k_rounded a multiple of 16)
+//   outputs: values  = TILE bf16 [..., R, k_rounded] (tile padding zero-filled)
+//            indices = TILE [..., R, k_rounded], dtype UINT16 when the logits'
+//                      tile-padded width fits 16 bits, else UINT32 — the same
+//                      boundary as the stock device op's compute_output_specs.
+//
+// Values are gathered element-wise from the TILE-layout source (no untilize of the
+// original) and copied BIT-EXACT — -inf lanes included; see the -inf clamp-trick
+// contract in topk.cpp. It replaces the unfused to_layout(ROW_MAJOR) + chunked
+// ttnn::gather + 2x to_layout(TILE) + typecast tail of the routed composite.
+//
+// Not registered with nanobind; called only from the routing composite via the
+// ttnn::operations::reduction::topk::topk_route_finish() entry function below.
+
+namespace ttnn::operations::reduction::topk_route_finish {
+
+// Everything the program needs is derived from the two input tensors'
+// shapes/layouts, so the op carries no attributes.
+struct operation_attributes_t {};
+
+struct tensor_args_t {
+    Tensor input_tensor;    // ORIGINAL TILE bf16 logits
+    Tensor indices_tensor;  // ROW_MAJOR UINT32 top-k_rounded indices
+};
+
+using tensor_return_value_t = std::tuple<Tensor, Tensor>;  // {values, indices}
+using spec_return_value_t = std::tuple<tt::tt_metal::TensorSpec, tt::tt_metal::TensorSpec>;
+
+namespace program {
+
+struct TopkRouteFinishSharedVariables {
+    tt::tt_metal::KernelHandle reader_kernel_id{};
+    tt::tt_metal::KernelHandle writer_kernel_id{};
+    std::vector<CoreCoord> cores{};
+};
+
+struct TopkRouteFinishProgramFactory {
+    using shared_variables_t = TopkRouteFinishSharedVariables;
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace program
+
+struct TopkRouteFinishDeviceOperation {
+    using operation_attributes_t = topk_route_finish::operation_attributes_t;
+    using tensor_args_t = topk_route_finish::tensor_args_t;
+    using tensor_return_value_t = topk_route_finish::tensor_return_value_t;
+    using spec_return_value_t = topk_route_finish::spec_return_value_t;
+
+    using program_factory_t = std::variant<program::TopkRouteFinishProgramFactory>;
+
+    static program_factory_t select_program_factory(
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
+
+    static void validate_on_program_cache_miss(const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
+    static void validate_on_program_cache_hit(const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
+    static ttsl::hash::hash_t compute_program_hash(
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
+
+    static spec_return_value_t compute_output_specs(
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
+
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& input_tensor, const Tensor& indices_tensor);
+};
+
+}  // namespace ttnn::operations::reduction::topk_route_finish
+
+namespace ttnn::operations::reduction::topk {
+
+// C++-only entry point (no nanobind): fused TILE-source gather + tile assembly +
+// index dtype emit. Returns {values, indices}. Lives in the ::topk namespace (next
+// to the routing composite, its only caller), mirroring topk_route_prep.
+std::vector<Tensor> topk_route_finish(const Tensor& input_tensor, const Tensor& indices_tensor);
+
+}  // namespace ttnn::operations::reduction::topk

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_route_finish_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_route_finish_program_factory.cpp
@@ -1,0 +1,277 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Program factory for topk_route_finish (fused TILE-source gather + tile assembly + dtype emit).
+//
+// Work unit = HALF of one output tile (a 16-row face-pair): unit(row_tile, kt, half) covers
+// output rows [row_tile*32 + half*16, +16) x output cols [kt*32, +32), where row_tile is
+// GLOBAL (all batches, tile-row-major) and kt indexes the k_rounded axis in 32-column tiles.
+// Total units = total_tile_rows x K_t x 2, flat-listed unit-major and split across the full
+// worker grid with a single cliff core (split_blocks_for_tilize, like topk_route_prep).
+// Halves whose 16 rows are ALL tile-height padding (r >= logical R) are kept, not dropped:
+// freshly allocated output pages hold garbage, and the contract promises zero-filled tile
+// padding, so those units exist purely to write zeros.
+//
+// Per unit the gather load is SPLIT ACROSS BOTH RISCs: the reader (BRISC) owns unit rows
+// [0, 8) and the writer (NCRISC) rows [8, 16). Each side reads its own <=8 RM u32
+// index-stick segments into private scratch, zero-fills ITS row ranges of the two staging
+// halves (one CB page each; the two row ranges touch disjoint 32 B face rows, so both RISCs
+// may fill the same page concurrently — see topk_route_finish_gather_common.hpp), and
+// gathers each selected bf16 element with a 64 B NoC read from the source tile's face-row
+// into a rotating bounce slot. Gather reads are issued in 32-deep waves tagged with
+// alternating NoC transaction ids (trids 1/2); each wave is retired with a per-trid barrier
+// while the next wave's reads are in flight, so extraction overlaps flight instead of every
+// wave paying a full-drain stall. The writer computes unit u's staging address from its own
+// (never-blocking) read pointer BEFORE wait_front — safe because its own pop of unit u-2
+// freed that page — gathers its rows, THEN wait_fronts (reader's rows done) and blasts each
+// staged half contiguously into the output tile page at offset half * (page_size/2).
+// Handshake = the two staging CBs themselves (2 pages each): the reader's push means
+// "rows [0,8) + their zero fill done", the writer's pop means "page drained". The RISC
+// split adds no blocking edge beyond that single producer/consumer pair (the full
+// protocol + termination argument lives at the top of the writer kernel). No compute
+// kernel: values are copied bit-exact from the TILE source (see the canonicalization note
+// at the composite call site in topk.cpp).
+
+#include "topk_route_finish_device_operation.hpp"
+
+#include "ttnn/operations/core/work_split/work_split_tilize.hpp"
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/math.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+
+#include <limits>
+
+using namespace tt::constants;
+
+namespace ttnn::operations::reduction::topk_route_finish::program {
+
+namespace {
+
+constexpr uint32_t reader_stick_cb_index = tt::CBIndex::c_0;   // reader-private index-stick staging
+constexpr uint32_t reader_bounce_cb_index = tt::CBIndex::c_1;  // reader-private gather bounce slots
+constexpr uint32_t writer_stick_cb_index = tt::CBIndex::c_2;   // writer-private index-stick staging
+constexpr uint32_t writer_bounce_cb_index = tt::CBIndex::c_3;  // writer-private gather bounce slots
+constexpr uint32_t values_cb_index = tt::CBIndex::c_16;        // staged value face-pairs, reader -> writer
+constexpr uint32_t indices_cb_index = tt::CBIndex::c_17;       // staged index face-pairs, reader -> writer
+
+// The sizing constants below must mirror topk_route_finish_gather_common.hpp — keep the
+// two files in sync.
+//
+// Gather bounce buffers (one per RISC — each is that RISC's private scratch): 64 slots of
+// 64 B. 64 B slot size (not the elements' 2 B) because Blackhole's NoC requires 64 B
+// alignment on BOTH ends of a DRAM read (NOC_DRAM_READ_ALIGNMENT_BYTES); the gatherer
+// aligns each source face-row read down to a 64 B boundary within the 2048 B tile page and
+// extracts the bf16 at (byte & 63). The 64 slots hold the trid pipeline's two in-flight
+// 32-read waves.
+constexpr uint32_t bounce_slots = 64;
+constexpr uint32_t bounce_slot_bytes = 64;
+
+// Index-stick staging (one per RISC): one 128 B segment (32 u32 indices = one output tile
+// width) per owned unit row, 8 rows per RISC (reader rows [0,8), writer rows [8,16)).
+// kt*128 source offsets and 128 B row strides keep DRAM-read alignment.
+constexpr uint32_t stick_segment_bytes = TILE_WIDTH * sizeof(uint32_t);
+constexpr uint32_t stick_rows_per_risc = TILE_HEIGHT / 4;  // 8
+
+struct FinishWorkSplit {
+    uint32_t width_tiles = 0;          // logits W_p / 32
+    uint32_t total_tile_rows = 0;      // logits padded volume / W_p / 32 (all batches)
+    uint32_t row_tiles_per_batch = 0;  // logits R_p / 32
+    uint32_t k_tiles = 0;              // div_up(k_rounded, 32)
+    uint32_t k_rounded = 0;
+    uint32_t total_units = 0;  // total_tile_rows * k_tiles * 2 (two face-pair halves per tile)
+    bool index_is_u32 = false;
+};
+
+FinishWorkSplit compute_work_split(const Tensor& input, const Tensor& indices) {
+    FinishWorkSplit split;
+    const auto& padded = input.padded_shape();
+    split.width_tiles = padded[-1] / TILE_WIDTH;
+    split.total_tile_rows = (input.physical_volume() / padded[-1]) / TILE_HEIGHT;
+    split.row_tiles_per_batch = padded[-2] / TILE_HEIGHT;
+    split.k_rounded = indices.logical_shape()[-1];
+    split.k_tiles = tt::div_up(split.k_rounded, TILE_WIDTH);
+    split.total_units = split.total_tile_rows * split.k_tiles * 2;
+    split.index_is_u32 = padded[-1] > std::numeric_limits<uint16_t>::max();
+    return split;
+}
+
+// (Re)computes every runtime arg from the tensors. Called by create() and, on cache hits, by
+// override_runtime_arguments(); the program hash pins every structural input (core partition,
+// K_t/W_t, page sizes, index dtype), so only addresses and the logical-R/k_rounded clamps can
+// differ here.
+void set_runtime_args(
+    tt::tt_metal::Program& program,
+    const TopkRouteFinishSharedVariables& shared,
+    const Tensor& input,
+    const Tensor& indices,
+    const Tensor& values_out,
+    const Tensor& indices_out) {
+    const auto split = compute_work_split(input, indices);
+    const auto grid = input.device()->compute_with_storage_grid_size();
+    const auto unit_split = ttnn::split_blocks_for_tilize(CoreCoord(grid.x, grid.y), split.total_units);
+
+    const uint32_t logical_rows = input.logical_shape()[-2];
+
+    uint32_t start_unit = 0;
+    for (uint32_t i = 0; i < shared.cores.size(); ++i) {
+        const CoreCoord& core = shared.cores[i];
+        const bool is_cliff = unit_split.nblocks_per_core_cliff > 0 && i + 1 == shared.cores.size();
+        const uint32_t nunits_this_core = is_cliff ? unit_split.nblocks_per_core_cliff : unit_split.nblocks_per_core;
+
+        tt::tt_metal::SetRuntimeArgs(
+            program,
+            shared.reader_kernel_id,
+            core,
+            {input.buffer()->address(),    // src_addr (TILE bf16 logits)
+             indices.buffer()->address(),  // idx_addr (RM u32 sticks)
+             start_unit,
+             nunits_this_core,
+             logical_rows,               // R (per-unit valid-row clamp)
+             split.row_tiles_per_batch,  // R_p / 32 (unit -> batch decomposition)
+             split.k_rounded});          // per-unit valid-column clamp
+
+        tt::tt_metal::SetRuntimeArgs(
+            program,
+            shared.writer_kernel_id,
+            core,
+            {values_out.buffer()->address(),   // dst values
+             indices_out.buffer()->address(),  // dst indices
+             start_unit,
+             nunits_this_core,
+             input.buffer()->address(),    // src_addr (TILE bf16 logits, writer's gather rows)
+             indices.buffer()->address(),  // idx_addr (RM u32 sticks, writer's gather rows)
+             logical_rows,                 // R (per-unit valid-row clamp)
+             split.row_tiles_per_batch,    // R_p / 32 (unit -> batch decomposition)
+             split.k_rounded});            // per-unit valid-column clamp
+
+        start_unit += nunits_this_core;
+    }
+}
+
+}  // namespace
+
+TopkRouteFinishProgramFactory::cached_program_t TopkRouteFinishProgramFactory::create(
+    const operation_attributes_t& /*operation_attributes*/,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    const auto& input = tensor_args.input_tensor;
+    const auto& indices = tensor_args.indices_tensor;
+    const Tensor& values_out = std::get<0>(tensor_return_value);
+    const Tensor& indices_out = std::get<1>(tensor_return_value);
+
+    auto program = tt::tt_metal::CreateProgram();
+
+    const auto split = compute_work_split(input, indices);
+    const auto grid = input.device()->compute_with_storage_grid_size();
+    const auto unit_split = ttnn::split_blocks_for_tilize(CoreCoord(grid.x, grid.y), split.total_units);
+    const auto& all_cores = unit_split.all_cores;
+
+    const uint32_t value_tile_bytes = tt::tile_size(tt::DataFormat::Float16_b);  // 2048
+    const uint32_t value_half_bytes = value_tile_bytes / 2;                      // one face-pair
+    const uint32_t idx_elem_bytes = split.index_is_u32 ? 4 : 2;
+    const uint32_t idx_half_bytes = (TILE_HW / 2) * idx_elem_bytes;  // 512 elements per face-pair
+    const tt::DataFormat idx_format = split.index_is_u32 ? tt::DataFormat::UInt32 : tt::DataFormat::UInt16;
+
+    // Per-RISC private scratch (a stick-stage + bounce pair for EACH data-movement RISC),
+    // allocated as 1-page CBs (never pushed/popped, so the write pointer stays at the
+    // base). CB bases are aligned to the DRAM alignment (64 B) by the program CB
+    // allocator, which the 64 B bounce slots and 128 B stick rows rely on.
+    constexpr uint32_t stick_cb_bytes = stick_rows_per_risc * stick_segment_bytes;
+    for (const auto stick_cb_index : {reader_stick_cb_index, writer_stick_cb_index}) {
+        const auto stick_stage_cb_config =
+            tt::tt_metal::CircularBufferConfig(stick_cb_bytes, {{stick_cb_index, tt::DataFormat::UInt32}})
+                .set_page_size(stick_cb_index, stick_cb_bytes);
+        tt::tt_metal::CreateCircularBuffer(program, all_cores, stick_stage_cb_config);
+    }
+
+    for (const auto bounce_cb_index : {reader_bounce_cb_index, writer_bounce_cb_index}) {
+        const auto bounce_cb_config =
+            tt::tt_metal::CircularBufferConfig(
+                bounce_slots * bounce_slot_bytes, {{bounce_cb_index, tt::DataFormat::Float16_b}})
+                .set_page_size(bounce_cb_index, bounce_slots * bounce_slot_bytes);
+        tt::tt_metal::CreateCircularBuffer(program, all_cores, bounce_cb_config);
+    }
+
+    // Reader -> writer staging: one page per face-pair half, double-buffered. The page byte
+    // layout is EXACTLY the output tile's face-pair range, so the writer issues one
+    // contiguous write per page.
+    const auto values_cb_config =
+        tt::tt_metal::CircularBufferConfig(2 * value_half_bytes, {{values_cb_index, tt::DataFormat::Float16_b}})
+            .set_page_size(values_cb_index, value_half_bytes);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, values_cb_config);
+
+    const auto indices_cb_config =
+        tt::tt_metal::CircularBufferConfig(2 * idx_half_bytes, {{indices_cb_index, idx_format}})
+            .set_page_size(indices_cb_index, idx_half_bytes);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, indices_cb_config);
+
+    std::vector<uint32_t> reader_compile_args = {
+        split.k_tiles,
+        split.width_tiles,
+        reader_stick_cb_index,
+        reader_bounce_cb_index,
+        values_cb_index,
+        indices_cb_index,
+        split.index_is_u32 ? 1u : 0u};
+    tt::tt_metal::TensorAccessorArgs(*input.buffer()).append_to(reader_compile_args);
+    tt::tt_metal::TensorAccessorArgs(*indices.buffer()).append_to(reader_compile_args);
+    auto reader_kernel = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/reader_topk_route_finish_gather.cpp",
+        all_cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_args));
+
+    std::vector<uint32_t> writer_compile_args = {
+        split.k_tiles,
+        split.width_tiles,
+        values_cb_index,
+        indices_cb_index,
+        writer_stick_cb_index,
+        writer_bounce_cb_index,
+        value_half_bytes,
+        idx_half_bytes,
+        split.index_is_u32 ? 1u : 0u};
+    tt::tt_metal::TensorAccessorArgs(*values_out.buffer()).append_to(writer_compile_args);
+    tt::tt_metal::TensorAccessorArgs(*indices_out.buffer()).append_to(writer_compile_args);
+    tt::tt_metal::TensorAccessorArgs(*input.buffer()).append_to(writer_compile_args);
+    tt::tt_metal::TensorAccessorArgs(*indices.buffer()).append_to(writer_compile_args);
+    auto writer_kernel = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_topk_route_finish_tiles.cpp",
+        all_cores,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_args));
+
+    // split_blocks_for_tilize(CoreCoord, ...) places core i at (i % grid.x, i / grid.x), cliff
+    // last; enumerate in that exact order so the contiguous unit partition lines up.
+    std::vector<CoreCoord> cores;
+    cores.reserve(unit_split.ncores);
+    for (uint32_t i = 0; i < unit_split.ncores; ++i) {
+        cores.push_back(CoreCoord{i % grid.x, i / grid.x});
+    }
+
+    TopkRouteFinishSharedVariables shared{
+        .reader_kernel_id = reader_kernel, .writer_kernel_id = writer_kernel, .cores = std::move(cores)};
+    set_runtime_args(program, shared, input, indices, values_out, indices_out);
+
+    return cached_program_t{std::move(program), std::move(shared)};
+}
+
+void TopkRouteFinishProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& /*operation_attributes*/,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    set_runtime_args(
+        cached_program.program,
+        cached_program.shared_variables,
+        tensor_args.input_tensor,
+        tensor_args.indices_tensor,
+        std::get<0>(tensor_return_value),
+        std::get<1>(tensor_return_value));
+}
+
+}  // namespace ttnn::operations::reduction::topk_route_finish::program

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_route_prep_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_route_prep_device_operation.cpp
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "topk_route_prep_device_operation.hpp"
+
+#include <tt-metalium/constants.hpp>
+
+namespace ttnn::operations::reduction::topk_route_prep {
+
+namespace {
+
+void validate_static_args(const operation_attributes_t& /*attrs*/, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input_tensor;
+
+    // These fields are part of the program hash; they are validated on cache miss before compiling
+    // the program and do not need to be rechecked on every cache hit.
+    TT_FATAL(input.layout() == Layout::TILE, "topk_route_prep input must be TILE layout");
+    TT_FATAL(input.dtype() == DataType::BFLOAT16, "topk_route_prep input must be BFLOAT16");
+    TT_FATAL(!input.memory_config().is_sharded(), "topk_route_prep input must use interleaved memory");
+}
+
+void validate_runtime_args(const operation_attributes_t& /*attrs*/, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input_tensor;
+
+    TT_FATAL(input.storage_type() == StorageType::DEVICE, "topk_route_prep input must be on device");
+    TT_FATAL(input.buffer() != nullptr, "topk_route_prep input must have an allocated buffer");
+    TT_FATAL(input.logical_shape().rank() >= 2, "topk_route_prep input must have rank >= 2");
+}
+
+}  // namespace
+
+void TopkRoutePrepDeviceOperation::validate_on_program_cache_hit(
+    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+    validate_runtime_args(attrs, tensor_args);
+}
+
+void TopkRoutePrepDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+    validate_static_args(attrs, tensor_args);
+    validate_runtime_args(attrs, tensor_args);
+}
+
+TopkRoutePrepDeviceOperation::program_factory_t TopkRoutePrepDeviceOperation::select_program_factory(
+    const operation_attributes_t& /*attrs*/, const tensor_args_t& /*tensor_args*/) {
+    return program::TopkRoutePrepProgramFactory{};
+}
+
+ttsl::hash::hash_t TopkRoutePrepDeviceOperation::compute_program_hash(
+    const operation_attributes_t& /*attrs*/, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input_tensor;
+    const auto grid = input.device()->compute_with_storage_grid_size();
+
+    // Program-structure terms, all W_p/R_p-derived (see the program factory's work split):
+    //   - width_tiles (W_p / 32) fixes the block widths (bw_full/bw_last -> kernel compile args,
+    //     CB page sizes) and the per-row block count;
+    //   - total_tile_rows (padded volume / W_p / 32) fixes the total block count and hence the
+    //     split_blocks_for_tilize core partition (which cores carry kernels is create-time state);
+    //   - the logical width fixes the output TensorAccessor's compile-time stick (page) size.
+    // Logical R stays hash-free: it only feeds writer runtime args (the partial-tile-height row
+    // clamp), re-derived from the tensors in override_runtime_arguments on every cache hit.
+    const auto& padded = input.padded_shape();
+    const uint32_t width_tiles = padded[-1] / tt::constants::TILE_WIDTH;
+    const uint32_t total_tile_rows = (input.physical_volume() / padded[-1]) / tt::constants::TILE_HEIGHT;
+
+    return tt::tt_metal::operation::hash_operation<TopkRoutePrepDeviceOperation>(
+        input.dtype(),
+        input.layout(),
+        input.memory_config().memory_layout(),
+        input.memory_config().buffer_type(),
+        grid.x,
+        grid.y,
+        width_tiles,
+        total_tile_rows,
+        input.logical_shape()[-1]);
+}
+
+spec_return_value_t TopkRoutePrepDeviceOperation::compute_output_specs(
+    const operation_attributes_t& /*attrs*/, const tensor_args_t& tensor_args) {
+    const auto& input = tensor_args.input_tensor;
+    // Same logical shape, ROW_MAJOR (logical sticks, tile padding dropped), same interleaved
+    // memory config — exactly what to_layout(ROW_MAJOR) produced in the unfused route.
+    return tt::tt_metal::TensorSpec(
+        input.logical_shape(),
+        tt::tt_metal::TensorLayout(
+            DataType::BFLOAT16, tt::tt_metal::PageConfig(Layout::ROW_MAJOR), input.memory_config()));
+}
+
+tensor_return_value_t TopkRoutePrepDeviceOperation::create_output_tensors(
+    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+    return create_device_tensor(compute_output_specs(attrs, tensor_args), tensor_args.input_tensor.device());
+}
+
+std::tuple<TopkRoutePrepDeviceOperation::operation_attributes_t, TopkRoutePrepDeviceOperation::tensor_args_t>
+TopkRoutePrepDeviceOperation::invoke(const Tensor& input_tensor) {
+    return {operation_attributes_t{}, tensor_args_t{.input_tensor = input_tensor}};
+}
+
+}  // namespace ttnn::operations::reduction::topk_route_prep
+
+namespace ttnn::operations::reduction::topk {
+
+Tensor topk_route_prep(const Tensor& input_tensor) {
+    using Op = ttnn::operations::reduction::topk_route_prep::TopkRoutePrepDeviceOperation;
+    auto [operation_attributes, tensor_args] = Op::invoke(input_tensor);
+    return ttnn::device_operation::launch<Op>(operation_attributes, tensor_args);
+}
+
+}  // namespace ttnn::operations::reduction::topk

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_route_prep_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_route_prep_device_operation.hpp
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <variant>
+#include <vector>
+
+#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+// topk_route_prep: PRIVATE prep op for ttnn.topk's large-k Blackhole routing composite
+// (topk.cpp: run_topk_large_indices_route). Fuses the route's first two stages —
+// untilize (TILE -> ROW_MAJOR) and the -inf clamp — into one kernel launch:
+//
+//   input:  TILE bf16 interleaved [..., R, W] (DRAM or L1)
+//   output: ROW_MAJOR bf16 interleaved, same logical shape, with every element
+//           floored at the lowest FINITE bf16 (bit pattern 0xFF7F,
+//           -3.3895313892515355e38) — see the clamp-trick contract in topk.cpp.
+//
+// Not registered with nanobind; called only from the routing composite via the
+// ttnn::operations::reduction::topk_route_prep() entry function below.
+
+namespace ttnn::operations::reduction::topk_route_prep {
+
+// Everything the program needs is derived from the input tensor's shape/layout,
+// so the op carries no attributes.
+struct operation_attributes_t {};
+
+struct tensor_args_t {
+    Tensor input_tensor;
+};
+
+using tensor_return_value_t = Tensor;
+using spec_return_value_t = tt::tt_metal::TensorSpec;
+
+namespace program {
+
+struct TopkRoutePrepSharedVariables {
+    tt::tt_metal::KernelHandle reader_kernel_id{};
+    tt::tt_metal::KernelHandle compute_kernel_id{};
+    tt::tt_metal::KernelHandle writer_kernel_id{};
+    std::vector<CoreCoord> cores{};
+};
+
+struct TopkRoutePrepProgramFactory {
+    using shared_variables_t = TopkRoutePrepSharedVariables;
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace program
+
+struct TopkRoutePrepDeviceOperation {
+    using operation_attributes_t = topk_route_prep::operation_attributes_t;
+    using tensor_args_t = topk_route_prep::tensor_args_t;
+    using tensor_return_value_t = topk_route_prep::tensor_return_value_t;
+    using spec_return_value_t = topk_route_prep::spec_return_value_t;
+
+    using program_factory_t = std::variant<program::TopkRoutePrepProgramFactory>;
+
+    static program_factory_t select_program_factory(
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
+
+    static void validate_on_program_cache_miss(const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
+    static void validate_on_program_cache_hit(const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
+    static ttsl::hash::hash_t compute_program_hash(
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
+
+    static spec_return_value_t compute_output_specs(
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
+
+    static tensor_return_value_t create_output_tensors(
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(const Tensor& input_tensor);
+};
+
+}  // namespace ttnn::operations::reduction::topk_route_prep
+
+namespace ttnn::operations::reduction::topk {
+
+// C++-only entry point (no nanobind): fused untilize + lowest-finite-bf16 clamp.
+// Lives in the ::topk namespace (next to the routing composite, its only caller);
+// ::reduction itself would collide with the op's topk_route_prep namespace above.
+Tensor topk_route_prep(const Tensor& input_tensor);
+
+}  // namespace ttnn::operations::reduction::topk

--- a/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_route_prep_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/device/topk_route_prep_program_factory.cpp
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Program factory for topk_route_prep (fused untilize + lowest-finite-bf16 clamp).
+//
+// Work split (split_blocks_for_tilize-style, over blocks instead of single tiles):
+// the padded input is a grid of 32x32 tiles, total_tile_rows x width_tiles. Each
+// tile-row is cut into blocks of bw_full = min(8, width_tiles) tiles (8 = the
+// bf16 half-sync DEST capacity AND the pack_untilize max block width) plus one
+// bw_last remainder block; blocks never cross a tile-row. The flat block list
+// (tile-row-major, so each core's blocks cover a CONTIGUOUS tile range — the
+// stock reader_unary_interleaved_start_id reader works unchanged) is split
+// across the full worker grid with a single cliff core, exactly like the
+// untilize parallelize-column factory's split.
+//
+// Per block, compute copy_tile's the tiles into DEST, floors each at the lowest
+// finite bf16 (unary_max_tile), and pack_untilize's DEST into one output-CB page;
+// the writer scatters that page's logical sticks into the ROW_MAJOR output.
+
+#include "topk_route_prep_device_operation.hpp"
+
+#include "ttnn/operations/core/work_split/work_split_tilize.hpp"
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/math.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+
+#include <algorithm>
+#include <bit>
+#include <map>
+#include <string>
+
+using namespace tt::constants;
+
+namespace ttnn::operations::reduction::topk_route_prep::program {
+
+namespace {
+
+constexpr uint32_t input_cb_index = tt::CBIndex::c_0;  // c_0: hardcoded in the reused reader
+constexpr uint32_t output_cb_index = tt::CBIndex::c_16;
+
+// 8 = bf16 half-sync DEST tile capacity (fp32_dest_acc_en=false, dst_full_sync_en=false —
+// the ComputeConfig below) and simultaneously pack_untilize's max block width in that mode.
+// The compute kernel static_asserts this against DEST_AUTO_LIMIT.
+constexpr uint32_t max_block_width_tiles = 8;
+
+// The clamp constant, as the fp32 bit pattern unary_max_tile takes (SFPU scalar params are
+// bit-cast floats). The lowest finite bf16 is 0xFF7F (sign=1, exp=0xFE, mantissa=0x7F, value
+// -3.3895313892515355e38); widened to fp32 by appending 16 zero mantissa bits: 0xFF7F0000.
+// Must stay bit-identical to what run_topk_large_indices_route documents (topk.cpp) — the
+// routed pipeline's -inf index parity depends on the op's input being floored exactly here.
+constexpr float lowest_finite_bf16 = -3.3895313892515355e38f;
+constexpr uint32_t clamp_bits = std::bit_cast<uint32_t>(lowest_finite_bf16);
+static_assert(clamp_bits == 0xFF7F0000u, "clamp constant must be the lowest finite bf16 widened to fp32");
+
+struct PrepWorkSplit {
+    uint32_t width_tiles = 0;      // W_p / 32
+    uint32_t total_tile_rows = 0;  // padded volume / W_p / 32 (all batches)
+    uint32_t bw_full = 0;          // full block width in tiles
+    uint32_t bw_last = 0;          // last (remainder) block width in tiles, in [1, bw_full]
+    uint32_t nblocks_per_row = 0;
+    uint32_t nblocks = 0;
+};
+
+PrepWorkSplit compute_work_split(const Tensor& input) {
+    PrepWorkSplit split;
+    const auto& padded = input.padded_shape();
+    split.width_tiles = padded[-1] / TILE_WIDTH;
+    split.total_tile_rows = (input.physical_volume() / padded[-1]) / TILE_HEIGHT;
+    split.bw_full = std::min(max_block_width_tiles, split.width_tiles);
+    split.nblocks_per_row = tt::div_up(split.width_tiles, split.bw_full);
+    split.bw_last = split.width_tiles - (split.nblocks_per_row - 1) * split.bw_full;
+    split.nblocks = split.total_tile_rows * split.nblocks_per_row;
+    return split;
+}
+
+// Tile index of the first tile of block `b` (blocks are tile-row-major, so a contiguous block
+// range maps to a contiguous tile range).
+uint32_t first_tile_of_block(const PrepWorkSplit& split, uint32_t b) {
+    return (b / split.nblocks_per_row) * split.width_tiles + (b % split.nblocks_per_row) * split.bw_full;
+}
+
+// (Re)computes every runtime arg from the tensors. Called by create() and, on cache hits, by
+// override_runtime_arguments(); the program hash pins every structural input (core partition,
+// block widths, stick size), so only addresses and the logical R/W clamps can differ here.
+void set_runtime_args(
+    tt::tt_metal::Program& program,
+    const TopkRoutePrepSharedVariables& shared,
+    const Tensor& input,
+    const Tensor& output) {
+    const auto split = compute_work_split(input);
+    const auto grid = input.device()->compute_with_storage_grid_size();
+    const auto block_split = ttnn::split_blocks_for_tilize(CoreCoord(grid.x, grid.y), split.nblocks);
+
+    const uint32_t tile_rows_per_batch = input.padded_shape()[-2] / TILE_HEIGHT;
+    const uint32_t logical_rows = input.logical_shape()[-2];
+    const uint32_t logical_width = input.logical_shape()[-1];
+
+    uint32_t start_block = 0;
+    for (uint32_t i = 0; i < shared.cores.size(); ++i) {
+        const CoreCoord& core = shared.cores[i];
+        const bool is_cliff = block_split.nblocks_per_core_cliff > 0 && i + 1 == shared.cores.size();
+        const uint32_t nblocks_this_core = is_cliff ? block_split.nblocks_per_core_cliff : block_split.nblocks_per_core;
+        const uint32_t ntiles_this_core =
+            first_tile_of_block(split, start_block + nblocks_this_core) - first_tile_of_block(split, start_block);
+
+        tt::tt_metal::SetRuntimeArgs(
+            program,
+            shared.reader_kernel_id,
+            core,
+            {input.buffer()->address(),                  // src_addr
+             ntiles_this_core,                           // ntiles
+             first_tile_of_block(split, start_block)});  // start_id
+
+        tt::tt_metal::SetRuntimeArgs(
+            program, shared.compute_kernel_id, core, {nblocks_this_core, start_block, split.nblocks_per_row});
+
+        tt::tt_metal::SetRuntimeArgs(
+            program,
+            shared.writer_kernel_id,
+            core,
+            {output.buffer()->address(),  // dst_addr
+             nblocks_this_core,
+             start_block,
+             split.nblocks_per_row,
+             tile_rows_per_batch,
+             logical_rows,
+             logical_width});
+
+        start_block += nblocks_this_core;
+    }
+}
+
+}  // namespace
+
+TopkRoutePrepProgramFactory::cached_program_t TopkRoutePrepProgramFactory::create(
+    const operation_attributes_t& /*operation_attributes*/,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    const auto& input = tensor_args.input_tensor;
+    const Tensor& output = tensor_return_value;
+
+    auto program = tt::tt_metal::CreateProgram();
+
+    const auto split = compute_work_split(input);
+    const auto grid = input.device()->compute_with_storage_grid_size();
+    const auto block_split = ttnn::split_blocks_for_tilize(CoreCoord(grid.x, grid.y), split.nblocks);
+    const auto& all_cores = block_split.all_cores;
+
+    const uint32_t tile_bytes = tt::tile_size(tt::DataFormat::Float16_b);
+
+    // Input CB: tile pages, double-buffered against one full block.
+    const auto input_cb_config = tt::tt_metal::CircularBufferConfig(
+                                     2 * split.bw_full * tile_bytes, {{input_cb_index, tt::DataFormat::Float16_b}})
+                                     .set_page_size(input_cb_index, tile_bytes);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, input_cb_config);
+
+    // Output CB: one page per BLOCK (uniform bw_full-sized pages so pack_untilize's contiguous
+    // block write can never straddle the CB wrap; a bw_last block simply leaves the page tail
+    // unused), double-buffered. Each page holds the untilized block: 32 sticks of bw*32 elements.
+    const uint32_t output_page_bytes = split.bw_full * tile_bytes;
+    const auto output_cb_config =
+        tt::tt_metal::CircularBufferConfig(2 * output_page_bytes, {{output_cb_index, tt::DataFormat::Float16_b}})
+            .set_page_size(output_cb_index, output_page_bytes);
+    tt::tt_metal::CreateCircularBuffer(program, all_cores, output_cb_config);
+
+    // Reader: reused BY PATH, with the same compile args the untilize parallelize-column factory
+    // passes (TensorAccessorArgs only; CB c_0 and its page size come from the CB interface).
+    std::vector<uint32_t> reader_compile_args;
+    tt::tt_metal::TensorAccessorArgs(*input.buffer()).append_to(reader_compile_args);
+    auto reader_kernel = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp",
+        all_cores,
+        tt::tt_metal::ReaderDataMovementConfig(reader_compile_args));
+
+    // Compute: fused clamp + pack_untilize. CLAMP_BITS is the fp32 bit pattern documented above.
+    std::map<std::string, std::string> compute_defines;
+    compute_defines["CLAMP_BITS"] = std::to_string(clamp_bits) + "u";
+    const std::vector<uint32_t> compute_compile_args = {split.bw_full, split.bw_last, input_cb_index, output_cb_index};
+    auto compute_kernel = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/compute/topk_route_prep_untilize_clamp.cpp",
+        all_cores,
+        tt::tt_metal::ComputeConfig{// bf16 half-sync: DEST holds 8 tiles == max_block_width_tiles above.
+                                    .fp32_dest_acc_en = false,
+                                    .dst_full_sync_en = false,
+                                    .compile_args = compute_compile_args,
+                                    .defines = compute_defines});
+
+    std::vector<uint32_t> writer_compile_args = {split.bw_full, split.bw_last, output_cb_index};
+    tt::tt_metal::TensorAccessorArgs(*output.buffer()).append_to(writer_compile_args);
+    auto writer_kernel = tt::tt_metal::CreateKernel(
+        program,
+        "ttnn/cpp/ttnn/operations/reduction/topk/device/kernels/dataflow/writer_topk_route_prep_stick_layout.cpp",
+        all_cores,
+        tt::tt_metal::WriterDataMovementConfig(writer_compile_args));
+
+    // split_blocks_for_tilize(CoreCoord, ...) places core i at (i % grid.x, i / grid.x), cliff
+    // last; enumerate in that exact order so the contiguous block partition lines up.
+    std::vector<CoreCoord> cores;
+    cores.reserve(block_split.ncores);
+    for (uint32_t i = 0; i < block_split.ncores; ++i) {
+        cores.push_back(CoreCoord{i % grid.x, i / grid.x});
+    }
+
+    TopkRoutePrepSharedVariables shared{
+        .reader_kernel_id = reader_kernel,
+        .compute_kernel_id = compute_kernel,
+        .writer_kernel_id = writer_kernel,
+        .cores = std::move(cores)};
+    set_runtime_args(program, shared, input, output);
+
+    return cached_program_t{std::move(program), std::move(shared)};
+}
+
+void TopkRoutePrepProgramFactory::override_runtime_arguments(
+    cached_program_t& cached_program,
+    const operation_attributes_t& /*operation_attributes*/,
+    const tensor_args_t& tensor_args,
+    tensor_return_value_t& tensor_return_value) {
+    set_runtime_args(
+        cached_program.program, cached_program.shared_variables, tensor_args.input_tensor, tensor_return_value);
+}
+
+}  // namespace ttnn::operations::reduction::topk_route_prep::program

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -16,14 +16,12 @@
 #include "ttnn/operations/data_movement/slice/slice.hpp"
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
 #include "ttnn/operations/data_movement/fill_pad/fill_pad.hpp"
-#include "ttnn/operations/data_movement/concat/concat.hpp"
-#include "ttnn/operations/data_movement/gather/gather.hpp"
-#include "ttnn/operations/copy/typecast/typecast.hpp"
-#include "ttnn/operations/eltwise/binary/binary_composite.hpp"
 #include "ttnn/operations/experimental/topk_large_indices/topk_large_indices.hpp"
 #include "ttnn/operations/reduction/reduction_common/reduction_common.hpp"
 #include "ttnn/operations/reduction/topk/device/topk_device_operation.hpp"
 #include "ttnn/operations/reduction/topk/device/topk_constants.hpp"
+#include "ttnn/operations/reduction/topk/device/topk_route_prep_device_operation.hpp"
+#include "ttnn/operations/reduction/topk/device/topk_route_finish_device_operation.hpp"
 
 #include <cstdint>
 #include <limits>
@@ -198,12 +196,13 @@ std::vector<Tensor> post_topk_transform_tensor(
 // indices of a ROW_MAJOR input, sorted by value descending. This composite
 // routes eligible calls through it:
 //
-//   TILE bf16 -> untilize -> clamp to the lowest finite bf16 (-inf parity,
-//   see below) -> topk_large_indices on the CLAMPED tensor (k rounded up to
-//   a multiple of 16, its own constraint) -> RM gather of the ORIGINAL
-//   (unclamped) values by index -> tilize values+indices -> index dtype
-//   match -> the shared post_topk_transform (slice to user k, rank/dim
-//   restore).
+//   TILE bf16 -> fused untilize+clamp to the lowest finite bf16 (the private
+//   topk_route_prep device op; -inf parity, see below) -> topk_large_indices
+//   on the CLAMPED tensor (k rounded up to a multiple of 16, its own
+//   constraint) -> fused gather of the ORIGINAL (unclamped) values straight
+//   from the TILE source + TILE assembly of both outputs + index dtype emit
+//   (the private topk_route_finish device op) -> the shared
+//   post_topk_transform (slice to user k, rank/dim restore).
 //
 // Routing lives here at the composite level, NOT in the device op's
 // select_program_factory, so the device op's program hash is untouched.
@@ -212,8 +211,8 @@ std::vector<Tensor> post_topk_transform_tensor(
 //   * values: input dtype (bf16), TILE, sorted descending — satisfies both
 //     sorted=true and sorted=false callers (torch.topk(largest=True) order).
 //   * indices: the device op emits UINT16 when the (tile-padded) width fits
-//     16 bits and UINT32 otherwise (see compute_output_specs); the routed
-//     path typecasts to match that exact boundary.
+//     16 bits and UINT32 otherwise (see compute_output_specs);
+//     topk_route_finish emits that exact boundary directly.
 //   * -inf lanes (the clamp trick): topk_large_indices marks lanes whose
 //     value is exactly bf16 -inf with the sentinel index 0xFFFFFFFF instead
 //     of a real position. The routed path never lets the op see a -inf: the
@@ -230,18 +229,9 @@ std::vector<Tensor> post_topk_transform_tensor(
 //     inside ttnn.topk's documented non-stable contract (stable=true never
 //     routes).
 //
-// Expected op count and cost shape (bench note):
-//   untilize + clamp + topk_large_indices + gather + 2x tilize
-//   [+ typecast] [+ 2x slice when k was rounded]  ~= 6-9 dispatches.
-//   Every stage except untilize, clamp and topk_large_indices touches only
-//   [rows, k_rounded <= 2048] tensors (micro-ops). Untilize and clamp read
-//   the (tile-padded) input — for a single logical row that is a 32x read
-//   amplification, but split across the full grid and DRAM-bandwidth-bound
-//   it is tens of microseconds, i.e. 3 orders of magnitude below the 158 ms
-//   single-core baseline it replaces; no extra width gating is warranted.
-//   Host dispatch (~8 ops) dominates only when the row is small — which the
-//   k > 64 gate (and the small-k arm's >= 4096 padded-width floor) already
-//   bounds.
+// Cost shape: only topk_route_prep and topk_large_indices touch the full
+// input width; every other stage works on [rows, k_rounded <= 2048] tensors
+// (topk_route_finish reads 64 B per selected element, not whole rows).
 
 // k <= 64 keeps the device op's fast multi-core bitonic path when that path
 // is eligible (padded width in [8192, 65535), power of two, cost check).
@@ -262,29 +252,11 @@ constexpr uint32_t large_k_route_max_k = 2048;
 // topk_large_indices requires k to be a multiple of 16. post_topk_transform
 // slices back down to the user's k when it was rounded.
 constexpr uint32_t large_k_route_k_multiple = 16;
-// The RM gather parks one full input row-stick in an L1 CB (W * 2 B for
-// bf16 — gather_program_factory.cpp, RmSingleRow* CB c_0 total_size =
-// input_stick_size_bytes): 2^19 sticks = 1 MB, comfortably inside
-// Blackhole's 1.5 MB budget next to the index/output CBs; 2^20 sticks =
-// 2 MB would fail CB allocation outright. Wider rows fall back to the stock
-// path. (topk_large_indices itself allows up to 2^30 columns; the widest
-// routed cells, 262144/524288, are pinned in test_topk.py.)
+// Routed width ceiling: 2^19 is the conservative, silicon-validated routing
+// envelope (the widest routed cells, 262144/524288, are pinned in
+// test_topk.py; topk_large_indices itself allows up to 2^30 columns).
+// Lifting it is a separate, perf-validated change.
 constexpr uint32_t large_k_route_max_width = 1u << 19;
-// gather selects its RM multi-core variant above GATHER_WT_THRESHOLD(60) * 32
-// index columns (gather_device_operation.cpp). That variant has no upstream
-// ROW_MAJOR test coverage and returned wrong values on silicon at
-// W_index=2048: each core fetches its index slice at byte offset w_start * 4
-// (gather_reader_rm_single_row_multi_core.cpp), which is not NoC-read-aligned
-// for most cores. Keep every routed gather call at or below this width so
-// only the silicon-proven RM single-core variant runs, chunking wider index
-// tensors (k_rounded > 1920 -> two gathers + concat on [rows, <=1024]
-// slices).
-constexpr uint32_t large_k_route_gather_max_index_width = 60 * 32;
-constexpr uint32_t large_k_route_gather_chunk_width = 1024;
-// Lowest finite bf16 (bit pattern 0xFF7F). Flooring the op's input here —
-// and gathering values from the ORIGINAL tensor — is what buys -inf index
-// parity (see the contract block above).
-constexpr float large_k_route_lowest_finite_bf16 = -3.3895313892515355e38f;
 
 bool should_route_to_topk_large_indices(
     const Tensor& transformed_tensor,
@@ -356,9 +328,10 @@ bool should_route_to_topk_large_indices(
     }
     const uint32_t width = transformed_tensor.logical_shape()[-1];
     const uint32_t k_rounded = large_k_route_k_multiple * tt::div_up(k, large_k_route_k_multiple);
-    // topk_large_indices needs width >= its (rounded) k; the gather's L1
-    // row-stick staging bounds the width from above. No pow2 / 16-bit width
-    // requirements here — that is the point of the route.
+    // topk_large_indices needs width >= its (rounded) k; the conservative
+    // routed envelope (see large_k_route_max_width) bounds the width from
+    // above. No pow2 / 16-bit width requirements here — that is the point of
+    // the route.
     return width >= k_rounded && width <= large_k_route_max_width;
 }
 
@@ -366,70 +339,27 @@ bool should_route_to_topk_large_indices(
 // Returns {values, indices} in TILE layout with last dim k_rounded, matching
 // what ttnn::prim::topk would have produced for adjusted_k == k_rounded, so
 // the shared post_topk_transform_tensor handles the rest.
-std::vector<Tensor> run_topk_large_indices_route(
-    const Tensor& transformed_tensor, const uint32_t k_rounded, const MemoryConfig& memory_config) {
-    // TILE -> ROW_MAJOR (topk_large_indices and the RM gather both want RM).
-    const Tensor input_rm = ttnn::to_layout(transformed_tensor, Layout::ROW_MAJOR);
-
-    // -inf parity (clamp trick): floor the op's input at the lowest finite
-    // bf16 so the op never sees a -inf and emits a REAL stamped source
-    // position for every lane (its 0xFFFFFFFF sentinel never fires). Values
-    // are gathered from the ORIGINAL tensor below, so -inf values come back
-    // bit-exact. ttnn::maximum with a scalar lowers to a single unary SFPU
-    // op (binary_composite_op.cpp: maximum(Tensor, ScalarVariant) ->
-    // UnaryOpType::MAXIMUM) and — unlike ttnn::clamp, which lowers to
-    // clamp_tss with an implicit FLT_MAX upper bound whose bf16 rounding
-    // behavior at +inf we would rather not depend on — cannot perturb +inf
-    // lanes.
-    const Tensor clamped_rm = ttnn::maximum(input_rm, large_k_route_lowest_finite_bf16);
+std::vector<Tensor> run_topk_large_indices_route(const Tensor& transformed_tensor, const uint32_t k_rounded) {
+    // Fused untilize + floor-at-lowest-finite-bf16 (the clamp trick — see the
+    // contract block above). A fused max, like the ttnn::maximum it replaced
+    // (and unlike ttnn::clamp, whose implicit FLT_MAX upper bound has bf16
+    // rounding behavior at +inf we would rather not depend on), cannot
+    // perturb +inf lanes. The routing predicate guarantees a TILE-layout
+    // input here; the op asserts it (no ROW_MAJOR branch).
+    const Tensor clamped_rm = topk_route_prep(transformed_tensor);
 
     // UINT32 row-major indices of the top k_rounded per row, sorted by value
-    // descending; every lane carries a real in-range position (no -inf in
-    // the clamped input, and the op's own -inf width padding can never beat
-    // a clamped-finite lane since width >= k_rounded).
+    // descending; every lane carries a real in-range position.
     const Tensor indices_rm = ttnn::experimental::topk_large_indices(clamped_rm, k_rounded);
 
-    // Gather the values back by index (torch.gather semantics on the last
-    // dim) from the ORIGINAL, unclamped tensor — this is what makes -inf
-    // values bit-exact. Index tensors wider than gather's RM multi-core
-    // threshold are chunked so every call stays on the RM single-core
-    // variant (see the constant's comment for the silicon failure this
-    // avoids).
-    Tensor values_rm;
-    if (k_rounded <= large_k_route_gather_max_index_width) {
-        values_rm = ttnn::gather(input_rm, /*dim=*/-1, indices_rm, /*sparse_grad=*/false, memory_config);
-    } else {
-        const auto& indices_shape = indices_rm.logical_shape();  // 4D: [d0, d1, d2, k_rounded]
-        std::vector<Tensor> gathered_chunks;
-        gathered_chunks.reserve(tt::div_up(k_rounded, large_k_route_gather_chunk_width));
-        for (uint32_t chunk_start = 0; chunk_start < k_rounded; chunk_start += large_k_route_gather_chunk_width) {
-            const uint32_t chunk_end = std::min(chunk_start + large_k_route_gather_chunk_width, k_rounded);
-            const ttsl::SmallVector<uint32_t> step = {1, 1, 1, 1};
-            const ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, chunk_start};
-            const ttsl::SmallVector<uint32_t> end_index = {
-                indices_shape[0], indices_shape[1], indices_shape[2], chunk_end};
-            const Tensor indices_chunk = ttnn::slice(indices_rm, start_index, end_index, step, memory_config);
-            gathered_chunks.push_back(
-                ttnn::gather(input_rm, /*dim=*/-1, indices_chunk, /*sparse_grad=*/false, memory_config));
-        }
-        values_rm = ttnn::concat(gathered_chunks, /*dim=*/-1, memory_config);
-    }
-
-    Tensor values = ttnn::to_layout(values_rm, Layout::TILE);
-    Tensor indices = ttnn::to_layout(indices_rm, Layout::TILE);
-
-    // Match the device op's index dtype contract: UINT16 iff the tile-padded
-    // width fits 16 bits (compute_output_specs compares the padded shape).
-    const uint32_t padded_width = transformed_tensor.padded_shape()[-1];
-    if (padded_width <= std::numeric_limits<uint16_t>::max()) {
-        indices = ttnn::typecast(indices, DataType::UINT16);
-    }
-
-    std::vector<Tensor> result;
-    result.reserve(2);
-    result.push_back(std::move(values));
-    result.push_back(std::move(indices));
-    return result;
+    // Gather values by index from the ORIGINAL, unclamped TILE tensor and
+    // assemble both TILE outputs (index dtype per the stock op's u16/u32
+    // width boundary). Canonicalization note: a tilize datacopy pass would
+    // canonicalize bf16 through DEST (-0 -> +0, NaN -> +/-inf);
+    // topk_route_finish is pure data movement and copies values BIT-EXACT
+    // from the source instead. NaN inputs are outside ttnn.topk's contract
+    // on every path.
+    return topk_route_finish(transformed_tensor, indices_rm);
 }
 
 }  // namespace CMAKE_UNIQUE_NAMESPACE
@@ -627,7 +557,7 @@ std::vector<Tensor> topk(
             operations::reduction::topk::CMAKE_UNIQUE_NAMESPACE::large_k_route_k_multiple *
             tt::div_up(k, operations::reduction::topk::CMAKE_UNIQUE_NAMESPACE::large_k_route_k_multiple);
         auto routed_result = operations::reduction::topk::CMAKE_UNIQUE_NAMESPACE::run_topk_large_indices_route(
-            transformed_tensor, k_rounded, input_memory_config);
+            transformed_tensor, k_rounded);
         auto routed_final = operations::reduction::topk::CMAKE_UNIQUE_NAMESPACE::post_topk_transform_tensor(
             transposed_tensor, routed_result, dim, is_dim_last_idx, k, k_rounded, original_lshape, input_memory_config);
         // Stock parity: the device op places outputs in

--- a/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/topk/topk.cpp
@@ -16,11 +16,17 @@
 #include "ttnn/operations/data_movement/slice/slice.hpp"
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
 #include "ttnn/operations/data_movement/fill_pad/fill_pad.hpp"
+#include "ttnn/operations/data_movement/concat/concat.hpp"
+#include "ttnn/operations/data_movement/gather/gather.hpp"
+#include "ttnn/operations/copy/typecast/typecast.hpp"
+#include "ttnn/operations/eltwise/binary/binary_composite.hpp"
+#include "ttnn/operations/experimental/topk_large_indices/topk_large_indices.hpp"
 #include "ttnn/operations/reduction/reduction_common/reduction_common.hpp"
 #include "ttnn/operations/reduction/topk/device/topk_device_operation.hpp"
 #include "ttnn/operations/reduction/topk/device/topk_constants.hpp"
 
 #include <cstdint>
+#include <limits>
 
 namespace ttnn::operations::reduction::topk {
 namespace {
@@ -178,6 +184,254 @@ std::vector<Tensor> post_topk_transform_tensor(
 
     return result;
 }
+
+// ---------------------------------------------------------------------------
+// Large-k routing onto ttnn::experimental::topk_large_indices (Blackhole)
+// ---------------------------------------------------------------------------
+//
+// The device op's multi-core bitonic path is gated at k <= 64 (plus pow2 width
+// and width < 65536), so every larger k runs the single-core factory: k=512 at
+// W=65536 measures ~158 ms on one core. topk_large_indices is a Blackhole-only
+// multi-core top-k that has NONE of those gates (arbitrary width up to 2^30,
+// k up to 2048; internally it splits rows across the grid when rows exceed it
+// and fuses segment merges inside a row), but returns only UINT32 row-major
+// indices of a ROW_MAJOR input, sorted by value descending. This composite
+// routes eligible calls through it:
+//
+//   TILE bf16 -> untilize -> clamp to the lowest finite bf16 (-inf parity,
+//   see below) -> topk_large_indices on the CLAMPED tensor (k rounded up to
+//   a multiple of 16, its own constraint) -> RM gather of the ORIGINAL
+//   (unclamped) values by index -> tilize values+indices -> index dtype
+//   match -> the shared post_topk_transform (slice to user k, rank/dim
+//   restore).
+//
+// Routing lives here at the composite level, NOT in the device op's
+// select_program_factory, so the device op's program hash is untouched.
+//
+// Contract matching vs the device op:
+//   * values: input dtype (bf16), TILE, sorted descending — satisfies both
+//     sorted=true and sorted=false callers (torch.topk(largest=True) order).
+//   * indices: the device op emits UINT16 when the (tile-padded) width fits
+//     16 bits and UINT32 otherwise (see compute_output_specs); the routed
+//     path typecasts to match that exact boundary.
+//   * -inf lanes (the clamp trick): topk_large_indices marks lanes whose
+//     value is exactly bf16 -inf with the sentinel index 0xFFFFFFFF instead
+//     of a real position. The routed path never lets the op see a -inf: the
+//     op's input is first clamped to the lowest FINITE bf16 (bit pattern
+//     0xFF7F, ~-3.39e38), so every lane keeps a REAL stamped source position
+//     and the sentinel never fires. The gather then runs against the
+//     ORIGINAL tensor, so -inf VALUES come back bit-exact. Net: stock/torch
+//     parity for both values and indices on -inf rows, and every returned
+//     index is in-range (the op's own -inf width padding can never outrank a
+//     clamped-finite lane, and width >= k_rounded is a predicate invariant).
+//     One documented caveat: a genuine 0xFF7F input element ties with
+//     clamped -inf lanes, so their relative order (and which of them makes
+//     the k cut) follows the op's deterministic-but-unspecified tie order —
+//     inside ttnn.topk's documented non-stable contract (stable=true never
+//     routes).
+//
+// Expected op count and cost shape (bench note):
+//   untilize + clamp + topk_large_indices + gather + 2x tilize
+//   [+ typecast] [+ 2x slice when k was rounded]  ~= 6-9 dispatches.
+//   Every stage except untilize, clamp and topk_large_indices touches only
+//   [rows, k_rounded <= 2048] tensors (micro-ops). Untilize and clamp read
+//   the (tile-padded) input — for a single logical row that is a 32x read
+//   amplification, but split across the full grid and DRAM-bandwidth-bound
+//   it is tens of microseconds, i.e. 3 orders of magnitude below the 158 ms
+//   single-core baseline it replaces; no extra width gating is warranted.
+//   Host dispatch (~8 ops) dominates only when the row is small — which the
+//   k > 64 gate (and the small-k arm's >= 4096 padded-width floor) already
+//   bounds.
+
+// k <= 64 keeps the device op's fast multi-core bitonic path when that path
+// is eligible (padded width in [8192, 65535), power of two, cost check).
+// When it is NOT eligible the stock op falls to the single-core factory,
+// which is linear in width (~137 ns/elem measured on p150a: 695 us at
+// W=5000, 1.38 ms at 10000, 6.87 ms at 50000, 9.49 ms at 65536) while the
+// routed composite is tens of microseconds. The small-k arm below therefore
+// routes exactly the structurally-ineligible cells; eligible pow2 cells keep
+// the bitonic path unchanged.
+constexpr uint32_t large_k_route_min_k_exclusive = 64;
+// Small-k arm floor (on the tile-padded width): below this the single-core
+// fallback is already sub-ms and the routed composite's fixed envelope is
+// not an empirically proven win. Measured win region starts at W=5000
+// (695 us stock vs tens of us routed); 4096 keeps a conservative floor.
+constexpr uint32_t small_k_route_min_padded_width = 4096;
+// topk_large_indices LLK ceiling.
+constexpr uint32_t large_k_route_max_k = 2048;
+// topk_large_indices requires k to be a multiple of 16. post_topk_transform
+// slices back down to the user's k when it was rounded.
+constexpr uint32_t large_k_route_k_multiple = 16;
+// The RM gather parks one full input row-stick in an L1 CB (W * 2 B for
+// bf16 — gather_program_factory.cpp, RmSingleRow* CB c_0 total_size =
+// input_stick_size_bytes): 2^19 sticks = 1 MB, comfortably inside
+// Blackhole's 1.5 MB budget next to the index/output CBs; 2^20 sticks =
+// 2 MB would fail CB allocation outright. Wider rows fall back to the stock
+// path. (topk_large_indices itself allows up to 2^30 columns; the widest
+// routed cells, 262144/524288, are pinned in test_topk.py.)
+constexpr uint32_t large_k_route_max_width = 1u << 19;
+// gather selects its RM multi-core variant above GATHER_WT_THRESHOLD(60) * 32
+// index columns (gather_device_operation.cpp). That variant has no upstream
+// ROW_MAJOR test coverage and returned wrong values on silicon at
+// W_index=2048: each core fetches its index slice at byte offset w_start * 4
+// (gather_reader_rm_single_row_multi_core.cpp), which is not NoC-read-aligned
+// for most cores. Keep every routed gather call at or below this width so
+// only the silicon-proven RM single-core variant runs, chunking wider index
+// tensors (k_rounded > 1920 -> two gathers + concat on [rows, <=1024]
+// slices).
+constexpr uint32_t large_k_route_gather_max_index_width = 60 * 32;
+constexpr uint32_t large_k_route_gather_chunk_width = 1024;
+// Lowest finite bf16 (bit pattern 0xFF7F). Flooring the op's input here —
+// and gathering values from the ORIGINAL tensor — is what buys -inf index
+// parity (see the contract block above).
+constexpr float large_k_route_lowest_finite_bf16 = -3.3895313892515355e38f;
+
+bool should_route_to_topk_large_indices(
+    const Tensor& transformed_tensor,
+    const uint32_t k,
+    const bool largest,
+    const bool stable,
+    const bool is_dim_last_idx,
+    const bool has_user_indices_tensor,
+    const bool has_preallocated_outputs,
+    const bool has_sub_core_grids,
+    const std::optional<MemoryConfig>& user_memory_config) {
+    // topk_large_indices only produces largest-first (descending) results.
+    if (!largest) {
+        return false;
+    }
+    // stable=true promises lowest-index tie-breaking; topk_large_indices tie
+    // order is deterministic but unspecified.
+    if (stable) {
+        return false;
+    }
+    // The routed pipeline creates its own index tensor and fresh outputs, and
+    // ignores custom core grids; keep the stock path for all three.
+    if (has_user_indices_tensor || has_preallocated_outputs || has_sub_core_grids) {
+        return false;
+    }
+    // The routed composite produces interleaved outputs; the stock path raises
+    // on sharded output configs. Keep the stock (loud) behavior.
+    if (user_memory_config.has_value() && user_memory_config->is_sharded()) {
+        return false;
+    }
+    // Conservative: only route reductions that were already on the last dim.
+    if (!is_dim_last_idx) {
+        return false;
+    }
+    if (k > large_k_route_max_k) {
+        return false;
+    }
+    if (k <= large_k_route_min_k_exclusive) {
+        const uint32_t padded_width = transformed_tensor.padded_shape()[-1];
+        // Wide arm: route only cells the device op's multi-core bitonic
+        // cannot take (mirrors select_program_factory requirements #1-#2,
+        // topk_device_operation.cpp:66-72 — padded width must be < 65535 and
+        // a power of two), where stock otherwise falls to the linear
+        // single-core factory. Cells that fail only verify_multi_core_cost
+        // stay on the stock path (unchanged, conservative).
+        const bool is_pow2 = padded_width != 0 && (padded_width & (padded_width - 1)) == 0;
+        // Structurally single-core in stock: width >= 65535, non-pow2, OR pow2
+        // below the bitonic's multi_core_min_width floor (8192) — the lone
+        // pow2 cell in [4096, 8192) otherwise stays on the linear factory.
+        const bool multicore_structurally_ineligible = padded_width >= std::numeric_limits<uint16_t>::max() ||
+                                                       !is_pow2 ||
+                                                       padded_width < ttnn::prim::constants::multi_core_min_width;
+        const bool wide_arm = multicore_structurally_ineligible && padded_width >= small_k_route_min_padded_width;
+        if (!wide_arm) {
+            return false;
+        }
+    }
+    if (transformed_tensor.dtype() != DataType::BFLOAT16) {
+        return false;
+    }
+    if (transformed_tensor.layout() != Layout::TILE) {
+        return false;
+    }
+    if (transformed_tensor.memory_config().is_sharded()) {
+        return false;
+    }
+    if (transformed_tensor.device()->arch() != tt::ARCH::BLACKHOLE) {
+        return false;
+    }
+    const uint32_t width = transformed_tensor.logical_shape()[-1];
+    const uint32_t k_rounded = large_k_route_k_multiple * tt::div_up(k, large_k_route_k_multiple);
+    // topk_large_indices needs width >= its (rounded) k; the gather's L1
+    // row-stick staging bounds the width from above. No pow2 / 16-bit width
+    // requirements here — that is the point of the route.
+    return width >= k_rounded && width <= large_k_route_max_width;
+}
+
+// Runs the routed pipeline on the 4D, last-dim-target TILE bf16 tensor.
+// Returns {values, indices} in TILE layout with last dim k_rounded, matching
+// what ttnn::prim::topk would have produced for adjusted_k == k_rounded, so
+// the shared post_topk_transform_tensor handles the rest.
+std::vector<Tensor> run_topk_large_indices_route(
+    const Tensor& transformed_tensor, const uint32_t k_rounded, const MemoryConfig& memory_config) {
+    // TILE -> ROW_MAJOR (topk_large_indices and the RM gather both want RM).
+    const Tensor input_rm = ttnn::to_layout(transformed_tensor, Layout::ROW_MAJOR);
+
+    // -inf parity (clamp trick): floor the op's input at the lowest finite
+    // bf16 so the op never sees a -inf and emits a REAL stamped source
+    // position for every lane (its 0xFFFFFFFF sentinel never fires). Values
+    // are gathered from the ORIGINAL tensor below, so -inf values come back
+    // bit-exact. ttnn::maximum with a scalar lowers to a single unary SFPU
+    // op (binary_composite_op.cpp: maximum(Tensor, ScalarVariant) ->
+    // UnaryOpType::MAXIMUM) and — unlike ttnn::clamp, which lowers to
+    // clamp_tss with an implicit FLT_MAX upper bound whose bf16 rounding
+    // behavior at +inf we would rather not depend on — cannot perturb +inf
+    // lanes.
+    const Tensor clamped_rm = ttnn::maximum(input_rm, large_k_route_lowest_finite_bf16);
+
+    // UINT32 row-major indices of the top k_rounded per row, sorted by value
+    // descending; every lane carries a real in-range position (no -inf in
+    // the clamped input, and the op's own -inf width padding can never beat
+    // a clamped-finite lane since width >= k_rounded).
+    const Tensor indices_rm = ttnn::experimental::topk_large_indices(clamped_rm, k_rounded);
+
+    // Gather the values back by index (torch.gather semantics on the last
+    // dim) from the ORIGINAL, unclamped tensor — this is what makes -inf
+    // values bit-exact. Index tensors wider than gather's RM multi-core
+    // threshold are chunked so every call stays on the RM single-core
+    // variant (see the constant's comment for the silicon failure this
+    // avoids).
+    Tensor values_rm;
+    if (k_rounded <= large_k_route_gather_max_index_width) {
+        values_rm = ttnn::gather(input_rm, /*dim=*/-1, indices_rm, /*sparse_grad=*/false, memory_config);
+    } else {
+        const auto& indices_shape = indices_rm.logical_shape();  // 4D: [d0, d1, d2, k_rounded]
+        std::vector<Tensor> gathered_chunks;
+        gathered_chunks.reserve(tt::div_up(k_rounded, large_k_route_gather_chunk_width));
+        for (uint32_t chunk_start = 0; chunk_start < k_rounded; chunk_start += large_k_route_gather_chunk_width) {
+            const uint32_t chunk_end = std::min(chunk_start + large_k_route_gather_chunk_width, k_rounded);
+            const ttsl::SmallVector<uint32_t> step = {1, 1, 1, 1};
+            const ttsl::SmallVector<uint32_t> start_index = {0, 0, 0, chunk_start};
+            const ttsl::SmallVector<uint32_t> end_index = {
+                indices_shape[0], indices_shape[1], indices_shape[2], chunk_end};
+            const Tensor indices_chunk = ttnn::slice(indices_rm, start_index, end_index, step, memory_config);
+            gathered_chunks.push_back(
+                ttnn::gather(input_rm, /*dim=*/-1, indices_chunk, /*sparse_grad=*/false, memory_config));
+        }
+        values_rm = ttnn::concat(gathered_chunks, /*dim=*/-1, memory_config);
+    }
+
+    Tensor values = ttnn::to_layout(values_rm, Layout::TILE);
+    Tensor indices = ttnn::to_layout(indices_rm, Layout::TILE);
+
+    // Match the device op's index dtype contract: UINT16 iff the tile-padded
+    // width fits 16 bits (compute_output_specs compares the padded shape).
+    const uint32_t padded_width = transformed_tensor.padded_shape()[-1];
+    if (padded_width <= std::numeric_limits<uint16_t>::max()) {
+        indices = ttnn::typecast(indices, DataType::UINT16);
+    }
+
+    std::vector<Tensor> result;
+    result.reserve(2);
+    result.push_back(std::move(values));
+    result.push_back(std::move(indices));
+    return result;
+}
+
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
@@ -351,6 +605,42 @@ std::vector<Tensor> topk(
 
     // Rank normalization - convert to 4D tensor format
     Tensor transformed_tensor = ::reduction_common::transform_to_4d_tensor(transposed_tensor, is_rank_le_4d);
+
+    // Blackhole routing onto ttnn::experimental::topk_large_indices covers
+    // two regions that otherwise land on the linear single-core factory:
+    // k in (64, 2048] (off the multi-core k <= 64 gate), and k <= 64 rows
+    // whose padded width is structurally ineligible for the multi-core
+    // bitonic (>= 65535, non-pow2, or pow2 below the 8192 multi-core floor)
+    // at padded width >= 4096. See the comment block on
+    // should_route_to_topk_large_indices for the full predicate and contract.
+    if (operations::reduction::topk::CMAKE_UNIQUE_NAMESPACE::should_route_to_topk_large_indices(
+            transformed_tensor,
+            k,
+            largest,
+            stable,
+            is_dim_last_idx,
+            indices_tensor.has_value(),
+            preallocated_output_tensors.has_value(),
+            sub_core_grids.has_value(),
+            memory_config)) {
+        const uint32_t k_rounded =
+            operations::reduction::topk::CMAKE_UNIQUE_NAMESPACE::large_k_route_k_multiple *
+            tt::div_up(k, operations::reduction::topk::CMAKE_UNIQUE_NAMESPACE::large_k_route_k_multiple);
+        auto routed_result = operations::reduction::topk::CMAKE_UNIQUE_NAMESPACE::run_topk_large_indices_route(
+            transformed_tensor, k_rounded, input_memory_config);
+        auto routed_final = operations::reduction::topk::CMAKE_UNIQUE_NAMESPACE::post_topk_transform_tensor(
+            transposed_tensor, routed_result, dim, is_dim_last_idx, k, k_rounded, original_lshape, input_memory_config);
+        // Stock parity: the device op places outputs in
+        // memory_config.value_or(input.memory_config()); the routed composite
+        // produces default interleaved outputs and post-transform only applies
+        // the config on its slice branches, so conform here.
+        for (auto& t : routed_final) {
+            if (t.memory_config() != input_memory_config) {
+                t = ttnn::to_memory_config(t, input_memory_config);
+            }
+        }
+        return routed_final;
+    }
 
     // Dimension size padding - ensure minimum dimension size for efficient processing
     auto padded_tensor = transformed_tensor;


### PR DESCRIPTION
### What

**Stacked on #53458** (base = its head; the diff here is routing + tests only). Composite-level routing — the device op's program hash is untouched. On Blackhole, bf16 last-dim `largest=True, stable=False` calls with no user indices tensor, no preallocated outputs, and no `sub_core_grids` route through `ttnn.experimental.topk_large_indices` when the shape falls off the stock fast paths:

| arm | shapes | measured |
|---|---|---|
| large-k | 64 < k ≤ 2048 | k=2048 W=65536: 631.5 ms → **51.5 µs (12,265×)**; k=512: 161.6 ms → 20.9 µs |
| small-k structural | k ≤ 64, padded W ≥ 65535 or non-pow2, ≥ 4096 | 40–423× off the linear single-core factory |
| MoE gates | k ≤ 16, padded W 128–512, ≤ 32 rows | 24.2 → 8.2 µs, 77.5 → 8.3 µs (2.95×/9.29×), zero model changes |
| multi-row rectangles | rows fit a rectangle tiling | rows=32 sampling shapes: routed 213.6 → **128.7 µs (74.5× vs stock e2e)** |

Everything else keeps today's engine bit-for-bit — including `stable=True`, `largest=False`, and all disqualifying-argument calls.

### Tie semantics (the deliberate contract)

The routed path returns a correct top-k **set** with deterministic-but-unspecified tie order (the op is non-stable; `stable=True` never routes). The added tests assert value-exactness (both sides sorted descending, bitwise) and index validity (`input[index] == value`, in-range, unique) — never index-order equality.

### Testing

- Routed regression tests (large-k, non-pow2, bfp8-inf fallback predicate) + a sweep-framework `large_k` suite for CI coverage of the routed path.
- Validated on this branch's own build: reduce/topk + op nightly = **414 passed**; the only failures are the four `test_topk_int32_indices[...W=8192...k=50]` cases, which **fail identically on unmodified `main` on Blackhole silicon** (verified by differential run against a pure-main `topk.cpp` build — pre-existing #48843 behavior at that shape, will file separately).
- `topk.cpp` here is a verified 3-way merge of the routing block with main's INT32-index support (disjoint regions, clean merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nkapre/topk-large-k-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nkapre/topk-large-k-routing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nkapre/topk-large-k-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nkapre/topk-large-k-routing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nkapre/topk-large-k-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nkapre/topk-large-k-routing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nkapre/topk-large-k-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nkapre/topk-large-k-routing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nkapre/topk-large-k-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nkapre/topk-large-k-routing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nkapre/topk-large-k-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nkapre/topk-large-k-routing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nkapre/topk-large-k-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nkapre/topk-large-k-routing)