### PR TITLE
LTX-2.3: make FPS real conditioning + tune conv3d blocking for 1080p/153f/25fps

### DIFF
--- a/models/tt_dit/pipelines/ltx/pipeline_ltx.py
+++ b/models/tt_dit/pipelines/ltx/pipeline_ltx.py
@@ -232,6 +232,7 @@ class LTXPipeline:
         num_frames: int = 0,
         height: int = 0,
         width: int = 0,
+        fps: float = 24.0,
         run_warmup: bool = False,
         traced: bool = False,
         extra_transformer_variants: list[tuple[str, list[LoraSpec]]] | None = None,
@@ -246,6 +247,11 @@ class LTXPipeline:
             tensor_parallel=ParallelFactor(factor=self.mesh_device.shape[1], mesh_axis=1),
         )
         self._traced = traced
+        # FPS is pipeline-level state, not a per-request argument: it sets the audio latent
+        # length (audio_frames = round(num_frames / fps * 25)) and scales the A/V cross-PE's
+        # temporal axis into seconds. Both are baked into the captured traces, so changing it
+        # per request would silently replay a trace built for a different shape.
+        self.fps = float(fps)
         self._trace_state: dict[str, LTXTransformerState] = {}
         self._prompt_v = StateTensor()
         self._prompt_a = StateTensor()
@@ -410,6 +416,7 @@ class LTXPipeline:
         num_frames: int = 0,
         height: int = 0,
         width: int = 0,
+        fps: float = 24.0,
         **extra_pipeline_kwargs,
     ) -> "LTXPipeline":
         """Auto-configure mesh-shape defaults and forward into ``__init__``.
@@ -500,6 +507,7 @@ class LTXPipeline:
             num_frames=num_frames,
             height=height,
             width=width,
+            fps=fps,
             run_warmup=run_warmup,
             traced=traced,
             **extra_pipeline_kwargs,
@@ -869,12 +877,13 @@ class LTXPipeline:
         self._prepare_vae()
         self.decode_latents(dummy, latent_frames, latent_h, latent_w)
 
-    def _warmup_audio_decode(self, audio_latent: torch.Tensor, num_frames: int, fps: float = 24.0) -> None:
+    def _warmup_audio_decode(self, audio_latent: torch.Tensor, num_frames: int, fps: float | None = None) -> None:
         """Eager (untraced) audio decode at the real shape: compiles kernels, warms lazy device
         state, and frees back to a deterministic allocator free-list so a later traced decode
         captures cleanly. No-op if the audio decoder is not configured."""
         if self.tt_mel_decoder is None or self.tt_vocoder_with_bwe is None:
             return
+        fps = self.fps if fps is None else fps
         mel_d, voc = self.tt_mel_decoder, self.tt_vocoder_with_bwe
         saved = (mel_d.use_trace, voc.use_trace, voc.use_trace_bwe)
         mel_d.use_trace = voc.use_trace = voc.use_trace_bwe = False
@@ -1024,7 +1033,7 @@ class LTXPipeline:
                 denoise_mask[:, :n_cond, :] = 1.0 - image_cond_strength
                 logger.info(f"I2V: pinning {n_cond} frame-0 tokens (strength={image_cond_strength})")
 
-        vps = VideoPixelShape(batch=B, frames=num_frames, height=height, width=width, fps=24)
+        vps = VideoPixelShape(batch=B, frames=num_frames, height=height, width=width, fps=self.fps)
         als = AudioLatentShape.from_video_pixel_shape(vps)
         audio_N_real = als.frames
         audio_N = self._sp_pad_len(audio_N_real)
@@ -1068,6 +1077,7 @@ class LTXPipeline:
             theta=self.positional_embedding_theta,
             mesh_device=self.mesh_device,
             parallel_config=self.parallel_config,
+            fps=self.fps,
         )
         trans_mat = self._prepare_trans_mat()
         sp_axis = self.parallel_config.sequence_parallel.mesh_axis

--- a/models/tt_dit/pipelines/ltx/pipeline_ltx.py
+++ b/models/tt_dit/pipelines/ltx/pipeline_ltx.py
@@ -877,6 +877,26 @@ class LTXPipeline:
         self._prepare_vae()
         self.decode_latents(dummy, latent_frames, latent_h, latent_w)
 
+    def _resolve_fps(self, fps: float | None) -> float:
+        """Resolve a per-call ``fps`` against the pipeline's own rate.
+
+        ``None`` means "use the pipeline's rate". A differing value is rejected rather
+        than substituted: FPS sets the audio latent length and scales the A/V cross-PE
+        temporal axis, both of which are baked into the captured traces, so honouring a
+        per-call rate would replay a trace built for another shape while the container
+        claims the requested one -- the desync this plumbing exists to prevent.
+        """
+        if fps is None:
+            return self.fps
+        if float(fps) != self.fps:
+            msg = (
+                f"fps={fps} does not match the pipeline's fps={self.fps}. FPS is fixed at "
+                "pipeline construction (it sets the audio latent length and the A/V cross-PE, "
+                "both baked into the captured traces). Build a pipeline with the desired fps."
+            )
+            raise ValueError(msg)
+        return self.fps
+
     def _warmup_audio_decode(self, audio_latent: torch.Tensor, num_frames: int, fps: float | None = None) -> None:
         """Eager (untraced) audio decode at the real shape: compiles kernels, warms lazy device
         state, and frees back to a deterministic allocator free-list so a later traced decode

--- a/models/tt_dit/pipelines/ltx/pipeline_ltx_distilled.py
+++ b/models/tt_dit/pipelines/ltx/pipeline_ltx_distilled.py
@@ -670,18 +670,7 @@ class LTXDistilledPipeline(LTXPipeline):
         assert height % 64 == 0, f"Height must be divisible by 64 (got {height})"
         assert width % 64 == 0, f"Width must be divisible by 64 (got {width})"
 
-        # Reject rather than substitute: silently generating at self.fps while the caller
-        # (and the MP4 container, which uses the value passed here) believes another rate
-        # is exactly the desync this plumbing exists to prevent.
-        if fps is None:
-            fps = self.fps
-        elif float(fps) != self.fps:
-            msg = (
-                f"fps={fps} does not match the pipeline's fps={self.fps}. FPS is fixed at "
-                "pipeline construction (it sets the audio latent length and the A/V cross-PE, "
-                "both baked into the captured traces). Build a pipeline with the desired fps."
-            )
-            raise ValueError(msg)
+        fps = self._resolve_fps(fps)
 
         s1_height = height // 2
         s1_width = width // 2

--- a/models/tt_dit/pipelines/ltx/pipeline_ltx_distilled.py
+++ b/models/tt_dit/pipelines/ltx/pipeline_ltx_distilled.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 import time
 from dataclasses import dataclass
@@ -27,6 +28,13 @@ from .pipeline_ltx import SPATIAL_COMPRESSION, TEMPORAL_COMPRESSION, LTXPipeline
 # Distilled sigma schedules for the two stages.
 DISTILLED_SIGMA_VALUES = [1.0, 0.99375, 0.9875, 0.98125, 0.975, 0.909375, 0.725, 0.421875, 0.0]
 STAGE_2_DISTILLED_SIGMA_VALUES = [0.909375, 0.725, 0.421875, 0.0]
