### PR TITLE
Fix expand right-align when output rank > input rank

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_expand.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_expand.py
@@ -45,7 +45,70 @@ def test_expand(input_shape, output_shape, tensor_layout, dtype, device):
         output_tensor = ttnn.expand(input_tensor, output_shape)
 
     output_tensor = ttnn.to_torch(output_tensor)
+    assert tuple(output_tensor.shape) == tuple(torch_output_tensor.shape)
     assert torch.allclose(torch_output_tensor, output_tensor, atol=1e-1, rtol=1e-2)
+
+
+@pytest.mark.parametrize(
+    "input_shape, output_shape",
+    [
+        # rank 2 -> rank 3: right-align trailing dims
+        [(3, 1), (2, 3, 1)],
+        [(3, 1), (2, -1, 4)],
+        [(1, 4), (3, 2, -1)],
+        # rank 2 -> rank 4
+        [(2, 1), (4, 3, 2, 5)],
+        [(1, 1), (2, 3, 4, 5)],
+        # rank 1 -> rank 3
+        [(1,), (2, 3, 4)],
+        [(4,), (2, 3, -1)],
+        # rank 3 -> rank 4
+        [(1, 3, 1), (2, -1, -1, 4)],
+        [(1, 1, 1), (5, 4, 3, 2)],
+        # rank 3 -> rank 5
+        [(2, 1, 4), (3, 2, -1, 3, -1)],
+        # zero-size dims (zero-volume tensors)
+        [(3, 1), (0, 3, 1)],
+        [(3, 1), (2, 3, 0)],
+    ],
+)
+@pytest.mark.parametrize(
+    "tensor_layout",
+    [
+        ttnn.ROW_MAJOR_LAYOUT,
+        ttnn.TILE_LAYOUT,
+    ],
+)
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.int32])
+def test_expand_rank_increase(input_shape, output_shape, tensor_layout, dtype, device):
+    """Expand with output rank > input rank (right-aligned dims)."""
+    torch.manual_seed(2024)
+    torch_input_tensor = random_torch_tensor(dtype, input_shape)
+    torch_output_tensor = torch_input_tensor.expand(output_shape)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=tensor_layout, device=device)
+    output_tensor = ttnn.expand(input_tensor, output_shape)
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert tuple(output_tensor.shape) == tuple(torch_output_tensor.shape)
+    assert torch.allclose(torch_output_tensor, output_tensor, atol=1e-1, rtol=1e-2)
+
+
+@pytest.mark.parametrize(
+    "input_shape, output_shape, error_msg",
+    [
+        # negative on a leading dim that has no corresponding input dim
+        [(3, 1), (-1, 3, 1), "Leading dimension must be non-negative"],
+        # non-singleton trailing dim mismatch
+        [(3, 1), (2, 4, 1), "Only size 1 dimensions can be expanded"],
+        # negative size other than -1 on trailing dim
+        [(3, 1), (2, 3, -2), "Expand dimension size must be -1"],
+    ],
+)
+def test_expand_invalid(input_shape, output_shape, error_msg, device, expect_error):
+    torch_input_tensor = torch.rand(input_shape).bfloat16().float()
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    with expect_error(RuntimeError, error_msg):
+        ttnn.expand(input_tensor, output_shape)
 
 
 @pytest.mark.parametrize(

--- a/tests/ttnn/unit_tests/base_functionality/test_expand.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_expand.py
@@ -70,6 +70,9 @@ def test_expand(input_shape, output_shape, tensor_layout, dtype, device):
         # zero-size dims (zero-volume tensors)
         [(3, 1), (0, 3, 1)],
         [(3, 1), (2, 3, 0)],
+        # all-ones repetition (exercises repeat early-return + rank fixup)
+        [(3, 1), (1, 3, 1)],
+        [(3, 1), (1, 1, 3, 1)],
     ],
 )
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/data_movement/expand/expand.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/expand/expand.cpp
@@ -7,15 +7,23 @@
 #include <functional>
 #include <ttnn/operations/functions.hpp>
 #include "ttnn/operations/data_movement/repeat/repeat.hpp"
