### PR TITLE
Tunning of Gate OP device matmul program configs for sharded and interleaved input

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
@@ -701,8 +701,8 @@ def test_forward_pass_tp1_interleaved(mesh_device, num_links, topology, gate_mod
 
     n_sp_devices, n_tp_devices = mesh_device.shape
     config_key = (config.sp_dim, config.dim // n_tp_devices, config.n_routed_experts)
-    assert config_key in config.mm_configs, (
-        f"no tuned matmul program config for {config_key}. This sweep exists to hold every model's "
+    assert config_key in config.mm_configs_interleaved, (
+        f"no tuned interleaved matmul program config for {config_key}. This sweep exists to hold every model's "
         "deployed gate shape on a tuned config, so a miss is the regression it is here to catch."
     )
 

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
@@ -33,7 +33,12 @@ from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     get_sp_mesh_composer,
     load_gate_weights_from_hf,
 )
-from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode, TtMoEGateConfig, TtMoEGatePrefill
+from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import (
+    GateComputeMode,
+    TtMoEGateConfig,
+    TtMoEGatePrefill,
+    gate_mm_config_key,
+)
 from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
     ValidationResult,
     compare_pcc,
@@ -682,25 +687,26 @@ def test_forward_pass_tp1_interleaved(mesh_device, num_links, topology, gate_mod
 
     At TP=1 adjust_shapes_for_testing divides the model dim by 4, so each model's per-device gate
     width lands on EMB_SIZE / 4 -- the width its TP=4 deployment resolves. The mm_configs lookup is
-    therefore the same (640, EMB_SIZE / 4, n_routed_experts) key production hits, but reached with the
-    interleaved input TtMoe actually passes rather than the height-sharded one every other case here
-    builds. That distinction is the point: a height-sharded input pins the matmul program config
-    (per_core_M must equal the shard height in tiles, and a 2D config additionally demands
-    K == in0_block_w and a single-column shard grid), so the sharded cases cannot cover the config the
-    deployment runs.
+    therefore the same key production hits, but reached with the interleaved input TtMoe actually
+    passes rather than the height-sharded one every other case here builds. That distinction is the
+    point: a height-sharded input pins the matmul program config (per_core_M must equal the shard
+    height in tiles, and a 2D config additionally demands K == in0_block_w and a single-column shard
+    grid), so the sharded cases cannot cover the config the deployment runs.
 
-    GPT-OSS is the one model whose width is not tile-aligned here: 2880 / 4 = 720 is 22.5 tiles, which
-    adjust_shapes_for_testing rounds to 736, and its mm_configs entry is keyed to that.
+    The width is also held un-rounded (tile_align_width=False), which only GPT-OSS notices: its
+    2880 / 4 = 720 is 22.5 tiles, and the other cases here round it to 736 so an L1 shard width stays
+    whole tiles. An interleaved input has no such constraint, so this case runs the raw deployed 720
+    and gate_mm_config_key resolves it to the tuned 23-K-tile entry the same way production does.
     """
     random.seed(42)
     torch.manual_seed(42)
 
     config = _gate_config(gate_model)
     config.ccl_config["NUM_LINKS"] = num_links
-    adjust_shapes_for_testing(config, mesh_device)
+    adjust_shapes_for_testing(config, mesh_device, tile_align_width=False)
 
     n_sp_devices, n_tp_devices = mesh_device.shape
-    config_key = (config.sp_dim, config.dim // n_tp_devices, config.n_routed_experts)
+    config_key = gate_mm_config_key(config.sp_dim, config.dim // n_tp_devices, config.n_routed_experts)
     assert config_key in config.mm_configs_interleaved, (
         f"no tuned interleaved matmul program config for {config_key}. This sweep exists to hold every model's "
         "deployed gate shape on a tuned config, so a miss is the regression it is here to catch."

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
@@ -258,6 +258,20 @@ MESH_CONFIGS = [
     ),
 ]
 
+# Blackhole LoudBox puts all 8 P150s on the SP axis, so TP is 1 and the gate does no TP all-reduce.
+LOUDBOX_TP1_MESH_CONFIG = pytest.param(
+    (8, 1),
+    {
+        "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+        "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
+    },
+    1,
+    ttnn.Topology.Linear,
+    marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
+    id="linear-8",
+)
+
+
 # (gate_model id, gate compute mode). Sigmoid models (V3/Kimi) exercise both the host and on-device
 # gates; V4 (sqrtsoftplus) runs the regular gate on device, where the kernel applies the activation.
 REGULAR_GATE_CASES = [
@@ -294,6 +308,22 @@ def _shard_gate_input(config, mesh_device, torch_input: torch.Tensor) -> ttnn.Te
         device=mesh_device,
         dtype=ttnn.bfloat16,
         memory_config=sharded_mem_config,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device,
+            dims=(0, -1),  # tensor parallel
+            mesh_shape=mesh_device.shape,
+        ),
+    )
+
+
+def _interleave_gate_input(config, mesh_device, torch_input: torch.Tensor) -> ttnn.Tensor:
+    """DRAM-interleaved gate input, matching what TtMoe hands the gate in the deployed model."""
+    return ttnn.from_torch(
+        torch_input,
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
         layout=ttnn.TILE_LAYOUT,
         mesh_mapper=ttnn.ShardTensor2dMesh(
             mesh_device,
@@ -390,48 +420,14 @@ def _validate_gate(
     merged.assert_passed("Gate prefill2d validation failed")
 
 
-@pytest.mark.parametrize("gate_model, gate_fallback_mode", REGULAR_GATE_CASES)
-@pytest.mark.parametrize(
-    "mesh_device, device_params, num_links, topology",
-    MESH_CONFIGS,
-    indirect=["mesh_device", "device_params"],
-)
-def test_forward_pass(
-    gate_model,
-    mesh_device,
-    num_links,
-    topology,
-    gate_fallback_mode,
-):
-    """Gate PCC across model variants and compute modes. The gate picks grouped vs plain top-k from
-    n_expert_groups (Kimi / V4 have one group) and sigmoid vs sqrtsoftplus from SCORE_FUNC, so the
-    test just passes the model config and the compute mode."""
-    random.seed(42)
-    torch.manual_seed(42)
+def _reference_topk(config, gate_model, gate_fallback_mode, gate_w, torch_input):
+    """Golden top-k indices and scores from each model's own reference router.
 
-    config = _gate_config(gate_model)
-    config.ccl_config["NUM_LINKS"] = num_links
-    adjust_shapes_for_testing(config, mesh_device)
-
-    # DeepSeek-V3's weights can't be reshaped to other expert counts or activations, so that path
-    # stays pinned to 256 experts + sigmoid; K3 loads its own 896-expert router.
-    use_real_weights = (
-        gate_model == "deepseek_v3" and config.n_routed_experts == 256 and config.score_func == "sigmoid"
-    ) or gate_model == "kimi_k3"
-    gate_w = _try_load_real_gate_weights(gate_model, config.n_routed_experts, config.dim) if use_real_weights else None
-    if gate_w is None:
-        gate_w = create_gate_weights(config.n_routed_experts, config.dim)
-
-    # The real gate input is a DeepSeek-V3 prefill trace, so it is only meaningful for that model.
-    use_real = gate_model == "deepseek_v3" and use_real_weights
-
-    n_sp_devices = mesh_device.shape[0]
-    total_seq_len = config.sp_dim * n_sp_devices
-    torch_input = _make_gate_input(config, total_seq_len, allow_real_input=use_real)
-
-    # Reference forward pass: V4 (sqrtsoftplus) routes through the activation-parametrized grouped
-    # gate (single group -> plain top-k, matching the V4 reference router); V3/Kimi use the V3 gate.
-    reference_logits = torch_input @ gate_w["weight"].T
+    The routing rule is not uniform across these models -- GPT-OSS takes top-k on biased logits
+    then softmaxes the selection, MiniMax sum-normalizes unbiased sigmoid, V4 uses sqrtsoftplus,
+    and V3/Kimi use the grouped noaux_tc gate -- so each dispatches to the upstream implementation
+    rather than to a reimplementation here.
+    """
     if gate_fallback_mode in (GateComputeMode.GPT_HOST, GateComputeMode.GPT_DEVICE):
         # GPT-OSS golden from the actual reference router: top-k on (x@W + bias), then softmax over the
         # selected top-k values. torch.topk (sorted=True, descending) matches _device_gpt_gate's order,
@@ -497,6 +493,54 @@ def test_forward_pass(
         reference_model.to(torch.bfloat16)
         reference_topk_indices, reference_topk_scores = reference_model.grouped_forward(torch_input.unsqueeze(0))
 
+    return reference_topk_indices, reference_topk_scores
+
+
+@pytest.mark.parametrize("gate_model, gate_fallback_mode", REGULAR_GATE_CASES)
+@pytest.mark.parametrize(
+    "mesh_device, device_params, num_links, topology",
+    MESH_CONFIGS,
+    indirect=["mesh_device", "device_params"],
+)
+def test_forward_pass(
+    gate_model,
+    mesh_device,
+    num_links,
+    topology,
+    gate_fallback_mode,
+):
+    """Gate PCC across model variants and compute modes. The gate picks grouped vs plain top-k from
+    n_expert_groups (Kimi / V4 have one group) and sigmoid vs sqrtsoftplus from SCORE_FUNC, so the
+    test just passes the model config and the compute mode."""
+    random.seed(42)
+    torch.manual_seed(42)
+
+    config = _gate_config(gate_model)
+    config.ccl_config["NUM_LINKS"] = num_links
+    adjust_shapes_for_testing(config, mesh_device)
+
+    # DeepSeek-V3's weights can't be reshaped to other expert counts or activations, so that path
+    # stays pinned to 256 experts + sigmoid; K3 loads its own 896-expert router.
+    use_real_weights = (
+        gate_model == "deepseek_v3" and config.n_routed_experts == 256 and config.score_func == "sigmoid"
+    ) or gate_model == "kimi_k3"
+    gate_w = _try_load_real_gate_weights(gate_model, config.n_routed_experts, config.dim) if use_real_weights else None
+    if gate_w is None:
+        gate_w = create_gate_weights(config.n_routed_experts, config.dim)
+
+    # The real gate input is a DeepSeek-V3 prefill trace, so it is only meaningful for that model.
+    use_real = gate_model == "deepseek_v3" and use_real_weights
+
+    n_sp_devices = mesh_device.shape[0]
+    total_seq_len = config.sp_dim * n_sp_devices
+    torch_input = _make_gate_input(config, total_seq_len, allow_real_input=use_real)
+
+    # Reference forward pass: V4 (sqrtsoftplus) routes through the activation-parametrized grouped
+    # gate (single group -> plain top-k, matching the V4 reference router); V3/Kimi use the V3 gate.
+    reference_logits = torch_input @ gate_w["weight"].T
+    reference_topk_indices, reference_topk_scores = _reference_topk(
+        config, gate_model, gate_fallback_mode, gate_w, torch_input
+    )
     tt_input = _shard_gate_input(config, mesh_device, torch_input)
 
     tt_model = TtMoEGatePrefill(
@@ -628,4 +672,79 @@ def test_hash_gate_forward_pass(
         recall_threshold=0.997,
         logits_pcc_threshold=0.997,
         scores_pcc_threshold=scores_pcc_threshold,
+    )
+
+
+# Only the device modes run the gate matmul on device, and covering that program config is the
+# entire point of the interleaved TP=1 sweep, so the host-side cases are filtered out.
+DEVICE_GATE_CASES = [
+    case for case in REGULAR_GATE_CASES if case.values[1] in (GateComputeMode.DEVICE_FP32, GateComputeMode.GPT_DEVICE)
+]
+
+
+@pytest.mark.parametrize("gate_model, gate_fallback_mode", DEVICE_GATE_CASES)
+@pytest.mark.parametrize(
+    "mesh_device, device_params, num_links, topology",
+    [LOUDBOX_TP1_MESH_CONFIG],
+    indirect=["mesh_device", "device_params"],
+)
+def test_forward_pass_tp1_interleaved(mesh_device, num_links, topology, gate_model, gate_fallback_mode):
+    """Every model's deployed gate matmul shape, on a TP=1 LoudBox with a DRAM-interleaved input.
+
+    At TP=1 adjust_shapes_for_testing divides the model dim by 4, so each model's per-device gate
+    width lands on EMB_SIZE / 4 -- the width its TP=4 deployment resolves. The mm_configs lookup is
+    therefore the same (640, EMB_SIZE / 4, n_routed_experts) key production hits, but reached with the
+    interleaved input TtMoe actually passes rather than the height-sharded one every other case here
+    builds. That distinction is the point: a height-sharded input pins the matmul program config
+    (per_core_M must equal the shard height in tiles, and a 2D config additionally demands
+    K == in0_block_w and a single-column shard grid), so the sharded cases cannot cover the config the
+    deployment runs.
+
+    GPT-OSS is the one model whose width is not tile-aligned here: 2880 / 4 = 720 is 22.5 tiles, which
+    adjust_shapes_for_testing rounds to 736, and its mm_configs entry is keyed to that.
+    """
+    random.seed(42)
+    torch.manual_seed(42)
+
+    config = _gate_config(gate_model)
+    config.ccl_config["NUM_LINKS"] = num_links
+    adjust_shapes_for_testing(config, mesh_device)
+
+    n_sp_devices, n_tp_devices = mesh_device.shape
+    config_key = (config.sp_dim, config.dim // n_tp_devices, config.n_routed_experts)
+    assert config_key in config.mm_configs, (
+        f"no tuned matmul program config for {config_key}. This sweep exists to hold every model's "
+        "deployed gate shape on a tuned config, so a miss is the regression it is here to catch."
+    )
+
+    # Scaling the dim to EMB_SIZE / 4 puts every model off its real router's width, so the checkpoint
+    # weights cannot be loaded here and the golden is built from seeded synthetic weights instead.
+    gate_w = create_gate_weights(config.n_routed_experts, config.dim)
+    torch_input = _make_gate_input(config, config.sp_dim * n_sp_devices, allow_real_input=False)
+    reference_logits = torch_input @ gate_w["weight"].T
+    reference_topk_indices, reference_topk_scores = _reference_topk(
+        config, gate_model, gate_fallback_mode, gate_w, torch_input
+    )
+
+    tt_model = TtMoEGatePrefill(
+        config,
+        mesh_device,
+        weight=gate_w["weight"],
+        bias=gate_w["e_score_correction_bias"],
+        fallback_mode=gate_fallback_mode,
+    )
+    tt_topk_scores, tt_topk_indices, tt_logits = tt_model(_interleave_gate_input(config, mesh_device, torch_input))
+
+    # Device-mode thresholds, matching the on-device branch of test_forward_pass.
+    _validate_gate(
+        mesh_device,
+        tt_topk_scores,
+        tt_topk_indices,
+        tt_logits,
+        reference_topk_indices,
+        reference_topk_scores,
+        reference_logits,
+        0.95,
+        0.997,
+        getattr(GATE_MODELS[gate_model], "GATE_SCORES_PCC_DEVICE", 0.93),
     )

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
@@ -60,29 +60,18 @@ GATE_MODELS = {
     "dsv4_flash": DeepSeekV4FlashConfig,
 }
 
-# Per-chip sequence every gate case runs at. Must be passed at construction: TtMoEGateConfig re-keys
-# its tuned matmul configs by sp_dim, so assigning it afterwards silently drops to default tiling.
+# Per-chip sequence every gate case runs at. Must be passed at construction: TtMoEGateConfig keeps
+# only the tuned matmul configs keyed to sp_dim, so assigning it afterwards drops to default tiling.
 GATE_SP_DIM = 640
 
 
 def _gate_config(gate_model: str) -> TtMoEGateConfig:
-    """Gate config at GATE_SP_DIM, minus tuned matmul entries authored for a different depth.
+    """Gate config at GATE_SP_DIM.
 
-    A tuned entry encodes its shard height in per_core_M, but TtMoEGateConfig re-keys every entry to
-    the sp_dim in use, so one tuned at 4096 claims to apply at 640 while still carrying per_core_M=2
-    -- and the matmul rejects it outright: "per_core_M (2) must equal shard_shape[0] (32) / in0_tile
-    height (32)". Entries that already match this depth are kept (K3's is authored at 640); the rest
-    are dropped so TTNN picks its default tiling, which is what the untuned models do here anyway.
+    The depth must be passed at construction: TtMoEGateConfig drops every tuned matmul entry keyed to
+    another depth, so assigning sp_dim afterwards leaves the lookup on TTNN's default tiling.
     """
-    config = TtMoEGateConfig.from_model_cfg(GATE_MODELS[gate_model], sp_dim=GATE_SP_DIM)
-    shard_height = (config.sp_dim + config.num_cores - 1) // config.num_cores
-    shard_height = ((shard_height + 31) // 32) * 32
-    config.mm_configs = {
-        key: value
-        for key, value in config.mm_configs.items()
-        if not isinstance(key, tuple) or value.per_core_M == shard_height // 32
-    }
-    return config
+    return TtMoEGateConfig.from_model_cfg(GATE_MODELS[gate_model], sp_dim=GATE_SP_DIM)
 
 
 # First MoE layer in DeepSeek-V3 (metadata moe_layer_offset == 3); the golden

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
@@ -265,6 +265,21 @@ LOUDBOX_TP1_MESH_CONFIG = pytest.param(
     id="linear-8",
 )
 
+# Galaxy TP=4: the deployed mesh. Unlike the LoudBox entry above this needs no dim scaling at all --
+# adjust_shapes_for_testing leaves a 4-wide TP axis alone -- so the gate runs the model's real dim and
+# the TP all-reduce is live, which the TP=1 case skips entirely.
+GALAXY_TP4_MESH_CONFIG = pytest.param(
+    (8, 4),
+    {
+        "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+        "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
+    },
+    2,
+    ttnn.Topology.Linear,
+    marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+    id="mesh-8x4",
+)
+
 
 # (gate_model id, gate compute mode). Sigmoid models (V3/Kimi) exercise both the host and on-device
 # gates; V4 (sqrtsoftplus) runs the regular gate on device, where the kernel applies the activation.
@@ -679,19 +694,21 @@ DEVICE_GATE_CASES = [
 @pytest.mark.parametrize("gate_model, gate_fallback_mode", DEVICE_GATE_CASES)
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
-    [LOUDBOX_TP1_MESH_CONFIG],
+    [GALAXY_TP4_MESH_CONFIG, LOUDBOX_TP1_MESH_CONFIG],
     indirect=["mesh_device", "device_params"],
 )
-def test_forward_pass_tp1_interleaved(mesh_device, num_links, topology, gate_model, gate_fallback_mode):
-    """Every model's deployed gate matmul shape, on a TP=1 LoudBox with a DRAM-interleaved input.
+def test_forward_pass_interleaved(mesh_device, num_links, topology, gate_model, gate_fallback_mode):
+    """Every model's deployed gate matmul shape, with the DRAM-interleaved input TtMoe really passes.
 
-    At TP=1 adjust_shapes_for_testing divides the model dim by 4, so each model's per-device gate
-    width lands on EMB_SIZE / 4 -- the width its TP=4 deployment resolves. The mm_configs lookup is
-    therefore the same key production hits, but reached with the interleaved input TtMoe actually
-    passes rather than the height-sharded one every other case here builds. That distinction is the
-    point: a height-sharded input pins the matmul program config (per_core_M must equal the shard
-    height in tiles, and a 2D config additionally demands K == in0_block_w and a single-column shard
-    grid), so the sharded cases cannot cover the config the deployment runs.
+    Both meshes land on the per-device width EMB_SIZE / 4 that a TP=4 deployment resolves, by
+    opposite routes: mesh-8x4 IS that deployment (real dim, TP=4, all-reduce live), while the TP=1
+    LoudBox gets there by adjust_shapes_for_testing dividing the dim by 4 and does no all-reduce at
+    all. The mm_configs lookup is therefore the same key production hits, but reached with the
+    interleaved input TtMoe actually passes rather than the height-sharded one every other case here
+    builds. That distinction is the point: a height-sharded input pins the matmul program config
+    (per_core_M must equal the shard height in tiles, and a 2D config additionally demands
+    K == in0_block_w and a single-column shard grid), so the sharded cases cannot cover the config the
+    deployment runs.
 
     The width is also held un-rounded (tile_align_width=False), which only GPT-OSS notices: its
     2880 / 4 = 720 is 22.5 tiles, and the other cases here round it to 736 so an L1 shard width stays

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -51,6 +51,11 @@ class GateComputeMode(Enum):
     GPT_DEVICE = "gpt_device"  # matmul device, ttnn.topk + ttnn.softmax on device
 
 
+# Per-chip prefill sequence the production deployment runs at, and the depth the MoE/gate tests
+# drive. Entries in mm_configs keyed at this depth override the any-depth (None) entries there.
+GATE_PRODUCTION_SP_DIM = 640
+
+
 @dataclass
 class TtMoEGateConfig:
     # gate_params
@@ -68,10 +73,20 @@ class TtMoEGateConfig:
     mm_configs: dict = field(
         default_factory=lambda: {
             # Keyed by (sp_dim, per_device_emb_dim, n_routed_experts); forward() looks up the tuple.
-            # The seq-len element below is a placeholder — __post_init__ rewrites it to the actual
-            # per-chip sequence length (self.sp_dim) so the lookup tracks the real workload.
+            # sp_dim None means "any depth": __post_init__ re-keys it to the depth in use. An entry
+            # authored at a real depth overrides the None entry at that depth (see __post_init__).
             # per_core_N = n_routed_experts / 32 (tile width). Missing key → TTNN auto-picks.
-            (4096, DeepSeekV3Config.EMB_SIZE // 4, DeepSeekV3Config.NUM_ROUTED_EXPERTS): (
+            #
+            # per_core_M is not free. It must equal max(1, ceil(sp_dim / (32 * num_cores))): below
+            # that the 1D matmul needs more blocks than the grid has cores ("num_blocks_total <=
+            # num_cores"), and for a height-sharded in0 it must also equal shard_shape[0] / 32. Both
+            # rules give 1 up to 3520 tokens/chip and 2 at 4096. out_block_h follows it.
+            #
+            # The None entries below were tuned at 4096 and carry per_core_M=2, which is why 640 --
+            # the production depth -- needs its own entries: at 640 per_core_M=2 splits 20 M-tiles
+            # over 10 cores instead of 20. K3's per_core_M was already 1 (MAX_GATE_SEQ_LEN_PER_CHIP
+            # keeps it under 3520), so its 640 entry exists only for out_block_w.
+            (None, DeepSeekV3Config.EMB_SIZE // 4, DeepSeekV3Config.NUM_ROUTED_EXPERTS): (
                 ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                     compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
                     in0_block_w=56,
@@ -85,7 +100,7 @@ class TtMoEGateConfig:
                     mcast_in0=False,
                 )
             ),
-            (4096, KimiK26Config.EMB_SIZE // 4, KimiK26Config.NUM_ROUTED_EXPERTS): (
+            (None, KimiK26Config.EMB_SIZE // 4, KimiK26Config.NUM_ROUTED_EXPERTS): (
                 ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                     compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
                     in0_block_w=56,
@@ -99,17 +114,55 @@ class TtMoEGateConfig:
                     mcast_in0=False,
                 )
             ),
-            # per_core_M is not free: for a height-sharded in0 the matmul asserts
-            # per_core_M == roundup32(ceil(sp_dim / num_cores)) / 32, which is 1 at K3's depths and 2
-            # at the other models' 4096. out_block_h follows it.
-            (KimiK3Config.MAX_GATE_SEQ_LEN_PER_CHIP, KimiK3Config.EMB_SIZE // 4, KimiK3Config.NUM_ROUTED_EXPERTS): (
+            # 640 tokens/chip: 20 M-tiles, so per_core_M=1 spreads them over 20 cores rather than 10.
+            #
+            # out_block_w and out_subblock_w are swept, not inherited: out_block_w wants to be the
+            # widest divisor of per_core_N that still builds (12 fails L1 allocation for 384 experts,
+            # 14 and 28 for 896), and out_subblock_w wants to be NARROW, not the widest the dest
+            # registers allow. Measured per call on a Blackhole Galaxy at 640 tokens/chip, medians of
+            # 7 rounds visited in rotated order (a single-pass sweep drifts enough to invert the
+            # ranking), every candidate at PCC 0.999999. Best three per model plus the alternatives:
+            #     256 experts  (8,1) 51.2  (8,2) 51.2  (8,4) 51.7 | default 54.7 | (4,1) 57.1 | shipped 89.3
+            #     384 experts  (6,1) 77.9  (6,2) 78.2  (6,3) 78.5 | (4,1) 84.2 | shipped 130.0 | default 436.5
+            #     896 experts  (7,1) 177.6 | (4,1) 194.3 | shipped 198.8 | default 437.6
+            # Do not "fix" out_subblock_w back up to 4 to match TTNN's own area-first heuristic
+            # (SUBBLOCK_HW_CHOICES): it is the slowest legal choice at every width measured.
+            (GATE_PRODUCTION_SP_DIM, DeepSeekV3Config.EMB_SIZE // 4, DeepSeekV3Config.NUM_ROUTED_EXPERTS): (
                 ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                     compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
                     in0_block_w=56,
                     out_subblock_h=1,
-                    out_subblock_w=4,
+                    out_subblock_w=1,
                     out_block_h=1,
-                    out_block_w=4,
+                    out_block_w=8,
+                    per_core_M=1,
+                    per_core_N=8,
+                    fuse_batch=True,
+                    mcast_in0=False,
+                )
+            ),
+            (GATE_PRODUCTION_SP_DIM, KimiK26Config.EMB_SIZE // 4, KimiK26Config.NUM_ROUTED_EXPERTS): (
+                ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                    compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
+                    in0_block_w=56,
+                    out_subblock_h=1,
+                    out_subblock_w=1,
+                    out_block_h=1,
+                    out_block_w=6,
+                    per_core_M=1,
+                    per_core_N=12,
+                    fuse_batch=True,
+                    mcast_in0=False,
+                )
+            ),
+            (GATE_PRODUCTION_SP_DIM, KimiK3Config.EMB_SIZE // 4, KimiK3Config.NUM_ROUTED_EXPERTS): (
+                ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                    compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
+                    in0_block_w=56,
+                    out_subblock_h=1,
+                    out_subblock_w=1,
+                    out_block_h=1,
+                    out_block_w=7,
                     per_core_M=1,
                     per_core_N=28,
                     fuse_batch=True,
@@ -155,14 +208,20 @@ class TtMoEGateConfig:
                 f"experts/32 and will fail L1 allocation above it. Raise the ceiling only alongside "
                 f"the op-side CB work that makes it true."
             )
-        # The mm_configs tuple keys are authored with a placeholder seq-len. Re-key them to the
-        # actual per-chip sequence length (sp_dim) so _device_matmul's lookup
-        # (sp_dim, per_device_emb_dim, n_routed_experts) hits the tuned program config instead of
-        # silently falling back to TTNN's default tiling.
-        self.mm_configs = {
-            ((self.sp_dim, *key[1:]) if isinstance(key, tuple) else key): value
-            for key, value in self.mm_configs.items()
-        }
+        # Resolve mm_configs against the depth actually in use, so _device_matmul's lookup
+        # (sp_dim, per_device_emb_dim, n_routed_experts) hits a tuned entry instead of silently
+        # falling back to TTNN's default tiling. Two passes, because the any-depth entries must be
+        # laid down first for the depth-specific ones to override them:
+        #   sp_dim None -> applies at whatever depth is in use (the old placeholder behaviour)
+        #   sp_dim int  -> applies only at that depth, and wins there over the any-depth entry
+        resolved = {key: value for key, value in self.mm_configs.items() if not isinstance(key, tuple)}
+        for key, value in self.mm_configs.items():
+            if isinstance(key, tuple) and key[0] is None:
+                resolved[(self.sp_dim, *key[1:])] = value
+        for key, value in self.mm_configs.items():
+            if isinstance(key, tuple) and key[0] == self.sp_dim:
+                resolved[key] = value
+        self.mm_configs = resolved
 
     @property
     def num_cores(self):

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -210,16 +210,18 @@ class TtMoEGateConfig:
             )
         # Resolve mm_configs against the depth actually in use, so _device_matmul's lookup
         # (sp_dim, per_device_emb_dim, n_routed_experts) hits a tuned entry instead of silently
-        # falling back to TTNN's default tiling. Two passes, because the any-depth entries must be
-        # laid down first for the depth-specific ones to override them:
+        # falling back to TTNN's default tiling:
         #   sp_dim None -> applies at whatever depth is in use (the old placeholder behaviour)
         #   sp_dim int  -> applies only at that depth, and wins there over the any-depth entry
-        resolved = {key: value for key, value in self.mm_configs.items() if not isinstance(key, tuple)}
+        # setdefault is what enforces that precedence: a re-keyed any-depth entry never displaces a
+        # depth-specific one, whichever order the two were authored in.
+        resolved = {}
         for key, value in self.mm_configs.items():
-            if isinstance(key, tuple) and key[0] is None:
-                resolved[(self.sp_dim, *key[1:])] = value
-        for key, value in self.mm_configs.items():
-            if isinstance(key, tuple) and key[0] == self.sp_dim:
+            if not isinstance(key, tuple):
+                resolved[key] = value
+            elif key[0] is None:
+                resolved.setdefault((self.sp_dim, *key[1:]), value)
+            elif key[0] == self.sp_dim:
                 resolved[key] = value
         self.mm_configs = resolved
 

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -16,8 +16,12 @@ import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.reference.deepseek_v4_flash_config import DeepSeekV4FlashConfig
+from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
+from models.demos.deepseek_v3_d_p.reference.gpt_oss_120b_config import GptOss120BConfig
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
+from models.demos.deepseek_v3_d_p.reference.minimax_m2_7_config import MiniMaxM27Config
 from models.demos.deepseek_v3_d_p.tt.mla.utils import rotated_chip_real_token_counts
 from models.demos.deepseek_v3_d_p.tt.tt_ccl import get_tt_ccl
 
@@ -54,6 +58,14 @@ class GateComputeMode(Enum):
 # Per-chip prefill sequence the production deployment runs at, and the depth the MoE/gate tests
 # drive. Entries in mm_configs keyed at this depth override the any-depth (None) entries there.
 GATE_PRODUCTION_SP_DIM = 640
+
+# GPT-OSS is the one model whose per-device gate width is not tile-aligned: EMB_SIZE 2880 over TP 4
+# is 720, i.e. 22.5 tiles. The gate tests' adjust_shapes_for_testing rounds the model dim up to a
+# multiple of 32*TP (2880 -> 2944), so the width _device_matmul actually looks up under test is 736.
+# Its entry below is keyed to that width deliberately; a production run at the raw 2880 would look
+# up (640, 720, 128), miss, and fall back to TTNN's default tiling. Closing that gap needs the
+# non-tile-aligned width handled on the gate path, not another mm_configs entry.
+GPT_OSS_TEST_PER_DEVICE_EMB_DIM = 736
 
 
 @dataclass
@@ -165,6 +177,79 @@ class TtMoEGateConfig:
                     out_block_w=7,
                     per_core_M=1,
                     per_core_N=28,
+                    fuse_batch=True,
+                    mcast_in0=False,
+                )
+            ),
+            # The four below are these models' only entries at any depth; without them all four fell
+            # back to TTNN's default tiling at 640. Swept like the three above, but timed with the
+            # DEVICE profiler (python -m tracy -r -p): a call here is ~130us of enqueue overhead
+            # around a 12-43us kernel, so host wall time cannot rank candidates. DEVICE KERNEL
+            # DURATION, medians of 11 rotated rounds, PCC >= 0.999, spread 0.1-0.7us:
+            #   glm_5_1      K/dev 1536, 256 exp  (8,1) 42.6 | (4,1) 45.4 | default 46.3 | (1,1) 52.0
+            #   dsv4_flash   K/dev 1024, 256 exp  (8,1) 29.0 | default 29.5 | (4,1) 30.9 | (1,1) 37.8
+            #   minimax_m2_7 K/dev  768, 256 exp  (8,1) 22.7 | default 23.3 | (4,1) 24.1 | (1,1) 30.6
+            #   gpt_oss_120b K/dev  736, 128 exp  (4,1) 11.8 | default 12.5 | (2,1) 13.1 | (1,1) 14.4
+            # Widest out_block_w wins and out_subblock_w wants to be narrow, as at 4096; (4,1) is
+            # slower than TTNN's default at every 256-expert shape, as it was there too.
+            (GATE_PRODUCTION_SP_DIM, GLM51Config.EMB_SIZE // 4, GLM51Config.NUM_ROUTED_EXPERTS): (
+                ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                    compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
+                    in0_block_w=48,
+                    out_subblock_h=1,
+                    out_subblock_w=1,
+                    out_block_h=1,
+                    out_block_w=8,
+                    per_core_M=1,
+                    per_core_N=8,
+                    fuse_batch=True,
+                    mcast_in0=False,
+                )
+            ),
+            (GATE_PRODUCTION_SP_DIM, MiniMaxM27Config.EMB_SIZE // 4, MiniMaxM27Config.NUM_ROUTED_EXPERTS): (
+                ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                    compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
+                    in0_block_w=24,
+                    out_subblock_h=1,
+                    out_subblock_w=1,
+                    out_block_h=1,
+                    out_block_w=8,
+                    per_core_M=1,
+                    per_core_N=8,
+                    fuse_batch=True,
+                    mcast_in0=False,
+                )
+            ),
+            (
+                GATE_PRODUCTION_SP_DIM,
+                DeepSeekV4FlashConfig.EMB_SIZE // 4,
+                DeepSeekV4FlashConfig.NUM_ROUTED_EXPERTS,
+            ): (
+                ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                    compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
+                    in0_block_w=32,
+                    out_subblock_h=1,
+                    out_subblock_w=1,
+                    out_block_h=1,
+                    out_block_w=8,
+                    per_core_M=1,
+                    per_core_N=8,
+                    fuse_batch=True,
+                    mcast_in0=False,
+                )
+            ),
+            # Keyed at the tile-aligned test width, not EMB_SIZE // 4 -- see
+            # GPT_OSS_TEST_PER_DEVICE_EMB_DIM.
+            (GATE_PRODUCTION_SP_DIM, GPT_OSS_TEST_PER_DEVICE_EMB_DIM, GptOss120BConfig.NUM_ROUTED_EXPERTS): (
+                ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+                    compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
+                    in0_block_w=23,
+                    out_subblock_h=1,
+                    out_subblock_w=1,
+                    out_block_h=1,
+                    out_block_w=4,
+                    per_core_M=1,
+                    per_core_N=4,
                     fuse_batch=True,
                     mcast_in0=False,
                 )

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -56,7 +56,7 @@ class GateComputeMode(Enum):
 
 
 # Per-chip prefill sequence the production deployment runs at, and the depth the MoE/gate tests
