### PR TITLE
[Performance] Bound the per-device fan-out in EnqueueMeshWorkload

### DIFF
--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -108,6 +108,12 @@ void record_program_sub_device_for_range(
 // per workload: the first task to reach the program takes ownership through `prepared` and the rest
 // block there until the update lands. If the owner throws, the flag stays clear and the next waiter
 // retries, so a waiter can never block forever.
+// Ceiling on how many workers a single MeshWorkload dispatch may fan out across, including the calling
+// thread. Bounded because the calling thread pays for every worker it wakes, serially: measured on a
+// 32-device mesh, a large workload is fastest at 8 and gets worse from there, as the wake-ups start to
+// cost more than the copying they overlap.
+constexpr size_t k_max_dispatch_fanout = 8;
+
 struct ProgramDispatchEntry {
     Program* program = nullptr;
     ProgramCommandSequence* cmd_seq = nullptr;
@@ -569,6 +575,9 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     std::vector<DeviceDispatchTask> program_tasks;
     program_tasks.reserve(mesh_device_->shape().mesh_size());
     std::unordered_set<uint32_t> chip_ids_in_workload = {};
+    // Command-stream bytes this workload will copy across all local devices, used below to size the
+    // fan-out.
+    size_t total_command_bytes = 0;
 
     uint32_t program_idx = 0;
     for (auto& [device_range, program] : programs) {
@@ -587,6 +596,9 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
             program_tasks.push_back(DeviceDispatchTask{device, &entry});
             chip_ids_in_workload.insert(device->id());
         });
+        total_command_bytes += static_cast<size_t>(entry.cmd_seq->get_one_shot_fetch_size(
+                                   dispatch_metadata.stall_first, dispatch_metadata.stall_before_program, true)) *
+                               (program_tasks.size() - tasks_before_program);
         if (program_tasks.size() == tasks_before_program) {
             // The program runs entirely on devices owned by another host, so no task will claim it.
             // Still update its dispatch commands here, to match what a single-host mesh would do.
@@ -631,17 +643,44 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
             dispatch_metadata.stall_before_program);
     };
 
-    // Each device has its own sysmem manager, so the program writes are independent and go out in
+    // Each device has its own sysmem manager, so the program writes are independent and can go out in
     // parallel on the pool, which has a thread pinned near each device. The pool is quiescent here:
     // every other user of it joins before releasing the MeshDevice API lock this function holds.
     //
-    // The calling thread keeps one write for itself rather than handing out all of them. Waking a
-    // worker costs tens of microseconds, so a workload covering a single device would otherwise pay
-    // for the pool without getting any overlap in return.
-    for (size_t i = 1; i < program_tasks.size(); i++) {
-        const auto& task = program_tasks[i];
+    // Hand out a bounded number of chunks rather than one task per device. Handing a device's write to
+    // a worker costs this thread a queue push and a futex wake, about 1.4 us and all of it serial,
+    // while performing the write inline costs about 0.66 us for a model-sized program. One task per
+    // device therefore makes a wide mesh pay more in wake-ups than it recovers in overlap: measured on
+    // a 4x8 mesh, a one-shot program cost 29 us of host time written serially and 67 us fanned out
+    // across all 32. With K chunks the wake cost is K rather than the device count, and each worker
+    // walks its devices back to back. The calling thread takes the first chunk, so a single-device
+    // workload never touches the pool at all.
+    auto write_chunk = [&](size_t begin, size_t end) {
+        for (size_t i = begin; i < end; i++) {
+            write_program_for_device(program_tasks[i]);
+        }
+    };
+    const size_t num_tasks = program_tasks.size();
+    // A chunk has to carry enough copying to pay for the wake that hands it over. At roughly 25 GB/s
+    // of hugepage write bandwidth the wake is worth about 32 KB of command stream, so scale the
+    // fan-out with the bytes on hand: a model-sized program stays serial on any mesh width, while a
+    // large one spreads out. Sizing by device count instead gets both ends wrong, fanning a cheap
+    // workload across a wide mesh out for nothing and confining an expensive one on a narrow mesh to
+    // a single thread.
+    constexpr size_t k_bytes_worth_a_wake = 32 * 1024;
+    size_t num_chunks = 0;
+    if (num_tasks) {
+        const size_t upper_bound = std::min(num_tasks, k_max_dispatch_fanout);
+        num_chunks = std::clamp(total_command_bytes / k_bytes_worth_a_wake, size_t{1}, upper_bound);
+    }
+    // Chunk c covers [num_tasks * c / num_chunks, num_tasks * (c + 1) / num_chunks), splitting the
+    // devices as evenly as an uneven division allows.
+    const auto chunk_start = [&](size_t chunk) { return num_chunks ? (num_tasks * chunk) / num_chunks : 0; };
+    for (size_t c = 1; c < num_chunks; c++) {
+        const size_t begin = chunk_start(c);
+        const size_t end = chunk_start(c + 1);
         dispatch_thread_pool_->enqueue(
-            [&write_program_for_device, &task]() { write_program_for_device(task); }, task.device->id());
+            [&write_chunk, begin, end]() { write_chunk(begin, end); }, program_tasks[begin].device->id());
     }
     // The work below can throw - a device timeout surfaces as an exception out of the fetch queue -
     // and the tasks enqueued above hold references into this frame. Join the pool on every path out
