### PR TITLE
Wire SiTU-GLU (Kimi K3) into the routed expert kernel

### DIFF
--- a/models/demos/deepseek_v3_d_p/reference/kimi_k3_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/kimi_k3_config.py
@@ -103,7 +103,8 @@ class KimiK3Config:
     ATTN_RES_BLOCK_SIZE = 12
 
     LATENT_MOE_USE_NORM = True
-    # Torch reference only: no TT kernel implements SiTU yet (#51335), so the device path runs SiLU.
+    # Must match SituGluConfigKimi, which the fused routed-expert kernel bakes in (#51351).
+    # Outside that kernel (shared expert, dense FFN) the device path still runs SiLU.
     ACTIVATION_SITU_BETA = 4.0
     ACTIVATION_SITU_LINEAR_BETA = 25.0
 
@@ -190,8 +191,8 @@ def kimi_k3_hf_config(max_seq: int = 8192):
         # LatentMoE: the routed experts' reduced hidden dim, and the latent RMSNorm flag.
         routed_expert_hidden_size=KimiK3Config.ROUTED_EXPERT_HIDDEN_SIZE,
         latent_moe_use_norm=KimiK3Config.LATENT_MOE_USE_NORM,
-        # The checkpoint says "situ", but no TT kernel implements it yet (#51335) and consumers of
-        # this field build the activation from it.
+        # The checkpoint says "situ", but consumers of this field index ACT2FN with it, which has
+        # no "situ" entry. The routed expert selects SiTU through RoutedExpertActivation instead.
         hidden_act="silu",
         activation_situ_beta=KimiK3Config.ACTIVATION_SITU_BETA,
         activation_situ_linear_beta=KimiK3Config.ACTIVATION_SITU_LINEAR_BETA,

--- a/models/demos/deepseek_v3_d_p/reference/kimi_k3_config.py
+++ b/models/demos/deepseek_v3_d_p/reference/kimi_k3_config.py
@@ -103,8 +103,11 @@ class KimiK3Config:
     ATTN_RES_BLOCK_SIZE = 12
 
     LATENT_MOE_USE_NORM = True
-    # Must match SituGluConfigKimi, which the fused routed-expert kernel bakes in (#51351).
-    # Outside that kernel (shared expert, dense FFN) the device path still runs SiLU.
+    # The routed experts run the checkpoint's SiTU-GLU on device (#51351). Spelled as a string
+    # because this config is torch-only; ROUTED_EXPERT_ACTIVATION_BY_NAME maps it onto the kernel
+    # enum. Routed only: the shared expert and the dense FFN have no SiTU kernel and stay on SiLU.
+    ROUTED_EXPERT_ACTIVATION = "situ"
+    # Must match SituGluConfigKimi, which the fused routed-expert kernel bakes in.
     ACTIVATION_SITU_BETA = 4.0
     ACTIVATION_SITU_LINEAR_BETA = 25.0
 

