### PR TITLE
[Test Only] decross the group_norm DRAM dtype grid, move 512x512 splits to nightly

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -225,7 +225,6 @@ def test_sdxl_base_group_norm_split_unit_shapes(device, N, C, H, W, num_groups, 
 
 
 # The 512x512 split shapes, same "512x512 or larger" criterion as test_group_norm_DRAM above.
-# Both specify_grid values, so nightly keeps the specify_grid=True variant post-commit used to run.
 @pytest.mark.parametrize("device_params", base.DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True)
 @pytest.mark.parametrize(
     "N, C, H, W, num_groups, num_splits",

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -224,7 +224,6 @@ def test_sdxl_base_group_norm_split_unit_shapes(device, N, C, H, W, num_groups, 
     base.test_sdxl_base_group_norm_split(device, N, C, H, W, num_groups, num_splits, specify_grid)
 
 
-# The 512x512 split shapes, same "512x512 or larger" criterion as test_group_norm_DRAM above.
 @pytest.mark.parametrize("device_params", base.DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True)
 @pytest.mark.parametrize(
     "N, C, H, W, num_groups, num_splits",

--- a/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/nightly/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -224,6 +224,21 @@ def test_sdxl_base_group_norm_split_unit_shapes(device, N, C, H, W, num_groups, 
     base.test_sdxl_base_group_norm_split(device, N, C, H, W, num_groups, num_splits, specify_grid)
 
 
+# The 512x512 split shapes, same "512x512 or larger" criterion as test_group_norm_DRAM above.
+# Both specify_grid values, so nightly keeps the specify_grid=True variant post-commit used to run.
+@pytest.mark.parametrize("device_params", base.DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True)
+@pytest.mark.parametrize(
+    "N, C, H, W, num_groups, num_splits",
+    [
+        (1, 256, 512, 512, 32, 8),
+        (1, 512, 512, 512, 32, 16),
+    ],
+)
+@pytest.mark.parametrize("specify_grid", [True, False])
+def test_sdxl_base_group_norm_split_large(device, N, C, H, W, num_groups, num_splits, specify_grid):
+    base.test_sdxl_base_group_norm_split(device, N, C, H, W, num_groups, num_splits, specify_grid)
+
+
 @pytest.mark.parametrize("device_params", base.DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True)
 @pytest.mark.parametrize(
     "N, C, H, W, num_groups, num_out_blocks, cores_y, cores_x, eps", base.GROUP_NORM_DRAM_OFT_PARAMS

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -1012,13 +1012,11 @@ GN_INTERLEAVED_SHAPES = [
 
 
 @pytest.mark.parametrize("N, C, H, W, num_groups, num_out_blocks, grid_y, grid_x", GN_INTERLEAVED_SHAPES)
-# One case per (reduction path x input dtype) pair, instead of the welford_mode x in_dtype x
-# gb_dtype product. Those two axes interact: the thresholds below branch on use_welford x in_dtype,
+# One case per (reduction path x input dtype) pair.
+# Those two axes interact: the accuracy thresholds branch on use_welford x in_dtype,
 # and fp32 input on the welford path additionally aliases cb_x onto cb_in0 and enables
-# UnpackToDestFp32. gamma/beta dtype interacts with neither -- it only selects the gamma/beta CB
-# format, and the thresholds are already pinned across the gamma-beta matrix (see the comment on
-# them below) -- so it is varied across the six cases rather than crossed with them, giving each
-# welford_mode and each in_dtype both gamma/beta formats.
+# UnpackToDestFp32. On the other hand, gamma/beta dtype interacts with neither: it only selects
+# the gamma/beta CB format, it is varied across the six cases rather than crossed with them.
 @pytest.mark.parametrize(
     "welford_mode, in_dtype, gb_dtype",
     [

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -1031,7 +1031,9 @@ GN_INTERLEAVED_SHAPES = [
     ],
     ids=[
         "legacy-bf16-gb_bf16",
+        "legacy-bf16-gb_fp32",
         "legacy-fp32-gb_fp32",
+        "legacy-fp32-gb_bf16",
         "welford_normal-bf16-gb_fp32",
         "welford_normal-fp32-gb_bf16",
         "welford_reciprocal-bf16-gb_bf16",

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -1021,7 +1021,9 @@ GN_INTERLEAVED_SHAPES = [
     "welford_mode, in_dtype, gb_dtype",
     [
         ("legacy", ttnn.bfloat16, ttnn.bfloat16),
+        ("legacy", ttnn.bfloat16, ttnn.float32),
         ("legacy", ttnn.float32, ttnn.float32),
+        ("legacy", ttnn.float32, ttnn.bfloat16),
         ("welford_normal", ttnn.bfloat16, ttnn.float32),
         ("welford_normal", ttnn.float32, ttnn.bfloat16),
         ("welford_reciprocal", ttnn.bfloat16, ttnn.bfloat16),

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -122,9 +122,6 @@ GROUP_NORM_NON_TILE_ALIGNED_SHIFT_CASES = [
 
 SDXL_BASE_GROUP_NORM_SPLIT_SHAPES = [
     # (1, 256, 1024, 1024, 32, 32), # does not fit -> input is [16384, 8] per core (~260kB) gets tilized internally to [16384, 32] which is ~1MB, and 2 buffers are of that size (cb_x and cb_in)
-    # The two 512x512 entries, (1, 256, 512, 512, 32, 8) and (1, 512, 512, 512, 32, 16), moved to
-    # nightly: 8-10 min each on the simulator, past the pipeline's own --timeout 300, and they were
-    # already skipped on Blackhole under watcher (#37645).
     (
         1,
         512,

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm_DRAM.py
@@ -122,14 +122,9 @@ GROUP_NORM_NON_TILE_ALIGNED_SHIFT_CASES = [
 
 SDXL_BASE_GROUP_NORM_SPLIT_SHAPES = [
     # (1, 256, 1024, 1024, 32, 32), # does not fit -> input is [16384, 8] per core (~260kB) gets tilized internally to [16384, 32] which is ~1MB, and 2 buffers are of that size (cb_x and cb_in)
-    (
-        1,
-        256,
-        512,
-        512,
-        32,
-        8,
-    ),  # Can fit in 8 slices, each slice does: (0,8ms for split, 0.3ms for interleavedToSharded + 0.68ms for GN) = 1.78ms, 8 slices x 1.78ms = 14.24ms + 4.6ms for concat = 18.84ms (original is 15.7ms)
+    # The two 512x512 entries, (1, 256, 512, 512, 32, 8) and (1, 512, 512, 512, 32, 16), moved to
+    # nightly: 8-10 min each on the simulator, past the pipeline's own --timeout 300, and they were
+    # already skipped on Blackhole under watcher (#37645).
     (
         1,
         512,
@@ -146,14 +141,6 @@ SDXL_BASE_GROUP_NORM_SPLIT_SHAPES = [
         32,
         4,
     ),  # Can fit in 4 slice, split= 0.3ms i2s = 0.1ms GN = 0.6ms, s2i = 0.421ms = 5.6ms + 1ms for concat = 6.6ms (original is 6.1ms)
-    (
-        1,
-        512,
-        512,
-        512,
-        32,
-        16,
-    ),  # Can fit in 16 slice, split= 0.8ms i2s = 0.33ms GN = 0.38ms, s2i = 1.58ms = 49.44ms + 7.806ms for concat = 57.246ms (original is 24ms)
     # (1, 128, 1024, 1024, 32, 32), # does not fit -> input is [16384, 4] per core (~130kB) gets tilized internally to [16384, 32] which is ~1MB, and 2 buffers are of that size (cb_x and cb_in). in addition to that, RM stick of size 4 is not L1 aligned
 ]
 
@@ -1028,9 +1015,32 @@ GN_INTERLEAVED_SHAPES = [
 
 
 @pytest.mark.parametrize("N, C, H, W, num_groups, num_out_blocks, grid_y, grid_x", GN_INTERLEAVED_SHAPES)
-@pytest.mark.parametrize("gb_dtype", [ttnn.bfloat16, ttnn.float32], ids=["gb_bf16", "gb_fp32"])
-@pytest.mark.parametrize("in_dtype", [ttnn.bfloat16, ttnn.float32], ids=["bf16", "fp32"])
-@pytest.mark.parametrize("welford_mode", WELFORD_MODES)
+# One case per (reduction path x input dtype) pair, instead of the welford_mode x in_dtype x
+# gb_dtype product. Those two axes interact: the thresholds below branch on use_welford x in_dtype,
+# and fp32 input on the welford path additionally aliases cb_x onto cb_in0 and enables
+# UnpackToDestFp32. gamma/beta dtype interacts with neither -- it only selects the gamma/beta CB
+# format, and the thresholds are already pinned across the gamma-beta matrix (see the comment on
+# them below) -- so it is varied across the six cases rather than crossed with them, giving each
+# welford_mode and each in_dtype both gamma/beta formats.
+@pytest.mark.parametrize(
+    "welford_mode, in_dtype, gb_dtype",
+    [
+        ("legacy", ttnn.bfloat16, ttnn.bfloat16),
+        ("legacy", ttnn.float32, ttnn.float32),
+        ("welford_normal", ttnn.bfloat16, ttnn.float32),
+        ("welford_normal", ttnn.float32, ttnn.bfloat16),
+        ("welford_reciprocal", ttnn.bfloat16, ttnn.bfloat16),
+        ("welford_reciprocal", ttnn.float32, ttnn.float32),
+    ],
+    ids=[
+        "legacy-bf16-gb_bf16",
+        "legacy-fp32-gb_fp32",
+        "welford_normal-bf16-gb_fp32",
+        "welford_normal-fp32-gb_bf16",
+        "welford_reciprocal-bf16-gb_bf16",
+        "welford_reciprocal-fp32-gb_fp32",
+    ],
+)
 def test_group_norm_interleaved_all_config(
     device, N, C, H, W, num_groups, num_out_blocks, grid_y, grid_x, in_dtype, gb_dtype, welford_mode
 ):


### PR DESCRIPTION
### PR Category
Test Only

### Summary

Follow-up to #53650 (#53648), which moved the slowest `test_group_norm_DRAM` shapes to nightly and superseded #53548.

#53650 fixed the outright timeout, but the fused simulator jobs are still approaching the 60 minute wall: on the last four green `main` runs (Aug 23–24) they took 46–57 min, with `sim_wh_n150` groups at 54/56 min and `sim_bh_p150` group 1 at 57 min in single runs. This PR removes ~15 min from group 1 and ~16 min from group 2, which adds a safe margin to the test suite.

### 1. Move the two 512x512 `test_sdxl_base_group_norm_split` entries to nightly

They are the second and third most expensive cases in the whole suite — 8.1 min for `(1,256,512,512,32,8)` and 10.0 min for `(1,512,512,512,32,16)`, i.e. one 8-10 min case in each split group.

### 2. `test_group_norm_interleaved_all_config`: 84 → 56 cases

- `welford_mode` x `in_dtype` interact: the accuracy thresholds in the test branch on `use_welford` x `in_dtype`, and fp32 input on the welford path additionally aliases `cb_x` onto `cb_in0` and enables `UnpackToDestFp32` in the mcast program factory. So all six pairs are kept.
- `gb_dtype` is decrossed: it only selects the gamma/beta CB format. It is now varied across the six cases so every `welford_mode` and every `in_dtype` still sees both formats.
- retaining mixed data types on legacy path to test unpacker reconfigs

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/fused-gn-grid-restructure)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/fused-gn-grid-restructure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/fused-gn-grid-restructure)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/fused-gn-grid-restructure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/fused-gn-grid-restructure)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/fused-gn-grid-restructure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/fused-gn-grid-restructure)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/fused-gn-grid-restructure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/fused-gn-grid-restructure)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/fused-gn-grid-restructure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/fused-gn-grid-restructure)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/fused-gn-grid-restructure)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/fused-gn-grid-restructure)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/fused-gn-grid-restructure)