-# drive. Entries in mm_configs keyed at this depth override the any-depth (None) entries there.
+# drive. Every tuned matmul entry is keyed to it; other depths fall back to TTNN's default tiling.
 GATE_PRODUCTION_SP_DIM = 640
 
 # GPT-OSS is the one model whose per-device gate width is not tile-aligned: EMB_SIZE 2880 over TP 4
@@ -85,46 +85,14 @@ class TtMoEGateConfig:
     mm_configs: dict = field(
         default_factory=lambda: {
             # Keyed by (sp_dim, per_device_emb_dim, n_routed_experts); forward() looks up the tuple.
-            # sp_dim None means "any depth": __post_init__ re-keys it to the depth in use. An entry
-            # authored at a real depth overrides the None entry at that depth (see __post_init__).
-            # per_core_N = n_routed_experts / 32 (tile width). Missing key → TTNN auto-picks.
+            # An entry applies only at the depth it is keyed to; a missing key → TTNN auto-picks.
+            # per_core_N = n_routed_experts / 32 (tile width).
             #
             # per_core_M is not free. It must equal max(1, ceil(sp_dim / (32 * num_cores))): below
             # that the 1D matmul needs more blocks than the grid has cores ("num_blocks_total <=
             # num_cores"), and for a height-sharded in0 it must also equal shard_shape[0] / 32. Both
             # rules give 1 up to 3520 tokens/chip and 2 at 4096. out_block_h follows it.
             #
-            # The None entries below were tuned at 4096 and carry per_core_M=2, which is why 640 --
-            # the production depth -- needs its own entries: at 640 per_core_M=2 splits 20 M-tiles
-            # over 10 cores instead of 20.
-            (None, DeepSeekV3Config.EMB_SIZE // 4, DeepSeekV3Config.NUM_ROUTED_EXPERTS): (
-                ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                    compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
-                    in0_block_w=56,
-                    out_subblock_h=1,
-                    out_subblock_w=4,
-                    out_block_h=2,
-                    out_block_w=4,
-                    per_core_M=2,
-                    per_core_N=8,
-                    fuse_batch=True,
-                    mcast_in0=False,
-                )
-            ),
-            (None, KimiK26Config.EMB_SIZE // 4, KimiK26Config.NUM_ROUTED_EXPERTS): (
-                ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-                    compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
-                    in0_block_w=56,
-                    out_subblock_h=1,
-                    out_subblock_w=4,
-                    out_block_h=2,
-                    out_block_w=4,
-                    per_core_M=2,
-                    per_core_N=12,
-                    fuse_batch=True,
-                    mcast_in0=False,
-                )
-            ),
             # 640 tokens/chip: 20 M-tiles, so per_core_M=1 spreads them over 20 cores rather than 10.
             #
             # The other three block sizes are measured, not derived, and none of them wants the value
