### PR TITLE
[Feature] #43050 - Generic reduce: DRAM-sharded I/O, and batch NoC reads in reduce readers

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_sharded_topology.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_sharded_topology.py
@@ -1,0 +1,359 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+# Sharded-topology coverage for generic reduce (sum/mean/max/min/std/var) on natural-axis reduces.
+# L1 and DRAM shard grids are disjoint coordinate spaces - worker-core (x,y) vs bank ids on row
+# y=0 - so buffer type is varied independently on input and output.
+
+import pytest
+
+pytestmark = pytest.mark.use_module_device
+
+import torch
+
+import ttnn
+from tests.ttnn.utils_for_testing import assert_numeric_metrics
+
+REDUCE_OPS = {
+    "sum": (ttnn.sum, lambda t, dim, keepdim: torch.sum(t, dim=dim, keepdim=keepdim)),
+    "mean": (ttnn.mean, lambda t, dim, keepdim: torch.mean(t, dim=dim, keepdim=keepdim)),
+    # amax/amin accept a tuple dim, needed by the full-HW tests.
+    "max": (ttnn.max, lambda t, dim, keepdim: torch.amax(t, dim=dim, keepdim=keepdim)),
+    "min": (ttnn.min, lambda t, dim, keepdim: torch.amin(t, dim=dim, keepdim=keepdim)),
+    # Bessel's correction defaults to True on both ttnn and torch.
+    "std": (ttnn.std, lambda t, dim, keepdim: torch.std(t, dim=dim, keepdim=keepdim)),
+    "var": (ttnn.var, lambda t, dim, keepdim: torch.var(t, dim=dim, keepdim=keepdim)),
+}
+
+
+def test_reduce_dram_block_sharded_construction_is_impossible(device, expect_error):
+    """DRAM's 1D, row-y=0 bank address space cannot hold BLOCK_SHARDED's 2D shard grid, so no
+    positive DRAM BLOCK_SHARDED case exists to test - for reduce or any other op."""
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))})
+    shard_spec = ttnn.ShardSpec(shard_grid, (32, 32), ttnn.ShardOrientation.ROW_MAJOR)
+    mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.DRAM, shard_spec)
+
+    torch_input_tensor = torch.randn((1, 1, 128, 128), dtype=torch.bfloat16)
+    with expect_error(RuntimeError, "DRAM banks are 1D"):
+        ttnn.from_torch(
+            torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mem_config
+        )
+
+
+# Geometries satisfying each layout's shard constraints (e.g. WIDTH_SHARDED needs shard height ==
+# full physical height) on a single-row DRAM bank grid. BLOCK_SHARDED is unconstructible on DRAM.
+_DRAM_SHARD_GEOMETRY = {
+    ttnn.TensorMemoryLayout.HEIGHT_SHARDED: {
+        "tensor_shape": (1, 1, 416, 32),
+        "shard_shape": (128, 32),
+        "shard_grid": ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+    },
+    ttnn.TensorMemoryLayout.WIDTH_SHARDED: {
+        "tensor_shape": (1, 1, 32, 128),
+        "shard_shape": (32, 32),
+        "shard_grid": ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))}),
+    },
+}
+
+
+def _dram_sharded_memory_config(shard_layout, shard_grid=None, shard_shape=None):
+    geometry = _DRAM_SHARD_GEOMETRY[shard_layout]
+    shard_spec = ttnn.ShardSpec(
+        shard_grid or geometry["shard_grid"],
+        shard_shape or geometry["shard_shape"],
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    return ttnn.MemoryConfig(shard_layout, ttnn.BufferType.DRAM, shard_spec)
+
+
+def _dram_sharded_input(device, shard_layout, dtype=ttnn.bfloat16, torch_input_tensor=None):
+    tensor_shape = _DRAM_SHARD_GEOMETRY[shard_layout]["tensor_shape"]
+    if torch_input_tensor is None:
+        torch_input_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
+    interleaved_input = ttnn.from_torch(torch_input_tensor, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    dram_sharded_input = ttnn.interleaved_to_sharded(interleaved_input, _dram_sharded_memory_config(shard_layout))
+    return torch_input_tensor, dram_sharded_input
+
+
+@pytest.mark.parametrize("op_name", list(REDUCE_OPS.keys()))
+@pytest.mark.parametrize("shard_layout", list(_DRAM_SHARD_GEOMETRY.keys()))
+@pytest.mark.parametrize("dim", [-1, -2])
+def test_reduce_dram_sharded(device, op_name, shard_layout, dim):
+    """DRAM-sharded input+output across both reduce-dim program factories: dim=-1 uses the W
+    factory, dim=-2 the H factory, whose width-sharded fast path is L1-only. WIDTH_SHARDED + dim=-1
+    reduces along the tensor's own sharded dimension, collapsing it to a single shard."""
+    torch.manual_seed(0)
+    ttnn_op, torch_op = REDUCE_OPS[op_name]
+
+    torch_input_tensor, dram_sharded_input = _dram_sharded_input(device, shard_layout)
+    torch_output_tensor = torch_op(torch_input_tensor, dim, True)
+
+    dram_sharded_config = _dram_sharded_memory_config(shard_layout)
+    output_tensor = ttnn_op(dram_sharded_input, dim=dim, keepdim=True, memory_config=dram_sharded_config)
+
+    output_mem_config = output_tensor.memory_config()
+    assert output_mem_config.buffer_type == ttnn.BufferType.DRAM
+    assert output_mem_config.is_sharded()
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.05,
+        atol=0.05,
+        frobenius_threshold=0.01,
+    )
+
+
+@pytest.mark.parametrize("op_name", list(REDUCE_OPS.keys()))
+@pytest.mark.parametrize("shard_layout", list(_DRAM_SHARD_GEOMETRY.keys()))
+def test_reduce_dram_sharded_full_hw_reduce(device, op_name, shard_layout):
+    """Full-HW reduce from a DRAM-sharded input; the output is interleaved since a collapsed 1x1
+    result cannot stay sharded across cores. sum/mean/max/min decompose host-side into a W-reduce
+    then an H-reduce, each reading the sharded or intermediate tensor; std/var use one Welford
+    call."""
+    torch.manual_seed(0)
+    ttnn_op, torch_op = REDUCE_OPS[op_name]
+
+    torch_input_tensor, dram_sharded_input = _dram_sharded_input(device, shard_layout)
+    torch_output_tensor = torch_op(torch_input_tensor, (-2, -1), True)
+
+    output_tensor = ttnn_op(dram_sharded_input, dim=(-2, -1), keepdim=True, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+
+    output_mem_config = output_tensor.memory_config()
+    assert output_mem_config.buffer_type == ttnn.BufferType.DRAM
+    assert not output_mem_config.is_sharded()
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.05,
+        atol=0.05,
+        frobenius_threshold=0.01,
+    )
+
+
+@pytest.mark.parametrize("op_name", ["sum", "max"])
+def test_reduce_dram_sharded_full_bank_width_h_reduce(device, op_name):
+    """A WIDTH_SHARDED grid spanning every DRAM bank."""
+    torch.manual_seed(0)
+    ttnn_op, torch_op = REDUCE_OPS[op_name]
+
+    num_banks = device.dram_grid_size().x
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_banks - 1, 0))})
+    tensor_shape = (1, 1, 32, 32 * num_banks)
+    shard_shape = (32, 32)
+
+    torch_input_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
+    torch_output_tensor = torch_op(torch_input_tensor, -2, True)
+
+    interleaved_input = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    dram_sharded_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    dram_sharded_input = ttnn.interleaved_to_sharded(interleaved_input, dram_sharded_config)
+
+    output_tensor = ttnn_op(dram_sharded_input, dim=-2, keepdim=True, memory_config=dram_sharded_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.05,
+        atol=0.05,
+        frobenius_threshold=0.01,
+    )
+
+
+@pytest.mark.parametrize("op_name", ["sum", "max"])
+@pytest.mark.parametrize("dram_side", ["input", "output"])
+def test_reduce_h_width_sharded_mixed_l1_dram(device, op_name, dram_side):
+    """One side DRAM-WIDTH_SHARDED, the other L1-WIDTH_SHARDED, on H-reduce: the use_width_sharding
+    gate must key off buffer type per side, not just layout."""
+    torch.manual_seed(0)
+    ttnn_op, torch_op = REDUCE_OPS[op_name]
+
+    tensor_shape = _DRAM_SHARD_GEOMETRY[ttnn.TensorMemoryLayout.WIDTH_SHARDED]["tensor_shape"]
+    shard_shape = _DRAM_SHARD_GEOMETRY[ttnn.TensorMemoryLayout.WIDTH_SHARDED]["shard_shape"]
+    shard_grid = _DRAM_SHARD_GEOMETRY[ttnn.TensorMemoryLayout.WIDTH_SHARDED]["shard_grid"]
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    dram_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, shard_spec)
+    l1_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
+
+    torch_input_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
+    torch_output_tensor = torch_op(torch_input_tensor, -2, True)
+
+    interleaved_input = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    input_config = dram_config if dram_side == "input" else l1_config
+    output_config = l1_config if dram_side == "input" else dram_config
+    input_tensor = ttnn.interleaved_to_sharded(interleaved_input, input_config)
+
+    output_tensor = ttnn_op(input_tensor, dim=-2, keepdim=True, memory_config=output_config)
+
+    output_mem_config = output_tensor.memory_config()
+    assert output_mem_config.buffer_type == (ttnn.BufferType.L1 if dram_side == "input" else ttnn.BufferType.DRAM)
+
+    output_tensor = ttnn.to_torch(output_tensor)
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.05,
+        atol=0.05,
+        frobenius_threshold=0.01,
+    )
+
+
+@pytest.mark.parametrize("op_name", list(REDUCE_OPS.keys()))
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32, ttnn.bfloat8_b])
+def test_reduce_dram_sharded_dtypes(device, op_name, dtype):
+    """Every supported dtype through the H-reduce generic branch, at one fixed geometry."""
+    torch.manual_seed(0)
+    ttnn_op, torch_op = REDUCE_OPS[op_name]
+    shard_layout = ttnn.TensorMemoryLayout.WIDTH_SHARDED
+
+    torch_dtype = torch.float32 if dtype == ttnn.float32 else torch.bfloat16
+    tensor_shape = _DRAM_SHARD_GEOMETRY[shard_layout]["tensor_shape"]
+    torch_input_tensor = torch.randn(tensor_shape, dtype=torch_dtype)
+    torch_output_tensor = torch_op(torch_input_tensor, -2, True)
+
+    _, dram_sharded_input = _dram_sharded_input(
+        device, shard_layout, dtype=dtype, torch_input_tensor=torch_input_tensor
+    )
+    dram_sharded_config = _dram_sharded_memory_config(shard_layout)
+    output_tensor = ttnn_op(dram_sharded_input, dim=-2, keepdim=True, memory_config=dram_sharded_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    # bfloat8_b's block-float quantization inflates relative error on near-zero sums; absolute
+    # error and PCC stay well within tolerance.
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=0.999,
+        rtol=0.1,
+        atol=0.2,
+        frobenius_threshold=0.02,
+    )
+
+
+def test_reduce_dram_sharded_non_natural_dim(device, expect_error):
+    """Non-natural-dim reduce moves the axis into H/W position via transpose or permute, whose
+    DRAM-sharded handling is out of scope here. Behavior differs across ops - ttnn.sum succeeds on
+    this input while mean/max/min/std/var fail building the intermediate's TensorSpec - so only
+    ttnn.mean is pinned."""
+    torch.manual_seed(0)
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))})
+    shard_spec = ttnn.ShardSpec(shard_grid, (416, 32), ttnn.ShardOrientation.ROW_MAJOR)  # one shard per (n, c) slice
+    dram_sharded_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.DRAM, shard_spec)
+
+    torch_input_tensor = torch.randn(1, 4, 416, 32, dtype=torch.bfloat16)
+    interleaved_input = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    dram_sharded_input = ttnn.interleaved_to_sharded(interleaved_input, dram_sharded_config)
+
+    with expect_error(RuntimeError, "Number of shards along height"):
+        ttnn.mean(dram_sharded_input, dim=1, keepdim=True)
+
+
+def test_reduce_h_width_sharded_l1_and_dram_use_distinct_programs(device):
+    """L1- and DRAM-WIDTH_SHARDED H-reduce take different branches, so the buffer type must reach
+    the program-cache key as distinct entries."""
+    shard_layout = ttnn.TensorMemoryLayout.WIDTH_SHARDED
+    tensor_shape = _DRAM_SHARD_GEOMETRY[shard_layout]["tensor_shape"]
+    shard_shape = _DRAM_SHARD_GEOMETRY[shard_layout]["shard_shape"]
+    shard_grid = _DRAM_SHARD_GEOMETRY[shard_layout]["shard_grid"]
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    l1_config = ttnn.MemoryConfig(shard_layout, ttnn.BufferType.L1, shard_spec)
+    dram_config = ttnn.MemoryConfig(shard_layout, ttnn.BufferType.DRAM, shard_spec)
+
+    torch_input_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
+    interleaved_input = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    # Ignore whatever earlier tests in this session compiled.
+    device.enable_program_cache()
+    device.clear_program_cache()
+    l1_input = ttnn.interleaved_to_sharded(interleaved_input, l1_config)
+    ttnn.sum(l1_input, dim=-2, keepdim=True, memory_config=l1_config)
+    entries_after_l1 = device.num_program_cache_entries()
+
+    dram_input = ttnn.interleaved_to_sharded(interleaved_input, dram_config)
+    ttnn.sum(dram_input, dim=-2, keepdim=True, memory_config=dram_config)
+    entries_after_dram = device.num_program_cache_entries()
+
+    assert entries_after_dram > entries_after_l1, "expected a new program cache entry for the DRAM-sharded case"
+
+
+def test_reduce_dram_sharded_requires_explicit_output_shard_spec_across_buffer_types(device, expect_error):
+    """A spec-less sharded output may only borrow the input's shard grid when both share a buffer
+    type; a DRAM input with an L1 spec-less output must be rejected."""
+    shard_layout = ttnn.TensorMemoryLayout.HEIGHT_SHARDED
+    torch_input_tensor, dram_sharded_input = _dram_sharded_input(device, shard_layout)
+    output_config_no_spec = ttnn.MemoryConfig(shard_layout, ttnn.BufferType.L1)
+
+    with expect_error(RuntimeError, "requires an explicit shard_spec"):
+        ttnn.sum(dram_sharded_input, dim=-1, keepdim=True, memory_config=output_config_no_spec)
+
+
+# Sharding C as well as H and W keeps the layout ND_SHARDED: no legacy layout can express a
+# split along C, so it cannot normalize to WIDTH/HEIGHT/BLOCK.
+_DRAM_ND_TENSOR_SHAPE = (1, 4, 128, 128)
+_DRAM_ND_SHARD_SHAPE = [1, 2, 64, 64]
+
+
+def _dram_nd_sharded_config():
+    grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))})
+    return ttnn.MemoryConfig(ttnn.BufferType.DRAM, ttnn.NdShardSpec(ttnn.Shape(_DRAM_ND_SHARD_SHAPE), grid))
+
+
+@pytest.mark.parametrize("op_name", ["sum", "std"])
+@pytest.mark.parametrize("dim", [-1, -2])
+def test_reduce_dram_nd_sharded(device, op_name, dim):
+    """DRAM ND_SHARDED input and output, covering build_reduce_output_tensor_spec's ND branch."""
+    torch.manual_seed(0)
+    ttnn_op, torch_op = REDUCE_OPS[op_name]
+
+    nd_config = _dram_nd_sharded_config()
+    torch_input_tensor = torch.randn(_DRAM_ND_TENSOR_SHAPE, dtype=torch.bfloat16)
+    torch_output_tensor = torch_op(torch_input_tensor, dim, True)
+
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device, memory_config=nd_config
+    )
+    assert input_tensor.memory_config().memory_layout == ttnn.TensorMemoryLayout.ND_SHARDED
+
+    output_tensor = ttnn_op(input_tensor, dim=dim, keepdim=True, memory_config=nd_config)
+
+    output_mem_config = output_tensor.memory_config()
+    assert output_mem_config.buffer_type == ttnn.BufferType.DRAM
+    assert output_mem_config.is_sharded()
+
+    assert_numeric_metrics(
+        torch_output_tensor,
+        ttnn.to_torch(output_tensor),
+        pcc_threshold=0.999,
+        rtol=0.05,
+        atol=0.05,
+        frobenius_threshold=0.01,
+    )
+
+
+def test_reduce_dram_nd_sharded_requires_explicit_output_nd_shard_spec(device, expect_error):
+    """ND counterpart of the legacy-fallback guard: an L1 ND output with no nd_shard_spec of its
+    own cannot borrow a DRAM input's bank grid."""
+    torch_input_tensor = torch.randn(_DRAM_ND_TENSOR_SHAPE, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=_dram_nd_sharded_config(),
+    )
+    output_config_no_spec = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.ND_SHARDED, ttnn.BufferType.L1)
+
+    with expect_error(RuntimeError, "requires an explicit nd_shard_spec"):
+        ttnn.sum(input_tensor, dim=-2, keepdim=True, memory_config=output_config_no_spec)

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_sharded_topology.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_sharded_topology.py
@@ -107,24 +107,43 @@ def test_reduce_dram_sharded(device, op_name, shard_layout, dim):
     )
 
 
