### PR TITLE
[LLK] Quasar: migrate tt-llk tests to the BFD allocator (and remove `construct_tdma_desc`)

### DIFF
--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/tensix_types.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/tensix_types.h
@@ -301,10 +301,4 @@ typedef union {
     buffer_descriptor_t f;
 } buffer_descriptor_u;
 
-typedef struct {
-    buffer_descriptor_u buf_desc;
-    std::uint32_t buf_desc_id;
-    DataFormat reg_data_format;
-} tdma_descriptor_t;
-
 #endif

--- a/tt_metal/tt-llk/tests/helpers/include/quasar_test_common.h
+++ b/tt_metal/tt-llk/tests/helpers/include/quasar_test_common.h
@@ -9,20 +9,6 @@
 #include "ckernel_trisc_common.h"
 #include "tensor_shape.h"
 
-/**
- * @brief Build a buffer descriptor from the tensor shape / L1 base / format and program it into the
- * BD table entry `buf_desc_id`. Test-side analog of the migrated op inits: it does what the product
- * `bfd_alloc_and_program` does, but with a caller-chosen id (tests pick fixed ids) and without
- * allocating. The register data format is passed separately to the `_llk_*_configure_` call.
- *
- * @tparam MODE: L1 access mode; Strided (PACR/UNPACR_STRIDE tiny-tiles) forces y_dim = z_dim = 1.
- */
-template <ckernel::trisc::L1AccessMode MODE = ckernel::trisc::L1AccessMode::Continuous>
-inline void program_buf_desc(std::uint32_t buf_desc_id, const ckernel::TensorShape& shape, unsigned base_l1_16B, unsigned data_format)
-{
-    ckernel::trisc::_configure_buf_desc_table_(buf_desc_id, ckernel::trisc::construct_buf_desc<MODE>(shape, base_l1_16B, data_format));
-}
-
 inline void clear_dest_dvalid_wait_mask(std::uint32_t wait_mask_addr)
 {
     volatile std::uint32_t* cfg = reinterpret_cast<volatile std::uint32_t*>(TENSIX_CFG_BASE);

--- a/tt_metal/tt-llk/tests/helpers/include/quasar_test_common.h
+++ b/tt_metal/tt-llk/tests/helpers/include/quasar_test_common.h
@@ -6,7 +6,22 @@
 
 #include <cstdint>
 
+#include "ckernel_trisc_common.h"
 #include "tensor_shape.h"
+
+/**
+ * @brief Build a buffer descriptor from the tensor shape / L1 base / format and program it into the
+ * BD table entry `buf_desc_id`. Test-side analog of the migrated op inits: it does what the product
+ * `bfd_alloc_and_program` does, but with a caller-chosen id (tests pick fixed ids) and without
+ * allocating. The register data format is passed separately to the `_llk_*_configure_` call.
+ *
+ * @tparam MODE: L1 access mode; Strided (PACR/UNPACR_STRIDE tiny-tiles) forces y_dim = z_dim = 1.
+ */
+template <ckernel::trisc::L1AccessMode MODE = ckernel::trisc::L1AccessMode::Continuous>
+inline void program_buf_desc(std::uint32_t buf_desc_id, const ckernel::TensorShape& shape, unsigned base_l1_16B, unsigned data_format)
+{
+    ckernel::trisc::_configure_buf_desc_table_(buf_desc_id, ckernel::trisc::construct_buf_desc<MODE>(shape, base_l1_16B, data_format));
+}
 
 inline void clear_dest_dvalid_wait_mask(std::uint32_t wait_mask_addr)
 {

--- a/tt_metal/tt-llk/tests/python_tests/fuser/operand.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/operand.py
@@ -230,20 +230,19 @@ class Operand:
         )
         return f"[[maybe_unused]] const Operand {self.cpp_name}({hex(self.l1_address)}, {buffer_size});\n"
 
-    def cpp_tdma_decl_init(self) -> str:
+    def cpp_buf_desc_decl(self) -> str:
         return (
-            f"tdma_descriptor_t {self.cpp_desc_name} = "
-            f"ckernel::trisc::construct_tdma_desc("
+            f"buffer_descriptor_u {self.cpp_desc_name} = "
+            f"ckernel::trisc::construct_buf_desc("
             f"{self.tile_shape.cpp_value}, "
             f"{hex(self.l1_address)} / 16, "
-            f"{self.data_format.cpp_underlying_value}, "
-            f"{self.buf_desc_id}, 0);\n"
+            f"{self.data_format.cpp_underlying_value});\n"
         )
 
     def emit_buf_desc_table_entry(self) -> str:
         if self.buf_desc_id is None:
             return ""
-        return f"ckernel::trisc::_configure_buf_desc_table_({self.buf_desc_id}, {self.cpp_desc_name}.buf_desc);\n"
+        return f"ckernel::trisc::_configure_buf_desc_table_({self.buf_desc_id}, {self.cpp_desc_name});\n"
 
 
 class OperandRegistry:
@@ -417,7 +416,7 @@ class OperandRegistry:
     def emit_operand_init(operands: list[Operand]) -> str:
         code = ""
         for op in operands:
-            code += op.cpp_tdma_decl_init()
+            code += op.cpp_buf_desc_decl()
             code += op.emit_buf_desc_table_entry()
         return code
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/packer/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/packer/common.py
@@ -21,7 +21,7 @@ def hw_configure_pack(
     pack_dst: DataFormat,
     pack_mode: str = "PackMode::Default",
 ) -> str:
-    return f"_llk_pack_hw_configure_<p_pacr::PACK0, {dest_acc}>({pack_src.cpp_underlying_value}, ReluConfig::from_packed(0));\n"
+    return f"_llk_pack_hw_configure_<p_pacr::PACK0, {dest_acc}>(static_cast<DataFormat>({pack_src.cpp_underlying_value}), ReluConfig::from_packed(0));\n"
 
 
 def configure_pack(
@@ -30,7 +30,7 @@ def configure_pack(
     pack_src: DataFormat,
     pack_dst: DataFormat,
 ) -> str:
-    return f"_llk_pack_hw_configure_<p_pacr::PACK0, {dest_acc}>({pack_src.cpp_underlying_value}, ReluConfig::from_packed(0));\n"
+    return f"_llk_pack_hw_configure_<p_pacr::PACK0, {dest_acc}>(static_cast<DataFormat>({pack_src.cpp_underlying_value}), ReluConfig::from_packed(0));\n"
 
 
 def relu_config(

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/common.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/common.py
@@ -33,7 +33,7 @@ def _emit_configure(
     unpack_B_dst: DataFormat,
 ) -> str:
     if _is_unary_broadcast_unpacker(compute_node):
-        return f"_llk_unpack_configure_unary_<p_unpacr::UNP_B>({unpack_B_dst.cpp_underlying_value});\n"
+        return f"_llk_unpack_configure_unary_<p_unpacr::UNP_B>(static_cast<DataFormat>({unpack_B_dst.cpp_underlying_value}));\n"
 
     is_unary = is_unary_unpacker(compute_node)
     has_reuse_dest = compute_node.reuse_dest != EltwiseBinaryReuseDestType.NONE
@@ -44,11 +44,11 @@ def _emit_configure(
         code += f"_llk_math_upk_to_dest_hw_configure_<false, {dest_acc}, false>();\n"
 
     if is_unary and ((dest_acc == "true" and not unpack_to_dest) or has_reuse_dest):
-        code += f"_llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>({unpack_A_dst.cpp_underlying_value}, {unpack_A_dst.cpp_underlying_value});\n"
+        code += f"_llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(static_cast<DataFormat>({unpack_A_dst.cpp_underlying_value}), static_cast<DataFormat>({unpack_A_dst.cpp_underlying_value}));\n"
     elif is_unary:
-        code += f"_llk_unpack_configure_unary_<p_unpacr::UNP_A>({unpack_A_dst.cpp_underlying_value});\n"
+        code += f"_llk_unpack_configure_unary_<p_unpacr::UNP_A>(static_cast<DataFormat>({unpack_A_dst.cpp_underlying_value}));\n"
     else:
-        code += f"_llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>({unpack_A_dst.cpp_underlying_value}, {unpack_B_dst.cpp_underlying_value});\n"
+        code += f"_llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(static_cast<DataFormat>({unpack_A_dst.cpp_underlying_value}), static_cast<DataFormat>({unpack_B_dst.cpp_underlying_value}));\n"
 
     return code
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/reduce_tilize_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/quasar/unpacker/reduce_tilize_a.py
@@ -54,9 +54,9 @@ class UnpackReduceTilize(Unpacker):
         reduce_pool = self.reduce_pool.cpp_enum_value
 
         return (
-            f"{desc_a}.buf_desc.f.y_dim = 1;\n"
-            f"{desc_a}.buf_desc.f.z_dim = 1;\n"
-            f"ckernel::trisc::_configure_buf_desc_table_({buf_desc_id_a}, {desc_a}.buf_desc);\n"
+            f"{desc_a}.f.y_dim = 1;\n"
+            f"{desc_a}.f.z_dim = 1;\n"
+            f"ckernel::trisc::_configure_buf_desc_table_({buf_desc_id_a}, {desc_a});\n"
             f"_llk_unpack_reduce_col_tilizeA_strided_init_<{reduce_pool}>"
             f"({buf_desc_id_a}, {buf_desc_id_b}, {full_ct_dim}, {tensor_shape});\n"
         )

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
@@ -9,6 +9,7 @@
 #include "llk_defs.h"
 #include "perf.h"
 #include "profiler.h"
+#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
 #ifdef LLK_TRISC_UNPACK
@@ -24,38 +25,22 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
-    const std::uint32_t TILE_CNT        = params.TILE_CNT;
-    const std::uint32_t num_faces       = params.num_faces;
-    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
-    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
-    const Operand& buffer_A             = params.buffer_A;
-    const Operand& buffer_B             = params.buffer_B;
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
+    const std::uint32_t num_faces   = params.num_faces;
+    const Operand& buffer_A         = params.buffer_A;
+    const Operand& buffer_B         = params.buffer_B;
 #endif
-    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>(); // allocate srcA (order matters: A before B)
-    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp1>(); // allocate srcB
     const std::uint32_t num_tiles_per_unpack = TILE_CNT;
 
     {
         ZONE_SCOPED("INIT")
         set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
-        buffer_descriptor_u bd_val_A = {0};
-        bd_val_A.f.l1_addr_16B       = buffer_A[0] / 16;
-        bd_val_A.f.format            = static_cast<std::uint8_t>(formats.unpack_A_src);
-        bd_val_A.f.x_dim             = TEST_FACE_C_DIM;
-        bd_val_A.f.y_dim             = TEST_FACE_R_DIM;
-        bd_val_A.f.z_dim             = num_faces;
-
-        buffer_descriptor_u bd_val_B = {0};
-        bd_val_B.f.l1_addr_16B       = buffer_B[0] / 16;
-        bd_val_B.f.format            = static_cast<std::uint8_t>(formats.unpack_B_src);
-        bd_val_B.f.x_dim             = TEST_FACE_C_DIM;
-        bd_val_B.f.y_dim             = TEST_FACE_R_DIM;
-        bd_val_B.f.z_dim             = num_faces;
-
-        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val_A);
-        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(), bd_val_B);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
+            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), buffer_A[0] / 16, formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(
+            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), buffer_B[0] / 16, formats.unpack_B_src);
         _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
             static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
         _llk_unpack_binary_broadcast_operands_init_<BROADCAST_TYPE>(
@@ -189,15 +174,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
-    const std::uint32_t TILE_CNT        = params.TILE_CNT;
-    const std::uint32_t num_faces       = params.num_faces;
-    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
-    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
-    const Operand& buffer_Res           = params.buffer_Res;
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
+    const Operand& buffer_Res       = params.buffer_Res;
 #endif
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
-    ckernel::trisc::bfd_alloc<pack_res>();
+    constexpr auto pack_res                = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
     const std::uint32_t num_tiles_per_pack = TILE_CNT;
 
     {
@@ -214,14 +195,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        buffer_descriptor_u bd_val = {0};
-        bd_val.f.l1_addr_16B       = buffer_Res[0] / 16;
-        bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
-        bd_val.f.x_dim             = TEST_FACE_C_DIM;
-        bd_val.f.y_dim             = TEST_FACE_R_DIM;
-        bd_val.f.z_dim             = num_faces;
-
-        _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
+        ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), buffer_Res[0] / 16, formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
         PROFILER_SYNC();

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
@@ -7,6 +7,7 @@
 
 #include "ckernel.h"
 #include "llk_defs.h"
+#include "llk_memory_checks.h"
 #include "perf.h"
 #include "profiler.h"
 #include "sfpu_stub.h"
@@ -36,8 +37,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ZONE_SCOPED("INIT")
         set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(ckernel::DEFAULT_TENSOR_SHAPE, buffer_A[0] / 16, formats.unpack_A_src);
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(ckernel::DEFAULT_TENSOR_SHAPE, buffer_B[0] / 16, formats.unpack_B_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
         _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
             static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
         _llk_unpack_binary_broadcast_operands_init_<BROADCAST_TYPE>(
@@ -191,7 +192,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, buffer_Res[0] / 16, formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
         PROFILER_SYNC();

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
@@ -37,8 +37,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ZONE_SCOPED("INIT")
         set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
+            ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(
+            ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
         _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
             static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
         _llk_unpack_binary_broadcast_operands_init_<BROADCAST_TYPE>(
@@ -192,7 +194,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
+            ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
         PROFILER_SYNC();

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
@@ -175,7 +175,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t TILE_CNT    = params.TILE_CNT;
     const Operand& buffer_Res       = params.buffer_Res;
 #endif
-    constexpr auto pack_res                = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
     const std::uint32_t num_tiles_per_pack = TILE_CNT;
 
     {
@@ -192,9 +191,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, buffer_Res[0] / 16, formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, buffer_Res[0] / 16, formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
@@ -31,7 +31,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A             = params.buffer_A;
     const Operand& buffer_B             = params.buffer_B;
 #endif
-    tdma_descriptor_t td_val_A, td_val_B;
     const std::uint32_t buf_desc_id_a        = 0;
     const std::uint32_t buf_desc_id_b        = 1;
     const std::uint32_t num_tiles_per_unpack = TILE_CNT;
@@ -47,10 +46,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val_A.f.y_dim             = TEST_FACE_R_DIM;
         bd_val_A.f.z_dim             = num_faces;
 
-        td_val_A.buf_desc        = bd_val_A;
-        td_val_A.buf_desc_id     = buf_desc_id_a;
-        td_val_A.reg_data_format = static_cast<DataFormat>(formats.unpack_A_dst);
-
         buffer_descriptor_u bd_val_B = {0};
         bd_val_B.f.l1_addr_16B       = buffer_B[0] / 16;
         bd_val_B.f.format            = static_cast<std::uint8_t>(formats.unpack_B_src);
@@ -58,13 +53,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val_B.f.y_dim             = TEST_FACE_R_DIM;
         bd_val_B.f.z_dim             = num_faces;
 
-        td_val_B.buf_desc        = bd_val_B;
-        td_val_B.buf_desc_id     = buf_desc_id_b;
-        td_val_B.reg_data_format = static_cast<DataFormat>(formats.unpack_B_dst);
-
-        _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
-        _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
-        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A.reg_data_format, td_val_B.reg_data_format);
+        _configure_buf_desc_table_(buf_desc_id_a, bd_val_A);
+        _configure_buf_desc_table_(buf_desc_id_b, bd_val_B);
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
+            static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
         _llk_unpack_binary_broadcast_operands_init_<BROADCAST_TYPE>(buf_desc_id_a, buf_desc_id_b, num_tiles_per_unpack);
         PROFILER_SYNC();
     }
@@ -223,14 +215,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val.f.y_dim             = TEST_FACE_R_DIM;
         bd_val.f.z_dim             = num_faces;
 
-        tdma_descriptor_t tdma_desc;
-
-        tdma_desc.buf_desc        = bd_val;
-        tdma_desc.buf_desc_id     = buf_desc_id;
-        tdma_desc.reg_data_format = static_cast<DataFormat>(formats.pack_src);
-
-        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc.reg_data_format, ckernel::ReluConfig::none());
+        _configure_buf_desc_table_(buf_desc_id, bd_val);
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
@@ -13,6 +13,7 @@
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_unpack_binary_broadcast_operands.h"
 #include "llk_unpack_common.h"
 #include "params.h"
@@ -31,8 +32,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A             = params.buffer_A;
     const Operand& buffer_B             = params.buffer_B;
 #endif
-    const std::uint32_t buf_desc_id_a        = 0;
-    const std::uint32_t buf_desc_id_b        = 1;
+    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>(); // allocate srcA (order matters: A before B)
+    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp1>(); // allocate srcB
     const std::uint32_t num_tiles_per_unpack = TILE_CNT;
 
     {
@@ -53,11 +54,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val_B.f.y_dim             = TEST_FACE_R_DIM;
         bd_val_B.f.z_dim             = num_faces;
 
-        _configure_buf_desc_table_(buf_desc_id_a, bd_val_A);
-        _configure_buf_desc_table_(buf_desc_id_b, bd_val_B);
+        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val_A);
+        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(), bd_val_B);
         _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
             static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
-        _llk_unpack_binary_broadcast_operands_init_<BROADCAST_TYPE>(buf_desc_id_a, buf_desc_id_b, num_tiles_per_unpack);
+        _llk_unpack_binary_broadcast_operands_init_<BROADCAST_TYPE>(
+            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(),
+            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(),
+            num_tiles_per_unpack);
         PROFILER_SYNC();
     }
     {
@@ -174,6 +178,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -191,7 +196,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
     const Operand& buffer_Res           = params.buffer_Res;
 #endif
-    std::uint32_t const buf_desc_id        = 8;
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
+    ckernel::trisc::bfd_alloc<pack_res>();
     const std::uint32_t num_tiles_per_pack = TILE_CNT;
 
     {
@@ -215,9 +221,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val.f.y_dim             = TEST_FACE_R_DIM;
         bd_val.f.z_dim             = num_faces;
 
-        _configure_buf_desc_table_(buf_desc_id, bd_val);
+        _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
@@ -9,7 +9,6 @@
 #include "llk_defs.h"
 #include "perf.h"
 #include "profiler.h"
-#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
 #ifdef LLK_TRISC_UNPACK
@@ -37,10 +36,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ZONE_SCOPED("INIT")
         set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
-            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), buffer_A[0] / 16, formats.unpack_A_src);
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(
-            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), buffer_B[0] / 16, formats.unpack_B_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(ckernel::DEFAULT_TENSOR_SHAPE, buffer_A[0] / 16, formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(ckernel::DEFAULT_TENSOR_SHAPE, buffer_B[0] / 16, formats.unpack_B_src);
         _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
             static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
         _llk_unpack_binary_broadcast_operands_init_<BROADCAST_TYPE>(
@@ -195,7 +192,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), buffer_Res[0] / 16, formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, buffer_Res[0] / 16, formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
         PROFILER_SYNC();

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
@@ -21,6 +21,7 @@ std::uint32_t math_sync_tile_dst_index = 0;
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_unary_operand.h"
 #include "params.h"
@@ -39,12 +40,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A             = params.buffer_A;
     const Operand& buffer_B             = params.buffer_B;
 #endif
-    const std::uint32_t buf_desc_id_a          = 0;
-    const std::uint32_t buf_desc_id_b          = 1;
-    constexpr bool TRANSPOSE_EN                = false;
-    constexpr bool IS_32B_DEST_EN              = false;
-    constexpr std::uint32_t buf_desc_id_phase2 = (REUSE_DEST_TYPE == EltwiseBinaryReuseDestType::DEST_TO_SRCB) ? buf_desc_id_a : buf_desc_id_b;
-    constexpr std::uint32_t unp_sel_phase2     = (REUSE_DEST_TYPE == EltwiseBinaryReuseDestType::DEST_TO_SRCA) ? p_unpacr::UNP_B : p_unpacr::UNP_A;
+    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>(); // allocate srcA (order matters: A before B)
+    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp1>(); // allocate srcB
+    constexpr bool TRANSPOSE_EN            = false;
+    constexpr bool IS_32B_DEST_EN          = false;
+    constexpr std::uint32_t unp_sel_phase2 = (REUSE_DEST_TYPE == EltwiseBinaryReuseDestType::DEST_TO_SRCA) ? p_unpacr::UNP_B : p_unpacr::UNP_A;
 
     {
         ZONE_SCOPED("INIT")
@@ -65,8 +65,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val_B.f.y_dim       = TEST_FACE_R_DIM;
         bd_val_B.f.z_dim       = num_faces;
 
-        _configure_buf_desc_table_(buf_desc_id_a, bd_val_A);
-        _configure_buf_desc_table_(buf_desc_id_b, bd_val_B);
+        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val_A);
+        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(), bd_val_B);
         _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
             static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
 
@@ -94,7 +94,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 // Phase 1 and phase 2 share unpack's bank0 instruction
                 // buffer, so select the phase 1 MOP before executing it.
                 _llk_unpack_unary_operand_init_<p_unpacr::UNP_A, TRANSPOSE_EN, IS_32B_DEST_EN>(
-                    buf_desc_id_a, ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_unpack*/);
+                    ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_unpack*/);
                 for (std::uint32_t i = 0; i < INPUT_TILE_CNT; ++i)
                 {
                     _llk_unpack_unary_operand_<p_unpacr::UNP_A>(i, ckernel::DEFAULT_TENSOR_SHAPE);
@@ -102,7 +102,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
                 // Select the reuse-dest phase 2 MOP after phase 1 completes.
                 _llk_unpack_unary_operand_init_<unp_sel_phase2, TRANSPOSE_EN, IS_32B_DEST_EN, REUSE_DEST_TYPE>(
-                    buf_desc_id_phase2, ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_unpack*/);
+                    (REUSE_DEST_TYPE == EltwiseBinaryReuseDestType::DEST_TO_SRCB) ? ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>()
+                                                                                  : ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(),
+                    ckernel::DEFAULT_TENSOR_SHAPE,
+                    1 /*num_tiles_per_unpack*/);
                 for (std::uint32_t i = 0; i < INPUT_TILE_CNT; ++i)
                 {
                     _llk_unpack_unary_operand_<unp_sel_phase2, REUSE_DEST_TYPE>(i, ckernel::DEFAULT_TENSOR_SHAPE);
@@ -209,6 +212,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -227,7 +231,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t OUTPUT_NUM_BLOCKS         = params.OUTPUT_NUM_BLOCKS;
     const Operand& buffer_Res                     = params.buffer_Res;
 #endif
-    std::uint32_t const buf_desc_id = 8;
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
+    ckernel::trisc::bfd_alloc<pack_res>();
 
     {
         ZONE_SCOPED("INIT")
@@ -250,9 +255,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val.f.y_dim       = TEST_FACE_R_DIM;
         bd_val.f.z_dim       = num_faces;
 
-        _configure_buf_desc_table_(buf_desc_id, bd_val);
+        _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
+        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
@@ -39,7 +39,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A             = params.buffer_A;
     const Operand& buffer_B             = params.buffer_B;
 #endif
-    tdma_descriptor_t td_val_A, td_val_B;
     const std::uint32_t buf_desc_id_a          = 0;
     const std::uint32_t buf_desc_id_b          = 1;
     constexpr bool TRANSPOSE_EN                = false;
@@ -59,10 +58,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val_A.f.y_dim       = TEST_FACE_R_DIM;
         bd_val_A.f.z_dim       = num_faces;
 
-        td_val_A.buf_desc        = bd_val_A;
-        td_val_A.buf_desc_id     = buf_desc_id_a;
-        td_val_A.reg_data_format = static_cast<DataFormat>(formats.unpack_A_dst);
-
         buffer_descriptor_u bd_val_B {};
         bd_val_B.f.l1_addr_16B = L1_ADDRESS(buffer_B[0]);
         bd_val_B.f.format      = static_cast<std::uint8_t>(formats.unpack_B_src);
@@ -70,13 +65,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val_B.f.y_dim       = TEST_FACE_R_DIM;
         bd_val_B.f.z_dim       = num_faces;
 
-        td_val_B.buf_desc        = bd_val_B;
-        td_val_B.buf_desc_id     = buf_desc_id_b;
-        td_val_B.reg_data_format = static_cast<DataFormat>(formats.unpack_B_dst);
-
-        _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
-        _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
-        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A.reg_data_format, td_val_B.reg_data_format);
+        _configure_buf_desc_table_(buf_desc_id_a, bd_val_A);
+        _configure_buf_desc_table_(buf_desc_id_b, bd_val_B);
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
+            static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
 
         PROFILER_SYNC();
     }
@@ -258,13 +250,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val.f.y_dim       = TEST_FACE_R_DIM;
         bd_val.f.z_dim       = num_faces;
 
-        tdma_descriptor_t tdma_desc;
-        tdma_desc.buf_desc        = bd_val;
-        tdma_desc.buf_desc_id     = buf_desc_id;
-        tdma_desc.reg_data_format = static_cast<DataFormat>(formats.pack_src);
-
-        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc.reg_data_format, ckernel::ReluConfig::none());
+        _configure_buf_desc_table_(buf_desc_id, bd_val);
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
@@ -12,7 +12,6 @@
 #include "llk_memory_checks.h"
 #include "perf.h"
 #include "profiler.h"
-#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
 // Globals
@@ -48,10 +47,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // Setup data valid scheme
         set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
