### PR TITLE
[Bug fix] Stabilize parallel mesh program publication

### DIFF
--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -119,6 +119,7 @@ struct ProgramDispatchEntry {
 struct DeviceDispatchTask {
     IDevice* device = nullptr;
     ProgramDispatchEntry* program_entry = nullptr;
+    uint32_t deferred_one_shot_fetch_size = 0;
 };
 
 [[maybe_unused]] MeshCoordinate get_local_start_coord(MeshDevice* mesh_device, const MeshCoordinateRange& range) {
@@ -584,7 +585,7 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
         const size_t tasks_before_program = program_tasks.size();
         for_each_local(mesh_device_, device_range, [&](const auto& coord) {
             auto* device = mesh_device_->impl().get_device(coord);
-            program_tasks.push_back(DeviceDispatchTask{device, &entry});
+            program_tasks.push_back(DeviceDispatchTask{device, &entry, 0});
             chip_ids_in_workload.insert(device->id());
         });
         if (program_tasks.size() == tasks_before_program) {
@@ -612,7 +613,24 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
         }
     }
 
-    auto write_program_for_device = [&](const DeviceDispatchTask& task) {
+    // A homogeneous program spanning several local devices is the launch-skew-sensitive collective shape. Prepare it
+    // before checking its final size, then copy its large one-shot issue entries in parallel and publish only after
+    // every device is ready. Keep heterogeneous workloads on the original fused prepare+copy path: splitting every
+    // model workload into two pool stages or synchronizing all of its programs adds material eager-mode overhead.
+    bool defer_program_launch = false;
+    if (program_tasks.size() > 1) {
+        auto* local_program_entry = program_tasks.front().program_entry;
+        const bool homogeneous = std::ranges::all_of(
+            program_tasks, [&](const auto& task) { return task.program_entry == local_program_entry; });
+        if (homogeneous) {
+            prepare_program(*local_program_entry);
+            defer_program_launch = local_program_entry->cmd_seq->get_one_shot_fetch_size(
+                                       dispatch_metadata.stall_first, dispatch_metadata.stall_before_program, true) <=
+                                   MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
+        }
+    }
+
+    auto write_program_for_device = [&](DeviceDispatchTask& task) {
         auto& entry = *task.program_entry;
         prepare_program(entry);
         if (record_sub_device) {
@@ -623,12 +641,14 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
                 sub_device_id,
                 num_available_worker_cores);
         }
-        program_dispatch::write_program_command_sequence(
+        task.deferred_one_shot_fetch_size = program_dispatch::write_program_command_sequence(
             *entry.cmd_seq,
             task.device->sysmem_manager(),
             id_,
             dispatch_metadata.stall_first,
-            dispatch_metadata.stall_before_program);
+            dispatch_metadata.stall_before_program,
+            true,
+            defer_program_launch);
     };
 
     // Each device has its own sysmem manager, so the program writes are independent and go out in
@@ -639,7 +659,7 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     // worker costs tens of microseconds, so a workload covering a single device would otherwise pay
     // for the pool without getting any overlap in return.
     for (size_t i = 1; i < program_tasks.size(); i++) {
-        const auto& task = program_tasks[i];
+        auto& task = program_tasks[i];
         dispatch_thread_pool_->enqueue(
             [&write_program_for_device, &task]() { write_program_for_device(task); }, task.device->id());
     }
@@ -675,6 +695,16 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     }
     if (dispatch_exception) {
         std::rethrow_exception(dispatch_exception);
+    }
+    if (defer_program_launch) {
+        // Reserve every device's fetch slot before publishing any entry. A blocking reservation after an earlier
+        // device was published would reintroduce arbitrary launch skew.
+        for (auto& task : program_tasks) {
+            task.device->sysmem_manager().fetch_queue_reserve_back(id_);
+        }
+        for (auto& task : program_tasks) {
+            task.device->sysmem_manager().fetch_queue_write(task.deferred_one_shot_fetch_size, id_);
+        }
     }
 
     // Increment Launch Message Buffer Write Pointers

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -67,6 +67,7 @@
 #include "tt_metal/jit_build/build_env_manager.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include <umd/device/types/xy_pair.hpp>
+#include <umd/device/driver_atomics.hpp>
 #include "impl/dispatch/vector_aligned.hpp"
 #include "dispatch/worker_config_buffer.hpp"
 #include "tt_metal/distributed/mesh_workload_impl.hpp"
@@ -3166,13 +3167,14 @@ void update_traced_program_dispatch_commands(
     }
 }
 
