### PR TITLE
fix(sfpu): add domain split to ttnn.i0

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_unary_i0.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_unary_i0.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+import ttnn
+
+
+_TOLS = {
+    ttnn.float32: dict(rtol=1e-4, atol=1e-6),
+    ttnn.bfloat16: dict(rtol=1e-2, atol=1e-3),
+}
+
+
+def _assert_close(name, got, ref, dtype):
+    tols = _TOLS[dtype]
+    got_f32 = got.float()
+    ref_f32 = ref.float()
+    if not torch.allclose(got_f32, ref_f32, rtol=tols["rtol"], atol=tols["atol"]):
+        diff = (got_f32 - ref_f32).abs()
+        rel = diff / (ref_f32.abs() + tols["atol"])
+        idx = rel.argmax()
+        raise AssertionError(
+            f"{name}: not allclose (rtol={tols['rtol']}, atol={tols['atol']}); "
+            f"worst rel_err={rel.flatten()[idx].item():.2e} "
+            f"ref={ref_f32.flatten()[idx].item():.4e} got={got_f32.flatten()[idx].item():.4e}"
+        )
+
+
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        [1, 1, 32, 32],
+        [4, 2, 96, 192],
+        [64, 64],
+    ],
+)
+def test_i0_range(device, shapes):
+    torch.manual_seed(0)
+
+    low, high = -7.0, 7.0
+    torch_input_tensor_a = torch.rand(shapes, dtype=torch.float32) * (high - low) + low
+    torch_output_tensor = torch.special.i0(torch_input_tensor_a)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.float32,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    output_tensor = ttnn.i0(input_tensor_a, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert torch.allclose(output_tensor, torch_output_tensor, rtol=1e-4, atol=1e-6)
+
+
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
+def test_i0_ood(device, dtype):
+    torch.manual_seed(0)
+
+    shapes = [4, 2, 96, 192]
+    torch_input_tensor_a = torch.rand(shapes, dtype=torch.float32) * 100.0 - 50.0
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    ref_input = torch_input_tensor_a.to(torch_dtype).to(torch.float32)
+    torch_output_tensor = torch.special.i0(ref_input)
+
+    input_tensor_a = ttnn.from_torch(
+        torch_input_tensor_a,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=dtype,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    output_tensor = ttnn.i0(input_tensor_a, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    _assert_close("test_i0_ood", output_tensor, torch_output_tensor, dtype)
+
+
+@pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
+def test_i0_clamp_boundary(device, dtype):
+    boundaries = torch.tensor(
+        [-100.0, -88.5, -88.0, -7.5, -7.0, -6.5, 6.5, 7.0, 7.5, 88.0, 88.5, 100.0],
+        dtype=torch.float32,
+    )
+    expected_input = torch.clamp(boundaries, min=-88.5, max=88.5)
+    torch_dtype = torch.bfloat16 if dtype == ttnn.bfloat16 else torch.float32
+    expected_input = expected_input.to(torch_dtype).to(torch.float32)
+    torch_output_tensor = torch.special.i0(expected_input)
+
+    padded = torch.zeros((1, 1, 32, 32), dtype=torch.float32)
+    padded[0, 0, 0, : boundaries.numel()] = boundaries
+
+    input_tensor_a = ttnn.from_torch(
+        padded,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=dtype,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    output_tensor = ttnn.i0(input_tensor_a, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    output_tensor = ttnn.to_torch(output_tensor)[0, 0, 0, : boundaries.numel()]
+
+    _assert_close("test_i0_clamp_boundary", output_tensor, torch_output_tensor, dtype)

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -6,7 +6,9 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "ckernel_sfpu_exp.h"
 #include "cmath_common.h"
+#include "sfpu/ckernel_sfpu_polyval.h"
 
 using namespace sfpi;
 
@@ -23,32 +25,71 @@ namespace sfpu {
            t4) *                                                                                                  \
           t4) *                                                                                                   \
      t4)
+
 inline void i0_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline sfpi::vFloat calculate_i0_asymptotic_(const sfpi::vFloat abs_x) {
+#ifdef INP_FLOAT32
+    const sfpi::vFloat exp_abs = _sfpu_exp_fp32_accurate_unsafe_(abs_x);
+#else
+    const sfpi::vFloat exp_abs = _sfpu_exp_21f_bf16_unsafe_<true>(abs_x);
+#endif
+
+    const sfpi::vInt rsqrt_i = sfpi::as<sfpi::vInt>(sfpi::as<sfpi::vUInt>(abs_x) >> 1);
+    sfpi::vFloat rsqrt_y = sfpi::as<sfpi::vFloat>(sfpi::vInt(0x5f1110a0) - rsqrt_i);
+    sfpi::vFloat c0 = (-rsqrt_y) * (abs_x * rsqrt_y);
+    rsqrt_y = rsqrt_y * (sfpi::vFloat(2.2825186f) + c0 * (sfpi::vFloat(2.2533049f) + c0));
+    c0 = 1.0f + (-rsqrt_y) * (abs_x * rsqrt_y);
+    rsqrt_y = c0 * sfpi::addexp(rsqrt_y, -1) + rsqrt_y;
+
+    const sfpi::vFloat inv_abs_x = rsqrt_y * rsqrt_y;
+    const sfpi::vFloat correction = PolynomialEvaluator::eval(
+        inv_abs_x,
+        9.9999994040e-01f,
+        1.2500022352e-01f,
+        7.0881240070e-02f,
+        4.6733535826e-02f,
+        4.8666957021e-01f,
+        -1.3541922569e+00f);
+    return exp_abs * rsqrt_y * correction;
+}
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_i0() {
+    constexpr float I0_MAX_INPUT = 88.5f;
+    constexpr float I0_THRESHOLD = 7.0f;
+
 #pragma GCC unroll 0
-
     for (int d = 0; d < ITERATIONS; d++) {
-        vFloat result = 0.0f;
-        vFloat input = dst_reg[0];
-        vFloat x = input * input;
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        x = sfpi::symmetric_clamp(x, I0_MAX_INPUT);
 
-        result = 1.0f + POLYVAL10(
-                            1.50E-22f,
-                            7.24E-20f,
-                            2.90E-17f,
-                            9.39E-15f,
-                            2.40E-12f,
-                            4.71E-10f,
-                            6.78E-08f,
-                            0.000006781684028f,
-                            0.0004340277778f,
-                            0.015625f,
-                            0.25f,
-                            x);
+        const sfpi::vFloat abs_x = sfpi::abs(x);
+        sfpi::vFloat val;
 
-        dst_reg[0] = result;
+        {
+            const sfpi::vFloat t = x * x;
+            val = 1.0f + POLYVAL10(
+                               1.50E-22f,
+                               7.24E-20f,
+                               2.90E-17f,
+                               9.39E-15f,
+                               2.40E-12f,
+                               4.71E-10f,
+                               6.78E-08f,
+                               0.000006781684028f,
+                               0.0004340277778f,
+                               0.015625f,
+                               0.25f,
+                               t);
+        }
+
+        v_if(abs_x > I0_THRESHOLD) { val = calculate_i0_asymptotic_(abs_x); }
+        v_endif;
+#ifndef INP_FLOAT32
+        val = sfpi::convert<sfpi::vFloat16b>(val, sfpi::RoundMode::Nearest);
+#endif
+        sfpi::dst_reg[0] = val;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_i0.h
@@ -6,7 +6,9 @@
 
 #include "ckernel.h"
 #include "ckernel_defs.h"
+#include "ckernel_sfpu_exp.h"
 #include "cmath_common.h"
+#include "sfpu/ckernel_sfpu_polyval.h"
 
 using namespace sfpi;
 
@@ -23,32 +25,71 @@ namespace sfpu {
            t4) *                                                                                                  \
           t4) *                                                                                                   \
      t4)
+
 inline void i0_init() { math::reset_counters(p_setrwc::SET_ABD_F); }
+
+inline sfpi::vFloat calculate_i0_asymptotic_(const sfpi::vFloat abs_x) {
+#ifdef INP_FLOAT32
+    const sfpi::vFloat exp_abs = _sfpu_exp_fp32_accurate_unsafe_(abs_x);
+#else
+    const sfpi::vFloat exp_abs = _sfpu_exp_21f_bf16_unsafe_<true>(abs_x);
+#endif
+
+    const sfpi::vInt rsqrt_i = sfpi::as<sfpi::vInt>(sfpi::as<sfpi::vUInt>(abs_x) >> 1);
+    sfpi::vFloat rsqrt_y = sfpi::as<sfpi::vFloat>(sfpi::vInt(0x5f1110a0) - rsqrt_i);
+    sfpi::vFloat c0 = (-rsqrt_y) * (abs_x * rsqrt_y);
+    rsqrt_y = rsqrt_y * (sfpi::vFloat(2.2825186f) + c0 * (sfpi::vFloat(2.2533049f) + c0));
+    c0 = 1.0f + (-rsqrt_y) * (abs_x * rsqrt_y);
+    rsqrt_y = c0 * sfpi::addexp(rsqrt_y, -1) + rsqrt_y;
+
+    const sfpi::vFloat inv_abs_x = rsqrt_y * rsqrt_y;
+    const sfpi::vFloat correction = PolynomialEvaluator::eval(
+        inv_abs_x,
+        9.9999994040e-01f,
+        1.2500022352e-01f,
+        7.0881240070e-02f,
+        4.6733535826e-02f,
+        4.8666957021e-01f,
+        -1.3541922569e+00f);
+    return exp_abs * rsqrt_y * correction;
+}
 
 template <bool APPROXIMATION_MODE, int ITERATIONS = 8>
 inline void calculate_i0() {
+    constexpr float I0_MAX_INPUT = 88.5f;
+    constexpr float I0_THRESHOLD = 7.0f;
+
 #pragma GCC unroll 0
-
     for (int d = 0; d < ITERATIONS; d++) {
-        vFloat result = 0.0f;
-        vFloat input = dst_reg[0];
-        vFloat x = input * input;
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        x = sfpi::symmetric_clamp(x, I0_MAX_INPUT);
 
-        result = 1.0f + POLYVAL10(
-                            1.50E-22f,
-                            7.24E-20f,
-                            2.90E-17f,
-                            9.39E-15f,
-                            2.40E-12f,
-                            4.71E-10f,
-                            6.78E-08f,
-                            0.000006781684028f,
-                            0.0004340277778f,
-                            0.015625f,
-                            0.25f,
-                            x);
+        const sfpi::vFloat abs_x = sfpi::abs(x);
+        sfpi::vFloat val;
 
-        dst_reg[0] = result;
+        {
+            const sfpi::vFloat t = x * x;
+            val = 1.0f + POLYVAL10(
+                               1.50E-22f,
+                               7.24E-20f,
+                               2.90E-17f,
+                               9.39E-15f,
+                               2.40E-12f,
+                               4.71E-10f,
+                               6.78E-08f,
+                               0.000006781684028f,
+                               0.0004340277778f,
+                               0.015625f,
+                               0.25f,
+                               t);
+        }
+
+        v_if(abs_x > I0_THRESHOLD) { val = calculate_i0_asymptotic_(abs_x); }
+        v_endif;
+#ifndef INP_FLOAT32
+        val = sfpi::convert<sfpi::vFloat16b>(val, sfpi::RoundMode::Nearest);
+#endif
+        sfpi::dst_reg[0] = val;
         dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -2762,7 +2762,7 @@ class UnarySFPUGolden:
         return self._torch_unary(x, torch.nn.functional.selu)
 
     def _i0(self, x):
-        # modified Bessel I0; kernel uses a poly approx valid on |x| <= 3.75.
+        # modified Bessel I0.
         return self._torch_unary(x, torch.special.i0)
 
     def _rdiv(self, x, value=2.0):

--- a/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/sfpu_domains.py
@@ -409,9 +409,9 @@ _OP_DOMAIN_REGISTRY: Dict[
     MathOperation.Selu: OperandSpecs(
         spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-5.0, high=5.0)
     ),
-    # i0: modified Bessel I0; kernel poly approx is only valid on |x| <= 3.75
+    # i0: modified Bessel I0; sweep past the handover so tests reach the asymptotic branch.
     MathOperation.I0: OperandSpecs(
-        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=-3.75, high=3.75)
+        spec_A=StimuliSpec(distribution=DistributionKind.UNIFORM, low=0.0, high=40.0)
     ),
     # i1: modified Bessel I1; poly path valid on |x| <= ~3.75 (asymptotic beyond)
     MathOperation.I1: OperandSpecs(

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/unary_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/unary_nanobind.cpp
@@ -1731,8 +1731,8 @@ void py_module(nb::module_& mod) {
     bind_unary_operation_subcoregrids<"i0">(
         mod,
         &ttnn::i0,
-        R"doc(\mathrm{{output\_tensor}}_i = \verb|i0|(\mathrm{{input\_tensor}}_i))doc",
-        "",
+        R"doc(\mathrm{{output\_tensor}}_i = I_0(\mathrm{{input\_tensor}}_i))doc",
+        "[Validated range: -88.5 to 88.5]",
         R"doc(BFLOAT16, BFLOAT8_B, FLOAT32)doc");
     bind_unary_operation_subcoregrids<"i1">(
         mod,


### PR DESCRIPTION
**## Summary**
Fixes #50465 by adding a two-region implementation for `ttnn.i0`.

`ttnn.i0` previously used a single fixed Maclaurin series and became silently inaccurate for large `|x|`. This change mirrors the proven `i1` structure:
- polynomial path for small inputs
- asymptotic path for large inputs
- clamp at `88.5` to avoid overflow

**The same fix is applied to both Wormhole and Blackhole kernel copies.**

**## Test updates**
- widened SFPU `I0` coverage to `[0, 40]`
- added a dedicated `ttnn.i0` unit test
- added in-range, OOD, and clamp-boundary coverage

**## Notes**
- `ttnn.i0` binding now documents the validated range
- threshold used here is `7`, based on the measured result reported in the issue discussion