### PR TITLE
[Test Only] move the 262144-wide group_norm DRAM shape to nightly

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -75,6 +75,12 @@ GROUP_NORM_ROW_MAJOR_SHAPES = [
         (1, 256 // 4, 1024, 1024, 32 // 4, 16, 8, 8),
         # for test below, PCC drops to 0.9565977077851433 of welford_normal and welford_reciprocal
         (1, 128 // 4, 1024, 1024, 32 // 4, 8, 8, 8),
+        # SD 1.4 VAE Issue #21131. Same "largest inputs" criterion as the shapes above: 33.5M
+        # elements on 32 of 64 cores with num_out_blocks=64, ~16 min per welford mode on the
+        # simulator. Was in base.GROUP_NORM_DRAM_SHAPES, which reached nightly only through
+        # test_group_norm_DRAM_unit_shapes (specify_grid=False); listing it here covers both
+        # specify_grid values.
+        (1, 128, 1, 262144, 32, 64, 8, 4),
         # mochi
         # (21, 128, 480, 848, 32, 140, 8, 8), Failing on single device CI.
     ],

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -56,7 +56,8 @@ GROUP_NORM_DRAM_SHAPES = [
     (1, 256 // 4, 256, 256, 32 // 4, 1, 8, 8),
     (1, 512 // 4, 128, 128, 32 // 4, 1, 8, 8),
     (1, 512 // 4, 256, 256, 32 // 4, 2, 8, 8),
-    (1, 128, 1, 262144, 32, 64, 8, 4),  # SD 1.4 VAE Issue #21131
+    # (1, 128, 1, 262144, 32, 64, 8, 4) SD 1.4 VAE Issue #21131 moved to nightly: 33.5M elements,
+    # ~16 min per welford mode on the simulator. Nightly runs it over both specify_grid values.
     # mochi
     # (21, 128, 480, 848, 32, 140, 8, 8), Failing on single device CI.
 ]


### PR DESCRIPTION
### PR Category
Test Only

### Summary

Fixes the `ttnn fused group 1 [sim_wormhole_b0]` timeout. Relates to #21131.

`tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py` carries

```python
(1, 128, 1, 262144, 32, 64, 8, 4),  # SD 1.4 VAE Issue #21131
```

in `GROUP_NORM_DRAM_SHAPES`, crossed with `WELFORD_MODES` (3 values). On the simulator those three cases are the most expensive parametrization in the whole fused suite, and they are why the job now exceeds its 60 minute budget.

Measured in [run 32125986468](https://github.com/tenstorrent/tt-metal/actions/runs/32125986468) on `main`, from the per-worker `[gwN] PASSED` timestamps:

| welford_mode | duration | split group |
|---|---|---|
| `legacy` | **16.6 min** | group 1 — slowest case in the suite, 2x the next |
| `welford_normal` | **8.0 min** | group 2 |
| `welford_reciprocal` | *n/a* | group 1 — still running when the job was killed |

The whole fused suite is at the wall on every simulator target, so this is not a flake:

| Job | Runtime | Result |
|---|---|---|
| fused group 1 `[sim_wormhole_b0]` | **61.9 min** | **timeout** |
| fused group 2 `[sim_wormhole_b0]` | 55.5 min | pass |
| fused group 1 `[sim_blackhole]` | 54.6 min | pass |
| fused group 2 `[sim_blackhole]` | 52.5 min | pass |
| fused group 1/2 `[wh_n300_civ2]` (HW) | 18 / 15 min | pass |

### Why this shape

It has the worst work-to-parallelism ratio in the list: 33.5M elements on 32 of 64 cores (`cores_y=8, cores_x=4`) with `num_out_blocks=64`, i.e. 64 sequential chunked passes per invocation. And `C=128, N=1` misses the `C > 512 or N > 2` guard at `test_group_norm_DRAM.py:279`, so `run_group_norm_DRAM` executes the op **twice** per case — 6 device executions across the three modes, all on the largest tensor in the file.

This is the same criterion, and the same remedy, as 05851183d65 (*"move slow test_group_norm_DRAM parameters to nightly"*, #30020), whose comment survives at line 43: `# All SDXL/sd35 tests with 512x512 or larger sizes moved to nightly`.

### Notes for reviewers

**Coverage is unchanged at 9 cases; none of them now sit in the post-commit job.**

| | before | after |
|---|---|---|
| unit `test_group_norm_DRAM` (`specify_grid=True`) | 3 | 0 |
| nightly `test_group_norm_DRAM` | 0 | **6** (3 modes x 2 `specify_grid`) |
| nightly `test_group_norm_DRAM_unit_shapes` (`specify_grid=False`) | 3 | 0 |
| nightly `test_group_norm_DRAM_row_major` | 3 | 3 |

The subtlety worth checking: `tests/ttnn/nightly/.../test_group_norm_DRAM.py:192` parametrizes `test_group_norm_DRAM_unit_shapes` from `base.GROUP_NORM_DRAM_SHAPES`. Deleting the entry on its own would therefore have silently dropped its nightly coverage too. Adding the literal to the explicit nightly list at `:76` both preserves it and gains the `specify_grid=True` variant, which nightly did not previously run for this shape.

`GROUP_NORM_DRAM_SHAPES` has exactly two consumers — unit `:333` and nightly `:192` — so there is no third path to check.

**Not a welford-mode reduction.** All three modes still run on this shape, just in nightly. Every other shape in the list keeps its full 3-mode crossing in post-commit. A follow-up PR addresses the wider grid structure.

**Not executed locally** (no device available); this relies on CI.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/fused-gn-w262144-prune)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/fused-gn-w262144-prune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/fused-gn-w262144-prune)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/fused-gn-w262144-prune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/fused-gn-w262144-prune)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/fused-gn-w262144-prune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/fused-gn-w262144-prune)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/fused-gn-w262144-prune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/fused-gn-w262144-prune)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/fused-gn-w262144-prune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/fused-gn-w262144-prune)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/fused-gn-w262144-prune)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/fused-gn-w262144-prune)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/fused-gn-w262144-prune)