-            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(
-            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
         _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
             static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
 
@@ -229,8 +226,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        ckernel::trisc::bfd_alloc_and_program<pack_res>(
-            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
         PROFILER_SYNC();

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
@@ -47,8 +47,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // Setup data valid scheme
         set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
+            ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(
+            ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
         _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
             static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
 
@@ -225,7 +227,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
+            ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
         PROFILER_SYNC();

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
@@ -12,6 +12,7 @@
 #include "llk_memory_checks.h"
 #include "perf.h"
 #include "profiler.h"
+#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
 // Globals
@@ -32,16 +33,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
-    const std::uint32_t INPUT_TILE_CNT  = params.INPUT_TILE_CNT;
-    const std::uint32_t num_faces       = params.num_faces;
-    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
-    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
-    const Operand& buffer_A             = params.buffer_A;
-    const Operand& buffer_B             = params.buffer_B;
+    const std::uint32_t LOOP_FACTOR    = params.LOOP_FACTOR;
+    const std::uint32_t INPUT_TILE_CNT = params.INPUT_TILE_CNT;
+    const std::uint32_t num_faces      = params.num_faces;
+    const Operand& buffer_A            = params.buffer_A;
+    const Operand& buffer_B            = params.buffer_B;
 #endif
-    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>(); // allocate srcA (order matters: A before B)
-    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp1>(); // allocate srcB
     constexpr bool TRANSPOSE_EN            = false;
     constexpr bool IS_32B_DEST_EN          = false;
     constexpr std::uint32_t unp_sel_phase2 = (REUSE_DEST_TYPE == EltwiseBinaryReuseDestType::DEST_TO_SRCA) ? p_unpacr::UNP_B : p_unpacr::UNP_A;
@@ -51,22 +48,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // Setup data valid scheme
         set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
-        buffer_descriptor_u bd_val_A {};
-        bd_val_A.f.l1_addr_16B = L1_ADDRESS(buffer_A[0]);
-        bd_val_A.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
-        bd_val_A.f.x_dim       = TEST_FACE_C_DIM;
-        bd_val_A.f.y_dim       = TEST_FACE_R_DIM;
-        bd_val_A.f.z_dim       = num_faces;
-
-        buffer_descriptor_u bd_val_B {};
-        bd_val_B.f.l1_addr_16B = L1_ADDRESS(buffer_B[0]);
-        bd_val_B.f.format      = static_cast<std::uint8_t>(formats.unpack_B_src);
-        bd_val_B.f.x_dim       = TEST_FACE_C_DIM;
-        bd_val_B.f.y_dim       = TEST_FACE_R_DIM;
-        bd_val_B.f.z_dim       = num_faces;
-
-        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val_A);
-        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(), bd_val_B);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
+            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(
+            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
         _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
             static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
 
@@ -224,15 +209,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 #ifndef SPEED_OF_LIGHT
     const std::uint32_t LOOP_FACTOR               = params.LOOP_FACTOR;
-    const std::uint32_t TEST_FACE_C_DIM           = params.TEST_FACE_C_DIM;
-    const std::uint32_t TEST_FACE_R_DIM           = params.TEST_FACE_R_DIM;
-    const std::uint32_t num_faces                 = params.num_faces;
     const std::uint32_t OUTPUT_NUM_TILES_IN_BLOCK = params.OUTPUT_NUM_TILES_IN_BLOCK;
     const std::uint32_t OUTPUT_NUM_BLOCKS         = params.OUTPUT_NUM_BLOCKS;
     const Operand& buffer_Res                     = params.buffer_Res;
 #endif
     constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
-    ckernel::trisc::bfd_alloc<pack_res>();
 
     {
         ZONE_SCOPED("INIT")
@@ -248,14 +229,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        buffer_descriptor_u bd_val {};
-        bd_val.f.l1_addr_16B = L1_ADDRESS(buffer_Res[0]);
-        bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
-        bd_val.f.x_dim       = TEST_FACE_C_DIM;
-        bd_val.f.y_dim       = TEST_FACE_R_DIM;
-        bd_val.f.z_dim       = num_faces;
-
-        _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
+        ckernel::trisc::bfd_alloc_and_program<pack_res>(
+            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
         PROFILER_SYNC();

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_reuse_dest_quasar_test.cpp
@@ -210,7 +210,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t OUTPUT_NUM_BLOCKS         = params.OUTPUT_NUM_BLOCKS;
     const Operand& buffer_Res                     = params.buffer_Res;
 #endif
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
 
     {
         ZONE_SCOPED("INIT")
@@ -226,9 +225,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
@@ -275,7 +275,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t DST_TILE_IDX = params.DST_TILE_IDX;
     const Operand& buffer_Res        = params.buffer_Res;
 #endif
-    constexpr auto pack_res                = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
     const std::uint32_t num_tiles_per_pack = 1; // only the SFPU result tile is packed
 
     {
@@ -298,10 +297,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
 
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
@@ -80,19 +80,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val.f.y_dim             = TEST_FACE_R_DIM;
         bd_val.f.z_dim             = num_faces;
 
-        tdma_descriptor_t td_val;
-        td_val.buf_desc        = bd_val;
-        td_val.buf_desc_id     = buf_desc_id;
-        td_val.reg_data_format = static_cast<DataFormat>(formats.unpack_A_dst);
-        _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+        _configure_buf_desc_table_(buf_desc_id, bd_val);
 
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
-            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val.reg_data_format, td_val.reg_data_format);
+            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
+                static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_A_dst));
         }
         else
         {
-            _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val.reg_data_format);
+            _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
         }
 
         _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, TILE_CNT);
@@ -319,13 +316,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val.f.y_dim             = TEST_FACE_R_DIM;
         bd_val.f.z_dim             = num_faces;
 
-        tdma_descriptor_t tdma_desc;
-        tdma_desc.buf_desc        = bd_val;
-        tdma_desc.buf_desc_id     = buf_desc_id;
-        tdma_desc.reg_data_format = static_cast<DataFormat>(formats.pack_src);
-        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+        _configure_buf_desc_table_(buf_desc_id, bd_val);
 
-        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc.reg_data_format, ckernel::ReluConfig::none());
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
@@ -38,14 +38,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t TILE_CNT        = params.TILE_CNT;
-    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
-    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
-    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
-    const std::uint32_t num_faces       = params.num_faces;
-    const Operand& buffer_A             = params.buffer_A;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const Operand& buffer_A         = params.buffer_A;
 #endif
-    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>(); // allocate srcA
 
     {
         ZONE_SCOPED("INIT")
@@ -74,14 +70,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*is_int_fpu_en*/>();
         }
 
-        buffer_descriptor_u bd_val = {0};
-        bd_val.f.l1_addr_16B       = L1_ADDRESS(buffer_A[0]);
-        bd_val.f.format            = static_cast<std::uint8_t>(formats.unpack_A_src);
-        bd_val.f.x_dim             = TEST_FACE_C_DIM;
-        bd_val.f.y_dim             = TEST_FACE_R_DIM;
-        bd_val.f.z_dim             = num_faces;
-
-        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
+            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
 
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
@@ -282,15 +272,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
-    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
-    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
-    const std::uint32_t num_faces       = params.num_faces;
-    const std::uint32_t DST_TILE_IDX    = params.DST_TILE_IDX;
-    const Operand& buffer_Res           = params.buffer_Res;
+    const std::uint32_t LOOP_FACTOR  = params.LOOP_FACTOR;
+    const std::uint32_t DST_TILE_IDX = params.DST_TILE_IDX;
+    const Operand& buffer_Res        = params.buffer_Res;
 #endif
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
-    ckernel::trisc::bfd_alloc<pack_res>();
+    constexpr auto pack_res                = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
     const std::uint32_t num_tiles_per_pack = 1; // only the SFPU result tile is packed
 
     {
@@ -313,14 +299,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        buffer_descriptor_u bd_val = {0};
-        bd_val.f.l1_addr_16B       = L1_ADDRESS(buffer_Res[0]);
-        bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
-        bd_val.f.x_dim             = TEST_FACE_C_DIM;
-        bd_val.f.y_dim             = TEST_FACE_R_DIM;
-        bd_val.f.z_dim             = num_faces;
-
-        _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
+        ckernel::trisc::bfd_alloc_and_program<pack_res>(
+            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
 
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
@@ -26,6 +26,7 @@
 #ifdef LLK_TRISC_UNPACK
 
 #include "cfg_defines.h"
+#include "llk_bfd_alloc.h"
 #include "llk_math_common.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_unary_operand.h"
@@ -44,7 +45,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t num_faces       = params.num_faces;
     const Operand& buffer_A             = params.buffer_A;
 #endif
-    const std::uint32_t buf_desc_id = 0;
+    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>(); // allocate srcA
 
     {
         ZONE_SCOPED("INIT")
@@ -80,7 +81,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val.f.y_dim             = TEST_FACE_R_DIM;
         bd_val.f.z_dim             = num_faces;
 
-        _configure_buf_desc_table_(buf_desc_id, bd_val);
+        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val);
 
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
@@ -92,7 +93,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
         }
 
-        _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, TILE_CNT);
+        _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
+            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, TILE_CNT);
         PROFILER_SYNC();
     }
     {
@@ -269,6 +271,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #ifdef LLK_TRISC_PACK
 
 #include "cfg_defines.h"
+#include "llk_bfd_alloc.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -286,7 +289,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t DST_TILE_IDX    = params.DST_TILE_IDX;
     const Operand& buffer_Res           = params.buffer_Res;
 #endif
-    std::uint32_t const buf_desc_id        = 8;
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
+    ckernel::trisc::bfd_alloc<pack_res>();
     const std::uint32_t num_tiles_per_pack = 1; // only the SFPU result tile is packed
 
     {
@@ -316,10 +320,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val.f.y_dim             = TEST_FACE_R_DIM;
         bd_val.f.z_dim             = num_faces;
 
-        _configure_buf_desc_table_(buf_desc_id, bd_val);
+        _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
 
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
@@ -70,8 +70,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*is_int_fpu_en*/>();
         }
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
-            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
 
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
@@ -299,8 +298,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        ckernel::trisc::bfd_alloc_and_program<pack_res>(
-            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
 
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_sfpu_quasar_test.cpp
@@ -70,7 +70,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*is_int_fpu_en*/>();
         }
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
+            ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
 
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
@@ -297,7 +298,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
+            ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
 
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
@@ -7,6 +7,7 @@
 
 #include "ckernel.h"
 #include "llk_defs.h"
+#include "llk_memory_checks.h"
 #include "perf.h"
 #include "profiler.h"
 #include "sfpu_stub.h"
@@ -39,8 +40,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ZONE_SCOPED("INIT")
         set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(ckernel::DEFAULT_TENSOR_SHAPE, buffer_A[0] / 16, formats.unpack_A_src);
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(ckernel::DEFAULT_TENSOR_SHAPE, buffer_B[0] / 16, formats.unpack_B_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
         _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
             static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
         _llk_unpack_binary_operands_init_(
@@ -186,7 +187,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, buffer_Res[0] / 16, formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
         PROFILER_SYNC();

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
@@ -9,7 +9,6 @@
 #include "llk_defs.h"
 #include "perf.h"
 #include "profiler.h"
-#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
 // Globals
@@ -40,10 +39,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ZONE_SCOPED("INIT")
         set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
-            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), buffer_A[0] / 16, formats.unpack_A_src);
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(
-            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), buffer_B[0] / 16, formats.unpack_B_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(ckernel::DEFAULT_TENSOR_SHAPE, buffer_A[0] / 16, formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(ckernel::DEFAULT_TENSOR_SHAPE, buffer_B[0] / 16, formats.unpack_B_src);
         _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
             static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
         _llk_unpack_binary_operands_init_(
@@ -190,7 +187,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), buffer_Res[0] / 16, formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, buffer_Res[0] / 16, formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
         PROFILER_SYNC();

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
@@ -9,6 +9,7 @@
 #include "llk_defs.h"
 #include "perf.h"
 #include "profiler.h"
+#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
 // Globals
@@ -29,37 +30,20 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
-    const std::uint32_t INPUT_TILE_CNT  = params.INPUT_TILE_CNT;
-    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
-    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
-    const std::uint32_t num_faces       = params.num_faces;
-    const Operand& buffer_A             = params.buffer_A;
-    const Operand& buffer_B             = params.buffer_B;
+    const std::uint32_t LOOP_FACTOR    = params.LOOP_FACTOR;
+    const std::uint32_t INPUT_TILE_CNT = params.INPUT_TILE_CNT;
+    const Operand& buffer_A            = params.buffer_A;
+    const Operand& buffer_B            = params.buffer_B;
 #endif
-    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>();
-    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp1>();
 
     {
         ZONE_SCOPED("INIT")
         set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
-        buffer_descriptor_u bd_val_A {};
-        bd_val_A.f.l1_addr_16B = buffer_A[0] / 16;
-        bd_val_A.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
-        bd_val_A.f.x_dim       = TEST_FACE_C_DIM;
-        bd_val_A.f.y_dim       = TEST_FACE_R_DIM;
-        bd_val_A.f.z_dim       = num_faces;
-
-        buffer_descriptor_u bd_val_B {};
-        bd_val_B.f.l1_addr_16B = buffer_B[0] / 16;
-        bd_val_B.f.format      = static_cast<std::uint8_t>(formats.unpack_B_src);
-        bd_val_B.f.x_dim       = TEST_FACE_C_DIM;
-        bd_val_B.f.y_dim       = TEST_FACE_R_DIM;
-        bd_val_B.f.z_dim       = num_faces;
-
-        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val_A);
-        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(), bd_val_B);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
+            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), buffer_A[0] / 16, formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(
+            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), buffer_B[0] / 16, formats.unpack_B_src);
         _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
             static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
         _llk_unpack_binary_operands_init_(
@@ -189,13 +173,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #ifndef SPEED_OF_LIGHT
     const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
     const std::uint32_t OUTPUT_TILE_CNT = params.OUTPUT_TILE_CNT;
-    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
-    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
-    const std::uint32_t num_faces       = params.num_faces;
     const Operand& buffer_Res           = params.buffer_Res;
 #endif
     constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
-    ckernel::trisc::bfd_alloc<pack_res>();
 
     {
         ZONE_SCOPED("INIT")
@@ -210,14 +190,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        buffer_descriptor_u bd_val {};
-        bd_val.f.l1_addr_16B = buffer_Res[0] / 16;
-        bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
-        bd_val.f.x_dim       = TEST_FACE_C_DIM;
-        bd_val.f.y_dim       = TEST_FACE_R_DIM;
-        bd_val.f.z_dim       = num_faces;
-
-        _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
+        ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), buffer_Res[0] / 16, formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
         PROFILER_SYNC();

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
@@ -172,7 +172,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t OUTPUT_TILE_CNT = params.OUTPUT_TILE_CNT;
     const Operand& buffer_Res           = params.buffer_Res;
 #endif
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
 
     {
         ZONE_SCOPED("INIT")
@@ -187,9 +186,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, buffer_Res[0] / 16, formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, buffer_Res[0] / 16, formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
@@ -36,7 +36,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A             = params.buffer_A;
     const Operand& buffer_B             = params.buffer_B;
 #endif
-    tdma_descriptor_t td_val_A, td_val_B;
     const std::uint32_t buf_desc_id_a = 0;
     const std::uint32_t buf_desc_id_b = 1;
 
@@ -51,10 +50,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val_A.f.y_dim       = TEST_FACE_R_DIM;
         bd_val_A.f.z_dim       = num_faces;
 
-        td_val_A.buf_desc        = bd_val_A;
-        td_val_A.buf_desc_id     = buf_desc_id_a;
-        td_val_A.reg_data_format = static_cast<DataFormat>(formats.unpack_A_dst);
-
         buffer_descriptor_u bd_val_B {};
         bd_val_B.f.l1_addr_16B = buffer_B[0] / 16;
         bd_val_B.f.format      = static_cast<std::uint8_t>(formats.unpack_B_src);
@@ -62,13 +57,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val_B.f.y_dim       = TEST_FACE_R_DIM;
         bd_val_B.f.z_dim       = num_faces;
 
-        td_val_B.buf_desc        = bd_val_B;
-        td_val_B.buf_desc_id     = buf_desc_id_b;
-        td_val_B.reg_data_format = static_cast<DataFormat>(formats.unpack_B_dst);
-
-        _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
-        _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
-        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A.reg_data_format, td_val_B.reg_data_format);
+        _configure_buf_desc_table_(buf_desc_id_a, bd_val_A);
+        _configure_buf_desc_table_(buf_desc_id_b, bd_val_B);
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
+            static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
         _llk_unpack_binary_operands_init_(buf_desc_id_a, buf_desc_id_b, 1 /*num_tiles_per_unpack*/);
         PROFILER_SYNC();
     }
@@ -219,13 +211,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val.f.y_dim       = TEST_FACE_R_DIM;
         bd_val.f.z_dim       = num_faces;
 
-        tdma_descriptor_t tdma_desc;
-        tdma_desc.buf_desc        = bd_val;
-        tdma_desc.buf_desc_id     = buf_desc_id;
-        tdma_desc.reg_data_format = static_cast<DataFormat>(formats.pack_src);
-
-        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc.reg_data_format, ckernel::ReluConfig::none());
+        _configure_buf_desc_table_(buf_desc_id, bd_val);
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
@@ -40,8 +40,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ZONE_SCOPED("INIT")
         set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
+            ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(
+            ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
         _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
             static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
         _llk_unpack_binary_operands_init_(
@@ -187,7 +189,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
+            ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
         PROFILER_SYNC();

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
@@ -18,6 +18,7 @@ std::uint32_t math_sync_tile_dst_index = 0;
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_unpack_binary_operands.h"
 #include "llk_unpack_common.h"
 #include "params.h"
@@ -36,8 +37,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A             = params.buffer_A;
     const Operand& buffer_B             = params.buffer_B;
 #endif
-    const std::uint32_t buf_desc_id_a = 0;
-    const std::uint32_t buf_desc_id_b = 1;
+    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>();
+    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp1>();
 
     {
         ZONE_SCOPED("INIT")
@@ -57,11 +58,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val_B.f.y_dim       = TEST_FACE_R_DIM;
         bd_val_B.f.z_dim       = num_faces;
 
-        _configure_buf_desc_table_(buf_desc_id_a, bd_val_A);
-        _configure_buf_desc_table_(buf_desc_id_b, bd_val_B);
+        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val_A);
+        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(), bd_val_B);
         _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
             static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
-        _llk_unpack_binary_operands_init_(buf_desc_id_a, buf_desc_id_b, 1 /*num_tiles_per_unpack*/);
+        _llk_unpack_binary_operands_init_(
+            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(),
+            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(),
+            1 /*num_tiles_per_unpack*/);
         PROFILER_SYNC();
     }
     {
@@ -172,6 +176,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -189,7 +194,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t num_faces       = params.num_faces;
     const Operand& buffer_Res           = params.buffer_Res;
 #endif
-    std::uint32_t const buf_desc_id = 8;
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
+    ckernel::trisc::bfd_alloc<pack_res>();
 
     {
         ZONE_SCOPED("INIT")
@@ -211,9 +217,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val.f.y_dim       = TEST_FACE_R_DIM;
         bd_val.f.z_dim       = num_faces;
 
-        _configure_buf_desc_table_(buf_desc_id, bd_val);
+        _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
+        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_sub_bcast_col_custom_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_sub_bcast_col_custom_quasar_test.cpp
@@ -40,14 +40,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     const auto tensor_shape = tensor_shape_from_params(params);
 
-    const tdma_descriptor_t td_val_A =
-        ckernel::trisc::construct_tdma_desc(tensor_shape, L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src, buf_desc_id_a, formats.unpack_A_dst);
-    const tdma_descriptor_t td_val_B =
-        ckernel::trisc::construct_tdma_desc(tensor_shape, L1_ADDRESS(params.buffer_B[0]), formats.unpack_B_src, buf_desc_id_b, formats.unpack_B_dst);
+    program_buf_desc(buf_desc_id_a, tensor_shape, L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
+    program_buf_desc(buf_desc_id_b, tensor_shape, L1_ADDRESS(params.buffer_B[0]), formats.unpack_B_src);
 
-    _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
-    _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
-    _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A.reg_data_format, td_val_B.reg_data_format);
+    _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
+        static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
 
     _llk_unpack_AB_sub_bcast_col_init_custom_(tensor_shape);
 
@@ -115,11 +112,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     const auto tensor_shape = tensor_shape_from_params(params);
 
-    const tdma_descriptor_t tdma_desc =
-        ckernel::trisc::construct_tdma_desc(tensor_shape, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
-
-    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc.reg_data_format, ckernel::ReluConfig::none());
+    program_buf_desc(buf_desc_id, tensor_shape, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
+    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
     _llk_pack_init_(buf_desc_id, tensor_shape, 1 /*num_tiles_per_pack*/);
 
     const std::uint32_t ct_dim     = params.OUTPUT_NUM_TILES_IN_BLOCK;

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_sub_bcast_col_custom_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_sub_bcast_col_custom_quasar_test.cpp
@@ -25,6 +25,7 @@ std::uint32_t math_sync_tile_dst_index = 0;
 #ifdef LLK_TRISC_UNPACK
 
 #include "experimental/llk_unpack_AB_sub_bcast_col_custom.h"
+#include "llk_bfd_alloc.h"
 #include "llk_unpack_common.h"
 #include "params.h"
 
@@ -33,15 +34,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t buf_desc_id_a = 0;
-    const std::uint32_t buf_desc_id_b = 1;
-
     set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
     const auto tensor_shape = tensor_shape_from_params(params);
 
-    program_buf_desc(buf_desc_id_a, tensor_shape, L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
-    program_buf_desc(buf_desc_id_b, tensor_shape, L1_ADDRESS(params.buffer_B[0]), formats.unpack_B_src);
+    ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(tensor_shape, L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
+    ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(tensor_shape, L1_ADDRESS(params.buffer_B[0]), formats.unpack_B_src);
 
     _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
         static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
@@ -54,7 +52,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
     for (std::uint32_t block = 0; block < num_blocks; block++)
     {
         // SrcB is the same single tile for every block, so its L1 tile index stays 0.
-        _llk_unpack_AB_sub_bcast_col_custom_(buf_desc_id_a, buf_desc_id_b, block * ct_dim, 0 /*start_l1_tile_idx_1*/, ct_dim, tensor_shape);
+        _llk_unpack_AB_sub_bcast_col_custom_(
+            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(),
+            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(),
+            block * ct_dim,
+            0 /*start_l1_tile_idx_1*/,
+            ct_dim,
+            tensor_shape);
     }
 }
 
@@ -97,24 +101,24 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t buf_desc_id = 8;
-
     set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
     const auto tensor_shape = tensor_shape_from_params(params);
 
-    program_buf_desc(buf_desc_id, tensor_shape, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
+    ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-    _llk_pack_init_(buf_desc_id, tensor_shape, 1 /*num_tiles_per_pack*/);
+    _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), tensor_shape, 1 /*num_tiles_per_pack*/);
 
     const std::uint32_t ct_dim     = params.OUTPUT_NUM_TILES_IN_BLOCK;
     const std::uint32_t num_blocks = static_cast<std::uint32_t>(params.OUTPUT_NUM_BLOCKS);

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_sub_bcast_col_custom_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_sub_bcast_col_custom_quasar_test.cpp
@@ -108,7 +108,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
@@ -116,9 +115,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     const auto tensor_shape = tensor_shape_from_params(params);
 
-    ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
+    ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(tensor_shape, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-    _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), tensor_shape, 1 /*num_tiles_per_pack*/);
+    _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape, 1 /*num_tiles_per_pack*/);
 
     const std::uint32_t ct_dim     = params.OUTPUT_NUM_TILES_IN_BLOCK;
     const std::uint32_t num_blocks = static_cast<std::uint32_t>(params.OUTPUT_NUM_BLOCKS);

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
@@ -33,7 +33,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const int num_faces_c_dim_A        = params.num_faces_c_dim_A;
     const Operand& buffer_B            = params.buffer_B;
 #endif
-    tdma_descriptor_t td_val_A, td_val_B;
     const std::uint32_t buf_desc_id_a = 0;
     const std::uint32_t buf_desc_id_b = 1;
     // Unpack to dest must use the num tiles per unpack parameter in order to unpack multiple tiles per Dest bank
@@ -61,13 +60,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
 
-        td_val_A = ckernel::trisc::construct_tdma_desc(tensor_shape, L1_ADDRESS(buffer_B[0]), formats.unpack_A_src, buf_desc_id_a, formats.unpack_A_dst);
-        td_val_B = ckernel::trisc::construct_tdma_desc(tensor_shape, L1_ADDRESS(buffer_B[0]), formats.unpack_A_src, buf_desc_id_b, formats.unpack_A_dst);
+        program_buf_desc(buf_desc_id_a, tensor_shape, L1_ADDRESS(buffer_B[0]), formats.unpack_A_src);
+        program_buf_desc(buf_desc_id_b, tensor_shape, L1_ADDRESS(buffer_B[0]), formats.unpack_A_src);
 
-        _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
-        _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
-
-        _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(unpack_to_dest ? td_val_A.reg_data_format : td_val_B.reg_data_format);
+        _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
         _llk_unpack_unary_broadcast_operands_init_<UNPACKER_ENGINE_SEL, BROADCAST_TYPE, unpack_to_dest>(
             unpack_to_dest ? buf_desc_id_a : buf_desc_id_b, num_tiles_per_unpack);
 
@@ -292,11 +288,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
 
-        tdma_descriptor_t tdma_desc =
-            ckernel::trisc::construct_tdma_desc(tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
-
-        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc.reg_data_format, ckernel::ReluConfig::none());
+        program_buf_desc(buf_desc_id, tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(buf_desc_id, tensor_shape, num_tiles_per_pack);
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
@@ -15,6 +15,7 @@
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_math_common.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_unary_broadcast_operands.h"
@@ -33,8 +34,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const int num_faces_c_dim_A        = params.num_faces_c_dim_A;
     const Operand& buffer_B            = params.buffer_B;
 #endif
-    const std::uint32_t buf_desc_id_a = 0;
-    const std::uint32_t buf_desc_id_b = 1;
     // Unpack to dest must use the num tiles per unpack parameter in order to unpack multiple tiles per Dest bank
     const std::uint32_t num_tiles_per_unpack = unpack_to_dest ? tiles_in_block : 1;
 
@@ -60,12 +59,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
 
-        program_buf_desc(buf_desc_id_a, tensor_shape, L1_ADDRESS(buffer_B[0]), formats.unpack_A_src);
-        program_buf_desc(buf_desc_id_b, tensor_shape, L1_ADDRESS(buffer_B[0]), formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(tensor_shape, L1_ADDRESS(buffer_B[0]), formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(tensor_shape, L1_ADDRESS(buffer_B[0]), formats.unpack_A_src);
 
         _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
         _llk_unpack_unary_broadcast_operands_init_<UNPACKER_ENGINE_SEL, BROADCAST_TYPE, unpack_to_dest>(
-            unpack_to_dest ? buf_desc_id_a : buf_desc_id_b, num_tiles_per_unpack);
+            unpack_to_dest ? ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>()
+                           : ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(),
+            num_tiles_per_unpack);
 
         PROFILER_SYNC();
     }
@@ -246,12 +247,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
@@ -262,7 +265,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_Res                 = params.buffer_Res;
 #endif
 
-    constexpr std::uint32_t buf_desc_id    = 8;
     const std::uint32_t num_tiles_per_pack = 1;
 
     {
@@ -288,9 +290,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
 
-        program_buf_desc(buf_desc_id, tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(buf_desc_id, tensor_shape, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), tensor_shape, num_tiles_per_pack);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
@@ -59,14 +59,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(tensor_shape, L1_ADDRESS(buffer_B[0]), formats.unpack_A_src);
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(tensor_shape, L1_ADDRESS(buffer_B[0]), formats.unpack_A_src);
+        // Record the descriptor under the engine UNPACKER_ENGINE_SEL actually drives (UNP_B -> UNPACR1/Unp1).
+        constexpr auto unp_res = (UNPACKER_ENGINE_SEL == p_unpacr::UNP_B) ? ckernel::trisc::BfdResource::Unp1 : ckernel::trisc::BfdResource::Unp0;
+        ckernel::trisc::bfd_alloc_and_program<unp_res>(tensor_shape, L1_ADDRESS(buffer_B[0]), formats.unpack_A_src);
 
         _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
         _llk_unpack_unary_broadcast_operands_init_<UNPACKER_ENGINE_SEL, BROADCAST_TYPE, unpack_to_dest>(
-            unpack_to_dest ? ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>()
-                           : ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(),
-            num_tiles_per_unpack);
+            ckernel::trisc::bfd_current<unp_res>(), num_tiles_per_unpack);
 
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_broadcast_quasar_test.cpp
@@ -254,7 +254,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
@@ -290,9 +289,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
 
-        ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), tensor_shape, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape, num_tiles_per_pack);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_datacopy_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_datacopy_quasar_test.cpp
@@ -197,7 +197,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
@@ -225,9 +224,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
 
