### PR TITLE
[skip ci] Suppress -Wdeprecated-declarations on Tracy's own build targets

### DIFF
--- a/tt_metal/third_party/CMakeLists.txt
+++ b/tt_metal/third_party/CMakeLists.txt
@@ -89,6 +89,12 @@ endif()
 target_compile_options(TracyClient PUBLIC -fno-omit-frame-pointer)
 # Tracy sources emit this warning under our global -Werror; keep suppression local to TracyClient.
 target_compile_options(TracyClient PRIVATE -Wno-unused-variable)
+# The top-level -Wno-deprecated-declarations (see CMakeLists.txt) is declared after these
+# subdirectories are added, so it never reaches Tracy's own targets: GCC's libstdc++ marks
+# std::get_temporary_buffer as deprecated, and Tracy's server code (e.g. TracyFileRead.hpp)
+# still triggers it internally via std::stable_sort/inplace_merge. Suppress it locally on all
+# real (non-vendored) Tracy targets rather than relying on the global flag's declaration order.
+target_compile_options(TracyClient PRIVATE -Wno-deprecated-declarations)
 # Their executable exports symbols (-rdynamic) → Tracy can map addresses to names.
 target_link_options(TracyClient PUBLIC -rdynamic)
 
@@ -121,6 +127,30 @@ set_target_properties(
         RUNTIME_OUTPUT_DIRECTORY
             "${TRACY_CLI_BIN_DIR}"
 )
+
+# Same -Wno-deprecated-declarations suppression as TracyClient above, extended to the rest of
+# Tracy's own (non-vendored) targets -- their server code is what actually triggers the warning.
+foreach(
+    _tt_tracy_deprecated_target
+    IN
+    ITEMS
+        TracyServer
+        TracyGetOpt
+        tracy-csvexport
+        tracy-capture
+        tracy-capture-daemon
+)
+    if(NOT TARGET ${_tt_tracy_deprecated_target})
+        continue()
+    endif()
+    get_target_property(_tt_tracy_deprecated_target_type ${_tt_tracy_deprecated_target} TYPE)
+    if(_tt_tracy_deprecated_target_type STREQUAL "INTERFACE_LIBRARY")
+        continue()
+    endif()
+    target_compile_options(${_tt_tracy_deprecated_target} PRIVATE -Wno-deprecated-declarations)
+endforeach()
+unset(_tt_tracy_deprecated_target)
+unset(_tt_tracy_deprecated_target_type)
 
 # Force a portable ISA baseline for Tracy server/CLI and key deps on x86_64.
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")


### PR DESCRIPTION
## Summary
- GCC 12's libstdc++ marks `std::get_temporary_buffer` as deprecated (since C++17). Tracy's server code (e.g. `TracyFileRead.hpp`) still uses it internally via `std::stable_sort`/`std::inplace_merge`, which surfaces a `-Wdeprecated-declarations` warning at the template instantiation site — noisy build output, not an actual bug in Tracy or tt-metal code.
- We already have a global `-Wno-deprecated-declarations` in the top-level `CMakeLists.txt`, but it's declared *after* `add_subdirectory(tt_metal/third_party SYSTEM)` runs, so it never reaches Tracy's own targets. The `SYSTEM` keyword only affects how *consumers* of Tracy's headers treat them (e.g. tt_metal itself won't warn on Tracy's public headers) — it doesn't add compile flags to Tracy's own compilation.
- This suppresses the warning locally on Tracy's own (non-vendored) targets — `TracyClient`, `TracyServer`, `TracyGetOpt`, `tracy-csvexport`, `tracy-capture`, `tracy-capture-daemon` — mirroring the existing local `-Wno-unused-variable` suppression already applied to `TracyClient` for the same reason.

## Test plan
- [x] Verified the change formats cleanly with the repo's pinned `gersemi==0.16.2` (no diff)
- [ ] CI build (GCC 12) no longer shows the `get_temporary_buffer<tracy::Int48>` deprecation warning from `stl_tempbuf.h`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brainclaw/tracy-suppress-deprecated-declarations)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brainclaw/tracy-suppress-deprecated-declarations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=brainclaw/tracy-suppress-deprecated-declarations)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:brainclaw/tracy-suppress-deprecated-declarations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brainclaw/tracy-suppress-deprecated-declarations)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brainclaw/tracy-suppress-deprecated-declarations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=brainclaw/tracy-suppress-deprecated-declarations)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:brainclaw/tracy-suppress-deprecated-declarations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=brainclaw/tracy-suppress-deprecated-declarations)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brainclaw/tracy-suppress-deprecated-declarations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=brainclaw/tracy-suppress-deprecated-declarations)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brainclaw/tracy-suppress-deprecated-declarations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=brainclaw/tracy-suppress-deprecated-declarations)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brainclaw/tracy-suppress-deprecated-declarations)