### PR TITLE
perf-regression-check: compare a test between any two commits

### DIFF
--- a/tt_metal/tt-llk/.claude/scripts/perf_compare_commits.sh
+++ b/tt_metal/tt-llk/.claude/scripts/perf_compare_commits.sh
@@ -11,7 +11,9 @@
 #   --baseline <ref>     what to compare against  (default: merge-base origin/main HEAD)
 #   --current  <ref>     what to judge            (default: HEAD)
 #   --iterations <N>     runs per side            (default: 3, median-vs-median)
-#   --threshold <T>      regression threshold     (default: 0.05 = 5%)
+#   --threshold <T>      relative slowdown that counts  (default: 0.02 = 2%)
+#   --min-cycles <N>     absolute slowdown it must ALSO exceed, in cycles
+#                        (default: 30; 0 disables the clause)
 #   --speed-of-light     compile-time-parameter build; applied to BOTH sides
 #   --refresh            ignore cached runs and re-measure both sides
 #   --keep-worktrees     leave the per-commit worktrees behind (for debugging)
@@ -89,7 +91,8 @@ Usage: perf_compare_commits.sh <arch> <test> [options]
   --baseline <ref>     what to compare against  (default: merge-base origin/main HEAD)
   --current  <ref>     what to judge            (default: HEAD)
   --iterations <N>     runs per side            (default: 3, median-vs-median)
-  --threshold <T>      regression threshold     (default: 0.05 = 5%)
+  --threshold <T>      relative slowdown that counts  (default: 0.02 = 2%)
+  --min-cycles <N>     absolute slowdown it must ALSO exceed, in cycles (default: 30)
   --speed-of-light     compile-time-parameter build; applied to BOTH sides
   --refresh            ignore cached runs and re-measure both sides
   --keep-worktrees     leave the per-commit worktrees behind (for debugging)
@@ -112,7 +115,11 @@ shift 2
 BASELINE_REF=""
 CURRENT_REF="HEAD"
 ITERATIONS=3
-THRESHOLD=0.05
+# Measured on a 5-run baseline of unchanged code, not guessed. See
+# docs/perf_evaluation/results/blackhole-nonsol/README.md and the constants in
+# perf_regression_compare.py.
+THRESHOLD=0.02
+MIN_CYCLES=30
 SPEED_OF_LIGHT=0
 REFRESH=0
 KEEP_WORKTREES=0
@@ -135,6 +142,10 @@ while [ $# -gt 0 ]; do
         ;;
     --threshold)
         THRESHOLD="${2:?--threshold needs a number}"
+        shift 2
+        ;;
+    --min-cycles)
+        MIN_CYCLES="${2:?--min-cycles needs a number}"
         shift 2
         ;;
     --out-dir)
@@ -213,10 +224,36 @@ fi
 REPORT_DIR="${OUT_DIR:-$BASE_HOME/reports/$ARCH/$TEST/${BASELINE_SHORT}_vs_${CURRENT_SHORT}_$VARIANT}"
 mkdir -p "$REPORT_DIR" "$WORK_ROOT"
 
-echo "== comparing $TEST on $ARCH ($VARIANT build, ${ITERATIONS} iteration(s)/side)"
-echo "   baseline: $BASELINE_SHORT  ($BASELINE_LABEL)"
-echo "   current:  $CURRENT_SHORT  ($CURRENT_LABEL)"
-echo "   report:   $REPORT_DIR"
+# Everything that decides the verdict, stated before any of it runs. A reader must
+# not have to guess which defaults applied, which refs a shorthand resolved to, or
+# what the pass/fail rule actually is.
+cat <<BANNER
+
+  Perf compare
+  ------------------------------------------------------------------
+  test          $TEST
+  arch          $ARCH
+  build         $VARIANT $([ "$SPEED_OF_LIGHT" = 1 ] && echo "(--speed-of-light, applied to BOTH sides)" || echo "(runtime parameters; pass --speed-of-light for the compile-time build)")
+  iterations    $ITERATIONS per side, interleaved; median vs median
+
+  baseline      $BASELINE_SHORT  $BASELINE_LABEL
+  current       $CURRENT_SHORT  $CURRENT_LABEL
+
+  verdict rule  slower by more than $(awk -v t="$THRESHOLD" 'BEGIN{printf "%g", t*100}')% AND more than $MIN_CYCLES cycles
+                Both must hold. The percentage alone fires on small markers such
+                as INIT, where a few cycles of jitter is a large percentage; the
+                cycle count alone fires on large markers, where a real 2% is
+                thousands of cycles. Defaults are measured, not guessed --
+                docs/perf_evaluation/results/blackhole-nonsol/README.md.
+
+  compared per  (marker, run type, sweep config) -- every row, matched
+  measured on   $(hostname)
+  parallelism   producer -n $PRODUCER_JOBS, consumer -n $CONSUMER_JOBS
+  cache         $BASE_HOME
+  report        $REPORT_DIR
+  ------------------------------------------------------------------
+
+BANNER
 
 # --- worktrees: one per commit, removed on exit unless asked to keep them
 WORKTREES=()
@@ -460,6 +497,7 @@ python3 "$COMPARE_PY" \
     --baseline "$BASELINE_CACHE/run_*.csv" \
     --current "$CURRENT_CACHE/run_*.csv" \
     --threshold "$THRESHOLD" \
+    --min-cycles "$MIN_CYCLES" \
     --report "$REPORT_DIR/regression_report.md" \
     --test "$TEST" \
     --baseline-sha "$BASELINE_SHA" --current-sha "$CURRENT_SHA" \

