### PR TITLE
[Performance] Dispatch a MeshWorkload's program writes from the calling thread

### DIFF
--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -849,7 +849,15 @@
 
 # MiniMax-M3 full-model chunked-prefill throughput regression (same harness as KV PCC, PCC skipped).
 # Gates whole-sequence tok/s against PREFILL_EXPECTED_TPS +/- PREFILL_PERF_MARGIN on high-power Galaxy.
-# Allowed range: ~3825–5175 tok/s (4500 +/- 15%).
+# Allowed range: ~5007-6774 tok/s (5890 +/- 15%).
+# 5890 is the measured whole-sequence median of run 32280869211 job 96161901672 (PREFILL_TPS_ITERS=5
+# within that one run), the first run of this pipeline after the per-device MeshWorkload dispatch
+# fan-out was removed - it exceeded the old 4500 ceiling, which is why this moved. That is a single
+# run, unlike the ten-run median the Kimi chunked
+# baseline uses, so if this proves noisy widen PREFILL_PERF_MARGIN rather than chasing the centre.
+# For scale, this pipeline is host-dispatch bound: it measured 5057.8 tok/s (run 31996994902) with the
+# fan-out absent and 3582.8 (run 32075671439) with it present, so the gate's own floor is what caught
+# #52775 here.
 # If this test fails: first check whether it is a true regression or a performance improvement.
 # If neither (CI noise), widen this range or comment out this test due to CI instability.
 - name: "Blaze - MiniMax-M3 Prefill Perf"
@@ -866,7 +874,7 @@
     export PREFILL_TPS_ITERS=5
     export PREFILL_SKIP_PCC=1
     export PREFILL_REQUIRE_HIGH_POWER=1
-    export PREFILL_EXPECTED_TPS=4500
+    export PREFILL_EXPECTED_TPS=5890
     export PREFILL_PERF_MARGIN=0.15
     mpirun --bind-to none --pernode --tag-output bash -lc '
       python3 models/demos/minimax_m3/tests/galaxy_prefill_kv_pcc.py

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -15,7 +15,6 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <algorithm>
 #include <array>
-#include <exception>
 #include <functional>
 #include <mutex>
 #include <optional>
@@ -102,24 +101,6 @@ void record_program_sub_device_for_range(
             num_available_worker_cores);
     });
 }
