### PR TITLE
[QUASAR] MOP-less Matmul: LLK & Compute Kernels

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_matmul_compute.cpp
@@ -29,6 +29,7 @@
 #include <tt-metalium/constants.hpp>
 #include "impl/dataflow_buffer/dataflow_buffer.hpp"
 #include "impl/host_api/temp_quasar_api.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/kernel_types.hpp>
 #include "llk_device_fixture.hpp"
@@ -980,7 +981,241 @@ bool blocked_matmul(const std::shared_ptr<distributed::MeshDevice>& mesh_device,
     return pass;
 }
 
+// MOP-less matmul (issue #52329): out[rt x ct] = in0[rt x kt] * in1[kt x ct] in one dest acquire.
+struct MatmulConfig {
+    uint32_t rt_dim = 1;
+    uint32_t ct_dim = 1;
+    uint32_t kt_dim = 1;
+    MathFidelity math_fidelity = MathFidelity::LoFi;
+};
+
+void run_matmul_no_mop(const std::shared_ptr<distributed::MeshDevice>& mesh_device, const MatmulConfig& test_config) {
+    auto& cq = mesh_device->mesh_command_queue();
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    distributed::MeshWorkload workload;
+
+    const experimental::NodeCoord node{0, 0};
+    const bool is_quasar = mesh_device->arch() == tt::ARCH::QUASAR;
+
+    const uint32_t rt_dim = test_config.rt_dim;
+    const uint32_t ct_dim = test_config.ct_dim;
+    const uint32_t kt_dim = test_config.kt_dim;
+    const uint32_t in0_num_tiles = rt_dim * kt_dim;
+    const uint32_t in1_num_tiles = kt_dim * ct_dim;
+    const uint32_t out_num_tiles = rt_dim * ct_dim;
+    const uint32_t single_tile_size = tt::constants::TILE_HW * sizeof(bfloat16);
+
+    log_info(
+        tt::LogTest,
+        "Testing matmul_block_no_mop rt_dim={} ct_dim={} kt_dim={} fidelity={}",
+        rt_dim,
+        ct_dim,
+        kt_dim,
+        static_cast<int>(test_config.math_fidelity));
+
+    distributed::DeviceLocalBufferConfig dram_config{
+        .page_size = single_tile_size, .buffer_type = tt_metal::BufferType::DRAM, .bottom_up = false};
+    auto make_dram = [&](uint32_t num_tiles) {
+        distributed::ReplicatedBufferConfig cfg{.size = single_tile_size * num_tiles};
+        return distributed::MeshBuffer::create(cfg, dram_config, mesh_device.get());
+    };
+    auto in0_dram = make_dram(in0_num_tiles);
+    auto in1_dram = make_dram(in1_num_tiles);
+    auto out_dram = make_dram(out_num_tiles);
+
+    experimental::KernelSpec::CompilerOptions::Defines defines_vec;
+    defines_vec.emplace("RT_DIM", std::to_string(rt_dim));
+    defines_vec.emplace("CT_DIM", std::to_string(ct_dim));
+    defines_vec.emplace("KT_DIM", std::to_string(kt_dim));
+
+    const experimental::DFBSpecName INP0_DFB{"inp0_dfb"};
+    const experimental::DFBSpecName INP1_DFB{"inp1_dfb"};
+    const experimental::DFBSpecName OUT_DFB{"out_dfb"};
+    const experimental::KernelSpecName READER{"reader"};
+    const experimental::KernelSpecName WRITER{"writer"};
+    const experimental::KernelSpecName COMPUTE{"compute"};
+
+    auto make_dfb = [&](const experimental::DFBSpecName& name, uint32_t num_entries) {
+        return experimental::DataflowBufferSpec{
+            .unique_id = name,
+            .entry_size = single_tile_size,
+            .num_entries = num_entries,
+            .data_format_metadata = tt::DataFormat::Float16_b,
+        };
+    };
+    // One matmul_block_no_mop call indexes a rt_dim x 1 slice of in0 and a 1 x ct_dim slice of in1 off
+    // the read pointer within a single dest acquire, so both operands must be fully resident.
+    experimental::DataflowBufferSpec inp0_dfb_spec = make_dfb(INP0_DFB, in0_num_tiles);
+    experimental::DataflowBufferSpec inp1_dfb_spec = make_dfb(INP1_DFB, in1_num_tiles);
+    experimental::DataflowBufferSpec out_dfb_spec = make_dfb(OUT_DFB, out_num_tiles);
+
+    // Quasar drives dataflow through the Gen2 config and takes its DFB sync explicitly
+    experimental::DataMovementHardwareConfig reader_hw_config;
+    experimental::DataMovementHardwareConfig writer_hw_config;
+    experimental::ComputeHardwareConfig compute_hw_config;
+    if (is_quasar) {
+        reader_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+        writer_hw_config = experimental::DataMovementGen2Config{.disable_dfb_implicit_sync_for_all = true};
+        compute_hw_config = experimental::ComputeGen2Config{.fpu_math_fidelity = test_config.math_fidelity};
+    } else {
+        reader_hw_config = experimental::DataMovementGen1Config{
+            .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = tt_metal::NOC::RISCV_1_default};
+        writer_hw_config = experimental::DataMovementGen1Config{
+            .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = tt_metal::NOC::RISCV_0_default};
+        compute_hw_config = experimental::ComputeGen1Config{.fpu_math_fidelity = test_config.math_fidelity};
+    }
+
+    // Reads num_tiles into in0 and num_bcast_tiles into in1 from two DRAM buffers, which is exactly
+    // the two matmul operands; nothing about it is broadcast-specific.
+    experimental::KernelSpec reader_spec{
+        .unique_id = READER,
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/reader_binary_bcast_col_reuse.cpp",
+        .num_threads = 1,
+        .dfb_bindings =
+            {{
+                 .dfb_spec_name = INP0_DFB,
+                 .accessor_name = "in0",
+                 .endpoint_type = experimental::DFBEndpointType::PRODUCER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
+             },
+             {
+                 .dfb_spec_name = INP1_DFB,
+                 .accessor_name = "in1",
+                 .endpoint_type = experimental::DFBEndpointType::PRODUCER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
+             }},
+        .runtime_arg_schema =
+            {.runtime_arg_names =
+                 {"src0_addr", "src0_bank_id", "src1_addr", "src1_bank_id", "num_tiles", "num_bcast_tiles"}},
+        .hw_config = reader_hw_config,
+    };
+
+    experimental::KernelSpec writer_spec{
+        .unique_id = WRITER,
+        .source = "tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_2_0.cpp",
+        .num_threads = 1,
+        .dfb_bindings = {experimental::ConsumerOf(OUT_DFB, "in")},
+        .runtime_arg_schema = {.runtime_arg_names = {"dst_addr", "bank_id", "num_tiles"}},
+        .hw_config = writer_hw_config,
+    };
+
+    experimental::KernelSpec compute_spec{
+        .unique_id = COMPUTE,
+        .source = "tests/tt_metal/tt_metal/test_kernels/compute/matmul_no_mop.cpp",
+        .num_threads = 1,
+        .compiler_options = {.defines = defines_vec},
+        .dfb_bindings =
+            {{
+                 .dfb_spec_name = INP0_DFB,
+                 .accessor_name = "in0",
+                 .endpoint_type = experimental::DFBEndpointType::CONSUMER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
+             },
+             {
+                 .dfb_spec_name = INP1_DFB,
+                 .accessor_name = "in1",
+                 .endpoint_type = experimental::DFBEndpointType::CONSUMER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
+             },
+             {
+                 .dfb_spec_name = OUT_DFB,
+                 .accessor_name = "out",
+                 .endpoint_type = experimental::DFBEndpointType::PRODUCER,
+                 .access_pattern = experimental::DFBAccessPattern::STRIDED,
+             }},
+        .hw_config = compute_hw_config,
+    };
+
+    experimental::WorkUnitSpec wu{
+        .name = "main",
+        .kernels = {READER, WRITER, COMPUTE},
+        .target_nodes = node,
+    };
+    experimental::ProgramSpec spec{
+        .name = "single_core_matmul_no_mop",
+        .kernels = {reader_spec, writer_spec, compute_spec},
+        .dataflow_buffers = {inp0_dfb_spec, inp1_dfb_spec, out_dfb_spec},
+        .work_units = {wu},
+    };
+
+    Program built_program = experimental::MakeProgramFromSpec(*mesh_device, spec);
+    workload.add_program(device_range, std::move(built_program));
+    auto& program_run = workload.get_programs().at(device_range);
+
+    experimental::ProgramRunArgs params;
+    params.kernel_run_args = {
+        experimental::ProgramRunArgs::KernelRunArgs{
+            .kernel = READER,
+            .runtime_arg_values = experimental::MakeRuntimeArgsForSingleNode(
+                node,
+                {{"src0_addr", static_cast<uint32_t>(in0_dram->address())},
+                 {"src0_bank_id", 0u},
+                 {"src1_addr", static_cast<uint32_t>(in1_dram->address())},
+                 {"src1_bank_id", 0u},
+                 {"num_tiles", in0_num_tiles},
+                 {"num_bcast_tiles", in1_num_tiles}}),
+        },
+        experimental::ProgramRunArgs::KernelRunArgs{
+            .kernel = WRITER,
+            .runtime_arg_values = experimental::MakeRuntimeArgsForSingleNode(
+                node,
+                {{"dst_addr", static_cast<uint32_t>(out_dram->address())},
+                 {"bank_id", 0u},
+                 {"num_tiles", out_num_tiles}}),
+        },
+        experimental::ProgramRunArgs::KernelRunArgs{.kernel = COMPUTE},
+    };
+    experimental::SetProgramRunArgs(program_run, params);
+
+    // make_operand_stimulus emits face-major tile order, which is the DRAM page order the reader
+    // streams and the order make_matmul_golden indexes, so no tilize/untilize round trip is needed.
+    MatmulStimulus stimulus = make_matmul_stimulus(tt::DataFormat::Float16_b, rt_dim, kt_dim, ct_dim);
+    std::vector<float> golden_floats =
+        make_matmul_golden(stimulus.in0_floats, stimulus.in1_floats, rt_dim, kt_dim, ct_dim);
+
+    distributed::WriteShard(cq, in0_dram, stimulus.packed_input0, zero_coord);
+    distributed::WriteShard(cq, in1_dram, stimulus.packed_input1, zero_coord);
+
+    distributed::EnqueueMeshWorkload(cq, workload, is_quasar);
+    distributed::Finish(cq);
+
+    std::vector<uint32_t> dest_buffer_data;
+    distributed::ReadShard(cq, dest_buffer_data, out_dram, zero_coord);
+    std::vector<float> dest_floats = bf16_to_floats(dest_buffer_data);
+
+    // BF16 dest accumulation, so per-element error grows with the kt_dim * TILE_WIDTH inner length;
+    // the PCC backstop catches structural mis-permutations pointwise tolerances would let slip.
+    const float rtol = 0.05f;
+    const float atol = (kt_dim > 1) ? 0.4f : 0.2f;
+    bool pass = tt::test_utils::is_close_vectors<float>(
+        dest_floats, golden_floats, [&](float a, float b) { return tt::test_utils::is_close(a, b, rtol, atol); });
+    pass &= check_pcc(dest_floats, golden_floats, /*min_pcc=*/0.99);
+    if (not pass) {
+        dump_matmul_debug(stimulus.in0_floats, stimulus.in1_floats, golden_floats, dest_floats);
+    }
+    ASSERT_TRUE(pass);
+}
+
 }  // namespace unit_tests::compute::matmul