-        ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), tensor_shape_A, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape_A, num_tiles_per_pack);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_datacopy_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_datacopy_quasar_test.cpp
@@ -48,7 +48,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
             l1_addr_16B = L1_ADDRESS(buffer_A[0]);
         }
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(tensor_shape_A, l1_addr_16B, formats.unpack_A_src);
+        // Record the descriptor under the engine UNPACKER_ENGINE_SEL actually drives (UNP_B -> UNPACR1/Unp1).
+        constexpr auto unp_res = (UNPACKER_ENGINE_SEL == p_unpacr::UNP_B) ? ckernel::trisc::BfdResource::Unp1 : ckernel::trisc::BfdResource::Unp0;
+        ckernel::trisc::bfd_alloc_and_program<unp_res>(tensor_shape_A, l1_addr_16B, formats.unpack_A_src);
 
         if constexpr (is_fp32_dest_acc_en)
         {
@@ -61,7 +63,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
 
         _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
-            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), tensor_shape_A, num_tiles_per_unpack);
+            ckernel::trisc::bfd_current<unp_res>(), tensor_shape_A, num_tiles_per_unpack);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_datacopy_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_datacopy_quasar_test.cpp
@@ -16,6 +16,7 @@
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_unary_operand.h"
 #include "params.h"
@@ -31,7 +32,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A         = params.buffer_A;
     const Operand& buffer_B         = params.buffer_B;
 #endif
-    const std::uint32_t buf_desc_id          = 0;
     const std::uint32_t num_tiles_per_unpack = TILE_CNT;
 
     {
@@ -48,7 +48,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             l1_addr_16B = L1_ADDRESS(buffer_A[0]);
         }
 
-        program_buf_desc(buf_desc_id, tensor_shape_A, l1_addr_16B, formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(tensor_shape_A, l1_addr_16B, formats.unpack_A_src);
 
         if constexpr (is_fp32_dest_acc_en)
         {
@@ -60,7 +60,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
         }
 
-        _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, tensor_shape_A, num_tiles_per_unpack);
+        _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
+            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), tensor_shape_A, num_tiles_per_unpack);
         PROFILER_SYNC();
     }
     {
@@ -189,12 +190,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
@@ -204,7 +207,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t DST_INDEX   = params.DST_INDEX;
     const Operand& buffer_Res       = params.buffer_Res;
 #endif
-    std::uint32_t const buf_desc_id        = 8;
     const std::uint32_t num_tiles_per_pack = TILE_CNT;
 
     {
@@ -223,9 +225,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
 
-        program_buf_desc(buf_desc_id, tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(buf_desc_id, tensor_shape_A, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), tensor_shape_A, num_tiles_per_pack);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_datacopy_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_datacopy_quasar_test.cpp
@@ -48,16 +48,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
             l1_addr_16B = L1_ADDRESS(buffer_A[0]);
         }
 
-        tdma_descriptor_t td_val = ckernel::trisc::construct_tdma_desc(tensor_shape_A, l1_addr_16B, formats.unpack_A_src, buf_desc_id, formats.unpack_A_dst);
+        program_buf_desc(buf_desc_id, tensor_shape_A, l1_addr_16B, formats.unpack_A_src);
 
-        _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
         if constexpr (is_fp32_dest_acc_en)
         {
-            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val.reg_data_format, td_val.reg_data_format);
+            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
+                static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_A_dst));
         }
         else
         {
-            _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val.reg_data_format);
+            _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
         }
 
         _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, tensor_shape_A, num_tiles_per_unpack);
@@ -223,11 +223,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
 
-        tdma_descriptor_t tdma_desc =
-            ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
-
-        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc.reg_data_format, ckernel::ReluConfig::none());
+        program_buf_desc(buf_desc_id, tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(buf_desc_id, tensor_shape_A, num_tiles_per_pack);
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
@@ -270,7 +270,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t DST_INDEX   = params.DST_INDEX;
     const Operand& buffer_Res       = params.buffer_Res;
 #endif
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
 
     {
         ZONE_SCOPED("INIT")
@@ -292,10 +291,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, buffer_Res[0] / 16, formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, buffer_Res[0] / 16, formats.pack_dst);
 
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, TILE_CNT);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, TILE_CNT);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
@@ -72,7 +72,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
+            ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
 
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
@@ -291,7 +292,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
+            ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
 
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, TILE_CNT);

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
@@ -15,6 +15,7 @@
 #ifdef LLK_TRISC_UNPACK
 
 #include "cfg_defines.h"
+#include "llk_bfd_alloc.h"
 #include "llk_math_common.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_unary_operand.h"
@@ -33,7 +34,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t num_faces       = params.num_faces;
     const Operand& buffer_A             = params.buffer_A;
 #endif
-    const std::uint32_t buf_desc_id = 0;
+    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>(); // allocate srcA
 
     {
         ZONE_SCOPED("INIT")
@@ -83,7 +84,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val.f.y_dim       = TEST_FACE_R_DIM;
         bd_val.f.z_dim       = num_faces;
 
-        _configure_buf_desc_table_(buf_desc_id, bd_val);
+        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val);
 
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
@@ -95,7 +96,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
         }
 
-        _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, TILE_CNT);
+        _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
+            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, TILE_CNT);
         PROFILER_SYNC();
     }
     {
@@ -264,6 +266,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #ifdef LLK_TRISC_PACK
 
 #include "cfg_defines.h"
+#include "llk_bfd_alloc.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -282,7 +285,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t DST_INDEX       = params.DST_INDEX;
     const Operand& buffer_Res           = params.buffer_Res;
 #endif
-    std::uint32_t const buf_desc_id = 8;
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
+    ckernel::trisc::bfd_alloc<pack_res>();
 
     {
         ZONE_SCOPED("INIT")
@@ -311,10 +315,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val.f.y_dim             = TEST_FACE_R_DIM;
         bd_val.f.z_dim             = num_faces;
 
-        _configure_buf_desc_table_(buf_desc_id, bd_val);
+        _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
 
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, TILE_CNT);
+        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, TILE_CNT);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
@@ -27,14 +27,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t TILE_CNT        = params.TILE_CNT;
-    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
-    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
-    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
-    const std::uint32_t num_faces       = params.num_faces;
-    const Operand& buffer_A             = params.buffer_A;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const Operand& buffer_A         = params.buffer_A;
 #endif
-    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>(); // allocate srcA
 
     {
         ZONE_SCOPED("INIT")
@@ -76,15 +72,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        buffer_descriptor_u bd_val = {0};
-
-        bd_val.f.l1_addr_16B = L1_ADDRESS(buffer_A[0]);
-        bd_val.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
-        bd_val.f.x_dim       = TEST_FACE_C_DIM;
-        bd_val.f.y_dim       = TEST_FACE_R_DIM;
-        bd_val.f.z_dim       = num_faces;
-
-        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
+            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
 
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
@@ -277,16 +266,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t TILE_CNT        = params.TILE_CNT;
-    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
-    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
-    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
-    const std::uint32_t num_faces       = params.num_faces;
-    const std::uint32_t DST_INDEX       = params.DST_INDEX;
-    const Operand& buffer_Res           = params.buffer_Res;
+    const std::uint32_t TILE_CNT    = params.TILE_CNT;
+    const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
+    const std::uint32_t DST_INDEX   = params.DST_INDEX;
+    const Operand& buffer_Res       = params.buffer_Res;
 #endif
     constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
-    ckernel::trisc::bfd_alloc<pack_res>();
 
     {
         ZONE_SCOPED("INIT")
@@ -308,14 +293,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        buffer_descriptor_u bd_val = {0};
-        bd_val.f.l1_addr_16B       = buffer_Res[0] / 16;
-        bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
-        bd_val.f.x_dim             = TEST_FACE_C_DIM;
-        bd_val.f.y_dim             = TEST_FACE_R_DIM;
-        bd_val.f.z_dim             = num_faces;
-
-        _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
+        ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), buffer_Res[0] / 16, formats.pack_dst);
 
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, TILE_CNT);

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
@@ -83,19 +83,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val.f.y_dim       = TEST_FACE_R_DIM;
         bd_val.f.z_dim       = num_faces;
 
-        tdma_descriptor_t td_val;
-        td_val.buf_desc        = bd_val;
-        td_val.buf_desc_id     = buf_desc_id;
-        td_val.reg_data_format = static_cast<DataFormat>(formats.unpack_A_dst);
-        _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+        _configure_buf_desc_table_(buf_desc_id, bd_val);
 
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
-            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val.reg_data_format, td_val.reg_data_format);
+            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
+                static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_A_dst));
         }
         else
         {
-            _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val.reg_data_format);
+            _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
         }
 
         _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, TILE_CNT);
@@ -314,13 +311,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val.f.y_dim             = TEST_FACE_R_DIM;
         bd_val.f.z_dim             = num_faces;
 
-        tdma_descriptor_t tdma_desc;
-        tdma_desc.buf_desc        = bd_val;
-        tdma_desc.buf_desc_id     = buf_desc_id;
-        tdma_desc.reg_data_format = static_cast<DataFormat>(formats.pack_src);
-        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+        _configure_buf_desc_table_(buf_desc_id, bd_val);
 
-        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc.reg_data_format, ckernel::ReluConfig::none());
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, TILE_CNT);
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
@@ -291,7 +291,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, buffer_Res[0] / 16, formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
 
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, TILE_CNT);

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
@@ -72,8 +72,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
-            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
 
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
@@ -293,7 +292,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), buffer_Res[0] / 16, formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, buffer_Res[0] / 16, formats.pack_dst);
 
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, TILE_CNT);

--- a/tt_metal/tt-llk/tests/sources/quasar/isolate_sfpu_add_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/isolate_sfpu_add_quasar_test.cpp
@@ -73,47 +73,35 @@ void run_kernel(RUNTIME_PARAMETERS params)
     constexpr std::uint32_t buf_desc_id_pack     = 8;
 
     buffer_descriptor_u bd_unpack_0 = {0};
-    tdma_descriptor_t td_unpack_0;
     buffer_descriptor_u bd_unpack_1 = {0};
-    tdma_descriptor_t td_unpack_1;
-    buffer_descriptor_u bd_pack = {0};
-    tdma_descriptor_t td_pack;
+    buffer_descriptor_u bd_pack     = {0};
 
     // Unpack BD 0: L1 input A -> SrcS slice 0
-    bd_unpack_0.f.l1_addr_16B   = L1_ADDRESS(params.buffer_A[0]);
-    bd_unpack_0.f.format        = static_cast<std::uint8_t>(formats.unpack_S_src);
-    bd_unpack_0.f.x_dim         = PARAM_SRCS_XDIM;
-    bd_unpack_0.f.y_dim         = PARAM_SRCS_YDIM;
-    bd_unpack_0.f.z_dim         = PARAM_SRCS_ZDIM;
-    td_unpack_0.buf_desc        = bd_unpack_0;
-    td_unpack_0.buf_desc_id     = buf_desc_id_unpack_0;
-    td_unpack_0.reg_data_format = static_cast<DataFormat>(formats.unpack_S_dst);
-    _configure_buf_desc_table_(td_unpack_0.buf_desc_id, td_unpack_0.buf_desc);
-    _llk_unpack_configure_unary_<p_unpacr::UNP_S>(td_unpack_0.reg_data_format);
+    bd_unpack_0.f.l1_addr_16B = L1_ADDRESS(params.buffer_A[0]);
+    bd_unpack_0.f.format      = static_cast<std::uint8_t>(formats.unpack_S_src);
+    bd_unpack_0.f.x_dim       = PARAM_SRCS_XDIM;
+    bd_unpack_0.f.y_dim       = PARAM_SRCS_YDIM;
+    bd_unpack_0.f.z_dim       = PARAM_SRCS_ZDIM;
+    _configure_buf_desc_table_(buf_desc_id_unpack_0, bd_unpack_0);
+    _llk_unpack_configure_unary_<p_unpacr::UNP_S>(static_cast<DataFormat>(formats.unpack_S_dst));
 
     // Unpack BD 1: L1 input B -> SrcS slice 1
-    bd_unpack_1.f.l1_addr_16B   = L1_ADDRESS(params.buffer_B[0]);
-    bd_unpack_1.f.format        = static_cast<std::uint8_t>(formats.unpack_S_src);
-    bd_unpack_1.f.x_dim         = PARAM_SRCS_XDIM;
-    bd_unpack_1.f.y_dim         = PARAM_SRCS_YDIM;
-    bd_unpack_1.f.z_dim         = PARAM_SRCS_ZDIM;
-    td_unpack_1.buf_desc        = bd_unpack_1;
-    td_unpack_1.buf_desc_id     = buf_desc_id_unpack_1;
-    td_unpack_1.reg_data_format = static_cast<DataFormat>(formats.unpack_S_dst);
-    _configure_buf_desc_table_(td_unpack_1.buf_desc_id, td_unpack_1.buf_desc);
-    _llk_unpack_configure_unary_<p_unpacr::UNP_S>(td_unpack_1.reg_data_format);
+    bd_unpack_1.f.l1_addr_16B = L1_ADDRESS(params.buffer_B[0]);
+    bd_unpack_1.f.format      = static_cast<std::uint8_t>(formats.unpack_S_src);
+    bd_unpack_1.f.x_dim       = PARAM_SRCS_XDIM;
+    bd_unpack_1.f.y_dim       = PARAM_SRCS_YDIM;
+    bd_unpack_1.f.z_dim       = PARAM_SRCS_ZDIM;
+    _configure_buf_desc_table_(buf_desc_id_unpack_1, bd_unpack_1);
+    _llk_unpack_configure_unary_<p_unpacr::UNP_S>(static_cast<DataFormat>(formats.unpack_S_dst));
 
     // Pack BD: SrcS slice 2 -> L1 output
-    bd_pack.f.l1_addr_16B   = L1_ADDRESS(params.buffer_Res[0]);
-    bd_pack.f.format        = static_cast<std::uint8_t>(formats.pack_S_dst);
-    bd_pack.f.x_dim         = PARAM_SRCS_XDIM;
-    bd_pack.f.y_dim         = PARAM_SRCS_YDIM;
-    bd_pack.f.z_dim         = PARAM_SRCS_ZDIM;
-    td_pack.buf_desc        = bd_pack;
-    td_pack.buf_desc_id     = buf_desc_id_pack;
-    td_pack.reg_data_format = static_cast<DataFormat>(formats.pack_S_src);
-    _configure_buf_desc_table_(td_pack.buf_desc_id, td_pack.buf_desc);
-    _llk_pack_hw_configure_<p_pacr::PACK1, false>(td_pack.reg_data_format, ckernel::ReluConfig::none());
+    bd_pack.f.l1_addr_16B = L1_ADDRESS(params.buffer_Res[0]);
+    bd_pack.f.format      = static_cast<std::uint8_t>(formats.pack_S_dst);
+    bd_pack.f.x_dim       = PARAM_SRCS_XDIM;
+    bd_pack.f.y_dim       = PARAM_SRCS_YDIM;
+    bd_pack.f.z_dim       = PARAM_SRCS_ZDIM;
+    _configure_buf_desc_table_(buf_desc_id_pack, bd_pack);
+    _llk_pack_hw_configure_<p_pacr::PACK1, false>(static_cast<DataFormat>(formats.pack_S_src), ckernel::ReluConfig::none());
 
     // Implied math format disable for SrcS and sfpmem mod selection
     cfg[DISABLE_IMPLIED_SRCS_FORMAT_ADDR32 + TRISC_ID] = !IMPLIED_MATH_FORMAT;

--- a/tt_metal/tt-llk/tests/sources/quasar/isolate_sfpu_square_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/isolate_sfpu_square_quasar_test.cpp
@@ -72,33 +72,25 @@ void run_kernel(RUNTIME_PARAMETERS params)
     constexpr std::uint32_t buf_desc_id_pack   = 8;
 
     buffer_descriptor_u bd_unpack = {0};
-    tdma_descriptor_t td_unpack;
-    buffer_descriptor_u bd_pack = {0};
-    tdma_descriptor_t td_pack;
+    buffer_descriptor_u bd_pack   = {0};
 
     // Unpack BD: L1 input -> SrcS
-    bd_unpack.f.l1_addr_16B   = L1_ADDRESS(params.buffer_A[0]);
-    bd_unpack.f.format        = static_cast<std::uint8_t>(formats.unpack_S_src);
-    bd_unpack.f.x_dim         = PARAM_SRCS_XDIM;
-    bd_unpack.f.y_dim         = PARAM_SRCS_YDIM;
-    bd_unpack.f.z_dim         = PARAM_SRCS_ZDIM;
-    td_unpack.buf_desc        = bd_unpack;
-    td_unpack.buf_desc_id     = buf_desc_id_unpack;
-    td_unpack.reg_data_format = static_cast<DataFormat>(formats.unpack_S_dst);
-    _configure_buf_desc_table_(td_unpack.buf_desc_id, td_unpack.buf_desc);
-    _llk_unpack_configure_unary_<p_unpacr::UNP_S>(td_unpack.reg_data_format);
+    bd_unpack.f.l1_addr_16B = L1_ADDRESS(params.buffer_A[0]);
+    bd_unpack.f.format      = static_cast<std::uint8_t>(formats.unpack_S_src);
+    bd_unpack.f.x_dim       = PARAM_SRCS_XDIM;
+    bd_unpack.f.y_dim       = PARAM_SRCS_YDIM;
+    bd_unpack.f.z_dim       = PARAM_SRCS_ZDIM;
+    _configure_buf_desc_table_(buf_desc_id_unpack, bd_unpack);
+    _llk_unpack_configure_unary_<p_unpacr::UNP_S>(static_cast<DataFormat>(formats.unpack_S_dst));
 
     // Pack BD: SrcS -> L1 output
-    bd_pack.f.l1_addr_16B   = L1_ADDRESS(params.buffer_Res[0]);
-    bd_pack.f.format        = static_cast<std::uint8_t>(formats.pack_S_dst);
-    bd_pack.f.x_dim         = PARAM_SRCS_XDIM;
-    bd_pack.f.y_dim         = PARAM_SRCS_YDIM;
-    bd_pack.f.z_dim         = PARAM_SRCS_ZDIM;
-    td_pack.buf_desc        = bd_pack;
-    td_pack.buf_desc_id     = buf_desc_id_pack;
-    td_pack.reg_data_format = static_cast<DataFormat>(formats.pack_S_src);
-    _configure_buf_desc_table_(td_pack.buf_desc_id, td_pack.buf_desc);
-    _llk_pack_hw_configure_<p_pacr::PACK1, false>(td_pack.reg_data_format, ckernel::ReluConfig::none());
+    bd_pack.f.l1_addr_16B = L1_ADDRESS(params.buffer_Res[0]);
+    bd_pack.f.format      = static_cast<std::uint8_t>(formats.pack_S_dst);
+    bd_pack.f.x_dim       = PARAM_SRCS_XDIM;
+    bd_pack.f.y_dim       = PARAM_SRCS_YDIM;
+    bd_pack.f.z_dim       = PARAM_SRCS_ZDIM;
+    _configure_buf_desc_table_(buf_desc_id_pack, bd_pack);
+    _llk_pack_hw_configure_<p_pacr::PACK1, false>(static_cast<DataFormat>(formats.pack_S_src), ckernel::ReluConfig::none());
 
     // Implied math format disable for SrcS and sfpmem mod selection
     cfg[DISABLE_IMPLIED_SRCS_FORMAT_ADDR32 + TRISC_ID] = !IMPLIED_MATH_FORMAT;

--- a/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
@@ -11,7 +11,6 @@
 #include "llk_memory_checks.h"
 #include "perf.h"
 #include "profiler.h"
-#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
 // Globals
@@ -43,10 +42,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ZONE_SCOPED("INIT")
         set_ttsync_enables<TRACK_ALL>(ckernel::TRISC_ID);
         // Full 32x32 tiles: 2x2 faces of 16x16 (tiny tiles not supported for quasar). srcA before srcB.
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
-            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(
-            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
         _llk_unpack_hw_configure_<ckernel::p_unpacr::UNP_B>(static_cast<DataFormat>(formats.unpack_A_dst));
         _llk_unpack_hw_configure_<ckernel::p_unpacr::UNP_A>(static_cast<DataFormat>(formats.unpack_B_dst));
 
@@ -204,8 +201,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
 
         // Full 32x32 tiles: 2x2 faces of 16x16 (tiny tiles not supported for quasar).
-        ckernel::trisc::bfd_alloc_and_program<pack_res>(
-            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_matmul_init_(
             ckernel::trisc::bfd_current<pack_res>(), RT_DIM, CT_DIM, 1 /*num_subblocks_c_dim*/); // Use destination buffer descriptor for packing output

--- a/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
@@ -18,13 +18,9 @@ std::uint32_t unp_cfg_context          = 0;
 std::uint32_t pack_sync_tile_dst_ptr   = 0;
 std::uint32_t math_sync_tile_dst_index = 0;
 
-// Buffer descriptor IDs for TDMA engines - these are indices into the hardware buffer descriptor table
-constexpr std::uint32_t buf_desc_id_src_a = 29; // Source A matrix input buffer
-constexpr std::uint32_t buf_desc_id_src_b = 30; // Source B matrix input buffer
-constexpr std::uint32_t buf_desc_id_dst   = 31; // Destination matrix output buffer
-
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_unpack_matmul.h"
 #include "params.h"
 
@@ -47,6 +43,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
         set_ttsync_enables<TRACK_ALL>(ckernel::TRISC_ID);
+        ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>(); // allocate srcA (order matters: A before B)
+        ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp1>(); // allocate srcB
         // src A input configuration
         buffer_descriptor_u bd_src_a = {0};
         bd_src_a.f.l1_addr_16B       = L1_ADDRESS(buffer_A[0]);
@@ -65,13 +63,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_src_b.f.y_dim             = FACE_R_DIM;  // Default face dimension is 16, tiny tiles not supported for quasar
         bd_src_b.f.z_dim             = num_faces_B; // Number of faces = 4, tiny tiles not supported for quasar
 
-        _configure_buf_desc_table_(buf_desc_id_src_a, bd_src_a);
-        _configure_buf_desc_table_(buf_desc_id_src_b, bd_src_b);
+        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_src_a);
+        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(), bd_src_b);
         _llk_unpack_hw_configure_<ckernel::p_unpacr::UNP_B>(static_cast<DataFormat>(formats.unpack_A_dst));
         _llk_unpack_hw_configure_<ckernel::p_unpacr::UNP_A>(static_cast<DataFormat>(formats.unpack_B_dst));
 
