### PR TITLE
[Bug fix] Preserve fused QK rows on Galaxy

### DIFF
--- a/models/tt_transformers/tests/test_rope_utils.py
+++ b/models/tt_transformers/tests/test_rope_utils.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from models.tt_transformers.tt.rope import get_batch_size_per_device_group
+
+
+@pytest.mark.parametrize(
+    ("batch_size", "use_qk_fused", "num_devices", "mesh_shape", "expected"),
+    [
+        (1, True, 32, (8, 4), 2),
+        (1, False, 32, (8, 4), 1),
+        (32, True, 32, (8, 4), 16),
+        (1, True, 1, (), 2),
+    ],
+)
+def test_get_batch_size_per_device_group(batch_size, use_qk_fused, num_devices, mesh_shape, expected):
+    assert get_batch_size_per_device_group(batch_size, use_qk_fused, num_devices, mesh_shape, 1) == expected

--- a/models/tt_transformers/tt/rope.py
+++ b/models/tt_transformers/tt/rope.py
@@ -17,6 +17,15 @@ from models.tt_transformers.tt.prefetcher import Prefetcher
 from ttnn import replicate_tensor_to_mesh_mapper
 
 
+def get_batch_size_per_device_group(
+    batch_size: int, use_qk_fused: bool, num_devices: int, mesh_shape: Tuple[int, ...], shard_batch_to_mesh_dim: int
+) -> int:
+    batch_size_per_device_group = (
+        max(batch_size // mesh_shape[shard_batch_to_mesh_dim], 1) if num_devices == 32 else batch_size
+    )
+    return batch_size_per_device_group * (2 if use_qk_fused else 1)
+
+
 # Copied from DeepseekV3RotaryEmbedding: https://huggingface.co/deepseek-ai/DeepSeek-V3/blob/main/modeling_deepseek.py#L114
 class RotaryEmbedding(nn.Module):
     def __init__(self, dim: int, max_position_embeddings: int, base: float, device: Optional[Any] = None) -> None:
@@ -767,12 +776,13 @@ class RotarySetup(LightweightModule):
         self.device = device
         self.is_mesh_device = isinstance(device, ttnn._ttnn.multi_device.MeshDevice)
         self.num_devices = device.get_num_devices() if self.is_mesh_device else 1
-        if self.num_devices == 32:
-            self.batch_size_per_device_group = max(
-                self.doubled_batch_size // list(device.shape)[shard_batch_to_mesh_dim], 1
-            )
-        else:
-            self.batch_size_per_device_group = self.doubled_batch_size
+        self.batch_size_per_device_group = get_batch_size_per_device_group(
+            self.original_batch_size,
+            use_qk_fused,
+            self.num_devices,
+            tuple(device.shape) if self.is_mesh_device else (),
+            shard_batch_to_mesh_dim,
+        )
         # Always use (8, 8) on wormhole (compute_with_storage_grid_size returns (8, 9) on Galaxy)
         self.core_grid = (
             device.compute_with_storage_grid_size() if ttnn.get_arch_name() == "blackhole" else ttnn.CoreCoord(8, 8)


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Fix Galaxy fused-QK RoPE batch sizing for batches smaller than the mesh sharding dimension. The old expression doubled before integer sharding, so batch 1 on an 8x4 Galaxy computed one per-device-group row; `get_rot_idxs()` correctly produced two Q/K positions and then asserted against one. Sharding the original batch first and doubling afterward preserves the required two rows.

This is the focused current-main extraction of commit `7f1bf30c336` from draft multichip PR #45389. It is required by craq-sim current-main Galaxy model validation: https://github.com/tenstorrent/craq-sim/actions/runs/32199895732

### Notes for reviewers
Adds four focused CPU cases covering fused/non-fused, batch 1/32, Galaxy/single-device sizing. All four pass. A full BH Galaxy simulator validation is running here: https://github.com/tenstorrent/craq-sim/actions/runs/32206644013

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=codex/verify-main-galaxy-rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:codex/verify-main-galaxy-rope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=codex/verify-main-galaxy-rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:codex/verify-main-galaxy-rope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=codex/verify-main-galaxy-rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:codex/verify-main-galaxy-rope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=codex/verify-main-galaxy-rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:codex/verify-main-galaxy-rope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=codex/verify-main-galaxy-rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:codex/verify-main-galaxy-rope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=codex/verify-main-galaxy-rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:codex/verify-main-galaxy-rope)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=codex/verify-main-galaxy-rope)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:codex/verify-main-galaxy-rope)