### PR TITLE
[ai summary] cover all sanity-tests legs with per-job and per-run summaries

### DIFF
--- a/.github/workflows/blackhole-multi-card-sanity-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-sanity-tests-impl.yaml
@@ -30,6 +30,15 @@ on:
         type: string
         default: ""
         description: "Commit SHA to test (default: HEAD)"
+      summary-scope:
+        required: false
+        type: string
+        default: ""
+        description: "Discriminator for the AI summaries when the calling workflow is invoked more than once per run"
+    outputs:
+      matrix:
+        description: "Filtered matrix of legs that ran (consumed by ai_summary/run for INFRA_FAILURE reconciliation)"
+        value: ${{ jobs.load-test-matrix.outputs.matrix }}
 
 jobs:
   load-test-matrix:
@@ -134,7 +143,7 @@ jobs:
         uses: tenstorrent/tt-metal/.github/actions/generate-gtest-failure-message@main
         if: ${{ failure() }}
       - name: 🤖 AI job summary
-        if: always() && !cancelled()
+        if: ${{ !cancelled() }}
         continue-on-error: true
         uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
         with:
@@ -143,47 +152,11 @@ jobs:
               "model": "${{ vars.AI_SUMMARY_MODEL }}",
               "workspace": "$GITHUB_WORKSPACE/docker-job",
               "input_dirs": ["generated/test_logs"],