@@ -404,20 +372,15 @@ class TtMoEGateConfig:
                 f"the op-side CB work that makes it true."
             )
 
-        # Resolve mm_configs against the depth actually in use, so _device_matmul's lookup
-        # (sp_dim, per_device_emb_dim, n_routed_experts) hits a tuned entry instead of silently
-        # falling back to TTNN's default tiling:
-        #   sp_dim None -> applies at whatever depth is in use (the old placeholder behaviour)
-        #   sp_dim int  -> applies only at that depth, and wins there over the any-depth entry
-        # setdefault is what enforces that precedence: a re-keyed any-depth entry never displaces a
-        # depth-specific one, whichever order the two were authored in.
+        # Drop the tuned entries authored at other depths, so _device_matmul's lookup
+        # (sp_dim, per_device_emb_dim, n_routed_experts) either hits an entry tuned at the depth in
+        # use or misses and falls back to TTNN's default tiling. per_core_M encodes the depth, so a
+        # foreign-depth entry is not merely mistuned -- the matmul rejects it against a sharded in0.
         def resolve(configs):
             resolved = {}
             for key, value in configs.items():
                 if not isinstance(key, tuple):
                     resolved[key] = value
-                elif key[0] is None:
-                    resolved.setdefault((self.sp_dim, *key[1:]), value)
                 elif key[0] == self.sp_dim:
                     resolved[key] = value
             return resolved

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -784,10 +784,6 @@ class TtMoEGatePrefill(LightweightModule):
             per_device_dim * n_tp_devices == self.config.dim
         ), f"Expected per-device dim {self.config.dim // n_tp_devices}, got {per_device_dim}"
         config_key = (self.config.sp_dim, per_device_dim, self.config.n_routed_experts)
