### PR TITLE
[Bug fix] Fix incorrect int32 results for ttnn.remainder and ttnn.fmod with a scalar operand

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -1210,6 +1210,36 @@ def test_binary_remainder_fmod_int32_scalar(ttnn_op, scalar, device):
     assert torch.equal(output_tensor, torch_output_tensor)
 
 
+@pytest.mark.parametrize("scalar", [3, 7, -3])
+@pytest.mark.parametrize(
+    "activation, torch_activation",
+    [
+        (ttnn.UnaryOpType.NEG, lambda t: -t),
+        (ttnn.UnaryOpType.SQUARE, lambda t: t * t),
+        (ttnn.UnaryOpType.RELU, torch.relu),
+    ],
+    ids=["neg", "square", "relu"],
+)
+def test_binary_remainder_int32_scalar_activations(scalar, activation, torch_activation, device):
+    # Activations force the scalar overload off the unary fast path, so this covers the
+    # other side of that branch. Values stay small enough that SQUARE cannot overflow int32.
+    torch_input_tensor_a = torch.tensor([0, 1, 5, 7, -5, -7, 100, -100, 1000, -1000], dtype=torch.int32)
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    activations = [ttnn.UnaryWithParam(activation)]
+
+    post_output = ttnn.to_torch(ttnn.remainder(input_tensor_a, scalar, activations=activations))
+    assert torch.equal(post_output, torch_activation(torch.remainder(torch_input_tensor_a, scalar)))
+
+    pre_output = ttnn.to_torch(ttnn.remainder(input_tensor_a, scalar, input_tensor_a_activations=activations))
+    assert torch.equal(pre_output, torch.remainder(torch_activation(torch_input_tensor_a), scalar))
+
+
 @pytest.mark.parametrize(
     "ttnn_op",
     [

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -1189,10 +1189,10 @@ def test_binary_scalar_div_int32(device):
         ttnn.fmod,
     ],
 )
-@pytest.mark.parametrize("scalar", [1, 2, 3, 7, 100, 65535, -3, -7])
+@pytest.mark.parametrize("scalar", [1, 2, 3, 7, 100, 65535, -3, -7, -2147483648, 2147483647])
 def test_binary_remainder_fmod_int32_scalar(ttnn_op, scalar, device):
     torch_input_tensor_a = torch.tensor(
-        [0, 1, 5, 7, -5, -7, 100, -100, 2147483647, -2147483647, 1073872896, -1073872896]
+        [0, 1, 5, 7, -5, -7, 100, -100, 2147483647, -2147483647, -2147483648, 1073872896, -1073872896]
     )
     input_tensor_a = ttnn.from_torch(
         torch_input_tensor_a,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_int32.py
@@ -1189,6 +1189,34 @@ def test_binary_scalar_div_int32(device):
         ttnn.fmod,
     ],
 )
