### PR TITLE
Test Only: reduction test cleanup: repeated tests, stale skips, masked negative tests

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_min_max.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_min_max.py
@@ -17,19 +17,13 @@ TEST_PADDING_VALUE = -42
 
 
 @pytest.mark.parametrize(
-    "shape_dim",
+    "shape",
     (
-        ((1, 1, 32, 32), 3),
-        ((1, 2, 32, 32), 3),
-        ((2, 3, 32, 32), 3),
-        ((1, 1, 32, 32), 2),
-        ((1, 2, 32, 32), 2),
-        ((2, 3, 32, 32), 2),
-        ((32, 32, 32, 32), 1),
-        ((32, 32, 32, 32), 0),
-        ((32, 32, 32, 32), 2),
-        ((32, 32, 32, 32), 3),
-        ((1, 2, 18, 20), 3),
+        (1, 1, 32, 32),
+        (1, 2, 32, 32),
+        (2, 3, 32, 32),
+        (32, 32, 32, 32),
+        (1, 2, 18, 20),
     ),
 )
 @pytest.mark.parametrize(
@@ -47,8 +41,9 @@ TEST_PADDING_VALUE = -42
         ttnn.TILE_LAYOUT,
     ),
 )
-def test_min_max_for_dim_hw(device, shape_dim, kind, layout):
-    shape, dim = shape_dim
+def test_min_max_mean_global(device, shape, kind, layout):
+    # Global (dim=None) reduces only; per-dim min/max/mean coverage lives in the
+    # unit tier (test_max.py, test_reduction_min.py, test_reduction_mean.py).
     torch.manual_seed(0)
 
     N = shape[0]

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_op_corners.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_op_corners.py
@@ -501,9 +501,7 @@ def test_accumulation(device, tensor_shape, dim, dtype, layout, op):
     ), f"Preallocated {op} result: {prealloc_result} does not match non-preallocated: {ttnn_result_in_torch}"
 
 
-@pytest.mark.parametrize(
-    "tensor_shape", [(), (1, 1, 32, 64), (1, 1, 0, 64), (1, 1, 15, 23), (2, 2, 32, 64), (1, 1, 0, 64)]
-)
+@pytest.mark.parametrize("tensor_shape", [(), (1, 1, 32, 64), (1, 1, 0, 64), (1, 1, 15, 23), (2, 2, 32, 64)])
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
 def test_moe(device, tensor_shape, dtype, layout):

