### PR TITLE
[ttml] gumbel_sample device optimizations: fused SFPI noise chain, distributed merge, approx log (−54% e2e)

### DIFF
--- a/tt-train/sources/ttml/metal/ops/gumbel_sample/device/gumbel_sample_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/gumbel_sample/device/gumbel_sample_program_factory.cpp
@@ -5,6 +5,7 @@
 #include "gumbel_sample_program_factory.hpp"
 
 #include <algorithm>
+#include <array>
 #include <bit>
 #include <cmath>
 #include <cstdint>
@@ -43,26 +44,27 @@ constexpr auto kOutputStagingCbIndex = tt::CBIndex::c_3;
 constexpr auto kRecordsCbIndex = tt::CBIndex::c_4;
 
 // Boundary-row partials exchanged between cores: [valid, row, 32 maxima, 32 indices]
-// padded to 288 bytes, two per core (a core's first and last row). Bounded by core
-// count, never by shape -- see writer_gumbel_sample.cpp.
+// padded to 288 bytes. Each split row is merged by the core holding its FIRST tile, so a core
+// sends at most one record (its first row's shard) and receives at most the row's shard fan-in --
+// see writer_gumbel_sample.cpp.
 constexpr uint32_t kRecordBytes = 72U * sizeof(uint32_t);
-constexpr uint32_t kRecordsPerCore = 2U;
 
 const std::string kDoLogitsMaskDefineKey = "DO_LOGITS_MASK";
 const std::string kDoGumbelNoiseDefineKey = "DO_GUMBEL_NOISE";
 const std::string kDoPositionsDefineKey = "DO_POSITIONS";
 
-// The reader carries Ht as a runtime arg at slot 4 (see reader_gumbel_sample.cpp), so the positions
-// BUFFER ADDRESS that follows sits one slot later than the writer's. These two MUST diverge --
-// bumping them together would make the writer read its core_index as the positions address.
+// The reader carries Ht as a runtime arg at slot 4 (see reader_gumbel_sample.cpp), the writer does
+// not, so the positions BUFFER ADDRESS lands at a different slot in each kernel. These two MUST
+// stay independent -- equalizing them would make one kernel read a neighbouring arg as the
+// positions address.
 constexpr uint32_t kReaderHtIdx = 4U;
 constexpr uint32_t kReaderPositionsBufferIdx = 5U;
-constexpr uint32_t kWriterPositionsBufferIdx = 4U;
+constexpr uint32_t kWriterPositionsBufferIdx = 3U;
 static_assert(kReaderPositionsBufferIdx == kReaderHtIdx + 1U);
 
 // Per-entry token positions live in a small device TENSOR, not in runtime args. Each core stages the
-// whole local list into L1 once at kernel start (the origin core needs all of it to re-derive target
-// rows during the boundary merge).
+// whole local list into L1 once at kernel start (slots are indexed by absolute entry id, so the full
+// list keeps the addressing uniform even though only local entries are consumed).
 constexpr auto kReaderPositionsCbIndex = tt::CBIndex::c_5;
 constexpr auto kWriterPositionsCbIndex = tt::CBIndex::c_6;
 
@@ -237,6 +239,47 @@ tt::tt_metal::Program build_program(
     const uint32_t score_tile_bytes = tt::tile_size(tt::DataFormat::Float32);
 
     // -------------------------------------------------------------------------
+    // Split-row merge routing. The owner of a row is the core holding its FIRST tile; the split
+    // hands each core one contiguous tile range, so a core can hold a foreign shard only of its
+    // first row (=> at most one record to send) and can own a split row only as its last (=> one
+    // wait). Senders to a given owner are enumerated in core order, which hands each one a
+    // collision-free slot in the owner's records CB. Derived from the same core_layout as the
+    // work-split runtime args, so the two can never disagree.
+    // -------------------------------------------------------------------------
+    const auto work = core_layout(layout);
+    std::vector<uint32_t> expected_shards(layout.num_cores, 0U);
+    std::vector<std::array<uint32_t, 3U>> send_routing(layout.num_cores, {0U, 0U, 0U});  // x, y, slot
+    for (uint32_t sender = 1U; sender < layout.num_cores; ++sender) {
+        if (work[sender].start_tile % layout.Wt == 0U) {
+            continue;  // first row starts here: nothing to send
+        }
+        const uint32_t row_first_tile = (work[sender].start_tile / layout.Wt) * layout.Wt;
+        uint32_t owner = sender - 1U;
+        while (work[owner].start_tile > row_first_tile) {
+            --owner;
+        }
+        const auto owner_phys = logits.device()->worker_core_from_logical_core(work[owner].core);
+        send_routing[sender] = {
+            static_cast<uint32_t>(owner_phys.x), static_cast<uint32_t>(owner_phys.y), expected_shards[owner]};
+        ++expected_shards[owner];
+    }
+    const uint32_t max_foreign_shards = *std::max_element(expected_shards.begin(), expected_shards.end());
+    // Every sender's run BEGINS strictly inside the owned row's Wt tiles, and consecutive starts
+    // are at least the smaller group's tile count apart, which bounds the fan-in by the split
+    // rather than the core count. The CB is sized from the exact fan-in above; this guards the
+    // derivation against a work-split change.
+    const uint32_t min_tiles_per_core =
+        layout.core_group_2.ranges().empty()
+            ? layout.tiles_per_core_group_1
+            : std::min(layout.tiles_per_core_group_1, layout.tiles_per_core_group_2);
+    TT_FATAL(
+        max_foreign_shards <= (layout.Wt - 1U) / std::max(min_tiles_per_core, 1U) + 1U,
+        "GumbelSample: merge fan-in {} exceeds the split-derived bound (Wt={}, min tiles/core={})",
+        max_foreign_shards,
+        layout.Wt,
+        min_tiles_per_core);
+
+    // -------------------------------------------------------------------------
     // Circular buffers. Peak L1 is a handful of tiles regardless of V: this is the whole point of
     // the fusion -- avoiding materializing several full [B, 1, tokens, V] tensors in DRAM.
     // -------------------------------------------------------------------------
@@ -261,14 +304,15 @@ tt::tt_metal::Program build_program(
         tt::DataFormat::UInt32,
         tt::constants::TILE_HEIGHT * kOutputSlotBytes);
 
-    // Boundary-row partials. Every core reserves the FULL table so the origin can receive each
-    // core's records at that core's own offset -- a fixed 2 records per core, independent of shape.
+    // Boundary-row partials: `max_foreign_shards` receive slots for the one row this core may own,
+    // plus one staging slot for the record it may send. Sized by the actual split fan-in (a few
+    // records), never by the core count.
     create_circular_buffer_bytes(
         program,
         layout.all_cores,
         kRecordsCbIndex,
         tt::DataFormat::UInt32,
-        layout.num_cores * kRecordsPerCore * kRecordBytes);
+        (max_foreign_shards + 1U) * kRecordBytes);
 
     // Positions staging. One ALIGNED page per entry, not four packed bytes: a DRAM read moves a
     // whole aligned page, and the NOC requires the L1 destination to match the DRAM alignment