-              "output_dir": "generated/ai_summaries"
+              "output_dir": "generated/ai_summaries",
+              "scope": "${{ inputs.summary-scope }}"
             }
           api-key: ${{ secrets.TT_CHAT_API_KEY }}
           api-url: ${{ secrets.TT_CHAT_URL }}
           job-name: ${{ matrix.test-group.name }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()
-
-  ai-run-summary:
-    name: "AI Run Summary"
-    needs: [load-test-matrix, multi-card-unit-tests]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        timeout-minutes: 20
-      - id: ai-run-summary
-        continue-on-error: true
-        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/run@main
-        with:
-          config: |
-            {
-              "model": "${{ vars.AI_SUMMARY_MODEL }}",
-              "workspace": "$GITHUB_WORKSPACE",
-              "input_dir": "ai_job_summaries",
-              "output_dir": "ai_run_summaries"
-            }
-          api-key: ${{ secrets.TT_CHAT_API_KEY }}
-          api-url: ${{ secrets.TT_CHAT_URL }}
-          expected-jobs: ${{ needs.load-test-matrix.outputs.matrix }}
-          run-result: ${{ needs.multi-card-unit-tests.result }}
-      - name: Show report
-        if: always() && steps.ai-run-summary.outputs.report-file != ''
-        continue-on-error: true
-        shell: bash
-        env:
-          REPORT_FILE: ${{ steps.ai-run-summary.outputs.report-file }}
-        run: |
-          if [ -f "$REPORT_FILE" ]; then
-            cat "$REPORT_FILE"
-            cat "$REPORT_FILE" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "::warning::Report file not found: $REPORT_FILE"
-          fi

--- a/.github/workflows/ops-sanity-impl.yaml
+++ b/.github/workflows/ops-sanity-impl.yaml
@@ -38,6 +38,15 @@ on:
         type: string
         default: ""
         description: "Commit SHA to test (default: HEAD)"
+      summary-scope:
+        required: false
+        type: string
+        default: ""
+        description: "Discriminator for the AI summaries when the calling workflow is invoked more than once per run"
+    outputs:
+      matrix:
+        description: "Filtered matrix of legs that ran (consumed by ai_summary/run for INFRA_FAILURE reconciliation)"
+        value: ${{ jobs.load-test-matrix.outputs.matrix }}
 
 jobs:
   load-test-matrix:
@@ -117,23 +126,32 @@ jobs:
 
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        env:
-          TRACY_NO_INVARIANT_CHECK: 1
-          _TEST_CMD: ${{ matrix.test-group.cmd }}
-        run: |
-          if [ "${{ matrix.test-group.slow_dispatch }}" = "true" ]; then
-            export TT_METAL_SLOW_DISPATCH_MODE=1
-          fi
-          python3 tools/tt-power-sidecar/tt_power_sidecar.py \
-            --backend sysfs \
-            --out /work/power_report.json \
-            -- bash -c "$_TEST_CMD"
+        uses: ./docker-job/.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          # Step-level env does not reach a composite action's script (see
+          # .github/actions/run-with-log/README.md), so the cmd arrives via a
+          # quoted heredoc: the shell running this body never expands it, and
+          # the delimiter must not appear in any test-group cmd.
+          run: |
+            export TRACY_NO_INVARIANT_CHECK=1
+            _TEST_CMD=$(cat <<'TEST_CMD_EOF'
+            ${{ matrix.test-group.cmd }}
+            TEST_CMD_EOF
+            )
+            if [ "${{ matrix.test-group.slow_dispatch }}" = "true" ]; then
+              export TT_METAL_SLOW_DISPATCH_MODE=1
+            fi
+            python3 tools/tt-power-sidecar/tt_power_sidecar.py \
+              --backend sysfs \
+              --out /work/power_report.json \
+              -- bash -c "$_TEST_CMD"
 
-          # Device perf branch
-          export DEVICE_PERF_REPORT_FILENAME="Ops_Perf.csv"
-          python3 models/perf/merge_device_perf_results.py "$DEVICE_PERF_REPORT_FILENAME" REPORT
-          echo "Showing ops perf report... will fail if not found"
-          cat $DEVICE_PERF_REPORT_FILENAME
+            # Device perf branch
+            export DEVICE_PERF_REPORT_FILENAME="Ops_Perf.csv"
+            python3 models/perf/merge_device_perf_results.py "$DEVICE_PERF_REPORT_FILENAME" REPORT
+            echo "Showing ops perf report... will fail if not found"
+            cat $DEVICE_PERF_REPORT_FILENAME
 
       - name: Upload power report
         if: ${{ !cancelled() }}
@@ -158,5 +176,21 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
+      - name: 🤖 AI job summary
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "input_dirs": ["generated/test_logs"],
+              "output_dir": "generated/ai_summaries",
+              "scope": "${{ inputs.summary-scope }}"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()

--- a/.github/workflows/runtime-sanity-tests-impl.yaml
+++ b/.github/workflows/runtime-sanity-tests-impl.yaml
@@ -21,6 +21,15 @@ on:
         type: string
         default: ""
         description: "Commit SHA to test (default: HEAD)"
+      summary-scope:
+        required: false
+        type: string
+        default: ""
+        description: "Discriminator for the AI summaries when the calling workflow is invoked more than once per run"
+    outputs:
+      matrix:
+        description: "Filtered matrix of legs that ran (consumed by ai_summary/run for INFRA_FAILURE reconciliation)"
+        value: ${{ jobs.load-test-matrix.outputs.matrix }}
 
 jobs:
   load-test-matrix:
@@ -146,24 +155,32 @@ jobs:
       - name: ${{ matrix.test-group.name }}
         if: ${{ !startsWith(matrix.test-group.sku, 'sim_') }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          mkdir -p generated/test_reports
-          echo "${{ matrix.test-group.cmd }}"
-          ${{ matrix.test-group.cmd }}
+        uses: ./docker-job/.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: |
+            mkdir -p generated/test_reports
+            echo "${{ matrix.test-group.cmd }}"
+            ${{ matrix.test-group.cmd }}
+      # The HW and simulator steps are mutually exclusive by SKU, so one log
+      # filename is safe for both.
       - name: ${{ matrix.test-group.name }} (simulator)
         if: ${{ startsWith(matrix.test-group.sku, 'sim_') }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          mkdir -p generated/test_reports
-          echo "${{ matrix.test-group.cmd }}"
-          cat > /tmp/sim_cmd.sh <<'SIM_CMD_EOF'
-          ${{ matrix.test-group.cmd }}
-          SIM_CMD_EOF
-          .github/scripts/utils/host-load-sidecar.sh \
-            --interval 1 \
-            --label "${{ matrix.test-group.name }} (simulator)" \
-            --output /work/mem_report.json \
-            -- bash --noprofile --norc -eo pipefail /tmp/sim_cmd.sh
+        uses: ./docker-job/.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: |
+            mkdir -p generated/test_reports
+            echo "${{ matrix.test-group.cmd }}"
+            cat > /tmp/sim_cmd.sh <<'SIM_CMD_EOF'
+            ${{ matrix.test-group.cmd }}
+            SIM_CMD_EOF
+            .github/scripts/utils/host-load-sidecar.sh \
+              --interval 1 \
+              --label "${{ matrix.test-group.name }} (simulator)" \
+              --output /work/mem_report.json \
+              -- bash --noprofile --norc -eo pipefail /tmp/sim_cmd.sh
       - name: Upload mem report
         if: ${{ !cancelled() && startsWith(matrix.test-group.sku, 'sim_') }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -180,6 +197,22 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
+      - name: 🤖 AI job summary
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "input_dirs": ["generated/test_logs"],
+              "output_dir": "generated/ai_summaries",
+              "scope": "${{ inputs.summary-scope }}"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}
       - uses: tenstorrent/tt-metal/.github/actions/slack-report@main
         if: ${{ failure() }}
         with:

--- a/.github/workflows/sanity-tests.yaml
+++ b/.github/workflows/sanity-tests.yaml
@@ -93,6 +93,11 @@ on:
         type: string
         default: ""
         description: "Commit SHA to test (default: HEAD)"
+      publish-run-summary:
+        required: false
+        type: boolean
+        default: true
+        description: "Publish the AI run summary. A caller that invokes this workflow more than once per run must pass false on all but one invocation, or the reports collide on the artifact name."
   workflow_dispatch:
     inputs:
       with-retries:
@@ -339,6 +344,7 @@ jobs:
     if: ${{ always() && !cancelled() && needs.build-artifact.result == 'success' && needs.generate-sku-matrix.outputs.sanity-skus != '' && toJSON(inputs.run-ttnn-sanity-tests) != 'false' }}
     uses: ./.github/workflows/ttnn-sanity-tests-impl.yaml
     with:
+      summary-scope: ${{ inputs.platform }}
       # HW and sim SKUs share one call; sim_* SKUs run on ubuntu-latest (no Harbor access), so this
       # uses the canonical GHCR image from build-artifact (not the Harbor-resolved ref).
       enabled-skus: ${{ needs.generate-sku-matrix.outputs.sanity-skus }}
@@ -356,6 +362,7 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/t3000-sanity-tests-impl.yaml
     with:
+      summary-scope: ${{ inputs.platform }}
       enabled-skus: "wh_llmbox_civ2"
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
@@ -373,6 +380,7 @@ jobs:
     if: ${{ always() && !cancelled() && needs.resolve-docker-pull-refs.result == 'success' && needs.build-artifact.result == 'success' && (needs.generate-sku-matrix.outputs.run-wormhole == 'true' || needs.generate-sku-matrix.outputs.run-blackhole == 'true') && toJSON(inputs.run-ops-sanity-tests) != 'false' }}
     uses: ./.github/workflows/ops-sanity-impl.yaml
     with:
+      summary-scope: ${{ inputs.platform }}
       docker-image: ${{ needs.resolve-docker-pull-refs.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
@@ -389,6 +397,7 @@ jobs:
     if: ${{ always() && !cancelled() && needs.resolve-docker-pull-refs.result == 'success' && needs.build-artifact.result == 'success' && needs.generate-sku-matrix.outputs.run-blackhole == 'true' && toJSON(inputs.run-umd-sanity-tests) != 'false' }}
     uses: ./.github/workflows/umd-sanity-tests-impl.yaml
     with:
+      summary-scope: ${{ inputs.platform }}
       enabled-skus: ${{ needs.generate-sku-matrix.outputs.bh-skus }}
       docker-image: ${{ needs.resolve-docker-pull-refs.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
@@ -402,6 +411,7 @@ jobs:
     uses: ./.github/workflows/ttsim-sanity-tests-impl.yaml
     secrets: inherit
     with:
+      summary-scope: ${{ inputs.platform }}
       basic-docker-image: ${{ needs.build-artifact.outputs.basic-dev-docker-image }}
       package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
       ref: ${{ inputs.ref || github.sha }}
@@ -412,6 +422,7 @@ jobs:
     uses: ./.github/workflows/runtime-sanity-tests-impl.yaml
     secrets: inherit
     with:
+      summary-scope: ${{ inputs.platform }}
       docker-image: ${{ needs.build-artifact.outputs.ci-test-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
@@ -426,9 +437,118 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/blackhole-multi-card-sanity-tests-impl.yaml
     with:
+      summary-scope: ${{ inputs.platform }}
       enabled-skus: ${{ needs.generate-sku-matrix.outputs.sanity-skus }}
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
       ref: ${{ inputs.ref || github.sha }}
+
+  # ── AI run summary ────────────────────────────────────────────────
+  # Aggregates the per-leg ai-job-summary artifacts from the sanity impls this
+  # workflow invokes (galaxy-sanity-impl is driven by galaxy-sanity.yaml and is
+  # not covered) into one run-level report. expected-jobs is the union of each
+  # impl's matrix, so a leg whose runner died is reported as an infra failure
+  # rather than silently dropped. A new impl must be added to `needs:` below or
+  # its legs are absent from that union with no error.
+  #
+  # build-artifact and the matrix jobs are in `needs:` because every impl is
+  # gated on them: when a build fails the impls are *skipped*, not failed, and
+  # without them the combined result would be `skipped` — which suppresses
+  # infra synthesis entirely and reports a broken run as if nothing was due.
+  ai-run-summary:
+    name: "AI Run Summary"
+    needs:
+      - build-artifact
+      - resolve-docker-pull-refs
+      - generate-sku-matrix
+      - ttnn-sanity-tests
+      - t3000-sanity-tests
+      - ops-sanity-tests
+      - umd-sanity-tests
+      - ttsim-sanity-tests
+      - runtime-sim-sanity-tests
+      - blackhole-multi-card-fast-sanity-tests
+    # always(): a cancelled run still reports on the legs that finished. A
+    # cancelled child contributes no expected-jobs, so its unfinished legs are
+    # not stubbed as infra failures.
+    #
+    # A caller that invokes this workflow twice per run (sanity-tests-debug)
+    # passes false, so the two reports don't collide on the artifact name.
+    # The github.workflow arm covers this workflow's own push/schedule triggers,
+    # where the `inputs` context is empty and the default above never applies;
+    # it is the caller's workflow name for a workflow_call, so it is false there.
+    if: ${{ always() && (inputs.publish-run-summary || github.workflow == 'Sanity tests') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 20
+        with:
+          filter: blob:none
+          sparse-checkout: .github
+      - name: Aggregate child matrices and results
+        id: aggregate
+        # Reporting must never fail the run: a jq error here would turn a green
+        # sanity run red.
+        continue-on-error: true
+        env:
+          # toJSON(needs) is one object keyed by child job name, each with
+          # `result` and `outputs.matrix`; aggregating from it keeps this
+          # data-driven as impls are added to or removed from the `needs` list.
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          # Expected legs come from the children that ran. A cancelled child
+          # keeps a successful load-test-matrix, so including it would stub its
+          # legs as INFRA_FAILURE when another child failed; skipped children
+          # expose a null/empty matrix, which fromjson would throw on.
+          RAN=$(jq -cn --argjson n "$NEEDS" '
+            [$n[] | select(.result != "cancelled" and .result != "skipped")]')
+
+          EXPECTED=$(jq -cn --argjson r "$RAN" '
+            [$r[] | .outputs.matrix | select(. != null and . != "") | fromjson] | add // []')
+          echo "expected-jobs=$EXPECTED" >> "$GITHUB_OUTPUT"
+          echo "Merged $(echo "$EXPECTED" | jq 'length') expected legs"
+
+          # Most-severe-wins over every child, so a cancelled run says so in the
+          # report instead of reading as a clean pass. Upstream also treats
+          # cancelled/skipped as "expect nothing", which is what we want: legs
+          # that never finished were aborted, not infra failures.
+          RESULT=$(jq -rn --argjson n "$NEEDS" '
+            [$n[].result] as $s |
+            if   any($s[]; . == "failure")   then "failure"
+            elif any($s[]; . == "cancelled") then "cancelled"
+            elif any($s[]; . == "success")   then "success"
+            else                                  "skipped"
+            end')
+          echo "run-result=$RESULT" >> "$GITHUB_OUTPUT"
+          echo "Combined run-result: $RESULT"
+      - id: ai-run-summary
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/run@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE",
+              "input_dir": "ai_job_summaries",
+              "output_dir": "ai_run_summaries",
+              "scope": "${{ inputs.platform }}"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          expected-jobs: ${{ steps.aggregate.outputs.expected-jobs }}
+          run-result: ${{ steps.aggregate.outputs.run-result }}
+      - name: Show report
+        if: ${{ always() && steps.ai-run-summary.outputs.report-file != '' }}
+        continue-on-error: true
+        shell: bash
+        env:
+          REPORT_FILE: ${{ steps.ai-run-summary.outputs.report-file }}
+        run: |
+          if [ -f "$REPORT_FILE" ]; then
+            cat "$REPORT_FILE"
+            cat "$REPORT_FILE" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::Report file not found: $REPORT_FILE"
+          fi

--- a/.github/workflows/t3000-sanity-tests-impl.yaml
+++ b/.github/workflows/t3000-sanity-tests-impl.yaml
@@ -46,6 +46,15 @@ on:
         type: string
         default: ""
         description: "Comma-separated test names from t3000_sanity_tests.yaml to run (default: all)."
+      summary-scope:
+        required: false
+        type: string
+        default: ""
+        description: "Discriminator for the AI summaries when the calling workflow is invoked more than once per run"
+    outputs:
+      matrix:
+        description: "Filtered matrix of legs that ran (consumed by ai_summary/run for INFRA_FAILURE reconciliation)"
+        value: ${{ jobs.load-test-matrix.outputs.matrix }}
 
 jobs:
   load-test-matrix:
@@ -153,14 +162,23 @@ jobs:
 
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ inputs.timeout-minutes-override > 0 && inputs.timeout-minutes-override || matrix.test-group.timeout }}
-        env:
-          _TEST_CMD: ${{ matrix.test-group.cmd }}
-        run: |
-          mkdir -p generated/test_reports
-          python3 tools/tt-power-sidecar/tt_power_sidecar.py \
-            --backend sysfs \
-            --out /work/power_report.json \
-            -- bash -c "$_TEST_CMD"
+        uses: ./docker-job/.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          # run-with-log is a composite action, which does not inherit step-level
+          # env, so the test command is materialised via a quoted heredoc rather
+          # than passed inline to `bash -c` — this keeps its embedded quoting
+          # intact and prevents injection into the sidecar command line.
+          run: |
+            mkdir -p generated/test_reports
+            _TEST_CMD=$(cat <<'TEST_CMD_EOF'
+            ${{ matrix.test-group.cmd }}
+            TEST_CMD_EOF
+            )
+            python3 tools/tt-power-sidecar/tt_power_sidecar.py \
+              --backend sysfs \
+              --out /work/power_report.json \
+              -- bash -c "$_TEST_CMD"
 
       - name: Upload power report
         if: ${{ !cancelled() }}
@@ -223,5 +241,21 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
+      - name: 🤖 AI job summary
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "input_dirs": ["generated/test_logs"],
+              "output_dir": "generated/ai_summaries",
+              "scope": "${{ inputs.summary-scope }}"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()

--- a/.github/workflows/ttnn-sanity-tests-impl.yaml
+++ b/.github/workflows/ttnn-sanity-tests-impl.yaml
@@ -61,6 +61,15 @@ on:
         type: string
         default: "1000"
         description: "perf sample frequency in Hz"
+      summary-scope:
+        required: false
+        type: string
+        default: ""
+        description: "Discriminator for the AI summaries when the calling workflow is invoked more than once per run"
+    outputs:
+      matrix:
+        description: "Filtered matrix of legs that ran (consumed by ai_summary/run for INFRA_FAILURE reconciliation)"
+        value: ${{ jobs.load-test-matrix.outputs.matrix }}
 
 jobs:
   load-test-matrix:
@@ -246,14 +255,18 @@ jobs:
       # exist). All are no-ops (skipped) when the experiment is disabled, so there is zero
       # overhead on the default path.
       #
-      # SECURITY: user-controlled inputs (perf-target-group, perf-install-package) are never
-      # interpolated into a shell body via ${{ ... }}; they are passed through `env:` and only
-      # expanded as quoted "$VAR" at runtime so they cannot inject shell.
+      # SECURITY: user-controlled inputs (perf-target-group, perf-install-package,
+      # perf-sample-frequency) are never interpolated into a shell body via ${{ ... }}; they are
+      # passed through `env:` and only expanded as quoted "$VAR" at runtime so they cannot inject
+      # shell. run-with-log is a composite action and does not see step-level `env:`, so a value
+      # its body needs goes through $GITHUB_ENV instead.
       - name: Validate perf profiling target (host profiling)
         if: ${{ inputs.enable-perf-host-profiling && !startsWith(matrix.test-group.sku, 'sim_') }}
         env:
           PERF_TARGET_GROUP: ${{ inputs.perf-target-group }}
+          PERF_SAMPLE_FREQUENCY: ${{ inputs.perf-sample-frequency }}
         run: |
+          echo "PERF_SAMPLE_FREQUENCY=$PERF_SAMPLE_FREQUENCY" >> "$GITHUB_ENV"
           if [ -z "$PERF_TARGET_GROUP" ]; then
             echo "::error::enable-perf-host-profiling is true but perf-target-group is empty."
             echo "::error::You must supply the exact matrix test-group name to profile (e.g. 'ttnn eltwise group 1')."
@@ -306,57 +319,59 @@ jobs:
       - name: ${{ matrix.test-group.name }} tests
         if: ${{ !startsWith(matrix.test-group.sku, 'sim_') }}
         timeout-minutes: ${{ inputs.timeout-minutes-override > 0 && inputs.timeout-minutes-override || matrix.test-group.timeout }}
-        env:
-          # Cap PyTorch/ATen host-side OpenMP threads and use passive waiting. A brief host
-          # reference-tensor op is enough to spin up the OpenMP/MKL thread pool; its worker
-          # threads then busy-wait for the rest of the job — including while the device is
-          # doing the actual (much longer) work — which is where most of the CPU burn comes from.
-          OMP_NUM_THREADS: 2
-          MKL_NUM_THREADS: 2
-          OMP_WAIT_POLICY: passive
-          # Whether THIS matrix leg should be profiled: experiment on + this is the chosen HW group.
-          # (Never true on sim legs — this step's `if` already excludes sim_* SKUs.)
-          PERF_PROFILE_THIS: ${{ inputs.enable-perf-host-profiling && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) }}
-          # Whether the probe confirmed perf can actually record. Empty when the probe step was
-          # skipped (experiment off / not the target group); treated as "not ready".
-          PERF_READY: ${{ steps.perf-probe.outputs.perf_ready }}
-          PERF_SAMPLE_FREQUENCY: ${{ inputs.perf-sample-frequency }}
-          PERF_TARGET_GROUP: ${{ inputs.perf-target-group }}
-          TEST_GROUP_NAME: ${{ matrix.test-group.name }}
-          TEST_GROUP_CMD: ${{ matrix.test-group.cmd }}
-        run: |
-          # Build the inner command passed to the power sidecar's `bash -c`. Use a shell variable
-          # for the pytest command (from $TEST_GROUP_CMD) to avoid YAML/shell quoting hell.
-          #
-          # Non-profiled path (default): byte-for-byte the original behaviour — run the group cmd
-          # directly under the power sidecar.
-          # Profiled path (experiment): wrap the group cmd in `perf record -g -F <freq> -o <out>`,
-          # writing perf.data to /work so the host mount at ${{ github.workspace }}/docker-job can
-          # upload it. Only wrap when the recording-capability probe (perf-probe step) succeeded;
-          # otherwise fall back to running the cmd unwrapped so the group still tests.
-          #
-          # The whole group cmd is wrapped in `perf record ... -- bash -c '<cmd>'` so that a group
-          # command with chained commands (e.g. `pytest ... && pytest ...`) is captured in full,
-          # not just the first simple command. $TEST_GROUP_CMD is passed as a positional arg to the
-          # inner `bash -c` (see the sidecar invocation below), never spliced into a string, so its
-          # &&/quotes survive intact and it can't inject into the perf command line.
-          if [ "$PERF_PROFILE_THIS" = "true" ] && [ "$PERF_READY" = "true" ]; then
-            # Sanitize the group name for use in a filename: spaces and any non [A-Za-z0-9._-] -> '_'.
-            SANITIZED=$(printf '%s' "$TEST_GROUP_NAME" | sed -E 's/[^A-Za-z0-9._-]+/_/g')
-            PERF_OUTPUT="/work/perf_${SANITIZED}.data"
-            echo "perf host profiling ENABLED for '$TEST_GROUP_NAME' -> $PERF_OUTPUT (freq ${PERF_SAMPLE_FREQUENCY}Hz)"
-            RUNNER=(perf record -g -F "${PERF_SAMPLE_FREQUENCY}" -o "${PERF_OUTPUT}" -- bash -c "$TEST_GROUP_CMD")
-          else
-            if [ "$PERF_PROFILE_THIS" = "true" ]; then
-              echo "::warning::perf recording not available; running '$TEST_GROUP_NAME' without profiling."
+        uses: ./docker-job/.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: |
+            # Step-level env does not reach a composite action's script (see
+            # .github/actions/run-with-log/README.md), so every value this body
+            # needs is set here. TEST_GROUP_CMD arrives via a quoted heredoc, so
+            # the shell running this body never expands it — the delimiter must
+            # not appear in any test-group cmd.
+            # Cap PyTorch/ATen host-side OpenMP threads and wait passively. A brief
+            # host reference-tensor op spins up the OpenMP/MKL pool, whose workers
+            # then busy-wait for the rest of the job — including while the device
+            # does the much longer real work. That is most of the CPU burn.
+            export OMP_NUM_THREADS=2
+            export MKL_NUM_THREADS=2
+            export OMP_WAIT_POLICY=passive
+            # Whether THIS matrix leg should be profiled: experiment on + this is the chosen HW group.
+            # (Never true on sim legs — this step's `if` already excludes sim_* SKUs.)
+            PERF_PROFILE_THIS="${{ inputs.enable-perf-host-profiling && matrix.test-group.name == format('{0} [{1}]', inputs.perf-target-group, matrix.test-group.sku) }}"
+            # Whether the probe confirmed perf can actually record. Empty when the probe step was
+            # skipped (experiment off / not the target group); treated as "not ready".
+            PERF_READY="${{ steps.perf-probe.outputs.perf_ready }}"
+            TEST_GROUP_NAME="${{ matrix.test-group.name }}"
+            TEST_GROUP_CMD=$(cat <<'TEST_CMD_EOF'
+            ${{ matrix.test-group.cmd }}
+            TEST_CMD_EOF
+            )
+            # Non-profiled path (default): run the group cmd directly under the power sidecar.
+            # Profiled path (experiment): wrap the group cmd in `perf record -g -F <freq> -o <out>`,
+            # writing perf.data to /work so the host mount at ${{ github.workspace }}/docker-job can
+            # upload it. Only wrap when the recording-capability probe (perf-probe step) succeeded;
+            # otherwise fall back to running the cmd unwrapped so the group still tests.
+            #
+            # The whole group cmd is wrapped in `bash -c "$TEST_GROUP_CMD"` so that a group command
+            # with chained commands (e.g. `pytest ... && pytest ...`) is captured in full, not just
+            # the first simple command.
+            if [ "$PERF_PROFILE_THIS" = "true" ] && [ "$PERF_READY" = "true" ]; then
+              # Sanitize the group name for use in a filename: spaces and any non [A-Za-z0-9._-] -> '_'.
+              SANITIZED=$(printf '%s' "$TEST_GROUP_NAME" | sed -E 's/[^A-Za-z0-9._-]+/_/g')
+              PERF_OUTPUT="/work/perf_${SANITIZED}.data"
+              echo "perf host profiling ENABLED for '$TEST_GROUP_NAME' -> $PERF_OUTPUT (freq ${PERF_SAMPLE_FREQUENCY}Hz)"
+              RUNNER=(perf record -g -F "${PERF_SAMPLE_FREQUENCY}" -o "${PERF_OUTPUT}" -- bash -c "$TEST_GROUP_CMD")
+            else
+              if [ "$PERF_PROFILE_THIS" = "true" ]; then
+                echo "::warning::perf recording not available; running '$TEST_GROUP_NAME' without profiling."
+              fi
+              RUNNER=(bash -c "$TEST_GROUP_CMD")
             fi
-            RUNNER=(bash -c "$TEST_GROUP_CMD")
-          fi
 
-          python3 tools/tt-power-sidecar/tt_power_sidecar.py \
-            --backend sysfs \
-            --out /work/power_report.json \
-            -- "${RUNNER[@]}"
+            python3 tools/tt-power-sidecar/tt_power_sidecar.py \
+              --backend sysfs \
+              --out /work/power_report.json \
+              -- "${RUNNER[@]}"
 
       # Simulator runs have no hardware power telemetry, so swap the HW power sidecar for the
       # host-load sidecar — it reports host CPU/memory/disk/network usage (a "mem report", not
@@ -365,41 +380,46 @@ jobs:
       - name: ${{ matrix.test-group.name }} tests (simulator)
         if: ${{ startsWith(matrix.test-group.sku, 'sim_') }}
         timeout-minutes: ${{ inputs.timeout-minutes-override > 0 && inputs.timeout-minutes-override || matrix.test-group.timeout }}
-        env:
-          PYTEST_ADDOPTS: "-p no:timeout -n 4 ${{ startsWith(matrix.test-group.sku, 'sim_wh') && needs.load-test-matrix.outputs.skip-args-wormhole_b0 || startsWith(matrix.test-group.sku, 'sim_bh') && needs.load-test-matrix.outputs.skip-args-blackhole || '' }}"
-          # Cap PyTorch/ATen host-side OpenMP threads and use passive waiting. A brief host
-          # reference-tensor op is enough to spin up the OpenMP/MKL thread pool; its worker
-          # threads then busy-wait for the rest of the job, which is where most of the CPU
-          # burn comes from — not the (much shorter) reference-tensor computation itself.
-          OMP_NUM_THREADS: 2
-          MKL_NUM_THREADS: 2
-          OMP_WAIT_POLICY: passive
-        run: |
-          # Strip the per-test `pytest --timeout N` from the cmd: the simulator is ~10-50x slower than
-          # HW, so that per-op limit kills slow-but-correct ops (the job timeout-minutes is the backstop;
-          # PYTEST_ADDOPTS also sets -p no:timeout). Run that cmd with xdist; if a worker crashes (xdist
-          # only reports "worker crashed"), re-run serially (drop -n 4 via the PYTEST_ADDOPTS override)
-          # with --lf for actionable diagnostics.
-          export cmd=$(printf '%s' '${{ matrix.test-group.cmd }}' | sed -E 's/[[:space:]]+--timeout[[:space:]]+[0-9]+//g')
-          # PYTEST_ADDOPTS for the serial fallback re-run (drops -n 4); applied only on retry.
-          export SERIAL_ADDOPTS="-p no:timeout ${{ startsWith(matrix.test-group.sku, 'sim_wh') && needs.load-test-matrix.outputs.skip-args-wormhole_b0 || startsWith(matrix.test-group.sku, 'sim_bh') && needs.load-test-matrix.outputs.skip-args-blackhole || '' }}"
-          # Wrap the whole sim run in the host-load sidecar so its usage report covers both
-          # the parallel run and any serial re-run. Written to /work/mem_report.json (even
-          # on failure — emitted before the sidecar exits) so the Upload mem report step
-          # picks it up. The sidecar is the final command, so it propagates the run's exit code.
-          .github/scripts/utils/host-load-sidecar.sh \
-            --interval 1 \
-            --label "${{ matrix.test-group.name }} (simulator)" \
-            --output /work/mem_report.json \
-            -- bash -c '
-              if eval "$cmd"; then
-                exit 0
-              fi
-              echo "::warning::Parallel run failed. Re-running failed tests serially for clear diagnostics..."
-              export PYTEST_ADDOPTS="$SERIAL_ADDOPTS"
-              eval "$cmd --lf --lfnf=all --tb=long -v" || true
-              exit 1
-            '
+        uses: ./docker-job/.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: |
+            # Step-level env does not reach a composite action's script (see
+            # .github/actions/run-with-log/README.md), so every value this body
+            # needs is set here.
+            # Cap PyTorch/ATen host-side OpenMP threads and wait passively. A brief
+            # host reference-tensor op spins up the OpenMP/MKL pool, whose workers
+            # then busy-wait for the rest of the job — including while the device
+            # does the much longer real work. That is most of the CPU burn.
+            export OMP_NUM_THREADS=2
+            export MKL_NUM_THREADS=2
+            export OMP_WAIT_POLICY=passive
+            export PYTEST_ADDOPTS="-p no:timeout -n 4 ${{ startsWith(matrix.test-group.sku, 'sim_wh') && needs.load-test-matrix.outputs.skip-args-wormhole_b0 || startsWith(matrix.test-group.sku, 'sim_bh') && needs.load-test-matrix.outputs.skip-args-blackhole || '' }}"
+            # Strip the per-test `pytest --timeout N` from the cmd: the simulator is ~10-50x slower than
+            # HW, so that per-op limit kills slow-but-correct ops (the job timeout-minutes is the backstop;
+            # PYTEST_ADDOPTS also sets -p no:timeout). Run that cmd with xdist; if a worker crashes (xdist
+            # only reports "worker crashed"), re-run serially (drop -n 4 via the PYTEST_ADDOPTS override)
+            # with --lf for actionable diagnostics.
+            export cmd=$(printf '%s' '${{ matrix.test-group.cmd }}' | sed -E 's/[[:space:]]+--timeout[[:space:]]+[0-9]+//g')
+            # PYTEST_ADDOPTS for the serial fallback re-run (drops -n 4); applied only on retry.
+            export SERIAL_ADDOPTS="-p no:timeout ${{ startsWith(matrix.test-group.sku, 'sim_wh') && needs.load-test-matrix.outputs.skip-args-wormhole_b0 || startsWith(matrix.test-group.sku, 'sim_bh') && needs.load-test-matrix.outputs.skip-args-blackhole || '' }}"
+            # Wrap the whole sim run in the host-load sidecar so its usage report covers both
+            # the parallel run and any serial re-run. Written to /work/mem_report.json (even
+            # on failure — emitted before the sidecar exits) so the Upload mem report step
+            # picks it up. The sidecar is the final command, so it propagates the run's exit code.
+            .github/scripts/utils/host-load-sidecar.sh \
+              --interval 1 \
+              --label "${{ matrix.test-group.name }} (simulator)" \
+              --output /work/mem_report.json \
+              -- bash -c '
+                if eval "$cmd"; then
+                  exit 0
+                fi
+                echo "::warning::Parallel run failed. Re-running failed tests serially for clear diagnostics..."
+                export PYTEST_ADDOPTS="$SERIAL_ADDOPTS"
+                eval "$cmd --lf --lfnf=all --tb=long -v" || true
+                exit 1
+              '
 
       - name: Upload power report
         if: ${{ !cancelled() && !startsWith(matrix.test-group.sku, 'sim_') }}
@@ -545,6 +565,23 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           prefix: "test_reports_"
+
+      - name: 🤖 AI job summary
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "input_dirs": ["generated/test_logs"],
+              "output_dir": "generated/ai_summaries",
+              "scope": "${{ inputs.summary-scope }}"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}
 
       - uses: tenstorrent/tt-metal/.github/actions/cleanup@main
         if: always()

--- a/.github/workflows/ttsim-sanity-tests-impl.yaml
+++ b/.github/workflows/ttsim-sanity-tests-impl.yaml
@@ -14,6 +14,15 @@ on:
         type: string
         default: ""
         description: "Commit SHA to test (default: HEAD)"
+      summary-scope:
+        required: false
+        type: string
+        default: ""
+        description: "Discriminator for the AI summaries when the calling workflow is invoked more than once per run"
+    outputs:
+      matrix:
+        description: "Filtered matrix of legs that ran (consumed by ai_summary/run for INFRA_FAILURE reconciliation)"
+        value: ${{ jobs.load-test-matrix.outputs.matrix }}
 
 jobs:
   load-test-matrix:
@@ -116,6 +125,7 @@ jobs:
             .github/actions/download-artifact-with-retry
             .github/actions/setup-ttsim
             .github/sku_config.yaml
+            .github/actions/run-with-log
             .github/scripts/utils/host-load-sidecar.sh
           sparse-checkout-cone-mode: false
           ref: ${{ inputs.ref || github.sha }}
@@ -153,15 +163,18 @@ jobs:
       # (uploaded below) and the sidecar propagates the run's exit code so failures still fail the job.
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          cat > /tmp/ttsim_cmd.sh <<'TTSIM_CMD_EOF'
-          ${{ matrix.test-group.cmd }}
-          TTSIM_CMD_EOF
-          .github/scripts/utils/host-load-sidecar.sh \
-            --interval 1 \
-            --label "${{ matrix.test-group.name }}" \
-            --output /work/mem_report.json \
-            -- bash --noprofile --norc -eo pipefail /tmp/ttsim_cmd.sh
+        uses: ./.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: |
+            cat > /tmp/ttsim_cmd.sh <<'TTSIM_CMD_EOF'
+            ${{ matrix.test-group.cmd }}
+            TTSIM_CMD_EOF
+            .github/scripts/utils/host-load-sidecar.sh \
+              --interval 1 \
+              --label "${{ matrix.test-group.name }}" \
+              --output /work/mem_report.json \
+              -- bash --noprofile --norc -eo pipefail /tmp/ttsim_cmd.sh
       - name: Upload mem report
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
@@ -173,3 +186,21 @@ jobs:
           path: ${{ github.workspace }}/mem_report.json
           if-no-files-found: warn
           retention-days: 30
+      # This container mounts the workspace root at /work (no docker-job subdir),
+      # so the tool's workspace is /work rather than $GITHUB_WORKSPACE/docker-job.
+      - name: 🤖 AI job summary
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "/work",
+              "input_dirs": ["generated/test_logs"],
+              "output_dir": "generated/ai_summaries",
+              "scope": "${{ inputs.summary-scope }}"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}

--- a/.github/workflows/umd-sanity-tests-impl.yaml
+++ b/.github/workflows/umd-sanity-tests-impl.yaml
@@ -27,6 +27,15 @@ on:
         type: string
         default: ""
         description: "Commit SHA to test (default: HEAD)"
+      summary-scope:
+        required: false
+        type: string
+        default: ""
+        description: "Discriminator for the AI summaries when the calling workflow is invoked more than once per run"
+    outputs:
+      matrix:
+        description: "Filtered matrix of legs that ran (consumed by ai_summary/run for INFRA_FAILURE reconciliation)"
+        value: ${{ jobs.load-test-matrix.outputs.matrix }}
 
 jobs:
   load-test-matrix:
@@ -103,5 +112,23 @@ jobs:
           enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          ${{ matrix.test-group.cmd }}
+        uses: ./docker-job/.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: ${{ matrix.test-group.cmd }}
+      - name: 🤖 AI job summary
+        if: ${{ !cancelled() }}
+        continue-on-error: true
+        uses: tenstorrent/tt-github-actions/.github/actions/ai_summary/job@main
+        with:
+          config: |
+            {
+              "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "workspace": "$GITHUB_WORKSPACE/docker-job",
+              "input_dirs": ["generated/test_logs"],
+              "output_dir": "generated/ai_summaries",
+              "scope": "${{ inputs.summary-scope }}"
+            }
+          api-key: ${{ secrets.TT_CHAT_API_KEY }}
+          api-url: ${{ secrets.TT_CHAT_URL }}
+          job-name: ${{ matrix.test-group.name }}

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_bcast.py
@@ -101,12 +101,12 @@ def test_01_volume_tensors(device, a, b, c_golden, memory_config_a, memory_confi
         [[1, 2, 3, 3, 4, 32, 32], [5, 1, 3, 3, 4, 32, 32]],
     ],
 )
-def test_binary_invalid_rank(device, a_shape, b_shape):
+def test_binary_invalid_rank(device, a_shape, b_shape, expect_error):
     torch.manual_seed(0)
     pt_a, tt_a = rand_bf16_gen(a_shape, device)
     pt_b, tt_b = rand_bf16_gen(b_shape, device)
 
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "Broadcasting rule violation for rank"):
         ttnn.add(tt_a, tt_b)
 
 
@@ -1641,7 +1641,9 @@ def test_binary_sharded_bcast_scalar_value_uneven(
         ],
     ),
 )
-def test_binary_sharded_scalar_invalid_row_major(scalar, a_shape, shard_type, shard_size, core_range, device):
+def test_binary_sharded_scalar_invalid_row_major(
+    scalar, a_shape, shard_type, shard_size, core_range, device, expect_error
+):
     torch.manual_seed(0)
     a_sharded_config = ttnn.create_sharded_memory_config(
         shard_size,
@@ -1656,7 +1658,7 @@ def test_binary_sharded_scalar_invalid_row_major(scalar, a_shape, shard_type, sh
         a_shape
     )
 
-    with pytest.raises(RuntimeError) as e:
+    with expect_error(RuntimeError, "Optional output tensor with Row Major input is not supported"):
         a_tt = ttnn.from_torch(
             a_pt,
             dtype=ttnn.bfloat16,
@@ -2007,7 +2009,7 @@ def test_binary_sharded_bcast_w_size(a_shape, b_shape, a_shard_size, b_shard_siz
     ),
 )
 def test_binary_sharded_invalid_row_major_layout(
-    a_shape, b_shape, shard_type, shard_size, core_range, dtype_pt, dtype_tt, device
+    a_shape, b_shape, shard_type, shard_size, core_range, dtype_pt, dtype_tt, device, expect_error
 ):
     torch.manual_seed(0)
     a_sharded_config = ttnn.create_sharded_memory_config(
@@ -2028,7 +2030,7 @@ def test_binary_sharded_invalid_row_major_layout(
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=dtype_pt), dtype_tt)(a_shape)
     b_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=dtype_pt), dtype_tt)(b_shape)
 
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "Physical shard shape"):
         a_tt = ttnn.from_torch(
             a_pt,
             dtype=ttnn.bfloat16,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_binary_sub_device_id.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_binary_sub_device_id.py
@@ -110,7 +110,7 @@ def test_binary_tensor_scalar_with_sub_device_id(device, op_fn, op_name):
 # Mutual exclusion: sub_core_grids + sub_device_id = TT_FATAL
 # ---------------------------------------------------------------------------
 @skip_for_slow_dispatch()
-def test_binary_sub_device_id_and_sub_core_grids_mutual_exclusion(device):
+def test_binary_sub_device_id_and_sub_core_grids_mutual_exclusion(device, expect_error):
     """TT_FATAL when both sub_core_grids and sub_device_id are provided."""
     torch.manual_seed(0)
     shape = [1, 1, 32, 32]
@@ -125,7 +125,7 @@ def test_binary_sub_device_id_and_sub_core_grids_mutual_exclusion(device):
 
         some_cores = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 1))})
 
