### PR TITLE
Derive mesh axis topology from real fabric wiring for all_gather

### DIFF
--- a/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
+++ b/tests/ttnn/unit_tests/operations/ccl/test_minimals.py
@@ -389,6 +389,31 @@ def test_all_gather_only(
     )
 
 
+# A (1, 8) view of T3K's 2x4 fabric is its perimeter cycle, so consecutive view coords turn corners.
+@skip_for_blackhole("This is a wormhole test")
+@pytest.mark.parametrize("num_iters", [2])
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}], indirect=True)
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
+def test_all_gather_folded_line_2d_fabric(
+    mesh_device,
+    num_iters,
+    function_level_defaults,
+):
+    run_all_gather_impl(
+        mesh_device,
+        8,
+        [1, 1, 32, 1024],
+        3,
+        ttnn.bfloat16,
+        ttnn.TILE_LAYOUT,
+        function_level_defaults,
+        (32, 128),
+        ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 0))}),
+        num_iters=num_iters,
+        tensor_mem_layout=ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+    )
+
+
 # Enumerate the post-commit cases explicitly
 @skip_for_wormhole_b0()
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
@@ -241,6 +241,11 @@ AllGatherDeviceOperation::program_factory_t AllGatherDeviceOperation::select_pro
         // Decide between multicast or unicast algorithm
         const auto& input_tensor = tensor_args.input_tensor;
         const uint32_t axis = args.get_1d_axis();