-        _llk_unpack_matmul_init_<UNPACK_TRANSPOSE_FACES>(buf_desc_id_src_a, buf_desc_id_src_b, CT_DIM, RT_DIM, KT_DIM); // transpose in src_A not supported for
-                                                                                                                        // quasar
+        _llk_unpack_matmul_init_<UNPACK_TRANSPOSE_FACES>(
+            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(),
+            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(),
+            CT_DIM,
+            RT_DIM,
+            KT_DIM); // transpose in src_A not supported for quasar
         PROFILER_SYNC();
     }
     {
@@ -188,6 +190,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_pack.h"
 #include "llk_pack_matmul.h"
 #include "params.h"
@@ -204,6 +207,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
     const Operand& buffer_Res       = params.buffer_Res;
 #endif
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
+    ckernel::trisc::bfd_alloc<pack_res>();
     {
         ZONE_SCOPED("INIT")
         // PACK_ISOLATE and L1_CONGESTION pack without a math↔pack handshake.
@@ -226,9 +231,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_dst.f.y_dim             = FACE_R_DIM;
         bd_dst.f.z_dim             = num_faces;
 
-        _configure_buf_desc_table_(buf_desc_id_dst, bd_dst);
+        _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_matmul_init_(buf_desc_id_dst, RT_DIM, CT_DIM, 1 /*num_subblocks_c_dim*/); // Use destination buffer descriptor for packing output
+        _llk_pack_matmul_init_(
+            ckernel::trisc::bfd_current<pack_res>(), RT_DIM, CT_DIM, 1 /*num_subblocks_c_dim*/); // Use destination buffer descriptor for packing output
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
@@ -48,31 +48,27 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ZONE_SCOPED("INIT")
         set_ttsync_enables<TRACK_ALL>(ckernel::TRISC_ID);
         // src A input configuration
-        tdma_descriptor_t tdma_desc_src_a;
-        tdma_desc_src_a.buf_desc.f.l1_addr_16B  = L1_ADDRESS(buffer_A[0]);
-        tdma_desc_src_a.buf_desc.f.format       = static_cast<std::uint8_t>(formats.unpack_A_src);
-        tdma_desc_src_a.buf_desc.f.lmt_addr_16B = 0;
-        tdma_desc_src_a.buf_desc.f.x_dim        = FACE_C_DIM;  // Default face dimension is 16, tiny tiles not supported for quasar
-        tdma_desc_src_a.buf_desc.f.y_dim        = FACE_R_DIM;  // Default face dimension is 16, tiny tiles not supported for quasar
-        tdma_desc_src_a.buf_desc.f.z_dim        = num_faces_A; // Number of faces = 4, tiny tiles not supported for quasar
-        tdma_desc_src_a.buf_desc_id             = buf_desc_id_src_a;
-        tdma_desc_src_a.reg_data_format         = static_cast<DataFormat>(formats.unpack_A_dst);
+        buffer_descriptor_u bd_src_a = {0};
+        bd_src_a.f.l1_addr_16B       = L1_ADDRESS(buffer_A[0]);
+        bd_src_a.f.format            = static_cast<std::uint8_t>(formats.unpack_A_src);
+        bd_src_a.f.lmt_addr_16B      = 0;
+        bd_src_a.f.x_dim             = FACE_C_DIM;  // Default face dimension is 16, tiny tiles not supported for quasar
+        bd_src_a.f.y_dim             = FACE_R_DIM;  // Default face dimension is 16, tiny tiles not supported for quasar
+        bd_src_a.f.z_dim             = num_faces_A; // Number of faces = 4, tiny tiles not supported for quasar
 
         // src B input configuration
-        tdma_descriptor_t tdma_desc_src_b;
-        tdma_desc_src_b.buf_desc.f.l1_addr_16B  = L1_ADDRESS(buffer_B[0]);
-        tdma_desc_src_b.buf_desc.f.format       = static_cast<std::uint8_t>(formats.unpack_B_src);
-        tdma_desc_src_b.buf_desc.f.lmt_addr_16B = 0;
-        tdma_desc_src_b.buf_desc.f.x_dim        = FACE_C_DIM;  // Default face dimension is 16, tiny tiles not supported for quasar
-        tdma_desc_src_b.buf_desc.f.y_dim        = FACE_R_DIM;  // Default face dimension is 16, tiny tiles not supported for quasar
-        tdma_desc_src_b.buf_desc.f.z_dim        = num_faces_B; // Number of faces = 4, tiny tiles not supported for quasar
-        tdma_desc_src_b.buf_desc_id             = buf_desc_id_src_b;
-        tdma_desc_src_b.reg_data_format         = static_cast<DataFormat>(formats.unpack_B_dst);
+        buffer_descriptor_u bd_src_b = {0};
+        bd_src_b.f.l1_addr_16B       = L1_ADDRESS(buffer_B[0]);
+        bd_src_b.f.format            = static_cast<std::uint8_t>(formats.unpack_B_src);
+        bd_src_b.f.lmt_addr_16B      = 0;
+        bd_src_b.f.x_dim             = FACE_C_DIM;  // Default face dimension is 16, tiny tiles not supported for quasar
+        bd_src_b.f.y_dim             = FACE_R_DIM;  // Default face dimension is 16, tiny tiles not supported for quasar
+        bd_src_b.f.z_dim             = num_faces_B; // Number of faces = 4, tiny tiles not supported for quasar
 
-        _configure_buf_desc_table_(tdma_desc_src_a.buf_desc_id, tdma_desc_src_a.buf_desc);
-        _configure_buf_desc_table_(tdma_desc_src_b.buf_desc_id, tdma_desc_src_b.buf_desc);
-        _llk_unpack_hw_configure_<ckernel::p_unpacr::UNP_B>(tdma_desc_src_a.reg_data_format);
-        _llk_unpack_hw_configure_<ckernel::p_unpacr::UNP_A>(tdma_desc_src_b.reg_data_format);
+        _configure_buf_desc_table_(buf_desc_id_src_a, bd_src_a);
+        _configure_buf_desc_table_(buf_desc_id_src_b, bd_src_b);
+        _llk_unpack_hw_configure_<ckernel::p_unpacr::UNP_B>(static_cast<DataFormat>(formats.unpack_A_dst));
+        _llk_unpack_hw_configure_<ckernel::p_unpacr::UNP_A>(static_cast<DataFormat>(formats.unpack_B_dst));
 
         _llk_unpack_matmul_init_<UNPACK_TRANSPOSE_FACES>(buf_desc_id_src_a, buf_desc_id_src_b, CT_DIM, RT_DIM, KT_DIM); // transpose in src_A not supported for
                                                                                                                         // quasar
@@ -222,18 +218,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        tdma_descriptor_t tdma_desc_dst;
-        tdma_desc_dst.buf_desc.f.l1_addr_16B  = L1_ADDRESS(buffer_Res[0]);
-        tdma_desc_dst.buf_desc.f.lmt_addr_16B = 0;
-        tdma_desc_dst.buf_desc.f.format       = static_cast<std::uint8_t>(formats.pack_dst);
-        tdma_desc_dst.buf_desc.f.x_dim        = FACE_C_DIM;
-        tdma_desc_dst.buf_desc.f.y_dim        = FACE_R_DIM;
-        tdma_desc_dst.buf_desc.f.z_dim        = num_faces;
-        tdma_desc_dst.buf_desc_id             = buf_desc_id_dst;
-        tdma_desc_dst.reg_data_format         = static_cast<DataFormat>(formats.pack_src);
+        buffer_descriptor_u bd_dst = {0};
+        bd_dst.f.l1_addr_16B       = L1_ADDRESS(buffer_Res[0]);
+        bd_dst.f.lmt_addr_16B      = 0;
+        bd_dst.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
+        bd_dst.f.x_dim             = FACE_C_DIM;
+        bd_dst.f.y_dim             = FACE_R_DIM;
+        bd_dst.f.z_dim             = num_faces;
 
-        _configure_buf_desc_table_(tdma_desc_dst.buf_desc_id, tdma_desc_dst.buf_desc);
-        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc_dst.reg_data_format, ckernel::ReluConfig::none());
+        _configure_buf_desc_table_(buf_desc_id_dst, bd_dst);
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_matmul_init_(buf_desc_id_dst, RT_DIM, CT_DIM, 1 /*num_subblocks_c_dim*/); // Use destination buffer descriptor for packing output
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
@@ -44,8 +44,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // Full 32x32 tiles: 2x2 faces of 16x16 (tiny tiles not supported for quasar).
         // Matmul flips the unpacker roles: _llk_unpack_matmul_init_ arg0 drives UNPACR1/SrcB, arg1 drives
         // UNPACR0/SrcA -- so operand A is recorded under Unp1 and operand B under Unp0 (matches product).
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(
+            ckernel::tensor_shape_from_num_faces(FACE_R_DIM, params.num_faces_A), L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
+            ckernel::tensor_shape_from_num_faces(FACE_R_DIM, params.num_faces_B), L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
         _llk_unpack_hw_configure_<ckernel::p_unpacr::UNP_B>(static_cast<DataFormat>(formats.unpack_A_dst));
         _llk_unpack_hw_configure_<ckernel::p_unpacr::UNP_A>(static_cast<DataFormat>(formats.unpack_B_dst));
 
@@ -202,7 +204,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
 
         // Full 32x32 tiles: 2x2 faces of 16x16 (tiny tiles not supported for quasar).
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
+            ckernel::tensor_shape_from_num_faces(FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_matmul_init_(
             ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(),

--- a/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
@@ -185,7 +185,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
     const Operand& buffer_Res       = params.buffer_Res;
 #endif
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
     {
         ZONE_SCOPED("INIT")
         // PACK_ISOLATE and L1_CONGESTION pack without a math↔pack handshake.
@@ -201,10 +200,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
 
         // Full 32x32 tiles: 2x2 faces of 16x16 (tiny tiles not supported for quasar).
-        ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_matmul_init_(
-            ckernel::trisc::bfd_current<pack_res>(), RT_DIM, CT_DIM, 1 /*num_subblocks_c_dim*/); // Use destination buffer descriptor for packing output
+            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(),
+            RT_DIM,
+            CT_DIM,
+            1 /*num_subblocks_c_dim*/); // Use destination buffer descriptor for packing output
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
@@ -41,15 +41,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
         set_ttsync_enables<TRACK_ALL>(ckernel::TRISC_ID);
-        // Full 32x32 tiles: 2x2 faces of 16x16 (tiny tiles not supported for quasar). srcA before srcB.
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
+        // Full 32x32 tiles: 2x2 faces of 16x16 (tiny tiles not supported for quasar).
+        // Matmul flips the unpacker roles: _llk_unpack_matmul_init_ arg0 drives UNPACR1/SrcB, arg1 drives
+        // UNPACR0/SrcA -- so operand A is recorded under Unp1 and operand B under Unp0 (matches product).
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
         _llk_unpack_hw_configure_<ckernel::p_unpacr::UNP_B>(static_cast<DataFormat>(formats.unpack_A_dst));
         _llk_unpack_hw_configure_<ckernel::p_unpacr::UNP_A>(static_cast<DataFormat>(formats.unpack_B_dst));
 
         _llk_unpack_matmul_init_<UNPACK_TRANSPOSE_FACES>(
-            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(),
             ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(),
+            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(),
             CT_DIM,
             RT_DIM,
             KT_DIM); // transpose in src_A not supported for quasar

--- a/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/matmul_quasar_test.cpp
@@ -11,6 +11,7 @@
 #include "llk_memory_checks.h"
 #include "perf.h"
 #include "profiler.h"
+#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
 // Globals
@@ -33,8 +34,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t CT_DIM      = params.CT_DIM;
     const std::uint32_t RT_DIM      = params.RT_DIM;
     const std::uint32_t KT_DIM      = params.KT_DIM;
-    const std::uint32_t num_faces_A = params.num_faces_A;
-    const std::uint32_t num_faces_B = params.num_faces_B;
     const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
     const Operand& buffer_A         = params.buffer_A;
     const Operand& buffer_B         = params.buffer_B;
@@ -43,28 +42,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
         set_ttsync_enables<TRACK_ALL>(ckernel::TRISC_ID);
-        ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>(); // allocate srcA (order matters: A before B)
-        ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp1>(); // allocate srcB
-        // src A input configuration
-        buffer_descriptor_u bd_src_a = {0};
-        bd_src_a.f.l1_addr_16B       = L1_ADDRESS(buffer_A[0]);
-        bd_src_a.f.format            = static_cast<std::uint8_t>(formats.unpack_A_src);
-        bd_src_a.f.lmt_addr_16B      = 0;
-        bd_src_a.f.x_dim             = FACE_C_DIM;  // Default face dimension is 16, tiny tiles not supported for quasar
-        bd_src_a.f.y_dim             = FACE_R_DIM;  // Default face dimension is 16, tiny tiles not supported for quasar
-        bd_src_a.f.z_dim             = num_faces_A; // Number of faces = 4, tiny tiles not supported for quasar
-
-        // src B input configuration
-        buffer_descriptor_u bd_src_b = {0};
-        bd_src_b.f.l1_addr_16B       = L1_ADDRESS(buffer_B[0]);
-        bd_src_b.f.format            = static_cast<std::uint8_t>(formats.unpack_B_src);
-        bd_src_b.f.lmt_addr_16B      = 0;
-        bd_src_b.f.x_dim             = FACE_C_DIM;  // Default face dimension is 16, tiny tiles not supported for quasar
-        bd_src_b.f.y_dim             = FACE_R_DIM;  // Default face dimension is 16, tiny tiles not supported for quasar
-        bd_src_b.f.z_dim             = num_faces_B; // Number of faces = 4, tiny tiles not supported for quasar
-
-        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_src_a);
-        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(), bd_src_b);
+        // Full 32x32 tiles: 2x2 faces of 16x16 (tiny tiles not supported for quasar). srcA before srcB.
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
+            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(
+            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
         _llk_unpack_hw_configure_<ckernel::p_unpacr::UNP_B>(static_cast<DataFormat>(formats.unpack_A_dst));
         _llk_unpack_hw_configure_<ckernel::p_unpacr::UNP_A>(static_cast<DataFormat>(formats.unpack_B_dst));
 
@@ -203,12 +185,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #ifndef SPEED_OF_LIGHT
     const std::uint32_t CT_DIM      = params.CT_DIM;
     const std::uint32_t RT_DIM      = params.RT_DIM;
-    const std::uint32_t num_faces   = params.num_faces;
     const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
     const Operand& buffer_Res       = params.buffer_Res;
 #endif
     constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
-    ckernel::trisc::bfd_alloc<pack_res>();
     {
         ZONE_SCOPED("INIT")
         // PACK_ISOLATE and L1_CONGESTION pack without a math↔pack handshake.
@@ -223,15 +203,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        buffer_descriptor_u bd_dst = {0};
-        bd_dst.f.l1_addr_16B       = L1_ADDRESS(buffer_Res[0]);
-        bd_dst.f.lmt_addr_16B      = 0;
-        bd_dst.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
-        bd_dst.f.x_dim             = FACE_C_DIM;
-        bd_dst.f.y_dim             = FACE_R_DIM;
-        bd_dst.f.z_dim             = num_faces;
-
-        _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_dst);
+        // Full 32x32 tiles: 2x2 faces of 16x16 (tiny tiles not supported for quasar).
+        ckernel::trisc::bfd_alloc_and_program<pack_res>(
+            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_matmul_init_(
             ckernel::trisc::bfd_current<pack_res>(), RT_DIM, CT_DIM, 1 /*num_subblocks_c_dim*/); // Use destination buffer descriptor for packing output

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_l1_acc_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_l1_acc_quasar_test.cpp
@@ -72,7 +72,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
+            ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
             _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
@@ -302,7 +303,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
+            ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         const ckernel::ReluConfig relu_config = ckernel::ReluConfig::from_packed(RELU_CONFIG);
         _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_l1_acc_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_l1_acc_quasar_test.cpp
@@ -36,8 +36,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A                       = params.buffer_A;
 #endif
     constexpr std::uint32_t SELECTED_UNPACKER = unpack_to_dest ? p_unpacr::UNP_DEST : p_unpacr::UNP_A;
-    tdma_descriptor_t td_val;
-    const std::uint32_t buf_desc_id = 0;
+    const std::uint32_t buf_desc_id           = 0;
 
     {
         ZONE_SCOPED("INIT")
@@ -83,18 +82,15 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val.f.y_dim             = TEST_FACE_R_DIM;
         bd_val.f.z_dim             = num_faces;
 
-        td_val.buf_desc        = bd_val;
-        td_val.buf_desc_id     = buf_desc_id;
-        td_val.reg_data_format = static_cast<DataFormat>(formats.unpack_A_dst);
-
-        _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+        _configure_buf_desc_table_(buf_desc_id, bd_val);
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
-            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val.reg_data_format, td_val.reg_data_format);
+            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
+                static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_A_dst));
         }
         else
         {
-            _llk_unpack_configure_unary_<SELECTED_UNPACKER>(td_val.reg_data_format);
+            _llk_unpack_configure_unary_<SELECTED_UNPACKER>(static_cast<DataFormat>(formats.unpack_A_dst));
         }
 
         if constexpr (unpack_to_dest)
@@ -321,7 +317,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
 
         buffer_descriptor_u bd_val = {0};
-        tdma_descriptor_t tdma_desc;
 
         bd_val.f.l1_addr_16B = L1_ADDRESS(buffer_Res[0]);
         bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
@@ -329,12 +324,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val.f.y_dim       = TEST_FACE_R_DIM;
         bd_val.f.z_dim       = num_faces;
 
-        tdma_desc.buf_desc        = bd_val;
-        tdma_desc.buf_desc_id     = buf_desc_id;
-        tdma_desc.reg_data_format = static_cast<DataFormat>(formats.pack_src);
-
-        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc.reg_data_format, ckernel::ReluConfig::none());
+        _configure_buf_desc_table_(buf_desc_id, bd_val);
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         const ckernel::ReluConfig relu_config = ckernel::ReluConfig::from_packed(RELU_CONFIG);
         _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
         _llk_pack_relu_config_<p_pacr::PACK0, is_fp32_dest_acc_en>(relu_config);

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_l1_acc_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_l1_acc_quasar_test.cpp
@@ -29,15 +29,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #ifndef SPEED_OF_LIGHT
     const std::uint32_t LOOP_FACTOR               = params.LOOP_FACTOR;
     const std::uint32_t TILE_CNT                  = params.TILE_CNT;
-    const std::uint32_t TEST_FACE_C_DIM           = params.TEST_FACE_C_DIM;
-    const std::uint32_t TEST_FACE_R_DIM           = params.TEST_FACE_R_DIM;
-    const std::uint32_t num_faces                 = params.num_faces;
     const std::uint32_t OUTPUT_NUM_TILES_IN_BLOCK = params.OUTPUT_NUM_TILES_IN_BLOCK;
     const std::uint32_t OUTPUT_NUM_BLOCKS         = params.OUTPUT_NUM_BLOCKS;
     const Operand& buffer_A                       = params.buffer_A;
 #endif
     constexpr std::uint32_t SELECTED_UNPACKER = unpack_to_dest ? p_unpacr::UNP_DEST : p_unpacr::UNP_A;
-    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>(); // allocate srcA
 
     {
         ZONE_SCOPED("INIT")
@@ -76,14 +72,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        buffer_descriptor_u bd_val = {0};
-        bd_val.f.l1_addr_16B       = L1_ADDRESS(buffer_A[0]);
-        bd_val.f.format            = static_cast<std::uint8_t>(formats.unpack_A_src);
-        bd_val.f.x_dim             = TEST_FACE_C_DIM;
-        bd_val.f.y_dim             = TEST_FACE_R_DIM;
-        bd_val.f.z_dim             = num_faces;
-
-        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
+            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
             _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
@@ -286,9 +276,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 #ifndef SPEED_OF_LIGHT
     const std::uint32_t LOOP_FACTOR               = params.LOOP_FACTOR;
-    const std::uint32_t TEST_FACE_C_DIM           = params.TEST_FACE_C_DIM;
-    const std::uint32_t TEST_FACE_R_DIM           = params.TEST_FACE_R_DIM;
-    const std::uint32_t num_faces                 = params.num_faces;
     const int RELU_CONFIG                         = params.RELU_CONFIG;
     const std::uint32_t OUTPUT_NUM_BLOCKS         = params.OUTPUT_NUM_BLOCKS;
     const std::uint32_t OUTPUT_NUM_TILES_IN_BLOCK = params.OUTPUT_NUM_TILES_IN_BLOCK;
@@ -296,7 +283,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
-    ckernel::trisc::bfd_alloc<pack_res>();
 
     {
         ZONE_SCOPED("INIT")
@@ -319,15 +305,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        buffer_descriptor_u bd_val = {0};
-
-        bd_val.f.l1_addr_16B = L1_ADDRESS(buffer_Res[0]);
-        bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
-        bd_val.f.x_dim       = TEST_FACE_C_DIM;
-        bd_val.f.y_dim       = TEST_FACE_R_DIM;
-        bd_val.f.z_dim       = num_faces;
-
-        _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
+        ckernel::trisc::bfd_alloc_and_program<pack_res>(
+            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         const ckernel::ReluConfig relu_config = ckernel::ReluConfig::from_packed(RELU_CONFIG);
         _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_l1_acc_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_l1_acc_quasar_test.cpp
@@ -15,6 +15,7 @@
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_math_common.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_unary_operand.h"
@@ -36,7 +37,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A                       = params.buffer_A;
 #endif
     constexpr std::uint32_t SELECTED_UNPACKER = unpack_to_dest ? p_unpacr::UNP_DEST : p_unpacr::UNP_A;
-    const std::uint32_t buf_desc_id           = 0;
+    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>(); // allocate srcA
 
     {
         ZONE_SCOPED("INIT")
@@ -82,7 +83,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val.f.y_dim             = TEST_FACE_R_DIM;
         bd_val.f.z_dim             = num_faces;
 
-        _configure_buf_desc_table_(buf_desc_id, bd_val);
+        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val);
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
             _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
@@ -99,12 +100,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
             // ISSUE tt-llk #988: For unpack to dest cannot init the unpacker with 1 tile per unpack, because it will
             // keep writing to dest_idx=0.
             _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(
-                buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, tiles_in_block /*num_tiles_per_unpack*/);
+                ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, tiles_in_block /*num_tiles_per_unpack*/);
         }
         else
         {
             _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(
-                buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_unpack*/);
+                ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_unpack*/);
         }
         PROFILER_SYNC();
     }
@@ -273,6 +274,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -293,7 +295,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_Res                     = params.buffer_Res;
 #endif
 
-    std::uint32_t const buf_desc_id = 8;
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
+    ckernel::trisc::bfd_alloc<pack_res>();
 
     {
         ZONE_SCOPED("INIT")
@@ -324,10 +327,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val.f.y_dim       = TEST_FACE_R_DIM;
         bd_val.f.z_dim       = num_faces;
 
-        _configure_buf_desc_table_(buf_desc_id, bd_val);
+        _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         const ckernel::ReluConfig relu_config = ckernel::ReluConfig::from_packed(RELU_CONFIG);
-        _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
+        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
         _llk_pack_relu_config_<p_pacr::PACK0, is_fp32_dest_acc_en>(relu_config);
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_l1_acc_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_l1_acc_quasar_test.cpp
@@ -72,8 +72,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
-            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
             _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
@@ -305,8 +304,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        ckernel::trisc::bfd_alloc_and_program<pack_res>(
-            tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         const ckernel::ReluConfig relu_config = ckernel::ReluConfig::from_packed(RELU_CONFIG);
         _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_l1_acc_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_l1_acc_quasar_test.cpp
@@ -281,8 +281,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_Res                     = params.buffer_Res;
 #endif
 
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
-
     {
         ZONE_SCOPED("INIT")
         // PACK_ISOLATE and L1_CONGESTION pack without a math↔pack handshake.
@@ -304,10 +302,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         const ckernel::ReluConfig relu_config = ckernel::ReluConfig::from_packed(RELU_CONFIG);
-        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
         _llk_pack_relu_config_<p_pacr::PACK0, is_fp32_dest_acc_en>(relu_config);
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_quasar_test.cpp
@@ -74,17 +74,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
 
-        tdma_descriptor_t td_val =
-            ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src, buf_desc_id, formats.unpack_A_dst);
+        program_buf_desc(buf_desc_id, tensor_shape_A, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
 
-        _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
-            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val.reg_data_format, td_val.reg_data_format);
+            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
+                static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_A_dst));
         }
         else
         {
-            _llk_unpack_configure_unary_<SELECTED_UNPACKER>(td_val.reg_data_format);
+            _llk_unpack_configure_unary_<SELECTED_UNPACKER>(static_cast<DataFormat>(formats.unpack_A_dst));
         }
         _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, tensor_shape_A, num_tiles_per_unpack);
         PROFILER_SYNC();
@@ -270,11 +269,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
 
-        tdma_descriptor_t tdma_desc =
-            ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
-
-        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc.reg_data_format, ckernel::ReluConfig::none());
+        program_buf_desc(buf_desc_id, tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         const ckernel::ReluConfig relu_config = ckernel::ReluConfig::from_packed(RELU_CONFIG);
         _llk_pack_init_(buf_desc_id, tensor_shape_A, num_tiles_per_pack);
         _llk_pack_relu_config_<p_pacr::PACK0, is_fp32_dest_acc_en>(relu_config);

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_quasar_test.cpp
@@ -16,6 +16,7 @@
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_math_common.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_unary_operand.h"
@@ -32,7 +33,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A         = params.buffer_A;
 #endif
     constexpr std::uint32_t SELECTED_UNPACKER = unpack_to_dest ? p_unpacr::UNP_DEST : p_unpacr::UNP_A;
-    const std::uint32_t buf_desc_id           = 0;
     const std::uint32_t num_tiles_per_unpack  = TILE_CNT;
 
     {
@@ -74,7 +74,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
 
-        program_buf_desc(buf_desc_id, tensor_shape_A, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(tensor_shape_A, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
 
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
@@ -85,7 +85,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             _llk_unpack_configure_unary_<SELECTED_UNPACKER>(static_cast<DataFormat>(formats.unpack_A_dst));
         }
-        _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, tensor_shape_A, num_tiles_per_unpack);
+        _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(
+            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), tensor_shape_A, num_tiles_per_unpack);
         PROFILER_SYNC();
     }
     {
@@ -228,12 +229,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
@@ -243,7 +246,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const int RELU_CONFIG           = params.RELU_CONFIG;
     const Operand& buffer_Res       = params.buffer_Res;
 #endif
-    std::uint32_t const buf_desc_id        = 8;
     const std::uint32_t num_tiles_per_pack = TILE_CNT;
 
     {
@@ -269,10 +271,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
 
-        program_buf_desc(buf_desc_id, tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         const ckernel::ReluConfig relu_config = ckernel::ReluConfig::from_packed(RELU_CONFIG);
-        _llk_pack_init_(buf_desc_id, tensor_shape_A, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), tensor_shape_A, num_tiles_per_pack);
         _llk_pack_relu_config_<p_pacr::PACK0, is_fp32_dest_acc_en>(relu_config);
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_quasar_test.cpp
@@ -236,7 +236,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
@@ -271,10 +270,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
 
-        ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         const ckernel::ReluConfig relu_config = ckernel::ReluConfig::from_packed(RELU_CONFIG);
-        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), tensor_shape_A, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape_A, num_tiles_per_pack);
         _llk_pack_relu_config_<p_pacr::PACK0, is_fp32_dest_acc_en>(relu_config);
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_untilize_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_untilize_quasar_test.cpp
@@ -33,7 +33,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_B         = params.buffer_B;
 #endif
     constexpr std::uint32_t SELECTED_UNPACKER = unpack_to_dest ? p_unpacr::UNP_DEST : p_unpacr::UNP_A;
-    tdma_descriptor_t td_val;
     const std::uint32_t buf_desc_id           = 0;
     const std::uint32_t num_tiles_per_unpack  = TILE_CNT;
     const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
@@ -90,12 +89,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
             l1_addr_16B = L1_ADDRESS(buffer_A[0]);
         }
 
-        td_val = ckernel::trisc::construct_tdma_desc(tensor_shape_A, l1_addr_16B, formats.unpack_A_src, buf_desc_id, formats.unpack_A_dst);
+        program_buf_desc(buf_desc_id, tensor_shape_A, l1_addr_16B, formats.unpack_A_src);
 
-        _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
         if constexpr (unpack_to_dest)
         {
-            _llk_unpack_configure_unary_<SELECTED_UNPACKER>(td_val.reg_data_format);
+            _llk_unpack_configure_unary_<SELECTED_UNPACKER>(static_cast<DataFormat>(formats.unpack_A_dst));
             // Unpack one tile row at a time for double-buffering with packer (SyncHalf).
             // Writing all tiles at once would cause _llk_pack_dest_dvalid_section_done_'s
             // ZEROACC to wipe subsequent tile rows after packing the first one.
@@ -105,11 +103,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             if constexpr (is_fp32_dest_acc_en)
             {
-                _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val.reg_data_format, td_val.reg_data_format);
+                _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
+                    static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_A_dst));
             }
             else
             {
-                _llk_unpack_configure_unary_<SELECTED_UNPACKER>(td_val.reg_data_format);
+                _llk_unpack_configure_unary_<SELECTED_UNPACKER>(static_cast<DataFormat>(formats.unpack_A_dst));
             }
             _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, tensor_shape_A, num_tiles_per_unpack);
         }
@@ -309,21 +308,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        tdma_descriptor_t tdma_desc;
-
         if (tensor_shape.face_r_dim < ckernel::pack::PACR_STRIDE_OFFSET_ROWS)
         {
             // PACR_STRIDE quirk: tiny-tiles index L1 rows as tiles, so the BD is built with y_dim = 1.
-            tdma_desc = ckernel::trisc::construct_tdma_desc<ckernel::trisc::L1AccessMode::Strided>(
-                tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
+            program_buf_desc<ckernel::trisc::L1AccessMode::Strided>(buf_desc_id, tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         }
         else
         {
-            tdma_desc = ckernel::trisc::construct_tdma_desc(tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
+            program_buf_desc(buf_desc_id, tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         }
 
-        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc.reg_data_format, ckernel::ReluConfig::none());
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         if (tensor_shape.total_num_faces() == NUM_FACES)
         {
             _llk_pack_untilize_init_<FULL_CT_DIM, BLOCK_CT_DIM>(buf_desc_id, tensor_shape);

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_untilize_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_untilize_quasar_test.cpp
@@ -280,7 +280,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
@@ -314,22 +313,23 @@ void run_kernel(RUNTIME_PARAMETERS params)
         if (tensor_shape.face_r_dim < ckernel::pack::PACR_STRIDE_OFFSET_ROWS)
         {
             // PACR_STRIDE quirk: tiny-tiles index L1 rows as tiles, so the BD is built with y_dim = 1.
-            ckernel::trisc::bfd_alloc_and_program<pack_res, ckernel::trisc::L1AccessMode::Strided>(tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+            ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0, ckernel::trisc::L1AccessMode::Strided>(
+                tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         }
         else
         {
-            ckernel::trisc::bfd_alloc_and_program<pack_res, ckernel::trisc::L1AccessMode::Continuous>(
+            ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0, ckernel::trisc::L1AccessMode::Continuous>(
                 tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         }
 
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         if (tensor_shape.total_num_faces() == NUM_FACES)
         {
-            _llk_pack_untilize_init_<FULL_CT_DIM, BLOCK_CT_DIM>(ckernel::trisc::bfd_current<pack_res>(), tensor_shape);
+            _llk_pack_untilize_init_<FULL_CT_DIM, BLOCK_CT_DIM>(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape);
         }
         else
         {
-            _llk_pack_untilize_strided_init_<FULL_CT_DIM, BLOCK_CT_DIM>(ckernel::trisc::bfd_current<pack_res>(), tensor_shape);
+            _llk_pack_untilize_strided_init_<FULL_CT_DIM, BLOCK_CT_DIM>(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape);
         }
         PROFILER_SYNC();
     }
@@ -358,7 +358,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     else
                     {
                         _llk_pack_untilize_strided_<FULL_CT_DIM>(
-                            ckernel::trisc::bfd_current<pack_res>(), tensor_shape, y * y_stride_external, 0 /*src_tile_idx*/);
+                            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape, y * y_stride_external, 0 /*src_tile_idx*/);
                     }
                 }
             }
@@ -376,7 +376,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     else
                     {
                         _llk_pack_untilize_strided_<FULL_CT_DIM>(
-                            ckernel::trisc::bfd_current<pack_res>(), tensor_shape, y * y_stride_external, 0 /*src_tile_idx*/);
+                            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape, y * y_stride_external, 0 /*src_tile_idx*/);
                     }
                     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
                 }

--- a/tt_metal/tt-llk/tests/sources/quasar/pack_untilize_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/pack_untilize_quasar_test.cpp
@@ -16,6 +16,7 @@
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_math_common.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_unary_operand.h"
@@ -33,7 +34,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_B         = params.buffer_B;
 #endif
     constexpr std::uint32_t SELECTED_UNPACKER = unpack_to_dest ? p_unpacr::UNP_DEST : p_unpacr::UNP_A;
-    const std::uint32_t buf_desc_id           = 0;
     const std::uint32_t num_tiles_per_unpack  = TILE_CNT;
     const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
 
@@ -89,7 +89,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             l1_addr_16B = L1_ADDRESS(buffer_A[0]);
         }
 
-        program_buf_desc(buf_desc_id, tensor_shape_A, l1_addr_16B, formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(tensor_shape_A, l1_addr_16B, formats.unpack_A_src);
 
         if constexpr (unpack_to_dest)
         {
@@ -97,7 +97,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             // Unpack one tile row at a time for double-buffering with packer (SyncHalf).
             // Writing all tiles at once would cause _llk_pack_dest_dvalid_section_done_'s
             // ZEROACC to wipe subsequent tile rows after packing the first one.
-            _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, tensor_shape_A, BLOCK_CT_DIM);
+            _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(
+                ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), tensor_shape_A, BLOCK_CT_DIM);
         }
         else
         {
@@ -110,7 +111,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             {
                 _llk_unpack_configure_unary_<SELECTED_UNPACKER>(static_cast<DataFormat>(formats.unpack_A_dst));
             }
-            _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, tensor_shape_A, num_tiles_per_unpack);
+            _llk_unpack_unary_operand_init_<SELECTED_UNPACKER, false /*transpose*/, is_fp32_dest_acc_en>(
+                ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), tensor_shape_A, num_tiles_per_unpack);
         }
         PROFILER_SYNC();
     }