--- a/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_argmax.py
@@ -50,7 +50,6 @@ def _argmax_row_major_wide_reduce_last_dim():
     return [
         _case([64, 128], RM, -1, True, torch.float32),
         _case([64, 128], RM, -1, False, torch.int32),
-        _case([64, 128], RM, -1, True, torch.float32),
         _case([32, 64, 128], RM, -1, True, torch.float32),
         _case([32, 64, 128], RM, -1, True, torch.bfloat16),
         _case([32, 64, 128], TL, -1, False, torch.bfloat16),

--- a/tests/ttnn/unit_tests/operations/reduce/test_cumprod.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_cumprod.py
@@ -201,8 +201,12 @@ def test_cumprod_preallocated(dim, shape, dtypes, device):
         pytest.skip(f"skipping for dim == {dim} and shape == {shape}")
 
 
+# The preallocated `out` tensor must live on device: the on-device check in
+# validate_output_tensor fires before any other validation, so a host `out`
+# would mask the check each row targets. Each row asserts the exact message of
+# the check it exercises.
 @pytest.mark.parametrize(
-    "dim, input_shape, output_shape, torch_dtype, input_dtype, output_dtype, memory_config, layout",
+    "dim, input_shape, output_shape, torch_dtype, input_dtype, output_dtype, memory_config, layout, error_msg",
     [
         (
             -10,
@@ -213,6 +217,7 @@ def test_cumprod_preallocated(dim, shape, dtypes, device):
             ttnn.bfloat16,
             ttnn.DRAM_MEMORY_CONFIG,
             ttnn.Layout.TILE,
+            "The requested accumulation axis is -10, while the input tensor has rank 9",
         ),  # input_rank vs dim
         (
             10,
@@ -223,6 +228,7 @@ def test_cumprod_preallocated(dim, shape, dtypes, device):
             ttnn.bfloat16,
             ttnn.DRAM_MEMORY_CONFIG,
             ttnn.Layout.TILE,
+            "The requested accumulation axis is 10, while the input tensor has rank 9",
         ),  # input_rank vs dim
         (
             3,
@@ -233,6 +239,7 @@ def test_cumprod_preallocated(dim, shape, dtypes, device):
             ttnn.bfloat16,
             ttnn.DRAM_MEMORY_CONFIG,
             ttnn.Layout.TILE,
+            "Shape mismatch: input tensor shape",
         ),  # input_shape vs output_shape
         (
             3,
@@ -243,6 +250,7 @@ def test_cumprod_preallocated(dim, shape, dtypes, device):
             ttnn.bfloat16,
             ttnn.DRAM_MEMORY_CONFIG,
             ttnn.Layout.TILE,
+            "Shape mismatch: input tensor shape",
         ),  # input_shape vs output_shape
         (
             3,
@@ -253,6 +261,7 @@ def test_cumprod_preallocated(dim, shape, dtypes, device):
             ttnn.bfloat16,
             ttnn.DRAM_MEMORY_CONFIG,
             ttnn.Layout.ROW_MAJOR,
+            "The provided input tensor has a non-tile layout: ROW_MAJOR",
         ),  # unsupported layout
     ],
 )
@@ -265,13 +274,15 @@ def test_cumprod_failing_cases(
     output_dtype,
     memory_config,
     layout,
+    error_msg,
     device,
+    expect_error,
 ):
     torch.manual_seed(0)
     torch_input_tensor = torch.randn(input_shape, dtype=torch_dtype)
     ttnn_input_tensor = ttnn.from_torch(
         torch_input_tensor, dtype=input_dtype, layout=layout, device=device, memory_config=memory_config
     )
-    ttnn_preallocated_tensor = ttnn.zeros(output_shape, dtype=output_dtype)
-    with pytest.raises(RuntimeError):
+    ttnn_preallocated_tensor = ttnn.zeros(output_shape, dtype=output_dtype, layout=ttnn.Layout.TILE, device=device)
+    with expect_error(RuntimeError, error_msg):
         ttnn.cumprod(ttnn_input_tensor, memory_config=memory_config, dim=dim, out=ttnn_preallocated_tensor)

--- a/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_cumsum.py
@@ -183,8 +183,12 @@ def test_cumsum_backward(size, dim, dtypes, device):
     assert_cumsum_quality(torch_input_tensor.grad, tt_input_grad_cpu)
 
 
+# The preallocated `out` tensor must live on device: the on-device check in
+# validate_output_tensor fires before any other validation, so a host `out`
+# would mask the check each row targets. Each row asserts the exact message of
+# the check it exercises.
 @pytest.mark.parametrize(
-    "dim, input_shape, output_shape, torch_dtype, input_dtype, output_dtype, memory_config, layout",
+    "dim, input_shape, output_shape, torch_dtype, input_dtype, output_dtype, memory_config, layout, error_msg",
     [
         (
             -10,
@@ -195,6 +199,7 @@ def test_cumsum_backward(size, dim, dtypes, device):
             ttnn.bfloat16,
             ttnn.DRAM_MEMORY_CONFIG,
             ttnn.Layout.TILE,
+            "The requested accumulation axis is -10, while the input tensor has rank 9",
         ),  # input_rank vs dim
         (
             10,
@@ -205,6 +210,7 @@ def test_cumsum_backward(size, dim, dtypes, device):
             ttnn.bfloat16,
             ttnn.DRAM_MEMORY_CONFIG,
             ttnn.Layout.TILE,
+            "The requested accumulation axis is 10, while the input tensor has rank 9",
         ),  # input_rank vs dim
         (
             3,
@@ -215,6 +221,7 @@ def test_cumsum_backward(size, dim, dtypes, device):
             ttnn.bfloat16,
             ttnn.DRAM_MEMORY_CONFIG,
             ttnn.Layout.TILE,
+            "Shape mismatch: input tensor shape",
         ),  # input_shape vs output_shape
         (
             3,
@@ -225,6 +232,7 @@ def test_cumsum_backward(size, dim, dtypes, device):
             ttnn.bfloat16,
             ttnn.DRAM_MEMORY_CONFIG,
             ttnn.Layout.TILE,
+            "Shape mismatch: input tensor shape",
         ),  # input_shape vs output_shape
         (
             3,
@@ -235,6 +243,7 @@ def test_cumsum_backward(size, dim, dtypes, device):
             ttnn.bfloat16,
             ttnn.DRAM_MEMORY_CONFIG,
             ttnn.Layout.ROW_MAJOR,
+            "The provided input tensor has a non-tile layout: ROW_MAJOR",
         ),  # unsupported layout
     ],
 )
@@ -247,13 +256,15 @@ def test_cumsum_failing_cases(
     output_dtype,
     memory_config,
     layout,
+    error_msg,
     device,
+    expect_error,
 ):
     torch.manual_seed(0)
     torch_input_tensor = torch.randn(input_shape, dtype=torch_dtype)
     ttnn_input_tensor = ttnn.from_torch(
         torch_input_tensor, dtype=input_dtype, layout=layout, device=device, memory_config=memory_config
     )
-    ttnn_preallocated_tensor = ttnn.zeros(output_shape, dtype=output_dtype)
-    with pytest.raises(RuntimeError):
+    ttnn_preallocated_tensor = ttnn.zeros(output_shape, dtype=output_dtype, layout=ttnn.Layout.TILE, device=device)
+    with expect_error(RuntimeError, error_msg):
         ttnn.cumsum(ttnn_input_tensor, memory_config=memory_config, dim=dim, out=ttnn_preallocated_tensor)

--- a/tests/ttnn/unit_tests/operations/reduce/test_ema.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_ema.py
@@ -5,7 +5,6 @@
 import pytest
 import torch
 from loguru import logger
-from models.common.utility_functions import is_watcher_enabled
 
 import ttnn
 from tests.ttnn.utils_for_testing import assert_numeric_metrics
@@ -18,9 +17,6 @@ TEST_PADDING_VALUE = -42
     [(2048, 2, 4096, 0, 0), (2048, 2, 4096, 4, 4), (10, 3, 18, 0, 0)],  # base case  # custom grid  # implicit padding
 )
 def test_ema(device, T, B, C, cores_y, cores_x):