-        with pytest.raises(RuntimeError, match="Cannot specify both"):
+        with expect_error(RuntimeError, "Cannot specify both"):
             ttnn.add(
                 tt_a,
                 tt_b,

--- a/tests/ttnn/unit_tests/operations/eltwise/test_broadcast_to.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_broadcast_to.py
@@ -198,17 +198,19 @@ def test_broadcast_to_profile(device, dtype_pt, dtype_tt, shape_and_broadcast_sp
         ttnn.synchronize_device(device)
 
 
-input_bcast_shape_pairs = [
-    ((1, 1, 1, 1), (1, 1, 1)),
-    ((1, 1, 1, 1), (1, 1, 1, 1, 1)),
-    ((1, 1, 1, 1, 1), (1, 1, 1, 1, 1)),
-    ((2, 1), (3, 1)),
+# Each shape pair provokes a distinct TT_FATAL, so the expected message travels
+# with it — one shared pattern would let any case pass on another's error.
+input_bcast_shape_pairs_and_errors = [
+    ((1, 1, 1, 1), (1, 1, 1), "must be at least as large as the broadcast shape"),
+    ((1, 1, 1, 1), (1, 1, 1, 1, 1), "must be at most 4D"),
+    ((1, 1, 1, 1, 1), (1, 1, 1, 1, 1), "must be at most 4D"),
+    ((2, 1), (3, 1), "cannot be broadcast to output dimension"),
 ]
 
 
 @pytest.mark.parametrize("dtype_pt, dtype_tt", ((torch.bfloat16, ttnn.bfloat16),))
-@pytest.mark.parametrize("input, bcast", input_bcast_shape_pairs)
-def test_broadcast_to_invalid(input, bcast, dtype_pt, dtype_tt, device):
+@pytest.mark.parametrize("input, bcast, error", input_bcast_shape_pairs_and_errors)
+def test_broadcast_to_invalid(input, bcast, error, dtype_pt, dtype_tt, device, expect_error):
     torch.manual_seed(0)
 
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=dtype_pt), dtype_tt)(input)
@@ -219,7 +221,7 @@ def test_broadcast_to_invalid(input, bcast, dtype_pt, dtype_tt, device):
         layout=ttnn.TILE_LAYOUT,
     )
 
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, error):
         _ = ttnn.experimental.broadcast_to(a_tt, bcast)
 
 