@@ -271,12 +273,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #ifdef LLK_TRISC_PACK
 
 #include "cpack_common.h"
+#include "llk_bfd_alloc.h"
 #include "llk_pack_common.h"
 #include "llk_pack_untilize.h"
 #include "params.h"
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
@@ -285,7 +289,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_Res       = params.buffer_Res;
 #endif
     const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
-    std::uint32_t const buf_desc_id         = 31;
     {
         ZONE_SCOPED("INIT")
         // Match WH/BH PACK_ISOLATE and L1_CONGESTION: no math↔pack handshake;
@@ -311,21 +314,22 @@ void run_kernel(RUNTIME_PARAMETERS params)
         if (tensor_shape.face_r_dim < ckernel::pack::PACR_STRIDE_OFFSET_ROWS)
         {
             // PACR_STRIDE quirk: tiny-tiles index L1 rows as tiles, so the BD is built with y_dim = 1.
-            program_buf_desc<ckernel::trisc::L1AccessMode::Strided>(buf_desc_id, tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+            ckernel::trisc::bfd_alloc_and_program<pack_res, ckernel::trisc::L1AccessMode::Strided>(tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         }
         else
         {
-            program_buf_desc(buf_desc_id, tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+            ckernel::trisc::bfd_alloc_and_program<pack_res, ckernel::trisc::L1AccessMode::Continuous>(
+                tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         }
 
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         if (tensor_shape.total_num_faces() == NUM_FACES)
         {
-            _llk_pack_untilize_init_<FULL_CT_DIM, BLOCK_CT_DIM>(buf_desc_id, tensor_shape);
+            _llk_pack_untilize_init_<FULL_CT_DIM, BLOCK_CT_DIM>(ckernel::trisc::bfd_current<pack_res>(), tensor_shape);
         }
         else
         {
-            _llk_pack_untilize_strided_init_<FULL_CT_DIM, BLOCK_CT_DIM>(buf_desc_id, tensor_shape);
+            _llk_pack_untilize_strided_init_<FULL_CT_DIM, BLOCK_CT_DIM>(ckernel::trisc::bfd_current<pack_res>(), tensor_shape);
         }
         PROFILER_SYNC();
     }
@@ -353,7 +357,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     }
                     else
                     {
-                        _llk_pack_untilize_strided_<FULL_CT_DIM>(buf_desc_id, tensor_shape, y * y_stride_external, 0 /*src_tile_idx*/);
+                        _llk_pack_untilize_strided_<FULL_CT_DIM>(
+                            ckernel::trisc::bfd_current<pack_res>(), tensor_shape, y * y_stride_external, 0 /*src_tile_idx*/);
                     }
                 }
             }
@@ -370,7 +375,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     }
                     else
                     {
-                        _llk_pack_untilize_strided_<FULL_CT_DIM>(buf_desc_id, tensor_shape, y * y_stride_external, 0 /*src_tile_idx*/);
+                        _llk_pack_untilize_strided_<FULL_CT_DIM>(
+                            ckernel::trisc::bfd_current<pack_res>(), tensor_shape, y * y_stride_external, 0 /*src_tile_idx*/);
                     }
                     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
                 }

--- a/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
@@ -204,7 +204,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
@@ -229,9 +228,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), tensor_shape_A, 1 /*num_tiles_per_pack*/);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape_A, 1 /*num_tiles_per_pack*/);
         _llk_pack_reduce_mask_config_<REDUCE_DIM>(tensor_shape_A);
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
@@ -33,20 +33,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A         = params.buffer_A;
     const Operand& buffer_B         = params.buffer_B;
 #endif
-    tdma_descriptor_t td_val_A;
-    tdma_descriptor_t td_val_B;
     const std::uint32_t buf_desc_id_a         = 0;
     const std::uint32_t buf_desc_id_b         = 1;
     const ckernel::TensorShape tensor_shape_A = tensor_shape_from_params(params);
 
     {
         ZONE_SCOPED("INIT")
-        td_val_A = ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src, buf_desc_id_a, formats.unpack_A_dst);
-        td_val_B = ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(buffer_B[0]), formats.unpack_B_src, buf_desc_id_b, formats.unpack_B_dst);
+        program_buf_desc(buf_desc_id_a, tensor_shape_A, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
+        program_buf_desc(buf_desc_id_b, tensor_shape_A, L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
 
-        _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
-        _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
-        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A.reg_data_format, td_val_B.reg_data_format);
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
+            static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
         _llk_unpack_reduce_init_<POOL_TYPE, REDUCE_DIM>(buf_desc_id_a, buf_desc_id_b, tensor_shape_A, 1 /*num_tiles_per_unpack*/);
         PROFILER_SYNC();
     }
@@ -228,11 +225,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        tdma_descriptor_t tdma_desc =
-            ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
-
-        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc.reg_data_format, ckernel::ReluConfig::none());
+        program_buf_desc(buf_desc_id, tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(buf_desc_id, tensor_shape_A, 1 /*num_tiles_per_pack*/);
         _llk_pack_reduce_mask_config_<REDUCE_DIM>(tensor_shape_A);
         PROFILER_SYNC();

--- a/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/reduce_quasar_test.cpp
@@ -17,6 +17,7 @@
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_reduce.h"
 #include "params.h"
@@ -33,18 +34,20 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A         = params.buffer_A;
     const Operand& buffer_B         = params.buffer_B;
 #endif
-    const std::uint32_t buf_desc_id_a         = 0;
-    const std::uint32_t buf_desc_id_b         = 1;
     const ckernel::TensorShape tensor_shape_A = tensor_shape_from_params(params);
 
     {
         ZONE_SCOPED("INIT")
-        program_buf_desc(buf_desc_id_a, tensor_shape_A, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
-        program_buf_desc(buf_desc_id_b, tensor_shape_A, L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(tensor_shape_A, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(tensor_shape_A, L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
 
         _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
             static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
-        _llk_unpack_reduce_init_<POOL_TYPE, REDUCE_DIM>(buf_desc_id_a, buf_desc_id_b, tensor_shape_A, 1 /*num_tiles_per_unpack*/);
+        _llk_unpack_reduce_init_<POOL_TYPE, REDUCE_DIM>(
+            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(),
+            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(),
+            tensor_shape_A,
+            1 /*num_tiles_per_unpack*/);
         PROFILER_SYNC();
     }
     {
@@ -194,12 +197,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
@@ -208,7 +213,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t TILE_CNT    = params.TILE_CNT;
     const Operand& buffer_Res       = params.buffer_Res;
 #endif
-    const std::uint32_t buf_desc_id           = 8;
     const ckernel::TensorShape tensor_shape_A = tensor_shape_from_params(params);
 
     {
@@ -225,9 +229,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        program_buf_desc(buf_desc_id, tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(buf_desc_id, tensor_shape_A, 1 /*num_tiles_per_pack*/);
+        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), tensor_shape_A, 1 /*num_tiles_per_pack*/);
         _llk_pack_reduce_mask_config_<REDUCE_DIM>(tensor_shape_A);
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/semaphore_sync_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/semaphore_sync_quasar_test.cpp
@@ -14,6 +14,7 @@
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_reduce.h"
 #include "params.h"
@@ -23,8 +24,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t buf_desc_id_a = 0;
-    const std::uint32_t buf_desc_id_b = 1;
+    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>(); // allocate srcA (order matters: A before B)
+    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp1>(); // allocate srcB
 
     buffer_descriptor_u bd_val_A = {0};
     buffer_descriptor_u bd_val_B = {0};
@@ -41,12 +42,15 @@ void run_kernel(RUNTIME_PARAMETERS params)
     bd_val_B.f.y_dim       = params.TEST_FACE_R_DIM;
     bd_val_B.f.z_dim       = params.num_faces;
 
-    _configure_buf_desc_table_(buf_desc_id_a, bd_val_A);
-    _configure_buf_desc_table_(buf_desc_id_b, bd_val_B);
+    _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val_A);
+    _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(), bd_val_B);
     _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
         static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
     _llk_unpack_reduce_init_<POOL_TYPE, REDUCE_DIM>(
-        buf_desc_id_a, buf_desc_id_b, ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_unpack*/); // tiny-tiles not yet supported with reduce
+        ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(),
+        ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(),
+        ckernel::DEFAULT_TENSOR_SHAPE,
+        1 /*num_tiles_per_unpack*/); // tiny-tiles not yet supported with reduce
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
         _llk_unpack_reduce_(i, 0, ckernel::DEFAULT_TENSOR_SHAPE);
@@ -86,6 +90,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -95,7 +100,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    std::uint32_t const buf_desc_id = 8;
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
+    ckernel::trisc::bfd_alloc<pack_res>();
 
     buffer_descriptor_u bd_val = {0};
 
@@ -105,9 +111,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
     bd_val.f.z_dim       = params.num_faces;
 
-    _configure_buf_desc_table_(buf_desc_id, bd_val);
+    _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-    _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
+    _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
     _llk_pack_reduce_mask_config_<REDUCE_DIM>(ckernel::DEFAULT_TENSOR_SHAPE);
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/semaphore_sync_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/semaphore_sync_quasar_test.cpp
@@ -87,11 +87,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
-    ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
+    ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
+        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
 
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-    _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
+    _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
     _llk_pack_reduce_mask_config_<REDUCE_DIM>(ckernel::DEFAULT_TENSOR_SHAPE);
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/semaphore_sync_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/semaphore_sync_quasar_test.cpp
@@ -26,10 +26,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
     // allocate srcA (order matters: A before B)
     ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
-        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
+        ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
     // allocate srcB
     ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(
-        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_B[0]), formats.unpack_B_src);
+        ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(params.buffer_B[0]), formats.unpack_B_src);
 
     _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
         static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
@@ -88,7 +88,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
     ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
-        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
+        ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
 
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
     _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);

--- a/tt_metal/tt-llk/tests/sources/quasar/semaphore_sync_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/semaphore_sync_quasar_test.cpp
@@ -9,7 +9,6 @@
 #include "ckernel.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
-#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 #include "tensor_shape.h"
 
@@ -27,10 +26,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
     // allocate srcA (order matters: A before B)
     ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
-        tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
+        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
     // allocate srcB
     ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(
-        tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(params.buffer_B[0]), formats.unpack_B_src);
+        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_B[0]), formats.unpack_B_src);
 
     _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
         static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
@@ -89,8 +88,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
     constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
-    ckernel::trisc::bfd_alloc_and_program<pack_res>(
-        tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
+    ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
 
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
     _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);

--- a/tt_metal/tt-llk/tests/sources/quasar/semaphore_sync_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/semaphore_sync_quasar_test.cpp
@@ -23,8 +23,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    tdma_descriptor_t td_val_A;
-    tdma_descriptor_t td_val_B;
     const std::uint32_t buf_desc_id_a = 0;
     const std::uint32_t buf_desc_id_b = 1;
 
@@ -37,23 +35,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
     bd_val_A.f.y_dim       = params.TEST_FACE_R_DIM;
     bd_val_A.f.z_dim       = params.num_faces;
 
-    td_val_A.buf_desc        = bd_val_A;
-    td_val_A.buf_desc_id     = buf_desc_id_a;
-    td_val_A.reg_data_format = static_cast<DataFormat>(formats.unpack_A_dst);
-
     bd_val_B.f.l1_addr_16B = L1_ADDRESS(params.buffer_B[0]);
     bd_val_B.f.format      = static_cast<std::uint8_t>(formats.unpack_B_src);
     bd_val_B.f.x_dim       = params.TEST_FACE_C_DIM;
     bd_val_B.f.y_dim       = params.TEST_FACE_R_DIM;
     bd_val_B.f.z_dim       = params.num_faces;
 
-    td_val_B.buf_desc        = bd_val_B;
-    td_val_B.buf_desc_id     = buf_desc_id_b;
-    td_val_B.reg_data_format = static_cast<DataFormat>(formats.unpack_B_dst);
-
-    _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
-    _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
-    _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A.reg_data_format, td_val_B.reg_data_format);
+    _configure_buf_desc_table_(buf_desc_id_a, bd_val_A);
+    _configure_buf_desc_table_(buf_desc_id_b, bd_val_B);
+    _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
+        static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
     _llk_unpack_reduce_init_<POOL_TYPE, REDUCE_DIM>(
         buf_desc_id_a, buf_desc_id_b, ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_unpack*/); // tiny-tiles not yet supported with reduce
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
@@ -107,7 +98,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     std::uint32_t const buf_desc_id = 8;
 
     buffer_descriptor_u bd_val = {0};
-    tdma_descriptor_t tdma_desc;
 
     bd_val.f.l1_addr_16B = L1_ADDRESS(params.buffer_Res[0]);
     bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
@@ -115,12 +105,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
     bd_val.f.z_dim       = params.num_faces;
 
-    tdma_desc.buf_desc        = bd_val;
-    tdma_desc.buf_desc_id     = buf_desc_id;
-    tdma_desc.reg_data_format = static_cast<DataFormat>(formats.pack_src);
-
-    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc.reg_data_format, ckernel::ReluConfig::none());
+    _configure_buf_desc_table_(buf_desc_id, bd_val);
+    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
     _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
     _llk_pack_reduce_mask_config_<REDUCE_DIM>(ckernel::DEFAULT_TENSOR_SHAPE);
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)

--- a/tt_metal/tt-llk/tests/sources/quasar/semaphore_sync_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/semaphore_sync_quasar_test.cpp
@@ -9,6 +9,7 @@
 #include "ckernel.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
+#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 #include "tensor_shape.h"
 
@@ -24,26 +25,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>(); // allocate srcA (order matters: A before B)
-    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp1>(); // allocate srcB
+    // allocate srcA (order matters: A before B)
+    ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
+        tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
+    // allocate srcB
+    ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(
+        tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(params.buffer_B[0]), formats.unpack_B_src);
 
-    buffer_descriptor_u bd_val_A = {0};
-    buffer_descriptor_u bd_val_B = {0};
-
-    bd_val_A.f.l1_addr_16B = L1_ADDRESS(params.buffer_A[0]);
-    bd_val_A.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
-    bd_val_A.f.x_dim       = params.TEST_FACE_C_DIM;
-    bd_val_A.f.y_dim       = params.TEST_FACE_R_DIM;
-    bd_val_A.f.z_dim       = params.num_faces;
-
-    bd_val_B.f.l1_addr_16B = L1_ADDRESS(params.buffer_B[0]);
-    bd_val_B.f.format      = static_cast<std::uint8_t>(formats.unpack_B_src);
-    bd_val_B.f.x_dim       = params.TEST_FACE_C_DIM;
-    bd_val_B.f.y_dim       = params.TEST_FACE_R_DIM;
-    bd_val_B.f.z_dim       = params.num_faces;
-
-    _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val_A);
-    _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(), bd_val_B);
     _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
         static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
     _llk_unpack_reduce_init_<POOL_TYPE, REDUCE_DIM>(
@@ -101,17 +89,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
     constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
-    ckernel::trisc::bfd_alloc<pack_res>();
+    ckernel::trisc::bfd_alloc_and_program<pack_res>(
+        tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
 
-    buffer_descriptor_u bd_val = {0};
-
-    bd_val.f.l1_addr_16B = L1_ADDRESS(params.buffer_Res[0]);
-    bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
-    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim       = params.num_faces;
-
-    _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
     _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, 1 /*num_tiles_per_pack*/);
     _llk_pack_reduce_mask_config_<REDUCE_DIM>(ckernel::DEFAULT_TENSOR_SHAPE);

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_add_parallel_matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_add_parallel_matmul_quasar_test.cpp
@@ -34,29 +34,26 @@ void run_kernel(RUNTIME_PARAMETERS params)
     set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
     set_ttsync_enables<TRACK_ALL>(ckernel::TRISC_ID);
 
-    tdma_descriptor_t tdma_desc_src_a;
-    tdma_desc_src_a.buf_desc.f.l1_addr_16B  = L1_ADDRESS(params.buffer_A[0]);
-    tdma_desc_src_a.buf_desc.f.format       = static_cast<std::uint8_t>(formats.unpack_A_src);
-    tdma_desc_src_a.buf_desc.f.lmt_addr_16B = 0;
-    tdma_desc_src_a.buf_desc.f.x_dim        = FACE_C_DIM;
-    tdma_desc_src_a.buf_desc.f.y_dim        = FACE_R_DIM;
-    tdma_desc_src_a.buf_desc.f.z_dim        = params.num_faces_A;
-    tdma_desc_src_a.buf_desc_id             = buf_desc_id_src_a;
-    tdma_desc_src_a.reg_data_format         = static_cast<DataFormat>(formats.unpack_A_dst);
+    buffer_descriptor_u bd_src_a = {0};
+    bd_src_a.f.l1_addr_16B       = L1_ADDRESS(params.buffer_A[0]);
+    bd_src_a.f.format            = static_cast<std::uint8_t>(formats.unpack_A_src);
+    bd_src_a.f.lmt_addr_16B      = 0;
+    bd_src_a.f.x_dim             = FACE_C_DIM;
+    bd_src_a.f.y_dim             = FACE_R_DIM;
+    bd_src_a.f.z_dim             = params.num_faces_A;
 
-    tdma_descriptor_t tdma_desc_src_b;
-    tdma_desc_src_b.buf_desc.f.l1_addr_16B  = L1_ADDRESS(params.buffer_B[0]);
-    tdma_desc_src_b.buf_desc.f.format       = static_cast<std::uint8_t>(formats.unpack_B_src);
-    tdma_desc_src_b.buf_desc.f.lmt_addr_16B = 0;
-    tdma_desc_src_b.buf_desc.f.x_dim        = FACE_C_DIM;
-    tdma_desc_src_b.buf_desc.f.y_dim        = FACE_R_DIM;
-    tdma_desc_src_b.buf_desc.f.z_dim        = params.num_faces_B;
-    tdma_desc_src_b.buf_desc_id             = buf_desc_id_src_b;
-    tdma_desc_src_b.reg_data_format         = static_cast<DataFormat>(formats.unpack_B_dst);
+    buffer_descriptor_u bd_src_b = {0};
+    bd_src_b.f.l1_addr_16B       = L1_ADDRESS(params.buffer_B[0]);
+    bd_src_b.f.format            = static_cast<std::uint8_t>(formats.unpack_B_src);
+    bd_src_b.f.lmt_addr_16B      = 0;
+    bd_src_b.f.x_dim             = FACE_C_DIM;
+    bd_src_b.f.y_dim             = FACE_R_DIM;
+    bd_src_b.f.z_dim             = params.num_faces_B;
 
-    _configure_buf_desc_table_(tdma_desc_src_a.buf_desc_id, tdma_desc_src_a.buf_desc);
-    _configure_buf_desc_table_(tdma_desc_src_b.buf_desc_id, tdma_desc_src_b.buf_desc);
-    _llk_unpack_configure_binary_<p_unpacr::UNP_B, p_unpacr::UNP_A>(tdma_desc_src_a.reg_data_format, tdma_desc_src_b.reg_data_format);
+    _configure_buf_desc_table_(buf_desc_id_src_a, bd_src_a);
+    _configure_buf_desc_table_(buf_desc_id_src_b, bd_src_b);
+    _llk_unpack_configure_binary_<p_unpacr::UNP_B, p_unpacr::UNP_A>(
+        static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
 
     _llk_unpack_matmul_init_<UNPACK_TRANSPOSE_FACES>(buf_desc_id_src_a, buf_desc_id_src_b, params.CT_DIM, params.RT_DIM, params.KT_DIM);
 
@@ -126,46 +123,34 @@ void run_kernel(RUNTIME_PARAMETERS params)
     constexpr std::uint32_t buf_desc_id_pack     = 8;
 
     buffer_descriptor_u bd_unpack_0 = {0};
-    tdma_descriptor_t td_unpack_0;
     buffer_descriptor_u bd_unpack_1 = {0};
-    tdma_descriptor_t td_unpack_1;
-    buffer_descriptor_u bd_pack = {0};
-    tdma_descriptor_t td_pack;
+    buffer_descriptor_u bd_pack     = {0};
 
-    bd_unpack_0.f.l1_addr_16B   = L1_ADDRESS(params.buffer_S[0]);
-    bd_unpack_0.f.format        = static_cast<std::uint8_t>(formats.unpack_S_src);
-    bd_unpack_0.f.x_dim         = PARAM_SRCS_XDIM;
-    bd_unpack_0.f.y_dim         = PARAM_SRCS_YDIM;
-    bd_unpack_0.f.z_dim         = PARAM_SRCS_ZDIM;
-    td_unpack_0.buf_desc        = bd_unpack_0;
-    td_unpack_0.buf_desc_id     = buf_desc_id_unpack_0;
-    td_unpack_0.reg_data_format = static_cast<DataFormat>(formats.unpack_S_dst);
-    _configure_buf_desc_table_(td_unpack_0.buf_desc_id, td_unpack_0.buf_desc);
-    _llk_unpack_configure_unary_<p_unpacr::UNP_S>(td_unpack_0.reg_data_format);
+    bd_unpack_0.f.l1_addr_16B = L1_ADDRESS(params.buffer_S[0]);
+    bd_unpack_0.f.format      = static_cast<std::uint8_t>(formats.unpack_S_src);
+    bd_unpack_0.f.x_dim       = PARAM_SRCS_XDIM;
+    bd_unpack_0.f.y_dim       = PARAM_SRCS_YDIM;
+    bd_unpack_0.f.z_dim       = PARAM_SRCS_ZDIM;
+    _configure_buf_desc_table_(buf_desc_id_unpack_0, bd_unpack_0);
+    _llk_unpack_configure_unary_<p_unpacr::UNP_S>(static_cast<DataFormat>(formats.unpack_S_dst));
 
     // FormatConfig has no unpack_T_* fields, so T is unpacked with S's format. Callers must keep
     // stimuli_T_format == stimuli_S_format or T will be read with the wrong format.
-    bd_unpack_1.f.l1_addr_16B   = L1_ADDRESS(params.buffer_T[0]);
-    bd_unpack_1.f.format        = static_cast<std::uint8_t>(formats.unpack_S_src);
-    bd_unpack_1.f.x_dim         = PARAM_SRCS_XDIM;
-    bd_unpack_1.f.y_dim         = PARAM_SRCS_YDIM;
-    bd_unpack_1.f.z_dim         = PARAM_SRCS_ZDIM;
-    td_unpack_1.buf_desc        = bd_unpack_1;
-    td_unpack_1.buf_desc_id     = buf_desc_id_unpack_1;
-    td_unpack_1.reg_data_format = static_cast<DataFormat>(formats.unpack_S_dst);
-    _configure_buf_desc_table_(td_unpack_1.buf_desc_id, td_unpack_1.buf_desc);
-    _llk_unpack_configure_unary_<p_unpacr::UNP_S>(td_unpack_1.reg_data_format);
+    bd_unpack_1.f.l1_addr_16B = L1_ADDRESS(params.buffer_T[0]);
+    bd_unpack_1.f.format      = static_cast<std::uint8_t>(formats.unpack_S_src);
+    bd_unpack_1.f.x_dim       = PARAM_SRCS_XDIM;
+    bd_unpack_1.f.y_dim       = PARAM_SRCS_YDIM;
+    bd_unpack_1.f.z_dim       = PARAM_SRCS_ZDIM;
+    _configure_buf_desc_table_(buf_desc_id_unpack_1, bd_unpack_1);
+    _llk_unpack_configure_unary_<p_unpacr::UNP_S>(static_cast<DataFormat>(formats.unpack_S_dst));
 
-    bd_pack.f.l1_addr_16B   = L1_ADDRESS(params.buffer_Res[0]);
-    bd_pack.f.format        = static_cast<std::uint8_t>(formats.pack_S_dst);
-    bd_pack.f.x_dim         = PARAM_SRCS_XDIM;
-    bd_pack.f.y_dim         = PARAM_SRCS_YDIM;
-    bd_pack.f.z_dim         = PARAM_SRCS_ZDIM;
-    td_pack.buf_desc        = bd_pack;
-    td_pack.buf_desc_id     = buf_desc_id_pack;
-    td_pack.reg_data_format = static_cast<DataFormat>(formats.pack_S_src);
-    _configure_buf_desc_table_(td_pack.buf_desc_id, td_pack.buf_desc);
-    _llk_pack_hw_configure_<p_pacr::PACK1, false>(td_pack.reg_data_format, ckernel::ReluConfig::none());
+    bd_pack.f.l1_addr_16B = L1_ADDRESS(params.buffer_Res[0]);
+    bd_pack.f.format      = static_cast<std::uint8_t>(formats.pack_S_dst);
+    bd_pack.f.x_dim       = PARAM_SRCS_XDIM;
+    bd_pack.f.y_dim       = PARAM_SRCS_YDIM;
+    bd_pack.f.z_dim       = PARAM_SRCS_ZDIM;
+    _configure_buf_desc_table_(buf_desc_id_pack, bd_pack);
+    _llk_pack_hw_configure_<p_pacr::PACK1, false>(static_cast<DataFormat>(formats.pack_S_src), ckernel::ReluConfig::none());
 
     cfg[DISABLE_IMPLIED_SRCS_FORMAT_ADDR32 + TRISC_ID] = !IMPLIED_MATH_FORMAT;
 
@@ -251,18 +236,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
     set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
-    tdma_descriptor_t tdma_desc_dst;
-    tdma_desc_dst.buf_desc.f.l1_addr_16B  = L1_ADDRESS(params.buffer_C[0]);
-    tdma_desc_dst.buf_desc.f.lmt_addr_16B = 0;
-    tdma_desc_dst.buf_desc.f.format       = static_cast<std::uint8_t>(formats.pack_dst);
-    tdma_desc_dst.buf_desc.f.x_dim        = FACE_C_DIM;
-    tdma_desc_dst.buf_desc.f.y_dim        = FACE_R_DIM;
-    tdma_desc_dst.buf_desc.f.z_dim        = params.num_faces;
-    tdma_desc_dst.buf_desc_id             = buf_desc_id_dst;
-    tdma_desc_dst.reg_data_format         = static_cast<DataFormat>(formats.pack_src);
+    buffer_descriptor_u bd_dst = {0};
+    bd_dst.f.l1_addr_16B       = L1_ADDRESS(params.buffer_C[0]);
+    bd_dst.f.lmt_addr_16B      = 0;
+    bd_dst.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
+    bd_dst.f.x_dim             = FACE_C_DIM;
+    bd_dst.f.y_dim             = FACE_R_DIM;
+    bd_dst.f.z_dim             = params.num_faces;
 
-    _configure_buf_desc_table_(tdma_desc_dst.buf_desc_id, tdma_desc_dst.buf_desc);
-    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc_dst.reg_data_format, ckernel::ReluConfig::none());
+    _configure_buf_desc_table_(buf_desc_id_dst, bd_dst);
+    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
     _llk_pack_matmul_init_(buf_desc_id_dst, params.RT_DIM, params.CT_DIM, 1);
 
     _llk_pack_matmul_(0, 0);

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_exp_parallel_matmul_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_exp_parallel_matmul_quasar_test.cpp
@@ -44,14 +44,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         const ckernel::TensorShape tensor_shape_A = ckernel::tensor_shape_from_num_faces(FACE_R_DIM, params.num_faces_A);
         const ckernel::TensorShape tensor_shape_B = ckernel::tensor_shape_from_num_faces(FACE_R_DIM, params.num_faces_B);
-        tdma_descriptor_t tdma_desc_src_a =
-            ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src, buf_desc_id_src_a, formats.unpack_A_dst);
-        tdma_descriptor_t tdma_desc_src_b =
-            ckernel::trisc::construct_tdma_desc(tensor_shape_B, L1_ADDRESS(params.buffer_B[0]), formats.unpack_B_src, buf_desc_id_src_b, formats.unpack_B_dst);
-
-        _configure_buf_desc_table_(tdma_desc_src_a.buf_desc_id, tdma_desc_src_a.buf_desc);
-        _configure_buf_desc_table_(tdma_desc_src_b.buf_desc_id, tdma_desc_src_b.buf_desc);
-        _llk_unpack_configure_binary_<p_unpacr::UNP_B, p_unpacr::UNP_A>(tdma_desc_src_a.reg_data_format, tdma_desc_src_b.reg_data_format);
+        _configure_buf_desc_table_(buf_desc_id_src_a, ckernel::trisc::construct_buf_desc(tensor_shape_A, L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src));
+        _configure_buf_desc_table_(buf_desc_id_src_b, ckernel::trisc::construct_buf_desc(tensor_shape_B, L1_ADDRESS(params.buffer_B[0]), formats.unpack_B_src));
+        _llk_unpack_configure_binary_<p_unpacr::UNP_B, p_unpacr::UNP_A>(
+            static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
         _llk_unpack_matmul_init_<UNPACK_TRANSPOSE_FACES>(buf_desc_id_src_a, buf_desc_id_src_b, CT_DIM, RT_DIM, KT_DIM);
         PROFILER_SYNC();
     }