+#include "ttnn/operations/data_movement/view/view.hpp"
 
 namespace {
 
-ttsl::SmallVector<uint32_t> create_repetition_vector(const ttnn::Tensor& tensor, std::span<const int32_t> shape) {
-    ttsl::SmallVector<uint32_t> expansion_vector(shape.size());
-    auto tensor_shape = tensor.logical_shape();
+struct ExpandPlan {
+    ttsl::SmallVector<uint32_t> repetitions;
+    ttsl::SmallVector<uint32_t> output_shape;
+};
+
+ExpandPlan build_expand_plan(const ttnn::Tensor& tensor, std::span<const int32_t> shape) {
+    const auto& tensor_shape = tensor.logical_shape();
     const auto source_rank = tensor_shape.rank();
     const auto new_rank = shape.size();
     TT_FATAL(source_rank <= new_rank, "Output rank must be >= input rank for expand");
+
+    ttsl::SmallVector<uint32_t> expansion_vector(new_rank);
+    ttsl::SmallVector<uint32_t> output_shape(new_rank);
 
     // Right-align: input dims map to the trailing output dims, matching
     // torch.expand semantics and repeat's own match_input_rank (copy_backward).
@@ -27,21 +35,21 @@ ttsl::SmallVector<uint32_t> create_repetition_vector(const ttnn::Tensor& tensor,
                 "Leading dimension must be non-negative (got {}); it has no corresponding input dimension",
                 shape[index]);
             expansion_vector[index] = shape[index];
+            output_shape[index] = shape[index];
         } else {
             const auto src_dim = tensor_shape[static_cast<int32_t>(index - offset)];
             if ((shape[index] == -1) || (shape[index] == static_cast<int32_t>(src_dim))) {
                 expansion_vector[index] = 1;
+                output_shape[index] = src_dim;
             } else {
-                TT_FATAL(
-                    shape[index] >= 0,
-                    "Expand dimension size must be -1, match the input, or be non-negative (got {})",
-                    shape[index]);
+                TT_FATAL(shape[index] >= 0, "Expand dimension size must be -1 or non-negative (got {})", shape[index]);
                 TT_FATAL(src_dim == 1, "Only size 1 dimensions can be expanded in the output shape");
                 expansion_vector[index] = shape[index];
+                output_shape[index] = shape[index];
             }
         }
     }
-    return expansion_vector;
+    return {std::move(expansion_vector), std::move(output_shape)};
 }
 
 }  // namespace