@@ -329,10 +373,9 @@ tt::tt_metal::Program build_program(
     shared_vars.reader_kernel_id =
         create_reader_kernel(program, layout.all_cores, reader_ct_args, defines, kReaderKernelPath);
 
-    // Origin core (index 0) merges the boundary rows; the others signal it once each.
+    // Each split row's owner counts its senders on its own copy of this semaphore; cores that own
+    // nothing never wait on it.
     const uint32_t reduction_sem_id = tt::tt_metal::CreateSemaphore(program, layout.all_cores, 0);
-    const auto origin_logical = tt::tt_metal::CoreCoord{0, 0};
-    const auto origin_phys = logits.device()->worker_core_from_logical_core(origin_logical);
 
     std::vector<uint32_t> writer_ct_args{
         layout.Wt,
@@ -346,10 +389,8 @@ tt::tt_metal::Program build_program(
         // guard is ever refactored away.
         layout.position_aware ? 1U : layout.logical_tokens,
         layout.position_aware ? 1U : layout.Ht,
-        layout.num_cores,
         reduction_sem_id,
-        static_cast<uint32_t>(origin_phys.x),
-        static_cast<uint32_t>(origin_phys.y),
+        max_foreign_shards,
         layout.num_entries};
     tt::tt_metal::TensorAccessorArgs(output_buffer).append_to(writer_ct_args);
     if (layout.position_aware) {
@@ -383,8 +424,8 @@ tt::tt_metal::Program build_program(
     // unconditionally, exactly as it does for Ht.
     const uint32_t positions_address = layout.position_aware ? tensor_args.positions->buffer()->address() : 0U;
 
-    uint32_t core_index = 0U;
-    for (const auto& [core, num_tiles, start_tile] : core_layout(layout)) {
+    for (uint32_t core_index = 0U; core_index < layout.num_cores; ++core_index) {
+        const auto& [core, num_tiles, start_tile] = work[core_index];
         SetRuntimeArgs(
             program,
             shared_vars.reader_kernel_id,
@@ -400,7 +441,14 @@ tt::tt_metal::Program build_program(
             program,
             shared_vars.writer_kernel_id,
             core,
-            {output_buffer->address(), num_tiles, start_tile, core_index, positions_address});
+            {output_buffer->address(),
+             num_tiles,
+             start_tile,
+             positions_address,
+             send_routing[core_index][0],
+             send_routing[core_index][1],
+             send_routing[core_index][2],
+             expected_shards[core_index]});
 
         const auto compute_kernel = layout.core_group_1.contains(core) ? shared_vars.compute_kernel_group_1_id
                                                                        : shared_vars.compute_kernel_group_2_id;
@@ -413,7 +461,6 @@ tt::tt_metal::Program build_program(
              rand_scale_bits,
              inv_temperature_bits,
              rand_stream_id(layout, device_index, start_tile)});
-        ++core_index;
     }
 
     shared_vars.core_group_1 = layout.core_group_1;
@@ -494,8 +541,9 @@ void GumbelSampleProgramFactory::override_runtime_arguments(
                                     ? compute_g1_args
                                     : GetRuntimeArgs(program, vars.compute_kernel_group_2_id);
 
-        // core_index is not re-patched here: it is a property of the work split, which is identical
-        // on every dispatch. Only the buffer addresses and the seed change.
+        // The merge routing (owner coords, slot, expected shard count) is not re-patched here: it
+        // is a property of the work split, which is identical on every dispatch. Only the buffer
+        // addresses and the seed change.
         for (const auto& [core, num_tiles, start_tile] : work) {
             {
                 auto& core_args = reader_args[core.x][core.y];

--- a/tt-train/sources/ttml/metal/ops/gumbel_sample/device/gumbel_sample_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/gumbel_sample/device/gumbel_sample_program_factory.cpp
@@ -44,9 +44,9 @@ constexpr auto kOutputStagingCbIndex = tt::CBIndex::c_3;
 constexpr auto kRecordsCbIndex = tt::CBIndex::c_4;
 
 // Boundary-row partials exchanged between cores: [valid, row, 32 maxima, 32 indices]
-// padded to 288 bytes. Each split row is merged by the core holding its FIRST tile, so a core
-// sends at most one record (its first row's shard) and receives at most the row's shard fan-in --
-// see writer_gumbel_sample.cpp.
+// padded to 288 bytes; valid and row are watcher/debug breadcrumbs the merge never reads. Each
+// split row is merged by the core holding its FIRST tile, so a core sends at most one record (its
+// first row's shard) and receives at most the row's shard fan-in -- see writer_gumbel_sample.cpp.
 constexpr uint32_t kRecordBytes = 72U * sizeof(uint32_t);
 
 const std::string kDoLogitsMaskDefineKey = "DO_LOGITS_MASK";
@@ -74,9 +74,13 @@ constexpr auto kWriterPositionsCbIndex = tt::CBIndex::c_6;
 //
 // The UPPER bound : `rand_tile` produces values on a CLOSED interval [from, from + scale],
 // so U == 1.0 is attainable, and then log(1) = 0, -log(0) = +inf, g = +inf, which pins the
-// argmax onto that token with certainty. It is a ~2^-32-per-element event, but it is a real one, so
-// here the top of the range is the largest float32 strictly below 1.0 and g stays finite (max
-// ~16.6).
+// argmax onto that token with certainty. It is a ~2^-32-per-element event, but it is a real one,
+// so here the top of the range is the largest float32 strictly below 1.0 and g stays FINITE --
+// that finiteness is the point of the bound. The ceiling itself is ~16.6 with an exact log; the
+// approximate log in gumbel_sfpu.h caps it lower, near 13.75.
+//
+// gumbel_sfpu.h's approximate log drops its zero guard on the strength of exactly these bounds --
+// change them only together with that header.
 constexpr float kGumbelUniformLowerBound = 0x1p-32F;
 constexpr float kGumbelUniformUpperBound = 0x1.fffffep-1F;  // nextafterf(1.0F, 0.0F)
 
@@ -377,6 +381,10 @@ tt::tt_metal::Program build_program(
     // nothing never wait on it.
     const uint32_t reduction_sem_id = tt::tt_metal::CreateSemaphore(program, layout.all_cores, 0);
 
+    // Keep this count in step with TensorAccessorArgs<7> in writer_gumbel_sample.cpp -- the
+    // accessor offset is hard-coded there and the positions accessor chains off it, so a mismatch
+    // misdecodes the accessor words (page size read as the config flags) instead of failing to
+    // compile.
     std::vector<uint32_t> writer_ct_args{
         layout.Wt,
         layout.logical_vocab,

--- a/tt-train/sources/ttml/metal/ops/gumbel_sample/device/gumbel_sample_program_factory.cpp
+++ b/tt-train/sources/ttml/metal/ops/gumbel_sample/device/gumbel_sample_program_factory.cpp
@@ -62,15 +62,18 @@ constexpr uint32_t kReaderHtIdx = 4U;
 constexpr uint32_t kReaderPositionsBufferIdx = 5U;
 constexpr uint32_t kWriterPositionsBufferIdx = 3U;
 static_assert(kReaderPositionsBufferIdx == kReaderHtIdx + 1U);
+// The writer's merge routing (owner x/y, send slot, expected shards) occupies the four slots after
+// the positions address.
+constexpr uint32_t kWriterMergeRoutingArgs = 4U;
 // Logical token count, appended LAST in both kernels so every earlier slot keeps its index. It
 // bounds the position clamp in both kernels (they consume disjoint bit fields of the SAME clamped
 // value, so both need it). A RUNTIME arg for the same reason Ht is: it derives from the token
 // dimension, which the program hash normalizes away in position mode -- as a compile-time arg it
 // would put every prompt length back on the JIT-miss path.
 constexpr uint32_t kReaderLogicalTokensIdx = 6U;
-constexpr uint32_t kWriterLogicalTokensIdx = 5U;
+constexpr uint32_t kWriterLogicalTokensIdx = 8U;
 static_assert(kReaderLogicalTokensIdx == kReaderPositionsBufferIdx + 1U);
-static_assert(kWriterLogicalTokensIdx == kWriterPositionsBufferIdx + 1U);
+static_assert(kWriterLogicalTokensIdx == kWriterPositionsBufferIdx + kWriterMergeRoutingArgs + 1U);
 
 // Per-entry token positions live in a small device TENSOR, not in runtime args. Each core stages the
 // whole local list into L1 once at kernel start (slots are indexed by absolute entry id, so the full
@@ -395,7 +398,7 @@ tt::tt_metal::Program build_program(
     // nothing never wait on it.
     const uint32_t reduction_sem_id = tt::tt_metal::CreateSemaphore(program, layout.all_cores, 0);
 
-    // Keep this count in step with TensorAccessorArgs<7> in writer_gumbel_sample.cpp -- the
+    // Keep this count in step with TensorAccessorArgs<6> in writer_gumbel_sample.cpp -- the
     // accessor offset is hard-coded there and the positions accessor chains off it, so a mismatch
     // misdecodes the accessor words (page size read as the config flags) instead of failing to
     // compile.

--- a/tt-train/sources/ttml/metal/ops/gumbel_sample/device/kernels/compute/gumbel_sample_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/gumbel_sample/device/kernels/compute/gumbel_sample_kernel.cpp
@@ -4,17 +4,17 @@
 
 // Fused Gumbel-max sampling, compute half.
 //
-// Per vocab tile this kernel does, entirely inside DST, what a composite sample would spell as five
-// separate ttnn ops (rand -> log -> neg -> log -> neg -> mul -> add -> sub):
+// Per vocab tile this kernel does, entirely inside DST, what a composite sample would spell as a
+// chain of separate ttnn ops (rand -> log -> neg -> log -> neg -> mul -> add -> sub):
 //
 //     score = logits * (1 / temperature) + (-log(-log(U)))  [ - padding_mask ]
 //
 // and hands the score tile straight to the writer, which folds it into a running per-row argmax.
 // Nothing [B, 1, tokens, V]-sized is ever written to DRAM.
 //
-// The noise chain itself is two SFPU passes over DST, not seven: rand_tile draws the raw uniforms,
-// then one op-local SFPI sweep (gumbel_sfpu.h) folds both logs, both negations, the temperature
-// scale and the add into LREGs, storing each score datum exactly once.
+// The noise chain is two SFPU passes over DST: rand_tile draws the raw uniforms, then one op-local
+// SFPI sweep (gumbel_sfpu.h) folds both logs, both negations, the temperature scale and the add
+// into LREGs, storing each score datum exactly once.
 
 #include <cstdint>
 
@@ -109,8 +109,9 @@ void kernel_main() {
                 if constexpr (do_gumbel_noise) {
                     // ---- pass 1: U ~ Uniform[from, from + scale] into the score slot ----
                     // rand_tile stays a standalone pass: the PRNG's per-tile draw order defines the
-                    // reproducible noise stream, and the generator owns LREG0-6 plus replay slots
-                    // 0-16 while it runs, so nothing may interleave with it.
+                    // reproducible noise stream, and rand owns the mutable LREG file (LREG0-7),
+                    // programs const LREG12/13 on Wormhole, and a 16-instruction replay row;
+                    // nothing may interleave with it (see ckernel_sfpu_rand.h).
                     rand_tile(score_reg, rand_from_bits, rand_scale_bits);
 
                     copy_tile_init(cb_logits);
@@ -122,6 +123,9 @@ void kernel_main() {
                     // The init reprograms what rand_tile left behind (counters, SFPU config);
                     // the fused pass itself relies on no replay slots or const LREGs.
                     gumbel_score_tile_init();
+                    // The offset template arg is unsigned, so a reversed pair would wrap into a
+                    // silent out-of-bounds DST read rather than a negative offset.
+                    static_assert(operand_reg > score_reg, "logits tile must sit above the noise tile in DST");
                     gumbel_score_tile<operand_reg - score_reg>(score_reg, inv_temperature_bits);
                 } else {
                     // ---- greedy (temperature == 0): the logits ARE the scores ----

--- a/tt-train/sources/ttml/metal/ops/gumbel_sample/device/kernels/compute/gumbel_sample_kernel.cpp
+++ b/tt-train/sources/ttml/metal/ops/gumbel_sample/device/kernels/compute/gumbel_sample_kernel.cpp
@@ -11,22 +11,25 @@
 //
 // and hands the score tile straight to the writer, which folds it into a running per-row argmax.
 // Nothing [B, 1, tokens, V]-sized is ever written to DRAM.
+//
+// The noise chain itself is two SFPU passes over DST, not seven: rand_tile draws the raw uniforms,
+// then one op-local SFPI sweep (gumbel_sfpu.h) folds both logs, both negations, the temperature
+// scale and the add into LREGs, storing each score datum exactly once.
 
 #include <cstdint>
 
 #include "api/compute/bcast.h"  // unary_bcast, for the [1, V] padding mask
 #include "api/compute/cb_api.h"
-#include "api/compute/compute_kernel_api.h"  // log_tile, pack_tile, tile_regs_*
+#include "api/compute/compute_kernel_api.h"  // pack_tile, tile_regs_*
 #include "api/compute/compute_kernel_hw_startup.h"
 #include "api/compute/eltwise_binary_sfpu.h"
-#include "api/compute/eltwise_unary/binop_with_scalar.h"  // mul_unary_tile
 #include "api/compute/eltwise_unary/eltwise_unary.h"
-#include "api/compute/eltwise_unary/negative.h"
 #include "api/compute/eltwise_unary/rand.h"
 #include "api/compute/pack.h"
 #include "api/compute/reconfig_data_format.h"
 #include "api/compute/reg_api.h"
 #include "api/compute/tile_move_copy.h"
+#include "gumbel_sfpu.h"  // gumbel_score_tile, the fused noise/scale/add pass
 
 constexpr uint32_t num_tiles = get_compile_time_arg_val(0);
 constexpr uint32_t block_size = get_compile_time_arg_val(1);
@@ -77,6 +80,9 @@ void kernel_main() {
     compute_kernel_hw_startup(cb_logits, cb_scores);
     init_sfpu(cb_logits, cb_scores);
 
+    // The packer only ever emits cb_scores, so its format is loop-invariant.
+    pack_reconfig_data_format(cb_scores);
+
     // One init for the whole core: the LFSR then advances monotonically across every rand_tile call
     // below. Combined with the (device, core) specific stream id this makes the noise reproducible
     // for a given seed and work split, and disjoint across cores and data-parallel devices.
@@ -101,31 +107,22 @@ void kernel_main() {
                 tile_regs_acquire();
 
                 if constexpr (do_gumbel_noise) {
-                    // ---- Gumbel noise: g = -log(-log(U)), U ~ Uniform[from, from + scale] ----
-                    //
-                    // Every SFPU step below re-runs its *_init. That is not boilerplate: rand_tile
-                    // records replay slots 0-15/0-16 and (on Wormhole) programs LREG12/LREG13, so
-                    // any SFPU op that follows it must reprogram what it depends on. Dropping these
-                    // inits would leave log/neg reading whatever rand left behind.
+                    // ---- pass 1: U ~ Uniform[from, from + scale] into the score slot ----
+                    // rand_tile stays a standalone pass: the PRNG's per-tile draw order defines the
+                    // reproducible noise stream, and the generator owns LREG0-6 plus replay slots
+                    // 0-16 while it runs, so nothing may interleave with it.
                     rand_tile(score_reg, rand_from_bits, rand_scale_bits);
-                    log_tile_init();
-                    log_tile(score_reg);
-                    negative_tile_init();
-                    negative_tile(score_reg);
-                    log_tile_init();
-                    log_tile(score_reg);
-                    negative_tile_init();
-                    negative_tile(score_reg);
 
-                    // ---- logits / temperature, accumulated onto the noise ----
-                    // The scaling is applied to the LOGITS, never to the noise: score = logits/T + g.
-                    // Scaling the noise instead would invert the temperature's meaning entirely.
                     copy_tile_init(cb_logits);
                     copy_tile(cb_logits, block_idx, operand_reg);
-                    binop_with_scalar_tile_init();
-                    mul_unary_tile(operand_reg, inv_temperature_bits);
-                    add_binary_tile_init();
-                    add_binary_tile(score_reg, operand_reg, score_reg);
+
+                    // ---- pass 2: score = logits * (1/T) + (-log(-log(U))), one SFPI sweep ----
+                    // The scaling is applied to the LOGITS, never to the noise: score = logits/T + g.
+                    // Scaling the noise instead would invert the temperature's meaning entirely.
+                    // The init reprograms what rand_tile left behind (counters, SFPU config);
+                    // the fused pass itself relies on no replay slots or const LREGs.
+                    gumbel_score_tile_init();
+                    gumbel_score_tile<operand_reg - score_reg>(score_reg, inv_temperature_bits);
                 } else {
                     // ---- greedy (temperature == 0): the logits ARE the scores ----
                     // No 1/temperature scaling: it would be a division by zero on the host, and a
@@ -146,7 +143,6 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_reconfig_data_format(cb_scores);
                 pack_tile(score_reg, cb_scores);
                 tile_regs_release();
 

--- a/tt-train/sources/ttml/metal/ops/gumbel_sample/device/kernels/compute/gumbel_sfpu.h
+++ b/tt-train/sources/ttml/metal/ops/gumbel_sample/device/kernels/compute/gumbel_sfpu.h
@@ -25,9 +25,11 @@
  * tile in place. U must be strictly inside (0, 1) so both logs stay finite;
  * the caller's rand from/scale bits enforce that.
  *
- * Both logs run through tt-llk's _calculate_log_body_no_init_, which uses
- * immediate constants only -- no programmable const LREGs and no replay
- * slots -- so this pass composes with rand_tile on both architectures
+ * Both logs feed only the Gumbel noise magnitude, so they run through a
+ * cheap approximation (see _gumbel_noise_log_) rather than tt-llk's precise
+ * minimax body; define GUMBEL_SAMPLE_PRECISE_LOG to switch back. Either way
+ * the pass uses immediate constants only -- no programmable const LREGs and
+ * no replay slots -- so it composes with rand_tile on both architectures
  * (Wormhole's rand programs LREG12/LREG13; nothing here reads them).
  */
 
@@ -36,6 +38,42 @@ namespace ckernel {
 #ifdef TRISC_MATH
 
 namespace sfpu {
+
+#ifdef GUMBEL_SAMPLE_PRECISE_LOG
+sfpi_inline sfpi::vFloat _gumbel_noise_log_(const sfpi::vFloat v) { return _calculate_log_body_no_init_(v); }
+#else
+/**
+ * Approximate ln(v) for the noise chain: exponent split plus one quadratic
+ * over the mantissa octave -- 2 MADs and 4 constants (3 of them single-load
+ * fp16a) versus the precise body's 3 MADs, 4 two-load fp32 constants, and
+ * predicated zero guard.
+ *
+ * The noise needs distributional fidelity, not ULP accuracy. Invariants:
+ *  - Monotone: p(m) = m*(m*B + C) + D rises on [1,2) (p' >= 0.45), and the
+ *    stored constants satisfy p(1) = -2^-20 and p(2) = LN2 - 2^-20 exactly,
+ *    so e*LN2 + p(m) is continuous and increasing across octave boundaries
+ *    (up to 1-ulp fp32 jitter). A monotone transform of U cannot reorder
+ *    samples, so argmax semantics survive the approximation.
+ *  - Error: |p - ln| <= 5.4e-3 on [1,2), plus |e|*2.1e-4 from the fp16a
+ *    ln(2) -- orders below the sampling test's binomial resolution.
+ *  - No zero guard: the caller's rand bounds give U in [2^-32, 1-2^-24],
+ *    and the uniform 2^-20 downward shift keeps -log(U) >= ~1e-6 under
+ *    fp32 rounding, so the outer log's argument never reaches zero or
+ *    flips sign. Cost: noise tops out near 13.75 instead of 16.64,
+ *    compressing only the ~1e-6 upper quantile of the Gumbel tail.
+ */
+sfpi_inline sfpi::vFloat _gumbel_noise_log_(const sfpi::vFloat v) {
+    constexpr float kLn2 = 0.693359375F;  // ln(2) to fp16a precision
+    constexpr float kB = -0.240234375F;   // fp16a-exact minimax under the endpoint ties
+    constexpr float kC = 1.4140625F;      // kLn2 - 3*kB, fp16a-exact
+    constexpr float kD = -0x1.2c801p+0F;  // 2*kB - kLn2 - 2^-20, fp32-exact
+    const sfpi::vFloat m = sfpi::setexp(v, 127);
+    const sfpi::vFloat poly = m * (m * kB + kC) + kD;
+    const auto exp = sfpi::convert<sfpi::vSMag>(sfpi::exexp(v));
+    const sfpi::vFloat expf = sfpi::convert<sfpi::vFloat>(exp, sfpi::RoundMode::Nearest);
+    return expf * kLn2 + poly;
+}
+#endif
 
 template <std::uint32_t LOGITS_DST_OFFSET>
 inline void _calculate_gumbel_score_(const std::uint32_t inv_temperature_bits) {
@@ -48,8 +86,8 @@ inline void _calculate_gumbel_score_(const std::uint32_t inv_temperature_bits) {
         const sfpi::vFloat u = sfpi::dst_reg[0];
         const sfpi::vFloat logits = sfpi::dst_reg[LOGITS_DST_OFFSET * dst_tile_size_sfpi];
         // Negations are LREG sign flips; neither intermediate touches DST.
-        const sfpi::vFloat neg_log_u = -_calculate_log_body_no_init_(u);
-        const sfpi::vFloat gumbel = -_calculate_log_body_no_init_(neg_log_u);
+        const sfpi::vFloat neg_log_u = -_gumbel_noise_log_(u);
+        const sfpi::vFloat gumbel = -_gumbel_noise_log_(neg_log_u);
         sfpi::vFloat score = logits * inv_temperature + gumbel;
         if constexpr (!DST_ACCUM_MODE) {
             score = sfpi::convert<sfpi::vFloat16b>(score, sfpi::RoundMode::Nearest);

--- a/tt-train/sources/ttml/metal/ops/gumbel_sample/device/kernels/compute/gumbel_sfpu.h
+++ b/tt-train/sources/ttml/metal/ops/gumbel_sample/device/kernels/compute/gumbel_sfpu.h
@@ -12,7 +12,11 @@
 #include "llk_math_eltwise_unary_sfpu_macros.h"
 #include "sfpi.h"
 #include "sfpu/ckernel_sfpu_converter.h"
+#ifdef GUMBEL_SAMPLE_PRECISE_LOG
+// The precise branch is the only llk-internal dependency in this header, so the default build
+// carries none.
 #include "sfpu/ckernel_sfpu_log.h"
+#endif
 #endif
 
 /**
@@ -26,29 +30,37 @@
  * the caller's rand from/scale bits enforce that.
  *
  * Both logs feed only the Gumbel noise magnitude, so they run through a
- * cheap approximation (see _gumbel_noise_log_) rather than tt-llk's precise
- * minimax body; define GUMBEL_SAMPLE_PRECISE_LOG to switch back. Either way
- * the pass uses immediate constants only -- no programmable const LREGs and
- * no replay slots -- so it composes with rand_tile on both architectures
+ * cheap approximation (see gumbel_noise_log) rather than tt-llk's precise
+ * minimax body; define GUMBEL_SAMPLE_PRECISE_LOG to use it instead. Either
+ * way the pass uses immediate constants only -- no programmable const LREGs
+ * and no replay slots -- so it composes with rand_tile on both architectures
  * (Wormhole's rand programs LREG12/LREG13; nothing here reads them).
  */
 
-namespace ckernel {
+namespace ttml::metal::sfpu {
 
 #ifdef TRISC_MATH
 
-namespace sfpu {
-
 #ifdef GUMBEL_SAMPLE_PRECISE_LOG
-sfpi_inline sfpi::vFloat _gumbel_noise_log_(const sfpi::vFloat v) { return _calculate_log_body_no_init_(v); }
+// Source-level debugging toggle, deliberately NOT wired through the factory's defines map: every
+// define the factory emits is derived from an op attribute that compute_program_hash keys on, and
+// this one has no attribute -- emitted from ambient host state (an env var, say) it would change
+// the compiled binary without changing the program hash, silently serving stale cached programs.
+// Flipping it means editing this header, which the JIT source hash does see.
+sfpi_inline sfpi::vFloat gumbel_noise_log(const sfpi::vFloat v) {
+    return ckernel::sfpu::_calculate_log_body_no_init_(v);
+}
 #else
 /**
  * Approximate ln(v) for the noise chain: exponent split plus one quadratic
  * over the mantissa octave -- 2 MADs and 4 constants (3 of them single-load
  * fp16a) versus the precise body's 3 MADs, 4 two-load fp32 constants, and
- * predicated zero guard.
+ * predicated zero guard. kLn2, kB, and kC sit exactly on the fp16a grid
+ * because an fp16a-exact literal loads with a single SFPLOADI where a full
+ * fp32 constant takes two -- keep them on that grid when re-fitting.
  *
- * The noise needs distributional fidelity, not ULP accuracy. Invariants:
+ * The noise needs distributional fidelity, not ULP accuracy. Invariants
+ * (pinned host-side by TestGumbelApproxLogInvariants):
  *  - Monotone: p(m) = m*(m*B + C) + D rises on [1,2) (p' >= 0.45), and the
  *    stored constants satisfy p(1) = -2^-20 and p(2) = LN2 - 2^-20 exactly,
  *    so e*LN2 + p(m) is continuous and increasing across octave boundaries
@@ -62,7 +74,7 @@ sfpi_inline sfpi::vFloat _gumbel_noise_log_(const sfpi::vFloat v) { return _calc
  *    flips sign. Cost: noise tops out near 13.75 instead of 16.64,
  *    compressing only the ~1e-6 upper quantile of the Gumbel tail.
  */
-sfpi_inline sfpi::vFloat _gumbel_noise_log_(const sfpi::vFloat v) {
+sfpi_inline sfpi::vFloat gumbel_noise_log(const sfpi::vFloat v) {
     constexpr float kLn2 = 0.693359375F;  // ln(2) to fp16a precision
     constexpr float kB = -0.240234375F;   // fp16a-exact minimax under the endpoint ties
     constexpr float kC = 1.4140625F;      // kLn2 - 3*kB, fp16a-exact
@@ -76,18 +88,21 @@ sfpi_inline sfpi::vFloat _gumbel_noise_log_(const sfpi::vFloat v) {
 #endif
 
 template <std::uint32_t LOGITS_DST_OFFSET>
-inline void _calculate_gumbel_score_(const std::uint32_t inv_temperature_bits) {
+inline void calculate_gumbel_score(const std::uint32_t inv_temperature_bits) {
     // One DST tile spans 64 rows / SFP_DESTREG_STRIDE = 32 sfpi rows -- same
-    // convention as tt-llk's binary SFPU ops.
+    // convention as tt-llk's binary SFPU ops. The 8 iterations below cover
+    // ONE face: SFPU_UNARY_CALL re-invokes this body per face with dst_reg
+    // re-based to that face, so the tile-sized logits offset lands on the
+    // matching face of the logits tile each time.
     constexpr std::uint32_t dst_tile_size_sfpi = 32U;
-    const sfpi::vFloat inv_temperature = Converter::as_float(inv_temperature_bits);
+    const sfpi::vFloat inv_temperature = ckernel::sfpu::Converter::as_float(inv_temperature_bits);
 #pragma GCC unroll 8
     for (int d = 0; d < 8; d++) {
         const sfpi::vFloat u = sfpi::dst_reg[0];
         const sfpi::vFloat logits = sfpi::dst_reg[LOGITS_DST_OFFSET * dst_tile_size_sfpi];
         // Negations are LREG sign flips; neither intermediate touches DST.
-        const sfpi::vFloat neg_log_u = -_gumbel_noise_log_(u);
-        const sfpi::vFloat gumbel = -_gumbel_noise_log_(neg_log_u);
+        const sfpi::vFloat neg_log_u = -gumbel_noise_log(u);
+        const sfpi::vFloat gumbel = -gumbel_noise_log(neg_log_u);
         sfpi::vFloat score = logits * inv_temperature + gumbel;
         if constexpr (!DST_ACCUM_MODE) {
             score = sfpi::convert<sfpi::vFloat16b>(score, sfpi::RoundMode::Nearest);
@@ -97,8 +112,24 @@ inline void _calculate_gumbel_score_(const std::uint32_t inv_temperature_bits) {
     }
 }
 
-}  // namespace sfpu
+#endif  // TRISC_MATH
 
+}  // namespace ttml::metal::sfpu
+
+namespace ckernel {
+
+#ifdef TRISC_MATH
+namespace sfpu {
+
+// SFPU_UNARY_CALL resolves its functor as ::ckernel::sfpu::FN (see
+// llk_math_eltwise_unary_sfpu_macros.h), so this forwarder is the one piece
+// that must live here; the implementation is ttml's, in ttml::metal::sfpu.
+template <std::uint32_t LOGITS_DST_OFFSET>
+inline void _calculate_gumbel_score_(const std::uint32_t inv_temperature_bits) {
+    ttml::metal::sfpu::calculate_gumbel_score<LOGITS_DST_OFFSET>(inv_temperature_bits);
+}
+
+}  // namespace sfpu
 #endif  // TRISC_MATH
 
 /**

--- a/tt-train/sources/ttml/metal/ops/gumbel_sample/device/kernels/compute/gumbel_sfpu.h
+++ b/tt-train/sources/ttml/metal/ops/gumbel_sample/device/kernels/compute/gumbel_sfpu.h
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "api/compute/common_globals.h"
+
+#ifdef TRISC_MATH
+#include "llk_math_eltwise_unary_sfpu_macros.h"
+#include "sfpi.h"
+#include "sfpu/ckernel_sfpu_converter.h"
+#include "sfpu/ckernel_sfpu_log.h"
+#endif
+
+/**
+ * Fused Gumbel scoring: one SFPI pass computing, per DST datum,
+ *
+ *     score = logits * inv_temperature + (-log(-log(U)))
+ *
+ * DST layout contract: the uniform noise tile U sits at `idst`, the logits
+ * tile LOGITS_DST_OFFSET slots above it, and the score overwrites the noise
+ * tile in place. U must be strictly inside (0, 1) so both logs stay finite;
+ * the caller's rand from/scale bits enforce that.
+ *
+ * Both logs run through tt-llk's _calculate_log_body_no_init_, which uses
+ * immediate constants only -- no programmable const LREGs and no replay
+ * slots -- so this pass composes with rand_tile on both architectures
+ * (Wormhole's rand programs LREG12/LREG13; nothing here reads them).
+ */
+
+namespace ckernel {
+
+#ifdef TRISC_MATH
+
+namespace sfpu {
+
+template <std::uint32_t LOGITS_DST_OFFSET>
+inline void _calculate_gumbel_score_(const std::uint32_t inv_temperature_bits) {
+    // One DST tile spans 64 rows / SFP_DESTREG_STRIDE = 32 sfpi rows -- same
+    // convention as tt-llk's binary SFPU ops.
+    constexpr std::uint32_t dst_tile_size_sfpi = 32U;
+    const sfpi::vFloat inv_temperature = Converter::as_float(inv_temperature_bits);
+#pragma GCC unroll 8
+    for (int d = 0; d < 8; d++) {
+        const sfpi::vFloat u = sfpi::dst_reg[0];
+        const sfpi::vFloat logits = sfpi::dst_reg[LOGITS_DST_OFFSET * dst_tile_size_sfpi];
+        // Negations are LREG sign flips; neither intermediate touches DST.
+        const sfpi::vFloat neg_log_u = -_calculate_log_body_no_init_(u);
+        const sfpi::vFloat gumbel = -_calculate_log_body_no_init_(neg_log_u);
+        sfpi::vFloat score = logits * inv_temperature + gumbel;
+        if constexpr (!DST_ACCUM_MODE) {
+            score = sfpi::convert<sfpi::vFloat16b>(score, sfpi::RoundMode::Nearest);
+        }
+        sfpi::dst_reg[0] = score;
+        sfpi::dst_reg++;
+    }
+}
+
+}  // namespace sfpu
+
+#endif  // TRISC_MATH
+
+/**
+ * @brief Initializes the fused Gumbel scoring SFPU operation.
+ */
+ALWI void gumbel_score_tile_init() { MATH((llk_math_eltwise_unary_sfpu_init<SfpuType::unused>())); }
+
+/**
+ * @brief Overwrites the uniform tile at `idst` with the fused Gumbel score.
+ *
+ * The logits tile must already sit `logits_dst_offset` DST slots above
+ * `idst`. `inv_temperature_bits` is the FP32 bit pattern of 1/temperature.
+ */
+template <uint32_t logits_dst_offset = 1U>
+ALWI void gumbel_score_tile(uint32_t idst, uint32_t inv_temperature_bits) {
+    MATH(SFPU_UNARY_CALL(
+        DST_SYNC_MODE,
+        DST_ACCUM_MODE,
+        _calculate_gumbel_score_,
+        (logits_dst_offset),
+        idst,
+        VectorMode::RC,
+        inv_temperature_bits));
+}
+
+}  // namespace ckernel

--- a/tt-train/sources/ttml/metal/ops/gumbel_sample/device/kernels/dataflow/writer_gumbel_sample.cpp
+++ b/tt-train/sources/ttml/metal/ops/gumbel_sample/device/kernels/dataflow/writer_gumbel_sample.cpp
@@ -4,19 +4,20 @@
 
 // Fused Gumbel-max sampling, reduction half -- entirely on device, spread across the whole grid.
 //
-// The work unit is a TILE, so a token row's vocabulary is spread over many cores and no core owns a
-// whole row. The price of tile units is that the argmax becomes a
-// cross-core reduction, arranged here so the common case never pays for it:
+// The work unit is a TILE, so a token row's vocabulary MAY be split across cores. The price of
+// tile units is that the argmax then becomes a cross-core reduction, arranged here so the common
+// case never pays for it:
 //
-//   * A row whose tiles lie ENTIRELY inside this core's run is reduced and written right here. In
-//     prefill nearly every row is like that, so the exchange below is almost never used.
-//   * A row split across cores is merged by the row's OWNER -- the core holding the row's first
-//     tile. The split hands each core one contiguous tile range, so a core can hold a foreign shard
-//     only of its FIRST row (at most one record to send) and can own a split row only as its LAST
-//     (at most one merge to run). Senders NOC-write their record into a host-assigned slot in the
-//     owner's L1 and bump the owner's semaphore; the owner waits for exactly its shard count, folds
-//     the records into its own accumulators, and writes the row. Every split row merges on a
-//     different core, in parallel -- there is no global rendezvous core to serialize on.
+//   * A FULLY LOCAL row -- every tile inside this core's run -- is reduced and written right here.
+//     In prefill nearly every row is like that, so the exchange below is almost never used.
+//   * A split row is merged by the row's OWNER, which throughout this file means exactly one
+//     thing: the core holding the row's first tile. The split hands each core one contiguous tile
+//     range, so a core can hold a foreign shard only of its FIRST row (at most one record to send)
+//     and can own a split row only as its LAST (at most one merge to run). Senders NOC-write their
+//     record into a host-assigned slot in the owner's L1 and bump the owner's semaphore; the owner
+//     waits for exactly its shard count, folds the records into its accumulators, and writes the
+//     row. Every split row merges on a different core, in parallel -- there is no global
+//     rendezvous core to serialize on.
 //
 // Comparison is on raw FP32 bit patterns via float32_greater: the data-movement RISCs have no FPU.
 
@@ -35,8 +36,10 @@ constexpr uint32_t kFaceWidth = 16U;
 constexpr uint32_t kFaceSize = kFaceHeight * kFaceWidth;
 
 // A boundary record: [valid, row_id, 32 max bit-patterns, 32 indices], padded to a NOC-friendly
-// multiple of 16 bytes. The records CB holds the receive slots for the one row this core may own,
-// then one staging slot for the record it may send.
+// multiple of 16 bytes. The merge reads only the maxima and indices; valid and row_id are
+// watcher/debug breadcrumbs (the split geometry already fixes which row a record belongs to).
+// The records CB holds the receive slots for the one row this core may own, then one staging slot
+// for the record it may send.
 constexpr uint32_t kRecordStrideU32 = 72U;  // 66 used, padded to 288 bytes
 constexpr uint32_t kRecordBytes = kRecordStrideU32 * sizeof(uint32_t);
 
@@ -168,6 +171,8 @@ void kernel_main() {
     auto send_shard = [&](uint32_t tile_row) {
         const uint32_t staging = records_base + max_foreign_shards * kRecordBytes;
         auto* rec = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(staging);
+        // Watcher/debug breadcrumbs only -- the merge never reads them (the split geometry admits
+        // exactly one row per owner, so no row-id matching is needed).
         rec[0] = 1U;
         rec[1] = tile_row;
         for (uint32_t h = 0U; h < kTileHeight; ++h) {
@@ -186,6 +191,7 @@ void kernel_main() {
 
     auto finish_row = [&](uint32_t tile_row, uint32_t valid_rows) {
         const uint32_t row_first = tile_row * Wt;
+        // Fully local row: every tile was scanned here, so the write-out completes here too.
         if (row_first >= start_tile && row_first + Wt <= start_tile + num_tiles) {
             if (valid_rows != 0U) {
                 write_row(tile_row, valid_rows);
@@ -283,7 +289,7 @@ void kernel_main() {
         noc_semaphore_wait(sem_ptr, expected_shards);
         noc_semaphore_set(sem_ptr, 0U);  // re-arm for the next dispatch of this cached program
 
-        // The accumulators still hold this core's own shard: finish_row deferred exactly this row,
+        // The accumulators still hold this core's local shard: finish_row deferred exactly this row,
         // and it is the run's last, so no reset ran after it. Every received record is a shard of
         // this same row -- the split geometry admits no other sender -- so no row-id matching is
         // needed.

--- a/tt-train/sources/ttml/metal/ops/gumbel_sample/device/kernels/dataflow/writer_gumbel_sample.cpp
+++ b/tt-train/sources/ttml/metal/ops/gumbel_sample/device/kernels/dataflow/writer_gumbel_sample.cpp
@@ -10,11 +10,13 @@
 //
 //   * A row whose tiles lie ENTIRELY inside this core's run is reduced and written right here. In
 //     prefill nearly every row is like that, so the exchange below is almost never used.
-//   * A row this core only partially covers is a BOUNDARY row. A core has at most two (its first and
-//     its last), so the exchange is bounded at 2 records per core whatever the shape. Those records
-//     are NOC-written into the origin core's L1, which merges by row id and writes those rows.
-//     Follows frobenius_normalize: partials to origin's L1, noc_semaphore_inc, origin waits on
-//     num_cores - 1.
+//   * A row split across cores is merged by the row's OWNER -- the core holding the row's first
+//     tile. The split hands each core one contiguous tile range, so a core can hold a foreign shard
+//     only of its FIRST row (at most one record to send) and can own a split row only as its LAST
+//     (at most one merge to run). Senders NOC-write their record into a host-assigned slot in the
+//     owner's L1 and bump the owner's semaphore; the owner waits for exactly its shard count, folds
+//     the records into its own accumulators, and writes the row. Every split row merges on a
+//     different core, in parallel -- there is no global rendezvous core to serialize on.
 //
 // Comparison is on raw FP32 bit patterns via float32_greater: the data-movement RISCs have no FPU.
 
@@ -33,10 +35,10 @@ constexpr uint32_t kFaceWidth = 16U;
 constexpr uint32_t kFaceSize = kFaceHeight * kFaceWidth;
 
 // A boundary record: [valid, row_id, 32 max bit-patterns, 32 indices], padded to a NOC-friendly
-// multiple of 16 bytes. Two per core is the hard bound (the first and last row of a core's run).
+// multiple of 16 bytes. The records CB holds the receive slots for the one row this core may own,
+// then one staging slot for the record it may send.
 constexpr uint32_t kRecordStrideU32 = 72U;  // 66 used, padded to 288 bytes
 constexpr uint32_t kRecordBytes = kRecordStrideU32 * sizeof(uint32_t);
-constexpr uint32_t kRecordsPerCore = 2U;
 
 // Bytes per staged output value: a NOC write needs its L1 source aligned, so each token id gets its
 // own slot rather than sitting packed 4 bytes apart.
@@ -49,10 +51,16 @@ void kernel_main() {
     const uint32_t output_address = get_arg_val<uint32_t>(rt_idx++);
     const uint32_t num_tiles = get_arg_val<uint32_t>(rt_idx++);
     const uint32_t start_tile = get_arg_val<uint32_t>(rt_idx++);
-    const uint32_t core_index = get_arg_val<uint32_t>(rt_idx++);
     // Base address of the positions tensor, 0 when absent; emitted in both modes so the host can
     // patch the slot unconditionally.
     const uint32_t positions_address = get_arg_val<uint32_t>(rt_idx++);
+    // Merge routing, host-derived from the same work split that produced num_tiles/start_tile:
+    // where this core's first-row shard goes (meaningful only when that row began on an earlier
+    // core), and how many foreign shards of its last row to wait for (0 when that row ends here).
+    const uint32_t owner_phys_x = get_arg_val<uint32_t>(rt_idx++);
+    const uint32_t owner_phys_y = get_arg_val<uint32_t>(rt_idx++);
+    const uint32_t send_slot = get_arg_val<uint32_t>(rt_idx++);
+    const uint32_t expected_shards = get_arg_val<uint32_t>(rt_idx++);
 
     constexpr uint32_t cb_scores_idx = tt::CBIndex::c_2;
     constexpr uint32_t cb_output_staging_idx = tt::CBIndex::c_3;
@@ -63,11 +71,11 @@ void kernel_main() {
     constexpr uint32_t logical_vocab = get_compile_time_arg_val(1);
     constexpr uint32_t logical_tokens = get_compile_time_arg_val(2);
     constexpr uint32_t Ht = get_compile_time_arg_val(3);
-    constexpr uint32_t num_cores = get_compile_time_arg_val(4);
-    constexpr uint32_t reduction_sem_id = get_compile_time_arg_val(5);
-    constexpr uint32_t origin_phys_x = get_compile_time_arg_val(6);
-    constexpr uint32_t origin_phys_y = get_compile_time_arg_val(7);
-    constexpr uint32_t num_entries = get_compile_time_arg_val(8);
+    constexpr uint32_t reduction_sem_id = get_compile_time_arg_val(4);
+    // Receive-slot count in the records CB (the grid-wide worst-case shard fan-in for one row);
+    // the outgoing record is staged in the slot just past them.
+    constexpr uint32_t max_foreign_shards = get_compile_time_arg_val(5);
+    constexpr uint32_t num_entries = get_compile_time_arg_val(6);
 
 #ifdef DO_POSITIONS
     constexpr bool do_positions = true;
@@ -75,16 +83,17 @@ void kernel_main() {
     constexpr bool do_positions = false;
 #endif
 
-    constexpr auto output_args = TensorAccessorArgs<9>();
+    constexpr auto output_args = TensorAccessorArgs<7>();
     constexpr auto positions_args = TensorAccessorArgs<output_args.next_compile_time_args_offset()>();
     const auto output_address_generator = TensorAccessor(output_args, output_address);
 
     const uint32_t staging_address = get_write_ptr(cb_output_staging_idx);
     const uint32_t records_base = get_write_ptr(cb_records_idx);
 
-    // Stage the full local position list, as the reader does. This core needs entries beyond its own
-    // run: the origin re-derives the target row of every boundary entry it merges, which keeps that
-    // row out of the record format entirely.
+    // Stage the full local position list, as the reader does. Only this core's own entries are ever
+    // consumed -- the rows it scans and the one row it may merge all lie inside its run -- but the
+    // slots are indexed by absolute entry id, so staging the whole list keeps the addressing
+    // trivial and the reads hide under the scores wait below.
     //
     // The read is free here -- the next thing this kernel does is block on cb_wait_front(scores),
     // which cannot clear until the reader has already fetched logits from DRAM. BRISC issues reads
@@ -149,36 +158,47 @@ void kernel_main() {
         noc_async_write_barrier();
     };
 
-    uint32_t staged_records = 0U;
-
-    // All 32 slots travel verbatim: rows this core never scanned are still NEG_INF from
-    // reset_accumulators, so the merge below leaves them alone whichever mode is compiled.
-    auto stage_record = [&](uint32_t tile_row, uint32_t /*valid_rows*/) {
-        auto* rec = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-            records_base + (core_index * kRecordsPerCore + staged_records) * kRecordBytes);
+    // Ship this core's shard of its first row to that row's owner. All 32 slots travel verbatim:
+    // rows this core never scanned are still NEG_INF from reset_accumulators, so the merge leaves
+    // them alone whichever mode is compiled. Fires even for all-padding rows: the owner's expected
+    // count is derived from the split geometry alone, so a withheld record would deadlock it.
+    //
+    // The records CB sits at the same L1 address on every core, so the local base doubles as the
+    // remote destination base.
+    auto send_shard = [&](uint32_t tile_row) {
+        const uint32_t staging = records_base + max_foreign_shards * kRecordBytes;
+        auto* rec = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(staging);
         rec[0] = 1U;
         rec[1] = tile_row;
         for (uint32_t h = 0U; h < kTileHeight; ++h) {
             rec[2U + h] = max_values[h];
             rec[2U + kTileHeight + h] = arg_max[h];
         }
-        ++staged_records;
-    };
-
-    auto row_is_owned = [&](uint32_t tile_row) -> bool {
-        const uint32_t row_first = tile_row * Wt;
-        return (row_first >= start_tile) && (row_first + Wt <= start_tile + num_tiles);
+        // Record first, then the increment: the write barrier orders them, so the owner's
+        // semaphore never counts a record that has not landed.
+        noc_async_write(
+            staging,
+            get_noc_addr(owner_phys_x, owner_phys_y, records_base + send_slot * kRecordBytes),
+            kRecordBytes);
+        noc_async_write_barrier();
+        noc_semaphore_inc(get_noc_addr(owner_phys_x, owner_phys_y, get_semaphore(reduction_sem_id)), 1U);
     };
 
     auto finish_row = [&](uint32_t tile_row, uint32_t valid_rows) {
-        if (valid_rows == 0U) {
+        const uint32_t row_first = tile_row * Wt;
+        if (row_first >= start_tile && row_first + Wt <= start_tile + num_tiles) {
+            if (valid_rows != 0U) {
+                write_row(tile_row, valid_rows);
+            }
             return;
         }
-        if (row_is_owned(tile_row)) {
-            write_row(tile_row, valid_rows);
-        } else {
-            stage_record(tile_row, valid_rows);
+        if (row_first < start_tile) {
+            // A shard of a row that began on an earlier core -- necessarily this core's first row.
+            send_shard(tile_row);
+            return;
         }
+        // The row starts here but spills onto later cores -- necessarily this core's LAST row, so
+        // leaving the accumulators untouched hands them straight to the merge in pass 2.
     };
 
     auto reset_accumulators = [&]() {
@@ -257,59 +277,33 @@ void kernel_main() {
 
     finish_row(current_row, current_valid);
 
-    // ---- pass 2: combine boundary rows on the origin core ----
-    if constexpr (num_cores > 1U) {
-        const uint32_t local_base = records_base + core_index * kRecordsPerCore * kRecordBytes;
-        // Blank the unused slots so the origin can tell live records from stale L1.
-        for (uint32_t k = staged_records; k < kRecordsPerCore; ++k) {
-            *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_base + k * kRecordBytes) = 0U;
+    // ---- pass 2: merge the foreign shards of the one row this core owns but did not finish ----
+    if (expected_shards > 0U) {
+        auto* sem_ptr = get_sem_ptr(reduction_sem_id);
+        noc_semaphore_wait(sem_ptr, expected_shards);
+        noc_semaphore_set(sem_ptr, 0U);  // re-arm for the next dispatch of this cached program
+
+        // The accumulators still hold this core's own shard: finish_row deferred exactly this row,
+        // and it is the run's last, so no reset ran after it. Every received record is a shard of
+        // this same row -- the split geometry admits no other sender -- so no row-id matching is
+        // needed.
+        for (uint32_t s = 0U; s < expected_shards; ++s) {
+            auto* rec = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(records_base + s * kRecordBytes);
+            for (uint32_t h = 0U; h < kTileHeight; ++h) {
+                const uint32_t v = rec[2U + h];
+                const uint32_t i = rec[2U + kTileHeight + h];
+                // Ties keep the lower index, matching the in-row scan.
+                if (float32_greater(v, max_values[h]) || (v == max_values[h] && i < arg_max[h])) {
+                    max_values[h] = v;
+                    arg_max[h] = i;
+                }
+            }
         }
 
-        if (core_index != 0U) {
-            // One write and one increment per core, so the origin waits on a core count.
-            const uint64_t dst = get_noc_addr(origin_phys_x, origin_phys_y, local_base);
-            noc_async_write(local_base, dst, kRecordsPerCore * kRecordBytes);
-            noc_async_write_barrier();
-            noc_semaphore_inc(get_noc_addr(origin_phys_x, origin_phys_y, get_semaphore(reduction_sem_id)), 1U);
-        } else {
-            auto* sem_ptr = get_sem_ptr(reduction_sem_id);
-            noc_semaphore_wait(sem_ptr, num_cores - 1U);
-            noc_semaphore_set(sem_ptr, 0U);
-
-            // Merge by row id: fold every later record carrying the same row into the first one,
-            // then write that row once. Records number 2 per core, so the quadratic scan is cheap.
-            constexpr uint32_t total_records = num_cores * kRecordsPerCore;
-            for (uint32_t a = 0U; a < total_records; ++a) {
-                auto* ra = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(records_base + a * kRecordBytes);
-                if (ra[0] == 0U) {
-                    continue;
-                }
-                const uint32_t row = ra[1];
-                for (uint32_t h = 0U; h < kTileHeight; ++h) {
-                    max_values[h] = ra[2U + h];
-                    arg_max[h] = ra[2U + kTileHeight + h];
-                }
-                ra[0] = 0U;
-
-                for (uint32_t b = a + 1U; b < total_records; ++b) {
-                    auto* rb = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(records_base + b * kRecordBytes);
-                    if (rb[0] == 0U || rb[1] != row) {
-                        continue;
-                    }
-                    for (uint32_t h = 0U; h < kTileHeight; ++h) {
-                        const uint32_t v = rb[2U + h];
-                        const uint32_t i = rb[2U + kTileHeight + h];
-                        // Ties keep the lower index, matching the in-row scan.
-                        if (float32_greater(v, max_values[h]) || (v == max_values[h] && i < arg_max[h])) {
-                            max_values[h] = v;
-                            arg_max[h] = i;
-                        }
-                    }
-                    rb[0] = 0U;
-                }
-
-                write_row(row, valid_rows_of(row));
-            }
+        const uint32_t owned_row = (start_tile + num_tiles - 1U) / Wt;
+        const uint32_t valid = valid_rows_of(owned_row);
+        if (valid != 0U) {
+            write_row(owned_row, valid);
         }
     }
 }

--- a/tt-train/tests/CMakeLists.txt
+++ b/tt-train/tests/CMakeLists.txt
@@ -171,6 +171,14 @@ target_link_libraries(
         ttml
         TTNN::TTNN
 )
+
+add_executable(gumbel_sample_benchmark benchmark/gumbel_sample_benchmark.cpp)
+target_link_libraries(
+    gumbel_sample_benchmark
+    PUBLIC
+        ttml
+        TTNN::TTNN
+)
 ############################################################################################################################
 # Benchmark tests (using Google Benchmark)
 # Only available when building via tt-metal (Build from tt-train would require adding new dependency)

--- a/tt-train/tests/benchmark/gumbel_sample_benchmark.cpp
+++ b/tt-train/tests/benchmark/gumbel_sample_benchmark.cpp
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <fmt/format.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "autograd/auto_context.hpp"
+#include "benchmark_utils.hpp"
+#include "core/tt_tensor_utils.hpp"
+#include "ttnn_fixed/trivial_ttnn_ops.hpp"
+
+namespace {
+
+struct BenchConfig {
+    std::string name;
+    uint32_t batch = 1;
+    uint32_t tokens = 1;
+    uint32_t vocab = 1;
+    float temperature = 0.7F;
+    bool with_mask = false;
+    bool with_positions = false;
+    uint32_t warmup = 5;
+    uint32_t iters = 50;
+};
+
+// GRPO-representative shapes. decode: one token row per entry, full-row mode.
+// prefill: per-row positions so only the prompt-end tiles are read.
+// pos_large: batch large enough that positions staging and merge traffic dominate.
+const std::vector<BenchConfig>& all_configs() {
+    static const std::vector<BenchConfig> configs = {
+        {.name = "decode_b8_v151936", .batch = 8, .tokens = 1, .vocab = 151936, .warmup = 10, .iters = 100},
+        // Diagnostics, not part of the headline geomean: greedy compiles out the noise chain
+        // (DO_GUMBEL_NOISE off) — the gap to decode_b8_v151936 is the chain's device cost;
+        // the small-vocab run checks whether time scales with Wt (device-bound signature).
+        {.name = "greedy_b8_v151936",
+         .batch = 8,
+         .tokens = 1,
+         .vocab = 151936,
+         .temperature = 0.0F,
+         .warmup = 10,
+         .iters = 100},
+        {.name = "decode_b8_v16000", .batch = 8, .tokens = 1, .vocab = 16000, .warmup = 10, .iters = 100},
+        {.name = "decode_b8_v151936_mask",
+         .batch = 8,
+         .tokens = 1,
+         .vocab = 151936,
+         .with_mask = true,
+         .warmup = 10,
+         .iters = 100},
+        {.name = "prefill_pos_b8_t256_v151936",
+         .batch = 8,
+         .tokens = 256,
+         .vocab = 151936,
+         .with_positions = true,
+         .warmup = 5,
+         .iters = 30},
+        {.name = "pos_b512_t64_v16000",
+         .batch = 512,
+         .tokens = 64,
+         .vocab = 16000,
+         .with_positions = true,
+         .warmup = 3,
+         .iters = 20},
+    };
+    return configs;
+}
+
+std::vector<float> make_logits(const BenchConfig& cfg) {
+    const size_t count = static_cast<size_t>(cfg.batch) * cfg.tokens * cfg.vocab;
+    std::vector<float> data(count);
+    uint32_t state = 0x12345678U;
+    for (size_t i = 0; i < count; ++i) {
+        state = state * 1664525U + 1013904223U;
+        data[i] = static_cast<float>(state >> 8U) * (1.0F / 16777216.0F) * 8.0F - 4.0F;
+    }
+    return data;
+}
+
+ttnn::Tensor make_positions_tensor(const BenchConfig& cfg) {
+    std::vector<uint32_t> positions(cfg.batch);
+    for (uint32_t b = 0; b < cfg.batch; ++b) {
+        positions[b] = (b * 7U + 3U) % cfg.tokens;
+    }
+    return ttml::core::from_vector<uint32_t, ttnn::DataType::UINT32>(
+        positions,
+        ttnn::Shape({cfg.batch, 1U, 1U, 1U}),
+        &ttml::autograd::ctx().get_device(),
+        ttnn::Layout::ROW_MAJOR);
+}
+
+ttnn::Tensor make_mask_tensor(const BenchConfig& cfg) {
+    std::vector<float> mask(cfg.vocab, 0.0F);
+    for (uint32_t v = cfg.vocab - 64U; v < cfg.vocab; ++v) {
+        mask[v] = 1e9F;
+    }
+    return ttml::core::from_vector(
+        mask, ttnn::Shape({1U, 1U, 1U, cfg.vocab}), &ttml::autograd::ctx().get_device());
+}
+
+double percentile(std::vector<double> sorted, double p) {
+    const size_t idx = static_cast<size_t>(p * static_cast<double>(sorted.size() - 1));
+    return sorted[idx];
+}
+
+void run_config(const BenchConfig& cfg) {
+    auto* device = &ttml::autograd::ctx().get_device();
+
+    const auto logits_data = make_logits(cfg);
+    auto logits = ttml::core::from_vector(
+        logits_data, ttnn::Shape({cfg.batch, 1U, cfg.tokens, cfg.vocab}), device);
+
+    std::optional<ttnn::Tensor> mask;
+    if (cfg.with_mask) {
+        mask = make_mask_tensor(cfg);
+    }
+    std::optional<ttnn::Tensor> positions;
+    if (cfg.with_positions) {
+        positions = make_positions_tensor(cfg);
+    }
+
+    // Timed region includes the token-id readback: GRPO consumes the sampled ids on host
+    // every step, so enqueue-only timing would hide the cost the training loop actually pays.
+    auto step = [&](uint32_t seed) {
+        auto out = ttml::ttnn_fixed::sample(logits, cfg.temperature, seed, mask, std::nullopt, positions);
+        return ttml::core::to_vector<uint32_t>(out);
+    };
+
+    for (uint32_t i = 0; i < cfg.warmup; ++i) {
+        step(1000U + i);
+    }
+
+    std::vector<double> times_ms;
+    times_ms.reserve(cfg.iters);
+    for (uint32_t i = 0; i < cfg.iters; ++i) {
+        const auto start = std::chrono::high_resolution_clock::now();
+        auto ids = step(2000U + i);
+        const auto end = std::chrono::high_resolution_clock::now();
+        if (ids.empty()) {
+            fmt::print("ERROR: empty output for {}\n", cfg.name);
+            return;
+        }
+        times_ms.push_back(std::chrono::duration<double, std::milli>(end - start).count());
+    }
+
+    std::sort(times_ms.begin(), times_ms.end());
+    fmt::print(
+        "GUMBEL_BENCH_JSON {{\"config\":\"{}\",\"iters\":{},\"min_ms\":{:.4f},\"median_ms\":{:.4f},"
+        "\"p90_ms\":{:.4f},\"mean_ms\":{:.4f}}}\n",
+        cfg.name,
+        cfg.iters,
+        times_ms.front(),
+        percentile(times_ms, 0.5),
+        percentile(times_ms, 0.9),
+        ttml::benchmark_utils::average(times_ms));
+
+    // Pipelined mode: N async enqueues, one readback sync at the end. Per-call cost here is
+    // max(enqueue floor, device time) — the gap vs the synced number above isolates how much of
+    // the per-step latency is the host sync, and exposes device-time deltas the sync hides.
+    const uint32_t pipelined_n = cfg.iters;
+    ttnn::Tensor last;
+    const auto start = std::chrono::high_resolution_clock::now();
+    for (uint32_t i = 0; i < pipelined_n; ++i) {
+        last = ttml::ttnn_fixed::sample(logits, cfg.temperature, 3000U + i, mask, std::nullopt, positions);
+    }
+    auto ids = ttml::core::to_vector<uint32_t>(last);
+    const auto end = std::chrono::high_resolution_clock::now();
+    if (ids.empty()) {
+        fmt::print("ERROR: empty pipelined output for {}\n", cfg.name);
+        return;
+    }
+    const double per_call_ms = std::chrono::duration<double, std::milli>(end - start).count() / pipelined_n;
+    fmt::print(
+        "GUMBEL_BENCH_JSON {{\"config\":\"{}_pipelined\",\"iters\":{},\"median_ms\":{:.4f}}}\n",
+        cfg.name,
+        pipelined_n,
+        per_call_ms);
+}
+
+}  // namespace
+
+int main() {
+    ttml::autograd::ctx().open_device();
+    for (const auto& cfg : all_configs()) {
+        run_config(cfg);
+    }
+    ttml::autograd::ctx().close_device();
+    return 0;
+}

--- a/tt-train/tests/ttnn_fixed/trivial_ttnn_ops_test.cpp
+++ b/tt-train/tests/ttnn_fixed/trivial_ttnn_ops_test.cpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <array>
+#include <bit>
 #include <cmath>
 #include <cstdint>
 #include <memory>
@@ -981,4 +982,157 @@ TEST_F(TrivialTnnFixedTest, TestSamplingGumbelMatchesSoftmaxDistribution) {
             << "positions+mask: column " << kActiveCols[c] << " (weight " << kWeights[c] << ") selected "
             << pos_counts[c] << " / " << pos_total;
     }
+}
+
+TEST_F(TrivialTnnFixedTest, TestSamplingWideRowManyOwners) {
+    // The other shapes in this suite split a row over at most a few cores, so a row's owner merges
+    // at most ~3 foreign records. A single wide tile row spread over the whole grid is the other
+    // extreme: every core holding a shard of the row sends a record to the one owner, so the
+    // owner's exact-count semaphore wait, the host-assigned slot addressing and the merge loop all
+    // run at grid-scale fan-in.
+    constexpr uint32_t kTokens = 2U;    // one tile row (Ht = 1); both real rows ride the same merge
+    constexpr uint32_t kVocab = 4100U;  // Wt = 129; the last tile keeps 4 valid columns
+
+    xt::xarray<float>::shape_type shape = {1U, 1U, kTokens, kVocab};
+    xt::xarray<float> a = xt::zeros<float>(shape);
+    a.fill(-1.0F);
+
+    // Distinct winner per token row, in different vocab tiles -- one mid-run, one inside the
+    // ragged final tile -- so a merge that drops, duplicates or mis-slots records cannot pass by
+    // coincidence, and the ragged scan bound is exercised through the merge path too.
+    constexpr std::array<uint32_t, kTokens> kWinners = {1234U, kVocab - 1U};
+    std::vector<uint32_t> expected(kTokens);
+    for (uint32_t t = 0; t < kTokens; ++t) {
+        a(0, 0, t, kWinners[t]) = -0.5F;
+        expected[t] = kWinners[t];
+    }
+
+    auto tensor_a = ttml::core::from_xtensor(a, &ttml::autograd::ctx().get_device());
+
+    // Greedy is exact, so the winners must come back verbatim through the full-fan-in merge.
+    auto greedy = ttml::core::to_vector<uint32_t>(ttml::ttnn_fixed::sample(tensor_a, 0.0F, 7));
+    ASSERT_EQ(greedy.size(), kTokens);
+    EXPECT_EQ(greedy, expected);
+
+    // Position mode reruns the same wide-row merge under its own work split (NC * Wt virtual
+    // tiles) and the single-row writer path. One batch entry means one position per call; select
+    // each row in turn.
+    for (uint32_t t = 0; t < kTokens; ++t) {
+        auto at = ttml::core::to_vector<uint32_t>(ttml::ttnn_fixed::sample(
+            tensor_a,
+            0.0F,
+            7,
+            /* mask */ std::nullopt,
+            /* seed_axes */ std::nullopt,
+            make_positions(std::vector<uint32_t>{t})));
+        ASSERT_EQ(at.size(), 1U);
+        EXPECT_EQ(at[0], expected[t]) << "position " << t;
+    }
+}
+
+namespace {
+
+// gumbel_sfpu.h's approximate log, re-derived on the host. The four constants are DUPLICATED from
+// ttml::metal::sfpu::gumbel_noise_log in gumbel_sfpu.h -- keep them in sync with that header. The
+// header itself is TRISC-only, so the invariants the kernel relies on are pinned here by
+// reconstruction.
+constexpr float kApproxLogLn2 = 0.693359375F;
+constexpr float kApproxLogB = -0.240234375F;
+constexpr float kApproxLogC = 1.4140625F;
+constexpr float kApproxLogD = -0x1.2c801p+0F;
+
+// The mantissa polynomial p(m) = m*(m*B + C) + D on the octave [1, 2), in double.
+double approx_log_poly(double m) {
+    return m * (m * static_cast<double>(kApproxLogB) + static_cast<double>(kApproxLogC)) +
+           static_cast<double>(kApproxLogD);
+}
+
+// The full approximation log(v) ~= e*ln2 + p(m) for v = m * 2^e, m in [1, 2), matching the
+// setexp/exexp split the SFPI pass performs.
+template <typename T>
+T approx_log(T v) {
+    int exponent = 0;
+    const T half_mantissa = std::frexp(v, &exponent);  // v = half_mantissa * 2^exponent, in [0.5, 1)
+    const T m = half_mantissa * T(2);
+    const T e = static_cast<T>(exponent - 1);
+    const T poly = m * (m * T(kApproxLogB) + T(kApproxLogC)) + T(kApproxLogD);
+    return e * T(kApproxLogLn2) + poly;
+}
+
+}  // namespace
+
+TEST(GumbelSfpuHostTest, TestGumbelApproxLogInvariants) {
+    constexpr double kTwoPowNeg20 = 0x1p-20;
+
+    // Endpoint ties, exact: p(1) = -2^-20 and p(2) = ln2_c - 2^-20. These are what make
+    // e*ln2_c + p(m) continuous across octave boundaries, and the shared -2^-20 shift is what
+    // keeps -log(U) strictly positive without a zero guard.
+    EXPECT_EQ(approx_log_poly(1.0), -kTwoPowNeg20);
+    EXPECT_EQ(approx_log_poly(2.0), static_cast<double>(kApproxLogLn2) - kTwoPowNeg20);
+
+    // p rises across a dense sweep of the octave, including the fp32 neighbours of both
+    // endpoints, and stays within the fitted error bound of the exact log. A monotone transform
+    // of U cannot reorder samples, so this is the property that preserves argmax semantics.
+    constexpr int kGridPoints = 1'000'000;
+    std::vector<double> grid;
+    grid.reserve(kGridPoints + 4);
+    grid.push_back(1.0);
+    grid.push_back(static_cast<double>(std::nextafterf(1.0F, 2.0F)));
+    for (int i = 1; i < kGridPoints; ++i) {
+        grid.push_back(1.0 + static_cast<double>(i) / kGridPoints);
+    }
+    grid.push_back(static_cast<double>(std::nextafterf(2.0F, 1.0F)));
+    grid.push_back(2.0);
+    std::sort(grid.begin(), grid.end());
+
+    uint32_t monotonicity_violations = 0U;
+    double max_error = 0.0;
+    double prev = approx_log_poly(grid.front());
+    for (double m : grid) {
+        const double p = approx_log_poly(m);
+        if (p < prev) {
+            ++monotonicity_violations;
+        }
+        prev = p;
+        if (m < 2.0) {
+            max_error = std::max(max_error, std::abs(p - std::log(m)));
+        }
+    }
+    EXPECT_EQ(monotonicity_violations, 0U) << "p(m) must be nondecreasing on [1, 2]";
+    EXPECT_LE(max_error, 5.5e-3) << "|p(m) - ln(m)| left the fitted bound";
+
+    // Across octave boundaries: the full approximation, evaluated at fp32-adjacent points spanning
+    // powers of two, must be nondecreasing. The exponent range comfortably covers everything the
+    // noise chain feeds it: U in [2^-32, 1) and -log(U) in [~1e-6, ~22].
+    for (int e = -40; e <= 32; e += 8) {
+        const float x = std::ldexp(1.0F, e);
+        const float below = std::nextafterf(x, 0.0F);
+        const float above = std::nextafterf(x, HUGE_VALF);
+        EXPECT_LE(approx_log<double>(static_cast<double>(below)), approx_log<double>(static_cast<double>(x)))
+            << "octave boundary below 2^" << e;
+        EXPECT_LE(approx_log<double>(static_cast<double>(x)), approx_log<double>(static_cast<double>(above)))
+            << "octave boundary above 2^" << e;
+    }
+
+    // Noise ceiling. At the raw upper bound 1 - 2^-24 the fused chain stays finite (the whole
+    // point of bounding U below 1.0); the generator's ATTAINABLE top of range sits one fp32 step
+    // lower still, because the factory shrinks rand's closed-interval scale by one ULP when
+    // from + scale would round past the bound (compute_rand_scale_bits), and there the ceiling is
+    // near 13.75 -- the approximate-log analogue of the exact log's ~16.6.
+    const float u_raw_max = std::nextafterf(1.0F, 0.0F);  // kGumbelUniformUpperBound
+    const float raw_inner = approx_log<float>(u_raw_max);
+    ASSERT_LT(raw_inner, 0.0F) << "log(U) must stay strictly negative below 1.0";
+    EXPECT_LE(-approx_log<float>(-raw_inner), 13.9F);
+
+    const float lower = 0x1p-32F;  // kGumbelUniformLowerBound
+    float scale = u_raw_max - lower;
+    uint32_t scale_bits = std::bit_cast<uint32_t>(scale);
+    if (lower + scale > u_raw_max && scale_bits != 0U) {
+        --scale_bits;
+        scale = std::bit_cast<float>(scale_bits);
+    }
+    const float u_top = lower + scale;
+    const float top_inner = approx_log<float>(u_top);
+    ASSERT_LT(top_inner, 0.0F);
+    EXPECT_LE(-approx_log<float>(-top_inner), 13.8F) << "noise ceiling left the documented ~13.75 cap";
 }


### PR DESCRIPTION
### PR Category
Perf

### Summary
Stacks on #52973 (base = `awliu/ttml_sample_fix`): three device-side optimizations to the fused `gumbel_sample` op plus the benchmark that substantiates them. **End-to-end sample latency (dispatch + device + token readback, warm program cache, BH loudbox): −54% geomean** across GRPO-representative shapes.

| Config | #52973 head | this PR | Δ |
|---|---|---|---|
| decode `[8,1,1,151936]` | 1.212 ms | **0.552 ms** | −54% |
| decode + mask | 1.274 ms | 0.602 ms | −53% |
| positioned prefill `[8,1,256,151936]` | 1.184 ms | 0.556 ms | −53% |
| positions batch-512 `[512,1,64,16000]` | 7.289 ms | **3.206 ms** | −56% |
| greedy (T=0) `[8,1,1,151936]` | 0.516 ms | 0.361 ms | −30% |

Measured with the included `gumbel_sample_benchmark` (median of 100/30/20 iters, per-iter seed variation, timed region includes the token-id readback GRPO pays each step).

### The three optimizations
1. **Fused SFPI noise chain** (`gumbel_sfpu.h`): the per-tile chain rand → log → neg → log → neg → mul → add was 7 serialized full-tile DST passes; now `rand_tile` + ONE op-local SFPI pass computing `score = logit·(1/T) − log(−log U)` entirely in LREGs (pattern follows `moe_gate_mm`'s op-local SFPU header and tt-train's own `mul_then_sfpi_exp`). Device profile: noise-chain cost 686 → 270 µs per decode dispatch.
2. **Per-row-owner boundary merge** (writer + factory): the all-to-origin exchange serialized a ~134 µs (decode) / ~389 µs (b512) merge tail on one core after all workers finished. Rows split across cores are now merged by the core holding the row's first tile, with exact host-computed routing/fan-in (contiguous ranges ⇒ each core sends ≤1 record and merges ≤1 row); records CB shrinks 63 KB → ~4 KB. Profiled tail after: 0.2 µs.
3. **Approximate log in the noise chain**: noise needs distributional fidelity, not ULP accuracy. A monotone, endpoint-tied quadratic-per-octave (fp16a-exact constants) replaces both precise minimax log evaluations, −34% fused-pass instructions. `GUMBEL_SAMPLE_PRECISE_LOG` (source-level toggle, rationale in the commit) restores the exact body for A/B.

### Accuracy
All existing gates pass on BH silicon (P150 loudbox): exact argmax suite, positions suite incl. B=512 and cache-hit repatch, 5σ binomial distribution (8200 samples × 4 seeds, flat and positions+mask paths), same-seed reproducibility, cross-seed decorrelation. Two new tests added: `TestGumbelApproxLogInvariants` (host-only: monotonicity across octave boundaries, endpoint ties, ≤5.5e-3 error bound, noise ceiling) and `TestSamplingWideRowManyOwners` (grid-scale merge fan-in — every core feeding one owner — previously exercised only up to fan-in 3).

**Behavior notes for reviewers:**
- The noise log's accuracy family changes (Juffa-derived precise → op-local approx, max err ~5.4e-3 in ln): sampled distributions shift <1% in probability, invisible to the 5σ gate; greedy path is untouched (compiled out via `DO_GUMBEL_NOISE`).
- Max attainable Gumbel noise is now ~13.75 (was ~16.6) — compresses only the ~1e-6 upper quantile.
- RNG stream semantics unchanged (`rand_tile` verbatim, same draw order, same per-device/stream seeding).

### Validation coverage
BH silicon only. WH (N150/N300) not run: the SFPI constructs are byte-identical across both arches' llk headers and `rand_tile`'s documented register contract is respected, but the sampled-path binaries (`TestSamplingPositiveTemperature*`, distribution, seed EQ/NE) should run on WH before merge — flagged, not silently omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ayerofieiev/perf/gumbel-sample-device-opts)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ayerofieiev/perf/gumbel-sample-device-opts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ayerofieiev/perf/gumbel-sample-device-opts)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ayerofieiev/perf/gumbel-sample-device-opts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ayerofieiev/perf/gumbel-sample-device-opts)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ayerofieiev/perf/gumbel-sample-device-opts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ayerofieiev/perf/gumbel-sample-device-opts)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ayerofieiev/perf/gumbel-sample-device-opts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ayerofieiev/perf/gumbel-sample-device-opts)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ayerofieiev/perf/gumbel-sample-device-opts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ayerofieiev/perf/gumbel-sample-device-opts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ayerofieiev/perf/gumbel-sample-device-opts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ayerofieiev/perf/gumbel-sample-device-opts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ayerofieiev/perf/gumbel-sample-device-opts)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ayerofieiev/perf/gumbel-sample-device-opts)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ayerofieiev/perf/gumbel-sample-device-opts)