### PR TITLE
ttnn: remove non-relocatable build-dir path from INSTALL_RPATH

### DIFF
--- a/tt_metal/CMakeLists.txt
+++ b/tt_metal/CMakeLists.txt
@@ -145,7 +145,7 @@ set_target_properties(
     tt_metal
     PROPERTIES
         INSTALL_RPATH
-            "/opt/openmpi-v5.0.7-ulfm/lib;${PROJECT_BINARY_DIR}/lib;$ORIGIN"
+            "/opt/openmpi-v5.0.7-ulfm/lib;$ORIGIN"
         ADDITIONAL_CLEAN_FILES
             "${PROJECT_BINARY_DIR}/lib;${PROJECT_BINARY_DIR}/obj"
 )

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -206,7 +206,7 @@ set_target_properties(
         BUILD_RPATH
             "${PROJECT_BINARY_DIR}/tt_metal;${PROJECT_BINARY_DIR}/ttnn"
         INSTALL_RPATH
-            "${PROJECT_BINARY_DIR}/lib;$ORIGIN/build/lib;$ORIGIN" # FIXME: Install RPATH should not have a build path!
+            "$ORIGIN/build/lib;$ORIGIN"
         CXX_VISIBILITY_PRESET
             "default" # FIXME: Export the symbols we want, and use hidden visibility instead of default
         ADDITIONAL_CLEAN_FILES
@@ -295,7 +295,7 @@ if(WITH_PYTHON_BINDINGS)
             BUILD_RPATH
                 "${PROJECT_BINARY_DIR}/tt_metal;${PROJECT_BINARY_DIR}/ttnn"
             INSTALL_RPATH
-                "${PROJECT_BINARY_DIR}/lib;$ORIGIN/build/lib;$ORIGIN" # FIXME: Install RPATH should not have a build path!
+                "$ORIGIN/build/lib;$ORIGIN"
             CXX_VISIBILITY_PRESET
                 "default" # FIXME: Export the symbols we want, and use hidden visibility instead of default
             ADDITIONAL_CLEAN_FILES


### PR DESCRIPTION
## Summary

Several shared-library targets set `INSTALL_RPATH` to include `${PROJECT_BINARY_DIR}/lib` — the absolute path of the build directory. That path is unique per machine/checkout and gets baked into the installed `.so`'s RPATH, making the install non-relocatable and leaking the builder's local filesystem layout into shipped binaries. Two of the three sites already carried a maintainer `FIXME: Install RPATH should not have a build path!`.

This PR drops the build-tree entry from all three sites, keeping only relocatable `$ORIGIN`-relative entries, matching the convention already used elsewhere in the tree (`ttnn/test/CMakeLists.txt`, `tt_metal/test/CMakeLists.txt`, `tools/scaleout/CMakeLists.txt`). The now-resolved `FIXME` comments are removed.

## Changes

- **`ttnn/CMakeLists.txt` (`ttnncpp` target):**
  `"${PROJECT_BINARY_DIR}/lib;$ORIGIN/build/lib;$ORIGIN"` → `"$ORIGIN/build/lib;$ORIGIN"`
- **`ttnn/CMakeLists.txt` (`ttnn` Python bindings target):**
  `"${PROJECT_BINARY_DIR}/lib;$ORIGIN/build/lib;$ORIGIN"` → `"$ORIGIN/build/lib;$ORIGIN"`
- **`tt_metal/CMakeLists.txt` (`tt_metal` target):**
  `"/opt/openmpi-v5.0.7-ulfm/lib;${PROJECT_BINARY_DIR}/lib;$ORIGIN"` → `"/opt/openmpi-v5.0.7-ulfm/lib;$ORIGIN"`

The hardcoded `/opt/openmpi-v5.0.7-ulfm/lib` entry (tied to ULFM MPI detection in `tt_metal/distributed/CMakeLists.txt`) is explicitly out of scope per the issue and is left untouched. `BUILD_RPATH` (which legitimately points into the build tree) is also unchanged.

Fixes #53604

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/53604-install-rpath-build-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/53604-install-rpath-build-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/53604-install-rpath-build-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/53604-install-rpath-build-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/53604-install-rpath-build-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/53604-install-rpath-build-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/53604-install-rpath-build-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/53604-install-rpath-build-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/53604-install-rpath-build-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/53604-install-rpath-build-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/53604-install-rpath-build-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/53604-install-rpath-build-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/53604-install-rpath-build-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/53604-install-rpath-build-path)