+# Output configs a full-HW reduce accepts.  The 1x1 result can stay sharded in either buffer type;
+# std/var reshard the input to the output config on the way in, so the sharded variants reuse the
+# input's own shard spec.
+_HW_OUTPUT_KINDS = ["interleaved", "dram_sharded", "l1_sharded"]
+
+
+def _hw_output_config(output_kind, shard_layout):
+    if output_kind == "interleaved":
+        return ttnn.DRAM_MEMORY_CONFIG
+    geometry = _DRAM_SHARD_GEOMETRY[shard_layout]
+    buffer_type = ttnn.BufferType.DRAM if output_kind == "dram_sharded" else ttnn.BufferType.L1
+    shard_spec = ttnn.ShardSpec(geometry["shard_grid"], geometry["shard_shape"], ttnn.ShardOrientation.ROW_MAJOR)
+    return ttnn.MemoryConfig(shard_layout, buffer_type, shard_spec)
+
+
 @pytest.mark.parametrize("op_name", list(REDUCE_OPS.keys()))
 @pytest.mark.parametrize("shard_layout", list(_DRAM_SHARD_GEOMETRY.keys()))
-def test_reduce_dram_sharded_full_hw_reduce(device, op_name, shard_layout):
-    """Full-HW reduce from a DRAM-sharded input; the output is interleaved since a collapsed 1x1
-    result cannot stay sharded across cores. sum/mean/max/min decompose host-side into a W-reduce
-    then an H-reduce, each reading the sharded or intermediate tensor; std/var use one Welford
-    call."""
+@pytest.mark.parametrize("output_kind", _HW_OUTPUT_KINDS)
+def test_reduce_dram_sharded_full_hw_reduce(device, op_name, shard_layout, output_kind):
+    """Full-HW reduce from a DRAM-sharded input, across every output config the op accepts.
+    sum/mean/max/min decompose host-side into a W-reduce then an H-reduce, each reading the sharded
+    or intermediate tensor; std/var use one Welford call."""
     torch.manual_seed(0)
     ttnn_op, torch_op = REDUCE_OPS[op_name]
 
     torch_input_tensor, dram_sharded_input = _dram_sharded_input(device, shard_layout)
     torch_output_tensor = torch_op(torch_input_tensor, (-2, -1), True)
 
-    output_tensor = ttnn_op(dram_sharded_input, dim=(-2, -1), keepdim=True, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    output_config = _hw_output_config(output_kind, shard_layout)
+    output_tensor = ttnn_op(dram_sharded_input, dim=(-2, -1), keepdim=True, memory_config=output_config)
 
     output_mem_config = output_tensor.memory_config()
-    assert output_mem_config.buffer_type == ttnn.BufferType.DRAM
-    assert not output_mem_config.is_sharded()
+    assert output_mem_config.buffer_type == output_config.buffer_type
+    assert output_mem_config.is_sharded() == output_config.is_sharded()
+    if output_config.is_sharded():
+        # A 1x1 result is a single shard, so either sharded layout normalizes to the same spec.
+        assert output_mem_config.memory_layout == ttnn.TensorMemoryLayout.WIDTH_SHARDED
 
     output_tensor = ttnn.to_torch(output_tensor)
     assert_numeric_metrics(

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_sharded_topology.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_sharded_topology.py
@@ -229,6 +229,52 @@ def test_reduce_h_width_sharded_mixed_l1_dram(device, op_name, dram_side):
     )
 
 
+@pytest.mark.parametrize("op_name", ["sum", "max"])
+@pytest.mark.parametrize("dram_side", ["neither", "input", "output", "both"])
+def test_reduce_w_height_sharded_mixed_l1_dram(device, op_name, dram_side):
+    """W-reduce twin of the H-reduce gate check above, on a geometry whose shards tile the tensor
+    exactly so the height-sharded fast path is eligible. That path aliases both shards as circular
+    buffers, which only L1 can back, so any DRAM side has to fall through to the generic reader."""
+    torch.manual_seed(0)
+    ttnn_op, torch_op = REDUCE_OPS[op_name]
+
+    tensor_shape = (1, 1, 256, 256)
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 0))})
+    input_spec = ttnn.ShardSpec(shard_grid, (32, 256), ttnn.ShardOrientation.ROW_MAJOR)
+    output_spec = ttnn.ShardSpec(shard_grid, (32, 32), ttnn.ShardOrientation.ROW_MAJOR)
+
+    # The DRAM cases must differ from the L1 control in buffer type alone, so the rest of the fast
+    # path's terms stay satisfied here: equal shard heights, and shard_Ht * num_cores == NC * Ht
+    # (in rows rather than tiles).
+    assert input_spec.shape[0] == output_spec.shape[0]
+    assert input_spec.shape[0] * shard_grid.num_cores() == tensor_shape[1] * tensor_shape[2]
+
+    def config(spec, buffer_type):
+        return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, buffer_type, spec)
+
+    input_buffer = ttnn.BufferType.DRAM if dram_side in ("input", "both") else ttnn.BufferType.L1
+    output_buffer = ttnn.BufferType.DRAM if dram_side in ("output", "both") else ttnn.BufferType.L1
+
+    torch_input_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
+    torch_output_tensor = torch_op(torch_input_tensor, -1, True)
+
+    interleaved_input = ttnn.from_torch(torch_input_tensor, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor = ttnn.interleaved_to_sharded(interleaved_input, config(input_spec, input_buffer))
+
+    output_tensor = ttnn_op(input_tensor, dim=-1, keepdim=True, memory_config=config(output_spec, output_buffer))
+
+    assert output_tensor.memory_config().buffer_type == output_buffer
+
+    assert_numeric_metrics(
+        torch_output_tensor,
+        ttnn.to_torch(output_tensor),
+        pcc_threshold=0.999,
+        rtol=0.05,
+        atol=0.05,
+        frobenius_threshold=0.01,
+    )
+
+
 @pytest.mark.parametrize("op_name", list(REDUCE_OPS.keys()))
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32, ttnn.bfloat8_b])
 def test_reduce_dram_sharded_dtypes(device, op_name, dtype):

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction_sharded_topology.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction_sharded_topology.py
@@ -27,9 +27,19 @@ REDUCE_OPS = {
 }
 
 