+
+// Compute-layer coverage: experimental MOP-less matmul (issue #52329). Ordered so the first
+// failure localises: 1x1x1 is a single tile through init + execute, kt_dim>1 adds dest
+// accumulation across inner steps, rt/ct > 1 adds the block reuse walk.
+TEST_F(LLKQuasarMeshDeviceSingleCardFixture, TensixTestSingleCoreComputeMatmulNoMop) {
+    using unit_tests::compute::matmul::MatmulConfig;
+    const std::vector<MatmulConfig> cases = {
+        {.rt_dim = 1, .ct_dim = 1, .kt_dim = 1},
+        {.rt_dim = 1, .ct_dim = 1, .kt_dim = 2},
+        {.rt_dim = 2, .ct_dim = 2, .kt_dim = 1},
+        {.rt_dim = 2, .ct_dim = 2, .kt_dim = 2},
+        {.rt_dim = 1, .ct_dim = 1, .kt_dim = 1, .math_fidelity = MathFidelity::HiFi4},
+        {.rt_dim = 2, .ct_dim = 2, .kt_dim = 2, .math_fidelity = MathFidelity::HiFi4},
+    };
+    for (const auto& cfg : cases) {
+        unit_tests::compute::matmul::run_matmul_no_mop(this->devices_.at(0), cfg);
+    }
+}
 
 TEST_F(LLKMeshDeviceFixture, TensixTestSingleCoreSingleTileComputeMatmul) {
     for (auto& device : this->devices_) {

--- a/tests/tt_metal/tt_metal/test_kernels/compute/matmul_no_mop.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/compute/matmul_no_mop.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Blocked matmul driven through the experimental MOP-less Compute API (issue #52329).
+//
+// out[RT_DIM x CT_DIM] = in0[RT_DIM x KT_DIM] * in1[KT_DIM x CT_DIM], accumulated in DEST across the
+// KT_DIM inner steps of one dest acquire. The no-MOP path issues REPLAY + MVMUL straight from the
+// RISC core instead of running MOP BANK0, so the result must match the MOP matmul exactly.
+//
+// Structure mirrors matmul_block.cpp (the DFB-based MOP matmul kernel): the LLK does not walk kt_dim,
+// so the kernel loops it. in0 is [RT_DIM x KT_DIM] row-major and in1 is [KT_DIM x CT_DIM] row-major,
+// so step k reads in0 tile k (the LLK strides down the rows by kt_dim) and in1 tile k * CT_DIM.
+
+#include <cstdint>
+#include "api/compute/experimental/matmul_custom.h"
+#include "api/compute/compute_kernel_hw_startup.h"
+#include "api/compute/pack.h"
+#include "api/compute/reg_api.h"
+#include "api/dataflow/dataflow_buffer.h"
+
+void kernel_main() {
+    constexpr std::uint32_t ct_dim = CT_DIM;
+    constexpr std::uint32_t rt_dim = RT_DIM;
+    constexpr std::uint32_t kt_dim = KT_DIM;
+
+    constexpr std::uint32_t in0_num_tiles = rt_dim * kt_dim;
+    constexpr std::uint32_t in1_num_tiles = kt_dim * ct_dim;
+    constexpr std::uint32_t out_num_tiles = rt_dim * ct_dim;
+
+    DataflowBuffer dfb0(dfb::in0);
+    DataflowBuffer dfb1(dfb::in1);
+    DataflowBuffer dfb_out(dfb::out);
+    constexpr std::uint32_t icb0 = dfb::in0;
+    constexpr std::uint32_t icb1 = dfb::in1;
+    constexpr std::uint32_t ocb = dfb::out;
+
+    // Matmul maps in0 -> SrcB and in1 -> SrcA, the reverse of other ops, hence SrcOrder::Reverse.
+    compute_kernel_hw_startup<SrcOrder::Reverse>(icb0, icb1, ocb);
+    mm_no_mop_init_short(icb0, icb1, false /*transpose*/, ct_dim, rt_dim, kt_dim);
+
+    // The whole block of both operands must be resident: one matmul_block_no_mop call unpacks a
+    // rt_dim x 1 slice of in0 and a 1 x ct_dim slice of in1, indexed off the read pointer.
+    dfb0.wait_front(in0_num_tiles);
+    dfb1.wait_front(in1_num_tiles);
+    dfb_out.reserve_back(out_num_tiles);
+
+    tile_regs_acquire();
+    for (std::uint32_t k = 0; k < kt_dim; k++) {
+        matmul_block_no_mop(
+            icb0,
+            icb1,
+            k /*in0_tile_index*/,
+            k * ct_dim /*in1_tile_index*/,
+            0 /*idst*/,
+            false /*transpose*/,
+            ct_dim,
+            rt_dim,
+            kt_dim);
+    }
+    tile_regs_commit();
+
+    tile_regs_wait();
+    for (std::uint32_t i = 0; i < out_num_tiles; i++) {
+        pack_tile(i, ocb);
+    }
+    tile_regs_release();
+
+    dfb_out.push_back(out_num_tiles);
+    dfb0.pop_front(in0_num_tiles);
+    dfb1.pop_front(in1_num_tiles);
+}

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/experimental/llk_math_matmul_custom_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/experimental/llk_math_matmul_custom_api.h
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "llk_assert.h"
+#include "llk_math_common_api.h"
+#include "experimental/llk_math_matmul_custom_no_mop.h"
+
+/*************************************************************************
+ * LLK MATMUL (NO MOP)
+ *************************************************************************/
+
+// Both operands must agree on 2x-ness, as llk_math_matmul_init also requires.
+// Re-derived per call rather than cached at init so the execute path stays stateless (the MOP path
+// keeps this implicitly in its MOP config, which the no-MOP path has by definition given up).
+inline bool operands_use_2x_format(const std::uint32_t operand0, const std::uint32_t operand1) {
+    const DataFormat format0 = static_cast<DataFormat>(get_operand_dst_format(get_operand_id(operand0)));
+    const DataFormat format1 = static_cast<DataFormat>(get_operand_dst_format(get_operand_id(operand1)));
+    LLK_ASSERT(
+        is_2x_format(format0) == is_2x_format(format1), "Both operands must be 2x formats or both non-2x formats");
+    return is_2x_format(format0) && is_2x_format(format1);
+}
+
+/**
+ * @brief Initialize a matrix multiply of Input 0 * Input 1 -> SrcB * SrcA that runs without a MOP.
+ *
+ * Configures the ALU data-format state, then programs the matmul addrmods and records the replay buffer.
+ * MOP BANK0 is left untouched, so a fused op may own it.
+ *
+ * @tparam math_fidelity: 0 = LoFi, 2 = HiFi2, 3 = HiFi3, 4 = HiFi4 controls precision of multiplication
+ * @tparam THROTTLE_LEVEL: Accepted for API parity with Wormhole/Blackhole; Quasar has no throttled MVMUL sequences, so
+ * only 0 is valid
+ * @param operandA: Logical dataflow buffer identifier for input 0 (-> SrcB)
+ * @param operandB: Logical dataflow buffer identifier for input 1 (-> SrcA)
+ * @param transpose: Transpose flag; not supported on Quasar. Present so this signature matches
+ *        the Wormhole/Blackhole llk_api and the shared Compute API needs no arch branch.
+ * @param ct_dim: number of tiles in the column dimension for a matrix multiply
+ * @param rt_dim: number of tiles in the row dimension for a matrix multiply
+ * @note Run @ref llk_math_matmul_no_mop with matching template args to execute the configured matmul.
+ * @note Run @ref llk_math_matmul_reinit_no_mop instead when only the replay buffer and addrmods need
+ *       restoring, e.g. after an interleaved op that recorded over replay buffer slot 0.
+ */
+template <ckernel::MathFidelity math_fidelity, int THROTTLE_LEVEL = 0>
+inline void llk_math_matmul_init_no_mop(
+    const std::uint32_t operandA,
+    const std::uint32_t operandB,
+    const bool transpose = false,
+    const std::uint32_t ct_dim = 1,
+    const std::uint32_t rt_dim = 1) {
+    static_assert(
+        THROTTLE_LEVEL == 0,
+        "Quasar no-mop matmul only supports THROTTLE_LEVEL == 0; Quasar has no throttled MVMUL sequences");
+    LLK_ASSERT(!transpose, "non-default transpose not supported on Quasar");
+
+    const std::uint32_t operandA_id = get_operand_id(operandA);
+    const std::uint32_t operandB_id = get_operand_id(operandB);
+
+    // The replayed MVMUL walk marches SrcA/SrcB across all four faces, so it is valid for full 32x32
+    // tiles only: the same restriction llk_unpack_AB_matmul_init enforces on the unpack side.
+    LLK_ASSERT(
+        get_operand_tensor_shape(operandA_id).total_num_faces() == ckernel::MAX_NUM_FACES,
+        "no-mop matmul replays a four-face MVMUL walk, so it supports full 32x32 tiles only");
+    LLK_ASSERT(
+        get_operand_tensor_shape(operandB_id).total_num_faces() == ckernel::MAX_NUM_FACES,
+        "no-mop matmul replays a four-face MVMUL walk, so it supports full 32x32 tiles only");
+
+    const DataFormat srcB_format = static_cast<DataFormat>(get_operand_dst_format(operandA_id));
+    const DataFormat srcA_format = static_cast<DataFormat>(get_operand_dst_format(operandB_id));
+    _configure_default_alu_data_format_state_<false /* IMPLIED_MATH_FORMAT */, DST_ACCUM_MODE>(
+        srcA_format, srcB_format);
+
+    if (operands_use_2x_format(operandA, operandB)) {
+        _llk_math_matmul_init_no_mop_<math_fidelity, true /*EN_X2*/>(ct_dim, rt_dim);
+    } else {
+        _llk_math_matmul_init_no_mop_<math_fidelity, false /*EN_X2*/>(ct_dim, rt_dim);
+    }
+}
+
+/**
+ * @brief Performs a matrix multiply of Input 0 * Input 1 -> SrcB * SrcA over a block of tiles, without a MOP.
+ *
+ * Input 0 dim = [rt_dim, 1] -> SrcB reg, Input 1 dim = [1, ct_dim] -> SrcA reg;
+ * output is a matrix block of dimension [rt_dim, ct_dim].
+ * This function does not iterate over kt_dim, must iterate over kt_dim externally to this function.
+ * Dest index is always assumed to start at 0 for this operation.
+ *
+ * @tparam math_fidelity: 0 = LoFi, 2 = HiFi2, 3 = HiFi3, 4 = HiFi4 - controls precision of multiplication
+ * @tparam THROTTLE_LEVEL: Accepted for API parity with Wormhole/Blackhole; Quasar has no throttled MVMUL sequences, so
+ * only 0 is valid
+ * @param operandA: Logical dataflow buffer identifier for input 0 (-> SrcB)
+ * @param operandB: Logical dataflow buffer identifier for input 1 (-> SrcA)
+ * @param dst_index: First destination tile index; only 0 is supported on Quasar, whose block matmul
+ *        always starts at dest tile 0. Present so this signature matches the Wormhole/Blackhole
+ *        llk_api and the shared Compute API needs no arch branch.
+ * @param ct_dim: number of tiles in the column dimension for a matrix multiply
+ * @param rt_dim: number of tiles in the row dimension for a matrix multiply
+ * @note Run @ref llk_math_matmul_init_no_mop with matching template args first.
+ */
+template <ckernel::MathFidelity math_fidelity, int THROTTLE_LEVEL = 0>
+inline void llk_math_matmul_no_mop(
+    const std::uint32_t operandA,
+    const std::uint32_t operandB,
+    const std::uint32_t dst_index,
+    const std::uint32_t ct_dim = 1,
+    const std::uint32_t rt_dim = 1) {
+    static_assert(
+        THROTTLE_LEVEL == 0,
+        "Quasar no-mop matmul only supports THROTTLE_LEVEL == 0; Quasar has no throttled MVMUL sequences");
+    LLK_ASSERT(dst_index == 0, "non-default dst_index not supported on Quasar");
+
+    // Re-derive 2x-ness so the execute issues the same MVMUL count that init recorded.
+    if (operands_use_2x_format(operandA, operandB)) {
+        _llk_math_matmul_block_no_mop_<math_fidelity, true /*EN_X2*/>(ct_dim, rt_dim);
+    } else {
+        _llk_math_matmul_block_no_mop_<math_fidelity, false /*EN_X2*/>(ct_dim, rt_dim);
+    }
+}
+
+/**
+ * @brief Restores the no-mop matmul math state without touching the ALU data-format state.
+ *
+ * Reprograms the matmul addrmods and re-records the replay buffer. Unlike Wormhole/Blackhole where the
+ * math thread owns a dedicated replay-buffer offset and a reinit only has to restore addrmods every
+ * Quasar LLK records at replay buffer slot 0, so an interleaved op overwrites this matmul's image and it
+ * must be re-recorded here.
+ *
+ * @tparam math_fidelity: 0 = LoFi, 2 = HiFi2, 3 = HiFi3, 4 = HiFi4 - controls precision of multiplication
+ * @tparam THROTTLE_LEVEL: Accepted for API parity with Wormhole/Blackhole; Quasar has no throttled MVMUL sequences, so
+ * only 0 is valid
+ * @param operandA: Logical dataflow buffer identifier for input 0 (-> SrcB)
+ * @param operandB: Logical dataflow buffer identifier for input 1 (-> SrcA)
+ * @param transpose: Transpose flag; only false is supported on Quasar. Present so this signature matches
+ *        the Wormhole/Blackhole llk_api and the shared Compute API needs no arch branch.
+ * @param ct_dim: number of tiles in the column dimension for a matrix multiply
+ * @param rt_dim: number of tiles in the row dimension for a matrix multiply
+ * @note Run @ref llk_math_matmul_init_no_mop once before the steady-state loop; this call is the
+ *       per-iteration restore.
+ */
+template <ckernel::MathFidelity math_fidelity, int THROTTLE_LEVEL = 0>
+inline void llk_math_matmul_reinit_no_mop(
+    const std::uint32_t operandA,
+    const std::uint32_t operandB,
+    const bool transpose = false,
+    const std::uint32_t ct_dim = 1,
+    const std::uint32_t rt_dim = 1) {
+    static_assert(
+        THROTTLE_LEVEL == 0,
+        "Quasar no-mop matmul only supports THROTTLE_LEVEL == 0; Quasar has no throttled MVMUL sequences");
+    LLK_ASSERT(!transpose, "non-default transpose not supported on Quasar");
+
+    if (operands_use_2x_format(operandA, operandB)) {
+        _llk_math_matmul_init_no_mop_<math_fidelity, true /*EN_X2*/>(ct_dim, rt_dim);
+    } else {
+        _llk_math_matmul_init_no_mop_<math_fidelity, false /*EN_X2*/>(ct_dim, rt_dim);
+    }
+}

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -62,6 +62,31 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
 }
 
 /**
+ * @brief Runtime-transpose overload, signature-compatible with the Wormhole/Blackhole llk_api.
+ *
+ * Quasar takes transpose as a template argument, but the shared Compute API passes it as a runtime
+ * value. This overload absorbs that difference here rather than forcing an arch branch into the
+ * Compute API. Every parameter is required: the template overload above covers the shorter argument lists.
+ *
+ * @param operandA: The input0 operand circular buffer
+ * @param operandB: The input1 operand circular buffer
+ * @param transpose: Transpose flag; only 0 is supported on Quasar (transpose of SrcA is not implemented)
+ * @param ct_dim: number of tiles in the column dimension for input1 of matrix multiply
+ * @param rt_dim: number of tiles in the row dimension for input0 of matrix multiply
+ * @param kt_dim: number of tiles in the common dimension between input0 & input1 of matrix multiply
+ */
+__attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
+    const std::uint32_t operandA,
+    const std::uint32_t operandB,
+    const std::uint32_t transpose,
+    const std::uint32_t ct_dim,
+    const std::uint32_t rt_dim,
+    const std::uint32_t kt_dim) {
+    LLK_ASSERT(transpose == 0, "non-default transpose not supported on Quasar");
+    llk_unpack_AB_matmul_init<false /*TRANSPOSE_EN*/>(operandA, operandB, ct_dim, rt_dim, kt_dim);
+}
+
+/**
  *
  * @brief Performs unpack operation for matrix multiply such that:
  *

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_custom_no_mop_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_matmul_custom_no_mop_quasar.py
@@ -1,0 +1,320 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Quasar bring-up test for the MOP-less matmul LLK.
+
+Exercises _llk_math_matmul_init_no_mop_ / _llk_math_matmul_block_no_mop_. The MOP-based matmul
+programs BANK0 with [REPLAY(0, len), matmul_op] x FIDELITY_PHASES (matmul_op_last closing the
+last phase); the no-MOP path issues that identical stream from the RISC core so MOP BANK0 stays
+free for a fused op. Same replay image and addrmods, so the golden is the ordinary MatmulGolden
+any mismatch means the hand-issued stream diverged from what the MOP expands to.
+
+Axes mirror the Blackhole/Wormhole no-MOP test (test_matmul_custom.py): fidelity x format x
+dest_acc x dimensions. Two things differ from that test, both forced by the arch:
+
+  * Formats are Quasar's matmul set (test_matmul_quasar.MATMUL_FORMAT), not BH/WH's.
+  * The MXFP4_2x variant needs its own test because it changes the replay length (8 MVMULs per
+    tile instead of 16) and moves the two closing MVMULs to different addrmod slots. It is the
+    variant GPT-OSS needs, so it cannot go untested.
+
+Throttling is not swept: Quasar has no throttled MVMUL sequences, and the LLK API static_asserts
+THROTTLE_LEVEL == 0 (same on Wormhole).
+"""
+
+import pytest
+import torch
+from helpers.constraints import get_valid_dest_accumulation_modes
+from helpers.data_format_inference import data_formats
+from helpers.device import BootMode
+from helpers.format_config import DataFormat, InputOutputFormat, is_dest_acc_needed
+from helpers.golden_generators import (
+    MatmulGolden,
+    get_golden_generator,
+    quantize_mx_tensor_chunked,
+)
+from helpers.llk_params import (
+    DestAccumulation,
+    DestSync,
+    ImpliedMathFormat,
+    MathFidelity,
+    Transpose,
+    format_dict,
+)
+from helpers.matmul_sweep import (
+    generate_matmul_dimension_combinations,
+    generate_tile_dims,
+)
+from helpers.param_config import (
+    DEST_SYNC_TILE_LIMITS,
+    input_output_formats,
+    parametrize,
+    runtime,
+)
+from helpers.stimuli_config import StimuliConfig
+from helpers.stimuli_generator import StimuliSpec, generate_stimuli
+from helpers.test_config import TestConfig
+from helpers.test_variant_parameters import (
+    CRK_TILE_DIMM,
+    DEST_SYNC,
+    ENABLE_2X_FORMAT,
+    IMPLIED_MATH_FORMAT,
+    MATH_FIDELITY,
+    NUM_FACES,
+    TILE_COUNT,
+    UNPACK_TRANS_FACES,
+)
+from helpers.tilize_untilize import tilize_block, untilize_block
+from helpers.utils import passed_test
+
+# The no-MOP LLK replays a four-face MVMUL walk, so it is full-32x32-tile only (the same
+# restriction the regular Quasar matmul carries, tt-metal #45208).
+NUM_FACES_PER_TILE = 4
+
+# The kernel drives DestSync.Half, matching test_matmul_custom.py. Full-sync only widens the dest
+# capacity; it does not touch the REPLAY/MVMUL issue path this test is about.
+DEST_SYNC_MODE = DestSync.Half
+
+MATH_FIDELITIES = [
+    MathFidelity.LoFi,
+    MathFidelity.HiFi2,
+    MathFidelity.HiFi3,
+    MathFidelity.HiFi4,
+]
+
+# Plain (non-2x) formats out of Quasar's matmul set. MX formats are covered by the 2x test below,
+# which needs the MX golden machinery anyway.
+MATMUL_FORMATS = input_output_formats([DataFormat.Float16, DataFormat.Float16_b])
+
+
+def _dest_bank_max_tiles(formats, dest_acc):
+    """Max result-tile count for a (format, dest_acc) pair on DestSync.Half.
+
+    A 32-bit destination register (dest_acc=Yes, or a format the harness forces onto 32-bit dest)
+    holds half as many tiles as the 16-bit one. Mirrors test_matmul_custom._dest_bank_max_tiles.
+    """
+    capacity_divisor = (
+        2 if (is_dest_acc_needed(formats) or dest_acc == DestAccumulation.Yes) else 1
+    )
+    return DEST_SYNC_TILE_LIMITS[DEST_SYNC_MODE] // capacity_divisor
+
+
+def _run_matmul_custom_no_mop(
+    math_fidelity,
+    formats,
+    dest_acc,
+    implied_math_format,
+    input_A_dimensions,
+    input_B_dimensions,
+    enable_2x_format: bool,
+    boot_mode: BootMode,
+):
+    torch_format = format_dict[formats.output_format]
+
+    stimuli_spec = StimuliSpec.uniform(low=0.0, high=1.0)
+    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_A_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_B_dimensions,
+        spec_A=stimuli_spec,
+        spec_B=stimuli_spec,
+        output_format=formats.output_format,
+    )
+
+    tilized_A = tilize_block(
+        src_A, dimensions=input_A_dimensions, stimuli_format=formats.input_format
+    )
+    tilized_B = tilize_block(
+        src_B, dimensions=input_B_dimensions, stimuli_format=formats.input_format
+    )
+
+    matmul_dims = generate_tile_dims((input_A_dimensions, input_B_dimensions))
+
+    # MX inputs are quantized onto their lattice by the unpacker, so golden has to see
+    # quantized operands rather than the raw stimuli (mirrors test_matmul_quasar).
+    src_A_golden = src_A
+    src_B_golden = src_B
+    if formats.input_format.is_mx_format():
+        tilized_A_golden = quantize_mx_tensor_chunked(
+            tilized_A.flatten().to(torch.bfloat16), formats.input_format
+        ).reshape(tilized_A.shape)
+        tilized_B_golden = quantize_mx_tensor_chunked(
+            tilized_B.flatten().to(torch.bfloat16), formats.input_format
+        ).reshape(tilized_B.shape)
+        src_A_golden = untilize_block(
+            tilized_A_golden,
+            stimuli_format=formats.input_format,
+            dimensions=input_A_dimensions,
+        )
+        src_B_golden = untilize_block(
+            tilized_B_golden,
+            stimuli_format=formats.input_format,
+            dimensions=input_B_dimensions,
+        )
+
+    # 2x register-format opt-in has to flow through inference; only disable inference for plain MX
+    # formats, where there is nothing to infer.
+    disable_format_inference = (
+        formats.input_format.is_mx_format() and formats.register_format_hint is None
+    )
+
+    formats_config = data_formats(
+        input_format=formats.input_format,
+        input_format_B=formats.input_format_B,
+        output_format=formats.output_format,
+        is_fp32_dest_acc_en=dest_acc,
+        num_iterations=1,
+        unpacking_to_dest=False,
+        disable_format_inference=disable_format_inference,
+        register_format_hint=formats.register_format_hint,
+    )[0]
+    pack_src_format = formats_config.pack_src
+
+    generate_golden = get_golden_generator(MatmulGolden)
+    golden_tensor = generate_golden(
+        src_A_golden,
+        src_B_golden,
+        formats.output_format,
+        math_fidelity,
+        input_A_dimensions=input_A_dimensions,
+        input_B_dimensions=input_B_dimensions,
+        # Golden cannot model FPU strided for tilized data computation, so we tilize output after computation
+        tilize=True,
+        input_A_format=formats.input_format,
+        input_B_format=formats.input_format,
+        # For accumulation of results in matmul we require to calculate in pack_src_format.
+        math_format=pack_src_format,
+        dest_acc=dest_acc,
+    )
+
+    configuration = TestConfig(
+        test_name="sources/quasar/matmul_custom_no_mop_quasar_test.cpp",
+        formats=formats,
+        templates=[
+            MATH_FIDELITY(math_fidelity),
+            IMPLIED_MATH_FORMAT(implied_math_format),
+            ENABLE_2X_FORMAT(enable_2x_format),
+            DEST_SYNC(DEST_SYNC_MODE),
+            UNPACK_TRANS_FACES(Transpose.No),
+        ],
+        runtimes=[
+            CRK_TILE_DIMM(matmul_dims.ct_dim, matmul_dims.rt_dim, matmul_dims.kt_dim),
+            TILE_COUNT(matmul_dims.output_tile_cnt),
+            NUM_FACES(NUM_FACES_PER_TILE, NUM_FACES_PER_TILE, NUM_FACES_PER_TILE),
+        ],
+        variant_stimuli=StimuliConfig(
+            tilized_A.flatten(),
+            formats.input_format,
+            tilized_B.flatten(),
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_B,
+            tile_count_res=matmul_dims.output_tile_cnt,
+            num_faces=NUM_FACES_PER_TILE,
+        ),
+        unpack_to_dest=False,
+        dest_acc=dest_acc,
+        disable_format_inference=disable_format_inference,
+        boot_mode=boot_mode,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), "Result tensor and golden tensor are not of the same length"
+
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
+
+    # For MX outputs, model the packer: quantize the golden onto the MX lattice (from the math /
+    # pack_src format the result was produced in) so the comparison validates the device's MX output
+    # quantization, not just matmul-math-to-MX precision.
+    if formats.output_format.is_mx_format():
+        golden_tensor = quantize_mx_tensor_chunked(
+            golden_tensor.to(format_dict[pack_src_format]), formats.output_format
+        ).to(torch_format)
+
+    assert passed_test(
+        golden_tensor, res_tensor, formats.output_format
+    ), "Assert against golden failed"
+
+
+@pytest.mark.quasar
+@parametrize(
+    math_fidelity=MATH_FIDELITIES,
+    formats=MATMUL_FORMATS,
+    dest_acc=lambda formats: get_valid_dest_accumulation_modes(formats),
+    dimensions=runtime(
+        lambda formats, dest_acc: generate_matmul_dimension_combinations(
+            _dest_bank_max_tiles(formats, dest_acc)
+        )
+    ),
+)
+def test_matmul_custom_no_mop_quasar(
+    math_fidelity,
+    formats,
+    dest_acc,
+    dimensions,
+    boot_mode=BootMode.DEFAULT,
+):
+    input_A_dimensions, input_B_dimensions = dimensions
+    _run_matmul_custom_no_mop(
+        math_fidelity,
+        formats,
+        dest_acc,
+        # The metal llk_api wrapper configures the ALU format state with IMPLIED_MATH_FORMAT off,
+        # so the non-MX path is tested in that mode.
+        ImpliedMathFormat.No,
+        input_A_dimensions,
+        input_B_dimensions,
+        enable_2x_format=False,
+        boot_mode=boot_mode,
+    )
+
+
+# MXFP4 unpacked as MxFp4_2x_A/B in the src registers: SrcA expands two sub-datums per element, so a
+# tile takes 8 MVMULs instead of 16 and the two closing MVMULs move to ADDR_MOD_4/ADDR_MOD_5 (from
+# ADDR_MOD_5/ADDR_MOD_3). That is exactly the wiring the no-MOP path has to reproduce by hand, so it
+# gets its own sweep. MxFp4 is input-only here, the packer never writes it. So the output stays a
+# plain 16-bit float format.
+MATMUL_2X_FORMATS = [
+    InputOutputFormat(DataFormat.MxFp4, DataFormat.Float16_b, register_format_hint=hint)
+    for hint in (DataFormat.MxFp4_2x_A, DataFormat.MxFp4_2x_B)
+]
+
+# One tile-shape per K depth is enough: the 2x variant only changes the per-tile MVMUL sequence, and
+# the block/K walk around it is shared with the plain path covered above.
+MATMUL_2X_DIMENSIONS = [
+    ([32, 32], [32, 32]),
+    ([32, 64], [64, 32]),
+    ([64, 64], [64, 64]),
+]
+
+
+@pytest.mark.quasar
+@parametrize(
+    math_fidelity=MATH_FIDELITIES,
+    formats=MATMUL_2X_FORMATS,
+    dest_acc=lambda formats: get_valid_dest_accumulation_modes(formats),
+    dimensions=MATMUL_2X_DIMENSIONS,
+)
+def test_matmul_custom_no_mop_quasar_mxfp4_2x(
+    math_fidelity,
+    formats,
+    dest_acc,
+    dimensions,
+    boot_mode=BootMode.DEFAULT,
+):
+    input_A_dimensions, input_B_dimensions = dimensions
+    _run_matmul_custom_no_mop(
+        math_fidelity,
+        formats,
+        dest_acc,
+        # MX formats carry their exponent in the data, so the math format has to be implied.
+        ImpliedMathFormat.Yes,
+        input_A_dimensions,
+        input_B_dimensions,
+        enable_2x_format=True,
+        boot_mode=boot_mode,
+    )

--- a/tt_metal/tt-llk/tests/sources/quasar/matmul_custom_no_mop_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/matmul_custom_no_mop_quasar_test.cpp
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Matmul without a MOP (Quasar).
+//
+// Unpack and pack are the plain matmul paths; only math differs from matmul_quasar_test.cpp: instead of
+// running MOP BANK0 it issues REPLAY + MVMUL straight from the RISC core. The result must match the
+// MOP-based matmul bit for bit, so the golden remains ordinary MatmulGolden.
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "llk_memory_checks.h"
+#include "quasar_test_common.h"
+#include "sfpu_stub.h"
+
+// Globals
+std::uint32_t unp_cfg_context          = 0;
+std::uint32_t pack_sync_tile_dst_ptr   = 0;
+std::uint32_t math_sync_tile_dst_index = 0;
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_bfd_alloc.h"
+#include "llk_unpack_matmul.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t CT_DIM      = params.CT_DIM;
+    const std::uint32_t RT_DIM      = params.RT_DIM;
+    const std::uint32_t KT_DIM      = params.KT_DIM;
+    const std::uint32_t num_faces_A = params.num_faces_A;
+    const std::uint32_t num_faces_B = params.num_faces_B;
+    const Operand& buffer_A         = params.buffer_A;
+    const Operand& buffer_B         = params.buffer_B;
+
+    set_ttsync_enables<TRACK_ALL>(ckernel::TRISC_ID);
+
+    // No-mop matmul is full-tile only: the replayed MVMUL walk covers all four 16x16 faces, so
+    // num_faces_A/num_faces_B are always 4.
+    // Matmul flips the unpacker roles: _llk_unpack_matmul_init_ arg0 drives UNPACR1/SrcB, arg1 drives
+    // UNPACR0/SrcA -- so operand A is recorded under Unp1 and operand B under Unp0 (matches product).
+    ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(
+        ckernel::tensor_shape_from_num_faces(FACE_R_DIM, num_faces_A), L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
+    ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
+        ckernel::tensor_shape_from_num_faces(FACE_R_DIM, num_faces_B), L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
+    _llk_unpack_hw_configure_<ckernel::p_unpacr::UNP_B>(static_cast<DataFormat>(formats.unpack_A_dst));
+    _llk_unpack_hw_configure_<ckernel::p_unpacr::UNP_A>(static_cast<DataFormat>(formats.unpack_B_dst));
+
+    // transpose in src_A is not supported for quasar
+    _llk_unpack_matmul_init_<UNPACK_TRANSPOSE_FACES>(
+        ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(),
+        ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(),
+        CT_DIM,
+        RT_DIM,
+        KT_DIM);
+
+    for (std::uint32_t j = 0; j < KT_DIM; j++)
+    {
+        _llk_unpack_matmul_(CT_DIM, RT_DIM, KT_DIM, j, j * CT_DIM);
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+#include "experimental/llk_math_matmul_custom_no_mop.h"
+#include "llk_math_common.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t CT_DIM = params.CT_DIM;
+    const std::uint32_t RT_DIM = params.RT_DIM;
+    const std::uint32_t KT_DIM = params.KT_DIM;
+
+    set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::FPU>();
+
+    DataFormat math_format     = static_cast<DataFormat>(formats.math);
+    DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        if (pack_src_format == DataFormat::Int32)
+        {
+            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
+        }
+        else
+        {
+            _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, true /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
+        }
+    }
+    else
+    {
+        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, false /*int32_dest*/>(math_format, math_format);
+    }
+
+    // ENABLE_2X_FORMAT enables the 2x-packed FP4 matmul path (8 MVMULs per tile vs 16, K-dim halved per
+    // MVMUL via the SrcA 2x sub-datum expansion). Set when SrcA/SrcB are configured as MxFp4_2x_A/B.
+    _llk_math_matmul_init_no_mop_<(ckernel::MathFidelity)MATH_FIDELITY, ENABLE_2X_FORMAT>(CT_DIM, RT_DIM);
+
+    for (std::uint32_t i = 0; i < KT_DIM; i++)
+    {
+        _llk_math_matmul_block_no_mop_<(ckernel::MathFidelity)MATH_FIDELITY, ENABLE_2X_FORMAT>(CT_DIM, RT_DIM);
+    }
+    _llk_math_set_dvalid_<p_cleardvalid::FPU, dest_sync>();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "llk_bfd_alloc.h"
+#include "llk_pack.h"
+#include "llk_pack_matmul.h"
+#include "params.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    const std::uint32_t CT_DIM    = params.CT_DIM;
+    const std::uint32_t RT_DIM    = params.RT_DIM;
+    const std::uint32_t num_faces = params.num_faces;
+    const Operand& buffer_Res     = params.buffer_Res;
+
+    set_up_fpu_to_pack_dest_dvalid_chain<dest_dvalid_client::PACK>();
+
+    // Full 32x32 tiles: 2x2 faces of 16x16 (no-mop matmul is full-tile only).
+    ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
+        ckernel::tensor_shape_from_num_faces(FACE_R_DIM, num_faces), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
+    _llk_pack_matmul_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), RT_DIM, CT_DIM, 1 /*num_subblocks_c_dim*/);
+
+    _llk_pack_matmul_(0 /*start_math_dest_tile_idx*/, 0 /*start_l1_tile_idx*/);
+    _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
+}
+
+#endif

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_math_matmul_custom_no_mop.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_math_matmul_custom_no_mop.h
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "llk_math_common.h"
+#include "llk_math_matmul.h"
+
+using namespace ckernel;
+using namespace ckernel::trisc;
+using namespace ckernel::math;
+
+/*************************************************************************
+ * LLK MATH MATMUL CUSTOM NO MOP
+ *************************************************************************/
+
+// The MOP-based matmul programs BANK0 (see _llk_math_matmul_mop_config_) with
+//     outer = 1, inner = FIDELITY_PHASES, LOOP_INSTR0 = REPLAY(0, len), LOOP_INSTR1 = matmul_op,
+//     LOOP0_LAST_INSTR = matmul_op_last
+// which the MOP expands into [REPLAY, matmul_op] x (FIDELITY_PHASES - 1) then [REPLAY, matmul_op_last].
+//
+// This path issues that identical instruction stream straight from the RISC core, so MOP BANK0 stays
+// free for a fused op that needs it. Same replay image (_llk_math_matmul_load_replay_) and same addrmod
+// slots (_llk_math_matmul_addrmod_) as the MOP path, so the numeric result is unchanged, only the
+// issue mechanism differs, trading MOP occupancy for RISC instruction-issue bandwidth.
+
+/**
+ * @brief Issues the MVMUL stream for one Tile x Tile matrix multiply directly, bypassing the MOP.
+ *
+ * @tparam MATH_FIDELITY_TYPE: Controls multiplication precision via the number of FPU fidelity phases; higher values use more of the input mantissa bits,
+ * values = <LoFi/HiFi2/HiFi3/HiFi4>
+ * @tparam ENABLE_2X_FORMAT: When true, replays the non-DI MXFP4_2x sequence (8 MVMULs per tile instead of 16).
+ * @param reuse_a: True when SrcA is held across the reuse dimension (ct_dim >= rt_dim), so the closing MVMUL releases SrcA; otherwise it releases SrcB.
+ * @note Call @ref _llk_math_matmul_init_no_mop_ with matching template args first this replays the buffer and addrmod slots it programmed.
+ */
+template <ckernel::MathFidelity MATH_FIDELITY_TYPE, bool ENABLE_2X_FORMAT = false>
+inline void _llk_math_matmul_run_no_mop_(const bool reuse_a)
+{
+    constexpr std::uint32_t FIDELITY_PHASES = MATH_FIDELITY_TYPE == ckernel::MathFidelity::LoFi ? 1 : to_underlying(MATH_FIDELITY_TYPE);
+    constexpr std::uint32_t replay_buf_len  = _llk_math_matmul_replay_buf_len_<ENABLE_2X_FORMAT>();
+
+    constexpr std::uint8_t matmul_op_addr_mod      = _llk_math_matmul_op_addr_mod_<ENABLE_2X_FORMAT>();
+    constexpr std::uint8_t matmul_op_last_addr_mod = _llk_math_matmul_op_last_addr_mod_<ENABLE_2X_FORMAT>();
+
+    // load_mode = 0 makes REPLAY issue replay_buffer[0 +: replay_buf_len] to Tensix instead of recording
+    // into it, which is what the MOP's LOOP_INSTR0 does. FIDELITY_PHASES is constexpr, so this unrolls.
+    for (std::uint32_t phase = 0; phase < FIDELITY_PHASES - 1; phase++)
+    {
+        TTI_REPLAY(0, replay_buf_len, 0, 0, 0, 0);
+        // matmul_op: close this fidelity phase, rewind dest to the start of the tile, advance the fidelity counter.
+        TTI_MVMUL(p_setrwc::CLR_NONE, 0, matmul_op_addr_mod, 0);
+    }
+
+    TTI_REPLAY(0, replay_buf_len, 0, 0, 0, 0);
+    // matmul_op_last: close the tile, advance dest to the next one, clear the fidelity counter, and
+    // release whichever operand is not being reused across the block row.
+    if (reuse_a)
+    {
+        TTI_MVMUL(p_setrwc::CLR_A, 0, matmul_op_last_addr_mod, 0);
+    }
+    else
+    {
+        TTI_MVMUL(p_setrwc::CLR_B, 0, matmul_op_last_addr_mod, 0);
+    }
+}
+
+/**
+ * @brief Initializes addrmods and the replay buffer for a matrix multiply that runs without a MOP.
+ *
+ * Input 0 dim = [rt_dim, 1], Input 1 dim = [1, ct_dim]; output is a matrix block of dimension [rt_dim, ct_dim].
+ * For DstSync::SyncHalf: ct_dim * rt_dim <= 8 tiles in a 16-bit format, ct_dim * rt_dim <= 4 tiles in a 32-bit format.
+ * For DstSync::SyncFull: ct_dim * rt_dim <= 16 tiles in a 16-bit format, ct_dim * rt_dim <= 8 tiles in a 32-bit format.
+ *
+ * @tparam MATH_FIDELITY_TYPE: Controls multiplication precision via the number of FPU fidelity phases; higher values use more of the input mantissa bits,
+ * values = <LoFi/HiFi2/HiFi3/HiFi4>
+ * @tparam ENABLE_2X_FORMAT: Enable matrix multiplication with MXFP_2X mode (double the performance)
+ * @param ct_dim: Number of tiles in the column dimension for a matrix multiply
+ * @param rt_dim: Number of tiles in the row dimension for a matrix multiply
+ * @note On the unpack thread, pair with @ref _llk_unpack_matmul_init_ (T0); on the pack thread, with @ref _llk_pack_init_ (T2).
+ * @note @ref _llk_math_matmul_block_no_mop_ runs the configured matmul with matching template args.
+ * @note Reload before every matmul that is interleaved with another replay-using op: every Quasar LLK
+ *       records its replay buffer at slot 0, so an intervening op overwrites this one's image. Unlike the
+ *       MOP path there is no MOP config holding the length, so a stale image would silently replay the
+ *       wrong instructions.
+ */
+template <ckernel::MathFidelity MATH_FIDELITY_TYPE, bool ENABLE_2X_FORMAT = false>
+inline void _llk_math_matmul_init_no_mop_(std::uint8_t ct_dim, std::uint8_t rt_dim)
+{
+    _llk_math_matmul_addrmod_<MATH_FIDELITY_TYPE, ENABLE_2X_FORMAT>(ct_dim, rt_dim);
+    _llk_math_matmul_load_replay_<ENABLE_2X_FORMAT>();
+
+    _reset_counters_<p_setrwc::SET_ABD_F>();
+}
+
+/**
+ * @brief Does matrix multiply operation of Input 0 * Input 1 -> SrcB * SrcA over a block of tiles, without a MOP.
+ *
+ * Input 0 dim = [rt_dim, 1], Input 1 dim = [1, ct_dim]; output is a matrix block of dimension [rt_dim, ct_dim].
+ * For DstSync::SyncHalf: ct_dim * rt_dim <= 8 tiles in a 16-bit format, ct_dim * rt_dim <= 4 tiles in a 32-bit format.
+ * For DstSync::SyncFull: ct_dim * rt_dim <= 16 tiles in a 16-bit format, ct_dim * rt_dim <= 8 tiles in a 32-bit format.
+ *
+ * IMPORTANT NOTES:
+ * 1. Dest index always assumed to start at 0 for this operation.
+ * 2. If matrix multiplication includes kt_dim > 1 such that matrix multiplication is:
+ *    Input 0 [rt_dim, kt_dim] x Input 1 [kt_dim, ct_dim] = Output [rt_dim, ct_dim],
+ *    be aware that this function does not iterate over kt_dim; iterate over kt_dim externally to this function.
+ *
+ * @tparam MATH_FIDELITY_TYPE: Controls multiplication precision via the number of FPU fidelity phases; higher values use more of the input mantissa bits,
+ * values = <LoFi/HiFi2/HiFi3/HiFi4>
+ * @tparam ENABLE_2X_FORMAT: Enable matrix multiplication with MXFP_2X mode (double the performance)
+ * @param ct_dim: Number of tiles in the column dimension for a matrix multiply
+ * @param rt_dim: Number of tiles in the row dimension for a matrix multiply
+ * @note Call @ref _llk_math_matmul_init_no_mop_ with matching template args before this function.
+ */
+template <ckernel::MathFidelity MATH_FIDELITY_TYPE, bool ENABLE_2X_FORMAT = false>
+inline void _llk_math_matmul_block_no_mop_(std::uint8_t ct_dim, std::uint8_t rt_dim)
+{
+    // Matmul Block, reset the dest addr to 0 for fused kernels
+    _set_dst_write_addr_<DstTileShape::Tile32x32>(0);
+
+    const bool reuse_a          = ct_dim >= rt_dim;
+    const std::uint32_t t_dim   = reuse_a ? rt_dim : ct_dim;
+    const std::uint32_t rut_dim = reuse_a ? ct_dim : rt_dim; // reuse-dim
+
+    for (std::uint32_t t = 0; t < t_dim; t++)
+    {
+        for (std::uint32_t rut = 0; rut < rut_dim; rut++)
+        {
+            _llk_math_matmul_run_no_mop_<MATH_FIDELITY_TYPE, ENABLE_2X_FORMAT>(reuse_a);
+
+            // Clear srcB or srcA at end of reuse (once per u block row)
+            if (rut == (rut_dim - 1))
+            {
+                if (reuse_a)
+                {
+                    TTI_SETRWC(p_setrwc::CLR_B, 0, 0, p_setrwc::SET_AB_F);
+                }
+                else
+                {
+                    TTI_SETRWC(p_setrwc::CLR_A, 0, 0, p_setrwc::SET_AB_F);
+                }
+            }
+        }
+
+        //  When rt_dim > ct_dim, the matmul block dest tile indices are not equal to 0,1,2,3..7
+        //  Instead they have a ct_dim stride, for instance:
+        //  If rt_dim = 4, ct_dim = 2, dest tile indices = 0,2,4,6,  1,3,5,7
+        //  If rt_dim = 4, ct_dim = 3, dest tile indices = 0,3,6,9,  1,4,7,10,  2,5,8,11
+        //  Below offsets by 1 tile * (t+1), for every subsequence above to start from the next dest_idx
+        if (!reuse_a && ct_dim >= 2)
+        {
+            TT_SETRWC(p_setrwc::CLR_NONE, 0, 64 * (t + 1), p_setrwc::SET_D);
+            TTI_SETRWC(p_setrwc::CLR_NONE, p_setrwc::C_TO_CR_MODE, 0, p_setrwc::SET_D);
+        }
+    }
+    _reset_counters_<p_setrwc::SET_ABD_F>();
+}

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_matmul.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_matmul.h
@@ -192,32 +192,63 @@ inline void _llk_math_matmul_di_addrmod_(std::uint8_t ct_dim, std::uint8_t rt_di
 }
 
 /**
- * @brief Initializes mop config for matrix multiply operation.
+ * @brief Number of MVMULs recorded into the replay buffer for one Tile x Tile matrix multiply.
  *
- * Input 0 dim = [rt_dim, 1], Input 1 dim = [1, ct_dim]; output is a matrix block of dimension [rt_dim, ct_dim].
- * For DstSync::SyncHalf: ct_dim * rt_dim <= 8 tiles in a 16-bit format, ct_dim * rt_dim <= 4 tiles in a 32-bit format.
- * For DstSync::SyncFull: ct_dim * rt_dim <= 16 tiles in a 16-bit format, ct_dim * rt_dim <= 8 tiles in a 32-bit format.
+ * One less than the total MVMUL count: the closing MVMUL of the Tile x Tile operation is issued from
+ * outside the replay buffer by the MOP in @ref _llk_math_matmul_mop_config_, or directly from the
+ * RISC core in the experimental no-MOP path.
  *
- * @tparam MATH_FIDELITY_TYPE: Controls multiplication precision via the number of FPU fidelity phases; higher values use more of the input mantissa bits,
- * values = <LoFi/HiFi2/HiFi3/HiFi4>
- * @tparam ENABLE_2X_FORMAT: When true, emits the non-DI MXFP4_2x variant (7-MVMUL replay traversing only A0/A1 and B0/B1; relies on SrcA being unpacked as
- * MxFp4_2x_A/B for the 2x sub-element expansion).
- * @param ct_dim: Number of tiles in the column dimension for a matrix multiply
- * @param rt_dim: Number of tiles in the row dimension for a matrix multiply
+ * @tparam ENABLE_2X_FORMAT: Select the MXFP4_2x traversal (8 MVMULs) instead of the plain one (16).
  */
