### PR TITLE
#51100: Update DeepSeek Galaxy decode op gap target

### DIFF
--- a/models/demos/deepseek_v3/demo/test_decode_demo_perf.py
+++ b/models/demos/deepseek_v3/demo/test_decode_demo_perf.py
@@ -38,13 +38,19 @@ def _assert_within_margin(metric_name: str, measured: float, expected: float, ma
 # ---------------------------------------------------------------------------
 @pytest.mark.timeout(1200)
 @pytest.mark.parametrize(
-    "expected_kernel_duration_us, expected_op_to_op_latency_us, expected_e2e_time_us, margin",
+    "expected_kernel_duration_us, expected_op_to_op_latency_us, expected_e2e_time_us, margin, op_to_op_margin",
     [
-        pytest.param(10050.69, 127.00, 10050.69 + 127.00, 0.03, id="decode_e2e_perf"),
+        pytest.param(10050.69, 139.41, 10050.69 + 139.41, 0.03, 0.04, id="decode_e2e_perf"),
     ],
 )
 @pytest.mark.models_device_performance_bare_metal
-def test_decode_demo_perf(expected_kernel_duration_us, expected_op_to_op_latency_us, expected_e2e_time_us, margin):
+def test_decode_demo_perf(
+    expected_kernel_duration_us,
+    expected_op_to_op_latency_us,
+    expected_e2e_time_us,
+    margin,
+    op_to_op_margin,
+):
     """
     End-to-end device-performance test for the DeepSeek V3 2-layer decode demo.
     1st layer is dense decoder block and 2nd layer is MoE Decoder Block.
@@ -113,6 +119,6 @@ def test_decode_demo_perf(expected_kernel_duration_us, expected_op_to_op_latency
 
     _assert_within_margin("E2E Time", e2e_time_us, expected_e2e_time_us, margin)
     _assert_within_margin("Total Kernel Duration", total_kernel_us, expected_kernel_duration_us, margin)
-    _assert_within_margin("Total Op-to-Op Latency", total_latency_us, expected_op_to_op_latency_us, margin)
+    _assert_within_margin("Total Op-to-Op Latency", total_latency_us, expected_op_to_op_latency_us, op_to_op_margin)
 
     logger.info("All performance assertions passed!")


### PR DESCRIPTION
Codex: Retargets the DeepSeek V3 Galaxy decode op-to-op expectation after the deliberate RMSNorm de-fusion in #46890, without relaxing the kernel-duration or E2E guardrails.

## Summary

- update expected op-to-op latency from 127.00 us to 139.41 us, the mean of seven recent valid Galaxy profiler runs
- give op-to-op latency a separate 4% tolerance to cover its observed 135.01-144.30 us range
- retain the existing 3% kernel and E2E tolerances

## Why

[PR #46890](https://github.com/tenstorrent/tt-metal/pull/46890), authored and merged by @rmillerTT, deliberately removed the `Parallel()` fusion of the Q and KV RMSNorms because that experimental fusion required exposing `ProgramSpec` to Python before the infrastructure was production-ready. It replaced the fused call with two sequential `ttnn.rms_norm` calls.

This is expected to regress performance: the two RMSNorm kernels now execute serially instead of concurrently, and the profiler gains one additional dispatch boundary in each of the dense and MoE layers measured by this test. The profiled graph therefore grew from 164 to 166 operations.

The measured change is consistent with that expectation. The fused May baseline was 10.206 ms E2E. Across six valid post-removal runs from August 3 through August 17, mean E2E time is 10.280 ms: +0.074 ms, or +0.72%. In the August 6 sample, the +0.072 ms E2E delta versus May decomposes into approximately +0.065 ms of kernel duration and +0.008 ms of op-to-op gaps, which is the expected signature of serializing the RMSNorm work and adding two dispatch boundaries.

This PR accepts that small, understood regression only in the op-to-op expectation. It deliberately leaves the kernel and E2E guardrails unchanged. The later 10.551-10.575 ms samples are another 0.27-0.30 ms above the normal post-removal level and are not explained by the RMSNorm de-fusion; retaining the existing guardrails prevents this PR from masking that runner/environment variation or a separate regression if it persists.

Fixes #51100

## Testing

- `pre-commit run --files models/demos/deepseek_v3/demo/test_decode_demo_perf.py`
- `python3 -m compileall -q models/demos/deepseek_v3/demo/test_decode_demo_perf.py`
- Galaxy perf CI: [run 32161194008](https://github.com/tenstorrent/tt-metal/actions/runs/32161194008) reached the hardware job twice, but both attempts failed before profiling on runner `OM1-01A01-STGWH03` with stale hugepage/NOC-address conflicts followed by UMD segmentation faults
- Follow-up [run 32224550401](https://github.com/tenstorrent/tt-metal/actions/runs/32224550401) produced a valid 166-op profile on `g03glx04`; the revised op-gap guard passed, while the unchanged kernel/E2E guards caught the elevated 10.551 ms sample

**Why the badge is red:** the linked workflow contains both unhealthy-runner infrastructure failures and one valid 166-op profile. In that valid profile, this PR's revised op-gap check passed; only the unchanged kernel/E2E guardrails rejected the elevated 10.551 ms sample. The run remains linked as evidence of runner/device noise and of the unchanged guardrails working as intended—not as evidence that this PR's scoped change failed.

[![Galaxy perf tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml/badge.svg?branch=yieldthought/issue-51100-deepseek-gap-target)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-perf-tests.yaml?query=branch%3Ayieldthought%2Fissue-51100-deepseek-gap-target)