-
-// Per-program state shared by the per-device dispatch tasks targeting that program. A program's
-// cached dispatch commands are common to every device it runs on, so they are updated exactly once
-// per workload: the first task to reach the program takes ownership through `prepared` and the rest
-// block there until the update lands. If the owner throws, the flag stays clear and the next waiter
-// retries, so a waiter can never block forever.
-struct ProgramDispatchEntry {
-    Program* program = nullptr;
-    ProgramCommandSequence* cmd_seq = nullptr;
-    std::once_flag prepared;
-};
-
-// One local device and the program it runs. A MeshWorkload's programs cover disjoint device ranges,
-// so a device appears in at most one of these; devices in none of them are sent a go signal instead.
-struct DeviceDispatchTask {
-    IDevice* device = nullptr;
-    ProgramDispatchEntry* program_entry = nullptr;
-};
 
 [[maybe_unused]] MeshCoordinate get_local_start_coord(MeshDevice* mesh_device, const MeshCoordinateRange& range) {
     for (const auto& coord : range) {
@@ -506,6 +487,8 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
         program_ordering_sync_count,
         dispatch_metadata);
 
+    std::unordered_set<uint32_t> chip_ids_in_workload = {};
+
     auto max_program_kernels_sizeB = mesh_workload.impl().max_program_kernels_sizeB_;
     bool use_prefetcher_cache = mesh_workload.impl().use_prefetcher_cache_;
     if (use_prefetcher_cache) {
@@ -526,76 +509,40 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
         // prefetcher cache will be overwritten, reset for next workload
         this->reset_prefetcher_cache_manager();
     }
-    // Values that are constant across the whole workload, hoisted so that the per-device tasks below
-    // never have to reach back into this command queue or into cq_shared_state_.
-    const CoreCoord dispatch_core = this->virtual_program_dispatch_core();
-    const uint32_t mcast_launch_msg_wptr =
-        cq_shared_state_->worker_launch_message_buffer_state[*sub_device_id].get_mcast_wptr();
-    const uint32_t unicast_launch_msg_wptr =
-        cq_shared_state_->worker_launch_message_buffer_state[*sub_device_id].get_unicast_wptr();
-    const ProgramBinaryStatus program_binary_status = mesh_workload.impl().get_program_binary_status(mesh_device_id);
-    // Same guards record_program_sub_device_for_range() applies, evaluated once: sub_device_id is
-    // fixed for the whole workload, so whether to record and how many worker cores to record are
-    // workload constants rather than per-device queries.
-    const uint64_t active_sub_device_manager_id = *mesh_device_->get_active_sub_device_manager_id();
-    const bool record_sub_device = active_sub_device_manager_id != *mesh_device_->get_default_sub_device_manager_id();
-    const uint32_t num_available_worker_cores =
-        record_sub_device ? mesh_device_->num_worker_cores(HalProgrammableCoreType::TENSIX, sub_device_id) : 0;
-
-    // Update a program's dispatch commands to reflect current device state. This mutates state that
-    // every device running the program shares, so it must happen exactly once per program.
-    auto prepare_program = [&](ProgramDispatchEntry& entry) {
-        std::call_once(entry.prepared, [&]() {
-            program_dispatch::update_program_dispatch_commands(
-                entry.program->impl(),
-                *entry.cmd_seq,
-                mcast_launch_msg_wptr,
-                unicast_launch_msg_wptr,
-                expected_num_workers_completed,
-                dispatch_core,
-                sub_device_id,
-                dispatch_metadata,
-                program_binary_status,
-                std::pair<bool, int>(unicast_go_signals, num_virtual_eth_cores),
-                static_cast<uint8_t>(this->id()));
-        });
-    };
-
-    // Build the work list before dispatching any of it. Everything that can throw runs here, on the
-    // calling thread: once the first task is enqueued the tasks hold references into this frame, so
-    // an exception escaping before the join would leave them pointing at destroyed objects.
-    auto& programs = mesh_workload.get_programs();
-    std::vector<ProgramDispatchEntry> program_entries(programs.size());
-    std::vector<DeviceDispatchTask> program_tasks;
-    program_tasks.reserve(mesh_device_->shape().mesh_size());
-    std::unordered_set<uint32_t> chip_ids_in_workload = {};
-
-    uint32_t program_idx = 0;
-    for (auto& [device_range, program] : programs) {
-        auto& entry = program_entries[program_idx++];
-        entry.program = &program;
-        entry.cmd_seq = &mesh_workload.impl().get_dispatch_cmds_for_program(program, command_hash);
+    // Iterate over all programs. Update dispatch commands per program to reflect
+    // current device state. Write the finalized program command sequence to each
+    // physical device tied to the program.
+    for (auto& [device_range, program] : mesh_workload.get_programs()) {
+        auto& program_cmd_seq = mesh_workload.impl().get_dispatch_cmds_for_program(program, command_hash);
         TT_ASSERT(
-            use_prefetcher_cache == entry.cmd_seq->prefetcher_cache_used,
+            use_prefetcher_cache == program_cmd_seq.prefetcher_cache_used,
             "use_prefetcher_cache: {}, program_cmd_seq.prefetcher_cache_used: {}",
             use_prefetcher_cache,
-            entry.cmd_seq->prefetcher_cache_used);
+            program_cmd_seq.prefetcher_cache_used);
+        program_dispatch::update_program_dispatch_commands(
+            program.impl(),
+            program_cmd_seq,
+            cq_shared_state_->worker_launch_message_buffer_state[*sub_device_id].get_mcast_wptr(),
+            cq_shared_state_->worker_launch_message_buffer_state[*sub_device_id].get_unicast_wptr(),
+            expected_num_workers_completed,
+            this->virtual_program_dispatch_core(),
+            sub_device_id,
+            dispatch_metadata,
+            mesh_workload.impl().get_program_binary_status(mesh_device_id),
+            std::pair<bool, int>(unicast_go_signals, num_virtual_eth_cores),
+            static_cast<uint8_t>(this->id()));
 
-        const size_t tasks_before_program = program_tasks.size();
-        for_each_local(mesh_device_, device_range, [&](const auto& coord) {
-            auto* device = mesh_device_->impl().get_device(coord);
-            program_tasks.push_back(DeviceDispatchTask{device, &entry});
-            chip_ids_in_workload.insert(device->id());
-        });
-        if (program_tasks.size() == tasks_before_program) {
-            // The program runs entirely on devices owned by another host, so no task will claim it.
-            // Still update its dispatch commands here, to match what a single-host mesh would do.
-            prepare_program(entry);
-        }
+        record_program_sub_device_for_range(mesh_device_, device_range, program.get_runtime_id(), sub_device_id);
+
+        this->write_program_cmds_to_subgrid(
+            device_range,
+            program_cmd_seq,
+            dispatch_metadata.stall_first,
+            dispatch_metadata.stall_before_program,
+            chip_ids_in_workload);
 
         // Tag the host-side Tracy zone with the program's runtime_host_id so it pairs 1:1
-        // with the device-side zones emitted by the real-time profiler. Emitted from the calling
-        // thread, so that it lands inside this function's zone rather than on a worker's timeline.
+        // with the device-side zones emitted by the real-time profiler.
         if (!tt::tt_metal::getDeviceProfilerState()) {
             std::string msg = fmt::format("EnqueueProgram op_id={}", program.get_runtime_id());
             TracyMessage(msg.c_str(), msg.size());
@@ -612,71 +559,14 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
         }
     }
 
-    auto write_program_for_device = [&](const DeviceDispatchTask& task) {
-        auto& entry = *task.program_entry;
-        prepare_program(entry);
-        if (record_sub_device) {
-            tt::RecordProgramSubDevice(
-                task.device->id(),
-                active_sub_device_manager_id,
-                entry.program->get_runtime_id(),
-                sub_device_id,
-                num_available_worker_cores);
-        }
-        program_dispatch::write_program_command_sequence(
-            *entry.cmd_seq,
-            task.device->sysmem_manager(),
-            id_,
-            dispatch_metadata.stall_first,
-            dispatch_metadata.stall_before_program);
-    };
-
-    // Each device has its own sysmem manager, so the program writes are independent and go out in
-    // parallel on the pool, which has a thread pinned near each device. The pool is quiescent here:
-    // every other user of it joins before releasing the MeshDevice API lock this function holds.
-    //
-    // The calling thread keeps one write for itself rather than handing out all of them. Waking a
-    // worker costs tens of microseconds, so a workload covering a single device would otherwise pay
-    // for the pool without getting any overlap in return.
-    for (size_t i = 1; i < program_tasks.size(); i++) {
-        const auto& task = program_tasks[i];
-        dispatch_thread_pool_->enqueue(
-            [&write_program_for_device, &task]() { write_program_for_device(task); }, task.device->id());
-    }
-    // The work below can throw - a device timeout surfaces as an exception out of the fetch queue -
-    // and the tasks enqueued above hold references into this frame. Join the pool on every path out
-    // of here, including the throwing one, or a worker is left reading destroyed objects. The
-    // original exception wins over anything a worker reports.
-    std::exception_ptr dispatch_exception;
-    try {
-        // A go signal is a few hundred bytes, far less work than waking a worker to hand one over,
-        // so the calling thread issues them itself here, overlapping them with the workers above.
-        this->write_go_signal_sequences_to_unused_sub_grids(
-            chip_ids_in_workload,
-            sub_device_id,
-            expected_num_workers_completed,
-            mcast_go_signals,
-            unicast_go_signals,
-            dispatch_metadata);
-        if (!program_tasks.empty()) {
-            write_program_for_device(program_tasks.front());
-        }
-    } catch (...) {
-        dispatch_exception = std::current_exception();
-    }
-    if (program_tasks.size() > 1) {
-        try {
-            dispatch_thread_pool_->wait();
-        } catch (...) {
-            if (!dispatch_exception) {
-                dispatch_exception = std::current_exception();
-            }
-        }
-    }
-    if (dispatch_exception) {
-        std::rethrow_exception(dispatch_exception);
-    }
-
+    // Send go signals to devices not running a program to ensure consistent global state
+    this->write_go_signal_sequences_to_unused_sub_grids(
+        chip_ids_in_workload,
+        sub_device_id,
+        expected_num_workers_completed,
+        mcast_go_signals,
+        unicast_go_signals,
+        dispatch_metadata);
     // Increment Launch Message Buffer Write Pointers
     if (mcast_go_signals) {
         cq_shared_state_->worker_launch_message_buffer_state[*sub_device_id].inc_mcast_wptr(1);
@@ -1317,6 +1207,20 @@ void FDMeshCommandQueue::reset_worker_state(
             this->cq_shared_state_->worker_launch_message_buffer_state.begin() + num_sub_devices,
             std::mem_fn(&LaunchMessageRingBufferState::reset));
     }
+}
+
+void FDMeshCommandQueue::write_program_cmds_to_subgrid(
+    const MeshCoordinateRange& sub_grid,
+    ProgramCommandSequence& program_cmd_seq,
+    bool stall_first,
+    bool stall_before_program,
+    std::unordered_set<uint32_t>& chip_ids_in_workload) {
+    for_each_local(mesh_device_, sub_grid, [&](const auto& coord) {
+        auto device = mesh_device_->impl().get_device(coord);
+        program_dispatch::write_program_command_sequence(
+            program_cmd_seq, device->sysmem_manager(), id_, stall_first, stall_before_program);
+        chip_ids_in_workload.insert(device->id());
+    });
 }
 
 void FDMeshCommandQueue::write_go_signal_sequences_to_unused_sub_grids(

--- a/tt_metal/distributed/fd_mesh_command_queue.hpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.hpp
@@ -51,6 +51,14 @@ private:
         ttsl::Span<const SubDeviceId> sub_device_ids,
         bool notify_host,
         const std::optional<MeshCoordinateRange>& device_range = std::nullopt);
