### PR TITLE
Fix all_gather to derive axis topology and link count from real fabric wiring

### DIFF
--- a/tests/nightly/t3000/2d_ccl/test_all_gather.py
+++ b/tests/nightly/t3000/2d_ccl/test_all_gather.py
@@ -142,3 +142,36 @@ def test_all_gather_training_shapes(
         num_iters=num_iters,
         use_persistent_buffers=False,
     )
+
+
+# A 1x8 view of the 2x4 board is its perimeter, so axis 1 bends. Multicast cannot route that.
+@skip_for_blackhole("Requires wormhole_b0 to run")
+@pytest.mark.parametrize("mesh_device", [(1, 8)], indirect=True)
+@pytest.mark.parametrize("ag_output_shape, dim", [([1, 1, 128, 256], 3)])
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT])
+@pytest.mark.parametrize("ag_input_dtype", [ttnn.bfloat16])
+@pytest.mark.parametrize("mem_config_input, mem_config_ag", [(ttnn.DRAM_MEMORY_CONFIG, ttnn.DRAM_MEMORY_CONFIG)])
+@pytest.mark.parametrize(
+    "device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_2D}], indirect=True, ids=["fabric_2d"]
+)
+def test_all_gather_bent_axis(
+    mesh_device,
+    ag_output_shape,
+    dim,
+    ag_input_dtype,
+    layout,
+    mem_config_input,
+    mem_config_ag,
+):
+    run_all_gather_impl(
+        mesh_device,
+        ag_output_shape,
+        dim,
+        ag_input_dtype,
+        layout,
+        mem_config_input,
+        mem_config_ag,
+        enable_trace=False,
+        num_iters=2,
+        use_persistent_buffers=False,
+    )

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -172,7 +172,7 @@ void SetFabricConfig(
 FabricConfig GetFabricConfig();
 
 namespace experimental {
-    
+
 // How many ethernet links the weakest hop along one row or column can open. Planes held back for
 // dispatch do not count. `cluster_axis` picks the direction: 0 runs down a column, 1 runs along a
 // row. `row_or_col` picks which one of them. Returns 0 if no hop could be measured.

--- a/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
+++ b/tt_metal/api/tt-metalium/experimental/fabric/fabric.hpp
@@ -172,6 +172,10 @@ void SetFabricConfig(
 FabricConfig GetFabricConfig();
 
 namespace experimental {
+    
+// How many ethernet links the weakest hop along one row or column can open. Planes held back for
+// dispatch do not count. `cluster_axis` picks the direction: 0 runs down a column, 1 runs along a
+// row. `row_or_col` picks which one of them. Returns 0 if no hop could be measured.
 size_t get_number_of_available_routing_planes(
     const tt::tt_metal::distributed::MeshDevice& mesh_device, size_t cluster_axis, size_t row_or_col);
 }

--- a/tt_metal/fabric/fabric.cpp
+++ b/tt_metal/fabric/fabric.cpp
@@ -562,35 +562,44 @@ namespace experimental {
 
 size_t get_number_of_available_routing_planes(
     const tt::tt_metal::distributed::MeshDevice& mesh_device, size_t cluster_axis, size_t row_or_col) {
+    TT_FATAL(cluster_axis < 2, "Invalid cluster axis {}. Must be 0 or 1", cluster_axis);
     const auto& control_plane = tt::tt_metal::MetalContext::instance().get_control_plane();
+    const auto& mesh_view = mesh_device.get_view();
 
-    // Get any device from the cluster to determine fabric node
-    // For now, use chip 0 as a representative device
+    // Axis 0 runs down a column, axis 1 along a row.
+    const auto nodes = cluster_axis == 0 ? mesh_view.get_fabric_node_ids_on_column(row_or_col)
+                                         : mesh_view.get_fabric_node_ids_on_row(row_or_col);
 
-    size_t row_idx = cluster_axis == 0 ? 0 : row_or_col;
-    size_t col_idx = cluster_axis == 0 ? row_or_col : 0;
-    auto* first_chip = mesh_device.impl().get_device(row_idx, col_idx);
-    ChipId first_chip_id = first_chip->id();
-    auto fabric_node_in_row_or_col = control_plane.get_fabric_node_id_from_physical_chip_id(first_chip_id);
+    auto usable_planes = [&](const FabricNodeId& src, const FabricNodeId& dst) -> size_t {
+        const auto directions = get_neighbor_eth_directions(src, dst);
+        if (directions.empty()) {
+            return 0;  // the two chips are not wired together
+        }
+        return control_plane.get_num_usable_routing_planes(
+            src, control_plane.eth_direction_to_routing_direction(directions.front()));
+    };
 
-    // Map cluster axis to routing directions
-    constexpr std::array<std::array<RoutingDirection, 2>, 2> cluster_axis_directions_to_check = {
-        std::array<RoutingDirection, 2>{RoutingDirection::N, RoutingDirection::S},
-        std::array<RoutingDirection, 2>{RoutingDirection::E, RoutingDirection::W}};
+    std::optional<size_t> num_planes;
+    // Both ends describe the same link, so take the lower count. Never report more links than one
+    // side can open.
+    auto measure_link = [&](const FabricNodeId& a, const FabricNodeId& b) {
+        for (const size_t planes : {usable_planes(a, b), usable_planes(b, a)}) {
+            // Zero means the pair is not wired, or every plane is reserved for dispatch, or the
+            // chip belongs to another host. None of those say anything about what this row or
+            // column can open, so skip it instead of pulling the min down to zero.
+            if (planes > 0) {
+                num_planes = num_planes.has_value() ? std::min(*num_planes, planes) : planes;
+            }
+        }
+    };
 
-    TT_FATAL(
-        cluster_axis < cluster_axis_directions_to_check.size(),
-        "Invalid cluster axis {}. Must be less than {}",
-        cluster_axis,
-        cluster_axis_directions_to_check.size());
-    const auto& directions_to_check = cluster_axis_directions_to_check[cluster_axis];
-
-    size_t planes_dir0 = control_plane.get_num_usable_routing_planes(fabric_node_in_row_or_col, directions_to_check[0]);
-    size_t planes_dir1 = control_plane.get_num_usable_routing_planes(fabric_node_in_row_or_col, directions_to_check[1]);
-    // Take the min: dispatch-reserved planes can legitimately reduce the count in only one of the two
-    // opposing directions on an MMIO chip (e.g., the tunnel descends only southward), making the two
-    // values asymmetric while both remain valid. Conservatively take what both directions can support.
-    return std::min(planes_dir0, planes_dir1);
+    for (size_t i = 1; i < nodes.size(); i++) {
+        measure_link(nodes[i - 1], nodes[i]);
+    }
+    if (nodes.size() > 2) {
+        measure_link(nodes.back(), nodes.front());  // the closing link of a ring, if it is wired
+    }
+    return num_planes.value_or(0);
 }
 
 }  // namespace experimental

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
@@ -232,6 +232,7 @@ AllGatherDeviceOperation::program_factory_t AllGatherDeviceOperation::select_pro
     if (args.is_true_2d()) {
         // Limitation: Unicast algorithm currently does not support true 2D topologies
         use_unicast = false;
+        // NOLINTNEXTLINE(bugprone-branch-clone) - one branch per limitation, kept separate to document each
     } else if (tt::tt_fabric::is_2d_fabric_config(args.fabric_config) && !args.axis_is_straight[args.get_1d_axis()]) {
         // Limitation: Multicast cannot handle 2D topology reshapes/views that bend an axis
         use_unicast = true;

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
@@ -227,18 +227,19 @@ AllGatherDeviceOperation::create_op_performance_model(
 
 AllGatherDeviceOperation::program_factory_t AllGatherDeviceOperation::select_program_factory(
     const AllGatherParams& args, const AllGatherInputs& tensor_args) {
-    // Heuristics to pick the kernel algorithm.
-    // Multicast supports all Fabric topologies, unicast only supports (effectively) 1D topologies.
-    // Unicast is empirically found to be faster for large tensors.
+    // Pick the kernel algorithm based on limitations and heuristics
     bool use_unicast = false;
     if (args.is_true_2d()) {
-        // Unicast algorithm currently does not support true Fabric 2D topologies
+        // Limitation: Unicast algorithm currently does not support true 2D topologies
         use_unicast = false;
+    } else if (tt::tt_fabric::is_2d_fabric_config(args.fabric_config) && !args.axis_is_straight[args.get_1d_axis()]) {
+        // Limitation: Multicast cannot handle 2D topology reshapes/views that bend an axis
+        use_unicast = true;
     } else if (args.fabric_config == tt::tt_fabric::FabricConfig::FABRIC_1D_NEIGHBOR_EXCHANGE) {
-        // NeighborExchange only permits 1-hop unicast
+        // Limitation: NeighborExchange only permits 1-hop unicast
         use_unicast = true;
     } else {
-        // Decide between multicast or unicast algorithm
+        // Heuristics: Decide between multicast or unicast algorithm
         const auto& input_tensor = tensor_args.input_tensor;
         const uint32_t axis = args.get_1d_axis();
         switch (input_tensor.device()->arch()) {
@@ -317,6 +318,7 @@ std::tuple<AllGatherParams, AllGatherInputs> all_gather_build_operation_args(
     // An inactive axis has num_devices = 1, num_links = 0, Linear topology.
     std::array<tt::tt_fabric::Topology, 2> axis_topology{
         tt::tt_fabric::Topology::Linear, tt::tt_fabric::Topology::Linear};
+    std::array<bool, 2> axis_is_straight{true, true};
     std::array<uint32_t, 2> axis_num_devices{1u, 1u};
     std::array<uint32_t, 2> axis_num_links{0u, 0u};
     for (uint32_t axis = 0; axis < 2; ++axis) {
@@ -325,6 +327,7 @@ std::tuple<AllGatherParams, AllGatherInputs> all_gather_build_operation_args(
             continue;
         }
         axis_topology[axis] = ::ttnn::ccl::get_axis_topology(input_tensor, fabric_config, axis);
+        axis_is_straight[axis] = ::ttnn::ccl::is_axis_straight(*mesh_device, axis);
         axis_num_devices[axis] = ::ttnn::ccl::get_topological_dimension(input_tensor, axis);
         axis_num_links[axis] = ttnn::operations::ccl::common::get_num_links(*mesh_device, axis);
     }
@@ -352,6 +355,7 @@ std::tuple<AllGatherParams, AllGatherInputs> all_gather_build_operation_args(
             cluster_axis,
             fabric_config,
             axis_topology,
+            axis_is_straight,
             axis_num_devices,
             axis_num_links,
             num_devices,

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation_types.hpp
@@ -33,6 +33,7 @@ struct AllGatherParams {
     tt::tt_fabric::FabricConfig fabric_config{};
     // Per-axis info (an inactive axis has num_devices = 1, num_links = 0, and Linear topology)
     std::array<tt::tt_fabric::Topology, 2> axis_topology{};
+    std::array<bool, 2> axis_is_straight{};  // is the axis wired as a straight physical line
     std::array<uint32_t, 2> axis_num_devices{};
     std::array<uint32_t, 2> axis_num_links{};
     uint32_t num_devices = 0;  // number of devices participating in the collective
@@ -48,6 +49,7 @@ struct AllGatherParams {
         "cluster_axis",
         "fabric_config",
         "axis_topology",
+        "axis_is_straight",
         "axis_num_devices",
         "axis_num_links",
         "num_devices",
@@ -61,6 +63,7 @@ struct AllGatherParams {
             cluster_axis,
             fabric_config,
             axis_topology,
+            axis_is_straight,
             axis_num_devices,
             axis_num_links,
             num_devices,

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_multicast_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_multicast_factory.cpp
@@ -92,6 +92,12 @@ AllGatherMulticastFactory::cached_program_t AllGatherMulticastFactory::create_at
         if (!is_axis_active) {
             continue;
         }
+        // A true 2D collective cannot fall back to unicast, so factory selection cannot save us
+        // here. No mesh view bends a true 2D axis today, so this only guards a future one.
+        TT_FATAL(
+            !fabric_is_2d || operation_attributes.axis_is_straight[axis],
+            "AllGather 2D multicast needs mesh axis {} wired straight, but it turns corners",
+            axis);
 
         const auto axis_topology = operation_attributes.axis_topology[axis];
         const uint32_t axis_index = sender_device_coord[axis];

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -123,6 +123,48 @@ tt::tt_metal::distributed::MeshCoordinate::BoundaryMode get_boundary_mode(
     return tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::WRAP;
 }
 
+bool is_axis_straight(const tt::tt_metal::distributed::MeshDevice& mesh_device, uint32_t axis) {
+    const auto& mesh_view = mesh_device.get_view();
+    const auto mesh_shape = mesh_view.shape();
+    if (mesh_shape[axis] < 2) {
+        return true;  // no hops to compare
+    }
+
+    // Axis 0 runs down a column, axis 1 along a row.
+    std::optional<tt::tt_fabric::eth_chan_directions> axis_direction;
+    for (uint32_t row_or_col = 0; row_or_col < mesh_shape[1 - axis]; row_or_col++) {
+        const auto nodes = axis == 0 ? mesh_view.get_fabric_node_ids_on_column(row_or_col)
+                                     : mesh_view.get_fabric_node_ids_on_row(row_or_col);
+        for (size_t i = 1; i < nodes.size(); i++) {
+            const auto directions = tt::tt_fabric::get_neighbor_eth_directions(nodes[i - 1], nodes[i]);
+            if (directions.empty() || (axis_direction.has_value() && directions.front() != *axis_direction)) {
+                return false;
+            }
+            axis_direction = directions.front();
+        }
+    }
+    return true;
+}
+
+bool is_axis_wrap_wired(const tt::tt_metal::distributed::MeshDevice& mesh_device, uint32_t axis) {
+    const auto& mesh_view = mesh_device.get_view();
+    const auto mesh_shape = mesh_view.shape();
+    // A 2-device axis would close on the link it already uses, so it stays open and never rings.
+    if (!tt::tt_fabric::is_genuine_torus_dim(mesh_shape[axis])) {
+        return false;
+    }
+
+    // Axis 0 runs down a column, axis 1 along a row.
+    for (uint32_t row_or_col = 0; row_or_col < mesh_shape[1 - axis]; row_or_col++) {
+        const auto nodes = axis == 0 ? mesh_view.get_fabric_node_ids_on_column(row_or_col)
+                                     : mesh_view.get_fabric_node_ids_on_row(row_or_col);
+        if (tt::tt_fabric::get_neighbor_eth_directions(nodes.back(), nodes.front()).empty()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 tt::tt_fabric::Topology get_axis_topology(
     const Tensor& tensor, tt::tt_fabric::FabricConfig fabric_config, uint32_t axis) {
     // Whether the fabric wraps this axis into a ring/torus.
@@ -140,9 +182,9 @@ tt::tt_fabric::Topology get_axis_topology(
         axis_can_wrap = fabric_config == tt::tt_fabric::FabricConfig::FABRIC_1D_RING;
     }
 
-    // Ring only if the fabric can wrap this axis AND the device set spans [0..size-1].
-    const bool axis_is_ring = axis_can_wrap && get_boundary_mode(tensor, tt::tt_fabric::Topology::Torus, axis) ==
-                                                   tt::tt_metal::distributed::MeshCoordinate::BoundaryMode::WRAP;
+    // The torus flags name a fabric axis. A view axis can be a permutation of it, so the flag alone
+    // says nothing about this axis: only a wired closing link makes it a ring.
+    const bool axis_is_ring = axis_can_wrap && is_axis_wrap_wired(*tensor.device(), axis);
     return axis_is_ring ? tt::tt_fabric::Topology::Ring : tt::tt_fabric::Topology::Linear;
 }
 

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.cpp
@@ -125,7 +125,7 @@ tt::tt_metal::distributed::MeshCoordinate::BoundaryMode get_boundary_mode(
 
 bool is_axis_straight(const tt::tt_metal::distributed::MeshDevice& mesh_device, uint32_t axis) {
     const auto& mesh_view = mesh_device.get_view();
-    const auto mesh_shape = mesh_view.shape();
+    const auto& mesh_shape = mesh_view.shape();
     if (mesh_shape[axis] < 2) {
         return true;  // no hops to compare
     }
@@ -148,7 +148,7 @@ bool is_axis_straight(const tt::tt_metal::distributed::MeshDevice& mesh_device, 
 
 bool is_axis_wrap_wired(const tt::tt_metal::distributed::MeshDevice& mesh_device, uint32_t axis) {
     const auto& mesh_view = mesh_device.get_view();
-    const auto mesh_shape = mesh_view.shape();
+    const auto& mesh_shape = mesh_view.shape();
     // A 2-device axis would close on the link it already uses, so it stays open and never rings.
     if (!tt::tt_fabric::is_genuine_torus_dim(mesh_shape[axis])) {
         return false;

--- a/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/ccl_common.hpp
@@ -39,6 +39,13 @@ tt::tt_fabric::Topology get_usable_topology(
     const std::optional<tt::tt_fabric::Topology>& topology,
     const std::optional<uint32_t>& cluster_axis = std::nullopt);
 
+// Is every hop along this mesh axis wired in same dir? Ex: a 1x8 view of a 2x4 board makes axis-1 turn corners.
+bool is_axis_straight(const tt::tt_metal::distributed::MeshDevice& mesh_device, uint32_t axis);
+
+// Is the link that would close this mesh axis into a ring wired? Always false for an axis of 2 or
+// fewer devices, which closes on the link it already uses.
+bool is_axis_wrap_wired(const tt::tt_metal::distributed::MeshDevice& mesh_device, uint32_t axis);
+
 // Resolve the topology (Ring vs Linear) for a single mesh axis
 tt::tt_fabric::Topology get_axis_topology(
     const Tensor& tensor, tt::tt_fabric::FabricConfig fabric_config, uint32_t axis);

--- a/ttnn/cpp/ttnn/operations/ccl/common/host/moe_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/common/host/moe_utils.cpp
@@ -3,8 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <tt_stl/reflection.hpp>
+#include <algorithm>
 #include <array>
 #include <limits>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -103,14 +105,7 @@ uint32_t get_linearized_index(const ttnn::MeshCoordinate& mesh_coordinate, const
 }
 
 size_t get_num_links(const tt::tt_metal::distributed::MeshDevice& mesh_device, std::optional<size_t> cluster_axis) {
-    auto mesh_range = tt::tt_metal::distributed::MeshCoordinateRange(mesh_device.shape());
-    const auto& mesh_view = mesh_device.get_view();
-    auto mesh_shape = mesh_view.shape();
-    auto topology = tt::tt_fabric::get_fabric_topology();
-
-    constexpr std::array<std::array<tt::tt_fabric::RoutingDirection, 2>, 2> directions = {
-        {{tt::tt_fabric::RoutingDirection::N, tt::tt_fabric::RoutingDirection::S},
-         {tt::tt_fabric::RoutingDirection::W, tt::tt_fabric::RoutingDirection::E}}};
+    const auto mesh_shape = mesh_device.get_view().shape();
 
     ttsl::SmallVector<size_t> cluster_axes;
     if (cluster_axis.has_value()) {
@@ -119,48 +114,26 @@ size_t get_num_links(const tt::tt_metal::distributed::MeshDevice& mesh_device, s
         cluster_axes = {0, 1};
     }
 
-    auto positive_direction = [&](tt::tt_fabric::RoutingDirection direction) {
-        return direction == tt::tt_fabric::RoutingDirection::E || direction == tt::tt_fabric::RoutingDirection::S;
-    };
-
-    auto applicable_to_coord =
-        [&](const MeshCoordinate& coord, size_t cluster_axis, tt::tt_fabric::RoutingDirection direction) -> bool {
-        auto boundary_mode = detail::get_boundary_mode(topology);
-        int offset = positive_direction(direction) ? 1 : -1;
-        auto neighbor = coord.get_neighbor(mesh_shape, offset, cluster_axis, boundary_mode);
-        return neighbor.has_value();
-    };
-
-    size_t num_available_routing_planes = std::numeric_limits<size_t>::max();
-    for (const auto& coord : mesh_range) {
-        const auto fabric_node_id = mesh_device.get_fabric_node_id(coord);
-
-        for (const auto axis : cluster_axes) {
-            for (const auto direction : directions[axis]) {
-                if (applicable_to_coord(coord, axis, direction)) {
-                    auto planes_in_direction = tt::tt_fabric::get_num_usable_routing_planes(fabric_node_id, direction);
-                    log_debug(
-                        tt::LogOp,
-                        "fabric_node_id: {}, direction: {}, planes_in_direction: {}",
-                        fabric_node_id,
-                        direction,
-                        planes_in_direction);
-                    // Skip over planes_in_direction=0 to avoid collapsing the running min to 0.
-                    // This can happen when, for example, there's only 1 or 2 devices, a wrap-around can detect a
-                    // neighbor though there's no fabric link.
-                    if (planes_in_direction > 0) {
-                        num_available_routing_planes = std::min(num_available_routing_planes, planes_in_direction);
-                    }
-                }
+    std::optional<size_t> num_links;
+    for (const auto axis : cluster_axes) {
+        // The op runs on every row (or column) along the axis, and they can be wired differently.
+        // All of them must be able to open the link, so take the lowest count. Hops owned by
+        // another host report 0 and are skipped, so this counts what this host can see.
+        for (uint32_t row_or_col = 0; row_or_col < mesh_shape[1 - axis]; row_or_col++) {
+            const size_t planes =
+                tt::tt_fabric::experimental::get_number_of_available_routing_planes(mesh_device, axis, row_or_col);
+            if (planes > 0) {
+                num_links = num_links.has_value() ? std::min(*num_links, planes) : planes;
             }
         }
     }
-    log_debug(tt::LogOp, "num_available_routing_planes: {}", num_available_routing_planes);
-    if (num_available_routing_planes <= 0 || num_available_routing_planes == std::numeric_limits<size_t>::max()) {
+
+    if (!num_links.has_value()) {
         log_warning(tt::LogOp, "Failed to discover available ethernet links; falling back to 1 link");
-        num_available_routing_planes = 1;
+        return 1;
     }
-    return num_available_routing_planes;
+    log_debug(tt::LogOp, "num_links: {}", *num_links);
+    return *num_links;
 }
 
 }  // namespace ttnn::operations::ccl::common


### PR DESCRIPTION
### PR Category
Bug fix

### Problem

This PR solves Fabric routing in ttnn.all_gather for bent axis cases. Ex: a 1x8 view/reshape of a 2x4 board makes axis-1 turn corners. Three places didn't support this:
- Fabric multicast inherently can't support this since it performs N straight hops from source.
- `get_axis_topology`: Ring decided from the `FabricConfig` enum alone, no cabling query.
- `get_num_links`: hardcoded `axis0->{N,S}`, `axis1->{W,E}`, so it measured links a folded axis never uses.

### Changes

- **fabric**: fixed `experimental::get_number_of_available_routing_planes` - same signature, zero callers before this PR. Was: one sampled chip, hardcoded `axis0->{N,S}` / `axis1->{E,W}`. Now: walks every hop of the row/column, direction from wiring, returns the weakest. Ignores hops reporting 0 (unwired, reserved, or another host's chip) so silence doesn't zero the answer. Uses fabric node ids, so remote chips don't break it.
- **ccl_common**: new `is_axis_straight` and `is_axis_wrap_wired`. `get_axis_topology` returns Ring only if the closing link is physically wired.
- **moe_utils**: `get_num_links` = fold over the axis's rows/columns calling the fabric helper. Direction table gone. Signature unchanged (32 callers).
- **all_gather**: new `axis_is_straight` attr. Use unicast algo in 2D fabric + bent axis.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=scardoza/fix-ag-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:scardoza/fix-ag-routing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=scardoza/fix-ag-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:scardoza/fix-ag-routing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=scardoza/fix-ag-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:scardoza/fix-ag-routing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=scardoza/fix-ag-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:scardoza/fix-ag-routing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=scardoza/fix-ag-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:scardoza/fix-ag-routing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=scardoza/fix-ag-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:scardoza/fix-ag-routing)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=scardoza/fix-ag-routing)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:scardoza/fix-ag-routing)