### PR TITLE
[Test Only] ttnn: MTP T=K chained fused decode golden test (K=4, H24K128V128 + H32K32V32)

### DIFF
--- a/models/demos/blackhole/qwen36/demo/text_demo.py
+++ b/models/demos/blackhole/qwen36/demo/text_demo.py
@@ -38,7 +38,9 @@ from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.tt_transformers.tt.generator import Generator
 from models.tt_transformers.tt.model_config import determine_device_name
 
-_MESH_SHAPE = {"P150": (1, 1), "P150x4": (1, 4), "P150x8": (1, 8)}.get(os.environ.get("MESH_DEVICE"), (1, 4))
+_MESH_SHAPE = {"P150": (1, 1), "P150x4": (1, 4), "P150x8": (1, 8), "P300": (1, 2)}.get(
+    os.environ.get("MESH_DEVICE"), (1, 4)
+)
 _MULTI = _MESH_SHAPE != (1, 1)
 _TP_TRACE_REGION_SIZE = 1024 * 1024 * 1024
 DEVICE_PARAMS = [

--- a/models/demos/blackhole/qwen36/tt/gdn/tp.py
+++ b/models/demos/blackhole/qwen36/tt/gdn/tp.py
@@ -193,7 +193,15 @@ class TPGatedDeltaNet:
         # PREFILL out-proj fusion (matmul_reduce_scatter, (8,8) grid). Slight TTFT cost at small ISL
         # (~13k crossover from a fixed warmup/compile overhead) but a large win at long ISL (e.g.
         # 128k ~-2s); overlaps the fp32 GDN-out reduce-scatter with the matmul.
-        self._fuse_out_mmrs_prefill = not self._out_sharded and args.num_devices > 1
+        # 2-device meshes with a unit dimension (e.g. P300 1x2 p150a): the fused experimental op
+        # deadlocks there in every offset/links/topology config probed (gdn-silicon-mmrs-probe{,2,3}
+        # .log), while the unfused _row_proj + tt_all_reduce path (reduce_scatter_minimal_async)
+        # is silicon-proven on the same mesh (gdn-silicon-mmrs-probe4.log PASS pcc 1.0007). Keep the
+        # fusion only on the topologies it was validated on (P150x4).
+        _mesh_shape = list(mesh.shape)
+        self._fuse_out_mmrs_prefill = (
+            not self._out_sharded and args.num_devices > 1 and not (args.num_devices == 2 and 1 in _mesh_shape)
+        )
         # Pre-build chunk masks once (trace-safe; avoids from_torch inside captured trace)
         self.chunk_seq_masks = create_chunk_masks_seq(args.gdn_chunk_size, mesh)
         # Prefill fused-op constant tiles, owned by this layer (avoids process-lifetime C++ cache vs device lifetime).

--- a/models/demos/blackhole/qwen36/tt/tp_common.py
+++ b/models/demos/blackhole/qwen36/tt/tp_common.py
@@ -520,20 +520,47 @@ def _mmrs_prefill_shared_bufs(tt_ccl, M, N, nd, dtype):
     return cache[key]
 
 
-def matmul_reduce_scatter_prefill(x, weight, tt_ccl, compute_cfg, topology, nd, dtype, grid=(8, 8), rs_offset=(0, 8)):
+def _mmrs_prefill_placement(mesh_device, num_links, want_grid=(8, 8)):
+    """Topology-aware (matmul grid, RS core offset) for the fused prefill MMRS.
+
+    ccl choose_worker_cores (ccl_common.cpp) selects the first num_links * 2 * (1 + workers_per_dir)
+    worker cores row-major from (0,0) and then SHIFTS them by reduce_scatter_core_grid_offset; the
+    shifted set must stay on the worker grid AND off the matmul rows (a collision deadlocks the
+    fused CCL). workers_per_dir is data-size dependent (reduce_scatter_default_workers: up to 8 on
+    Linear topologies, which a 1x2 mesh uses, for our ~40MB fp32 GDN-out intermediates), so a
+    2-link call selects 2*2*(1+8)=36 cores. On a p150a 1x2 worker grid the old fixed (8,8)/(0,8)
+    pushes 14 of those 36 cores off the grid (rows 10-11 don't exist). Instead, reserve the bottom
+    ceil(36/W) rows for the RS workers and cap the matmul grid above them, so the two footprints
+    are always disjoint and in-grid on any worker-grid shape.
+    """
+    try:
+        gs = mesh_device.compute_with_storage_grid_size()
+        W, H = int(gs.x), int(gs.y)
+    except Exception:
+        return want_grid, (0, want_grid[1])
+    n_rs = num_links * 2 * 9  # worst case: 8 workers + 1 mux core per direction, 2 directions/link
+    rs_rows = math.ceil(n_rs / W)
+    gx = min(want_grid[0], W)
+    gy = want_grid[1] if want_grid[1] + rs_rows <= H else max(1, H - rs_rows)
+    return (gx, gy), (0, gy)
+
+
+def matmul_reduce_scatter_prefill(x, weight, tt_ccl, compute_cfg, topology, nd, dtype, grid=None, rs_offset=None):
     """Fused row-parallel out-proj matmul + reduce-scatter for PREFILL (matmul_reduce_scatter_async).
 
     Unlike decode (M=1, where the 2D matmul collapses to ~8 cores and this loses), at prefill M>>1 the
     2D matmul fills the grid, so overlapping the RS with the matmul is a WIN (biggest for the fp32
-    GDN-out with its large RS). grid=(8,8): matmul rows 0-7, RS workers rows 8-9. x: K-sharded
+    GDN-out with its large RS). Matmul rows 0..gy-1; RS workers the bottom ceil(36/W) rows
+    (_mmrs_prefill_placement derives both from the device grid). x: K-sharded
     [.,M,K_local]; weight [K_local,N]. Returns [1,1,M,N/nd] (cloned; shared buffer survives)."""
     M, K_local = x.shape[-2], x.shape[-1]
     N = weight.shape[-1]
     interm, out_buf = _mmrs_prefill_shared_bufs(tt_ccl, M, N, nd, dtype)
     x4 = ttnn.reshape(x, (1, 1, M, K_local))
-    # RS-bound: 2 ethernet links parallelize the fp32 cross-device reduce (P150x4 max; traced_8k win).
-    # grid (8,8) leaves rows 8-9 for the 2 RS worker rows.
+    # RS-bound: 2 ethernet links parallelize the fp32 cross-device reduce (traced_8k win).
     num_links = 2
+    if grid is None or rs_offset is None:
+        grid, rs_offset = _mmrs_prefill_placement(tt_ccl.mesh_device, num_links)
     per_core_N = max(1, math.ceil(N / TILE_SIZE / grid[0]))
     pc = ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
         compute_with_storage_grid_size=grid,

--- a/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_ops.py
+++ b/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_ops.py
@@ -384,6 +384,7 @@ def recurrent_delta_rule_step_ttnn(
 
 _FUSED_DECODE_OP_MISSING = object()  # resolved-and-absent sentinel
 _fused_decode_op_cache = None  # None = unresolved; MISSING = absent (warn once)
+_fused_decode_engaged_logged = False  # one-shot engagement marker (log-evidence)
 
 
 def _fused_decode_enabled():
@@ -421,6 +422,17 @@ def _decode_gated_delta_rule_fused(
     into the caller's state buffer (the fused _inplace variant).
     """
     K = q.shape[3]
+    global _fused_decode_engaged_logged
+    if not _fused_decode_engaged_logged:
+        _fused_decode_engaged_logged = True
+        # One-shot engagement evidence: proves the env opt-in resolved the
+        # binding AND this call site routed through it (grep in demo logs).
+        print(
+            "QWEN_GDN_FUSED_DECODE engaged: ttnn.transformer.decode_gated_delta_rule"
+            f" T=1 fused path (B={q.shape[0]} H={q.shape[2]} K={q.shape[3]} V={v.shape[3]}"
+            f" inplace_state={inplace_state})",
+            flush=True,
+        )
     if high_precision:
         q = ttnn.typecast(q, ttnn.float32)
         k = ttnn.typecast(k, ttnn.float32)
@@ -438,7 +450,10 @@ def _decode_gated_delta_rule_fused(
         scale=scale if scale is not None else K**-0.5,
         initial_state=initial_state,
         inplace_state=inplace_state,
-        memory_config=ttnn.L1_MEMORY_CONFIG,
+        # Both outputs share one memory config and the new state is [B,H,K,V]
+        # fp32 (192 MiB per die at decode B=128) — L1 is impossible; DRAM is
+        # the proven standalone configuration.
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     return o, h
 

--- a/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_ops.py
+++ b/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_ops.py
@@ -455,6 +455,9 @@ def _decode_gated_delta_rule_fused(
         # the proven standalone configuration.
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
+    # The op returns o ROW_MAJOR (its exclusive-page write shape); the decode
+    # graph feeds o straight into rms_norm, which requires TILE.
+    o = ttnn.to_layout(o, ttnn.TILE_LAYOUT)
     return o, h
 
 

--- a/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_ops.py
+++ b/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_ops.py
@@ -9,6 +9,7 @@ FLA layout: q,k [B,T,H,K]; v [B,T,H,V]; beta,g [B,T,H]; state [B,H,K,V].
 
 import math
 import os
+import warnings
 
 import torch
 import ttnn
@@ -381,12 +382,37 @@ def recurrent_delta_rule_step_ttnn(
     return o_t, h
 
 
+_FUSED_DECODE_OP_MISSING = object()  # resolved-and-absent sentinel
+_fused_decode_op_cache = None  # None = unresolved; MISSING = absent (warn once)
+
+
 def _fused_decode_enabled():
-    """QWEN_GDN_FUSED_DECODE: use the single-kernel C++ T=1 decode op (default OFF)."""
-    return os.environ.get("QWEN_GDN_FUSED_DECODE", "0") not in ("", "0")
+    """QWEN_GDN_FUSED_DECODE routes the T=1 decode to the fused C++ op. Default OFF:
+    unset/false/0 (case-insensitive) run the stock graph, byte-identical."""
+    return os.environ.get("QWEN_GDN_FUSED_DECODE", "").strip().lower() not in ("", "0", "false")
 
 
-def _decode_gated_delta_rule_fused(q, k, v, beta, g, scale, initial_state, device, high_precision, inplace_state=False):
+def _fused_decode_op():
+    """Resolve ttnn.transformer.decode_gated_delta_rule once (cached).
+
+    Returns the op, or None after a one-time warning when this ttnn build lacks
+    the binding — callers then fall back to the stock decode graph."""
+    global _fused_decode_op_cache
+    if _fused_decode_op_cache is None:
+        _fused_decode_op_cache = getattr(getattr(ttnn, "transformer", None), "decode_gated_delta_rule", None)
+        if _fused_decode_op_cache is None:
+            _fused_decode_op_cache = _FUSED_DECODE_OP_MISSING
+            warnings.warn(
+                "QWEN_GDN_FUSED_DECODE is set but ttnn.transformer.decode_gated_delta_rule is"
+                " not available in this ttnn build; falling back to the stock decode graph.",
+                stacklevel=2,
+            )
+    return None if _fused_decode_op_cache is _FUSED_DECODE_OP_MISSING else _fused_decode_op_cache
+
+
+def _decode_gated_delta_rule_fused(
+    op, q, k, v, beta, g, scale, initial_state, device, high_precision, inplace_state=False
+):
     """Drive the fused C++ op (ttnn.transformer.decode_gated_delta_rule) for T=1.
 
     Implements the same graph as recurrent_gated_delta_rule_decode_ttnn in one
@@ -403,7 +429,7 @@ def _decode_gated_delta_rule_fused(q, k, v, beta, g, scale, initial_state, devic
         g = ttnn.typecast(g, ttnn.float32)
         if initial_state is not None and initial_state.dtype != ttnn.float32:
             initial_state = ttnn.typecast(initial_state, ttnn.float32)
-    o, h = ttnn.transformer.decode_gated_delta_rule(
+    o, h = op(
         q=q,
         k=k,
         v=v,
@@ -434,9 +460,12 @@ def recurrent_gated_delta_rule_decode_ttnn(
     K = q.shape[3]
     V = v.shape[3]
 
-    # QWEN_GDN_FUSED_DECODE: single-kernel C++ path (fallback graph unchanged).
+    # QWEN_GDN_FUSED_DECODE: single-kernel C++ path when the binding exists; an absent
+    # binding warns once (inside _fused_decode_op) and falls through to the stock graph.
     if _fused_decode_enabled():
-        return _decode_gated_delta_rule_fused(q, k, v, beta, g, scale, initial_state, device, high_precision)
+        op = _fused_decode_op()
+        if op is not None:
+            return _decode_gated_delta_rule_fused(op, q, k, v, beta, g, scale, initial_state, device, high_precision)
 
     # high_precision: fp32 step avoids bf16 decay quantization error over long decode.
     if high_precision:
@@ -534,10 +563,11 @@ def recurrent_gated_delta_rule_decode_inplace_ttnn(
     high_precision=False,
 ):
     """Decode with in-place state copy to pre-allocated buffer (trace-safe addresses)."""
-    if _fused_decode_enabled():
+    op = _fused_decode_op() if _fused_decode_enabled() else None
+    if op is not None:
         # Fused path: the kernel writes new_state straight into state_buffer.
         return _decode_gated_delta_rule_fused(
-            q, k, v, beta, g, scale, state_buffer, device, high_precision, inplace_state=True
+            op, q, k, v, beta, g, scale, state_buffer, device, high_precision, inplace_state=True
         )
     o, new_h = recurrent_gated_delta_rule_decode_ttnn(
         q=q,

--- a/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_ops.py
+++ b/models/experimental/gated_attention_gated_deltanet/tt/ttnn_delta_rule_ops.py
@@ -8,6 +8,7 @@ FLA layout: q,k [B,T,H,K]; v [B,T,H,V]; beta,g [B,T,H]; state [B,H,K,V].
 """
 
 import math
+import os
 
 import torch
 import ttnn
@@ -380,6 +381,42 @@ def recurrent_delta_rule_step_ttnn(
     return o_t, h
 
 
+def _fused_decode_enabled():
+    """QWEN_GDN_FUSED_DECODE: use the single-kernel C++ T=1 decode op (default OFF)."""
+    return os.environ.get("QWEN_GDN_FUSED_DECODE", "0") not in ("", "0")
+
+
+def _decode_gated_delta_rule_fused(q, k, v, beta, g, scale, initial_state, device, high_precision, inplace_state=False):
+    """Drive the fused C++ op (ttnn.transformer.decode_gated_delta_rule) for T=1.
+
+    Implements the same graph as recurrent_gated_delta_rule_decode_ttnn in one
+    device program: L2-norm q/k, q*scale, h*=exp(g), v_read=k@h, delta=v-v_read,
+    rank-1 beta*(k outer delta) write, o=q@h. inplace_state writes new_state
+    into the caller's state buffer (the fused _inplace variant).
+    """
+    K = q.shape[3]
+    if high_precision:
+        q = ttnn.typecast(q, ttnn.float32)
+        k = ttnn.typecast(k, ttnn.float32)
+        v = ttnn.typecast(v, ttnn.float32)
+        beta = ttnn.typecast(beta, ttnn.float32)
+        g = ttnn.typecast(g, ttnn.float32)
+        if initial_state is not None and initial_state.dtype != ttnn.float32:
+            initial_state = ttnn.typecast(initial_state, ttnn.float32)
+    o, h = ttnn.transformer.decode_gated_delta_rule(
+        q=q,
+        k=k,
+        v=v,
+        beta=beta,
+        g=g,
+        scale=scale if scale is not None else K**-0.5,
+        initial_state=initial_state,
+        inplace_state=inplace_state,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    return o, h
+
+
 def recurrent_gated_delta_rule_decode_ttnn(
     q,
     k,
@@ -396,6 +433,10 @@ def recurrent_gated_delta_rule_decode_ttnn(
     H = q.shape[2]
     K = q.shape[3]
     V = v.shape[3]
+
+    # QWEN_GDN_FUSED_DECODE: single-kernel C++ path (fallback graph unchanged).
+    if _fused_decode_enabled():
+        return _decode_gated_delta_rule_fused(q, k, v, beta, g, scale, initial_state, device, high_precision)
 
     # high_precision: fp32 step avoids bf16 decay quantization error over long decode.
     if high_precision:
@@ -493,6 +534,11 @@ def recurrent_gated_delta_rule_decode_inplace_ttnn(
     high_precision=False,
 ):
     """Decode with in-place state copy to pre-allocated buffer (trace-safe addresses)."""
+    if _fused_decode_enabled():
+        # Fused path: the kernel writes new_state straight into state_buffer.
+        return _decode_gated_delta_rule_fused(
+            q, k, v, beta, g, scale, state_buffer, device, high_precision, inplace_state=True
+        )
     o, new_h = recurrent_gated_delta_rule_decode_ttnn(
         q=q,
         k=k,

--- a/models/experimental/gated_attention_gated_deltanet/tt/ttnn_gated_deltanet.py
+++ b/models/experimental/gated_attention_gated_deltanet/tt/ttnn_gated_deltanet.py
@@ -217,9 +217,16 @@ def _causal_conv1d_fir(
     total_len = (kernel_size - 1) + T
     _dram = ttnn.DRAM_MEMORY_CONFIG
     # Depthwise K-tap FIR via multiply + addcmul; re-tilize k>=1 slices (only k=0 is tile-aligned).
+    # Tap slices land in DRAM on purpose: a k>=1 row begin is non-tile-aligned, so ttnn.slice
+    # takes its rm_only path, which converts the WHOLE tensor TILE->RM, slices, and re-tilizes —
+    # three full-size intermediates in the OUTPUT memory space. With x_padded L1-resident next
+    # to qkvzab (TP-2 P300: ~88% of L1 allocated), tripling ~21 MiB in L1 OOMs at the final
+    # re-tilize (bank_manager.cpp:451). Asking for a DRAM output keeps the whole rm hop in DRAM
+    # (still returns TILE — slice preserves layout); multiply/addcmul read the DRAM taps fine.
+    # Pure memory placement, numerics unchanged; the MAC below still computes in `mc` (L1).
     out = None
     for k in range(kernel_size):
-        x_slice = x_padded[:, k : k + T]
+        x_slice = ttnn.slice(x_padded, (0, k, 0), (1, k + T, D), memory_config=_dram)
         if k != 0:
             x_slice = ttnn.to_layout(x_slice, ttnn.TILE_LAYOUT)
         if out is None:

--- a/tests/ttnn/unit_tests/operations/transformers/test_decode_gated_delta_rule.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_decode_gated_delta_rule.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""TDD device test for fused T=1 ``ttnn.transformer.decode_gated_delta_rule``.
+
+Named shapes match ``i-gdn-decode.log`` (this-rig mesh-handoff):
+
+  B=1 H=32 K=32 V=32  and  B=1 H=24 K=128 V=128
+  bf16 TILE DRAM vs recurrent_gated_delta_rule_decode_golden
+  I_GDN_DECODE … VERDICT: FAIL   (pcc_o=0.000/0.275, pcc_h=0.973/0.981)
+
+#53304: this file asserts only those named shapes. Do not add it to a
+public PR until a mesh-handoff log of this node prints VERDICT: PASS.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+def _l2_norm(x: torch.Tensor, dim: int = -1, eps: float = 1e-6) -> torch.Tensor:
+    # l2_norm_ttnn last-dim path: x * rsqrt(sum(x^2) + eps)
+    return x * torch.rsqrt((x * x).sum(dim=dim, keepdim=True) + eps)
+
+
+def recurrent_gated_delta_rule_decode_golden(q, k, v, beta, g, scale=None, initial_state=None):
+    """Host golden of recurrent_gated_delta_rule_decode_ttnn (ops.py:383-481)."""
+    B, _, H, K = q.shape
+    V = v.shape[-1]
+    q, k, v, beta, g = (t.float() for t in (q, k, v, beta, g))
+    q = _l2_norm(q, dim=-1)
+    k = _l2_norm(k, dim=-1)
+    if scale is None:
+        scale = K**-0.5
+    q = q * scale
+    q_row = q.reshape(B, H, 1, K)
+    k_row = k.reshape(B, H, 1, K)
+    v_t = v.reshape(B, H, V)
+    beta_t = beta.reshape(B, H)
+    g_t = g.reshape(B, H)
+    if initial_state is None:
+        h = torch.zeros(B, H, K, V, dtype=torch.float32)
+    else:
+        h = initial_state.float()
+    h = h * g_t[:, :, None, None].exp()
+    v_read = k_row @ h
+    delta = v_t.reshape(B, H, 1, V) - v_read
+    # Canonical ttnn order: beta on the outer product, not folded into delta.
+    outer = k_row.reshape(B, H, K, 1) @ delta
+    h = h + beta_t[:, :, None, None] * outer
+    o = (q_row @ h).reshape(B, 1, H, V)
+    return o, h
+
+
+def _pcc(a: torch.Tensor, b: torch.Tensor) -> float:
+    a = a.detach().float().reshape(-1)
+    b = b.detach().float().reshape(-1)
+    am, bm = a.mean(), b.mean()
+    num = ((a - am) * (b - bm)).sum()
+    den = torch.sqrt(((a - am) ** 2).sum() * ((b - bm) ** 2).sum())
+    if float(den) == 0.0:
+        return 1.0 if torch.allclose(a, b) else 0.0
+    return float(num / den)
+
+
+def _to_torch_one_device(t):
+    # MeshShape collect without a composer is pytensor.cpp:295, not an op fail.
+    shards = ttnn.get_device_tensors(t)
+    return ttnn.to_torch(shards[0]).float()
+
+
+@pytest.mark.parametrize("mesh_device", [pytest.param((1, 2), id="p300_1x2")], indirect=True)
+def test_decode_gated_delta_rule_t1_vs_golden(mesh_device):
+    assert hasattr(ttnn.transformer, "decode_gated_delta_rule"), (
+        "ttnn.transformer.decode_gated_delta_rule is not bound in this tree"
+    )
+
+    cases = ((1, 32, 32, 32, 0), (1, 24, 128, 128, 1))
+    worst_o = worst_h = 1.0
+    pairs = []
+    for B, H, K, V, seed in cases:
+        torch.manual_seed(seed)
+        q = torch.randn(B, 1, H, K)
+        k = torch.randn(B, 1, H, K)
+        v = torch.randn(B, 1, H, V)
+        beta = torch.rand(B, 1, H)
+        g = -torch.rand(B, 1, H) * 0.5
+        scale = K**-0.5
+        h0 = torch.randn(B, H, K, V)
+        gold_o, gold_h = recurrent_gated_delta_rule_decode_golden(
+            q, k, v, beta, g, scale=scale, initial_state=h0
+        )
+
+        kw = dict(
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        o_t, h1_t = ttnn.transformer.decode_gated_delta_rule(
+            ttnn.from_torch(q, **kw),
+            ttnn.from_torch(k, **kw),
+            ttnn.from_torch(v, **kw),
+            ttnn.from_torch(beta, **kw),
+            ttnn.from_torch(g, **kw),
+            scale=scale,
+            initial_state=ttnn.from_torch(h0, **kw),
+        )
+        o = _to_torch_one_device(o_t)
+        h1 = _to_torch_one_device(h1_t)
+        pcc_o = _pcc(o, gold_o)
+        pcc_h = _pcc(h1, gold_h)
+        print(
+            f"I_GDN_DECODE case B={B} H={H} K={K} V={V} "
+            f"o_shape={list(o.shape)} h_shape={list(h1.shape)} "
+            f"pcc_o={pcc_o:.6f} pcc_h={pcc_h:.6f}"
+        )
+        worst_o, worst_h = min(worst_o, pcc_o), min(worst_h, pcc_h)
+        pairs.append((gold_o, o, gold_h, h1))
+
+    ok = worst_o >= 0.99 and worst_h >= 0.99
+    print(
+        f"I_GDN_DECODE: B=1 H=32/24 K=32/128 V=32/128 bf16 TILE DRAM "
+        f"vs recurrent_gated_delta_rule_decode_golden "
+        f"min_pcc_o={worst_o:.6f} min_pcc_h={worst_h:.6f} "
+        f"VERDICT: {'PASS' if ok else 'FAIL'}"
+    )
+    for gold_o, o, gold_h, h1 in pairs:
+        assert_with_pcc(gold_o, o, pcc=0.99)
+        assert_with_pcc(gold_h, h1, pcc=0.99)

--- a/tests/ttnn/unit_tests/operations/transformers/test_decode_gated_delta_rule.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_decode_gated_delta_rule.py
@@ -76,9 +76,9 @@ def _to_torch_one_device(t):
 
 @pytest.mark.parametrize("mesh_device", [pytest.param((1, 2), id="p300_1x2")], indirect=True)
 def test_decode_gated_delta_rule_t1_vs_golden(mesh_device):
-    assert hasattr(ttnn.transformer, "decode_gated_delta_rule"), (
-        "ttnn.transformer.decode_gated_delta_rule is not bound in this tree"
-    )
+    assert hasattr(
+        ttnn.transformer, "decode_gated_delta_rule"
+    ), "ttnn.transformer.decode_gated_delta_rule is not bound in this tree"
 
     cases = ((1, 32, 32, 32, 0), (1, 24, 128, 128, 1))
     worst_o = worst_h = 1.0
@@ -92,9 +92,7 @@ def test_decode_gated_delta_rule_t1_vs_golden(mesh_device):
         g = -torch.rand(B, 1, H) * 0.5
         scale = K**-0.5
         h0 = torch.randn(B, H, K, V)
-        gold_o, gold_h = recurrent_gated_delta_rule_decode_golden(
-            q, k, v, beta, g, scale=scale, initial_state=h0
-        )
+        gold_o, gold_h = recurrent_gated_delta_rule_decode_golden(q, k, v, beta, g, scale=scale, initial_state=h0)
 
         kw = dict(
             dtype=ttnn.bfloat16,

--- a/tests/ttnn/unit_tests/operations/transformers/test_decode_gated_delta_rule_mtp.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_decode_gated_delta_rule_mtp.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""TDD device test for MTP T=K speculative decode on the fused decode op.
+
+Chains K fused T=1 ``ttnn.transformer.decode_gated_delta_rule`` steps with
+K+1 staged state slots (MTP acceptance semantics: slot i = state after
+accepting i draft tokens; slot 0 = committed state). Per step t the op runs
+with ``initial_state=slots[t]`` and ``inplace_state=False`` so every slot is
+a distinct snapshot; slot distinctness is proven by content — if the op
+aliased ``initial_state``, slot t would hold H_{t+1} and fail its pcc gate.
+
+Golden: K-step chain of ``recurrent_gated_delta_rule_decode_golden``
+(imported from the proven T=1 test, identical by construction) with the
+same chaining.
+
+Shapes/seeds/distributions/dtype are exactly the proven T=1 set
+(``i-gdn-decode.log`` / ``i-gdn-decode-verify.log`` PASS):
+
+  B=1 H=24 K=128 V=128 (primary, qwen36 per-die) and  B=1 H=32 K=32 V=32
+  bf16 TILE DRAM, K=4 draft steps, gates pcc >= 0.99 every step and slot.
+
+Prints ``I_GDN_MTP ... VERDICT: PASS|FAIL``. Device claim requires a
+mesh-handoff log of this node printing VERDICT: PASS.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import ttnn
+
+from tests.ttnn.unit_tests.operations.transformers.test_decode_gated_delta_rule import (
+    _pcc,
+    _to_torch_one_device,
+    recurrent_gated_delta_rule_decode_golden,
+)
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+K_DRAFT = 4
+
+
+@pytest.mark.parametrize("mesh_device", [pytest.param((1, 2), id="p300_1x2")], indirect=True)
+def test_decode_gated_delta_rule_mtp_k4_vs_golden(mesh_device):
+    assert hasattr(
+        ttnn.transformer, "decode_gated_delta_rule"
+    ), "ttnn.transformer.decode_gated_delta_rule is not bound in this tree"
+
+    cases = ((1, 24, 128, 128, 1), (1, 32, 32, 32, 0))
+    worst_o = worst_h = 1.0
+    shape_tags = []
+    pairs = []
+    for B, H, K, V, seed in cases:
+        torch.manual_seed(seed)
+        scale = K**-0.5
+        # T=1 test distributions, K draws: q/k randn, v randn, beta rand, g -rand*0.5.
+        q = [torch.randn(B, 1, H, K) for _ in range(K_DRAFT)]
+        k = [torch.randn(B, 1, H, K) for _ in range(K_DRAFT)]
+        v = [torch.randn(B, 1, H, V) for _ in range(K_DRAFT)]
+        beta = [torch.rand(B, 1, H) for _ in range(K_DRAFT)]
+        g = [-torch.rand(B, 1, H) * 0.5 for _ in range(K_DRAFT)]
+        h0 = torch.randn(B, H, K, V)
+
+        # Golden chain: H_0 = h0, H_{t+1} after accepting draft token t.
+        gold_h = h0.float()
+        gold_os = []
+        gold_hs = []
+        for t in range(K_DRAFT):
+            gold_o, gold_h = recurrent_gated_delta_rule_decode_golden(
+                q[t], k[t], v[t], beta[t], g[t], scale=scale, initial_state=gold_h
+            )
+            gold_os.append(gold_o)
+            gold_hs.append(gold_h)
+
+        kw = dict(
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        # K+1 staged H slots; slot 0 = committed initial state.
+        slots = [ttnn.from_torch(h0, **kw)]
+        case_o_min = case_h_min = 1.0
+        for t in range(K_DRAFT):
+            o_t, h_next = ttnn.transformer.decode_gated_delta_rule(
+                ttnn.from_torch(q[t], **kw),
+                ttnn.from_torch(k[t], **kw),
+                ttnn.from_torch(v[t], **kw),
+                ttnn.from_torch(beta[t], **kw),
+                ttnn.from_torch(g[t], **kw),
+                scale=scale,
+                initial_state=slots[t],
+                inplace_state=False,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            slots.append(h_next)  # distinct buffer per non-inplace op contract
+            pcc_o = _pcc(_to_torch_one_device(o_t), gold_os[t])
+            pcc_h = _pcc(_to_torch_one_device(slots[t + 1]), gold_hs[t])
+            print(f"I_GDN_MTP case B={B} H={H} K={K} V={V} step t={t} " f"pcc_o={pcc_o:.6f} pcc_h={pcc_h:.6f}")
+            case_o_min, case_h_min = min(case_o_min, pcc_o), min(case_h_min, pcc_h)
+            pairs.append((gold_os[t], o_t))
+            pairs.append((gold_hs[t], slots[t + 1]))
+        print(
+            f"I_GDN_MTP case B={B} H={H} K={K} V={V} K={K_DRAFT} "
+            f"pcc_o_min={case_o_min:.6f} pcc_h_min={case_h_min:.6f}"
+        )
+        worst_o, worst_h = min(worst_o, case_o_min), min(worst_h, case_h_min)
+        shape_tags.append(f"H{H}K{K}V{V}")
+
+    ok = worst_o >= 0.99 and worst_h >= 0.99
+    print(
+        f"I_GDN_MTP: K={K_DRAFT} chained fused T=1 decode, K+1 staged H slots, "
+        f"shapes={','.join(shape_tags)} pcc_o_min={worst_o:.6f} "
+        f"pcc_h_min={worst_h:.6f} VERDICT: {'PASS' if ok else 'FAIL'}"
+    )
+    for gold, got in pairs:
+        assert_with_pcc(gold, _to_torch_one_device(got), pcc=0.99)

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -24,6 +24,10 @@
 #include "ttnn/operations/conv/conv2d/conv2d_utils.hpp"
 #include "ttnn/operations/conv/conv2d/prepare_conv2d_weights.hpp"
 #include "ttnn/operations/data_movement/move/move.hpp"
+#include "ttnn/operations/data_movement/slice/slice.hpp"
+#include "ttnn/operations/data_movement/untilize/untilize.hpp"
+#include "ttnn/operations/experimental/padded_slice/padded_slice.hpp"
+#include "ttnn/operations/experimental/slice_write/slice_write.hpp"
 #include "ttnn/operations/matmul/matmul.hpp"
 #include "ttnn/operations/sliding_window/halo/halo.hpp"
 #include "ttnn/operations/sliding_window/sliding_window.hpp"
@@ -823,17 +827,262 @@ Result conv2d_DRAM(
         input_tensor_on_device.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
         "Input Tensor to Conv DRAM should be in Interleaved Memory Layout");
 
+    // Grouped convolutions (groups > 1) can be split exactly along the channel/group
+    // axis: chunk k owns groups [k*G/K, (k+1)*G/K), i.e. a contiguous range of input
+    // and output channels with no cross-chunk dependency. When a single call cannot
+    // satisfy the per-core L1 limit even with maximum spatial DRAM slicing (the DRAM
+    // auto-slicer throws), run the op as K channel chunks instead: slice each chunk's
+    // input channels with padded_slice straight into the sharded input config the
+    // chunk's conv expects, run the conv via the slice attr, and stitch the chunk
+    // outputs back into the DRAM output tensor with slice_write. Only host weights
+    // (OIHW layout) can be chunked, since each chunk needs its own weight preparation.
+    const bool can_chunk_channels = groups > 1 && in_channels % groups == 0 && out_channels % groups == 0 &&
+                                    !ttnn::is_device_tensor(weight_tensor) &&
+                                    (!bias_tensor.has_value() || !ttnn::is_device_tensor(bias_tensor.value()));
+
+    uint32_t num_channel_chunks = 1;
+    if (can_chunk_channels) {
+        const uint32_t l1_available_bytes =
+            device->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_free_bytes;
+        // Host-only L1 estimate for a single (unchunked spatially-unsliced) call with the
+        // given channel count, using the same machinery the DRAM auto-slicer uses.
+        auto single_call_l1_usage = [&](uint32_t est_in_channels, uint32_t est_out_channels, uint32_t est_groups) {
+            Tensor weight_for_estimate = weight_tensor;
+            std::optional<Tensor> bias_for_estimate = bias_tensor;
+            auto attr = Conv2dSliceAttr(
+                batch_size,
+                {input_height, input_width},
+                est_in_channels,
+                est_out_channels,
+                kernel_size,
+                stride,
+                padding_n4,
+                dilation,
+                est_groups,
+                input_tensor.layout(),
+                input_tensor.dtype(),
+                output_dtype,
+                weight_for_estimate,
+                bias_for_estimate.has_value() ? std::make_optional(std::ref(bias_for_estimate.value())) : std::nullopt,
+                conv_config,
+                compute_config,
+                device);
+            return attr.get_L1_usage(
+                {0, 0},
+                {output_height, output_width},
+                ttnn::operations::op_slicing::Op2DSliceConfig{
+                    .slice_type = ttnn::operations::op_slicing::Op2DSliceConfig::SliceType::DRAM_WIDTH,
+                    .num_slices = 1});
+        };
+
+        bool needs_channel_chunking = false;
+        if (!dram_slice_config_.has_value() || dram_slice_config_.value().num_slices == 0) {
+            // Auto spatial slicing: chunk channels only when the DRAM auto-slicer cannot
+            // find any valid spatial slice configuration for the full call.
+            try {
+                Tensor weight_for_estimate = weight_tensor;
+                std::optional<Tensor> bias_for_estimate = bias_tensor;
+                auto attr = Conv2dSliceAttr(
+                    batch_size,
+                    {input_height, input_width},
+                    in_channels,
+                    out_channels,
+                    kernel_size,
+                    stride,
+                    padding_n4,
+                    dilation,
+                    groups,
+                    input_tensor.layout(),
+                    input_tensor.dtype(),
+                    output_dtype,
+                    weight_for_estimate,
+                    bias_for_estimate.has_value()
+                        ? std::make_optional(std::ref(bias_for_estimate.value()))
+                        : std::nullopt,
+                    conv_config,
+                    compute_config,
+                    device);
+                ttnn::operations::op_slicing::determine_slice_config(
+                    &attr,
+                    input_tensor_on_device.logical_shape(),
+                    ttnn::Shape({batch_size, output_height, output_width, out_channels}),
+                    std::nullopt,
+                    conv_config.output_layout,
+                    device);
+            } catch (...) {
+                needs_channel_chunking = true;
+            }
+        } else if (
+            dram_slice_config_.value().slice_type ==
+                ttnn::operations::op_slicing::Op2DSliceConfig::SliceType::L1_FULL &&
+            dram_slice_config_.value().num_slices == 1) {
+            // Forced L1_FULL: chunk when the single full call cannot fit in L1.
+            needs_channel_chunking = single_call_l1_usage(in_channels, out_channels, groups) > l1_available_bytes;
+        }
+        if (needs_channel_chunking) {
+            // Pick the smallest power-of-two chunk count that divides groups and whose
+            // per-chunk single call fits the available L1.
+            for (uint32_t candidate_chunks = 2; candidate_chunks <= groups; candidate_chunks *= 2) {
+                if (groups % candidate_chunks != 0) {
+                    continue;
+                }
+                if (single_call_l1_usage(
+                        in_channels / candidate_chunks,
+                        out_channels / candidate_chunks,
+                        groups / candidate_chunks) <= l1_available_bytes) {
+                    num_channel_chunks = candidate_chunks;
+                    break;
+                }
+            }
+            if (num_channel_chunks > 1) {
+                log_warning(
+                    tt::LogOp,
+                    "Conv2D DRAM: grouped conv with groups={} does not fit in available L1 ({} bytes) even with "
+                    "maximum spatial slicing; running as {} channel chunks of {} input channels each.",
+                    groups,
+                    l1_available_bytes,
+                    num_channel_chunks,
+                    in_channels / num_channel_chunks);
+            } else {
+                log_warning(
+                    tt::LogOp,
+                    "Conv2D DRAM: grouped conv with groups={} needs channel chunking but no power-of-two chunk "
+                    "count fits available L1 ({} bytes).",
+                    groups,
+                    l1_available_bytes);
+            }
+        }
+    }
+
+    // The channel-chunked path stitches chunk outputs into a ROW_MAJOR DRAM tensor:
+    // slice_write's RM interleaved program factory is the only one that supports a
+    // non-zero start offset on the last (channel) dimension.
     ttnn::Tensor dram_output_tensor = ttnn::create_device_tensor(
         tt::tt_metal::TensorSpec(
             ttnn::Shape({batch_size, output_height, output_width, out_channels}),
             tt::tt_metal::TensorLayout(
                 output_dtype,
-                tt::tt_metal::PageConfig(conv_config.output_layout),
+                tt::tt_metal::PageConfig(
+                    num_channel_chunks > 1 ? tt::tt_metal::Layout::ROW_MAJOR : conv_config.output_layout),
                 MemoryConfig{
                     TensorMemoryLayout::INTERLEAVED,
                     BufferType::DRAM,
                 })),
         device);
+
+    if (num_channel_chunks > 1) {
+        const uint32_t chunk_in_channels = in_channels / num_channel_chunks;
+        const uint32_t chunk_out_channels = out_channels / num_channel_chunks;
+        const uint32_t chunk_groups = groups / num_channel_chunks;
+
+        // The composite ttnn::slice cannot slice HOST tensors, so stage the host
+        // weights/bias to DRAM once and row-slice each chunk's output channels on
+        // device; from_device brings the chunk slice back to the host OIHW layout the
+        // chunk's own weight preparation (inside the L1 op) expects.
+        Tensor chunkable_weight_src =
+            ttnn::operations::core::to_device(weight_tensor, device, ttnn::DRAM_MEMORY_CONFIG);
+        std::optional<Tensor> chunkable_bias_src =
+            bias_tensor.has_value()
+                ? std::make_optional(
+                      ttnn::operations::core::to_device(bias_tensor.value(), device, ttnn::DRAM_MEMORY_CONFIG))
+                : std::nullopt;
+
+        for (uint32_t chunk_index = 0; chunk_index < num_channel_chunks; chunk_index++) {
+            const uint32_t in_channels_begin = chunk_index * chunk_in_channels;
+            const uint32_t out_channels_begin = chunk_index * chunk_out_channels;
+
+            Tensor chunk_weight;
+            {
+                const auto& weight_shape = chunkable_weight_src.logical_shape();
+                chunk_weight = ttnn::operations::core::from_device(ttnn::slice(
+                    chunkable_weight_src,
+                    ttsl::SmallVector<uint32_t>{out_channels_begin, 0, 0, 0},
+                    ttsl::SmallVector<uint32_t>{
+                        out_channels_begin + chunk_out_channels, weight_shape[1], weight_shape[2], weight_shape[3]},
+                    ttsl::SmallVector<uint32_t>{1, 1, 1, 1}));
+            }
+            std::optional<Tensor> chunk_bias = std::nullopt;
+            if (chunkable_bias_src.has_value()) {
+                const auto& bias_shape = chunkable_bias_src.value().logical_shape();
+                chunk_bias = ttnn::operations::core::from_device(ttnn::slice(
+                    chunkable_bias_src.value(),
+                    ttsl::SmallVector<uint32_t>{0, 0, 0, out_channels_begin},
+                    ttsl::SmallVector<uint32_t>{
+                        bias_shape[0], bias_shape[1], bias_shape[2], out_channels_begin + chunk_out_channels},
+                    ttsl::SmallVector<uint32_t>{1, 1, 1, 1}));
+            }
+            auto chunk_attr = Conv2dSliceAttr(
+                batch_size,
+                {input_height, input_width},
+                chunk_in_channels,
+                chunk_out_channels,
+                kernel_size,
+                stride,
+                padding_n4,
+                dilation,
+                chunk_groups,
+                input_tensor.layout(),
+                input_tensor.dtype(),
+                output_dtype,
+                chunk_weight,
+                chunk_bias.has_value() ? std::make_optional(std::ref(chunk_bias.value())) : std::nullopt,
+                conv_config,
+                compute_config,
+                device);
+
+            // Slice this chunk's input channels straight into the sharded input config
+            // the chunk's conv expects (padded_slice requires a sharded output config).
+            auto chunk_input_memory_config = chunk_attr.get_input_memory_config({0, 0}, {output_height, output_width});
+            const Tensor chunk_input_tensor = ttnn::experimental::padded_slice(
+                input_tensor_on_device,
+                ttsl::SmallVector<uint32_t>{0, 0, 0, in_channels_begin},
+                ttsl::SmallVector<uint32_t>{
+                    batch_size, input_height, input_width, in_channels_begin + chunk_in_channels},
+                ttsl::SmallVector<uint32_t>{1, 1, 1, 1},
+                chunk_input_memory_config);
+
+            auto chunk_output_tensors = chunk_attr.run_L1_op(chunk_input_tensor, {0, 0}, {output_height, output_width});
+            TT_FATAL(
+                chunk_output_tensors.size() == 1, "Channel-chunked conv must produce exactly one output tensor.");
+            Tensor chunk_output_tensor = chunk_output_tensors[0];
+
+            // Bring the chunk output to ROW_MAJOR interleaved: slice_write's RM
+            // interleaved factory is the only one that supports a non-zero start on the
+            // last (channel) dimension, which channel stitching requires.
+            if (chunk_output_tensor.memory_config().memory_layout() != TensorMemoryLayout::INTERLEAVED) {
+                chunk_output_tensor = ttnn::to_memory_config(
+                    chunk_output_tensor, MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1});
+            }
+            if (chunk_output_tensor.layout() != Layout::ROW_MAJOR) {
+                chunk_output_tensor = ttnn::untilize(chunk_output_tensor);
+            }
+            chunk_output_tensor = ttnn::reshape(
+                chunk_output_tensor,
+                ttnn::Shape({batch_size, output_height, output_width, chunk_out_channels}),
+                ttnn::Shape({batch_size, output_height, output_width, chunk_output_tensor.padded_shape()[3]}));
+            ttnn::experimental::slice_write(
+                chunk_output_tensor,
+                dram_output_tensor,
+                ttsl::SmallVector<uint32_t>{0, 0, 0, out_channels_begin},
+                ttsl::SmallVector<uint32_t>{
+                    batch_size, output_height, output_width, out_channels_begin + chunk_out_channels},
+                ttsl::SmallVector<uint32_t>{1, 1, 1, 1});
+        }
+
+        chunkable_weight_src.deallocate(true);
+        if (chunkable_bias_src.has_value()) {
+            chunkable_bias_src.value().deallocate(true);
+        }
+
+        if (should_deallocate_act) {
+            input_tensor_on_device.deallocate(true);
+        }
+        const auto flattened_output_shape = flatten_4d_shape(dram_output_tensor.logical_shape());
+        const auto flattened_padded_output_shape = flatten_4d_shape(dram_output_tensor.padded_shape());
+        dram_output_tensor = ttnn::reshape(dram_output_tensor, flattened_output_shape, flattened_padded_output_shape);
+
+        return {dram_output_tensor, output_height, output_width, weight_tensor, bias_tensor};
+    }
 
     weight_tensor_on_device = weight_tensor;
     bias_tensor_on_device = bias_tensor;

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d.cpp
@@ -12,8 +12,10 @@
 #include <tt_stl/assert.hpp>
 #include <tt-logger/tt-logger.hpp>
 
+#include "tt-metalium/constants.hpp"
 #include "tt-metalium/math.hpp"
 #include "ttnn/operations/sliding_window/op_slicing/op_slicing.hpp"
+#include "ttnn/operations/core/to_layout/to_layout_op.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/tensor/types.hpp"
 #include "ttnn/types.hpp"
@@ -715,6 +717,182 @@ public:
     }
 };
 
+// Channel-chunk decision for grouped convs: a grouped conv can be split exactly along
+// the channel/group axis (chunk k owns groups [k*G/K, (k+1)*G/K)) with no cross-chunk
+// dependency, so when a single call cannot satisfy the per-core L1 limit even with
+// maximum spatial slicing, the op can run as K channel chunks instead. Returns the
+// number of channel chunks to use (1 = do not chunk). Two weight forms are chunkable:
+//  - Host weights in OIHW layout: each chunk re-prepares its own weight slice on host.
+//  - Prepared device weights in the 1D-depthwise layout [1, 1, act_block_h*32*K, C_padded]
+//    (TILE, see convert_conv_weight_tensor_to_depthwise_layout): each chunk slices its
+//    channel range out fully on device (untilize once, slice the last dim, tilize) and
+//    the chunk conv consumes the TILE slice as-is (valid device weights), so no host
+//    weight re-preparation runs and the path stays safe under trace capture. The chunk
+//    conv_config pins act_block_h to the prepared tap-slab height so the kernel reads
+//    each kernel tap's slab at the boundaries the preparation laid out.
+static uint32_t channel_chunk_count_if_needed(
+    const ttnn::Tensor& weight_tensor,
+    const std::optional<const ttnn::Tensor>& bias_tensor,
+    MeshDevice* device,
+    uint32_t batch_size,
+    uint32_t input_height,
+    uint32_t input_width,
+    uint32_t in_channels,
+    uint32_t out_channels,
+    std::array<uint32_t, 2> kernel_size,
+    std::array<uint32_t, 2> stride,
+    std::array<uint32_t, 4> padding_n4,
+    std::array<uint32_t, 2> dilation,
+    uint32_t groups,
+    tt::tt_metal::Layout input_layout,
+    tt::tt_metal::DataType input_dtype,
+    tt::tt_metal::DataType output_dtype,
+    const Conv2dConfig& conv_config,
+    const DeviceComputeKernelConfig& compute_config,
+    const std::optional<const Conv2dSliceConfig>& dram_slice_config_) {
+    const uint32_t kernel_taps = kernel_size[0] * kernel_size[1];
+    const bool weight_is_host = !ttnn::is_device_tensor(weight_tensor);
+    const bool weight_is_prepared_depthwise =
+        !weight_is_host && kernel_size[0] == 1 && groups == in_channels && groups == out_channels &&
+        conv_config.shard_layout.has_value() &&
+        !conv_config.enable_kernel_stride_folding.value_or(false) && !conv_config.enable_activation_reuse &&
+        is_valid_device_conv_weights(weight_tensor, in_channels, out_channels, conv_config.weights_dtype) &&
+        [kernel_taps, &weight_tensor]() {
+            const auto& weight_shape = weight_tensor.logical_shape();
+            return weight_shape[2] % kernel_taps == 0 &&
+                   (weight_shape[2] / kernel_taps) % tt::constants::TILE_HEIGHT == 0;
+        }();
+    const bool can_chunk_channels =
+        groups > 1 && in_channels % groups == 0 && out_channels % groups == 0 &&
+        (weight_is_host || weight_is_prepared_depthwise) &&
+        (!bias_tensor.has_value() || !ttnn::is_device_tensor(bias_tensor.value()));
+    if (!can_chunk_channels) {
+        return 1;
+    }
+
+    Conv2dConfig estimate_conv_config = conv_config;
+    if (weight_is_prepared_depthwise) {
+        // Pin the act block height to the prepared tap-slab height so the L1 estimate
+        // matches what the chunk runs will actually use (mirrored in conv2d_DRAM).
+        estimate_conv_config.act_block_h_override = weight_tensor.logical_shape()[2] / kernel_taps;
+    }
+
+    auto [output_height, output_width] =
+        calculate_output_image_size({input_height, input_width}, kernel_size, stride, padding_n4, dilation);
+    const uint32_t l1_available_bytes =
+        device->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_free_bytes;
+    // Host-only L1 estimate for a single (unchunked, spatially-unsliced) call with the
+    // given channel count, using the same machinery the DRAM auto-slicer uses.
+    auto single_call_l1_usage = [&](uint32_t est_in_channels, uint32_t est_out_channels, uint32_t est_groups) {
+        Tensor weight_for_estimate = weight_tensor;
+        std::optional<Tensor> bias_for_estimate = bias_tensor;
+        auto attr = Conv2dSliceAttr(
+            batch_size,
+            {input_height, input_width},
+            est_in_channels,
+            est_out_channels,
+            kernel_size,
+            stride,
+            padding_n4,
+            dilation,
+            est_groups,
+            input_layout,
+            input_dtype,
+            output_dtype,
+            weight_for_estimate,
+            bias_for_estimate.has_value() ? std::make_optional(std::ref(bias_for_estimate.value())) : std::nullopt,
+            estimate_conv_config,
+            compute_config,
+            device);
+        return attr.get_L1_usage(
+            {0, 0},
+            {output_height, output_width},
+            ttnn::operations::op_slicing::Op2DSliceConfig{
+                .slice_type = ttnn::operations::op_slicing::Op2DSliceConfig::SliceType::DRAM_WIDTH,
+                .num_slices = 1});
+    };
+
+    bool needs_channel_chunking = false;
+    if (dram_slice_config_.has_value() &&
+        dram_slice_config_.value().slice_type ==
+            ttnn::operations::op_slicing::Op2DSliceConfig::SliceType::L1_FULL &&
+        dram_slice_config_.value().num_slices <= 1) {
+        // Forced L1_FULL (num_slices==0 is the default for the L1_FULL slice config):
+        // chunk when the single full call cannot fit in L1.
+        needs_channel_chunking = single_call_l1_usage(in_channels, out_channels, groups) > l1_available_bytes;
+    } else if (!dram_slice_config_.has_value() || dram_slice_config_.value().num_slices == 0) {
+        // Auto spatial slicing: chunk channels only when the DRAM auto-slicer cannot
+        // find any valid spatial slice configuration for the full call.
+        try {
+            Tensor weight_for_estimate = weight_tensor;
+            std::optional<Tensor> bias_for_estimate = bias_tensor;
+            auto attr = Conv2dSliceAttr(
+                batch_size,
+                {input_height, input_width},
+                in_channels,
+                out_channels,
+                kernel_size,
+                stride,
+                padding_n4,
+                dilation,
+                groups,
+                input_layout,
+                input_dtype,
+                output_dtype,
+                weight_for_estimate,
+                bias_for_estimate.has_value() ? std::make_optional(std::ref(bias_for_estimate.value())) : std::nullopt,
+                estimate_conv_config,
+                compute_config,
+                device);
+            ttnn::operations::op_slicing::determine_slice_config(
+                &attr,
+                ttnn::Shape({batch_size, input_height, input_width, in_channels}),
+                ttnn::Shape({batch_size, output_height, output_width, out_channels}),
+                std::nullopt,
+                estimate_conv_config.output_layout,
+                device);
+        } catch (...) {
+            needs_channel_chunking = true;
+        }
+    }
+    if (!needs_channel_chunking) {
+        return 1;
+    }
+    // Pick the smallest power-of-two chunk count that divides groups and whose
+    // per-chunk single call fits the available L1.
+    uint32_t num_channel_chunks = 1;
+    for (uint32_t candidate_chunks = 2; candidate_chunks <= groups; candidate_chunks *= 2) {
+        if (groups % candidate_chunks != 0) {
+            continue;
+        }
+        if (single_call_l1_usage(
+                in_channels / candidate_chunks, out_channels / candidate_chunks, groups / candidate_chunks) <=
+            l1_available_bytes) {
+            num_channel_chunks = candidate_chunks;
+            break;
+        }
+    }
+    if (num_channel_chunks > 1) {
+        log_warning(
+            tt::LogOp,
+            "Conv2D DRAM: grouped conv with groups={} does not fit in available L1 ({} bytes) even with maximum "
+            "spatial slicing; running as {} channel chunks of {} input channels each{}.",
+            groups,
+            l1_available_bytes,
+            num_channel_chunks,
+            in_channels / num_channel_chunks,
+            weight_is_prepared_depthwise ? " (prepared device weights, chunked on device)" : "");
+    } else {
+        log_warning(
+            tt::LogOp,
+            "Conv2D DRAM: grouped conv with groups={} needs channel chunking but no power-of-two chunk count fits "
+            "available L1 ({} bytes).",
+            groups,
+            l1_available_bytes);
+    }
+    return num_channel_chunks;
+}
+
 // This function is used for DRAM Slicing
 // It divides the output tensor into slices, and calculates the corresponding input slices.
 // Uses ttnn::slice to slice the input tensor and bring it to L1.
@@ -827,132 +1005,29 @@ Result conv2d_DRAM(
         input_tensor_on_device.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,
         "Input Tensor to Conv DRAM should be in Interleaved Memory Layout");
 
-    // Grouped convolutions (groups > 1) can be split exactly along the channel/group
-    // axis: chunk k owns groups [k*G/K, (k+1)*G/K), i.e. a contiguous range of input
-    // and output channels with no cross-chunk dependency. When a single call cannot
-    // satisfy the per-core L1 limit even with maximum spatial DRAM slicing (the DRAM
-    // auto-slicer throws), run the op as K channel chunks instead: slice each chunk's
-    // input channels with padded_slice straight into the sharded input config the
-    // chunk's conv expects, run the conv via the slice attr, and stitch the chunk
-    // outputs back into the DRAM output tensor with slice_write. Only host weights
-    // (OIHW layout) can be chunked, since each chunk needs its own weight preparation.
-    const bool can_chunk_channels = groups > 1 && in_channels % groups == 0 && out_channels % groups == 0 &&
-                                    !ttnn::is_device_tensor(weight_tensor) &&
-                                    (!bias_tensor.has_value() || !ttnn::is_device_tensor(bias_tensor.value()));
-
-    uint32_t num_channel_chunks = 1;
-    if (can_chunk_channels) {
-        const uint32_t l1_available_bytes =
-            device->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_free_bytes;
-        // Host-only L1 estimate for a single (unchunked spatially-unsliced) call with the
-        // given channel count, using the same machinery the DRAM auto-slicer uses.
-        auto single_call_l1_usage = [&](uint32_t est_in_channels, uint32_t est_out_channels, uint32_t est_groups) {
-            Tensor weight_for_estimate = weight_tensor;
-            std::optional<Tensor> bias_for_estimate = bias_tensor;
-            auto attr = Conv2dSliceAttr(
-                batch_size,
-                {input_height, input_width},
-                est_in_channels,
-                est_out_channels,
-                kernel_size,
-                stride,
-                padding_n4,
-                dilation,
-                est_groups,
-                input_tensor.layout(),
-                input_tensor.dtype(),
-                output_dtype,
-                weight_for_estimate,
-                bias_for_estimate.has_value() ? std::make_optional(std::ref(bias_for_estimate.value())) : std::nullopt,
-                conv_config,
-                compute_config,
-                device);
-            return attr.get_L1_usage(
-                {0, 0},
-                {output_height, output_width},
-                ttnn::operations::op_slicing::Op2DSliceConfig{
-                    .slice_type = ttnn::operations::op_slicing::Op2DSliceConfig::SliceType::DRAM_WIDTH,
-                    .num_slices = 1});
-        };
-
-        bool needs_channel_chunking = false;
-        if (!dram_slice_config_.has_value() || dram_slice_config_.value().num_slices == 0) {
-            // Auto spatial slicing: chunk channels only when the DRAM auto-slicer cannot
-            // find any valid spatial slice configuration for the full call.
-            try {
-                Tensor weight_for_estimate = weight_tensor;
-                std::optional<Tensor> bias_for_estimate = bias_tensor;
-                auto attr = Conv2dSliceAttr(
-                    batch_size,
-                    {input_height, input_width},
-                    in_channels,
-                    out_channels,
-                    kernel_size,
-                    stride,
-                    padding_n4,
-                    dilation,
-                    groups,
-                    input_tensor.layout(),
-                    input_tensor.dtype(),
-                    output_dtype,
-                    weight_for_estimate,
-                    bias_for_estimate.has_value()
-                        ? std::make_optional(std::ref(bias_for_estimate.value()))
-                        : std::nullopt,
-                    conv_config,
-                    compute_config,
-                    device);
-                ttnn::operations::op_slicing::determine_slice_config(
-                    &attr,
-                    input_tensor_on_device.logical_shape(),
-                    ttnn::Shape({batch_size, output_height, output_width, out_channels}),
-                    std::nullopt,
-                    conv_config.output_layout,
-                    device);
-            } catch (...) {
-                needs_channel_chunking = true;
-            }
-        } else if (
-            dram_slice_config_.value().slice_type ==
-                ttnn::operations::op_slicing::Op2DSliceConfig::SliceType::L1_FULL &&
-            dram_slice_config_.value().num_slices == 1) {
-            // Forced L1_FULL: chunk when the single full call cannot fit in L1.
-            needs_channel_chunking = single_call_l1_usage(in_channels, out_channels, groups) > l1_available_bytes;
-        }
-        if (needs_channel_chunking) {
-            // Pick the smallest power-of-two chunk count that divides groups and whose
-            // per-chunk single call fits the available L1.
-            for (uint32_t candidate_chunks = 2; candidate_chunks <= groups; candidate_chunks *= 2) {
-                if (groups % candidate_chunks != 0) {
-                    continue;
-                }
-                if (single_call_l1_usage(
-                        in_channels / candidate_chunks,
-                        out_channels / candidate_chunks,
-                        groups / candidate_chunks) <= l1_available_bytes) {
-                    num_channel_chunks = candidate_chunks;
-                    break;
-                }
-            }
-            if (num_channel_chunks > 1) {
-                log_warning(
-                    tt::LogOp,
-                    "Conv2D DRAM: grouped conv with groups={} does not fit in available L1 ({} bytes) even with "
-                    "maximum spatial slicing; running as {} channel chunks of {} input channels each.",
-                    groups,
-                    l1_available_bytes,
-                    num_channel_chunks,
-                    in_channels / num_channel_chunks);
-            } else {
-                log_warning(
-                    tt::LogOp,
-                    "Conv2D DRAM: grouped conv with groups={} needs channel chunking but no power-of-two chunk "
-                    "count fits available L1 ({} bytes).",
-                    groups,
-                    l1_available_bytes);
-            }
-        }
-    }
+    // Grouped convolutions that cannot satisfy the per-core L1 limit even with maximum
+    // spatial DRAM slicing run as channel chunks instead (see
+    // channel_chunk_count_if_needed for the decision and the two supported weight forms).
+    const uint32_t num_channel_chunks = channel_chunk_count_if_needed(
+        weight_tensor,
+        bias_tensor,
+        device,
+        batch_size,
+        input_height,
+        input_width,
+        in_channels,
+        out_channels,
+        kernel_size,
+        stride,
+        padding_n4,
+        dilation,
+        groups,
+        input_tensor.layout(),
+        input_tensor.dtype(),
+        output_dtype,
+        conv_config,
+        compute_config,
+        dram_slice_config_);
 
     // The channel-chunked path stitches chunk outputs into a ROW_MAJOR DRAM tensor:
     // slice_write's RM interleaved program factory is the only one that supports a
@@ -975,24 +1050,54 @@ Result conv2d_DRAM(
         const uint32_t chunk_out_channels = out_channels / num_channel_chunks;
         const uint32_t chunk_groups = groups / num_channel_chunks;
 
-        // The composite ttnn::slice cannot slice HOST tensors, so stage the host
-        // weights/bias to DRAM once and row-slice each chunk's output channels on
-        // device; from_device brings the chunk slice back to the host OIHW layout the
-        // chunk's own weight preparation (inside the L1 op) expects.
-        Tensor chunkable_weight_src =
-            ttnn::operations::core::to_device(weight_tensor, device, ttnn::DRAM_MEMORY_CONFIG);
+        // Host OIHW weights: the composite ttnn::slice cannot slice HOST tensors, so
+        // stage them to DRAM once and row-slice each chunk's output channels on device;
+        // from_device brings the chunk slice back to the host OIHW layout the chunk's
+        // own weight preparation (inside the L1 op) expects.
+        // Prepared depthwise device weights ([1, 1, act_block_h*32*K, C_padded], TILE):
+        // untilize once to ROW_MAJOR DRAM, then slice each chunk's channel range (last
+        // dim) and tilize it back — the chunk conv consumes the TILE slice as-is (valid
+        // device weights), so no host weight re-preparation runs and the path stays safe
+        // under trace capture. act_block_h is pinned to the prepared tap slab height so
+        // the kernel reads each kernel tap's slab at its prepared boundaries.
+        const bool chunk_prepared_device_weights = ttnn::is_device_tensor(weight_tensor);
+        Tensor chunkable_weight_src;
         std::optional<Tensor> chunkable_bias_src =
             bias_tensor.has_value()
                 ? std::make_optional(
                       ttnn::operations::core::to_device(bias_tensor.value(), device, ttnn::DRAM_MEMORY_CONFIG))
                 : std::nullopt;
+        Tensor prepared_weight_rm;
+        Conv2dConfig chunk_conv_config = conv_config;
+        if (chunk_prepared_device_weights) {
+            prepared_weight_rm = ttnn::untilize(ttnn::to_memory_config(
+                weight_tensor, MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM}));
+            const uint32_t prepared_tap_slab_rows =
+                weight_tensor.logical_shape()[2] / (kernel_size[0] * kernel_size[1]);
+            chunk_conv_config.act_block_h_override = prepared_tap_slab_rows;
+            log_debug(
+                tt::LogOp,
+                "Conv2D DRAM channel chunking: prepared device weights with {} rows per kernel tap slab.",
+                prepared_tap_slab_rows);
+        } else {
+            chunkable_weight_src =
+                ttnn::operations::core::to_device(weight_tensor, device, ttnn::DRAM_MEMORY_CONFIG);
+        }
 
         for (uint32_t chunk_index = 0; chunk_index < num_channel_chunks; chunk_index++) {
             const uint32_t in_channels_begin = chunk_index * chunk_in_channels;
             const uint32_t out_channels_begin = chunk_index * chunk_out_channels;
 
             Tensor chunk_weight;
-            {
+            if (chunk_prepared_device_weights) {
+                const uint32_t prepared_slab_rows = weight_tensor.logical_shape()[2];
+                Tensor chunk_weight_rm = ttnn::slice(
+                    prepared_weight_rm,
+                    ttsl::SmallVector<uint32_t>{0, 0, 0, out_channels_begin},
+                    ttsl::SmallVector<uint32_t>{1, 1, prepared_slab_rows, out_channels_begin + chunk_out_channels},
+                    ttsl::SmallVector<uint32_t>{1, 1, 1, 1});
+                chunk_weight = ttnn::to_layout(chunk_weight_rm, tt::tt_metal::Layout::TILE);
+            } else {
                 const auto& weight_shape = chunkable_weight_src.logical_shape();
                 chunk_weight = ttnn::operations::core::from_device(ttnn::slice(
                     chunkable_weight_src,
@@ -1026,7 +1131,7 @@ Result conv2d_DRAM(
                 output_dtype,
                 chunk_weight,
                 chunk_bias.has_value() ? std::make_optional(std::ref(chunk_bias.value())) : std::nullopt,
-                conv_config,
+                chunk_conv_config,
                 compute_config,
                 device);
 
@@ -1069,7 +1174,10 @@ Result conv2d_DRAM(
                 ttsl::SmallVector<uint32_t>{1, 1, 1, 1});
         }
 
-        chunkable_weight_src.deallocate(true);
+        if (!chunk_prepared_device_weights) {
+            chunkable_weight_src.deallocate(true);
+        }
+        prepared_weight_rm.deallocate(true);
         if (chunkable_bias_src.has_value()) {
             chunkable_bias_src.value().deallocate(true);
         }
@@ -1151,6 +1259,51 @@ Conv2dResultWithOptions conv2d(
     using operations::conv::determine_conv2d_execution_path;
     // Determine execution path based on configuration and input properties
     Conv2dExecutionPath path = determine_conv2d_execution_path(input_tensor, slice_config_);
+
+    // An L1_FULL conv over a DRAM interleaved input whose single call cannot fit L1
+    // (e.g. the grouped depthwise conv1d that GDN prefill runs at large per-device
+    // channel counts) is rerouted to the DRAM path so the channel-chunk fallback can
+    // execute it; conv2d_DRAM re-derives the identical decision, so any call this
+    // check does not reroute keeps its exact existing behavior.
+    if (path == Conv2dExecutionPath::L1 && slice_config_.has_value() &&
+        slice_config_->slice_type == Conv2dSliceConfig::SliceType::L1_FULL && slice_config_->num_slices <= 1 &&
+        ttnn::is_device_tensor(input_tensor) &&
+        input_tensor.memory_config().buffer_type() == tt::tt_metal::BufferType::DRAM &&
+        input_tensor.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::INTERLEAVED) {
+        Conv2dConfig conv_config = conv_config_.value_or(Conv2dConfig());
+        const DataType output_dtype = dtype.value_or(input_tensor.dtype());
+        DataType weight_dtype = conv_config.weights_dtype.value_or(weight_tensor.dtype());
+        DeviceComputeKernelConfig compute_config = compute_config_.value_or(
+            operations::conv::get_conv_default_compute_kernel_config(device, input_tensor.dtype(), weight_dtype));
+        if (!conv_config.weights_dtype.has_value()) {
+            conv_config.weights_dtype = weight_tensor.dtype();
+        }
+        if (channel_chunk_count_if_needed(
+                weight_tensor,
+                bias_tensor,
+                device,
+                batch_size,
+                input_height,
+                input_width,
+                in_channels,
+                out_channels,
+                kernel_size,
+                stride,
+                operations::sliding_window::get_pair_n4_padding(padding),
+                dilation,
+                groups,
+                input_tensor.layout(),
+                input_tensor.dtype(),
+                output_dtype,
+                conv_config,
+                compute_config,
+                slice_config_) > 1) {
+            log_warning(
+                tt::LogOp,
+                "Conv2D L1_FULL: single call does not fit L1; routing to the DRAM path for channel chunking.");
+            path = Conv2dExecutionPath::DRAM;
+        }
+    }
 
     // Execute L1 path
     if (path == Conv2dExecutionPath::L1) {

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -325,6 +325,45 @@ ttnn::Tensor slice(
         if (!no_step) {
             TT_FATAL(input.dtype() != DataType::BFLOAT8_B, "Strided slice is not supported for BFLOAT8 tensors");
         }
+        // Narrow a TILE input to the minimal tile-aligned row window before the ROW_MAJOR hop.
+        // rm_only converts the WHOLE tensor to ROW_MAJOR; the untilize's per-core CBs are sized
+        // from the L1 free at program-creation time, so a row-subset slice of a wide activation
+        // can allocate CBs that cross concurrently resident L1 tensors and fail the launch-time
+        // CB/L1 clash check (program.cpp "static circular buffers ... clash with L1 buffers").
+        // Carving the tile window first (e.g. [1,2048,5120] rows 2045..2048 -> 32-row window)
+        // shrinks the untilize input by the row ratio; the tile-window slice is exact (row
+        // bounds tile-aligned) so numerics are unchanged. Interleaved + full-width + step-1
+        // inputs only; everything else keeps the existing whole-tensor conversion.
+        if (input_tensor.layout() == Layout::TILE && no_step && !one_dimensional &&
+            !input_tensor.is_sharded() && modified_begins[input_rank - 1] == 0 &&
+            modified_ends[input_rank - 1] == input_tensor.padded_shape()[input_rank - 1]) {
+            const uint32_t tile_h = tile_shape[0];
+            const uint32_t in_rows = input_tensor.padded_shape()[input_rank - 2];
+            const uint32_t win_begin = (modified_begins[input_rank - 2] / tile_h) * tile_h;
+            uint32_t win_end = std::min(tt::round_up(modified_ends[input_rank - 2], tile_h), in_rows);
+            win_end = std::max(win_end, tile_h);
+            if (win_begin < win_end && (win_end - win_begin) < in_rows) {
+                ttsl::SmallVector<uint32_t> win_begins = modified_begins;
+                ttsl::SmallVector<uint32_t> win_ends = modified_ends;
+                win_begins[input_rank - 2] = win_begin;
+                win_ends[input_rank - 2] = win_end;
+                input = ttnn::prim::slice(
+                    input,
+                    ttnn::Shape(win_begins),
+                    ttnn::Shape(win_ends),
+                    ttnn::Shape(modified_step),
+                    memory_config,
+                    /*use_tensor_args*/ false,
+                    std::nullopt,
+                    std::nullopt,
+                    std::nullopt,
+                    std::nullopt,
+                    sub_core_grids,
+                    std::nullopt);
+                modified_begins[input_rank - 2] -= win_begin;
+                modified_ends[input_rank - 2] -= win_begin;
+            }
+        }
         input = ttnn::to_layout(input, Layout::ROW_MAJOR, std::nullopt, memory_config);
     }
 

--- a/ttnn/cpp/ttnn/operations/transformer/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/transformer/CMakeLists.txt
@@ -19,6 +19,7 @@ file(
     sdpa_decode/device/kernels/*.hpp
     gated_delta_attn/device/kernels/*.cpp
     chunk_gated_delta_rule/device/kernels/*.cpp
+    decode_gated_delta_rule/device/kernels/*.cpp
 )
 target_sources(
     ttnn_op_transformer

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/decode_gated_delta_rule.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/decode_gated_delta_rule.cpp
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "decode_gated_delta_rule.hpp"
+
+#include <cmath>
+
+#include "device/decode_gated_delta_rule_device_operation.hpp"
+
+using namespace tt::tt_metal;
+
+namespace ttnn::transformer {
+
+std::tuple<ttnn::Tensor, ttnn::Tensor> decode_gated_delta_rule(
+    const ttnn::Tensor& q,
+    const ttnn::Tensor& k,
+    const ttnn::Tensor& v,
+    const ttnn::Tensor& beta,
+    const ttnn::Tensor& g,
+    std::optional<float> scale,
+    const std::optional<ttnn::Tensor>& initial_state,
+    bool inplace_state,
+    const std::optional<ttnn::MemoryConfig>& memory_config) {
+    const auto& qs = q.logical_shape();  // [B,1,H,K]
+    const uint32_t K = qs[3];
+    const float s = scale.value_or(1.0f / std::sqrt(static_cast<float>(K)));
+
+    // No host preprocessing: the T=1 [B,1,H,*] shapes are consumed directly
+    // (the reader gathers each head's row out of the shared TILE pages), so
+    // the whole graph above is one device program.
+    auto results = ttnn::prim::decode_gated_delta_rule(
+        q, k, v, beta, g, initial_state, inplace_state, s, memory_config.value_or(ttnn::DRAM_MEMORY_CONFIG));
+    return {results[0], results[1]};
+}
+
+}  // namespace ttnn::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/decode_gated_delta_rule.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/decode_gated_delta_rule.hpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include <tuple>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::transformer {
+
+/**
+ * Fused T=1 (decode step) Gated Delta Rule forward.
+ *
+ * Implements the recurrent decode graph of
+ * `recurrent_gated_delta_rule_decode_ttnn` in ONE reader/compute/writer
+ * program, one Tensix core per (B*H) head, fp32 accumulation:
+ *
+ *   qn = l2norm(q) * scale ; kn = l2norm(k)
+ *   h  = initial_state * exp(g)
+ *   v_read = kn @ h ; delta = v - v_read
+ *   h += (kn)^T @ (beta * delta)          (rank-1 write)
+ *   o  = qn @ h
+ *
+ *   q, k          [B, 1, H, K]   TILE, bf16 or fp32 (all one dtype)
+ *   v             [B, 1, H, V]   (H heads only; no GQA)
+ *   beta, g       [B, 1, H]      g is log-space decay
+ *   initial_state [B, H, K, V]   TILE, same dtype (absent => zeros)
+ *
+ * Returns:
+ *   o          [B, 1, H, V] TILE
+ *   new_state  [B, H, K, V] TILE
+ *
+ * inplace_state=True (requires initial_state): the writer stores new_state
+ * into initial_state's buffer and initial_state is returned unchanged as
+ * new_state — the fused equivalent of the python `_inplace` variant's
+ * copy-back into a preallocated state buffer (trace-safe addresses, no
+ * allocation).
+ */
+std::tuple<ttnn::Tensor, ttnn::Tensor> decode_gated_delta_rule(
+    const ttnn::Tensor& q,
+    const ttnn::Tensor& k,
+    const ttnn::Tensor& v,
+    const ttnn::Tensor& beta,
+    const ttnn::Tensor& g,
+    std::optional<float> scale = std::nullopt,
+    const std::optional<ttnn::Tensor>& initial_state = std::nullopt,
+    bool inplace_state = false,
+    const std::optional<ttnn::MemoryConfig>& memory_config = std::nullopt);
+
+}  // namespace ttnn::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/decode_gated_delta_rule_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/decode_gated_delta_rule_nanobind.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "decode_gated_delta_rule_nanobind.hpp"
+#include "decode_gated_delta_rule.hpp"
+
+#include "ttnn-nanobind/bind_function.hpp"
+
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/tuple.h>
+
+namespace ttnn::operations::transformer {
+
+void bind_decode_gated_delta_rule(nb::module_& mod) {
+    const auto* doc =
+        R\"doc(
+        Fused T=1 (decode step) Gated Delta Rule forward: one reader/compute/writer
+        program, one core per head, replacing the ~12-kernel python decode graph.
+
+        Args:
+            q (ttnn.Tensor):    [B, 1, H, K] TILE
+            k (ttnn.Tensor):    [B, 1, H, K] TILE
+            v (ttnn.Tensor):    [B, 1, H, V] TILE
+            beta (ttnn.Tensor): [B, 1, H] TILE
+            g (ttnn.Tensor):    [B, 1, H] TILE, log-space decay
+
+        Keyword Args:
+            scale (float, optional): defaults to K**-0.5.
+            initial_state (ttnn.Tensor, optional): [B, H, K, V] TILE, same dtype; zeros if absent.
+            inplace_state (bool): default False. When True (requires initial_state),
+                new_state is written into initial_state's buffer and initial_state is
+                returned as new_state (trace-safe, no allocation).
+            memory_config (ttnn.MemoryConfig, optional).
+
+        Returns:
+            tuple[ttnn.Tensor, ttnn.Tensor]: o [B,1,H,V] TILE, new_state [B,H,K,V] TILE.
+        )doc\";
+
+    ttnn::bind_function<"decode_gated_delta_rule", "ttnn.transformer.">(
+        mod,
+        doc,
+        &ttnn::transformer::decode_gated_delta_rule,
+        nb::arg("q").noconvert(),
+        nb::arg("k").noconvert(),
+        nb::arg("v").noconvert(),
+        nb::arg("beta").noconvert(),
+        nb::arg("g").noconvert(),
+        nb::kw_only(),
+        nb::arg("scale") = nb::none(),
+        nb::arg("initial_state") = nb::none(),
+        nb::arg("inplace_state") = false,
+        nb::arg("memory_config") = nb::none());
+}
+
+}  // namespace ttnn::operations::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/decode_gated_delta_rule_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/decode_gated_delta_rule_nanobind.cpp
@@ -13,7 +13,7 @@ namespace ttnn::operations::transformer {
 
 void bind_decode_gated_delta_rule(nb::module_& mod) {
     const auto* doc =
-        R\"doc(
+        R"doc(
         Fused T=1 (decode step) Gated Delta Rule forward: one reader/compute/writer
         program, one core per head, replacing the ~12-kernel python decode graph.
 
@@ -34,7 +34,7 @@ void bind_decode_gated_delta_rule(nb::module_& mod) {
 
         Returns:
             tuple[ttnn.Tensor, ttnn.Tensor]: o [B,1,H,V] TILE, new_state [B,H,K,V] TILE.
-        )doc\";
+        )doc";
 
     ttnn::bind_function<"decode_gated_delta_rule", "ttnn.transformer.">(
         mod,

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/decode_gated_delta_rule_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/decode_gated_delta_rule_nanobind.hpp
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <nanobind/nanobind.h>
+namespace nb = nanobind;
+
+namespace ttnn::operations::transformer {
+
+void bind_decode_gated_delta_rule(nb::module_& mod);
+
+}  // namespace ttnn::operations::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/decode_gated_delta_rule_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/decode_gated_delta_rule_device_operation.cpp
@@ -49,10 +49,16 @@ void DecodeGatedDeltaRuleDeviceOperation::validate_on_program_cache_miss(
 DecodeGatedDeltaRuleDeviceOperation::spec_return_value_t
 DecodeGatedDeltaRuleDeviceOperation::compute_output_specs(const operation_attributes_t& attrs, const tensor_args_t& in) {
     const DataType dt = in.q.dtype();
-    const auto layout = TensorLayout(dt, PageConfig(Layout::TILE), attrs.output_mem_config);
+    // o is ROW_MAJOR on purpose: its flat 2D is [B*H, V], so page bh is head
+    // bh's own [V] stick and the writer kernel issues ONE full-page write per
+    // head (page-exclusive). A TILE o would share each page across 32 heads,
+    // forcing sub-page writes, which silently no-op on this stack (red-state
+    // pcc_o=0.000). Callers wanting TILE o pass it through ttnn.to_layout.
+    const auto layout_rm = TensorLayout(dt, PageConfig(Layout::ROW_MAJOR), attrs.output_mem_config);
+    const auto layout_tile = TensorLayout(dt, PageConfig(Layout::TILE), attrs.output_mem_config);
     return {
-        tt::tt_metal::TensorSpec(ttnn::Shape({attrs.B, 1, attrs.H, attrs.V}), layout),
-        tt::tt_metal::TensorSpec(ttnn::Shape({attrs.B, attrs.H, attrs.K, attrs.V}), layout)};
+        tt::tt_metal::TensorSpec(ttnn::Shape({attrs.B, 1, attrs.H, attrs.V}), layout_rm),
+        tt::tt_metal::TensorSpec(ttnn::Shape({attrs.B, attrs.H, attrs.K, attrs.V}), layout_tile)};
 }
 
 DecodeGatedDeltaRuleDeviceOperation::tensor_return_value_t

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/decode_gated_delta_rule_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/decode_gated_delta_rule_device_operation.cpp
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "decode_gated_delta_rule_device_operation.hpp"
+
+#include <tt-metalium/constants.hpp>
+#include "ttnn/device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+using namespace tt::tt_metal;
+
+namespace ttnn::prim {
+
+DecodeGatedDeltaRuleDeviceOperation::program_factory_t DecodeGatedDeltaRuleDeviceOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return DecodeGatedDeltaRuleProgramFactory{};
+}
+
+void DecodeGatedDeltaRuleDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& attrs, const tensor_args_t& in) {
+    using namespace tt::constants;
+    const DataType dt = in.q.dtype();
+    auto check = [&](const Tensor& t, const char* name) {
+        TT_FATAL(t.layout() == Layout::TILE, "decode_gated_delta_rule: {} must be TILE layout", name);
+        TT_FATAL(t.dtype() == dt, "decode_gated_delta_rule: all inputs must share one dtype", name);
+        TT_FATAL(dt == DataType::BFLOAT16 || dt == DataType::FLOAT32, "decode_gated_delta_rule: dtype must be bf16 or fp32");
+        TT_FATAL(t.buffer() != nullptr, "decode_gated_delta_rule: {} must be on device", name);
+    };
+    check(in.q, "q");
+    check(in.k, "k");
+    check(in.v, "v");
+    check(in.beta, "beta");
+    check(in.g, "g");
+    TT_FATAL(in.q.logical_shape()[1] == 1, "decode_gated_delta_rule: q must be T=1 [B,1,H,K]");
+    TT_FATAL(in.v.logical_shape()[2] == attrs.H, "decode_gated_delta_rule: v heads must equal q heads (no GQA)");
+    TT_FATAL(attrs.K % TILE_WIDTH == 0, "decode_gated_delta_rule: K must be a multiple of 32");
+    TT_FATAL(attrs.V % TILE_WIDTH == 0, "decode_gated_delta_rule: V must be a multiple of 32");
+    if (in.initial_state.has_value()) {
+        check(*in.initial_state, "initial_state");
+        const auto& s = in.initial_state->logical_shape();
+        TT_FATAL(
+            s[0] == attrs.B && s[1] == attrs.H && s[2] == attrs.K && s[3] == attrs.V,
+            "decode_gated_delta_rule: initial_state must be [B,H,K,V]");
+    } else {
+        TT_FATAL(!attrs.inplace_state, "decode_gated_delta_rule: inplace_state requires initial_state");
+    }
+}
+
+DecodeGatedDeltaRuleDeviceOperation::spec_return_value_t
+DecodeGatedDeltaRuleDeviceOperation::compute_output_specs(const operation_attributes_t& attrs, const tensor_args_t& in) {
+    const DataType dt = in.q.dtype();
+    const auto layout = TensorLayout(dt, PageConfig(Layout::TILE), attrs.output_mem_config);
+    return {
+        tt::tt_metal::TensorSpec(ttnn::Shape({attrs.B, 1, attrs.H, attrs.V}), layout),
+        tt::tt_metal::TensorSpec(ttnn::Shape({attrs.B, attrs.H, attrs.K, attrs.V}), layout)};
+}
+
+DecodeGatedDeltaRuleDeviceOperation::tensor_return_value_t
+DecodeGatedDeltaRuleDeviceOperation::create_output_tensors(const operation_attributes_t& attrs, const tensor_args_t& in) {
+    auto specs = compute_output_specs(attrs, in);
+    auto* device = in.q.device();
+    std::vector<Tensor> outs;
+    outs.reserve(2);
+    outs.push_back(create_device_tensor(specs[0], device));
+    if (attrs.inplace_state) {
+        outs.push_back(*in.initial_state);  // write new state back into the caller's buffer
+    } else {
+        outs.push_back(create_device_tensor(specs[1], device));
+    }
+    return outs;
+}
+
+std::vector<Tensor> decode_gated_delta_rule(
+    const Tensor& q,
+    const Tensor& k,
+    const Tensor& v,
+    const Tensor& beta,
+    const Tensor& g,
+    const std::optional<Tensor>& initial_state,
+    bool inplace_state,
+    float scale,
+    const tt::tt_metal::MemoryConfig& output_mem_config) {
+    using OperationType = DecodeGatedDeltaRuleDeviceOperation;
+
+    const auto& qs = q.logical_shape();  // [B,1,H,K]
+    const auto& vs = v.logical_shape();  // [B,1,H,V]
+
+    auto attrs = OperationType::operation_attributes_t{
+        .B = qs[0],
+        .H = qs[2],
+        .BH = qs[0] * qs[2],
+        .K = qs[3],
+        .V = vs[3],
+        .has_initial_state = initial_state.has_value(),
+        .inplace_state = inplace_state,
+        .scale = scale,
+        .output_mem_config = output_mem_config,
+    };
+    auto tensor_args = OperationType::tensor_args_t{
+        .q = q,
+        .k = k,
+        .v = v,
+        .beta = beta,
+        .g = g,
+        .initial_state = initial_state,
+    };
+    return ttnn::device_operation::launch<OperationType>(attrs, tensor_args);
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/decode_gated_delta_rule_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/decode_gated_delta_rule_device_operation.hpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <optional>
+#include <variant>
+#include <vector>
+
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/tensor/tensor.hpp"
+
+#include "decode_gated_delta_rule_device_operation_types.hpp"
+#include "decode_gated_delta_rule_program_factory.hpp"
+
+namespace ttnn::prim {
+
+// Device operation returning two tensors: {o [B,1,H,V], new_state [B,H,K,V]}.
+// new_state is the caller's initial_state tensor itself when inplace_state.
+struct DecodeGatedDeltaRuleDeviceOperation {
+    using operation_attributes_t = DecodeGatedDeltaRuleParams;
+    using tensor_args_t = DecodeGatedDeltaRuleInputs;
+    using spec_return_value_t = std::vector<tt::tt_metal::TensorSpec>;
+    using tensor_return_value_t = std::vector<Tensor>;
+    using program_factory_t = std::variant<DecodeGatedDeltaRuleProgramFactory>;
+
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+};
+
+// Low-level primitive dispatch.
+std::vector<Tensor> decode_gated_delta_rule(
+    const Tensor& q,
+    const Tensor& k,
+    const Tensor& v,
+    const Tensor& beta,
+    const Tensor& g,
+    const std::optional<Tensor>& initial_state,
+    bool inplace_state,
+    float scale,
+    const tt::tt_metal::MemoryConfig& output_mem_config);
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/decode_gated_delta_rule_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/decode_gated_delta_rule_device_operation_types.hpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Types for the fused T=1 (decode step) gated delta rule ttnn op.
+// One Tensix core per (B*H) head; the whole recurrent step
+// (L2-norm q/k, decay, v_read, delta, rank-1 write, o = q@h) runs in one
+// reader/compute/writer program, matching the python graph
+// `recurrent_gated_delta_rule_decode_ttnn`.
+
+#pragma once
+
+#include <optional>
+
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::prim {
+
+struct DecodeGatedDeltaRuleParams {
+    uint32_t B;    // batch
+    uint32_t H;    // heads (== v heads; no GQA in the decode graph)
+    uint32_t BH;   // B * H (one core per head)
+    uint32_t K;    // key dim (multiple of 32)
+    uint32_t V;    // value dim (multiple of 32)
+    bool has_initial_state;
+    bool inplace_state;  // write new state back into initial_state's buffer
+    float scale;         // folded into q's L2-norm factor (K**-0.5 by default)
+    tt::tt_metal::MemoryConfig output_mem_config;
+};
+
+// All inputs are python-facing shapes, TILE layout, same dtype (bf16 or fp32),
+// on device. T=1 inputs ([B,1,H,*]) share TILE pages across 32 heads; the
+// reader gathers each head's row out of the shared pages.
+struct DecodeGatedDeltaRuleInputs {
+    Tensor q;                             // [B,1,H,K]
+    Tensor k;                             // [B,1,H,K]
+    Tensor v;                             // [B,1,H,V]
+    Tensor beta;                          // [B,1,H]
+    Tensor g;                             // [B,1,H]  log-space decay
+    std::optional<Tensor> initial_state;  // [B,H,K,V] (absent => zeros)
+};
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/decode_gated_delta_rule_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/decode_gated_delta_rule_device_operation_types.hpp
@@ -29,7 +29,9 @@ struct DecodeGatedDeltaRuleParams {
 
 // All inputs are python-facing shapes, TILE layout, same dtype (bf16 or fp32),
 // on device. T=1 inputs ([B,1,H,*]) share TILE pages across 32 heads; the
-// reader gathers each head's row out of the shared pages.
+// reader gathers each head's row out of the shared pages. Outputs: o comes
+// back ROW_MAJOR (page bh == head bh's [V] stick; full-page writes only), the
+// new state is TILE [B,H,K,V].
 struct DecodeGatedDeltaRuleInputs {
     Tensor q;                             // [B,1,H,K]
     Tensor k;                             // [B,1,H,K]

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/decode_gated_delta_rule_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/decode_gated_delta_rule_program_factory.cpp
@@ -87,13 +87,17 @@ tt::tt_metal::ProgramDescriptor DecodeGatedDeltaRuleProgramFactory::create_descr
     auto* device = in.q.device();
     const CoreCoord grid = device->compute_with_storage_grid_size();
     const uint32_t grid_y = grid.y;
-    TT_FATAL(BH <= grid.x * grid.y, "num_heads {} exceeds compute cores {}", BH, grid.x * grid.y);
-
-    std::vector<CoreCoord> head_cores(BH);
+    // BH can exceed the grid (decode BH = B*H, e.g. 128*24 = 3072 on a 110-core
+    // die): each active core processes a contiguous chunk of head-instances
+    // [c*per_core, min((c+1)*per_core, BH)). For BH <= ncores, per_core == 1 and
+    // this reduces to the original one-instance-per-core mapping (core c <-> c).
+    const uint32_t ncores = grid.x * grid.y;
+    const uint32_t per_core = (BH + ncores - 1) / ncores;
+    std::vector<CoreCoord> active_cores;
     std::set<CoreRange> core_set;
-    for (uint32_t h = 0; h < BH; h++) {
-        head_cores[h] = CoreCoord{h / grid_y, h % grid_y};
-        core_set.insert(CoreRange{head_cores[h], head_cores[h]});
+    for (uint32_t c = 0; c < ncores && c * per_core < BH; c++) {
+        active_cores.push_back(CoreCoord{c / grid_y, c % grid_y});
+        core_set.insert(CoreRange{active_cores.back(), active_cores.back()});
     }
     CoreRangeSet cores{core_set};
 
@@ -125,7 +129,7 @@ tt::tt_metal::ProgramDescriptor DecodeGatedDeltaRuleProgramFactory::create_descr
     add_cb(cb::gexp, 1, 1, tt::DataFormat::Float32);
     add_cb(cb::sdec, kv, 1, tt::DataFormat::Float32);
     add_cb(cb::vread, Vt, 1, tt::DataFormat::Float32);
-    add_cb(cb::delta, Vt, 2, tt::DataFormat::Float32);  // 2x pages: in-place *beta
+    add_cb(cb::delta, Vt, 2, tt::DataFormat::Float32);  // 2x pages: in-place *beta  // 2x pages: in-place *beta
     add_cb(cb::outer, kv, 1, tt::DataFormat::Float32);
     add_cb(cb::sout, kv, 1, df_io);
     add_cb(cb::out, Vt, 2, df_io);
@@ -136,7 +140,7 @@ tt::tt_metal::ProgramDescriptor DecodeGatedDeltaRuleProgramFactory::create_descr
     add_cb(cb::betaf, 1, 1, tt::DataFormat::Float32);
     add_cb(cb::sf, kv, 1, tt::DataFormat::Float32);
     add_cb(cb::snew, kv, 1, tt::DataFormat::Float32);
-    add_cb(cb::scratch, std::max(Kt, Vt), 1, df_io);
+    add_cb(cb::scratch, 2, 1, df_io);
 
     const std::string kdir = "ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/kernels/";
     const std::vector<uint32_t> ct_args = {Kt, Vt, has_s0, eps_bits, scale_bits};
@@ -190,13 +194,17 @@ tt::tt_metal::ProgramDescriptor DecodeGatedDeltaRuleProgramFactory::create_descr
     auto* o_buf = outputs[0].buffer();
     auto* s1_buf = outputs[1].buffer();
 
-    for (uint32_t h = 0; h < BH; h++) {
-        const auto& core = head_cores[h];
-        reader.emplace_runtime_args(core, {h, q_buf, k_buf, v_buf, beta_buf, g_buf, s0_buf});
+    for (uint32_t c = 0; c < active_cores.size(); c++) {
+        const auto& core = active_cores[c];
+        const uint32_t start = c * per_core;
+        const uint32_t n_inst = std::min(per_core, BH - start);
+        // Runtime args carry the instance RANGE [start, start+n_inst); each
+        // kernel derives bh = start + i in its per-instance loop.
+        reader.emplace_runtime_args(core, {start, n_inst, q_buf, k_buf, v_buf, beta_buf, g_buf, s0_buf});
         // o is ROW_MAJOR: pass its stick page size (page bh == head bh's row).
         writer.emplace_runtime_args(
-            core, {h, o_buf, static_cast<uint32_t>(o_buf->page_size()), s1_buf});
-        compute.emplace_runtime_args(core, {h});
+            core, {start, n_inst, o_buf, static_cast<uint32_t>(o_buf->page_size()), s1_buf});
+        compute.emplace_runtime_args(core, {n_inst});
     }
     desc.kernels.push_back(std::move(reader));
     desc.kernels.push_back(std::move(writer));

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/decode_gated_delta_rule_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/decode_gated_delta_rule_program_factory.cpp
@@ -7,9 +7,10 @@
 // Parallelism: one Tensix core per (B*H) head. The T=1 inputs [B,1,H,*] are
 // TILE tensors whose flat 2D view is [B*H rows, D cols] — 32 heads share each
 // row of TILE pages, so the reader GATHERS head bh's row out of the shared
-// pages (face-layout addressing) into private row-0 tiles; the writer SCATTERS
-// o's row back the same way. The state [B,H,K,V] pages are head-aligned
-// (K multiple of 32) and move as full tiles.
+// pages (face-layout addressing) into private row-0 tiles. o is returned
+// ROW_MAJOR so head bh owns DRAM page bh (its [V] stick) exclusively and the
+// writer uses only full-page writes (sub-page writes do not land). The state
+// [B,H,K,V] pages are head-aligned (K multiple of 32) and move as full tiles.
 
 #include "decode_gated_delta_rule_program_factory.hpp"
 
@@ -39,7 +40,11 @@ constexpr uint32_t state = tt::CBIndex::c_5;  // [Kt,Vt] io input state (or zero
 constexpr uint32_t ones = tt::CBIndex::c_6;   // 1 tile fp32 all-ones (rowsum contraction)
 constexpr uint32_t qsq = tt::CBIndex::c_7;    // [1,Kt] fp32 q*q
 constexpr uint32_t ksq = tt::CBIndex::c_8;    // [1,Kt] fp32 k*k
-constexpr uint32_t sc = tt::CBIndex::c_9;     // 2 tiles fp32 rowsum/inv-norm ping-pong
+constexpr uint32_t sc = tt::CBIndex::c_9;     // 1 tile fp32 rowsum of squares
+constexpr uint32_t sc2 = tt::CBIndex::c_28;  // 1 tile fp32 q-chain inv-rms factor
+constexpr uint32_t sc3 = tt::CBIndex::c_29;  // 1 tile fp32 k-chain inv-rms factor
+// (each norm chain gets its OWN factor CB: reusing one ring made the second
+// chain's bcast read the first chain's factor - ttsim gdn_decode_simdiag3)
 constexpr uint32_t qn = tt::CBIndex::c_10;    // [1,Kt] fp32 normalized (scaled) q
 constexpr uint32_t kn = tt::CBIndex::c_11;    // [1,Kt] fp32 normalized k
 constexpr uint32_t kcol = tt::CBIndex::c_12;  // [Kt,1] fp32 transpose(kn)
@@ -50,6 +55,16 @@ constexpr uint32_t delta = tt::CBIndex::c_16; // 2x[1,Vt] fp32 v-v_read, then *b
 constexpr uint32_t outer = tt::CBIndex::c_17; // [Kt,Vt] fp32 kcol @ delta
 constexpr uint32_t sout = tt::CBIndex::c_18;  // [Kt,Vt] io new state
 constexpr uint32_t out = tt::CBIndex::c_19;   // [1,Vt] io  o = q@h
+// fp32 mirrors of the io inputs + fp32 new state: every math operand is fp32
+// (mixed bf16-srcA x fp32-srcB pairs corrupt the fp32 side; chunk-scan pattern).
+constexpr uint32_t qf = tt::CBIndex::c_20;      // [1,Kt] fp32 q
+constexpr uint32_t kf = tt::CBIndex::c_21;      // [1,Kt] fp32 k
+constexpr uint32_t vf = tt::CBIndex::c_22;      // [1,Vt] fp32 v
+constexpr uint32_t gf = tt::CBIndex::c_23;      // 1 tile fp32 g_h
+constexpr uint32_t betaf = tt::CBIndex::c_24;   // 1 tile fp32 beta_h
+constexpr uint32_t sf = tt::CBIndex::c_25;      // [Kt,Vt] fp32 input state
+constexpr uint32_t snew = tt::CBIndex::c_26;    // [Kt,Vt] fp32 new state
+constexpr uint32_t scratch = tt::CBIndex::c_27; // max(Kt,Vt) io staging pages (full-page DMA)
 }  // namespace cb
 
 tt::tt_metal::ProgramDescriptor DecodeGatedDeltaRuleProgramFactory::create_descriptor(
@@ -101,7 +116,9 @@ tt::tt_metal::ProgramDescriptor DecodeGatedDeltaRuleProgramFactory::create_descr
     add_cb(cb::ones, 1, 1, tt::DataFormat::Float32);
     add_cb(cb::qsq, Kt, 1, tt::DataFormat::Float32);
     add_cb(cb::ksq, Kt, 1, tt::DataFormat::Float32);
-    add_cb(cb::sc, 1, 2, tt::DataFormat::Float32);   // 2 pages: in-place inv-norm
+    add_cb(cb::sc, 1, 1, tt::DataFormat::Float32);   // rowsum of squares
+    add_cb(cb::sc2, 1, 1, tt::DataFormat::Float32);  // q-chain inv-rms factor
+    add_cb(cb::sc3, 1, 1, tt::DataFormat::Float32);  // k-chain inv-rms factor
     add_cb(cb::qn, Kt, 1, tt::DataFormat::Float32);
     add_cb(cb::kn, Kt, 1, tt::DataFormat::Float32);
     add_cb(cb::kcol, Kt, 1, tt::DataFormat::Float32);
@@ -112,12 +129,22 @@ tt::tt_metal::ProgramDescriptor DecodeGatedDeltaRuleProgramFactory::create_descr
     add_cb(cb::outer, kv, 1, tt::DataFormat::Float32);
     add_cb(cb::sout, kv, 1, df_io);
     add_cb(cb::out, Vt, 2, df_io);
+    add_cb(cb::qf, Kt, 1, tt::DataFormat::Float32);
+    add_cb(cb::kf, Kt, 1, tt::DataFormat::Float32);
+    add_cb(cb::vf, Vt, 1, tt::DataFormat::Float32);
+    add_cb(cb::gf, 1, 1, tt::DataFormat::Float32);
+    add_cb(cb::betaf, 1, 1, tt::DataFormat::Float32);
+    add_cb(cb::sf, kv, 1, tt::DataFormat::Float32);
+    add_cb(cb::snew, kv, 1, tt::DataFormat::Float32);
+    add_cb(cb::scratch, std::max(Kt, Vt), 1, df_io);
 
     const std::string kdir = "ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/kernels/";
     const std::vector<uint32_t> ct_args = {Kt, Vt, has_s0, eps_bits, scale_bits};
 
-    // Reader compile args: {Kt,Vt,has_s0,eps,scale} + TensorAccessorArgs per input (in order).
-    std::vector<uint32_t> reader_ct = ct_args;
+    // Reader compile args: {Kt,Vt,has_s0,eps,scale,H} + TensorAccessorArgs per
+    // input (in order). H decomposes bh = b*H + h for the [B,1,H] scalar gather
+    // (beta/g flat 2D is [B,H]: head (b,h) at row b, col h).
+    std::vector<uint32_t> reader_ct = {Kt, Vt, has_s0, eps_bits, scale_bits, attrs.H};
     TensorAccessorArgs(*in.q.buffer()).append_to(reader_ct);
     TensorAccessorArgs(*in.k.buffer()).append_to(reader_ct);
     TensorAccessorArgs(*in.v.buffer()).append_to(reader_ct);
@@ -166,10 +193,11 @@ tt::tt_metal::ProgramDescriptor DecodeGatedDeltaRuleProgramFactory::create_descr
     for (uint32_t h = 0; h < BH; h++) {
         const auto& core = head_cores[h];
         reader.emplace_runtime_args(core, {h, q_buf, k_buf, v_buf, beta_buf, g_buf, s0_buf});
-        writer.emplace_runtime_args(core, {h, o_buf, s1_buf});
+        // o is ROW_MAJOR: pass its stick page size (page bh == head bh's row).
+        writer.emplace_runtime_args(
+            core, {h, o_buf, static_cast<uint32_t>(o_buf->page_size()), s1_buf});
         compute.emplace_runtime_args(core, {h});
     }
-
     desc.kernels.push_back(std::move(reader));
     desc.kernels.push_back(std::move(writer));
     desc.kernels.push_back(std::move(compute));

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/decode_gated_delta_rule_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/decode_gated_delta_rule_program_factory.cpp
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Program factory for the fused T=1 decode gated delta rule op (Device 2.0
+// descriptor style, mirroring chunk_gated_delta_rule).
+//
+// Parallelism: one Tensix core per (B*H) head. The T=1 inputs [B,1,H,*] are
+// TILE tensors whose flat 2D view is [B*H rows, D cols] — 32 heads share each
+// row of TILE pages, so the reader GATHERS head bh's row out of the shared
+// pages (face-layout addressing) into private row-0 tiles; the writer SCATTERS
+// o's row back the same way. The state [B,H,K,V] pages are head-aligned
+// (K multiple of 32) and move as full tiles.
+
+#include "decode_gated_delta_rule_program_factory.hpp"
+
+#include <bit>
+#include <cmath>
+#include <set>
+#include <vector>
+
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+using namespace tt::tt_metal;
+using namespace tt::constants;
+
+namespace ttnn::prim {
+
+// CB index plan (io = input dtype, scratch fp32). Kept in sync with kernels.
+namespace cb {
+constexpr uint32_t q = tt::CBIndex::c_0;      // [1,Kt] io  gathered q row
+constexpr uint32_t k = tt::CBIndex::c_1;      // [1,Kt] io  gathered k row
+constexpr uint32_t v = tt::CBIndex::c_2;      // [1,Vt] io  gathered v row
+constexpr uint32_t g = tt::CBIndex::c_3;      // 1 tile io  scalar g_h at [0,0]
+constexpr uint32_t beta = tt::CBIndex::c_4;   // 1 tile io  scalar beta_h at [0,0]
+constexpr uint32_t state = tt::CBIndex::c_5;  // [Kt,Vt] io input state (or zeros)
+constexpr uint32_t ones = tt::CBIndex::c_6;   // 1 tile fp32 all-ones (rowsum contraction)
+constexpr uint32_t qsq = tt::CBIndex::c_7;    // [1,Kt] fp32 q*q
+constexpr uint32_t ksq = tt::CBIndex::c_8;    // [1,Kt] fp32 k*k
+constexpr uint32_t sc = tt::CBIndex::c_9;     // 2 tiles fp32 rowsum/inv-norm ping-pong
+constexpr uint32_t qn = tt::CBIndex::c_10;    // [1,Kt] fp32 normalized (scaled) q
+constexpr uint32_t kn = tt::CBIndex::c_11;    // [1,Kt] fp32 normalized k
+constexpr uint32_t kcol = tt::CBIndex::c_12;  // [Kt,1] fp32 transpose(kn)
+constexpr uint32_t gexp = tt::CBIndex::c_13;  // 1 tile fp32 exp(g_h)
+constexpr uint32_t sdec = tt::CBIndex::c_14;  // [Kt,Vt] fp32 decayed state h*exp(g)
+constexpr uint32_t vread = tt::CBIndex::c_15; // [1,Vt] fp32 k@h
+constexpr uint32_t delta = tt::CBIndex::c_16; // 2x[1,Vt] fp32 v-v_read, then *beta (ping-pong)
+constexpr uint32_t outer = tt::CBIndex::c_17; // [Kt,Vt] fp32 kcol @ delta
+constexpr uint32_t sout = tt::CBIndex::c_18;  // [Kt,Vt] io new state
+constexpr uint32_t out = tt::CBIndex::c_19;   // [1,Vt] io  o = q@h
+}  // namespace cb
+
+tt::tt_metal::ProgramDescriptor DecodeGatedDeltaRuleProgramFactory::create_descriptor(
+    const DecodeGatedDeltaRuleParams& attrs, const DecodeGatedDeltaRuleInputs& in, std::vector<Tensor>& outputs) {
+    const uint32_t BH = attrs.BH;
+    const uint32_t Kt = attrs.K / TILE_WIDTH;
+    const uint32_t Vt = attrs.V / TILE_WIDTH;
+    const uint32_t kv = Kt * Vt;
+    const uint32_t has_s0 = attrs.has_initial_state ? 1u : 0u;
+
+    // q/k/v/o (and state) carry the caller's dtype; all math scratch is fp32.
+    const tt::DataFormat df_io =
+        (in.q.dtype() == DataType::FLOAT32) ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
+
+    // python l2_norm_ttnn: rms_norm(x, eps/K) * K**-0.5 == x / sqrt(sumsq + eps)
+    constexpr float kEps = 1e-6f;
+    const uint32_t eps_bits = std::bit_cast<uint32_t>(kEps);
+    const uint32_t scale_bits = std::bit_cast<uint32_t>(attrs.scale);
+
+    auto* device = in.q.device();
+    const CoreCoord grid = device->compute_with_storage_grid_size();
+    const uint32_t grid_y = grid.y;
+    TT_FATAL(BH <= grid.x * grid.y, "num_heads {} exceeds compute cores {}", BH, grid.x * grid.y);
+
+    std::vector<CoreCoord> head_cores(BH);
+    std::set<CoreRange> core_set;
+    for (uint32_t h = 0; h < BH; h++) {
+        head_cores[h] = CoreCoord{h / grid_y, h % grid_y};
+        core_set.insert(CoreRange{head_cores[h], head_cores[h]});
+    }
+    CoreRangeSet cores{core_set};
+
+    ProgramDescriptor desc;
+    auto add_cb = [&](uint32_t idx, uint32_t n_tiles, uint32_t nbuf, tt::DataFormat fmt) {
+        const uint32_t ts = tt::tile_size(fmt);
+        desc.cbs.push_back(CBDescriptor{
+            .total_size = n_tiles * nbuf * ts,
+            .core_ranges = cores,
+            .format_descriptors = {
+                {CBFormatDescriptor{.buffer_index = static_cast<uint8_t>(idx), .data_format = fmt, .page_size = ts}}}});
+    };
+
+    add_cb(cb::q, Kt, 1, df_io);
+    add_cb(cb::k, Kt, 1, df_io);
+    add_cb(cb::v, Vt, 1, df_io);
+    add_cb(cb::g, 1, 1, df_io);
+    add_cb(cb::beta, 1, 1, df_io);
+    add_cb(cb::state, kv, 1, df_io);
+    add_cb(cb::ones, 1, 1, tt::DataFormat::Float32);
+    add_cb(cb::qsq, Kt, 1, tt::DataFormat::Float32);
+    add_cb(cb::ksq, Kt, 1, tt::DataFormat::Float32);
+    add_cb(cb::sc, 1, 2, tt::DataFormat::Float32);   // 2 pages: in-place inv-norm
+    add_cb(cb::qn, Kt, 1, tt::DataFormat::Float32);
+    add_cb(cb::kn, Kt, 1, tt::DataFormat::Float32);
+    add_cb(cb::kcol, Kt, 1, tt::DataFormat::Float32);
+    add_cb(cb::gexp, 1, 1, tt::DataFormat::Float32);
+    add_cb(cb::sdec, kv, 1, tt::DataFormat::Float32);
+    add_cb(cb::vread, Vt, 1, tt::DataFormat::Float32);
+    add_cb(cb::delta, Vt, 2, tt::DataFormat::Float32);  // 2x pages: in-place *beta
+    add_cb(cb::outer, kv, 1, tt::DataFormat::Float32);
+    add_cb(cb::sout, kv, 1, df_io);
+    add_cb(cb::out, Vt, 2, df_io);
+
+    const std::string kdir = "ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/kernels/";
+    const std::vector<uint32_t> ct_args = {Kt, Vt, has_s0, eps_bits, scale_bits};
+
+    // Reader compile args: {Kt,Vt,has_s0,eps,scale} + TensorAccessorArgs per input (in order).
+    std::vector<uint32_t> reader_ct = ct_args;
+    TensorAccessorArgs(*in.q.buffer()).append_to(reader_ct);
+    TensorAccessorArgs(*in.k.buffer()).append_to(reader_ct);
+    TensorAccessorArgs(*in.v.buffer()).append_to(reader_ct);
+    TensorAccessorArgs(*in.beta.buffer()).append_to(reader_ct);
+    TensorAccessorArgs(*in.g.buffer()).append_to(reader_ct);
+    TensorAccessorArgs(in.initial_state.has_value() ? in.initial_state->buffer() : nullptr).append_to(reader_ct);
+
+    std::vector<uint32_t> writer_ct = {Kt, Vt};
+    TensorAccessorArgs(*outputs[0].buffer()).append_to(writer_ct);  // o
+    TensorAccessorArgs(*outputs[1].buffer()).append_to(writer_ct);  // new state
+
+    KernelDescriptor reader;
+    reader.kernel_source = kdir + "dataflow/reader_decode_gated_delta_rule.cpp";
+    reader.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader.core_ranges = cores;
+    reader.compile_time_args = reader_ct;
+    reader.config = ReaderConfigDescriptor{};
+    reader.runtime_args.reserve(BH);
+
+    KernelDescriptor writer;
+    writer.kernel_source = kdir + "dataflow/writer_decode_gated_delta_rule.cpp";
+    writer.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer.core_ranges = cores;
+    writer.compile_time_args = writer_ct;
+    writer.config = WriterConfigDescriptor{};
+    writer.runtime_args.reserve(BH);
+
+    KernelDescriptor compute;
+    compute.kernel_source = kdir + "compute/decode_gated_delta_rule.cpp";
+    compute.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    compute.core_ranges = cores;
+    compute.compile_time_args = ct_args;
+    compute.config = ComputeConfigDescriptor{
+        .math_fidelity = MathFidelity::HiFi4, .fp32_dest_acc_en = true, .math_approx_mode = false};
+    compute.runtime_args.reserve(BH);
+
+    auto* q_buf = in.q.buffer();
+    auto* k_buf = in.k.buffer();
+    auto* v_buf = in.v.buffer();
+    auto* beta_buf = in.beta.buffer();
+    auto* g_buf = in.g.buffer();
+    auto* s0_buf = in.initial_state.has_value() ? in.initial_state->buffer() : nullptr;
+    auto* o_buf = outputs[0].buffer();
+    auto* s1_buf = outputs[1].buffer();
+
+    for (uint32_t h = 0; h < BH; h++) {
+        const auto& core = head_cores[h];
+        reader.emplace_runtime_args(core, {h, q_buf, k_buf, v_buf, beta_buf, g_buf, s0_buf});
+        writer.emplace_runtime_args(core, {h, o_buf, s1_buf});
+        compute.emplace_runtime_args(core, {h});
+    }
+
+    desc.kernels.push_back(std::move(reader));
+    desc.kernels.push_back(std::move(writer));
+    desc.kernels.push_back(std::move(compute));
+    return desc;
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/decode_gated_delta_rule_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/decode_gated_delta_rule_program_factory.hpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <vector>
+
+#include <tt-metalium/program_descriptors.hpp>
+
+#include "decode_gated_delta_rule_device_operation_types.hpp"
+#include "ttnn/tensor/tensor.hpp"
+
+namespace ttnn::prim {
+
+struct DecodeGatedDeltaRuleProgramFactory {
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const DecodeGatedDeltaRuleParams& attrs,
+        const DecodeGatedDeltaRuleInputs& in,
+        std::vector<Tensor>& outputs);
+};
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/kernels/compute/decode_gated_delta_rule.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/kernels/compute/decode_gated_delta_rule.cpp
@@ -254,7 +254,14 @@ void kernel_main() {
 
     constexpr uint32_t kv = Kt * Vt;
 
+    // Runtime arg: instance count for this core (BH = B*H can exceed the grid;
+    // each core loops over its contiguous instance chunk — the math below is
+    // per-instance, CB-mediated against the reader/writer per instance).
+    const uint32_t n_inst = get_arg_val<uint32_t>(0);
+
     compute_kernel_hw_startup(cb_q, cb_k, cb_out);
+
+    for (uint32_t it = 0; it < n_inst; ++it) {
 
     WAIT(cb_q, Kt);
     WAIT(cb_k, Kt);
@@ -358,4 +365,5 @@ void kernel_main() {
     // ---- new state -> io for the writer ----
     copy_tiles(cb_snew, cb_sout, kv);
     POP(cb_snew, kv);
+    }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/kernels/compute/decode_gated_delta_rule.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/kernels/compute/decode_gated_delta_rule.cpp
@@ -37,10 +37,17 @@ namespace {
 
 constexpr uint32_t cb_q = 0, cb_k = 1, cb_v = 2, cb_g = 3, cb_beta = 4;
 constexpr uint32_t cb_state = 5, cb_ones = 6;
-constexpr uint32_t cb_qsq = 7, cb_ksq = 8, cb_sc = 9;
+constexpr uint32_t cb_qsq = 7, cb_ksq = 8;
+constexpr uint32_t cb_sc = 9;     // 1 tile fp32 rowsum of squares
+constexpr uint32_t cb_sc2 = 28;   // 1 tile fp32 q-chain inv-rms factor (dedicated)
+constexpr uint32_t cb_sc3 = 29;   // 1 tile fp32 k-chain inv-rms factor (dedicated)
 constexpr uint32_t cb_qn = 10, cb_kn = 11, cb_kcol = 12, cb_gexp = 13;
 constexpr uint32_t cb_sdec = 14, cb_vread = 15, cb_delta = 16;
 constexpr uint32_t cb_outer = 17, cb_sout = 18, cb_out = 19;
+// fp32 mirrors of the io-dtype inputs (every math operand must be fp32:
+// mixed bf16-srcA x fp32-srcB pairs corrupt the fp32 side) + fp32 new state.
+constexpr uint32_t cb_qf = 20, cb_kf = 21, cb_vf = 22, cb_gf = 23;
+constexpr uint32_t cb_betaf = 24, cb_sf = 25, cb_snew = 26;
 
 inline void WAIT(uint32_t cb, uint32_t n) { CircularBuffer(cb).wait_front(n); }
 inline void POP(uint32_t cb, uint32_t n) { CircularBuffer(cb).pop_front(n); }
@@ -49,7 +56,8 @@ inline void POP(uint32_t cb, uint32_t n) { CircularBuffer(cb).pop_front(n); }
 void mm(uint32_t a, uint32_t b, uint32_t o, uint32_t Mt, uint32_t Kt, uint32_t Nt, bool tr) {
     cb_reserve_back(o, Mt * Nt);
     pack_reconfig_data_format(o);
-    reconfig_data_format(b, a);  // matmul_tiles(a,b): in0=a->srcB, in1=b->srcA
+    // matmul_tiles(a,b): in0=a->srcA, in1=b->srcB (reconfig src formats to match).
+    reconfig_data_format(a, b);
     matmul_init(a, b, tr ? 1 : 0);
     for (uint32_t mi = 0; mi < Mt; mi++) {
         for (uint32_t ni = 0; ni < Nt; ni++) {
@@ -157,7 +165,7 @@ void bcast_cols_mul(uint32_t a, uint32_t col, uint32_t o, uint32_t Mt, uint32_t 
 void rowsum_k(uint32_t in, uint32_t o, uint32_t Kt) {
     cb_reserve_back(o, 1);
     pack_reconfig_data_format(o);
-    reconfig_data_format(cb_ones, in);  // matmul(in, ones): in->srcB, ones->srcA
+    reconfig_data_format(in, cb_ones);  // matmul(in, ones): in->srcA, ones->srcB
     matmul_init(in, cb_ones, 0);
     tile_regs_acquire();
     for (uint32_t ki = 0; ki < Kt; ki++) {
@@ -173,8 +181,9 @@ void rowsum_k(uint32_t in, uint32_t o, uint32_t Kt) {
 // inv_rms: o = rsqrt(in + eps) [* scale]. in holds per-row sums of squares
 // (rowsum_k output); every column of a row carries the same factor, so the
 // result feeds bcast_cols_mul directly. eps/scale arrive as fp32-bit-cast
-// uint32 compile args. Same CB for in/out: requires 2 pages (reserved by the
-// program factory).
+// uint32 compile args. in (cb_sc) and o (cb_sc2) must be DISTINCT CBs: with
+// in==out on the 2-page ring, the second norm chain's bcast consumed the
+// first chain's factor (ttsim: gdn_decode_simdiag3.py swap experiment).
 void inv_rms(uint32_t in, uint32_t o, uint32_t eps_bits, uint32_t scale_bits, bool do_scale) {
     cb_reserve_back(o, 1);
     pack_reconfig_data_format(o);
@@ -195,6 +204,24 @@ void inv_rms(uint32_t in, uint32_t o, uint32_t eps_bits, uint32_t scale_bits, bo
     pack_tile(0, o, 0);
     tile_regs_release();
     cb_push_back(o, 1);
+}
+
+// o = copy of the n tiles of `in` (format conversion happens on the copy:
+// unpack converts io->fp32 dest, packer converts fp32 dest->io).
+void copy_tiles(uint32_t in, uint32_t o, uint32_t n) {
+    cb_reserve_back(o, n);
+    pack_reconfig_data_format(o);
+    reconfig_data_format_srca(in);
+    copy_tile_to_dst_init_short(in);
+    for (uint32_t i = 0; i < n; i++) {
+        tile_regs_acquire();
+        copy_tile(in, i, 0);
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, o, i);
+        tile_regs_release();
+    }
+    cb_push_back(o, n);
 }
 
 // o[Kt,1] = transpose(in[1,Kt]): tile ki of o is the transposed tile ki of in
@@ -237,50 +264,78 @@ void kernel_main() {
     WAIT(cb_state, kv);
     WAIT(cb_ones, 1);
 
+    // ---- io -> fp32: every later operand is fp32 (mixed bf16 x fp32 srcA/srcB
+    // pairs lose the fp32 side; all scratch math must be uniform fp32). ----
+    copy_tiles(cb_q, cb_qf, Kt);
+    copy_tiles(cb_k, cb_kf, Kt);
+    copy_tiles(cb_v, cb_vf, Vt);
+    copy_tiles(cb_g, cb_gf, 1);
+    copy_tiles(cb_beta, cb_betaf, 1);
+    copy_tiles(cb_state, cb_sf, kv);
+    POP(cb_q, Kt);
+    POP(cb_k, Kt);
+    POP(cb_v, Vt);
+    POP(cb_g, 1);
+    POP(cb_beta, 1);
+    POP(cb_state, kv);
+
+    // Read-back barrier discipline (the canonical layernorm pattern: every CB
+    // page this kernel packed is wait_front'ed before this kernel reads it —
+    // without the wait the unpacker can run ahead of the packer and read the
+    // page's PREVIOUS contents; ttsim showed stale/zero norm factors).
+    WAIT(cb_qf, Kt);
+    WAIT(cb_kf, Kt);
+    WAIT(cb_vf, Vt);
+    WAIT(cb_gf, 1);
+    WAIT(cb_betaf, 1);
+    WAIT(cb_sf, kv);
+
     // ---- L2 norm q (scale folded): qn = q * scale / sqrt(||q||^2 + eps) ----
-    ew(cb_q, cb_q, cb_qsq, Kt, 2);  // q^2
+    ew(cb_qf, cb_qf, cb_qsq, Kt, 2);  // q^2
     WAIT(cb_qsq, Kt);
     rowsum_k(cb_qsq, cb_sc, Kt);  // [0,*] = ||q||^2
     WAIT(cb_sc, 1);
     POP(cb_qsq, Kt);
-    inv_rms(cb_sc, cb_sc, EPS_BITS, SCALE_BITS, true);
-    POP(cb_sc, 1);  // drop the sumsq page; front is now the inv-norm page
-    bcast_cols_mul(cb_q, cb_sc, cb_qn, 1, Kt);
+    inv_rms(cb_sc, cb_sc2, EPS_BITS, SCALE_BITS, true);
+    POP(cb_sc, 1);  // drop the sumsq page
+    WAIT(cb_sc2, 1);  // packer drain before the read-back
+    bcast_cols_mul(cb_qf, cb_sc2, cb_qn, 1, Kt);
     WAIT(cb_qn, Kt);
-    POP(cb_q, Kt);
-    POP(cb_sc, 1);
+    POP(cb_qf, Kt);
+    POP(cb_sc2, 1);
 
     // ---- L2 norm k (no scale) ----
-    ew(cb_k, cb_k, cb_ksq, Kt, 2);
+    ew(cb_kf, cb_kf, cb_ksq, Kt, 2);
     WAIT(cb_ksq, Kt);
     rowsum_k(cb_ksq, cb_sc, Kt);
     WAIT(cb_sc, 1);
     POP(cb_ksq, Kt);
-    inv_rms(cb_sc, cb_sc, EPS_BITS, SCALE_BITS, false);
+    inv_rms(cb_sc, cb_sc3, EPS_BITS, SCALE_BITS, false);
     POP(cb_sc, 1);
-    bcast_cols_mul(cb_k, cb_sc, cb_kn, 1, Kt);
+    WAIT(cb_sc3, 1);  // packer drain before the read-back
+    bcast_cols_mul(cb_kf, cb_sc3, cb_kn, 1, Kt);
     WAIT(cb_kn, Kt);
-    POP(cb_k, Kt);
-    POP(cb_sc, 1);
+    POP(cb_kf, Kt);
+    POP(cb_sc3, 1);
 
     // ---- decay: h = state * exp(g) ----
-    expc(cb_g, cb_gexp, 1);  // [0,0] = exp(g_h)
+    expc(cb_gf, cb_gexp, 1);  // [0,0] = exp(g_h)
     WAIT(cb_gexp, 1);
-    POP(cb_g, 1);
-    bcast_scalar_mul(cb_state, cb_gexp, cb_sdec, kv);
+    POP(cb_gf, 1);
+    bcast_scalar_mul(cb_sf, cb_gexp, cb_sdec, kv);
     WAIT(cb_sdec, kv);
-    POP(cb_state, kv);
+    POP(cb_sf, kv);
     POP(cb_gexp, 1);
 
     // ---- v_read = kn @ h; delta = v - v_read; delta *= beta ----
     mm(cb_kn, cb_sdec, cb_vread, 1, Kt, Vt, false);
     WAIT(cb_vread, Vt);
-    ew(cb_v, cb_vread, cb_delta, Vt, 1);  // delta = v - v_read
+    ew(cb_vf, cb_vread, cb_delta, Vt, 1);  // delta = v - v_read
     WAIT(cb_delta, Vt);
-    POP(cb_v, Vt);
+    POP(cb_vf, Vt);
     POP(cb_vread, Vt);
-    bcast_scalar_mul(cb_delta, cb_beta, cb_delta, Vt);  // in-place (2-page CB)
-    POP(cb_beta, 1);
+    bcast_scalar_mul(cb_delta, cb_betaf, cb_delta, Vt);  // in-place (2-page CB)
+    POP(cb_betaf, 1);
     POP(cb_delta, Vt);  // drop the pre-beta page
 
     // ---- rank-1 write: new_h = h + (kn)^T @ (beta*delta) ----
@@ -291,12 +346,16 @@ void kernel_main() {
     WAIT(cb_outer, kv);
     POP(cb_delta, Vt);
     POP(cb_kcol, Kt);
-    ew(cb_sdec, cb_outer, cb_sout, kv, 0);  // new state (io dtype)
-    WAIT(cb_sout, kv);
+    ew(cb_sdec, cb_outer, cb_snew, kv, 0);  // fp32 new state
+    WAIT(cb_snew, kv);
     POP(cb_sdec, kv);
     POP(cb_outer, kv);
 
-    // ---- o = qn @ new_h ----
-    mm(cb_qn, cb_sout, cb_out, 1, Kt, Vt, false);
+    // ---- o = qn @ new_h (fp32 x fp32; packed straight to io) ----
+    mm(cb_qn, cb_snew, cb_out, 1, Kt, Vt, false);
     POP(cb_qn, Kt);
+
+    // ---- new state -> io for the writer ----
+    copy_tiles(cb_snew, cb_sout, kv);
+    POP(cb_snew, kv);
 }

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/kernels/compute/decode_gated_delta_rule.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/kernels/compute/decode_gated_delta_rule.cpp
@@ -1,0 +1,302 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Compute kernel: the whole T=1 gated delta rule recurrent step for one head,
+// fp32 accumulation throughout. Mirrors the python graph
+// `recurrent_gated_delta_rule_decode_ttnn` (bf16/fp32 IO tiles, math in fp32):
+//
+//   qn = l2norm(q) * scale        (scale == K**-0.5; folded into the norm)
+//   kn = l2norm(k)
+//   h  = state * exp(g)           (per-head scalar g broadcast)
+//   v_read = kn @ h               ([1,K]@[K,V] -> [1,V])
+//   delta  = v - v_read           ([1,V])
+//   outer  = (kn)^T @ (beta*delta)  ([K,1]@[1,V] rank-1)
+//   new_h  = h + outer
+//   o      = qn @ new_h           ([1,K]@[K,V] -> [1,V])
+//
+// All inputs arrive as row-0 tiles (reader gather). Padding rows are exact
+// zeros, so the rank-1 outer product and row-broadcast norms are exact.
+//
+// Compile args: {Kt, Vt, has_s0, EPS_BITS, SCALE_BITS} (eps/scale fp32 bits).
+
+#include <cstdint>
+#include "api/compute/common.h"
+#include "api/compute/matmul.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/eltwise_unary/exp.h"
+#include "api/compute/eltwise_unary/rsqrt.h"
+#include "api/compute/eltwise_unary/binop_with_scalar.h"
+#include "api/compute/bcast.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/transpose.h"
+#include "api/compute/reconfig_data_format.h"
+#include "api/dataflow/circular_buffer.h"
+
+namespace {
+
+constexpr uint32_t cb_q = 0, cb_k = 1, cb_v = 2, cb_g = 3, cb_beta = 4;
+constexpr uint32_t cb_state = 5, cb_ones = 6;
+constexpr uint32_t cb_qsq = 7, cb_ksq = 8, cb_sc = 9;
+constexpr uint32_t cb_qn = 10, cb_kn = 11, cb_kcol = 12, cb_gexp = 13;
+constexpr uint32_t cb_sdec = 14, cb_vread = 15, cb_delta = 16;
+constexpr uint32_t cb_outer = 17, cb_sout = 18, cb_out = 19;
+
+inline void WAIT(uint32_t cb, uint32_t n) { CircularBuffer(cb).wait_front(n); }
+inline void POP(uint32_t cb, uint32_t n) { CircularBuffer(cb).pop_front(n); }
+
+// out[Mt,Nt] = A[Mt,Kt] @ (tr ? B[Nt,Kt]^T : B[Kt,Nt]). Inputs must be available.
+void mm(uint32_t a, uint32_t b, uint32_t o, uint32_t Mt, uint32_t Kt, uint32_t Nt, bool tr) {
+    cb_reserve_back(o, Mt * Nt);
+    pack_reconfig_data_format(o);
+    reconfig_data_format(b, a);  // matmul_tiles(a,b): in0=a->srcB, in1=b->srcA
+    matmul_init(a, b, tr ? 1 : 0);
+    for (uint32_t mi = 0; mi < Mt; mi++) {
+        for (uint32_t ni = 0; ni < Nt; ni++) {
+            tile_regs_acquire();
+            for (uint32_t ki = 0; ki < Kt; ki++) {
+                uint32_t bi = tr ? (ni * Kt + ki) : (ki * Nt + ni);
+                matmul_tiles(a, b, mi * Kt + ki, bi, 0);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(0, o, mi * Nt + ni);
+            tile_regs_release();
+        }
+    }
+    cb_push_back(o, Mt * Nt);
+}
+
+// out = A (op) B elementwise, n tiles. op: 0 add, 1 sub, 2 mul.
+void ew(uint32_t a, uint32_t b, uint32_t o, uint32_t n, int op) {
+    cb_reserve_back(o, n);
+    pack_reconfig_data_format(o);
+    reconfig_data_format(a, b);  // binary(a,b): a->srcA, b->srcB
+    if (op == 0) {
+        add_init(a, b);
+    } else if (op == 1) {
+        sub_init(a, b);
+    } else {
+        mul_init(a, b);
+    }
+    for (uint32_t i = 0; i < n; i++) {
+        tile_regs_acquire();
+        if (op == 0) {
+            add_tiles(a, b, i, i, 0);
+        } else if (op == 1) {
+            sub_tiles(a, b, i, i, 0);
+        } else {
+            mul_tiles(a, b, i, i, 0);
+        }
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, o, i);
+        tile_regs_release();
+    }
+    cb_push_back(o, n);
+}
+
+// out = exp(in), n tiles (copy to fp32 DST, SFPU exp).
+void expc(uint32_t in, uint32_t o, uint32_t n) {
+    cb_reserve_back(o, n);
+    pack_reconfig_data_format(o);
+    reconfig_data_format_srca(in);
+    copy_tile_to_dst_init_short(in);
+    exp_tile_init();
+    for (uint32_t i = 0; i < n; i++) {
+        tile_regs_acquire();
+        copy_tile(in, i, 0);
+        exp_tile(0);
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, o, i);
+        tile_regs_release();
+    }
+    cb_push_back(o, n);
+}
+
+// out = S * scalar[0,0], n tiles.
+void bcast_scalar_mul(uint32_t a, uint32_t scal, uint32_t o, uint32_t n) {
+    cb_reserve_back(o, n);
+    pack_reconfig_data_format(o);
+    reconfig_data_format(a, scal);  // bcast(a,scal): a->srcA, scal->srcB
+    mul_bcast_scalar_init(a, scal);
+    for (uint32_t i = 0; i < n; i++) {
+        tile_regs_acquire();
+        mul_tiles_bcast_scalar(a, scal, i, 0, 0);
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, o, i);
+        tile_regs_release();
+    }
+    cb_push_back(o, n);
+}
+
+// out[Mt,Nt] = A[Mt,Nt] * col[Mt,1] (broadcast col's single column across N).
+void bcast_cols_mul(uint32_t a, uint32_t col, uint32_t o, uint32_t Mt, uint32_t Nt) {
+    cb_reserve_back(o, Mt * Nt);
+    pack_reconfig_data_format(o);
+    reconfig_data_format(a, col);  // bcast(a,col): a->srcA, col->srcB
+    mul_bcast_cols_init(a, col);
+    for (uint32_t mi = 0; mi < Mt; mi++) {
+        for (uint32_t ni = 0; ni < Nt; ni++) {
+            tile_regs_acquire();
+            mul_tiles_bcast_cols(a, col, mi * Nt + ni, mi, 0);
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_tile(0, o, mi * Nt + ni);
+            tile_regs_release();
+        }
+    }
+    cb_push_back(o, Mt * Nt);
+}
+
+// rowsum_k: o[1 tile] = in[1,Kt] @ ones — every element [r,c] of the output
+// holds the row-r sum (row 0 = this head's sum of squares of `in`). Reuses the
+// reader-built fp32 ones tile as the contraction operand.
+void rowsum_k(uint32_t in, uint32_t o, uint32_t Kt) {
+    cb_reserve_back(o, 1);
+    pack_reconfig_data_format(o);
+    reconfig_data_format(cb_ones, in);  // matmul(in, ones): in->srcB, ones->srcA
+    matmul_init(in, cb_ones, 0);
+    tile_regs_acquire();
+    for (uint32_t ki = 0; ki < Kt; ki++) {
+        matmul_tiles(in, cb_ones, ki, 0, 0);
+    }
+    tile_regs_commit();
+    tile_regs_wait();
+    pack_tile(0, o, 0);
+    tile_regs_release();
+    cb_push_back(o, 1);
+}
+
+// inv_rms: o = rsqrt(in + eps) [* scale]. in holds per-row sums of squares
+// (rowsum_k output); every column of a row carries the same factor, so the
+// result feeds bcast_cols_mul directly. eps/scale arrive as fp32-bit-cast
+// uint32 compile args. Same CB for in/out: requires 2 pages (reserved by the
+// program factory).
+void inv_rms(uint32_t in, uint32_t o, uint32_t eps_bits, uint32_t scale_bits, bool do_scale) {
+    cb_reserve_back(o, 1);
+    pack_reconfig_data_format(o);
+    reconfig_data_format_srca(in);
+    copy_tile_to_dst_init_short(in);
+    tile_regs_acquire();
+    copy_tile(in, 0, 0);
+    binop_with_scalar_tile_init();
+    add_unary_tile(0, eps_bits);  // + eps  (== python rms_norm(x, eps/K))
+    rsqrt_tile_init();
+    rsqrt_tile(0);  // 1/sqrt(sumsq + eps)
+    if (do_scale) {
+        binop_with_scalar_tile_init();
+        mul_unary_tile(0, scale_bits);  // * scale (q only; == python q*K**-0.5)
+    }
+    tile_regs_commit();
+    tile_regs_wait();
+    pack_tile(0, o, 0);
+    tile_regs_release();
+    cb_push_back(o, 1);
+}
+
+// o[Kt,1] = transpose(in[1,Kt]): tile ki of o is the transposed tile ki of in
+// (row 0 -> column 0), the column form needed for the rank-1 outer product.
+void transpose_row(uint32_t in, uint32_t o, uint32_t Kt) {
+    cb_reserve_back(o, Kt);
+    pack_reconfig_data_format(o);
+    reconfig_data_format_srca(in);
+    transpose_init(in);
+    for (uint32_t ki = 0; ki < Kt; ki++) {
+        tile_regs_acquire();
+        transpose_tile(in, ki, 0);
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, o, ki);
+        tile_regs_release();
+    }
+    cb_push_back(o, Kt);
+}
+
+}  // namespace
+
+void kernel_main() {
+    constexpr uint32_t Kt = get_compile_time_arg_val(0);
+    constexpr uint32_t Vt = get_compile_time_arg_val(1);
+    constexpr uint32_t has_s0 = get_compile_time_arg_val(2);
+    constexpr uint32_t EPS_BITS = get_compile_time_arg_val(3);
+    constexpr uint32_t SCALE_BITS = get_compile_time_arg_val(4);
+    (void)has_s0;
+
+    constexpr uint32_t kv = Kt * Vt;
+
+    compute_kernel_hw_startup(cb_q, cb_k, cb_out);
+
+    WAIT(cb_q, Kt);
+    WAIT(cb_k, Kt);
+    WAIT(cb_v, Vt);
+    WAIT(cb_g, 1);
+    WAIT(cb_beta, 1);
+    WAIT(cb_state, kv);
+    WAIT(cb_ones, 1);
+
+    // ---- L2 norm q (scale folded): qn = q * scale / sqrt(||q||^2 + eps) ----
+    ew(cb_q, cb_q, cb_qsq, Kt, 2);  // q^2
+    WAIT(cb_qsq, Kt);
+    rowsum_k(cb_qsq, cb_sc, Kt);  // [0,*] = ||q||^2
+    WAIT(cb_sc, 1);
+    POP(cb_qsq, Kt);
+    inv_rms(cb_sc, cb_sc, EPS_BITS, SCALE_BITS, true);
+    POP(cb_sc, 1);  // drop the sumsq page; front is now the inv-norm page
+    bcast_cols_mul(cb_q, cb_sc, cb_qn, 1, Kt);
+    WAIT(cb_qn, Kt);
+    POP(cb_q, Kt);
+    POP(cb_sc, 1);
+
+    // ---- L2 norm k (no scale) ----
+    ew(cb_k, cb_k, cb_ksq, Kt, 2);
+    WAIT(cb_ksq, Kt);
+    rowsum_k(cb_ksq, cb_sc, Kt);
+    WAIT(cb_sc, 1);
+    POP(cb_ksq, Kt);
+    inv_rms(cb_sc, cb_sc, EPS_BITS, SCALE_BITS, false);
+    POP(cb_sc, 1);
+    bcast_cols_mul(cb_k, cb_sc, cb_kn, 1, Kt);
+    WAIT(cb_kn, Kt);
+    POP(cb_k, Kt);
+    POP(cb_sc, 1);
+
+    // ---- decay: h = state * exp(g) ----
+    expc(cb_g, cb_gexp, 1);  // [0,0] = exp(g_h)
+    WAIT(cb_gexp, 1);
+    POP(cb_g, 1);
+    bcast_scalar_mul(cb_state, cb_gexp, cb_sdec, kv);
+    WAIT(cb_sdec, kv);
+    POP(cb_state, kv);
+    POP(cb_gexp, 1);
+
+    // ---- v_read = kn @ h; delta = v - v_read; delta *= beta ----
+    mm(cb_kn, cb_sdec, cb_vread, 1, Kt, Vt, false);
+    WAIT(cb_vread, Vt);
+    ew(cb_v, cb_vread, cb_delta, Vt, 1);  // delta = v - v_read
+    WAIT(cb_delta, Vt);
+    POP(cb_v, Vt);
+    POP(cb_vread, Vt);
+    bcast_scalar_mul(cb_delta, cb_beta, cb_delta, Vt);  // in-place (2-page CB)
+    POP(cb_beta, 1);
+    POP(cb_delta, Vt);  // drop the pre-beta page
+
+    // ---- rank-1 write: new_h = h + (kn)^T @ (beta*delta) ----
+    transpose_row(cb_kn, cb_kcol, Kt);  // kn -> column form
+    WAIT(cb_kcol, Kt);
+    POP(cb_kn, Kt);
+    mm(cb_kcol, cb_delta, cb_outer, Kt, 1, Vt, false);  // [K,1]@[1,V]
+    WAIT(cb_outer, kv);
+    POP(cb_delta, Vt);
+    POP(cb_kcol, Kt);
+    ew(cb_sdec, cb_outer, cb_sout, kv, 0);  // new state (io dtype)
+    WAIT(cb_sout, kv);
+    POP(cb_sdec, kv);
+    POP(cb_outer, kv);
+
+    // ---- o = qn @ new_h ----
+    mm(cb_qn, cb_sout, cb_out, 1, Kt, Vt, false);
+    POP(cb_qn, Kt);
+}

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/kernels/dataflow/reader_decode_gated_delta_rule.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/kernels/dataflow/reader_decode_gated_delta_rule.cpp
@@ -25,7 +25,9 @@
 // all-ones tile is synthesized for the compute row-sum.
 //
 // Compile args: {Kt, Vt, has_s0, eps_bits, scale_bits, H} + accessor args per
-// input (q,k,v,beta,g,state). Runtime args: {bh, q,k,v,beta,g,state addrs}.
+// input (q,k,v,beta,g,state). Runtime args: {bh_start, n_inst, q,k,v,beta,g,
+// state addrs}: this core loops over its contiguous instance chunk
+// [bh_start, bh_start+n_inst) (BH = B*H can exceed the core count).
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
@@ -36,6 +38,17 @@
 // CB indices (must match program factory / compute).
 constexpr uint32_t cb_q = 0, cb_k = 1, cb_v = 2, cb_g = 3, cb_beta = 4;
 constexpr uint32_t cb_state = 5, cb_ones = 6, cb_scratch = 27;
+// Destination element offsets for row 0 of a private page (faces 0 and 1).
+constexpr uint32_t dst_e0 = 0;
+constexpr uint32_t dst_e1 = 256;
+
+// TILE physical layout: the last two dims of each outer slice pad to 32.
+// q/k/v [B,1,H,D]: head (b,h) lives at physical row b*padH + h (padH =
+// ceil32(H)), NOT at flat row b*H + h — equal only when B == 1 or H%32 == 0
+// (the original bug: batch>0 gathered per-batch padding zeros / the wrong
+// head's row). beta/g [B,1,H]: dims (1,H) pad per batch: (b,hcol) sits at
+// page b*ppb + hcol/32, ROW 0, col hcol%32 (ppb = padH/32 pages/batch).
+// state [B,H,K,V]: K,V are 32-multiples — flat contiguous, head bh at bh*kv.
 
 void kernel_main() {
     constexpr uint32_t Kt = get_compile_time_arg_val(0);
@@ -50,13 +63,17 @@ void kernel_main() {
     constexpr auto g_a = TensorAccessorArgs<beta_a.next_compile_time_args_offset()>();
     constexpr auto s0_a = TensorAccessorArgs<g_a.next_compile_time_args_offset()>();
 
-    const uint32_t bh = get_arg_val<uint32_t>(0);
-    const uint32_t q_addr = get_arg_val<uint32_t>(1);
-    const uint32_t k_addr = get_arg_val<uint32_t>(2);
-    const uint32_t v_addr = get_arg_val<uint32_t>(3);
-    const uint32_t beta_addr = get_arg_val<uint32_t>(4);
-    const uint32_t g_addr = get_arg_val<uint32_t>(5);
-    const uint32_t s0_addr = get_arg_val<uint32_t>(6);
+    // Runtime args (factory order): {bh_start(0), n_inst(1), q(2), k(3), v(4),
+    // beta(5), g(6), state(7)}: this core loops over its contiguous instance
+    // chunk [bh_start, bh_start+n_inst) (BH = B*H can exceed the core count).
+    const uint32_t bh_start = get_arg_val<uint32_t>(0);
+    const uint32_t n_inst = get_arg_val<uint32_t>(1);
+    const uint32_t q_addr = get_arg_val<uint32_t>(2);
+    const uint32_t k_addr = get_arg_val<uint32_t>(3);
+    const uint32_t v_addr = get_arg_val<uint32_t>(4);
+    const uint32_t beta_addr = get_arg_val<uint32_t>(5);
+    const uint32_t g_addr = get_arg_val<uint32_t>(6);
+    const uint32_t s0_addr = get_arg_val<uint32_t>(7);
 
     const uint32_t tb_io = get_tile_size(cb_q);   // q/k/v/g/beta/state share one dtype
     const uint32_t elem = tb_io / 1024;           // bytes per element
@@ -68,19 +85,11 @@ void kernel_main() {
     const auto s0_acc = TensorAccessor(s0_a, s0_addr, tb_io);
 
     constexpr uint32_t kv = Kt * Vt;
+    // Per-batch padded head-row geometry (see the layout note above).
+    const uint32_t padH = ((H + 31) / 32) * 32;
+    const uint32_t ppb = padH / 32;  // beta/g pages per batch
 
     Noc noc;
-
-    // This head's row inside the shared 32-row tile pages, in face coords.
-    const uint32_t r = bh % 32;
-    const uint32_t frow = r % 16;   // row within a face
-    const uint32_t fhalf = r / 16;  // 0: rows 0-15 (faces 0,1), 1: rows 16-31 (faces 2,3)
-    // Source element offsets (within a DRAM page) of cols 0-15 / 16-31 of row r:
-    const uint32_t src_e0 = (fhalf * 2 + 0) * 256 + frow * 16;
-    const uint32_t src_e1 = (fhalf * 2 + 1) * 256 + frow * 16;
-    // Destination element offsets for row 0 of the private page (faces 0 and 1):
-    constexpr uint32_t dst_e0 = 0;
-    constexpr uint32_t dst_e1 = 256;
 
     // Zero an L1 region of n words, then return. Pages are zeroed so padded
     // rows/cols are exact zeros (the rank-1 outer product multiplies through
@@ -96,14 +105,16 @@ void kernel_main() {
         asm volatile("" ::: "memory");
     };
 
-    // Core-side L1 copy of one 16-element face-row chunk (8 words). The source
-    // words were written by NOC DMA: volatile reads + a compiler barrier keep
-    // the loads after the DMA barrier (core_local_mem.h ordering note).
+    // Core-side L1 copy of one 16-element face-row chunk (16*elem/4 words:
+    // 8 at bf16, 16 at fp32 — a fixed word count silently dropped half the
+    // chunk at fp32). The source words were written by NOC DMA: volatile
+    // reads + a compiler barrier keep the loads after the DMA barrier
+    // (core_local_mem.h ordering note).
     auto copy_chunk = [&](uint32_t src_bytes, uint32_t dst_bytes) {
         asm volatile("" ::: "memory");
         auto s = CoreLocalMem<volatile uint32_t>(src_bytes);
         auto d = CoreLocalMem<volatile uint32_t>(dst_bytes);
-        for (uint32_t w = 0; w < 8; w++) {
+        for (uint32_t w = 0; w < 16 * elem / 4; w++) {
             d[w] = s[w];
         }
         asm volatile("" ::: "memory");
@@ -121,48 +132,58 @@ void kernel_main() {
         cb.push_back(n_tiles);
     };
 
-    // Gather head bh's single row (n_tiles tiles of D=32 each) out of the
-    // staged shared pages into row 0 of n_tiles private CB pages.
-    auto gather_row = [&](const auto& acc, uint32_t cb_id, uint32_t n_tiles) {
-        read_pages(acc, (bh / 32) * n_tiles, n_tiles);
-        CircularBuffer scb(cb_scratch);
-        scb.wait_front(n_tiles);
-        const uint32_t sbase = scb.get_read_ptr();
+    // Gather the row at PHYSICAL row `physrow` (each tile-row spans n_tiles
+    // pages of D=32 columns): DMA the shared tile pages DIRECTLY into the
+    // target CB (the proven full-page read shape — the scratch-staged variant
+    // deadlocked at fp32 with multiple instances per core), then extract row
+    // r into row 0 IN PLACE (row r and row 0 are distinct rows; r == 0 is a
+    // no-op) and zero every other row so the tile is row-0-only as the compute
+    // expects.
+    auto gather_row = [&](const auto& acc, uint32_t cb_id, uint32_t n_tiles, uint32_t physrow) {
+        const uint32_t first_page = (physrow / 32) * n_tiles;
+        const uint32_t r = physrow % 32;
+        const uint32_t frow = r % 16;   // row within a face
+        const uint32_t fhalf = r / 16;  // 0: rows 0-15 (faces 0,1), 1: rows 16-31 (faces 2,3)
+        const uint32_t src_e0 = (fhalf * 2 + 0) * 256 + frow * 16;
+        const uint32_t src_e1 = (fhalf * 2 + 1) * 256 + frow * 16;
         CircularBuffer cb(cb_id);
         cb.reserve_back(n_tiles);
         const uint32_t base = cb.get_write_ptr();
         for (uint32_t t = 0; t < n_tiles; t++) {
-            zero(base + t * tb_io, tb_io / 4);
+            noc.async_read(acc, cb, tb_io, {.page_id = first_page + t}, {.offset_bytes = t * tb_io});
         }
+        noc.async_read_barrier();
         for (uint32_t t = 0; t < n_tiles; t++) {
-            const uint32_t src = sbase + t * tb_io;
-            const uint32_t dst = base + t * tb_io;
-            copy_chunk(src + src_e0 * elem, dst + dst_e0 * elem);
-            copy_chunk(src + src_e1 * elem, dst + dst_e1 * elem);
+            const uint32_t p = base + t * tb_io;
+            if (r != 0) {
+                copy_chunk(p + src_e0 * elem, p);                  // row 0 cols 0-15
+                copy_chunk(p + src_e1 * elem, p + 256 * elem);     // row 0 cols 16-31
+            }
+            // zero everything except row 0's two 16-element face chunks
+            zero(p + 16 * elem, (256 - 16) * elem / 4);
+            zero(p + (256 + 16) * elem, (1024 - 272) * elem / 4);
         }
-        scb.pop_front(n_tiles);
         cb.push_back(n_tiles);
     };
 
-    // Gather the single [B,1,H] head-scalar of head bh=(b,h): the [B,H] flat
-    // 2D puts it at (row b, col h) — page b/32, row b%32, col h. Copy the one
-    // element (word load, 16-bit select for bf16) into [0,0] of a zeroed tile.
-    auto gather_scalar = [&](const auto& acc, uint32_t cb_id) {
+    // Gather the single [B,1,H] head-scalar of head bh=(b,h): (b,hcol) sits
+    // at page b*ppb + hcol/32, ROW 0, col hcol%32 of the per-batch padded
+    // tiles (layout note above). DMA the full tile page DIRECTLY into the
+    // target CB page (the proven full-page read shape; no scratch staging),
+    // then select the one element (word load, 16-bit select for bf16) into
+    // [0,0] of the same zeroed page.
+    auto gather_scalar = [&](const auto& acc, uint32_t cb_id, uint32_t bh) {
         const uint32_t b = bh / H;
         const uint32_t hcol = bh % H;
-        read_pages(acc, b / 32, 1);
-        CircularBuffer scb(cb_scratch);
-        scb.wait_front(1);
-        const uint32_t sbase = scb.get_read_ptr();
         CircularBuffer cb(cb_id);
         cb.reserve_back(1);
         const uint32_t base = cb.get_write_ptr();
         zero(base, tb_io / 4);
-        // element (row b%32, col hcol) offset within the tile page
-        const uint32_t rr = b % 32;
-        const uint32_t eoff =
-            ((rr / 16) * 2 + (hcol / 16)) * 256 + (rr % 16) * 16 + (hcol % 16);
-        const uint32_t byte = sbase + eoff * elem;
+        noc.async_read(acc, cb, tb_io, {.page_id = b * ppb + hcol / 32}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        const uint32_t cc = hcol % 32;
+        const uint32_t eoff = (cc / 16) * 256 + (cc % 16);
+        const uint32_t byte = base + eoff * elem;
         asm volatile("" ::: "memory");
         auto s = CoreLocalMem<volatile uint32_t>(byte & ~3u);
         auto d = CoreLocalMem<volatile uint32_t>(base);
@@ -172,7 +193,6 @@ void kernel_main() {
         }
         d[0] = w;  // [0,0] of the private tile = low half of word 0
         asm volatile("" ::: "memory");
-        scb.pop_front(1);
         cb.push_back(1);
     };
 
@@ -188,25 +208,32 @@ void kernel_main() {
         cb.push_back(1);
     }
 
-    gather_row(q_acc, cb_q, Kt);
-    gather_row(k_acc, cb_k, Kt);
-    gather_row(v_acc, cb_v, Vt);
-    gather_scalar(beta_acc, cb_beta);
-    gather_scalar(g_acc, cb_g);
+    // Per-instance loop: this core owns the contiguous chunk
+    // [bh_start, bh_start + n_inst) of head-instances.
+    for (uint32_t bh = bh_start; bh < bh_start + n_inst; ++bh) {
+        // Head (b,h)'s physical row in the [B,1,H,D] TILE tensors.
+        const uint32_t physrow = (bh / H) * padH + (bh % H);
 
-    // State [B,H,K,V] flat 2D is [B*H*K, V]: head bh owns full row-tiles
-    // (bh*Kt .. bh*Kt+Kt), so its kv pages are contiguous.
-    CircularBuffer cbs(cb_state);
-    cbs.reserve_back(kv);
-    if (has_s0) {
-        const uint32_t base_page = bh * kv;
-        for (uint32_t t = 0; t < kv; t++) {
-            noc.async_read(
-                s0_acc, cbs, tb_io, {.page_id = base_page + t}, {.offset_bytes = t * tb_io});
+        gather_row(q_acc, cb_q, Kt, physrow);
+        gather_row(k_acc, cb_k, Kt, physrow);
+        gather_row(v_acc, cb_v, Vt, physrow);
+        gather_scalar(beta_acc, cb_beta, bh);
+        gather_scalar(g_acc, cb_g, bh);
+
+        // State [B,H,K,V] flat 2D is [B*H*K, V] (K,V are 32-multiples: no
+        // per-batch padding): head bh owns full row-tiles (bh*Kt .. bh*Kt+Kt).
+        CircularBuffer cbs(cb_state);
+        cbs.reserve_back(kv);
+        if (has_s0) {
+            const uint32_t base_page = bh * kv;
+            for (uint32_t t = 0; t < kv; t++) {
+                noc.async_read(
+                    s0_acc, cbs, tb_io, {.page_id = base_page + t}, {.offset_bytes = t * tb_io});
+            }
+            noc.async_read_barrier();
+        } else {
+            zero(cbs.get_write_ptr(), kv * tb_io / 4);
         }
-        noc.async_read_barrier();
-    } else {
-        zero(cbs.get_write_ptr(), kv * tb_io / 4);
+        cbs.push_back(kv);
     }
-    cbs.push_back(kv);
 }

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/kernels/dataflow/reader_decode_gated_delta_rule.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/kernels/dataflow/reader_decode_gated_delta_rule.cpp
@@ -7,13 +7,24 @@
 // heads share each row of TILE pages. This core owns head bh; its row lives at
 // row (bh % 32) of the shared pages. TILE pages are four 16x16 faces in
 // row-major face order (face_idx = (r/16)*2 + (c/16), elem offset
-// face_idx*256 + (r%16)*16 + (c%16)). We zero each private CB page, then
-// gather the head's 32 values per tile as two 16-elem face-row chunks into
-// row 0 of the page. g/beta [B,1,H] pack one scalar per row: gather the single
-// element to [0,0]. The state [B,H,K,V] is head-aligned (K%32==0): full-tile
-// reads. A fp32 all-ones tile is synthesized for the compute row-sum.
+// face_idx*256 + (r%16)*16 + (c%16)).
 //
-// Compile args: {Kt, Vt, has_s0, eps_bits, scale_bits} + accessor args per
+// Dataflow rule (learned the hard way): noc reads must be FULL tile-size,
+// page-aligned accessor reads — sub-page reads (any size, either via accessor
+// offset_bytes or a raw tensor_accessor::Page address) silently fail and leave
+// the zero-filled CB pages untouched. So: full pages are DMA'd into a staging
+// CB, then the head's row is extracted with core-side L1 word copies into the
+// private row-0 CB pages. (Sub-page WRITES fail the same way — see the writer.)
+//
+// Scalar tensors beta/g are [B,1,H]: their flat 2D is [B,H], so head (b,h)'s
+// scalar lives at ROW b, COLUMN h of the shared page — NOT at (bh, 0). Reading
+// (bh,0) was the red-state bug: every head but (0,0) gathered zero padding
+// (beta=0, g=0 => state returned unchanged, pcc_h ~0.97).
+//
+// The state [B,H,K,V] is head-aligned (K%32==0): full-tile reads. A fp32
+// all-ones tile is synthesized for the compute row-sum.
+//
+// Compile args: {Kt, Vt, has_s0, eps_bits, scale_bits, H} + accessor args per
 // input (q,k,v,beta,g,state). Runtime args: {bh, q,k,v,beta,g,state addrs}.
 
 #include "api/dataflow/dataflow_api.h"
@@ -24,14 +35,15 @@
 
 // CB indices (must match program factory / compute).
 constexpr uint32_t cb_q = 0, cb_k = 1, cb_v = 2, cb_g = 3, cb_beta = 4;
-constexpr uint32_t cb_state = 5, cb_ones = 6;
+constexpr uint32_t cb_state = 5, cb_ones = 6, cb_scratch = 27;
 
 void kernel_main() {
     constexpr uint32_t Kt = get_compile_time_arg_val(0);
     constexpr uint32_t Vt = get_compile_time_arg_val(1);
     constexpr uint32_t has_s0 = get_compile_time_arg_val(2);
+    constexpr uint32_t H = get_compile_time_arg_val(5);  // heads (bh = b*H + h)
 
-    constexpr auto q_a = TensorAccessorArgs<5>();
+    constexpr auto q_a = TensorAccessorArgs<6>();
     constexpr auto k_a = TensorAccessorArgs<q_a.next_compile_time_args_offset()>();
     constexpr auto v_a = TensorAccessorArgs<k_a.next_compile_time_args_offset()>();
     constexpr auto beta_a = TensorAccessorArgs<v_a.next_compile_time_args_offset()>();
@@ -48,7 +60,6 @@ void kernel_main() {
 
     const uint32_t tb_io = get_tile_size(cb_q);   // q/k/v/g/beta/state share one dtype
     const uint32_t elem = tb_io / 1024;           // bytes per element
-    const uint32_t chunk = 16 * elem;             // one face row (16 elements)
     const auto q_acc = TensorAccessor(q_a, q_addr, tb_io);
     const auto k_acc = TensorAccessor(k_a, k_addr, tb_io);
     const auto v_acc = TensorAccessor(v_a, v_addr, tb_io);
@@ -74,56 +85,94 @@ void kernel_main() {
     // Zero an L1 region of n words, then return. Pages are zeroed so padded
     // rows/cols are exact zeros (the rank-1 outer product multiplies through
     // padding and must produce exact zeros, matching the python TILE graph).
+    // Volatile: these words are later overwritten by NOC DMA / read back after
+    // DMA — non-volatile accesses can be reordered by the compiler (see the
+    // note in core_local_mem.h).
     auto zero = [&](uint32_t base, uint32_t n_words) {
-        auto ptr = CoreLocalMem<uint32_t>(base);
+        auto ptr = CoreLocalMem<volatile uint32_t>(base);
         for (uint32_t w = 0; w < n_words; w++) {
             ptr[w] = 0u;
         }
+        asm volatile("" ::: "memory");
+    };
+
+    // Core-side L1 copy of one 16-element face-row chunk (8 words). The source
+    // words were written by NOC DMA: volatile reads + a compiler barrier keep
+    // the loads after the DMA barrier (core_local_mem.h ordering note).
+    auto copy_chunk = [&](uint32_t src_bytes, uint32_t dst_bytes) {
+        asm volatile("" ::: "memory");
+        auto s = CoreLocalMem<volatile uint32_t>(src_bytes);
+        auto d = CoreLocalMem<volatile uint32_t>(dst_bytes);
+        for (uint32_t w = 0; w < 8; w++) {
+            d[w] = s[w];
+        }
+        asm volatile("" ::: "memory");
+    };
+
+    // DMA n_tiles FULL pages (page-aligned, tile-size reads — the only proven
+    // read shape) into the staging CB; caller then extracts the head's row.
+    auto read_pages = [&](const auto& acc, uint32_t first_page, uint32_t n_tiles) {
+        CircularBuffer cb(cb_scratch);
+        cb.reserve_back(n_tiles);
+        for (uint32_t t = 0; t < n_tiles; t++) {
+            noc.async_read(acc, cb, tb_io, {.page_id = first_page + t}, {.offset_bytes = t * tb_io});
+        }
+        noc.async_read_barrier();
+        cb.push_back(n_tiles);
     };
 
     // Gather head bh's single row (n_tiles tiles of D=32 each) out of the
-    // shared [B*H, 32*n_tiles] pages into row 0 of n_tiles private CB pages.
+    // staged shared pages into row 0 of n_tiles private CB pages.
     auto gather_row = [&](const auto& acc, uint32_t cb_id, uint32_t n_tiles) {
+        read_pages(acc, (bh / 32) * n_tiles, n_tiles);
+        CircularBuffer scb(cb_scratch);
+        scb.wait_front(n_tiles);
+        const uint32_t sbase = scb.get_read_ptr();
         CircularBuffer cb(cb_id);
         cb.reserve_back(n_tiles);
         const uint32_t base = cb.get_write_ptr();
         for (uint32_t t = 0; t < n_tiles; t++) {
             zero(base + t * tb_io, tb_io / 4);
         }
-        const uint32_t row_group = (bh / 32) * n_tiles;  // first page of the shared row-group
         for (uint32_t t = 0; t < n_tiles; t++) {
-            const uint32_t page = row_group + t;
+            const uint32_t src = sbase + t * tb_io;
             const uint32_t dst = base + t * tb_io;
-            noc.async_read(
-                acc,
-                CoreLocalMem<uint32_t>(dst),
-                chunk,
-                {.page_id = page, .offset_bytes = src_e0 * elem},
-                {.offset_bytes = dst_e0 * elem});
-            noc.async_read(
-                acc,
-                CoreLocalMem<uint32_t>(dst),
-                chunk,
-                {.page_id = page, .offset_bytes = src_e1 * elem},
-                {.offset_bytes = dst_e1 * elem});
+            copy_chunk(src + src_e0 * elem, dst + dst_e0 * elem);
+            copy_chunk(src + src_e1 * elem, dst + dst_e1 * elem);
         }
-        noc.async_read_barrier();
+        scb.pop_front(n_tiles);
         cb.push_back(n_tiles);
     };
 
-    // Gather the single [B,1,H] head-scalar at (r, 0) to [0,0] of a zeroed tile.
+    // Gather the single [B,1,H] head-scalar of head bh=(b,h): the [B,H] flat
+    // 2D puts it at (row b, col h) — page b/32, row b%32, col h. Copy the one
+    // element (word load, 16-bit select for bf16) into [0,0] of a zeroed tile.
     auto gather_scalar = [&](const auto& acc, uint32_t cb_id) {
+        const uint32_t b = bh / H;
+        const uint32_t hcol = bh % H;
+        read_pages(acc, b / 32, 1);
+        CircularBuffer scb(cb_scratch);
+        scb.wait_front(1);
+        const uint32_t sbase = scb.get_read_ptr();
         CircularBuffer cb(cb_id);
         cb.reserve_back(1);
         const uint32_t base = cb.get_write_ptr();
         zero(base, tb_io / 4);
-        noc.async_read(
-            acc,
-            CoreLocalMem<uint32_t>(base),
-            elem,
-            {.page_id = bh / 32, .offset_bytes = src_e0 * elem},
-            {.offset_bytes = 0});
-        noc.async_read_barrier();
+        // element (row b%32, col hcol) offset within the tile page
+        const uint32_t rr = b % 32;
+        const uint32_t eoff =
+            ((rr / 16) * 2 + (hcol / 16)) * 256 + (rr % 16) * 16 + (hcol % 16);
+        const uint32_t byte = sbase + eoff * elem;
+        asm volatile("" ::: "memory");
+        auto s = CoreLocalMem<volatile uint32_t>(byte & ~3u);
+        auto d = CoreLocalMem<volatile uint32_t>(base);
+        uint32_t w = s[0];
+        if (elem == 2 && (byte & 2u)) {
+            w >>= 16;  // bf16 scalar sits in the high half of this word
+        }
+        d[0] = w;  // [0,0] of the private tile = low half of word 0
+        asm volatile("" ::: "memory");
+        scb.pop_front(1);
         cb.push_back(1);
     };
 

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/kernels/dataflow/reader_decode_gated_delta_rule.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/kernels/dataflow/reader_decode_gated_delta_rule.cpp
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Reader for the fused T=1 decode gated delta rule. Device 2.0 API.
+//
+// T=1 inputs [B,1,H,*] are TILE tensors whose flat 2D view is [B*H, D]: 32
+// heads share each row of TILE pages. This core owns head bh; its row lives at
+// row (bh % 32) of the shared pages. TILE pages are four 16x16 faces in
+// row-major face order (face_idx = (r/16)*2 + (c/16), elem offset
+// face_idx*256 + (r%16)*16 + (c%16)). We zero each private CB page, then
+// gather the head's 32 values per tile as two 16-elem face-row chunks into
+// row 0 of the page. g/beta [B,1,H] pack one scalar per row: gather the single
+// element to [0,0]. The state [B,H,K,V] is head-aligned (K%32==0): full-tile
+// reads. A fp32 all-ones tile is synthesized for the compute row-sum.
+//
+// Compile args: {Kt, Vt, has_s0, eps_bits, scale_bits} + accessor args per
+// input (q,k,v,beta,g,state). Runtime args: {bh, q,k,v,beta,g,state addrs}.
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+// CB indices (must match program factory / compute).
+constexpr uint32_t cb_q = 0, cb_k = 1, cb_v = 2, cb_g = 3, cb_beta = 4;
+constexpr uint32_t cb_state = 5, cb_ones = 6;
+
+void kernel_main() {
+    constexpr uint32_t Kt = get_compile_time_arg_val(0);
+    constexpr uint32_t Vt = get_compile_time_arg_val(1);
+    constexpr uint32_t has_s0 = get_compile_time_arg_val(2);
+
+    constexpr auto q_a = TensorAccessorArgs<5>();
+    constexpr auto k_a = TensorAccessorArgs<q_a.next_compile_time_args_offset()>();
+    constexpr auto v_a = TensorAccessorArgs<k_a.next_compile_time_args_offset()>();
+    constexpr auto beta_a = TensorAccessorArgs<v_a.next_compile_time_args_offset()>();
+    constexpr auto g_a = TensorAccessorArgs<beta_a.next_compile_time_args_offset()>();
+    constexpr auto s0_a = TensorAccessorArgs<g_a.next_compile_time_args_offset()>();
+
+    const uint32_t bh = get_arg_val<uint32_t>(0);
+    const uint32_t q_addr = get_arg_val<uint32_t>(1);
+    const uint32_t k_addr = get_arg_val<uint32_t>(2);
+    const uint32_t v_addr = get_arg_val<uint32_t>(3);
+    const uint32_t beta_addr = get_arg_val<uint32_t>(4);
+    const uint32_t g_addr = get_arg_val<uint32_t>(5);
+    const uint32_t s0_addr = get_arg_val<uint32_t>(6);
+
+    const uint32_t tb_io = get_tile_size(cb_q);   // q/k/v/g/beta/state share one dtype
+    const uint32_t elem = tb_io / 1024;           // bytes per element
+    const uint32_t chunk = 16 * elem;             // one face row (16 elements)
+    const auto q_acc = TensorAccessor(q_a, q_addr, tb_io);
+    const auto k_acc = TensorAccessor(k_a, k_addr, tb_io);
+    const auto v_acc = TensorAccessor(v_a, v_addr, tb_io);
+    const auto beta_acc = TensorAccessor(beta_a, beta_addr, tb_io);
+    const auto g_acc = TensorAccessor(g_a, g_addr, tb_io);
+    const auto s0_acc = TensorAccessor(s0_a, s0_addr, tb_io);
+
+    constexpr uint32_t kv = Kt * Vt;
+
+    Noc noc;
+
+    // This head's row inside the shared 32-row tile pages, in face coords.
+    const uint32_t r = bh % 32;
+    const uint32_t frow = r % 16;   // row within a face
+    const uint32_t fhalf = r / 16;  // 0: rows 0-15 (faces 0,1), 1: rows 16-31 (faces 2,3)
+    // Source element offsets (within a DRAM page) of cols 0-15 / 16-31 of row r:
+    const uint32_t src_e0 = (fhalf * 2 + 0) * 256 + frow * 16;
+    const uint32_t src_e1 = (fhalf * 2 + 1) * 256 + frow * 16;
+    // Destination element offsets for row 0 of the private page (faces 0 and 1):
+    constexpr uint32_t dst_e0 = 0;
+    constexpr uint32_t dst_e1 = 256;
+
+    // Zero an L1 region of n words, then return. Pages are zeroed so padded
+    // rows/cols are exact zeros (the rank-1 outer product multiplies through
+    // padding and must produce exact zeros, matching the python TILE graph).
+    auto zero = [&](uint32_t base, uint32_t n_words) {
+        auto ptr = CoreLocalMem<uint32_t>(base);
+        for (uint32_t w = 0; w < n_words; w++) {
+            ptr[w] = 0u;
+        }
+    };
+
+    // Gather head bh's single row (n_tiles tiles of D=32 each) out of the
+    // shared [B*H, 32*n_tiles] pages into row 0 of n_tiles private CB pages.
+    auto gather_row = [&](const auto& acc, uint32_t cb_id, uint32_t n_tiles) {
+        CircularBuffer cb(cb_id);
+        cb.reserve_back(n_tiles);
+        const uint32_t base = cb.get_write_ptr();
+        for (uint32_t t = 0; t < n_tiles; t++) {
+            zero(base + t * tb_io, tb_io / 4);
+        }
+        const uint32_t row_group = (bh / 32) * n_tiles;  // first page of the shared row-group
+        for (uint32_t t = 0; t < n_tiles; t++) {
+            const uint32_t page = row_group + t;
+            const uint32_t dst = base + t * tb_io;
+            noc.async_read(
+                acc,
+                CoreLocalMem<uint32_t>(dst),
+                chunk,
+                {.page_id = page, .offset_bytes = src_e0 * elem},
+                {.offset_bytes = dst_e0 * elem});
+            noc.async_read(
+                acc,
+                CoreLocalMem<uint32_t>(dst),
+                chunk,
+                {.page_id = page, .offset_bytes = src_e1 * elem},
+                {.offset_bytes = dst_e1 * elem});
+        }
+        noc.async_read_barrier();
+        cb.push_back(n_tiles);
+    };
+
+    // Gather the single [B,1,H] head-scalar at (r, 0) to [0,0] of a zeroed tile.
+    auto gather_scalar = [&](const auto& acc, uint32_t cb_id) {
+        CircularBuffer cb(cb_id);
+        cb.reserve_back(1);
+        const uint32_t base = cb.get_write_ptr();
+        zero(base, tb_io / 4);
+        noc.async_read(
+            acc,
+            CoreLocalMem<uint32_t>(base),
+            elem,
+            {.page_id = bh / 32, .offset_bytes = src_e0 * elem},
+            {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb.push_back(1);
+    };
+
+    // fp32 all-ones tile for the compute kernel's row-sum contraction.
+    {
+        CircularBuffer cb(cb_ones);
+        cb.reserve_back(1);
+        const uint32_t base = cb.get_write_ptr();
+        auto ptr = CoreLocalMem<uint32_t>(base);
+        for (uint32_t w = 0; w < 1024; w++) {
+            ptr[w] = 0x3F800000u;  // fp32 1.0
+        }
+        cb.push_back(1);
+    }
+
+    gather_row(q_acc, cb_q, Kt);
+    gather_row(k_acc, cb_k, Kt);
+    gather_row(v_acc, cb_v, Vt);
+    gather_scalar(beta_acc, cb_beta);
+    gather_scalar(g_acc, cb_g);
+
+    // State [B,H,K,V] flat 2D is [B*H*K, V]: head bh owns full row-tiles
+    // (bh*Kt .. bh*Kt+Kt), so its kv pages are contiguous.
+    CircularBuffer cbs(cb_state);
+    cbs.reserve_back(kv);
+    if (has_s0) {
+        const uint32_t base_page = bh * kv;
+        for (uint32_t t = 0; t < kv; t++) {
+            noc.async_read(
+                s0_acc, cbs, tb_io, {.page_id = base_page + t}, {.offset_bytes = t * tb_io});
+        }
+        noc.async_read_barrier();
+    } else {
+        zero(cbs.get_write_ptr(), kv * tb_io / 4);
+    }
+    cbs.push_back(kv);
+}

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/kernels/dataflow/writer_decode_gated_delta_rule.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/kernels/dataflow/writer_decode_gated_delta_rule.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Writer for the fused T=1 decode gated delta rule. Device 2.0 API.
+//
+// o is [B,1,H,V] TILE: flat [B*H, V] — head bh's output row lives at row
+// (bh % 32) of the shared o pages, so each output tile's row 0 is scattered
+// back as two 16-elem face-row chunks (inverse of the reader gather). The new
+// state [B,H,K,V] is head-aligned and written as full tiles.
+//
+// Compile args: {Kt, Vt} + accessor args for (o, new_state).
+// Runtime args: {bh, o addr, state addr}.
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+constexpr uint32_t cb_out = 19, cb_sout = 18;
+
+void kernel_main() {
+    constexpr uint32_t Kt = get_compile_time_arg_val(0);
+    constexpr uint32_t Vt = get_compile_time_arg_val(1);
+
+    constexpr auto o_a = TensorAccessorArgs<2>();
+    constexpr auto s_a = TensorAccessorArgs<o_a.next_compile_time_args_offset()>();
+
+    const uint32_t bh = get_arg_val<uint32_t>(0);
+    const uint32_t o_addr = get_arg_val<uint32_t>(1);
+    const uint32_t s_addr = get_arg_val<uint32_t>(2);
+
+    const uint32_t tb_io = get_tile_size(cb_out);
+    const uint32_t elem = tb_io / 1024;
+    const uint32_t chunk = 16 * elem;
+    const auto o_acc = TensorAccessor(o_a, o_addr, tb_io);
+    const auto s_acc = TensorAccessor(s_a, s_addr, tb_io);
+
+    constexpr uint32_t kv = Kt * Vt;
+
+    Noc noc;
+
+    const uint32_t r = bh % 32;
+    const uint32_t frow = r % 16;
+    const uint32_t fhalf = r / 16;
+    const uint32_t dst_e0 = (fhalf * 2 + 0) * 256 + frow * 16;
+    const uint32_t dst_e1 = (fhalf * 2 + 1) * 256 + frow * 16;
+
+    // o: scatter row 0 of each [1,Vt] tile into row r of the shared o pages.
+    {
+        CircularBuffer cb(cb_out);
+        cb.wait_front(Vt);
+        const uint32_t src = cb.get_read_ptr();
+        const uint32_t row_group = (bh / 32) * Vt;
+        for (uint32_t t = 0; t < Vt; t++) {
+            const uint32_t page = row_group + t;
+            const uint32_t s = src + t * tb_io;
+            noc.async_write(
+                CoreLocalMem<uint32_t>(s), o_acc, chunk, {.offset_bytes = 0}, {.page_id = page, .offset_bytes = dst_e0 * elem});
+            noc.async_write(
+                CoreLocalMem<uint32_t>(s),
+                o_acc,
+                chunk,
+                {.offset_bytes = 256 * elem},
+                {.page_id = page, .offset_bytes = dst_e1 * elem});
+        }
+        noc.async_write_barrier();
+        cb.pop_front(Vt);
+    }
+
+    // new state: full tiles, head-aligned contiguous pages.
+    {
+        CircularBuffer cb(cb_sout);
+        cb.wait_front(kv);
+        const uint32_t base_page = bh * kv;
+        auto src = use<CircularBuffer::AddrSelector::READ_PTR>(cb);
+        for (uint32_t t = 0; t < kv; t++) {
+            noc.async_write(src, s_acc, tb_io, {.offset_bytes = t * tb_io}, {.page_id = base_page + t});
+        }
+        noc.async_write_barrier();
+        cb.pop_front(kv);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/kernels/dataflow/writer_decode_gated_delta_rule.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/kernels/dataflow/writer_decode_gated_delta_rule.cpp
@@ -3,21 +3,27 @@
 //
 // Writer for the fused T=1 decode gated delta rule. Device 2.0 API.
 //
-// o is [B,1,H,V] TILE: flat [B*H, V] — head bh's output row lives at row
-// (bh % 32) of the shared o pages, so each output tile's row 0 is scattered
-// back as two 16-elem face-row chunks (inverse of the reader gather). The new
-// state [B,H,K,V] is head-aligned and written as full tiles.
+// o is [B,1,H,V] ROW_MAJOR: its flat 2D is [B*H, V], so page bh is head bh's
+// own [V] stick — each head owns its DRAM page EXCLUSIVELY and the write is a
+// single full-page accessor write (page_id form), the same proven write shape
+// the new-state path uses. The stick is staged in L1 from the [1,Vt] o tiles
+// (row 0 of each tile holds cols 32t..32t+31 as two 16-element face chunks),
+// then written with one full-page noc write.
+//
+// The new state [B,H,K,V] is TILE and head-aligned (K%32==0): full-tile pages,
+// also written exclusively per head.
 //
 // Compile args: {Kt, Vt} + accessor args for (o, new_state).
-// Runtime args: {bh, o addr, state addr}.
+// Runtime args: {bh, o addr, o page bytes, state addr}.
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "api/tensor/page.h"
 
-constexpr uint32_t cb_out = 19, cb_sout = 18;
+constexpr uint32_t cb_out = 19, cb_sout = 18, cb_scratch = 27;
 
 void kernel_main() {
     constexpr uint32_t Kt = get_compile_time_arg_val(0);
@@ -28,43 +34,63 @@ void kernel_main() {
 
     const uint32_t bh = get_arg_val<uint32_t>(0);
     const uint32_t o_addr = get_arg_val<uint32_t>(1);
-    const uint32_t s_addr = get_arg_val<uint32_t>(2);
+    const uint32_t o_page = get_arg_val<uint32_t>(2);  // RM stick page bytes
+    const uint32_t s_addr = get_arg_val<uint32_t>(3);
 
     const uint32_t tb_io = get_tile_size(cb_out);
     const uint32_t elem = tb_io / 1024;
-    const uint32_t chunk = 16 * elem;
-    const auto o_acc = TensorAccessor(o_a, o_addr, tb_io);
+    const auto o_acc = TensorAccessor(o_a, o_addr, o_page);
     const auto s_acc = TensorAccessor(s_a, s_addr, tb_io);
 
     constexpr uint32_t kv = Kt * Vt;
 
     Noc noc;
+    uint32_t stage = 0;  // staged o stick base (state write below is untouched)
 
-    const uint32_t r = bh % 32;
-    const uint32_t frow = r % 16;
-    const uint32_t fhalf = r / 16;
-    const uint32_t dst_e0 = (fhalf * 2 + 0) * 256 + frow * 16;
-    const uint32_t dst_e1 = (fhalf * 2 + 1) * 256 + frow * 16;
+    // Zero an L1 region of n words (page padding stays exact zeros).
+    // Volatile: these words are later read back after core-side copies.
+    auto zero = [&](uint32_t base, uint32_t n_words) {
+        auto ptr = CoreLocalMem<volatile uint32_t>(base);
+        for (uint32_t w = 0; w < n_words; w++) {
+            ptr[w] = 0u;
+        }
+        asm volatile("" ::: "memory");
+    };
 
-    // o: scatter row 0 of each [1,Vt] tile into row r of the shared o pages.
+    // Core-side L1 copy of n words (volatile both sides + compiler barriers).
+    auto copy_words = [&](uint32_t src_bytes, uint32_t dst_bytes, uint32_t n_words) {
+        asm volatile("" ::: "memory");
+        auto s = CoreLocalMem<volatile uint32_t>(src_bytes);
+        auto d = CoreLocalMem<volatile uint32_t>(dst_bytes);
+        for (uint32_t w = 0; w < n_words; w++) {
+            d[w] = s[w];
+        }
+        asm volatile("" ::: "memory");
+    };
+
+    // o: stage head bh's [V] stick in scratch, then ONE full-page write to
+    // o page bh via the o accessor's page_id form (the same write shape the
+    // new-state write below uses and that ttsim/silicon both land). Tile t's
+    // row 0 holds o cols 32t..32t+31: face 0 (cols 0-15) at element offset 0,
+    // face 1 (cols 16-31) at element offset 256.
     {
         CircularBuffer cb(cb_out);
         cb.wait_front(Vt);
         const uint32_t src = cb.get_read_ptr();
-        const uint32_t row_group = (bh / 32) * Vt;
+        CircularBuffer scb(cb_scratch);
+        scb.reserve_back(1);
+        const uint32_t stage_ = scb.get_write_ptr();
+        stage = stage_;
+        zero(stage, (o_page + 3) / 4);
+        const uint32_t cw = 16 * elem / 4;  // words per 16-element face chunk
         for (uint32_t t = 0; t < Vt; t++) {
-            const uint32_t page = row_group + t;
             const uint32_t s = src + t * tb_io;
-            noc.async_write(
-                CoreLocalMem<uint32_t>(s), o_acc, chunk, {.offset_bytes = 0}, {.page_id = page, .offset_bytes = dst_e0 * elem});
-            noc.async_write(
-                CoreLocalMem<uint32_t>(s),
-                o_acc,
-                chunk,
-                {.offset_bytes = 256 * elem},
-                {.page_id = page, .offset_bytes = dst_e1 * elem});
+            copy_words(s, stage + (32 * t) * elem, cw);
+            copy_words(s + 256 * elem, stage + (32 * t + 16) * elem, cw);
         }
+        noc.async_write(CoreLocalMem<uint32_t>(stage), o_acc, o_page, {}, {.page_id = bh});
         noc.async_write_barrier();
+        scb.pop_front(1);
         cb.pop_front(Vt);
     }
 

--- a/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/kernels/dataflow/writer_decode_gated_delta_rule.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/decode_gated_delta_rule/device/kernels/dataflow/writer_decode_gated_delta_rule.cpp
@@ -14,7 +14,8 @@
 // also written exclusively per head.
 //
 // Compile args: {Kt, Vt} + accessor args for (o, new_state).
-// Runtime args: {bh, o addr, o page bytes, state addr}.
+// Runtime args: {bh_start, n_inst, o addr, o page bytes, state addr}: this
+// core loops over its contiguous instance chunk [bh_start, bh_start+n_inst).
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
@@ -32,10 +33,11 @@ void kernel_main() {
     constexpr auto o_a = TensorAccessorArgs<2>();
     constexpr auto s_a = TensorAccessorArgs<o_a.next_compile_time_args_offset()>();
 
-    const uint32_t bh = get_arg_val<uint32_t>(0);
-    const uint32_t o_addr = get_arg_val<uint32_t>(1);
-    const uint32_t o_page = get_arg_val<uint32_t>(2);  // RM stick page bytes
-    const uint32_t s_addr = get_arg_val<uint32_t>(3);
+    const uint32_t bh_start = get_arg_val<uint32_t>(0);
+    const uint32_t n_inst = get_arg_val<uint32_t>(1);
+    const uint32_t o_addr = get_arg_val<uint32_t>(2);
+    const uint32_t o_page = get_arg_val<uint32_t>(3);  // RM stick page bytes
+    const uint32_t s_addr = get_arg_val<uint32_t>(4);
 
     const uint32_t tb_io = get_tile_size(cb_out);
     const uint32_t elem = tb_io / 1024;
@@ -68,6 +70,8 @@ void kernel_main() {
         asm volatile("" ::: "memory");
     };
 
+    // Per-instance loop: this core owns [bh_start, bh_start + n_inst).
+    for (uint32_t bh = bh_start; bh < bh_start + n_inst; ++bh) {
     // o: stage head bh's [V] stick in scratch, then ONE full-page write to
     // o page bh via the o accessor's page_id form (the same write shape the
     // new-state write below uses and that ttsim/silicon both land). Tile t's
@@ -106,4 +110,5 @@ void kernel_main() {
         noc.async_write_barrier();
         cb.pop_front(kv);
     }
+    }  // per-instance loop
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/transformer/sources.cmake
@@ -36,6 +36,9 @@ set(TTNN_OP_TRANSFORMER_SRCS
     chunk_gated_delta_rule/device/chunk_gdn_phased.cpp
     chunk_gated_delta_rule/device/chunk_gdn_phased_program_factory.cpp
     chunk_gated_delta_rule/chunk_gated_delta_rule.cpp
+    decode_gated_delta_rule/device/decode_gated_delta_rule_device_operation.cpp
+    decode_gated_delta_rule/device/decode_gated_delta_rule_program_factory.cpp
+    decode_gated_delta_rule/decode_gated_delta_rule.cpp
 )
 
 # Registered on the shared `ttnn` Python module target from
@@ -51,5 +54,6 @@ set(TTNN_OP_TRANSFORMER_NANOBIND_SRCS
     split_query_key_value_and_split_heads/split_query_key_value_and_split_heads_nanobind.cpp
     gated_delta_attn/gated_delta_attn_nanobind.cpp
     chunk_gated_delta_rule/chunk_gated_delta_rule_nanobind.cpp
+    decode_gated_delta_rule/decode_gated_delta_rule_nanobind.cpp
     transformer_nanobind.cpp
 )

--- a/ttnn/cpp/ttnn/operations/transformer/transformer_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/transformer_nanobind.cpp
@@ -16,6 +16,7 @@
 #include "concatenate_heads/concatenate_heads_nanobind.hpp"
 #include "gated_delta_attn/gated_delta_attn_nanobind.hpp"
 #include "chunk_gated_delta_rule/chunk_gated_delta_rule_nanobind.hpp"
+#include "decode_gated_delta_rule/decode_gated_delta_rule_nanobind.hpp"
 #include "sdpa/sdpa_nanobind.hpp"
 #include "sdpa_config.hpp"
 #include "sdpa_decode/sdpa_decode_nanobind.hpp"
@@ -77,6 +78,7 @@ void py_module(nb::module_& mod) {
     bind_sdpa_decode(mod);
     bind_gated_delta_attn_seq(mod);
     bind_chunk_gated_delta_rule(mod);
+    bind_decode_gated_delta_rule(mod);
 }
 
 }  // namespace ttnn::operations::transformer


### PR DESCRIPTION
## What

- Adds a golden-equivalence test for MTP-style speculative decode: K=4 chained calls of the fused T=1 ttnn.transformer.decode_gated_delta_rule with K+1 staged recurrent-state slots (slot 0 = committed state, K staged draft states).
- Golden = K-step chain of the existing recurrent decode golden, imported from the T=1 test module.
- Asserts only the two silicon-proven shapes (B=1 H=24 K=128 V=128 and B=1 H=32 K=32 V=32) at pcc >= 0.99, per step and per staged slot.

The commit also carries an AST-identical black pass (repo pin 23.10.1) on the new test and on the pre-existing base T=1 test, which did not conform before (disclosed in the commit body).

Commit: db263c84615c7723abf1332995d4c1f7e0e1cee8

## Silicon (2x Blackhole p150a, 1x2 mesh)

Log i-gdn-mtp-verify.log, final blob commit db263c84615:

I_GDN_MTP: K=4 chained fused T=1 decode, K+1 staged H slots, shapes=H24K128V128,H32K32V32 pcc_o_min=0.999991 pcc_h_min=0.999992 VERDICT: PASS

## Extra coverage

- Simulator, same tree: i-gdn-mtp-ttsim-black.log — I_TT_CI_SIM sku=bh_x2 VERDICT: PASS

## Gates

- i-gdn-mtp-static-gates.log — I_TT_CI_STATIC VERDICT: PASS

Stacks on #53482 (gdn-decode-fused-dw).