@@ -192,15 +188,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         ZONE_SCOPED("INIT")
         const ckernel::TensorShape srcs_shape = tensor_shape_from_dimensions(PARAM_SRCS_YDIM, PARAM_SRCS_XDIM, PARAM_SRCS_ZDIM, PARAM_SRCS_ZDIM);
-        tdma_descriptor_t td_unpack =
-            ckernel::trisc::construct_tdma_desc(srcs_shape, L1_ADDRESS(params.buffer_S[0]), formats.unpack_S_src, buf_desc_id_unpack, formats.unpack_S_dst);
-        _configure_buf_desc_table_(td_unpack.buf_desc_id, td_unpack.buf_desc);
-        _llk_unpack_configure_unary_<p_unpacr::UNP_S>(td_unpack.reg_data_format);
+        _configure_buf_desc_table_(buf_desc_id_unpack, ckernel::trisc::construct_buf_desc(srcs_shape, L1_ADDRESS(params.buffer_S[0]), formats.unpack_S_src));
+        _llk_unpack_configure_unary_<p_unpacr::UNP_S>(static_cast<DataFormat>(formats.unpack_S_dst));
 
-        tdma_descriptor_t td_pack =
-            ckernel::trisc::construct_tdma_desc(srcs_shape, L1_ADDRESS(params.buffer_Res[0]), formats.pack_S_dst, buf_desc_id_pack, formats.pack_S_src);
-        _configure_buf_desc_table_(td_pack.buf_desc_id, td_pack.buf_desc);
-        _llk_pack_hw_configure_<p_pacr::PACK1, false>(td_pack.reg_data_format, ckernel::ReluConfig::none());
+        _configure_buf_desc_table_(buf_desc_id_pack, ckernel::trisc::construct_buf_desc(srcs_shape, L1_ADDRESS(params.buffer_Res[0]), formats.pack_S_dst));
+        _llk_pack_hw_configure_<p_pacr::PACK1, false>(static_cast<DataFormat>(formats.pack_S_src), ckernel::ReluConfig::none());
 
         _llk_unpack_srcs_config_for_tile_<PARAM_SRCS_INSTRN_COUNT>(PARAM_SRCS_32BIT_MODE);
         _llk_pack_srcs_config_for_tile_<PARAM_SRCS_INSTRN_COUNT>(PARAM_SRCS_32BIT_MODE);
@@ -272,11 +264,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
 
         const ckernel::TensorShape tensor_shape = ckernel::tensor_shape_from_num_faces(FACE_R_DIM, params.num_faces);
-        tdma_descriptor_t tdma_desc_dst =
-            ckernel::trisc::construct_tdma_desc(tensor_shape, L1_ADDRESS(params.buffer_C[0]), formats.pack_dst, buf_desc_id_dst, formats.pack_src);
-
-        _configure_buf_desc_table_(tdma_desc_dst.buf_desc_id, tdma_desc_dst.buf_desc);
-        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc_dst.reg_data_format, ckernel::ReluConfig::none());
+        _configure_buf_desc_table_(buf_desc_id_dst, ckernel::trisc::construct_buf_desc(tensor_shape, L1_ADDRESS(params.buffer_C[0]), formats.pack_dst));
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_matmul_init_(buf_desc_id_dst, RT_DIM, CT_DIM, 1);
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_fill_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_fill_quasar_test.cpp
@@ -171,7 +171,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    constexpr auto pack_res                = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
     const std::uint32_t num_tiles_per_pack = params.TILE_CNT;
 
     // PACK is the final consumer of the DEST DVALID chain.
@@ -180,11 +179,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // Destination descriptor: buffer_Res in L1, L1-side format = formats.pack_dst,
     // face geometry from the harness. reg_data_format = pack_src is the DEST-side
     // format the packer reads.
-    ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
+    ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
+        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
 
     // Configure pack engine 0 → init → pack tile from DST_INDEX into buffer_Res → release section.
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-    _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+    _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
     _llk_pack_(params.DST_INDEX, 0, ckernel::DEFAULT_TENSOR_SHAPE);
     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_fill_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_fill_quasar_test.cpp
@@ -36,6 +36,7 @@ inline bool is_int_fill_format(DataFormat fmt)
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_math_common.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_unary_operand.h"
@@ -46,8 +47,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t buf_desc_id = 0; // T0 source descriptor slot for buffer_A
-    const std::uint32_t num_tiles   = params.TILE_CNT;
+    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>(); // T0 source descriptor slot for buffer_A
+    const std::uint32_t num_tiles = params.TILE_CNT;
 
     // DEST DVALID handshake: T0 is the producer, T1 (SFPU) and T2 (PACK) are the consumers.
     // fill always uses unpack_to_dest (SFPU test — no FPU datacopy path).
@@ -76,11 +77,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // TDMA descriptor: bind the buffer descriptor to slot 0; reg_data_format =
     // unpack_A_dst is the DEST-side (post-conversion) format.
-    _configure_buf_desc_table_(buf_desc_id, bd_val);
+    _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val);
 
     // Configure unpacker → init unary operand path → unpack tile 0 from L1 into DEST.
     _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
-    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles);
+    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
+        ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles);
     _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0, ckernel::DEFAULT_TENSOR_SHAPE);
 
     // Release DEST section to the SFPU consumer.
@@ -168,6 +170,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #ifdef LLK_TRISC_PACK
 
 #include "cfg_defines.h"
+#include "llk_bfd_alloc.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -177,7 +180,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    std::uint32_t const buf_desc_id        = 8; // T2 destination descriptor slot for buffer_Res
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
+    ckernel::trisc::bfd_alloc<pack_res>(); // T2 destination descriptor slot for buffer_Res
     const std::uint32_t num_tiles_per_pack = params.TILE_CNT;
 
     // PACK is the final consumer of the DEST DVALID chain.
@@ -194,11 +198,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // TDMA descriptor: bind buffer_Res to slot 8; reg_data_format = pack_src is
     // the DEST-side format the packer reads.
-    _configure_buf_desc_table_(buf_desc_id, bd_val);
+    _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
 
     // Configure pack engine 0 → init → pack tile from DST_INDEX into buffer_Res → release section.
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-    _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+    _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
     _llk_pack_(params.DST_INDEX, 0, ckernel::DEFAULT_TENSOR_SHAPE);
     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_fill_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_fill_quasar_test.cpp
@@ -76,14 +76,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // TDMA descriptor: bind the buffer descriptor to slot 0; reg_data_format =
     // unpack_A_dst is the DEST-side (post-conversion) format.
-    tdma_descriptor_t td_val;
-    td_val.buf_desc        = bd_val;
-    td_val.buf_desc_id     = buf_desc_id;
-    td_val.reg_data_format = static_cast<DataFormat>(formats.unpack_A_dst);
-    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+    _configure_buf_desc_table_(buf_desc_id, bd_val);
 
     // Configure unpacker → init unary operand path → unpack tile 0 from L1 into DEST.
-    _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val.reg_data_format);
+    _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
     _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles);
     _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0, ckernel::DEFAULT_TENSOR_SHAPE);
 
@@ -198,14 +194,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // TDMA descriptor: bind buffer_Res to slot 8; reg_data_format = pack_src is
     // the DEST-side format the packer reads.
-    tdma_descriptor_t tdma_desc;
-    tdma_desc.buf_desc        = bd_val;
-    tdma_desc.buf_desc_id     = buf_desc_id;
-    tdma_desc.reg_data_format = static_cast<DataFormat>(formats.pack_src);
-    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+    _configure_buf_desc_table_(buf_desc_id, bd_val);
 
     // Configure pack engine 0 → init → pack tile from DST_INDEX into buffer_Res → release section.
-    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc.reg_data_format, ckernel::ReluConfig::none());
+    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
     _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
     _llk_pack_(params.DST_INDEX, 0, ckernel::DEFAULT_TENSOR_SHAPE);
     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_fill_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_fill_quasar_test.cpp
@@ -8,7 +8,6 @@
 #include "ckernel.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
-#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
 using namespace ckernel;
@@ -69,7 +68,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // face geometry from the harness. reg_data_format = unpack_A_dst is the
     // DEST-side (post-conversion) format.
     ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
-        tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
+        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
 
     // Configure unpacker → init unary operand path → unpack tile 0 from L1 into DEST.
     _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
@@ -181,8 +180,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // Destination descriptor: buffer_Res in L1, L1-side format = formats.pack_dst,
     // face geometry from the harness. reg_data_format = pack_src is the DEST-side
     // format the packer reads.
-    ckernel::trisc::bfd_alloc_and_program<pack_res>(
-        tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
+    ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
 
     // Configure pack engine 0 → init → pack tile from DST_INDEX into buffer_Res → release section.
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_fill_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_fill_quasar_test.cpp
@@ -8,6 +8,7 @@
 #include "ckernel.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
+#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
 using namespace ckernel;
@@ -47,7 +48,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>(); // T0 source descriptor slot for buffer_A
     const std::uint32_t num_tiles = params.TILE_CNT;
 
     // DEST DVALID handshake: T0 is the producer, T1 (SFPU) and T2 (PACK) are the consumers.
@@ -66,18 +66,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     // Source descriptor: buffer_A in L1, L1-side format = formats.unpack_A_src,
-    // face geometry from the harness.
-    buffer_descriptor_u bd_val = {0};
-
-    bd_val.f.l1_addr_16B = L1_ADDRESS(params.buffer_A[0]);
-    bd_val.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
-    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim       = params.num_faces;
-
-    // TDMA descriptor: bind the buffer descriptor to slot 0; reg_data_format =
-    // unpack_A_dst is the DEST-side (post-conversion) format.
-    _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val);
+    // face geometry from the harness. reg_data_format = unpack_A_dst is the
+    // DEST-side (post-conversion) format.
+    ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
+        tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
 
     // Configure unpacker → init unary operand path → unpack tile 0 from L1 into DEST.
     _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
@@ -180,25 +172,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
-    ckernel::trisc::bfd_alloc<pack_res>(); // T2 destination descriptor slot for buffer_Res
+    constexpr auto pack_res                = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
     const std::uint32_t num_tiles_per_pack = params.TILE_CNT;
 
     // PACK is the final consumer of the DEST DVALID chain.
     set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::UNPACK, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
 
     // Destination descriptor: buffer_Res in L1, L1-side format = formats.pack_dst,
-    // face geometry from the harness.
-    buffer_descriptor_u bd_val = {0};
-    bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_Res[0]);
-    bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
-    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim             = params.num_faces;
-
-    // TDMA descriptor: bind buffer_Res to slot 8; reg_data_format = pack_src is
-    // the DEST-side format the packer reads.
-    _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
+    // face geometry from the harness. reg_data_format = pack_src is the DEST-side
+    // format the packer reads.
+    ckernel::trisc::bfd_alloc_and_program<pack_res>(
+        tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
 
     // Configure pack engine 0 → init → pack tile from DST_INDEX into buffer_Res → release section.
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_fill_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_fill_quasar_test.cpp
@@ -68,7 +68,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // face geometry from the harness. reg_data_format = unpack_A_dst is the
     // DEST-side (post-conversion) format.
     ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
-        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
+        ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
 
     // Configure unpacker → init unary operand path → unpack tile 0 from L1 into DEST.
     _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
@@ -180,7 +180,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // face geometry from the harness. reg_data_format = pack_src is the DEST-side
     // format the packer reads.
     ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
-        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
+        ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
 
     // Configure pack engine 0 → init → pack tile from DST_INDEX into buffer_Res → release section.
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_trisc3_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_trisc3_quasar_test.cpp
@@ -13,6 +13,7 @@
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_math_common.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_unary_operand.h"
@@ -23,8 +24,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t buf_desc_id = 0;
-    const std::uint32_t num_tiles   = params.TILE_CNT;
+    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>();
+    const std::uint32_t num_tiles = params.TILE_CNT;
 
     if (unpack_to_dest)
     {
@@ -44,7 +45,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
     bd_val.f.z_dim       = params.num_faces;
 
-    _configure_buf_desc_table_(buf_desc_id, bd_val);
+    _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val);
 
     if (is_fp32_dest_acc_en && !unpack_to_dest)
     {
@@ -56,7 +57,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
     }
 
-    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles);
+    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
+        ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles);
     _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0, ckernel::DEFAULT_TENSOR_SHAPE);
 
     if (unpack_to_dest)
@@ -151,6 +153,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #ifdef LLK_TRISC_PACK
 
 #include "cfg_defines.h"
+#include "llk_bfd_alloc.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -160,7 +163,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    std::uint32_t const buf_desc_id        = 8;
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
+    ckernel::trisc::bfd_alloc<pack_res>();
     const std::uint32_t num_tiles_per_pack = params.TILE_CNT;
 
     if (unpack_to_dest)
@@ -179,10 +183,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
     bd_val.f.z_dim             = params.num_faces;
 
-    _configure_buf_desc_table_(buf_desc_id, bd_val);
+    _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
 
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-    _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+    _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
     _llk_pack_(params.DST_INDEX, 0, ckernel::DEFAULT_TENSOR_SHAPE);
     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_trisc3_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_trisc3_quasar_test.cpp
@@ -37,7 +37,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
-        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
+        ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
 
     if (is_fp32_dest_acc_en && !unpack_to_dest)
     {
@@ -167,7 +167,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
-        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
+        ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
 
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
     _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_trisc3_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_trisc3_quasar_test.cpp
@@ -10,6 +10,7 @@
 #include "ckernel.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
+#include "quasar_test_common.h"
 
 #ifdef LLK_TRISC_UNPACK
 
@@ -24,7 +25,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>();
     const std::uint32_t num_tiles = params.TILE_CNT;
 
     if (unpack_to_dest)
@@ -37,15 +37,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
     }
 
-    buffer_descriptor_u bd_val = {0};
-
-    bd_val.f.l1_addr_16B = L1_ADDRESS(params.buffer_A[0]);
-    bd_val.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
-    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim       = params.num_faces;
-
-    _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val);
+    ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
+        tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
 
     if (is_fp32_dest_acc_en && !unpack_to_dest)
     {
@@ -163,8 +156,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
-    ckernel::trisc::bfd_alloc<pack_res>();
+    constexpr auto pack_res                = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
     const std::uint32_t num_tiles_per_pack = params.TILE_CNT;
 
     if (unpack_to_dest)
@@ -176,14 +168,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
     }
 
-    buffer_descriptor_u bd_val = {0};
-    bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_Res[0]);
-    bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
-    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim             = params.num_faces;
-
-    _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
+    ckernel::trisc::bfd_alloc_and_program<pack_res>(
+        tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
 
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
     _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_trisc3_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_trisc3_quasar_test.cpp
@@ -44,19 +44,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
     bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
     bd_val.f.z_dim       = params.num_faces;
 
-    tdma_descriptor_t td_val;
-    td_val.buf_desc        = bd_val;
-    td_val.buf_desc_id     = buf_desc_id;
-    td_val.reg_data_format = static_cast<DataFormat>(formats.unpack_A_dst);
-    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+    _configure_buf_desc_table_(buf_desc_id, bd_val);
 
     if (is_fp32_dest_acc_en && !unpack_to_dest)
     {
-        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val.reg_data_format, td_val.reg_data_format);
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
+            static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_A_dst));
     }
     else
     {
-        _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val.reg_data_format);
+        _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
     }
 
     _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles);
@@ -182,13 +179,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
     bd_val.f.z_dim             = params.num_faces;
 
-    tdma_descriptor_t tdma_desc;
-    tdma_desc.buf_desc        = bd_val;
-    tdma_desc.buf_desc_id     = buf_desc_id;
-    tdma_desc.reg_data_format = static_cast<DataFormat>(formats.pack_src);
-    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+    _configure_buf_desc_table_(buf_desc_id, bd_val);
 
-    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc.reg_data_format, ckernel::ReluConfig::none());
+    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
     _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
     _llk_pack_(params.DST_INDEX, 0, ckernel::DEFAULT_TENSOR_SHAPE);
     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_trisc3_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_trisc3_quasar_test.cpp
@@ -155,7 +155,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    constexpr auto pack_res                = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
     const std::uint32_t num_tiles_per_pack = params.TILE_CNT;
 
     if (unpack_to_dest)
@@ -167,10 +166,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
     }
 
-    ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
+    ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
+        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
 
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-    _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+    _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
     _llk_pack_(params.DST_INDEX, 0, ckernel::DEFAULT_TENSOR_SHAPE);
     _llk_pack_dest_dvalid_section_done_<dest_sync, is_fp32_dest_acc_en>();
 }

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_trisc3_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_square_trisc3_quasar_test.cpp
@@ -10,7 +10,6 @@
 #include "ckernel.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
-#include "quasar_test_common.h"
 
 #ifdef LLK_TRISC_UNPACK
 
@@ -38,7 +37,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
-        tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
+        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
 
     if (is_fp32_dest_acc_en && !unpack_to_dest)
     {
@@ -168,8 +167,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
     }
 
-    ckernel::trisc::bfd_alloc_and_program<pack_res>(
-        tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
+    ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
 
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
     _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_swiglu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_swiglu_quasar_test.cpp
@@ -180,7 +180,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    constexpr auto pack_res                  = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
     constexpr std::uint32_t num_output_tiles = 1;
 
     // Declare the same dvalid client chain that UNPACK/MATH used, seen from
@@ -194,10 +193,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
     }
 
-    ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, params.buffer_Res[0] / 16, formats.pack_dst);
+    ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, params.buffer_Res[0] / 16, formats.pack_dst);
 
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-    _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_output_tiles);
+    _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_output_tiles);
 
     // Output lives at Dest tile index 2 — this is the layout *this driver*
     // uses (see "Layout used by this test" at the top of the file): gate=0,

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_swiglu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_swiglu_quasar_test.cpp
@@ -44,7 +44,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
-        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
+        ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
 
     if (is_fp32_dest_acc_en && !unpack_to_dest)
     {
@@ -194,7 +194,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
-        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
+        ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
 
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
     _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_output_tiles);

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_swiglu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_swiglu_quasar_test.cpp
@@ -12,6 +12,7 @@
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_math_common.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_unary_operand.h"
@@ -30,7 +31,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t buf_desc_id     = 0;
+    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>();
     const std::uint32_t num_input_tiles = 2; // gate + up
 
     if (unpack_to_dest)
@@ -51,7 +52,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
     bd_val.f.z_dim       = params.num_faces;
 
-    _configure_buf_desc_table_(buf_desc_id, bd_val);
+    _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val);
 
     if (is_fp32_dest_acc_en && !unpack_to_dest)
     {
@@ -65,7 +66,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
     }
 
-    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_input_tiles);
+    _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
+        ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_input_tiles);
     _llk_unpack_unary_operand_<UNPACKER_ENGINE_SEL>(0, ckernel::DEFAULT_TENSOR_SHAPE);
 
     if (unpack_to_dest)
@@ -176,6 +178,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #ifdef LLK_TRISC_PACK
 
 #include "cfg_defines.h"
+#include "llk_bfd_alloc.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -185,7 +188,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    std::uint32_t const buf_desc_id          = 8;
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
+    ckernel::trisc::bfd_alloc<pack_res>();
     constexpr std::uint32_t num_output_tiles = 1;
 
     // Declare the same dvalid client chain that UNPACK/MATH used, seen from
@@ -206,10 +210,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
     bd_val.f.z_dim             = params.num_faces;
 
-    _configure_buf_desc_table_(buf_desc_id, bd_val);
+    _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
 
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-    _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_output_tiles);
+    _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_output_tiles);
 
     // Output lives at Dest tile index 2 — this is the layout *this driver*
     // uses (see "Layout used by this test" at the top of the file): gate=0,

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_swiglu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_swiglu_quasar_test.cpp
@@ -8,7 +8,6 @@
 #include "ckernel.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
-#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
 #ifdef LLK_TRISC_UNPACK
@@ -45,7 +44,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
-        tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
+        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
 
     if (is_fp32_dest_acc_en && !unpack_to_dest)
     {
@@ -195,7 +194,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
     }
 
-    ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), params.buffer_Res[0] / 16, formats.pack_dst);
+    ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, params.buffer_Res[0] / 16, formats.pack_dst);
 
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
     _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_output_tiles);

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_swiglu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_swiglu_quasar_test.cpp
@@ -51,21 +51,18 @@ void run_kernel(RUNTIME_PARAMETERS params)
     bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
     bd_val.f.z_dim       = params.num_faces;
 
-    tdma_descriptor_t td_val;
-    td_val.buf_desc        = bd_val;
-    td_val.buf_desc_id     = buf_desc_id;
-    td_val.reg_data_format = static_cast<DataFormat>(formats.unpack_A_dst);
-    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+    _configure_buf_desc_table_(buf_desc_id, bd_val);
 
     if (is_fp32_dest_acc_en && !unpack_to_dest)
     {
         // Same workaround as unary tests: MOVA2D for 32-bit dest requires both
         // SrcA/B format configs because the datacopy uses ELWADD internally.
-        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val.reg_data_format, td_val.reg_data_format);
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
+            static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_A_dst));
     }
     else
     {
-        _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val.reg_data_format);
+        _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
     }
 
     _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_input_tiles);
@@ -209,13 +206,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
     bd_val.f.z_dim             = params.num_faces;
 
-    tdma_descriptor_t tdma_desc;
-    tdma_desc.buf_desc        = bd_val;
-    tdma_desc.buf_desc_id     = buf_desc_id;
-    tdma_desc.reg_data_format = static_cast<DataFormat>(formats.pack_src);
-    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+    _configure_buf_desc_table_(buf_desc_id, bd_val);
 
-    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc.reg_data_format, ckernel::ReluConfig::none());
+    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
     _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_output_tiles);
 
     // Output lives at Dest tile index 2 — this is the layout *this driver*

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_swiglu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_swiglu_quasar_test.cpp
@@ -193,7 +193,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
     }
 
-    ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, params.buffer_Res[0] / 16, formats.pack_dst);
+    ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
+        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
 
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
     _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_output_tiles);

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_swiglu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_swiglu_quasar_test.cpp
@@ -8,6 +8,7 @@
 #include "ckernel.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
+#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
 #ifdef LLK_TRISC_UNPACK
@@ -31,7 +32,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>();
     const std::uint32_t num_input_tiles = 2; // gate + up
 
     if (unpack_to_dest)
@@ -44,15 +44,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
     }
 
-    buffer_descriptor_u bd_val = {0};
-
-    bd_val.f.l1_addr_16B = L1_ADDRESS(params.buffer_A[0]);
-    bd_val.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
-    bd_val.f.x_dim       = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim       = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim       = params.num_faces;
-
-    _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val);
+    ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
+        tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
 
     if (is_fp32_dest_acc_en && !unpack_to_dest)
     {
@@ -188,8 +181,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
-    ckernel::trisc::bfd_alloc<pack_res>();
+    constexpr auto pack_res                  = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
     constexpr std::uint32_t num_output_tiles = 1;
 
     // Declare the same dvalid client chain that UNPACK/MATH used, seen from
@@ -203,14 +195,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
     }
 
-    buffer_descriptor_u bd_val = {0};
-    bd_val.f.l1_addr_16B       = params.buffer_Res[0] / 16;
-    bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
-    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim             = params.num_faces;
-
-    _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
+    ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), params.buffer_Res[0] / 16, formats.pack_dst);
 
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
     _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_output_tiles);

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_topk_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_topk_quasar_test.cpp
@@ -71,10 +71,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     bd_val.f.y_dim             = FACE_R_DIM;
     bd_val.f.z_dim             = 4;
 
