### PR TITLE
Run op-validation in the release pipeline

### DIFF
--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -174,15 +174,9 @@ jobs:
             echo "::warning::Report file not found: $REPORT_FILE"
           fi
 
-  # Op-level validation of the packaged release artifacts: install the debs
-  # built by build-artifact and run the tt-metalium / tt-nn validation-basic
-  # gtest binaries (op correctness incl. matmul, eltwise ULP and the
-  # branch-keyed reduction smoke suite) on the SKUs defined in
-  # {runtime,ttnn}_validation_basic_tests.yaml. Same suites as the merge gate's
-  # basic tier, but run against the actual release packages, so a release
-  # cannot ship with broken op kernels while the tier-1 model demos stay green.
-  # Cheap (~15 min per leg), so unlike release-demo-tests it also runs on dry
-  # runs and untagged invocations.
+  # Op-level validation of the packaged artifacts: install the debs and run
+  # the validation-basic gtest binaries. Same tests as in the merge gate,
+  # but run against the actual release packages.
   release-op-validation:
     needs: [build-artifact]
     strategy:

--- a/.github/workflows/release-build-test-publish.yaml
+++ b/.github/workflows/release-build-test-publish.yaml
@@ -174,6 +174,29 @@ jobs:
             echo "::warning::Report file not found: $REPORT_FILE"
           fi
 
+  # Op-level validation of the packaged release artifacts: install the debs
+  # built by build-artifact and run the tt-metalium / tt-nn validation-basic
+  # gtest binaries (op correctness incl. matmul, eltwise ULP and the
+  # branch-keyed reduction smoke suite) on the SKUs defined in
+  # {runtime,ttnn}_validation_basic_tests.yaml. Same suites as the merge gate's
+  # basic tier, but run against the actual release packages, so a release
+  # cannot ship with broken op kernels while the tier-1 model demos stay green.
+  # Cheap (~15 min per leg), so unlike release-demo-tests it also runs on dry
+  # runs and untagged invocations.
+  release-op-validation:
+    needs: [build-artifact]
+    strategy:
+      fail-fast: false
+      matrix:
+        product: [tt-metalium, tt-nn]
+    uses: ./.github/workflows/basic.yaml
+    with:
+      docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
+      package-artifact-name: ${{ needs.build-artifact.outputs.packages-artifact-name }}
+      enabled-skus: ALL_SKUS_IN_TESTS
+      per-test-timeout: 15 # max minutes for any SKU timeout in the basic tests yamls
+      product: ${{ matrix.product }}
+
   # Polls the "RTL Sim CI test" GitHub check on stable HEAD (posted by the
   # tt-umd-simulators polling agent -- GitLab issue #71). Runs in parallel
   # with release-demo-tests so other tests still surface failures, and is


### PR DESCRIPTION
### Problem description

The package-and-release pipeline has limited op-level test coverage. Its only test gate is `release-demo-tests` (tier-1 model demos), so a release can ship with many operations broken, while every demo stays green. Meanwhile the op-correctness suites that already exist (`tt-metalium-validation-basic`, `tt-nn-validation-basic`) are packaged into the release debs themselves.

### What's changed

One new job in `release-build-test-publish.yaml`: `release-op-validation`.

- Same suites as in the merge gate, but against the actual shipped artifacts.
- **Gating**: `package-and-release.yaml`'s `publish-to-pypi` has `needs: [build-test-publish]`, so a failed op test fails the reusable workflow and blocks public PyPI publication, etc. 
- **Runs on every invocation, including dry runs**, but note that this is ≤15 min run, per product SKU

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/release-op-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/release-op-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/release-op-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/release-op-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/release-op-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/release-op-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/release-op-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/release-op-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/release-op-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/release-op-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/release-op-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/release-op-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/release-op-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/release-op-validation)