### PR TITLE
[skip ci] [LLK] Document FP16B unity constant

### DIFF
--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_instr_params.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_instr_params.h
@@ -418,8 +418,8 @@ struct p_sfpu
         constexpr static std::uint32_t RoundZero  = 0x2;
     };
 
-    // TO DO: Clean up if needed #44713
-    // Needed for exp_tile() to be architecture agnostic
+    // bfloat16 encoding of 1.0. Used by the architecture-agnostic exp_tile() API;
+    // Quasar currently accepts only this unscaled value.
     constexpr static std::uint32_t kCONST_1_FP16B = 0x3F80;
 };
 


### PR DESCRIPTION
### PR Category
Cleanup
### Summary
Closes #44713

Although Quasar does not currently support scaled exponential, the constant is not unused: the architecture-agnostic `exp_tile()` API uses it as the default scale value.

  The same API declaration is compiled for Wormhole, Blackhole, and Quasar:

  ```cpp
  exp_tile(..., uint16_t scale = p_sfpu::kCONST_1_FP16B)
```
  Removing only the Quasar definition would require an architecture-specific conditional, a magic 0x3F80 literal, or another constant containing the same value. That would relocate the value without changing behavior and would make the shared API less uniform.

  The presence of the constant does not indicate that Quasar supports scaling. Quasar explicitly restricts SCALE_EN to false and accepts only the unity/unscaled value.

  This change therefore keeps the constant as part of the shared API contract and documents its purpose.
### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=cleanup/quasar-fp16b-constant)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:cleanup/quasar-fp16b-constant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=cleanup/quasar-fp16b-constant)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:cleanup/quasar-fp16b-constant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=cleanup/quasar-fp16b-constant)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:cleanup/quasar-fp16b-constant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=cleanup/quasar-fp16b-constant)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:cleanup/quasar-fp16b-constant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=cleanup/quasar-fp16b-constant)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:cleanup/quasar-fp16b-constant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=cleanup/quasar-fp16b-constant)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:cleanup/quasar-fp16b-constant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=cleanup/quasar-fp16b-constant)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:cleanup/quasar-fp16b-constant)