### PR TITLE
#53616: Increase Quasar compute MOP timeout in TRISC firmware

### DIFF
--- a/tt_metal/hw/firmware/src/tt-2xx/trisck.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisck.cc
@@ -110,6 +110,15 @@ uint32_t _start() {
 
     EARLY_RETURN_FOR_DEBUG
 
+#ifdef ARCH_QUASAR
+    // Raise the compute MOP timeout so a slow-reader MOP (e.g. the avg-pool / reduce datacopy that
+    // stalls on a lagging reader) does not trip a 0x19/0x119 (MOP timeout) on the emulator.
+#ifndef CSR_TIMEOUT_COUNT
+#define CSR_TIMEOUT_COUNT 0xBD0
+#endif
+    asm volatile("csrw %0, %1" : : "i"(CSR_TIMEOUT_COUNT), "r"(0x100000));
+#endif
+
     WAYPOINT("K");
     run_kernel();
     WAYPOINT("KD");

--- a/tt_metal/hw/firmware/src/tt-2xx/trisck.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisck.cc
@@ -111,8 +111,7 @@ uint32_t _start() {
     EARLY_RETURN_FOR_DEBUG
 
 #ifdef ARCH_QUASAR
-    // Raise the compute MOP timeout so a slow-reader MOP (e.g. the avg-pool / reduce datacopy that
-    // stalls on a lagging reader) does not trip a 0x19/0x119 (MOP timeout) on the emulator.
+    // Raise the Memory Access Hang timeout so that it does not falsely trip a 0x19/0x119 hw trap.
 #ifndef CSR_TIMEOUT_COUNT
 #define CSR_TIMEOUT_COUNT 0xBD0
 #endif


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Feature

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #53616 

On quasar emulator it was found that some ops need to have an increased CSR timeout to avoid MOP timeout errors. avgpool was found to need this even with DPRINT/WATCHER/ASSERTS off.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-53616_qsr_csr)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-53616_qsr_csr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-53616_qsr_csr)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-53616_qsr_csr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-53616_qsr_csr)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-53616_qsr_csr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-53616_qsr_csr)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-53616_qsr_csr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-53616_qsr_csr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-53616_qsr_csr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-53616_qsr_csr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-53616_qsr_csr)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-53616_qsr_csr)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-53616_qsr_csr)