+
+# Warn when a post-denoise latent's whiteness exceeds this. 1.0 is indistinguishable from
+# the Gaussian the sampler started from; 21 healthy 1080p generations measured 0.25-0.71
+# (mean 0.49), so this sits above the observed good range while still catching a partially
+# corrupted latent. These are log warnings, not request rejections -- a false positive is
+# cheap, a missed corruption costs us the next occurrence.
+WHITENESS_WARN_THRESHOLD = 0.85
 
 
 @dataclass
@@ -167,7 +175,7 @@ class LTXDistilledPipeline(LTXPipeline):
             latent_frames, full_lh, full_lw = latent_grid(num_frames, height, width)
             dummy_v_init = torch.zeros(1, latent_frames * full_lh * full_lw, self.in_channels)
             als = AudioLatentShape.from_video_pixel_shape(
-                VideoPixelShape(batch=1, frames=num_frames, height=height, width=width, fps=24)
+                VideoPixelShape(batch=1, frames=num_frames, height=height, width=width, fps=self.fps)
             )
             dummy_a_init = torch.zeros(1, als.frames, self.in_channels)
 
@@ -257,6 +265,7 @@ class LTXDistilledPipeline(LTXPipeline):
             theta=self.positional_embedding_theta,
             mesh_device=self.mesh_device,
             parallel_config=self.parallel_config,
+            fps=self.fps,
         )
         tt_attn_mask, tt_pad_mask_sp, tt_pad_mask_full = build_audio_masks(
             audio_N, audio_N_real, mesh_device=self.mesh_device, sp_axis=sp_axis
@@ -295,7 +304,7 @@ class LTXDistilledPipeline(LTXPipeline):
         video_N_real = latent_frames * latent_h * latent_w
         video_N = self._sp_pad_len(video_N_real)
         als = AudioLatentShape.from_video_pixel_shape(
-            VideoPixelShape(batch=1, frames=num_frames, height=height, width=width, fps=24)
+            VideoPixelShape(batch=1, frames=num_frames, height=height, width=width, fps=self.fps)
         )
         audio_N_real = als.frames
         audio_N = self._sp_pad_len(audio_N_real)
@@ -367,7 +376,7 @@ class LTXDistilledPipeline(LTXPipeline):
         # SP padding: round video seq dim up to TILE_SIZE * sp_factor for ring SDPA.
         video_N = self._sp_pad_len(video_N_real)
         als = AudioLatentShape.from_video_pixel_shape(
-            VideoPixelShape(batch=B, frames=num_frames, height=height, width=width, fps=24)
+            VideoPixelShape(batch=B, frames=num_frames, height=height, width=width, fps=self.fps)
         )
         audio_N_real = als.frames
         audio_N = self._sp_pad_len(audio_N_real)
@@ -570,6 +579,71 @@ class LTXDistilledPipeline(LTXPipeline):
         ).squeeze(0)
         return v_final[:, :video_N_real, :], a_final[:, :audio_N_real, :]
 
+    @staticmethod
+    def _latent_stats(x: torch.Tensor) -> dict:
+        """Numeric fingerprint of a latent, for triaging noise outputs after the fact.
+
+        ``whiteness`` is the mean absolute difference between adjacent tokens divided by
+        what iid Gaussian noise of the same std would give (2/sqrt(pi) * std). It is ~1.0
+        when the tensor is statistically indistinguishable from the noise the sampler
+        started from -- i.e. the transformer's output never landed -- and well below 1
+        for a latent carrying real spatial structure. std alone cannot tell these apart:
+        LTX latents are per-channel normalised, so a correctly denoised latent is also
+        ~unit variance.
+
+        ``zeros`` is the fraction of exactly-zero elements. Diffusion output is never
+        exactly zero, so a non-trivial value means part of the buffer was never written --
+        the flat rectangles seen in corrupted decodes.
+        """
+        t = x.detach().float()
+        if t.dim() == 3:
+            t = t[0]
+        flat = t.reshape(-1)
+        std = flat.std().item()
+        whiteness = float("nan")
+        if t.dim() == 2 and t.shape[0] > 1 and std > 0:
+            adjacent = (t[1:] - t[:-1]).abs().mean().item()
+            whiteness = adjacent / (std * 2.0 * math.sqrt(1.0 / math.pi))
+        return {
+            "mean": flat.mean().item(),
+            "std": std,
+            "whiteness": whiteness,
+            "zeros": (flat == 0).float().mean().item(),
+            "nonfinite": int((~torch.isfinite(flat)).sum().item()),
+        }
+
+    def _log_latent_stats(
+        self, label: str, video: torch.Tensor, audio: torch.Tensor | None, *, warn: bool = False
+    ) -> None:
+        """Log a fingerprint per latent; optionally flag the corrupted-generation signature.
+
+        Good and bad generations are otherwise indistinguishable in the log -- same steps,
+        same sigmas, same timings -- so without this a noise report has nothing to correlate.
+        """
+        for name, tensor in (("video", video), ("audio", audio)):
+            if tensor is None:
+                continue
+            s = self._latent_stats(tensor)
+            logger.info(
+                f"  latent[{label}/{name}]: mean={s['mean']:+.3f} std={s['std']:.3f} "
+                f"whiteness={s['whiteness']:.2f} zeros={s['zeros']:.2%} nonfinite={s['nonfinite']}"
+            )
+            if not warn:
+                continue
+            if s["whiteness"] > WHITENESS_WARN_THRESHOLD:
+                logger.warning(
+                    f"{label}/{name}: post-denoise latent is ~white noise "
+                    f"(whiteness={s['whiteness']:.2f}); the transformer output never landed -- "
+                    "expect a noise result"
+                )
+            if s["zeros"] > 0.01:
+                logger.warning(
+                    f"{label}/{name}: post-denoise latent is {s['zeros']:.2%} exactly zero; "
+                    "part of the buffer was never written -- expect flat patches in the decode"
+                )
+            if s["nonfinite"]:
+                logger.warning(f"{label}/{name}: {s['nonfinite']} non-finite elements in post-denoise latent")
+
     def generate(
         self,
         prompt: str,
@@ -582,15 +656,32 @@ class LTXDistilledPipeline(LTXPipeline):
         height: int = 512,
         width: int = 768,
         seed: int = 10,
-        fps: int = 24,
+        fps: float | None = None,
     ):
         """Run the distilled 2-stage AV pipeline.
 
         output_path given → encode an AV MP4 and return its path (str).
         output_path None  → return ``(frames, audio)`` for the caller to encode.
+
+        ``fps`` defaults to the pipeline's own rate and may not differ from it: the audio
+        latent length and the A/V cross-PE are derived from it and are baked into the
+        captured traces, so a per-request rate would replay a trace built for another shape.
         """
         assert height % 64 == 0, f"Height must be divisible by 64 (got {height})"
         assert width % 64 == 0, f"Width must be divisible by 64 (got {width})"
+
+        # Reject rather than substitute: silently generating at self.fps while the caller
+        # (and the MP4 container, which uses the value passed here) believes another rate
+        # is exactly the desync this plumbing exists to prevent.
+        if fps is None:
+            fps = self.fps
+        elif float(fps) != self.fps:
+            msg = (
+                f"fps={fps} does not match the pipeline's fps={self.fps}. FPS is fixed at "
+                "pipeline construction (it sets the audio latent length and the A/V cross-PE, "
+                "both baked into the captured traces). Build a pipeline with the desired fps."
+            )
+            raise ValueError(msg)
 
         s1_height = height // 2
         s1_width = width // 2