+    // Workload dispatch utility functions
+    // Write dispatch commands associated with running a program on a Virtual Mesh subgrid
+    void write_program_cmds_to_subgrid(
+        const MeshCoordinateRange& sub_grid,
+        ProgramCommandSequence& program_cmd_seq,
+        bool stall_first,
+        bool stall_before_program,
+        std::unordered_set<uint32_t>& chip_ids_in_workload);
     // For a given MeshWorkload, a subgrid is unused if no programs are run on it. Dispatch sequences
     // must be sent to this subgrid to ensure consistent global state across the Virtual Mesh.
     // This function generates and writes dispatch commands forwarding go signal sequences to


### PR DESCRIPTION
### PR Category

Performance

### Summary

#52775 regressed several Blaze prefill device-perf jobs. GLM 5.2 chunked prefill went from 1.762 s to 1.988 s per chunk on a 32-chip Blackhole Galaxy, +12.8% (#53545), and five more perf jobs went red and bisect to the same commit (#53638). This reverts the one change of the four responsible and keeps the other three, which measure as worth having.

**Root cause.** #52775 spread the per-device command-stream writes of an `EnqueueMeshWorkload` across the dispatch thread pool. That is a large win when a device's stream is big enough to dominate the cost of handing it over, and a loss otherwise. Instrumenting the failing job gives the shape of a real op:

| GLM 5.2 per enqueue, steady state | |
|---|---|
| device tasks | 32 |
| programs | 10.8 (~3 devices each) |
| command stream | **9,286 bytes per device**, 297 KB total |
| enqueues per prefill chunk | ~6,000 |

At 9 KB per device there is about 0.4 µs of copying to overlap against ~1.4 µs to wake a pinned worker, so the fan-out costs roughly 4× the work it parallelises, and the loss grows with mesh width. The regression works out to 37.7 µs per enqueue over 6,000 enqueues per chunk, which matches the 37.9 µs measured directly in a host microbenchmark.

The same mechanism explains a detail of the failing run in #53638: **Chunked Kimi perf passed with trace and failed without it.** A traced workload replays from device memory and never re-pays host dispatch cost; an eager one pays it per op.

**Attribution.** Each candidate was run through the failing GLM job on Blackhole Galaxy:

| configuration | GLM per chunk | |
|---|---|---|
| pre-#52775 (`e1c940b2`) | 1.762 s | baseline |
| #52775 as merged | 1.988 s | +12.8% |
| full revert of #52775 | 1.780 s | back to baseline |
| **#52775 with only the fan-out reverted** | **1.623 s** | **−7.9% vs baseline** |
| #52775 with the pool's blocking switch reverted | 2.437 s | +38.3% |
| **this PR, measured** | **1.596 s** | **−9.4% vs baseline** |