@@ -229,7 +231,7 @@ input_bcast_shape_pairs = [
 
 
 @pytest.mark.parametrize("input, bcast", input_bcast_shape_pairs)
-def test_invalid_broadcast_to_sharding(input, bcast, device):
+def test_invalid_broadcast_to_sharding(input, bcast, device, expect_error):
     torch.manual_seed(0)
     dtype_pt, dtype_tt = [torch.bfloat16, ttnn.bfloat16]
     a_pt = gen_func_with_cast_tt(partial(torch_random, low=-50, high=50, dtype=torch.float32), dtype_tt)(input)
@@ -248,7 +250,7 @@ def test_invalid_broadcast_to_sharding(input, bcast, device):
         memory_config=sharded_config,
     )
 
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "bcast_to: Invalid input memory config"):
         _ = ttnn.experimental.broadcast_to(a_tt, bcast, memory_config=sharded_config)
 
 

--- a/tests/ttnn/unit_tests/operations/matmul/test_addmm.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_addmm.py
@@ -396,7 +396,7 @@ def test_addmm_non_tile_multiple_dimensions(device, dtype, shape):
         assert_numeric_metrics(torch_output_tensor, output_tensor_torch, pcc_threshold=0.9999, check_ulp=False)
 
 
-def test_alpha_zero_should_throw_error(device):
+def test_alpha_zero_should_throw_error(device, expect_error):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn(4, 4, dtype=torch.bfloat16)
@@ -422,16 +422,11 @@ def test_alpha_zero_should_throw_error(device):
         device=device,
     )
 