@@ -658,13 +697,13 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
             mcast_go_signals,
             unicast_go_signals,
             dispatch_metadata);
-        if (!program_tasks.empty()) {
-            write_program_for_device(program_tasks.front());
+        if (num_chunks) {
+            write_chunk(chunk_start(0), chunk_start(1));
         }
     } catch (...) {
         dispatch_exception = std::current_exception();
     }
-    if (program_tasks.size() > 1) {
+    if (num_chunks > 1) {
         try {
             dispatch_thread_pool_->wait();
         } catch (...) {

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -117,6 +117,8 @@ constexpr size_t k_max_dispatch_fanout = 8;
 struct ProgramDispatchEntry {
     Program* program = nullptr;
     ProgramCommandSequence* cmd_seq = nullptr;
+    // Command-stream bytes one device pays to run this program, used to place the chunk boundaries.
+    size_t cmd_bytes = 0;
     std::once_flag prepared;
 };
 
@@ -596,9 +598,9 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
             program_tasks.push_back(DeviceDispatchTask{device, &entry});
             chip_ids_in_workload.insert(device->id());
         });
-        total_command_bytes += static_cast<size_t>(entry.cmd_seq->get_one_shot_fetch_size(
-                                   dispatch_metadata.stall_first, dispatch_metadata.stall_before_program, true)) *
-                               (program_tasks.size() - tasks_before_program);
+        entry.cmd_bytes = entry.cmd_seq->get_one_shot_fetch_size(
+            dispatch_metadata.stall_first, dispatch_metadata.stall_before_program, true);
+        total_command_bytes += entry.cmd_bytes * (program_tasks.size() - tasks_before_program);
         if (program_tasks.size() == tasks_before_program) {
             // The program runs entirely on devices owned by another host, so no task will claim it.
             // Still update its dispatch commands here, to match what a single-host mesh would do.
@@ -673,12 +675,32 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
         const size_t upper_bound = std::min(num_tasks, k_max_dispatch_fanout);
         num_chunks = std::clamp(total_command_bytes / k_bytes_worth_a_wake, size_t{1}, upper_bound);
     }
-    // Chunk c covers [num_tasks * c / num_chunks, num_tasks * (c + 1) / num_chunks), splitting the
-    // devices as evenly as an uneven division allows.
-    const auto chunk_start = [&](size_t chunk) { return num_chunks ? (num_tasks * chunk) / num_chunks : 0; };
-    for (size_t c = 1; c < num_chunks; c++) {
-        const size_t begin = chunk_start(c);
-        const size_t end = chunk_start(c + 1);
+    // Place the boundaries by cumulative bytes rather than by device count, so that a workload whose
+    // programs differ in size splits by the work each chunk carries. Splitting by device count would
+    // put all the copying in whichever chunk held the largest program while the others were woken to
+    // do nothing. Closing a chunk once it holds its even share also collapses the fan-out on its own
+    // when the bytes are lopsided: a single large program among small ones ends up alone in one chunk
+    // with the remainder in the next, rather than spread across all of them.
+    std::array<size_t, k_max_dispatch_fanout + 1> chunk_bounds{};
+    size_t num_bounds = 0;
+    chunk_bounds[num_bounds++] = 0;
+    if (num_chunks) {
+        const size_t target_bytes = total_command_bytes / num_chunks;
+        size_t bytes_this_chunk = 0;
+        for (size_t i = 0; i < num_tasks; i++) {
+            bytes_this_chunk += program_tasks[i].program_entry->cmd_bytes;
+            const bool more_chunks_allowed = num_bounds < num_chunks;
+            const bool more_tasks_left = i + 1 < num_tasks;
+            if (bytes_this_chunk >= target_bytes && more_chunks_allowed && more_tasks_left) {
+                chunk_bounds[num_bounds++] = i + 1;
+                bytes_this_chunk = 0;
+            }
+        }
+    }
+    chunk_bounds[num_bounds] = num_tasks;
+    for (size_t c = 1; c < num_bounds; c++) {
+        const size_t begin = chunk_bounds[c];
+        const size_t end = chunk_bounds[c + 1];
         dispatch_thread_pool_->enqueue(
             [&write_chunk, begin, end]() { write_chunk(begin, end); }, program_tasks[begin].device->id());
     }
@@ -692,8 +714,8 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
         // last participating device's launch, while a device outside the workload only needs its go
         // signal before the next barrier, so writing the go signals first delays every launch by the
         // time they take.
-        if (num_chunks) {
-            write_chunk(chunk_start(0), chunk_start(1));
+        if (num_tasks) {
+            write_chunk(chunk_bounds[0], chunk_bounds[1]);
         }
         // A go signal is a few hundred bytes, far less work than waking a worker to hand one over, so
         // the calling thread issues them itself, overlapping them with the workers above.
@@ -707,7 +729,7 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     } catch (...) {
         dispatch_exception = std::current_exception();
     }
-    if (num_chunks > 1) {
+    if (num_bounds > 1) {
         try {
             dispatch_thread_pool_->wait();
         } catch (...) {

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -688,8 +688,15 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
     // original exception wins over anything a worker reports.
     std::exception_ptr dispatch_exception;
     try {
-        // A go signal is a few hundred bytes, far less work than waking a worker to hand one over,
-        // so the calling thread issues them itself here, overlapping them with the workers above.
+        // This thread's own share of the program writes comes first. What the workload waits on is the
+        // last participating device's launch, while a device outside the workload only needs its go
+        // signal before the next barrier, so writing the go signals first delays every launch by the
+        // time they take.
+        if (num_chunks) {
+            write_chunk(chunk_start(0), chunk_start(1));
+        }
+        // A go signal is a few hundred bytes, far less work than waking a worker to hand one over, so
+        // the calling thread issues them itself, overlapping them with the workers above.
         this->write_go_signal_sequences_to_unused_sub_grids(
             chip_ids_in_workload,
             sub_device_id,
@@ -697,9 +704,6 @@ void FDMeshCommandQueue::enqueue_mesh_workload(MeshWorkload& mesh_workload, bool
             mcast_go_signals,
             unicast_go_signals,
             dispatch_metadata);
-        if (num_chunks) {
-            write_chunk(chunk_start(0), chunk_start(1));
-        }
     } catch (...) {
         dispatch_exception = std::current_exception();
     }


### PR DESCRIPTION
### PR Category

Performance

### Summary

`EnqueueMeshWorkload` hands each local device's command-stream write to its own pinned pool worker. Handing one over costs the calling thread a queue push and a futex wake — about 1.4 µs, all of it serial — while performing the write inline costs about 0.66 µs for a model-sized program. One task per device therefore spends more on wake-ups than it recovers in overlap, and the cost grows with mesh width.

Measured on a 4×8 Wormhole Galaxy, one one-shot program spanning N devices, p50 host time per enqueue, 1000 samples:

| devices | serial | one task per device |
|---|---|---|
| 8 | 23.1 µs | 33.2 µs |
| 16 | 25.0 µs | 43.6 µs |
| 32 | 29.2 µs | 67.1 µs |

The fitted marginal cost is 0.25 µs per device written inline against 1.41 µs per device handed out, on the same ~21 µs of fixed cost. Launch skew follows the same curve: the spread between the first and last device's fetch-queue doorbell went from 20.4 to 49.1 µs at 32 devices, worst case 409 µs. That matters because a collective cannot finish until its last participant is running, which is the shape behind the ring-MLA variance in #53535.

The earlier measurement that motivated the fan-out used `create_benchmark_programs`, whose 443 KB command stream costs ~17 µs of copying per device. Parallelising that pays. A model-sized op is two orders of magnitude smaller, and does not.

Three changes:

1. **Bound the fan-out.** Hand out a bounded number of chunks rather than one task per device, each worker walking several devices back to back and the calling thread taking the first chunk, so the wake cost is the chunk count rather than the device count. The width is sized by the bytes on hand — a wake is worth about 32 KB of command stream at 25 GB/s — so a model-sized program stays serial on any mesh width while a large one spreads out to a ceiling of 8. Sizing by device count gets both ends wrong: it fans a cheap workload across a wide mesh out for nothing, and confines an expensive one on a narrow mesh to a single thread. A single-device workload still never touches the pool.

2. **Write a workload's own programs before the unused-device go signals.** The calling thread issued go signals to uncovered devices first. A full-mesh workload has none, so this was free there, but an 8-device workload on a 4×8 mesh writes 24 of them — about 10 µs — ahead of every program launch.

3. **Cut the chunks at equal cumulative bytes** rather than equal device counts, so a workload whose programs differ in size splits by the work each chunk carries instead of leaving all the copying in whichever chunk held the largest program.

Results, p50 µs, `last` being the time from the enqueue call to the last participating device's doorbell:

| shape | metric | before #52775 | main today | this branch |
|---|---|---|---|---|
| one-shot, 8 dev | last | 10.0 | 29.5 | 10.5 |
| one-shot, 16 dev | last | 15.3 | 39.7 | 15.9 |
| one-shot, 32 dev | call | 29.2 | 67.1 | 29.7 |
| one-shot, 32 dev | skew | 20.4 | 49.1 | 19.2 |
| one-shot, 32 dev | skew max | 41.5 | 409.0 | 32.1 |
| 443 KB program, 32 dev | skew | 549.8 | 248.8 | 185.3 |

Every shape is back to its pre-#52775 cost or better, and the runtime-arg-heavy program that #52775 was tuned against keeps its win and improves on it, because 32 chunks was past the useful width for it too.

Relates to #53545. Relates to #52756.

### Notes for reviewers

**Where to focus — change 2 interacts with #52782.** That PR made `write_go_signal_sequences_to_unused_sub_grids` carry a config-ring stall count so uncovered devices receive it before a later workload overwrites the freed ring region. Change 2 reorders that call relative to the calling thread's own program writes. My reading is that the invariant is cross-workload — both the covered devices' stall, via their program sequence, and the uncovered devices' stall still land inside the same enqueue, so their order within it does not affect it. I did not write that fix, so this is the claim I would most like a second opinion on.

**The two constants are the arguable part, not the shape of the fix.** The 32 KB per-wake figure comes from ~1.4 µs of wake against ~25 GB/s of hugepage write bandwidth. The ceiling of 8 was the best of a 1/2/4/8/16/32 sweep on a 32-device mesh, where 16 and 32 were both worse than 8 for every shape measured, including the large program:

| fan-out | 8 dev call | 32 dev call | 32 dev last | 32 dev skew | 443 KB skew |
|---|---|---|---|---|---|
| 1 (serial) | 23.5 | 29.5 | 26.4 | 19.1 | 531.1 |
| 2 | 25.1 | 31.4 | 27.0 | 16.3 | 341.0 |
| 4 | 28.2 | 30.5 | 25.7 | 10.8 | 242.6 |
| 8 | 34.3 | 31.6 | 26.4 | 11.6 | 181.2 |
| 16 | 34.4 | 42.5 | 37.1 | 22.6 | 243.2 |
| 32 (today) | 34.6 | 71.3 | 64.1 | 49.4 | 285.5 |

Both are host-CPU and bandwidth properties, so they want re-measuring on Blackhole Galaxy before being trusted there. I had these behind an environment variable while sweeping and have removed it — they are plain constants now.

**Change 3 earns less than changes 1 and 2, and is the one to drop if you want a smaller PR.** Measured on a deliberately lopsided workload — one 443 KB program on a single device, small programs on the other 31, drained before each timed call so the numbers are host-side rather than backpressure:

| lopsided workload | equal device counts | equal cumulative bytes |
|---|---|---|
| call p50 | 256.4 µs | 242.9 µs |
| last p50 | 230.1 µs | 227.1 µs |
| skew p50 | 56.9 µs | 57.7 µs |

It does what it is designed to do — the byte-cut collapses this workload from 8 chunks to 2, since the large program fills the first chunk by itself and the 31 small ones cannot reach the target, saving six wakes. But the critical path is the 443 KB copy either way, so `last` moves only 3 µs. The argument for it is that it removes a footgun rather than that it speeds up a common case, and it is a no-op for the homogeneous workloads that dominate, where equal bytes and equal counts give the same cut. Happy to drop it.

**Measurement method.** All figures are p50 over 1000 back-to-back enqueues, using a temporary patch that timestamps each device's fetch-queue doorbell. Neither the instrumentation nor the benchmark is in this branch, because the benchmark depends on `extern "C"` globals in `dispatch.cpp`. There is no in-tree perf guard for this path — an enqueue-timing test that stands alone would catch this class of regression and is worth adding separately.

**Testing.** On a 32-chip Wormhole Galaxy, the `MeshWorkload`, `MeshTrace`, `MeshEvents` and `MeshSubDevice` suites in `distributed_unit_tests` pass 49/49 against the tip, and 49/49 with change 3 reverted.

A Blaze prefill run of the GLM 5.2 chunked stage from #53545 is dispatched against this branch on Blackhole Galaxy, which is both the workload that motivated the fix and the first end-to-end model measurement of it: everything above is a microbenchmark on synthetic programs.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/bound-mesh-dispatch-fanout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/bound-mesh-dispatch-fanout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/bound-mesh-dispatch-fanout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/bound-mesh-dispatch-fanout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/bound-mesh-dispatch-fanout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/bound-mesh-dispatch-fanout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/bound-mesh-dispatch-fanout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/bound-mesh-dispatch-fanout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/bound-mesh-dispatch-fanout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/bound-mesh-dispatch-fanout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/bound-mesh-dispatch-fanout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/bound-mesh-dispatch-fanout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/bound-mesh-dispatch-fanout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/bound-mesh-dispatch-fanout)