Two things fall out. Reverting only the fan-out beats reverting everything, because skipping an already-laid-out program's allocation and keeping the per-program compile off the pool remove work the pre-#52775 code did on every enqueue — and it matters here because these workloads carry ~11 programs each, so the old per-program fan-out was paid 11 times per op. And the pool's switch to blocking is load-bearing: reverting it costs a further 22.6%, because pickup latency becomes a ~55 µs constant.

**What this PR does.** Restores the per-program loop and `write_program_cmds_to_subgrid`, so `enqueue_mesh_workload` returns to the shape it had before #52775. Everything the fan-out needed goes with it: the per-program and per-device task structs, the two lambdas, the workload constants hoisted so a task need not reach back into the command queue, the `std::once_flag` guarding a preparation that can no longer race, and the exception plumbing that existed to join the pool on a throwing path. The dispatch change is +61/−149 in two files; the third file is the CI baseline below.

Go signals to uncovered devices land after the program writes again, which is where they belong and is what the pre-#52775 code did: what a workload waits on is its last participating device's launch, while an uncovered device only needs its go signal before the next barrier, so sending them first delayed every launch by the time they take — about 10 µs for the 24 idle devices of an 8-device workload on a 32-device mesh.

Changes 1, 2 and 3 of #52775 are untouched; they live in `program.cpp`, `mesh_workload.cpp` and `thread_pool.cpp`, and these two files carried only change 4.

Host dispatch cost on a 32-device Wormhole mesh, p50 per enqueue, over three command-stream sizes:

| shape | per device | main | this PR | |
|---|---|---|---|---|
| small | ~0.7 KB | 123.9 µs | 85.4 µs | −31% |
| model_like | ~9 KB | 127.4 µs | 93.4 µs | −27% |
| bytes_heavy | ~400 KB | 238.9 µs | 689.5 µs | **+189%** |

Fixes #53545. Relates to #53638 and #52756.

### Notes for reviewers

**The `bytes_heavy` row is a real regression and I am proposing to accept it.** A 443 KB per-device command stream has enough copying to pay for the hand-off, and that is the shape #52775 was validated against — its benchmark used `create_benchmark_programs`, which is 48× larger per device than a GLM op and needs 10 fetch entries per device where a real op needs one. No model op looks like that today. If one appears, the fan-out belongs behind a per-workload size test rather than applied unconditionally; I tried exactly that — fan out only above 32 KB of total command stream — and it recovered nothing in CI, because a real op is 9× over any threshold low enough to be useful.

**Where to focus — the go-signal ordering interacts with #52782.** That PR made `write_go_signal_sequences_to_unused_sub_grids` carry a config-ring stall count so uncovered devices receive it before a later workload overwrites the freed ring region. Reverting the fan-out moves that call back after the program writes. My reading is that the invariant is cross-workload and both stalls still land inside the same enqueue, so their order within it does not matter — but I did not write that fix and would like a second opinion. This was the only real conflict when reverse-applying #52775 to these two files; it and the function rename are resolved in favour of #52782.

**One thing deliberately not restored.** Reverse-applying #52775 dropped `#include <mutex>`, which it had added for `std::once_flag`. This file uses `std::mutex` and `std::lock_guard` directly and before #52775 got them only through a transitive include, so the include stays.