-    try:
+    with expect_error(RuntimeError, "alpha parameter cannot be 0"):
         ttnn.addmm(input_tensor, mat1_tensor, mat2_tensor, alpha=0.0)
-    except Exception as e:
-        if not "alpha parameter cannot be 0" in str(e):
-            pytest.fail("Expected error message not found.")
-    else:
-        pytest.fail("Calling ttnn.addmm with alpha=0 should throw an error.")
 
 
-def test_input_tensor_with_invalid_shape_should_throw_error(device):
+def test_input_tensor_with_invalid_shape_should_throw_error(device, expect_error):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn(8, 8, dtype=torch.bfloat16)
@@ -457,13 +452,8 @@ def test_input_tensor_with_invalid_shape_should_throw_error(device):
         device=device,
     )
 
-    try:
+    with expect_error(RuntimeError, "input_tensor must have shape matching one of result of mat1_tensor @ mat2_tensor"):
         ttnn.addmm(input_tensor, mat1_tensor, mat2_tensor)
-    except Exception as e:
-        if not "input_tensor must have shape matching one of result of mat1_tensor @ mat2_tensor" in str(e):
-            pytest.fail("Expected error message not found.")
-    else:
-        pytest.fail("Calling ttnn.addmm with incompatible shapes should throw an error.")
 
 
 def test_input_tensor_with_invalid_shape_should_be_ignored_if_beta_is_0(device):