-    if T == 2048 and B == 2 and C == 4096 and is_watcher_enabled():
-        pytest.skip("Skipping test due to watcher being enabled, github issue #37021")
-
     torch.manual_seed(0)
 
     grid_size = ttnn.CoreGrid(y=cores_y, x=cores_x) if cores_y > 0 and cores_x > 0 else None

--- a/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
@@ -254,8 +254,10 @@ def test_std_row_major(device, input_shape, dim):
     output_tensor = ttnn.to_torch(output_tensor)
 
     # test for equivalance
-    # Tolerances match the TILE-layout welford std/var tests in test_reduction.py;
-    # bf16 outputs cannot meet 1e-06/1e-09 (sub-ULP) bounds.
+    # Tolerances lifted from test_reduction.py::test_std: an RM input is tilized and dispatched
+    # to the same welford_reduce primitive as a TILE input (generic_reductions.cpp), so the TILE
+    # bounds apply. check_ulp keeps its default (False) like the sibling; bf16 outputs cannot
+    # meet the previous 1e-06/1e-09 (sub-ULP) bounds.
     assert_numeric_metrics(
         torch_output_tensor,
         output_tensor,
@@ -291,8 +293,10 @@ def test_var_row_major(device, input_shape, dim):
     output_tensor = ttnn.to_torch(output_tensor)
 
     # test for equivalance
-    # Tolerances match the TILE-layout welford std/var tests in test_reduction.py;
-    # bf16 outputs cannot meet 1e-06/1e-09 (sub-ULP) bounds.
+    # Tolerances lifted from test_reduction.py::test_var: an RM input is tilized and dispatched
+    # to the same welford_reduce primitive as a TILE input (generic_reductions.cpp), so the TILE
+    # bounds apply. check_ulp keeps its default (False) like the sibling; bf16 outputs cannot
+    # meet the previous 1e-06/1e-09 (sub-ULP) bounds.
     assert_numeric_metrics(
         torch_output_tensor,
         output_tensor,

--- a/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
@@ -254,10 +254,9 @@ def test_std_row_major(device, input_shape, dim):
     output_tensor = ttnn.to_torch(output_tensor)
 
     # test for equivalance
-    # Tolerances lifted from test_reduction.py::test_std: an RM input is tilized and dispatched
+    # Tolerances taken from test_reduction.py::test_std: an RM input is tilized and dispatched
     # to the same welford_reduce primitive as a TILE input (generic_reductions.cpp), so the TILE
-    # bounds apply. check_ulp keeps its default (False) like the sibling; bf16 outputs cannot
-    # meet the previous 1e-06/1e-09 (sub-ULP) bounds.
+    # bounds apply. check_ulp keeps its default (False) like the TILE version.
     assert_numeric_metrics(
         torch_output_tensor,
         output_tensor,

--- a/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
@@ -229,7 +229,6 @@ def test_min_row_major(device, input_shape, dim, keepdim):
     )
 
 
-@pytest.mark.skip(reason="Skipping std test due to issue #32830")
 @pytest.mark.parametrize(
     "input_shape, dim",
     [
@@ -255,18 +254,18 @@ def test_std_row_major(device, input_shape, dim):
     output_tensor = ttnn.to_torch(output_tensor)
 
     # test for equivalance
+    # Tolerances match the TILE-layout welford std/var tests in test_reduction.py;
+    # bf16 outputs cannot meet 1e-06/1e-09 (sub-ULP) bounds.
     assert_numeric_metrics(
         torch_output_tensor,
         output_tensor,
         pcc_threshold=0.99,
-        rtol=1e-06,
-        atol=1e-06,
-        frobenius_threshold=1e-09,
-        check_ulp=True,
+        rtol=0.01,
+        atol=0.01,
+        frobenius_threshold=0.007,
     )
 
 
-@pytest.mark.skip(reason="Skipping var test due to issue #32830")
 @pytest.mark.parametrize(
     "input_shape, dim",
     [
@@ -292,14 +291,15 @@ def test_var_row_major(device, input_shape, dim):
     output_tensor = ttnn.to_torch(output_tensor)
 
     # test for equivalance
+    # Tolerances match the TILE-layout welford std/var tests in test_reduction.py;
+    # bf16 outputs cannot meet 1e-06/1e-09 (sub-ULP) bounds.
     assert_numeric_metrics(
         torch_output_tensor,
         output_tensor,
         pcc_threshold=0.99,
-        rtol=1e-06,
-        atol=1e-06,
-        frobenius_threshold=1e-09,
-        check_ulp=True,
+        rtol=0.01,
+        atol=0.01,
+        frobenius_threshold=0.007,
     )
 
 

--- a/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_row_major_reduce.py
@@ -262,7 +262,7 @@ def test_std_row_major(device, input_shape, dim):
         pcc_threshold=0.99,
         rtol=0.01,
         atol=0.01,
-        frobenius_threshold=0.007,
+        frobenius_threshold=0.005,
     )
 
 


### PR DESCRIPTION
### Problem description

Cleanup pass over reduction nightly tests, fixing:

1. Several tests are skipped although the blocking issue is now fixed
2. Duplicated test cases
3. Wrong validation method

### What's changed

- Un-skip std/var RM and relax their tolerances from sub-ULP bounds to the proven TILE-sibling values from `test_reduction.py`. The original bounds demanded bit-identical outputs; the sibling values are the tolerances the same Welford kernel is already held to on TILE inputs.
- Remove the ema watcher skip
- Deduplicate the argmax and moe tests
- Collapse nightly `test_min_max.py` to 5 unique shapes : identical coverage; per-dim min/max/mean coverage lives in the Sanity tier, and rename to `test_min_max_mean_global`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/reduction-test-hygiene)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/reduction-test-hygiene)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/reduction-test-hygiene)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/reduction-test-hygiene)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/reduction-test-hygiene)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/reduction-test-hygiene)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/reduction-test-hygiene)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/reduction-test-hygiene)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/reduction-test-hygiene)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/reduction-test-hygiene)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/reduction-test-hygiene)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/reduction-test-hygiene)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/reduction-test-hygiene)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/reduction-test-hygiene)