### PR TITLE
Fix HEIGHT_SHARDED page stride in untilize_with_unpadding

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py
@@ -211,6 +211,40 @@ def test_untilize_with_unpadding_height_sharded_narrow_width_regression(device, 
     assert_equal(result, torch_input)
 
 
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32])
+@pytest.mark.parametrize("output_width", [30, 31, 32])
+def test_untilize_with_unpadding_interleaved_to_height_sharded_unaligned_row(device, dtype, output_width):
+    """INTERLEAVED input -> HEIGHT_SHARDED output whose row size is not a multiple of the
+    buffer alignment (16 bytes in L1).
+    """
+    torch.manual_seed(0)
+    shape = [1, 1, 256, 64]
+    output_end = [0, 0, 255, output_width - 1]
+    torch_input = torch.rand(shape, dtype=TTNN_TO_TORCH_DTYPE[dtype])
+
+    # Shard width tracks the unpadded output width, so the output row size in bytes stays
+    # unaligned - padding the shard out to a tile width would hide the mis-striding.
+    num_cores = 4
+    shard_core_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, num_cores - 1))})
+    output_shard_spec = ttnn.ShardSpec(
+        shard_core_grid, (shape[2] // num_cores, output_width), ttnn.ShardOrientation.ROW_MAJOR
+    )
+    output_memory_config = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, output_shard_spec
+    )
+
+    tile_tensor = ttnn.from_torch(
+        torch_input, dtype=dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    untilized = ttnn.untilize_with_unpadding(
+        tile_tensor, output_tensor_end=output_end, memory_config=output_memory_config
+    )
+    result = ttnn.to_torch(untilized)
+
+    slices = tuple(slice(0, output_end[i] + 1) for i in range(len(output_end)))
+    assert_equal(result, torch_input[slices])
+
+
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
 @pytest.mark.parametrize(
     "shape, output_end, shard_shape, num_cores",

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
@@ -103,13 +103,19 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreInterleavedProgram
      */
     // BLOCK/WIDTH-sharded outputs split a logical row across shards - the writer's
     // noc_async_write_sharded needs the per-shard page size (shard width in bytes), not the full
-    // row size, to do that split correctly. HEIGHT-sharded and interleaved outputs keep a whole row
-    // per page, same as the full row size.
+    // row size, to do that split correctly. A HEIGHT-sharded output keeps a whole row per page, but
+    // the sharded accessor strides by exactly the page size it is handed and the allocator pads
+    // each row up to the buffer alignment. It needs the padded stride, not the row size. Interleaved
+    // outputs keep a whole row per page, same as the full row size.
     uint32_t writer_page_size = unpadded_row_size_bytes;
     const auto& out_mem_config = output.memory_config();
-    if (out_mem_config.is_sharded() && (out_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
-                                        out_mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED)) {
-        writer_page_size = out_mem_config.shard_spec().value().shape[1] * output.element_size();
+    if (out_mem_config.is_sharded()) {
+        if (out_mem_config.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
+            out_mem_config.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED) {
+            writer_page_size = out_mem_config.shard_spec().value().shape[1] * output.element_size();
+        } else {
+            writer_page_size = static_cast<uint32_t>(dst_buffer->aligned_page_size());
+        }
     }
     std::vector<uint32_t> writer_ct_args = {
         (input_cb_data_format == tt::DataFormat::Float32 or input_cb_data_format == tt::DataFormat::UInt32 or

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multicore.cpp
@@ -24,8 +24,10 @@ void kernel_main() {
     constexpr bool FLOAT32_DTYPE = get_compile_time_arg_val(0) == 1;
     constexpr uint32_t unpadded_X_size = get_compile_time_arg_val(1);
     // Per-shard page size in bytes: shard width for BLOCK/WIDTH-sharded output (a logical row
-    // spans multiple shards), full unpadded row otherwise. Feeds noc_async_write_sharded's
-    // multi-shard row split, same mechanism used by the ROW_MAJOR-input factory.
+    // spans multiple shards), the destination buffer's aligned page size for HEIGHT-sharded output
+    // (one row per page, padded up to the buffer alignment), full unpadded row for interleaved.
+    // Feeds noc_async_write_sharded's multi-shard row split and the accessor's page stride, same
+    // mechanism used by the ROW_MAJOR-input factory.
     constexpr uint32_t writer_page_size = get_compile_time_arg_val(2);
     constexpr auto dst_args = TensorAccessorArgs<3>();
 


### PR DESCRIPTION
### Issue 
Related to https://github.com/tenstorrent/tt-metal/issues/51308

### PR Category
Bug fix

### Problem
`UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory` bakes an explicit page size into its writer, which passes it as the third argument of `TensorAccessor`. For a sharded destination, that argument is stored verbatim and used as the page stride. The factory only overwrites that value for BLOCK/WIDTH-sharded outputs, where a logical row spans several shards. A HEIGHT_SHARDED output fell through to `unpadded_row_size_bytes`, which is the buffer's logical page size, not physical stride. So whenever the output row size is not a multiple of the buffer alignment, page N is addressed at `N * page_size()` instead of `N * aligned_page_size()`. The result produced  arbitrary output widths.

It went unnoticed because interleaved input to HEIGHT_SHARDED output was not covered in `test_untilize_with_unpadding.py`.

### Fix
HEIGHT_SHARDED takes the destination buffer's aligned page size.

### Notes for reviewers
This was found by the Metal 2.0 pre-port audit of `untilize_with_unpadding`, which classified the site as Class 3 (latent bug) and gated `MultiCoreInterleavedProgramFactory` on it.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anasuya/fix_untilize_with_unpadding)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anasuya/fix_untilize_with_unpadding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anasuya/fix_untilize_with_unpadding)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anasuya/fix_untilize_with_unpadding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anasuya/fix_untilize_with_unpadding)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anasuya/fix_untilize_with_unpadding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anasuya/fix_untilize_with_unpadding)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anasuya/fix_untilize_with_unpadding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anasuya/fix_untilize_with_unpadding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anasuya/fix_untilize_with_unpadding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anasuya/fix_untilize_with_unpadding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anasuya/fix_untilize_with_unpadding)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anasuya/fix_untilize_with_unpadding)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anasuya/fix_untilize_with_unpadding)