-def test_reduce_dram_block_sharded_construction_is_impossible(device, expect_error):
-    """DRAM's 1D, row-y=0 bank address space cannot hold BLOCK_SHARDED's 2D shard grid, so no
-    positive DRAM BLOCK_SHARDED case exists to test - for reduce or any other op."""
+_DRAM_BLOCK_TENSOR_SHAPE = (1, 1, 32, 128)
+
+
+def _dram_block_sharded_memory_config(buffer_type):
+    """A one-row block grid: DRAM's single bank row caps a legacy block layout at one row of shards,
+    so this degenerate shape is the only DRAM BLOCK_SHARDED spec that constructs at all."""
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 0))})
+    shard_spec = ttnn.ShardSpec(shard_grid, (32, 32), ttnn.ShardOrientation.ROW_MAJOR)
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, buffer_type, shard_spec)
+
+
+def test_reduce_dram_block_sharded_2d_grid_is_unconstructible(device, expect_error):
+    """A 2D block grid needs shard cores off row 0, which DRAM has no banks for."""
     shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(3, 3))})
     shard_spec = ttnn.ShardSpec(shard_grid, (32, 32), ttnn.ShardOrientation.ROW_MAJOR)
     mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.DRAM, shard_spec)
@@ -41,8 +51,36 @@ def test_reduce_dram_block_sharded_construction_is_impossible(device, expect_err
         )
 
 
+@pytest.mark.parametrize("op_name", ["sum", "std"])
+@pytest.mark.parametrize("dram_side", ["input", "output"])
+def test_reduce_dram_block_sharded_is_rejected(device, expect_error, op_name, dram_side):
+    """The one-row DRAM block spec does construct, so reduce has to reject it itself: every op that
+    moves a tensor (interleaved_to_sharded, reshard, to_memory_config) refuses the layout, and a
+    reduce that produced one would hand back a tensor nothing else accepts."""
+    ttnn_op, _ = REDUCE_OPS[op_name]
+    input_buffer = ttnn.BufferType.DRAM if dram_side == "input" else ttnn.BufferType.L1
+    output_buffer = ttnn.BufferType.L1 if dram_side == "input" else ttnn.BufferType.DRAM
+
+    torch_input_tensor = torch.randn(_DRAM_BLOCK_TENSOR_SHAPE, dtype=torch.bfloat16)
+    input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=_dram_block_sharded_memory_config(input_buffer),
+    )
+
+    with expect_error(RuntimeError, "DRAM block sharding is not supported"):
+        ttnn_op(
+            input_tensor,
+            dim=-1,
+            keepdim=True,
+            memory_config=_dram_block_sharded_memory_config(output_buffer),
+        )
+
+
 # Geometries satisfying each layout's shard constraints (e.g. WIDTH_SHARDED needs shard height ==
