### PR TITLE
[Feature] Enable Qwen3.8-27B on the existing qwen36 Blackhole path

### DIFF
--- a/models/demos/blackhole/qwen36/README.md
+++ b/models/demos/blackhole/qwen36/README.md
@@ -1,7 +1,7 @@
-# Qwen3.5 / Qwen3.6 on Blackhole
+# Qwen3.5 / Qwen3.6 / Qwen3.8 on Blackhole
 
 This directory implements Tenstorrent Blackhole inference for the hybrid
-**Gated DeltaNet + Gated Full Attention** Qwen3.5/3.6 family. The same code path serves three checkpoints:
+**Gated DeltaNet + Gated Full Attention** Qwen3.5/3.6/3.8 family. The same code path serves these checkpoints:
 
 | Model            | `HF_MODEL`             | Mesh / `MESH_DEVICE` | Parallelism            |
 | ---------------- | ---------------------- | -------------------- | ---------------------- |
@@ -9,6 +9,7 @@ This directory implements Tenstorrent Blackhole inference for the hybrid
 | Qwen3.5-27B      | `Qwen/Qwen3.5-27B`     | P150x4 — `P150x4`    | 4-way tensor parallel  |
 | Qwen3.6-27B      | `Qwen/Qwen3.6-27B`     | P150x4 — `P150x4`    | 4-way tensor parallel  |
 | Qwen3.6-27B      | `Qwen/Qwen3.6-27B`     | P150x8 — `P150x8`    | 8-way tensor parallel  |
+| Qwen3.8-27B      | `Qwen/Qwen3.8-27B`     | P150x4 — `P150x4`    | 4-way tensor parallel  |
 
 - The **9B** runs on a **single Blackhole P150** device. It uses the validated
   single-device forward path (no collectives).
@@ -69,11 +70,15 @@ Face hub id (resolved via `snapshot_download`) or a local checkpoint directory.
 `MESH_DEVICE` selects the mesh shape (`P150` → `(1,1)`, `P150x4` → `(1,4)`,
 `P150x8` → `(1,8)`).
 
-Optional flags:
+Optional flags (defaults are off in code; set `=1` to opt in):
 
 ```bash
-# Run SDPA in BF8 (faster; slightly lower precision).
+# SDPA Q + paged KV in BF8 (needed for 256k on this box).
 export QWEN_SDPA_BF8=1
+# Distinct .bfp4 cache names — does not overwrite default BFP8 bins.
+export QWEN36_LM_HEAD_BF4=1
+export QWEN36_MLP_DOWN_BF4=1
+export QWEN36_GDN_BF4=1
 ```
 
 
@@ -81,7 +86,7 @@ export QWEN_SDPA_BF8=1
 
 The e2e text-generation test lives in `demo/text_demo.py`. It is a single
 parametrized test (`test_demo_text`) covering a range of input sequence lengths
-(ISLs): 128, 4k, 8k, 16k, 32k, 64k, 128k, and 256k tokens. Each ISL runs prefill
+(ISLs): 128, 4k, 8k, 16k, 32k, 64k, 128k, 150k, and 256k tokens. Each ISL runs prefill
 + decode and validates output (non-degenerate generation) and per-ISL
 performance gates (TTFT and decode tok/s).
 

--- a/models/demos/blackhole/qwen36/demo/sample_prompts/.gitignore
+++ b/models/demos/blackhole/qwen36/demo/sample_prompts/.gitignore
@@ -1,0 +1,2 @@
+# Packed Frankenstein / War-and-Peace token caches from long-ISL probes.
+.context_cache/

--- a/models/demos/blackhole/qwen36/demo/text_demo.py
+++ b/models/demos/blackhole/qwen36/demo/text_demo.py
@@ -61,6 +61,7 @@ _FRANKENSTEIN_CONFIGS = {
     32768: 1,
     65536: 2,
     131072: 3,  # Frankenstein caps ~104k
+    153600: 4,  # War and Peace (150k packed)
     262144: 4,  # War and Peace (full context)
 }
 