-template <ckernel::MathFidelity MATH_FIDELITY_TYPE, bool ENABLE_2X_FORMAT = false>
-inline void _llk_math_matmul_mop_config_(std::uint8_t ct_dim, std::uint8_t rt_dim)
+template <bool ENABLE_2X_FORMAT>
+inline constexpr std::uint32_t _llk_math_matmul_replay_buf_len_()
+{
+    return ENABLE_2X_FORMAT ? (8 - 1) : (16 - 1);
+}
+
+/**
+ * @brief Addrmod slot used by the per-fidelity-phase closing MVMUL of a Tile x Tile matrix multiply.
+ *
+ * @tparam ENABLE_2X_FORMAT: Select the MXFP4_2x addrmod layout instead of the plain one.
+ * @note Paired with @ref _llk_math_matmul_op_last_addr_mod_; both slots are programmed by @ref _llk_math_matmul_addrmod_.
+ */
+template <bool ENABLE_2X_FORMAT>
+inline constexpr std::uint8_t _llk_math_matmul_op_addr_mod_()
+{
+    return ENABLE_2X_FORMAT ? ADDR_MOD_4 : ADDR_MOD_5;
+}
+
+/**
+ * @brief Addrmod slot used by the final MVMUL of a Tile x Tile matrix multiply (advances dest to the next tile).
+ *
+ * @tparam ENABLE_2X_FORMAT: Select the MXFP4_2x addrmod layout instead of the plain one.
+ * @note Paired with @ref _llk_math_matmul_op_addr_mod_; both slots are programmed by @ref _llk_math_matmul_addrmod_.
+ */
+template <bool ENABLE_2X_FORMAT>
+inline constexpr std::uint8_t _llk_math_matmul_op_last_addr_mod_()
+{
+    return ENABLE_2X_FORMAT ? ADDR_MOD_5 : ADDR_MOD_3;
+}
+
+/**
+ * @brief Records the MVMUL sequence for one Tile x Tile matrix multiply into replay buffer slot 0.
+ *
+ * Extracted from @ref _llk_math_matmul_mop_config_ so the experimental no-MOP matmul replays this exact
+ * sequence rather than restating it. Length is @ref _llk_math_matmul_replay_buf_len_.
+ *
+ * @tparam ENABLE_2X_FORMAT: When true, records the non-DI MXFP4_2x variant (7-MVMUL replay traversing only A0/A1 and B0/B1; relies on SrcA being unpacked as
+ * MxFp4_2x_A/B for the 2x sub-element expansion).
+ * @note Call @ref _llk_math_matmul_addrmod_ with the matching template args first, the recorded MVMULs select its addrmod slots.
+ */
+template <bool ENABLE_2X_FORMAT>
+inline void _llk_math_matmul_load_replay_()
 {
     // in0 - loaded to SrcB
     // in1 - loaded to SrcA
     // Unpacker will always load faces in f0,f1,f2,f3 order
     // if in1 is transposed then faces 1&2 need to be swapped during read
     // by changing address increment amount via addr_mods
-    constexpr std::uint32_t FIDELITY_PHASES = MATH_FIDELITY_TYPE == ckernel::MathFidelity::LoFi ? 1 : to_underlying(MATH_FIDELITY_TYPE);
-
-    const bool reuse_a = ct_dim >= rt_dim;
-
-    constexpr std::uint32_t replay_buf_len = ENABLE_2X_FORMAT ? (8 - 1) : (16 - 1);
+    constexpr std::uint32_t replay_buf_len = _llk_math_matmul_replay_buf_len_<ENABLE_2X_FORMAT>();
 
     if constexpr (ENABLE_2X_FORMAT)
     {
@@ -269,10 +300,39 @@ inline void _llk_math_matmul_mop_config_(std::uint8_t ct_dim, std::uint8_t rt_di
                 TTI_MVMUL(p_setrwc::CLR_NONE, 0, ADDR_MOD_0, 0); // B3A3 // srca=srca, srcb+=8,  dest+=8
             });
     }