--- a/models/demos/deepseek_v3_d_p/reference/tt/moe/expert.py
+++ b/models/demos/deepseek_v3_d_p/reference/tt/moe/expert.py
@@ -40,8 +40,10 @@ def apply_glu_activation(
     separate arguments avoids a concat the device path would not do either. Computed in fp32 to match
     upstream, which casts both halves up before the tanh/sigmoid.
 
-    NOTE: no TT kernel implements SiTU yet (issue #51335). ``situ`` exists so the host reference can
-    model the checkpoint faithfully; device comparisons must run ``silu`` on both sides.
+    NOTE: the fused routed-expert kernel implements SiTU on Blackhole
+    (``ttnn.RoutedExpertActivation.SituGlu``, issue #51351); everywhere else -- shared expert,
+    dense FFN, Wormhole -- the device path still runs SiLU, so those comparisons must run
+    ``silu`` on both sides.
     """
     if activation == ACTIVATION_SILU:
         return F.silu(gate_out) * up_out

--- a/models/demos/deepseek_v3_d_p/reference/tt/moe/moe.py
+++ b/models/demos/deepseek_v3_d_p/reference/tt/moe/moe.py
@@ -178,6 +178,7 @@ class TorchMoe(nn.Module):
         activation: str = ACTIVATION_SILU,
         situ_beta: float = 1.0,
         situ_linear_beta: float | None = None,
+        shared_activation: str | None = None,
     ):
         """
         Initialize MinimalMoE with configuration parameters.
@@ -212,9 +213,12 @@ class TorchMoe(nn.Module):
                 num_shared_experts (6144), not at moe_intermediate_size (3072).
             latent_weights: Optional dict with down_proj / up_proj / norm for the latent projections.
             latent_use_norm / rms_norm_eps: latent RMSNorm control (K3: True / 1e-5).
-            activation / situ_beta / situ_linear_beta: GLU activation for both the routed and shared
-                experts. Defaults to "silu", which is also what the device path runs; "situ" models
-                the K3 checkpoint faithfully but has no TT kernel yet (#51335).
+            activation / situ_beta / situ_linear_beta: GLU activation for the ROUTED experts, and
+                for the shared expert unless shared_activation overrides it. Defaults to "silu".
+                Kimi-K3's routed experts run "situ" on device (RoutedExpertActivation.SituGlu).
+            shared_activation: GLU activation for the SHARED expert; defaults to activation. K3 needs
+                the split because its checkpoint uses SiTU for both but the device has a SiTU kernel
+                for the routed expert only, so the shared side must stay on SiLU to compare.
         """
         super().__init__()
 
@@ -304,7 +308,9 @@ class TorchMoe(nn.Module):
 
         # The shared expert stays at emb_dim on the pre-projection input, with its own intermediate.
         use_identity = routed_weights is None
-        act = dict(activation=activation, situ_beta=situ_beta, situ_linear_beta=situ_linear_beta)
+        situ = dict(situ_beta=situ_beta, situ_linear_beta=situ_linear_beta)
+        act = dict(activation=activation, **situ)
+        shared_act = dict(activation=activation if shared_activation is None else shared_activation, **situ)
         self.routed_experts = nn.ModuleList(
             [
                 TorchExpert(
@@ -322,7 +328,7 @@ class TorchMoe(nn.Module):
             self.shared_hidden_dim,
             torch_weights=shared_weights,
             use_identity=use_identity,
-            **act,
+            **shared_act,
         )
 
         # Create reduce module (sums over topk dimension)

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -77,6 +77,13 @@ _TORCH_ROUTED_ACTIVATION = {
     ttnn.RoutedExpertActivation.SituGlu: ACTIVATION_SITU,
 }
 
+# ...and -> the upstream vendored model's hidden_act spelling. None leaves the variant config's own
+# hidden_act alone, which is what every SiLU model wants.
+_UPSTREAM_ACT = {
+    ttnn.RoutedExpertActivation.Silu: None,
+    ttnn.RoutedExpertActivation.SituGlu: "situ",
+}
+
 
 def run_model(
     variant,
@@ -642,6 +649,9 @@ def run_model(
         shared_expert_weights=shared_expert_weights,
         latent_weights=latent_weights,
         x=x,
+        # Same routed/shared split the device runs; see run_reference_moe.
+        hidden_act=_UPSTREAM_ACT[routed_activation],
+        shared_hidden_act="silu" if _UPSTREAM_ACT[routed_activation] is not None else None,
     )
     if ref_out is not None and tt_output is not None:
         logger.info("Running upstream MoE reference")

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -30,7 +30,6 @@ from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.expert import ACTIVATION_SILU, ACTIVATION_SITU
 from models.demos.deepseek_v3_d_p.reference.tt.moe.moe import TorchMoe
 from models.demos.deepseek_v3_d_p.tests.reference_runners import run_reference_moe
-from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import ROUTED_EXPERT_ACTIVATION_BY_NAME
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     ExpertMapping,
     compute_constants,
@@ -46,6 +45,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
 )
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe import TtMoe
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
+from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import ROUTED_EXPERT_ACTIVATION_BY_NAME
 from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
     compare_recall,
     log_combine_mismatch_details,

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -30,6 +30,7 @@ from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
 from models.demos.deepseek_v3_d_p.reference.tt.moe.expert import ACTIVATION_SILU, ACTIVATION_SITU
 from models.demos.deepseek_v3_d_p.reference.tt.moe.moe import TorchMoe
 from models.demos.deepseek_v3_d_p.tests.reference_runners import run_reference_moe
+from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import ROUTED_EXPERT_ACTIVATION_BY_NAME
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
     ExpertMapping,
     compute_constants,
@@ -127,9 +128,10 @@ def run_model(
     torch reference. The shared expert always runs SiLU: no SiTU kernel exists outside the
     routed-expert op, so both sides must stay on SiLU there for the comparison to mean anything.
     """
-    torch_routed_activation = _TORCH_ROUTED_ACTIVATION.get(routed_activation)
-    if torch_routed_activation is None:
+    if routed_activation not in _TORCH_ROUTED_ACTIVATION or routed_activation not in _UPSTREAM_ACT:
         raise ValueError(f"no torch reference for {routed_activation}; supported: {list(_TORCH_ROUTED_ACTIVATION)}")
+    torch_routed_activation = _TORCH_ROUTED_ACTIVATION[routed_activation]
+    upstream_activation = _UPSTREAM_ACT[routed_activation]
 
     # Scoped: only the linear-8 / 64-expert / HOST_ALL / pcc-check case OOMs without this.
     # Cached all-gather semaphores get placed at the wrong offset for that specific config.
@@ -650,8 +652,8 @@ def run_model(
         latent_weights=latent_weights,
         x=x,
         # Same routed/shared split the device runs; see run_reference_moe.
-        hidden_act=_UPSTREAM_ACT[routed_activation],
-        shared_hidden_act="silu" if _UPSTREAM_ACT[routed_activation] is not None else None,
+        hidden_act=upstream_activation,
+        shared_hidden_act="silu" if upstream_activation is not None else None,
     )
     if ref_out is not None and tt_output is not None:
         logger.info("Running upstream MoE reference")
@@ -1026,5 +1028,5 @@ def test_kimi_k3_moe(
         latent_use_norm=KimiK3Config.LATENT_MOE_USE_NORM,
         rms_norm_eps=KimiK3Config.RMS_NORM_EPS,
         final_output_pcc=0.965,
-        routed_activation=ttnn.RoutedExpertActivation.SituGlu,
+        routed_activation=ROUTED_EXPERT_ACTIVATION_BY_NAME[KimiK3Config.ROUTED_EXPERT_ACTIVATION],
     )

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -27,6 +27,7 @@ from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3
 from models.demos.deepseek_v3_d_p.reference.glm_5_2_config import GLM52Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
+from models.demos.deepseek_v3_d_p.reference.tt.moe.expert import ACTIVATION_SILU, ACTIVATION_SITU
 from models.demos.deepseek_v3_d_p.reference.tt.moe.moe import TorchMoe
 from models.demos.deepseek_v3_d_p.tests.reference_runners import run_reference_moe
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
@@ -70,6 +71,13 @@ _MOE_LAYER_IDX = 3
 # dispatch_buffer_capacity_factor below is ceil(N/2) of the most conservative
 # integer N such that dgs*seq*N >= theoretical worst-case dispatch buffer.
 # Real traffic never approaches the worst case, so half-capacity is sufficient.
+# Fused routed-expert activation -> the TorchExpert reference that must match it.
+_TORCH_ROUTED_ACTIVATION = {
+    ttnn.RoutedExpertActivation.Silu: ACTIVATION_SILU,
+    ttnn.RoutedExpertActivation.SituGlu: ACTIVATION_SITU,
+}
+
+
 def run_model(
     variant,
     config,
@@ -93,6 +101,7 @@ def run_model(
     latent_use_norm=True,
     rms_norm_eps=1e-5,
     final_output_pcc=0.982,
+    routed_activation=ttnn.RoutedExpertActivation.Silu,
 ):
     """TtMoe PCC body — shared between `test_ds_moe` / `test_kimi_moe`.
 
@@ -106,7 +115,14 @@ def run_model(
     mismatch on the skipped padded rows, and padded-row correctness is covered by the
     dedicated grouped_topk / routing_setup tests. HOST_ALL gates ignore padding entirely
     (TtMoe falls back to padding_config=None for non-DEVICE_FP32 gates).
+
+    ``routed_activation`` selects the fused routed-expert kernel's activation and the matching
+    torch reference. The shared expert always runs SiLU: no SiTU kernel exists outside the
+    routed-expert op, so both sides must stay on SiLU there for the comparison to mean anything.
     """
+    torch_routed_activation = _TORCH_ROUTED_ACTIVATION.get(routed_activation)
+    if torch_routed_activation is None:
+        raise ValueError(f"no torch reference for {routed_activation}; supported: {list(_TORCH_ROUTED_ACTIVATION)}")
 
     # Scoped: only the linear-8 / 64-expert / HOST_ALL / pcc-check case OOMs without this.
     # Cached all-gather semaphores get placed at the wrong offset for that specific config.
@@ -338,9 +354,12 @@ def run_model(
             latent_weights=latent_weights,
             latent_use_norm=latent_use_norm,
             rms_norm_eps=rms_norm_eps,
-            # SiLU on both sides: the device has no SiTU kernel yet (#51335), and comparing against a
-            # SiTU reference would measure that gap rather than this dataflow.
-            activation="silu",
+            # Routed side matches whatever the fused kernel runs; the shared expert stays on SiLU
+            # (no SiTU kernel outside the routed-expert op).
+            activation=torch_routed_activation,
+            situ_beta=KimiK3Config.ACTIVATION_SITU_BETA,
+            situ_linear_beta=KimiK3Config.ACTIVATION_SITU_LINEAR_BETA,
+            shared_activation=ACTIVATION_SILU,
         )
         profiler.end("torch_moe_creation")
 
@@ -372,6 +391,7 @@ def run_model(
         shared_expert_weights=shared_expert_weights,
         routed_expert_activations_dtype=ttnn.bfloat8_b,
         routed_expert_weights_dtype=ttnn.bfloat4_b,
+        routed_expert_activation=routed_activation,
         shared_expert_activations_dtype=ttnn.bfloat16,
         shared_expert_weights_dtype=ttnn.bfloat8_b,
         gate_weights=gate_weights,
@@ -955,14 +975,13 @@ def test_kimi_k3_moe(
 ):
     """Kimi-K3 MoE: 896 experts / top-16 with the LatentMoE projections around the routed side.
 
-    Two deliberate limits on what this proves, both from the bring-up scope:
+    The routed experts run the checkpoint's SiTU-GLU on device
+    (``RoutedExpertActivation.SituGlu``, #51351), matched by a SiTU torch reference. The SHARED
+    expert stays on SiLU on both sides: the SiTU kernel is the routed-expert op's, and nothing
+    implements it at the shared expert's 6144 width, so holding both sides to SiLU there keeps
+    this a test of the dataflow rather than of a gap the device cannot close.
 
-      * **SiLU, not SiTU.** No TT kernel implements SiTU-GLU yet (issue #51335), so both the device and
-        the torch reference run SiLU. That keeps this an honest test of the dataflow -- dispatch and
-        combine at 896/top-16, the latent down/up projections, the latent RMSNorm, and the
-        routed/shared dimension split -- rather than a measurement of the missing activation. SiTU
-        itself is validated host-side against upstream ``KimiSparseMoeBlock`` in
-        ``tests/torch/test_moe_reference_comparison.py::test_kimi_k3_latent_moe_reference_pcc``.
+    One deliberate limit remains from the bring-up scope:
 
       * **Seeded random weights, not the checkpoint.** Everything routed is MXFP4 and no dequantizer
         exists yet, so device-vs-torch parity is checked on identical seeded weights. That is the same
@@ -997,4 +1016,5 @@ def test_kimi_k3_moe(
         latent_use_norm=KimiK3Config.LATENT_MOE_USE_NORM,
         rms_norm_eps=KimiK3Config.RMS_NORM_EPS,
         final_output_pcc=0.965,
+        routed_activation=ttnn.RoutedExpertActivation.SituGlu,
     )

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
@@ -107,9 +107,8 @@ _CMD_K3_8X4 = f"pytest {_K3_TEST_PATH} -k 'fabric2d-mesh-8x4 and kimi_k3-5k-perf
 @pytest.mark.timeout(0)
 def test_kimi_k3_moe_perf_galaxy():
     """
-    Measures the SiLU path, not the checkpoint's SiTU-GLU (#51335), so this baseline moves when that
-    kernel lands. MoE_START/MoE_END bracket the forward only -- the constructor's one-time weight
-    tilize/typecast is a large share of wall time at 896 experts, but is not per-token cost.
+    MoE_START/MoE_END bracket the forward only -- the constructor's one-time weight tilize/typecast
+    is a large share of wall time at 896 experts, but is not per-token cost.
     """
     if not _is_galaxy_env():
         pytest.skip("This test requires 8x4 mesh - galaxy. (set MESH_DEVICE=TG)")

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
@@ -109,6 +109,14 @@ def test_kimi_k3_moe_perf_galaxy():
     """
     MoE_START/MoE_END bracket the forward only -- the constructor's one-time weight tilize/typecast
     is a large share of wall time at 896 experts, but is not per-token cost.
+
+    NOTE: this gate does not currently execute anywhere -- see #53612. Its blaze entry does not
+    export MESH_DEVICE, so _is_galaxy_env() is false and the test skips itself, and the blaze
+    pipeline builds without tracy, so run_model_device_perf_test_with_merge could not profile even
+    if it did run. The baseline below is therefore a hand measurement, taken on the SiLU path before
+    #51351 moved K3's routed experts to SiTU-GLU, and it has never been checked by CI. Expect it to
+    move once the gate runs: the routed expert is ~79% of MoE device kernel time and costs ~14% more
+    under SiTU-GLU at these token counts.
     """
     if not _is_galaxy_env():
         pytest.skip("This test requires 8x4 mesh - galaxy. (set MESH_DEVICE=TG)")
@@ -127,5 +135,5 @@ def test_kimi_k3_moe_perf_galaxy():
         batch_size=1,
         margin=margin,
         between_signposts=("MoE_START", "MoE_END"),
-        comments="seq640_5k_isl_glx_8x4_fabric2d_ground_truth_latent_moe_silu",
+        comments="seq640_5k_isl_glx_8x4_fabric2d_ground_truth_latent_moe_situ",
     )

--- a/models/demos/deepseek_v3_d_p/tests/reference_runners.py
+++ b/models/demos/deepseek_v3_d_p/tests/reference_runners.py
@@ -15,7 +15,6 @@ from copy import copy, deepcopy
 from typing import Optional
 
 import torch
-
 from transformers.activations import ACT2FN
 
 from models.demos.common.prefill.adapter import PrefillModelAdapter as TestVariant

--- a/models/demos/deepseek_v3_d_p/tests/reference_runners.py
+++ b/models/demos/deepseek_v3_d_p/tests/reference_runners.py
@@ -11,10 +11,12 @@ bundled reference return `None` and the comparison is skipped at the call
 site.
 """
 
-from copy import deepcopy
+from copy import copy, deepcopy
 from typing import Optional
 
 import torch
+
+from transformers.activations import ACT2FN
 
 from models.demos.common.prefill.adapter import PrefillModelAdapter as TestVariant
 
@@ -28,8 +30,17 @@ def run_reference_moe(
     shared_expert_weights,
     x,
     latent_weights=None,
+    hidden_act: Optional[str] = None,
+    shared_hidden_act: Optional[str] = None,
 ) -> Optional[torch.Tensor]:
-    """Forward the variant's upstream MoE reference on CPU."""
+    """Forward the variant's upstream MoE reference on CPU.
+
+    ``hidden_act`` overrides the config's GLU activation; ``shared_hidden_act`` overrides it for the
+    shared expert alone. The upstream block picks one activation for routed and shared alike, but a
+    device may implement the two halves differently (Kimi-K3: SiTU-GLU in the fused routed-expert
+    kernel, SiLU for the shared expert), and this reference is only a fair cross-check if it splits
+    the same way.
+    """
     if variant.reference_moe_cls is None:
         return None
     # Test params can override the variant's default MoE dims (expert count, hidden/intermediate size —
@@ -47,7 +58,18 @@ def run_reference_moe(
         # Kimi-K3's routed experts read the latent width, not hidden_size.
         if getattr(cfg, "routed_expert_hidden_size", None) is not None:
             cfg.routed_expert_hidden_size = routed_expert_weights[0]["gate_proj"].shape[1]
+    if hidden_act is not None:
+        cfg.hidden_act = hidden_act
     moe = variant.reference_moe_cls(cfg)
+    # The shared expert reads hidden_act off the config object it was handed, so giving it a copy
+    # with a different activation retargets that half only.
+    if shared_hidden_act is not None and shared_hidden_act != cfg.hidden_act:
+        shared = getattr(moe, "shared_experts", None)
+        assert shared is not None, "shared_hidden_act was given but the reference has no shared expert"
+        shared_cfg = copy(cfg)
+        shared_cfg.hidden_act = shared_hidden_act
+        shared.config = shared_cfg
+        shared.act_fn = ACT2FN[shared_hidden_act]
     moe.load_state_dict(
         _pack_reference_moe_state_dict(moe, gate_weights, routed_expert_weights, shared_expert_weights, latent_weights),
         strict=True,

--- a/models/demos/deepseek_v3_d_p/tests/reference_runners.py
+++ b/models/demos/deepseek_v3_d_p/tests/reference_runners.py
@@ -20,6 +20,23 @@ from transformers.activations import ACT2FN
 from models.demos.common.prefill.adapter import PrefillModelAdapter as TestVariant
 
 
+def _build_act_fn(cfg):
+    """The activation an upstream MLP would build for this config.
+
+    Mirrors KimiMLP/KimiBlockSparseMLP rather than going straight to ACT2FN, which has no "situ"
+    entry -- so the override below can name either activation for either half.
+    """
+    if getattr(cfg, "hidden_act", None) == "situ":
+        from models.demos.deepseek_v3_d_p.reference.kimi_k3.modeling_kimi_moe import (
+            SituAndMul,
+            _get_situ_activation_params,
+        )
+
+        beta, linear_beta = _get_situ_activation_params(cfg)
+        return SituAndMul(beta=beta, linear_beta=linear_beta)
+    return ACT2FN[cfg.hidden_act]
+
+
 def run_reference_moe(
     variant: TestVariant,
     *,
@@ -68,7 +85,7 @@ def run_reference_moe(
         shared_cfg = copy(cfg)
         shared_cfg.hidden_act = shared_hidden_act
         shared.config = shared_cfg
-        shared.act_fn = ACT2FN[shared_hidden_act]
+        shared.act_fn = _build_act_fn(shared_cfg)
     moe.load_state_dict(
         _pack_reference_moe_state_dict(moe, gate_weights, routed_expert_weights, shared_expert_weights, latent_weights),
         strict=True,

--- a/models/demos/deepseek_v3_d_p/tests/torch/test_moe_reference_comparison.py
+++ b/models/demos/deepseek_v3_d_p/tests/torch/test_moe_reference_comparison.py
@@ -488,7 +488,7 @@ def _tt_moe_from_kimi_block(blk, cfg, *, seq_len, dispatch_group_size, capacity_
     [
         # The checkpoint's real combination.
         ("situ", True),
-        # What the device runs until #51335 lands a SiTU kernel.
+        # What the device still runs outside the routed experts (shared expert, dense FFN).
         ("silu", True),
         # Upstream's own default, even though K3's checkpoint sets it true.
         ("situ", False),
@@ -508,9 +508,10 @@ def test_kimi_k3_latent_moe_reference_pcc(activation, latent_use_norm):
     the dataflow under test from any gate-implementation difference -- gate parity is covered by the
     device-side gate tests.
 
-    Both activations are exercised: ``situ`` is what the checkpoint actually does, and ``silu`` is
-    what the device runs until #51335 lands a SiTU kernel. Testing both means the SiLU path the
-    device is compared against is itself validated against upstream, not just assumed.
+    Both activations are exercised: ``situ`` is what the checkpoint does and what the routed experts
+    now run on device (#51351), and ``silu`` is what the shared expert and the dense FFN still run,
+    having no SiTU kernel at their widths. Testing both means each half of that split is validated
+    against upstream rather than assumed.
     """
     torch.manual_seed(42)
 

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -199,6 +199,7 @@ class TtMoe(LightweightModule):
         shared_expert_weights: dict = None,
         routed_expert_activations_dtype=ttnn.bfloat8_b,
         routed_expert_weights_dtype=ttnn.bfloat4_b,
+        routed_expert_activation=ttnn.RoutedExpertActivation.Silu,
         shared_expert_activations_dtype=ttnn.bfloat16,
         shared_expert_weights_dtype=ttnn.bfloat8_b,
         gate_fallback_mode: GateComputeMode = GateComputeMode.HOST_ALL,
@@ -267,6 +268,9 @@ class TtMoe(LightweightModule):
                 (K3: latent_moe_use_norm=True).
             rms_norm_eps: eps for that latent norm. Passed explicitly because
                 TtDistributedRmsNorm defaults to 1e-6 while K3's config says 1e-5.
+            routed_expert_activation: GLU activation the fused routed-expert kernel runs.
+                Defaults to SiLU (DeepSeek / K2.6 / GLM). Kimi-K3 passes SituGlu. Routed only:
+                the shared expert and the dense FFN have no SiTU kernel and stay on SiLU.
         """
         super().__init__()
         self.mesh_device = mesh_device
@@ -482,7 +486,7 @@ class TtMoe(LightweightModule):
             weights_dtype=routed_expert_weights_dtype,
             weight_cache_path=weight_cache_path,
             cache_name_prefix=f"layer_{layer_idx}.routed_expert",
-            activation=ttnn.RoutedExpertActivation.Silu,
+            activation=routed_expert_activation,
         )
 
         # Initialize shared expert (col axis: axis 1)

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
@@ -24,6 +24,13 @@ from models.common.lightweightmodule import LightweightModule
 from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import ExpertMapping
 
+# Activations whose fused kernel path carries the bias branch (gate/up bias before the
+# activation, down bias after the down matmul). SiLU has no bias branch.
+_BIAS_CAPABLE_ACTIVATIONS = (
+    ttnn.RoutedExpertActivation.SwiGluOai,
+    ttnn.RoutedExpertActivation.SituGlu,
+)
+
 COMPUTE_KERNEL_CONFIG_LOFI = ttnn.WormholeComputeKernelConfig(
     math_fidelity=ttnn.MathFidelity.LoFi,
     math_approx_mode=False,
@@ -282,9 +289,10 @@ class TtRoutedExpert(LightweightModule):
                           global ids. Required.
             activation: Required ttnn.RoutedExpertActivation selecting the fused kernel's
                           activation. Pass RoutedExpertActivation.Silu for the DeepSeek path
-                          (byte-identical) or RoutedExpertActivation.SwiGluOai for the
-                          MiniMax-M3 / gpt-oss clamped swigluoai activation. Keyword-only and
-                          without a default so the caller must choose explicitly.
+                          (byte-identical), RoutedExpertActivation.SwiGluOai for the
+                          MiniMax-M3 / gpt-oss clamped swigluoai activation, or
+                          RoutedExpertActivation.SituGlu for Kimi K3's SiTU-GLU. Keyword-only
+                          and without a default so the caller must choose explicitly.
         """
         super().__init__()
         self.mesh_device = mesh_device
@@ -302,20 +310,33 @@ class TtRoutedExpert(LightweightModule):
         # Activation variant for the fused unified_routed_expert_moe kernel.
         # Required RoutedExpertActivation, chosen explicitly by the caller (no
         # silent default): pass ttnn.RoutedExpertActivation.Silu for the DeepSeek
-        # path (byte-identical) or .SwiGluOai for the MiniMax-M3 / gpt-oss clamped
-        # swigluoai activation. Enforcing presence avoids silently running the
-        # wrong activation when a caller forgets to set it.
+        # path (byte-identical), .SwiGluOai for the MiniMax-M3 / gpt-oss clamped
+        # swigluoai activation, or .SituGlu for Kimi K3's SiTU-GLU. Enforcing presence
+        # avoids silently running the wrong activation when a caller forgets to set it.
         if activation is None:
             raise ValueError(
-                "TtRoutedExpert requires an explicit `activation` (ttnn.RoutedExpertActivation.Silu or .SwiGluOai)"
+                "TtRoutedExpert requires an explicit `activation` "
+                "(ttnn.RoutedExpertActivation.Silu, .SwiGluOai or .SituGlu)"
             )
         self.activation = activation
 
-        # Optional per-expert projection biases (gpt-oss). Only supported with
-        # SwiGluOai (the kernel adds gate/up bias before the clamp and down bias
+        # Every non-SiLU activation lives in the fused Blackhole kernel only; the Wormhole
+        # fallback in forward() calls routed_expert_ffn, which has no activation parameter and
+        # always computes SiLU. Reject here rather than silently returning SiLU output.
+        if activation != ttnn.RoutedExpertActivation.Silu and not is_blackhole():
+            raise NotImplementedError(
+                f"TtRoutedExpert {activation} is only supported on the Blackhole fused path; "
+                "the fallback path computes SiLU"
+            )
+
+        # Optional per-expert projection biases (gpt-oss). Supported by any fused binary
+        # activation (the kernel adds gate/up bias before the activation and down bias
         # after the down matmul). Converted + distributed like the weights below.
-        if torch_biases is not None and activation != ttnn.RoutedExpertActivation.SwiGluOai:
-            raise ValueError("TtRoutedExpert expert biases are only supported with RoutedExpertActivation.SwiGluOai")
+        if torch_biases is not None and activation not in _BIAS_CAPABLE_ACTIVATIONS:
+            raise ValueError(
+                "TtRoutedExpert expert biases require a fused binary activation "
+                "(RoutedExpertActivation.SwiGluOai or .SituGlu); the SiLU path has no bias branch."
+            )
 
         total_experts = self.num_devices * experts_per_chip
         logger.debug(f"Initializing TtRoutedExpert with experts_per_chip={experts_per_chip}")

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_routed_expert.py
@@ -24,6 +24,14 @@ from models.common.lightweightmodule import LightweightModule
 from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import ExpertMapping
 
+# Model configs are torch-only and so name their activation as a string; this is the one place
+# that maps those names onto the kernel enum. Keys match the HF ``hidden_act`` spelling.
+ROUTED_EXPERT_ACTIVATION_BY_NAME = {
+    "silu": ttnn.RoutedExpertActivation.Silu,
+    "swiglu_oai": ttnn.RoutedExpertActivation.SwiGluOai,
+    "situ": ttnn.RoutedExpertActivation.SituGlu,
+}
+
 # Activations whose fused kernel path carries the bias branch (gate/up bias before the
 # activation, down bias after the down matmul). SiLU has no bias branch.
 _BIAS_CAPABLE_ACTIVATIONS = (

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k3.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k3.py
@@ -88,9 +88,10 @@ class KimiK3Adapter(MLAPrefillAdapter):
     def reference_moe_cls(self):
         """K3's MoE block: DeepSeek-V3's, wrapped in the shared low-rank latent projection pair.
 
-        Note this reference computes **SiTU-GLU**, which no TT kernel implements yet (#51335). It is
-        therefore the truth model for the host-side latent-structure test, not for device PCC -- the
-        device runs SiLU, so device comparisons must use a SiLU-configured reference on both sides.
+        The block applies one activation to routed and shared experts alike, while the device has a
+        SiTU-GLU kernel for the routed expert only (#51351). ``run_reference_moe`` therefore builds
+        it with hidden_act="situ" and pins the shared half back to SiLU, so both sides of a device
+        comparison split the same way.
         """
         from models.demos.deepseek_v3_d_p.reference.kimi_k3.modeling_kimi_moe import KimiSparseMoeBlock
 

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k3.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k3.py
@@ -66,10 +66,14 @@ class KimiK3Adapter(MLAPrefillAdapter):
 
     # Device vs upstream KimiSparseMoeBlock. Held at test_kimi_k3_moe's final_output_pcc: the two
     # compare the same device tensor against references that agree to 1.7e-5, so they measure the
-    # same thing and cannot carry different bars. The old 0.99 was measured on 2x4 (0.995692) and
-    # does not transfer -- 8x4 spreads 896 experts over 32 chips instead of 8, so the top-16 combine
-    # accumulates across 4x as many chips in the bf8 latent space, and both checks land together at
-    # 0.9694 (reference 0.969434, final_output 0.969454). 0.965 keeps the usual ~0.005 of margin.
+    # same thing and cannot carry different bars. The 8x4 value is 0.9694 (reference 0.969434,
+    # final_output 0.969454) -- 8x4 spreads 896 experts over 32 chips instead of 8, so the top-16
+    # combine accumulates across 4x as many chips in the bf8 latent space than on the 2x4 proxy
+    # (0.995693). 0.965 keeps the usual ~0.005 of margin.
+    #
+    # Moving the routed experts onto SiTU-GLU did not move either figure: 2x4 measures 0.995693
+    # against 0.995692 before. K3's realistic activations sit well inside both tanh caps, so the
+    # bf4 accuracy cost that _K3_SATURATION_CASES documents does not arise at these scales.
     moe_pcc_threshold = 0.965
 
     @property

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k3.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k3.py
@@ -65,15 +65,16 @@ class KimiK3Adapter(MLAPrefillAdapter):
     shared_path = None
 
     # Device vs upstream KimiSparseMoeBlock. Held at test_kimi_k3_moe's final_output_pcc: the two
-    # compare the same device tensor against references that agree to 1.7e-5, so they measure the
-    # same thing and cannot carry different bars. The 8x4 value is 0.9694 (reference 0.969434,
-    # final_output 0.969454) -- 8x4 spreads 896 experts over 32 chips instead of 8, so the top-16
+    # compare the same device tensor against references that agree to 2e-5, so they measure the same
+    # thing and cannot carry different bars. The 8x4 value is 0.9696 (reference 0.969567,
+    # final_output 0.969585) -- 8x4 spreads 896 experts over 32 chips instead of 8, so the top-16
     # combine accumulates across 4x as many chips in the bf8 latent space than on the 2x4 proxy
     # (0.995693). 0.965 keeps the usual ~0.005 of margin.
     #
-    # Moving the routed experts onto SiTU-GLU did not move either figure: 2x4 measures 0.995693
-    # against 0.995692 before. K3's realistic activations sit well inside both tanh caps, so the
-    # bf4 accuracy cost that _K3_SATURATION_CASES documents does not arise at these scales.
+    # Moving the routed experts onto SiTU-GLU did not cost anything here: 8x4 went 0.969434 ->
+    # 0.969567 and 2x4 0.995692 -> 0.995693. K3's realistic activations sit well inside both tanh
+    # caps, so the bf4 accuracy cost that _K3_SATURATION_CASES documents does not arise at these
+    # scales.
     moe_pcc_threshold = 0.965
 
     @property

--- a/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k3.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/adapters/kimi_k3.py
@@ -18,8 +18,9 @@ and ``allocate_kv_cache`` are inherited but would size the KV cache to ``params.
 is wrong for 24-of-93; they are overridden to fail loudly rather than mislead.
 
 MoE scope (issue #51336): the latent-MoE structure -- routed experts at the reduced 3584 hidden,
-896 experts / top-16, a latent RMSNorm, and one shared expert at 6144. Two deliberate limits:
-  * the device path runs **SiLU**, not the checkpoint's SiTU-GLU, until the kernel in #51335 lands;
+896 experts / top-16, a latent RMSNorm, and one shared expert at 6144. The routed experts run the
+checkpoint's **SiTU-GLU** on device (#51351); the shared expert and the dense FFN still run SiLU,
+having no SiTU kernel at their widths. One deliberate limit remains:
   * only the **gate** uses real checkpoint weights. Experts, shared expert and the latent
     projections use seeded random weights, because everything routed is MXFP4 and no dequantizer
     exists yet. Device PCC is therefore TT-vs-torch on identical seeded weights.

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -15,6 +15,7 @@ from models.common.lightweightmodule import LightweightModule
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import compute_constants, extract_mesh_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe import TtMoe
+from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import ROUTED_EXPERT_ACTIVATION_BY_NAME
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
 from models.demos.deepseek_v3_d_p.tt.tt_ffn import TtFfn
@@ -453,6 +454,10 @@ class TtPrefillBlock(LightweightModule):
             shared_expert_weights=state_dict.get("shared_expert_weights"),  # None if cache exists
             routed_expert_activations_dtype=routed_expert_activations_dtype,
             routed_expert_weights_dtype=routed_expert_weights_dtype,
+            # Kimi-K3 is the only config that names one; everything else defaults to SiLU.
+            routed_expert_activation=ROUTED_EXPERT_ACTIVATION_BY_NAME[
+                getattr(model_cfg, "ROUTED_EXPERT_ACTIVATION", "silu")
+            ],
             shared_expert_activations_dtype=shared_expert_activations_dtype,
             shared_expert_weights_dtype=shared_expert_weights_dtype,
             gate_weights=state_dict.get("gate_weights"),  # None if cache exists

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -15,8 +15,8 @@ from models.common.lightweightmodule import LightweightModule
 from models.demos.deepseek_v3_d_p.tt.mla import ttMLA
 from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import compute_constants, extract_mesh_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe import TtMoe
-from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import ROUTED_EXPERT_ACTIVATION_BY_NAME
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
+from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import ROUTED_EXPERT_ACTIVATION_BY_NAME
 from models.demos.deepseek_v3_d_p.tt.tt_distributed_rms_norm import TtDistributedRmsNorm
 from models.demos.deepseek_v3_d_p.tt.tt_ffn import TtFfn
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import MlaKvCache, MlaKvCacheFormat

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_routed_expert_bias.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_routed_expert_bias.py
@@ -38,6 +38,8 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
+from models.demos.deepseek_v3_d_p.reference.tt.moe.expert import ACTIVATION_SITU, apply_glu_activation
 from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import TtRoutedExpert
 from tests.ttnn.utils_for_testing import comp_pcc
 
@@ -65,8 +67,32 @@ def _torch_swigluoai_expert_with_bias(x, w, b, alpha=SWIGLU_ALPHA, limit=SWIGLU_
     return F.linear(activated, w["down_proj"], b["down_proj_bias"])
 
 
-def run_bias_routed_expert(mesh_device, num_tokens, emb_dim, hidden_dim):
-    """1 chip, 1 expert. Compares the fused op (SwiGLU-OAI + biases) vs a torch reference."""
+def _torch_situglu_expert_with_bias(x, w, b):
+    """SiTU-GLU FFN WITH gate/up/down biases (Kimi K3), fp32. Weights HF (out, in)."""
+    gate = F.linear(x, w["gate_proj"], b["gate_proj_bias"])
+    up = F.linear(x, w["up_proj"], b["up_proj_bias"])
+    activated = apply_glu_activation(
+        gate,
+        up,
+        activation=ACTIVATION_SITU,
+        situ_beta=KimiK3Config.ACTIVATION_SITU_BETA,
+        situ_linear_beta=KimiK3Config.ACTIVATION_SITU_LINEAR_BETA,
+    )
+    return F.linear(activated, w["down_proj"], b["down_proj_bias"])
+
+
+# Bias-capable activation -> its torch reference. The kernel's bias branch lives in the
+# shared binary-activation phase, so every fused binary activation supports biases.
+_BIAS_REFERENCE = {
+    ttnn.RoutedExpertActivation.SwiGluOai: _torch_swigluoai_expert_with_bias,
+    ttnn.RoutedExpertActivation.SituGlu: _torch_situglu_expert_with_bias,
+}
+
+
+def run_bias_routed_expert(
+    mesh_device, num_tokens, emb_dim, hidden_dim, activation=ttnn.RoutedExpertActivation.SwiGluOai
+):
+    """1 chip, 1 expert. Compares the fused op (activation + biases) vs a torch reference."""
     torch.manual_seed(42)
 
     weights = {
@@ -83,8 +109,11 @@ def run_bias_routed_expert(mesh_device, num_tokens, emb_dim, hidden_dim):
     }
 
     torch_input = torch.randn(num_tokens, emb_dim, dtype=torch.float32)
+    reference = _BIAS_REFERENCE.get(activation)
+    if reference is None:
+        raise ValueError(f"no bias reference for {activation}; supported: {list(_BIAS_REFERENCE)}")
     with torch.no_grad():
-        torch_output = _torch_swigluoai_expert_with_bias(torch_input, weights, biases)
+        torch_output = reference(torch_input, weights, biases)
 
     tt_input = ttnn.from_torch(
         torch_input,
@@ -116,7 +145,7 @@ def run_bias_routed_expert(mesh_device, num_tokens, emb_dim, hidden_dim):
         torch_biases=[biases],  # PROPOSED — bias support is the subject of this PR
         activations_dtype=ttnn.bfloat8_b,
         weights_dtype=ttnn.bfloat4_b,
-        activation=ttnn.RoutedExpertActivation.SwiGluOai,
+        activation=activation,
     )
 
     tt_output = tt_expert(tt_input, _idx([num_tokens]), _idx([0]))
@@ -126,7 +155,7 @@ def run_bias_routed_expert(mesh_device, num_tokens, emb_dim, hidden_dim):
     )[:num_tokens]
 
     passing, pcc = comp_pcc(torch_output, tt_output_torch, 0.97)
-    logger.info(f"bias routed expert num_tokens={num_tokens}: PCC={pcc}")
+    logger.info(f"bias routed expert {activation} num_tokens={num_tokens}: PCC={pcc}")
     assert not torch.isnan(tt_output_torch).any(), "Output contains NaN"
     assert not torch.isinf(tt_output_torch).any(), "Output contains Inf"
     assert passing, f"PCC below threshold: {pcc}"
@@ -140,6 +169,27 @@ def run_bias_routed_expert(mesh_device, num_tokens, emb_dim, hidden_dim):
 def test_gptoss_bias_routed_expert(mesh_device, device_params, num_tokens):
     """gpt-oss expert biases (gate/up/down) + SwiGLU-OAI vs torch. SPEC — skipped until kernel support lands."""
     run_bias_routed_expert(mesh_device, num_tokens=num_tokens, emb_dim=GPT_OSS_EMB, hidden_dim=GPT_OSS_HIDDEN)
+
+
+@pytest.mark.skipif(not is_blackhole(), reason="SiTU-GLU routed expert is Blackhole-only")
+@pytest.mark.parametrize("num_tokens", [128, 1024], ids=["t128", "t1k"])
+@pytest.mark.parametrize(
+    "mesh_device, device_params", SINGLE_CHIP_MESH_PARAMS, indirect=["mesh_device", "device_params"]
+)
+def test_situglu_bias_routed_expert(mesh_device, device_params, num_tokens):
+    """Expert biases + SiTU-GLU at Kimi K3 routed-expert dims.
+
+    The kernel's bias branch sits inside the shared binary-activation phase, so it applies to
+    SiTU-GLU as much as to SwiGLU-OAI; the host validation permits both. This covers the
+    SiTU-GLU half so that permission is backed by a measurement rather than by inspection.
+    """
+    run_bias_routed_expert(
+        mesh_device,
+        num_tokens=num_tokens,
+        emb_dim=KimiK3Config.ROUTED_EXPERT_HIDDEN_SIZE,
+        hidden_dim=KimiK3Config.MOE_INTERMEDIATE_SIZE,
+        activation=ttnn.RoutedExpertActivation.SituGlu,
+    )
 
 
 # Multiple experts on ONE chip. Different real token count per expert (all multiples of TILE=32,

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
@@ -21,8 +21,9 @@ from models.demos.deepseek_v3_d_p.reference.deepseek_v4_pro_config import DeepSe
 from models.demos.deepseek_v3_d_p.reference.glm_5_1_config import GLM51Config
 from models.demos.deepseek_v3_d_p.reference.gpt_oss_120b_config import GptOss120BConfig
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
 from models.demos.deepseek_v3_d_p.reference.minimax_m2_7_config import MiniMaxM27Config
-from models.demos.deepseek_v3_d_p.reference.tt.moe.expert import TorchExpert
+from models.demos.deepseek_v3_d_p.reference.tt.moe.expert import ACTIVATION_SILU, ACTIVATION_SITU, TorchExpert
 from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import TtRoutedExpert
 from tests.ttnn.utils_for_testing import comp_pcc
 
@@ -35,6 +36,19 @@ SINGLE_CHIP_MESH_PARAMS = [
     ),
 ]
 
+# Device activation -> the TorchExpert reference that must match it. Keeping the pairing
+# in one place stops a case from measuring one activation against another's golden.
+# SwiGluOai is absent on purpose: its reference lives in test_swigluoai_routed_expert.py.
+_TORCH_ACTIVATION = {
+    ttnn.RoutedExpertActivation.Silu: ACTIVATION_SILU,
+    ttnn.RoutedExpertActivation.SituGlu: ACTIVATION_SITU,
+}
+
+# Kimi K3 SiTU-GLU betas. The device kernel bakes SituGluConfigKimi; these must match it,
+# or the reference silently grades against a different activation.
+_SITU_BETA_GATE = KimiK3Config.ACTIVATION_SITU_BETA
+_SITU_BETA_UP = KimiK3Config.ACTIVATION_SITU_LINEAR_BETA
+
 
 def run_single_routed_expert(
     device,
@@ -43,6 +57,11 @@ def run_single_routed_expert(
     hidden_dim: int,
     active_tokens: int = None,
     x_row_major: bool = False,
+    activation=None,
+    weight_scale: float = 0.02,
+    weights_dtype=ttnn.bfloat4_b,
+    pcc_threshold: float = 0.97,
+    min_cap_frac: tuple[float, float] | None = None,
 ):
     """
     Simplest scenario: 1 chip, 1 expert. Shared body for the per-model entrypoints below — they
@@ -55,12 +74,38 @@ def run_single_routed_expert(
     count-aware sparsity: the kernel must (a) produce correct output on the active slice and
     (b) not do matmuls on the inactive padding rows. The ROW_MAJOR variant additionally drives
     the reader's clamp-read of the inactive rows past the runtime count.
+
+    ``activation`` selects the fused kernel's activation and the matching torch reference;
+    it defaults to SiLU (the DeepSeek path all pre-existing cases measure).
+
+    ``weight_scale`` sets the gate/up/down init std. The default keeps the gate/up matmul
+    outputs near O(1); raising it pushes them into the saturating region of the tanh-capped
+    activations, which is the only way a SiTU-GLU case actually exercises the caps rather
+    than their near-linear middle.
+
+    ``weights_dtype`` defaults to the production bfloat4_b; ``pcc_threshold`` defaults to
+    the usual 0.97. Both are parameters because saturating a capped activation costs
+    accuracy under bf4 specifically: saturation turns the output nearly two-level, so bf4
+    weight error stops passing through proportionally and instead flips whole terms of the
+    down matmul. That is a property of bf4 + saturation rather than of the kernel (SiTU-GLU
+    holds ~0.999 at every scale with bf8/bf16 weights, and the SFPU op passes its own
+    saturation-coverage test), so a saturated bf4 case needs its own bar to stay meaningful.
+
+    ``min_cap_frac`` is a ``(gate, up)`` pair of minimum fractions of activation inputs that
+    must land past their respective beta. Set it on any case whose point is the saturated
+    region: without it, a change to ``weight_scale``, the dims or the seed would quietly drop
+    the case back into the near-linear middle of both tanhs while still passing.
     """
     if active_tokens is None:
         active_tokens = allocated_tokens
+    if activation is None:
+        activation = ttnn.RoutedExpertActivation.Silu
+    torch_activation = _TORCH_ACTIVATION.get(activation)
+    if torch_activation is None:
+        raise ValueError(f"no torch reference for {activation}; supported: {list(_TORCH_ACTIVATION)}")
     experts_per_chip = 1
 
-    signpost(f"SingleRoutedExpert {allocated_tokens=} {active_tokens=} {emb_dim=} {hidden_dim=}")
+    signpost(f"SingleRoutedExpert {allocated_tokens=} {active_tokens=} {emb_dim=} {hidden_dim=} {activation=}")
 
     logger.debug(f"Testing single routed expert: {allocated_tokens=}, {active_tokens=}, {emb_dim=}, {hidden_dim=}")
     logger.debug(f"Mesh: {device.shape}, num_devices={device.get_num_devices()}")
@@ -68,13 +113,20 @@ def run_single_routed_expert(
     # Create random weights
     torch.manual_seed(42)
     weights = {
-        "gate_proj": torch.randn(hidden_dim, emb_dim, dtype=torch.float32) * 0.02,
-        "up_proj": torch.randn(hidden_dim, emb_dim, dtype=torch.float32) * 0.02,
-        "down_proj": torch.randn(emb_dim, hidden_dim, dtype=torch.float32) * 0.02,
+        "gate_proj": torch.randn(hidden_dim, emb_dim, dtype=torch.float32) * weight_scale,
+        "up_proj": torch.randn(hidden_dim, emb_dim, dtype=torch.float32) * weight_scale,
+        "down_proj": torch.randn(emb_dim, hidden_dim, dtype=torch.float32) * weight_scale,
     }
 
     # Create torch reference
-    torch_expert = TorchExpert(emb_dim, hidden_dim, weights)
+    torch_expert = TorchExpert(
+        emb_dim,
+        hidden_dim,
+        weights,
+        activation=torch_activation,
+        situ_beta=_SITU_BETA_GATE,
+        situ_linear_beta=_SITU_BETA_UP,
+    )
 
     # 2D input (allocated_tokens, emb_dim) — the single expert's dispatch buffer. The first
     # active_tokens rows hold real data; the rest is zero padding (a no-op when active==allocated).
@@ -87,6 +139,21 @@ def run_single_routed_expert(
     logger.debug("Running torch reference...")
     with torch.no_grad():
         torch_output_active = torch_expert(torch_active)
+        if torch_activation == ACTIVATION_SITU:
+            # How far into each tanh cap the inputs actually reach. Asserted below for the
+            # saturation cases, so one of those can't silently degrade into a near-linear run.
+            gate_out = torch.nn.functional.linear(torch_active, weights["gate_proj"])
+            up_out = torch.nn.functional.linear(torch_active, weights["up_proj"])
+            gate_frac = (gate_out.abs() > _SITU_BETA_GATE).float().mean().item()
+            up_frac = (up_out.abs() > _SITU_BETA_UP).float().mean().item()
+            logger.info(
+                f"SiTU-GLU cap coverage: |gate|>{_SITU_BETA_GATE}: {gate_frac:.1%}, "
+                f"|up|>{_SITU_BETA_UP}: {up_frac:.1%}"
+            )
+            if min_cap_frac is not None:
+                gate_min, up_min = min_cap_frac
+                assert gate_frac >= gate_min, f"gate cap coverage {gate_frac:.1%} below {gate_min:.1%}"
+                assert up_frac >= up_min, f"up cap coverage {up_frac:.1%} below {up_min:.1%}"
     logger.debug(f"Torch output shape: {torch_output_active.shape}")
 
     # Create TTNN input: 2D (allocated_tokens, emb_dim), replicated across the 1-device mesh.
@@ -129,8 +196,8 @@ def run_single_routed_expert(
         max_tokens=allocated_tokens,
         torch_weights=[weights],  # List with single expert weights
         activations_dtype=ttnn.bfloat8_b,
-        weights_dtype=ttnn.bfloat4_b,
-        activation=ttnn.RoutedExpertActivation.Silu,
+        weights_dtype=weights_dtype,
+        activation=activation,
     )
 
     # Run TTNN forward
@@ -152,7 +219,6 @@ def run_single_routed_expert(
     logger.debug(f"PCC over active slice ({active_tokens} rows): {pcc:.6f}")
 
     # Validate
-    pcc_threshold = 0.97
     assert pcc >= pcc_threshold, f"PCC {pcc:.6f} below threshold {pcc_threshold}"
     assert not torch.isnan(tt_output_active).any(), "Active output contains NaN"
     assert not torch.isinf(tt_output_active).any(), "Active output contains Inf"
@@ -172,6 +238,9 @@ SINGLE_EXPERT_MODELS = [
     ("gptoss_120b", GptOss120BConfig, True),
     ("kimi_k26", KimiK26Config, True),
 ]
+# Kimi K3 is deliberately absent: _isl_params below takes config.EMB_SIZE as the routed-expert K
+# axis, which holds only for models with no pre-projection. K3's LatentMoE projects 7168 -> 3584
+# first, so adding it here would silently run it at 2x its real K. Its sweeps are below instead.
 
 
 # Registry of currently-failing single-routed-expert cases -> xfail reason (with tracking issue), so
@@ -277,4 +346,88 @@ def test_single_routed_expert_isl_sweep(
         hidden_dim,
         active_tokens=active_tokens,
         x_row_major=x_row_major,
+    )
+
+
+# Kimi K3 token sweep. Unlike the ISL sweeps above (fixed 5K buffer, varying active count,
+# which measures count-aware sparsity) this runs allocated == active, so each case is a
+# fully-packed buffer at that token count -- the shape the DRAM-bandwidth / utilization /
+# raw-time numbers are read off. 32 is one tile-row, 5120 the prefill dispatch width.
+_K3_TOKEN_SWEEP = [32, 64, 128, 256, 512, 1024, 2048, 5120]
+
+
+@pytest.mark.parametrize("num_tokens", _K3_TOKEN_SWEEP, ids=[f"t{t}" for t in _K3_TOKEN_SWEEP])
+@pytest.mark.parametrize("x_row_major", [True, False], ids=["x_rm", "x_tile"])
+@pytest.mark.extended_model
+@pytest.mark.skipif(not is_blackhole(), reason="SiTU-GLU routed expert is Blackhole-only")
+def test_single_routed_expert_k3_sweep(device, num_tokens: int, x_row_major: bool):
+    """Kimi K3 routed expert: SiTU-GLU activation at the post-projection dims.
+
+    K3's LatentMoE down-projects the embedding (EMB_SIZE -> ROUTED_EXPERT_HIDDEN_SIZE)
+    before the routed experts, so the op's K axis is ROUTED_EXPERT_HIDDEN_SIZE=3584 with
+    hidden 3072 -- the projection itself is a separate op and is not measured here.
+    """
+    run_single_routed_expert(
+        device,
+        num_tokens,
+        KimiK3Config.ROUTED_EXPERT_HIDDEN_SIZE,
+        KimiK3Config.MOE_INTERMEDIATE_SIZE,
+        x_row_major=x_row_major,
+        activation=ttnn.RoutedExpertActivation.SituGlu,
+    )
+
+
+# (gate, up) minimum cap-coverage floors, set just under the measured coverage at each
+# weight_scale so a case fails loudly if it ever stops exercising the caps. Measured at the
+# 512-token / 3584x3072 shape with seed 42: 65.6% / 0.5% at scale 0.15, 86.7% / 29.6% at 0.4.
+# Scale 0.15 grazes the up cap by design -- it is the case where the gate cap carries the
+# result on its own, which is exactly what makes it distinct from sat_deep.
+_SAT_PARTIAL_CAP_FRAC = (0.60, 0.004)
+_SAT_DEEP_CAP_FRAC = (0.80, 0.25)
+
+# Saturation cases: (weight_scale, weights_dtype, pcc_threshold, min_cap_frac).
+#
+# bf8 isolates the activation -- it holds ~0.999 no matter how deep the saturation, so a
+# regression in either tanh cap shows up immediately against the 0.97 bar.
+#
+# bf4 is the production weight dtype and is kept here deliberately, at a threshold matched
+# to its measured floor (0.976 at scale 0.15, 0.968 at 0.4). Saturation makes the output
+# near two-level, so bf4 weight error stops passing through proportionally and instead
+# flips whole terms of the down matmul; that cost is real and is what K3 prefill will see,
+# so it is measured rather than excluded. The bar still catches a genuine regression -- it
+# sits just under the measured value, not at an arbitrary low number.
+_K3_SATURATION_CASES = [
+    pytest.param(0.15, ttnn.bfloat8_b, 0.97, _SAT_PARTIAL_CAP_FRAC, id="sat_partial-bf8"),
+    pytest.param(0.4, ttnn.bfloat8_b, 0.97, _SAT_DEEP_CAP_FRAC, id="sat_deep-bf8"),
+    pytest.param(0.15, ttnn.bfloat4_b, 0.97, _SAT_PARTIAL_CAP_FRAC, id="sat_partial-bf4"),
+    pytest.param(0.4, ttnn.bfloat4_b, 0.96, _SAT_DEEP_CAP_FRAC, id="sat_deep-bf4"),
+]
+
+_K3_SATURATION_TOKENS = 512
+
+
+@pytest.mark.parametrize("weight_scale, weights_dtype, pcc_threshold, min_cap_frac", _K3_SATURATION_CASES)
+@pytest.mark.extended_model
+@pytest.mark.skipif(not is_blackhole(), reason="SiTU-GLU routed expert is Blackhole-only")
+def test_single_routed_expert_k3_saturated(
+    device, weight_scale: float, weights_dtype, pcc_threshold: float, min_cap_frac: tuple[float, float]
+):
+    """Kimi K3 SiTU-GLU driven into the saturating region of both tanh caps.
+
+    The sweep above runs at the default weight scale, where gate/up land around O(1) --
+    well inside the near-linear middle of tanh(x/4) and tanh(x/25). A kernel that dropped
+    either cap entirely would still pass there. These cases scale the weights so the caps
+    carry the result (sat_deep reaches ~87% of gate and ~30% of up past their beta), across
+    both the production bf4 weights and bf8 -- see _K3_SATURATION_CASES for why both.
+    """
+    run_single_routed_expert(
+        device,
+        _K3_SATURATION_TOKENS,
+        KimiK3Config.ROUTED_EXPERT_HIDDEN_SIZE,
+        KimiK3Config.MOE_INTERMEDIATE_SIZE,
+        activation=ttnn.RoutedExpertActivation.SituGlu,
+        weight_scale=weight_scale,
+        weights_dtype=weights_dtype,
+        pcc_threshold=pcc_threshold,
+        min_cap_frac=min_cap_frac,
     )

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert.py
@@ -139,9 +139,11 @@ def run_single_routed_expert(
     logger.debug("Running torch reference...")
     with torch.no_grad():
         torch_output_active = torch_expert(torch_active)
-        if torch_activation == ACTIVATION_SITU:
-            # How far into each tanh cap the inputs actually reach. Asserted below for the
-            # saturation cases, so one of those can't silently degrade into a near-linear run.
+        if torch_activation == ACTIVATION_SITU and min_cap_frac is not None:
+            # How far into each tanh cap the inputs actually reach, so a saturation case can't
+            # silently degrade into a near-linear run. Only the cases that assert it pay for the
+            # two extra host matmuls (~225 GFLOP at the 5120-token shape, and the perf harness
+            # calls this body once per iteration).
             gate_out = torch.nn.functional.linear(torch_active, weights["gate_proj"])
             up_out = torch.nn.functional.linear(torch_active, weights["up_proj"])
             gate_frac = (gate_out.abs() > _SITU_BETA_GATE).float().mean().item()
@@ -150,10 +152,9 @@ def run_single_routed_expert(
                 f"SiTU-GLU cap coverage: |gate|>{_SITU_BETA_GATE}: {gate_frac:.1%}, "
                 f"|up|>{_SITU_BETA_UP}: {up_frac:.1%}"
             )
-            if min_cap_frac is not None:
-                gate_min, up_min = min_cap_frac
-                assert gate_frac >= gate_min, f"gate cap coverage {gate_frac:.1%} below {gate_min:.1%}"
-                assert up_frac >= up_min, f"up cap coverage {up_frac:.1%} below {up_min:.1%}"
+            gate_min, up_min = min_cap_frac
+            assert gate_frac >= gate_min, f"gate cap coverage {gate_frac:.1%} below {gate_min:.1%}"
+            assert up_frac >= up_min, f"up cap coverage {up_frac:.1%} below {up_min:.1%}"
     logger.debug(f"Torch output shape: {torch_output_active.shape}")
 
     # Create TTNN input: 2D (allocated_tokens, emb_dim), replicated across the 1-device mesh.

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert_perf.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert_perf.py
@@ -11,9 +11,11 @@ Needs a host-IOMMU runner, hence requires_host_iommu: on Blackhole the profiler'
 
 import pytest
 
+import ttnn
 from models.common.utility_functions import is_blackhole, skip_with_llk_assert, skip_with_watcher
 from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import is_p150
 from tests.ttnn.profiling.realtime_profiler_utils import assert_op_duration_merged, require_realtime_profiler
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
 from tests.ttnn.nightly.unit_tests.operations.experimental.deepseek_prefill.test_single_routed_expert import (
     _ISL_ALLOCATED_TOKENS,
     _ISL_EXHAUSTIVE_MODELS,
@@ -62,6 +64,28 @@ _EXPECTED_NS: dict[tuple[str, int], int] = {
 }
 
 
+# Kimi K3 runs SiTU-GLU at the post-projection dims, so its K axis is ROUTED_EXPERT_HIDDEN_SIZE and
+# it cannot be driven from SINGLE_EXPERT_MODELS (which reads config.EMB_SIZE). Same measurement as
+# _EXPECTED_NS: median of 3 dispatches, x_rm layout, on a BH p150b (2026-08-18). The SiLU column at
+# the same dims read 175_024 / 177_389 / 233_381 / 346_628 / 604_844 / 1_186_341 / 1_514_379, so
+# SiTU costs ~6% up to the ~256-token DRAM-read knee and ~14% past it; a regression in either tanh
+# cap moves these well outside the band.
+_K3_SITU_EXPECTED_NS: dict[int, int] = {
+    0: 3_775,
+    128: 185_646,
+    256: 188_005,
+    512: 254_270,
+    1024: 386_543,
+    2048: 690_807,
+    4096: 1_360_016,
+    5120: 1_730_264,
+}
+
+
+def _margin_for(active: int) -> float:
+    return _CEILING_ONLY if active == 0 else _LOW_ISL_MARGIN if active <= 256 else _MARGIN
+
+
 def _perf_params():
     """Baseline and margin per (model, active) over the exhaustive ISL sweep, dims from
     SINGLE_EXPERT_MODELS. No extended_model mark: the markers below already scope where these run."""
@@ -77,7 +101,7 @@ def _perf_params():
                     config.EMB_SIZE,
                     config.MOE_INTERMEDIATE_SIZE,
                     _EXPECTED_NS[(name, active)],
-                    _CEILING_ONLY if active == 0 else _LOW_ISL_MARGIN if active <= 256 else _MARGIN,
+                    _margin_for(active),
                     # "-perf" keeps ids collision-free under -k: "512-perf" is not in "5120-perf".
                     id=f"{name}-isl-{active}-perf",
                 )
@@ -118,6 +142,42 @@ def test_single_routed_expert_perf(
         expected_ns=expected_ns,
         margin=margin,
         label=f'("{model_name}", {active_tokens})',
+        iters=_ITERS,
+        verbose=_VERBOSE,
+    )
+
+
+@pytest.mark.parametrize(
+    "active_tokens, expected_ns, margin",
+    [
+        pytest.param(active, _K3_SITU_EXPECTED_NS[active], _margin_for(active), id=f"k3-isl-{active}-perf")
+        for active in _ISL_EXHAUSTIVE_SWEEP
+    ],
+)
+@pytest.mark.requires_host_iommu
+@pytest.mark.skipif(not is_blackhole(), reason="SiTU-GLU is Blackhole-only")
+@pytest.mark.skipif(not is_p150(), reason="perf baselines are P150-specific; skip on any other board")
+@skip_with_llk_assert("No need to verify LLK asserts for performance tests.")
+@skip_with_watcher("Watcher perturbs kernel timing; perf checks are not meaningful with it enabled.")
+def test_single_routed_expert_k3_perf(device, active_tokens: int, expected_ns: int, margin: float):
+    """Kimi K3 routed expert (SiTU-GLU) device duration over the same ISL sweep as above."""
+    require_realtime_profiler("single routed expert perf checks")
+
+    assert_op_duration_merged(
+        device,
+        lambda: run_single_routed_expert(
+            device,
+            _ISL_ALLOCATED_TOKENS,
+            KimiK3Config.ROUTED_EXPERT_HIDDEN_SIZE,
+            KimiK3Config.MOE_INTERMEDIATE_SIZE,
+            active_tokens=active_tokens,
+            x_row_major=True,
+            activation=ttnn.RoutedExpertActivation.SituGlu,
+        ),
+        _OP_KERNEL_DIR,
+        expected_ns=expected_ns,
+        margin=margin,
+        label=f'("kimi_k3", {active_tokens})',
         iters=_ITERS,
         verbose=_VERBOSE,
     )

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert_perf.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert_perf.py
@@ -66,10 +66,8 @@ _EXPECTED_NS: dict[tuple[str, int], int] = {
 
 # Kimi K3 runs SiTU-GLU at the post-projection dims, so its K axis is ROUTED_EXPERT_HIDDEN_SIZE and
 # it cannot be driven from SINGLE_EXPERT_MODELS (which reads config.EMB_SIZE). Same measurement as
-# _EXPECTED_NS: median of 3 dispatches, x_rm layout, on a BH p150b (2026-08-18). The SiLU column at
-# the same dims read 175_024 / 177_389 / 233_381 / 346_628 / 604_844 / 1_186_341 / 1_514_379, so
-# SiTU costs ~6% up to the ~256-token DRAM-read knee and ~14% past it; a regression in either tanh
-# cap moves these well outside the band.
+# _EXPECTED_NS: median of 3 dispatches, x_rm layout, on a BH p150b (2026-08-18). Flat to ~256 tokens
+# (the op sits on its DRAM weight-read floor there), linear in tokens past that.
 _K3_SITU_EXPECTED_NS: dict[int, int] = {
     0: 3_775,
     128: 185_646,

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert_perf.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_single_routed_expert_perf.py
@@ -66,22 +66,33 @@ _EXPECTED_NS: dict[tuple[str, int], int] = {
 
 # Kimi K3 runs SiTU-GLU at the post-projection dims, so its K axis is ROUTED_EXPERT_HIDDEN_SIZE and
 # it cannot be driven from SINGLE_EXPERT_MODELS (which reads config.EMB_SIZE). Same measurement as
-# _EXPECTED_NS: median of 3 dispatches, x_rm layout, on a BH p150b (2026-08-18). Flat to ~256 tokens
-# (the op sits on its DRAM weight-read floor there), linear in tokens past that.
+# _EXPECTED_NS: median of 3 dispatches, x_rm layout, on a BH p150b (2026-08-19), centred over 8
+# sweeps rather than taken from one. Flat to ~256 tokens (the op sits on its DRAM weight-read
+# floor), linear in tokens past that.
 _K3_SITU_EXPECTED_NS: dict[int, int] = {
-    0: 3_775,
-    128: 185_646,
-    256: 188_005,
-    512: 254_270,
-    1024: 386_543,
-    2048: 690_807,
-    4096: 1_360_016,
-    5120: 1_730_264,
+    0: 3_820,
+    128: 185_670,
+    256: 187_970,
+    512: 259_000,
+    1024: 390_000,
+    2048: 690_900,
+    4096: 1_359_500,
+    5120: 1_730_500,
 }
+
+# K3's DRAM weight read is 18.58 MB against a ~185 us floor, so its knee sits a token count later
+# than kimi_k26's or glm_51's: 512 is the first case where compute starts to cover the read, and it
+# inherits the long right tail _LOW_ISL_MARGIN exists for (measured 254.0-265.8 us over 12 sweeps,
+# against 1.5% spread at 1024 and above). Everything past the knee holds inside the usual 3%.
+_K3_KNEE_TOKENS = 512
 
 
 def _margin_for(active: int) -> float:
     return _CEILING_ONLY if active == 0 else _LOW_ISL_MARGIN if active <= 256 else _MARGIN
+
+
+def _margin_for_k3(active: int) -> float:
+    return _CEILING_ONLY if active == 0 else _LOW_ISL_MARGIN if active <= _K3_KNEE_TOKENS else _MARGIN
 
 
 def _perf_params():
@@ -148,7 +159,7 @@ def test_single_routed_expert_perf(
 @pytest.mark.parametrize(
     "active_tokens, expected_ns, margin",
     [
-        pytest.param(active, _K3_SITU_EXPECTED_NS[active], _margin_for(active), id=f"k3-isl-{active}-perf")
+        pytest.param(active, _K3_SITU_EXPECTED_NS[active], _margin_for_k3(active), id=f"k3-isl-{active}-perf")
         for active in _ISL_EXHAUSTIVE_SWEEP
     ],
 )

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
@@ -72,8 +72,19 @@
 #include "api/compute/bcast.h"
 #endif
 
+// SwiGLU-OAI and SiTU-GLU both evaluate their activation as one binary SFPU op over the
+// raw gate/up accumulators, so they share the phase-3 path below and differ only in the op
+// called. The program factory sets exactly one of the two variant defines; each variant
+// caches as a distinct program, so a stray second define would mean wrong numerics with no
+// host-side signal.
+#if defined(SWIGLU_OAI) && defined(SITU_GLU)
+#error "SWIGLU_OAI and SITU_GLU are mutually exclusive activation variants"
+#endif
+#if defined(SWIGLU_OAI) || defined(SITU_GLU)
+#define FUSED_BINARY_ACT 1
+#endif
+
 #ifdef SWIGLU_OAI
-// SwiGLU-OAI (gpt-oss / MiniMax-M3) activation: reuse the proven binary SFPU op.
 // Computes (clamp(up,±L)+1) * clamp(gate,max=L) * sigmoid(alpha*clamp(gate,max=L)).
 // Default SwiGLUConfigGPTOSS (alpha=1.702, clamp_limit=7.0) matches M3's config.json.
 // swiglu_sfpu.h lives under the gpt-oss moe_gpt op; this repo-root-relative include
@@ -81,6 +92,12 @@
 // above). It could later move to a shared kernel-include dir, but the path is valid
 // as-is (verified on Blackhole via test_swigluoai_routed_expert.py).
 #include "ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/swiglu_sfpu.h"
+#endif
+
+#ifdef SITU_GLU
+// Computes (beta_gate*tanh(gate/beta_gate)*sigmoid(gate)) * (beta_up*tanh(up/beta_up)).
+// Bakes SituGluConfigKimi (beta_gate=4.0, beta_up=25.0), Kimi K3's config.
+#include "api/compute/situ_glu.h"
 #endif
 
 namespace {
@@ -485,13 +502,9 @@ FORCE_INLINE void matmul_phase_fused_gu(
     PACK((llk_pack_reconfig_l1_acc(0)));
 #endif
 
-#ifdef SWIGLU_OAI
-    // SwiGLU-OAI path: do NOT apply silu here and do NOT consume the partials.
-    // Both partials_gu and partials_up are left pushed (bf16, full precision) so
-    // swiglu_oai_activation_phase() in kernel_main can read raw gate AND raw up
-    // together and run the fused clamp/alpha-sigmoid/(up+1) binary SFPU op.
-    // (Keeping the activation off the bf8 gate_intermed avoids a precision loss
-    // before the activation.)
+#ifdef FUSED_BINARY_ACT
+    // Leave both partials pushed (bf16) so binary_activation_phase() can read raw gate and
+    // up together. Activating off the bf8 gate_intermed would lose precision first.
     (void)gate_intermed_cb_id;
     (void)up_intermed_cb_id;
 #else
@@ -535,30 +548,37 @@ FORCE_INLINE void matmul_phase_fused_gu(
 #endif
 }
 
-#ifdef SWIGLU_OAI
+#ifdef FUSED_BINARY_ACT
 // Dst-accumulator mode (fp32 dest accum on/off) from the host ComputeConfig,
 // passed via -DFP32_DEST_ACC_EN. Defaults to bf16 dst (0) if not passed.
 #ifndef FP32_DEST_ACC_EN
 #define FP32_DEST_ACC_EN 0
 #endif
-// SwiGLU-OAI activation pass (replaces gate-silu + multiply_phase for M3/gpt-oss).
-// Reads the raw bf16 gate & up matmul accumulators (both still resident in their
-// partials CBs) and writes the activated result into activated_cb:
-//   (clamp(up,±L)+1) * clamp(gate,max=L) * sigmoid(alpha*clamp(gate,max=L))
-// via the reusable binary SFPU op (swiglu_sfpu.h, SwiGLUConfigGPTOSS = M3 config).
+
+// Both ops share the (gate, up, out) dst-index signature and bake their constants into a
+// config struct, so only these lines differ. Each variant is named explicitly rather than
+// left to an #else, so adding a third one fails the build instead of silently compiling as
+// whichever variant owned the fallback.
+#if defined(SWIGLU_OAI)
+#define BINARY_ACT_INIT() MATH((ckernel::llk_math_eltwise_binary_sfpu_swiglu_init()))
+#define BINARY_ACT_TILE(fp32, g, u, o) MATH((ckernel::llk_math_eltwise_binary_sfpu_swiglu<fp32>(g, u, o)))
+#elif defined(SITU_GLU)
+// situ_glu_tile takes its fp32-dest mode from DST_ACCUM_MODE and wraps itself in MATH().
+#define BINARY_ACT_INIT() situ_glu_tile_init()
+#define BINARY_ACT_TILE(fp32, g, u, o) situ_glu_tile(g, u, o)
+#else
+#error "FUSED_BINARY_ACT is set but no activation variant matched"
+#endif
+
+// Replaces gate-silu + multiply_phase: reads the raw bf16 gate/up accumulators from their
+// partials CBs and writes the activated result to activated_cb. Runs on MATH (between
+// tile_regs_acquire/commit), matching this kernel's silu_tile structure.
 //
-// SFPU thread: invoked on MATH (between tile_regs_acquire/commit), matching this
-// kernel's existing silu_tile structure (copy_tile -> SFPU -> pack). gpt-oss's
-// moe_gpt runs it on PACK only because of its bespoke pack-fused pipeline.
-//
-// DST budget: the binary swiglu pins BOTH gate and up in dst at the same time, so
-// each output tile costs 2 dst slots. With fp32_dest_acc_en=false the MATH thread
-// has 8 dst tiles (DST_CAPACITY in the program factory), so we stream the block in
-// chunks of <=4 output tiles (<=8 dst). The activated CB is drained count-based by
-// the reader (cb_activated_obj.wait_front(d_in0_block_num_tiles)), so the push
-// granularity here is free and need not match out_subblock_num_tiles.
+// The binary op pins BOTH gate and up in dst, so each output tile costs 2 dst slots. With
+// 8 dst tiles available we stream in chunks of <=4 output tiles. The activated CB is
+// drained count-based, so push granularity need not match out_subblock_num_tiles.
 template <uint32_t out_block_num_tiles, uint32_t per_core_N_gu = 0>
-FORCE_INLINE void swiglu_oai_activation_phase(
+FORCE_INLINE void binary_activation_phase(
     uint32_t prev_srcA_cb_id,
     uint32_t gate_partials_cb_id,
     uint32_t up_partials_cb_id,
@@ -578,6 +598,9 @@ FORCE_INLINE void swiglu_oai_activation_phase(
     // 16-tile dst reg file halves under fp32 dest accum. Each output tile pins
     // gate+up simultaneously -> 2 dst slots -> kActChunk output tiles / acquire.
     constexpr bool kFp32DestAccEn = (FP32_DEST_ACC_EN != 0);
+    // SiTU-GLU's op reads DST_ACCUM_MODE instead of the define; both come from the same
+    // host fp32_dest_acc_en, so assert they agree rather than trusting it.
+    static_assert(kFp32DestAccEn == DST_ACCUM_MODE, "FP32_DEST_ACC_EN disagrees with DST_ACCUM_MODE");
     constexpr uint32_t kDstCapacity = kFp32DestAccEn ? 4u : 8u;
     constexpr uint32_t kActChunk = kDstCapacity / 2;
 
@@ -595,7 +618,7 @@ FORCE_INLINE void swiglu_oai_activation_phase(
     // single init covers reads from gate AND up partials. (Passing a Float16_b CB
     // as the "old" operand would no-op the reconfig and leave SrcA on bf4.)
 #ifdef FUSE_BIAS
-    // gpt-oss: add gate/up bias (broadcast across rows) before the clamp. The
+    // Add gate/up bias (broadcast across rows) before the activation. The
     // bias CBs were read once by the reader (per_core_N_gu tiles each) and are
     // NOT popped here (reused across chunks). add_bcast_rows sets SrcA=partials,
     // SrcB=bias — same format for gate and up, so one init covers both.
@@ -619,7 +642,7 @@ FORCE_INLINE void swiglu_oai_activation_phase(
         const uint32_t remaining = EFF_OUT - base;
         const uint32_t c = remaining < kActChunk ? remaining : kActChunk;
         tile_regs_acquire();
-        // gate -> dst[0..c), up -> dst[c..2c) (with gpt-oss bias when FUSE_BIAS)
+        // gate -> dst[0..c), up -> dst[c..2c) (bias-added when FUSE_BIAS)
         for (uint32_t j = 0; j < c; ++j) {
 #ifdef FUSE_BIAS
             const uint32_t ncol = (base + j) % per_core_N_gu;
@@ -630,10 +653,10 @@ FORCE_INLINE void swiglu_oai_activation_phase(
             copy_tile(up_partials_cb_id, base + j, c + j);
 #endif
         }
-        // Fused clamp + alpha-sigmoid + (up+1) multiply; result written in place to
-        // dst[j] (out == gate slot, mirroring moe_gpt's swiglu(0,1,0)).
+        // Fused gate/up activation; result written in place to dst[j]
+        // (out == gate slot, mirroring moe_gpt's swiglu(0,1,0)).
         for (uint32_t j = 0; j < c; ++j) {
-            MATH((ckernel::llk_math_eltwise_binary_sfpu_swiglu<kFp32DestAccEn>(j, c + j, j)));
+            BINARY_ACT_TILE(kFp32DestAccEn, j, c + j, j);
         }
         tile_regs_commit();
         tile_regs_wait();
@@ -831,6 +854,11 @@ void kernel_main() {
     const uint32_t effective_chunks =
         effective_chunks_runtime < num_chunks_max ? effective_chunks_runtime : num_chunks_max;
 
+    // Must precede every other Compute API call, init included: it does MMIO config of
+    // MATH/PACK/UNPACK requiring those units idle, so an earlier SFPU init risks the startup
+    // writes racing the constants it loaded (SiTU-GLU's tanh_init in particular).
+    compute_kernel_hw_startup<SrcOrder::Reverse>(cb_in0_x, cb_in1_gate, cb_partials_gu);
+
     // SiLU is now applied as a MATH-thread SFPU pass on dst (silu_tile)
     // between copy_tile and pack_tile — not packer-fused via
     // apply_activation_from_pack. Empirically the packer-fused variant
@@ -838,14 +866,13 @@ void kernel_main() {
     // gate-intermed write. silu_tile_init() configures the MATH-side SFPU
     // for silu; the pack then runs plain (no per-tile SFPU on the pack
     // thread). Same total compute, better pipelining.
-#ifdef SWIGLU_OAI
-    // SwiGLU-OAI uses the binary swiglu SFPU op (sigmoid/recip table init).
-    MATH((ckernel::llk_math_eltwise_binary_sfpu_swiglu_init()));
+#ifdef FUSED_BINARY_ACT
+    // The binary activations init their own SFPU tables (recip for SwiGLU-OAI,
+    // tanh for SiTU-GLU) instead of silu's.
+    BINARY_ACT_INIT();
 #else
     silu_tile_init();
 #endif
-
-    compute_kernel_hw_startup<SrcOrder::Reverse>(cb_in0_x, cb_in1_gate, cb_partials_gu);
 
     for (uint32_t chunk = 0; chunk < effective_chunks; ++chunk) {
         // Per-chunk per_core_M (per_core_M_max for full chunks, a smaller divisor
@@ -899,13 +926,11 @@ void kernel_main() {
             cb_up_intermed,
             /*m_subblocks=*/re_m_valid);
 
-#ifdef SWIGLU_OAI
-        // Phase 3 (SwiGLU-OAI): fused clamp + alpha-sigmoid + (up+1) directly on
-        // the raw bf16 gate/up accumulators -> cb_activated. Replaces both the
-        // gate-silu pass (skipped above) and the plain multiply_phase. cb_in1_up is
-        // the unpacker's last SrcA operand (up matmul in1), passed so the partials
-        // reconfig (weights df -> Float16_b) actually fires.
-        swiglu_oai_activation_phase<gu_out_block_num_tiles, g_in1_per_core_w>(
+#ifdef FUSED_BINARY_ACT
+        // Phase 3: fused activation on the raw bf16 accumulators -> cb_activated.
+        // cb_in1_up is the unpacker's last SrcA operand, passed so the partials reconfig
+        // (weights df -> Float16_b) actually fires.
+        binary_activation_phase<gu_out_block_num_tiles, g_in1_per_core_w>(
             cb_in1_up, cb_partials_gu, cb_partials_up, cb_activated, re_eff_out_gu, cb_gate_bias, cb_up_bias);
         (void)cb_gate_intermed;
         (void)cb_up_intermed;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
@@ -816,6 +816,12 @@ void kernel_main() {
     constexpr uint32_t cb_down_bias = 0;
 #endif
 
+    // First Compute API call in the kernel, as compute_kernel_hw_startup.h requires: it does MMIO
+    // config of MATH/PACK/UNPACK and needs those units idle. Nothing below it depends on the count
+    // handshake, and the SFPU init that follows must not run before it (SiTU-GLU's tanh_init loads
+    // the vConstFloatPrgm registers the activation reads back on every tile).
+    compute_kernel_hw_startup<SrcOrder::Reverse>(cb_in0_x, cb_in1_gate, cb_partials_gu);
+
     CircularBuffer counts_scratch_cb(cb_counts_scratch);
     CircularBuffer idx_scratch_cb(cb_idx_scratch);
 
@@ -853,11 +859,6 @@ void kernel_main() {
     const uint32_t effective_chunks_runtime = adaptive_chunk::num_chunks(count_tiles, chunk_M_max);
     const uint32_t effective_chunks =
         effective_chunks_runtime < num_chunks_max ? effective_chunks_runtime : num_chunks_max;
-
-    // Must precede every other Compute API call, init included: it does MMIO config of
-    // MATH/PACK/UNPACK requiring those units idle, so an earlier SFPU init risks the startup
-    // writes racing the constants it loaded (SiTU-GLU's tanh_init in particular).
-    compute_kernel_hw_startup<SrcOrder::Reverse>(cb_in0_x, cb_in1_gate, cb_partials_gu);
 
     // SiLU is now applied as a MATH-thread SFPU pass on dst (silu_tile)
     // between copy_tile and pack_tile — not packer-fused via

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
@@ -26,6 +26,14 @@ bool is_dram_interleaved(const ttnn::Tensor& t) {
 void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& op, const tensor_args_t& t) {
     TT_FATAL(t.x.storage_type() == ttnn::StorageType::DEVICE, "x must be on device");
+    // Scoped to Blackhole, matching ttnn::softcap / ttnn::situ_glu. The underlying SFPU
+    // primitives exist on Wormhole, but that combination is unverified.
+    if (op.activation == RoutedExpertActivation::SituGlu) {
+        TT_FATAL(
+            t.x.device()->arch() == tt::ARCH::BLACKHOLE,
+            "unified_routed_expert_ffn: SiTU-GLU is implemented for Blackhole only, got arch {}",
+            t.x.device()->arch());
+    }
     // x layout/dtype depends on x_is_row_major:
     //   false (default): x is TILE BFLOAT8_B — the reader reads tile pages directly.
     //   true: x is ROW_MAJOR BFLOAT16 (the dispatch output) — the reader streams
@@ -267,13 +275,13 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
             t.gate_bias->dtype(),
             t.up_bias->dtype(),
             t.down_bias->dtype());
-        // Bias fusion is implemented only for the SwiGLU-OAI activation (gpt-oss):
-        // the kernel adds gate/up bias before the clamp and down bias after the
-        // down matmul. The SiLU path has no bias branch.
+        // Bias fusion lives in the kernel's shared binary-activation phase and is
+        // activation-agnostic, so every fused binary activation supports it. Only the SiLU
+        // path has no bias branch.
         TT_FATAL(
-            op.activation == RoutedExpertActivation::SwiGluOai,
-            "unified_routed_expert_ffn: expert biases are only supported with RoutedExpertActivation::SwiGluOai "
-            "(got the SiLU path).");
+            op.activation == RoutedExpertActivation::SwiGluOai || op.activation == RoutedExpertActivation::SituGlu,
+            "unified_routed_expert_ffn: expert biases require a fused binary activation "
+            "(SwiGluOai or SituGlu); the SiLU path has no bias branch.");
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -830,8 +830,8 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     // PACKER_L1_ACC controls cross-K-block accumulation via packer L1 RMW.
     std::map<std::string, std::string> compute_defines{};
     compute_defines["PACKER_L1_ACC"] = "1";
-    // Dst-accumulator mode -> compute kernel: the SwiGLU-OAI dst budget and the
-    // SFPU fp32-dest template derive from this, staying in sync with
+    // Dst-accumulator mode -> compute kernel: the fused-binary-activation dst budget and
+    // the SFPU fp32-dest template derive from this, staying in sync with
     // DST_CAPACITY / ComputeConfig.fp32_dest_acc_en (single source above).
     compute_defines["FP32_DEST_ACC_EN"] = kFp32DestAccEn ? "1" : "0";
     if (op.activation == RoutedExpertActivation::SwiGluOai) {
@@ -839,10 +839,14 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         // clamp(up,±L), (up+1)*gate*sigmoid(alpha*gate). Bakes alpha=1.702,
         // limit=7.0 (SwiGLUConfigGPTOSS) in the kernel.
         compute_defines["SWIGLU_OAI"] = "1";
+    } else if (op.activation == RoutedExpertActivation::SituGlu) {
+        // SiTU-GLU (Kimi K3), with beta_gate=4.0 / beta_up=25.0 baked into the kernel.
+        compute_defines["SITU_GLU"] = "1";
     }
     if (fuse_bias) {
-        // FUSE_BIAS: add gate/up bias (broadcast across rows) before the
-        // SwiGLU-OAI activation and down bias after the down matmul (gpt-oss).
+        // FUSE_BIAS: add gate/up bias (broadcast across rows) before the fused binary
+        // activation and down bias after the down matmul. Validation restricts this to
+        // the activations that have that branch.
         compute_defines["FUSE_BIAS"] = "1";
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_types.hpp
@@ -34,10 +34,14 @@ inline constexpr uint32_t MAX_GLOBAL_EXPERTS = tt::constants::TILE_HW;  // 1024
 // the compute kernel via a compile-time define, so each variant caches as a
 // distinct program. For SwiGluOai the alpha/limit are baked to the M3/gpt-oss
 // values (1.702 / 7.0, SwiGLUConfigGPTOSS) in the kernel — no extra params.
+// Likewise SituGlu bakes the Kimi K3 betas (beta_gate=4.0, beta_up=25.0,
+// SituGluConfigKimi).
 enum class RoutedExpertActivation : uint8_t {
     Silu = 0,  // plain SiLU SwiGLU: silu(gate) * up                      (DeepSeek default)
     SwiGluOai =
         1,  // clamped swigluoai: (clamp(up,±L)+1)·clamp(gate,max=L)·σ(α·clamp(gate,max=L))  (MiniMax-M3 / gpt-oss)
+    // SiTU-GLU: (beta_gate*tanh(gate/beta_gate)*sigmoid(gate)) * (beta_up*tanh(up/beta_up))  (Kimi K3)
+    SituGlu = 2,
 };
 
 // Attributes (the constants known at host time).

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
@@ -18,7 +18,8 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
     // function bindings so it can serve as a default kwarg value.
     nb::enum_<RoutedExpertActivation>(mod, "RoutedExpertActivation")
         .value("Silu", RoutedExpertActivation::Silu)
-        .value("SwiGluOai", RoutedExpertActivation::SwiGluOai);
+        .value("SwiGluOai", RoutedExpertActivation::SwiGluOai)
+        .value("SituGlu", RoutedExpertActivation::SituGlu);
 
     ttnn::bind_function<"unified_routed_expert_ffn", "ttnn.experimental.deepseek_prefill.">(
         mod,
@@ -89,7 +90,8 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
                 reader streams sticks and the compute kernel tilizes them to bf8_b
                 before the matmul (fusing to_layout). Default False (TILE bf8_b).
             activation (ttnn.RoutedExpertActivation, optional):
-                Silu (default, DeepSeek) or SwiGluOai (clamped, MiniMax-M3 / gpt-oss).
+                Silu (default, DeepSeek), SwiGluOai (clamped, MiniMax-M3 / gpt-oss),
+                or SituGlu (tanh-capped, Kimi K3; Blackhole only).
 
         The kernel picks chunk_M_tiles / per_core_M / num_chunks at RUNTIME from
         the device-resident token count, so there is no chunk-sizing argument.
@@ -147,7 +149,8 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
         Keyword Args:
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional)
             activation (ttnn.RoutedExpertActivation, optional):
-                Silu (default, DeepSeek) or SwiGluOai (clamped, MiniMax-M3 / gpt-oss).
+                Silu (default, DeepSeek), SwiGluOai (clamped, MiniMax-M3 / gpt-oss),
+                or SituGlu (tanh-capped, Kimi K3; Blackhole only).
 
         Each per-expert FFN picks its chunk_M_tiles / per_core_M / num_chunks at
         RUNTIME from the device-resident token count, so there is no expected-token


### PR DESCRIPTION
Runs Kimi K3's routed experts on their real activation. Replaces #52634, rebased onto
main now that #52448 (the `situ_glu` SFPU op) has landed.

Closes #51351. Refs #51335.

## Change

- New `RoutedExpertActivation::SituGlu` on `unified_routed_expert_ffn`, evaluated by
  `situ_glu_tile` over the raw bf16 gate/up matmul accumulators. Betas come from
  `SituGluConfigKimi` (4.0 / 25.0); no extra params. Blackhole only, matching `ttnn::situ_glu`.
- SwiGLU-OAI and SiTU-GLU differ only in the SFPU op they call, so the compute kernel's whole
  phase-3 path (keep the raw partials, skip the gate silu, stream gate+up through dst at 2 slots
  per output tile) is now shared behind `FUSED_BINARY_ACT`. `swiglu_oai_activation_phase` becomes
  `binary_activation_phase`. The bias branch moved with it, so the host bias gate is keyed to the
  set of fused binary activations rather than to `SwiGluOai` alone.
- `TtMoe` gains `routed_expert_activation` and `KimiK3Config` names `"situ"`, so both the MoE test
  and the model path (`tt_prefill_block._build_moe`) run SiTU. Every other model keeps the SiLU
  default, unchanged.
- The torch references split the same way the device does: SiTU on the routed experts, SiLU on the
  shared one, which has no SiTU kernel at its 6144 width. `TorchMoe` gains `shared_activation` and
  `run_reference_moe` gains `hidden_act` / `shared_hidden_act` for the vendored
  `KimiSparseMoeBlock`, which otherwise applies one activation to both halves.

## Activation per model

SiTU-GLU is opt-in and reaches K3 alone. `TtMoe(routed_expert_activation=...)` defaults to `Silu`,
and `tt_prefill_block` reads `getattr(model_cfg, "ROUTED_EXPERT_ACTIVATION", "silu")` -- `KimiK3Config`
is the only config that declares it. Nothing else changes activation.

| model | routed-expert activation | selected by |
|---|---|---|
| Kimi-K3 | SiTU-GLU | `KimiK3Config.ROUTED_EXPERT_ACTIVATION = "situ"` |
| Kimi-K2.6 | SiLU | no attribute, takes the default |
| Kimi-K2.7 | SiLU | `KimiK27Adapter` subclasses `KimiK26Adapter` (only the checkpoint differs), so same config, same default |
| MiniMax-M3 | SwiGLU-OAI | explicit at `tt_minimax_moe.py:163`, unchanged |
| gpt-oss-120B | SwiGLU-OAI | explicit at `tt_gpt_oss_moe.py:153`, unchanged |
| DeepSeek V3 / V3.2 / V4-Pro / V4-Flash, GLM-5.1 / 5.2 | SiLU | no attribute, take the default |

The kernel's phase-3 path is now shared between SiTU-GLU and SwiGLU-OAI, but which activation a model
selects is untouched. Two checks that this holds in practice rather than just by construction: Kimi-K2.6
on Galaxy 8x4 returned bit-identical to the figures already in the tree for the pre-change path
(`shared_output` 0.999779, `routed_output` 0.967471, `final_output` 0.983272), and the gpt-oss and
MiniMax-M3 unit suites pass unchanged.

Within K3 the split is narrower still: only the **routed** experts run SiTU-GLU. The shared expert
(6144) and the dense FFN (33792) stay on SiLU, no kernel implementing SiTU at those widths -- which is
why `TorchMoe` gained `shared_activation` and `run_reference_moe` gained `hidden_act` /
`shared_hidden_act`, so both sides of the comparison split exactly as the device does.

K3's checkpoint sets `hidden_act = "situ"` for all three FFN sites, so closing that split is tracked
as **#53625**. Neither remaining site goes through the fused routed-expert kernel -- both fold SiLU
into a matmul as a *unary* activation, and SiTU-GLU is binary over `(gate, up)` -- so it is follow-up
work rather than something this PR can extend into. The reference hooks it needs are already here.

## Kimi-K3 MoE

`test_kimi_k3_moe`, 896 experts / top-16, FABRIC_2D, 640 tok/chip. The 8x4 column is the production
shape, from Galaxy CI on this branch; 2x4 is the loudbox proxy.

| stage | 8x4 | 2x4 | bar |
|---|---:|---:|---|
| shared_output | 0.999759 | 0.999701 | 0.997 |
| latent_input | 0.999882 | 0.999808 | 0.998 |
| latent_routed_output | 0.969906 | 0.972775 | 0.965 |
| routed_output | 0.969555 | 0.972620 | 0.96 |
| final_output | 0.969585 | 0.995710 | 0.965 |
| reference_output (upstream `KimiSparseMoeBlock`) | 0.969567 | 0.995693 | 0.965 |

Every existing threshold holds unchanged. K3's activations sit well inside both tanh caps at
realistic weight scales, so the bf4 cost the saturation cases document does not arise here -- 8x4
`reference_output` went 0.969434 to 0.969567 and 2x4 0.995692 to 0.995693 against the SiLU
stand-in the bring-up used.

## Utilization of routed expert with SiTU-GLU

`UnifiedRoutedExpertFfnDeviceOperation` at the K3 post-projection dims (3584 x 3072), x_rm
production path, bf8 activations / bf4 weights, allocated == active. Realtime profiler, median of
3 dispatches, BH p150b, DDR 16000.

Core utilization counts the three matmuls and ignores the eltwise/activation work:

    FLOP  = 2 * M * K * N * 3 matmuls
    FLOPs = 4096/cycle * 1.35 GHz / fidelity * cores    (fidelity = 1, LoFi; cores = 88)
    util  = (FLOP / FLOPs) / measured

giving a 486.6 TFLOP/s ceiling. DRAM counts 18.58 MB of bf4 weights plus the bf16 x read and the
bf8 output write, against the 512 GB/s spec peak (GDDR6 16 Gbps/pin, 8 x 32-bit channels).

| tokens | us | core util % | TFLOP/s | DRAM GB/s | DRAM util % |
|---:|---:|---:|---:|---:|---:|
| 32 | 184.4 | 2.4 | 11.5 | 102.6 | 20.0 |
| 64 | 184.7 | 4.7 | 22.9 | 104.4 | 20.4 |
| 128 | 185.0 | 9.4 | 45.7 | 108.0 | 21.1 |
| 256 | 187.6 | 18.5 | 90.2 | 114.0 | 22.3 |
| 512 | 256.1 | 27.1 | 132.1 | 94.5 | 18.5 |
| 1024 | 386.0 | 36.0 | 175.2 | 77.2 | 15.1 |
| 2048 | 690.4 | 40.3 | 196.0 | 59.5 | 11.6 |
| 5120 | 1730.8 | 40.2 | 195.4 | 43.2 | 8.4 |

## Tests

Blackhole, all passing:

- `test_single_routed_expert_k3_sweep` -- 32..5120 tokens x both x layouts at 3584x3072, 16 cases.
- `test_single_routed_expert_k3_saturated` -- drives both tanh caps (86.7% of gate and 29.6% of up
  past their beta at the deep setting), across bf8 and the production bf4 weights. The cap coverage
  is asserted, not just logged, so a case cannot quietly slide back into the near-linear middle.
- `test_routed_expert_bias.py::test_situglu_bias_routed_expert` -- expert biases + SiTU-GLU, which
  the widened bias gate newly permits.
- `test_single_routed_expert_k3_perf` -- the 8 device-duration gates above.
- Regression: `test_swigluoai_routed_expert.py`, all of `test_routed_expert_bias.py`, and the
  74 existing `test_single_routed_expert` functional + ISL cases, confirming the shared phase-3
  refactor left the SiLU and SwiGLU-OAI paths intact.
- Wider local sweeps on the rebased tree: 551/551 of the nightly `deepseek_prefill` op suite, and
  Kimi-K2.6 MoE on 4x2 unchanged (`final_output` 0.987011) to confirm the `TtMoe` default is inert
  for every other model.

## Notes

- The K3 single-expert perf gates are calibrated over 8 sweeps rather than one sample. The 512-token
  case sits on K3's DRAM-floor knee, which lands later than kimi_k26's or glm_51's because K3 reads
  18.58 MB of weights against a ~185 us floor, so it carries the same wide band the file already
  gives sub-256 cases. Past the knee everything holds inside 1.5%.
- `TtRoutedExpert` now rejects any non-SiLU activation at construction when not on Blackhole. The
  Wormhole fallback calls `routed_expert_ffn`, which has no activation parameter and always computes
  SiLU, so the old behaviour was a silent wrong answer. This also closes the same pre-existing hole
  for `SwiGluOai`. Both consumers of that path are Blackhole-only in CI and both were re-run against
  the guard: gpt-oss `tests/unit` 11 passed / 1 skipped, MiniMax-M3 `tests/unit` 25 passed /
  27 skipped.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kgrujcic/51351-k3-routed-expert)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kgrujcic/51351-k3-routed-expert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kgrujcic/51351-k3-routed-expert)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kgrujcic/51351-k3-routed-expert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kgrujcic/51351-k3-routed-expert)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kgrujcic/51351-k3-routed-expert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kgrujcic/51351-k3-routed-expert)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kgrujcic/51351-k3-routed-expert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kgrujcic/51351-k3-routed-expert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kgrujcic/51351-k3-routed-expert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kgrujcic/51351-k3-routed-expert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kgrujcic/51351-k3-routed-expert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kgrujcic/51351-k3-routed-expert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kgrujcic/51351-k3-routed-expert)