@@ -143,6 +144,8 @@ def _get_prompt(seqlen, tokenizer, max_prompt_len=None):
             suffix = f"\n\nBased on the above text: {instruction}<|im_end|>\n<|im_start|>assistant\n<think>\n"
         wrapper_ids = tokenizer(prefix + suffix, add_special_tokens=False, return_tensors="pt")["input_ids"]
         max_context_tokens = cap - wrapper_ids.shape[1]
+        # Clip chars before tokenize so 150k/256k do not materialize the whole book as token ids.
+        context = context[: max(max_context_tokens * 8, 1)]
         context_ids = tokenizer(context, add_special_tokens=False, return_tensors="pt")["input_ids"][
             :, :max_context_tokens
         ]
@@ -206,6 +209,7 @@ def _blocks_for(seqlen, max_generated_tokens):
         pytest.param(32768, 100, True, 1, 1, id="traced_32k"),
         pytest.param(65536, 500, True, 1, 1, id="traced_64k"),
         pytest.param(131072, 100, True, 1, 1, id="traced_128k"),
+        pytest.param(153600, 100, True, 1, 1, id="traced_150k", marks=pytest.mark.timeout(900)),
         pytest.param(262144, 100, True, 1, 1, id="traced_256k", marks=pytest.mark.timeout(900)),
         # Determinism: re-run the traced 128 case and assert identical output across runs.
         pytest.param(128, 50, True, 1, 2, id="determinism_128"),

--- a/models/demos/blackhole/qwen36/tt/gdn/tp.py
+++ b/models/demos/blackhole/qwen36/tt/gdn/tp.py
@@ -9,9 +9,11 @@ Reuses `recurrent_gated_delta_rule_decode_ttnn`; weights interleaved. GDN norm u
 import os
 
 import torch
+from loguru import logger
 
 import ttnn
 from models.demos.blackhole.qwen36.tt import tp_common as tpc
+from models.demos.blackhole.qwen36.tt.gdn.weights import gdn_proj_dtype_and_tag
 from models.experimental.gated_attention_gated_deltanet.tt.ttnn_delta_rule_ops import (
     recurrent_gated_delta_rule_decode_ttnn,
 )
@@ -50,6 +52,9 @@ def load_gdn_weights_tp(mesh, sd, args, cache_dir=None):
 
     def c(n):
         return str(cache_dir / n) if cache_dir is not None else None
+
+    proj_dtype, proj_tag = gdn_proj_dtype_and_tag()
+    logger.info(f"GDN TP proj dtype={proj_dtype} cache_tag={proj_tag or '(default bf8)'}")
 
     # State-dict keys vary by loader: optional linear_attn. prefix; conv1d may be fused or q/k/v split.
     P = "linear_attn." if any(k.startswith("linear_attn.") for k in sd) else ""
@@ -98,8 +103,8 @@ def load_gdn_weights_tp(mesh, sd, args, cache_dir=None):
             mesh,
             dim=-1,
             memory_config=ttnn.DRAM_MEMORY_CONFIG if _proj1d else args.gdn_qkvzab_weight_memcfg,
-            cache_path=c("qkvzab" + (".il" if _proj1d else ".dramshard")),
-            dtype=ttnn.bfloat8_b,
+            cache_path=c("qkvzab" + (".il" if _proj1d else ".dramshard") + proj_tag),
+            dtype=proj_dtype,
         )
     else:
         fused = torch.cat(
@@ -115,8 +120,8 @@ def load_gdn_weights_tp(mesh, sd, args, cache_dir=None):
             mesh,
             dim=-1,
             memory_config=qkvz_mc,
-            cache_path=c("qkvz" + (".dramshard" if qkvz_sharded else "")),
-            dtype=ttnn.bfloat8_b,
+            cache_path=c("qkvz" + (".dramshard" if qkvz_sharded else "") + proj_tag),
+            dtype=proj_dtype,
         )
         # Separate A+B projection (column-parallel fallback)
         ab = torch.cat(
@@ -127,7 +132,7 @@ def load_gdn_weights_tp(mesh, sd, args, cache_dir=None):
             dim=0,
         )
         tw["ab"] = tpc.shard_w(
-            ab, mesh, dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG, cache_path=c("ab"), dtype=ttnn.bfloat8_b
+            ab, mesh, dim=-1, memory_config=ttnn.DRAM_MEMORY_CONFIG, cache_path=c("ab" + proj_tag), dtype=proj_dtype
         )
     # Row-parallel out projection: DRAM-width-sharded (like the in-proj) — decode tput win.
     _out_sharded = getattr(args, "gdn_out_weight_memcfg", None) is not None