-    tdma_descriptor_t td_val;
-    td_val.buf_desc    = bd_val;
-    td_val.buf_desc_id = buf_desc_id;
-
     for (int current_tile_row = 0; current_tile_row < NUM_TOPK_PIPELINE_EXECUTIONS; ++current_tile_row)
     {
         const int tile_row_offset = current_tile_row * params.FULL_CT_DIM;
@@ -114,11 +110,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
                     const int stage_offset = stage_index * NUM_VALUE_TILES_PER_ROW;
 
-                    td_val.buf_desc.f.format = static_cast<std::uint8_t>(unpack_src_format);
-                    td_val.reg_data_format   = static_cast<DataFormat>(unpack_dst_format);
+                    bd_val.f.format = static_cast<std::uint8_t>(unpack_src_format);
 
-                    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
-                    _llk_unpack_configure_unary_<p_unpacr::UNP_A>(td_val.reg_data_format);
+                    _configure_buf_desc_table_(buf_desc_id, bd_val);
+                    _llk_unpack_configure_unary_<p_unpacr::UNP_A>(static_cast<DataFormat>(unpack_dst_format));
 
                     if (first_iteration)
                     {
@@ -339,12 +334,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     // Tile dims and buf_desc_id are stable; only the format and L1 address change
     // per stage. Keep the descriptor here and update those fields inside the loop.
-    tdma_descriptor_t tdma_desc;
-    tdma_desc.buf_desc         = buffer_descriptor_u {0};
-    tdma_desc.buf_desc.f.x_dim = FACE_C_DIM;
-    tdma_desc.buf_desc.f.y_dim = FACE_R_DIM;
-    tdma_desc.buf_desc.f.z_dim = 4;
-    tdma_desc.buf_desc_id      = buf_desc_id;
+    buffer_descriptor_u bd_val = {0};
+    bd_val.f.x_dim             = FACE_C_DIM;
+    bd_val.f.y_dim             = FACE_R_DIM;
+    bd_val.f.z_dim             = 4;
 
     for (int current_tile_row = 0; current_tile_row < NUM_TOPK_PIPELINE_EXECUTIONS; ++current_tile_row)
     {
@@ -368,27 +361,26 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     const int tile_dest_offset = stage_index * NUM_TILES_PER_STAGE;
 
                     // Configure the per-stage format and L1 address for packing.
-                    tdma_desc.buf_desc.f.format = static_cast<std::uint8_t>(pack_dst_format);
+                    bd_val.f.format = static_cast<std::uint8_t>(pack_dst_format);
 
                     if (last_iter)
                     {
-                        const int tile_row_offset        = current_tile_row * NUM_TILES_IN_RESULT_BUFFER_PER_ROW;
-                        const int tile_L1_offset         = tile_row_offset + stage_index;
-                        tdma_desc.buf_desc.f.l1_addr_16B = params.buffer_Res[tile_L1_offset] / 16;
+                        const int tile_row_offset = current_tile_row * NUM_TILES_IN_RESULT_BUFFER_PER_ROW;
+                        const int tile_L1_offset  = tile_row_offset + stage_index;
+                        bd_val.f.l1_addr_16B      = params.buffer_Res[tile_L1_offset] / 16;
                     }
                     else
                     {
-                        const int tile_row_offset        = current_tile_row * params.FULL_CT_DIM;
-                        const int tile_pair_offset       = current_tile_pair_idx * (distance * NUM_TILES_PER_STAGE);
-                        const int stage_offset           = stage_index * NUM_VALUE_TILES_PER_ROW;
-                        const int tile_L1_offset         = tile_row_offset + stage_offset + tile_pair_offset;
-                        tdma_desc.buf_desc.f.l1_addr_16B = params.buffer_A[tile_L1_offset] / 16;
+                        const int tile_row_offset  = current_tile_row * params.FULL_CT_DIM;
+                        const int tile_pair_offset = current_tile_pair_idx * (distance * NUM_TILES_PER_STAGE);
+                        const int stage_offset     = stage_index * NUM_VALUE_TILES_PER_ROW;
+                        const int tile_L1_offset   = tile_row_offset + stage_offset + tile_pair_offset;
+                        bd_val.f.l1_addr_16B       = params.buffer_A[tile_L1_offset] / 16;
                     }
 
-                    tdma_desc.reg_data_format = static_cast<DataFormat>(pack_src_format);
-                    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+                    _configure_buf_desc_table_(buf_desc_id, bd_val);
 
-                    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc.reg_data_format, ckernel::ReluConfig::none());
+                    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(pack_src_format), ckernel::ReluConfig::none());
                     _llk_pack_(tile_dest_offset, 0, ckernel::DEFAULT_TENSOR_SHAPE);
 
                 } // Stage loop.

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_topk_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_topk_quasar_test.cpp
@@ -11,6 +11,7 @@
 #include "ckernel.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
+#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
 // ============================================================================
@@ -60,18 +61,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // Dvalid setup: FPU -> SFPU -> PACK
     set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
 
-    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>();
-
     // The L1 base is stable; tile offsets are passed to execute.
     // Keep unpack configuration per stage because values use
     // formats.unpack_A_* while indices use TOPK_INDEX_FORMAT
     // (Quasar Int16 transport for the uint16 index payload).
-    buffer_descriptor_u bd_val = {0};
-    bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_A[0]);
-    bd_val.f.x_dim             = FACE_C_DIM;
-    bd_val.f.y_dim             = FACE_R_DIM;
-    bd_val.f.z_dim             = 4;
-
     for (int current_tile_row = 0; current_tile_row < NUM_TOPK_PIPELINE_EXECUTIONS; ++current_tile_row)
     {
         const int tile_row_offset = current_tile_row * params.FULL_CT_DIM;
@@ -111,9 +104,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
                     const int stage_offset = stage_index * NUM_VALUE_TILES_PER_ROW;
 
-                    bd_val.f.format = static_cast<std::uint8_t>(unpack_src_format);
-
-                    _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val);
+                    ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
+                        tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(params.buffer_A[0]), unpack_src_format);
                     _llk_unpack_configure_unary_<p_unpacr::UNP_A>(static_cast<DataFormat>(unpack_dst_format));
 
                     if (first_iteration)
@@ -323,7 +315,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const int NUM_TILES_IN_RESULT_BUFFER_PER_ROW = (TOPK_K / ckernel::trisc::TILE_C_DIM) * NUM_STAGES;
 
     constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
-    ckernel::trisc::bfd_alloc<pack_res>();
 
     // Dest dvalid sync chain: FPU (datacopy) -> SFPU (topk) -> PACK.
     set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
@@ -335,13 +326,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t pack_src_data_types[NUM_STAGES] = {formats.pack_src, TOPK_INDEX_FORMAT};
     const std::uint32_t pack_dst_data_types[NUM_STAGES] = {formats.pack_dst, TOPK_INDEX_FORMAT};
 
-    // Tile dims and buf_desc_id are stable; only the format and L1 address change
-    // per stage. Keep the descriptor here and update those fields inside the loop.
-    buffer_descriptor_u bd_val = {0};
-    bd_val.f.x_dim             = FACE_C_DIM;
-    bd_val.f.y_dim             = FACE_R_DIM;
-    bd_val.f.z_dim             = 4;
-
+    // Tile dims are stable; only the format and L1 address change per stage,
+    // so program a fresh descriptor per stage inside the loop.
     for (int current_tile_row = 0; current_tile_row < NUM_TOPK_PIPELINE_EXECUTIONS; ++current_tile_row)
     {
         for (std::uint32_t current_iteration = 0; current_iteration < TOPK_NUM_ITERATIONS; ++current_iteration)
@@ -352,8 +338,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
             for (int current_tile_pair_idx = 0; current_tile_pair_idx < num_pairs; ++current_tile_pair_idx)
             {
-                _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, 1);
-
                 // PACR stalls on the SFPU dvalid; no explicit math-done wait needed.
                 for (Stage stage : {Stage::Values, Stage::Indices})
                 {
@@ -364,13 +348,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     const int tile_dest_offset = stage_index * NUM_TILES_PER_STAGE;
 
                     // Configure the per-stage format and L1 address for packing.
-                    bd_val.f.format = static_cast<std::uint8_t>(pack_dst_format);
-
+                    std::uint32_t l1_addr_16B;
                     if (last_iter)
                     {
                         const int tile_row_offset = current_tile_row * NUM_TILES_IN_RESULT_BUFFER_PER_ROW;
                         const int tile_L1_offset  = tile_row_offset + stage_index;
-                        bd_val.f.l1_addr_16B      = params.buffer_Res[tile_L1_offset] / 16;
+                        l1_addr_16B               = params.buffer_Res[tile_L1_offset] / 16;
                     }
                     else
                     {
@@ -378,10 +361,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
                         const int tile_pair_offset = current_tile_pair_idx * (distance * NUM_TILES_PER_STAGE);
                         const int stage_offset     = stage_index * NUM_VALUE_TILES_PER_ROW;
                         const int tile_L1_offset   = tile_row_offset + stage_offset + tile_pair_offset;
-                        bd_val.f.l1_addr_16B       = params.buffer_A[tile_L1_offset] / 16;
+                        l1_addr_16B                = params.buffer_A[tile_L1_offset] / 16;
                     }
 
-                    _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
+                    ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), l1_addr_16B, pack_dst_format);
+                    _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, 1);
 
                     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(pack_src_format), ckernel::ReluConfig::none());
                     _llk_pack_(tile_dest_offset, 0, ckernel::DEFAULT_TENSOR_SHAPE);

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_topk_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_topk_quasar_test.cpp
@@ -313,8 +313,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const int NUM_VALUE_TILES_PER_ROW            = params.FULL_CT_DIM / NUM_STAGES;
     const int NUM_TILES_IN_RESULT_BUFFER_PER_ROW = (TOPK_K / ckernel::trisc::TILE_C_DIM) * NUM_STAGES;
 
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
-
     // Dest dvalid sync chain: FPU (datacopy) -> SFPU (topk) -> PACK.
     set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
 
@@ -363,8 +361,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
                         l1_addr_16B                = params.buffer_A[tile_L1_offset] / 16;
                     }
 
-                    ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, l1_addr_16B, pack_dst_format);
-                    _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, 1);
+                    ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(ckernel::DEFAULT_TENSOR_SHAPE, l1_addr_16B, pack_dst_format);
+                    _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1);
 
                     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(pack_src_format), ckernel::ReluConfig::none());
                     _llk_pack_(tile_dest_offset, 0, ckernel::DEFAULT_TENSOR_SHAPE);

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_topk_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_topk_quasar_test.cpp
@@ -40,6 +40,7 @@ constexpr std::uint8_t TOPK_L1_WB_SEM = 2;
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_math_common.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_unary_operand.h"
@@ -59,7 +60,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // Dvalid setup: FPU -> SFPU -> PACK
     set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
 
-    const std::uint32_t buf_desc_id = 0;
+    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>();
 
     // The L1 base is stable; tile offsets are passed to execute.
     // Keep unpack configuration per stage because values use
@@ -112,18 +113,18 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
                     bd_val.f.format = static_cast<std::uint8_t>(unpack_src_format);
 
-                    _configure_buf_desc_table_(buf_desc_id, bd_val);
+                    _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val);
                     _llk_unpack_configure_unary_<p_unpacr::UNP_A>(static_cast<DataFormat>(unpack_dst_format));
 
                     if (first_iteration)
                     {
                         _llk_unpack_unary_operand_init_<p_unpacr::UNP_A, true /*transpose*/, is_fp32_dest_acc_en>(
-                            buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1);
+                            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1);
                     }
                     else
                     {
                         _llk_unpack_unary_operand_init_<p_unpacr::UNP_A, false /*transpose*/, is_fp32_dest_acc_en>(
-                            buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1);
+                            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, 1);
                     }
 
                     const int first_tile_index  = tile_row_offset + stage_offset + tile_pair_offset;
@@ -307,6 +308,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #ifdef LLK_TRISC_PACK
 
 #include "cfg_defines.h"
+#include "llk_bfd_alloc.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -320,7 +322,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const int NUM_VALUE_TILES_PER_ROW            = params.FULL_CT_DIM / NUM_STAGES;
     const int NUM_TILES_IN_RESULT_BUFFER_PER_ROW = (TOPK_K / ckernel::trisc::TILE_C_DIM) * NUM_STAGES;
 
-    const std::uint32_t buf_desc_id = 8;
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
+    ckernel::trisc::bfd_alloc<pack_res>();
 
     // Dest dvalid sync chain: FPU (datacopy) -> SFPU (topk) -> PACK.
     set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
@@ -349,7 +352,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
             for (int current_tile_pair_idx = 0; current_tile_pair_idx < num_pairs; ++current_tile_pair_idx)
             {
-                _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, 1);
+                _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, 1);
 
                 // PACR stalls on the SFPU dvalid; no explicit math-done wait needed.
                 for (Stage stage : {Stage::Values, Stage::Indices})
@@ -378,7 +381,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                         bd_val.f.l1_addr_16B       = params.buffer_A[tile_L1_offset] / 16;
                     }
 
-                    _configure_buf_desc_table_(buf_desc_id, bd_val);
+                    _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
 
                     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(pack_src_format), ckernel::ReluConfig::none());
                     _llk_pack_(tile_dest_offset, 0, ckernel::DEFAULT_TENSOR_SHAPE);

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_topk_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_topk_quasar_test.cpp
@@ -11,7 +11,6 @@
 #include "ckernel.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
-#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
 // ============================================================================
@@ -105,7 +104,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                     const int stage_offset = stage_index * NUM_VALUE_TILES_PER_ROW;
 
                     ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
-                        tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(params.buffer_A[0]), unpack_src_format);
+                        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_A[0]), unpack_src_format);
                     _llk_unpack_configure_unary_<p_unpacr::UNP_A>(static_cast<DataFormat>(unpack_dst_format));
 
                     if (first_iteration)
@@ -364,7 +363,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
                         l1_addr_16B                = params.buffer_A[tile_L1_offset] / 16;
                     }
 
-                    ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), l1_addr_16B, pack_dst_format);
+                    ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, l1_addr_16B, pack_dst_format);
                     _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, 1);
 
                     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(pack_src_format), ckernel::ReluConfig::none());

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_where_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_where_quasar_test.cpp
@@ -7,6 +7,7 @@
 #include "ckernel.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
+#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
 #ifdef LLK_TRISC_UNPACK
@@ -22,7 +23,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>();
     const std::uint32_t num_tiles_per_unpack = params.TILE_CNT;
 
     // UNPACK-to-DEST path: UNPACK writes DEST; SFPU reads/writes DEST; PACK reads DEST.
@@ -35,14 +35,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_math_upk_to_dest_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*is_int_fpu_en*/>();
     }
 
-    buffer_descriptor_u bd_val = {0};
-    bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_A[0]);
-    bd_val.f.format            = static_cast<std::uint8_t>(formats.unpack_A_src);
-    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim             = params.num_faces;
-
-    _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val);
+    ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
+        tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
 
     if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
     {
@@ -153,21 +147,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
-    ckernel::trisc::bfd_alloc<pack_res>();
+    constexpr auto pack_res                = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
     const std::uint32_t num_tiles_per_pack = 1;
 
     constexpr auto unpack_dest = unpack_to_dest ? dest_dvalid_client::UNPACK : dest_dvalid_client::FPU;
     set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({unpack_dest, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
 
-    buffer_descriptor_u bd_val = {0};
-    bd_val.f.l1_addr_16B       = L1_ADDRESS(params.buffer_Res[0]);
-    bd_val.f.format            = static_cast<std::uint8_t>(formats.pack_dst);
-    bd_val.f.x_dim             = params.TEST_FACE_C_DIM;
-    bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
-    bd_val.f.z_dim             = params.num_faces;
-
-    _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
+    ckernel::trisc::bfd_alloc_and_program<pack_res>(
+        tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
 
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
     _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_where_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_where_quasar_test.cpp
@@ -7,7 +7,6 @@
 #include "ckernel.h"
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
-#include "quasar_test_common.h"
 #include "sfpu_stub.h"
 
 #ifdef LLK_TRISC_UNPACK
@@ -36,7 +35,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
-        tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
+        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
 
     if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
     {
@@ -153,8 +152,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     constexpr auto unpack_dest = unpack_to_dest ? dest_dvalid_client::UNPACK : dest_dvalid_client::FPU;
     set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({unpack_dest, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
 
-    ckernel::trisc::bfd_alloc_and_program<pack_res>(
-        tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2), L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
+    ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
 
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
     _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_where_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_where_quasar_test.cpp
@@ -41,20 +41,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
     bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
     bd_val.f.z_dim             = params.num_faces;
 
-    tdma_descriptor_t td_val;
-    td_val.buf_desc        = bd_val;
-    td_val.buf_desc_id     = buf_desc_id;
-    td_val.reg_data_format = static_cast<DataFormat>(formats.unpack_A_dst);
-    _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+    _configure_buf_desc_table_(buf_desc_id, bd_val);
 
     if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
     {
         // If Dst is 32b and MATH uses FPU datacopy (MOVA2D → ELWADD fallback), we need both SrcA and SrcB formats configured.
-        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val.reg_data_format, td_val.reg_data_format);
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
+            static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_A_dst));
     }
     else
     {
-        _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val.reg_data_format);
+        _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
     }
 
     _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
@@ -167,13 +164,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
     bd_val.f.z_dim             = params.num_faces;
 
-    tdma_descriptor_t tdma_desc;
-    tdma_desc.buf_desc        = bd_val;
-    tdma_desc.buf_desc_id     = buf_desc_id;
-    tdma_desc.reg_data_format = static_cast<DataFormat>(formats.pack_src);
-    _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
+    _configure_buf_desc_table_(buf_desc_id, bd_val);
 
-    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc.reg_data_format, ckernel::ReluConfig::none());
+    _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
     _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
 
     // Packs only the result tile (DEST[DST_INDEX]); where produces one output tile

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_where_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_where_quasar_test.cpp
@@ -146,16 +146,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    constexpr auto pack_res                = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
     const std::uint32_t num_tiles_per_pack = 1;
 
     constexpr auto unpack_dest = unpack_to_dest ? dest_dvalid_client::UNPACK : dest_dvalid_client::FPU;
     set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({unpack_dest, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
 
-    ckernel::trisc::bfd_alloc_and_program<pack_res>(ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
+    ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
+        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
 
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-    _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+    _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
 
     // Packs only the result tile (DEST[DST_INDEX]); where produces one output tile
     // regardless of how many input tiles were loaded.

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_where_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_where_quasar_test.cpp
@@ -35,7 +35,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(
-        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
+        ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src);
 
     if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
     {
@@ -152,7 +152,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({unpack_dest, dest_dvalid_client::SFPU, dest_dvalid_client::PACK});
 
     ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
-        ckernel::DEFAULT_TENSOR_SHAPE, L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
+        ckernel::tensor_shape_from_num_faces(params.TEST_FACE_R_DIM, params.num_faces), L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst);
 
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
     _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);

--- a/tt_metal/tt-llk/tests/sources/quasar/sfpu_where_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/sfpu_where_quasar_test.cpp
@@ -11,6 +11,7 @@
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_math_common.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_unary_operand.h"
@@ -21,7 +22,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t buf_desc_id          = 0;
+    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>();
     const std::uint32_t num_tiles_per_unpack = params.TILE_CNT;
 
     // UNPACK-to-DEST path: UNPACK writes DEST; SFPU reads/writes DEST; PACK reads DEST.
@@ -41,7 +42,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
     bd_val.f.z_dim             = params.num_faces;
 
-    _configure_buf_desc_table_(buf_desc_id, bd_val);
+    _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val);
 
     if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
     {
@@ -55,7 +56,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
-        buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_unpack);
+        ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_unpack);
 
     // Unpacks all three input tiles (cond, true_val, false_val) from buffer_A in one call;
     // tile count is taken from num_tiles_per_unpack set during init.
@@ -142,6 +143,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #ifdef LLK_TRISC_PACK
 
 #include "cfg_defines.h"
+#include "llk_bfd_alloc.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -151,7 +153,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t buf_desc_id        = 8;
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
+    ckernel::trisc::bfd_alloc<pack_res>();
     const std::uint32_t num_tiles_per_pack = 1;
 
     constexpr auto unpack_dest = unpack_to_dest ? dest_dvalid_client::UNPACK : dest_dvalid_client::FPU;
@@ -164,10 +167,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     bd_val.f.y_dim             = params.TEST_FACE_R_DIM;
     bd_val.f.z_dim             = params.num_faces;
 
-    _configure_buf_desc_table_(buf_desc_id, bd_val);
+    _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
 
     _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-    _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+    _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
 
     // Packs only the result tile (DEST[DST_INDEX]); where produces one output tile
     // regardless of how many input tiles were loaded.

--- a/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
@@ -288,7 +288,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const int DST_INDEX                       = params.DST_INDEX;
     const Operand& buffer_Res                 = params.buffer_Res;
 #endif
-    constexpr auto pack_res                = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
     const std::uint32_t num_tiles_per_pack = output_tiles_in_block;
 
     {
@@ -312,9 +311,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        ckernel::trisc::bfd_alloc_and_program<pack_res>(TENSOR_SHAPE_FROM_PARAMS(params), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(
+            TENSOR_SHAPE_FROM_PARAMS(params), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
@@ -16,6 +16,7 @@
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_math_common.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_unary_operand.h"
@@ -36,7 +37,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A             = params.buffer_A;
     const Operand& buffer_B             = params.buffer_B;
 #endif
-    const std::uint32_t buf_desc_id          = 0;
+    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>();
     const std::uint32_t num_tiles_per_unpack = tiles_in_block;
 
     {
@@ -77,7 +78,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val.f.y_dim       = TEST_FACE_R_DIM;
         bd_val.f.z_dim       = num_faces;
 
-        _configure_buf_desc_table_(buf_desc_id, bd_val);
+        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val);
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
             // If Dest is in 32bit mode and operation is Mov2D, we need both SrcA/B fmts to be configured since Mov2D will be implemented via ELWADD
@@ -90,7 +91,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
 
         _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
-            buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_unpack);
+            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_unpack);
         PROFILER_SYNC();
     }
     {
@@ -282,6 +283,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
@@ -301,7 +303,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const int DST_INDEX                       = params.DST_INDEX;
     const Operand& buffer_Res                 = params.buffer_Res;
 #endif
-    std::uint32_t const buf_desc_id        = 8;
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
+    ckernel::trisc::bfd_alloc<pack_res>();
     const std::uint32_t num_tiles_per_pack = output_tiles_in_block;
 
     {
@@ -333,9 +336,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val.f.y_dim       = TEST_FACE_R_DIM;
         bd_val.f.z_dim       = num_faces;
 
-        _configure_buf_desc_table_(buf_desc_id, bd_val);
+        _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
@@ -36,7 +36,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A             = params.buffer_A;
     const Operand& buffer_B             = params.buffer_B;
 #endif
-    tdma_descriptor_t td_val;
     const std::uint32_t buf_desc_id          = 0;
     const std::uint32_t num_tiles_per_unpack = tiles_in_block;
 
@@ -78,19 +77,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val.f.y_dim       = TEST_FACE_R_DIM;
         bd_val.f.z_dim       = num_faces;
 
-        td_val.buf_desc        = bd_val;
-        td_val.buf_desc_id     = buf_desc_id;
-        td_val.reg_data_format = static_cast<DataFormat>(formats.unpack_A_dst);
-
-        _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
+        _configure_buf_desc_table_(buf_desc_id, bd_val);
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
             // If Dest is in 32bit mode and operation is Mov2D, we need both SrcA/B fmts to be configured since Mov2D will be implemented via ELWADD
-            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val.reg_data_format, td_val.reg_data_format);
+            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
+                static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_A_dst));
         }
         else
         {
-            _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val.reg_data_format);
+            _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
         }
 
         _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, false /*transpose*/, is_fp32_dest_acc_en>(
@@ -330,7 +326,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
 
         buffer_descriptor_u bd_val = {0};
-        tdma_descriptor_t tdma_desc;
 
         bd_val.f.l1_addr_16B = L1_ADDRESS(buffer_Res[0]);
         bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
@@ -338,12 +333,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         bd_val.f.y_dim       = TEST_FACE_R_DIM;
         bd_val.f.z_dim       = num_faces;
 
-        tdma_desc.buf_desc        = bd_val;
-        tdma_desc.buf_desc_id     = buf_desc_id;
-        tdma_desc.reg_data_format = static_cast<DataFormat>(formats.pack_src);
-
-        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc.reg_data_format, ckernel::ReluConfig::none());
+        _configure_buf_desc_table_(buf_desc_id, bd_val);
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(buf_desc_id, ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/transpose_dest_quasar_test.cpp
@@ -28,16 +28,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 #ifndef SPEED_OF_LIGHT
-    const std::uint32_t LOOP_FACTOR     = params.LOOP_FACTOR;
-    const std::uint32_t tiles_in_block  = params.OUTPUT_NUM_TILES_IN_BLOCK;
-    const std::uint32_t num_blocks      = static_cast<std::uint32_t>(params.INPUT_NUM_BLOCKS);
-    const std::uint32_t num_faces       = params.num_faces;
-    const std::uint32_t TEST_FACE_C_DIM = params.TEST_FACE_C_DIM;
-    const std::uint32_t TEST_FACE_R_DIM = params.TEST_FACE_R_DIM;
-    const Operand& buffer_A             = params.buffer_A;
-    const Operand& buffer_B             = params.buffer_B;
+    const std::uint32_t LOOP_FACTOR    = params.LOOP_FACTOR;
+    const std::uint32_t tiles_in_block = params.OUTPUT_NUM_TILES_IN_BLOCK;
+    const std::uint32_t num_blocks     = static_cast<std::uint32_t>(params.INPUT_NUM_BLOCKS);
+    const Operand& buffer_A            = params.buffer_A;
+    const Operand& buffer_B            = params.buffer_B;
 #endif
-    ckernel::trisc::bfd_alloc<ckernel::trisc::BfdResource::Unp0>();
     const std::uint32_t num_tiles_per_unpack = tiles_in_block;
 
     {
@@ -60,8 +56,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::UNPACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        buffer_descriptor_u bd_val = {0};
-
         unsigned l1_addr_16B;
         if constexpr (UNPACKER_ENGINE_SEL == p_unpacr::UNP_B)
         {
@@ -72,13 +66,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             l1_addr_16B = L1_ADDRESS(buffer_A[0]);
         }
 
-        bd_val.f.l1_addr_16B = l1_addr_16B;
-        bd_val.f.format      = static_cast<std::uint8_t>(formats.unpack_A_src);
-        bd_val.f.x_dim       = TEST_FACE_C_DIM;
-        bd_val.f.y_dim       = TEST_FACE_R_DIM;
-        bd_val.f.z_dim       = num_faces;
-
-        _configure_buf_desc_table_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), bd_val);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(TENSOR_SHAPE_FROM_PARAMS(params), l1_addr_16B, formats.unpack_A_src);
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
             // If Dest is in 32bit mode and operation is Mov2D, we need both SrcA/B fmts to be configured since Mov2D will be implemented via ELWADD
@@ -297,14 +285,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t LOOP_FACTOR           = params.LOOP_FACTOR;
     const std::uint32_t output_num_blocks     = params.OUTPUT_NUM_BLOCKS;
     const std::uint32_t output_tiles_in_block = params.OUTPUT_NUM_TILES_IN_BLOCK;
-    const std::uint32_t num_faces             = params.num_faces;
-    const std::uint32_t TEST_FACE_C_DIM       = params.TEST_FACE_C_DIM;
-    const std::uint32_t TEST_FACE_R_DIM       = params.TEST_FACE_R_DIM;
     const int DST_INDEX                       = params.DST_INDEX;
     const Operand& buffer_Res                 = params.buffer_Res;
 #endif
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
-    ckernel::trisc::bfd_alloc<pack_res>();
+    constexpr auto pack_res                = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
     const std::uint32_t num_tiles_per_pack = output_tiles_in_block;
 
     {
@@ -328,15 +312,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             }
         }
 
-        buffer_descriptor_u bd_val = {0};
-
-        bd_val.f.l1_addr_16B = L1_ADDRESS(buffer_Res[0]);
-        bd_val.f.format      = static_cast<std::uint8_t>(formats.pack_dst);
-        bd_val.f.x_dim       = TEST_FACE_C_DIM;
-        bd_val.f.y_dim       = TEST_FACE_R_DIM;
-        bd_val.f.z_dim       = num_faces;
-
-        _configure_buf_desc_table_(ckernel::trisc::bfd_current<pack_res>(), bd_val);
+        ckernel::trisc::bfd_alloc_and_program<pack_res>(TENSOR_SHAPE_FROM_PARAMS(params), L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), ckernel::DEFAULT_TENSOR_SHAPE, num_tiles_per_pack);
         PROFILER_SYNC();

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp
@@ -202,7 +202,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
@@ -228,10 +227,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
 
