### PR TITLE
[Performance]: Use NoC for Local L1 copies in FD on Quasar

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -1592,12 +1592,13 @@ public:
         helper.add_paged_dram_read(worker_range, 0, 0, 128, 128, 0);
         helper.add_paged_dram_read(worker_range, 4, dram_alignment, 2048, num_banks_ + 4, 0);
         helper.add_paged_dram_read(worker_range, 5, dram_alignment, 2048, (num_banks_ * 3) + 1, 0);
-        helper.add_paged_dram_read(worker_range, 3, tt::align(128, dram_alignment), 6144, num_banks_ - 1, 0);
-        helper.add_paged_dram_read(worker_range, 3, tt::align(128, dram_alignment), 6144, num_banks_ - 1, 0);
+        const uint32_t num_banks_minus_one = std::max(num_banks_, 2u) - 1;  // 1-bank sim would give 0 pages
+        helper.add_paged_dram_read(worker_range, 3, tt::align(128, dram_alignment), 6144, num_banks_minus_one, 0);
+        helper.add_paged_dram_read(worker_range, 3, tt::align(128, dram_alignment), 6144, num_banks_minus_one, 0);
         helper.add_paged_dram_read(worker_range, 0, 0, 128, 128, 32);
         helper.add_paged_dram_read(worker_range, 4, dram_alignment, 2048, num_banks_ * 2, 1536);
         helper.add_paged_dram_read(worker_range, 5, dram_alignment, 2048, (num_banks_ * 2) + 1, 256);
-        helper.add_paged_dram_read(worker_range, 3, tt::align(128, dram_alignment), 6144, num_banks_ - 1, 640);
+        helper.add_paged_dram_read(worker_range, 3, tt::align(128, dram_alignment), 6144, num_banks_minus_one, 640);
         // Large pages
         helper.add_paged_dram_read(worker_range, 0, 0, DEFAULT_SCRATCH_DB_SIZE / 2 + dram_alignment, 2, 128);
         helper.add_paged_dram_read(worker_range, 0, 0, DEFAULT_SCRATCH_DB_SIZE, 2, 0);

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
@@ -332,6 +332,27 @@ inline __attribute__((always_inline)) uint64_t noc_local_xy() {
     return NOC_XY_COORD(my_x, my_y);
 }
 
