### PR TITLE
[Test Only] Flux.1 attention + transformer block tests: enumerate mesh sizes directly, require exact device count

### DIFF
--- a/models/tt_dit/tests/models/flux1/test_attention_flux1.py
+++ b/models/tt_dit/tests/models/flux1/test_attention_flux1.py
@@ -18,20 +18,20 @@ from ....utils.tensor import bf16_tensor
 
 
 @pytest.mark.parametrize(
-    ("mesh_device", "mesh_shape", "sp_axis", "tp_axis"),
+    ("mesh_device", "sp_axis", "tp_axis"),
     [
-        pytest.param((2, 4), (1, 1), 0, 1, id="1x1sp0tp1"),
-        pytest.param((2, 4), (1, 2), 0, 1, id="1x2sp0tp1"),
-        pytest.param((2, 4), (1, 2), 1, 0, id="1x2sp1tp0"),
-        pytest.param((2, 4), (2, 1), 0, 1, id="2x1sp0tp1"),
-        pytest.param((2, 4), (2, 1), 1, 0, id="2x1sp1tp0"),
-        pytest.param((2, 4), (2, 2), 0, 1, id="2x2sp0tp1"),
-        pytest.param((2, 4), (2, 2), 1, 0, id="2x2sp1tp0"),
-        pytest.param((2, 4), (2, 4), 0, 1, id="2x4sp0tp1"),
-        pytest.param((2, 4), (2, 4), 1, 0, id="2x4sp1tp0"),
-        pytest.param((4, 8), (4, 4), 0, 1, id="4x4sp0tp1"),
-        pytest.param((4, 8), (4, 8), 0, 1, id="4x8sp0tp1"),
-        pytest.param((4, 8), (4, 8), 1, 0, id="4x8sp1tp0"),
+        pytest.param((1, 1), 0, 1, id="1x1sp0tp1"),
+        pytest.param((1, 2), 0, 1, id="1x2sp0tp1"),
+        pytest.param((1, 2), 1, 0, id="1x2sp1tp0"),
+        pytest.param((2, 1), 0, 1, id="2x1sp0tp1"),
+        pytest.param((2, 1), 1, 0, id="2x1sp1tp0"),
+        pytest.param((2, 2), 0, 1, id="2x2sp0tp1"),
+        pytest.param((2, 2), 1, 0, id="2x2sp1tp0"),
+        pytest.param((2, 4), 0, 1, id="2x4sp0tp1"),
+        pytest.param((2, 4), 1, 0, id="2x4sp1tp0"),
+        pytest.param((4, 4), 0, 1, id="4x4sp0tp1"),
+        pytest.param((4, 8), 0, 1, id="4x8sp0tp1"),
+        pytest.param((4, 8), 1, 0, id="4x8sp1tp0"),
     ],
     indirect=["mesh_device"],
 )
@@ -42,20 +42,25 @@ from ....utils.tensor import bf16_tensor
         # (1, 4096 + 512, 0),
     ],
 )
-@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "require_exact_physical_num_devices": True,
+        }
+    ],
+    indirect=True,
+)
 def test_attention_flux1(
     *,
     mesh_device: ttnn.MeshDevice,
-    mesh_shape: tuple[int, int],
     sp_axis: int,
     tp_axis: int,
     batch_size: int,
     spatial_seq_len: int,
     prompt_seq_len: int,
 ) -> None:
-    parent_mesh = mesh_device
-    mesh_device = parent_mesh.create_submesh(ttnn.MeshShape(*mesh_shape))
-
     torch.manual_seed(0)
 
     query_dim = 3072

--- a/models/tt_dit/tests/models/flux1/test_transformer_block_flux1.py
+++ b/models/tt_dit/tests/models/flux1/test_transformer_block_flux1.py
@@ -41,7 +41,16 @@ from ....utils.tensor import bf16_tensor, bf16_tensor_2dshard
         (1, 4096, 512),
     ],
 )