@@ -663,6 +754,7 @@ class LTXDistilledPipeline(LTXPipeline):
         t_stage1 = time.time() - t0
         timings.append(("Stage 1 denoise", t_stage1))
         logger.info(f"Stage 1 denoise: {t_stage1:.1f}s")
+        self._log_latent_stats("s1", s1_video, s1_audio)
 
         latent_frames = (num_frames - 1) // TEMPORAL_COMPRESSION + 1
         s1_h, s1_w = s1_height // SPATIAL_COMPRESSION, s1_width // SPATIAL_COMPRESSION
@@ -697,6 +789,9 @@ class LTXDistilledPipeline(LTXPipeline):
         t_stage2 = time.time() - t0
         timings.append(("Stage 2 denoise", t_stage2))
         logger.info(f"Stage 2 denoise: {t_stage2:.1f}s")
+        # Last point before the VAE: if this latent is white or partly unwritten, the
+        # decode cannot recover and the served MP4 will be noise.
+        self._log_latent_stats("s2", s2_video, s2_audio, warn=True)
 
         t0 = time.time()
         self._prepare_vae()

--- a/models/tt_dit/pipelines/ltx/pipeline_ltx_one_stage.py
+++ b/models/tt_dit/pipelines/ltx/pipeline_ltx_one_stage.py
@@ -58,7 +58,7 @@ class LTXOneStagePipeline(LTXPipeline):
         # Warm the on-device audio decode eagerly so the first real (traced) decode captures on
         # warm state at a deterministic free-list.
         als = AudioLatentShape.from_video_pixel_shape(
-            VideoPixelShape(batch=1, frames=num_frames, height=height, width=width, fps=24)
+            VideoPixelShape(batch=1, frames=num_frames, height=height, width=width, fps=self.fps)
         )
         self._warmup_audio_decode(torch.zeros(1, als.frames, self.in_channels), num_frames)
 
@@ -85,10 +85,11 @@ class LTXOneStagePipeline(LTXPipeline):
         stg_block: int = 28,
         seed: int = 10,
         ge_gamma: float = 0.0,
-        fps: int = 24,
+        fps: float | None = None,
     ) -> str:
         """Run LTX-2.3 Pro AV generation and write an MP4. Guidance defaults match the
         reference ``LTX_2_3_PARAMS``; ``ge_gamma`` > 0 enables gradient-estimation sampling."""
+        fps = self._resolve_fps(fps)
         neg = negative_prompt if negative_prompt is not None else DEFAULT_NEGATIVE_PROMPT
 
         total_t0 = time.time()

--- a/models/tt_dit/pipelines/ltx/pipeline_ltx_two_stages.py
+++ b/models/tt_dit/pipelines/ltx/pipeline_ltx_two_stages.py
@@ -124,7 +124,7 @@ class LTXTwoStagesPipeline(LTXPipeline):
         latent_frames, full_lh, full_lw = latent_grid(num_frames, height, width)
         full_latent_count = latent_frames * full_lh * full_lw
         dummy_v_init = torch.zeros(1, full_latent_count, self.in_channels)
-        vps = VideoPixelShape(batch=1, frames=num_frames, height=height, width=width, fps=24)
+        vps = VideoPixelShape(batch=1, frames=num_frames, height=height, width=width, fps=self.fps)
         als = AudioLatentShape.from_video_pixel_shape(vps)
         dummy_a_init = torch.zeros(1, als.frames, self.in_channels)
 
@@ -186,11 +186,12 @@ class LTXTwoStagesPipeline(LTXPipeline):
         # Stage 2 (refine) knobs.
         stage_2_sigma_values: list[float] | None = None,
         seed: int = 10,
-        fps: int = 24,
+        fps: float | None = None,
     ) -> str:
         """Run the 2-stage AV pipeline (full-guidance s1 + distilled s2) and write an MP4."""
         assert height % 64 == 0, f"Height must be divisible by 64 (got {height})"
         assert width % 64 == 0, f"Width must be divisible by 64 (got {width})"
+        fps = self._resolve_fps(fps)
 
         s1_h, s1_w = height // 2, width // 2
         s2_sigma_values = list(stage_2_sigma_values) if stage_2_sigma_values else STAGE_2_DISTILLED_SIGMA_VALUES