@@ -525,7 +515,7 @@ def test_cast_to_another_dtype(device):
     assert output_tensor.dtype == ttnn.float32, "Output tensor must be float32"
 
 
-def test_unsupported_dtype_should_throw_error(device):
+def test_unsupported_dtype_should_throw_error(device, expect_error):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn(4, 4, dtype=torch.bfloat16)
@@ -551,13 +541,8 @@ def test_unsupported_dtype_should_throw_error(device):
         device=device,
     )
 
-    try:
+    with expect_error(RuntimeError, "types are supported for input_tensor"):
         ttnn.addmm(input_tensor, mat1_tensor, mat2_tensor)
-    except Exception as e:
-        if not "only ttnn.bfloat16, ttnn.float32 and ttnn.bfloat8_b types are supported" in str(e):
-            pytest.fail("Expected error message not found.")
-    else:
-        pytest.fail("Calling ttnn.addmm with invalid dtype of input tensors should throw an error.")
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32, ttnn.bfloat8_b])

--- a/tests/ttnn/unit_tests/operations/matmul/test_linear.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_linear.py
@@ -630,11 +630,17 @@ def test_vector_linear(device, shape_a, shape_b, shape_bias) -> tuple:
     # Run ttnn linear with the same operations
     ttnn_errored = False
     ttnn_error_msg = ""
