### PR TITLE
[skip ci] [Cleanup] Fix ttnn.where and ttnn.where_bw docs and examples

### DIFF
--- a/tests/ttnn/docs_examples/test_pointwise_ternary_examples.py
+++ b/tests/ttnn/docs_examples/test_pointwise_ternary_examples.py
@@ -61,19 +61,19 @@ def test_mac(device):
 
 
 def test_where(device):
-    # Create condition tensor and two value tensors
-    tensor1 = ttnn.from_torch(
-        torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device
+    # Create predicate tensor of 0's and 1's and two value tensors
+    predicate = ttnn.from_torch(
+        torch.tensor([[1, 0], [0, 1]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device
     )
-    tensor2 = ttnn.from_torch(
+    true_value = ttnn.from_torch(
         torch.tensor([[5, 6], [7, 8]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device
     )
-    tensor3 = ttnn.from_torch(
+    false_value = ttnn.from_torch(
         torch.tensor([[9, 10], [11, 12]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device
     )
 
-    # Perform the where operation
-    output = ttnn.where(tensor1, tensor2, tensor3)
+    # Perform the where operation, giving [[5, 10], [11, 8]]
+    output = ttnn.where(predicate, true_value, false_value)
     logger.info(f"Where result: {output}")
 
 
@@ -137,22 +137,25 @@ def test_addcdiv_bw(device):
 
 
 def test_where_bw(device):
-    # Create three tensors and a gradient tensor for the operation
+    # Create the forward inputs, with a predicate of 0's and 1's, and a gradient tensor
     grad_tensor = ttnn.from_torch(
         torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device
     )
-    tensor1 = ttnn.from_torch(
-        torch.tensor([[1, 0], [1, 0]], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device
+    predicate = ttnn.from_torch(
+        torch.tensor([[1, 0], [1, 0]], dtype=torch.bfloat16), layout=ttnn.TILE_LAYOUT, device=device
     )
-    tensor2 = ttnn.from_torch(
-        torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device
+    true_value = ttnn.from_torch(
+        torch.tensor([[5, 6], [7, 8]], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device
     )
-    tensor3 = ttnn.from_torch(
-        torch.tensor([[1, 2], [3, 4]], dtype=torch.bfloat16, requires_grad=True), layout=ttnn.TILE_LAYOUT, device=device
+    false_value = ttnn.from_torch(
+        torch.tensor([[9, 10], [11, 12]], dtype=torch.bfloat16, requires_grad=True),
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
     )
 
-    # Perform the where backward operation
-    output = ttnn.where_bw(grad_tensor, tensor1, tensor2, tensor3)
+    # Perform the where backward operation. Each gradient depends only on grad_tensor and the predicate,
+    # giving [[1, 0], [3, 0]] for true_value and [[0, 2], [0, 4]] for false_value
+    output = ttnn.where_bw(grad_tensor, predicate, true_value, false_value)
     logger.info(f"Where Backward result: {output}")
 
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/ternary_nanobind.cpp
@@ -28,9 +28,9 @@ void bind_ternary_where(nb::module_& mod, const std::string& description) {
             {2}
 
         Args:
-            condition (ttnn.Tensor): the condition tensor must contain only 0's or 1's.
-            true_value (ttnn.Tensor or Number): The value selected if the corresponding element in condition is 1.
-            false_value (ttnn.Tensor or Number): The value selected if the corresponding element in condition is 0.
+            predicate (ttnn.Tensor): the predicate tensor must contain only 0's or 1's.
+            true_value (ttnn.Tensor or Number): The value selected if the corresponding element in predicate is 1.
+            false_value (ttnn.Tensor or Number): The value selected if the corresponding element in predicate is 0.
 
 
         Keyword Args:
@@ -399,7 +399,7 @@ void py_module(nb::module_& mod) {
         "FLOAT32, BFLOAT16, BFLOAT8_B");
     bind_ternary_where(
         mod,
-        R"doc(Selects elements from :attr:`true_value` or :attr:`false_value` depending on the corresponding value in :attr:`condition`. For each element, if the corresponding entry in :attr:`condition` is 1, the output element is taken from :attr:`true_value`; otherwise, it is taken from :attr:`false_value`.)doc");
+        R"doc(Selects elements from :attr:`true_value` or :attr:`false_value` depending on the corresponding value in :attr:`predicate`. For each element, if the corresponding entry in :attr:`predicate` is 1, the output element is taken from :attr:`true_value`; otherwise, it is taken from :attr:`false_value`.)doc");
 
     bind_ternary_lerp(
         mod,

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary_backward/ternary_backward_nanobind.cpp
@@ -106,21 +106,29 @@ void py_module(nb::module_& mod) {
         R"doc(
         Performs backward operations for where of :attr:`input_tensor_a`, :attr:`input_tensor_b` and :attr:`input_tensor_c` with given :attr:`grad_tensor`.
 
+        The three input tensors are the arguments of a forward `ttnn.where` call, with :attr:`input_tensor_a` as its predicate,
+        and :attr:`grad_tensor` is the gradient with respect to the output of that call, so its elements line up one to one
+        with that output. The forward `ttnn.where` copies each output element from :attr:`input_tensor_b` where the predicate
+        is 1 and from :attr:`input_tensor_c` where the predicate is 0, so each element of :attr:`grad_tensor` belongs to
+        whichever tensor supplied the element in that position. This function returns (up to) two gradients derived from
+        :attr:`grad_tensor` split by the predicate: `where(predicate, grad_tensor, 0)` and `where(predicate, 0, grad_tensor)`.
+        The values of :attr:`input_tensor_b` and :attr:`input_tensor_c` do not affect the result.
+
 
         Args:
-            grad_tensor (ttnn.Tensor): the input gradient tensor.
-            input_tensor_a (ttnn.Tensor): the input tensor.
-            input_tensor_b (ttnn.Tensor): the input tensor.
-            input_tensor_c (ttnn.Tensor): the input tensor.
+            grad_tensor (ttnn.Tensor): the gradient with respect to the output of the forward `ttnn.where` call.
+            input_tensor_a (ttnn.Tensor): the predicate tensor of the forward `ttnn.where` call, containing only 0's or 1's.
+            input_tensor_b (ttnn.Tensor): the true_value tensor of the forward `ttnn.where` call.
+            input_tensor_c (ttnn.Tensor): the false_value tensor of the forward `ttnn.where` call.
 
         Keyword args:
             memory_config (ttnn.MemoryConfig, optional): memory configuration for the operation. Defaults to `None`.
-            are_required_outputs (List[bool], optional): list of required outputs. Defaults to `[True, True]`.
-            input_a_grad (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
-            input_b_grad (ttnn.Tensor, optional): preallocated output tensor. Defaults to `None`.
+            are_required_outputs (List[bool], optional): which output gradients to compute. A `False` entry skips that gradient, and the returned list holds `None` in its place. Defaults to `[True, True]`.
+            input_a_grad (ttnn.Tensor, optional): preallocated tensor to hold the first of the two results (corresponding to :attr:`input_tensor_b`). Defaults to `None`.
+            input_b_grad (ttnn.Tensor, optional): preallocated tensor to hold the second of the two results (corresponding to :attr:`input_tensor_c`). Defaults to `None`.
 
         Returns:
-            List of ttnn.Tensor: the output tensor.
+            List of ttnn.Tensor: the gradients with respect to :attr:`input_tensor_b` and :attr:`input_tensor_c`, or `None` if the corresponding entry in :attr:`are_required_outputs` is `False`.
 
 
         Note:


### PR DESCRIPTION
### Summary
The `ttnn.where` example on the docs site used a condition tensor of `[[1, 2], [3, 4]]`, which breaks the documented rule that the condition holds only 0's or 1's. Every element being nonzero also made the whole result come from `true_value`, so the example didn't demonstrate selection from the other parameter. The docs named the first parameter `condition`, but the keyword in the binding is `predicate`. `ttnn.where_bw` documented all three inputs as "the input tensor" and gave no explanation of what it computes.

This PR improves the documentation and examples to address these issues

### Notes for reviewers
Docstrings and example bodies only, no functional change. The examples are injected into the docs pages from `tests/ttnn/docs_examples/` by `docs/source/ttnn/_ext/doc_modifier.py`, so the example edits change the published pages for `ttnn.where` and `ttnn.where_bw`.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fplavec/fix_where_doc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fplavec/fix_where_doc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fplavec/fix_where_doc)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fplavec/fix_where_doc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fplavec/fix_where_doc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fplavec/fix_where_doc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fplavec/fix_where_doc)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fplavec/fix_where_doc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fplavec/fix_where_doc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fplavec/fix_where_doc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fplavec/fix_where_doc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fplavec/fix_where_doc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fplavec/fix_where_doc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fplavec/fix_where_doc)