### PR TITLE
Kimi K3 - Fix for MoE perf test in CI being skipped

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -110,6 +110,7 @@ def run_model(
     rms_norm_eps=1e-5,
     final_output_pcc=0.982,
     routed_activation=ttnn.RoutedExpertActivation.Silu,
+    measure=None,
 ):
     """TtMoe PCC body — shared between `test_ds_moe` / `test_kimi_moe`.
 
@@ -127,6 +128,12 @@ def run_model(
     ``routed_activation`` selects the fused routed-expert kernel's activation and the matching
     torch reference. The shared expert always runs SiLU: no SiTU kernel exists outside the
     routed-expert op, so both sides must stay on SiLU there for the comparison to mean anything.
+
+    ``measure`` wraps the forward for a perf caller: it is called as ``measure(forward)``,
+    must invoke the thunk and return its result, and owns the device sync. The perf gates use
+    it to run the forward inside a real-time-profiler window (see
+    ``tests/perf/test_kimi_k3_moe_perf.py``) so the measured region is the forward alone --
+    the constructor's one-time weight tilize/typecast stays outside it.
     """
     if routed_activation not in _TORCH_ROUTED_ACTIVATION or routed_activation not in _UPSTREAM_ACT:
         raise ValueError(f"no torch reference for {routed_activation}; supported: {list(_TORCH_ROUTED_ACTIVATION)}")
