### PR TITLE
[Bug fix] ttnn: derive default mesh composer from tensor topology in to_torch

### DIFF
--- a/tests/ttnn/distributed/test_default_mesh_composer.py
+++ b/tests/ttnn/distributed/test_default_mesh_composer.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""to_torch()/to_numpy() without an explicit mesh_composer on a multi-device tensor.
+
+Repro of record: TT_FATAL at pytensor.cpp ("Can't convert a tensor distributed on
+MeshShape([1, 2]) mesh to row-major logical tensor. Supply a mesh composer to
+concatenate multi-device shards.") fired from Tensor.to_torch() with
+mesh_composer=None.
+
+Part (a): a replicated distribution still raises the original error verbatim --
+the fallback must not silently mask distributions it cannot derive.
+
+Part (b): the same site/mesh/layout with a 1-D shard distribution (the exact
+case the error message names: "concatenate multi-device shards") now derives a
+default composer from the tensor's recorded topology, both host-side and after a
+full device write/readback round trip on MeshShape(1, 2).
+"""
+
+import pytest
+import torch
+import ttnn
+
+MESH_SHAPE = (1, 2)  # P300: 2x p150a
+SHARD_DIM = 3
+SHAPE = (1, 1, 64, 128)  # -> per-device shard (1, 1, 64, 64)
+
+
+def test_sharded_to_torch_without_composer_on_1x2_mesh():
+    device = ttnn.open_mesh_device(ttnn.MeshShape(*MESH_SHAPE))
+    try:
+        torch.manual_seed(0)
+        torch_input = torch.randn(*SHAPE, dtype=torch.float32)
+        torch_bf16 = torch_input.to(torch.bfloat16)
+
+        # (a) Original failure mode preserved: replicated distribution, no composer.
+        replicated = ttnn.from_torch(torch_bf16, mesh_mapper=ttnn.ReplicateTensorToMesh(device))
+        with pytest.raises(RuntimeError, match="Supply a mesh composer"):
+            replicated.to_torch()
+
+        # (b) Fixed path: 1-D sharded distribution, no composer.
+        mapper = ttnn.shard_tensor_to_mesh_mapper(device, dim=SHARD_DIM)
+        sharded = ttnn.from_torch(torch_bf16, mesh_mapper=mapper)
+
+        shards = ttnn.get_device_tensors(sharded)
+        assert len(shards) == 2
+        expected = torch.cat([s.to_torch() for s in shards], dim=SHARD_DIM)
+
+        composed = sharded.to_torch()
+        assert tuple(composed.shape) == SHAPE
+        assert torch.equal(composed, expected)
+        assert torch.equal(composed, torch_bf16)
+
+        # Same site/layout through the device: TILE layout, to_device + from_device.
+        sharded_tile = ttnn.from_torch(
+            torch_bf16, layout=ttnn.TILE_LAYOUT, mesh_mapper=ttnn.shard_tensor_to_mesh_mapper(device, dim=SHARD_DIM)
+        )
+        read_back = ttnn.from_device(ttnn.to_device(sharded_tile, device))
+        composed_tile = read_back.to_torch()
+        assert tuple(composed_tile.shape) == SHAPE
+        assert torch.equal(composed_tile, expected)
+    finally:
+        ttnn.close_mesh_device(device)

--- a/ttnn/api/ttnn/distributed/distributed_tensor.hpp
+++ b/ttnn/api/ttnn/distributed/distributed_tensor.hpp
@@ -85,6 +85,10 @@ public:
 
     static MeshToTensor create(const MeshDevice& mesh_device, const MeshComposerConfig& config);
 
+    // Shape-only overload for callers without a `MeshDevice` handle (e.g. composing an already
+    // host-side distributed tensor). Mirrors the shape-only `TensorToMesh::create` overload.
+    static MeshToTensor create(const MeshShape& mesh_shape, const MeshComposerConfig& config);
+
     // Composes a tensor distributed over a mesh.
     // The input tensor is expected to be distributed over a mesh of the same shape as the mesh device.
     // The output tensor will be a host-side tensor consisting of 1 device shard (i.e., mapped to 1x1 mesh).

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -485,6 +485,17 @@ public:
         distribution_shape_(distribution_shape),
         config_(config) {}
 
+    // Shape-only ctor for callers without a `MeshDevice` handle.
+    Impl(
+        const MeshShape& mesh_shape,
+        DistributionMode distribution_mode,
+        const MeshShape& distribution_shape,
+        const MeshComposerConfig& config) :
+        global_range_(mesh_shape),
+        distribution_mode_(distribution_mode),
+        distribution_shape_(distribution_shape),
+        config_(config) {}
+
     template <typename T>
     std::pair<std::vector<T>, Shape> compose(const Tensor& tensor) const {
         const auto cpu_tensor = tensor.cpu();
@@ -676,6 +687,26 @@ MeshToTensor MeshToTensor::create(const MeshDevice& mesh_device, const MeshCompo
     validate_mesh_offset(config.mesh_offset_override, distribution_mode, distributed_shape, mesh_device.shape());
 
     return MeshToTensor(std::make_unique<Impl>(mesh_device, distribution_mode, distributed_shape, config));
+}
+
+MeshToTensor MeshToTensor::create(const MeshShape& mesh_shape, const MeshComposerConfig& config) {
+    const auto distributed_shape = config.mesh_shape_override.value_or(mesh_shape);
+    TT_FATAL(
+        distributed_shape.mesh_size() <= mesh_shape.mesh_size(),
+        "The size of the supplied mesh shape {} does not match the mesh shape size {}",
+        distributed_shape,
+        mesh_shape);
+    TT_FATAL(
+        distributed_shape.dims() == config.dims.size(),
+        "The number of dimensions in the mesh shape {} does not match the "
+        "number of dimensions in the config {}",
+        distributed_shape,
+        config);
+
+    const auto distribution_mode = compute_distribution_mode(config.mesh_shape_override, mesh_shape);
+    validate_mesh_offset(config.mesh_offset_override, distribution_mode, distributed_shape, mesh_shape);
+
+    return MeshToTensor(std::make_unique<Impl>(mesh_shape, distribution_mode, distributed_shape, config));
 }
 
 const MeshMapperConfig& TensorToMesh::config() const { return impl_->config(); }

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -223,6 +223,53 @@ RowMajorHostBuffer convert_block_float_to_logical_row_major(const HostBuffer& bu
     return RowMajorHostBuffer::create_logical(HostBuffer(std::move(logical_data)), tensor_spec);
 }
 
+RowMajorHostBuffer convert_to_row_major_host_buffer(
+    const Tensor& tt_tensor, const ttnn::distributed::MeshToTensor& mesh_composer);
+
+// Derives a default composer from the tensor's recorded distribution topology: every
+// distribution axis spanning more than one device must be a `Shard` placement; the
+// composer then concatenates the shards along those dims. Returns nullopt when the
+// topology does not unambiguously describe a concatenation (replicated or unrecorded
+// distributions), leaving the caller to fail loudly.
+std::optional<RowMajorHostBuffer> compose_from_recorded_topology(
+    const Tensor& tt_tensor, const tt::tt_metal::distributed::MeshShape& mesh_shape) {
+    using tt::tt_metal::distributed::MeshComposerConfig;
+    using tt::tt_metal::distributed::MeshMapperConfig;
+
+    const auto& topology = tt_tensor.tensor_topology();
+    const auto& distribution_shape = topology.distribution_shape();
+    const auto& placements = topology.placements();
+    if (distribution_shape.mesh_size() <= 1 || distribution_shape.dims() != placements.size()) {
+        return std::nullopt;
+    }
+
+    const int tensor_rank = static_cast<int>(tt_tensor.tensor_spec().logical_shape().rank());
+    if (tensor_rank < 1) {
+        return std::nullopt;
+    }
+    ttsl::SmallVector<int> dims;
+    dims.reserve(placements.size());
+    for (size_t axis = 0; axis < placements.size(); ++axis) {
+        if (const auto* shard = std::get_if<MeshMapperConfig::Shard>(&placements[axis])) {
+            if (shard->dim < 0 || shard->dim >= tensor_rank) {
+                return std::nullopt;
+            }
+            dims.push_back(shard->dim);
+        } else if (distribution_shape[axis] <= 1) {
+            // A single-device axis contributes exactly one shard; concatenating a single
+            // chunk is an identity, so any valid dim works as a placeholder.
+            dims.push_back(dims.empty() ? 0 : dims.front());
+        } else {
+            // A replicated axis spanning multiple devices cannot be expressed as a concatenation.
+            return std::nullopt;
+        }
+    }
+
+    const auto composer = ttnn::distributed::MeshToTensor::create(
+        mesh_shape, MeshComposerConfig{.dims = std::move(dims), .mesh_shape_override = distribution_shape});
+    return convert_to_row_major_host_buffer(tt_tensor, composer);
+}
+
 // Converts a TT tensor to a RowMajorHostBuffer.
 //
 // If `padded_output` is true, the returned buffer will be padded to the tile size.
@@ -292,6 +339,12 @@ RowMajorHostBuffer convert_to_row_major_host_buffer(const Tensor& tt_tensor, con
     const auto& storage = tt_tensor.host_storage();
     std::vector<HostBuffer> buffers;
     storage.buffer().apply([&buffers](const HostBuffer& shard) { buffers.push_back(shard); });
+    if (buffers.size() > 1) {
+        // No composer was supplied: fall back to the distribution recorded in the tensor topology.
+        if (auto composed = compose_from_recorded_topology(tt_tensor, storage.buffer().shape())) {
+            return *composed;
+        }
+    }
     TT_FATAL(
         buffers.size() == 1,
         "Can't convert a tensor distributed on {} mesh to row-major logical tensor. Supply a mesh "


### PR DESCRIPTION
## Problem
`Tensor.to_torch()` / `to_numpy()` with `mesh_composer=None` on a tensor distributed on `MeshShape(1, 2)` hits `TT_FATAL` at pytensor.cpp:295:

```
Can't convert a tensor distributed on MeshShape([1, 2]) mesh to row-major logical tensor. Supply a mesh composer to concatenate multi-device shards.
```

## Fix
When every multi-device distribution axis is a Shard placement, derive a concat `MeshToTensor` from the tensor's recorded topology and compose implicitly. Replicated or unrecorded distributions still raise.

## Test
`tests/ttnn/distributed/test_default_mesh_composer.py`. Replicated distribution still raises the original error. A 1-D shard on `MeshShape(1, 2)` host + device roundtrip is the named closer.

## Evidence
- `i-mesh-composer.log` — `I_MESH_COMPOSER_ORIGINAL_FATAL: MeshShape(1,2) dim=3 to_torch(no composer) VERDICT: REPRODUCED`; then `I_MESH_COMPOSER: MeshShape(1,2) dim=3 shape=(1,1,64,128) bf16 RM+TILE host+device sha=f9434d5a0f0 VERDICT: PASS`
- `i-mesh-composer-verify.log` — remesh at this head: `I_MESH_COMPOSER: MeshShape(1,2) dim=3 shape=(1,1,64,128) bf16 RM+TILE host+device sha=a04e6ddf769 VERDICT: PASS`