-        # The 2D configs parallelise over N as well as M and are the faster of the two, but the matmul
-        # rejects them for a sharded in0 (it requires K == in0_block_w and a single-column shard grid).
-        # Interleaved therefore prefers the 2D table and falls back to the 1D entry, which is legal on
-        # either layout; anything sharded goes straight to 1D.
         program_config = None
         if x.memory_config().memory_layout == ttnn.TensorMemoryLayout.INTERLEAVED:
             program_config = self.config.mm_configs_interleaved.get(config_key)

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -96,8 +96,7 @@ class TtMoEGateConfig:
             #
             # The None entries below were tuned at 4096 and carry per_core_M=2, which is why 640 --
             # the production depth -- needs its own entries: at 640 per_core_M=2 splits 20 M-tiles
-            # over 10 cores instead of 20. K3's per_core_M was already 1 (MAX_GATE_SEQ_LEN_PER_CHIP
-            # keeps it under 3520), so its 640 entry exists only for out_block_w.
+            # over 10 cores instead of 20.
             (None, DeepSeekV3Config.EMB_SIZE // 4, DeepSeekV3Config.NUM_ROUTED_EXPERTS): (
                 ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                     compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
@@ -128,21 +127,28 @@ class TtMoEGateConfig:
             ),
             # 640 tokens/chip: 20 M-tiles, so per_core_M=1 spreads them over 20 cores rather than 10.
             #