@@ -424,11 +431,18 @@ def run_model(
     logger.debug("Running TtMoe forward pass...")
 
     tt_x = upload_tt_x()
+
+    def forward():
+        return tt_moe(tt_x, return_intermediates=run_pcc_check, actual_isl=actual_isl, padding_side="right")
+
     signpost(header="tt_forward_START")
-    tt_output, tt_intermediates = tt_moe(
-        tt_x, return_intermediates=run_pcc_check, actual_isl=actual_isl, padding_side="right"
-    )
-    ttnn.synchronize_device(mesh_device)
+    if measure is None:
+        tt_output, tt_intermediates = forward()
+        ttnn.synchronize_device(mesh_device)
+    else:
+        # measure() syncs: the real-time profiler stops collecting once the window closes, so
+        # the sync has to happen inside it or the last programs' records are still in flight.
+        tt_output, tt_intermediates = measure(forward)
     signpost(header="tt_forward_END")
 
     profiler.end("tt_forward")

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_k3_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_k3_moe_perf.py
@@ -7,22 +7,11 @@ Kimi-K3 LatentMoE device-perf gate on the 8x4 galaxy, measured with the real-tim
 profiler -- same mechanism as ``test_ttnn_hca_perf.py``, which already gates HCA perf on this
 SKU.
 
-Why not the tracy harness the deepseek MoE gates in ``test_moe_perf.py`` use: blaze builds
-with the profiler disabled (``blaze-models-prefill-tests.yaml`` passes no ``tracy:`` input ->
-``build-artifact.yaml`` adds ``--disable-profiler`` -> ``ENABLE_TRACY=OFF``, which early-returns
-before tracy's capture/csvexport targets), so ``build/tools/profiler/bin`` is empty there and the
-``python -m tracy`` subprocess that ``run_model_device_perf_test_with_merge`` shells out to has
-nothing to run. The real-time profiler is an in-process device API
-(``tt_metal/distributed/realtime_profiler_manager.cpp``), not gated on ``TRACY_ENABLE``, so it
-measures on the pipeline's ordinary build. It also drops the nested pytest re-run, which is what
-keeps this inside the leg's 22-minute slot.
-
 What the number is: over the programs the MoE forward dispatched, the sum of each program's
 critical path (max duration across the 32 chips). Close to but NOT the same as the tracy
 baseline it replaces -- ``merge_device_rows`` averages CCL ops across devices where this takes
 their max -- so this baseline was measured with the real-time profiler and must not be
-back-ported to the tracy path. For reference the tracy number was 12_924_852 ns, split Matmul
-2_196 us / CCL 1_042 us / Other 9_687 us (dispatch/combine/top-k dominates).
+back-ported to the tracy path.
 
 What the number excludes, verified on an 8x4 galaxy (warm caches, 58 programs x 32 chips =
 1856 records, 0 dropped, no program dispatched more than once per chip):
@@ -37,22 +26,13 @@ What the number excludes, verified on an 8x4 galaxy (warm caches, 58 programs x 
     get pulled *inside* the records: the same forward measured cold (JIT compiling ~1080 kernels)
     reported 19.01 ms, i.e. the E2E span rather than the sum. Hence the warm-up pass in the test.
 
-Still inside each record: the dispatcher prologue (loop-top -> go-signal mcast -> worker launch) and
-the completion-semaphore tail. Measured at <=1.5% against tracy's kernel-only sum -- roughly the
-observed run-to-run noise (12.944 / 13.080 ms on two warm runs). Isolating kernel spans exactly
-needs the kernel-zone instrumentation (``PROFILE_KERNEL``), which only a Tracy build compiles in --
-use tracy on a dev box for op-level tuning.
-
-Report-only until calibrated: ``_EXPECTED_NS`` starts as ``None``, so the first galaxy runs
-measure and log without gating. See the constant for what to do with the logged number.
+Recalibrating: set ``_EXPECTED_NS = None`` and the test measures and logs without gating, printing
+the value to set it back to. Do that on any box whose baseline you need to re-cut.
 
 Two limits carried over from the tracy version:
 
   * Measures the SiLU path, not the checkpoint's SiTU-GLU (#51335), so this baseline moves when
     that kernel lands.
-  * Forward only. At 896 experts the constructor's one-time weight tilize/typecast is a large
-    share of wall time but is not per-token cost; the profiler window is the forward call, so it
-    is excluded by construction (no signposts needed).
 """
 
 import os
@@ -75,15 +55,12 @@ _SEQ_LEN_PER_CHIP = 640
 # Capacity factor 5 carries over from K2.6, as in the pcc parametrize.
 _DISPATCH_BUFFER_CAPACITY_FACTOR = 5
 
-# None = report only, no perf gate. The tracy baseline this replaces (12_924_852 ns) is not a
-# comparable number (see the module docstring), so there is nothing honest to assert against until
-# the real-time profiler has reported once on the galaxy. Calibration is one step: take the
-# "realtime perf" ns this test logs on its first green run and set it here (TODO #53269) -- that
-# alone turns the gate on. The measurement itself still fails loudly if it produced no records.
-_EXPECTED_NS = None
-# 10 warm measurements on one 8x4 galaxy spanned 12.915-13.159 ms (median 12.991, stdev 0.64%),
-# i.e. +/-1.3% around the median holds every sample. 3% covers that, and sub-nominal DDR doubles it
-# to 6% via adjust_margin_for_ddr_speed.
+# Measured 2026-08-19 on an 8x4 BH galaxy (DDR 16000, 130W), warm forward, 58 programs.
+_EXPECTED_NS = 13_088_659
+# Repeated warm measurements on that box spanned 12.915-13.159 ms (stdev 0.63%, 1.89% peak to
+# peak), so 3% holds the observed run-to-run noise; sub-nominal DDR doubles it to 6% via
+# adjust_margin_for_ddr_speed. The baseline above is one run, so the band sits nearer the top of
+# that spread than the middle -- recentre it if a regression this shallow ever needs catching.
 _MARGIN = 0.03
 
 # The profiler's default 1s collection deadline is sized for a single block's programs. The MoE

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_k3_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_k3_moe_perf.py
@@ -24,6 +24,25 @@ their max -- so this baseline was measured with the real-time profiler and must 
 back-ported to the tracy path. For reference the tracy number was 12_924_852 ns, split Matmul
 2_196 us / CCL 1_042 us / Other 9_687 us (dispatch/combine/top-k dominates).
 
+What the number excludes, verified on an 8x4 galaxy (warm caches, 58 programs x 32 chips =
+1856 records, 0 dropped, no program dispatched more than once per chip):
+
+  * **Op-to-op dispatch gaps: 7.29 ms, excluded.** A record runs from the dispatch_s loop-top that
+    picks up the program's GO command to the last worker's completion semaphore
+    (``cq_dispatch_subordinate.cpp``, ``record_realtime_timestamp`` at both ends), so the time from
+    one program's workers-done to the next program's loop-top falls *between* records. The forward's
+    first_start->last_end span was 19.39 ms against a 12.53 ms sum of program durations.
+  * **Host stalls: excluded, but only because the measured pass is warm.** The start stamp is taken
+    before ``cb_acquire_pages_dispatch_s`` blocks on host-fed pages, so when the host lags the gaps
+    get pulled *inside* the records: the same forward measured cold (JIT compiling ~1080 kernels)
+    reported 19.01 ms, i.e. the E2E span rather than the sum. Hence the warm-up pass in the test.
+
+Still inside each record: the dispatcher prologue (loop-top -> go-signal mcast -> worker launch) and
+the completion-semaphore tail. Measured at <=1.5% against tracy's kernel-only sum -- roughly the
+observed run-to-run noise (12.944 / 13.080 ms on two warm runs). Isolating kernel spans exactly
+needs the kernel-zone instrumentation (``PROFILE_KERNEL``), which only a Tracy build compiles in --
+use tracy on a dev box for op-level tuning.
+
 Report-only until calibrated: ``_EXPECTED_NS`` starts as ``None``, so the first galaxy runs
 measure and log without gating. See the constant for what to do with the logged number.
 
@@ -62,6 +81,9 @@ _DISPATCH_BUFFER_CAPACITY_FACTOR = 5
 # "realtime perf" ns this test logs on its first green run and set it here (TODO #53269) -- that
 # alone turns the gate on. The measurement itself still fails loudly if it produced no records.
 _EXPECTED_NS = None
+# 10 warm measurements on one 8x4 galaxy spanned 12.915-13.159 ms (median 12.991, stdev 0.64%),
+# i.e. +/-1.3% around the median holds every sample. 3% covers that, and sub-nominal DDR doubles it
+# to 6% via adjust_margin_for_ddr_speed.
 _MARGIN = 0.03
 
 # The profiler's default 1s collection deadline is sized for a single block's programs. The MoE
@@ -109,6 +131,15 @@ def test_kimi_k3_moe_perf_galaxy(variant, config_only, mesh_device, device_param
     per_program = {}
 
     def measure(forward):
+        # Warm-up pass, discarded. An RT record starts when the dispatcher picks up the command --
+        # before cb_acquire_pages_dispatch_s blocks on host-fed pages -- so host stalls land inside
+        # the measured window. On a cold run that means JIT compilation of ~1080 kernels. Dispatch
+        # overhead itself is device work and stays in the number; host compile time is not device
+        # time and must not be.
+        warm = forward()
+        ttnn.synchronize_device(mesh_device)
+        del warm  # 896 experts: free the discarded outputs before allocating the measured pass
+
         result, records = profile_realtime_program_merged(
             mesh_device, forward, record_timeout_seconds=_RECORD_TIMEOUT_S
         )

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_k3_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_kimi_k3_moe_perf.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Kimi-K3 LatentMoE device-perf gate on the 8x4 galaxy, measured with the real-time program
+profiler -- same mechanism as ``test_ttnn_hca_perf.py``, which already gates HCA perf on this
+SKU.
+
+Why not the tracy harness the deepseek MoE gates in ``test_moe_perf.py`` use: blaze builds
+with the profiler disabled (``blaze-models-prefill-tests.yaml`` passes no ``tracy:`` input ->
+``build-artifact.yaml`` adds ``--disable-profiler`` -> ``ENABLE_TRACY=OFF``, which early-returns
+before tracy's capture/csvexport targets), so ``build/tools/profiler/bin`` is empty there and the
+``python -m tracy`` subprocess that ``run_model_device_perf_test_with_merge`` shells out to has
+nothing to run. The real-time profiler is an in-process device API
+(``tt_metal/distributed/realtime_profiler_manager.cpp``), not gated on ``TRACY_ENABLE``, so it
+measures on the pipeline's ordinary build. It also drops the nested pytest re-run, which is what
+keeps this inside the leg's 22-minute slot.
+
+What the number is: over the programs the MoE forward dispatched, the sum of each program's
+critical path (max duration across the 32 chips). Close to but NOT the same as the tracy
+baseline it replaces -- ``merge_device_rows`` averages CCL ops across devices where this takes
+their max -- so this baseline was measured with the real-time profiler and must not be
+back-ported to the tracy path. For reference the tracy number was 12_924_852 ns, split Matmul
+2_196 us / CCL 1_042 us / Other 9_687 us (dispatch/combine/top-k dominates).
+
+Report-only until calibrated: ``_EXPECTED_NS`` starts as ``None``, so the first galaxy runs
+measure and log without gating. See the constant for what to do with the logged number.
+
+Two limits carried over from the tracy version:
+
+  * Measures the SiLU path, not the checkpoint's SiTU-GLU (#51335), so this baseline moves when
+    that kernel lands.
+  * Forward only. At 896 experts the constructor's one-time weight tilize/typecast is a large
+    share of wall time but is not per-token cost; the profiler window is the forward call, so it
+    is excluded by construction (no signposts needed).
+"""
+
+import os
+
+import pytest
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.reference.kimi_k3_config import KimiK3Config
+from models.demos.deepseek_v3_d_p.tests.pcc.test_ttnn_moe import run_model
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
+from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
+from models.demos.deepseek_v3_d_p.utils.perf_utils import adjust_margin_for_ddr_speed
+from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import is_high_power
+from tests.ttnn.profiling.realtime_profiler_utils import profile_realtime_program_merged, require_realtime_profiler
+
+# 640 tokens/chip over SP=8 = the 5k ISL the pcc leg's `kimi_k3-5k-perf` case runs.
+_SEQ_LEN_PER_CHIP = 640
+# Capacity factor 5 carries over from K2.6, as in the pcc parametrize.
+_DISPATCH_BUFFER_CAPACITY_FACTOR = 5
+
+# None = report only, no perf gate. The tracy baseline this replaces (12_924_852 ns) is not a
+# comparable number (see the module docstring), so there is nothing honest to assert against until
+# the real-time profiler has reported once on the galaxy. Calibration is one step: take the
+# "realtime perf" ns this test logs on its first green run and set it here (TODO #53269) -- that
+# alone turns the gate on. The measurement itself still fails loudly if it produced no records.
+_EXPECTED_NS = None
+_MARGIN = 0.03
+
+# The profiler's default 1s collection deadline is sized for a single block's programs. The MoE
+# forward at 896 experts dispatches far more, and records arrive asynchronously from the receiver
+# thread: a record still in flight when the window closes is NOT counted as dropped, so a short
+# deadline would silently under-report. Costs nothing when records arrive promptly -- collection
+# still exits on the settle window, not the deadline.
+_RECORD_TIMEOUT_S = 5.0
+
+# The team gates perf on the 14kW hosts. Set this to run anywhere for bring-up, where the
+# baseline describes nothing and only "does it run" is being checked.
+_IGNORE_POWER = os.environ.get("K3_MOE_PERF_IGNORE_POWER") == "1"
+
+
+@pytest.mark.skipif(not is_blackhole(), reason="Kimi-K3 LatentMoE requires Blackhole")
+@pytest.mark.skipif(
+    not (is_high_power() or _IGNORE_POWER),
+    reason="perf job requires a high-power (>=130W TDP) galaxy; guards the exabox.tenstorrent.com/power=14kw "
+    "label. K3_MOE_PERF_IGNORE_POWER=1 runs it anyway, for bring-up only",
+)
+@pytest.mark.timeout(0)
+@pytest.mark.parametrize(
+    "mesh_device, device_params, num_links, topology",
+    [
+        pytest.param(
+            (8, 4),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK3Config.FABRIC_PAYLOAD_SIZE),
+                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
+            },
+            2,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 4), topology="mesh-8x4"),
+            id="fabric2d-mesh-8x4",
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("variant", ["kimi_k3"], indirect=True, ids=["kimi_k3"])
+def test_kimi_k3_moe_perf_galaxy(variant, config_only, mesh_device, device_params, num_links, topology, request):
+    """896 experts / top-16, 3584 latent: device time of one MoE forward at 5k ISL."""
+    require_realtime_profiler("the Kimi-K3 MoE perf gate")
+
+    per_program = {}
+
+    def measure(forward):
+        result, records = profile_realtime_program_merged(
+            mesh_device, forward, record_timeout_seconds=_RECORD_TIMEOUT_S
+        )
+        per_program.update(records)
+        return result
+
+    run_model(
+        variant,
+        config_only,
+        mesh_device,
+        device_params,
+        _SEQ_LEN_PER_CHIP,
+        KimiK3Config.EMB_SIZE,
+        KimiK3Config.MOE_INTERMEDIATE_SIZE,
+        KimiK3Config.NUM_ROUTED_EXPERTS,
+        KimiK3Config.NUM_EXPERTS_PER_TOKEN,
+        _DISPATCH_BUFFER_CAPACITY_FACTOR,
+        False,  # run_pcc_check -- the pcc leg (kimi_k3-5k-pcc) owns correctness
+        num_links,
+        topology,
+        GateComputeMode.DEVICE_FP32,
+        request,
+        routed_emb_dim=KimiK3Config.ROUTED_EXPERT_HIDDEN_SIZE,
+        shared_hidden_dim=KimiK3Config.SHARED_EXPERT_INTERMEDIATE_SIZE,
+        latent_use_norm=KimiK3Config.LATENT_MOE_USE_NORM,
+        rms_norm_eps=KimiK3Config.RMS_NORM_EPS,
+        measure=measure,
+    )
+
+    # run_model returns early on the perf path, so an empty dict means measure() never ran --
+    # i.e. the forward was not the thing profiled. Never report green off that.
+    assert per_program, "real-time profiler produced no program records for the MoE forward"
+
+    total_ns = sum(entry["duration_ns"] for entry in per_program.values())
+
+    if _EXPECTED_NS is None:
+        logger.warning(
+            f"kimi-k3 moe 8x4 realtime perf: {total_ns:,.0f} ns ({total_ns / 1e6:.3f} ms) over "
+            f"{len(per_program)} programs -- REPORT ONLY, this run does NOT gate perf. "
+            f"Set _EXPECTED_NS = {total_ns:,.0f} in {os.path.basename(__file__)} (TODO #53269) to start gating."
+        )
+        return
+
+    margin = adjust_margin_for_ddr_speed(_MARGIN)
+    lower, upper = _EXPECTED_NS * (1 - margin), _EXPECTED_NS * (1 + margin)
+    logger.info(
+        f"kimi-k3 moe 8x4 realtime perf: {total_ns:,.0f} ns ({total_ns / 1e6:.3f} ms) over "
+        f"{len(per_program)} programs, expected {_EXPECTED_NS:,} ns, "
+        f"band [{lower:,.0f}, {upper:,.0f}] (margin +/- {margin * 100:.1f}%)"
+    )
+    assert lower <= total_ns <= upper, (
+        f"device time {total_ns:,.0f} ns outside band [{lower:,.0f}, {upper:,.0f}] "
+        f"(expected {_EXPECTED_NS:,} ns, margin +/- {margin * 100:.1f}%)"
+    )

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
@@ -97,8 +97,3 @@ def test_deepseek_v3_moe_perf_galaxy_pad50():
         margin=margin,
         comments="seq3200_glx_8x4_ground_truth_padded_50_percent_w_awareness",
     )
-
-
-# Kimi-K3's LatentMoE perf gate is NOT here: it needs a profiler build that blaze does not
-# produce, so it measures with the real-time profiler instead -- see
-# `test_kimi_k3_moe_perf.py`.

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
@@ -99,41 +99,6 @@ def test_deepseek_v3_moe_perf_galaxy_pad50():
     )
 
 