-# full physical height) on a single-row DRAM bank grid. BLOCK_SHARDED is unconstructible on DRAM.
+# full physical height) on a single-row DRAM bank grid. BLOCK_SHARDED is rejected on DRAM.
 _DRAM_SHARD_GEOMETRY = {
     ttnn.TensorMemoryLayout.HEIGHT_SHARDED: {
         "tensor_shape": (1, 1, 416, 32),
@@ -344,13 +382,16 @@ def test_reduce_h_width_sharded_l1_and_dram_use_distinct_programs(device):
     device.clear_program_cache()
     l1_input = ttnn.interleaved_to_sharded(interleaved_input, l1_config)
     ttnn.sum(l1_input, dim=-2, keepdim=True, memory_config=l1_config)
-    entries_after_l1 = device.num_program_cache_entries()
 
     dram_input = ttnn.interleaved_to_sharded(interleaved_input, dram_config)
-    ttnn.sum(dram_input, dim=-2, keepdim=True, memory_config=dram_config)
-    entries_after_dram = device.num_program_cache_entries()
+    entries_before_dram_reduce = device.num_program_cache_entries()
 
-    assert entries_after_dram > entries_after_l1, "expected a new program cache entry for the DRAM-sharded case"
+    ttnn.sum(dram_input, dim=-2, keepdim=True, memory_config=dram_config)
+    entries_after_dram_reduce = device.num_program_cache_entries()
+
+    assert (
+        entries_after_dram_reduce > entries_before_dram_reduce
+    ), "expected a new program cache entry for the DRAM-sharded reduce"
 
 
 def test_reduce_dram_sharded_requires_explicit_output_shard_spec_across_buffer_types(device, expect_error):

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.cpp
@@ -191,16 +191,25 @@ tt::tt_metal::TensorSpec build_reduce_output_tensor_spec(
             if (legacy) {
                 return {legacy->grid, legacy->orientation};
             }
-            if (input_nd) {
-                return {input_nd->grid, input_nd->orientation};
-            }
-            if (input_legacy) {
-                return {input_legacy->grid, input_legacy->orientation};
-            }
-            TT_THROW(
+            TT_FATAL(
+                input_nd.has_value() || input_legacy.has_value(),
                 "Sharded memory layout {} requires either nd_shard_spec or shard_spec to be set "
                 "on the output memory config or the input tensor",
                 mem_layout);
+            // DRAM shard grids are bank ids (1D, row y=0) and L1 shard grids are worker-core
+            // (x,y) coordinates, so borrowing the input's grid across buffer types would pair a
+            // buffer type with a grid from the wrong coordinate space.
+            TT_FATAL(
+                output_mem_config.buffer_type() == input_mem_config.buffer_type(),
+                "Sharded memory layout {} on an output with buffer type {} requires an explicit "
+                "shard_spec (cannot fall back to the input tensor's {} shard grid)",
+                mem_layout,
+                output_mem_config.buffer_type(),
+                input_mem_config.buffer_type());
+            if (input_nd) {
+                return {input_nd->grid, input_nd->orientation};
+            }
+            return {input_legacy->grid, input_legacy->orientation};
         };
         const auto& [grid, orientation] = get_grid_and_orientation();
 
@@ -229,6 +238,16 @@ tt::tt_metal::TensorSpec build_reduce_output_tensor_spec(
             nd_shard_spec.has_value() || input_nd_shard_spec.has_value(),
             "ND_SHARDED memory layout requires nd_shard_spec to be set "
             "on the output memory config or the input tensor");
+        if (!nd_shard_spec.has_value()) {
+            // Same cross-buffer-type hazard as the legacy-sharding fallback above: an ND shard
+            // grid borrowed from the input is only valid for an output of the same buffer type.
+            TT_FATAL(
+                output_mem_config.buffer_type() == input_mem_config.buffer_type(),
+                "ND_SHARDED memory layout on an output with buffer type {} requires an explicit "
+                "nd_shard_spec (cannot fall back to the input tensor's {} shard grid)",
+                output_mem_config.buffer_type(),
+                input_mem_config.buffer_type());
+        }
         auto nd_shard_spec_copy = nd_shard_spec.has_value() ? *nd_shard_spec : *input_nd_shard_spec;
         if (reduce_dim == ReduceOpDim::W || reduce_dim == ReduceOpDim::HW) {
             nd_shard_spec_copy.shard_shape[-1] = 1;
@@ -252,21 +271,23 @@ void validate_reduce_sharded_buffer_types(
     const tt::tt_metal::MemoryConfig& output_mem_config,
     std::string_view op_name) {
     TT_FATAL(
-        !output_mem_config.is_sharded() || output_mem_config.is_l1(),
-        "{}: sharded output memory layout {} is only supported with L1 buffers, got buffer type {}",
+        !output_mem_config.is_sharded() || output_mem_config.is_l1() || output_mem_config.is_dram(),
+        "{}: sharded output memory layout {} is only supported with L1 or DRAM buffers, got buffer type {}",
         op_name,
         output_mem_config.memory_layout(),
         output_mem_config.buffer_type());
     TT_FATAL(
-        !input_mem_config.is_sharded() || input_mem_config.is_l1(),
-        "{}: sharded input memory layout {} is only supported with L1 buffers, got buffer type {}",
+        !input_mem_config.is_sharded() || input_mem_config.is_l1() || input_mem_config.is_dram(),
+        "{}: sharded input memory layout {} is only supported with L1 or DRAM buffers, got buffer type {}",
         op_name,
         input_mem_config.memory_layout(),
         input_mem_config.buffer_type());
 }
 
 bool h_reduce_negate_fits_in_l1(
-    const ttnn::Tensor& input_tensor, const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids) {
+    const ttnn::Tensor& input_tensor,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids) {
     using namespace tt::tt_metal;
 
     const auto& shape = input_tensor.padded_shape();
@@ -283,7 +304,12 @@ bool h_reduce_negate_fits_in_l1(
     const uint32_t Ht = H / tile_height;
 
     auto* device = input_tensor.device();
-    const bool use_width_sharding = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
+    // Must mirror the H factory's gate exactly: the shard-based CB sizing below only describes
+    // the program it actually builds when the width-sharded fast path is selected, which needs
+    // WIDTH_SHARDED L1 on both sides.
+    const bool use_width_sharding = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED &&
+                                    output_mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED &&
+                                    input_tensor.memory_config().is_l1() && output_mem_config.is_l1();
 
     uint32_t num_cols_per_core_group_1 = 0;
     uint32_t num_cols_per_core_group_2 = 0;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.cpp
@@ -196,9 +196,7 @@ tt::tt_metal::TensorSpec build_reduce_output_tensor_spec(
                 "Sharded memory layout {} requires either nd_shard_spec or shard_spec to be set "
                 "on the output memory config or the input tensor",
                 mem_layout);
-            // DRAM shard grids are bank ids (1D, row y=0) and L1 shard grids are worker-core
-            // (x,y) coordinates, so borrowing the input's grid across buffer types would pair a
-            // buffer type with a grid from the wrong coordinate space.
+            // L1 worker grids and DRAM bank ids are disjoint; do not borrow a grid across buffer types.
             TT_FATAL(
                 output_mem_config.buffer_type() == input_mem_config.buffer_type(),
                 "Sharded memory layout {} on an output with buffer type {} requires an explicit "
@@ -239,8 +237,7 @@ tt::tt_metal::TensorSpec build_reduce_output_tensor_spec(
             "ND_SHARDED memory layout requires nd_shard_spec to be set "
             "on the output memory config or the input tensor");
         if (!nd_shard_spec.has_value()) {
-            // Same cross-buffer-type hazard as the legacy-sharding fallback above: an ND shard
-            // grid borrowed from the input is only valid for an output of the same buffer type.
+            // Same as the legacy fallback: do not borrow an ND shard grid across buffer types.
             TT_FATAL(
                 output_mem_config.buffer_type() == input_mem_config.buffer_type(),
                 "ND_SHARDED memory layout on an output with buffer type {} requires an explicit "
@@ -270,6 +267,17 @@ void validate_reduce_sharded_buffer_types(
     const tt::tt_metal::MemoryConfig& input_mem_config,
     const tt::tt_metal::MemoryConfig& output_mem_config,
     std::string_view op_name) {
+    const auto is_dram_block_sharded = [](const tt::tt_metal::MemoryConfig& mem_config) {
+        return mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED && mem_config.is_dram();
+    };
+    TT_FATAL(
+        !is_dram_block_sharded(input_mem_config) && !is_dram_block_sharded(output_mem_config),
+        "{}: DRAM block sharding is not supported, got input layout {} on {}, output layout {} on {}",
+        op_name,
+        input_mem_config.memory_layout(),
+        input_mem_config.buffer_type(),
+        output_mem_config.memory_layout(),
+        output_mem_config.buffer_type());
     TT_FATAL(
         !output_mem_config.is_sharded() || output_mem_config.is_l1() || output_mem_config.is_dram(),
         "{}: sharded output memory layout {} is only supported with L1 or DRAM buffers, got buffer type {}",
@@ -304,9 +312,7 @@ bool h_reduce_negate_fits_in_l1(
     const uint32_t Ht = H / tile_height;
 
     auto* device = input_tensor.device();
-    // Must mirror the H factory's gate exactly: the shard-based CB sizing below only describes
-    // the program it actually builds when the width-sharded fast path is selected, which needs
-    // WIDTH_SHARDED L1 on both sides.
+    // Mirror the H factory: shard-based CB sizing is only valid on the width-sharded L1 path.
     const bool use_width_sharding = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED &&
                                     output_mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED &&
                                     input_tensor.memory_config().is_l1() && output_mem_config.is_l1();

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
@@ -33,6 +33,23 @@ enum class ReduceOpParallelizationStrategy { MULTI_CORE_H, MULTI_CORE_W, MULTI_C
 
 namespace ttnn::prim {
 
+// Tiles the universal reduce reader fetches per NoC barrier. One read in flight leaves the whole
+// read latency exposed on every tile, which costs 12-16% on a read-bound reduce; 8 per barrier is
+// 2-3% slower than 4, so 4 is the peak.
+inline constexpr uint32_t kReduceReaderTilesPerBatch = 4;
+
+// Reader batch for a kernel whose smallest core streams min_tiles_per_core tiles: a core with fewer
+// tiles than a batch never reaches the batched loop, so the whole program reads unbatched instead of
+// leaving that core on a path the batch size does not fit. 1 is unbatched.
+inline uint32_t reduce_reader_batch(uint32_t min_tiles_per_core) {
+    return min_tiles_per_core < kReduceReaderTilesPerBatch ? 1u : kReduceReaderTilesPerBatch;
+}
+
+// Input CB depth for that batch: two batches, so the reader fills one while compute drains the other,
+// and a whole number of them, since the CB write pointer only wraps at fifo_limit and a reserved
+// batch straddling the end would overrun it.
+inline uint32_t reduce_reader_input_cb_tiles(uint32_t tiles_per_batch) { return 2 * tiles_per_batch; }
+
 // Identity element for the given reduction math op: -inf for MAX, +inf for MIN, 0 otherwise.
 // Used by the dense RM paths to pad partial chunks without disturbing the result.
 inline float get_reduce_pad_value(tt::tt_metal::ReduceOpMath reduce_math) {

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
@@ -158,8 +158,12 @@ tt::tt_metal::ReduceOpParallelizationStrategy get_parallelization_strategy(
 // and c_5 (ineg) are each sized at Ht * lcm(Wt_per_core_g1, Wt_per_core_g2)
 // tiles.  For wide reductions this can exceed L1, in which case callers must
 // fall back to external negation around a non-fused (regular) reduce.
+// `output_mem_config` is needed because the per-core tile count depends on whether the H factory
+// selects its width-sharded fast path, which keys off both sides of the reduce.
 bool h_reduce_negate_fits_in_l1(
-    const ttnn::Tensor& input_tensor, const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids);
+    const ttnn::Tensor& input_tensor,
+    const tt::tt_metal::MemoryConfig& output_mem_config,
+    const std::optional<tt::tt_metal::CoreRangeSet>& sub_core_grids);
 
 // Builds a tt::tt_metal::TensorSpec for a reduction-style op output, given the already
 // shape-adjusted output shape and the dimension that was reduced.
@@ -186,13 +190,10 @@ tt::tt_metal::TensorSpec build_reduce_output_tensor_spec(
     tt::tt_metal::ReduceOpDim reduce_dim,
     tt::tt_metal::Layout output_layout = tt::tt_metal::Layout::TILE);
 
-// Enforces the documented contract that, for reduction-style ops, any sharded
-// participant (input or output) must live in L1.  Sharded layouts and DRAM
-// buffers use disjoint coordinate spaces (worker cores vs DRAM bank cores), so
-// silently borrowing a grid across buffer types — as the shard-spec fallback
-// in `build_reduce_output_tensor_spec` would otherwise allow — produces an
-// invalid spec.  Pass an `op_name` (e.g. "reduce", "Std/Var reduction") for a
-// readable error message.
+// Rejects a sharded input or output whose buffer type is neither L1 nor DRAM.  The rest of the
+// sharded contract lives elsewhere: `build_reduce_output_tensor_spec` rejects borrowing a shard
+// grid across buffer types, and tt_metal's `validate_buffer_parameters` enforces DRAM's 1D,
+// row-y=0 bank grid.  `op_name` (e.g. "reduce", "Std/Var reduction") labels the error.
 void validate_reduce_sharded_buffer_types(
     const tt::tt_metal::MemoryConfig& input_mem_config,
     const tt::tt_metal::MemoryConfig& output_mem_config,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/common.hpp
@@ -33,21 +33,14 @@ enum class ReduceOpParallelizationStrategy { MULTI_CORE_H, MULTI_CORE_W, MULTI_C
 
 namespace ttnn::prim {
 
-// Tiles the universal reduce reader fetches per NoC barrier. One read in flight leaves the whole
-// read latency exposed on every tile, which costs 12-16% on a read-bound reduce; 8 per barrier is
-// 2-3% slower than 4, so 4 is the peak.
+// Tiles the universal reduce reader fetches per NoC barrier.
 inline constexpr uint32_t kReduceReaderTilesPerBatch = 4;
 
-// Reader batch for a kernel whose smallest core streams min_tiles_per_core tiles: a core with fewer
-// tiles than a batch never reaches the batched loop, so the whole program reads unbatched instead of
-// leaving that core on a path the batch size does not fit. 1 is unbatched.
 inline uint32_t reduce_reader_batch(uint32_t min_tiles_per_core) {
     return min_tiles_per_core < kReduceReaderTilesPerBatch ? 1u : kReduceReaderTilesPerBatch;
 }
 
-// Input CB depth for that batch: two batches, so the reader fills one while compute drains the other,
-// and a whole number of them, since the CB write pointer only wraps at fifo_limit and a reserved
-// batch straddling the end would overrun it.
+// Depth is a multiple of the batch so a reserve never straddles fifo_limit.
 inline uint32_t reduce_reader_input_cb_tiles(uint32_t tiles_per_batch) { return 2 * tiles_per_batch; }
 
 // Identity element for the given reduction math op: -inf for MAX, +inf for MIN, 0 otherwise.
@@ -169,14 +162,8 @@ tt::tt_metal::experimental::KernelSpec::CompileTimeArgs build_rm_compute_ct_args
 tt::tt_metal::ReduceOpParallelizationStrategy get_parallelization_strategy(
     const ttnn::Tensor& input_tensors, tt::tt_metal::ReduceOpDim reduce_dim);
 
-// Returns true if the fused-negate H reduce path's CBs fit in available L1.
-// The reduce_h_neg compute kernel pushes ntiles tiles per inner-loop iteration;
-// to make the FIFO write pointer wrap cleanly across all push sizes, c_4 (acc)
-// and c_5 (ineg) are each sized at Ht * lcm(Wt_per_core_g1, Wt_per_core_g2)
-// tiles.  For wide reductions this can exceed L1, in which case callers must
-// fall back to external negation around a non-fused (regular) reduce.
-// `output_mem_config` is needed because the per-core tile count depends on whether the H factory
-// selects its width-sharded fast path, which keys off both sides of the reduce.
+// True when fused-negate CBs (acc and ineg, each Ht * lcm of the two per-core Wts) fit in L1.
+// Per-core Wt depends on the H factory's width-sharded path, so output_mem_config is required.
 bool h_reduce_negate_fits_in_l1(
     const ttnn::Tensor& input_tensor,
     const tt::tt_metal::MemoryConfig& output_mem_config,
@@ -207,10 +194,8 @@ tt::tt_metal::TensorSpec build_reduce_output_tensor_spec(
     tt::tt_metal::ReduceOpDim reduce_dim,
     tt::tt_metal::Layout output_layout = tt::tt_metal::Layout::TILE);
 
-// Rejects a sharded input or output whose buffer type is neither L1 nor DRAM.  The rest of the
-// sharded contract lives elsewhere: `build_reduce_output_tensor_spec` rejects borrowing a shard
-// grid across buffer types, and tt_metal's `validate_buffer_parameters` enforces DRAM's 1D,
-// row-y=0 bank grid.  `op_name` (e.g. "reduce", "Std/Var reduction") labels the error.
+// Sharded I/O must be L1 or DRAM; DRAM BLOCK_SHARDED is unsupported.
+// Grid borrowing and DRAM's 1D bank grid are checked elsewhere.
 void validate_reduce_sharded_buffer_types(
     const tt::tt_metal::MemoryConfig& input_mem_config,
     const tt::tt_metal::MemoryConfig& output_mem_config,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_reduce_universal_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_reduce_universal_start_id.cpp
@@ -14,11 +14,10 @@ void kernel_main() {
     uint32_t num_tiles = get_arg(args::num_tiles);
     uint32_t start_id = get_arg(args::start_id);
     constexpr auto scaler_bits = get_arg(args::scaler_bits);
+    constexpr uint32_t tiles_per_batch = get_arg(args::tiles_per_batch);
 
     float scaler_f = __builtin_bit_cast(float, scaler_bits);
     dataflow_kernel_lib::prepare_reduce_scaler<dfb::scaler, REDUCE_OP, REDUCE_DIM>(scaler_f);
-
-    constexpr uint32_t onetile = 1;
 
     auto tensor_accessor = TensorAccessor(tensor::src);
 
@@ -27,11 +26,19 @@ void kernel_main() {
     DataflowBuffer dfb_in0(dfb::in0);
     uint32_t tile_bytes = dfb_in0.get_tile_size();
 
-    // read a ublock of tiles from src to the buffer, and then push the ublock to unpacker
-    for (uint32_t i = start_id; i < start_id + num_tiles; i++) {
-        dfb_in0.reserve_back(onetile);
-        noc.async_read(tensor_accessor, dfb_in0, tile_bytes, {.page_id = i}, {.offset_bytes = 0});
+    // Issue a whole batch of reads before the barrier so a core keeps that many tiles in flight;
+    // barriering per tile exposes the full read latency on every one of them. The host sizes the
+    // input CB at two batches, so a reservation is always contiguous: every full batch leaves the
+    // write pointer batch-aligned, and a short batch can only be the last one.
+    const uint32_t end_id = start_id + num_tiles;
+    for (uint32_t i = start_id; i < end_id;) {
+        const uint32_t batch = std::min(tiles_per_batch, end_id - i);
+        dfb_in0.reserve_back(batch);
+        for (uint32_t k = 0; k < batch; ++k) {
+            noc.async_read(tensor_accessor, dfb_in0, tile_bytes, {.page_id = i + k}, {.offset_bytes = k * tile_bytes});
+        }
         noc.async_read_barrier();
-        dfb_in0.push_back(onetile);
+        dfb_in0.push_back(batch);
+        i += batch;
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_reduce_universal_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_reduce_universal_start_id.cpp
@@ -26,10 +26,7 @@ void kernel_main() {
     DataflowBuffer dfb_in0(dfb::in0);
     uint32_t tile_bytes = dfb_in0.get_tile_size();
 
-    // Issue a whole batch of reads before the barrier so a core keeps that many tiles in flight;
-    // barriering per tile exposes the full read latency on every one of them. The host sizes the
-    // input CB at two batches, so a reservation is always contiguous: every full batch leaves the
-    // write pointer batch-aligned, and a short batch can only be the last one.
+    // One barrier per batch; a short final batch uses the same path.
     const uint32_t end_id = start_id + num_tiles;
     for (uint32_t i = start_id; i < end_id;) {
         const uint32_t batch = std::min(tiles_per_batch, end_id - i);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
@@ -43,11 +43,8 @@ void kernel_main() {
 
     constexpr uint32_t onetile = 1;
 
-    // A full chunk's reads go out behind a single barrier instead of one barrier per tile, which
-    // would expose the whole read latency on every tile. The host sizes the input CB at two batches
-    // of tiles_per_batch, so a multi-tile reserve is only contiguous while the chunk is exactly that
-    // batch: a row_chunk the host did not predict (the SFPU path shortens it) stays per-tile.
-    constexpr bool batch_reads = row_chunk == tiles_per_batch;
+    // Batch only when row_chunk matches the host's tiles_per_batch; SFPU shortens the chunk.
+    constexpr bool batch_reads = (row_chunk == tiles_per_batch);
 
     Noc noc;
     // dfb::in0 is the reduce input pipe: this kernel fills it, the compute kernel drains it.
@@ -82,8 +79,8 @@ void kernel_main() {
         uint32_t reset_curr_id = curr_id;
         uint32_t reset_w = w;
         uint32_t reset_col_start = col_start_tile_id;
-        // The tail chunk is shorter than a batch, so it keeps the per-tile path.
-        const bool batch_chunk = batch_reads && (chunk_end - i) == row_chunk;
+        // Tail is shorter than the CB batch, so the reserve would not be contiguous.
+        const bool batch_chunk = batch_reads && ((chunk_end - i) == row_chunk);
 
         for (uint32_t j = 0; j < Ht; ++j) {
             w = reset_w;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/reader_unary_transpose_wh_universal_input_cols_partitioned.cpp
@@ -25,6 +25,7 @@ void kernel_main() {
     constexpr auto scaler_bits = get_arg(args::scaler_bits);
     constexpr bool use_welford = get_arg(args::use_welford) != 0;
     constexpr auto fp32_mode = get_arg(args::enable_fp32_sfpu) != 0 ? ReduceFp32Mode::Accurate : ReduceFp32Mode::Fast;
+    constexpr uint32_t tiles_per_batch = get_arg(args::tiles_per_batch);
 
     // Welford must process one column at a time because the SFPU can only maintain
     // a single running mean/M2 state. DEST_AUTO_LIMIT interleaves multiple columns
@@ -41,6 +42,12 @@ void kernel_main() {
                                                                        : compute_kernel_lib::DEST_AUTO_LIMIT);
 
     constexpr uint32_t onetile = 1;
+
+    // A full chunk's reads go out behind a single barrier instead of one barrier per tile, which
+    // would expose the whole read latency on every tile. The host sizes the input CB at two batches
+    // of tiles_per_batch, so a multi-tile reserve is only contiguous while the chunk is exactly that
+    // batch: a row_chunk the host did not predict (the SFPU path shortens it) stays per-tile.
+    constexpr bool batch_reads = row_chunk == tiles_per_batch;
 
     Noc noc;
     // dfb::in0 is the reduce input pipe: this kernel fills it, the compute kernel drains it.
@@ -75,15 +82,31 @@ void kernel_main() {
         uint32_t reset_curr_id = curr_id;
         uint32_t reset_w = w;
         uint32_t reset_col_start = col_start_tile_id;
+        // The tail chunk is shorter than a batch, so it keeps the per-tile path.
+        const bool batch_chunk = batch_reads && (chunk_end - i) == row_chunk;
 
         for (uint32_t j = 0; j < Ht; ++j) {
             w = reset_w;
             col_start_tile_id = reset_col_start;
+            if (batch_chunk) {
+                dfb_in0.reserve_back(row_chunk);
+            }
+            uint32_t slot = 0;
             for (uint32_t k = i; k < chunk_end; ++k) {
-                dfb_in0.reserve_back(onetile);
-                noc.async_read(tensor_accessor, dfb_in0, tile_bytes, {.page_id = curr_id}, {.offset_bytes = 0});
-                noc.async_read_barrier();
-                dfb_in0.push_back(onetile);
+                if (batch_chunk) {
+                    noc.async_read(
+                        tensor_accessor,
+                        dfb_in0,
+                        tile_bytes,
+                        {.page_id = curr_id},
+                        {.offset_bytes = slot * tile_bytes});
+                    ++slot;
+                } else {
+                    dfb_in0.reserve_back(onetile);
+                    noc.async_read(tensor_accessor, dfb_in0, tile_bytes, {.page_id = curr_id}, {.offset_bytes = 0});
+                    noc.async_read_barrier();
+                    dfb_in0.push_back(onetile);
+                }
 
                 ++w;
 
@@ -95,6 +118,10 @@ void kernel_main() {
                     ++curr_id;
                     ++col_start_tile_id;
                 }
+            }
+            if (batch_chunk) {
+                noc.async_read_barrier();
+                dfb_in0.push_back(row_chunk);
             }
             curr_id = reset_curr_id + (j + 1) * Wt;  // stride in H
         }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op.cpp
@@ -217,10 +217,8 @@ Tensor reduce(
     // reduce kernel.
     auto h_reduce_with_external_negate =
         [&](const Tensor& h_input, float h_scaler, float h_post_mul, tt::tt_metal::DataType h_out_dtype) {
-            // Keep neg_input in h_input's memory config (pass std::nullopt) so the
-            // pre-reduce negation stays in place; forcing output_mem_config here
-            // could trigger a reshard (DRAM↔L1, interleaved↔sharded) before the
-            // H-reduce.  Only the final neg enforces output_mem_config.
+            // Each neg inherits its input's memory config.  The final one must inherit h_out rather
+            // than output_mem_config: only h_out's shard shape is recomputed for the reduced height.
             Tensor neg_input = ttnn::neg(h_input, std::nullopt, std::nullopt, sub_core_grids);
             Tensor h_out = ttnn::prim::reduce(
                 neg_input,
@@ -233,7 +231,7 @@ Tensor reduce(
                 sub_core_grids,
                 /*negate=*/false,
                 /*post_mul_scaler=*/h_post_mul);
-            return ttnn::neg(h_out, output_mem_config, std::nullopt, sub_core_grids);
+            return ttnn::neg(h_out, std::nullopt, std::nullopt, sub_core_grids);
         };
 
     // The single-core HW path uses REDUCE_SCALAR mode, which applies the
@@ -287,7 +285,7 @@ Tensor reduce(
             /*row_major_h_dense_path=*/false,
             /*use_sfpu_reduce=*/use_sfpu_fp32_reduce);
 
-        if (negate && !ttnn::prim::h_reduce_negate_fits_in_l1(output_tensor, sub_core_grids)) {
+        if (negate && !ttnn::prim::h_reduce_negate_fits_in_l1(output_tensor, output_mem_config, sub_core_grids)) {
             return h_reduce_with_external_negate(output_tensor, reduce_scaler, post_mul, out_final_dtype);
         }
 
@@ -308,7 +306,7 @@ Tensor reduce(
     }
 
     if (negate && reduce_dim == tt::tt_metal::ReduceOpDim::H &&
-        !ttnn::prim::h_reduce_negate_fits_in_l1(prepared_input, sub_core_grids)) {
+        !ttnn::prim::h_reduce_negate_fits_in_l1(prepared_input, output_mem_config, sub_core_grids)) {
         return h_reduce_with_external_negate(
             prepared_input, reduce_scaler, post_mul, output_dtype.value_or(input_tensor.dtype()));
     }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -133,11 +133,13 @@ void ReduceDeviceOperation::validate_on_program_cache_miss(
         // reaches here is on a tilized path.
         const auto& in_shard = tensor_args.shard_spec().value();
         const auto& input_shard_grid = in_shard.grid;
-        TT_FATAL(
-            program_grid.contains(input_shard_grid),
-            "Input shard grid {} must be contained in program core grid {}",
-            input_shard_grid,
-            program_grid);
+        if (tensor_args.memory_config().is_l1()) {
+            TT_FATAL(
+                program_grid.contains(input_shard_grid),
+                "Input shard grid {} must be contained in program core grid {}",
+                input_shard_grid,
+                program_grid);
+        }
         const uint32_t tile_height = tensor_args.tensor_spec().tile().get_height();
         const uint32_t tile_width = tensor_args.tensor_spec().tile().get_width();
         TT_FATAL(
@@ -164,16 +166,18 @@ void ReduceDeviceOperation::validate_on_program_cache_miss(
         const uint32_t output_tile_height = out_spec.tile().get_height();
         const uint32_t output_tile_width = out_spec.tile().get_width();
 
-        TT_FATAL(
-            program_grid.contains(output_shard_grid),
-            "Output shard grid {} must be contained in program core grid {}",
-            output_shard_grid,
-            program_grid);
-        TT_FATAL(
-            device_grid.contains(output_shard_grid),
-            "Output shard grid {} must be contained in device grid {}",
-            output_shard_grid,
-            device_grid);
+        if (operation_attributes.output_mem_config.is_l1()) {
+            TT_FATAL(
+                program_grid.contains(output_shard_grid),
+                "Output shard grid {} must be contained in program core grid {}",
+                output_shard_grid,
+                program_grid);
+            TT_FATAL(
+                device_grid.contains(output_shard_grid),
+                "Output shard grid {} must be contained in device grid {}",
+                output_shard_grid,
+                device_grid);
+        }
         if (output_nd_shard_spec.shard_shape.rank() >= 2) {
             TT_FATAL(
                 output_nd_shard_spec.shard_shape[-2] > 0 && output_nd_shard_spec.shard_shape[-1] > 0,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -151,6 +151,13 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
     const TensorParamName INPUT_TENSOR{"input"};
     const TensorParamName OUTPUT_TENSOR{"output"};
 
+    // The column reader issues a whole chunk of columns behind one barrier, so batching needs a core
+    // that owns a full chunk.
+    const uint32_t min_cols_per_core = num_cols_per_core_group_2 == 0
+                                           ? num_cols_per_core_group_1
+                                           : std::min(num_cols_per_core_group_1, num_cols_per_core_group_2);
+    const uint32_t reader_tiles_per_batch = min_cols_per_core < chunk_size ? 1u : chunk_size;
+
     ProgramSpec spec;
     spec.name = rm_path ? "reduce_multi_core_h_dense_rm"
                         : (use_width_sharding ? "reduce_multi_core_h_width_sharded" : "reduce_multi_core_h");
@@ -216,7 +223,7 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
             .borrowed_from = INPUT_TENSOR,
         });
     } else {
-        uint32_t num_input_tiles = use_fpu_negate ? chunk_size : 2;
+        uint32_t num_input_tiles = use_fpu_negate ? chunk_size : reduce_reader_input_cb_tiles(reader_tiles_per_batch);
         spec.dataflow_buffers.push_back(DataflowBufferSpec{
             .unique_id = IN_DFB,
             .entry_size = src0_single_tile_size,
@@ -452,6 +459,7 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
             {"scaler_bits", scaler_bits},
             {"use_welford", 0u},
             {"enable_fp32_sfpu", fp32_sfpu_reduce ? 1u : 0u},
+            {"tiles_per_batch", reader_tiles_per_batch},
         };
         reader_rta_names = {"col_start_tile_id", "curr_col_in_batch", "num_cols"};
         // Pass DEST config so reader can compute DEST_AUTO_LIMIT

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -59,8 +59,11 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
 
     tt_metal::IDevice* device = &a.mutable_device();
 
+    // This path runs on the input's shard grid and aliases the input and output CBs onto the
+    // tensors' own buffers; CBs live in L1, so both sides must be width-sharded there.
     bool use_width_sharding = a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED &&
-                              output.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
+                              output.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED &&
+                              a.memory_config().is_l1() && output.memory_config().is_l1();
 
     // Populate the RM-only locals (chunk sizes, page bytes, padding identity, datum sizes) into
     // a single struct so the per-site formulas don't drift between this factory and the W one.

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_h_program_factory.cpp
@@ -59,8 +59,7 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
 
     tt_metal::IDevice* device = &a.mutable_device();
 
-    // This path runs on the input's shard grid and aliases the input and output CBs onto the
-    // tensors' own buffers; CBs live in L1, so both sides must be width-sharded there.
+    // Fast path aliases I/O CBs onto the tensors; CBs are L1-only.
     bool use_width_sharding = a.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED &&
                               output.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED &&
                               a.memory_config().is_l1() && output.memory_config().is_l1();
@@ -151,8 +150,7 @@ ReduceDeviceOperation::ReduceMultiCoreHProgramFactory::create_program_artifacts(
     const TensorParamName INPUT_TENSOR{"input"};
     const TensorParamName OUTPUT_TENSOR{"output"};
 
-    // The column reader issues a whole chunk of columns behind one barrier, so batching needs a core
-    // that owns a full chunk.
+    // The column reader batches a dest chunk; a core that owns fewer columns stays unbatched.
     const uint32_t min_cols_per_core = num_cols_per_core_group_2 == 0
                                            ? num_cols_per_core_group_1
                                            : std::min(num_cols_per_core_group_1, num_cols_per_core_group_2);

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -43,13 +43,14 @@ ReduceDeviceOperation::ReduceMultiCoreWProgramFactory::create_program_artifacts(
     // gathering tiles over the NoC. Needs matching shard grid, height and orientation, plus shards
     // that tile the tensor exactly; anything else falls through to the generic path.
     const uint32_t shard_Ht = a.shard_spec().has_value() ? a.shard_spec()->shape[0] / tile_height : 0;
-    const bool use_height_sharding =
-        !rm_path && a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED &&
-        output.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED && a.shard_spec().has_value() &&
-        output.shard_spec().has_value() && a.shard_spec()->grid == output.shard_spec()->grid &&
-        a.shard_spec()->shape[0] == output.shard_spec()->shape[0] &&
-        a.shard_spec()->orientation == output.shard_spec()->orientation &&
-        shard_Ht * a.shard_spec()->grid.num_cores() == NC * Ht;
+    const bool use_height_sharding = !rm_path && a.memory_config().is_l1() && output.memory_config().is_l1() &&
+                                     a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED &&
+                                     output.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED &&
+                                     a.shard_spec().has_value() && output.shard_spec().has_value() &&
+                                     a.shard_spec()->grid == output.shard_spec()->grid &&
+                                     a.shard_spec()->shape[0] == output.shard_spec()->shape[0] &&
+                                     a.shard_spec()->orientation == output.shard_spec()->orientation &&
+                                     shard_Ht * a.shard_spec()->grid.num_cores() == NC * Ht;
 
     if (rm_path) {
         validate_rm_preconditions(
@@ -183,7 +184,14 @@ ReduceDeviceOperation::ReduceMultiCoreWProgramFactory::create_program_artifacts(
         });
     }
 
-    uint32_t num_input_tiles = 2;
+    // Every core reads its rows whole, so even the smallest core streams rows * Wt tiles.
+    const uint32_t min_rows_per_core = num_rows_per_core_group_2 == 0
+                                           ? num_rows_per_core_group_1
+                                           : std::min(num_rows_per_core_group_1, num_rows_per_core_group_2);
+    const uint32_t reader_tiles_per_batch =
+        rm_path || use_height_sharding ? 1u : reduce_reader_batch(min_rows_per_core * Wt);
+
+    uint32_t num_input_tiles = reduce_reader_input_cb_tiles(reader_tiles_per_batch);
     if (rm_path) {
         num_input_tiles = std::max(num_input_tiles, plan.wt_tiles_per_chunk);
     }
@@ -334,7 +342,9 @@ ReduceDeviceOperation::ReduceMultiCoreWProgramFactory::create_program_artifacts(
         reader_source =
             "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/"
             "reader_unary_reduce_universal_start_id.cpp";
-        reader_ct_args = {{"scaler_bits", std::bit_cast<uint32_t>(operation_attributes.scaler)}};
+        reader_ct_args = {
+            {"scaler_bits", std::bit_cast<uint32_t>(operation_attributes.scaler)},
+            {"tiles_per_batch", reader_tiles_per_batch}};
         reader_rta_names = {"num_tiles", "start_id"};
         reader_dfb_bindings = {
             DFBBinding{

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -188,8 +188,10 @@ ReduceDeviceOperation::ReduceMultiCoreWProgramFactory::create_program_artifacts(
     const uint32_t min_rows_per_core = num_rows_per_core_group_2 == 0
                                            ? num_rows_per_core_group_1
                                            : std::min(num_rows_per_core_group_1, num_rows_per_core_group_2);
-    const uint32_t reader_tiles_per_batch =
-        rm_path || use_height_sharding ? 1u : reduce_reader_batch(min_rows_per_core * Wt);
+    // The fused-negate kernel only profits from batching once a core owns several rows: with one
+    // row per core it measures 18-32% slower batched, and 6-8% faster with two or more.
+    const bool batch_reads = !rm_path && !use_height_sharding && !(use_fpu_negate && min_rows_per_core < 2);
+    const uint32_t reader_tiles_per_batch = batch_reads ? reduce_reader_batch(min_rows_per_core * Wt) : 1u;
 
     uint32_t num_input_tiles = reduce_reader_input_cb_tiles(reader_tiles_per_batch);
     if (rm_path) {

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_multi_core_w_program_factory.cpp
@@ -39,9 +39,8 @@ ReduceDeviceOperation::ReduceMultiCoreWProgramFactory::create_program_artifacts(
     uint32_t Wt = tt::div_up(W, tile_width);
     uint32_t Ht = tt::div_up(H, tile_height);
 
-    // Height-sharded fast path: each core reduces its own L1-resident shard locally instead of
-    // gathering tiles over the NoC. Needs matching shard grid, height and orientation, plus shards
-    // that tile the tensor exactly; anything else falls through to the generic path.
+    // Fast path: each core reduces its L1 shard locally. Needs matching grid/height/orientation
+    // and shards that tile the tensor; otherwise the generic path.
     const uint32_t shard_Ht = a.shard_spec().has_value() ? a.shard_spec()->shape[0] / tile_height : 0;
     const bool use_height_sharding = !rm_path && a.memory_config().is_l1() && output.memory_config().is_l1() &&
                                      a.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED &&
@@ -188,8 +187,7 @@ ReduceDeviceOperation::ReduceMultiCoreWProgramFactory::create_program_artifacts(
     const uint32_t min_rows_per_core = num_rows_per_core_group_2 == 0
                                            ? num_rows_per_core_group_1
                                            : std::min(num_rows_per_core_group_1, num_rows_per_core_group_2);
-    // The fused-negate kernel only profits from batching once a core owns several rows: with one
-    // row per core it measures 18-32% slower batched, and 6-8% faster with two or more.
+    // Fused-negate with one row per core is slower batched.
     const bool batch_reads = !rm_path && !use_height_sharding && !(use_fpu_negate && min_rows_per_core < 2);
     const uint32_t reader_tiles_per_batch = batch_reads ? reduce_reader_batch(min_rows_per_core * Wt) : 1u;
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
@@ -103,7 +103,9 @@ ReduceDeviceOperation::ReduceSingleCoreHwProgramFactory::create_program_artifact
     spec.name = "reduce_single_core_hw";
 
     // ---- Dataflow buffers ----
-    constexpr uint32_t num_input_tiles = 2;
+    // One core streams the whole tensor here, so only a tensor smaller than a batch turns it off.
+    const uint32_t reader_tiles_per_batch = reduce_reader_batch(num_tensor_tiles);
+    const uint32_t num_input_tiles = reduce_reader_input_cb_tiles(reader_tiles_per_batch);
     spec.dataflow_buffers.push_back(DataflowBufferSpec{
         .unique_id = IN_DFB,
         .entry_size = src0_single_tile_size,
@@ -170,7 +172,8 @@ ReduceDeviceOperation::ReduceSingleCoreHwProgramFactory::create_program_artifact
                 },
             },
         .tensor_bindings = {TensorBinding{.tensor_parameter_name = INPUT_TENSOR, .accessor_name = "src"}},
-        .compile_time_args = {{"scaler_bits", std::bit_cast<uint32_t>(scaler)}},
+        .compile_time_args =
+            {{"scaler_bits", std::bit_cast<uint32_t>(scaler)}, {"tiles_per_batch", reader_tiles_per_batch}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_tiles", "start_id"}},
         .hw_config = ttnn::create_reader_datamovement_config(a.device().arch()),
     });

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_single_core_hw_program_factory.cpp
@@ -103,7 +103,7 @@ ReduceDeviceOperation::ReduceSingleCoreHwProgramFactory::create_program_artifact
     spec.name = "reduce_single_core_hw";
 
     // ---- Dataflow buffers ----
-    // One core streams the whole tensor here, so only a tensor smaller than a batch turns it off.
+    // One core owns every tile, so a tensor smaller than a batch stays unbatched.
     const uint32_t reader_tiles_per_batch = reduce_reader_batch(num_tensor_tiles);
     const uint32_t num_input_tiles = reduce_reader_input_cb_tiles(reader_tiles_per_batch);
     spec.dataflow_buffers.push_back(DataflowBufferSpec{

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_program_factory.cpp
@@ -321,6 +321,8 @@ WelfordReduceDeviceOperation::WelfordReduceProgramFactory::create_program_artifa
             {"scaler_bits", scaler_bits},
             {"use_welford", 1u},
             {"enable_fp32_sfpu", 0u},
+            // Welford is compute-bound: batching the reader's tiles measures flat, so it stays off.
+            {"tiles_per_batch", 1u},
         };
         reader_rta_names = {"col_start_tile_id", "curr_col_in_batch", "num_cols"};
     } else {
@@ -328,7 +330,8 @@ WelfordReduceDeviceOperation::WelfordReduceProgramFactory::create_program_artifa
         reader_source =
             "ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/dataflow/"
             "reader_unary_reduce_universal_start_id.cpp";
-        reader_ct_args = {{"scaler_bits", scaler_bits}};
+        // Welford is compute-bound: batching the reader's tiles measures flat, so it stays off.
+        reader_ct_args = {{"scaler_bits", scaler_bits}, {"tiles_per_batch", 1u}};
         reader_rta_names = {"num_tiles", "start_id"};
     }
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions_nanobind.hpp
@@ -81,8 +81,11 @@ inline std::string get_generic_reduction_doc(
 
         Memory Support:
             - Interleaved: DRAM and L1
-            - Sharded (L1): Width, Height, and ND sharding
+            - Sharded (L1): Width, Height, Block, and ND sharding
+            - Sharded (DRAM): Width, Height, and ND sharding
             - Output sharding will mirror the input
+            - Not supported: DRAM block sharding; sharded ROW_MAJOR inputs; and sharded
+              reduction along a dimension other than -1 / -2
         )doc",
         op_name,
         qualified_name,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/std_var_reductions_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/std_var_reductions_nanobind.cpp
@@ -57,8 +57,11 @@ static std::string get_std_var_reduction_doc(const char* op_name, const char* qu
 
         Memory Support:
             - Interleaved: DRAM and L1
-            - Sharded (L1): Width, Height, and ND sharding
+            - Sharded (L1): Width, Height, Block, and ND sharding
+            - Sharded (DRAM): Width, Height, and ND sharding
             - Output sharding will mirror the input
+            - Not supported: DRAM block sharding; sharded ROW_MAJOR inputs; and sharded
+              reduction along a dimension other than -1 / -2
         )doc",
         op_name,
         qualified_name);


### PR DESCRIPTION
### PR Category
Feature — DRAM-sharded input and output for generic reduce + batched reader reads (`sum`/`mean`/`max`/`min`/`std`/`var`), issue [[#43050](https://github.com/tenstorrent/tt-metal/issues/43050)]

## Summary

Generic reduce now accepts DRAM-sharded inputs and outputs.

DRAM sharding uses the same `ShardSpec`, but its grid names DRAM banks — a single row at `y=0` — rather than worker cores. Three places in reduce read that grid as worker cores, so each now branches on buffer type:

- **Grid borrowing** — when a sharded output config has no `shard_spec`, `build_reduce_output_tensor_spec` copies the input's grid. It now rejects that when the two sides are in different memory spaces, on the legacy and ND branches alike.
- **Tensix-grid containment** — checking a shard grid against the compute grid is meaningless for bank ids, so it applies to L1 only. `validate_buffer_parameters` already enforces DRAM's bank-grid rules when the buffer is created.
- **The sharded fast paths** — the H factory's width-sharded path and the W factory's height-sharded path both back their circular buffers with the tensor's own buffer, which only L1 can do, so each now needs L1 on both sides. DRAM tensors take the generic `TensorAccessor` path.

Covers `dim=-1`, `dim=-2` and `dim=(-2,-1)`. `std`/`var` need no change: they share the same validator and have no fast path of their own.

Two changes ride along, both on the generic path that DRAM tensors now take:

- **Batched reader reads** — both reduce readers issued one `async_read` per barrier, so every tile paid the full read latency. They now issue a batch behind one barrier (4 tiles for the universal reader, one DEST chunk for the column reader) with the input CB sized at two batches, keeping every reservation contiguous. A program whose smallest core owns less than a batch stays unbatched, as does the fused-negate W path with a single row per core.
- **Negate L1 gate** — `h_reduce_negate_fits_in_l1` now sizes the program the factory actually builds, so `min` stops falling back to `neg + reduce + neg` when the fused kernel fits, and stops asserting when it doesn't.

## Changes Made

**common.cpp / common.hpp**

- `validate_reduce_sharded_buffer_types` accepts DRAM as well as L1 on both sides.
- `build_reduce_output_tensor_spec` rejects borrowing a shard grid across buffer types. The check runs after confirming the input has a grid at all, so an interleaved input still gets the `requires either nd_shard_spec or shard_spec` message.
- `h_reduce_negate_fits_in_l1` takes an `output_mem_config` and mirrors the H factory's fast-path gate, so its buffer sizing matches the program the factory actually builds.
- `kReduceReaderTilesPerBatch`, `reduce_reader_batch` and `reduce_reader_input_cb_tiles` derive the reader batch and input CB depth from the smallest core's tile count.

**reduce_op.cpp**

- Both `h_reduce_negate_fits_in_l1` call sites pass `output_mem_config`.
- The external-negate fallback's final `neg` inherits `h_out` rather than `output_mem_config`. Only `h_out` has a shard shape recomputed for the reduced height.

**Device operation — reduce_op_device_operation.cpp**

- The input-side and output-side grid-containment checks apply to L1 only.

**Reader kernels**

- `reader_unary_reduce_universal_start_id.cpp` — a single loop issues `tiles_per_batch` reads per barrier and publishes them with one `push_back`; the short final batch takes the same path.
- `reader_unary_transpose_wh_universal_input_cols_partitioned.cpp` — reads a whole column chunk per barrier.

**Program factories**

- `reduce_op_multi_core_h_program_factory.cpp` — `use_width_sharding` also requires `is_l1()` on both sides, so DRAM width-sharded tensors use the generic branch. The reader batches a DEST chunk when the smallest core owns one.
- `reduce_op_multi_core_w_program_factory.cpp` — `use_height_sharding` also requires `is_l1()`. The reader batches when the smallest core streams a full batch (`rows/core × Wt`), except on the fused-negate path with a single row per core, which measures 18-32% slower batched.
- `reduce_op_single_core_hw_program_factory.cpp` / `welford_reduce_program_factory.cpp` — pass the unbatched reader.

**Front end — generic_reductions_nanobind.hpp / std_var_reductions_nanobind.cpp**

- Memory Support gains `Sharded (DRAM): Width, Height, and ND sharding` and an explicit unsupported list. The L1 line gains `Block`, which already worked but was undocumented.

## Tests

**test_reduction_sharded_topology.py** (new, 101 cases)

- `test_reduce_dram_sharded` / `_full_hw_reduce` / `_dtypes` — DRAM-sharded in+out across every op, shard layout, dim and dtype. `_full_hw_reduce` covers every output config the op accepts — interleaved, DRAM-sharded and L1-sharded — since a 1×1 result can stay sharded.
- `test_reduce_dram_sharded_full_bank_width_h_reduce` — a WIDTH_SHARDED grid spanning every DRAM bank. On Wormhole that grid is 12 wide against an 8-wide Tensix grid, so it only passes with the containment check gated to L1.
- `test_reduce_h_width_sharded_mixed_l1_dram` and `_l1_and_dram_use_distinct_programs` — the fast-path gate must key off buffer type per side, and must reach the program-cache key.
- `test_reduce_w_height_sharded_mixed_l1_dram` — the W twin, on a geometry whose shards tile the tensor exactly so buffer type is the only term left deciding the fast path; the geometry itself is asserted so the DRAM cases cannot silently stop covering the gate.
- `test_reduce_dram_nd_sharded` — DRAM ND sharding; the shard shape splits C as well as H and W, so the layout cannot normalize to a legacy one.

## Performance

#### Perf: batched reader reads

Wormhole B0, tile layout, device kernel duration. PR = median of 50 iterations; baseline = median of 27 (3 runs × 9) on a fresh build of the base commit. 
| regime                      | cases | median Δ% | range           |
| --------------------------- | ----: | --------: | --------------- |
| W reader batches            |    28 |    −10.4% | −31.8% .. +4.2% |
| H reader batches            |     4 |     −6.7% | −7.6% .. −6.5%  |
| reader unbatched or Welford |    51 |     −0.0% | −1.8% .. +1.3%  |


<!DOCTYPE html>
S. No | op | dim | config (layout/dtype, in → out) | shape | main µs | PR µs | Δ% | batched by | prog
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | sum | -2 | tile/bf16, WS-L1 → WS-L1 | 1×1×1024×256 | 6.63 | 6.63 | (+0.09%) | H, no batch | Reduce
2 | sum | -1 | tile/bf16, WS-L1 → WS-L1 | 1×1×1024×256 | 14.6 | 14.7 | (+0.65%) | W batched | Reduce
3 | sum | -1 | tile/bf16, WS-L1 → WS-L1 | 1×1×256×2048 | 31.9 | 25.9 | −18.87% | W batched | Reduce
4 | max | -1 | tile/bf16, WS-L1 → WS-L1 | 1×1×256×2048 | 31.9 | 25.7 | −19.70% | W batched | Reduce
5 | sum | -1 | tile/bf16, HS-L1 → HS-L1 | 1×1×1024×256 | 6.25 | 6.25 | (−0.01%) | W, no batch | Reduce
6 | sum | -2 | tile/bf16, HS-L1 → HS-L1 | 1×1×1024×256 | 18.19 | 18.19 | (+0.01%) | H, no batch | Reduce
7 | min | -1 | tile/bf16, HS-L1 → HS-L1 | 1×1×1024×256 | 19.64 | 19.63 | (−0.03%) | W, no batch | Reduce
8 | min | -2 | tile/bf16, HS-L1 → HS-L1 | 1×1×1024×256 | 25.19 | 25.18 | (−0.06%) | H, no batch | Reduce
9 | std | -1 | tile/bf16, HS-L1 → HS-L1 | 1×1×1024×256 | 107.17 | 107.23 | (+0.06%) | welford | WelfordReduce
10 | std | -2 | tile/bf16, HS-L1 → HS-L1 | 1×1×1024×256 | 420.54 | 420.47 | (−0.02%) | welford | WelfordReduce
11 | sum | -1 | tile/bf16, BS-L1 → BS-L1 | 1×1×512×512 | 8.4 | 8.5 | (+0.85%) | W batched | Reduce
12 | sum | -2 | tile/bf16, BS-L1 → BS-L1 | 1×1×512×512 | 12.9 | 13.0 | (+0.39%) | H, no batch | Reduce
13 | max | -1 | tile/bf16, BS-L1 → BS-L1 | 1×1×512×512 | 8.4 | 8.5 | +1.22% | W batched | Reduce
14 | std | -1 | tile/bf16, BS-L1 → BS-L1 | 1×1×512×512 | 212.2 | 212.3 | (+0.06%) | welford | WelfordReduce
15 | std | -2 | tile/bf16, BS-L1 → BS-L1 | 1×1×512×512 | 212.3 | 213.7 | (+0.67%) | welford | WelfordReduce
16 | sum | -1 | tile/bf16, ND-L1 → ND-L1 | 1×4×128×128 | 4.7 | 4.9 | +3.96% | W batched | Reduce
17 | sum | -2 | tile/bf16, ND-L1 → ND-L1 | 1×4×128×128 | 5.13 | 5.10 | (−0.58%) | H, no batch | Reduce
18 | sum | -1 | tile/bf16, IL-DRAM → IL-DRAM | 1×1×1024×256 | 7.5 | 6.3 | −15.47% | W batched | Reduce
19 | sum | HW | tile/bf16, IL-DRAM → IL-DRAM | 1×1×1024×256 | 28.5 | 27.2 | −4.36% | W batched + H, no batch | Reduce+Reduce
20 | mean | -1 | tile/bf16, IL-DRAM → IL-DRAM | 1×1×1024×256 | 7.5 | 6.4 | −14.23% | W batched | Reduce
21 | mean | HW | tile/bf16, IL-DRAM → IL-DRAM | 1×1×1024×256 | 24.9 | 23.5 | −5.51% | W batched + H, no batch | Reduce+Reduce
22 | max | -1 | tile/bf16, IL-DRAM → IL-DRAM | 1×1×1024×256 | 7.5 | 6.4 | −13.96% | W batched | Reduce
23 | max | HW | tile/bf16, IL-DRAM → IL-DRAM | 1×1×1024×256 | 24.8 | 23.5 | −5.10% | H, no batch | Reduce+Reduce
24 | min | -1 | tile/bf16, IL-DRAM → IL-DRAM | 1×1×1024×256 | 8.32 | 8.31 | (−0.17%) | W, no batch | Reduce
25 | min | -2 | tile/bf16, IL-DRAM → IL-DRAM | 1×1×1024×256 | 25.6 | 25.5 | (−0.12%) | H, no batch | Reduce
26 | min | HW | tile/bf16, IL-DRAM → IL-DRAM | 1×1×1024×256 | 33.2 | 33.4 | (+0.35%) | H, no batch | Reduce+Reduce
27 | sum | -1 | tile/fp32, IL-DRAM → IL-DRAM | 1×1×1024×256 | 12.1 | 12.6 | +4.22% | W batched | Reduce
28 | min | -1 | tile/fp32, IL-DRAM → IL-DRAM | 1×1×1024×256 | 12.2 | 12.3 | (+0.97%) | W batched | Reduce
29 | min | -2 | tile/fp32, IL-DRAM → IL-DRAM | 1×1×1024×256 | 27.7 | 27.8 | (+0.40%) | H, no batch | Reduce
30 | sum | -1 | tile/bf8, IL-DRAM → IL-DRAM | 1×1×1024×256 | 5.9 | 4.1 | −31.78% | W batched | Reduce
31 | min | -1 | tile/bf8, IL-DRAM → IL-DRAM | 1×1×1024×256 | 6.81 | 6.80 | (−0.26%) | W, no batch | Reduce
32 | min | -2 | tile/bf8, IL-DRAM → IL-DRAM | 1×1×1024×256 | 24.68 | 24.68 | (+0.02%) | H, no batch | Reduce
33 | min | -1 | tile/bf16, IL-L1 → IL-L1 | 1×1×1024×256 | 6.94 | 6.89 | (−0.68%) | W, no batch | Reduce
34 | min | -2 | tile/bf16, IL-L1 → IL-L1 | 1×1×1024×256 | 25.21 | 25.20 | (−0.01%) | H, no batch | Reduce
35 | sum | -1 | tile/bf16, IL-DRAM → IL-DRAM | 1×1×2048×2048 | 47.2 | 42.3 | −10.37% | W batched | Reduce
36 | sum | -1 | tile/bf16, IL-DRAM → IL-DRAM | 1×1×2048×8192 | 178.0 | 161.3 | −9.36% | W batched | Reduce
37 | max | -1 | tile/bf16, IL-DRAM → IL-DRAM | 1×1×2048×2048 | 47.3 | 42.3 | −10.45% | W batched | Reduce
38 | sum | -2 | tile/bf16, IL-DRAM → IL-DRAM | 1×1×2048×8192 | 171.5 | 160.2 | −6.54% | H batched | Reduce
39 | sum | -2 | tile/bf16, IL-DRAM → IL-DRAM | 1×1×1024×16384 | 174.5 | 162.4 | −6.91% | H batched | Reduce
40 | sum | -2 | tile/bf16, IL-DRAM → IL-DRAM | 1×1×512×32768 | 179.6 | 165.8 | −7.65% | H batched | Reduce
41 | mean | -2 | tile/bf16, IL-DRAM → IL-DRAM | 1×1×2048×8192 | 171.4 | 160.3 | −6.50% | H batched | Reduce
42 | sum | HW | tile/bf16, IL-DRAM → IL-DRAM | 1×1×2048×2048 | 88.1 | 83.1 | −5.62% | W batched + H, no batch | Reduce+Reduce
43 | sum | -1 | tile/fp32, IL-DRAM → IL-DRAM | 1×1×2048×2048 | 91.5 | 89.0 | −2.74% | W batched | Reduce
44 | sum | -1 | tile/bf16, IL-L1 → IL-L1 | 1×1×2048×2048 | 46.4 | 40.4 | −12.94% | W batched | Reduce
45 | sum | -1 | tile/bf16, IL-DRAM → IL-DRAM | 1×1×2048×128 | 7.6 | 5.7 | −25.01% | W batched | Reduce
46 | sum | -1 | tile/bf16, IL-DRAM → IL-DRAM | 1×1×2048×256 | 9.9 | 7.9 | −20.99% | W batched | Reduce
47 | sum | -1 | tile/bf16, IL-DRAM → IL-DRAM | 1×1×2048×512 | 15.0 | 12.8 | −14.48% | W batched | Reduce
48 | sum | -1 | tile/bf16, IL-DRAM → IL-DRAM | 1×1×2048×1024 | 25.7 | 22.5 | −12.42% | W batched | Reduce
49 | sum | -1 | tile/bf16, IL-DRAM → IL-DRAM | 1×1×2048×2048 | 47.4 | 42.3 | −10.81% | W batched | Reduce
50 | sum | -1 | tile/bf16, IL-DRAM → IL-DRAM | 1×1×2048×4096 | 93.0 | 83.3 | −10.49% | W batched | Reduc



#### Perf: negate L1 gate

`ttnn.min` lowers to `-max(-x)` for bf16 and bf8 inputs (int32, and fp32 on the accurate SFPU path, drive a direct MIN instead). Those negations can be applied two ways:

- **Fused** — `reduce_h_neg` negates inline: one device op, at the cost of two circular buffers, `cb_acc` and `cb_ineg`, each `Ht × per-core Wt` tiles.
- **External** — `neg` over the input → plain reduce → `neg` over the output: three device ops, the first reading and rewriting the whole tensor.

`h_reduce_negate_fits_in_l1()` previously used the width-sharded sizing whenever the input was WIDTH_SHARDED L1, even when an interleaved output forced the factory to build the split-across-grid program; matching the estimator to the actual program reduced the estimated CB requirement by 2–4× in the measured cases and enabled the faster fused path.

<!DOCTYPE html>
S. No | op | dim | config (layout/dtype, in → out) | shape | main µs | PR µs | Δ% | batched by | prog
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
1 | min | -2 | tile/bf16, WS-L1 → IL-L1 | 1×1×2048×1024 | 172.5 | 121.6 | −29.49% | H, no batch | Unary+Reduce+Unary → Reduce
2 | min | -2 | tile/bf16, WS-L1 → IL-DRAM | 1×1×2048×1024 | 172.9 | 121.8 | −29.57% | H, no batch | Unary+Reduce+Unary → Reduce
3 | min | -2 | tile/bf16, WS-L1 → IL-L1 | 1×1×2048×1024 | 172.6 | 121.6 | −29.53% | H, no batch | Unary+Reduce+Unary → Reduce
4 | min | -2 | tile/bf16, WS-L1 → IL-DRAM | 1×1×2048×1024 | 173.1 | 121.7 | −29.68% | H, no batch | Unary+Reduce+Unary → Reduce
5 | min | -2 | tile/bf16, WS-L1 → IL-L1 | 1×1×4096×1024 | 172.2 | 133.8 | −22.29% | H, no batch | Unary+Reduce+Unary → Reduce
6 | min | -2 | tile/bf16, WS-L1 → IL-DRAM | 1×1×4096×1024 | 172.5 | 133.6 | −22.54% | H, no batch | Unary+Reduce+Unary → Reduce




### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/43050_reduce_dram_shard_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/43050_reduce_dram_shard_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/43050_reduce_dram_shard_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/43050_reduce_dram_shard_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/43050_reduce_dram_shard_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/43050_reduce_dram_shard_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/43050_reduce_dram_shard_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/43050_reduce_dram_shard_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/43050_reduce_dram_shard_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/43050_reduce_dram_shard_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/43050_reduce_dram_shard_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/43050_reduce_dram_shard_support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/43050_reduce_dram_shard_support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/43050_reduce_dram_shard_support)