+}
 
-    constexpr std::uint32_t matmul_op_addr_mod      = ENABLE_2X_FORMAT ? ADDR_MOD_4 : ADDR_MOD_5;
-    constexpr std::uint32_t matmul_op_last_addr_mod = ENABLE_2X_FORMAT ? ADDR_MOD_5 : ADDR_MOD_3;
-    constexpr static std::uint32_t matmul_op        = TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, matmul_op_addr_mod, 0);
+/**
+ * @brief Initializes mop config for matrix multiply operation.
+ *
+ * Input 0 dim = [rt_dim, 1], Input 1 dim = [1, ct_dim]; output is a matrix block of dimension [rt_dim, ct_dim].
+ * For DstSync::SyncHalf: ct_dim * rt_dim <= 8 tiles in a 16-bit format, ct_dim * rt_dim <= 4 tiles in a 32-bit format.
+ * For DstSync::SyncFull: ct_dim * rt_dim <= 16 tiles in a 16-bit format, ct_dim * rt_dim <= 8 tiles in a 32-bit format.
+ *
+ * Expands to FIDELITY_PHASES iterations of [REPLAY(0, replay_buf_len), matmul_op], with matmul_op_last
+ * replacing matmul_op in the final iteration.
+ *
+ * @tparam MATH_FIDELITY_TYPE: Controls multiplication precision via the number of FPU fidelity phases; higher values use more of the input mantissa bits,
+ * values = <LoFi/HiFi2/HiFi3/HiFi4>
+ * @tparam ENABLE_2X_FORMAT: When true, emits the non-DI MXFP4_2x variant (7-MVMUL replay traversing only A0/A1 and B0/B1; relies on SrcA being unpacked as
+ * MxFp4_2x_A/B for the 2x sub-element expansion).
+ * @param ct_dim: Number of tiles in the column dimension for a matrix multiply
+ * @param rt_dim: Number of tiles in the row dimension for a matrix multiply
+ */
+template <ckernel::MathFidelity MATH_FIDELITY_TYPE, bool ENABLE_2X_FORMAT = false>
+inline void _llk_math_matmul_mop_config_(std::uint8_t ct_dim, std::uint8_t rt_dim)
+{
+    constexpr std::uint32_t FIDELITY_PHASES = MATH_FIDELITY_TYPE == ckernel::MathFidelity::LoFi ? 1 : to_underlying(MATH_FIDELITY_TYPE);
+
+    const bool reuse_a = ct_dim >= rt_dim;
+
+    constexpr std::uint32_t replay_buf_len = _llk_math_matmul_replay_buf_len_<ENABLE_2X_FORMAT>();
+
+    _llk_math_matmul_load_replay_<ENABLE_2X_FORMAT>();
+
+    constexpr std::uint8_t matmul_op_addr_mod      = _llk_math_matmul_op_addr_mod_<ENABLE_2X_FORMAT>();
+    constexpr std::uint8_t matmul_op_last_addr_mod = _llk_math_matmul_op_last_addr_mod_<ENABLE_2X_FORMAT>();
+    constexpr static std::uint32_t matmul_op       = TT_OP_MVMUL(p_setrwc::CLR_NONE, 0, matmul_op_addr_mod, 0);
     const std::uint32_t matmul_op_last =
         reuse_a ? TT_OP_MVMUL(p_setrwc::CLR_A, 0, matmul_op_last_addr_mod, 0) : TT_OP_MVMUL(p_setrwc::CLR_B, 0, matmul_op_last_addr_mod, 0);
 


### PR DESCRIPTION
### PR Category
Feature

### Summary
Closes #52329.

Adds the MOP-less matmul path for Quasar (llk_math_matmul_*_no_mop) and brings up api/compute/experimental/matmul_custom.h on Quasar, needed for the ChatGPT-OSS models.

The no-MOP path issues the same REPLAY + MVMUL-per-fidelity-phase stream straight from the RISC core that MOP BANK0 would expand, so numerics are unchanged and BANK0 is left free for a fused op. MXFP4_2x is covered.

  - LLK: new tt_llk_quasar/llk_lib/experimental/llk_math_matmul_custom_no_mop.h; the replay-buffer image and addrmod slots are factored out of llk_math_matmul.h and shared with the MOP path.
  - Metal llk_api: llk_math_matmul_init_no_mop / llk_math_matmul_no_mop / llk_math_matmul_reinit_no_mop, signature-matched to WH/BH so the shared Compute API needs no arch branch. Same reason for the new runtime-transpose overload of llk_unpack_AB_matmul_init.
  - Tests: tt-llk test_matmul_custom_no_mop_quasar.py (format / fidelity / dest-acc / dimension sweep + a dedicated MXFP4_2x sweep) and metal TensixTestSingleCoreComputeMatmulNoMop (blocked matmul through the Compute API, golden + PCC).

### Notes for reviewers
  - The refactor in llk_math_matmul.h is the main risk to existing code: _llk_math_matmul_mop_config_ now pulls the replay length and the two addrmod slots from shared constexpr helpers instead of computing them inline. The MOP path should be behaviourally identical, worth a second pair of eyes on that equivalence.
  - matmul_no_mop_is_2x_format re-derives 2x-ness per call rather than caching it at init, to keep the execute path stateless. The MOP path holds this implicitly in its MOP config, which the no-MOP path gives up by definition.
  - transpose != 0 and THROTTLE_LEVEL != 0 are rejected (assert / static_assert) rather than silently ignored, neither exists on Quasar. The parameters are kept only for signature parity with WH/BH.
  - mm_no_mop_reinit_short exists for the case where an interleaved op records over replay buffer slot 0; if you know of a fused-op pattern that hits this, it'd be good to confirm the reinit is sufficient.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skotarac/matmul_mopless)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skotarac/matmul_mopless)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skotarac/matmul_mopless)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skotarac/matmul_mopless)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skotarac/matmul_mopless)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skotarac/matmul_mopless)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skotarac/matmul_mopless)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skotarac/matmul_mopless)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skotarac/matmul_mopless)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skotarac/matmul_mopless)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skotarac/matmul_mopless)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skotarac/matmul_mopless)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skotarac/matmul_mopless)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skotarac/matmul_mopless)