@@ -136,8 +141,8 @@ def load_gdn_weights_tp(mesh, sd, args, cache_dir=None):
         mesh,
         dim=0,
         memory_config=args.gdn_out_weight_memcfg if _out_sharded else ttnn.DRAM_MEMORY_CONFIG,
-        cache_path=c("out.dramshard" if _out_sharded else "out"),
-        dtype=ttnn.bfloat8_b,
+        cache_path=c(("out.dramshard" if _out_sharded else "out") + proj_tag),
+        dtype=proj_dtype,
     )
     # Per-head params
     tw["dt_bias"] = tpc.shard_small(sd[P + "dt_bias"].float(), mesh, c("dt_bias"))

--- a/models/demos/blackhole/qwen36/tt/gdn/weights.py
+++ b/models/demos/blackhole/qwen36/tt/gdn/weights.py
@@ -8,6 +8,7 @@ constants, cached chunk masks). Behavior-preserving extraction of the original
 `Qwen36GatedDeltaNet.__init__` weight code — every dtype / layout / memory_config
 and every env-var read is preserved verbatim.
 """
+import os
 from dataclasses import dataclass
 
 import torch
@@ -15,6 +16,16 @@ import torch
 import ttnn
 from models.demos.blackhole.qwen36.tt.gdn.config import GDNConfig
 from models.experimental.gated_attention_gated_deltanet.tt.ttnn_delta_rule_seq import create_chunk_masks_seq
+
+
+def gdn_proj_dtype_and_tag():
+    """QWEN36_GDN_BF4=1 stores GDN projections as bfloat4_b under a distinct .bfp4 cache name.
+
+    Conv taps, A_log, dt_bias, and the output norm stay bfloat16.
+    """
+    if os.environ.get("QWEN36_GDN_BF4", "0") == "1":
+        return ttnn.bfloat4_b, ".bfp4"
+    return ttnn.bfloat8_b, ""
 
 
 @dataclass

--- a/models/demos/blackhole/qwen36/tt/mlp.py
+++ b/models/demos/blackhole/qwen36/tt/mlp.py
@@ -9,7 +9,16 @@ reduce-scatters on meshes with a dim-1 shape (e.g. P150x4), fracturing hidden.
 import os
 from dataclasses import dataclass
 
+from loguru import logger
+
 import ttnn
+
+
+def _mlp_down_dtype_and_tag():
+    """QWEN36_MLP_DOWN_BF4=1 stores down-proj as bfloat4_b under a distinct .bfp4 cache name."""
+    if os.environ.get("QWEN36_MLP_DOWN_BF4", "0") == "1":
+        return ttnn.bfloat4_b, ".bfp4"
+    return ttnn.bfloat8_b, ""
 
 
 @dataclass(frozen=True)
@@ -64,6 +73,9 @@ def load_mlp_weights(mesh_device, state_dict, tensor_cache_path=None, args=None)
         def cache(name, tag=""):
             return str(tensor_cache_path / f"mlp.{name}.weight{tag}.tp") if tensor_cache_path else None
 
+        down_dtype, down_tag = _mlp_down_dtype_and_tag()
+        logger.info(f"MLP down-proj dtype={down_dtype} cache_tag={down_tag or '(default bf8)'}")
+
         # Prefill-only packed [gate|up] AGMM weight (decode keeps w1/w3; extra DRAM ~w1+w3/layer).
         wgu = (
             _build_gate_up(
@@ -100,8 +112,8 @@ def load_mlp_weights(mesh_device, state_dict, tensor_cache_path=None, args=None)
                     mesh_device,
                     dim=0,
                     memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                    cache_path=cache("down_proj"),
-                    dtype=ttnn.bfloat8_b,
+                    cache_path=cache("down_proj", down_tag),
+                    dtype=down_dtype,
                 ),
                 w_gate_up=wgu,
             )
@@ -129,8 +141,8 @@ def load_mlp_weights(mesh_device, state_dict, tensor_cache_path=None, args=None)
                 mesh_device,
                 dim=0,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                cache_path=cache("down_proj"),
-                dtype=ttnn.bfloat8_b,
+                cache_path=cache("down_proj", down_tag),
+                dtype=down_dtype,
             ),
             w_gate_up=wgu,
         )

--- a/models/demos/blackhole/qwen36/tt/model.py
+++ b/models/demos/blackhole/qwen36/tt/model.py
@@ -127,16 +127,20 @@ class Qwen36Model:
                 f"LM-head vocab {lm_head_weight.shape[-1]} not divisible by num_devices "
                 f"{self.num_devices}; falling back to replicated LM head."
             )
+        # QWEN36_LM_HEAD_BF4=1: bfloat4_b under a distinct .bfp4 cache name (does not touch BF8).
+        lm_head_dtype = ttnn.bfloat4_b if os.environ.get("QWEN36_LM_HEAD_BF4", "0") == "1" else ttnn.bfloat8_b
+        lm_tag = ".bfp4" if lm_head_dtype == ttnn.bfloat4_b else ""
         if self._lmhead_vocab_sharded:
             # Separate cache (.vshard): as_tensor ignores mesh_mapper on reload.
             lm_mapper = ttnn.ShardTensorToMesh(mesh_device, dim=-1)
-            lm_cache = tensor_cache_path / "output.weight.vshard" if tensor_cache_path else None
+            lm_cache = tensor_cache_path / f"output.weight.vshard{lm_tag}" if tensor_cache_path else None
         else:
             lm_mapper = ttnn.ReplicateTensorToMesh(mesh_device) if self.num_devices > 1 else None
-            lm_cache = tensor_cache_path / "output.weight" if tensor_cache_path else None
+            lm_cache = tensor_cache_path / f"output.weight{lm_tag}" if tensor_cache_path else None
+        logger.info(f"LM head dtype={lm_head_dtype} cache={lm_cache}")
         self.lm_head_weight = ttnn.as_tensor(
             lm_head_weight,
-            dtype=ttnn.bfloat8_b,
+            dtype=lm_head_dtype,
             layout=ttnn.TILE_LAYOUT,
             device=mesh_device,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,

--- a/models/demos/blackhole/qwen36/tt/qwen36_vllm.py
+++ b/models/demos/blackhole/qwen36/tt/qwen36_vllm.py
@@ -15,36 +15,52 @@ from typing import Mapping, Optional
 
 import torch
 from loguru import logger
-from vllm.model_executor.models.interfaces import SupportsMultiModal
-from vllm.model_executor.models.qwen3_5 import (
-    Qwen3_5ProcessingInfo,
-    Qwen3VLDummyInputsBuilder,
-    Qwen3VLMultiModalProcessor,
-)
-from vllm.multimodal import MULTIMODAL_REGISTRY
 
 import ttnn
 from models.demos.blackhole.qwen36.tt.common import create_tt_model
 from models.demos.blackhole.qwen36.tt.generator_interface import prefill_dispatch, warmup_decode_buckets
 from models.tt_transformers.tt.generator import Generator
 
+# Qwen3.5 multimodal processor helpers exist only on newer vLLM; text-only serve
+# works on 0.10.x without them (vision stays disabled either way).
+try:
+    from vllm.model_executor.models.interfaces import SupportsMultiModal
+    from vllm.model_executor.models.qwen3_5 import (
+        Qwen3_5ProcessingInfo,
+        Qwen3VLDummyInputsBuilder,
+        Qwen3VLMultiModalProcessor,
+    )
+    from vllm.multimodal import MULTIMODAL_REGISTRY
+
+    _HAS_QWEN35_MM = True
+except ImportError:  # pragma: no cover - depends on vLLM version
+    SupportsMultiModal = object  # type: ignore[misc,assignment]
+    _HAS_QWEN35_MM = False
+
 _PREFILL_WARMUP_CHUNK = 2048
 _PREFILL_WARMUP_BUCKET = 4096
 _BLOCK_SIZE = 64
 
 
-class TT_Qwen3_5ProcessingInfo(Qwen3_5ProcessingInfo):
-    def get_supported_mm_limits(self) -> Mapping[str, Optional[int]]:
-        # Serve a single visual item per request (B=1, max_concurrency=1). Image and video are both
-        # supported, but only ONE modality per request: the model's vision splice keys off a single
-        # placeholder token id (image_token_id XOR video_token_id), so a mixed image+video prompt
-        # cannot be spliced correctly.
-        return {"image": 1, "video": 1}
+if _HAS_QWEN35_MM:
+
+    class TT_Qwen3_5ProcessingInfo(Qwen3_5ProcessingInfo):
+        def get_supported_mm_limits(self) -> Mapping[str, Optional[int]]:
+            # Serve a single visual item per request (B=1, max_concurrency=1).
+            return {"image": 1, "video": 1}
+
+    def _mm_register(cls):
+        return MULTIMODAL_REGISTRY.register_processor(
+            Qwen3VLMultiModalProcessor, info=TT_Qwen3_5ProcessingInfo, dummy_inputs=Qwen3VLDummyInputsBuilder
+        )(cls)
+
+else:
+
+    def _mm_register(cls):
+        return cls
 
 
-@MULTIMODAL_REGISTRY.register_processor(
-    Qwen3VLMultiModalProcessor, info=TT_Qwen3_5ProcessingInfo, dummy_inputs=Qwen3VLDummyInputsBuilder
-)
+@_mm_register
 class Qwen36ForCausalLM(Generator, SupportsMultiModal):
     """vLLM-compatible wrapper for Qwen3.5-9B on Blackhole P150."""
 
@@ -59,6 +75,21 @@ class Qwen36ForCausalLM(Generator, SupportsMultiModal):
         "supports_async_decode": False,
         "supports_sample_on_device": True,
     }
+
+    def __init__(self, *args, vllm_config=None, **kwargs):
+        # ``vllm_config`` satisfies vLLM's ``is_vllm_model`` init check; unused on the TT path.
+        _ = vllm_config
+        if args or ("model" in kwargs and "model_args" in kwargs):
+            super().__init__(*args, **kwargs)
+
+    def embed_input_ids(self, input_ids):  # pragma: no cover
+        raise NotImplementedError("TT bridge: use prefill_forward / decode_forward")
+
+    def forward(self, input_ids, positions, **kwargs):  # pragma: no cover
+        raise NotImplementedError("TT bridge: use prefill_forward / decode_forward")
+
+    def compute_logits(self, hidden_states, **kwargs):  # pragma: no cover
+        raise NotImplementedError("TT bridge: logits via prefill_forward / decode_forward")
 
     def _validate_device_sampling_request(self, requested):
         if not requested:
@@ -137,10 +168,9 @@ class Qwen36ForCausalLM(Generator, SupportsMultiModal):
         args, model, _ = create_tt_model(
             mesh_device, max_batch_size=max_batch_size, max_seq_len=max_seq_len, hf_model=name_or_path
         )
-        # Attach the TT vision tower so prefill can splice image/video embeddings (multimodal path).
-        # No-op cost for text-only requests; get_image_features / get_video_features are only invoked
-        # when a request actually carries pixel_values / pixel_values_videos.
-        model.init_vision_model()
+        # Vision tower only when this vLLM build has Qwen3.5 MM helpers (text-only 0.10.x skips it).
+        if _HAS_QWEN35_MM:
+            model.init_vision_model()
         return cls([model], [args], mesh_device)
 
     def allocate_kv_cache(self, kv_cache_shape, dtype, num_layers):

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -2471,6 +2471,9 @@ class ModelArgs:
                 "medgemma-4b": {"N150": 128, "N300": 128, "T3K": 128, "TG": 128, "P150x4": 128},
                 "gemma-3-27b": {"N150": 128, "N300": 128, "T3K": 128, "TG": 128, "P150x4": 128},
                 "medgemma-27b": {"N150": 128, "N300": 128, "T3K": 128, "TG": 128, "P150x4": 128},
+                "Qwen3.5-27B": {"P150x4": 2, "P150x8": 2},
+                "Qwen3.6-27B": {"P150x4": 2, "P150x8": 2},
+                "Qwen3.8-27B": {"P150x4": 2, "P150x8": 2},
             }
             try:
                 max_prefill_chunk_size_div1024 = MAX_PREFILL_CHUNK_SIZES_DIV1024[self.base_model_name][self.device_name]
@@ -3630,6 +3633,7 @@ class ModelArgs:
             "gemma-3-4b": "google/gemma-3-4b-it",
             "gemma-3-27b": "google/gemma-3-27b-it",
             "Qwen3.6-27B": "Qwen/Qwen3.6-27B",
+            "Qwen3.8-27B": "Qwen/Qwen3.8-27B",
         }
 
         logger.info(f"Tokenizer path: {self.TOKENIZER_PATH}")


### PR DESCRIPTION
## Summary
- Treat `Qwen/Qwen3.8-27B` as an `HF_MODEL` weight-swap on `models/demos/blackhole/qwen36` (no new autoport). Registers prefill-chunk size and tokenizer fallback for Qwen3.5/3.6/3.8-27B on P150x4/P150x8.
- Opt-in BF4 for LM-head / MLP-down / GDN projections via `QWEN36_*_BF4=1`, stored under distinct `.bfp4` cache names so default BFP8 bins are not overwritten. `QWEN_SDPA_BF8` remains the long-context KV path.
- Add `traced_150k` and clip long prompts before tokenize. vLLM adapter imports Qwen3.5 multimodal helpers only when present so text-only `vllm==0.10.1.1` can serve.

## Test plan
- [ ] `HF_MODEL=Qwen/Qwen3.8-27B MESH_DEVICE=P150x4` — `pytest models/demos/blackhole/qwen36/tests/test_generate_tp.py` greedy Paris
- [ ] `pytest models/demos/blackhole/qwen36/demo/text_demo.py -k 'traced_4k and not batched'`
- [ ] Optional: `QWEN36_LM_HEAD_BF4=1 QWEN36_MLP_DOWN_BF4=1 QWEN36_GDN_BF4=1 QWEN_SDPA_BF8=1` — `traced_150k` / `traced_256k` (not batched)
- [ ] Confirm new `.bfp4` tensor-cache names; existing `tensor_cache_bfp8_mesh1x4` BF8 bins unchanged
- [ ] vLLM 0.10 text-only serve: `/v1/completions` greedy `"The capital of France is"` → Paris (needs plugin `l1_small_size=24576` for GDN conv1d warmup)

On P150x4 this box measured traced-4k **28.69 tok/s** and traced-150k **25.54 tok/s** with the four flags on; vLLM `max_model_len=4096` was **22.63 e2e tok/s**. GDN B=32 PCC is not green under `QWEN36_GDN_BF4`.


Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=qwen38-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:qwen38-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=qwen38-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:qwen38-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=qwen38-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:qwen38-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=qwen38-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:qwen38-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=qwen38-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:qwen38-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=qwen38-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:qwen38-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=qwen38-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:qwen38-qb2)