### PR TITLE
ci: give the vLLM structured output benchmark its own timeout

### DIFF
--- a/.github/workflows/vllm-model-tests-impl.yaml
+++ b/.github/workflows/vllm-model-tests-impl.yaml
@@ -507,7 +507,7 @@ jobs:
 
       - name: 📐 Run structured output benchmark
         if: ${{ matrix.test-group.structured-output }}
-        timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
+        timeout-minutes: ${{ matrix.test-group.structured-output-timeout || matrix.test-group.benchmark-timeout }}
         uses: ./docker-job/.github/actions/run-with-log
         with:
           log-file: ${{ env.FILE_BENCHMARK_STRUCTURED_OUTPUT_LOG }}

--- a/tests/pipeline_reorg/vllm_model_tests.yaml
+++ b/tests/pipeline_reorg/vllm_model_tests.yaml
@@ -14,6 +14,8 @@
 #
 # vLLM-specific per-entry keys (consumed by vllm-model-tests-impl.yaml):
 #   server-timeout / benchmark-timeout / sampling-test-timeout: per-step timeouts (minutes).
+#   structured-output-timeout: per-step timeout for the structured output benchmark
+#     (minutes). Defaults to benchmark-timeout; set it when that run is the long pole.
 #   mesh-device, arch, tt-config, additional-server-args, additional-benchmark-args,
 #   additional-structured-output-args, default-chat-template-kwargs, tt-llama-text-ver,
 #   tt-qwen3-text-ver, tt_mm_throttle_perf: server / benchmark configuration.
@@ -200,6 +202,10 @@
   tt-config: '{"sample_on_device_mode": "all"}'
   additional-server-args: "--max_num_seqs 1 --async-scheduling"
   structured-output: true
+  # The structured output run issues 32 x 1024-token requests against a server
+  # pinned to --max_num_seqs 1, so they are served strictly one at a time and the
+  # run takes far longer than the plain benchmark that shares benchmark-timeout.
+  structured-output-timeout: 30
   additional-structured-output-args: "--backend openai-chat --endpoint /v1/chat/completions --dataset json"
   skus:
     wh_galaxy_perf:


### PR DESCRIPTION
## Problem

`vllm-tests / GPT-OSS-120B (low-latency) [wh_galaxy_perf]` fails on every nightly at the `📐 Run structured output benchmark` step with `The action has timed out.` It is not a hang: the benchmark is making steady progress when the runner kills it.

Example: https://github.com/tenstorrent/tt-metal/actions/runs/32199971504/job/95916272849#step:18:163

That step inherits `benchmark-timeout: 15`, a value shared with the plain `📐 Run benchmark` step. The plain benchmark finishes in ~3.4 min, so 15 min was sized for it, not for the structured output run.

The structured output run is much longer by construction. It issues 32 requests at `--output-len 1024` against a server started with `--max_num_seqs 1` (this is the low-latency config), so the requests are served strictly one at a time.

## Evidence

Progress reported by the benchmark at the moment the 15 min timeout fired, across recent nightlies, with the implied total for all 32 requests:

| Run | Progress at kill | Rate | Extrapolated total |
|---|---|---|---|
| [32199971504](https://github.com/tenstorrent/tt-metal/actions/runs/32199971504/job/95916272849) | 25/32 at 13:44 | 33.0 s/req | ~17.6 min |
| 32138421992 | 20/32 at 14:26 | 43.3 s/req | ~23.1 min |
| 32083255283 | 19/32 at 14:02 | 44.3 s/req | ~23.6 min |
| 31980997763 | 22/32 at 13:55 | 37.9 s/req | ~20.2 min |
| 31852656266 | 27/32 at 14:39 | 32.6 s/req | ~17.4 min |

Worst case is ~24 min of benchmark loop plus ~35 s of process and tokenizer startup before the first request. 15 min was never enough.

## Change

Adds an optional `structured-output-timeout` per-entry key that the structured output step prefers, falling back to `benchmark-timeout` when unset. This mirrors the existing `sampling-test-timeout` pattern, so entries that do not set it are unaffected.

`GPT-OSS-120B (low-latency)` sets it to 30 min, roughly 25% headroom over the worst extrapolation. Raising the shared `benchmark-timeout` instead would have doubled the guard on the plain benchmark for no reason.

## Budget and job guard

- The time budget checker sums only the SKU-level `timeout`, not per-step timeouts, so this does not consume budget. `wh_galaxy_perf` is at 430/430 and stays there.
- The whole-job guard (`timeout: 75`) is untouched and still fits. In the linked run the structured output step started 12.8 min into the job, so a full 30 min run lands at ~43 min plus reporting.

## Out of scope

`GPT-OSS-120B (high-throughput)` also fails its structured output step, but for a different reason: it completes in ~7:15 within its 10 min budget and fails the `correct_rate(%) == 100.0` gate. That is a correctness problem, not a timeout, and is not addressed here.

## Checks

- `verify_time_budget.py` passes.
- `prepare_test_matrix.py` carries `structured-output-timeout: 30` into the low-latency matrix entry and leaves the key absent elsewhere, so the `||` fallback applies.
- `pre-commit` passes on both changed files.

CI: https://github.com/tenstorrent/tt-metal/actions/runs/32228990874/job/96011687326 (fails, but not on timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=viktorpus/vllm-structured-output-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:viktorpus/vllm-structured-output-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=viktorpus/vllm-structured-output-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:viktorpus/vllm-structured-output-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/vllm-structured-output-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/vllm-structured-output-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=viktorpus/vllm-structured-output-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:viktorpus/vllm-structured-output-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/vllm-structured-output-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/vllm-structured-output-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/vllm-structured-output-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/vllm-structured-output-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/vllm-structured-output-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/vllm-structured-output-timeout)