**On the numbers.** The GLM figures are p50 per-chunk medians over 9 timed iterations. Four of the attribution runs executed concurrently on the same exabox while the two reference runs ran alone, and the concurrent ones carry 0.3–0.4 s standard deviations against the references' 0.02 s, so treat the absolute values as approximate — the ordering is consistent and the gaps are far larger than the spread. Note also that the GLM job is `record-only (no baseline)`: it does not gate on performance, so it never went red for the original regression and will not go red for a future one.

**No test is added, and that is a gap.** A bug fix should come with a regression test, and a hot-path
behaviour change with a micro-benchmark. Neither exists in-tree for multi-device dispatch cost: the
dispatch perf goldens track `test_pgm_dispatch`, which opens a unit mesh, so no CI perf test can see a
per-device cost. The host numbers above come from a `MeshDispatchPerfTest.EnqueueMeshWorkloadHostCost`
benchmark I wrote to get them — three command-stream sizes on whatever mesh the machine has — which is
not in this PR. It should land, either here or straight after; without it the only thing standing
between a repeat of this regression and a model gate weeks later is that someone remembers.

**Testing.** `MeshWorkload`, `MeshTrace`, `MeshEvents` and `MeshSubDevice` in `distributed_unit_tests` pass 49/49 on a 32-chip Wormhole Galaxy against the dispatch commit.

Blaze prefill on Blackhole Galaxy, this branch against the #53638 stages and the GLM stage:

| stage | main after #52775 | this branch | |
|---|---|---|---|
| GLM chunked | 1.988 s/chunk | **1.596 s/chunk** | −19.7%, and −9.4% vs pre-#52775 |
| HCA perf | fail | **pass** | |
| K3 MLA perf | fail | **pass** | |
| Kimi chunked, no trace | 1.328 s/chunk | **0.981 s/chunk** | −26%; gate fails *low*, see below |
| MiniMax-M3 prefill perf | 3582.8 tok/s | **5889.9 tok/s** | +64%; gate fails *high*, see below |
| high_bw_all_gather | 74.61 GB/s | 78.49 GB/s | +5.2%, still 0.6% under its 79.0 gate |
| Kimi chunked, traced | pass | infra failure | container setup failed, no signal |

**Two of those gates are two-sided and now fail because this is faster than they were calibrated for.** MiniMax asserts throughput inside a band and measures 14% above the ceiling; its baseline of 4500 tok/s predated all of this, and even pre-#52775 sat near the top of the band at 5057.8, so `0230b8b7bdd` raises it to the measured 5890. Kimi untraced asserts per-chunk time inside ±5% and measures 10% below the floor. I have **not** touched that baseline: it is documented as the median over ten CI runs, explicitly "a single run is not a usable baseline here", and recalibrating it properly needs several green runs on this code. Both gates were failing on main in the opposite direction, so both are doing their job.

**`high_bw_all_gather` is the one stage this does not fix.** It recovers about two thirds of the regression — 74.61 to 78.49 GB/s — but the gate wants 79.0, and the two passing references measured 80.661 (pre-#52775) and 81.085 (full revert). A 2.7% shortfall against both is more than I want to attribute to noise on one run, so something else in #52775 is likely costing a little all-gather bandwidth; change 3, the pool's switch to blocking, is the obvious suspect since it affects every pool user. That is worth its own investigation, and is why #53638 is listed as related here rather than closed by this PR.

**Not addressed here.** Nothing in CI measures multi-device dispatch cost — the dispatch perf goldens track `test_pgm_dispatch`, which opens a unit mesh, so a per-device cost is invisible to it. That gap is why this reached model gates instead of a perf job, and closing it is separate work.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/revert-52775)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/revert-52775)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/revert-52775)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/revert-52775)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/revert-52775)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/revert-52775)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/revert-52775)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/revert-52775)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=jbauman/revert-52775)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:jbauman/revert-52775)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/revert-52775)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/revert-52775)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/revert-52775)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/revert-52775)
