### PR TITLE
prefill: move sc4 KV-PCC leg budget to shield team

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -185,14 +185,10 @@ shield:
   device_perf:
     wh_n150: 100
     bh_p150: 60
+  demo:
+    bh_sc4: 15
 
 scaleout:
-  demo:
-    # blaze_models_prefill_tests.yaml (sc4 job): Kimi-2.7 disaggregated prefill
-    # runner+producer KV-PCC leg (blaze verifies under workflow key "demo"). Distinct from
-    # scaleout.e2e.bh_sc4 below (a different workflow key). Needs scaleout-owner
-    # sign-off before merge. Matches the leg's 15-min timeout.
-    bh_sc4: 15
   merge_gate:
     cpu_medium: 10
     wh_n300_civ2: 10

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -810,10 +810,10 @@
   skus:
     bh_sc4:
       # Measured test step ~6 min; headroom for the up-to-120s producer connect plus
-      # model-load/NFS variance on a 4-galaxy run. Must match the scaleout/demo budget.
+      # model-load/NFS variance on a 4-galaxy run. Must match the shield/demo budget.
       timeout: 15
   owner_id: U0AC4LTJH1P # Jaksa Jovicic
-  team: scaleout
+  team: shield
   sp_config: sc4
 
 # MiniMax-M3 full-model real-weights prefill + per-layer KV PCC (standalone harness, not pytest).


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Post-merge follow-up to #52192 addressing @roseli-TT's review comments on the
SC4 disaggregated-prefill runner+producer KV-PCC leg (Kimi-2.7).

- **Team ownership** — the leg is retagged `team: scaleout` → `team: shield`,
  and its 15-min budget moves from `scaleout.demo.bh_sc4` to
  `shield.demo.bh_sc4` (new `demo:` section under `shield`). `scaleout.demo`
  had only this entry, so the now-empty key is removed.
- **No comments in `time_budget.yaml`** — the justification block is dropped;
  the rationale (measured ~6 min test step + up-to-120s producer H2D connect +
  model-load/NFS variance on a 4-galaxy run → 15 min) lives here in the PR
  description instead.

The inline test command is left as-is (@roseli-TT flagged it as optional —
"putting the script in here is also fine, up to you guys").

### Timeout rationale (per infra request to keep it out of the yaml)
Measured test step on run 31182054918 was ~6 min. 15 min leaves headroom for
the up-to-120s producer H2D connect plus model-load / NFS variance on a
4-galaxy run.

### Validation
`verify_time_budget.py tests/pipeline_reorg/blaze_models_prefill_tests.yaml .github/time_budget.yaml demo` passes:
`Team 'shield', SKU 'bh_sc4': Requested = 15 min, Budget = 15 min [OK]`. Both
yaml files parse; `scaleout.demo` is gone. No test behavior changes — this is
pure ownership/budget bookkeeping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-sc4-team-shield)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/prefill-sc4-team-shield)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-sc4-team-shield)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/prefill-sc4-team-shield)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/prefill-sc4-team-shield)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/prefill-sc4-team-shield)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/prefill-sc4-team-shield)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/prefill-sc4-team-shield)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/prefill-sc4-team-shield)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/prefill-sc4-team-shield)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/prefill-sc4-team-shield)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/prefill-sc4-team-shield)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/prefill-sc4-team-shield)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/prefill-sc4-team-shield)