-        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), tensor_shape, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape, num_tiles_per_pack);
         _llk_pack_reduce_mask_config_<REDUCE_DIM>(tensor_shape);
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp
@@ -43,16 +43,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
         ZONE_SCOPED("INIT")
         // SrcA is tilized out of a row-major tensor, so its descriptor must address L1 in units of a single
         // 16-datum row (y_dim = z_dim = 1) for every tile shape.
-        tdma_descriptor_t td_val_A = ckernel::trisc::construct_tdma_desc<L1AccessMode::Strided>(
-            tensor_shape, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src, buf_desc_id_a, formats.unpack_A_dst);
+        program_buf_desc<L1AccessMode::Strided>(buf_desc_id_a, tensor_shape, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
 
         // SrcB holds the reduce scalar and is unpacked face by face, so it uses the tile-shaped descriptor.
-        tdma_descriptor_t td_val_B =
-            ckernel::trisc::construct_tdma_desc(tensor_shape, L1_ADDRESS(buffer_B[0]), formats.unpack_B_src, buf_desc_id_b, formats.unpack_B_dst);
+        program_buf_desc(buf_desc_id_b, tensor_shape, L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
 
-        _configure_buf_desc_table_(td_val_A.buf_desc_id, td_val_A.buf_desc);
-        _configure_buf_desc_table_(td_val_B.buf_desc_id, td_val_B.buf_desc);
-        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val_A.reg_data_format, td_val_B.reg_data_format);
+        _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
+            static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
 
         _llk_unpack_reduce_col_tilizeA_strided_init_<POOL_TYPE>(buf_desc_id_a, buf_desc_id_b, FULL_CT_DIM, tensor_shape);
         PROFILER_SYNC();
@@ -226,11 +223,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        tdma_descriptor_t tdma_desc =
-            ckernel::trisc::construct_tdma_desc(tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
-
-        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc.reg_data_format, ckernel::ReluConfig::none());
+        program_buf_desc(buf_desc_id, tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
 
         _llk_pack_init_(buf_desc_id, tensor_shape, num_tiles_per_pack);
         _llk_pack_reduce_mask_config_<REDUCE_DIM>(tensor_shape);

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_reduce_col_tilizeA_strided_quasar_test.cpp
@@ -16,6 +16,7 @@
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_reduce_col_tilizeA_strided.h"
 #include "params.h"
@@ -35,23 +36,26 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A          = params.buffer_A;
     const Operand& buffer_B          = params.buffer_B;
 #endif
-    const std::uint32_t buf_desc_id_a = 0;
-    const std::uint32_t buf_desc_id_b = 1;
-    const auto tensor_shape           = tensor_shape_from_params(params);
+    const auto tensor_shape = tensor_shape_from_params(params);
 
     {
         ZONE_SCOPED("INIT")
         // SrcA is tilized out of a row-major tensor, so its descriptor must address L1 in units of a single
         // 16-datum row (y_dim = z_dim = 1) for every tile shape.
-        program_buf_desc<L1AccessMode::Strided>(buf_desc_id_a, tensor_shape, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0, ckernel::trisc::L1AccessMode::Strided>(
+            tensor_shape, L1_ADDRESS(buffer_A[0]), formats.unpack_A_src);
 
         // SrcB holds the reduce scalar and is unpacked face by face, so it uses the tile-shaped descriptor.
-        program_buf_desc(buf_desc_id_b, tensor_shape, L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp1>(tensor_shape, L1_ADDRESS(buffer_B[0]), formats.unpack_B_src);
 
         _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
             static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_B_dst));
 
-        _llk_unpack_reduce_col_tilizeA_strided_init_<POOL_TYPE>(buf_desc_id_a, buf_desc_id_b, FULL_CT_DIM, tensor_shape);
+        _llk_unpack_reduce_col_tilizeA_strided_init_<POOL_TYPE>(
+            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(),
+            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp1>(),
+            FULL_CT_DIM,
+            tensor_shape);
         PROFILER_SYNC();
     }
     {
@@ -191,12 +195,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
@@ -205,7 +211,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t TILE_CNT    = params.TILE_CNT;
     const Operand& buffer_Res       = params.buffer_Res;
 #endif
-    std::uint32_t const buf_desc_id        = 8;
     const std::uint32_t num_tiles_per_pack = TILE_CNT;
     const auto tensor_shape                = tensor_shape_from_params(params);
 
@@ -223,10 +228,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
             set_up_dest_dvalid_per_thread<dest_dvalid_client::PACK>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
         }
 
-        program_buf_desc(buf_desc_id, tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
 
-        _llk_pack_init_(buf_desc_id, tensor_shape, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), tensor_shape, num_tiles_per_pack);
         _llk_pack_reduce_mask_config_<REDUCE_DIM>(tensor_shape);
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_tilize_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_tilize_quasar_test.cpp
@@ -283,7 +283,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
@@ -311,9 +310,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
 
         const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
-        ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape, L1_ADDRESS(buffer_Res[0]) /*l1_addr_16B*/, formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(tensor_shape, L1_ADDRESS(buffer_Res[0]) /*l1_addr_16B*/, formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none() /*relu_config*/);
-        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), tensor_shape, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape, num_tiles_per_pack);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_tilize_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_tilize_quasar_test.cpp
@@ -31,7 +31,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A         = params.buffer_A;
     const Operand& buffer_B         = params.buffer_B;
 #endif
-    tdma_descriptor_t td_val;
     const std::uint32_t buf_desc_id = 0;
 
     {
@@ -82,22 +81,21 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         if (tensor_shape.face_r_dim <= ckernel::unpack::UNPACR_STRIDE_MAX_ROWS)
         {
-            td_val =
-                ckernel::trisc::construct_tdma_desc<L1AccessMode::Strided>(tensor_shape, l1_addr_16B, formats.unpack_A_src, buf_desc_id, formats.unpack_A_dst);
+            program_buf_desc<L1AccessMode::Strided>(buf_desc_id, tensor_shape, l1_addr_16B, formats.unpack_A_src);
         }
         else
         {
-            td_val = ckernel::trisc::construct_tdma_desc(tensor_shape, l1_addr_16B, formats.unpack_A_src, buf_desc_id, formats.unpack_A_dst);
+            program_buf_desc(buf_desc_id, tensor_shape, l1_addr_16B, formats.unpack_A_src);
         }
 
-        _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
-            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val.reg_data_format, td_val.reg_data_format);
+            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
+                static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_A_dst));
         }
         else
         {
-            _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val.reg_data_format);
+            _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
         }
 
         if constexpr (unpack_to_dest)
@@ -308,11 +306,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
 
         const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
-        tdma_descriptor_t tdma_desc =
-            ckernel::trisc::construct_tdma_desc(tensor_shape, L1_ADDRESS(buffer_Res[0]) /*l1_addr_16B*/, formats.pack_dst, buf_desc_id, formats.pack_src);
-
-        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc.reg_data_format, ckernel::ReluConfig::none() /*relu_config*/);
+        program_buf_desc(buf_desc_id, tensor_shape, L1_ADDRESS(buffer_Res[0]) /*l1_addr_16B*/, formats.pack_dst);
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none() /*relu_config*/);
         _llk_pack_init_(buf_desc_id, tensor_shape, num_tiles_per_pack);
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_tilize_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_tilize_quasar_test.cpp
@@ -79,15 +79,15 @@ void run_kernel(RUNTIME_PARAMETERS params)
             l1_addr_16B = L1_ADDRESS(buffer_B[0]);
         }
 
+        // Record the descriptor under the engine UNPACKER_ENGINE_SEL actually drives (UNP_B -> UNPACR1/Unp1).
+        constexpr auto unp_res = (UNPACKER_ENGINE_SEL == p_unpacr::UNP_B) ? ckernel::trisc::BfdResource::Unp1 : ckernel::trisc::BfdResource::Unp0;
         if (tensor_shape.face_r_dim <= ckernel::unpack::UNPACR_STRIDE_MAX_ROWS)
         {
-            ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0, ckernel::trisc::L1AccessMode::Strided>(
-                tensor_shape, l1_addr_16B, formats.unpack_A_src);
+            ckernel::trisc::bfd_alloc_and_program<unp_res, ckernel::trisc::L1AccessMode::Strided>(tensor_shape, l1_addr_16B, formats.unpack_A_src);
         }
         else
         {
-            ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0, ckernel::trisc::L1AccessMode::Continuous>(
-                tensor_shape, l1_addr_16B, formats.unpack_A_src);
+            ckernel::trisc::bfd_alloc_and_program<unp_res, ckernel::trisc::L1AccessMode::Continuous>(tensor_shape, l1_addr_16B, formats.unpack_A_src);
         }
 
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
@@ -102,17 +102,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         if constexpr (unpack_to_dest)
         {
-            _llk_unpack_tilize_block_init_<FULL_CT_DIM, BLOCK_CT_DIM>(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), tensor_shape);
+            _llk_unpack_tilize_block_init_<FULL_CT_DIM, BLOCK_CT_DIM>(ckernel::trisc::bfd_current<unp_res>(), tensor_shape);
         }
         else if (tensor_shape.face_r_dim < FACE_R_DIM)
         {
             _llk_unpack_tilize_strided_init_small_faces_<UNPACKER_ENGINE_SEL, is_fp32_dest_acc_en>(
-                ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), tensor_shape, FULL_CT_DIM, BLOCK_CT_DIM);
+                ckernel::trisc::bfd_current<unp_res>(), tensor_shape, FULL_CT_DIM, BLOCK_CT_DIM);
         }
         else
         {
-            _llk_unpack_tilize_init_<UNPACKER_ENGINE_SEL, is_fp32_dest_acc_en>(
-                ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), FULL_CT_DIM, BLOCK_CT_DIM, tensor_shape);
+            _llk_unpack_tilize_init_<UNPACKER_ENGINE_SEL, is_fp32_dest_acc_en>(ckernel::trisc::bfd_current<unp_res>(), FULL_CT_DIM, BLOCK_CT_DIM, tensor_shape);
         }
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_tilize_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_tilize_quasar_test.cpp
@@ -16,6 +16,7 @@
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_math_common.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_tilize.h"
@@ -31,7 +32,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A         = params.buffer_A;
     const Operand& buffer_B         = params.buffer_B;
 #endif
-    const std::uint32_t buf_desc_id = 0;
 
     {
         ZONE_SCOPED("INIT")
@@ -81,11 +81,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         if (tensor_shape.face_r_dim <= ckernel::unpack::UNPACR_STRIDE_MAX_ROWS)
         {
-            program_buf_desc<L1AccessMode::Strided>(buf_desc_id, tensor_shape, l1_addr_16B, formats.unpack_A_src);
+            ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0, ckernel::trisc::L1AccessMode::Strided>(
+                tensor_shape, l1_addr_16B, formats.unpack_A_src);
         }
         else
         {
-            program_buf_desc(buf_desc_id, tensor_shape, l1_addr_16B, formats.unpack_A_src);
+            ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0, ckernel::trisc::L1AccessMode::Continuous>(
+                tensor_shape, l1_addr_16B, formats.unpack_A_src);
         }
 
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
@@ -100,15 +102,17 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         if constexpr (unpack_to_dest)
         {
-            _llk_unpack_tilize_block_init_<FULL_CT_DIM, BLOCK_CT_DIM>(buf_desc_id, tensor_shape);
+            _llk_unpack_tilize_block_init_<FULL_CT_DIM, BLOCK_CT_DIM>(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), tensor_shape);
         }
         else if (tensor_shape.face_r_dim < FACE_R_DIM)
         {
-            _llk_unpack_tilize_strided_init_small_faces_<UNPACKER_ENGINE_SEL, is_fp32_dest_acc_en>(buf_desc_id, tensor_shape, FULL_CT_DIM, BLOCK_CT_DIM);
+            _llk_unpack_tilize_strided_init_small_faces_<UNPACKER_ENGINE_SEL, is_fp32_dest_acc_en>(
+                ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), tensor_shape, FULL_CT_DIM, BLOCK_CT_DIM);
         }
         else
         {
-            _llk_unpack_tilize_init_<UNPACKER_ENGINE_SEL, is_fp32_dest_acc_en>(buf_desc_id, FULL_CT_DIM, BLOCK_CT_DIM, tensor_shape);
+            _llk_unpack_tilize_init_<UNPACKER_ENGINE_SEL, is_fp32_dest_acc_en>(
+                ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), FULL_CT_DIM, BLOCK_CT_DIM, tensor_shape);
         }
         PROFILER_SYNC();
     }
@@ -272,12 +276,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
@@ -286,7 +292,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t TILE_CNT    = params.TILE_CNT;
     const Operand& buffer_Res       = params.buffer_Res;
 #endif
-    std::uint32_t const buf_desc_id        = 8;
     const std::uint32_t num_tiles_per_pack = TILE_CNT;
 
     {
@@ -306,9 +311,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
 
         const ckernel::TensorShape tensor_shape = TENSOR_SHAPE_FROM_PARAMS(params);
-        program_buf_desc(buf_desc_id, tensor_shape, L1_ADDRESS(buffer_Res[0]) /*l1_addr_16B*/, formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape, L1_ADDRESS(buffer_Res[0]) /*l1_addr_16B*/, formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none() /*relu_config*/);
-        _llk_pack_init_(buf_desc_id, tensor_shape, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), tensor_shape, num_tiles_per_pack);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
@@ -69,16 +69,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
             l1_addr_16B = L1_ADDRESS(buffer_B[0]);
         }
 
-        tdma_descriptor_t td_val = ckernel::trisc::construct_tdma_desc(tensor_shape_A, l1_addr_16B, formats.unpack_A_src, buf_desc_id, formats.unpack_A_dst);
+        program_buf_desc(buf_desc_id, tensor_shape_A, l1_addr_16B, formats.unpack_A_src);
 
-        _configure_buf_desc_table_(td_val.buf_desc_id, td_val.buf_desc);
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
-            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(td_val.reg_data_format, td_val.reg_data_format);
+            _llk_unpack_configure_binary_<p_unpacr::UNP_A, p_unpacr::UNP_B>(
+                static_cast<DataFormat>(formats.unpack_A_dst), static_cast<DataFormat>(formats.unpack_A_dst));
         }
         else
         {
-            _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(td_val.reg_data_format);
+            _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
         }
 
         _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, TRANSPOSE_EN, is_fp32_dest_acc_en>(buf_desc_id, tensor_shape_A, num_tiles_per_unpack);
@@ -247,11 +247,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
 
-        tdma_descriptor_t tdma_desc =
-            ckernel::trisc::construct_tdma_desc(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst, buf_desc_id, formats.pack_src);
-
-        _configure_buf_desc_table_(tdma_desc.buf_desc_id, tdma_desc.buf_desc);
-        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(tdma_desc.reg_data_format, ckernel::ReluConfig::none());
+        program_buf_desc(buf_desc_id, tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
         _llk_pack_init_(buf_desc_id, tensor_shape_A, num_tiles_per_pack);
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
@@ -69,7 +69,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
             l1_addr_16B = L1_ADDRESS(buffer_B[0]);
         }
 
-        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(tensor_shape_A, l1_addr_16B, formats.unpack_A_src);
+        // Record the descriptor under the engine UNPACKER_ENGINE_SEL actually drives (UNP_B -> UNPACR1/Unp1).
+        constexpr auto unp_res = (UNPACKER_ENGINE_SEL == p_unpacr::UNP_B) ? ckernel::trisc::BfdResource::Unp1 : ckernel::trisc::BfdResource::Unp0;
+        ckernel::trisc::bfd_alloc_and_program<unp_res>(tensor_shape_A, l1_addr_16B, formats.unpack_A_src);
 
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
@@ -82,7 +84,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
 
         _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, TRANSPOSE_EN, is_fp32_dest_acc_en>(
-            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), tensor_shape_A, num_tiles_per_unpack);
+            ckernel::trisc::bfd_current<unp_res>(), tensor_shape_A, num_tiles_per_unpack);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
@@ -216,7 +216,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
-    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
@@ -249,9 +248,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
 
-        ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Pack0>(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), tensor_shape_A, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Pack0>(), tensor_shape_A, num_tiles_per_pack);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/unpack_unary_operand_quasar_test.cpp
@@ -16,6 +16,7 @@
 
 #ifdef LLK_TRISC_UNPACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_math_common.h"
 #include "llk_unpack_common.h"
 #include "llk_unpack_unary_operand.h"
@@ -32,7 +33,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const Operand& buffer_A         = params.buffer_A;
     const Operand& buffer_B         = params.buffer_B;
 #endif
-    const std::uint32_t buf_desc_id          = 0;
     const std::uint32_t num_tiles_per_unpack = TILE_CNT;
 
     {
@@ -69,7 +69,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             l1_addr_16B = L1_ADDRESS(buffer_B[0]);
         }
 
-        program_buf_desc(buf_desc_id, tensor_shape_A, l1_addr_16B, formats.unpack_A_src);
+        ckernel::trisc::bfd_alloc_and_program<ckernel::trisc::BfdResource::Unp0>(tensor_shape_A, l1_addr_16B, formats.unpack_A_src);
 
         if constexpr (is_fp32_dest_acc_en && !unpack_to_dest)
         {
@@ -81,7 +81,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             _llk_unpack_configure_unary_<UNPACKER_ENGINE_SEL>(static_cast<DataFormat>(formats.unpack_A_dst));
         }
 
-        _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, TRANSPOSE_EN, is_fp32_dest_acc_en>(buf_desc_id, tensor_shape_A, num_tiles_per_unpack);
+        _llk_unpack_unary_operand_init_<UNPACKER_ENGINE_SEL, TRANSPOSE_EN, is_fp32_dest_acc_en>(
+            ckernel::trisc::bfd_current<ckernel::trisc::BfdResource::Unp0>(), tensor_shape_A, num_tiles_per_unpack);
         PROFILER_SYNC();
     }
     {
@@ -208,12 +209,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef LLK_TRISC_PACK
 
+#include "llk_bfd_alloc.h"
 #include "llk_pack.h"
 #include "llk_pack_common.h"
 #include "params.h"
 
 void run_kernel(RUNTIME_PARAMETERS params)
 {
+    constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? ckernel::trisc::BfdResource::Pack0 : ckernel::trisc::BfdResource::Pack1;
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
@@ -222,7 +225,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t TILE_CNT    = params.TILE_CNT;
     const Operand& buffer_Res       = params.buffer_Res;
 #endif
-    std::uint32_t const buf_desc_id        = 8;
     const std::uint32_t num_tiles_per_pack = TILE_CNT;
 
     {
@@ -247,9 +249,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         const ckernel::TensorShape tensor_shape_A = TENSOR_SHAPE_FROM_PARAMS(params);
 
-        program_buf_desc(buf_desc_id, tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
+        ckernel::trisc::bfd_alloc_and_program<pack_res>(tensor_shape_A, L1_ADDRESS(buffer_Res[0]), formats.pack_dst);
         _llk_pack_hw_configure_<p_pacr::PACK0, is_fp32_dest_acc_en>(static_cast<DataFormat>(formats.pack_src), ckernel::ReluConfig::none());
-        _llk_pack_init_(buf_desc_id, tensor_shape_A, num_tiles_per_pack);
+        _llk_pack_init_(ckernel::trisc::bfd_current<pack_res>(), tensor_shape_A, num_tiles_per_pack);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_trisc_common.h
@@ -484,26 +484,4 @@ inline buffer_descriptor_u construct_buf_desc(const TensorShape& tensor_shape, u
     return buf_desc;
 }
 
-/**
- * @brief Creates a tdma_descriptor_t structure from TensorShape and other needed parameters
- * Currently supported buffer descriptor dimensions are:
- * x=16; y=[1, 2, 4, 8, 16]; z=1; or x=16; y=16; z=4; these are hardware constraints.
- *
- * @tparam MODE: L1 access mode. Strided (PACR/UNPACR_STRIDE tiny-tiles) forces y_dim = 1 and z_dim = 1
- *        so L1 rows are indexed as tiles; Continuous keeps the tensor-shape derived y_dim, z_dim.
- * @param tensor_shape: Tile/face dimensions and shape of input tensor
- * @param base_l1_16B: base address of the buffer in L1
- * @param data_format: L1 data encoding format
- * @param buf_desc_id: buffer descriptor table ID
- * @param reg_data_format: Register data encoding format
- */
-template <L1AccessMode MODE = L1AccessMode::Continuous>
-inline tdma_descriptor_t construct_tdma_desc(
-    const TensorShape& tensor_shape, unsigned base_l1_16B, unsigned data_format, std::uint32_t buf_desc_id, unsigned reg_data_format)
-{
-    tdma_descriptor_t tdma_desc = {construct_buf_desc<MODE>(tensor_shape, base_l1_16B, data_format), buf_desc_id, static_cast<DataFormat>(reg_data_format)};
-
-    return tdma_desc;
-}
-
 } // namespace ckernel::trisc

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/experimental/llk_unpack_AB_sub_bcast_col_custom.h
@@ -53,7 +53,7 @@ inline void _llk_unpack_AB_sub_bcast_col_init_custom_(const ckernel::TensorShape
  * ahead of the math thread.
  *
  * A 16x32 tiny tile is registered as one HW tile per face (buffer-descriptor z_dim = 1, see
- * @ref ckernel::trisc::construct_tdma_desc), so a SrcA tile takes one UNPACR per face and its L1 tile
+ * @ref ckernel::trisc::construct_buf_desc), so a SrcA tile takes one UNPACR per face and its L1 tile
  * indices count faces, not tiles. A full 32x32 tile is a single HW tile (z_dim = 4) unpacked by one
  * UNPACR. Either way exactly one dvalid is raised per tile, which is what the math thread's per-tile
  * CLR_A (and single CLR_B for the held SrcB) consumes. SrcB stays at one UNPACR in both cases: a full


### PR DESCRIPTION
### Summary

Builds on the merged Quasar BFD decoupling (#52762). Two related cleanups, on top of which the tt-llk
quasar tests are moved onto the **BFD allocator** so they exercise the same descriptor path as product code:

1. **Remove the dead `construct_tdma_desc` wrapper / `tdma_descriptor_t` type** — superseded by the BFD
   allocator; nothing in product code used them anymore.
2. **Migrate the quasar tt-llk test sources to the allocator** — the tests hand-picked fixed
   `buf_desc_id`s (0/1/8/29/30/31) and hand-rolled `buffer_descriptor_u`s, bypassing the allocator
   entirely. They now allocate through `bfd_alloc_and_program` / `bfd_current`, exactly like product LLK.

Net **−444 lines** (568 insertions / 1012 deletions across 35 files). No product-LLK behavior change.

### Why

After #52762, product LLK allocates descriptor ids from a per-TRISC partition at op-init
(`bfd_alloc_and_program<E,MODE>()` → `construct_buf_desc` + `_configure_buf_desc_table_`) and reads them
back with `bfd_current<E>()`. But the tt-llk tests still:

- carried a dead `construct_tdma_desc` wrapper and `tdma_descriptor_t` bundle, and
- hand-programmed the BD table with **fixed ids that ignored the partitions** — pack picked `8`, matmul
  picked `29/30/31`, all of which sit in the *unpack* partition `[0,16)` / the TRISC3 partition
  `[24,32)`. They only worked because nothing else collided.

So the allocator's real behavior (partitions, bump-and-wrap, compile-time ownership `static_assert`s) was
covered **only** by product ops and the `QuasarBfdDatacopy` gtest — not by the LLK tests meant to cover it.
This PR closes that gap.

### What changed

**1. Remove `construct_tdma_desc` / `tdma_descriptor_t`** (`ckernel_trisc_common.h`, `tensix_types.h`)
- Kept the live path (`construct_buf_desc`, `_configure_buf_desc_table_`, `buffer_descriptor_u`).
- Fixed one dangling `@ref` doc comment.
- Migrated the fuser codegen (`operand.py`, `reduce_tilize_a.py`) off the removed symbol, plus a
  pre-existing fuser bug fix (uint8→`DataFormat` cast in the configure emissions).

**2. Migrate the quasar test sources to the allocator** (`tests/sources/quasar/*.cpp`)
- Each unpack/pack descriptor is now a single `ckernel::trisc::bfd_alloc_and_program<E[,MODE]>(shape,
  l1_base_16B, data_format)`, with `ckernel::trisc::bfd_current<E>()` passed directly into the
  `_llk_*_init_` / execute calls (no intermediate id local).
- Engine mapping is explicit per test in the `.cpp`: srcA→`Unp0`, srcB→`Unp1`; pack via
  `constexpr auto pack_res = (ckernel::TRISC_ID == 2) ? BfdResource::Pack0 : BfdResource::Pack1;`
  (resolves to `Pack0` on the pack TU, `Pack1` for the one TRISC3-pack test).
- Removed the now-unused fixed-id/hand-rolled scaffolding: the `program_buf_desc` test helper, the
  hand-rolled `buffer_descriptor_u` blocks, and the dead `x/y/z_dim` dim locals. The descriptor shape now
  comes from a `TensorShape` (`TENSOR_SHAPE_FROM_PARAMS(params)` where the test's params carry the face
  decomposition, else an explicit `tensor_shape_from_dimensions(FACE_R_DIM, FACE_C_DIM, 2, 2)` for the
  full-tile tests whose params only track a flat `num_faces`).

**Not migrated (left as-is):** SrcS / isolate-SFPU tests (`isolate_sfpu_add/square`,
`sfpu_add/exp_parallel_matmul`) — there is no `BfdResource` for the UNP_S/SrcS engine yet; a follow-up
will wire SrcS through the allocator.

### Verification

- **Compile gate:** all 27 quasar pytest sweeps compile under the allocator (`pytest --compile-producer`,
  ~50 cases/sweep), **1166 cases, 0 failures** — every engine-ownership `static_assert` holds (matmul on
  TRISC0/TRISC2, the TRISC3-pack test on `Pack1`, all Strided paths).
- **Emulator (1x3 sim), bit-exact vs golden**, on a representative serial spot-check covering the risky
  shapes: `unpack_unary_operand`, `unpack_tilize` (Strided), `matmul` (id-restructure), `sfpu_square_trisc3`
  (Pack1/TRISC3), `semaphore_sync` + `eltwise_binary_broadcast` (2-operand), `sfpu_topk` (per-stage
  re-alloc + re-init), `sfpu_where`, `transpose_dest`, and a `fused` config — all pass.

### Notes for reviewers

- Pure test-side change apart from deleting the two dead symbols; no product LLK/API behavior changes.
- `sfpu_topk` now re-allocates + re-inits its descriptor per stage inside the loop (the Quasar
  "re-init before every op" pattern) rather than reusing one hand-picked id — verified bit-exact.
- Category: **Cleanup / test-infra**.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rtawfik/quasar-remove-tdma-desc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rtawfik/quasar-remove-tdma-desc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rtawfik/quasar-remove-tdma-desc)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rtawfik/quasar-remove-tdma-desc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rtawfik/quasar-remove-tdma-desc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rtawfik/quasar-remove-tdma-desc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rtawfik/quasar-remove-tdma-desc)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rtawfik/quasar-remove-tdma-desc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rtawfik/quasar-remove-tdma-desc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rtawfik/quasar-remove-tdma-desc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rtawfik/quasar-remove-tdma-desc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rtawfik/quasar-remove-tdma-desc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rtawfik/quasar-remove-tdma-desc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rtawfik/quasar-remove-tdma-desc)