-void write_program_command_sequence(
+uint32_t write_program_command_sequence(
     const ProgramCommandSequence& program_command_sequence,
     SystemMemoryManager& manager,
     uint32_t command_queue_id,
     bool stall_first,
     bool stall_before_program,
-    bool send_binary) {
+    bool send_binary,
+    bool defer_one_shot_commit) {
     LOG_TRACE_LAZY(tt::LogDispatch, "");
     LOG_TRACE_LAZY(
         tt::LogDispatch, "========== Writing Program Command Sequence to CQ {} ==========", command_queue_id);
@@ -3187,6 +3189,7 @@ void write_program_command_sequence(
     uint32_t one_shot_fetch_size =
         program_command_sequence.get_one_shot_fetch_size(stall_first, stall_before_program, send_binary);
     bool one_shot = one_shot_fetch_size <= MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
+    TT_FATAL(one_shot || !defer_one_shot_commit, "Only one-shot program commands can defer fetch queue publication");
 
     LOG_TRACE_LAZY(tt::LogDispatch, "One-shot mode: {}, Fetch size: {} bytes", one_shot, one_shot_fetch_size);
     if (one_shot) {
@@ -3272,12 +3275,20 @@ void write_program_command_sequence(
 
     if (one_shot) {
         manager.issue_queue_push_back(one_shot_fetch_size, command_queue_id);
+        if (defer_one_shot_commit) {
+            // The command payload may have been copied with non-temporal stores. Fence on the worker that performed
+            // those stores before reporting that this device is ready; a fence on the publishing thread cannot order
+            // writes performed by a different CPU.
+            tt_driver_atomics::sfence();
+            return one_shot_fetch_size;
+        }
         manager.fetch_queue_reserve_back(command_queue_id);
         manager.fetch_queue_write(one_shot_fetch_size, command_queue_id);
     }
 
     LOG_TRACE_LAZY(tt::LogDispatch, "========== Finished Writing Program Command Sequence ==========");
     LOG_TRACE_LAZY(tt::LogDispatch, "");
+    return 0;
 }
 
 TraceNode create_trace_node(

--- a/tt_metal/impl/program/dispatch.hpp
+++ b/tt_metal/impl/program/dispatch.hpp
@@ -190,13 +190,16 @@ TraceNode create_trace_node(
     uint32_t num_workers,
     bool use_prefetcher_cache);
 
-void write_program_command_sequence(
+// Returns the fetch size when a one-shot command was copied and its issue queue entry was pushed, but the fetch queue
+// entry was intentionally not published. Otherwise returns zero.
+uint32_t write_program_command_sequence(
     const ProgramCommandSequence& program_command_sequence,
     SystemMemoryManager& manager,
     uint32_t command_queue_id,
     bool stall_first,
     bool stall_before_program,
-    bool send_binary = true);
+    bool send_binary = true,
+    bool defer_one_shot_commit = false);
 
 KernelHandle get_device_local_kernel_handle(KernelHandle kernel_handle);
 


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

Fixes increased timing variance in the BH Galaxy ring-MLA perf gate after `22b39540bcc` / #52775 parallelized per-device `MeshWorkload` command writes.

Normal chip runtime remained near 5.713 ms, but scheduler-dependent publication caused different ring participants to become stragglers. Since the test measures the maximum across 32 devices, this produced intermittent 5.8-6.0+ ms results.

Affected CI: [Blaze Models Prefill / Ring Joint SDPA](https://github.com/tenstorrent/tt-metal/actions/runs/32101623404/job/95633607588), `test_ring_mla_chunked_perf_check[kimi50k-q32-k640-ring8]`.

### Evidence

| Revision | Five maximum device times |
|---|---|
| Parent `e1c940b2` | 5.723, 5.724, 5.732, 5.735, 5.723 ms |
| `22b39540` | 6.016, 5.880, 9.542, 5.835, 5.727 ms |
| `main` before fix | 5.815, 5.729, 5.760, 6.015, 5.895 ms |

The slowest physical chip changed between runs, indicating launch skew rather than a fixed bad chip or route.

### Fix

Keep command copies and issue-queue pushes parallel, but defer one-shot fetch publication until every local target is ready:

1. Prepare commands before final one-shot sizing.
2. Copy and push issue entries in parallel; each producer fences its own non-temporal stores.
3. Join producers and reserve every fetch slot.
4. Publish the fetch entries together.

This preserves parallel transfer bandwidth while preventing worker scheduling or queue pressure from staggering cooperating device launches. Non-one-shot and single-local-device workloads retain the existing path.

### Validation

- Release build passed.
- Kimi50k 5x: 5.720, 5.724, 5.738, 5.736, 5.737 ms; all passed.
- Kimi K3: 9.674 ms; passed.
- DRAM-backed CQ Kimi50k: 5.734 ms; passed.
- High-effort independent review passed after producer fencing, post-preparation sizing, and all-slot reservation were added.

Focused `sdpa_perf` CI: https://github.com/tenstorrent/tt-metal/actions/runs/32149272368

### Notes for reviewers

Please check the issue/fetch queue split, producer-side WC fencing, and the effect of caller-side program preparation on heterogeneous multi-program enqueue performance.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-parallel-mesh-launch-skew)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/fix-parallel-mesh-launch-skew)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/fix-parallel-mesh-launch-skew)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/fix-parallel-mesh-launch-skew)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/fix-parallel-mesh-launch-skew)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/fix-parallel-mesh-launch-skew)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/fix-parallel-mesh-launch-skew)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/fix-parallel-mesh-launch-skew)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/fix-parallel-mesh-launch-skew)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/fix-parallel-mesh-launch-skew)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/fix-parallel-mesh-launch-skew)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/fix-parallel-mesh-launch-skew)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/fix-parallel-mesh-launch-skew)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/fix-parallel-mesh-launch-skew)