+        if (tt::tt_fabric::is_2d_fabric_config(args.fabric_config) && !args.axis_is_straight[axis]) {
+            // 2D multicast walks N hops out one physical direction, so a bent axis needs unicast's
+            // one-hop relay. 1D hops ride the cabled chain, which is the bent axis itself.
+            return program_factory_t{AllGatherUnicastFactory{}};
+        }
         switch (input_tensor.device()->arch()) {
             case tt::ARCH::WORMHOLE_B0: {
                 const uint64_t num_pages = input_tensor.buffer()->num_pages();       // per-device shard
@@ -317,6 +322,7 @@ std::tuple<AllGatherParams, AllGatherInputs> all_gather_build_operation_args(
     // An inactive axis has num_devices = 1, num_links = 0, Linear topology.
     std::array<tt::tt_fabric::Topology, 2> axis_topology{
         tt::tt_fabric::Topology::Linear, tt::tt_fabric::Topology::Linear};
+    std::array<bool, 2> axis_is_straight{true, true};
     std::array<uint32_t, 2> axis_num_devices{1u, 1u};
     std::array<uint32_t, 2> axis_num_links{0u, 0u};
     for (uint32_t axis = 0; axis < 2; ++axis) {
@@ -325,6 +331,7 @@ std::tuple<AllGatherParams, AllGatherInputs> all_gather_build_operation_args(
             continue;
         }
         axis_topology[axis] = ::ttnn::ccl::get_axis_topology(input_tensor, fabric_config, axis);
+        axis_is_straight[axis] = ttnn::operations::ccl::common::get_axis_geometry(*mesh_device, axis).is_straight;
         axis_num_devices[axis] = ::ttnn::ccl::get_topological_dimension(input_tensor, axis);
         axis_num_links[axis] = ttnn::operations::ccl::common::get_num_links(*mesh_device, axis);
     }
@@ -352,6 +359,7 @@ std::tuple<AllGatherParams, AllGatherInputs> all_gather_build_operation_args(
             cluster_axis,
             fabric_config,
             axis_topology,
+            axis_is_straight,
             axis_num_devices,
             axis_num_links,
             num_devices,

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation_types.hpp
@@ -33,6 +33,9 @@ struct AllGatherParams {
     tt::tt_fabric::FabricConfig fabric_config{};
     // Per-axis info (an inactive axis has num_devices = 1, num_links = 0, and Linear topology)
     std::array<tt::tt_fabric::Topology, 2> axis_topology{};
+    // Whether the axis is wired as a straight physical line. A view axis need not be one: a line
+    // view of a 2x4 board is its perimeter cycle. Multicast needs it; unicast does not.
+    std::array<bool, 2> axis_is_straight{true, true};
     std::array<uint32_t, 2> axis_num_devices{};
     std::array<uint32_t, 2> axis_num_links{};
     uint32_t num_devices = 0;  // number of devices participating in the collective
@@ -48,6 +51,7 @@ struct AllGatherParams {
         "cluster_axis",
         "fabric_config",
         "axis_topology",
+        "axis_is_straight",
         "axis_num_devices",
         "axis_num_links",
         "num_devices",
@@ -61,6 +65,7 @@ struct AllGatherParams {
             cluster_axis,
             fabric_config,
             axis_topology,
+            axis_is_straight,
             axis_num_devices,
             axis_num_links,
             num_devices,

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_multicast_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_multicast_factory.cpp
@@ -92,6 +92,12 @@ AllGatherMulticastFactory::cached_program_t AllGatherMulticastFactory::create_at
         if (!is_axis_active) {
             continue;
         }
+        // A true 2D collective cannot fall back to unicast, so a bent axis has no valid algorithm
+        // here and must not be silently mis-routed.
+        TT_FATAL(
+            !fabric_is_2d || operation_attributes.axis_is_straight[axis],
+            "AllGather 2D multicast needs mesh axis {} wired as a straight line, but it turns corners",
+            axis);
 
         const auto axis_topology = operation_attributes.axis_topology[axis];
         const uint32_t axis_index = sender_device_coord[axis];

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -9,6 +9,7 @@
 #include <cmath>
 
 #include "ccl_host_datastructures.hpp"
+#include "ttnn/operations/ccl/common/host/moe_utils.hpp"
 #include "ttnn/operations/data_movement/slice/slice.hpp"
 #include "ttnn/operations/data_movement/concat/concat.hpp"
 
@@ -140,9 +141,11 @@ tt::tt_fabric::Topology get_axis_topology(
         axis_can_wrap = fabric_config == tt::tt_fabric::FabricConfig::FABRIC_1D_RING;
     }
 
-    // Ring only if the fabric can wrap this axis AND the device set spans [0..size-1].
-    const bool axis_is_ring = axis_can_wrap && get_boundary_mode(tensor, tt::tt_fabric::Topology::Torus, axis) ==
-                                                   tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::WRAP;
+    // The FabricConfig torus flags name a *fabric* mesh axis. A MeshDevice view axis may be a
+    // permutation of the fabric mesh (a line view of a 2x4 board is its perimeter cycle), so the
+    // flag alone says nothing about this axis. Ring only if the axis is actually wired closed.
+    const bool axis_is_ring =
+        axis_can_wrap && ::ttnn::operations::ccl::common::get_axis_geometry(*tensor.device(), axis).wrap_edge_exists;
     return axis_is_ring ? tt::tt_fabric::Topology::Ring : tt::tt_fabric::Topology::Linear;
 }
 

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/moe_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/moe_utils.cpp
@@ -3,10 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt_stl/reflection.hpp>
+#include <algorithm>
 #include <array>
 #include <limits>
+#include <optional>
 #include <utility>
 #include <vector>
+
+#include <tt-metalium/experimental/fabric/pipeline_builder.hpp>
 
 #include "ttnn/operations/ccl/common/host/moe_utils.hpp"
 
@@ -102,61 +106,132 @@ uint32_t get_linearized_index(const ttnn::MeshCoordinate& mesh_coordinate, const
     return (mesh_coordinate[0] * mesh_view.num_cols()) + mesh_coordinate[1];
 }
 
+namespace detail {
+
+// Direction of the single fabric hop src->dst, or nullopt if the two are not directly wired.
+// A route always exists between any two nodes, so routability alone does not prove adjacency.
+// TODO: belongs in tt::tt_fabric beside the pipeline_get_* wrappers it composes. The same sequence is
+// open-coded in multiple CCL ops and fabric's own pipeline_builder.cpp.
+std::optional<tt::tt_fabric::RoutingDirection> get_wired_hop_direction(
+    tt::tt_fabric::FabricNodeId src, tt::tt_fabric::FabricNodeId dst) {
+    const auto direction = tt::tt_fabric::pipeline_get_forwarding_direction(src, dst);
+    if (!direction.has_value()) {
+        return std::nullopt;
+    }
+    const auto neighbors = tt::tt_fabric::pipeline_get_chip_neighbors(src, *direction);
+    const auto mesh_it = neighbors.find(*dst.mesh_id);
+    if (mesh_it == neighbors.end() ||
+        std::find(mesh_it->second.begin(), mesh_it->second.end(), dst.chip_id) == mesh_it->second.end()) {
+        return std::nullopt;  // routable, but more than one hop away
+    }
+    return direction;
+}
+
+struct AxisEdge {
+    tt::tt_fabric::FabricNodeId src;
+    tt::tt_fabric::FabricNodeId dst;
+    std::optional<tt::tt_fabric::RoutingDirection> direction;  // set iff the pair is wired
+    bool is_wrap = false;
+};
+
+// Every consecutive coordinate pair along `axis`, for every line on that axis, plus the closing
+// pair. Unwired pairs are returned with no direction so callers can tell a missing wrap edge
+// (just a line) from a missing interior edge (not a chain at all).
+std::vector<AxisEdge> axis_edges(const tt::tt_metal::distributed::MeshDevice& mesh_device, uint32_t axis) {
+    const auto mesh_shape = mesh_device.get_view().shape();
+    TT_FATAL(mesh_shape.dims() == 2, "Axis geometry requires a 2D mesh shape, got {}", mesh_shape);
+    TT_FATAL(axis < 2, "Axis must be 0 or 1, got {}", axis);
+
+    const uint32_t extent = mesh_shape[axis];
+    // A 2-device axis is spanned by a single link; closing it would use that link twice, so it
+    // is a line and never a ring. Matches the fabric's own is_genuine_torus_dim(dim > 2).
+    const bool include_wrap = extent > 2;
+    const uint32_t edges_per_line = extent < 2 ? 0 : (include_wrap ? extent : extent - 1);
+
+    std::vector<AxisEdge> edges;
+    for (uint32_t group = 0; group < mesh_shape[1 - axis]; group++) {
+        for (uint32_t rank = 0; rank < edges_per_line; rank++) {
+            const uint32_t next = (rank + 1) % extent;
+            const auto src_coord = axis == 0 ? MeshCoordinate(rank, group) : MeshCoordinate(group, rank);
+            const auto dst_coord = axis == 0 ? MeshCoordinate(next, group) : MeshCoordinate(group, next);
+            const auto src = mesh_device.get_fabric_node_id(src_coord);
+            const auto dst = mesh_device.get_fabric_node_id(dst_coord);
+            edges.push_back(AxisEdge{src, dst, get_wired_hop_direction(src, dst), next == 0});
+        }
+    }
+    return edges;
+}
+
+}  // namespace detail
+
+AxisGeometry get_axis_geometry(const tt::tt_metal::distributed::MeshDevice& mesh_device, uint32_t axis) {
+    const auto edges = detail::axis_edges(mesh_device, axis);
+
+    AxisGeometry geometry;
+    std::optional<tt::tt_fabric::RoutingDirection> axis_direction;
+    size_t wrap_edges = 0;
+    size_t wired_wrap_edges = 0;
+
+    for (const auto& edge : edges) {
+        wrap_edges += edge.is_wrap;
+        if (!edge.direction.has_value()) {
+            // A missing wrap edge just means this axis is a line. A missing interior edge means
+            // consecutive coords are not neighbours at all, so no hop count describes the axis.
+            if (!edge.is_wrap) {
+                geometry.is_straight = false;
+            }
+            continue;
+        }
+        wired_wrap_edges += edge.is_wrap;
+        if (!axis_direction.has_value()) {
+            axis_direction = edge.direction;
+        } else if (*axis_direction != *edge.direction) {
+            geometry.is_straight = false;
+        }
+    }
+    geometry.wrap_edge_exists = wrap_edges > 0 && wired_wrap_edges == wrap_edges;
+
+    log_debug(
+        tt::LogOp,
+        "axis {}: is_straight {}, wrap_edge_exists {}",
+        axis,
+        geometry.is_straight,
+        geometry.wrap_edge_exists);
+    return geometry;
+}
+
 size_t get_num_links(const tt::tt_metal::distributed::MeshDevice& mesh_device, std::optional<size_t> cluster_axis) {
-    auto mesh_range = tt::tt_metal::distributed::MeshCoordinateRange(mesh_device.shape());
-    const auto& mesh_view = mesh_device.get_view();
-    auto mesh_shape = mesh_view.shape();
-    auto topology = tt::tt_fabric::get_fabric_topology();
-
-    constexpr std::array<std::array<tt::tt_fabric::RoutingDirection, 2>, 2> directions = {
-        {{tt::tt_fabric::RoutingDirection::N, tt::tt_fabric::RoutingDirection::S},
-         {tt::tt_fabric::RoutingDirection::W, tt::tt_fabric::RoutingDirection::E}}};
-
-    ttsl::SmallVector<size_t> cluster_axes;
+    ttsl::SmallVector<uint32_t> cluster_axes;
     if (cluster_axis.has_value()) {
-        cluster_axes = {cluster_axis.value()};
+        cluster_axes = {static_cast<uint32_t>(cluster_axis.value())};
     } else {
         cluster_axes = {0, 1};
     }
 
-    auto positive_direction = [&](tt::tt_fabric::RoutingDirection direction) {
-        return direction == tt::tt_fabric::RoutingDirection::E || direction == tt::tt_fabric::RoutingDirection::S;
-    };
-
-    auto applicable_to_coord =
-        [&](const MeshCoordinate& coord, size_t cluster_axis, tt::tt_fabric::RoutingDirection direction) -> bool {
-        auto boundary_mode = detail::get_boundary_mode(topology);
-        int offset = positive_direction(direction) ? 1 : -1;
-        auto neighbor = coord.get_neighbor(mesh_shape, offset, cluster_axis, boundary_mode);
-        return neighbor.has_value();
-    };
-
+    size_t num_edges = 0;
     size_t num_available_routing_planes = std::numeric_limits<size_t>::max();
-    for (const auto& coord : mesh_range) {
-        const auto fabric_node_id = mesh_device.get_fabric_node_id(coord);
-
-        for (const auto axis : cluster_axes) {
-            for (const auto direction : directions[axis]) {
-                if (applicable_to_coord(coord, axis, direction)) {
-                    auto planes_in_direction = tt::tt_fabric::get_num_usable_routing_planes(fabric_node_id, direction);
-                    log_debug(
-                        tt::LogOp,
-                        "fabric_node_id: {}, direction: {}, planes_in_direction: {}",
-                        fabric_node_id,
-                        direction,
-                        planes_in_direction);
-                    // Skip over planes_in_direction=0 to avoid collapsing the running min to 0.
-                    // This can happen when, for example, there's only 1 or 2 devices, a wrap-around can detect a
-                    // neighbor though there's no fabric link.
-                    if (planes_in_direction > 0) {
-                        num_available_routing_planes = std::min(num_available_routing_planes, planes_in_direction);
-                    }
-                }
+    for (const auto axis : cluster_axes) {
+        for (const auto& edge : detail::axis_edges(mesh_device, axis)) {
+            if (!edge.direction.has_value()) {
+                continue;
+            }
+            num_edges++;
+            // Both ends describe the same link, so take the lower count: reporting more links than
+            // either side offers makes the op open a link index the fabric rejects.
+            num_available_routing_planes = std::min(
+                num_available_routing_planes, tt::tt_fabric::get_num_usable_routing_planes(edge.src, *edge.direction));
+            if (const auto reverse = detail::get_wired_hop_direction(edge.dst, edge.src); reverse.has_value()) {
+                num_available_routing_planes = std::min(
+                    num_available_routing_planes, tt::tt_fabric::get_num_usable_routing_planes(edge.dst, *reverse));
             }
         }
     }
+
+    if (num_edges == 0) {
+        return 1;  // nothing to measure (single device, or an axis of extent 1)
+    }
     log_debug(tt::LogOp, "num_available_routing_planes: {}", num_available_routing_planes);
-    if (num_available_routing_planes <= 0 || num_available_routing_planes == std::numeric_limits<size_t>::max()) {
+    if (num_available_routing_planes == 0 || num_available_routing_planes == std::numeric_limits<size_t>::max()) {
         log_warning(tt::LogOp, "Failed to discover available ethernet links; falling back to 1 link");
         num_available_routing_planes = 1;
     }

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/moe_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/moe_utils.hpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <optional>
+
 #include "ttnn/distributed/types.hpp"
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
@@ -28,6 +30,15 @@ std::string stringify(const T& vec) {
 }
 
 uint32_t get_linearized_index(const ttnn::MeshCoordinate& mesh_coordinate, const ttnn::MeshDeviceView& mesh_view);
+
+// How a MeshDevice view axis is actually wired. A view axis is not necessarily a fabric axis:
+// a line view of a 2x4 board is the perimeter cycle, so its consecutive coords turn corners.
+struct AxisGeometry {
+    bool is_straight = true;        // every wired edge on the axis leaves in the same direction
+    bool wrap_edge_exists = false;  // the closing edge of every line on the axis is wired
+};
+
+AxisGeometry get_axis_geometry(const tt::tt_metal::distributed::MeshDevice& mesh_device, uint32_t axis);
 
 size_t get_num_links(
     const tt::tt_metal::distributed::MeshDevice& mesh_device, std::optional<size_t> cluster_axis = std::nullopt);


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
#### Problem
- CCL built fabric routes from MeshDevice **view** coords. A view axis isn't always a fabric axis — a line view of a 2x4 board is its perimeter cycle, so coords turn corners.
- Multicast charges all hops to the first neighbour's direction. On a `(1,8)` T3K view, device 0 asks for 7 hops East with 3 chips to its east → peers never get data → hang.
- `get_axis_topology` inferred Ring from the `FabricConfig` enum against the **view** shape. The fabric applies the same rule to the **fabric** shape, so they disagree.
- `get_num_links` hardcoded axis 0 → {N,S}, axis 1 → {W,E}, so on a bent axis it measured links the collective never uses.

#### Solution
- New `get_axis_geometry(mesh_device, axis)` → `{is_straight, wrap_edge_exists}`. Walks real cables via `pipeline_get_chip_neighbors`; a route existing doesn't make two chips neighbours.
- `get_axis_topology` gates Ring on `wrap_edge_exists`.
- `get_num_links` walks real edges, reads planes per edge's own direction, min over both ends.
- Under 2D fabric a bent axis picks the unicast factory (one hop at a time). `TT_FATAL` for true-2D, which can't fall back.
- 1D untouched — it folds corner chips, so its cabled chain already *is* the bent axis.

### Notes for reviewers
- Only `all_gather` behaviour changes. No fabric/metal/kernel/API edits; no signature churn.
- A Ring claim with no wrap cable now reports Linear (e.g. 2x4 row of 4 under `FABRIC_1D_RING`).
- Adds `test_all_gather_folded_line_2d_fabric` — hangs without this.
- Out of scope: `prefill/dispatch`, `prefill/combine`, `all_to_all_async_generic` have the same bug.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=scardoza/ccl-axis-wiring)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:scardoza/ccl-axis-wiring)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=scardoza/ccl-axis-wiring)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:scardoza/ccl-axis-wiring)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=scardoza/ccl-axis-wiring)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:scardoza/ccl-axis-wiring)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=scardoza/ccl-axis-wiring)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:scardoza/ccl-axis-wiring)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=scardoza/ccl-axis-wiring)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:scardoza/ccl-axis-wiring)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=scardoza/ccl-axis-wiring)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:scardoza/ccl-axis-wiring)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=scardoza/ccl-axis-wiring)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:scardoza/ccl-axis-wiring)