--- a/models/tt_dit/tests/models/ltx/bruteforce_conv3d_sweep_ltx.py
+++ b/models/tt_dit/tests/models/ltx/bruteforce_conv3d_sweep_ltx.py
@@ -68,27 +68,54 @@ from ..wan2_2.bruteforce_conv3d_sweep import TRACE_REGION_SIZE, run_sweep
 # Names are descriptive of (T, channels) rather than guessing the module attribute names.
 # ---------------------------------------------------------------------------
 _SWEEP_LAYERS_LTX_1080P_153F = [
-    # (name,                 C_in, C_out, kernel,    stride,    padding,    T,   H,  W, h, w)
+    # H and W here are the PADDED CONV3D INPUT dims, not the _BLOCKINGS key dims.
+    # run_sweep derives the key as H_out_key = H - (kH - 1) (see wan2_2/
+    # bruteforce_conv3d_sweep.py, "Seed best_us from the production blocking table"), so a
+    # production key of (155, 68, 60) with a (3,3,3) kernel must be swept with input
+    # (155, 70, 62). Passing the key dims directly benchmarks a smaller tensor AND looks up a
+    # key that does not exist, silently falling back to the channel-level table.
+    #
+    # (name,                C_in, C_out, kernel,    stride,    padding,    T,   H,  W, h, w)
     # --- 94% of total volume: the T=155 / T=79 decoder convs ---
-    ("t155_c128x128", 128, 128, (3, 3, 3), (1, 1, 1), (0, 0, 0), 155, 68, 60, 4, 8),
-    ("t155_c128x48", 128, 48, (3, 3, 3), (1, 1, 1), (0, 0, 0), 155, 68, 60, 4, 8),
-    ("t79_c512x512", 512, 512, (3, 3, 3), (1, 1, 1), (0, 0, 0), 79, 34, 30, 4, 8),
-    ("t155_c256x512", 256, 512, (3, 3, 3), (1, 1, 1), (0, 0, 0), 155, 34, 30, 4, 8),
-    ("t155_c256x256", 256, 256, (3, 3, 3), (1, 1, 1), (0, 0, 0), 155, 34, 30, 4, 8),
+    ("t155_c128x128", 128, 128, (3, 3, 3), (1, 1, 1), (0, 0, 0), 155, 70, 62, 4, 8),  # key 68x60
+    ("t155_c128x48", 128, 48, (3, 3, 3), (1, 1, 1), (0, 0, 0), 155, 70, 62, 4, 8),  # key 68x60
+    ("t79_c512x512", 512, 512, (3, 3, 3), (1, 1, 1), (0, 0, 0), 79, 36, 32, 4, 8),  # key 34x30
+    ("t155_c256x512", 256, 512, (3, 3, 3), (1, 1, 1), (0, 0, 0), 155, 36, 32, 4, 8),  # key 34x30
+    ("t155_c256x256", 256, 256, (3, 3, 3), (1, 1, 1), (0, 0, 0), 155, 36, 32, 4, 8),  # key 34x30
     # --- mid volume ---
-    ("t41_c512x4096", 512, 4096, (3, 3, 3), (1, 1, 1), (0, 0, 0), 41, 17, 15, 4, 8),
-    ("t41_c512x512", 512, 512, (3, 3, 3), (1, 1, 1), (0, 0, 0), 41, 17, 15, 4, 8),
+    ("t41_c512x4096", 512, 4096, (3, 3, 3), (1, 1, 1), (0, 0, 0), 41, 19, 17, 4, 8),  # key 17x15
+    ("t41_c512x512", 512, 512, (3, 3, 3), (1, 1, 1), (0, 0, 0), 41, 19, 17, 4, 8),  # key 17x15
     # --- the latent upsampler (separate 0.20s -> 0.62s regression) ---
-    ("t20_ups_c1024x4096", 1024, 4096, (1, 3, 3), (1, 1, 1), (0, 0, 0), 20, 5, 4, 4, 8),
+    ("t20_ups_c1024x4096", 1024, 4096, (1, 3, 3), (1, 1, 1), (0, 0, 0), 20, 7, 6, 4, 8),  # key 5x4
     # --- small: T=22 sites ---
-    ("t22_c1024x1024_h10", 1024, 1024, (3, 3, 3), (1, 1, 1), (0, 0, 0), 22, 10, 8, 4, 8),
-    ("t22_c1024x128_h10", 1024, 128, (3, 3, 3), (1, 1, 1), (0, 0, 0), 22, 10, 8, 4, 8),
-    ("t22_c1024x4096_h9", 1024, 4096, (3, 3, 3), (1, 1, 1), (0, 0, 0), 22, 9, 8, 4, 8),
-    ("t22_c1024x1024_h9", 1024, 1024, (3, 3, 3), (1, 1, 1), (0, 0, 0), 22, 9, 8, 4, 8),
-    ("t22_c1024x1024_h5", 1024, 1024, (3, 3, 3), (1, 1, 1), (0, 0, 0), 22, 5, 4, 4, 8),
-    ("t22_c128x1024_h9", 128, 1024, (3, 3, 3), (1, 1, 1), (0, 0, 0), 22, 9, 8, 4, 8),
-    ("t22_c128x1024_h5", 128, 1024, (3, 3, 3), (1, 1, 1), (0, 0, 0), 22, 5, 4, 4, 8),
+    ("t22_c1024x1024_h10", 1024, 1024, (3, 3, 3), (1, 1, 1), (0, 0, 0), 22, 12, 10, 4, 8),  # key 10x8
+    ("t22_c1024x128_h10", 1024, 128, (3, 3, 3), (1, 1, 1), (0, 0, 0), 22, 12, 10, 4, 8),  # key 10x8
+    ("t22_c1024x4096_h9", 1024, 4096, (3, 3, 3), (1, 1, 1), (0, 0, 0), 22, 11, 10, 4, 8),  # key 9x8
+    ("t22_c1024x1024_h9", 1024, 1024, (3, 3, 3), (1, 1, 1), (0, 0, 0), 22, 11, 10, 4, 8),  # key 9x8
+    ("t22_c1024x1024_h5", 1024, 1024, (3, 3, 3), (1, 1, 1), (0, 0, 0), 22, 7, 6, 4, 8),  # key 5x4
+    ("t22_c128x1024_h9", 128, 1024, (3, 3, 3), (1, 1, 1), (0, 0, 0), 22, 11, 10, 4, 8),  # key 9x8
+    ("t22_c128x1024_h5", 128, 1024, (3, 3, 3), (1, 1, 1), (0, 0, 0), 22, 7, 6, 4, 8),  # key 5x4
 ]