+@pytest.mark.parametrize("scalar", [1, 2, 3, 7, 100, 65535, -3, -7])
+def test_binary_remainder_fmod_int32_scalar(ttnn_op, scalar, device):
+    torch_input_tensor_a = torch.tensor(
+        [0, 1, 5, 7, -5, -7, 100, -100, 2147483647, -2147483647, 1073872896, -1073872896]
+    )
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        dtype=ttnn.int32,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    golden_function = ttnn.get_golden_function(ttnn_op)
+    torch_output_tensor = golden_function(torch_input_tensor_a, scalar, device=device)
+
+    output_tensor = ttnn.to_torch(ttnn_op(input_tensor_a, scalar))
+
+    assert torch.equal(output_tensor, torch_output_tensor)
+
+
+@pytest.mark.parametrize(
+    "ttnn_op",
+    [
+        ttnn.remainder,
+        ttnn.fmod,
+    ],
+)
 def test_binary_remainder_fmod_int32_edge_cases(ttnn_op, device):
     torch_input_tensor_a = torch.tensor(
         [0, 0, 1, 1, -1, -1, 2147483647, -2147483647, -2147483647, 2147483647, 0, 1073872896, -1073872896, -2147483647]

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -481,8 +481,9 @@ Tensor remainder(
     ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<CoreRangeSet>& sub_core_grids,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
-    if (!output_dtype.has_value() && !sub_device_id.has_value() && post_activations.empty() &&
-        lhs_activations.empty() && rhs_activations.empty()) {
+    // The unary SFPU fast path has no int32 kernel and would reinterpret the tile as float.
+    if (input.dtype() != DataType::INT32 && !output_dtype.has_value() && !sub_device_id.has_value() &&
+        post_activations.empty() && lhs_activations.empty() && rhs_activations.empty()) {
         return ttnn::unary_remainder(input, scalar, output_mem_config, output_tensor, sub_core_grids);
     }
     return ttnn::detail::invoke_binary_ng(
@@ -526,8 +527,24 @@ Tensor fmod(
     const Tensor& input,
     unary::ScalarVariant scalar,
     const std::optional<MemoryConfig>& output_mem_config,
-    const std::optional<CoreRangeSet>& /*sub_core_grids*/,
-    const std::optional<tt::tt_metal::SubDeviceId>& /*sub_device_id*/) {
+    const std::optional<CoreRangeSet>& sub_core_grids,
+    const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
+    // The unary SFPU fast path has no int32 kernel and would reinterpret the tile as float.
+    if (input.dtype() == DataType::INT32) {
+        return ttnn::detail::invoke_binary_ng(
+            input,
+            scalar,
+            binary::BinaryOpType::FMOD,
+            std::nullopt,
+            output_mem_config,
+            std::nullopt,
+            {},
+            {},
+            {},
+            std::nullopt,
+            sub_core_grids,
+            sub_device_id);
+    }
     float scalar_f = std::visit([](auto v) -> float { return static_cast<float>(v); }, scalar);
     return ttnn::unary_fmod(input, scalar_f, output_mem_config);
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -481,7 +481,8 @@ Tensor remainder(
     ttsl::Span<const unary::EltwiseUnaryWithParam> rhs_activations,
     const std::optional<CoreRangeSet>& sub_core_grids,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
-    // The unary SFPU fast path has no int32 kernel and would reinterpret the tile as float.
+    // TODO: add INT32 support for unary SFPU fast path. Until then int32 must route through
+    // binary_ng, since the float kernel would reinterpret the tile.
     if (input.dtype() != DataType::INT32 && !output_dtype.has_value() && !sub_device_id.has_value() &&
         post_activations.empty() && lhs_activations.empty() && rhs_activations.empty()) {
         return ttnn::unary_remainder(input, scalar, output_mem_config, output_tensor, sub_core_grids);
@@ -529,8 +530,9 @@ Tensor fmod(
     const std::optional<MemoryConfig>& output_mem_config,
     const std::optional<CoreRangeSet>& sub_core_grids,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
-    // The unary SFPU fast path has no int32 kernel (it would reinterpret the tile as float)
-    // and cannot honor sub_device_id.
+    // TODO: add INT32 support for unary SFPU fast path. Until then int32 must route through
+    // binary_ng, since the float kernel would reinterpret the tile. The fast path also cannot
+    // honor sub_device_id.
     if (input.dtype() == DataType::INT32 || sub_device_id.has_value()) {
         return ttnn::detail::invoke_binary_ng(
             input,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_composite_op.cpp
@@ -529,8 +529,9 @@ Tensor fmod(
     const std::optional<MemoryConfig>& output_mem_config,
     const std::optional<CoreRangeSet>& sub_core_grids,
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id) {
-    // The unary SFPU fast path has no int32 kernel and would reinterpret the tile as float.
-    if (input.dtype() == DataType::INT32) {
+    // The unary SFPU fast path has no int32 kernel (it would reinterpret the tile as float)
+    // and cannot honor sub_device_id.
+    if (input.dtype() == DataType::INT32 || sub_device_id.has_value()) {
         return ttnn::detail::invoke_binary_ng(
             input,
             scalar,
@@ -546,7 +547,7 @@ Tensor fmod(
             sub_device_id);
     }
     float scalar_f = std::visit([](auto v) -> float { return static_cast<float>(v); }, scalar);
-    return ttnn::unary_fmod(input, scalar_f, output_mem_config);
+    return ttnn::unary_fmod(input, scalar_f, output_mem_config, std::nullopt, sub_core_grids);
 }
 
 Tensor floor_div(

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar.cpp
@@ -16,6 +16,7 @@
 #include "api/compute/div_int32_sfpu.h"
 #include "api/compute/div_int32_floor.h"
 #include "api/compute/binary_remainder.h"
+#include "api/compute/binary_fmod.h"
 #include "api/compute/quantization.h"
 #include "api/compute/xlogy.h"
 #include "api/compute/atan2.h"


### PR DESCRIPTION
## Summary

Closes #53389

`ttnn.remainder(int32_tensor, scalar)` and `ttnn.fmod(int32_tensor, scalar)` silently returned wrong values for every divisor — not just edge cases. Positive dividends came back as `0` and negative dividends as a float NaN bit pattern reinterpreted as int32.

```python
a = torch.tensor([[0, 1, 5, 7, -5, -7, 100]], dtype=torch.int32)
tt_a = ttnn.from_torch(a, dtype=ttnn.int32, layout=ttnn.TILE_LAYOUT, device=device)

ttnn.remainder(tt_a, 3)   # [0, 0, 0, 0, 2143289344, 2143289344, 0]
torch.remainder(a, 3)     # [0, 1, 2, 1, 1, 2, 1]
```

There was no error or warning — just incorrect data flowing downstream. int32 is a documented, supported operand dtype for both ops.

## Root cause

Both scalar overloads take a unary SFPU fast path when no output dtype is requested. That path only special-cases `UINT32`, so `INT32` fell through to the **float** kernel and the int32 tile was reinterpreted as float32. Small positive ints become denormals ≈ 0; negative ints have the sign bit set and produce a NaN bit pattern.

The binary_ng path already dispatches correctly on dtype (`remainder_int32_tile` / `fmod_int32_tile`), which is why the tensor-tensor form and the `ttnn.remainder(..., dtype=ttnn.int32)` form were both unaffected.

`fmod` was worse: its scalar overload unconditionally cast the scalar to `float` and called the unary path, so it had no `dtype=` escape hatch at all, and it silently discarded `sub_core_grids` / `sub_device_id`.

## Changes

- `binary_composite_op.cpp`: exclude `INT32` from the `remainder` scalar fast path so it routes to binary_ng, which has the correct int32 kernel. `UINT32` keeps the fast path since its dedicated kernel is already correct.
- `binary_composite_op.cpp`: route int32 `fmod` scalar to binary_ng as well, and stop dropping `sub_core_grids` / `sub_device_id`.
- `eltwise_binary_sfpu_scalar.cpp`: add the missing `binary_fmod.h` include. The scalar compute kernel lacked a header the tensor-tensor kernel already had, so `fmod_int32_tile` was unreachable from the scalar path and JIT compilation failed with `'fmod_int32_tile' was not declared in this scope`.
- Added `test_binary_remainder_fmod_int32_scalar` covering both ops across 8 divisors including negatives.

Non-int32 dtypes are untouched and stay on the unary fast path.

## Why this was not caught

The existing int32 coverage (`test_binary_remainder_fmod_int32_edge_cases`, `test_binary_remainder_fmod_int32_range_1e15`) only exercises the tensor-tensor overload. The scalar overload had no int32 test at all. The new test closes that gap.

## Test plan

Validated on Blackhole p150b. Worth a confirmation run on Wormhole; the faulty dispatch is host-side and arch-independent, and the only arch-visible difference was the garbage NaN encoding.

- [x] New test: 16/16 pass with the fix. Verified it is a real guard by reverting the host change and rebuilding — 16/16 fail without it.
- [x] `test_binary_int32.py` + `test_binary_uint32.py`: 860 passed, 6 skipped
- [x] Adding `test_binary_dtype_validation.py`: 910 passed, 6 skipped
- [x] `test_unary.py` + `test_div_ops.py` filtered to remainder/fmod: 130 passed, 2 xfailed

Post-fix values match torch across int32, uint32, float32, bfloat16, scalar and tensor-tensor forms, including fmod's negative-dividend truncation semantics:

```
fmod int32 scalar: [0, 1, 2, 1, -2, -1, 1]
fmod torch:        [0, 1, 2, 1, -2, -1, 1]
```

## Performance

Shape `(1,1,512,512)`, 20 invocations per case, 3 repeats per state, run-to-run spread ~0.2%. Per-op device kernel duration:

| Case | Before | After | Delta |
|---|---|---|---|
| `remainder` int32 scalar (changed) | 10,306 ns | 11,856 ns | +15.0% |
| `fmod` int32 scalar (changed) | 9,536 ns | 10,812 ns | +13.4% |
| `remainder` float32 scalar | 10,326 ns | 10,330 ns | +0.04% |
| `remainder` bfloat16 scalar | 9,133 ns | 9,135 ns | +0.02% |
| `remainder` uint32 scalar | 6,918 ns | 6,994 ns | +1.1% |
| `remainder` int32 tensor-tensor | 11,244 ns | 11,339 ns | +0.8% |

Only the two changed paths move; every control is within noise. Profiler confirms the intended dispatch change and nothing more — int32 moves from `UnaryDeviceOperation` to `BinaryNgDeviceOperation` while float32 stays on `UnaryDeviceOperation`.

Note the "before" number is not a meaningful baseline: it is the cost of a kernel that returned garbage. This is the price of correctness on a previously broken path, and int32 scalar (11,856 ns) now lands near int32 tensor-tensor (11,339 ns), as expected since both use the same binary_ng kernel.

A follow-up could recover the difference by adding a `remainder_tile_int32` unary SFPU primitive so int32 keeps the fast path. That requires a cross-repo `tt-llk` change and is pure optimization, so it should not gate this correctness fix.

Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=aswinmcw/fix-int32-scalar-remainder-fmod)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:aswinmcw/fix-int32-scalar-remainder-fmod)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=aswinmcw/fix-int32-scalar-remainder-fmod)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:aswinmcw/fix-int32-scalar-remainder-fmod)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=aswinmcw/fix-int32-scalar-remainder-fmod)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:aswinmcw/fix-int32-scalar-remainder-fmod)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=aswinmcw/fix-int32-scalar-remainder-fmod)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:aswinmcw/fix-int32-scalar-remainder-fmod)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=aswinmcw/fix-int32-scalar-remainder-fmod)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:aswinmcw/fix-int32-scalar-remainder-fmod)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=aswinmcw/fix-int32-scalar-remainder-fmod)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:aswinmcw/fix-int32-scalar-remainder-fmod)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=aswinmcw/fix-int32-scalar-remainder-fmod)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:aswinmcw/fix-int32-scalar-remainder-fmod)