-@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "require_exact_physical_num_devices": True,
+        }
+    ],
+    indirect=True,
+)
 def test_transformer_block_flux1(
     *,
     mesh_device: ttnn.MeshDevice,


### PR DESCRIPTION
### PR Category
Test Only

### Summary
Two changes to the flux1 unit tests that #52504 wired into the `flux.1-dev` `bh_quietbox_2` CI leg on Aug 11.

**1. `test_transformer_block_flux1` — require exact physical device count (fixes the current CI break)**

This test has failed on `bh_quietbox_2` in **every** `(Tier 1) Models Unit Tests` run on `main` since Aug 11 — 12 consecutive scheduled runs, identical signature. The `1x2sp0tp1` param asks for a `(1, 2)` parent mesh on the 4-chip QuietBox and errors at setup:

```
ERROR at setup of test_transformer_block_flux1[blackhole-device_params0-1-4096-512-1x2sp0tp1]
RuntimeError: TT_THROW @ tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp:271
Fabric Router Sync: Timeout after 10000 ms on Device 0|2: expected status 0xa2b2c2d2.
Master chan=2 got 0xa0b0c0d0. furthest-behind stage: STARTED
  -> FabricFirmwareInitializer::wait_for_fabric_router_sync
  -> DeviceManager::initialize_fabric_and_dispatch_fw
  -> MeshDevice::create / open_mesh_device
```

The full `2x2` mesh on the same box initializes fine and that param passes immediately afterwards, so this is specific to opening a *partial* (1x2) mesh on QB2 — not a broken board and not a model bug.

Adding `require_exact_physical_num_devices: True` makes the `mesh_device` fixture (`conftest.py:575`) skip params whose parent mesh doesn't match the physical device count — the same idiom `test_pipeline_flux1.py:31`, `test_transformer_flux1.py:57,218` and `test_performance_flux1.py:46` already use. On QB2 the suite goes from `1 passed, 6 skipped, 1 error` to `1 passed, 7 skipped`, keeping exactly the coverage that was already green.

**2. `test_attention_flux1` — enumerate mesh sizes directly instead of submeshing**

This test parameterized *both* a parent `mesh_device` and a `mesh_shape` submesh carved out of it, so the parent was pure scaffolding: every case opened a `(2, 4)` or `(4, 8)` mesh only to `create_submesh()` the shape it actually wanted. The submesh is gone; the mesh sizes we care about are now enumerated directly as the `mesh_device` param, with every sp/tp permutation preserved (same 12 ids). Same `require_exact_physical_num_devices` treatment.

### CI validation

Dispatched `(Tier 1) Models Unit Tests` (`model=flux.1-dev`, `sku=bh_quietbox_2`) on this branch.

Change 1 is verified green — [run 32187216280](https://github.com/tenstorrent/tt-metal/actions/runs/32187216280), `test_transformer_block_flux1` reporting `1 passed, 7 skipped` with the `1x2` param gated out:

```
PASSED  test_transformer_block_flux1[...-2x2sp0tp1]
SKIPPED [1] Test requires exact match of requested num devices (2) to available physical num devices (4)
SKIPPED [3] ... (8) ...
SKIPPED [3] ... (32) ...
```

and zero `Fabric Router Sync: Timeout` occurrences, versus one in each of the 12 preceding runs on main.

Change 2 is verified green too — [run 32202326345](https://github.com/tenstorrent/tt-metal/actions/runs/32202326345). All four flux.1-dev suites on QB2:

| suite | before | after |
|---|---|---|
| `test_pipeline_flux1 -k flux_dev` | 2 passed, 18 skipped, 22 deselected | unchanged |
| `test_transformer_flux1 -k flux_dev` | 2 passed, 12 skipped, 14 deselected | unchanged |
| `test_attention_flux1` | 12 skipped | **2 passed, 10 skipped** |
| `test_transformer_block_flux1` | 1 passed, 6 skipped, **1 error** | **1 passed, 7 skipped** |

The two attention configs that had never executed on QB2 both pass:

```
PASSED  test_attention_flux1[...-2x2sp0tp1]
PASSED  test_attention_flux1[...-2x2sp1tp0]
```

and the skip reasons now resolve against real device counts (1, 2, 8, 16, 32) rather than collapsing to the old 8-and-32 parent meshes — i.e. the enumerated sizes are the meshes actually opened.

### Notes for reviewers

- **The attention refactor is a genuine coverage *increase* on QB2.** Previously all 12 params skipped there (every parent mesh was 8 or 32 devices on a 4-device box) — the suite reported `12 skipped in 1.87s`, i.e. it was dead weight in CI. With meshes enumerated directly, `2x2sp0tp1` and `2x2sp1tp0` match the box and now execute for the first time. Both pass (see CI validation above), but flagging it since it means this suite is doing real work on QB2 where it previously did none.
- **Coverage tradeoff on larger boxes.** Exact-match is stricter than the old `>` check everywhere, not just QB2. On a Galaxy (32 devices) the small-mesh params previously opened an undersized parent mesh and ran; now only the `(4, 8)` params will. Same tradeoff the sibling flux1 tests already accepted, but flagging it explicitly since it applies to both files here.
- **This does not fix the underlying fabric issue.** Fabric init on a 1x2 submesh of a 4-chip BH QuietBox still times out on the router handshake; this only stops the test asking for a configuration that doesn't work there. Happy to file a separate issue against fabric if one doesn't already exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