+    # Add expected error markers, so log analyzing agents don't trigger on TT_FATAL.
+    # Same as the expect_error fixture from conftest.py (not used here, as we don't
+    # always expect an exception).
+    logger.info('[EXPECTED_ERROR BEGIN] RuntimeError message="Unsupported bias shape"')
     try:
         ttnn_result = ttnn.linear(ttnn_a, ttnn_b, bias=ttnn_bias)
     except Exception as e:
         ttnn_errored = True
         ttnn_error_msg = str(e)
+    finally:
+        logger.info('[EXPECTED_ERROR END] RuntimeError message="Unsupported bias shape"')
 
     # Compare error behavior
     if torch_errored != ttnn_errored:

--- a/tests/ttnn/unit_tests/operations/transformers/test_transformer.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_transformer.py
@@ -539,7 +539,7 @@ def test_sharded_split_query_key_value_and_split_heads(
     assert_with_pcc(torch_value_tensor, value_tensor, 0.999)
 
 
-def test_split_query_key_value_and_split_heads_when_head_size_is_not_a_multiple_of_32(device):
+def test_split_query_key_value_and_split_heads_when_head_size_is_not_a_multiple_of_32(device, expect_error):
     """
     This test is to check that the split_query_key_value_and_split_heads function raises an error when the head size is not a multiple of 32
     And then it shows what user could do to fix the error
@@ -576,14 +576,8 @@ def test_split_query_key_value_and_split_heads_when_head_size_is_not_a_multiple_
         layout=ttnn.TILE_LAYOUT,
     )
 
-    with pytest.raises(RuntimeError) as e:
-        query_tensor, key_tensor, value_tensor = ttnn.transformer.split_query_key_value_and_split_heads(
-            input_tensor, num_heads=num_heads
-        )
-        assert (
-            "Head size must be a multiple of 32! Update the preceding matmul to have the padding in the weights!"
-            in str(e.value)
-        )
+    with expect_error(RuntimeError, "The head size must be a multiple of the tile width"):
+        ttnn.transformer.split_query_key_value_and_split_heads(input_tensor, num_heads=num_heads)
 
     # Manually each head to a mutliple of 32
     input_tensor_heads = torch.split(torch_input_tensor, head_size, dim=-1)
@@ -616,7 +610,7 @@ def test_split_query_key_value_and_split_heads_when_head_size_is_not_a_multiple_
 
 @pytest.mark.requires_fast_runtime_mode_off
 @pytest.mark.skip(reason="#9267: need to fix since it never ran in CI")
-def test_concatenate_heads_when_head_size_is_not_a_multiple_of_32(device):
+def test_concatenate_heads_when_head_size_is_not_a_multiple_of_32(device, expect_error):
     """
     This test is to check that the concatenate_heads function raises an error when the head size is not a multiple of 32
     And then it shows what user could do to fix the error
@@ -646,13 +640,8 @@ def test_concatenate_heads_when_head_size_is_not_a_multiple_of_32(device):
         layout=ttnn.TILE_LAYOUT,
     )
 