+// Per quasar noc spec, a tagged packet prevents the next packet from committing until all previous
+// packets have committed. Tagging just the final transfer therefore guarantees the whole payload is
+// committed before any later same-VC packet to that destination.
+//
+// Persistent command-buffer state, not a per-transaction argument: set it, issue the transfer that
+// should carry it, then clear it. Left set, it tags every subsequent packet on this buffer.
+//
+// Whole-register write (no read-modify-write): assumes sole ownership of PACKET_TAGS on cmd_buf 0/1.
+template <uint32_t cmd_buf>
+inline __attribute__((always_inline)) void noc_set_packet_flush(bool enable) {
+    static_assert(
+        cmd_buf == OVERLAY_WR_CMD_BUF || cmd_buf == OVERLAY_RD_CMD_BUF,
+        "packet-tag flush is only defined for the full command buffers (0/1)");
+    TT_ROCC_CMD_BUF_PACKET_TAGS_reg_u tags;
+    tags.val = 0;
+    tags.f.snoop_bit = 0;
+    tags.f.flush_bit = enable;
+    __builtin_riscv_ttrocc_cmdbuf_wr_reg(
+        cmd_buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PACKET_TAGS_REG_OFFSET / 8, tags.val);
+}
+
 inline __attribute__((always_inline)) void init_wr_cmd_buf(uint64_t my_xy) {
     __builtin_riscv_ttrocc_cmdbuf_reset(OVERLAY_WR_CMD_BUF);
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/noc_nonblocking_api_v2.h
@@ -332,23 +332,25 @@ inline __attribute__((always_inline)) uint64_t noc_local_xy() {
     return NOC_XY_COORD(my_x, my_y);
 }
 
-// Per quasar noc spec, a tagged packet prevents the next packet from committing until all previous
-// packets have committed. Tagging just the final transfer therefore guarantees the whole payload is
-// committed before any later same-VC packet to that destination.
+// snoop asks the destination NIU to raise a cache snoop on receive. flush, per quasar noc spec,
+// prevents the next packet from committing until all previous packets have committed -- so tagging
+// just the final transfer guarantees the whole payload is committed before any later same-VC packet
+// to that destination.
 //
-// Persistent command-buffer state, not a per-transaction argument: set it, issue the transfer that
-// should carry it, then clear it. Left set, it tags every subsequent packet on this buffer.
+// Persistent command-buffer state, not a per-transaction argument: set the tags, issue the transfer
+// that should carry them, then call again with both false. Left set, they tag every subsequent packet
+// on this buffer.
 //
-// Whole-register write (no read-modify-write): assumes sole ownership of PACKET_TAGS on cmd_buf 0/1.
+// Writes the whole register, so a call overwrites the other caller's bit as well as its own.
 template <uint32_t cmd_buf>
-inline __attribute__((always_inline)) void noc_set_packet_flush(bool enable) {
+inline __attribute__((always_inline)) void noc_set_packet_tags(bool snoop, bool flush) {
     static_assert(
         cmd_buf == OVERLAY_WR_CMD_BUF || cmd_buf == OVERLAY_RD_CMD_BUF,
-        "packet-tag flush is only defined for the full command buffers (0/1)");
+        "packet tags are only defined for the full command buffers (0/1)");
     TT_ROCC_CMD_BUF_PACKET_TAGS_reg_u tags;
     tags.val = 0;
-    tags.f.snoop_bit = 0;
-    tags.f.flush_bit = enable;
+    tags.f.snoop_bit = snoop;
+    tags.f.flush_bit = flush;
     __builtin_riscv_ttrocc_cmdbuf_wr_reg(
         cmd_buf, TT_ROCC_ACCEL_TT_ROCC_CPU0_CMD_BUF_R_PACKET_TAGS_REG_OFFSET / 8, tags.val);
 }

--- a/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch.cpp
@@ -594,7 +594,7 @@ void DispatchKernel::CreateKernel() {
     defines["OFFSETOF_ROUTER_DIRECTION"] = std::to_string(static_config_.offsetof_router_direction.value_or(0));
 
     // Compile at Os on IERISC to fit in code region.
-    auto optimization_level = (GetCoreType() == CoreType::WORKER) ? KernelBuildOptLevel::O2 : KernelBuildOptLevel::Os;
+    auto optimization_level = (GetCoreType() == CoreType::ETH) ? KernelBuildOptLevel::Os : KernelBuildOptLevel::O2;
     configure_kernel_variant(dispatch_kernel_file_names[DISPATCH], compile_args, defines, optimization_level);
 }
 

--- a/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/prefetch.cpp
@@ -560,7 +560,7 @@ void PrefetchKernel::CreateKernel() {
     defines["OFFSETOF_ROUTER_DIRECTION"] = std::to_string(static_config_.offsetof_router_direction.value_or(0));
 
     // Compile at Os on IERISC to fit in code region.
-    auto optimization_level = (GetCoreType() == CoreType::WORKER) ? KernelBuildOptLevel::O2 : KernelBuildOptLevel::Os;
+    auto optimization_level = (GetCoreType() == CoreType::ETH) ? KernelBuildOptLevel::Os : KernelBuildOptLevel::O2;
     configure_kernel_variant(dispatch_kernel_file_names[PREFETCH], {}, defines, optimization_level);
 }
 

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -158,9 +158,9 @@ FORCE_INLINE void cq_noc_async_wwrite_with_state(
 
 // More generic version of cq_noc_async_write_with_state: Allows writing an arbitrary amount of data, when the NOC
 // config (dst_noc, VC..) have been specified.
-// flush_last_transfer tags the final transfer so that a credit atomic issued after this call -- typically
-// from CBWriter::release_pages -- cannot commit to L1 ahead of the payload (see noc_set_packet_flush).
-// No-op on tt-1xx, which has no flush bit.
+// flush_last_transfer sets the flush packet tag on the final transfer so that a credit atomic issued after
+// this call -- typically from CBWriter::release_pages -- cannot commit to L1 ahead of the payload.
+// No-op on tt-1xx, which has no packet tags.
 template <
     bool write_last_packet = true,
     bool update_counters = false,
@@ -186,14 +186,14 @@ inline uint32_t cq_noc_async_write_with_state_any_len(
     if constexpr (write_last_packet) {
 #if defined(ARCH_QUASAR)
         if constexpr (flush_last_transfer) {
-            noc_set_packet_flush<cmd_buf>(true);
+            noc_set_packet_tags<cmd_buf>(/*snoop=*/false, /*flush=*/true);
         }
 #endif
         cq_noc_async_write_with_state<CQ_NOC_SnDL, CQ_NOC_WAIT, CQ_NOC_SEND, cmd_buf, update_counters>(
             src_addr, dst_addr, size, ndests, noc);
 #if defined(ARCH_QUASAR)
         if constexpr (flush_last_transfer) {
-            noc_set_packet_flush<cmd_buf>(false);
+            noc_set_packet_tags<cmd_buf>(/*snoop=*/false, /*flush=*/false);
         }
 #endif
         return 0;

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -158,11 +158,15 @@ FORCE_INLINE void cq_noc_async_wwrite_with_state(
 
 // More generic version of cq_noc_async_write_with_state: Allows writing an arbitrary amount of data, when the NOC
 // config (dst_noc, VC..) have been specified.
+// flush_last_transfer tags the final transfer so that a credit atomic issued after this call -- typically
+// from CBWriter::release_pages -- cannot commit to L1 ahead of the payload (see noc_set_packet_flush).
+// No-op on tt-1xx, which has no flush bit.
 template <
     bool write_last_packet = true,
     bool update_counters = false,
     enum CQNocWait wait_first = CQ_NOC_WAIT,
-    uint32_t cmd_buf = NCRISC_WR_CMD_BUF>
+    uint32_t cmd_buf = NCRISC_WR_CMD_BUF,
+    bool flush_last_transfer = false>
 inline uint32_t cq_noc_async_write_with_state_any_len(
     uint32_t src_addr, uint64_t dst_addr, uint32_t size = 0, uint32_t ndests = 1, uint8_t noc = noc_index) {
     if (size > NOC_MAX_BURST_SIZE) {
@@ -180,10 +184,24 @@ inline uint32_t cq_noc_async_write_with_state_any_len(
         }
     }
     if constexpr (write_last_packet) {
+#if defined(ARCH_QUASAR)
+        if constexpr (flush_last_transfer) {
+            noc_set_packet_flush<cmd_buf>(true);
+        }
+#endif
         cq_noc_async_write_with_state<CQ_NOC_SnDL, CQ_NOC_WAIT, CQ_NOC_SEND, cmd_buf, update_counters>(
             src_addr, dst_addr, size, ndests, noc);
+#if defined(ARCH_QUASAR)
+        if constexpr (flush_last_transfer) {
+            noc_set_packet_flush<cmd_buf>(false);
+        }
+#endif
         return 0;
     } else {
+        static_assert(
+            !flush_last_transfer,
+            "flush_last_transfer requires write_last_packet: this call does not issue the final transfer, so there "
+            "is nothing to tag here. Tag it at the call that does.");
         return size;
     }
 }
@@ -397,12 +415,10 @@ public:
             }
         }
 #endif
-#ifdef ARCH_QUASAR
-        Semaphore<programmable_core_type>(downstream_sem_id).up(n);
-#else
         noc_semaphore_inc(
-            get_noc_addr_helper(downstream_noc_xy, get_semaphore<programmable_core_type>(downstream_sem_id)), n, noc_idx);
-#endif
+            get_noc_addr_helper(downstream_noc_xy, get_semaphore<programmable_core_type>(downstream_sem_id)),
+            n,
+            noc_idx);
     }
 
     uint32_t additional_count{0};

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -28,6 +28,8 @@
 
 // FABRIC_RELAY is defined exactly when !is_hd(), so this catches an _h/_d build.
 // Quasar FD assumes prefetcher and dispatcher share a Tensix; remote-chip support needs cross-Tensix verification.
+// That includes payload-before-credit ordering: these builds relay over fabric, where the NoC packet flush tag
+// this file relies on does not apply.
 #if defined(ARCH_QUASAR) && defined(FABRIC_RELAY)
 #error "Quasar FD supports the _hd prefetcher only; the split _h/_d variants are not supported yet."
 #endif
@@ -913,6 +915,9 @@ static uint32_t process_relay_inline_noflush_cmd(uintptr_t cmd_ptr, uint32_t& di
     if (dispatch_data_ptr == downstream_cb_end) {
         dispatch_data_ptr = downstream_cb_base;
     }
+    // On Quasar these writes carry no flush tag: this routine does not release the page, so the header
+    // and the payload that follows are published by one release_pages, and the flush on the payload's
+    // last transfer covers all packets before it.
     uint32_t remaining = cmddat_q_end - data_ptr;
     if (cmddat_wrap_enable && length > remaining) {
         // wrap cmddat

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -26,6 +26,12 @@
 #include "api/debug/dprint.h"
 #include "noc/noc_parameters.h"  // PCIE_ALIGNMENT
 
+// FABRIC_RELAY is defined exactly when !is_hd(), so this catches an _h/_d build.
+// Quasar FD assumes prefetcher and dispatcher share a Tensix; remote-chip support needs cross-Tensix verification.
+#if defined(ARCH_QUASAR) && defined(FABRIC_RELAY)
+#error "Quasar FD supports the _hd prefetcher only; the split _h/_d variants are not supported yet."
+#endif
+
 #include <array>
 #include <cstdint>
 
@@ -264,6 +270,11 @@ struct DispatchSRelayInlineState {
     static constexpr uint32_t downstream_log_page_size = dispatch_s_cb_log_page_size;
     static constexpr uint32_t downstream_cb_base_addr = dispatch_s_buffer_base;
     static constexpr uint32_t downstream_cb_end_addr = dispatch_s_buffer_end;
+    // tt-1xx has a separate cmd buf for small writes, so this state keeps its own DEST_COORD there. Quasar has
+    // only one full write buffer, so this aliases onto cmd buf 0 and shares DispatchRelayInlineState's
+    // DEST_COORD, which cq_noc_async_write_init_state programs once (CQ_NOC_SnDL does not refresh it). Safe
+    // only while dispatch_s is co-resident with the dispatcher, so both init calls write the same coordinate.
+    // TODO: revisit when the FD command-buffer policy is reworked.
     static constexpr uint32_t downstream_write_cmd_buf = BRISC_WR_REG_CMD_BUF;
     static constexpr uint32_t downstream_noc_index = my_noc_index;
     static inline CBWriter<
@@ -349,30 +360,6 @@ bool process_cmd(
     uint32_t* l1_cache,
     PrefetchExecBufState& exec_buf_state);
 
-#ifdef ARCH_QUASAR
-// Same-core copy: L1->L1 memcpy through the L1 uncached alias, used when prefetcher and dispatcher are on
-// the same core.
-FORCE_INLINE void local_copy_bytes(uintptr_t dst_addr, uintptr_t src_addr, uint32_t num_bytes, uint32_t dst_end) {
-    ASSERT((src_addr & 0x3u) == 0);
-    ASSERT((dst_addr & 0x3u) == 0);
-    ASSERT(dst_addr + num_bytes <= dst_end);
-    volatile uint32_t tt_l1_ptr* dst_ptr = uncached_l1_ptr<uint32_t>(dst_addr);
-    volatile uint32_t tt_l1_ptr* src_ptr = uncached_l1_ptr<uint32_t>(src_addr);
-    const uint32_t words = num_bytes >> 2;
-    for (uint32_t i = 0; i < words; ++i) {
-        dst_ptr[i] = src_ptr[i];
-    }
-    const uint32_t tail_bytes = num_bytes & 0x3u;
-    if (tail_bytes != 0) {
-        volatile uint8_t tt_l1_ptr* dst_tail = uncached_l1_ptr<uint8_t>(dst_addr + (words << 2));
-        volatile uint8_t tt_l1_ptr* src_tail = uncached_l1_ptr<uint8_t>(src_addr + (words << 2));
-        for (uint32_t i = 0; i < tail_bytes; ++i) {
-            dst_tail[i] = src_tail[i];
-        }
-    }
-}
-#endif
-
 template <uint32_t downstream_cb_base_addr, uint32_t downstream_cmd_buf>
 FORCE_INLINE void write_downstream(
     uintptr_t& data_ptr,
@@ -388,8 +375,6 @@ FORCE_INLINE void write_downstream(
                 static_cast<uint32_t>(data_ptr),
                 get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr),
                 remaining);
-#elif defined(ARCH_QUASAR)
-            local_copy_bytes(local_downstream_data_ptr, data_ptr, remaining, downstream_end);
 #else
             cq_noc_async_write_with_state_any_len<true, true, CQNocWait::CQ_NOC_WAIT, downstream_cmd_buf>(
                 static_cast<uint32_t>(data_ptr),
@@ -407,10 +392,13 @@ FORCE_INLINE void write_downstream(
         static_cast<uint32_t>(data_ptr),
         get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr),
         length);
-#elif defined(ARCH_QUASAR)
-    local_copy_bytes(local_downstream_data_ptr, data_ptr, length, downstream_end);
 #else
-    cq_noc_async_write_with_state_any_len<true, true, CQNocWait::CQ_NOC_WAIT, downstream_cmd_buf>(
+    cq_noc_async_write_with_state_any_len<
+        true,
+        true,
+        CQNocWait::CQ_NOC_WAIT,
+        downstream_cmd_buf,
+        /*flush_last_transfer=*/true>(
         static_cast<uint32_t>(data_ptr),
         get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr),
         length);
@@ -928,21 +916,13 @@ static uint32_t process_relay_inline_noflush_cmd(uintptr_t cmd_ptr, uint32_t& di
     uint32_t remaining = cmddat_q_end - data_ptr;
     if (cmddat_wrap_enable && length > remaining) {
         // wrap cmddat
-#if defined(ARCH_QUASAR)
-        local_copy_bytes(dispatch_data_ptr, data_ptr, remaining, downstream_cb_end);
-#else
         noc_async_write(
             static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
-#endif
         dispatch_data_ptr += remaining;
         length -= remaining;
         data_ptr = cmddat_q_base;
     }
-#if defined(ARCH_QUASAR)
-    local_copy_bytes(dispatch_data_ptr, data_ptr, length, downstream_cb_end);
-#else
     noc_async_write(static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
-#endif
     dispatch_data_ptr += length;
 
     return cmd->relay_inline.stride;
@@ -963,35 +943,36 @@ static uint32_t write_pages_to_dispatcher(
         DispatchRelayInlineState::cb_writer.acquire_pages(npages);
     }
 
-    [[maybe_unused]] uint64_t noc_addr;
+    uint64_t noc_addr;
     if (downstream_data_ptr == downstream_cb_end) {
         downstream_data_ptr = downstream_cb_base;
     } else if (downstream_data_ptr + amt_to_write > downstream_cb_end) {  // wrap
         uint32_t last_chunk_size = downstream_cb_end - downstream_data_ptr;
-#if defined(FABRIC_RELAY) || !defined(ARCH_QUASAR)
         noc_addr = get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr);
-#endif
 #if defined(FABRIC_RELAY)
         noc_async_write(scratch_write_addr, noc_addr, last_chunk_size);
-#elif defined(ARCH_QUASAR)
-        local_copy_bytes(downstream_data_ptr, scratch_write_addr, last_chunk_size, downstream_cb_end);
 #else
-        cq_noc_async_write_with_state_any_len<true, true>(scratch_write_addr, noc_addr, last_chunk_size);
+        cq_noc_async_write_with_state_any_len<
+            true,
+            true,
+            CQNocWait::CQ_NOC_WAIT,
+            DispatchRelayInlineState::downstream_write_cmd_buf>(scratch_write_addr, noc_addr, last_chunk_size);
 #endif
         downstream_data_ptr = downstream_cb_base;
         scratch_write_addr += last_chunk_size;
         amt_to_write -= last_chunk_size;
     }
-#if defined(FABRIC_RELAY) || !defined(ARCH_QUASAR)
     noc_addr = get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr);
-#endif
 
 #if defined(FABRIC_RELAY)
     noc_async_write(scratch_write_addr, noc_addr, amt_to_write);
-#elif defined(ARCH_QUASAR)
-    local_copy_bytes(downstream_data_ptr, scratch_write_addr, amt_to_write, downstream_cb_end);
 #else
-    cq_noc_async_write_with_state_any_len<true, true>(scratch_write_addr, noc_addr, amt_to_write);
+    cq_noc_async_write_with_state_any_len<
+        true,
+        true,
+        CQNocWait::CQ_NOC_WAIT,
+        DispatchRelayInlineState::downstream_write_cmd_buf,
+        /*flush_last_transfer=*/true>(scratch_write_addr, noc_addr, amt_to_write);
 #endif
     downstream_data_ptr += amt_to_write;
 
@@ -2001,10 +1982,12 @@ static uint32_t process_exec_buf_relay_inline_noflush_cmd(
 #if defined(FABRIC_RELAY)
         noc_async_write(
             static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
-#elif defined(ARCH_QUASAR)
-        local_copy_bytes(dispatch_data_ptr, data_ptr, remaining, downstream_cb_end);
 #else
-        cq_noc_async_write_with_state_any_len<true, true>(
+        cq_noc_async_write_with_state_any_len<
+            true,
+            true,
+            CQNocWait::CQ_NOC_WAIT,
+            DispatchRelayInlineState::downstream_write_cmd_buf>(
             static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
 #endif
         dispatch_data_ptr += remaining;
@@ -2023,10 +2006,12 @@ static uint32_t process_exec_buf_relay_inline_noflush_cmd(
 
 #if defined(FABRIC_RELAY)
     noc_async_write(static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
-#elif defined(ARCH_QUASAR)
-    local_copy_bytes(dispatch_data_ptr, data_ptr, length, downstream_cb_end);
 #else
-    cq_noc_async_write_with_state_any_len<true, true>(
+    cq_noc_async_write_with_state_any_len<
+        true,
+        true,
+        CQNocWait::CQ_NOC_WAIT,
+        DispatchRelayInlineState::downstream_write_cmd_buf>(
         static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
 #endif
     dispatch_data_ptr += length;
@@ -3058,13 +3043,10 @@ void kernel_main_d() {
         num_hops,
         NCRISC_WR_CMD_BUF>(get_noc_addr_helper(downstream_noc_xy, 0), my_dev_id, to_dev_id, router_direction);
 #else
-#if !defined(ARCH_QUASAR)
-    // On Quasar, relay to the dispatcher is a same-core uncached memcpy; no NOC init-state needed.
     cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, DispatchRelayInlineState::downstream_write_cmd_buf>(
         0, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), 0, 1, my_noc_index);
     cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, DispatchSRelayInlineState::downstream_write_cmd_buf>(
         0, get_noc_addr_helper(dispatch_s_noc_xy, downstream_data_ptr_s), 0, 1, my_noc_index);
-#endif
 #endif
 
     // Initialize cmd_ptr tracking for release_pages synchronization assertions
@@ -3116,13 +3098,10 @@ void kernel_main_hd() {
     uint32_t l1_cache[l1_cache_elements_rounded];
     PrefetchExecBufState exec_buf_state;
 
-#if !defined(ARCH_QUASAR)
-    // On Quasar, relay to the dispatcher is a same-core uncached memcpy; no NOC init-state needed.
     cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, DispatchRelayInlineState::downstream_write_cmd_buf>(
         0, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), 0);
     cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, DispatchSRelayInlineState::downstream_write_cmd_buf>(
         0, get_noc_addr_helper(dispatch_s_noc_xy, downstream_data_ptr_s), 0);
-#endif
 
     while (!done) {
         DeviceZoneScopedN("CQ-PREFETCH");


### PR DESCRIPTION
### PR Category
Performance

### Summary
Currently, on Quasar, local copies from prefetcher to dispatcher in FD is very slow. Uncached accesses are slow so this loop dominates the command period.
                                                                                                                                                                                                                     This PR routes the local copies via NoC write path instead already used on Blackhole/Wormhole. The credit atomic that follows the payload now also travels the NoC along the same VC, so a new NoC flush bit (`noc_set_packet_flush`) is set on each write's last packet - same-VC traffic arrives in order on Quasar but can still commit to L1 out of order, so the flush bit stops the credit from landing ahead of its payload.

Measured on `RelayLinearPayloadSweep` (Quasar simulator, n=99):

| Payload | Before (period, cyc) | After (period, cyc) | Speedup |
|---|---:|---:|---:|
| 32 KB | 500,817.8 | 2,417.5 | 207× |
| 48 KB | 749,720.9 | 2,467.2 | 304× |

### Notes for reviewers
- Check the flush bit is set on the last packet only of each transfer (`write_downstream`, `write_pages_to_dispatcher`) - it persists in cmd buf state, so leaving it set tags every later packet and collapses bandwidth
- Also added correct optimization flag for dispatch engines kernels.
- The prefetcher's downstream write sites now name `DispatchRelayInlineState::downstream_write_cmd_buf` instead of a `NCRISC_WR_CMD_BUF`, value identical on every arch, no behavior change.


Runtime perf tests: https://github.com/tenstorrent/tt-metal/actions/runs/32174911004
Runtime unit tests: https://github.com/tenstorrent/tt-metal/actions/runs/32174843722

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadkarni/fd_qsr_noc_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadkarni/fd_qsr_noc_opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadkarni/fd_qsr_noc_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadkarni/fd_qsr_noc_opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadkarni/fd_qsr_noc_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadkarni/fd_qsr_noc_opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadkarni/fd_qsr_noc_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadkarni/fd_qsr_noc_opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadkarni/fd_qsr_noc_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadkarni/fd_qsr_noc_opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadkarni/fd_qsr_noc_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadkarni/fd_qsr_noc_opt)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadkarni/fd_qsr_noc_opt)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadkarni/fd_qsr_noc_opt)