-# --- Kimi-K3 LatentMoE ---------------------------------------------------------------------------
-_K3_TEST_PATH = "models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_kimi_k3_moe"
-_CMD_K3_8X4 = f"pytest {_K3_TEST_PATH} -k 'fabric2d-mesh-8x4 and kimi_k3-5k-perf'"
-
-
-@pytest.mark.timeout(0)
-def test_kimi_k3_moe_perf_galaxy():
-    """
-    MoE_START/MoE_END bracket the forward only -- the constructor's one-time weight tilize/typecast
-    is a large share of wall time at 896 experts, but is not per-token cost.
-
-    NOTE: this gate does not currently execute anywhere -- see #53612. Its blaze entry does not
-    export MESH_DEVICE, so _is_galaxy_env() is false and the test skips itself, and the blaze
-    pipeline builds without tracy, so run_model_device_perf_test_with_merge could not profile even
-    if it did run. The baseline below is therefore a hand measurement, taken on the SiLU path before
-    #51351 moved K3's routed experts to SiTU-GLU, and it has never been checked by CI. Expect it to
-    move once the gate runs: the routed expert is ~79% of MoE device kernel time and costs ~14% more
-    under SiTU-GLU at these token counts.
-    """
-    if not _is_galaxy_env():
-        pytest.skip("This test requires 8x4 mesh - galaxy. (set MESH_DEVICE=TG)")
-
-    margin = adjust_margin_for_ddr_speed(0.03)
-
-    run_model_device_perf_test_with_merge(
-        command=_CMD_K3_8X4,
-        # Measured 2026-08-07 on bh-glx-120-c04u02 (8x4, DDR 14000 -- sub-nominal, so
-        # adjust_margin_for_ddr_speed doubles the 3% margin to 6%). Dispatch/combine/top-k dominates:
-        # Matmul 2_196 us, CCL 1_042 us, Other 9_687 us.
-        expected_device_perf_ns_per_iteration=12_924_852,
-        subdir="kimi_k3_moe",
-        model_name="kimi_k3_moe_glx_8x4",
-        num_iterations=1,
-        batch_size=1,
-        margin=margin,
-        between_signposts=("MoE_START", "MoE_END"),
-        comments="seq640_5k_isl_glx_8x4_fabric2d_ground_truth_latent_moe_situ",
-    )
+# Kimi-K3's LatentMoE perf gate is NOT here: it needs a profiler build that blaze does not
+# produce, so it measures with the real-time profiler instead -- see
+# `test_kimi_k3_moe_perf.py`.

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -396,8 +396,7 @@
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
-      export MESH_DEVICE=TG
-      python3 -m pytest models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py::test_kimi_k3_moe_perf_galaxy -vvv --tb=short
+      python3 -m pytest models/demos/deepseek_v3_d_p/tests/perf/test_kimi_k3_moe_perf.py -vvv --tb=short
     '
   test_type: kimi_k3_moe_perf
   test_group: module

