### PR TITLE
K3 MLA chunked test against its golden trace

### DIFF
--- a/.github/workflows/blaze-models-prefill-tests.yaml
+++ b/.github/workflows/blaze-models-prefill-tests.yaml
@@ -13,7 +13,7 @@ on:
           "sdpa_perf" runs ring-joint SDPA and high-bandwidth all-gather.
           Valid stages: dsa_mla_glm, glm_chunked, glm_chunked_accuracy,
           glm_moe, glm_prefill_block, hca_chunked, hca_perf, high_bw_all_gather_perf,
-          k3_mla, k3_mla_perf, kimi_chunked, kimi_chunked_padded, kimi_dflash,
+          k3_mla, k3_mla_perf, k3_mla_trace, kimi_chunked, kimi_chunked_padded, kimi_dflash,
           kimi_k3_moe, kimi_k3_moe_perf, kimi_mla, kimi_moe, kimi_prefill_block,
           kv_cache_table, minimax_prefill_kv_pcc, minimax_prefill_perf, mla,
           mla_chunked, moe_gate, prefill_block, prefill_block_determinism,

--- a/models/demos/common/prefill/adapter.py
+++ b/models/demos/common/prefill/adapter.py
@@ -206,9 +206,7 @@ class PrefillModelAdapter(ABC):
     moe_pcc_threshold: float = 0.999
     mla_pcc_threshold: float = 0.999
     supports_pretrained: bool = True
-    # Model layer whose ``self_attn.*`` holds the MLA weights. Distinct from ``supports_pretrained``,
-    # which means the FULL transformer loads: Kimi-K3's attention is loadable (bf16, layer 3) while its
-    # MXFP4 MoE is not. ``None`` = no reachable checkpoint, hence no GPU trace either.
+    # Model layer whose ``self_attn.*`` holds the MLA weights; None if no checkpoint is reachable.
     pretrained_mla_layer: Optional[int] = 0
     # This variant's OWN golden MLA-trace dirs (each holding mla_io/ + kv_cache/), for the
     # MLA-level trace tests; one per user, cycled. Empty = no trace was ever recorded for it.

--- a/models/demos/common/prefill/adapter.py
+++ b/models/demos/common/prefill/adapter.py
@@ -206,6 +206,10 @@ class PrefillModelAdapter(ABC):
     moe_pcc_threshold: float = 0.999
     mla_pcc_threshold: float = 0.999
     supports_pretrained: bool = True
+    # Model layer whose ``self_attn.*`` holds the MLA weights. Distinct from ``supports_pretrained``,
+    # which means the FULL transformer loads: Kimi-K3's attention is loadable (bf16, layer 3) while its
+    # MXFP4 MoE is not. ``None`` = no reachable checkpoint, hence no GPU trace either.
+    pretrained_mla_layer: Optional[int] = 0
     # Whether the tokenizer needs trust_remote_code=True (custom tokenizer code shipped in the repo,
     # e.g. Kimi's tiktoken-backed BBPE). DeepSeek-V3 uses a stock fast tokenizer, so it turns this off
     # to avoid the flat-config trust_remote_code import path that otherwise breaks its load.

--- a/models/demos/common/prefill/adapter.py
+++ b/models/demos/common/prefill/adapter.py
@@ -210,6 +210,9 @@ class PrefillModelAdapter(ABC):
     # which means the FULL transformer loads: Kimi-K3's attention is loadable (bf16, layer 3) while its
     # MXFP4 MoE is not. ``None`` = no reachable checkpoint, hence no GPU trace either.
     pretrained_mla_layer: Optional[int] = 0
+    # This variant's OWN golden MLA-trace dirs (each holding mla_io/ + kv_cache/), for the
+    # MLA-level trace tests; one per user, cycled. Empty = no trace was ever recorded for it.
+    mla_trace_defaults: tuple[str, ...] = ()
     # Whether the tokenizer needs trust_remote_code=True (custom tokenizer code shipped in the repo,
     # e.g. Kimi's tiktoken-backed BBPE). DeepSeek-V3 uses a stock fast tokenizer, so it turns this off
     # to avoid the flat-config trust_remote_code import path that otherwise breaks its load.

--- a/models/demos/deepseek_v3_d_p/tests/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/conftest.py
@@ -983,12 +983,8 @@ def random_weights(config_only):
 
 
 def _load_mla_weights(state_dict, hf_config, prefix: str, layer_idx: int) -> dict:
-    """One layer's MLA weights, read without the rest of the layer.
-
-    The narrow `self_attn.` prefix is load-bearing: a whole-layer view drags in the MoE experts, and
-    Kimi-K3 packs those as MXFP4, which `convert_state_dict` raises on. Attention is exempt from
-    quantization in every checkpoint here, so this view is plain bf16.
-    """
+    """One layer's MLA weights, read without the rest of the layer: a whole-layer view drags in the
+    MoE experts, which Kimi-K3 packs as MXFP4 and convert_state_dict raises on."""
     sd = convert_state_dict(sub_state_dict(state_dict, f"{prefix}model.layers.{layer_idx}.self_attn."), hf_config)
     names = [
         "q_a_proj.weight",

--- a/models/demos/deepseek_v3_d_p/tests/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/conftest.py
@@ -1094,7 +1094,7 @@ def pretrained_transformer_weights(variant, model_path, hf_config, state_dict, r
 
 
 @pytest.fixture
-def pretrained_mla_weights(variant, model_path, hf_config, state_dict):
+def pretrained_mla_layer_weights(variant, model_path, hf_config, state_dict):
     """Pretrained MLA weights from ``variant.pretrained_mla_layer``, as ``(hf_config, weights)``.
 
     Same shape ``random_weights`` returns, so an MLA test swaps one fixture for the other. Separate
@@ -1110,15 +1110,13 @@ def pretrained_mla_weights(variant, model_path, hf_config, state_dict):
     if state_dict is None:
         pytest.skip(f"{variant.name}: failed to load state dict. Check model path and weights.")
 
-    # The torch MLA reference reads these with no defaults, and Kimi-K3's checkpoint config omits all
-    # three -- transformers synthesizes a factor-less rope_scaling, on which _init_rope KeyErrors.
-    # Inert for a NoPE bias-free model; only filled when absent, so DeepSeek-V3 / Kimi-K2.6 (real YaRN)
-    # are untouched.
+    # The torch MLA reference reads all three with no defaults. Kimi-K3's checkpoint config omits the
+    # first two, and for the third transformers synthesizes {'rope_type': 'default'}, on which
+    # _init_rope KeyErrors -- a NoPE model has no scaling, so None is the value it wants.
     for field, default in (("attention_bias", False), ("attention_dropout", 0.0)):
         if not hasattr(hf_config, field):
             setattr(hf_config, field, default)
-    rope_scaling = getattr(hf_config, "rope_scaling", None)
-    if rope_scaling is not None and not {"type", "factor"} & set(rope_scaling):
+    if getattr(hf_config, "mla_use_nope", False):
         hf_config.rope_scaling = None
 
     layer_idx = variant.pretrained_mla_layer

--- a/models/demos/deepseek_v3_d_p/tests/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/conftest.py
@@ -982,6 +982,28 @@ def random_weights(config_only):
     return config, weights
 
 
+def _load_mla_weights(state_dict, hf_config, prefix: str, layer_idx: int) -> dict:
+    """One layer's MLA weights, read without the rest of the layer.
+
+    The narrow `self_attn.` prefix is load-bearing: a whole-layer view drags in the MoE experts, and
+    Kimi-K3 packs those as MXFP4, which `convert_state_dict` raises on. Attention is exempt from
+    quantization in every checkpoint here, so this view is plain bf16.
+    """
+    sd = convert_state_dict(sub_state_dict(state_dict, f"{prefix}model.layers.{layer_idx}.self_attn."), hf_config)
+    names = [
+        "q_a_proj.weight",
+        "q_a_layernorm.weight",
+        "q_b_proj.weight",
+        "kv_a_proj_with_mqa.weight",
+        "kv_a_layernorm.weight",
+        "kv_b_proj.weight",
+        "o_proj.weight",
+    ]
+    if getattr(hf_config, "mla_use_output_gate", False):
+        names.append("g_proj.weight")  # Kimi-K3; ttMLA reads it with no default
+    return {name: sd[name] for name in names}
+
+
 @pytest.fixture
 def pretrained_transformer_weights(variant, model_path, hf_config, state_dict, request):
     """
@@ -1038,15 +1060,7 @@ def pretrained_transformer_weights(variant, model_path, hf_config, state_dict, r
 
         layer_dict = {
             "attn_norm_weight": layer_dequant["input_layernorm.weight"],
-            "mla_weights": {
-                "q_a_proj.weight": layer_dequant["self_attn.q_a_proj.weight"],
-                "q_a_layernorm.weight": layer_dequant["self_attn.q_a_layernorm.weight"],
-                "q_b_proj.weight": layer_dequant["self_attn.q_b_proj.weight"],
-                "kv_a_proj_with_mqa.weight": layer_dequant["self_attn.kv_a_proj_with_mqa.weight"],
-                "kv_a_layernorm.weight": layer_dequant["self_attn.kv_a_layernorm.weight"],
-                "kv_b_proj.weight": layer_dequant["self_attn.kv_b_proj.weight"],
-                "o_proj.weight": layer_dequant["self_attn.o_proj.weight"],
-            },
+            "mla_weights": _load_mla_weights(state_dict, hf_config, prefix, i),
             "ffn_norm_weight": layer_dequant["post_attention_layernorm.weight"],
         }
 
@@ -1081,6 +1095,42 @@ def pretrained_transformer_weights(variant, model_path, hf_config, state_dict, r
 
     logger.info(f"Loaded pretrained transformer weights for {num_layers} layers")
     return hf_config, result
+
+
+@pytest.fixture
+def pretrained_mla_weights(variant, model_path, hf_config, state_dict):
+    """Pretrained MLA weights from ``variant.pretrained_mla_layer``, as ``(hf_config, weights)``.
+
+    Same shape ``random_weights`` returns, so an MLA test swaps one fixture for the other. Separate
+    from ``pretrained_transformer_weights`` because that one also loads the embedding, the norms and
+    the full MoE side, which Kimi-K3 cannot do.
+    """
+    if variant.pretrained_mla_layer is None:
+        pytest.skip(f"{variant.name}: no reachable checkpoint, so no MLA weights to load")
+    if not _check_pretrained_available(model_path):
+        pytest.skip(f"{variant.name}: pretrained weights not available. Set {variant.env_var} or download model.")
+    if hf_config is None:
+        pytest.skip(f"{variant.name}: failed to load HF config. Check model path.")
+    if state_dict is None:
+        pytest.skip(f"{variant.name}: failed to load state dict. Check model path and weights.")
+
+    # The torch MLA reference reads these with no defaults, and Kimi-K3's checkpoint config omits all
+    # three -- transformers synthesizes a factor-less rope_scaling, on which _init_rope KeyErrors.
+    # Inert for a NoPE bias-free model; only filled when absent, so DeepSeek-V3 / Kimi-K2.6 (real YaRN)
+    # are untouched.
+    for field, default in (("attention_bias", False), ("attention_dropout", 0.0)):
+        if not hasattr(hf_config, field):
+            setattr(hf_config, field, default)
+    rope_scaling = getattr(hf_config, "rope_scaling", None)
+    if rope_scaling is not None and not {"type", "factor"} & set(rope_scaling):
+        hf_config.rope_scaling = None
+
+    layer_idx = variant.pretrained_mla_layer
+    prefix = detect_language_model_prefix(state_dict)
+    logger.info(f"Loading pretrained MLA weights from layer {layer_idx} of {model_path}")
+    weights = _load_mla_weights(state_dict, hf_config, prefix, layer_idx)
+    logger.info(f"Loaded {len(weights)} MLA weight tensors (layer {layer_idx})")
+    return hf_config, weights
 
 
 # ---------------------------------------------------------------------------

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -590,9 +590,9 @@ def _run_chunked_prefill(
     `reference` selects how inputs + ground truth are produced -- independent of prefill_len / env:
       * "cpu"   -> synthetic inputs + torch MLA reference (k_pe in Meta basis). Partial-chunk iters
                    (rotation) allowed; any prefix is preloaded from the CPU reference KV.
-      * "trace" -> GPU-trace inputs + reference (k_pe in HF basis, re-interleaved to compare). TRACE
-                    ONLY: dirs come from variant.mla_trace_defaults (or MLA_CHUNKED_TRACE_PATH);
-                    supports partial iters.
+      * "trace" -> GPU-trace inputs + reference (k_pe re-interleaved for a roped trace, compared
+                    directly under NoPE). TRACE ONLY: dirs come from variant.mla_trace_defaults (or
+                    MLA_CHUNKED_TRACE_PATH); supports partial iters.
       * None    -> no reference (functional/perf): random inputs + random prefix, finite-output check.
     Multi-user partitions iters_isl across users (last gets the remainder); each user is independent in
     its own cache slot, so cross-user contamination surfaces as a per-user output PCC drop.
@@ -655,8 +655,8 @@ def _run_chunked_prefill(
     config.max_seq_len = seq_len_cache
     kvpe_dim = config.kv_lora_rank + config.qk_rope_head_dim
     hidden_size = config.hidden_size
-    # The GPU trace stores k_pe HF half-split while the device cache is Meta interleaved. Under NoPE
-    # (Kimi-K3) neither side rotates.
+    # A roped GPU trace stores k_pe HF half-split while the device cache is Meta interleaved; under NoPE
+    # (Kimi-K3) neither side rotates, so there is no basis difference to correct.
     trace_pe_interleave = use_trace and not getattr(config, "mla_use_nope", False)
 
     logger.info(

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -1015,8 +1015,8 @@ def test_mla_chunked_prefill(
     reference), so this works for both variants. It complements the deepseek GPU-trace path, which only
     replays full-chunk iters and so never exercises real weights across the rotation/partial-chunk edge
     scenarios that the cpu path covers. Without the env var, fall back to random (mirroring
-    test_kimi_mla). kimi_k2_6 also runs the trace path (loader + k_pe re-interleave are arch-agnostic; needs kimi
-    its own registered traces). It otherwise runs the same config-driven driver on any arch/mesh.
+    test_kimi_mla). kimi_k2_6 also runs the trace path (loader + k_pe re-interleave are arch-agnostic),
+    against its own registered traces. It otherwise runs the same config-driven driver on any arch/mesh.
 
     kimi_k3 (NoPE + output gate, 96 heads) runs 'scalar' only -- 'metadata' is skipped explicitly
     below. It runs 'trace' like kimi_k2_6, taking real weights from layer 3 via

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -1004,8 +1004,8 @@ def test_mla_chunked_prefill(
 ):
     """Unified chunked-prefill driver crossed with independent mesh and reference axes. Each
     functionality scenario (rotation edges, production depth, multi-user, deep prefix) runs on any mesh
-    and is validated against the CPU torch reference ('cpu'), the GPU trace ('trace', skips without
-    the variant has no registered trace), or run with no reference ('func'). Select with e.g.
+    and is validated against the CPU torch reference ('cpu'), the GPU trace ('trace', asserts if the
+    variant has no registered trace), or run with no reference ('func'). Select with e.g.
     -k 'maxedge-1u and trace and 8x4'. See _run_chunked_prefill.
 
     Real weights on the CPU-reference path: point the variant's HF env var (DEEPSEEK_V3_HF_MODEL /

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -631,11 +631,11 @@ def _run_chunked_prefill(
                 "reference='trace' requires MLA_CHUNKED_TRACE_DIR (root) or "
                 "MLA_CHUNKED_TRACE_PATH (single trace) -- trace-only scenario"
             )
-        # Must ASSERT, not skip: discover_traces filters siblings on a "kimi" substring, so Kimi-K3
-        # would be handed Kimi-K2.6's traces silently. Checked here -- the one point both the
-        # TRACE_DIR and TRACE_PATH routes cross.
+        # Must ASSERT, not skip: trace resolution would otherwise hand this variant someone else's
+        # traces and compare across architectures. Checked here -- the one point both the TRACE_DIR
+        # and TRACE_PATH routes cross.
         trace_variant = request.getfixturevalue("variant")
-        assert getattr(trace_variant, "supports_pretrained", True), (
+        assert trace_variant.pretrained_mla_layer is not None, (
             f"reference='trace' is not supported for variant '{trace_variant.name}': it has no "
             "reachable pretrained checkpoint, so no GPU trace was ever recorded for it, and trace "
             "resolution would silently substitute another variant's traces. Use reference='cpu' "
@@ -668,13 +668,18 @@ def _run_chunked_prefill(
     seq_len_cache = ((max_window + chunk_size_global - 1) // chunk_size_global) * chunk_size_global
 
     if use_pretrained:
-        config, sd = request.getfixturevalue("pretrained_transformer_weights")
-        weights = sd["layers"][0]["mla_weights"]
+        # MLA-only fixture: this driver uses nothing but the attention weights, and the full-layer one
+        # cannot load Kimi-K3's MXFP4 MoE side.
+        config, weights = request.getfixturevalue("pretrained_mla_weights")
     else:
         config, weights = request.getfixturevalue("random_weights")
     config.max_seq_len = seq_len_cache
     kvpe_dim = config.kv_lora_rank + config.qk_rope_head_dim
     hidden_size = config.hidden_size
+    # The GPU trace stores k_pe HF half-split while the device cache is Meta interleaved. Under NoPE
+    # (Kimi-K3) neither side rotates, so the bases coincide and re-interleaving would corrupt k_pe:
+    # measured 1.000000 raw against 0.078 re-interleaved.
+    trace_pe_interleave = use_trace and not getattr(config, "mla_use_nope", False)
 
     logger.info(
         f"chunked prefill: mesh={tuple(mesh_device.shape)} chunk={chunk_size_global} prefill={prefill_len} "
@@ -757,12 +762,11 @@ def _run_chunked_prefill(
         cache_host = torch.zeros(num_users, 1, seq_len_cache, kvpe_dim, dtype=torch.bfloat16)
         for u in range(num_users):
             kv_prior = users[u]["kv_prior"]
-            if use_trace:
-                # The GPU trace stores k_pe in the HF half-split basis; the device cache is the Meta
-                # interleaved basis. Re-interleave the k_pe block before preload (k_nope is basis-
-                # agnostic) -- same transform the post-run cache comparison applies. Without this the
-                # 50k preloaded prefix attends in the wrong basis and only the output PCC (not the
-                # cache PCC, which checks just the new region) shows the ~0.92 drop.
+            if trace_pe_interleave:
+                # Re-interleave the k_pe block before preload (k_nope is basis-agnostic) -- same
+                # transform the post-run cache comparison applies. Without this the 50k preloaded
+                # prefix attends in the wrong basis and only the output PCC (not the cache PCC, which
+                # checks just the new region) shows the ~0.92 drop.
                 kv_prior = kv_prior.clone()
                 d = kvpe_dim - config.kv_lora_rank
                 pe = kv_prior[:, config.kv_lora_rank :]
@@ -926,7 +930,7 @@ def _run_chunked_prefill(
     # ---- check the measured KV cache vs the reference. The rotation accumulates into the canonical
     #      block-cyclic layout, so blockcyclic_positions un-rotates the final cache (incl. partial
     #      chunks). k_nope is compared directly; k_pe is direct for the CPU ref (mla_reference is
-    #      Meta-style) but re-interleaved for the GPU trace (HF half-split -> device Meta basis). ----
+    #      Meta-style) and for NoPE, re-interleaved for a roped GPU trace -- see trace_pe_interleave. ----
     if any(users[u]["kv_post"] is not None for u in range(num_users)):
         cache_sr = ttnn.to_torch(
             tt_kvpe_cache.storage,
@@ -945,11 +949,11 @@ def _run_chunked_prefill(
             dev = nat[prefill_len : users[u]["total_len"]]
             ref = users[u]["kv_post"][prefill_len:].to(torch.float32)
             ref_pe = ref[:, kv_lora:]
-            if use_trace:  # GPU trace stores k_pe HF half-split -> re-interleave to the device Meta basis
+            if trace_pe_interleave:  # HF half-split -> device Meta basis
                 ref_pe = torch.stack([ref_pe[:, : d // 2], ref_pe[:, d // 2 :]], dim=-1).reshape(-1, d)
             _, nope_msg = assert_with_pcc(ref[:, :kv_lora], dev[:, :kv_lora], 0.98)
             _, pe_msg = assert_with_pcc(ref_pe, dev[:, kv_lora:], 0.98)
-            basis = "Meta-aligned" if use_trace else "direct"
+            basis = "Meta-aligned" if trace_pe_interleave else "direct"
             logger.info(f"  user {u} KV cache PCC -- k_nope: {nope_msg}  k_pe[{basis}]: {pe_msg}")
 
     logger.success(f"✓ Chunked prefill passed ({'trace' if use_trace else 'cpu'} ref, {num_users} user(s))")
@@ -1039,10 +1043,11 @@ def test_mla_chunked_prefill(
     GPU traces in MLA_CHUNKED_TRACE_DIR). It otherwise runs the same
     config-driven driver on any arch/mesh.
 
-    kimi_k3 (NoPE + output gate, 96 heads) runs 'cpu' and 'func' only, and 'scalar' only -- 'trace'
-    and 'metadata' are both skipped explicitly below. Random weights only (supports_pretrained=False).
-    Its rotation scenarios still matter: rotation comes from the block-cyclic cache write and the
-    causal offset, not from RoPE."""
+    kimi_k3 (NoPE + output gate, 96 heads) runs 'scalar' only -- 'metadata' is skipped explicitly
+    below. It runs 'trace' like kimi_k2_6, but needs MLA_CHUNKED_TRACE_PATH rather than
+    MLA_CHUNKED_TRACE_DIR (its trace dir name collides with K2.6's), and takes real weights from layer
+    3 via variant.pretrained_mla_layer. Its rotation scenarios still matter: rotation comes from the
+    block-cyclic cache write and the causal offset, not from RoPE."""
     # Per-variant, not module-level: two CI selectors for this test are variant-unqualified, so
     # without this a kimi_k3 case would run on Wormhole T3K where it has never been validated.
     if variant.name == "kimi_k3" and not is_blackhole():
@@ -1053,13 +1058,6 @@ def test_mla_chunked_prefill(
     # Incidental, not a K3 guarantee; re-enable when K3 has a runtime that actually feeds metadata.
     if variant.name == "kimi_k3" and use_metadata_tensor:
         pytest.skip("kimi_k3 has no runtime, so the metadata (device-scalar) path is unreachable for it")
-    # No K3 checkpoint is reachable, so no GPU trace was ever recorded for it. _run_chunked_prefill
-    # already asserts on supports_pretrained, but only once a trace root is configured -- so on a box
-    # with MLA_CHUNKED_TRACE_DIR set these cases would hard-fail instead of being cleanly out of
-    # scope. Skip up front; the assert stays as the backstop for any future supports_pretrained=False
-    # variant and for the silent K2.6-trace-substitution it was written to catch.
-    if variant.name == "kimi_k3" and reference == "trace":
-        pytest.skip("kimi_k3 has no reachable checkpoint, so no GPU trace exists for it")
     # Opt into real weights on the cpu path when the variant's checkpoint env var is set. The "trace"
     # path already forces pretrained; "func" is ref-less so weights don't matter. The pretrained
     # fixture skips the test if the env var is set but the checkpoint is incomplete.

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -629,10 +629,7 @@ def _run_chunked_prefill(
             "trace was ever recorded for it (mla_trace_defaults is empty). Use reference='cpu' or "
             "reference='func', or point MLA_CHUNKED_TRACE_PATH at a trace."
         )
-        try:
-            traces = resolve_traces(trace_paths, num_users)
-        except FileNotFoundError as e:  # registered but not staged here -- out of scope, not a failure
-            pytest.skip(f"{trace_variant.name}: {e}")
+        traces = resolve_traces(trace_paths, num_users)
         # The trace is a DENSE token sequence; iters_isl just chunks it variably. Partial iters pad
         # the device's fixed-width chunk (masked by causality) -- they are not pad in the sequence --
         # so any iters_isl / prefill works exactly like the CPU ref. The only trace constraint is
@@ -746,10 +743,8 @@ def _run_chunked_prefill(
         for u in range(num_users):
             kv_prior = users[u]["kv_prior"]
             if trace_pe_interleave:
-                # Re-interleave the k_pe block before preload (k_nope is basis-agnostic) -- same
-                # transform the post-run cache comparison applies. Without this the 50k preloaded
-                # prefix attends in the wrong basis and only the output PCC (not the cache PCC, which
-                # checks just the new region) shows the ~0.92 drop.
+                # Same transform the post-run cache comparison applies (k_nope is basis-agnostic);
+                # without it the preloaded prefix attends in the wrong basis.
                 kv_prior = kv_prior.clone()
                 d = kvpe_dim - config.kv_lora_rank
                 pe = kv_prior[:, config.kv_lora_rank :]

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -197,8 +197,7 @@ def run_model(
 
     # Conditionally load fixtures - only load what we need!
     if use_pretrained:
-        config, sd = request.getfixturevalue("pretrained_transformer_weights")
-        weights = sd["layers"][0]["mla_weights"]
+        config, weights = request.getfixturevalue("pretrained_mla_layer_weights")
     else:
         config, weights = request.getfixturevalue("random_weights")
 
@@ -650,15 +649,14 @@ def _run_chunked_prefill(
     if use_pretrained:
         # MLA-only fixture: this driver uses nothing but the attention weights, and the full-layer one
         # cannot load Kimi-K3's MXFP4 MoE side.
-        config, weights = request.getfixturevalue("pretrained_mla_weights")
+        config, weights = request.getfixturevalue("pretrained_mla_layer_weights")
     else:
         config, weights = request.getfixturevalue("random_weights")
     config.max_seq_len = seq_len_cache
     kvpe_dim = config.kv_lora_rank + config.qk_rope_head_dim
     hidden_size = config.hidden_size
     # The GPU trace stores k_pe HF half-split while the device cache is Meta interleaved. Under NoPE
-    # (Kimi-K3) neither side rotates, so the bases coincide and re-interleaving would corrupt k_pe:
-    # measured 1.000000 raw against 0.078 re-interleaved.
+    # (Kimi-K3) neither side rotates.
     trace_pe_interleave = use_trace and not getattr(config, "mla_use_nope", False)
 
     logger.info(

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -33,10 +33,9 @@ from models.demos.deepseek_v3_d_p.tt.mla.utils import (
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config, get_max_payload_size
 from models.demos.deepseek_v3_d_p.utils.chunked_prefill_utils import (
     cpu_mla_reference,
-    discover_traces,
     load_trace,
     partition_iters,
-    single_trace,
+    resolve_traces,
 )
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCacheFormat, init_kvpe_cache, init_mla_kv_cache
 from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import is_high_power
@@ -526,14 +525,9 @@ def test_kimi_mla(
 # Unified chunked-prefill driver. One loop (preload -> N iters of write+rope+ring_mla -> compare)
 # parametrized by where the prefix/reference come from. See test_mla_chunked_prefill below.
 # ---------------------------------------------------------------------------------------------------
-# Set MLA_CHUNKED_TRACE_DIR to the ROOT dir holding one subdir per layer-0 GPU trace (each with
-# mla_io/ + kv_cache/). It enables the prefill>0 scenarios (load the prior KV + reference from the
-# real GPU run); multi-user pulls one trace per user, cycling if there are fewer traces than users.
-# The root may mix kimi and deepseek traces as siblings; discover_traces filters by variant name.
-MLA_CHUNKED_TRACE_DIR = os.environ.get("MLA_CHUNKED_TRACE_DIR")
-# MLA_CHUNKED_TRACE_PATH points straight at ONE specific trace dir (the leaf holding mla_io/ +
-# kv_cache/, not the root). It takes precedence over MLA_CHUNKED_TRACE_DIR and skips the root
-# scan/variant-filter entirely; the single trace is shared (cycled) across all users.
+# reference='trace' takes its trace dirs from variant.mla_trace_defaults. MLA_CHUNKED_TRACE_PATH
+# overrides that with ONE specific trace dir (the leaf holding mla_io/ + kv_cache/), shared across all
+# users -- for a trace that is not the variant's registered one.
 MLA_CHUNKED_TRACE_PATH = os.environ.get("MLA_CHUNKED_TRACE_PATH")
 
 # Per-iteration VALID token counts for the rotation/padding edge cases, tuned for the TARGET 8x4 mesh
@@ -598,7 +592,8 @@ def _run_chunked_prefill(
       * "cpu"   -> synthetic inputs + torch MLA reference (k_pe in Meta basis). Partial-chunk iters
                    (rotation) allowed; any prefix is preloaded from the CPU reference KV.
       * "trace" -> GPU-trace inputs + reference (k_pe in HF basis, re-interleaved to compare). TRACE
-                    ONLY: requires MLA_CHUNKED_TRACE_DIR or MLA_CHUNKED_TRACE_PATH (skips if both unset); supports partial iters.
+                    ONLY: dirs come from variant.mla_trace_defaults (or MLA_CHUNKED_TRACE_PATH);
+                    supports partial iters.
       * None    -> no reference (functional/perf): random inputs + random prefix, finite-output check.
     Multi-user partitions iters_isl across users (last gets the remainder); each user is independent in
     its own cache slot, so cross-user contamination surfaces as a per-user output PCC drop.
@@ -625,22 +620,19 @@ def _run_chunked_prefill(
     assert prefill_len % tile == 0, f"prefill_len {prefill_len} must be tile-aligned"
 
     use_trace = reference == "trace"
+    traces = None
     if use_trace:
-        if MLA_CHUNKED_TRACE_DIR is None and MLA_CHUNKED_TRACE_PATH is None:
-            pytest.skip(
-                "reference='trace' requires MLA_CHUNKED_TRACE_DIR (root) or "
-                "MLA_CHUNKED_TRACE_PATH (single trace) -- trace-only scenario"
-            )
-        # Must ASSERT, not skip: trace resolution would otherwise hand this variant someone else's
-        # traces and compare across architectures. Checked here -- the one point both the TRACE_DIR
-        # and TRACE_PATH routes cross.
         trace_variant = request.getfixturevalue("variant")
-        assert trace_variant.pretrained_mla_layer is not None, (
-            f"reference='trace' is not supported for variant '{trace_variant.name}': it has no "
-            "reachable pretrained checkpoint, so no GPU trace was ever recorded for it, and trace "
-            "resolution would silently substitute another variant's traces. Use reference='cpu' "
-            "(CPU torch reference, random or real weights) or reference='func' (no reference)."
+        trace_paths = [MLA_CHUNKED_TRACE_PATH] if MLA_CHUNKED_TRACE_PATH else trace_variant.mla_trace_defaults
+        assert trace_paths, (
+            f"reference='trace' is not supported for variant '{trace_variant.name}': no golden MLA "
+            "trace was ever recorded for it (mla_trace_defaults is empty). Use reference='cpu' or "
+            "reference='func', or point MLA_CHUNKED_TRACE_PATH at a trace."
         )
+        try:
+            traces = resolve_traces(trace_paths, num_users)
+        except FileNotFoundError as e:  # registered but not staged here -- out of scope, not a failure
+            pytest.skip(f"{trace_variant.name}: {e}")
         # The trace is a DENSE token sequence; iters_isl just chunks it variably. Partial iters pad
         # the device's fixed-width chunk (masked by causality) -- they are not pad in the sequence --
         # so any iters_isl / prefill works exactly like the CPU ref. The only trace constraint is
@@ -648,15 +640,6 @@ def _run_chunked_prefill(
         use_pretrained = True  # the GPU trace was generated with the real checkpoint
 
     groups = partition_iters(iters_isl, num_users)
-    # Resolve trace dirs: a single explicit trace (MLA_CHUNKED_TRACE_PATH) wins; otherwise scan the
-    # root (MLA_CHUNKED_TRACE_DIR) and filter the kimi/deepseek siblings by variant name.
-    if not use_trace:
-        traces = None
-    elif MLA_CHUNKED_TRACE_PATH is not None:
-        traces = single_trace(MLA_CHUNKED_TRACE_PATH, num_users)
-    else:
-        variant_name = request.getfixturevalue("variant").name
-        traces = discover_traces(MLA_CHUNKED_TRACE_DIR, num_users, variant_name)
 
     # Cache holds the max (kv_actual + chunk) window across all users/iters, slab-aligned, >= 2 slabs.
     max_window = chunk_size_global * 2
@@ -1029,7 +1012,7 @@ def test_mla_chunked_prefill(
     """Unified chunked-prefill driver crossed with independent mesh and reference axes. Each
     functionality scenario (rotation edges, production depth, multi-user, deep prefix) runs on any mesh
     and is validated against the CPU torch reference ('cpu'), the GPU trace ('trace', skips without
-    MLA_CHUNKED_TRACE_DIR/PATH), or run with no reference ('func'). Select with e.g.
+    the variant has no registered trace), or run with no reference ('func'). Select with e.g.
     -k 'maxedge-1u and trace and 8x4'. See _run_chunked_prefill.
 
     Real weights on the CPU-reference path: point the variant's HF env var (DEEPSEEK_V3_HF_MODEL /
@@ -1040,13 +1023,11 @@ def test_mla_chunked_prefill(
     replays full-chunk iters and so never exercises real weights across the rotation/partial-chunk edge
     scenarios that the cpu path covers. Without the env var, fall back to random (mirroring
     test_kimi_mla). kimi_k2_6 also runs the trace path (loader + k_pe re-interleave are arch-agnostic; needs kimi
-    GPU traces in MLA_CHUNKED_TRACE_DIR). It otherwise runs the same
-    config-driven driver on any arch/mesh.
+    its own registered traces). It otherwise runs the same config-driven driver on any arch/mesh.
 
     kimi_k3 (NoPE + output gate, 96 heads) runs 'scalar' only -- 'metadata' is skipped explicitly
-    below. It runs 'trace' like kimi_k2_6, but needs MLA_CHUNKED_TRACE_PATH rather than
-    MLA_CHUNKED_TRACE_DIR (its trace dir name collides with K2.6's), and takes real weights from layer
-    3 via variant.pretrained_mla_layer. Its rotation scenarios still matter: rotation comes from the
+    below. It runs 'trace' like kimi_k2_6, taking real weights from layer 3 via
+    variant.pretrained_mla_layer. Its rotation scenarios still matter: rotation comes from the
     block-cyclic cache write and the causal offset, not from RoPE."""
     # Per-variant, not module-level: two CI selectors for this test are variant-unqualified, so
     # without this a kimi_k3 case would run on Wormhole T3K where it has never been validated.

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/deepseek_v3.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/deepseek_v3.py
@@ -19,6 +19,10 @@ class DeepSeekV3Adapter(MLAPrefillAdapter):
     ttnn_cache_default = "/mnt/models/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-Cache-prefill_secure"
     default_gate_mode = "DEVICE_FP32"
     prefill_trace_default = "/mnt/models/deepseek-prefill-cache/golden/longbook_qa_eng_prefill_56320_nopad"
+    mla_trace_defaults = (
+        "/mnt/models/deepseek-prefill-cache/golden/mla_sdpa_traces/deepseek_math_56320_sdpa_mla",
+        "/mnt/models/deepseek-prefill-cache/golden/mla_sdpa_traces/deepseek_metal_56320_sdpa_mla",
+    )
 
     # --- test metadata (HF download coordinates + PCC thresholds) ---
     hf_repo_id = "deepseek-ai/DeepSeek-R1-0528"

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_1.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/glm_5_1.py
@@ -38,6 +38,7 @@ class GLM51Adapter(MLAPrefillAdapter):
     ttnn_cache_default = "/mnt/models/deepseek-prefill-cache/GLM-5_1-Cache"
     default_gate_mode = "DEVICE_FP32"  # GLM: single expert group
     prefill_trace_default = "/mnt/models/deepseek-prefill-cache/golden/structured_traces/glm_51_code_debug_55k_vllm"
+    mla_trace_defaults = ("/mnt/models/deepseek-prefill-cache/golden/mla_sdpa_traces/glm_51_56320_sdpa_mla",)
 
     # Routing consumes 512 B; leave 256 B for sparse-MLA high-bandwidth-gather semaphores and rest for other needs.
     l1_small_size = 1152

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k2_6.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k2_6.py
@@ -30,6 +30,10 @@ class KimiK26Adapter(MLAPrefillAdapter):
     ttnn_cache_default = "/mnt/models/Kimi-K2_6-Cache/Kimi-K2_6-Cache-prefill"
     default_gate_mode = "DEVICE_FP32"  # Kimi (1 expert group)
     prefill_trace_default = "/mnt/models/deepseek-prefill-cache/golden/kimi-26/kimi_longbook_56320"
+    mla_trace_defaults = (
+        "/mnt/models/deepseek-prefill-cache/golden/mla_sdpa_traces/kimi_math_56320_sdpa_mla",
+        "/mnt/models/deepseek-prefill-cache/golden/mla_sdpa_traces/kimi_metal_56320_sdpa_mla",
+    )
 
     # Single expert group + device gate: route routing-all-gather semaphores to L1_SMALL.
     # Routing consumes 512 B; leave 256 B for MLA high-bandwidth-gather semaphores.

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k2_7.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k2_7.py
@@ -27,3 +27,5 @@ class KimiK27Adapter(KimiK26Adapter):
     test_prefill_trace_default = (
         "/mnt/models/deepseek-prefill-cache/golden/structured_traces/vllm-kimi-k27-codedebug-56320"
     )
+    # Not inherited from Kimi-K2.6: different checkpoint, and K2.7's trace has no mla_io/ streams.
+    mla_trace_defaults = ()

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k3.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k3.py
@@ -57,9 +57,12 @@ class KimiK3Adapter(MLAPrefillAdapter):
     mla_ref_cache_env = "KIMI_K3_MLA_REF_CACHE"
     ttnn_cache_env = "TT_KIMI_K3_PREFILL_TTNN_CACHE"
     # Loading the staged checkpoint wholesale needs an MXFP4 -> bf16 dequantizer that does not exist
-    # yet, so the pretrained fixtures stay skipped. The MoE gate is exempt: it is unquantized and read
+    # yet, so the full-transformer fixtures stay skipped. The MoE gate is exempt: it is unquantized and read
     # through a prefix-filtered safe_open.
     supports_pretrained = False
+    # MLA alone is loadable: quantization_config.ignore covers self_attn, so those weights are bf16.
+    # The first full-attention layer, not 0 -- layers 0-2 are KDA and hold no MLA tensors.
+    pretrained_mla_layer = KimiK3Config.mla_layer_ids()[0]
     # Left as None: shared_path feeds conftest's state_dict fixture, which pytest would resolve --
     # loading all 1.5 TB -- before the supports_pretrained skip in the fixture body runs.
     shared_path = None

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k3.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k3.py
@@ -52,7 +52,8 @@ class KimiK3Adapter(MLAPrefillAdapter):
     hf_repo_id = "moonshotai/Kimi-K3"
     env_var = "KIMI_K3_HF_MODEL"
     default_local_path = Path("models/demos/deepseek_v3_d_p/reference/kimi_k3")
-    num_layers_to_download = 1
+    # The download fallback fetches layers 0..N-1, and pretrained_mla_layer is 3.
+    num_layers_to_download = 4
     ref_cache_env = "TT_KIMI_K3_PREFILL_HOST_REF_CACHE"
     mla_ref_cache_env = "KIMI_K3_MLA_REF_CACHE"
     ttnn_cache_env = "TT_KIMI_K3_PREFILL_TTNN_CACHE"

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k3.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k3.py
@@ -58,7 +58,7 @@ class KimiK3Adapter(MLAPrefillAdapter):
     mla_ref_cache_env = "KIMI_K3_MLA_REF_CACHE"
     ttnn_cache_env = "TT_KIMI_K3_PREFILL_TTNN_CACHE"
     # Loading the staged checkpoint wholesale needs an MXFP4 -> bf16 dequantizer that does not exist
-    # yet, so the pretrained fixtures stay skipped. The MoE gate is exempt: it is unquantized and read
+    # yet, so the full-transformer fixtures stay skipped. The MoE gate is exempt: it is unquantized and read
     # through a prefix-filtered safe_open.
     supports_pretrained = False
     # MLA alone is loadable: quantization_config.ignore covers self_attn, so those weights are bf16.

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k3.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k3.py
@@ -57,7 +57,7 @@ class KimiK3Adapter(MLAPrefillAdapter):
     mla_ref_cache_env = "KIMI_K3_MLA_REF_CACHE"
     ttnn_cache_env = "TT_KIMI_K3_PREFILL_TTNN_CACHE"
     # Loading the staged checkpoint wholesale needs an MXFP4 -> bf16 dequantizer that does not exist
-    # yet, so the full-transformer fixtures stay skipped. The MoE gate is exempt: it is unquantized and read
+    # yet, so the pretrained fixtures stay skipped. The MoE gate is exempt: it is unquantized and read
     # through a prefix-filtered safe_open.
     supports_pretrained = False
     # MLA alone is loadable: quantization_config.ignore covers self_attn, so those weights are bf16.

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k3.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k3.py
@@ -63,6 +63,7 @@ class KimiK3Adapter(MLAPrefillAdapter):
     # MLA alone is loadable: quantization_config.ignore covers self_attn, so those weights are bf16.
     # The first full-attention layer, not 0 -- layers 0-2 are KDA and hold no MLA tensors.
     pretrained_mla_layer = KimiK3Config.mla_layer_ids()[0]
+    mla_trace_defaults = ("/mnt/models/deepseek-prefill-cache/golden/structured_traces/kimi_k3_100k_vllm",)
     # Left as None: shared_path feeds conftest's state_dict fixture, which pytest would resolve --
     # loading all 1.5 TB -- before the supports_pretrained skip in the fixture body runs.
     shared_path = None

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/sparse_mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/sparse_mla.py
@@ -40,6 +40,7 @@ class SparseMLAPrefillAdapter(MLAPrefillAdapter):
     """
 
     supports_pretrained = False
+    pretrained_mla_layer = None  # no reachable checkpoint, hence no MLA weights and no GPU trace
     # No golden prefill trace: these variants are exercised only by the sparse-MLA reference
     # tests, which build their own traces. Set explicitly so ``.prefill_trace_default`` is always
     # readable (the base declares it annotation-only).

--- a/models/demos/deepseek_v3_d_p/utils/chunked_prefill_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/chunked_prefill_utils.py
@@ -69,12 +69,12 @@ def discover_traces(root, num_users, variant_name=None):
     deepseek_*_sdpa_mla). When `variant_name` is given, select by whether the dir name contains 'kimi':
     a kimi variant keeps the kimi_* dirs, any other variant keeps the rest.
 
-    NOTE the filter is a substring test and so cannot separate two variants of the same family: every
-    kimi_* variant selects the same dirs. It is therefore only safe for variants that actually have
-    recorded traces. Callers must reject the others *before* getting here -- test_mla.py's
-    _run_chunked_prefill asserts on ``variant.supports_pretrained``, since a trace is recorded from a
-    real checkpoint and a variant without one (kimi_k3, sparse_mla) would otherwise be handed
-    Kimi-K2.6's traces and silently compared across architectures.
+    NOTE the filter is a substring test on the VARIANT name, so it cannot separate two variants of one
+    family: `kimi_k2_6` and `kimi_k3` both select every kimi_* dir. Renaming the dirs does not help --
+    ``want_kimi`` comes from the variant name. Such a variant must be given MLA_CHUNKED_TRACE_PATH; with
+    a root it silently gets its sibling's traces and the comparison fails at ~0 PCC.
+    _run_chunked_prefill additionally asserts ``variant.pretrained_mla_layer`` is not None, since a
+    variant with no checkpoint never had a trace recorded at all.
     """
     dirs = sorted(d for d in Path(root).iterdir() if d.is_dir())
     assert dirs, f"no trace subdirs under {root}"
@@ -98,10 +98,17 @@ def single_trace(path, num_users):
 
 
 def load_trace(d):
-    """Return (mla_input [S,H], mla_output [S,H], kv_post [S,kvpe]) for layer 0, all bf16."""
-    mi = load_file(d / "mla_io" / "mla_input_layer_0.safetensors")["mla_input_layer_0"]
-    mo = load_file(d / "mla_io" / "mla_output_layer_0.safetensors")["mla_output_layer_0"]
-    kv = load_file(d / "kv_cache" / "layer_0.safetensors")["kv_post_transform_layer_0"]
+    """Return (mla_input [S,H], mla_output [S,H], kv_post [S,kvpe]) for the traced layer, all bf16.
+
+    The layer index comes off the filenames rather than being assumed 0: on a hybrid model it cannot
+    be 0 (Kimi-K3 traces layer 3, its first full-attention layer).
+    """
+    inputs = sorted((d / "mla_io").glob("mla_input_layer_*.safetensors"))
+    assert len(inputs) == 1, f"trace dir {d}: expected exactly one traced MLA layer, found {len(inputs)}"
+    layer = inputs[0].stem[len("mla_input_layer_") :]
+    mi = load_file(inputs[0])[f"mla_input_layer_{layer}"]
+    mo = load_file(d / "mla_io" / f"mla_output_layer_{layer}.safetensors")[f"mla_output_layer_{layer}"]
+    kv = load_file(d / "kv_cache" / f"layer_{layer}.safetensors")[f"kv_post_transform_layer_{layer}"]
     return mi.to(torch.bfloat16), mo.to(torch.bfloat16), kv.to(torch.bfloat16)
 
 

--- a/models/demos/deepseek_v3_d_p/utils/chunked_prefill_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/chunked_prefill_utils.py
@@ -62,39 +62,22 @@ def _ref_cache_key(config, weights, hidden_2d) -> str:
     return h.hexdigest()[:16]
 
 
-def discover_traces(root, num_users, variant_name=None):
-    """Immediate subdirs of `root`, one per user (cycled if fewer than num_users). Assert mla_io/ + kv_cache/.
+def resolve_traces(paths, num_users):
+    """One trace dir per user, cycled if there are fewer dirs than users. `paths` is either the
+    variant's own mla_trace_defaults or a single explicit override.
 
-    `root` may hold both kimi and deepseek traces as sibling subdirs (e.g. kimi_*_sdpa_mla next to
-    deepseek_*_sdpa_mla). When `variant_name` is given, select by whether the dir name contains 'kimi':
-    a kimi variant keeps the kimi_* dirs, any other variant keeps the rest.
-
-    NOTE the filter is a substring test on the VARIANT name, so it cannot separate two variants of one
-    family: `kimi_k2_6` and `kimi_k3` both select every kimi_* dir. Renaming the dirs does not help --
-    ``want_kimi`` comes from the variant name. Such a variant must be given MLA_CHUNKED_TRACE_PATH; with
-    a root it silently gets its sibling's traces and the comparison fails at ~0 PCC.
-    _run_chunked_prefill additionally asserts ``variant.pretrained_mla_layer`` is not None, since a
-    variant with no checkpoint never had a trace recorded at all.
+    Raises FileNotFoundError when a registered dir is simply not staged on this box (the caller turns
+    that into a skip); asserts when a dir is there but is not a trace.
     """
-    dirs = sorted(d for d in Path(root).iterdir() if d.is_dir())
-    assert dirs, f"no trace subdirs under {root}"
-    if variant_name is not None:
-        want_kimi = "kimi" in variant_name.lower()
-        dirs = [d for d in dirs if ("kimi" in d.name.lower()) == want_kimi]
-        assert dirs, f"no {'kimi' if want_kimi else 'non-kimi'} trace subdirs under {root} (variant={variant_name})"
+    assert paths, "no trace dirs given"
+    dirs = [Path(p) for p in paths]
+    missing = [str(d) for d in dirs if not d.is_dir()]
+    if missing:
+        raise FileNotFoundError(f"MLA trace dir(s) not present: {missing}")
     for d in dirs:
         assert (d / "mla_io").is_dir(), f"trace dir {d} is missing mla_io/"
         assert (d / "kv_cache").is_dir(), f"trace dir {d} is missing kv_cache/"
     return [dirs[u % len(dirs)] for u in range(num_users)]
-
-
-def single_trace(path, num_users):
-    """Use `path` directly as ONE trace dir (the leaf holding mla_io/ + kv_cache/), shared across all
-    users. For MLA_CHUNKED_TRACE_PATH, which points at a specific trace rather than the root of many."""
-    d = Path(path)
-    assert (d / "mla_io").is_dir(), f"trace dir {d} is missing mla_io/"
-    assert (d / "kv_cache").is_dir(), f"trace dir {d} is missing kv_cache/"
-    return [d for _ in range(num_users)]
 
 
 def load_trace(d):

--- a/models/demos/deepseek_v3_d_p/utils/chunked_prefill_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/chunked_prefill_utils.py
@@ -64,17 +64,11 @@ def _ref_cache_key(config, weights, hidden_2d) -> str:
 
 def resolve_traces(paths, num_users):
     """One trace dir per user, cycled if there are fewer dirs than users. `paths` is either the
-    variant's own mla_trace_defaults or a single explicit override.
-
-    Raises FileNotFoundError when a registered dir is simply not staged on this box (the caller turns
-    that into a skip); asserts when a dir is there but is not a trace.
-    """
+    variant's own mla_trace_defaults or a single explicit override."""
     assert paths, "no trace dirs given"
     dirs = [Path(p) for p in paths]
-    missing = [str(d) for d in dirs if not d.is_dir()]
-    if missing:
-        raise FileNotFoundError(f"MLA trace dir(s) not present: {missing}")
     for d in dirs:
+        assert d.is_dir(), f"trace dir {d} does not exist"
         assert (d / "mla_io").is_dir(), f"trace dir {d} is missing mla_io/"
         assert (d / "kv_cache").is_dir(), f"trace dir {d} is missing kv_cache/"
     return [dirs[u % len(dirs)] for u in range(num_users)]

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -118,7 +118,6 @@
 - name: "Kimi-K3-2.8T MLA chunked accuracy 55k@5k (vs golden trace)"
   cmd: |
     export KIMI_K3_HF_MODEL=/mnt/models/blaze/moonshotai/Kimi-K3
-    export MLA_CHUNKED_TRACE_PATH=/mnt/models/deepseek-prefill-cache/golden/structured_traces/kimi_k3_100k_vllm
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -115,6 +115,25 @@
   team: models
   sp_config: sc1
 
+- name: "Kimi-K3-2.8T MLA chunked accuracy 55k@5k (vs golden trace)"
+  cmd: |
+    export KIMI_K3_HF_MODEL=/mnt/models/blaze/moonshotai/Kimi-K3
+    export MLA_CHUNKED_TRACE_PATH=/mnt/models/deepseek-prefill-cache/golden/structured_traces/kimi_k3_100k_vllm
+
+    mpirun --bind-to none --pernode --tag-output bash -lc '
+      export OMP_NUM_THREADS=$(nproc)
+      uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "k3 and production-50k+5k and trace and 8x4 and fabric2d and scalar and no_determinism" -vvv --tb=short
+    '
+  test_type: k3_mla_trace
+  test_group: module
+  skus:
+    bh_sc1:
+      timeout: 6
+  owner_id: U07N3CUUN05  # Iva Potkonjak
+  team: models
+  sp_config: sc1
+
 - name: "Kimi-K3-2.8T MLA chunked perf 55k@5k"
   cmd: |
 


### PR DESCRIPTION
### PR Category
Feature

### Issue
[[Kimi K3] MLA: validate against real weights](https://github.com/tenstorrent/tt-metal/issues/53154)


### Summary

Kimi-K3 MLA chunked prefill is validated against its golden vLLM trace, not just random weights.

- Real weights come from **layer 3** — K3's first full-attention layer, 0-2 are KDA
- K3 is **NoPE**, so `k_pe` is cached unrotated on both sides and must *not* be re-interleaved the way a roped trace is
- Trace dirs now come from `variant.mla_trace_defaults` instead of scanning a root and matching names. That filter could not separate `kimi_k2_6` from `kimi_k3`, and handed DeepSeek-V3 the GLM dirs. `MLA_CHUNKED_TRACE_DIR` is gone, `MLA_CHUNKED_TRACE_PATH` stays as an override.
- New CI stage `k3_mla_trace`: 56320 tokens as 11 chunks with no preload, the same shape the transformer trace jobs use. +6 min to the `models`/`bh_sc1` budget.

Device vs trace on 8x4 — K3 output `0.99949`, k_nope `0.99989`, k_pe `0.99994`.

### Notes for reviewers
- [ ] [Blaze Models Prefill tests](https://github.com/tenstorrent/tt-metal/actions/runs/32276234699) (`k3_mla_trace,k3_mla,k3_mla_perf,mla_chunked,kv_cache_table,mla,kimi_mla,dsa_mla_glm,kimi_k3_moe`) in progress⚠️

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jmitrovic/k3_mla_trace_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jmitrovic/k3_mla_trace_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jmitrovic/k3_mla_trace_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jmitrovic/k3_mla_trace_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jmitrovic/k3_mla_trace_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jmitrovic/k3_mla_trace_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jmitrovic/k3_mla_trace_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jmitrovic/k3_mla_trace_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jmitrovic/k3_mla_trace_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jmitrovic/k3_mla_trace_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jmitrovic/k3_mla_trace_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jmitrovic/k3_mla_trace_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jmitrovic/k3_mla_trace_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jmitrovic/k3_mla_trace_test)