--- a/tt_metal/tt-llk/.claude/scripts/perf_compare_commits.sh
+++ b/tt_metal/tt-llk/.claude/scripts/perf_compare_commits.sh
@@ -1,0 +1,480 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Compare ONE LLK perf test between TWO commits, on this machine, right now.
+#
+# Usage:
+#   perf_compare_commits.sh <arch> <test> [options]
+#
+#   --baseline <ref>     what to compare against  (default: merge-base origin/main HEAD)
+#   --current  <ref>     what to judge            (default: HEAD)
+#   --iterations <N>     runs per side            (default: 3, median-vs-median)
+#   --threshold <T>      regression threshold     (default: 0.05 = 5%)
+#   --speed-of-light     compile-time-parameter build; applied to BOTH sides
+#   --refresh            ignore cached runs and re-measure both sides
+#   --keep-worktrees     leave the per-commit worktrees behind (for debugging)
+#   --out-dir <dir>      where the report goes
+#   --dry-run            resolve the refs, say what would be measured, measure nothing
+#
+# Examples:
+#   perf_compare_commits.sh blackhole perf_math_matmul                      # branch vs branch point
+#   perf_compare_commits.sh blackhole perf_math_matmul --baseline v0.60.0   # any two refs
+#   perf_compare_commits.sh wormhole perf_math_matmul --baseline 1a2b3c4 --current 9f8e7d6
+#
+# Any ref git understands works on either side: a hash, a tag, origin/main, HEAD~5.
+#
+# Your checkout is never touched. Each commit is materialized as its own sparse
+# git worktree (see SPARSE_PATHS) with its own build tree, so no branch is checked
+# out, a dirty working tree is fine, and a crash cannot leave you on a detached
+# HEAD. What is measured is the COMMITTED state of each ref -- your uncommitted
+# edits are not part of the comparison.
+#
+# Runs are cached per (arch, test, variant, commit) under $PERF_COMPARE_HOME, so
+# comparing A-vs-B and then B-vs-C only measures C. Iterations of the two sides
+# are interleaved (baseline, current, baseline, current, ...) so machine drift --
+# thermals, other tenants -- hits both sides equally instead of biasing one.
+#
+# Environment:
+#   PERF_COMPARE_HOME=<dir>   cache + reports (default: ~/.cache/tt-llk-perf-compare)
+#   WORK_ROOT=<dir>           worktrees + build trees, large and disposable
+#                             (default: /tmp/tt-llk-perf-compare)
+#   PRODUCER_JOBS / CONSUMER_JOBS   pytest -n for each phase (default 10 / 15).
+#                             Keep these constant across the commits you compare:
+#                             they are not part of the cache key, so changing them
+#                             mid-comparison silently compares unlike runs.
+#   RESET_BETWEEN_RUNS=1      tt-smi -r between iterations
+#   ALLOW_CROSS_HOST=1        reuse cached runs measured on another host (invalid
+#                             comparison; only for inspecting old data)
+#   SPARSE_PATHS=<paths>      what each worktree checks out. The default is tt-llk plus
+#                             the trees a kernel build includes from outside it
+#                             (tt_metal/hw, tt_metal/hostdevcommon, the ttnn
+#                             experimental kernels) -- about a fifth of the repo. If a
+#                             commit needs more and a compile fails on a missing
+#                             header, add the path here, or set SPARSE_PATHS= (empty)
+#                             for a full checkout.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMPARE_PY="$SCRIPT_DIR/perf_regression_compare.py"
+LLK_PRIMARY="$(cd "$SCRIPT_DIR/../.." && pwd)"
+REPO_ROOT="$(git -C "$LLK_PRIMARY" rev-parse --show-toplevel)"
+# tt-llk relative to the repo root -- the same path inside every worktree.
+LLK_RELPATH="${LLK_PRIMARY#"$REPO_ROOT"/}"
+
+BASE_HOME="${PERF_COMPARE_HOME:-$HOME/.cache/tt-llk-perf-compare}"
+WORK_ROOT="${WORK_ROOT:-/tmp/tt-llk-perf-compare}"
+PRODUCER_JOBS="${PRODUCER_JOBS:-10}"
+CONSUMER_JOBS="${CONSUMER_JOBS:-15}"
+# Kernel compiles reach out of tt-llk: ../../hw/inc, ../../hw/ckernels/<arch>/metal,
+# ../../hostdevcommon/api and ../../../ttnn/cpp/ttnn/operations/experimental (see
+# TestConfig.INCLUDES). A worktree missing those builds nothing.
+SPARSE_PATHS="${SPARSE_PATHS-$LLK_RELPATH tt_metal/hw tt_metal/hostdevcommon ttnn/cpp/ttnn/operations/experimental}"
+
+[ "$LLK_RELPATH" != "$LLK_PRIMARY" ] || {
+    echo "error: $LLK_PRIMARY is not under the repo root $REPO_ROOT" >&2
+    exit 2
+}
+
+die() {
+    echo "error: $*" >&2
+    exit 2
+}
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: perf_compare_commits.sh <arch> <test> [options]
+
+  --baseline <ref>     what to compare against  (default: merge-base origin/main HEAD)
+  --current  <ref>     what to judge            (default: HEAD)
+  --iterations <N>     runs per side            (default: 3, median-vs-median)
+  --threshold <T>      regression threshold     (default: 0.05 = 5%)
+  --speed-of-light     compile-time-parameter build; applied to BOTH sides
+  --refresh            ignore cached runs and re-measure both sides
+  --keep-worktrees     leave the per-commit worktrees behind (for debugging)
+  --out-dir <dir>      where the report goes
+  --dry-run            resolve the refs, say what would be measured, measure nothing
+
+  perf_compare_commits.sh blackhole perf_math_matmul                     # branch vs branch point
+  perf_compare_commits.sh blackhole perf_math_matmul --baseline v0.60.0  # any two refs
+  perf_compare_commits.sh wormhole perf_math_matmul --baseline 1a2b3c4 --current 9f8e7d6
+EOF
+    exit 2
+}
+
+# --- arguments
+[ $# -ge 2 ] || usage
+ARCH="$1"
+TEST="$2"
+shift 2
+
+BASELINE_REF=""
+CURRENT_REF="HEAD"
+ITERATIONS=3
+THRESHOLD=0.05
+SPEED_OF_LIGHT=0
+REFRESH=0
+KEEP_WORKTREES=0
+DRY_RUN=0
+OUT_DIR=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+    --baseline)
+        BASELINE_REF="${2:?--baseline needs a ref}"
+        shift 2
+        ;;
+    --current)
+        CURRENT_REF="${2:?--current needs a ref}"
+        shift 2
+        ;;
+    --iterations)
+        ITERATIONS="${2:?--iterations needs a number}"
+        shift 2
+        ;;
+    --threshold)
+        THRESHOLD="${2:?--threshold needs a number}"
+        shift 2
+        ;;
+    --out-dir)
+        OUT_DIR="${2:?--out-dir needs a path}"
+        shift 2
+        ;;
+    --speed-of-light)
+        SPEED_OF_LIGHT=1
+        shift
+        ;;
+    --refresh)
+        REFRESH=1
+        shift
+        ;;
+    --keep-worktrees)
+        KEEP_WORKTREES=1
+        shift
+        ;;
+    --dry-run)
+        DRY_RUN=1
+        shift
+        ;;
+    -h | --help) usage ;;
+    *) die "unknown option '$1'" ;;
+    esac
+done
+
+case "$ARCH" in
+wormhole | blackhole) ;;
+*) die "arch must be 'wormhole' or 'blackhole', got '$ARCH'" ;;
+esac
+
+[[ "$ITERATIONS" =~ ^[1-9][0-9]*$ ]] || die "--iterations must be a positive integer"
+
+TEST="${TEST%.py}"
+TEST="$(basename "$TEST")"
+
+VARIANT=runtime
+PYTEST_VARIANT_ARGS=()
+if [ "$SPEED_OF_LIGHT" = 1 ]; then
+    VARIANT=sol
+    PYTEST_VARIANT_ARGS+=(--speed-of-light)
+fi
+
+# --- resolve both sides to full commit hashes
+cd "$LLK_PRIMARY"
+if [ -z "$BASELINE_REF" ]; then
+    git fetch origin main --quiet || echo "warning: could not fetch origin/main; using the local ref" >&2
+    BASELINE_REF="$(git merge-base origin/main HEAD)"
+    BASELINE_LABEL="branch point on main"
+else
+    BASELINE_LABEL="$BASELINE_REF"
+fi
+CURRENT_LABEL="$CURRENT_REF"
+
+resolve() {
+    git rev-parse --verify --quiet "$1^{commit}" || die "not a commit this repo knows: '$1'"
+}
+BASELINE_SHA="$(resolve "$BASELINE_REF")"
+CURRENT_SHA="$(resolve "$CURRENT_REF")"
+BASELINE_SHORT="${BASELINE_SHA:0:12}"
+CURRENT_SHORT="${CURRENT_SHA:0:12}"
+
+[ "$BASELINE_SHA" != "$CURRENT_SHA" ] ||
+    die "both sides resolve to $BASELINE_SHORT -- nothing to compare"
+
+# A ref only ever names a commit, so uncommitted work is invisible here. Say so
+# rather than let someone read the verdict as covering their working tree. .claude/
+# is agent tooling (this script included) and never a build input, so changes there
+# are not worth a warning.
+if [ -n "$(git status --porcelain -- "$LLK_PRIMARY" ':(exclude,glob)**/.claude/**')" ]; then
+    echo "note: uncommitted changes under $LLK_RELPATH are NOT measured -- each side is"
+    echo "      the committed state of its ref. Commit them if they should count."
+fi
+
+REPORT_DIR="${OUT_DIR:-$BASE_HOME/reports/$ARCH/$TEST/${BASELINE_SHORT}_vs_${CURRENT_SHORT}_$VARIANT}"
+mkdir -p "$REPORT_DIR" "$WORK_ROOT"
+
+echo "== comparing $TEST on $ARCH ($VARIANT build, ${ITERATIONS} iteration(s)/side)"
+echo "   baseline: $BASELINE_SHORT  ($BASELINE_LABEL)"
+echo "   current:  $CURRENT_SHORT  ($CURRENT_LABEL)"
+echo "   report:   $REPORT_DIR"
+
+# --- worktrees: one per commit, removed on exit unless asked to keep them
+WORKTREES=()
+cleanup() {
+    local wt
+    if [ "$KEEP_WORKTREES" = 1 ]; then
+        if [ ${#WORKTREES[@]} -gt 0 ]; then
+            echo "note: worktrees kept: ${WORKTREES[*]}"
+        fi
+        return 0
+    fi
+    for wt in ${WORKTREES+"${WORKTREES[@]}"}; do
+        git -C "$REPO_ROOT" worktree remove --force "$wt" 2>/dev/null || rm -rf "$wt"
+    done
+    return 0
+}
+trap cleanup EXIT INT TERM
+
+make_worktree() {
+    # Worktree at commit $1 (sparse unless SPARSE_PATHS is empty); prints its path.
+    # Nothing here checks out a branch, so the user's working tree is never involved.
+    local sha="$1"
+    local dir="$WORK_ROOT/wt-${sha:0:12}"
+    if [ -d "$dir/$LLK_RELPATH/tests/python_tests" ]; then # resume
+        echo "$dir"
+        return
+    fi
+    rm -rf "$dir"
+    # A run killed outright (no trap) leaves the path registered but gone; without
+    # this, 'worktree add' refuses the same path forever.
+    git -C "$REPO_ROOT" worktree prune
+    if [ -n "$SPARSE_PATHS" ]; then
+        git -C "$REPO_ROOT" worktree add --no-checkout --detach "$dir" "$sha" >/dev/null
+        # sparse-checkout only sets the patterns; the checkout after it populates.
+        if ! (git -C "$dir" sparse-checkout set --cone $SPARSE_PATHS &&
+            git -C "$dir" checkout --detach "$sha") >/dev/null 2>&1; then
+            # Old git, or a pattern it dislikes: fall back to a full checkout.
+            git -C "$REPO_ROOT" worktree remove --force "$dir" 2>/dev/null || rm -rf "$dir"
+            git -C "$REPO_ROOT" worktree add --detach "$dir" "$sha" >/dev/null
+        fi
+    else
+        git -C "$REPO_ROOT" worktree add --detach "$dir" "$sha" >/dev/null
+    fi
+    [ -d "$dir/$LLK_RELPATH/tests/python_tests" ] ||
+        die "worktree for ${sha:0:12} has no $LLK_RELPATH/tests/python_tests"
+    # A path that existed when this script was written may not exist at an old
+    # commit; say so once here rather than as a puzzling missing-header error.
+    local p
+    for p in $SPARSE_PATHS; do
+        if [ ! -e "$dir/$p" ]; then
+            echo "warning: '$p' does not exist at ${sha:0:12}; if a compile fails on a" >&2
+            echo "         missing header, set SPARSE_PATHS for that commit's layout" >&2
+        fi
+    done
+    echo "$dir"
+}
+
+ensure_sfpi() {
+    # tests/sfpi is downloaded, not tracked, so a fresh worktree has none. Reuse
+    # the primary checkout's toolchain when it is the version this commit pins,
+    # otherwise let the commit's own setup script fetch the right one.
+    local llk="$1" sha="$2"
+    local want have="" primary_ver=""
+    want="$(sed -n "s/^sfpi_version='\(.*\)'/\1/p" "$llk/tests/sfpi-version" | head -1)"
+    if [ -f "$llk/tests/sfpi/sfpi.version" ]; then
+        have="$(cat "$llk/tests/sfpi/sfpi.version")"
+    fi
+    if [ -n "$want" ] && [ "$have" = "$want" ]; then
+        return 0
+    fi
+
+    if [ -f "$LLK_PRIMARY/tests/sfpi/sfpi.version" ]; then
+        primary_ver="$(cat "$LLK_PRIMARY/tests/sfpi/sfpi.version")"
+    fi
+    if [ -n "$want" ] && [ "$primary_ver" = "$want" ]; then
+        rm -rf "$llk/tests/sfpi"
+        ln -sfn "$LLK_PRIMARY/tests/sfpi" "$llk/tests/sfpi"
+        echo "   sfpi $want: reusing the toolchain from your checkout"
+        return 0
+    fi
+    echo "   sfpi ${want:-?} for ${sha:0:12} differs from your checkout's (${primary_ver:-none}); fetching"
+    (cd "$llk" && ./tests/setup_testing_env.sh) ||
+        die "could not install the sfpi toolchain ${want:-?} that ${sha:0:12} pins"
+}
+
+# --- cache: runs are identified by what can change a measured cycle
+cache_dir_for() {
+    echo "$BASE_HOME/runs/$ARCH/$TEST/$VARIANT/$1"
+}
+
+check_cache_provenance() {
+    # Cycles from another machine are not comparable to cycles from this one, and
+    # sweep parallelism is not part of the cache key, so check both here.
+    local meta="$1/meta.txt" cached_host cached_jobs
+    if [ ! -f "$meta" ]; then
+        return 0
+    fi
+    cached_jobs="$(sed -n 's/^consumer_jobs: //p' "$meta" | head -1)"
+    if [ -n "$cached_jobs" ] && [ "$cached_jobs" != "$CONSUMER_JOBS" ]; then
+        echo "warning: cached runs in $1 used CONSUMER_JOBS=$cached_jobs, this run uses" >&2
+        echo "         $CONSUMER_JOBS -- re-run with --refresh to compare like with like" >&2
+    fi
+    cached_host="$(sed -n 's/^host: //p' "$meta" | head -1)"
+    if [ -n "$cached_host" ] && [ "$cached_host" != "$(hostname)" ]; then
+        if [ -z "${ALLOW_CROSS_HOST:-}" ]; then
+            die "cached runs in $1 were measured on '$cached_host', not '$(hostname)'.
+       Cross-machine cycles are not comparable. Re-measure with --refresh, or set
+       ALLOW_CROSS_HOST=1 if you only want to look at the old numbers."
+        fi
+        echo "warning: reusing runs measured on '$cached_host' -- the comparison is not valid" >&2
+    fi
+}
+
+write_meta() {
+    {
+        echo "commit: $2"
+        echo "arch: $ARCH"
+        echo "test: $TEST"
+        echo "variant: $VARIANT"
+        echo "host: $(hostname)"
+        echo "producer_jobs: $PRODUCER_JOBS"
+        echo "consumer_jobs: $CONSUMER_JOBS"
+    } >"$1/meta.txt"
+}
+
+measure_iteration() {
+    # One producer+consumer sweep of $TEST at commit $1, snapshotted to $4.
+    local sha="$1" wt="$2" side="$3" out_csv="$4"
+    local llk="$wt/$LLK_RELPATH"
+    local perf_data="$llk/perf_data"
+    local build_root="$WORK_ROOT/build-${sha:0:12}"
+    local test_file="$llk/tests/python_tests/$TEST.py"
+
+    if [ ! -f "$test_file" ]; then
+        die "$TEST.py does not exist at ${sha:0:12} (${side}). If the test was ADDED after
+       that commit there is nothing to compare against; pick a ref that has it."
+    fi
+    mkdir -p "$build_root"
+
+    # A stale perf_data would let the previous iteration's CSV stand in for a
+    # sweep that failed to report this time.
+    rm -rf "$perf_data"
+    (
+        cd "$llk/tests/python_tests"
+        export LLK_HOME="$llk"
+        export RUNNER_TEMP="$build_root" # -> ARTEFACTS_DIR, private per commit
+        export CHIP_ARCH="$ARCH"
+        # No -x: it aborts mid-sweep and the combined CSV is silently partial.
+        pytest -q --override-ini=log_cli=false --compile-producer \
+            -n "$PRODUCER_JOBS" -m perf \
+            ${PYTEST_VARIANT_ARGS+"${PYTEST_VARIANT_ARGS[@]}"} "./$TEST.py"
+        pytest -q --override-ini=log_cli=false --compile-consumer \
+            -n "$CONSUMER_JOBS" -m perf \
+            ${PYTEST_VARIANT_ARGS+"${PYTEST_VARIANT_ARGS[@]}"} "./$TEST.py"
+    )
+
+    local csv="$perf_data/$TEST/$TEST.csv"
+    if [ ! -f "$csv" ]; then
+        csv="$(find "$llk" -path "*/perf_data/$TEST/$TEST.csv" | head -1)"
+    fi
+    if [ -z "$csv" ] || [ ! -f "$csv" ]; then
+        die "no perf CSV from ${sha:0:12} (${side}). Was every case deselected -- does
+       $TEST carry the 'perf' marker?"
+    fi
+    cp "$csv" "$out_csv"
+}
+
+# --- plan: which iterations are missing per side (cache hit = nothing to run)
+BASELINE_CACHE="$(cache_dir_for "$BASELINE_SHA")"
+CURRENT_CACHE="$(cache_dir_for "$CURRENT_SHA")"
+if [ "$REFRESH" = 1 ]; then
+    rm -rf "$BASELINE_CACHE" "$CURRENT_CACHE"
+fi
+mkdir -p "$BASELINE_CACHE" "$CURRENT_CACHE"
+check_cache_provenance "$BASELINE_CACHE"
+check_cache_provenance "$CURRENT_CACHE"
+
+missing_for() {
+    local dir="$1" i
+    for i in $(seq 1 "$ITERATIONS"); do
+        [ -f "$dir/run_$i.csv" ] || echo "$i"
+    done
+}
+BASELINE_MISSING=($(missing_for "$BASELINE_CACHE"))
+CURRENT_MISSING=($(missing_for "$CURRENT_CACHE"))
+
+cached_count() { find "$1" -name 'run_*.csv' | wc -l | tr -d ' '; }
+echo "   cached: baseline $(cached_count "$BASELINE_CACHE") run(s), current $(cached_count "$CURRENT_CACHE") run(s)"
+echo "   to run: baseline ${#BASELINE_MISSING[@]} sweep(s), current ${#CURRENT_MISSING[@]} sweep(s)"
+
+if [ "$DRY_RUN" = 1 ]; then
+    echo "== dry run, stopping here"
+    exit 0
+fi
+
+if [ ${#BASELINE_MISSING[@]} -gt 0 ]; then
+    echo "== worktree for baseline $BASELINE_SHORT"
+    BASELINE_WT="$(make_worktree "$BASELINE_SHA")"
+    WORKTREES+=("$BASELINE_WT")
+    ensure_sfpi "$BASELINE_WT/$LLK_RELPATH" "$BASELINE_SHA"
+    write_meta "$BASELINE_CACHE" "$BASELINE_SHA"
+fi
+if [ ${#CURRENT_MISSING[@]} -gt 0 ]; then
+    echo "== worktree for current $CURRENT_SHORT"
+    CURRENT_WT="$(make_worktree "$CURRENT_SHA")"
+    WORKTREES+=("$CURRENT_WT")
+    ensure_sfpi "$CURRENT_WT/$LLK_RELPATH" "$CURRENT_SHA"
+    write_meta "$CURRENT_CACHE" "$CURRENT_SHA"
+fi
+
+# --- measure, interleaved so drift is shared between the two sides
+TOTAL=$((${#BASELINE_MISSING[@]} + ${#CURRENT_MISSING[@]}))
+DONE=0
+for i in $(seq 1 "$ITERATIONS"); do
+    for side in baseline current; do
+        if [ "$side" = baseline ]; then
+            if [ -f "$BASELINE_CACHE/run_$i.csv" ]; then
+                continue
+            fi
+            sha="$BASELINE_SHA" wt="$BASELINE_WT" cache="$BASELINE_CACHE"
+        else
+            if [ -f "$CURRENT_CACHE/run_$i.csv" ]; then
+                continue
+            fi
+            sha="$CURRENT_SHA" wt="$CURRENT_WT" cache="$CURRENT_CACHE"
+        fi
+        DONE=$((DONE + 1))
+        echo "== [$DONE/$TOTAL] $side ${sha:0:12}, iteration $i ($(date -u +%H:%M:%SZ))"
+        measure_iteration "$sha" "$wt" "$side" "$cache/run_$i.csv"
+        if [ -n "${RESET_BETWEEN_RUNS:-}" ] && [ "$DONE" -lt "$TOTAL" ]; then
+            tt-smi -r
+        fi
+    done
+done
+
+# --- compare. Every cached run counts, not just this invocation's iterations:
+# more samples per side is a better median, and the two sides may differ in count.
+echo "== comparing"
+set +e
+python3 "$COMPARE_PY" \
+    --baseline "$BASELINE_CACHE/run_*.csv" \
+    --current "$CURRENT_CACHE/run_*.csv" \
+    --threshold "$THRESHOLD" \
+    --report "$REPORT_DIR/regression_report.md" \
+    --test "$TEST" \
+    --baseline-sha "$BASELINE_SHA" --current-sha "$CURRENT_SHA" \
+    --baseline-label "$BASELINE_LABEL" --current-label "$CURRENT_LABEL"
+STATUS=$?
+set -e
+
+# The compare exits 1 for "regressions found", which a crash would look like too.
+# The report only exists if it got far enough to have a verdict.
+if [ ! -f "$REPORT_DIR/regression_report.md" ]; then
+    die "the compare step failed before writing a report -- see its error above.
+       The measured runs are kept, so fixing it and re-running costs no sweeps."
+fi
+
+echo
+echo "report: $REPORT_DIR/regression_report.md"
+echo "runs:   $BASELINE_CACHE  |  $CURRENT_CACHE"
+exit "$STATUS"

--- a/tt_metal/tt-llk/.claude/scripts/perf_regression_compare.py
+++ b/tt_metal/tt-llk/.claude/scripts/perf_regression_compare.py
@@ -59,17 +59,49 @@ def _medians(frames):
     return {k: median(v) for k, v in samples.items()}
 
 
-def compare_runs(current_csvs, baseline_csvs, *, threshold=0.05):
+# Defaults are measured, not guessed: five runs of one commit on one card, over
+# 108,377 points (L1_TO_L1) and 311,352 (isolates). The numbers below come from
+# docs/perf_evaluation/results/blackhole-nonsol/README.md.
+#
+#   THRESHOLD   No TILE_LOOP or KERNEL measurement moved more than 1.9% between
+#               identical runs. 2% sits above every observed sample and is still
+#               tight enough to catch a real regression.
+#   MIN_CYCLES  INIT and UNINIT are a few hundred cycles and wobble by up to 25.
+#               That is a large *percentage* of a small number. 30 cycles clears
+#               every wobble we saw.
+#
+# A point must exceed BOTH. Either clause alone is wrong: percentage-only fires on
+# the small markers (474 of 108,377 points, all moving 25 cycles or less), and
+# cycles-only fires on the big ones (TILE_LOOP moves up to 5,110 cycles and that
+# is still only 1.9%). Together they flagged nothing across four of the five
+# configurations measured.
+DEFAULT_THRESHOLD = 0.02
+DEFAULT_MIN_CYCLES = 30.0
+
+
+def compare_runs(
+    current_csvs,
+    baseline_csvs,
+    *,
+    threshold=DEFAULT_THRESHOLD,
+    min_cycles=DEFAULT_MIN_CYCLES,
+):
     """Median-vs-median comparison.
 
-    Returns ``{records, regressions, improvements, new_points}``. ``delta`` is the
-    fractional change vs baseline (0.12 = 12% slower, -0.12 = 12% faster), so a
-    regression is ``delta > threshold`` and an improvement ``delta < -threshold``.
+    Returns ``{records, regressions, improvements, new_points, noise_filtered}``.
+    ``delta`` is the fractional change vs baseline (0.12 = 12% slower, -0.12 = 12%
+    faster) and ``abs_delta`` is the same change in cycles. A regression needs
+    ``delta > threshold`` AND ``abs_delta > min_cycles``; an improvement is the
+    mirror image. See the constants above for why both are required.
+
+    ``noise_filtered`` counts points that cleared the percentage but not the cycle
+    floor — exactly the points a relative-only rule would have failed on.
     """
     cur = _medians([pd.read_csv(p) for p in current_csvs])
     base = _medians([pd.read_csv(p) for p in baseline_csvs])
 
     records, regressions, improvements, new_points = [], [], [], []
+    noise_filtered = 0
     for (key, mean_col), cval in cur.items():
         marker, config = key
         run_type = mean_col[len("mean(") : -1]
@@ -84,12 +116,17 @@ def compare_runs(current_csvs, baseline_csvs, *, threshold=0.05):
             new_points.append(point)  # no baseline (new config / new test)
             continue
         delta = (cval - bval) / bval if bval else 0.0
+        abs_delta = cval - bval
+        big_enough = abs(abs_delta) > min_cycles
+        if abs(delta) > threshold and not big_enough:
+            noise_filtered += 1
         record = {
             **point,
             "baseline": bval,
             "delta": delta,
-            "regression": delta > threshold,
-            "improvement": delta < -threshold,
+            "abs_delta": abs_delta,
+            "regression": delta > threshold and big_enough,
+            "improvement": delta < -threshold and big_enough,
         }
         records.append(record)
         if record["regression"]:
@@ -101,6 +138,7 @@ def compare_runs(current_csvs, baseline_csvs, *, threshold=0.05):
         "regressions": regressions,
         "improvements": improvements,
         "new_points": new_points,
+        "noise_filtered": noise_filtered,
     }
 
 
@@ -119,8 +157,8 @@ def _delta_table(rows, *, caption):
     lines = [
         f"## {caption}",
         "",
-        "| marker | run type | current | baseline | Δ | config |",
-        "|---|---|--:|--:|--:|---|",
+        "| marker | run type | current | baseline | Δ | Δ cycles | config |",
+        "|---|---|--:|--:|--:|--:|---|",
     ]
     for r in rows:
         cfg = ", ".join(f"{k}={v}" for k, v in sorted(r["config"].items()))
@@ -128,7 +166,8 @@ def _delta_table(rows, *, caption):
             cfg = cfg[:87] + "…"
         lines.append(
             f"| {r['marker']} | {r['run_type']} | {r['current']:.1f} | "
-            f"{r['baseline']:.1f} | {r['delta'] * 100:+.1f}% | {cfg} |"
+            f"{r['baseline']:.1f} | {r['delta'] * 100:+.1f}% | "
+            f"{r.get('abs_delta', 0.0):+.0f} | {cfg} |"
         )
     return lines
 
@@ -140,6 +179,7 @@ def render_report(
     test,
     baseline_sha,
     current_sha,
+    min_cycles=DEFAULT_MIN_CYCLES,
     baseline_iters=None,
     current_iters=None,
     baseline_label=None,
@@ -161,15 +201,27 @@ def render_report(
     lines = [
         f"# Perf compare — {test}",
         "",
-        f"**{verdict}** (threshold {threshold * 100:.0f}%, median-vs-median)",
+        f"**{verdict}**",
+        "",
+        f"Rule: a point is a regression when it is **more than {threshold * 100:.0f}% "
+        f"slower AND more than {min_cycles:.0f} cycles slower**. Both must hold. "
+        "Comparison is median-vs-median, per (marker, run type, sweep config).",
         "",
         _side_line("baseline", baseline_sha, baseline_label, baseline_iters),
         _side_line("current", current_sha, current_label, current_iters),
         f"- {len(result['records'])} points compared, "
         f"**{len(regs)} regression(s)**, {len(imps)} improvement(s), "
         f"{len(result['new_points'])} new point(s)",
-        "",
     ]
+    filtered = result.get("noise_filtered", 0)
+    if filtered:
+        lines.append(
+            f"- {filtered} point(s) moved more than {threshold * 100:.0f}% but by "
+            f"{min_cycles:.0f} cycles or fewer, so they are ignored. Small markers "
+            "(INIT, UNINIT) are a few hundred cycles, where a handful of cycles of "
+            "jitter looks like a large percentage."
+        )
+    lines.append("")
     if regs:
         shown = regs[:_TOP_N]
         lines += _delta_table(
@@ -212,6 +264,7 @@ def _points_csv(records):
             "current": r["current"],
             "baseline": r["baseline"],
             "delta_pct": round(r["delta"] * 100, 2),
+            "delta_cycles": round(r.get("abs_delta", 0.0), 1),
         }
         row.update(r["config"])
         rows.append(row)
@@ -224,7 +277,20 @@ def main(argv=None):
     )
     ap.add_argument("--current", required=True, help="glob for current-run CSVs")
     ap.add_argument("--baseline", required=True, help="glob for baseline-run CSVs")
-    ap.add_argument("--threshold", type=float, default=0.05)
+    ap.add_argument(
+        "--threshold",
+        type=float,
+        default=DEFAULT_THRESHOLD,
+        help=f"relative slowdown that counts as a regression (default {DEFAULT_THRESHOLD})",
+    )
+    ap.add_argument(
+        "--min-cycles",
+        type=float,
+        default=DEFAULT_MIN_CYCLES,
+        help="absolute slowdown, in cycles, that a point must ALSO exceed "
+        f"(default {DEFAULT_MIN_CYCLES:.0f}). Stops small markers such as INIT "
+        "from failing the gate on a few cycles of jitter. 0 disables the clause.",
+    )
     ap.add_argument("--report", default="regression_report.md")
     ap.add_argument("--test", default="?")
     ap.add_argument("--baseline-sha", default="?")
@@ -243,10 +309,13 @@ def main(argv=None):
             f"no CSVs matched (current={len(current)}, baseline={len(baseline)})"
         )
 
-    result = compare_runs(current, baseline, threshold=a.threshold)
+    result = compare_runs(
+        current, baseline, threshold=a.threshold, min_cycles=a.min_cycles
+    )
     report = render_report(
         result,
         threshold=a.threshold,
+        min_cycles=a.min_cycles,
         test=a.test,
         baseline_sha=a.baseline_sha,
         current_sha=a.current_sha,

--- a/tt_metal/tt-llk/.claude/scripts/perf_regression_compare.py
+++ b/tt_metal/tt-llk/.claude/scripts/perf_regression_compare.py
@@ -2,12 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Self-contained perf regression compare for the perf-regression-check skill.
+"""Self-contained perf compare for the perf-regression-check skill.
 
-Compares a branch's perf run (current) to the commit it was branched from
-(baseline), for one test. Both sides may have several iterations; we take the
-**median per point** on each side and flag points where current is more than
-``threshold`` slower than baseline.
+Compares two perf runs of the same test — ``current`` against ``baseline``. The
+two sides are usually two commits (a branch HEAD vs the commit it was branched
+from, or any two commit hashes). Both sides may have several iterations; we take
+the **median per point** on each side, flag points where current is more than
+``threshold`` slower than baseline (regressions) and, symmetrically, points that
+are more than ``threshold`` faster (improvements).
 
 Deliberately dependency-light so it runs on any branch, merged or not: reads the
 raw ``perf_data`` CSVs directly (no Parquet, no perf schema). A "point" is
@@ -58,14 +60,16 @@ def _medians(frames):
 
 
 def compare_runs(current_csvs, baseline_csvs, *, threshold=0.05):
-    """Median-vs-median comparison. Returns {records, regressions, new_points}.
+    """Median-vs-median comparison.
 
-    ``delta`` is the fractional change vs baseline (0.12 = 12% slower).
+    Returns ``{records, regressions, improvements, new_points}``. ``delta`` is the
+    fractional change vs baseline (0.12 = 12% slower, -0.12 = 12% faster), so a
+    regression is ``delta > threshold`` and an improvement ``delta < -threshold``.
     """
     cur = _medians([pd.read_csv(p) for p in current_csvs])
     base = _medians([pd.read_csv(p) for p in baseline_csvs])
 
-    records, regressions, new_points = [], [], []
+    records, regressions, improvements, new_points = [], [], [], []
     for (key, mean_col), cval in cur.items():
         marker, config = key
         run_type = mean_col[len("mean(") : -1]
@@ -85,54 +89,107 @@ def compare_runs(current_csvs, baseline_csvs, *, threshold=0.05):
             "baseline": bval,
             "delta": delta,
             "regression": delta > threshold,
+            "improvement": delta < -threshold,
         }
         records.append(record)
         if record["regression"]:
             regressions.append(record)
-    return {"records": records, "regressions": regressions, "new_points": new_points}
+        elif record["improvement"]:
+            improvements.append(record)
+    return {
+        "records": records,
+        "regressions": regressions,
+        "improvements": improvements,
+        "new_points": new_points,
+    }
 
 
 _TOP_N = 25
 
 
-def render_report(result, *, threshold, test, baseline_sha, current_sha, iters):
-    """A short Markdown report: verdict + the worst regressions + new points.
+def _side_line(role, sha, label, iters):
+    """``- baseline (v1.2 tag): `abc123` — 3 iteration(s)``; label/iters optional."""
+    named = f"{role} ({label})" if label else role
+    tail = f" — {iters} iteration(s)" if iters else ""
+    return f"- {named}: `{sha}`{tail}"
 
-    Only the ``_TOP_N`` biggest regressions are tabled; the full list goes to a
-    companion ``*.regressions.csv`` (written by main).
+
+def _delta_table(rows, *, caption):
+    """One Markdown table of points, worst delta first, config truncated to fit."""
+    lines = [
+        f"## {caption}",
+        "",
+        "| marker | run type | current | baseline | Δ | config |",
+        "|---|---|--:|--:|--:|---|",
+    ]
+    for r in rows:
+        cfg = ", ".join(f"{k}={v}" for k, v in sorted(r["config"].items()))
+        if len(cfg) > 90:
+            cfg = cfg[:87] + "…"
+        lines.append(
+            f"| {r['marker']} | {r['run_type']} | {r['current']:.1f} | "
+            f"{r['baseline']:.1f} | {r['delta'] * 100:+.1f}% | {cfg} |"
+        )
+    return lines
+
+
+def render_report(
+    result,
+    *,
+    threshold,
+    test,
+    baseline_sha,
+    current_sha,
+    baseline_iters=None,
+    current_iters=None,
+    baseline_label=None,
+    current_label=None,
+):
+    """A short Markdown report: verdict + worst regressions + improvements + new points.
+
+    ``baseline_label``/``current_label`` say what each side *is* (``branch point on
+    main``, a ref as the user typed it, …); the comparison itself is just
+    current-vs-baseline, so any two commits work.
+
+    Only the ``_TOP_N`` biggest regressions are tabled; every compared point goes
+    to a companion ``*.points.csv`` and every regression to ``*.regressions.csv``
+    (both written by main).
     """
     regs = sorted(result["regressions"], key=lambda r: -r["delta"])
+    imps = sorted(result.get("improvements", []), key=lambda r: r["delta"])
     verdict = "❌ REGRESSIONS FOUND" if regs else "✅ no regressions"
     lines = [
-        f"# Perf regression check — {test}",
+        f"# Perf compare — {test}",
         "",
-        f"**{verdict}** (threshold {threshold * 100:.0f}%, {iters} iteration(s)/side, median-vs-median)",
+        f"**{verdict}** (threshold {threshold * 100:.0f}%, median-vs-median)",
         "",
-        f"- baseline (branch point on main): `{baseline_sha}`",
-        f"- current (your branch HEAD): `{current_sha}`",
+        _side_line("baseline", baseline_sha, baseline_label, baseline_iters),
+        _side_line("current", current_sha, current_label, current_iters),
         f"- {len(result['records'])} points compared, "
-        f"**{len(regs)} regression(s)**, {len(result['new_points'])} new point(s)",
+        f"**{len(regs)} regression(s)**, {len(imps)} improvement(s), "
+        f"{len(result['new_points'])} new point(s)",
         "",
     ]
     if regs:
         shown = regs[:_TOP_N]
-        lines += [f"## Top {len(shown)} regressions (slower on your branch)", ""]
-        lines += [
-            "| marker | run type | current | baseline | Δ | config |",
-            "|---|---|--:|--:|--:|---|",
-        ]
-        for r in shown:
-            cfg = ", ".join(f"{k}={v}" for k, v in sorted(r["config"].items()))
-            if len(cfg) > 90:
-                cfg = cfg[:87] + "…"
-            lines.append(
-                f"| {r['marker']} | {r['run_type']} | {r['current']:.1f} | "
-                f"{r['baseline']:.1f} | +{r['delta'] * 100:.1f}% | {cfg} |"
-            )
+        lines += _delta_table(
+            shown, caption=f"Top {len(shown)} regressions (slower on current)"
+        )
         if len(regs) > _TOP_N:
             lines.append("")
             lines.append(
                 f"_… and {len(regs) - _TOP_N} more — see the companion `.regressions.csv`._"
+            )
+        lines.append("")
+    if imps:
+        shown = imps[:_TOP_N]
+        lines += _delta_table(
+            shown, caption=f"Top {len(shown)} improvements (faster on current)"
+        )
+        if len(imps) > _TOP_N:
+            lines.append("")
+            lines.append(
+                f"_… and {len(imps) - _TOP_N} more — see the companion `.points.csv`._"
             )
         lines.append("")
     if result["new_points"]:
@@ -140,15 +197,15 @@ def render_report(result, *, threshold, test, baseline_sha, current_sha, iters):
             f"## New points ({len(result['new_points'])}) — no baseline, not counted as regressions"
         )
         lines.append(
-            "_These configs/markers exist on your branch but not at the branch point._"
+            "_These configs/markers exist at the current commit but not at the baseline commit._"
         )
     return "\n".join(lines)
 
 
-def _write_regressions_csv(result, path):
-    """Full regression list (every point, full config) as CSV — nothing truncated."""
+def _points_csv(records):
+    """Records as flat CSV rows (full config, nothing truncated), worst delta first."""
     rows = []
-    for r in sorted(result["regressions"], key=lambda x: -x["delta"]):
+    for r in sorted(records, key=lambda x: -x["delta"]):
         row = {
             "marker": r["marker"],
             "run_type": r["run_type"],
@@ -158,13 +215,12 @@ def _write_regressions_csv(result, path):
         }
         row.update(r["config"])
         rows.append(row)
-    if rows:
-        pd.DataFrame(rows).to_csv(path, index=False)
+    return pd.DataFrame(rows) if rows else None
 
 
 def main(argv=None):
     ap = argparse.ArgumentParser(
-        description="Compare current perf CSVs to a baseline's."
+        description="Compare current perf CSVs to a baseline's (usually two commits)."
     )
     ap.add_argument("--current", required=True, help="glob for current-run CSVs")
     ap.add_argument("--baseline", required=True, help="glob for baseline-run CSVs")
@@ -173,6 +229,11 @@ def main(argv=None):
     ap.add_argument("--test", default="?")
     ap.add_argument("--baseline-sha", default="?")
     ap.add_argument("--current-sha", default="?")
+    ap.add_argument(
+        "--baseline-label",
+        help="what the baseline side is, e.g. 'branch point on main' or the ref as typed",
+    )
+    ap.add_argument("--current-label", help="what the current side is")
     a = ap.parse_args(argv)
 
     current = sorted(glob.glob(a.current))
@@ -189,18 +250,27 @@ def main(argv=None):
         test=a.test,
         baseline_sha=a.baseline_sha,
         current_sha=a.current_sha,
-        iters=len(current),
+        baseline_iters=len(baseline),
+        current_iters=len(current),
+        baseline_label=a.baseline_label,
+        current_label=a.current_label,
     )
     with open(a.report, "w") as f:
         f.write(report + "\n")
-    csv_path = a.report.rsplit(".", 1)[0] + ".regressions.csv"
-    _write_regressions_csv(result, csv_path)
+
+    stem = a.report.rsplit(".", 1)[0]
+    written = [a.report]
+    points = _points_csv(result["records"])
+    if points is not None:
+        points.to_csv(f"{stem}.points.csv", index=False)
+        written.append(f"{stem}.points.csv")
+    regressions = _points_csv(result["regressions"])
+    if regressions is not None:
+        regressions.to_csv(f"{stem}.regressions.csv", index=False)
+        written.append(f"{stem}.regressions.csv")
+
     print(report)
-    print(
-        f"\n(wrote {a.report}"
-        + (f" + {csv_path}" if result["regressions"] else "")
-        + ")"
-    )
+    print("\n(wrote " + " + ".join(written) + ")")
     # exit non-zero if regressions, so the skill/CI can gate on it
     raise SystemExit(1 if result["regressions"] else 0)
 

--- a/tt_metal/tt-llk/.claude/skills/perf-regression-check/README.md
+++ b/tt_metal/tt-llk/.claude/skills/perf-regression-check/README.md
@@ -1,56 +1,69 @@
 # perf-regression-check
 
-Locally check whether **your branch introduced an LLK performance regression** versus the exact
-`main` commit you branched from — before you push.
+Compare **one LLK perf test between two commits** on your machine, before you push.
 
-It runs a perf test on **your HEAD** and on **`git merge-base origin/main HEAD`** (the commit you
-branched off, *not* latest main), a few iterations each, and reports per-config slowdowns.
+By default it compares your **HEAD** against **`git merge-base origin/main HEAD`** — the commit
+you branched off, *not* latest main. Name any two refs and it compares those instead.
 
 ## Requirements
 - A Tenstorrent machine — it runs the real perf sweep on hardware.
-- A **clean working tree** — commit or stash first. The tool checks out the baseline commit and
-  restores your branch afterward, so uncommitted work would get in the way.
 - Your usual LLK Python test environment active.
+- A clean working tree is **not** required: each commit is measured in its own git worktree, so
+  your checkout is never touched. Note the flip side — uncommitted edits are not measured.
 
-## Use it (in Claude Code)
-Either run the slash command:
+## Use it
+```bash
+S=tt_metal/tt-llk/.claude/scripts/perf_compare_commits.sh
+
+$S blackhole perf_math_matmul                                   # branch vs branch point
+$S blackhole perf_math_matmul --baseline v0.60.0                # vs a tag
+$S wormhole  perf_math_matmul --baseline 1a2b3c4 --current 9f8e7d6   # two hashes
+$S blackhole perf_math_matmul --baseline HEAD~5 --dry-run       # what would it measure?
 ```
-/perf-regression-check perf_math_matmul
-```
-…or, if it isn't listed (these skills live in a nested folder), just say:
-> Read `tt_metal/tt-llk/.claude/skills/perf-regression-check/SKILL.md` and follow it for
-> `perf_math_matmul` (arch: blackhole).
 
-Claude figures out the two commits, runs the sweep on both, compares, and writes the report.
+In Claude Code, `/perf-regression-check perf_math_matmul` (or "compare perf of
+`perf_math_matmul` between abc123 and def456") drives the same script.
 
-## Inputs
-| input | required | default |
+## Options
+| option | default | meaning |
 |---|---|---|
-| **test** | yes | — e.g. `perf_math_matmul` (one test) |
-| **arch** | inferred, else asked | `wormhole` or `blackhole` |
-| **threshold** | no | `0.05` (5%) |
-| **iterations** | no | `3` per side (median-vs-median) |
+| `--baseline <ref>` | `merge-base origin/main HEAD` | what to compare against |
+| `--current <ref>` | `HEAD` | what to judge |
+| `--iterations <N>` | `3` | sweeps per side; median-vs-median |
+| `--threshold <T>` | `0.05` | 5% — flagged in both directions |
+| `--speed-of-light` | off | compile-time-parameter build, applied to both sides |
+| `--refresh` | off | ignore cached runs and re-measure |
+| `--dry-run` | off | resolve refs, report the plan, measure nothing |
+| `--out-dir <dir>` | under `$PERF_COMPARE_HOME` | where the report goes |
+
+Env knobs: `PERF_COMPARE_HOME` (cache + reports, default `~/.cache/tt-llk-perf-compare`),
+`WORK_ROOT` (worktrees and build trees, default `/tmp/tt-llk-perf-compare`), `PRODUCER_JOBS`,
+`CONSUMER_JOBS`, `RESET_BETWEEN_RUNS=1`, `SPARSE_PATHS`, `ALLOW_CROSS_HOST=1`.
 
 ## Output
-- `/tmp/perf-regression-check/regression_report.md` — verdict + the top regressions.
-- `…/regression_report.regressions.csv` — every regression, full config.
+- `regression_report.md` — verdict, top regressions, top improvements, new points.
+- `regression_report.regressions.csv` — every regression, full config.
+- `regression_report.points.csv` — every compared point with its delta.
 - Exit code is non-zero when a regression is found (usable in scripts).
 
 ## Reading the report
 - Comparison is per **(marker, sweep-config)**, on `mean(<run_type>)` cycles, **median across
-  iterations**.
-- Cleanest when only your **kernel / LLK code** changed (not the test's sweep) — then every config
-  has a baseline. If you changed the test itself, expect "new points" (no baseline; not counted as
+  iterations**. `Δ` is signed: `+` slower on current, `−` faster.
+- Cleanest when only **kernel / LLK code** differs between the commits — then every config has
+  a baseline. If the test's sweep changed, expect "new points" (no baseline; never counted as
   regressions).
-- **Noise:** deltas right at the threshold can be measurement noise. Raise the iterations or the
-  threshold if a result looks marginal.
+- **Noise:** deltas right at the threshold can be measurement noise. Raise `--iterations` — a
+  re-run reuses the sweeps you already paid for and only measures the new ones.
 
 ## Cost
-It runs the test's full sweep on **both** commits × iterations, and rebuilds at the baseline — for
-a test like `perf_math_matmul` expect **~15 min**. Pick a focused test; that's why a test name is
-required.
+A full sweep per side per iteration, plus a build per commit — for a test like
+`perf_math_matmul` expect **~15 min** the first time. After that, any comparison involving an
+already-measured commit reuses its cached runs, so a chain of comparisons (A-vs-B, then
+B-vs-C) only pays for the new commit.
 
 ## How it works
-`sweep(HEAD)` + `sweep(merge-base(origin/main, HEAD))` → median-vs-median compare via the
-self-contained `perf_regression_compare.py`, which reads the raw `perf_data` CSVs directly (no
-Parquet, no database — works on any branch, merged or not).
+For each side: a sparse `git worktree` at that commit (tt-llk plus the trees a kernel build
+includes from outside it), a private build tree, then N producer/consumer sweeps — interleaved
+between the two sides so thermals and other tenants bias neither. The two sets of CSVs go to
+`perf_regression_compare.py`, which reads the raw `perf_data` CSVs directly (no Parquet, no
+database — works on any commit, merged or not) and reports median-vs-median per point.

--- a/tt_metal/tt-llk/.claude/skills/perf-regression-check/SKILL.md
+++ b/tt_metal/tt-llk/.claude/skills/perf-regression-check/SKILL.md
@@ -1,103 +1,78 @@
 ---
 name: perf-regression-check
 description: >
-  Check whether the current branch introduced an LLK performance regression versus
-  the exact main commit it was branched from (the merge-base, not latest main). Runs
-  a chosen perf test on both commits, several iterations each, and reports per-config
-  regressions. Use when a developer asks "did my branch make perf worse", "check my
-  changes for regressions", or "compare my branch to where I branched off". Needs
-  Tenstorrent hardware (runs the real perf sweep).
+  Compare one LLK perf test between two commits on this machine — by default the branch
+  HEAD against the exact main commit it was branched from (the merge-base, not latest
+  main), or any two refs the user names (hash, tag, origin/main, HEAD~5). Runs the sweep
+  on both, several iterations each, and reports per-config regressions and improvements.
+  Use when a developer asks "did my branch make perf worse", "check my changes for
+  regressions", "compare my branch to where I branched off", or "compare perf between
+  these two commits". Needs Tenstorrent hardware (runs the real perf sweep).
 ---
 
-# Perf regression check (branch vs its branch point on main)
+# Perf compare (one test, two commits)
 
-Compares **current** = the branch's HEAD against **baseline** = `git merge-base origin/main HEAD`
-(the exact main commit the branch was cut from). Runs the same perf test on both, N iterations
-each, takes the median per point, and flags points where current is slower by more than the
-threshold. Self-contained: uses only `perf_regression_compare.py` (in `.claude/scripts/`), so
-it works on any branch whether or not the perf infra is merged.
+`perf_compare_commits.sh` does the whole job: resolve both refs, sweep each, compare
+median-vs-median, write the report. Do not hand-roll the checkout/sweep loop — the script
+already handles worktrees, caching, interleaving and cleanup.
 
-## Inputs to collect from the user (ask if not given)
+```bash
+SCRIPT="$(git rev-parse --show-toplevel)/tt_metal/tt-llk/.claude/scripts/perf_compare_commits.sh"
+
+# branch HEAD vs the commit the branch was cut from (the default)
+"$SCRIPT" <arch> <test>
+
+# any two commits
+"$SCRIPT" <arch> <test> --baseline <ref> --current <ref>
+```
+
+It prints the report, writes it under `~/.cache/tt-llk-perf-compare/reports/…`, and exits
+non-zero when a regression is found. `--dry-run` shows what it would measure (and what is
+already cached) without running a sweep — cheap, use it to confirm the refs first.
+
+## Inputs to collect from the user (ask only what you cannot infer)
 - **test** (required): the perf test module, e.g. `perf_math_matmul`. One test per run.
-- **arch**: `wormhole` or `blackhole`. Infer from the machine if possible (`tt-smi`), else ask.
-- **threshold**: default `0.05` (5%).
-- **iterations**: default `3` per side.
-- **speed_of_light**: default off. If used, apply the SAME flag to both sides.
+- **arch** (required): `wormhole` or `blackhole`. Infer from the machine (`tt-smi`) if possible.
+- **baseline / current**: any refs. Default: baseline = `git merge-base origin/main HEAD`,
+  current = `HEAD`. If the user names commits ("compare abc123 and def456"), pass both.
+- **threshold**: `--threshold`, default `0.05` (5%).
+- **iterations**: `--iterations`, default `3` per side.
+- **speed of light**: `--speed-of-light`. The script applies it to both sides.
 
-## Safety first — never lose the user's work
-1. Confirm the working tree is clean: `git status --porcelain`. If dirty, **stop and ask** the
-   user to commit or stash; do not proceed with uncommitted changes (the baseline checkout would
-   collide). Optionally `git stash push -u` yourself and restore at the end.
-2. Record `BRANCH=$(git rev-parse --abbrev-ref HEAD)` and `CURRENT=$(git rev-parse HEAD)`.
-3. **Always restore** at the end (and on any failure/interrupt): `git checkout "$BRANCH"` (and
-   `git stash pop` if you stashed). Treat this as mandatory cleanup.
+## What the script guarantees (so you do not have to)
+- **Your checkout is never touched.** Each commit is a separate sparse git worktree with
+  its own build tree — no branch switch, no stash, a dirty tree is fine, and an interrupted
+  run cannot leave the user on a detached HEAD. Worktrees are removed on exit.
+- **Only committed code is measured.** Uncommitted edits are invisible to a ref; the script
+  says so. If the user wants their working tree measured, they must commit it first.
+- **Runs are cached** per (arch, test, variant, commit), so a commit already measured on this
+  machine costs nothing to reuse — comparing A-vs-B then B-vs-C only sweeps C. `--refresh`
+  re-measures. Cached runs from another host are refused (cycles are not comparable).
+- **Iterations are interleaved** baseline, current, baseline, current…, so machine drift
+  hits both sides equally instead of biasing one.
 
-## Procedure
-Let `WORK=/tmp/perf-regression-check` (mkdir -p) and the compare script be resolved from the repo
-root (cwd-independent):
-```bash
-SCRIPT="$(git rev-parse --show-toplevel)/tt_metal/tt-llk/.claude/scripts/perf_regression_compare.py"
-```
-
-**0. Determine commits.**
-```bash
-git fetch origin main --quiet
-BASELINE=$(git merge-base origin/main HEAD)
-CURRENT=$(git rev-parse HEAD)
-echo "baseline (branch point): $BASELINE"; echo "current: $CURRENT"
-```
-If `BASELINE == CURRENT`, the branch has no commits vs main — tell the user there's nothing to
-compare.
-
-**1. Run the sweep N times on the CURRENT branch.** From the `tests/` directory:
-```bash
-cd tt_metal/tt-llk/tests
-for i in $(seq 1 <iterations>); do
-  CHIP_ARCH=<arch> pytest --compile-producer -n 10 -m perf ./python_tests/<test>.py
-  CHIP_ARCH=<arch> pytest --compile-consumer -n 15 -m perf ./python_tests/<test>.py
-  cp "$(find . -path '*/perf_data/<test>/<test>.csv' | head -1)" "$WORK/current_run_$i.csv"
-done
-```
-Notes: do **not** pass `-x` (it aborts mid-sweep and the combined CSV is partial). The combine
-step writes `perf_data/<test>/<test>.csv`; the `cp` snapshots it before the next iteration
-overwrites it. If `speed_of_light` is on, add `--speed-of-light` to both pytest calls.
-
-**2. Run the same sweep N times on the BASELINE commit.**
-```bash
-git checkout "$BASELINE"          # detached HEAD; user's branch is safe
-# repeat the same loop, writing "$WORK/baseline_run_$i.csv"
-git checkout "$BRANCH"            # restore — do this even if a run failed
-```
-If the test file does not exist at the baseline (the user *added* it on their branch), there is no
-baseline to compare — report that and stop.
-
-**3. Compare + report.**
-```bash
-python "$SCRIPT" \
-  --current  "$WORK/current_run_*.csv" \
-  --baseline "$WORK/baseline_run_*.csv" \
-  --threshold <threshold> \
-  --report "$WORK/regression_report.md" \
-  --test <test> --baseline-sha "$BASELINE" --current-sha "$CURRENT"
-```
-It prints and writes a Markdown report (verdict + top-25 regressions), plus a full
-`regression_report.regressions.csv` with every regression. It exits non-zero if any regression is
-found.
-
-**4. Present the result.** Show the verdict and the top regressions. Point the user to
-`$WORK/regression_report.md` and the companion `.regressions.csv`. If there are many "new points",
-explain the branch changed the test's sweep/configs (so those points have no baseline).
+## Present the result
+Show the verdict, the top regressions, and the improvements if any. Point at
+`regression_report.md` plus its companions `.regressions.csv` (every regression) and
+`.points.csv` (every compared point, full config).
 
 ## Interpreting results (tell the user)
-- Comparison is **per (marker, sweep-config)**; `mean(<run_type>)` cycles, median across iterations.
-- A cleanest comparison is when only the **kernel/LLK code** changed, not the test's sweep — then
-  every config has a baseline. If the test itself changed, expect "new points".
-- **Noise:** 3 iterations + median reduces it, but deltas near the threshold can still be noise;
-  suggest more iterations or a higher threshold if results look marginal.
-- `TILE_LOOP` marker is the steady-state per-tile cost; `INIT`/`KERNEL` include one-time overheads.
+- Comparison is **per (marker, sweep-config)** on `mean(<run_type>)` cycles, median across
+  iterations. A point exists on both sides or it is a "new point" (no baseline).
+- Cleanest when only **kernel/LLK code** differs between the commits. If the test's sweep
+  changed, expect "new points" — those are reported, never counted as regressions.
+- **Noise:** 3 iterations + median reduces it, but deltas near the threshold can still be
+  noise. Suggest more iterations (cheap — cached runs are reused, so `--iterations 5` after
+  a 3-iteration run only measures 2 more per side) or a higher threshold.
+- The further apart the two commits are, the more unrelated change is in the delta. For
+  "did *this* work regress perf", the merge-base default is the honest baseline.
+- `TILE_LOOP` is the steady-state per-tile cost; `INIT`/`KERNEL` include one-time overheads.
 
 ## Failure handling
-- Any failure after checkout of the baseline: **restore the branch** before surfacing the error.
-- `TENSIX TIMED OUT` / device hang during a run: `tt-smi -r`, then retry that iteration.
-- No CSV produced: the test may have been deselected by the marker — check the test carries the
-  `perf` marker and the module name is correct.
+- `TENSIX TIMED OUT` / device hang: `tt-smi -r`, then re-run the same command — completed
+  iterations are cached, so it resumes instead of starting over.
+- Missing header at compile time on an older commit: that commit's layout needs more than
+  the default sparse checkout — re-run with `SPARSE_PATHS=` (empty) for a full checkout.
+- "no perf CSV": the test may have been deselected — check the module name and that the
+  test carries the `perf` marker.
+- "does not exist at <sha>": the test was added after that commit; pick a baseline that has it.

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_regression_compare.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_regression_compare.py
@@ -15,7 +15,7 @@ import pandas as pd
 # The script lives in the skill's scripts dir, not on the test path; add it.
 _SCRIPTS = pathlib.Path(__file__).parents[2] / ".claude" / "scripts"
 sys.path.insert(0, str(_SCRIPTS))
-from perf_regression_compare import compare_runs  # noqa: E402
+from perf_regression_compare import compare_runs, render_report  # noqa: E402
 
 
 def _csv(tmp_path, name, math):
@@ -48,6 +48,40 @@ def test_no_regression_within_threshold(tmp_path):
 
     assert not result["regressions"]
     assert result["records"]  # still compared
+
+
+def test_faster_current_is_an_improvement_not_a_regression(tmp_path):
+    # Comparing two arbitrary commits, the current side can be the faster one.
+    baseline = [_csv(tmp_path, f"b{i}.csv", 120.0) for i in range(3)]
+    current = [_csv(tmp_path, f"c{i}.csv", 100.0) for i in range(3)]  # -16.7%
+
+    result = compare_runs(current, baseline, threshold=0.05)
+
+    assert not result["regressions"]
+    assert len(result["improvements"]) == 2  # both markers
+    assert result["improvements"][0]["delta"] < -0.05
+
+
+def test_report_names_each_side_and_its_iterations(tmp_path):
+    baseline = [_csv(tmp_path, "b.csv", 100.0)]
+    current = [_csv(tmp_path, f"c{i}.csv", 100.0) for i in range(2)]
+    result = compare_runs(current, baseline, threshold=0.05)
+
+    report = render_report(
+        result,
+        threshold=0.05,
+        test="perf_math_matmul",
+        baseline_sha="aaaa",
+        current_sha="bbbb",
+        baseline_iters=1,
+        current_iters=2,
+        baseline_label="v0.60.0",
+        current_label="1a2b3c4",
+    )
+
+    assert "- baseline (v0.60.0): `aaaa` — 1 iteration(s)" in report
+    assert "- current (1a2b3c4): `bbbb` — 2 iteration(s)" in report
+    assert "✅ no regressions" in report
 
 
 def test_new_config_reported_not_regression(tmp_path):

--- a/tt_metal/tt-llk/tests/python_tests/test_perf_regression_compare.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_perf_regression_compare.py
@@ -15,7 +15,16 @@ import pandas as pd
 # The script lives in the skill's scripts dir, not on the test path; add it.
 _SCRIPTS = pathlib.Path(__file__).parents[2] / ".claude" / "scripts"
 sys.path.insert(0, str(_SCRIPTS))
-from perf_regression_compare import compare_runs, render_report  # noqa: E402
+from perf_regression_compare import (  # noqa: E402
+    DEFAULT_MIN_CYCLES,
+    DEFAULT_THRESHOLD,
+    compare_runs,
+    render_report,
+)
+
+# Magnitudes are realistic cycle counts, not toy numbers: the verdict now depends
+# on the absolute change as well as the relative one, so a fixture measured in
+# tens of cycles would be filtered as jitter and test nothing.
 
 
 def _csv(tmp_path, name, math):
@@ -24,25 +33,26 @@ def _csv(tmp_path, name, math):
         {
             "marker": ["INIT", "KERNEL"],
             "tile_cnt": [4, 4],  # a config column -> part of the point key
-            "mean(MATH_ISOLATE)": [math, math + 10.0],
+            "mean(MATH_ISOLATE)": [math, math + 100.0],
         }
     ).to_csv(p, index=False)
     return str(p)
 
 
 def test_flags_regression_median_vs_median(tmp_path):
-    baseline = [_csv(tmp_path, f"b{i}.csv", 100.0) for i in range(3)]
-    current = [_csv(tmp_path, f"c{i}.csv", 120.0) for i in range(3)]  # +20%
+    baseline = [_csv(tmp_path, f"b{i}.csv", 1000.0) for i in range(3)]
+    current = [_csv(tmp_path, f"c{i}.csv", 1200.0) for i in range(3)]  # +20%
 
     result = compare_runs(current, baseline, threshold=0.05)
 
     assert result["regressions"]
     assert abs(result["regressions"][0]["delta"] - 0.20) < 1e-9
+    assert result["regressions"][0]["abs_delta"] == 200.0
 
 
 def test_no_regression_within_threshold(tmp_path):
-    baseline = [_csv(tmp_path, f"b{i}.csv", 100.0) for i in range(3)]
-    current = [_csv(tmp_path, f"c{i}.csv", 102.0) for i in range(3)]  # +2%, under 5%
+    baseline = [_csv(tmp_path, f"b{i}.csv", 1000.0) for i in range(3)]
+    current = [_csv(tmp_path, f"c{i}.csv", 1020.0) for i in range(3)]  # +2%, under 5%
 
     result = compare_runs(current, baseline, threshold=0.05)
 
@@ -52,8 +62,8 @@ def test_no_regression_within_threshold(tmp_path):
 
 def test_faster_current_is_an_improvement_not_a_regression(tmp_path):
     # Comparing two arbitrary commits, the current side can be the faster one.
-    baseline = [_csv(tmp_path, f"b{i}.csv", 120.0) for i in range(3)]
-    current = [_csv(tmp_path, f"c{i}.csv", 100.0) for i in range(3)]  # -16.7%
+    baseline = [_csv(tmp_path, f"b{i}.csv", 1200.0) for i in range(3)]
+    current = [_csv(tmp_path, f"c{i}.csv", 1000.0) for i in range(3)]  # -16.7%
 
     result = compare_runs(current, baseline, threshold=0.05)
 
@@ -62,9 +72,82 @@ def test_faster_current_is_an_improvement_not_a_regression(tmp_path):
     assert result["improvements"][0]["delta"] < -0.05
 
 
+# --- the absolute-cycle clause -------------------------------------------------
+# Measured on 5 runs of unchanged code: INIT points are a few hundred cycles and
+# wobble by up to 25, which is a large percentage of a small number. Without the
+# cycle floor those points fail the gate constantly.
+
+
+def test_small_marker_over_threshold_but_under_cycle_floor_is_not_a_regression(
+    tmp_path,
+):
+    # 350 -> 370 is +5.7%, but only 20 cycles: exactly the INIT jitter we measured.
+    baseline = [_csv(tmp_path, "b.csv", 350.0)]
+    current = [_csv(tmp_path, "c.csv", 370.0)]
+
+    result = compare_runs(current, baseline, threshold=0.02, min_cycles=30)
+
+    assert not result["regressions"]
+    assert (
+        result["noise_filtered"] == 2
+    )  # both markers cleared %, neither cleared cycles
+
+
+def test_regression_needs_both_clauses(tmp_path):
+    # 1000 -> 1100 is +10% and +100 cycles: both clauses hold.
+    baseline = [_csv(tmp_path, "b.csv", 1000.0)]
+    current = [_csv(tmp_path, "c.csv", 1100.0)]
+
+    result = compare_runs(current, baseline, threshold=0.02, min_cycles=30)
+
+    assert len(result["regressions"]) == 2
+    assert result["noise_filtered"] == 0
+
+
+def test_large_cycle_move_under_threshold_is_not_a_regression(tmp_path):
+    # 100000 -> 100500 is +500 cycles, far over the floor, but only +0.5%.
+    # A cycles-only rule would fail here; the percentage clause saves it.
+    baseline = [_csv(tmp_path, "b.csv", 100_000.0)]
+    current = [_csv(tmp_path, "c.csv", 100_500.0)]
+
+    result = compare_runs(current, baseline, threshold=0.02, min_cycles=30)
+
+    assert not result["regressions"]
+    assert result["noise_filtered"] == 0  # never cleared the percentage
+
+
+def test_improvement_also_needs_the_cycle_floor(tmp_path):
+    # A 20-cycle speedup on a small marker is jitter, not an improvement.
+    baseline = [_csv(tmp_path, "b.csv", 370.0)]
+    current = [_csv(tmp_path, "c.csv", 350.0)]
+
+    result = compare_runs(current, baseline, threshold=0.02, min_cycles=30)
+
+    assert not result["improvements"]
+
+
+def test_min_cycles_zero_disables_the_clause(tmp_path):
+    baseline = [_csv(tmp_path, "b.csv", 350.0)]
+    current = [_csv(tmp_path, "c.csv", 370.0)]
+
+    result = compare_runs(current, baseline, threshold=0.02, min_cycles=0)
+
+    assert len(result["regressions"]) == 2
+
+
+def test_defaults_are_the_measured_ones():
+    # These are load-bearing: the shell wrapper documents the same numbers, and
+    # the baseline that justifies them is in docs/perf_evaluation/results/.
+    assert DEFAULT_THRESHOLD == 0.02
+    assert DEFAULT_MIN_CYCLES == 30.0
+
+
+# --- report --------------------------------------------------------------------
+
+
 def test_report_names_each_side_and_its_iterations(tmp_path):
-    baseline = [_csv(tmp_path, "b.csv", 100.0)]
-    current = [_csv(tmp_path, f"c{i}.csv", 100.0) for i in range(2)]
+    baseline = [_csv(tmp_path, "b.csv", 1000.0)]
+    current = [_csv(tmp_path, f"c{i}.csv", 1000.0) for i in range(2)]
     result = compare_runs(current, baseline, threshold=0.05)
 
     report = render_report(
@@ -84,12 +167,47 @@ def test_report_names_each_side_and_its_iterations(tmp_path):
     assert "✅ no regressions" in report
 
 
+def test_report_states_both_clauses_of_the_rule(tmp_path):
+    baseline = [_csv(tmp_path, "b.csv", 1000.0)]
+    current = [_csv(tmp_path, "c.csv", 1000.0)]
+    result = compare_runs(current, baseline)
+
+    report = render_report(
+        result,
+        threshold=DEFAULT_THRESHOLD,
+        min_cycles=DEFAULT_MIN_CYCLES,
+        test="perf_math_matmul",
+        baseline_sha="aaaa",
+        current_sha="bbbb",
+    )
+
+    assert "more than 2% slower AND more than 30 cycles slower" in report
+
+
+def test_report_explains_points_filtered_by_the_cycle_floor(tmp_path):
+    baseline = [_csv(tmp_path, "b.csv", 350.0)]
+    current = [_csv(tmp_path, "c.csv", 370.0)]
+    result = compare_runs(current, baseline, threshold=0.02, min_cycles=30)
+
+    report = render_report(
+        result,
+        threshold=0.02,
+        min_cycles=30,
+        test="perf_math_matmul",
+        baseline_sha="aaaa",
+        current_sha="bbbb",
+    )
+
+    assert "2 point(s) moved more than 2%" in report
+    assert "30 cycles or fewer" in report
+
+
 def test_new_config_reported_not_regression(tmp_path):
-    baseline = [_csv(tmp_path, "b.csv", 100.0)]
+    baseline = [_csv(tmp_path, "b.csv", 1000.0)]
     # current has a config (tile_cnt=8) with no baseline -> a "new point"
     p = tmp_path / "c.csv"
     pd.DataFrame(
-        {"marker": ["INIT"], "tile_cnt": [8], "mean(MATH_ISOLATE)": [999.0]}
+        {"marker": ["INIT"], "tile_cnt": [8], "mean(MATH_ISOLATE)": [9990.0]}
     ).to_csv(p, index=False)
 
     result = compare_runs([str(p)], baseline, threshold=0.05)


### PR DESCRIPTION
The tool could only answer one question: is my branch slower than the commit it was cut from. The comparison itself never needed that -- it is just current-vs-baseline -- so this opens both sides up to any ref (hash, tag, origin/main, HEAD~5) and keeps branch-vs-branch-point as the default.

New perf_compare_commits.sh drives it end to end. Each commit is measured in its own sparse git worktree with its own build tree, so the user's checkout is never touched: no branch switch, no stash, a dirty tree is fine, and an interrupted run cannot strand anyone on a detached HEAD. The worktree carries tt-llk plus the trees a kernel build includes from outside it (tt_metal/hw, tt_metal/hostdevcommon, the ttnn experimental kernels).

Runs are cached per (arch, test, variant, commit), so A-vs-B then B-vs-C only measures C, and raising --iterations only pays for the new sweeps. Cached runs from another host are refused -- cycles from another machine are not comparable. Iterations of the two sides are interleaved rather than run side after side, so thermals and other tenants bias neither.

perf_regression_compare.py loses its "your branch" wording for role labels the caller supplies, reports per-side iteration counts, and now reports improvements as well as regressions -- with two arbitrary commits the current side can be the faster one. Every compared point is written to a .points.csv next to the existing .regressions.csv.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstojictt/perf-compare-commits)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstojictt/perf-compare-commits)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstojictt/perf-compare-commits)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstojictt/perf-compare-commits)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstojictt/perf-compare-commits)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstojictt/perf-compare-commits)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstojictt/perf-compare-commits)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstojictt/perf-compare-commits)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstojictt/perf-compare-commits)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstojictt/perf-compare-commits)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstojictt/perf-compare-commits)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstojictt/perf-compare-commits)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstojictt/perf-compare-commits)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstojictt/perf-compare-commits)