+
+
+def _hw_product(kernel, h_in: int, w_in: int) -> int:
+    """Largest supported (H_out_block * W_out_block) product that is actually achievable.
+
+    ``run_sweep`` filters candidates with ``h * w != hw_product`` -- an exact match -- so a
+    value no divisor pair can satisfy yields zero valid combos and the layer sweeps to
+    nothing. Blocks are bounded by the OUTPUT dims, so reachability is tested against
+    ``h_in - (kH - 1)``.
+
+    32 mirrors the wan2_2 h4w8 sweeps (non-32 products hung BH on their shapes). Where 32 is
+    unreachable -- the T=20 upsampler and the T=22 H=5/W=4 sites, whose 5x4 outputs cap the
+    product at 20 -- fall back to 16, satisfiable as 4x4.
+    """
+    h_out, w_out = h_in - (kernel[1] - 1), w_in - (kernel[2] - 1)
+    for product in (32, 16):
+        if any(product % h == 0 and h <= h_out and product // h <= w_out for h in range(1, product + 1)):
+            return product
+    msg = f"no achievable hw_product for output {h_out}x{w_out}"
+    raise ValueError(msg)
 
 
 @pytest.mark.parametrize(
@@ -123,13 +150,8 @@ def test_bruteforce_sweep_ltx_1080p_153f(
         w_factor=w_factor,
         max_combos=500,
         max_t_block=8,
-        # hw_product=32 mirrors the wan2_2 h4w8 sweeps (non-32 hw products hung BH there), but
-        # the filter is `h * w != hw_product` -- an EXACT match. Layers whose per-device spatial
-        # dims cannot reach 32 (e.g. the T=20 upsampler and the T=22 H=5/W=4 sites: 5*4 = 20)
-        # yield zero valid combos and sweep to nothing. Only constrain where it is satisfiable.
-        # Exact-match filter on (H_out_block * W_out_block): 32 where reachable; where it is not
-        # (H=5,W=4 -> max 20) use 16, satisfiable as 4x4. Do NOT pass None: unconstrained, the
-        # search balloons past 500 candidates and some blockings take MINUTES to compile
-        # (measured: t22_c1024x1024_h5 advanced <10 combos in 27 min at 90% host CPU).
-        hw_product=32 if H * W >= 32 else 16,
+        # Never pass None here: unconstrained, the search balloons past 500 candidates and
+        # some blockings take minutes each to compile (measured: t22_c1024x1024_h5 advanced
+        # fewer than 10 combos in 27 min at 90% host CPU before being abandoned).
+        hw_product=_hw_product(kernel, H, W),
     )

--- a/models/tt_dit/tests/models/ltx/bruteforce_conv3d_sweep_ltx.py
+++ b/models/tt_dit/tests/models/ltx/bruteforce_conv3d_sweep_ltx.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Conv3d blocking sweep for the LTX-2.3 1080p / 153-frame (25 fps) shape.
+
+Reuses the generic brute-force harness in ``..wan2_2.bruteforce_conv3d_sweep``; only the
+layer list is LTX-specific.
+
+WHY THIS EXISTS
+---------------
+``_BLOCKINGS`` in ``models/tt_dit/utils/conv3d.py`` is keyed on
+``(h_factor, w_factor, C_in, C_out, kernel, T, H, W)``. It is tuned for the 145-frame
+production shape. Moving to 153 frames (6.12 s @ 25 fps, the Console target) shifts the
+decoder's latent T from 19 to 20, which walks a different T-chain (T -> 2T-1 per
+depth-to-space stage) and misses the table at 15 sites. Those convs fall back to
+channel-only blocking, which costs:
+
+    VAE decode      1s   -> 5s
+    Latent upsample 0.20s -> 0.62s
+    total generate  6.7s -> 12.1s     (measured 2026-08-19)
+
+The traced denoise is unaffected and 25 fps itself is free (145f@25 measured 6.6s vs
+145f@24's 6.7s), so this table is the *entire* gap to serving 6.12 s at full speed.
+
+LAYERS ARE ORDERED BY COMPUTE VOLUME (T*H*W*C_in). The first five are 94% of the total —
+sweep those first if time is short.
+
+The exact keys were harvested from the ``conv3d blocking [fallback|NONE]`` warnings that
+``get_conv3d_config`` (conv3d.py:649/655) emits on a real 153-frame run, diffed against a
+145-frame run so only genuinely NEW misses are listed.
+
+RUN
+---
+Needs the Galaxy (stop the media server first). The sweep itself runs on a (1,1) submesh --
+one conv layer on one chip -- so it does not need the full mesh, just exclusive access.
+
+    pytest models/tt_dit/tests/models/ltx/bruteforce_conv3d_sweep_ltx.py -k t155_c128x128 -s --timeout=0
+    pytest models/tt_dit/tests/models/ltx/bruteforce_conv3d_sweep_ltx.py -s --timeout=0   # all 15
+
+Each layer writes ``sweep_results_ltx_1080p_153f/<name>_<Cin>x<Cout>.json`` containing
+``best_blocking`` (the winner) and ``table_blocking``/``table_us`` (what the table would
+have used), so the speedup is visible per layer.
+
+THEN
+----
+Add each winner to ``_BLOCKINGS`` as
+``(4, 8, C_in, C_out, kernel, T, H, W): tuple(best_blocking)``
+and re-run the 153f validation (``~/ltx-25fps-validate.sh``) to confirm ~7 s.
+"""
+
+import pytest
+
+import ttnn
+
+from ..wan2_2.bruteforce_conv3d_sweep import TRACE_REGION_SIZE, run_sweep
+
+# ---------------------------------------------------------------------------
+# LTX-2.3, 1920x1088, 153 frames (25 fps), BH Galaxy 4x8 (h_factor=4, w_factor=8).
+#
+# h_factor comes from tensor_parallel (mesh axis 0, factor 4) and w_factor from
+# sequence_parallel (mesh axis 1, factor 8) -- see LTXPipeline's VaeHWParallelConfig.
+#
+# T here is the value the conv3d kernel sees (post temporal pad). The decoder chain for
+# 153 frames is latent T=20 -> 22, 41, 79, 155 at the four (3,3,3) conv depths; the
+# latent upsampler asks for T=20 with a (1,3,3) kernel.
+#
+# Names are descriptive of (T, channels) rather than guessing the module attribute names.
+# ---------------------------------------------------------------------------
+_SWEEP_LAYERS_LTX_1080P_153F = [
+    # (name,                 C_in, C_out, kernel,    stride,    padding,    T,   H,  W, h, w)
+    # --- 94% of total volume: the T=155 / T=79 decoder convs ---
+    ("t155_c128x128", 128, 128, (3, 3, 3), (1, 1, 1), (0, 0, 0), 155, 68, 60, 4, 8),
+    ("t155_c128x48", 128, 48, (3, 3, 3), (1, 1, 1), (0, 0, 0), 155, 68, 60, 4, 8),
+    ("t79_c512x512", 512, 512, (3, 3, 3), (1, 1, 1), (0, 0, 0), 79, 34, 30, 4, 8),
+    ("t155_c256x512", 256, 512, (3, 3, 3), (1, 1, 1), (0, 0, 0), 155, 34, 30, 4, 8),
+    ("t155_c256x256", 256, 256, (3, 3, 3), (1, 1, 1), (0, 0, 0), 155, 34, 30, 4, 8),
+    # --- mid volume ---
+    ("t41_c512x4096", 512, 4096, (3, 3, 3), (1, 1, 1), (0, 0, 0), 41, 17, 15, 4, 8),
+    ("t41_c512x512", 512, 512, (3, 3, 3), (1, 1, 1), (0, 0, 0), 41, 17, 15, 4, 8),
+    # --- the latent upsampler (separate 0.20s -> 0.62s regression) ---
+    ("t20_ups_c1024x4096", 1024, 4096, (1, 3, 3), (1, 1, 1), (0, 0, 0), 20, 5, 4, 4, 8),
+    # --- small: T=22 sites ---
+    ("t22_c1024x1024_h10", 1024, 1024, (3, 3, 3), (1, 1, 1), (0, 0, 0), 22, 10, 8, 4, 8),
+    ("t22_c1024x128_h10", 1024, 128, (3, 3, 3), (1, 1, 1), (0, 0, 0), 22, 10, 8, 4, 8),
+    ("t22_c1024x4096_h9", 1024, 4096, (3, 3, 3), (1, 1, 1), (0, 0, 0), 22, 9, 8, 4, 8),
+    ("t22_c1024x1024_h9", 1024, 1024, (3, 3, 3), (1, 1, 1), (0, 0, 0), 22, 9, 8, 4, 8),
+    ("t22_c1024x1024_h5", 1024, 1024, (3, 3, 3), (1, 1, 1), (0, 0, 0), 22, 5, 4, 4, 8),
+    ("t22_c128x1024_h9", 128, 1024, (3, 3, 3), (1, 1, 1), (0, 0, 0), 22, 9, 8, 4, 8),
+    ("t22_c128x1024_h5", 128, 1024, (3, 3, 3), (1, 1, 1), (0, 0, 0), 22, 5, 4, 4, 8),
+]
+
+
+@pytest.mark.parametrize(
+    "mesh_device, mesh_shape, device_params",
+    [[(1, 1), (1, 1), {"trace_region_size": TRACE_REGION_SIZE}]],
+    ids=["bh_ltx_1080p_153f_1x1"],
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize(
+    "layer_name, C_in, C_out, kernel, stride, padding, T, H, W, h_factor, w_factor",
+    _SWEEP_LAYERS_LTX_1080P_153F,
+    ids=[l[0] for l in _SWEEP_LAYERS_LTX_1080P_153F],
+)
+def test_bruteforce_sweep_ltx_1080p_153f(
+    mesh_device, mesh_shape, layer_name, C_in, C_out, kernel, stride, padding, T, H, W, h_factor, w_factor
+):
+    parent_mesh = mesh_device
+    device = parent_mesh.create_submesh(ttnn.MeshShape(*mesh_shape))
+    output = f"sweep_results_ltx_1080p_153f/{layer_name}_{C_in}x{C_out}.json"
+    run_sweep(
+        device,
+        C_in,
+        C_out,
+        kernel,
+        T,
+        H,
+        W,
+        output,
+        stride=stride,
+        padding=padding,
+        h_factor=h_factor,
+        w_factor=w_factor,
+        max_combos=500,
+        max_t_block=8,
+        # hw_product=32 mirrors the wan2_2 h4w8 sweeps (non-32 hw products hung BH there), but
+        # the filter is `h * w != hw_product` -- an EXACT match. Layers whose per-device spatial
+        # dims cannot reach 32 (e.g. the T=20 upsampler and the T=22 H=5/W=4 sites: 5*4 = 20)
+        # yield zero valid combos and sweep to nothing. Only constrain where it is satisfiable.
+        # Exact-match filter on (H_out_block * W_out_block): 32 where reachable; where it is not
+        # (H=5,W=4 -> max 20) use 16, satisfiable as 4x4. Do NOT pass None: unconstrained, the
+        # search balloons past 500 candidates and some blockings take MINUTES to compile
+        # (measured: t22_c1024x1024_h5 advanced <10 combos in 27 min at 90% host CPU).
+        hw_product=32 if H * W >= 32 else 16,
+    )

--- a/models/tt_dit/tests/models/ltx/test_fps_conditioning_ltx.py
+++ b/models/tt_dit/tests/models/ltx/test_fps_conditioning_ltx.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Device-free regression tests for LTX FPS conditioning.
+
+FPS is not a container label: it sets the audio latent length
+(``AudioLatentShape.from_video_pixel_shape`` divides frames by fps to get a duration) and
+scales the A/V cross-PE temporal axis into seconds (``rope_ltx.prepare_video_rope`` /
+``prepare_av_cross_pe``). Both are baked into captured traces, so the rate is fixed at
+pipeline construction and a mismatched per-call value must be rejected rather than
+substituted.
+
+These run on CPU so the conditioning path is covered in CI without a Galaxy. The
+end-to-end behaviour at the served shape (153 frames @ 25 fps) is exercised by
+``test_pipeline_distilled``; this file guards the arithmetic and the guard, which is what
+a future edit would silently break while every device test stayed green.
+"""
+
+import pytest
+
+from ....models.transformers.ltx.rope_ltx import prepare_av_cross_pe, prepare_video_rope
+from ....pipelines.ltx.pipeline_ltx import LTXPipeline
+from ....utils.patchifiers import AudioLatentShape, VideoPixelShape
+
+
+class _FpsOnly:
+    """Minimal stand-in so ``_resolve_fps`` can be tested without a mesh device."""
+
+    def __init__(self, fps: float):
+        self.fps = fps
+
+
+def _audio_frames(num_frames: int, fps: float) -> int:
+    return AudioLatentShape.from_video_pixel_shape(
+        VideoPixelShape(batch=1, frames=num_frames, height=1088, width=1920, fps=fps)
+    ).frames
+
+
+# (num_frames, fps, expected audio latent frames). The audio latent rate is
+# 16000 / 160 / 4 = 25/s, so audio_frames = round(num_frames / fps * 25).
+@pytest.mark.parametrize(
+    "num_frames, fps, expected",
+    [
+        (145, 24, 151),  # today's legacy shape: lopsided, 145 video -> 151 audio
+        (145, 25, 145),  # at 25 fps the two grids coincide exactly
+        (153, 25, 153),  # the served Console shape
+        (153, 24, 159),  # same frame count at 24 fps -> a DIFFERENT audio length
+        (241, 25, 241),
+    ],
+)
+def test_audio_latent_length_tracks_fps(num_frames, fps, expected):
+    assert _audio_frames(num_frames, fps) == expected
+
+
+def test_fps_changes_audio_length_for_a_fixed_frame_count():
+    """The regression this guards: hardcoding 24 while serving 25.
+
+    153 frames yields 159 audio latents at 24 fps and 153 at 25. If a future edit restores a
+    literal 24 at the VideoPixelShape sites, the audio latent (and the A/V alignment built
+    against it) is sized for the wrong timeline even though the container still says 25.
+    """
+    assert _audio_frames(153, 24) != _audio_frames(153, 25)
+
+
+def test_audio_and_video_grids_coincide_at_25fps():
+    """25 fps matches the audio latent rate, so the grids align 1:1 at any legal length."""
+    for num_frames in (145, 153, 161, 241, 481):
+        assert _audio_frames(num_frames, 25) == num_frames
+
+
+@pytest.mark.parametrize("fps", [24, 25.0])
+def test_resolve_fps_accepts_none_and_matching(fps):
+    pipeline = _FpsOnly(float(fps))
+    assert LTXPipeline._resolve_fps(pipeline, None) == float(fps)
+    assert LTXPipeline._resolve_fps(pipeline, fps) == float(fps)
+
+
+def test_resolve_fps_rejects_a_mismatch(expect_error):
+    """Rejected, not substituted: generating at one rate while the caller and the MP4
+    container believe another is exactly the desync the plumbing removes."""
+    pipeline = _FpsOnly(25.0)
+    with expect_error(ValueError, "does not match the pipeline's fps"):
+        LTXPipeline._resolve_fps(pipeline, 24)
+
+
+def test_served_shape_is_a_legal_frame_count():
+    """(num_frames - 1) % 8 == 0 is required for the VAE to decode latent_frames exactly.
+
+    6s x 25fps = 150 is illegal, which is why the served shape is 153 (6.12s) rather than
+    150, and why 145f@25 (5.80s) would under-deliver a "6 second" product.
+    """
+    assert (153 - 1) % 8 == 0
+    assert (150 - 1) % 8 != 0
+    assert 153 / 25 == pytest.approx(6.12)
+
+
+@pytest.mark.parametrize("fn", [prepare_video_rope, prepare_av_cross_pe])
+def test_rope_builders_still_take_fps(fn):
+    """Guard the cross-PE / rope rate plumbing against silent removal.
+
+    ``prepare_av_cross_pe`` scales the video temporal axis into seconds by dividing by fps,
+    which is what aligns audio against video. That parameter existed but was never passed
+    for a long time, so the A/V alignment was built at 24 fps regardless of the requested
+    rate -- the bug this suite exists to prevent regressing.
+
+    Exercising the scaling itself needs a mesh device (both builders return ttnn tensors),
+    so that is covered end-to-end by the 153f/25fps CI case. What this asserts is narrower
+    but still useful on CPU: the keyword remains part of the contract, so a refactor that
+    drops it fails here instead of silently reinstating a fixed 24 fps.
+    """
+    import inspect
+
+    params = inspect.signature(fn).parameters
+    assert "fps" in params, f"{fn.__name__} lost its fps parameter"
+    assert params["fps"].kind is inspect.Parameter.KEYWORD_ONLY, (
+        f"{fn.__name__}'s fps must stay keyword-only so a positional call cannot silently "
+        "bind the wrong argument to it"
+    )

--- a/models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py
+++ b/models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py
@@ -105,6 +105,10 @@ def test_pipeline_distilled(
     num_frames = int(os.environ.get("NUM_FRAMES", "145"))
     height = int(os.environ.get("HEIGHT", "1088"))
     width = int(os.environ.get("WIDTH", "1920"))
+    # FPS conditions the model (audio latent length + A/V cross-PE temporal scaling), so it is
+    # fixed at create_pipeline. 6s lands on 145f@24 (6.04s) or 153f@25 (6.12s) -- (n-1)%8 == 0
+    # forbids the exact 144/150.
+    fps = float(os.environ.get("FPS", "24"))
 
     run_warmup = os.environ.get("RUN_WARMUP", "0") in ("1", "true", "True")
     traced = os.environ.get("LTX_TRACED", "0") in ("1", "true", "True")
@@ -135,6 +139,7 @@ def test_pipeline_distilled(
         num_frames=num_frames,
         height=height,
         width=width,
+        fps=fps,
         image_conditioning=bool(image_path),
     )
 
@@ -149,7 +154,7 @@ def test_pipeline_distilled(
     def run(*, prompt, number, seed):
         output_filename = os.environ.get("OUTPUT_PATH", f"ltx_av_fast_{width}x{height}_{number}.mp4")
         logger.info(f"Running LTX AV Fast: '{prompt[:80]}...'")
-        logger.info(f"Config: {height}x{width}, {num_frames} frames")
+        logger.info(f"Config: {height}x{width}, {num_frames} frames @ {fps}fps ({num_frames / fps:.4f}s)")
         if images:
             logger.info(f"I2V: conditioning image {images[0][0]} (strength={images[0][2]})")
 
@@ -165,6 +170,7 @@ def test_pipeline_distilled(
             height=height,
             width=width,
             seed=seed,
+            fps=fps,
         )
         logger.info(f"Saved video to: {output_filename}")
         print_ltx_timing_table(

--- a/models/tt_dit/utils/conv3d.py
+++ b/models/tt_dit/utils/conv3d.py
@@ -148,6 +148,21 @@ def compute_encoder_dims(height, width, h_factor, w_factor, encoder_t_chunk_size
 # Each production (mesh, resolution, temporal-mode, layer) combination gets its own entry.
 # Blockings are (C_in_block, C_out_block, T_out_block, H_out_block, W_out_block).
 _BLOCKINGS = {
+    # === LTX-2.3 22B, 1920x1088, 153 frames @ 25 fps (latent T=20) — swept 2026-08-19
+    # (h,w,C_in,C_out,kernel,T,H,W) -> (C_in_blk,C_out_blk,T_blk,H_blk,W_blk)
+    (4, 8, 128, 128, (3, 3, 3), 155, 68, 60): (128, 64, 6, 2, 16),  # 5810us, 3.7x vs fallback
+    (4, 8, 128, 48, (3, 3, 3), 155, 68, 60): (128, 64, 6, 2, 16),  # 2973us, 3.9x vs fallback
+    (4, 8, 512, 512, (3, 3, 3), 79, 34, 30): (64, 256, 1, 16, 2),  # 8679us, 31.8x vs fallback
+    (4, 8, 256, 512, (3, 3, 3), 155, 34, 30): (64, 256, 1, 16, 2),  # 8590us, 3.1x vs fallback
+    (4, 8, 256, 256, (3, 3, 3), 155, 34, 30): (64, 256, 1, 16, 2),  # 4537us, 7.2x vs fallback
+    (4, 8, 512, 4096, (3, 3, 3), 41, 17, 15): (128, 64, 5, 16, 2),  # 11489us, 23.5x vs fallback
+    (4, 8, 512, 512, (3, 3, 3), 41, 17, 15): (64, 256, 1, 16, 2),  # 1301us, 23.2x vs fallback
+    (4, 8, 1024, 1024, (3, 3, 3), 22, 10, 8): (64, 256, 2, 8, 4),  # 1414us, 17.3x vs fallback
+    (4, 8, 1024, 128, (3, 3, 3), 22, 10, 8): (128, 64, 3, 4, 8),  # 178us, 11.0x vs fallback
+    (4, 8, 1024, 4096, (3, 3, 3), 22, 9, 8): (128, 64, 5, 4, 8),  # 3887us, 13.9x vs fallback
+    (4, 8, 1024, 1024, (3, 3, 3), 22, 9, 8): (128, 64, 5, 4, 8),  # 1373us, 15.6x vs fallback
+    (4, 8, 1024, 1024, (3, 3, 3), 22, 5, 4): (128, 128, 5, 2, 2),  # 485us, 6.9x vs fallback, partial sweep 350/500
+    # === end LTX-2.3 153f ===
     # ===================================================================
     # BH Galaxy 6U 4x32, 480p, 81 frames full-T (latent T=21)
     # Per-device (H,W): stage0(15,3) stage1(30,6) stage2(60,12) stage3(120,24)

--- a/models/tt_dit/utils/tracing.py
+++ b/models/tt_dit/utils/tracing.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import functools
 import inspect
+import os
 import weakref
 from types import NoneType
 from typing import TYPE_CHECKING, Any, overload
@@ -53,6 +54,55 @@ class StateTensor:
             self._value = value
         else:
             ttnn.copy(value, self._value)
+
+
+def _region_usage(device: ttnn.MeshDevice, buffer_type: Any) -> tuple[int, int, int]:
+    """Per-device (allocated, free, capacity) in bytes for one allocator region.
+
+    ``get_memory_view`` reports per-bank figures, so each is scaled by the bank count to get
+    the device-wide number that ``trace_region_size`` / DRAM capacity are expressed in.
+    """
+    mv = ttnn.get_memory_view(device, buffer_type)
+    n = mv.num_banks
+    return (
+        mv.total_bytes_allocated_per_bank * n,
+        mv.total_bytes_free_per_bank * n,
+        mv.total_bytes_per_bank * n,
+    )
+
+
+def _trace_region_usage(device: ttnn.MeshDevice) -> tuple[int, int, int]:
+    """Total TRACE-region (allocated, free, capacity) in bytes, summed across DRAM banks."""
+    return _region_usage(device, ttnn.BufferType.TRACE)
+
+
+def _log_trace_region(label: str, devices: Sequence[ttnn.MeshDevice], before: int | None = None) -> int | None:
+    """Log TRACE-region occupancy. Returns the allocated byte count (device 0), or ``None``.
+
+    Enabled only when ``TT_DIT_TRACE_MEM_LOG=1`` so the default path is untouched.
+    """
+    if os.environ.get("TT_DIT_TRACE_MEM_LOG") != "1" or not devices:
+        return None
+    try:
+        used, free, cap = _trace_region_usage(devices[0])
+    except Exception as e:  # never let instrumentation break a capture
+        logger.warning(f"trace-mem: could not read TRACE region: {e}")
+        return None
+    mb = 1024 * 1024
+    delta = f", delta={(used - before) / mb:+.2f}MB" if before is not None else ""
+    extra = ""
+    for name, bt in (("dram", ttnn.BufferType.DRAM), ("l1", ttnn.BufferType.L1)):
+        try:
+            u, f, c = _region_usage(devices[0], bt)
+        except Exception:  # a region may be unavailable; never break the capture
+            continue
+        extra += f" | {name}: used={u / mb:.1f}MB free={f / mb:.1f}MB cap={c / mb:.1f}MB"
+    logger.info(
+        f"trace-mem [{label}]: used={used / mb:.2f}MB free={free / mb:.2f}MB "
+        f"capacity={cap / mb:.2f}MB live_traces={Tracer._traces_live.get(devices[0].id(), 0)}{delta}"
+        f"{extra}"
+    )
+    return used
 
 
 class Tracer:
@@ -229,6 +279,8 @@ class Tracer:
         self._args = _tree_map(self._tensor_to_device, args, path_label="args")
         self._kwargs = _tree_map(self._tensor_to_device, kwargs, path_label="kwargs")
 
+        trace_mem_before = _log_trace_region("before capture", self._devices)
+
         if self._prep_run:
             if self._clone_prep_inputs:
                 prep_args = _tree_map(_clone_tensor, self._args, path_label="args")
@@ -260,6 +312,8 @@ class Tracer:
             Tracer._traces_live[d.id()] += 1
         self._trace_ids = trace_ids
         self._outputs = outputs
+
+        _log_trace_region(f"after capture of {self._function!r}", self._devices, trace_mem_before)
 
         if execute:
             # Trace capture records commands but does not execute them. Execute the trace to
@@ -320,9 +374,11 @@ class Tracer:
         self._args = ()
         self._kwargs = {}
         self._outputs = None
+        released_before = _log_trace_region("before release", self._devices)
         for d, trace_id in zip(self._devices, trace_ids, strict=True):
             Tracer._traces_live[d.id()] -= 1
             ttnn.release_trace(d, trace_id)
+        _log_trace_region("after release", self._devices, released_before)
 
     def release_function(self) -> None:
         """Drop the reference to the wrapped function.

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -1152,6 +1152,14 @@
     export TT_MESH_HOST_RANK=0
     export TT_METAL_SHM_TRACKING_DISABLED=1
     export TT_MESH_GRAPH_DESC_PATH="${TT_METAL_HOME}/models/tt_dit/tests/models/ltx/scaleout_configs/single_galaxy/mesh_graph_descriptor.textproto"
+    # Cover the shape actually served (Console: 1080p / ~6s / 25fps), not the legacy
+    # 145f@24. FPS is real conditioning -- it sets the audio latent length and scales the
+    # A/V cross-PE -- so without these the 25fps path has no automated coverage and a
+    # regression to a hardcoded 24 would keep every LTX test green. 153 because
+    # 6s x 25fps = 150 does not satisfy (num_frames-1) % 8 == 0.
+    # The 24-vs-25 arithmetic is additionally guarded on CPU by
+    # models/tt_dit/tests/models/ltx/test_fps_conditioning_ltx.py.
+    export NUM_FRAMES=153 FPS=25
     mpirun -np 1 --bind-to none --tag-output --wdir "${TT_METAL_HOME}" \
       python3 -m pytest --timeout 2100 models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py::test_pipeline_distilled -k "4x8sp1tp0nl2_ring_is_fsdp0"
   model: ltx-2.3-fast-t2v


### PR DESCRIPTION
Makes FPS real generation conditioning in the LTX-2.3 pipelines, and tunes conv3d blocking for the 153-frame shape, so 1080p / ~6s / 25fps can be served at full speed.

Driven by a Console requirement for a single configuration: **1080p, 6 seconds, 25 fps**. Production served 1920×1088 / 145 frames / **24** fps.

## 1. FPS was silently half-wired

`fps` was hardcoded to `24` at the three `VideoPixelShape` sites, and `prepare_av_cross_pe`'s `fps` parameter was never passed, so it defaulted to 24 as well. Only `decode_audio` and the exporter honoured the requested rate.

That combination is worse than ignoring FPS outright. `rope_ltx.py:346` scales the A/V cross-PE temporal axis into *seconds* by dividing by FPS, and `AudioLatentShape` derives the audio latent length from `num_frames / fps`. So requesting 25 built the latents and the A/V alignment on a 24 fps timeline, while `decode_audio` trimmed audio to `num_frames/25` and the container declared 25. Total lengths matched — so it looked correct — but the audio was generated against a 6.04 s video played back over 5.80 s: **lip sync drifts ~0.24 s across a 6 s clip.**

FPS is now pipeline-level state, not a per-call argument: it changes `audio_N`, which changes the traced shape, so it must be fixed at construction alongside `num_frames`/`height`/`width`. `generate()` rejects a mismatched value rather than substituting silently.

**At `fps=24` this is a no-op**, verified on a 4×8 BH Galaxy: the 145-frame shape reproduces bit-for-bit with **3628/3628 JIT cache hits**. Had any compile-time argument shifted, those programs would have hashed differently and appeared as misses. 25 fps itself is free — 6.6 s at 145f/25 vs 6.7 s at 145f/24.

## 2. conv3d blocking for latent T=20

153 frames (6.12 s at 25 fps; 150 isn't `8k+1`) moves the decoder's latent T from 19 to 20, so the conv3d T-chain walks 22/41/79/155 instead of 21/39/75/147 and misses `_BLOCKINGS` at 15 sites. Five fell through to the hardcoded `T=1 H=1 W=1` default, 20–30× off optimal.

| Stage | Before | After | 145f@24 baseline |
|---|---|---|---|
| Stage 1 denoise | 2.41 s | 2.39 s | 2.35 s |
| Latent upsample | 0.62 s | **0.16 s** | 0.18 s |
| Stage 2 denoise | 2.91 s | 2.88 s | 2.61 s |
| VAE decode | 5 s | **1 s** | 1 s |
| **Total** | **12.06 s** | **6.68 s** | 6.72 s |

Biggest wins: `512→512 T=79` **31.8×** (×9 invocations, ~2.4 s alone), `512→4096 T=41` 23.5×, `512→512 T=41` 23.2×, `1024→1024 T=22` 17.3×, `256→256 T=155` 7.2× (×12).

**153f @ 25fps is now at parity with the 145f @ 24fps baseline** despite 5.3% more tokens — the fresh sweep beats the existing 2026-06 entries.

Three keys still fall back and cost nothing measurable: `128→1024 T=22` (×2 sites) and the `1024→4096 (1,3,3) T=20` upsampler. The upsampler's sweep could not run, but upsample landed at 0.16 s *without* an entry — faster than baseline — so its 0.62 s was collateral from badly-blocked decode work queued ahead of it, not its own conv.

## 3. Verification

Six of the twelve entries use temporal blocking, and `conv3d.py:313` documents a prior entry disabled because `T_out_block=4` caused a frame-24-25 artifact — so blocking can affect correctness, not just speed. Three clips were generated and checked with a periodic-seam and flat-region detector, using the pre-tune output as a control: all clean, **stride-6 seam contrast below baseline** (+0.233 / +0.289 vs +0.363), with frame-level stills inspected by eye. Output verified 1920×1088 / 25 fps / 153 frames / 6.120 s, h264 + AAC.

## 4. Also included

- **Trace-memory instrumentation** (`TT_DIT_TRACE_MEM_LOG=1`, off by default). `ttnn.get_memory_view` already exposes TRACE/DRAM/L1 but nothing in `tt_dit` used it, so per-trace device memory was unmeasurable from Python. Measured at 1920×1088/145f: denoise traces 91.31 and 97.69 MB, VAE decoder 4.94 MB, vocoders 37.06 and 29.44 MB, Gemma encoder 20.31 MB — **280.75 MB per shape against a 476.88 MB region**. Trace bytes are near-independent of tensor volume (stage 1→2 is 4× the tokens for +7%; 720p→1080p is 2.9× for +2.4%), because a trace holds the dispatch command stream and the op graph is fixed by architecture.
- **`bruteforce_conv3d_sweep_ltx.py`** — 15 LTX layer specs reusing the wan2_2 harness.
- Pre-existing **latent whiteness/zeros diagnostics** in the distilled pipeline, for triaging noise outputs; already in the working tree and unrelated to the FPS change.

## Notes for future sweeps

- `hw_product` is an **exact-match** filter. Layers whose per-device spatial dims can't reach it (H=5, W=4 → max 20) sweep to zero combos.
- Relaxing it explodes the search space *and* hits the documented BH hang on non-32 products. Two H=5/W=4 layers hung this way and were abandoned at negligible cost.
- A hung Galaxy needs **`tt-smi -glx_reset`** before another device kernel runs; plain `tt-smi -r` fails in topology discovery.

## Dependency

`tenstorrent/tt-inference-server` has a companion PR that flips the served shape to 153f/25fps. **That one must land after this**, or generation takes 12.1 s and `LTX_FPS=25` raises `ValueError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rsalman/ltx-25fps-1080p-6s)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rsalman/ltx-25fps-1080p-6s)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rsalman/ltx-25fps-1080p-6s)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rsalman/ltx-25fps-1080p-6s)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rsalman/ltx-25fps-1080p-6s)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rsalman/ltx-25fps-1080p-6s)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rsalman/ltx-25fps-1080p-6s)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rsalman/ltx-25fps-1080p-6s)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rsalman/ltx-25fps-1080p-6s)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rsalman/ltx-25fps-1080p-6s)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rsalman/ltx-25fps-1080p-6s)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rsalman/ltx-25fps-1080p-6s)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rsalman/ltx-25fps-1080p-6s)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rsalman/ltx-25fps-1080p-6s)