### PR TITLE
Prep moreh_nll_loss_unreduced_backward for Metal 2.0 Port

### DIFF
--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_program_factory.cpp
@@ -85,6 +85,12 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_unreduced_backward_impl_2d(
         desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_2), weight_has_value ? Ct : 0u, data_format);  // weight
     push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_16), 1, data_format);  // input_grad
 
+    if (weight_has_value) {
+        // This CB will be used as scratch storage when reading data from DRAM into L1
+        push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_7), 1, data_format);
+    }
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_8), 1, data_format);
+
     // create read/write kernel
     KernelDescriptor::CompileTimeArgs reader_compile_time_args{};
     TensorAccessorArgs(*target.buffer()).append_to(reader_compile_time_args);
@@ -213,6 +219,11 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_unreduced_backward_impl_3d(
     push_cb(
         desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_2), weight_has_value ? Ct : 0u, data_format);  // weight
     push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_16), 1, data_format);  // input_grad
+
+    if (weight_has_value) {
+        // This CB will be used as scratch storage when reading data from DRAM into L1
+        push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_7), 1, data_format);
+    }
 
     // create read/write kernel
     KernelDescriptor::CompileTimeArgs reader_compile_time_args{};
@@ -345,6 +356,11 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_unreduced_backward_impl_4d(
     push_cb(
         desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_2), weight_has_value ? Ct : 0u, data_format);  // weight
     push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_16), 1, data_format);  // input_grad
+
+    if (weight_has_value) {
+        // This CB will be used as scratch storage when reading data from DRAM into L1
+        push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_7), 1, data_format);
+    }
 
     // create read/write kernel
     KernelDescriptor::CompileTimeArgs reader_compile_time_args{};

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_nll_loss_unreduced_backward/device/moreh_nll_loss_unreduced_backward_program_factory.cpp
@@ -87,9 +87,10 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_unreduced_backward_impl_2d(
 
     if (weight_has_value) {
         // This CB will be used as scratch storage when reading data from DRAM into L1
-        push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_7), 1, data_format);
+        push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_7), 1, data_format);  // weight scratch
     }
-    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_8), 1, data_format);
+    // Need another scratch CB for output_grad reading data from DRAM into L1.
+    push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_8), 1, data_format);  // output_grad scratch
 
     // create read/write kernel
     KernelDescriptor::CompileTimeArgs reader_compile_time_args{};
@@ -222,7 +223,7 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_unreduced_backward_impl_3d(
 
     if (weight_has_value) {
         // This CB will be used as scratch storage when reading data from DRAM into L1
-        push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_7), 1, data_format);
+        push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_7), 1, data_format);  // weight scratch
     }
 
     // create read/write kernel
@@ -359,7 +360,7 @@ tt::tt_metal::ProgramDescriptor moreh_nll_loss_unreduced_backward_impl_4d(
 
     if (weight_has_value) {
         // This CB will be used as scratch storage when reading data from DRAM into L1
-        push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_7), 1, data_format);
+        push_cb(desc, all_cores, static_cast<uint8_t>(tt::CBIndex::c_7), 1, data_format);  // weight scratch
     }
 
     // create read/write kernel


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/53527

### Summary
The readers built DFB objects on `c_7` and `c_8` but the factory only allocated `c_0`, `c_1`, `c_2` and `c_16`. `read_line` used the write pointer of a CB that was never configured. It only takes that branch when the DRAM read alignment exceeds the valid element run (32 bytes on WH and 64 on BH).

| Arch | NOC_DRAM_READ_ALIGNMENT_BYTES | Branch taken | Effect |
|---|---|---|---|
| WH | 32 | `max(32,32) == 32` → direct | scratch never touched — masked |
| BH | 64 | `max(32,64) ≠ 32` → scratch | 64-byte NoC read through an unconfigured CB's write pointer |

### Fix
All three rank paths now allocate the two scratch CBs their readers construct and pass to `read_line`: `c_7` (weight) under `weight_has_value` in 2d/3d/4d, `c_8` (output_grad) in 2d only.

### Verification (BH)
The illegal access is only surfaced with **Watcher** (`TT_METAL_WATCHER=1`), which sanitizes every NoC transaction.

**Run on a BH:**
```bash
ARCH_NAME=blackhole TT_METAL_WATCHER=1 \
pytest tests/ttnn/nightly/unit_tests/operations/moreh/test_moreh_nll_loss_unreduced.py \
  -k "unreduced_backward" -v
```
**Result after fix:** 28 passed, 16 skipped, 27 deselected
(16 skipped are the unconditionally-skipped bfloat8_b cases; no arch-related skips)

**Result in main:** Watcher detected NOC error and stopped device.
<img width="911" height="393" alt="Screenshot 2026-08-19 at 10 56 13" src="https://github.com/user-attachments/assets/657a6054-8db3-4234-b440-4831b08d1545" />



### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anasuya/fix_nll_loss_unreduced_bw_scratch_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anasuya/fix_nll_loss_unreduced_bw_scratch_cbs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anasuya/fix_nll_loss_unreduced_bw_scratch_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anasuya/fix_nll_loss_unreduced_bw_scratch_cbs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anasuya/fix_nll_loss_unreduced_bw_scratch_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anasuya/fix_nll_loss_unreduced_bw_scratch_cbs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anasuya/fix_nll_loss_unreduced_bw_scratch_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anasuya/fix_nll_loss_unreduced_bw_scratch_cbs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anasuya/fix_nll_loss_unreduced_bw_scratch_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anasuya/fix_nll_loss_unreduced_bw_scratch_cbs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anasuya/fix_nll_loss_unreduced_bw_scratch_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anasuya/fix_nll_loss_unreduced_bw_scratch_cbs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anasuya/fix_nll_loss_unreduced_bw_scratch_cbs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anasuya/fix_nll_loss_unreduced_bw_scratch_cbs)