--- a/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
+++ b/tests/pipeline_reorg/blaze_models_prefill_tests.yaml
@@ -396,6 +396,7 @@
 
     mpirun --bind-to none --pernode --tag-output bash -lc '
       export OMP_NUM_THREADS=$(nproc)
+      export MESH_DEVICE=TG
       python3 -m pytest models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py::test_kimi_k3_moe_perf_galaxy -vvv --tb=short
     '
   test_type: kimi_k3_moe_perf


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-metal/issues/53612

### Problem

Kimi K3 perf test was previously done using "legacy way" with tracy, which was skipped in Blaze Prefill CI.

### What's changed

- Added new `test_kimi_k3_moe_perf.py` test for Kimi K3 that uses realtime profilling like it's done inside `test_ttnn_hca_perf.py`
- New `measure` wrapper for `test_ttnn_moe.py` for realtime profiller usage
 
### Prefill CI

- [x] [![(BH) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pmilojevic/k3-perf-enablement)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pmilojevic/k3-perf-enablement)
- [x] [![(Galaxy) Blaze Models Prefill tests ](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml/badge.svg?branch=pmilojevic/k3-perf-enablement)](https://github.com/tenstorrent/tt-metal/actions/workflows/blaze-models-prefill-tests.yaml?query=branch:pmilojevic/k3-perf-enablement)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilojevic/k3-perf-enablement)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilojevic/k3-perf-enablement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilojevic/k3-perf-enablement)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilojevic/k3-perf-enablement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilojevic/k3-perf-enablement)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilojevic/k3-perf-enablement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilojevic/k3-perf-enablement)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilojevic/k3-perf-enablement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilojevic/k3-perf-enablement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilojevic/k3-perf-enablement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilojevic/k3-perf-enablement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilojevic/k3-perf-enablement)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilojevic/k3-perf-enablement)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilojevic/k3-perf-enablement)