-    with pytest.raises(RuntimeError) as e:
-        output_tensor = ttnn.transformer.concatenate_heads(input_tensor)
-
-    assert (
-        "Head size must be a multiple of 32!  Update matmul that uses the output of this operation to have the padding in the weights!"
-        in str(e.value)
-    )
+    with expect_error(RuntimeError, "Head size must be a multiple of 32"):
+        ttnn.transformer.concatenate_heads(input_tensor)
 
     input_tensor = torch.nn.functional.pad(torch_input_tensor, (0, padded_head_size - head_size), "constant", 0)
     input_tensor = ttnn.from_torch(


### PR DESCRIPTION
Replaces #51362, which predates the pipeline reorg (#48943).

All seven workflows reachable from `sanity-tests.yaml` now emit a per-leg AI job summary, aggregated into one run report. Coverage was `blackhole-multi-card` only — 7 of ~100 legs. Summarization is `continue-on-error` throughout and never changes a leg's verdict.

Also fixes green jobs being reported `CRASHED`: four negative tests used bare `pytest.raises`, which leaves `TT_FATAL` unmasked in the log, and `has_crash` is checked ahead of the exit code. They now use the `expect_error` fixture. Teaching `get_job_status` to trust a clean exit instead would mask real crashes in jobs that exit 0 by accident.

Requires tenstorrent/tt-github-actions#151 — the workflows pin `@main`. Merge that first.

## Verified

[Run 32126839220](https://github.com/tenstorrent/tt-metal/actions/runs/32126839220/attempts/3) — ttnn sanity, 15 legs, run against a deliberately stale reused build so most legs fail. Three consecutive attempts (new run, partial re-run, full re-run) each reported 15/15 legs, and the two previously-misreported eltwise groups came back green in all three.

The run report renders on the run's summary page; per-job summaries land as `ai_job_summary_*` artifacts on the run. [AI Run Summary job](https://github.com/tenstorrent/tt-metal/actions/runs/32126839220/job/95711293575) shows the report and the per-leg reconciliation.

Wider coverage on earlier runs: 74/81 legs in [32040486115](https://github.com/tenstorrent/tt-metal/actions/runs/32040486115) — the 7 gaps are a GitHub Actions outage — and 35/35 in [32059018423](https://github.com/tenstorrent/tt-metal/actions/runs/32059018423).

## Reviewer notes

- Each impl exposes its `load-test-matrix` output so the run report can tell "leg failed" from "leg never reported", the latter becoming an explicit infra-failure row instead of a silent gap. A new impl must be added to `ai-run-summary`'s `needs:` or its legs are absent from that union with no error.
- `sanity-tests.yaml` is `workflow_call`-ed **twice per run** by `sanity-tests-debug.yaml`. Both invocations previously aggregated the whole run's per-leg artifacts, so each report covered the other platform's legs, the two uploads collided on one artifact name, and — because both run identical leg names — one invocation's artifacts satisfied the other's `expected-jobs` and suppressed its infra stubs. `inputs.platform` is now passed down as the summaries' scope, which partitions all three. Both debug invocations therefore publish.
- `publish-run-summary` (default `true`) remains as the opt-out for a caller that wants no report at all, or whose invocations would share a scope. The `github.workflow` arm of the job's `if:` covers this workflow's own `push`/`schedule` triggers, where the `inputs` context is empty and the declared default never applies.
- The `ci_digest` consumer change is **#53644**, split out so it can land before tenstorrent/tt-github-actions#151 renames the artifact. Merge order: #53644, then #151, then this.
- `runtime-sanity-tests-impl.yaml` is shared with the standalone `runtime-sanity-tests.yaml`, which therefore also gets per-leg summaries (it has no aggregator, so no run report). `galaxy-sanity-impl.yaml` is the one sanity impl left uncovered.
- Step-level `env:` does not reach a composite action's script, but `container.env` does, so job-wide values live there rather than in step bodies.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ppetrovic/sanity)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ppetrovic/sanity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ppetrovic/sanity)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ppetrovic/sanity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ppetrovic/sanity)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ppetrovic/sanity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ppetrovic/sanity)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ppetrovic/sanity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ppetrovic/sanity)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ppetrovic/sanity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ppetrovic/sanity)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ppetrovic/sanity)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ppetrovic/sanity)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ppetrovic/sanity)