-            # out_block_w and out_subblock_w are swept, not inherited: out_block_w wants to be the
-            # widest divisor of per_core_N that still builds (12 fails L1 allocation for 384 experts,
-            # 14 and 28 for 896), and out_subblock_w wants to be NARROW, not the widest the dest
-            # registers allow. Measured per call on a Blackhole Galaxy at 640 tokens/chip, medians of
-            # 7 rounds visited in rotated order (a single-pass sweep drifts enough to invert the
-            # ranking), every candidate at PCC 0.999999. Best three per model plus the alternatives:
-            #     256 experts  (8,1) 51.2  (8,2) 51.2  (8,4) 51.7 | default 54.7 | (4,1) 57.1 | shipped 89.3
-            #     384 experts  (6,1) 77.9  (6,2) 78.2  (6,3) 78.5 | (4,1) 84.2 | shipped 130.0 | default 436.5
-            #     896 experts  (7,1) 177.6 | (4,1) 194.3 | shipped 198.8 | default 437.6
-            # Do not "fix" out_subblock_w back up to 4 to match TTNN's own area-first heuristic
-            # (SUBBLOCK_HW_CHOICES): it is the slowest legal choice at every width measured.
+            # The other three block sizes are measured, not derived, and none of them wants the value
+            # a first reading suggests:
+            #   in0_block_w wants roughly a QUARTER of K, not all of it. Kernel time is U-shaped in
+            #   it, and full-K is the slow end: a single K block leaves no weight read to overlap
+            #   with math, and its L1 footprint bars the widest out_block_w below.
+            #   out_block_w trades against in0_block_w for L1, so the two are not separable: 12 (384
+            #   experts) and 14 (896) only fit at in0_block_w <= 14, and 28 (896) only at <= 8. The
+            #   widest that fits is not automatically fastest -- (8,28) fits and still loses to
+            #   (14,14) -- so the pair has to be swept together.
+            #   out_subblock_w wants to be NARROW, not the widest the dest registers allow. Do not
+            #   "fix" it up to 4 to match TTNN's own area-first heuristic (SUBBLOCK_HW_CHOICES): it
+            #   is the slowest legal choice at every width measured.
+            # DEVICE KERNEL DURATION per call on a Blackhole QuietBox 2, medians of 15 rounds visited
+            # in rotated order (a single-pass sweep drifts enough to invert the ranking), every
+            # candidate at PCC >= 0.99998. (in0_block_w, out_block_w) at out_subblock_w=1:
+            #     256 experts  (14,8) 37.3 | (28,8) 41.9 | (56,8) 49.9 | default 53.0
+            #     384 experts  (14,12) 54.4 | (14,6) 57.6 | (56,6) 77.2 | default 434.9
+            #     896 experts  (14,14) 125.1 | (14,7) 130.5 | (56,7) 175.7 | default 435.1
             (GATE_PRODUCTION_SP_DIM, DeepSeekV3Config.EMB_SIZE // 4, DeepSeekV3Config.NUM_ROUTED_EXPERTS): (
                 ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                     compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
-                    in0_block_w=56,
+                    in0_block_w=14,
                     out_subblock_h=1,
                     out_subblock_w=1,
                     out_block_h=1,
@@ -156,11 +162,11 @@ class TtMoEGateConfig:
             (GATE_PRODUCTION_SP_DIM, KimiK26Config.EMB_SIZE // 4, KimiK26Config.NUM_ROUTED_EXPERTS): (
                 ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                     compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
-                    in0_block_w=56,
+                    in0_block_w=14,
                     out_subblock_h=1,
                     out_subblock_w=1,
                     out_block_h=1,
-                    out_block_w=6,
+                    out_block_w=12,
                     per_core_M=1,
                     per_core_N=12,
                     fuse_batch=True,
@@ -170,32 +176,30 @@ class TtMoEGateConfig:
             (GATE_PRODUCTION_SP_DIM, KimiK3Config.EMB_SIZE // 4, KimiK3Config.NUM_ROUTED_EXPERTS): (
                 ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                     compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
-                    in0_block_w=56,
+                    in0_block_w=14,
                     out_subblock_h=1,
                     out_subblock_w=1,
                     out_block_h=1,
-                    out_block_w=7,
+                    out_block_w=14,
                     per_core_M=1,
                     per_core_N=28,
                     fuse_batch=True,
                     mcast_in0=False,
                 )
             ),
-            # The four below are these models' only entries at any depth; without them all four fell
-            # back to TTNN's default tiling at 640. Swept like the three above, but timed with the
-            # DEVICE profiler (python -m tracy -r -p): a call here is ~130us of enqueue overhead
-            # around a 12-43us kernel, so host wall time cannot rank candidates. DEVICE KERNEL
-            # DURATION, medians of 11 rotated rounds, PCC >= 0.999, spread 0.1-0.7us:
-            #   glm_5_1      K/dev 1536, 256 exp  (8,1) 42.6 | (4,1) 45.4 | default 46.3 | (1,1) 52.0
-            #   dsv4_flash   K/dev 1024, 256 exp  (8,1) 29.0 | default 29.5 | (4,1) 30.9 | (1,1) 37.8
-            #   minimax_m2_7 K/dev  768, 256 exp  (8,1) 22.7 | default 23.3 | (4,1) 24.1 | (1,1) 30.6
-            #   gpt_oss_120b K/dev  736, 128 exp  (4,1) 11.8 | default 12.5 | (2,1) 13.1 | (1,1) 14.4
-            # Widest out_block_w wins and out_subblock_w wants to be narrow, as at 4096; (4,1) is
-            # slower than TTNN's default at every 256-expert shape, as it was there too.
+            # The four below are these models' only entries at any depth; without them all four fall
+            # back to TTNN's default tiling at 640. Same three rules as above, and timed the same way.
+            # These kernels are 12-46us, small enough that per-call host overhead swamps the spread
+            # between candidates, so only DEVICE KERNEL DURATION ranks them. (in0_block_w, out_block_w):
+            #   glm_5_1      K/dev 1536, 256 exp  (12,8) 32.7 | (24,8) 36.2 | (48,8) 42.8 | default 45.7
+            #   dsv4_flash   K/dev 1024, 256 exp  (8,8) 24.6 | (16,8) 26.1 | (32,8) 29.0 | default 31.5
+            #   minimax_m2_7 K/dev  768, 256 exp  (8,8) 20.1 | (4,8) 22.1 | (24,8) 22.7 | default 24.5
+            #   gpt_oss_120b K/dev  736, 128 exp  (23,4) 12.4 | default 21.8
+            # gpt_oss is the one model with no in0_block_w to choose: 736/32 = 23 tiles is prime.
             (GATE_PRODUCTION_SP_DIM, GLM51Config.EMB_SIZE // 4, GLM51Config.NUM_ROUTED_EXPERTS): (
                 ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                     compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
-                    in0_block_w=48,
+                    in0_block_w=12,
                     out_subblock_h=1,
                     out_subblock_w=1,
                     out_block_h=1,
@@ -209,7 +213,7 @@ class TtMoEGateConfig:
             (GATE_PRODUCTION_SP_DIM, MiniMaxM27Config.EMB_SIZE // 4, MiniMaxM27Config.NUM_ROUTED_EXPERTS): (
                 ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                     compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
-                    in0_block_w=24,
+                    in0_block_w=8,
                     out_subblock_h=1,
                     out_subblock_w=1,
                     out_block_h=1,
@@ -227,7 +231,7 @@ class TtMoEGateConfig:
             ): (
                 ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                     compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
-                    in0_block_w=32,
+                    in0_block_w=8,
                     out_subblock_h=1,
                     out_subblock_w=1,
                     out_block_h=1,

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -267,6 +267,81 @@ class TtMoEGateConfig:
         }
     )
 
+    # 2D program configs, used only when in0 arrives INTERLEAVED (the layout TtMoe feeds in the
+    # deployed model). Keyed like mm_configs; a missing key falls back to the 1D entry there.
+    #
+    # These are not a tuning variant of the 1D entries, they are a different parallelisation. The 1D
+    # mcast_in0=False config splits the work over M alone, and at 640 tokens per_core_M=1 leaves 20
+    # M-tiles on 20 of the 110 cores. Splitting N as well puts 40-80 cores to work, and the speedup
+    # tracks the core count almost exactly.
+    #
+    # They cannot serve a height-sharded in0, which is why the layout picks the table rather than the
+    # entry carrying both: that path additionally requires K == in0_block_w (forfeiting the
+    # in0_block_w win) and a single-column shard grid, which the gate's 11-wide grid is not.
+    #
+    # DEVICE KERNEL DURATION per call on Blackhole, 640 tokens/chip, DRAM-interleaved in0, medians of
+    # 5 rotated rounds, PCC >= 0.999, measured independently on all 8 chips (spread <= 0.2x):
+    #     256 experts / K 1792   37.5 -> 17.5us (2.14x, 80 cores)
+    #     384 experts / K 1792   54.6 -> 18.6us (2.94x, 60 cores)
+    #     896 experts / K 1792  126.4 -> 32.1us (3.93x, 70 cores)
+    #     256 experts / K 1536   33.0 -> 14.9us (2.22x, 80 cores)
+    #     256 experts / K  768   20.3 ->  8.7us (2.33x, 80 cores)
+    #     256 experts / K 1024   24.8 -> 10.7us (2.32x, 80 cores)
+    #     128 experts / K  736   12.4 ->  8.6us (1.44x, 40 cores)
+    mm_configs_interleaved: dict = field(
+        default_factory=lambda: {
+            key: ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                compute_with_storage_grid_size=ttnn.CoreCoord(grid_x, 10),
+                in0_block_w=in0_block_w,
+                out_subblock_h=1,
+                out_subblock_w=out_subblock_w,
+                out_block_h=2,
+                out_block_w=per_core_N,
+                per_core_M=2,  # 20 M-tiles over the grid's 10 rows
+                per_core_N=per_core_N,
+                transpose_mcast=False,
+                fuse_batch=True,
+            )
+            for key, grid_x, per_core_N, in0_block_w, out_subblock_w in (
+                (
+                    (GATE_PRODUCTION_SP_DIM, DeepSeekV3Config.EMB_SIZE // 4, DeepSeekV3Config.NUM_ROUTED_EXPERTS),
+                    8,
+                    1,
+                    14,
+                    1,
+                ),
+                ((GATE_PRODUCTION_SP_DIM, KimiK26Config.EMB_SIZE // 4, KimiK26Config.NUM_ROUTED_EXPERTS), 6, 2, 14, 2),
+                ((GATE_PRODUCTION_SP_DIM, KimiK3Config.EMB_SIZE // 4, KimiK3Config.NUM_ROUTED_EXPERTS), 7, 4, 14, 2),
+                ((GATE_PRODUCTION_SP_DIM, GLM51Config.EMB_SIZE // 4, GLM51Config.NUM_ROUTED_EXPERTS), 8, 1, 12, 1),
+                (
+                    (GATE_PRODUCTION_SP_DIM, MiniMaxM27Config.EMB_SIZE // 4, MiniMaxM27Config.NUM_ROUTED_EXPERTS),
+                    8,
+                    1,
+                    8,
+                    1,
+                ),
+                (
+                    (
+                        GATE_PRODUCTION_SP_DIM,
+                        DeepSeekV4FlashConfig.EMB_SIZE // 4,
+                        DeepSeekV4FlashConfig.NUM_ROUTED_EXPERTS,
+                    ),
+                    8,
+                    1,
+                    8,
+                    1,
+                ),
+                (
+                    (GATE_PRODUCTION_SP_DIM, GPT_OSS_TEST_PER_DEVICE_EMB_DIM, GptOss120BConfig.NUM_ROUTED_EXPERTS),
+                    4,
+                    1,
+                    23,
+                    1,
+                ),
+            )
+        }
+    )
+
     dim: int = DeepSeekV3Config.EMB_SIZE
     sp_dim: int = 4096  # ISL per chip
     # Enforced in __post_init__. At high expert counts moe_grouped_topk's circular buffers stop
@@ -297,6 +372,7 @@ class TtMoEGateConfig:
                 f"experts/32 and will fail L1 allocation above it. Raise the ceiling only alongside "
                 f"the op-side CB work that makes it true."
             )
+
         # Resolve mm_configs against the depth actually in use, so _device_matmul's lookup
         # (sp_dim, per_device_emb_dim, n_routed_experts) hits a tuned entry instead of silently
         # falling back to TTNN's default tiling:
@@ -304,15 +380,19 @@ class TtMoEGateConfig:
         #   sp_dim int  -> applies only at that depth, and wins there over the any-depth entry
         # setdefault is what enforces that precedence: a re-keyed any-depth entry never displaces a
         # depth-specific one, whichever order the two were authored in.
-        resolved = {}
-        for key, value in self.mm_configs.items():
-            if not isinstance(key, tuple):
-                resolved[key] = value
-            elif key[0] is None:
-                resolved.setdefault((self.sp_dim, *key[1:]), value)
-            elif key[0] == self.sp_dim:
-                resolved[key] = value
-        self.mm_configs = resolved
+        def resolve(configs):
+            resolved = {}
+            for key, value in configs.items():
+                if not isinstance(key, tuple):
+                    resolved[key] = value
+                elif key[0] is None:
+                    resolved.setdefault((self.sp_dim, *key[1:]), value)
+                elif key[0] == self.sp_dim:
+                    resolved[key] = value
+            return resolved
+
+        self.mm_configs = resolve(self.mm_configs)
+        self.mm_configs_interleaved = resolve(self.mm_configs_interleaved)
 
     @property
     def num_cores(self):
@@ -726,7 +806,15 @@ class TtMoEGatePrefill(LightweightModule):
             per_device_dim * n_tp_devices == self.config.dim
         ), f"Expected per-device dim {self.config.dim // n_tp_devices}, got {per_device_dim}"
         config_key = (self.config.sp_dim, per_device_dim, self.config.n_routed_experts)
-        program_config = self.config.mm_configs.get(config_key)
+        # The 2D configs parallelise over N as well as M and are 1.4-3.9x the 1D ones, but the matmul
+        # rejects them for a sharded in0 (it requires K == in0_block_w and a single-column shard grid).
+        # Interleaved therefore prefers the 2D table and falls back to the 1D entry, which is legal on
+        # either layout; anything sharded goes straight to 1D.
+        program_config = None
+        if x.memory_config().memory_layout == ttnn.TensorMemoryLayout.INTERLEAVED:
+            program_config = self.config.mm_configs_interleaved.get(config_key)
+        if program_config is None:
+            program_config = self.config.mm_configs.get(config_key)
         if program_config is None:
             logger.warning(f"[MoeGate] No matmul program config for {config_key}, using TTNN default")
 

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -59,10 +59,19 @@ class GateComputeMode(Enum):
 # drive. Every tuned matmul entry is keyed to it; other depths fall back to TTNN's default tiling.
 GATE_PRODUCTION_SP_DIM = 640
 
-# GPT-OSS's per-device gate width is the one that is not tile-aligned: 2880 over TP 4 is 720, i.e.
-# 22.5 tiles, which the tests' adjust_shapes_for_testing rounds to 736. A production run at the raw
-# 2880 looks up 720, misses, and takes TTNN's default tiling -- that needs a fix on the gate path.
-GPT_OSS_TEST_PER_DEVICE_EMB_DIM = 736
+
+def gate_mm_config_key(sp_dim: int, per_device_emb_dim: int, n_routed_experts: int) -> tuple[int, int, int]:
+    """Key one gate matmul shape into mm_configs / mm_configs_interleaved.
+
+    The width is rounded up to a whole tile because that is the K the matmul contracts: a TILE_LAYOUT
+    tensor's K comes from its padded shape, so a per-device width that is not tile-aligned runs the
+    same matmul -- same K tiles, same L1 footprint -- as the next multiple of 32. GPT-OSS is the only
+    model where that bites: 2880 over TP 4 is 720, i.e. 22.5 tiles. Rounding here is what keeps that
+    production width and the 736 a height-sharded test's adjust_shapes_for_testing rounds it to (an
+    L1 shard width must be whole tiles) on one tuned entry, instead of the production key missing.
+    """
+    k_tiles = (per_device_emb_dim + ttnn.TILE_SIZE - 1) // ttnn.TILE_SIZE
+    return (sp_dim, k_tiles * ttnn.TILE_SIZE, n_routed_experts)
 
 
 @dataclass
@@ -81,7 +90,8 @@ class TtMoEGateConfig:
     )
     mm_configs: dict = field(
         default_factory=lambda: {
-            # Keyed by (sp_dim, per_device_emb_dim, n_routed_experts); forward() looks up the tuple.
+            # Keyed by gate_mm_config_key(sp_dim, per_device_emb_dim, n_routed_experts): __post_init__
+            # re-keys every entry through it and _device_matmul looks the tuple up through it too.
             # An entry applies only at the depth it is keyed to; a missing key → TTNN auto-picks.
             # per_core_N = n_routed_experts / 32 (tile width).
             #
@@ -184,9 +194,9 @@ class TtMoEGateConfig:
                     mcast_in0=False,
                 )
             ),
-            # Keyed at the tile-aligned test width, not EMB_SIZE // 4 -- see
-            # GPT_OSS_TEST_PER_DEVICE_EMB_DIM.
-            (GATE_PRODUCTION_SP_DIM, GPT_OSS_TEST_PER_DEVICE_EMB_DIM, GptOss120BConfig.NUM_ROUTED_EXPERTS): (
+            # 2880 // 4 is 720, i.e. 22.5 tiles, which gate_mm_config_key keys at 736: in0_block_w=23
+            # is the full K, and out_block_w=4 the whole 128-expert N.
+            (GATE_PRODUCTION_SP_DIM, GptOss120BConfig.EMB_SIZE // 4, GptOss120BConfig.NUM_ROUTED_EXPERTS): (
                 ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                     compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
                     in0_block_w=23,
@@ -308,7 +318,7 @@ class TtMoEGateConfig:
                     fuse_batch=True,
                 )
             ),
-            (GATE_PRODUCTION_SP_DIM, GPT_OSS_TEST_PER_DEVICE_EMB_DIM, GptOss120BConfig.NUM_ROUTED_EXPERTS): (
+            (GATE_PRODUCTION_SP_DIM, GptOss120BConfig.EMB_SIZE // 4, GptOss120BConfig.NUM_ROUTED_EXPERTS): (
                 ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                     compute_with_storage_grid_size=ttnn.CoreCoord(4, 10),
                     in0_block_w=23,
@@ -356,17 +366,18 @@ class TtMoEGateConfig:
                 f"the op-side CB work that makes it true."
             )
 
-        # Drop the tuned entries authored at other depths, so _device_matmul's lookup
-        # (sp_dim, per_device_emb_dim, n_routed_experts) either hits an entry tuned at the depth in
-        # use or misses and falls back to TTNN's default tiling. per_core_M encodes the depth, so a
-        # foreign-depth entry is not merely mistuned -- the matmul rejects it against a sharded in0.
+        # Drop the tuned entries authored at other depths, so _device_matmul's lookup either hits an
+        # entry tuned at the depth in use or misses and falls back to TTNN's default tiling. per_core_M
+        # encodes the depth, so a foreign-depth entry is not merely mistuned -- the matmul rejects it
+        # against a sharded in0. The surviving keys are normalized through gate_mm_config_key, the same
+        # call _device_matmul forms its lookup with.
         def resolve(configs):
             resolved = {}
             for key, value in configs.items():
                 if not isinstance(key, tuple):
                     resolved[key] = value
                 elif key[0] == self.sp_dim:
-                    resolved[key] = value
+                    resolved[gate_mm_config_key(*key)] = value
             return resolved
 
         self.mm_configs = resolve(self.mm_configs)
@@ -783,7 +794,7 @@ class TtMoEGatePrefill(LightweightModule):
         assert (
             per_device_dim * n_tp_devices == self.config.dim
         ), f"Expected per-device dim {self.config.dim // n_tp_devices}, got {per_device_dim}"
-        config_key = (self.config.sp_dim, per_device_dim, self.config.n_routed_experts)
+        config_key = gate_mm_config_key(self.config.sp_dim, per_device_dim, self.config.n_routed_experts)
         program_config = None
         if x.memory_config().memory_layout == ttnn.TensorMemoryLayout.INTERLEAVED:
             program_config = self.config.mm_configs_interleaved.get(config_key)

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -59,12 +59,9 @@ class GateComputeMode(Enum):
 # drive. Every tuned matmul entry is keyed to it; other depths fall back to TTNN's default tiling.
 GATE_PRODUCTION_SP_DIM = 640
 
-# GPT-OSS is the one model whose per-device gate width is not tile-aligned: EMB_SIZE 2880 over TP 4
-# is 720, i.e. 22.5 tiles. The gate tests' adjust_shapes_for_testing rounds the model dim up to a
-# multiple of 32*TP (2880 -> 2944), so the width _device_matmul actually looks up under test is 736.
-# Its entry below is keyed to that width deliberately; a production run at the raw 2880 would look
-# up (640, 720, 128), miss, and fall back to TTNN's default tiling. Closing that gap needs the
-# non-tile-aligned width handled on the gate path, not another mm_configs entry.
+# GPT-OSS's per-device gate width is the one that is not tile-aligned: 2880 over TP 4 is 720, i.e.
+# 22.5 tiles, which the tests' adjust_shapes_for_testing rounds to 736. A production run at the raw
+# 2880 looks up 720, misses, and takes TTNN's default tiling -- that needs a fix on the gate path.
 GPT_OSS_TEST_PER_DEVICE_EMB_DIM = 736
 
 
@@ -88,39 +85,17 @@ class TtMoEGateConfig:
             # An entry applies only at the depth it is keyed to; a missing key → TTNN auto-picks.
             # per_core_N = n_routed_experts / 32 (tile width).
             #
-            # per_core_M is not free. It must equal max(1, ceil(sp_dim / (32 * num_cores))): below
-            # that the 1D matmul needs more blocks than the grid has cores ("num_blocks_total <=
-            # num_cores"), and for a height-sharded in0 it must also equal shard_shape[0] / 32. Both
-            # rules give 1 up to 3520 tokens/chip and 2 at 4096. out_block_h follows it.
+            # per_core_M is not free: it must equal max(1, ceil(sp_dim / (32 * num_cores))), below
+            # which the 1D matmul wants more blocks than the grid has cores ("num_blocks_total <=
+            # num_cores"), and a height-sharded in0 additionally pins it to shard_shape[0] / 32.
+            # out_block_h follows it, and at 640 tokens it is 1: one M-tile per block.
             #
-            # 640 tokens/chip: 20 M-tiles, so per_core_M=1 spreads them over 20 cores rather than 10.
-            #
-            # The other three block sizes are measured, not derived, and none of them wants the value
-            # a first reading suggests:
-            #   in0_block_w wants roughly a QUARTER of K, not all of it. Kernel time is U-shaped in
-            #   it, and full-K is the slow end: a single K block leaves no weight read to overlap
-            #   with math, and its L1 footprint bars the widest out_block_w below.
-            #   out_block_w trades against in0_block_w for L1, so the two are not separable: 12 (384
-            #   experts) and 14 (896) only fit at in0_block_w <= 14, and 28 (896) only at <= 8. The
-            #   widest that fits is not automatically fastest -- (8,28) fits and still loses to
-            #   (14,14) -- so the pair has to be swept together.
-            #   out_subblock_w is not simply "as narrow as legal": 1 wins only while in0_block_w is
-            #   full-K. At the quarter-K value above, 2 takes every out_block_w of 8 or 14, and the
-            #   12-wide pair want 4; only out_block_w 4 (128 experts) still prefers 1. TTNN's own
-            #   area-first heuristic (SUBBLOCK_HW_CHOICES) reaches for the widest the dest registers
-            #   allow, which is right for the 12-wide shapes and wrong for the rest.
-            # DEVICE KERNEL DURATION per call on a Blackhole QuietBox 2, medians of 15 rounds visited
-            # in rotated order (a single-pass sweep drifts enough to invert the ranking), every
-            # candidate at PCC >= 0.99998. (in0_block_w, out_block_w) at out_subblock_w=1:
-            #     256 experts  (14,8) 37.3 | (28,8) 41.9 | (56,8) 49.9 | default 53.0
-            #     384 experts  (14,12) 54.4 | (14,6) 57.6 | (56,6) 77.2 | default 434.9
-            #     896 experts  (14,14) 125.1 | (14,7) 130.5 | (56,7) 175.7 | default 435.1
-            # out_subblock_w swept separately on a height-sharded in0, the layout this table serves
-            # now that an interleaved one resolves mm_configs_interleaved first (11 rotated rounds):
-            #     out_block_w 8   osw 2 wins: 36.5 / 31.7 / 19.3 / 23.4 vs 36.9 / 32.5 / 19.9 / 24.4
-            #     out_block_w 12  osw 4 wins by 0.3% over 3 and 2 -- inside the run-to-run spread
-            #     out_block_w 14  osw 2 wins: 120.8 vs 125.4
-            #     out_block_w 4   osw 1 wins: 11.8 vs 12.0
+            # The other three are measured, and none takes the value a first reading suggests:
+            #   in0_block_w wants roughly a QUARTER of K: one K block leaves no weight read to overlap
+            #   with math, and its L1 footprint caps out_block_w -- the two couple through L1, so they
+            #   are swept as a pair, and the widest that fits is not the fastest.
+            #   out_subblock_w=1 wins only at a full-K in0_block_w; TTNN's area-first SUBBLOCK_HW_CHOICES
+            #   (widest the dest allows) is right only for the 12-wide out_block_w.
             (GATE_PRODUCTION_SP_DIM, DeepSeekV3Config.EMB_SIZE // 4, DeepSeekV3Config.NUM_ROUTED_EXPERTS): (
                 ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                     compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
@@ -163,15 +138,6 @@ class TtMoEGateConfig:
                     mcast_in0=False,
                 )
             ),
-            # The four below are these models' only entries at any depth; without them all four fall
-            # back to TTNN's default tiling at 640. Same three rules as above, and timed the same way.
-            # These kernels are 12-46us, small enough that per-call host overhead swamps the spread
-            # between candidates, so only DEVICE KERNEL DURATION ranks them. (in0_block_w, out_block_w):
-            #   glm_5_1      K/dev 1536, 256 exp  (12,8) 32.7 | (24,8) 36.2 | (48,8) 42.8 | default 45.7
-            #   dsv4_flash   K/dev 1024, 256 exp  (8,8) 24.6 | (16,8) 26.1 | (32,8) 29.0 | default 31.5
-            #   minimax_m2_7 K/dev  768, 256 exp  (8,8) 20.1 | (4,8) 22.1 | (24,8) 22.7 | default 24.5
-            #   gpt_oss_120b K/dev  736, 128 exp  (23,4) 12.4 | default 21.8
-            # gpt_oss is the one model with no in0_block_w to choose: 736/32 = 23 tiles is prime.
             (GATE_PRODUCTION_SP_DIM, GLM51Config.EMB_SIZE // 4, GLM51Config.NUM_ROUTED_EXPERTS): (
                 ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                     compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
@@ -243,50 +209,19 @@ class TtMoEGateConfig:
         }
     )
 
-    # 2D program configs, used only when in0 arrives INTERLEAVED (the layout TtMoe feeds in the
-    # deployed model). Keyed like mm_configs; a missing key falls back to the 1D entry there.
+    # 2D program configs for an INTERLEAVED in0 (what TtMoe feeds); keyed like mm_configs, and a miss
+    # falls back to the 1D entry there. The pick is by layout, not tuning: a height-sharded in0 also
+    # requires K == in0_block_w and a single-column shard grid, which the gate's 11-wide grid is not.
     #
-    # These are not a tuning variant of the 1D entries, they are a different parallelisation. The 1D
-    # mcast_in0=False config splits the work over M alone, and at 640 tokens per_core_M=1 leaves 20
-    # M-tiles on 20 of the 110 cores. Splitting N as well puts 40-100 cores to work, and the speedup
-    # tracks the core count almost exactly.
+    # The op only requires ceil(N_tiles / per_core_N) <= grid.x and ceil(M_tiles / per_core_M) <=
+    # grid.y, so per_core_N need NOT divide N_tiles: 896 experts' 28 N-tiles reach 10 columns at
+    # per_core_N=3 (the last padded) where exact division stops at 7. The usable grid is 11x10, and 20
+    # M-tiles over 10 rows forces per_core_M=2, so only the column count varies.
     #
-    # They cannot serve a height-sharded in0, which is why the layout picks the table rather than the
-    # entry carrying both: that path additionally requires K == in0_block_w (forfeiting the
-    # in0_block_w win) and a single-column shard grid, which the gate's 11-wide grid is not.
-    #
-    # Core count is set by how many output blocks the grid can hold, and the op only requires
-    # ceil(N_tiles / per_core_N) <= grid.x and ceil(M_tiles / per_core_M) <= grid.y -- per_core_N need
-    # NOT divide N_tiles. That is what 896 experts turns on: 28 N-tiles at per_core_N=4 is 7 columns,
-    # but at per_core_N=3 it is 10 (the last covering 2 tiles of padding), for 100 cores instead of 70.
-    # Exact division would have missed it. The usable grid is 11x10: compute_with_storage_grid_size()
-    # reports 12x10 but a column goes to op dispatch, which is why the gate's core_grid is 11 wide.
-    #
-    # Given that, these ceilings are structural rather than untuned -- 20 M-tiles over at most 10 rows
-    # forces per_core_M >= 2, so the row count is always 10 and only the column count is in play:
-    #     128 experts (4 N-tiles)   4 cols  ->  40 cores
-    #     256 experts (8 N-tiles)   8 cols  ->  80 cores
-    #     384 experts (12 N-tiles)  6 cols  ->  60 cores, since 12 cols would exceed the 11 available
-    #     896 experts (28 N-tiles) 10 cols  -> 100 cores
-    # Trading columns for per_core_N always loses (~20% at half the cores), and transpose_mcast=True
-    # loses badly even at equal core count (gpt_oss 14.2 vs 8.7us), so mcast direction is not free.
-    #
-    # in0_block_w does not follow the 1D table's quarter-of-K rule -- that rule is a property of the 1D
-    # parallelisation, where a core owns the whole N. Here an exhaustive sweep over the divisors of K
-    # put it at 8 for every entry except 896 experts (14) and gpt_oss, whose 736/32 = 23 tiles is prime,
-    # leaving 1 and 23 as the sole legal widths with 1 running 2.2x slower. in0_block_w and the subblock
-    # have to be swept together, not in sequence: at 384 experts, 14 beats 8 while out_subblock is
-    # pinned to 1x1 and loses to it once the subblock is free.
-    #
-    # DEVICE KERNEL DURATION per call on Blackhole, 640 tokens/chip, DRAM-interleaved in0, medians of
-    # 9 rotated rounds, PCC >= 0.999, measured independently on all 32 chips (spread <= 0.5us):
-    #     256 experts / K 1792   37.1 -> 16.2us (2.29x,  80 cores)
-    #     384 experts / K 1792   53.2 -> 19.0us (2.80x,  60 cores)
-    #     896 experts / K 1792  121.3 -> 25.2us (4.81x, 100 cores)
-    #     256 experts / K 1536   32.3 -> 14.5us (2.23x,  80 cores)
-    #     256 experts / K  768   19.7 ->  8.8us (2.24x,  80 cores)
-    #     256 experts / K 1024   23.8 -> 10.6us (2.25x,  80 cores)
-    #     128 experts / K  736   12.4 ->  8.7us (1.43x,  40 cores)
+    # The block sizes are swept, not derived: in0_block_w does NOT follow the 1D table's quarter-of-K
+    # rule (that one belongs to a 1D core owning all of N), it must be swept jointly with out_subblock_w
+    # because the ranking inverts once the subblock is free, and neither mcast knob is free -- trading
+    # grid columns for a wider per_core_N and transpose_mcast=True both lose.
     mm_configs_interleaved: dict = field(
         default_factory=lambda: {
             key: ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
@@ -800,7 +735,7 @@ class TtMoEGatePrefill(LightweightModule):
             per_device_dim * n_tp_devices == self.config.dim
         ), f"Expected per-device dim {self.config.dim // n_tp_devices}, got {per_device_dim}"
         config_key = (self.config.sp_dim, per_device_dim, self.config.n_routed_experts)
-        # The 2D configs parallelise over N as well as M and are 1.4-3.9x the 1D ones, but the matmul
+        # The 2D configs parallelise over N as well as M and are the faster of the two, but the matmul
         # rejects them for a sharded in0 (it requires K == in0_block_w and a single-column shard grid).
         # Interleaved therefore prefers the 2D table and falls back to the 1D entry, which is legal on
         # either layout; anything sharded goes straight to 1D.

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -224,55 +224,104 @@ class TtMoEGateConfig:
     # grid columns for a wider per_core_N and transpose_mcast=True both lose.
     mm_configs_interleaved: dict = field(
         default_factory=lambda: {
-            key: ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
-                compute_with_storage_grid_size=ttnn.CoreCoord(grid_x, 10),
-                in0_block_w=in0_block_w,
-                out_subblock_h=1,
-                out_subblock_w=out_subblock_w,
-                out_block_h=2,
-                out_block_w=per_core_N,
-                per_core_M=2,  # 20 M-tiles over the grid's 10 rows
-                per_core_N=per_core_N,
-                transpose_mcast=False,
-                fuse_batch=True,
-            )
-            for key, grid_x, per_core_N, in0_block_w, out_subblock_w in (
-                (
-                    (GATE_PRODUCTION_SP_DIM, DeepSeekV3Config.EMB_SIZE // 4, DeepSeekV3Config.NUM_ROUTED_EXPERTS),
-                    8,
-                    1,
-                    8,
-                    1,
-                ),
-                ((GATE_PRODUCTION_SP_DIM, KimiK26Config.EMB_SIZE // 4, KimiK26Config.NUM_ROUTED_EXPERTS), 6, 2, 8, 2),
-                ((GATE_PRODUCTION_SP_DIM, KimiK3Config.EMB_SIZE // 4, KimiK3Config.NUM_ROUTED_EXPERTS), 10, 3, 14, 3),
-                ((GATE_PRODUCTION_SP_DIM, GLM51Config.EMB_SIZE // 4, GLM51Config.NUM_ROUTED_EXPERTS), 8, 1, 8, 1),
-                (
-                    (GATE_PRODUCTION_SP_DIM, MiniMaxM27Config.EMB_SIZE // 4, MiniMaxM27Config.NUM_ROUTED_EXPERTS),
-                    8,
-                    1,
-                    8,
-                    1,
-                ),
-                (
-                    (
-                        GATE_PRODUCTION_SP_DIM,
-                        DeepSeekV4FlashConfig.EMB_SIZE // 4,
-                        DeepSeekV4FlashConfig.NUM_ROUTED_EXPERTS,
-                    ),
-                    8,
-                    1,
-                    8,
-                    1,
-                ),
-                (
-                    (GATE_PRODUCTION_SP_DIM, GPT_OSS_TEST_PER_DEVICE_EMB_DIM, GptOss120BConfig.NUM_ROUTED_EXPERTS),
-                    4,
-                    1,
-                    23,
-                    1,
-                ),
-            )
+            (GATE_PRODUCTION_SP_DIM, DeepSeekV3Config.EMB_SIZE // 4, DeepSeekV3Config.NUM_ROUTED_EXPERTS): (
+                ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=ttnn.CoreCoord(8, 10),
+                    in0_block_w=8,
+                    out_subblock_h=1,
+                    out_subblock_w=1,
+                    out_block_h=2,
+                    out_block_w=1,
+                    per_core_M=2,
+                    per_core_N=1,
+                    transpose_mcast=False,
+                    fuse_batch=True,
+                )
+            ),
+            (GATE_PRODUCTION_SP_DIM, KimiK26Config.EMB_SIZE // 4, KimiK26Config.NUM_ROUTED_EXPERTS): (
+                ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=ttnn.CoreCoord(6, 10),
+                    in0_block_w=8,
+                    out_subblock_h=1,
+                    out_subblock_w=2,
+                    out_block_h=2,
+                    out_block_w=2,
+                    per_core_M=2,
+                    per_core_N=2,
+                    transpose_mcast=False,
+                    fuse_batch=True,
+                )
+            ),
+            (GATE_PRODUCTION_SP_DIM, KimiK3Config.EMB_SIZE // 4, KimiK3Config.NUM_ROUTED_EXPERTS): (
+                ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=ttnn.CoreCoord(10, 10),
+                    in0_block_w=14,
+                    out_subblock_h=1,
+                    out_subblock_w=3,
+                    out_block_h=2,
+                    out_block_w=3,
+                    per_core_M=2,
+                    per_core_N=3,
+                    transpose_mcast=False,
+                    fuse_batch=True,
+                )
+            ),
+            (GATE_PRODUCTION_SP_DIM, GLM51Config.EMB_SIZE // 4, GLM51Config.NUM_ROUTED_EXPERTS): (
+                ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=ttnn.CoreCoord(8, 10),
+                    in0_block_w=8,
+                    out_subblock_h=1,
+                    out_subblock_w=1,
+                    out_block_h=2,
+                    out_block_w=1,
+                    per_core_M=2,
+                    per_core_N=1,
+                    transpose_mcast=False,
+                    fuse_batch=True,
+                )
+            ),
+            (GATE_PRODUCTION_SP_DIM, MiniMaxM27Config.EMB_SIZE // 4, MiniMaxM27Config.NUM_ROUTED_EXPERTS): (
+                ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=ttnn.CoreCoord(8, 10),
+                    in0_block_w=8,
+                    out_subblock_h=1,
+                    out_subblock_w=1,
+                    out_block_h=2,
+                    out_block_w=1,
+                    per_core_M=2,
+                    per_core_N=1,
+                    transpose_mcast=False,
+                    fuse_batch=True,
+                )
+            ),
+            (GATE_PRODUCTION_SP_DIM, DeepSeekV4FlashConfig.EMB_SIZE // 4, DeepSeekV4FlashConfig.NUM_ROUTED_EXPERTS): (
+                ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=ttnn.CoreCoord(8, 10),
+                    in0_block_w=8,
+                    out_subblock_h=1,
+                    out_subblock_w=1,
+                    out_block_h=2,
+                    out_block_w=1,
+                    per_core_M=2,
+                    per_core_N=1,
+                    transpose_mcast=False,
+                    fuse_batch=True,
+                )
+            ),
+            (GATE_PRODUCTION_SP_DIM, GPT_OSS_TEST_PER_DEVICE_EMB_DIM, GptOss120BConfig.NUM_ROUTED_EXPERTS): (
+                ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                    compute_with_storage_grid_size=ttnn.CoreCoord(4, 10),
+                    in0_block_w=23,
+                    out_subblock_h=1,
+                    out_subblock_w=1,
+                    out_block_h=2,
+                    out_block_w=1,
+                    per_core_M=2,
+                    per_core_N=1,
+                    transpose_mcast=False,
+                    fuse_batch=True,
+                )
+            ),
         }
     )
 

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -280,22 +280,45 @@ class TtMoEGateConfig:
     #
     # These are not a tuning variant of the 1D entries, they are a different parallelisation. The 1D
     # mcast_in0=False config splits the work over M alone, and at 640 tokens per_core_M=1 leaves 20
-    # M-tiles on 20 of the 110 cores. Splitting N as well puts 40-80 cores to work, and the speedup
+    # M-tiles on 20 of the 110 cores. Splitting N as well puts 40-100 cores to work, and the speedup
     # tracks the core count almost exactly.
     #
     # They cannot serve a height-sharded in0, which is why the layout picks the table rather than the
     # entry carrying both: that path additionally requires K == in0_block_w (forfeiting the
     # in0_block_w win) and a single-column shard grid, which the gate's 11-wide grid is not.
     #
+    # Core count is set by how many output blocks the grid can hold, and the op only requires
+    # ceil(N_tiles / per_core_N) <= grid.x and ceil(M_tiles / per_core_M) <= grid.y -- per_core_N need
+    # NOT divide N_tiles. That is what 896 experts turns on: 28 N-tiles at per_core_N=4 is 7 columns,
+    # but at per_core_N=3 it is 10 (the last covering 2 tiles of padding), for 100 cores instead of 70.
+    # Exact division would have missed it. The usable grid is 11x10: compute_with_storage_grid_size()
+    # reports 12x10 but a column goes to op dispatch, which is why the gate's core_grid is 11 wide.
+    #
+    # Given that, these ceilings are structural rather than untuned -- 20 M-tiles over at most 10 rows
+    # forces per_core_M >= 2, so the row count is always 10 and only the column count is in play:
+    #     128 experts (4 N-tiles)   4 cols  ->  40 cores
+    #     256 experts (8 N-tiles)   8 cols  ->  80 cores
+    #     384 experts (12 N-tiles)  6 cols  ->  60 cores, since 12 cols would exceed the 11 available
+    #     896 experts (28 N-tiles) 10 cols  -> 100 cores
+    # Trading columns for per_core_N always loses (~20% at half the cores), and transpose_mcast=True
+    # loses badly even at equal core count (gpt_oss 14.2 vs 8.7us), so mcast direction is not free.
+    #
+    # in0_block_w does not follow the 1D table's quarter-of-K rule -- that rule is a property of the 1D
+    # parallelisation, where a core owns the whole N. Here an exhaustive sweep over the divisors of K
+    # put it at 8 for every entry except 896 experts (14) and gpt_oss, whose 736/32 = 23 tiles is prime,
+    # leaving 1 and 23 as the sole legal widths with 1 running 2.2x slower. in0_block_w and the subblock
+    # have to be swept together, not in sequence: at 384 experts, 14 beats 8 while out_subblock is
+    # pinned to 1x1 and loses to it once the subblock is free.
+    #
     # DEVICE KERNEL DURATION per call on Blackhole, 640 tokens/chip, DRAM-interleaved in0, medians of
-    # 5 rotated rounds, PCC >= 0.999, measured independently on all 8 chips (spread <= 0.2x):
-    #     256 experts / K 1792   37.5 -> 17.5us (2.14x, 80 cores)
-    #     384 experts / K 1792   54.6 -> 18.6us (2.94x, 60 cores)
-    #     896 experts / K 1792  126.4 -> 32.1us (3.93x, 70 cores)
-    #     256 experts / K 1536   33.0 -> 14.9us (2.22x, 80 cores)
-    #     256 experts / K  768   20.3 ->  8.7us (2.33x, 80 cores)
-    #     256 experts / K 1024   24.8 -> 10.7us (2.32x, 80 cores)
-    #     128 experts / K  736   12.4 ->  8.6us (1.44x, 40 cores)
+    # 9 rotated rounds, PCC >= 0.999, measured independently on all 32 chips (spread <= 0.5us):
+    #     256 experts / K 1792   37.1 -> 16.2us (2.29x,  80 cores)
+    #     384 experts / K 1792   53.2 -> 19.0us (2.80x,  60 cores)
+    #     896 experts / K 1792  121.3 -> 25.2us (4.81x, 100 cores)
+    #     256 experts / K 1536   32.3 -> 14.5us (2.23x,  80 cores)
+    #     256 experts / K  768   19.7 ->  8.8us (2.24x,  80 cores)
+    #     256 experts / K 1024   23.8 -> 10.6us (2.25x,  80 cores)
+    #     128 experts / K  736   12.4 ->  8.7us (1.43x,  40 cores)
     mm_configs_interleaved: dict = field(
         default_factory=lambda: {
             key: ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
@@ -315,12 +338,12 @@ class TtMoEGateConfig:
                     (GATE_PRODUCTION_SP_DIM, DeepSeekV3Config.EMB_SIZE // 4, DeepSeekV3Config.NUM_ROUTED_EXPERTS),
                     8,
                     1,
-                    14,
+                    8,
                     1,
                 ),
-                ((GATE_PRODUCTION_SP_DIM, KimiK26Config.EMB_SIZE // 4, KimiK26Config.NUM_ROUTED_EXPERTS), 6, 2, 14, 2),
-                ((GATE_PRODUCTION_SP_DIM, KimiK3Config.EMB_SIZE // 4, KimiK3Config.NUM_ROUTED_EXPERTS), 7, 4, 14, 2),
-                ((GATE_PRODUCTION_SP_DIM, GLM51Config.EMB_SIZE // 4, GLM51Config.NUM_ROUTED_EXPERTS), 8, 1, 12, 1),
+                ((GATE_PRODUCTION_SP_DIM, KimiK26Config.EMB_SIZE // 4, KimiK26Config.NUM_ROUTED_EXPERTS), 6, 2, 8, 2),
+                ((GATE_PRODUCTION_SP_DIM, KimiK3Config.EMB_SIZE // 4, KimiK3Config.NUM_ROUTED_EXPERTS), 10, 3, 14, 3),
+                ((GATE_PRODUCTION_SP_DIM, GLM51Config.EMB_SIZE // 4, GLM51Config.NUM_ROUTED_EXPERTS), 8, 1, 8, 1),
                 (
                     (GATE_PRODUCTION_SP_DIM, MiniMaxM27Config.EMB_SIZE // 4, MiniMaxM27Config.NUM_ROUTED_EXPERTS),
                     8,

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -136,21 +136,29 @@ class TtMoEGateConfig:
             #   experts) and 14 (896) only fit at in0_block_w <= 14, and 28 (896) only at <= 8. The
             #   widest that fits is not automatically fastest -- (8,28) fits and still loses to
             #   (14,14) -- so the pair has to be swept together.
-            #   out_subblock_w wants to be NARROW, not the widest the dest registers allow. Do not
-            #   "fix" it up to 4 to match TTNN's own area-first heuristic (SUBBLOCK_HW_CHOICES): it
-            #   is the slowest legal choice at every width measured.
+            #   out_subblock_w is not simply "as narrow as legal": 1 wins only while in0_block_w is
+            #   full-K. At the quarter-K value above, 2 takes every out_block_w of 8 or 14, and the
+            #   12-wide pair want 4; only out_block_w 4 (128 experts) still prefers 1. TTNN's own
+            #   area-first heuristic (SUBBLOCK_HW_CHOICES) reaches for the widest the dest registers
+            #   allow, which is right for the 12-wide shapes and wrong for the rest.
             # DEVICE KERNEL DURATION per call on a Blackhole QuietBox 2, medians of 15 rounds visited
             # in rotated order (a single-pass sweep drifts enough to invert the ranking), every
             # candidate at PCC >= 0.99998. (in0_block_w, out_block_w) at out_subblock_w=1:
             #     256 experts  (14,8) 37.3 | (28,8) 41.9 | (56,8) 49.9 | default 53.0
             #     384 experts  (14,12) 54.4 | (14,6) 57.6 | (56,6) 77.2 | default 434.9
             #     896 experts  (14,14) 125.1 | (14,7) 130.5 | (56,7) 175.7 | default 435.1
+            # out_subblock_w swept separately on a height-sharded in0, the layout this table serves
+            # now that an interleaved one resolves mm_configs_interleaved first (11 rotated rounds):
+            #     out_block_w 8   osw 2 wins: 36.5 / 31.7 / 19.3 / 23.4 vs 36.9 / 32.5 / 19.9 / 24.4
+            #     out_block_w 12  osw 4 wins by 0.3% over 3 and 2 -- inside the run-to-run spread
+            #     out_block_w 14  osw 2 wins: 120.8 vs 125.4
+            #     out_block_w 4   osw 1 wins: 11.8 vs 12.0
             (GATE_PRODUCTION_SP_DIM, DeepSeekV3Config.EMB_SIZE // 4, DeepSeekV3Config.NUM_ROUTED_EXPERTS): (
                 ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                     compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
                     in0_block_w=14,
                     out_subblock_h=1,
-                    out_subblock_w=1,
+                    out_subblock_w=2,
                     out_block_h=1,
                     out_block_w=8,
                     per_core_M=1,
@@ -164,7 +172,7 @@ class TtMoEGateConfig:
                     compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
                     in0_block_w=14,
                     out_subblock_h=1,
-                    out_subblock_w=1,
+                    out_subblock_w=4,
                     out_block_h=1,
                     out_block_w=12,
                     per_core_M=1,
@@ -178,7 +186,7 @@ class TtMoEGateConfig:
                     compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
                     in0_block_w=14,
                     out_subblock_h=1,
-                    out_subblock_w=1,
+                    out_subblock_w=2,
                     out_block_h=1,
                     out_block_w=14,
                     per_core_M=1,
@@ -201,7 +209,7 @@ class TtMoEGateConfig:
                     compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
                     in0_block_w=12,
                     out_subblock_h=1,
-                    out_subblock_w=1,
+                    out_subblock_w=2,
                     out_block_h=1,
                     out_block_w=8,
                     per_core_M=1,
@@ -215,7 +223,7 @@ class TtMoEGateConfig:
                     compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
                     in0_block_w=8,
                     out_subblock_h=1,
-                    out_subblock_w=1,
+                    out_subblock_w=2,
                     out_block_h=1,
                     out_block_w=8,
                     per_core_M=1,
@@ -233,7 +241,7 @@ class TtMoEGateConfig:
                     compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
                     in0_block_w=8,
                     out_subblock_h=1,
-                    out_subblock_w=1,
+                    out_subblock_w=2,
                     out_block_h=1,
                     out_block_w=8,
                     per_core_M=1,

--- a/models/demos/deepseek_v3_d_p/utils/test_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/test_utils.py
@@ -92,17 +92,21 @@ def print_l1_small_buffers(device, name):
     print_buffers(device, name, ttnn.BufferType.L1_SMALL)
 
 
-def adjust_shapes_for_testing(config, mesh_device):
-    """Scale TP dimension for smaller meshes. sp_dim (per-device seq len) is always correct."""
+def adjust_shapes_for_testing(config, mesh_device, tile_align_width: bool = True):
+    """Scale TP dimension for smaller meshes. sp_dim (per-device seq len) is always correct.
+
+    `tile_align_width` rounds the model dim up so the per-device width (config.dim / n_tp_devices) is
+    a multiple of 32. An L1-sharded gate input needs that -- a shard width must be whole tiles -- so
+    it is the default, and it is a no-op for every model whose per-device width already is (only
+    GPT-OSS is not: 2880 -> 720/device, 22.5 tiles). Pass False when the input is DRAM-interleaved,
+    where TILE_LAYOUT padding covers the ragged width and the test can hold the deployed dim exactly.
+    """
     _, n_tp_devices = mesh_device.shape
     if n_tp_devices != 4:
         config.dim = config.dim // (4 // n_tp_devices)
-    # The gate input/weight are width-sharded across the TP axis, so the per-device width
-    # (config.dim / n_tp_devices) must be tile-aligned (a multiple of 32). Round the model dim up to
-    # a multiple of 32 * n_tp_devices when it does not divide evenly (e.g. GPT-OSS 2880 -> 720/device,
-    # which is 22.5 tiles). This is a no-op for models whose per-device width is already tile-aligned.
-    tile_multiple = 32 * n_tp_devices
-    config.dim = ((config.dim + tile_multiple - 1) // tile_multiple) * tile_multiple
+    if tile_align_width:
+        tile_multiple = 32 * n_tp_devices
+        config.dim = ((config.dim + tile_multiple - 1) // tile_multiple) * tile_multiple
 
 
 def get_input_mem_config(config, mesh_shape):


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/53269


### Problem description

Program configs for gate OP device matmul are not tunned for 5K (640 ISL per chip) input and DRAM interleaved memory config of input. `test_moe_gate_prefill2d.py` previously had only sharded input tests and input is DRAM Interleaved in real usecase scenario for all models.

### What's changed

- Added new `test_forward_pass_tp1_interleaved` for BH Loudbox for DRAM Interleaved input of gate, which shows real usecase input
- Moved test reference making logic to `_reference_topk` so both tests can use, without just copy-pasting code
- New tunned matmul 1D program configs for sharded input inside `mm_configs` dictionary
- New tunned matmul 2D program configs for DRAM Interleaved input inside `mm_configs_interleaved` dictionary
- If input is DRAM interleaved and there isn't config for it inside `mm_configs_interleaved` then code will look for appropriate config inside `mm_configs` even if there it doesn't exist, then TTNN default program config for matmul will be used

### Analysis for DRAM interleaved (real usecase) input

<img width="2946" height="676" alt="image" src="https://github.com/user-attachments/assets/87aa5fd4-ee62-4331-a674-00b40c9c0075" />

**util = (math work in the matmul) / (what the gate's 110-core grid could have done in the measured time), at HiFi4**




### Prefill CI

- [x] [![(BH) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pmilojevic/53269-gate-matmul-tunning)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pmilojevic/53269-gate-matmul-tunning)
- [x] [![(Galaxy) Blaze Models Prefill tests ](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=pmilojevic/53269-gate-matmul-tunning)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:pmilojevic/53269-gate-matmul-tunning)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilojevic/53269-gate-matmul-tunning)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilojevic/53269-gate-matmul-tunning)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilojevic/53269-gate-matmul-tunning)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilojevic/53269-gate-matmul-tunning)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilojevic/53269-gate-matmul-tunning)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilojevic/53269-gate-matmul-tunning)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilojevic/53269-gate-matmul-tunning)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilojevic/53269-gate-matmul-tunning)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilojevic/53269-gate-matmul-tunning)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilojevic/53269-gate-matmul-tunning)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilojevic/53269-gate-matmul-tunning)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilojevic/53269-gate-matmul-tunning)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilojevic/53269-gate-matmul-tunning)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilojevic/53269-gate-matmul-tunning)