### PR TITLE
fix(tt-llk): serialize unpack/math dest-base RMWs with REG_RMW mutex (#53416)

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_unary_datacopy.h
@@ -60,7 +60,12 @@ inline void _llk_math_eltwise_unary_datacopy_(
     if (unpack_to_dest && is_32bit_input(src_format, dst_format))
     {
         math_unpack_to_dest_math_ready();
+        // #53416: hold mutex::REG_RMW across the dest-index handoff so this mailbox write is
+        // ordered against the unpacker's guarded dest-base RMW section; released before the
+        // MATH|WAIT_SFPU semaphore wait in math_unpack_to_dest_tile_ready().
+        t6_mutex_acquire(mutex::REG_RMW);
         math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::DestReg>(dst_index);
+        t6_mutex_release(mutex::REG_RMW);
         math::math_unpack_to_dest_tile_ready();
 
         // Due to bug in Blackhole Tensix (more details in budabackend/#2730) when an event with side effect of clearing DEST zero flags

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -444,7 +444,12 @@ inline void _llk_unpack_A_(const std::uint32_t address, const std::uint32_t unpa
     {
         if (is_32bit_input(unpack_src_format, unpack_dst_format))
         {
+            // #53416: issue the dest-base CIB RMW section under mutex::REG_RMW (the in-tree
+            // cross-thread CFG-RMW mutex) so it cannot straddle the semaphore handshake below;
+            // released before wait_for_dest_available(), keeping the original RMW-then-wait order.
+            t6_mutex_acquire(mutex::REG_RMW);
             set_dst_write_addr(unp_cfg_context, unpack_dst_format);
+            t6_mutex_release(mutex::REG_RMW);
             wait_for_dest_available();
         }
     }


### PR DESCRIPTION
## What

- **The race (issue #53416):** on Blackhole, the unpacker and math TRISCs both read-modify-write the unpacker dest-base CFG (set_dst_write_addr), with only single-slot semaphore 2 between them — and each side performs its RMW *before* its semaphore wait, so the two RMWs can interleave. Reproduces as a deterministic hang on sfpu_binary under TT-NOP injection.
- **The fix:** wrap the dest-base RMW sections on both sides in t6_mutex_acquire/release(mutex::REG_RMW), matching the existing pack-side REG_RMW precedent. Sections are minimal: acquire -> RMW -> release, with the mutex released before wait_for_dest_available() (unpack side) and before math_unpack_to_dest_tile_ready() (math side) — no semaphore wait is spanned.
- Files touched: llk_unpack_A.h, llk_math_eltwise_unary_datacopy.h (+10/-0, two files, no new files). Fixes #53416.

## Commit

91cb76f774e73e8d6cc95caea4a2f324fd354c1f

## Silicon evidence (2x Blackhole p150a, 1x2 mesh)

- Reproduction on pristine tree: i53416-si-sfpu-binary-repro1.log — deterministic wedge at injected delay n=5, 2/2 attempts.
- Threshold: i53416-si-diag-p*.log — n<=4 pass, n>=5 wedge.
- Refuted alternates: i53416-si-diag-d1.log (reordering the RMW after the semaphore wait — still TENSIX-timeouts) and i53416-si-fence-c1.log / i53416-si-fence-c2.log (fence before the RMW — wedges on clean runs without injection).
- Fix PASS from this tree: i53416-si-fix2-c1.log, i53416-si-fix2-c2.log (clean, 2/2), i53416-si-fix2-f5a.log, i53416-si-fix2-f5b.log (delay n=5 armed, 2/2), i53416-si-fix2-f6a.log, i53416-si-fix2-f6b.log (delay n=6 armed, 2/2), i53416-si-fix2-ctl0.log — 0 wedges across all 7 runs.
- Static gates: I_TT_CI_STATIC VERDICT: PASS.

## Scope

One fact: the mutex serialization only; no other LLK changes. The same-pattern unguarded set_dst_write_addr in llk_unpack_tilize.h is explicitly out of scope here.