@@ -52,7 +60,15 @@ Tensor expand(
     const ttnn::Tensor& tensor,
     const ttsl::Span<const int32_t> shape_vector,
     const std::optional<MemoryConfig>& memory_config) {
-    return ttnn::repeat(tensor, create_repetition_vector(tensor, shape_vector), memory_config);
+    auto [repetitions, expected_shape] = build_expand_plan(tensor, shape_vector);
+    auto result = ttnn::repeat(tensor, repetitions, memory_config);
+
+    // repeat's all-ones early return discards the rank padding from
+    // match_input_rank, so reshape to the expected output rank if needed.
+    if (result.logical_shape().rank() != expected_shape.size()) {
+        result = ttnn::view(result, ttnn::Shape(expected_shape));
+    }
+    return result;
 }
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/data_movement/expand/expand.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/expand/expand.cpp
@@ -15,15 +15,30 @@ ttsl::SmallVector<uint32_t> create_repetition_vector(const ttnn::Tensor& tensor,
     auto tensor_shape = tensor.logical_shape();
     const auto source_rank = tensor_shape.rank();
     const auto new_rank = shape.size();
-    TT_FATAL(source_rank <= new_rank, "Only size 1 dimensions can be expanded in the output shape");
-    for (auto index = 0; index < new_rank; ++index) {
-        if (index >= source_rank) {
+    TT_FATAL(source_rank <= new_rank, "Output rank must be >= input rank for expand");
+
+    // Right-align: input dims map to the trailing output dims, matching
+    // torch.expand semantics and repeat's own match_input_rank (copy_backward).
+    const auto offset = new_rank - source_rank;
+    for (size_t index = 0; index < new_rank; ++index) {
+        if (index < offset) {
+            TT_FATAL(
+                shape[index] >= 0,
+                "Leading dimension must be non-negative (got {}); it has no corresponding input dimension",
+                shape[index]);
             expansion_vector[index] = shape[index];
-        } else if ((shape[index] == -1) || (shape[index] == tensor_shape[index])) {
-            expansion_vector[index] = 1;
         } else {
-            TT_FATAL(tensor_shape[index] == 1, "Only size 1 dimensions can be expanded in the output shape");
-            expansion_vector[index] = shape[index];
+            const auto src_dim = tensor_shape[static_cast<int32_t>(index - offset)];
+            if ((shape[index] == -1) || (shape[index] == static_cast<int32_t>(src_dim))) {
+                expansion_vector[index] = 1;
+            } else {
+                TT_FATAL(
+                    shape[index] >= 0,
+                    "Expand dimension size must be -1, match the input, or be non-negative (got {})",
+                    shape[index]);
+                TT_FATAL(src_dim == 1, "Only size 1 dimensions can be expanded in the output shape");
+                expansion_vector[index] = shape[index];
+            }
         }
     }
     return expansion_vector;

--- a/ttnn/cpp/ttnn/operations/data_movement/expand/expand.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/expand/expand.cpp
@@ -25,28 +25,30 @@ ExpandPlan build_expand_plan(const ttnn::Tensor& tensor, std::span<const int32_t
     ttsl::SmallVector<uint32_t> expansion_vector(new_rank);
     ttsl::SmallVector<uint32_t> output_shape(new_rank);
 
-    // Right-align: input dims map to the trailing output dims, matching
-    // torch.expand semantics and repeat's own match_input_rank (copy_backward).
-    const auto offset = new_rank - source_rank;
-    for (size_t index = 0; index < new_rank; ++index) {
-        if (index < offset) {
-            TT_FATAL(
-                shape[index] >= 0,
-                "Leading dimension must be non-negative (got {}); it has no corresponding input dimension",
-                shape[index]);
-            expansion_vector[index] = shape[index];
-            output_shape[index] = shape[index];
-        } else {
-            const auto src_dim = tensor_shape[static_cast<int32_t>(index - offset)];
-            if ((shape[index] == -1) || (shape[index] == static_cast<int32_t>(src_dim))) {
-                expansion_vector[index] = 1;
-                output_shape[index] = src_dim;
+    // Right-align: walk output dims trailing-to-leading, pairing with input dims
+    // from the end — mirrors repeat's match_input_rank (copy_backward).
+    int32_t src_idx = static_cast<int32_t>(source_rank) - 1;
+    for (int32_t out_idx = static_cast<int32_t>(new_rank) - 1; out_idx >= 0; --out_idx) {
+        if (src_idx >= 0) {
+            const auto src_dim = tensor_shape[src_idx];
+            if ((shape[out_idx] == -1) || (shape[out_idx] == static_cast<int32_t>(src_dim))) {
+                expansion_vector[out_idx] = 1;
+                output_shape[out_idx] = src_dim;
             } else {
-                TT_FATAL(shape[index] >= 0, "Expand dimension size must be -1 or non-negative (got {})", shape[index]);
+                TT_FATAL(
+                    shape[out_idx] >= 0, "Expand dimension size must be -1 or non-negative (got {})", shape[out_idx]);
                 TT_FATAL(src_dim == 1, "Only size 1 dimensions can be expanded in the output shape");
-                expansion_vector[index] = shape[index];
-                output_shape[index] = shape[index];
+                expansion_vector[out_idx] = shape[out_idx];
+                output_shape[out_idx] = shape[out_idx];
             }
+            --src_idx;
+        } else {
+            TT_FATAL(
+                shape[out_idx] >= 0,
+                "Leading dimension must be non-negative (got {}); it has no corresponding input dimension",
+                shape[out_idx]);
+            expansion_vector[out_idx] = shape[out_idx];
+            output_shape[out_idx] = shape[out_idx];
         }
     }
     return {std::move(expansion_vector), std::move(output_shape)};


### PR DESCRIPTION
Issue : https://github.com/tenstorrent/tt-metal/issues/53462

## Summary
- `create_repetition_vector()` in `expand.cpp` compared input dims to output dims **left-aligned**, producing wrong data or `TT_FATAL` for valid expands when output rank exceeded input rank.
- Fixed to **right-align** trailing dims (offset = new_rank − source_rank), matching `torch.expand` semantics and `repeat`'s own `match_input_rank` (`copy_backward`).

## Changes
| File | What |
|------|------|
| `ttnn/.../expand/expand.cpp` | Right-align dim mapping in `create_repetition_vector()` |
| `tests/.../test_expand.py` | 12 positive + 3 negative parametrised cases, shape assertions |

---

### Pipeline status

- [x]  Sanity
- [x]  (Runtime) Sanity Test
- [x]  Nightly for DM Category
- [x]  All model test
- [x]  Single card
- [x]  T3K
- [x]  Galaxy
- [x] (Tier 1) Models Device Perf Tests
- [x] ([TM-DM](https://github.com/tenstorrent/tt-metal/actions/runs/32479974955)) Data Movement Test Suite

---

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/expand_53462)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/expand_53462)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/expand_53462)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/expand_53462)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/expand_53462)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/expand_53462)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/expand_53462)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/expand_53462)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/expand_53462)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/expand_53462)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/expand_53462)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/expand_53462)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/expand_53462)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/expand_53462)